### PR TITLE
collision-free branches: drop salt, plumb lifecycleTag (step 2)

### DIFF
--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -937,7 +937,7 @@ describe('Flow 7: orphan relaunch on restart', () => {
 
 // ── Flow 8: Restart Workflow with Generation Salt ───────────
 
-describe('Flow 8: restart workflow with generation salt', () => {
+describe('Flow 8: restart workflow with generation lifecycle tag', () => {
   let h: TestHarness;
 
   beforeEach(() => {

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -39,8 +39,13 @@ export interface WorkRequestInputs {
   }>;
   /** Branch names from completed upstream dependencies to merge into the worktree. */
   upstreamBranches?: string[];
-  /** Generation salt (workflow + task execution) — changes content-addressable branch hashes on recreate/restart. */
-  salt?: string;
+  /**
+   * Visible lifecycle tag (e.g. `g0.t1.aabc12345`) embedded in the branch name
+   * to make every dispatch unique-by-construction across recreates and retries.
+   * Replaces the legacy `salt` field that mixed lifecycle context into the
+   * content-hash itself.
+   */
+  lifecycleTag?: string;
   /** Workflow base branch — worktrees are created from this ref instead of HEAD. */
   baseBranch?: string;
   /** Name of the execution agent to use (e.g. 'claude', 'codex'). Defaults to 'claude'. */

--- a/packages/execution-engine/src/__tests__/branch-chain.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-chain.test.ts
@@ -203,15 +203,15 @@ describe('A→B→C branch chain', { timeout: 120_000 }, () => {
       const { tasks, executor } = buildChain({ a: worktreeCmd, b: worktreeCmd, c: worktreeCmd });
 
       await executeTask(executor, tasks, 'task-a');
-      expect(tasks[0].execution.branch).toMatch(/^experiment\/task-a-[a-f0-9]{8}$/);
+      expect(tasks[0].execution.branch).toMatch(/^experiment\/task-a\/g\d+\.t\d+\.a[a-z0-9_-]*-[a-f0-9]{8}$/);
       expect(branchExists(tmpDir, tasks[0].execution.branch!)).toBe(true);
 
       await executeTask(executor, tasks, 'task-b');
-      expect(tasks[1].execution.branch).toMatch(/^experiment\/task-b-[a-f0-9]{8}$/);
+      expect(tasks[1].execution.branch).toMatch(/^experiment\/task-b\/g\d+\.t\d+\.a[a-z0-9_-]*-[a-f0-9]{8}$/);
       expect(branchExists(tmpDir, tasks[1].execution.branch!)).toBe(true);
 
       await executeTask(executor, tasks, 'task-c');
-      expect(tasks[2].execution.branch).toMatch(/^experiment\/task-c-[a-f0-9]{8}$/);
+      expect(tasks[2].execution.branch).toMatch(/^experiment\/task-c\/g\d+\.t\d+\.a[a-z0-9_-]*-[a-f0-9]{8}$/);
       expect(branchExists(tmpDir, tasks[2].execution.branch!)).toBe(true);
     });
 

--- a/packages/execution-engine/src/__tests__/branch-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-utils.test.ts
@@ -4,7 +4,6 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import {
-  computeBranchHash,
   computeContentHash,
   formatLifecycleTag,
   buildExperimentBranchName,
@@ -32,78 +31,76 @@ function gitExec(cmd: string, cwd: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// computeBranchHash (pure TypeScript, no git)
+// computeContentHash (pure TypeScript, no git)
 // ---------------------------------------------------------------------------
 
-describe('computeBranchHash', () => {
+describe('computeContentHash', () => {
   it('is deterministic: same inputs produce same hash', () => {
-    const a = computeBranchHash('task-1', 'echo hi', undefined, [], 'abc123');
-    const b = computeBranchHash('task-1', 'echo hi', undefined, [], 'abc123');
+    const a = computeContentHash('task-1', 'echo hi', undefined, [], 'abc123');
+    const b = computeContentHash('task-1', 'echo hi', undefined, [], 'abc123');
     expect(a).toBe(b);
   });
 
   it('is sensitive to command changes', () => {
-    const a = computeBranchHash('task-1', 'echo a', undefined, [], 'abc');
-    const b = computeBranchHash('task-1', 'echo b', undefined, [], 'abc');
+    const a = computeContentHash('task-1', 'echo a', undefined, [], 'abc');
+    const b = computeContentHash('task-1', 'echo b', undefined, [], 'abc');
     expect(a).not.toBe(b);
   });
 
   it('is sensitive to prompt changes', () => {
-    const a = computeBranchHash('task-1', undefined, 'prompt a', [], 'abc');
-    const b = computeBranchHash('task-1', undefined, 'prompt b', [], 'abc');
+    const a = computeContentHash('task-1', undefined, 'prompt a', [], 'abc');
+    const b = computeContentHash('task-1', undefined, 'prompt b', [], 'abc');
     expect(a).not.toBe(b);
   });
 
   it('is sensitive to baseHead changes', () => {
-    const a = computeBranchHash('task-1', 'cmd', undefined, [], 'head-a');
-    const b = computeBranchHash('task-1', 'cmd', undefined, [], 'head-b');
+    const a = computeContentHash('task-1', 'cmd', undefined, [], 'head-a');
+    const b = computeContentHash('task-1', 'cmd', undefined, [], 'head-b');
     expect(a).not.toBe(b);
   });
 
   it('is sensitive to upstream commit changes', () => {
-    const a = computeBranchHash('task-1', 'cmd', undefined, ['c1'], 'abc');
-    const b = computeBranchHash('task-1', 'cmd', undefined, ['c2'], 'abc');
+    const a = computeContentHash('task-1', 'cmd', undefined, ['c1'], 'abc');
+    const b = computeContentHash('task-1', 'cmd', undefined, ['c2'], 'abc');
     expect(a).not.toBe(b);
   });
 
   it('is order-independent for upstream commits', () => {
-    const a = computeBranchHash('task-1', 'cmd', undefined, ['c1', 'c2'], 'abc');
-    const b = computeBranchHash('task-1', 'cmd', undefined, ['c2', 'c1'], 'abc');
-    expect(a).toBe(b);
-  });
-
-  it('is sensitive to salt changes', () => {
-    const a = computeBranchHash('task-1', 'cmd', undefined, [], 'abc', 'salt-a');
-    const b = computeBranchHash('task-1', 'cmd', undefined, [], 'abc', 'salt-b');
-    expect(a).not.toBe(b);
-  });
-
-  it('produces 8-character hex string', () => {
-    const h = computeBranchHash('task-1', 'cmd', undefined, [], 'abc');
-    expect(h).toMatch(/^[0-9a-f]{8}$/);
-  });
-});
-
-// ---------------------------------------------------------------------------
-// computeContentHash
-// ---------------------------------------------------------------------------
-
-describe('computeContentHash', () => {
-  it('matches computeBranchHash without salt', () => {
-    const a = computeContentHash('task-1', 'cmd', undefined, ['c1'], 'head');
-    const b = computeBranchHash('task-1', 'cmd', undefined, ['c1'], 'head');
-    expect(a).toBe(b);
-  });
-
-  it('is insensitive to lifecycle (no salt parameter exists)', () => {
-    const a = computeContentHash('task-1', 'cmd', undefined, [], 'head');
-    const b = computeContentHash('task-1', 'cmd', undefined, [], 'head');
+    const a = computeContentHash('task-1', 'cmd', undefined, ['c1', 'c2'], 'abc');
+    const b = computeContentHash('task-1', 'cmd', undefined, ['c2', 'c1'], 'abc');
     expect(a).toBe(b);
   });
 
   it('produces 8-character hex string', () => {
-    const h = computeContentHash('task-1', 'cmd', undefined, [], 'head');
+    const h = computeContentHash('task-1', 'cmd', undefined, [], 'abc');
     expect(h).toMatch(/^[0-9a-f]{8}$/);
+  });
+
+  it('is insensitive to lifecycle context (no salt parameter)', () => {
+    // Two consecutive recreates of the identical spec must yield the same content
+    // hash. Lifecycle uniqueness lives in the branch name (lifecycle tag), not
+    // the hash. Regression test for the salt-collision bug.
+    const a = computeContentHash('task-1', 'cmd', 'prompt', ['c1'], 'head');
+    const b = computeContentHash('task-1', 'cmd', 'prompt', ['c1'], 'head');
+    expect(a).toBe(b);
+  });
+
+  it('combined with formatLifecycleTag yields distinct branch names per attempt', () => {
+    const contentHash = computeContentHash('wf-1/t', 'cmd', undefined, [], 'head');
+    const branchA = buildExperimentBranchName(
+      'wf-1/t',
+      formatLifecycleTag({ wfGen: 0, taskGen: 0, attemptShort: 'aaa11111' }),
+      contentHash,
+    );
+    const branchB = buildExperimentBranchName(
+      'wf-1/t',
+      formatLifecycleTag({ wfGen: 0, taskGen: 1, attemptShort: 'bbb22222' }),
+      contentHash,
+    );
+    expect(branchA).not.toBe(branchB);
+    // Same spec → same content hash, even though branch names differ.
+    expect(branchA.endsWith(`-${contentHash}`)).toBe(true);
+    expect(branchB.endsWith(`-${contentHash}`)).toBe(true);
   });
 });
 

--- a/packages/execution-engine/src/__tests__/docker-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/docker-executor.test.ts
@@ -150,7 +150,7 @@ describe('DockerExecutor', () => {
       const request = args[1] as WorkRequest;
       const handle = args[2] as ExecutorHandle;
       const opts = args[3] as { branchName?: string } | undefined;
-      handle.branch = opts?.branchName ?? `experiment/${request.actionId}-00000000`;
+      handle.branch = opts?.branchName ?? `experiment/${request.actionId}/g0.t0.a-00000000`;
       return undefined;
     }) as any);
 
@@ -230,14 +230,14 @@ describe('DockerExecutor', () => {
       expect.objectContaining({ actionId: 'action-1' }),
       expect.any(Object),
       expect.objectContaining({
-        branchName: expect.stringMatching(/^experiment\/action-1-[0-9a-f]{8}$/),
+        branchName: expect.stringMatching(/^experiment\/action-1\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}$/),
       }),
     );
   });
 
   it('sets handle.branch from setupTaskBranch', async () => {
     const handle = await executor.start(makeRequest());
-    expect(handle.branch).toMatch(/^experiment\/action-1-[0-9a-f]{8}$/);
+    expect(handle.branch).toMatch(/^experiment\/action-1\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}$/);
   });
 
   // -------------------------------------------------------------------------
@@ -286,7 +286,7 @@ describe('DockerExecutor', () => {
       expect.objectContaining({ actionId: 'act-exit' }),
       '/app',
       0,
-      expect.objectContaining({ branch: expect.stringMatching(/^experiment\/act-exit-[0-9a-f]{8}$/) }),
+      expect.objectContaining({ branch: expect.stringMatching(/^experiment\/act-exit\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}$/) }),
     );
   });
 

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -6,7 +6,7 @@ import type { WorkRequest } from '@invoker/contracts';
 import type { PersistedTaskMeta } from '../executor.js';
 import { createSshRemoteScriptError } from '../ssh-git-exec.js';
 import { computeRepoUrlHash } from '../git-utils.js';
-import { computeBranchHash } from '../branch-utils.js';
+import { computeContentHash, buildExperimentBranchName, formatLifecycleTag } from '../branch-utils.js';
 
 function makeRequest(overrides: Partial<WorkRequest> = {}): WorkRequest {
   return {
@@ -196,7 +196,7 @@ describe('SshExecutor managed workspace mode', () => {
     const handle = await ssh.start(req);
 
     expect(handle.workspacePath).toMatch(/^\~\/\.invoker\/worktrees\/[a-f0-9]{12}\//);
-    expect(handle.branch).toMatch(/^experiment\/test-task-[a-f0-9]{8}$/);
+    expect(handle.branch).toMatch(/^experiment\/test-task\/g\d+\.t\d+\.a[a-z0-9_-]*-[a-f0-9]{8}$/);
 
     // Verify spawnSshRemoteStdin was called with correct arguments
     expect(spawnStub).toHaveBeenCalledTimes(1);
@@ -255,7 +255,7 @@ branch refs/heads/experiment/test-task-oldhash
 
     const handle = await ssh.start(req);
 
-    expect(handle.workspacePath).toMatch(new RegExp(`^~/.invoker/worktrees/${repoHash}/experiment-test-task-[0-9a-f]{8}$`));
+    expect(handle.workspacePath).toMatch(new RegExp(`^~/.invoker/worktrees/${repoHash}/experiment-test-task-g\\d+\\.t\\d+\\.a[a-z0-9_-]*-[0-9a-f]{8}$`));
     expect(handle.workspacePath).not.toBe(`~/.invoker/worktrees/${repoHash}/experiment-test-task-oldhash`);
     expect(setupTaskBranchSpy).toHaveBeenCalledTimes(1);
     expect(execRemoteCapture).not.toHaveBeenCalledWith(expect.stringContaining('branch -m'), 'rename_reuse_branch');
@@ -304,7 +304,7 @@ branch refs/heads/experiment/test-task-oldhash
 
     expect(err.message).toContain('already used by worktree');
     expect(err.workspacePath).toBe(ownerPath);
-    expect(err.branch).toMatch(/^experiment\/test-task-[0-9a-f]{8}$/);
+    expect(err.branch).toMatch(/^experiment\/test-task\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}$/);
   });
 
   it('cleans up the existing branch-owner worktree before recreating a conflicting target branch (when cleanup enabled)', async () => {
@@ -320,15 +320,14 @@ branch refs/heads/experiment/test-task-oldhash
 
     const repoHash = computeRepoUrlHash('git@github.com:owner/repo.git');
     const baseHead = 'abc123def456abc123def456abc123def456abc1';
-    const branchHash = computeBranchHash(
+    const branchHash = computeContentHash(
       'test-task-conflict',
       'pnpm test',
       undefined,
       [],
       baseHead,
-      '',
     );
-    const targetBranch = `experiment/test-task-conflict-${branchHash}`;
+    const targetBranch = buildExperimentBranchName('test-task-conflict', '', branchHash);
     const ownerPath = `/home/testuser/.invoker/worktrees/${repoHash}/stale-owner-${branchHash}`;
     let cleanupScript = '';
     vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string, phase?: string) => {
@@ -940,7 +939,7 @@ describe('SshExecutor entry lifecycle', () => {
     await new Promise((r) => setTimeout(r, 50));
   });
 
-  it('changes managed branch and worktree when request salt changes, as recreate does', async () => {
+  it('changes managed branch and worktree when request lifecycleTag changes, as recreate does', async () => {
     const ssh2 = new SshExecutor({
       host: 'localhost',
       user: 'testuser',
@@ -970,18 +969,27 @@ describe('SshExecutor entry lifecycle', () => {
     const first = await ssh2.start(makeRequest({
       requestId: 'req-salt-1',
       actionType: 'command',
-      inputs: { ...baseInputs, salt: 'wf:1|task:4' },
+      inputs: {
+        ...baseInputs,
+        lifecycleTag: formatLifecycleTag({ wfGen: 1, taskGen: 4, attemptShort: 'a1' }),
+      },
     }));
     const second = await ssh2.start(makeRequest({
       requestId: 'req-salt-2',
       actionType: 'command',
-      inputs: { ...baseInputs, salt: 'wf:1|task:5' },
+      inputs: {
+        ...baseInputs,
+        lifecycleTag: formatLifecycleTag({ wfGen: 1, taskGen: 5, attemptShort: 'a2' }),
+      },
     }));
 
     const firstOpts = setupTaskBranchSpy.mock.calls[0]?.[3];
     const secondOpts = setupTaskBranchSpy.mock.calls[1]?.[3];
-    expect(firstOpts?.branchName).toMatch(/^experiment\/test-task-[0-9a-f]{8}$/);
-    expect(secondOpts?.branchName).toMatch(/^experiment\/test-task-[0-9a-f]{8}$/);
+    const branchPattern = /^experiment\/test-task\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}$/;
+    expect(firstOpts?.branchName).toMatch(branchPattern);
+    expect(secondOpts?.branchName).toMatch(branchPattern);
+    // Same content (cmd/prompt/base) → same content hash; lifecycle tag must
+    // still differentiate the two branches.
     expect(firstOpts?.branchName).not.toBe(secondOpts?.branchName);
     expect(firstOpts?.worktreeDir).not.toBe(secondOpts?.worktreeDir);
     expect(first.branch).toBe(firstOpts?.branchName);

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1567,7 +1567,7 @@ describe('TaskRunner', () => {
   });
 
   describe('baseBranch in WorkRequest', () => {
-    it('encodes workflow generation, task generation, and attemptId in request salt', async () => {
+    it('encodes workflow generation, task generation, and attemptId in request lifecycleTag', async () => {
       let capturedRequest: any;
       const capturingExecutor = {
         type: 'worktree',
@@ -1611,10 +1611,12 @@ describe('TaskRunner', () => {
       await executor.executeTask(task);
 
       expect(capturedRequest).toBeDefined();
-      expect(capturedRequest.inputs.salt).toBe('wf:3|task:5|attempt:attempt-abc');
+      // Lifecycle tag embeds wfGen=3, taskGen=5, attemptShort sanitized from
+      // 'attempt-abc' (truncated to 12 chars, lowercased, kept dash chars).
+      expect(capturedRequest.inputs.lifecycleTag).toBe('g3.t5.aattempt-abc');
     });
 
-    it('still includes attemptId in salt when both generations are zero', async () => {
+    it('still includes attemptId in lifecycleTag when both generations are zero', async () => {
       let capturedRequest: any;
       const capturingExecutor = {
         type: 'worktree',
@@ -1658,7 +1660,7 @@ describe('TaskRunner', () => {
       await executor.executeTask(task);
 
       expect(capturedRequest).toBeDefined();
-      expect(capturedRequest.inputs.salt).toBe('wf:0|task:0|attempt:attempt-xyz');
+      expect(capturedRequest.inputs.lifecycleTag).toBe('g0.t0.aattempt-xyz');
     });
 
     it('includes workflow baseBranch in request inputs', async () => {

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -18,7 +18,7 @@ vi.mock('node:fs', async (importOriginal) => {
 // Must import after mock setup
 import { spawn } from 'node:child_process';
 import { existsSync, mkdirSync } from 'node:fs';
-import { WorktreeExecutor, computeBranchHash } from '../worktree-executor.js';
+import { WorktreeExecutor, computeContentHash } from '../worktree-executor.js';
 import { BaseExecutor } from '../base-executor.js';
 
 const mockedSpawn = vi.mocked(spawn);
@@ -160,75 +160,21 @@ async function waitForCondition(predicate: () => boolean, timeoutMs = 500): Prom
   }
 }
 
-describe('computeBranchHash', () => {
+describe('computeContentHash (re-exported by worktree-executor)', () => {
   it('is deterministic: same inputs produce same hash', () => {
-    const a = computeBranchHash('t1', 'echo hi', undefined, ['c1'], 'HEAD1');
-    const b = computeBranchHash('t1', 'echo hi', undefined, ['c1'], 'HEAD1');
+    const a = computeContentHash('t1', 'echo hi', undefined, ['c1'], 'HEAD1');
+    const b = computeContentHash('t1', 'echo hi', undefined, ['c1'], 'HEAD1');
     expect(a).toBe(b);
     expect(a).toMatch(/^[0-9a-f]{8}$/);
   });
 
-  it('is sensitive to command changes', () => {
-    const a = computeBranchHash('t1', 'echo hi', undefined, [], 'HEAD1');
-    const b = computeBranchHash('t1', 'echo bye', undefined, [], 'HEAD1');
-    expect(a).not.toBe(b);
-  });
-
-  it('is sensitive to prompt changes', () => {
-    const a = computeBranchHash('t1', undefined, 'prompt A', [], 'HEAD1');
-    const b = computeBranchHash('t1', undefined, 'prompt B', [], 'HEAD1');
-    expect(a).not.toBe(b);
-  });
-
-  it('is sensitive to baseHead changes', () => {
-    const a = computeBranchHash('t1', 'cmd', undefined, [], 'abc123');
-    const b = computeBranchHash('t1', 'cmd', undefined, [], 'def456');
-    expect(a).not.toBe(b);
-  });
-
-  it('is sensitive to upstream commit changes', () => {
-    const a = computeBranchHash('t1', 'cmd', undefined, ['c1'], 'HEAD1');
-    const b = computeBranchHash('t1', 'cmd', undefined, ['c2'], 'HEAD1');
-    expect(a).not.toBe(b);
-  });
-
-  it('is order-independent for upstream commits', () => {
-    const a = computeBranchHash('t1', 'cmd', undefined, ['c1', 'c2'], 'HEAD1');
-    const b = computeBranchHash('t1', 'cmd', undefined, ['c2', 'c1'], 'HEAD1');
+  it('is insensitive to lifecycle context (no salt parameter)', () => {
+    // Two recreates of identical spec produce identical content hash. The
+    // collision-free guarantee comes from the lifecycle tag in the branch
+    // name, not from mixing lifecycle into the hash.
+    const a = computeContentHash('t1', 'cmd', undefined, [], 'HEAD1');
+    const b = computeContentHash('t1', 'cmd', undefined, [], 'HEAD1');
     expect(a).toBe(b);
-  });
-
-  it('is sensitive to salt changes', () => {
-    const a = computeBranchHash('t1', 'cmd', undefined, [], 'HEAD1', '0');
-    const b = computeBranchHash('t1', 'cmd', undefined, [], 'HEAD1', '1');
-    expect(a).not.toBe(b);
-  });
-
-  it('produces same hash when salt is identical', () => {
-    const a = computeBranchHash('t1', 'cmd', undefined, [], 'HEAD1', '42');
-    const b = computeBranchHash('t1', 'cmd', undefined, [], 'HEAD1', '42');
-    expect(a).toBe(b);
-  });
-
-  it('is stable when workflow/task generation salt is unchanged', () => {
-    const salt = 'wf:2|task:4';
-    const a = computeBranchHash('t1', 'cmd', undefined, ['c1'], 'HEAD1', salt);
-    const b = computeBranchHash('t1', 'cmd', undefined, ['c1'], 'HEAD1', salt);
-    expect(a).toBe(b);
-  });
-
-  it('changes when either workflow or task generation salt changes', () => {
-    const base = computeBranchHash('t1', 'cmd', undefined, ['c1'], 'HEAD1', 'wf:2|task:4');
-    const workflowBumped = computeBranchHash('t1', 'cmd', undefined, ['c1'], 'HEAD1', 'wf:3|task:4');
-    const taskBumped = computeBranchHash('t1', 'cmd', undefined, ['c1'], 'HEAD1', 'wf:2|task:5');
-    expect(base).not.toBe(workflowBumped);
-    expect(base).not.toBe(taskBumped);
-  });
-
-  it('is backward compatible when salt is omitted or empty', () => {
-    const noSalt = computeBranchHash('t1', 'cmd', undefined, [], 'HEAD1');
-    const emptySalt = computeBranchHash('t1', 'cmd', undefined, [], 'HEAD1', '');
-    expect(noSalt).toBe(emptySalt);
   });
 });
 
@@ -299,10 +245,10 @@ describe('WorktreeExecutor', () => {
     expect(pool.acquireWorktree).toHaveBeenCalledTimes(1);
     const [calledUrl, calledBranch] = pool.acquireWorktree.mock.calls[0];
     expect(calledUrl).toBe('git@github.com:test/repo.git');
-    expect(calledBranch).toMatch(/^experiment\/action-1-[0-9a-f]{8}$/);
+    expect(calledBranch).toMatch(/^experiment\/action-1\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}$/);
 
     // Branch should be content-addressable
-    expect(handle.branch).toMatch(/^experiment\/action-1-[0-9a-f]{8}$/);
+    expect(handle.branch).toMatch(/^experiment\/action-1\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}$/);
 
     // Cleanup: emit close on task process to prevent hanging
     taskProcess.emit('close', 0, null);
@@ -373,7 +319,7 @@ describe('WorktreeExecutor', () => {
     expect(response.requestId).toBe('req-1');
     expect(response.actionId).toBe('action-1');
     expect(response.outputs.exitCode).toBe(0);
-    expect(response.outputs.summary).toMatch(/experiment\/action-1-[0-9a-f]{8}/);
+    expect(response.outputs.summary).toMatch(/experiment\/action-1\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}/);
     expect(response.outputs.summary).toContain('abc123def456');
   });
 
@@ -658,7 +604,7 @@ describe('WorktreeExecutor', () => {
     const pool = (executor as any).pool;
     expect(pool.acquireWorktree).toHaveBeenCalledTimes(1);
     expect(handle.workspacePath).toMatch(/^\/fake\/worktrees\//);
-    expect(handle.branch).toMatch(/^experiment\/action-1-[0-9a-f]{8}$/);
+    expect(handle.branch).toMatch(/^experiment\/action-1\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}$/);
 
     // No non-git spawn should have occurred
     const taskCalls = mockedSpawn.mock.calls.filter(
@@ -1232,8 +1178,8 @@ describe('WorktreeExecutor', () => {
     });
 
     it('baseBranch changes content-addressable branch hash', () => {
-      const hashWithMaster = computeBranchHash('t1', 'cmd', undefined, [], 'master-sha');
-      const hashWithDev = computeBranchHash('t1', 'cmd', undefined, [], 'dev-sha');
+      const hashWithMaster = computeContentHash('t1', 'cmd', undefined, [], 'master-sha');
+      const hashWithDev = computeContentHash('t1', 'cmd', undefined, [], 'dev-sha');
       expect(hashWithMaster).not.toBe(hashWithDev);
     });
   });
@@ -1249,7 +1195,7 @@ describe('WorktreeExecutor', () => {
       const pool = (executor as any).pool;
       expect(pool.acquireWorktree).toHaveBeenCalledTimes(1);
       const [, calledBranch] = pool.acquireWorktree.mock.calls[0];
-      expect(calledBranch).toMatch(/^experiment\/action-1-[0-9a-f]{8}$/);
+      expect(calledBranch).toMatch(/^experiment\/action-1\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}$/);
 
       taskProcess.emit('close', 0, null);
     });

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -2,41 +2,16 @@ import { createHash } from 'node:crypto';
 import { spawn } from 'node:child_process';
 
 /**
- * Merkle-style hash for content-addressable branch naming.
- * Inputs: task identity + command/prompt + upstream dependency commits + base branch HEAD.
- * When any input changes (e.g. master moves forward), the hash changes and a fresh branch is created.
- *
- * The optional `salt` parameter is retained for backward compatibility with call
- * sites that still mix lifecycle context into the hash. New call sites should
- * use {@link computeContentHash} (which omits salt entirely) and put lifecycle
- * uniqueness into the visible branch suffix via {@link buildExperimentBranchName}.
- */
-export function computeBranchHash(
-  actionId: string,
-  command: string | undefined,
-  prompt: string | undefined,
-  upstreamCommits: string[],
-  baseHead: string,
-  salt: string = '',
-): string {
-  const h = createHash('sha256');
-  h.update(actionId);
-  h.update(command ?? '');
-  h.update(prompt ?? '');
-  for (const c of [...upstreamCommits].sort()) h.update(c);
-  h.update(baseHead);
-  if (salt) h.update(salt);
-  return h.digest('hex').slice(0, 8);
-}
-
-/**
  * Pure content fingerprint of a task's execution spec.
  *
- * Identical inputs (actionId, command, prompt, upstream commits, baseHead)
- * always produce the same 8-char hash. Lifecycle state (workflow generation,
- * task generation, attempt id) is *not* mixed in — that uniqueness is supplied
- * by {@link formatLifecycleTag} in the visible branch name instead, so two
- * recreates of the same spec can be detected as cache-equivalent and reused.
+ * Inputs: task identity + command/prompt + upstream dependency commits + base
+ * branch HEAD. Identical inputs always produce the same 8-char hash. Lifecycle
+ * state (workflow generation, task generation, attempt id) is intentionally
+ * *not* mixed in — that uniqueness is supplied by {@link formatLifecycleTag}
+ * in the visible branch name via {@link buildExperimentBranchName}. Two
+ * recreates of the same spec therefore produce the same `contentHash` but
+ * different branch names, allowing the acquire layer to recognise them as
+ * cache-equivalent.
  */
 export function computeContentHash(
   actionId: string,
@@ -45,7 +20,13 @@ export function computeContentHash(
   upstreamCommits: string[],
   baseHead: string,
 ): string {
-  return computeBranchHash(actionId, command, prompt, upstreamCommits, baseHead, '');
+  const h = createHash('sha256');
+  h.update(actionId);
+  h.update(command ?? '');
+  h.update(prompt ?? '');
+  for (const c of [...upstreamCommits].sort()) h.update(c);
+  h.update(baseHead);
+  return h.digest('hex').slice(0, 8);
 }
 
 export interface LifecycleTagInputs {

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -4,7 +4,7 @@ import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import { loadSecretsFile } from './secrets-loader.js';
 import { killProcessGroup, cleanElectronEnv, SIGKILL_TIMEOUT_MS } from './process-utils.js';
-import { computeBranchHash } from './branch-utils.js';
+import { computeContentHash, buildExperimentBranchName } from './branch-utils.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { traceExecution } from './exec-trace.js';
 
@@ -353,15 +353,18 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
     const upstreamCommits = (request.inputs.upstreamContext ?? [])
       .map(c => c.commitHash)
       .filter((h): h is string => !!h);
-    const hash = computeBranchHash(
+    const contentHash = computeContentHash(
       request.actionId,
       request.inputs.command,
       request.inputs.prompt,
       upstreamCommits,
       baseHead,
-      request.inputs.salt,
     );
-    const branchName = `experiment/${request.actionId}-${hash}`;
+    const branchName = buildExperimentBranchName(
+      request.actionId,
+      request.inputs.lifecycleTag ?? '',
+      contentHash,
+    );
     const baseBranch = request.inputs.upstreamBranches?.[0]
       ?? request.inputs.baseBranch
       ?? 'HEAD';

--- a/packages/execution-engine/src/plan-base-remote.ts
+++ b/packages/execution-engine/src/plan-base-remote.ts
@@ -104,7 +104,7 @@ export function shouldResolveViaOriginTracking(ref: string): boolean {
 }
 
 /**
- * Resolve base ref to a full commit SHA for computeBranchHash / worktree base.
+ * Resolve base ref to a full commit SHA for computeContentHash / worktree base.
  * For short branch names and legacy remote-qualified refs, uses origin/<branch>.
  */
 export async function resolvePlanBaseRevision(

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -5,7 +5,7 @@ import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import { killProcessGroup, cleanElectronEnv, SIGKILL_TIMEOUT_MS } from './process-utils.js';
-import { computeBranchHash } from './branch-utils.js';
+import { computeContentHash, buildExperimentBranchName } from './branch-utils.js';
 import { planManagedWorktree } from './managed-worktree-controller.js';
 import { findManagedWorktreeForBranch, abbrevRefMatchesBranch } from './worktree-discovery.js';
 import { DEFAULT_WORKTREE_PROVISION_COMMAND } from './default-worktree-provision-command.js';
@@ -299,7 +299,7 @@ echo ${payloadB64} | base64 -d | bash -se
     const upstreamCommits = (request.inputs.upstreamContext ?? [])
       .map(c => c.commitHash)
       .filter((x): x is string => !!x);
-    const salt = request.inputs.salt ?? '';
+    const lifecycleTag = request.inputs.lifecycleTag ?? '';
     handle.agentSessionId = agentSessionId;
 
     // Use configured remoteInvokerHome (default ~/.invoker)
@@ -322,15 +322,18 @@ echo ${payloadB64} | base64 -d | bash -se
         `[WARNING] Continuing with existing refs. Tasks may use stale commits.\n`;
       this.emitOutput(executionId, msg);
     }
-    const hash8 = computeBranchHash(
+    const contentHash = computeContentHash(
       request.actionId,
       request.inputs.command,
       request.inputs.prompt,
       upstreamCommits,
       baseHead,
-      salt,
     );
-    const experimentBranch = `experiment/${request.actionId}-${hash8}`;
+    const experimentBranch = buildExperimentBranchName(
+      request.actionId,
+      lifecycleTag,
+      contentHash,
+    );
     const san = sanitizeBranchForPath(experimentBranch);
     const remoteClone = `${invokerHome}/repos/${h}`;
     const canonicalRemoteWt = `${invokerHome}/worktrees/${h}/${san}`;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -26,6 +26,7 @@ import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
 import { isInvokerManagedPoolBranch } from './plan-base-remote.js';
+import { formatLifecycleTag } from './branch-utils.js';
 import { SshExecutor } from './ssh-executor.js';
 import {
   executeMergeNodeImpl,
@@ -407,15 +408,19 @@ export class TaskRunner {
       }
     }
 
-    // Read workflow + task generations for content-addressable branch salt.
-    // attemptId is mixed in unconditionally so that every attempt produces a
-    // brand-new branch hash. This makes cleanup of old worktrees/refs
-    // unnecessary for correctness: a fresh attempt can never collide with
-    // leftover state from a prior attempt.
+    // Read workflow + task generations to build the visible lifecycle tag that
+    // is appended to every experiment branch name. Lifecycle uniqueness lives
+    // in the branch *name* (via `formatLifecycleTag`), not in the content hash
+    // — so two recreates of the same spec produce the same content fingerprint
+    // (cache-equivalent) but distinct branch names (collision-free).
     const workflow = task.config.workflowId ? this.persistence.loadWorkflow?.(task.config.workflowId) : undefined;
     const workflowGeneration = (workflow as any)?.generation ?? 0;
     const taskExecutionGeneration = task.execution.generation ?? 0;
-    const generationSalt = `wf:${workflowGeneration}|task:${taskExecutionGeneration}|attempt:${attemptId}`;
+    const lifecycleTag = formatLifecycleTag({
+      wfGen: workflowGeneration,
+      taskGen: taskExecutionGeneration,
+      attemptShort: attemptId,
+    });
     const baseBranch = workflow?.baseBranch ?? this.defaultBranch;
     const repoUrl = workflow?.repoUrl;
 
@@ -435,7 +440,7 @@ export class TaskRunner {
         upstreamContext: upstreamContext.length > 0 ? upstreamContext : undefined,
         alternatives: alternatives.length > 0 ? alternatives : undefined,
         upstreamBranches: upstreamBranches.length > 0 ? upstreamBranches : undefined,
-        salt: generationSalt,
+        lifecycleTag,
         baseBranch,
         freshWorkspace: this.shouldUseFreshWorkspace(task),
       },

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -8,7 +8,12 @@ import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import { RepoPool } from './repo-pool.js';
 import { killProcessGroup, cleanElectronEnv, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 import { DEFAULT_WORKTREE_PROVISION_COMMAND } from './default-worktree-provision-command.js';
-import { computeBranchHash, bashMergeUpstreams, parseMergeError } from './branch-utils.js';
+import {
+  computeContentHash,
+  buildExperimentBranchName,
+  bashMergeUpstreams,
+  parseMergeError,
+} from './branch-utils.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import {
   syncPlanBaseRemote,
@@ -21,7 +26,7 @@ import { remoteFetchForPool } from './remote-fetch-policy.js';
 import { sanitizeBranchForPath } from './git-utils.js';
 
 // Re-export for backward compatibility
-export { computeBranchHash } from './branch-utils.js';
+export { computeContentHash, buildExperimentBranchName } from './branch-utils.js';
 
 export interface WorktreeExecutorConfig {
   /** Directory where worktrees are created. */
@@ -141,16 +146,19 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     const upstreamCommits = (request.inputs.upstreamContext ?? [])
       .map(c => c.commitHash)
       .filter((h): h is string => !!h);
-    const hash = computeBranchHash(
+    const contentHash = computeContentHash(
       request.actionId,
       request.inputs.command,
       request.inputs.prompt,
       upstreamCommits,
       baseHead,
-      request.inputs.salt,
     );
-    const branch = `experiment/${request.actionId}-${hash}`;
-    traceExecution(`[WorktreeExecutor] branch=${branch} hash=${hash}`);
+    const branch = buildExperimentBranchName(
+      request.actionId,
+      request.inputs.lifecycleTag ?? '',
+      contentHash,
+    );
+    traceExecution(`[WorktreeExecutor] branch=${branch} contentHash=${contentHash}`);
 
     // -- Reconciliation: real pool worktree at plan base (no upstream merges), then needs_input --
     if (request.actionType === 'reconciliation') {


### PR DESCRIPTION
## Summary
This migrates the branch-name call sites onto the new grammar. `WorkInputs.salt` becomes `WorkInputs.lifecycleTag`, the task runner builds the visible lifecycle tag from workflow, task generation, and attempt id, and the worktree, docker, and SSH executors all assemble branches with `buildExperimentBranchName(actionId, lifecycleTag, contentHash)`. Identical specs can now reuse the same content hash across recreates without collapsing onto the same branch.

## Problem
The new branch grammar existed, but real executor and task-runner code still used the old salted naming model.

## Root Cause
Step 1 established the format boundary but did not yet migrate the runtime call sites that actually construct experiment branches.

## Approach
Replace `salt` with `lifecycleTag` across contracts and executors, and route branch construction through the new grammar everywhere.

## Why This Fix Is Right
The naming model only becomes meaningful once every backend uses it consistently. This step turns the conceptual split between content and lifecycle identity into runtime behavior.

## Tradeoffs And Considerations
This is a broader churn across task runner and multiple executors, but it is necessary to keep all backends aligned on one naming contract.

## Before
```mermaid
flowchart LR
  A[task runner] --> B[salt string]
  B --> C[executor-specific branch construction]
  C --> D[old experiment/<actionId>-<sha8> shape]
```

## After
```mermaid
flowchart LR
  A2[task runner] --> B2[lifecycleTag]
  B2 --> C2[executors]
  D2[content hash] --> E2[buildExperimentBranchName]
  C2 --> E2
  E2 --> F2[new experiment/<actionId>/<tag>-<hash> branch]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `collision-free branches: drop salt, plumb lifecycleTag (step 2)`
