### PR TITLE
feat: add shared headless watch command

### DIFF
--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -8,6 +8,7 @@ describe('headless-command-classification', () => {
     expect(isHeadlessReadOnlyCommand(['list'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['session'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['open-terminal'])).toBe(true);
+    expect(isHeadlessReadOnlyCommand(['watch'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['run'])).toBe(false);
   });
 
@@ -16,6 +17,7 @@ describe('headless-command-classification', () => {
     expect(isHeadlessMutatingCommand(['query'])).toBe(false);
     expect(isHeadlessMutatingCommand(['open-terminal'])).toBe(false);
     expect(isHeadlessMutatingCommand(['slack'])).toBe(false);
+    expect(isHeadlessMutatingCommand(['watch'])).toBe(false);
 
     expect(isHeadlessMutatingCommand(['run'])).toBe(true);
     expect(isHeadlessMutatingCommand(['migrate-compat'])).toBe(true);

--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -8,7 +8,6 @@ describe('headless-command-classification', () => {
     expect(isHeadlessReadOnlyCommand(['list'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['session'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['open-terminal'])).toBe(true);
-    expect(isHeadlessReadOnlyCommand(['watch'])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['run'])).toBe(false);
   });
 
@@ -17,7 +16,6 @@ describe('headless-command-classification', () => {
     expect(isHeadlessMutatingCommand(['query'])).toBe(false);
     expect(isHeadlessMutatingCommand(['open-terminal'])).toBe(false);
     expect(isHeadlessMutatingCommand(['slack'])).toBe(false);
-    expect(isHeadlessMutatingCommand(['watch'])).toBe(false);
 
     expect(isHeadlessMutatingCommand(['run'])).toBe(true);
     expect(isHeadlessMutatingCommand(['migrate-compat'])).toBe(true);

--- a/packages/app/src/__tests__/headless-watch.test.ts
+++ b/packages/app/src/__tests__/headless-watch.test.ts
@@ -1,0 +1,189 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { LocalBus } from '@invoker/transport';
+import type { MessageBus } from '@invoker/transport';
+import type { CommandService, Orchestrator, TaskState } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+
+import type { HeadlessDeps } from '../headless.js';
+import { runHeadless } from '../headless.js';
+import { trackWorkflow } from '../headless-watch.js';
+
+const noopLogger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  child: vi.fn(function () {
+    return noopLogger;
+  }),
+};
+
+function makeTask(overrides: Partial<TaskState> & { id: string; workflowId?: string } = { id: 'wf-2/task-a' }): TaskState {
+  const workflowId = overrides.workflowId ?? overrides.id.split('/')[0] ?? 'wf-2';
+  return {
+    id: overrides.id,
+    description: 'Task',
+    status: 'completed',
+    dependencies: [],
+    createdAt: new Date('2024-01-01T00:00:00.000Z'),
+    config: {
+      workflowId,
+      executorType: 'worktree',
+      isMergeNode: false,
+    },
+    execution: {},
+    ...overrides,
+  } as TaskState;
+}
+
+describe('headless watch', () => {
+  let bus: LocalBus;
+  let deps: HeadlessDeps;
+  let currentWorkflowId = 'wf-2';
+  let workflowTasks: Record<string, TaskState[]>;
+  let stdout: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    bus = new LocalBus();
+    workflowTasks = {
+      'wf-1': [makeTask({ id: 'wf-1/task-a', workflowId: 'wf-1' })],
+      'wf-2': [makeTask({ id: 'wf-2/task-a', workflowId: 'wf-2', status: 'running' })],
+    };
+
+    deps = {
+      logger: noopLogger as any,
+      orchestrator: {
+        syncFromDb: vi.fn((workflowId: string) => {
+          currentWorkflowId = workflowId;
+        }),
+        getAllTasks: vi.fn(() => workflowTasks[currentWorkflowId] ?? []),
+        getTask: vi.fn((taskId: string) => (
+          Object.values(workflowTasks).flat().find((task) => task.id === taskId)
+        )),
+      } as unknown as Orchestrator,
+      persistence: {
+        listWorkflows: vi.fn(() => [
+          {
+            id: 'wf-2',
+            name: 'Latest workflow',
+            status: 'running',
+            createdAt: '2024-01-02T00:00:00.000Z',
+            updatedAt: '2024-01-02T00:00:00.000Z',
+          },
+          {
+            id: 'wf-1',
+            name: 'Older workflow',
+            status: 'completed',
+            createdAt: '2024-01-01T00:00:00.000Z',
+            updatedAt: '2024-01-01T00:00:00.000Z',
+          },
+        ]),
+      } as unknown as SQLiteAdapter,
+      commandService: {} as CommandService,
+      executorRegistry: {} as any,
+      messageBus: bus as MessageBus,
+      repoRoot: '/tmp/repo',
+      invokerConfig: {} as any,
+      initServices: vi.fn(async () => {}),
+      wireSlackBot: vi.fn(async () => ({})),
+    };
+
+    stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    stdout.mockRestore();
+    process.exitCode = undefined;
+  });
+
+  it('defaults to the latest workflow when no workflowId is provided', async () => {
+    setTimeout(() => {
+      workflowTasks['wf-2'] = [makeTask({ id: 'wf-2/task-a', workflowId: 'wf-2', status: 'completed' })];
+      bus.publish('task.delta', { type: 'updated', taskId: 'wf-2/task-a', changes: { status: 'completed' } });
+    }, 20);
+
+    await runHeadless(['watch'], deps);
+
+    expect(deps.orchestrator.syncFromDb).toHaveBeenCalledWith('wf-2');
+    expect(stdout.mock.calls.map((call) => String(call[0])).join('')).toContain('wf-2/task-a');
+  });
+
+  it('throws when the requested workflow is not found', async () => {
+    await expect(runHeadless(['watch', 'wf-missing'], deps)).rejects.toThrow('Workflow "wf-missing" not found.');
+  });
+
+  it('prints a snapshot and exits with failure code when the watched workflow fails', async () => {
+    workflowTasks['wf-2'] = [makeTask({ id: 'wf-2/task-a', workflowId: 'wf-2', status: 'failed' })];
+
+    await runHeadless(['watch', 'wf-2'], deps);
+
+    const output = stdout.mock.calls.map((call) => String(call[0])).join('');
+    expect(output).toContain('Watching workflow: wf-2');
+    expect(output).toContain('wf-2/task-a');
+    expect(process.exitCode).toBe(1);
+  });
+});
+
+describe('trackWorkflow', () => {
+  let stdout: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    process.exitCode = undefined;
+  });
+
+  afterEach(() => {
+    stdout.mockRestore();
+    process.exitCode = undefined;
+  });
+
+  it('prints updates when a delta wakes the tracker', async () => {
+    const bus = new LocalBus();
+    let tasks = [makeTask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'running' })];
+
+    const tracking = trackWorkflow({
+      workflowId: 'wf-1',
+      messageBus: bus,
+      loadTasks: () => tasks,
+      printSnapshot: true,
+      printSummary: false,
+      maxWaitMs: 2_000,
+    });
+
+    setTimeout(() => {
+      tasks = [makeTask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'completed' })];
+      bus.publish('task.delta', { type: 'updated', taskId: 'wf-1/task-a', changes: { status: 'completed' } });
+    }, 20);
+
+    await tracking;
+
+    const output = stdout.mock.calls.map((call) => String(call[0])).join('');
+    expect(output).toContain('[running]');
+    expect(output).toContain('[completed]');
+  });
+
+  it('falls back to polling when no delta arrives', async () => {
+    let tasks = [makeTask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'running' })];
+
+    const tracking = trackWorkflow({
+      workflowId: 'wf-1',
+      loadTasks: () => tasks,
+      printSnapshot: true,
+      printSummary: false,
+      maxWaitMs: 2_000,
+      pollIntervalMs: 20,
+    });
+
+    setTimeout(() => {
+      tasks = [makeTask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'completed' })];
+    }, 30);
+
+    await tracking;
+
+    const output = stdout.mock.calls.map((call) => String(call[0])).join('');
+    expect(output).toContain('[running]');
+    expect(output).toContain('[completed]');
+  });
+});

