### PR TITLE
Fix stale SSH worktree owner cleanup

### DIFF
--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -3,6 +3,7 @@ import { writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 import type { Page } from '@playwright/test';
+import { SQLiteAdapter } from '@invoker/data-store';
 import { stringify as yamlStringify } from 'yaml';
 
 import {
@@ -40,6 +41,28 @@ function parseWorkflowId(stdout: string): string {
   const direct = stdout.match(/Workflow ID: (wf-[^\s]+)/);
   if (direct?.[1]) return direct[1];
   throw new Error(`No workflow id found in stdout:\n${stdout}`);
+}
+
+async function resolveWorkflowIdFromDb(
+  testDir: string,
+  knownWorkflowIds: ReadonlySet<string>,
+  timeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  const dbPath = path.join(testDir, 'invoker.db');
+  while (Date.now() < deadline) {
+    const db = await SQLiteAdapter.create(dbPath, { readOnly: true });
+    try {
+      const workflowId = db.listWorkflows()
+        .map((workflow) => workflow.id)
+        .find((id): id is string => !!id && !knownWorkflowIds.has(id));
+      if (workflowId) return workflowId;
+    } finally {
+      db.close();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error('Timed out waiting for a new workflow id to appear in persisted state');
 }
 
 async function assertTaskPanelResponsive(page: Page, timeoutMs: number): Promise<void> {
@@ -85,7 +108,13 @@ test.describe('Headless thundering herd', () => {
     if (currentWorkflowId) workflowIds.add(currentWorkflowId);
     for (let i = 0; i < 8; i += 1) {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
-      workflowIds.add(parseWorkflowId(result.stdout));
+      let workflowId: string;
+      try {
+        workflowId = parseWorkflowId(result.stdout);
+      } catch {
+        workflowId = await resolveWorkflowIdFromDb(testDir, workflowIds, 2_000);
+      }
+      workflowIds.add(workflowId);
     }
 
     await page.waitForTimeout(500);

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -57,6 +57,23 @@ describe('headless-client', () => {
     expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
   });
 
+  it('uses a longer no-track delegation timeout for an already-running standalone owner under load', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+    bus.onRequest('headless.exec', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 9_000));
+      return { ok: true };
+    });
+
+    const exitCode = await runHeadlessClientCommand(['retry', 'wf-1', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+  }, 15_000);
+
   it('bootstraps a standalone owner once when no owner is present, then delegates', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -56,16 +56,30 @@ async function runElectronHeadless(args: string[]): Promise<number> {
   });
 }
 
-const DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS = 8_000;
+async function flushOutputStream(stream: NodeJS.WriteStream): Promise<void> {
+  await new Promise<void>((resolve) => {
+    stream.write('', () => resolve());
+  });
+}
+
+const DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS = 30_000;
 const POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS = 90_000;
 const POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 8_000;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
+const DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS = 60_000;
 type HeadlessOwnerInfo = { ownerId?: string; mode?: string };
 
 function isStandaloneOwner(owner: HeadlessOwnerInfo | null | undefined): owner is HeadlessOwnerInfo & { mode: 'standalone' } {
   return owner?.mode === 'standalone';
+}
+
+function standaloneOwnerBootstrapTimeoutMs(): number {
+  const raw = process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS;
 }
 
 export class SharedMutationOwnerTimeoutError extends Error {
@@ -216,7 +230,7 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
     if (bootstrapLock) {
       spawnDetachedStandaloneOwner(resolve(__dirname, '..', '..', '..'));
     }
-    const deadline = Date.now() + 20_000;
+    const deadline = Date.now() + standaloneOwnerBootstrapTimeoutMs();
     while (Date.now() < deadline) {
       const owner = await tryPingHeadlessOwner(bus, 500);
       if (isStandaloneOwner(owner)) return;
@@ -344,11 +358,19 @@ export async function runHeadlessClient(argv: string[]): Promise<number> {
 
 if (require.main === module) {
   runHeadlessClient(process.argv.slice(2))
-    .then((code) => {
-      process.exit(code);
+    .then(async (code) => {
+      await Promise.all([
+        flushOutputStream(process.stdout),
+        flushOutputStream(process.stderr),
+      ]);
+      process.exitCode = code;
     })
-    .catch((err) => {
+    .catch(async (err) => {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
+      await Promise.all([
+        flushOutputStream(process.stdout),
+        flushOutputStream(process.stderr),
+      ]);
+      process.exitCode = 1;
     });
 }

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -67,8 +67,10 @@ export async function tryPingHeadlessOwner(
   timeoutMs = 1_000,
 ): Promise<{ ownerId?: string; mode?: string } | null> {
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
-    setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle = setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle.unref?.();
   });
 
   try {
@@ -83,6 +85,8 @@ export async function tryPingHeadlessOwner(
       return null;
     }
     throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 }
 
@@ -100,8 +104,10 @@ export async function tryDelegateQuery(
   timeoutMs = 5_000,
 ): Promise<Record<string, unknown> | null> {
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
-    setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle = setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle.unref?.();
   });
 
   try {
@@ -116,6 +122,8 @@ export async function tryDelegateQuery(
       return null;
     }
     throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 }
 
@@ -127,8 +135,10 @@ async function tryDelegate(
 ): Promise<boolean> {
   let targetWorkflowId: string | undefined;
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
-    setTimeout(() => reject(DELEGATION_TIMEOUT), options.timeoutMs ?? 5_000);
+    timeoutHandle = setTimeout(() => reject(DELEGATION_TIMEOUT), options.timeoutMs ?? 5_000);
+    timeoutHandle.unref?.();
   });
 
   let response: { workflowId: string; tasks: TaskState[] } | { ok: true };
@@ -145,6 +155,8 @@ async function tryDelegate(
       return false;
     }
     throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
   if ('workflowId' in response) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -860,12 +860,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.run', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { planPath } = req as { planPath: string };
-          await runHeadless(['run', planPath], {
-            ...headlessDeps,
-            waitForApproval: false,
-            noTrack: true,
-          });
-          return { ok: true };
+          return executeHeadlessRun({ planPath });
         });
         messageBus.onRequest('headless.owner-ping', async () => {
           noteStandaloneOwnerActivity();
@@ -895,12 +890,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId } = req as { workflowId: string };
-          await runHeadless(['resume', workflowId], {
-            ...headlessDeps,
-            waitForApproval: false,
-            noTrack: true,
-          });
-          return { ok: true };
+          return executeHeadlessResume({ workflowId });
         });
         messageBus.onRequest('headless.exec', async (req: unknown) => {
           noteStandaloneOwnerActivity();

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -338,17 +338,96 @@ branch refs/heads/experiment/test-task-oldhash
         ].join('\n');
       }
       if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (phase === 'cleanup_worktree') {
+        cleanupScript = script;
+        return '';
+      }
       if (script.includes('worktree list --porcelain')) {
         return `worktree ${ownerPath}
 HEAD deadbeef
 branch refs/heads/${targetBranch}
 `;
       }
+      if (script.includes('rev-parse --abbrev-ref HEAD')) return 'not-the-target-branch\n';
+      return '';
+    });
+
+    const setupTaskBranchSpy = vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any) => handle,
+    );
+
+    const req = makeRequest({
+      actionType: 'command',
+      actionId: 'test-task-conflict',
+      inputs: {
+        command: 'pnpm test',
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    });
+
+    try {
+      await ssh.start(req);
+
+      const encodedPaths = cleanupScript.match(/WORKTREES_B64="([^"]+)"/)?.[1];
+      const decodedPaths = Buffer.from(encodedPaths ?? '', 'base64').toString('utf8');
+      expect(decodedPaths).toContain(ownerPath);
+      expect(setupTaskBranchSpy).toHaveBeenCalled();
+    } finally {
+      if (prevCleanup === undefined) {
+        delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+      } else {
+        process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = prevCleanup;
+      }
+    }
+  });
+
+  it('cleans up a stale exact-branch owner when HEAD probing fails even with cleanup disabled', async () => {
+    const prevCleanup = process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+    delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+    }) as any;
+
+    const repoHash = computeRepoUrlHash('git@github.com:owner/repo.git');
+    const baseHead = 'abc123def456abc123def456abc123def456abc1';
+    const branchHash = computeContentHash(
+      'test-task-conflict',
+      'pnpm test',
+      undefined,
+      [],
+      baseHead,
+    );
+    const targetBranch = buildExperimentBranchName('test-task-conflict', '', branchHash);
+    const ownerPath = `/home/testuser/.invoker/worktrees/${repoHash}/stale-owner-${branchHash}`;
+    let cleanupScript = '';
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string, phase?: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return [
+          '__INVOKER_BASE_REF__=origin/main',
+          `__INVOKER_BASE_HEAD__=${baseHead}`,
+        ].join('\n');
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
       if (phase === 'cleanup_worktree') {
         cleanupScript = script;
         return '';
       }
