### PR TITLE
Harden headless owner recovery and review polling

### DIFF
--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -3,6 +3,7 @@ import { writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 import type { Page } from '@playwright/test';
+import { SQLiteAdapter } from '@invoker/data-store';
 import { stringify as yamlStringify } from 'yaml';
 
 import {
@@ -40,6 +41,28 @@ function parseWorkflowId(stdout: string): string {
   const direct = stdout.match(/Workflow ID: (wf-[^\s]+)/);
   if (direct?.[1]) return direct[1];
   throw new Error(`No workflow id found in stdout:\n${stdout}`);
+}
+
+async function resolveWorkflowIdFromDb(
+  testDir: string,
+  knownWorkflowIds: ReadonlySet<string>,
+  timeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  const dbPath = path.join(testDir, 'invoker.db');
+  while (Date.now() < deadline) {
+    const db = await SQLiteAdapter.create(dbPath, { readOnly: true });
+    try {
+      const workflowId = db.listWorkflows()
+        .map((workflow) => workflow.id)
+        .find((id): id is string => !!id && !knownWorkflowIds.has(id));
+      if (workflowId) return workflowId;
+    } finally {
+      db.close();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error('Timed out waiting for a new workflow id to appear in persisted state');
 }
 
 async function assertTaskPanelResponsive(page: Page, timeoutMs: number): Promise<void> {
@@ -85,7 +108,13 @@ test.describe('Headless thundering herd', () => {
     if (currentWorkflowId) workflowIds.add(currentWorkflowId);
     for (let i = 0; i < 8; i += 1) {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
-      workflowIds.add(parseWorkflowId(result.stdout));
+      let workflowId: string;
+      try {
+        workflowId = parseWorkflowId(result.stdout);
+      } catch {
+        workflowId = await resolveWorkflowIdFromDb(testDir, workflowIds, 2_000);
+      }
+      workflowIds.add(workflowId);
     }
 
     await page.waitForTimeout(500);

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -57,6 +57,23 @@ describe('headless-client', () => {
     expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
   });
 
+  it('uses a longer no-track delegation timeout for an already-running standalone owner under load', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+    bus.onRequest('headless.exec', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 9_000));
+      return { ok: true };
+    });
+
+    const exitCode = await runHeadlessClientCommand(['retry', 'wf-1', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+  }, 15_000);
+
   it('bootstraps a standalone owner once when no owner is present, then delegates', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));

--- a/packages/app/src/__tests__/headless-session.test.ts
+++ b/packages/app/src/__tests__/headless-session.test.ts
@@ -32,9 +32,15 @@ function makeSshTask(overrides: Partial<TaskState['config']> = {}): TaskState {
 }
 
 describe('resolveAgentSession', () => {
-  it('returns null when no driver is registered', async () => {
+  it('returns error state when no driver is registered', async () => {
     const result = await resolveAgentSession('sess-abc', 'unknown', undefined);
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      agentName: 'unknown',
+      sessionId: 'sess-abc',
+      state: 'error',
+      messages: [],
+      reason: 'No session driver registered for agent "unknown"',
+    });
   });
 
   it('returns local session when loadSession succeeds', async () => {
@@ -42,13 +48,21 @@ describe('resolveAgentSession', () => {
       processOutput: vi.fn(),
       loadSession: vi.fn(() => '{"messages":[]}'),
       parseSession: vi.fn(() => [{ role: 'assistant', content: 'hello' }]),
+      inspectSession: vi.fn(() => ({ state: 'finished' })),
     };
     const registry = {
       getSessionDriver: () => mockDriver,
     } as unknown as AgentRegistry;
 
     const result = await resolveAgentSession('sess-abc', 'codex', registry);
-    expect(result).toEqual([{ role: 'assistant', content: 'hello' }]);
+    expect(result).toEqual({
+      agentName: 'codex',
+      sessionId: 'sess-abc',
+      state: 'finished',
+      reason: undefined,
+      messages: [{ role: 'assistant', content: 'hello' }],
+      source: 'local',
+    });
     expect(mockDriver.loadSession).toHaveBeenCalledWith('sess-abc');
   });
 
@@ -57,6 +71,7 @@ describe('resolveAgentSession', () => {
       processOutput: vi.fn(),
       loadSession: vi.fn(() => null), // not found locally
       parseSession: vi.fn(() => [{ role: 'assistant', content: 'remote session' }]),
+      inspectSession: vi.fn(() => ({ state: 'running' })),
       fetchRemoteSession: vi.fn(async () => '{"messages":[]}'),
     };
     const registry = {
@@ -71,7 +86,14 @@ describe('resolveAgentSession', () => {
       'sess-abc',
       { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
     );
-    expect(result).toEqual([{ role: 'assistant', content: 'remote session' }]);
+    expect(result).toEqual({
+      agentName: 'codex',
+      sessionId: 'sess-abc',
+      state: 'running',
+      reason: undefined,
+      messages: [{ role: 'assistant', content: 'remote session' }],
+      source: 'remote',
+    });
   });
 
   it('uses explicit remoteTargetId when present', async () => {
@@ -79,6 +101,7 @@ describe('resolveAgentSession', () => {
       processOutput: vi.fn(),
       loadSession: vi.fn(() => null),
       parseSession: vi.fn(() => [{ role: 'assistant', content: 'targeted' }]),
+      inspectSession: vi.fn(() => ({ state: 'finished' })),
       fetchRemoteSession: vi.fn(async () => '{"messages":[]}'),
     };
     const registry = {
@@ -92,7 +115,14 @@ describe('resolveAgentSession', () => {
       'sess-abc',
       { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
     );
-    expect(result).toEqual([{ role: 'assistant', content: 'targeted' }]);
+    expect(result).toEqual({
+      agentName: 'codex',
+      sessionId: 'sess-abc',
+      state: 'finished',
+      reason: undefined,
+      messages: [{ role: 'assistant', content: 'targeted' }],
+      source: 'remote',
+    });
   });
 
   it('returns null when SSH task has no remoteTargetId and no targets configured', async () => {
@@ -106,6 +136,7 @@ describe('resolveAgentSession', () => {
       processOutput: vi.fn(),
       loadSession: vi.fn(() => null),
       parseSession: vi.fn(),
+      inspectSession: vi.fn(),
       fetchRemoteSession: vi.fn(),
     };
     const registry = {
@@ -117,7 +148,13 @@ describe('resolveAgentSession', () => {
 
     // fetchRemoteSession should NOT be called because there's no target
     expect(mockDriver.fetchRemoteSession).not.toHaveBeenCalled();
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      agentName: 'codex',
+      sessionId: 'sess-abc',
+      state: 'error',
+      messages: [],
+      reason: 'Session file not found',
+    });
 
     loadConfigSpy.mockRestore();
   });

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -417,6 +417,49 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(adapter.listWorkflowMutationIntents('wf-1', ['completed'])).toHaveLength(2);
   });
 
+  it('requeues interrupted fix-with-agent workflow mutations on restart', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const firstGate = deferred();
+    const owner1Order: string[] = [];
+    const owner1 = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        owner1Order.push(`${channel}:${String(args[0])}`);
+        await firstGate.promise;
+      },
+    );
+
+    void owner1.enqueue<void>('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/task-fail', 'claude']);
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const owner2Order: string[] = [];
+    const owner2 = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-2',
+      async (channel, args) => {
+        owner2Order.push(`${channel}:${String(args[0])}`);
+      },
+    );
+
+    adapter.requeueExpiredWorkflowMutationLeases(new Date(Date.now() + 60_000));
+    await owner2.resumePending();
+
+    expect(owner1Order).toEqual(['invoker:fix-with-agent:wf-1/task-fail']);
+    expect(owner2Order).toEqual(['invoker:fix-with-agent:wf-1/task-fail']);
+    expect(adapter.listWorkflowMutationIntents('wf-1', ['queued', 'running'])).toEqual([]);
+    expect(adapter.listWorkflowMutationIntents('wf-1', ['completed'])).toHaveLength(1);
+  });
+
   it('does not let another owner steal a live workflow lease', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/app/src/__tests__/workflow-mutation-startup.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-startup.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Logger } from '@invoker/contracts';
+import { recoverWorkflowMutationsOnStartup } from '../workflow-mutation-startup.js';
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    error: vi.fn(),
+  } as unknown as Logger & { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+}
+
+describe('recoverWorkflowMutationsOnStartup', () => {
+  it('requeues and resumes pending mutations for owner startup without env gating', async () => {
+    const persistence = {
+      requeueExpiredWorkflowMutationLeases: vi.fn(),
+    };
+    const workflowMutationCoordinator = {
+      resumePending: vi.fn(async () => {}),
+    };
+    const maybeDelayResume = vi.fn(async () => {});
+    const logger = makeLogger();
+
+    await recoverWorkflowMutationsOnStartup({
+      ownerMode: true,
+      persistence,
+      workflowMutationCoordinator,
+      logger,
+      maybeDelayResume,
+    });
+
+    expect(persistence.requeueExpiredWorkflowMutationLeases).toHaveBeenCalledTimes(1);
+    expect(maybeDelayResume).toHaveBeenCalledTimes(1);
+    expect(workflowMutationCoordinator.resumePending).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('requeued expired workflow mutation leases on startup', { module: 'init' });
+    expect(logger.info).toHaveBeenCalledWith('resuming pending workflow mutations on startup', { module: 'init' });
+    expect(logger.info).toHaveBeenCalledWith('workflow mutation recovery finished on startup', { module: 'init' });
+  });
+
+  it('does nothing in follower mode', async () => {
+    const persistence = {
+      requeueExpiredWorkflowMutationLeases: vi.fn(),
+    };
+    const workflowMutationCoordinator = {
+      resumePending: vi.fn(async () => {}),
+    };
+    const logger = makeLogger();
+
+    await recoverWorkflowMutationsOnStartup({
+      ownerMode: false,
+      persistence,
+      workflowMutationCoordinator,
+      logger,
+    });
+
+    expect(persistence.requeueExpiredWorkflowMutationLeases).not.toHaveBeenCalled();
+    expect(workflowMutationCoordinator.resumePending).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -56,16 +56,30 @@ async function runElectronHeadless(args: string[]): Promise<number> {
   });
 }
 
-const DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS = 8_000;
+async function flushOutputStream(stream: NodeJS.WriteStream): Promise<void> {
+  await new Promise<void>((resolve) => {
+    stream.write('', () => resolve());
+  });
+}
+
+const DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS = 30_000;
 const POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS = 90_000;
 const POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 8_000;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
+const DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS = 60_000;
 type HeadlessOwnerInfo = { ownerId?: string; mode?: string };
 
 function isStandaloneOwner(owner: HeadlessOwnerInfo | null | undefined): owner is HeadlessOwnerInfo & { mode: 'standalone' } {
   return owner?.mode === 'standalone';
+}
+
+function standaloneOwnerBootstrapTimeoutMs(): number {
+  const raw = process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS;
 }
 
 export class SharedMutationOwnerTimeoutError extends Error {
@@ -216,7 +230,7 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
     if (bootstrapLock) {
       spawnDetachedStandaloneOwner(resolve(__dirname, '..', '..', '..'));
     }
-    const deadline = Date.now() + 20_000;
+    const deadline = Date.now() + standaloneOwnerBootstrapTimeoutMs();
     while (Date.now() < deadline) {
       const owner = await tryPingHeadlessOwner(bus, 500);
       if (isStandaloneOwner(owner)) return;
@@ -344,11 +358,19 @@ export async function runHeadlessClient(argv: string[]): Promise<number> {
 
 if (require.main === module) {
   runHeadlessClient(process.argv.slice(2))
-    .then((code) => {
-      process.exit(code);
+    .then(async (code) => {
+      await Promise.all([
+        flushOutputStream(process.stdout),
+        flushOutputStream(process.stderr),
+      ]);
+      process.exitCode = code;
     })
-    .catch((err) => {
+    .catch(async (err) => {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
+      await Promise.all([
+        flushOutputStream(process.stdout),
+        flushOutputStream(process.stderr),
+      ]);
+      process.exitCode = 1;
     });
 }

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -67,8 +67,10 @@ export async function tryPingHeadlessOwner(
   timeoutMs = 1_000,
 ): Promise<{ ownerId?: string; mode?: string } | null> {
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
-    setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle = setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle.unref?.();
   });
 
   try {
@@ -83,6 +85,8 @@ export async function tryPingHeadlessOwner(
       return null;
     }
     throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 }
 
@@ -100,8 +104,10 @@ export async function tryDelegateQuery(
   timeoutMs = 5_000,
 ): Promise<Record<string, unknown> | null> {
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
-    setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle = setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle.unref?.();
   });
 
   try {
@@ -116,6 +122,8 @@ export async function tryDelegateQuery(
       return null;
     }
     throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 }
 
@@ -127,8 +135,10 @@ async function tryDelegate(
 ): Promise<boolean> {
   let targetWorkflowId: string | undefined;
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
-    setTimeout(() => reject(DELEGATION_TIMEOUT), options.timeoutMs ?? 5_000);
+    timeoutHandle = setTimeout(() => reject(DELEGATION_TIMEOUT), options.timeoutMs ?? 5_000);
+    timeoutHandle.unref?.();
   });
 
   let response: { workflowId: string; tasks: TaskState[] } | { ok: true };
@@ -145,6 +155,8 @@ async function tryDelegate(
       return false;
     }
     throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
   if ('workflowId' in response) {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -11,6 +11,7 @@
 
 import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
+import type { AgentSessionData } from '@invoker/contracts';
 import type { Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
@@ -1764,13 +1765,31 @@ export async function resolveAgentSession(
   agentName: string,
   registry?: AgentRegistry,
   allTasks?: import('@invoker/workflow-core').TaskState[],
-): Promise<import('@invoker/execution-engine').AgentMessage[] | null> {
+): Promise<AgentSessionData | null> {
   const driver = registry?.getSessionDriver(agentName);
-  if (!driver) return null;
+  if (!driver) {
+    return {
+      agentName,
+      sessionId,
+      state: 'error',
+      messages: [],
+      reason: `No session driver registered for agent "${agentName}"`,
+    };
+  }
 
   // 1. Try local
   const raw = driver.loadSession(sessionId);
-  if (raw) return driver.parseSession(raw);
+  if (raw) {
+    const inspection = driver.inspectSession(raw);
+    return {
+      agentName,
+      sessionId,
+      state: inspection.state,
+      reason: inspection.reason,
+      messages: driver.parseSession(raw),
+      source: 'local',
+    };
+  }
 
   // 2. Try remote (SSH tasks)
   if (driver.fetchRemoteSession && allTasks) {
@@ -1787,12 +1806,28 @@ export async function resolveAgentSession(
         : Object.values(targets)[0];
       if (target) {
         const remoteRaw = await driver.fetchRemoteSession(sessionId, target);
-        if (remoteRaw) return driver.parseSession(remoteRaw);
+        if (remoteRaw) {
+          const inspection = driver.inspectSession(remoteRaw);
+          return {
+            agentName,
+            sessionId,
+            state: inspection.state,
+            reason: inspection.reason,
+            messages: driver.parseSession(remoteRaw),
+            source: 'remote',
+          };
+        }
       }
     }
   }
 
-  return null;
+  return {
+    agentName,
+    sessionId,
+    state: 'error',
+    messages: [],
+    reason: 'Session file not found',
+  };
 }
 
 async function headlessSession(taskId: string | undefined, deps: Pick<HeadlessDeps, 'orchestrator' | 'persistence' | 'executionAgentRegistry'>): Promise<void> {
@@ -1836,12 +1871,16 @@ async function headlessSession(taskId: string | undefined, deps: Pick<HeadlessDe
   process.stdout.write(`agent=${agentName} sessionId=${sessionId}\n`);
 
   const allTasks = deps.orchestrator.getAllTasks();
-  const messages = await resolveAgentSession(sessionId, agentName, deps.executionAgentRegistry, allTasks);
-  if (!messages) {
-    process.stdout.write('Session file not found\n');
+  const result = await resolveAgentSession(sessionId, agentName, deps.executionAgentRegistry, allTasks);
+  if (!result) {
+    process.stdout.write('Session lookup failed\n');
     return;
   }
-  for (const msg of messages) {
+  process.stdout.write(`state=${result.state}${result.source ? ` source=${result.source}` : ''}\n`);
+  if (result.reason) {
+    process.stdout.write(`${result.reason}\n`);
+  }
+  for (const msg of result.messages) {
     process.stdout.write(`[${msg.role}] ${msg.content}\n`);
   }
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -860,12 +860,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.run', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { planPath } = req as { planPath: string };
-          await runHeadless(['run', planPath], {
-            ...headlessDeps,
-            waitForApproval: false,
-            noTrack: true,
-          });
-          return { ok: true };
+          return executeHeadlessRun({ planPath });
         });
         messageBus.onRequest('headless.owner-ping', async () => {
           noteStandaloneOwnerActivity();
@@ -895,12 +890,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId } = req as { workflowId: string };
-          await runHeadless(['resume', workflowId], {
-            ...headlessDeps,
-            waitForApproval: false,
-            noTrack: true,
-          });
-          return { ok: true };
+          return executeHeadlessResume({ workflowId });
         });
         messageBus.onRequest('headless.exec', async (req: unknown) => {
           noteStandaloneOwnerActivity();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -127,6 +127,7 @@ import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
+import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
 import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
 import { computeDeferredLaunchTiming } from './deferred-runnable.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
@@ -696,6 +697,34 @@ if (isHeadless) {
         return executor;
       };
 
+      const executeStandaloneHeadlessRun = async (payload: HeadlessRunMutationPayload): Promise<unknown> => {
+        const { parsePlanFile } = await import('./plan-parser.js');
+        const plan = await parsePlanFile(payload.planPath);
+        const executor = createStandaloneTaskExecutor();
+        void executor;
+        backupPlan(plan, undefined, logger);
+        const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
+        orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+        const workflowId = orchestrator.getWorkflowIds().find((id) => !wfIdsBefore.has(id));
+        if (!workflowId) {
+          throw new Error(`Failed to resolve workflow id for delegated plan: ${payload.planPath}`);
+        }
+        const started = orchestrator.startExecution();
+        logger.info(`standalone started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
+        const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
+        return { workflowId, tasks };
+      };
+
+      const executeStandaloneHeadlessResume = async (payload: HeadlessResumeMutationPayload): Promise<unknown> => {
+        const { workflowId } = payload;
+        createStandaloneTaskExecutor();
+        orchestrator.syncFromDb(workflowId);
+        const started = relaunchOrphansAndStartReady(orchestrator, logger, 'standalone-ipc-delegate', workflowId);
+        logger.info(`standalone resumed ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
+        const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
+        return { workflowId, tasks };
+      };
+
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
         switch (payload.channel) {
           case 'invoker:load-plan': {
@@ -864,7 +893,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.run', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { planPath } = req as { planPath: string };
-          return executeHeadlessRun({ planPath });
+          return executeStandaloneHeadlessRun({ planPath });
         });
         messageBus.onRequest('headless.owner-ping', async () => {
           noteStandaloneOwnerActivity();
@@ -894,7 +923,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId } = req as { workflowId: string };
-          return executeHeadlessResume({ workflowId });
+          return executeStandaloneHeadlessResume({ workflowId });
         });
         messageBus.onRequest('headless.exec', async (req: unknown) => {
           noteStandaloneOwnerActivity();
@@ -2104,34 +2133,13 @@ if (isHeadless) {
       });
       recordStartupMark('api-server.started');
 
-      if (ownerMode && workflowMutationCoordinator) {
-        try {
-          persistence.requeueExpiredWorkflowMutationLeases();
-          logger.info('requeued expired workflow mutation leases on startup', { module: 'init' });
-        } catch (err) {
-          logger.error(
-            `requeueExpiredWorkflowMutationLeases failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-            { module: 'init' },
-          );
-        }
-        if (process.env.INVOKER_RESUME_WORKFLOW_MUTATIONS_ON_STARTUP === '1') {
-          void (async () => {
-            try {
-              await maybeDelayWorkflowResumeForTest();
-              await workflowMutationCoordinator.resumePending();
-            } catch (err) {
-              logger.error(
-                `resumePending failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-                { module: 'init' },
-              );
-            }
-          })();
-        } else {
-          logger.info('startup workflow mutation drain deferred; queued intents remain durable until explicit activity', {
-            module: 'init',
-          });
-        }
-      }
+      void recoverWorkflowMutationsOnStartup({
+        ownerMode,
+        persistence,
+        workflowMutationCoordinator,
+        logger,
+        maybeDelayResume: maybeDelayWorkflowResumeForTest,
+      });
 
       startSlackBot(requireTaskExecutor(), taskHandles).catch((err) => {
         logger.info(`Not started: ${err instanceof Error ? err.message : String(err)}`, { module: 'slack' });

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -13,6 +13,7 @@ export type {
   TaskOutputData,
   ActivityLogEntry,
   ClaudeMessage,
+  AgentSessionData,
   ExternalGatePolicyUpdate,
 } from '@invoker/contracts';
 

--- a/packages/app/src/workflow-mutation-startup.ts
+++ b/packages/app/src/workflow-mutation-startup.ts
@@ -1,0 +1,46 @@
+import type { Logger } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
+
+type RecoveryDeps = {
+  ownerMode: boolean;
+  persistence: Pick<SQLiteAdapter, 'requeueExpiredWorkflowMutationLeases'>;
+  workflowMutationCoordinator?: Pick<PersistedWorkflowMutationCoordinator, 'resumePending'>;
+  logger: Logger;
+  maybeDelayResume?: () => Promise<void>;
+};
+
+export async function recoverWorkflowMutationsOnStartup({
+  ownerMode,
+  persistence,
+  workflowMutationCoordinator,
+  logger,
+  maybeDelayResume,
+}: RecoveryDeps): Promise<void> {
+  if (!ownerMode || !workflowMutationCoordinator) {
+    return;
+  }
+
+  try {
+    persistence.requeueExpiredWorkflowMutationLeases();
+    logger.info('requeued expired workflow mutation leases on startup', { module: 'init' });
+  } catch (err) {
+    logger.error(
+      `requeueExpiredWorkflowMutationLeases failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+      { module: 'init' },
+    );
+    return;
+  }
+
+  try {
+    await maybeDelayResume?.();
+    logger.info('resuming pending workflow mutations on startup', { module: 'init' });
+    await workflowMutationCoordinator.resumePending();
+    logger.info('workflow mutation recovery finished on startup', { module: 'init' });
+  } catch (err) {
+    logger.error(
+      `resumePending failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+      { module: 'init' },
+    );
+  }
+}

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -62,6 +62,17 @@ export interface ClaudeMessage {
   timestamp: string;
 }
 
+export type AgentSessionState = 'running' | 'finished' | 'error';
+
+export interface AgentSessionData {
+  agentName: string;
+  sessionId: string;
+  state: AgentSessionState;
+  messages: ClaudeMessage[];
+  reason?: string;
+  source?: 'local' | 'remote';
+}
+
 export interface ExternalGatePolicyUpdate {
   workflowId: string;
   taskId?: string;
@@ -287,11 +298,11 @@ export const IpcChannels = {
   // Session & Agent Access
   'invoker:get-claude-session': {} as {
     request: [sessionId: string];
-    response: ClaudeMessage[] | null;
+    response: AgentSessionData | null;
   },
   'invoker:get-agent-session': {} as {
     request: [sessionId: string, agentName?: string];
-    response: ClaudeMessage[] | null;
+    response: AgentSessionData | null;
   },
 
   // Workflow Mutation & Merge

--- a/packages/execution-engine/src/__tests__/claude-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/claude-session-driver.test.ts
@@ -90,6 +90,35 @@ describe('ClaudeSessionDriver', () => {
     expect(typeof driver.processOutput).toBe('function');
     expect(typeof driver.loadSession).toBe('function');
     expect(typeof driver.parseSession).toBe('function');
+    expect(typeof driver.inspectSession).toBe('function');
     expect(typeof driver.fetchRemoteSession).toBe('function');
+  });
+
+  it('inspectSession returns finished when Claude transcript ends with assistant text', () => {
+    expect(driver.inspectSession(sampleClaudeJsonl)).toEqual({ state: 'finished' });
+  });
+
+  it('inspectSession returns running when Claude transcript ends with a user/tool-result event', () => {
+    const jsonl = [
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash' }] }, timestamp: 'ts0' }),
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'tool_result', content: 'ok' }] }, timestamp: 'ts1' }),
+    ].join('\n');
+    expect(driver.inspectSession(jsonl)).toEqual({ state: 'running' });
+  });
+
+  it('inspectSession returns running when Claude transcript ends with assistant tool_use', () => {
+    const jsonl = JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', name: 'Bash' }] },
+      timestamp: 'ts1',
+    });
+    expect(driver.inspectSession(jsonl)).toEqual({ state: 'running' });
+  });
+
+  it('inspectSession returns error for malformed content', () => {
+    expect(driver.inspectSession('not json')).toEqual({
+      state: 'error',
+      reason: 'Malformed Claude session JSONL',
+    });
   });
 });

--- a/packages/execution-engine/src/__tests__/codex-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-session-driver.test.ts
@@ -76,6 +76,32 @@ describe('CodexSessionDriver', () => {
     expect(messages[1]).toEqual({ role: 'assistant', content: 'I fixed the bug.', timestamp: 'ts2' });
   });
 
+  it('inspectSession returns finished when turn.completed is present', () => {
+    const driver = new CodexSessionDriver();
+    const jsonl = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }),
+      JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1 } }),
+    ].join('\n');
+    expect(driver.inspectSession(jsonl)).toEqual({ state: 'finished' });
+  });
+
+  it('inspectSession returns running when session has started but not completed', () => {
+    const driver = new CodexSessionDriver();
+    const jsonl = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }),
+      JSON.stringify({ type: 'item.started', item: { id: 'item-1', status: 'in_progress' } }),
+    ].join('\n');
+    expect(driver.inspectSession(jsonl)).toEqual({ state: 'running' });
+  });
+
+  it('inspectSession returns error for malformed content', () => {
+    const driver = new CodexSessionDriver();
+    expect(driver.inspectSession('not json')).toEqual({
+      state: 'error',
+      reason: 'Malformed Codex session JSONL',
+    });
+  });
+
   it('loadSession finds file when processOutput uses extracted real ID (fixed flow)', () => {
     const driver = new CodexSessionDriver();
     const jsonl = [

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -108,4 +108,52 @@ describe('GitHubMergeGateProvider', () => {
       );
     });
   });
+
+  describe('checkApproval', () => {
+    it('prefers the full review URL when present', async () => {
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        expect(cmd).toBe('gh');
+        return mockSpawnResult('{"state":"OPEN","reviewDecision":null,"url":"https://github.com/owner/repo/pull/42"}', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({
+        reviewUrl: 'https://github.com/owner/repo/pull/42',
+        reviewId: '42',
+        workspacePath: '/tmp/gate',
+        fallbackCwd: '/tmp/root',
+      });
+
+      expect(result.statusText).toBe('Awaiting review');
+      expect(spawnMock).toHaveBeenCalledWith(
+        'gh',
+        ['pr', 'view', 'https://github.com/owner/repo/pull/42', '--json', 'state,reviewDecision,url'],
+        expect.objectContaining({ cwd: '/tmp/gate' }),
+      );
+    });
+
+    it('uses --repo for repo-qualified review ids', async () => {
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        expect(cmd).toBe('gh');
+        return mockSpawnResult('{"state":"MERGED","reviewDecision":"REVIEW_REQUIRED","url":"https://github.com/owner/repo/pull/42"}', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({
+        reviewId: 'owner/repo#42',
+        fallbackCwd: '/tmp/root',
+      });
+
+      expect(result.approved).toBe(true);
+      expect(spawnMock).toHaveBeenCalledWith(
+        'gh',
+        ['pr', 'view', '42', '--repo', 'owner/repo', '--json', 'state,reviewDecision,url'],
+        expect.objectContaining({ cwd: '/tmp/root' }),
+      );
+    });
+  });
 });

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -338,17 +338,96 @@ branch refs/heads/experiment/test-task-oldhash
         ].join('\n');
       }
       if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (phase === 'cleanup_worktree') {
+        cleanupScript = script;
+        return '';
+      }
       if (script.includes('worktree list --porcelain')) {
         return `worktree ${ownerPath}
 HEAD deadbeef
 branch refs/heads/${targetBranch}
 `;
       }