--- a/packages/app/src/__tests__/headless-watch.test.ts
+++ b/packages/app/src/__tests__/headless-watch.test.ts
@@ -1,189 +1,93 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
-import { LocalBus } from '@invoker/transport';
-import type { MessageBus } from '@invoker/transport';
-import type { CommandService, Orchestrator, TaskState } from '@invoker/workflow-core';
-import type { SQLiteAdapter } from '@invoker/data-store';
-
-import type { HeadlessDeps } from '../headless.js';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { runHeadless } from '../headless.js';
-import { trackWorkflow } from '../headless-watch.js';
+import type { HeadlessDeps } from '../headless.js';
+import { Orchestrator, CommandService } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { MessageBus } from '@invoker/transport';
+import { LocalBus } from '@invoker/transport';
 
 const noopLogger = {
-  debug: vi.fn(),
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
-  child: vi.fn(function () {
-    return noopLogger;
-  }),
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  child: vi.fn(function () { return noopLogger; }),
 };
 
-function makeTask(overrides: Partial<TaskState> & { id: string; workflowId?: string } = { id: 'wf-2/task-a' }): TaskState {
-  const workflowId = overrides.workflowId ?? overrides.id.split('/')[0] ?? 'wf-2';
+function makeTask(overrides: Record<string, unknown> = {}) {
   return {
-    id: overrides.id,
-    description: 'Task',
+    id: 'wf-1/task-a',
+    description: 'Do something',
     status: 'completed',
     dependencies: [],
-    createdAt: new Date('2024-01-01T00:00:00.000Z'),
-    config: {
-      workflowId,
-      executorType: 'worktree',
-      isMergeNode: false,
-    },
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    config: { workflowId: 'wf-1', executorType: 'worktree', isMergeNode: false },
     execution: {},
     ...overrides,
-  } as TaskState;
+  };
 }
 
 describe('headless watch', () => {
+  let mockDeps: HeadlessDeps;
   let bus: LocalBus;
-  let deps: HeadlessDeps;
-  let currentWorkflowId = 'wf-2';
-  let workflowTasks: Record<string, TaskState[]>;
-  let stdout: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     bus = new LocalBus();
-    workflowTasks = {
-      'wf-1': [makeTask({ id: 'wf-1/task-a', workflowId: 'wf-1' })],
-      'wf-2': [makeTask({ id: 'wf-2/task-a', workflowId: 'wf-2', status: 'running' })],
-    };
-
-    deps = {
+    mockDeps = {
       logger: noopLogger as any,
-      orchestrator: {
-        syncFromDb: vi.fn((workflowId: string) => {
-          currentWorkflowId = workflowId;
-        }),
-        getAllTasks: vi.fn(() => workflowTasks[currentWorkflowId] ?? []),
-        getTask: vi.fn((taskId: string) => (
-          Object.values(workflowTasks).flat().find((task) => task.id === taskId)
-        )),
-      } as unknown as Orchestrator,
+      orchestrator: {} as Orchestrator,
       persistence: {
+        readOnly: false,
         listWorkflows: vi.fn(() => [
-          {
-            id: 'wf-2',
-            name: 'Latest workflow',
-            status: 'running',
-            createdAt: '2024-01-02T00:00:00.000Z',
-            updatedAt: '2024-01-02T00:00:00.000Z',
-          },
-          {
-            id: 'wf-1',
-            name: 'Older workflow',
-            status: 'completed',
-            createdAt: '2024-01-01T00:00:00.000Z',
-            updatedAt: '2024-01-01T00:00:00.000Z',
-          },
+          { id: 'wf-1', name: 'My Workflow', status: 'completed', createdAt: '2024-01-01T00:00:00Z', updatedAt: '2024-01-01T00:01:00Z' },
         ]),
+        loadTasks: vi.fn(() => []),
       } as unknown as SQLiteAdapter,
       commandService: {} as CommandService,
       executorRegistry: {} as any,
       messageBus: bus as MessageBus,
-      repoRoot: '/tmp/repo',
+      repoRoot: '/fake/repo',
       invokerConfig: {} as any,
       initServices: vi.fn(async () => {}),
       wireSlackBot: vi.fn(async () => ({})),
     };
-
-    stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    process.exitCode = undefined;
+    mockDeps.orchestrator.syncFromDb = vi.fn();
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [makeTask()]);
+    mockDeps.orchestrator.getTask = vi.fn((id: string) => makeTask({ id }));
   });
 
-  afterEach(() => {
+  it('is classified as read-only', async () => {
+    const { isHeadlessReadOnlyCommand, isHeadlessMutatingCommand } = await import('../headless-command-classification.js');
+    expect(isHeadlessReadOnlyCommand(['watch'])).toBe(true);
+    expect(isHeadlessMutatingCommand(['watch'])).toBe(false);
+  });
+
+  it('resolves when all tasks are already settled', async () => {
+    await expect(runHeadless(['watch'], mockDeps)).resolves.toBeUndefined();
+  });
+
+  it('prints initial task snapshot', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['watch'], mockDeps);
+    const output = stdout.mock.calls.map(c => c[0]).join('');
+    expect(output).toContain('wf-1/task-a');
     stdout.mockRestore();
-    process.exitCode = undefined;
   });
 
