### PR TITLE
Task invalidation step 14: remove in-place remake

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -96,6 +96,11 @@ function createMocks() {
       editTaskAgent: vi.fn(() => [makeTask()]),
       setTaskExternalGatePolicies: vi.fn(() => [makeTask()]),
       cancelTask: vi.fn(() => ({ cancelled: ['task-1'], runningCancelled: ['task-1'] })),
+      forkWorkflow: vi.fn((workflowId: string) => ({
+        sourceWorkflowId: workflowId,
+        forkedWorkflowId: `${workflowId}-fork`,
+        started: [makeTask({ id: `${workflowId}-fork/task-1`, config: { workflowId: `${workflowId}-fork` } })],
+      })),
       deleteWorkflow: vi.fn(),
       getQueueStatus: vi.fn(() => ({
         maxConcurrency: 4,
@@ -745,6 +750,33 @@ describe('POST /api/workflows/:id/restart', () => {
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
     expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
     expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [topup]);
+  });
+});
+
+// Step 14 (`docs/architecture/task-invalidation-roadmap.md`,
+// chart "Topology inconsistency"): live-workflow topology
+// mutations now route through `Orchestrator.forkWorkflow` and
+// surfaces expose an explicit `fork` verb. The api-server
+// returns both the source and forked workflow ids so callers
+// can follow the new workflow.
+describe('POST /api/workflows/:id/fork', () => {
+  it('forks the workflow via shared forkWorkflow and returns both ids', async () => {
+    const res = await request(port, 'POST', '/api/workflows/wf-1/fork');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.sourceWorkflowId).toBe('wf-1');
+    expect(res.body.forkedWorkflowId).toBe('wf-1-fork');
+    expect(mocks.orchestrator.forkWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+  });
+
+  it('returns an error status when forkWorkflow throws', async () => {
+    mocks.orchestrator.forkWorkflow.mockImplementationOnce(() => {
+      throw new Error('Workflow missing not found');
+    });
+    const res = await request(port, 'POST', '/api/workflows/missing/fork');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('not found');
   });
 });
 

--- a/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
+++ b/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
@@ -134,13 +134,14 @@ describe('app-layer handoff repros', () => {
     h.loadAndStart(LINEAR_PLAN);
     h.failTask('A', 'broken');
 
-    // Step 11 (`docs/architecture/task-invalidation-roadmap.md`):
-    // `replaceTask` is a topology mutation and now throws
-    // `TopologyForkRequired` whenever any non-merge task is still in a
-    // live status. LINEAR_PLAN is A → B; after failTask('A'), B is
-    // `pending` so we cancel it before exercising the in-place
-    // replacement path. The handoff/workspacePath assertions below
-    // are unchanged.
+    // Steps 11 → 14 (`docs/architecture/task-invalidation-roadmap.md`):
+    // `replaceTask` on a *live* workflow now routes through
+    // `forkWorkflow` (Step 14) instead of throwing
+    // `TopologyForkRequired` (Step 11). This test exercises the
+    // **in-place** handoff path on purpose, so it cancels the live
+    // downstream task to make the workflow terminal first; then
+    // `replaceTask` lands in-place on the same workflow and the
+    // workspacePath handoff assertions below are unchanged.
     h.orchestrator.cancelTask('B');
 
     const started = h.orchestrator.replaceTask('A', [

--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -541,16 +541,17 @@ describe('Flow 4: edit/fork mutations', () => {
     expect(h.getTask('A')!.status).toBe('failed');
     expect(h.getTask('B')!.status).toBe('pending');
 
-    // Step 11 (`docs/architecture/task-invalidation-roadmap.md`):
-    // `replaceTask` now throws `TopologyForkRequired` when the workflow
-    // is live (any non-merge task still pending/running/...). LINEAR_PLAN
-    // here is A → B → C, and after failTask('A') both B and C remain
-    // `pending`, so we cancel the live downstream subgraph (B drags C
-    // with it) before exercising the in-place replacement path. The
-    // assertions about the replacement subgraph are unchanged.
+    // Steps 11 → 14 (`docs/architecture/task-invalidation-roadmap.md`):
+    // `replaceTask` on a *live* workflow now routes through
+    // `forkWorkflow` (Step 14) instead of throwing
+    // `TopologyForkRequired` (Step 11). This test exercises the
+    // **in-place** replacement path on purpose, so it cancels the
+    // live downstream subgraph (B drags C with it) to make the
+    // workflow terminal first. The assertions about the in-place
+    // replacement subgraph below are unchanged.
     h.orchestrator.cancelTask('B');
 
-    // Replace A with two sub-tasks
+    // Replace A with two sub-tasks (in-place — workflow is terminal)
     const replacements = h.orchestrator.replaceTask('A', [
       { id: 'A-fix-1', description: 'Fix part 1', command: 'echo fix1' },
       { id: 'A-fix-2', description: 'Fix part 2', command: 'echo fix2', dependencies: ['A-fix-1'] },

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -1238,6 +1238,38 @@ describe('buildInvalidationDeps', () => {
     );
   });
 
+  // Step 14 (`docs/architecture/task-invalidation-roadmap.md`,
+  // chart "Topology inconsistency"): `workflowFork` is wired to
+  // `Orchestrator.forkWorkflow`. The policy router only consumes
+  // the `started` task list, so the wire adapts the orchestrator's
+  // richer `ForkWorkflowResult` to `TaskState[]`. The forked
+  // workflow id remains discoverable via `started[0].config.workflowId`
+  // for callers that need it.
+  it('routes workflowFork to orchestrator.forkWorkflow and returns started tasks', async () => {
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      forkWorkflow: vi.fn((workflowId: string) => ({
+        sourceWorkflowId: workflowId,
+        forkedWorkflowId: `${workflowId}-fork`,
+        started: [makeRunningTask({ id: `${workflowId}-fork/task-a`, config: { workflowId: `${workflowId}-fork` } as any })],
+      })),
+    };
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
+    expect(deps.workflowFork).toBeDefined();
+    const result = await deps.workflowFork!('wf-1');
+
+    expect(orchestrator.forkWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(result).toHaveLength(1);
+    // The forked workflow id is discoverable from the returned tasks.
+    expect((result as any[])[0].config.workflowId).toBe('wf-1-fork');
+  });
+
   it('builds a cancel-first hook that cancels orchestrator state and kills runners', async () => {
     const orchestrator = makeBaseOrchestrator();
     orchestrator.cancelTask = vi.fn(() => ({

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -41,6 +41,7 @@ import {
   approveTask as sharedApproveTask,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
+  forkWorkflow as sharedForkWorkflow,
   cancelWorkflow as sharedCancelWorkflow,
   retryTask as sharedRetryTask,
   rejectTask as sharedRejectTask,
@@ -397,6 +398,34 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+        }
+        return;
+      }
+
+      const wfForkMatch = path.match(/^\/api\/workflows\/([^/]+)\/fork$/);
+      if (method === 'POST' && wfForkMatch) {
+        const workflowId = decodeURIComponent(wfForkMatch[1]);
+        try {
+          const result = sharedForkWorkflow(workflowId, { orchestrator, logger: apiLogger });
+          const runnable = result.started.filter((t) => t.status === 'running');
+          await taskExecutor.executeTasks(runnable);
+          await executeGlobalTopup({
+            orchestrator,
+            taskExecutor,
+            logger: apiLogger,
+            context: 'api.workflows.fork',
+            alreadyDispatched: runnable,
+          });
+          json(res, 200, {
+            ok: true,
+            sourceWorkflowId: result.sourceWorkflowId,
+            forkedWorkflowId: result.forkedWorkflowId,
+            tasksStarted: runnable.length,
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          const statusCode = message.includes('not found') ? 404 : 400;
+          json(res, statusCode, { error: message });
         }
         return;
       }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -35,6 +35,7 @@ import {
   resolveConflictAction,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
+  forkWorkflow as sharedForkWorkflow,
   setWorkflowMergeMode,
   finalizeAppliedFix,
 } from './workflow-actions.js';
@@ -605,6 +606,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'replace-task':
       await headlessReplaceTask(args[1], args[2], deps);
       break;
+    case 'fork-workflow':
+      await headlessForkWorkflow(args[1], deps);
+      break;
     case 'rebase':
       await headlessRebaseAndRetry(args[1], deps);
       break;
@@ -768,6 +772,7 @@ ${BOLD}Execute:${RESET}
   recreate <workflowId>                                Recreate workflow: wipe all state, new generation
   recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
   replace-task <taskId> <replacementTasksJson>        Replace a task with new task definitions
+  fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
   rebase <taskId>                                     Refresh pool base + nuclear restart
   fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
   resolve-conflict <taskId> [claude|codex]            Resolve merge conflict + restart
@@ -1378,6 +1383,15 @@ async function headlessReplaceTask(
     throw new Error(`Invalid replacementTasks JSON: ${reason}`);
   }
 
+  // Step 14 (`docs/architecture/task-invalidation-roadmap.md`,
+  // chart "Topology inconsistency"): for *live* workflows
+  // `Orchestrator.replaceTask` now routes the topology mutation
+  // through `forkWorkflow` and lands the replacement on a brand-new
+  // workflow id. We snapshot the source workflow id BEFORE issuing
+  // the command so we can detect the redirect and report the new id
+  // to the caller. Terminal workflows still mutate in place, so the
+  // pre-/post- ids match and we report the in-place result.
+  const sourceWorkflowId = deps.orchestrator.getTask?.(taskId)?.config.workflowId;
   const envelope = makeEnvelope('replace-task', 'headless', 'task', { taskId, replacementTasks });
   const result = await deps.commandService.replaceTask(envelope);
   if (!result.ok) throw new Error(result.error.message);
@@ -1391,8 +1405,42 @@ async function headlessReplaceTask(
     started: result.data,
   });
 
+  const landedWorkflowId = result.data[0]?.config.workflowId;
+  if (sourceWorkflowId && landedWorkflowId && landedWorkflowId !== sourceWorkflowId) {
+    process.stdout.write(
+      `Live-workflow topology mutation: forked ${sourceWorkflowId} → ${landedWorkflowId}; ` +
+        `replaced task ${taskId} with ${replacementTasks.length} task(s) in the fork; ` +
+        `launched ${runnable.length} task(s)\n`,
+    );
+  } else {
+    process.stdout.write(
+      `Replaced task ${taskId} with ${replacementTasks.length} task(s); launched ${runnable.length} task(s)\n`,
+    );
+  }
+}
+
+async function headlessForkWorkflow(
+  workflowId: string,
+  deps: HeadlessDeps,
+): Promise<void> {
+  if (!workflowId) {
+    throw new Error('Missing arguments. Usage: --headless fork-workflow <workflowId>');
+  }
+  const result = sharedForkWorkflow(workflowId, {
+    orchestrator: deps.orchestrator,
+    logger: deps.logger,
+  });
+  const taskExecutor = createHeadlessExecutor(deps);
+  const { runnable } = await dispatchStartedTasksWithGlobalTopup({
+    orchestrator: deps.orchestrator,
+    taskExecutor,
+    logger: deps.logger,
+    context: 'headless.fork-workflow',
+    started: result.started,
+  });
   process.stdout.write(
-    `Replaced task ${taskId} with ${replacementTasks.length} task(s); launched ${runnable.length} task(s)\n`,
+    `Forked workflow ${result.sourceWorkflowId} → ${result.forkedWorkflowId}; ` +
+      `launched ${runnable.length} task(s)\n`,
   );
 }
 

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -308,7 +308,20 @@ export function buildInvalidationDeps(
         persistence: deps.persistence,
         taskExecutor: deps.taskExecutor,
       }),
+    workflowFork: (workflowId: string) => deps.orchestrator.forkWorkflow(workflowId).started,
   };
+}
+
+export function forkWorkflow(
+  workflowId: string,
+  deps: Pick<ActionDeps, 'orchestrator' | 'logger'>,
+): { forkedWorkflowId: string; sourceWorkflowId: string; started: TaskState[] } {
+  const result = deps.orchestrator.forkWorkflow(workflowId);
+  deps.logger?.info(
+    `forkWorkflow: source=${workflowId} fork=${result.forkedWorkflowId} started=${result.started.length}`,
+    { module: 'workflow' },
+  );
+  return result;
 }
 
 export function editTaskCommand(

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -242,18 +242,12 @@ describe('applyInvalidation: recreateWorkflowFromFreshBase optional dep', () => 
   });
 });
 
-// Step 11 (`docs/architecture/task-invalidation-roadmap.md`): the
-// `'workflowFork'` action represents fork-class / workflow scope. Like
-// `'recreateWorkflowFromFreshBase'` it is gated behind an optional dep
-// that Step 12 supplies. Until then any caller that selects this
-// action sees an explicit "not yet wired (Step 12)" error so misuse
-// fails fast instead of silently no-op'ing.
 describe('applyInvalidation: workflowFork optional dep', () => {
-  it('throws an explicit "not yet wired (Step 12)" error when dep is absent', async () => {
+  it('throws an explicit missing-dep error when dep is absent', async () => {
     const deps = makeDeps();
     await expect(
       applyInvalidation('workflow', 'workflowFork', 'wf-1', deps),
-    ).rejects.toThrow(/not yet wired \(Step 12\)/);
+    ).rejects.toThrow(/'workflowFork' dep is missing/);
   });
 
   it('routes to the provided dep when present', async () => {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { reconciliationNeedsInputWorkResponse } from './reconciliation-needs-input-shim.js';
 import { rid, sid } from './scoped-test-helpers.js';
-import { Orchestrator, PlanConflictError, TopologyForkRequired, descriptionForMergeNode } from '../orchestrator.js';
+import { Orchestrator, PlanConflictError, descriptionForMergeNode } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
 import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
@@ -8646,13 +8646,8 @@ describe('Orchestrator', () => {
     });
   });
 
-  // Step 11 (`docs/architecture/task-invalidation-roadmap.md`): topology
-  // mutations on a live workflow throw `TopologyForkRequired`. The
-  // orchestrator unit-test layer asserts the gate's interaction with
-  // adjacent invariants here; replace-task.test.ts and
-  // state-topology-matrix.test.ts cover the full matrix.
   describe('replaceTask topology-fork gate', () => {
-    it('throws TopologyForkRequired with workflowId + taskId on a live workflow', () => {
+    it('forks the workflow instead of mutating a live workflow in place', () => {
       orchestrator.loadPlan({
         name: 'topology-gate-live',
         tasks: [
@@ -8673,24 +8668,21 @@ describe('Orchestrator', () => {
       const wfId = xTask.config.workflowId!;
       const scopedXId = xTask.id;
 
-      let caught: unknown;
-      try {
-        orchestrator.replaceTask('X', [
-          { id: 'fix', description: 'Fix', command: 'echo fix' },
-        ]);
-      } catch (err) {
-        caught = err;
-      }
-      expect(caught).toBeInstanceOf(TopologyForkRequired);
-      const err = caught as TopologyForkRequired;
-      expect(err.workflowId).toBe(wfId);
-      expect(err.taskId).toBe(scopedXId);
-      expect(err.message).toContain(wfId);
-      expect(err.message).toContain(scopedXId);
+      const started = orchestrator.replaceTask('X', [
+        { id: 'fix', description: 'Fix', command: 'echo fix' },
+      ]);
 
-      // Source unchanged, no replacement created.
-      expect(orchestrator.getTask('X')!.status).toBe('failed');
-      expect(orchestrator.getTask('fix')).toBeUndefined();
+      const forkedWorkflowId = orchestrator
+        .getWorkflowIds()
+        .find((id) => id !== wfId);
+
+      expect(forkedWorkflowId).toBeDefined();
+      expect(orchestrator.getTask(scopedXId)?.status).toBe('failed');
+      const forkedFix = orchestrator
+        .getAllTasks()
+        .find((t) => t.config.workflowId === forkedWorkflowId && t.id.endsWith('/fix'));
+      expect(forkedFix).toBeDefined();
+      expect(started.some((t) => t.id === forkedFix?.id)).toBe(true);
     });
 
     it('allows in-place replacement on a fully terminal workflow', () => {

--- a/packages/workflow-core/src/__tests__/replace-task.test.ts
+++ b/packages/workflow-core/src/__tests__/replace-task.test.ts
@@ -461,11 +461,10 @@ describe('replaceTask', () => {
   // The chart's Decision Table row "Change graph topology" makes
   // graph-shape changes fork-class / workflow scope: they must NOT
   // mutate a live workflow in place. Instead, callers see a
-  // `TopologyForkRequired` error pointing them at the (Step 12)
-  // forkWorkflow API. In-place is preserved on a fully terminal
+  // workflow fork path. In-place is preserved on a fully terminal
   // workflow because there is no in-flight work to race with.
   describe('topology-fork policy', () => {
-    it('throws TopologyForkRequired when downstream is still pending', () => {
+    it('forks the workflow when downstream is still pending', () => {
       orchestrator.loadPlan({
         name: 'topology-live',
         tasks: [
@@ -482,33 +481,24 @@ describe('replaceTask', () => {
       const s = (l: string) => sid(orchestrator, 0, l);
       const wfId = orchestrator.getTask(s('X'))!.config.workflowId!;
 
-      let caught: unknown;
-      try {
-        orchestrator.replaceTask('X', [
-          { id: 'fix', description: 'Fix', command: 'echo fix' },
-        ]);
-      } catch (err) {
-        caught = err;
-      }
+      const started = orchestrator.replaceTask('X', [
+        { id: 'fix', description: 'Fix', command: 'echo fix' },
+      ]);
 
-      expect(caught).toBeInstanceOf(TopologyForkRequired);
-      const err = caught as TopologyForkRequired;
-      expect(err.workflowId).toBe(wfId);
-      expect(err.taskId).toBe(s('X'));
-      // Message must surface both ids for the caller and the fix-up
-      // hint pointing at Step 12's forkWorkflow API.
-      expect(err.message).toContain(wfId);
-      expect(err.message).toContain(s('X'));
-      expect(err.message).toMatch(/fork/i);
-      expect(err.message).toMatch(/Step 12/);
+      const forkedWorkflowId = orchestrator
+        .getWorkflowIds()
+        .find((id) => id !== wfId);
 
-      // Source must NOT have been mutated in place.
+      expect(forkedWorkflowId).toBeDefined();
       expect(orchestrator.getTask(s('X'))!.status).toBe('failed');
-      expect(orchestrator.getTask(s('C'))!.status).toBe('pending');
-      expect(orchestrator.getTask('fix')).toBeUndefined();
+      const forkedFix = orchestrator
+        .getAllTasks()
+        .find((t) => t.config.workflowId === forkedWorkflowId && t.id.endsWith('/fix'));
+      expect(forkedFix).toBeDefined();
+      expect(started.some((t) => t.id === forkedFix?.id)).toBe(true);
     });
 
-    it('throws TopologyForkRequired when a sibling is still running', () => {
+    it('forks the workflow when a sibling is still running', () => {
       orchestrator.loadPlan({
         name: 'topology-live-sibling',
         tasks: [
@@ -525,15 +515,22 @@ describe('replaceTask', () => {
       expect(orchestrator.getTask('Y')!.status).toBe('running');
 
       const s = (l: string) => sid(orchestrator, 0, l);
-      expect(() =>
-        orchestrator.replaceTask('X', [
-          { id: 'fix', description: 'Fix', command: 'echo fix' },
-        ]),
-      ).toThrow(TopologyForkRequired);
+      const wfId = orchestrator.getTask(s('X'))!.config.workflowId!;
+      const started = orchestrator.replaceTask('X', [
+        { id: 'fix', description: 'Fix', command: 'echo fix' },
+      ]);
 
-      // Y is still running, X is still failed — no in-place mutation.
-      expect(orchestrator.getTask('Y')!.status).toBe('running');
+      const forkedWorkflowId = orchestrator
+        .getWorkflowIds()
+        .find((id) => id !== wfId);
+
       expect(orchestrator.getTask(s('X'))!.status).toBe('failed');
+      expect(forkedWorkflowId).toBeDefined();
+      const forkedFix = orchestrator
+        .getAllTasks()
+        .find((t) => t.config.workflowId === forkedWorkflowId && t.id.endsWith('/fix'));
+      expect(forkedFix).toBeDefined();
+      expect(started.some((t) => t.id === forkedFix?.id)).toBe(true);
     });
 
     it('allows in-place replacement on a terminal workflow', () => {

--- a/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
@@ -6,7 +6,7 @@
  * state machine — no executor, no git.
  */
 import { describe, it, expect, beforeEach } from 'vitest';
-import { Orchestrator, TopologyForkRequired } from '../orchestrator.js';
+import { Orchestrator } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
 import type { TaskState, TaskStateChanges, Attempt } from '../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
@@ -656,11 +656,8 @@ describe('State × Topology Matrix', () => {
   //      first-class fork-class entry rather than a special-cased
   //      restart.
   //
-  //   2. **Live-workflow gating.** `Orchestrator.replaceTask` now
-  //      throws `TopologyForkRequired` whenever any non-merge task in
-  //      the same workflow is in a live status, surfacing both the
-  //      workflow id and the offending task id so the caller can
-  //      route the request to the (Step 12) fork API. In-place
+  //   2. **Live-workflow gating.** `Orchestrator.replaceTask` forks a
+  //      live workflow instead of mutating it in place. In-place
   //      remains permitted on a fully terminal workflow because there
   //      is no in-flight work to race with.
   describe('graph topology is fork-class / workflow scope', () => {
@@ -679,7 +676,7 @@ describe('State × Topology Matrix', () => {
       expect(forkEntries.map(([k]) => k)).toEqual(['topology']);
     });
 
-    it('replaceTask throws TopologyForkRequired on a live diamond workflow', () => {
+    it('replaceTask forks a live diamond workflow instead of mutating it in place', () => {
       orchestrator.loadPlan(diamondPlan());
       orchestrator.startExecution();
 
@@ -691,24 +688,21 @@ describe('State × Topology Matrix', () => {
       const bTask = orchestrator.getTask('B')!;
       const wfId = bTask.config.workflowId!;
       const scopedBId = bTask.id;
+      const started = orchestrator.replaceTask('B', [
+        { id: 'B-fix', description: 'Fix B', command: 'echo fix' },
+      ]);
+      const forkedWorkflowId = orchestrator
+        .getWorkflowIds()
+        .find((id) => id !== wfId);
 
-      let caught: unknown;
-      try {
-        orchestrator.replaceTask('B', [
-          { id: 'B-fix', description: 'Fix B', command: 'echo fix' },
-        ]);
-      } catch (err) {
-        caught = err;
-      }
-      expect(caught).toBeInstanceOf(TopologyForkRequired);
-      const err = caught as TopologyForkRequired;
-      expect(err.workflowId).toBe(wfId);
-      expect(err.taskId).toBe(scopedBId);
-
-      // No in-place mutation: B stays failed, no replacement node was
-      // created, and the merge gate's deps are unchanged.
-      expect(orchestrator.getTask('B')!.status).toBe('failed');
-      expect(orchestrator.getTask('B-fix')).toBeUndefined();
+      // No in-place mutation on the original workflow.
+      expect(orchestrator.getTask(scopedBId)?.status).toBe('failed');
+      expect(forkedWorkflowId).toBeDefined();
+      const forkedFix = orchestrator
+        .getAllTasks()
+        .find((t) => t.config.workflowId === forkedWorkflowId && t.id.endsWith('/B-fix'));
+      expect(forkedFix).toBeDefined();
+      expect(started.some((t) => t.id === forkedFix?.id)).toBe(true);
     });
 
     it('replaceTask succeeds in place on a terminal diamond workflow', () => {

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -72,11 +72,13 @@ export interface InvalidationDeps {
   recreateWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflowFromFreshBase?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   /**
-   * Step 11 surfaces `'workflowFork'` as the topology-class action.
-   * Step 12 supplies the implementation that creates a new workflow
-   * rooted from the relevant node/result. Until then, invocation
-   * fails fast through `applyInvalidation` with an explicit
-   * "not yet wired (Step 12)" error.
+   * Step 11 surfaced `'workflowFork'` as the topology-class action;
+   * Step 14 (`docs/architecture/task-invalidation-roadmap.md`) wires
+   * the implementation. Production callers (`buildInvalidationDeps`
+   * in `packages/app/src/workflow-actions.ts`) supply
+   * `Orchestrator.forkWorkflow` here, so the "not yet wired" error
+   * path below is now dead code in production — it only fires for
+   * focused unit tests that build a partial `InvalidationDeps`.
    */
   workflowFork?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
 }
@@ -137,9 +139,15 @@ export async function applyInvalidation(
     }
     case 'workflowFork': {
       if (!deps.workflowFork) {
+        // Step 14 wires this dep in production via
+        // `buildInvalidationDeps` (`packages/app/src/workflow-actions.ts`).
+        // This branch is reachable only from focused unit tests that
+        // build a partial `InvalidationDeps` without the topology dep.
         throw new Error(
-          "applyInvalidation: 'workflowFork' is not yet wired (Step 12). " +
-            'Provide deps.workflowFork to use this action.',
+          "applyInvalidation: 'workflowFork' dep is missing. " +
+            'Production callers wire this via buildInvalidationDeps in ' +
+            '@invoker/app/workflow-actions; tests must supply ' +
+            'deps.workflowFork to use this action.',
         );
       }
       return await deps.workflowFork(id);

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -290,6 +290,12 @@ export class TopologyForkRequired extends Error {
   }
 }
 
+export interface ForkWorkflowResult {
+  readonly forkedWorkflowId: string;
+  readonly sourceWorkflowId: string;
+  readonly started: TaskState[];
+}
+
 export interface GraphMutationNodeDef {
   id: string;
   description: string;
@@ -2761,6 +2767,127 @@ export class Orchestrator {
     return started;
   }
 
+  forkWorkflow(workflowId: string, opts?: { autoStart?: boolean }): ForkWorkflowResult {
+    this.refreshWorkflowFromDb(workflowId);
+
+    const sourceTasks = this.stateMachine
+      .getAllTasks()
+      .filter((t) => t.config.workflowId === workflowId);
+    if (sourceTasks.length === 0) {
+      throw new Error(`forkWorkflow: workflow ${workflowId} not found (no tasks)`);
+    }
+
+    this.cancelWorkflow(workflowId);
+
+    this.refreshWorkflowFromDb(workflowId);
+    const settledSourceTasks = this.stateMachine
+      .getAllTasks()
+      .filter((t) => t.config.workflowId === workflowId);
+
+    const newWfId = nextWorkflowId();
+    const sourceMeta = this.persistence.loadWorkflow?.(workflowId);
+    const createdAt = workflowTimestamp().toISOString();
+    const baseSaveWf: Parameters<OrchestratorPersistence['saveWorkflow']>[0] = {
+      id: newWfId,
+      name: sourceMeta && (sourceMeta as { name?: string }).name
+        ? `${(sourceMeta as { name: string }).name} (fork of ${workflowId})`
+        : `Fork of ${workflowId}`,
+      status: 'running',
+      createdAt,
+      updatedAt: createdAt,
+    };
+    if (sourceMeta) {
+      const m = sourceMeta as Record<string, unknown>;
+      if (typeof m.description === 'string') baseSaveWf.description = m.description;
+      if (typeof m.visualProof === 'boolean') baseSaveWf.visualProof = m.visualProof as boolean;
+      if (typeof m.repoUrl === 'string') baseSaveWf.repoUrl = m.repoUrl;
+      if (typeof m.onFinish === 'string') baseSaveWf.onFinish = m.onFinish;
+      if (typeof m.baseBranch === 'string') baseSaveWf.baseBranch = m.baseBranch;
+      if (typeof m.featureBranch === 'string') baseSaveWf.featureBranch = m.featureBranch;
+      if (m.mergeMode === 'manual' || m.mergeMode === 'automatic' || m.mergeMode === 'external_review') {
+        baseSaveWf.mergeMode = m.mergeMode;
+      }
+    }
+    this.persistence.saveWorkflow(baseSaveWf);
+    this.persistence.updateWorkflow?.(newWfId, { generation: 1, updatedAt: createdAt });
+
+    const sourceMergeNode = settledSourceTasks.find((t) => t.config.isMergeNode);
+    const sourceNonMerge = settledSourceTasks.filter((t) => !t.config.isMergeNode);
+
+    const idRemap = new Map<string, string>();
+    for (const t of sourceNonMerge) {
+      const planLocalId = this.extractPlanLocalId(t.id, workflowId);
+      idRemap.set(t.id, scopePlanTaskId(newWfId, planLocalId));
+    }
+    const newMergeId = `__merge__${newWfId}`;
+
+    this.activeWorkflowIds.add(newWfId);
+
+    const dependedOn = new Set<string>();
+    for (const t of sourceNonMerge) {
+      for (const dep of t.dependencies) {
+        if (idRemap.has(dep)) dependedOn.add(dep);
+      }
+    }
+
+    const createdNew: TaskState[] = [];
+    for (const src of sourceNonMerge) {
+      const newId = idRemap.get(src.id)!;
+      const newDeps = src.dependencies.map((d) => idRemap.get(d) ?? d);
+      const baseConfig = src.config;
+      const remappedParent = baseConfig.parentTask && idRemap.has(baseConfig.parentTask)
+        ? idRemap.get(baseConfig.parentTask)!
+        : baseConfig.parentTask;
+      const newConfig: TaskConfig = {
+        ...baseConfig,
+        workflowId: newWfId,
+        parentTask: remappedParent,
+        summary: undefined,
+      };
+      const newTask = createTaskState(newId, src.description, newDeps, newConfig);
+      this.createAndSync(newTask);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, { type: 'created', task: newTask });
+      this.persistence.logEvent?.(newId, 'task.forked_from', { sourceTaskId: src.id });
+      createdNew.push(newTask);
+    }
+
+    const leafIds = sourceNonMerge
+      .filter((t) => !dependedOn.has(t.id))
+      .map((t) => idRemap.get(t.id)!);
+    const mergeDescription = sourceMergeNode?.description
+      ?? `Workflow gate (fork of ${workflowId})`;
+    const newMerge = createTaskState(
+      newMergeId,
+      mergeDescription,
+      leafIds,
+      { workflowId: newWfId, isMergeNode: true, executorType: 'merge' },
+    );
+    this.createAndSync(newMerge);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, { type: 'created', task: newMerge });
+
+    this.reconcileMergeLeaves(newWfId);
+
+    const autoStart = opts?.autoStart !== false;
+    let started: TaskState[] = [];
+    if (autoStart) {
+      const readyIds = this.stateMachine
+        .getReadyTasks()
+        .map((t) => t.id)
+        .filter((id) => this.stateGetTask(id)?.config.workflowId === newWfId);
+      started = this.autoStartReadyTasks(readyIds);
+    }
+
+    return { forkedWorkflowId: newWfId, sourceWorkflowId: workflowId, started };
+  }
+
+  private extractPlanLocalId(scopedId: string, workflowId: string): string {
+    const prefix = `${workflowId}/`;
+    if (scopedId.startsWith(prefix)) {
+      return scopedId.slice(prefix.length);
+    }
+    return scopedId;
+  }
+
   /**
    * Replace a broken/failed task with a new subgraph.
    *
@@ -2778,17 +2905,41 @@ export class Orchestrator {
     const wfId = task.config.workflowId;
     if (!wfId) throw new Error(`replaceTask: task ${taskId} has no workflowId`);
 
-    // Step 11: topology mutations must not mutate a live workflow in place.
-    // `replaceTask` is unconditionally a topology change (it stales the
-    // source, can stale downstream, and creates new nodes), so the gate
-    // sits at the entry. In-place is still permitted on a fully terminal
-    // workflow (all non-merge tasks in completed/failed/stale) since
-    // there is no in-flight work to race with.
-    //
-    // Use `task.id` (the resolved/scoped id) for the error so callers
-    // can route the request to the (Step 12) forkWorkflow API without
-    // re-resolving the bare plan-local id themselves.
-    this.assertTopologyMutationAllowed(wfId, task.id);
+    if (this.isWorkflowLive(wfId)) {
+      const fork = this.forkWorkflow(wfId, { autoStart: false });
+      const planLocalId = this.extractPlanLocalId(task.id, wfId);
+      const forkedTaskId = scopePlanTaskId(fork.forkedWorkflowId, planLocalId);
+      const forkedTask = this.stateGetTask(forkedTaskId);
+      if (!forkedTask) {
+        throw new Error(
+          `replaceTask: forked workflow ${fork.forkedWorkflowId} missing copy of ` +
+            `task ${task.id} (expected ${forkedTaskId})`,
+        );
+      }
+      const startedFromReplacement = this.replaceTaskInPlace(
+        forkedTask,
+        fork.forkedWorkflowId,
+        replacementTasks,
+      );
+      const forkReadyIds = this.stateMachine
+        .getReadyTasks()
+        .map((t) => t.id)
+        .filter(
+          (id) =>
+            this.stateGetTask(id)?.config.workflowId === fork.forkedWorkflowId &&
+            !startedFromReplacement.some((s) => s.id === id),
+        );
+      return [...startedFromReplacement, ...this.autoStartReadyTasks(forkReadyIds)];
+    }
+
+    return this.replaceTaskInPlace(task, wfId, replacementTasks);
+  }
+
+  private replaceTaskInPlace(
+    task: TaskState,
+    wfId: string,
+    replacementTasks: TaskReplacementDef[],
+  ): TaskState[] {
 
     const replacementRawIds = new Set(replacementTasks.map((t) => t.id));
     const scopeLocal = (local: string) => scopePlanTaskId(wfId, local);
@@ -2901,22 +3052,6 @@ export class Orchestrator {
       .getAllTasks()
       .filter((t) => t.config.workflowId === workflowId && !t.config.isMergeNode);
     return tasks.some((t) => LIVE_TASK_STATUSES.has(t.status));
-  }
-
-  /**
-   * Throws `TopologyForkRequired` when the workflow is live.
-   *
-   * Per `docs/architecture/task-invalidation-chart.md` ("Topology
-   * inconsistency"), graph-shape changes must fork from the relevant
-   * node/result instead of mutating a live workflow in place. Until
-   * Step 12 ships the `forkWorkflow*` API, callers handling this
-   * error must wait for the workflow to terminate (or cancel its
-   * remaining live work) before retrying.
-   */
-  private assertTopologyMutationAllowed(workflowId: string, sourceTaskId: string): void {
-    if (this.isWorkflowLive(workflowId)) {
-      throw new TopologyForkRequired(workflowId, sourceTaskId);
-    }
   }
 
   private assertMergeLeavesInvariant(workflowId: string): void {


### PR DESCRIPTION
## Summary
This change wires `Orchestrator.forkWorkflow` and makes live topology mutations execute by forking instead of mutating the active workflow in place. `replaceTask` now branches on liveness: terminal workflows still use the in-place path, while live workflows cancel the source, clone the graph into a new workflow, apply the topology rewrite there, and then start ready tasks in the fork. The app layer also exposes this through invalidation deps, headless, and the API.

## Problem
After the topology gate landed, live topology edits still had no safe implementation path.

## Root Cause
Live topology mutation requires a different lifecycle operation from terminal edits. The system needed a fork-based path that preserves the original workflow while applying changes to a new one.

## Approach
Implement `forkWorkflow`, clone live workflow state into a new workflow, apply topology changes there, and start ready tasks in the fork after canceling active source work.

## Why This Fix Is Right
Forking is the only safe way to mutate live topology without rewriting the active workflow graph under running execution.

## Tradeoffs And Considerations
Forking is operationally heavier than in-place mutation because it allocates a new workflow and copies state. That is the correct trade because preserving source-workflow integrity matters more than minimizing internal churn.

## Before
```mermaid
flowchart LR
  A[replaceTask on live workflow] --> B[Rewrite active workflow in place]
  B --> C[Live topology mutation risk]
```

## After
```mermaid
flowchart LR
  A[replaceTask on live workflow] --> B[forkWorkflow]
  B --> C[Cancel source active tasks]
  C --> D[Clone graph into new workflow]
  D --> E[Apply topology rewrite on fork]
  E --> F[Start ready tasks in fork]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 14: live topology fork`
