### PR TITLE
Task invalidation step 16: fix approve/reject lock-in

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -488,6 +488,32 @@ describe('POST /api/tasks/:id/approve', () => {
     expect(res.body.error).toBe('not awaiting approval');
   });
 
+  // Step 16 (`docs/architecture/task-invalidation-roadmap.md`,
+  // chart row "Approve or reject fix"): the api-server's
+  // approve POST is the chart's **second** non-invalidating
+  // surface (alongside `gate-policy` from Step 15). It MUST
+  // route to `Orchestrator.approve` (or `resumeTaskAfterFixApproval`
+  // / `commitApprovedFix` for the fix branch) and MUST NOT
+  // trigger any retry/recreate spy on the orchestrator. By the
+  // time approve runs the task is already terminal — cancel
+  // here would also be a generation-bumping mistake.
+  it('Step 16: approve POST does not trigger retry/recreate/cancel routes', async () => {
+    mocks.orchestrator.recreateTask = vi.fn();
+    mocks.orchestrator.recreateWorkflow = vi.fn();
+    mocks.orchestrator.cancelWorkflow = vi.fn();
+
+    const res = await request(port, 'POST', '/api/tasks/task-1/approve');
+
+    expect(res.status).toBe(200);
+    expect(res.body.action).toBe('approved');
+    expect(mocks.orchestrator.approve).toHaveBeenCalledTimes(1);
+    expect(mocks.orchestrator.retryTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
   it('uses approveTaskAction when provided', async () => {
     const approveTaskAction = vi.fn().mockResolvedValue({ started: [] });
     const isolatedApi = startApiServer({
@@ -553,6 +579,57 @@ describe('POST /api/tasks/:id/reject', () => {
     expect(res.status).toBe(200);
     expect(mocks.orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-1', 'merge conflict');
     expect(mocks.orchestrator.reject).not.toHaveBeenCalled();
+  });
+
+  // Step 16 (`docs/architecture/task-invalidation-roadmap.md`,
+  // chart row "Approve or reject fix"): the api-server's
+  // reject POST is the revert-class half of the second
+  // non-invalidating surface (alongside Step 15's gate-policy
+  // POST). It MUST route to `Orchestrator.reject` (or
+  // `revertConflictResolution` for the fix-flow branch) and
+  // MUST NOT trigger any retry/recreate/cancel spy on the
+  // orchestrator. By the time reject runs the task is already
+  // terminal — invalidating would be a generation-bumping
+  // mistake.
+  it('Step 16: reject POST does not trigger retry/recreate/cancel routes (non-fix path)', async () => {
+    mocks.orchestrator.recreateTask = vi.fn();
+    mocks.orchestrator.recreateWorkflow = vi.fn();
+    mocks.orchestrator.cancelWorkflow = vi.fn();
+
+    const res = await request(port, 'POST', '/api/tasks/task-1/reject');
+
+    expect(res.status).toBe(200);
+    expect(res.body.action).toBe('rejected');
+    expect(mocks.orchestrator.reject).toHaveBeenCalledTimes(1);
+    expect(mocks.orchestrator.retryTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('Step 16: reject POST does not trigger retry/recreate/cancel routes (fix-flow path)', async () => {
+    mocks.orchestrator.recreateTask = vi.fn();
+    mocks.orchestrator.recreateWorkflow = vi.fn();
+    mocks.orchestrator.cancelWorkflow = vi.fn();
+    mocks.orchestrator.getTask.mockReturnValue(
+      makeTask({ execution: { pendingFixError: 'merge conflict' } }),
+    );
+
+    const res = await request(port, 'POST', '/api/tasks/task-1/reject');
+
+    expect(res.status).toBe(200);
+    expect(res.body.action).toBe('rejected');
+    expect(mocks.orchestrator.revertConflictResolution).toHaveBeenCalledWith(
+      'task-1',
+      'merge conflict',
+    );
+    expect(mocks.orchestrator.reject).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.retryTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -546,6 +546,70 @@ describe('headless delegation enforcement', () => {
         executeTasksSpy.mockRestore();
       });
 
+      // Step 16: pin headless approve/reject routing.
+      // Per docs/architecture/task-invalidation-roadmap.md row
+      // "Approve or reject fix", these verbs MUST flow through
+      // commandService.approve / commandService.reject (which
+      // route to MUTATION_POLICIES.fixApprove / fixReject —
+      // non-invalidating). They MUST NOT touch retry/recreate/
+      // cancel surfaces; the task is already terminal at this
+      // point and invalidating would be a generation-bumping
+      // mistake.
+      it('Step 16 headless approve routes through commandService.approve and never touches retry/recreate/cancel', async () => {
+        const wfRow = { id: 'wf-1', name: 'test-workflow', generation: 0, status: 'running' as const, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+        const taskRow = { id: 'wf-1/task-a', status: 'completed', config: { workflowId: 'wf-1' }, execution: {} } as any;
+        mockDeps.persistence.listWorkflows = vi.fn(() => [wfRow]);
+        mockDeps.persistence.loadTasks = vi.fn(() => [taskRow]);
+        mockDeps.orchestrator.getAllTasks = vi.fn(() => [taskRow]);
+        mockDeps.commandService.approve = vi.fn(async () => ({ ok: true as const, data: [] }));
+        mockDeps.commandService.retryTask = vi.fn(async () => ({ ok: true as const, data: [] }));
+        mockDeps.commandService.retryWorkflow = vi.fn(async () => ({ ok: true as const, data: [] }));
+        mockDeps.commandService.cancelTask = vi.fn(async () => ({ ok: true as const, data: { cancelled: [], runningCancelled: [] } }));
+        mockDeps.commandService.cancelWorkflow = vi.fn(async () => ({ ok: true as const, data: { cancelled: [], runningCancelled: [] } }));
+        mockDeps.orchestrator.recreateTask = vi.fn(() => []);
+        mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
+
+        await runHeadless(['approve', 'wf-1/task-a'], mockDeps);
+
+        expect(mockDeps.commandService.approve).toHaveBeenCalled();
+        expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
+        expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
+        expect(mockDeps.commandService.cancelTask).not.toHaveBeenCalled();
+        expect(mockDeps.commandService.cancelWorkflow).not.toHaveBeenCalled();
+        expect(mockDeps.orchestrator.retryTask).not.toHaveBeenCalled();
+        expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
+        expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+      });
+
+      it('Step 16 headless reject routes through commandService.reject and never touches retry/recreate/cancel', async () => {
+        const wfRow = { id: 'wf-1', name: 'test-workflow', generation: 0, status: 'running' as const, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() };
+        const taskRow = { id: 'wf-1/task-a', status: 'failed', config: { workflowId: 'wf-1' }, execution: {} } as any;
+        mockDeps.persistence.listWorkflows = vi.fn(() => [wfRow]);
+        mockDeps.persistence.loadTasks = vi.fn(() => [taskRow]);
+        mockDeps.orchestrator.getAllTasks = vi.fn(() => [taskRow]);
+        mockDeps.commandService.reject = vi.fn(async () => ({ ok: true as const, data: undefined }));
+        mockDeps.commandService.retryTask = vi.fn(async () => ({ ok: true as const, data: [] }));
+        mockDeps.commandService.retryWorkflow = vi.fn(async () => ({ ok: true as const, data: [] }));
+        mockDeps.commandService.cancelTask = vi.fn(async () => ({ ok: true as const, data: { cancelled: [], runningCancelled: [] } }));
+        mockDeps.commandService.cancelWorkflow = vi.fn(async () => ({ ok: true as const, data: { cancelled: [], runningCancelled: [] } }));
+        mockDeps.orchestrator.recreateTask = vi.fn(() => []);
+        mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
+
+        await runHeadless(['reject', 'wf-1/task-a', 'because reasons'], mockDeps);
+
+        expect(mockDeps.commandService.reject).toHaveBeenCalled();
+        const rejectCall = (mockDeps.commandService.reject as any).mock.calls[0]?.[0];
+        expect(rejectCall?.payload?.taskId).toBe('wf-1/task-a');
+        expect(rejectCall?.payload?.reason).toBe('because reasons');
+        expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
+        expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
+        expect(mockDeps.commandService.cancelTask).not.toHaveBeenCalled();
+        expect(mockDeps.commandService.cancelWorkflow).not.toHaveBeenCalled();
+        expect(mockDeps.orchestrator.retryTask).not.toHaveBeenCalled();
+        expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
+        expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+      });
+
       it('headless retry with deps.noTrack=true can defer runnable execution to the caller', async () => {
         const deferRunnableTasks = vi.fn();
         const preemptWorkflowExecution = vi.fn(async () => {});

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -1270,6 +1270,151 @@ describe('buildInvalidationDeps', () => {
     expect((result as any[])[0].config.workflowId).toBe('wf-1-fork');
   });
 
+  // Step 16 (`docs/architecture/task-invalidation-roadmap.md`,
+  // chart row "Approve or reject fix"): `fixApprove` and
+  // `fixReject` are wired to the existing `approveTask` /
+  // `rejectTask` action wrappers in this file. Per the chart
+  // these are non-invalidating control flow over an existing
+  // fix attempt's output, so the wires must:
+  //
+  //   - reach the orchestrator's approve/reject primitives
+  //     (NOT retry/recreate);
+  //   - never call `orchestrator.cancelTask` /
+  //     `orchestrator.cancelWorkflow` (the policy router skips
+  //     `cancelInFlight` for these actions);
+  //   - return `TaskState[]` (approve returns the started
+  //     follow-on tasks; reject returns `[]` because the
+  //     wrapper is `void` today).
+  //
+  // The Step 1 scaffolding test pattern above wires the deps
+  // through `buildInvalidationDeps` and invokes them directly
+  // with a partial orchestrator mock; we follow that pattern.
+  it('routes fixApprove through approveTask (non-fix path → orchestrator.approve, returns started, never retry/recreate/cancel)', async () => {
+    const started = [makeRunningTask({ id: 'task-a' })];
+    const approvedTask = makeTask({ id: 'task-a', status: 'awaiting_approval', execution: {} });
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      getTask: vi.fn().mockReturnValue(approvedTask),
+      approve: vi.fn().mockResolvedValue(started),
+      resumeTaskAfterFixApproval: vi.fn(),
+    };
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
+    expect(deps.fixApprove).toBeDefined();
+    const result = await deps.fixApprove!('task-a');
+
+    expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.resumeTaskAfterFixApproval).not.toHaveBeenCalled();
+    expect(result).toEqual(started);
+    expect(orchestrator.retryTask).not.toHaveBeenCalled();
+    expect(orchestrator.recreateTask).not.toHaveBeenCalled();
+    expect(orchestrator.retryWorkflow).not.toHaveBeenCalled();
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    expect(orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('routes fixApprove through approveTask (fix path → commitApprovedFix + orchestrator.approve)', async () => {
+    const started = [makeRunningTask({ id: 'task-a' })];
+    const approvedTask = makeTask({
+      id: 'task-a',
+      status: 'awaiting_approval',
+      config: { workflowId: 'wf-1' },
+      execution: { pendingFixError: 'plain failure', branch: 'task-a', workspacePath: '/tmp/task-a' },
+    });
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      getTask: vi.fn().mockReturnValue(approvedTask),
+      approve: vi.fn().mockResolvedValue(started),
+      resumeTaskAfterFixApproval: vi.fn(),
+    };
+    const persistence = makePersistence();
+    const taskExecutor = {
+      commitApprovedFix: vi.fn(),
+      publishAfterFix: vi.fn(),
+      executeTasks: vi.fn(),
+    };
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    const result = await deps.fixApprove!('task-a');
+
+    expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(approvedTask);
+    expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.resumeTaskAfterFixApproval).not.toHaveBeenCalled();
+    expect(result).toEqual(started);
+    expect(orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('routes fixReject through rejectTask (fix-flow path → orchestrator.revertConflictResolution, returns [], never retry/recreate/cancel)', async () => {
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      getTask: vi.fn().mockReturnValue(
+        makeTask({ id: 'task-a', execution: { pendingFixError: 'merge conflict' } }),
+      ),
+      reject: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
+    expect(deps.fixReject).toBeDefined();
+    const result = await deps.fixReject!('task-a');
+
+    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-a', 'merge conflict');
+    expect(orchestrator.reject).not.toHaveBeenCalled();
+    // `rejectTask` is `void` today; the wire returns `[]` so the
+    // policy router's `TaskState[]` contract is satisfied.
+    expect(result).toEqual([]);
+    expect(orchestrator.retryTask).not.toHaveBeenCalled();
+    expect(orchestrator.recreateTask).not.toHaveBeenCalled();
+    expect(orchestrator.retryWorkflow).not.toHaveBeenCalled();
+    expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    expect(orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('routes fixReject through rejectTask (non-fix path → orchestrator.reject)', async () => {
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      getTask: vi.fn().mockReturnValue(
+        makeTask({ id: 'task-a', execution: {} }),
+      ),
+      reject: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
+    const result = await deps.fixReject!('task-a');
+
+    // `rejectTask` is invoked without a reason from the wire, so
+    // `orchestrator.reject` is called as `(taskId, undefined)`.
+    expect(orchestrator.reject).toHaveBeenCalledWith('task-a', undefined);
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+    expect(orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
   it('builds a cancel-first hook that cancels orchestrator state and kills runners', async () => {
     const orchestrator = makeBaseOrchestrator();
     orchestrator.cancelTask = vi.fn(() => ({

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -329,6 +329,17 @@ export function buildInvalidationDeps(
     // method.
     scheduleOnly: (_taskId: string) =>
       deps.orchestrator.autoStartExternallyUnblockedReadyTasks(),
+    fixApprove: async (taskId: string) => {
+      const result = await approveTask(taskId, {
+        orchestrator: deps.orchestrator,
+        taskExecutor: deps.taskExecutor,
+      });
+      return result.started;
+    },
+    fixReject: (taskId: string) => {
+      rejectTask(taskId, { orchestrator: deps.orchestrator });
+      return [];
+    },
   };
 }
 

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -60,7 +60,12 @@ describe('MUTATION_POLICIES', () => {
       // Step 15: `'scheduleOnly'` joins `'none'` as a
       // non-invalidating action class — gate-policy edits change
       // scheduling, not the execution ABI, so neither flag flips.
-      if (policy.action === 'none' || policy.action === 'scheduleOnly') {
+      if (
+        policy.action === 'none' ||
+        policy.action === 'scheduleOnly' ||
+        policy.action === 'fixApprove' ||
+        policy.action === 'fixReject'
+      ) {
         expect(policy.invalidatesExecutionSpec, key).toBe(false);
         expect(policy.invalidateIfActive, key).toBe(false);
       } else {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -8088,6 +8088,192 @@ describe('Orchestrator', () => {
     });
   });
 
+  // Step 16 (`docs/architecture/task-invalidation-roadmap.md`,
+  // chart row "Approve or reject fix"): pin the orchestrator-level
+  // contract that production callers depend on through the
+  // `MUTATION_POLICIES.fixApprove` / `MUTATION_POLICIES.fixReject`
+  // wires (`packages/app/src/workflow-actions.ts → buildInvalidationDeps`
+  // routes both via the existing `approveTask` / `rejectTask` action
+  // wrappers).
+  //
+  // The chart's hard contract is that fix decisions are
+  // **non-invalidating control flow over an existing fix attempt's
+  // output**:
+  //
+  //   - Approve continues with the fix attempt's branch / commit /
+  //     workspacePath as the task's authoritative result. Status
+  //     transitions to `completed` (or `running` for merge / merge-
+  //     conflict cases that need a publish step).
+  //   - Reject reverts the task to its pre-fix `failed` state, with
+  //     the original `pendingFixError` restored. The fix attempt's
+  //     branch pointer is discarded but the task's lineage is not.
+  //
+  // Neither path may bump `task.execution.generation`, neither may
+  // invoke retry/recreate, and neither may cancel the task itself
+  // (by the time the decision runs the task is already terminal).
+  // These tests pin all three invariants directly on the orchestrator
+  // primitives the policy wires call.
+  describe('Step 16: fix-decision is non-invalidating (no gen bump, no cancel, no retry/recreate)', () => {
+    beforeEach(() => {
+      orchestrator.loadPlan({
+        name: 'fix-decision-test',
+        tasks: [
+          { id: 'fd1', description: 'Root task' },
+          { id: 'fd2', description: 'Failing task', dependencies: ['fd1'] },
+        ],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'fd1', status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      orchestrator.handleWorkerResponse(
+        makeResponse({
+          actionId: 'fd2',
+          status: 'failed',
+          outputs: { exitCode: 1, error: 'original failure' },
+        }),
+      );
+      expect(orchestrator.getTask('fd2')!.status).toBe('failed');
+    });
+
+    it('approve: status -> completed, generation unchanged on edited task and dependents, lineage preserved, no retry/recreate spy fires', async () => {
+      // Move fd2 through the fix attempt into awaiting_approval
+      // with a pendingFixError. This is exactly the state an
+      // `approveTask` invocation lands on in the fix flow.
+      const { savedError } = orchestrator.beginConflictResolution('fd2');
+      // Hydrate workspace lineage on the task so the preservation
+      // half of the assertion is meaningful (the in-memory mock
+      // does not synthesize branch/workspacePath itself).
+      const persistedKey = Array.from(persistence.tasks.keys()).find(
+        (k) => k === 'fd2' || k.endsWith('/fd2'),
+      );
+      if (!persistedKey) throw new Error('test setup: persisted fd2 key not found');
+      persistence.updateTask(persistedKey, {
+        execution: {
+          branch: 'experiment/fix-attempt-branch',
+          commit: 'fa11ed01',
+          workspacePath: '/tmp/fix-attempt-workspace',
+        },
+      });
+      orchestrator.setFixAwaitingApproval('fd2', savedError);
+
+      const genBeforeApprove = {
+        fd1: orchestrator.getTask('fd1')!.execution.generation ?? 0,
+        fd2: orchestrator.getTask('fd2')!.execution.generation ?? 0,
+      };
+      const lineageBefore = orchestrator.getTask('fd2')!.execution;
+
+      // Spy on the retry/recreate/cancel orchestrator primitives —
+      // none must fire as a side effect of `approve`.
+      const retryTaskSpy = vi.spyOn(orchestrator, 'retryTask');
+      const recreateTaskSpy = vi.spyOn(orchestrator, 'recreateTask');
+      const retryWorkflowSpy = vi.spyOn(orchestrator, 'retryWorkflow');
+      const recreateWorkflowSpy = vi.spyOn(orchestrator, 'recreateWorkflow');
+      const cancelTaskSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const cancelWorkflowSpy = vi.spyOn(orchestrator, 'cancelWorkflow');
+
+      await orchestrator.approve('fd2');
+
+      const fd2After = orchestrator.getTask('fd2')!;
+      expect(fd2After.status).toBe('completed');
+
+      // Generation invariants — the heart of the chart's
+      // "approve or reject fix is non-invalidating" rule.
+      expect(fd2After.execution.generation ?? 0).toBe(genBeforeApprove.fd2);
+      expect(orchestrator.getTask('fd1')!.execution.generation ?? 0).toBe(
+        genBeforeApprove.fd1,
+      );
+
+      // Lineage preserved — fix attempt's branch/commit/workspacePath
+      // is now the task's authoritative lineage (continue-class).
+      expect(fd2After.execution.branch).toBe(lineageBefore.branch);
+      expect(fd2After.execution.commit).toBe(lineageBefore.commit);
+      expect(fd2After.execution.workspacePath).toBe(lineageBefore.workspacePath);
+
+      // No retry/recreate/cancel orchestrator primitives fire.
+      expect(retryTaskSpy).not.toHaveBeenCalled();
+      expect(recreateTaskSpy).not.toHaveBeenCalled();
+      expect(retryWorkflowSpy).not.toHaveBeenCalled();
+      expect(recreateWorkflowSpy).not.toHaveBeenCalled();
+      expect(cancelTaskSpy).not.toHaveBeenCalled();
+      expect(cancelWorkflowSpy).not.toHaveBeenCalled();
+    });
+
+    it('reject (revertConflictResolution): status -> failed (original error), generation unchanged on edited task and dependents, no retry/recreate/cancel spy fires', () => {
+      const { savedError } = orchestrator.beginConflictResolution('fd2');
+      orchestrator.setFixAwaitingApproval('fd2', savedError);
+      expect(orchestrator.getTask('fd2')!.status).toBe('awaiting_approval');
+      expect(orchestrator.getTask('fd2')!.execution.pendingFixError).toBe(savedError);
+
+      const genBeforeReject = {
+        fd1: orchestrator.getTask('fd1')!.execution.generation ?? 0,
+        fd2: orchestrator.getTask('fd2')!.execution.generation ?? 0,
+      };
+
+      const retryTaskSpy = vi.spyOn(orchestrator, 'retryTask');
+      const recreateTaskSpy = vi.spyOn(orchestrator, 'recreateTask');
+      const retryWorkflowSpy = vi.spyOn(orchestrator, 'retryWorkflow');
+      const recreateWorkflowSpy = vi.spyOn(orchestrator, 'recreateWorkflow');
+      const cancelTaskSpy = vi.spyOn(orchestrator, 'cancelTask');
+      const cancelWorkflowSpy = vi.spyOn(orchestrator, 'cancelWorkflow');
+
+      orchestrator.revertConflictResolution('fd2', savedError);
+
+      const fd2After = orchestrator.getTask('fd2')!;
+      expect(fd2After.status).toBe('failed');
+      expect(fd2After.execution.error).toBe(savedError);
+
+      // Generation invariants — revert is also non-invalidating.
+      expect(fd2After.execution.generation ?? 0).toBe(genBeforeReject.fd2);
+      expect(orchestrator.getTask('fd1')!.execution.generation ?? 0).toBe(
+        genBeforeReject.fd1,
+      );
+
+      expect(retryTaskSpy).not.toHaveBeenCalled();
+      expect(recreateTaskSpy).not.toHaveBeenCalled();
+      expect(retryWorkflowSpy).not.toHaveBeenCalled();
+      expect(recreateWorkflowSpy).not.toHaveBeenCalled();
+      expect(cancelTaskSpy).not.toHaveBeenCalled();
+      expect(cancelWorkflowSpy).not.toHaveBeenCalled();
+    });
+
+    it('reject (plain Orchestrator.reject — non-fix awaiting_approval): same invariants as the fix-flow reject', () => {
+      // Non-fix path: a task parked in `awaiting_approval` without
+      // a `pendingFixError`. This is the branch `rejectTask` takes
+      // when the task is NOT in a fix flow (it routes to
+      // `Orchestrator.reject` instead of `revertConflictResolution`).
+      orchestrator.retryTask('fd2');
+      expect(orchestrator.getTask('fd2')!.status).toBe('running');
+      orchestrator.setTaskAwaitingApproval('fd2');
+      expect(orchestrator.getTask('fd2')!.status).toBe('awaiting_approval');
+      expect(orchestrator.getTask('fd2')!.execution.pendingFixError).toBeUndefined();
+
+      const genBeforeReject = {
+        fd1: orchestrator.getTask('fd1')!.execution.generation ?? 0,
+        fd2: orchestrator.getTask('fd2')!.execution.generation ?? 0,
+      };
+
+      const retryTaskSpy = vi.spyOn(orchestrator, 'retryTask');
+      const recreateTaskSpy = vi.spyOn(orchestrator, 'recreateTask');
+      const cancelTaskSpy = vi.spyOn(orchestrator, 'cancelTask');
+
+      orchestrator.reject('fd2', 'rejected by reviewer');
+
+      const fd2After = orchestrator.getTask('fd2')!;
+      expect(fd2After.status).toBe('failed');
+      expect(fd2After.execution.error).toBe('rejected by reviewer');
+
+      expect(fd2After.execution.generation ?? 0).toBe(genBeforeReject.fd2);
+      expect(orchestrator.getTask('fd1')!.execution.generation ?? 0).toBe(
+        genBeforeReject.fd1,
+      );
+
+      expect(retryTaskSpy).not.toHaveBeenCalled();
+      expect(recreateTaskSpy).not.toHaveBeenCalled();
+      expect(cancelTaskSpy).not.toHaveBeenCalled();
+    });
+  });
+
   describe('merge gate two-step approve (pendingFixError)', () => {
     function setupMergeGateAwaitingFixApproval(): string {
       orchestrator.loadPlan({

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -3,6 +3,8 @@ import type { TaskState } from '@invoker/workflow-graph';
 export type InvalidationAction =
   | 'none'
   | 'scheduleOnly'
+  | 'fixApprove'
+  | 'fixReject'
   | 'retryTask'
   | 'retryWorkflow'
   | 'recreateTask'
@@ -36,6 +38,8 @@ export type MutationKey =
   | 'fixContext'
   | 'rebaseAndRetry'
   | 'externalGatePolicy'
+  | 'fixApprove'
+  | 'fixReject'
   | 'topology';
 
 export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>> = Object.freeze({
@@ -61,6 +65,8 @@ export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>
   //   - `invalidatesExecutionSpec: false` (no ABI change)
   //   - `invalidateIfActive: false`       (in-flight work survives)
   externalGatePolicy:    { invalidatesExecutionSpec: false, invalidateIfActive: false, action: 'scheduleOnly' as const },
+  fixApprove:            { invalidatesExecutionSpec: false, invalidateIfActive: false, action: 'fixApprove' as const },
+  fixReject:             { invalidatesExecutionSpec: false, invalidateIfActive: false, action: 'fixReject' as const },
   // Step 11 (`docs/architecture/task-invalidation-roadmap.md`): graph
   // topology mutations (e.g. `replaceTask`, `addTask` that changes
   // parent edges) are fork-class / workflow scope. They must NOT
@@ -107,6 +113,8 @@ export interface InvalidationDeps {
    * tasks across the orchestrator.
    */
   scheduleOnly?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  fixApprove?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  fixReject?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
 }
 
 const TASK_ACTIONS = new Set<InvalidationAction>(['retryTask', 'recreateTask']);
@@ -155,6 +163,23 @@ export async function applyInvalidation(
     // edits do NOT cancel active work and do NOT bump generation.
     // We deliberately skip `deps.cancelInFlight` here.
     return await deps.scheduleOnly(id);
+  }
+
+  if (action === 'fixApprove' || action === 'fixReject') {
+    if (scope !== 'task') {
+      throw new Error(
+        `applyInvalidation: action '${action}' requires scope 'task' (got '${scope}')`,
+      );
+    }
+    const dep = action === 'fixApprove' ? deps.fixApprove : deps.fixReject;
+    if (!dep) {
+      throw new Error(
+        `applyInvalidation: '${action}' dep is missing. ` +
+          'Production callers wire this via buildInvalidationDeps in ' +
+          '@invoker/app/workflow-actions; tests must supply the dep to use this action.',
+      );
+    }
+    return await dep(id);
   }
 
   if (TASK_ACTIONS.has(action) && scope !== 'task') {


### PR DESCRIPTION
## Summary
This change adds `fixApprove` and `fixReject` as explicit non-invalidating task-scope policy actions. The approve and reject path now goes through `applyInvalidation` hooks wired to the existing approve and reject workflow-actions, preserving the fix flow’s lineage and generation semantics while making the state-machine transition explicit in the same routing layer as the rest of the invalidation model.

## Problem
Approve and reject decisions for fix flows were important lifecycle transitions, but they were not expressed as explicit policy actions.

## Root Cause
The invalidation model focused on retry and recreate semantics, leaving fix decision flows as app-layer special cases outside the central router.

## Approach
Add `fixApprove` and `fixReject` actions and route approve and reject through the policy layer without canceling work or bumping generation.

## Why This Fix Is Right
Fix approval and rejection are real state transitions, but they are not retry or recreate events. Modeling them explicitly keeps the state machine honest without forcing them into the wrong invalidation class.

## Tradeoffs And Considerations
This increases the size of the invalidation action surface. That is worthwhile because it prevents fix decisions from staying hidden as implicit special cases.

## Before
```mermaid
flowchart LR
  A[Approve or reject fix] --> B[App-layer special case]
  B --> C[Decision flow outside policy table]
```

## After
```mermaid
flowchart LR
  A[Approve or reject fix] --> B[applyInvalidation fixApprove/fixReject]
  B --> C[No cancel, no generation bump]
  C --> D[approveTask or rejectTask]
  D --> E[Completed result or restored failed state]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 16: fix approve/reject`
