### PR TITLE
feat: add query stats subcommand

### DIFF
--- a/packages/app/src/__tests__/headless-query-stats.test.ts
+++ b/packages/app/src/__tests__/headless-query-stats.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { runHeadless } from '../headless.js';
+import type { HeadlessDeps } from '../headless.js';
+import { Orchestrator, CommandService } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { MessageBus } from '@invoker/transport';
+import { LocalBus } from '@invoker/transport';
+
+const noopLogger = {
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  child: vi.fn(function () { return noopLogger; }),
+};
+
+function makeWorkflow(id: string, status: 'completed' | 'failed' | 'running', overrides: Record<string, unknown> = {}) {
+  return { id, name: `Workflow ${id}`, status, createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:01:00Z', ...overrides };
+}
+
+function makeTask(wfId: string, status: string, description = 'Run tests') {
+  return {
+    id: `${wfId}/task-a`,
+    description,
+    status,
+    dependencies: [],
+    createdAt: new Date(),
+    config: { workflowId: wfId, isMergeNode: false },
+    execution: {},
+  };
+}
+
+describe('headless query stats', () => {
+  let mockDeps: HeadlessDeps;
+
+  beforeEach(() => {
+    mockDeps = {
+      logger: noopLogger as any,
+      orchestrator: {} as Orchestrator,
+      persistence: {
+        readOnly: false,
+        listWorkflows: vi.fn(() => [
+          makeWorkflow('wf-1', 'completed'),
+          makeWorkflow('wf-2', 'completed'),
+          makeWorkflow('wf-3', 'failed'),
+        ]),
+        loadTasks: vi.fn(() => []),
+      } as unknown as SQLiteAdapter,
+      commandService: {} as CommandService,
+      executorRegistry: {} as any,
+      messageBus: new LocalBus() as MessageBus,
+      repoRoot: '/fake/repo',
+      invokerConfig: {} as any,
+      initServices: vi.fn(async () => {}),
+      wireSlackBot: vi.fn(async () => ({})),
+    };
+    mockDeps.orchestrator.syncFromDb = vi.fn();
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => []);
+  });
+
+  it('resolves without error', async () => {
+    await expect(runHeadless(['query', 'stats'], mockDeps)).resolves.toBeUndefined();
+  });
+
+  it('outputs correct counts in JSON', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'stats', '--output', 'json'], mockDeps);
+    const parsed = JSON.parse(stdout.mock.calls[0][0] as string);
+    expect(parsed.totalWorkflows).toBe(3);
+    expect(parsed.completed).toBe(2);
+    expect(parsed.failed).toBe(1);
+    expect(parsed.running).toBe(0);
+    stdout.mockRestore();
+  });
+
+  it('computes success rate correctly', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'stats', '--output', 'json'], mockDeps);
+    const parsed = JSON.parse(stdout.mock.calls[0][0] as string);
+    // 2 completed out of 3 terminal = 66.67%
+    expect(parsed.successRate).toBeCloseTo(66.67, 1);
+    stdout.mockRestore();
+  });
+
+  it('outputs label as success rate percentage', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'stats', '--output', 'label'], mockDeps);
+    expect(stdout.mock.calls[0][0]).toMatch(/\d+\.\d+%\n/);
+    stdout.mockRestore();
+  });
+
+  it('includes most failed tasks ranked by frequency', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn((wfId?: string) => {
+      const id = (mockDeps.orchestrator.syncFromDb as ReturnType<typeof vi.fn>).mock.calls.at(-1)?.[0] ?? 'wf-1';
+      return [makeTask(id, 'failed', 'Run tests')] as any;
+    });
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'stats', '--output', 'json'], mockDeps);
+    const parsed = JSON.parse(stdout.mock.calls[0][0] as string);
+    expect(parsed.mostFailedTasks.length).toBeGreaterThan(0);
+    expect(parsed.mostFailedTasks[0].description).toBe('Run tests');
+    expect(parsed.mostFailedTasks[0].failCount).toBeGreaterThan(0);
+    stdout.mockRestore();
+  });
+
+  it('returns 100% success rate when all workflows completed', async () => {
+    (mockDeps.persistence.listWorkflows as ReturnType<typeof vi.fn>).mockReturnValue([
+      makeWorkflow('wf-1', 'completed'),
+      makeWorkflow('wf-2', 'completed'),
+    ]);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'stats', '--output', 'json'], mockDeps);
+    const parsed = JSON.parse(stdout.mock.calls[0][0] as string);
+    expect(parsed.successRate).toBe(100);
+    stdout.mockRestore();
+  });
+
+  it('returns 0% success rate when no terminal workflows', async () => {
+    (mockDeps.persistence.listWorkflows as ReturnType<typeof vi.fn>).mockReturnValue([
+      makeWorkflow('wf-1', 'running'),
+    ]);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'stats', '--output', 'json'], mockDeps);
+    const parsed = JSON.parse(stdout.mock.calls[0][0] as string);
+    expect(parsed.successRate).toBe(0);
+    stdout.mockRestore();
+  });
+
+  it('omits avgDurationMs when no workflows have timestamps', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['query', 'stats', '--output', 'json'], mockDeps);
+    const parsed = JSON.parse(stdout.mock.calls[0][0] as string);
+    expect(parsed.avgDurationMs).toBeNull();
+    stdout.mockRestore();
+  });
+});

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -193,6 +193,45 @@ export function formatQueueStatus(status: {
   return lines.join('\n');
 }
 
+/**
+ * Format aggregate stats across all workflows.
+ */
+export function formatWorkflowStats(stats: {
+  totalWorkflows: number;
+  completed: number;
+  failed: number;
+  running: number;
+  successRate: number;
+  avgDurationMs: number | null;
+  mostFailedTasks: Array<{ description: string; failCount: number }>;
+}): string {
+  const lines: string[] = [];
+
+  lines.push(`${BOLD}Workflow stats${RESET}`);
+  lines.push('');
+  lines.push(`  Total      ${BOLD}${stats.totalWorkflows}${RESET}`);
+  lines.push(`  ${GREEN}Completed  ${stats.completed}${RESET}`);
+  lines.push(`  ${RED}Failed     ${stats.failed}${RESET}`);
+  lines.push(`  ${YELLOW}Running    ${stats.running}${RESET}`);
+  lines.push(`  Success    ${BOLD}${stats.successRate.toFixed(1)}%${RESET}`);
+
+  if (stats.avgDurationMs !== null) {
+    const secs = Math.round(stats.avgDurationMs / 1000);
+    const avg = secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${secs % 60}s`;
+    lines.push(`  Avg time   ${BOLD}${avg}${RESET}`);
+  }
+
+  if (stats.mostFailedTasks.length > 0) {
+    lines.push('');
+    lines.push(`${BOLD}Most failed tasks:${RESET}`);
+    for (const t of stats.mostFailedTasks) {
+      lines.push(`  ${RED}${t.failCount}x${RESET}  ${t.description}`);
+    }
+  }
+
+  return lines.join('\n');
+}
+
 // ── Output Format Type ──────────────────────────────────────
 
 export type OutputFormat = 'text' | 'label' | 'json' | 'jsonl';

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -346,7 +346,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
 
   const {
     formatWorkflowList, formatTaskStatus, formatWorkflowStatus,
-    formatEventLog, formatQueueStatus,
+    formatEventLog, formatQueueStatus, formatWorkflowStats,
     serializeWorkflow, serializeTask, serializeEvent,
     formatAsLabel, formatAsJson, formatAsJsonl,
   } = await import('./formatter.js');
@@ -506,8 +506,61 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
       }
       break;
     }
+    case 'stats': {
+      const { orchestrator, persistence } = deps;
+      const workflows = persistence.listWorkflows();
+
+      const completed = workflows.filter(w => w.status === 'completed').length;
+      const failed = workflows.filter(w => w.status === 'failed').length;
+      const running = workflows.filter(w => w.status === 'running').length;
+      const terminal = completed + failed;
+      const successRate = terminal > 0 ? (completed / terminal) * 100 : 0;
+
+      // Average duration across workflows that have both timestamps.
+      // startedAt/completedAt are added by the workflow-duration feature; guard for older DBs.
+      const durations = (workflows as Array<typeof workflows[0] & { startedAt?: string; completedAt?: string }>)
+        .filter(w => w.startedAt && w.completedAt)
+        .map(w => new Date(w.completedAt!).getTime() - new Date(w.startedAt!).getTime());
+      const avgDurationMs = durations.length > 0
+        ? durations.reduce((a, b) => a + b, 0) / durations.length
+        : null;
+
+      // Most-failed task descriptions across all workflows
+      const failCounts = new Map<string, number>();
+      for (const wf of workflows) {
+        orchestrator.syncFromDb(wf.id);
+        const tasks = orchestrator.getAllTasks().filter(
+          t => t.config.workflowId === wf.id && !t.config.isMergeNode && t.status === 'failed',
+        );
+        for (const t of tasks) {
+          failCounts.set(t.description, (failCounts.get(t.description) ?? 0) + 1);
+        }
+      }
+      const mostFailedTasks = [...failCounts.entries()]
+        .sort((a, b) => b[1] - a[1])
+        .slice(0, 5)
+        .map(([description, failCount]) => ({ description, failCount }));
+
+      const stats = {
+        totalWorkflows: workflows.length,
+        completed,
+        failed,
+        running,
+        successRate,
+        avgDurationMs,
+        mostFailedTasks,
+      };
+
+      switch (flags.output) {
+        case 'label': process.stdout.write(`${successRate.toFixed(1)}%\n`); break;
+        case 'json':  process.stdout.write(formatAsJson(stats) + '\n'); break;
+        case 'jsonl': process.stdout.write(formatAsJsonl([stats]) + '\n'); break;
+        default:      process.stdout.write(formatWorkflowStats(stats) + '\n'); break;
+      }
+      break;
+    }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, ui-perf`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, ui-perf, stats`);
   }
 }
 
@@ -740,6 +793,7 @@ ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
   query audit <taskId> [--output F]                   Print event history
   query session <taskId>                              Print agent session messages
   query ui-perf [--output F] [--reset]               Print live UI perf stats
+  query stats [--output F]                           Aggregate stats across all workflows
 
 ${BOLD}Execute:${RESET}
   run <plan.yaml>                                     Load and execute plan


### PR DESCRIPTION
Adds `--headless query stats`.

Aggregates across all workflows: total runs, completed/failed/running counts, success rate, average duration, and the top 5 most-failed task descriptions ranked by frequency.

**Usage**
```
electron dist/main.js --headless query stats
electron dist/main.js --headless query stats --output json   # for scripting
electron dist/main.js --headless query stats --output label  # success rate only
```

**Example output**
```
Workflow stats

  Total      47
  Completed  38
  Failed     9
  Running    0
  Success    80.9%
  Avg time   2m 14s

Most failed tasks:
  3x  Run the complete fixture test suite
  2x  Build TypeScript packages
  1x  Run full app test suite
```

**Note:** average duration requires `startedAt`/`completedAt` from PR #16. Degrades gracefully on older DBs without those columns.

8 tests added.