### PR TITLE
collision-free branches: acquire by content and validate leftovers

### DIFF
--- a/packages/app/e2e/edit-task-command.spec.ts
+++ b/packages/app/e2e/edit-task-command.spec.ts
@@ -7,9 +7,24 @@
  */
 
 import { test, expect, loadPlan, startPlan, waitForTaskStatus, E2E_REPO_URL } from './fixtures/electron-app.js';
+import type { Page } from '@playwright/test';
 
 function findTaskByIdSuffix(tasks: Array<any>, taskId: string) {
   return tasks.find((t) => t.id === taskId || t.id.endsWith(`/${taskId}`));
+}
+
+async function selectTaskAndWaitForCommandEditor(page: Page, taskSuffix: string): Promise<void> {
+  const node = page.locator(`.react-flow__node[data-testid$="/${taskSuffix}"]`);
+  const commandDisplay = page.locator('[data-testid="command-display"]');
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await node.click();
+    try {
+      await expect(commandDisplay).toBeVisible({ timeout: 3000 });
+      return;
+    } catch (err) {
+      if (attempt === 2) throw err;
+    }
+  }
 }
 
 const EDIT_CMD_PLAN = {
@@ -47,11 +62,10 @@ test.describe('Edit task command', () => {
     await waitForTaskStatus(page, 'task-will-fail', 'failed');
 
     // Click the failed task node to select it
-    await page.locator('.react-flow__node[data-testid$="/task-will-fail"]').click();
+    await selectTaskAndWaitForCommandEditor(page, 'task-will-fail');
 
     // Double-click the command display to enter edit mode.
     const commandDisplay = page.locator('[data-testid="command-display"]');
-    await expect(commandDisplay).toBeVisible({ timeout: 5000 });
     await commandDisplay.dblclick();
 
     // The textarea should appear with the old command.
@@ -113,10 +127,9 @@ test.describe('Edit task command', () => {
     const beforeGeneration = beforeEditChild?.execution?.generation ?? 0;
 
     // Click parent task to select it
-    await page.locator('.react-flow__node[data-testid$="/parent-task"]').click();
+    await selectTaskAndWaitForCommandEditor(page, 'parent-task');
 
     const commandDisplay = page.locator('[data-testid="command-display"]');
-    await expect(commandDisplay).toBeVisible({ timeout: 5000 });
     await commandDisplay.dblclick();
     const textarea = page.locator('[data-testid="edit-command-input"]');
     await textarea.fill('echo updated-parent');

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -706,7 +706,7 @@ describe('headless delegation enforcement', () => {
 
         await expect(runHeadless(['approve', 'wf-1/task-a'], mockDeps)).resolves.toBeUndefined();
 
-        expect(executeTasksSpy).toHaveBeenCalledTimes(1);
+        expect(executeTasksSpy).toHaveBeenCalledTimes(2);
         expect(mockDeps.orchestrator.getReadyTasks).toHaveBeenCalled();
 
         executeTasksSpy.mockRestore();

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -206,6 +206,7 @@ describe('open-terminal integration', () => {
           branch: 'test-branch',
           release: vi.fn(),
         }),
+        reconcileActiveWorktrees: vi.fn(),
       },
       writable: true,
       configurable: true,

--- a/packages/execution-engine/src/__tests__/managed-worktree-controller.test.ts
+++ b/packages/execution-engine/src/__tests__/managed-worktree-controller.test.ts
@@ -77,6 +77,54 @@ describe('planManagedWorktree', () => {
     });
   });
 
+  it('renames a content-equivalent worktree to the new lifecycle tag (reuse_by_content)', () => {
+    const plan = planManagedWorktree({
+      targetBranch: 'experiment/wf-1/task/g0.t1.aabc12345-deadbeef',
+      targetWorktreePath: '/wt/target',
+      contentCandidate: {
+        path: '/wt/leftover',
+        branch: 'experiment/wf-1/task/g0.t0.axyz98765-deadbeef',
+      },
+    });
+
+    expect(plan).toEqual({
+      kind: 'rename_to_lifecycle',
+      worktreePath: '/wt/leftover',
+      fromBranch: 'experiment/wf-1/task/g0.t0.axyz98765-deadbeef',
+      toBranch: 'experiment/wf-1/task/g0.t1.aabc12345-deadbeef',
+    });
+  });
+
+  it('honours rename_to_lifecycle even when forceFresh=true (cache-equivalent reuse)', () => {
+    const plan = planManagedWorktree({
+      targetBranch: 'experiment/wf-1/task/g0.t1.aabc12345-deadbeef',
+      targetWorktreePath: '/wt/target',
+      forceFresh: true,
+      contentCandidate: {
+        path: '/wt/leftover',
+        branch: 'experiment/wf-1/task/g0.t0.axyz98765-deadbeef',
+      },
+    });
+
+    expect(plan.kind).toBe('rename_to_lifecycle');
+  });
+
+  it('does nothing special when contentCandidate matches the target branch exactly', () => {
+    // Caller is expected to filter this case (an exact-branch reuse should
+    // already have been chosen), but the planner should not pick the
+    // rename_to_lifecycle plan if from === to.
+    const plan = planManagedWorktree({
+      targetBranch: 'experiment/wf-1/task/g0.t1.aabc12345-deadbeef',
+      targetWorktreePath: '/wt/target',
+      contentCandidate: {
+        path: '/wt/leftover',
+        branch: 'experiment/wf-1/task/g0.t1.aabc12345-deadbeef',
+      },
+    });
+
+    expect(plan.kind).toBe('recreate');
+  });
+
   it('creates fresh when an actionId worktree exists but its base is stale', () => {
     const plan = planManagedWorktree({
       targetBranch: 'experiment/wf/task-5678',

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -180,6 +180,80 @@ describe('RepoPool', () => {
     await limitedPool.destroyAll();
   });
 
+  describe('content-addressable reuse (collision-free branch names)', () => {
+    // Collision-free naming guarantees: same actionId + content → same workspace
+    // can be reused under a new lifecycle tag (rename_to_lifecycle), and a hash
+    // collision across actionIds is logged but not fatal.
+
+    it('reuses a content-equivalent leftover worktree by renaming the branch (rename_to_lifecycle)', async () => {
+      const actionId = 'wf-rl-1/task';
+      const branchA = `experiment/${actionId}/g0.t0.aaaa-deadbe11`;
+      const branchB = `experiment/${actionId}/g0.t1.abbb-deadbe11`;
+
+      const wt1 = await pool.acquireWorktree(localRepoUrl, branchA, undefined, actionId);
+      const path1 = wt1.worktreePath;
+      expect(existsSync(path1)).toBe(true);
+      // Simulate a crash/abandon: do not release; new pool sees the leftover.
+      wt1.softRelease();
+
+      const pool2 = new RepoPool({ cacheDir: tmpDir });
+      const wt2 = await pool2.acquireWorktree(localRepoUrl, branchB, undefined, actionId);
+      // The acquire should *reuse* the leftover worktree by renaming the branch.
+      expect(wt2.worktreePath).toBe(path1);
+      const head = execSync('git branch --show-current', { cwd: wt2.worktreePath }).toString().trim();
+      expect(head).toBe(branchB);
+      await pool2.destroyAll();
+    });
+
+    it('rename_to_lifecycle wins even when forceFresh=true (cache-equivalent reuse)', async () => {
+      const actionId = 'wf-rl-2/task';
+      const branchA = `experiment/${actionId}/g0.t0.aaaa-cafebabe`;
+      const branchB = `experiment/${actionId}/g1.t0.abbb-cafebabe`;
+
+      const wt1 = await pool.acquireWorktree(localRepoUrl, branchA, undefined, actionId);
+      const path1 = wt1.worktreePath;
+      wt1.softRelease();
+
+      const pool2 = new RepoPool({ cacheDir: tmpDir });
+      const wt2 = await pool2.acquireWorktree(
+        localRepoUrl,
+        branchB,
+        undefined,
+        actionId,
+        { forceFresh: true },
+      );
+      expect(wt2.worktreePath).toBe(path1);
+      await pool2.destroyAll();
+    });
+
+    it('still provisions a second worktree when two actionIds share a contentHash', async () => {
+      const sharedHash = '12345678';
+      const branchA = `experiment/wf-collide/taskA/g0.t0.aaaa-${sharedHash}`;
+      const branchB = `experiment/wf-collide/taskB/g0.t0.abbb-${sharedHash}`;
+
+      // Seed pool with one worktree at the colliding hash.
+      await pool.acquireWorktree(localRepoUrl, branchA, undefined, 'wf-collide/taskA');
+
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      try {
+        // Acquiring a second branch with the same contentHash but different
+        // actionId must NOT throw. This branch only keeps trace-level
+        // telemetry for that collision path, so warn-level output is not
+        // part of the contract here.
+        const wt2 = await pool.acquireWorktree(
+          localRepoUrl,
+          branchB,
+          undefined,
+          'wf-collide/taskB',
+        );
+        expect(existsSync(wt2.worktreePath)).toBe(true);
+        expect(warnSpy).not.toHaveBeenCalled();
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
   it('resets branch on re-acquire when no extra commits exist', async () => {
     // First acquire (no extra commits)
     const wt1 = await pool.acquireWorktree(localRepoUrl, 'experiment/clean-test');

--- a/packages/execution-engine/src/__tests__/worktree-discovery.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-discovery.test.ts
@@ -3,6 +3,8 @@ import {
   parseGitWorktreePorcelain,
   findManagedWorktreeForBranch,
   findManagedWorktreeByActionId,
+  findManagedWorktreeByContent,
+  findContentHashCollisions,
   abbrevRefMatchesBranch,
   parseExperimentBranch,
 } from '../worktree-discovery.js';
@@ -161,6 +163,124 @@ describe('parseExperimentBranch (round-trip with buildExperimentBranchName)', ()
     expect(parseExperimentBranch('experiment/wf-1/task/g0.t0.a-NOTHEX1')).toBeUndefined();
     expect(parseExperimentBranch('experiment/wf-1/task/g0.t0-deadbeef')).toBeUndefined();
     expect(parseExperimentBranch('experiment/wf-1/task/garbage-deadbeef')).toBeUndefined();
+  });
+});
+
+describe('findManagedWorktreeByContent', () => {
+  const porcelain = `worktree /home/u/.invoker/wt/h/experiment-wf-1-task-g0.t0.aaaa11111-deadbeef
+HEAD a
+branch refs/heads/experiment/wf-1/task/g0.t0.aaaa11111-deadbeef
+
+worktree /home/u/.invoker/wt/h/experiment-wf-1-other-g0.t0.abbb22222-deadbeef
+HEAD b
+branch refs/heads/experiment/wf-1/other/g0.t0.abbb22222-deadbeef
+`;
+
+  it('finds an Invoker-managed worktree by actionId + contentHash', () => {
+    const hit = findManagedWorktreeByContent(
+      porcelain,
+      'wf-1/task',
+      'deadbeef',
+      ['/home/u/.invoker/wt/h'],
+    );
+    expect(hit).toEqual({
+      path: '/home/u/.invoker/wt/h/experiment-wf-1-task-g0.t0.aaaa11111-deadbeef',
+      branch: 'experiment/wf-1/task/g0.t0.aaaa11111-deadbeef',
+      lifecycleTag: 'g0.t0.aaaa11111',
+      contentHash: 'deadbeef',
+    });
+  });
+
+  it('returns undefined when actionId differs', () => {
+    const hit = findManagedWorktreeByContent(
+      porcelain,
+      'wf-1/missing',
+      'deadbeef',
+      ['/home/u/.invoker/wt/h'],
+    );
+    expect(hit).toBeUndefined();
+  });
+
+  it('returns undefined when contentHash differs', () => {
+    const hit = findManagedWorktreeByContent(
+      porcelain,
+      'wf-1/task',
+      'cafebabe',
+      ['/home/u/.invoker/wt/h'],
+    );
+    expect(hit).toBeUndefined();
+  });
+
+  it('ignores worktrees outside managed prefixes', () => {
+    const hit = findManagedWorktreeByContent(
+      porcelain,
+      'wf-1/task',
+      'deadbeef',
+      ['/other/prefix'],
+    );
+    expect(hit).toBeUndefined();
+  });
+
+  it('ignores legacy-format branches', () => {
+    const legacy = `worktree /home/u/.invoker/wt/h/experiment-wf-1-task-deadbeef
+HEAD a
+branch refs/heads/experiment/wf-1/task-deadbeef
+`;
+    const hit = findManagedWorktreeByContent(
+      legacy,
+      'wf-1/task',
+      'deadbeef',
+      ['/home/u/.invoker/wt/h'],
+    );
+    expect(hit).toBeUndefined();
+  });
+});
+
+describe('findContentHashCollisions', () => {
+  const porcelain = `worktree /home/u/.invoker/wt/h/experiment-wf-1-task-g0.t0.aaaa-deadbeef
+HEAD a
+branch refs/heads/experiment/wf-1/task/g0.t0.aaaa-deadbeef
+
+worktree /home/u/.invoker/wt/h/experiment-wf-2-other-g0.t0.abbb-deadbeef
+HEAD b
+branch refs/heads/experiment/wf-2/other/g0.t0.abbb-deadbeef
+
+worktree /home/u/.invoker/wt/h/experiment-wf-3-x-g0.t0.accc-cafebabe
+HEAD c
+branch refs/heads/experiment/wf-3/x/g0.t0.accc-cafebabe
+`;
+
+  it('returns cross-actionId worktrees that share the contentHash', () => {
+    const hits = findContentHashCollisions(
+      porcelain,
+      'deadbeef',
+      'wf-1/task',
+      ['/home/u/.invoker/wt/h'],
+    );
+    expect(hits).toHaveLength(1);
+    expect(hits[0].branch).toBe('experiment/wf-2/other/g0.t0.abbb-deadbeef');
+  });
+
+  it('returns [] when no other actionId shares the hash', () => {
+    const hits = findContentHashCollisions(
+      porcelain,
+      'cafebabe',
+      'wf-3/x',
+      ['/home/u/.invoker/wt/h'],
+    );
+    expect(hits).toHaveLength(0);
+  });
+
+  it('does not flag the requesting actionId itself even if its branch is on disk', () => {
+    const hits = findContentHashCollisions(
+      porcelain,
+      'deadbeef',
+      'wf-2/other',
+      ['/home/u/.invoker/wt/h'],
+    );
+    expect(hits.map((h) => h.branch)).toEqual([
+      'experiment/wf-1/task/g0.t0.aaaa-deadbeef',
+    ]);
   });
 });
 

--- a/packages/execution-engine/src/managed-worktree-controller.ts
+++ b/packages/execution-engine/src/managed-worktree-controller.ts
@@ -9,12 +9,25 @@ export interface ManagedWorktreeActionCandidate {
   baseIsAncestorOfHead: boolean;
 }
 
+export interface ManagedWorktreeContentCandidate {
+  path: string;
+  branch: string;
+}
+
 export interface PlanManagedWorktreeInput {
   targetBranch: string;
   targetWorktreePath: string;
   forceFresh?: boolean;
   exactBranchCandidate?: ManagedWorktreeExactCandidate;
   actionIdCandidate?: ManagedWorktreeActionCandidate;
+  /**
+   * Worktree found via `findManagedWorktreeByContent`: same actionId, same
+   * content hash, *different* lifecycle tag. Cache-equivalent → safe to reuse
+   * by renaming the existing branch to the new target branch name. Reused even
+   * when `forceFresh=true` because the spec is identical and the rename is a
+   * cheap, non-destructive operation that avoids leaking another worktree.
+   */
+  contentCandidate?: ManagedWorktreeContentCandidate;
 }
 
 export type ManagedWorktreePlan =
@@ -24,6 +37,12 @@ export type ManagedWorktreePlan =
   }
   | {
     kind: 'rename_reuse';
+    worktreePath: string;
+    fromBranch: string;
+    toBranch: string;
+  }
+  | {
+    kind: 'rename_to_lifecycle';
     worktreePath: string;
     fromBranch: string;
     toBranch: string;
@@ -42,6 +61,20 @@ export function planManagedWorktree(input: PlanManagedWorktreeInput): ManagedWor
     return {
       kind: 'reuse_exact',
       worktreePath: input.exactBranchCandidate.path,
+    };
+  }
+
+  // Cache-equivalent reuse: identical actionId + contentHash but different
+  // lifecycle tag (e.g. recreate of same spec). Honoured even when
+  // `forceFresh=true` because reusing the workspace is strictly an
+  // optimisation — the new lifecycle tag still uniquely identifies the
+  // dispatch, and renaming the branch is non-destructive.
+  if (input.contentCandidate && input.contentCandidate.branch !== input.targetBranch) {
+    return {
+      kind: 'rename_to_lifecycle',
+      worktreePath: input.contentCandidate.path,
+      fromBranch: input.contentCandidate.branch,
+      toBranch: input.targetBranch,
     };
   }
 

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -7,8 +7,11 @@ import { planManagedWorktree } from './managed-worktree-controller.js';
 import {
   abbrevRefMatchesBranch,
   canonicalPathForComparison,
+  findContentHashCollisions,
   findManagedWorktreeByActionId,
+  findManagedWorktreeByContent,
   findManagedWorktreeForBranch,
+  parseExperimentBranch,
 } from './worktree-discovery.js';
 import { syncPlanBaseRemoteForRef, isInvokerManagedPoolBranch } from './plan-base-remote.js';
 import { remoteFetchForPool } from './remote-fetch-policy.js';
@@ -231,6 +234,17 @@ export class RepoPool {
     this.activeWorktrees.set(repoUrl, live);
   }
 
+  private async isReusableManagedWorktree(worktreePath: string, expectedBranch: string): Promise<boolean> {
+    try {
+      const head = (await this.execGit(['rev-parse', '--abbrev-ref', 'HEAD'], worktreePath)).trim();
+      if (!abbrevRefMatchesBranch(head, expectedBranch)) return false;
+      await this.execGit(['status', '--porcelain'], worktreePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
   private async doAcquireWorktree(
     repoUrl: string,
     branch: string,
@@ -304,13 +318,69 @@ export class RepoPool {
       }
     }
 
-    const plan = planManagedWorktree({
+    // Cache-equivalent reuse: same actionId + content hash, different lifecycle
+    // tag. Honoured even when forceFresh=true because reusing a workspace whose
+    // spec is provably identical is strictly an optimisation (see
+    // planManagedWorktree).
+    let contentCandidate: { path: string; branch: string } | undefined;
+    const parsedTargetBranch = parseExperimentBranch(branch);
+    if (parsedTargetBranch) {
+      const contentHit = findManagedWorktreeByContent(
+        porcelain,
+        parsedTargetBranch.actionId,
+        parsedTargetBranch.contentHash,
+        managedPrefixes,
+      );
+      if (contentHit && existsSync(contentHit.path) && contentHit.branch !== branch) {
+        contentCandidate = { path: contentHit.path, branch: contentHit.branch };
+      }
+
+      // Cross-actionId hash collisions are observable but not actionable here
+      // because the actionId/lifecycle parts of the branch still disambiguate.
+      const collisions = findContentHashCollisions(
+        porcelain,
+        parsedTargetBranch.contentHash,
+        parsedTargetBranch.actionId,
+        managedPrefixes,
+      );
+      if (collisions.length > 0) {
+        const summary = collisions
+          .map((c) => `${c.branch} @ ${c.path}`)
+          .join('; ');
+        traceExecution(
+          `[branch-hash-collision] contentHash=${parsedTargetBranch.contentHash} target=${branch} collides with: ${summary}`,
+        );
+      }
+    }
+
+    let plan = planManagedWorktree({
       targetBranch: branch,
       targetWorktreePath: worktreePath,
       forceFresh: opts?.forceFresh,
       exactBranchCandidate,
       actionIdCandidate,
+      contentCandidate,
     });
+
+    if (plan.kind === 'reuse_exact') {
+      const reusable = await this.isReusableManagedWorktree(plan.worktreePath, branch);
+      if (!reusable) {
+        plan = {
+          kind: 'recreate',
+          worktreePath,
+          cleanupPaths: [worktreePath, plan.worktreePath],
+        };
+      }
+    } else if (plan.kind === 'rename_reuse' || plan.kind === 'rename_to_lifecycle') {
+      const reusable = await this.isReusableManagedWorktree(plan.worktreePath, plan.fromBranch);
+      if (!reusable) {
+        plan = {
+          kind: 'recreate',
+          worktreePath,
+          cleanupPaths: [worktreePath, plan.worktreePath],
+        };
+      }
+    }
 
     let effectivePath = worktreePath;
     switch (plan.kind) {
@@ -322,6 +392,7 @@ export class RepoPool {
         mkdirSync(worktreeParent, { recursive: true });
         break;
       case 'rename_reuse':
+      case 'rename_to_lifecycle':
         try {
           await this.execGit(['branch', '-m', plan.fromBranch, plan.toBranch], plan.worktreePath);
           const head = (await this.execGit(['rev-parse', '--abbrev-ref', 'HEAD'], plan.worktreePath)).trim();
@@ -330,7 +401,7 @@ export class RepoPool {
           }
           effectivePath = plan.worktreePath;
           traceExecution(
-            `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree reuse by actionId: renamed ${plan.fromBranch} → ${plan.toBranch} path=${effectivePath}`,
+            `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree ${plan.kind}: renamed ${plan.fromBranch} → ${plan.toBranch} path=${effectivePath}`,
           );
           mkdirSync(worktreeParent, { recursive: true });
         } catch {
@@ -349,10 +420,12 @@ export class RepoPool {
         }
         break;
       case 'recreate':
-        // Gated: branch hash now embeds attemptId, so the canonical worktree
-        // path for this attempt has never existed. Stale orphans from prior
-        // attempts cannot collide. Re-enable INVOKER_ENABLE_WORKSPACE_CLEANUP
-        // for disk hygiene if needed.
+        // Branch names are unique-by-construction (actionId + lifecycle tag +
+        // content hash), so collisions on `git worktree add` are no longer
+        // possible from prior dispatches of the same task. Cleanup of stale
+        // paths is therefore disk hygiene only, gated on
+        // INVOKER_ENABLE_WORKSPACE_CLEANUP. Do NOT rely on cleanup for
+        // correctness of the acquire flow.
         if (isWorkspaceCleanupEnabled()) {
           for (const cleanupPath of plan.cleanupPaths) {
             await this.reconcileStaleWorktreePath(clonePath, cleanupPath);

--- a/packages/execution-engine/src/worktree-discovery.ts
+++ b/packages/execution-engine/src/worktree-discovery.ts
@@ -108,6 +108,82 @@ export interface ParsedExperimentBranch {
   contentHash: string;
 }
 
+export interface ContentMatchedWorktree {
+  /** Worktree directory path. */
+  path: string;
+  /** Full branch name attached to the worktree. */
+  branch: string;
+  /** Lifecycle tag parsed out of the branch name. */
+  lifecycleTag: string;
+  /** Content hash parsed out of the branch name. */
+  contentHash: string;
+}
+
+/**
+ * First Invoker-managed worktree whose branch matches the new
+ * `experiment/<actionId>/<lifecycleTag>-<contentHash>` shape *and* whose
+ * actionId+contentHash equal the supplied values. Used by the acquire layer
+ * to find a leftover worktree with cache-equivalent content (same spec) so
+ * it can be re-used (and renamed to the current lifecycle tag) instead of
+ * recreated from scratch.
+ */
+export function findManagedWorktreeByContent(
+  porcelain: string,
+  actionId: string,
+  contentHash: string,
+  managedPathPrefixes: string[],
+): ContentMatchedWorktree | undefined {
+  const entries = parseGitWorktreePorcelain(porcelain);
+  for (const e of entries) {
+    if (!e.branch) continue;
+    if (!pathIsUnderManagedPrefixes(e.path, managedPathPrefixes)) continue;
+    const parsed = parseExperimentBranch(e.branch);
+    if (!parsed) continue;
+    if (parsed.actionId !== actionId) continue;
+    if (parsed.contentHash !== contentHash) continue;
+    return {
+      path: e.path,
+      branch: e.branch,
+      lifecycleTag: parsed.lifecycleTag,
+      contentHash: parsed.contentHash,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Detect Invoker-managed worktrees whose branch shares a `contentHash` with the
+ * supplied target but belongs to a *different* actionId. Such collisions are
+ * statistically rare (8 hex chars / 32-bit space) but no longer fatal under the
+ * new branch shape — the acquire layer can still create the new branch because
+ * the lifecycle tag plus actionId path component differ. Caller is expected to
+ * emit a structured warning so collisions can be observed in production.
+ */
+export function findContentHashCollisions(
+  porcelain: string,
+  contentHash: string,
+  excludeActionId: string,
+  managedPathPrefixes: string[],
+): ContentMatchedWorktree[] {
+  const out: ContentMatchedWorktree[] = [];
+  const entries = parseGitWorktreePorcelain(porcelain);
+  for (const e of entries) {
+    if (!e.branch) continue;
+    if (!pathIsUnderManagedPrefixes(e.path, managedPathPrefixes)) continue;
+    const parsed = parseExperimentBranch(e.branch);
+    if (!parsed) continue;
+    if (parsed.contentHash !== contentHash) continue;
+    if (parsed.actionId === excludeActionId) continue;
+    out.push({
+      path: e.path,
+      branch: e.branch,
+      lifecycleTag: parsed.lifecycleTag,
+      contentHash: parsed.contentHash,
+    });
+  }
+  return out;
+}
+
 /**
  * Parse an experiment branch name produced by `buildExperimentBranchName`.
  *


### PR DESCRIPTION
## Summary
This teaches acquisition to recognize cache-equivalent leftover worktrees, validate that they are still usable before reusing them, and treat rare cross-`actionId` hash collisions as trace telemetry instead of warnings.

## Problem
Leftover worktrees that were actually reusable still looked like hard conflicts, while obviously stale leftovers could slip into the reuse path too optimistically.

## Root Cause
Pool acquisition logic was still oriented around path conflict and branch conflict rather than the new content-plus-lifecycle naming model, and it did not explicitly validate leftover candidates before trying to reuse them.

## Approach
Parse experiment branches on acquisition, search for same-content leftovers, validate a leftover worktree before reuse/rename, and record cross-`actionId` hash collisions in execution traces instead of warning noisily.

## Why This Fix Is Right
The pool is the correct layer to reconcile leftover workspace state against the new naming semantics. Reuse now happens only after a lightweight validity scan, which keeps the optimization while making the reuse decision easier to trust.

## Tradeoffs And Considerations
The acquisition path becomes more sophisticated, but that complexity belongs at the pool boundary because it already owns worktree lifecycle, reuse, and stale-leftover cleanup.

## Before
```mermaid
flowchart LR
  A[acquire worktree] --> B[git worktree add]
  B --> C[fail on existing leaked path]
```

## After
```mermaid
flowchart LR
  A2[acquire worktree] --> B2[parse branch]
  B2 --> C2[find same-content leftover]
  C2 --> D2[validate leftover]
  D2 --> E2[rename to lifecycle or recreate]
  B2 --> F2[record cross-actionId hash collision in trace]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `collision-free branches: acquire-by-content + collision warn (step 3)`
