### PR TITLE
Route approvals through shared commit-and-resume flow

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -466,6 +466,38 @@ describe('POST /api/tasks/:id/approve', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('not awaiting approval');
   });
+
+  it('uses approveTaskAction when provided', async () => {
+    const approveTaskAction = vi.fn().mockResolvedValue(undefined);
+    const isolatedApi = startApiServer({
+      orchestrator: mocks.orchestrator as any,
+      persistence: mocks.persistence as any,
+      executorRegistry: mocks.executorRegistry as any,
+      taskExecutor: mocks.taskExecutor as any,
+      approveTaskAction,
+      cancelTask: mocks.cancelTask,
+      cancelWorkflow: mocks.cancelWorkflow,
+      killRunningTask: mocks.killRunningTask,
+    });
+    await new Promise<void>((resolve) => {
+      if (isolatedApi.server.listening) {
+        resolve();
+      } else {
+        isolatedApi.server.on('listening', resolve);
+      }
+    });
+    const addr = isolatedApi.server.address();
+    const isolatedPort = typeof addr === 'object' && addr ? addr.port : isolatedApi.port;
+
+    try {
+      const res = await request(isolatedPort, 'POST', '/api/tasks/task-1/approve');
+      expect(res.status).toBe(200);
+      expect(approveTaskAction).toHaveBeenCalledWith('task-1');
+      expect(mocks.orchestrator.approve).not.toHaveBeenCalled();
+    } finally {
+      await isolatedApi.close();
+    }
+  });
 });
 
 describe('POST /api/tasks/:id/reject', () => {

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -185,16 +185,124 @@ describe('restartTask', () => {
 });
 
 describe('approveTask', () => {
-  it('calls orchestrator.approve and returns result', async () => {
+  it('calls orchestrator.approve and returns structured result', async () => {
     const tasks = [makeRunningTask()];
-    const orchestrator = { approve: vi.fn().mockResolvedValue(tasks) };
+    const approvedTask = makeTask({ status: 'awaiting_approval' });
+    const orchestrator = {
+      approve: vi.fn().mockResolvedValue(tasks),
+      getTask: vi.fn().mockReturnValue(approvedTask),
+      resumeTaskAfterFixApproval: vi.fn(),
+    };
 
     const result = await approveTask('task-a', {
       orchestrator: orchestrator as unknown as Orchestrator,
     });
 
     expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
-    expect(result).toBe(tasks);
+    expect(result).toEqual({
+      approvedTask,
+      fixedTask: false,
+      started: tasks,
+    });
+  });
+
+  it('continues post-fix merge approvals through publishAfterFix', async () => {
+    const started = [
+      makeRunningTask({ id: 'merge-a', config: { workflowId: 'wf-1', isMergeNode: true } }),
+    ];
+    const orchestrator = {
+      approve: vi.fn().mockResolvedValue(started),
+      getTask: vi.fn().mockReturnValue(makeTask({
+        id: 'merge-a',
+        status: 'awaiting_approval',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: { pendingFixError: 'fix pending' },
+      })),
+      resumeTaskAfterFixApproval: vi.fn().mockResolvedValue(started),
+    };
+    const taskExecutor = {
+      commitApprovedFix: vi.fn(),
+      publishAfterFix: vi.fn(),
+      executeTasks: vi.fn(),
+    };
+
+    const result = await approveTask('merge-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    expect(result.fixedTask).toBe(true);
+    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'merge-a' }),
+    );
+    expect(orchestrator.resumeTaskAfterFixApproval).toHaveBeenCalledWith('merge-a');
+    expect(orchestrator.approve).not.toHaveBeenCalled();
+    expect(taskExecutor.publishAfterFix).toHaveBeenCalledWith(started[0]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
+  });
+
+  it('commits approved fixes before completing non-merge approvals', async () => {
+    const started = [makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } })];
+    const approvedTask = makeTask({
+      id: 'task-a',
+      status: 'awaiting_approval',
+      config: { workflowId: 'wf-1' },
+      execution: { pendingFixError: 'plain failure', workspacePath: '/tmp/task-a', branch: 'task-a' },
+    });
+    const orchestrator = {
+      approve: vi.fn().mockResolvedValue(started),
+      getTask: vi.fn().mockReturnValue(approvedTask),
+      resumeTaskAfterFixApproval: vi.fn(),
+    };
+    const taskExecutor = {
+      commitApprovedFix: vi.fn(),
+      publishAfterFix: vi.fn(),
+      executeTasks: vi.fn(),
+    };
+
+    await approveTask('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(approvedTask);
+    expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
+    expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
+    expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
+  });
+
+  it('commits then resumes merge-conflict fixed tasks', async () => {
+    const started = [makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } })];
+    const approvedTask = makeTask({
+      id: 'task-a',
+      status: 'awaiting_approval',
+      config: { workflowId: 'wf-1' },
+      execution: {
+        pendingFixError: JSON.stringify({ type: 'merge_conflict', conflictFiles: ['a.ts'] }),
+        workspacePath: '/tmp/task-a',
+        branch: 'task-a',
+      },
+    });
+    const orchestrator = {
+      approve: vi.fn(),
+      getTask: vi.fn().mockReturnValue(approvedTask),
+      resumeTaskAfterFixApproval: vi.fn().mockResolvedValue(started),
+    };
+    const taskExecutor = {
+      commitApprovedFix: vi.fn(),
+      publishAfterFix: vi.fn(),
+      executeTasks: vi.fn(),
+    };
+
+    await approveTask('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(approvedTask);
+    expect(orchestrator.resumeTaskAfterFixApproval).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.approve).not.toHaveBeenCalled();
+    expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
   });
 });
 