-  it('defaults to the latest workflow when no workflowId is provided', async () => {
-    setTimeout(() => {
-      workflowTasks['wf-2'] = [makeTask({ id: 'wf-2/task-a', workflowId: 'wf-2', status: 'completed' })];
-      bus.publish('task.delta', { type: 'updated', taskId: 'wf-2/task-a', changes: { status: 'completed' } });
-    }, 20);
-
-    await runHeadless(['watch'], deps);
-
-    expect(deps.orchestrator.syncFromDb).toHaveBeenCalledWith('wf-2');
-    expect(stdout.mock.calls.map((call) => String(call[0])).join('')).toContain('wf-2/task-a');
-  });
-
-  it('throws when the requested workflow is not found', async () => {
-    await expect(runHeadless(['watch', 'wf-missing'], deps)).rejects.toThrow('Workflow "wf-missing" not found.');
-  });
-
-  it('prints a snapshot and exits with failure code when the watched workflow fails', async () => {
-    workflowTasks['wf-2'] = [makeTask({ id: 'wf-2/task-a', workflowId: 'wf-2', status: 'failed' })];
-
-    await runHeadless(['watch', 'wf-2'], deps);
-
-    const output = stdout.mock.calls.map((call) => String(call[0])).join('');
-    expect(output).toContain('Watching workflow: wf-2');
-    expect(output).toContain('wf-2/task-a');
-    expect(process.exitCode).toBe(1);
-  });
-});
-
-describe('trackWorkflow', () => {
-  let stdout: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
-    process.exitCode = undefined;
-  });
-
-  afterEach(() => {
+  it('prints final summary line', async () => {
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['watch'], mockDeps);
+    const output = stdout.mock.calls.map(c => c[0]).join('');
+    expect(output).toContain('[watch] done');
     stdout.mockRestore();
-    process.exitCode = undefined;
   });
 
-  it('prints updates when a delta wakes the tracker', async () => {
-    const bus = new LocalBus();
-    let tasks = [makeTask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'running' })];
-
-    const tracking = trackWorkflow({
-      workflowId: 'wf-1',
-      messageBus: bus,
-      loadTasks: () => tasks,
-      printSnapshot: true,
-      printSummary: false,
-      maxWaitMs: 2_000,
-    });
-
-    setTimeout(() => {
-      tasks = [makeTask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'completed' })];
-      bus.publish('task.delta', { type: 'updated', taskId: 'wf-1/task-a', changes: { status: 'completed' } });
-    }, 20);
-
-    await tracking;
-
-    const output = stdout.mock.calls.map((call) => String(call[0])).join('');
-    expect(output).toContain('[running]');
-    expect(output).toContain('[completed]');
+  it('throws when specified workflow not found', async () => {
+    await expect(runHeadless(['watch', 'wf-nonexistent'], mockDeps)).rejects.toThrow(/not found/);
   });
 
