### PR TITLE
Expand overload matrix for restart delete-all tracked races

### DIFF
--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -61,6 +61,8 @@ owner-bootstrap-under-saturated-mutations|headless-standalone|hang|delegation_st
 owner-restart-loop-during-bootstrap-saturation|headless-standalone|hang|owner_restart_loop_delegation_starvation|restart_loop_delegate_under_saturation|8|10|run_owner_restart_loop_during_bootstrap_saturation
 delete-all-during-tracked-fix|headless-standalone|hang|global_destructive_during_tracked_fix|delete_all_during_fix|8|8|run_delete_all_during_tracked_fix
 delete-all-during-tracked-approve|headless-standalone|hang|global_destructive_during_tracked_approve|delete_all_during_approve|8|8|run_delete_all_during_tracked_approve
+owner-restart-loop-during-delete-all-tracked-fix|headless-standalone|hang|owner_restart_loop_global_destructive_tracked_fix|restart_loop_delete_all_during_fix|8|10|run_owner_restart_loop_during_delete_all_tracked_fix
+owner-restart-loop-during-delete-all-tracked-approve|headless-standalone|hang|owner_restart_loop_global_destructive_tracked_approve|restart_loop_delete_all_during_approve|8|10|run_owner_restart_loop_during_delete_all_tracked_approve
 fixing-with-ai-visibility|headless-standalone|hang|fixing_state_visibility|fix_under_timeout|6|1|run_fixing_with_ai_visibility
 EOF
 }