@@ -257,6 +365,7 @@ describe('finalizeAppliedFix', () => {
       approve: vi.fn(),
     };
     const taskExecutor = {
+      commitApprovedFix: vi.fn(),
       publishAfterFix: vi.fn(),
       executeTasks: vi.fn(),
     };
@@ -279,8 +388,15 @@ describe('finalizeAppliedFix', () => {
     const orchestrator = {
       setFixAwaitingApproval: vi.fn(),
       approve: vi.fn().mockResolvedValue(started),
+      getTask: vi.fn().mockReturnValue(makeTask({
+        id: 'task-a',
+        status: 'awaiting_approval',
+        config: { workflowId: 'wf-1' },
+        execution: { pendingFixError: 'saved-error', workspacePath: '/tmp/task-a', branch: 'task-a' },
+      })),
     };
     const taskExecutor = {
+      commitApprovedFix: vi.fn(),
       publishAfterFix: vi.fn(),
       executeTasks: vi.fn(),
     };
@@ -293,6 +409,9 @@ describe('finalizeAppliedFix', () => {
 
     expect(result).toEqual({ autoApproved: true, started });
     expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
+    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'task-a' }),
+    );
     expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
     expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
   });
@@ -304,8 +423,16 @@ describe('finalizeAppliedFix', () => {
     const orchestrator = {
       setFixAwaitingApproval: vi.fn(),
       approve: vi.fn().mockResolvedValue(started),
+      getTask: vi.fn().mockReturnValue(makeTask({
+        id: 'merge-a',
+        status: 'awaiting_approval',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: { pendingFixError: 'saved-error', workspacePath: '/tmp/merge-a' },
+      })),
+      resumeTaskAfterFixApproval: vi.fn().mockResolvedValue(started),
     };
     const taskExecutor = {
+      commitApprovedFix: vi.fn(),
       publishAfterFix: vi.fn(),
       executeTasks: vi.fn(),
     };
@@ -316,6 +443,9 @@ describe('finalizeAppliedFix', () => {
       autoApproveAIFixes: true,
     });
 
+    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'merge-a' }),
+    );
     expect(taskExecutor.publishAfterFix).toHaveBeenCalledWith(started[0]);
     expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