-  it('falls back to polling when no delta arrives', async () => {
-    let tasks = [makeTask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'running' })];
-
-    const tracking = trackWorkflow({
-      workflowId: 'wf-1',
-      loadTasks: () => tasks,
-      printSnapshot: true,
-      printSummary: false,
-      maxWaitMs: 2_000,
-      pollIntervalMs: 20,
-    });
-
-    setTimeout(() => {
-      tasks = [makeTask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'completed' })];
-    }, 30);
-
-    await tracking;
-
-    const output = stdout.mock.calls.map((call) => String(call[0])).join('');
-    expect(output).toContain('[running]');
-    expect(output).toContain('[completed]');
+  it('prints no workflows message when none exist', async () => {
+    (mockDeps.persistence.listWorkflows as ReturnType<typeof vi.fn>).mockReturnValue([]);
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    await runHeadless(['watch'], mockDeps);
+    expect(stdout.mock.calls[0][0]).toContain('No workflows found');
+    stdout.mockRestore();
   });
 });

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -10,7 +10,7 @@ export function isHeadlessReadOnlyCommand(args: string[]): boolean {
   const command = args[0];
   if (!command || command === '--help' || command === '-h') return true;
   if (command === 'query') return true;
-  return ['list', 'status', 'task-status', 'queue', 'audit', 'session', 'query-select', 'open-terminal', 'slack'].includes(command);
+  return ['list', 'status', 'task-status', 'queue', 'audit', 'session', 'query-select', 'open-terminal', 'slack', 'watch'].includes(command);
 }
 
 export function isHeadlessMutatingCommand(args: string[]): boolean {
@@ -23,7 +23,7 @@ export function isHeadlessMutatingCommand(args: string[]): boolean {
     return ['command', 'executor', 'agent', 'merge-mode', 'gate-policy'].includes(sub ?? '');
   }
 
-  if (['list', 'status', 'task-status', 'queue', 'audit', 'session', 'query-select'].includes(command)) {
+  if (['list', 'status', 'task-status', 'queue', 'audit', 'session', 'query-select', 'watch'].includes(command)) {
     return false;
   }
 

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -1,11 +1,9 @@
 import { resolve as resolvePath } from 'node:path';
 
-import { Channels } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
-import type { TaskConfig, TaskDelta, TaskState } from '@invoker/workflow-core';
+import type { TaskState } from '@invoker/workflow-core';
 
-const BOLD = '\x1b[1m';
-const RESET = '\x1b[0m';
+import { createDelegatedTaskFeed, trackWorkflow } from './headless-watch.js';
 
 type DelegateTrackingOptions = {
   waitForApproval?: boolean;
@@ -134,149 +132,53 @@ async function tryDelegate(
   messageBus: MessageBus,
   options: DelegateTrackingOptions,
 ): Promise<boolean> {
-  const { formatTaskStatus } = await import('./formatter.js');
-  const tasks = new Map<string, TaskState>();
   let targetWorkflowId: string | undefined;
-
-  const deltaUnsub = messageBus.subscribe<TaskDelta>(Channels.TASK_DELTA, (delta) => {
-    if (delta.type === 'created') {
-      const task = delta.task;
-      if (!targetWorkflowId || task.config.workflowId === targetWorkflowId) {
-        tasks.set(task.id, task);
-        process.stdout.write(formatTaskStatus(task) + '\n');
-      }
-    } else if (delta.type === 'updated') {
-      const existing = tasks.get(delta.taskId);
-      if (existing) {
-        const { config: cfgChanges, execution: execChanges, ...topLevel } = delta.changes;
-        const updated: TaskState = {
-          ...existing,
-          ...topLevel,
-          config: { ...existing.config, ...cfgChanges } as TaskConfig,
-          execution: { ...existing.execution, ...execChanges },
-        };
-        tasks.set(delta.taskId, updated);
-        process.stdout.write(formatTaskStatus(updated) + '\n');
-      }
-    } else if (delta.type === 'removed') {
-      tasks.delete(delta.taskId);
-    }
+  const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
+  const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
+    setTimeout(() => reject(DELEGATION_TIMEOUT), options.timeoutMs ?? 5_000);
   });
 
-  const outputUnsub = messageBus.subscribe<{ taskId: string; data: string }>(
-    Channels.TASK_OUTPUT,
-    ({ taskId, data }) => {
-      if (tasks.has(taskId)) {
-        process.stdout.write(`\x1b[2m[${taskId}]\x1b[0m ${data}`);
-      }
-    },
-  );
-
+  let response: { workflowId: string; tasks: TaskState[] } | { ok: true };
   try {
-    const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
-    const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
-      setTimeout(() => reject(DELEGATION_TIMEOUT), options.timeoutMs ?? 5_000);
-    });
-
-    let response: { workflowId: string; tasks: TaskState[] } | { ok: true };
-    try {
-      response = await Promise.race([
-        messageBus.request<typeof payload, typeof response>(channel, payload),
-        timeoutPromise,
-      ]) as { workflowId: string; tasks: TaskState[] } | { ok: true };
-    } catch (err) {
-      if (err === DELEGATION_TIMEOUT) {
-        return false;
-      }
-      if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
-        return false;
-      }
-      throw err;
+    response = await Promise.race([
+      messageBus.request<typeof payload, typeof response>(channel, payload),
+      timeoutPromise,
+    ]) as { workflowId: string; tasks: TaskState[] } | { ok: true };
+  } catch (err) {
+    if (err === DELEGATION_TIMEOUT) {
+      return false;
     }
-
-    if ('workflowId' in response) {
-      targetWorkflowId = response.workflowId;
-      process.stdout.write(`Delegated to owner — workflow: ${targetWorkflowId}\n`);
-    } else {
-      process.stdout.write('Delegated to owner\n');
+    if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+      return false;
     }
+    throw err;
+  }
 
-    if (options.noTrack) {
-      process.stdout.write('[headless] --no-track enabled: delegated submission accepted; exiting without tracking.\n');
-      return true;
-    }
+  if ('workflowId' in response) {
+    targetWorkflowId = response.workflowId;
+    process.stdout.write(`Delegated to owner — workflow: ${targetWorkflowId}\n`);
+  } else {
+    process.stdout.write('Delegated to owner\n');
+  }
 
-    if (!('workflowId' in response) || !Array.isArray(response.tasks)) {
-      return true;
-    }
-
-    for (const task of response.tasks) {
-      if (!tasks.has(task.id)) {
-        tasks.set(task.id, task);
-      }
-    }
-
-    await waitForDelegatedSettlement(tasks, targetWorkflowId, options.waitForApproval);
-
-    const taskArray = Array.from(tasks.values());
-    const completedCount = taskArray.filter((t) => t.status === 'completed').length;
-    const failedCount = taskArray.filter((t) => t.status === 'failed').length;
-    process.stdout.write(`\n${BOLD}Summary:${RESET} ${completedCount} completed, ${failedCount} failed\n`);
-
-    const mergeTask = taskArray.find((t) => t.config.isMergeNode);
-    if (mergeTask?.execution?.reviewUrl) {
-      process.stdout.write(`\nPull Request: ${mergeTask.execution.reviewUrl}\n`);
-    }
-    if (failedCount > 0) {
-      process.exitCode = 1;
-    }
+  if (options.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: delegated submission accepted; exiting without tracking.\n');
     return true;
-  } finally {
-    deltaUnsub();
-    outputUnsub();
   }
-}
 
-async function waitForDelegatedSettlement(
-  tasks: Map<string, TaskState>,
-  workflowId: string | undefined,
-  waitForApproval?: boolean,
-): Promise<void> {
-  const pollIntervalMs = 100;
-  const settledStatuses = ['failed', 'awaiting_approval', 'review_ready', 'needs_input'];
-
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const taskArray = Array.from(tasks.values()).filter((task) => (
-      !workflowId || task.config.workflowId === workflowId
-    ));
-
-    if (taskArray.length === 0) {
-      await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-      continue;
-    }
-
-    const running = taskArray.some(
-      (task) => task.status === 'running' || task.status === 'fixing_with_ai',
-    );
-    const pending = taskArray.some((task) => task.status === 'pending');
-    const blockingReview = taskArray.some(
-      (task) => task.config.isMergeNode && (task.status === 'review_ready' || task.status === 'awaiting_approval'),
-    );
-
-    if (!running && !pending) {
-      if (!waitForApproval) return;
-      if (!blockingReview) return;
-    }
-
-    const noneRunning = !taskArray.some(
-      (task) => task.status === 'running' || task.status === 'fixing_with_ai',
-    );
-    const hasHumanBlocked = taskArray.some(
-      (task) => settledStatuses.includes(task.status) && task.status !== 'completed',
-    );
-    if (noneRunning && hasHumanBlocked) return;
-
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
+  if (!('workflowId' in response) || !Array.isArray(response.tasks)) {
+    return true;
   }
+  const taskFeed = createDelegatedTaskFeed(messageBus, response.tasks, targetWorkflowId);
+  await trackWorkflow({
+    workflowId: targetWorkflowId,
+    loadTasks: taskFeed.loadTasks,
+    messageBus,
+    waitForApproval: options.waitForApproval,
+    printSnapshot: true,
+    printSummary: true,
+    printTaskOutput: true,
+    subscribeToChanges: taskFeed.subscribeToChanges,
+  });
+  return true;
 }

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -169,6 +169,7 @@ async function tryDelegate(
   if (!('workflowId' in response) || !Array.isArray(response.tasks)) {
     return true;
   }
+  targetWorkflowId = response.workflowId;
   const taskFeed = createDelegatedTaskFeed(messageBus, response.tasks, targetWorkflowId);
   await trackWorkflow({
     workflowId: targetWorkflowId,

--- a/packages/app/src/headless-watch.ts
+++ b/packages/app/src/headless-watch.ts
@@ -1,0 +1,259 @@
+import { Channels } from '@invoker/transport';
+import type { MessageBus } from '@invoker/transport';
+import type { TaskConfig, TaskDelta, TaskState } from '@invoker/workflow-core';
+
+import { formatTaskStatus, formatWorkflowStatus } from './formatter.js';
+
+const DIM = '\x1b[2m';
+const RESET = '\x1b[0m';
+
+export interface TrackWorkflowOptions {
+  workflowId: string;
+  loadTasks: () => TaskState[] | Promise<TaskState[]>;
+  messageBus?: MessageBus;
+  subscribeToChanges?: (notify: () => void) => () => void;
+  waitForApproval?: boolean;
+  hasBackgroundWork?: () => boolean;
+  printSnapshot?: boolean;
+  printSummary?: boolean;
+  printTaskOutput?: boolean;
+  allowSignals?: boolean;
+  setExitCodeOnFailure?: boolean;
+  maxWaitMs?: number;
+  pollIntervalMs?: number;
+}
+
+export interface TrackWorkflowResult {
+  interrupted: boolean;
+  tasks: TaskState[];
+  status: {
+    total: number;
+    completed: number;
+    failed: number;
+    running: number;
+    pending: number;
+  };
+  reviewUrl?: string;
+}
+
+export interface DelegatedTaskFeed {
+  loadTasks: () => TaskState[];
+  subscribeToChanges: (notify: () => void) => () => void;
+}
+
+export function createDelegatedTaskFeed(
+  messageBus: MessageBus,
+  initialTasks: TaskState[],
+  workflowId?: string,
+): DelegatedTaskFeed {
+  const tasks = new Map<string, TaskState>(initialTasks.map((task) => [task.id, task]));
+
+  return {
+    loadTasks: () => Array.from(tasks.values()).filter((task) => (
+      !workflowId || task.config.workflowId === workflowId
+    )),
+    subscribeToChanges: (notify) => {
+      const deltaUnsub = messageBus.subscribe<TaskDelta>(Channels.TASK_DELTA, (delta) => {
+        if (delta.type === 'created') {
+          const task = delta.task;
+          if (workflowId && task.config.workflowId !== workflowId) return;
+          tasks.set(task.id, task);
+          notify();
+          return;
+        }
+
+        if (delta.type === 'updated') {
+          const existing = tasks.get(delta.taskId);
+          if (!existing) return;
+          const { config: cfgChanges, execution: execChanges, ...topLevel } = delta.changes;
+          const updated: TaskState = {
+            ...existing,
+            ...topLevel,
+            config: { ...existing.config, ...cfgChanges } as TaskConfig,
+            execution: { ...existing.execution, ...execChanges },
+          };
+          tasks.set(delta.taskId, updated);
+          notify();
+          return;
+        }
+
+        if (delta.type === 'removed') {
+          if (!tasks.delete(delta.taskId)) return;
+          notify();
+        }
+      });
+
+      return () => deltaUnsub();
+    },
+  };
+}
+
+export async function trackWorkflow(options: TrackWorkflowOptions): Promise<TrackWorkflowResult> {
+  const printSnapshot = options.printSnapshot ?? false;
+  const printSummary = options.printSummary ?? true;
+  const printTaskOutput = options.printTaskOutput ?? false;
+  const allowSignals = options.allowSignals ?? false;
+  const setExitCodeOnFailure = options.setExitCodeOnFailure ?? printSummary;
+  const pollIntervalMs = options.pollIntervalMs ?? 100;
+  const maxWaitMs = options.maxWaitMs;
+  const taskLineById = new Map<string, string>();
+  let tasks: TaskState[] = [];
+  let interrupted = false;
+
+  let wake: (() => void) | null = null;
+  let wakePromise: Promise<void> | null = null;
+  const signalWake = (): void => {
+    wake?.();
+  };
+  const nextWake = (): Promise<void> => {
+    wakePromise ??= new Promise<void>((resolve) => {
+      wake = () => {
+        wake = null;
+        wakePromise = null;
+        resolve();
+      };
+    });
+    return wakePromise;
+  };
+
+  const refresh = async (forceSnapshot = false): Promise<void> => {
+    tasks = filterWorkflowTasks(await options.loadTasks(), options.workflowId);
+    const visibleTasks = tasks;
+    const currentIds = new Set(visibleTasks.map((task) => task.id));
+    for (const task of visibleTasks) {
+      const line = formatTaskStatus(task);
+      const previous = taskLineById.get(task.id);
+      if (forceSnapshot || previous !== line) {
+        process.stdout.write(line + '\n');
+      }
+      taskLineById.set(task.id, line);
+    }
+    for (const taskId of Array.from(taskLineById.keys())) {
+      if (!currentIds.has(taskId)) {
+        taskLineById.delete(taskId);
+      }
+    }
+  };
+
+  const deltaUnsub = options.subscribeToChanges
+    ? options.subscribeToChanges(signalWake)
+    : options.messageBus?.subscribe<TaskDelta>(Channels.TASK_DELTA, (delta) => {
+      const deltaWorkflowId = delta.type === 'created'
+        ? delta.task.config.workflowId
+        : delta.type === 'updated'
+          ? tasks.find((task) => task.id === delta.taskId)?.config.workflowId
+          : undefined;
+      if (!deltaWorkflowId || deltaWorkflowId === options.workflowId) {
+        signalWake();
+      }
+    }) ?? (() => {});
+
+  const outputUnsub = printTaskOutput
+    ? options.messageBus?.subscribe<{ taskId: string; data: string }>(Channels.TASK_OUTPUT, ({ taskId, data }) => {
+      if (taskBelongsToWorkflow(taskId, options.workflowId)) {
+        process.stdout.write(`${DIM}[${taskId}]${RESET} ${data}`);
+      }
+    }) ?? (() => {})
+    : (() => {});
+
+  const signalHandler = (): void => {
+    interrupted = true;
+    signalWake();
+  };
+  if (allowSignals) {
+    process.once('SIGINT', signalHandler);
+    process.once('SIGTERM', signalHandler);
+  }
+
+  const startedAt = Date.now();
+
+  try {
+    await refresh(printSnapshot);
+
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      if (workflowHasSettled(tasks, options.waitForApproval, options.hasBackgroundWork)) {
+        break;
+      }
+      if (interrupted) {
+        break;
+      }
+      if (typeof maxWaitMs === 'number' && Date.now() - startedAt >= maxWaitMs) {
+        break;
+      }
+
+      await Promise.race([
+        nextWake(),
+        new Promise<void>((resolve) => {
+          const timer = setTimeout(resolve, pollIntervalMs);
+          timer.unref?.();
+        }),
+      ]);
+
+      await refresh(false);
+    }
+  } finally {
+    deltaUnsub();
+    outputUnsub();
+    if (allowSignals) {
+      process.removeListener('SIGINT', signalHandler);
+      process.removeListener('SIGTERM', signalHandler);
+    }
+  }
+
+  const result = summarizeWorkflowTasks(tasks);
+  if (printSummary) {
+    process.stdout.write(`\n${formatWorkflowStatus(result.status)}\n`);
+    if (result.reviewUrl) {
+      process.stdout.write(`\nPull Request: ${result.reviewUrl}\n`);
+    }
+  }
+  if (setExitCodeOnFailure && result.status.failed > 0) {
+    process.exitCode = 1;
+  }
+
+  return {
+    interrupted,
+    tasks,
+    status: result.status,
+    reviewUrl: result.reviewUrl,
+  };
+}
+
+function filterWorkflowTasks(tasks: TaskState[], workflowId: string): TaskState[] {
+  return tasks.filter((task) => task.config.workflowId === workflowId);
+}
+
+function taskBelongsToWorkflow(taskId: string, workflowId: string): boolean {
+  return taskId === workflowId || taskId.startsWith(`${workflowId}/`);
+}
+
+function workflowHasSettled(
+  tasks: TaskState[],
+  waitForApproval?: boolean,
+  hasBackgroundWork?: () => boolean,
+): boolean {
+  const settledStatuses = waitForApproval
+    ? new Set(['completed', 'failed', 'needs_input', 'blocked', 'stale'])
+    : new Set(['completed', 'failed', 'needs_input', 'awaiting_approval', 'review_ready', 'blocked', 'stale']);
+  const allSettled = tasks.length > 0 && tasks.every((task) => settledStatuses.has(task.status));
+  if (allSettled && !hasBackgroundWork?.()) {
+    return true;
+  }
+
+  const noneRunning = !tasks.some((task) => task.status === 'running' || task.status === 'fixing_with_ai');
+  const hasHumanBlocked = tasks.some((task) => settledStatuses.has(task.status) && task.status !== 'completed');
+  return noneRunning && hasHumanBlocked && !hasBackgroundWork?.();
+}
+
+function summarizeWorkflowTasks(tasks: TaskState[]): Pick<TrackWorkflowResult, 'status' | 'reviewUrl'> {
+  const status = {
+    total: tasks.length,
+    completed: tasks.filter((task) => task.status === 'completed').length,
+    failed: tasks.filter((task) => task.status === 'failed').length,
+    running: tasks.filter((task) => task.status === 'running' || task.status === 'fixing_with_ai').length,
+    pending: tasks.filter((task) => task.status === 'pending').length,
+  };
+  const reviewUrl = tasks.find((task) => task.config.isMergeNode)?.execution.reviewUrl;
+  return { status, reviewUrl };
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -808,11 +808,11 @@ async function trackHeadlessWorkflow(
     syncFromDb?: boolean;
     setExitCodeOnFailure?: boolean;
   } = {},
-): Promise<void> {
+): Promise<Awaited<ReturnType<typeof trackWorkflow>>> {
   if (options.waitForApproval) {
     process.stdout.write('[headless] Waiting for PR approval (--wait-for-approval)...\n');
   }
-  await trackWorkflow({
+  return await trackWorkflow({
     workflowId,
     messageBus: deps.messageBus,
     waitForApproval: options.waitForApproval,
@@ -845,7 +845,7 @@ async function headlessWatch(workflowId: string | undefined, deps: HeadlessDeps)
   }
 
   process.stdout.write(`${BOLD}Watching workflow: ${workflow.id}${RESET}\n\n`);
-  await trackHeadlessWorkflow(workflow.id, deps, {
+  const result = await trackHeadlessWorkflow(workflow.id, deps, {
     printSnapshot: true,
     printSummary: true,
     printTaskOutput: false,
@@ -853,6 +853,7 @@ async function headlessWatch(workflowId: string | undefined, deps: HeadlessDeps)
     syncFromDb: true,
     setExitCodeOnFailure: true,
   });
+  process.stdout.write(`\n[watch] done — ${result.status.completed} completed, ${result.status.failed} failed\n`);
 }
 
 // ── Headless Commands ────────────────────────────────────────

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -11,7 +11,7 @@
 
 import type { Logger } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
-import type { Orchestrator, CommandService, TaskDelta, TaskState, TaskConfig } from '@invoker/workflow-core';
+import type { Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import { Channels } from '@invoker/transport';
@@ -46,6 +46,7 @@ import {
   tryDelegateResume,
   tryDelegateRun,
 } from './headless-delegation.js';
+import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
 
@@ -567,6 +568,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'migrate-compat':
       await headlessMigrateCompatibility(deps);
       break;
+    case 'watch':
+      await headlessWatch(args[1], deps);
+      break;
 
     // ── Execute (unchanged) ──
     case 'run':
@@ -742,6 +746,7 @@ ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
   query ui-perf [--output F] [--reset]               Print live UI perf stats
 
 ${BOLD}Execute:${RESET}
+  watch [<workflowId>]                                Watch workflow status until settled or Ctrl-C
   run <plan.yaml>                                     Load and execute plan
   resume <id>                                         Resume incomplete workflow
   retry <workflowId>                                  Retry workflow: rerun failed, keep completed
@@ -790,6 +795,66 @@ ${BOLD}Options:${RESET}
 `);
 }
 
+async function trackHeadlessWorkflow(
+  workflowId: string,
+  deps: Pick<HeadlessDeps, 'orchestrator' | 'messageBus'>,
+  options: {
+    waitForApproval?: boolean;
+    hasBackgroundWork?: () => boolean;
+    printSnapshot?: boolean;
+    printSummary?: boolean;
+    printTaskOutput?: boolean;
+    allowSignals?: boolean;
+    syncFromDb?: boolean;
+    setExitCodeOnFailure?: boolean;
+  } = {},
+): Promise<void> {
+  if (options.waitForApproval) {
+    process.stdout.write('[headless] Waiting for PR approval (--wait-for-approval)...\n');
+  }
+  await trackWorkflow({
+    workflowId,
+    messageBus: deps.messageBus,
+    waitForApproval: options.waitForApproval,
+    hasBackgroundWork: options.hasBackgroundWork,
+    printSnapshot: options.printSnapshot,
+    printSummary: options.printSummary,
+    printTaskOutput: options.printTaskOutput,
+    allowSignals: options.allowSignals,
+    setExitCodeOnFailure: options.setExitCodeOnFailure,
+    maxWaitMs: options.allowSignals ? undefined : (options.waitForApproval ? 86_400_000 : 1_800_000),
+    loadTasks: () => {
+      if (options.syncFromDb) {
+        deps.orchestrator.syncFromDb(workflowId);
+      }
+      return deps.orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
+    },
+  });
+}
+
+async function headlessWatch(workflowId: string | undefined, deps: HeadlessDeps): Promise<void> {
+  const workflows = deps.persistence.listWorkflows();
+  if (workflows.length === 0) {
+    process.stdout.write('No workflows found. Run a plan first.\n');
+    return;
+  }
+  const targetWorkflowId = workflowId ?? workflows[0]?.id;
+  const workflow = workflows.find((item) => item.id === targetWorkflowId);
+  if (!workflow || !targetWorkflowId) {
+    throw new Error(`Workflow "${workflowId}" not found.`);
+  }
+
+  process.stdout.write(`${BOLD}Watching workflow: ${workflow.id}${RESET}\n\n`);
+  await trackHeadlessWorkflow(workflow.id, deps, {
+    printSnapshot: true,
+    printSummary: true,
+    printTaskOutput: false,
+    allowSignals: true,
+    syncFromDb: true,
+    setExitCodeOnFailure: true,
+  });
+}
+
 // ── Headless Commands ────────────────────────────────────────
 
 async function headlessRun(
@@ -798,12 +863,11 @@ async function headlessRun(
   waitForApproval?: boolean,
   noTrack?: boolean,
 ): Promise<void> {
-  const { orchestrator, messageBus, repoRoot, invokerConfig } = deps;
+  const { orchestrator, repoRoot, invokerConfig } = deps;
   if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
 
   const { readFile } = await import('node:fs/promises');
   const { parsePlanFile } = await import('./plan-parser.js');
-  const { formatTaskStatus, formatWorkflowStatus } = await import('./formatter.js');
 
   const yamlSource = await readFile(planPath, 'utf-8');
   const plan = await parsePlanFile(planPath);
@@ -812,15 +876,6 @@ async function headlessRun(
   backupPlan(plan, yamlSource, deps.logger);
   process.stdout.write(`${BOLD}Loading plan: ${plan.name}${RESET}\n`);
   process.stdout.write(`Tasks: ${plan.tasks.length}\n\n`);
-
-  messageBus.subscribe<TaskDelta>(Channels.TASK_DELTA, (delta) => {
-    if (delta.type === 'updated') {
-      const task = orchestrator.getTask(delta.taskId);
-      if (task) process.stdout.write(formatTaskStatus(task) + '\n');
-    } else if (delta.type === 'created') {
-      process.stdout.write(formatTaskStatus(delta.task) + '\n');
-    }
-  });
 
   const taskExecutor = createHeadlessExecutor(deps);
   wireHeadlessApproveHook(deps, taskExecutor);
@@ -852,22 +907,19 @@ async function headlessRun(
     return;
   }
 
-  await waitForCompletion(orchestrator, currentWorkflowId, waitForApproval, autoFix.isBusy);
+  if (currentWorkflowId) {
+    await trackHeadlessWorkflow(currentWorkflowId, deps, {
+      waitForApproval,
+      hasBackgroundWork: autoFix.isBusy,
+      printSnapshot: true,
+      printSummary: true,
+      printTaskOutput: true,
+      setExitCodeOnFailure: true,
+    });
+  }
 
   await api.close().catch(() => {});
   autoFix.unsubscribe();
-
-  const status = orchestrator.getWorkflowStatus(currentWorkflowId);
-  process.stdout.write(`\n${formatWorkflowStatus(status)}\n`);
-
-  const mergeTask = orchestrator.getAllTasks().find(
-    t => t.config.workflowId === currentWorkflowId && t.config.isMergeNode,
-  );
-  if (mergeTask?.execution?.reviewUrl) {
-    process.stdout.write(`\nPull Request: ${mergeTask.execution.reviewUrl}\n`);
-  }
-
-  if (status.failed > 0) process.exitCode = 1;
 }
 
 async function headlessResume(
@@ -876,21 +928,10 @@ async function headlessResume(
   waitForApproval?: boolean,
   noTrack?: boolean,
 ): Promise<void> {
-  const { orchestrator, messageBus } = deps;
+  const { orchestrator } = deps;
   if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
 
-  const { formatTaskStatus, formatWorkflowStatus } = await import('./formatter.js');
-
   process.stdout.write(`${BOLD}Resuming workflow: ${workflowId}${RESET}\n\n`);
-
-  messageBus.subscribe<TaskDelta>(Channels.TASK_DELTA, (delta) => {
-    if (delta.type === 'updated') {
-      const task = orchestrator.getTask(delta.taskId);
-      if (task) process.stdout.write(formatTaskStatus(task) + '\n');
-    } else if (delta.type === 'created') {
-      process.stdout.write(formatTaskStatus(delta.task) + '\n');
-    }
-  });
 
   const taskExecutor = createHeadlessExecutor(deps);
   wireHeadlessApproveHook(deps, taskExecutor);
@@ -936,15 +977,17 @@ async function headlessResume(
 
   await taskExecutor.executeTasks(allStarted);
 
-  await waitForCompletion(orchestrator, workflowId, waitForApproval, autoFix.isBusy);
+  await trackHeadlessWorkflow(workflowId, deps, {
+    waitForApproval,
+    hasBackgroundWork: autoFix.isBusy,
+    printSnapshot: true,
+    printSummary: true,
+    printTaskOutput: true,
+    setExitCodeOnFailure: true,
+  });
 
   await api.close().catch(() => {});
   autoFix.unsubscribe();
-
-  const status = orchestrator.getWorkflowStatus();
-  process.stdout.write(`\n${formatWorkflowStatus(status)}\n`);
-
-  if (status.failed > 0) process.exitCode = 1;
 }
 
 async function headlessApprove(taskId: string, deps: HeadlessDeps): Promise<void> {
@@ -966,7 +1009,12 @@ async function headlessApprove(taskId: string, deps: HeadlessDeps): Promise<void
     autoFix.unsubscribe();
     return;
   }
-  await waitForCompletion(deps.orchestrator, restored.workflowId, undefined, autoFix.isBusy);
+  await trackHeadlessWorkflow(restored.workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
   autoFix.unsubscribe();
 }
 
@@ -1000,13 +1048,19 @@ async function headlessSelect(taskId: string, experimentId: string, deps: Headle
   const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
   const started = deps.orchestrator.resumeWorkflow(workflowId);
   void started;
-  await waitForCompletion(deps.orchestrator, undefined, undefined, autoFix.isBusy);
+  await trackHeadlessWorkflow(workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
   autoFix.unsubscribe();
 }
 
 async function headlessRestart(taskId: string, deps: HeadlessDeps): Promise<void> {
   if (!taskId) throw new Error('Missing arguments. Usage: --headless retry-task <taskId>');
-  taskId = restoreWorkflowForTask(taskId, deps).resolvedTaskId;
+  const restored = restoreWorkflowForTask(taskId, deps);
+  taskId = restored.resolvedTaskId;
   await preemptTaskSubgraph(taskId, deps);
 
   const envelope = makeEnvelope('restart-task', 'headless', 'task', { taskId });
@@ -1029,7 +1083,12 @@ async function headlessRestart(taskId: string, deps: HeadlessDeps): Promise<void
     autoFix.unsubscribe();
     return;
   }
-  await waitForCompletion(deps.orchestrator, undefined, undefined, autoFix.isBusy);
+  await trackHeadlessWorkflow(restored.workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
   autoFix.unsubscribe();
 }
 
@@ -1138,7 +1197,12 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
     autoFix.unsubscribe();
     return;
   }
-  await waitForCompletion(deps.orchestrator, workflowId, undefined, autoFix.isBusy);
+  await trackHeadlessWorkflow(workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
   autoFix.unsubscribe();
 
   const tasksStarted = runnable.length;
@@ -1182,7 +1246,12 @@ async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps):
       autoFix.unsubscribe();
       return;
     }
-    await waitForCompletion(deps.orchestrator, workflowId, undefined, autoFix.isBusy);
+    await trackHeadlessWorkflow(workflowId, deps, {
+      hasBackgroundWork: autoFix.isBusy,
+      printSummary: false,
+      printTaskOutput: true,
+      setExitCodeOnFailure: false,
+    });
     autoFix.unsubscribe();
   }
   const tasksStarted = runnable.length;
@@ -1224,7 +1293,14 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
     autoFix.unsubscribe();
     return;
   }
-  await waitForCompletion(deps.orchestrator, workflowId, undefined, autoFix.isBusy);
+  if (workflowId) {
+    await trackHeadlessWorkflow(workflowId, deps, {
+      hasBackgroundWork: autoFix.isBusy,
+      printSummary: false,
+      printTaskOutput: true,
+      setExitCodeOnFailure: false,
+    });
+  }
   autoFix.unsubscribe();
 }
 
@@ -1338,7 +1414,12 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
     autoFix.unsubscribe();
     return;
   }
-  await waitForCompletion(deps.orchestrator, workflowId, undefined, autoFix.isBusy);
+  await trackHeadlessWorkflow(workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
   autoFix.unsubscribe();
 }
 
@@ -1399,7 +1480,12 @@ async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDe
     autoFix.unsubscribe();
     return;
   }
-  await waitForCompletion(deps.orchestrator, restored.workflowId, undefined, autoFix.isBusy);
+  await trackHeadlessWorkflow(restored.workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
   autoFix.unsubscribe();
 }
 
@@ -1428,7 +1514,12 @@ async function headlessEditExecutor(taskId: string, executorType: string, deps: 
     autoFix.unsubscribe();
     return;
   }
-  await waitForCompletion(deps.orchestrator, restored.workflowId, undefined, autoFix.isBusy);
+  await trackHeadlessWorkflow(restored.workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
   autoFix.unsubscribe();
 }
 
@@ -1457,7 +1548,12 @@ async function headlessEditAgent(taskId: string, agentName: string, deps: Headle
     autoFix.unsubscribe();
     return;
   }
-  await waitForCompletion(deps.orchestrator, restored.workflowId, undefined, autoFix.isBusy);
+  await trackHeadlessWorkflow(restored.workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
   autoFix.unsubscribe();
 }
 
@@ -1780,41 +1876,6 @@ function restoreWorkflowForTask(
     }
   }
   throw new Error(`Task "${taskId}" not found in any workflow`);
-}
-
-async function waitForCompletion(
-  orchestrator: Orchestrator,
-  workflowId?: string,
-  waitForApproval?: boolean,
-  hasBackgroundWork?: () => boolean,
-): Promise<void> {
-  const maxWaitMs = waitForApproval ? 86_400_000 : 1_800_000; // 24 hours if waiting for approval, else 30 minutes
-  const pollIntervalMs = 100;
-  const start = Date.now();
-
-  if (waitForApproval) {
-    process.stdout.write('[headless] Waiting for PR approval (--wait-for-approval)...\n');
-  }
-
-  while (Date.now() - start < maxWaitMs) {
-    let tasks = orchestrator.getAllTasks();
-    if (workflowId) {
-      tasks = tasks.filter((t) => t.config.workflowId === workflowId);
-    }
-    const settledStatuses = waitForApproval
-      ? ['completed', 'failed', 'needs_input', 'blocked', 'stale']
-      : ['completed', 'failed', 'needs_input', 'awaiting_approval', 'review_ready', 'blocked', 'stale'];
-    const allSettled = tasks.every((t) => settledStatuses.includes(t.status));
-    if (allSettled && !hasBackgroundWork?.()) return;
-    // Also settle if nothing is running and at least one task awaits human action.
-    // Pending merge gates can't progress until their upstream is approved.
-    const noneRunning = !tasks.some(
-      (t) => t.status === 'running' || t.status === 'fixing_with_ai',
-    );
-    const hasHumanBlocked = tasks.some((t) => settledStatuses.includes(t.status) && t.status !== 'completed');
-    if (noneRunning && hasHumanBlocked && !hasBackgroundWork?.()) return;
-    await new Promise((resolve) => setTimeout(resolve, pollIntervalMs));
-  }
 }
 
 // ── Headless Delegation ──────────────────────────────────────


### PR DESCRIPTION
## Summary
- add a standalone read-only `--headless watch [<workflowId>]` command
- extract shared headless workflow tracking into `headless-watch.ts`
- route delegated tracking and local headless tracking through the same watcher path

## What Changed
- added `watch` to headless command routing, help text, and read-only command classification
- moved the workflow-following logic that had been split between `headless.ts` (`waitForCompletion` plus inline `TASK_DELTA` subscriptions in `run` and `resume`) and `headless-delegation.ts` (delegated task-map tracking and settlement polling) into the new shared module `packages/app/src/headless-watch.ts`
- `headless-watch.ts` now owns task snapshot rendering, delta-driven wakeups, polling fallback, final workflow summary rendering, and failure exit-code handling
- rewired local headless commands in `headless.ts` to call the shared tracker instead of their previous ad hoc wait path, including `run`, `resume`, `retry`, `recreate`, `recreate-task`, `rebase`, `retry-task`, `approve`, `select`, and the task edit flows
- rewired delegated tracking in `headless-delegation.ts` to build a delegated task feed and pass it through the same shared tracker so local and delegated output stay aligned
- added focused tests for the new `watch` command and command classification

## Verification
- `pnpm run check:types`
- `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-watch.test.ts src/__tests__/headless-command-classification.test.ts src/__tests__/owner-delegation.test.ts src/__tests__/headless-client.test.ts`
- `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-delegation.test.ts`

## Notes
- the earlier PR revision had a TypeScript narrowing issue in `headless-delegation.ts`; that has been fixed in the latest commit
- `playwright / 1-of-3` failed once in CI on `e2e/headless-thundering-herd.spec.ts`, but the same symptom did not reproduce locally while validating the follow-up fix
