### PR TITLE
Expand overload matrix for tracked restart loops

### DIFF
--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -53,7 +53,9 @@ delete-all-under-load|headless-standalone|destructive|global_destructive|delete_
 repeated-delete-all-under-load|headless-standalone|destructive|repeated_global_destructive|delete_all_repeated|10|10|run_repeated_delete_all_under_load
 owner-restart-loop-during-delete-all|headless-standalone|destructive|owner_restart_loop_global_destructive|restart_loop_delete_all|10|12|run_owner_restart_loop_during_delete_all
 tracked-approve-zero-running-hang|headless-standalone|hang|false_idle_tracked_mutation|approve_under_starvation|8|6|run_tracked_approve_zero_running_hang
+owner-restart-loop-during-tracked-approve|headless-standalone|hang|owner_restart_loop_tracked_approve_starvation|restart_loop_approve_under_starvation|8|10|run_owner_restart_loop_during_tracked_approve
 tracked-fix-churn-under-load|headless-standalone|hang|tracked_fix_starvation|fix_under_neighbor_churn|8|10|run_tracked_fix_churn_under_load
+owner-restart-loop-during-tracked-fix-churn|headless-standalone|hang|owner_restart_loop_tracked_fix_starvation|restart_loop_fix_under_neighbor_churn|8|12|run_owner_restart_loop_during_tracked_fix_churn
 owner-bootstrap-under-saturated-mutations|headless-standalone|hang|delegation_starvation|delegate_under_saturation|8|8|run_owner_bootstrap_under_saturated_mutations
 fixing-with-ai-visibility|headless-standalone|hang|fixing_state_visibility|fix_under_timeout|6|1|run_fixing_with_ai_visibility
 EOF
@@ -739,6 +741,99 @@ run_tracked_approve_zero_running_hang() {
   invoker_e2e_assert_no_owned_headless_processes 1
 }
 
+run_owner_restart_loop_during_tracked_approve() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN=""
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_LABELS="tracked-approve"
+  ov_start_owner
+
+  local target_info target_workflow target_task
+  target_info="$(ov_submit_workflow approval "restart-loop-tracked-approve-target" "" no-track)"
+  target_workflow="${target_info%%|*}"
+  target_task="$target_workflow/approve-me"
+  echo "seed tracked approve target: $target_workflow"
+  ov_wait_task_status "$target_task" awaiting_approval 30
+
+  local -a filler_workflows=()
+  local filler_count="$((workflow_count - 1))"
+  if [ "$filler_count" -gt 2 ]; then
+    filler_count=2
+  fi
+  local idx info workflow_id
+  for idx in $(seq 1 "$filler_count"); do
+    info="$(ov_submit_workflow slow "restart-loop-tracked-approve-filler-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    filler_workflows+=("$workflow_id")
+    echo "seed filler slow workflow: $workflow_id"
+    ov_wait_task_status "$workflow_id/root" running 120
+  done
+
+  echo "==> overload: starting tracked approve before owner restart loop"
+  ov_spawn_command_timed "tracked-approve" 120 invoker_e2e_run_headless approve "$target_task"
+  sleep 2
+
+  local restart_cycles=3
+  local cycle filler_workflow
+  for cycle in $(seq 1 "$restart_cycles"); do
+    filler_workflow="${filler_workflows[$(((cycle - 1) % ${#filler_workflows[@]}))]}"
+    echo "==> overload: owner restart cycle $cycle/$restart_cycles"
+    ov_spawn_command "cancel-filler-cycle-$cycle" invoker_e2e_run_headless cancel "$filler_workflow/root"
+    ov_spawn_command "query-workflows-cycle-$cycle" invoker_e2e_run_headless query workflows --output jsonl
+    ov_spawn_command "query-queue-cycle-$cycle" invoker_e2e_run_headless query queue --output json
+    ov_stop_owner
+    sleep 1
+    ov_start_owner
+    sleep 1
+  done
+
+  for idx in $(seq 0 $((operation_burst - 1))); do
+    if [ "$idx" -lt "${#filler_workflows[@]}" ]; then
+      workflow_id="${filler_workflows[$idx]}"
+      ov_spawn_command "cancel-filler-$idx" invoker_e2e_run_headless cancel "$workflow_id/root"
+    else
+      case $((idx % 3)) in
+        0) ov_spawn_command "query-workflows-$idx" invoker_e2e_run_headless query workflows --output jsonl ;;
+        1) ov_spawn_command "query-tasks-$idx" invoker_e2e_run_headless query tasks --workflow "$target_workflow" --output jsonl ;;
+        2) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
+      esac
+    fi
+  done
+
+  ov_detect_false_idle "$target_workflow" "tracked-approve" 45
+  ov_wait_background_commands
+
+  local tracked_status target_status
+  tracked_status="$(cat "${OVERLOAD_TMP_DIR}/tracked-approve.code" 2>/dev/null || echo 1)"
+  target_status="$(invoker_e2e_task_status "$target_task" 2>/dev/null || true)"
+  if [ "${tracked_status:-1}" -eq 124 ] || [ "${tracked_status:-1}" -eq 137 ] || [ "${tracked_status:-1}" -eq 143 ]; then
+    if [ "$target_status" != "completed" ] && [ "$target_status" != "failed" ]; then
+      echo "FAIL: tracked command hung for $target_task (status=$target_status exit=$tracked_status)" >&2
+      return 1
+    fi
+  elif [ "${tracked_status:-1}" -ne 0 ]; then
+    echo "FAIL: tracked approve command exited with $tracked_status for $target_task" >&2
+    cat "${OVERLOAD_TMP_DIR}/tracked-approve.out" >&2 || true
+    return 1
+  fi
+
+  ov_cancel_all_workflows
+  sleep 2
+  ov_stop_owner
+  ov_wait_queries_healthy 45
+  invoker_e2e_assert_no_stuck_mutation_intents 45
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
 run_owner_bootstrap_under_saturated_mutations() {
   local workflow_count="$1"
   local operation_burst="$2"
@@ -910,6 +1005,101 @@ run_tracked_fix_churn_under_load() {
       1) workflow_id="${fail_workflows[$((idx % ${#fail_workflows[@]}))]}"; ov_spawn_command "retry-fail-$idx" invoker_e2e_run_headless --no-track retry "$workflow_id" ;;
       2) workflow_id="${approval_workflows[$((idx % ${#approval_workflows[@]}))]}"; ov_spawn_command "approve-$idx" invoker_e2e_run_headless --no-track approve "$workflow_id/approve-me" ;;
       3) workflow_id="${approval_workflows[$((idx % ${#approval_workflows[@]}))]}"; ov_spawn_command "reject-$idx" invoker_e2e_run_headless --no-track reject "$workflow_id/approve-me" "tracked fix churn reject" ;;
