### PR TITLE
Use make-pr skill and lookup-based delegation resolution

### DIFF
--- a/docs/persistence-architecture-single-writer.md
+++ b/docs/persistence-architecture-single-writer.md
@@ -49,10 +49,10 @@ This table lists every mutating command path and how the owner-boundary contract
 | **Headless Commands** (delegate when GUI present, standalone otherwise) |
 | `run` | headless.ts:565 | **Yes** (line 356) | `tryDelegateRun()` → IPC `headless.run` (owner handles) OR standalone opens writable via `initServices({ readOnly: false })` | Delegation timeout = 5s |
 | `resume` | headless.ts:620 | **Yes** (line 361) | `tryDelegateResume()` → IPC `headless.resume` OR standalone writable | |
-| `restart` | headless.ts:707 | **Yes** (line 365) | `tryDelegateExec()` → IPC `headless.exec` OR standalone writable | |
+| `restart` | headless.ts:707 | **Yes** (line 365) | `tryDelegateExec()` → IPC `headless.exec` OR standalone writable | Workflow-scoped `restart wf-…` delegates with a 60s timeout; task-scoped restart stays at 5s |
 | `recreate` | headless.ts:769 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
 | `recreate-task` | headless.ts:788 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `rebase` | headless.ts:754 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
+| `rebase` | headless.ts:754 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | Workflow-scoped `rebase wf-…` and deprecated `rebase-and-retry wf-…` delegates use a 60s timeout; task-scoped rebase stays at 5s |
 | `approve` | headless.ts:666 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
 | `reject` | headless.ts:681 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
 | `input` | headless.ts:688 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
@@ -94,7 +94,7 @@ This table lists every mutating command path and how the owner-boundary contract
 | Component | File | Line(s) | Enforcement Mechanism |
 |-----------|------|---------|----------------------|
 | **GUI main process** | packages/app/src/main.ts | 605-613 | `initServices()` opens writable DB (no `readOnly` flag) |
-| **Headless delegation** | packages/app/src/main.ts | 346-381 | `tryDelegateRun()`, `tryDelegateResume()`, `tryDelegateExec()` send IPC request to owner; 5s timeout → standalone fallback |
+| **Headless delegation** | packages/app/src/main.ts, packages/app/src/headless-delegation.ts | 346-381, 14-65 | `tryDelegateRun()`, `tryDelegateResume()`, `tryDelegateExec()` send IPC request to owner; `run`, `resume`, and default `exec` delegation use 5s timeout, while workflow-scoped `rebase` / `rebase-and-retry` / `restart` use 60s before standalone fallback |
 | **Headless standalone** | packages/app/src/main.ts | 386 | `initServices({ readOnly: isHeadlessReadOnlyCommand(cliArgs) })` — read-only for query commands, writable for standalone mutating commands (when `INVOKER_HEADLESS_STANDALONE=1` or no GUI) |
 | **SQLiteAdapter read-only gate** | packages/persistence/src/sqlite-adapter.ts | 113-117 | `ensureWritable()` throws if `readOnly: true` and a write is attempted |
 | **Delegation handlers (owner)** | packages/app/src/main.ts | 618-674 | `headless.run`, `headless.resume`, `headless.exec` IPC handlers receive delegated commands, execute via owner's writable orchestrator/persistence |
@@ -102,10 +102,10 @@ This table lists every mutating command path and how the owner-boundary contract
 ### Critical Guarantees
 
 1. **GUI always owns DB**: When GUI is running, `initServices()` (main.ts:605) opens writable persistence. All IPC handlers mutate via this owner instance.
-2. **Headless delegates by default**: When GUI is present, headless commands try delegation (5s timeout). Only if delegation fails (no GUI) does headless open its own writable DB.
+2. **Headless delegates by default**: When GUI is present, headless commands try delegation first. `run`, `resume`, and most `headless.exec` commands use a 5s timeout; workflow-scoped `rebase`, `rebase-and-retry`, and `restart` use 60s. Only if delegation fails (no GUI or timeout) does headless open its own writable DB.
 3. **Read-only commands never delegate**: `query` subcommands always open `readOnly: true` persistence (main.ts:386), never write.
 4. **Standalone escape hatch**: `INVOKER_HEADLESS_STANDALONE=1` skips delegation, allowing headless to own the DB (main.ts:348-349).
-5. **Delegation timeout prevents deadlock**: 5s IPC timeout (headless.ts:1145, 1219) ensures headless doesn't hang if GUI is unresponsive.
+5. **Delegation timeout prevents deadlock**: IPC delegation is bounded so headless does not hang if GUI is unresponsive. The default is 5s, with a 60s allowance for workflow-scoped `rebase`, `rebase-and-retry`, and `restart` command shapes in `headless.exec`.
 
 ### Test Coverage
 

--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -1,7 +1,24 @@
 import { describe, expect, it } from 'vitest';
