### PR TITLE
Fix node context menu outside dismiss

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -279,6 +279,52 @@ test.describe('Visual proof capture', () => {
     await assertPageScreenshot(page, 'context-menu-danger-separator-fallback');
   });
 
+  test('context menu dismisses on outside left-click even when bubbling is stopped', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+    await injectTaskStates(page, [
+      {
+        taskId: 'task-alpha',
+        changes: {
+          status: 'failed',
+          execution: { exitCode: 1, stderr: 'failed for visual proof' },
+        },
+      },
+    ]);
+
+    await page.evaluate(() => {
+      document.getElementById('outside-dismiss-target')?.remove();
+      const target = document.createElement('button');
+      target.id = 'outside-dismiss-target';
+      target.setAttribute('aria-label', 'Outside dismiss target');
+      Object.assign(target.style, {
+        position: 'fixed',
+        top: '16px',
+        right: '16px',
+        width: '28px',
+        height: '28px',
+        opacity: '0',
+        zIndex: '2147483647',
+      });
+      target.addEventListener('mousedown', (event) => {
+        event.stopPropagation();
+      });
+      document.body.appendChild(target);
+    });
+
+    await page.locator('.react-flow__node[data-testid$="task-alpha"]').click({ button: 'right' });
+    const menu = page.getByRole('menu');
+    await expect(menu).toBeVisible();
+
+    await captureScreenshot(page, 'context-menu-outside-dismiss-open');
+
+    await page.getByRole('button', { name: 'Outside dismiss target' }).click();
+    await page.waitForTimeout(200);
+
+    await captureScreenshot(page, 'context-menu-outside-dismiss-after-click');
+
+    await expect(menu).not.toBeVisible();
+  });
+
   test('status filter dims non-matching nodes', async ({ page }) => {
     await loadPlan(page, TEST_PLAN);
     const now = new Date();

--- a/packages/ui/src/__tests__/context-menu-dismiss.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-dismiss.test.tsx
@@ -1,27 +1,20 @@
 /**
- * Regression test: context menu dismissal must not depend on document mousedown
- * bubbling.
+ * Regression test: context menu dismissal must not depend on document
+ * mousedown bubbling.
  *
- * Models the node-right-click repro: in ReactFlow, certain canvas/node
- * interactions call stopPropagation() on mousedown, preventing it from
- * reaching a document-level listener. The ContextMenu must still close
- * reliably when the user clicks outside of it.
+ * The fix renders a full-screen backdrop behind the menu and closes from that
+ * backdrop's own `onMouseDown`. This test encodes that contract directly:
+ * right-click a node, then left-click the backdrop, and assert the menu is
+ * dismissed.
  *
- * Strategy:
- * - The ContextMenu renders a transparent backdrop overlay behind the menu.
- * - Clicking the backdrop fires onClose directly — no bubbling required.
- * - This test fires mousedown on the backdrop element (role="presentation"),
- *   which is immune to intermediate stopPropagation() calls since the click
- *   target is the backdrop itself.
- *
- * Old implementation (document.addEventListener('mousedown')) fails when an
- * intermediate element swallows the event. The backdrop approach passes
- * because the click lands directly on the backdrop.
+ * Why this fails on the old implementation:
+ * - the old code relied on `document.addEventListener('mousedown', ...)`
+ * - there was no dedicated backdrop target to click outside the menu
+ * - this test therefore cannot find `context-menu-backdrop`
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
-import { vi } from 'vitest';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
 
@@ -66,68 +59,20 @@ describe('Context menu dismissal (node-right-click regression)', () => {
 
     fireEvent.contextMenu(screen.getByTestId('rf__node-task-node-1'));
 
-    await waitFor(() => {
-      expect(screen.getByRole('menu')).toBeInTheDocument();
-    });
+    return screen.findByRole('menu');
   }
 
-  it('closes when clicking the backdrop overlay (not dependent on document mousedown bubbling)', async () => {
-    await openContextMenu();
+  it('dismisses from a backdrop left-click after right-clicking a node', async () => {
+    const menu = await openContextMenu();
+    expect(menu).toBeInTheDocument();
 
-    // The backdrop is a full-screen overlay rendered behind the menu.
-    // Clicking it fires onClose directly — no event bubbling through the
-    // DOM tree required. This is what makes the test immune to
-    // stopPropagation() calls by intermediate elements (e.g. ReactFlow nodes).
     const backdrop = screen.getByTestId('context-menu-backdrop');
-    expect(backdrop).toBeInTheDocument();
+    expect(backdrop).toHaveAttribute('role', 'presentation');
 
-    fireEvent.mouseDown(backdrop);
-
-    await waitFor(() => {
-      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
-    });
-  });
-
-  it('backdrop does not intercept clicks inside the menu', async () => {
-    await openContextMenu();
-
-    // Click a menu item — should work normally (backdrop sits behind menu)
-    const restartBtn = screen.getByText('Restart Task');
-    expect(restartBtn).toBeInTheDocument();
-
-    fireEvent.click(restartBtn);
+    fireEvent.mouseDown(backdrop, { button: 0 });
 
     await waitFor(() => {
       expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     });
-
-    // Verify the action was dispatched
-    expect(mock.api.restartTask).toHaveBeenCalledWith('task-node-1');
-  });
-
-  it('dismissal works even when an intermediate element stops propagation', async () => {
-    await openContextMenu();
-
-    // Simulate what ReactFlow does: a node element that swallows mousedown.
-    // Attach a stopPropagation handler on the node's parent to model a
-    // real ReactFlow canvas swallowing the event.
-    const node = screen.getByTestId('rf__node-task-node-1');
-    const trap = (e: Event) => e.stopPropagation();
-    node.addEventListener('mousedown', trap, { capture: true });
-
-    try {
-      // With the old implementation (document mousedown listener only),
-      // clicking the node would NOT close the menu because the event
-      // never reaches document. With the backdrop, clicking outside the
-      // menu (on the backdrop layer) bypasses the node entirely.
-      const backdrop = screen.getByTestId('context-menu-backdrop');
-      fireEvent.mouseDown(backdrop);
-
-      await waitFor(() => {
-        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
-      });
-    } finally {
-      node.removeEventListener('mousedown', trap, { capture: true });
-    }
   });
 });

--- a/packages/ui/src/__tests__/context-menu-dismiss.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-dismiss.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * Regression test: context menu dismissal must not depend on document mousedown
+ * bubbling.
+ *
+ * Models the node-right-click repro: in ReactFlow, certain canvas/node
+ * interactions call stopPropagation() on mousedown, preventing it from
+ * reaching a document-level listener. The ContextMenu must still close
+ * reliably when the user clicks outside of it.
+ *
+ * Strategy:
+ * - The ContextMenu renders a transparent backdrop overlay behind the menu.
+ * - Clicking the backdrop fires onClose directly — no bubbling required.
+ * - This test fires mousedown on the backdrop element (role="presentation"),
+ *   which is immune to intermediate stopPropagation() calls since the click
+ *   target is the backdrop itself.
+ *
+ * Old implementation (document.addEventListener('mousedown')) fails when an
+ * intermediate element swallows the event. The backdrop approach passes
+ * because the click lands directly on the backdrop.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+const task = makeUITask({
+  id: 'task-node-1',
+  description: 'Node repro task',
+  status: 'pending',
+  command: 'echo repro',
+  workflowId: 'wf-repro',
+});
+
+const workflows: WorkflowMeta[] = [
+  { id: 'wf-repro', name: 'Repro Workflow', status: 'running', baseBranch: 'master' },
+];
+
+describe('Context menu dismissal (node-right-click regression)', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  async function openContextMenu() {
+    render(<App />);
+    act(() => mock.setTasks([task], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-task-node-1')).toBeInTheDocument();
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('rf__node-task-node-1'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('menu')).toBeInTheDocument();
+    });
+  }
+
+  it('closes when clicking the backdrop overlay (not dependent on document mousedown bubbling)', async () => {
+    await openContextMenu();
+
+    // The backdrop is a full-screen overlay rendered behind the menu.
+    // Clicking it fires onClose directly — no event bubbling through the
+    // DOM tree required. This is what makes the test immune to
+    // stopPropagation() calls by intermediate elements (e.g. ReactFlow nodes).
+    const backdrop = screen.getByTestId('context-menu-backdrop');
+    expect(backdrop).toBeInTheDocument();
+
+    fireEvent.mouseDown(backdrop);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  it('backdrop does not intercept clicks inside the menu', async () => {
+    await openContextMenu();
+
+    // Click a menu item — should work normally (backdrop sits behind menu)
+    const restartBtn = screen.getByText('Restart Task');
+    expect(restartBtn).toBeInTheDocument();
+
+    fireEvent.click(restartBtn);
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+
+    // Verify the action was dispatched
+    expect(mock.api.restartTask).toHaveBeenCalledWith('task-node-1');
+  });
+
+  it('dismissal works even when an intermediate element stops propagation', async () => {
+    await openContextMenu();
+
+    // Simulate what ReactFlow does: a node element that swallows mousedown.
+    // Attach a stopPropagation handler on the node's parent to model a
+    // real ReactFlow canvas swallowing the event.
+    const node = screen.getByTestId('rf__node-task-node-1');
+    const trap = (e: Event) => e.stopPropagation();
+    node.addEventListener('mousedown', trap, { capture: true });
+
+    try {
+      // With the old implementation (document mousedown listener only),
+      // clicking the node would NOT close the menu because the event
+      // never reaches document. With the backdrop, clicking outside the
+      // menu (on the backdrop layer) bypasses the node entirely.
+      const backdrop = screen.getByTestId('context-menu-backdrop');
+      fireEvent.mouseDown(backdrop);
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    } finally {
+      node.removeEventListener('mousedown', trap, { capture: true });
+    }
+  });
+});

--- a/packages/ui/src/__tests__/context-menu-dismiss.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-dismiss.test.tsx
@@ -2,15 +2,15 @@
  * Regression test: context menu dismissal must not depend on document
  * mousedown bubbling.
  *
- * The fix renders a full-screen backdrop behind the menu and closes from that
- * backdrop's own `onMouseDown`. This test encodes that contract directly:
- * right-click a node, then left-click the backdrop, and assert the menu is
- * dismissed.
+ * The fix closes from a capture-phase document mousedown listener, so outside
+ * dismissal does not depend on bubbling surviving React Flow or graph-layer
+ * handlers. This test encodes that directly by stopping bubbling on the click
+ * target itself and asserting the menu still closes.
  *
  * Why this fails on the old implementation:
- * - the old code relied on `document.addEventListener('mousedown', ...)`
- * - there was no dedicated backdrop target to click outside the menu
- * - this test therefore cannot find `context-menu-backdrop`
+ * - the old code relied on a bubble-phase `document` mousedown listener
+ * - the outside target below stops propagation during bubbling
+ * - the old listener never observed the event, so the menu stayed open
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
@@ -62,17 +62,25 @@ describe('Context menu dismissal (node-right-click regression)', () => {
     return screen.findByRole('menu');
   }
 
-  it('dismisses from a backdrop left-click after right-clicking a node', async () => {
+  it('dismisses from an outside left-click even when bubbling is stopped', async () => {
     const menu = await openContextMenu();
     expect(menu).toBeInTheDocument();
 
-    const backdrop = screen.getByTestId('context-menu-backdrop');
-    expect(backdrop).toHaveAttribute('role', 'presentation');
-
-    fireEvent.mouseDown(backdrop, { button: 0 });
-
-    await waitFor(() => {
-      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    const interceptor = document.createElement('div');
+    interceptor.setAttribute('data-testid', 'outside-dismiss-target');
+    interceptor.addEventListener('mousedown', (event) => {
+      event.stopPropagation();
     });
+    document.body.appendChild(interceptor);
+
+    try {
+      fireEvent.mouseDown(interceptor, { button: 0 });
+
+      await waitFor(() => {
+        expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+      });
+    } finally {
+      interceptor.remove();
+    }
   });
 });

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -228,6 +228,16 @@ export function ContextMenu({
   );
 
   return (
+    <>
+    {/* Full-screen transparent backdrop — catches clicks that might be
+        swallowed by stopPropagation() before reaching document listeners
+        (e.g. ReactFlow canvas/node mousedown handlers). */}
+    <div
+      data-testid="context-menu-backdrop"
+      role="presentation"
+      className="fixed inset-0 z-40"
+      onMouseDown={onClose}
+    />
     <div
       ref={menuRef}
       role="menu"
@@ -277,5 +287,6 @@ export function ContextMenu({
         </div>
       )}
     </div>
+    </>
   );
 }

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -114,9 +114,11 @@ export function ContextMenu({
     setPosition({ left, top });
   }, [x, y]);
 
