### PR TITLE
Mix attemptId into branch hash and gate workspace cleanup

### DIFF
--- a/packages/app/src/__tests__/rebase-and-retry.test.ts
+++ b/packages/app/src/__tests__/rebase-and-retry.test.ts
@@ -84,13 +84,24 @@ function makeTaskState(overrides: {
 
 describe('rebase-and-retry: pool mirror cleanup before restart', { timeout: 120_000 }, () => {
   let tmpDir: string;
+  let prevCleanupEnv: string | undefined;
 
   beforeEach(() => {
+    // This suite specifically validates managed-branch cleanup behavior, which
+    // is gated behind INVOKER_ENABLE_WORKSPACE_CLEANUP. Force-enable for the
+    // duration of the suite; production default (off) is covered elsewhere.
+    prevCleanupEnv = process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+    process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = '1';
     tmpDir = createTempRepo();
   });
 
   afterEach(() => {
     rmSync(tmpDir, { recursive: true, force: true });
+    if (prevCleanupEnv === undefined) {
+      delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+    } else {
+      process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = prevCleanupEnv;
+    }
   });
 
   function buildHarness() {

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -307,7 +307,10 @@ branch refs/heads/experiment/test-task-oldhash
     expect(err.branch).toMatch(/^experiment\/test-task-[0-9a-f]{8}$/);
   });
 
-  it('cleans up the existing branch-owner worktree before recreating a conflicting target branch', async () => {
+  it('cleans up the existing branch-owner worktree before recreating a conflicting target branch (when cleanup enabled)', async () => {
+    const prevCleanup = process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+    process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = '1';
+
     const ssh = new SshExecutor({
       host: 'localhost',
       user: 'testuser',
@@ -365,12 +368,20 @@ branch refs/heads/${targetBranch}
       },
     });
 
-    await ssh.start(req);
+    try {
+      await ssh.start(req);
 
-    const encodedPaths = cleanupScript.match(/WORKTREES_B64="([^"]+)"/)?.[1];
-    const decodedPaths = Buffer.from(encodedPaths ?? '', 'base64').toString('utf8');
-    expect(decodedPaths).toContain(ownerPath);
-    expect(setupTaskBranchSpy).toHaveBeenCalled();
+      const encodedPaths = cleanupScript.match(/WORKTREES_B64="([^"]+)"/)?.[1];
+      const decodedPaths = Buffer.from(encodedPaths ?? '', 'base64').toString('utf8');
+      expect(decodedPaths).toContain(ownerPath);
+      expect(setupTaskBranchSpy).toHaveBeenCalled();
+    } finally {
+      if (prevCleanup === undefined) {
+        delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+      } else {
+        process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = prevCleanup;
+      }
+    }
   });
 
   it('throws when managedWorkspaces=true but repoUrl is missing', async () => {

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1567,7 +1567,7 @@ describe('TaskRunner', () => {
   });
 
   describe('baseBranch in WorkRequest', () => {
-    it('encodes workflow and task execution generations in request salt', async () => {
+    it('encodes workflow generation, task generation, and attemptId in request salt', async () => {
       let capturedRequest: any;
       const capturingExecutor = {
         type: 'worktree',
@@ -1606,15 +1606,15 @@ describe('TaskRunner', () => {
         id: 'task-salt-1',
         status: 'running',
         config: { command: 'echo hi', workflowId: 'wf-1' },
-        execution: { generation: 5 },
+        execution: { generation: 5, selectedAttemptId: 'attempt-abc' },
       });
       await executor.executeTask(task);
 
       expect(capturedRequest).toBeDefined();
-      expect(capturedRequest.inputs.salt).toBe('wf:3|task:5');
+      expect(capturedRequest.inputs.salt).toBe('wf:3|task:5|attempt:attempt-abc');
     });
 
-    it('keeps salt undefined when both workflow and task generations are zero', async () => {
+    it('still includes attemptId in salt when both generations are zero', async () => {
       let capturedRequest: any;
       const capturingExecutor = {
         type: 'worktree',
@@ -1653,12 +1653,12 @@ describe('TaskRunner', () => {
         id: 'task-salt-2',
         status: 'running',
         config: { command: 'echo hi', workflowId: 'wf-1' },
-        execution: { generation: 0 },
+        execution: { generation: 0, selectedAttemptId: 'attempt-xyz' },
       });
       await executor.executeTask(task);
 
       expect(capturedRequest).toBeDefined();
-      expect(capturedRequest.inputs.salt).toBeUndefined();
+      expect(capturedRequest.inputs.salt).toBe('wf:0|task:0|attempt:attempt-xyz');
     });
 
     it('includes workflow baseBranch in request inputs', async () => {

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -12,6 +12,7 @@ import {
 } from './worktree-discovery.js';
 import { syncPlanBaseRemoteForRef, isInvokerManagedPoolBranch } from './plan-base-remote.js';
 import { remoteFetchForPool } from './remote-fetch-policy.js';
+import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { computeRepoUrlHash, sanitizeBranchForPath } from './git-utils.js';
 
 export interface RepoPoolConfig {
@@ -113,6 +114,11 @@ export class RepoPool {
   }
 
   private async doRemoveManagedBranchesInMirror(repoUrl: string, branches: string[]): Promise<void> {
+    // Gated: with attemptId in branch hash, leftover refs cannot collide with
+    // future attempts, so deletion is unnecessary. Set
+    // INVOKER_ENABLE_WORKSPACE_CLEANUP=1 to restore the rebase-and-retry
+    // branch sweep.
+    if (!isWorkspaceCleanupEnabled()) return;
     const dir = this.cloneDir(repoUrl);
     if (!existsSync(dir) || !this.worktreeBaseDir) return;
     for (const branch of branches) {
@@ -311,7 +317,9 @@ export class RepoPool {
           );
           mkdirSync(worktreeParent, { recursive: true });
         } catch {
-          await this.reconcileStaleWorktreePath(clonePath, worktreePath);
+          if (isWorkspaceCleanupEnabled()) {
+            await this.reconcileStaleWorktreePath(clonePath, worktreePath);
+          }
           mkdirSync(worktreeParent, { recursive: true });
           const script = bashPreserveOrReset({
             repoDir: clonePath,
@@ -324,8 +332,14 @@ export class RepoPool {
         }
         break;
       case 'recreate':
-        for (const cleanupPath of plan.cleanupPaths) {
-          await this.reconcileStaleWorktreePath(clonePath, cleanupPath);
+        // Gated: branch hash now embeds attemptId, so the canonical worktree
+        // path for this attempt has never existed. Stale orphans from prior
+        // attempts cannot collide. Re-enable INVOKER_ENABLE_WORKSPACE_CLEANUP
+        // for disk hygiene if needed.
+        if (isWorkspaceCleanupEnabled()) {
+          for (const cleanupPath of plan.cleanupPaths) {
+            await this.reconcileStaleWorktreePath(clonePath, cleanupPath);
+          }
         }
         mkdirSync(worktreeParent, { recursive: true });
         {

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -11,6 +11,7 @@ import { findManagedWorktreeForBranch, abbrevRefMatchesBranch } from './worktree
 import { DEFAULT_WORKTREE_PROVISION_COMMAND } from './default-worktree-provision-command.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { computeRepoUrlHash, sanitizeBranchForPath } from './git-utils.js';
+import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import {
   shellPosixSingleQuote as sshGitShellQuote,
   base64Encode as sshGitB64,
@@ -386,11 +387,17 @@ echo ${payloadB64} | base64 -d | bash -se
       case 'rename_reuse':
         throw new Error('SSH managed workspaces do not support same-task different-branch rename reuse');
       case 'recreate': {
-        const cleanupScript = buildWorktreeCleanupScript({
-          remoteClone,
-          worktreePaths: worktreePlan.cleanupPaths,
-        });
-        await this.execRemoteCapture(cleanupScript, 'cleanup_worktree');
+        // Workspace cleanup is gated by INVOKER_ENABLE_WORKSPACE_CLEANUP. With
+        // attemptId mixed into the branch hash, the canonical worktree path
+        // for the new attempt has never existed, so cleanup is unnecessary
+        // for correctness. Re-enable the env flag if you need disk hygiene.
+        if (isWorkspaceCleanupEnabled()) {
+          const cleanupScript = buildWorktreeCleanupScript({
+            remoteClone,
+            worktreePaths: worktreePlan.cleanupPaths,
+          });
+          await this.execRemoteCapture(cleanupScript, 'cleanup_worktree');
+        }
         remoteWt = canonicalRemoteWt;
         break;
       }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -408,12 +408,14 @@ export class TaskRunner {
     }
 
     // Read workflow + task generations for content-addressable branch salt.
+    // attemptId is mixed in unconditionally so that every attempt produces a
+    // brand-new branch hash. This makes cleanup of old worktrees/refs
+    // unnecessary for correctness: a fresh attempt can never collide with
+    // leftover state from a prior attempt.
     const workflow = task.config.workflowId ? this.persistence.loadWorkflow?.(task.config.workflowId) : undefined;
     const workflowGeneration = (workflow as any)?.generation ?? 0;
     const taskExecutionGeneration = task.execution.generation ?? 0;
-    const generationSalt = workflowGeneration > 0 || taskExecutionGeneration > 0
-      ? `wf:${workflowGeneration}|task:${taskExecutionGeneration}`
-      : undefined;
+    const generationSalt = `wf:${workflowGeneration}|task:${taskExecutionGeneration}|attempt:${attemptId}`;
     const baseBranch = workflow?.baseBranch ?? this.defaultBranch;
     const repoUrl = workflow?.repoUrl;
 

--- a/packages/execution-engine/src/workspace-cleanup-policy.ts
+++ b/packages/execution-engine/src/workspace-cleanup-policy.ts
@@ -1,0 +1,16 @@
+/**
+ * Controls whether per-task and rebase-and-retry workspace cleanup runs.
+ *
+ * Background: branch hashes now embed `attemptId`, guaranteeing that every
+ * attempt produces a brand-new branch/worktree path. Cleaning up old
+ * worktrees and branch refs is therefore unnecessary for correctness, and
+ * historically these cleanup paths have caused "cannot lock ref" / "cannot
+ * force update branch" failures on the SSH remote when state from earlier
+ * attempts collided with newly computed paths.
+ *
+ * Default: cleanup is DISABLED. Set INVOKER_ENABLE_WORKSPACE_CLEANUP=1 to
+ * re-enable for diagnostic or disk-pressure scenarios.
+ */
+export function isWorkspaceCleanupEnabled(): boolean {
+  return process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP === '1';
+}


### PR DESCRIPTION
## Summary
This change makes each task attempt content-addressable on `attemptId`, so a retry or recreate produces a brand-new branch and worktree path instead of reusing the prior attempt’s canonical location. The execution engine and SSH executor still keep workspace cleanup available behind `INVOKER_ENABLE_WORKSPACE_CLEANUP`, but cleanup is no longer required for correctness once the branch hash is unique per attempt.

## Problem
Retry and recreate flows could collide with stale branch and workspace state from prior attempts because they reused the same canonical branch identity.

## Root Cause
Branch naming mixed stable task identity with attempt identity too weakly. That made cleanup a correctness requirement instead of just a hygiene step, because a new attempt could land on the same branch path as an old attempt.

## Approach
Mix `attemptId` into the branch hash so each attempt gets a distinct branch and workspace identity, then gate cleanup behind an env flag because correctness no longer depends on branch deletion timing.

## Main Changes
- include `attemptId` in branch hash inputs
- give each attempt a distinct canonical branch and worktree path
- keep cleanup available behind `INVOKER_ENABLE_WORKSPACE_CLEANUP` rather than requiring it by default

## Why This Fix Is Right
The real bug was branch identity collision, not insufficient cleanup. Making branch identity unique per attempt removes the collision class directly instead of relying on timely deletion to preserve correctness.

## Tradeoffs And Considerations
The tradeoff is that stale refs and worktrees can linger longer when cleanup stays disabled. That is acceptable because the system remains correct without cleanup, and operators can still opt into cleanup for disk hygiene.

## Before
```mermaid
flowchart LR
  A[Task retry or recreate] --> B[Reuse prior canonical branch]
  B --> C[Collide with stale worktree state]
  C --> D[Cleanup required for correctness]
```

## After
```mermaid
flowchart LR
  A[Task attempt] --> B[Hash inputs include workflow, task, and attemptId]
  B --> C[Compute unique branch hash]
  C --> D[New canonical worktree path]
  D --> E[Skip cleanup by default]
  E --> F[Optional cleanup only for disk hygiene]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Mix attemptId into branch hash and gate workspace cleanup`