-import { isHeadlessMutatingCommand, isHeadlessReadOnlyCommand } from '../headless-command-classification.js';
+import {
+  isHeadlessMutatingCommand,
+  isHeadlessReadOnlyCommand,
+  resolveHeadlessTarget,
+  resolveHeadlessTargetWorkflowId,
+  type HeadlessTargetLookup,
+} from '../headless-command-classification.js';
 
 describe('headless-command-classification', () => {
+  const targetLookup: HeadlessTargetLookup = {
+    loadWorkflow: (workflowId) => workflowId === 'wf-1' ? { id: workflowId } as any : undefined,
+    listWorkflows: () => [{ id: 'wf-1' } as any, { id: 'wf-2' } as any],
+    loadTasks: (workflowId) => {
+      if (workflowId === 'wf-2') {
+        return [{ id: 'wf-2/task-1' }] as any;
+      }
+      return [];
+    },
+  };
+
   it('classifies read-only commands', () => {
     expect(isHeadlessReadOnlyCommand([])).toBe(true);
     expect(isHeadlessReadOnlyCommand(['query'])).toBe(true);
@@ -22,5 +39,24 @@ describe('headless-command-classification', () => {
     expect(isHeadlessMutatingCommand(['cancel-workflow'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'agent'])).toBe(true);
     expect(isHeadlessMutatingCommand(['set', 'unknown'])).toBe(false);
+  });
+
+  it('resolves workflow and task targets via lookup', () => {
+    expect(resolveHeadlessTarget('wf-1', targetLookup)).toEqual({
+      kind: 'workflow',
+      workflowId: 'wf-1',
+    });
+    expect(resolveHeadlessTarget('wf-2/task-1', targetLookup)).toEqual({
+      kind: 'task',
+      workflowId: 'wf-2',
+      taskId: 'wf-2/task-1',
+      resolvedTaskId: 'wf-2/task-1',
+    });
+  });
+
+  it('throws when target workflow cannot be resolved', () => {
+    expect(() => resolveHeadlessTargetWorkflowId('missing-target', targetLookup)).toThrow(
+      'Could not resolve headless target workflow for "missing-target"',
+    );
   });
 });

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { delegationTimeoutMs, tryDelegateExec, tryDelegateRun, tryDelegateResume } from '../headless.js';
 import { LocalBus } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
@@ -16,6 +16,31 @@ describe('headless→owner delegation', () => {
   beforeEach(() => {
     messageBus = new LocalBus();
   });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  function trackPromise<T>(promise: Promise<T>) {
+    const state: {
+      settled: boolean;
+      value?: T;
+      error?: unknown;
+    } = { settled: false };
+
+    promise.then(
+      (value) => {
+        state.settled = true;
+        state.value = value;
+      },
+      (error) => {
+        state.settled = true;
+        state.error = error;
+      },
+    );
+
+    return state;
+  }
 
   describe('delegation timeout policy', () => {
     it('uses 60s timeout for workflow-scoped rebase', () => {
@@ -175,16 +200,57 @@ describe('headless→owner delegation', () => {
     });
 
     it('returns false when delegation times out (owner unresponsive)', async () => {
-      // Register handler that hangs (never resolves)
-      messageBus.onRequest('headless.exec', async () => {
-        return new Promise(() => {}); // Never resolves
-      });
+      vi.useFakeTimers();
+      messageBus.onRequest('headless.exec', async () => new Promise(() => {}));
 
-      // Should timeout and return false.
-      const delegated = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus, undefined, undefined, 25);
+      const delegatedPromise = tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      const tracked = trackPromise(delegatedPromise);
 
-      expect(delegated).toBe(false);
-    }, 5_000);
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(tracked.settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(delegatedPromise).resolves.toBe(false);
+    });
+  });
+
+  describe('tryDelegateExec applies command-aware timeout selection deterministically', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+      messageBus.onRequest('headless.exec', async () => new Promise(() => {}));
+    });
+
+    it.each([
+      ['rebase', ['rebase', 'wf-1']],
+      ['rebase-and-retry', ['rebase-and-retry', 'wf-1']],
+      ['restart workflow', ['restart', 'wf-123']],
+    ])('keeps %s pending at 5s and only times out at 60s', async (_label, args) => {
+      const delegatedPromise = tryDelegateExec(args, messageBus);
+      const tracked = trackPromise(delegatedPromise);
+
+      await vi.advanceTimersByTimeAsync(5_000);
+      expect(tracked.settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(54_999);
+      expect(tracked.settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(delegatedPromise).resolves.toBe(false);
+    });
+
+    it.each([
+      ['restart task', ['restart', 'wf-123/task-1']],
+      ['approve', ['approve', 'wf-123/task-1']],
+    ])('times out at the default 5s for %s', async (_label, args) => {
+      const delegatedPromise = tryDelegateExec(args, messageBus);
+      const tracked = trackPromise(delegatedPromise);
+
+      await vi.advanceTimersByTimeAsync(4_999);
+      expect(tracked.settled).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(1);
+      await expect(delegatedPromise).resolves.toBe(false);
+    });
   });
 
   describe('error propagation from owner', () => {

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { delegationTimeoutMs, tryDelegateExec, tryDelegateRun, tryDelegateResume } from '../headless.js';
 import { LocalBus } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
+import type { HeadlessTargetLookup } from '../headless-command-classification.js';
 
 /**
  * Regression tests for headless→owner RPC delegation.
@@ -12,9 +13,24 @@ import type { MessageBus } from '@invoker/transport';
  */
 describe('headless→owner delegation', () => {
   let messageBus: MessageBus;
+  let targetLookup: HeadlessTargetLookup;
 
   beforeEach(() => {
     messageBus = new LocalBus();
+    targetLookup = {
+      loadWorkflow: (workflowId) => (
+        workflowId === 'wf-1' || workflowId === 'wf-123'
+          ? { id: workflowId } as any
+          : undefined
+      ),
+      listWorkflows: () => [{ id: 'wf-1' } as any, { id: 'wf-123' } as any],
+      loadTasks: (workflowId) => {
+        if (workflowId === 'wf-123') {
+          return [{ id: 'wf-123/task-1' }] as any;
+        }
+        return [];
+      },
+    };
   });
 
   afterEach(() => {
@@ -44,27 +60,27 @@ describe('headless→owner delegation', () => {
 
   describe('delegation timeout policy', () => {
     it('uses 60s timeout for workflow-scoped rebase', () => {
-      expect(delegationTimeoutMs(['rebase', 'wf-1'])).toBe(60_000);
+      expect(delegationTimeoutMs(['rebase', 'wf-1'], targetLookup)).toBe(60_000);
     });
 
     it('uses 60s timeout for workflow-scoped rebase-and-retry', () => {
-      expect(delegationTimeoutMs(['rebase-and-retry', 'wf-1'])).toBe(60_000);
+      expect(delegationTimeoutMs(['rebase-and-retry', 'wf-1'], targetLookup)).toBe(60_000);
     });
 
     it('uses 60s timeout for workflow-scoped restart', () => {
-      expect(delegationTimeoutMs(['restart', 'wf-123'])).toBe(60_000);
+      expect(delegationTimeoutMs(['restart', 'wf-123'], targetLookup)).toBe(60_000);
     });
 
     it('keeps task-scoped rebase at the default timeout', () => {
-      expect(delegationTimeoutMs(['rebase', 'wf-123/task-1'])).toBe(5_000);
+      expect(delegationTimeoutMs(['rebase', 'wf-123/task-1'], targetLookup)).toBe(5_000);
     });
 
     it('keeps non-matching workflow ids at the default timeout', () => {
-      expect(delegationTimeoutMs(['restart', 'not-a-workflow-id'])).toBe(5_000);
+      expect(delegationTimeoutMs(['restart', 'not-a-workflow-id'], targetLookup)).toBe(5_000);
     });
 
     it('keeps unrelated commands at the default timeout', () => {
-      expect(delegationTimeoutMs(['approve', 'wf-123/task-1'])).toBe(5_000);
+      expect(delegationTimeoutMs(['approve', 'wf-123/task-1'], targetLookup)).toBe(5_000);
     });
   });
 
@@ -225,7 +241,13 @@ describe('headless→owner delegation', () => {
       ['rebase-and-retry', ['rebase-and-retry', 'wf-1']],
       ['restart workflow', ['restart', 'wf-123']],
     ])('keeps %s pending at 5s and only times out at 60s', async (_label, args) => {
-      const delegatedPromise = tryDelegateExec(args, messageBus);
+      const delegatedPromise = tryDelegateExec(
+        args,
+        messageBus,
+        undefined,
+        undefined,
+        delegationTimeoutMs(args, targetLookup),
+      );
       const tracked = trackPromise(delegatedPromise);
 
       await vi.advanceTimersByTimeAsync(5_000);
@@ -242,7 +264,13 @@ describe('headless→owner delegation', () => {
       ['restart task', ['restart', 'wf-123/task-1']],
       ['approve', ['approve', 'wf-123/task-1']],
     ])('times out at the default 5s for %s', async (_label, args) => {
-      const delegatedPromise = tryDelegateExec(args, messageBus);
+      const delegatedPromise = tryDelegateExec(
+        args,
+        messageBus,
+        undefined,
+        undefined,
+        delegationTimeoutMs(args, targetLookup),
+      );
       const tracked = trackPromise(delegatedPromise);
 
       await vi.advanceTimersByTimeAsync(4_999);

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -18,24 +18,28 @@ describe('headless→owner delegation', () => {
   });
 
   describe('delegation timeout policy', () => {
-    it('uses extended timeout for rebase', () => {
-      expect(delegationTimeoutMs(['rebase', 'wf-1/task-1'])).toBe(900_000);
+    it('uses 60s timeout for workflow-scoped rebase', () => {
+      expect(delegationTimeoutMs(['rebase', 'wf-1'])).toBe(60_000);
     });
 
-    it('uses extended timeout for rebase-and-retry', () => {
-      expect(delegationTimeoutMs(['rebase-and-retry', 'wf-1/task-1'])).toBe(900_000);
+    it('uses 60s timeout for workflow-scoped rebase-and-retry', () => {
+      expect(delegationTimeoutMs(['rebase-and-retry', 'wf-1'])).toBe(60_000);
     });
 
-    it('uses extended timeout for retry at workflow scope', () => {
-      expect(delegationTimeoutMs(['retry', 'wf-123'])).toBe(900_000);
+    it('uses 60s timeout for workflow-scoped restart', () => {
+      expect(delegationTimeoutMs(['restart', 'wf-123'])).toBe(60_000);
     });
 
-    it('treats task-scoped retry as long-running maintenance too', () => {
-      expect(delegationTimeoutMs(['retry-task', 'wf-123/task-1'])).toBe(900_000);
+    it('keeps task-scoped rebase at the default timeout', () => {
+      expect(delegationTimeoutMs(['rebase', 'wf-123/task-1'])).toBe(5_000);
     });
 
-    it('uses the extended timeout for tracked mutation commands', () => {
-      expect(delegationTimeoutMs(['approve', 'wf-123/task-1'])).toBe(900_000);
+    it('keeps non-matching workflow ids at the default timeout', () => {
+      expect(delegationTimeoutMs(['restart', 'not-a-workflow-id'])).toBe(5_000);
+    });
+
+    it('keeps unrelated commands at the default timeout', () => {
+      expect(delegationTimeoutMs(['approve', 'wf-123/task-1'])).toBe(5_000);
     });
   });
 

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -7,7 +7,7 @@ import type { MessageBus } from '@invoker/transport';
 import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { isHeadlessMutatingCommand } from './headless-command-classification.js';
 import {
-  delegationTimeoutMs,
+  resolveDelegationTimeoutMs,
   tryDelegateExec,
   tryDelegateQuery,
   tryDelegateQueryUiPerf,
@@ -97,7 +97,7 @@ async function delegateMutation(
     if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
     return tryDelegateResume(workflowId, bus, waitForApproval, noTrack);
   }
-  const timeoutMs = noTrack ? noTrackTimeoutMs : delegationTimeoutMs(args);
+  const timeoutMs = noTrack ? noTrackTimeoutMs : await resolveDelegationTimeoutMs(args);
   return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
 }
 

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -6,6 +6,69 @@
  * - tests/policy checks to keep command routing behavior consistent
  */
 
+import type { PersistenceAdapter } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+export type HeadlessTargetLookup = Pick<PersistenceAdapter, 'loadWorkflow' | 'listWorkflows' | 'loadTasks'>;
+
+export type HeadlessTargetResolution =
+  | { kind: 'workflow'; workflowId: string }
+  | { kind: 'task'; workflowId: string; taskId: string; resolvedTaskId: string }
+  | { kind: 'unknown'; target: string };
+
+function findStoredTaskByTarget(
+  lookup: HeadlessTargetLookup,
+  target: string,
+): { workflowId: string; task: TaskState } | null {
+  for (const workflow of lookup.listWorkflows()) {
+    const task = lookup.loadTasks(workflow.id).find((candidate) => (
+      candidate.id === target || candidate.id.endsWith(`/${target}`)
+    ));
+    if (task) {
+      return { workflowId: workflow.id, task };
+    }
+  }
+  return null;
+}
+
+export function resolveHeadlessTarget(
+  targetArg: unknown,
+  lookup: HeadlessTargetLookup,
+): HeadlessTargetResolution {
+  const target = String(targetArg ?? '');
+  if (!target) {
+    return { kind: 'unknown', target: '' };
+  }
+
+  const workflow = lookup.loadWorkflow(target);
+  if (workflow) {
+    return { kind: 'workflow', workflowId: workflow.id };
+  }
+
+  const storedTask = findStoredTaskByTarget(lookup, target);
+  if (storedTask) {
+    return {
+      kind: 'task',
+      workflowId: storedTask.workflowId,
+      taskId: target,
+      resolvedTaskId: storedTask.task.id,
+    };
+  }
+
+  return { kind: 'unknown', target };
+}
+
+export function resolveHeadlessTargetWorkflowId(
+  targetArg: unknown,
+  lookup: HeadlessTargetLookup,
+): string | undefined {
+  const resolved = resolveHeadlessTarget(targetArg, lookup);
+  if (resolved.kind === 'workflow' || resolved.kind === 'task') {
+    return resolved.workflowId;
+  }
+  return undefined;
+}
+
 export function isHeadlessReadOnlyCommand(args: string[]): boolean {
   const command = args[0];
   if (!command || command === '--help' || command === '-h') return true;

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -61,12 +61,13 @@ export function resolveHeadlessTarget(
 export function resolveHeadlessTargetWorkflowId(
   targetArg: unknown,
   lookup: HeadlessTargetLookup,
-): string | undefined {
+): string {
   const resolved = resolveHeadlessTarget(targetArg, lookup);
   if (resolved.kind === 'workflow' || resolved.kind === 'task') {
     return resolved.workflowId;
   }
-  return undefined;
+  const renderedTarget = resolved.target || String(targetArg ?? '');
+  throw new Error(`Could not resolve headless target workflow for "${renderedTarget}"`);
 }
 
 export function isHeadlessReadOnlyCommand(args: string[]): boolean {

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -1,8 +1,14 @@
-import { resolve as resolvePath } from 'node:path';
+import { resolve as resolvePath, join as joinPath } from 'node:path';
 
+import { SQLiteAdapter } from '@invoker/data-store';
 import type { MessageBus } from '@invoker/transport';
 import type { TaskState } from '@invoker/workflow-core';
 
+import {
+  resolveHeadlessTarget,
+  type HeadlessTargetLookup,
+} from './headless-command-classification.js';
+import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { createDelegatedTaskFeed, trackWorkflow } from './headless-watch.js';
 
 type DelegateTrackingOptions = {
@@ -39,16 +45,34 @@ export async function tryDelegateResume(
   );
 }
 
-export function delegationTimeoutMs(args: string[]): number {
+function usesExtendedDelegationTimeout(command: string): boolean {
+  return command === 'rebase' || command === 'rebase-and-retry' || command === 'restart';
+}
+
+export function delegationTimeoutMs(
+  args: string[],
+  targetLookup: HeadlessTargetLookup,
+): number {
   const command = args[0] ?? '';
-  const target = args[1] ?? '';
-  if (
-    (command === 'rebase' || command === 'rebase-and-retry' || command === 'restart')
-    && /^wf-[^/]+$/.test(target)
-  ) {
+  if (!usesExtendedDelegationTimeout(command)) {
+    return 5_000;
+  }
+
+  const resolvedTarget = resolveHeadlessTarget(args[1], targetLookup);
+  if (resolvedTarget.kind === 'workflow') {
     return 60_000;
   }
   return 5_000;
+}
+
+export async function resolveDelegationTimeoutMs(args: string[]): Promise<number> {
+  const dbPath = joinPath(resolveInvokerHomeRoot(), 'invoker.db');
+  const targetLookup = await SQLiteAdapter.create(dbPath, { readOnly: true });
+  try {
+    return delegationTimeoutMs(args, targetLookup);
+  } finally {
+    targetLookup.close();
+  }
 }
 
 export async function tryDelegateExec(
@@ -56,13 +80,14 @@ export async function tryDelegateExec(
   messageBus: MessageBus,
   waitForApproval?: boolean,
   noTrack?: boolean,
-  timeoutMs: number = delegationTimeoutMs(args),
+  timeoutMs?: number,
 ): Promise<boolean> {
+  const resolvedTimeoutMs = timeoutMs ?? await resolveDelegationTimeoutMs(args);
   return tryDelegate(
     'headless.exec',
     { args, waitForApproval, noTrack },
     messageBus,
-    { waitForApproval, noTrack, timeoutMs },
+    { waitForApproval, noTrack, timeoutMs: resolvedTimeoutMs },
   );
 }
 

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -41,10 +41,14 @@ export async function tryDelegateResume(
 
 export function delegationTimeoutMs(args: string[]): number {
   const command = args[0] ?? '';
-  if (command) {
-    return 900_000;
+  const target = args[1] ?? '';
+  if (
+    (command === 'rebase' || command === 'rebase-and-retry' || command === 'restart')
+    && /^wf-[^/]+$/.test(target)
+  ) {
+    return 60_000;
   }
-  return 15_000;
+  return 5_000;
 }
 
 export async function tryDelegateExec(

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -44,6 +44,7 @@ import { openExternalTerminalForTask } from './open-terminal-for-task.js';
 import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
 import {
   delegationTimeoutMs,
+  resolveDelegationTimeoutMs,
   tryDelegateExec,
   tryDelegateQuery,
   tryDelegateResume,
@@ -56,6 +57,7 @@ import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
 export { bumpGenerationAndRecreate } from './workflow-actions.js';
 export {
   delegationTimeoutMs,
+  resolveDelegationTimeoutMs,
   tryDelegateExec,
   tryDelegateQuery,
   tryDelegateResume,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -85,7 +85,12 @@ import {
   createHourlySnapshot,
   resolveInvokerHomeRoot,
 } from './delete-all-snapshot.js';
-import { isHeadlessMutatingCommand, isHeadlessReadOnlyCommand } from './headless-command-classification.js';
+import {
+  isHeadlessMutatingCommand,
+  isHeadlessReadOnlyCommand,
+  resolveHeadlessTarget,
+  resolveHeadlessTargetWorkflowId,
+} from './headless-command-classification.js';
 import { backupPlan } from './plan-backup.js';
 // applyPlanDefinitionDefaults removed — parsePlan() applies defaults internally
 import { startApiServer, type ApiServer } from './api-server.js';
@@ -93,6 +98,7 @@ import {
   runHeadless,
   tryDelegateRun,
   tryDelegateResume,
+  resolveDelegationTimeoutMs,
   tryDelegateExec,
   tryDelegateQuery,
   resolveAgentSession,
@@ -600,7 +606,8 @@ if (isHeadless) {
           if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
           delegated = await tryDelegateResume(workflowId, delegationBus, waitForApproval, noTrack);
         } else {
-          delegated = await tryDelegateExec(cliArgs, delegationBus, waitForApproval, noTrack);
+          const timeoutMs = noTrack ? undefined : await resolveDelegationTimeoutMs(cliArgs);
+          delegated = await tryDelegateExec(cliArgs, delegationBus, waitForApproval, noTrack, timeoutMs);
         }
 
         if (delegated) {
@@ -813,10 +820,7 @@ if (isHeadless) {
           if (!command) return { priority: 'normal' };
 
           const standaloneWorkflowIdForTaskArg = (taskIdArg: unknown): string | undefined => {
-            const taskId = String(taskIdArg ?? '');
-            const scopedMatch = taskId.match(/^(wf-[^/]+)\//);
-            if (scopedMatch) return scopedMatch[1];
-            return orchestrator.getTask(taskId)?.config.workflowId;
+            return resolveHeadlessTargetWorkflowId(taskIdArg, persistence);
           };
 
           switch (command) {
@@ -1505,11 +1509,12 @@ if (isHeadless) {
     });
     const headlessCommand = String(payload.args[0] ?? '');
     const headlessTarget = String(payload.args[1] ?? '');
+    const resolvedHeadlessTarget = resolveHeadlessTarget(headlessTarget, persistence);
     if (
       (headlessCommand === 'recreate' || headlessCommand === 'retry')
-      && /^wf-[^/]+$/.test(headlessTarget)
+      && resolvedHeadlessTarget.kind === 'workflow'
     ) {
-      cancelDeferredWorkflowLaunch(headlessTarget, `headless.${headlessCommand}`);
+      cancelDeferredWorkflowLaunch(resolvedHeadlessTarget.workflowId, `headless.${headlessCommand}`);
     }
     await runHeadless(payload.args, {
       logger,
@@ -1613,10 +1618,7 @@ if (isHeadless) {
   }
 
   function workflowIdForTaskArg(taskIdArg: unknown): string | undefined {
-    const taskId = String(taskIdArg ?? '');
-    const scopedMatch = taskId.match(/^(wf-[^/]+)\//);
-    if (scopedMatch) return scopedMatch[1];
-    return orchestrator.getTask(taskId)?.config.workflowId;
+    return resolveHeadlessTargetWorkflowId(taskIdArg, persistence);
   }
 
   function classifyHeadlessExecMutation(payload: HeadlessExecMutationPayload): {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -819,14 +819,14 @@ if (isHeadless) {
           const [command, arg0] = payload.args;
           if (!command) return { priority: 'normal' };
 
-          const standaloneWorkflowIdForTaskArg = (taskIdArg: unknown): string | undefined => {
+          const standaloneWorkflowIdForTaskArg = (taskIdArg: unknown): string => {
             return resolveHeadlessTargetWorkflowId(taskIdArg, persistence);
           };
 
           switch (command) {
             case 'retry':
               return {
-                workflowId: standaloneWorkflowIdForTaskArg(arg0) ?? (arg0 === undefined ? undefined : String(arg0)),
+                workflowId: arg0 === undefined ? undefined : standaloneWorkflowIdForTaskArg(arg0),
                 priority: 'high',
               };
             case 'recreate':
@@ -1618,6 +1618,7 @@ if (isHeadless) {
   }
 
   function workflowIdForTaskArg(taskIdArg: unknown): string | undefined {
+    if (taskIdArg === undefined) return undefined;
     return resolveHeadlessTargetWorkflowId(taskIdArg, persistence);
   }
 
@@ -1630,7 +1631,7 @@ if (isHeadless) {
 
     switch (command) {
       case 'retry':
-        return { workflowId: workflowIdForTaskArg(arg0) ?? (arg0 === undefined ? undefined : String(arg0)), priority: 'high' };
+        return { workflowId: workflowIdForTaskArg(arg0), priority: 'high' };
       case 'recreate':
       case 'cancel-workflow':
         return { workflowId: arg0, priority: 'high' };

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -3067,6 +3067,11 @@ describe('TaskRunner', () => {
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body',
+        sessionId: 'sess-pr-1',
+        agentName: 'codex',
+      });
       (executor as any).execPr = vi.fn().mockResolvedValue('https://github.com/owner/repo/pull/55');
 
       const logSpy = vi.spyOn(console, 'log');
@@ -3074,7 +3079,13 @@ describe('TaskRunner', () => {
       await executor.approveMerge('wf-1');
 
       // Should push + create PR (with clone dir as cwd)
-      expect((executor as any).execPr).toHaveBeenCalledWith('master', 'plan/feature', 'Test Workflow', expect.any(String), '/tmp/mock-wt');
+      expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Test Workflow',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        cwd: '/tmp/mock-wt',
+      }));
+      expect((executor as any).execPr).toHaveBeenCalledWith('master', 'plan/feature', 'Test Workflow', '## Summary\n\nAuthored body', '/tmp/mock-wt');
 
       // Should persist the PR URL on the merge task
       expect(persistence.updateTask).toHaveBeenCalledWith(
@@ -3132,6 +3143,11 @@ describe('TaskRunner', () => {
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuto authored body',
+        sessionId: 'sess-pr-2',
+        agentName: 'codex',
+      });
       (executor as any).execPr = vi.fn().mockResolvedValue('https://github.com/owner/repo/pull/77');
 
       const mergeTask = makeTask({
@@ -3315,12 +3331,21 @@ describe('TaskRunner', () => {
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).buildMergeSummary = vi.fn().mockResolvedValue('## Summary\nApprove summary');
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nApprove authored body',
+        sessionId: 'sess-pr-3',
+        agentName: 'codex',
+      });
       (executor as any).execPr = vi.fn().mockResolvedValue('https://github.com/owner/repo/pull/88');
 
       await executor.approveMerge('wf-1');
 
+      expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Test Workflow',
+        workflowSummary: '## Summary\nApprove summary',
+      }));
       expect((executor as any).execPr).toHaveBeenCalledWith(
-        'master', 'plan/feature', 'Test Workflow', '## Summary\nApprove summary', '/tmp/mock-wt',
+        'master', 'plan/feature', 'Test Workflow', '## Summary\n\nApprove authored body', '/tmp/mock-wt',
       );
       expect(persistence.updateTask).toHaveBeenCalledWith(
         '__merge__wf-1',
@@ -3734,8 +3759,6 @@ describe('TaskRunner', () => {
       const result = await executor.buildMergeSummary('wf-1');
 
       expect(result).toContain('## Summary');
-      // Check that horizontal rule separator is NOT present
-      // (table header separator contains dashes but is different format)
       const lines = result.split('\n');
       const summaryIdx = lines.indexOf('## Summary');
       expect(lines[summaryIdx + 1]).toContain('Feature Workflow — 1 tasks completed');
@@ -4484,6 +4507,11 @@ describe('TaskRunner', () => {
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).runVisualProofCapture = vi.fn().mockResolvedValue('## Visual Proof\n| Before | After |');
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored consolidate body',
+        sessionId: 'sess-pr-5',
+        agentName: 'codex',
+      });
       (executor as any).execPr = vi.fn().mockResolvedValue('https://example.com/pr');
 
       await executor.consolidateAndMerge(
@@ -4532,6 +4560,11 @@ describe('TaskRunner', () => {
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).runVisualProofCapture = vi.fn().mockResolvedValue(undefined);
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored consolidate body',
+        sessionId: 'sess-pr-6',
+        agentName: 'codex',
+      });
       (executor as any).execPr = vi.fn().mockResolvedValue('https://example.com/pr');
 
       // Should not throw
@@ -5496,6 +5529,103 @@ describe('TaskRunner', () => {
       expect(createCall?.[createCall.indexOf('--head') + 1]).toBe('plan/experiment');
     });
 
+    it('authorPrBodyWithSkill uses the configured workflow agent when available', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const executor = new TaskRunner({
+          orchestrator: {
+            getTask: () => null,
+            getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-1', executionAgent: 'codex' } })],
+          } as any,
+          persistence: {} as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          executionAgentRegistry: {
+            getOrThrow: vi.fn().mockReturnValue({
+              name: 'codex',
+              stdinMode: 'ignore',
+              linuxTerminalTail: 'exec_bash',
+              buildCommand: () => ({
+                cmd: 'node',
+                args: ['-e', 'process.stdout.write("## Summary\\n\\nAuthored\\n\\n## Test Plan\\n\\n- [x] `pnpm test`\\n\\n## Revert Plan\\n\\n- Safe to revert? Yes\\n- Revert command: `git revert <sha>`\\n- Post-revert steps: None\\n- Data migration? No\\n")'],
+                sessionId: 'sess-pr-body',
+              }),
+              buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+            }),
+            getSessionDriver: vi.fn().mockReturnValue(undefined),
+          } as any,
+          cwd: '/tmp',
+        });
+
+        const result = await (executor as any).authorPrBodyWithSkill({
+          workflowId: 'wf-1',
+          title: 'Test Workflow',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: '## Summary\nSource summary',
+          cwd: '/tmp',
+        });
+
+        expect(result.agentName).toBe('codex');
+        expect(result.body).toContain('## Summary');
+        expect(result.body).toContain('## Test Plan');
+        expect(result.body).toContain('## Revert Plan');
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
+    it('authorPrBodyWithSkill fails closed when the authored body is invalid', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const executor = new TaskRunner({
+          orchestrator: {
+            getTask: () => null,
+            getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-1', executionAgent: 'codex' } })],
+          } as any,
+          persistence: {} as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          executionAgentRegistry: {
+            getOrThrow: vi.fn().mockReturnValue({
+              name: 'codex',
+              stdinMode: 'ignore',
+              linuxTerminalTail: 'exec_bash',
+              buildCommand: () => ({
+                cmd: 'node',
+                args: ['-e', 'process.stdout.write("## Summary\\n\\nOnly summary")'],
+                sessionId: 'sess-invalid-pr',
+              }),
+              buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+            }),
+            getSessionDriver: vi.fn().mockReturnValue(undefined),
+          } as any,
+          cwd: '/tmp',
+        });
+
+        await expect((executor as any).authorPrBodyWithSkill({
+          workflowId: 'wf-1',
+          title: 'Test Workflow',
+          baseBranch: 'master',
+          featureBranch: 'plan/feature',
+          workflowSummary: '## Summary\nSource summary',
+          cwd: '/tmp',
+        })).rejects.toThrow('PR body authored via invoker-make-pr is invalid');
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
     it('resolveConflict includes dep description in merge -m', async () => {
       const workspacePath = createTempWorkspace();
       const tasks = new Map<string, TaskState>();
@@ -5728,6 +5858,11 @@ describe('TaskRunner', () => {
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
       (executor as any).buildMergeSummary = vi.fn().mockResolvedValue('## Summary');
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nPublished body',
+        sessionId: 'sess-pr-4',
+        agentName: 'codex',
+      });
       (executor as any).execPr = vi.fn().mockResolvedValue('https://github.com/owner/repo/pull/100');
 
       return { executor, mergeTask, orchestrator, persistence, mergeGateProvider, gitCalls };
@@ -5816,7 +5951,12 @@ describe('TaskRunner', () => {
 
       await executor.publishAfterFix(mergeTask);
 
-      expect((executor as any).execPr).toHaveBeenCalledWith('master', 'plan/feature', 'Test Workflow', '## Summary', '/tmp/gate-clone');
+      expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Test Workflow',
+        workflowSummary: '## Summary',
+        cwd: '/tmp/gate-clone',
+      }));
+      expect((executor as any).execPr).toHaveBeenCalledWith('master', 'plan/feature', 'Test Workflow', '## Summary\n\nPublished body', '/tmp/gate-clone');
       expect(persistence.updateTask).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
         execution: expect.objectContaining({ reviewUrl: 'https://github.com/owner/repo/pull/100' }),
       }));

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -149,6 +149,15 @@ export interface MergeRunnerHost {
   removeMergeWorktree(dir: string): Promise<void>;
   execGh(args: string[], cwd?: string): Promise<string>;
   execPr(baseBranch: string, featureBranch: string, title: string, body?: string, cwd?: string): Promise<string>;
+  authorPrBodyWithSkill?(args: {
+    workflowId?: string;
+    mergeNodeTaskId?: string;
+    title: string;
+    baseBranch: string;
+    featureBranch: string;
+    workflowSummary: string;
+    cwd: string;
+  }): Promise<{ body: string; sessionId: string; agentName: string }>;
   detectDefaultBranch(): Promise<string>;
   gitLogMessage(commitHash: string, cwd?: string): Promise<string>;
   gitDiffStat(branch: string, cwd?: string): Promise<string>;
@@ -170,6 +179,28 @@ export interface MergeRunnerHost {
     baseCheckoutRef?: string,
     mergeNodeTaskId?: string,
   ): Promise<string | undefined>;
+}
+
+async function authorPrBodyForMerge(
+  host: MergeRunnerHost,
+  args: {
+    workflowId?: string;
+    mergeNodeTaskId?: string;
+    title: string;
+    baseBranch: string;
+    featureBranch: string;
+    workflowSummary: string;
+    cwd: string;
+  },
+): Promise<string> {
+  if (!host.authorPrBodyWithSkill) {
+    throw new Error('authorPrBodyWithSkill is required for merge PR authoring');
+  }
+  const authored = await host.authorPrBodyWithSkill(args);
+  console.log(
+    `[merge] Authored PR body via ${authored.agentName} skill session=${authored.sessionId}`,
+  );
+  return authored.body;
 }
 
 /**
@@ -613,7 +644,16 @@ export async function approveMergeImpl(
       mergeTrace('GIT_PUSH', { featureBranch, worktreeDir });
       // Push feature branch directly to origin (GitHub) from the clone
       await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
-      const reviewUrl = await host.execPr(baseBranch, featureBranch, mergeMessage, fullSummary, worktreeDir);
+      const prBody = await authorPrBodyForMerge(host, {
+        workflowId,
+        mergeNodeTaskId: mergeTaskId,
+        title: mergeMessage,
+        baseBranch,
+        featureBranch,
+        workflowSummary: fullSummary ?? '',
+        cwd: worktreeDir,
+      });
+      const reviewUrl = await host.execPr(baseBranch, featureBranch, mergeMessage, prBody, worktreeDir);
       mergeTrace('PR_CREATED', { featureBranch, baseBranch, reviewUrl });
       console.log(`[merge] Approved: created pull request ${reviewUrl}`);
       host.persistence.updateTask(mergeTaskId, {
@@ -899,7 +939,16 @@ export async function publishAfterFixImpl(
 
     // manual mode with pull_request onFinish
     if (onFinish === 'pull_request') {
-      const reviewUrl = await host.execPr(baseBranch, featureBranch, workflow?.name ?? 'Workflow', fullSummary, consolidateDir);
+      const prBody = await authorPrBodyForMerge(host, {
+        workflowId,
+        mergeNodeTaskId: task.id,
+        title: workflow?.name ?? 'Workflow',
+        baseBranch,
+        featureBranch,
+        workflowSummary: fullSummary ?? '',
+        cwd: consolidateDir,
+      });
+      const reviewUrl = await host.execPr(baseBranch, featureBranch, workflow?.name ?? 'Workflow', prBody, consolidateDir);
       console.log(`[merge] Post-fix: created pull request ${reviewUrl}`);
       host.persistence.updateTask(task.id, {
         config: { summary },
@@ -1217,7 +1266,16 @@ export async function consolidateAndMergeImpl(
     } else if (onFinish === 'pull_request') {
       // Push feature branch directly to origin (GitHub) from the clone
       await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
-      const reviewUrl = await host.execPr(baseBranch, featureBranch, workflowName ?? 'Workflow', body, worktreeDir);
+      const prBody = await authorPrBodyForMerge(host, {
+        workflowId,
+        mergeNodeTaskId,
+        title: workflowName ?? 'Workflow',
+        baseBranch,
+        featureBranch,
+        workflowSummary: body ?? '',
+        cwd: worktreeDir,
+      });
+      const reviewUrl = await host.execPr(baseBranch, featureBranch, workflowName ?? 'Workflow', prBody, worktreeDir);
       console.log(`[merge] Created pull request: ${reviewUrl}`);
       return reviewUrl;
     }

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -1,0 +1,182 @@
+import { spawn } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { homedir, tmpdir } from 'node:os';
+
+import type { ExecutionAgent } from './agent.js';
+import type { SessionDriver } from './session-driver.js';
+import { cleanElectronEnv } from './process-utils.js';
+
+const REQUIRED_SECTIONS = ['## Summary', '## Test Plan', '## Revert Plan'] as const;
+const DISCOURAGED_HEADINGS = ['## Testing', '## Notes'] as const;
+const DEFAULT_MAX_INLINE_PROMPT_BYTES = 64 * 1024;
+const MAX_INLINE_PROMPT_BYTES = (() => {
+  const raw = process.env.INVOKER_MAX_INLINE_AGENT_PROMPT_BYTES;
+  if (!raw) return DEFAULT_MAX_INLINE_PROMPT_BYTES;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_MAX_INLINE_PROMPT_BYTES;
+})();
+
+export function validateCanonicalPrBody(body: string): string[] {
+  const errors: string[] = [];
+  const trimmed = body.trim();
+
+  if (!trimmed) {
+    return [
+      'PR body is empty. Use the canonical schema: ## Summary, ## Test Plan, ## Revert Plan, plus optional ## Architecture.',
+    ];
+  }
+
+  for (const heading of REQUIRED_SECTIONS) {
+    if (!trimmed.includes(heading)) {
+      errors.push(`Missing required section: ${heading}`);
+    }
+  }
+
+  for (const heading of DISCOURAGED_HEADINGS) {
+    if (trimmed.includes(heading)) {
+      errors.push(
+        `Unsupported section: ${heading}. Do not use the lightweight PR format; use ## Test Plan and ## Revert Plan instead.`,
+      );
+    }
+  }
+
+  if (trimmed.includes('## Architecture')) {
+    for (const subsection of ['### Before', '### After']) {
+      if (!trimmed.includes(subsection)) {
+        errors.push(`Architecture section is missing required subsection: ${subsection}`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+function promptByteLength(prompt: string): number {
+  return Buffer.byteLength(prompt, 'utf8');
+}
+
+function buildPromptFileBootstrap(promptPath: string): string {
+  return [
+    `The full task instructions are in this file: ${promptPath}`,
+    'Read the file completely, then execute those instructions in this workspace.',
+    'Do not ask for the file contents.',
+  ].join('\n');
+}
+
+function materializeLocalPrompt(prompt: string): { effectivePrompt: string; cleanup: () => void } {
+  if (promptByteLength(prompt) <= MAX_INLINE_PROMPT_BYTES) {
+    return { effectivePrompt: prompt, cleanup: () => {} };
+  }
+  const dir = mkdtempSync(join(tmpdir(), 'invoker-pr-author-prompt-'));
+  const promptPath = join(dir, 'prompt.md');
+  writeFileSync(promptPath, prompt, 'utf8');
+  return {
+    effectivePrompt: buildPromptFileBootstrap(promptPath),
+    cleanup: () => {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {
+        /* best effort */
+      }
+    },
+  };
+}
+
+function extractAssistantBody(driver: SessionDriver | undefined, sessionId: string, fallback: string): string {
+  const rawSession = driver?.loadSession(sessionId);
+  if (rawSession && driver) {
+    const messages = driver.parseSession(rawSession);
+    for (let idx = messages.length - 1; idx >= 0; idx--) {
+      const message = messages[idx];
+      if (message?.role === 'assistant' && message.content.trim()) {
+        return message.content.trim();
+      }
+    }
+  }
+  return fallback.trim();
+}
+
+export function resolveInstalledSkillPathForAgent(agentName: string, skillName: string): string | null {
+  const normalized = agentName.trim().toLowerCase();
+  const home = homedir();
+  const skillDir = normalized === 'codex'
+    ? join(home, '.codex', 'skills', `invoker-${skillName}`)
+    : normalized === 'claude'
+      ? join(home, '.claude', 'skills', `invoker-${skillName}`)
+      : null;
+  if (!skillDir) return null;
+  return existsSync(join(skillDir, 'SKILL.md')) ? skillDir : null;
+}
+
+export function buildMakePrPrompt(args: {
+  skillPath: string;
+  title: string;
+  baseBranch: string;
+  featureBranch: string;
+  workflowSummary: string;
+}): string {
+  return [
+    `You are authoring the GitHub PR body for the branch "${args.featureBranch}" targeting "${args.baseBranch}".`,
+    '',
+    `Use the installed skill "invoker-make-pr" at: ${args.skillPath}`,
+    'Read that SKILL.md first and follow it exactly.',
+    '',
+    'Requirements:',
+    `- The PR title is already decided: "${args.title}"`,
+    '- Output only the final PR body markdown. Do not include commentary, explanations, or code fences.',
+    '- Use the repo-local PR conventions and tooling referenced by the skill.',
+    '- Only include `## Architecture` when the change modifies component interactions, control flow, state flow, or data flow.',
+    '- If the change is small and has no architectural impact, omit `## Architecture`.',
+    '- Ensure the final body satisfies the canonical schema required by this repo.',
+    '',
+    'You may inspect the working tree, git diff, `scripts/pr-body-template.md`, and `scripts/validate-pr-body.mjs` before writing.',
+    '',
+    'Merge workflow context:',
+    '```md',
+    args.workflowSummary.trim(),
+    '```',
+  ].join('\n');
+}
+
+export function spawnAgentPrAuthorViaRegistry(
+  prompt: string,
+  cwd: string,
+  agent: ExecutionAgent,
+  driver?: SessionDriver,
+): Promise<{ body: string; stdout: string; sessionId: string }> {
+  const promptTransport = materializeLocalPrompt(prompt);
+  const spec = agent.buildCommand(promptTransport.effectivePrompt);
+  const sessionId = spec.sessionId ?? randomUUID();
+
+  return new Promise<{ body: string; stdout: string; sessionId: string }>((resolve, reject) => {
+    const child = spawn(spec.cmd, spec.args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: cleanElectronEnv(),
+    });
+
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('close', (code) => {
+      const realId = driver?.extractSessionId?.(stdout);
+      const effectiveSessionId = realId ?? sessionId;
+      const displayStdout = driver ? driver.processOutput(effectiveSessionId, stdout) : stdout;
+      if (code === 0) {
+        const body = extractAssistantBody(driver, effectiveSessionId, displayStdout);
+        promptTransport.cleanup();
+        resolve({ body, stdout: displayStdout, sessionId: effectiveSessionId });
+        return;
+      }
+      promptTransport.cleanup();
+      reject(new Error(`${agent.name} PR authoring exited with code ${code}: ${stderr.trim()}`));
+    });
+    child.on('error', (err) => {
+      promptTransport.cleanup();
+      reject(err);
+    });
+  });
+}

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -43,6 +43,12 @@ import {
   spawnAgentFixViaRegistry,
 } from './conflict-resolver.js';
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
+import {
+  buildMakePrPrompt,
+  resolveInstalledSkillPathForAgent,
+  spawnAgentPrAuthorViaRegistry,
+  validateCanonicalPrBody,
+} from './pr-authoring.js';
 
 /** Keeps `lastHeartbeatAt` fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). Matches BaseExecutor default heartbeat cadence. */
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -1505,6 +1511,82 @@ export class TaskRunner {
     }
     const driver = this.executionAgentRegistry.getSessionDriver(agentName);
     return spawnAgentFixViaRegistry(prompt, cwd, agent, driver);
+  }
+
+  async authorPrBodyWithSkill(args: {
+    workflowId?: string;
+    mergeNodeTaskId?: string;
+    title: string;
+    baseBranch: string;
+    featureBranch: string;
+    workflowSummary: string;
+    cwd: string;
+  }): Promise<{ body: string; sessionId: string; agentName: string }> {
+    if (!this.executionAgentRegistry) {
+      throw new Error('executionAgentRegistry is required for authorPrBodyWithSkill');
+    }
+
+    const agentName = this.resolvePrAuthoringAgentName(args.workflowId, args.mergeNodeTaskId);
+    const skillPath = resolveInstalledSkillPathForAgent(agentName, 'make-pr');
+    if (!skillPath) {
+      throw new Error(
+        `Required bundled skill "invoker-make-pr" is not installed for agent "${agentName}".`,
+      );
+    }
+
+    const agent = this.executionAgentRegistry.getOrThrow(agentName);
+    const driver = this.executionAgentRegistry.getSessionDriver(agentName);
+    const prompt = buildMakePrPrompt({
+      skillPath,
+      title: args.title,
+      baseBranch: args.baseBranch,
+      featureBranch: args.featureBranch,
+      workflowSummary: args.workflowSummary,
+    });
+    const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
+    const validationErrors = validateCanonicalPrBody(result.body);
+    if (validationErrors.length > 0) {
+      throw new Error(
+        [
+          `PR body authored via invoker-make-pr is invalid for agent "${agentName}".`,
+          ...validationErrors.map((error) => `- ${error}`),
+        ].join('\n'),
+      );
+    }
+    return { body: result.body, sessionId: result.sessionId, agentName };
+  }
+
+  private resolvePrAuthoringAgentName(workflowId?: string, mergeNodeTaskId?: string): string {
+    const allTasks = this.orchestrator.getAllTasks();
+    let candidateTasks = allTasks.filter((task) => !task.config.isMergeNode);
+    if (workflowId) {
+      candidateTasks = candidateTasks.filter((task) => task.config.workflowId === workflowId);
+    }
+    if (mergeNodeTaskId && workflowId) {
+      const mergeTask = allTasks.find((task) => task.id === mergeNodeTaskId && task.config.isMergeNode);
+      if (mergeTask) {
+        const allowedTaskIds = collectTransitiveNonMergeTaskIds(
+          mergeTask,
+          (id) => this.orchestrator.getTask(id),
+        );
+        candidateTasks = candidateTasks.filter((task) => allowedTaskIds.has(task.id));
+      }
+    }
+
+    const distinctAgents = [...new Set(
+      candidateTasks
+        .map((task) => task.config.executionAgent?.trim())
+        .filter((agent): agent is string => Boolean(agent)),
+    )];
+    if (distinctAgents.length === 0) {
+      return DEFAULT_EXECUTION_AGENT;
+    }
+    if (distinctAgents.length > 1) {
+      console.warn(
+        `[merge] Multiple execution agents found for PR authoring (${distinctAgents.join(', ')}); using ${distinctAgents[0]}`,
+      );
+    }
+    return distinctAgents[0];
   }
 
   get agentRegistry(): AgentRegistry | undefined {


### PR DESCRIPTION
## Summary

This PR fixes two related sources of ad hoc behavior in Invoker's headless and merge flows.

First, merge-gate PR publication now uses the packaged `invoker-make-pr` skill instead of publishing the raw workflow summary directly to GitHub. The merge path now treats the merge summary as authoring context, invokes the configured execution agent with the installed skill, validates the returned body against the canonical PR schema, and fails closed if the skill is missing or returns an invalid body.

Second, headless delegation timeout classification no longer decides workflow scope from target-shape regexes. The delegating side now opens the Invoker database in read-only mode, resolves whether the target is a workflow or a task through persistence lookups, and uses that shared resolver to decide whether workflow-scoped `rebase`, `rebase-and-retry`, and `restart` should keep the extended 60 second timeout. The same resolver is also reused on the owner side for headless mutation classification and deferred workflow-launch cancellation, so both sides derive target identity from the same store-backed source of truth.

That resolver now fails closed for unresolved targets. Instead of returning `undefined` and letting owner-side mutation classification silently degrade, unresolved workflow or task targets now throw immediately, making malformed or stale headless mutation requests fail explicitly.

## Architecture

### Before

```mermaid
flowchart TD
  subgraph Headless Delegation
    CLI[Headless mutating command] --> Timeout[delegationTimeoutMs args inspection]
    Timeout --> Regex[Inline workflow-id regex]
    Regex --> Owner[Delegate to GUI or standalone owner]
    Owner --> OwnerParse[Separate owner-side target parsing]
    OwnerParse --> SilentFallback[Unknown targets can collapse to undefined]
  end

  subgraph Merge PR Publication
    Merge[Merge gate publish] --> Summary[buildMergeSummary]
    Summary --> ExecPr[execPr]
    ExecPr --> GitHub[PR body = raw merge summary]
  end
```

### After

```mermaid
flowchart TD
  subgraph Headless Delegation
    CLI[Headless mutating command] --> Reader[Open read-only Invoker DB]
    Reader --> Resolve[Resolve target via workflow and task lookups]
    Resolve --> Timeout[Shared timeout policy]
    Timeout --> Owner[Delegate to GUI or standalone owner]
    Resolve --> OwnerClassify[Shared owner-side mutation classification]
    OwnerClassify --> FailClosed[Unknown targets throw immediately]
  end

  subgraph Merge PR Publication
    Merge[Merge gate publish] --> Summary[buildMergeSummary context]
    Summary --> Skill[Author PR body with invoker-make-pr]
    Skill --> Validate[validate-pr-body]
    Validate --> ExecPr[execPr]
    ExecPr --> GitHub[PR body = skill-authored canonical body]
  end
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/owner-delegation.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-delegation.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-command-classification.test.ts src/__tests__/owner-delegation.test.ts src/__tests__/headless-delegation.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e4cc08c f5655ba a4dcdca`
- Post-revert steps: Re-run the focused tests above to confirm merge PR authoring returns to the raw-summary path and headless delegation returns to the previous target-classification behavior.
- Data migration? No