+      if (script.includes('rev-parse --abbrev-ref HEAD')) return 'not-the-target-branch\n';
+      return '';
+    });
+
+    const setupTaskBranchSpy = vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any) => handle,
+    );
+
+    const req = makeRequest({
+      actionType: 'command',
+      actionId: 'test-task-conflict',
+      inputs: {
+        command: 'pnpm test',
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    });
+
+    try {
+      await ssh.start(req);
+
+      const encodedPaths = cleanupScript.match(/WORKTREES_B64="([^"]+)"/)?.[1];
+      const decodedPaths = Buffer.from(encodedPaths ?? '', 'base64').toString('utf8');
+      expect(decodedPaths).toContain(ownerPath);
+      expect(setupTaskBranchSpy).toHaveBeenCalled();
+    } finally {
+      if (prevCleanup === undefined) {
+        delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+      } else {
+        process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = prevCleanup;
+      }
+    }
+  });
+
+  it('cleans up a stale exact-branch owner when HEAD probing fails even with cleanup disabled', async () => {
+    const prevCleanup = process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+    delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+    }) as any;
+
+    const repoHash = computeRepoUrlHash('git@github.com:owner/repo.git');
+    const baseHead = 'abc123def456abc123def456abc123def456abc1';
+    const branchHash = computeContentHash(
+      'test-task-conflict',
+      'pnpm test',
+      undefined,
+      [],
+      baseHead,
+    );
+    const targetBranch = buildExperimentBranchName('test-task-conflict', '', branchHash);
+    const ownerPath = `/home/testuser/.invoker/worktrees/${repoHash}/stale-owner-${branchHash}`;
+    let cleanupScript = '';
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string, phase?: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return [
+          '__INVOKER_BASE_REF__=origin/main',
+          `__INVOKER_BASE_HEAD__=${baseHead}`,
+        ].join('\n');
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
       if (phase === 'cleanup_worktree') {
         cleanupScript = script;
         return '';
       }
