### PR TITLE
ci: install sqlite3 in docker job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,9 @@ jobs:
           git update-ref refs/heads/main refs/remotes/origin/master || true
           git update-ref refs/remotes/origin/main refs/remotes/origin/master || true
 
+      - name: Install sqlite3
+        run: sudo apt-get install -y sqlite3
+
       - name: Build invoker agent base image
         run: bash scripts/build-agent-base-image.sh
 


### PR DESCRIPTION
The docker comprehensive test suite queries task state from the DB using `sqlite3` after plan execution. The `ubuntu-latest` runner does not have it pre-installed, so the pre-flight check exits early with code 2 before any tests run.

**Fix:** add `sqlite3` install step to the `docker / comprehensive` job, consistent with how the `ssh` job installs `openssh-server`.

**Verified:** traced the failure to the pre-flight check at line 159 of `scripts/test-docker-comprehensive.sh` — the DB file does not exist at that point, so the `sqlite3` availability check runs and fails.

> **Note:** PR #20 fixes the `master` branch conflict in the same docker job. This PR should be merged after #20 to get a clean green run.