+      4) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
+      5) ov_spawn_command "query-workflows-$idx" invoker_e2e_run_headless query workflows --output jsonl ;;
+    esac
+  done
+
+  ov_detect_false_idle "$target_workflow" "tracked-fix" 45
+  ov_wait_background_commands
+
+  local tracked_status target_status
+  tracked_status="$(cat "${OVERLOAD_TMP_DIR}/tracked-fix.code" 2>/dev/null || echo 1)"
+  target_status="$(invoker_e2e_task_status "$target_task" 2>/dev/null || true)"
+  if [ "${tracked_status:-1}" -eq 124 ] || [ "${tracked_status:-1}" -eq 137 ] || [ "${tracked_status:-1}" -eq 143 ]; then
+    if [ "$target_status" = "fixing_with_ai" ] || [ "$target_status" = "review_ready" ] || [ "$target_status" = "awaiting_approval" ]; then
+      echo "FAIL: tracked command hung for $target_task (status=$target_status exit=$tracked_status)" >&2
+      return 1
+    fi
+  elif [ "${tracked_status:-1}" -ne 0 ]; then
+    echo "FAIL: tracked fix command exited with $tracked_status for $target_task" >&2
+    cat "${OVERLOAD_TMP_DIR}/tracked-fix.out" >&2 || true
+    return 1
+  fi
+
+  ov_cancel_all_workflows
+  sleep 2
+  ov_stop_owner
+  ov_wait_queries_healthy 45
+  invoker_e2e_assert_no_stuck_mutation_intents 45
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
+run_owner_restart_loop_during_tracked_fix_churn() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN=""
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_LABELS="tracked-fix"
+  ov_start_owner
+
+  local target_info target_workflow target_task
+  target_info="$(ov_submit_workflow fail "restart-loop-tracked-fix-target" "" no-track)"
+  target_workflow="${target_info%%|*}"
+  target_task="$target_workflow/root"
+  echo "seed tracked fix target: $target_workflow"
+  ov_wait_task_status "$target_task" failed 30
+
+  local -a fail_workflows=()
+  local -a approval_workflows=()
+  local idx info workflow_id
+  for idx in $(seq 1 3); do
+    info="$(ov_submit_workflow fail "restart-loop-tracked-fix-neighbor-fail-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    fail_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/root" failed 30
+  done
+  for idx in $(seq 1 2); do
+    info="$(ov_submit_workflow approval "restart-loop-tracked-fix-neighbor-approval-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    approval_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/approve-me" awaiting_approval 30
+  done
+
+  echo "==> overload: starting tracked fix before owner restart loop"
+  ov_spawn_command_timed "tracked-fix" 120 invoker_e2e_run_headless fix "$target_task" codex
+  ov_wait_task_status_any "$target_task" "fixing_with_ai,awaiting_approval,completed,failed" 30
+
+  local restart_cycles=3
+  local cycle fail_workflow approval_workflow
+  for cycle in $(seq 1 "$restart_cycles"); do
+    fail_workflow="${fail_workflows[$(((cycle - 1) % ${#fail_workflows[@]}))]}"
+    approval_workflow="${approval_workflows[$(((cycle - 1) % ${#approval_workflows[@]}))]}"
+    echo "==> overload: owner restart cycle $cycle/$restart_cycles"
+    ov_spawn_command "recreate-fail-cycle-$cycle" invoker_e2e_run_headless --no-track recreate "$fail_workflow"
+    ov_spawn_command "retry-fail-cycle-$cycle" invoker_e2e_run_headless --no-track retry "$fail_workflow"
+    ov_spawn_command "approve-cycle-$cycle" invoker_e2e_run_headless --no-track approve "$approval_workflow/approve-me"
+    ov_spawn_command "query-queue-cycle-$cycle" invoker_e2e_run_headless query queue --output json
+    ov_stop_owner
+    sleep 1
+    ov_start_owner
+    sleep 1
+  done
+
+  for idx in $(seq 0 $((operation_burst - 1))); do
+    case $((idx % 6)) in
+      0) workflow_id="${fail_workflows[$((idx % ${#fail_workflows[@]}))]}"; ov_spawn_command "recreate-fail-$idx" invoker_e2e_run_headless --no-track recreate "$workflow_id" ;;
+      1) workflow_id="${fail_workflows[$((idx % ${#fail_workflows[@]}))]}"; ov_spawn_command "retry-fail-$idx" invoker_e2e_run_headless --no-track retry "$workflow_id" ;;
+      2) workflow_id="${approval_workflows[$((idx % ${#approval_workflows[@]}))]}"; ov_spawn_command "approve-$idx" invoker_e2e_run_headless --no-track approve "$workflow_id/approve-me" ;;
+      3) workflow_id="${approval_workflows[$((idx % ${#approval_workflows[@]}))]}"; ov_spawn_command "reject-$idx" invoker_e2e_run_headless --no-track reject "$workflow_id/approve-me" "tracked fix restart churn reject" ;;
       4) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
       5) ov_spawn_command "query-workflows-$idx" invoker_e2e_run_headless query workflows --output jsonl ;;
     esac

