### PR TITLE
Preserve stale SSH branch-owner cleanup on probe failure

### DIFF
--- a/packages/app/e2e/fix-with-claude.spec.ts
+++ b/packages/app/e2e/fix-with-claude.spec.ts
@@ -40,6 +40,23 @@ const FAILING_PLAN = {
 };
 
 test.describe('Fix with Claude', () => {
+  async function openFixWithClaude(page: any) {
+    const moreMenuItem = page.getByRole('menuitem', { name: 'More' });
+    if (await moreMenuItem.isVisible().catch(() => false)) {
+      await moreMenuItem.click();
+    }
+
+    const fixMenuItem = page.getByRole('menuitem', { name: 'Fix with Claude' });
+    if (await fixMenuItem.isVisible().catch(() => false)) {
+      await fixMenuItem.click();
+      return;
+    }
+
+    const fixButton = page.locator('button').filter({ hasText: 'Fix with Claude' });
+    await expect(fixButton).toBeVisible({ timeout: 10000 });
+    await fixButton.click();
+  }
+
   test('Fix with Claude -> Approve -> task completes', async ({ page }) => {
     await loadPlan(page, FAILING_PLAN);
     await startPlan(page);
@@ -49,13 +66,7 @@ test.describe('Fix with Claude', () => {
     const scopedTaskId = await resolveTaskId(page, 'task-fail');
 
     await page.locator('.react-flow__node[data-testid$="/task-fail"]').click({ button: 'right' });
-    const moreBtn = page.getByRole('menuitem', { name: 'More' });
-    if (await moreBtn.isVisible().catch(() => false)) {
-      await moreBtn.click();
-    }
-    const fixBtn = page.getByRole('menuitem', { name: 'Fix with Claude' });
-    await expect(fixBtn).toBeVisible({ timeout: 10000 });
-    await fixBtn.click();
+    await openFixWithClaude(page);
 
     await waitForTaskStatus(page, 'task-fail', 'awaiting_approval', 15000);
 
@@ -73,13 +84,7 @@ test.describe('Fix with Claude', () => {
     const scopedTaskId = await resolveTaskId(page, 'task-fail');
 
     await page.locator('.react-flow__node[data-testid$="/task-fail"]').click({ button: 'right' });
-    const moreBtn = page.getByRole('menuitem', { name: 'More' });
-    if (await moreBtn.isVisible().catch(() => false)) {
-      await moreBtn.click();
-    }
-    const fixBtn = page.getByRole('menuitem', { name: 'Fix with Claude' });
-    await expect(fixBtn).toBeVisible({ timeout: 10000 });
-    await fixBtn.click();
+    await openFixWithClaude(page);
 
     await waitForTaskStatus(page, 'task-fail', 'awaiting_approval', 15000);
 

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -114,6 +114,7 @@ function createMocks() {
     executorRegistry: {},
     taskExecutor: {
       executeTasks: vi.fn().mockResolvedValue(undefined),
+      killActiveExecution: vi.fn().mockResolvedValue(undefined),
       publishAfterFix: vi.fn().mockResolvedValue(undefined),
       resolveConflict: vi.fn().mockResolvedValue(undefined),
       fixWithAgent: vi.fn().mockResolvedValue(undefined),
@@ -191,6 +192,7 @@ beforeEach(() => {
   mocks.cancelWorkflow.mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
   mocks.killRunningTask.mockResolvedValue(undefined);
   mocks.taskExecutor.executeTasks.mockResolvedValue(undefined);
+  mocks.taskExecutor.killActiveExecution.mockResolvedValue(undefined);
   mocks.taskExecutor.publishAfterFix.mockResolvedValue(undefined);
   mocks.taskExecutor.resolveConflict.mockResolvedValue(undefined);
   mocks.taskExecutor.fixWithAgent.mockResolvedValue(undefined);
@@ -571,6 +573,22 @@ describe('POST /api/tasks/:id/edit', () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('command_edited');
+    expect(mocks.orchestrator.editTaskCommand).toHaveBeenCalledWith('task-1', 'npm test');
+  });
+
+  it('interrupts fixing_with_ai before editing the command', async () => {
+    mocks.orchestrator.getTask.mockReturnValue({
+      id: 'task-1',
+      status: 'fixing_with_ai',
+      execution: { pendingFixError: 'saved failure' },
+      config: {},
+    });
+
+    const res = await request(port, 'POST', '/api/tasks/task-1/edit', { command: 'npm test' });
+
+    expect(res.status).toBe(200);
+    expect(mocks.taskExecutor.killActiveExecution).toHaveBeenCalledWith('task-1');
+    expect(mocks.orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-1', 'saved failure');
     expect(mocks.orchestrator.editTaskCommand).toHaveBeenCalledWith('task-1', 'npm test');
   });
 

--- a/packages/app/src/__tests__/auto-fix-session.test.ts
+++ b/packages/app/src/__tests__/auto-fix-session.test.ts
@@ -51,6 +51,48 @@ describe('auto-fix-session', () => {
     });
   });
 
+  it('skips enqueue for broad lint failures', () => {
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => ({
+        id: 'wf-1/task-1',
+        status: 'failed',
+        config: { command: 'eslint packages/' },
+        execution: { autoFixAttempts: 0, error: "✖ 1696 problems\nno-explicit-any\nno-undef" },
+      })),
+    };
+    const persistence = {
+      listWorkflowMutationIntents: vi.fn(() => []),
+    };
+
+    expect(getAutoFixEnqueueDecision(orchestrator as any, persistence as any, 'wf-1', 'wf-1/task-1')).toEqual({
+      shouldEnqueue: false,
+      reason: 'failure-disposition-fail-fast',
+      status: 'failed',
+      dispositionReason: 'broad-lint-failure',
+    });
+  });
+
+  it('skips dispatch for DTS build failures', () => {
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => ({
+        id: 'wf-1/task-1',
+        status: 'failed',
+        config: { command: 'pnpm -r build' },
+        execution: { autoFixAttempts: 0, error: 'TS6307: File is not listed within the file list of project.\nError: error occurred in dts build' },
+      })),
+    };
+
+    expect(getAutoFixDispatchDecision(orchestrator as any, 'wf-1/task-1')).toEqual({
+      shouldDispatch: false,
+      reason: 'failure-disposition-fail-fast',
+      status: 'failed',
+      autoFixAttempts: 0,
+      dispositionReason: 'dts-build-config-failure',
+    });
+  });
+
   it('allows dispatch when the task is still failed and auto-fix eligible', () => {
     const task = { id: 'wf-1/task-1', status: 'failed', execution: { autoFixAttempts: 1 } };
     const orchestrator = {

--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -8,14 +8,24 @@ describe('wireHeadlessAutoFix', () => {
   it('subscribes auto-fix for failed deltas in generic headless execution paths', async () => {
     const messageBus = new LocalBus() as MessageBus;
     const shouldAutoFix = vi.fn((taskId: string) => taskId === 'wf-1/task-1');
+    const getTask = vi.fn((taskId: string) =>
+      taskId === 'wf-1/task-1'
+        ? {
+            id: taskId,
+            status: 'failed',
+            execution: { autoFixAttempts: 0, error: 'narrow fixable failure' },
+            config: { command: 'pnpm test' },
+          }
+        : undefined,
+    );
     const invokeAutoFix = vi.fn(async () => {});
     const onError = vi.fn();
 
     wireHeadlessAutoFix(
       {
         messageBus,
-        orchestrator: { shouldAutoFix } as any,
-        persistence: {} as any,
+        orchestrator: { shouldAutoFix, getTask } as any,
+        persistence: { logEvent: vi.fn(), appendTaskOutput: vi.fn() } as any,
       },
       {} as any,
       invokeAutoFix,
@@ -37,9 +47,56 @@ describe('wireHeadlessAutoFix', () => {
     await Promise.resolve();
 
     expect(shouldAutoFix).toHaveBeenCalledWith('wf-1/task-1');
-    expect(shouldAutoFix).toHaveBeenCalledWith('wf-1/task-2');
+    expect(getTask).toHaveBeenCalledWith('wf-1/task-2');
     expect(invokeAutoFix).toHaveBeenCalledTimes(1);
     expect(invokeAutoFix).toHaveBeenCalledWith('wf-1/task-1');
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('emits a task-output skip message for fail-fast auto-fix decisions', async () => {
+    const messageBus = new LocalBus() as MessageBus;
+    const appendTaskOutput = vi.fn();
+    const getTask = vi.fn(() => ({
+      id: 'wf-1/task-1',
+      status: 'failed',
+      execution: {
+        error: '✖ 1696 problems\nno-explicit-any\nno-undef',
+        autoFixAttempts: 0,
+      },
+      config: {
+        command: 'eslint packages/',
+      },
+    }));
+    const shouldAutoFix = vi.fn(() => true);
+    const invokeAutoFix = vi.fn(async () => {});
+
+    wireHeadlessAutoFix(
+      {
+        messageBus,
+        orchestrator: { shouldAutoFix, getTask } as any,
+        persistence: { appendTaskOutput, logEvent: vi.fn() } as any,
+      },
+      {} as any,
+      invokeAutoFix,
+    );
+
+    messageBus.publish(Channels.TASK_DELTA, {
+      type: 'updated',
+      taskId: 'wf-1/task-1',
+      changes: { status: 'failed' },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invokeAutoFix).not.toHaveBeenCalled();
+    expect(appendTaskOutput).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      expect.stringContaining('[Auto-fix] Skipped: the task failed with a broad lint error set.'),
+    );
+    expect(appendTaskOutput).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      expect.stringContaining('[Auto-fix] Primary failure: ✖ 1696 problems'),
+    );
   });
 });

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -102,6 +102,10 @@ describe('headless delegation enforcement', () => {
       mockDeps.orchestrator.getWorkflowStatus = vi.fn(() => 'running');
       mockDeps.orchestrator.syncFromDb = vi.fn();
       mockDeps.orchestrator.restartTask = vi.fn(() => []);
+      mockDeps.orchestrator.getTask = vi.fn(() => undefined);
+      mockDeps.orchestrator.editTaskCommand = vi.fn(() => []);
+      mockDeps.orchestrator.editTaskType = vi.fn(() => []);
+      mockDeps.orchestrator.editTaskAgent = vi.fn(() => []);
       mockDeps.orchestrator.approve = vi.fn(async () => []);
       mockDeps.orchestrator.setBeforeApproveHook = vi.fn();
       mockDeps.orchestrator.provideInput = vi.fn();
@@ -284,6 +288,10 @@ describe('headless delegation enforcement', () => {
         mockDeps.orchestrator.resumeWorkflow = vi.fn(() => []);
         mockDeps.orchestrator.syncFromDb = vi.fn();
         mockDeps.orchestrator.restartTask = vi.fn(() => []);
+        mockDeps.orchestrator.getTask = vi.fn(() => undefined);
+        mockDeps.orchestrator.editTaskCommand = vi.fn(() => []);
+        mockDeps.orchestrator.editTaskType = vi.fn(() => []);
+        mockDeps.orchestrator.editTaskAgent = vi.fn(() => []);
         mockDeps.orchestrator.setBeforeApproveHook = vi.fn();
         mockDeps.orchestrator.provideInput = vi.fn();
         mockDeps.orchestrator.approve = vi.fn(async () => []);
@@ -446,7 +454,7 @@ describe('headless delegation enforcement', () => {
           config: { workflowId: 'wf-1' },
           execution: {},
         } as any;
-        mockDeps.commandService.editTaskCommand = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
+        mockDeps.orchestrator.editTaskCommand = vi.fn(() => [runnableTask]);
         mockDeps.commandService.editTaskType = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
         mockDeps.commandService.editTaskAgent = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
 
@@ -463,7 +471,7 @@ describe('headless delegation enforcement', () => {
         await runHeadless(['set', 'agent', 'wf-1/task-1', 'codex'], mockDeps);
 
         expect(executeTasksSpy).toHaveBeenCalledTimes(3);
-        expect(mockDeps.commandService.editTaskCommand).toHaveBeenCalled();
+        expect(mockDeps.orchestrator.editTaskCommand).toHaveBeenCalledWith('wf-1/task-1', 'echo ok');
         expect(mockDeps.commandService.editTaskType).toHaveBeenCalled();
         expect(mockDeps.commandService.editTaskAgent).toHaveBeenCalled();
 

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -868,18 +868,143 @@ describe('autoFixOnFailure', () => {
       }),
     );
   });
+
+  it('reverts conflict resolution when remote fix-with-agent times out', async () => {
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1', executorType: 'ssh', remoteTargetId: 'remote-1' },
+        execution: { autoFixAttempts: 0, workspacePath: '~/worktrees/remote' },
+      })),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      restartTask: vi.fn(() => []),
+      revertConflictResolution: vi.fn(),
+    };
+    const logEvent = vi.fn();
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+      logEvent,
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockRejectedValue(new Error('Remote agent fix timed out after 600000ms (phase=remote_agent_fix)')),
+      resolveConflict: vi.fn(),
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await autoFixOnFailure('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    expect(orchestrator.restartTask).not.toHaveBeenCalled();
+    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith(
+      'task-a',
+      'boom',
+      expect.stringContaining('Remote agent fix timed out after 600000ms'),
+    );
+    expect(logEvent).toHaveBeenCalledWith(
+      'task-a',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'auto-fix-route-failed',
+        errorMessage: 'Remote agent fix timed out after 600000ms (phase=remote_agent_fix)',
+      }),
+    );
+  });
+
+  it('fails fast and skips auto-fix for broad lint failures', async () => {
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1', command: 'eslint packages/' },
+        execution: { autoFixAttempts: 0, error: '✖ 1696 problems\nno-explicit-any\nno-undef' },
+      })),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      restartTask: vi.fn(() => []),
+      revertConflictResolution: vi.fn(),
+    };
+    const logEvent = vi.fn();
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+      logEvent,
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn(),
+      resolveConflict: vi.fn(),
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await autoFixOnFailure('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
+    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(logEvent).toHaveBeenCalledWith(
+      'task-a',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'auto-fix-skip',
+        reason: 'failure-disposition-fail-fast',
+        dispositionReason: 'broad-lint-failure',
+      }),
+    );
+    expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
+      'task-a',
+      expect.stringContaining('[Auto-fix] Skipped: the task failed with a broad lint error set.'),
+    );
+    expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
+      'task-a',
+      expect.stringContaining('[Auto-fix] Primary failure: ✖ 1696 problems'),
+    );
+  });
 });
 
 describe('editTaskCommand', () => {
-  it('calls orchestrator.editTaskCommand and returns result', () => {
+  it('calls orchestrator.editTaskCommand and returns result', async () => {
     const tasks = [makeRunningTask()];
-    const orchestrator = { editTaskCommand: vi.fn(() => tasks) };
+    const orchestrator = { getTask: vi.fn(() => undefined), editTaskCommand: vi.fn(() => tasks) };
 
-    const result = editTaskCommand('task-a', 'npm test', {
+    const result = await editTaskCommand('task-a', 'npm test', {
       orchestrator: orchestrator as unknown as Orchestrator,
     });
 
     expect(orchestrator.editTaskCommand).toHaveBeenCalledWith('task-a', 'npm test');
+    expect(result).toBe(tasks);
+  });
+
+  it('cancels fixing_with_ai before editing and restarting with the new command', async () => {
+    const tasks = [makeRunningTask({ id: 'task-a', config: { command: 'npm test' } })];
+    const orchestrator = {
+      getTask: vi.fn(() => ({
+        id: 'task-a',
+        status: 'fixing_with_ai',
+        execution: { pendingFixError: 'original failure' },
+      })),
+      revertConflictResolution: vi.fn(),
+      editTaskCommand: vi.fn(() => tasks),
+    };
+    const taskExecutor = { killActiveExecution: vi.fn().mockResolvedValue(undefined) };
+
+    const result = await editTaskCommand('task-a', 'npm run lint', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as any,
+    });
+
+    expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-a', 'original failure');
+    expect(orchestrator.editTaskCommand).toHaveBeenCalledWith('task-a', 'npm run lint');
     expect(result).toBe(tasks);
   });
 });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -437,7 +437,10 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "command" in request body' });
             return;
           }
-          const started = sharedEditTaskCommand(taskId, command, { orchestrator });
+          const started = await sharedEditTaskCommand(taskId, command, {
+            orchestrator,
+            taskExecutor,
+          });
           const runnable = await dispatchTasksIfNeeded({
             orchestrator,
             taskExecutor,

--- a/packages/app/src/auto-fix-disposition.ts
+++ b/packages/app/src/auto-fix-disposition.ts
@@ -1,0 +1,35 @@
+import type { TaskState } from '@invoker/workflow-core';
+
+export type AutoFixFailureDisposition = 'auto_fix_code' | 'fail_fast';
+
+export function classifyAutoFixFailure(task: TaskState | undefined): {
+  disposition: AutoFixFailureDisposition;
+  reason: string;
+} {
+  if (!task) {
+    return { disposition: 'fail_fast', reason: 'task-missing' };
+  }
+
+  const error = task.execution?.error ?? '';
+  const command = task.config?.command ?? '';
+
+  const broadLintFailure =
+    /\beslint\b/i.test(command) ||
+    /\beslint packages\/\b/i.test(error) ||
+    /\bno-explicit-any\b/.test(error) ||
+    /\bno-undef\b/.test(error) ||
+    /✖\s+\d+\s+problems?/.test(error);
+  if (broadLintFailure) {
+    return { disposition: 'fail_fast', reason: 'broad-lint-failure' };
+  }
+
+  const dtsBuildFailure =
+    /\bTS6307:/.test(error) ||
+    /error occurred in dts build/i.test(error) ||
+    /Projects must list all files or use an 'include' pattern/i.test(error);
+  if (dtsBuildFailure) {
+    return { disposition: 'fail_fast', reason: 'dts-build-config-failure' };
+  }
+
+  return { disposition: 'auto_fix_code', reason: 'auto-fix-eligible' };
+}

--- a/packages/app/src/auto-fix-session.ts
+++ b/packages/app/src/auto-fix-session.ts
@@ -1,6 +1,7 @@
 import type { SQLiteAdapter, WorkflowMutationIntent } from '@invoker/data-store';
 import type { TaskState } from '@invoker/workflow-core';
 import { listOpenFixIntentsForTask } from './auto-fix-intents.js';
+import { classifyAutoFixFailure } from './auto-fix-disposition.js';
 
 type AutoFixOrchestrator = {
   shouldAutoFix(taskId: string): boolean;
@@ -13,18 +14,20 @@ export type AutoFixEnqueueDecision =
   | { shouldEnqueue: true }
   | {
     shouldEnqueue: false;
-    reason: 'shouldAutoFix-false' | 'already-live-intent';
+    reason: 'shouldAutoFix-false' | 'already-live-intent' | 'failure-disposition-fail-fast';
     status?: string;
     existingIntentIds?: number[];
+    dispositionReason?: string;
   };
 
 export type AutoFixDispatchDecision =
   | { shouldDispatch: true; task: TaskState }
   | {
     shouldDispatch: false;
-    reason: 'shouldAutoFix-false';
+    reason: 'shouldAutoFix-false' | 'failure-disposition-fail-fast';
     status: string;
     autoFixAttempts: number | null;
+    dispositionReason?: string;
   };
 
 export function getOpenAutoFixIntentsForTask(
@@ -43,11 +46,21 @@ export function getAutoFixEnqueueDecision(
   taskId: string,
 ): AutoFixEnqueueDecision {
   const shouldAutoFixNow = orchestrator.shouldAutoFix(taskId);
+  const task = orchestrator.getTask(taskId);
   if (!shouldAutoFixNow) {
     return {
       shouldEnqueue: false,
       reason: 'shouldAutoFix-false',
-      status: orchestrator.getTask(taskId)?.status,
+      status: task?.status,
+    };
+  }
+  const disposition = classifyAutoFixFailure(task);
+  if (disposition.disposition === 'fail_fast') {
+    return {
+      shouldEnqueue: false,
+      reason: 'failure-disposition-fail-fast',
+      status: task?.status,
+      dispositionReason: disposition.reason,
     };
   }
 
@@ -70,6 +83,16 @@ export function getAutoFixDispatchDecision(
 ): AutoFixDispatchDecision {
   const task = orchestrator.getTask(taskId);
   if (task && orchestrator.shouldAutoFix(taskId)) {
+    const disposition = classifyAutoFixFailure(task);
+    if (disposition.disposition === 'fail_fast') {
+      return {
+        shouldDispatch: false,
+        reason: 'failure-disposition-fail-fast',
+        status: task.status,
+        autoFixAttempts: task.execution.autoFixAttempts ?? null,
+        dispositionReason: disposition.reason,
+      };
+    }
     return { shouldDispatch: true, task };
   }
   return {
@@ -78,4 +101,33 @@ export function getAutoFixDispatchDecision(
     status: task?.status ?? 'missing',
     autoFixAttempts: task?.execution.autoFixAttempts ?? null,
   };
+}
+
+function describeAutoFixSkipReason(dispositionReason?: string): string {
+  switch (dispositionReason) {
+    case 'broad-lint-failure':
+      return 'the task failed with a broad lint error set';
+    case 'dts-build-config-failure':
+      return 'the task failed with a DTS/build configuration error';
+    case 'task-missing':
+      return 'the task is no longer available';
+    default:
+      return 'the failure is not in an auto-fixable class';
+  }
+}
+
+export function buildAutoFixSkipOutput(
+  task: TaskState | undefined,
+  reason: 'shouldAutoFix-false' | 'already-live-intent' | 'failure-disposition-fail-fast',
+  dispositionReason?: string,
+): string | null {
+  if (reason !== 'failure-disposition-fail-fast') {
+    return null;
+  }
+  const primaryError = task?.execution?.error?.trim();
+  const lines = [`[Auto-fix] Skipped: ${describeAutoFixSkipReason(dispositionReason)}.`];
+  if (primaryError) {
+    lines.push(`[Auto-fix] Primary failure: ${primaryError}`);
+  }
+  return `\n${lines.join('\n')}`;
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -31,6 +31,7 @@ import { backupPlan } from './plan-backup.js';
 import { startApiServer, type ApiServerDeps } from './api-server.js';
 import {
   approveTask,
+  editTaskCommand as sharedEditTaskCommand,
   rebaseAndRetry,
   resolveConflictAction,
   recreateWorkflow as sharedRecreateWorkflow,
@@ -40,6 +41,7 @@ import {
 } from './workflow-actions.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
 import { dispatchTasksIfNeeded, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { buildAutoFixSkipOutput, getAutoFixDispatchDecision } from './auto-fix-session.js';
 import {
   delegationTimeoutMs,
   tryDelegateExec,
@@ -234,12 +236,28 @@ export function wireHeadlessAutoFix(
   const unsubscribe = deps.messageBus.subscribe<TaskDelta>(Channels.TASK_DELTA, (delta) => {
     if (delta.type !== 'updated' || delta.changes.status !== 'failed') return;
     const inProgress = autoFixInProgress.has(delta.taskId);
-    const shouldAutoFix = deps.orchestrator.shouldAutoFix(delta.taskId);
-    logHeadlessAutoFixDebug(delta.taskId, 'delta-failed', { shouldAutoFix, inProgress });
+    const dispatchDecision = getAutoFixDispatchDecision(deps.orchestrator as any, delta.taskId);
+    const shouldAutoFix = dispatchDecision.shouldDispatch;
+    logHeadlessAutoFixDebug(delta.taskId, 'delta-failed', {
+      shouldAutoFix,
+      inProgress,
+      dispositionReason: dispatchDecision.shouldDispatch ? undefined : dispatchDecision.dispositionReason,
+    });
     if (inProgress || !shouldAutoFix) {
       logHeadlessAutoFixDebug(delta.taskId, 'schedule-skip', {
-        reason: !shouldAutoFix ? 'shouldAutoFix-false' : 'already-in-progress',
+        reason: !shouldAutoFix ? dispatchDecision.reason : 'already-in-progress',
+        dispositionReason: dispatchDecision.shouldDispatch ? undefined : dispatchDecision.dispositionReason,
       });
+      if (!shouldAutoFix) {
+        const skipOutput = buildAutoFixSkipOutput(
+          deps.orchestrator.getTask(delta.taskId),
+          dispatchDecision.reason,
+          dispatchDecision.dispositionReason,
+        );
+        if (skipOutput) {
+          deps.persistence.appendTaskOutput(delta.taskId, skipOutput);
+        }
+      }
       return;
     }
     autoFixInProgress.add(delta.taskId);
@@ -1514,15 +1532,19 @@ async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDe
   taskId = restored.resolvedTaskId;
   const taskExecutor = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
-
-  const envelope = makeEnvelope('edit-task-command', 'headless', 'task', { taskId, newCommand });
-  const result = await deps.commandService.editTaskCommand(envelope);
-  if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((task) => task.status === 'running');
-  if (runnable.length > 0) {
-    await taskExecutor.executeTasks(runnable);
-  }
+  const started = await sharedEditTaskCommand(taskId, newCommand, {
+    orchestrator: deps.orchestrator,
+    taskExecutor,
+  });
   process.stdout.write(`Edited task "${taskId}" command → "${newCommand}"\n`);
+
+  const runnable = await dispatchTasksIfNeeded({
+    orchestrator: deps.orchestrator,
+    taskExecutor,
+    tasks: started,
+    logger: deps.logger,
+    context: 'headless.edit-command',
+  });
 
   if (deps.noTrack) {
     process.stdout.write('[headless] --no-track enabled: set command accepted; exiting without tracking.\n');

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -94,6 +94,7 @@ import {
 } from './headless.js';
 import {
   approveTask as sharedApproveTask,
+  editTaskCommand as sharedEditTaskCommand,
   rebaseAndRetry,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
@@ -108,7 +109,7 @@ import { createRequire } from 'node:module';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
 import { applyDelta } from './delta-merge.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
-import { getAutoFixDispatchDecision, getAutoFixEnqueueDecision } from './auto-fix-session.js';
+import { buildAutoFixSkipOutput, getAutoFixDispatchDecision, getAutoFixEnqueueDecision } from './auto-fix-session.js';
 import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -1121,7 +1122,16 @@ if (isHeadless) {
           reason: dispatchDecision.reason,
           status: dispatchDecision.status,
           autoFixAttempts: dispatchDecision.autoFixAttempts,
+          dispositionReason: dispatchDecision.dispositionReason,
         });
+        const skipOutput = buildAutoFixSkipOutput(
+          orchestrator.getTask(taskId),
+          dispatchDecision.reason,
+          dispatchDecision.dispositionReason,
+        );
+        if (skipOutput) {
+          persistence.appendTaskOutput(taskId, skipOutput);
+        }
         return [];
       }
       const task = dispatchDecision.task;
@@ -1174,7 +1184,16 @@ if (isHeadless) {
         reason: enqueueDecision.reason,
         status: enqueueDecision.status,
         existingIntentIds: enqueueDecision.existingIntentIds,
+        dispositionReason: enqueueDecision.dispositionReason,
       });
+      const skipOutput = buildAutoFixSkipOutput(
+        orchestrator.getTask(taskId),
+        enqueueDecision.reason,
+        enqueueDecision.dispositionReason,
+      );
+      if (skipOutput) {
+        persistence.appendTaskOutput(taskId, skipOutput);
+      }
       return;
     }
     const configuredAgent = loadConfig().autoFixAgent?.trim();
@@ -3086,10 +3105,11 @@ if (isHeadless) {
       const newCommand = String(newCommandArg);
       logger.info(`edit-task-command: "${taskId}" → "${newCommand}"`, { module: 'ipc' });
       try {
-        const envelope = makeEnvelope('edit-task-command', 'ui', 'task', { taskId, newCommand });
-        const result = await commandService.editTaskCommand(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        const runnable = result.data.filter(t => t.status === 'running');
+        const started = await sharedEditTaskCommand(taskId, newCommand, {
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+        });
+        const runnable = started.filter(t => t.status === 'running');
         void runnable;
       } catch (err) {
         logger.error(`edit-task-command failed: ${err}`, { module: 'ipc' });

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -10,6 +10,7 @@ import type { Logger } from '@invoker/contracts';
 import type { Orchestrator, ExternalGatePolicyUpdate } from '@invoker/workflow-core';
 import type { TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
+import { buildAutoFixSkipOutput, getAutoFixDispatchDecision } from './auto-fix-session.js';
 import type { TaskRunner } from '@invoker/execution-engine';
 import { dispatchTasksIfNeeded } from './global-topup.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
@@ -185,11 +186,22 @@ export async function rebaseAndRetry(
   return bumpGenerationAndRecreate(workflowId, deps);
 }
 
-export function editTaskCommand(
+export async function editTaskCommand(
   taskId: string,
   newCommand: string,
-  deps: Pick<ActionDeps, 'orchestrator'>,
-): TaskState[] {
+  deps: Pick<ActionDeps, 'orchestrator'> & { taskExecutor?: Pick<TaskRunner, 'killActiveExecution'> },
+): Promise<TaskState[]> {
+  const task = deps.orchestrator.getTask?.(taskId);
+  if (task?.status === 'fixing_with_ai') {
+    if (!deps.taskExecutor) {
+      throw new Error(`Cannot edit fixing_with_ai task ${taskId} without a task executor`);
+    }
+    await deps.taskExecutor.killActiveExecution(taskId);
+    deps.orchestrator.revertConflictResolution(
+      taskId,
+      task.execution.pendingFixError ?? task.execution.error ?? '',
+    );
+  }
   return deps.orchestrator.editTaskCommand(taskId, newCommand);
 }
 
@@ -441,10 +453,28 @@ export async function autoFixOnFailure(
   inlineRetryDepth = 0,
 ): Promise<void> {
   const { orchestrator, persistence, taskExecutor } = deps;
-  if (!orchestrator.shouldAutoFix(taskId)) return;
+  const dispatchDecision = getAutoFixDispatchDecision(orchestrator as any, taskId);
+  if (!dispatchDecision.shouldDispatch) {
+    persistence.logEvent?.(taskId, 'debug.auto-fix', {
+      phase: 'auto-fix-skip',
+      reason: dispatchDecision.reason,
+      status: dispatchDecision.status,
+      autoFixAttempts: dispatchDecision.autoFixAttempts,
+      dispositionReason: dispatchDecision.dispositionReason ?? null,
+    });
+    const task = orchestrator.getTask(taskId);
+    const skipOutput = buildAutoFixSkipOutput(
+      task,
+      dispatchDecision.reason,
+      dispatchDecision.dispositionReason,
+    );
+    if (skipOutput) {
+      persistence.appendTaskOutput(taskId, skipOutput);
+    }
+    return;
+  }
 
-  const task = orchestrator.getTask(taskId);
-  if (!task || task.status !== 'failed') return;
+  const task = dispatchDecision.task;
 
   const attempts = (task.execution.autoFixAttempts ?? 0) + 1;
   const max = orchestrator.getAutoFixRetryBudget(taskId);

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "echo 'compat package: tests moved to @invoker/workflow-core'",
     "test:watch": "echo 'compat package: tests moved to @invoker/workflow-core'",
     "clean": "rm -rf dist"

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/data-store/package.json
+++ b/packages/data-store/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/data-store/tsconfig.build.json
+++ b/packages/data-store/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/execution-engine/package.json
+++ b/packages/execution-engine/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "docker:build": "bash ../../scripts/build-agent-base-image.sh",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/execution-engine/src/__tests__/git-branch-push-recovery.test.ts
+++ b/packages/execution-engine/src/__tests__/git-branch-push-recovery.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+import { pushBranchWithRecovery } from '../git-branch-push-recovery.js';
+
+describe('pushBranchWithRecovery', () => {
+  it('retries when publish path B loses the workflow feature-branch push to overlapping publish path A', async () => {
+    const exec = vi.fn()
+      .mockRejectedValueOnce(
+        new Error(
+          "git push --force -u origin feature/test failed (code 1): cannot lock ref 'refs/heads/feature/test': is at aaa111 but expected bbb222",
+        ),
+      )
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('local-tree\n')
+      .mockResolvedValueOnce('remote-tree\n')
+      .mockResolvedValueOnce('');
+
+    await pushBranchWithRecovery({ exec }, '/tmp/repo', 'feature/test');
+
+    expect(exec.mock.calls.map((call) => call[0])).toEqual([
+      ['push', '--force', '-u', 'origin', 'feature/test'],
+      ['fetch', 'origin', '+refs/heads/feature/test:refs/remotes/origin/feature/test'],
+      ['rev-parse', 'HEAD^{tree}'],
+      ['rev-parse', 'refs/remotes/origin/feature/test^{tree}'],
+      ['push', '--force', '-u', 'origin', 'feature/test'],
+    ]);
+  });
+
+  it('treats the race as success when overlapping publish path A already pushed equivalent branch content', async () => {
+    const exec = vi.fn()
+      .mockRejectedValueOnce(
+        new Error(
+          "git push --force -u origin feature/test failed (code 1): cannot lock ref 'refs/heads/feature/test': is at aaa111 but expected bbb222",
+        ),
+      )
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('same-tree\n')
+      .mockResolvedValueOnce('same-tree\n');
+
+    await pushBranchWithRecovery({ exec }, '/tmp/repo', 'feature/test');
+
+    expect(exec).toHaveBeenCalledTimes(4);
+  });
+
+  it('does not swallow non-race push failures', async () => {
+    const exec = vi.fn().mockRejectedValueOnce(
+      new Error('git push --force -u origin feature/test failed (code 1): authentication failed'),
+    );
+
+    await expect(pushBranchWithRecovery({ exec }, '/tmp/repo', 'feature/test')).rejects.toThrow(
+      'authentication failed',
+    );
+    expect(exec).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -19,6 +19,23 @@ function mockSpawnResult(stdoutData: string, exitCode: number) {
   return child;
 }
 
+function mockSpawnResultWithStderr(stdoutData: string, stderrData: string, exitCode: number) {
+  const { EventEmitter } = require('events');
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  const child = new EventEmitter();
+  (child as any).stdout = stdout;
+  (child as any).stderr = stderr;
+
+  setTimeout(() => {
+    if (stdoutData) stdout.emit('data', Buffer.from(stdoutData));
+    if (stderrData) stderr.emit('data', Buffer.from(stderrData));
+    child.emit('close', exitCode);
+  }, 0);
+
+  return child;
+}
+
 describe('GitHubMergeGateProvider', () => {
   let provider: GitHubMergeGateProvider;
 
@@ -104,6 +121,46 @@ describe('GitHubMergeGateProvider', () => {
       expect(spawnMock).toHaveBeenCalledWith(
         'gh',
         ['api', 'repos/{owner}/{repo}/pulls/10', '--method', 'PATCH', '-f', 'title=Updated PR', '-f', 'body=## Summary'],
+        expect.objectContaining({ cwd: '/tmp/repo' }),
+      );
+    });
+
+    it('continues when createReview publish path B loses the same workflow feature branch to overlapping publish path A', async () => {
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      let callCount = 0;
+      spawnMock.mockImplementation(((cmd: string, args: string[]) => {
+        callCount += 1;
+        if (cmd === 'git' && args[0] === 'push') {
+          // Exact scenario: merge-gate publish path A already updated the
+          // workflow's stable feature branch. createReview publish path B then
+          // reaches the same push target and loses the atomic ref update race,
+          // even though the remote branch now contains equivalent tree content.
+          return mockSpawnResultWithStderr(
+            '',
+            "To https://github.com/owner/repo\n ! [remote rejected] feature/test -> feature/test (cannot lock ref 'refs/heads/feature/test': is at aaa111 but expected bbb222)\n",
+            1,
+          );
+        }
+        if (cmd === 'git' && args[0] === 'fetch') return mockSpawnResult('', 0);
+        if (cmd === 'git' && args[0] === 'rev-parse' && args[1] === 'HEAD^{tree}') return mockSpawnResult('same-tree\n', 0);
+        if (cmd === 'git' && args[0] === 'rev-parse' && args[1] === 'refs/remotes/origin/feature/test^{tree}') return mockSpawnResult('same-tree\n', 0);
+        if (cmd === 'gh' && args[0] === 'pr' && args[1] === 'list') return mockSpawnResult('[]', 0);
+        return mockSpawnResult('{"html_url":"https://github.com/owner/repo/pull/42","number":42}', 0);
+      }) as any);
+
+      const result = await provider.createReview({
+        baseBranch: 'main',
+        featureBranch: 'feature/test',
+        title: 'Race-safe PR',
+        cwd: '/tmp/repo',
+      });
+
+      expect(result.identifier).toBe('42');
+      expect(spawnMock).toHaveBeenCalledWith(
+        'git',
+        ['fetch', 'origin', '+refs/heads/feature/test:refs/remotes/origin/feature/test'],
         expect.objectContaining({ cwd: '/tmp/repo' }),
       );
     });

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -334,6 +334,82 @@ branch refs/heads/${targetBranch}
     expect(setupTaskBranchSpy).toHaveBeenCalled();
   });
 
+  it('retains stale branch-owner cleanup when the owner-path head probe fails', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+    }) as any;
+
+    const repoHash = computeRepoUrlHash('git@github.com:owner/repo.git');
+    const baseHead = 'abc123def456abc123def456abc123def456abc1';
+    const branchHash = computeBranchHash(
+      'test-task-conflict',
+      'pnpm test',
+      undefined,
+      [],
+      baseHead,
+      '',
+    );
+    const targetBranch = `experiment/test-task-conflict-${branchHash}`;
+    const ownerPath = `/home/testuser/.invoker/worktrees/${repoHash}/stale-owner-13b9e4d0`;
+    const canonicalPath = `~/.invoker/worktrees/${repoHash}/experiment-test-task-conflict-${branchHash}`;
+    let cleanupScript = '';
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string, phase?: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return [
+          '__INVOKER_BASE_REF__=origin/main',
+          `__INVOKER_BASE_HEAD__=${baseHead}`,
+        ].join('\n');
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) {
+        return `worktree ${ownerPath}
+HEAD deadbeef
+branch refs/heads/${targetBranch}
+`;
+      }
+      if (script.includes('rev-parse --abbrev-ref HEAD')) {
+        throw createSshRemoteScriptError(
+          128,
+          '',
+          `fatal: cannot change to '${ownerPath}': No such file or directory\n`,
+          phase,
+        );
+      }
+      if (phase === 'cleanup_worktree') {
+        cleanupScript = script;
+        return '';
+      }
+      return '';
+    });
+
+    const setupTaskBranchSpy = vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any) => handle,
+    );
+
+    const req = makeRequest({
+      actionType: 'command',
+      actionId: 'test-task-conflict',
+      inputs: {
+        command: 'pnpm test',
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    });
+
+    await ssh.start(req);
+
+    const encodedPaths = cleanupScript.match(/WORKTREES_B64="([^"]+)"/)?.[1];
+    const decodedPaths = Buffer.from(encodedPaths ?? '', 'base64').toString('utf8');
+    expect(decodedPaths).toContain(canonicalPath);
+    expect(decodedPaths).toContain(ownerPath);
+    expect(setupTaskBranchSpy).toHaveBeenCalled();
+  });
+
   it('throws when managedWorkspaces=true but repoUrl is missing', async () => {
     const ssh = new SshExecutor({
       host: 'localhost',

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -410,6 +410,78 @@ branch refs/heads/${targetBranch}
     expect(setupTaskBranchSpy).toHaveBeenCalled();
   });
 
+  it('retries setup after parsing a stale branch-owner path from setupTaskBranch failure', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+    }) as any;
+
+    const repoHash = computeRepoUrlHash('git@github.com:owner/repo.git');
+    const baseHead = 'abc123def456abc123def456abc123def456abc1';
+    const branchHash = computeBranchHash(
+      'test-task-conflict',
+      'pnpm test',
+      undefined,
+      [],
+      baseHead,
+      '',
+    );
+    const targetBranch = `experiment/test-task-conflict-${branchHash}`;
+    const canonicalPath = `~/.invoker/worktrees/${repoHash}/experiment-test-task-conflict-${branchHash}`;
+    const ownerPath = `/home/testuser/.invoker/worktrees/${repoHash}/experiment-test-task-conflict-stale-owner`;
+    let cleanupScript = '';
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string, phase?: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return [
+          '__INVOKER_BASE_REF__=origin/main',
+          `__INVOKER_BASE_HEAD__=${baseHead}`,
+        ].join('\n');
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      if (phase === 'cleanup_worktree') {
+        cleanupScript = script;
+        return '';
+      }
+      return '';
+    });
+
+    const setupTaskBranchSpy = vi.spyOn(ssh, 'setupTaskBranch')
+      .mockRejectedValueOnce(
+        createSshRemoteScriptError(
+          128,
+          '',
+          `fatal: '${targetBranch}' is already used by worktree at '${ownerPath}'\n`,
+          'setup_branch',
+        ),
+      )
+      .mockResolvedValueOnce(undefined);
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any) => handle,
+    );
+
+    const req = makeRequest({
+      actionType: 'command',
+      actionId: 'test-task-conflict',
+      inputs: {
+        command: 'pnpm test',
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    });
+
+    await ssh.start(req);
+
+    const encodedPaths = cleanupScript.match(/WORKTREES_B64="([^"]+)"/)?.[1];
+    const decodedPaths = Buffer.from(encodedPaths ?? '', 'base64').toString('utf8');
+    expect(decodedPaths).toContain(canonicalPath);
+    expect(decodedPaths).toContain(ownerPath);
+    expect(setupTaskBranchSpy).toHaveBeenCalledTimes(2);
+  });
+
   it('throws when managedWorkspaces=true but repoUrl is missing', async () => {
     const ssh = new SshExecutor({
       host: 'localhost',
@@ -1099,5 +1171,126 @@ describe('SshExecutor entry lifecycle', () => {
     expect(spec.command).toBe('ssh');
     expect(spec.args).toBeTruthy();
     expect(spec.args!.length).toBeGreaterThan(0);
+  });
+
+  it('keeps the task running after process exit until remote record/push finishes', async () => {
+    const finalize = createDeferred<{ commitHash?: string; error?: string }>();
+    const remoteFinalizeSpy = vi
+      .spyOn(ssh as any, 'remoteGitRecordAndPush')
+      .mockImplementation(() => finalize.promise);
+
+    const request = makeRequest({
+      inputs: {
+        command: 'echo hello',
+        repoUrl: 'git@github.com:test/repo.git',
+      },
+    });
+
+    const handle = await ssh.start(request);
+    let completedResponse: any;
+    ssh.onComplete(handle, (response) => {
+      completedResponse = response;
+    });
+
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    sshProcess.emit('close', 0, null);
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(remoteFinalizeSpy).toHaveBeenCalledTimes(1);
+    expect(completedResponse).toBeUndefined();
+    expect((ssh as any).entries.get(handle.executionId)).toBeDefined();
+
+    finalize.resolve({ commitHash: 'abc123def456' });
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(completedResponse).toMatchObject({
+      status: 'completed',
+      outputs: expect.objectContaining({
+        exitCode: 0,
+        commitHash: 'abc123def456',
+      }),
+    });
+  });
+
+  it('fails the task instead of hanging when remote record/push times out', async () => {
+    vi.useFakeTimers();
+    const finalize = createDeferred<{ commitHash?: string; error?: string }>();
+    vi.spyOn(ssh as any, 'remoteGitRecordAndPush').mockImplementation(() => finalize.promise);
+
+    try {
+      const request = makeRequest({
+        inputs: {
+          command: 'echo hello',
+          repoUrl: 'git@github.com:test/repo.git',
+        },
+      });
+
+      const handle = await ssh.start(request);
+      let completedResponse: any;
+      ssh.onComplete(handle, (response) => {
+        completedResponse = response;
+      });
+
+      const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+      sshProcess.emit('close', 0, null);
+
+      await vi.advanceTimersByTimeAsync(20);
+      expect(completedResponse).toBeUndefined();
+
+      finalize.resolve({ error: 'SSH record and push task result timed out after 600000ms' });
+      await vi.advanceTimersByTimeAsync(20);
+
+      expect(completedResponse).toMatchObject({
+        status: 'failed',
+        outputs: expect.objectContaining({
+          exitCode: 1,
+          error: 'SSH record and push task result timed out after 600000ms',
+        }),
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves the primary failure when the remote worktree vanishes during execution and finalize hits the same missing path', async () => {
+    const remoteFinalizeSpy = vi
+      .spyOn(ssh as any, 'remoteGitRecordAndPush')
+      .mockResolvedValue({
+        error: 'remote commit or push failed (code 1): bash: line 8: cd: /tmp/missing-worktree: No such file or directory',
+      });
+
+    const request = makeRequest({
+      inputs: {
+        command: 'echo hello',
+        repoUrl: 'git@github.com:test/repo.git',
+      },
+    });
+
+    const handle = await ssh.start(request);
+    let completedResponse: any;
+    ssh.onComplete(handle, (response) => {
+      completedResponse = response;
+    });
+
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    // Exact scenario: the managed remote worktree disappears while the task is
+    // still running. Execution fails first with uv_cwd / ENOENT, then finalize
+    // fails later when it tries to cd back into that same missing worktree.
+    sshProcess.stderr!.emit('data', Buffer.from('Error: ENOENT: no such file or directory, uv_cwd\n'));
+    sshProcess.stderr!.emit('data', Buffer.from('pnpm: ENOENT: no such file or directory, mkdir \'/tmp/missing-worktree/node_modules/.bin\'\n'));
+    sshProcess.emit('close', 1, null);
+
+    await new Promise((r) => setTimeout(r, 20));
+
+    expect(remoteFinalizeSpy).toHaveBeenCalledTimes(1);
+    expect(completedResponse).toMatchObject({
+      status: 'failed',
+      outputs: expect.objectContaining({
+        exitCode: 1,
+      }),
+    });
+    expect(String(completedResponse.outputs.error)).toContain('uv_cwd');
+    expect(String(completedResponse.outputs.error)).not.toContain('remote commit or push failed');
   });
 });

--- a/packages/execution-engine/src/git-branch-push-recovery.ts
+++ b/packages/execution-engine/src/git-branch-push-recovery.ts
@@ -1,0 +1,61 @@
+export interface BranchPushExecutor {
+  exec(args: string[], cwd: string): Promise<string>;
+}
+
+const BRANCH_PUSH_RACE_PATTERNS = [
+  /cannot lock ref ['"]refs\/heads\/[^'"]+['"]:\s*is at [0-9a-f]+ but expected [0-9a-f]+/i,
+  /reference already exists/i,
+];
+
+export function isGitBranchPushRaceError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return BRANCH_PUSH_RACE_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+async function remoteTreeMatchesLocal(
+  executor: BranchPushExecutor,
+  cwd: string,
+  branch: string,
+): Promise<boolean> {
+  try {
+    await executor.exec(
+      ['fetch', 'origin', `+refs/heads/${branch}:refs/remotes/origin/${branch}`],
+      cwd,
+    );
+    const localTree = (await executor.exec(['rev-parse', 'HEAD^{tree}'], cwd)).trim();
+    const remoteTree = (await executor.exec(['rev-parse', `refs/remotes/origin/${branch}^{tree}`], cwd)).trim();
+    return localTree.length > 0 && localTree === remoteTree;
+  } catch {
+    return false;
+  }
+}
+
+export async function pushBranchWithRecovery(
+  executor: BranchPushExecutor,
+  cwd: string,
+  branch: string,
+  opts?: { maxAttempts?: number },
+): Promise<void> {
+  const maxAttempts = opts?.maxAttempts ?? 3;
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      await executor.exec(['push', '--force', '-u', 'origin', branch], cwd);
+      return;
+    } catch (err) {
+      lastError = err;
+      if (!isGitBranchPushRaceError(err)) {
+        throw err;
+      }
+      if (await remoteTreeMatchesLocal(executor, cwd, branch)) {
+        return;
+      }
+      if (attempt === maxAttempts) {
+        throw err;
+      }
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -2,6 +2,7 @@ import { spawn } from 'node:child_process';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 import type { MergeGateProvider, MergeGateProviderResult, MergeGateApprovalStatus } from './merge-gate-provider.js';
 import { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
+import { pushBranchWithRecovery } from './git-branch-push-recovery.js';
 
 export class GitHubMergeGateProvider implements MergeGateProvider {
   readonly name = 'github';
@@ -22,7 +23,9 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     const ghHead = normalizeBranchForGithubCli(featureBranch);
     console.log(`[merge-gate] createReview: ghBase=${ghBase} apiHead=${ghHead} cwd=${cwd}`);
 
-    await this.exec('git', ['push', '--force', '-u', 'origin', featureBranch], cwd);
+    await pushBranchWithRecovery({
+      exec: (args, execCwd) => this.exec('git', args, execCwd),
+    }, cwd, featureBranch);
 
     const listOutput = await this.exec('gh', [
       'pr', 'list',

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -17,6 +17,7 @@ import type { TaskRunnerCallbacks } from './task-runner.js';
 import type { MergeGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
+import { pushBranchWithRecovery } from './git-branch-push-recovery.js';
 
 // ── Trace logging ────────────────────────────────────────
 
@@ -127,6 +128,20 @@ async function execGitInMergeSafe(
     );
   }
   return host.execGitIn(args, dir);
+}
+
+async function pushFeatureBranchFromMergeClone(
+  host: MergeRunnerHost,
+  cwd: string,
+  featureBranch: string,
+): Promise<void> {
+  await pushBranchWithRecovery(
+    {
+      exec: (args, dir) => execGitInMergeSafe(host, args, dir),
+    },
+    cwd,
+    featureBranch,
+  );
 }
 
 // ── Host interface ───────────────────────────────────────
@@ -613,7 +628,7 @@ export async function approveMergeImpl(
     try {
       mergeTrace('GIT_PUSH', { featureBranch, worktreeDir });
       // Push feature branch directly to origin (GitHub) from the clone
-      await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
+      await pushFeatureBranchFromMergeClone(host, worktreeDir, featureBranch);
       const reviewUrl = await host.execPr(baseBranch, featureBranch, mergeMessage, fullSummary, worktreeDir);
       mergeTrace('PR_CREATED', { featureBranch, baseBranch, reviewUrl });
       console.log(`[merge] Approved: created pull request ${reviewUrl}`);
@@ -853,7 +868,7 @@ export async function publishAfterFixImpl(
     }
 
     // Push feature branch directly to origin (GitHub) from the gate clone
-    await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], consolidateDir);
+    await pushFeatureBranchFromMergeClone(host, consolidateDir, featureBranch);
 
     let fullSummary = summary;
     if (visualProof && host.runVisualProofCapture) {
@@ -1185,7 +1200,7 @@ export async function consolidateAndMergeImpl(
     // Push feature branch to origin so other clones (e.g., the gate clone used
     // by external review providers can access it. The consolidation clone is removed
     // in the finally block, so without this push the branch would be lost.
-    await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
+    await pushFeatureBranchFromMergeClone(host, worktreeDir, featureBranch);
 
     if (visualProof && onFinish === 'pull_request' && host.runVisualProofCapture) {
       const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
@@ -1217,7 +1232,7 @@ export async function consolidateAndMergeImpl(
       }
     } else if (onFinish === 'pull_request') {
       // Push feature branch directly to origin (GitHub) from the clone
-      await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
+      await pushFeatureBranchFromMergeClone(host, worktreeDir, featureBranch);
       const reviewUrl = await host.execPr(baseBranch, featureBranch, workflowName ?? 'Workflow', body, worktreeDir);
       console.log(`[merge] Created pull request: ${reviewUrl}`);
       return reviewUrl;

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -366,7 +366,13 @@ echo ${payloadB64} | base64 -d | bash -se
           headMatchesTargetBranch: abbrevRefMatchesBranch(head, experimentBranch),
         };
       } catch {
-        exactBranchCandidate = undefined;
+        // Worktree discovery is authoritative for branch ownership. If the
+        // follow-up HEAD probe fails, treat the discovered owner path as stale
+        // so it still gets reconciled before recreate.
+        exactBranchCandidate = {
+          path: reuseAbs,
+          headMatchesTargetBranch: false,
+        };
       }
     }
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -26,6 +26,20 @@ import {
   createSshRemoteScriptError,
 } from './ssh-git-exec.js';
 
+const DEFAULT_SSH_REMOTE_CAPTURE_TIMEOUT_MS = 10 * 60 * 1000;
+const SSH_BRANCH_OWNER_CONFLICT_PATTERNS = [
+  /is already used by worktree at '([^']+)'/i,
+  /cannot force update the branch [\s\S]*?used by worktree at '([^']+)'/i,
+];
+
+function getSshRemoteCaptureTimeoutMs(): number {
+  const raw = process.env.INVOKER_SSH_REMOTE_CAPTURE_TIMEOUT_MS?.trim();
+  if (!raw) return DEFAULT_SSH_REMOTE_CAPTURE_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_SSH_REMOTE_CAPTURE_TIMEOUT_MS;
+  return parsed;
+}
+
 export interface SshExecutorConfig {
   host: string;
   user: string;
@@ -90,6 +104,56 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     this.remoteInvokerHome = config.remoteInvokerHome ?? '~/.invoker';
     this.provisionCommand = config.provisionCommand ?? DEFAULT_WORKTREE_PROVISION_COMMAND;
     this.remotePath = process.env.PATH ?? '';
+  }
+
+  private extractManagedOwnerPathFromSetupError(
+    err: unknown,
+    managedPrefix: string,
+  ): string | undefined {
+    const text = err instanceof Error ? err.message : String(err);
+    for (const pattern of SSH_BRANCH_OWNER_CONFLICT_PATTERNS) {
+      const match = text.match(pattern);
+      const ownerPath = match?.[1]?.trim();
+      if (!ownerPath) continue;
+      const normalizedOwnerPath = normalize(ownerPath);
+      if (
+        normalizedOwnerPath === managedPrefix ||
+        normalizedOwnerPath.startsWith(`${managedPrefix}/`)
+      ) {
+        return normalizedOwnerPath;
+      }
+    }
+    return undefined;
+  }
+
+  private async setupTaskBranchWithStaleOwnerFallback(
+    remoteClone: string,
+    request: WorkRequest,
+    handle: ExecutorHandle,
+    opts: {
+      branchName: string;
+      base: string;
+      worktreeDir: string;
+    },
+    managedPrefix: string,
+    canonicalRemoteWt: string,
+  ): Promise<void> {
+    try {
+      await this.setupTaskBranch(remoteClone, request, handle, opts);
+      return;
+    } catch (err) {
+      const ownerPath = this.extractManagedOwnerPathFromSetupError(err, managedPrefix);
+      if (!ownerPath) {
+        throw err;
+      }
+
+      const cleanupScript = buildWorktreeCleanupScript({
+        remoteClone,
+        worktreePaths: [canonicalRemoteWt, ownerPath],
+      });
+      await this.execRemoteCapture(cleanupScript, 'cleanup_worktree');
+      await this.setupTaskBranch(remoteClone, request, handle, opts);
+    }
   }
 
 
@@ -366,9 +430,15 @@ echo ${payloadB64} | base64 -d | bash -se
           headMatchesTargetBranch: abbrevRefMatchesBranch(head, experimentBranch),
         };
       } catch {
-        // Worktree discovery is authoritative for branch ownership. If the
-        // follow-up HEAD probe fails, treat the discovered owner path as stale
-        // so it still gets reconciled before recreate.
+        // Temporary invariant: today we still treat "managed branch appears in
+        // git worktree list" as authoritative ownership for cleanup/recreate.
+        // That only works while Invoker effectively assumes one managed
+        // worktree per branch. This invariant will go away once
+        // multi-worktree-per-branch support lands, so this fallback must be
+        // replaced with worktree identity that does not collapse into branch
+        // ownership.
+        // For now, if the follow-up HEAD probe fails, treat the discovered
+        // owner path as stale so it still gets reconciled before recreate.
         exactBranchCandidate = {
           path: reuseAbs,
           headMatchesTargetBranch: false,
@@ -458,11 +528,11 @@ git -C "$WT" merge-base --is-ancestor "$BASE" HEAD
       await this.mergeRequestUpstreamBranches(request, remoteWt, resolvedBaseRef);
     } else {
       try {
-        await this.setupTaskBranch(remoteClone, request, handle, {
+        await this.setupTaskBranchWithStaleOwnerFallback(remoteClone, request, handle, {
           branchName: experimentBranch,
           base: resolvedBaseRef,
           worktreeDir: remoteWt,
-        });
+        }, managedPrefix, canonicalRemoteWt);
       } catch (err) {
         const wrapped = err instanceof Error ? err : new Error(String(err));
         if (!(wrapped as any).phase) (wrapped as any).phase = 'setup_branch';
@@ -630,6 +700,15 @@ echo ${payloadB64} | base64 -d | bash -se
           mappedError = `Merge conflict merging upstream branch "${branch}" on remote.\nConflicting files:\n${files}`;
         }
 
+        if (!mappedError && exitCode !== 0 && e) {
+          const allOutput = e.outputBuffer.join('');
+          const lines = allOutput.split('\n');
+          const tail = lines.slice(-50).join('\n').trim();
+          if (tail) {
+            mappedError = tail.length > 3000 ? tail.slice(-3000) : tail;
+          }
+        }
+
         let commitHash: string | undefined;
 
         if (finalizeRemote) {
@@ -645,18 +724,9 @@ echo ${payloadB64} | base64 -d | bash -se
           if (fin.error) {
             this.emitOutput(executionId, `[SshExecutor] ${fin.error}\n`);
             if (exitCode === 0) status = 'failed';
-            mappedError = fin.error;
-          }
-        }
-
-        // When the command fails but no specific error was mapped (exit 30/31),
-        // capture the tail of the output buffer so the UI shows what went wrong.
-        if (!mappedError && exitCode !== 0 && e) {
-          const allOutput = e.outputBuffer.join('');
-          const lines = allOutput.split('\n');
-          const tail = lines.slice(-50).join('\n').trim();
-          if (tail) {
-            mappedError = tail.length > 3000 ? tail.slice(-3000) : tail;
+            if (!mappedError || exitCode === 0) {
+              mappedError = fin.error;
+            }
           }
         }
 

--- a/packages/execution-engine/tsconfig.build.json
+++ b/packages/execution-engine/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/protocol/tsconfig.build.json
+++ b/packages/protocol/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/runtime-adapters/package.json
+++ b/packages/runtime-adapters/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/runtime-adapters/tsconfig.build.json
+++ b/packages/runtime-adapters/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/runtime-domain/package.json
+++ b/packages/runtime-domain/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/runtime-domain/tsconfig.build.json
+++ b/packages/runtime-domain/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/runtime-service/package.json
+++ b/packages/runtime-service/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/runtime-service/tsconfig.build.json
+++ b/packages/runtime-service/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/shell/tsconfig.build.json
+++ b/packages/shell/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/transport/tsconfig.build.json
+++ b/packages/transport/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/transport/tsup.config.ts
+++ b/packages/transport/tsup.config.ts
@@ -7,6 +7,7 @@ const root = path.dirname(fileURLToPath(import.meta.url));
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['esm'],
+  tsconfig: 'tsconfig.build.json',
   dts: {
     compilerOptions: {
       module: 'NodeNext',

--- a/packages/workflow-core/package.json
+++ b/packages/workflow-core/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5745,20 +5745,19 @@ describe('Orchestrator', () => {
       expect(failedDeltas).toHaveLength(1);
     });
 
-    it('revertConflictResolution uses agent-agnostic fix failure prefix', () => {
+    it('revertConflictResolution preserves the original task failure as primary when auto-fix fails', () => {
       const { savedError } = orchestrator.beginConflictResolution('t2');
       orchestrator.revertConflictResolution('t2', savedError, 'startup failed');
       const task = orchestrator.getTask('t2')!;
-      expect(task.execution.error).toContain('[Fix with Agent failed] startup failed');
+      expect(task.execution.error).toBe(mergeConflictError);
     });
 
-    it('revertConflictResolution does not duplicate an existing fix failure wrapper', () => {
+    it('revertConflictResolution strips older fix wrappers and restores the original failure', () => {
       const wrappedSavedError =
         '[Fix with Claude failed] first attempt failed\n\n' + mergeConflictError;
       orchestrator.revertConflictResolution('t2', wrappedSavedError, 'second attempt failed');
       const task = orchestrator.getTask('t2')!;
-      expect(task.execution.error).toContain('[Fix with Agent failed] second attempt failed');
-      expect(task.execution.error).not.toContain('first attempt failed');
+      expect(task.execution.error).toBe(mergeConflictError);
       expect(task.execution.mergeConflict).toEqual({
         failedBranch: 'experiment/upstream-branch-abc123',
         conflictFiles: ['src/App.tsx', 'src/utils.ts'],

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1952,9 +1952,7 @@ export class Orchestrator {
     const normalizedSavedError = stripFixFailureWrapper(savedError);
     const mergeConflict = parseMergeConflictError(normalizedSavedError);
 
-    const displayError = fixError
-      ? `[Fix with Agent failed] ${fixError}\n\n${normalizedSavedError}`
-      : savedError;
+    const displayError = normalizedSavedError;
     const completedAt = new Date();
     const changes: TaskStateChanges = {
       status: 'failed',

--- a/packages/workflow-core/tsconfig.build.json
+++ b/packages/workflow-core/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/scripts/check-tsup-dts-build-config.mjs
+++ b/scripts/check-tsup-dts-build-config.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const packagesDir = path.join(repoRoot, 'packages');
+
+const ALLOWED_DTS_TSCONFIGS = new Set(['tsconfig.build.json', 'tsconfig.tsup.json']);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function extractScriptTsconfig(buildScript) {
+  const match = buildScript.match(/--tsconfig\s+([^\s]+)/);
+  return match ? match[1].replace(/^["']|["']$/g, '') : undefined;
+}
+
+function extractConfigTsconfig(tsupConfigSource) {
+  const match = tsupConfigSource.match(/\btsconfig\s*:\s*['"]([^'"]+)['"]/);
+  return match ? match[1] : undefined;
+}
+
+function configEnablesDts(buildScript, tsupConfigSource) {
+  if (typeof buildScript === 'string' && buildScript.includes('--dts')) {
+    return true;
+  }
+  return /\bdts\s*:/.test(tsupConfigSource);
+}
+
+function resolvePackageTsconfig(packageDir, tsconfigRef) {
+  if (!tsconfigRef) return undefined;
+  return path.resolve(packageDir, tsconfigRef);
+}
+
+function assertDedicatedNonCompositeTsconfig(packageName, packageDir, tsconfigRef, failures) {
+  if (!tsconfigRef) {
+    failures.push(`${packageName}: missing explicit tsconfig for tsup DTS build`);
+    return;
+  }
+
+  const baseName = path.basename(tsconfigRef);
+  if (!ALLOWED_DTS_TSCONFIGS.has(baseName)) {
+    failures.push(
+      `${packageName}: tsup DTS build uses disallowed tsconfig "${tsconfigRef}" (expected one of ${Array.from(ALLOWED_DTS_TSCONFIGS).join(', ')})`,
+    );
+    return;
+  }
+
+  const tsconfigPath = resolvePackageTsconfig(packageDir, tsconfigRef);
+  if (!tsconfigPath || !fs.existsSync(tsconfigPath)) {
+    failures.push(`${packageName}: referenced tsconfig "${tsconfigRef}" does not exist`);
+    return;
+  }
+
+  const tsconfig = readJson(tsconfigPath);
+  if (tsconfig?.compilerOptions?.composite !== false) {
+    failures.push(`${packageName}: ${tsconfigRef} must set compilerOptions.composite=false`);
+  }
+}
+
+const failures = [];
+const checkedPackages = [];
+
+for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const packageDir = path.join(packagesDir, entry.name);
+  const packageJsonPath = path.join(packageDir, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) continue;
+
+  const pkg = readJson(packageJsonPath);
+  const buildScript = pkg?.scripts?.build;
+  const tsupConfigPath = path.join(packageDir, 'tsup.config.ts');
+  const tsupConfigSource = fs.existsSync(tsupConfigPath)
+    ? fs.readFileSync(tsupConfigPath, 'utf8')
+    : '';
+
+  const usesTsup = (typeof buildScript === 'string' && /\btsup\b/.test(buildScript)) || tsupConfigSource.length > 0;
+  if (!usesTsup) continue;
+
+  if (!configEnablesDts(buildScript, tsupConfigSource)) continue;
+
+  const tsconfigRef = fs.existsSync(tsupConfigPath)
+    ? extractConfigTsconfig(tsupConfigSource)
+    : extractScriptTsconfig(buildScript);
+
+  checkedPackages.push({
+    packageName: pkg.name ?? entry.name,
+    packageDir,
+    tsconfigRef: tsconfigRef ?? '(missing)',
+  });
+  assertDedicatedNonCompositeTsconfig(pkg.name ?? entry.name, packageDir, tsconfigRef, failures);
+}
+
+if (checkedPackages.length === 0) {
+  console.error('No tsup DTS packages found to validate.');
+  process.exit(1);
+}
+
+console.log('Validated tsup DTS build config for:');
+for (const checked of checkedPackages) {
+  console.log(`- ${checked.packageName}: ${checked.tsconfigRef}`);
+}
+
+if (failures.length > 0) {
+  console.error('\nFailures:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('\nAll tsup DTS packages use dedicated non-composite tsconfigs.');

--- a/scripts/repro/repro-tsup-dts-build-config-guard.sh
+++ b/scripts/repro/repro-tsup-dts-build-config-guard.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Repro/proof: keep the original TS6307 tsup DTS regression fixed by enforcing
+# that every tsup DTS package uses a dedicated non-composite tsconfig, then
+# re-building the packages that originally exposed the failure class.
+#
+# Usage:
+#   bash scripts/repro/repro-tsup-dts-build-config-guard.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "==> guard: every tsup DTS package uses a dedicated non-composite tsconfig"
+node scripts/check-tsup-dts-build-config.mjs
+
+echo
+echo "==> direct regression checks for the original TS6307 packages"
+pnpm --filter @invoker/runtime-domain build
+pnpm --filter @invoker/runtime-adapters build
+pnpm --filter @invoker/transport build
+
+echo
+echo "repro result:"
+echo "- the repo guard confirms every tsup DTS package uses a dedicated build tsconfig"
+echo "- runtime-domain, runtime-adapters, and transport still build successfully"
+echo "- this keeps the original TS6307 class from silently drifting back in"


### PR DESCRIPTION
## Summary
`packages/ui/src/App.tsx` now treats `window.invoker.reportUiPerf` as optional when the renderer runs under Vitest and jsdom. That keeps the perf timer from throwing uncaught `TypeError`s in non-Electron contexts while preserving the same behavior in Electron, where the bridge is expected to exist.

The motivation is to make UI tests model the actual platform boundary instead of crashing on an Electron-only bridge API. The tradeoff is that jsdom can no longer expose missing bridge wiring by exploding at runtime, but that is the correct trade because `reportUiPerf` is only meaningful in the Electron shell.

## Test plan
- [x] GitHub Actions for this PR are green.
