### PR TITLE
feat: add query summary subcommand

### DIFF
--- a/packages/app/src/__tests__/headless-query-summary.test.ts
+++ b/packages/app/src/__tests__/headless-query-summary.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runHeadless } from '../headless.js';
+import type { HeadlessDeps } from '../headless.js';
+import { Orchestrator, CommandService } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { MessageBus } from '@invoker/transport';
+import { LocalBus } from '@invoker/transport';
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn(function () { return noopLogger; }),
+};
+
+function makeTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'wf-1/task-a',
+    description: 'Do something',
+    status: 'completed',
+    dependencies: [],
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    config: { workflowId: 'wf-1', executorType: 'worktree', isMergeNode: false },
+    execution: {
+      startedAt: new Date('2024-01-01T00:00:00Z'),
+      completedAt: new Date('2024-01-01T00:01:00Z'),
+    },
+    ...overrides,
+  };
+}
+
+describe('headless query summary', () => {
+  let mockDeps: HeadlessDeps;
+
+  beforeEach(() => {
+    mockDeps = {
+      logger: noopLogger as any,
+      orchestrator: {} as Orchestrator,
+      persistence: {
+        readOnly: false,
+        listWorkflows: vi.fn(() => [
+          { id: 'wf-1', name: 'My Workflow', status: 'completed', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:01:00Z' },
+        ]),
+        loadTasks: vi.fn(() => []),
+      } as unknown as SQLiteAdapter,
+      commandService: {} as CommandService,
+      executorRegistry: {} as any,
+      messageBus: new LocalBus() as MessageBus,
+      repoRoot: '/fake/repo',
+      invokerConfig: {} as any,
+      initServices: vi.fn(async () => {}),
+      wireSlackBot: vi.fn(async () => ({})),
+    };
+    mockDeps.orchestrator.syncFromDb = vi.fn();
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [makeTask()]);
+  });
+
+  it('resolves without error', async () => {
+    await expect(runHeadless(['query', 'summary'], mockDeps)).resolves.toBeUndefined();
+  });
+
+  it('outputs JSON with counts and status', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'summary', '--output', 'json'], mockDeps);
+    const out = (stdout.mock.calls[0][0] as string);
+    const parsed = JSON.parse(out);
+    expect(parsed.workflowId).toBe('wf-1');
+    expect(parsed.status).toBe('completed');
+    expect(parsed.counts.completed).toBe(1);
+    expect(parsed.failedTasks).toEqual([]);
+    stdout.mockRestore();
+  });
+
+  it('includes failed task details in JSON output', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [
+      makeTask({ id: 'wf-1/task-a', status: 'failed', execution: { error: 'exit code 1' } }),
+    ]);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'summary', '--output', 'json'], mockDeps);
+    const parsed = JSON.parse(stdout.mock.calls[0][0] as string);
+    expect(parsed.counts.failed).toBe(1);
+    expect(parsed.failedTasks[0].error).toBe('exit code 1');
+    stdout.mockRestore();
+  });
+
+  it('outputs label as workflow status', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'summary', '--output', 'label'], mockDeps);
+    expect(stdout.mock.calls[0][0]).toBe('completed\n');
+    stdout.mockRestore();
+  });
+
+  it('throws when no workflows exist', async () => {
+    (mockDeps.persistence.listWorkflows as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'summary'], mockDeps);
+    expect(stdout.mock.calls[0][0]).toContain('No workflows found');
+    stdout.mockRestore();
+  });
+
+  it('throws when specified workflow not found', async () => {
+    await expect(
+      runHeadless(['query', 'summary', 'wf-nonexistent'], mockDeps)
+    ).rejects.toThrow(/not found/);
+  });
+
+  it('excludes merge nodes from counts', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [
+      makeTask({ id: 'wf-1/task-a', status: 'completed' }),
+      makeTask({ id: 'wf-1/__merge__wf-1', status: 'completed', config: { workflowId: 'wf-1', isMergeNode: true } }),
+    ]);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'summary', '--output', 'json'], mockDeps);
+    const parsed = JSON.parse(stdout.mock.calls[0][0] as string);
+    expect(parsed.counts.completed).toBe(1);
+    stdout.mockRestore();
+  });
+});

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -193,6 +193,53 @@ export function formatQueueStatus(status: {
   return lines.join('\n');
 }
 
+/**
+ * Format a workflow summary: task counts by status, failed task names, elapsed time.
+ */
+export function formatWorkflowSummary(summary: {
+  workflowId: string;
+  name: string;
+  status: string;
+  counts: Record<string, number>;
+  failedTasks: Array<{ id: string; description: string; error?: string }>;
+  elapsedMs: number | null;
+}): string {
+  const lines: string[] = [];
+
+  const wfColor = summary.status === 'completed' ? GREEN : summary.status === 'failed' ? RED : YELLOW;
+  lines.push(`${BOLD}${summary.workflowId}${RESET} — ${summary.name} ${wfColor}[${summary.status}]${RESET}`);
+  lines.push('');
+
+  const total = Object.values(summary.counts).reduce((a, b) => a + b, 0);
+  const countParts = [
+    `${BOLD}${total}${RESET} total`,
+    `${GREEN}${summary.counts.completed ?? 0} completed${RESET}`,
+    `${RED}${summary.counts.failed ?? 0} failed${RESET}`,
+    `${YELLOW}${summary.counts.running ?? 0} running${RESET}`,
+    `${DIM}${summary.counts.pending ?? 0} pending${RESET}`,
+  ];
+  if ((summary.counts.blocked ?? 0) > 0) countParts.push(`${DIM}${summary.counts.blocked} blocked${RESET}`);
+  if ((summary.counts.review_ready ?? 0) > 0) countParts.push(`${CYAN}${summary.counts.review_ready} review_ready${RESET}`);
+  lines.push(countParts.join(' | '));
+
+  if (summary.elapsedMs !== null) {
+    const secs = Math.round(summary.elapsedMs / 1000);
+    const elapsed = secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${secs % 60}s`;
+    lines.push(`${DIM}Elapsed: ${elapsed}${RESET}`);
+  }
+
+  if (summary.failedTasks.length > 0) {
+    lines.push('');
+    lines.push(`${RED}${BOLD}Failed tasks:${RESET}`);
+    for (const t of summary.failedTasks) {
+      lines.push(`  ${RED}✗ ${BOLD}${t.id}${RESET}${RED} — ${t.description}${RESET}`);
+      if (t.error) lines.push(`    ${DIM}${t.error.split('\n')[0]}${RESET}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
 // ── Output Format Type ──────────────────────────────────────
 
 export type OutputFormat = 'text' | 'label' | 'json' | 'jsonl';

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -346,7 +346,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
 
   const {
     formatWorkflowList, formatTaskStatus, formatWorkflowStatus,
-    formatEventLog, formatQueueStatus,
+    formatEventLog, formatQueueStatus, formatWorkflowSummary,
     serializeWorkflow, serializeTask, serializeEvent,
     formatAsLabel, formatAsJson, formatAsJsonl,
   } = await import('./formatter.js');
@@ -506,8 +506,51 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
       }
       break;
     }
+    case 'summary': {
+      const { orchestrator, persistence } = deps;
+      const workflows = persistence.listWorkflows();
+      if (workflows.length === 0) {
+        process.stdout.write('No workflows found.\n');
+        return;
+      }
+      const workflowId = flags.positional[0] ?? flags.workflow ?? workflows[0].id;
+      const wf = workflows.find(w => w.id === workflowId);
+      if (!wf) throw new Error(`Workflow "${workflowId}" not found.`);
+
+      orchestrator.syncFromDb(wf.id);
+      const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === wf.id && !t.config.isMergeNode);
+
+      const counts: Record<string, number> = {};
+      for (const t of tasks) counts[t.status] = (counts[t.status] ?? 0) + 1;
+
+      const failedTasks = tasks
+        .filter(t => t.status === 'failed')
+        .map(t => ({ id: t.id, description: t.description, error: t.execution.error ?? undefined }));
+
+      // Elapsed: from earliest startedAt to latest completedAt (or now if still running)
+      let elapsedMs: number | null = null;
+      const starts = tasks.map(t => t.execution.startedAt).filter(Boolean) as Date[];
+      if (starts.length > 0) {
+        const earliest = Math.min(...starts.map(d => d instanceof Date ? d.getTime() : new Date(d).getTime()));
+        const ends = tasks.map(t => t.execution.completedAt).filter(Boolean) as Date[];
+        const latest = ends.length === tasks.length
+          ? Math.max(...ends.map(d => d instanceof Date ? d.getTime() : new Date(d).getTime()))
+          : Date.now();
+        elapsedMs = latest - earliest;
+      }
+
+      const summary = { workflowId: wf.id, name: wf.name, status: wf.status, counts, failedTasks, elapsedMs };
+
+      switch (flags.output) {
+        case 'label': process.stdout.write(wf.status + '\n'); break;
+        case 'json':  process.stdout.write(formatAsJson(summary) + '\n'); break;
+        case 'jsonl': process.stdout.write(formatAsJsonl([summary]) + '\n'); break;
+        default:      process.stdout.write(formatWorkflowSummary(summary) + '\n'); break;
+      }
+      break;
+    }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, ui-perf`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, ui-perf, summary`);
   }
 }
 
@@ -740,6 +783,7 @@ ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
   query audit <taskId> [--output F]                   Print event history
   query session <taskId>                              Print agent session messages
   query ui-perf [--output F] [--reset]               Print live UI perf stats
+  query summary [<workflowId>] [--output F]          Task counts, failed tasks, elapsed time
 
 ${BOLD}Execute:${RESET}
   run <plan.yaml>                                     Load and execute plan


### PR DESCRIPTION
Adds `--headless query summary [<workflowId>]`.

Prints task counts by status, names of failed tasks with their error messages, and elapsed time. Defaults to the latest workflow if no ID is given. Merge nodes are excluded from counts.

**Usage**
```
# human-readable
electron dist/main.js --headless query summary

# scriptable
electron dist/main.js --headless query summary --output json
electron dist/main.js --headless query summary --output label  # workflow status only
```

**Example output**
```
wf-1775932917566-8 — ci-hardening [failed]

12 total | 9 completed | 3 failed | 0 running | 0 pending

Failed tasks:
  ✗ wf-.../run-all-fixture-tests — Run the complete fixture test suite
    merge_conflict: packages/app/src/config.ts
```

7 tests added.