### PR TITLE
Expand overload matrix for fixing visibility restart loops

### DIFF
--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -56,6 +56,7 @@ tracked-approve-zero-running-hang|headless-standalone|hang|false_idle_tracked_mu
 owner-restart-loop-during-tracked-approve|headless-standalone|hang|owner_restart_loop_tracked_approve_starvation|restart_loop_approve_under_starvation|8|10|run_owner_restart_loop_during_tracked_approve
 tracked-fix-churn-under-load|headless-standalone|hang|tracked_fix_starvation|fix_under_neighbor_churn|8|10|run_tracked_fix_churn_under_load
 owner-restart-loop-during-tracked-fix-churn|headless-standalone|hang|owner_restart_loop_tracked_fix_starvation|restart_loop_fix_under_neighbor_churn|8|12|run_owner_restart_loop_during_tracked_fix_churn
+owner-restart-loop-during-fixing-visibility|headless-standalone|hang|owner_restart_loop_fixing_visibility|restart_loop_fix_visibility|6|8|run_owner_restart_loop_during_fixing_visibility
 owner-bootstrap-under-saturated-mutations|headless-standalone|hang|delegation_starvation|delegate_under_saturation|8|8|run_owner_bootstrap_under_saturated_mutations
 fixing-with-ai-visibility|headless-standalone|hang|fixing_state_visibility|fix_under_timeout|6|1|run_fixing_with_ai_visibility
 EOF
@@ -1111,6 +1112,102 @@ run_owner_restart_loop_during_tracked_fix_churn() {
   local tracked_status target_status
   tracked_status="$(cat "${OVERLOAD_TMP_DIR}/tracked-fix.code" 2>/dev/null || echo 1)"
   target_status="$(invoker_e2e_task_status "$target_task" 2>/dev/null || true)"
+  if [ "${tracked_status:-1}" -eq 124 ] || [ "${tracked_status:-1}" -eq 137 ] || [ "${tracked_status:-1}" -eq 143 ]; then
+    if [ "$target_status" = "fixing_with_ai" ] || [ "$target_status" = "review_ready" ] || [ "$target_status" = "awaiting_approval" ]; then
+      echo "FAIL: tracked command hung for $target_task (status=$target_status exit=$tracked_status)" >&2
+      return 1
+    fi
+  elif [ "${tracked_status:-1}" -ne 0 ]; then
+    echo "FAIL: tracked fix command exited with $tracked_status for $target_task" >&2
+    cat "${OVERLOAD_TMP_DIR}/tracked-fix.out" >&2 || true
+    return 1
+  fi
+
+  ov_cancel_all_workflows
+  sleep 2
+  ov_stop_owner
+  ov_wait_queries_healthy 45
+  invoker_e2e_assert_no_stuck_mutation_intents 45
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
+run_owner_restart_loop_during_fixing_visibility() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN=""
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_LABELS="tracked-fix"
+  ov_start_owner
+
+  local target_info target_workflow target_task
+  target_info="$(ov_submit_workflow fail "restart-loop-fixing-visibility-target" "" no-track)"
+  target_workflow="${target_info%%|*}"
+  target_task="$target_workflow/root"
+  echo "seed fix target workflow: $target_workflow"
+  ov_wait_task_status "$target_task" failed 30
+
+  local idx info workflow_id
+  local -a fail_workflows=()
+  for idx in $(seq 1 3); do
+    info="$(ov_submit_workflow fail "restart-loop-fixing-visibility-neighbor-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    fail_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/root" failed 30
+  done
+
+  echo "==> overload: starting tracked fix and observing fixing_with_ai through restart loop"
+  ov_spawn_command_timed "tracked-fix" 120 invoker_e2e_run_headless fix "$target_task" codex
+  ov_wait_task_status_any "$target_task" "fixing_with_ai,awaiting_approval,completed,failed" 30
+
+  local saw_fixing=0
+  local restart_cycles=3
+  local cycle query_json task_status
+  for cycle in $(seq 1 "$restart_cycles"); do
+    echo "==> overload: owner restart cycle $cycle/$restart_cycles"
+    ov_spawn_command "query-queue-cycle-$cycle" invoker_e2e_run_headless query queue --output json
+    ov_spawn_command "query-ui-perf-cycle-$cycle" invoker_e2e_run_headless query ui-perf --output json
+    ov_spawn_command "retry-neighbor-cycle-$cycle" invoker_e2e_run_headless --no-track retry "${fail_workflows[$(((cycle - 1) % ${#fail_workflows[@]}))]}"
+    ov_stop_owner
+    sleep 1
+    ov_start_owner
+    sleep 1
+    query_json="$(invoker_e2e_run_headless query queue --output json 2>/dev/null || true)"
+    task_status="$(invoker_e2e_task_status "$target_task" 2>/dev/null || true)"
+    if printf '%s\n' "$query_json" | grep -q 'fixing_with_ai'; then
+      saw_fixing=1
+    fi
+    if [ "$task_status" = "fixing_with_ai" ] || [ "$task_status" = "awaiting_approval" ] || [ "$task_status" = "review_ready" ]; then
+      saw_fixing=1
+    fi
+  done
+
+  for idx in $(seq 0 $((operation_burst - 1))); do
+    case $((idx % 4)) in
+      0) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
+      1) ov_spawn_command "query-ui-perf-$idx" invoker_e2e_run_headless query ui-perf --output json ;;
+      2) ov_spawn_command "query-tasks-$idx" invoker_e2e_run_headless query tasks --workflow "$target_workflow" --output jsonl ;;
+      3) ov_spawn_command "retry-neighbor-$idx" invoker_e2e_run_headless --no-track retry "${fail_workflows[$((idx % ${#fail_workflows[@]}))]}" ;;
+    esac
+  done
+
+  ov_detect_false_idle "$target_workflow" "tracked-fix" 45
+  ov_wait_background_commands
+
+  local tracked_status target_status
+  tracked_status="$(cat "${OVERLOAD_TMP_DIR}/tracked-fix.code" 2>/dev/null || echo 1)"
+  target_status="$(invoker_e2e_task_status "$target_task" 2>/dev/null || true)"
+  if [ "$saw_fixing" -ne 1 ] && [ "$target_status" = "fixing_with_ai" ]; then
+    echo "FAIL: fixing_with_ai invisible to queue for $target_task across restart loop" >&2
+    return 1
+  fi
   if [ "${tracked_status:-1}" -eq 124 ] || [ "${tracked_status:-1}" -eq 137 ] || [ "${tracked_status:-1}" -eq 143 ]; then
     if [ "$target_status" = "fixing_with_ai" ] || [ "$target_status" = "review_ready" ] || [ "$target_status" = "awaiting_approval" ]; then
       echo "FAIL: tracked command hung for $target_task (status=$target_status exit=$tracked_status)" >&2

