### PR TITLE
Fix worktree recreate leaks and branch collisions

### DIFF
--- a/packages/execution-engine/src/__tests__/branch-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-utils.test.ts
@@ -123,9 +123,25 @@ describe('formatLifecycleTag', () => {
     expect(new Set([a, b, c, d]).size).toBe(4);
   });
 
-  it('sanitizes attempt-short to safe characters and bounds length', () => {
+  it('sanitizes attempt-short to safe characters without truncating unique suffixes', () => {
     expect(formatLifecycleTag({ wfGen: 1, taskGen: 2, attemptShort: 'AB$%C12/34D-56-EXTRA' }))
-      .toBe('g1.t2.aabc1234d-56-');
+      .toBe('g1.t2.aabc1234d-56-extra');
+  });
+
+  it('preserves distinct attempt tails even when workflow/task prefixes match', () => {
+    const tagA = formatLifecycleTag({
+      wfGen: 20,
+      taskGen: 17,
+      attemptShort: 'wf-1775874004544-6add-visual-proof-test-a05cb19b8',
+    });
+    const tagB = formatLifecycleTag({
+      wfGen: 20,
+      taskGen: 17,
+      attemptShort: 'wf-1775874004544-6add-visual-proof-test-a8a6ba2f5',
+    });
+    expect(tagA).not.toBe(tagB);
+    expect(tagA).toContain('a05cb19b8');
+    expect(tagB).toContain('a8a6ba2f5');
   });
 
   it('clamps negative or non-finite generations to 0', () => {

--- a/packages/execution-engine/src/__tests__/managed-worktree-controller.test.ts
+++ b/packages/execution-engine/src/__tests__/managed-worktree-controller.test.ts
@@ -95,7 +95,7 @@ describe('planManagedWorktree', () => {
     });
   });
 
-  it('honours rename_to_lifecycle even when forceFresh=true (cache-equivalent reuse)', () => {
+  it('forces recreate instead of rename_to_lifecycle when forceFresh=true', () => {
     const plan = planManagedWorktree({
       targetBranch: 'experiment/wf-1/task/g0.t1.aabc12345-deadbeef',
       targetWorktreePath: '/wt/target',
@@ -106,7 +106,11 @@ describe('planManagedWorktree', () => {
       },
     });
 
-    expect(plan.kind).toBe('rename_to_lifecycle');
+    expect(plan).toEqual({
+      kind: 'recreate',
+      worktreePath: '/wt/target',
+      cleanupPaths: ['/wt/target'],
+    });
   });
 
   it('does nothing special when contentCandidate matches the target branch exactly', () => {

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
@@ -131,6 +131,26 @@ describe('RepoPool', () => {
     await pool2.destroyAll();
   });
 
+  it('acquireWorktree: repairs leaked target directory even when it is not a registered worktree', async () => {
+    const branch = 'experiment/leaked-dir';
+    const poolWithExternalBase = new RepoPool({
+      cacheDir: tmpDir,
+      worktreeBaseDir: join(tmpDir, 'managed-worktrees'),
+    });
+
+    const leakedPath = poolWithExternalBase.externalWorktreePath(localRepoUrl, branch);
+    mkdirSync(leakedPath, { recursive: true });
+    writeFileSync(join(leakedPath, 'leaked.txt'), 'partial workspace');
+
+    const wt = await poolWithExternalBase.acquireWorktree(localRepoUrl, branch);
+    expect(wt.worktreePath).toBe(leakedPath);
+    expect(existsSync(join(wt.worktreePath, '.git'))).toBe(true);
+    const currentBranch = execSync('git branch --show-current', { cwd: wt.worktreePath }).toString().trim();
+    expect(currentBranch).toBe(branch);
+
+    await poolWithExternalBase.destroyAll();
+  });
+
   it('softRelease: frees slot without removing worktree from disk', async () => {
     const limitedPool = new RepoPool({ cacheDir: tmpDir, maxWorktrees: 1 });
     const wt1 = await limitedPool.acquireWorktree(localRepoUrl, 'branch-soft');
@@ -181,9 +201,9 @@ describe('RepoPool', () => {
   });
 
   describe('content-addressable reuse (collision-free branch names)', () => {
-    // Collision-free naming guarantees: same actionId + content → same workspace
-    // can be reused under a new lifecycle tag (rename_to_lifecycle), and a hash
-    // collision across actionIds is logged but not fatal.
+    // Collision-free naming guarantees: same actionId + content can be reused
+    // under a new lifecycle tag for non-fresh flows, and a hash collision
+    // across actionIds is logged but not fatal.
 
     it('reuses a content-equivalent leftover worktree by renaming the branch (rename_to_lifecycle)', async () => {
       const actionId = 'wf-rl-1/task';
@@ -205,7 +225,7 @@ describe('RepoPool', () => {
       await pool2.destroyAll();
     });
 
-    it('rename_to_lifecycle wins even when forceFresh=true (cache-equivalent reuse)', async () => {
+    it('forceFresh=true provisions a new workspace path even for a content-equivalent branch', async () => {
       const actionId = 'wf-rl-2/task';
       const branchA = `experiment/${actionId}/g0.t0.aaaa-cafebabe`;
       const branchB = `experiment/${actionId}/g1.t0.abbb-cafebabe`;
@@ -222,7 +242,9 @@ describe('RepoPool', () => {
         actionId,
         { forceFresh: true },
       );
-      expect(wt2.worktreePath).toBe(path1);
+      expect(wt2.worktreePath).not.toBe(path1);
+      const head = execSync('git branch --show-current', { cwd: wt2.worktreePath }).toString().trim();
+      expect(head).toBe(branchB);
       await pool2.destroyAll();
     });
 

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -86,13 +86,15 @@ export function buildExperimentBranchName(
 }
 
 /**
- * Restrict the attempt-short component to filesystem- and git-safe characters
- * and bound its length. Keeps a-z, 0-9, dash, underscore. Truncates to 12
- * characters which is more than enough entropy at the per-task scale.
+ * Restrict the attempt-short component to filesystem- and git-safe characters.
+ * Keeps a-z, 0-9, dash, underscore.
+ *
+ * Do not truncate here: attempt ids are workflow/task prefixed, so prefix
+ * truncation destroys the unique tail and causes different attempts for the
+ * same task to collide onto the same branch/worktree identity.
  */
 function sanitizeAttemptShort(raw: string): string {
-  const lower = raw.toLowerCase().replace(/[^a-z0-9_-]+/g, '');
-  return lower.slice(0, 12);
+  return raw.toLowerCase().replace(/[^a-z0-9_-]+/g, '');
 }
 
 export interface PreserveOrResetOpts {

--- a/packages/execution-engine/src/managed-worktree-controller.ts
+++ b/packages/execution-engine/src/managed-worktree-controller.ts
@@ -23,9 +23,9 @@ export interface PlanManagedWorktreeInput {
   /**
    * Worktree found via `findManagedWorktreeByContent`: same actionId, same
    * content hash, *different* lifecycle tag. Cache-equivalent → safe to reuse
-   * by renaming the existing branch to the new target branch name. Reused even
-   * when `forceFresh=true` because the spec is identical and the rename is a
-   * cheap, non-destructive operation that avoids leaking another worktree.
+   * by renaming the existing branch to the new target branch name, but only
+   * when `forceFresh` is false. Recreate-style flows must allocate both a fresh
+   * branch identity and a fresh workspace path.
    */
   contentCandidate?: ManagedWorktreeContentCandidate;
 }
@@ -65,11 +65,9 @@ export function planManagedWorktree(input: PlanManagedWorktreeInput): ManagedWor
   }
 
   // Cache-equivalent reuse: identical actionId + contentHash but different
-  // lifecycle tag (e.g. recreate of same spec). Honoured even when
-  // `forceFresh=true` because reusing the workspace is strictly an
-  // optimisation — the new lifecycle tag still uniquely identifies the
-  // dispatch, and renaming the branch is non-destructive.
-  if (input.contentCandidate && input.contentCandidate.branch !== input.targetBranch) {
+  // lifecycle tag. This is only allowed for non-fresh flows. Recreate-style
+  // acquisitions must not inherit the old workspace path.
+  if (allowReuse && input.contentCandidate && input.contentCandidate.branch !== input.targetBranch) {
     return {
       kind: 'rename_to_lifecycle',
       worktreePath: input.contentCandidate.path,

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -11,6 +11,7 @@ import {
   findManagedWorktreeByActionId,
   findManagedWorktreeByContent,
   findManagedWorktreeForBranch,
+  parseGitWorktreePorcelain,
   parseExperimentBranch,
 } from './worktree-discovery.js';
 import { syncPlanBaseRemoteForRef, isInvokerManagedPoolBranch } from './plan-base-remote.js';
@@ -179,6 +180,33 @@ export class RepoPool {
     }
   }
 
+  private isPathRegisteredInPorcelain(porcelain: string, worktreePath: string): boolean {
+    const target = canonicalPathForComparison(worktreePath);
+    return parseGitWorktreePorcelain(porcelain).some((entry) => canonicalPathForComparison(entry.path) === target);
+  }
+
+  private async reconcileLeakedTargetPath(
+    clonePath: string,
+    worktreePath: string,
+    porcelain: string,
+    branch: string,
+  ): Promise<void> {
+    if (!existsSync(worktreePath)) return;
+    const registered = this.isPathRegisteredInPorcelain(porcelain, worktreePath);
+    traceExecution(
+      `[RepoPool] reconcileLeakedTargetPath branch=${branch} path=${worktreePath} exists=true registered=${registered}`,
+    );
+    if (registered) {
+      await this.reconcileStaleWorktreePath(clonePath, worktreePath);
+      return;
+    }
+    try {
+      rmSync(worktreePath, { recursive: true, force: true });
+    } catch {
+      /* best-effort; bashPreserveOrReset will surface failure */
+    }
+  }
+
   private async doEnsureClone(repoUrl: string): Promise<string> {
     const dir = this.cloneDir(repoUrl);
     if (existsSync(dir)) {
@@ -319,9 +347,8 @@ export class RepoPool {
     }
 
     // Cache-equivalent reuse: same actionId + content hash, different lifecycle
-    // tag. Honoured even when forceFresh=true because reusing a workspace whose
-    // spec is provably identical is strictly an optimisation (see
-    // planManagedWorktree).
+    // tag. This remains available for non-fresh flows only; recreate-style
+    // flows must allocate a fresh workspace path as well as a fresh branch.
     let contentCandidate: { path: string; branch: string } | undefined;
     const parsedTargetBranch = parseExperimentBranch(branch);
     if (parsedTargetBranch) {
@@ -405,9 +432,7 @@ export class RepoPool {
           );
           mkdirSync(worktreeParent, { recursive: true });
         } catch {
-          if (isWorkspaceCleanupEnabled()) {
-            await this.reconcileStaleWorktreePath(clonePath, worktreePath);
-          }
+          await this.reconcileLeakedTargetPath(clonePath, worktreePath, porcelain, branch);
           mkdirSync(worktreeParent, { recursive: true });
           const script = bashPreserveOrReset({
             repoDir: clonePath,
@@ -420,12 +445,7 @@ export class RepoPool {
         }
         break;
       case 'recreate':
-        // Branch names are unique-by-construction (actionId + lifecycle tag +
-        // content hash), so collisions on `git worktree add` are no longer
-        // possible from prior dispatches of the same task. Cleanup of stale
-        // paths is therefore disk hygiene only, gated on
-        // INVOKER_ENABLE_WORKSPACE_CLEANUP. Do NOT rely on cleanup for
-        // correctness of the acquire flow.
+        await this.reconcileLeakedTargetPath(clonePath, worktreePath, porcelain, branch);
         if (isWorkspaceCleanupEnabled()) {
           for (const cleanupPath of plan.cleanupPaths) {
             await this.reconcileStaleWorktreePath(clonePath, cleanupPath);

--- a/scripts/repro/repro-orphan-worktree-path-collision.sh
+++ b/scripts/repro/repro-orphan-worktree-path-collision.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION=""
+KEEP_ARTIFACTS=0
+TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-120}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-orphan-worktree-path-collision.sh --expect bug|fixed [--keep-artifacts]
+
+What it proves:
+  1. A directory can exist at the target worktree path while NOT being registered in
+     `git worktree list --porcelain` ("leaked/orphan path").
+  2. Raw `git worktree add -B` fails in that state with `already exists`.
+  3. The current RepoPool implementation either repairs that orphan path (`fixed`)
+     or still fails with the same error (`bug`).
+
+Exit codes:
+  0  observed behavior matches --expect
+  1  observed behavior does not match --expect
+  2  repro setup or assertion was invalid / unexpected
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --keep-artifacts)
+      KEEP_ARTIFACTS=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  echo "repro: --expect requires bug|fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-orphan-worktree.XXXXXX")"
+FIXTURE_REPO="$TMP_DIR/fixture-repo"
+CACHE_DIR="$TMP_DIR/cache"
+WORKTREE_BASE="$TMP_DIR/worktrees"
+HELPER_TEST="$(mktemp "$ROOT_DIR/packages/execution-engine/src/__tests__/tmp-repro-orphan-worktree.XXXXXX.test.ts")"
+RAW_STDERR="$TMP_DIR/raw-git.stderr.log"
+RAW_STDOUT="$TMP_DIR/raw-git.stdout.log"
+VITEST_LOG="$TMP_DIR/vitest.log"
+
+cleanup() {
+  rm -f "$HELPER_TEST" 2>/dev/null || true
+  if [[ "$KEEP_ARTIFACTS" != "1" ]]; then
+    rm -rf "$TMP_DIR" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+die() {
+  echo "repro: $*" >&2
+  exit 2
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+require_cmd git
+require_cmd pnpm
+require_cmd timeout
+require_cmd sha256sum
+
+mkdir -p "$CACHE_DIR" "$WORKTREE_BASE"
+
+git init "$FIXTURE_REPO" >/dev/null 2>&1
+git -C "$FIXTURE_REPO" config user.email "repro@example.com"
+git -C "$FIXTURE_REPO" config user.name "Invoker Repro"
+printf 'seed\n' > "$FIXTURE_REPO/README.md"
+git -C "$FIXTURE_REPO" add README.md >/dev/null 2>&1
+git -C "$FIXTURE_REPO" commit -m "seed repro fixture" >/dev/null 2>&1
+
+REPO_URL="$FIXTURE_REPO"
+REPO_HASH="$(printf '%s' "$REPO_URL" | sha256sum | awk '{print $1}' | cut -c1-12)"
+BRANCH="experiment/repro-orphan-worktree-path-collision"
+SANITIZED_BRANCH="${BRANCH//\//-}"
+MIRROR="$CACHE_DIR/$REPO_HASH"
+WORKTREE_PATH="$WORKTREE_BASE/$REPO_HASH/$SANITIZED_BRANCH"
+
+echo "==> repro: fixture repo"
+echo "repo_url      : $REPO_URL"
+echo "repo_hash     : $REPO_HASH"
+echo "mirror        : $MIRROR"
+echo "branch        : $BRANCH"
+echo "worktree_path : $WORKTREE_PATH"
+
+git clone "$REPO_URL" "$MIRROR" >/dev/null 2>&1
+
+mkdir -p "$WORKTREE_PATH"
+printf 'orphaned directory\n' > "$WORKTREE_PATH/leaked.txt"
+
+echo "==> repro: prove orphan state"
+if [[ ! -e "$WORKTREE_PATH" ]]; then
+  die "expected worktree path to exist: $WORKTREE_PATH"
+fi
+
+if git -C "$MIRROR" worktree list --porcelain | grep -F "$WORKTREE_PATH" >/dev/null 2>&1; then
+  die "target path is registered as a git worktree; expected an unregistered orphan path"
+fi
+
+echo "filesystem_exists : yes"
+echo "git_registered    : no"
+
+echo "==> repro: raw git mechanism"
+set +e
+git -C "$MIRROR" worktree add -B "$BRANCH" "$WORKTREE_PATH" HEAD >"$RAW_STDOUT" 2>"$RAW_STDERR"
+RAW_STATUS=$?
+set -e
+
+if [[ "$RAW_STATUS" -eq 0 ]]; then
+  die "raw git unexpectedly succeeded; expected 'already exists' failure"
+fi
+
+if ! grep -q "already exists" "$RAW_STDERR"; then
+  echo "raw git stderr:" >&2
+  cat "$RAW_STDERR" >&2 || true
+  die "raw git failed, but not with the expected 'already exists' message"
+fi
+
+echo "raw_git_status   : $RAW_STATUS"
+echo "raw_git_failure  : $(tr '\n' ' ' < "$RAW_STDERR" | sed 's/  */ /g')"
+
+cat > "$HELPER_TEST" <<EOF
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+import { RepoPool } from '${ROOT_DIR}/packages/execution-engine/src/repo-pool.ts';
+
+describe('orphan worktree path collision repro', () => {
+  it('repairs or surfaces the leaked target path deterministically', async () => {
+    const pool = new RepoPool({
+      cacheDir: '${CACHE_DIR}',
+      worktreeBaseDir: '${WORKTREE_BASE}',
+    });
+    const acquired = await pool.acquireWorktree('${REPO_URL}', '${BRANCH}');
+    expect(acquired.worktreePath).toBe('${WORKTREE_PATH}');
+    expect(existsSync('${WORKTREE_PATH}/.git')).toBe(true);
+    const currentBranch = execSync('git branch --show-current', {
+      cwd: acquired.worktreePath,
+      encoding: 'utf8',
+    }).trim();
+    expect(currentBranch).toBe('${BRANCH}');
+    await pool.destroyAll();
+  });
+});
+EOF
+
+echo "==> repro: current RepoPool behavior"
+set +e
+timeout "$TIMEOUT_SECONDS" \
+  pnpm --filter @invoker/execution-engine exec vitest run "$HELPER_TEST" \
+  >"$VITEST_LOG" 2>&1
+VITEST_STATUS=$?
+set -e
+
+OBSERVED=""
+if [[ "$VITEST_STATUS" -eq 0 ]]; then
+  OBSERVED="fixed"
+else
+  if grep -q "already exists" "$VITEST_LOG"; then
+    OBSERVED="bug"
+  else
+    echo "==> repro: unexpected vitest failure"
+    cat "$VITEST_LOG" >&2 || true
+    die "vitest failed, but not with the orphan-path collision signature"
+  fi
+fi
+
+echo "observed      : $OBSERVED"
+echo "expected      : $EXPECTATION"
+
+echo "==> repro summary"
+echo "orphan_path        : $WORKTREE_PATH"
+echo "mirror_registered  : no"
+echo "raw_git_already_exists : yes"
+echo "repo_pool_observed : $OBSERVED"
+echo "artifacts          : $TMP_DIR"
+
+if [[ "$OBSERVED" != "$EXPECTATION" ]]; then
+  echo "==> repro mismatch"
+  cat "$VITEST_LOG" >&2 || true
+  exit 1
+fi
+
+echo "==> repro matched expectation"
+exit 0

--- a/skills/plan-to-invoker/scripts/check-policy-coverage.sh
+++ b/skills/plan-to-invoker/scripts/check-policy-coverage.sh
@@ -9,6 +9,32 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+if command -v rg >/dev/null 2>&1; then
+  text_search_count() {
+    local pattern="$1"
+    local file="$2"
+    rg -c "$pattern" "$file" || true
+  }
+
+  text_search_has_match() {
+    local pattern="$1"
+    local file="$2"
+    rg -q "$pattern" "$file"
+  }
+else
+  text_search_count() {
+    local pattern="$1"
+    local file="$2"
+    grep -E -c "$pattern" "$file" || true
+  }
+
+  text_search_has_match() {
+    local pattern="$1"
+    local file="$2"
+    grep -E -q "$pattern" "$file"
+  }
+fi
+
 source_kind="$(jq -r '.sourceKind // "generic"' "$assumptions_file")"
 if [[ "$source_kind" != "policy_matrix" ]]; then
   echo "true"
@@ -22,11 +48,11 @@ if [[ "$coverage_count" -le 0 ]]; then
 fi
 
 if [[ -n "$verify_plan_file" ]]; then
-  if rg -q '^  - id: verify-noop$' "$verify_plan_file"; then
+  if text_search_has_match '^  - id: verify-noop$' "$verify_plan_file"; then
     echo "Policy-matrix source degraded to verify-noop" >&2
     exit 1
   fi
-  verify_count="$(rg -c '^  - id: verify-coverage-' "$verify_plan_file" || true)"
+  verify_count="$(text_search_count '^  - id: verify-coverage-' "$verify_plan_file")"
   if [[ "$verify_count" -le 0 ]]; then
     echo "Policy-matrix verify plan contains no coverage verification tasks" >&2
     exit 1


### PR DESCRIPTION
## Summary
This fixes the recreate/startup worktree failures caused by two separate issues: leaked orphan worktree directories and branch identity collisions across attempts.

It also adds a standalone repro script that proves the orphan-path failure mode directly against `RepoPool.acquireWorktree`.

## Changes
- stop truncating attempt-derived lifecycle tags so different attempts do not collide onto the same branch suffix
- prevent `forceFresh` recreate flows from reusing content-equivalent worktree paths
- repair orphan target directories before `git worktree add`
- add regression coverage and a shell repro for the orphan-path case

## Verification
- `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/managed-worktree-controller.test.ts src/__tests__/branch-utils.test.ts src/__tests__/repo-pool.test.ts`
- `scripts/repro/repro-orphan-worktree-path-collision.sh --expect fixed`