### PR TITLE
Task invalidation step 9: merge-mode

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -923,7 +923,10 @@ describe('selectExperiment', () => {
 });
 
 describe('setWorkflowMergeMode', () => {
-  let orchestrator: { restartTask: ReturnType<typeof vi.fn> };
+  // These tests pin the wrapper's two branches:
+  //   - merge node present  -> `orchestrator.editTaskMergeMode`
+  //   - merge node absent   -> direct `persistence.updateWorkflow`
+  let orchestrator: { editTaskMergeMode: ReturnType<typeof vi.fn> };
   let persistence: {
     updateWorkflow: ReturnType<typeof vi.fn>;
     loadTasks: ReturnType<typeof vi.fn>;
@@ -932,7 +935,7 @@ describe('setWorkflowMergeMode', () => {
 
   beforeEach(() => {
     orchestrator = {
-      restartTask: vi.fn(() => [makeRunningTask({ id: 'merge-task', config: { isMergeNode: true } })]),
+      editTaskMergeMode: vi.fn(() => [makeRunningTask({ id: 'merge-task', config: { isMergeNode: true } })]),
     };
     persistence = {
       updateWorkflow: vi.fn(),
@@ -946,31 +949,32 @@ describe('setWorkflowMergeMode', () => {
     };
   });
 
-  it('updates persistence with canonical mode', async () => {
+  it('routes through orchestrator.editTaskMergeMode with the canonical mode when a merge node exists', async () => {
     await setWorkflowMergeMode('wf-1', 'external_review', {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { mergeMode: 'external_review' });
+    expect(orchestrator.editTaskMergeMode).toHaveBeenCalledWith('merge-task', 'external_review');
+    // Workflow-record write happens INSIDE the orchestrator seam
+    // when a merge node exists — the wrapper MUST NOT double-write.
+    expect(persistence.updateWorkflow).not.toHaveBeenCalled();
   });
 
-  it('restarts merge node when it is completed', async () => {
+  it('executes runnable tasks returned by the orchestrator', async () => {
     await setWorkflowMergeMode('wf-1', 'automatic', {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.restartTask).toHaveBeenCalledWith('merge-task');
+    expect(orchestrator.editTaskMergeMode).toHaveBeenCalledWith('merge-task', 'automatic');
     expect(taskExecutor.executeTasks).toHaveBeenCalled();
   });
 
-  it('restarts merge node when it is awaiting_approval', async () => {
-    persistence.loadTasks.mockReturnValue([
-      makeTask({ id: 'merge-task', status: 'awaiting_approval', config: { isMergeNode: true } }),
-    ]);
+  it('does not execute when the orchestrator returns no runnable tasks (e.g. same-mode no-op)', async () => {
+    orchestrator.editTaskMergeMode.mockReturnValueOnce([]);
 
     await setWorkflowMergeMode('wf-1', 'manual', {
       orchestrator: orchestrator as unknown as Orchestrator,
@@ -978,25 +982,11 @@ describe('setWorkflowMergeMode', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.restartTask).toHaveBeenCalledWith('merge-task');
-  });
-
-  it('does not restart merge node when it is pending', async () => {
-    persistence.loadTasks.mockReturnValue([
-      makeTask({ id: 'merge-task', status: 'pending', config: { isMergeNode: true } }),
-    ]);
-
-    await setWorkflowMergeMode('wf-1', 'manual', {
-      orchestrator: orchestrator as unknown as Orchestrator,
-      persistence: persistence as unknown as SQLiteAdapter,
-      taskExecutor: taskExecutor as unknown as TaskRunner,
-    });
-
-    expect(orchestrator.restartTask).not.toHaveBeenCalled();
+    expect(orchestrator.editTaskMergeMode).toHaveBeenCalledWith('merge-task', 'manual');
     expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
-  it('does not restart when no merge node exists', async () => {
+  it('falls back to a direct persistence write when no merge node exists (no-merge-gate workflow)', async () => {
     persistence.loadTasks.mockReturnValue([makeTask({ id: 'task-a', status: 'completed' })]);
 
     await setWorkflowMergeMode('wf-1', 'manual', {
@@ -1005,7 +995,9 @@ describe('setWorkflowMergeMode', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.restartTask).not.toHaveBeenCalled();
+    expect(orchestrator.editTaskMergeMode).not.toHaveBeenCalled();
+    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { mergeMode: 'manual' });
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('throws on invalid merge mode', async () => {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -38,6 +38,7 @@ import {
   setWorkflowMergeMode,
   finalizeAppliedFix,
 } from './workflow-actions.js';
+import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
 import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
 import {
@@ -1890,6 +1891,36 @@ async function headlessDeleteWorkflow(workflowId: string, deps: Pick<HeadlessDep
   process.stdout.write(`Deleted workflow: ${workflowId}\n`);
 }
 
+/**
+ * Headless `set merge-mode` — **retry-class** invalidation route per
+ * Step 9 of `docs/architecture/task-invalidation-roadmap.md` (chart
+ * Decision Table row "Change merge mode";
+ * `MUTATION_POLICIES.mergeMode` → `retryTask` / task scope, scoped
+ * to the merge node). Mirrors the Step 5 `set type` headless pattern
+ * (retry-class, preserves branch / workspacePath lineage) rather
+ * than the Step 2/3/4 recreate-class headless paths
+ * (`set command` / `set prompt` / `set agent`).
+ *
+ * Step 9 routes the headless surface through
+ * `commandService.editTaskMergeMode` so the orchestrator's
+ * cancel-first seam (`Orchestrator.editTaskMergeMode`) runs under
+ * the workflow mutex; same-mode no-op detection,
+ * `persistence.updateWorkflow({ mergeMode })`, and the single
+ * `withBumpedExecutionGeneration` bump live in `restartTask` (today's
+ * `retryTask` compatibility wire — see `MUTATION_POLICIES.mergeMode`
+ * and `buildInvalidationDeps`).
+ *
+ * The CLI argument is still a workflow id (matches the legacy
+ * `set-merge-mode <workflowId> <mode>` surface and the
+ * `invoker:set-merge-mode` IPC). `mergeMode` is normalized at the
+ * app boundary because that concerns UI/CLI input parsing, not the
+ * chart's invalidation routing. The merge-task-id translation
+ * (`workflowId → __merge__<workflowId>`) happens here because the
+ * orchestrator seam speaks merge-node task ids. When the workflow
+ * has no merge node (degenerate workflows that opted out of a merge
+ * gate) we persist the new mode directly via the shared
+ * `setWorkflowMergeMode` action — there is nothing to retry.
+ */
 async function headlessSetMergeMode(
   workflowId: string,
   mergeMode: string,
@@ -1900,13 +1931,36 @@ async function headlessSetMergeMode(
       'Missing arguments. Usage: --headless set-merge-mode <workflowId> <manual|automatic|external_review>',
     );
   }
+  const normalized = normalizeMergeModeForPersistence(mergeMode);
+
+  const tasks = deps.persistence.loadTasks(workflowId);
+  const mergeTask = tasks.find((t) => t.config.isMergeNode);
+  if (!mergeTask) {
+    const taskExecutor = createHeadlessExecutor(deps);
+    await setWorkflowMergeMode(workflowId, normalized, {
+      orchestrator: deps.orchestrator,
+      persistence: deps.persistence,
+      taskExecutor,
+    });
+    const wf = deps.persistence.loadWorkflow(workflowId);
+    process.stdout.write(`Merge mode updated for ${workflowId}: ${wf?.mergeMode ?? '?'}\n`);
+    return;
+  }
+
+  deps.orchestrator.syncFromDb(workflowId);
   const taskExecutor = createHeadlessExecutor(deps);
   wireHeadlessApproveHook(deps, taskExecutor);
-  await setWorkflowMergeMode(workflowId, mergeMode, {
-    orchestrator: deps.orchestrator,
-    persistence: deps.persistence,
-    taskExecutor,
+
+  const envelope = makeEnvelope('edit-task-merge-mode', 'headless', 'task', {
+    taskId: mergeTask.id,
+    mergeMode: normalized,
   });
+  const result = await deps.commandService.editTaskMergeMode(envelope);
+  if (!result.ok) throw new Error(result.error.message);
+  const runnable = result.data.filter((t) => t.status === 'running');
+  if (runnable.length > 0) {
+    await taskExecutor.executeTasks(runnable);
+  }
   const wf = deps.persistence.loadWorkflow(workflowId);
   process.stdout.write(`Merge mode updated for ${workflowId}: ${wf?.mergeMode ?? '?'}\n`);
 }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -293,8 +293,53 @@ export async function selectExperiments(
  * Same sequence as GUI `invoker:resolve-conflict` and headless `resolve-conflict`.
  */
 /**
- * Persist merge mode and re-run the merge
- * gate when it was already finished or waiting, matching GUI `invoker:set-merge-mode`.
+ * Persist merge mode and re-run the merge node — **retry-class**
+ * invalidation route per Step 9 of
+ * `docs/architecture/task-invalidation-roadmap.md` and the Decision
+ * Table row "Change merge mode" in
+ * `docs/architecture/task-invalidation-chart.md`
+ * (`MUTATION_POLICIES.mergeMode` → `retryTask` / task scope, scoped
+ * to the merge node).
+ *
+ * Step 9 migrates this surface from an app-layer-only special case
+ * to a proper orchestrator policy seam. Prior to Step 9 this wrapper
+ * persisted the new mergeMode unconditionally and only restarted the
+ * merge node when its status was `completed` / `awaiting_approval` /
+ * `review_ready` — the chart's "Merge-mode inconsistency" section
+ * explicitly flagged that as the bug ("only at the app layer, and
+ * only when the merge node is already terminal or waiting … no
+ * general active invalidation rule for an in-flight merge node").
+ *
+ * The substantive routing — same-mode no-op detection, cancel-first
+ * interruption when the merge node is actively executing or waiting
+ * on external review (`running` / `fixing_with_ai` /
+ * `awaiting_approval` / `review_ready`), `mergeMode` persistence on
+ * the workflow, and the retry-class reset via `restartTask` (today's
+ * `retryTask` compatibility wire — see `MUTATION_POLICIES.mergeMode`
+ * and `buildInvalidationDeps`) — now lives in
+ * `Orchestrator.editTaskMergeMode`. That method is the synchronous
+ * orchestrator-internal seam of `applyInvalidation`'s Hard Invariant
+ * (cancel BEFORE authoritative reset) and reuses `restartTask`'s
+ * reset shape so the merge node's `agentSessionId` / `containerId` /
+ * `error` / `exitCode` / timing fields are cleared while
+ * branch / workspacePath lineage survives — the chart's retry-class
+ * semantics for merge-mode mutations.
+ *
+ * This wrapper deliberately stays a thin async delegate to keep the
+ * public surface (`(workflowId, mergeMode, deps)` returning `void`)
+ * backward compatible for IPC handlers (`invoker:set-merge-mode`),
+ * the api-server (`POST /api/workflows/:id/merge-mode`), and Slack
+ * surfaces. The merge-task-id translation (`workflowId → mergeNodeId`)
+ * happens here because callers speak workflow ids; the orchestrator
+ * speaks merge-node task ids. When the workflow has no merge node
+ * (degenerate workflows that opted out of a merge gate) the wrapper
+ * persists the new mode directly and returns — there is nothing to
+ * retry. Input normalization (`'manual' | 'automatic' |
+ * 'external_review'`) lives in the app layer because it concerns
+ * UI/CLI input parsing, not the chart's invalidation routing.
+ *
+ * Cancel-first is enforced inside the orchestrator method — this
+ * wrapper MUST NOT add a parallel cancel call.
  */
 export async function setWorkflowMergeMode(
   workflowId: string,
@@ -302,15 +347,15 @@ export async function setWorkflowMergeMode(
   deps: Pick<ActionDeps, 'orchestrator' | 'persistence'> & { taskExecutor: TaskRunner },
 ): Promise<void> {
   const normalized = normalizeMergeModeForPersistence(mergeMode);
-  deps.persistence.updateWorkflow(workflowId, { mergeMode: normalized });
   const tasks = deps.persistence.loadTasks(workflowId);
   const mergeTask = tasks.find((t) => t.config.isMergeNode);
-  if (
-    mergeTask &&
-    (mergeTask.status === 'completed' || mergeTask.status === 'awaiting_approval' || mergeTask.status === 'review_ready')
-  ) {
-    const started = deps.orchestrator.restartTask(mergeTask.id);
-    const runnable = started.filter((t) => t.status === 'running');
+  if (!mergeTask) {
+    deps.persistence.updateWorkflow(workflowId, { mergeMode: normalized });
+    return;
+  }
+  const started = deps.orchestrator.editTaskMergeMode(mergeTask.id, normalized);
+  const runnable = started.filter((t) => t.status === 'running');
+  if (runnable.length > 0) {
     await deps.taskExecutor.executeTasks(runnable);
   }
 }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -9,23 +9,65 @@ import type { WorkResponse } from '@invoker/contracts';
 // ── In-Memory Persistence Mock ──────────────────────────────
 
 class InMemoryPersistence implements OrchestratorPersistence {
-  workflows = new Map<string, { id: string; name: string; status: string; createdAt: string; updatedAt: string }>();
+  workflows = new Map<string, {
+    id: string;
+    name: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+    repoUrl?: string;
+    mergeMode?: 'manual' | 'automatic' | 'external_review';
+  }>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
   events: Array<{ taskId: string; eventType: string; payload?: unknown }> = [];
   updateWorkflowCalls = new Map<string, number>();
 
-  saveWorkflow(workflow: { id: string; name: string; status: string }): void {
+  saveWorkflow(workflow: {
+    id: string;
+    name: string;
+    status: string;
+    repoUrl?: string;
+    mergeMode?: 'manual' | 'automatic' | 'external_review';
+  }): void {
     const now = new Date().toISOString();
-    this.workflows.set(workflow.id, { ...workflow, createdAt: (workflow as any).createdAt ?? now, updatedAt: (workflow as any).updatedAt ?? now });
+    this.workflows.set(workflow.id, {
+      ...workflow,
+      // Synthesize a placeholder repoUrl so SSH-validation tests
+      // (Step 5 `editTaskType` → ssh) keep passing without each
+      // plan having to spell out a remote URL.
+      repoUrl: workflow.repoUrl ?? 'memory://test-repo',
+      createdAt: (workflow as any).createdAt ?? now,
+      updatedAt: (workflow as any).updatedAt ?? now,
+    });
   }
 
-  updateWorkflow(workflowId: string, changes: { status?: string; updatedAt?: string }): void {
+  updateWorkflow(
+    workflowId: string,
+    changes: {
+      status?: string;
+      updatedAt?: string;
+      mergeMode?: 'manual' | 'automatic' | 'external_review';
+    },
+  ): void {
     const wf = this.workflows.get(workflowId);
     this.updateWorkflowCalls.set(workflowId, (this.updateWorkflowCalls.get(workflowId) ?? 0) + 1);
     if (wf && changes.status) {
       wf.status = changes.status;
     }
+    if (wf && changes.mergeMode !== undefined) {
+      wf.mergeMode = changes.mergeMode;
+    }
+  }
+
+  loadWorkflow(workflowId: string): {
+    repoUrl?: string;
+    baseBranch?: string;
+    mergeMode?: 'manual' | 'automatic' | 'external_review';
+  } | undefined {
+    const wf = this.workflows.get(workflowId);
+    if (!wf) return undefined;
+    return { repoUrl: wf.repoUrl, mergeMode: wf.mergeMode };
   }
 
   saveTask(workflowId: string, task: TaskState): void {
@@ -6437,6 +6479,184 @@ describe('Orchestrator', () => {
 
       cancelSpy.mockRestore();
       recreateSpy.mockRestore();
+    });
+  });
+
+  describe('editTaskMergeMode invalidation', () => {
+    function setupMergeWorkflow(initialMergeMode: 'manual' | 'automatic' | 'external_review' = 'manual'): {
+      mergeId: string;
+      workflowId: string;
+      leafId: string;
+    } {
+      orchestrator.loadPlan({
+        name: 'edit-merge-mode-step9',
+        mergeMode: initialMergeMode,
+        tasks: [
+          { id: 'leaf', description: 'Leaf task' },
+        ],
+      });
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeNode = orchestrator
+        .getAllTasks()
+        .find((t) => t.config.isMergeNode && t.config.workflowId === workflowId);
+      expect(mergeNode).toBeDefined();
+      return {
+        mergeId: mergeNode!.id,
+        workflowId,
+        leafId: sid(orchestrator, 0, 'leaf'),
+      };
+    }
+
+    function driveMergeNodeToRunning(mergeId: string, leafId: string): void {
+      orchestrator.startExecution();
+      // Complete the leaf so the merge node becomes ready and
+      // auto-starts (`startExecution`'s ready-set scheduler drives
+      // it into `running`).
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: leafId, status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      expect(orchestrator.getTask(mergeId)?.status).toBe('running');
+    }
+
+    it('routes through restartTask and cancels active merge work first', () => {
+      const { mergeId, leafId } = setupMergeWorkflow('manual');
+      driveMergeNodeToRunning(mergeId, leafId);
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
+
+      orchestrator.editTaskMergeMode(mergeId, 'automatic');
+
+      expect(cancelSpy).toHaveBeenCalledWith(mergeId);
+      expect(restartSpy).toHaveBeenCalledWith(mergeId);
+      expect(recreateSpy).not.toHaveBeenCalled();
+      // Hard Invariant: cancel-first MUST precede the retry-class
+      // reset. `mock.invocationCallOrder` is the global vi-internal
+      // ordering counter — comparing the first cancel/restart call
+      // pins the synchronous ordering inside `editTaskMergeMode`.
+      expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        restartSpy.mock.invocationCallOrder[0],
+      );
+
+      cancelSpy.mockRestore();
+      restartSpy.mockRestore();
+      recreateSpy.mockRestore();
+    });
+
+    it('same-mode flips are a no-op', () => {
+      const { mergeId, leafId, workflowId } = setupMergeWorkflow('manual');
+      driveMergeNodeToRunning(mergeId, leafId);
+
+      const beforeGeneration = orchestrator.getTask(mergeId)!.execution.generation ?? 0;
+      const beforeUpdates = persistence.updateWorkflowCalls.get(workflowId) ?? 0;
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+
+      const result = orchestrator.editTaskMergeMode(mergeId, 'manual');
+
+      expect(result).toEqual([]);
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(restartSpy).not.toHaveBeenCalled();
+
+      const afterGeneration = orchestrator.getTask(mergeId)!.execution.generation ?? 0;
+      expect(afterGeneration).toBe(beforeGeneration);
+
+      const afterUpdates = persistence.updateWorkflowCalls.get(workflowId) ?? 0;
+      expect(afterUpdates).toBe(beforeUpdates);
+
+      cancelSpy.mockRestore();
+      restartSpy.mockRestore();
+    });
+
+    it('different-mode flips on active merge nodes bump execution generation by exactly one', () => {
+      const { mergeId, leafId } = setupMergeWorkflow('manual');
+      driveMergeNodeToRunning(mergeId, leafId);
+
+      const before = orchestrator.getTask(mergeId)!.execution.generation ?? 0;
+
+      orchestrator.editTaskMergeMode(mergeId, 'automatic');
+
+      const after = orchestrator.getTask(mergeId)!.execution.generation ?? 0;
+      expect(after).toBe(before + 1);
+    });
+
+    it('different-mode flips persist the new mode on the workflow record', () => {
+      const { mergeId, leafId, workflowId } = setupMergeWorkflow('manual');
+      driveMergeNodeToRunning(mergeId, leafId);
+
+      orchestrator.editTaskMergeMode(mergeId, 'external_review');
+
+      const wf = persistence.loadWorkflow(workflowId);
+      expect(wf?.mergeMode).toBe('external_review');
+    });
+
+    it('inactive merge nodes skip cancel-first but still route through restartTask', () => {
+      // Do NOT drive the merge node into a running state; with the
+      // leaf still pending the merge node sits in `pending` (no
+      // in-flight merge work). Cancel-first MUST be skipped because
+      // calling `cancelTask` on a `pending` merge node would mark it
+      // `failed` — exactly the failure mode this guard prevents.
+      const { mergeId } = setupMergeWorkflow('manual');
+      expect(orchestrator.getTask(mergeId)?.status).toBe('pending');
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+
+      orchestrator.editTaskMergeMode(mergeId, 'automatic');
+
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(restartSpy).toHaveBeenCalledWith(mergeId);
+      // Merge node remains `pending` after the retry-class reset
+      // (it is the natural target state of `restartTask`).
+      expect(orchestrator.getTask(mergeId)?.status).toBe('pending');
+
+      cancelSpy.mockRestore();
+      restartSpy.mockRestore();
+    });
+
+    it('active awaiting_approval merge nodes cancel first, then reset via restartTask', () => {
+      // The chart calls out `awaiting_approval` (the manual-gate
+      // wait state) explicitly as an ACTIVE state for the merge
+      // node — switching modes mid-review must interrupt the
+      // pending approval and re-schedule the merge under the new
+      // policy.
+      const { mergeId, leafId } = setupMergeWorkflow('manual');
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: leafId, status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      orchestrator.setTaskAwaitingApproval(mergeId);
+      expect(orchestrator.getTask(mergeId)?.status).toBe('awaiting_approval');
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+
+      orchestrator.editTaskMergeMode(mergeId, 'automatic');
+
+      expect(cancelSpy).toHaveBeenCalledWith(mergeId);
+      expect(restartSpy).toHaveBeenCalledWith(mergeId);
+      expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        restartSpy.mock.invocationCallOrder[0],
+      );
+
+      cancelSpy.mockRestore();
+      restartSpy.mockRestore();
+    });
+
+    it('throws when called on a non-merge task', () => {
+      const { leafId } = setupMergeWorkflow('manual');
+      expect(() => orchestrator.editTaskMergeMode(leafId, 'automatic')).toThrow(
+        /not a merge node/,
+      );
+    });
+
+    it('throws when called on an unknown task id', () => {
+      setupMergeWorkflow('manual');
+      expect(() => orchestrator.editTaskMergeMode('does-not-exist', 'automatic')).toThrow(
+        /not found/,
+      );
     });
   });
 

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -185,6 +185,48 @@ export class CommandService {
     );
   }
 
+  /**
+   * Edit the merge mode of a workflow's merge node — **retry-class**
+   * invalidation route per Step 9 of the task-invalidation roadmap
+   * (chart Decision Table row "Change merge mode";
+   * `MUTATION_POLICIES.mergeMode` → `retryTask` / task scope, scoped
+   * to the merge node). Mirrors the Step 5/7/8 retry-class seams
+   * (`editTaskType` / `selectExperiment` / `selectExperiments`) rather
+   * than the recreate-class `editTaskCommand` / `editTaskPrompt` /
+   * `editTaskAgent` seams: a merge-mode flip changes the merge
+   * execution policy but preserves the merge node's branch /
+   * workspacePath lineage.
+   *
+   * The orchestrator method (`Orchestrator.editTaskMergeMode`) is the
+   * synchronous cancel-first seam — it owns same-mode no-op detection,
+   * cancel-first interruption when the merge node is active
+   * (`running` / `fixing_with_ai` / `awaiting_approval` /
+   * `review_ready`), the `persistence.updateWorkflow({ mergeMode })`
+   * write, and the `restartTask` retry-class reset that bumps the
+   * merge node's execution generation exactly once. This service-level
+   * entrypoint just serializes the mutation through the workflow mutex
+   * so concurrent merge-mode flips never interleave with each other or
+   * with other in-workflow mutations, then wraps the result in a
+   * `CommandResult`. `taskId` MUST be the merge node id
+   * (`__merge__<workflowId>`); the workflow id is read from the merge
+   * node's config.
+   */
+  async editTaskMergeMode(
+    envelope: CommandEnvelope<{
+      taskId: string;
+      mergeMode: 'manual' | 'automatic' | 'external_review';
+    }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'EDIT_TASK_MERGE_MODE_FAILED',
+      () => this.orchestrator.editTaskMergeMode(
+        envelope.payload.taskId,
+        envelope.payload.mergeMode,
+      ),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
   async setTaskExternalGatePolicies(
     envelope: CommandEnvelope<{ taskId: string; updates: ExternalGatePolicyUpdate[] }>,
   ): Promise<CommandResult<TaskState[]>> {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -162,8 +162,18 @@ export interface OrchestratorPersistence {
     taskChanges: TaskStateChanges,
     attemptPatch: Partial<Pick<Attempt, 'status' | 'exitCode' | 'error' | 'completedAt'>>
   ): void;
-  /** Load a workflow by ID (needed for SSH validation in editTaskType). */
-  loadWorkflow?(workflowId: string): { repoUrl?: string; baseBranch?: string } | undefined;
+  /**
+   * Load a workflow by ID. Used by:
+   *   - SSH validation in `editTaskType` (`repoUrl`),
+   *   - same-mode no-op detection in `editTaskMergeMode` (`mergeMode`).
+   * The interface lists only the fields the orchestrator actually reads;
+   * concrete adapters (e.g. `SQLiteAdapter.loadWorkflow`) return more.
+   */
+  loadWorkflow?(workflowId: string): {
+    repoUrl?: string;
+    baseBranch?: string;
+    mergeMode?: 'manual' | 'automatic' | 'external_review';
+  } | undefined;
   /** Delete a single workflow and its tasks from the DB. */
   deleteWorkflow?(workflowId: string): void;
   /** Delete all workflows and tasks from the DB. */
@@ -1521,7 +1531,6 @@ export class Orchestrator {
       prevCanon.length === newCanon.length &&
       prevCanon.every((id, i) => id === newCanon[i]);
     const isReSelection = previousSet !== undefined && !sameAsPrev;
-
     const allTasksBefore = this.stateMachine.getAllTasks();
 
     if (isReSelection) {
@@ -1608,7 +1617,7 @@ export class Orchestrator {
       for (const dsId of downstreamIds) {
         const dt = this.stateGetTask(dsId);
         if (!dt) continue;
-        if (dt.status === 'running' || dt.status === 'fixing_with_ai') {
+        if (isActiveForInvalidation(dt.status)) {
           this.cancelTask(dsId);
         }
       }
@@ -2155,6 +2164,145 @@ export class Orchestrator {
     this.messageBus.publish(TASK_DELTA_CHANNEL, agentDelta);
 
     return this.recreateTask(taskId);
+  }
+
+  /**
+   * Edit the merge mode of a workflow's merge node — **retry-class**
+   * invalidation route per Step 9 of
+   * `docs/architecture/task-invalidation-roadmap.md` and the Decision
+   * Table row "Change merge mode" in
+   * `docs/architecture/task-invalidation-chart.md`
+   * (`MUTATION_POLICIES.mergeMode` → `retryTask` / task scope, scoped
+   * to the merge node).
+   *
+   * Why retry-class (not recreate-class). The chart classifies a
+   * merge-mode change as a merge-node-only execution-policy change:
+   * the merge node's merge strategy (`manual` / `automatic` /
+   * `external_review`) flips, but downstream branch/workspace lineage
+   * and the upstream leaf results that feed the merge node are still
+   * authoritative. The "Why" column reads "Merge execution policy
+   * changed". `applyInvalidation('task','retryTask', mergeNodeId, deps)`
+   * is wired to today's `Orchestrator.restartTask` via
+   * `buildInvalidationDeps` (the compatibility seam Step 1 introduced;
+   * Step 13 will rename `restartTask` → `retryTask` to close the matrix).
+   *
+   * Why this lives on the orchestrator (Step 9 migration). Prior to
+   * Step 9 the merge-mode mutation surface was an app-layer-only
+   * special case in `setWorkflowMergeMode` that restarted the merge
+   * node *only* when it was already terminal or waiting
+   * (`completed` / `awaiting_approval` / `review_ready`). Per the
+   * chart's "Merge-mode inconsistency" section that left no general
+   * active invalidation rule for an in-flight merge node — a `running`
+   * merge node would silently keep using the old mode. Step 9 lifts
+   * the routing into a proper orchestrator policy seam (this method)
+   * so the Hard Invariant (cancel-first) and the retry-class reset
+   * are enforced uniformly across all merge-node states; the app
+   * wrapper becomes a thin delegate (mirrors Steps 2–6).
+   *
+   * Sequence (mirrors `applyInvalidation`'s contract for the
+   * synchronous orchestrator-internal seam — see
+   * `invalidation-policy.ts` and the Step 5/7/8 retry-class precedents):
+   *   1. **Same-mode no-op.** If the workflow's persisted `mergeMode`
+   *      already matches the requested value the method returns `[]`
+   *      without canceling, persisting, or bumping the merge node's
+   *      execution generation. This prevents a no-op rewrite from
+   *      invalidating valid in-flight merge work.
+   *   2. **Cancel-first (Hard Invariant).** If the merge node is
+   *      actively executing or waiting on external review
+   *      (`running` / `fixing_with_ai` / `awaiting_approval` /
+   *      `review_ready`) we interrupt it via `cancelTask` BEFORE any
+   *      authoritative state is reset. The chart's "Merge-mode
+   *      inconsistency" section explicitly flags external-review
+   *      waits and in-flight merge runs as scope that the new model
+   *      must invalidate consistently. Inactive states
+   *      (`pending` / `completed` / `failed` / `needs_input` /
+   *      `blocked`) skip the cancel — there is no in-flight work to
+   *      interrupt and `cancelTask` would otherwise mark a `pending`
+   *      merge node as `failed`.
+   *   3. **Persist new mode.** `persistence.updateWorkflow` writes the
+   *      new `mergeMode` so the retried merge attempt picks up the
+   *      new policy when it next runs.
+   *   4. **Retry-class reset.** Delegate to `restartTask`, which is
+   *      the current `retryTask` compatibility wire (Step 13 will
+   *      rename it). `restartTask` resets the merge node to `pending`,
+   *      clears volatile attempt state (`agentSessionId` /
+   *      `containerId` / `error` / `exitCode` / `startedAt` /
+   *      `completedAt`), and bumps execution generation exactly once
+   *      via `withBumpedExecutionGeneration`. Crucially it does NOT
+   *      clear `branch` / `workspacePath` — that lineage (the merge
+   *      node's accumulated workspace) is the artifact the chart
+   *      preserves for retry-class merge-mode mutations.
+   *
+   * Public surface: `(taskId, mergeMode)` returning `TaskState[]` of
+   * newly-started tasks. `taskId` MUST be the merge node id
+   * (`__merge__<workflowId>`); the workflow id is read from
+   * `task.config.workflowId`. Throws if the task does not exist or is
+   * not a merge node — keeping merge-mode mutation scoped to the
+   * single execution policy slot the chart classifies. Backward-
+   * compatible callers continue to use the workflow-scoped
+   * `setWorkflowMergeMode` wrapper which translates `workflowId →
+   * mergeNodeId` and delegates here.
+   *
+   * NOTE: `recreateTask`'s lineage-discarding reset shape is
+   * deliberately NOT used here. A merge-mode flip does not invalidate
+   * the merge node's accumulated workspace (the merged branch lineage
+   * built from upstream leaf results); only the merge execution
+   * policy changed. That distinction is what makes merge-mode the
+   * single retry-class route alongside the other retry-class rows
+   * (`executorType`, `selectedExperiment`, `selectedExperimentSet`)
+   * in the chart's Decision Table.
+   */
+  editTaskMergeMode(
+    taskId: string,
+    mergeMode: 'manual' | 'automatic' | 'external_review',
+  ): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task.config.isMergeNode) {
+      throw new Error(`Task ${taskId} is not a merge node`);
+    }
+    const workflowId = task.config.workflowId;
+    if (!workflowId) {
+      throw new Error(`Merge node ${taskId} has no workflowId`);
+    }
+
+    // Step 9 same-mode no-op: skip cancel + persist + retry when the
+    // requested mode already matches what's persisted on the workflow.
+    // Without this guard a UI/CLI re-affirm would needlessly cancel
+    // active merge work and bump the merge node's execution generation.
+    const wf = this.persistence.loadWorkflow?.(workflowId);
+    if (wf && wf.mergeMode === mergeMode) {
+      return [];
+    }
+
+    // Step 9 cancel-first (chart Hard Invariant): when the merge node
+    // is actively executing or waiting on external review, interrupt
+    // it BEFORE we mutate the workflow's mergeMode and reset merge
+    // state. Stale merge work (an in-flight merge run, a merge fix
+    // session, or an external review wait) cannot survive a policy
+    // change because the merge attempt's execution input — the merge
+    // mode — just changed. Inactive statuses
+    // (`pending`/`completed`/`failed`/`needs_input`/`blocked`) skip
+    // cancel: there is no in-flight work to interrupt and
+    // `cancelTask` would otherwise mark a `pending` merge node as
+    // `failed`.
+    if (isActiveForInvalidation(task.status)) {
+      this.cancelTask(taskId);
+    }
+
+    // Persist new mode on the workflow record so the retried merge
+    // attempt picks up the new policy when restartTask reschedules it.
+    this.persistence.updateWorkflow?.(workflowId, { mergeMode });
+
+    // Step 9 retry-class reset: restartTask is today's `retryTask`
+    // compatibility wire (`buildInvalidationDeps` →
+    // `orchestrator.restartTask`). It resets the merge node to
+    // `pending`, clears volatile attempt state, and bumps execution
+    // generation exactly once via `withBumpedExecutionGeneration`
+    // while preserving branch/workspacePath lineage — the chart's
+    // retry-class semantics for merge-mode mutations.
+    return this.restartTask(taskId);
   }
 
   /**


### PR DESCRIPTION
## Summary
This PR moves merge-mode edits out of the app wrapper and into an orchestrator-owned retry-class path. `setWorkflowMergeMode` stays as the thin edge wrapper, but the merge node itself now owns same-mode no-op handling, workflow persistence, active-state interruption, and the retry-style reset.

## Problem
A merge-mode flip could leave the merge node executing under stale merge policy because the change lived in app-layer special casing instead of the invalidation seam.

## Root Cause
The merge-mode mutation was implemented as wrapper logic rather than as an orchestrator lifecycle mutation. That split made active-state handling drift-prone and left the cancel-first rule implicit.

## Approach
Route merge-mode edits through `Orchestrator.editTaskMergeMode`, persist the new workflow merge mode there, and use the shared invalidation-active classification for active merge states before resetting the merge node.

## Why This Fix Is Right
Changing merge mode changes execution policy, not task identity or workspace lineage. That makes retry-class invalidation the right fit. In this part of the stack the retry-class primitive is still named `restartTask`; the later lifecycle cleanup renames that surface, but the intent here is already retry semantics rather than recreate semantics.

## Tradeoffs And Considerations
This path now resets active merge nodes more aggressively than the old wrapper logic. That is the right trade because continuing a live merge node under stale policy is the real bug.

## Before
```mermaid
flowchart LR
  A[setWorkflowMergeMode] --> B[persist mergeMode in app layer]
  B --> C[partial active-state handling]
  C --> D[merge node can keep stale policy]
```

## After
```mermaid
flowchart LR
  A[setWorkflowMergeMode] --> B[orchestrator.editTaskMergeMode]
  B --> C{same mode?}
  C -- yes --> D[return no-op]
  C -- no --> E{merge node active?}
  E -- yes --> F[cancel first]
  E -- no --> G[persist mergeMode]
  F --> G
  G --> H[retry-class reset via current restartTask primitive]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 9: merge-mode`
