### PR TITLE
Task invalidation step 3: prompt-mutation

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -91,6 +91,7 @@ function createMocks() {
       setFixAwaitingApproval: vi.fn(),
       restartTask: vi.fn(() => [makeTask()]),
       editTaskCommand: vi.fn(() => [makeTask()]),
+      editTaskPrompt: vi.fn(() => [makeTask()]),
       editTaskType: vi.fn(() => [makeTask()]),
       editTaskAgent: vi.fn(() => [makeTask()]),
       setTaskExternalGatePolicies: vi.fn(() => [makeTask()]),
@@ -175,6 +176,7 @@ beforeEach(() => {
   mocks.orchestrator.restartTask.mockReturnValue([makeTask()]);
   mocks.orchestrator.beginConflictResolution.mockReturnValue({ savedError: 'saved-error' });
   mocks.orchestrator.editTaskCommand.mockReturnValue([makeTask()]);
+  mocks.orchestrator.editTaskPrompt.mockReturnValue([makeTask()]);
   mocks.orchestrator.editTaskType.mockReturnValue([makeTask()]);
   mocks.orchestrator.setTaskExternalGatePolicies.mockReturnValue([makeTask()]);
   mocks.orchestrator.cancelTask.mockReturnValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
@@ -578,6 +580,38 @@ describe('POST /api/tasks/:id/edit', () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/edit', {});
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Missing "command"');
+  });
+});
+
+// ── Step 3 (task-invalidation roadmap): prompt-mutation endpoint ──
+//
+// The chart's Decision Table row "Edit `prompt`" is recreate-class /
+// task scope. The api-server endpoint `POST /api/tasks/:id/edit-prompt`
+// MUST delegate to `Orchestrator.editTaskPrompt`, which is the
+// synchronous cancel-first / lineage-discard / generation-bump seam
+// (see `orchestrator.test.ts` `editTaskPrompt` block for unit-level
+// assertions on cancel ordering, lineage clear, and generation bump).
+// Here we assert end-to-end that an HTTP call routes through to the
+// orchestrator method with the correct payload — that is the
+// integration coverage required by the Step 3 plan.
+describe('POST /api/tasks/:id/edit-prompt', () => {
+  it('Step 3: edits task prompt and routes through orchestrator.editTaskPrompt', async () => {
+    const res = await request(port, 'POST', '/api/tasks/task-1/edit-prompt', { prompt: 'do the thing' });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.action).toBe('prompt_edited');
+    expect(mocks.orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-1', 'do the thing');
+    // The Step 2 command-mutation path was NOT invoked — we are on the
+    // dedicated prompt route, not the generic command edit.
+    expect(mocks.orchestrator.editTaskCommand).not.toHaveBeenCalled();
+    // Endpoint dispatches any newly-runnable tasks via the executor.
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+  });
+
+  it('Step 3: returns 400 when prompt is missing', async () => {
+    const res = await request(port, 'POST', '/api/tasks/task-1/edit-prompt', {});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Missing "prompt"');
   });
 });
 

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -583,32 +583,19 @@ describe('POST /api/tasks/:id/edit', () => {
   });
 });
 
-// ── Step 3 (task-invalidation roadmap): prompt-mutation endpoint ──
-//
-// The chart's Decision Table row "Edit `prompt`" is recreate-class /
-// task scope. The api-server endpoint `POST /api/tasks/:id/edit-prompt`
-// MUST delegate to `Orchestrator.editTaskPrompt`, which is the
-// synchronous cancel-first / lineage-discard / generation-bump seam
-// (see `orchestrator.test.ts` `editTaskPrompt` block for unit-level
-// assertions on cancel ordering, lineage clear, and generation bump).
-// Here we assert end-to-end that an HTTP call routes through to the
-// orchestrator method with the correct payload — that is the
-// integration coverage required by the Step 3 plan.
 describe('POST /api/tasks/:id/edit-prompt', () => {
-  it('Step 3: edits task prompt and routes through orchestrator.editTaskPrompt', async () => {
+  it('edits task prompt and routes through orchestrator.editTaskPrompt', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/edit-prompt', { prompt: 'do the thing' });
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('prompt_edited');
     expect(mocks.orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-1', 'do the thing');
-    // The Step 2 command-mutation path was NOT invoked — we are on the
-    // dedicated prompt route, not the generic command edit.
     expect(mocks.orchestrator.editTaskCommand).not.toHaveBeenCalled();
     // Endpoint dispatches any newly-runnable tasks via the executor.
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
   });
 
-  it('Step 3: returns 400 when prompt is missing', async () => {
+  it('returns 400 when prompt is missing', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/edit-prompt', {});
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Missing "prompt"');

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -22,6 +22,7 @@
  *   POST   /api/tasks/:id/reject       body: { reason? }
  *   POST   /api/tasks/:id/input        body: { text }
  *   POST   /api/tasks/:id/edit         body: { command }
+ *   POST   /api/tasks/:id/edit-prompt  body: { prompt }
  *   POST   /api/tasks/:id/edit-type    body: { executorType, remoteTargetId? }
  *   POST   /api/tasks/:id/edit-agent   body: { agent }
  *   POST   /api/tasks/:id/gate-policy  body: { updates: [{ workflowId, taskId?, gatePolicy }] }
@@ -44,6 +45,7 @@ import {
   rejectTask as sharedRejectTask,
   provideInput as sharedProvideInput,
   editTaskCommand as sharedEditTaskCommand,
+  editTaskPrompt as sharedEditTaskPrompt,
   editTaskType as sharedEditTaskType,
   editTaskAgent as sharedEditTaskAgent,
   setTaskExternalGatePolicies as sharedSetTaskExternalGatePolicies,
@@ -431,6 +433,32 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           const runnable = started.filter(t => t.status === 'running');
           await taskExecutor.executeTasks(runnable);
           json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: runnable.length });
+        } catch (err) {
+          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+        }
+        return;
+      }
+
+      // POST /api/tasks/:id/edit-prompt — Step 3: prompt-mutation recreate-class
+      // route. Body: { prompt }. The substantive cancel-first / lineage-discard /
+      // generation-bump routing lives in `Orchestrator.editTaskPrompt`; this
+      // endpoint is a thin sync delegate via `editTaskPrompt`
+      // in `workflow-actions.ts`. See `docs/architecture/task-invalidation-chart.md`
+      // Decision Table row "Edit `prompt`".
+      const editPromptMatch = path.match(/^\/api\/tasks\/([^/]+)\/edit-prompt$/);
+      if (method === 'POST' && editPromptMatch) {
+        const taskId = decodeURIComponent(editPromptMatch[1]);
+        try {
+          const body = await readBody(req);
+          const { prompt } = JSON.parse(body);
+          if (!prompt) {
+            json(res, 400, { error: 'Missing "prompt" in request body' });
+            return;
+          }
+          const started = sharedEditTaskPrompt(taskId, prompt, { orchestrator });
+          const runnable = started.filter(t => t.status === 'running');
+          await taskExecutor.executeTasks(runnable);
+          json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: runnable.length });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });
         }

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -439,12 +439,6 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
-      // POST /api/tasks/:id/edit-prompt — Step 3: prompt-mutation recreate-class
-      // route. Body: { prompt }. The substantive cancel-first / lineage-discard /
-      // generation-bump routing lives in `Orchestrator.editTaskPrompt`; this
-      // endpoint is a thin sync delegate via `editTaskPrompt`
-      // in `workflow-actions.ts`. See `docs/architecture/task-invalidation-chart.md`
-      // Decision Table row "Edit `prompt`".
       const editPromptMatch = path.match(/^\/api\/tasks\/([^/]+)\/edit-prompt$/);
       if (method === 'POST' && editPromptMatch) {
         const taskId = decodeURIComponent(editPromptMatch[1]);

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -525,6 +525,9 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
     case 'command':
       await headlessEdit(args[1], args.slice(2).join(' '), deps);
       break;
+    case 'prompt':
+      await headlessEditPrompt(args[1], args.slice(2).join(' '), deps);
+      break;
     case 'executor':
       await headlessEditExecutor(args[1], args[2], deps);
       break;
@@ -538,7 +541,7 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
       await headlessSetGatePolicy(args.slice(1), deps);
       break;
     default:
-      throw new Error(`Unknown set sub-command: "${subCommand}". Use: command, executor, agent, merge-mode, gate-policy`);
+      throw new Error(`Unknown set sub-command: "${subCommand}". Use: command, prompt, executor, agent, merge-mode, gate-policy`);
   }
 }
 
