### PR TITLE
feat: surface merge conflict files in task output

### DIFF
--- a/packages/app/src/__tests__/conflict-summary.test.ts
+++ b/packages/app/src/__tests__/conflict-summary.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest';
+import { formatTaskStatus, serializeTask } from '../formatter.js';
+import type { TaskState } from '@invoker/workflow-core';
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id: 'wf-1/task-a',
+    description: 'Merge upstream',
+    status: 'failed',
+    dependencies: [],
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    config: { workflowId: 'wf-1', executorType: 'worktree' } as any,
+    execution: {},
+    ...overrides,
+  } as TaskState;
+}
+
+describe('conflict summary in task output', () => {
+  describe('formatTaskStatus', () => {
+    it('shows conflicting files when mergeConflict is present', () => {
+      const task = makeTask({
+        execution: {
+          mergeConflict: {
+            failedBranch: 'invoker/task-a',
+            conflictFiles: ['src/config.ts', 'src/main.ts'],
+          },
+        } as any,
+      });
+      const output = formatTaskStatus(task);
+      expect(output).toContain('src/config.ts');
+      expect(output).toContain('src/main.ts');
+    });
+
+    it('omits conflict suffix when no mergeConflict', () => {
+      const task = makeTask({ execution: {} as any });
+      const output = formatTaskStatus(task);
+      expect(output).not.toContain('conflict');
+    });
+
+    it('shows all conflicting files joined by comma', () => {
+      const task = makeTask({
+        execution: {
+          mergeConflict: {
+            failedBranch: 'invoker/task-a',
+            conflictFiles: ['a.ts', 'b.ts', 'c.ts'],
+          },
+        } as any,
+      });
+      const output = formatTaskStatus(task);
+      expect(output).toContain('a.ts, b.ts, c.ts');
+    });
+  });
+
+  describe('serializeTask', () => {
+    it('includes mergeConflict in execution when present', () => {
+      const task = makeTask({
+        execution: {
+          mergeConflict: {
+            failedBranch: 'invoker/task-a',
+            conflictFiles: ['src/config.ts'],
+          },
+        } as any,
+      });
+      const result = serializeTask(task);
+      const exec = result.execution as Record<string, unknown>;
+      expect(exec.mergeConflict).toEqual({
+        failedBranch: 'invoker/task-a',
+        conflictFiles: ['src/config.ts'],
+      });
+    });
+
+    it('omits mergeConflict from execution when not present', () => {
+      const task = makeTask({ execution: {} as any });
+      const result = serializeTask(task);
+      const exec = result.execution as Record<string, unknown>;
+      expect(exec.mergeConflict).toBeUndefined();
+    });
+
+    it('serializes conflictFiles as a plain array', () => {
+      const task = makeTask({
+        execution: {
+          mergeConflict: {
+            failedBranch: 'invoker/task-a',
+            conflictFiles: ['x.ts', 'y.ts'],
+          },
+        } as any,
+      });
+      const result = serializeTask(task);
+      const exec = result.execution as Record<string, unknown>;
+      const mc = exec.mergeConflict as Record<string, unknown>;
+      expect(Array.isArray(mc.conflictFiles)).toBe(true);
+      expect(mc.conflictFiles).toEqual(['x.ts', 'y.ts']);
+    });
+  });
+});

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -65,7 +65,10 @@ export function formatTaskStatus(task: TaskState): string {
   const phaseSuffix = task.status === 'running' && task.execution.phase
     ? ` (phase=${task.execution.phase})`
     : '';
-  return `${color}  ${icon} ${BOLD}${task.id}${RESET}${color} — ${task.description} [${label}]${phaseSuffix}${RESET}`;
+  const conflictSuffix = task.execution.mergeConflict
+    ? ` ${DIM}[conflict: ${task.execution.mergeConflict.conflictFiles.join(', ')}]${RESET}`
+    : '';
+  return `${color}  ${icon} ${BOLD}${task.id}${RESET}${color} — ${task.description} [${label}]${phaseSuffix}${RESET}${conflictSuffix}`;
 }
 
 /**
@@ -254,6 +257,12 @@ export function serializeTask(task: TaskState): Record<string, unknown> {
   if (task.execution.launchStartedAt != null) execution.launchStartedAt = task.execution.launchStartedAt instanceof Date ? task.execution.launchStartedAt.toISOString() : task.execution.launchStartedAt;
   if (task.execution.launchCompletedAt != null) execution.launchCompletedAt = task.execution.launchCompletedAt instanceof Date ? task.execution.launchCompletedAt.toISOString() : task.execution.launchCompletedAt;
   if (task.execution.lastHeartbeatAt != null) execution.lastHeartbeatAt = task.execution.lastHeartbeatAt instanceof Date ? task.execution.lastHeartbeatAt.toISOString() : task.execution.lastHeartbeatAt;
+  if (task.execution.mergeConflict != null) {
+    execution.mergeConflict = {
+      failedBranch: task.execution.mergeConflict.failedBranch,
+      conflictFiles: [...task.execution.mergeConflict.conflictFiles],
+    };
+  }
 
   return {
     id: task.id,


### PR DESCRIPTION
When a task fails due to a merge conflict, the conflicting file names now appear in the task status line and in JSON output.

**Why:** the merge conflict as a workflow event is one of the most distinctive things in Invoker, but the details were buried. This surfaces them wherever tasks are displayed — `query tasks`, `watch`, any JSON consumer — without digging into raw DB state.

**Before**
```
  ✗ wf-.../run-all-fixture-tests — Run fixture tests [failed]
```

**After**
```
  ✗ wf-.../run-all-fixture-tests — Run fixture tests [failed] [conflict: packages/app/src/config.ts, packages/app/src/main.ts]
```

**JSON (`serializeTask`)**
```json
{
  "execution": {
    "mergeConflict": {
      "failedBranch": "invoker/run-all-fixture-tests",
      "conflictFiles": ["packages/app/src/config.ts", "packages/app/src/main.ts"]
    }
  }
}
```

6 tests added.