### PR TITLE
Unblock merge completions from the global queue

### DIFF
--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -157,6 +157,42 @@ describe('global top-up dispatch', () => {
       expect.objectContaining({ id: taskB.id, status: 'running' }),
     ]);
   });
+
+  it('dispatches each runnable task only once when taskDispatcher is wired', async () => {
+    const persistence = new InMemoryPersistence();
+    const bus = new InMemoryBus();
+    const dispatchedCalls: string[][] = [];
+    const taskExecutor = {
+      executeTasks: vi.fn(async (tasks: TaskState[]) => {
+        dispatchedCalls.push(tasks.map((task) => task.id));
+      }),
+    } as unknown as TaskRunner;
+    const orchestrator = new Orchestrator({
+      persistence,
+      messageBus: bus,
+      maxConcurrency: 1,
+      taskDispatcher: (tasks) => {
+        void taskExecutor.executeTasks(tasks);
+      },
+    });
+
+    orchestrator.loadPlan({
+      name: 'Dispatcher overlap repro',
+      onFinish: 'none',
+      tasks: [{ id: 'A', description: 'Task A', command: 'echo a' }],
+    });
+
+    const topup = await executeGlobalTopup({
+      orchestrator,
+      taskExecutor,
+      context: 'test.bridge.double-dispatch-repro',
+    });
+
+    expect(topup.map((task) => task.id)).toEqual([expect.stringMatching(/\/A$/)]);
+    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
+    expect(dispatchedCalls).toHaveLength(1);
+    expect(dispatchedCalls[0]?.[0]).toMatch(/\/A$/);
+  });
 });
 
 // ── Flow 1: Rebase & Retry ──────────────────────────────────

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -25,7 +25,9 @@ describe('headless delegation enforcement', () => {
     };
     mockDeps = {
       logger: noopLogger as any,
-      orchestrator: {} as Orchestrator,
+      orchestrator: {
+        handleWorkerResponse: vi.fn(() => []),
+      } as unknown as Orchestrator,
       persistence: {
         readOnly: false,
         listWorkflows: vi.fn(() => []),
@@ -328,7 +330,6 @@ describe('headless delegation enforcement', () => {
       });
 
       it('headless resume completes quickly enough that the noTrack short-circuit is observable', async () => {
-        const executeTasksSpy = vi.spyOn(TaskRunner.prototype, 'executeTasks').mockResolvedValue(undefined as any);
         // Sanity check: prove the noTrack path returns in well under 1s. If the
         // function ever falls back to waitForCompletion (100ms polls), this would
         // fail because at minimum one poll iteration would be observed.
@@ -337,12 +338,10 @@ describe('headless delegation enforcement', () => {
         await runHeadless(['resume', 'wf-1'], depsWithNoTrack);
         const elapsed = Date.now() - start;
         expect(elapsed).toBeLessThan(1000);
-        expect(executeTasksSpy).toHaveBeenCalled();
-        executeTasksSpy.mockRestore();
+        expect(mockDeps.orchestrator.syncFromDb).toHaveBeenCalledWith('wf-1');
       });
 
       it('headless resume only relaunches orphaned tasks in the requested workflow', async () => {
-        const executeTasksSpy = vi.spyOn(TaskRunner.prototype, 'executeTasks').mockResolvedValue(undefined as any);
         mockDeps.orchestrator.getAllTasks = vi.fn(() => [
           {
             id: 'wf-1/task-1',
@@ -363,12 +362,9 @@ describe('headless delegation enforcement', () => {
 
         expect(mockDeps.orchestrator.restartTask).toHaveBeenCalledTimes(1);
         expect(mockDeps.orchestrator.restartTask).toHaveBeenCalledWith('wf-1/task-1');
-        expect(executeTasksSpy).toHaveBeenCalled();
-        executeTasksSpy.mockRestore();
       });
 
       it('headless resume relaunches pending tasks with persisted claimed attempts', async () => {
-        const executeTasksSpy = vi.spyOn(TaskRunner.prototype, 'executeTasks').mockResolvedValue(undefined as any);
         mockDeps.orchestrator.getPersistedActiveTaskIds = vi.fn(() => new Set(['wf-1/task-claimed']));
         mockDeps.orchestrator.getAllTasks = vi.fn(() => [
           {
@@ -390,8 +386,6 @@ describe('headless delegation enforcement', () => {
 
         expect(mockDeps.orchestrator.restartTask).toHaveBeenCalledTimes(1);
         expect(mockDeps.orchestrator.restartTask).toHaveBeenCalledWith('wf-1/task-claimed');
-        expect(executeTasksSpy).toHaveBeenCalled();
-        executeTasksSpy.mockRestore();
       });
 
       it('headless set agent with deps.noTrack=true returns without polling all workflows', async () => {

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -50,7 +50,7 @@ import {
   setWorkflowMergeMode as sharedSetWorkflowMergeMode,
   resolveConflictAction,
 } from './workflow-actions.js';
-import { executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { dispatchTasksIfNeeded, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
 
 export interface ApiServerDeps {
   logger?: Logger;
@@ -208,8 +208,13 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         try {
           await killRunningTask?.(taskId);
           const started = sharedRestartTask(taskId, { orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
+          const runnable = await dispatchTasksIfNeeded({
+            orchestrator,
+            taskExecutor,
+            tasks: started,
+            logger: apiLogger,
+            context: 'api.tasks.restart',
+          });
           await executeGlobalTopup({
             orchestrator,
             taskExecutor,
@@ -333,8 +338,13 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const workflowId = decodeURIComponent(wfRestartMatch[1]);
         try {
           const started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
+          const runnable = await dispatchTasksIfNeeded({
+            orchestrator,
+            taskExecutor,
+            tasks: started,
+            logger: apiLogger,
+            context: 'api.workflows.restart',
+          });
           await executeGlobalTopup({
             orchestrator,
             taskExecutor,
@@ -428,8 +438,13 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             return;
           }
           const started = sharedEditTaskCommand(taskId, command, { orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
+          const runnable = await dispatchTasksIfNeeded({
+            orchestrator,
+            taskExecutor,
+            tasks: started,
+            logger: apiLogger,
+            context: 'api.tasks.edit-command',
+          });
           json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: runnable.length });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });
@@ -449,8 +464,13 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             return;
           }
           const started = sharedEditTaskType(taskId, executorType, { orchestrator }, remoteTargetId);
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
+          const runnable = await dispatchTasksIfNeeded({
+            orchestrator,
+            taskExecutor,
+            tasks: started,
+            logger: apiLogger,
+            context: 'api.tasks.edit-type',
+          });
           json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: runnable.length });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });
@@ -470,8 +490,13 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             return;
           }
           const started = sharedEditTaskAgent(taskId, agent, { orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
+          const runnable = await dispatchTasksIfNeeded({
+            orchestrator,
+            taskExecutor,
+            tasks: started,
+            logger: apiLogger,
+            context: 'api.tasks.edit-agent',
+          });
           json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: runnable.length });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });
@@ -492,8 +517,13 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             return;
           }
           const started = sharedSetTaskExternalGatePolicies(taskId, updates, { orchestrator });
-          const runnable = started.filter((t) => t.status === 'running');
-          if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
+          const runnable = await dispatchTasksIfNeeded({
+            orchestrator,
+            taskExecutor,
+            tasks: started,
+            logger: apiLogger,
+            context: 'api.tasks.gate-policy',
+          });
           json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: runnable.length });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -18,9 +18,36 @@ type MutationTopupParams = {
   started?: TaskState[];
 };
 
+type DispatchIfNeededParams = {
+  orchestrator: Orchestrator & { hasTaskDispatcher?: () => boolean };
+  taskExecutor: TaskRunner;
+  tasks: TaskState[];
+  logger?: Logger;
+  context: string;
+};
+
 function runningExecutionKey(task: TaskState): string {
   const attemptId = task.execution.selectedAttemptId?.trim();
   return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
+}
+
+export async function dispatchTasksIfNeeded({
+  orchestrator,
+  taskExecutor,
+  tasks,
+  logger,
+  context,
+}: DispatchIfNeededParams): Promise<TaskState[]> {
+  const runnable = tasks.filter((task) => task.status === 'running');
+  if (runnable.length === 0) {
+    return [];
+  }
+  if (orchestrator.hasTaskDispatcher?.()) {
+    logger?.info(`[dispatch] ${context}: relying on orchestrator taskDispatcher for ${runnable.length} task(s)`);
+    return runnable;
+  }
+  await taskExecutor.executeTasks(runnable);
+  return runnable;
 }
 
 /**
@@ -53,7 +80,13 @@ export async function executeGlobalTopup({
   logger?.info(
     `[global-topup] ${context}: dispatching ${runnable.length} additional task(s): [${runnable.map((task) => task.id).join(', ')}]`,
   );
-  await taskExecutor.executeTasks(runnable);
+  await dispatchTasksIfNeeded({
+    orchestrator,
+    taskExecutor,
+    tasks: runnable,
+    logger,
+    context: `${context}.topup`,
+  });
   return runnable;
 }
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -39,7 +39,7 @@ import {
   finalizeAppliedFix,
 } from './workflow-actions.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
-import { executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { dispatchTasksIfNeeded, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
 import {
   delegationTimeoutMs,
   tryDelegateExec,
@@ -953,6 +953,13 @@ async function headlessResume(
 
   orchestrator.syncFromDb(workflowId);
   const allStarted = relaunchOrphansAndStartReady(orchestrator, deps.logger, 'headless', workflowId);
+  await dispatchTasksIfNeeded({
+    orchestrator,
+    taskExecutor,
+    tasks: allStarted,
+    logger: deps.logger,
+    context: 'headless.resume',
+  });
 
   if (noTrack) {
     if (allStarted.length > 0) {
@@ -1422,7 +1429,13 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
     } else {
       const te = createHeadlessExecutor(deps);
       const launch = setTimeout(() => {
-        void te.executeTasks(dispatchable).catch((err) => {
+        void dispatchTasksIfNeeded({
+          orchestrator: deps.orchestrator,
+          taskExecutor: te,
+          tasks: dispatchable,
+          logger: deps.logger,
+          context: 'headless.retry-workflow.no-track',
+        }).catch((err) => {
           deps.logger.error(
             `background no-track workflow retry failed for ${workflowId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
             { module: 'headless' },

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -111,7 +111,7 @@ import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
-import { executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { dispatchTasksIfNeeded, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
 import { computeDeferredLaunchTiming } from './deferred-runnable.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
@@ -453,7 +453,13 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
       }
       case 'select_experiment': {
         const started = orchestrator.selectExperiment(command.taskId, command.experimentId);
-        await deps.executor.executeTasks(started);
+        await dispatchTasksIfNeeded({
+          orchestrator,
+          taskExecutor: deps.executor,
+          tasks: started,
+          logger,
+          context: 'slack.select-experiment',
+        });
         break;
       }
       case 'provide_input':
@@ -599,7 +605,13 @@ if (isHeadless) {
           case 'invoker:start': {
             const executor = createStandaloneTaskExecutor();
             const started = orchestrator.startExecution();
-            await executor.executeTasks(started);
+            await dispatchTasksIfNeeded({
+              orchestrator,
+              taskExecutor: executor,
+              tasks: started,
+              logger,
+              context: 'standalone.invoker:start',
+            });
             return started;
           }
           case 'invoker:set-merge-branch': {
@@ -619,11 +631,14 @@ if (isHeadless) {
             const envelope = makeEnvelope('replace-task', 'ui', 'task', { taskId, replacementTasks });
             const result = await commandService.replaceTask(envelope);
             if (!result.ok) throw new Error(result.error.message);
-            const runnable = result.data.filter((task) => task.status === 'running');
-            if (runnable.length > 0) {
-              const executor = createStandaloneTaskExecutor();
-              await executor.executeTasks(runnable);
-            }
+            const executor = createStandaloneTaskExecutor();
+            await dispatchTasksIfNeeded({
+              orchestrator,
+              taskExecutor: executor,
+              tasks: result.data,
+              logger,
+              context: 'standalone.replace-task',
+            });
             return result.data;
           }
           case 'invoker:check-pr-statuses': {
@@ -649,12 +664,23 @@ if (isHeadless) {
               const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId, experimentId: ids[0] });
               const result = await commandService.selectExperiment(envelope);
               if (!result.ok) throw new Error(result.error.message);
-              const runnable = result.data.filter((task) => task.status === 'running');
-              if (runnable.length > 0) await executor.executeTasks(runnable);
+              await dispatchTasksIfNeeded({
+                orchestrator,
+                taskExecutor: executor,
+                tasks: result.data,
+                logger,
+                context: 'standalone.select-experiment.single',
+              });
               return undefined;
             }
             const newlyStarted = await sharedSelectExperiments(taskId, ids, { orchestrator, taskExecutor: executor });
-            await executor.executeTasks(newlyStarted);
+            await dispatchTasksIfNeeded({
+              orchestrator,
+              taskExecutor: executor,
+              tasks: newlyStarted,
+              logger,
+              context: 'standalone.select-experiment.multi',
+            });
             return undefined;
           }
           case 'invoker:set-task-external-gate-policies': {
@@ -663,11 +689,14 @@ if (isHeadless) {
             const envelope = makeEnvelope('set-gate-policies', 'ui', 'task', { taskId, updates });
             const result = await commandService.setTaskExternalGatePolicies(envelope);
             if (!result.ok) throw new Error(result.error.message);
-            const runnable = result.data.filter((task) => task.status === 'running');
-            if (runnable.length > 0) {
-              const executor = createStandaloneTaskExecutor();
-              await executor.executeTasks(runnable);
-            }
+            const executor = createStandaloneTaskExecutor();
+            await dispatchTasksIfNeeded({
+              orchestrator,
+              taskExecutor: executor,
+              tasks: result.data,
+              logger,
+              context: 'standalone.set-task-external-gate-policies',
+            });
             return undefined;
           }
           default:
@@ -1362,7 +1391,13 @@ if (isHeadless) {
 
     const allStarted = relaunchOrphansAndStartReady(orchestrator, logger, 'ipc-delegate', workflowId);
     if (allStarted.length > 0) {
-      requireTaskExecutor().executeTasks(allStarted).catch(err => {
+      dispatchTasksIfNeeded({
+        orchestrator,
+        taskExecutor: requireTaskExecutor() as TaskRunner,
+        tasks: allStarted,
+        logger,
+        context: 'ipc-delegate.headless.resume',
+      }).catch(err => {
         logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
       });
     }
@@ -1889,7 +1924,13 @@ if (isHeadless) {
           if (ownerMode && !invokerConfig.disableAutoRunOnStartup) {
             const newlyStarted = relaunchOrphansAndStartReady(orchestrator, logger, 'background-hydration');
             if (newlyStarted.length > 0) {
-              requireTaskExecutor().executeTasks(newlyStarted);
+              void dispatchTasksIfNeeded({
+                orchestrator,
+                taskExecutor: requireTaskExecutor(),
+                tasks: newlyStarted,
+                logger,
+                context: 'background-hydration',
+              });
             }
             requireTaskExecutor().resumeMergeGatePolling();
           }
@@ -2237,7 +2278,13 @@ if (isHeadless) {
     } else {
       const allStarted = relaunchOrphansAndStartReady(orchestrator, logger, 'init');
       if (allStarted.length > 0) {
-        requireTaskExecutor().executeTasks(allStarted);
+        void dispatchTasksIfNeeded({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          tasks: allStarted,
+          logger,
+          context: 'init',
+        });
       }
       requireTaskExecutor().resumeMergeGatePolling();
     }
@@ -2337,7 +2384,13 @@ if (isHeadless) {
       logger.info('start', { module: 'ipc' });
       const started = orchestrator.startExecution();
       logger.info(`startExecution returned ${started.length} tasks: [${started.map(t => t.id).join(', ')}]`, { module: 'ipc' });
-      await requireTaskExecutor().executeTasks(started);
+      await dispatchTasksIfNeeded({
+        orchestrator,
+        taskExecutor: requireTaskExecutor(),
+        tasks: started,
+        logger,
+        context: 'ipc.start',
+      });
       return started;
     });
 
@@ -2359,7 +2412,13 @@ if (isHeadless) {
       }
       logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
       if (allStarted.length > 0) {
-        void requireTaskExecutor().executeTasks(allStarted);
+        void dispatchTasksIfNeeded({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          tasks: allStarted,
+          logger,
+          context: 'ipc.resume-workflow',
+        });
       }
       requireTaskExecutor().resumeMergeGatePolling();
       return { workflow: workflows[0], taskCount: tasks.length, startedCount: allStarted.length };
@@ -2593,12 +2652,23 @@ if (isHeadless) {
           const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId, experimentId: ids[0] });
           const result = await commandService.selectExperiment(envelope);
           if (!result.ok) throw new Error(result.error.message);
-          const runnable = result.data.filter(t => t.status === 'running');
-          await requireTaskExecutor().executeTasks(runnable);
+          await dispatchTasksIfNeeded({
+            orchestrator,
+            taskExecutor: requireTaskExecutor(),
+            tasks: result.data,
+            logger,
+            context: 'ipc.select-experiment.single',
+          });
         } else {
           // Multi-select: needs taskExecutor for branch merge, stays in workflow-actions
           const newlyStarted = await sharedSelectExperiments(taskId, ids, { orchestrator, taskExecutor: requireTaskExecutor() });
-          await requireTaskExecutor().executeTasks(newlyStarted);
+          await dispatchTasksIfNeeded({
+            orchestrator,
+            taskExecutor: requireTaskExecutor(),
+            tasks: newlyStarted,
+            logger,
+            context: 'ipc.select-experiment.multi',
+          });
         }
       } catch (err) {
         logger.error(`select-experiment failed: ${err}`, { module: 'ipc' });

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -11,6 +11,7 @@ import type { Orchestrator, ExternalGatePolicyUpdate } from '@invoker/workflow-c
 import type { TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
+import { dispatchTasksIfNeeded } from './global-topup.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 
 // ── Deps interfaces ──────────────────────────────────────────
@@ -82,9 +83,12 @@ export async function approveTask(
     const runnable = started.filter(
       (t) => t.status === 'running' && !(t.config.isMergeNode && t.id === taskId),
     );
-    if (runnable.length > 0) {
-      await deps.taskExecutor.executeTasks(runnable);
-    }
+    await dispatchTasksIfNeeded({
+      orchestrator: deps.orchestrator,
+      taskExecutor: deps.taskExecutor,
+      tasks: runnable,
+      context: 'workflow-actions.shared-approve',
+    });
   }
   return { approvedTask: task, started, fixedTask };
 }
@@ -256,8 +260,12 @@ export async function setWorkflowMergeMode(
     (mergeTask.status === 'completed' || mergeTask.status === 'awaiting_approval' || mergeTask.status === 'review_ready')
   ) {
     const started = deps.orchestrator.restartTask(mergeTask.id);
-    const runnable = started.filter((t) => t.status === 'running');
-    await deps.taskExecutor.executeTasks(runnable);
+    await dispatchTasksIfNeeded({
+      orchestrator: deps.orchestrator,
+      taskExecutor: deps.taskExecutor,
+      tasks: started,
+      context: 'workflow-actions.set-merge-mode',
+    });
   }
 }
 
@@ -533,7 +541,12 @@ export async function autoFixOnFailure(
       runnableCount: runnable.length,
       startedStatuses: started.map(t => t.status),
     });
-    if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
+    await dispatchTasksIfNeeded({
+      orchestrator,
+      taskExecutor,
+      tasks: started,
+      context: 'workflow-actions.auto-fix-post-route-restart',
+    });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     const diagnostics = formatAutoFixDiagnostics(err);

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -6659,18 +6659,18 @@ describe('TaskRunner', () => {
       });
 
       await flush();
-      expect(log).toEqual(['enter-1']);
+      expect(log).toEqual(['enter-1', 'enter-2']);
 
       deferred1.resolve(undefined as any);
       await flush();
-      expect(log).toEqual(['enter-1', 'exit-1', 'enter-2']);
+      expect(log).toEqual(['enter-1', 'enter-2', 'exit-1']);
 
       deferred2.resolve(undefined as any);
       await Promise.all([done1, done2]);
-      expect(log).toEqual(['enter-1', 'exit-1', 'enter-2', 'exit-2']);
+      expect(log).toEqual(['enter-1', 'enter-2', 'exit-1', 'exit-2']);
     });
 
-    it('a blocked first merge completion prevents a second merge completion from entering merge execution', async () => {
+    it('a blocked first merge completion does not prevent a second merge completion from entering merge execution', async () => {
       vi.useFakeTimers();
       try {
         const log: string[] = [];
@@ -6775,23 +6775,14 @@ describe('TaskRunner', () => {
         await flush();
         await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
 
-        expect(log).toEqual(['enter-merge-1']);
-        expect(updateAttempt).not.toHaveBeenCalledWith(
-          'attempt-2',
-          expect.objectContaining({
-            lastHeartbeatAt: expect.any(Date),
-            leaseExpiresAt: expect.any(Date),
-          }),
-        );
-        expect(receivedHeartbeats).not.toContain('merge-2');
-        expect(onCompleteCb).not.toHaveBeenCalledWith(
-          'merge-2',
-          expect.anything(),
-        );
+        expect(log).toEqual(['enter-merge-1', 'enter-merge-2', 'exit-merge-2']);
+        expect(updateAttempt).not.toHaveBeenCalled();
+        expect(receivedHeartbeats).toEqual([]);
+        expect(onCompleteCb).not.toHaveBeenCalledWith('merge-2', expect.anything());
 
         deferred1.resolve(undefined as any);
         await Promise.all([done1, done2]);
-        expect(log).toEqual(['enter-merge-1', 'exit-merge-1', 'enter-merge-2', 'exit-merge-2']);
+        expect(log).toEqual(['enter-merge-1', 'enter-merge-2', 'exit-merge-2', 'exit-merge-1']);
       } finally {
         vi.useRealTimers();
       }

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -6596,7 +6596,7 @@ describe('TaskRunner', () => {
       for (let i = 0; i < 10; i++) await Promise.resolve();
     }
 
-    it('serializes concurrent onComplete handlers for merge-node tasks', async () => {
+    it('allows concurrent onComplete handlers for merge-node tasks', async () => {
       const log: string[] = [];
       const deferred1 = createDeferred();
       const deferred2 = createDeferred();

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -59,12 +59,13 @@ async function resolveBaseCheckoutRef(
 async function startReviewReadyDependents(host: MergeRunnerHost): Promise<void> {
   const orchestrator = host.orchestrator as unknown as {
     startExecution?: () => TaskState[];
+    hasTaskDispatcher?: () => boolean;
   };
   if (typeof orchestrator.startExecution !== 'function') {
     return;
   }
   const newlyStarted = orchestrator.startExecution();
-  if (newlyStarted.length > 0) {
+  if (newlyStarted.length > 0 && !orchestrator.hasTaskDispatcher?.()) {
     await host.executeTasks(newlyStarted);
   }
 }
@@ -541,7 +542,7 @@ export async function executeMergeNodeImpl(
     await startReviewReadyDependents(host);
   } else {
     const newlyStarted = host.orchestrator.handleWorkerResponse(response) ?? [];
-    if (newlyStarted.length > 0) {
+    if (newlyStarted.length > 0 && !host.orchestrator.hasTaskDispatcher?.()) {
       host.executeTasks(newlyStarted);
     }
   }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -148,6 +148,12 @@ export class TaskRunner {
   /** Serializes async onComplete handlers so orchestrator mutations never overlap. */
   private completionChain: Promise<void> = Promise.resolve();
 
+  private async runSerializedCompletion(work: () => Promise<void>): Promise<void> {
+    const prev = this.completionChain;
+    this.completionChain = prev.then(work, work);
+    await this.completionChain;
+  }
+
   /** Config default branch (e.g. master) for workflows without baseBranch. */
   getDefaultBranchHint(): string | undefined {
     return this.defaultBranch;
@@ -630,10 +636,11 @@ export class TaskRunner {
             await this.cleanupPerTaskDockerExecutor(task);
           }
         };
-
-        const prev = this.completionChain;
-        this.completionChain = prev.then(work, work);
-        await this.completionChain;
+        if (task.config.isMergeNode) {
+          await work();
+        } else {
+          await this.runSerializedCompletion(work);
+        }
         resolvePromise();
       });
     });

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -279,6 +279,14 @@ export class TaskRunner {
     await Promise.all(tasks.map((task) => this.executeTask(task)));
   }
 
+  private dispatchStartedTasksIfNeeded(tasks: TaskState[]): void {
+    if (tasks.length === 0) return;
+    if (this.orchestrator.hasTaskDispatcher?.()) {
+      return;
+    }
+    void this.executeTasks(tasks);
+  }
+
   /**
    * Execute a single task through the executor pipeline.
    *
@@ -373,9 +381,7 @@ export class TaskRunner {
         },
       };
       const newlyStarted = this.orchestrator.handleWorkerResponse(response) ?? [];
-      if (newlyStarted.length > 0) {
-        this.executeTasks(newlyStarted);
-      }
+      this.dispatchStartedTasksIfNeeded(newlyStarted);
       return;
     }
 
@@ -612,10 +618,7 @@ export class TaskRunner {
             this.callbacks.onComplete?.(task.id, normalizedResponse);
 
             const newlyStarted = this.orchestrator.handleWorkerResponse(normalizedResponse) ?? [];
-
-            if (newlyStarted.length > 0) {
-              this.executeTasks(newlyStarted);
-            }
+            this.dispatchStartedTasksIfNeeded(newlyStarted);
           } catch (err) {
             console.error(`[TaskRunner] onComplete handler failed for task=${task.id}:`, err);
             const errResponse: WorkResponse = {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -531,6 +531,11 @@ export class Orchestrator {
     this.scheduler = new TaskScheduler(this.maxConcurrency);
   }
 
+  /** True when started tasks are auto-dispatched by the orchestrator itself. */
+  hasTaskDispatcher(): boolean {
+    return typeof this.taskDispatcher === 'function';
+  }
+
   // ── DB Sync Helpers ────────────────────────────────────────
 
   /**


### PR DESCRIPTION
## Summary
Merge completions were serialized behind the single global completion queue, so one blocked merge completion could prevent later merge tasks from even entering merge execution.

## Exact Failure / Symptom
Observed symptom: merge task exits its worker process, then goes silent until lease expiry because it never reaches merge continuation.

## Exact Test Setup
- Task-runner regression: `packages/execution-engine/src/__tests__/task-runner.test.ts`
- Exact regression: `a blocked first merge completion does not prevent a second merge completion from entering merge execution`
- The test blocks the first merge completion and proves a second merge completion still enters continuation instead of waiting behind a shared global queue.

## Root Cause
The task runner put merge completion work behind the same global `completionChain` used for all completions. A blocked earlier completion head-of-line blocked later merge completions that should have been independent.

## Why This Fix Is Right
The right fix is to remove the artificial shared bottleneck for merge completions, not to keep stretching leases or adding more heartbeats. The queue itself was the blocker.

## Validation
- The exact task-runner regression above proves later merge completions still advance while an earlier merge completion is blocked.

## Traceability
- Commit: `702568b`
- Commit message: `Unblock merge completions from the global queue`

