### PR TITLE
Track provisioning processes and harden shared-owner startup

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -48,6 +48,93 @@ describe('headless-client', () => {
     expect(ownerHandler).toHaveBeenCalledTimes(1);
   });
 
+  it('refreshes the message bus around bootstrap when no owner is initially reachable', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    const ownerHandler = vi.fn(async () => ({ ok: true }));
+
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
+    secondBus.onRequest('headless.exec', ownerHandler);
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(firstBus)
+      .mockResolvedValueOnce(secondBus);
+
+    const exitCode = await runHeadlessClientCommand(['rebase', 'wf-2/root', '--no-track'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+    expect(ensureStandaloneOwner).toHaveBeenCalledWith(firstBus);
+    expect(refreshMessageBus).toHaveBeenCalledTimes(2);
+    expect(ownerHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries no-track delegated mutations after the first owner request times out', async () => {
+    const bus = new LocalBus();
+    let execCalls = 0;
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.exec', async () => {
+      execCalls += 1;
+      if (execCalls === 1) {
+        return await new Promise(() => {});
+      }
+      return { ok: true };
+    });
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+
+    const exitCode = await runHeadlessClientCommand(['recreate', 'wf-2', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+    expect(execCalls).toBe(2);
+  }, 15_000);
+
+  it('refreshes the message bus before retrying after an owner restart', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    let firstExecCalls = 0;
+    let secondExecCalls = 0;
+
+    firstBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    firstBus.onRequest('headless.exec', async () => {
+      firstExecCalls += 1;
+      return await new Promise(() => {});
+    });
+
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
+    secondBus.onRequest('headless.exec', async () => {
+      secondExecCalls += 1;
+      return { ok: true };
+    });
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const refreshMessageBus = vi.fn(async () => secondBus);
+
+    const exitCode = await runHeadlessClientCommand(['recreate', 'wf-3', '--no-track'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(refreshMessageBus).toHaveBeenCalledTimes(1);
+    expect(firstExecCalls).toBe(1);
+    expect(secondExecCalls).toBe(1);
+  }, 15_000);
+
   it('falls back to the electron runtime for non-mutating commands', async () => {
     const runElectronHeadless = vi.fn(async () => 0);
     const exitCode = await runHeadlessClientCommand(['query', 'workflows'], {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -7,6 +7,7 @@ import type { MessageBus } from '@invoker/transport';
 import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { isHeadlessMutatingCommand } from './headless-command-classification.js';
 import {
+  delegationTimeoutMs,
   tryDelegateExec,
   tryDelegateQuery,
   tryDelegateQueryUiPerf,
@@ -67,7 +68,8 @@ async function delegateMutation(args: string[], bus: MessageBus, waitForApproval
     if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
     return tryDelegateResume(workflowId, bus, waitForApproval, noTrack);
   }
-  return tryDelegateExec(args, bus, waitForApproval, noTrack);
+  const timeoutMs = noTrack ? 8_000 : delegationTimeoutMs(args);
+  return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
 }
 
 async function delegateReadOnlyQuery(args: string[], bus: MessageBus): Promise<boolean> {
@@ -134,7 +136,8 @@ async function delegateReadOnlyQuery(args: string[], bus: MessageBus): Promise<b
 
 export interface HeadlessClientDeps {
   messageBus: MessageBus;
-  ensureStandaloneOwner: () => Promise<void>;
+  ensureStandaloneOwner: (bus?: MessageBus) => Promise<void>;
+  refreshMessageBus?: () => Promise<MessageBus>;
   runElectronHeadless: (args: string[]) => Promise<number>;
 }
 
@@ -181,6 +184,7 @@ export async function runHeadlessClientCommand(
   // even for commands that do not boot the full Electron owner process.
   loadConfig();
 
+  let messageBus = deps.messageBus;
   const { args, waitForApproval, noTrack } = parseArgs(argv);
   const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
   const internalOwnerServe = args[0] === 'owner-serve';
@@ -189,7 +193,7 @@ export async function runHeadlessClientCommand(
     return typeof exitCode === 'number' ? exitCode : 0;
   };
 
-  if (!standaloneMode && !internalOwnerServe && await delegateReadOnlyQuery(args, deps.messageBus)) {
+  if (!standaloneMode && !internalOwnerServe && await delegateReadOnlyQuery(args, messageBus)) {
     return resolvedExitCode();
   }
 
@@ -197,14 +201,27 @@ export async function runHeadlessClientCommand(
     return deps.runElectronHeadless(argv);
   }
 
-  const owner = await tryPingHeadlessOwner(deps.messageBus, 3_000);
+  const owner = await tryPingHeadlessOwner(messageBus, 3_000);
   if (owner) {
-    if (await delegateMutation(args, deps.messageBus, waitForApproval, noTrack)) {
+    if (await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
       return resolvedExitCode();
     }
   }
-  await deps.ensureStandaloneOwner();
-  if (await delegateMutation(args, deps.messageBus, waitForApproval, noTrack)) {
+  if (owner && deps.refreshMessageBus) {
+    messageBus = await deps.refreshMessageBus();
+    const refreshedOwner = await tryPingHeadlessOwner(messageBus, 1_000);
+    if (refreshedOwner && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+      return resolvedExitCode();
+    }
+  }
+  if (deps.refreshMessageBus) {
+    messageBus = await deps.refreshMessageBus();
+  }
+  await deps.ensureStandaloneOwner(messageBus);
+  if (deps.refreshMessageBus) {
+    messageBus = await deps.refreshMessageBus();
+  }
+  if (await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
     return resolvedExitCode();
   }
   process.stderr.write(
@@ -214,12 +231,19 @@ export async function runHeadlessClientCommand(
 }
 
 export async function runHeadlessClient(argv: string[]): Promise<number> {
-  const bus = new IpcBus(undefined, { allowServe: false });
+  let bus = new IpcBus(undefined, { allowServe: false });
+  const refreshMessageBus = async (): Promise<MessageBus> => {
+    bus.disconnect();
+    bus = new IpcBus(undefined, { allowServe: false });
+    await bus.ready();
+    return bus;
+  };
   try {
     await bus.ready();
     return await runHeadlessClientCommand(argv, {
       messageBus: bus,
       ensureStandaloneOwner: () => ensureStandaloneOwnerViaBootstrap(bus),
+      refreshMessageBus,
       runElectronHeadless,
     });
   } finally {

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -149,6 +149,16 @@ function setupSpawnMock(): {
   return { gitProcesses, taskProcess };
 }
 
+async function waitForCondition(predicate: () => boolean, timeoutMs = 500): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('timed out waiting for condition');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
 describe('computeBranchHash', () => {
   it('is deterministic: same inputs produce same hash', () => {
     const a = computeBranchHash('t1', 'echo hi', undefined, ['c1'], 'HEAD1');
@@ -463,6 +473,139 @@ describe('WorktreeExecutor', () => {
     vi.mocked(process.kill).mockRestore();
   });
 
+  it('kill terminates provisioning without removing the worktree', async () => {
+    const handle = { executionId: 'exec-provision-1', taskId: 'action-1' };
+    vi.spyOn(executor as any, 'createHandle').mockReturnValue(handle);
+
+    const installProc = createMockProcess();
+    mockedSpawn.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (cmd === 'git') {
+        const gitProc = createMockProcess();
+        Promise.resolve().then(() => {
+          const argsArr = args as string[];
+          if (argsArr?.includes('rev-parse')) {
+            gitProc.stdout!.emit('data', Buffer.from('abc123\n'));
+          }
+          gitProc.emit('close', 0, null);
+        });
+        return gitProc as any;
+      }
+
+      const argsArr = args as string[] | undefined;
+      if (cmd === '/bin/bash' && argsArr?.[1]?.includes('pnpm install')) {
+        return installProc as any;
+      }
+
+      throw new Error(`unexpected spawn: ${cmd}`);
+    });
+
+    const startPromise = executor.start(makeRequest({ inputs: { command: 'sleep 60' } }));
+    const startResult = startPromise.then(
+      () => ({ ok: true as const }),
+      (error) => ({ ok: false as const, error }),
+    );
+    await waitForCondition(() => (executor as any).entries.has(handle.executionId));
+
+    vi.spyOn(process, 'kill').mockImplementation((_pid, _signal?) => {
+      setTimeout(() => installProc.emit('close', null, 'SIGTERM'), 0);
+      return true;
+    });
+
+    await executor.kill(handle);
+    const startOutcome = await startResult;
+    expect(startOutcome.ok).toBe(false);
+    expect(String((startOutcome as { error: Error }).error)).toMatch(/Worktree provisioning failed/);
+
+    const removeCalls = mockedSpawn.mock.calls.filter(
+      (call) =>
+        call[0] === 'git' &&
+        (call[1] as string[])?.includes('worktree') &&
+        (call[1] as string[])?.includes('remove'),
+    );
+    expect(removeCalls.length).toBe(0);
+    expect((executor as any).entries.has(handle.executionId)).toBe(false);
+
+    vi.mocked(process.kill).mockRestore();
+  });
+
+  it('destroyAll terminates provisioning processes without removing worktrees', async () => {
+    const handles = [
+      { executionId: 'exec-provision-1', taskId: 'action-1' },
+      { executionId: 'exec-provision-2', taskId: 'action-2' },
+    ];
+    vi.spyOn(executor as any, 'createHandle')
+      .mockReturnValueOnce(handles[0])
+      .mockReturnValueOnce(handles[1]);
+
+    const installProcs = [createMockProcess(), createMockProcess()];
+    let installIndex = 0;
+    mockedSpawn.mockImplementation((cmd: string, args?: readonly string[]) => {
+      if (cmd === 'git') {
+        const gitProc = createMockProcess();
+        Promise.resolve().then(() => {
+          const argsArr = args as string[];
+          if (argsArr?.includes('rev-parse')) {
+            gitProc.stdout!.emit('data', Buffer.from('abc123\n'));
+          }
+          gitProc.emit('close', 0, null);
+        });
+        return gitProc as any;
+      }
+
+      const argsArr = args as string[] | undefined;
+      if (cmd === '/bin/bash' && argsArr?.[1]?.includes('pnpm install')) {
+        return installProcs[installIndex++] as any;
+      }
+
+      throw new Error(`unexpected spawn: ${cmd}`);
+    });
+
+    const startPromise1 = executor.start(
+      makeRequest({ requestId: 'req-1', actionId: 'action-1', inputs: { command: 'sleep 60' } }),
+    );
+    const startResult1 = startPromise1.then(
+      () => ({ ok: true as const }),
+      (error) => ({ ok: false as const, error }),
+    );
+    const startPromise2 = executor.start(
+      makeRequest({ requestId: 'req-2', actionId: 'action-2', inputs: { command: 'sleep 60' } }),
+    );
+    const startResult2 = startPromise2.then(
+      () => ({ ok: true as const }),
+      (error) => ({ ok: false as const, error }),
+    );
+    await waitForCondition(() => (executor as any).entries.size === 2);
+
+    vi.spyOn(process, 'kill').mockImplementation((_pid, _signal?) => {
+      for (const proc of installProcs) {
+        if (!(proc as any)._closed) {
+          (proc as any)._closed = true;
+          setTimeout(() => proc.emit('close', null, 'SIGTERM'), 0);
+        }
+      }
+      return true;
+    });
+
+    await executor.destroyAll();
+    const outcome1 = await startResult1;
+    const outcome2 = await startResult2;
+    expect(outcome1.ok).toBe(false);
+    expect(String((outcome1 as { error: Error }).error)).toMatch(/Worktree provisioning failed/);
+    expect(outcome2.ok).toBe(false);
+    expect(String((outcome2 as { error: Error }).error)).toMatch(/Worktree provisioning failed/);
+
+    const removeCalls = mockedSpawn.mock.calls.filter(
+      (call) =>
+        call[0] === 'git' &&
+        (call[1] as string[])?.includes('worktree') &&
+        (call[1] as string[])?.includes('remove'),
+    );
+    expect(removeCalls.length).toBe(0);
+    expect((executor as any).entries.size).toBe(0);
+
+    vi.mocked(process.kill).mockRestore();
+  });
+
   it('handles git worktree creation failure gracefully', async () => {
     setupSpawnMock();
 
@@ -589,7 +732,10 @@ describe('WorktreeExecutor', () => {
       getClonePath: vi.fn().mockReturnValue('/fake/cache/clone'),
     };
     (executor as any).pool = pool;
-    vi.spyOn(executor as any, 'provisionWorktree').mockRejectedValue(new Error('lockfile mismatch'));
+    vi.spyOn(executor as any, 'provisionWorktree').mockReturnValue({
+      child: createMockProcess(),
+      completion: Promise.reject(new Error('lockfile mismatch')),
+    });
 
     const err = await executor.start(makeRequest()).catch((e: unknown) => e as Error & { workspacePath?: string; branch?: string });
 

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -44,6 +44,7 @@ interface WorktreeEntry extends BaseEntry {
   process: ChildProcess | null;
   worktreeDir: string;
   branch: string;
+  phase: 'preparing' | 'provisioning' | 'running' | 'completed';
   /** Full pool release: git worktree remove (used on provision failure, not on destroyAll). */
   poolRelease?: () => Promise<void>;
   /** Soft-release: frees the pool slot without removing the worktree from disk. */
@@ -149,6 +150,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         request,
         worktreeDir: acquired.worktreePath,
         branch: acquired.branch,
+        phase: 'preparing',
         outputListeners: new Set(),
         outputBuffer: [],
         outputBufferBytes: 0,
@@ -211,6 +213,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
           const parsed = parseMergeError(exitCode, stderr);
           const entry: WorktreeEntry = {
             process: null, request, worktreeDir: acquired.worktreePath, branch,
+            phase: 'completed',
             outputListeners: new Set(), outputBuffer: [],
             outputBufferBytes: 0, evictedChunkCount: 0,
             completeListeners: new Set(), heartbeatListeners: new Set(),
@@ -247,6 +250,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     if (!request.inputs.command && !request.inputs.prompt) {
       const entry: WorktreeEntry = {
         process: null, request, worktreeDir: acquired.worktreePath, branch,
+        phase: 'preparing',
         outputListeners: new Set(), outputBuffer: [],
         outputBufferBytes: 0, evictedChunkCount: 0,
         completeListeners: new Set(), heartbeatListeners: new Set(),
@@ -258,16 +262,45 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       handle.workspacePath = acquired.worktreePath;
       handle.branch = acquired.branch;
       await this.handleProcessExit(executionId, request, acquired.worktreePath, 0, { branch });
+      entry.phase = 'completed';
       entry.poolSoftRelease?.();
       return handle;
     }
 
+    const entry: WorktreeEntry = {
+      process: null,
+      request,
+      worktreeDir: acquired.worktreePath,
+      branch: acquired.branch,
+      phase: 'provisioning',
+      outputListeners: new Set(),
+      outputBuffer: [],
+      outputBufferBytes: 0,
+      evictedChunkCount: 0,
+      completeListeners: new Set(),
+      heartbeatListeners: new Set(),
+      completed: false,
+      poolRelease: acquired.release,
+      poolSoftRelease: acquired.softRelease,
+    };
+    this.registerEntry(handle, entry);
+    handle.workspacePath = acquired.worktreePath;
+    handle.branch = acquired.branch;
+
+    const provisioning = this.provisionWorktree(acquired.worktreePath, executionId);
+    entry.process = provisioning.child;
     try {
-      await this.provisionWorktree(acquired.worktreePath);
+      await provisioning.completion;
+      entry.process = null;
+      entry.phase = 'running';
     } catch (err) {
       // Keep the failed workspace on disk for post-failure debugging/fix flows.
       // Only free the in-memory pool slot so retries are not blocked.
+      entry.process = null;
+      entry.phase = 'completed';
+      entry.completed = true;
       acquired.softRelease();
+      this.entries.delete(executionId);
       const startupErr = err instanceof Error ? err : new Error(String(err));
       (startupErr as Error & { workspacePath?: string; branch?: string }).workspacePath = acquired.worktreePath;
       (startupErr as Error & { workspacePath?: string; branch?: string }).branch = acquired.branch;
@@ -307,27 +340,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       acquired.softRelease();
     });
 
-    const entry: WorktreeEntry = {
-      process: child,
-      request,
-      worktreeDir: acquired.worktreePath,
-      branch: acquired.branch,
-      outputListeners: new Set(),
-      outputBuffer: [],
-      outputBufferBytes: 0,
-      evictedChunkCount: 0,
-      completeListeners: new Set(),
-      heartbeatListeners: new Set(),
-      completed: false,
-      poolRelease: acquired.release,
-      poolSoftRelease: acquired.softRelease,
-      agentSessionId,
-    };
-
-    this.registerEntry(handle, entry);
-    handle.workspacePath = acquired.worktreePath;
-    handle.branch = acquired.branch;
+    entry.process = child;
+    entry.phase = 'running';
     if (agentSessionId) {
+      entry.agentSessionId = agentSessionId;
       handle.agentSessionId = agentSessionId;
     }
 
@@ -361,6 +377,8 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         branch,
         agentSessionId: entry.agentSessionId,
       });
+      entry.process = null;
+      entry.phase = 'completed';
       entry.poolSoftRelease?.();
     });
 
@@ -539,17 +557,17 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     }
   }
 
-  private provisionWorktree(dir: string, executionId?: string): Promise<void> {
+  private provisionWorktree(dir: string, executionId?: string): { child: ChildProcess; completion: Promise<void> } {
     traceExecution(`[WorktreeExecutor] provisionWorktree begin dir=${dir}`);
     const t0 = Date.now();
-    return new Promise((resolve, reject) => {
-      const cmd = `set -euo pipefail; ${DEFAULT_WORKTREE_PROVISION_COMMAND}`;
-      const child = spawn('/bin/bash', ['-c', cmd], {
-        cwd: dir,
-        env: cleanElectronEnv(),
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-      traceExecution(`[WorktreeExecutor] provisionWorktree spawned pid=${child.pid}`);
+    const cmd = `set -euo pipefail; ${DEFAULT_WORKTREE_PROVISION_COMMAND}`;
+    const child = spawn('/bin/bash', ['-c', cmd], {
+      cwd: dir,
+      env: cleanElectronEnv(),
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    traceExecution(`[WorktreeExecutor] provisionWorktree spawned pid=${child.pid}`);
+    const completion = new Promise<void>((resolve, reject) => {
       let stdout = '';
       let stderr = '';
       child.stdout?.on('data', (d: Buffer) => {
@@ -568,15 +586,17 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         traceExecution(`[WorktreeExecutor] provisionWorktree error: ${err.message}`);
         reject(new Error(`Failed to spawn provisioning process: ${err.message}`));
       });
-      child.on('close', (code) => {
-        traceExecution(`[WorktreeExecutor] provisionWorktree finished dir=${dir} code=${code} elapsed=${Date.now() - t0}ms`);
+      child.on('close', (code, signal) => {
+        traceExecution(`[WorktreeExecutor] provisionWorktree finished dir=${dir} code=${code} signal=${signal ?? 'none'} elapsed=${Date.now() - t0}ms`);
         if (code === 0) resolve();
         else {
+          const exitCode = code ?? (signal ? 1 : 0);
           const combined = [stderr.trim(), stdout.trim()].filter(Boolean).join('\n');
-          reject(new Error(`Worktree provisioning failed in ${dir} (exit ${code}): ${combined}`));
+          reject(new Error(`Worktree provisioning failed in ${dir} (exit ${exitCode}): ${combined}`));
         }
       });
     });
+    return { child, completion };
   }
 
 }

--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -44,8 +44,11 @@ catalog() {
   cat <<EOF
 mixed-control-plane-storm|headless-standalone|core|mixed_mutation_storm|mixed_resets_cancels_retries|12|14|run_mixed_control_plane_storm
 late-return-rejection-under-storm|headless-standalone|core|stale_worker_response|recreate_and_reject_stale|12|8|run_late_return_rejection_under_storm
+owner-restart-during-active-load|headless-standalone|core|owner_restart_churn|restart_and_recover|10|10|run_owner_restart_during_active_load
 delete-all-under-load|headless-standalone|destructive|global_destructive|delete_all|10|6|run_delete_all_under_load
+repeated-delete-all-under-load|headless-standalone|destructive|repeated_global_destructive|delete_all_repeated|10|10|run_repeated_delete_all_under_load
 tracked-approve-zero-running-hang|headless-standalone|hang|false_idle_tracked_mutation|approve_under_starvation|8|6|run_tracked_approve_zero_running_hang
+tracked-fix-churn-under-load|headless-standalone|hang|tracked_fix_starvation|fix_under_neighbor_churn|8|10|run_tracked_fix_churn_under_load
 owner-bootstrap-under-saturated-mutations|headless-standalone|hang|delegation_starvation|delegate_under_saturation|8|8|run_owner_bootstrap_under_saturated_mutations
 fixing-with-ai-visibility|headless-standalone|hang|fixing_state_visibility|fix_under_timeout|6|1|run_fixing_with_ai_visibility
 EOF
@@ -834,6 +837,85 @@ run_fixing_with_ai_visibility() {
   invoker_e2e_assert_no_owned_headless_processes 1
 }
 
+run_tracked_fix_churn_under_load() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN=""
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_LABELS="tracked-fix"
+  ov_start_owner
+
+  local target_info target_workflow target_task
+  target_info="$(ov_submit_workflow fail "tracked-fix-target" "" no-track)"
+  target_workflow="${target_info%%|*}"
+  target_task="$target_workflow/root"
+  echo "seed tracked fix target: $target_workflow"
+  ov_wait_task_status "$target_task" failed 30
+
+  local -a fail_workflows=()
+  local -a approval_workflows=()
+  local idx info workflow_id
+  for idx in $(seq 1 3); do
+    info="$(ov_submit_workflow fail "tracked-fix-neighbor-fail-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    fail_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/root" failed 30
+  done
+  for idx in $(seq 1 2); do
+    info="$(ov_submit_workflow approval "tracked-fix-neighbor-approval-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    approval_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/approve-me" awaiting_approval 30
+  done
+
+  echo "==> overload: starting tracked fix with overlapping neighbor churn"
+  ov_spawn_command_timed "tracked-fix" 90 invoker_e2e_run_headless fix "$target_task" codex
+  ov_wait_task_status_any "$target_task" "fixing_with_ai,awaiting_approval,completed,failed" 30
+
+  for idx in $(seq 0 $((operation_burst - 1))); do
+    case $((idx % 6)) in
+      0) workflow_id="${fail_workflows[$((idx % ${#fail_workflows[@]}))]}"; ov_spawn_command "recreate-fail-$idx" invoker_e2e_run_headless --no-track recreate "$workflow_id" ;;
+      1) workflow_id="${fail_workflows[$((idx % ${#fail_workflows[@]}))]}"; ov_spawn_command "retry-fail-$idx" invoker_e2e_run_headless --no-track retry "$workflow_id" ;;
+      2) workflow_id="${approval_workflows[$((idx % ${#approval_workflows[@]}))]}"; ov_spawn_command "approve-$idx" invoker_e2e_run_headless --no-track approve "$workflow_id/approve-me" ;;
+      3) workflow_id="${approval_workflows[$((idx % ${#approval_workflows[@]}))]}"; ov_spawn_command "reject-$idx" invoker_e2e_run_headless --no-track reject "$workflow_id/approve-me" "tracked fix churn reject" ;;
+      4) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
+      5) ov_spawn_command "query-workflows-$idx" invoker_e2e_run_headless query workflows --output jsonl ;;
+    esac
+  done
+
+  ov_detect_false_idle "$target_workflow" "tracked-fix" 45
+  ov_wait_background_commands
+
+  local tracked_status target_status
+  tracked_status="$(cat "${OVERLOAD_TMP_DIR}/tracked-fix.code" 2>/dev/null || echo 1)"
+  target_status="$(invoker_e2e_task_status "$target_task" 2>/dev/null || true)"
+  if [ "${tracked_status:-1}" -eq 124 ] || [ "${tracked_status:-1}" -eq 137 ] || [ "${tracked_status:-1}" -eq 143 ]; then
+    if [ "$target_status" = "fixing_with_ai" ] || [ "$target_status" = "review_ready" ] || [ "$target_status" = "awaiting_approval" ]; then
+      echo "FAIL: tracked command hung for $target_task (status=$target_status exit=$tracked_status)" >&2
+      return 1
+    fi
+  elif [ "${tracked_status:-1}" -ne 0 ]; then
+    echo "FAIL: tracked fix command exited with $tracked_status for $target_task" >&2
+    cat "${OVERLOAD_TMP_DIR}/tracked-fix.out" >&2 || true
+    return 1
+  fi
+
+  ov_cancel_all_workflows
+  sleep 2
+  ov_stop_owner
+  ov_wait_queries_healthy 45
+  invoker_e2e_assert_no_stuck_mutation_intents 45
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
 run_mixed_control_plane_storm() {
   local workflow_count="$1"
   local operation_burst="$2"
@@ -1090,6 +1172,128 @@ run_delete_all_under_load() {
   ov_stop_owner
   ov_wait_queries_healthy 30
   invoker_e2e_assert_no_stuck_mutation_intents 30
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
+run_repeated_delete_all_under_load() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN='No tasks found for workflow|Task ".*" not found|Workflow .* not found'
+  ov_start_owner
+
+  local -a workflows=()
+  local idx workflow_id info kind
+  echo "==> overload: seeding workflows before repeated delete-all"
+  for idx in $(seq 1 "$workflow_count"); do
+    case $((idx % 4)) in
+      0) kind="approval" ;;
+      1) kind="slow" ;;
+      2) kind="fail" ;;
+      3) kind="late" ;;
+    esac
+    info="$(ov_submit_workflow "$kind" "repeat-delete-$idx" "${OVERLOAD_TMP_DIR}/repeat-delete-$idx.marker" no-track)"
+    workflow_id="${info%%|*}"
+    workflows+=("$workflow_id")
+  done
+
+  sleep 3
+  echo "==> overload: issuing repeated delete-all bursts"
+  ov_spawn_command "delete-all-1" invoker_e2e_run_headless delete-all
+  sleep 1
+  ov_spawn_command "delete-all-2" invoker_e2e_run_headless delete-all
+  for idx in $(seq 1 "$operation_burst"); do
+    workflow_id="${workflows[$(( (idx - 1) % ${#workflows[@]} ))]}"
+    case $((idx % 5)) in
+      0) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
+      1) ov_spawn_command "query-wf-$idx" invoker_e2e_run_headless query workflows --output label ;;
+      2) ov_spawn_command "query-tasks-$idx" invoker_e2e_run_headless query tasks --workflow "$workflow_id" --output jsonl ;;
+      3) ov_spawn_command "retry-$idx" invoker_e2e_run_headless --no-track retry "$workflow_id" ;;
+      4) ov_spawn_command "recreate-$idx" invoker_e2e_run_headless --no-track recreate "$workflow_id" ;;
+    esac
+  done
+  ov_wait_background_commands
+
+  local remaining max_secs
+  max_secs=60
+  while [ "$max_secs" -gt 0 ]; do
+    remaining="$(ov_count_workflows)"
+    if [ "$remaining" -eq 0 ]; then
+      break
+    fi
+    sleep 1
+    max_secs=$((max_secs - 1))
+  done
+  remaining="$(ov_count_workflows)"
+  if [ "$remaining" -ne 0 ]; then
+    echo "FAIL: delete-all left workflows behind ($remaining remaining)" >&2
+    invoker_e2e_run_headless query workflows --output label >&2 || true
+    return 1
+  fi
+
+  ov_stop_owner
+  ov_wait_queries_healthy 30
+  invoker_e2e_assert_no_stuck_mutation_intents 30
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
+run_owner_restart_during_active_load() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN='timed out waiting for owner response|could not reach a shared owner after bootstrap'
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_LABELS="approve-before-restart,recreate-before-restart,queue-before-restart"
+  ov_start_owner
+
+  local slow_info approval_info slow_workflow approval_workflow
+  slow_info="$(ov_submit_workflow slow "owner-restart-slow" "" no-track)"
+  slow_workflow="${slow_info%%|*}"
+  ov_wait_task_status "$slow_workflow/root" running 120
+  approval_info="$(ov_submit_workflow approval "owner-restart-approval" "" no-track)"
+  approval_workflow="${approval_info%%|*}"
+  ov_wait_task_status "$approval_workflow/approve-me" awaiting_approval 30
+
+  echo "==> overload: mutating before owner restart"
+  ov_spawn_command "approve-before-restart" invoker_e2e_run_headless --no-track approve "$approval_workflow/approve-me"
+  ov_spawn_command "recreate-before-restart" invoker_e2e_run_headless --no-track recreate "$slow_workflow"
+  ov_spawn_command "queue-before-restart" invoker_e2e_run_headless query queue --output json
+  sleep 2
+  ov_stop_owner
+  sleep 1
+  ov_start_owner
+
+  echo "==> overload: verifying post-restart recovery"
+  local idx
+  for idx in $(seq 0 $((operation_burst - 1))); do
+    case $((idx % 4)) in
+      0) ov_spawn_command "approve-after-$idx" invoker_e2e_run_headless --no-track approve "$approval_workflow/approve-me" ;;
+      1) ov_spawn_command "cancel-after-$idx" invoker_e2e_run_headless cancel "$slow_workflow/root" ;;
+      2) ov_spawn_command "queue-after-$idx" invoker_e2e_run_headless query queue --output json ;;
+      3) ov_spawn_command "tasks-after-$idx" invoker_e2e_run_headless query tasks --workflow "$slow_workflow" --output jsonl ;;
+    esac
+  done
+  ov_wait_background_commands
+  ov_wait_queries_healthy 45
+  ov_cancel_all_workflows
+  sleep 2
+  ov_stop_owner
+  invoker_e2e_assert_no_stuck_mutation_intents 45
   invoker_e2e_assert_no_owned_headless_processes 1
 }
 

--- a/scripts/repro/repro-owner-restart-during-active-load.sh
+++ b/scripts/repro/repro-owner-restart-during-active-load.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec timeout "${INVOKER_REPRO_TIMEOUT_SECONDS:-300}" \
+  env INVOKER_CHAOS_OVERLOAD_SCENARIO=owner-restart-during-active-load \
+  ./scripts/e2e-chaos/run-overload.sh


### PR DESCRIPTION
## Summary
This PR hardens shared-owner startup under overload by tracking provisioning processes separately from normal runtime work inside the worktree executor. That gives the headless layer an explicit view of whether the shared mutation owner is still starting up or reconnecting, rather than forcing it to infer that from partial executor state.

## Problem
The shared mutation owner could be misclassified as idle or absent while provisioning work was still in flight during restart churn.

## Root Cause
Provisioning work and steady-state runtime work were mixed together in executor bookkeeping, so owner startup logic had to guess whether the owner was gone, still starting, or already live.

## Approach
Track provisioning processes explicitly and use that state during shared-owner startup and restart handling.

## Why This Fix Is Right
The important concept here is shared-owner startup, not “bootstrap” as jargon. Other headless clients delegate mutations to a single shared owner process, so the startup path needs explicit state for “still provisioning” versus “ready to serve”, especially under overload and restart churn.

## Tradeoffs And Considerations
This adds more executor bookkeeping, but that cost is small compared with the restart and overload bugs caused by treating shared-owner startup as an inference problem.

## Before
```mermaid
flowchart LR
  A[executor] --> B[provisioning and runtime mixed together]
  C[owner startup] --> D[guess whether owner is still busy]
```

## After
```mermaid
flowchart LR
  A[executor] --> B[tracked provisioning processes]
  B --> C[explicit shared-owner startup state]
  C --> D[restart-safe delegation decisions]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Track provisioning processes and harden owner bootstrap`
