### PR TITLE
Normalize macOS GUI PATH from shell env

### DIFF
--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -25,6 +25,7 @@ import type { TaskStateChanges } from '@invoker/workflow-graph';
 import {
   DockerExecutor, WorktreeExecutor, ExecutorRegistry, SshExecutor,
   BaseExecutor,
+  getEffectivePath,
   type ExecutorHandle, type TerminalSpec, type PersistedTaskMeta,
 } from '@invoker/execution-engine';
 import type { WorkResponse, WorkRequest } from '@invoker/contracts';
@@ -107,7 +108,7 @@ function buildCleanEnv(): Record<string, string> {
   for (const k of keep) {
     if (process.env[k]) cleanEnv[k] = process.env[k]!;
   }
-  cleanEnv.PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
+  cleanEnv.PATH = getEffectivePath();
   if (!cleanEnv.TERM) cleanEnv.TERM = 'xterm-256color';
   return cleanEnv;
 }
@@ -353,7 +354,7 @@ describe('open-terminal integration', () => {
       const spawnCall = mockSpawn.mock.calls[0] as unknown[];
       const env = (spawnCall[2] as Record<string, unknown>).env as Record<string, string>;
       expect(env).toHaveProperty('HOME');
-      expect(env).toHaveProperty('PATH', '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin');
+      expect(env).toHaveProperty('PATH', getEffectivePath());
       expect(env).not.toHaveProperty('GTK_PATH');
       expect(env).not.toHaveProperty('GDK_PIXBUF_MODULE_FILE');
       expect(env).not.toHaveProperty('LD_LIBRARY_PATH');

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -66,6 +66,7 @@ import type { MessageBus } from '@invoker/transport';
 import {
   ExecutorRegistry, TaskRunner,
   DockerExecutor, WorktreeExecutor, SshExecutor, GitHubMergeGateProvider, ReviewProviderRegistry,
+  initializeShellEnvironment,
   RESTART_TO_BRANCH_TRACE,
   remoteFetchForPool,
   registerBuiltinAgents,
@@ -319,6 +320,14 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
   });
   // Upgrade root logger with DB persistence now that SQLiteAdapter is ready.
   logger = new FileAndDbLogger({ module: 'main' }, { persistence });
+  const shellEnv = await initializeShellEnvironment();
+  if (process.platform === 'darwin') {
+    const suffix = shellEnv.reason ? ` (${shellEnv.reason})` : '';
+    logger.info(
+      `[init] shell environment ${shellEnv.status} via ${shellEnv.shell}; PATH=${shellEnv.path}${suffix}`,
+      { module: 'init' },
+    );
+  }
   if (!readOnly && !hourlyBackupInterval) {
     const hourlyMs = Number(process.env.INVOKER_HOURLY_BACKUP_MS ?? 60 * 60 * 1000);
     if (Number.isFinite(hourlyMs) && hourlyMs > 0) {

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -8,6 +8,7 @@ import { execSync } from 'node:child_process';
 import { homedir } from 'node:os';
 import {
   DockerExecutor,
+  getEffectivePath,
   WorktreeExecutor,
   SshExecutor,
   type ExecutorRegistry,
@@ -267,7 +268,7 @@ export async function openExternalTerminalForTask(
     for (const k of keep) {
       if (process.env[k]) cleanEnv[k] = process.env[k]!;
     }
-    cleanEnv.PATH = '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin';
+    cleanEnv.PATH = getEffectivePath();
     if (!cleanEnv.TERM) cleanEnv.TERM = 'xterm-256color';
 
     const bashScript = buildLinuxXTerminalBashScript(spec, cwd);

--- a/packages/execution-engine/src/__tests__/process-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/process-utils.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type { ChildProcess } from 'node:child_process';
+
+vi.mock('node:child_process', () => ({
+  spawn: vi.fn(),
+}));
+
+function createMockProcess(): ChildProcess & EventEmitter {
+  const proc = new EventEmitter() as ChildProcess & EventEmitter;
+  const stdout = new EventEmitter();
+  const stderr = new EventEmitter();
+  (proc as any).stdout = stdout;
+  (proc as any).stderr = stderr;
+  (proc as any).pid = 4321;
+  proc.kill = vi.fn().mockReturnValue(true);
+  return proc;
+}
+
+const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+const originalPath = process.env.PATH;
+const originalShell = process.env.SHELL;
+const originalElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
+const originalElectronNoAsar = process.env.ELECTRON_NO_ASAR;
+const originalElectronNoAttachConsole = process.env.ELECTRON_NO_ATTACH_CONSOLE;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+}
+
+async function loadProcessUtils() {
+  vi.resetModules();
+  const childProcess = await import('node:child_process');
+  const processUtils = await import('../process-utils.js');
+  return { processUtils, mockedSpawn: vi.mocked(childProcess.spawn) };
+}
+
+describe('process-utils shell environment resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+    }
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalShell === undefined) delete process.env.SHELL;
+    else process.env.SHELL = originalShell;
+    if (originalElectronRunAsNode === undefined) delete process.env.ELECTRON_RUN_AS_NODE;
+    else process.env.ELECTRON_RUN_AS_NODE = originalElectronRunAsNode;
+    if (originalElectronNoAsar === undefined) delete process.env.ELECTRON_NO_ASAR;
+    else process.env.ELECTRON_NO_ASAR = originalElectronNoAsar;
+    if (originalElectronNoAttachConsole === undefined) delete process.env.ELECTRON_NO_ATTACH_CONSOLE;
+    else process.env.ELECTRON_NO_ATTACH_CONSOLE = originalElectronNoAttachConsole;
+  });
+
+  afterEach(() => {
+    if (originalPlatformDescriptor) {
+      Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+    }
+  });
+
+  it('parses shell PATH markers from noisy output', async () => {
+    const { processUtils } = await loadProcessUtils();
+    const parsed = processUtils.parseResolvedShellPath(
+      'warning\n__INVOKER_EFFECTIVE_PATH_START__/opt/homebrew/bin:/usr/bin__INVOKER_EFFECTIVE_PATH_END__\nfooter',
+    );
+    expect(parsed).toBe('/opt/homebrew/bin:/usr/bin');
+  });
+
+  it('prepends common Homebrew paths in the macOS fallback PATH', async () => {
+    setPlatform('darwin');
+    const { processUtils } = await loadProcessUtils();
+    expect(processUtils.applyMacOSPathFallback('/usr/bin:/bin:/usr/local/bin')).toBe(
+      '/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin',
+    );
+  });
+
+  it('initializes and caches the resolved shell PATH on macOS', async () => {
+    setPlatform('darwin');
+    process.env.SHELL = '/bin/zsh';
+    process.env.PATH = '/usr/bin:/bin';
+    process.env.ELECTRON_RUN_AS_NODE = '1';
+    process.env.ELECTRON_NO_ASAR = '1';
+    process.env.ELECTRON_NO_ATTACH_CONSOLE = '1';
+
+    const { processUtils, mockedSpawn } = await loadProcessUtils();
+    const proc = createMockProcess();
+    mockedSpawn.mockReturnValue(proc as never);
+
+    const initPromise = processUtils.initializeShellEnvironment();
+    proc.stdout?.emit(
+      'data',
+      Buffer.from(
+        'noise before __INVOKER_EFFECTIVE_PATH_START__/opt/homebrew/bin:/Users/test/.local/bin:/usr/bin__INVOKER_EFFECTIVE_PATH_END__ noise after',
+      ),
+    );
+    proc.emit('close', 0, null);
+
+    const result = await initPromise;
+    expect(result.status).toBe('resolved');
+    expect(result.path).toBe('/opt/homebrew/bin:/usr/local/bin:/Users/test/.local/bin:/usr/bin');
+    expect(process.env.PATH).toBe(result.path);
+    expect(processUtils.getEffectivePath()).toBe(result.path);
+    expect(processUtils.cleanElectronEnv()).toMatchObject({
+      PATH: result.path,
+    });
+    expect(processUtils.cleanElectronEnv()).not.toHaveProperty('ELECTRON_RUN_AS_NODE');
+    expect(processUtils.cleanElectronEnv()).not.toHaveProperty('ELECTRON_NO_ASAR');
+    expect(processUtils.cleanElectronEnv()).not.toHaveProperty('ELECTRON_NO_ATTACH_CONSOLE');
+
+    const second = await processUtils.initializeShellEnvironment();
+    expect(second).toEqual(result);
+    expect(mockedSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back cleanly when shell resolution times out', async () => {
+    setPlatform('darwin');
+    process.env.PATH = '/usr/bin:/bin';
+
+    const { processUtils, mockedSpawn } = await loadProcessUtils();
+    const proc = createMockProcess();
+    mockedSpawn.mockReturnValue(proc as never);
+
+    await expect(processUtils.probeMacOSShellPath('/bin/zsh', 5)).rejects.toThrow(/timed out/);
+    expect(proc.kill).toHaveBeenCalledWith('SIGKILL');
+  });
+
+  it('skips shell probing outside macOS', async () => {
+    setPlatform('linux');
+    process.env.PATH = '/usr/local/bin:/usr/bin:/bin';
+
+    const { processUtils, mockedSpawn } = await loadProcessUtils();
+    const result = await processUtils.initializeShellEnvironment();
+
+    expect(result.status).toBe('skipped');
+    expect(result.path).toBe('/usr/local/bin:/usr/bin:/bin');
+    expect(mockedSpawn).not.toHaveBeenCalled();
+  });
+});

--- a/packages/execution-engine/src/process-utils.ts
+++ b/packages/execution-engine/src/process-utils.ts
@@ -1,6 +1,35 @@
-import type { ChildProcess } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 
 export const SIGKILL_TIMEOUT_MS = 5_000;
+const SHELL_ENV_RESOLUTION_TIMEOUT_MS = 10_000;
+const SHELL_ENV_MARKER_START = '__INVOKER_EFFECTIVE_PATH_START__';
+const SHELL_ENV_MARKER_END = '__INVOKER_EFFECTIVE_PATH_END__';
+export const INVOKER_RESOLVING_ENVIRONMENT = 'INVOKER_RESOLVING_ENVIRONMENT';
+
+const MACOS_PATH_FALLBACK_PREFIXES = [
+  '/opt/homebrew/bin',
+  '/usr/local/bin',
+];
+
+const MACOS_STANDARD_PATH_ENTRIES = [
+  '/usr/local/sbin',
+  '/usr/local/bin',
+  '/usr/bin',
+  '/bin',
+  '/usr/sbin',
+  '/sbin',
+];
+
+export interface ShellEnvironmentInitResult {
+  status: 'resolved' | 'fallback' | 'skipped';
+  path: string;
+  shell: string;
+  reason?: string;
+}
+
+let effectivePath = applyMacOSPathFallback(process.env.PATH);
+let initializationPromise: Promise<ShellEnvironmentInitResult> | null = null;
+let initializationResult: ShellEnvironmentInitResult | null = null;
 
 /**
  * Sends a signal to the entire process group.
@@ -16,11 +45,160 @@ export function killProcessGroup(child: ChildProcess, signal: NodeJS.Signals): b
   }
 }
 
+function splitPathEntries(rawPath?: string): string[] {
+  if (!rawPath) return [];
+  return rawPath.split(':').map((entry) => entry.trim()).filter(Boolean);
+}
+
+function joinPathEntries(entries: string[]): string {
+  return entries.join(':');
+}
+
+function withPrependedUniqueEntries(prefixes: string[], rest: string[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const entry of [...prefixes, ...rest]) {
+    if (!entry || seen.has(entry)) continue;
+    seen.add(entry);
+    ordered.push(entry);
+  }
+  return ordered;
+}
+
+export function applyMacOSPathFallback(rawPath?: string): string {
+  const current = splitPathEntries(rawPath);
+  const preferred = process.platform === 'darwin' ? MACOS_PATH_FALLBACK_PREFIXES : [];
+  const fallback = current.length > 0 ? current : MACOS_STANDARD_PATH_ENTRIES;
+  return joinPathEntries(withPrependedUniqueEntries(preferred, fallback));
+}
+
+export function parseResolvedShellPath(output: string): string | null {
+  const start = output.lastIndexOf(SHELL_ENV_MARKER_START);
+  if (start === -1) return null;
+  const payloadStart = start + SHELL_ENV_MARKER_START.length;
+  const end = output.indexOf(SHELL_ENV_MARKER_END, payloadStart);
+  if (end === -1) return null;
+  const resolved = output.slice(payloadStart, end).trim();
+  return resolved.length > 0 ? resolved : null;
+}
+
+export function getEffectivePath(): string {
+  return effectivePath;
+}
+
+export async function probeMacOSShellPath(shell: string, timeoutMs = SHELL_ENV_RESOLUTION_TIMEOUT_MS): Promise<string> {
+  const probeScript = `printf '%s%s%s' '${SHELL_ENV_MARKER_START}' "$PATH" '${SHELL_ENV_MARKER_END}'`;
+
+  return await new Promise<string>((resolve, reject) => {
+    let settled = false;
+    let stdout = '';
+    let stderr = '';
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      fn();
+    };
+
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(shell, ['-i', '-l', '-c', probeScript], {
+        stdio: ['ignore', 'pipe', 'pipe'],
+        env: {
+          ...process.env,
+          [INVOKER_RESOLVING_ENVIRONMENT]: '1',
+        },
+      });
+    } catch (err) {
+      reject(err);
+      return;
+    }
+
+    child.stdout?.on('data', (chunk: Buffer | string) => {
+      stdout += chunk.toString();
+    });
+    child.stderr?.on('data', (chunk: Buffer | string) => {
+      stderr += chunk.toString();
+    });
+    child.on('error', (err) => finish(() => reject(err)));
+    child.on('close', (code, signal) => {
+      finish(() => {
+        const combinedOutput = `${stdout}${stderr}`;
+        const resolved = parseResolvedShellPath(combinedOutput);
+        if (resolved) {
+          resolve(resolved);
+          return;
+        }
+        const reason = code === 0
+          ? `shell probe did not emit a PATH marker`
+          : `shell probe exited with code ${code ?? 'null'}${signal ? ` signal ${signal}` : ''}`;
+        reject(new Error(reason));
+      });
+    });
+
+    timeout = setTimeout(() => {
+      child.kill('SIGKILL');
+      finish(() => reject(new Error(`shell environment resolution timed out after ${timeoutMs}ms`)));
+    }, timeoutMs);
+  });
+}
+
+export async function initializeShellEnvironment(): Promise<ShellEnvironmentInitResult> {
+  if (initializationResult) return initializationResult;
+  if (initializationPromise) return await initializationPromise;
+
+  initializationPromise = (async () => {
+    const shell = process.env.SHELL?.trim() || '/bin/zsh';
+    if (process.platform !== 'darwin') {
+      initializationResult = {
+        status: 'skipped',
+        path: effectivePath,
+        shell,
+        reason: 'shell environment resolution is only used on macOS',
+      };
+      return initializationResult;
+    }
+
+    try {
+      const resolvedPath = await probeMacOSShellPath(shell);
+      effectivePath = applyMacOSPathFallback(resolvedPath);
+      process.env.PATH = effectivePath;
+      initializationResult = {
+        status: 'resolved',
+        path: effectivePath,
+        shell,
+      };
+      return initializationResult;
+    } catch (err) {
+      effectivePath = applyMacOSPathFallback(process.env.PATH);
+      process.env.PATH = effectivePath;
+      initializationResult = {
+        status: 'fallback',
+        path: effectivePath,
+        shell,
+        reason: err instanceof Error ? err.message : String(err),
+      };
+      return initializationResult;
+    }
+  })();
+
+  return await initializationPromise;
+}
+
+export function resetShellEnvironmentForTests(): void {
+  effectivePath = applyMacOSPathFallback(process.env.PATH);
+  initializationPromise = null;
+  initializationResult = null;
+}
+
 /** Strip Electron-specific env vars so child processes use the system Node.js. */
 export function cleanElectronEnv(): NodeJS.ProcessEnv {
   const env = { ...process.env };
   delete env.ELECTRON_RUN_AS_NODE;
   delete env.ELECTRON_NO_ASAR;
   delete env.ELECTRON_NO_ATTACH_CONSOLE;
+  env.PATH = getEffectivePath();
   return env;
 }


### PR DESCRIPTION
## Summary

Normalize the macOS desktop app PATH by probing the user's shell environment at startup and reusing that resolved PATH for child processes.

This keeps GUI-launched workflows aligned with the PATH users expect after installing tools with Homebrew, instead of relying on Finder's narrower default environment.

## Architecture

### Before

```mermaid
flowchart TD
    A[Finder-launched Electron app] --> B[process.env.PATH from launchd]
    B --> C[cleanElectronEnv]
    C --> D[worktree provisioning / git / pnpm / agent CLIs]
```

### After

```mermaid
flowchart TD
    A[Finder-launched Electron app] --> B[initializeShellEnvironment]
    B --> C[probe login shell PATH once]
    C --> D[getEffectivePath cache]
    D --> E[cleanElectronEnv]
    D --> F[open terminal allowlisted env]
    E --> G[worktree provisioning / git / pnpm / agent CLIs]
    F --> H[external terminal launches]
```

## Test Plan

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/process-utils.test.ts`
- [x] `pnpm --filter @invoker/app build`
- [ ] `cd packages/app && pnpm exec vitest run src/__tests__/open-terminal.test.ts --reporter=verbose` currently has one unrelated pre-existing failure: `this.pool.reconcileActiveWorktrees is not a function`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 42b1983604f2f7a0312ac0c7620b37260b145d82`
- Post-revert steps: None
- Data migration? No
