### PR TITLE
Split fixed-task approval resume from approve

### DIFF
--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -22,6 +22,7 @@ function makeEnvelope<P>(
 function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
   return {
     approve: vi.fn().mockResolvedValue([] as TaskState[]),
+    resumeTaskAfterFixApproval: vi.fn().mockResolvedValue([] as TaskState[]),
     reject: vi.fn(),
     getTask: vi.fn().mockReturnValue(undefined),
     revertConflictResolution: vi.fn(),
@@ -83,6 +84,16 @@ describe('CommandService', () => {
         ok: false,
         error: { code: 'APPROVE_FAILED', message: 'boom' },
       });
+    });
+  });
+
+  describe('resumeTaskAfterFixApproval', () => {
+    it('delegates to orchestrator.resumeTaskAfterFixApproval', async () => {
+      const envelope = makeEnvelope({ taskId: 't-1' });
+      const result = await service.resumeTaskAfterFixApproval(envelope);
+
+      expect(result).toEqual({ ok: true, data: [] });
+      expect(orchestrator.resumeTaskAfterFixApproval).toHaveBeenCalledWith('t-1');
     });
   });
 

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5790,7 +5790,7 @@ describe('Orchestrator', () => {
       expect(task.execution.error).toBe('test failed: expected 1 to be 2');
     });
 