-      if (script.includes('rev-parse --abbrev-ref HEAD')) return 'not-the-target-branch\n';
+      if (script.includes('worktree list --porcelain')) {
+        return `worktree ${ownerPath}
+HEAD deadbeef
+branch refs/heads/${targetBranch}
+`;
+      }
+      if (script.includes('rev-parse --abbrev-ref HEAD')) {
+        throw createSshRemoteScriptError(1, '', `bash: line 1: cd: ${ownerPath}: No such file or directory\n`);
+      }
       return '';
     });
 

--- a/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
@@ -74,6 +74,41 @@ describe('SSH worktree metadata repro', () => {
     }).toThrow(new RegExp(`already used by worktree at '${realOldPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
   });
 
+  it('reproduces a same-branch relaunch failure when the worktree dir is deleted without clearing git admin state', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-worktree-race-repro-'));
+    tempRoots.push(root);
+
+    const repoDir = join(root, 'repo');
+    const worktreePath = join(root, 'experiment-wf-1-run-app-retry-tests-g0.t5.aaaa-12345678');
+    const branch = 'experiment/wf-1/run-app-retry-tests/g0.t5.aaaa-12345678';
+
+    execSync(`mkdir -p ${JSON.stringify(repoDir)}`);
+    git('git init -b master', repoDir);
+    git('git config user.email "test@example.com"', repoDir);
+    git('git config user.name "Test User"', repoDir);
+    writeFileSync(join(repoDir, 'README.md'), 'seed\n');
+    git('git add README.md', repoDir);
+    git('git commit -m "seed"', repoDir);
+
+    // First launch claims the branch and creates the worktree.
+    git(`git worktree add -B ${JSON.stringify(branch)} ${JSON.stringify(worktreePath)} master`, repoDir);
+    expect(existsSync(worktreePath)).toBe(true);
+
+    // Raw directory deletion leaves git's worktree admin entry behind.
+    rmSync(worktreePath, { recursive: true, force: true });
+    expect(existsSync(worktreePath)).toBe(false);
+
+    const porcelain = git('git worktree list --porcelain', repoDir);
+    expect(porcelain).toContain(`branch refs/heads/${branch}`);
+    expect(porcelain).toContain(`worktree ${worktreePath}`);
+
+    // Second launch of the same task/branch now collides with the stale admin
+    // registration, even though the filesystem path is gone.
+    expect(() => {
+      git(`git worktree add -B ${JSON.stringify(branch)} ${JSON.stringify(worktreePath)} master`, repoDir);
+    }).toThrow(new RegExp(`already used by worktree at '${worktreePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
+  });
+
   it('proves TaskRunner should persist the owning worktree path on SSH startup failure', async () => {
     const ownerPath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-bc7a0b71';
     const branch = 'experiment/wf-1/test-execution-engine-b68b146f';

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -373,7 +373,13 @@ echo ${payloadB64} | base64 -d | bash -se
           headMatchesTargetBranch: abbrevRefMatchesBranch(head, experimentBranch),
         };
       } catch {
-        exactBranchCandidate = undefined;
+        // If the branch still appears in `git worktree list --porcelain` but we
+        // cannot read its HEAD, treat it as a stale owner that must be cleaned
+        // up before recreating the canonical branch/worktree pair.
+        exactBranchCandidate = {
+          path: reuseAbs,
+          headMatchesTargetBranch: false,
+        };
       }
     }
 
