### PR TITLE
Task invalidation step 10: fix-context

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -538,11 +538,17 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
     case 'merge-mode':
       await headlessSetMergeMode(args[1], args[2], deps);
       break;
+    case 'fix-prompt':
+      await headlessSetFixContext(args[1], { fixPrompt: args.slice(2).join(' ') }, deps);
+      break;
+    case 'fix-context':
+      await headlessSetFixContext(args[1], { fixContext: args.slice(2).join(' ') }, deps);
+      break;
     case 'gate-policy':
       await headlessSetGatePolicy(args.slice(1), deps);
       break;
     default:
-      throw new Error(`Unknown set sub-command: "${subCommand}". Use: command, prompt, executor, agent, merge-mode, gate-policy`);
+      throw new Error(`Unknown set sub-command: "${subCommand}". Use: command, prompt, executor, agent, merge-mode, fix-prompt, fix-context, gate-policy`);
   }
 }
 
@@ -778,6 +784,8 @@ ${BOLD}Configure:${RESET}
   set executor <taskId> <type>                        Change executor type (worktree|docker|ssh)
   set agent <taskId> <agent>                          Change execution agent (claude|codex)
   set merge-mode <workflowId> <mode>                  manual | automatic | external_review
+  set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
+  set fix-context <taskId> <text>                     Update fix-session context and retry
   set gate-policy <taskId> <wfId> [depTaskId] <policy>
                                                       policy: completed | review_ready
   migrate-compat                                     Normalize persisted compatibility workflow/task state
@@ -1963,6 +1971,79 @@ async function headlessSetMergeMode(
   }
   const wf = deps.persistence.loadWorkflow(workflowId);
   process.stdout.write(`Merge mode updated for ${workflowId}: ${wf?.mergeMode ?? '?'}\n`);
