### PR TITLE
Add owner restart late-return repro wrapper

### DIFF
--- a/scripts/repro/repro-owner-restart-during-late-return-storm.sh
+++ b/scripts/repro/repro-owner-restart-during-late-return-storm.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec timeout "${INVOKER_REPRO_TIMEOUT_SECONDS:-600}" \
+  env \
+    INVOKER_CHAOS_OVERLOAD_MODE=nightly \
+    INVOKER_CHAOS_OVERLOAD_SCENARIO=owner-restart-during-late-return-storm@nightly \
+    ./scripts/e2e-chaos/run-overload.sh


### PR DESCRIPTION
## Summary
This adds a thin repro entrypoint for the nightly `owner-restart-during-late-return-storm` scenario. It does not change runtime behavior; it gives the restart and late-return failure mode a stable command-line wrapper with the right timeout and environment so the chaos harness is easy to invoke and share.

## Root Cause
The restart-plus-late-return scenario was reproducible only through an implicit overload invocation, which made it harder to run and reason about consistently.

## Approach
Add a dedicated wrapper script that binds the correct overload scenario and runtime parameters.

## Tradeoffs And Considerations
This adds another small repro script, but it keeps scenario selection explicit and avoids cluttering the shared harness with more hand-tuned entry logic.

## Validation
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Add owner restart late-return repro wrapper`
