### PR TITLE
fix(headless): prefer standalone owner for CLI mutations

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ If you need to turn a product or implementation plan into an Invoker workflow, u
 ./run.sh --headless run /path/to/plan.yaml
 ```
 
+Mutating headless CLI commands use a standalone headless owner process. They do not delegate execution into the desktop GUI process, even if the GUI app is already running. Read-only shared queries such as `query queue` and `query ui-perf` may still talk to an existing owner.
+
+GUI-launched workflows still inherit the GUI app environment. On macOS, apps launched from Finder often have a narrower `PATH` than your terminal. If you start workflows from the desktop app, make sure tools like `pnpm`, `git`, and any configured agent CLIs are available to the GUI launch context.
+
 **Hot-reload app development**:
 
 ```bash
@@ -220,7 +224,8 @@ Layer rules: [ARCHITECTURE.md](ARCHITECTURE.md). Agent/repo conventions: [CLAUDE
 
 ## Troubleshooting
 
-- **DB conflicts** — Do not run two writers on the same DB; use the owning process for mutating headless commands.
+- **DB conflicts** — Do not run two writers on the same DB; headless CLI mutations use a standalone owner, while GUI-started workflows stay owned by the desktop app process.
+- **`pnpm` or `git` not found from the desktop app** — On macOS this is often a Finder/GUI `PATH` issue. Launch Invoker from a terminal with `./run.sh`, or make the required binaries available to GUI-launched apps.
 - **Missing Cursor skills** — `bash scripts/setup-agent-skills.sh`
 - **Install failures** — Use Node 22 as per `engines`
 - **Obsidian (README / Mermaid)** — In **Source** mode the diagram stays plain text. Open **Reading view** (book icon in the header, or the *Toggle reading view* command). **Live Preview** usually renders Mermaid as well; if you see an empty box or a parse error, update Obsidian, try the default theme, and disable CSS snippets (some themes hide Mermaid).

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -4,11 +4,11 @@ import { LocalBus } from '@invoker/transport';
 import { SharedMutationOwnerTimeoutError, runHeadlessClientCommand } from '../headless-client.js';
 
 describe('headless-client', () => {
-  it('delegates mutating commands to an existing owner without electron fallback', async () => {
+  it('delegates mutating commands to an existing standalone owner without electron fallback', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));
     bus.onRequest('headless.exec', ownerHandler);
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
 
     const runElectronHeadless = vi.fn(async () => 0);
     const ensureStandaloneOwner = vi.fn(async () => {});
@@ -27,6 +27,34 @@ describe('headless-client', () => {
     });
     expect(ensureStandaloneOwner).not.toHaveBeenCalled();
     expect(runElectronHeadless).not.toHaveBeenCalled();
+  });
+
+  it('does not delegate mutating commands to a GUI owner and bootstraps standalone instead', async () => {
+    const bus = new LocalBus();
+    const guiOwnerHandler = vi.fn(async () => ({ ok: true }));
+    const standaloneOwnerHandler = vi.fn(async () => ({ ok: true }));
+    let ownerMode: 'gui' | 'standalone' = 'gui';
+
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: ownerMode }));
+    bus.onRequest('headless.exec', async (payload) => {
+      if (ownerMode === 'gui') return guiOwnerHandler(payload);
+      return standaloneOwnerHandler(payload);
+    });
+
+    const ensureStandaloneOwner = vi.fn(async () => {
+      ownerMode = 'standalone';
+    });
+
+    const exitCode = await runHeadlessClientCommand(['retry', 'wf-1', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(guiOwnerHandler).not.toHaveBeenCalled();
+    expect(standaloneOwnerHandler).toHaveBeenCalledTimes(1);
+    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
   });
 
   it('bootstraps a standalone owner once when no owner is present, then delegates', async () => {
@@ -225,32 +253,7 @@ describe('headless-client', () => {
     expect(refreshMessageBus).toHaveBeenCalled();
   }, 15_000);
 
-  it('retries no-track delegated mutations after the first owner request times out', async () => {
-    const bus = new LocalBus();
-    let execCalls = 0;
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    bus.onRequest('headless.exec', async () => {
-      execCalls += 1;
-      if (execCalls === 1) {
-        return await new Promise(() => {});
-      }
-      return { ok: true };
-    });
-
-    const ensureStandaloneOwner = vi.fn(async () => {});
-
-    const exitCode = await runHeadlessClientCommand(['recreate', 'wf-2', '--no-track'], {
-      messageBus: bus,
-      ensureStandaloneOwner,
-      runElectronHeadless: vi.fn(async () => 0),
-    });
-
-    expect(exitCode).toBe(0);
-    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
-    expect(execCalls).toBe(2);
-  }, 15_000);
-
-  it('refreshes the message bus before retrying after an owner restart', async () => {
+  it('refreshes the message bus before retrying after switching away from a GUI owner', async () => {
     const firstBus = new LocalBus();
     const secondBus = new LocalBus();
     let firstExecCalls = 0;
@@ -281,7 +284,7 @@ describe('headless-client', () => {
     expect(exitCode).toBe(0);
     expect(ensureStandaloneOwner).not.toHaveBeenCalled();
     expect(refreshMessageBus).toHaveBeenCalledTimes(1);
-    expect(firstExecCalls).toBe(1);
+    expect(firstExecCalls).toBe(0);
     expect(secondExecCalls).toBe(1);
   }, 15_000);
 

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -62,9 +62,14 @@ const POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 8_000;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
+type HeadlessOwnerInfo = { ownerId?: string; mode?: string };
+
+function isStandaloneOwner(owner: HeadlessOwnerInfo | null | undefined): owner is HeadlessOwnerInfo & { mode: 'standalone' } {
+  return owner?.mode === 'standalone';
+}
 
 export class SharedMutationOwnerTimeoutError extends Error {
-  constructor(message: string = 'Timed out waiting for a shared mutation owner to become available') {
+  constructor(message: string = 'Timed out waiting for a standalone shared mutation owner to become available') {
     super(message);
     this.name = 'SharedMutationOwnerTimeoutError';
   }
@@ -108,7 +113,7 @@ async function delegateReadOnlyQuery(
   }
   const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
   let messageBus = bus;
-  let owner: { ownerId?: string; mode?: string } | null = null;
+  let owner: HeadlessOwnerInfo | null = null;
   while (Date.now() < deadline) {
     owner = await tryPingHeadlessOwner(messageBus, 2_000);
     if (owner) break;
@@ -180,7 +185,7 @@ async function delegateAfterBootstrap(
   let messageBus = bus;
   while (Date.now() < deadline) {
     const owner = await tryPingHeadlessOwner(messageBus, 1_000);
-    if (owner && await delegateMutation(
+    if (isStandaloneOwner(owner) && await delegateMutation(
       args,
       messageBus,
       waitForApproval,
@@ -214,7 +219,7 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
     const deadline = Date.now() + 20_000;
     while (Date.now() < deadline) {
       const owner = await tryPingHeadlessOwner(bus, 500);
-      if (owner) return;
+      if (isStandaloneOwner(owner)) return;
       await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
     }
     throw new SharedMutationOwnerTimeoutError();
@@ -265,7 +270,7 @@ export async function runHeadlessClientCommand(
   }
 
   const owner = await tryPingHeadlessOwner(messageBus, 3_000);
-  if (owner) {
+  if (isStandaloneOwner(owner)) {
     if (await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
       return resolvedExitCode();
     }
@@ -273,7 +278,7 @@ export async function runHeadlessClientCommand(
   if (owner && deps.refreshMessageBus) {
     messageBus = await deps.refreshMessageBus();
     const refreshedOwner = await tryPingHeadlessOwner(messageBus, 1_000);
-    if (refreshedOwner && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+    if (isStandaloneOwner(refreshedOwner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
       return resolvedExitCode();
     }
   }
@@ -311,7 +316,7 @@ export async function runHeadlessClientCommand(
     messageBus = await deps.refreshMessageBus();
   }
   process.stderr.write(
-    `${RED}Error:${RESET} Mutation command "${args[0] ?? ''}" could not reach a shared owner after bootstrap.\n`,
+    `${RED}Error:${RESET} Mutation command "${args[0] ?? ''}" could not reach a standalone shared owner after bootstrap.\n`,
   );
   return 1;
 }


### PR DESCRIPTION
## Summary

Headless CLI mutation commands now require a standalone owner instead of delegating into an already-running GUI owner. This keeps CLI-triggered worktree provisioning and executor startup bound to the terminal environment, which avoids Finder/GUI PATH mismatches such as `pnpm: command not found`.

README now documents the routing split: mutating headless CLI commands bootstrap/use a standalone owner, while GUI-launched workflows still inherit the desktop app environment.

## Architecture

### Before

```mermaid
graph TD
    CLI[Headless CLI mutation] --> Ping[Any shared owner]
    Ping --> GUI[GUI owner]
    GUI --> Exec[WorktreeExecutor provisioning]
```

### After

```mermaid
graph TD
    CLI[Headless CLI mutation] --> Ping[Any shared owner]
    Ping --> Standalone[Standalone headless owner only]
    CLI --> Bootstrap[Bootstrap standalone owner if needed]
    Standalone --> Exec[WorktreeExecutor provisioning]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/headless-client.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 93a893be`
- Post-revert steps: None
- Data migration? No