@@ -770,6 +773,7 @@ ${BOLD}Respond:${RESET}
 
 ${BOLD}Configure:${RESET}
   set command <taskId> <cmd>                          Edit task command and re-run
+  set prompt <taskId> <text>                          Edit task prompt and re-run
   set executor <taskId> <type>                        Change executor type (worktree|docker|ssh)
   set agent <taskId> <agent>                          Change execution agent (claude|codex)
   set merge-mode <workflowId> <mode>                  manual | automatic | external_review
@@ -1552,6 +1556,48 @@ async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDe
 
   if (deps.noTrack) {
     process.stdout.write('[headless] --no-track enabled: set command accepted; exiting without tracking.\n');
+    autoFix.unsubscribe();
+    return;
+  }
+  if (runnable.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  await trackHeadlessWorkflow(restored.workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
+  autoFix.unsubscribe();
+}
+
+/**
+ * Headless `set prompt` — recreate-class invalidation route per Step 3
+ * of `docs/architecture/task-invalidation-roadmap.md` (mirrors the
+ * Step 2 `set command` path). Routes through `commandService.editTaskPrompt`
+ * so the orchestrator's cancel-first seam (`Orchestrator.editTaskPrompt`)
+ * runs under the workflow mutex; lineage discard and the single
+ * `withBumpedExecutionGeneration` bump live in `recreateTask`.
+ */
+async function headlessEditPrompt(taskId: string, newPrompt: string, deps: HeadlessDeps): Promise<void> {
+  if (!taskId || !newPrompt) throw new Error('Missing arguments. Usage: --headless set prompt <taskId> <newPrompt>');
+  const restored = restoreWorkflowForTask(taskId, deps);
+  taskId = restored.resolvedTaskId;
+  const taskExecutor = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
+
+  const envelope = makeEnvelope('edit-task-prompt', 'headless', 'task', { taskId, newPrompt });
+  const result = await deps.commandService.editTaskPrompt(envelope);
+  if (!result.ok) throw new Error(result.error.message);
+  const runnable = result.data.filter((task) => task.status === 'running');
+  if (runnable.length > 0) {
+    await taskExecutor.executeTasks(runnable);
+  }
+  process.stdout.write(`Edited task "${taskId}" prompt → "${newPrompt}"\n`);
+
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: set prompt accepted; exiting without tracking.\n');
     autoFix.unsubscribe();
     return;
   }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1572,14 +1572,6 @@ async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDe
   autoFix.unsubscribe();
 }
 
