### PR TITLE
Retry post-bootstrap mutations across owner-broker restart loops

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -160,6 +160,41 @@ describe('headless-client', () => {
     expect(pingCalls).toBeGreaterThanOrEqual(2);
   });
 
+  it('re-bootstraps after repeated owner loss during post-bootstrap no-track delegation', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    const thirdBus = new LocalBus();
+    let bootstrapCalls = 0;
+    let refreshCalls = 0;
+    let thirdBusExecCalls = 0;
+
+    const ensureStandaloneOwner = vi.fn(async () => {
+      bootstrapCalls += 1;
+    });
+    const refreshMessageBus = vi.fn(async () => {
+      refreshCalls += 1;
+      return refreshCalls <= 90 ? secondBus : thirdBus;
+    });
+
+    secondBus.onRequest('headless.owner-ping', async () => null);
+    thirdBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-8', mode: 'standalone' }));
+    thirdBus.onRequest('headless.exec', async () => {
+      thirdBusExecCalls += 1;
+      return { ok: true };
+    });
+
+    const exitCode = await runHeadlessClientCommand(['recreate', 'wf-24', '--no-track'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(bootstrapCalls).toBeGreaterThanOrEqual(2);
+    expect(thirdBusExecCalls).toBe(1);
+  }, 30_000);
+
   it('refreshes and retries queue queries when owner ping succeeds before query service is ready', async () => {
     const firstBus = new LocalBus();
     const secondBus = new LocalBus();

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -61,6 +61,7 @@ const POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS = 90_000;
 const POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 8_000;
+const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
 
 export class SharedMutationOwnerTimeoutError extends Error {
   constructor(message: string = 'Timed out waiting for a shared mutation owner to become available') {
@@ -279,29 +280,35 @@ export async function runHeadlessClientCommand(
   if (deps.refreshMessageBus) {
     messageBus = await deps.refreshMessageBus();
   }
-  try {
-    await deps.ensureStandaloneOwner(messageBus);
-  } catch (err) {
-    if (!isSharedMutationOwnerTimeoutError(err)) {
-      throw err;
+  for (let attempt = 0; attempt < POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS; attempt += 1) {
+    try {
+      await deps.ensureStandaloneOwner(messageBus);
+    } catch (err) {
+      if (!isSharedMutationOwnerTimeoutError(err)) {
+        throw err;
+      }
+      if (!deps.refreshMessageBus) {
+        throw err;
+      }
+      messageBus = await deps.refreshMessageBus();
+      await deps.ensureStandaloneOwner(messageBus);
+    }
+    if (deps.refreshMessageBus) {
+      messageBus = await deps.refreshMessageBus();
+    }
+    if (await delegateAfterBootstrap(
+      args,
+      deps,
+      messageBus,
+      waitForApproval,
+      noTrack,
+    )) {
+      return resolvedExitCode();
     }
     if (!deps.refreshMessageBus) {
-      throw err;
+      break;
     }
     messageBus = await deps.refreshMessageBus();
-    await deps.ensureStandaloneOwner(messageBus);
-  }
-  if (deps.refreshMessageBus) {
-    messageBus = await deps.refreshMessageBus();
-  }
-  if (await delegateAfterBootstrap(
-    args,
-    deps,
-    messageBus,
-    waitForApproval,
-    noTrack,
-  )) {
-    return resolvedExitCode();
   }
   process.stderr.write(
     `${RED}Error:${RESET} Mutation command "${args[0] ?? ''}" could not reach a shared owner after bootstrap.\n`,


### PR DESCRIPTION
## Summary
This PR hardens post-bootstrap mutation retries across repeated owner restart loops. It keeps the client in the retry path long enough to refresh its bus connection, rediscover the owner broker process, and retry delegation within a bounded window instead of failing immediately on the first restart race.

## Exact Failure / Symptom
A mutating headless command could still fail after bootstrap if the shared owner disappeared during the handoff from bootstrap to delegation, even though the next owner would have succeeded.

## Root Cause
The client treated one successful bootstrap attempt as enough and did not model the possibility that the owner could restart again before the delegation path was actually ready.

## Approach
Add bounded retry around bus refresh, owner startup, and delegation for post-bootstrap mutation flows.

## Why This Fix Is Right
The process here is best described as an owner broker: it is the local process currently acting as the shared mutation owner and serving delegated commands from peer headless clients. The message bus is the local IPC transport used to discover that broker, route delegated commands, and stream updates. When either side of that handoff restarts, the right fix is bounded recovery rather than immediate failure.

## Tradeoffs And Considerations
This adds some latency in failure cases, but only within a bounded retry window and only for mutation commands that are specifically vulnerable to owner restart churn.

## Before
```mermaid
flowchart TD
  A[CLI mutation] --> B[bootstrap owner once]
  B --> C[delegate over current bus]
  C --> D[owner restarts again]
  D --> E[fail command]
```

## After
```mermaid
flowchart TD
  A[CLI mutation] --> B[refresh bus]
  B --> C[bootstrap or rediscover owner broker]
  C --> D[retry delegation within bounded window]
  D --> E[succeed across restart loop or fail cleanly]
```

## Validation
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Retry post-bootstrap mutations across owner restart loops`