-      if (script.includes('rev-parse --abbrev-ref HEAD')) return 'not-the-target-branch\n';
+      if (script.includes('worktree list --porcelain')) {
+        return `worktree ${ownerPath}
+HEAD deadbeef
+branch refs/heads/${targetBranch}
+`;
+      }
+      if (script.includes('rev-parse --abbrev-ref HEAD')) {
+        throw createSshRemoteScriptError(1, '', `bash: line 1: cd: ${ownerPath}: No such file or directory\n`);
+      }
       return '';
     });
 

--- a/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
@@ -74,6 +74,41 @@ describe('SSH worktree metadata repro', () => {
     }).toThrow(new RegExp(`already used by worktree at '${realOldPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
   });
 
+  it('reproduces a same-branch relaunch failure when the worktree dir is deleted without clearing git admin state', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-worktree-race-repro-'));
+    tempRoots.push(root);
+
+    const repoDir = join(root, 'repo');
+    const worktreePath = join(root, 'experiment-wf-1-run-app-retry-tests-g0.t5.aaaa-12345678');
+    const branch = 'experiment/wf-1/run-app-retry-tests/g0.t5.aaaa-12345678';
+
+    execSync(`mkdir -p ${JSON.stringify(repoDir)}`);
+    git('git init -b master', repoDir);
+    git('git config user.email "test@example.com"', repoDir);
+    git('git config user.name "Test User"', repoDir);
+    writeFileSync(join(repoDir, 'README.md'), 'seed\n');
+    git('git add README.md', repoDir);
+    git('git commit -m "seed"', repoDir);
+
+    // First launch claims the branch and creates the worktree.
+    git(`git worktree add -B ${JSON.stringify(branch)} ${JSON.stringify(worktreePath)} master`, repoDir);
+    expect(existsSync(worktreePath)).toBe(true);
+
+    // Raw directory deletion leaves git's worktree admin entry behind.
+    rmSync(worktreePath, { recursive: true, force: true });
+    expect(existsSync(worktreePath)).toBe(false);
+
+    const porcelain = git('git worktree list --porcelain', repoDir);
+    expect(porcelain).toContain(`branch refs/heads/${branch}`);
+    expect(porcelain).toContain(`worktree ${worktreePath}`);
+
+    // Second launch of the same task/branch now collides with the stale admin
+    // registration, even though the filesystem path is gone.
+    expect(() => {
+      git(`git worktree add -B ${JSON.stringify(branch)} ${JSON.stringify(worktreePath)} master`, repoDir);
+    }).toThrow(new RegExp(`already used by worktree at '${worktreePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
+  });
+
   it('proves TaskRunner should persist the owning worktree path on SSH startup failure', async () => {
     const ownerPath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-bc7a0b71';
     const branch = 'experiment/wf-1/test-execution-engine-b68b146f';

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -2662,7 +2662,7 @@ describe('TaskRunner', () => {
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
 
       // Should start polling
-      expect((executor as any).startPrPolling).toHaveBeenCalledWith('__merge__wf-1', 'owner/repo#55', 'wf-1');
+      expect((executor as any).startPrPolling).toHaveBeenCalledWith('__merge__wf-1');
     });
 
     it('executeMergeNode anchors external_review gate worktrees on the origin-backed base branch', async () => {
@@ -3395,8 +3395,10 @@ describe('TaskRunner', () => {
 
       expect(orchestrator.getTask).toHaveBeenCalledWith('task-1');
       expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
-        identifier: 'owner/repo#42',
-        cwd: '/tmp',
+        reviewUrl: undefined,
+        reviewId: 'owner/repo#42',
+        workspacePath: undefined,
+        fallbackCwd: '/tmp',
       });
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
         execution: { reviewStatus: 'Awaiting review' },
@@ -3413,7 +3415,11 @@ describe('TaskRunner', () => {
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
-          execution: { reviewId: 'owner/repo#42' },
+          execution: {
+            reviewUrl: 'https://github.com/owner/repo/pull/42',
+            reviewId: 'owner/repo#42',
+            workspacePath: '/tmp/gate-wt',
+          },
         })),
         approve: vi.fn(),
       };
@@ -3443,6 +3449,12 @@ describe('TaskRunner', () => {
 
       await executor.checkPrApprovalNow('task-1');
 
+      expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+        reviewUrl: 'https://github.com/owner/repo/pull/42',
+        reviewId: 'owner/repo#42',
+        workspacePath: '/tmp/gate-wt',
+        fallbackCwd: '/tmp',
+      });
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
         execution: { reviewStatus: 'Approved' },
       });

