### PR TITLE
Add seedable chaos battle-test matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Types: [packages/workflow-graph/src/types.ts](packages/workflow-graph/src/types.
 | `pnpm run dev:hot` | Vite dev server + app |
 | `pnpm run build` | Build all packages |
 | `pnpm test` | Skill check + package tests (sequential) |
+| `pnpm run test:e2e-chaos` | Run the seedable chaos battle-test matrix |
 | `pnpm run test:high-resource` | Package tests in parallel |
 | `pnpm run test:all` | Full aggregated test script |
 | `pnpm run check:all` | Deps graph + types + owner boundary |

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:guarded": "bash scripts/run-with-resource-guard.sh bash scripts/workspace-test.sh",
     "test:plan-to-invoker-skill": "bash scripts/test-plan-to-invoker-skill.sh",
     "test:e2e-dry-run": "bash scripts/e2e-dry-run/run-all.sh",
+    "test:e2e-chaos": "bash scripts/e2e-chaos/run-matrix.sh",
     "test:e2e-ssh": "bash scripts/e2e-ssh/run-all.sh",
     "test:all": "bash scripts/run-all-tests.sh",
     "test:all:extended": "env INVOKER_TEST_ALL_EXTENDED=1 bash scripts/run-all-tests.sh",

--- a/scripts/e2e-chaos/cases/case-owner-approve-delegated.sh
+++ b/scripts/e2e-chaos/cases/case-owner-approve-delegated.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# GUI owner active, headless approve must delegate cleanly and not hang.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+# shellcheck disable=SC1091
+source "$ROOT/scripts/e2e-dry-run/lib/common.sh"
+
+export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=512"
+unset INVOKER_HEADLESS_STANDALONE
+unset ELECTRON_RUN_AS_NODE
+
+TMP_HOME="$(mktemp -d "${TMPDIR:-/tmp}/invoker-chaos-owner-approve-home.XXXXXX")"
+export HOME="$TMP_HOME"
+mkdir -p "$HOME/.invoker"
+export INVOKER_DB_DIR="$HOME/.invoker"
+export INVOKER_REPO_CONFIG_PATH="$(mktemp "${TMPDIR:-/tmp}/invoker-chaos-owner-approve-config.XXXXXX.json")"
+printf '{\n  "autoFixRetries": 0\n}\n' > "$INVOKER_REPO_CONFIG_PATH"
+
+OWNER_LOG="$(mktemp "${TMPDIR:-/tmp}/invoker-chaos-owner-approve-owner.XXXXXX.log")"
+SUBMIT_LOG="$(mktemp "${TMPDIR:-/tmp}/invoker-chaos-owner-approve-submit.XXXXXX.log")"
+PLAN_PATH="$(mktemp "${TMPDIR:-/tmp}/invoker-chaos-owner-approve-plan.XXXXXX.yaml")"
+OWNER_PID=""
+
+cleanup() {
+  if [ -n "$OWNER_PID" ]; then
+    kill "$OWNER_PID" 2>/dev/null || true
+    wait "$OWNER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_HOME" 2>/dev/null || true
+  rm -f "$INVOKER_REPO_CONFIG_PATH" "$OWNER_LOG" "$SUBMIT_LOG" "$PLAN_PATH" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==> owner-approve: start GUI owner"
+./run.sh >"$OWNER_LOG" 2>&1 &
+OWNER_PID=$!
+
+echo "==> owner-approve: wait for GUI owner readiness"
+READY=0
+for i in $(seq 1 240); do
+  if [ -S "$HOME/.invoker/ipc-transport.sock" ]; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
+if [ "$READY" -ne 1 ]; then
+  echo "FAIL owner-approve: owner never exposed ipc socket"
+  cat "$OWNER_LOG"
+  exit 1
+fi
+
+cat > "$PLAN_PATH" <<EOF
+name: chaos owner delegated approve
+repoUrl: $(python3 - <<'PY' "$ROOT"
+import pathlib, sys
+print(pathlib.Path(sys.argv[1]).resolve().as_uri())
+PY
+)
+tasks:
+  - id: manual-owner-approve
+    description: Manual approval routed through GUI owner
+    requiresManualApproval: true
+    command: bash -lc 'exit 0'
+EOF
+
+echo "==> owner-approve: submit workflow via owner"
+./submit-plan.sh "$PLAN_PATH" 2>&1 | tee "$SUBMIT_LOG"
+WF_ID="$(python3 - <<'PY' "$SUBMIT_LOG"
+import re, sys
+text = open(sys.argv[1], encoding='utf-8', errors='ignore').read()
+matches = re.findall(r'wf-\d+-\d+', text)
+print(matches[-1] if matches else '')
+PY
+)"
+if [ -z "$WF_ID" ]; then
+  echo "FAIL owner-approve: could not resolve workflow id"
+  cat "$SUBMIT_LOG"
+  exit 1
+fi
+
+TASK_ID="$WF_ID/manual-owner-approve"
+echo "==> owner-approve: wait for awaiting_approval"
+invoker_e2e_wait_task_status "$TASK_ID" awaiting_approval 60
+
+echo "==> owner-approve: delegated headless approve"
+invoker_e2e_run_headless approve "$TASK_ID"
+invoker_e2e_wait_task_status "$TASK_ID" completed 60
+invoker_e2e_assert_liveness_clean 15 30 0
+
+echo "PASS owner-approve-delegated ($TASK_ID completed via delegated approve)"

--- a/scripts/e2e-chaos/cases/case-owner-reject-delegated.sh
+++ b/scripts/e2e-chaos/cases/case-owner-reject-delegated.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# GUI owner active, headless reject must delegate cleanly and not hang.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+# shellcheck disable=SC1091
+source "$ROOT/scripts/e2e-dry-run/lib/common.sh"
+
+export NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=512"
+unset INVOKER_HEADLESS_STANDALONE
+unset ELECTRON_RUN_AS_NODE
+
+TMP_HOME="$(mktemp -d "${TMPDIR:-/tmp}/invoker-chaos-owner-reject-home.XXXXXX")"
+export HOME="$TMP_HOME"
+mkdir -p "$HOME/.invoker"
+export INVOKER_DB_DIR="$HOME/.invoker"
+export INVOKER_REPO_CONFIG_PATH="$(mktemp "${TMPDIR:-/tmp}/invoker-chaos-owner-reject-config.XXXXXX.json")"
+printf '{\n  "autoFixRetries": 0\n}\n' > "$INVOKER_REPO_CONFIG_PATH"
+
+OWNER_LOG="$(mktemp "${TMPDIR:-/tmp}/invoker-chaos-owner-reject-owner.XXXXXX.log")"
+SUBMIT_LOG="$(mktemp "${TMPDIR:-/tmp}/invoker-chaos-owner-reject-submit.XXXXXX.log")"
+PLAN_PATH="$(mktemp "${TMPDIR:-/tmp}/invoker-chaos-owner-reject-plan.XXXXXX.yaml")"
+OWNER_PID=""
+
+cleanup() {
+  if [ -n "$OWNER_PID" ]; then
+    kill "$OWNER_PID" 2>/dev/null || true
+    wait "$OWNER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_HOME" 2>/dev/null || true
+  rm -f "$INVOKER_REPO_CONFIG_PATH" "$OWNER_LOG" "$SUBMIT_LOG" "$PLAN_PATH" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "==> owner-reject: start GUI owner"
+./run.sh >"$OWNER_LOG" 2>&1 &
+OWNER_PID=$!
+
+echo "==> owner-reject: wait for GUI owner readiness"
+READY=0
+for i in $(seq 1 240); do
+  if [ -S "$HOME/.invoker/ipc-transport.sock" ]; then
+    READY=1
+    break
+  fi
+  sleep 1
+done
+if [ "$READY" -ne 1 ]; then
+  echo "FAIL owner-reject: owner never exposed ipc socket"
+  cat "$OWNER_LOG"
+  exit 1
+fi
+
+cat > "$PLAN_PATH" <<EOF
+name: chaos owner delegated reject
+repoUrl: $(python3 - <<'PY' "$ROOT"
+import pathlib, sys
+print(pathlib.Path(sys.argv[1]).resolve().as_uri())
+PY
+)
+tasks:
+  - id: manual-owner-reject
+    description: Manual reject routed through GUI owner
+    requiresManualApproval: true
+    command: bash -lc 'exit 0'
+EOF
+
+echo "==> owner-reject: submit workflow via owner"
+./submit-plan.sh "$PLAN_PATH" 2>&1 | tee "$SUBMIT_LOG"
+WF_ID="$(python3 - <<'PY' "$SUBMIT_LOG"
+import re, sys
+text = open(sys.argv[1], encoding='utf-8', errors='ignore').read()
+matches = re.findall(r'wf-\d+-\d+', text)
+print(matches[-1] if matches else '')
+PY
+)"
+if [ -z "$WF_ID" ]; then
+  echo "FAIL owner-reject: could not resolve workflow id"
+  cat "$SUBMIT_LOG"
+  exit 1
+fi
+
+TASK_ID="$WF_ID/manual-owner-reject"
+echo "==> owner-reject: wait for awaiting_approval"
+invoker_e2e_wait_task_status "$TASK_ID" awaiting_approval 60
+
+echo "==> owner-reject: delegated headless reject"
+invoker_e2e_run_headless reject "$TASK_ID"
+invoker_e2e_wait_task_status "$TASK_ID" failed 60
+invoker_e2e_assert_liveness_clean 15 30 0
+
+echo "PASS owner-reject-delegated ($TASK_ID failed via delegated reject)"

--- a/scripts/e2e-chaos/run-matrix.sh
+++ b/scripts/e2e-chaos/run-matrix.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+MODE="${INVOKER_CHAOS_MODE:-deterministic}"
+SEED="${INVOKER_CHAOS_SEED:-20260417}"
+SCENARIO_FILTER="${INVOKER_CHAOS_SCENARIO:-}"
+CASE_TIMEOUT_SECONDS="${INVOKER_CHAOS_CASE_TIMEOUT_SECONDS:-900}"
+RUN_ID="${INVOKER_CHAOS_RUN_ID:-$(date +%Y%m%d-%H%M%S)-$$}"
+RESULT_ROOT="${INVOKER_CHAOS_RESULT_ROOT:-$ROOT/.git/invoker-chaos/$RUN_ID}"
+RESULTS_FILE="${INVOKER_CHAOS_RESULTS_FILE:-$RESULT_ROOT/results.jsonl}"
+
+mkdir -p "$RESULT_ROOT/logs"
+: > "$RESULTS_FILE"
+
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$seconds" "$@"
+    return $?
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$seconds" "$@"
+    return $?
+  fi
+  "$@"
+}
+
+catalog() {
+  cat <<'EOF'
+fix-approve-standalone|headless-standalone|single|task_failed|approve|autofix_manual|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.5-fix-approve.sh
+fix-reject-standalone|headless-standalone|single|task_failed|reject|autofix_manual|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.6-fix-reject.sh
+manual-approve-standalone|headless-standalone|single|awaiting_approval|approve|off|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.7-manual-approve.sh
+manual-reject-standalone|headless-standalone|single|awaiting_approval|reject|off|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-1.8-manual-reject.sh
+cancel-downstream-standalone|headless-standalone|sequential|running_task|cancel_task|off|overlap|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.10-cancel-downstream.sh
+reset-race-coalesced|headless-standalone|fan-in|failed_upstream|recreate_vs_rebase|off|overlap|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
+timeout-deadlock-guard|headless-standalone|single|owner_timeout_guard|rebase_and_retry|off|timeout_window|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.14-standalone-timeout-deadlock-guard.sh
+retry-vs-recreate-window|headless-standalone|single|late_reset_window|retry_vs_recreate|off|five_second_window|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
+owner-autofix-intent|gui-owner|single|task_failed|autofix_enqueue|autofix_retry_1|none|bash __ROOT__/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
+owner-approve-delegated|gui-owner|single|awaiting_approval|approve|off|delegated|bash __ROOT__/scripts/e2e-chaos/cases/case-owner-approve-delegated.sh
+owner-reject-delegated|gui-owner|single|awaiting_approval|reject|off|delegated|bash __ROOT__/scripts/e2e-chaos/cases/case-owner-reject-delegated.sh
+stale-late-completion-both|gui-owner|sequential|stale_worker_response|recreate_and_retry_task|off|late_completion|bash __ROOT__/scripts/repro/repro-stale-late-completion-after-reset.sh --mode=both --expect-fixed
+EOF
+}
+
+expand_catalog() {
+  local base_lines
+  base_lines="$(catalog | sed "s|__ROOT__|$ROOT|g")"
+  BASE_LINES="$base_lines" python3 - "$MODE" "$SEED" <<'PY'
+import os
+import random
+import sys
+
+mode = sys.argv[1]
+seed = int(sys.argv[2])
+lines = [line.strip() for line in os.environ["BASE_LINES"].splitlines() if line.strip()]
+
+high_risk = {
+    "reset-race-coalesced",
+    "timeout-deadlock-guard",
+    "owner-autofix-intent",
+    "owner-approve-delegated",
+    "owner-reject-delegated",
+    "stale-late-completion-both",
+}
+
+entries = []
+for line in lines:
+    parts = line.split("|", 7)
+    if len(parts) != 8:
+        raise SystemExit(f"invalid scenario line: {line}")
+    entries.append(parts)
+
+expanded = []
+for entry in entries:
+    scenario_id = entry[0]
+    expanded.append(entry)
+    if mode == "nightly" and scenario_id in high_risk:
+        for idx in range(1, 3):
+            clone = entry.copy()
+            clone[0] = f"{scenario_id}@repeat{idx}"
+            expanded.append(clone)
+
+rng = random.Random(seed)
+rng.shuffle(expanded)
+for entry in expanded:
+    print("\t".join(entry))
+PY
+}
+
+record_result() {
+  local scenario_id="$1"
+  local surface_mode="$2"
+  local topology="$3"
+  local failure_mode="$4"
+  local recovery_action="$5"
+  local auto_fix_policy="$6"
+  local race_profile="$7"
+  local log_file="$8"
+  local exit_code="$9"
+  local duration_ms="${10}"
+  python3 - "$RESULTS_FILE" "$scenario_id" "$SEED" "$surface_mode" "$topology" "$failure_mode" "$recovery_action" "$auto_fix_policy" "$race_profile" "$log_file" "$exit_code" "$duration_ms" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+(
+    results_file,
+    scenario_id,
+    seed,
+    surface_mode,
+    topology,
+    failure_mode,
+    recovery_action,
+    auto_fix_policy,
+    race_profile,
+    log_file,
+    exit_code,
+    duration_ms,
+) = sys.argv[1:]
+
+text = pathlib.Path(log_file).read_text(encoding="utf-8", errors="ignore")
+workflow_ids = re.findall(r"wf-\d+-\d+", text)
+workflow_ids = list(dict.fromkeys(workflow_ids))
+hang_detected = exit_code in {"124", "137", "143"}
+result = "passed" if exit_code == "0" else ("timeout" if hang_detected else "failed")
+record = {
+    "scenarioId": scenario_id,
+    "seed": int(seed),
+    "surfaceMode": surface_mode,
+    "topology": topology,
+    "failureMode": failure_mode,
+    "recoveryAction": recovery_action,
+    "autoFixPolicy": auto_fix_policy,
+    "raceProfile": race_profile,
+    "result": result,
+    "hangDetected": hang_detected,
+    "staleRunningTasks": "FAIL: found stale running task" in text,
+    "orphanProcesses": "FAIL: expected at most" in text,
+    "stuckMutationIntents": "FAIL: found stuck workflow mutation intent" in text,
+    "workflowIds": workflow_ids,
+    "exitCode": int(exit_code),
+    "durationMs": int(duration_ms),
+    "logFile": log_file,
+}
+with open(results_file, "a", encoding="utf-8") as fh:
+    fh.write(json.dumps(record, sort_keys=True) + "\n")
+PY
+}
+
+echo "==> chaos matrix mode=$MODE seed=$SEED timeout=${CASE_TIMEOUT_SECONDS}s"
+echo "==> chaos results: $RESULTS_FILE"
+
+total=0
+passed=0
+failed=0
+
+while IFS=$'\t' read -r scenario_id surface_mode topology failure_mode recovery_action auto_fix_policy race_profile command; do
+  [ -n "$scenario_id" ] || continue
+  if [ -n "$SCENARIO_FILTER" ] && [[ "$scenario_id" != *"$SCENARIO_FILTER"* ]]; then
+    continue
+  fi
+
+  total=$((total + 1))
+  log_file="$RESULT_ROOT/logs/${scenario_id//[^A-Za-z0-9._-]/_}.log"
+  echo ""
+  echo "======== $scenario_id ========"
+  echo "surface=$surface_mode topology=$topology failure=$failure_mode recovery=$recovery_action autofix=$auto_fix_policy race=$race_profile"
+  echo "command=$command"
+
+  start_ms="$(python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+)"
+  set +e
+  run_with_timeout "$CASE_TIMEOUT_SECONDS" bash -lc "$command" >"$log_file" 2>&1
+  exit_code=$?
+  set -e
+  end_ms="$(python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+)"
+  duration_ms=$((end_ms - start_ms))
+
+  cat "$log_file"
+  record_result "$scenario_id" "$surface_mode" "$topology" "$failure_mode" "$recovery_action" "$auto_fix_policy" "$race_profile" "$log_file" "$exit_code" "$duration_ms"
+
+  if [ "$exit_code" -eq 0 ]; then
+    passed=$((passed + 1))
+  else
+    failed=$((failed + 1))
+    echo "FAILED: $scenario_id (exit=$exit_code)"
+  fi
+done < <(expand_catalog)
+
+if [ "$total" -eq 0 ]; then
+  echo "No chaos scenarios matched filter: ${SCENARIO_FILTER:-<none>}" >&2
+  exit 1
+fi
+
+echo ""
+echo "chaos matrix: $passed passed, $failed failed ($total total)"
+echo "results jsonl: $RESULTS_FILE"
+
+if [ "$failed" -ne 0 ]; then
+  exit 1
+fi

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -409,3 +409,124 @@ invoker_e2e_wait_workflow_visible() {
   echo "TIMEOUT: workflow $workflow_id not visible after ${max_secs}s" >&2
   return 1
 }
