### PR TITLE
Retry owner restarts for queue queries and restart loops

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { LocalBus } from '@invoker/transport';
 
-import { runHeadlessClientCommand } from '../headless-client.js';
+import { SharedMutationOwnerTimeoutError, runHeadlessClientCommand } from '../headless-client.js';
 
 describe('headless-client', () => {
   it('delegates mutating commands to an existing owner without electron fallback', async () => {
@@ -93,6 +93,101 @@ describe('headless-client', () => {
 
     expect(exitCode).toBe(0);
     expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+  }, 15_000);
+
+  it('retries bootstrap once after a stale-bus timeout', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    const ownerHandler = vi.fn(async () => ({ ok: true }));
+    let bootstrapCalls = 0;
+
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-4', mode: 'standalone' }));
+    secondBus.onRequest('headless.exec', ownerHandler);
+
+    const ensureStandaloneOwner = vi.fn(async () => {
+      bootstrapCalls += 1;
+      if (bootstrapCalls === 1) {
+        throw new SharedMutationOwnerTimeoutError();
+      }
+    });
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(firstBus)
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValue(secondBus);
+
+    const exitCode = await runHeadlessClientCommand(['recreate', 'wf-22', '--no-track'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(2);
+    expect(ownerHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries post-bootstrap delegation until a restarted owner is reachable', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    let pingCalls = 0;
+    let execCalls = 0;
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValue(secondBus);
+
+    secondBus.onRequest('headless.owner-ping', async () => {
+      pingCalls += 1;
+      return pingCalls >= 2 ? { ok: true, ownerId: 'owner-5', mode: 'standalone' } : null;
+    });
+    secondBus.onRequest('headless.exec', async () => {
+      execCalls += 1;
+      return { ok: true };
+    });
+
+    const exitCode = await runHeadlessClientCommand(['recreate', 'wf-23', '--no-track'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+    expect(execCalls).toBe(1);
+    expect(pingCalls).toBeGreaterThanOrEqual(2);
+  });
+
+  it('refreshes and retries queue queries when owner ping succeeds before query service is ready', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    let queueCalls = 0;
+
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-6', mode: 'standalone' }));
+    secondBus.onRequest('headless.query', async () => {
+      queueCalls += 1;
+      if (queueCalls === 1) {
+        return await new Promise(() => {});
+      }
+      return { running: [], queued: [], runningCount: 0, maxConcurrency: 5 };
+    });
+
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValue(secondBus);
+
+    const exitCode = await runHeadlessClientCommand(['query', 'queue', '--output', 'json'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      refreshMessageBus,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(queueCalls).toBe(2);
+    expect(refreshMessageBus).toHaveBeenCalled();
   }, 15_000);
 
   it('retries no-track delegated mutations after the first owner request times out', async () => {
@@ -198,7 +293,7 @@ describe('headless-client', () => {
         runElectronHeadless: vi.fn(async () => 0),
       }),
     ).rejects.toThrow(/requires a running shared owner process/);
-  });
+  }, 30_000);
 
   it('delegates query queue to an existing owner without electron fallback', async () => {
     const bus = new LocalBus();

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -58,6 +58,20 @@ async function runElectronHeadless(args: string[]): Promise<number> {
 
 const DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS = 8_000;
 const POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS = 90_000;
+const POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS = 20_000;
+const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
+const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 8_000;
+
+export class SharedMutationOwnerTimeoutError extends Error {
+  constructor(message: string = 'Timed out waiting for a shared mutation owner to become available') {
+    super(message);
+    this.name = 'SharedMutationOwnerTimeoutError';
+  }
+}
+
+export function isSharedMutationOwnerTimeoutError(error: unknown): error is SharedMutationOwnerTimeoutError {
+  return error instanceof SharedMutationOwnerTimeoutError;
+}
 
 async function delegateMutation(
   args: string[],
@@ -81,17 +95,25 @@ async function delegateMutation(
   return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
 }
 
-async function delegateReadOnlyQuery(args: string[], bus: MessageBus): Promise<boolean> {
+async function delegateReadOnlyQuery(
+  args: string[],
+  bus: MessageBus,
+  refreshMessageBus?: () => Promise<MessageBus>,
+): Promise<boolean> {
   const isUiPerf = args[0] === 'query' && args[1] === 'ui-perf';
   const isQueue = (args[0] === 'query' && args[1] === 'queue') || args[0] === 'queue';
   if (!isUiPerf && !isQueue) {
     return false;
   }
-  const deadline = Date.now() + 8_000;
+  const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
+  let messageBus = bus;
   let owner: { ownerId?: string; mode?: string } | null = null;
   while (Date.now() < deadline) {
-    owner = await tryPingHeadlessOwner(bus, 2_000);
+    owner = await tryPingHeadlessOwner(messageBus, 2_000);
     if (owner) break;
+    if (refreshMessageBus) {
+      messageBus = await refreshMessageBus();
+    }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   if (!owner) {
@@ -103,11 +125,14 @@ async function delegateReadOnlyQuery(args: string[], bus: MessageBus): Promise<b
   while (Date.now() < deadline) {
     if (isUiPerf) {
       const reset = args.includes('--reset');
-      response = await tryDelegateQueryUiPerf(bus, reset, 5_000);
+      response = await tryDelegateQueryUiPerf(messageBus, reset, READ_ONLY_QUERY_REQUEST_TIMEOUT_MS);
     } else {
-      response = await tryDelegateQuery(bus, { kind: 'queue' }, 5_000);
+      response = await tryDelegateQuery(messageBus, { kind: 'queue' }, READ_ONLY_QUERY_REQUEST_TIMEOUT_MS);
     }
     if (response) break;
+    if (refreshMessageBus) {
+      messageBus = await refreshMessageBus();
+    }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   if (!response) {
@@ -143,6 +168,34 @@ async function delegateReadOnlyQuery(args: string[], bus: MessageBus): Promise<b
   return true;
 }
 
+async function delegateAfterBootstrap(
+  args: string[],
+  deps: Pick<HeadlessClientDeps, 'refreshMessageBus'>,
+  bus: MessageBus,
+  waitForApproval?: boolean,
+  noTrack?: boolean,
+): Promise<boolean> {
+  const deadline = Date.now() + POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS;
+  let messageBus = bus;
+  while (Date.now() < deadline) {
+    const owner = await tryPingHeadlessOwner(messageBus, 1_000);
+    if (owner && await delegateMutation(
+      args,
+      messageBus,
+      waitForApproval,
+      noTrack,
+      noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
+    )) {
+      return true;
+    }
+    if (deps.refreshMessageBus) {
+      messageBus = await deps.refreshMessageBus();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  return false;
+}
+
 export interface HeadlessClientDeps {
   messageBus: MessageBus;
   ensureStandaloneOwner: (bus?: MessageBus) => Promise<void>;
@@ -163,7 +216,7 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
       if (owner) return;
       await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
     }
-    throw new Error('Timed out waiting for a shared mutation owner to become available');
+    throw new SharedMutationOwnerTimeoutError();
   } finally {
     bootstrapLock?.release();
   }
@@ -202,7 +255,7 @@ export async function runHeadlessClientCommand(
     return typeof exitCode === 'number' ? exitCode : 0;
   };
 
-  if (!standaloneMode && !internalOwnerServe && await delegateReadOnlyQuery(args, messageBus)) {
+  if (!standaloneMode && !internalOwnerServe && await delegateReadOnlyQuery(args, messageBus, deps.refreshMessageBus)) {
     return resolvedExitCode();
   }
 
@@ -226,16 +279,27 @@ export async function runHeadlessClientCommand(
   if (deps.refreshMessageBus) {
     messageBus = await deps.refreshMessageBus();
   }
-  await deps.ensureStandaloneOwner(messageBus);
+  try {
+    await deps.ensureStandaloneOwner(messageBus);
+  } catch (err) {
+    if (!isSharedMutationOwnerTimeoutError(err)) {
+      throw err;
+    }
+    if (!deps.refreshMessageBus) {
+      throw err;
+    }
+    messageBus = await deps.refreshMessageBus();
+    await deps.ensureStandaloneOwner(messageBus);
+  }
   if (deps.refreshMessageBus) {
     messageBus = await deps.refreshMessageBus();
   }
-  if (await delegateMutation(
+  if (await delegateAfterBootstrap(
     args,
+    deps,
     messageBus,
     waitForApproval,
     noTrack,
-    noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
   )) {
     return resolvedExitCode();
   }

--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -46,6 +46,7 @@ mixed-control-plane-storm|headless-standalone|core|mixed_mutation_storm|mixed_re
 late-return-rejection-under-storm|headless-standalone|core|stale_worker_response|recreate_and_reject_stale|12|8|run_late_return_rejection_under_storm
 owner-restart-during-active-load|headless-standalone|core|owner_restart_churn|restart_and_recover|10|10|run_owner_restart_during_active_load
 owner-restart-during-late-return-storm|headless-standalone|core|owner_restart_stale_return|restart_during_recreate|12|10|run_owner_restart_during_late_return_storm
+owner-restart-loop-during-late-return-storm|headless-standalone|core|owner_restart_loop_stale_return|restart_loop_during_recreate|12|12|run_owner_restart_loop_during_late_return_storm
 delete-all-under-load|headless-standalone|destructive|global_destructive|delete_all|10|6|run_delete_all_under_load
 repeated-delete-all-under-load|headless-standalone|destructive|repeated_global_destructive|delete_all_repeated|10|10|run_repeated_delete_all_under_load
 tracked-approve-zero-running-hang|headless-standalone|hang|false_idle_tracked_mutation|approve_under_starvation|8|6|run_tracked_approve_zero_running_hang
@@ -1391,6 +1392,104 @@ run_owner_restart_during_late_return_storm() {
     ov_assert_stale_completion_rejected "$workflow_id" "$reset_started_at"
   done
   ov_wait_queries_healthy 60
+  ov_cancel_all_workflows
+  sleep 2
+  ov_stop_owner
+  invoker_e2e_assert_no_stuck_mutation_intents 45
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
+run_owner_restart_loop_during_late_return_storm() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" "${MARKER_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  MARKER_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload-markers.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN=""
+  ov_start_owner
+
+  local -a late_workflows=()
+  local -a filler_workflows=()
+  local idx workflow_id info marker_path
+
+  echo "==> overload: seeding late-return workflows before restart loop"
+  local late_seed_count=3
+  for idx in $(seq 1 "$late_seed_count"); do
+    marker_path="$MARKER_DIR/restart-loop-late-$idx.marker"
+    info="$(ov_submit_workflow late "restart-loop-late-$idx" "$marker_path" no-track)"
+    workflow_id="${info%%|*}"
+    late_workflows+=("$workflow_id")
+    echo "$marker_path" > "$OVERLOAD_TMP_DIR/${workflow_id}.marker"
+    echo "seed late workflow: $workflow_id"
+    ov_wait_task_status "$workflow_id/late" running 120
+  done
+  for idx in $(seq 1 "$((workflow_count - late_seed_count))"); do
+    info="$(ov_submit_workflow fail "restart-loop-filler-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    filler_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/root" failed 45
+  done
+
+  local reset_started_at
+  reset_started_at="$(date -u '+%Y-%m-%d %H:%M:%S')"
+  for workflow_id in "${late_workflows[@]}"; do
+    touch "$(cat "$OVERLOAD_TMP_DIR/${workflow_id}.marker")"
+  done
+
+  echo "==> overload: recreating late workflows before restart loop"
+  for idx in "${!late_workflows[@]}"; do
+    workflow_id="${late_workflows[$idx]}"
+    ov_spawn_command "recreate-late-$idx" invoker_e2e_run_headless --no-track recreate "$workflow_id"
+  done
+  sleep 2
+
+  local restart_cycles=3
+  local cycle filler_idx filler_workflow
+  for cycle in $(seq 1 "$restart_cycles"); do
+    echo "==> overload: owner restart cycle $cycle/$restart_cycles"
+    ov_stop_owner
+    sleep 1
+    ov_start_owner
+
+    filler_idx=$((cycle - 1))
+    if [ "${#filler_workflows[@]}" -gt 0 ]; then
+      filler_workflow="${filler_workflows[$((filler_idx % ${#filler_workflows[@]}))]}"
+      ov_spawn_command "retry-filler-cycle-$cycle" invoker_e2e_run_headless --no-track retry "$filler_workflow"
+      ov_spawn_command "query-workflows-cycle-$cycle" invoker_e2e_run_headless query workflows --output jsonl
+      ov_spawn_command "query-queue-cycle-$cycle" invoker_e2e_run_headless query queue --output json
+      ov_spawn_command "query-tasks-cycle-$cycle" invoker_e2e_run_headless query tasks --workflow "$filler_workflow" --output jsonl
+    fi
+    sleep 1
+  done
+
+  local max_fillers="$((operation_burst - ${#late_workflows[@]} - (restart_cycles * 2)))"
+  if [ "$max_fillers" -lt 0 ]; then
+    max_fillers=0
+  fi
+  for idx in $(seq 0 $((max_fillers - 1))); do
+    workflow_id="${filler_workflows[$((idx % ${#filler_workflows[@]}))]}"
+    case $((idx % 4)) in
+      0) ov_spawn_command "retry-filler-$idx" invoker_e2e_run_headless --no-track retry "$workflow_id" ;;
+      1) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
+      2) ov_spawn_command "query-workflows-$idx" invoker_e2e_run_headless query workflows --output jsonl ;;
+      3) ov_spawn_command "query-tasks-$idx" invoker_e2e_run_headless query tasks --workflow "$workflow_id" --output jsonl ;;
+    esac
+  done
+
+  ov_wait_background_commands
+
+  for workflow_id in "${late_workflows[@]}"; do
+    ov_assert_stale_completion_rejected "$workflow_id" "$reset_started_at"
+  done
+  ov_wait_queries_healthy 60
+
   ov_cancel_all_workflows
   sleep 2
   ov_stop_owner

--- a/scripts/repro/repro-owner-restart-loop-during-late-return-storm.sh
+++ b/scripts/repro/repro-owner-restart-loop-during-late-return-storm.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec timeout "${INVOKER_REPRO_TIMEOUT_SECONDS:-900}" \
+  env \
+    INVOKER_CHAOS_OVERLOAD_MODE=nightly \
+    INVOKER_CHAOS_OVERLOAD_SCENARIO=owner-restart-loop-during-late-return-storm@nightly \
+    ./scripts/e2e-chaos/run-overload.sh


### PR DESCRIPTION
## Summary
This PR separates owner discovery from request-path readiness in the headless client. The client can now distinguish "there is no reachable shared owner" from "the owner exists, but I am still talking to a stale bus or a not-yet-ready query path."

## Problem
Queries and restart-sensitive requests could fail during owner restart loops even after a replacement owner existed.

## Root Cause
The client treated owner existence and request readiness as the same thing, so stale transport state was misclassified as total owner absence. It also relied on a raw error-message match to decide whether the retry path should continue.

## Approach
Use a two-phase readiness model:
1. ping and bus refresh to rediscover the shared owner
2. bounded retry for the actual delegation or query once the owner is reachable

This PR now routes the retry gate through a typed timeout error instead of a magic string check.

## Why This Fix Is Right
The failure mode here is usually stale transport state during restart churn, not permanently missing infrastructure. Splitting owner discovery from request readiness lets the client repair the bus connection first and only then retry the actual work. Using a typed timeout error keeps that retry path narrow without coupling control flow to string matching.

## Tradeoffs And Considerations
The retry window adds bounded latency before surfacing failure, but only for the narrow restart window this PR targets.

## Before
```mermaid
flowchart LR
  A[client] --> B[ping owner once]
  B --> C[delegate or query on current bus]
  C --> D[stale bus looks like total failure]
```

## After
```mermaid
flowchart LR
  A[client] --> B[owner ping plus bus refresh]
  B --> C[owner rediscovered]
  C --> D[bounded delegate or query retry]
  D --> E[request succeeds after restart churn]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Retry owner restarts for queue queries and restart loops`
