### PR TITLE
Guard tsup DTS builds against TS6307 config regressions

### DIFF
--- a/scripts/check-tsup-dts-build-config.mjs
+++ b/scripts/check-tsup-dts-build-config.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const packagesDir = path.join(repoRoot, 'packages');
+
+const ALLOWED_DTS_TSCONFIGS = new Set(['tsconfig.build.json', 'tsconfig.tsup.json']);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function extractScriptTsconfig(buildScript) {
+  const match = buildScript.match(/--tsconfig\s+([^\s]+)/);
+  return match ? match[1].replace(/^["']|["']$/g, '') : undefined;
+}
+
+function extractConfigTsconfig(tsupConfigSource) {
+  const match = tsupConfigSource.match(/\btsconfig\s*:\s*['"]([^'"]+)['"]/);
+  return match ? match[1] : undefined;
+}
+
+function configEnablesDts(buildScript, tsupConfigSource) {
+  if (typeof buildScript === 'string' && buildScript.includes('--dts')) {
+    return true;
+  }
+  return /\bdts\s*:/.test(tsupConfigSource);
+}
+
+function resolvePackageTsconfig(packageDir, tsconfigRef) {
+  if (!tsconfigRef) return undefined;
+  return path.resolve(packageDir, tsconfigRef);
+}
+
+function assertDedicatedNonCompositeTsconfig(packageName, packageDir, tsconfigRef, failures) {
+  if (!tsconfigRef) {
+    failures.push(`${packageName}: missing explicit tsconfig for tsup DTS build`);
+    return;
+  }
+
+  const baseName = path.basename(tsconfigRef);
+  if (!ALLOWED_DTS_TSCONFIGS.has(baseName)) {
+    failures.push(
+      `${packageName}: tsup DTS build uses disallowed tsconfig "${tsconfigRef}" (expected one of ${Array.from(ALLOWED_DTS_TSCONFIGS).join(', ')})`,
+    );
+    return;
+  }
+
+  const tsconfigPath = resolvePackageTsconfig(packageDir, tsconfigRef);
+  if (!tsconfigPath || !fs.existsSync(tsconfigPath)) {
+    failures.push(`${packageName}: referenced tsconfig "${tsconfigRef}" does not exist`);
+    return;
+  }
+
+  const tsconfig = readJson(tsconfigPath);
+  if (tsconfig?.compilerOptions?.composite !== false) {
+    failures.push(`${packageName}: ${tsconfigRef} must set compilerOptions.composite=false`);
+  }
+}
+
+const failures = [];
+const checkedPackages = [];
+
+for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const packageDir = path.join(packagesDir, entry.name);
+  const packageJsonPath = path.join(packageDir, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) continue;
+
+  const pkg = readJson(packageJsonPath);
+  const buildScript = pkg?.scripts?.build;
+  const tsupConfigPath = path.join(packageDir, 'tsup.config.ts');
+  const tsupConfigSource = fs.existsSync(tsupConfigPath)
+    ? fs.readFileSync(tsupConfigPath, 'utf8')
+    : '';
+
+  const usesTsup = (typeof buildScript === 'string' && /\btsup\b/.test(buildScript)) || tsupConfigSource.length > 0;
+  if (!usesTsup) continue;
+
+  if (!configEnablesDts(buildScript, tsupConfigSource)) continue;
+
+  const tsconfigRef = fs.existsSync(tsupConfigPath)
+    ? extractConfigTsconfig(tsupConfigSource)
+    : extractScriptTsconfig(buildScript);
+
+  checkedPackages.push({
+    packageName: pkg.name ?? entry.name,
+    packageDir,
+    tsconfigRef: tsconfigRef ?? '(missing)',
+  });
+  assertDedicatedNonCompositeTsconfig(pkg.name ?? entry.name, packageDir, tsconfigRef, failures);
+}
+
+if (checkedPackages.length === 0) {
+  console.error('No tsup DTS packages found to validate.');
+  process.exit(1);
+}
+
+console.log('Validated tsup DTS build config for:');
+for (const checked of checkedPackages) {
+  console.log(`- ${checked.packageName}: ${checked.tsconfigRef}`);
+}
+
+if (failures.length > 0) {
+  console.error('\nFailures:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('\nAll tsup DTS packages use dedicated non-composite tsconfigs.');

--- a/scripts/repro/repro-tsup-dts-build-config-guard.sh
+++ b/scripts/repro/repro-tsup-dts-build-config-guard.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Repro/proof: keep the original TS6307 tsup DTS regression fixed by enforcing
+# that every tsup DTS package uses a dedicated non-composite tsconfig, then
+# re-building the packages that originally exposed the failure class.
+#
+# Usage:
+#   bash scripts/repro/repro-tsup-dts-build-config-guard.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "==> guard: every tsup DTS package uses a dedicated non-composite tsconfig"
+node scripts/check-tsup-dts-build-config.mjs
+
+echo
+echo "==> direct regression checks for the original TS6307 packages"
+pnpm --filter @invoker/runtime-domain build
+pnpm --filter @invoker/runtime-adapters build
+pnpm --filter @invoker/transport build
+
+echo
+echo "repro result:"
+echo "- the repo guard confirms every tsup DTS package uses a dedicated build tsconfig"
+echo "- runtime-domain, runtime-adapters, and transport still build successfully"
+echo "- this keeps the original TS6307 class from silently drifting back in"


### PR DESCRIPTION
## Summary
The dedicated DTS build-config fix was in place, but there was nothing structural preventing a package from drifting back to the original `tsup --dts` + composite-tsconfig shape that caused `TS6307`.

## Exact Failure / Symptom
Original failure being guarded against:
`TS6307 ... file is not listed within the file list of project` during `tsup --dts`

## Exact Guard Setup
- Repo guard: `scripts/check-tsup-dts-build-config.mjs`
- Repro/guard harness: `scripts/repro/repro-tsup-dts-build-config-guard.sh`
- The guard scans every package that uses `tsup --dts` and fails if it is not wired to a dedicated DTS tsconfig (`tsconfig.build.json` or `tsconfig.tsup.json`) with the expected non-composite shape.

## Root Cause
The repo had a convention but no invariant: `tsup --dts` packages were supposed to use dedicated non-composite build tsconfigs, but CI would not fail if someone pointed a package back at its normal composite tsconfig.

## Why This Fix Is Right
A structural config guard is the right anti-regression mechanism. Relying only on historical repros or memory would detect the problem too late and would not cover newly added packages.

## Validation
- The guard script passes and the original failing packages still build successfully under the dedicated DTS config pattern.
- PR #39 fixes the concrete DTS failure class; this PR keeps that config shape from regressing.

## Traceability
- Commit: `ef092be`
- Commit message: `Guard tsup DTS builds against TS6307 config regressions`