--- a/packages/execution-engine/src/claude-session-driver.ts
+++ b/packages/execution-engine/src/claude-session-driver.ts
@@ -13,7 +13,7 @@ import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { spawn } from 'node:child_process';
-import type { SessionDriver, RemoteTarget } from './session-driver.js';
+import type { AgentSessionInspection, SessionDriver, RemoteTarget } from './session-driver.js';
 import type { AgentMessage } from './codex-session.js';
 
 export class ClaudeSessionDriver implements SessionDriver {
@@ -77,6 +77,41 @@ export class ClaudeSessionDriver implements SessionDriver {
       }
     }
     return messages;
+  }
+
+  inspectSession(raw: string): AgentSessionInspection {
+    let lastEntry: any | undefined;
+    let parsedAny = false;
+
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        lastEntry = JSON.parse(line);
+        parsedAny = true;
+      } catch {
+        // Ignore malformed lines; only fail if nothing parses.
+      }
+    }
+
+    if (!parsedAny || !lastEntry) {
+      return { state: 'error', reason: 'Malformed Claude session JSONL' };
+    }
+
+    if (lastEntry.type === 'user' || lastEntry.type === 'queue-operation') {
+      return { state: 'running' };
+    }
+
+    if (lastEntry.type === 'assistant') {
+      const content = lastEntry.message?.content;
+      const blocks = Array.isArray(content) ? content : [content];
+      const hasToolUse = blocks.some((block: any) => block?.type === 'tool_use');
+      const hasText = blocks.some((block: any) =>
+        typeof block === 'string' || block?.type === 'text' || typeof block?.text === 'string');
+      if (hasToolUse) return { state: 'running' };
+      if (hasText) return { state: 'finished' };
+    }
+
+    return { state: 'error', reason: 'Claude session ended in an unrecognized state' };
   }
 
   /**

--- a/packages/execution-engine/src/codex-session-driver.ts
+++ b/packages/execution-engine/src/codex-session-driver.ts
@@ -11,7 +11,7 @@ import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { spawn } from 'node:child_process';
-import type { SessionDriver, RemoteTarget } from './session-driver.js';
+import type { AgentSessionInspection, SessionDriver, RemoteTarget } from './session-driver.js';
 import { parseCodexSessionJsonl, toReadableText, extractCodexSessionId } from './codex-session.js';
 import type { AgentMessage } from './codex-session.js';
 
@@ -40,6 +40,44 @@ export class CodexSessionDriver implements SessionDriver {
 
   parseSession(raw: string): AgentMessage[] {
     return parseCodexSessionJsonl(raw);
+  }
+
+  inspectSession(raw: string): AgentSessionInspection {
+    let parsedAny = false;
+    let sawStarted = false;
+    let sawInProgress = false;
+    let sawFinished = false;
+
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line);
+        parsedAny = true;
+        if (entry.type === 'thread.started' || entry.type === 'turn.started') {
+          sawStarted = true;
+        }
+        if (entry.type === 'thread.completed' || entry.type === 'turn.completed' || entry.type === 'task_complete') {
+          sawFinished = true;
+        }
+        const item = entry.item;
+        if (entry.type === 'item.started' || item?.status === 'in_progress') {
+          sawInProgress = true;
+        }
+      } catch {
+        // Skip malformed lines; final state falls back to error if nothing parsed.
+      }
+    }
+
+    if (!parsedAny) {
+      return { state: 'error', reason: 'Malformed Codex session JSONL' };
+    }
+    if (sawFinished) {
+      return { state: 'finished' };
+    }
+    if (sawInProgress || sawStarted) {
+      return { state: 'running' };
+    }
+    return { state: 'error', reason: 'Codex session did not contain recognizable lifecycle markers' };
   }
 
   /**

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -63,15 +63,14 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
   }
 
   async checkApproval(opts: {
-    identifier: string;
-    cwd: string;
+    reviewUrl?: string;
+    reviewId?: string;
+    workspacePath?: string;
+    fallbackCwd: string;
   }): Promise<MergeGateApprovalStatus> {
-    const { identifier, cwd } = opts;
-
-    const stdout = await this.exec('gh', [
-      'pr', 'view', identifier,
-      '--json', 'state,reviewDecision,url',
-    ], cwd);
+    const { reviewUrl, reviewId, workspacePath, fallbackCwd } = opts;
+    const cwd = workspacePath ?? fallbackCwd;
+    const stdout = await this.exec('gh', this.buildPrViewArgs(reviewUrl, reviewId), cwd);
 
     const data = JSON.parse(stdout) as {
       state: string;
@@ -101,6 +100,28 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       statusText,
       url: data.url,
     };
+  }
+
+  private buildPrViewArgs(reviewUrl?: string, reviewId?: string): string[] {
+    if (reviewUrl?.trim()) {
+      return ['pr', 'view', reviewUrl.trim(), '--json', 'state,reviewDecision,url'];
+    }
+
+    const normalizedReviewId = reviewId?.trim();
+    if (!normalizedReviewId) {
+      throw new Error('Missing reviewUrl/reviewId for merge-gate approval check');
+    }
+
+    const repoQualifiedMatch = normalizedReviewId.match(/^([^#\s]+\/[^#\s]+)#(\d+)$/);
+    if (repoQualifiedMatch) {
+      return ['pr', 'view', repoQualifiedMatch[2], '--repo', repoQualifiedMatch[1], '--json', 'state,reviewDecision,url'];
+    }
+
+    if (/^\d+$/.test(normalizedReviewId)) {
+      return ['pr', 'view', normalizedReviewId, '--json', 'state,reviewDecision,url'];
+    }
+
+    throw new Error(`Unsupported review identifier format: ${normalizedReviewId}`);
   }
 
   private async exec(cmd: string, args: string[], cwd: string): Promise<string> {

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -22,7 +22,9 @@ export interface MergeGateProvider {
   }): Promise<MergeGateProviderResult>;
 
   checkApproval(opts: {
-    identifier: string;
-    cwd: string;
+    reviewUrl?: string;
+    reviewId?: string;
+    workspacePath?: string;
+    fallbackCwd: string;
   }): Promise<MergeGateApprovalStatus>;
 }

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -161,7 +161,7 @@ export interface MergeRunnerHost {
   detectDefaultBranch(): Promise<string>;
   gitLogMessage(commitHash: string, cwd?: string): Promise<string>;
   gitDiffStat(branch: string, cwd?: string): Promise<string>;
-  startPrPolling(taskId: string, reviewId: string, workflowId: string): void;
+  startPrPolling(taskId: string): void;
   executeTasks(tasks: TaskState[]): Promise<void>;
   buildMergeSummary(workflowId: string): Promise<string>;
   runVisualProofCapture?(baseBranch: string, featureBranch: string, slug: string, repoUrl?: string): Promise<string | undefined>;
@@ -474,7 +474,7 @@ export async function executeMergeNodeImpl(
           },
         });
         await startReviewReadyDependents(host);
-        host.startPrPolling(task.id, result.identifier, workflowId!);
+        host.startPrPolling(task.id);
         return;
       }
       response = {
@@ -933,7 +933,7 @@ export async function publishAfterFixImpl(
         },
       });
       await startReviewReadyDependents(host);
-      host.startPrPolling(task.id, result.identifier, workflowId!);
+      host.startPrPolling(task.id);
       return;
     }
 

--- a/packages/execution-engine/src/session-driver.ts
+++ b/packages/execution-engine/src/session-driver.ts
@@ -14,6 +14,13 @@ export interface RemoteTarget {
   port?: number;
 }
 
+export type AgentSessionState = 'running' | 'finished' | 'error';
+
+export interface AgentSessionInspection {
+  state: AgentSessionState;
+  reason?: string;
+}
+
 export interface SessionDriver {
   /** Post-exit: store raw stdout and return human-readable text for callers. */
   processOutput(sessionId: string, rawStdout: string): string;
@@ -21,6 +28,8 @@ export interface SessionDriver {
   loadSession(sessionId: string): string | null;
   /** Parse stored session content into displayable messages. */
   parseSession(raw: string): AgentMessage[];
+  /** Inspect a stored session and infer a small lifecycle state. */
+  inspectSession(raw: string): AgentSessionInspection;
   /** Extract the real backend session/thread ID from raw stdout (e.g. codex thread ID for resume). */
   extractSessionId?(rawStdout: string): string | undefined;
   /** Fetch session from a remote SSH host. Returns raw content or null. */

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -373,7 +373,13 @@ echo ${payloadB64} | base64 -d | bash -se
           headMatchesTargetBranch: abbrevRefMatchesBranch(head, experimentBranch),
         };
       } catch {
-        exactBranchCandidate = undefined;
+        // If the branch still appears in `git worktree list --porcelain` but we
+        // cannot read its HEAD, treat it as a stale owner that must be cleaned
+        // up before recreating the canonical branch/worktree pair.
+        exactBranchCandidate = {
+          path: reuseAbs,
+          headMatchesTargetBranch: false,
+        };
       }
     }
 
