### PR TITLE
Publish approved non-merge AI fixes before completion

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -240,6 +240,10 @@ export function wireHeadlessApproveHook(deps: HeadlessDeps, te: TaskRunner): voi
       const workflow = deps.persistence.loadWorkflow(task.config.workflowId);
       if (workflow?.mergeMode === "external_review") return;
       await te.approveMerge(task.config.workflowId);
+      return;
+    }
+    if (!task.config.isMergeNode && task.execution.pendingFixError !== undefined) {
+      await te.publishApprovedFix(task);
     }
   });
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1238,6 +1238,10 @@ if (isHeadless) {
         const workflow = persistence.loadWorkflow(task.config.workflowId);
         if (workflow?.mergeMode === "external_review") return; // external review is the merge mechanism
         await requireTaskExecutor().approveMerge(task.config.workflowId);
+        return;
+      }
+      if (!task.config.isMergeNode && task.execution.pendingFixError !== undefined) {
+        await requireTaskExecutor().publishApprovedFix(task);
       }
     });
   }

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1,9 +1,11 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
 import { collectTransitiveNonMergeTaskIds } from '../merge-runner.js';
+import { SshExecutor } from '../ssh-executor.js';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse } from '@invoker/contracts';
 import { EventEmitter } from 'events';
@@ -4851,6 +4853,133 @@ describe('TaskRunner', () => {
       (executor as any).spawnAgentFix = async () => ({ stdout: '', sessionId: 'sess-xyz' });
       await executor.fixWithAgent('fix-task', 'error output');
       expect(gitCalls.find(c => c[0] === 'checkout')).toBeUndefined();
+    });
+  });
+
+  describe('publishApprovedFix', () => {
+    it('commits and pushes approved non-merge fixes in a local worktree', async () => {
+      const bareDir = createTempWorkspace();
+      const repoDir = createTempWorkspace();
+      execSync('git init --bare', { cwd: bareDir });
+      execSync(`git clone ${JSON.stringify(bareDir)} ${JSON.stringify(repoDir)}`);
+      execSync('git config user.email "test@example.com"', { cwd: repoDir });
+      execSync('git config user.name "Test Runner"', { cwd: repoDir });
+      writeFileSync(join(repoDir, 'fix-target.txt'), 'BROKEN\n');
+      writeFileSync(join(repoDir, 'package.json'), '{"name":"publish-approved-fix","private":true}\n');
+      execSync('git add -A', { cwd: repoDir });
+      execSync('git commit -m "seed"', { cwd: repoDir });
+      execSync('git push origin HEAD', { cwd: repoDir });
+      execSync('git checkout -b experiment/fix-gap', { cwd: repoDir });
+      execSync('git push -u origin experiment/fix-gap', { cwd: repoDir });
+      writeFileSync(join(repoDir, 'fix-target.txt'), 'FIXED\n');
+
+      const task = makeTask({
+        id: 'fix-task',
+        description: 'Apply approved fix',
+        config: { executorType: 'worktree', command: 'bash -lc false' },
+        execution: {
+          workspacePath: repoDir,
+          branch: 'experiment/fix-gap',
+          selectedAttemptId: 'attempt-1',
+        },
+      });
+      const tasks = new Map<string, TaskState>([['fix-task', task]]);
+      const updateTask = vi.fn();
+      const updateAttempt = vi.fn();
+      const persistence = { updateTask, updateAttempt };
+      const registryMap = new Map<string, any>();
+      const executorRegistry = {
+        getDefault: () => {
+          throw new Error('unexpected getDefault');
+        },
+        get: (name: string) => registryMap.get(name) ?? null,
+        register: (name: string, executor: any) => {
+          registryMap.set(name, executor);
+        },
+        getAll: () => [...registryMap.values()],
+      };
+      const runner = new TaskRunner({
+        orchestrator: { getTask: (id: string) => tasks.get(id) } as any,
+        persistence: persistence as any,
+        executorRegistry: executorRegistry as any,
+        cwd: repoDir,
+      });
+
+      await runner.publishApprovedFix(task);
+
+      const headSha = execSync('git rev-parse HEAD', { cwd: repoDir, encoding: 'utf8' }).trim();
+      const headValue = execSync('git show HEAD:fix-target.txt', { cwd: repoDir, encoding: 'utf8' }).trim();
+      const remoteValue = execSync('git show origin/experiment/fix-gap:fix-target.txt', { cwd: repoDir, encoding: 'utf8' }).trim();
+      expect(headValue).toBe('FIXED');
+      expect(remoteValue).toBe('FIXED');
+      expect(() => execSync('git diff --quiet', { cwd: repoDir })).not.toThrow();
+      expect(updateTask).toHaveBeenCalledWith('fix-task', {
+        execution: { commit: headSha },
+      });
+      expect(updateAttempt).toHaveBeenCalledWith('attempt-1', {
+        branch: 'experiment/fix-gap',
+        commit: headSha,
+      });
+    });
+
+    it('routes SSH approved-fix publish through SshExecutor and persists the returned hash', async () => {
+      const publishSpy = vi.spyOn(SshExecutor.prototype, 'publishApprovedFix').mockResolvedValue({
+        commitHash: 'abc1234',
+      });
+
+      const task = makeTask({
+        id: 'ssh-fix-task',
+        description: 'Apply approved fix over ssh',
+        config: {
+          executorType: 'ssh',
+          remoteTargetId: 'remote-1',
+          command: 'bash -lc false',
+        },
+        execution: {
+          workspacePath: '/remote/worktree',
+          branch: 'experiment/ssh-fix-gap',
+          selectedAttemptId: 'attempt-ssh-1',
+        },
+      });
+      const tasks = new Map<string, TaskState>([['ssh-fix-task', task]]);
+      const updateTask = vi.fn();
+      const updateAttempt = vi.fn();
+      const executorRegistry = {
+        getDefault: () => ({ type: 'worktree' }),
+        get: () => null,
+        register: () => {},
+        getAll: () => [],
+      };
+      const runner = new TaskRunner({
+        orchestrator: { getTask: (id: string) => tasks.get(id) } as any,
+        persistence: { updateTask, updateAttempt } as any,
+        executorRegistry: executorRegistry as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'remote-1': {
+            host: 'example.com',
+            user: 'invoker',
+            sshKeyPath: '/tmp/test-key',
+          },
+        }),
+      });
+
+      await runner.publishApprovedFix(task);
+
+      expect(publishSpy).toHaveBeenCalledWith(
+        '/remote/worktree',
+        expect.objectContaining({
+          actionId: 'ssh-fix-task',
+        }),
+        'experiment/ssh-fix-gap',
+      );
+      expect(updateTask).toHaveBeenCalledWith('ssh-fix-task', {
+        execution: { commit: 'abc1234' },
+      });
+      expect(updateAttempt).toHaveBeenCalledWith('attempt-ssh-1', {
+        branch: 'experiment/ssh-fix-gap',
+        commit: 'abc1234',
+      });
     });
   });
 

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -584,6 +584,26 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
   }
 
   /**
+   * Commit and push an already-applied workspace fix without rerunning the task command.
+   * Used when an AI-applied fix is approved for a non-merge task.
+   */
+  async publishApprovedFix(
+    cwd: string,
+    request: WorkRequest,
+    branch: string,
+  ): Promise<{ commitHash?: string; error?: string }> {
+    const commitHash = await this.recordTaskResult(cwd, request, 0);
+    if (!commitHash) {
+      return { error: 'commit approved fix failed' };
+    }
+    const pushError = await this.pushBranchToRemote(cwd, branch);
+    if (pushError) {
+      return { error: pushError };
+    }
+    return { commitHash };
+  }
+
+  /**
    * Restore the original branch after task completion.
    * No-op if originalBranch is undefined (e.g., not in a git repo).
    */

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -473,6 +473,14 @@ echo ${payloadB64} | base64 -d | bash -se
     }
   }
 
