### PR TITLE
fix(ui): guard window.invoker?.reportUiPerf for non-Electron contexts

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -347,7 +347,6 @@ export function App() {
     }
   }, [invoker]);
 
-
   const handleStop = useCallback(async () => {
     if (!invoker) return;
     try {
@@ -392,7 +391,6 @@ export function App() {
       console.error('Failed to delete workflows:', err);
     }
   }, [invoker, clearTasks]);
-
 
   // True when all tasks have reached a terminal state.
   const allSettled = useMemo(() => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -90,7 +90,8 @@ export function App() {
       const lagMs = Math.max(0, now - expected);
       expected += 1000;
       if (lagMs >= 250 && shouldEmit('event_loop_lag', 5000)) {
-        void window.invoker.reportUiPerf('renderer_event_loop_lag', { lagMs: Math.round(lagMs) });
+        // Defensive: window.invoker is undefined in vitest/jsdom environments.
+        void window.invoker?.reportUiPerf?.('renderer_event_loop_lag', { lagMs: Math.round(lagMs) });
       }
     }, 1000);
 
@@ -101,7 +102,8 @@ export function App() {
         perfObserver = new PerformanceObserver((list) => {
           for (const entry of list.getEntries()) {
             if (entry.duration >= 200 && shouldEmit('long_task', 3000)) {
-              void window.invoker.reportUiPerf('renderer_long_task', {
+              // Defensive: window.invoker is undefined in vitest/jsdom environments.
+              void window.invoker?.reportUiPerf?.('renderer_long_task', {
                 durationMs: Math.round(entry.duration),
                 name: entry.name,
               });


### PR DESCRIPTION
## Summary
`packages/ui/src/App.tsx` now treats `window.invoker.reportUiPerf` as optional when the renderer runs under Vitest and jsdom. That keeps the perf timer from throwing uncaught `TypeError`s in non-Electron contexts while preserving the same behavior in Electron, where the bridge is expected to exist.

## Exact Failure / Symptom
UI tests running outside Electron could crash on `window.invoker.reportUiPerf` access even though the bridge does not exist in jsdom.

## Root Cause
The renderer assumed the Electron bridge existed in every environment. That assumption is valid in the packaged app but false in test environments.

## Approach
Guard the bridge call and make perf reporting a no-op outside Electron.

## Why This Fix Is Right
The platform boundary is real: perf reporting belongs to the Electron shell. Treating it as optional in jsdom is more correct than using crashes as a proxy for bridge wiring.

## Tradeoffs And Considerations
The tradeoff is that jsdom can no longer surface missing bridge wiring by throwing here. That is acceptable because this API is not meaningful outside Electron anyway.

## Validation
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `fix(ui): guard window.invoker?.reportUiPerf for non-Electron contexts`