--- a/scripts/repro/repro-owner-restart-loop-during-fixing-visibility.sh
+++ b/scripts/repro/repro-owner-restart-loop-during-fixing-visibility.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec timeout "${INVOKER_REPRO_TIMEOUT_SECONDS:-900}" \
+  env \
+    INVOKER_CHAOS_OVERLOAD_SCENARIO=owner-restart-loop-during-fixing-visibility \
+    ./scripts/e2e-chaos/run-overload.sh


### PR DESCRIPTION
## Summary
This adds a restart-loop scenario focused on `fixing_with_ai` visibility while the owner is bouncing. The harness now checks that a tracked fix remains observable in the queue and task status during repeated restarts, instead of only validating visibility during one uninterrupted owner lifetime.

## Problem
A tracked fix could still be running while visibility into that work degraded across owner restarts.

## Root Cause
Existing coverage proved steady-state visibility but not whether state rehydration preserved visibility semantics during restart churn.

## Approach
Add a visibility-focused restart-loop scenario that polls queue and task status through repeated owner restarts.

## Why This Fix Is Right
The missing behavior is observability continuity, not execution continuity alone. This scenario tests the correct contract.

## Tradeoffs And Considerations
The tradeoff is a heavier scenario with extra polling. That is appropriate because visibility bugs often only show up under repeated state rehydration.

## Before
```mermaid
flowchart LR
  A[Tracked fix] --> B[Queue visibility check]
  B --> C[Single owner lifetime]
```

## After
```mermaid
flowchart LR
  A[Tracked fix] --> B[Queue visibility check]
  B --> C[Owner restart loop]
  C --> D[Visibility rechecked after each restart]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Expand overload matrix for fixing visibility restart loops`
