### PR TITLE
Task invalidation step 1: routing-foundation

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -23,6 +23,8 @@ import {
   setWorkflowMergeMode,
   finalizeAppliedFix,
   autoFixOnFailure,
+  buildCancelInFlight,
+  buildInvalidationDeps,
 } from '../workflow-actions.js';
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -1014,5 +1016,199 @@ describe('setWorkflowMergeMode', () => {
         taskExecutor: taskExecutor as unknown as TaskRunner,
       }),
     ).rejects.toThrow('Invalid mergeMode');
+  });
+});
+
+// ── Invalidation routing scaffolding (Phase A, Step 1) ───────
+
+describe('buildCancelInFlight', () => {
+  it('cancels task before awaiting killActiveExecution for each runningCancelled id', async () => {
+    const orchestrator = {
+      cancelTask: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: ['task-a'] })),
+      cancelWorkflow: vi.fn(),
+    };
+    const taskExecutor = {
+      killActiveExecution: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const cancel = buildCancelInFlight({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+    await cancel('task', 'task-a');
+
+    expect(orchestrator.cancelTask).toHaveBeenCalledWith('task-a');
+    expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.cancelTask.mock.invocationCallOrder[0]).toBeLessThan(
+      taskExecutor.killActiveExecution.mock.invocationCallOrder[0],
+    );
+    expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('cancels workflow before awaiting killActiveExecution per runningCancelled id', async () => {
+    const orchestrator = {
+      cancelTask: vi.fn(),
+      cancelWorkflow: vi.fn(() => ({
+        cancelled: ['task-a', 'task-b'],
+        runningCancelled: ['task-a', 'task-b'],
+      })),
+    };
+    const taskExecutor = {
+      killActiveExecution: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const cancel = buildCancelInFlight({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+    await cancel('workflow', 'wf-1');
+
+    expect(orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(taskExecutor.killActiveExecution).toHaveBeenCalledTimes(2);
+    expect(taskExecutor.killActiveExecution).toHaveBeenNthCalledWith(1, 'task-a');
+    expect(taskExecutor.killActiveExecution).toHaveBeenNthCalledWith(2, 'task-b');
+    expect(orchestrator.cancelWorkflow.mock.invocationCallOrder[0]).toBeLessThan(
+      taskExecutor.killActiveExecution.mock.invocationCallOrder[0],
+    );
+    expect(orchestrator.cancelTask).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when scope is "none"', async () => {
+    const orchestrator = { cancelTask: vi.fn(), cancelWorkflow: vi.fn() };
+    const taskExecutor = { killActiveExecution: vi.fn() };
+
+    const cancel = buildCancelInFlight({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+    await cancel('none', 'whatever');
+
+    expect(orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+    expect(taskExecutor.killActiveExecution).not.toHaveBeenCalled();
+  });
+
+  it('still cancels orchestrator state when no taskExecutor is provided', async () => {
+    const orchestrator = {
+      cancelTask: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: ['task-a'] })),
+      cancelWorkflow: vi.fn(),
+    };
+    const cancel = buildCancelInFlight({
+      orchestrator: orchestrator as unknown as Orchestrator,
+    });
+    await cancel('task', 'task-a');
+
+    expect(orchestrator.cancelTask).toHaveBeenCalledWith('task-a');
+  });
+});
+
+describe('buildInvalidationDeps', () => {
+  function makeBaseOrchestrator() {
+    return {
+      restartTask: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
+      recreateTask: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
+      retryWorkflow: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
+      recreateWorkflow: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
+      cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+    };
+  }
+  function makePersistence() {
+    return {
+      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 0 })),
+      updateWorkflow: vi.fn(),
+    };
+  }
+
+  it('routes retryTask to orchestrator.restartTask (compat wire for Step 13)', async () => {
+    const orchestrator = makeBaseOrchestrator();
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+    const result = await deps.retryTask('task-a');
+
+    expect(orchestrator.restartTask).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.recreateTask).not.toHaveBeenCalled();
+    expect(result).toHaveLength(1);
+  });
+
+  it('routes recreateTask to orchestrator.recreateTask', async () => {
+    const orchestrator = makeBaseOrchestrator();
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+    await deps.recreateTask('task-a');
+
+    expect(orchestrator.recreateTask).toHaveBeenCalledWith('task-a');
+  });
+
+  it('routes retryWorkflow to orchestrator.retryWorkflow', async () => {
+    const orchestrator = makeBaseOrchestrator();
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+    await deps.retryWorkflow('wf-1');
+
+    expect(orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
+  });
+
+  it('routes recreateWorkflow through bumpGenerationAndRecreate', async () => {
+    const orchestrator = makeBaseOrchestrator();
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+    await deps.recreateWorkflow('wf-1');
+
+    expect(persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 1 });
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+  });
+
+  it('does NOT wire recreateWorkflowFromFreshBase in Step 1 (Step 12 promotes it)', () => {
+    const orchestrator = makeBaseOrchestrator();
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+    expect(deps.recreateWorkflowFromFreshBase).toBeUndefined();
+  });
+
+  it('builds a cancel-first hook that cancels orchestrator state and kills runners', async () => {
+    const orchestrator = makeBaseOrchestrator();
+    orchestrator.cancelTask = vi.fn(() => ({
+      cancelled: ['task-a'],
+      runningCancelled: ['task-a'],
+    }));
+    const persistence = makePersistence();
+    const taskExecutor = {
+      killActiveExecution: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+    await deps.cancelInFlight('task', 'task-a');
+
+    expect(orchestrator.cancelTask).toHaveBeenCalledWith('task-a');
+    expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.cancelTask.mock.invocationCallOrder[0]).toBeLessThan(
+      taskExecutor.killActiveExecution.mock.invocationCallOrder[0],
+    );
   });
 });

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -186,33 +186,11 @@ export async function rebaseAndRetry(
   return bumpGenerationAndRecreate(workflowId, deps);
 }
 
-// ── Invalidation routing scaffolding (Phase A, Step 1) ───────
-//
-// These helpers wire the new InvalidationAction surface from
-// `@invoker/workflow-core/invalidation-policy` to today's orchestrator
-// primitives. They are exported but UNUSED in Step 1 by design — Steps
-// 2–18 migrate individual mutation paths onto `applyInvalidation()`.
-// See `docs/architecture/task-invalidation-roadmap.md` for the order.
-
 export interface BuildCancelInFlightDeps {
   orchestrator: Orchestrator;
   taskExecutor?: TaskRunner;
 }
 
-/**
- * Build the cancel-first runtime hook for the new invalidation surface.
- *
- * Sequence (per chart "Hard Invariant" in
- * `docs/architecture/task-invalidation-chart.md`):
- *   1. orchestrator.cancelTask / cancelWorkflow → `runningCancelled[]`
- *   2. for each id in `runningCancelled`, await taskExecutor.killActiveExecution(id)
- *
- * This mirrors the order already used by headless's `cancelTask` /
- * `cancelWorkflow` adapters; consolidating it here gives every
- * invalidation route a single cancel-first entrypoint.
- *
- * Step 1 scaffolding: exported but unused; later steps wire callers.
- */
 export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
   return async (scope: InvalidationScope, id: string): Promise<void> => {
     if (scope === 'none') return;
@@ -228,24 +206,6 @@ export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlig
   };
 }
 
