### PR TITLE
fix: make docker fixture branch reset idempotent

### DIFF
--- a/scripts/test-docker-comprehensive.sh
+++ b/scripts/test-docker-comprehensive.sh
@@ -107,8 +107,7 @@ RUN cd /app \
     && printf '# docker comprehensive fixture\n' > README.md \
     && git add . \
     && git -c user.email="test@invoker.local" -c user.name="Invoker Docker Test" commit -m "seed" \
-    && git branch "${CURRENT_BRANCH}" \
-    && git checkout "${CURRENT_BRANCH}" \
+    && git checkout -B "${CURRENT_BRANCH}" \
     && chown -R invoker:invoker /app
 
 USER invoker


### PR DESCRIPTION
## Summary
Fix the Docker comprehensive fixture image setup so it works when CI is running on `master` after merge.

## Root Cause
The fixture builder always did `git branch "${CURRENT_BRANCH}"` followed by `git checkout "${CURRENT_BRANCH}"` inside `/app`. The base image already seeds a git repo on `master`, so post-merge push runs failed when `CURRENT_BRANCH=master` with:

`fatal: a branch named 'master' already exists`

PR runs passed because they used a non-`master` branch name.

## Change
Replace branch creation plus checkout with:

`git checkout -B "${CURRENT_BRANCH}"`

That keeps the fixture setup idempotent for both PR and post-merge push runs.

## Verification
- Reproduced the failing git sequence for an existing `master` branch.
- Verified that `git checkout -B master` succeeds in the same state.
- Docker daemon was not available locally in this environment, so I could not rerun the full Docker CI job here.
