### PR TITLE
step 4: persist attempt.branch before git worktree add

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -68,6 +68,15 @@ export interface WorkRequest {
     startedAt?: string;
     completedAt?: string;
   };
+  /**
+   * In-process callback invoked by the executor as soon as the experiment
+   * branch name is determined (i.e. before any `git worktree add` that could
+   * leak a worktree). Lets the orchestrator persist `attempt.branch` early so
+   * a leftover worktree from a crashed dispatch can still be reconciled.
+   *
+   * Non-serializable. Producers and consumers live in the same process.
+   */
+  onBranchResolved?: (branch: string) => void;
 }
 
 // ── Work Response ───────────────────────────────────────────

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -6288,6 +6288,71 @@ describe('TaskRunner', () => {
       );
     });
 
+    it('persists attempt.branch via onBranchResolved when executor crashes mid-acquire', async () => {
+      // Executor that resolves the branch (calls onBranchResolved) and then
+      // crashes before attaching `branch` metadata to the thrown error —
+      // simulating a `git worktree add` failure between branch computation
+      // and worktree creation.
+      let observedBranch: string | undefined;
+      const failingExecutor = {
+        type: 'worktree',
+        start: vi.fn().mockImplementation(async (req: any) => {
+          const branch = 'experiment/task-mid-acquire/g0.t0.aabc12345-deadbeef';
+          observedBranch = branch;
+          req.onBranchResolved?.(branch);
+          // Simulate `git worktree add` failure — note: error has NO branch attached.
+          throw new Error("fatal: 'experiment/...' is already used by worktree");
+        }),
+        onComplete: vi.fn(),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+        destroyAll: vi.fn(),
+      };
+
+      const task = makeTask({
+        id: 'task-mid-acquire',
+        status: 'pending',
+        config: { command: 'echo test', executorType: 'worktree' },
+      });
+
+      const updateAttemptSpy = vi.fn();
+      const updateTaskSpy = vi.fn();
+
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: () => task,
+          getAllTasks: () => [task],
+          handleWorkerResponse: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask: updateTaskSpy,
+          updateAttempt: updateAttemptSpy,
+        } as any,
+        executorRegistry: {
+          getDefault: () => failingExecutor,
+          get: () => failingExecutor,
+          getAll: () => [failingExecutor],
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await runner.executeTask(task);
+
+      expect(observedBranch).toBeDefined();
+      // The early callback must have persisted branch on the attempt row,
+      // even though the error did not carry branch metadata.
+      expect(updateAttemptSpy).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ branch: observedBranch }),
+      );
+      // And on the task execution mirror as well.
+      expect(updateTaskSpy).toHaveBeenCalledWith(
+        'task-mid-acquire',
+        expect.objectContaining({ execution: expect.objectContaining({ branch: observedBranch }) }),
+      );
+    });
+
     it('allows BYO mode executor with workspacePath but no branch', async () => {
       const byoExecutor = {
         type: 'ssh',

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -365,6 +365,16 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
       request.inputs.lifecycleTag ?? '',
       contentHash,
     );
+    // Persist the branch on the attempt row before any branch-creating git
+    // operation runs. If the container or git step crashes mid-startup, the
+    // attempt still records which branch it was about to use so leftover
+    // state can be reconciled.
+    try {
+      request.onBranchResolved?.(branchName);
+    } catch {
+      // Best-effort early persistence; the post-start path persists the
+      // same value again.
+    }
     const baseBranch = request.inputs.upstreamBranches?.[0]
       ?? request.inputs.baseBranch
       ?? 'HEAD';

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -334,6 +334,13 @@ echo ${payloadB64} | base64 -d | bash -se
       lifecycleTag,
       contentHash,
     );
+    // Persist the branch on the attempt row before we run any remote git
+    // command that could leak a worktree without a recorded branch.
+    try {
+      request.onBranchResolved?.(experimentBranch);
+    } catch {
+      // Best-effort; the post-start path persists this again.
+    }
     const san = sanitizeBranchForPath(experimentBranch);
     const remoteClone = `${invokerHome}/repos/${h}`;
     const canonicalRemoteWt = `${invokerHome}/worktrees/${h}/${san}`;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -424,6 +424,31 @@ export class TaskRunner {
     const baseBranch = workflow?.baseBranch ?? this.defaultBranch;
     const repoUrl = workflow?.repoUrl;
 
+    // Persist the experiment branch as soon as the executor knows it — well
+    // before `git worktree add` could leak a worktree without a recorded branch
+    // on the attempt row. Reconciliation paths can then observe the branch
+    // even if the executor crashes mid-startup.
+    let branchPersistedEarly = false;
+    const onBranchResolved = (branch: string): void => {
+      if (!branch || branchPersistedEarly) return;
+      branchPersistedEarly = true;
+      try {
+        this.persistence.updateAttempt?.(attemptId, { branch } as any);
+        this.persistence.updateTask(task.id, {
+          execution: { branch } as any,
+        });
+        traceExecution(
+          `${RESTART_TO_BRANCH_TRACE} task=${task.id} attempt=${attemptId} branch persisted early branch=${branch}`,
+        );
+      } catch (err) {
+        // Early persistence is best-effort: the post-start path persists the
+        // same field again, so a transient failure here is not fatal.
+        traceExecution(
+          `${RESTART_TO_BRANCH_TRACE} task=${task.id} attempt=${attemptId} early branch persist failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    };
+
     const request: WorkRequest = {
       requestId: randomUUID(),
       actionId: task.id,
@@ -448,6 +473,7 @@ export class TaskRunner {
       timestamps: {
         createdAt: new Date().toISOString(),
       },
+      onBranchResolved,
     };
 
     traceExecution(
@@ -551,6 +577,20 @@ export class TaskRunner {
         },
       };
       this.persistence.updateTask(task.id, changes);
+      // Mirror branch + workspacePath onto the attempt row so reconciliation
+      // and post-mortem flows can recover provenance from the attempt without
+      // joining back to the task. Pairs with the early `onBranchResolved`
+      // persistence; this is the authoritative success-path write.
+      try {
+        this.persistence.updateAttempt?.(attemptId, {
+          branch: handle.branch ?? undefined,
+          workspacePath: handle.workspacePath,
+        } as any);
+      } catch (err) {
+        traceExecution(
+          `${RESTART_TO_BRANCH_TRACE} task=${task.id} attempt=${attemptId} post-start attempt persist failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       traceExecution(
         `[agent-session-trace] TaskRunner.persistStartMetadata task=${task.id} agentSessionId=${handle.agentSessionId ?? 'null'}`,
       );

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -159,6 +159,15 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       contentHash,
     );
     traceExecution(`[WorktreeExecutor] branch=${branch} contentHash=${contentHash}`);
+    // Notify the orchestrator before any `git worktree add` so a leaked
+    // worktree (process killed mid-acquire) can still be reconciled.
+    try {
+      request.onBranchResolved?.(branch);
+    } catch (err) {
+      traceExecution(
+        `[WorktreeExecutor] onBranchResolved threw — continuing: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
 
     // -- Reconciliation: real pool worktree at plan base (no upstream merges), then needs_input --
     if (request.actionType === 'reconciliation') {


### PR DESCRIPTION
## Summary
This closes a recovery gap by persisting the attempt branch as soon as the executor resolves it, before any branch-creating git operation runs. `WorkRequest.onBranchResolved` lets the task runner write `attempt.branch` early so a later reconciliation step can still attribute a leaked worktree even if the executor crashes before startup completes.

## Problem
A dispatch crash could leave behind a real worktree without enough persisted metadata to reconcile it back to the attempt cleanly.

## Root Cause
Attempt branch metadata was written too late in the acquire path, after branch-creating git work had already started. A crash in that gap left recovery without a durable branch-to-attempt link.

## Approach
Persist `attempt.branch` as soon as the executor resolves branch identity, before `git worktree add` runs.

## Why This Fix Is Right
Under the new one-branch-to-one-worktree invariant, the branch name is the important early recovery key. This PR does not try to persist `workspacePath` before acquisition; that still becomes authoritative after the worktree exists. The early write is only there to close the branch-resolution crash gap.

## Tradeoffs And Considerations
This adds an earlier persistence write and a non-serializable callback in the acquire path. That is a small price for deterministic crash recovery.

## Before
```mermaid
flowchart LR
  A[executor computes branch] --> B[git worktree add]
  B --> C[attempt.branch written later]
  C --> D[crash before branch persistence, leaked worktree hard to attribute]
```

## After
```mermaid
flowchart LR
  A2[executor resolves branch] --> B2[onBranchResolved callback]
  B2 --> C2[persist attempt.branch]
  C2 --> D2[git worktree add]
  D2 --> E2[crash recovery can map leaked worktree back to attempt]
```

## Verification
- GitHub Actions for this PR are green.

## Traceability
- Commit message: `step 4: persist attempt.branch before git worktree add`
