### PR TITLE
Task invalidation step 2: command-mutation

### DIFF
--- a/packages/workflow-core/src/__tests__/edit-task-command-invalidation.test.ts
+++ b/packages/workflow-core/src/__tests__/edit-task-command-invalidation.test.ts
@@ -24,7 +24,7 @@ function makeDeps(overrides: Partial<MockedDeps> = {}): MockedDeps {
   } as MockedDeps;
 }
 
-describe('Step 2: command-mutation invalidation contract', () => {
+describe('command-mutation invalidation contract', () => {
   it('MUTATION_POLICIES.command is recreate-class and invalidates active attempts', () => {
     expect(MUTATION_POLICIES.command.action).toBe('recreateTask');
     expect(MUTATION_POLICIES.command.invalidatesExecutionSpec).toBe(true);

--- a/packages/workflow-core/src/__tests__/edit-task-command-invalidation.test.ts
+++ b/packages/workflow-core/src/__tests__/edit-task-command-invalidation.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  applyInvalidation,
+  MUTATION_POLICIES,
+  type InvalidationDeps,
+} from '../invalidation-policy.js';
+
+type MockedDeps = InvalidationDeps & {
+  cancelInFlight: ReturnType<typeof vi.fn>;
+  retryTask: ReturnType<typeof vi.fn>;
+  recreateTask: ReturnType<typeof vi.fn>;
+  retryWorkflow: ReturnType<typeof vi.fn>;
+  recreateWorkflow: ReturnType<typeof vi.fn>;
+};
+
+function makeDeps(overrides: Partial<MockedDeps> = {}): MockedDeps {
+  return {
+    cancelInFlight: vi.fn(async () => undefined),
+    retryTask: vi.fn(async () => []),
+    recreateTask: vi.fn(async () => []),
+    retryWorkflow: vi.fn(async () => []),
+    recreateWorkflow: vi.fn(async () => []),
+    ...overrides,
+  } as MockedDeps;
+}
+
+describe('Step 2: command-mutation invalidation contract', () => {
+  it('MUTATION_POLICIES.command is recreate-class and invalidates active attempts', () => {
+    expect(MUTATION_POLICIES.command.action).toBe('recreateTask');
+    expect(MUTATION_POLICIES.command.invalidatesExecutionSpec).toBe(true);
+    expect(MUTATION_POLICIES.command.invalidateIfActive).toBe(true);
+  });
+
+  it('routes through applyInvalidation with cancelInFlight invoked BEFORE recreateTask dep', async () => {
+    const deps = makeDeps();
+    const policy = MUTATION_POLICIES.command;
+    await applyInvalidation('task', policy.action, 'task-a', deps);
+
+    expect(deps.cancelInFlight).toHaveBeenCalledWith('task', 'task-a');
+    expect(deps.recreateTask).toHaveBeenCalledWith('task-a');
+    expect(deps.retryTask).not.toHaveBeenCalled();
+    expect(deps.retryWorkflow).not.toHaveBeenCalled();
+    expect(deps.recreateWorkflow).not.toHaveBeenCalled();
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.recreateTask.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('aborts the recreate when cancelInFlight rejects (stale work must not survive a failed cancel)', async () => {
+    const cancelError = new Error('cancel failed');
+    const deps = makeDeps({
+      cancelInFlight: vi.fn(async () => {
+        throw cancelError;
+      }),
+    });
+
+    await expect(
+      applyInvalidation('task', MUTATION_POLICIES.command.action, 'task-a', deps),
+    ).rejects.toBe(cancelError);
+    expect(deps.recreateTask).not.toHaveBeenCalled();
+  });
+
+  it('idempotence: two consecutive command edits trigger two cancel-first cycles, ordering preserved', async () => {
+    const deps = makeDeps();
+    const policy = MUTATION_POLICIES.command;
+
+    await applyInvalidation('task', policy.action, 'task-a', deps);
+    await applyInvalidation('task', policy.action, 'task-a', deps);
+
+    expect(deps.cancelInFlight).toHaveBeenCalledTimes(2);
+    expect(deps.recreateTask).toHaveBeenCalledTimes(2);
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.recreateTask.mock.invocationCallOrder[0],
+    );
+    expect(deps.cancelInFlight.mock.invocationCallOrder[1]).toBeLessThan(
+      deps.recreateTask.mock.invocationCallOrder[1],
+    );
+    expect(deps.recreateTask.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.cancelInFlight.mock.invocationCallOrder[1],
+    );
+  });
+
+  it('rejects task-scoped wiring with workflow-only actions (defensive scope/action mismatch)', async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('workflow', MUTATION_POLICIES.command.action, 'task-a', deps),
+    ).rejects.toThrow(/requires scope 'task'/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+    expect(deps.recreateTask).not.toHaveBeenCalled();
+  });
+});

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2785,14 +2785,150 @@ describe('Orchestrator', () => {
       expect(orchestrator.getAllTasks().length).toBe(taskCountBefore);
     });
 
-    it('throws when trying to edit a running task', () => {
+    it('Step 2: editing an ACTIVE (running) task does NOT throw and cancels first, then recreates', () => {
       orchestrator.loadPlan({
         name: 'edit-running-test',
         tasks: [{ id: 't1', description: 'Task 1', command: 'sleep 100' }],
       });
       orchestrator.startExecution();
+      const taskId = sid(orchestrator, 0, 't1');
+      expect(orchestrator.getTask(taskId)?.status).toBe('running');
 
-      expect(() => orchestrator.editTaskCommand('t1', 'echo new')).toThrow();
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
+
+      const started = orchestrator.editTaskCommand(taskId, 'echo new');
+
+      expect(cancelSpy).toHaveBeenCalledWith(taskId);
+      expect(recreateSpy).toHaveBeenCalledWith(taskId);
+      expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        recreateSpy.mock.invocationCallOrder[0],
+      );
+
+      const task = orchestrator.getTask(taskId);
+      expect(task?.config.command).toBe('echo new');
+      expect(task?.status).toBe('running');
+      expect(started).toHaveLength(1);
+      expect(started[0].id).toBe(taskId);
+
+      cancelSpy.mockRestore();
+      recreateSpy.mockRestore();
+    });
+
+    it('Step 2: editing an INACTIVE (failed) task skips cancel but still routes through recreateTask', () => {
+      orchestrator.loadPlan({
+        name: 'edit-inactive-test',
+        tasks: [{ id: 't1', description: 'Task 1', command: 'echo old' }],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 't1', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
+      );
+      const taskId = sid(orchestrator, 0, 't1');
+      expect(orchestrator.getTask(taskId)?.status).toBe('failed');
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
+
+      orchestrator.editTaskCommand(taskId, 'echo new');
+
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(recreateSpy).toHaveBeenCalledWith(taskId);
+
+      cancelSpy.mockRestore();
+      recreateSpy.mockRestore();
+    });
+
+    it('Step 2: discards stale lineage (matches recreateTask reset shape)', () => {
+      orchestrator.loadPlan({
+        name: 'edit-lineage-test',
+        tasks: [{ id: 't1', description: 'Task 1', command: 'echo old' }],
+      });
+      orchestrator.startExecution();
+      const taskId = sid(orchestrator, 0, 't1');
+
+      persistence.updateTask(taskId, {
+        execution: {
+          branch: 'experiment/old-cmd',
+          commit: 'deadbeef',
+          workspacePath: '/tmp/old-workspace',
+          agentSessionId: 'sess-stale',
+          containerId: 'container-stale',
+          error: 'previous error',
+          exitCode: 1,
+          completedAt: new Date(),
+          startedAt: new Date(),
+        },
+      });
+      orchestrator.syncFromDb(taskId.split('/')[0]!);
+
+      orchestrator.editTaskCommand(taskId, 'echo new');
+
+      const task = orchestrator.getTask(taskId)!;
+      expect(task.execution.branch).toBeUndefined();
+      expect(task.execution.commit).toBeUndefined();
+      expect(task.execution.workspacePath).toBeUndefined();
+      expect(task.execution.agentSessionId).toBeUndefined();
+      expect(task.execution.containerId).toBeUndefined();
+      expect(task.execution.error).toBeUndefined();
+      expect(task.execution.exitCode).toBeUndefined();
+    });
+
+    it('Step 2: bumps execution generation by exactly one per command edit', () => {
+      orchestrator.loadPlan({
+        name: 'edit-gen-test',
+        tasks: [{ id: 't1', description: 'Task 1', command: 'echo old' }],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 't1', status: 'failed', outputs: { exitCode: 1, error: 'x' } }),
+      );
+      const taskId = sid(orchestrator, 0, 't1');
+
+      const before = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+
+      orchestrator.editTaskCommand(taskId, 'echo new');
+
+      const after = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+      expect(after).toBe(before + 1);
+    });
+
+    it('Step 2: idempotence — two consecutive command edits trigger two cancel-first cycles and two generation bumps', () => {
+      orchestrator.loadPlan({
+        name: 'edit-idempotence-test',
+        tasks: [{ id: 't1', description: 'Task 1', command: 'sleep 100' }],
+      });
+      orchestrator.startExecution();
+      const taskId = sid(orchestrator, 0, 't1');
+      expect(orchestrator.getTask(taskId)?.status).toBe('running');
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
+
+      const gen0 = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+
+      orchestrator.editTaskCommand(taskId, 'echo first');
+      const gen1 = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+      expect(gen1).toBe(gen0 + 1);
+      expect(orchestrator.getTask(taskId)?.status).toBe('running');
+
+      orchestrator.editTaskCommand(taskId, 'echo second');
+      const gen2 = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+      expect(gen2).toBe(gen0 + 2);
+
+      expect(cancelSpy).toHaveBeenCalledTimes(2);
+      expect(recreateSpy).toHaveBeenCalledTimes(2);
+      expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        recreateSpy.mock.invocationCallOrder[0],
+      );
+      expect(cancelSpy.mock.invocationCallOrder[1]).toBeLessThan(
+        recreateSpy.mock.invocationCallOrder[1],
+      );
+
+      expect(orchestrator.getTask(taskId)?.config.command).toBe('echo second');
+
+      cancelSpy.mockRestore();
+      recreateSpy.mockRestore();
     });
 
     it('persists the updated command', () => {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2785,7 +2785,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getAllTasks().length).toBe(taskCountBefore);
     });
 
-    it('Step 2: editing an ACTIVE (running) task does NOT throw and cancels first, then recreates', () => {
+    it('editing an ACTIVE (running) task does NOT throw and cancels first, then recreates', () => {
       orchestrator.loadPlan({
         name: 'edit-running-test',
         tasks: [{ id: 't1', description: 'Task 1', command: 'sleep 100' }],
@@ -2815,7 +2815,7 @@ describe('Orchestrator', () => {
       recreateSpy.mockRestore();
     });
 
-    it('Step 2: editing an INACTIVE (failed) task skips cancel but still routes through recreateTask', () => {
+    it('editing an INACTIVE (failed) task skips cancel but still routes through recreateTask', () => {
       orchestrator.loadPlan({
         name: 'edit-inactive-test',
         tasks: [{ id: 't1', description: 'Task 1', command: 'echo old' }],
@@ -2839,7 +2839,7 @@ describe('Orchestrator', () => {
       recreateSpy.mockRestore();
     });
 
-    it('Step 2: discards stale lineage (matches recreateTask reset shape)', () => {
+    it('discards stale lineage (matches recreateTask reset shape)', () => {
       orchestrator.loadPlan({
         name: 'edit-lineage-test',
         tasks: [{ id: 't1', description: 'Task 1', command: 'echo old' }],
@@ -2874,7 +2874,7 @@ describe('Orchestrator', () => {
       expect(task.execution.exitCode).toBeUndefined();
     });
 
-    it('Step 2: bumps execution generation by exactly one per command edit', () => {
+    it('bumps execution generation by exactly one per command edit', () => {
       orchestrator.loadPlan({
         name: 'edit-gen-test',
         tasks: [{ id: 't1', description: 'Task 1', command: 'echo old' }],
@@ -2893,7 +2893,7 @@ describe('Orchestrator', () => {
       expect(after).toBe(before + 1);
     });
 
-    it('Step 2: idempotence — two consecutive command edits trigger two cancel-first cycles and two generation bumps', () => {
+    it('idempotence — two consecutive command edits trigger two cancel-first cycles and two generation bumps', () => {
       orchestrator.loadPlan({
         name: 'edit-idempotence-test',
         tasks: [{ id: 't1', description: 'Task 1', command: 'sleep 100' }],

--- a/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
@@ -314,13 +314,7 @@ describe('State × Topology Matrix', () => {
       expect(allTasks.find((t) => t.id === 'D-v2')).toBeUndefined();
     });
 
-    // Step 2 (task-invalidation roadmap):
-    // The chart's Decision Table row "Edit `command`" is recreate-class /
-    // task scope. After the edit, the root task AND every transitive
-    // dependent must have their execution generation bumped by exactly one
-    // (`recreateTask`'s `withBumpedExecutionGeneration` reset shape) — that
-    // is what makes the new branch hash diverge from the stale lineage.
-    it('Step 2 matrix entry: command edit is recreate-class / task scope (root + descendants get gen bump)', () => {
+    it('matrix entry: command edit is recreate-class / task scope (root + descendants get gen bump)', () => {
       orchestrator.loadPlan(diamondPlan());
       orchestrator.startExecution();
 

--- a/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
@@ -313,6 +313,44 @@ describe('State × Topology Matrix', () => {
       expect(allTasks.find((t) => t.id === 'C-v2')).toBeUndefined();
       expect(allTasks.find((t) => t.id === 'D-v2')).toBeUndefined();
     });
+
+    // Step 2 (task-invalidation roadmap):
+    // The chart's Decision Table row "Edit `command`" is recreate-class /
+    // task scope. After the edit, the root task AND every transitive
+    // dependent must have their execution generation bumped by exactly one
+    // (`recreateTask`'s `withBumpedExecutionGeneration` reset shape) — that
+    // is what makes the new branch hash diverge from the stale lineage.
+    it('Step 2 matrix entry: command edit is recreate-class / task scope (root + descendants get gen bump)', () => {
+      orchestrator.loadPlan(diamondPlan());
+      orchestrator.startExecution();
+
+      orchestrator.handleWorkerResponse(complete('A'));
+      orchestrator.handleWorkerResponse(complete('B'));
+      orchestrator.handleWorkerResponse(complete('C'));
+      orchestrator.handleWorkerResponse(complete('D'));
+
+      const genBefore = {
+        A: orchestrator.getTask('A')!.execution.generation ?? 0,
+        B: orchestrator.getTask('B')!.execution.generation ?? 0,
+        C: orchestrator.getTask('C')!.execution.generation ?? 0,
+        D: orchestrator.getTask('D')!.execution.generation ?? 0,
+      };
+
+      orchestrator.editTaskCommand('A', 'echo A-v2');
+
+      const genAfter = {
+        A: orchestrator.getTask('A')!.execution.generation ?? 0,
+        B: orchestrator.getTask('B')!.execution.generation ?? 0,
+        C: orchestrator.getTask('C')!.execution.generation ?? 0,
+        D: orchestrator.getTask('D')!.execution.generation ?? 0,
+      };
+
+      // Task scope: root + transitive dependents within the same workflow.
+      expect(genAfter.A).toBe(genBefore.A + 1);
+      expect(genAfter.B).toBe(genBefore.B + 1);
+      expect(genAfter.C).toBe(genBefore.C + 1);
+      expect(genAfter.D).toBe(genBefore.D + 1);
+    });
   });
 
   // ── Fork: A→{B,C} ──────────────────────────────────────

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1972,15 +1972,15 @@ export class Orchestrator {
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
 
-  /**
-   * Edit a task's command, fork its downstream subtree, and restart it.
-   */
   editTaskCommand(taskId: string, newCommand: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new Error(`Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot edit merge node ${taskId}`);
-    if (task.status === 'running' || task.status === 'fixing_with_ai') throw new Error(`Cannot edit running task ${taskId}`);
+
+    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+      this.cancelTask(taskId);
+    }
 
     const cmdChanges: TaskStateChanges = { config: { command: newCommand } };
     this.writeAndSync(taskId, cmdChanges);
@@ -1988,7 +1988,7 @@ export class Orchestrator {
     this.persistence.logEvent?.(taskId, 'task.updated', cmdChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, cmdDelta);
 
-    return this.restartTask(taskId);
+    return this.recreateTask(taskId);
   }
 
   /**


### PR DESCRIPTION
## Summary
This migrates `edit command` onto the new invalidation scaffold. A command edit now cancels any active attempt first, persists the new command, and then recreates the task through the existing reset and restart shape instead of throwing when the task is running. The app-layer wrapper stays backward-compatible; the real behavior change lives in the orchestrator path.

This PR is intentionally an intermediate migration step. The mutation policies are already recorded in `MUTATION_POLICIES`, but the system is still in the middle of moving individual mutation surfaces onto the fully shared invalidation engine. In this step, the code is making `command` obey the recorded policy by replicating that behavior at the current synchronous seam rather than routing everything end-to-end through the final shared path yet.

## Exact Failure / Symptom
Editing a command on a running task could fail or behave inconsistently because command mutation was not using the new invalidation model.

## Root Cause
Command edits were still treated as a mutation-specific special case instead of an execution-input change that should recreate task state through the shared invalidation boundary.

## Approach
Route command edits through the orchestrator invalidation path: cancel active work if necessary, persist the new command, and recreate the task from authoritative state.

## Why This Fix Is Right
A command edit changes how the task executes, so it should follow the same recreate-class semantics as other execution-shaping mutations. Moving it toward the policy layer keeps that reasoning explicit even though the migration is not fully centralized yet.

## Tradeoffs And Considerations
This intentionally broadens behavior for active tasks instead of rejecting them. That is the right trade because active-task rejection was hiding a missing lifecycle policy rather than enforcing a real invariant.

The other tradeoff is architectural: this commit still mirrors the policy behavior manually in the current synchronous seam instead of routing fully through the final shared invalidation engine. That is deliberate for the migration sequence. The point of this PR is to align behavior with the recorded policy first, while later steps continue collapsing execution onto the shared machinery.

## Before
```mermaid
flowchart LR
  A[Edit command on running task] --> B[Mutation-specific handling]
  B --> C[Throw or inconsistent reset]
```

## After
```mermaid
flowchart LR
  A[Edit command request] --> B[Orchestrator command mutation]
  B --> C[Cancel active attempt]
  C --> D[Persist new command]
  D --> E[Recreate task/downstream]
  E --> F[Resume execution]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 2: command-mutation`
