### PR TITLE
Task invalidation step 11: topology-fork

### DIFF
--- a/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
+++ b/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
@@ -134,6 +134,15 @@ describe('app-layer handoff repros', () => {
     h.loadAndStart(LINEAR_PLAN);
     h.failTask('A', 'broken');
 
+    // Step 11 (`docs/architecture/task-invalidation-roadmap.md`):
+    // `replaceTask` is a topology mutation and now throws
+    // `TopologyForkRequired` whenever any non-merge task is still in a
+    // live status. LINEAR_PLAN is A → B; after failTask('A'), B is
+    // `pending` so we cancel it before exercising the in-place
+    // replacement path. The handoff/workspacePath assertions below
+    // are unchanged.
+    h.orchestrator.cancelTask('B');
+
     const started = h.orchestrator.replaceTask('A', [
       { id: 'A-fix-1', description: 'Fix part 1', command: 'echo fix1' },
       { id: 'A-fix-2', description: 'Fix part 2', command: 'echo fix2', dependencies: ['A-fix-1'] },

--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -541,6 +541,15 @@ describe('Flow 4: edit/fork mutations', () => {
     expect(h.getTask('A')!.status).toBe('failed');
     expect(h.getTask('B')!.status).toBe('pending');
 
+    // Step 11 (`docs/architecture/task-invalidation-roadmap.md`):
+    // `replaceTask` now throws `TopologyForkRequired` when the workflow
+    // is live (any non-merge task still pending/running/...). LINEAR_PLAN
+    // here is A → B → C, and after failTask('A') both B and C remain
+    // `pending`, so we cancel the live downstream subgraph (B drags C
+    // with it) before exercising the in-place replacement path. The
+    // assertions about the replacement subgraph are unchanged.
+    h.orchestrator.cancelTask('B');
+
     // Replace A with two sub-tasks
     const replacements = h.orchestrator.replaceTask('A', [
       { id: 'A-fix-1', description: 'Fix part 1', command: 'echo fix1' },

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -13,6 +13,7 @@ type MockedDeps = InvalidationDeps & {
   retryWorkflow: ReturnType<typeof vi.fn>;
   recreateWorkflow: ReturnType<typeof vi.fn>;
   recreateWorkflowFromFreshBase?: ReturnType<typeof vi.fn>;
+  workflowFork?: ReturnType<typeof vi.fn>;
 };
 
 function makeDeps(overrides: Partial<MockedDeps> = {}): MockedDeps {
@@ -39,6 +40,10 @@ describe('MUTATION_POLICIES', () => {
     expect(MUTATION_POLICIES.fixContext.action).toBe('retryTask');
     expect(MUTATION_POLICIES.rebaseAndRetry.action).toBe('recreateWorkflowFromFreshBase');
     expect(MUTATION_POLICIES.externalGatePolicy.action).toBe('none');
+    // Step 11: graph topology is the lone fork-class / workflow-scope row.
+    expect(MUTATION_POLICIES.topology.action).toBe('workflowFork');
+    expect(MUTATION_POLICIES.topology.invalidatesExecutionSpec).toBe(true);
+    expect(MUTATION_POLICIES.topology.invalidateIfActive).toBe(true);
   });
 
   it('marks every spec-changing mutation as invalidating-if-active', () => {
@@ -234,5 +239,45 @@ describe('applyInvalidation: recreateWorkflowFromFreshBase optional dep', () => 
     const deps = makeDeps({ recreateWorkflowFromFreshBase });
     await applyInvalidation('workflow', 'recreateWorkflowFromFreshBase', 'wf-1', deps);
     expect(recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1');
+  });
+});
+
+// Step 11 (`docs/architecture/task-invalidation-roadmap.md`): the
+// `'workflowFork'` action represents fork-class / workflow scope. Like
+// `'recreateWorkflowFromFreshBase'` it is gated behind an optional dep
+// that Step 12 supplies. Until then any caller that selects this
+// action sees an explicit "not yet wired (Step 12)" error so misuse
+// fails fast instead of silently no-op'ing.
+describe('applyInvalidation: workflowFork optional dep', () => {
+  it('throws an explicit "not yet wired (Step 12)" error when dep is absent', async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('workflow', 'workflowFork', 'wf-1', deps),
+    ).rejects.toThrow(/not yet wired \(Step 12\)/);
+  });
+
+  it('routes to the provided dep when present', async () => {
+    const workflowFork = vi.fn(async () => []);
+    const deps = makeDeps({ workflowFork });
+    await applyInvalidation('workflow', 'workflowFork', 'wf-1', deps);
+    expect(workflowFork).toHaveBeenCalledWith('wf-1');
+  });
+
+  it('rejects task-scoped invocation with workflowFork action', async () => {
+    const deps = makeDeps({ workflowFork: vi.fn(async () => []) });
+    await expect(
+      applyInvalidation('task', 'workflowFork', 'task-a', deps),
+    ).rejects.toThrow(/requires scope 'workflow'/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+  });
+
+  it('cancel-first ordering applies to workflowFork', async () => {
+    const workflowFork = vi.fn(async () => []);
+    const deps = makeDeps({ workflowFork });
+    await applyInvalidation('workflow', 'workflowFork', 'wf-1', deps);
+    expect(deps.cancelInFlight).toHaveBeenCalledWith('workflow', 'wf-1');
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      workflowFork.mock.invocationCallOrder[0],
+    );
   });
 });

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { reconciliationNeedsInputWorkResponse } from './reconciliation-needs-input-shim.js';
 import { rid, sid } from './scoped-test-helpers.js';
-import { Orchestrator, PlanConflictError, descriptionForMergeNode } from '../orchestrator.js';
+import { Orchestrator, PlanConflictError, TopologyForkRequired, descriptionForMergeNode } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
 import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
@@ -8375,6 +8375,105 @@ describe('Orchestrator', () => {
         makeResponse({ actionId: 'task-b', status: 'completed', outputs: { exitCode: 0 } }),
       );
       expect(orchestrator.getTask('task-a')!.status).toBe('failed');
+    });
+  });
+
+  // Step 11 (`docs/architecture/task-invalidation-roadmap.md`): topology
+  // mutations on a live workflow throw `TopologyForkRequired`. The
+  // orchestrator unit-test layer asserts the gate's interaction with
+  // adjacent invariants here; replace-task.test.ts and
+  // state-topology-matrix.test.ts cover the full matrix.
+  describe('replaceTask topology-fork gate', () => {
+    it('throws TopologyForkRequired with workflowId + taskId on a live workflow', () => {
+      orchestrator.loadPlan({
+        name: 'topology-gate-live',
+        tasks: [
+          { id: 'A', description: 'A', command: 'echo A' },
+          { id: 'X', description: 'X', command: 'echo X', dependencies: ['A'] },
+          { id: 'C', description: 'C', command: 'echo C', dependencies: ['X'] },
+        ],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'A', status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'X', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
+      );
+
+      const xTask = orchestrator.getTask('X')!;
+      const wfId = xTask.config.workflowId!;
+      const scopedXId = xTask.id;
+
+      let caught: unknown;
+      try {
+        orchestrator.replaceTask('X', [
+          { id: 'fix', description: 'Fix', command: 'echo fix' },
+        ]);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(TopologyForkRequired);
+      const err = caught as TopologyForkRequired;
+      expect(err.workflowId).toBe(wfId);
+      expect(err.taskId).toBe(scopedXId);
+      expect(err.message).toContain(wfId);
+      expect(err.message).toContain(scopedXId);
+
+      // Source unchanged, no replacement created.
+      expect(orchestrator.getTask('X')!.status).toBe('failed');
+      expect(orchestrator.getTask('fix')).toBeUndefined();
+    });
+
+    it('allows in-place replacement on a fully terminal workflow', () => {
+      orchestrator.loadPlan({
+        name: 'topology-gate-terminal',
+        tasks: [
+          { id: 'A', description: 'A', command: 'echo A' },
+          { id: 'X', description: 'X', command: 'echo X', dependencies: ['A'] },
+          { id: 'C', description: 'C', command: 'echo C', dependencies: ['X'] },
+        ],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'A', status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'X', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
+      );
+      // Cancel C → workflow now has no live non-merge tasks.
+      orchestrator.cancelTask('C');
+
+      orchestrator.replaceTask('X', [
+        { id: 'fix', description: 'Fix', command: 'echo fix' },
+      ]);
+
+      expect(orchestrator.getTask('X')!.status).toBe('stale');
+      expect(orchestrator.getTask('fix')).toBeDefined();
+    });
+
+    it('does not gate pure-attribute mutations even when the workflow is live', () => {
+      orchestrator.loadPlan({
+        name: 'topology-gate-attr',
+        tasks: [
+          { id: 'A', description: 'A', command: 'echo A' },
+          { id: 'X', description: 'X', command: 'echo X', dependencies: ['A'] },
+          { id: 'C', description: 'C', command: 'echo C', dependencies: ['X'] },
+        ],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'A', status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'X', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
+      );
+      // C is `pending` → workflow is live by the Step 11 definition.
+      expect(orchestrator.getTask('C')!.status).toBe('pending');
+
+      // Pure-attribute edit must succeed without raising the topology gate.
+      expect(() => orchestrator.editTaskCommand('A', 'echo A-v2')).not.toThrow();
+      expect(orchestrator.getTask('A')!.config.command).toBe('echo A-v2');
     });
   });
 });

--- a/packages/workflow-core/src/__tests__/replace-task.test.ts
+++ b/packages/workflow-core/src/__tests__/replace-task.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { sid } from './scoped-test-helpers.js';
-import { Orchestrator } from '../orchestrator.js';
+import { Orchestrator, TopologyForkRequired } from '../orchestrator.js';
 import type { OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
 import type { TaskState, TaskStateChanges, Attempt } from '../task-types.js';
 import { validateDAG } from '../dag.js';
@@ -111,6 +111,27 @@ function getNonStaleTasks(orchestrator: Orchestrator): TaskState[] {
   return orchestrator.getAllTasks().filter((t) => t.status !== 'stale');
 }
 
+/**
+ * Step 11 (`docs/architecture/task-invalidation-roadmap.md`) makes
+ * `replaceTask` throw `TopologyForkRequired` whenever the workflow has
+ * any non-merge task in a live status (pending, running, ...). The
+ * existing in-place replacement scenarios in this file model a
+ * "downstream is still pending" case, which is precisely what the new
+ * gate forbids. To preserve the underlying assertions about the
+ * post-mutation graph shape (source → stale, replacement created,
+ * merge node reconciled), each scenario first terminates the live
+ * downstream subgraph by cancelling the topmost live descendant. The
+ * cancel marks the descendant + its transitive dependents as `failed`,
+ * making the workflow terminal so `replaceTask` can mutate in place.
+ *
+ * The post-mutation `expect(... .status).toBe('stale')` assertions
+ * still hold because `replaceTask` unconditionally re-marks all
+ * non-merge transitive descendants of the source as `stale`.
+ */
+function terminateLiveDescendant(orchestrator: Orchestrator, descendantId: string): void {
+  orchestrator.cancelTask(descendantId);
+}
+
 // ── Tests ────────────────────────────────────────────────────
 
 describe('replaceTask', () => {
@@ -142,6 +163,7 @@ describe('replaceTask', () => {
     failTask(orchestrator, 'X');
 
     const s = (l: string) => sid(orchestrator, 0, l);
+    terminateLiveDescendant(orchestrator, 'C');
     const started = orchestrator.replaceTask('X', [
       { id: 'fix', description: 'Fix X', command: 'echo fix' },
     ]);
@@ -176,6 +198,7 @@ describe('replaceTask', () => {
     failTask(orchestrator, 'X');
 
     const s = (l: string) => sid(orchestrator, 0, l);
+    terminateLiveDescendant(orchestrator, 'C');
     orchestrator.replaceTask('X', [
       { id: 's1', description: 'Step 1', command: 'echo s1' },
       { id: 's2', description: 'Step 2', command: 'echo s2', dependencies: ['s1'] },
@@ -203,6 +226,7 @@ describe('replaceTask', () => {
     completeTask(orchestrator, 'A');
     failTask(orchestrator, 'X');
 
+    terminateLiveDescendant(orchestrator, 'C');
     orchestrator.replaceTask('X', [
       { id: 's1', description: 'Step 1', command: 'echo s1' },
       { id: 's2a', description: 'Branch A', command: 'echo s2a', dependencies: ['s1'] },
@@ -258,6 +282,7 @@ describe('replaceTask', () => {
     failTask(orchestrator, 'X');
 
     const s = (l: string) => sid(orchestrator, 0, l);
+    terminateLiveDescendant(orchestrator, 'C');
     orchestrator.replaceTask('X', [
       { id: 'fix', description: 'Fix', command: 'echo fix' },
     ]);
@@ -283,6 +308,7 @@ describe('replaceTask', () => {
     expect(orchestrator.getTask('D')!.status).toBe('pending');
 
     const s = (l: string) => sid(orchestrator, 0, l);
+    terminateLiveDescendant(orchestrator, 'C');
     orchestrator.replaceTask('X', [
       { id: 'fix', description: 'Fix', command: 'echo fix' },
     ]);
@@ -343,6 +369,7 @@ describe('replaceTask', () => {
     failTask(orchestrator, 'X');
 
     const s = (l: string) => sid(orchestrator, 0, l);
+    terminateLiveDescendant(orchestrator, 'C');
     orchestrator.replaceTask('X', [
       { id: 'fix', description: 'Fix', command: 'echo fix' },
     ]);
@@ -378,6 +405,8 @@ describe('replaceTask', () => {
     completeTask(orchestrator, 'A');
     failTask(orchestrator, 'X');
 
+    terminateLiveDescendant(orchestrator, 'C');
+    terminateLiveDescendant(orchestrator, 'D');
     orchestrator.replaceTask('X', [
       { id: 's1', description: 'S1', command: 'echo s1' },
       { id: 's2', description: 'S2', command: 'echo s2', dependencies: ['s1'] },
@@ -425,5 +454,169 @@ describe('replaceTask', () => {
     ]);
 
     expect(orchestrator.getTask('fix')!.config.executorType).toBe('docker');
+  });
+
+  // ── Step 11 (task-invalidation roadmap): topology-fork policy ──
+  //
+  // The chart's Decision Table row "Change graph topology" makes
+  // graph-shape changes fork-class / workflow scope: they must NOT
+  // mutate a live workflow in place. Instead, callers see a
+  // `TopologyForkRequired` error pointing them at the (Step 12)
+  // forkWorkflow API. In-place is preserved on a fully terminal
+  // workflow because there is no in-flight work to race with.
+  describe('topology-fork policy', () => {
+    it('throws TopologyForkRequired when downstream is still pending', () => {
+      orchestrator.loadPlan({
+        name: 'topology-live',
+        tasks: [
+          { id: 'A', description: 'A', command: 'echo A' },
+          { id: 'X', description: 'X', command: 'echo X', dependencies: ['A'] },
+          { id: 'C', description: 'C', command: 'echo C', dependencies: ['X'] },
+        ],
+      });
+      orchestrator.startExecution();
+      completeTask(orchestrator, 'A');
+      failTask(orchestrator, 'X');
+
+      // C is still pending → workflow is live → must fork, not mutate.
+      const s = (l: string) => sid(orchestrator, 0, l);
+      const wfId = orchestrator.getTask(s('X'))!.config.workflowId!;
+
+      let caught: unknown;
+      try {
+        orchestrator.replaceTask('X', [
+          { id: 'fix', description: 'Fix', command: 'echo fix' },
+        ]);
+      } catch (err) {
+        caught = err;
+      }
+
+      expect(caught).toBeInstanceOf(TopologyForkRequired);
+      const err = caught as TopologyForkRequired;
+      expect(err.workflowId).toBe(wfId);
+      expect(err.taskId).toBe(s('X'));
+      // Message must surface both ids for the caller and the fix-up
+      // hint pointing at Step 12's forkWorkflow API.
+      expect(err.message).toContain(wfId);
+      expect(err.message).toContain(s('X'));
+      expect(err.message).toMatch(/fork/i);
+      expect(err.message).toMatch(/Step 12/);
+
+      // Source must NOT have been mutated in place.
+      expect(orchestrator.getTask(s('X'))!.status).toBe('failed');
+      expect(orchestrator.getTask(s('C'))!.status).toBe('pending');
+      expect(orchestrator.getTask('fix')).toBeUndefined();
+    });
+
+    it('throws TopologyForkRequired when a sibling is still running', () => {
+      orchestrator.loadPlan({
+        name: 'topology-live-sibling',
+        tasks: [
+          { id: 'A', description: 'A', command: 'echo A' },
+          { id: 'X', description: 'X', command: 'echo X', dependencies: ['A'] },
+          { id: 'Y', description: 'Y', command: 'echo Y', dependencies: ['A'] },
+        ],
+      });
+      orchestrator.startExecution();
+      completeTask(orchestrator, 'A');
+      failTask(orchestrator, 'X');
+      // Y is now `running` after A completed.
+
+      expect(orchestrator.getTask('Y')!.status).toBe('running');
+
+      const s = (l: string) => sid(orchestrator, 0, l);
+      expect(() =>
+        orchestrator.replaceTask('X', [
+          { id: 'fix', description: 'Fix', command: 'echo fix' },
+        ]),
+      ).toThrow(TopologyForkRequired);
+
+      // Y is still running, X is still failed — no in-place mutation.
+      expect(orchestrator.getTask('Y')!.status).toBe('running');
+      expect(orchestrator.getTask(s('X'))!.status).toBe('failed');
+    });
+
+    it('allows in-place replacement on a terminal workflow', () => {
+      orchestrator.loadPlan({
+        name: 'topology-terminal',
+        tasks: [
+          { id: 'A', description: 'A', command: 'echo A' },
+          { id: 'X', description: 'X', command: 'echo X', dependencies: ['A'] },
+          { id: 'C', description: 'C', command: 'echo C', dependencies: ['X'] },
+        ],
+      });
+      orchestrator.startExecution();
+      completeTask(orchestrator, 'A');
+      failTask(orchestrator, 'X');
+      // Cancel C to make the workflow terminal (no live non-merge tasks).
+      terminateLiveDescendant(orchestrator, 'C');
+
+      const s = (l: string) => sid(orchestrator, 0, l);
+      const started = orchestrator.replaceTask('X', [
+        { id: 'fix', description: 'Fix', command: 'echo fix' },
+      ]);
+
+      expect(orchestrator.getTask(s('X'))!.status).toBe('stale');
+      expect(orchestrator.getTask(s('fix'))).toBeDefined();
+      expect(started.find((t) => t.id === s('fix'))).toBeDefined();
+    });
+
+    it('error class round-trips workflowId / taskId properties', () => {
+      const err = new TopologyForkRequired('wf-42', 'wf-42/X');
+      expect(err).toBeInstanceOf(Error);
+      expect(err.name).toBe('TopologyForkRequired');
+      expect(err.workflowId).toBe('wf-42');
+      expect(err.taskId).toBe('wf-42/X');
+      expect(err.message).toContain('wf-42');
+      expect(err.message).toContain('wf-42/X');
+    });
+
+    // The Step 11 gate sits BEFORE the topology mutation but AFTER the
+    // earliest validation errors (not-found, running, empty). Those
+    // errors continue to take precedence so that callers see the same
+    // diagnostics they did before this step.
+    it('not-found error still wins over topology check', () => {
+      orchestrator.loadPlan({
+        name: 'topology-precedence',
+        tasks: [
+          { id: 'A', description: 'A', command: 'echo A' },
+          { id: 'X', description: 'X', command: 'echo X', dependencies: ['A'] },
+          { id: 'C', description: 'C', command: 'echo C', dependencies: ['X'] },
+        ],
+      });
+      orchestrator.startExecution();
+      // Workflow is live (everything pending), but the task id is bogus.
+      expect(() =>
+        orchestrator.replaceTask('does-not-exist', [
+          { id: 'fix', description: 'Fix', command: 'echo fix' },
+        ]),
+      ).toThrow(/not found/);
+    });
+
+    // Step 11 must not affect pure-attribute mutations (Steps 2-10).
+    // `editTaskCommand` is recreate-class / task scope and routes through
+    // the per-attribute mutation path; topology gating must not block it
+    // even though the workflow is unmistakably live (C is `pending`).
+    it('does NOT throw for pure-attribute mutations on a live workflow', () => {
+      orchestrator.loadPlan({
+        name: 'pure-attribute-on-live',
+        tasks: [
+          { id: 'A', description: 'A', command: 'echo A' },
+          { id: 'X', description: 'X', command: 'echo X', dependencies: ['A'] },
+          { id: 'C', description: 'C', command: 'echo C', dependencies: ['X'] },
+        ],
+      });
+      orchestrator.startExecution();
+      completeTask(orchestrator, 'A');
+      failTask(orchestrator, 'X');
+      // C is `pending` (blocked by failed X) → workflow is live by the
+      // Step 11 definition. Editing A's command must still succeed —
+      // no graph edge changes, only a per-attribute mutation routed
+      // through the existing `editTaskCommand` path (Step 2).
+      expect(orchestrator.getTask('C')!.status).toBe('pending');
+
+      expect(() => orchestrator.editTaskCommand('A', 'echo A-v2')).not.toThrow();
+      expect(orchestrator.getTask('A')!.config.command).toBe('echo A-v2');
+    });
   });
 });

--- a/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
@@ -6,10 +6,11 @@
  * state machine — no executor, no git.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { Orchestrator } from '../orchestrator.js';
+import { Orchestrator, TopologyForkRequired } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
 import type { TaskState, TaskStateChanges, Attempt } from '../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
+import { MUTATION_POLICIES } from '../invalidation-policy.js';
 
 // ── In-Memory Persistence Mock ──────────────────────────────
 
@@ -632,6 +633,101 @@ describe('State × Topology Matrix', () => {
       const allTasks = orchestrator.getAllTasks();
       expect(allTasks.find((t) => t.id === 'B-v2')).toBeUndefined();
       expect(allTasks.find((t) => t.id === 'C-v2')).toBeUndefined();
+    });
+  });
+
+  // Step 11 (`docs/architecture/task-invalidation-roadmap.md`):
+  // The chart's Decision Table row "Change graph topology" is the lone
+  // **fork-class** / workflow-scope row. Unlike Steps 2–10 (per-mutation
+  // routes that resolve to retry/recreate × task scope), topology
+  // mutations CANNOT be applied in place on a live workflow — they must
+  // create a new workflow fork rooted from the offending node/result.
+  // Step 12 wires the matching `forkWorkflow*` lifecycle dep; Step 11
+  // surfaces the gate via `Orchestrator.replaceTask` and the
+  // `MUTATION_POLICIES.topology` policy entry.
+  //
+  // The matrix asserts two distinct invariants compared to every
+  // earlier (per-attribute) entry:
+  //
+  //   1. **Policy classification.** `MUTATION_POLICIES.topology` is
+  //      the only entry whose `action` is `'workflowFork'`. All other
+  //      spec-changing entries route to retry/recreate × task or
+  //      workflow scope. This is what makes "graph topology" a
+  //      first-class fork-class entry rather than a special-cased
+  //      restart.
+  //
+  //   2. **Live-workflow gating.** `Orchestrator.replaceTask` now
+  //      throws `TopologyForkRequired` whenever any non-merge task in
+  //      the same workflow is in a live status, surfacing both the
+  //      workflow id and the offending task id so the caller can
+  //      route the request to the (Step 12) fork API. In-place
+  //      remains permitted on a fully terminal workflow because there
+  //      is no in-flight work to race with.
+  describe('graph topology is fork-class / workflow scope', () => {
+    it('MUTATION_POLICIES.topology classifies the row as fork-class / workflow scope', () => {
+      const policy = MUTATION_POLICIES.topology;
+      expect(policy).toBeDefined();
+      expect(policy.action).toBe('workflowFork');
+      expect(policy.invalidatesExecutionSpec).toBe(true);
+      expect(policy.invalidateIfActive).toBe(true);
+    });
+
+    it('topology is the only fork-class entry in the policy table', () => {
+      const forkEntries = Object.entries(MUTATION_POLICIES).filter(
+        ([, p]) => p.action === 'workflowFork',
+      );
+      expect(forkEntries.map(([k]) => k)).toEqual(['topology']);
+    });
+
+    it('replaceTask throws TopologyForkRequired on a live diamond workflow', () => {
+      orchestrator.loadPlan(diamondPlan());
+      orchestrator.startExecution();
+
+      orchestrator.handleWorkerResponse(complete('A'));
+      orchestrator.handleWorkerResponse(complete('C'));
+      orchestrator.handleWorkerResponse(fail('B'));
+      // D is `pending` (blocked by failed B) — workflow is live.
+
+      const bTask = orchestrator.getTask('B')!;
+      const wfId = bTask.config.workflowId!;
+      const scopedBId = bTask.id;
+
+      let caught: unknown;
+      try {
+        orchestrator.replaceTask('B', [
+          { id: 'B-fix', description: 'Fix B', command: 'echo fix' },
+        ]);
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(TopologyForkRequired);
+      const err = caught as TopologyForkRequired;
+      expect(err.workflowId).toBe(wfId);
+      expect(err.taskId).toBe(scopedBId);
+
+      // No in-place mutation: B stays failed, no replacement node was
+      // created, and the merge gate's deps are unchanged.
+      expect(orchestrator.getTask('B')!.status).toBe('failed');
+      expect(orchestrator.getTask('B-fix')).toBeUndefined();
+    });
+
+    it('replaceTask succeeds in place on a terminal diamond workflow', () => {
+      orchestrator.loadPlan(diamondPlan());
+      orchestrator.startExecution();
+
+      orchestrator.handleWorkerResponse(complete('A'));
+      orchestrator.handleWorkerResponse(complete('C'));
+      orchestrator.handleWorkerResponse(fail('B'));
+      // Cancel D so the workflow has no live non-merge tasks.
+      orchestrator.cancelTask('D');
+
+      orchestrator.replaceTask('B', [
+        { id: 'B-fix', description: 'Fix B', command: 'echo fix' },
+      ]);
+
+      // B is staled and the replacement node now exists.
+      expect(orchestrator.getTask('B')!.status).toBe('stale');
+      expect(orchestrator.getTask('B-fix')).toBeDefined();
     });
   });
 });

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -7,7 +7,8 @@ export type InvalidationAction =
   | 'retryWorkflow'
   | 'recreateTask'
   | 'recreateWorkflow'
-  | 'recreateWorkflowFromFreshBase';
+  | 'recreateWorkflowFromFreshBase'
+  | 'workflowFork';
 
 /**
  * Scope at which an `InvalidationAction` applies.
@@ -34,7 +35,8 @@ export type MutationKey =
   | 'mergeMode'
   | 'fixContext'
   | 'rebaseAndRetry'
-  | 'externalGatePolicy';
+  | 'externalGatePolicy'
+  | 'topology';
 
 export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>> = Object.freeze({
   command:               { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
@@ -48,6 +50,13 @@ export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>
   fixContext:            { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
   rebaseAndRetry:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateWorkflowFromFreshBase' as const },
   externalGatePolicy:    { invalidatesExecutionSpec: false, invalidateIfActive: false, action: 'none' as const },
+  // Step 11 (`docs/architecture/task-invalidation-roadmap.md`): graph
+  // topology mutations (e.g. `replaceTask`, `addTask` that changes
+  // parent edges) are fork-class / workflow scope. They must NOT
+  // mutate a live workflow in place; they fork a new workflow rooted
+  // from the relevant node/result. Step 12 wires the matching
+  // `forkWorkflow*` lifecycle dep on `applyInvalidation`.
+  topology:              { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'workflowFork' as const },
 });
 
 export type CancelInFlightFn = (
@@ -62,6 +71,14 @@ export interface InvalidationDeps {
   retryWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflowFromFreshBase?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
+  /**
+   * Step 11 surfaces `'workflowFork'` as the topology-class action.
+   * Step 12 supplies the implementation that creates a new workflow
+   * rooted from the relevant node/result. Until then, invocation
+   * fails fast through `applyInvalidation` with an explicit
+   * "not yet wired (Step 12)" error.
+   */
+  workflowFork?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
 }
 
 const TASK_ACTIONS = new Set<InvalidationAction>(['retryTask', 'recreateTask']);
@@ -69,6 +86,7 @@ const WORKFLOW_ACTIONS = new Set<InvalidationAction>([
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',
+  'workflowFork',
 ]);
 
 export async function applyInvalidation(
@@ -116,6 +134,15 @@ export async function applyInvalidation(
         );
       }
       return await deps.recreateWorkflowFromFreshBase(id);
+    }
+    case 'workflowFork': {
+      if (!deps.workflowFork) {
+        throw new Error(
+          "applyInvalidation: 'workflowFork' is not yet wired (Step 12). " +
+            'Provide deps.workflowFork to use this action.',
+        );
+      }
+      return await deps.workflowFork(id);
     }
   }
 }

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -235,6 +235,61 @@ export function descriptionForMergeNode(plan: Pick<PlanDefinition, 'name' | 'onF
   return `Workflow gate for ${plan.name}`;
 }
 
+/**
+ * Statuses that count a workflow as "live" for topology-mutation policy.
+ *
+ * Per `docs/architecture/task-invalidation-chart.md` ("Topology
+ * inconsistency"), topology-changing requests must NOT mutate a live
+ * workflow in place — they must instead fork a new workflow rooted from
+ * the relevant node/result. A workflow is live if any non-merge task in
+ * it is in any of these statuses.
+ *
+ * The merge node is intentionally excluded: it is `pending` for the
+ * entire workflow lifetime, so including it would make every workflow
+ * "live" forever and defeat the policy.
+ */
+const LIVE_TASK_STATUSES = new Set<string>([
+  'pending',
+  'running',
+  'fixing_with_ai',
+  'needs_input',
+  'awaiting_approval',
+  'review_ready',
+  'blocked',
+]);
+
+/**
+ * Thrown when a topology-changing graph mutation is requested against
+ * a workflow that still has any live (non-terminal) task.
+ *
+ * Step 11 (`docs/architecture/task-invalidation-roadmap.md`) introduces
+ * this surface; Step 12 builds the `forkWorkflow*` API the message
+ * points callers at. Until then, callers handling this error must
+ * either wait for the workflow to terminate or mark the affected
+ * subgraph as terminal (e.g. via `cancelWorkflow`) before retrying.
+ *
+ * The message embeds both the workflow id and the offending task id so
+ * the caller (and tests) can route the request to the correct fork
+ * source without re-querying the orchestrator.
+ */
+export class TopologyForkRequired extends Error {
+  readonly workflowId: string;
+  readonly taskId: string;
+  constructor(workflowId: string, taskId: string, detail?: string) {
+    super(
+      `TopologyForkRequired: cannot mutate graph topology in place on live ` +
+        `workflow ${workflowId} (offending task ${taskId})` +
+        (detail ? ` — ${detail}` : '') +
+        `. Topology changes must fork a new workflow from the relevant ` +
+        `node/result (see docs/architecture/task-invalidation-chart.md ` +
+        `"Topology inconsistency"; forkWorkflow API lands in Step 12).`,
+    );
+    this.name = 'TopologyForkRequired';
+    this.workflowId = workflowId;
+    this.taskId = taskId;
+  }
+}
+
 export interface GraphMutationNodeDef {
   id: string;
   description: string;
@@ -2598,6 +2653,18 @@ export class Orchestrator {
     const wfId = task.config.workflowId;
     if (!wfId) throw new Error(`replaceTask: task ${taskId} has no workflowId`);
 
+    // Step 11: topology mutations must not mutate a live workflow in place.
+    // `replaceTask` is unconditionally a topology change (it stales the
+    // source, can stale downstream, and creates new nodes), so the gate
+    // sits at the entry. In-place is still permitted on a fully terminal
+    // workflow (all non-merge tasks in completed/failed/stale) since
+    // there is no in-flight work to race with.
+    //
+    // Use `task.id` (the resolved/scoped id) for the error so callers
+    // can route the request to the (Step 12) forkWorkflow API without
+    // re-resolving the bare plan-local id themselves.
+    this.assertTopologyMutationAllowed(wfId, task.id);
+
     const replacementRawIds = new Set(replacementTasks.map((t) => t.id));
     const scopeLocal = (local: string) => scopePlanTaskId(wfId, local);
 
@@ -2692,6 +2759,39 @@ export class Orchestrator {
   private reconcileMergeLeaves(workflowId: string): void {
     reconcileMergeLeavesImpl(this as unknown as GraphMutationHost, workflowId);
     assertMergeLeavesInvariantImpl(this as unknown as GraphMutationHost, workflowId);
+  }
+
+  /**
+   * Returns true if the workflow has any non-merge task in a live status
+   * (`pending`, `running`, `fixing_with_ai`, `needs_input`,
+   * `awaiting_approval`, `review_ready`, `blocked`).
+   *
+   * The merge node is excluded because it stays `pending` for the whole
+   * workflow lifetime — including it would make every workflow live
+   * forever. Step 11 uses this check to gate topology-changing graph
+   * mutations (`replaceTask`).
+   */
+  private isWorkflowLive(workflowId: string): boolean {
+    const tasks = this.stateMachine
+      .getAllTasks()
+      .filter((t) => t.config.workflowId === workflowId && !t.config.isMergeNode);
+    return tasks.some((t) => LIVE_TASK_STATUSES.has(t.status));
+  }
+
+  /**
+   * Throws `TopologyForkRequired` when the workflow is live.
+   *
+   * Per `docs/architecture/task-invalidation-chart.md` ("Topology
+   * inconsistency"), graph-shape changes must fork from the relevant
+   * node/result instead of mutating a live workflow in place. Until
+   * Step 12 ships the `forkWorkflow*` API, callers handling this
+   * error must wait for the workflow to terminate (or cancel its
+   * remaining live work) before retrying.
+   */
+  private assertTopologyMutationAllowed(workflowId: string, sourceTaskId: string): void {
+    if (this.isWorkflowLive(workflowId)) {
+      throw new TopologyForkRequired(workflowId, sourceTaskId);
+    }
   }
 
   private assertMergeLeavesInvariant(workflowId: string): void {


### PR DESCRIPTION
## Summary
This PR adds the safety gate for topology-changing mutations on live workflows. It does not expand `replaceTask` as a preferred product path; it fences that legacy topology surface so live workflows fail fast until the dedicated fork implementation lands in the next step.

## Problem
Topology-changing mutations could still edit a live workflow in place, which risks diverging execution state from the workflow graph.

## Root Cause
Topology mutation had not yet been modeled as its own invalidation class, so the code could treat graph edits like ordinary task-attribute edits even when the workflow still had live execution.

## Approach
Classify topology as fork-class invalidation and throw `TopologyForkRequired` for live workflows instead of mutating them in place. Terminal workflows can still be edited in place because there is no live execution state left to race.

## Why This Fix Is Right
"Live" here is broader than "running right this second." It means the workflow still has unresolved execution state, so mutating topology in place is unsafe even if the specific task you looked at is not currently `running`. The gate is there to stop unsafe graph surgery before the explicit fork path is available.

## Tradeoffs And Considerations
We are trying to remove `replaceTask`, and this PR does not argue otherwise. The topology gate exists as compatibility scaffolding while that legacy surface still exists in code. Once `replaceTask` is removed, this topology-fork path should shrink or disappear with it instead of becoming a new preferred user workflow.

## Before
```mermaid
flowchart LR
  A[replaceTask on live workflow] --> B[Mutate workflow graph in place]
  B --> C[Execution state and topology can diverge]
```

## After
```mermaid
flowchart LR
  A[replaceTask on live workflow] --> B{workflow still live?}
  B -- yes --> C[throw TopologyForkRequired]
  B -- no --> D[allow terminal in-place edit]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 11: topology-gate`
