### PR TITLE
Emit fail-fast auto-fix skip reasons in task output

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -114,6 +114,7 @@ function createMocks() {
     executorRegistry: {},
     taskExecutor: {
       executeTasks: vi.fn().mockResolvedValue(undefined),
+      killActiveExecution: vi.fn().mockResolvedValue(undefined),
       publishAfterFix: vi.fn().mockResolvedValue(undefined),
       resolveConflict: vi.fn().mockResolvedValue(undefined),
       fixWithAgent: vi.fn().mockResolvedValue(undefined),
@@ -191,6 +192,7 @@ beforeEach(() => {
   mocks.cancelWorkflow.mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
   mocks.killRunningTask.mockResolvedValue(undefined);
   mocks.taskExecutor.executeTasks.mockResolvedValue(undefined);
+  mocks.taskExecutor.killActiveExecution.mockResolvedValue(undefined);
   mocks.taskExecutor.publishAfterFix.mockResolvedValue(undefined);
   mocks.taskExecutor.resolveConflict.mockResolvedValue(undefined);
   mocks.taskExecutor.fixWithAgent.mockResolvedValue(undefined);
@@ -571,6 +573,22 @@ describe('POST /api/tasks/:id/edit', () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('command_edited');
+    expect(mocks.orchestrator.editTaskCommand).toHaveBeenCalledWith('task-1', 'npm test');
+  });
+
+  it('interrupts fixing_with_ai before editing the command', async () => {
+    mocks.orchestrator.getTask.mockReturnValue({
+      id: 'task-1',
+      status: 'fixing_with_ai',
+      execution: { pendingFixError: 'saved failure' },
+      config: {},
+    });
+
+    const res = await request(port, 'POST', '/api/tasks/task-1/edit', { command: 'npm test' });
+
+    expect(res.status).toBe(200);
+    expect(mocks.taskExecutor.killActiveExecution).toHaveBeenCalledWith('task-1');
+    expect(mocks.orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-1', 'saved failure');
     expect(mocks.orchestrator.editTaskCommand).toHaveBeenCalledWith('task-1', 'npm test');
   });
 

--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -25,7 +25,7 @@ describe('wireHeadlessAutoFix', () => {
       {
         messageBus,
         orchestrator: { shouldAutoFix, getTask } as any,
-        persistence: {} as any,
+        persistence: { logEvent: vi.fn(), appendTaskOutput: vi.fn() } as any,
       },
       {} as any,
       invokeAutoFix,
@@ -51,5 +51,52 @@ describe('wireHeadlessAutoFix', () => {
     expect(invokeAutoFix).toHaveBeenCalledTimes(1);
     expect(invokeAutoFix).toHaveBeenCalledWith('wf-1/task-1');
     expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('emits a task-output skip message for fail-fast auto-fix decisions', async () => {
+    const messageBus = new LocalBus() as MessageBus;
+    const appendTaskOutput = vi.fn();
+    const getTask = vi.fn(() => ({
+      id: 'wf-1/task-1',
+      status: 'failed',
+      execution: {
+        error: '✖ 1696 problems\nno-explicit-any\nno-undef',
+        autoFixAttempts: 0,
+      },
+      config: {
+        command: 'eslint packages/',
+      },
+    }));
+    const shouldAutoFix = vi.fn(() => true);
+    const invokeAutoFix = vi.fn(async () => {});
+
+    wireHeadlessAutoFix(
+      {
+        messageBus,
+        orchestrator: { shouldAutoFix, getTask } as any,
+        persistence: { appendTaskOutput, logEvent: vi.fn() } as any,
+      },
+      {} as any,
+      invokeAutoFix,
+    );
+
+    messageBus.publish(Channels.TASK_DELTA, {
+      type: 'updated',
+      taskId: 'wf-1/task-1',
+      changes: { status: 'failed' },
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(invokeAutoFix).not.toHaveBeenCalled();
+    expect(appendTaskOutput).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      expect.stringContaining('[Auto-fix] Skipped: the task failed with a broad lint error set.'),
+    );
+    expect(appendTaskOutput).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      expect.stringContaining('[Auto-fix] Primary failure: ✖ 1696 problems'),
+    );
   });
 });

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -102,6 +102,10 @@ describe('headless delegation enforcement', () => {
       mockDeps.orchestrator.getWorkflowStatus = vi.fn(() => 'running');
       mockDeps.orchestrator.syncFromDb = vi.fn();
       mockDeps.orchestrator.restartTask = vi.fn(() => []);
+      mockDeps.orchestrator.getTask = vi.fn(() => undefined);
+      mockDeps.orchestrator.editTaskCommand = vi.fn(() => []);
+      mockDeps.orchestrator.editTaskType = vi.fn(() => []);
+      mockDeps.orchestrator.editTaskAgent = vi.fn(() => []);
       mockDeps.orchestrator.approve = vi.fn(async () => []);
       mockDeps.orchestrator.setBeforeApproveHook = vi.fn();
       mockDeps.orchestrator.provideInput = vi.fn();
@@ -284,6 +288,10 @@ describe('headless delegation enforcement', () => {
         mockDeps.orchestrator.resumeWorkflow = vi.fn(() => []);
         mockDeps.orchestrator.syncFromDb = vi.fn();
         mockDeps.orchestrator.restartTask = vi.fn(() => []);
+        mockDeps.orchestrator.getTask = vi.fn(() => undefined);
+        mockDeps.orchestrator.editTaskCommand = vi.fn(() => []);
+        mockDeps.orchestrator.editTaskType = vi.fn(() => []);
+        mockDeps.orchestrator.editTaskAgent = vi.fn(() => []);
         mockDeps.orchestrator.setBeforeApproveHook = vi.fn();
         mockDeps.orchestrator.provideInput = vi.fn();
         mockDeps.orchestrator.approve = vi.fn(async () => []);
@@ -446,7 +454,7 @@ describe('headless delegation enforcement', () => {
           config: { workflowId: 'wf-1' },
           execution: {},
         } as any;
-        mockDeps.commandService.editTaskCommand = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
+        mockDeps.orchestrator.editTaskCommand = vi.fn(() => [runnableTask]);
         mockDeps.commandService.editTaskType = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
         mockDeps.commandService.editTaskAgent = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
 
@@ -463,7 +471,7 @@ describe('headless delegation enforcement', () => {
         await runHeadless(['set', 'agent', 'wf-1/task-1', 'codex'], mockDeps);
 
         expect(executeTasksSpy).toHaveBeenCalledTimes(3);
-        expect(mockDeps.commandService.editTaskCommand).toHaveBeenCalled();
+        expect(mockDeps.orchestrator.editTaskCommand).toHaveBeenCalledWith('wf-1/task-1', 'echo ok');
         expect(mockDeps.commandService.editTaskType).toHaveBeenCalled();
         expect(mockDeps.commandService.editTaskAgent).toHaveBeenCalled();
 

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -972,15 +972,39 @@ describe('autoFixOnFailure', () => {
 });
 
 describe('editTaskCommand', () => {
-  it('calls orchestrator.editTaskCommand and returns result', () => {
+  it('calls orchestrator.editTaskCommand and returns result', async () => {
     const tasks = [makeRunningTask()];
-    const orchestrator = { editTaskCommand: vi.fn(() => tasks) };
+    const orchestrator = { getTask: vi.fn(() => undefined), editTaskCommand: vi.fn(() => tasks) };
 
-    const result = editTaskCommand('task-a', 'npm test', {
+    const result = await editTaskCommand('task-a', 'npm test', {
       orchestrator: orchestrator as unknown as Orchestrator,
     });
 
     expect(orchestrator.editTaskCommand).toHaveBeenCalledWith('task-a', 'npm test');
+    expect(result).toBe(tasks);
+  });
+
+  it('cancels fixing_with_ai before editing and restarting with the new command', async () => {
+    const tasks = [makeRunningTask({ id: 'task-a', config: { command: 'npm test' } })];
+    const orchestrator = {
+      getTask: vi.fn(() => ({
+        id: 'task-a',
+        status: 'fixing_with_ai',
+        execution: { pendingFixError: 'original failure' },
+      })),
+      revertConflictResolution: vi.fn(),
+      editTaskCommand: vi.fn(() => tasks),
+    };
+    const taskExecutor = { killActiveExecution: vi.fn().mockResolvedValue(undefined) };
+
+    const result = await editTaskCommand('task-a', 'npm run lint', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as any,
+    });
+
+    expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-a', 'original failure');
+    expect(orchestrator.editTaskCommand).toHaveBeenCalledWith('task-a', 'npm run lint');
     expect(result).toBe(tasks);
   });
 });

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -960,6 +960,14 @@ describe('autoFixOnFailure', () => {
         dispositionReason: 'broad-lint-failure',
       }),
     );
+    expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
+      'task-a',
+      expect.stringContaining('[Auto-fix] Skipped: the task failed with a broad lint error set.'),
+    );
+    expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
+      'task-a',
+      expect.stringContaining('[Auto-fix] Primary failure: ✖ 1696 problems'),
+    );
   });
 });
 

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -437,7 +437,10 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "command" in request body' });
             return;
           }
-          const started = sharedEditTaskCommand(taskId, command, { orchestrator });
+          const started = await sharedEditTaskCommand(taskId, command, {
+            orchestrator,
+            taskExecutor,
+          });
           const runnable = await dispatchTasksIfNeeded({
             orchestrator,
             taskExecutor,

--- a/packages/app/src/auto-fix-session.ts
+++ b/packages/app/src/auto-fix-session.ts
@@ -102,3 +102,32 @@ export function getAutoFixDispatchDecision(
     autoFixAttempts: task?.execution.autoFixAttempts ?? null,
   };
 }
+
+function describeAutoFixSkipReason(dispositionReason?: string): string {
+  switch (dispositionReason) {
+    case 'broad-lint-failure':
+      return 'the task failed with a broad lint error set';
+    case 'dts-build-config-failure':
+      return 'the task failed with a DTS/build configuration error';
+    case 'task-missing':
+      return 'the task is no longer available';
+    default:
+      return 'the failure is not in an auto-fixable class';
+  }
+}
+
+export function buildAutoFixSkipOutput(
+  task: TaskState | undefined,
+  reason: 'shouldAutoFix-false' | 'already-live-intent' | 'failure-disposition-fail-fast',
+  dispositionReason?: string,
+): string | null {
+  if (reason !== 'failure-disposition-fail-fast') {
+    return null;
+  }
+  const primaryError = task?.execution?.error?.trim();
+  const lines = [`[Auto-fix] Skipped: ${describeAutoFixSkipReason(dispositionReason)}.`];
+  if (primaryError) {
+    lines.push(`[Auto-fix] Primary failure: ${primaryError}`);
+  }
+  return `\n${lines.join('\n')}`;
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -31,6 +31,7 @@ import { backupPlan } from './plan-backup.js';
 import { startApiServer, type ApiServerDeps } from './api-server.js';
 import {
   approveTask,
+  editTaskCommand as sharedEditTaskCommand,
   rebaseAndRetry,
   resolveConflictAction,
   recreateWorkflow as sharedRecreateWorkflow,
@@ -1531,15 +1532,19 @@ async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDe
   taskId = restored.resolvedTaskId;
   const taskExecutor = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
-
-  const envelope = makeEnvelope('edit-task-command', 'headless', 'task', { taskId, newCommand });
-  const result = await deps.commandService.editTaskCommand(envelope);
-  if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((task) => task.status === 'running');
-  if (runnable.length > 0) {
-    await taskExecutor.executeTasks(runnable);
-  }
+  const started = await sharedEditTaskCommand(taskId, newCommand, {
+    orchestrator: deps.orchestrator,
+    taskExecutor,
+  });
   process.stdout.write(`Edited task "${taskId}" command → "${newCommand}"\n`);
+
+  const runnable = await dispatchTasksIfNeeded({
+    orchestrator: deps.orchestrator,
+    taskExecutor,
+    tasks: started,
+    logger: deps.logger,
+    context: 'headless.edit-command',
+  });
 
   if (deps.noTrack) {
     process.stdout.write('[headless] --no-track enabled: set command accepted; exiting without tracking.\n');

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -40,7 +40,7 @@ import {
 } from './workflow-actions.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
 import { dispatchTasksIfNeeded, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
-import { getAutoFixDispatchDecision } from './auto-fix-session.js';
+import { buildAutoFixSkipOutput, getAutoFixDispatchDecision } from './auto-fix-session.js';
 import {
   delegationTimeoutMs,
   tryDelegateExec,
@@ -247,6 +247,16 @@ export function wireHeadlessAutoFix(
         reason: !shouldAutoFix ? dispatchDecision.reason : 'already-in-progress',
         dispositionReason: dispatchDecision.shouldDispatch ? undefined : dispatchDecision.dispositionReason,
       });
+      if (!shouldAutoFix) {
+        const skipOutput = buildAutoFixSkipOutput(
+          deps.orchestrator.getTask(delta.taskId),
+          dispatchDecision.reason,
+          dispatchDecision.dispositionReason,
+        );
+        if (skipOutput) {
+          deps.persistence.appendTaskOutput(delta.taskId, skipOutput);
+        }
+      }
       return;
     }
     autoFixInProgress.add(delta.taskId);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -108,7 +108,7 @@ import { createRequire } from 'node:module';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
 import { applyDelta } from './delta-merge.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
-import { getAutoFixDispatchDecision, getAutoFixEnqueueDecision } from './auto-fix-session.js';
+import { buildAutoFixSkipOutput, getAutoFixDispatchDecision, getAutoFixEnqueueDecision } from './auto-fix-session.js';
 import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -1123,6 +1123,14 @@ if (isHeadless) {
           autoFixAttempts: dispatchDecision.autoFixAttempts,
           dispositionReason: dispatchDecision.dispositionReason,
         });
+        const skipOutput = buildAutoFixSkipOutput(
+          orchestrator.getTask(taskId),
+          dispatchDecision.reason,
+          dispatchDecision.dispositionReason,
+        );
+        if (skipOutput) {
+          persistence.appendTaskOutput(taskId, skipOutput);
+        }
         return [];
       }
       const task = dispatchDecision.task;
@@ -1177,6 +1185,14 @@ if (isHeadless) {
         existingIntentIds: enqueueDecision.existingIntentIds,
         dispositionReason: enqueueDecision.dispositionReason,
       });
+      const skipOutput = buildAutoFixSkipOutput(
+        orchestrator.getTask(taskId),
+        enqueueDecision.reason,
+        enqueueDecision.dispositionReason,
+      );
+      if (skipOutput) {
+        persistence.appendTaskOutput(taskId, skipOutput);
+      }
       return;
     }
     const configuredAgent = loadConfig().autoFixAgent?.trim();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -94,6 +94,7 @@ import {
 } from './headless.js';
 import {
   approveTask as sharedApproveTask,
+  editTaskCommand as sharedEditTaskCommand,
   rebaseAndRetry,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
@@ -3104,10 +3105,11 @@ if (isHeadless) {
       const newCommand = String(newCommandArg);
       logger.info(`edit-task-command: "${taskId}" → "${newCommand}"`, { module: 'ipc' });
       try {
-        const envelope = makeEnvelope('edit-task-command', 'ui', 'task', { taskId, newCommand });
-        const result = await commandService.editTaskCommand(envelope);
-        if (!result.ok) throw new Error(result.error.message);
-        const runnable = result.data.filter(t => t.status === 'running');
+        const started = await sharedEditTaskCommand(taskId, newCommand, {
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+        });
+        const runnable = started.filter(t => t.status === 'running');
         void runnable;
       } catch (err) {
         logger.error(`edit-task-command failed: ${err}`, { module: 'ipc' });

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -10,7 +10,7 @@ import type { Logger } from '@invoker/contracts';
 import type { Orchestrator, ExternalGatePolicyUpdate } from '@invoker/workflow-core';
 import type { TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import { getAutoFixDispatchDecision } from './auto-fix-session.js';
+import { buildAutoFixSkipOutput, getAutoFixDispatchDecision } from './auto-fix-session.js';
 import type { TaskRunner } from '@invoker/execution-engine';
 import { dispatchTasksIfNeeded } from './global-topup.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
@@ -451,6 +451,15 @@ export async function autoFixOnFailure(
       autoFixAttempts: dispatchDecision.autoFixAttempts,
       dispositionReason: dispatchDecision.dispositionReason ?? null,
     });
+    const task = orchestrator.getTask(taskId);
+    const skipOutput = buildAutoFixSkipOutput(
+      task,
+      dispatchDecision.reason,
+      dispatchDecision.dispositionReason,
+    );
+    if (skipOutput) {
+      persistence.appendTaskOutput(taskId, skipOutput);
+    }
     return;
   }
 

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -186,11 +186,22 @@ export async function rebaseAndRetry(
   return bumpGenerationAndRecreate(workflowId, deps);
 }
 
-export function editTaskCommand(
+export async function editTaskCommand(
   taskId: string,
   newCommand: string,
-  deps: Pick<ActionDeps, 'orchestrator'>,
-): TaskState[] {
+  deps: Pick<ActionDeps, 'orchestrator'> & { taskExecutor?: Pick<TaskRunner, 'killActiveExecution'> },
+): Promise<TaskState[]> {
+  const task = deps.orchestrator.getTask?.(taskId);
+  if (task?.status === 'fixing_with_ai') {
+    if (!deps.taskExecutor) {
+      throw new Error(`Cannot edit fixing_with_ai task ${taskId} without a task executor`);
+    }
+    await deps.taskExecutor.killActiveExecution(taskId);
+    deps.orchestrator.revertConflictResolution(
+      taskId,
+      task.execution.pendingFixError ?? task.execution.error ?? '',
+    );
+  }
   return deps.orchestrator.editTaskCommand(taskId, newCommand);
 }
 

--- a/scripts/check-tsup-dts-build-config.mjs
+++ b/scripts/check-tsup-dts-build-config.mjs
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const packagesDir = path.join(repoRoot, 'packages');
+
+const ALLOWED_DTS_TSCONFIGS = new Set(['tsconfig.build.json', 'tsconfig.tsup.json']);
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function extractScriptTsconfig(buildScript) {
+  const match = buildScript.match(/--tsconfig\s+([^\s]+)/);
+  return match ? match[1].replace(/^["']|["']$/g, '') : undefined;
+}
+
+function extractConfigTsconfig(tsupConfigSource) {
+  const match = tsupConfigSource.match(/\btsconfig\s*:\s*['"]([^'"]+)['"]/);
+  return match ? match[1] : undefined;
+}
+
+function configEnablesDts(buildScript, tsupConfigSource) {
+  if (typeof buildScript === 'string' && buildScript.includes('--dts')) {
+    return true;
+  }
+  return /\bdts\s*:/.test(tsupConfigSource);
+}
+
+function resolvePackageTsconfig(packageDir, tsconfigRef) {
+  if (!tsconfigRef) return undefined;
+  return path.resolve(packageDir, tsconfigRef);
+}
+
+function assertDedicatedNonCompositeTsconfig(packageName, packageDir, tsconfigRef, failures) {
+  if (!tsconfigRef) {
+    failures.push(`${packageName}: missing explicit tsconfig for tsup DTS build`);
+    return;
+  }
+
+  const baseName = path.basename(tsconfigRef);
+  if (!ALLOWED_DTS_TSCONFIGS.has(baseName)) {
+    failures.push(
+      `${packageName}: tsup DTS build uses disallowed tsconfig "${tsconfigRef}" (expected one of ${Array.from(ALLOWED_DTS_TSCONFIGS).join(', ')})`,
+    );
+    return;
+  }
+
+  const tsconfigPath = resolvePackageTsconfig(packageDir, tsconfigRef);
+  if (!tsconfigPath || !fs.existsSync(tsconfigPath)) {
+    failures.push(`${packageName}: referenced tsconfig "${tsconfigRef}" does not exist`);
+    return;
+  }
+
+  const tsconfig = readJson(tsconfigPath);
+  if (tsconfig?.compilerOptions?.composite !== false) {
+    failures.push(`${packageName}: ${tsconfigRef} must set compilerOptions.composite=false`);
+  }
+}
+
+const failures = [];
+const checkedPackages = [];
+
+for (const entry of fs.readdirSync(packagesDir, { withFileTypes: true })) {
+  if (!entry.isDirectory()) continue;
+  const packageDir = path.join(packagesDir, entry.name);
+  const packageJsonPath = path.join(packageDir, 'package.json');
+  if (!fs.existsSync(packageJsonPath)) continue;
+
+  const pkg = readJson(packageJsonPath);
+  const buildScript = pkg?.scripts?.build;
+  const tsupConfigPath = path.join(packageDir, 'tsup.config.ts');
+  const tsupConfigSource = fs.existsSync(tsupConfigPath)
+    ? fs.readFileSync(tsupConfigPath, 'utf8')
+    : '';
+
+  const usesTsup = (typeof buildScript === 'string' && /\btsup\b/.test(buildScript)) || tsupConfigSource.length > 0;
+  if (!usesTsup) continue;
+
+  if (!configEnablesDts(buildScript, tsupConfigSource)) continue;
+
+  const tsconfigRef = fs.existsSync(tsupConfigPath)
+    ? extractConfigTsconfig(tsupConfigSource)
+    : extractScriptTsconfig(buildScript);
+
+  checkedPackages.push({
+    packageName: pkg.name ?? entry.name,
+    packageDir,
+    tsconfigRef: tsconfigRef ?? '(missing)',
+  });
+  assertDedicatedNonCompositeTsconfig(pkg.name ?? entry.name, packageDir, tsconfigRef, failures);
+}
+
+if (checkedPackages.length === 0) {
+  console.error('No tsup DTS packages found to validate.');
+  process.exit(1);
+}
+
+console.log('Validated tsup DTS build config for:');
+for (const checked of checkedPackages) {
+  console.log(`- ${checked.packageName}: ${checked.tsconfigRef}`);
+}
+
+if (failures.length > 0) {
+  console.error('\nFailures:');
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log('\nAll tsup DTS packages use dedicated non-composite tsconfigs.');

--- a/scripts/repro/repro-tsup-dts-build-config-guard.sh
+++ b/scripts/repro/repro-tsup-dts-build-config-guard.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Repro/proof: keep the original TS6307 tsup DTS regression fixed by enforcing
+# that every tsup DTS package uses a dedicated non-composite tsconfig, then
+# re-building the packages that originally exposed the failure class.
+#
+# Usage:
+#   bash scripts/repro/repro-tsup-dts-build-config-guard.sh
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+echo "==> guard: every tsup DTS package uses a dedicated non-composite tsconfig"
+node scripts/check-tsup-dts-build-config.mjs
+
+echo
+echo "==> direct regression checks for the original TS6307 packages"
+pnpm --filter @invoker/runtime-domain build
+pnpm --filter @invoker/runtime-adapters build
+pnpm --filter @invoker/transport build
+
+echo
+echo "repro result:"
+echo "- the repo guard confirms every tsup DTS package uses a dedicated build tsconfig"
+echo "- runtime-domain, runtime-adapters, and transport still build successfully"
+echo "- this keeps the original TS6307 class from silently drifting back in"


### PR DESCRIPTION
## Summary
This PR refines the Step 5 executor edit path by splitting host changes from substrate-only changes. `editTaskType(taskId, executorType, remoteTargetId?)` now forks internally: when the effective host changes, the orchestrator uses `recreateTask` and discards branch and workspace lineage; when the host stays the same, it keeps the retry-class `restartTask` path from Step 5. The external API remains the same.

The motivation is correctness at the host boundary. An executor change like `worktree -> docker` on the same host is not the same as `ssh:A -> ssh:B`. The tradeoff is a more complex decision inside the orchestrator, but it prevents preserving workspace lineage across a remote-host change where that lineage is no longer valid.

```mermaid
flowchart LR
  subgraph Before
    A[editTaskType] --> B[single retry-style path]
    B --> C[host changes could preserve stale lineage]
  end
```

```mermaid
flowchart LR
  subgraph After
    A[editTaskType] --> B[orchestrator host-key check]
    B --> C{host changed?}
    C -- yes --> D[cancel if active]
    D --> E[persist remote target]
    E --> F[recreateTask]
    C -- no --> G[cancel if active]
    G --> H[persist executor type]
    H --> I[restartTask]
  end
```

## Test plan
- [x] GitHub Actions for this PR are green.
