### PR TITLE
Avoid false launch stalls during SSH startup

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -862,6 +862,7 @@ if (isHeadless) {
   let apiServer: ApiServer | null = null;
   let ownerMode = true;
   const taskHandles = new Map<string, { handle: ExecutorHandle; executor: Executor }>();
+  const launchingTasks = new Set<string>();
   const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
   let dbPollInterval: ReturnType<typeof setInterval> | null = null;
   let activityPollInterval: ReturnType<typeof setInterval> | null = null;
@@ -1205,7 +1206,19 @@ if (isHeadless) {
         onOutput: (taskId, data) => {
           enqueueTaskOutput(taskId, data);
         },
+        onLaunchStart: (taskId, executor) => {
+          launchingTasks.add(taskId);
+          logger.info(`Task "${taskId}" launch started (executor: ${executor.type})`, { module: 'exec' });
+        },
+        onLaunchFailed: (taskId, error, executor) => {
+          launchingTasks.delete(taskId);
+          logger.error(
+            `Task "${taskId}" launch failed before spawn (executor: ${executor.type}): ${error.message}`,
+            { module: 'exec' },
+          );
+        },
         onSpawned: (taskId, handle, executor) => {
+          launchingTasks.delete(taskId);
           flushTaskOutput(taskId);
           logger.info(
             `Task "${taskId}" spawned (handle: ${handle.executionId}, executor: ${executor.type}, workspace: ${handle.workspacePath ?? 'none'}, branch: ${handle.branch ?? 'none'})`,
@@ -2033,7 +2046,8 @@ if (isHeadless) {
                     task.execution.phase === 'launching'
                     && launchStartedAt !== undefined
                     && launchAgeMs >= launchingStallTimeoutMs
-                    && !taskHandles.has(task.id);
+                    && !taskHandles.has(task.id)
+                    && !launchingTasks.has(task.id);
                   if (launchStalled) {
                     const launchError =
                       `Launch stalled: task remained in running/launching for ${Math.floor(launchingStallTimeoutMs / 1000)}s without a spawned execution handle`;

--- a/packages/execution-engine/src/__tests__/managed-worktree-controller.test.ts
+++ b/packages/execution-engine/src/__tests__/managed-worktree-controller.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+import { planManagedWorktree } from '../managed-worktree-controller.js';
+
+describe('planManagedWorktree', () => {
+  it('reuses the exact branch worktree when the checked out head matches', () => {
+    const plan = planManagedWorktree({
+      targetBranch: 'experiment/wf/task-1234',
+      targetWorktreePath: '/wt/target',
+      exactBranchCandidate: {
+        path: '/wt/existing',
+        headMatchesTargetBranch: true,
+      },
+    });
+
+    expect(plan).toEqual({
+      kind: 'reuse_exact',
+      worktreePath: '/wt/existing',
+    });
+  });
+
+  it('reuses an actionId worktree by renaming the branch when base is still compatible', () => {
+    const plan = planManagedWorktree({
+      targetBranch: 'experiment/wf/task-5678',
+      targetWorktreePath: '/wt/target',
+      actionIdCandidate: {
+        path: '/wt/existing',
+        branch: 'experiment/wf/task-1234',
+        baseIsAncestorOfHead: true,
+      },
+    });
+
+    expect(plan).toEqual({
+      kind: 'rename_reuse',
+      worktreePath: '/wt/existing',
+      fromBranch: 'experiment/wf/task-1234',
+      toBranch: 'experiment/wf/task-5678',
+    });
+  });
+
+  it('reconciles both the canonical target path and stale branch-owner path before recreate', () => {
+    const plan = planManagedWorktree({
+      targetBranch: 'experiment/wf/task-5678',
+      targetWorktreePath: '/wt/target',
+      exactBranchCandidate: {
+        path: '/wt/other-owner',
+        headMatchesTargetBranch: false,
+      },
+    });
+
+    expect(plan).toEqual({
+      kind: 'recreate',
+      worktreePath: '/wt/target',
+      cleanupPaths: ['/wt/target', '/wt/other-owner'],
+    });
+  });
+
+  it('forces recreate when requested even if a reuse candidate exists', () => {
+    const plan = planManagedWorktree({
+      targetBranch: 'experiment/wf/task-5678',
+      targetWorktreePath: '/wt/target',
+      forceFresh: true,
+      exactBranchCandidate: {
+        path: '/wt/existing',
+        headMatchesTargetBranch: true,
+      },
+      actionIdCandidate: {
+        path: '/wt/action-id',
+        branch: 'experiment/wf/task-1234',
+        baseIsAncestorOfHead: true,
+      },
+    });
+
+    expect(plan).toEqual({
+      kind: 'recreate',
+      worktreePath: '/wt/target',
+      cleanupPaths: ['/wt/target'],
+    });
+  });
+
+  it('creates fresh when an actionId worktree exists but its base is stale', () => {
+    const plan = planManagedWorktree({
+      targetBranch: 'experiment/wf/task-5678',
+      targetWorktreePath: '/wt/target',
+      actionIdCandidate: {
+        path: '/wt/action-id',
+        branch: 'experiment/wf/task-1234',
+        baseIsAncestorOfHead: false,
+      },
+    });
+
+    expect(plan).toEqual({
+      kind: 'recreate',
+      worktreePath: '/wt/target',
+      cleanupPaths: ['/wt/target'],
+    });
+  });
+});

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -5,6 +5,8 @@ import { SshExecutor } from '../ssh-executor.js';
 import type { WorkRequest } from '@invoker/contracts';
 import type { PersistedTaskMeta } from '../executor.js';
 import { createSshRemoteScriptError } from '../ssh-git-exec.js';
+import { computeRepoUrlHash } from '../git-utils.js';
+import { computeBranchHash } from '../branch-utils.js';
 
 function makeRequest(overrides: Partial<WorkRequest> = {}): WorkRequest {
   return {
@@ -207,6 +209,129 @@ describe('SshExecutor managed workspace mode', () => {
     expect(callScript).toMatch(/base64 -d/);
     expect(callAgentId).toBeUndefined();
     expect(callFinalize).toEqual({ branch: handle.branch, worktreePath: handle.workspacePath });
+  });
+
+  it('reuses a managed SSH worktree by actionId when the old base is still compatible', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+    }) as any;
+
+    const repoHash = computeRepoUrlHash('git@github.com:owner/repo.git');
+    const remotePath = `/home/testuser/.invoker/worktrees/${repoHash}/experiment-test-task-oldhash`;
+    const execRemoteCapture = vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return [
+          '__INVOKER_BASE_REF__=origin/main',
+          '__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1',
+        ].join('\n');
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) {
+        return `worktree ${remotePath}
+HEAD deadbeef
+branch refs/heads/experiment/test-task-oldhash
+`;
+      }
+      if (script.includes('merge-base --is-ancestor')) return '';
+      if (script.includes('branch -m')) {
+        const toEncoded = script.match(/TO=\$\(echo ([^ ]+) \| base64 -d\)/)?.[1];
+        const toBranch = Buffer.from(toEncoded ?? '', 'base64').toString('utf8');
+        return `${toBranch}\n`;
+      }
+      return '';
+    });
+
+    const setupTaskBranchSpy = vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+    const mergeUpstreamsSpy = vi.spyOn(ssh, 'mergeRequestUpstreamBranches').mockResolvedValue(undefined);
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any) => handle,
+    );
+
+    const req = makeRequest({
+      actionType: 'command',
+      actionId: 'test-task',
+      inputs: {
+        command: 'pnpm test',
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    });
+
+    const handle = await ssh.start(req);
+
+    expect(handle.workspacePath).toBe(`~/.invoker/worktrees/${repoHash}/experiment-test-task-oldhash`);
+    expect(setupTaskBranchSpy).not.toHaveBeenCalled();
+    expect(mergeUpstreamsSpy).toHaveBeenCalled();
+    expect(execRemoteCapture).toHaveBeenCalledWith(expect.stringContaining('branch -m'), 'rename_reuse_branch');
+  });
+
+  it('cleans up the existing branch-owner worktree before recreating a conflicting target branch', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+    }) as any;
+
+    const repoHash = computeRepoUrlHash('git@github.com:owner/repo.git');
+    const baseHead = 'abc123def456abc123def456abc123def456abc1';
+    const branchHash = computeBranchHash(
+      'test-task-conflict',
+      'pnpm test',
+      undefined,
+      [],
+      baseHead,
+      '',
+    );
+    const targetBranch = `experiment/test-task-conflict-${branchHash}`;
+    const ownerPath = `/home/testuser/.invoker/worktrees/${repoHash}/stale-owner-${branchHash}`;
+    let cleanupScript = '';
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string, phase?: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return [
+          '__INVOKER_BASE_REF__=origin/main',
+          `__INVOKER_BASE_HEAD__=${baseHead}`,
+        ].join('\n');
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) {
+        return `worktree ${ownerPath}
+HEAD deadbeef
+branch refs/heads/${targetBranch}
+`;
+      }
+      if (phase === 'cleanup_worktree') {
+        cleanupScript = script;
+        return '';
+      }
+      if (script.includes('rev-parse --abbrev-ref HEAD')) return 'not-the-target-branch\n';
+      return '';
+    });
+
+    const setupTaskBranchSpy = vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any) => handle,
+    );
+
+    const req = makeRequest({
+      actionType: 'command',
+      actionId: 'test-task-conflict',
+      inputs: {
+        command: 'pnpm test',
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    });
+
+    await ssh.start(req);
+
+    const encodedPaths = cleanupScript.match(/WORKTREES_B64="([^"]+)"/)?.[1];
+    const decodedPaths = Buffer.from(encodedPaths ?? '', 'base64').toString('utf8');
+    expect(decodedPaths).toContain(ownerPath);
+    expect(setupTaskBranchSpy).toHaveBeenCalled();
   });
 
   it('throws when managedWorkspaces=true but repoUrl is missing', async () => {

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -33,6 +33,16 @@ function createMockProcess(): ChildProcess & EventEmitter {
   return proc;
 }
 
+function createDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 // ---------------------------------------------------------------------------
 // Module-level spawn mock
 //
@@ -295,6 +305,56 @@ describe('SshExecutor managed workspace mode', () => {
     expect(capturedScript).toContain('exit 42');
     // Note: We're testing that the provision command is included in the script.
     // The actual exit code propagation is tested by integration tests with real SSH.
+  });
+
+  it('does not return a handle until managed remote bootstrap/setup has finished', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+    }) as any;
+
+    const bootstrap = createDeferred<string>();
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return bootstrap.promise;
+      }
+      if (script.includes('printf %s \"$HOME\"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+
+    const setupTaskBranchSpy = vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+    const spawnSpy = vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any) => handle,
+    );
+
+    const req = makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: 'echo hello',
+        description: 'test',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    });
+
+    let settled = false;
+    const pending = ssh.start(req).then(() => {
+      settled = true;
+    });
+
+    await new Promise((r) => setImmediate(r));
+
+    expect(settled).toBe(false);
+    expect(setupTaskBranchSpy).not.toHaveBeenCalled();
+    expect(spawnSpy).not.toHaveBeenCalled();
+
+    bootstrap.resolve('__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123');
+    await pending;
+
+    expect(setupTaskBranchSpy).toHaveBeenCalledTimes(1);
+    expect(spawnSpy).toHaveBeenCalledTimes(1);
   });
 
   it('uses configured remoteInvokerHome instead of default ~/.invoker', async () => {

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -13,6 +13,7 @@ import {
   buildWorktreeListScript,
   buildWorktreeHeadScript,
   buildWorktreeCleanupScript,
+  buildWorktreeRenameBranchScript,
   buildRecordAndPushScript,
   parseRecordAndPushOutput,
   execRemoteCapture,
@@ -246,14 +247,14 @@ describe('buildWorktreeCleanupScript', () => {
   it('generates cleanup script with prune and remove logic', () => {
     const script = buildWorktreeCleanupScript({
       remoteClone: '$HOME/.invoker/repos/abc123',
-      canonicalRemoteWt: '$HOME/.invoker/worktrees/abc123/exp-task-def',
+      worktreePaths: ['$HOME/.invoker/worktrees/abc123/exp-task-def'],
     });
 
     expect(script).toContain('set -euo pipefail');
     expect(script).toContain('CLONE="$HOME/.invoker/repos/abc123"');
-    expect(script).toContain('WT="$HOME/.invoker/worktrees/abc123/exp-task-def"');
     expect(script).toContain('CLONE="$HOME"');
-    expect(script).toContain('WT="$HOME"');
+    expect(script).toContain('WORKTREES_B64=');
+    expect(script).toContain('while IFS= read -r WT; do');
     expect(script).toContain('mkdir -p "$(dirname "$WT")"');
     expect(script).toContain('git -C "$CLONE" worktree prune');
     expect(script).toContain('git -C "$CLONE" worktree remove --force "$WT"');
@@ -274,7 +275,7 @@ describe('buildWorktreeCleanupScript', () => {
 
     const script = buildWorktreeCleanupScript({
       remoteClone: '~/.invoker/repos/abc123',
-      canonicalRemoteWt: '~/.invoker/worktrees/abc123/exp-task-def',
+      worktreePaths: ['~/.invoker/worktrees/abc123/exp-task-def'],
     });
 
     execFileSync('bash', ['-lc', script], {
@@ -287,6 +288,22 @@ describe('buildWorktreeCleanupScript', () => {
     expect(() => execSync(`test ! -e ${JSON.stringify(join(staleWt, 'sentinel.txt'))}`)).not.toThrow();
     expect(() => execSync(`test ! -e ${JSON.stringify(literalTildeRoot)}`)).not.toThrow();
     execSync(`rm -rf ${JSON.stringify(literalTildeRoot)}`);
+  });
+});
+
+describe('buildWorktreeRenameBranchScript', () => {
+  it('renames a managed branch and prints the new HEAD ref', () => {
+    const script = buildWorktreeRenameBranchScript({
+      worktreePath: '~/.invoker/worktrees/abc123/exp-task-old',
+      fromBranch: 'experiment/task-old',
+      toBranch: 'experiment/task-new',
+    });
+
+    expect(script).toContain('WT=$(echo');
+    expect(script).toContain('FROM=$(echo');
+    expect(script).toContain('TO=$(echo');
+    expect(script).toContain('git -C "$WT" branch -m "$FROM" "$TO"');
+    expect(script).toContain('git -C "$WT" rev-parse --abbrev-ref HEAD');
   });
 });
 

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1418,6 +1418,54 @@ describe('TaskRunner', () => {
   });
 
   describe('launch timeout repro', () => {
+    it('reports launch-in-progress callbacks while executor.start is still pending', async () => {
+      const launchStart = vi.fn();
+      const launchFailed = vi.fn();
+      const deferred = new Promise<never>(() => {});
+      const hangingExecutor = {
+        type: 'ssh',
+        start: vi.fn(async () => await deferred),
+        onOutput: vi.fn(),
+        onComplete: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+        destroyAll: vi.fn(),
+      };
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: () => undefined,
+          handleWorkerResponse: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask: vi.fn(),
+          updateAttempt: vi.fn(),
+        } as any,
+        executorRegistry: {
+          getDefault: () => hangingExecutor,
+          get: () => hangingExecutor,
+          getAll: () => [hangingExecutor],
+        } as any,
+        cwd: '/tmp',
+        callbacks: {
+          onLaunchStart: launchStart,
+          onLaunchFailed: launchFailed,
+        },
+      });
+
+      const task = makeTask({
+        id: 'launch-in-progress',
+        status: 'running',
+        config: { command: 'echo hello' },
+        execution: { selectedAttemptId: 'launch-in-progress-a1' },
+      });
+
+      void runner.executeTask(task);
+      await vi.waitFor(() => expect(hangingExecutor.start).toHaveBeenCalledTimes(1));
+
+      expect(launchStart).toHaveBeenCalledWith('launch-in-progress', hangingExecutor);
+      expect(launchFailed).not.toHaveBeenCalled();
+    });
+
     it('fails a task when executor.start never resolves and keeps it in launching', async () => {
       vi.useFakeTimers();
       const previousTimeout = process.env.INVOKER_EXECUTOR_START_TIMEOUT_MS;
@@ -1425,6 +1473,8 @@ describe('TaskRunner', () => {
       try {
         const handleWorkerResponse = vi.fn();
         const onComplete = vi.fn();
+        const onLaunchStart = vi.fn();
+        const onLaunchFailed = vi.fn();
         const persistence = {
           updateTask: vi.fn(),
           updateAttempt: vi.fn(),
@@ -1463,7 +1513,7 @@ describe('TaskRunner', () => {
             getAll: () => [hangingExecutor],
           } as any,
           cwd: '/tmp',
-          callbacks: { onComplete },
+          callbacks: { onComplete, onLaunchStart, onLaunchFailed },
         });
 
         const done = runner.executeTask(task);
@@ -1478,6 +1528,14 @@ describe('TaskRunner', () => {
               error: expect.stringContaining('Executor startup timed out after 100ms'),
             }),
           }),
+        );
+        expect(onLaunchStart).toHaveBeenCalledWith('launch-hang', hangingExecutor);
+        expect(onLaunchFailed).toHaveBeenCalledWith(
+          'launch-hang',
+          expect.objectContaining({
+            message: expect.stringContaining('Executor startup failed (worktree): Executor startup timed out after 100ms'),
+          }),
+          hangingExecutor,
         );
         expect(handleWorkerResponse).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -3323,11 +3381,11 @@ describe('TaskRunner', () => {
       (executor as any).activePrPollers.delete('task-1');
     });
 
-    it('completes merge gate when PR is approved', async () => {
+    it('approved external_review PR auto-completes a review_ready merge gate', async () => {
       const orchestrator = {
         getTask: vi.fn((id: string) => ({
           id,
-          status: 'awaiting_approval',
+          status: 'review_ready',
           execution: { reviewId: 'owner/repo#42' },
         })),
         approve: vi.fn(),

--- a/packages/execution-engine/src/managed-worktree-controller.ts
+++ b/packages/execution-engine/src/managed-worktree-controller.ts
@@ -1,0 +1,75 @@
+export interface ManagedWorktreeExactCandidate {
+  path: string;
+  headMatchesTargetBranch: boolean;
+}
+
+export interface ManagedWorktreeActionCandidate {
+  path: string;
+  branch: string;
+  baseIsAncestorOfHead: boolean;
+}
+
+export interface PlanManagedWorktreeInput {
+  targetBranch: string;
+  targetWorktreePath: string;
+  forceFresh?: boolean;
+  exactBranchCandidate?: ManagedWorktreeExactCandidate;
+  actionIdCandidate?: ManagedWorktreeActionCandidate;
+}
+
+export type ManagedWorktreePlan =
+  | {
+    kind: 'reuse_exact';
+    worktreePath: string;
+  }
+  | {
+    kind: 'rename_reuse';
+    worktreePath: string;
+    fromBranch: string;
+    toBranch: string;
+  }
+  | {
+    kind: 'recreate';
+    worktreePath: string;
+    cleanupPaths: string[];
+  };
+
+export function planManagedWorktree(input: PlanManagedWorktreeInput): ManagedWorktreePlan {
+  const cleanupPaths = new Set<string>([input.targetWorktreePath]);
+  const allowReuse = input.forceFresh !== true;
+
+  if (allowReuse && input.exactBranchCandidate?.headMatchesTargetBranch) {
+    return {
+      kind: 'reuse_exact',
+      worktreePath: input.exactBranchCandidate.path,
+    };
+  }
+
+  // If the target branch is already attached to another managed worktree but
+  // that worktree is not reusable, we must reconcile that owning path before
+  // creating/resetting the target branch again.
+  if (input.exactBranchCandidate && !input.exactBranchCandidate.headMatchesTargetBranch) {
+    cleanupPaths.add(input.exactBranchCandidate.path);
+  }
+
+  // Fallback: reuse worktree for same actionId but different hash (preserves
+  // conflict resolutions). Only reuse when the requested base is an ancestor
+  // of the existing worktree's HEAD — this means the worktree already contains
+  // the caller's base revision and only the experiment commits are extra. If
+  // the base has advanced beyond what the worktree contains, skip reuse and
+  // fall through to fresh creation from the new base.
+  if (allowReuse && input.actionIdCandidate?.baseIsAncestorOfHead) {
+    return {
+      kind: 'rename_reuse',
+      worktreePath: input.actionIdCandidate.path,
+      fromBranch: input.actionIdCandidate.branch,
+      toBranch: input.targetBranch,
+    };
+  }
+
+  return {
+    kind: 'recreate',
+    worktreePath: input.targetWorktreePath,
+    cleanupPaths: [...cleanupPaths],
+  };
+}

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -3,6 +3,7 @@ import { mkdirSync, existsSync, rmSync } from 'node:fs';
 import { normalize } from 'node:path';
 import { bashPreserveOrReset, runBashLocal } from './branch-utils.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
+import { planManagedWorktree } from './managed-worktree-controller.js';
 import {
   abbrevRefMatchesBranch,
   canonicalPathForComparison,
@@ -243,77 +244,101 @@ export class RepoPool {
       porcelain = '';
     }
 
-    let effectivePath = worktreePath;
-    let reusedExisting = false;
     const allowReuse = opts?.forceFresh !== true;
-
     const reuseCandidate = allowReuse ? findManagedWorktreeForBranch(porcelain, branch, managedPrefixes) : undefined;
+    let exactBranchCandidate: { path: string; headMatchesTargetBranch: boolean } | undefined;
     if (reuseCandidate && existsSync(reuseCandidate)) {
       try {
         const head = (await this.execGit(['rev-parse', '--abbrev-ref', 'HEAD'], reuseCandidate)).trim();
-        if (abbrevRefMatchesBranch(head, branch)) {
-          effectivePath = reuseCandidate;
-          reusedExisting = true;
-          traceExecution(
-            `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree reuse existing worktree path=${effectivePath} branch=${branch}`,
-          );
-        }
+        exactBranchCandidate = {
+          path: reuseCandidate,
+          headMatchesTargetBranch: abbrevRefMatchesBranch(head, branch),
+        };
       } catch {
-        /* fall through to create */
+        exactBranchCandidate = undefined;
       }
     }
 
-    // Fallback: reuse worktree for same actionId but different hash (preserves conflict resolutions).
-    // Only reuse when the new `base` is an ancestor of the existing worktree's HEAD — this means
-    // the worktree already contains the caller's base revision and only the experiment commits are
-    // "extra" (e.g. conflict resolution). If `base` has advanced beyond what the worktree contains
-    // (e.g. master moved forward and rebaseAndRetry/bumpGeneration wants a fresh branch from the
-    // new base), skip reuse and fall through to fresh creation.
-    if (allowReuse && !reusedExisting && actionId) {
+    let actionIdCandidate:
+      | { path: string; branch: string; baseIsAncestorOfHead: boolean }
+      | undefined;
+    if (allowReuse && actionId) {
       const actionIdHit = findManagedWorktreeByActionId(porcelain, actionId, managedPrefixes);
       if (actionIdHit && existsSync(actionIdHit.path)) {
         let baseIsAncestorOfHead = true;
         if (base) {
           try {
             await this.execGit(['merge-base', '--is-ancestor', base, 'HEAD'], actionIdHit.path);
-            // exit 0 → base is ancestor of HEAD → worktree is up-to-date with caller's base
           } catch {
             baseIsAncestorOfHead = false;
           }
         }
-        if (baseIsAncestorOfHead) {
-          try {
-            await this.execGit(['branch', '-m', actionIdHit.branch, branch], actionIdHit.path);
-            const head = (await this.execGit(['rev-parse', '--abbrev-ref', 'HEAD'], actionIdHit.path)).trim();
-            if (abbrevRefMatchesBranch(head, branch)) {
-              effectivePath = actionIdHit.path;
-              reusedExisting = true;
-              traceExecution(
-                `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree reuse by actionId: renamed ${actionIdHit.branch} → ${branch} path=${effectivePath}`,
-              );
-            }
-          } catch { /* fall through to create fresh */ }
-        } else {
-          traceExecution(
-            `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree skip actionId reuse: base=${base?.slice(0, 8) ?? 'unset'} is not ancestor of HEAD at ${actionIdHit.path} (base advanced → fresh branch)`,
-          );
-        }
+        actionIdCandidate = {
+          path: actionIdHit.path,
+          branch: actionIdHit.branch,
+          baseIsAncestorOfHead,
+        };
       }
     }
 
-    if (!reusedExisting) {
-      await this.reconcileStaleWorktreePath(clonePath, worktreePath);
-      mkdirSync(worktreeParent, { recursive: true });
-      const script = bashPreserveOrReset({
-        repoDir: clonePath,
-        worktreeDir: worktreePath,
-        branch,
-        base: base ?? 'HEAD',
-      });
-      await runBashLocal(script, clonePath);
-      effectivePath = worktreePath;
-    } else {
-      mkdirSync(worktreeParent, { recursive: true });
+    const plan = planManagedWorktree({
+      targetBranch: branch,
+      targetWorktreePath: worktreePath,
+      forceFresh: opts?.forceFresh,
+      exactBranchCandidate,
+      actionIdCandidate,
+    });
+
+    let effectivePath = worktreePath;
+    switch (plan.kind) {
+      case 'reuse_exact':
+        effectivePath = plan.worktreePath;
+        traceExecution(
+          `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree reuse existing worktree path=${effectivePath} branch=${branch}`,
+        );
+        mkdirSync(worktreeParent, { recursive: true });
+        break;
+      case 'rename_reuse':
+        try {
+          await this.execGit(['branch', '-m', plan.fromBranch, plan.toBranch], plan.worktreePath);
+          const head = (await this.execGit(['rev-parse', '--abbrev-ref', 'HEAD'], plan.worktreePath)).trim();
+          if (!abbrevRefMatchesBranch(head, plan.toBranch)) {
+            throw new Error(`renamed worktree HEAD mismatch: ${head}`);
+          }
+          effectivePath = plan.worktreePath;
+          traceExecution(
+            `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree reuse by actionId: renamed ${plan.fromBranch} → ${plan.toBranch} path=${effectivePath}`,
+          );
+          mkdirSync(worktreeParent, { recursive: true });
+        } catch {
+          await this.reconcileStaleWorktreePath(clonePath, worktreePath);
+          mkdirSync(worktreeParent, { recursive: true });
+          const script = bashPreserveOrReset({
+            repoDir: clonePath,
+            worktreeDir: worktreePath,
+            branch,
+            base: base ?? 'HEAD',
+          });
+          await runBashLocal(script, clonePath);
+          effectivePath = worktreePath;
+        }
+        break;
+      case 'recreate':
+        for (const cleanupPath of plan.cleanupPaths) {
+          await this.reconcileStaleWorktreePath(clonePath, cleanupPath);
+        }
+        mkdirSync(worktreeParent, { recursive: true });
+        {
+          const script = bashPreserveOrReset({
+            repoDir: clonePath,
+            worktreeDir: worktreePath,
+            branch,
+            base: base ?? 'HEAD',
+          });
+          await runBashLocal(script, clonePath);
+        }
+        effectivePath = worktreePath;
+        break;
     }
 
     effectivePath = canonicalPathForComparison(effectivePath);

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -6,7 +6,8 @@ import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import { killProcessGroup, cleanElectronEnv, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 import { computeBranchHash } from './branch-utils.js';
-import { findManagedWorktreeForBranch, abbrevRefMatchesBranch } from './worktree-discovery.js';
+import { planManagedWorktree } from './managed-worktree-controller.js';
+import { findManagedWorktreeForBranch, findManagedWorktreeByActionId, abbrevRefMatchesBranch } from './worktree-discovery.js';
 import { DEFAULT_WORKTREE_PROVISION_COMMAND } from './default-worktree-provision-command.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { computeRepoUrlHash, sanitizeBranchForPath } from './git-utils.js';
@@ -19,6 +20,7 @@ import {
   buildWorktreeListScript,
   buildWorktreeHeadScript,
   buildWorktreeCleanupScript,
+  buildWorktreeRenameBranchScript,
   buildRecordAndPushScript,
   parseRecordAndPushOutput,
   createSshRemoteScriptError,
@@ -352,39 +354,102 @@ echo ${payloadB64} | base64 -d | bash -se
       : invokerHome;
     const managedPrefix = normalize(`${expandedInvokerHome}/worktrees/${h}`);
     const reuseAbs = findManagedWorktreeForBranch(porcelain, experimentBranch, [managedPrefix]);
-
-    let remoteWt = canonicalRemoteWt;
-    let skippedRemotePreserve = false;
-
+    let exactBranchCandidate:
+      | { path: string; headMatchesTargetBranch: boolean }
+      | undefined;
     if (reuseAbs) {
       const headScript = buildWorktreeHeadScript(reuseAbs);
       try {
         const head = (await this.execRemoteCapture(headScript)).trim();
-        if (abbrevRefMatchesBranch(head, experimentBranch)) {
-          skippedRemotePreserve = true;
-          remoteWt = reuseAbs;
-          // Update handle.workspacePath to reused path (may differ from canonical if tilde-expanded)
-          handle.workspacePath =
-            reuseAbs.startsWith(`${remoteHome}/`) ? `~${reuseAbs.slice(remoteHome.length)}` : reuseAbs;
-        }
+        exactBranchCandidate = {
+          path: reuseAbs,
+          headMatchesTargetBranch: abbrevRefMatchesBranch(head, experimentBranch),
+        };
       } catch {
-        /* fall through to fresh setup */
+        exactBranchCandidate = undefined;
       }
     }
 
-    if (!skippedRemotePreserve) {
-      const cleanupScript = buildWorktreeCleanupScript({
-        remoteClone,
-        canonicalRemoteWt,
-      });
-      await this.execRemoteCapture(cleanupScript, 'cleanup_worktree');
-      remoteWt = canonicalRemoteWt;
-      // handle.workspacePath already set to canonical path above; no update needed
+    let actionIdCandidate:
+      | { path: string; branch: string; baseIsAncestorOfHead: boolean }
+      | undefined;
+    const actionIdHit = findManagedWorktreeByActionId(porcelain, request.actionId, [managedPrefix]);
+    if (actionIdHit && actionIdHit.path !== reuseAbs) {
+      let baseIsAncestorOfHead = true;
+      try {
+        await this.execRemoteCapture(
+          `set -euo pipefail
+WT=${sshGitShellQuote(actionIdHit.path)}
+BASE=${sshGitShellQuote(resolvedBaseRef)}
+git -C "$WT" merge-base --is-ancestor "$BASE" HEAD
+`,
+          'check_action_reuse_base',
+        );
+      } catch {
+        baseIsAncestorOfHead = false;
+      }
+      actionIdCandidate = {
+        path: actionIdHit.path,
+        branch: actionIdHit.branch,
+        baseIsAncestorOfHead,
+      };
+    }
+
+    const worktreePlan = planManagedWorktree({
+      targetBranch: experimentBranch,
+      targetWorktreePath: canonicalRemoteWt,
+      forceFresh: request.inputs.freshWorkspace === true,
+      exactBranchCandidate,
+      actionIdCandidate,
+    });
+
+    let remoteWt = canonicalRemoteWt;
+    let skippedRemotePreserve = false;
+
+    switch (worktreePlan.kind) {
+      case 'reuse_exact':
+        skippedRemotePreserve = true;
+        remoteWt = worktreePlan.worktreePath;
+        handle.workspacePath =
+          remoteWt.startsWith(`${remoteHome}/`) ? `~${remoteWt.slice(remoteHome.length)}` : remoteWt;
+        break;
+      case 'rename_reuse': {
+        const renameScript = buildWorktreeRenameBranchScript({
+          worktreePath: worktreePlan.worktreePath,
+          fromBranch: worktreePlan.fromBranch,
+          toBranch: worktreePlan.toBranch,
+        });
+        try {
+          const head = (await this.execRemoteCapture(renameScript, 'rename_reuse_branch')).trim();
+          if (abbrevRefMatchesBranch(head, worktreePlan.toBranch)) {
+            skippedRemotePreserve = true;
+            remoteWt = worktreePlan.worktreePath;
+            handle.workspacePath =
+              remoteWt.startsWith(`${remoteHome}/`) ? `~${remoteWt.slice(remoteHome.length)}` : remoteWt;
+          }
+        } catch {
+          const cleanupScript = buildWorktreeCleanupScript({
+            remoteClone,
+            worktreePaths: [canonicalRemoteWt],
+          });
+          await this.execRemoteCapture(cleanupScript, 'cleanup_worktree');
+          remoteWt = canonicalRemoteWt;
+        }
+        break;
+      }
+      case 'recreate': {
+        const cleanupScript = buildWorktreeCleanupScript({
+          remoteClone,
+          worktreePaths: worktreePlan.cleanupPaths,
+        });
+        await this.execRemoteCapture(cleanupScript, 'cleanup_worktree');
+        remoteWt = canonicalRemoteWt;
+        break;
+      }
     }
 
     if (skippedRemotePreserve) {
       await this.mergeRequestUpstreamBranches(request, remoteWt, resolvedBaseRef);
-      // handle.branch already set above; no update needed
     } else {
       try {
         await this.setupTaskBranch(remoteClone, request, handle, {

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -235,26 +235,50 @@ git -C ${wtQ} rev-parse --abbrev-ref HEAD
 
 export interface GitWorktreeCleanupOpts {
   remoteClone: string;
-  canonicalRemoteWt: string;
+  worktreePaths: string[];
 }
 
 /**
- * Generate script to prune stale worktrees and remove a specific worktree path.
+ * Generate script to prune stale worktrees and remove specific worktree paths.
  */
 export function buildWorktreeCleanupScript(opts: GitWorktreeCleanupOpts): string {
+  const worktreesB64 = base64Encode(`${opts.worktreePaths.join('\n')}\n`);
   return `set -euo pipefail
 CLONE="${opts.remoteClone}"
-WT="${opts.canonicalRemoteWt}"
 ${bashNormalizeTildePath('CLONE')}
-${bashNormalizeTildePath('WT')}
-mkdir -p "$(dirname "$WT")"
+WORKTREES_B64="${worktreesB64}"
 git -C "$CLONE" worktree prune 2>/dev/null || true
-if [ -e "$WT" ]; then
-  echo "[SshGitExec] Removing stale worktree path: $WT"
-  git -C "$CLONE" worktree remove --force "$WT" 2>/dev/null || true
-  rm -rf "$WT"
-  git -C "$CLONE" worktree prune 2>/dev/null || true
-fi
+while IFS= read -r WT; do
+  [ -z "$WT" ] && continue
+  ${bashNormalizeTildePath('WT')}
+  mkdir -p "$(dirname "$WT")"
+  if [ -e "$WT" ]; then
+    echo "[SshGitExec] Removing stale worktree path: $WT"
+    git -C "$CLONE" worktree remove --force "$WT" 2>/dev/null || true
+    rm -rf "$WT"
+    git -C "$CLONE" worktree prune 2>/dev/null || true
+  fi
+done < <(echo "$WORKTREES_B64" | base64 -d)
+`;
+}
+
+export interface GitWorktreeRenameBranchOpts {
+  worktreePath: string;
+  fromBranch: string;
+  toBranch: string;
+}
+
+export function buildWorktreeRenameBranchScript(opts: GitWorktreeRenameBranchOpts): string {
+  const wtB64 = base64Encode(opts.worktreePath);
+  const fromB64 = base64Encode(opts.fromBranch);
+  const toB64 = base64Encode(opts.toBranch);
+  return `set -euo pipefail
+WT=$(echo ${wtB64} | base64 -d)
+FROM=$(echo ${fromB64} | base64 -d)
+TO=$(echo ${toB64} | base64 -d)
+${bashNormalizeTildePath('WT')}
+git -C "$WT" branch -m "$FROM" "$TO"
+git -C "$WT" rev-parse --abbrev-ref HEAD
 `;
 }
 

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -78,6 +78,8 @@ function getExecutorStartTimeoutMs(): number {
 
 export interface TaskRunnerCallbacks {
   onOutput?: (taskId: string, data: string) => void;
+  onLaunchStart?: (taskId: string, executor: Executor) => void;
+  onLaunchFailed?: (taskId: string, error: Error, executor: Executor) => void;
   onSpawned?: (taskId: string, handle: ExecutorHandle, executor: Executor) => void;
   onComplete?: (taskId: string, response: WorkResponse) => void;
   onHeartbeat?: (taskId: string) => void;
@@ -449,6 +451,7 @@ export class TaskRunner {
       `${RESTART_TO_BRANCH_TRACE} executeTaskInner taskId=${task.id} selectExecutor → type=${executor.type} calling executor.start()`,
     );
     traceExecution(`[trace] TaskRunner: task=${task.id} calling executor.start() type=${executor.type}`);
+    this.callbacks.onLaunchStart?.(task.id, executor);
     const startT0 = Date.now();
     const startTimeoutMs = getExecutorStartTimeoutMs();
     const preStartHeartbeatTimer = setInterval(() => {
@@ -493,10 +496,12 @@ export class TaskRunner {
           execution: execution as any,
         });
       }
-      throw new Error(
-        startupErrorMessage.trimEnd(),
+      const wrapped = new Error(
+        `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}`,
         { cause: err },
       );
+      this.callbacks.onLaunchFailed?.(task.id, wrapped, executor);
+      throw wrapped;
     } finally {
       clearInterval(preStartHeartbeatTimer);
       if (preStartTimeout) clearTimeout(preStartTimeout);


### PR DESCRIPTION
## Summary
SSH startup was being force-failed as a launch stall even when `executor.start()` was still legitimately doing remote bootstrap/setup work before returning a handle.

## Exact Failure / Symptom
`Launch stalled: task remained in running/launching for 60s without a spawned execution handle`

## Exact Test Setup
- SSH executor regression: `packages/execution-engine/src/__tests__/ssh-executor.test.ts`
  - `does not return a handle until managed remote bootstrap/setup has finished`
- Task-runner regressions: `packages/execution-engine/src/__tests__/task-runner.test.ts`
  - `reports launch-in-progress callbacks while executor.start is still pending`
  - `fails a task when executor.start never resolves and keeps it in launching`

The tests model the exact slow-startup scenario: managed SSH bootstrap is still in progress, no execution handle exists yet, and the owner must distinguish live startup from a true orphaned launch.

## Root Cause
The app watchdog treated “no execution handle yet” as equivalent to “startup is orphaned”. For managed SSH startup that was wrong because clone/fetch/worktree/setup all happen before the handle is returned.

## Why This Fix Is Right
The fix adds explicit launch-in-progress state instead of just increasing the timeout. A larger timeout would still conflate slow valid startup with dead startup.

## Validation
- The exact regressions above prove handle creation is delayed until bootstrap completes while keeping the real timeout path covered.

## Traceability
- Commit: `576a9ed`
- Commit message: `Avoid false launch stalls during SSH startup`