+  async publishApprovedFix(
+    worktreePath: string,
+    request: WorkRequest,
+    branch: string,
+  ): Promise<{ commitHash?: string; error?: string }> {
+    return this.remoteGitRecordAndPush('publish-approved-fix', request, worktreePath, branch, 0);
+  }
+
   /** Run a bash script on the remote (fed to `bash -s` on stdin). */
   private spawnSshRemoteStdin(
     executionId: string,

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -16,6 +16,7 @@ import type { Orchestrator, TaskState, ExperimentVariant, ExecutorType } from '@
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkRequest, WorkResponse, ActionType } from '@invoker/contracts';
 import type { Executor, ExecutorHandle } from './executor.js';
+import { BaseExecutor } from './base-executor.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import { ResourceLimitError } from './repo-pool.js';
 import type { ExecutorRegistry } from './registry.js';
@@ -788,6 +789,66 @@ export class TaskRunner {
 
   async publishAfterFix(task: TaskState): Promise<void> {
     return publishAfterFixImpl(this, task);
+  }
+
+  async publishApprovedFix(task: TaskState): Promise<void> {
+    const workspacePath = task.execution.workspacePath?.trim();
+    if (!workspacePath) {
+      throw new Error(`Task ${task.id} has no workspacePath for approved-fix publish`);
+    }
+    const branch = task.execution.branch?.trim();
+    if (!branch) {
+      throw new Error(`Task ${task.id} has no branch for approved-fix publish`);
+    }
+
+    const request: WorkRequest = {
+      requestId: randomUUID(),
+      actionId: task.id,
+      attemptId: task.execution.selectedAttemptId,
+      executionGeneration: task.execution.generation ?? 0,
+      actionType: this.determineActionType(task),
+      inputs: {
+        description: task.description,
+        command: task.config.command,
+        prompt: task.config.prompt,
+      },
+      callbackUrl: '',
+      timestamps: {
+        createdAt: new Date().toISOString(),
+      },
+    };
+
+    const executor = this.selectExecutor(task);
+    let result: { commitHash?: string; error?: string };
+    if (executor instanceof SshExecutor) {
+      result = await executor.publishApprovedFix(workspacePath, request, branch);
+    } else if (executor instanceof BaseExecutor) {
+      result = await executor.publishApprovedFix(workspacePath, request, branch);
+    } else {
+      throw new Error(
+        `Executor ${executor.type} does not support approved-fix publish for task ${task.id}`,
+      );
+    }
+
+    if (result.error) {
+      throw new Error(result.error);
+    }
+    if (!result.commitHash) {
+      throw new Error(`Approved-fix publish produced no commit hash for task ${task.id}`);
+    }
+
+    this.persistence.updateTask(task.id, {
+      execution: {
+        commit: result.commitHash,
+      },
+    });
+    const attemptId = task.execution.selectedAttemptId;
+    if (attemptId) {
+      this.persistence.updateAttempt(attemptId, {
+        branch,
+        commit: result.commitHash,
+      });
+    }
   }
 
   async buildMergeSummary(workflowId: string): Promise<string> {

--- a/scripts/repro/repro-nonmerge-fix-approval-missing-commit.sh
+++ b/scripts/repro/repro-nonmerge-fix-approval-missing-commit.sh
@@ -1,0 +1,289 @@
+#!/usr/bin/env bash
+# Repro: non-merge AI fix approval completes task without committing the fix.
+#
+# Usage:
+#   bash scripts/repro/repro-nonmerge-fix-approval-missing-commit.sh --expect bug
+#   bash scripts/repro/repro-nonmerge-fix-approval-missing-commit.sh --expect fixed
+#
+# Exit codes:
+#   0 - observed expected behavior for the selected mode
+#   1 - behavior did not match expectation
+#   2 - usage/environment error
+set -euo pipefail
+
+EXPECT="bug"
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      if [[ $# -lt 2 ]]; then
+        echo "repro: --expect requires bug|fixed" >&2
+        exit 2
+      fi
+      EXPECT="$2"
+      shift 2
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECT" != "bug" && "$EXPECT" != "fixed" ]]; then
+  echo "repro: --expect must be bug or fixed" >&2
+  exit 2
+fi
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-nonmerge-fix.XXXXXX")"
+TMP_HOME="$TMP_DIR/home"
+STUB_DIR="$TMP_DIR/stubs"
+FIXTURE_DIR="$TMP_DIR/fixture"
+OWNER_LOG="$TMP_DIR/owner.log"
+SUBMIT_LOG="$TMP_DIR/submit.log"
+PLAN_PATH="$TMP_DIR/repro-plan.yaml"
+CONFIG_PATH="$TMP_DIR/config.json"
+DB_PATH="$TMP_HOME/.invoker/invoker.db"
+OWNER_PID=""
+
+cleanup() {
+  if [[ -n "$OWNER_PID" ]]; then
+    kill "$OWNER_PID" 2>/dev/null || true
+    wait "$OWNER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$TMP_HOME/.invoker" "$STUB_DIR" "$FIXTURE_DIR"
+
+cat >"$CONFIG_PATH" <<'EOF'
+{
+  "autoFixRetries": 1,
+  "autoApproveAIFixes": true
+}
+EOF
+
+cat >"$STUB_DIR/claude" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+SESSION_ID=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --session-id)
+      SESSION_ID="${2:-}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+if [[ -n "${INVOKER_REPRO_MARKER_DIR:-}" ]]; then
+  mkdir -p "$INVOKER_REPRO_MARKER_DIR"
+  printf '%s\n' "${SESSION_ID:-no-session}" >"$INVOKER_REPRO_MARKER_DIR/claude-ran.marker"
+fi
+
+printf 'FIXED\n' > fix-target.txt
+echo "repro stub applied fix in $(pwd)"
+EOF
+chmod +x "$STUB_DIR/claude"
+
+git -C "$FIXTURE_DIR" init -b master >/dev/null 2>&1
+git -C "$FIXTURE_DIR" config user.email "repro@example.com"
+git -C "$FIXTURE_DIR" config user.name "Repro Bot"
+printf 'BROKEN\n' >"$FIXTURE_DIR/fix-target.txt"
+cat >"$FIXTURE_DIR/package.json" <<'EOF'
+{"name":"repro-fix-gap","private":true}
+EOF
+git -C "$FIXTURE_DIR" add fix-target.txt package.json
+git -C "$FIXTURE_DIR" commit -m "seed repro fixture" >/dev/null 2>&1
+
+REPO_URL="$(python3 - <<'PY' "$FIXTURE_DIR"
+import pathlib, sys
+print(pathlib.Path(sys.argv[1]).resolve().as_uri())
+PY
+)"
+
+cat >"$PLAN_PATH" <<EOF
+name: repro nonmerge fix approval missing commit
+repoUrl: $REPO_URL
+onFinish: none
+tasks:
+  - id: fix-gap
+    description: Fail until AI edits fix-target.txt
+    command: bash -lc 'test "\$(cat fix-target.txt)" = "FIXED"'
+EOF
+
+export HOME="$TMP_HOME"
+export INVOKER_REPO_CONFIG_PATH="$CONFIG_PATH"
+export INVOKER_UNSAFE_DISABLE_DB_WRITER_LOCK=1
+export PATH="$STUB_DIR:$PATH"
+export INVOKER_REPRO_MARKER_DIR="$TMP_DIR/markers"
+unset INVOKER_HEADLESS_STANDALONE
+unset INVOKER_DB_DIR
+
+echo "==> repro: start owner"
+unset ELECTRON_RUN_AS_NODE
+./run.sh >"$OWNER_LOG" 2>&1 &
+OWNER_PID=$!
+
+echo "==> repro: wait for owner IPC socket"
+READY=0
+for _ in $(seq 1 240); do
+  if find "$HOME/.invoker" -maxdepth 1 -type s -name 'ipc-tra*' | grep -q .; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
+if [[ "$READY" -ne 1 ]]; then
+  echo "repro: owner never exposed ipc-transport socket" >&2
+  cat "$OWNER_LOG" >&2
+  exit 1
+fi
+
+echo "==> repro: submit plan"
+./submit-plan.sh "$PLAN_PATH" 2>&1 | tee "$SUBMIT_LOG" || true
+WF_ID="$(python3 - <<'PY' "$SUBMIT_LOG"
+import re, sys
+text = open(sys.argv[1], encoding='utf-8', errors='ignore').read()
+matches = re.findall(r'wf-\d+-\d+', text)
+print(matches[-1] if matches else '')
+PY
+)"
+if [[ -z "$WF_ID" ]]; then
+  echo "repro: failed to resolve workflow id from submit output" >&2
+  cat "$SUBMIT_LOG" >&2
+  exit 1
+fi
+TASK_ID="$WF_ID/fix-gap"
+
+echo "==> repro: wait for task completion"
+python3 - <<'PY' "$DB_PATH" "$TASK_ID"
+import sqlite3, sys, time
+db_path, task_id = sys.argv[1], sys.argv[2]
+deadline = time.time() + 180
+while time.time() < deadline:
+    try:
+        conn = sqlite3.connect(db_path)
+        row = conn.execute(
+            "select coalesce(status,''), coalesce(workspace_path,''), coalesce(commit_hash,''), coalesce(selected_attempt_id,'') "
+            "from tasks where id = ? limit 1",
+            (task_id,),
+        ).fetchone()
+        conn.close()
+    except sqlite3.Error:
+        row = None
+    if row and row[0] in ("completed", "failed", "review_ready", "needs_input", "blocked", "stale"):
+        print("\t".join(row))
+        raise SystemExit(0)
+    time.sleep(1)
+raise SystemExit(1)
+PY
+
+IFS='|' read -r TASK_STATUS WORKSPACE_PATH TASK_COMMIT_HASH ATTEMPT_ID < <(
+  python3 - <<'PY' "$DB_PATH" "$TASK_ID"
+import sqlite3, sys
+conn = sqlite3.connect(sys.argv[1])
+row = conn.execute(
+    "select coalesce(status,''), coalesce(workspace_path,''), coalesce(commit_hash,''), coalesce(selected_attempt_id,'') "
+    "from tasks where id = ? limit 1",
+    (sys.argv[2],),
+).fetchone()
+conn.close()
+if not row:
+    raise SystemExit(1)
+print("|".join(value.replace("|", "/") for value in row))
+PY
+)
+
+if [[ "$TASK_STATUS" != "completed" ]]; then
+  echo "repro: expected task to complete via auto-approved fix, got status=$TASK_STATUS" >&2
+  sqlite3 -header -column "$DB_PATH" "select id, status, branch, commit_hash, workspace_path from tasks where workflow_id='$WF_ID' order by id;" >&2 || true
+  exit 1
+fi
+if [[ -z "$WORKSPACE_PATH" || ! -d "$WORKSPACE_PATH" ]]; then
+  echo "repro: task workspace path missing: $WORKSPACE_PATH" >&2
+  exit 1
+fi
+if [[ ! -f "$TMP_DIR/markers/claude-ran.marker" ]]; then
+  echo "repro: claude stub was not invoked" >&2
+  exit 1
+fi
+
+IFS='|' read -r ATTEMPT_STATUS ATTEMPT_COMMIT_HASH TASK_BRANCH < <(
+  python3 - <<'PY' "$DB_PATH" "$ATTEMPT_ID" "$TASK_ID"
+import sqlite3, sys
+conn = sqlite3.connect(sys.argv[1])
+attempt = conn.execute(
+    "select coalesce(status,''), coalesce(commit_hash,''), coalesce(branch,'') from attempts where id = ? limit 1",
+    (sys.argv[2],),
+).fetchone()
+if not attempt:
+    task = conn.execute(
+        "select '', '', coalesce(branch,'') from tasks where id = ? limit 1",
+        (sys.argv[3],),
+    ).fetchone()
+    attempt = task
+conn.close()
+print("|".join(value.replace("|", "/") for value in attempt))
+PY
+)
+
+WORKTREE_VALUE="$(tr -d '\r\n' <"$WORKSPACE_PATH/fix-target.txt")"
+HEAD_VALUE="$(git -C "$WORKSPACE_PATH" show HEAD:fix-target.txt | tr -d '\r\n')"
+HEAD_SHA="$(git -C "$WORKSPACE_PATH" rev-parse HEAD | tr -d '\r\n')"
+DIRTY=0
+if ! git -C "$WORKSPACE_PATH" diff --quiet -- fix-target.txt; then
+  DIRTY=1
+fi
+
+REMOTE_SHA=""
+if [[ -n "$TASK_BRANCH" ]]; then
+  REMOTE_SHA="$(git -C "$WORKSPACE_PATH" rev-parse "$TASK_BRANCH" 2>/dev/null | tr -d '\r\n' || true)"
+  if [[ -z "$REMOTE_SHA" ]]; then
+    REMOTE_SHA="$(git -C "$WORKSPACE_PATH" rev-parse "origin/$TASK_BRANCH" 2>/dev/null | tr -d '\r\n' || true)"
+  fi
+fi
+
+echo "==> repro summary"
+echo "workflow:            $WF_ID"
+echo "task:                $TASK_ID"
+echo "status:              $TASK_STATUS"
+echo "workspace:           $WORKSPACE_PATH"
+echo "branch:              ${TASK_BRANCH:-<none>}"
+echo "head sha:            ${HEAD_SHA:-<none>}"
+echo "task commit_hash:    ${TASK_COMMIT_HASH:-<empty>}"
+echo "attempt commit_hash: ${ATTEMPT_COMMIT_HASH:-<empty>}"
+echo "remote sha:          ${REMOTE_SHA:-<none>}"
+echo "worktree value:      $WORKTREE_VALUE"
+echo "HEAD value:          $HEAD_VALUE"
+echo "dirty:               $DIRTY"
+
+if [[ "$EXPECT" = "bug" ]]; then
+  if [[ "$WORKTREE_VALUE" = "FIXED" && "$HEAD_VALUE" != "FIXED" && "$DIRTY" -eq 1 ]]; then
+    echo "repro: confirmed bug"
+    exit 0
+  fi
+  echo "repro: expected dirty accepted fix without commit, but did not observe it" >&2
+  exit 1
+fi
+
+if [[ "$WORKTREE_VALUE" = "FIXED" \
+   && "$HEAD_VALUE" = "FIXED" \
+   && "$DIRTY" -eq 0 \
+   && -n "$TASK_COMMIT_HASH" \
+   && -n "$ATTEMPT_COMMIT_HASH" \
+   && "$TASK_COMMIT_HASH" = "$HEAD_SHA" \
+   && "$ATTEMPT_COMMIT_HASH" = "$HEAD_SHA" ]] \
+   && [[ -z "$REMOTE_SHA" || "$REMOTE_SHA" = "$HEAD_SHA" ]]; then
+  echo "repro: confirmed fix"
+  exit 0
+fi
+
+echo "repro: expected committed accepted fix, but observed stale/dirty state" >&2
+exit 1


### PR DESCRIPTION
## Summary

Before this change, approving an AI-applied fix on a normal non-merge task could mark the task `completed` and unblock downstream work without ever committing or pushing the approved workspace changes. Merge-gate fixes already had an explicit publish step, but ordinary fixed tasks did not.

This PR makes non-merge fixed-task approval durable. When a task with `pendingFixError` is approved, Invoker now commits the approved fix, pushes the task branch, and records the resulting commit metadata before the task transitions to `completed`.

## Architecture

### Before

```mermaid
graph TD
    APPROVE["Approve fixed non-merge task"] --> ORC["Orchestrator.approve()"]
    ORC --> COMPLETE["Task completed"]
    COMPLETE --> NEXT["Downstream tasks may start"]
    COMPLETE -.-> GAP["Approved workspace changes may still be uncommitted"]

    style GAP fill:#ffcdd2
```

### After

```mermaid
graph TD
    APPROVE["Approve fixed non-merge task"] --> HOOK["Approve hook"]
    HOOK --> PUBLISH["TaskRunner.publishApprovedFix()"]
    PUBLISH --> EXEC["Executor commit + push"]
    EXEC --> META["Persist commit on task + attempt"]
    META --> ORC["Orchestrator.approve()"]
    ORC --> COMPLETE["Task completed"]

    style PUBLISH fill:#e3f2fd
    style EXEC fill:#fff3e0
    style META fill:#e8f5e9
```

**Key changes:**
- Added a shared approved-fix publish primitive on `BaseExecutor`, with SSH support in `SshExecutor`.
- Added `TaskRunner.publishApprovedFix()` to route the publish step through the selected executor and persist commit metadata.
- Wired Electron and headless approve hooks to publish approved non-merge fixes before completion.
- Added a repro script covering the original missing-commit failure mode.

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts`
- [x] `bash scripts/repro/repro-nonmerge-fix-approval-missing-commit.sh --expect fixed`

## Revert Plan

- **Safe to revert?** Yes
- **Revert command:** `git revert aba3072`
- **Post-revert steps:** None
- **What breaks if reverted:** Approved non-merge AI fixes can again complete without producing a durable fix commit on the task branch.
- **Data migration?** No