@@ -508,6 +638,12 @@ describe('autoFixOnFailure', () => {
       }))
       .mockReturnValueOnce(makeTask({
         id: 'merge-a',
+        status: 'awaiting_approval',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a', pendingFixError: 'boom' },
+      }))
+      .mockReturnValueOnce(makeTask({
+        id: 'merge-a',
         status: 'failed',
         config: { workflowId: 'wf-1', isMergeNode: true },
         execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a', error: 'Post-fix PR prep failed: conflict' },
@@ -518,11 +654,17 @@ describe('autoFixOnFailure', () => {
         config: { workflowId: 'wf-1', isMergeNode: true },
         execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a' },
       }))
+      .mockReturnValueOnce(makeTask({
+        id: 'merge-a',
+        status: 'awaiting_approval',
+        config: { workflowId: 'wf-1', isMergeNode: true },
+        execution: { autoFixAttempts: 2, workspacePath: '/tmp/merge-a', pendingFixError: 'boom' },
+      }))
       .mockReturnValue(makeTask({
         id: 'merge-a',
         status: 'awaiting_approval',
         config: { workflowId: 'wf-1', isMergeNode: true },
-        execution: { autoFixAttempts: 2, workspacePath: '/tmp/merge-a' },
+        execution: { autoFixAttempts: 2, workspacePath: '/tmp/merge-a', pendingFixError: 'boom' },
       }));
     const shouldAutoFix = vi
       .fn()
@@ -538,6 +680,7 @@ describe('autoFixOnFailure', () => {
       restartTask: vi.fn(() => []),
       setFixAwaitingApproval: vi.fn(),
       approve: vi.fn().mockResolvedValue(started),
+      resumeTaskAfterFixApproval: vi.fn().mockResolvedValue(started),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -549,6 +692,7 @@ describe('autoFixOnFailure', () => {
     const taskExecutor = {
       fixWithAgent: vi.fn().mockResolvedValue(undefined),
       resolveConflict: vi.fn(),
+      commitApprovedFix: vi.fn().mockResolvedValue(undefined),
       execGitIn: vi.fn().mockResolvedValue('abc123'),
       publishAfterFix: vi
         .fn()

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -37,6 +37,7 @@ import type { Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { ExecutorRegistry, TaskRunner } from '@invoker/execution-engine';
 import {
+  approveTask as sharedApproveTask,
   recreateWorkflow as sharedRecreateWorkflow,
   cancelWorkflow as sharedCancelWorkflow,
   restartTask as sharedRestartTask,
@@ -58,6 +59,7 @@ export interface ApiServerDeps {
   executorRegistry: ExecutorRegistry;
   taskExecutor: TaskRunner;
   autoApproveAIFixes?: boolean;
+  approveTaskAction?: (taskId: string) => Promise<void>;
   killRunningTask?: (taskId: string) => Promise<void>;
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
@@ -128,6 +130,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     executorRegistry,
     taskExecutor,
     autoApproveAIFixes,
+    approveTaskAction,
     killRunningTask,
     cancelTask,
     cancelWorkflow,
@@ -251,15 +254,14 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && approveMatch) {
         const taskId = decodeURIComponent(approveMatch[1]);
         try {
-          const started = await orchestrator.approve(taskId);
-          const postFixMerge = started.filter(t => t.status === 'running' && t.config.isMergeNode && t.id === taskId);
-          for (const task of postFixMerge) {
-            taskExecutor.publishAfterFix(task).catch(err => {
-              apiLogger?.error(`approve: publishAfterFix failed for "${task.id}": ${err}`, { module: 'api' });
+          if (approveTaskAction) {
+            await approveTaskAction(taskId);
+          } else {
+            await sharedApproveTask(taskId, {
+              orchestrator,
+              taskExecutor,
             });
           }
-          const runnable = started.filter(t => t.status === 'running' && !(t.config.isMergeNode && t.id === taskId));
-          if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
           json(res, 200, { ok: true, taskId, action: 'approved' });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -30,6 +30,7 @@ import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from './config
 import { backupPlan } from './plan-backup.js';
 import { startApiServer, type ApiServerDeps } from './api-server.js';
 import {
+  approveTask,
   rebaseAndRetry,
   resolveConflictAction,
   recreateWorkflow as sharedRecreateWorkflow,
@@ -73,6 +74,7 @@ export interface HeadlessDeps {
   wireSlackBot: (deps: {
     executor: TaskRunner;
     logFn: (source: string, level: string, message: string) => void;
+    approveTaskAction?: (taskId: string) => Promise<void>;
     onPlanLoaded?: () => void;
   }) => Promise<any>;
   getUiPerfStats?: () => Record<string, unknown>;
@@ -122,6 +124,30 @@ function buildHeadlessApiCancelHooks(
       }
       return cmdResult.data;
     },
+  };
+}
+
+function buildHeadlessApproveAction(
+  deps: Pick<HeadlessDeps, 'orchestrator' | 'commandService'>,
+  taskExecutor: TaskRunner,
+): (taskId: string) => Promise<void> {
+  return async (taskId: string) => {
+    await approveTask(taskId, {
+      orchestrator: deps.orchestrator,
+      taskExecutor,
+      approve: async (approvedTaskId) => {
+        const envelope = makeEnvelope('approve', 'headless', 'task', { taskId: approvedTaskId });
+        const result = await deps.commandService.approve(envelope);
+        if (!result.ok) throw new Error(result.error.message);
+        return result.data;
+      },
+      resumeAfterFixApproval: async (approvedTaskId) => {
+        const envelope = makeEnvelope('approve', 'headless', 'task', { taskId: approvedTaskId });
+        const result = await deps.commandService.resumeTaskAfterFixApproval(envelope);
+        if (!result.ok) throw new Error(result.error.message);
+        return result.data;
+      },
+    });
   };
 }
 
@@ -236,14 +262,10 @@ export function wireHeadlessAutoFix(
 
 export function wireHeadlessApproveHook(deps: HeadlessDeps, te: TaskRunner): void {
   deps.orchestrator.setBeforeApproveHook(async (task) => {
-    if (task.config.isMergeNode && task.config.workflowId) {
+    if (task.config.isMergeNode && task.config.workflowId && task.execution.pendingFixError === undefined) {
       const workflow = deps.persistence.loadWorkflow(task.config.workflowId);
       if (workflow?.mergeMode === "external_review") return;
       await te.approveMerge(task.config.workflowId);
-      return;
-    }
-    if (!task.config.isMergeNode && task.execution.pendingFixError !== undefined) {
-      await te.publishApprovedFix(task);
     }
   });
 }
@@ -803,6 +825,7 @@ async function headlessRun(
   const taskExecutor = createHeadlessExecutor(deps);
   wireHeadlessApproveHook(deps, taskExecutor);
   const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
+  const approveTaskAction = buildHeadlessApproveAction(deps, taskExecutor);
 
   const api = startApiServer({
     logger: deps.logger,
@@ -811,6 +834,7 @@ async function headlessRun(
     executorRegistry: deps.executorRegistry,
     taskExecutor,
     autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
+    approveTaskAction,
     ...buildHeadlessApiCancelHooks(deps, taskExecutor),
   });
 
@@ -871,6 +895,7 @@ async function headlessResume(
   const taskExecutor = createHeadlessExecutor(deps);
   wireHeadlessApproveHook(deps, taskExecutor);
   const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
+  const approveTaskAction = buildHeadlessApproveAction(deps, taskExecutor);
 
   const api = startApiServer({
     logger: deps.logger,
@@ -879,6 +904,7 @@ async function headlessResume(
     executorRegistry: deps.executorRegistry,
     taskExecutor,
     autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
+    approveTaskAction,
     ...buildHeadlessApiCancelHooks(deps, taskExecutor),
   });
 
@@ -928,20 +954,15 @@ async function headlessApprove(taskId: string, deps: HeadlessDeps): Promise<void
   const te = createHeadlessExecutor(deps);
   wireHeadlessApproveHook(deps, te);
   const autoFix = wireHeadlessAutoFix(deps, te);
-  const envelope = makeEnvelope('approve', 'headless', 'task', { taskId });
-  const result = await deps.commandService.approve(envelope);
-  if (!result.ok) throw new Error(result.error.message);
-  const started = result.data;
-  const runnable = started.filter((task) => task.status === 'running');
-  if (runnable.length > 0) {
-    await te.executeTasks(runnable);
-  }
-  const postFixMerge = started.filter(t => t.status === 'running' && t.config.isMergeNode && t.id === taskId);
-  for (const task of postFixMerge) {
-    await te.publishAfterFix(task);
-  }
+  const approveTaskAction = buildHeadlessApproveAction(deps, te);
+  const beforeStatus = deps.orchestrator.getWorkflowStatus(restored.workflowId);
+  await approveTaskAction(taskId);
   process.stdout.write(`Approved task: ${taskId}\n`);
-  if (runnable.length === 0) {
+  const afterStatus = deps.orchestrator.getWorkflowStatus(restored.workflowId);
+  const resumedWork =
+    afterStatus.running > beforeStatus.running
+    || afterStatus.pending < beforeStatus.pending;
+  if (!resumedWork) {
     autoFix.unsubscribe();
     return;
   }
@@ -1708,6 +1729,7 @@ async function headlessSlack(deps: HeadlessDeps): Promise<void> {
     },
   });
   wireHeadlessApproveHook(deps, taskExecutor);
+  const approveTaskAction = buildHeadlessApproveAction(deps, taskExecutor);
 
   const api = startApiServer({
     logger: deps.logger,
@@ -1715,6 +1737,7 @@ async function headlessSlack(deps: HeadlessDeps): Promise<void> {
     persistence,
     executorRegistry: deps.executorRegistry,
     taskExecutor,
+    approveTaskAction,
     ...buildHeadlessApiCancelHooks(deps, taskExecutor),
   });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -93,6 +93,7 @@ import {
   type HeadlessDeps,
 } from './headless.js';
 import {
+  approveTask as sharedApproveTask,
   rebaseAndRetry,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
@@ -364,6 +365,7 @@ function loadSurfaces(): any {
 interface SlackBotDeps {
   executor: TaskRunner;
   logFn: (source: string, level: string, message: string) => void;
+  approveTaskAction?: (taskId: string) => Promise<void>;
   onStartPlan?: () => void;
   onPlanLoaded?: (plan: PlanDefinition) => void;
 }
@@ -418,18 +420,29 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
     deps.logFn('trace', 'info', `slackBot: command received — type=${command.type}`);
     switch (command.type) {
       case 'approve': {
-        const env = makeEnvelope('approve', 'surface', 'task', { taskId: command.taskId as string });
-        const approveResult = await commandService.approve(env);
-        if (!approveResult.ok) throw new Error(approveResult.error.message);
-        const approveStarted = approveResult.data;
-        const pfm = approveStarted.filter(t => t.status === 'running' && t.config.isMergeNode && t.id === command.taskId);
-        for (const task of pfm) {
-          deps.executor.publishAfterFix(task).catch(err => {
-            logger.error(`approve: publishAfterFix failed for "${task.id}": ${err}`, { module: 'slack' });
-          });
+        const taskId = command.taskId as string;
+        if (deps.approveTaskAction) {
+          await deps.approveTaskAction(taskId);
+          break;
         }
-        const runnable = approveStarted.filter(t => t.status === 'running' && !(t.config.isMergeNode && t.id === command.taskId));
-        if (runnable.length > 0) await deps.executor.executeTasks(runnable);
+        await sharedApproveTask(taskId, {
+          orchestrator,
+          taskExecutor: deps.executor,
+          approve: async (approvedTaskId) => {
+            const result = await commandService.approve(
+              makeEnvelope('approve', 'surface', 'task', { taskId: approvedTaskId }),
+            );
+            if (!result.ok) throw new Error(result.error.message);
+            return result.data;
+          },
+          resumeAfterFixApproval: async (approvedTaskId) => {
+            const result = await commandService.resumeTaskAfterFixApproval(
+              makeEnvelope('approve', 'surface', 'task', { taskId: approvedTaskId }),
+            );
+            if (!result.ok) throw new Error(result.error.message);
+            return result.data;
+          },
+        });
         break;
       }
       case 'reject': {
@@ -1234,14 +1247,10 @@ if (isHeadless) {
 
   function wireApproveHook(): void {
     orchestrator.setBeforeApproveHook(async (task) => {
-      if (task.config.isMergeNode && task.config.workflowId) {
+      if (task.config.isMergeNode && task.config.workflowId && task.execution.pendingFixError === undefined) {
         const workflow = persistence.loadWorkflow(task.config.workflowId);
         if (workflow?.mergeMode === "external_review") return; // external review is the merge mechanism
         await requireTaskExecutor().approveMerge(task.config.workflowId);
-        return;
-      }
-      if (!task.config.isMergeNode && task.execution.pendingFixError !== undefined) {
-        await requireTaskExecutor().publishApprovedFix(task);
       }
     });
   }
@@ -1585,6 +1594,28 @@ if (isHeadless) {
     }
   }
 
+  async function performSharedApproveTask(
+    taskId: string,
+    source: 'ui' | 'surface' | 'api',
+    scope: 'task' | 'workflow' = 'task',
+  ): Promise<{ started: TaskState[] }> {
+    const envelope = makeEnvelope('approve', source === 'api' ? 'surface' : source, scope, { taskId });
+    return sharedApproveTask(taskId, {
+      orchestrator,
+      taskExecutor: requireTaskExecutor(),
+      approve: async (approvedTaskId) => {
+        const result = await commandService.approve({ ...envelope, payload: { taskId: approvedTaskId } });
+        if (!result.ok) throw new Error(result.error.message);
+        return result.data;
+      },
+      resumeAfterFixApproval: async (approvedTaskId) => {
+        const result = await commandService.resumeTaskAfterFixApproval({ ...envelope, payload: { taskId: approvedTaskId } });
+        if (!result.ok) throw new Error(result.error.message);
+        return result.data;
+      },
+    });
+  }
+
   function registerGuiMutationHandler<TResult = unknown>(
     channel: string,
     handler: (...args: unknown[]) => Promise<TResult>,
@@ -1897,6 +1928,12 @@ if (isHeadless) {
         executorRegistry,
         taskExecutor: requireTaskExecutor(),
         autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+        approveTaskAction: async (taskId: string) => {
+          const workflowId = orchestrator.getTask(taskId)?.config.workflowId;
+          await runWorkflowMutation(workflowId, 'normal', 'api:approve-task', [taskId], async () => {
+            await performSharedApproveTask(taskId, 'api');
+          });
+        },
         killRunningTask,
         cancelTask: performCancelTask,
         cancelWorkflow: performCancelWorkflow,
@@ -2101,6 +2138,12 @@ if (isHeadless) {
     if (ownerMode) {
       workflowMutationDispatcher.set('headless.exec', async (payloadArg: unknown) => {
         return executeHeadlessExec(payloadArg as HeadlessExecMutationPayload);
+      });
+      workflowMutationDispatcher.set('api:approve-task', async (taskIdArg: unknown) => {
+        await performSharedApproveTask(String(taskIdArg), 'api');
+      });
+      workflowMutationDispatcher.set('surface:approve-task', async (taskIdArg: unknown) => {
+        await performSharedApproveTask(String(taskIdArg), 'surface');
       });
       messageBus.onRequest('headless.owner-ping', async () => ({
         ok: true,
@@ -2489,27 +2532,17 @@ if (isHeadless) {
       if (!result.ok) throw new Error(result.error.message);
     });
 
-    registerGuiMutationHandler('invoker:approve', async (taskIdArg: unknown) => {
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:approve',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'normal',
+      async (taskIdArg: unknown) => {
       const taskId = String(taskIdArg);
       logger.info(`approve: "${taskId}"`, { module: 'ipc' });
-      const envelope = makeEnvelope('approve', 'ui', 'task', { taskId });
-      const result = await commandService.approve(envelope);
-      if (!result.ok) throw new Error(result.error.message);
-      const started = result.data;
+      const { started } = await performSharedApproveTask(taskId, 'ui');
       logger.info(`approve: commandService returned ${started.length} started tasks: [${started.map(t => `${t.id}(${t.status})`).join(', ')}]`, { module: 'ipc' });
-
-      const postFixMerge = started.filter(t => t.status === 'running' && t.config.isMergeNode && t.id === taskId);
-      for (const task of postFixMerge) {
-        logger.info(`approve: post-fix PR prep for merge gate "${task.id}"`, { module: 'ipc' });
-        requireTaskExecutor().publishAfterFix(task).catch(err => {
-          logger.error(`approve: publishAfterFix failed for "${task.id}": ${err}`, { module: 'ipc' });
-        });
-      }
-
-      const runnable = started.filter(t => t.status === 'running' && !(t.config.isMergeNode && t.id === taskId));
-      logger.info(`approve: ${runnable.length} runnable after filter: [${runnable.map(t => t.id).join(', ')}]`, { module: 'ipc' });
-      if (runnable.length > 0) await requireTaskExecutor().executeTasks(runnable);
-    });
+      },
+    );
 
     registerGuiMutationHandler('invoker:reject', async (taskIdArg: unknown, reasonArg?: unknown) => {
       const taskId = String(taskIdArg);
@@ -2824,29 +2857,23 @@ if (isHeadless) {
       }
     });
 
-    registerGuiMutationHandler('invoker:approve-merge', async (workflowIdArg: unknown) => {
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:approve-merge',
+      (workflowIdArg: unknown) => String(workflowIdArg),
+      'normal',
+      async (workflowIdArg: unknown) => {
       const workflowId = String(workflowIdArg);
       logger.info(`approve-merge: "${workflowId}"`, { module: 'ipc' });
       try {
         const mergeTask = orchestrator.getMergeNode(workflowId);
         if (!mergeTask) throw new Error(`No merge node for workflow ${workflowId}`);
-        const envelope = makeEnvelope('approve', 'ui', 'workflow', { taskId: mergeTask.id });
-        const result = await commandService.approve(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        const started = result.data;
-        const postFixMerge = started.filter(t => t.status === 'running' && t.config.isMergeNode && t.id === mergeTask.id);
-        for (const task of postFixMerge) {
-          requireTaskExecutor().publishAfterFix(task).catch(err => {
-            logger.error(`approve-merge: publishAfterFix failed for "${task.id}": ${err}`, { module: 'ipc' });
-          });
-        }
-        const runnable = started.filter(t => t.status === 'running' && !(t.config.isMergeNode && t.id === mergeTask.id));
-        if (runnable.length > 0) await requireTaskExecutor().executeTasks(runnable);
+        await performSharedApproveTask(mergeTask.id, 'ui', 'workflow');
       } catch (err) {
         logger.error(`approve-merge failed: ${err}`, { module: 'ipc' });
         throw err;
       }
-    });
+      },
+    );
 
     registerGuiMutationHandler('invoker:check-pr-statuses', async () => {
       logger.info('check-pr-statuses', { module: 'ipc' });
@@ -3103,6 +3130,12 @@ if (isHeadless) {
     await wireSlackBot({
       executor,
       logFn,
+      approveTaskAction: async (taskId: string) => {
+        const workflowId = orchestrator.getTask(taskId)?.config.workflowId;
+        await runWorkflowMutation(workflowId, 'normal', 'surface:approve-task', [taskId], async () => {
+          await performSharedApproveTask(taskId, 'surface');
+        });
+      },
       onStartPlan: () => handles.clear(),
       onPlanLoaded: () => {},
     });

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -27,6 +27,12 @@ export interface ActionDeps {
   autoApproveAIFixes?: boolean;
 }
 
+export interface ApproveTaskResult {
+  approvedTask?: TaskState;
+  started: TaskState[];
+  fixedTask: boolean;
+}
+
 // ── Actions ──────────────────────────────────────────────────
 
 export function bumpGenerationAndRecreate(
@@ -45,9 +51,42 @@ export function bumpGenerationAndRecreate(
 
 export async function approveTask(
   taskId: string,
-  deps: Pick<ActionDeps, 'orchestrator'>,
-): Promise<TaskState[]> {
-  return deps.orchestrator.approve(taskId);
+  deps: Pick<ActionDeps, 'orchestrator'> & {
+    taskExecutor?: TaskRunner;
+    approve?: (taskId: string) => Promise<TaskState[]>;
+    resumeAfterFixApproval?: (taskId: string) => Promise<TaskState[]>;
+  },
+): Promise<ApproveTaskResult> {
+  const task = deps.orchestrator.getTask?.(taskId);
+  const fixedTask = task?.execution.pendingFixError !== undefined;
+  if (fixedTask && task && deps.taskExecutor) {
+    await deps.taskExecutor.commitApprovedFix(task);
+  }
+
+  const shouldResume =
+    fixedTask &&
+    task !== undefined &&
+    (task.config.isMergeNode || isMergeConflictError(task.execution.pendingFixError ?? ''));
+  const started = await (
+    shouldResume
+      ? (deps.resumeAfterFixApproval ?? deps.orchestrator.resumeTaskAfterFixApproval.bind(deps.orchestrator))
+      : (deps.approve ?? deps.orchestrator.approve.bind(deps.orchestrator))
+  )(taskId);
+  const postFixMerge = started.filter(
+    (t) => t.status === 'running' && t.config.isMergeNode && t.id === taskId,
+  );
+  if (deps.taskExecutor) {
+    for (const task of postFixMerge) {
+      await deps.taskExecutor.publishAfterFix(task);
+    }
+    const runnable = started.filter(
+      (t) => t.status === 'running' && !(t.config.isMergeNode && t.id === taskId),
+    );
+    if (runnable.length > 0) {
+      await deps.taskExecutor.executeTasks(runnable);
+    }
+  }
+  return { approvedTask: task, started, fixedTask };
 }
 
 /**
@@ -251,19 +290,7 @@ export async function finalizeAppliedFix(
     return { autoApproved: false, started: [] };
   }
 
-  const started = await deps.orchestrator.approve(taskId);
-  const postFixMerge = started.filter(
-    (t) => t.status === 'running' && t.config.isMergeNode && t.id === taskId,
-  );
-  for (const task of postFixMerge) {
-    await deps.taskExecutor.publishAfterFix(task);
-  }
-  const runnable = started.filter(
-    (t) => t.status === 'running' && !(t.config.isMergeNode && t.id === taskId),
-  );
-  if (runnable.length > 0) {
-    await deps.taskExecutor.executeTasks(runnable);
-  }
+  const { started } = await approveTask(taskId, deps);
   return { autoApproved: true, started };
 }
 


### PR DESCRIPTION
## Summary

This PR routes approval through one shared app-layer commit-and-resume flow across Electron, headless, and the API server. Before this change, each surface had its own mix of `orchestrator.approve()`, `publishAfterFix()`, and task execution follow-up, which made fixed-task approval behavior inconsistent and easy to bypass.

After this change, the shared `approveTask(...)` action owns the full decision: inspect the approved task, commit the approved fix when needed, choose `approve()` vs `resumeTaskAfterFixApproval()`, and then dispatch either downstream execution or merge-gate continuation.

## Architecture

### Before

```mermaid
graph TD
    UI["Electron UI"] --> RAW1["Raw approve / merge follow-up"]
    HL["Headless"] --> RAW2["Custom approve wiring"]
    API["API server"] --> RAW3["Direct orchestrator.approve()"]

    RAW1 --> ORC["Orchestrator"]
    RAW2 --> ORC
    RAW3 --> ORC
    RAW1 --> EXEC["TaskRunner side effects"]
    RAW2 --> EXEC
    RAW3 --> EXEC

    style RAW1 fill:#ffcdd2
    style RAW2 fill:#ffcdd2
    style RAW3 fill:#ffcdd2
```

### After

```mermaid
graph TD
    UI["Electron UI"] --> ACTION["workflow-actions.approveTask()"]
    HL["Headless"] --> ACTION
    API["API server"] --> ACTION

    ACTION --> COMMIT["commitApprovedFix() when pendingFixError exists"]
    ACTION --> CHOOSE["approve() or resumeTaskAfterFixApproval()"]
    CHOOSE --> EXECUTE["executeTasks() for normal flow"]
    CHOOSE --> MERGE["publishAfterFix() for merge continuation"]

    style ACTION fill:#e3f2fd
    style COMMIT fill:#fff3e0
    style MERGE fill:#e8f5e9
```

**Key changes:**
- Added a shared structured `approveTask(...)` action in `workflow-actions.ts`.
- Routed fixed-task approval decisions through commit-first logic before continuation.
- Let the API server accept an injected `approveTaskAction` so it no longer has to bypass the shared flow.
- Added API and workflow-action tests that cover non-fix, non-merge fix, merge-conflict fix, and merge-gate fix approval behavior.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts src/__tests__/api-server.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts src/__tests__/command-service.test.ts`

## Revert Plan

- **Safe to revert?** Yes
- **Revert command:** `git revert 4555dd3`
- **Post-revert steps:** None
- **What breaks if reverted:** Approval handling becomes surface-specific again, and fixed-task approval can bypass the shared commit-and-resume path.
- **Data migration?** No
