### PR TITLE
release: publish mac intel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,12 +20,19 @@ jobs:
       matrix:
         include:
           - runner: ubuntu-latest
-            target: linux
+            build_command: pnpm run dist:desktop:linux
+            artifact_name: release-linux
             artifact_glob: |
               release/*.AppImage
               release/*.deb
           - runner: macos-latest
-            target: mac
+            build_command: pnpm run dist:desktop:mac:arm64
+            artifact_name: release-mac-arm64
+            artifact_glob: |
+              release/*.dmg
+          - runner: macos-13
+            build_command: pnpm run dist:desktop:mac:x64
+            artifact_name: release-mac-x64
             artifact_glob: |
               release/*.dmg
 
@@ -48,18 +55,14 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build desktop artifacts
-        run: pnpm run dist:desktop:${{ matrix.target }}
-
-      - name: Generate checksums
-        run: bash scripts/release-sha256.sh
+        run: ${{ matrix.build_command }}
 
       - name: Upload packaged artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: release-${{ matrix.target }}
+          name: ${{ matrix.artifact_name }}
           path: |
             ${{ matrix.artifact_glob }}
-            release/SHA256SUMS
           if-no-files-found: error
 
   publish-release:
@@ -73,6 +76,9 @@ jobs:
           pattern: release-*
           merge-multiple: true
           path: release
+
+      - name: Generate combined checksums
+        run: bash scripts/release-sha256.sh
 
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@v2

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "dist:desktop": "bash scripts/package-desktop.sh",
     "dist:desktop:linux": "bash scripts/package-desktop.sh --linux",
     "dist:desktop:mac": "bash scripts/package-desktop.sh --mac",
+    "dist:desktop:mac:arm64": "bash scripts/package-desktop.sh --mac --arm64",
+    "dist:desktop:mac:x64": "bash scripts/package-desktop.sh --mac --x64",
     "build:tsc": "tsc -b tsconfig.build.json",
     "build:tsc:clean": "tsc -b tsconfig.build.json --clean",
     "clean": "pnpm -r clean",

--- a/scripts/package-desktop.sh
+++ b/scripts/package-desktop.sh
@@ -5,15 +5,34 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 TARGET="all"
-case "${1:-}" in
-  --linux) TARGET="linux" ;;
-  --mac) TARGET="mac" ;;
-  "" ) ;;
-  *)
-    echo "Usage: bash scripts/package-desktop.sh [--linux|--mac]" >&2
-    exit 64
-    ;;
-esac
+MAC_ARCH=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --linux)
+      TARGET="linux"
+      ;;
+    --mac)
+      TARGET="mac"
+      ;;
+    --x64)
+      MAC_ARCH="x64"
+      ;;
+    --arm64)
+      MAC_ARCH="arm64"
+      ;;
+    *)
+      echo "Usage: bash scripts/package-desktop.sh [--linux|--mac] [--x64|--arm64]" >&2
+      exit 64
+      ;;
+  esac
+  shift
+done
+
+if [ -n "$MAC_ARCH" ] && [ "$TARGET" != "mac" ]; then
+  echo "--x64/--arm64 requires --mac" >&2
+  exit 64
+fi
 
 pnpm --filter @invoker/ui build
 pnpm --filter @invoker/app build
@@ -30,7 +49,11 @@ case "$TARGET" in
     pnpm --filter @invoker/app exec electron-builder --linux AppImage deb --publish never
     ;;
   mac)
-    pnpm --filter @invoker/app exec electron-builder --mac dmg --publish never
+    if [ -n "$MAC_ARCH" ]; then
+      pnpm --filter @invoker/app exec electron-builder --mac dmg "--$MAC_ARCH" --publish never
+    else
+      pnpm --filter @invoker/app exec electron-builder --mac dmg --publish never
+    fi
     ;;
   all)
     pnpm --filter @invoker/app exec electron-builder --publish never


### PR DESCRIPTION
## Summary
The release workflow currently publishes only one macOS DMG, which comes from the architecture of the single macOS runner. For `v0.0.1`, that produced `Invoker-0.0.1-arm64.dmg` but no Intel/macOS x64 artifact.

This change splits macOS packaging into explicit `arm64` and `x64` jobs, using separate runners for each architecture. It also moves checksum generation to the publish job so the release gets one combined `SHA256SUMS` file for all uploaded artifacts instead of per-job partial checksums.

## Problem
The current `Release` workflow has exactly one macOS build entry. That means the release only includes the runner-native DMG. On current GitHub-hosted macOS, that yielded an Apple Silicon DMG and skipped Intel.

The workflow also generates `SHA256SUMS` inside each build job, then merges artifacts later. That is fine with one artifact producer, but wrong once multiple jobs contribute release assets because the checksums are partial and can overwrite each other.

## Root Cause
The build matrix modeled macOS as a single platform dimension instead of separate architecture-specific build units. The packaging script also had no way to request a specific mac architecture, so the workflow could not reliably ask electron-builder for `x64` vs `arm64` output.

## Approach
Add explicit mac packaging commands for `arm64` and `x64`, teach `scripts/package-desktop.sh` to accept `--arm64` / `--x64` for mac builds, and expand the release matrix to run:
- `macos-latest` for Apple Silicon DMGs
- `macos-13` for Intel/x64 DMGs

Then generate checksums once, after all release artifacts are downloaded into the publish job.

## Why This Fix Is Right
This keeps the release pipeline aligned with the actual distribution contract: one Linux build lane, one Apple Silicon mac lane, and one Intel mac lane. Using separate macOS runners is simpler and less fragile than depending on cross-arch packaging behavior for a production release.

Moving checksum generation to the publish job also makes the release assets internally consistent. The uploaded `SHA256SUMS` now reflects the full release payload instead of whichever build job last wrote the file.

## Tradeoffs And Considerations
This adds one more macOS runner job per tagged release, so release CI will cost a little more and take slightly longer.

This change fixes the release process going forward. It does not retroactively attach an Intel DMG to the already-published `v0.0.1` release; that still needs a rerun/manual backfill if we want the current release page updated.

## Before
```mermaid
flowchart TD
  Tag[v* tag] --> Linux[ubuntu release build]
  Tag --> Mac[one macOS release build]
  Linux --> Publish[merge artifacts]
  Mac --> Publish
  Publish --> Release[GitHub release]

  note1[mac output depends on runner arch]
  note2[checksums generated per job]
```

## After
```mermaid
flowchart TD
  Tag[v* tag] --> Linux[ubuntu release build]
  Tag --> MacArm[macos-latest arm64 release build]
  Tag --> MacX64[macos-13 x64 release build]
  Linux --> Publish[download all artifacts]
  MacArm --> Publish
  MacX64 --> Publish
  Publish --> Checksums[generate combined SHA256SUMS]
  Checksums --> Release[GitHub release]
```

## Verification
- `bash -n scripts/package-desktop.sh`
- inspected release workflow diff to confirm:
  - separate `arm64` and `x64` mac lanes
  - combined checksum generation happens only in the publish job

## Traceability
- Current release missing Intel mac artifact: https://github.com/Neko-Catpital-Labs/Invoker/releases/tag/v0.0.1
- Release workflow source: `.github/workflows/release.yml`
