### PR TITLE
collision-free branches: add branch naming primitives

### DIFF
--- a/packages/execution-engine/src/__tests__/branch-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-utils.test.ts
@@ -5,6 +5,9 @@ import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import {
   computeBranchHash,
+  computeContentHash,
+  formatLifecycleTag,
+  buildExperimentBranchName,
   bashPreserveOrReset,
   bashMergeUpstreams,
   bashEnsureRef,
@@ -12,6 +15,7 @@ import {
   parseMergeError,
   runBashLocal,
 } from '../branch-utils.js';
+import { parseExperimentBranch } from '../worktree-discovery.js';
 
 function createTempRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), 'branch-utils-test-'));
@@ -77,6 +81,100 @@ describe('computeBranchHash', () => {
   it('produces 8-character hex string', () => {
     const h = computeBranchHash('task-1', 'cmd', undefined, [], 'abc');
     expect(h).toMatch(/^[0-9a-f]{8}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// computeContentHash
+// ---------------------------------------------------------------------------
+
+describe('computeContentHash', () => {
+  it('matches computeBranchHash without salt', () => {
+    const a = computeContentHash('task-1', 'cmd', undefined, ['c1'], 'head');
+    const b = computeBranchHash('task-1', 'cmd', undefined, ['c1'], 'head');
+    expect(a).toBe(b);
+  });
+
+  it('is insensitive to lifecycle (no salt parameter exists)', () => {
+    const a = computeContentHash('task-1', 'cmd', undefined, [], 'head');
+    const b = computeContentHash('task-1', 'cmd', undefined, [], 'head');
+    expect(a).toBe(b);
+  });
+
+  it('produces 8-character hex string', () => {
+    const h = computeContentHash('task-1', 'cmd', undefined, [], 'head');
+    expect(h).toMatch(/^[0-9a-f]{8}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatLifecycleTag
+// ---------------------------------------------------------------------------
+
+describe('formatLifecycleTag', () => {
+  it('formats with all components', () => {
+    expect(formatLifecycleTag({ wfGen: 0, taskGen: 0, attemptShort: 'abc12345' })).toBe(
+      'g0.t0.aabc12345',
+    );
+  });
+
+  it('bumps yield distinct tags', () => {
+    const a = formatLifecycleTag({ wfGen: 1, taskGen: 0, attemptShort: 'aaa' });
+    const b = formatLifecycleTag({ wfGen: 2, taskGen: 0, attemptShort: 'aaa' });
+    const c = formatLifecycleTag({ wfGen: 1, taskGen: 1, attemptShort: 'aaa' });
+    const d = formatLifecycleTag({ wfGen: 1, taskGen: 0, attemptShort: 'bbb' });
+    expect(new Set([a, b, c, d]).size).toBe(4);
+  });
+
+  it('sanitizes attempt-short to safe characters and bounds length', () => {
+    expect(formatLifecycleTag({ wfGen: 1, taskGen: 2, attemptShort: 'AB$%C12/34D-56-EXTRA' }))
+      .toBe('g1.t2.aabc1234d-56-');
+  });
+
+  it('clamps negative or non-finite generations to 0', () => {
+    expect(formatLifecycleTag({ wfGen: -3, taskGen: NaN as unknown as number, attemptShort: 'x' }))
+      .toBe('g0.t0.ax');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildExperimentBranchName + parseExperimentBranch (round trip)
+// ---------------------------------------------------------------------------
+
+describe('buildExperimentBranchName / parseExperimentBranch', () => {
+  it('builds the canonical shape', () => {
+    const branch = buildExperimentBranchName('wf-1/task', 'g0.t1.aabc12345', 'deadbeef');
+    expect(branch).toBe('experiment/wf-1/task/g0.t1.aabc12345-deadbeef');
+  });
+
+  it('round-trips through parseExperimentBranch', () => {
+    const lifecycleTag = formatLifecycleTag({ wfGen: 4, taskGen: 7, attemptShort: '3f9c0d2' });
+    const contentHash = computeContentHash('wf-9/build', 'pnpm build', undefined, ['c1'], 'head');
+    const branch = buildExperimentBranchName('wf-9/build', lifecycleTag, contentHash);
+    const parsed = parseExperimentBranch(branch);
+    expect(parsed).toEqual({
+      actionId: 'wf-9/build',
+      lifecycleTag,
+      contentHash,
+    });
+  });
+
+  it('rejects invalid shapes', () => {
+    expect(parseExperimentBranch('master')).toBeUndefined();
+    expect(parseExperimentBranch('experiment/foo-deadbeef')).toBeUndefined();
+    expect(parseExperimentBranch('experiment/wf-1/task/no-suffix')).toBeUndefined();
+    expect(parseExperimentBranch('experiment/wf-1/task/g0.t0.a-NOTHEX1')).toBeUndefined();
+    expect(parseExperimentBranch('experiment/wf-1/task/badtag-deadbeef')).toBeUndefined();
+  });
+
+  it('throws on missing actionId or contentHash', () => {
+    expect(() => buildExperimentBranchName('', 'g0.t0.a', 'deadbeef')).toThrow(/actionId/);
+    expect(() => buildExperimentBranchName('wf/x', 'g0.t0.a', '')).toThrow(/contentHash/);
+  });
+
+  it('falls back to a default lifecycle tag when none provided', () => {
+    const branch = buildExperimentBranchName('wf-1/task', '', 'deadbeef');
+    expect(branch).toBe('experiment/wf-1/task/g0.t0.a-deadbeef');
   });
 });
 

--- a/packages/execution-engine/src/__tests__/worktree-discovery.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-discovery.test.ts
@@ -4,7 +4,9 @@ import {
   findManagedWorktreeForBranch,
   findManagedWorktreeByActionId,
   abbrevRefMatchesBranch,
+  parseExperimentBranch,
 } from '../worktree-discovery.js';
+import { buildExperimentBranchName, formatLifecycleTag } from '../branch-utils.js';
 
 describe('parseGitWorktreePorcelain', () => {
   it('parses main + linked worktree with branch', () => {
@@ -120,6 +122,45 @@ branch refs/heads/task1-aabb1122
       ['/home/u/.invoker/wt/h'],
     );
     expect(result).toBeUndefined();
+  });
+});
+
+describe('parseExperimentBranch (round-trip with buildExperimentBranchName)', () => {
+  it('round-trips canonical names', () => {
+    const lifecycleTag = formatLifecycleTag({ wfGen: 3, taskGen: 5, attemptShort: 'abc12345' });
+    const branch = buildExperimentBranchName('wf-1/build-app', lifecycleTag, 'deadbeef');
+    expect(branch).toBe('experiment/wf-1/build-app/g3.t5.aabc12345-deadbeef');
+    expect(parseExperimentBranch(branch)).toEqual({
+      actionId: 'wf-1/build-app',
+      lifecycleTag: 'g3.t5.aabc12345',
+      contentHash: 'deadbeef',
+    });
+  });
+
+  it('handles nested action ids with multiple slashes', () => {
+    const branch = buildExperimentBranchName('wf-9/group/sub', 'g0.t0.az', 'cafebabe');
+    expect(parseExperimentBranch(branch)).toEqual({
+      actionId: 'wf-9/group/sub',
+      lifecycleTag: 'g0.t0.az',
+      contentHash: 'cafebabe',
+    });
+  });
+
+  it('rejects legacy experiment/<actionId>-<sha8> format', () => {
+    expect(parseExperimentBranch('experiment/wf-1/task-deadbeef')).toBeUndefined();
+    expect(parseExperimentBranch('experiment/wf-1-deadbeef')).toBeUndefined();
+  });
+
+  it('rejects non-experiment branches', () => {
+    expect(parseExperimentBranch('master')).toBeUndefined();
+    expect(parseExperimentBranch('feature/foo')).toBeUndefined();
+    expect(parseExperimentBranch('')).toBeUndefined();
+  });
+
+  it('rejects malformed lifecycle tag or hash', () => {
+    expect(parseExperimentBranch('experiment/wf-1/task/g0.t0.a-NOTHEX1')).toBeUndefined();
+    expect(parseExperimentBranch('experiment/wf-1/task/g0.t0-deadbeef')).toBeUndefined();
+    expect(parseExperimentBranch('experiment/wf-1/task/garbage-deadbeef')).toBeUndefined();
   });
 });
 

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -5,6 +5,11 @@ import { spawn } from 'node:child_process';
  * Merkle-style hash for content-addressable branch naming.
  * Inputs: task identity + command/prompt + upstream dependency commits + base branch HEAD.
  * When any input changes (e.g. master moves forward), the hash changes and a fresh branch is created.
+ *
+ * The optional `salt` parameter is retained for backward compatibility with call
+ * sites that still mix lifecycle context into the hash. New call sites should
+ * use {@link computeContentHash} (which omits salt entirely) and put lifecycle
+ * uniqueness into the visible branch suffix via {@link buildExperimentBranchName}.
  */
 export function computeBranchHash(
   actionId: string,
@@ -22,6 +27,91 @@ export function computeBranchHash(
   h.update(baseHead);
   if (salt) h.update(salt);
   return h.digest('hex').slice(0, 8);
+}
+
+/**
+ * Pure content fingerprint of a task's execution spec.
+ *
+ * Identical inputs (actionId, command, prompt, upstream commits, baseHead)
+ * always produce the same 8-char hash. Lifecycle state (workflow generation,
+ * task generation, attempt id) is *not* mixed in — that uniqueness is supplied
+ * by {@link formatLifecycleTag} in the visible branch name instead, so two
+ * recreates of the same spec can be detected as cache-equivalent and reused.
+ */
+export function computeContentHash(
+  actionId: string,
+  command: string | undefined,
+  prompt: string | undefined,
+  upstreamCommits: string[],
+  baseHead: string,
+): string {
+  return computeBranchHash(actionId, command, prompt, upstreamCommits, baseHead, '');
+}
+
+export interface LifecycleTagInputs {
+  /** Workflow generation counter (bumped by recreateWorkflow / fork). */
+  wfGen: number;
+  /** Task execution generation counter (bumped by every retry/recreate-class action). */
+  taskGen: number;
+  /**
+   * Short attempt id derived from the attempt UUID. Pass an empty string to
+   * indicate "attempt id not yet known" — the resulting tag will use a single
+   * `-` placeholder. Callers should normally supply a non-empty value.
+   */
+  attemptShort: string;
+}
+
+/**
+ * Format a visible lifecycle tag for embedding in branch names.
+ *
+ * Shape: `g<wfGen>.t<taskGen>.a<attemptShort>`. The tag is stable per
+ * (workflow generation, task generation, attempt) triple — bumping any
+ * component yields a different tag and therefore a different branch name.
+ * That uniqueness-by-construction is what makes `git worktree add` collision-
+ * free even when stale worktrees from prior dispatches remain on disk.
+ */
+export function formatLifecycleTag(inputs: LifecycleTagInputs): string {
+  const wfGen = Number.isFinite(inputs.wfGen) ? Math.max(0, Math.floor(inputs.wfGen)) : 0;
+  const taskGen = Number.isFinite(inputs.taskGen) ? Math.max(0, Math.floor(inputs.taskGen)) : 0;
+  const rawAttempt = (inputs.attemptShort ?? '').toString();
+  const attemptShort = sanitizeAttemptShort(rawAttempt);
+  return `g${wfGen}.t${taskGen}.a${attemptShort}`;
+}
+
+/**
+ * Build the canonical experiment branch name for a dispatch.
+ *
+ * Shape: `experiment/<actionId>/<lifecycleTag>-<contentHash>`.
+ *
+ * `actionId` is workflow-scoped (e.g. `wf-1234/task-name`), so the literal
+ * `experiment/<actionId>/` prefix already makes the branch unique to the
+ * (workflow, task) pair. The `<lifecycleTag>` segment makes it unique per
+ * dispatch. The `<contentHash>` segment is the spec fingerprint and is the
+ * cache key for "same spec → may reuse workspace".
+ */
+export function buildExperimentBranchName(
+  actionId: string,
+  lifecycleTag: string,
+  contentHash: string,
+): string {
+  if (!actionId) {
+    throw new Error('buildExperimentBranchName: actionId is required');
+  }
+  if (!contentHash) {
+    throw new Error('buildExperimentBranchName: contentHash is required');
+  }
+  const tag = lifecycleTag && lifecycleTag.length > 0 ? lifecycleTag : 'g0.t0.a';
+  return `experiment/${actionId}/${tag}-${contentHash}`;
+}
+
+/**
+ * Restrict the attempt-short component to filesystem- and git-safe characters
+ * and bound its length. Keeps a-z, 0-9, dash, underscore. Truncates to 12
+ * characters which is more than enough entropy at the per-task scale.
+ */
+function sanitizeAttemptShort(raw: string): string {
+  const lower = raw.toLowerCase().replace(/[^a-z0-9_-]+/g, '');
+  return lower.slice(0, 12);
 }
 
 export interface PreserveOrResetOpts {

--- a/packages/execution-engine/src/worktree-discovery.ts
+++ b/packages/execution-engine/src/worktree-discovery.ts
@@ -98,3 +98,39 @@ export function abbrevRefMatchesBranch(abbrevRef: string, branch: string): boole
   if (t === 'HEAD') return false;
   return t === branch;
 }
+
+export interface ParsedExperimentBranch {
+  /** Workflow-scoped action id (e.g. `wf-1234/task-name`). */
+  actionId: string;
+  /** Lifecycle tag (e.g. `g0.t1.a3f9c0d2`). */
+  lifecycleTag: string;
+  /** 8-char content hash (fingerprint of spec inputs). */
+  contentHash: string;
+}
+
+/**
+ * Parse an experiment branch name produced by `buildExperimentBranchName`.
+ *
+ * Returns the structured pieces, or `undefined` if the input does not match
+ * the new `experiment/<actionId>/<lifecycleTag>-<contentHash>` shape.
+ *
+ * Note: the legacy `experiment/<actionId>-<sha8>` shape is intentionally not
+ * recognized here — old-format branches are ignored by the new code paths
+ * and are expected to be wiped manually by the operator.
+ */
+export function parseExperimentBranch(branch: string): ParsedExperimentBranch | undefined {
+  if (typeof branch !== 'string' || !branch.startsWith('experiment/')) return undefined;
+  const rest = branch.slice('experiment/'.length);
+  const lastSlash = rest.lastIndexOf('/');
+  if (lastSlash <= 0) return undefined;
+  const actionId = rest.slice(0, lastSlash);
+  const tail = rest.slice(lastSlash + 1);
+  const dash = tail.lastIndexOf('-');
+  if (dash <= 0 || dash === tail.length - 1) return undefined;
+  const lifecycleTag = tail.slice(0, dash);
+  const contentHash = tail.slice(dash + 1);
+  if (!/^[0-9a-f]{8}$/.test(contentHash)) return undefined;
+  if (!/^g\d+\.t\d+\.a[a-z0-9_-]*$/.test(lifecycleTag)) return undefined;
+  if (!actionId.length) return undefined;
+  return { actionId, lifecycleTag, contentHash };
+}


### PR DESCRIPTION
## Summary
This introduces the new branch-naming primitives without changing acquisition behavior yet. `computeContentHash` becomes a pure spec fingerprint, `formatLifecycleTag` carries workflow/task/attempt lifecycle state, and `buildExperimentBranchName` plus `parseExperimentBranch` define the new `experiment/<actionId>/<lifecycleTag>-<contentHash>` grammar.

## Problem
Branch naming mixed content identity and lifecycle identity too tightly, which made later collision-avoidance work harder to express and reason about.

## Root Cause
The existing branch format did not separate stable spec fingerprinting from per-attempt lifecycle state.

## Approach
Introduce explicit format and parse primitives for a branch grammar that encodes content hash and lifecycle tag separately.

## Why This Fix Is Right
This step removes the old salt-style uniqueness model instead of keeping it in parallel. The new naming model makes lifecycle uniqueness visible in the branch name and keeps the content hash stable. `parseExperimentBranch(...)` exists for pool recovery and worktree discovery only; dispatch still builds the branch name directly from first principles rather than reverse-engineering it.

## Tradeoffs And Considerations
The branch grammar is more explicit than the old single-hash shape, but that explicitness is what makes later recovery and worktree-management steps understandable.

## Before
```mermaid
flowchart LR
  A[spec + lifecycle mixed into one hash] --> B[legacy branch name]
  B --> C[hard to distinguish content from dispatch state]
```

## After
```mermaid
flowchart LR
  A2[spec fingerprint] --> B2[content hash]
  D2[lifecycle state] --> E2[lifecycle tag]
  B2 --> F2[new branch grammar]
  E2 --> F2
  F2 --> G2[parseable, collision-free branch name]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `collision-free branches: add format/parse plumbing (step 1)`