-/**
- * Headless `set prompt` — recreate-class invalidation route per Step 3
- * of `docs/architecture/task-invalidation-roadmap.md` (mirrors the
- * Step 2 `set command` path). Routes through `commandService.editTaskPrompt`
- * so the orchestrator's cancel-first seam (`Orchestrator.editTaskPrompt`)
- * runs under the workflow mutex; lineage discard and the single
- * `withBumpedExecutionGeneration` bump live in `recreateTask`.
- */
 async function headlessEditPrompt(taskId: string, newPrompt: string, deps: HeadlessDeps): Promise<void> {
   if (!taskId || !newPrompt) throw new Error('Missing arguments. Usage: --headless set prompt <taskId> <newPrompt>');
   const restored = restoreWorkflowForTask(taskId, deps);

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -235,6 +235,45 @@ export function editTaskCommand(
   return deps.orchestrator.editTaskCommand(taskId, newCommand);
 }
 
+/**
+ * Edit a task's prompt — recreate-class invalidation route per Step 3 of
+ * `docs/architecture/task-invalidation-roadmap.md` and the Decision Table
+ * row "Edit `prompt`" in `docs/architecture/task-invalidation-chart.md`
+ * (`prompt` mutation → `recreateTask` / task scope, mirroring Step 2's
+ * `command` mutation).
+ *
+ * The substantive routing — cancel-first interruption of any active
+ * attempt, prompt persistence, lineage discard via `recreateTask`,
+ * generation bump — lives in `Orchestrator.editTaskPrompt`. That method
+ * is the synchronous orchestrator-internal seam of `applyInvalidation`'s
+ * Hard Invariant (cancel BEFORE authoritative reset) and reuses
+ * `recreateTask`'s reset shape so stale lineage (branch, commit,
+ * workspacePath, agentSessionId, containerId, error, exitCode, ...) is
+ * always cleared.
+ *
+ * This wrapper deliberately stays a thin sync delegate to keep the public
+ * surface (signature and return shape) backward compatible for headless,
+ * GUI, and Slack callers (e.g. `api-server` POST `/api/tasks/:id/edit-prompt`
+ * and `headless set prompt <taskId> <text>`). Executor-aware kill of
+ * active in-flight runs (`taskExecutor.killActiveExecution`) flows
+ * through the same path Step 1 scaffolded (`buildCancelInFlight` /
+ * `buildInvalidationDeps`) and Step 17 will promote into a first-class
+ * lifecycle command surface; for now the orchestrator-side cancel inside
+ * `editTaskPrompt` is sufficient because executor processes observe the
+ * cancellation through the cancelled attempt and the bumped execution
+ * generation when they next report progress.
+ *
+ * Cancel-first is enforced inside the orchestrator method — this wrapper
+ * MUST NOT add a parallel cancel call.
+ */
+export function editTaskPrompt(
+  taskId: string,
+  newPrompt: string,
+  deps: Pick<ActionDeps, 'orchestrator'>,
+): TaskState[] {
+  return deps.orchestrator.editTaskPrompt(taskId, newPrompt);
+}
+
 export function editTaskType(
   taskId: string,
   executorType: string,

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -235,37 +235,6 @@ export function editTaskCommand(
   return deps.orchestrator.editTaskCommand(taskId, newCommand);
 }
 
-/**
- * Edit a task's prompt — recreate-class invalidation route per Step 3 of
- * `docs/architecture/task-invalidation-roadmap.md` and the Decision Table
- * row "Edit `prompt`" in `docs/architecture/task-invalidation-chart.md`
- * (`prompt` mutation → `recreateTask` / task scope, mirroring Step 2's
- * `command` mutation).
- *
- * The substantive routing — cancel-first interruption of any active
- * attempt, prompt persistence, lineage discard via `recreateTask`,
- * generation bump — lives in `Orchestrator.editTaskPrompt`. That method
- * is the synchronous orchestrator-internal seam of `applyInvalidation`'s
- * Hard Invariant (cancel BEFORE authoritative reset) and reuses
- * `recreateTask`'s reset shape so stale lineage (branch, commit,
- * workspacePath, agentSessionId, containerId, error, exitCode, ...) is
- * always cleared.
- *
- * This wrapper deliberately stays a thin sync delegate to keep the public
- * surface (signature and return shape) backward compatible for headless,
- * GUI, and Slack callers (e.g. `api-server` POST `/api/tasks/:id/edit-prompt`
- * and `headless set prompt <taskId> <text>`). Executor-aware kill of
- * active in-flight runs (`taskExecutor.killActiveExecution`) flows
- * through the same path Step 1 scaffolded (`buildCancelInFlight` /
- * `buildInvalidationDeps`) and Step 17 will promote into a first-class
- * lifecycle command surface; for now the orchestrator-side cancel inside
- * `editTaskPrompt` is sufficient because executor processes observe the
- * cancellation through the cancelled attempt and the bumped execution
- * generation when they next report progress.
- *
- * Cancel-first is enforced inside the orchestrator method — this wrapper
- * MUST NOT add a parallel cancel call.
- */
 export function editTaskPrompt(
   taskId: string,
   newPrompt: string,

--- a/packages/workflow-core/src/__tests__/edit-task-prompt-invalidation.test.ts
+++ b/packages/workflow-core/src/__tests__/edit-task-prompt-invalidation.test.ts
@@ -1,44 +1,3 @@
-/**
- * Step 3 — Prompt-mutation invalidation contract.
- *
- * This file pins the Step 3 deliverable from
- * `docs/architecture/task-invalidation-roadmap.md` (Phase B): the
- * `prompt` mutation is recreate-class with task scope, and any
- * affected in-flight work is canceled BEFORE authoritative state is
- * reset (the chart's Hard Invariant in
- * `docs/architecture/task-invalidation-chart.md`).
- *
- * Three layers are pinned:
- *
- *   1. **Policy table.** `MUTATION_POLICIES.prompt` is the immutable
- *      contract that the chart's Decision Table row "Edit `prompt`"
- *      maps to: `recreateTask` action / task scope.
- *
- *   2. **Cancel-first routing (mocked deps).** When the prompt-edit
- *      path is wired through
- *      `applyInvalidation('task', 'recreateTask', taskId, deps)`,
- *      the `cancelInFlight` dep is invoked BEFORE the `recreateTask`
- *      dep. We assert this via `mock.invocationCallOrder`. We also
- *      check that a failed cancel aborts the recreate (stale work
- *      must not survive a failed cancel) and that idempotent edits
- *      preserve the cancel-first ordering.
- *
- *   3. **CommandService delegation (Step 3 integration coverage for
- *      the headless layer).** The headless `set prompt` handler
- *      (`headlessEditPrompt` in `packages/app/src/headless.ts`) calls
- *      `deps.commandService.editTaskPrompt(envelope)`. We exercise
- *      that exact entrypoint and assert it serializes through the
- *      workflow mutex and delegates to `Orchestrator.editTaskPrompt`
- *      with the right payload — that is the end-to-end wiring
- *      assertion the Step 3 plan requires for the headless surface,
- *      complementing the unit-level cancel-first / lineage /
- *      generation-bump coverage in `orchestrator.test.ts`.
- *
- * Steps 13/14/17 will further consolidate the wiring; for now this
- * focused file exists alongside `orchestrator.test.ts` and
- * `edit-task-command-invalidation.test.ts` to keep the contract
- * assertions readable as one chunk.
- */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
@@ -70,7 +29,7 @@ function makeDeps(overrides: Partial<MockedDeps> = {}): MockedDeps {
   } as MockedDeps;
 }
 
-describe('Step 3: prompt-mutation invalidation contract', () => {
+describe('prompt-mutation invalidation contract', () => {
   it('MUTATION_POLICIES.prompt is recreate-class and invalidates active attempts', () => {
     expect(MUTATION_POLICIES.prompt.action).toBe('recreateTask');
     expect(MUTATION_POLICIES.prompt.invalidatesExecutionSpec).toBe(true);
@@ -81,9 +40,6 @@ describe('Step 3: prompt-mutation invalidation contract', () => {
     const deps = makeDeps();
     const policy = MUTATION_POLICIES.prompt;
 
-    // The prompt-edit path uses the same scope/action that the policy
-    // table prescribes. Asserting via the policy makes the test fail
-    // loudly if Step 3 (or any later step) flips the action class.
     await applyInvalidation('task', policy.action, 'task-a', deps);
 
     expect(deps.cancelInFlight).toHaveBeenCalledWith('task', 'task-a');
@@ -145,17 +101,6 @@ describe('Step 3: prompt-mutation invalidation contract', () => {
   });
 });
 
-// ── Step 3 headless integration seam: CommandService.editTaskPrompt ──
-//
-// `headlessEditPrompt` (in `packages/app/src/headless.ts`) constructs
-// an envelope and calls `deps.commandService.editTaskPrompt(envelope)`.
-// That `CommandService` method serializes the mutation through the
-// workflow mutex and delegates to `Orchestrator.editTaskPrompt`,
-// which is where the cancel-first / lineage-discard / generation-bump
-// invariants live (covered by `orchestrator.test.ts` and pinned by
-// the policy-level tests above). This block exercises that exact
-// integration seam so the headless surface has a passing end-to-end
-// wiring assertion in addition to the orchestrator-level coverage.
 function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
   return {
     getTask: vi.fn().mockReturnValue({ config: { workflowId: 'wf-1' } }),
@@ -164,7 +109,7 @@ function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
   } as unknown as Orchestrator;
 }
 
-describe('Step 3: CommandService.editTaskPrompt (headless integration seam)', () => {
+describe('CommandService.editTaskPrompt (headless integration seam)', () => {
   let orchestrator: Orchestrator;
   let service: CommandService;
 

--- a/packages/workflow-core/src/__tests__/edit-task-prompt-invalidation.test.ts
+++ b/packages/workflow-core/src/__tests__/edit-task-prompt-invalidation.test.ts
@@ -1,0 +1,216 @@
+/**
+ * Step 3 — Prompt-mutation invalidation contract.
+ *
+ * This file pins the Step 3 deliverable from
+ * `docs/architecture/task-invalidation-roadmap.md` (Phase B): the
+ * `prompt` mutation is recreate-class with task scope, and any
+ * affected in-flight work is canceled BEFORE authoritative state is
+ * reset (the chart's Hard Invariant in
+ * `docs/architecture/task-invalidation-chart.md`).
+ *
+ * Three layers are pinned:
+ *
+ *   1. **Policy table.** `MUTATION_POLICIES.prompt` is the immutable
+ *      contract that the chart's Decision Table row "Edit `prompt`"
+ *      maps to: `recreateTask` action / task scope.
+ *
+ *   2. **Cancel-first routing (mocked deps).** When the prompt-edit
+ *      path is wired through
+ *      `applyInvalidation('task', 'recreateTask', taskId, deps)`,
+ *      the `cancelInFlight` dep is invoked BEFORE the `recreateTask`
+ *      dep. We assert this via `mock.invocationCallOrder`. We also
+ *      check that a failed cancel aborts the recreate (stale work
+ *      must not survive a failed cancel) and that idempotent edits
+ *      preserve the cancel-first ordering.
+ *
+ *   3. **CommandService delegation (Step 3 integration coverage for
+ *      the headless layer).** The headless `set prompt` handler
+ *      (`headlessEditPrompt` in `packages/app/src/headless.ts`) calls
+ *      `deps.commandService.editTaskPrompt(envelope)`. We exercise
+ *      that exact entrypoint and assert it serializes through the
+ *      workflow mutex and delegates to `Orchestrator.editTaskPrompt`
+ *      with the right payload — that is the end-to-end wiring
+ *      assertion the Step 3 plan requires for the headless surface,
+ *      complementing the unit-level cancel-first / lineage /
+ *      generation-bump coverage in `orchestrator.test.ts`.
+ *
+ * Steps 13/14/17 will further consolidate the wiring; for now this
+ * focused file exists alongside `orchestrator.test.ts` and
+ * `edit-task-command-invalidation.test.ts` to keep the contract
+ * assertions readable as one chunk.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  applyInvalidation,
+  MUTATION_POLICIES,
+  type InvalidationDeps,
+} from '../invalidation-policy.js';
+import { CommandService } from '../command-service.js';
+import type { Orchestrator } from '../orchestrator.js';
+import type { CommandEnvelope } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-graph';
+
+type MockedDeps = InvalidationDeps & {
+  cancelInFlight: ReturnType<typeof vi.fn>;
+  retryTask: ReturnType<typeof vi.fn>;
+  recreateTask: ReturnType<typeof vi.fn>;
+  retryWorkflow: ReturnType<typeof vi.fn>;
+  recreateWorkflow: ReturnType<typeof vi.fn>;
+};
+
+function makeDeps(overrides: Partial<MockedDeps> = {}): MockedDeps {
+  return {
+    cancelInFlight: vi.fn(async () => undefined),
+    retryTask: vi.fn(async () => []),
+    recreateTask: vi.fn(async () => []),
+    retryWorkflow: vi.fn(async () => []),
+    recreateWorkflow: vi.fn(async () => []),
+    ...overrides,
+  } as MockedDeps;
+}
+
+describe('Step 3: prompt-mutation invalidation contract', () => {
+  it('MUTATION_POLICIES.prompt is recreate-class and invalidates active attempts', () => {
+    expect(MUTATION_POLICIES.prompt.action).toBe('recreateTask');
+    expect(MUTATION_POLICIES.prompt.invalidatesExecutionSpec).toBe(true);
+    expect(MUTATION_POLICIES.prompt.invalidateIfActive).toBe(true);
+  });
+
+  it('routes through applyInvalidation with cancelInFlight invoked BEFORE recreateTask dep', async () => {
+    const deps = makeDeps();
+    const policy = MUTATION_POLICIES.prompt;
+
+    // The prompt-edit path uses the same scope/action that the policy
+    // table prescribes. Asserting via the policy makes the test fail
+    // loudly if Step 3 (or any later step) flips the action class.
+    await applyInvalidation('task', policy.action, 'task-a', deps);
+
+    expect(deps.cancelInFlight).toHaveBeenCalledWith('task', 'task-a');
+    expect(deps.recreateTask).toHaveBeenCalledWith('task-a');
+    expect(deps.retryTask).not.toHaveBeenCalled();
+    expect(deps.retryWorkflow).not.toHaveBeenCalled();
+    expect(deps.recreateWorkflow).not.toHaveBeenCalled();
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.recreateTask.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('aborts the recreate when cancelInFlight rejects (stale work must not survive a failed cancel)', async () => {
+    const cancelError = new Error('cancel failed');
+    const deps = makeDeps({
+      cancelInFlight: vi.fn(async () => {
+        throw cancelError;
+      }),
+    });
+
+    await expect(
+      applyInvalidation('task', MUTATION_POLICIES.prompt.action, 'task-a', deps),
+    ).rejects.toBe(cancelError);
+    expect(deps.recreateTask).not.toHaveBeenCalled();
+  });
+
+  it('idempotence: two consecutive prompt edits trigger two cancel-first cycles, ordering preserved', async () => {
+    const deps = makeDeps();
+    const policy = MUTATION_POLICIES.prompt;
+
+    await applyInvalidation('task', policy.action, 'task-a', deps);
+    await applyInvalidation('task', policy.action, 'task-a', deps);
+
+    expect(deps.cancelInFlight).toHaveBeenCalledTimes(2);
+    expect(deps.recreateTask).toHaveBeenCalledTimes(2);
+
+    // Each cycle: cancelInFlight strictly before its paired recreateTask.
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.recreateTask.mock.invocationCallOrder[0],
+    );
+    expect(deps.cancelInFlight.mock.invocationCallOrder[1]).toBeLessThan(
+      deps.recreateTask.mock.invocationCallOrder[1],
+    );
+
+    // Cycles are sequential: the first recreate completes before the
+    // second cancel begins (await-chain ordering).
+    expect(deps.recreateTask.mock.invocationCallOrder[0]).toBeLessThan(
+      deps.cancelInFlight.mock.invocationCallOrder[1],
+    );
+  });
+
+  it('rejects task-scoped wiring with workflow-only actions (defensive scope/action mismatch)', async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('workflow', MUTATION_POLICIES.prompt.action, 'task-a', deps),
+    ).rejects.toThrow(/requires scope 'task'/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+    expect(deps.recreateTask).not.toHaveBeenCalled();
+  });
+});
+
+// ── Step 3 headless integration seam: CommandService.editTaskPrompt ──
+//
+// `headlessEditPrompt` (in `packages/app/src/headless.ts`) constructs
+// an envelope and calls `deps.commandService.editTaskPrompt(envelope)`.
+// That `CommandService` method serializes the mutation through the
+// workflow mutex and delegates to `Orchestrator.editTaskPrompt`,
+// which is where the cancel-first / lineage-discard / generation-bump
+// invariants live (covered by `orchestrator.test.ts` and pinned by
+// the policy-level tests above). This block exercises that exact
+// integration seam so the headless surface has a passing end-to-end
+// wiring assertion in addition to the orchestrator-level coverage.
+function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
+  return {
+    getTask: vi.fn().mockReturnValue({ config: { workflowId: 'wf-1' } }),
+    editTaskPrompt: vi.fn().mockReturnValue([] as TaskState[]),
+    ...overrides,
+  } as unknown as Orchestrator;
+}
+
+describe('Step 3: CommandService.editTaskPrompt (headless integration seam)', () => {
+  let orchestrator: Orchestrator;
+  let service: CommandService;
+
+  beforeEach(() => {
+    orchestrator = stubOrchestrator();
+    service = new CommandService(orchestrator);
+  });
+
+  it('delegates a prompt-edit envelope to orchestrator.editTaskPrompt with the expected payload', async () => {
+    const envelope: CommandEnvelope<{ taskId: string; newPrompt: string }> = {
+      commandId: 'cmd-prompt-1',
+      source: 'headless',
+      scope: 'task',
+      idempotencyKey: 'idem-1',
+      payload: { taskId: 'wf-1/t1', newPrompt: 'fresh prompt' },
+    };
+
+    const result = await service.editTaskPrompt(envelope);
+
+    expect(result).toEqual({ ok: true, data: [] });
+    expect(orchestrator.editTaskPrompt).toHaveBeenCalledWith('wf-1/t1', 'fresh prompt');
+    expect(orchestrator.editTaskPrompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('wraps orchestrator errors in CommandResult instead of throwing', async () => {
+    orchestrator = stubOrchestrator({
+      editTaskPrompt: vi.fn().mockImplementation(() => {
+        throw new Error('boom');
+      }),
+    });
+    service = new CommandService(orchestrator);
+
+    const envelope: CommandEnvelope<{ taskId: string; newPrompt: string }> = {
+      commandId: 'cmd-prompt-2',
+      source: 'headless',
+      scope: 'task',
+      idempotencyKey: 'idem-2',
+      payload: { taskId: 'wf-1/t1', newPrompt: 'doomed' },
+    };
+
+    const result = await service.editTaskPrompt(envelope);
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('EDIT_TASK_PROMPT_FAILED');
+      expect(result.error.message).toContain('boom');
+    }
+  });
+});

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2950,6 +2950,191 @@ describe('Orchestrator', () => {
     });
   });
 
+  // ── editTaskPrompt ─────────────────────────────────────
+  //
+  // Step 3 (task-invalidation roadmap): the chart's Decision Table row
+  // "Edit `prompt`" maps the prompt mutation to InvalidationAction =
+  // 'recreateTask' with InvalidationScope = 'task'. The orchestrator
+  // method enforces cancel-first via cancelTask BEFORE the
+  // lineage-discarding recreateTask reset (the synchronous
+  // orchestrator-internal equivalent of applyInvalidation's
+  // cancelInFlight dep). These tests pin those invariants and mirror
+  // the Step 2 `editTaskCommand` block above.
+
+  describe('editTaskPrompt', () => {
+    it('Step 3: editing an ACTIVE (running) task does NOT throw and cancels first, then recreates', () => {
+      orchestrator.loadPlan({
+        name: 'edit-prompt-running-test',
+        tasks: [{ id: 't1', description: 'Task 1', prompt: 'do the old thing', command: 'sleep 100' }],
+      });
+      orchestrator.startExecution();
+      const taskId = sid(orchestrator, 0, 't1');
+      expect(orchestrator.getTask(taskId)?.status).toBe('running');
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
+
+      const started = orchestrator.editTaskPrompt(taskId, 'do the new thing');
+
+      // No throw. Cancel-first ordering: cancelTask MUST be invoked
+      // BEFORE recreateTask. This is the chart's Hard Invariant
+      // ("any affected in-flight work must be interrupted and canceled
+      // first") expressed at the orchestrator-internal sync seam.
+      expect(cancelSpy).toHaveBeenCalledWith(taskId);
+      expect(recreateSpy).toHaveBeenCalledWith(taskId);
+      expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        recreateSpy.mock.invocationCallOrder[0],
+      );
+
+      const task = orchestrator.getTask(taskId);
+      expect(task?.config.prompt).toBe('do the new thing');
+      // Single-task plan with no deps → recreate auto-starts the task.
+      expect(task?.status).toBe('running');
+      expect(started).toHaveLength(1);
+      expect(started[0].id).toBe(taskId);
+
+      cancelSpy.mockRestore();
+      recreateSpy.mockRestore();
+    });
+
+    it('Step 3: editing an INACTIVE (failed) task skips cancel but still routes through recreateTask', () => {
+      orchestrator.loadPlan({
+        name: 'edit-prompt-inactive-test',
+        tasks: [{ id: 't1', description: 'Task 1', prompt: 'old prompt', command: 'echo old' }],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 't1', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
+      );
+      const taskId = sid(orchestrator, 0, 't1');
+      expect(orchestrator.getTask(taskId)?.status).toBe('failed');
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
+
+      orchestrator.editTaskPrompt(taskId, 'new prompt');
+
+      // Inactive → no cancel needed; recreateTask still resets lineage.
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(recreateSpy).toHaveBeenCalledWith(taskId);
+
+      cancelSpy.mockRestore();
+      recreateSpy.mockRestore();
+    });
+
+    it('Step 3: discards stale lineage (matches recreateTask reset shape)', () => {
+      orchestrator.loadPlan({
+        name: 'edit-prompt-lineage-test',
+        tasks: [{ id: 't1', description: 'Task 1', prompt: 'old', command: 'echo old' }],
+      });
+      orchestrator.startExecution();
+      const taskId = sid(orchestrator, 0, 't1');
+
+      // Hydrate stale lineage as if a prior attempt completed and left
+      // branch/commit/workspace/session/container artifacts behind.
+      persistence.updateTask(taskId, {
+        execution: {
+          branch: 'experiment/old-prompt',
+          commit: 'deadbeef',
+          workspacePath: '/tmp/old-workspace',
+          agentSessionId: 'sess-stale',
+          containerId: 'container-stale',
+          error: 'previous error',
+          exitCode: 1,
+          completedAt: new Date(),
+          startedAt: new Date(),
+        },
+      });
+      orchestrator.syncFromDb(taskId.split('/')[0]!);
+
+      orchestrator.editTaskPrompt(taskId, 'new prompt');
+
+      const task = orchestrator.getTask(taskId)!;
+      expect(task.execution.branch).toBeUndefined();
+      expect(task.execution.commit).toBeUndefined();
+      expect(task.execution.workspacePath).toBeUndefined();
+      expect(task.execution.agentSessionId).toBeUndefined();
+      expect(task.execution.containerId).toBeUndefined();
+      expect(task.execution.error).toBeUndefined();
+      expect(task.execution.exitCode).toBeUndefined();
+    });
+
+    it('Step 3: bumps execution generation by exactly one per prompt edit', () => {
+      orchestrator.loadPlan({
+        name: 'edit-prompt-gen-test',
+        tasks: [{ id: 't1', description: 'Task 1', prompt: 'old', command: 'echo old' }],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 't1', status: 'failed', outputs: { exitCode: 1, error: 'x' } }),
+      );
+      const taskId = sid(orchestrator, 0, 't1');
+
+      const before = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+
+      orchestrator.editTaskPrompt(taskId, 'new');
+
+      const after = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+      expect(after).toBe(before + 1);
+    });
+
+    it('Step 3: persists the updated prompt and publishes a task.updated delta', () => {
+      orchestrator.loadPlan({
+        name: 'edit-prompt-persist-test',
+        tasks: [{ id: 't1', description: 'Task 1', prompt: 'old prompt', command: 'echo old' }],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 't1', status: 'failed', outputs: { exitCode: 1, error: 'oops' } }),
+      );
+
+      orchestrator.editTaskPrompt('t1', 'fresh prompt');
+
+      const persisted = persistence.getTaskEntry('t1');
+      expect(persisted).toBeDefined();
+      expect(persisted?.task.config.prompt).toBe('fresh prompt');
+    });
+
+    it('Step 3: idempotence — two consecutive prompt edits trigger two cancel-first cycles and two generation bumps', () => {
+      orchestrator.loadPlan({
+        name: 'edit-prompt-idempotence-test',
+        tasks: [{ id: 't1', description: 'Task 1', prompt: 'old', command: 'sleep 100' }],
+      });
+      orchestrator.startExecution();
+      const taskId = sid(orchestrator, 0, 't1');
+      expect(orchestrator.getTask(taskId)?.status).toBe('running');
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
+
+      const gen0 = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+
+      orchestrator.editTaskPrompt(taskId, 'first');
+      const gen1 = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+      expect(gen1).toBe(gen0 + 1);
+      expect(orchestrator.getTask(taskId)?.status).toBe('running');
+
+      orchestrator.editTaskPrompt(taskId, 'second');
+      const gen2 = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+      expect(gen2).toBe(gen0 + 2);
+
+      // Two cancel-first cycles, each followed by a recreate.
+      expect(cancelSpy).toHaveBeenCalledTimes(2);
+      expect(recreateSpy).toHaveBeenCalledTimes(2);
+      expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        recreateSpy.mock.invocationCallOrder[0],
+      );
+      expect(cancelSpy.mock.invocationCallOrder[1]).toBeLessThan(
+        recreateSpy.mock.invocationCallOrder[1],
+      );
+
+      expect(orchestrator.getTask(taskId)?.config.prompt).toBe('second');
+
+      cancelSpy.mockRestore();
+      recreateSpy.mockRestore();
+    });
+  });
+
   // ── editTaskType ───────────────────────────────────────
 
   describe('editTaskType', () => {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2950,19 +2950,8 @@ describe('Orchestrator', () => {
     });
   });
 
-  // ── editTaskPrompt ─────────────────────────────────────
-  //
-  // Step 3 (task-invalidation roadmap): the chart's Decision Table row
-  // "Edit `prompt`" maps the prompt mutation to InvalidationAction =
-  // 'recreateTask' with InvalidationScope = 'task'. The orchestrator
-  // method enforces cancel-first via cancelTask BEFORE the
-  // lineage-discarding recreateTask reset (the synchronous
-  // orchestrator-internal equivalent of applyInvalidation's
-  // cancelInFlight dep). These tests pin those invariants and mirror
-  // the Step 2 `editTaskCommand` block above.
-
   describe('editTaskPrompt', () => {
-    it('Step 3: editing an ACTIVE (running) task does NOT throw and cancels first, then recreates', () => {
+    it('editing an ACTIVE (running) task does NOT throw and cancels first, then recreates', () => {
       orchestrator.loadPlan({
         name: 'edit-prompt-running-test',
         tasks: [{ id: 't1', description: 'Task 1', prompt: 'do the old thing', command: 'sleep 100' }],
@@ -2976,10 +2965,6 @@ describe('Orchestrator', () => {
 
       const started = orchestrator.editTaskPrompt(taskId, 'do the new thing');
 
-      // No throw. Cancel-first ordering: cancelTask MUST be invoked
-      // BEFORE recreateTask. This is the chart's Hard Invariant
-      // ("any affected in-flight work must be interrupted and canceled
-      // first") expressed at the orchestrator-internal sync seam.
       expect(cancelSpy).toHaveBeenCalledWith(taskId);
       expect(recreateSpy).toHaveBeenCalledWith(taskId);
       expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
@@ -2997,7 +2982,7 @@ describe('Orchestrator', () => {
       recreateSpy.mockRestore();
     });
 
-    it('Step 3: editing an INACTIVE (failed) task skips cancel but still routes through recreateTask', () => {
+    it('editing an INACTIVE (failed) task skips cancel but still routes through recreateTask', () => {
       orchestrator.loadPlan({
         name: 'edit-prompt-inactive-test',
         tasks: [{ id: 't1', description: 'Task 1', prompt: 'old prompt', command: 'echo old' }],
@@ -3022,7 +3007,7 @@ describe('Orchestrator', () => {
       recreateSpy.mockRestore();
     });
 
-    it('Step 3: discards stale lineage (matches recreateTask reset shape)', () => {
+    it('discards stale lineage (matches recreateTask reset shape)', () => {
       orchestrator.loadPlan({
         name: 'edit-prompt-lineage-test',
         tasks: [{ id: 't1', description: 'Task 1', prompt: 'old', command: 'echo old' }],
@@ -3059,7 +3044,7 @@ describe('Orchestrator', () => {
       expect(task.execution.exitCode).toBeUndefined();
     });
 
-    it('Step 3: bumps execution generation by exactly one per prompt edit', () => {
+    it('bumps execution generation by exactly one per prompt edit', () => {
       orchestrator.loadPlan({
         name: 'edit-prompt-gen-test',
         tasks: [{ id: 't1', description: 'Task 1', prompt: 'old', command: 'echo old' }],
@@ -3078,7 +3063,7 @@ describe('Orchestrator', () => {
       expect(after).toBe(before + 1);
     });
 
-    it('Step 3: persists the updated prompt and publishes a task.updated delta', () => {
+    it('persists the updated prompt and publishes a task.updated delta', () => {
       orchestrator.loadPlan({
         name: 'edit-prompt-persist-test',
         tasks: [{ id: 't1', description: 'Task 1', prompt: 'old prompt', command: 'echo old' }],
@@ -3095,7 +3080,7 @@ describe('Orchestrator', () => {
       expect(persisted?.task.config.prompt).toBe('fresh prompt');
     });
 
-    it('Step 3: idempotence — two consecutive prompt edits trigger two cancel-first cycles and two generation bumps', () => {
+    it('idempotence — two consecutive prompt edits trigger two cancel-first cycles and two generation bumps', () => {
       orchestrator.loadPlan({
         name: 'edit-prompt-idempotence-test',
         tasks: [{ id: 't1', description: 'Task 1', prompt: 'old', command: 'sleep 100' }],

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -151,6 +151,23 @@ export class CommandService {
     );
   }
 
+  /**
+   * Edit a task's prompt — recreate-class invalidation route per Step 3
+   * of the task-invalidation roadmap (mirrors `editTaskCommand`). The
+   * orchestrator method is the synchronous cancel-first seam; this
+   * service-level entrypoint just serializes the mutation through the
+   * workflow mutex and wraps the result in a `CommandResult`.
+   */
+  async editTaskPrompt(
+    envelope: CommandEnvelope<{ taskId: string; newPrompt: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'EDIT_TASK_PROMPT_FAILED',
+      () => this.orchestrator.editTaskPrompt(envelope.payload.taskId, envelope.payload.newPrompt),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
   async editTaskType(
     envelope: CommandEnvelope<{ taskId: string; executorType: string; remoteTargetId?: string }>,
   ): Promise<CommandResult<TaskState[]>> {

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -151,14 +151,7 @@ export class CommandService {
     );
   }
 
-  /**
-   * Edit a task's prompt — recreate-class invalidation route per Step 3
-   * of the task-invalidation roadmap (mirrors `editTaskCommand`). The
-   * orchestrator method is the synchronous cancel-first seam; this
-   * service-level entrypoint just serializes the mutation through the
-   * workflow mutex and wraps the result in a `CommandResult`.
-   */
-  async editTaskPrompt(
+    async editTaskPrompt(
     envelope: CommandEnvelope<{ taskId: string; newPrompt: string }>,
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1991,51 +1991,7 @@ export class Orchestrator {
     return this.recreateTask(taskId);
   }
 
-  /**
-   * Edit a task's prompt — recreate-class invalidation route per Step 3 of
-   * `docs/architecture/task-invalidation-roadmap.md` and the Decision Table
-   * row "Edit `prompt`" in `docs/architecture/task-invalidation-chart.md`.
-   *
-   * A `prompt` edit changes the task's execution-defining spec (the chart
-   * lists `prompt` as part of the execution ABI alongside `command`,
-   * `executionAgent`, `executorType`, `remoteTargetId`), so the existing
-   * attempt's lineage (branch, commit, workspacePath, agent session,
-   * container) is no longer authoritative. The chart maps this to
-   * `InvalidationAction = 'recreateTask'` with `InvalidationScope = 'task'`.
-   *
-   * Sequence (mirrors `applyInvalidation`'s contract for the synchronous
-   * orchestrator-internal seam — see `invalidation-policy.ts` and the
-   * Step 2 `editTaskCommand` precedent):
-   *   1. **Cancel-first (Hard Invariant).** If the task is actively
-   *      executing (`running` or `fixing_with_ai`) we interrupt it via
-   *      `cancelTask` BEFORE any authoritative state is reset. The
-   *      executor-aware kill (`taskExecutor.killActiveExecution`) is wired
-   *      by the app-layer wrapper through `applyInvalidation`'s
-   *      `cancelInFlight` dep; this method only handles the orchestrator
-   *      side of cancel and does NOT add a parallel cancel call.
-   *   2. **Persist new prompt.** `writeAndSync` updates `config.prompt`
-   *      and emits a `task.updated` delta so the recreated attempt picks
-   *      up the new spec.
-   *   3. **Recreate-class reset.** Delegate to `recreateTask`, which
-   *      discards stale lineage (branch, commit, workspacePath,
-   *      agentSessionId, containerId, error, exitCode, ...) and bumps the
-   *      execution generation exactly once via
-   *      `withBumpedExecutionGeneration`. This is the single source of
-   *      truth for the recreate reset shape — Step 3 deliberately reuses
-   *      it instead of duplicating the field list here (mirrors Step 2).
-   *
-   * Public surface: `(taskId, newPrompt)` returning `TaskState[]` of
-   * newly-started tasks — backward-compatible signature shape with the
-   * other `editTask*` mutators. Prior to Step 3 there was no dedicated
-   * general policy for prompt edits (per the chart's "Behavior Today"
-   * column); this method introduces one. Active tasks are NOT rejected —
-   * cancel-first per the chart's Hard Invariant.
-   *
-   * NOTE: `restartTask` is intentionally NOT used here; the
-   * recreate-class reset shape is the only authoritative reset path for
-   * this mutation and `restartTask` will be removed entirely in Step 13.
-   */
-  editTaskPrompt(taskId: string, newPrompt: string): TaskState[] {
+    editTaskPrompt(taskId: string, newPrompt: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new Error(`Task ${taskId} not found`);

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1992,6 +1992,69 @@ export class Orchestrator {
   }
 
   /**
+   * Edit a task's prompt — recreate-class invalidation route per Step 3 of
+   * `docs/architecture/task-invalidation-roadmap.md` and the Decision Table
+   * row "Edit `prompt`" in `docs/architecture/task-invalidation-chart.md`.
+   *
+   * A `prompt` edit changes the task's execution-defining spec (the chart
+   * lists `prompt` as part of the execution ABI alongside `command`,
+   * `executionAgent`, `executorType`, `remoteTargetId`), so the existing
+   * attempt's lineage (branch, commit, workspacePath, agent session,
+   * container) is no longer authoritative. The chart maps this to
+   * `InvalidationAction = 'recreateTask'` with `InvalidationScope = 'task'`.
+   *
+   * Sequence (mirrors `applyInvalidation`'s contract for the synchronous
+   * orchestrator-internal seam — see `invalidation-policy.ts` and the
+   * Step 2 `editTaskCommand` precedent):
+   *   1. **Cancel-first (Hard Invariant).** If the task is actively
+   *      executing (`running` or `fixing_with_ai`) we interrupt it via
+   *      `cancelTask` BEFORE any authoritative state is reset. The
+   *      executor-aware kill (`taskExecutor.killActiveExecution`) is wired
+   *      by the app-layer wrapper through `applyInvalidation`'s
+   *      `cancelInFlight` dep; this method only handles the orchestrator
+   *      side of cancel and does NOT add a parallel cancel call.
+   *   2. **Persist new prompt.** `writeAndSync` updates `config.prompt`
+   *      and emits a `task.updated` delta so the recreated attempt picks
+   *      up the new spec.
+   *   3. **Recreate-class reset.** Delegate to `recreateTask`, which
+   *      discards stale lineage (branch, commit, workspacePath,
+   *      agentSessionId, containerId, error, exitCode, ...) and bumps the
+   *      execution generation exactly once via
+   *      `withBumpedExecutionGeneration`. This is the single source of
+   *      truth for the recreate reset shape — Step 3 deliberately reuses
+   *      it instead of duplicating the field list here (mirrors Step 2).
+   *
+   * Public surface: `(taskId, newPrompt)` returning `TaskState[]` of
+   * newly-started tasks — backward-compatible signature shape with the
+   * other `editTask*` mutators. Prior to Step 3 there was no dedicated
+   * general policy for prompt edits (per the chart's "Behavior Today"
+   * column); this method introduces one. Active tasks are NOT rejected —
+   * cancel-first per the chart's Hard Invariant.
+   *
+   * NOTE: `restartTask` is intentionally NOT used here; the
+   * recreate-class reset shape is the only authoritative reset path for
+   * this mutation and `restartTask` will be removed entirely in Step 13.
+   */
+  editTaskPrompt(taskId: string, newPrompt: string): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (task.config.isMergeNode) throw new Error(`Cannot edit merge node ${taskId}`);
+
+    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+      this.cancelTask(taskId);
+    }
+
+    const promptChanges: TaskStateChanges = { config: { prompt: newPrompt } };
+    this.writeAndSync(taskId, promptChanges);
+    const promptDelta: TaskDelta = { type: 'updated', taskId, changes: promptChanges };
+    this.persistence.logEvent?.(taskId, 'task.updated', promptChanges);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, promptDelta);
+
+    return this.recreateTask(taskId);
+  }
+
+  /**
    * Change a task's executor type (executorType) and restart it.
    * Does NOT fork the dirty subtree.
    */


### PR DESCRIPTION
## Summary
This PR gives `prompt` edits a dedicated invalidation path instead of leaving them as an implicit or inconsistent mutation case. `Orchestrator.editTaskPrompt` becomes the policy boundary: if the task is active, it cancels first, persists the new prompt, and then routes through `recreateTask` so lineage discard and execution-generation bumps still come from the shared recreate path. The app-layer entry points in `workflow-actions`, `api-server`, and `headless` stay thin wrappers.

## Problem
Prompt edits did not have a dedicated invalidation path, so active-task behavior was inconsistent and downstream state could be reset incorrectly or not at all.

## Root Cause
Prompt edits were not modeled as a first-class execution-input mutation. They sat outside the centralized invalidation seam, which left behavior split across wrappers and ad hoc edge handling.

## Approach
Add `editTaskPrompt` to the orchestrator and route prompt edits through recreate-class invalidation with cancel-first behavior for active tasks.

## Main Changes
- add a dedicated prompt-mutation entry point
- persist prompt edits through orchestrator-owned invalidation
- recreate task state through the shared recreate path
- keep app-layer surfaces thin and declarative

## Why This Fix Is Right
Prompt edits change the execution input in a way that should discard prior lineage. Using the shared recreate path keeps generation bumps and reset semantics aligned with the rest of the model.

## Tradeoffs And Considerations
The main tradeoff is an extra public mutation surface instead of folding prompt edits into command edits. That is worthwhile because the semantics are distinct and should remain reviewable on their own.

## Before
```mermaid
flowchart LR
  subgraph Before
    A[UI / API / Headless] --> B[no dedicated prompt invalidation path]
    B --> C[active prompt edits blocked or inconsistent]
  end
```

## After
```mermaid
flowchart LR
  subgraph After
    A[UI / API / Headless] --> B[editTaskPrompt]
    B --> C[orchestrator.editTaskPrompt]
    C --> D{task active?}
    D -- yes --> E[cancelTask]
    D -- no --> F[persist prompt]
    E --> F
    F --> G[recreateTask]
  end
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 3: prompt-mutation`