-    it('non-merge merge_conflict JSON pendingFixError approve transitions failed -> fixing_with_ai -> awaiting_approval -> running and clears pendingFixError', async () => {
+    it('non-merge merge_conflict JSON pendingFixError resume transitions failed -> fixing_with_ai -> awaiting_approval -> running and clears pendingFixError', async () => {
       const mergeConflictError = JSON.stringify({
         type: 'merge_conflict',
         failedBranch: 'experiment/non-merge-branch-abc123',
@@ -5810,7 +5810,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('f2')!.status).toBe('awaiting_approval');
       expect(orchestrator.getTask('f2')!.execution.pendingFixError).toBe(mergeConflictError);
 
-      await orchestrator.approve('f2');
+      await orchestrator.resumeTaskAfterFixApproval('f2');
       const task = orchestrator.getTask('f2')!;
       expect(task.status).toBe('running');
       expect(task.status).not.toBe('completed');
@@ -5868,12 +5868,12 @@ describe('Orchestrator', () => {
       return mergeNode.id;
     }
 
-    it('first approve transitions to running (for PR prep), clears pendingFixError, does not fire beforeApproveHook', async () => {
+    it('resumeTaskAfterFixApproval transitions to running (for PR prep), clears pendingFixError, does not fire beforeApproveHook', async () => {
       const hookSpy = vi.fn();
       orchestrator.setBeforeApproveHook(hookSpy);
       const mergeId = setupMergeGateAwaitingFixApproval();
 
-      const started = await orchestrator.approve(mergeId);
+      const started = await orchestrator.resumeTaskAfterFixApproval(mergeId);
 
       expect(started).toHaveLength(1);
       expect(started[0].id).toBe(mergeId);
@@ -5884,12 +5884,12 @@ describe('Orchestrator', () => {
       expect(task.execution.pendingFixError).toBeUndefined();
     });
 
-    it('after PR prep sets awaiting_approval, second approve completes and fires hook', async () => {
+    it('after PR prep sets awaiting_approval, approve completes and fires hook', async () => {
       const hookSpy = vi.fn();
       orchestrator.setBeforeApproveHook(hookSpy);
       const mergeId = setupMergeGateAwaitingFixApproval();
 
-      await orchestrator.approve(mergeId);
+      await orchestrator.resumeTaskAfterFixApproval(mergeId);
       orchestrator.setTaskAwaitingApproval(mergeId);
       await orchestrator.approve(mergeId);
 

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -78,6 +78,16 @@ export class CommandService {
     );
   }
 
+  async resumeTaskAfterFixApproval(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'APPROVE_FAILED',
+      () => this.orchestrator.resumeTaskAfterFixApproval(envelope.payload.taskId),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
   async reject(
     envelope: CommandEnvelope<{ taskId: string; reason?: string }>,
   ): Promise<CommandResult<void>> {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1284,69 +1284,6 @@ export class Orchestrator {
       return [];
     }
 
-    // Merge gate fixed by Claude: approve the fix → running while PR/git
-    // prep executes; caller must drive the async publish work via executor.
-    if (
-      task.config.isMergeNode &&
-      task.execution.pendingFixError !== undefined
-    ) {
-      console.log(
-        `[merge-gate-workspace] approve(post-fix) mergeNode=${taskId} ` +
-          `before writeAndSync execution.workspacePath=${task.execution.workspacePath ?? 'none'}`,
-      );
-      mergeTrace('GATE_WS_APPROVE_POST_FIX', {
-        taskId,
-        workspacePathBefore: task.execution.workspacePath ?? null,
-      });
-      const now = new Date();
-      const fixClearChanges: TaskStateChanges = {
-        status: 'running',
-        execution: { pendingFixError: undefined, startedAt: now, lastHeartbeatAt: now },
-      };
-      this.writeAndSync(taskId, fixClearChanges);
-      this.updateSelectedAttempt(taskId, {
-        status: 'running',
-        startedAt: now,
-        lastHeartbeatAt: now,
-      });
-      const fixDelta: TaskDelta = { type: 'updated', taskId, changes: fixClearChanges };
-      this.persistence.logEvent?.(taskId, 'task.running', fixClearChanges);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, fixDelta);
-      const updated = this.stateGetTask(taskId)!;
-      console.log(
-        `[merge-gate-workspace] approve(post-fix) mergeNode=${taskId} ` +
-          `after writeAndSync execution.workspacePath=${updated.execution.workspacePath ?? 'none'} ` +
-          '(pendingFix cleared; path should be unchanged)',
-      );
-      mergeTrace('GATE_WS_APPROVE_POST_FIX_AFTER', {
-        taskId,
-        workspacePathAfter: updated.execution.workspacePath ?? null,
-      });
-      return [updated];
-    }
-
-    if (
-      !task.config.isMergeNode &&
-      task.execution.pendingFixError !== undefined &&
-      parseMergeConflictError(task.execution.pendingFixError) !== undefined
-    ) {
-      const now = new Date();
-      const fixClearChanges: TaskStateChanges = {
-        status: 'running',
-        execution: { pendingFixError: undefined, startedAt: now, lastHeartbeatAt: now },
-      };
-      this.writeAndSync(taskId, fixClearChanges);
-      this.updateSelectedAttempt(taskId, {
-        status: 'running',
-        startedAt: now,
-        lastHeartbeatAt: now,
-      });
-      const fixDelta: TaskDelta = { type: 'updated', taskId, changes: fixClearChanges };
-      this.persistence.logEvent?.(taskId, 'task.running', fixClearChanges);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, fixDelta);
-      return [this.stateGetTask(taskId)!];
-    }
-
     if (this.beforeApproveHook) {
       mergeTrace('APPROVE_HOOK_FIRING', { taskId, workflowId: task.config.workflowId });
       await this.beforeApproveHook(task);
@@ -1393,6 +1330,31 @@ export class Orchestrator {
     mergeTrace('APPROVE_STARTED', { taskId: task.id, startedIds: started.map(t => t.id), startedStatuses: started.map(t => t.status) });
     this.checkWorkflowCompletion();
     return started;
+  }
+
+  async resumeTaskAfterFixApproval(taskId: string): Promise<TaskState[]> {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    const isApprovalState = task?.status === 'awaiting_approval' || task?.status === 'review_ready';
+    if (!task || !isApprovalState || task.execution.pendingFixError === undefined) {
+      return [];
+    }
+
+    const now = new Date();
+    const changes: TaskStateChanges = {
+      status: 'running',
+      execution: { pendingFixError: undefined, startedAt: now, lastHeartbeatAt: now },
+    };
+    this.writeAndSync(taskId, changes);
+    this.updateSelectedAttempt(taskId, {
+      status: 'running',
+      startedAt: now,
+      lastHeartbeatAt: now,
+    });
+    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    this.persistence.logEvent?.(taskId, 'task.running', changes);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+    return [this.stateGetTask(taskId)!];
   }
 
   /**


### PR DESCRIPTION
## Summary

This PR separates “approve a task” from “resume a task after an approved fix.” Before this change, `Orchestrator.approve()` handled both normal approval completion and fixed-task resume behavior, which forced callers to understand hidden task-type-specific branches inside approval.

After this change, normal approval remains on `approve()`, while fixed tasks that should go back to `running` now use an explicit `resumeTaskAfterFixApproval()` path. That makes approval semantics narrower and moves the fixed-task continuation decision up to the app layer.

## Architecture

### Before

```mermaid
graph TD
    APPROVE["approve(taskId)"] --> ORC["Orchestrator.approve()"]
    ORC --> NORMAL["Complete normal approval"]
    ORC --> FIXED["Hidden fixed-task branch"]
    FIXED --> RUNNING["Clear pendingFixError and resume running"]

    style FIXED fill:#ffcdd2
```

### After

```mermaid
graph TD
    APPROVE["approve(taskId)"] --> ORC1["Orchestrator.approve()"]
    ORC1 --> NORMAL["Complete normal approval"]

    RESUME["resumeTaskAfterFixApproval(taskId)"] --> ORC2["Orchestrator.resumeTaskAfterFixApproval()"]
    ORC2 --> RUNNING["Clear pendingFixError and resume running"]

    style RESUME fill:#e3f2fd
    style RUNNING fill:#e8f5e9
```

**Key changes:**
- Removed fixed-task special cases from `Orchestrator.approve()`.
- Added `resumeTaskAfterFixApproval()` for state-only fixed-task resumption.
- Extended `CommandService` so resumed fixed-task approval can also use the command envelope path.
- Updated orchestrator and command-service tests to assert the split behavior directly.

## Test Plan

- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts src/__tests__/command-service.test.ts`

## Revert Plan

- **Safe to revert?** Yes
- **Revert command:** `git revert 06a137b`
- **Post-revert steps:** None
- **What breaks if reverted:** Fixed-task approval semantics collapse back into `approve()`, making later shared approval routing changes harder to reason about and test.
- **Data migration?** No
