### PR TITLE
feat: add headless watch command

### DIFF
--- a/packages/app/src/__tests__/headless-watch.test.ts
+++ b/packages/app/src/__tests__/headless-watch.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runHeadless } from '../headless.js';
+import type { HeadlessDeps } from '../headless.js';
+import { Orchestrator, CommandService } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { MessageBus } from '@invoker/transport';
+import { LocalBus } from '@invoker/transport';
+
+const noopLogger = {
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  child: vi.fn(function () { return noopLogger; }),
+};
+
+function makeTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'wf-1/task-a',
+    description: 'Do something',
+    status: 'completed',
+    dependencies: [],
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    config: { workflowId: 'wf-1', executorType: 'worktree', isMergeNode: false },
+    execution: {},
+    ...overrides,
+  };
+}
+
+describe('headless watch', () => {
+  let mockDeps: HeadlessDeps;
+  let bus: LocalBus;
+
+  beforeEach(() => {
+    bus = new LocalBus();
+    mockDeps = {
+      logger: noopLogger as any,
+      orchestrator: {} as Orchestrator,
+      persistence: {
+        readOnly: false,
+        listWorkflows: vi.fn(() => [
+          { id: 'wf-1', name: 'My Workflow', status: 'completed', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:01:00Z' },
+        ]),
+        loadTasks: vi.fn(() => []),
+      } as unknown as SQLiteAdapter,
+      commandService: {} as CommandService,
+      executorRegistry: {} as any,
+      messageBus: bus as MessageBus,
+      repoRoot: '/fake/repo',
+      invokerConfig: {} as any,
+      initServices: vi.fn(async () => {}),
+      wireSlackBot: vi.fn(async () => ({})),
+    };
+    mockDeps.orchestrator.syncFromDb = vi.fn();
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [makeTask()]);
+    mockDeps.orchestrator.getTask = vi.fn((id: string) => makeTask({ id }));
+  });
+
+  it('is classified as read-only', async () => {
+    const { isHeadlessReadOnlyCommand, isHeadlessMutatingCommand } = await import('../headless-command-classification.js');
+    expect(isHeadlessReadOnlyCommand(['watch'])).toBe(true);
+    expect(isHeadlessMutatingCommand(['watch'])).toBe(false);
+  });
+
+  it('resolves when all tasks are already settled', async () => {
+    await expect(runHeadless(['watch'], mockDeps)).resolves.toBeUndefined();
+  });
+
+  it('prints initial task snapshot', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['watch'], mockDeps);
+    const output = stdout.mock.calls.map(c => c[0]).join('');
+    expect(output).toContain('wf-1/task-a');
+    stdout.mockRestore();
+  });
+
+  it('prints final summary line', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['watch'], mockDeps);
+    const output = stdout.mock.calls.map(c => c[0]).join('');
+    expect(output).toContain('[watch] done');
+    stdout.mockRestore();
+  });
+
+  it('throws when specified workflow not found', async () => {
+    await expect(runHeadless(['watch', 'wf-nonexistent'], mockDeps)).rejects.toThrow(/not found/);
+  });
+
+  it('prints no workflows message when none exist', async () => {
+    (mockDeps.persistence.listWorkflows as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['watch'], mockDeps);
+    expect(stdout.mock.calls[0][0]).toContain('No workflows found');
+    stdout.mockRestore();
+  });
+});

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -10,7 +10,7 @@ export function isHeadlessReadOnlyCommand(args: string[]): boolean {
   const command = args[0];
   if (!command || command === '--help' || command === '-h') return true;
   if (command === 'query') return true;
-  return ['list', 'status', 'task-status', 'queue', 'audit', 'session', 'query-select', 'open-terminal', 'slack'].includes(command);
+  return ['list', 'status', 'task-status', 'queue', 'audit', 'session', 'query-select', 'open-terminal', 'slack', 'watch'].includes(command);
 }
 
 export function isHeadlessMutatingCommand(args: string[]): boolean {
@@ -23,7 +23,7 @@ export function isHeadlessMutatingCommand(args: string[]): boolean {
     return ['command', 'executor', 'agent', 'merge-mode', 'gate-policy'].includes(sub ?? '');
   }
 
-  if (['list', 'status', 'task-status', 'queue', 'audit', 'session', 'query-select'].includes(command)) {
+  if (['list', 'status', 'task-status', 'queue', 'audit', 'session', 'query-select', 'watch'].includes(command)) {
     return false;
   }
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -568,6 +568,10 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessMigrateCompatibility(deps);
       break;
 
+    case 'watch':
+      await headlessWatch(args[1], deps);
+      break;
+
     // ── Execute (unchanged) ──
     case 'run':
       await headlessRun(args[1], deps, deps.waitForApproval, deps.noTrack);
@@ -742,6 +746,7 @@ ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
   query ui-perf [--output F] [--reset]               Print live UI perf stats
 
 ${BOLD}Execute:${RESET}
+  watch [<workflowId>]                                Stream live task changes until settled or Ctrl-C
   run <plan.yaml>                                     Load and execute plan
   resume <id>                                         Resume incomplete workflow
   retry <workflowId>                                  Retry workflow: rerun failed, keep completed
@@ -1815,6 +1820,84 @@ async function waitForCompletion(
     if (noneRunning && hasHumanBlocked && !hasBackgroundWork?.()) return;
     await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
   }
+}
+
+// ── Watch ────────────────────────────────────────────────────
+
+/**
+ * Stream live task state changes to stdout until the workflow settles or SIGINT.
+ *
+ * Each state change prints one line: "<timestamp> <taskId> <status>"
+ * Exits cleanly on SIGINT or when all tasks reach a terminal state.
+ */
+async function headlessWatch(workflowId: string | undefined, deps: HeadlessDeps): Promise<void> {
+  const { orchestrator, persistence, messageBus } = deps;
+
+  const { formatTaskStatus, formatAsJson } = await import('./formatter.js');
+
+  const workflows = persistence.listWorkflows();
+  if (workflows.length === 0) {
+    process.stdout.write('No workflows found.\n');
+    return;
+  }
+
+  const targetId = workflowId ?? workflows[0].id;
+  const wf = workflows.find(w => w.id === targetId);
+  if (!wf) throw new Error(`Workflow "${targetId}" not found.`);
+
+  process.stdout.write(`[watch] ${wf.id} — ${wf.name}\n\n`);
+
+  // Print current state snapshot first
+  orchestrator.syncFromDb(wf.id);
+  const initial = orchestrator.getAllTasks().filter(t => t.config.workflowId === wf.id && !t.config.isMergeNode);
+  for (const task of initial) {
+    process.stdout.write(formatTaskStatus(task) + '\n');
+  }
+  process.stdout.write('\n');
+
+  const settledStatuses = new Set(['completed', 'failed', 'needs_input', 'awaiting_approval', 'review_ready', 'blocked', 'stale']);
+
+  let done = false;
+
+  const unsubscribe = messageBus.subscribe<TaskDelta>(Channels.TASK_DELTA, (delta) => {
+    if (delta.type === 'updated') {
+      const task = orchestrator.getTask(delta.taskId);
+      if (!task || task.config.workflowId !== targetId || task.config.isMergeNode) return;
+      const ts = new Date().toISOString();
+      process.stdout.write(`${ts} ${formatTaskStatus(task)}\n`);
+    } else if (delta.type === 'created') {
+      if (delta.task.config.workflowId !== targetId || delta.task.config.isMergeNode) return;
+      const ts = new Date().toISOString();
+      process.stdout.write(`${ts} ${formatTaskStatus(delta.task)}\n`);
+    }
+  });
+
+  await new Promise<void>((resolve) => {
+    const onSignal = () => {
+      done = true;
+      resolve();
+    };
+    process.once('SIGINT', onSignal);
+    process.once('SIGTERM', onSignal);
+
+    const pollMs = 200;
+    const timer = setInterval(() => {
+      if (done) { clearInterval(timer); resolve(); return; }
+      const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === targetId && !t.config.isMergeNode);
+      const allSettled = tasks.length > 0 && tasks.every(t => settledStatuses.has(t.status));
+      const noneRunning = !tasks.some(t => t.status === 'running' || t.status === 'fixing_with_ai');
+      if (allSettled || noneRunning) { clearInterval(timer); resolve(); }
+    }, pollMs);
+    timer.unref?.();
+  });
+
+  unsubscribe();
+
+  // Final summary line
+  const finalTasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === targetId && !t.config.isMergeNode);
+  const failed = finalTasks.filter(t => t.status === 'failed').length;
+  const completed = finalTasks.filter(t => t.status === 'completed').length;
+  process.stdout.write(`\n[watch] done — ${completed} completed, ${failed} failed\n`);
 }
 
 // ── Headless Delegation ──────────────────────────────────────


### PR DESCRIPTION
Adds `--headless watch [<workflowId>]`.

Streams live task state changes to stdout as they happen. Exits when the workflow settles or on Ctrl-C. Defaults to the latest workflow if no ID is given.

**Usage**
```
electron dist/main.js --headless watch
electron dist/main.js --headless watch wf-1775932917566-8
```

**Example output**
```
[watch] wf-1775932917566-8 — ci-hardening

  ✓ wf-.../deps — Install dependencies [completed]
  ● wf-.../tests — Run tests [running]

2024-01-01T00:01:05.123Z   ✓ wf-.../tests — Run tests [completed]

[watch] done — 2 completed, 0 failed
```

- Prints a snapshot of current state on start, then one timestamped line per change
- Classified as read-only — no owner process required
- Exits cleanly on SIGINT or when all tasks settle

6 tests added.