### PR TITLE
Fix stale SSH worktree owner cleanup

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -338,17 +338,96 @@ branch refs/heads/experiment/test-task-oldhash
         ].join('\n');
       }
       if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (phase === 'cleanup_worktree') {
+        cleanupScript = script;
+        return '';
+      }
       if (script.includes('worktree list --porcelain')) {
         return `worktree ${ownerPath}
 HEAD deadbeef
 branch refs/heads/${targetBranch}
 `;
       }
+      if (script.includes('rev-parse --abbrev-ref HEAD')) return 'not-the-target-branch\n';
+      return '';
+    });
+
+    const setupTaskBranchSpy = vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any) => handle,
+    );
+
+    const req = makeRequest({
+      actionType: 'command',
+      actionId: 'test-task-conflict',
+      inputs: {
+        command: 'pnpm test',
+        description: 'run tests',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    });
+
+    try {
+      await ssh.start(req);
+
+      const encodedPaths = cleanupScript.match(/WORKTREES_B64="([^"]+)"/)?.[1];
+      const decodedPaths = Buffer.from(encodedPaths ?? '', 'base64').toString('utf8');
+      expect(decodedPaths).toContain(ownerPath);
+      expect(setupTaskBranchSpy).toHaveBeenCalled();
+    } finally {
+      if (prevCleanup === undefined) {
+        delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+      } else {
+        process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = prevCleanup;
+      }
+    }
+  });
+
+  it('cleans up a stale exact-branch owner when HEAD probing fails even with cleanup disabled', async () => {
+    const prevCleanup = process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+    delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+    }) as any;
+
+    const repoHash = computeRepoUrlHash('git@github.com:owner/repo.git');
+    const baseHead = 'abc123def456abc123def456abc123def456abc1';
+    const branchHash = computeContentHash(
+      'test-task-conflict',
+      'pnpm test',
+      undefined,
+      [],
+      baseHead,
+    );
+    const targetBranch = buildExperimentBranchName('test-task-conflict', '', branchHash);
+    const ownerPath = `/home/testuser/.invoker/worktrees/${repoHash}/stale-owner-${branchHash}`;
+    let cleanupScript = '';
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string, phase?: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return [
+          '__INVOKER_BASE_REF__=origin/main',
+          `__INVOKER_BASE_HEAD__=${baseHead}`,
+        ].join('\n');
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
       if (phase === 'cleanup_worktree') {
         cleanupScript = script;
         return '';
       }
-      if (script.includes('rev-parse --abbrev-ref HEAD')) return 'not-the-target-branch\n';
+      if (script.includes('worktree list --porcelain')) {
+        return `worktree ${ownerPath}
+HEAD deadbeef
+branch refs/heads/${targetBranch}
+`;
+      }
+      if (script.includes('rev-parse --abbrev-ref HEAD')) {
+        throw createSshRemoteScriptError(1, '', `bash: line 1: cd: ${ownerPath}: No such file or directory\n`);
+      }
       return '';
     });
 