+}
+
+/**
+ * Headless `set fix-prompt` / `set fix-context` — **retry-class**
+ * invalidation route per Step 10 of
+ * `docs/architecture/task-invalidation-roadmap.md` (chart Decision
+ * Table row "Change fix prompt or fix context while
+ * `fixing_with_ai`"; `MUTATION_POLICIES.fixContext` → `retryTask` /
+ * task scope, scoped to the failed/fixing task).
+ *
+ * Step 10 routes the headless surface through
+ * `commandService.editTaskFixContext` so the orchestrator's
+ * cancel-first seam (`Orchestrator.editTaskFixContext`) runs under
+ * the workflow mutex; same-content no-op detection,
+ * `config.fixPrompt` / `config.fixContext` persistence, and the
+ * single `withBumpedExecutionGeneration` bump live in `restartTask`
+ * (today's `retryTask` compatibility wire — see
+ * `MUTATION_POLICIES.fixContext` and `buildInvalidationDeps`).
+ *
+ * The CLI argument is a task id (matches the Step 2/3 `set command` /
+ * `set prompt` headless surface). The `patch` discriminates between
+ * `fixPrompt` and `fixContext` at the dispatcher: `set fix-prompt`
+ * forwards `{ fixPrompt }`, `set fix-context` forwards
+ * `{ fixContext }`. Omitted keys leave the existing config field
+ * untouched per `Orchestrator.editTaskFixContext`'s same-content
+ * detection contract.
+ */
+async function headlessSetFixContext(
+  taskId: string,
+  patch: { fixPrompt?: string; fixContext?: string },
+  deps: HeadlessDeps,
+): Promise<void> {
+  const which = 'fixPrompt' in patch ? 'fix-prompt' : 'fix-context';
+  if (!taskId) {
+    throw new Error(`Missing arguments. Usage: --headless set ${which} <taskId> <text>`);
+  }
+  const restored = restoreWorkflowForTask(taskId, deps);
+  taskId = restored.resolvedTaskId;
+  const taskExecutor = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
+
+  const envelope = makeEnvelope('edit-task-fix-context', 'headless', 'task', {
+    taskId,
+    ...patch,
+  });
+  const result = await deps.commandService.editTaskFixContext(envelope);
+  if (!result.ok) {
+    autoFix.unsubscribe();
+    throw new Error(result.error.message);
+  }
+  const runnable = result.data.filter((t) => t.status === 'running');
+  if (runnable.length > 0) {
+    await taskExecutor.executeTasks(runnable);
+  }
+  const value = 'fixPrompt' in patch ? patch.fixPrompt : patch.fixContext;
+  process.stdout.write(`Updated ${which} for "${taskId}" → "${value ?? ''}"\n`);
+
+  if (deps.noTrack) {
+    process.stdout.write(`[headless] --no-track enabled: set ${which} accepted; exiting without tracking.\n`);
+    autoFix.unsubscribe();
+    return;
+  }
+  if (runnable.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  await trackHeadlessWorkflow(restored.workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
+  autoFix.unsubscribe();
 }
 
 async function headlessSetGatePolicy(args: string[], deps: HeadlessDeps): Promise<void> {

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -360,6 +360,52 @@ export async function setWorkflowMergeMode(
   }
 }
 
+/**
+ * Persist new fix-session prompt / fix-session context and re-run
+ * the failed task — **retry-class** invalidation route per Step 10
+ * of `docs/architecture/task-invalidation-roadmap.md` and the
+ * Decision Table row "Change fix prompt or fix context while
+ * `fixing_with_ai`" in
+ * `docs/architecture/task-invalidation-chart.md`
+ * (`MUTATION_POLICIES.fixContext` → `retryTask` / task scope).
+ *
+ * Step 10 introduces this wrapper as a thin async delegate around
+ * `Orchestrator.editTaskFixContext` (mirrors the Step 2–9 wrapper
+ * pattern). Prior to Step 10 the fix-session mutation surface had
+ * **no general policy** at all — the chart's "Fix-session
+ * inconsistency" section flagged the bespoke
+ * `beginConflictResolution` / `revertConflictResolution` rollback
+ * as "one special active invalidation mechanism, not a general
+ * one". The substantive routing — same-content no-op detection,
+ * cancel-first interruption when the task is in an active fix
+ * session (`fixing_with_ai`), `fixPrompt` / `fixContext`
+ * persistence on the task config, and the retry-class reset via
+ * `restartTask` (today's `retryTask` compatibility wire — see
+ * `MUTATION_POLICIES.fixContext` and `buildInvalidationDeps`) —
+ * lives in `Orchestrator.editTaskFixContext`. That method is the
+ * synchronous orchestrator-internal seam of `applyInvalidation`'s
+ * Hard Invariant (cancel BEFORE authoritative reset) and reuses
+ * `restartTask`'s reset shape so the task's `agentSessionId` /
+ * `containerId` / `error` / `exitCode` / timing fields are cleared
+ * while branch / workspacePath lineage survives — the chart's
+ * retry-class semantics for fix-context mutations.
+ *
+ * Cancel-first is enforced inside the orchestrator method — this
+ * wrapper MUST NOT add a parallel cancel call.
+ */
+export async function setTaskFixContext(
+  taskId: string,
+  patch: { fixPrompt?: string; fixContext?: string },
+  deps: Pick<ActionDeps, 'orchestrator'> & { taskExecutor: TaskRunner },
+): Promise<TaskState[]> {
+  const started = deps.orchestrator.editTaskFixContext(taskId, patch);
+  const runnable = started.filter((t) => t.status === 'running');
+  if (runnable.length > 0) {
+    await deps.taskExecutor.executeTasks(runnable);
+  }
+  return started;
+}
+
 export async function resolveConflictAction(
   taskId: string,
   deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -6660,6 +6660,477 @@ describe('Orchestrator', () => {
     });
   });
 
+  // ── Step 9 (task-invalidation roadmap): editTaskMergeMode ──────────────
+  //
+  // The chart's Decision Table row "Change merge mode" maps the
+  // `mergeMode` workflow-level mutation to InvalidationAction =
+  // 'retryTask' with InvalidationScope = 'task' applied to the merge
+  // node (`__merge__<workflowId>`). Step 9 migrates the previously
+  // app-layer-only special casing in `setWorkflowMergeMode` onto a
+  // proper orchestrator policy seam: `Orchestrator.editTaskMergeMode`
+  // owns the cancel-first interruption, the workflow-level
+  // `mergeMode` write, and the retry-class merge-node reset (via
+  // `restartTask`), in parity with Step 5/6 (`editTaskType`) and
+  // Step 7/8 (`selectExperiment` / `selectExperiments`).
+  //
+  // The hard invariants pinned below are:
+  //   - same-mode flips are no-ops (no cancel, no generation bump)
+  //   - different-mode flips while the merge node is ACTIVE
+  //     (`running` / `awaiting_approval`) cancel-first BEFORE the
+  //     retry-class reset, and the merge node's execution generation
+  //     bumps by exactly one
+  //   - INACTIVE merge nodes (e.g. `pending`) skip cancel but still
+  //     route through `restartTask` (state reset only, no spurious
+  //     `cancelTask` that would mark a `pending` merge node `failed`)
+  //   - the route NEVER touches `recreateTask` (retry-class only,
+  //     per the chart Decision Table)
+
+  describe('editTaskMergeMode (Step 9 invalidation)', () => {
+    function setupMergeWorkflow(initialMergeMode: 'manual' | 'automatic' | 'external_review' = 'manual'): {
+      mergeId: string;
+      workflowId: string;
+      leafId: string;
+    } {
+      orchestrator.loadPlan({
+        name: 'edit-merge-mode-step9',
+        mergeMode: initialMergeMode,
+        tasks: [
+          { id: 'leaf', description: 'Leaf task' },
+        ],
+      });
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeNode = orchestrator
+        .getAllTasks()
+        .find((t) => t.config.isMergeNode && t.config.workflowId === workflowId);
+      expect(mergeNode).toBeDefined();
+      return {
+        mergeId: mergeNode!.id,
+        workflowId,
+        leafId: sid(orchestrator, 0, 'leaf'),
+      };
+    }
+
+    function driveMergeNodeToRunning(mergeId: string, leafId: string): void {
+      orchestrator.startExecution();
+      // Complete the leaf so the merge node becomes ready and
+      // auto-starts (`startExecution`'s ready-set scheduler drives
+      // it into `running`).
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: leafId, status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      expect(orchestrator.getTask(mergeId)?.status).toBe('running');
+    }
+
+    it('Step 9: routes through restartTask and (when ACTIVE) cancels first — recreateTask MUST NOT be on the route', () => {
+      const { mergeId, leafId } = setupMergeWorkflow('manual');
+      driveMergeNodeToRunning(mergeId, leafId);
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
+
+      orchestrator.editTaskMergeMode(mergeId, 'automatic');
+
+      expect(cancelSpy).toHaveBeenCalledWith(mergeId);
+      expect(restartSpy).toHaveBeenCalledWith(mergeId);
+      expect(recreateSpy).not.toHaveBeenCalled();
+      // Hard Invariant: cancel-first MUST precede the retry-class
+      // reset. `mock.invocationCallOrder` is the global vi-internal
+      // ordering counter — comparing the first cancel/restart call
+      // pins the synchronous ordering inside `editTaskMergeMode`.
+      expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        restartSpy.mock.invocationCallOrder[0],
+      );
+
+      cancelSpy.mockRestore();
+      restartSpy.mockRestore();
+      recreateSpy.mockRestore();
+    });
+
+    it('Step 9: same-mode flip is a NO-OP (no cancel, no restart, no generation bump, no workflow write)', () => {
+      const { mergeId, leafId, workflowId } = setupMergeWorkflow('manual');
+      driveMergeNodeToRunning(mergeId, leafId);
+
+      const beforeGeneration = orchestrator.getTask(mergeId)!.execution.generation ?? 0;
+      const beforeUpdates = persistence.updateWorkflowCalls.get(workflowId) ?? 0;
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+
+      const result = orchestrator.editTaskMergeMode(mergeId, 'manual');
+
+      expect(result).toEqual([]);
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(restartSpy).not.toHaveBeenCalled();
+
+      const afterGeneration = orchestrator.getTask(mergeId)!.execution.generation ?? 0;
+      expect(afterGeneration).toBe(beforeGeneration);
+
+      const afterUpdates = persistence.updateWorkflowCalls.get(workflowId) ?? 0;
+      expect(afterUpdates).toBe(beforeUpdates);
+
+      cancelSpy.mockRestore();
+      restartSpy.mockRestore();
+    });
+
+    it('Step 9: different-mode flip when merge node is ACTIVE bumps execution generation by exactly one', () => {
+      const { mergeId, leafId } = setupMergeWorkflow('manual');
+      driveMergeNodeToRunning(mergeId, leafId);
+
+      const before = orchestrator.getTask(mergeId)!.execution.generation ?? 0;
+
+      orchestrator.editTaskMergeMode(mergeId, 'automatic');
+
+      const after = orchestrator.getTask(mergeId)!.execution.generation ?? 0;
+      expect(after).toBe(before + 1);
+    });
+
+    it('Step 9: different-mode flip persists the new mode on the workflow record', () => {
+      const { mergeId, leafId, workflowId } = setupMergeWorkflow('manual');
+      driveMergeNodeToRunning(mergeId, leafId);
+
+      orchestrator.editTaskMergeMode(mergeId, 'external_review');
+
+      const wf = persistence.loadWorkflow(workflowId);
+      expect(wf?.mergeMode).toBe('external_review');
+    });
+
+    it('Step 9: INACTIVE merge node (pending) skips cancel-first but still routes through restartTask', () => {
+      // Do NOT drive the merge node into a running state; with the
+      // leaf still pending the merge node sits in `pending` (no
+      // in-flight merge work). Cancel-first MUST be skipped because
+      // calling `cancelTask` on a `pending` merge node would mark it
+      // `failed` — exactly the failure mode this guard prevents.
+      const { mergeId } = setupMergeWorkflow('manual');
+      expect(orchestrator.getTask(mergeId)?.status).toBe('pending');
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+
+      orchestrator.editTaskMergeMode(mergeId, 'automatic');
+
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(restartSpy).toHaveBeenCalledWith(mergeId);
+      // Merge node remains `pending` after the retry-class reset
+      // (it is the natural target state of `restartTask`).
+      expect(orchestrator.getTask(mergeId)?.status).toBe('pending');
+
+      cancelSpy.mockRestore();
+      restartSpy.mockRestore();
+    });
+
+    it('Step 9: ACTIVE awaiting_approval (manual gate) merge node cancels first, then resets via restartTask', () => {
+      // The chart calls out `awaiting_approval` (the manual-gate
+      // wait state) explicitly as an ACTIVE state for the merge
+      // node — switching modes mid-review must interrupt the
+      // pending approval and re-schedule the merge under the new
+      // policy.
+      const { mergeId, leafId } = setupMergeWorkflow('manual');
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: leafId, status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      orchestrator.setTaskAwaitingApproval(mergeId);
+      expect(orchestrator.getTask(mergeId)?.status).toBe('awaiting_approval');
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+
+      orchestrator.editTaskMergeMode(mergeId, 'automatic');
+
+      expect(cancelSpy).toHaveBeenCalledWith(mergeId);
+      expect(restartSpy).toHaveBeenCalledWith(mergeId);
+      expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        restartSpy.mock.invocationCallOrder[0],
+      );
+
+      cancelSpy.mockRestore();
+      restartSpy.mockRestore();
+    });
+
+    it('Step 9: throws when called on a non-merge task', () => {
+      const { leafId } = setupMergeWorkflow('manual');
+      expect(() => orchestrator.editTaskMergeMode(leafId, 'automatic')).toThrow(
+        /not a merge node/,
+      );
+    });
+
+    it('Step 9: throws when called on an unknown task id', () => {
+      setupMergeWorkflow('manual');
+      expect(() => orchestrator.editTaskMergeMode('does-not-exist', 'automatic')).toThrow(
+        /not found/,
+      );
+    });
+  });
+
+  // ── Step 10 (task-invalidation roadmap): editTaskFixContext ────────────
+  //
+  // The chart's Decision Table row "Change fix prompt or fix context
+  // while `fixing_with_ai`" maps the `fixContext` mutation to
+  // InvalidationAction = 'retryTask' with InvalidationScope = 'task'
+  // applied to the failed/fixing task. Step 10 lifts the previously
+  // bespoke fix-session handling (`beginConflictResolution` /
+  // `revertConflictResolution`) into a proper orchestrator policy
+  // seam: `Orchestrator.editTaskFixContext` owns the same-content
+  // no-op detection, cancel-first interruption when the task is
+  // actively running an AI fix (`fixing_with_ai`), the
+  // `config.fixPrompt` / `config.fixContext` write, and the
+  // retry-class reset (via `restartTask`), in parity with Step 5/6
+  // (`editTaskType`), Step 7/8 (`selectExperiment` /
+  // `selectExperiments`), and Step 9 (`editTaskMergeMode`).
+  //
+  // The hard invariants pinned below are:
+  //   - same-content edits are no-ops (no cancel, no generation
+  //     bump, no `restartTask`)
+  //   - active fix sessions (`fixing_with_ai`) cancel-first BEFORE
+  //     the retry-class reset, and the task's execution generation
+  //     bumps by exactly one
+  //   - INACTIVE failed tasks skip cancel but still route through
+  //     `restartTask` (state reset only — `agentSessionId` cleared,
+  //     new fix prompt/context persisted)
+  //   - the route NEVER touches `recreateTask` (retry-class only,
+  //     per the chart Decision Table — fix prompt/context changes do
+  //     NOT change the task's execution-defining spec)
+
+  describe('editTaskFixContext invalidation', () => {
+    function setupFailedTask(): { taskId: string; workflowId: string } {
+      orchestrator.loadPlan({
+        name: 'edit-fix-context-step10',
+        onFinish: 'none',
+        tasks: [
+          { id: 't1', description: 'Failing task', command: 'exit 1' },
+        ],
+      });
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const taskId = orchestrator
+        .getAllTasks()
+        .find((t) => t.config.workflowId === workflowId && !t.config.isMergeNode)!.id;
+
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({
+          actionId: taskId,
+          status: 'failed',
+          outputs: { exitCode: 1, error: 'boom' },
+        }),
+      );
+      expect(orchestrator.getTask(taskId)?.status).toBe('failed');
+      publishedDeltas = [];
+      return { taskId, workflowId };
+    }
+
+    function driveTaskToFixingWithAi(taskId: string): void {
+      orchestrator.beginConflictResolution(taskId);
+      expect(orchestrator.getTask(taskId)?.status).toBe('fixing_with_ai');
+      publishedDeltas = [];
+    }
+
+    it('routes through restartTask and cancels active fix sessions first', () => {
+      const { taskId } = setupFailedTask();
+      driveTaskToFixingWithAi(taskId);
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
+
+      orchestrator.editTaskFixContext(taskId, { fixPrompt: 'try a different approach' });
+
+      expect(cancelSpy).toHaveBeenCalledWith(taskId);
+      expect(restartSpy).toHaveBeenCalledWith(taskId);
+      expect(recreateSpy).not.toHaveBeenCalled();
+      // Hard Invariant: cancel-first MUST precede the retry-class
+      // reset. `mock.invocationCallOrder` is the global vi-internal
+      // ordering counter — comparing the first cancel/restart call
+      // pins the synchronous ordering inside `editTaskFixContext`.
+      expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
+        restartSpy.mock.invocationCallOrder[0],
+      );
+
+      cancelSpy.mockRestore();
+      restartSpy.mockRestore();
+      recreateSpy.mockRestore();
+    });
+
+    it('edit on ACTIVE fix session reverts to the failed baseline and persists new fix inputs', () => {
+      const { taskId, workflowId } = setupFailedTask();
+      driveTaskToFixingWithAi(taskId);
+
+      // Seed an `agentSessionId` on the in-flight fix attempt so we
+      // can prove the retry-class reset clears it (the chart's
+      // "retry from reverted failed state" semantics — volatile
+      // fix-attempt state is dropped).
+      persistence.updateTask(taskId, {
+        execution: { agentSessionId: 'agent-session-stale' },
+      });
+      orchestrator.syncFromDb(workflowId);
+      expect(orchestrator.getTask(taskId)?.execution.agentSessionId).toBe(
+        'agent-session-stale',
+      );
+
+      orchestrator.editTaskFixContext(taskId, {
+        fixPrompt: 'use codex instead',
+        fixContext: 'see notes/foo.md',
+      });
+
+      const task = orchestrator.getTask(taskId)!;
+      // restartTask resets to `pending` and may auto-start to
+      // `running` if the task is ready — both are valid
+      // post-retry pre-execution states for the chart's "retry
+      // from reverted failed state" baseline (the fix-loop attempt
+      // is dropped, the failed task lineage is what we retry).
+      expect(['pending', 'running']).toContain(task.status);
+      expect(task.execution.agentSessionId).toBeUndefined();
+      expect(task.config.fixPrompt).toBe('use codex instead');
+      expect(task.config.fixContext).toBe('see notes/foo.md');
+    });
+
+    it('edit on INACTIVE failed task skips cancel but still routes through restartTask', () => {
+      // Failed (not fixing_with_ai) is the inactive fix-loop state.
+      // Cancel-first MUST be skipped because there is no in-flight
+      // fix attempt to interrupt; the task is still settled in
+      // `failed` and a spurious `cancelTask` would treat it as
+      // already-resolved work.
+      const { taskId } = setupFailedTask();
+      expect(orchestrator.getTask(taskId)?.status).toBe('failed');
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+
+      orchestrator.editTaskFixContext(taskId, { fixPrompt: 'fresh try' });
+
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(restartSpy).toHaveBeenCalledWith(taskId);
+
+      const task = orchestrator.getTask(taskId)!;
+      expect(['pending', 'running']).toContain(task.status);
+      expect(task.config.fixPrompt).toBe('fresh try');
+
+      cancelSpy.mockRestore();
+      restartSpy.mockRestore();
+    });
+
+    it('same-content edit is a NO-OP', () => {
+      const { taskId, workflowId } = setupFailedTask();
+      // Seed an existing fixPrompt/fixContext so the next call is a
+      // true same-content re-affirm.
+      persistence.updateTask(taskId, {
+        config: { fixPrompt: 'identical', fixContext: 'identical-ctx' },
+      });
+      orchestrator.syncFromDb(workflowId);
+      const beforeGeneration = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+      publishedDeltas = [];
+
+      const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+
+      const result = orchestrator.editTaskFixContext(taskId, {
+        fixPrompt: 'identical',
+        fixContext: 'identical-ctx',
+      });
+
+      expect(result).toEqual([]);
+      expect(cancelSpy).not.toHaveBeenCalled();
+      expect(restartSpy).not.toHaveBeenCalled();
+
+      const afterGeneration = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+      expect(afterGeneration).toBe(beforeGeneration);
+
+      const fixContextDeltas = publishedDeltas.filter(
+        (d) =>
+          d.type === 'updated' &&
+          d.taskId === taskId &&
+          (d.changes.config?.fixPrompt !== undefined ||
+            d.changes.config?.fixContext !== undefined),
+      );
+      expect(fixContextDeltas).toHaveLength(0);
+
+      cancelSpy.mockRestore();
+      restartSpy.mockRestore();
+    });
+
+    it('omitted patch key leaves the existing config field untouched', () => {
+      const { taskId, workflowId } = setupFailedTask();
+      persistence.updateTask(taskId, {
+        config: { fixPrompt: 'old-prompt', fixContext: 'preserved-context' },
+      });
+      orchestrator.syncFromDb(workflowId);
+
+      orchestrator.editTaskFixContext(taskId, { fixPrompt: 'new-prompt' });
+
+      const task = orchestrator.getTask(taskId)!;
+      expect(task.config.fixPrompt).toBe('new-prompt');
+      expect(task.config.fixContext).toBe('preserved-context');
+    });
+
+    it('content change bumps execution generation by exactly one', () => {
+      const { taskId } = setupFailedTask();
+      const before = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+
+      orchestrator.editTaskFixContext(taskId, { fixPrompt: 'one-shot' });
+
+      const after = orchestrator.getTask(taskId)!.execution.generation ?? 0;
+      expect(after).toBe(before + 1);
+    });
+
+    it('emits a task.updated delta carrying the new fix prompt/context', () => {
+      const { taskId } = setupFailedTask();
+      publishedDeltas = [];
+
+      orchestrator.editTaskFixContext(taskId, {
+        fixPrompt: 'new-prompt',
+        fixContext: 'new-context',
+      });
+
+      const fixContextDeltas = publishedDeltas.filter(
+        (d) =>
+          d.type === 'updated' &&
+          d.taskId === taskId &&
+          d.changes.config?.fixPrompt === 'new-prompt' &&
+          d.changes.config?.fixContext === 'new-context',
+      );
+      expect(fixContextDeltas).toHaveLength(1);
+    });
+
+    it('throws when called on a merge node', () => {
+      orchestrator.loadPlan({
+        name: 'edit-fix-context-merge-step10',
+        mergeMode: 'manual',
+        tasks: [{ id: 'leaf', description: 'Leaf task' }],
+      });
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeNode = orchestrator
+        .getAllTasks()
+        .find((t) => t.config.isMergeNode && t.config.workflowId === workflowId)!;
+      expect(() =>
+        orchestrator.editTaskFixContext(mergeNode.id, { fixPrompt: 'x' }),
+      ).toThrow(/merge node/);
+    });
+
+    it('throws when called on an unknown task id', () => {
+      setupFailedTask();
+      expect(() =>
+        orchestrator.editTaskFixContext('does-not-exist', { fixPrompt: 'x' }),
+      ).toThrow(/not found/);
+    });
+
+    it('throws when called on a task whose status is neither failed nor fixing_with_ai', () => {
+      orchestrator.loadPlan({
+        name: 'edit-fix-context-pending-step10',
+        onFinish: 'none',
+        tasks: [{ id: 't1', description: 'Pending task', command: 'echo hi' }],
+      });
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const taskId = orchestrator
+        .getAllTasks()
+        .find((t) => t.config.workflowId === workflowId && !t.config.isMergeNode)!.id;
+      expect(orchestrator.getTask(taskId)?.status).toBe('pending');
+
+      expect(() =>
+        orchestrator.editTaskFixContext(taskId, { fixPrompt: 'x' }),
+      ).toThrow(/expected: failed \| fixing_with_ai/);
+    });
+  });
+
   // ── Missing state transitions ─────────────────────────────
 
   describe('missing state transitions', () => {

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -227,6 +227,62 @@ export class CommandService {
     );
   }
 
+  /**
+   * Edit a task's fix-session prompt and/or context — **retry-class**
+   * invalidation route per Step 10 of the task-invalidation roadmap
+   * (chart Decision Table row "Change fix prompt or fix context while
+   * `fixing_with_ai`"; `MUTATION_POLICIES.fixContext` → `retryTask` /
+   * task scope, scoped to the failed/fixing task). Mirrors the Step
+   * 5/7/8/9 retry-class seams (`editTaskType` / `selectExperiment` /
+   * `selectExperiments` / `editTaskMergeMode`) rather than the
+   * recreate-class `editTaskCommand` / `editTaskPrompt` /
+   * `editTaskAgent` seams: a fix prompt/context edit redirects the
+   * AI fix attempt without changing the task's execution-defining
+   * spec, so the failed task's branch / workspacePath lineage is
+   * preserved.
+   *
+   * The orchestrator method (`Orchestrator.editTaskFixContext`) is
+   * the synchronous cancel-first seam — it owns same-content no-op
+   * detection, cancel-first interruption when the task is actively
+   * running an AI fix (`fixing_with_ai`), the
+   * `config.fixPrompt` / `config.fixContext` write, and the
+   * `restartTask` retry-class reset that bumps the task's execution
+   * generation exactly once and clears volatile fix-attempt state
+   * (`agentSessionId`, `containerId`, transient
+   * `error`/`exitCode`/timing fields). This service-level entrypoint
+   * just serializes the mutation through the workflow mutex so
+   * concurrent fix-context edits never interleave with each other or
+   * with other in-workflow mutations, then wraps the result in a
+   * `CommandResult`.
+   *
+   * Patch shape: `{ fixPrompt?, fixContext? }`. Either or both keys
+   * may be present in `envelope.payload`. The orchestrator method
+   * treats omitted keys as "no change" so callers can tweak only one
+   * of the two fields without re-supplying the other.
+   */
+  async editTaskFixContext(
+    envelope: CommandEnvelope<{
+      taskId: string;
+      fixPrompt?: string;
+      fixContext?: string;
+    }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'EDIT_TASK_FIX_CONTEXT_FAILED',
+      () => this.orchestrator.editTaskFixContext(
+        envelope.payload.taskId,
+        {
+          ...('fixPrompt' in envelope.payload
+            ? { fixPrompt: envelope.payload.fixPrompt }
+            : {}),
+          ...('fixContext' in envelope.payload
+            ? { fixContext: envelope.payload.fixContext }
+            : {}),
+        },
+      ),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
   async setTaskExternalGatePolicies(
     envelope: CommandEnvelope<{ taskId: string; updates: ExternalGatePolicyUpdate[] }>,
   ): Promise<CommandResult<TaskState[]>> {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1508,7 +1508,75 @@ export class Orchestrator {
   }
 
   /**
-   * Select a winning experiment for a reconciliation task.
+   * Select a winning experiment for a reconciliation task — **retry-class**
+   * invalidation route per Step 7 of
+   * `docs/architecture/task-invalidation-roadmap.md` and the Decision Table
+   * row "Edit selected experiment" in
+   * `docs/architecture/task-invalidation-chart.md`
+   * (`MUTATION_POLICIES.selectedExperiment` → `retryTask` / task scope).
+   *
+   * Why retry-class (not recreate-class). The chart classifies single
+   * experiment selection as a downstream-input mutation: the
+   * reconciliation task's *result* (its selected branch/commit) is the
+   * execution input that downstream consumers use, so changing the
+   * winner invalidates downstream attempts but does NOT change the
+   * reconciliation task's own spec. The chart's "Why" column reads
+   * "Downstream execution inputs changed". `applyInvalidation('task',
+   * 'retryTask', reconId, deps)` is wired to today's
+   * `Orchestrator.restartTask` via `buildInvalidationDeps` (the
+   * compatibility seam Step 1 introduced; Step 13 will rename
+   * `restartTask` → `retryTask` to close the matrix).
+   *
+   * Sequence (mirrors `applyInvalidation`'s contract for the
+   * synchronous orchestrator-internal seam — see `invalidation-policy.ts`
+   * and the Step 5/6 `editTaskType` precedent):
+   *   1. **Cancel-first (Hard Invariant).** Compute the transitive
+   *      downstream subgraph of the reconciliation task and cancel any
+   *      member that is actively executing (`running` or
+   *      `fixing_with_ai`) BEFORE we mutate the recon's
+   *      `selectedExperiment`. This is the "any AFFECTED in-flight
+   *      work" guarantee from the chart: stale downstream attempts
+   *      cannot survive a re-selection because they would consume the
+   *      OLD winner's lineage. For the common initial-selection path
+   *      (recon `needs_input` → `completed` with downstream blocked at
+   *      `pending`) this loop is a no-op — there is nothing active.
+   *   2. **Persist new winner.** `writeAndSync` updates
+   *      `execution.selectedExperiment` (and the recon's
+   *      `branch`/`commit` to mirror the winner's lineage) and emits a
+   *      `task.completed` delta. The reconciliation task's status
+   *      transitions to `completed`; this matches the existing
+   *      "Behavior Today" column in the chart ("completes
+   *      reconciliation task and unblocks downstream").
+   *   3. **Retry-class reset of downstream (re-selection only).** When
+   *      the recon was previously completed with a *different* winner,
+   *      every direct downstream consumer is reset via `restartTask`,
+   *      which is the current `retryTask` compatibility wire.
+   *      `restartTask` cascades to its own descendants and bumps each
+   *      affected task's execution generation exactly once via
+   *      `withBumpedExecutionGeneration` (single source of truth for the
+   *      retry reset shape — Step 7 deliberately reuses it instead of
+   *      duplicating the field list here, mirroring Steps 5/6). For
+   *      the initial-selection path no downstream reset is needed
+   *      because nothing has executed yet against the recon's result.
+   *   4. **Auto-start newly ready tasks.** Existing behavior:
+   *      `findNewlyReadyTasks(reconId)` plus `autoStartReadyTasks`
+   *      unblocks downstream that just became ready due to recon
+   *      completing.
+   *
+   * Public surface is unchanged: same `(taskId, experimentId)` signature
+   * returning `TaskState[]` of newly-started tasks. Active downstream is
+   * NO LONGER silently overwritten with a new winner — that's the whole
+   * point of cancel-first per the chart's Hard Invariant. Prior to
+   * Step 7 there was no general active invalidation model for selection
+   * (per the chart's "Behavior Today" column); this method introduces
+   * one.
+   *
+   * NOTE: `recreateTask`'s lineage-discarding reset shape is
+   * deliberately NOT used here. Downstream tasks may still hold valid
+   * workspace lineage (their own branch, their own workspacePath) that
+   * the executor can reuse when the new winner's branch is rebased onto
+   * theirs; that is what makes selection retry-class rather than
+   * recreate-class in the chart's Decision Table.
    */
   selectExperiment(taskId: string, experimentId: string): TaskState[] {
     this.refreshFromDb();
@@ -1532,7 +1600,6 @@ export class Orchestrator {
       prevCanon.every((id, i) => id === newCanon[i]);
     const isReSelection = previousSet !== undefined && !sameAsPrev;
     const allTasksBefore = this.stateMachine.getAllTasks();
-
     if (isReSelection) {
       const taskMapBefore = new Map(allTasksBefore.map((t) => [t.id, t]));
       const downstreamIds = getTransitiveDependents(reconId, taskMapBefore, () => false);
@@ -2302,6 +2369,155 @@ export class Orchestrator {
     // generation exactly once via `withBumpedExecutionGeneration`
     // while preserving branch/workspacePath lineage — the chart's
     // retry-class semantics for merge-mode mutations.
+    return this.restartTask(taskId);
+  }
+
+  /**
+   * Edit a task's fix-session prompt and/or context — **retry-class**
+   * invalidation route per Step 10 of
+   * `docs/architecture/task-invalidation-roadmap.md` and the Decision
+   * Table row "Change fix prompt or fix context while `fixing_with_ai`"
+   * in `docs/architecture/task-invalidation-chart.md`
+   * (`MUTATION_POLICIES.fixContext` → `retryTask` / task scope).
+   *
+   * Why this is a migration, not a new policy. Prior to Step 10 the
+   * fix-session mutation surface had **no general policy** at all —
+   * the chart's "Behavior Today" column flags this row as
+   * "only command edit has explicit handling today; no general
+   * fix-context mutation policy" and the chart's "Fix-session
+   * inconsistency" subsection calls out the bespoke
+   * `beginConflictResolution` / `revertConflictResolution` rollback
+   * as "one special active invalidation mechanism, not a general
+   * one". Step 10 lifts that bespoke fix-session handling into a
+   * proper orchestrator policy seam (`Orchestrator.editTaskFixContext`)
+   * so cancel-first + retry-class reset are enforced uniformly across
+   * `failed` and `fixing_with_ai` task states; the app wrapper
+   * (`setTaskFixContext`) becomes a thin async delegate (mirrors
+   * Steps 2–9).
+   *
+   * "Retry from reverted failed state" semantics. The chart's
+   * `Target Action` column for this row reads
+   * `retryTask` from reverted failed state — i.e. when the user
+   * changes `fixPrompt`/`fixContext` mid-fix-session the in-flight
+   * AI fix attempt is dropped, the task lineage falls back to its
+   * `failed` baseline (volatile fix-attempt state — `agentSessionId`,
+   * `containerId`, transient `error`/`exitCode`/timing fields —
+   * cleared by `restartTask`), and a fresh fix attempt is scheduled
+   * with the new prompt/context. Branch / workspacePath lineage
+   * survives because this is the same failed task being retried
+   * through the fix loop, not a new task topology.
+   *
+   * Sequence (mirrors `applyInvalidation`'s contract for the
+   * synchronous orchestrator-internal seam — see
+   * `invalidation-policy.ts` and the Step 9 `editTaskMergeMode`
+   * precedent):
+   *   1. **Same-content no-op.** If neither `fixPrompt` nor
+   *      `fixContext` is changing (omitted keys count as "no
+   *      change"), return `[]` without canceling, persisting, or
+   *      bumping execution generation. Without this guard a UI/CLI
+   *      re-affirm of identical fix context would needlessly cancel
+   *      an active fix session and bump the task's execution
+   *      generation.
+   *   2. **Cancel-first (Hard Invariant).** When the task is
+   *      actively running an AI fix (`fixing_with_ai`) interrupt it
+   *      via `cancelTask` BEFORE the new fix prompt/context is
+   *      persisted or `restartTask` resets the task. A failed task
+   *      (the inactive fix-loop state) skips cancel — there is no
+   *      in-flight fix attempt to interrupt and `cancelTask` would
+   *      otherwise treat the failed task as already settled.
+   *   3. **Persist new fix prompt/context.** `writeAndSync` updates
+   *      `config.fixPrompt` / `config.fixContext` (only the keys
+   *      present in the patch) and emits a `task.updated` delta so
+   *      the retried fix attempt picks up the new prompt/context.
+   *   4. **Retry-class reset.** Delegate to `restartTask` (today's
+   *      `retryTask` compatibility wire — see
+   *      `MUTATION_POLICIES.fixContext` and `buildInvalidationDeps`).
+   *      It resets the task to `pending`, clears volatile attempt
+   *      state (`agentSessionId`, `containerId`, transient
+   *      `error`/`exitCode`/timing fields), and bumps execution
+   *      generation exactly once via
+   *      `withBumpedExecutionGeneration`, preserving branch /
+   *      workspacePath lineage. This is the chart's "retry from
+   *      reverted failed state" baseline.
+   *
+   * Patch shape: `{ fixPrompt?, fixContext? }`. Either or both keys
+   * may be present. Omitted keys leave the existing config field
+   * untouched — same-content detection treats missing keys as "no
+   * change" so a `fix-prompt`-only edit does not clobber an
+   * existing `fixContext`.
+   *
+   * Active states accepted: `failed`, `fixing_with_ai`. Other states
+   * throw — the chart scopes this mutation to the fix loop.
+   *
+   * NOTE: `restartTask` is intentionally used here (not
+   * `recreateTask`) because Step 10 is retry-class — fix
+   * prompt/context changes do NOT change the task's execution-defining
+   * spec (`command` / `prompt` / `executionAgent` / `executorType` /
+   * `remoteTargetId`); they only redirect the AI fix attempt that
+   * runs against an already-failed task lineage.
+   */
+  editTaskFixContext(
+    taskId: string,
+    patch: { fixPrompt?: string; fixContext?: string },
+  ): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (task.config.isMergeNode) {
+      throw new Error(`Cannot edit fix context of merge node ${taskId}`);
+    }
+    if (task.status !== 'failed' && task.status !== 'fixing_with_ai') {
+      throw new Error(
+        `Cannot edit fix context for task "${taskId}" in status "${task.status}" ` +
+          `(expected: failed | fixing_with_ai)`,
+      );
+    }
+
+    // Step 10 same-content no-op: skip cancel + persist + retry when
+    // neither key in the patch differs from the persisted config.
+    // Omitted keys count as "no change" so a prompt-only edit does
+    // not require the caller to also re-supply the existing context.
+    const hasPromptKey = Object.prototype.hasOwnProperty.call(patch, 'fixPrompt');
+    const hasContextKey = Object.prototype.hasOwnProperty.call(patch, 'fixContext');
+    const promptMatches = !hasPromptKey || patch.fixPrompt === task.config.fixPrompt;
+    const contextMatches = !hasContextKey || patch.fixContext === task.config.fixContext;
+    if (promptMatches && contextMatches) {
+      return [];
+    }
+
+    // Step 10 cancel-first (chart Hard Invariant): when the task is
+    // actively running an AI fix attempt (`fixing_with_ai`) interrupt
+    // it BEFORE we persist the new fix prompt/context and reset the
+    // task via `restartTask`. The in-flight fix attempt's execution
+    // input — the prompt/context — just changed, so it cannot
+    // survive. A failed task (the inactive fix-loop state) skips
+    // cancel: there is no in-flight fix attempt to interrupt.
+    if (task.status === 'fixing_with_ai') {
+      this.cancelTask(taskId);
+    }
+
+    const configPatch: Record<string, unknown> = {};
+    if (hasPromptKey) configPatch.fixPrompt = patch.fixPrompt;
+    if (hasContextKey) configPatch.fixContext = patch.fixContext;
+    const fixContextChanges: TaskStateChanges = { config: configPatch };
+    this.writeAndSync(taskId, fixContextChanges);
+    const fixContextDelta: TaskDelta = {
+      type: 'updated',
+      taskId,
+      changes: fixContextChanges,
+    };
+    this.persistence.logEvent?.(taskId, 'task.updated', fixContextChanges);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, fixContextDelta);
+
+    // Step 10 retry-class reset: restartTask is today's `retryTask`
+    // compatibility wire (`buildInvalidationDeps` →
+    // `orchestrator.restartTask`). It resets the task to `pending`,
+    // clears volatile attempt state (`agentSessionId`, `containerId`,
+    // transient `error`/`exitCode`/timing fields), and bumps
+    // execution generation exactly once via
+    // `withBumpedExecutionGeneration` while preserving branch /
+    // workspacePath lineage — the chart's "retry from reverted
+    // failed state" baseline for fix-context mutations.
     return this.restartTask(taskId);
   }
 

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -45,6 +45,20 @@ export interface BaseTaskConfig {
   readonly externalDependencies?: readonly ExternalDependency[];
   /** Remote target identifier for executor routing. Primarily used by SSH executors but can be set on any task via routing rules. */
   readonly remoteTargetId?: string;
+  /**
+   * Fix-session prompt override carried on the failed task across the
+   * `failed` → `fixing_with_ai` → `failed` cycle (Step 10 of the
+   * task-invalidation roadmap). Mutating either `fixPrompt` or
+   * `fixContext` routes through `Orchestrator.editTaskFixContext`
+   * (`MUTATION_POLICIES.fixContext` → `retryTask` / task scope) and
+   * retries from the reverted failed-state baseline.
+   */
+  readonly fixPrompt?: string;
+  /**
+   * Fix-session context override (e.g. extra notes/files surfaced to the
+   * fix agent) carried alongside `fixPrompt`. See `fixPrompt`.
+   */
+  readonly fixContext?: string;
 }
 
 export interface WorktreeTaskConfig extends BaseTaskConfig {


### PR DESCRIPTION
## Summary
This change makes fix prompt and fix context edits explicit lifecycle mutations instead of ad hoc fix-session inputs. The new path gives those values a typed home in task config and routes updates through the invalidation seam rather than letting conflict-resolution code synthesize them implicitly.

## Problem
Fix prompt and fix context changes were applied as special-case fix-session input, which made their lifecycle behavior hard to reason about and hard to verify.

## Root Cause
The system treated fix-session prompt/context as resolver-local data instead of first-class mutation input. That hid when a live fix attempt was now running with stale input.

## Approach
Add `CommandService.editTaskFixContext` and `Orchestrator.editTaskFixContext`, persist the updated config there, and apply retry-class invalidation when the fix input changes.

## Why This Fix Is Right
The important distinction is not "AI gets special treatment." The real rule is that editing fix prompt or fix context changes the input being consumed by an active fix session. If the task is already in `fixing_with_ai`, cancel-first is correct because continuing the live attempt with stale prompt/context is the bug. If the task is merely `failed`, there is no live fix session to cancel.

## Tradeoffs And Considerations
This adds a broader explicit mutation surface. That is worth it because the old implicit behavior was harder to audit and easy to mis-describe as product-specific magic rather than plain lifecycle handling.

## Before
```mermaid
flowchart LR
  A[Fix prompt/context edit] --> B[Conflict resolver builds prompt ad hoc]
  B --> C[No explicit lifecycle mutation]
  C --> D[Active fix can keep stale input]
```

## After
```mermaid
flowchart LR
  A[Fix prompt/context edit] --> B[CommandService.editTaskFixContext]
  B --> C[Orchestrator.editTaskFixContext]
  C --> D{task already fixing?}
  D -- yes --> E[cancel active fix first]
  D -- no --> F[skip cancel]
  E --> G[retry-class reset with updated config]
  F --> G
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 10: fix-context`
