### PR TITLE
Task invalidation step 12: workflow-scope

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -815,6 +815,178 @@ describe('headless delegation enforcement', () => {
         expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
       });
 
+      // ── Step 12: routing assertions ────────────────────────────────────
+      //
+      // These pin the chart's three-way distinction at the headless layer:
+      // each verb routes to its own orchestrator method, and `rebase` reaches
+      // the new first-class `recreateWorkflowFromFreshBase` (which closes
+      // Step 11's "not yet wired" hole on `applyInvalidation`).
+      describe('workflow-scope routing', () => {
+        function seedRebaseHappyPath(): { preemptWorkflowExecution: ReturnType<typeof vi.fn>; preparePoolSpy: ReturnType<typeof vi.spyOn> } {
+          const preemptWorkflowExecution = vi.fn(async () => ({ cancelled: [], runningCancelled: [] }));
+          const wf = {
+            id: 'wf-1',
+            name: 'wf-1',
+            status: 'running' as const,
+            generation: 3,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+            repoUrl: 'https://example/repo.git',
+            baseBranch: 'main',
+          };
+          mockDeps.persistence.listWorkflows = vi.fn(() => [wf]);
+          mockDeps.persistence.loadTasks = vi.fn(() => [{
+            id: 'wf-1/task-1',
+            status: 'failed',
+            config: { workflowId: 'wf-1' },
+            execution: {},
+          } as any]);
+          mockDeps.persistence.loadWorkflow = vi.fn(() => wf as any);
+          mockDeps.persistence.updateWorkflow = vi.fn();
+          mockDeps.orchestrator.syncFromDb = vi.fn();
+          mockDeps.orchestrator.getTask = vi.fn((id: string) => {
+            if (id === 'wf-1/task-1' || id === 'task-1') {
+              return {
+                id: 'wf-1/task-1',
+                status: 'failed',
+                config: { workflowId: 'wf-1' },
+                execution: {},
+              } as any;
+            }
+            return undefined;
+          });
+          mockDeps.orchestrator.recreateWorkflowFromFreshBase = vi.fn(
+            async (_workflowId: string, options?: any) => {
+              // Drive the refresh callback the way the orchestrator does in
+              // production so we exercise the real `preparePoolForRebaseRetry`
+              // wiring inside `workflow-actions.recreateWorkflowFromFreshBase`.
+              await options?.refreshBase?.(_workflowId);
+              return [];
+            },
+          ) as any;
+
+          // Spy on `preparePoolForRebaseRetry` to assert the app-layer
+          // `recreateWorkflowFromFreshBase` actually invokes pool prep
+          // (the part `recreateWorkflow` does NOT do).
+          const preparePoolSpy = vi
+            .spyOn(TaskRunner.prototype, 'preparePoolForRebaseRetry')
+            .mockImplementation(async () => undefined);
+
+          return { preemptWorkflowExecution, preparePoolSpy };
+        }
+
+        it('headless `rebase <taskId>` routes to orchestrator.recreateWorkflowFromFreshBase', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['rebase', 'task-1'], depsWithNoTrack);
+
+          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledTimes(1);
+          expect(
+            (mockDeps.orchestrator.recreateWorkflowFromFreshBase as any).mock.calls[0][0],
+          ).toBe('wf-1');
+          // Cancel-first invariant: preempt before the recreate-from-fresh-base method.
+          const preemptOrder = (preemptWorkflowExecution.mock.invocationCallOrder ?? [])[0];
+          const recreateOrder = (
+            (mockDeps.orchestrator.recreateWorkflowFromFreshBase as any).mock.invocationCallOrder ?? []
+          )[0];
+          expect(preemptOrder).toBeLessThan(recreateOrder);
+
+          preparePoolSpy.mockRestore();
+        });
+
+        it('headless `rebase` exercises the fresh-base-distinct pool prep step (preparePoolForRebaseRetry)', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['rebase', 'task-1'], depsWithNoTrack);
+
+          // The whole reason `recreateWorkflowFromFreshBase` is distinct
+          // from `recreateWorkflow`: it refreshes the upstream pool/base.
+          expect(preparePoolSpy).toHaveBeenCalledWith(
+            'wf-1',
+            'https://example/repo.git',
+            'main',
+          );
+
+          preparePoolSpy.mockRestore();
+        });
+
+        it('deprecated alias `rebase-and-retry` routes to the same orchestrator.recreateWorkflowFromFreshBase method', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['rebase-and-retry', 'task-1'], depsWithNoTrack);
+
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+            'wf-1',
+            expect.objectContaining({ refreshBase: expect.any(Function) }),
+          );
+
+          preparePoolSpy.mockRestore();
+        });
+
+        it('headless `recreate <wfId>` routes to orchestrator.recreateWorkflow — NOT recreateWorkflowFromFreshBase (no upstream pool refresh)', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+          mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
+
+          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+          // Distinction guard — recreate must NOT refresh the upstream pool.
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
+          expect(preparePoolSpy).not.toHaveBeenCalled();
+
+          preparePoolSpy.mockRestore();
+        });
+
+        it('headless `retry <wfId>` routes to commandService.retryWorkflow — NOT to recreateWorkflow / recreateWorkflowFromFreshBase', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+          mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
+          mockDeps.commandService.retryWorkflow = vi.fn(async () => ({
+            ok: true as const,
+            data: [],
+          }));
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['retry', 'wf-1'], depsWithNoTrack);
+
+          expect(mockDeps.commandService.retryWorkflow).toHaveBeenCalled();
+          expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
+          expect(preparePoolSpy).not.toHaveBeenCalled();
+
+          preparePoolSpy.mockRestore();
+        });
+      });
+
       it('headless cancel-workflow prefers preemptWorkflowExecution when available', async () => {
         const preemptWorkflowExecution = vi.fn(async () => ({ cancelled: ['wf-1/task-1'], runningCancelled: ['wf-1/task-1'] }));
         mockDeps.commandService.cancelWorkflow = vi.fn(async () => ({

--- a/packages/app/src/__tests__/rebase-and-retry.test.ts
+++ b/packages/app/src/__tests__/rebase-and-retry.test.ts
@@ -156,6 +156,17 @@ describe('rebase-and-retry: pool mirror cleanup before restart', { timeout: 120_
         }
         return tasks;
       },
+      // Step 12: rebaseAndRetry now delegates through
+      // recreateWorkflowFromFreshBase. Mirror the real orchestrator: drive
+      // the refreshBase callback (so pool prep runs) before reusing the
+      // recreateWorkflow reset path.
+      recreateWorkflowFromFreshBase: async (
+        workflowId: string,
+        options?: { refreshBase?: (workflowId: string) => Promise<unknown> },
+      ): Promise<TaskState[]> => {
+        await options?.refreshBase?.(workflowId);
+        return orchestrator.recreateWorkflow(workflowId);
+      },
     };
 
     const repoUrl = `file://${tmpDir}`;

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -1168,15 +1168,74 @@ describe('buildInvalidationDeps', () => {
     expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
   });
 
-  it('does NOT wire recreateWorkflowFromFreshBase in Step 1 (Step 12 promotes it)', () => {
-    const orchestrator = makeBaseOrchestrator();
+  it('wires recreateWorkflowFromFreshBase to the orchestrator method', async () => {
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      // The real orchestrator drives the `refreshBase` callback; mirror
+      // that here so the test exercises the app-layer's pool-prep wiring.
+      recreateWorkflowFromFreshBase: vi.fn(async (_id: string, options?: any) => {
+        await options?.refreshBase?.(_id);
+        return [makeRunningTask({ id: 'task-a' })];
+      }),
+    };
     const persistence = makePersistence();
+    const taskExecutor = {
+      preparePoolForRebaseRetry: vi.fn(async () => undefined),
+    };
 
     const deps = buildInvalidationDeps({
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
     });
-    expect(deps.recreateWorkflowFromFreshBase).toBeUndefined();
+
+    // Step 12 promotes this dep — the policy router's
+    // "not yet wired (Step 12)" error path is dead code in production.
+    expect(deps.recreateWorkflowFromFreshBase).toBeDefined();
+
+    persistence.loadWorkflow = vi.fn(() => ({
+      id: 'wf-1',
+      generation: 4,
+      repoUrl: 'https://example/repo.git',
+      baseBranch: 'main',
+    } as any));
+
+    const result = await deps.recreateWorkflowFromFreshBase!('wf-1');
+
+    // Workflow generation bumped (matches recreateWorkflow's wrapper semantics).
+    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 5 });
+    // Pool prep ran before delegating to the orchestrator's first-class method.
+    expect(taskExecutor.preparePoolForRebaseRetry).toHaveBeenCalledWith(
+      'wf-1',
+      'https://example/repo.git',
+      'main',
+    );
+    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledTimes(1);
+    expect(orchestrator.recreateWorkflowFromFreshBase.mock.calls[0]?.[0]).toBe('wf-1');
+    expect(result).toHaveLength(1);
+  });
+
+  it('recreateWorkflowFromFreshBase wire still calls orchestrator method when no taskExecutor is supplied', async () => {
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      recreateWorkflowFromFreshBase: vi.fn(async () => []),
+    };
+    const persistence = makePersistence();
+    persistence.loadWorkflow = vi.fn(() => ({ id: 'wf-1', generation: 0, repoUrl: 'https://example/repo.git', baseBranch: 'main' } as any));
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      // taskExecutor intentionally omitted — the orchestrator method
+      // still runs (refreshBase callback is a no-op without an executor).
+    });
+
+    await deps.recreateWorkflowFromFreshBase!('wf-1');
+
+    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+      'wf-1',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
+    );
   });
 
   it('builds a cancel-first hook that cancels orchestrator state and kills runners', async () => {

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -156,11 +156,91 @@ export function cancelWorkflow(
 }
 
 /**
+ * Recreate a workflow from a refreshed upstream base — the chart's
+ * `recreateWorkflowFromFreshBase` action
+ * (`docs/architecture/task-invalidation-chart.md` rows
+ * "Rebase and retry" + "Repo/base invalidation inconsistency",
+ * `docs/architecture/task-invalidation-roadmap.md` Step 12).
+ *
+ * This is strictly stronger than `recreateWorkflow`: in addition to
+ * the full reset (workspace path, branch, commit, agent session,
+ * container, merge gate workspace, etc.) it first refreshes the pool
+ * mirror and origin base via `taskExecutor.preparePoolForRebaseRetry`
+ * and removes managed experiment/invoker branches in that mirror.
+ * Plain `recreateWorkflow` preserves the workflow's currently-known
+ * upstream base; this one advances it.
+ *
+ * Wiring (composite, kept here per
+ * `docs/architecture/task-invalidation-roadmap.md` "Out of scope":
+ * the composite implementation is preserved semantically — replacing
+ * it with a single primitive is a follow-up):
+ *
+ *   1. Bump the workflow's generation counter (matches
+ *      `bumpGenerationAndRecreate` so any downstream observers that
+ *      key off `workflow.generation` notice the new round).
+ *   2. Delegate to `Orchestrator.recreateWorkflowFromFreshBase` with
+ *      a `refreshBase` callback that runs
+ *      `taskExecutor.preparePoolForRebaseRetry` when both
+ *      `taskExecutor` and `workflow.repoUrl` are available. The
+ *      orchestrator method is the seam that records the fresh-base
+ *      effect (`knownFreshBaseCommits`) and then runs the same reset
+ *      as `recreateWorkflow`. Cancel-first is supplied by
+ *      `applyInvalidation`'s `cancelInFlight` dep
+ *      (`buildCancelInFlight` → `Orchestrator.cancelWorkflow` +
+ *      `taskExecutor.killActiveExecution`) when invoked through that
+ *      route — this wrapper does not add a parallel cancel call.
+ *
+ * The `refreshBase` callback returns `undefined` today because
+ * `preparePoolForRebaseRetry` does not yet expose the resulting
+ * upstream HEAD SHA; recording the SHA is a follow-up. Tests inject
+ * their own `refreshBase` callback (via the orchestrator method
+ * directly) to assert the fresh-base observable.
+ */
+export async function recreateWorkflowFromFreshBase(
+  workflowId: string,
+  deps: ActionDeps,
+): Promise<TaskState[]> {
+  const workflow = deps.persistence.loadWorkflow(workflowId);
+  if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+  const nextGen = (workflow.generation ?? 0) + 1;
+  deps.persistence.updateWorkflow(workflowId, { generation: nextGen });
+  deps.logger?.info(
+    `recreateWorkflowFromFreshBase: workflowId=${workflowId} bumped generation to ${nextGen}`,
+    { module: 'workflow' },
+  );
+  deps.logger?.info(
+    `recreateWorkflowFromFreshBase: workflowId=${workflowId} → orchestrator.recreateWorkflowFromFreshBase (pool prep if taskExecutor+repoUrl)`,
+    { module: 'agent-session-trace' },
+  );
+
+  return deps.orchestrator.recreateWorkflowFromFreshBase(workflowId, {
+    refreshBase: async () => {
+      if (deps.taskExecutor && workflow.repoUrl) {
+        await deps.taskExecutor.preparePoolForRebaseRetry(
+          workflowId,
+          workflow.repoUrl,
+          workflow.baseBranch,
+        );
+      }
+      // `preparePoolForRebaseRetry` does not yet expose the resulting
+      // upstream HEAD SHA; surfacing it (so the orchestrator can
+      // record `knownFreshBaseCommits` in production too) is the
+      // follow-up the roadmap calls out in "Out of scope".
+      return undefined;
+    },
+  });
+}
+
+/**
  * Rebase-and-retry: refresh the pool mirror / origin base, remove managed
  * experiment/invoker branches in that mirror, bump generation, and restart the DAG.
  *
- * When `taskExecutor` is provided, `preparePoolForRebaseRetry` runs first; the
- * caller then executes runnable tasks (normal pool fetch + origin base resolution apply).
+ * Step 12: this wrapper is now a thin delegate to
+ * `recreateWorkflowFromFreshBase` — the chart's first-class action
+ * for this behavior. It is preserved as a separate export because
+ * existing callers (notably `headlessRebaseAndRetry`) speak in task
+ * ids while the workflow-scope action speaks in workflow ids; this
+ * function continues to do the `taskId → workflowId` translation.
  */
 export async function rebaseAndRetry(
   taskId: string,
@@ -169,21 +249,11 @@ export async function rebaseAndRetry(
   const task = deps.orchestrator.getTask(taskId);
   if (!task?.config.workflowId) throw new Error(`Task ${taskId} not found or has no workflow`);
   const workflowId = task.config.workflowId;
-
-  const workflow = deps.persistence.loadWorkflow(workflowId);
   deps.logger?.info(
-    `rebaseAndRetry: taskId=${taskId} workflowId=${workflowId} → pool prep (if taskExecutor+repoUrl) → bumpGenerationAndRecreate → recreateWorkflow`,
+    `rebaseAndRetry: taskId=${taskId} workflowId=${workflowId} → recreateWorkflowFromFreshBase (Step 12 delegate)`,
     { module: 'agent-session-trace' },
   );
-  if (deps.taskExecutor && workflow?.repoUrl) {
-    await deps.taskExecutor.preparePoolForRebaseRetry(
-      workflowId,
-      workflow.repoUrl,
-      workflow.baseBranch,
-    );
-  }
-
-  return bumpGenerationAndRecreate(workflowId, deps);
+  return recreateWorkflowFromFreshBase(workflowId, deps);
 }
 
 export interface BuildCancelInFlightDeps {
@@ -223,6 +293,13 @@ export function buildInvalidationDeps(
         logger: deps.logger,
         orchestrator: deps.orchestrator,
         persistence: deps.persistence,
+      }),
+    recreateWorkflowFromFreshBase: (workflowId: string) =>
+      recreateWorkflowFromFreshBase(workflowId, {
+        logger: deps.logger,
+        orchestrator: deps.orchestrator,
+        persistence: deps.persistence,
+        taskExecutor: deps.taskExecutor,
       }),
   };
 }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5704,6 +5704,300 @@ describe('Orchestrator', () => {
     });
   });
 
