### PR TITLE
Expand overload matrix for tracked rebase restart loops

### DIFF
--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -54,6 +54,7 @@ repeated-delete-all-under-load|headless-standalone|destructive|repeated_global_d
 owner-restart-loop-during-delete-all|headless-standalone|destructive|owner_restart_loop_global_destructive|restart_loop_delete_all|10|12|run_owner_restart_loop_during_delete_all
 tracked-approve-zero-running-hang|headless-standalone|hang|false_idle_tracked_mutation|approve_under_starvation|8|6|run_tracked_approve_zero_running_hang
 owner-restart-loop-during-tracked-approve|headless-standalone|hang|owner_restart_loop_tracked_approve_starvation|restart_loop_approve_under_starvation|8|10|run_owner_restart_loop_during_tracked_approve
+owner-restart-loop-during-tracked-rebase|headless-standalone|hang|owner_restart_loop_tracked_rebase_starvation|restart_loop_rebase_under_neighbor_churn|8|10|run_owner_restart_loop_during_tracked_rebase
 tracked-fix-churn-under-load|headless-standalone|hang|tracked_fix_starvation|fix_under_neighbor_churn|8|10|run_tracked_fix_churn_under_load
 owner-restart-loop-during-tracked-fix-churn|headless-standalone|hang|owner_restart_loop_tracked_fix_starvation|restart_loop_fix_under_neighbor_churn|8|12|run_owner_restart_loop_during_tracked_fix_churn
 owner-restart-loop-during-fixing-visibility|headless-standalone|hang|owner_restart_loop_fixing_visibility|restart_loop_fix_visibility|6|8|run_owner_restart_loop_during_fixing_visibility
@@ -831,6 +832,100 @@ run_owner_restart_loop_during_tracked_approve() {
   elif [ "${tracked_status:-1}" -ne 0 ]; then
     echo "FAIL: tracked approve command exited with $tracked_status for $target_task" >&2
     cat "${OVERLOAD_TMP_DIR}/tracked-approve.out" >&2 || true
+    return 1
+  fi
+
+  ov_cancel_all_workflows
+  sleep 2
+  ov_stop_owner
+  ov_wait_queries_healthy 45
+  invoker_e2e_assert_no_stuck_mutation_intents 45
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
+run_owner_restart_loop_during_tracked_rebase() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN=""
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_LABELS="tracked-rebase"
+  ov_start_owner
+
+  local target_info target_workflow target_task
+  target_info="$(ov_submit_workflow fail "restart-loop-tracked-rebase-target" "" no-track)"
+  target_workflow="${target_info%%|*}"
+  target_task="$target_workflow/root"
+  echo "seed tracked rebase target: $target_workflow"
+  ov_wait_task_status "$target_task" failed 30
+
+  local -a fail_workflows=()
+  local -a approval_workflows=()
+  local idx info workflow_id
+  for idx in $(seq 1 3); do
+    info="$(ov_submit_workflow fail "restart-loop-tracked-rebase-neighbor-fail-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    fail_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/root" failed 30
+  done
+  for idx in $(seq 1 2); do
+    info="$(ov_submit_workflow approval "restart-loop-tracked-rebase-neighbor-approval-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    approval_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/approve-me" awaiting_approval 30
+  done
+
+  echo "==> overload: starting tracked rebase before owner restart loop"
+  ov_spawn_command_timed "tracked-rebase" 120 invoker_e2e_run_headless rebase "$target_task"
+  sleep 2
+
+  local restart_cycles=3
+  local cycle fail_workflow approval_workflow
+  for cycle in $(seq 1 "$restart_cycles"); do
+    fail_workflow="${fail_workflows[$(((cycle - 1) % ${#fail_workflows[@]}))]}"
+    approval_workflow="${approval_workflows[$(((cycle - 1) % ${#approval_workflows[@]}))]}"
+    echo "==> overload: owner restart cycle $cycle/$restart_cycles"
+    ov_spawn_command "retry-fail-cycle-$cycle" invoker_e2e_run_headless --no-track retry "$fail_workflow"
+    ov_spawn_command "recreate-fail-cycle-$cycle" invoker_e2e_run_headless --no-track recreate "$fail_workflow"
+    ov_spawn_command "approve-cycle-$cycle" invoker_e2e_run_headless --no-track approve "$approval_workflow/approve-me"
+    ov_spawn_command "query-queue-cycle-$cycle" invoker_e2e_run_headless query queue --output json
+    ov_stop_owner
+    sleep 1
+    ov_start_owner
+    sleep 1
+  done
+
+  for idx in $(seq 0 $((operation_burst - 1))); do
+    case $((idx % 6)) in
+      0) workflow_id="${fail_workflows[$((idx % ${#fail_workflows[@]}))]}"; ov_spawn_command "retry-fail-$idx" invoker_e2e_run_headless --no-track retry "$workflow_id" ;;
+      1) workflow_id="${fail_workflows[$((idx % ${#fail_workflows[@]}))]}"; ov_spawn_command "recreate-fail-$idx" invoker_e2e_run_headless --no-track recreate "$workflow_id" ;;
+      2) workflow_id="${approval_workflows[$((idx % ${#approval_workflows[@]}))]}"; ov_spawn_command "approve-$idx" invoker_e2e_run_headless --no-track approve "$workflow_id/approve-me" ;;
+      3) workflow_id="${approval_workflows[$((idx % ${#approval_workflows[@]}))]}"; ov_spawn_command "reject-$idx" invoker_e2e_run_headless --no-track reject "$workflow_id/approve-me" "tracked rebase restart churn reject" ;;
+      4) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
+      5) ov_spawn_command "query-workflows-$idx" invoker_e2e_run_headless query workflows --output jsonl ;;
+    esac
+  done
+
+  ov_wait_background_commands
+
+  local tracked_status target_status
+  tracked_status="$(cat "${OVERLOAD_TMP_DIR}/tracked-rebase.code" 2>/dev/null || echo 1)"
+  target_status="$(invoker_e2e_task_status "$target_task" 2>/dev/null || true)"
+  if [ "${tracked_status:-1}" -eq 124 ] || [ "${tracked_status:-1}" -eq 137 ] || [ "${tracked_status:-1}" -eq 143 ]; then
+    if [ "$target_status" != "completed" ] && [ "$target_status" != "failed" ]; then
+      echo "FAIL: tracked command hung for $target_task (status=$target_status exit=$tracked_status)" >&2
+      return 1
+    fi
+  elif [ "${tracked_status:-1}" -ne 0 ]; then
+    echo "FAIL: tracked rebase command exited with $tracked_status for $target_task" >&2
+    cat "${OVERLOAD_TMP_DIR}/tracked-rebase.out" >&2 || true
     return 1
   fi
 

