### PR TITLE
Add config-based heavyweight command routing

### DIFF
--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -27,6 +27,16 @@
     }
   },
 
+  "heavyweightCommandRouting": {
+    "comment": "Auto-route heavyweight shell commands like pnpm test to a remote target",
+    "remoteTargetId": "staging-server",
+    "matchers": [
+      {
+        "regex": "\\bpnpm(?:\\s|$)"
+      }
+    ]
+  },
+
   "autoFixRetries": 3,
   "autoApproveAIFixes": true,
 

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -137,4 +137,17 @@ describe('loadConfig', () => {
     expect(config.imageStorage).toEqual(imageStorage);
   });
 
+  it('reads heavyweightCommandRouting from user config', () => {
+    const heavyweightCommandRouting = {
+      remoteTargetId: 'ci-box',
+      matchers: [{ regex: '\\bpnpm(?:\\s|$)' }],
+    };
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ heavyweightCommandRouting }),
+    );
+    const config = loadConfig();
+    expect(config.heavyweightCommandRouting).toEqual(heavyweightCommandRouting);
+  });
+
 });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -102,6 +102,24 @@ export interface InvokerConfig {
     provisionCommand?: string;
   }>;
   /**
+   * Config-owned routing policy for heavyweight shell commands.
+   * Matching tasks are auto-routed to the configured executor/target at plan submission time.
+   * Default matcher set for v1 is any command invoking `pnpm`.
+   */
+  heavyweightCommandRouting?: {
+    /** Set false to disable heavyweight auto-routing without deleting the config block. */
+    enabled?: boolean;
+    /** Destination executor type. Default: "ssh". */
+    executorType?: string;
+    /** Required destination remote target ID for heavyweight commands. */
+    remoteTargetId: string;
+    /** Optional command matchers; defaults to matching any `pnpm` invocation. */
+    matchers?: Array<{
+      pattern?: string;
+      regex?: string;
+    }>;
+  };
+  /**
    * Pattern-based rules that enforce task execution environment conformance.
    * When a rule matches a task command, the orchestrator validates that the task's
    * executorType and remoteTargetId explicitly declared in the plan YAML match the

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -114,6 +114,7 @@ Rules:
    - To target a specific test file: \`cd packages/<pkg> && pnpm test -- src/__tests__/file.test.ts\`
    - NEVER run \`pnpm test <path>\` from the repo root — it runs \`pnpm -r test\` across all packages and the path will be wrong
    - NEVER use \`npx vitest run\` — always use \`pnpm test\` which runs the package.json test script
+   - If Invoker config auto-routes heavyweight commands, keep \`pnpm ...\` as a normal command unless the task must name a specific remote target
    - NEVER invent test file names. Verify the test file exists before referencing it in a command.
 6. Use meaningful task IDs (kebab-case).
 7. When ready, output the plan inside a \`\`\`yaml code block.

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1032,6 +1032,107 @@ describe('Orchestrator', () => {
         expect(mergeNode).toBeDefined();
         expect(mergeNode!.config.executorType).toBe('merge');
       });
+
+      it('auto-routes pnpm test to heavyweight SSH target when executor is omitted', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          heavyweightCommandRouting: {
+            remoteTargetId: 'ci-box',
+          },
+          availableRemoteTargetIds: ['ci-box'],
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'heavyweight-routing-test',
+          tasks: [{ id: 't1', description: 'Run tests', command: 'cd packages/app && pnpm test' }],
+        });
+
+        const task = routedOrchestrator.getTask('t1');
+        expect(task!.config.executorType).toBe('ssh');
+        expect(task!.config.remoteTargetId).toBe('ci-box');
+      });
+
+      it('auto-routes pnpm install to heavyweight SSH target when executor is omitted', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          heavyweightCommandRouting: {
+            remoteTargetId: 'ci-box',
+          },
+          availableRemoteTargetIds: ['ci-box'],
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'heavyweight-install-routing-test',
+          tasks: [{ id: 't1', description: 'Install deps', command: 'pnpm install --frozen-lockfile' }],
+        });
+
+        const task = routedOrchestrator.getTask('t1');
+        expect(task!.config.executorType).toBe('ssh');
+        expect(task!.config.remoteTargetId).toBe('ci-box');
+      });
+
+      it('throws when heavyweight command explicitly declares conflicting local executor', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          heavyweightCommandRouting: {
+            remoteTargetId: 'ci-box',
+          },
+          availableRemoteTargetIds: ['ci-box'],
+        });
+
+        expect(() => {
+          routedOrchestrator.loadPlan({
+            name: 'heavyweight-conflict-test',
+            tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test', executorType: 'worktree' }],
+          });
+        }).toThrow('matched heavyweight command routing');
+      });
+
+      it('throws when heavyweight command routing target is not configured', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          heavyweightCommandRouting: {
+            remoteTargetId: 'ci-box',
+          },
+          availableRemoteTargetIds: [],
+        });
+
+        expect(() => {
+          routedOrchestrator.loadPlan({
+            name: 'heavyweight-missing-target',
+            tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test' }],
+          });
+        }).toThrow('no remoteTargets are configured');
+      });
+
+      it('leaves non-matching commands unchanged under heavyweight routing', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          heavyweightCommandRouting: {
+            remoteTargetId: 'ci-box',
+          },
+          availableRemoteTargetIds: ['ci-box'],
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'non-heavyweight-command',
+          tasks: [{ id: 't1', description: 'Echo hello', command: 'echo hello' }],
+        });
+
+        const task = routedOrchestrator.getTask('t1');
+        expect(task!.config.executorType).toBe('worktree');
+        expect(task!.config.remoteTargetId).toBeUndefined();
+      });
     });
 
     // ── atomicity ───────────────────────────────────────────

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -274,6 +274,97 @@ export interface ExecutorRoutingRule {
   remoteTargetId: string;
 }
 
+export interface CommandRoutingMatcher {
+  pattern?: string;
+  regex?: string;
+}
+
+export interface HeavyweightCommandRoutingPolicy {
+  enabled?: boolean;
+  executorType?: string;
+  remoteTargetId: string;
+  matchers?: CommandRoutingMatcher[];
+}
+
+const DEFAULT_HEAVYWEIGHT_COMMAND_MATCHERS: CommandRoutingMatcher[] = [
+  { regex: '\\bpnpm(?:\\s|$)' },
+];
+
+function findMatchingCommandRoutingMatcher(
+  command: string,
+  matchers: CommandRoutingMatcher[],
+): CommandRoutingMatcher | undefined {
+  for (const matcher of matchers) {
+    const patternMatch = matcher.pattern !== undefined && command.includes(matcher.pattern);
+    const regexMatch = matcher.regex !== undefined && new RegExp(matcher.regex).test(command);
+    if (patternMatch || regexMatch) {
+      return matcher;
+    }
+  }
+  return undefined;
+}
+
+function resolveHeavyweightCommandRouting(
+  taskId: string,
+  command: string | undefined,
+  planExecutorType: string | undefined,
+  planRemoteTargetId: string | undefined,
+  policy: HeavyweightCommandRoutingPolicy | undefined,
+  availableRemoteTargetIds: Set<string>,
+): { executorType?: string; remoteTargetId?: string } | undefined {
+  if (!command || !policy || policy.enabled === false) {
+    return undefined;
+  }
+
+  const matchers = policy.matchers?.length ? policy.matchers : DEFAULT_HEAVYWEIGHT_COMMAND_MATCHERS;
+  const matched = findMatchingCommandRoutingMatcher(command, matchers);
+  if (!matched) {
+    return undefined;
+  }
+
+  const policyExecutorType = normalizeExecutorType(policy.executorType) ?? 'ssh';
+  if (policyExecutorType !== 'ssh') {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched heavyweight command routing, ` +
+      `but config executorType="${policyExecutorType}" is unsupported. Expected "ssh".`,
+    );
+  }
+
+  if (availableRemoteTargetIds.size > 0 && !availableRemoteTargetIds.has(policy.remoteTargetId)) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched heavyweight command routing, ` +
+      `but config remoteTargetId="${policy.remoteTargetId}" is not defined in remoteTargets.`,
+    );
+  }
+
+  if (availableRemoteTargetIds.size === 0) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched heavyweight command routing, ` +
+      `but no remoteTargets are configured.`,
+    );
+  }
+
+  const normalizedPlanType = normalizeExecutorType(planExecutorType) ?? 'worktree';
+  if (planExecutorType !== undefined && normalizedPlanType !== policyExecutorType) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched heavyweight command routing and must use ` +
+      `executorType="${policyExecutorType}", but plan declares executorType="${normalizedPlanType}"`,
+    );
+  }
+
+  if (planRemoteTargetId !== undefined && planRemoteTargetId !== policy.remoteTargetId) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched heavyweight command routing and must use ` +
+      `remoteTargetId="${policy.remoteTargetId}", but plan declares remoteTargetId="${planRemoteTargetId}"`,
+    );
+  }
+
+  return {
+    executorType: policyExecutorType,
+    remoteTargetId: policy.remoteTargetId,
+  };
+}
+
 /**
  * Finds the first executor routing rule that matches the given command.
  * A rule matches when `pattern` is a substring of `command`, `regex` compiles and tests
@@ -389,6 +480,10 @@ export interface OrchestratorConfig {
    * a rule have the required executorType and remoteTargetId specified in the plan.
    */
   executorRoutingRules?: ExecutorRoutingRule[];
