### PR TITLE
Harden owner restart shutdown in overload runs

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -507,6 +507,7 @@ if (isHeadless) {
     const readOnlyMode = isHeadlessReadOnlyCommand(cliArgs);
     const mutatingMode = isHeadlessMutatingCommand(cliArgs);
     const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
+    const ownsHeadlessShutdown = standaloneMode && !readOnlyMode && command === 'owner-serve';
     const queueQueryMode = command === 'queue' || (command === 'query' && cliArgs[1] === 'queue');
 
     const delegatedQueueOutputFormat = (): 'json' | 'jsonl' | 'label' | 'text' => {
@@ -900,6 +901,22 @@ if (isHeadless) {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
       exitCode = 1;
     } finally {
+      if (ownsHeadlessShutdown && executorRegistry) {
+        await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
+      }
+      if (ownsHeadlessShutdown && orchestrator) {
+        for (const task of orchestrator.getAllTasks()) {
+          if (task.status === 'running' || task.status === 'fixing_with_ai') {
+            orchestrator.handleWorkerResponse({
+              requestId: `quit-${task.id}`,
+              actionId: task.id,
+              executionGeneration: task.execution.generation ?? 0,
+              status: 'failed',
+              outputs: { exitCode: 1, error: 'Application quit' },
+            });
+          }
+        }
+      }
       if (persistence) persistence.close();
       if (writerLock) writerLock.release();
       if (messageBus) messageBus.disconnect();

--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -45,6 +45,7 @@ catalog() {
 mixed-control-plane-storm|headless-standalone|core|mixed_mutation_storm|mixed_resets_cancels_retries|12|14|run_mixed_control_plane_storm
 late-return-rejection-under-storm|headless-standalone|core|stale_worker_response|recreate_and_reject_stale|12|8|run_late_return_rejection_under_storm
 owner-restart-during-active-load|headless-standalone|core|owner_restart_churn|restart_and_recover|10|10|run_owner_restart_during_active_load
+owner-restart-during-late-return-storm|headless-standalone|core|owner_restart_stale_return|restart_during_recreate|12|10|run_owner_restart_during_late_return_storm
 delete-all-under-load|headless-standalone|destructive|global_destructive|delete_all|10|6|run_delete_all_under_load
 repeated-delete-all-under-load|headless-standalone|destructive|repeated_global_destructive|delete_all_repeated|10|10|run_repeated_delete_all_under_load
 tracked-approve-zero-running-hang|headless-standalone|hang|false_idle_tracked_mutation|approve_under_starvation|8|6|run_tracked_approve_zero_running_hang
@@ -500,14 +501,33 @@ ov_start_owner() {
 }
 
 ov_stop_owner() {
+  local wait_secs=30
+  local waited=0
   if [ -n "${OVERLOAD_OWNER_PID:-}" ]; then
     kill -- "-${OVERLOAD_OWNER_PID}" >/dev/null 2>&1 || kill "${OVERLOAD_OWNER_PID}" >/dev/null 2>&1 || true
     pkill -TERM -P "${OVERLOAD_OWNER_PID}" >/dev/null 2>&1 || true
+    while [ "$waited" -lt "$wait_secs" ]; do
+      if ! kill -0 "${OVERLOAD_OWNER_PID}" >/dev/null 2>&1; then
+        break
+      fi
+      waited=$((waited + 1))
+      sleep 1
+    done
+    if kill -0 "${OVERLOAD_OWNER_PID}" >/dev/null 2>&1; then
+      kill -KILL -- "-${OVERLOAD_OWNER_PID}" >/dev/null 2>&1 || kill -KILL "${OVERLOAD_OWNER_PID}" >/dev/null 2>&1 || true
+    fi
     wait "${OVERLOAD_OWNER_PID}" 2>/dev/null || true
-    unset OVERLOAD_OWNER_PID
+    unset OVERLOAD_OWNER_PID waited
   fi
   pkill -TERM -f 'packages/app/dist/main.js --headless owner-serve' >/dev/null 2>&1 || true
-  sleep 1
+  waited=0
+  while [ "$waited" -lt "$wait_secs" ]; do
+    if ! pgrep -f 'packages/app/dist/main.js --headless owner-serve' >/dev/null 2>&1; then
+      return 0
+    fi
+    waited=$((waited + 1))
+    sleep 1
+  done
   pkill -KILL -f 'packages/app/dist/main.js --headless owner-serve' >/dev/null 2>&1 || true
   sleep 1
 }
@@ -1290,6 +1310,87 @@ run_owner_restart_during_active_load() {
   done
   ov_wait_background_commands
   ov_wait_queries_healthy 45
+  ov_cancel_all_workflows
+  sleep 2
+  ov_stop_owner
+  invoker_e2e_assert_no_stuck_mutation_intents 45
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
+run_owner_restart_during_late_return_storm() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" "${MARKER_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  MARKER_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload-markers.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN=""
+  ov_start_owner
+
+  local -a late_workflows=()
+  local -a filler_workflows=()
+  local idx workflow_id info marker_path
+
+  echo "==> overload: seeding late-return workflows before owner restart"
+  local late_seed_count=3
+  for idx in $(seq 1 "$late_seed_count"); do
+    marker_path="$MARKER_DIR/restart-late-$idx.marker"
+    info="$(ov_submit_workflow late "restart-late-$idx" "$marker_path" no-track)"
+    workflow_id="${info%%|*}"
+    late_workflows+=("$workflow_id")
+    echo "$marker_path" > "$OVERLOAD_TMP_DIR/${workflow_id}.marker"
+    echo "seed late workflow: $workflow_id"
+    ov_wait_task_status "$workflow_id/late" running 120
+  done
+  for idx in $(seq 1 "$((workflow_count - late_seed_count))"); do
+    info="$(ov_submit_workflow fail "restart-filler-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    filler_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/root" failed 30
+  done
+
+  local reset_started_at
+  reset_started_at="$(date -u '+%Y-%m-%d %H:%M:%S')"
+  for workflow_id in "${late_workflows[@]}"; do
+    touch "$(cat "$OVERLOAD_TMP_DIR/${workflow_id}.marker")"
+  done
+
+  echo "==> overload: recreating late workflows before owner restart"
+  for idx in "${!late_workflows[@]}"; do
+    workflow_id="${late_workflows[$idx]}"
+    ov_spawn_command "recreate-late-$idx" invoker_e2e_run_headless --no-track recreate "$workflow_id"
+  done
+  sleep 2
+
+  echo "==> overload: restarting owner mid-storm"
+  ov_stop_owner
+  sleep 1
+  ov_start_owner
+
+  local max_fillers="$((operation_burst - ${#late_workflows[@]}))"
+  if [ "$max_fillers" -lt 0 ]; then
+    max_fillers=0
+  fi
+  for idx in $(seq 0 $((max_fillers - 1))); do
+    workflow_id="${filler_workflows[$((idx % ${#filler_workflows[@]}))]}"
+    case $((idx % 3)) in
+      0) ov_spawn_command "retry-filler-$idx" invoker_e2e_run_headless --no-track retry "$workflow_id" ;;
+      1) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
+      2) ov_spawn_command "query-workflows-$idx" invoker_e2e_run_headless query workflows --output jsonl ;;
+    esac
+  done
+  ov_wait_background_commands
+
+  for workflow_id in "${late_workflows[@]}"; do
+    ov_assert_stale_completion_rejected "$workflow_id" "$reset_started_at"
+  done
+  ov_wait_queries_healthy 60
   ov_cancel_all_workflows
   sleep 2
   ov_stop_owner


### PR DESCRIPTION
## Summary
Standalone owner shutdown now takes explicit responsibility for draining in-flight work before process exit. When the headless owner is quitting, it destroys executors and marks running or fixing tasks failed instead of relying on generic teardown, which prevents late responses from a half-dead owner from polluting the restart path.

## Exact Failure / Symptom
Owner restart loops could inherit stale late-return effects from the previous owner instead of starting from a clean failed state.

## Root Cause
Shutdown depended on generic teardown behavior that did not explicitly fail or drain running work before the owner disappeared.

## Approach
Make standalone shutdown destroy executors and mark in-flight work failed before persistence and bus teardown.

## Why This Fix Is Right
A forceful owner restart path should leave the system in a deterministic failed state, not in a partially alive state where late returns can still mutate state.

## Tradeoffs And Considerations
This is a more aggressive shutdown path than graceful teardown. That is acceptable because the overload restart harness is explicitly testing restart safety, not graceful long-lived process shutdown.

## Before
```mermaid
flowchart LR
  subgraph Before
    A[standalone owner exit] --> B[persistence close]
    A --> C[bus disconnect]
    D[running tasks] -. late responses .-> E[orphaned state]
  end
```

## After
```mermaid
flowchart LR
  subgraph After
    F[standalone owner exit] --> G[destroy executors]
    G --> H[fail running/fixing tasks]
    H --> I[persistence close + bus disconnect]
  end
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Harden owner restart shutdown in overload runs`
