### PR TITLE
Task invalidation step 15: external-gate-policy lock-in

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -691,6 +691,33 @@ describe('POST /api/tasks/:id/gate-policy', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Missing non-empty "updates" array');
   });
+
+  // Step 15 (`docs/architecture/task-invalidation-roadmap.md`,
+  // chart row "Change external gate policy"): the api-server's
+  // gate-policy POST is the chart's intentional non-invalidating
+  // surface. It MUST route to `setTaskExternalGatePolicies` and
+  // MUST NOT trigger any retry/recreate spy on the orchestrator.
+  // This pins the cross-cutting contract at the http boundary.
+  it('Step 15: gate-policy POST does not trigger retry/recreate routes', async () => {
+    mocks.orchestrator.recreateTask = vi.fn();
+    mocks.orchestrator.recreateWorkflow = vi.fn();
+    mocks.orchestrator.cancelWorkflow = vi.fn();
+
+    const res = await request(port, 'POST', '/api/tasks/task-1/gate-policy', {
+      updates: [
+        { workflowId: 'wf-upstream', taskId: '__merge__', gatePolicy: 'review_ready' },
+      ],
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.action).toBe('gate_policy_updated');
+    expect(mocks.orchestrator.setTaskExternalGatePolicies).toHaveBeenCalledTimes(1);
+    expect(mocks.orchestrator.retryTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
 });
 
 describe('POST /api/workflows/:id/restart', () => {

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -308,7 +308,27 @@ export function buildInvalidationDeps(
         persistence: deps.persistence,
         taskExecutor: deps.taskExecutor,
       }),
-    workflowFork: (workflowId: string) => deps.orchestrator.forkWorkflow(workflowId).started,
+    workflowFork: (workflowId: string) => {
+      const result = deps.orchestrator.forkWorkflow(workflowId);
+      deps.logger?.info(
+        `workflowFork: source=${workflowId} fork=${result.forkedWorkflowId} started=${result.started.length}`,
+        { module: 'workflow' },
+      );
+      return result.started;
+    },
+    // Step 15 wiring (`docs/architecture/task-invalidation-roadmap.md`,
+    // chart row "Change external gate policy"). The dep is invoked
+    // by `applyInvalidation` for action `'scheduleOnly'` WITHOUT a
+    // preceding `cancelInFlight` call — gate-policy edits are
+    // non-invalidating per the chart. The orchestrator's existing
+    // `autoStartExternallyUnblockedReadyTasks` primitive is the
+    // right scheduler entrypoint: it re-evaluates every task with
+    // external dependencies whose blocker has cleared. Today's
+    // primitive is workflow-agnostic; the `taskId` argument is
+    // accepted for future scoping but ignored by the underlying
+    // method.
+    scheduleOnly: (_taskId: string) =>
+      deps.orchestrator.autoStartExternallyUnblockedReadyTasks(),
   };
 }
 

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -14,6 +14,7 @@ type MockedDeps = InvalidationDeps & {
   recreateWorkflow: ReturnType<typeof vi.fn>;
   recreateWorkflowFromFreshBase?: ReturnType<typeof vi.fn>;
   workflowFork?: ReturnType<typeof vi.fn>;
+  scheduleOnly?: ReturnType<typeof vi.fn>;
 };
 
 function makeDeps(overrides: Partial<MockedDeps> = {}): MockedDeps {
@@ -39,7 +40,15 @@ describe('MUTATION_POLICIES', () => {
     expect(MUTATION_POLICIES.mergeMode.action).toBe('retryTask');
     expect(MUTATION_POLICIES.fixContext.action).toBe('retryTask');
     expect(MUTATION_POLICIES.rebaseAndRetry.action).toBe('recreateWorkflowFromFreshBase');
-    expect(MUTATION_POLICIES.externalGatePolicy.action).toBe('none');
+    // Step 15: external gate policy is the chart's intentional
+    // non-invalidating outlier. Action upgraded from `'none'`
+    // (Step 1 placeholder) to `'scheduleOnly'` so the policy table
+    // expresses what really happens (an unblock-pass) and so
+    // `applyInvalidation` can route the action through the
+    // `scheduleOnly` dep WITHOUT calling `cancelInFlight`.
+    expect(MUTATION_POLICIES.externalGatePolicy.action).toBe('scheduleOnly');
+    expect(MUTATION_POLICIES.externalGatePolicy.invalidatesExecutionSpec).toBe(false);
+    expect(MUTATION_POLICIES.externalGatePolicy.invalidateIfActive).toBe(false);
     // Step 11: graph topology is the lone fork-class / workflow-scope row.
     expect(MUTATION_POLICIES.topology.action).toBe('workflowFork');
     expect(MUTATION_POLICIES.topology.invalidatesExecutionSpec).toBe(true);
@@ -48,7 +57,10 @@ describe('MUTATION_POLICIES', () => {
 
   it('marks every spec-changing mutation as invalidating-if-active', () => {
     for (const [key, policy] of Object.entries(MUTATION_POLICIES)) {
-      if (policy.action === 'none') {
+      // Step 15: `'scheduleOnly'` joins `'none'` as a
+      // non-invalidating action class — gate-policy edits change
+      // scheduling, not the execution ABI, so neither flag flips.
+      if (policy.action === 'none' || policy.action === 'scheduleOnly') {
         expect(policy.invalidatesExecutionSpec, key).toBe(false);
         expect(policy.invalidateIfActive, key).toBe(false);
       } else {
@@ -56,6 +68,18 @@ describe('MUTATION_POLICIES', () => {
         expect(policy.invalidateIfActive, key).toBe(true);
       }
     }
+  });
+
+  // Step 15 lock-in: `externalGatePolicy` is the lone `'scheduleOnly'`
+  // entry in the policy table, mirroring how `topology` is the lone
+  // `'workflowFork'` entry. This pins the chart's "Change external
+  // gate policy" row as the engine's only intentional non-invalidating
+  // execution-spec-adjacent mutation.
+  it('externalGatePolicy is the only scheduleOnly entry in the policy table', () => {
+    const scheduleOnlyEntries = Object.entries(MUTATION_POLICIES).filter(
+      ([, p]) => p.action === 'scheduleOnly',
+    );
+    expect(scheduleOnlyEntries.map(([k]) => k)).toEqual(['externalGatePolicy']);
   });
 
   it('is frozen — the policy table is a constant, not a mutable map', () => {
@@ -273,5 +297,75 @@ describe('applyInvalidation: workflowFork optional dep', () => {
     expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
       workflowFork.mock.invocationCallOrder[0],
     );
+  });
+});
+
+// Step 15 (`docs/architecture/task-invalidation-roadmap.md`): the
+// `'scheduleOnly'` action represents the chart's intentional
+// non-invalidating outlier — "Change external gate policy" is a
+// scheduling-policy edit, not an execution-spec edit. The router
+// MUST skip `cancelInFlight` for this action and instead invoke
+// `deps.scheduleOnly(taskId)` to trigger an unblock-pass that
+// re-evaluates tasks newly unblocked by the gate-policy change.
+// Active execution lineage and any in-flight attempts are preserved.
+describe("applyInvalidation: action='scheduleOnly' (Step 15)", () => {
+  it('does NOT call cancelInFlight and routes to deps.scheduleOnly', async () => {
+    const scheduleOnly = vi.fn(async () => []);
+    const deps = makeDeps({ scheduleOnly });
+    const out = await applyInvalidation('task', 'scheduleOnly', 'task-a', deps);
+    expect(out).toEqual([]);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+    expect(scheduleOnly).toHaveBeenCalledWith('task-a');
+  });
+
+  it('returns the started tasks from deps.scheduleOnly verbatim', async () => {
+    const fakeTasks = [{ id: 'task-a' } as never, { id: 'task-b' } as never];
+    const scheduleOnly = vi.fn(async () => fakeTasks);
+    const deps = makeDeps({ scheduleOnly });
+    const out = await applyInvalidation('task', 'scheduleOnly', 'task-a', deps);
+    expect(out).toBe(fakeTasks);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+  });
+
+  it('rejects workflow-scoped invocation with scheduleOnly action', async () => {
+    const scheduleOnly = vi.fn(async () => []);
+    const deps = makeDeps({ scheduleOnly });
+    await expect(
+      applyInvalidation('workflow', 'scheduleOnly', 'wf-1', deps),
+    ).rejects.toThrow(/requires scope 'task'/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+    expect(scheduleOnly).not.toHaveBeenCalled();
+  });
+
+  it('rejects scope=none with scheduleOnly action', async () => {
+    const scheduleOnly = vi.fn(async () => []);
+    const deps = makeDeps({ scheduleOnly });
+    await expect(
+      applyInvalidation('none', 'scheduleOnly', 'task-a', deps),
+    ).rejects.toThrow(/requires scope 'task'/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+    expect(scheduleOnly).not.toHaveBeenCalled();
+  });
+
+  it('throws an explicit missing-dep error when scheduleOnly dep is absent', async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('task', 'scheduleOnly', 'task-a', deps),
+    ).rejects.toThrow(/'scheduleOnly' dep is missing/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+  });
+
+  it('does not call any retry/recreate/fork lifecycle dep', async () => {
+    const scheduleOnly = vi.fn(async () => []);
+    const recreateWorkflowFromFreshBase = vi.fn(async () => []);
+    const workflowFork = vi.fn(async () => []);
+    const deps = makeDeps({ scheduleOnly, recreateWorkflowFromFreshBase, workflowFork });
+    await applyInvalidation('task', 'scheduleOnly', 'task-a', deps);
+    expect(deps.retryTask).not.toHaveBeenCalled();
+    expect(deps.recreateTask).not.toHaveBeenCalled();
+    expect(deps.retryWorkflow).not.toHaveBeenCalled();
+    expect(deps.recreateWorkflow).not.toHaveBeenCalled();
+    expect(recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
+    expect(workflowFork).not.toHaveBeenCalled();
   });
 });

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -8736,4 +8736,204 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('A')!.config.command).toBe('echo A-v2');
     });
   });
+
+  // Step 15 (`docs/architecture/task-invalidation-roadmap.md`,
+  // chart row "Change external gate policy"): the orchestrator's
+  // `setTaskExternalGatePolicies` is the engine's intentional
+  // non-invalidating mutation. These tests pin the chart's
+  // contract end-to-end inside the orchestrator: cancel/retry/
+  // recreate are NEVER called, `task.execution.generation` is
+  // unchanged, the persisted gate-policy field changes, and a
+  // task previously blocked on the gate transitions to runnable
+  // via the post-update scheduling pass.
+  describe('setTaskExternalGatePolicies (Step 15 non-invalidating lock-in)', () => {
+    it('does not invoke cancelTask, retryTask, or recreateTask', () => {
+      orchestrator.loadPlan({
+        name: 'gate-prereq',
+        tasks: [{ id: 'verify', description: 'Prereq task' }],
+      });
+      const prereqTaskId = sid(orchestrator, 0, 'verify');
+      const prereqWfId = prereqTaskId.split('/')[0]!;
+      const prereqMergeId = `__merge__${prereqWfId}`;
+
+      orchestrator.loadPlan({
+        name: 'gate-downstream',
+        tasks: [
+          {
+            id: 'leaf',
+            description: 'leaf waits on upstream completion gate',
+            externalDependencies: [{ workflowId: prereqWfId, gatePolicy: 'completed' }],
+          },
+        ],
+      });
+      const leafId = sid(orchestrator, 1, 'leaf');
+
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(makeResponse({ actionId: prereqTaskId, status: 'completed' }));
+      orchestrator.setTaskAwaitingApproval(prereqMergeId);
+      expect(orchestrator.getTask(leafId)!.status).toBe('pending');
+
+      const cancelTaskSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const retryTaskSpy = vi.spyOn(orchestrator, 'retryTask');
+      const recreateTaskSpy = vi.spyOn(orchestrator, 'recreateTask');
+      const cancelWorkflowSpy = vi.spyOn(orchestrator, 'cancelWorkflow');
+
+      orchestrator.setTaskExternalGatePolicies(leafId, [
+        { workflowId: prereqWfId, gatePolicy: 'review_ready' },
+      ]);
+
+      expect(cancelTaskSpy).not.toHaveBeenCalled();
+      expect(retryTaskSpy).not.toHaveBeenCalled();
+      expect(recreateTaskSpy).not.toHaveBeenCalled();
+      expect(cancelWorkflowSpy).not.toHaveBeenCalled();
+
+      cancelTaskSpy.mockRestore();
+      retryTaskSpy.mockRestore();
+      recreateTaskSpy.mockRestore();
+      cancelWorkflowSpy.mockRestore();
+    });
+
+    it("does not bump task.execution.generation on the edited task or upstream", () => {
+      orchestrator.loadPlan({
+        name: 'gate-prereq-gen',
+        tasks: [{ id: 'verify', description: 'Prereq task' }],
+      });
+      const prereqTaskId = sid(orchestrator, 0, 'verify');
+      const prereqWfId = prereqTaskId.split('/')[0]!;
+      const prereqMergeId = `__merge__${prereqWfId}`;
+
+      orchestrator.loadPlan({
+        name: 'gate-downstream-gen',
+        tasks: [
+          {
+            id: 'leaf',
+            description: 'leaf waits on upstream completion gate',
+            externalDependencies: [{ workflowId: prereqWfId, gatePolicy: 'completed' }],
+          },
+        ],
+      });
+      const leafId = sid(orchestrator, 1, 'leaf');
+
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(makeResponse({ actionId: prereqTaskId, status: 'completed' }));
+      orchestrator.setTaskAwaitingApproval(prereqMergeId);
+
+      const genBefore = orchestrator.getTask(leafId)!.execution.generation ?? 0;
+      const upstreamGenBefore = orchestrator.getTask(prereqTaskId)!.execution.generation ?? 0;
+
+      orchestrator.setTaskExternalGatePolicies(leafId, [
+        { workflowId: prereqWfId, gatePolicy: 'review_ready' },
+      ]);
+
+      const genAfter = orchestrator.getTask(leafId)!.execution.generation ?? 0;
+      const upstreamGenAfter = orchestrator.getTask(prereqTaskId)!.execution.generation ?? 0;
+      expect(genAfter).toBe(genBefore);
+      expect(upstreamGenAfter).toBe(upstreamGenBefore);
+    });
+
+    it('persists the updated gate-policy field on the task config', () => {
+      orchestrator.loadPlan({
+        name: 'gate-prereq-persist',
+        tasks: [{ id: 'verify', description: 'Prereq task' }],
+      });
+      const prereqTaskId = sid(orchestrator, 0, 'verify');
+      const prereqWfId = prereqTaskId.split('/')[0]!;
+
+      orchestrator.loadPlan({
+        name: 'gate-downstream-persist',
+        tasks: [
+          {
+            id: 'leaf',
+            description: 'leaf waits on upstream completion gate',
+            externalDependencies: [{ workflowId: prereqWfId, gatePolicy: 'completed' }],
+          },
+        ],
+      });
+      const leafId = sid(orchestrator, 1, 'leaf');
+
+      orchestrator.setTaskExternalGatePolicies(leafId, [
+        { workflowId: prereqWfId, gatePolicy: 'review_ready' },
+      ]);
+
+      const inMemoryDeps = orchestrator.getTask(leafId)!.config.externalDependencies!;
+      expect(inMemoryDeps[0]!.gatePolicy).toBe('review_ready');
+      const persisted = persistence.getTaskEntry(leafId)!.task.config.externalDependencies!;
+      expect(persisted[0]!.gatePolicy).toBe('review_ready');
+    });
+
+    it('transitions a previously gate-blocked task to runnable via the scheduling pass', () => {
+      orchestrator.loadPlan({
+        name: 'gate-prereq-unblock',
+        tasks: [{ id: 'verify', description: 'Prereq task' }],
+      });
+      const prereqTaskId = sid(orchestrator, 0, 'verify');
+      const prereqWfId = prereqTaskId.split('/')[0]!;
+      const prereqMergeId = `__merge__${prereqWfId}`;
+
+      orchestrator.loadPlan({
+        name: 'gate-downstream-unblock',
+        tasks: [
+          {
+            id: 'leaf',
+            description: 'leaf waits on upstream completion gate',
+            externalDependencies: [{ workflowId: prereqWfId, gatePolicy: 'completed' }],
+          },
+        ],
+      });
+      const leafId = sid(orchestrator, 1, 'leaf');
+
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(makeResponse({ actionId: prereqTaskId, status: 'completed' }));
+      orchestrator.setTaskAwaitingApproval(prereqMergeId);
+      expect(orchestrator.getTask(leafId)!.status).toBe('pending');
+
+      const started = orchestrator.setTaskExternalGatePolicies(leafId, [
+        { workflowId: prereqWfId, gatePolicy: 'review_ready' },
+      ]);
+
+      expect(started.map((t) => t.id)).toContain(leafId);
+      expect(orchestrator.getTask(leafId)!.status).toBe('running');
+    });
+
+    it('does NOT cancel an already-running task on the same workflow', () => {
+      orchestrator.loadPlan({
+        name: 'gate-prereq-running',
+        tasks: [{ id: 'verify', description: 'Prereq task' }],
+      });
+      const prereqTaskId = sid(orchestrator, 0, 'verify');
+      const prereqWfId = prereqTaskId.split('/')[0]!;
+      const prereqMergeId = `__merge__${prereqWfId}`;
+
+      orchestrator.loadPlan({
+        name: 'gate-mixed-downstream',
+        tasks: [
+          { id: 'busy', description: 'already running task' },
+          {
+            id: 'leaf',
+            description: 'leaf waits on upstream completion gate',
+            externalDependencies: [{ workflowId: prereqWfId, gatePolicy: 'completed' }],
+          },
+        ],
+      });
+      const busyId = sid(orchestrator, 1, 'busy');
+      const leafId = sid(orchestrator, 1, 'leaf');
+
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(makeResponse({ actionId: prereqTaskId, status: 'completed' }));
+      orchestrator.setTaskAwaitingApproval(prereqMergeId);
+      expect(orchestrator.getTask(busyId)!.status).toBe('running');
+      const busyGenBefore = orchestrator.getTask(busyId)!.execution.generation ?? 0;
+
+      orchestrator.setTaskExternalGatePolicies(leafId, [
+        { workflowId: prereqWfId, gatePolicy: 'review_ready' },
+      ]);
+
+      // The unrelated already-running task keeps its execution
+      // lineage and stays running on the same generation — the
+      // chart's "in-flight work survives" guarantee.
+      expect(orchestrator.getTask(busyId)!.status).toBe('running');
+      const busyGenAfter = orchestrator.getTask(busyId)!.execution.generation ?? 0;
+      expect(busyGenAfter).toBe(busyGenBefore);
+    });
+  });
 });

--- a/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
@@ -724,4 +724,98 @@ describe('State × Topology Matrix', () => {
       expect(orchestrator.getTask('B-fix')).toBeDefined();
     });
   });
+
+  // Step 15 (`docs/architecture/task-invalidation-roadmap.md`,
+  // chart row "Change external gate policy"): the matrix entry
+  // for `external gate policy` mutations is the chart's
+  // intentional non-invalidating outlier — `none-class` /
+  // task scope. Concretely:
+  //
+  //   1. `MUTATION_POLICIES.externalGatePolicy.action` is the
+  //      lone `'scheduleOnly'` entry in the policy table (mirrors
+  //      how `topology` is the lone `'workflowFork'` entry).
+  //   2. The mutation does NOT bump execution generation on the
+  //      edited task or any other task in the workflow — unlike
+  //      every Step 2–10 row above which bumps `generation` on
+  //      the root + transitive dependents.
+  //   3. The mutation only re-evaluates ready tasks newly
+  //      unblocked by the gate-policy change; in-flight work on
+  //      unrelated tasks survives untouched.
+  describe('Step 15 matrix entry: external gate policy is none-class / task scope', () => {
+    it('MUTATION_POLICIES.externalGatePolicy classifies the row as scheduleOnly / non-invalidating', () => {
+      const policy = MUTATION_POLICIES.externalGatePolicy;
+      expect(policy).toBeDefined();
+      expect(policy.action).toBe('scheduleOnly');
+      expect(policy.invalidatesExecutionSpec).toBe(false);
+      expect(policy.invalidateIfActive).toBe(false);
+    });
+
+    it('externalGatePolicy is the only scheduleOnly entry in the policy table', () => {
+      const scheduleOnlyEntries = Object.entries(MUTATION_POLICIES).filter(
+        ([, p]) => p.action === 'scheduleOnly',
+      );
+      expect(scheduleOnlyEntries.map(([k]) => k)).toEqual(['externalGatePolicy']);
+    });
+
+    // Mirrors the Step 2/5 matrix shape (gen-bump assertion) but
+    // INVERTED — the chart's "no invalidation" rule for gate
+    // policy means generation MUST be unchanged on the edited
+    // task and every task in its workflow. The orchestrator
+    // requires the task to have at least one external dependency
+    // before `setTaskExternalGatePolicies` accepts the update, so
+    // we use a bespoke 2-task plan with an external dependency on
+    // a never-resolved upstream workflow. The matrix entry's
+    // claim is simply: edits to gate policy don't bump
+    // generation, whether or not the task is actually unblocked.
+    it('does not bump task.execution.generation on the edited task or its dependents', () => {
+      // Pre-create the upstream workflow so the gate dependency is
+      // resolvable. The upstream is intentionally left in a state
+      // that does not satisfy the gate so the downstream task
+      // stays blocked — but the policy edit's generation contract
+      // is independent of whether unblocking occurs.
+      orchestrator.loadPlan({
+        name: 'gate-matrix-upstream',
+        tasks: [{ id: 'upstream', description: 'Prereq', command: 'echo upstream' }],
+      });
+      const upstreamWfId = orchestrator.getAllTasks()[0]!.config.workflowId!;
+
+      orchestrator.loadPlan({
+        name: 'gate-matrix-row',
+        tasks: [
+          {
+            id: 'A',
+            description: 'Gated root',
+            command: 'echo A',
+            externalDependencies: [{ workflowId: upstreamWfId, gatePolicy: 'completed' }],
+          },
+          { id: 'B', description: 'Dependent', command: 'echo B', dependencies: ['A'] },
+        ],
+      });
+
+      const aTask = orchestrator
+        .getAllTasks()
+        .find((t) => t.id.endsWith('/A') && t.config.workflowId !== upstreamWfId)!;
+      const bTask = orchestrator
+        .getAllTasks()
+        .find((t) => t.id.endsWith('/B') && t.config.workflowId !== upstreamWfId)!;
+
+      const genBefore = {
+        A: aTask.execution.generation ?? 0,
+        B: bTask.execution.generation ?? 0,
+      };
+
+      orchestrator.setTaskExternalGatePolicies(aTask.id, [
+        { workflowId: upstreamWfId, gatePolicy: 'review_ready' },
+      ]);
+
+      const aTaskAfter = orchestrator.getTask(aTask.id)!;
+      const bTaskAfter = orchestrator.getTask(bTask.id)!;
+      expect(aTaskAfter.execution.generation ?? 0).toBe(genBefore.A);
+      expect(bTaskAfter.execution.generation ?? 0).toBe(genBefore.B);
+
+      // Persistence reflects the new gate policy.
+      const deps = aTaskAfter.config.externalDependencies!;
+      expect(deps[0]!.gatePolicy).toBe('review_ready');
+    });
+  });
 });

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -1,8 +1,8 @@
 
 import type { TaskState } from '@invoker/workflow-graph';