+  /** Config-owned routing for heavyweight commands (for example `pnpm ...`). */
+  heavyweightCommandRouting?: HeavyweightCommandRoutingPolicy;
+  /** Valid SSH remote target IDs available at plan submission time. */
+  availableRemoteTargetIds?: string[];
   /**
    * When true, keep tasks persisted as `pending` until the executor confirms
    * startup success, then transition to `running`.
@@ -413,6 +508,8 @@ export class Orchestrator {
   private readonly taskDispatcher?: (tasks: TaskState[]) => void;
   private readonly maxConcurrency: number;
   private readonly executorRoutingRules: ExecutorRoutingRule[];
+  private readonly heavyweightCommandRouting?: HeavyweightCommandRoutingPolicy;
+  private readonly availableRemoteTargetIds: Set<string>;
   private readonly defaultAutoFixRetries: number;
   private readonly deferRunningUntilLaunch: boolean;
 
@@ -427,6 +524,8 @@ export class Orchestrator {
     this.taskRepository = config.taskRepository ?? taskRepositoryFromPersistence(config.persistence);
     this.taskDispatcher = config.taskDispatcher;
     this.executorRoutingRules = config.executorRoutingRules ?? [];
+    this.heavyweightCommandRouting = config.heavyweightCommandRouting;
+    this.availableRemoteTargetIds = new Set(config.availableRemoteTargetIds ?? []);
     this.defaultAutoFixRetries = Math.min(Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0)), 10);
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
 
@@ -857,12 +956,23 @@ export class Orchestrator {
 
     const validatedTasks: TaskState[] = [];
     for (const taskDef of plan.tasks) {
-      // Validate executor routing conformance for tasks with commands
-      assertExecutorRoutingConforms(
+      const resolvedHeavyweightRouting = resolveHeavyweightCommandRouting(
         taskDef.id,
         taskDef.command,
         taskDef.executorType,
         taskDef.remoteTargetId,
+        this.heavyweightCommandRouting,
+        this.availableRemoteTargetIds,
+      );
+      const effectiveExecutorType = resolvedHeavyweightRouting?.executorType ?? taskDef.executorType;
+      const effectiveRemoteTargetId = resolvedHeavyweightRouting?.remoteTargetId ?? taskDef.remoteTargetId;
+
+      // Validate executor routing conformance for tasks with commands
+      assertExecutorRoutingConforms(
+        taskDef.id,
+        taskDef.command,
+        effectiveExecutorType,
+        effectiveRemoteTargetId,
         this.executorRoutingRules,
       );
 
@@ -892,17 +1002,17 @@ export class Orchestrator {
         executionAgent: taskDef.executionAgent,
         externalDependencies,
       } as const;
-      const executorType = normalizeExecutorType(taskDef.executorType) ?? 'worktree';
+      const executorType = normalizeExecutorType(effectiveExecutorType) ?? 'worktree';
       let taskConfig: TaskConfig;
       switch (executorType) {
         case 'docker':
-          taskConfig = { ...baseConfig, executorType, dockerImage: taskDef.dockerImage, remoteTargetId: taskDef.remoteTargetId };
+          taskConfig = { ...baseConfig, executorType, dockerImage: taskDef.dockerImage, remoteTargetId: effectiveRemoteTargetId };
           break;
         case 'ssh':
-          taskConfig = { ...baseConfig, executorType, remoteTargetId: taskDef.remoteTargetId };
+          taskConfig = { ...baseConfig, executorType, remoteTargetId: effectiveRemoteTargetId };
           break;
         default:
-          taskConfig = { ...baseConfig, executorType: 'worktree' as const, remoteTargetId: taskDef.remoteTargetId };
+          taskConfig = { ...baseConfig, executorType: 'worktree' as const, remoteTargetId: effectiveRemoteTargetId };
           break;
       }
       const task = createTaskState(

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -96,6 +96,8 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
 - Invoker headless lane: run `./submit-plan.sh plans/verify-<slug>.yaml` when flow involves orchestrator/executor/persistence/headless behavior
 - Visual proof lane when UI changes apply
 
+When Invoker config enables heavyweight command routing, keep `pnpm ...` commands in the plan as normal command tasks unless a specific remote target must be declared explicitly. Runtime config may auto-route those commands to SSH.
+
 Authoring YAML is not verification; execution is verification.
 
 ## Deterministic scripts


### PR DESCRIPTION
## Summary

This PR adds config-owned routing for heavyweight shell commands at plan submission time. Instead of requiring every plan author or surface prompt to explicitly select SSH for commands like `pnpm test`, Invoker can now enforce that policy centrally from config.

The orchestrator now evaluates submitted task commands against a configurable heavyweight-command policy, auto-applies the configured executor and remote target when a command matches, and rejects plans that explicitly conflict with the required routing.

## Architecture

### Before

```mermaid
graph TD
    PLAN["Plan task command"] --> ORC["Orchestrator.validate plan"]
    ORC --> DECL["Task keeps plan-declared executorType / remoteTargetId"]
    DECL --> AUTHOR["Plan author or prompt must choose remote routing"]

    style AUTHOR fill:#ffcdd2
```

### After

```mermaid
graph TD
    PLAN["Plan task command"] --> MATCH["Heavyweight command matcher"]
    MATCH -->|"match"| POLICY["Config-owned routing policy"]
    MATCH -->|"no match"| DECL["Use plan-declared routing"]
    POLICY --> EFFECTIVE["Effective executorType + remoteTargetId"]
    EFFECTIVE --> VALIDATE["Executor routing conformance checks"]
    DECL --> VALIDATE
    VALIDATE --> TASK["Persist task with resolved routing"]

    style MATCH fill:#e3f2fd
    style POLICY fill:#fff3e0
    style TASK fill:#e8f5e9
```

**Key changes:**
- Added `heavyweightCommandRouting` config support with matcher-driven command routing.
- Defaulted the first matcher set to `pnpm` commands while allowing explicit matcher overrides.
- Validated policy targets against configured remote target IDs and existing routing rules.
- Updated Slack plan guidance and example config to reflect config-owned heavyweight routing.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts`

## Revert Plan

- **Safe to revert?** Yes
- **Revert command:** `git revert cbd14d6`
- **Post-revert steps:** Remove `heavyweightCommandRouting` from local config if it is no longer understood by the codebase.
- **What breaks if reverted:** Heavyweight commands stop being auto-routed from config and must again be routed explicitly in each plan.
- **Data migration?** No
