### PR TITLE
Add cancel late-return overload repro

### DIFF
--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -45,6 +45,7 @@ catalog() {
 mixed-control-plane-storm|headless-standalone|core|mixed_mutation_storm|mixed_resets_cancels_retries|12|14|run_mixed_control_plane_storm
 owner-restart-loop-during-mixed-storm|headless-standalone|core|owner_restart_loop_mixed_mutation_storm|restart_loop_mixed_resets_cancels_retries|12|16|run_owner_restart_loop_during_mixed_storm
 late-return-rejection-under-storm|headless-standalone|core|stale_worker_response|recreate_and_reject_stale|12|8|run_late_return_rejection_under_storm
+cancel-late-return-under-storm|headless-standalone|core|canceled_late_worker_response|cancel_and_reject_late_return|12|8|run_cancel_late_return_under_storm
 owner-restart-during-active-load|headless-standalone|core|owner_restart_churn|restart_and_recover|10|10|run_owner_restart_during_active_load
 owner-restart-loop-during-active-load|headless-standalone|core|owner_restart_loop_churn|restart_loop_and_recover|10|12|run_owner_restart_loop_during_active_load
 owner-restart-during-late-return-storm|headless-standalone|core|owner_restart_stale_return|restart_during_recreate|12|10|run_owner_restart_during_late_return_storm
@@ -2516,6 +2517,83 @@ run_late_return_rejection_under_storm() {
 
   for workflow_id in "${late_workflows[@]}"; do
     ov_assert_stale_completion_rejected "$workflow_id" "$reset_started_at"
+  done
+  ov_wait_queries_healthy 60
+  ov_cancel_all_workflows
+  sleep 2
+  ov_stop_owner
+  invoker_e2e_assert_no_stuck_mutation_intents 45
+  invoker_e2e_assert_no_owned_headless_processes 1
+}
+
+run_cancel_late_return_under_storm() {
+  local workflow_count="$1"
+  local operation_burst="$2"
+  invoker_e2e_init
+  trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" "${MARKER_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
+  cd "$INVOKER_E2E_REPO_ROOT"
+  unset ELECTRON_RUN_AS_NODE
+  unset INVOKER_HEADLESS_STANDALONE
+  ov_set_overload_config "$((workflow_count + 2))"
+
+  OVERLOAD_TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload.XXXXXX")"
+  MARKER_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-overload-markers.XXXXXX")"
+  OVERLOAD_OP_PIDS=()
+  OVERLOAD_ALLOWED_BACKGROUND_FAILURE_PATTERN=""
+  ov_start_owner
+
+  local -a late_workflows=()
+  local -a filler_workflows=()
+  local idx workflow_id info marker_path
+
+  echo "==> overload: seeding filler workflows before cancel-late targets"
+  local late_seed_count=3
+  for idx in $(seq 1 "$((workflow_count - late_seed_count))"); do
+    info="$(ov_submit_workflow fail "cancel-late-filler-$idx" "" no-track)"
+    workflow_id="${info%%|*}"
+    filler_workflows+=("$workflow_id")
+    ov_wait_task_status "$workflow_id/root" failed 30
+  done
+  echo "==> overload: seeding cancel-late workflows"
+  for idx in $(seq 1 "$late_seed_count"); do
+    marker_path="$MARKER_DIR/cancel-late-$idx.marker"
+    info="$(ov_submit_workflow late "cancel-late-$idx" "$marker_path" no-track)"
+    workflow_id="${info%%|*}"
+    late_workflows+=("$workflow_id")
+    echo "$marker_path" > "$OVERLOAD_TMP_DIR/${workflow_id}.marker"
+    echo "seed late workflow: $workflow_id"
+    ov_wait_task_status "$workflow_id/late" running 120
+  done
+
+  local cancel_started_at
+  cancel_started_at="$(date -u '+%Y-%m-%d %H:%M:%S')"
+
+  echo "==> overload: canceling all late tasks while background retries and queries fire"
+  for idx in "${!late_workflows[@]}"; do
+    workflow_id="${late_workflows[$idx]}"
+    ov_spawn_command "cancel-late-$idx" invoker_e2e_run_headless cancel "$workflow_id/late"
+  done
+
+  for workflow_id in "${late_workflows[@]}"; do
+    touch "$(cat "$OVERLOAD_TMP_DIR/${workflow_id}.marker")"
+  done
+
+  local max_fillers="$((operation_burst - ${#late_workflows[@]}))"
+  if [ "$max_fillers" -lt 0 ]; then
+    max_fillers=0
+  fi
+  for idx in $(seq 0 $((max_fillers - 1))); do
+    workflow_id="${filler_workflows[$((idx % ${#filler_workflows[@]}))]}"
+    case $((idx % 3)) in
+      0) ov_spawn_command "retry-filler-$idx" invoker_e2e_run_headless --no-track retry "$workflow_id" ;;
+      1) ov_spawn_command "query-queue-$idx" invoker_e2e_run_headless query queue --output json ;;
+      2) ov_spawn_command "query-workflows-$idx" invoker_e2e_run_headless query workflows --output jsonl ;;
+    esac
+  done
+  ov_wait_background_commands
+
+  for workflow_id in "${late_workflows[@]}"; do
+    ov_assert_canceled_task_did_not_complete "$workflow_id/late" "$cancel_started_at"
   done
   ov_wait_queries_healthy 60
   ov_cancel_all_workflows

--- a/scripts/repro/repro-cancel-late-return-under-storm.sh
+++ b/scripts/repro/repro-cancel-late-return-under-storm.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec timeout "${INVOKER_REPRO_TIMEOUT_SECONDS:-600}" \
+  env INVOKER_CHAOS_OVERLOAD_SCENARIO=cancel-late-return-under-storm \
+  INVOKER_CHAOS_OVERLOAD_MODE=deterministic \
+  ./scripts/e2e-chaos/run-overload.sh


### PR DESCRIPTION
## Summary
This adds a cancel-specific late-return overload scenario to the chaos matrix. The repro seeds late-return workflows, issues cancel commands against the late task, and then pounds the system with retry and query traffic so the harness can verify that a canceled task does not later complete because of a stale worker return.

## Problem
Cancel semantics under late worker returns were not isolated in the chaos matrix.

## Root Cause
Late-return coverage existed, but the suite did not yet prove that cancel remained authoritative when a stale worker response arrived under load.

## Approach
Add a cancel-focused late-return scenario with background retry and query churn.

## Why This Fix Is Right
Cancel authority is exactly the property at risk here. A dedicated repro is more useful than hoping a general late-return storm exercises the right edge.

## Tradeoffs And Considerations
This adds matrix cost and scenario-specific assertions, but the edge case is important enough to justify the narrower repro.

## Before
```mermaid
flowchart LR
  A[late-return storm] --> B[recreate/reject coverage]
  B --> C[cancel behavior not isolated]
```

## After
```mermaid
flowchart LR
  A[cancel-late-return-under-storm]
  A --> B[seed late workflows]
  B --> C[issue cancel on late task]
  C --> D[background retry/query pressure]
  D --> E[assert canceled task never completes]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `Add cancel late-return overload repro`