@@ -397,11 +403,10 @@ echo ${payloadB64} | base64 -d | bash -se
       case 'rename_reuse':
         throw new Error('SSH managed workspaces do not support same-task different-branch rename reuse');
       case 'recreate': {
-        // Workspace cleanup is gated by INVOKER_ENABLE_WORKSPACE_CLEANUP. With
-        // attemptId mixed into the branch hash, the canonical worktree path
-        // for the new attempt has never existed, so cleanup is unnecessary
-        // for correctness. Re-enable the env flag if you need disk hygiene.
-        if (isWorkspaceCleanupEnabled()) {
+        // General workspace cleanup remains opt-in for disk hygiene, but exact
+        // branch-owner collisions must always be reconciled for correctness.
+        const needsOwnerCleanup = !!exactBranchCandidate;
+        if (isWorkspaceCleanupEnabled() || needsOwnerCleanup) {
           const cleanupScript = buildWorktreeCleanupScript({
             remoteClone,
             worktreePaths: worktreePlan.cleanupPaths,

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -257,12 +257,12 @@ while IFS= read -r WT; do
   [ -z "$WT" ] && continue
   ${bashNormalizeTildePath('WT')}
   mkdir -p "$(dirname "$WT")"
-  if [ -e "$WT" ]; then
+  if git -C "$CLONE" worktree list --porcelain | grep -Fq "worktree $WT"; then
     echo "[SshGitExec] Removing stale worktree path: $WT"
     git -C "$CLONE" worktree remove --force "$WT" 2>/dev/null || true
-    rm -rf "$WT"
     git -C "$CLONE" worktree prune 2>/dev/null || true
   fi
+  rm -rf "$WT"
 done < <(echo "$WORKTREES_B64" | base64 -d)
 `;
 }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1385,11 +1385,11 @@ export class TaskRunner {
       if (
         task.config.isMergeNode &&
         (task.status === 'review_ready' || task.status === 'awaiting_approval') &&
-        task.execution.reviewId &&
+        (task.execution.reviewUrl || task.execution.reviewId) &&
         !this.activePrPollers.has(task.id)
       ) {
-        console.log(`[merge-gate] Resuming PR polling for ${task.id} (PR ${task.execution.reviewId})`);
-        this.startPrPolling(task.id, task.execution.reviewId, task.config.workflowId!);
+        console.log(`[merge-gate] Resuming PR polling for ${task.id} (${this.getReviewPollLabel(task)})`);
+        this.startPrPolling(task.id);
       }
     }
   }
@@ -1400,22 +1400,19 @@ export class TaskRunner {
       if (
         task.config.isMergeNode &&
         (task.status === 'review_ready' || task.status === 'awaiting_approval') &&
-        task.execution.reviewId
+        (task.execution.reviewUrl || task.execution.reviewId)
       ) {
         try {
-          const status = await this.mergeGateProvider.checkApproval({
-            identifier: task.execution.reviewId,
-            cwd: this.cwd,
-          });
+          const status = await this.mergeGateProvider.checkApproval(this.getReviewPollTarget(task));
           this.persistence.updateTask(task.id, {
             execution: { reviewStatus: status.statusText },
           });
           if (status.approved) {
-            console.log(`[merge-gate] PR ${task.execution.reviewId} approved (refresh), completing merge gate`);
+            console.log(`[merge-gate] ${this.getReviewPollLabel(task)} approved (refresh), completing merge gate`);
             this.stopPrPolling(task.id);
             await this.orchestrator.approve(task.id);
           } else if (status.rejected) {
-            console.log(`[merge-gate] PR ${task.execution.reviewId} rejected (refresh): ${status.statusText}`);
+            console.log(`[merge-gate] ${this.getReviewPollLabel(task)} rejected (refresh): ${status.statusText}`);
             this.stopPrPolling(task.id);
           }
         } catch (err) {
@@ -1425,15 +1422,17 @@ export class TaskRunner {
     }
   }
 
-  /** @internal */ startPrPolling(taskId: string, reviewId: string, workflowId: string): void {
+  /** @internal */ startPrPolling(taskId: string): void {
     const pollIntervalMs = 30_000;
     const interval = setInterval(async () => {
       try {
         if (!this.mergeGateProvider) return;
-        const status = await this.mergeGateProvider.checkApproval({
-          identifier: reviewId,
-          cwd: this.cwd,
-        });
+        const task = this.orchestrator.getTask(taskId);
+        if (!task || (!task.execution.reviewUrl && !task.execution.reviewId)) {
+          this.stopPrPolling(taskId);
+          return;
+        }
+        const status = await this.mergeGateProvider.checkApproval(this.getReviewPollTarget(task));
 
         // Update PR status on task
         this.persistence.updateTask(taskId, {
@@ -1441,11 +1440,11 @@ export class TaskRunner {
         });
 
         if (status.approved) {
-          console.log(`[merge-gate] PR ${reviewId} approved, completing merge gate`);
+          console.log(`[merge-gate] ${this.getReviewPollLabel(task)} approved, completing merge gate`);
           this.stopPrPolling(taskId);
           await this.orchestrator.approve(taskId);
         } else if (status.rejected) {
-          console.log(`[merge-gate] PR ${reviewId} rejected: ${status.statusText}`);
+          console.log(`[merge-gate] ${this.getReviewPollLabel(task)} rejected: ${status.statusText}`);
           this.stopPrPolling(taskId);
           // Leave in review_ready/awaiting_approval — user can retry
         }
@@ -1471,30 +1470,44 @@ export class TaskRunner {
 
     // Read reviewId from persistence
     const task = this.orchestrator.getTask(taskId);
-    const reviewId = task?.execution.reviewId;
-    if (!reviewId) return;
+    if (!task || (!task.execution.reviewUrl && !task.execution.reviewId)) return;
 
     try {
-      const status = await this.mergeGateProvider.checkApproval({
-        identifier: reviewId,
-        cwd: this.cwd,
-      });
+      const status = await this.mergeGateProvider.checkApproval(this.getReviewPollTarget(task));
 
       this.persistence.updateTask(taskId, {
         execution: { reviewStatus: status.statusText },
       });
 
       if (status.approved) {
-        console.log(`[merge-gate] PR ${reviewId} approved (manual check), completing merge gate`);
+        console.log(`[merge-gate] ${this.getReviewPollLabel(task)} approved (manual check), completing merge gate`);
         this.stopPrPolling(taskId);
         await this.orchestrator.approve(taskId);
       } else if (status.rejected) {
-        console.log(`[merge-gate] PR ${reviewId} rejected (manual check): ${status.statusText}`);
+        console.log(`[merge-gate] ${this.getReviewPollLabel(task)} rejected (manual check): ${status.statusText}`);
         this.stopPrPolling(taskId);
       }
     } catch (err) {
       console.error(`[merge-gate] Manual PR check error for ${taskId}:`, err);
     }
+  }
+
+  private getReviewPollTarget(task: TaskState): {
+    reviewUrl?: string;
+    reviewId?: string;
+    workspacePath?: string;
+    fallbackCwd: string;
+  } {
+    return {
+      reviewUrl: task.execution.reviewUrl,
+      reviewId: task.execution.reviewId,
+      workspacePath: task.execution.workspacePath,
+      fallbackCwd: this.cwd,
+    };
+  }
+
+  private getReviewPollLabel(task: TaskState): string {
+    return task.execution.reviewUrl ?? task.execution.reviewId ?? `review for ${task.id}`;
   }
 
   spawnAgentFix(

--- a/packages/ui/src/__tests__/approval-modal.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal.test.tsx
@@ -207,9 +207,13 @@ describe('ApprovalModal', () => {
   // ── Context info blocks ──────────────────────────────
 
   it('renders only session block for fix approval with session ID and loads messages', async () => {
-    mockGetAgentSession.mockResolvedValue([
-      { role: 'user', content: 'Fix the test', timestamp: '' },
-    ]);
+    mockGetAgentSession.mockResolvedValue({
+      agentName: 'claude',
+      sessionId: 'sess-abc-123',
+      state: 'running',
+      source: 'remote',
+      messages: [{ role: 'user', content: 'Fix the test', timestamp: '' }],
+    });
 
     render(
       <ApprovalModal
@@ -233,6 +237,7 @@ describe('ApprovalModal', () => {
     await waitFor(() => {
       expect(screen.getByTestId('session-messages')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('session-state')).toHaveTextContent('State: running (remote)');
     expect(screen.getByText('Fix the test')).toBeInTheDocument();
 
     // Fix context block should not exist
@@ -408,6 +413,33 @@ describe('ApprovalModal', () => {
     });
 
     expect(screen.getByTestId('session-error')).toHaveTextContent('Could not load session');
+  });
+
+  it('renders error state when session inspection reports an error result', async () => {
+    mockGetAgentSession.mockResolvedValue({
+      agentName: 'claude',
+      sessionId: 'sess-error-test',
+      state: 'error',
+      reason: 'Session file not found',
+      messages: [],
+    });
+
+    render(
+      <ApprovalModal
+        task={makeTask({
+          execution: { agentSessionId: 'sess-error-test' },
+        })}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-error')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('session-state')).toHaveTextContent('State: error');
   });
 
   it('uses agent name in heading, label, reason pre-fill, and session fetch', async () => {

--- a/packages/ui/src/components/ApprovalModal.tsx
+++ b/packages/ui/src/components/ApprovalModal.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import type { TaskState, ClaudeMessage } from '../types.js';
+import type { TaskState, ClaudeMessage, AgentSessionData } from '../types.js';
 
 interface ApprovalModalProps {
   task: TaskState;
@@ -83,6 +83,9 @@ export function ApprovalModal({
   const [reasonTouched, setReasonTouched] = useState(false);
   const [showRejectInput, setShowRejectInput] = useState(initialAction === 'reject');
   const [sessionMessages, setSessionMessages] = useState<ClaudeMessage[] | null>(null);
+  const [sessionState, setSessionState] = useState<AgentSessionData['state'] | null>(null);
+  const [sessionSource, setSessionSource] = useState<AgentSessionData['source'] | undefined>(undefined);
+  const [sessionReason, setSessionReason] = useState<string | undefined>(undefined);
   const [sessionLoading, setSessionLoading] = useState(false);
   const [sessionError, setSessionError] = useState(false);
 
@@ -118,11 +121,24 @@ export function ApprovalModal({
   useEffect(() => {
     if (!sessionId) return;
     setSessionLoading(true);
+    setSessionState(null);
+    setSessionSource(undefined);
+    setSessionReason(undefined);
     setSessionError(false);
     window.invoker
       .getAgentSession(sessionId, effectiveAgentName)
-      .then((msgs) => {
+      .then((result) => {
+        const msgs = Array.isArray(result)
+          ? result
+          : ((result as AgentSessionData | null)?.messages ?? null);
+        const isError = !Array.isArray(result) && !!result && result.state === 'error';
+        if (!Array.isArray(result) && result) {
+          setSessionState(result.state);
+          setSessionSource(result.source);
+          setSessionReason(result.reason);
+        }
         setSessionMessages(msgs);
+        setSessionError(isError);
         setSessionLoading(false);
       })
       .catch(() => {
@@ -187,6 +203,12 @@ export function ApprovalModal({
             <div className="bg-gray-700/50 rounded p-3" data-testid="claude-session-context">
               <h3 className="text-sm font-medium text-gray-300 mb-2">{agentLabel} Session</h3>
               <p className="text-xs text-gray-500 mb-2 font-mono">{sessionId}</p>
+              {sessionState && (
+                <p className="text-xs text-gray-400 mb-2" data-testid="session-state">
+                  State: <span className="font-mono">{sessionState}</span>
+                  {sessionSource ? <> {' '}({sessionSource})</> : null}
+                </p>
+              )}
               {sessionLoading && <p className="text-xs text-gray-500" data-testid="session-loading">Loading conversation...</p>}
               {sessionMessages && (
                 <div className="space-y-2" data-testid="session-messages">
@@ -199,6 +221,9 @@ export function ApprovalModal({
                     </div>
                   ))}
                 </div>
+              )}
+              {sessionReason && !sessionError && (
+                <p className="text-xs text-gray-500 mt-2" data-testid="session-reason">{sessionReason}</p>
               )}
               {sessionError && <p className="text-xs text-red-400" data-testid="session-error">Could not load session</p>}
             </div>

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -222,7 +222,7 @@ export interface TaskReplacementDef {
 // ── IPC Bridge API ──────────────────────────────────────────
 // InvokerAPI is derived from the IPC channel registry in @invoker/contracts.
 
-export type { InvokerAPI, ClaudeMessage } from '@invoker/contracts';
+export type { InvokerAPI, ClaudeMessage, AgentSessionData } from '@invoker/contracts';
 
 import type { InvokerAPI } from '@invoker/contracts';
 

--- a/scripts/auto-select-reconciliation-refactor.sh
+++ b/scripts/auto-select-reconciliation-refactor.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RUNNER="$REPO_ROOT/run.sh"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 LOCK_FILE="${TMPDIR:-/tmp}/invoker-auto-select-reconciliation-refactor.lock"
 
 if [[ ! -x "$RUNNER" ]]; then
@@ -71,7 +72,7 @@ while IFS=$'\t' read -r recon_id experiment_id; do
   [[ -z "$recon_id" || -z "$experiment_id" ]] && continue
   attempts=$((attempts + 1))
   echo "Selecting experiment '$experiment_id' for reconciliation node '$recon_id'..."
-  if "$RUNNER" --headless select "$recon_id" "$experiment_id" --no-track; then
+  if node "$IPC_HELPER" exec --no-track -- select "$recon_id" "$experiment_id"; then
     success=$((success + 1))
   else
     failed=$((failed + 1))

--- a/scripts/convert-claude-to-codex.sh
+++ b/scripts/convert-claude-to-codex.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ELECTRON="$REPO_ROOT/packages/app/node_modules/.bin/electron"
 MAIN="$REPO_ROOT/packages/app/dist/main.js"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 
 # Parse args
 DRY_RUN=false
@@ -49,8 +50,7 @@ headless_query() {
 
 # Helper: mutating command (stderr preserved for debugging real failures)
 headless_mutation() {
-  # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@"
+  node "$IPC_HELPER" exec -- "$@"
 }
 
 # Helper: extract workflow IDs (filter Electron init noise)

--- a/scripts/headless-ipc.js
+++ b/scripts/headless-ipc.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const { IpcBus } = require(path.join(repoRoot, 'packages', 'transport', 'dist'));
+
+for (const stream of [process.stdout, process.stderr]) {
+  stream.on('error', (error) => {
+    if (error && error.code === 'EPIPE') {
+      process.exit(0);
+    }
+    throw error;
+  });
+}
+
+function usage() {
+  console.error(
+    'Usage:\n' +
+    '  node scripts/headless-ipc.js exec [--no-track] [--wait-for-approval] [--timeout-ms N] -- <headless args...>\n' +
+    '  node scripts/headless-ipc.js batch-exec [--no-track] [--wait-for-approval] [--timeout-ms N] [--parallel N] < commands.jsonl',
+  );
+}
+
+function withTimeout(promise, timeoutMs) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return promise;
+  }
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      const timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+      timer.unref?.();
+    }),
+  ]);
+}
+
+function parseCli(argv) {
+  const mode = argv[0];
+  if (mode !== 'exec' && mode !== 'batch-exec') {
+    usage();
+    process.exit(2);
+  }
+
+  let noTrack = false;
+  let waitForApproval = false;
+  let parallel = 1;
+  let timeoutMs = 30_000;
+  const args = [];
+  let afterDoubleDash = false;
+
+  for (let i = 1; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (afterDoubleDash) {
+      args.push(token);
+      continue;
+    }
+    if (token === '--') {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (token === '--no-track') {
+      noTrack = true;
+      continue;
+    }
+    if (token === '--wait-for-approval') {
+      waitForApproval = true;
+      continue;
+    }
+    if (token === '--parallel') {
+      parallel = Number.parseInt(argv[i + 1] ?? '', 10);
+      i += 1;
+      continue;
+    }
+    if (token === '--timeout-ms') {
+      timeoutMs = Number.parseInt(argv[i + 1] ?? '', 10);
+      i += 1;
+      continue;
+    }
+    args.push(token);
+  }
+
+  return { mode, noTrack, waitForApproval, parallel, timeoutMs, args };
+}
+
+async function readStdinLines() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8').split('\n').map((line) => line.trim()).filter(Boolean);
+}
+
+async function requestExec(bus, item, options) {
+  const payload = {
+    args: item.args,
+    noTrack: options.noTrack,
+    waitForApproval: options.waitForApproval,
+  };
+  const response = await withTimeout(bus.request('headless.exec', payload), options.timeoutMs);
+  return {
+    ...item,
+    ok: true,
+    response,
+  };
+}
+
+async function main() {
+  const options = parseCli(process.argv.slice(2));
+  const bus = new IpcBus(undefined, { allowServe: false });
+  await bus.ready();
+
+  try {
+    if (options.mode === 'exec') {
+      if (options.args.length === 0) {
+        throw new Error('Missing headless args for exec');
+      }
+      const result = await requestExec(bus, { args: options.args }, options);
+      process.stdout.write(`${JSON.stringify(result)}\n`);
+      return;
+    }
+
+    const lines = await readStdinLines();
+    const items = lines.map((line) => {
+      const parsed = JSON.parse(line);
+      if (Array.isArray(parsed)) {
+        return { args: parsed };
+      }
+      if (!parsed || !Array.isArray(parsed.args)) {
+        throw new Error(`Invalid batch item: ${line}`);
+      }
+      return parsed;
+    });
+
+    let nextIndex = 0;
+    const parallel = Math.max(1, Number.isFinite(options.parallel) ? options.parallel : 1);
+
+    async function worker() {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+        if (index >= items.length) {
+          return;
+        }
+        const item = items[index];
+        try {
+          const result = await requestExec(bus, item, options);
+          process.stdout.write(`${JSON.stringify(result)}\n`);
+        } catch (error) {
+          process.stdout.write(`${JSON.stringify({
+            ...item,
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          })}\n`);
+        }
+      }
+    }
+
+    await Promise.all(Array.from({ length: Math.min(parallel, items.length) }, () => worker()));
+  } finally {
+    bus.disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/rebase-retry-all.sh
+++ b/scripts/rebase-retry-all.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Detect repo root
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 
 # Set Electron paths
 ELECTRON="$REPO_ROOT/packages/app/node_modules/.bin/electron"
@@ -128,8 +129,7 @@ headless_query() {
 }
 
 headless_mutation() {
-  # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@"
+  node "$IPC_HELPER" exec -- "$@"
 }
 
 headless_workflow_ids() {
@@ -285,14 +285,14 @@ if [ "$FOLLOW" = true ]; then
     if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ]; then
       set +e
       cmd_out="$(
-        run_with_optional_timeout "$COMMAND_TIMEOUT_SECONDS" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless --no-track rebase "$task_id" 2>&1
+        run_with_optional_timeout "$COMMAND_TIMEOUT_SECONDS" node "$IPC_HELPER" exec --no-track -- rebase "$task_id" 2>&1
       )"
       cmd_status=$?
       set -e
     else
       set +e
       cmd_out="$(
-        headless_mutation --no-track rebase "$task_id" 2>&1
+        node "$IPC_HELPER" exec --no-track -- rebase "$task_id" 2>&1
       )"
       cmd_status=$?
       set -e
@@ -352,27 +352,9 @@ if [ "$FOLLOW" = true ]; then
   fi
 else
   LOG_DIR="$(mktemp -d -t rebase-retry-all-logs.XXXXXX)"
-  TIMEOUT_TOOL=""
-  if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ]; then
-    if command -v timeout >/dev/null 2>&1; then
-      TIMEOUT_TOOL="timeout"
-    elif command -v gtimeout >/dev/null 2>&1; then
-      TIMEOUT_TOOL="gtimeout"
-    else
-      echo "WARNING: timeout/gtimeout unavailable; fire-and-forget mode will run without per-command timeout." >&2
-    fi
-  fi
-
-  launch_detached() {
-    local log_file="$1"
-    shift
-    if command -v setsid >/dev/null 2>&1; then
-      setsid "$@" >"$log_file" 2>&1 < /dev/null &
-    else
-      nohup "$@" >"$log_file" 2>&1 < /dev/null &
-    fi
-    echo "$!"
-  }
+  RESULT_FILE="$(mktemp -t rebase-retry-all-results.XXXXXX)"
+  COMMANDS_FILE="$(mktemp -t rebase-retry-all-commands.XXXXXX)"
+  OUTPUT_JSONL="$(mktemp -t rebase-retry-all-output.XXXXXX)"
 
   IDX=0
   while IFS= read -r WF_ID; do
@@ -394,22 +376,44 @@ else
     fi
 
     log_file="$LOG_DIR/${WF_ID}.log"
-    if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ] && [ -n "$TIMEOUT_TOOL" ]; then
-      # shellcheck disable=SC2086
-      pid="$(launch_detached "$log_file" "$TIMEOUT_TOOL" "$COMMAND_TIMEOUT_SECONDS" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless --no-track rebase "$task_id")" || pid=""
-    else
-      # shellcheck disable=SC2086
-      pid="$(launch_detached "$log_file" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless --no-track rebase "$task_id")" || pid=""
-    fi
-
-    if [ -n "$pid" ]; then
-      echo "  dispatched pid=$pid log=$log_file" >&2
-      DISPATCHED=$((DISPATCHED + 1))
-    else
-      echo "  failed to dispatch" >&2
-      LAUNCH_FAILED=$((LAUNCH_FAILED + 1))
-    fi
+    printf '{"label":"%s","workflowId":"%s","taskId":"%s","args":["rebase","%s"]}\n' "$WF_ID" "$WF_ID" "$task_id" "$task_id" >> "$COMMANDS_FILE"
+    echo "  queued log=$log_file" >&2
   done <<< "$WORKFLOW_IDS"
+
+  BATCH_ARGS=(batch-exec --no-track --parallel "$PARALLELISM")
+  if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ]; then
+    BATCH_ARGS+=(--timeout-ms "$((COMMAND_TIMEOUT_SECONDS * 1000))")
+  fi
+  node "$IPC_HELPER" "${BATCH_ARGS[@]}" < "$COMMANDS_FILE" > "$OUTPUT_JSONL"
+  python3 - "$RESULT_FILE" "$LOG_DIR" "$OUTPUT_JSONL" <<'PY'
+import json
+import pathlib
+import sys
+
+result_file = pathlib.Path(sys.argv[1])
+log_dir = pathlib.Path(sys.argv[2])
+output_jsonl = pathlib.Path(sys.argv[3])
+
+for raw in output_jsonl.read_text(encoding="utf-8").splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    item = json.loads(raw)
+    workflow_id = item.get("workflowId") or item.get("label") or "unknown"
+    (log_dir / f"{workflow_id}.log").write_text(raw + "\n", encoding="utf-8")
+    with result_file.open("a", encoding="utf-8") as handle:
+        handle.write(f"{workflow_id}\t{'SUCCEEDED' if item.get('ok') else 'FAILED'}\n")
+PY
+  rm -f "$COMMANDS_FILE"
+  rm -f "$OUTPUT_JSONL"
+
+  while IFS=$'\t' read -r _wf result; do
+    case "$result" in
+      SUCCEEDED) DISPATCHED=$((DISPATCHED + 1)) ;;
+      FAILED) LAUNCH_FAILED=$((LAUNCH_FAILED + 1)) ;;
+    esac
+  done < "$RESULT_FILE"
+  rm -f "$RESULT_FILE"
 
   echo "" >&2
   echo "Summary (fire-and-forget):" >&2

--- a/scripts/recreate-all.sh
+++ b/scripts/recreate-all.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ELECTRON="$REPO_ROOT/packages/app/node_modules/.bin/electron"
 MAIN="$REPO_ROOT/packages/app/dist/main.js"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 
 # Parse args
 DRY_RUN=false
@@ -56,8 +57,7 @@ headless_query() {
 
 # Helper: mutating command delegated to the current owner (GUI or standalone headless)
 headless_mutation() {
-  # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@"
+  node "$IPC_HELPER" exec -- "$@"
 }
 
 # Helper: extract workflow IDs from label output.
@@ -159,32 +159,47 @@ else
   LOG_DIR="$(mktemp -d -t recreate-all-logs.XXXXXX)"
   DISPATCHED=0
   LAUNCH_FAILED=0
-
-  launch_detached() {
-    local log_file="$1"
-    shift
-    if command -v setsid >/dev/null 2>&1; then
-      setsid "$@" >"$log_file" 2>&1 < /dev/null &
-    else
-      nohup "$@" >"$log_file" 2>&1 < /dev/null &
-    fi
-    echo "$!"
-  }
+  RESULT_FILE="$(mktemp -t recreate-all-results.XXXXXX)"
+  COMMANDS_FILE="$(mktemp -t recreate-all-commands.XXXXXX)"
+  OUTPUT_JSONL="$(mktemp -t recreate-all-output.XXXXXX)"
 
   while IFS= read -r WF_ID; do
     [[ -z "$WF_ID" ]] && continue
     IDX=$((IDX + 1))
-    log_file="$LOG_DIR/${WF_ID}.log"
-    # shellcheck disable=SC2086
-    pid="$(launch_detached "$log_file" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless recreate "$WF_ID")" || pid=""
-    if [[ -n "$pid" ]]; then
-      echo "[dispatch $IDX/$TOTAL] $WF_ID pid=$pid log=$log_file"
-      DISPATCHED=$((DISPATCHED + 1))
-    else
-      echo "[dispatch $IDX/$TOTAL] $WF_ID FAILED_TO_START"
-      LAUNCH_FAILED=$((LAUNCH_FAILED + 1))
-    fi
+    printf '{"label":"%s","workflowId":"%s","args":["recreate","%s"]}\n' "$WF_ID" "$WF_ID" "$WF_ID" >> "$COMMANDS_FILE"
+    echo "[dispatch $IDX/$TOTAL] $WF_ID log=$LOG_DIR/${WF_ID}.log"
   done <<< "$WORKFLOWS"
+
+  node "$IPC_HELPER" batch-exec --no-track --parallel "$PARALLELISM" < "$COMMANDS_FILE" > "$OUTPUT_JSONL"
+  python3 - "$RESULT_FILE" "$LOG_DIR" "$OUTPUT_JSONL" <<'PY'
+import json
+import pathlib
+import sys
+
+result_file = pathlib.Path(sys.argv[1])
+log_dir = pathlib.Path(sys.argv[2])
+output_jsonl = pathlib.Path(sys.argv[3])
+
+for raw in output_jsonl.read_text(encoding="utf-8").splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    item = json.loads(raw)
+    workflow_id = item.get("workflowId") or item.get("label") or "unknown"
+    (log_dir / f"{workflow_id}.log").write_text(raw + "\n", encoding="utf-8")
+    with result_file.open("a", encoding="utf-8") as handle:
+        handle.write(f"{workflow_id}\t{'SUCCEEDED' if item.get('ok') else 'FAILED'}\n")
+PY
+  rm -f "$COMMANDS_FILE"
+  rm -f "$OUTPUT_JSONL"
+
+  while IFS=$'\t' read -r _wf result; do
+    case "$result" in
+      SUCCEEDED) DISPATCHED=$((DISPATCHED + 1)) ;;
+      FAILED) LAUNCH_FAILED=$((LAUNCH_FAILED + 1)) ;;
+    esac
+  done < "$RESULT_FILE"
+  rm -f "$RESULT_FILE"
 fi
 
 echo "---"

--- a/scripts/recreate-failed-tasks.sh
+++ b/scripts/recreate-failed-tasks.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Recreate the earliest non-completed tasks in each workflow.
+#
+# For each selected workflow, query all tasks, ignore completed ones for
+# selection purposes, and recreate the pending/failed tasks that are closest to
+# the start of the DAG: tasks whose dependencies are all completed.
+#
+# This keeps the script intentionally explicit rather than DRY with the retry
+# scripts.
+#
+# Usage:
+#   bash scripts/recreate-failed-tasks.sh
+#   bash scripts/recreate-failed-tasks.sh --dry-run
+#   bash scripts/recreate-failed-tasks.sh --status failed
+#   bash scripts/recreate-failed-tasks.sh --workflow wf-123
+#   bash scripts/recreate-failed-tasks.sh --parallel 2
+#   bash scripts/recreate-failed-tasks.sh --follow
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ELECTRON="$REPO_ROOT/packages/app/node_modules/.bin/electron"
+MAIN="$REPO_ROOT/packages/app/dist/main.js"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
+
+DRY_RUN=false
+STATUS_FILTER=""
+WORKFLOW_FILTER=""
+PARALLELISM=""
+FOLLOW=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --follow)
+      FOLLOW=true
+      shift
+      ;;
+    --status)
+      STATUS_FILTER="${2:-}"
+      if [[ -z "$STATUS_FILTER" ]]; then
+        echo "Missing value for --status" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --workflow)
+      WORKFLOW_FILTER="${2:-}"
+      if [[ -z "$WORKFLOW_FILTER" ]]; then
+        echo "Missing value for --workflow" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --parallel)
+      PARALLELISM="${2:-}"
+      if [[ -z "$PARALLELISM" ]]; then
+        echo "Missing value for --parallel" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      echo "Usage: $0 [--dry-run] [--follow] [--status <workflow-status>] [--workflow <id>] [--parallel <n>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "$PARALLELISM" ]] && ! [[ "$PARALLELISM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid --parallel value: $PARALLELISM (expected integer >= 1)" >&2
+  exit 1
+fi
+
+unset ELECTRON_RUN_AS_NODE
+SANDBOX_FLAG=""
+if [ "$(uname)" = "Linux" ]; then
+  SANDBOX_BIN="$REPO_ROOT/node_modules/.pnpm/electron@*/node_modules/electron/dist/chrome-sandbox"
+  # shellcheck disable=SC2086
+  if ! stat -c '%U:%a' $SANDBOX_BIN 2>/dev/null | grep -q '^root:4755$'; then
+    SANDBOX_FLAG="--no-sandbox"
+  fi
+  export LIBGL_ALWAYS_SOFTWARE=1
+fi
+
+headless_query() {
+  # shellcheck disable=SC2086
+  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
+}
+
+headless_mutation() {
+  node "$IPC_HELPER" exec -- "$@"
+}
+
+headless_workflow_ids() {
+  headless_query "$@" | grep -E '^wf-[0-9]+-[0-9]+$' || true
+}
+
+QUERY_ARGS=(query workflows --output label)
+if [[ -n "$STATUS_FILTER" ]]; then
+  QUERY_ARGS+=(--status "$STATUS_FILTER")
+fi
+
+WORKFLOWS="$(headless_workflow_ids "${QUERY_ARGS[@]}")"
+if [[ -n "$WORKFLOW_FILTER" ]]; then
+  WORKFLOWS="$(printf '%s\n' "$WORKFLOWS" | grep -Fx "$WORKFLOW_FILTER" || true)"
+fi
+
+if [[ -z "$WORKFLOWS" ]]; then
+  echo "No workflows found."
+  exit 0
+fi
+
+TARGETS_FILE="$(mktemp -t recreate-failed-tasks.targets.XXXXXX)"
+RESULTS_FILE=""
+cleanup() {
+  rm -f "$TARGETS_FILE"
+  if [[ -n "$RESULTS_FILE" ]]; then
+    rm -f "$RESULTS_FILE"
+  fi
+}
+trap cleanup EXIT
+
+while IFS= read -r WF_ID; do
+  [[ -z "$WF_ID" ]] && continue
+  TASKS_JSONL="$(headless_query query tasks --workflow "$WF_ID" --output jsonl | grep '^{' || true)"
+  [[ -z "$TASKS_JSONL" ]] && continue
+
+  WORKFLOW_TASKS_JSONL="$TASKS_JSONL" python3 - "$WF_ID" <<'PY' >> "$TARGETS_FILE"
+import json
+import os
+import sys
+
+workflow_id = sys.argv[1]
+raw = os.environ.get("WORKFLOW_TASKS_JSONL", "").strip()
+if not raw:
+    raise SystemExit(0)
+
+tasks = [json.loads(line) for line in raw.splitlines() if line.strip()]
+task_by_id = {task["id"]: task for task in tasks if task.get("id")}
+selected_statuses = {"pending", "failed"}
+
+for task in tasks:
+    task_id = task.get("id")
+    if not task_id:
+        continue
+    if task.get("status") not in selected_statuses:
+        continue
+
+    deps = task.get("dependencies", [])
+    if all((task_by_id.get(dep_id) or {}).get("status") == "completed" for dep_id in deps):
+        print(f"{workflow_id}\t{task_id}")
+PY
+done <<< "$WORKFLOWS"
+
+if [[ ! -s "$TARGETS_FILE" ]]; then
+  echo "No pending/failed frontier tasks found."
+  exit 0
+fi
+
+WORKFLOW_IDS="$(cut -f1 "$TARGETS_FILE" | awk '!seen[$0]++')"
+WORKFLOW_COUNT="$(printf '%s\n' "$WORKFLOW_IDS" | wc -l | tr -d ' ')"
+TARGET_COUNT="$(wc -l < "$TARGETS_FILE" | tr -d ' ')"
+
+if [[ -z "$PARALLELISM" ]]; then
+  PARALLELISM=1
+fi
+
+echo "Found $TARGET_COUNT frontier task(s) across $WORKFLOW_COUNT workflow(s)."
+echo "Parallelism: $PARALLELISM"
+echo "Follow mode: $FOLLOW"
+echo ""
+
+if $DRY_RUN; then
+  IDX=0
+  while IFS= read -r WF_ID; do
+    [[ -z "$WF_ID" ]] && continue
+    IDX=$((IDX + 1))
+    echo "[$IDX/$WORKFLOW_COUNT] $WF_ID"
+    while IFS=$'\t' read -r TARGET_WF TASK_ID; do
+      [[ "$TARGET_WF" == "$WF_ID" ]] || continue
+      echo "         (dry-run) would run: recreate-task $TASK_ID"
+    done < "$TARGETS_FILE"
+    echo ""
+  done <<< "$WORKFLOW_IDS"
+
+  echo "---"
+  echo "Dry run complete. $TARGET_COUNT frontier task(s) would be recreated."
+  exit 0
+fi
+
+launch_one_workflow() {
+  local wf_id="$1"
+  local log_file="$2"
+  local failed=0
+  local task_id=""
+  local cmd_out=""
+  local code=0
+
+  : > "$log_file"
+  while IFS=$'\t' read -r TARGET_WF TASK_ID; do
+    [[ "$TARGET_WF" == "$wf_id" ]] || continue
+    task_id="$TASK_ID"
+
+    {
+      echo "[$wf_id] recreate-task $task_id"
+      set +e
+      cmd_out="$(headless_mutation --no-track recreate-task "$task_id" 2>&1)"
+      code=$?
+      set -e
+      printf "%s\n" "$cmd_out"
+      if [[ "$code" -eq 0 ]]; then
+        echo "[$wf_id] OK $task_id"
+      else
+        echo "[$wf_id] FAILED $task_id (exit $code)"
+        failed=1
+      fi
+      echo ""
+    } >> "$log_file"
+  done < "$TARGETS_FILE"
+
+  if [[ "$failed" -eq 0 ]]; then
+    echo "[$wf_id] OK"
+    return 0
+  fi
+
+  echo "[$wf_id] FAILED"
+  return 1
+}
+
+FAILED=0
+SUCCEEDED=0
+IDX=0
+
+if $FOLLOW; then
+  RESULTS_FILE="$(mktemp -t recreate-failed-tasks-results.XXXXXX)"
+  LOG_DIR="$(mktemp -d -t recreate-failed-tasks-logs.XXXXXX)"
+  PIDS=()
+
+  while IFS= read -r WF_ID; do
+    [[ -z "$WF_ID" ]] && continue
+    IDX=$((IDX + 1))
+    echo "[queue $IDX/$WORKFLOW_COUNT] $WF_ID"
+    log_file="$LOG_DIR/${WF_ID}.log"
+    (
+      if launch_one_workflow "$WF_ID" "$log_file"; then
+        printf "%s\tSUCCEEDED\n" "$WF_ID" >> "$RESULTS_FILE"
+      else
+        printf "%s\tFAILED\n" "$WF_ID" >> "$RESULTS_FILE"
+      fi
+      cat "$log_file"
+    ) &
+    PIDS+=("$!")
+
+    while [[ "$(jobs -pr | wc -l | tr -d ' ')" -ge "$PARALLELISM" ]]; do
+      sleep 0.2
+    done
+  done <<< "$WORKFLOW_IDS"
+
+  for pid in "${PIDS[@]}"; do
+    wait "$pid" || true
+  done
+
+  while IFS=$'\t' read -r _wf result; do
+    case "$result" in
+      SUCCEEDED) SUCCEEDED=$((SUCCEEDED + 1)) ;;
+      FAILED) FAILED=$((FAILED + 1)) ;;
+    esac
+  done < "$RESULTS_FILE"
+else
+  LOG_DIR="$(mktemp -d -t recreate-failed-tasks-logs.XXXXXX)"
+  DISPATCHED=0
+  RESULTS_FILE="$(mktemp -t recreate-failed-tasks-results.XXXXXX)"
+  PIDS=()
+
+  while IFS= read -r WF_ID; do
+    [[ -z "$WF_ID" ]] && continue
+    IDX=$((IDX + 1))
+    log_file="$LOG_DIR/${WF_ID}.log"
+    (
+      if launch_one_workflow "$WF_ID" "$log_file"; then
+        printf "%s\tSUCCEEDED\n" "$WF_ID" >> "$RESULTS_FILE"
+      else
+        printf "%s\tFAILED\n" "$WF_ID" >> "$RESULTS_FILE"
+      fi
+    ) &
+    PIDS+=("$!")
+    echo "[dispatch $IDX/$WORKFLOW_COUNT] $WF_ID log=$log_file"
+
+    while [[ "$(jobs -pr | wc -l | tr -d ' ')" -ge "$PARALLELISM" ]]; do
+      sleep 0.2
+    done
+  done <<< "$WORKFLOW_IDS"
+
+  for pid in "${PIDS[@]}"; do
+    wait "$pid" || true
+  done
+
+  while IFS=$'\t' read -r _wf result; do
+    case "$result" in
+      SUCCEEDED)
+        DISPATCHED=$((DISPATCHED + 1))
+        ;;
+      FAILED)
+        FAILED=$((FAILED + 1))
+        ;;
+    esac
+  done < "$RESULTS_FILE"
+fi
+
+echo "---"
+if $FOLLOW; then
+  echo "Done. $SUCCEEDED succeeded, $FAILED failed out of $WORKFLOW_COUNT."
+  echo "Logs: $LOG_DIR"
+  if [[ "$FAILED" -ne 0 ]]; then
+    exit 1
+  fi
+else
+  echo "Submitted $DISPATCHED workflow(s) with bounded concurrency. Logs: $LOG_DIR"
+  if [[ "$FAILED" -ne 0 ]]; then
+    echo "$FAILED workflow(s) failed to submit."
+    exit 1
+  fi
+fi

--- a/scripts/retry-all.sh
+++ b/scripts/retry-all.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Retry every workflow via the existing workflow-scope retry script.
+# This intentionally does not do any rebase/fresh-base work.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+exec bash "$REPO_ROOT/scripts/retry-failed-and-pending-all-workflows.sh" "$@"

--- a/scripts/retry-failed-and-pending-all-workflows.sh
+++ b/scripts/retry-failed-and-pending-all-workflows.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RUNNER="$REPO_ROOT/run.sh"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 
 DRY_RUN=false
 STATUS_FILTER=""
@@ -118,6 +119,7 @@ if $DRY_RUN; then
 else
   FAILED=0
   SUCCEEDED=0
+  DISPATCHED=0
   IDX=0
 
   launch_one_workflow() {
@@ -127,7 +129,7 @@ else
     local code=0
 
     set +e
-    cmd_out="$("$RUNNER" --headless retry "$wf_id" --no-track 2>&1)"
+    cmd_out="$(node "$IPC_HELPER" exec --no-track -- retry "$wf_id" 2>&1)"
     code=$?
     set -e
 
@@ -182,32 +184,40 @@ else
     rm -f "$RESULTS_FILE"
   else
     LOG_DIR="$(mktemp -d -t retry-failed-logs.XXXXXX)"
-    DISPATCHED=0
-    PIDS=()
     RESULT_FILE="$(mktemp -t retry-failed-results.XXXXXX)"
-
+    COMMANDS_FILE="$(mktemp -t retry-failed-commands.XXXXXX)"
+    OUTPUT_JSONL="$(mktemp -t retry-failed-output.XXXXXX)"
     while IFS= read -r WF_ID; do
       [[ -z "$WF_ID" ]] && continue
       IDX=$((IDX + 1))
-      log_file="$LOG_DIR/${WF_ID}.log"
-      (
-        if launch_one_workflow "$WF_ID" "$log_file"; then
-          printf "%s\tSUCCEEDED\n" "$WF_ID" >> "$RESULT_FILE"
-        else
-          printf "%s\tFAILED\n" "$WF_ID" >> "$RESULT_FILE"
-        fi
-      ) &
-      PIDS+=("$!")
-      echo "[dispatch $IDX/$TOTAL] $WF_ID log=$log_file"
-
-      while [[ "$(jobs -pr | wc -l | tr -d ' ')" -ge "$PARALLELISM" ]]; do
-        sleep 0.2
-      done
+      printf '{"label":"%s","workflowId":"%s","args":["retry","%s"]}\n' "$WF_ID" "$WF_ID" "$WF_ID" >> "$COMMANDS_FILE"
+      echo "[dispatch $IDX/$TOTAL] $WF_ID log=$LOG_DIR/${WF_ID}.log"
     done <<<"$WORKFLOWS"
 
-    for pid in "${PIDS[@]}"; do
-      wait "$pid" || true
-    done
+    node "$IPC_HELPER" batch-exec --no-track --parallel "$PARALLELISM" < "$COMMANDS_FILE" > "$OUTPUT_JSONL"
+    python3 - "$RESULT_FILE" "$LOG_DIR" "$OUTPUT_JSONL" <<'PY'
+import json
+import pathlib
+import sys
+
+result_file = pathlib.Path(sys.argv[1])
+log_dir = pathlib.Path(sys.argv[2])
+output_jsonl = pathlib.Path(sys.argv[3])
+
+for raw in output_jsonl.read_text(encoding="utf-8").splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    item = json.loads(raw)
+    workflow_id = item.get("workflowId") or item.get("label") or "unknown"
+    log_path = log_dir / f"{workflow_id}.log"
+    with log_path.open("w", encoding="utf-8") as handle:
+        handle.write(raw + "\n")
+    with result_file.open("a", encoding="utf-8") as handle:
+        handle.write(f"{workflow_id}\t{'SUCCEEDED' if item.get('ok') else 'FAILED'}\n")
+PY
+    rm -f "$COMMANDS_FILE"
+    rm -f "$OUTPUT_JSONL"
 
     while IFS=$'\t' read -r _wf result; do
       case "$result" in


### PR DESCRIPTION
## Summary

This branch hardens several owner and review-control paths that were leaving workflows in misleading or unrecoverable states.

- adds normalized agent session inspection state for Codex and Claude so approval/review surfaces can tell whether a session is still running, finished, or errored
- moves bulk retry/recreate/rebase scripts onto direct headless IPC batching so they stop paying one client startup per workflow submission
- recovers expired workflow mutation leases on owner startup even when general auto-run is disabled, preventing `fix-with-agent` intents from staying stranded forever after an owner restart
- fixes merge-gate PR polling to use persisted review context, preferring the full PR URL and merge workspace over repo-root `cwd`, which prevents false auto-completion when different repos share the same PR number

## Architecture

### Before

```mermaid
graph TD
    A[Headless bulk scripts] --> B[Spawn one headless client per workflow]
    B --> C[Owner IPC]
    D[Owner restart] --> E[Expired workflow mutation requeued but not resumed]
    F[Merge gate review task] --> G[Poll bare reviewId in TaskRunner.cwd]
    G --> H[Wrong repo PR can mark merge gate completed]
    I[Approval modal] --> J[Raw session messages only]
```

### After

```mermaid
graph TD
    A[Headless bulk scripts] --> B[Batch headless.exec IPC submissions]
    D[Owner restart] --> E[Expired workflow mutations requeued and resumed]
    F[Merge gate review task] --> G[Poll persisted reviewUrl/reviewId/workspacePath]
    G --> H[Correct repo PR state drives merge gate completion]
    I[Approval modal] --> J[Normalized session state from driver inspection]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/codex-session-driver.test.ts src/__tests__/claude-session-driver.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-session.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/approval-modal.test.tsx`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/persisted-workflow-mutation-coordinator.test.ts src/__tests__/workflow-mutation-startup.test.ts`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/github-merge-gate-provider.test.ts src/__tests__/task-runner.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 4eb2e427 ca73a0c7 5b30cbeb 2215e795 cbca3f83`
- Post-revert steps: Manually repair any merge gates or workflow mutations that were reset during investigation if needed.
- Data migration? No