@@ -397,11 +403,10 @@ echo ${payloadB64} | base64 -d | bash -se
       case 'rename_reuse':
         throw new Error('SSH managed workspaces do not support same-task different-branch rename reuse');
       case 'recreate': {
-        // Workspace cleanup is gated by INVOKER_ENABLE_WORKSPACE_CLEANUP. With
-        // attemptId mixed into the branch hash, the canonical worktree path
-        // for the new attempt has never existed, so cleanup is unnecessary
-        // for correctness. Re-enable the env flag if you need disk hygiene.
-        if (isWorkspaceCleanupEnabled()) {
+        // General workspace cleanup remains opt-in for disk hygiene, but exact
+        // branch-owner collisions must always be reconciled for correctness.
+        const needsOwnerCleanup = !!exactBranchCandidate;
+        if (isWorkspaceCleanupEnabled() || needsOwnerCleanup) {
           const cleanupScript = buildWorktreeCleanupScript({
             remoteClone,
             worktreePaths: worktreePlan.cleanupPaths,

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -257,12 +257,12 @@ while IFS= read -r WT; do
   [ -z "$WT" ] && continue
   ${bashNormalizeTildePath('WT')}
   mkdir -p "$(dirname "$WT")"
-  if [ -e "$WT" ]; then
+  if git -C "$CLONE" worktree list --porcelain | grep -Fq "worktree $WT"; then
     echo "[SshGitExec] Removing stale worktree path: $WT"
     git -C "$CLONE" worktree remove --force "$WT" 2>/dev/null || true
-    rm -rf "$WT"
     git -C "$CLONE" worktree prune 2>/dev/null || true
   fi
+  rm -rf "$WT"
 done < <(echo "$WORKTREES_B64" | base64 -d)
 `;
 }


### PR DESCRIPTION
## Summary

Fix SSH managed workspace startup when Git still registers the target branch as owned by a stale worktree.

This change closes the failure mode behind `wf-1777324024407-4/run-app-retry-tests`: the executor could detect that the target branch was already owned, but if probing the owning worktree’s `HEAD` failed, it dropped that owner from planning and skipped the cleanup needed to clear Git’s stale worktree registration. The next `git worktree add -B ...` then failed with `cannot force update the branch ... used by worktree at ...`.

The fix does two things:
1. Treat an exact-branch owner with unreadable `HEAD` as stale ownership that must be reconciled before recreate.
2. Make SSH worktree cleanup clear registered Git worktrees even when the worktree directory has already been deleted from disk.

Regression coverage includes both the executor path and an in-repo repro for stale Git worktree admin state.

## Architecture

### Before

```mermaid
graph TD
    A[SSH startup] --> B[List managed worktrees]
    B --> C[Find exact branch owner]
    C --> D[Probe owner HEAD]
    D -->|HEAD readable and matches| E[Reuse existing worktree]
    D -->|HEAD readable and differs| F[Plan recreate and cleanup]
    D -->|HEAD probe fails| G[Drop owner candidate]
    G --> H[Skip cleanup when workspace cleanup is disabled]
    H --> I[setupTaskBranch runs git worktree add -B]
    I --> J[Git rejects branch as already used by worktree]
```

### After

```mermaid
graph TD
    A[SSH startup] --> B[List managed worktrees]
    B --> C[Find exact branch owner]
    C --> D[Probe owner HEAD]
    D -->|HEAD readable and matches| E[Reuse existing worktree]
    D -->|HEAD readable and differs| F[Plan recreate with cleanup]
    D -->|HEAD probe fails| G[Treat owner as stale exact-branch owner]
    G --> H[Force cleanup for correctness]
    F --> H
    H --> I[Cleanup removes registered worktree entry and prunes metadata]
    I --> J[setupTaskBranch recreates branch/worktree cleanly]
```

## Test Plan

- [x] `pnpm -C packages/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts`
- [x] `pnpm -C packages/execution-engine exec vitest run src/__tests__/ssh-worktree-metadata-repro.test.ts src/__tests__/managed-worktree-controller.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert cbca3f83`
- Post-revert steps: None
- Data migration? No