+  // ── Step 12: workflow-scope paths (retryWorkflow / recreateWorkflow / recreateWorkflowFromFreshBase) ────
+  //
+  // Pins the chart's three-way distinction
+  // (`docs/architecture/task-invalidation-chart.md` rows
+  // "Retry workflow", "Recreate workflow", "Rebase and retry") +
+  // closes the Step 11 "not yet wired (Step 12)" hole on
+  // `applyInvalidation('workflow', 'recreateWorkflowFromFreshBase', ...)`.
+  describe('workflow-scope paths', () => {
+    function seedSimpleWorkflow(p: InMemoryPersistence, wfId: string): void {
+      p.saveTask(wfId, {
+        id: 'a',
+        description: 'Task A',
+        status: 'completed',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: wfId },
+        execution: { exitCode: 0, branch: 'br-a', commit: 'aaa', workspacePath: '/wt/a' },
+      });
+      p.saveTask(wfId, {
+        id: 'b',
+        description: 'Task B',
+        status: 'failed',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: wfId },
+        execution: { exitCode: 1, error: 'boom', branch: 'br-b', commit: 'bbb', workspacePath: '/wt/b' },
+      });
+    }
+
+    describe('retryWorkflow preserves lineage and bumps per-task execution generation', () => {
+      it('keeps branch/workspacePath on the reset task', () => {
+        const p = new InMemoryPersistence();
+        const b = new InMemoryBus();
+        const wfId = 'wf-step12-retry-lineage';
+        seedSimpleWorkflow(p, wfId);
+        const o = new Orchestrator({ persistence: p, messageBus: b, maxConcurrency: 2 });
+        o.syncFromDb(wfId);
+
+        o.retryWorkflow(wfId);
+
+        const bTask = o.getTask('b')!;
+        expect(bTask.execution.branch).toBe('br-b');
+        expect(bTask.execution.workspacePath).toBe('/wt/b');
+        expect(bTask.execution.commit).toBe('bbb');
+        expect(bTask.execution.error).toBeUndefined();
+      });
+
+      it('bumps per-task execution.generation on the retried task (workflow-scope generation surrogate)', () => {
+        const p = new InMemoryPersistence();
+        const b = new InMemoryBus();
+        const wfId = 'wf-step12-retry-gen';
+        seedSimpleWorkflow(p, wfId);
+        const o = new Orchestrator({ persistence: p, messageBus: b, maxConcurrency: 2 });
+        o.syncFromDb(wfId);
+
+        const beforeGen = o.getTask('b')!.execution.generation ?? 0;
+        o.retryWorkflow(wfId);
+        const afterGen = o.getTask('b')!.execution.generation ?? 0;
+        expect(afterGen).toBeGreaterThan(beforeGen);
+      });
+    });
+
+    describe('recreateWorkflow clears lineage and preserves the workflow base', () => {
+      it('clears branch/workspacePath/commit on every task', () => {
+        const p = new InMemoryPersistence();
+        const b = new InMemoryBus();
+        const wfId = 'wf-step12-recreate-lineage';
+        seedSimpleWorkflow(p, wfId);
+        const o = new Orchestrator({ persistence: p, messageBus: b, maxConcurrency: 2 });
+        o.syncFromDb(wfId);
+
+        o.recreateWorkflow(wfId);
+
+        for (const id of ['a', 'b']) {
+          const t = o.getTask(id)!;
+          expect(t.execution.branch).toBeUndefined();
+          expect(t.execution.commit).toBeUndefined();
+          expect(t.execution.workspacePath).toBeUndefined();
+        }
+      });
+
+      it('does NOT record a fresh upstream base commit (that is recreateWorkflowFromFreshBase territory)', () => {
+        const p = new InMemoryPersistence();
+        const b = new InMemoryBus();
+        const wfId = 'wf-step12-recreate-no-fresh-base';
+        seedSimpleWorkflow(p, wfId);
+        const o = new Orchestrator({ persistence: p, messageBus: b, maxConcurrency: 2 });
+        o.syncFromDb(wfId);
+
+        expect(o.getKnownFreshBaseCommit(wfId)).toBeUndefined();
+        o.recreateWorkflow(wfId);
+        expect(o.getKnownFreshBaseCommit(wfId)).toBeUndefined();
+      });
+    });
+
+    describe('recreateWorkflowFromFreshBase: stronger than recreateWorkflow', () => {
+      it('does everything recreateWorkflow does (clears branch/workspacePath/commit) AND advances the known fresh base', async () => {
+        const p = new InMemoryPersistence();
+        const b = new InMemoryBus();
+        const wfId = 'wf-step12-fresh-base';
+        seedSimpleWorkflow(p, wfId);
+        const o = new Orchestrator({ persistence: p, messageBus: b, maxConcurrency: 2 });
+        o.syncFromDb(wfId);
+
+        expect(o.getKnownFreshBaseCommit(wfId)).toBeUndefined();
+        await o.recreateWorkflowFromFreshBase(wfId, {
+          refreshBase: async () => ({ commit: 'fresh-upstream-sha' }),
+        });
+
+        // Recreate-class reset:
+        for (const id of ['a', 'b']) {
+          const t = o.getTask(id)!;
+          expect(t.execution.branch).toBeUndefined();
+          expect(t.execution.commit).toBeUndefined();
+          expect(t.execution.workspacePath).toBeUndefined();
+        }
+
+        // Fresh-base distinction:
+        expect(o.getKnownFreshBaseCommit(wfId)).toBe('fresh-upstream-sha');
+      });
+
+      it('runs refreshBase BEFORE the reset (chart: "refresh repo/base state first, then recreate the workflow")', async () => {
+        const p = new InMemoryPersistence();
+        const b = new InMemoryBus();
+        const wfId = 'wf-step12-fresh-base-ordering';
+        seedSimpleWorkflow(p, wfId);
+        const o = new Orchestrator({ persistence: p, messageBus: b, maxConcurrency: 2 });
+        o.syncFromDb(wfId);
+
+        let refreshBaseCalledAt: number | undefined;
+        let resetObservedAt: number | undefined;
+        let counter = 0;
+
+        // Re-spy persistence.updateTask to detect when the recreate
+        // reset begins (the recreateWorkflow loop calls updateTask
+        // on every reset task; the first such call is our marker).
+        const originalUpdateTask = p.updateTask.bind(p);
+        p.updateTask = (taskId: string, changes: any) => {
+          if (resetObservedAt === undefined && changes?.status === 'pending') {
+            resetObservedAt = ++counter;
+          }
+          originalUpdateTask(taskId, changes);
+        };
+
+        await o.recreateWorkflowFromFreshBase(wfId, {
+          refreshBase: async () => {
+            refreshBaseCalledAt = ++counter;
+            return { commit: 'sha-fresh' };
+          },
+        });
+
+        expect(refreshBaseCalledAt).toBeDefined();
+        expect(resetObservedAt).toBeDefined();
+        expect(refreshBaseCalledAt!).toBeLessThan(resetObservedAt!);
+      });
+
+      it('updates persisted baseBranch when refreshBase returns one', async () => {
+        const p = new InMemoryPersistence();
+        const b = new InMemoryBus();
+        const wfId = 'wf-step12-fresh-base-branch';
+        // Save workflow first so updateWorkflow has something to update
+        p.saveWorkflow({
+          id: wfId,
+          name: 'wf',
+          status: 'running',
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        } as any);
+        seedSimpleWorkflow(p, wfId);
+        const o = new Orchestrator({ persistence: p, messageBus: b, maxConcurrency: 2 });
+        o.syncFromDb(wfId);
+
+        const updateWorkflowSpy = vi.spyOn(p, 'updateWorkflow');
+
+        await o.recreateWorkflowFromFreshBase(wfId, {
+          refreshBase: async () => ({ branch: 'main', commit: 'sha-x' }),
+        });
+
+        expect(updateWorkflowSpy).toHaveBeenCalledWith(wfId, { baseBranch: 'main' });
+      });
+
+      it('skips refreshBase invocation when no callback is supplied (degenerate caller path) and still resets', async () => {
+        const p = new InMemoryPersistence();
+        const b = new InMemoryBus();
+        const wfId = 'wf-step12-no-refresh-cb';
+        seedSimpleWorkflow(p, wfId);
+        const o = new Orchestrator({ persistence: p, messageBus: b, maxConcurrency: 2 });
+        o.syncFromDb(wfId);
+
+        await o.recreateWorkflowFromFreshBase(wfId);
+
+        for (const id of ['a', 'b']) {
+          const t = o.getTask(id)!;
+          expect(t.execution.branch).toBeUndefined();
+          expect(t.execution.commit).toBeUndefined();
+        }
+        // No fresh base recorded — the caller did not provide one.
+        expect(o.getKnownFreshBaseCommit(wfId)).toBeUndefined();
+      });
+    });
+
+    describe('applyInvalidation routing (Step 11 "not yet wired" path is closed)', () => {
+      it("applyInvalidation('workflow', 'recreateWorkflowFromFreshBase', ...) succeeds when the dep is wired", async () => {
+        const { applyInvalidation } = await import('../invalidation-policy.js');
+
+        const p = new InMemoryPersistence();
+        const b = new InMemoryBus();
+        const wfId = 'wf-step12-apply-invalidation';
+        seedSimpleWorkflow(p, wfId);
+        const o = new Orchestrator({ persistence: p, messageBus: b, maxConcurrency: 2 });
+        o.syncFromDb(wfId);
+
+        const cancelInFlight = vi.fn(async () => undefined);
+        await applyInvalidation('workflow', 'recreateWorkflowFromFreshBase', wfId, {
+          cancelInFlight,
+          retryTask: async () => [],
+          recreateTask: async () => [],
+          retryWorkflow: async () => [],
+          recreateWorkflow: async () => [],
+          recreateWorkflowFromFreshBase: (workflowId: string) =>
+            o.recreateWorkflowFromFreshBase(workflowId, {
+              refreshBase: async () => ({ commit: 'sha-from-applyInvalidation' }),
+            }),
+        });
+
+        // Cancel-first invariant.
+        expect(cancelInFlight).toHaveBeenCalledWith('workflow', wfId);
+        // Fresh-base step actually advanced.
+        expect(o.getKnownFreshBaseCommit(wfId)).toBe('sha-from-applyInvalidation');
+        // Recreate reset ran.
+        expect(o.getTask('b')!.execution.branch).toBeUndefined();
+      });
+
+      it('cancel-first runs strictly before the recreateWorkflowFromFreshBase reset', async () => {
+        const { applyInvalidation } = await import('../invalidation-policy.js');
+
+        const p = new InMemoryPersistence();
+        const b = new InMemoryBus();
+        const wfId = 'wf-step12-cancel-first-ordering';
+        seedSimpleWorkflow(p, wfId);
+        const o = new Orchestrator({ persistence: p, messageBus: b, maxConcurrency: 2 });
+        o.syncFromDb(wfId);
+
+        const order: string[] = [];
+        await applyInvalidation('workflow', 'recreateWorkflowFromFreshBase', wfId, {
+          cancelInFlight: async () => {
+            order.push('cancelInFlight');
+          },
+          retryTask: async () => [],
+          recreateTask: async () => [],
+          retryWorkflow: async () => [],
+          recreateWorkflow: async () => [],
+          recreateWorkflowFromFreshBase: async (workflowId: string) => {
+            order.push('recreateWorkflowFromFreshBase');
+            return o.recreateWorkflowFromFreshBase(workflowId, {
+              refreshBase: async () => ({ commit: 'sha-x' }),
+            });
+          },
+        });
+
+        expect(order).toEqual(['cancelInFlight', 'recreateWorkflowFromFreshBase']);
+      });
+
+      it("applyInvalidation('workflow', 'retryWorkflow', ...) routes through cancelInFlight first", async () => {
+        const { applyInvalidation } = await import('../invalidation-policy.js');
+
+        const p = new InMemoryPersistence();
+        const b = new InMemoryBus();
+        const wfId = 'wf-step12-retry-cancel-first';
+        seedSimpleWorkflow(p, wfId);
+        const o = new Orchestrator({ persistence: p, messageBus: b, maxConcurrency: 2 });
+        o.syncFromDb(wfId);
+
+        const order: string[] = [];
+        await applyInvalidation('workflow', 'retryWorkflow', wfId, {
+          cancelInFlight: async () => {
+            order.push('cancelInFlight');
+          },
+          retryTask: async () => [],
+          recreateTask: async () => [],
+          retryWorkflow: async (workflowId: string) => {
+            order.push('retryWorkflow');
+            return o.retryWorkflow(workflowId);
+          },
+          recreateWorkflow: async () => [],
+        });
+
+        expect(order).toEqual(['cancelInFlight', 'retryWorkflow']);
+        // Retry-class lineage preserved.
+        expect(o.getTask('b')!.execution.branch).toBe('br-b');
+      });
+    });
+  });
+
   // ── Long session resilience ────────────────────────────
 
   describe('long session resilience', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -588,6 +588,26 @@ export class Orchestrator {
   private deferredTaskIds = new Set<string>();
   private beforeApproveHook?: (task: TaskState) => Promise<void>;
 
+  /**
+   * Per-workflow record of the most recently observed upstream base
+   * commit, written by `recreateWorkflowFromFreshBase` whenever its
+   * `refreshBase` callback returns a fresh SHA.
+   *
+   * Step 12 introduces this map as the orchestrator-side observable
+   * for the chart's `recreateWorkflowFromFreshBase` semantic
+   * (`docs/architecture/task-invalidation-chart.md` rows
+   * "Rebase and retry" + "Repo/base invalidation inconsistency"):
+   * the only thing that distinguishes `recreateWorkflowFromFreshBase`
+   * from plain `recreateWorkflow` at the orchestrator layer is that
+   * the workflow's known upstream base advanced. The map gives tests
+   * (and future API consumers) a stable signal that the fresh-base
+   * step actually ran without coupling the orchestrator to the
+   * executor's pool-mirror state. Production today still drives the
+   * actual git-side refresh through `taskExecutor.preparePoolForRebaseRetry`
+   * (wired by `packages/app/src/workflow-actions.ts → recreateWorkflowFromFreshBase`).
+   */
+  private knownFreshBaseCommits = new Map<string, string>();
+
   constructor(config: OrchestratorConfig) {
     this.maxConcurrency = config.maxConcurrency ?? 3;
     this.persistence = config.persistence;
@@ -2091,6 +2111,107 @@ export class Orchestrator {
       .map((t) => t.id)
       .filter((id) => this.stateGetTask(id)?.config.workflowId === workflowId);
     return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
+  }
+
+  /**
+   * Workflow-scope **fresh-base** recreate (Step 12 of
+   * `docs/architecture/task-invalidation-roadmap.md`, Decision Table
+   * row "Rebase and retry" + "Repo/base invalidation inconsistency"
+   * in `docs/architecture/task-invalidation-chart.md`).
+   *
+   * This is strictly stronger than `recreateWorkflow`:
+   *
+   *   recreateWorkflow                 — full reset; preserves the
+   *                                      workflow's currently-known
+   *                                      upstream base.
+   *   recreateWorkflowFromFreshBase    — full reset PLUS refreshes
+   *                                      the upstream base (HEAD of
+   *                                      `baseBranch`) before reset.
+   *
+   * The chart's "Repo/base invalidation inconsistency" section called
+   * this distinction out as previously hidden: today the only
+   * primitive carrying the fresh-base semantic is the composite
+   * `rebaseAndRetry()` flow in `packages/app/src/workflow-actions.ts`
+   * (`preparePoolForRebaseRetry → bumpGenerationAndRecreate →
+   * recreateWorkflow`). Step 12 promotes the fresh-base step to a
+   * first-class orchestrator method so the three workflow-scope
+   * paths (`retryWorkflow`, `recreateWorkflow`,
+   * `recreateWorkflowFromFreshBase`) are individually testable and
+   * routed through `applyInvalidation` from
+   * `packages/workflow-core/src/invalidation-policy.ts`.
+   *
+   * The orchestrator deliberately does NOT touch git itself: the
+   * `refreshBase` callback (wired by the app layer to
+   * `taskExecutor.preparePoolForRebaseRetry`) is what actually
+   * refreshes the pool mirror and removes managed branches. The
+   * orchestrator only:
+   *
+   *   1. awaits the optional `refreshBase` callback, and
+   *   2. records any returned `commit` in `knownFreshBaseCommits` and
+   *      any returned `branch` in persistence (`baseBranch`) so the
+   *      effect of the refresh is observable from orchestrator state.
+   *   3. delegates the actual reset to `recreateWorkflow` so all
+   *      lineage-discard behavior (workspace path, branch, commit,
+   *      agent session, container, merge gate workspace, etc.) stays
+   *      single-sourced.
+   *
+   * Cancel-first invariant (`docs/architecture/task-invalidation-chart.md`
+   * → "Hard Invariant"): the chart requires every retry/recreate
+   * route to interrupt and cancel any in-flight work in the affected
+   * scope BEFORE authoritative reset. That cancel is supplied by
+   * `applyInvalidation`'s `cancelInFlight` dep (built by
+   * `buildCancelInFlight` in `packages/app/src/workflow-actions.ts`,
+   * which calls `Orchestrator.cancelWorkflow` for workflow scope and
+   * then awaits `taskExecutor.killActiveExecution` for every running
+   * attempt). This method MUST NOT add a parallel cancel call —
+   * doing so would double-cancel and would also defeat the existing
+   * "skips running tasks" semantics that direct callers of
+   * `recreateWorkflow` rely on.
+   */
+  async recreateWorkflowFromFreshBase(
+    workflowId: string,
+    options?: {
+      refreshBase?: (
+        workflowId: string,
+      ) => Promise<{ commit?: string; branch?: string } | undefined | void>;
+    },
+  ): Promise<TaskState[]> {
+    if (options?.refreshBase) {
+      const fresh = await options.refreshBase(workflowId);
+      if (fresh && typeof fresh === 'object') {
+        if (typeof fresh.commit === 'string' && fresh.commit.length > 0) {
+          this.knownFreshBaseCommits.set(workflowId, fresh.commit);
+          console.log(
+            `[orchestrator] recreateWorkflowFromFreshBase: workflow=${workflowId} ` +
+              `freshBaseCommit=${fresh.commit.slice(0, 12)}`,
+          );
+        }
+        if (typeof fresh.branch === 'string' && fresh.branch.length > 0 && this.persistence.updateWorkflow) {
+          this.persistence.updateWorkflow(workflowId, { baseBranch: fresh.branch });
+          console.log(
+            `[orchestrator] recreateWorkflowFromFreshBase: workflow=${workflowId} ` +
+              `freshBaseBranch=${fresh.branch}`,
+          );
+        }
+      }
+    }
+    return this.recreateWorkflow(workflowId);
+  }
+
+  /**
+   * Most recently observed upstream base commit for `workflowId`,
+   * recorded by `recreateWorkflowFromFreshBase` when its `refreshBase`
+   * callback returns a SHA. Returns `undefined` when no fresh-base
+   * recreate has run for the workflow yet.
+   *
+   * This is the orchestrator-side observable for the chart's
+   * `recreateWorkflowFromFreshBase` semantic — see the comment on
+   * `knownFreshBaseCommits` for why this lives on the orchestrator
+   * rather than the executor pool. Tests assert on this getter to
+   * prove the fresh-base step actually advanced.
+   */
+  getKnownFreshBaseCommit(workflowId: string): string | undefined {
+    return this.knownFreshBaseCommits.get(workflowId);
   }
 
   /**


### PR DESCRIPTION
## Summary
This change makes the three workflow-scope invalidation paths explicit in code: `retryWorkflow`, `recreateWorkflow`, and the new `recreateWorkflowFromFreshBase`. The orchestrator now models these as distinct operations with different lineage semantics, while the app layer wires fresh-base refresh through a callback so git and pool concerns stay outside workflow-core. `rebaseAndRetry` becomes a thin delegate to the new first-class fresh-base path.

## Problem
Workflow-scope retry, recreate, and fresh-base rebase behavior were overloaded into one path with ambiguous semantics.

## Root Cause
The code carried multiple meanings under restart and rebase terminology, which hid whether lineage should be preserved, cleared, or rebuilt from a refreshed base.

## Approach
Split workflow invalidation into three explicit primitives with app-layer refresh-base wiring for the fresh-base path.

## Why This Fix Is Right
These operations are semantically different. Making them first-class gives the policy layer a precise target and keeps git refresh concerns outside workflow-core.

## Tradeoffs And Considerations
The tradeoff is a larger API surface. That is justified because collapsing these operations together was already costing clarity and correctness.

## Before
```mermaid
flowchart LR
  A[Workflow invalidation] --> B[Mixed retry/recreate/rebase path]
  B --> C[Base refresh semantics implicit]
```

## After
```mermaid
flowchart LR
  A[Workflow invalidation] --> B[retryWorkflow]
  A --> C[recreateWorkflow]
  A --> D[recreateWorkflowFromFreshBase]
  D --> E[App-layer refreshBase callback]
  E --> F[Recreate from refreshed upstream base]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 12: workflow-scope primitives`
