### PR TITLE
Task invalidation step 18: cancel-first audit

### DIFF
--- a/packages/workflow-core/src/__tests__/cancel-first-invariant.test.ts
+++ b/packages/workflow-core/src/__tests__/cancel-first-invariant.test.ts
@@ -1,0 +1,483 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  applyInvalidation,
+  MUTATION_POLICIES,
+  type InvalidationAction,
+  type InvalidationDeps,
+  type InvalidationScope,
+  type MutationKey,
+} from '../invalidation-policy.js';
+import {
+  Orchestrator,
+  type OrchestratorPersistence,
+  type OrchestratorMessageBus,
+} from '../orchestrator.js';
+import type { TaskState, TaskStateChanges, Attempt } from '../task-types.js';
+
+// ── In-memory fixtures (focused, mirrors orchestrator.test.ts) ──
+
+class InMemoryPersistence implements OrchestratorPersistence {
+  workflows = new Map<string, {
+    id: string;
+    name: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+    repoUrl?: string;
+    mergeMode?: 'manual' | 'automatic' | 'external_review';
+  }>();
+  tasks = new Map<string, { workflowId: string; task: TaskState }>();
+  private attempts = new Map<string, Attempt[]>();
+  events: Array<{ taskId: string; eventType: string; payload?: unknown }> = [];
+
+  saveWorkflow(workflow: {
+    id: string;
+    name: string;
+    status: string;
+    repoUrl?: string;
+    mergeMode?: 'manual' | 'automatic' | 'external_review';
+  }): void {
+    const now = new Date().toISOString();
+    this.workflows.set(workflow.id, {
+      ...workflow,
+      repoUrl: workflow.repoUrl ?? 'memory://test-repo',
+      createdAt: (workflow as { createdAt?: string }).createdAt ?? now,
+      updatedAt: (workflow as { updatedAt?: string }).updatedAt ?? now,
+    });
+  }
+  updateWorkflow(): void {}
+  loadWorkflow(workflowId: string): { repoUrl?: string } | undefined {
+    const wf = this.workflows.get(workflowId);
+    return wf ? { repoUrl: wf.repoUrl } : undefined;
+  }
+  saveTask(workflowId: string, task: TaskState): void {
+    this.tasks.set(task.id, { workflowId, task });
+  }
+  getTaskEntry(taskId: string): { workflowId: string; task: TaskState } | undefined {
+    return this.tasks.get(taskId);
+  }
+  updateTask(taskId: string, changes: TaskStateChanges): void {
+    const entry = this.tasks.get(taskId);
+    if (!entry) return;
+    entry.task = {
+      ...entry.task,
+      ...(changes.status !== undefined ? { status: changes.status } : {}),
+      ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
+      config: { ...entry.task.config, ...changes.config },
+      execution: { ...entry.task.execution, ...changes.execution },
+    } as TaskState;
+  }
+  listWorkflows() { return Array.from(this.workflows.values()); }
+  loadTasks(workflowId: string): TaskState[] {
+    return Array.from(this.tasks.values())
+      .filter((e) => e.workflowId === workflowId)
+      .map((e) => e.task);
+  }
+  logEvent(taskId: string, eventType: string, payload?: unknown): void {
+    this.events.push({ taskId, eventType, payload });
+  }
+  saveAttempt(attempt: Attempt): void {
+    const list = this.attempts.get(attempt.nodeId) ?? [];
+    list.push(attempt);
+    this.attempts.set(attempt.nodeId, list);
+  }
+  loadAttempts(nodeId: string): Attempt[] { return this.attempts.get(nodeId) ?? []; }
+  loadAttempt(attemptId: string): Attempt | undefined {
+    for (const list of this.attempts.values()) {
+      const found = list.find((a) => a.id === attemptId);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  updateAttempt(
+    attemptId: string,
+    changes: Partial<Pick<Attempt,
+      | 'status' | 'startedAt' | 'completedAt' | 'exitCode' | 'error'
+      | 'lastHeartbeatAt' | 'branch' | 'commit' | 'summary'
+      | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>,
+  ): void {
+    for (const list of this.attempts.values()) {
+      const idx = list.findIndex((a) => a.id === attemptId);
+      if (idx !== -1) {
+        list[idx] = { ...list[idx], ...changes } as Attempt;
+        return;
+      }
+    }
+  }
+  deleteWorkflow(workflowId: string): void {
+    this.workflows.delete(workflowId);
+    for (const [id, entry] of this.tasks) {
+      if (entry.workflowId === workflowId) this.tasks.delete(id);
+    }
+  }
+  deleteAllWorkflows(): void { this.workflows.clear(); this.tasks.clear(); }
+}
+
+class InMemoryBus implements OrchestratorMessageBus {
+  publish<T>(_channel: string, _message: T): void {}
+  subscribe(_channel: string, _handler: (msg: unknown) => void): () => void {
+    return () => undefined;
+  }
+}
+
+// ── Sub-suite 1: applyInvalidation routing per MUTATION_POLICIES ──
+
+interface SpyDeps {
+  deps: InvalidationDeps;
+  callOrder: string[];
+  spies: {
+    cancelInFlight: ReturnType<typeof vi.fn>;
+    retryTask: ReturnType<typeof vi.fn>;
+    recreateTask: ReturnType<typeof vi.fn>;
+    retryWorkflow: ReturnType<typeof vi.fn>;
+    recreateWorkflow: ReturnType<typeof vi.fn>;
+    recreateWorkflowFromFreshBase: ReturnType<typeof vi.fn>;
+    workflowFork: ReturnType<typeof vi.fn>;
+    scheduleOnly: ReturnType<typeof vi.fn>;
+    fixApprove: ReturnType<typeof vi.fn>;
+    fixReject: ReturnType<typeof vi.fn>;
+  };
+}
+
+function buildSpyDeps(): SpyDeps {
+  const callOrder: string[] = [];
+  const tag = (name: string) => async (...args: unknown[]) => {
+    callOrder.push(`${name}:${args.join(':')}`);
+    return [] as TaskState[];
+  };
+  const cancelInFlight = vi.fn(tag('cancelInFlight'));
+  const retryTask = vi.fn(tag('retryTask'));
+  const recreateTask = vi.fn(tag('recreateTask'));
+  const retryWorkflow = vi.fn(tag('retryWorkflow'));
+  const recreateWorkflow = vi.fn(tag('recreateWorkflow'));
+  const recreateWorkflowFromFreshBase = vi.fn(tag('recreateWorkflowFromFreshBase'));
+  const workflowFork = vi.fn(tag('workflowFork'));
+  const scheduleOnly = vi.fn(tag('scheduleOnly'));
+  const fixApprove = vi.fn(tag('fixApprove'));
+  const fixReject = vi.fn(tag('fixReject'));
+  return {
+    deps: {
+      cancelInFlight,
+      retryTask,
+      recreateTask,
+      retryWorkflow,
+      recreateWorkflow,
+      recreateWorkflowFromFreshBase,
+      workflowFork,
+      scheduleOnly,
+      fixApprove,
+      fixReject,
+    },
+    callOrder,
+    spies: {
+      cancelInFlight,
+      retryTask,
+      recreateTask,
+      retryWorkflow,
+      recreateWorkflow,
+      recreateWorkflowFromFreshBase,
+      workflowFork,
+      scheduleOnly,
+      fixApprove,
+      fixReject,
+    },
+  };
+}
+
+const TASK_SCOPED_ACTIONS = new Set<InvalidationAction>([
+  'retryTask',
+  'recreateTask',
+]);
+const WORKFLOW_SCOPED_ACTIONS = new Set<InvalidationAction>([
+  'retryWorkflow',
+  'recreateWorkflow',
+  'recreateWorkflowFromFreshBase',
+  'workflowFork',
+]);
+const NON_INVALIDATING_ACTIONS = new Set<InvalidationAction>([
+  'scheduleOnly',
+  'fixApprove',
+  'fixReject',
+  'none',
+]);
+
+function classify(action: InvalidationAction): {
+  invalidating: boolean;
+  scope: InvalidationScope;
+  expectedDep: keyof SpyDeps['spies'] | null;
+} {
+  if (action === 'none') return { invalidating: false, scope: 'none', expectedDep: null };
+  if (NON_INVALIDATING_ACTIONS.has(action)) {
+    return {
+      invalidating: false,
+      scope: 'task',
+      expectedDep: action as keyof SpyDeps['spies'],
+    };
+  }
+  if (TASK_SCOPED_ACTIONS.has(action)) {
+    return { invalidating: true, scope: 'task', expectedDep: action as keyof SpyDeps['spies'] };
+  }
+  if (WORKFLOW_SCOPED_ACTIONS.has(action)) {
+    return { invalidating: true, scope: 'workflow', expectedDep: action as keyof SpyDeps['spies'] };
+  }
+  throw new Error(`Unclassified action: ${action}`);
+}
+
+describe('cancel-first invariant — policy-table iteration', () => {
+  // Walk every entry in MUTATION_POLICIES so any future policy
+  // addition is forced to classify itself per the chart.
+  const allEntries = Object.entries(MUTATION_POLICIES) as Array<[
+    MutationKey,
+    typeof MUTATION_POLICIES[MutationKey],
+  ]>;
+
+  it('covers every MUTATION_POLICIES entry (no gaps in the audit)', () => {
+    expect(allEntries.length).toBeGreaterThan(0);
+    for (const [key, policy] of allEntries) {
+      expect(policy.action, `MUTATION_POLICIES.${key} missing action`).toBeTruthy();
+    }
+  });
+
+  for (const [key, policy] of allEntries) {
+    const { invalidating, scope, expectedDep } = classify(policy.action);
+    const id = scope === 'workflow' ? `wf-${key}` : `t-${key}`;
+
+    it(`MUTATION_POLICIES.${key} (action=${policy.action}) → ${
+      invalidating ? 'cancelInFlight BEFORE' : 'NO cancelInFlight then'
+    } deps.${expectedDep ?? '(none)'}`, async () => {
+      const { deps, spies, callOrder } = buildSpyDeps();
+
+      await applyInvalidation(scope, policy.action, id, deps);
+
+      if (invalidating) {
+        expect(spies.cancelInFlight, `expected cancelInFlight for ${policy.action}`).toHaveBeenCalledTimes(1);
+        expect(spies.cancelInFlight).toHaveBeenCalledWith(scope, id);
+        expect(expectedDep).not.toBeNull();
+        const depSpy = spies[expectedDep as keyof SpyDeps['spies']];
+        expect(depSpy).toHaveBeenCalledWith(id);
+
+        const cancelIdx = callOrder.findIndex((e) => e.startsWith('cancelInFlight:'));
+        const lifecycleIdx = callOrder.findIndex((e) => e.startsWith(`${expectedDep}:`));
+        expect(cancelIdx, `cancelInFlight missing from call order: ${callOrder.join(' -> ')}`).toBeGreaterThanOrEqual(0);
+        expect(lifecycleIdx).toBeGreaterThanOrEqual(0);
+        expect(
+          cancelIdx,
+          `cancel-first invariant violated for ${policy.action}: order=${callOrder.join(' -> ')}`,
+        ).toBeLessThan(lifecycleIdx);
+      } else {
+        // Non-invalidating outliers (scheduleOnly / fixApprove /
+        // fixReject) MUST NOT cancel; that is the chart's
+        // intentional carve-out (Steps 15 + 16).
+        expect(
+          spies.cancelInFlight,
+          `cancel-first leak: ${policy.action} should NOT call cancelInFlight`,
+        ).not.toHaveBeenCalled();
+        if (expectedDep) {
+          const depSpy = spies[expectedDep as keyof SpyDeps['spies']];
+          expect(depSpy).toHaveBeenCalledWith(id);
+        }
+      }
+    });
+  }
+
+  it('aborts BEFORE the lifecycle dep when cancelInFlight rejects (cross-action lock-in)', async () => {
+    // A failed cancel MUST NOT leave a lifecycle dep called —
+    // this is the same lock-in lifecycle-matrix.test.ts asserts
+    // for the canonical 5-cell matrix; here we re-check a sample
+    // invalidating action to keep the cross-cutting guarantee
+    // self-contained.
+    const { deps, spies } = buildSpyDeps();
+    spies.cancelInFlight.mockRejectedValueOnce(new Error('boom-cancel-first'));
+
+    await expect(
+      applyInvalidation('task', 'recreateTask', 't-rejected', deps),
+    ).rejects.toThrow('boom-cancel-first');
+
+    expect(spies.recreateTask).not.toHaveBeenCalled();
+  });
+});
+
+// ── Sub-suite 2: direct primitive calls bypass applyInvalidation ──
+
+function seedActiveTask(p: InMemoryPersistence, wfId: string, taskId: string): void {
+  p.saveWorkflow({ id: wfId, name: 'fixture', status: 'running' });
+  p.saveTask(wfId, {
+    id: taskId,
+    description: 'Active task',
+    status: 'running',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { workflowId: wfId },
+    execution: { startedAt: new Date(), selectedAttemptId: `${taskId}-att-0` },
+  });
+  p.saveTask(wfId, {
+    id: `__merge__${wfId}`,
+    description: 'Workflow gate',
+    status: 'pending',
+    dependencies: [taskId],
+    createdAt: new Date(),
+    config: { workflowId: wfId, isMergeNode: true, executorType: 'merge' },
+    execution: {},
+  });
+}
+
+function makeOrchestrator(p: InMemoryPersistence): Orchestrator {
+  // Disable scheduling drains so the test observes the post-reset
+  // state without auto-restart side effects (some primitives
+  // auto-start ready tasks which would re-launch the cancelled
+  // task into 'running' on the same tick — irrelevant to the
+  // cancel-first invariant being asserted here).
+  return new Orchestrator({
+    persistence: p,
+    messageBus: new InMemoryBus(),
+    maxConcurrency: 0,
+  });
+}
+
+describe('cancel-first invariant — direct primitive calls bypass applyInvalidation', () => {
+  // Every direct caller (CommandService.retryTask /
+  // CommandService.recreateTask /
+  // CommandService.retryWorkflow /
+  // CommandService.recreateWorkflow /
+  // CommandService.recreateWorkflowFromFreshBase, plus
+  // forkWorkflow's existing internal cancel) MUST emit a
+  // `task.cancelled` event for the active task BEFORE any
+  // task.pending / task.forked reset event for that task.
+
+  function expectCancelBeforeReset(
+    p: InMemoryPersistence,
+    taskId: string,
+    resetEventTypes: readonly string[],
+  ): void {
+    const cancelIdx = p.events.findIndex(
+      (e) => e.taskId === taskId && e.eventType === 'task.cancelled',
+    );
+    expect(
+      cancelIdx,
+      `expected task.cancelled for ${taskId}, got events: ${p.events
+        .filter((e) => e.taskId === taskId)
+        .map((e) => e.eventType)
+        .join(',')}`,
+    ).toBeGreaterThanOrEqual(0);
+    for (const evType of resetEventTypes) {
+      const resetIdx = p.events.findIndex(
+        (e) => e.taskId === taskId && e.eventType === evType,
+      );
+      if (resetIdx === -1) continue;
+      expect(
+        cancelIdx,
+        `cancel-first violated for ${taskId}: ${evType} (idx=${resetIdx}) must come AFTER task.cancelled (idx=${cancelIdx})`,
+      ).toBeLessThan(resetIdx);
+    }
+  }
+
+  it('retryTask cancels the active task BEFORE resetting it', () => {
+    const p = new InMemoryPersistence();
+    const wfId = 'wf-direct-retry-task';
+    seedActiveTask(p, wfId, 't1');
+    const o = makeOrchestrator(p);
+    o.syncFromDb(wfId);
+
+    o.retryTask('t1');
+
+    expectCancelBeforeReset(p, 't1', ['task.pending']);
+  });
+
+  it('recreateTask cancels the active task BEFORE resetting it', () => {
+    const p = new InMemoryPersistence();
+    const wfId = 'wf-direct-recreate-task';
+    seedActiveTask(p, wfId, 't1');
+    const o = makeOrchestrator(p);
+    o.syncFromDb(wfId);
+
+    o.recreateTask('t1');
+
+    expectCancelBeforeReset(p, 't1', ['task.pending']);
+  });
+
+  it('retryWorkflow cancels the active task BEFORE resetting it', () => {
+    const p = new InMemoryPersistence();
+    const wfId = 'wf-direct-retry-wf';
+    seedActiveTask(p, wfId, 't1');
+    const o = makeOrchestrator(p);
+    o.syncFromDb(wfId);
+
+    o.retryWorkflow(wfId);
+
+    expectCancelBeforeReset(p, 't1', ['task.pending']);
+  });
+
+  it('recreateWorkflow cancels the active task BEFORE resetting it', () => {
+    const p = new InMemoryPersistence();
+    const wfId = 'wf-direct-recreate-wf';
+    seedActiveTask(p, wfId, 't1');
+    const o = makeOrchestrator(p);
+    o.syncFromDb(wfId);
+
+    o.recreateWorkflow(wfId);
+
+    expectCancelBeforeReset(p, 't1', ['task.pending']);
+  });
+
+  it('recreateWorkflowFromFreshBase cancels the active task BEFORE resetting it', async () => {
+    const p = new InMemoryPersistence();
+    const wfId = 'wf-direct-fresh-base';
+    seedActiveTask(p, wfId, 't1');
+    const o = makeOrchestrator(p);
+    o.syncFromDb(wfId);
+
+    await o.recreateWorkflowFromFreshBase(wfId, {
+      refreshBase: async () => ({ commit: 'fresh-sha' }),
+    });
+
+    expectCancelBeforeReset(p, 't1', ['task.pending']);
+  });
+
+  it('forkWorkflow cancels the source workflow BEFORE forking (Step 14 invariant, re-checked here)', () => {
+    const p = new InMemoryPersistence();
+    const wfId = 'wf-direct-fork';
+    seedActiveTask(p, wfId, 't1');
+    const o = makeOrchestrator(p);
+    o.syncFromDb(wfId);
+
+    o.forkWorkflow(wfId, { autoStart: false });
+
+    // forkWorkflow is the one primitive that already wired its
+    // own cancel-first call (Step 14). This test is a regression
+    // guard that the cancel still runs and is recorded as a
+    // task.cancelled event for the active task on the source
+    // workflow, BEFORE any task.forked_from event for the
+    // forked successor.
+    const cancelIdx = p.events.findIndex(
+      (e) => e.taskId === 't1' && e.eventType === 'task.cancelled',
+    );
+    expect(cancelIdx).toBeGreaterThanOrEqual(0);
+
+    const forkedFromIdx = p.events.findIndex(
+      (e) => e.eventType === 'task.forked_from',
+    );
+    if (forkedFromIdx !== -1) {
+      expect(cancelIdx).toBeLessThan(forkedFromIdx);
+    }
+  });
+
+  it('the cancel marker on the cancelled task is the explicit step-18 cancel-before-invalidation error', () => {
+    // Anchor the marker string so future audits / log scrapers
+    // can grep for cancel-first interventions on retry-class /
+    // recreate-class paths.
+    const p = new InMemoryPersistence();
+    const wfId = 'wf-direct-marker';
+    seedActiveTask(p, wfId, 't1');
+    const o = makeOrchestrator(p);
+    o.syncFromDb(wfId);
+
+    o.recreateTask('t1');
+
+    const cancelEvent = p.events.find(
+      (e) => e.taskId === 't1' && e.eventType === 'task.cancelled',
+    );
+    expect(cancelEvent).toBeDefined();
+    const payload = cancelEvent!.payload as TaskStateChanges | undefined;
+    expect(payload?.execution?.error).toMatch(/Cancelled before .*invalidation/);
+  });
+});

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5271,7 +5271,7 @@ describe('Orchestrator', () => {
       expect(merge.status).toBe('running');
     });
 
-    it('skips running tasks', () => {
+    it('cancels running tasks before resetting them', () => {
       const p = new InMemoryPersistence();
       const b = new InMemoryBus();
       const wfId = 'wf-retry-running';
@@ -5292,9 +5292,34 @@ describe('Orchestrator', () => {
 
       o.retryWorkflow(wfId);
 
-      // Running task should not be touched
+      // Cancel-first marked the task as failed before the reset; the
+      // reset re-picked it up because 'failed' is in retryStatuses
+      // and autoStartReadyTasks then drains it back into 'running'.
+      // The exact terminal value isn't important — what matters is
+      // that the task is no longer the original 'running' attempt
+      // (the cancel event is the proof of interruption) and that the
+      // `task.cancelled` event was emitted BEFORE the reset cycle so
+      // any executor-side cleanup observed it.
       const a = o.getTask('a')!;
-      expect(a.status).toBe('running');
+      expect(['pending', 'running']).toContain(a.status);
+      const cancelEvents = p.events.filter(
+        (e) => e.taskId === 'a' && e.eventType === 'task.cancelled',
+      );
+      expect(cancelEvents.length).toBeGreaterThanOrEqual(1);
+      const pendingEvents = p.events.filter(
+        (e) => e.taskId === 'a' && e.eventType === 'task.pending',
+      );
+      // Cancel must precede the pending reset.
+      const firstCancelIdx = p.events.findIndex(
+        (e) => e.taskId === 'a' && e.eventType === 'task.cancelled',
+      );
+      const firstPendingIdx = p.events.findIndex(
+        (e) => e.taskId === 'a' && e.eventType === 'task.pending',
+      );
+      if (pendingEvents.length > 0) {
+        expect(firstCancelIdx).toBeGreaterThanOrEqual(0);
+        expect(firstCancelIdx).toBeLessThan(firstPendingIdx);
+      }
     });
 
     it('handles all-completed workflow (no resets needed)', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -835,6 +835,90 @@ export class Orchestrator {
     return { affectedIds, readyIds };
   }
 
+  /**
+   * Cancel-first invariant defense-in-depth (Step 18 of
+   * `docs/architecture/task-invalidation-roadmap.md`, Hard Invariant
+   * from `docs/architecture/task-invalidation-chart.md`).
+   *
+   * Marks any actively-running task in the targeted scope as `failed`
+   * with an explicit cancel marker BEFORE the caller resets state.
+   * This guarantees the chart's "interrupt and cancel all in-flight
+   * work in the affected scope" rule for direct callers of the
+   * orchestrator primitives — notably the `commandService.retryTask`
+   * / `recreateTask` / `retryWorkflow` / `recreateWorkflow` /
+   * `recreateWorkflowFromFreshBase` lifecycle commands wired in
+   * Step 17, which bypass the upstream `applyInvalidation` cancel.
+   *
+   * Calls via `applyInvalidation` already cancel via `cancelInFlight`
+   * (executor kill + orchestrator-side `cancelTask`/`cancelWorkflow`),
+   * so this helper is a defense-in-depth no-op there: by the time the
+   * primitive runs the targeted scope has no active tasks and the
+   * `isActive` filter below skips them all.
+   *
+   * Implementation notes:
+   *   - Only `running` / `fixing_with_ai` tasks are touched. Pending /
+   *     blocked / failed / completed / etc. tasks are left alone so
+   *     the subsequent reset path (`resetSubgraphToPending` /
+   *     `recreateWorkflow` / `replaceSelectedAttempt`) sees the
+   *     expected lineage.
+   *   - The selected attempt's status is intentionally NOT mutated
+   *     here — the subsequent reset's `replaceSelectedAttempt` sees
+   *     it as still `running` and marks it `superseded`, preserving
+   *     the existing attempt-supersession contract that retry/recreate
+   *     primitives (and their tests) rely on.
+   *   - Deferred-set / queued scheduler entries are cleared per
+   *     cancelled task so the slot frees up for the upcoming reset.
+   */
+  private cancelActiveBeforeInvalidation(
+    scope: 'task' | 'workflow',
+    id: string,
+  ): string[] {
+    let candidates: TaskState[];
+    if (scope === 'task') {
+      const root = this.stateGetTask(id);
+      if (!root) return [];
+      const allTasks = this.stateMachine.getAllTasks();
+      const taskMap = new Map(allTasks.map((t) => [t.id, t]));
+      const descendantIds = getTransitiveDependents(
+        id,
+        taskMap,
+        (t) => t.status === 'completed' || t.status === 'stale',
+      );
+      candidates = [
+        root,
+        ...descendantIds
+          .map((d) => taskMap.get(d))
+          .filter((t): t is TaskState => !!t),
+      ];
+    } else {
+      candidates = this.stateMachine
+        .getAllTasks()
+        .filter((t) => t.config.workflowId === id);
+    }
+
+    const cancelled: string[] = [];
+    for (const t of candidates) {
+      if (!isActiveForInvalidation(t.status)) continue;
+      const error = `Cancelled before ${scope}-scope invalidation`;
+      const completedAt = new Date();
+      const changes: TaskStateChanges = {
+        status: 'failed',
+        execution: { error, completedAt },
+      };
+      this.writeAndSync(t.id, changes);
+      this.persistence.logEvent?.(t.id, 'task.cancelled', changes);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, {
+        type: 'updated',
+        taskId: t.id,
+        changes,
+      });
+      this.deferredTaskIds.delete(t.id);
+      this.clearQueuedSchedulerEntries(t.id, t.execution.selectedAttemptId);
+      cancelled.push(t.id);
+    }
+    return cancelled;
+  }
+
   private getExecutionGeneration(task: TaskState | undefined): number {
     return task?.execution.generation ?? 0;
   }
@@ -1825,6 +1909,14 @@ export class Orchestrator {
     if (!task) throw new Error(`Task ${taskId} not found`);
     const id = task.id;
 
+    // Step 18 (`docs/architecture/task-invalidation-roadmap.md`,
+    // Hard Invariant): cancel any active attempt on this task or its
+    // downstream subgraph BEFORE the reset writes pending state.
+    // Defense-in-depth for direct callers (CommandService.retryTask
+    // wired in Step 17) that bypass `applyInvalidation`'s upstream
+    // cancel; a no-op when invoked through `applyInvalidation`.
+    this.cancelActiveBeforeInvalidation('task', id);
+
     const prevStatus = task.status;
     console.log(`[orchestrator] retryTask "${id}" (was ${prevStatus})`);
     if (task.config.isMergeNode) {
@@ -1920,10 +2012,22 @@ export class Orchestrator {
     this.refreshWorkflowFromDb(workflowId);
     const afterRefreshMs = Date.now();
 
-    const allTasks = this.stateMachine.getAllTasks().filter(
+    let allTasks = this.stateMachine.getAllTasks().filter(
       (t) => t.config.workflowId === workflowId,
     );
     if (allTasks.length === 0) throw new Error(`No tasks found for workflow ${workflowId}`);
+
+    // Step 18 cancel-first invariant: interrupt any active task in
+    // the workflow scope BEFORE the retry reset. Defense-in-depth
+    // for direct callers (CommandService.retryWorkflow wired in
+    // Step 17); a no-op when invoked through `applyInvalidation`.
+    // Re-snapshot tasks afterwards so the retry filter (which
+    // includes 'failed' in `retryStatuses`) re-picks any newly
+    // cancelled tasks for reset to pending.
+    this.cancelActiveBeforeInvalidation('workflow', workflowId);
+    allTasks = this.stateMachine.getAllTasks().filter(
+      (t) => t.config.workflowId === workflowId,
+    );
 
     const retryStatuses = new Set([
       'failed',
@@ -1995,6 +2099,12 @@ export class Orchestrator {
     if (!task) throw new Error(`Task ${taskId} not found`);
 
     const rootId = task.id;
+
+    // Step 18 cancel-first invariant: interrupt active attempts on
+    // this task / downstream subgraph BEFORE the recreate reset.
+    // Defense-in-depth for direct callers (CommandService.recreateTask
+    // wired in Step 17); a no-op when invoked through `applyInvalidation`.
+    this.cancelActiveBeforeInvalidation('task', rootId);
     const allTasks = this.stateMachine.getAllTasks();
     const taskMap = new Map(allTasks.map((t) => [t.id, t]));
     const descendantIds = getTransitiveDependents(rootId, taskMap, () => false);
@@ -2059,6 +2169,13 @@ export class Orchestrator {
       (t) => t.config.workflowId === workflowId,
     );
     if (allTasks.length === 0) throw new Error(`No tasks found for workflow ${workflowId}`);
+
+    // Step 18 cancel-first invariant: interrupt any active task in
+    // the workflow scope BEFORE the recreate reset. Defense-in-depth
+    // for direct callers (CommandService.recreateWorkflow and
+    // recreateWorkflowFromFreshBase wired in Step 17); a no-op when
+    // invoked through `applyInvalidation`.
+    this.cancelActiveBeforeInvalidation('workflow', workflowId);
 
     const resetChanges: TaskStateChanges = {
       status: 'pending',
@@ -2168,15 +2285,21 @@ export class Orchestrator {
    * Cancel-first invariant (`docs/architecture/task-invalidation-chart.md`
    * → "Hard Invariant"): the chart requires every retry/recreate
    * route to interrupt and cancel any in-flight work in the affected
-   * scope BEFORE authoritative reset. That cancel is supplied by
-   * `applyInvalidation`'s `cancelInFlight` dep (built by
-   * `buildCancelInFlight` in `packages/app/src/workflow-actions.ts`,
-   * which calls `Orchestrator.cancelWorkflow` for workflow scope and
-   * then awaits `taskExecutor.killActiveExecution` for every running
-   * attempt). This method MUST NOT add a parallel cancel call —
-   * doing so would double-cancel and would also defeat the existing
-   * "skips running tasks" semantics that direct callers of
-   * `recreateWorkflow` rely on.
+   * scope BEFORE authoritative reset. Two layers cooperate:
+   *
+   *   1. `applyInvalidation`'s `cancelInFlight` dep (built by
+   *      `buildCancelInFlight` in
+   *      `packages/app/src/workflow-actions.ts`) calls
+   *      `Orchestrator.cancelWorkflow` and awaits
+   *      `taskExecutor.killActiveExecution` for each running attempt.
+   *   2. `recreateWorkflow` (delegated to below) additionally invokes
+   *      `cancelActiveBeforeInvalidation('workflow', …)` so direct
+   *      callers (`CommandService.recreateWorkflowFromFreshBase`
+   *      wired in Step 17) that bypass `applyInvalidation` still
+   *      observe the invariant. The helper is idempotent — already
+   *      cancelled tasks are skipped, so layer (2) is a no-op when
+   *      layer (1) ran first. See Step 18 of
+   *      `docs/architecture/task-invalidation-roadmap.md`.
    */
   async recreateWorkflowFromFreshBase(
     workflowId: string,


### PR DESCRIPTION
## Summary
This step closes the chart’s hard invariant by making cancel-first part of invalidation itself, not an assumption about who called it. `applyInvalidation` still cancels upstream for retry, recreate, and fork paths, and the orchestrator now adds `cancelActiveBeforeInvalidation` so direct primitive calls also clear active work before the authoritative reset.

## Problem
Direct lifecycle primitive calls could still bypass the cancel-first invariant even though the policy router enforced it.

## Root Cause
Cancel-first existed as a convention in some paths rather than as a mechanically enforced precondition for all invalidating lifecycle operations.

## Approach
Push cancel-first into the orchestrator primitives themselves so both routed and direct callers satisfy the same invariant.

## Why This Fix Is Right
An invariant is only real if bypassing the router does not bypass the rule. This change makes cancel-first part of the execution contract instead of a caller responsibility.

## Tradeoffs And Considerations
This adds extra cancellation bookkeeping and markers. That is the right place to pay the cost because the invariant is foundational to the whole invalidation model.

## Before
```mermaid
flowchart LR
  subgraph Before
    A[applyInvalidation] --> P[lifecycle primitive]
    P --> R[reset]
  end
```

## After
```mermaid
flowchart LR
  subgraph After
    A2[applyInvalidation] --> C[cancelInFlight]
    C --> P2[lifecycle primitive]
    P2 --> R2[reset]
    D[direct primitive] --> H[cancelActiveBeforeInvalidation]
    H --> R2
  end
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Task invalidation step 18: cancel-first audit`