@@ -1114,6 +1116,174 @@ run_delete_all_during_tracked_approve() {
   target_status="$(invoker_e2e_task_status "$target_task" 2>/dev/null || true)"
   if [ "${tracked_status:-0}" -eq 124 ] && [ "$target_status" = "awaiting_approval" ]; then
     echo "FAIL: tracked command hung for $target_task while delete-all drained" >&2
+    return 1
+  fi
+
+  ov_stop_owner
+  ov_wait_queries_healthy 45
+  invoker_e2e_assert_no_stuck_mutation_intents 45
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
+run_owner_restart_loop_during_delete_all_tracked_fix() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN='Task ".*" not found( in any workflow)?'
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_LABELS="tracked-fix,delete-all-cycle-1,delete-all-cycle-2,delete-all-cycle-3"
+  ov_start_owner
+
+  local target_info target_workflow target_task
+  target_info="$(ov_submit_workflow fail "restart-loop-delete-all-tracked-fix-target" "" no-track)"
+  target_workflow="${target_info%%|*}"
+  target_task="$target_workflow/root"
+  echo "seed tracked fix target: $target_workflow"
+  ov_wait_task_status "$target_task" failed 30
+
+  local -a filler_workflows=()
+  local idx info workflow_id
+  for idx in $(seq 1 3); do
+    info="$(ov_submit_workflow slow "restart-loop-delete-all-tracked-fix-filler-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    filler_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/root" running 120
+  done
+
+  echo "==> overload: starting tracked fix before delete-all restart loop"
+  ov_spawn_command_timed "tracked-fix" 120 invoker_e2e_run_headless fix "$target_task" codex
+  ov_wait_task_status_any "$target_task" "fixing_with_ai,awaiting_approval,completed,failed" 30
+
+  local restart_cycles=3
+  local cycle filler_workflow
+  for cycle in $(seq 1 "$restart_cycles"); do
+    filler_workflow="${filler_workflows[$(((cycle - 1) % ${#filler_workflows[@]}))]}"
+    echo "==> overload: delete-all restart cycle $cycle/$restart_cycles"
+    ov_spawn_command "delete-all-cycle-$cycle" invoker_e2e_run_headless delete-all
+    ov_spawn_command "cancel-filler-cycle-$cycle" invoker_e2e_run_headless cancel "$filler_workflow/root"
+    ov_spawn_command "query-queue-cycle-$cycle" invoker_e2e_run_headless query queue --output json
+    ov_spawn_command "query-ui-perf-cycle-$cycle" invoker_e2e_run_headless query ui-perf --output json
+    ov_stop_owner
+    sleep 1
+    ov_start_owner
+    sleep 1
+  done
+
+  for idx in $(seq 0 $((operation_burst - 1))); do
+    case $((idx % 5)) in
+      0) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
+      1) ov_spawn_command "query-workflows-$idx" invoker_e2e_run_headless query workflows --output label ;;
+      2) workflow_id="${filler_workflows[$((idx % ${#filler_workflows[@]}))]}"; ov_spawn_command "cancel-workflow-$idx" invoker_e2e_run_headless cancel-workflow "$workflow_id" ;;
+      3) ov_spawn_command "query-tasks-$idx" invoker_e2e_run_headless query tasks --output jsonl ;;
+      4) ov_spawn_command "query-ui-perf-$idx" invoker_e2e_run_headless query ui-perf --output json ;;
+    esac
+  done
+
+  ov_wait_background_commands
+
+  local remaining tracked_status target_status
+  remaining="$(ov_count_workflows)"
+  if [ "${remaining:-0}" -ne 0 ]; then
+    echo "FAIL: delete-all left workflows behind ($remaining remaining)" >&2
+    invoker_e2e_run_headless query workflows --output label >&2 || true
+    return 1
+  fi
+
+  tracked_status="$(cat "${OVERLOAD_TMP_DIR}/tracked-fix.code" 2>/dev/null || echo 0)"
+  target_status="$(invoker_e2e_task_status "$target_task" 2>/dev/null || true)"
+  if [ "${tracked_status:-0}" -eq 124 ] && [ "$target_status" = "fixing_with_ai" ]; then
+    echo "FAIL: tracked command hung for $target_task while delete-all restart loop drained" >&2
+    return 1
+  fi
+
+  ov_stop_owner
+  ov_wait_queries_healthy 45
+  invoker_e2e_assert_no_stuck_mutation_intents 45
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
+run_owner_restart_loop_during_delete_all_tracked_approve() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN='Task ".*" not found( in any workflow)?'
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_LABELS="tracked-approve,delete-all-cycle-1,delete-all-cycle-2,delete-all-cycle-3"
+  ov_start_owner
+
+  local target_info target_workflow target_task
+  target_info="$(ov_submit_workflow approval "restart-loop-delete-all-tracked-approve-target" "" no-track)"
+  target_workflow="${target_info%%|*}"
+  target_task="$target_workflow/approve-me"
+  echo "seed tracked approve target: $target_workflow"
+  ov_wait_task_status "$target_task" awaiting_approval 30
+
+  local -a filler_workflows=()
+  local idx info workflow_id
+  for idx in $(seq 1 3); do
+    info="$(ov_submit_workflow slow "restart-loop-delete-all-tracked-approve-filler-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    filler_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/root" running 120
+  done
+
+  echo "==> overload: starting tracked approve before delete-all restart loop"
+  ov_spawn_command_timed "tracked-approve" 120 invoker_e2e_run_headless approve "$target_task"
+  sleep 2
+
+  local restart_cycles=3
+  local cycle filler_workflow
+  for cycle in $(seq 1 "$restart_cycles"); do
+    filler_workflow="${filler_workflows[$(((cycle - 1) % ${#filler_workflows[@]}))]}"
+    echo "==> overload: delete-all restart cycle $cycle/$restart_cycles"
+    ov_spawn_command "delete-all-cycle-$cycle" invoker_e2e_run_headless delete-all
+    ov_spawn_command "cancel-filler-cycle-$cycle" invoker_e2e_run_headless cancel "$filler_workflow/root"
+    ov_spawn_command "query-queue-cycle-$cycle" invoker_e2e_run_headless query queue --output json
+    ov_spawn_command "query-ui-perf-cycle-$cycle" invoker_e2e_run_headless query ui-perf --output json
+    ov_stop_owner
+    sleep 1
+    ov_start_owner
+    sleep 1
+  done
+
+  for idx in $(seq 0 $((operation_burst - 1))); do
+    case $((idx % 5)) in
+      0) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
+      1) ov_spawn_command "query-workflows-$idx" invoker_e2e_run_headless query workflows --output label ;;
+      2) workflow_id="${filler_workflows[$((idx % ${#filler_workflows[@]}))]}"; ov_spawn_command "cancel-workflow-$idx" invoker_e2e_run_headless cancel-workflow "$workflow_id" ;;
+      3) ov_spawn_command "query-tasks-$idx" invoker_e2e_run_headless query tasks --output jsonl ;;
+      4) ov_spawn_command "query-ui-perf-$idx" invoker_e2e_run_headless query ui-perf --output json ;;
+    esac
+  done
+
+  ov_wait_background_commands
+
+  local remaining tracked_status target_status
+  remaining="$(ov_count_workflows)"
+  if [ "${remaining:-0}" -ne 0 ]; then
+    echo "FAIL: delete-all left workflows behind ($remaining remaining)" >&2
+    invoker_e2e_run_headless query workflows --output label >&2 || true
+    return 1
+  fi
+
+  tracked_status="$(cat "${OVERLOAD_TMP_DIR}/tracked-approve.code" 2>/dev/null || echo 0)"
+  target_status="$(invoker_e2e_task_status "$target_task" 2>/dev/null || true)"
+  if [ "${tracked_status:-0}" -eq 124 ] && [ "$target_status" = "awaiting_approval" ]; then
+    echo "FAIL: tracked command hung for $target_task while delete-all restart loop drained" >&2
     return 1
   fi
 