-  // Close on click-outside or Escape
+  // Capture-phase outside dismissal stays reliable even if graph layers stop
+  // bubbling on mousedown before it reaches document listeners.
   useEffect(() => {
-    const handleClick = (e: MouseEvent) => {
+    const handleMouseDownCapture = (e: MouseEvent) => {
+      if (e.button !== 0) return;
       if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
         onClose();
       }
@@ -125,10 +127,10 @@ export function ContextMenu({
       if (e.key === 'Escape') onClose();
     };
 
-    document.addEventListener('mousedown', handleClick);
+    document.addEventListener('mousedown', handleMouseDownCapture, true);
     document.addEventListener('keydown', handleKey);
     return () => {
-      document.removeEventListener('mousedown', handleClick);
+      document.removeEventListener('mousedown', handleMouseDownCapture, true);
       document.removeEventListener('keydown', handleKey);
     };
   }, [onClose]);
@@ -228,16 +230,6 @@ export function ContextMenu({
   );
 
   return (
-    <>
-    {/* Full-screen transparent backdrop — catches clicks that might be
-        swallowed by stopPropagation() before reaching document listeners
-        (e.g. ReactFlow canvas/node mousedown handlers). */}
-    <div
-      data-testid="context-menu-backdrop"
-      role="presentation"
-      className="fixed inset-0 z-40"
-      onMouseDown={onClose}
-    />
     <div
       ref={menuRef}
       role="menu"
@@ -287,6 +279,5 @@ export function ContextMenu({
         </div>
       )}
     </div>
-    </>
   );
 }


### PR DESCRIPTION
## Summary

Fix the node context-menu outside-dismiss regression by handling outside clicks in the capture phase so graph-layer bubbling interference does not keep the menu open.

This PR also adds two forms of regression coverage:
- a DOM-level UI regression test for outside left-click dismissal when bubbling is stopped
- a Playwright visual-proof case that captures the menu before the outside click and after the outside click, showing the failure on `master` and the fixed behavior on this branch

## Architecture

### Before

```mermaid
graph TD
    A[User opens node context menu] --> B[Left-click outside menu]
    B --> C[Bubble-phase document mousedown listener]
    C --> D{Graph layer or target stops bubbling?}
    D -- Yes --> E[Dismiss handler never runs]
    D -- No --> F[Menu closes]
```

### After

```mermaid
graph TD
    A[User opens node context menu] --> B[Left-click outside menu]
    B --> C[Capture-phase document mousedown listener]
    C --> D{Click target is outside menu?}
    D -- Yes --> E[Menu closes]
    D -- No --> F[Menu remains open]
```

## Visual Proof

The targeted interaction proof uses a Playwright case that opens the menu, clicks an outside target that stops `mousedown` bubbling, captures the post-click state, and then asserts dismissal.

Before: the same case fails on `master` and still shows the menu after the outside click.
After: the case passes on this branch and the menu is gone after the outside click.

<details open>
<summary>1. Menu Open Before Outside Click</summary>

| Before | After |
|--------|-------|
| ![before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260428-f54197/before--context-menu-outside-dismiss-open.png) | ![after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260428-f54197/after--context-menu-outside-dismiss-open.png) |

</details>

<details open>
<summary>2. After Outside Left-Click With Bubbling Stopped</summary>

| Before | After |
|--------|-------|
| ![before](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260428-f54197/before--context-menu-outside-dismiss-after-click.png) | ![after](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260428-f54197/after--context-menu-outside-dismiss-after-click.png) |

</details>

## Test Plan

- [x] `cd packages/app && xvfb-run --auto-servernum npx playwright test e2e/visual-proof.spec.ts --grep "context menu dismisses on outside left-click even when bubbling is stopped"`
- [x] `bash scripts/ui-visual-proof.sh capture-after`
- [x] `cd packages/ui && pnpm test -- --run src/__tests__/context-menu-dismiss.test.tsx`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge_commit_sha>`
- Post-revert steps: None
- Data migration? No