--- a/scripts/repro/repro-owner-restart-loop-during-tracked-rebase.sh
+++ b/scripts/repro/repro-owner-restart-loop-during-tracked-rebase.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec timeout "${INVOKER_REPRO_TIMEOUT_SECONDS:-900}" \
+  env \
+    INVOKER_CHAOS_OVERLOAD_SCENARIO=owner-restart-loop-during-tracked-rebase \
+    ./scripts/e2e-chaos/run-overload.sh


### PR DESCRIPTION
## Summary
This adds a chaos overload scenario that exercises a tracked `rebase` command while the owner process is repeatedly restarted and neighboring workflows continue to churn. The goal is to prove that the tracked rebase path tolerates owner restarts without hanging or losing its own work item, which is a failure mode the earlier matrix did not cover.

## Problem
Tracked rebase behavior under restart loops was not a dedicated, replayable scenario in the chaos matrix.

## Root Cause
Restart-loop coverage had been focused on other tracked mutations, leaving rebase semantics untested under the same churn.

## Approach
Add a tracked-rebase overload scenario that seeds a failed target and interleaves owner restarts with neighboring workflow churn.

## Why This Fix Is Right
Rebase has workflow-scope semantics distinct from fix and approve. Treating it as its own scenario keeps the matrix honest about verb-specific behavior.

## Tradeoffs And Considerations
This adds runtime and another scenario row, but the added surface is justified because it targets a previously uncovered lifecycle mutation.

## Before
```mermaid
flowchart LR
  A[overload catalog] --> B[run_scenario]
  B --> C[tracked-fix / approve / query scenarios]
```

## After
```mermaid
flowchart LR
  A[overload catalog] --> B[run_scenario]
  B --> C[tracked-rebase scenario]
  C --> D[seed failed target]
  D --> E[start tracked rebase]
  E --> F[owner restart loops + neighbor churn]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Expand overload matrix for tracked rebase restart loops`