--- a/scripts/repro/repro-owner-restart-loop-during-delete-all-tracked-approve.sh
+++ b/scripts/repro/repro-owner-restart-loop-during-delete-all-tracked-approve.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec timeout "${INVOKER_REPRO_TIMEOUT_SECONDS:-900}" \
+  env \
+    INVOKER_CHAOS_OVERLOAD_SCENARIO=owner-restart-loop-during-delete-all-tracked-approve \
+    ./scripts/e2e-chaos/run-overload.sh

--- a/scripts/repro/repro-owner-restart-loop-during-delete-all-tracked-fix.sh
+++ b/scripts/repro/repro-owner-restart-loop-during-delete-all-tracked-fix.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec timeout "${INVOKER_REPRO_TIMEOUT_SECONDS:-900}" \
+  env \
+    INVOKER_CHAOS_OVERLOAD_SCENARIO=owner-restart-loop-during-delete-all-tracked-fix \
+    ./scripts/e2e-chaos/run-overload.sh


### PR DESCRIPTION
## Summary
This layers owner restart loops on top of the `delete-all` plus tracked-fix and `delete-all` plus tracked-approve cases. The key change is that `delete-all` is no longer only tested as a one-shot destructive operation; it is now exercised while the owner is repeatedly torn down and brought back up.

## Problem
The suite still lacked restart-loop coverage for the most destructive control-plane path.

## Root Cause
`delete-all` coverage existed, but not under repeated owner rehydration where persistence, cancellation, and cleanup are all under pressure.

## Approach
Run `delete-all` destructive scenarios through repeated owner restart loops while tracked operations remain in play.

## Why This Fix Is Right
If destructive drains are going to regress, restart churn is exactly where they will do it. This scenario targets that boundary directly.

## Tradeoffs And Considerations
The stack gets slower because these scenarios include multiple restart cycles. That is an acceptable cost for making destructive restart behavior observable.

## Before
```mermaid
flowchart LR
  A[delete-all] --> B[Single owner lifetime]
  C[Tracked work] --> D[No restart churn]
```

## After
```mermaid
flowchart LR
  A[delete-all] --> B[Owner restart loop]
  C[Tracked fix / approve] --> D[delete-all continues across restarts]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Expand overload matrix for restart delete-all tracked races`