--- a/scripts/repro/repro-owner-restart-loop-during-tracked-approve.sh
+++ b/scripts/repro/repro-owner-restart-loop-during-tracked-approve.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec timeout "${INVOKER_REPRO_TIMEOUT_SECONDS:-900}" \
+  env \
+    INVOKER_CHAOS_OVERLOAD_SCENARIO=owner-restart-loop-during-tracked-approve \
+    ./scripts/e2e-chaos/run-overload.sh

--- a/scripts/repro/repro-owner-restart-loop-during-tracked-fix-churn.sh
+++ b/scripts/repro/repro-owner-restart-loop-during-tracked-fix-churn.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec timeout "${INVOKER_REPRO_TIMEOUT_SECONDS:-900}" \
+  env \
+    INVOKER_CHAOS_OVERLOAD_SCENARIO=owner-restart-loop-during-tracked-fix-churn \
+    ./scripts/e2e-chaos/run-overload.sh


### PR DESCRIPTION
## Summary
This extends the chaos matrix with restart-loop coverage for tracked approve and tracked fix churn cases, plus dedicated repro entrypoints. The intent is to keep a tracked mutation in flight while the owner is repeatedly stopped and restarted, so the harness exercises the rebind and recovery path rather than just the steady-state tracked mutation path.

## Root Cause
Tracked restart-loop starvation bugs were mostly visible as long-tail flakes, not as named scenarios with dedicated repro entrypoints.

## Approach
Add restart-loop overload scenarios and wrapper scripts for tracked approve and tracked fix.

## Tradeoffs And Considerations
The matrix grows and takes longer to run, but the new cost buys directly targeted restart-loop coverage rather than vague chaos churn.

## Before
```mermaid
flowchart LR
  R[repro scripts] --> O[run-overload.sh]
  O --> S1[tracked approve under load]
  O --> S2[tracked fix under load]
```

## After
```mermaid
flowchart LR
  R1[tracked approve repro] --> O[run-overload.sh]
  R2[tracked fix repro] --> O
  O --> H1[tracked approve + owner restart loop]
  O --> H2[tracked fix + owner restart loop]
```

## Validation
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Expand overload matrix for tracked restart loops`
