### PR TITLE
Task invalidation step 13: remove restart semantics

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -89,7 +89,7 @@ function createMocks() {
       provideInput: vi.fn(),
       beginConflictResolution: vi.fn(() => ({ savedError: 'saved-error' })),
       setFixAwaitingApproval: vi.fn(),
-      restartTask: vi.fn(() => [makeTask()]),
+      retryTask: vi.fn(() => [makeTask()]),
       editTaskCommand: vi.fn(() => [makeTask()]),
       editTaskPrompt: vi.fn(() => [makeTask()]),
       editTaskType: vi.fn(() => [makeTask()]),
@@ -173,7 +173,7 @@ beforeEach(() => {
   mocks.orchestrator.startExecution.mockReturnValue([]);
   mocks.orchestrator.getTask.mockImplementation((id: string) => (id === 'task-1' ? makeTask() : undefined));
   mocks.orchestrator.approve.mockResolvedValue([]);
-  mocks.orchestrator.restartTask.mockReturnValue([makeTask()]);
+  mocks.orchestrator.retryTask.mockReturnValue([makeTask()]);
   mocks.orchestrator.beginConflictResolution.mockReturnValue({ savedError: 'saved-error' });
   mocks.orchestrator.editTaskCommand.mockReturnValue([makeTask()]);
   mocks.orchestrator.editTaskPrompt.mockReturnValue([makeTask()]);
@@ -376,17 +376,17 @@ describe('POST /api/workflows/:id/cancel', () => {
 });
 
 describe('POST /api/tasks/:id/restart', () => {
-  it('restarts task via shared restartTask', async () => {
+  it('restarts task via shared retryTask', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/restart');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('restarted');
-    expect(mocks.orchestrator.restartTask).toHaveBeenCalledWith('task-1');
+    expect(mocks.orchestrator.retryTask).toHaveBeenCalledWith('task-1');
     expect(mocks.killRunningTask).toHaveBeenCalledWith('task-1');
   });
 
   it('returns 400 on error', async () => {
-    mocks.orchestrator.restartTask.mockImplementation(() => {
+    mocks.orchestrator.retryTask.mockImplementation(() => {
       throw new Error('task not restartable');
     });
     const res = await request(port, 'POST', '/api/tasks/task-1/restart');
@@ -406,7 +406,7 @@ describe('POST /api/tasks/:id/restart', () => {
       status: 'running',
       execution: { selectedAttemptId: 'attempt-9' },
     });
-    mocks.orchestrator.restartTask.mockReturnValue([scoped]);
+    mocks.orchestrator.retryTask.mockReturnValue([scoped]);
     mocks.orchestrator.startExecution.mockReturnValue([topup]);
 
     const res = await request(port, 'POST', '/api/tasks/task-1/restart');
@@ -427,7 +427,7 @@ describe('POST /api/tasks/:id/restart', () => {
       status: 'running',
       execution: { selectedAttemptId: 'attempt-1' },
     });
-    mocks.orchestrator.restartTask.mockReturnValue([scoped]);
+    mocks.orchestrator.retryTask.mockReturnValue([scoped]);
     mocks.orchestrator.startExecution.mockReturnValue([duplicate]);
 
     const res = await request(port, 'POST', '/api/tasks/task-1/restart');

--- a/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
+++ b/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
@@ -168,7 +168,7 @@ describe('app-layer handoff repros', () => {
     expect(h.getTask(mergeTaskId)!.status).toBe('completed');
 
     h.persistence.updateWorkflow(workflowId, { baseBranch: 'develop' });
-    const started = h.orchestrator.restartTask(mergeTaskId);
+    const started = h.orchestrator.retryTask(mergeTaskId);
     expect(started.some((task) => task.id === mergeTaskId && task.status === 'running')).toBe(true);
     expect(h.getTask(mergeTaskId)!.execution.workspacePath).toBe('/tmp/mock-merge-worktree');
 
@@ -190,7 +190,7 @@ describe('app-layer handoff repros', () => {
     await h.executor.executeTasks([h.getTask(mergeTaskId)!]);
 
     h.persistence.updateWorkflow(workflowId, { baseBranch: 'release' });
-    const started = h.orchestrator.restartTask(mergeTaskId);
+    const started = h.orchestrator.retryTask(mergeTaskId);
     await dispatchStarted(h, started, 'test.standalone.set-merge-branch');
 
     expect(h.getTask(mergeTaskId)!.execution.workspacePath).toBe('/tmp/mock-merge-worktree');

--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -197,7 +197,7 @@ describe('Flow 1: rebase-and-retry', () => {
 
     // Restart merge gate only
     h.git.reset();
-    const restarted = h.orchestrator.restartTask(mergeId);
+    const restarted = h.orchestrator.retryTask(mergeId);
     expect(restarted.some(t => t.id === mergeId && t.status === 'running')).toBe(true);
 
     // Leaf tasks should still be completed
@@ -333,7 +333,7 @@ describe('Flow 1b: rebase-and-retry from any node', () => {
 
     // Clean rebase: restart merge gate only
     h.git.reset();
-    const restarted = h.orchestrator.restartTask(foundMerge!.id);
+    const restarted = h.orchestrator.retryTask(foundMerge!.id);
     expect(restarted.some(t => t.id === mergeId && t.status === 'running')).toBe(true);
 
     // Leaf tasks stay completed
@@ -404,8 +404,8 @@ describe('Flow 2: restart task', () => {
     expect(h.getTask('A')!.status).toBe('completed');
     expect(h.getTask('B')!.status).toBe('running');
 
-    // Restart A — B is running (not blocked), so restartTask only resets A
-    h.orchestrator.restartTask('A');
+    // Restart A — B is running (not blocked), so retryTask only resets A
+    h.orchestrator.retryTask('A');
 
     // A should be running (no deps, auto-started)
     expect(h.getTask('A')!.status).toBe('running');
@@ -419,7 +419,7 @@ describe('Flow 2: restart task', () => {
     expect(h.getTask('B')!.status).toBe('pending');
 
     // Restart A
-    h.orchestrator.restartTask('A');
+    h.orchestrator.retryTask('A');
     expect(h.getTask('A')!.status).toBe('running');
 
     // Complete A -> B should unblock
@@ -713,7 +713,7 @@ describe('Flow 6b: set-merge-branch', () => {
     h.persistence.updateWorkflow(wfId, { baseBranch: 'develop' });
 
     // Restart merge gate
-    const restarted = h.orchestrator.restartTask(mergeId);
+    const restarted = h.orchestrator.retryTask(mergeId);
     expect(restarted.some(t => t.id === mergeId && t.status === 'running')).toBe(true);
 
     // Re-execute merge gate (it will re-run with new baseBranch)
@@ -864,11 +864,11 @@ describe('Flow 7: orphan relaunch on restart', () => {
     // t1 is still 'running' in the DB — orphaned
     expect(orchestrator2.getTask('A')?.status).toBe('running');
 
-    // Reconcile: restartTask resets to pending, auto-starts (deps met)
+    // Reconcile: retryTask resets to pending, auto-starts (deps met)
     const restarted: TaskState[] = [];
     for (const task of orchestrator2.getAllTasks()) {
       if (task.status === 'running') {
-        const started = orchestrator2.restartTask(task.id);
+        const started = orchestrator2.retryTask(task.id);
         restarted.push(...started.filter(t => t.status === 'running'));
       }
     }
@@ -920,7 +920,7 @@ describe('Flow 7: orphan relaunch on restart', () => {
     const restarted: TaskState[] = [];
     for (const task of orchestrator2.getAllTasks()) {
       if (task.status === 'running') {
-        const started = orchestrator2.restartTask(task.id);
+        const started = orchestrator2.retryTask(task.id);
         restarted.push(...started.filter(t => t.status === 'running'));
       }
     }
@@ -1552,8 +1552,8 @@ describe('Flow: scheduler health across experiment lifecycle', () => {
     const wfId = h.orchestrator.getWorkflowIds()[0];
     h.orchestrator.syncFromDb(wfId);
 
-    // The scheduler still has a slot for A (leaked). restartTask triggers drainScheduler.
-    const restarted = h.orchestrator.restartTask('A');
+    // The scheduler still has a slot for A (leaked). retryTask triggers drainScheduler.
+    const restarted = h.orchestrator.retryTask('A');
     expect(h.getTask('A')!.status).toBe('running');
 
     // Scheduler should be healthy

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -99,7 +99,7 @@ describe('headless delegation enforcement', () => {
       mockDeps.orchestrator.getPersistedActiveTaskIds = vi.fn(() => new Set<string>());
       mockDeps.orchestrator.getWorkflowStatus = vi.fn(() => 'running');
       mockDeps.orchestrator.syncFromDb = vi.fn();
-      mockDeps.orchestrator.restartTask = vi.fn(() => []);
+      mockDeps.orchestrator.retryTask = vi.fn(() => []);
       mockDeps.orchestrator.approve = vi.fn(async () => []);
       mockDeps.orchestrator.setBeforeApproveHook = vi.fn();
       mockDeps.orchestrator.provideInput = vi.fn();
@@ -189,12 +189,12 @@ describe('headless delegation enforcement', () => {
         mockDeps.orchestrator.getAllTasks = vi.fn(() => []);
         mockDeps.orchestrator.getWorkflowStatus = vi.fn(() => 'running');
         mockDeps.orchestrator.syncFromDb = vi.fn();
-        mockDeps.orchestrator.restartTask = vi.fn(() => []);
+        mockDeps.orchestrator.retryTask = vi.fn(() => []);
         mockDeps.orchestrator.approve = vi.fn(async () => []);
         mockDeps.orchestrator.setBeforeApproveHook = vi.fn();
         mockDeps.orchestrator.provideInput = vi.fn();
         // CommandService mocks (headless now routes through commandService)
-        mockDeps.commandService.restartTask = vi.fn(async () => ({ ok: true as const, data: [] }));
+        mockDeps.commandService.retryTask = vi.fn(async () => ({ ok: true as const, data: [] }));
         mockDeps.commandService.approve = vi.fn(async () => ({ ok: true as const, data: [] }));
         mockDeps.persistence.loadWorkflow = vi.fn(() => ({
           id: 'wf-1',
@@ -248,7 +248,7 @@ describe('headless delegation enforcement', () => {
 
         // retry-task command (now routed through commandService)
         await runHeadless(['retry-task', 'wf-1/task-1'], mockDeps);
-        expect(mockDeps.commandService.restartTask).toHaveBeenCalled();
+        expect(mockDeps.commandService.retryTask).toHaveBeenCalled();
 
         // approve command (now routed through commandService)
         mockDeps.orchestrator.getAllTasks = vi.fn(() => [
@@ -281,7 +281,7 @@ describe('headless delegation enforcement', () => {
         mockDeps.orchestrator.startExecution = vi.fn(() => []);
         mockDeps.orchestrator.resumeWorkflow = vi.fn(() => []);
         mockDeps.orchestrator.syncFromDb = vi.fn();
-        mockDeps.orchestrator.restartTask = vi.fn(() => []);
+        mockDeps.orchestrator.retryTask = vi.fn(() => []);
         mockDeps.orchestrator.setBeforeApproveHook = vi.fn();
         mockDeps.orchestrator.provideInput = vi.fn();
         mockDeps.orchestrator.approve = vi.fn(async () => []);
@@ -361,8 +361,8 @@ describe('headless delegation enforcement', () => {
         const depsWithNoTrack: HeadlessDeps = { ...mockDeps, noTrack: true } as HeadlessDeps;
         await runHeadless(['resume', 'wf-1'], depsWithNoTrack);
 
-        expect(mockDeps.orchestrator.restartTask).toHaveBeenCalledTimes(1);
-        expect(mockDeps.orchestrator.restartTask).toHaveBeenCalledWith('wf-1/task-1');
+        expect(mockDeps.orchestrator.retryTask).toHaveBeenCalledTimes(1);
+        expect(mockDeps.orchestrator.retryTask).toHaveBeenCalledWith('wf-1/task-1');
         expect(executeTasksSpy).toHaveBeenCalled();
         executeTasksSpy.mockRestore();
       });
@@ -388,8 +388,8 @@ describe('headless delegation enforcement', () => {
         const depsWithNoTrack: HeadlessDeps = { ...mockDeps, noTrack: true } as HeadlessDeps;
         await runHeadless(['resume', 'wf-1'], depsWithNoTrack);
 
-        expect(mockDeps.orchestrator.restartTask).toHaveBeenCalledTimes(1);
-        expect(mockDeps.orchestrator.restartTask).toHaveBeenCalledWith('wf-1/task-claimed');
+        expect(mockDeps.orchestrator.retryTask).toHaveBeenCalledTimes(1);
+        expect(mockDeps.orchestrator.retryTask).toHaveBeenCalledWith('wf-1/task-claimed');
         expect(executeTasksSpy).toHaveBeenCalled();
         executeTasksSpy.mockRestore();
       });

--- a/packages/app/src/__tests__/no-manual-dispatch.test.ts
+++ b/packages/app/src/__tests__/no-manual-dispatch.test.ts
@@ -8,7 +8,7 @@ const FILES = [
 ];
 
 const AUTO_START_CALLS = [
-  'restartTask',
+  'retryTask',
   'retryWorkflow',
   'recreateTask',
   'recreateWorkflow',

--- a/packages/app/src/__tests__/orphan-reconciliation.test.ts
+++ b/packages/app/src/__tests__/orphan-reconciliation.test.ts
@@ -78,7 +78,7 @@ describe('orphan reconciliation on resume', () => {
     // t1 is still 'running' in the DB — orphaned
     expect(orchestrator2.getTask('t1')?.status).toBe('running');
 
-    // Reconcile: restartTask resets to pending, then auto-starts (deps met)
+    // Reconcile: retryTask resets to pending, then auto-starts (deps met)
     const restarted = relaunchOrphansAndStartReady(orchestrator2, testLogger, 'test');
 
     expect(restarted.length).toBe(1);

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -13,7 +13,7 @@ import {
   recreateWorkflow,
   recreateTask,
   cancelWorkflow,
-  restartTask,
+  retryTask,
   approveTask,
   rejectTask,
   provideInput,
@@ -172,16 +172,16 @@ describe('cancelWorkflow', () => {
   });
 });
 
-describe('restartTask', () => {
-  it('calls orchestrator.restartTask and returns result', () => {
+describe('retryTask', () => {
+  it('calls orchestrator.retryTask and returns result', () => {
     const tasks = [makeRunningTask()];
-    const orchestrator = { restartTask: vi.fn(() => tasks) };
+    const orchestrator = { retryTask: vi.fn(() => tasks) };
 
-    const result = restartTask('task-a', {
+    const result = retryTask('task-a', {
       orchestrator: orchestrator as unknown as Orchestrator,
     });
 
-    expect(orchestrator.restartTask).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
     expect(result).toBe(tasks);
   });
 });
@@ -464,7 +464,7 @@ describe('autoFixOnFailure', () => {
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
-      restartTask: vi.fn(() => started),
+      retryTask: vi.fn(() => started),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -487,7 +487,7 @@ describe('autoFixOnFailure', () => {
     expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'claude', 'boom');
     expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
-    expect(orchestrator.restartTask).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
   });
 
@@ -506,7 +506,7 @@ describe('autoFixOnFailure', () => {
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
-      restartTask: vi.fn(() => started),
+      retryTask: vi.fn(() => started),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -529,7 +529,7 @@ describe('autoFixOnFailure', () => {
     expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
-    expect(orchestrator.restartTask).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
   });
 
@@ -548,7 +548,7 @@ describe('autoFixOnFailure', () => {
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
-      restartTask: vi.fn(() => started),
+      retryTask: vi.fn(() => started),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -586,7 +586,7 @@ describe('autoFixOnFailure', () => {
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
-      restartTask: vi.fn(() => []),
+      retryTask: vi.fn(() => []),
       setFixAwaitingApproval: vi.fn(),
       approve: vi.fn().mockResolvedValue(started),
       revertConflictResolution: vi.fn(),
@@ -622,7 +622,7 @@ describe('autoFixOnFailure', () => {
         }),
       }),
     );
-    expect(orchestrator.restartTask).not.toHaveBeenCalled();
+    expect(orchestrator.retryTask).not.toHaveBeenCalled();
     expect(taskExecutor.publishAfterFix).toHaveBeenCalledWith(started[0]);
   });
 
@@ -679,7 +679,7 @@ describe('autoFixOnFailure', () => {
       getTask,
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
-      restartTask: vi.fn(() => []),
+      retryTask: vi.fn(() => []),
       setFixAwaitingApproval: vi.fn(),
       approve: vi.fn().mockResolvedValue(started),
       resumeTaskAfterFixApproval: vi.fn().mockResolvedValue(started),
@@ -720,7 +720,7 @@ describe('autoFixOnFailure', () => {
         phase: 'auto-fix-post-route-inline-retry',
       }),
     );
-    expect(orchestrator.restartTask).not.toHaveBeenCalled();
+    expect(orchestrator.retryTask).not.toHaveBeenCalled();
   });
 
   it('prefers config.autoFixAgent over task executionAgent', async () => {
@@ -736,7 +736,7 @@ describe('autoFixOnFailure', () => {
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
-      restartTask: vi.fn(() => started),
+      retryTask: vi.fn(() => started),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -786,7 +786,7 @@ describe('autoFixOnFailure', () => {
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
-      restartTask: vi.fn(() => started),
+      retryTask: vi.fn(() => started),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -837,7 +837,7 @@ describe('autoFixOnFailure', () => {
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
-      restartTask: vi.fn(() => started),
+      retryTask: vi.fn(() => started),
       revertConflictResolution: vi.fn(),
     };
     const persistence = {
@@ -1097,7 +1097,7 @@ describe('buildCancelInFlight', () => {
 describe('buildInvalidationDeps', () => {
   function makeBaseOrchestrator() {
     return {
-      restartTask: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
+      retryTask: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
       recreateTask: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
       retryWorkflow: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
       recreateWorkflow: vi.fn(() => [makeRunningTask({ id: 'task-a' })]),
@@ -1112,7 +1112,7 @@ describe('buildInvalidationDeps', () => {
     };
   }
 
-  it('routes retryTask to orchestrator.restartTask (compat wire for Step 13)', async () => {
+  it('routes retryTask to orchestrator.retryTask', async () => {
     const orchestrator = makeBaseOrchestrator();
     const persistence = makePersistence();
 
@@ -1122,7 +1122,7 @@ describe('buildInvalidationDeps', () => {
     });
     const result = await deps.retryTask('task-a');
 
-    expect(orchestrator.restartTask).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
     expect(orchestrator.recreateTask).not.toHaveBeenCalled();
     expect(result).toHaveLength(1);
   });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -40,8 +40,9 @@ import type { ExecutorRegistry, TaskRunner } from '@invoker/execution-engine';
 import {
   approveTask as sharedApproveTask,
   recreateWorkflow as sharedRecreateWorkflow,
+  recreateTask as sharedRecreateTask,
   cancelWorkflow as sharedCancelWorkflow,
-  restartTask as sharedRestartTask,
+  retryTask as sharedRetryTask,
   rejectTask as sharedRejectTask,
   provideInput as sharedProvideInput,
   editTaskCommand as sharedEditTaskCommand,
@@ -203,23 +204,59 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
-      // POST /api/tasks/:id/restart
+      // POST /api/tasks/:id/retry
+      const retryMatch = path.match(/^\/api\/tasks\/([^/]+)\/retry$/);
       const restartMatch = path.match(/^\/api\/tasks\/([^/]+)\/restart$/);
-      if (method === 'POST' && restartMatch) {
-        const taskId = decodeURIComponent(restartMatch[1]);
+      if (method === 'POST' && (retryMatch || restartMatch)) {
+        const isLegacy = !!restartMatch;
+        const taskId = decodeURIComponent((retryMatch ?? restartMatch)![1]);
         try {
           await killRunningTask?.(taskId);
-          const started = sharedRestartTask(taskId, { orchestrator });
+          const started = sharedRetryTask(taskId, { orchestrator });
           const runnable = started.filter(t => t.status === 'running');
           await taskExecutor.executeTasks(runnable);
           await executeGlobalTopup({
             orchestrator,
             taskExecutor,
             logger: apiLogger,
-            context: 'api.tasks.restart',
+            context: isLegacy ? 'api.tasks.restart' : 'api.tasks.retry',
             alreadyDispatched: runnable,
           });
-          json(res, 200, { ok: true, taskId, action: 'restarted', tasksStarted: runnable.length });
+          if (isLegacy) {
+            res.setHeader(
+              'Deprecation',
+              'true; reason="Use /api/tasks/:id/retry or /api/tasks/:id/recreate"',
+            );
+          }
+          json(res, 200, {
+            ok: true,
+            taskId,
+            action: isLegacy ? 'restarted' : 'retried',
+            tasksStarted: runnable.length,
+            ...(isLegacy ? { deprecated: true, replacement: '/api/tasks/:id/retry' } : {}),
+          });
+        } catch (err) {
+          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+        }
+        return;
+      }
+
+      const recreateTaskMatch = path.match(/^\/api\/tasks\/([^/]+)\/recreate$/);
+      if (method === 'POST' && recreateTaskMatch) {
+        const taskId = decodeURIComponent(recreateTaskMatch[1]);
+        try {
+          await killRunningTask?.(taskId);
+          const started = sharedRecreateTask(taskId, { orchestrator, persistence });
+          const runnable = started.filter(t => t.status === 'running');
+          await taskExecutor.executeTasks(runnable);
+          await executeGlobalTopup({
+            orchestrator,
+            taskExecutor,
+            logger: apiLogger,
+            context: 'api.tasks.recreate',
+            alreadyDispatched: runnable,
+          });
+          json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted: runnable.length });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });
         }
@@ -329,10 +366,11 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
-      // POST /api/workflows/:id/restart
+      const wfRecreateMatch = path.match(/^\/api\/workflows\/([^/]+)\/recreate$/);
       const wfRestartMatch = path.match(/^\/api\/workflows\/([^/]+)\/restart$/);
-      if (method === 'POST' && wfRestartMatch) {
-        const workflowId = decodeURIComponent(wfRestartMatch[1]);
+      if (method === 'POST' && (wfRecreateMatch || wfRestartMatch)) {
+        const isLegacy = !!wfRestartMatch;
+        const workflowId = decodeURIComponent((wfRecreateMatch ?? wfRestartMatch)![1]);
         try {
           const started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
           const runnable = started.filter(t => t.status === 'running');
@@ -341,10 +379,22 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             orchestrator,
             taskExecutor,
             logger: apiLogger,
-            context: 'api.workflows.restart',
+            context: isLegacy ? 'api.workflows.restart' : 'api.workflows.recreate',
             alreadyDispatched: runnable,
           });
-          json(res, 200, { ok: true, workflowId, action: 'restarted', tasksStarted: runnable.length });
+          if (isLegacy) {
+            res.setHeader(
+              'Deprecation',
+              'true; reason="Use /api/workflows/:id/recreate"',
+            );
+          }
+          json(res, 200, {
+            ok: true,
+            workflowId,
+            action: isLegacy ? 'restarted' : 'recreated',
+            tasksStarted: runnable.length,
+            ...(isLegacy ? { deprecated: true, replacement: '/api/workflows/:id/recreate' } : {}),
+          });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });
         }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -594,7 +594,7 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessRetryWorkflow(args[1], deps);
       break;
     case 'retry-task':
-      await headlessRestart(args[1], deps);
+      await headlessRetryTask(args[1], deps);
       break;
     case 'recreate':
       await headlessRecreateWorkflow(args[1], deps);
@@ -1083,14 +1083,14 @@ async function headlessSelect(taskId: string, experimentId: string, deps: Headle
   autoFix.unsubscribe();
 }
 
-async function headlessRestart(taskId: string, deps: HeadlessDeps): Promise<void> {
+async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<void> {
   if (!taskId) throw new Error('Missing arguments. Usage: --headless retry-task <taskId>');
   const restored = restoreWorkflowForTask(taskId, deps);
   taskId = restored.resolvedTaskId;
   await preemptTaskSubgraph(taskId, deps);
 
   const envelope = makeEnvelope('restart-task', 'headless', 'task', { taskId });
-  const result = await deps.commandService.restartTask(envelope);
+  const result = await deps.commandService.retryTask(envelope);
   if (!result.ok) throw new Error(result.error.message);
   const runnable = result.data.filter(t => t.status === 'running');
   process.stdout.write(`Restarted task "${taskId}" — ${runnable.length} task(s) to execute\n`);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -610,7 +610,7 @@ if (isHeadless) {
             const mergeTask = tasks.find((task) => task.config.isMergeNode);
             if (!mergeTask) return undefined;
             const executor = createStandaloneTaskExecutor();
-            const started = orchestrator.restartTask(mergeTask.id);
+            const started = orchestrator.retryTask(mergeTask.id);
             await dispatchStartedTasksWithGlobalTopup({
               orchestrator,
               taskExecutor: executor,
@@ -2618,21 +2618,29 @@ if (isHeadless) {
       }
     });
 
+    // `invoker:restart-task` IPC channel — the channel name is kept
+    // for UI compatibility (renaming would require coordinated UI
+    // changes, deferred to a follow-up). The handler now routes
+    // through `commandService.retryTask` per Step 13's vocabulary
+    // cleanup so the UI's "Restart" context-menu action keeps its
+    // historical retry-class semantics (preserves
+    // branch/workspacePath lineage). The channel itself carries an
+    // `@deprecated` marker in `packages/contracts/src/ipc-channels.ts`.
     registerWorkflowScopedGuiMutationHandler(
       'invoker:restart-task',
       (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
       'high',
       async (taskIdArg: unknown) => {
       const taskId = String(taskIdArg);
-      logger.info(`restart-task: "${taskId}"`, { module: 'ipc' });
+      logger.info(`restart-task → retry-task (Step 13 vocabulary): "${taskId}"`, { module: 'ipc' });
       try {
         await preemptTaskSubgraph(taskId);
-        const envelope = makeEnvelope('restart-task', 'ui', 'task', { taskId });
-        const result = await commandService.restartTask(envelope);
+        const envelope = makeEnvelope('retry-task', 'ui', 'task', { taskId });
+        const result = await commandService.retryTask(envelope);
         if (!result.ok) throw new Error(result.error.message);
         const started = result.data;
         logger.info(
-          `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task after commandService.restartTask: count=${started.length} [${started.map((t) => `${t.id}(${t.status})`).join(', ')}]`,
+          `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task after commandService.retryTask: count=${started.length} [${started.map((t) => `${t.id}(${t.status})`).join(', ')}]`,
           { module: 'ipc' },
         );
         const runnable = started.filter(t => t.status === 'running');
@@ -2880,7 +2888,7 @@ if (isHeadless) {
         const tasks = persistence.loadTasks(workflowId);
         const mergeTask = tasks.find(t => t.config.isMergeNode);
         if (mergeTask) {
-          const started = orchestrator.restartTask(mergeTask.id);
+          const started = orchestrator.retryTask(mergeTask.id);
           await dispatchStartedTasksWithGlobalTopup({
             orchestrator,
             taskExecutor: requireTaskExecutor(),

--- a/packages/app/src/orphan-relaunch.ts
+++ b/packages/app/src/orphan-relaunch.ts
@@ -30,7 +30,7 @@ export function relaunchOrphansAndStartReady(
         `startedAt=${startedAt} lastHeartbeatAt=${lastHeartbeat} generation=${task.execution.generation ?? 0}`,
       { module: logPrefix },
     );
-    const started = orchestrator.restartTask(task.id);
+    const started = orchestrator.retryTask(task.id);
     const runnable = started.filter((candidate) => candidate.status === 'running');
     if (runnable.length > 0) {
       orphanRestarted.push(...runnable);

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -120,11 +120,18 @@ export function provideInput(
   deps.orchestrator.provideInput(taskId, text);
 }
 
+export function retryTask(
+  taskId: string,
+  deps: Pick<ActionDeps, 'orchestrator'>,
+): TaskState[] {
+  return deps.orchestrator.retryTask(taskId);
+}
+
 export function restartTask(
   taskId: string,
   deps: Pick<ActionDeps, 'orchestrator'>,
 ): TaskState[] {
-  return deps.orchestrator.restartTask(taskId);
+  return deps.orchestrator.recreateTask(taskId);
 }
 
 export function retryWorkflow(
@@ -285,7 +292,7 @@ export function buildInvalidationDeps(
   });
   return {
     cancelInFlight,
-    retryTask: (taskId: string) => deps.orchestrator.restartTask(taskId),
+    retryTask: (taskId: string) => deps.orchestrator.retryTask(taskId),
     recreateTask: (taskId: string) => deps.orchestrator.recreateTask(taskId),
     retryWorkflow: (workflowId: string) => deps.orchestrator.retryWorkflow(workflowId),
     recreateWorkflow: (workflowId: string) =>
@@ -747,7 +754,7 @@ export async function autoFixOnFailure(
       }
       return;
     }
-    const started = orchestrator.restartTask(taskId);
+    const started = orchestrator.retryTask(taskId);
     const runnable = started.filter(t => t.status === 'running');
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-post-route-restart',

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -195,6 +195,19 @@ export const IpcChannels = {
     request: [taskId: string, experimentId: string | string[]];
     response: void;
   },
+  /**
+   * @deprecated Step 13 (`docs/architecture/task-invalidation-roadmap.md`):
+   * `invoker:restart-task` is the legacy channel name from when
+   * `restartTask` was the overloaded "retry-or-recreate" verb the
+   * chart's "Naming inconsistency" section flagged. The channel
+   * itself is preserved for UI compatibility but its handler in
+   * `main.ts` now routes through `commandService.retryTask` →
+   * `Orchestrator.retryTask` (retry-class semantics: preserves
+   * branch/workspacePath lineage). Prefer the explicit channels —
+   * `invoker:retry-task` (when wired) for retry-class invalidation
+   * or `invoker:recreate-task` for recreate-class invalidation.
+   * Once UI is migrated this channel can be removed.
+   */
   'invoker:restart-task': {} as {
     request: [taskId: string];
     response: void;

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -27,7 +27,7 @@ function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
     getTask: vi.fn().mockReturnValue(undefined),
     revertConflictResolution: vi.fn(),
     provideInput: vi.fn(),
-    restartTask: vi.fn().mockReturnValue([]),
+    retryTask: vi.fn().mockReturnValue([]),
     selectExperiment: vi.fn().mockReturnValue([]),
     editTaskCommand: vi.fn().mockReturnValue([]),
     editTaskType: vi.fn().mockReturnValue([]),
@@ -145,21 +145,21 @@ describe('CommandService', () => {
     });
   });
 
-  // ── restartTask ──────────────────────────────────────────
+  // ── retryTask ──────────────────────────────────────────
 
-  describe('restartTask', () => {
-    it('delegates to orchestrator.restartTask', async () => {
-      const result = await service.restartTask(makeEnvelope({ taskId: 't-1' }));
+  describe('retryTask', () => {
+    it('delegates to orchestrator.retryTask', async () => {
+      const result = await service.retryTask(makeEnvelope({ taskId: 't-1' }));
       expect(result).toEqual({ ok: true, data: [] });
-      expect(orchestrator.restartTask).toHaveBeenCalledWith('t-1');
+      expect(orchestrator.retryTask).toHaveBeenCalledWith('t-1');
     });
 
     it('returns error on exception', async () => {
-      (orchestrator.restartTask as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      (orchestrator.retryTask as ReturnType<typeof vi.fn>).mockImplementation(() => {
         throw new Error('not failed');
       });
-      const result = await service.restartTask(makeEnvelope({ taskId: 't-1' }));
-      expect(result).toEqual({ ok: false, error: { code: 'RESTART_TASK_FAILED', message: 'not failed' } });
+      const result = await service.retryTask(makeEnvelope({ taskId: 't-1' }));
+      expect(result).toEqual({ ok: false, error: { code: 'RETRY_TASK_FAILED', message: 'not failed' } });
     });
   });
 
@@ -364,7 +364,7 @@ describe('CommandService', () => {
         config: { workflowId: taskId === 't-1' ? 'wf-1' : 'wf-1' },
       }));
 
-      (orchestrator.restartTask as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      (orchestrator.retryTask as ReturnType<typeof vi.fn>).mockImplementation(async () => {
         order.push('restart-start');
         await firstPromise;
         order.push('restart-end');
@@ -376,7 +376,7 @@ describe('CommandService', () => {
         return [];
       });
 
-      const p1 = service.restartTask(makeEnvelope({ taskId: 't-1' }, 'k1'));
+      const p1 = service.retryTask(makeEnvelope({ taskId: 't-1' }, 'k1'));
       const p2 = service.editTaskCommand(makeEnvelope({ taskId: 't-2', newCommand: 'x' }, 'k2'));
 
       // Let the first call complete
@@ -399,7 +399,7 @@ describe('CommandService', () => {
         config: { workflowId: taskId === 't-1' ? 'wf-1' : 'wf-2' },
       }));
 
-      (orchestrator.restartTask as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      (orchestrator.retryTask as ReturnType<typeof vi.fn>).mockImplementation(async () => {
         order.push('restart-start');
         await restartGate;
         order.push('restart-end');
@@ -412,7 +412,7 @@ describe('CommandService', () => {
         return [];
       });
 
-      const p1 = service.restartTask(makeEnvelope({ taskId: 't-1' }, 'k1'));
+      const p1 = service.retryTask(makeEnvelope({ taskId: 't-1' }, 'k1'));
       const p2 = service.editTaskCommand(makeEnvelope({ taskId: 't-2', newCommand: 'x' }, 'k2'));
 
       await Promise.resolve();

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -180,7 +180,7 @@ describe('Orchestrator taskDispatcher', () => {
     respondForTask(orchestrator, taskId, 'failed', 1);
 
     dispatched.length = 0;
-    orchestrator.restartTask(taskId);
+    orchestrator.retryTask(taskId);
     expect(dispatched).toEqual([taskId]);
 
     respondForTask(orchestrator, taskId, 'failed', 1);

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -294,7 +294,7 @@ describe('Orchestrator', () => {
 
       persistence.workflows.get(workflowId)!.status = 'failed';
 
-      const restarted = orchestrator.restartTask(taskId);
+      const restarted = orchestrator.retryTask(taskId);
 
       expect(restarted.some((task) => task.id === taskId && task.status === 'running')).toBe(true);
       expect(persistence.workflows.get(workflowId)?.status).toBe('running');
@@ -537,7 +537,7 @@ describe('Orchestrator', () => {
       repro.handleWorkerResponse(makeResponse({ actionId: midId, status: 'completed', outputs: { exitCode: 0 } }));
       expect(repro.getTask(lateId)?.status).toBe('running');
 
-      repro.restartTask(prepareId);
+      repro.retryTask(prepareId);
       expect(repro.getTask(prepareId)?.status).toBe('running');
       expect(repro.getTask(midId)?.status).toBe('pending');
       expect(repro.getTask(lateId)?.status).toBe('pending');
@@ -1610,7 +1610,7 @@ describe('Orchestrator', () => {
       orchestrator.deleteWorkflow(upstreamWfId);
       expect(orchestrator.getTask(downstreamTaskId)).toBeDefined();
 
-      const restarted = orchestrator.restartTask(downstreamTaskId);
+      const restarted = orchestrator.retryTask(downstreamTaskId);
       expect(restarted.map((t) => t.id)).toContain(downstreamTaskId);
       expect(orchestrator.getTask(downstreamTaskId)!.status).toBe('blocked');
       expect(orchestrator.getTask(downstreamTaskId)!.execution.blockedBy).toContain('missing prerequisite');
@@ -2217,7 +2217,7 @@ describe('Orchestrator', () => {
       });
 
       hydrateOrchestrator.syncFromDb('wf-hydrate');
-      const started = hydrateOrchestrator.restartTask('t1');
+      const started = hydrateOrchestrator.retryTask('t1');
 
       expect(started).toHaveLength(1);
       expect(started[0].status).toBe('running');
@@ -2247,7 +2247,7 @@ describe('Orchestrator', () => {
       });
 
       hydrateOrchestrator.syncFromDb('wf-hydrate');
-      const started = hydrateOrchestrator.restartTask('t1');
+      const started = hydrateOrchestrator.retryTask('t1');
 
       expect(started).toHaveLength(1);
       expect(started[0].status).toBe('running');
@@ -2285,7 +2285,7 @@ describe('Orchestrator', () => {
       expect(hydrateOrchestrator.getTask('a1')!.status).toBe('completed');
 
       hydrateOrchestrator.syncFromDb('wf-b');
-      const started = hydrateOrchestrator.restartTask('b1');
+      const started = hydrateOrchestrator.retryTask('b1');
       expect(started).toHaveLength(1);
       expect(started[0].status).toBe('running');
     });
@@ -3217,15 +3217,15 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(taskId)?.status).toBe('running');
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
       const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
 
       const started = orchestrator.editTaskType(taskId, 'worktree');
 
       expect(cancelSpy).toHaveBeenCalledWith(taskId);
-      expect(restartSpy).toHaveBeenCalledWith(taskId);
+      expect(retrySpy).toHaveBeenCalledWith(taskId);
       expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
-        restartSpy.mock.invocationCallOrder[0],
+        retrySpy.mock.invocationCallOrder[0],
       );
       expect(recreateSpy).not.toHaveBeenCalled();
 
@@ -3237,11 +3237,11 @@ describe('Orchestrator', () => {
       expect(started[0].id).toBe(taskId);
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
       recreateSpy.mockRestore();
     });
 
-    it('editing an INACTIVE (failed) task skips cancel but still routes through restartTask (retry-class)', () => {
+    it('editing an INACTIVE (failed) task skips cancel but still routes through retryTask', () => {
       orchestrator.loadPlan({
         name: 'edit-type-inactive-test',
         tasks: [{ id: 't1', description: 'Task 1', command: 'echo old', executorType: 'docker' }],
@@ -3254,17 +3254,17 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(taskId)?.status).toBe('failed');
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
 
       orchestrator.editTaskType(taskId, 'worktree');
 
-      // Inactive → no cancel needed; restartTask still resets volatile
+      // Inactive → no cancel needed; retryTask still resets volatile
       // attempt state and bumps generation.
       expect(cancelSpy).not.toHaveBeenCalled();
-      expect(restartSpy).toHaveBeenCalledWith(taskId);
+      expect(retrySpy).toHaveBeenCalledWith(taskId);
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
     });
 
     it('preserves valid lineage (branch / workspacePath) — retry-class does NOT discard substrate lineage', () => {
@@ -3296,7 +3296,7 @@ describe('Orchestrator', () => {
       // ── Preserved (chart says substrate-only change keeps these) ──
       expect(task.execution.branch).toBe('experiment/preserved-branch');
       expect(task.execution.workspacePath).toBe('/tmp/preserved-workspace');
-      // ── Cleared (volatile attempt state per restartTask reset shape) ──
+      // ── Cleared (volatile attempt state per retryTask reset shape) ──
       expect(task.execution.agentSessionId).toBeUndefined();
       expect(task.execution.containerId).toBeUndefined();
       expect(task.execution.error).toBeUndefined();
@@ -4186,7 +4186,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('A')!.status).toBe('completed');
       expect(orchestrator.getTask('B')!.status).toBe('completed');
 
-      orchestrator.restartTask('A');
+      orchestrator.retryTask('A');
       expect(orchestrator.getTask('B')!.status).toBe('pending');
       expect(warnSpy).not.toHaveBeenCalled();
     });
@@ -4211,7 +4211,7 @@ describe('Orchestrator', () => {
       );
       expect(orchestrator.getTask('C')!.status).toBe('pending');
 
-      orchestrator.restartTask('B');
+      orchestrator.retryTask('B');
 
       // C still pending because A is still failed
       expect(orchestrator.getTask('C')!.status).toBe('pending');
@@ -4237,7 +4237,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('C')!.status).toBe('pending');
 
       // Restart A — C stays pending because B is still failed
-      orchestrator.restartTask('A');
+      orchestrator.retryTask('A');
       expect(orchestrator.getTask('C')!.status).toBe('pending');
     });
 
@@ -4298,9 +4298,9 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('D')!.status).toBe('pending');
 
       // Phase 2: Restart all three roots
-      orchestrator.restartTask('A');
-      orchestrator.restartTask('B');
-      orchestrator.restartTask('C');
+      orchestrator.retryTask('A');
+      orchestrator.retryTask('B');
+      orchestrator.retryTask('C');
       expect(orchestrator.getTask('D')!.status).toBe('pending');
 
       // Phase 3: Complete A, B, C — D should become ready after the last one
@@ -4362,7 +4362,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('B')!.status).toBe('pending');
 
       // Restart A, then complete it → B starts
-      orchestrator.restartTask('A');
+      orchestrator.retryTask('A');
       logSpy.mockClear();
       orchestrator.handleWorkerResponse(
         makeResponse({
@@ -4396,7 +4396,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('C')!.status).toBe('pending');
 
       // Restart A, then complete it → B starts; C still pending (B not completed yet)
-      orchestrator.restartTask('A');
+      orchestrator.retryTask('A');
       orchestrator.handleWorkerResponse(
         makeResponse({
           actionId: 'A',
@@ -4572,7 +4572,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(t1Scoped)!.status).toBe('completed');
       expect(persistence.loadAttempt(staleAttemptId)?.status).toBe('running');
 
-      const started = orchestrator.restartTask(t1Scoped);
+      const started = orchestrator.retryTask(t1Scoped);
 
       expect(started.some(task => task.id === t1Scoped)).toBe(true);
       expect(orchestrator.getTask(t1Scoped)!.status).toBe('running');
@@ -4676,7 +4676,7 @@ describe('Orchestrator', () => {
       );
       expect(orchestrator.getTask('B')!.status).toBe('pending');
 
-      const result = orchestrator.restartTask('B');
+      const result = orchestrator.retryTask('B');
 
       // B stays pending because A is still failed
       expect(result).toHaveLength(1);
@@ -4702,7 +4702,7 @@ describe('Orchestrator', () => {
       );
       expect(orchestrator.getTask('t1')!.status).toBe('needs_input');
 
-      const result = orchestrator.restartTask('t1');
+      const result = orchestrator.retryTask('t1');
 
       expect(result).toHaveLength(1);
       expect(result[0].status).toBe('running');
@@ -4719,7 +4719,7 @@ describe('Orchestrator', () => {
       orchestrator.startExecution();
       expect(orchestrator.getTask('t1')!.status).toBe('running');
 
-      const result = orchestrator.restartTask('t1');
+      const result = orchestrator.retryTask('t1');
 
       expect(result).toHaveLength(1);
       expect(result[0].status).toBe('running');
@@ -4753,7 +4753,7 @@ describe('Orchestrator', () => {
       });
 
       testOrchestrator.syncFromDb('wf-branch-test');
-      testOrchestrator.restartTask('t1');
+      testOrchestrator.retryTask('t1');
 
       const task = testOrchestrator.getTask('t1')!;
       expect(task.execution.commit).toBeUndefined();
@@ -4781,7 +4781,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('C')!.status).toBe('pending');
 
       // Restart only A — C stays pending because B is still failed
-      orchestrator.restartTask('A');
+      orchestrator.retryTask('A');
       expect(orchestrator.getTask('C')!.status).toBe('pending');
     });
 
@@ -4831,7 +4831,7 @@ describe('Orchestrator', () => {
 
       expect(orchestrator.getTask(rid(orchestrator, 0, 'pivot'))!.status).toBe('needs_input');
 
-      orchestrator.restartTask(sid(orchestrator, 0, 'pivot-exp-v1'));
+      orchestrator.retryTask(sid(orchestrator, 0, 'pivot-exp-v1'));
 
       expect(orchestrator.getTask(rid(orchestrator, 0, 'pivot'))!.status).toBe('pending');
     });
@@ -4864,7 +4864,7 @@ describe('Orchestrator', () => {
       });
 
       testOrchestrator.syncFromDb('heartbeat-test');
-      testOrchestrator.restartTask('t1');
+      testOrchestrator.retryTask('t1');
 
       const task = testOrchestrator.getTask('t1')!;
 
@@ -6055,7 +6055,7 @@ describe('Orchestrator', () => {
       orchestrator.syncFromDb(wfId);
 
       // restartTask should recover
-      const started = orchestrator.restartTask('t1');
+      const started = orchestrator.retryTask('t1');
       const t1 = orchestrator.getTask('t1')!;
       expect(t1.status).toBe('running');
       expect(started.length).toBeGreaterThanOrEqual(1);
@@ -6128,7 +6128,7 @@ describe('Orchestrator', () => {
       expect(claimedAttemptId).toBeTruthy();
 
       orchestrator.refreshFromDb();
-      const restarted = orchestrator.restartTask(taskId);
+      const restarted = orchestrator.retryTask(taskId);
       const restartedTask = orchestrator.getTask(taskId);
       const latestAttemptId = restartedTask?.execution.selectedAttemptId;
 
@@ -6812,29 +6812,29 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(mergeId)?.status).toBe('running');
     }
 
-    it('routes through restartTask and cancels active merge work first', () => {
+    it('routes through retryTask and cancels active merge work first', () => {
       const { mergeId, leafId } = setupMergeWorkflow('manual');
       driveMergeNodeToRunning(mergeId, leafId);
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
       const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
 
       orchestrator.editTaskMergeMode(mergeId, 'automatic');
 
       expect(cancelSpy).toHaveBeenCalledWith(mergeId);
-      expect(restartSpy).toHaveBeenCalledWith(mergeId);
+      expect(retrySpy).toHaveBeenCalledWith(mergeId);
       expect(recreateSpy).not.toHaveBeenCalled();
       // Hard Invariant: cancel-first MUST precede the retry-class
       // reset. `mock.invocationCallOrder` is the global vi-internal
       // ordering counter — comparing the first cancel/restart call
       // pins the synchronous ordering inside `editTaskMergeMode`.
       expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
-        restartSpy.mock.invocationCallOrder[0],
+        retrySpy.mock.invocationCallOrder[0],
       );
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
       recreateSpy.mockRestore();
     });
 
@@ -6846,13 +6846,13 @@ describe('Orchestrator', () => {
       const beforeUpdates = persistence.updateWorkflowCalls.get(workflowId) ?? 0;
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
 
       const result = orchestrator.editTaskMergeMode(mergeId, 'manual');
 
       expect(result).toEqual([]);
       expect(cancelSpy).not.toHaveBeenCalled();
-      expect(restartSpy).not.toHaveBeenCalled();
+      expect(retrySpy).not.toHaveBeenCalled();
 
       const afterGeneration = orchestrator.getTask(mergeId)!.execution.generation ?? 0;
       expect(afterGeneration).toBe(beforeGeneration);
@@ -6861,7 +6861,7 @@ describe('Orchestrator', () => {
       expect(afterUpdates).toBe(beforeUpdates);
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
     });
 
     it('different-mode flips on active merge nodes bump execution generation by exactly one', () => {
@@ -6886,7 +6886,7 @@ describe('Orchestrator', () => {
       expect(wf?.mergeMode).toBe('external_review');
     });
 
-    it('inactive merge nodes skip cancel-first but still route through restartTask', () => {
+    it('inactive merge nodes skip cancel-first but still route through retryTask', () => {
       // Do NOT drive the merge node into a running state; with the
       // leaf still pending the merge node sits in `pending` (no
       // in-flight merge work). Cancel-first MUST be skipped because
@@ -6896,21 +6896,20 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(mergeId)?.status).toBe('pending');
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
 
       orchestrator.editTaskMergeMode(mergeId, 'automatic');
 
       expect(cancelSpy).not.toHaveBeenCalled();
-      expect(restartSpy).toHaveBeenCalledWith(mergeId);
-      // Merge node remains `pending` after the retry-class reset
-      // (it is the natural target state of `restartTask`).
+      expect(retrySpy).toHaveBeenCalledWith(mergeId);
+      // Merge node remains `pending` after the retry-class reset.
       expect(orchestrator.getTask(mergeId)?.status).toBe('pending');
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
     });
 
-    it('active awaiting_approval merge nodes cancel first, then reset via restartTask', () => {
+    it('active awaiting_approval merge nodes cancel first, then reset via retryTask', () => {
       // The chart calls out `awaiting_approval` (the manual-gate
       // wait state) explicitly as an ACTIVE state for the merge
       // node — switching modes mid-review must interrupt the
@@ -6925,18 +6924,18 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(mergeId)?.status).toBe('awaiting_approval');
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
 
       orchestrator.editTaskMergeMode(mergeId, 'automatic');
 
       expect(cancelSpy).toHaveBeenCalledWith(mergeId);
-      expect(restartSpy).toHaveBeenCalledWith(mergeId);
+      expect(retrySpy).toHaveBeenCalledWith(mergeId);
       expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
-        restartSpy.mock.invocationCallOrder[0],
+        retrySpy.mock.invocationCallOrder[0],
       );
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
     });
 
     it('throws when called on a non-merge task', () => {
@@ -6954,32 +6953,7 @@ describe('Orchestrator', () => {
     });
   });
 
-  // ── Step 9 (task-invalidation roadmap): editTaskMergeMode ──────────────
-  //
-  // The chart's Decision Table row "Change merge mode" maps the
-  // `mergeMode` workflow-level mutation to InvalidationAction =
-  // 'retryTask' with InvalidationScope = 'task' applied to the merge
-  // node (`__merge__<workflowId>`). Step 9 migrates the previously
-  // app-layer-only special casing in `setWorkflowMergeMode` onto a
-  // proper orchestrator policy seam: `Orchestrator.editTaskMergeMode`
-  // owns the cancel-first interruption, the workflow-level
-  // `mergeMode` write, and the retry-class merge-node reset (via
-  // `restartTask`), in parity with Step 5/6 (`editTaskType`) and
-  // Step 7/8 (`selectExperiment` / `selectExperiments`).
-  //
-  // The hard invariants pinned below are:
-  //   - same-mode flips are no-ops (no cancel, no generation bump)
-  //   - different-mode flips while the merge node is ACTIVE
-  //     (`running` / `awaiting_approval`) cancel-first BEFORE the
-  //     retry-class reset, and the merge node's execution generation
-  //     bumps by exactly one
-  //   - INACTIVE merge nodes (e.g. `pending`) skip cancel but still
-  //     route through `restartTask` (state reset only, no spurious
-  //     `cancelTask` that would mark a `pending` merge node `failed`)
-  //   - the route NEVER touches `recreateTask` (retry-class only,
-  //     per the chart Decision Table)
-
-  describe('editTaskMergeMode (Step 9 invalidation)', () => {
+  describe('editTaskMergeMode invalidation', () => {
     function setupMergeWorkflow(initialMergeMode: 'manual' | 'automatic' | 'external_review' = 'manual'): {
       mergeId: string;
       workflowId: string;
@@ -7015,33 +6989,33 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(mergeId)?.status).toBe('running');
     }
 
-    it('Step 9: routes through restartTask and (when ACTIVE) cancels first — recreateTask MUST NOT be on the route', () => {
+    it('routes through retryTask and cancels active merge work first', () => {
       const { mergeId, leafId } = setupMergeWorkflow('manual');
       driveMergeNodeToRunning(mergeId, leafId);
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
       const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
 
       orchestrator.editTaskMergeMode(mergeId, 'automatic');
 
       expect(cancelSpy).toHaveBeenCalledWith(mergeId);
-      expect(restartSpy).toHaveBeenCalledWith(mergeId);
+      expect(retrySpy).toHaveBeenCalledWith(mergeId);
       expect(recreateSpy).not.toHaveBeenCalled();
       // Hard Invariant: cancel-first MUST precede the retry-class
       // reset. `mock.invocationCallOrder` is the global vi-internal
       // ordering counter — comparing the first cancel/restart call
       // pins the synchronous ordering inside `editTaskMergeMode`.
       expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
-        restartSpy.mock.invocationCallOrder[0],
+        retrySpy.mock.invocationCallOrder[0],
       );
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
       recreateSpy.mockRestore();
     });
 
-    it('Step 9: same-mode flip is a NO-OP (no cancel, no restart, no generation bump, no workflow write)', () => {
+    it('same-mode flip is a no-op', () => {
       const { mergeId, leafId, workflowId } = setupMergeWorkflow('manual');
       driveMergeNodeToRunning(mergeId, leafId);
 
@@ -7049,13 +7023,13 @@ describe('Orchestrator', () => {
       const beforeUpdates = persistence.updateWorkflowCalls.get(workflowId) ?? 0;
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
 
       const result = orchestrator.editTaskMergeMode(mergeId, 'manual');
 
       expect(result).toEqual([]);
       expect(cancelSpy).not.toHaveBeenCalled();
-      expect(restartSpy).not.toHaveBeenCalled();
+      expect(retrySpy).not.toHaveBeenCalled();
 
       const afterGeneration = orchestrator.getTask(mergeId)!.execution.generation ?? 0;
       expect(afterGeneration).toBe(beforeGeneration);
@@ -7064,10 +7038,10 @@ describe('Orchestrator', () => {
       expect(afterUpdates).toBe(beforeUpdates);
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
     });
 
-    it('Step 9: different-mode flip when merge node is ACTIVE bumps execution generation by exactly one', () => {
+    it('different-mode flip on an active merge node bumps execution generation by exactly one', () => {
       const { mergeId, leafId } = setupMergeWorkflow('manual');
       driveMergeNodeToRunning(mergeId, leafId);
 
@@ -7079,7 +7053,7 @@ describe('Orchestrator', () => {
       expect(after).toBe(before + 1);
     });
 
-    it('Step 9: different-mode flip persists the new mode on the workflow record', () => {
+    it('different-mode flip persists the new mode on the workflow record', () => {
       const { mergeId, leafId, workflowId } = setupMergeWorkflow('manual');
       driveMergeNodeToRunning(mergeId, leafId);
 
@@ -7089,7 +7063,7 @@ describe('Orchestrator', () => {
       expect(wf?.mergeMode).toBe('external_review');
     });
 
-    it('Step 9: INACTIVE merge node (pending) skips cancel-first but still routes through restartTask', () => {
+    it('inactive merge node (pending) skips cancel-first but still routes through retryTask', () => {
       // Do NOT drive the merge node into a running state; with the
       // leaf still pending the merge node sits in `pending` (no
       // in-flight merge work). Cancel-first MUST be skipped because
@@ -7099,21 +7073,21 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(mergeId)?.status).toBe('pending');
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
 
       orchestrator.editTaskMergeMode(mergeId, 'automatic');
 
       expect(cancelSpy).not.toHaveBeenCalled();
-      expect(restartSpy).toHaveBeenCalledWith(mergeId);
+      expect(retrySpy).toHaveBeenCalledWith(mergeId);
       // Merge node remains `pending` after the retry-class reset
       // (it is the natural target state of `restartTask`).
       expect(orchestrator.getTask(mergeId)?.status).toBe('pending');
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
     });
 
-    it('Step 9: ACTIVE awaiting_approval (manual gate) merge node cancels first, then resets via restartTask', () => {
+    it('active awaiting_approval merge node cancels first, then resets via retryTask', () => {
       // The chart calls out `awaiting_approval` (the manual-gate
       // wait state) explicitly as an ACTIVE state for the merge
       // node — switching modes mid-review must interrupt the
@@ -7128,18 +7102,18 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(mergeId)?.status).toBe('awaiting_approval');
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
 
       orchestrator.editTaskMergeMode(mergeId, 'automatic');
 
       expect(cancelSpy).toHaveBeenCalledWith(mergeId);
-      expect(restartSpy).toHaveBeenCalledWith(mergeId);
+      expect(retrySpy).toHaveBeenCalledWith(mergeId);
       expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
-        restartSpy.mock.invocationCallOrder[0],
+        retrySpy.mock.invocationCallOrder[0],
       );
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
     });
 
     it('Step 9: throws when called on a non-merge task', () => {
@@ -7219,29 +7193,29 @@ describe('Orchestrator', () => {
       publishedDeltas = [];
     }
 
-    it('routes through restartTask and cancels active fix sessions first', () => {
+    it('routes through retryTask and cancels active fix sessions first', () => {
       const { taskId } = setupFailedTask();
       driveTaskToFixingWithAi(taskId);
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
       const recreateSpy = vi.spyOn(orchestrator, 'recreateTask');
 
       orchestrator.editTaskFixContext(taskId, { fixPrompt: 'try a different approach' });
 
       expect(cancelSpy).toHaveBeenCalledWith(taskId);
-      expect(restartSpy).toHaveBeenCalledWith(taskId);
+      expect(retrySpy).toHaveBeenCalledWith(taskId);
       expect(recreateSpy).not.toHaveBeenCalled();
       // Hard Invariant: cancel-first MUST precede the retry-class
       // reset. `mock.invocationCallOrder` is the global vi-internal
       // ordering counter — comparing the first cancel/restart call
       // pins the synchronous ordering inside `editTaskFixContext`.
       expect(cancelSpy.mock.invocationCallOrder[0]).toBeLessThan(
-        restartSpy.mock.invocationCallOrder[0],
+        retrySpy.mock.invocationCallOrder[0],
       );
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
       recreateSpy.mockRestore();
     });
 
@@ -7267,7 +7241,7 @@ describe('Orchestrator', () => {
       });
 
       const task = orchestrator.getTask(taskId)!;
-      // restartTask resets to `pending` and may auto-start to
+      // retryTask resets to `pending` and may auto-start to
       // `running` if the task is ready — both are valid
       // post-retry pre-execution states for the chart's "retry
       // from reverted failed state" baseline (the fix-loop attempt
@@ -7278,7 +7252,7 @@ describe('Orchestrator', () => {
       expect(task.config.fixContext).toBe('see notes/foo.md');
     });
 
-    it('edit on INACTIVE failed task skips cancel but still routes through restartTask', () => {
+    it('edit on INACTIVE failed task skips cancel but still routes through retryTask', () => {
       // Failed (not fixing_with_ai) is the inactive fix-loop state.
       // Cancel-first MUST be skipped because there is no in-flight
       // fix attempt to interrupt; the task is still settled in
@@ -7288,19 +7262,19 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(taskId)?.status).toBe('failed');
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
 
       orchestrator.editTaskFixContext(taskId, { fixPrompt: 'fresh try' });
 
       expect(cancelSpy).not.toHaveBeenCalled();
-      expect(restartSpy).toHaveBeenCalledWith(taskId);
+      expect(retrySpy).toHaveBeenCalledWith(taskId);
 
       const task = orchestrator.getTask(taskId)!;
       expect(['pending', 'running']).toContain(task.status);
       expect(task.config.fixPrompt).toBe('fresh try');
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
     });
 
     it('same-content edit is a NO-OP', () => {
@@ -7315,7 +7289,7 @@ describe('Orchestrator', () => {
       publishedDeltas = [];
 
       const cancelSpy = vi.spyOn(orchestrator, 'cancelTask');
-      const restartSpy = vi.spyOn(orchestrator, 'restartTask');
+      const retrySpy = vi.spyOn(orchestrator, 'retryTask');
 
       const result = orchestrator.editTaskFixContext(taskId, {
         fixPrompt: 'identical',
@@ -7324,7 +7298,7 @@ describe('Orchestrator', () => {
 
       expect(result).toEqual([]);
       expect(cancelSpy).not.toHaveBeenCalled();
-      expect(restartSpy).not.toHaveBeenCalled();
+      expect(retrySpy).not.toHaveBeenCalled();
 
       const afterGeneration = orchestrator.getTask(taskId)!.execution.generation ?? 0;
       expect(afterGeneration).toBe(beforeGeneration);
@@ -7339,7 +7313,7 @@ describe('Orchestrator', () => {
       expect(fixContextDeltas).toHaveLength(0);
 
       cancelSpy.mockRestore();
-      restartSpy.mockRestore();
+      retrySpy.mockRestore();
     });
 
     it('omitted patch key leaves the existing config field untouched', () => {
@@ -7451,7 +7425,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('child')!.status).toBe('stale');
 
       // Restart the stale child — parent is completed, so child is ready and auto-starts
-      orchestrator.restartTask('child');
+      orchestrator.retryTask('child');
       expect(orchestrator.getTask('child')!.status).toBe('running');
     });
 
@@ -7468,7 +7442,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('t1')!.status).toBe('awaiting_approval');
       expect(orchestrator.getTask('t1')!.execution.completedAt).toBeDefined();
 
-      orchestrator.restartTask('t1');
+      orchestrator.retryTask('t1');
       expect(orchestrator.getTask('t1')!.status).toBe('running');
       expect(orchestrator.getTask('t1')!.execution.completedAt).toBeUndefined();
     });
@@ -7534,7 +7508,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(reconId)!.status).toBe('completed');
       expect(orchestrator.getTask(reconId)!.execution.selectedExperiment).toBe(exp1);
 
-      orchestrator.restartTask(reconId);
+      orchestrator.retryTask(reconId);
       const recon = orchestrator.getTask(reconId)!;
       expect(recon.status).toBe('running');
       expect(recon.execution.commit).toBeUndefined();
@@ -7561,7 +7535,7 @@ describe('Orchestrator', () => {
       // B stays pending (no blocked status)
       expect(orchestrator.getTask('B')!.status).toBe('pending');
 
-      orchestrator.restartTask('A');
+      orchestrator.retryTask('A');
       orchestrator.handleWorkerResponse(
         makeResponse({ actionId: 'A', executionGeneration: 1, status: 'completed', outputs: { exitCode: 0 } }),
       );
@@ -7952,7 +7926,7 @@ describe('Orchestrator', () => {
     });
 
     it('revert with non-JSON error preserves plain string without mergeConflict', () => {
-      orchestrator.restartTask('t2');
+      orchestrator.retryTask('t2');
       orchestrator.handleWorkerResponse(
         makeResponse({
           actionId: 't2',
@@ -8050,7 +8024,7 @@ describe('Orchestrator', () => {
     it('restartTask clears the fix state', () => {
       orchestrator.beginConflictResolution('f2');
       orchestrator.setFixAwaitingApproval('f2', 'error');
-      orchestrator.restartTask('f2');
+      orchestrator.retryTask('f2');
       const task = orchestrator.getTask('f2')!;
       expect(task.status === 'pending' || task.status === 'running').toBe(true);
       expect(task.execution.isFixingWithAI).toBeFalsy();
@@ -8613,7 +8587,7 @@ describe('Orchestrator', () => {
 
       orchestrator.deferTask('task-a');
       // Restart task-a clears it from deferredTaskIds
-      orchestrator.restartTask('task-a');
+      orchestrator.retryTask('task-a');
 
       // Complete task-b — no deferred tasks should re-enqueue
       // (task-a was already restarted independently)

--- a/packages/workflow-core/src/__tests__/restart-deprecation.test.ts
+++ b/packages/workflow-core/src/__tests__/restart-deprecation.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { Orchestrator } from '../orchestrator.js';
+import { CommandService } from '../command-service.js';
+import { makeEnvelope } from '@invoker/contracts';
+
+// ── Shared fixtures ────────────────────────────────────────────
+
+function envelope<P>(payload: P) {
+  return makeEnvelope<P>('test-cmd', 'headless', 'task', payload);
+}
+
+describe('restartTask deprecation shim', () => {
+  // ── Orchestrator-level shim ──────────────────────────────────
+
+  describe('Orchestrator.restartTask', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    let recreateSpy: ReturnType<typeof vi.spyOn>;
+    let retrySpy: ReturnType<typeof vi.spyOn>;
+    let orch: Orchestrator;
+
+    beforeEach(() => {
+      // Build a minimally-valid orchestrator. Because we're
+      // only asserting delegation we don't need plan loading;
+      // we stub the target methods directly.
+      orch = Object.create(Orchestrator.prototype) as Orchestrator;
+      // The shim only calls `this.recreateTask`, so stubbing
+      // that out and asserting the call is sufficient.
+      recreateSpy = vi.spyOn(orch, 'recreateTask').mockImplementation(() => []);
+      retrySpy = vi.spyOn(orch, 'retryTask').mockImplementation(() => []);
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    it('delegates restartTask to recreateTask (NOT retryTask)', () => {
+      orch.restartTask('task-1');
+
+      expect(recreateSpy).toHaveBeenCalledTimes(1);
+      expect(recreateSpy).toHaveBeenCalledWith('task-1');
+      expect(retrySpy).not.toHaveBeenCalled();
+    });
+
+    it('emits a deprecation warning on stderr', () => {
+      orch.restartTask('task-1');
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0][0]);
+      expect(message).toContain('restartTask');
+      expect(message).toContain('deprecated');
+      expect(message).toContain('Routing to recreateTask');
+      expect(message).toContain('retryTask');
+      expect(message).toContain('recreateTask');
+    });
+
+    it('returns whatever recreateTask returns (passthrough)', () => {
+      const sentinel = [{ id: 'task-1' } as never];
+      recreateSpy.mockReturnValueOnce(sentinel);
+
+      const result = orch.restartTask('task-1');
+
+      expect(result).toBe(sentinel);
+    });
+  });
+
+  // ── CommandService-level shim ────────────────────────────────
+
+  describe('CommandService.restartTask', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+    let svc: CommandService;
+    let orchestrator: {
+      retryTask: ReturnType<typeof vi.fn>;
+      recreateTask: ReturnType<typeof vi.fn>;
+      getTask: ReturnType<typeof vi.fn>;
+    };
+
+    beforeEach(() => {
+      orchestrator = {
+        retryTask: vi.fn(() => []),
+        recreateTask: vi.fn(() => []),
+        // CommandService consults getTask() to scope the mutex
+        // by workflow; returning undefined falls back to global.
+        getTask: vi.fn(() => undefined),
+      };
+      // CommandService is a thin mutex-serialized wrapper; for
+      // shim testing we just need the orchestrator delegate.
+      svc = new CommandService(orchestrator as never);
+      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    });
+
+    it('delegates restartTask to orchestrator.recreateTask (NOT retryTask)', async () => {
+      const result = await svc.restartTask(envelope({ taskId: 't-1' }));
+
+      expect(result).toEqual({ ok: true, data: [] });
+      expect(orchestrator.recreateTask).toHaveBeenCalledTimes(1);
+      expect(orchestrator.recreateTask).toHaveBeenCalledWith('t-1');
+      expect(orchestrator.retryTask).not.toHaveBeenCalled();
+    });
+
+    it('emits a deprecation warning', async () => {
+      await svc.restartTask(envelope({ taskId: 't-1' }));
+
+      expect(warnSpy).toHaveBeenCalled();
+      const message = String(warnSpy.mock.calls[0][0]);
+      expect(message).toContain('restartTask');
+      expect(message).toContain('deprecated');
+      expect(message).toContain('Routing to recreateTask');
+    });
+
+    it('exposes explicit retryTask + recreateTask methods', async () => {
+      // Sanity: the canonical verbs exist on the service
+      // surface (so callers have somewhere to migrate to). If
+      // either is missing, this test will fail at compile time.
+      expect(typeof svc.retryTask).toBe('function');
+      expect(typeof svc.recreateTask).toBe('function');
+
+      await svc.retryTask(envelope({ taskId: 't-1' }));
+      expect(orchestrator.retryTask).toHaveBeenCalledWith('t-1');
+
+      await svc.recreateTask(envelope({ taskId: 't-1' }));
+      expect(orchestrator.recreateTask).toHaveBeenCalledWith('t-1');
+    });
+  });
+
+  // ── Lock-in: no production code calls .restartTask( ──────────
+
+  describe('production lock-in: workflow-core/src/ has no .restartTask( call sites', () => {
+    /**
+     * Walk `packages/workflow-core/src/`, skipping `__tests__/`,
+     * and assert that no production source file invokes
+     * `.restartTask(`. The deprecated method DECLARATION still
+     * exists in `orchestrator.ts` (and the shim body calls
+     * `this.recreateTask`), so we explicitly allow:
+     *   - the method declaration line (`restartTask(taskId: string): TaskState[] {`)
+     *   - the deprecation warn message (`restartTask("...")`)
+     *   - JSDoc comments (`* `restartTask` ...`)
+     * We catch only actual `.restartTask(` invocations on a
+     * receiver, which is what the chart's "Naming
+     * inconsistency" section forbids going forward.
+     */
+    function walk(dir: string, files: string[] = []): string[] {
+      for (const entry of readdirSync(dir)) {
+        const full = join(dir, entry);
+        const st = statSync(full);
+        if (st.isDirectory()) {
+          if (entry === '__tests__' || entry === 'node_modules') continue;
+          walk(full, files);
+        } else if (entry.endsWith('.ts') && !entry.endsWith('.d.ts')) {
+          files.push(full);
+        }
+      }
+      return files;
+    }
+
+    it('no production .ts file under workflow-core/src/ calls .restartTask(', () => {
+      const srcRoot = new URL('..', import.meta.url).pathname;
+      const files = walk(srcRoot);
+      expect(files.length).toBeGreaterThan(0);
+
+      const offenders: string[] = [];
+      for (const file of files) {
+        const text = readFileSync(file, 'utf8');
+        const lines = text.split('\n');
+        for (let i = 0; i < lines.length; i++) {
+          const line = lines[i];
+          // Catch `.restartTask(` invocations on a receiver
+          // (this/orchestrator/foo). Allow the declaration
+          // (`  restartTask(`) and JSDoc references (`*` prefix
+          // or backtick-quoted), and the warn message string
+          // literal (which contains `restartTask("` not
+          // `.restartTask(`).
+          if (/\.\s*restartTask\s*\(/.test(line)) {
+            offenders.push(`${relative(srcRoot, file)}:${i + 1}: ${line.trim()}`);
+          }
+        }
+      }
+
+      expect(offenders, `Regression: production code still calls .restartTask(:\n${offenders.join('\n')}`).toEqual([]);
+    });
+  });
+});

--- a/packages/workflow-core/src/__tests__/state-machine.test.ts
+++ b/packages/workflow-core/src/__tests__/state-machine.test.ts
@@ -45,7 +45,7 @@ describe('TaskStateMachine', () => {
       expect((sm as any).failTask).toBeUndefined();
       expect((sm as any).createTask).toBeUndefined();
       expect((sm as any).updateTaskFields).toBeUndefined();
-      expect((sm as any).restartTask).toBeUndefined();
+      expect((sm as any).retryTask).toBeUndefined();
       expect((sm as any).markStale).toBeUndefined();
       expect((sm as any).approveTask).toBeUndefined();
       expect((sm as any).rejectTask).toBeUndefined();

--- a/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
@@ -240,7 +240,7 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(fail('B'));
       expect(orchestrator.getTask('D')!.status).toBe('pending');
 
-      orchestrator.restartTask('B');
+      orchestrator.retryTask('B');
       expect(orchestrator.getTask('D')!.status).toBe('pending');
 
       orchestrator.handleWorkerResponse(complete('B'));
@@ -267,7 +267,7 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(fail('B'));
       orchestrator.handleWorkerResponse(fail('C'));
 
-      orchestrator.restartTask('B');
+      orchestrator.retryTask('B');
       orchestrator.handleWorkerResponse(complete('B'));
 
       expect(orchestrator.getTask('D')!.status).toBe('pending');
@@ -282,7 +282,7 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(complete('C'));
       orchestrator.handleWorkerResponse(complete('D'));
 
-      orchestrator.restartTask('B');
+      orchestrator.retryTask('B');
 
       expect(orchestrator.getTask('B')!.status).toBe('running');
       expect(orchestrator.getTask('D')!.status).toBe('pending');
@@ -427,7 +427,7 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(fail('A'));
       expect(orchestrator.getTask('B')!.status).toBe('pending');
 
-      orchestrator.restartTask('A');
+      orchestrator.retryTask('A');
       orchestrator.handleWorkerResponse(complete('A'));
 
       expect(orchestrator.getTask('B')!.status).toBe('running');
@@ -446,7 +446,7 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(fail('B'));
       expect(orchestrator.getTask('C')!.status).toBe('pending');
 
-      orchestrator.restartTask('B');
+      orchestrator.retryTask('B');
       orchestrator.handleWorkerResponse(complete('B'));
 
       expect(orchestrator.getTask('C')!.status).toBe('running');
@@ -460,8 +460,8 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(fail('B'));
       expect(orchestrator.getTask('C')!.status).toBe('pending');
 
-      orchestrator.restartTask('A');
-      orchestrator.restartTask('B');
+      orchestrator.retryTask('A');
+      orchestrator.retryTask('B');
 
       orchestrator.handleWorkerResponse(complete('A'));
       orchestrator.handleWorkerResponse(complete('B'));
@@ -516,7 +516,7 @@ describe('State × Topology Matrix', () => {
       expect(orchestrator.getTask('F')!.status).toBe('pending');
       expect(orchestrator.getTask('G')!.status).toBe('pending');
 
-      orchestrator.restartTask('B');
+      orchestrator.retryTask('B');
       orchestrator.handleWorkerResponse(complete('B'));
       expect(orchestrator.getTask('D')!.status).toBe('running');
 
@@ -564,7 +564,7 @@ describe('State × Topology Matrix', () => {
       orchestrator.handleWorkerResponse(fail('A'));
       orchestrator.handleWorkerResponse(fail('B'));
 
-      orchestrator.restartTask('A');
+      orchestrator.retryTask('A');
       orchestrator.handleWorkerResponse(complete('A'));
 
       expect(orchestrator.getTask('C')!.status).toBe('pending');

--- a/packages/workflow-core/src/__tests__/type-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/type-topology-matrix.test.ts
@@ -405,7 +405,7 @@ describe('Type × Topology Matrix', () => {
       );
       expect(orchestrator.getTask('A')!.execution.agentSessionId).toBe('sess-1');
 
-      orchestrator.restartTask('A');
+      orchestrator.retryTask('A');
       const restarted = orchestrator.getTask('A')!;
       expect(restarted.status).toBe('running');
       expect(restarted.execution.commit).toBeUndefined();

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -121,14 +121,59 @@ export class CommandService {
     );
   }
 
-  async restartTask(
+  /**
+   * Retry a task — **retry-class** invalidation per Step 13's
+   * canonical `{retry, recreate} × {task, workflow}` matrix
+   * (`docs/architecture/task-invalidation-chart.md`). Preserves
+   * branch/workspacePath lineage; only volatile attempt state
+   * (`agentSessionId`, `containerId`, `error`, `exitCode`, timing
+   * fields) is cleared. Use this when callers want the task rerun
+   * with the same workspace.
+   */
+  async retryTask(
     envelope: CommandEnvelope<{ taskId: string }>,
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
-      'RESTART_TASK_FAILED',
-      () => this.orchestrator.restartTask(envelope.payload.taskId),
+      'RETRY_TASK_FAILED',
+      () => this.orchestrator.retryTask(envelope.payload.taskId),
       this.workflowIdForTask(envelope.payload.taskId),
     );
+  }
+
+  /**
+   * Recreate a task — **recreate-class** invalidation per Step 13's
+   * canonical matrix. Discards branch/commit/workspacePath lineage
+   * along with volatile attempt state, then auto-starts the task
+   * subgraph. Use this when callers want fresh workspace lineage.
+   */
+  async recreateTask(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'RECREATE_TASK_FAILED',
+      () => this.orchestrator.recreateTask(envelope.payload.taskId),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
+  /**
+   * @deprecated Step 13 (`docs/architecture/task-invalidation-roadmap.md`):
+   * `restartTask` was the overloaded "retry-or-recreate" verb the
+   * chart's "Naming inconsistency" section flagged. Use the explicit
+   * verb instead — `retryTask` to preserve branch/workspacePath
+   * lineage or `recreateTask` to discard it. This shim delegates to
+   * `recreateTask` (the conservative choice) so any unmigrated
+   * external caller gets the safer, more aggressive reset rather
+   * than the historical retry-class behavior.
+   */
+  async restartTask(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    console.warn(
+      `[command-service] restartTask("${envelope.payload.taskId}") is deprecated (Step 13). ` +
+        'Routing to recreateTask. Use retryTask/recreateTask explicitly.',
+    );
+    return this.recreateTask(envelope);
   }
 
   async selectExperiment(
@@ -202,7 +247,7 @@ export class CommandService {
    * cancel-first interruption when the merge node is active
    * (`running` / `fixing_with_ai` / `awaiting_approval` /
    * `review_ready`), the `persistence.updateWorkflow({ mergeMode })`
-   * write, and the `restartTask` retry-class reset that bumps the
+   * write, and the `retryTask` retry-class reset (Step 13 vocabulary) that bumps the
    * merge node's execution generation exactly once. This service-level
    * entrypoint just serializes the mutation through the workflow mutex
    * so concurrent merge-mode flips never interleave with each other or
@@ -246,7 +291,7 @@ export class CommandService {
    * detection, cancel-first interruption when the task is actively
    * running an AI fix (`fixing_with_ai`), the
    * `config.fixPrompt` / `config.fixContext` write, and the
-   * `restartTask` retry-class reset that bumps the task's execution
+   * `retryTask` retry-class reset (Step 13 vocabulary) that bumps the task's execution
    * generation exactly once and clears volatile fix-attempt state
    * (`agentSessionId`, `containerId`, transient
    * `error`/`exitCode`/timing fields). This service-level entrypoint

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1805,25 +1805,29 @@ export class Orchestrator {
     return started;
   }
 
-  /**
-   * Restart a non-running task: reset it to pending, unblock dependents,
-   * and auto-start if its own dependencies are satisfied.
-   */
   restartTask(taskId: string): TaskState[] {
+    console.warn(
+      `[orchestrator] restartTask("${taskId}") is deprecated. Routing to recreateTask. ` +
+        'Use retryTask() for lineage-preserving reset or recreateTask() for fresh-lineage reset explicitly.',
+    );
+    return this.recreateTask(taskId);
+  }
+
+  retryTask(taskId: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new Error(`Task ${taskId} not found`);
     const id = task.id;
 
     const prevStatus = task.status;
-    console.log(`[orchestrator] restartTask "${id}" (was ${prevStatus})`);
+    console.log(`[orchestrator] retryTask "${id}" (was ${prevStatus})`);
     if (task.config.isMergeNode) {
       console.log(
-        `[merge-gate-workspace] restartTask mergeNode=${id} ` +
+        `[merge-gate-workspace] retryTask mergeNode=${id} ` +
           `before reset workspacePath=${task.execution.workspacePath ?? 'none'} ` +
-          '(restartTask does not clear workspacePath)',
+          '(retryTask does not clear workspacePath)',
       );
-      mergeTrace('GATE_WS_RESTART_TASK_MERGE', {
+      mergeTrace('GATE_WS_RETRY_TASK_MERGE', {
         taskId: id,
         workspacePathBefore: task.execution.workspacePath ?? null,
       });
@@ -1847,7 +1851,7 @@ export class Orchestrator {
     };
     const t0 = this.stateGetTask(id)!;
     console.log(
-      `[agent-session-trace] restartTask: before writeAndSync task="${id}" agentSessionId=${t0.execution.agentSessionId ?? 'null'} ` +
+      `[agent-session-trace] retryTask: before writeAndSync task="${id}" agentSessionId=${t0.execution.agentSessionId ?? 'null'} ` +
         '(reset clears agentSessionId/containerId; branch/workspacePath unchanged)',
     );
     const { affectedIds } = this.resetSubgraphToPending([id], resetChanges, {
@@ -1855,27 +1859,27 @@ export class Orchestrator {
     });
     const afterRt = this.stateGetTask(id)!;
     console.log(
-      `[agent-session-trace] restartTask: after writeAndSync task="${id}" agentSessionId=${afterRt.execution.agentSessionId ?? 'null'}`,
+      `[agent-session-trace] retryTask: after writeAndSync task="${id}" agentSessionId=${afterRt.execution.agentSessionId ?? 'null'}`,
     );
     if (afterRt.config.isMergeNode) {
       console.log(
-        `[merge-gate-workspace] restartTask mergeNode=${id} ` +
+        `[merge-gate-workspace] retryTask mergeNode=${id} ` +
           `after reset workspacePath=${afterRt.execution.workspacePath ?? 'none'}`,
       );
-      mergeTrace('GATE_WS_RESTART_TASK_MERGE_AFTER', {
+      mergeTrace('GATE_WS_RETRY_TASK_MERGE_AFTER', {
         taskId: id,
         workspacePathAfter: afterRt.execution.workspacePath ?? null,
       });
     }
     if (affectedIds.length > 1) {
       console.log(
-        `[orchestrator] restartTask "${id}": invalidated ${affectedIds.length - 1} downstream task(s)`,
+        `[orchestrator] retryTask "${id}": invalidated ${affectedIds.length - 1} downstream task(s)`,
       );
     }
 
     const readyTasks = this.stateMachine.getReadyTasks();
     const isReady = readyTasks.some((t) => t.id === id);
-    console.log(`[orchestrator] restartTask "${id}": ready=${isReady}`);
+    console.log(`[orchestrator] retryTask "${id}": ready=${isReady}`);
     if (isReady) {
       const started = this.autoStartReadyTasks([id], Orchestrator.EXPEDITED_PRIORITY);
       if (started.some((t) => t.id === id)) return started;
@@ -2387,7 +2391,7 @@ export class Orchestrator {
     this.persistence.logEvent?.(taskId, 'task.updated', typeChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, typeDelta);
 
-    return hostChanged ? this.recreateTask(taskId) : this.restartTask(taskId);
+    return hostChanged ? this.recreateTask(taskId) : this.retryTask(taskId);
   }
 
     editTaskAgent(taskId: string, agentName: string): TaskState[] {
@@ -2545,7 +2549,7 @@ export class Orchestrator {
     // generation exactly once via `withBumpedExecutionGeneration`
     // while preserving branch/workspacePath lineage — the chart's
     // retry-class semantics for merge-mode mutations.
-    return this.restartTask(taskId);
+    return this.retryTask(taskId);
   }
 
   /**
@@ -2694,7 +2698,7 @@ export class Orchestrator {
     // `withBumpedExecutionGeneration` while preserving branch /
     // workspacePath lineage — the chart's "retry from reverted
     // failed state" baseline for fix-context mutations.
-    return this.restartTask(taskId);
+    return this.retryTask(taskId);
   }
 
   /**


### PR DESCRIPTION
## Summary
This step removes `restartTask` from the semantic center of the system and replaces it with explicit `retryTask` and `recreateTask` paths. Workflow-core, command-service, workflow-actions, headless, API, and IPC-facing surfaces now route to the verb that matches the intended lineage behavior, while deprecated `restartTask` shims remain only for compatibility. Internal callers that historically meant retry in place are updated to call `retryTask` directly.

## Problem
`restartTask` blurred retry-class and recreate-class behavior across the stack.

## Root Cause
One overloaded verb was carrying two different lifecycle meanings. That made intent hard to read at call sites and easy to misapply in mutation flows.

## Approach
Promote `retryTask` and `recreateTask` to the primary verbs, keep temporary compatibility shims, and migrate internal callers to the explicit operation they actually mean.

## Why This Fix Is Right
The invalidation model depends on whether lineage is preserved or discarded. Naming those behaviors explicitly is a prerequisite for keeping the policy matrix coherent.

## Tradeoffs And Considerations
The short-term tradeoff is some temporary duplication while compatibility shims remain. That is safer than a hard break and makes the migration reviewable.

## Before
```mermaid
flowchart LR
  A[Caller] --> B[restartTask]
  B --> C[Retry vs recreate intent hidden]
```

## After
```mermaid
flowchart LR
  A[Caller] --> B{Desired invalidation}
  B -->|Preserve lineage| C[retryTask]
  B -->|Discard lineage| D[recreateTask]
  C --> E[Retry-class semantics]
  D --> F[Recreate-class semantics]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 13: remove restartTask ambiguity`