-/**
- * Build the `InvalidationDeps` the engine uses to route an
- * `InvalidationAction` to today's orchestrator primitives.
- *
- * Compatibility wires:
- *   - `retryTask` → `orchestrator.restartTask` (rename happens in Step 13).
- *   - `recreateWorkflow` → `bumpGenerationAndRecreate` (matches today's
- *     `recreateWorkflow()` action wrapper that bumps generation first).
- *
- * `recreateWorkflowFromFreshBase` is intentionally left UNWIRED here.
- * Step 12 promotes today's composite `rebaseAndRetry` flow
- * (`preparePoolForRebaseRetry → recreateWorkflow`) to a first-class
- * primitive, which `applyInvalidation` will then route to. Until then,
- * `applyInvalidation` throws an explicit "not yet wired (Step 12)"
- * error if anyone selects that action.
- *
- * Step 1 scaffolding: exported but unused; later steps wire callers.
- */
 export function buildInvalidationDeps(
   deps: Pick<ActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'taskExecutor'>,
 ): InvalidationDeps {

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -8,7 +8,12 @@
 
 import type { Logger } from '@invoker/contracts';
 import type { Orchestrator, ExternalGatePolicyUpdate } from '@invoker/workflow-core';
-import type { TaskState } from '@invoker/workflow-core';
+import type {
+  CancelInFlightFn,
+  InvalidationDeps,
+  InvalidationScope,
+  TaskState,
+} from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
@@ -179,6 +184,87 @@ export async function rebaseAndRetry(
   }
 
   return bumpGenerationAndRecreate(workflowId, deps);
+}
+
+// ── Invalidation routing scaffolding (Phase A, Step 1) ───────
+//
+// These helpers wire the new InvalidationAction surface from
+// `@invoker/workflow-core/invalidation-policy` to today's orchestrator
+// primitives. They are exported but UNUSED in Step 1 by design — Steps
+// 2–18 migrate individual mutation paths onto `applyInvalidation()`.
+// See `docs/architecture/task-invalidation-roadmap.md` for the order.
+
+export interface BuildCancelInFlightDeps {
+  orchestrator: Orchestrator;
+  taskExecutor?: TaskRunner;
+}
+
+/**
+ * Build the cancel-first runtime hook for the new invalidation surface.
+ *
+ * Sequence (per chart "Hard Invariant" in
+ * `docs/architecture/task-invalidation-chart.md`):
+ *   1. orchestrator.cancelTask / cancelWorkflow → `runningCancelled[]`
+ *   2. for each id in `runningCancelled`, await taskExecutor.killActiveExecution(id)
+ *
+ * This mirrors the order already used by headless's `cancelTask` /
+ * `cancelWorkflow` adapters; consolidating it here gives every
+ * invalidation route a single cancel-first entrypoint.
+ *
+ * Step 1 scaffolding: exported but unused; later steps wire callers.
+ */
+export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
+  return async (scope: InvalidationScope, id: string): Promise<void> => {
+    if (scope === 'none') return;
+    const result =
+      scope === 'task'
+        ? deps.orchestrator.cancelTask(id)
+        : deps.orchestrator.cancelWorkflow(id);
+    const taskExecutor = deps.taskExecutor;
+    if (!taskExecutor) return;
+    for (const runningId of result.runningCancelled) {
+      await taskExecutor.killActiveExecution(runningId);
+    }
+  };
+}
+
+/**
+ * Build the `InvalidationDeps` the engine uses to route an
+ * `InvalidationAction` to today's orchestrator primitives.
+ *
+ * Compatibility wires:
+ *   - `retryTask` → `orchestrator.restartTask` (rename happens in Step 13).
+ *   - `recreateWorkflow` → `bumpGenerationAndRecreate` (matches today's
+ *     `recreateWorkflow()` action wrapper that bumps generation first).
+ *
+ * `recreateWorkflowFromFreshBase` is intentionally left UNWIRED here.
+ * Step 12 promotes today's composite `rebaseAndRetry` flow
+ * (`preparePoolForRebaseRetry → recreateWorkflow`) to a first-class
+ * primitive, which `applyInvalidation` will then route to. Until then,
+ * `applyInvalidation` throws an explicit "not yet wired (Step 12)"
+ * error if anyone selects that action.
+ *
+ * Step 1 scaffolding: exported but unused; later steps wire callers.
+ */
+export function buildInvalidationDeps(
+  deps: Pick<ActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'taskExecutor'>,
+): InvalidationDeps {
+  const cancelInFlight = buildCancelInFlight({
+    orchestrator: deps.orchestrator,
+    taskExecutor: deps.taskExecutor,
+  });
+  return {
+    cancelInFlight,
+    retryTask: (taskId: string) => deps.orchestrator.restartTask(taskId),
+    recreateTask: (taskId: string) => deps.orchestrator.recreateTask(taskId),
+    retryWorkflow: (workflowId: string) => deps.orchestrator.retryWorkflow(workflowId),
+    recreateWorkflow: (workflowId: string) =>
+      bumpGenerationAndRecreate(workflowId, {
+        logger: deps.logger,
+        orchestrator: deps.orchestrator,
+        persistence: deps.persistence,
+      }),
+  };
 }
 
 export function editTaskCommand(

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -1,14 +1,3 @@
-/**
- * Step 1 — Routing foundation regression coverage.
- *
- * Asserts:
- *   1. `MUTATION_POLICIES` shape matches the chart Decision Table.
- *   2. `applyInvalidation` enforces the chart's Hard Invariant
- *      (cancel-first ordering, abort on cancel failure).
- *   3. Scope/action mismatches fail fast before cancelInFlight runs.
- *   4. `recreateWorkflowFromFreshBase` is gated behind an explicit
- *      "not yet wired (Step 12)" error until the dep is supplied.
- */
 
 import { describe, it, expect, vi } from 'vitest';
 import {

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Step 1 — Routing foundation regression coverage.
+ *
+ * Asserts:
+ *   1. `MUTATION_POLICIES` shape matches the chart Decision Table.
+ *   2. `applyInvalidation` enforces the chart's Hard Invariant
+ *      (cancel-first ordering, abort on cancel failure).
+ *   3. Scope/action mismatches fail fast before cancelInFlight runs.
+ *   4. `recreateWorkflowFromFreshBase` is gated behind an explicit
+ *      "not yet wired (Step 12)" error until the dep is supplied.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import {
+  applyInvalidation,
+  MUTATION_POLICIES,
+  type InvalidationDeps,
+} from '../invalidation-policy.js';
+
+type MockedDeps = InvalidationDeps & {
+  cancelInFlight: ReturnType<typeof vi.fn>;
+  retryTask: ReturnType<typeof vi.fn>;
+  recreateTask: ReturnType<typeof vi.fn>;
+  retryWorkflow: ReturnType<typeof vi.fn>;
+  recreateWorkflow: ReturnType<typeof vi.fn>;
+  recreateWorkflowFromFreshBase?: ReturnType<typeof vi.fn>;
+};
+
+function makeDeps(overrides: Partial<MockedDeps> = {}): MockedDeps {
+  return {
+    cancelInFlight: vi.fn(async () => undefined),
+    retryTask: vi.fn(async () => []),
+    recreateTask: vi.fn(async () => []),
+    retryWorkflow: vi.fn(async () => []),
+    recreateWorkflow: vi.fn(async () => []),
+    ...overrides,
+  } as MockedDeps;
+}
+
+describe('MUTATION_POLICIES', () => {
+  it('matches the chart Decision Table for execution-spec mutations', () => {
+    expect(MUTATION_POLICIES.command.action).toBe('recreateTask');
+    expect(MUTATION_POLICIES.prompt.action).toBe('recreateTask');
+    expect(MUTATION_POLICIES.executionAgent.action).toBe('recreateTask');
+    expect(MUTATION_POLICIES.executorType.action).toBe('retryTask');
+    expect(MUTATION_POLICIES.remoteTargetId.action).toBe('recreateTask');
+    expect(MUTATION_POLICIES.selectedExperiment.action).toBe('retryTask');
+    expect(MUTATION_POLICIES.selectedExperimentSet.action).toBe('retryTask');
+    expect(MUTATION_POLICIES.mergeMode.action).toBe('retryTask');
+    expect(MUTATION_POLICIES.fixContext.action).toBe('retryTask');
+    expect(MUTATION_POLICIES.rebaseAndRetry.action).toBe('recreateWorkflowFromFreshBase');
+    expect(MUTATION_POLICIES.externalGatePolicy.action).toBe('none');
+  });
+
+  it('marks every spec-changing mutation as invalidating-if-active', () => {
+    for (const [key, policy] of Object.entries(MUTATION_POLICIES)) {
+      if (policy.action === 'none') {
+        expect(policy.invalidatesExecutionSpec, key).toBe(false);
+        expect(policy.invalidateIfActive, key).toBe(false);
+      } else {
+        expect(policy.invalidatesExecutionSpec, key).toBe(true);
+        expect(policy.invalidateIfActive, key).toBe(true);
+      }
+    }
+  });
+
+  it('is frozen — the policy table is a constant, not a mutable map', () => {
+    expect(Object.isFrozen(MUTATION_POLICIES)).toBe(true);
+  });
+});
+
+describe("applyInvalidation: action='none'", () => {
+  it('returns [] and never calls cancelInFlight or any lifecycle dep', async () => {
+    const deps = makeDeps();
+    const out = await applyInvalidation('none', 'none', 'task-a', deps);
+    expect(out).toEqual([]);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+    expect(deps.retryTask).not.toHaveBeenCalled();
+    expect(deps.recreateTask).not.toHaveBeenCalled();
+    expect(deps.retryWorkflow).not.toHaveBeenCalled();
+    expect(deps.recreateWorkflow).not.toHaveBeenCalled();
+  });
+
+  it("rejects when action is 'none' but scope is not 'none'", async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('task', 'none', 'task-a', deps),
+    ).rejects.toThrow(/scope must be 'none'/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyInvalidation: cancel-first ordering (Hard Invariant)', () => {
+  it('calls cancelInFlight before retryTask', async () => {
+    const deps = makeDeps();
+    await applyInvalidation('task', 'retryTask', 'task-a', deps);
+    expect(deps.cancelInFlight).toHaveBeenCalledWith('task', 'task-a');
+    expect(deps.retryTask).toHaveBeenCalledWith('task-a');
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.retryTask.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('calls cancelInFlight before recreateTask', async () => {
+    const deps = makeDeps();
+    await applyInvalidation('task', 'recreateTask', 'task-a', deps);
+    expect(deps.cancelInFlight).toHaveBeenCalledWith('task', 'task-a');
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.recreateTask.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('calls cancelInFlight before retryWorkflow', async () => {
+    const deps = makeDeps();
+    await applyInvalidation('workflow', 'retryWorkflow', 'wf-1', deps);
+    expect(deps.cancelInFlight).toHaveBeenCalledWith('workflow', 'wf-1');
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.retryWorkflow.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('calls cancelInFlight before recreateWorkflow', async () => {
+    const deps = makeDeps();
+    await applyInvalidation('workflow', 'recreateWorkflow', 'wf-1', deps);
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.recreateWorkflow.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('calls cancelInFlight before recreateWorkflowFromFreshBase when dep is wired', async () => {
+    const recreateWorkflowFromFreshBase = vi.fn(async () => []);
+    const deps = makeDeps({ recreateWorkflowFromFreshBase });
+    await applyInvalidation('workflow', 'recreateWorkflowFromFreshBase', 'wf-1', deps);
+    expect(recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1');
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      recreateWorkflowFromFreshBase.mock.invocationCallOrder[0],
+    );
+  });
+});
+
+describe('applyInvalidation: cancel-first failure aborts the route', () => {
+  it('rejects and never calls the lifecycle dep when cancelInFlight rejects (recreateTask)', async () => {
+    const cancelError = new Error('cancel failed');
+    const deps = makeDeps({
+      cancelInFlight: vi.fn(async () => {
+        throw cancelError;
+      }),
+    });
+    await expect(
+      applyInvalidation('task', 'recreateTask', 'task-a', deps),
+    ).rejects.toBe(cancelError);
+    expect(deps.recreateTask).not.toHaveBeenCalled();
+  });
+
+  it('rejects and never calls the lifecycle dep when cancelInFlight rejects (retryWorkflow)', async () => {
+    const deps = makeDeps({
+      cancelInFlight: vi.fn(async () => {
+        throw new Error('boom');
+      }),
+    });
+    await expect(
+      applyInvalidation('workflow', 'retryWorkflow', 'wf-1', deps),
+    ).rejects.toThrow('boom');
+    expect(deps.retryWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('aborts recreateWorkflowFromFreshBase when cancel rejects', async () => {
+    const recreateWorkflowFromFreshBase = vi.fn(async () => []);
+    const deps = makeDeps({
+      cancelInFlight: vi.fn(async () => {
+        throw new Error('cancel exploded');
+      }),
+      recreateWorkflowFromFreshBase,
+    });
+    await expect(
+      applyInvalidation('workflow', 'recreateWorkflowFromFreshBase', 'wf-1', deps),
+    ).rejects.toThrow('cancel exploded');
+    expect(recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyInvalidation: scope/action mismatch', () => {
+  it('rejects retryTask with workflow scope and never cancels', async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('workflow', 'retryTask', 'task-a', deps),
+    ).rejects.toThrow(/requires scope 'task'/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+  });
+
+  it('rejects recreateTask with workflow scope', async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('workflow', 'recreateTask', 'task-a', deps),
+    ).rejects.toThrow(/requires scope 'task'/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+  });
+
+  it('rejects retryWorkflow with task scope', async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('task', 'retryWorkflow', 'wf-1', deps),
+    ).rejects.toThrow(/requires scope 'workflow'/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+  });
+
+  it('rejects recreateWorkflow with task scope', async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('task', 'recreateWorkflow', 'wf-1', deps),
+    ).rejects.toThrow(/requires scope 'workflow'/);
+  });
+
+  it('rejects recreateWorkflowFromFreshBase with task scope', async () => {
+    const deps = makeDeps({
+      recreateWorkflowFromFreshBase: vi.fn(async () => []),
+    });
+    await expect(
+      applyInvalidation('task', 'recreateWorkflowFromFreshBase', 'wf-1', deps),
+    ).rejects.toThrow(/requires scope 'workflow'/);
+  });
+
+  it('rejects task-scoped invocation with workflow-only action and never cancels', async () => {
+    const deps = makeDeps({
+      recreateWorkflowFromFreshBase: vi.fn(async () => []),
+    });
+    await expect(
+      applyInvalidation('task', 'recreateWorkflow', 'wf-1', deps),
+    ).rejects.toThrow();
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+    expect(deps.recreateWorkflow).not.toHaveBeenCalled();
+  });
+});
+
+describe('applyInvalidation: recreateWorkflowFromFreshBase optional dep', () => {
+  it('throws an explicit "not yet wired (Step 12)" error when dep is absent', async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('workflow', 'recreateWorkflowFromFreshBase', 'wf-1', deps),
+    ).rejects.toThrow(/not yet wired \(Step 12\)/);
+  });
+
+  it('routes to the provided dep when present', async () => {
+    const recreateWorkflowFromFreshBase = vi.fn(async () => []);
+    const deps = makeDeps({ recreateWorkflowFromFreshBase });
+    await applyInvalidation('workflow', 'recreateWorkflowFromFreshBase', 'wf-1', deps);
+    expect(recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1');
+  });
+});

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -8,3 +8,4 @@ export * from './fallback-policy.js';
 export * from './graph-mutation.js';
 export * from './command-service.js';
 export * from './task-repository.js';
+export * from './invalidation-policy.js';

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -1,5 +1,5 @@
 
-import type { TaskState } from './state-machine.js';
+import type { TaskState } from '@invoker/workflow-graph';
 
 export type InvalidationAction =
   | 'none'

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -1,0 +1,194 @@
+/**
+ * Task invalidation policy — routing scaffolding (Step 1, Phase A).
+ *
+ * Implements the invalidation-class layer described in
+ * `docs/architecture/task-invalidation-chart.md`:
+ *
+ *   - `InvalidationAction` names every retry/recreate route
+ *     (`retryTask | recreateTask | retryWorkflow | recreateWorkflow |
+ *     recreateWorkflowFromFreshBase | none`).
+ *   - `InvalidationScope` separates `task` vs `workflow` ownership.
+ *   - `MUTATION_POLICIES` mirrors the chart's example mapping per
+ *     execution-defining mutation (command, prompt, executionAgent, ...).
+ *   - `applyInvalidation()` enforces the chart's Hard Invariant:
+ *     affected in-flight work is interrupted BEFORE the lifecycle dep
+ *     is invoked.
+ *
+ * Step 1 deliberately introduces this surface as scaffolding only.
+ * No existing mutation path is migrated onto it yet — Steps 2–18 do
+ * that one row at a time per `docs/architecture/task-invalidation-roadmap.md`.
+ */
+
+import type { TaskState } from './state-machine.js';
+
+/**
+ * Named invalidation classes from the chart's "Proposed API Direction".
+ * `none` is the explicit no-op for non-invalidating mutations
+ * (e.g. external gate policy edits, approve/reject of a finished fix).
+ */
+export type InvalidationAction =
+  | 'none'
+  | 'retryTask'
+  | 'retryWorkflow'
+  | 'recreateTask'
+  | 'recreateWorkflow'
+  | 'recreateWorkflowFromFreshBase';
+
+/**
+ * Scope at which an `InvalidationAction` applies.
+ *  - `'task'`     → applies to a single task identity within a workflow
+ *  - `'workflow'` → applies across an entire workflow's active scope
+ *  - `'none'`     → no-op (paired with action `'none'`)
+ */
+export type InvalidationScope = 'none' | 'task' | 'workflow';
+
+/**
+ * Per-mutation policy entry mirroring the chart Decision Table.
+ */
+export interface TaskMutationPolicy {
+  invalidatesExecutionSpec: boolean;
+  invalidateIfActive: boolean;
+  action: InvalidationAction;
+}
+
+/**
+ * Mutation keys that the policy table classifies in Step 1.
+ *
+ * The set mirrors the chart's example mapping plus the entries that
+ * Steps 2–10 migrate. Adding more keys later is additive.
+ */
+export type MutationKey =
+  | 'command'
+  | 'prompt'
+  | 'executionAgent'
+  | 'executorType'
+  | 'remoteTargetId'
+  | 'selectedExperiment'
+  | 'selectedExperimentSet'
+  | 'mergeMode'
+  | 'fixContext'
+  | 'rebaseAndRetry'
+  | 'externalGatePolicy';
+
+/**
+ * Mirrors the example mapping in
+ * `docs/architecture/task-invalidation-chart.md → "Proposed API Direction"`
+ * and the chart's Decision Table.
+ *
+ * Frozen to lock the policy as a constant. Migrations in Steps 2–10
+ * route through these entries rather than redefining them.
+ */
+export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>> = Object.freeze({
+  command:               { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
+  prompt:                { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
+  executionAgent:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
+  executorType:          { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
+  remoteTargetId:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
+  selectedExperiment:    { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
+  selectedExperimentSet: { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
+  mergeMode:             { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
+  fixContext:            { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
+  rebaseAndRetry:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateWorkflowFromFreshBase' as const },
+  externalGatePolicy:    { invalidatesExecutionSpec: false, invalidateIfActive: false, action: 'none' as const },
+});
+
+/**
+ * Cancel-first runtime hook.
+ *
+ * Implementations must:
+ *   1. interrupt orchestrator-side state for the affected scope, then
+ *   2. await any in-flight executor work being killed.
+ *
+ * Per the chart's Hard Invariant, every retry/recreate route MUST call
+ * this BEFORE invoking a lifecycle dep that resets authoritative state.
+ */
+export type CancelInFlightFn = (
+  scope: InvalidationScope,
+  id: string,
+) => Promise<void>;
+
+/**
+ * Lifecycle deps the engine wires to back each `InvalidationAction`.
+ *
+ * `recreateWorkflowFromFreshBase` is intentionally optional in Step 1.
+ * Today that semantic is the composite `rebaseAndRetry()` flow; Step 12
+ * promotes it to a first-class primitive and supplies it here.
+ */
+export interface InvalidationDeps {
+  cancelInFlight: CancelInFlightFn;
+  retryTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  recreateTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  retryWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
+  recreateWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
+  recreateWorkflowFromFreshBase?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
+}
+
+const TASK_ACTIONS = new Set<InvalidationAction>(['retryTask', 'recreateTask']);
+const WORKFLOW_ACTIONS = new Set<InvalidationAction>([
+  'retryWorkflow',
+  'recreateWorkflow',
+  'recreateWorkflowFromFreshBase',
+]);
+
+/**
+ * Centralized cancel-first router.
+ *
+ * Sequence (per chart "Hard Invariant"):
+ *   1. await deps.cancelInFlight(scope, id)
+ *   2. await deps.<action>(id)
+ *
+ * If `cancelInFlight` rejects, the lifecycle dep is NEVER called and
+ * `applyInvalidation` rejects with that error. Stale in-flight work
+ * must not survive a failed cancel — that is a hard policy.
+ *
+ * For `action === 'none'` this is a true no-op: `cancelInFlight` is
+ * not called and `[]` is returned. Scope must also be `'none'`.
+ */
+export async function applyInvalidation(
+  scope: InvalidationScope,
+  action: InvalidationAction,
+  id: string,
+  deps: InvalidationDeps,
+): Promise<TaskState[]> {
+  if (action === 'none') {
+    if (scope !== 'none') {
+      throw new Error(
+        `applyInvalidation: scope must be 'none' when action is 'none' (got scope='${scope}')`,
+      );
+    }
+    return [];
+  }
+
+  if (TASK_ACTIONS.has(action) && scope !== 'task') {
+    throw new Error(
+      `applyInvalidation: action '${action}' requires scope 'task' (got '${scope}')`,
+    );
+  }
+  if (WORKFLOW_ACTIONS.has(action) && scope !== 'workflow') {
+    throw new Error(
+      `applyInvalidation: action '${action}' requires scope 'workflow' (got '${scope}')`,
+    );
+  }
+
+  await deps.cancelInFlight(scope, id);
+
+  switch (action) {
+    case 'retryTask':
+      return await deps.retryTask(id);
+    case 'recreateTask':
+      return await deps.recreateTask(id);
+    case 'retryWorkflow':
+      return await deps.retryWorkflow(id);
+    case 'recreateWorkflow':
+      return await deps.recreateWorkflow(id);
+    case 'recreateWorkflowFromFreshBase': {
+      if (!deps.recreateWorkflowFromFreshBase) {
+        throw new Error(
+          "applyInvalidation: 'recreateWorkflowFromFreshBase' is not yet wired (Step 12). " +
+            'Provide deps.recreateWorkflowFromFreshBase to use this action.',
+        );
+      }
+      return await deps.recreateWorkflowFromFreshBase(id);
+    }
+  }
+}

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -1,31 +1,6 @@
-/**
- * Task invalidation policy — routing scaffolding (Step 1, Phase A).
- *
- * Implements the invalidation-class layer described in
- * `docs/architecture/task-invalidation-chart.md`:
- *
- *   - `InvalidationAction` names every retry/recreate route
- *     (`retryTask | recreateTask | retryWorkflow | recreateWorkflow |
- *     recreateWorkflowFromFreshBase | none`).
- *   - `InvalidationScope` separates `task` vs `workflow` ownership.
- *   - `MUTATION_POLICIES` mirrors the chart's example mapping per
- *     execution-defining mutation (command, prompt, executionAgent, ...).
- *   - `applyInvalidation()` enforces the chart's Hard Invariant:
- *     affected in-flight work is interrupted BEFORE the lifecycle dep
- *     is invoked.
- *
- * Step 1 deliberately introduces this surface as scaffolding only.
- * No existing mutation path is migrated onto it yet — Steps 2–18 do
- * that one row at a time per `docs/architecture/task-invalidation-roadmap.md`.
- */
 
 import type { TaskState } from './state-machine.js';
 
-/**
- * Named invalidation classes from the chart's "Proposed API Direction".
- * `none` is the explicit no-op for non-invalidating mutations
- * (e.g. external gate policy edits, approve/reject of a finished fix).
- */
 export type InvalidationAction =
   | 'none'
   | 'retryTask'
@@ -42,21 +17,12 @@ export type InvalidationAction =
  */
 export type InvalidationScope = 'none' | 'task' | 'workflow';
 
-/**
- * Per-mutation policy entry mirroring the chart Decision Table.
- */
 export interface TaskMutationPolicy {
   invalidatesExecutionSpec: boolean;
   invalidateIfActive: boolean;
   action: InvalidationAction;
 }
 
-/**
- * Mutation keys that the policy table classifies in Step 1.
- *
- * The set mirrors the chart's example mapping plus the entries that
- * Steps 2–10 migrate. Adding more keys later is additive.
- */
 export type MutationKey =
   | 'command'
   | 'prompt'
@@ -70,14 +36,6 @@ export type MutationKey =
   | 'rebaseAndRetry'
   | 'externalGatePolicy';
 
-/**
- * Mirrors the example mapping in
- * `docs/architecture/task-invalidation-chart.md → "Proposed API Direction"`
- * and the chart's Decision Table.
- *
- * Frozen to lock the policy as a constant. Migrations in Steps 2–10
- * route through these entries rather than redefining them.
- */
 export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>> = Object.freeze({
   command:               { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   prompt:                { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
@@ -92,28 +50,11 @@ export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>
   externalGatePolicy:    { invalidatesExecutionSpec: false, invalidateIfActive: false, action: 'none' as const },
 });
 
-/**
- * Cancel-first runtime hook.
- *
- * Implementations must:
- *   1. interrupt orchestrator-side state for the affected scope, then
- *   2. await any in-flight executor work being killed.
- *
- * Per the chart's Hard Invariant, every retry/recreate route MUST call
- * this BEFORE invoking a lifecycle dep that resets authoritative state.
- */
 export type CancelInFlightFn = (
   scope: InvalidationScope,
   id: string,
 ) => Promise<void>;
 
-/**
- * Lifecycle deps the engine wires to back each `InvalidationAction`.
- *
- * `recreateWorkflowFromFreshBase` is intentionally optional in Step 1.
- * Today that semantic is the composite `rebaseAndRetry()` flow; Step 12
- * promotes it to a first-class primitive and supplies it here.
- */
 export interface InvalidationDeps {
   cancelInFlight: CancelInFlightFn;
   retryTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
@@ -130,20 +71,6 @@ const WORKFLOW_ACTIONS = new Set<InvalidationAction>([
   'recreateWorkflowFromFreshBase',
 ]);
 
-/**
- * Centralized cancel-first router.
- *
- * Sequence (per chart "Hard Invariant"):
- *   1. await deps.cancelInFlight(scope, id)
- *   2. await deps.<action>(id)
- *
- * If `cancelInFlight` rejects, the lifecycle dep is NEVER called and
- * `applyInvalidation` rejects with that error. Stale in-flight work
- * must not survive a failed cancel — that is a hard policy.
- *
- * For `action === 'none'` this is a true no-op: `cancelInFlight` is
- * not called and `[]` is returned. Scope must also be `'none'`.
- */
 export async function applyInvalidation(
   scope: InvalidationScope,
   action: InvalidationAction,


### PR DESCRIPTION
## Summary
This introduces the centralized invalidation policy layer that describes mutation intent as `InvalidationAction` and `InvalidationScope`, then routes that intent through `applyInvalidation` instead of letting each mutation path decide how to cancel and recreate work. The new scaffolding is wired into the app-layer helpers and tests, but not yet attached to every mutation surface; the goal is to establish the contract before migrating individual paths.

## Problem
Mutation invalidation behavior was distributed across call sites, which made cancel-first behavior and retry-vs-recreate semantics easy to drift.

## Root Cause
The codebase had no single policy boundary for mutation invalidation. Each mutation path effectively carried its own local interpretation of how lifecycle resets should work.

## Approach
Introduce a central invalidation policy model and route mutation intent through `applyInvalidation`, even before every concrete mutation is migrated.

## Main Changes
- add `InvalidationAction` and `InvalidationScope`
- introduce `applyInvalidation` as the policy execution boundary
- wire scaffolding into app-layer helpers and tests for later migration steps

## Why This Fix Is Right
The stack needs a stable contract before it starts moving dozens of mutation surfaces. Landing the policy boundary first keeps later commits small and makes it possible to review semantics separately from individual mutation rewrites.

## Tradeoffs And Considerations
The tradeoff is an extra abstraction layer before end-to-end migration is complete. That is acceptable because the main risk here is semantic drift, and centralizing the policy is the right way to contain it.

## Before
```mermaid
flowchart LR
  A[Mutation path] --> B[Local invalidation logic]
  C[Another mutation path] --> D[Different local invalidation logic]
  B --> E[Semantics can drift]
  D --> E
```

## After
```mermaid
flowchart LR
  A[Mutation intent] --> B[Policy lookup]
  B --> C[applyInvalidation]
  C --> D[Cancel affected in-flight work first]
  D --> E[Reset or recreate authoritative state]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 1: routing-foundation`
