### PR TITLE
Fix global topup dispatch after mutations

### DIFF
--- a/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
+++ b/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { createTestHarness, type TestHarness } from '@invoker/test-kit';
+import type { PlanDefinition } from '@invoker/workflow-core';
+import { dispatchStartedTasksWithGlobalTopup } from '../global-topup.js';
+
+const LINEAR_PLAN: PlanDefinition = {
+  name: 'Linear Handoff Repro',
+  onFinish: 'merge',
+  mergeMode: 'automatic',
+  baseBranch: 'master',
+  featureBranch: 'plan/linear-handoff',
+  tasks: [
+    { id: 'A', description: 'Task A', command: 'echo a' },
+    { id: 'B', description: 'Task B', command: 'echo b', dependencies: ['A'] },
+  ],
+};
+
+const PARALLEL_PLAN: PlanDefinition = {
+  name: 'Parallel Handoff Repro',
+  onFinish: 'merge',
+  mergeMode: 'automatic',
+  baseBranch: 'master',
+  featureBranch: 'plan/parallel-handoff',
+  tasks: [
+    { id: 'A', description: 'Task A', command: 'echo a' },
+    { id: 'B', description: 'Task B', command: 'echo b' },
+    { id: 'C', description: 'Task C', command: 'echo c', dependencies: ['A', 'B'] },
+  ],
+};
+
+async function dispatchStarted(h: TestHarness, started: Array<any>, context: string) {
+  return dispatchStartedTasksWithGlobalTopup({
+    orchestrator: h.orchestrator,
+    taskExecutor: h.executor,
+    context,
+    started,
+  });
+}
+
+describe('app-layer handoff repros', () => {
+  let h: TestHarness;
+
+  beforeEach(() => {
+    h = createTestHarness();
+  });
+
+  it('edit-task-command launches restarted task and persists workspacePath', async () => {
+    h.loadAndStart(LINEAR_PLAN);
+    h.failTask('A', 'broken');
+
+    const started = h.orchestrator.editTaskCommand('A', 'echo fixed');
+    expect(started.some((task) => task.id.endsWith('/A') && task.status === 'running')).toBe(true);
+    expect(h.getTask('A')!.execution.workspacePath).toBeUndefined();
+
+    await dispatchStarted(h, started, 'test.edit-task-command');
+
+    expect(h.getTask('A')!.execution.workspacePath).toBe('/tmp/mock-worktree');
+    expect(h.getTask('A')!.status).toBe('completed');
+  });
+
+  it('edit-task-type launches restarted task and persists workspacePath', async () => {
+    h.loadAndStart(LINEAR_PLAN);
+    h.failTask('A', 'broken');
+
+    const started = h.orchestrator.editTaskType('A', 'worktree');
+    expect(started.some((task) => task.id.endsWith('/A') && task.status === 'running')).toBe(true);
+    expect(h.getTask('A')!.execution.workspacePath).toBeUndefined();
+
+    await dispatchStarted(h, started, 'test.edit-task-type');
+
+    expect(h.getTask('A')!.execution.workspacePath).toBe('/tmp/mock-worktree');
+    expect(h.getTask('A')!.status).toBe('completed');
+  });
+
+  it('edit-task-agent launches restarted task and persists workspacePath', async () => {
+    h.loadAndStart(LINEAR_PLAN);
+    h.failTask('A', 'broken');
+
+    const started = h.orchestrator.editTaskAgent('A', 'codex');
+    expect(started.some((task) => task.id.endsWith('/A') && task.status === 'running')).toBe(true);
+    expect(h.getTask('A')!.execution.workspacePath).toBeUndefined();
+
+    await dispatchStarted(h, started, 'test.edit-task-agent');
+
+    expect(h.getTask('A')!.execution.workspacePath).toBe('/tmp/mock-worktree');
+    expect(h.getTask('A')!.status).toBe('completed');
+  });
+
+  it('set-task-external-gate-policies launches newly unblocked task and persists workspacePath', async () => {
+    h.orchestrator.loadPlan({
+      name: 'upstream-workflow',
+      tasks: [{ id: 'verify', description: 'prereq task', command: 'echo verify' }],
+    });
+    const prereqTaskId = h.getTask('verify')!.id;
+    const prereqWorkflowId = prereqTaskId.split('/')[0]!;
+    const prereqMergeId = `__merge__${prereqWorkflowId}`;
+
+    h.orchestrator.loadPlan({
+      name: 'downstream-workflow',
+      tasks: [
+        {
+          id: 'leaf',
+          description: 'waits for upstream merge completion',
+          command: 'echo leaf',
+          externalDependencies: [{ workflowId: prereqWorkflowId, gatePolicy: 'completed' }],
+        },
+      ],
+    });
+    const leafId = h.getTask('leaf')!.id;
+
+    h.orchestrator.startExecution();
+    h.orchestrator.handleWorkerResponse({
+      requestId: 'complete-prereq',
+      actionId: prereqTaskId,
+      executionGeneration: h.getTask(prereqTaskId)!.execution.generation ?? 0,
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    });
+    h.orchestrator.setTaskAwaitingApproval(prereqMergeId);
+
+    const started = h.orchestrator.setTaskExternalGatePolicies(leafId, [
+      { workflowId: prereqWorkflowId, gatePolicy: 'review_ready' },
+    ]);
+    expect(started.some((task) => task.id === leafId && task.status === 'running')).toBe(true);
+    expect(h.getTask('leaf')!.execution.workspacePath).toBeUndefined();
+
+    await dispatchStarted(h, started, 'test.set-task-external-gate-policies');
+
+    expect(h.getTask('leaf')!.execution.workspacePath).toBe('/tmp/mock-worktree');
+    expect(h.getTask('leaf')!.status).toBe('completed');
+  });
+
+  it('replace-task launches replacement tasks and persists workspacePath', async () => {
+    h.loadAndStart(LINEAR_PLAN);
+    h.failTask('A', 'broken');
+
+    const started = h.orchestrator.replaceTask('A', [
+      { id: 'A-fix-1', description: 'Fix part 1', command: 'echo fix1' },
+      { id: 'A-fix-2', description: 'Fix part 2', command: 'echo fix2', dependencies: ['A-fix-1'] },
+    ]);
+    expect(started.some((task) => task.id.endsWith('/A-fix-1') && task.status === 'running')).toBe(true);
+    expect(h.getTask('A-fix-1')!.execution.workspacePath).toBeUndefined();
+
+    await dispatchStarted(h, started, 'test.replace-task');
+
+    expect(h.getTask('A-fix-1')!.execution.workspacePath).toBe('/tmp/mock-worktree');
+    expect(h.getTask('A-fix-1')!.status).toBe('completed');
+  });
+
+  it('set-merge-branch relaunches merge task and persists workspacePath', async () => {
+    h.loadAndStart(PARALLEL_PLAN);
+    h.completeTask('A');
+    h.completeTask('B');
+    h.completeTask('C');
+
+    const mergeTaskId = h.getAllTasks().find((task) => task.config.isMergeNode)!.id;
+    const workflowId = h.getTask(mergeTaskId)!.config.workflowId!;
+    await h.executor.executeTasks([h.getTask(mergeTaskId)!]);
+    expect(h.getTask(mergeTaskId)!.status).toBe('completed');
+
+    h.persistence.updateWorkflow(workflowId, { baseBranch: 'develop' });
+    const started = h.orchestrator.restartTask(mergeTaskId);
+    expect(started.some((task) => task.id === mergeTaskId && task.status === 'running')).toBe(true);
+    expect(h.getTask(mergeTaskId)!.execution.workspacePath).toBe('/tmp/mock-merge-worktree');
+
+    await dispatchStarted(h, started, 'test.set-merge-branch');
+
+    expect(h.getTask(mergeTaskId)!.execution.workspacePath).toBe('/tmp/mock-merge-worktree');
+    expect(h.getTask(mergeTaskId)!.status).toBe('completed');
+    expect(h.persistence.loadWorkflow(workflowId).baseBranch).toBe('develop');
+  });
+
+  it('standalone-owner set-merge-branch uses the same handoff and persists workspacePath', async () => {
+    h.loadAndStart(PARALLEL_PLAN);
+    h.completeTask('A');
+    h.completeTask('B');
+    h.completeTask('C');
+
+    const mergeTaskId = h.getAllTasks().find((task) => task.config.isMergeNode)!.id;
+    const workflowId = h.getTask(mergeTaskId)!.config.workflowId!;
+    await h.executor.executeTasks([h.getTask(mergeTaskId)!]);
+
+    h.persistence.updateWorkflow(workflowId, { baseBranch: 'release' });
+    const started = h.orchestrator.restartTask(mergeTaskId);
+    await dispatchStarted(h, started, 'test.standalone.set-merge-branch');
+
+    expect(h.getTask(mergeTaskId)!.execution.workspacePath).toBe('/tmp/mock-merge-worktree');
+    expect(h.getTask(mergeTaskId)!.status).toBe('completed');
+    expect(h.persistence.loadWorkflow(workflowId).baseBranch).toBe('release');
+  });
+});

