### PR TITLE
feat: track workflow startedAt and completedAt

### DIFF
--- a/packages/app/src/__tests__/workflow-duration.test.ts
+++ b/packages/app/src/__tests__/workflow-duration.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { serializeWorkflow, formatWorkflowList } from '../formatter.js';
+import type { Workflow } from '@invoker/data-store';
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: 'wf-1',
+    name: 'Test Workflow',
+    status: 'completed',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:02:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('workflow duration tracking', () => {
+  describe('serializeWorkflow', () => {
+    it('includes startedAt and completedAt when present', () => {
+      const wf = makeWorkflow({
+        startedAt: '2024-01-01T00:00:05.000Z',
+        completedAt: '2024-01-01T00:02:05.000Z',
+      });
+      const result = serializeWorkflow(wf);
+      expect(result.startedAt).toBe('2024-01-01T00:00:05.000Z');
+      expect(result.completedAt).toBe('2024-01-01T00:02:05.000Z');
+    });
+
+    it('computes durationMs from startedAt to completedAt', () => {
+      const wf = makeWorkflow({
+        startedAt: '2024-01-01T00:00:00.000Z',
+        completedAt: '2024-01-01T00:01:30.000Z',
+      });
+      const result = serializeWorkflow(wf);
+      expect(result.durationMs).toBe(90_000);
+    });
+
+    it('omits durationMs when startedAt is missing', () => {
+      const wf = makeWorkflow({ completedAt: '2024-01-01T00:01:00.000Z' });
+      const result = serializeWorkflow(wf);
+      expect(result.durationMs).toBeUndefined();
+    });
+
+    it('omits durationMs when completedAt is missing', () => {
+      const wf = makeWorkflow({ startedAt: '2024-01-01T00:00:00.000Z' });
+      const result = serializeWorkflow(wf);
+      expect(result.durationMs).toBeUndefined();
+    });
+
+    it('omits startedAt and completedAt when not set', () => {
+      const wf = makeWorkflow();
+      const result = serializeWorkflow(wf);
+      expect(result.startedAt).toBeUndefined();
+      expect(result.completedAt).toBeUndefined();
+    });
+  });
+
+  describe('formatWorkflowList', () => {
+    it('shows duration in seconds when both timestamps present', () => {
+      const wf = makeWorkflow({
+        startedAt: '2024-01-01T00:00:00.000Z',
+        completedAt: '2024-01-01T00:00:45.000Z',
+      });
+      const output = formatWorkflowList([wf]);
+      expect(output).toContain('45s');
+    });
+
+    it('shows duration in minutes when over 60s', () => {
+      const wf = makeWorkflow({
+        startedAt: '2024-01-01T00:00:00.000Z',
+        completedAt: '2024-01-01T00:02:30.000Z',
+      });
+      const output = formatWorkflowList([wf]);
+      expect(output).toContain('2m 30s');
+    });
+
+    it('omits duration when timestamps are missing', () => {
+      const wf = makeWorkflow();
+      const output = formatWorkflowList([wf]);
+      expect(output).not.toMatch(/\d+s/);
+    });
+  });
+});

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -96,7 +96,7 @@ export function formatWorkflowStatus(status: {
  * Each workflow gets one line: "  id — name [status] (created)"
  */
 export function formatWorkflowList(
-  workflows: Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string }>,
+  workflows: Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string; startedAt?: string; completedAt?: string }>,
 ): string {
   if (workflows.length === 0) {
     return `${DIM}No workflows found.${RESET}`;
@@ -110,7 +110,13 @@ export function formatWorkflowList(
 
   const lines = workflows.map((wf) => {
     const color = WORKFLOW_STATUS_COLORS[wf.status] ?? DIM;
-    return `${color}  ${BOLD}${wf.id}${RESET}${color} — ${wf.name} [${wf.status}] ${DIM}(${wf.createdAt})${RESET}`;
+    let durationSuffix = '';
+    if (wf.startedAt && wf.completedAt) {
+      const ms = new Date(wf.completedAt).getTime() - new Date(wf.startedAt).getTime();
+      const secs = Math.round(ms / 1000);
+      durationSuffix = ` ${DIM}(${secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${secs % 60}s`})${RESET}`;
+    }
+    return `${color}  ${BOLD}${wf.id}${RESET}${color} — ${wf.name} [${wf.status}]${durationSuffix}${color} ${DIM}(${wf.createdAt})${RESET}`;
   });
 
   return lines.join('\n');
@@ -221,6 +227,11 @@ export function serializeWorkflow(wf: Workflow): Record<string, unknown> {
     ...(wf.mergeMode != null && { mergeMode: wf.mergeMode }),
     ...(wf.reviewProvider != null && { reviewProvider: wf.reviewProvider }),
     ...(wf.generation != null && { generation: wf.generation }),
+    ...(wf.startedAt != null && { startedAt: wf.startedAt }),
+    ...(wf.completedAt != null && { completedAt: wf.completedAt }),
+    ...((wf.startedAt != null && wf.completedAt != null) && {
+      durationMs: new Date(wf.completedAt).getTime() - new Date(wf.startedAt).getTime(),
+    }),
   };
 }
 

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -47,6 +47,10 @@ export interface Workflow {
   generation?: number;
   createdAt: string;
   updatedAt: string;
+  /** ISO timestamp when the first task started executing. Set once on first task start. */
+  startedAt?: string;
+  /** ISO timestamp when the workflow reached a terminal state (completed or failed). */
+  completedAt?: string;
 }
 
 export interface TaskEvent {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -564,6 +564,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE attempts ADD COLUMN queue_priority INTEGER NOT NULL DEFAULT 0',
       'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
       'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
+      'ALTER TABLE workflows ADD COLUMN started_at TEXT',
+      'ALTER TABLE workflows ADD COLUMN completed_at TEXT',
     ];
     for (const sql of migrations) {
       try {
@@ -654,8 +656,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   saveWorkflow(workflow: Workflow): void {
     this.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, status, plan_file, repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, status, plan_file, repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, generation, created_at, updated_at, started_at, completed_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
@@ -667,10 +669,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
       workflow.reviewProvider ?? null,
       workflow.generation ?? 0,
       workflow.createdAt, workflow.updatedAt,
+      workflow.startedAt ?? null,
+      workflow.completedAt ?? null,
     ]);
   }
 
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'status' | 'updatedAt' | 'baseBranch' | 'generation' | 'mergeMode'>>): void {
+  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'status' | 'updatedAt' | 'baseBranch' | 'generation' | 'mergeMode' | 'startedAt' | 'completedAt'>>): void {
     const setClauses: string[] = [];
     const values: unknown[] = [];
     if (changes.status !== undefined) {
@@ -688,6 +692,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if (changes.mergeMode !== undefined) {
       setClauses.push('merge_mode = ?');
       values.push(changes.mergeMode);
+    }
+    if (changes.startedAt !== undefined) {
+      setClauses.push('started_at = ?');
+      values.push(changes.startedAt);
+    }
+    if (changes.completedAt !== undefined) {
+      setClauses.push('completed_at = ?');
+      values.push(changes.completedAt);
     }
     setClauses.push('updated_at = ?');
     values.push(changes.updatedAt ?? new Date().toISOString());
@@ -1598,6 +1610,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
       generation: row.generation ?? 0,
       createdAt: row.created_at,
       updatedAt: row.updated_at,
+      startedAt: row.started_at ?? undefined,
+      completedAt: row.completed_at ?? undefined,
     };
   }
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -127,7 +127,7 @@ export interface OrchestratorPersistence {
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
   }): void;
-  updateWorkflow?(workflowId: string, changes: { status?: string; updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' }): void;
+  updateWorkflow?(workflowId: string, changes: { status?: string; updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review'; startedAt?: string; completedAt?: string }): void;
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
@@ -154,7 +154,7 @@ export interface OrchestratorPersistence {
     attemptPatch: Partial<Pick<Attempt, 'status' | 'exitCode' | 'error' | 'completedAt'>>
   ): void;
   /** Load a workflow by ID (needed for SSH validation in editTaskType). */
-  loadWorkflow?(workflowId: string): { repoUrl?: string; baseBranch?: string } | undefined;
+  loadWorkflow?(workflowId: string): { repoUrl?: string; baseBranch?: string; startedAt?: string; completedAt?: string } | undefined;
   /** Delete a single workflow and its tasks from the DB. */
   deleteWorkflow?(workflowId: string): void;
   /** Delete all workflows and tasks from the DB. */
@@ -628,10 +628,30 @@ export class Orchestrator {
       status = allSucceeded ? 'completed' : 'failed';
     }
 
-    this.persistence.updateWorkflow(workflowId, {
+    const now = new Date().toISOString();
+    const changes: { status: string; updatedAt: string; startedAt?: string; completedAt?: string } = {
       status,
-      updatedAt: new Date().toISOString(),
-    });
+      updatedAt: now,
+    };
+
+    // Set startedAt once when the workflow first has a running task.
+    const hasRunning = tasks.some((task) => task.status === 'running' || task.status === 'fixing_with_ai');
+    if (hasRunning) {
+      const existing = this.persistence.loadWorkflow?.(workflowId);
+      if (existing && !existing.startedAt) {
+        changes.startedAt = now;
+      }
+    }
+
+    // Set completedAt when the workflow reaches a terminal state.
+    if (status === 'completed' || status === 'failed') {
+      const existing = this.persistence.loadWorkflow?.(workflowId);
+      if (existing && !existing.completedAt) {
+        changes.completedAt = now;
+      }
+    }
+
+    this.persistence.updateWorkflow(workflowId, changes);
   }
 
   /**


### PR DESCRIPTION
Records when a workflow first starts executing (`startedAt`) and when it reaches a terminal state (`completedAt`).

**Why:** there's no way to know how long a workflow took. This is the baseline needed for performance testing — especially useful when running a chaos matrix.

**What changed**
- `Workflow` interface gains `startedAt?` and `completedAt?` (ISO strings)
- Schema migration adds `started_at` / `completed_at` columns — additive, safe on existing DBs
- `syncWorkflowStatus` sets `startedAt` once on first running task, `completedAt` once on terminal state
- `serializeWorkflow` emits both fields plus a computed `durationMs`
- `formatWorkflowList` shows elapsed time next to each workflow (e.g. `2m 30s`)

8 tests added.