-
 export type InvalidationAction =
   | 'none'
+  | 'scheduleOnly'
   | 'retryTask'
   | 'retryWorkflow'
   | 'recreateTask'
@@ -49,7 +49,18 @@ export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>
   mergeMode:             { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
   fixContext:            { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
   rebaseAndRetry:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateWorkflowFromFreshBase' as const },
-  externalGatePolicy:    { invalidatesExecutionSpec: false, invalidateIfActive: false, action: 'none' as const },
+  // Step 15 (`docs/architecture/task-invalidation-roadmap.md`): the
+  // chart's Decision Table row "Change external gate policy" is the
+  // intentional non-invalidating outlier — it's a scheduling policy
+  // edit, not an execution-spec edit. Action is now the explicit
+  // `'scheduleOnly'` (was `'none'` in Step 1) so the lock-in is
+  // encoded in the policy table itself: `applyInvalidation` skips
+  // `cancelInFlight` for this action and routes to a `scheduleOnly`
+  // dep that triggers an unblock-pass (e.g.
+  // `Orchestrator.autoStartExternallyUnblockedReadyTasks`). Per chart:
+  //   - `invalidatesExecutionSpec: false` (no ABI change)
+  //   - `invalidateIfActive: false`       (in-flight work survives)
+  externalGatePolicy:    { invalidatesExecutionSpec: false, invalidateIfActive: false, action: 'scheduleOnly' as const },
   // Step 11 (`docs/architecture/task-invalidation-roadmap.md`): graph
   // topology mutations (e.g. `replaceTask`, `addTask` that changes
   // parent edges) are fork-class / workflow scope. They must NOT
@@ -81,6 +92,21 @@ export interface InvalidationDeps {
    * focused unit tests that build a partial `InvalidationDeps`.
    */
   workflowFork?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
+  /**
+   * Step 15 (`docs/architecture/task-invalidation-roadmap.md`):
+   * scheduling-only unblock pass for the chart's "Change external
+   * gate policy" row. Production callers wire this to a scheduler
+   * entrypoint (e.g.
+   * `Orchestrator.autoStartExternallyUnblockedReadyTasks`) via
+   * `buildInvalidationDeps` (`packages/app/src/workflow-actions.ts`).
+   * Unlike retry/recreate deps, this is invoked WITHOUT a
+   * preceding `cancelInFlight` call — gate-policy edits MUST NOT
+   * cancel active work. The dep takes the affected task id so it
+   * can scope the scheduling pass if desired; today's
+   * implementation re-evaluates all externally-unblocked ready
+   * tasks across the orchestrator.
+   */
+  scheduleOnly?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
 }
 
 const TASK_ACTIONS = new Set<InvalidationAction>(['retryTask', 'recreateTask']);
@@ -104,6 +130,31 @@ export async function applyInvalidation(
       );
     }
     return [];
+  }
+
+  if (action === 'scheduleOnly') {
+    if (scope !== 'task') {
+      throw new Error(
+        `applyInvalidation: action 'scheduleOnly' requires scope 'task' (got '${scope}')`,
+      );
+    }
+    if (!deps.scheduleOnly) {
+      // Step 15: production callers wire this dep via
+      // `buildInvalidationDeps` (`packages/app/src/workflow-actions.ts`)
+      // to `Orchestrator.autoStartExternallyUnblockedReadyTasks`. This
+      // branch is reachable only from focused unit tests that build a
+      // partial `InvalidationDeps` without the scheduler dep.
+      throw new Error(
+        "applyInvalidation: 'scheduleOnly' dep is missing. " +
+          'Production callers wire this via buildInvalidationDeps in ' +
+          '@invoker/app/workflow-actions; tests must supply ' +
+          'deps.scheduleOnly to use this action.',
+      );
+    }
+    // Per chart's "Change external gate policy" row: scheduling
+    // edits do NOT cancel active work and do NOT bump generation.
+    // We deliberately skip `deps.cancelInFlight` here.
+    return await deps.scheduleOnly(id);
   }
 
   if (TASK_ACTIONS.has(action) && scope !== 'task') {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2710,6 +2710,42 @@ export class Orchestrator {
   /**
    * Update gate policy on one or more external dependencies for a task, then
    * immediately re-evaluate ready tasks that were blocked by external deps.
+   *
+   * Step 15 lock-in (`docs/architecture/task-invalidation-roadmap.md`,
+   * chart row "Change external gate policy"): this is the engine's
+   * ONLY intentionally non-invalidating execution-spec-adjacent
+   * mutation. Per `MUTATION_POLICIES.externalGatePolicy`
+   * (`invalidatesExecutionSpec: false`, `invalidateIfActive: false`,
+   * `action: 'scheduleOnly'`):
+   *
+   *   - We do NOT bump `task.execution.generation`. Active and
+   *     pending lineage survives the edit untouched.
+   *   - We do NOT call `cancelTask` / `retryTask` / `recreateTask` /
+   *     `applyInvalidation` with any retry/recreate route. Tasks
+   *     that are running keep running on their existing execution
+   *     lineage; the chart's "Change external gate policy" row is
+   *     explicit that this "changes scheduling policy, not the task
+   *     execution ABI".
+   *   - We DO persist the updated gate-policy field on the task's
+   *     external dependency entry.
+   *   - We DO trigger a scheduling pass via
+   *     `autoStartExternallyUnblockedReadyTasks` so any task
+   *     previously blocked on the gate gets a fresh look.
+   *
+   * The orchestrator method is deliberately NOT routed through
+   * `applyInvalidation('task', 'scheduleOnly', taskId, deps)` here
+   * because the public method must remain synchronous for backward
+   * compatibility (callers in app-layer-handoff-repro tests, the
+   * api-server, and the headless `set gate-policy` verb invoke it
+   * sync and immediately consume the returned `TaskState[]`).
+   * `applyInvalidation` is `async`; routing through it would force
+   * the public surface async. The chart's lock-in is instead
+   * encoded in the policy table itself
+   * (`MUTATION_POLICIES.externalGatePolicy.action === 'scheduleOnly'`)
+   * and in `applyInvalidation`'s skip-cancel branch for that
+   * action — so any future caller that DOES route through the
+   * policy router (e.g. a hypothetical fork-class equivalent) gets
+   * the same non-invalidating semantics as this method.
    */
   setTaskExternalGatePolicies(taskId: string, updates: ExternalGatePolicyUpdate[]): TaskState[] {
     this.refreshFromDb();
@@ -3896,7 +3932,25 @@ export class Orchestrator {
     this.scheduler.enqueue({ taskId, attemptId, priority });
   }
 
-  private autoStartExternallyUnblockedReadyTasks(): TaskState[] {
+  /**
+   * Step 15 (`docs/architecture/task-invalidation-roadmap.md`,
+   * chart row "Change external gate policy"): public scheduler
+   * entrypoint that re-evaluates every task whose external
+   * dependency blocker has cleared and enqueues any newly-runnable
+   * tasks. Called internally by `setTaskExternalGatePolicies`
+   * AFTER the gate-policy field is persisted; also wired to the
+   * `'scheduleOnly'` action's `scheduleOnly` dep on
+   * `InvalidationDeps` (`buildInvalidationDeps` in
+   * `packages/app/src/workflow-actions.ts`) so future callers that
+   * route a gate-policy edit through `applyInvalidation` get the
+   * same chart-mandated unblock-pass without cancelling any
+   * in-flight work.
+   *
+   * Was `private` before Step 15; exposed publicly so
+   * `applyInvalidation`'s `'scheduleOnly'` dep can invoke it
+   * type-safely. No other behavior changes.
+   */
+  autoStartExternallyUnblockedReadyTasks(): TaskState[] {
     const readyTasks = this.stateMachine
       .getReadyTasks()
       .filter((task) => (task.config.externalDependencies?.length ?? 0) > 0)


### PR DESCRIPTION
## Summary
This locks external gate policy into the policy table as an intentional non-invalidating outlier. `MUTATION_POLICIES.externalGatePolicy` now declares `scheduleOnly` behavior, and `applyInvalidation` gains a matching action that reruns external gate scheduling without canceling work or bumping execution generation. The app layer wires that action to `autoStartExternallyUnblockedReadyTasks`, making the scheduler re-check explicit instead of incidental.

## Problem
External gate policy edits were a real exception to the invalidation model, but that exception was undocumented in code and easy to forget.

## Root Cause
The policy layer only modeled invalidating mutations. External gate policy is different: it should reschedule newly unblocked work without rewriting execution lineage.

## Approach
Add a `scheduleOnly` action to the policy model and route external gate policy edits through that explicit non-invalidating path.

## Why This Fix Is Right
Encoding the exception in the policy table is safer than leaving it as orchestrator folklore. It makes the non-invalidating behavior intentional and reviewable.

## Tradeoffs And Considerations
This adds a special-case action to the invalidation router. That is acceptable because the behavior is genuinely different and deserves an explicit name.

## Before
```mermaid
flowchart LR
  A[External gate policy edit] --> B[Persist policy]
  B --> C[Implicit scheduling side effect]
  C --> D[No policy-table representation]
```

## After
```mermaid
flowchart LR
  A[External gate policy edit] --> B[applyInvalidation scheduleOnly]
  B --> C[Skip cancelInFlight]
  C --> D[autoStartExternallyUnblockedReadyTasks]
  D --> E[Start newly unblocked work]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 15: external gate policy`