--- a/packages/app/src/__tests__/global-topup.test.ts
+++ b/packages/app/src/__tests__/global-topup.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from '../global-topup.js';
+
+function makeTask(id: string, status: TaskState['status'], attemptId?: string): TaskState {
+  return {
+    id,
+    description: id,
+    status,
+    dependencies: [],
+    createdAt: new Date(),
+    config: {},
+    execution: {
+      ...(attemptId ? { selectedAttemptId: attemptId } : {}),
+    },
+  } as TaskState;
+}
+
+describe('global-topup helpers', () => {
+  it('dispatches scoped started tasks before running global top-up', async () => {
+    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
+    const topupTask = makeTask('topup-task', 'running', 'attempt-topup');
+    const orchestrator = {
+      startExecution: vi.fn().mockReturnValue([scoped, topupTask]),
+    };
+    const taskExecutor = {
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: orchestrator as any,
+      taskExecutor: taskExecutor as any,
+      context: 'test.dispatch',
+      started: [scoped],
+    });
+
+    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
+    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
+    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [topupTask]);
+    expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
+    expect(result.runnable).toEqual([scoped]);
+    expect(result.topup).toEqual([topupTask]);
+  });
+
+  it('executeGlobalTopup skips tasks already marked as dispatched', async () => {
+    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
+    const topupTask = makeTask('topup-task', 'running', 'attempt-topup');
+    const orchestrator = {
+      startExecution: vi.fn().mockReturnValue([scoped, topupTask]),
+    };
+    const taskExecutor = {
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const topup = await executeGlobalTopup({
+      orchestrator: orchestrator as any,
+      taskExecutor: taskExecutor as any,
+      context: 'test.topup',
+      alreadyDispatched: [scoped],
+    });
+
+    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
+    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([topupTask]);
+    expect(topup).toEqual([topupTask]);
+  });
+
+  it('finalizeMutationWithGlobalTopup dispatches started runnable work', async () => {
+    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
+    const orchestrator = {
+      startExecution: vi.fn().mockReturnValue([]),
+    };
+    const taskExecutor = {
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await finalizeMutationWithGlobalTopup({
+      orchestrator: orchestrator as any,
+      taskExecutor: taskExecutor as any,
+      context: 'test.finalize',
+      started: [scoped],
+    });
+
+    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([scoped]);
+    expect(result.started).toEqual([scoped]);
+    expect(result.topup).toEqual([]);
+  });
+});

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -455,6 +455,8 @@ describe('headless delegation enforcement', () => {
         mockDeps.commandService.editTaskCommand = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
         mockDeps.commandService.editTaskType = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
         mockDeps.commandService.editTaskAgent = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
+        mockDeps.commandService.setTaskExternalGatePolicies = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
+        mockDeps.commandService.replaceTask = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
 
         const executeTasksSpy = vi
           .spyOn(TaskRunner.prototype, 'executeTasks')
@@ -467,11 +469,17 @@ describe('headless delegation enforcement', () => {
         await runHeadless(['set', 'executor', 'wf-1/task-1', 'shell'], mockDeps);
         taskStatus = 'running';
         await runHeadless(['set', 'agent', 'wf-1/task-1', 'codex'], mockDeps);
+        taskStatus = 'running';
+        await runHeadless(['set', 'gate-policy', 'wf-1/task-1', 'wf-upstream', 'review_ready'], mockDeps);
+        taskStatus = 'running';
+        await runHeadless(['replace-task', 'wf-1/task-1', '[{\"id\":\"fix\",\"description\":\"Fix\",\"command\":\"echo fix\"}]'], mockDeps);
 
-        expect(executeTasksSpy).toHaveBeenCalledTimes(3);
+        expect(executeTasksSpy).toHaveBeenCalledTimes(5);
         expect(mockDeps.commandService.editTaskCommand).toHaveBeenCalled();
         expect(mockDeps.commandService.editTaskType).toHaveBeenCalled();
         expect(mockDeps.commandService.editTaskAgent).toHaveBeenCalled();
+        expect(mockDeps.commandService.setTaskExternalGatePolicies).toHaveBeenCalled();
+        expect(mockDeps.commandService.replaceTask).toHaveBeenCalled();
 
         executeTasksSpy.mockRestore();
       });
@@ -531,7 +539,8 @@ describe('headless delegation enforcement', () => {
 
         await runHeadless(['approve', 'wf-1/task-a'], mockDeps);
 
-        expect(executeTasksSpy).toHaveBeenCalledTimes(1);
+        expect(executeTasksSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+        expect(executeTasksSpy).toHaveBeenCalledWith([runnableTask]);
         expect(mockDeps.commandService.approve).toHaveBeenCalled();
 
         executeTasksSpy.mockRestore();

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -58,6 +58,34 @@ export async function executeGlobalTopup({
 }
 
 /**
+ * Dispatch mutation-scoped runnable work first, then top up any additional
+ * globally ready tasks without double-launching the scoped set.
+ */
+export async function dispatchStartedTasksWithGlobalTopup({
+  orchestrator,
+  taskExecutor,
+  logger,
+  context,
+  started = [],
+}: MutationTopupParams): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
+  const runnable = started.filter((task) => task.status === 'running');
+  if (runnable.length > 0) {
+    logger?.info(
+      `[global-topup] ${context}: dispatching ${runnable.length} scoped task(s): [${runnable.map((task) => task.id).join(', ')}]`,
+    );
+    await taskExecutor.executeTasks(runnable);
+  }
+  const topup = await executeGlobalTopup({
+    orchestrator,
+    taskExecutor,
+    logger,
+    context,
+    alreadyDispatched: runnable,
+  });
+  return { runnable, topup };
+}
+
+/**
  * Shared post-mutation scheduler refill.
  * Mutations that can free global capacity should exit through this helper
  * so globally ready work is launched before returning to the caller.
@@ -69,13 +97,12 @@ export async function finalizeMutationWithGlobalTopup({
   context,
   started = [],
 }: MutationTopupParams): Promise<{ started: TaskState[]; topup: TaskState[] }> {
-  const runnable = started.filter((task) => task.status === 'running');
-  const topup = await executeGlobalTopup({
+  const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator,
     taskExecutor,
     logger,
     context,
-    alreadyDispatched: runnable,
+    started,
   });
   return { started, topup };
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -11,7 +11,7 @@
 
 import type { Logger } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
-import type { Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
+import type { Orchestrator, CommandService, TaskDelta, TaskReplacementDef, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import { Channels } from '@invoker/transport';
@@ -39,7 +39,7 @@ import {
   finalizeAppliedFix,
 } from './workflow-actions.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
-import { executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
 import {
   delegationTimeoutMs,
   tryDelegateExec,
@@ -592,6 +592,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'recreate-task':
       await headlessRecreateTask(args[1], deps);
       break;
+    case 'replace-task':
+      await headlessReplaceTask(args[1], args[2], deps);
+      break;
     case 'rebase':
       await headlessRebaseAndRetry(args[1], deps);
       break;
@@ -754,6 +757,7 @@ ${BOLD}Execute:${RESET}
   retry-task <taskId>                                 Retry a single failed/stuck task
   recreate <workflowId>                                Recreate workflow: wipe all state, new generation
   recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
+  replace-task <taskId> <replacementTasksJson>        Replace a task with new task definitions
   rebase <taskId>                                     Refresh pool base + nuclear restart
   fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
   resolve-conflict <taskId> [claude|codex]            Resolve merge conflict + restart
@@ -1080,13 +1084,12 @@ async function headlessRestart(taskId: string, deps: HeadlessDeps): Promise<void
 
   const taskExecutor = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
-  void runnable;
-  const topup = await executeGlobalTopup({
+  const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
     taskExecutor,
     logger: deps.logger,
     context: 'headless.restart-task',
-    alreadyDispatched: runnable,
+    started: result.data,
   });
   if (runnable.length + topup.length === 0) {
     autoFix.unsubscribe();
@@ -1221,12 +1224,12 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
   const autoFix = wireHeadlessAutoFix(deps, te);
   const started = await rebaseAndRetry(taskId, { ...deps, taskExecutor: te });
   const runnable = started.filter(t => t.status === 'running');
-  const topup = await executeGlobalTopup({
+  const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
     taskExecutor: te,
     logger: deps.logger,
     context: 'headless.rebase-and-retry',
-    alreadyDispatched: runnable,
+    started,
   });
   if (runnable.length + topup.length === 0) {
     autoFix.unsubscribe();
@@ -1314,13 +1317,13 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
   remoteFetchForPool.enabled = false;
   let topup: TaskState[] = [];
   try {
-    topup = await executeGlobalTopup({
+    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
       orchestrator: deps.orchestrator,
       taskExecutor: te,
       logger: deps.logger,
       context: 'headless.recreate-task',
-      alreadyDispatched: runnable,
-    });
+      started,
+    }));
   } finally {
     remoteFetchForPool.enabled = true;
   }
@@ -1342,6 +1345,42 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
     });
   }
   autoFix.unsubscribe();
+}
+
+async function headlessReplaceTask(
+  taskId: string,
+  replacementTasksJson: string | undefined,
+  deps: HeadlessDeps,
+): Promise<void> {
+  if (!taskId || !replacementTasksJson) {
+    throw new Error('Missing arguments. Usage: --headless replace-task <taskId> <replacementTasksJson>');
+  }
+  let replacementTasks: TaskReplacementDef[];
+  try {
+    const parsed = JSON.parse(replacementTasksJson) as unknown;
+    if (!Array.isArray(parsed)) throw new Error('Replacement tasks must be a JSON array');
+    replacementTasks = parsed as TaskReplacementDef[];
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`Invalid replacementTasks JSON: ${reason}`);
+  }
+
+  const envelope = makeEnvelope('replace-task', 'headless', 'task', { taskId, replacementTasks });
+  const result = await deps.commandService.replaceTask(envelope);
+  if (!result.ok) throw new Error(result.error.message);
+
+  const taskExecutor = createHeadlessExecutor(deps);
+  const { runnable } = await dispatchStartedTasksWithGlobalTopup({
+    orchestrator: deps.orchestrator,
+    taskExecutor,
+    logger: deps.logger,
+    context: 'headless.replace-task',
+    started: result.data,
+  });
+
+  process.stdout.write(
+    `Replaced task ${taskId} with ${replacementTasks.length} task(s); launched ${runnable.length} task(s)\n`,
+  );
 }
 
 async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {
@@ -1440,13 +1479,13 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
   remoteFetchForPool.enabled = false;
   let topup: TaskState[] = [];
   try {
-    topup = await executeGlobalTopup({
+    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
       orchestrator: deps.orchestrator,
       taskExecutor: te,
       logger: deps.logger,
       context: 'headless.retry-workflow',
-      alreadyDispatched: runnable,
-    });
+      started: dispatchable,
+    }));
   } finally {
     remoteFetchForPool.enabled = true;
   }
@@ -1856,7 +1895,10 @@ async function headlessSetGatePolicy(args: string[], deps: HeadlessDeps): Promis
   const result = await deps.commandService.setTaskExternalGatePolicies(envelope);
   if (!result.ok) throw new Error(result.error.message);
   const runnable = result.data.filter((t) => t.status === 'running');
-  void runnable;
+  if (runnable.length > 0) {
+    const taskExecutor = createHeadlessExecutor(deps);
+    await taskExecutor.executeTasks(runnable);
+  }
   process.stdout.write(
     `Updated gate policy for ${taskId}: ${workflowId}/${depTaskId} -> ${gatePolicy} (${runnable.length} task(s) started)\n`,
   );

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -111,7 +111,7 @@ import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
-import { executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
 import { computeDeferredLaunchTiming } from './deferred-runnable.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
@@ -609,8 +609,15 @@ if (isHeadless) {
             const tasks = persistence.loadTasks(workflowId);
             const mergeTask = tasks.find((task) => task.config.isMergeNode);
             if (!mergeTask) return undefined;
+            const executor = createStandaloneTaskExecutor();
             const started = orchestrator.restartTask(mergeTask.id);
-            void started;
+            await dispatchStartedTasksWithGlobalTopup({
+              orchestrator,
+              taskExecutor: executor,
+              logger,
+              context: 'standalone.set-merge-branch',
+              started,
+            });
             return undefined;
           }
           case 'invoker:replace-task': {
@@ -1603,6 +1610,11 @@ if (isHeadless) {
         args.push(update.gatePolicy);
         return { channel: 'headless.exec', request: { args } };
       }
+      case 'invoker:replace-task':
+        return {
+          channel: 'headless.exec',
+          request: { args: ['replace-task', String(arg0), JSON.stringify(Array.isArray(arg1) ? arg1 : [])] },
+        };
       default:
         return null;
     }
@@ -2628,12 +2640,12 @@ if (isHeadless) {
           `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task runnable=${runnable.length} [${runnable.map((t) => t.id).join(', ') || '(none)'}] → taskExecutor.executeTasks`,
           { module: 'ipc' },
         );
-        await executeGlobalTopup({
+        await dispatchStartedTasksWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
           logger,
           context: 'ipc.restart-task',
-          alreadyDispatched: runnable,
+          started,
         });
       } catch (err) {
         logger.error(`restart-task failed: ${err}`, { module: 'ipc' });
@@ -2738,15 +2750,14 @@ if (isHeadless) {
           context: 'ipc.recreate-workflow',
         });
         const started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
-        const runnable = started.filter(t => t.status === 'running');
         remoteFetchForPool.enabled = false;
         try {
-          await executeGlobalTopup({
+          await dispatchStartedTasksWithGlobalTopup({
             orchestrator,
             taskExecutor: requireTaskExecutor(),
             logger,
             context: 'ipc.recreate-workflow',
-            alreadyDispatched: runnable,
+            started,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -2768,15 +2779,14 @@ if (isHeadless) {
       try {
         await preemptTaskSubgraph(taskId);
         const started = sharedRecreateTask(taskId, { persistence, orchestrator });
-        const runnable = started.filter(t => t.status === 'running');
         remoteFetchForPool.enabled = false;
         try {
-          await executeGlobalTopup({
+          await dispatchStartedTasksWithGlobalTopup({
             orchestrator,
             taskExecutor: requireTaskExecutor(),
             logger,
             context: 'ipc.recreate-task',
-            alreadyDispatched: runnable,
+            started,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -2805,15 +2815,14 @@ if (isHeadless) {
         const envelope = makeEnvelope('retry-workflow', 'ui', 'workflow', { workflowId });
         const result = await commandService.retryWorkflow(envelope);
         if (!result.ok) throw new Error(result.error.message);
-        const runnable = result.data.filter(t => t.status === 'running');
         remoteFetchForPool.enabled = false;
         try {
-          await executeGlobalTopup({
+          await dispatchStartedTasksWithGlobalTopup({
             orchestrator,
             taskExecutor: requireTaskExecutor(),
             logger,
             context: 'ipc.retry-workflow',
-            alreadyDispatched: runnable,
+            started: result.data,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -2847,13 +2856,12 @@ if (isHeadless) {
           repoRoot,
           taskExecutor: requireTaskExecutor(),
         });
-        const runnable = started.filter(t => t.status === 'running');
-        await executeGlobalTopup({
+        await dispatchStartedTasksWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
           logger,
           context: 'ipc.rebase-and-retry',
-          alreadyDispatched: runnable,
+          started,
         });
       } catch (err) {
         logger.error(`rebase-and-retry failed: ${err}`, { module: 'ipc' });
@@ -2873,7 +2881,13 @@ if (isHeadless) {
         const mergeTask = tasks.find(t => t.config.isMergeNode);
         if (mergeTask) {
           const started = orchestrator.restartTask(mergeTask.id);
-          void started;
+          await dispatchStartedTasksWithGlobalTopup({
+            orchestrator,
+            taskExecutor: requireTaskExecutor(),
+            logger,
+            context: 'ipc.set-merge-branch',
+            started,
+          });
         }
       } catch (err) {
         logger.error(`set-merge-branch failed: ${err}`, { module: 'ipc' });
@@ -3017,8 +3031,13 @@ if (isHeadless) {
         const envelope = makeEnvelope('edit-task-command', 'ui', 'task', { taskId, newCommand });
         const result = await commandService.editTaskCommand(envelope);
         if (!result.ok) throw new Error(result.error.message);
-        const runnable = result.data.filter(t => t.status === 'running');
-        void runnable;
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.edit-task-command',
+          started: result.data,
+        });
       } catch (err) {
         logger.error(`edit-task-command failed: ${err}`, { module: 'ipc' });
         throw err;
@@ -3034,8 +3053,13 @@ if (isHeadless) {
         const envelope = makeEnvelope('edit-task-type', 'ui', 'task', { taskId, executorType, remoteTargetId });
         const result = await commandService.editTaskType(envelope);
         if (!result.ok) throw new Error(result.error.message);
-        const runnable = result.data.filter(t => t.status === 'running');
-        void runnable;
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.edit-task-type',
+          started: result.data,
+        });
       } catch (err) {
         logger.error(`edit-task-type failed: ${err}`, { module: 'ipc' });
         throw err;
@@ -3050,8 +3074,13 @@ if (isHeadless) {
         const envelope = makeEnvelope('edit-task-agent', 'ui', 'task', { taskId, agentName });
         const result = await commandService.editTaskAgent(envelope);
         if (!result.ok) throw new Error(result.error.message);
-        const runnable = result.data.filter(t => t.status === 'running');
-        void runnable;
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.edit-task-agent',
+          started: result.data,
+        });
       } catch (err) {
         logger.error(`edit-task-agent failed: ${err}`, { module: 'ipc' });
         throw err;
@@ -3068,8 +3097,13 @@ if (isHeadless) {
           const envelope = makeEnvelope('set-gate-policies', 'ui', 'task', { taskId, updates });
           const result = await commandService.setTaskExternalGatePolicies(envelope);
           if (!result.ok) throw new Error(result.error.message);
-          const runnable = result.data.filter((t) => t.status === 'running');
-          void runnable;
+          await dispatchStartedTasksWithGlobalTopup({
+            orchestrator,
+            taskExecutor: requireTaskExecutor(),
+            logger,
+            context: 'ipc.set-task-external-gate-policies',
+            started: result.data,
+          });
         } catch (err) {
           logger.error(`set-task-external-gate-policies failed: ${err}`, { module: 'ipc' });
           throw err;
@@ -3096,8 +3130,13 @@ if (isHeadless) {
         });
         const result = await commandService.replaceTask(envelope);
         if (!result.ok) throw new Error(result.error.message);
-        const runnable = result.data.filter((t) => t.status === 'running');
-        void runnable;
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.replace-task',
+          started: result.data,
+        });
         return result.data;
       } catch (err) {
         logger.error(`replace-task failed: ${err}`, { module: 'ipc' });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3022,7 +3022,6 @@ if (isHeadless) {
       },
     );
 
-
     registerGuiMutationHandler('invoker:edit-task-command', async (taskIdArg: unknown, newCommandArg: unknown) => {
       const taskId = String(taskIdArg);
       const newCommand = String(newCommandArg);


### PR DESCRIPTION
## Summary
This change centralizes post-mutation scheduling in `packages/app/src/global-topup.ts` so mutation handlers first dispatch the work they themselves started, then refill idle capacity with any remaining globally ready tasks. The main consumer is the merge-branch mutation path in `packages/app/src/main.ts`, which now preserves the runnable set returned by the mutation instead of dropping it on the floor.

## Problem
Post-mutation flows were not using one authoritative dispatch path. Some handlers started local runnable work, some topped up global capacity, and some effectively dropped runnable tasks on the floor.

## Root Cause
Dispatch ordering and runnable filtering were duplicated across mutation call sites instead of being modeled as one shared post-mutation step. That made it easy for a mutation path to lose the tasks it had just made runnable.

## Approach
Move post-mutation dispatch into a shared helper that always does the same two things in order: start the runnable work created by the mutation itself, then fill any remaining capacity from the global ready set.

## Main Changes
- add a shared post-mutation dispatch path in `packages/app/src/global-topup.ts`
- update mutation handlers to route through the shared helper
- preserve the runnable set returned by merge-branch mutations instead of recomputing and losing it

## Why This Fix Is Right
The failure was about ordering, not about raw executor capacity. Centralizing the dispatch sequence makes the invariant explicit and keeps each mutation path from re-implementing slightly different runnable selection logic.

## Tradeoffs And Considerations
The tradeoff is that more mutation handlers now depend on one shared helper. That increases coupling slightly, but it is the right coupling because post-mutation dispatch is supposed to be one consistent control-plane decision, not a per-handler policy.

## Before
```mermaid
flowchart LR
  M[Mutation handler] --> A[start some local runnable tasks]
  M --> B[maybe top up globally]
  A --> C[inconsistent runnable filtering]
  B --> D[mutation-created runnable work could be lost]
```

## After
```mermaid
flowchart LR
  M[Mutation handler] --> S[Start scoped runnable tasks]
  M --> T[Global top-up]
  S --> D[TaskExecutor.executeTasks]
  T --> G[Start additional globally ready tasks]
  G --> K[Dedup by running execution key]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Fix global topup dispatch after mutations`