+
+invoker_e2e_count_owned_headless_processes() {
+  local count=0
+  local pid environ_blob cmdline
+  if [ -z "${INVOKER_DB_DIR:-}" ] && [ -z "${INVOKER_API_PORT:-}" ]; then
+    printf '0'
+    return 0
+  fi
+  while IFS= read -r pid; do
+    [ -n "$pid" ] || continue
+    [ -r "/proc/$pid/environ" ] || continue
+    [ -r "/proc/$pid/cmdline" ] || continue
+    environ_blob="$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null || true)"
+    cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
+    case "$cmdline" in
+      *"--headless"*)
+        ;;
+      *)
+        continue
+        ;;
+    esac
+    if [ -n "${INVOKER_DB_DIR:-}" ] && ! printf '%s\n' "$environ_blob" | grep -Fqx "INVOKER_DB_DIR=$INVOKER_DB_DIR"; then
+      if [ -n "${INVOKER_API_PORT:-}" ] && ! printf '%s\n' "$environ_blob" | grep -Fqx "INVOKER_API_PORT=$INVOKER_API_PORT"; then
+        continue
+      fi
+    fi
+    count=$((count + 1))
+  done < <(pgrep -f '(/electron|packages/app/dist/main.js|headless-client.js|run.sh --headless)' 2>/dev/null || true)
+  printf '%s' "$count"
+}
+
+invoker_e2e_assert_no_owned_headless_processes() {
+  local allowed="${1:-0}"
+  local count
+  count="$(invoker_e2e_count_owned_headless_processes)"
+  if [ "$count" -gt "$allowed" ]; then
+    echo "FAIL: expected at most $allowed owned headless process(es), found $count" >&2
+    pgrep -af '(/electron|packages/app/dist/main.js|headless-client.js|run.sh --headless)' 2>/dev/null || true
+    return 1
+  fi
+}
+
+invoker_e2e_assert_no_stale_running_tasks() {
+  local threshold_secs="${1:-15}"
+  local stale
+  stale="$(
+    invoker_e2e_run_headless query tasks --output jsonl 2>/dev/null \
+      | grep '^{' \
+      | jq -r --argjson threshold "$threshold_secs" '
+        select(.status=="running")
+        | ((.execution.lastHeartbeatAt // .execution.startedAt // "1970-01-01T00:00:00Z")
+            | sub("\\.[0-9]+Z$"; "Z")
+            | fromdateiso8601) as $hb
+        | select((now - $hb) > $threshold)
+        | .id
+      ' 2>/dev/null || true
+  )"
+  if [ -n "$stale" ]; then
+    echo "FAIL: found stale running task(s) older than ${threshold_secs}s" >&2
+    echo "$stale" >&2
+    invoker_e2e_run_headless status 2>&1 || true
+    return 1
+  fi
+}
+
+invoker_e2e_assert_no_stuck_mutation_intents() {
+  local threshold_secs="${1:-30}"
+  local db_path="${INVOKER_DB_DIR:-}/invoker.db"
+  if [ -z "${INVOKER_DB_DIR:-}" ] || [ ! -f "$db_path" ]; then
+    return 0
+  fi
+  if ! python3 - <<'PY' "$db_path" "$threshold_secs"
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+
+db_path = sys.argv[1]
+threshold_secs = int(sys.argv[2])
+cutoff = datetime.now(timezone.utc) - timedelta(seconds=threshold_secs)
+
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+rows = conn.execute(
+    """
+    SELECT id, workflow_id, channel, status, created_at, started_at
+    FROM workflow_mutation_intents
+    WHERE status = 'running'
+    ORDER BY id ASC
+    """
+).fetchall()
+
+def parse_ts(value: str | None):
+    if not value:
+        return None
+    return datetime.strptime(value, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+
+stuck = []
+for row in rows:
+    ts = parse_ts(row["started_at"]) or parse_ts(row["created_at"])
+    if ts and ts < cutoff:
+      stuck.append(row)
+
+if stuck:
+    for row in stuck:
+        print(f'{row["id"]}\t{row["workflow_id"]}\t{row["channel"]}\t{row["started_at"] or row["created_at"]}')
+    raise SystemExit(1)
+PY
+  then
+    echo "FAIL: found stuck workflow mutation intent(s) older than ${threshold_secs}s" >&2
+    return 1
+  fi
+}
+
+invoker_e2e_assert_liveness_clean() {
+  local stale_running_threshold="${1:-15}"
+  local stuck_intent_threshold="${2:-30}"
+  local allowed_headless="${3:-0}"
+  invoker_e2e_assert_no_stale_running_tasks "$stale_running_threshold"
+  invoker_e2e_assert_no_stuck_mutation_intents "$stuck_intent_threshold"
+  invoker_e2e_assert_no_owned_headless_processes "$allowed_headless"
+}

--- a/scripts/test-suites/README.md
+++ b/scripts/test-suites/README.md
@@ -37,6 +37,10 @@ The orchestrator is **`scripts/run-all-tests.sh`**, invoked as **`pnpm run test:
 | `INVOKER_PLAYWRIGHT_SHARD_INDEX=1` + `INVOKER_PLAYWRIGHT_SHARD_TOTAL=4` | Alternate shard syntax for CI matrices |
 | `INVOKER_PLAYWRIGHT_RUN_LABEL=ci-linux` | Prefix isolated Playwright artifact and bare-repo paths |
 | `INVOKER_PLAYWRIGHT_ARGS='--grep \"visual proof\"'` | Forward simple extra args through the Playwright suite wrapper |
+| `INVOKER_CHAOS_MODE=nightly` | Expand the chaos suite with repeated high-risk scenarios |
+| `INVOKER_CHAOS_SEED=1234` | Deterministically shuffle chaos scenario order |
+| `INVOKER_CHAOS_SCENARIO=owner-approve` | Run only matching chaos scenarios |
+| `INVOKER_CHAOS_CASE_TIMEOUT_SECONDS=900` | Outer timeout applied to each chaos scenario |
 
 ## Resume and availability
 
@@ -52,6 +56,7 @@ The orchestrator is **`scripts/run-all-tests.sh`**, invoked as **`pnpm run test:
   - `required/20-e2e-dry-run.sh`: `case-1.*`
   - `required/21-e2e-dry-run-downstream.sh`: `case-2.*`
   - `required/22-e2e-dry-run-github.sh`: `case-4.*`
+  - `optional/32-e2e-chaos.sh`: generated local + GUI-owner chaos matrix
   - `optional/30-e2e-ssh.sh`: `case-3.1` to `case-3.3`
   - `optional/31-e2e-ssh-merge.sh`: `case-3.4` to `case-3.6`
 

--- a/scripts/test-suites/optional/32-e2e-chaos.sh
+++ b/scripts/test-suites/optional/32-e2e-chaos.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Generated battle-test matrix for local + GUI-owner chaos scenarios.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+exec bash "$ROOT/scripts/e2e-chaos/run-matrix.sh" "$@"


### PR DESCRIPTION
## Summary
This adds a seedable chaos battle-test matrix so overload and race scenarios can be replayed deterministically. The new runner and optional suite wiring move chaos execution from ad hoc case selection to a seeded matrix that can be rerun with the same inputs, which makes flakes and restart-loop races much easier to isolate.

## Problem
Chaos coverage was too ad hoc to replay deterministically when a specific overload race failed.

## Root Cause
Case selection and scheduling lived in loose script flows rather than a seeded matrix model, so the same repro sequence was hard to reconstruct.

## Approach
Introduce a seedable matrix runner and wire the chaos suite through it so the same seed replays the same scenario selection.

## Why This Fix Is Right
Deterministic replay is the real missing capability. A matrix with seed plumbing addresses that directly without changing runtime behavior.

## Tradeoffs And Considerations
The tradeoff is more harness surface and seed plumbing. That is acceptable because reproducibility is the core value of this change.

## Before
```mermaid
flowchart LR
  subgraph Before
    R[ad hoc chaos run] --> C[cases]
  end
```

## After
```mermaid
flowchart LR
  subgraph After
    S[seed] --> M[matrix runner]
    M --> C1[case owners]
    M --> C2[case rejects]
    M --> C3[other cases]
  end
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Add seedable chaos battle-test matrix`