--- a/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
@@ -74,6 +74,41 @@ describe('SSH worktree metadata repro', () => {
     }).toThrow(new RegExp(`already used by worktree at '${realOldPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
   });
 
+  it('reproduces a same-branch relaunch failure when the worktree dir is deleted without clearing git admin state', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-worktree-race-repro-'));
+    tempRoots.push(root);
+
+    const repoDir = join(root, 'repo');
+    const worktreePath = join(root, 'experiment-wf-1-run-app-retry-tests-g0.t5.aaaa-12345678');
+    const branch = 'experiment/wf-1/run-app-retry-tests/g0.t5.aaaa-12345678';
+
+    execSync(`mkdir -p ${JSON.stringify(repoDir)}`);
+    git('git init -b master', repoDir);
+    git('git config user.email "test@example.com"', repoDir);
+    git('git config user.name "Test User"', repoDir);
+    writeFileSync(join(repoDir, 'README.md'), 'seed\n');
+    git('git add README.md', repoDir);
+    git('git commit -m "seed"', repoDir);
+
+    // First launch claims the branch and creates the worktree.
+    git(`git worktree add -B ${JSON.stringify(branch)} ${JSON.stringify(worktreePath)} master`, repoDir);
+    expect(existsSync(worktreePath)).toBe(true);
+
+    // Raw directory deletion leaves git's worktree admin entry behind.
+    rmSync(worktreePath, { recursive: true, force: true });
+    expect(existsSync(worktreePath)).toBe(false);
+
+    const porcelain = git('git worktree list --porcelain', repoDir);
+    expect(porcelain).toContain(`branch refs/heads/${branch}`);
+    expect(porcelain).toContain(`worktree ${worktreePath}`);
+
+    // Second launch of the same task/branch now collides with the stale admin
+    // registration, even though the filesystem path is gone.
+    expect(() => {
+      git(`git worktree add -B ${JSON.stringify(branch)} ${JSON.stringify(worktreePath)} master`, repoDir);
+    }).toThrow(new RegExp(`already used by worktree at '${worktreePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}'`));
+  });
+
   it('proves TaskRunner should persist the owning worktree path on SSH startup failure', async () => {
     const ownerPath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-bc7a0b71';
     const branch = 'experiment/wf-1/test-execution-engine-b68b146f';

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -373,7 +373,13 @@ echo ${payloadB64} | base64 -d | bash -se
           headMatchesTargetBranch: abbrevRefMatchesBranch(head, experimentBranch),
         };
       } catch {
-        exactBranchCandidate = undefined;
+        // If the branch still appears in `git worktree list --porcelain` but we
+        // cannot read its HEAD, treat it as a stale owner that must be cleaned
+        // up before recreating the canonical branch/worktree pair.
+        exactBranchCandidate = {
+          path: reuseAbs,
+          headMatchesTargetBranch: false,
+        };
       }
     }
 
@@ -397,11 +403,10 @@ echo ${payloadB64} | base64 -d | bash -se
       case 'rename_reuse':
         throw new Error('SSH managed workspaces do not support same-task different-branch rename reuse');
       case 'recreate': {
-        // Workspace cleanup is gated by INVOKER_ENABLE_WORKSPACE_CLEANUP. With
-        // attemptId mixed into the branch hash, the canonical worktree path
-        // for the new attempt has never existed, so cleanup is unnecessary
-        // for correctness. Re-enable the env flag if you need disk hygiene.
-        if (isWorkspaceCleanupEnabled()) {
+        // General workspace cleanup remains opt-in for disk hygiene, but exact
+        // branch-owner collisions must always be reconciled for correctness.
+        const needsOwnerCleanup = !!exactBranchCandidate;
+        if (isWorkspaceCleanupEnabled() || needsOwnerCleanup) {
           const cleanupScript = buildWorktreeCleanupScript({
             remoteClone,
             worktreePaths: worktreePlan.cleanupPaths,

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -257,12 +257,12 @@ while IFS= read -r WT; do
   [ -z "$WT" ] && continue
   ${bashNormalizeTildePath('WT')}
   mkdir -p "$(dirname "$WT")"
-  if [ -e "$WT" ]; then
+  if git -C "$CLONE" worktree list --porcelain | grep -Fq "worktree $WT"; then
     echo "[SshGitExec] Removing stale worktree path: $WT"
     git -C "$CLONE" worktree remove --force "$WT" 2>/dev/null || true
-    rm -rf "$WT"
     git -C "$CLONE" worktree prune 2>/dev/null || true
   fi
+  rm -rf "$WT"
 done < <(echo "$WORKTREES_B64" | base64 -d)
 `;
 }


### PR DESCRIPTION
## Summary

Clean up stale SSH worktree owner state more aggressively before provisioning a new remote worktree.

- remove leaked remote worktree registrations and paths before reuse
- add focused SSH executor regression coverage for stale-owner cleanup and metadata recovery

## Architecture

### Before

```mermaid
graph TD
    A[SSH task launch] --> B[Existing worktree path leaks]
    B --> C[git worktree add fails]
```

### After

```mermaid
graph TD
    A[SSH task launch] --> B[Reconcile stale registration and path]
    B --> C[Provision clean remote worktree]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts src/__tests__/ssh-worktree-metadata-repro.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert eee48b90`
- Post-revert steps: None
- Data migration? No
