### PR TITLE
Add structured logging, config visibility, and build metadata

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -127,6 +127,9 @@ import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './work
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
 import { listOpenFixIntentsForTask } from './auto-fix-intents.js';
 
+declare const __BUILD_SHA__: string | undefined;
+declare const __BUILD_VERSION__: string | undefined;
+
 // ── Detect headless mode ─────────────────────────────────────
 
 // Electron passes extra args after `--` or interleaves them.
@@ -232,6 +235,9 @@ interface HeadlessExecMutationPayload {
 // Root logger: created early in initServices() once persistence is available.
 // Before initServices(), use the pre-init logger (file-only, no DB).
 let logger: Logger = new FileAndDbLogger({ module: 'main' });
+const buildSha = typeof __BUILD_SHA__ !== 'undefined' ? __BUILD_SHA__ : 'dev';
+const buildVersion = typeof __BUILD_VERSION__ !== 'undefined' ? __BUILD_VERSION__ : 'dev';
+logger.info(`Invoker ${buildVersion} (${buildSha})`, { module: 'startup' });
 
 process.on('uncaughtException', (err) => {
   try {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -261,6 +261,26 @@ const invokerConfig: InvokerConfig = (() => {
   }
 })();
 
+function getSafeInvokerConfigForLogging(config: InvokerConfig): Record<string, unknown> {
+  const safeConfig = { ...config } as Record<string, unknown> & {
+    docker?: InvokerConfig['docker'];
+    imageStorage?: InvokerConfig['imageStorage'];
+    r2?: unknown;
+  };
+  delete safeConfig.r2;
+  if (safeConfig.imageStorage) {
+    safeConfig.imageStorage = {
+      ...safeConfig.imageStorage,
+      accessKeyId: '<redacted>',
+      secretAccessKey: '<redacted>',
+    };
+  }
+  if (safeConfig.docker?.secretsFile) {
+    safeConfig.docker = { ...safeConfig.docker, secretsFile: '<redacted>' };
+  }
+  return safeConfig;
+}
+
 const effectiveMaxConcurrency = resolveEffectiveMaxConcurrency(
   invokerConfig.maxConcurrency,
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
@@ -374,8 +394,11 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
 
   const startupSyncMode = options?.startupSyncMode ?? 'all';
   const initLog = isHeadless
-    ? (...args: unknown[]) => { process.stderr.write(args.join(' ') + '\n'); }
-    : (msg: string) => { logger.info(msg, { module: 'init' }); };
+    ? (msg: string, meta?: Record<string, unknown>) => {
+      process.stderr.write(meta ? `${msg} ${JSON.stringify(meta)}\n` : `${msg}\n`);
+    }
+    : (msg: string, meta?: Record<string, unknown>) => { logger.info(msg, { ...meta, module: 'init' }); };
+  initLog('Effective configuration', { config: getSafeInvokerConfigForLogging(invokerConfig) });
   const workflows = persistence.listWorkflows();
   if (startupSyncMode === 'all') {
     try {
@@ -2398,6 +2421,7 @@ if (isHeadless) {
     logger.info(`Database: ${dbPath}`, { module: 'init' });
     logger.info(`Repo root: ${repoRoot}`, { module: 'init' });
     logger.info(`Config: disableAutoRunOnStartup=${invokerConfig.disableAutoRunOnStartup ?? false}`, { module: 'init' });
+    logger.info('Effective configuration', { config: getSafeInvokerConfigForLogging(invokerConfig), module: 'startup' });
     recordStartupMark('startup.ready-for-window');
 
     // Forward deltas to renderer and keep snapshot cache in sync so

--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -1,5 +1,8 @@
+import { execSync } from 'child_process';
 import { defineConfig } from 'tsup';
 import { cpSync } from 'node:fs';
+
+const gitSha = execSync('git rev-parse --short HEAD').toString().trim();
 
 export default defineConfig({
   entry: ['src/main.ts', 'src/preload.ts', 'src/headless-client.ts'],
@@ -16,6 +19,10 @@ export default defineConfig({
     'yaml',
   ],
   clean: true,
+  define: {
+    __BUILD_SHA__: JSON.stringify(gitSha),
+    __BUILD_VERSION__: JSON.stringify(require('./package.json').version),
+  },
   onSuccess: async () => {
     cpSync('assets', 'dist/assets', { recursive: true });
   },

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -7,7 +7,7 @@ import { TaskRunner } from '../task-runner.js';
 import { collectTransitiveNonMergeTaskIds } from '../merge-runner.js';
 import { SshExecutor } from '../ssh-executor.js';
 import type { TaskState } from '@invoker/workflow-core';
-import type { WorkResponse } from '@invoker/contracts';
+import type { WorkResponse, Logger } from '@invoker/contracts';
 import { EventEmitter } from 'events';
 
 /**
@@ -81,6 +81,18 @@ function createExecutorWithTasks(tasks: Map<string, TaskState>): TaskRunner {
     executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
     cwd: '/tmp',
   });
+}
+
+function createMockLogger(): Logger {
+  const logger: Logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child: vi.fn(),
+  };
+  (logger.child as any).mockReturnValue(logger);
+  return logger;
 }
 
 const tempWorkspaces: string[] = [];
@@ -2945,14 +2957,14 @@ describe('TaskRunner', () => {
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
 
-      const logSpy = vi.spyOn(console, 'log');
-
       const mergeTask = makeTask({
         id: '__merge__wf-1',
         status: 'running',
         dependencies: ['t1'],
         config: { isMergeNode: true, workflowId: 'wf-1' },
       });
+
+      const logSpy = vi.spyOn(console, 'log');
 
       await (executor as any).executeMergeNode(mergeTask);
 

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -14,7 +14,7 @@ import { homedir } from 'node:os';
 import { scopePlanTaskId } from '@invoker/workflow-core';
 import type { Orchestrator, TaskState, ExperimentVariant, ExecutorType } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { WorkRequest, WorkResponse, ActionType } from '@invoker/contracts';
+import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
 import type { Executor, ExecutorHandle } from './executor.js';
 import { BaseExecutor } from './base-executor.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
@@ -75,6 +75,14 @@ function getExecutorStartTimeoutMs(): number {
   return parsed;
 }
 
+const NOOP_LOGGER: Logger = {
+  debug: () => {},
+  info: () => {},
+  warn: () => {},
+  error: () => {},
+  child: () => NOOP_LOGGER,
+};
+
 // ── Callbacks ─────────────────────────────────────────────
 
 export interface TaskRunnerCallbacks {
@@ -121,6 +129,7 @@ export interface TaskRunnerConfig {
   };
   /** Shared execution agents (Claude, Codex). Passed into lazily constructed executors. */
   executionAgentRegistry?: AgentRegistry;
+  logger?: Logger;
 }
 
 // ── TaskRunner ──────────────────────────────────────────
@@ -139,6 +148,7 @@ export class TaskRunner {
   private getRemoteTargets: () => Record<string, { host: string; user: string; sshKeyPath: string; port?: number; managedWorkspaces?: boolean; remoteInvokerHome?: string; provisionCommand?: string }>;
   private dockerConfig: { imageName?: string; secretsFile?: string };
   private executionAgentRegistry?: AgentRegistry;
+  private logger: Logger;
   /** Cache for SSH executors, keyed by remoteTargetId. One instance per target for correct git locking. */
   private sshExecutorCache = new Map<string, SshExecutor>();
 
@@ -183,7 +193,7 @@ export class TaskRunner {
     try {
       return await executor.getRepoPool().ensureClone(trimmed);
     } catch (err) {
-      console.warn(`[merge] ensureRepoMirrorPath failed for ${trimmed}: ${err}`);
+      this.logger.warn(`[merge] ensureRepoMirrorPath failed for ${trimmed}`, { err });
       return undefined;
     }
   }
@@ -209,6 +219,7 @@ export class TaskRunner {
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
     this.dockerConfig = config.dockerConfig ?? {};
     this.executionAgentRegistry = config.executionAgentRegistry;
+    this.logger = config.logger ?? NOOP_LOGGER;
   }
 
   /**
@@ -307,7 +318,7 @@ export class TaskRunner {
         return;
       }
 
-      console.error(`[TaskRunner] executeTask failed for task=${task.id}:`, err);
+      this.logger.error(`[TaskRunner] executeTask failed for task=${task.id}`, { err });
       const launchFailedAt = new Date();
       try {
         const latest = this.orchestrator.getTask(task.id);
@@ -543,13 +554,13 @@ export class TaskRunner {
     const launchAccepted =
       this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true;
     if (!launchAccepted) {
-      console.warn(
+      this.logger.warn(
         `[TaskRunner] launch rejected as stale/non-executable for task=${task.id} attemptId=${attemptId}; killing spawned process`,
       );
       try {
         await executor.kill(handle);
       } catch (killErr) {
-        console.warn(`[TaskRunner] failed to kill rejected launch for task=${task.id}: ${killErr}`);
+        this.logger.warn(`[TaskRunner] failed to kill rejected launch for task=${task.id}`, { killErr });
       }
       await this.cleanupPerTaskDockerExecutor(task);
       return;
@@ -658,7 +669,7 @@ export class TaskRunner {
               this.executeTasks(newlyStarted);
             }
           } catch (err) {
-            console.error(`[TaskRunner] onComplete handler failed for task=${task.id}:`, err);
+            this.logger.error(`[TaskRunner] onComplete handler failed for task=${task.id}`, { err });
             const errResponse: WorkResponse = {
               requestId: response.requestId,
               actionId: task.id,
@@ -953,7 +964,7 @@ export class TaskRunner {
           child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
           child.stderr?.on('data', (d: Buffer) => {
             stderr += d.toString();
-            console.log(`[visual-proof] ${d.toString().trimEnd()}`);
+            this.logger.info(`[visual-proof] ${d.toString().trimEnd()}`);
           });
           child.on('error', (err) => reject(err));
           child.on('close', (code) => {
@@ -1017,7 +1028,10 @@ export class TaskRunner {
 
       return lines.join('\n');
     } catch (err) {
-      console.warn(`[visual-proof] Capture failed (non-blocking): ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.warn('[visual-proof] Capture failed (non-blocking)', {
+        error: err instanceof Error ? err.message : String(err),
+        err,
+      });
       return undefined;
     }
   }
@@ -1113,7 +1127,7 @@ export class TaskRunner {
         cloneSource = mirrorPath;
         originUrl = repoUrl;
       } else {
-        console.warn(`[createMergeWorktree] Pool mirror unavailable for ${repoUrl}, falling back to host repo`);
+        this.logger.warn(`[createMergeWorktree] Pool mirror unavailable for ${repoUrl}, falling back to host repo`);
       }
     }
 
@@ -1208,7 +1222,11 @@ export class TaskRunner {
     try {
       rmSync(dir, { recursive: true, force: true });
     } catch (err) {
-      console.warn(`[TaskRunner] removeMergeWorktree failed (best-effort): ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.warn('[TaskRunner] removeMergeWorktree failed (best-effort)', {
+        dir,
+        error: err instanceof Error ? err.message : String(err),
+        err,
+      });
     }
   }
 
@@ -1382,7 +1400,7 @@ export class TaskRunner {
         task.execution.reviewId &&
         !this.activePrPollers.has(task.id)
       ) {
-        console.log(`[merge-gate] Resuming PR polling for ${task.id} (PR ${task.execution.reviewId})`);
+        this.logger.info(`[merge-gate] Resuming PR polling for ${task.id} (PR ${task.execution.reviewId})`);
         this.startPrPolling(task.id, task.execution.reviewId, task.config.workflowId!);
       }
     }
@@ -1405,15 +1423,15 @@ export class TaskRunner {
             execution: { reviewStatus: status.statusText },
           });
           if (status.approved) {
-            console.log(`[merge-gate] PR ${task.execution.reviewId} approved (refresh), completing merge gate`);
+            this.logger.info(`[merge-gate] PR ${task.execution.reviewId} approved (refresh), completing merge gate`);
             this.stopPrPolling(task.id);
             await this.orchestrator.approve(task.id);
           } else if (status.rejected) {
-            console.log(`[merge-gate] PR ${task.execution.reviewId} rejected (refresh): ${status.statusText}`);
+            this.logger.info(`[merge-gate] PR ${task.execution.reviewId} rejected (refresh): ${status.statusText}`);
             this.stopPrPolling(task.id);
           }
         } catch (err) {
-          console.error(`[merge-gate] PR status check error for ${task.id}:`, err);
+          this.logger.error(`[merge-gate] PR status check error for ${task.id}`, { err });
         }
       }
     }
@@ -1435,16 +1453,16 @@ export class TaskRunner {
         });
 
         if (status.approved) {
-          console.log(`[merge-gate] PR ${reviewId} approved, completing merge gate`);
+          this.logger.info(`[merge-gate] PR ${reviewId} approved, completing merge gate`);
           this.stopPrPolling(taskId);
           await this.orchestrator.approve(taskId);
         } else if (status.rejected) {
-          console.log(`[merge-gate] PR ${reviewId} rejected: ${status.statusText}`);
+          this.logger.info(`[merge-gate] PR ${reviewId} rejected: ${status.statusText}`);
           this.stopPrPolling(taskId);
           // Leave in review_ready/awaiting_approval — user can retry
         }
       } catch (err) {
-        console.error(`[merge-gate] PR poll error for ${taskId}:`, err);
+        this.logger.error(`[merge-gate] PR poll error for ${taskId}`, { err });
         // Continue polling on transient errors
       }
     }, pollIntervalMs);
@@ -1479,15 +1497,15 @@ export class TaskRunner {
       });
 
       if (status.approved) {
-        console.log(`[merge-gate] PR ${reviewId} approved (manual check), completing merge gate`);
+        this.logger.info(`[merge-gate] PR ${reviewId} approved (manual check), completing merge gate`);
         this.stopPrPolling(taskId);
         await this.orchestrator.approve(taskId);
       } else if (status.rejected) {
-        console.log(`[merge-gate] PR ${reviewId} rejected (manual check): ${status.statusText}`);
+        this.logger.info(`[merge-gate] PR ${reviewId} rejected (manual check): ${status.statusText}`);
         this.stopPrPolling(taskId);
       }
     } catch (err) {
-      console.error(`[merge-gate] Manual PR check error for ${taskId}:`, err);
+      this.logger.error(`[merge-gate] Manual PR check error for ${taskId}`, { err });
     }
   }
 
@@ -1545,7 +1563,10 @@ export class TaskRunner {
     try {
       await dockerExec.destroyAll();
     } catch (err) {
-      console.warn(`[TaskRunner] cleanupPerTaskDockerExecutor destroyAll failed for ${dockerKey}: ${err instanceof Error ? err.message : String(err)}`);
+      this.logger.warn(`[TaskRunner] cleanupPerTaskDockerExecutor destroyAll failed for ${dockerKey}`, {
+        error: err instanceof Error ? err.message : String(err),
+        err,
+      });
     }
     this.executorRegistry.deregister(dockerKey);
   }
@@ -1728,11 +1749,11 @@ export class TaskRunner {
           // Push rebased branch from clone to origin (GitHub)
           await this.execGitIn(['push', '--force', 'origin', `${branch}:refs/heads/${branch}`], worktreeDir);
           rebasedBranches.push(branch);
-          console.log(`[rebase] Successfully rebased ${branch} onto ${baseBranch}`);
+          this.logger.info(`[rebase] Successfully rebased ${branch} onto ${baseBranch}`);
         } catch (err) {
           const msg = err instanceof Error ? err.message : String(err);
           errors.push(`${branch}: ${msg}`);
-          console.error(`[rebase] Failed to rebase ${branch}: ${msg}`);
+          this.logger.error(`[rebase] Failed to rebase ${branch}: ${msg}`, { branch, baseBranch, err });
           try { await this.execGitIn(['rebase', '--abort'], worktreeDir); } catch { /* no rebase in progress */ }
         }
       }

--- a/packages/workflow-core/src/__tests__/lifecycle-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/lifecycle-matrix.test.ts
@@ -207,16 +207,18 @@ describe('Step 17: canonical lifecycle matrix lock-in', () => {
       expect(typeof Orchestrator.prototype.restartTask).toBe('function');
 
       const orch = Object.create(Orchestrator.prototype) as Orchestrator;
+      const warnSpy = vi.fn();
+      (orch as unknown as { logger: { warn: typeof warnSpy } }).logger = {
+        warn: warnSpy,
+      } as never;
       const recreateSpy = vi.spyOn(orch, 'recreateTask').mockReturnValue([]);
       const retrySpy = vi.spyOn(orch, 'retryTask').mockReturnValue([]);
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
       try {
         orch.restartTask('t-x');
         expect(recreateSpy).toHaveBeenCalledTimes(1);
         expect(recreateSpy).toHaveBeenCalledWith('t-x');
         expect(retrySpy).not.toHaveBeenCalled();
       } finally {
-        warnSpy.mockRestore();
         recreateSpy.mockRestore();
         retrySpy.mockRestore();
       }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -4,7 +4,7 @@ import { rid, sid } from './scoped-test-helpers.js';
 import { Orchestrator, PlanConflictError, descriptionForMergeNode } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
 import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '../task-types.js';
-import type { WorkResponse } from '@invoker/contracts';
+import type { Logger, WorkResponse } from '@invoker/contracts';
 
 // ── In-Memory Persistence Mock ──────────────────────────────
 
@@ -205,6 +205,14 @@ class InMemoryBus implements OrchestratorMessageBus {
   }
 }
 
+const consoleLogger: Logger = {
+  debug: (msg, fields) => console.debug(msg, fields),
+  info: (msg, fields) => console.log(msg, fields),
+  warn: (msg, fields) => console.warn(msg, fields),
+  error: (msg, fields) => console.error(msg, fields),
+  child: () => consoleLogger,
+};
+
 // ── Helpers ─────────────────────────────────────────────────
 
 function makeResponse(overrides: Partial<WorkResponse>): WorkResponse {
@@ -239,6 +247,7 @@ describe('Orchestrator', () => {
       persistence,
       messageBus: bus,
       maxConcurrency: 3,
+      logger: consoleLogger,
     });
   });
 
@@ -502,7 +511,13 @@ describe('Orchestrator', () => {
         expect(orchestrator.getTask(taskId)?.status).toBe('running');
         expect(orchestrator.getTask(taskId)?.execution.selectedAttemptId).toBe(currentAttemptId);
         expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining(`STALE_ATTEMPT_REJECTED taskId=${taskId}`),
+          '[worker-response] STALE_ATTEMPT_REJECTED',
+          expect.objectContaining({
+            taskId,
+            responseAttemptId: oldAttemptId,
+            activeAttemptId: currentAttemptId,
+            workerResponseStatus: 'completed',
+          }),
         );
       } finally {
         warnSpy.mockRestore();
@@ -4261,8 +4276,8 @@ describe('Orchestrator', () => {
           (c) =>
             typeof c[0] === 'string' &&
             c[0].includes('handleCompleted') &&
-            c[0].includes('newly ready: [') &&
-            c[0].includes('/B]'),
+            Array.isArray(c[1]?.readyTaskIds) &&
+            c[1].readyTaskIds.some((id: string) => id.endsWith('/B')),
         ),
       ).toBe(true);
     });
@@ -4321,8 +4336,8 @@ describe('Orchestrator', () => {
           (c) =>
             typeof c[0] === 'string' &&
             c[0].includes('handleCompleted') &&
-            c[0].includes('newly ready: [') &&
-            c[0].includes('/D]'),
+            Array.isArray(c[1]?.readyTaskIds) &&
+            c[1].readyTaskIds.some((id: string) => id.endsWith('/D')),
         ),
       ).toBe(true);
       expect(orchestrator.getTask('D')!.status).toBe('running');
@@ -4430,7 +4445,12 @@ describe('Orchestrator', () => {
 
       expect(orchestrator.getTask('A')!.status).toBe('failed');
       expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('ignoring "completed" for non-executable task "A" (status=failed)'),
+        '[orchestrator] handleWorkerResponse: ignoring response for non-executable task',
+        expect.objectContaining({
+          taskId: 'A',
+          status: 'failed',
+          workerResponseStatus: 'completed',
+        }),
       );
     });
 
@@ -4638,7 +4658,7 @@ describe('Orchestrator', () => {
           (c) =>
             typeof c[0] === 'string' &&
             c[0].includes('selectExperiments') &&
-            c[0].includes('pivot-reconciliation'),
+            c[1]?.taskId?.includes('pivot-reconciliation'),
         ),
       ).toBe(true);
     });

--- a/packages/workflow-core/src/__tests__/restart-deprecation.test.ts
+++ b/packages/workflow-core/src/__tests__/restart-deprecation.test.ts
@@ -15,7 +15,7 @@ describe('restartTask deprecation shim', () => {
   // ── Orchestrator-level shim ──────────────────────────────────
 
   describe('Orchestrator.restartTask', () => {
-    let warnSpy: ReturnType<typeof vi.spyOn>;
+    let warnSpy: ReturnType<typeof vi.fn>;
     let recreateSpy: ReturnType<typeof vi.spyOn>;
     let retrySpy: ReturnType<typeof vi.spyOn>;
     let orch: Orchestrator;
@@ -25,11 +25,14 @@ describe('restartTask deprecation shim', () => {
       // only asserting delegation we don't need plan loading;
       // we stub the target methods directly.
       orch = Object.create(Orchestrator.prototype) as Orchestrator;
+      warnSpy = vi.fn();
+      (orch as unknown as { logger: { warn: typeof warnSpy } }).logger = {
+        warn: warnSpy,
+      } as never;
       // The shim only calls `this.recreateTask`, so stubbing
       // that out and asserting the call is sufficient.
       recreateSpy = vi.spyOn(orch, 'recreateTask').mockImplementation(() => []);
       retrySpy = vi.spyOn(orch, 'retryTask').mockImplementation(() => []);
-      warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
     });
 
     it('delegates restartTask to recreateTask (NOT retryTask)', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -22,7 +22,7 @@ import { TaskScheduler } from './scheduler.js';
 import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, TaskStatus } from '@invoker/workflow-graph';
 import type { ExecutorType } from '@invoker/workflow-graph';
 import { createTaskState, createAttempt } from '@invoker/workflow-graph';
-import type { WorkResponse } from '@invoker/contracts';
+import type { Logger, WorkResponse } from '@invoker/contracts';
 import { normalizeExecutorType } from '@invoker/workflow-graph';
 
 const MERGE_TRACE_LOG = resolve(homedir(), '.invoker', 'merge-trace.log');
@@ -74,6 +74,13 @@ const FIX_FAILURE_PREFIX_RE = /^\[Fix with (?:Claude|Agent) failed\] [^\n]*\n\n/
 const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
 const TRACE_PERSIST_SYNC = process.env.INVOKER_TRACE_PERSIST_SYNC === '1';
 const TRACE_WORKER_RESPONSE = process.env.INVOKER_TRACE_WORKER_RESPONSE === '1';
+const noopLogger: Logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+  child() { return noopLogger; },
+};
 
 function stripFixFailureWrapper(errorText: string): string {
   return errorText.replace(FIX_FAILURE_PREFIX_RE, '');
@@ -544,6 +551,7 @@ export function taskRepositoryFromPersistence(p: OrchestratorPersistence): TaskR
 export interface OrchestratorConfig {
   persistence: OrchestratorPersistence;
   messageBus: OrchestratorMessageBus;
+  logger?: Logger;
   /** Optional; defaults to an adapter wrapping `persistence`. */
   taskRepository?: TaskRepository;
   /** Optional callback for fire-and-forget task dispatch when tasks enter running/launching. */
@@ -581,6 +589,7 @@ export class Orchestrator {
   private readonly scheduler: TaskScheduler;
   private readonly persistence: OrchestratorPersistence;
   private readonly messageBus: OrchestratorMessageBus;
+  private readonly logger: Logger;
   private readonly taskRepository: TaskRepository;
   private readonly taskDispatcher?: (tasks: TaskState[]) => void;
   private readonly maxConcurrency: number;
@@ -618,6 +627,7 @@ export class Orchestrator {
     this.maxConcurrency = config.maxConcurrency ?? 3;
     this.persistence = config.persistence;
     this.messageBus = config.messageBus;
+    this.logger = config.logger ?? noopLogger;
     this.taskRepository = config.taskRepository ?? taskRepositoryFromPersistence(config.persistence);
     this.taskDispatcher = config.taskDispatcher;
     this.executorRoutingRules = config.executorRoutingRules ?? [];
@@ -684,12 +694,17 @@ export class Orchestrator {
     if (process.env.NODE_ENV !== 'test' && TRACE_PERSIST_SYNC) {
       const ex = updated.execution;
       const execKeys = changes.execution ? Object.keys(changes.execution).join(',') : '';
-      console.log(
-        `[persist-sync] taskId=${id} resolvedStatus=${updated.status} ` +
-          `isFixingWithAI=${ex.isFixingWithAI === true ? '1' : '0'} exitCode=${ex.exitCode ?? 'null'} ` +
-          `errorLen=${ex.error?.length ?? 0} pendingFix=${ex.pendingFixError ? '1' : '0'} ` +
-          `inputPrompt=${ex.inputPrompt ? '1' : '0'} changeStatus=${changes.status ?? '—'} execKeys=${execKeys || '—'}`,
-      );
+      this.logger.info('[persist-sync]', {
+        taskId: id,
+        resolvedStatus: updated.status,
+        isFixingWithAI: ex.isFixingWithAI === true,
+        exitCode: ex.exitCode ?? null,
+        errorLen: ex.error?.length ?? 0,
+        pendingFix: ex.pendingFixError !== undefined,
+        inputPrompt: ex.inputPrompt !== undefined,
+        changeStatus: changes.status ?? '—',
+        execKeys: execKeys || '—',
+      });
     }
     this.stateMachine.restoreTask(updated);
     if (!opts?.skipWorkflowStatusSync && changes.status !== undefined && existing.config.workflowId) {
@@ -1282,10 +1297,12 @@ export class Orchestrator {
     const readyTasks = this.stateMachine
       .getReadyTasks()
       .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
-    console.log(
-      `[orchestrator] startExecution: ready=${readyTasks.length} active=${activeAttempts} maxConcurrency=${this.maxConcurrency} ` +
-        `readyIds=[${readyTasks.map((task) => task.id).join(', ')}]`,
-    );
+    this.logger.info('[orchestrator] startExecution', {
+      ready: readyTasks.length,
+      active: activeAttempts,
+      maxConcurrency: this.maxConcurrency,
+      readyIds: readyTasks.map((task) => task.id),
+    });
     const started: TaskState[] = [];
 
     for (const task of readyTasks) {
@@ -1313,11 +1330,12 @@ export class Orchestrator {
         const activeAttemptId = earlyTask.execution.selectedAttemptId;
         if (response.attemptId) {
           if (!activeAttemptId || response.attemptId !== activeAttemptId) {
-            console.warn(
-              `[worker-response] STALE_ATTEMPT_REJECTED taskId=${earlyTask.id} ` +
-                `responseAttemptId=${response.attemptId} activeAttemptId=${activeAttemptId ?? 'none'} ` +
-                `workerResponseStatus=${response.status}`,
-            );
+            this.logger.warn('[worker-response] STALE_ATTEMPT_REJECTED', {
+              taskId: earlyTask.id,
+              responseAttemptId: response.attemptId,
+              activeAttemptId: activeAttemptId ?? 'none',
+              workerResponseStatus: response.status,
+            });
             return [];
           }
         }
@@ -1327,21 +1345,23 @@ export class Orchestrator {
           response.executionGeneration !== undefined &&
           response.executionGeneration !== activeGeneration
         ) {
-          console.warn(
-            `[worker-response] STALE_GENERATION_REJECTED taskId=${earlyTask.id} ` +
-              `responseGeneration=${response.executionGeneration} activeGeneration=${activeGeneration} ` +
-              `workerResponseStatus=${response.status}`,
-          );
+          this.logger.warn('[worker-response] STALE_GENERATION_REJECTED', {
+            taskId: earlyTask.id,
+            responseGeneration: response.executionGeneration,
+            activeGeneration,
+            workerResponseStatus: response.status,
+          });
           return [];
         }
       }
       if (earlyTask) {
         const executableStatuses = new Set(['running', 'fixing_with_ai']);
         if (!executableStatuses.has(earlyTask.status)) {
-          console.warn(
-            `[orchestrator] handleWorkerResponse: ignoring "${response.status}" for non-executable ` +
-              `task "${response.actionId}" (status=${earlyTask.status})`,
-          );
+          this.logger.warn('[orchestrator] handleWorkerResponse: ignoring response for non-executable task', {
+            workerResponseStatus: response.status,
+            taskId: response.actionId,
+            status: earlyTask.status,
+          });
           return [];
         }
       }
@@ -1353,16 +1373,18 @@ export class Orchestrator {
       const task = this.stateGetTask(response.actionId);
 
       if (!task) {
-        console.warn(
-          `[worker-response] PROTOCOL_FAILURE_UNKNOWN_TASK actionId=${response.actionId} parseError=${parseErr}`,
-        );
+        this.logger.warn('[worker-response] PROTOCOL_FAILURE_UNKNOWN_TASK', {
+          actionId: response.actionId,
+          parseError: parseErr,
+        });
         return [];
       }
 
       const canonicalTaskId = task.id;
-      console.warn(
-        `[worker-response] PROTOCOL_FAILURE taskId=${canonicalTaskId} parseError=${parseErr}`,
-      );
+      this.logger.warn('[worker-response] PROTOCOL_FAILURE', {
+        taskId: canonicalTaskId,
+        parseError: parseErr,
+      });
       return this.finalizeFailedTask(
         canonicalTaskId,
         {
@@ -1378,17 +1400,19 @@ export class Orchestrator {
     const taskId = parsed.taskId;
     const task = this.stateGetTask(taskId);
     if (!task) {
-      console.warn(`[worker-response] task not in graph taskId=${taskId} (stale response?)`);
+      this.logger.warn('[worker-response] task not in graph (stale response?)', { taskId });
       return [];
     }
 
     const canonicalTaskId = task.id;
     if (process.env.NODE_ENV !== 'test' && TRACE_WORKER_RESPONSE) {
-      console.log(
-        `[worker-response] write path parsedType=${parsed.type} taskId=${canonicalTaskId} ` +
-          `graphStatusBefore=${task.status} workerResponseStatus=${response.status} ` +
-          `executionGeneration=${response.executionGeneration}`,
-      );
+      this.logger.info('[worker-response] write path', {
+        parsedType: parsed.type,
+        taskId: canonicalTaskId,
+        graphStatusBefore: task.status,
+        workerResponseStatus: response.status,
+        executionGeneration: response.executionGeneration,
+      });
     }
 
     switch (parsed.type) {
@@ -1468,9 +1492,12 @@ export class Orchestrator {
         taskId: id,
         workspacePath: changes.execution.workspacePath ?? null,
       });
-      console.log(
-        `[merge-gate-workspace] setTask${status === 'review_ready' ? 'ReviewReady' : 'AwaitingApproval'} mergeNode=${id} ` +
-          `execution.workspacePath=${changes.execution.workspacePath ?? 'NULL'}`,
+      this.logger.info(
+        `[merge-gate-workspace] setTask${status === 'review_ready' ? 'ReviewReady' : 'AwaitingApproval'}`,
+        {
+          mergeNode: id,
+          workspacePath: changes.execution.workspacePath ?? 'NULL',
+        },
       );
     }
     this.writeAndSync(id, changes);
@@ -1512,12 +1539,16 @@ export class Orchestrator {
     if (task.status !== 'running' && task.status !== 'fixing_with_ai') {
       throw new Error(`Task ${tid} is not running or fixing with AI (status: ${task.status})`);
     }
-    console.log(`[setFixAwaitingApproval] taskId=${tid} agentSessionId=${task.execution.agentSessionId}`);
+    this.logger.info('[setFixAwaitingApproval]', {
+      taskId: tid,
+      agentSessionId: task.execution.agentSessionId,
+    });
     if (task.config.isMergeNode) {
-      console.log(
-        `[merge-gate-workspace] setFixAwaitingApproval mergeNode=${tid} ` +
-          `workspacePath unchanged by this call; current=${task.execution.workspacePath ?? 'none'}`,
-      );
+      this.logger.info('[merge-gate-workspace] setFixAwaitingApproval', {
+        mergeNode: tid,
+        workspacePath: task.execution.workspacePath ?? 'none',
+        note: 'workspacePath unchanged by this call',
+      });
       mergeTrace('GATE_WS_SET_FIX_AWAITING', {
         taskId: tid,
         workspacePath: task.execution.workspacePath ?? null,
@@ -1534,7 +1565,10 @@ export class Orchestrator {
         lastAgentName: task.execution.lastAgentName ?? task.execution.agentName,
       },
     };
-    console.log(`[setFixAwaitingApproval] delta.changes.execution=`, JSON.stringify(changes.execution));
+    this.logger.info('[setFixAwaitingApproval] delta.changes.execution', {
+      taskId: tid,
+      execution: changes.execution,
+    });
     this.writeAndSync(tid, changes);
     this.updateSelectedAttempt(tid, {
       status: 'needs_input',
@@ -1567,10 +1601,11 @@ export class Orchestrator {
         status: task?.status ?? 'NOT_FOUND',
         pendingFixError: task?.execution.pendingFixError !== undefined,
       });
-      console.log(
-        `[orchestrator.approve] skipped taskId=${taskId} ` +
-          (!task ? '(task not found)' : `(status=${task.status}, expected awaiting_approval|review_ready)`),
-      );
+      this.logger.info('[orchestrator.approve] skipped', {
+        taskId,
+        reason: !task ? 'task not found' : 'unexpected status',
+        status: task?.status,
+      });
       return [];
     }
 
@@ -1806,7 +1841,11 @@ export class Orchestrator {
       }
     }
     const readyTaskIds = this.stateMachine.findNewlyReadyTasks(reconId);
-    console.log(`[orchestrator] selectExperiment "${reconId}": ${readyTaskIds.length} newly ready: [${readyTaskIds.join(', ')}]`);
+    this.logger.info('[orchestrator] selectExperiment', {
+      taskId: reconId,
+      newlyReadyCount: readyTaskIds.length,
+      readyTaskIds,
+    });
     const started = this.autoStartReadyTasks(readyTaskIds);
     this.checkWorkflowCompletion();
     return started;
@@ -1889,16 +1928,20 @@ export class Orchestrator {
     }
 
     const readyTaskIds = this.stateMachine.findNewlyReadyTasks(reconId);
-    console.log(`[orchestrator] selectExperiments "${reconId}": ${readyTaskIds.length} newly ready: [${readyTaskIds.join(', ')}]`);
+    this.logger.info('[orchestrator] selectExperiments', {
+      taskId: reconId,
+      newlyReadyCount: readyTaskIds.length,
+      readyTaskIds,
+    });
     const started = this.autoStartReadyTasks(readyTaskIds);
     this.checkWorkflowCompletion();
     return started;
   }
 
   restartTask(taskId: string): TaskState[] {
-    console.warn(
-      `[orchestrator] restartTask("${taskId}") is deprecated. Routing to recreateTask. ` +
-        'Use retryTask() for lineage-preserving reset or recreateTask() for fresh-lineage reset explicitly.',
+    this.logger.warn(
+      '[orchestrator] restartTask is deprecated. Routing to recreateTask. Use retryTask() for lineage-preserving reset or recreateTask() for fresh-lineage reset explicitly.',
+      { taskId },
     );
     return this.recreateTask(taskId);
   }
@@ -1918,13 +1961,13 @@ export class Orchestrator {
     this.cancelActiveBeforeInvalidation('task', id);
 
     const prevStatus = task.status;
-    console.log(`[orchestrator] retryTask "${id}" (was ${prevStatus})`);
+    this.logger.info('[orchestrator] retryTask', { taskId: id, previousStatus: prevStatus });
     if (task.config.isMergeNode) {
-      console.log(
-        `[merge-gate-workspace] retryTask mergeNode=${id} ` +
-          `before reset workspacePath=${task.execution.workspacePath ?? 'none'} ` +
-          '(retryTask does not clear workspacePath)',
-      );
+      this.logger.info('[merge-gate-workspace] retryTask before reset', {
+        mergeNode: id,
+        workspacePath: task.execution.workspacePath ?? 'none',
+        note: 'retryTask does not clear workspacePath',
+      });
       mergeTrace('GATE_WS_RETRY_TASK_MERGE', {
         taskId: id,
         workspacePathBefore: task.execution.workspacePath ?? null,
@@ -1948,36 +1991,39 @@ export class Orchestrator {
       },
     };
     const t0 = this.stateGetTask(id)!;
-    console.log(
-      `[agent-session-trace] retryTask: before writeAndSync task="${id}" agentSessionId=${t0.execution.agentSessionId ?? 'null'} ` +
-        '(reset clears agentSessionId/containerId; branch/workspacePath unchanged)',
-    );
+    this.logger.info('[agent-session-trace] retryTask: before writeAndSync', {
+      taskId: id,
+      agentSessionId: t0.execution.agentSessionId ?? 'null',
+      note: 'reset clears agentSessionId/containerId; branch/workspacePath unchanged',
+    });
     const { affectedIds } = this.resetSubgraphToPending([id], resetChanges, {
       forceResetIds: new Set([id]),
     });
     const afterRt = this.stateGetTask(id)!;
-    console.log(
-      `[agent-session-trace] retryTask: after writeAndSync task="${id}" agentSessionId=${afterRt.execution.agentSessionId ?? 'null'}`,
-    );
+    this.logger.info('[agent-session-trace] retryTask: after writeAndSync', {
+      taskId: id,
+      agentSessionId: afterRt.execution.agentSessionId ?? 'null',
+    });
     if (afterRt.config.isMergeNode) {
-      console.log(
-        `[merge-gate-workspace] retryTask mergeNode=${id} ` +
-          `after reset workspacePath=${afterRt.execution.workspacePath ?? 'none'}`,
-      );
+      this.logger.info('[merge-gate-workspace] retryTask after reset', {
+        mergeNode: id,
+        workspacePath: afterRt.execution.workspacePath ?? 'none',
+      });
       mergeTrace('GATE_WS_RETRY_TASK_MERGE_AFTER', {
         taskId: id,
         workspacePathAfter: afterRt.execution.workspacePath ?? null,
       });
     }
     if (affectedIds.length > 1) {
-      console.log(
-        `[orchestrator] retryTask "${id}": invalidated ${affectedIds.length - 1} downstream task(s)`,
-      );
+      this.logger.info('[orchestrator] retryTask invalidated downstream tasks', {
+        taskId: id,
+        invalidatedCount: affectedIds.length - 1,
+      });
     }
 
     const readyTasks = this.stateMachine.getReadyTasks();
     const isReady = readyTasks.some((t) => t.id === id);
-    console.log(`[orchestrator] retryTask "${id}": ready=${isReady}`);
+    this.logger.info('[orchestrator] retryTask ready check', { taskId: id, ready: isReady });
     if (isReady) {
       const started = this.autoStartReadyTasks([id], Orchestrator.EXPEDITED_PRIORITY);
       if (started.some((t) => t.id === id)) return started;
@@ -2061,14 +2107,18 @@ export class Orchestrator {
     const { affectedIds } = this.resetSubgraphToPending(retryRootIds, resetChanges);
     const afterResetMs = Date.now();
 
-    console.log(
-      `[orchestrator] retryWorkflow invalidation: workflow=${workflowId} ` +
-      `roots=[${retryRootIds.join(', ')}] affected=${affectedIds.length}`,
-    );
-    console.log(
-      `[orchestrator] retryWorkflow: reset ${affectedIds.length}/${allTasks.length} tasks for ${workflowId} ` +
-        `(roots=${retryRootIds.length}, preserved completed outside invalidated subgraphs)`,
-    );
+    this.logger.info('[orchestrator] retryWorkflow invalidation', {
+      workflowId,
+      roots: retryRootIds,
+      affected: affectedIds.length,
+    });
+    this.logger.info('[orchestrator] retryWorkflow reset summary', {
+      workflowId,
+      resetCount: affectedIds.length,
+      totalTasks: allTasks.length,
+      rootCount: retryRootIds.length,
+      note: 'preserved completed outside invalidated subgraphs',
+    });
 
     const readyIds = this.stateMachine
       .getReadyTasks()
@@ -2080,11 +2130,14 @@ export class Orchestrator {
       });
     const started = this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
     const retryEndMs = Date.now();
-    console.log(
-      `[orchestrator] retryWorkflow timing workflow=${workflowId} ` +
-        `refreshMs=${afterRefreshMs - retryStartMs} resetMs=${afterResetMs - afterRefreshMs} ` +
-        `enqueueDrainMs=${retryEndMs - afterResetMs} totalMs=${retryEndMs - retryStartMs} started=${started.length}`,
-    );
+    this.logger.info('[orchestrator] retryWorkflow timing', {
+      workflowId,
+      refreshMs: afterRefreshMs - retryStartMs,
+      resetMs: afterResetMs - afterRefreshMs,
+      enqueueDrainMs: retryEndMs - afterResetMs,
+      totalMs: retryEndMs - retryStartMs,
+      started: started.length,
+    });
     return started;
   }
 
@@ -2133,9 +2186,10 @@ export class Orchestrator {
       },
     };
 
-    console.log(
-      `[orchestrator] recreateTask: resetting ${toResetIds.length} task(s) rooted at ${rootId}`,
-    );
+    this.logger.info('[orchestrator] recreateTask reset', {
+      taskId: rootId,
+      resetCount: toResetIds.length,
+    });
 
     for (const id of toResetIds) {
       const current = this.stateGetTask(id);
@@ -2199,34 +2253,47 @@ export class Orchestrator {
       },
     };
 
-    console.log(`[orchestrator] recreateWorkflow: resetting ${allTasks.length} tasks for workflow ${workflowId}`);
-    console.log(
+    this.logger.info('[orchestrator] recreateWorkflow reset', {
+      workflowId,
+      resetCount: allTasks.length,
+    });
+    this.logger.info(
       '[agent-session-trace] recreateWorkflow: resetChanges.execution clears agentSessionId/containerId (DB NULL before next run)',
     );
     for (const task of allTasks) {
       const prevSess = task.execution.agentSessionId ?? null;
       const prevCt = task.execution.containerId ?? null;
       if (task.config.isMergeNode) {
-        console.log(
-          `[merge-gate-workspace] recreateWorkflow mergeNode=${task.id} ` +
-            `will clear workspace_path (was ${task.execution.workspacePath ?? 'NULL'})`,
-        );
+        this.logger.info('[merge-gate-workspace] recreateWorkflow', {
+          mergeNode: task.id,
+          workspacePath: task.execution.workspacePath ?? 'NULL',
+          note: 'will clear workspace_path',
+        });
         mergeTrace('GATE_WS_RESTART_WORKFLOW_MERGE', {
           taskId: task.id,
           workspacePathBefore: task.execution.workspacePath ?? null,
         });
       }
-      console.log(`[orchestrator]   reset "${task.id}" (was ${task.status}, branch=${task.execution.branch ?? 'none'}, commit=${task.execution.commit?.slice(0, 7) ?? 'none'})`);
-      console.log(
-        `[agent-session-trace] recreateWorkflow: before writeAndSync task="${task.id}" agentSessionId=${prevSess ?? 'null'} containerId=${prevCt ?? 'null'}`,
-      );
+      this.logger.info('[orchestrator] recreateWorkflow task reset', {
+        taskId: task.id,
+        previousStatus: task.status,
+        branch: task.execution.branch ?? 'none',
+        commit: task.execution.commit?.slice(0, 7) ?? 'none',
+      });
+      this.logger.info('[agent-session-trace] recreateWorkflow: before writeAndSync', {
+        taskId: task.id,
+        agentSessionId: prevSess ?? 'null',
+        containerId: prevCt ?? 'null',
+      });
       const changesWithGeneration = this.withBumpedExecutionGeneration(task, resetChanges);
       const after = this.writeAndSync(task.id, changesWithGeneration);
       const priorAttemptId = task.execution.selectedAttemptId;
       this.replaceSelectedAttempt(task);
-      console.log(
-        `[agent-session-trace] recreateWorkflow: after writeAndSync task="${task.id}" agentSessionId=${after.execution.agentSessionId ?? 'null'} containerId=${after.execution.containerId ?? 'null'}`,
-      );
+      this.logger.info('[agent-session-trace] recreateWorkflow: after writeAndSync', {
+        taskId: task.id,
+        agentSessionId: after.execution.agentSessionId ?? 'null',
+        containerId: after.execution.containerId ?? 'null',
+      });
       const delta: TaskDelta = { type: 'updated', taskId: task.id, changes: changesWithGeneration };
       this.persistence.logEvent?.(task.id, 'task.pending', changesWithGeneration);
       this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
@@ -2314,17 +2381,17 @@ export class Orchestrator {
       if (fresh && typeof fresh === 'object') {
         if (typeof fresh.commit === 'string' && fresh.commit.length > 0) {
           this.knownFreshBaseCommits.set(workflowId, fresh.commit);
-          console.log(
-            `[orchestrator] recreateWorkflowFromFreshBase: workflow=${workflowId} ` +
-              `freshBaseCommit=${fresh.commit.slice(0, 12)}`,
-          );
+          this.logger.info('[orchestrator] recreateWorkflowFromFreshBase fresh base commit', {
+            workflowId,
+            freshBaseCommit: fresh.commit.slice(0, 12),
+          });
         }
         if (typeof fresh.branch === 'string' && fresh.branch.length > 0 && this.persistence.updateWorkflow) {
           this.persistence.updateWorkflow(workflowId, { baseBranch: fresh.branch });
-          console.log(
-            `[orchestrator] recreateWorkflowFromFreshBase: workflow=${workflowId} ` +
-              `freshBaseBranch=${fresh.branch}`,
-          );
+          this.logger.info('[orchestrator] recreateWorkflowFromFreshBase fresh base branch', {
+            workflowId,
+            freshBaseBranch: fresh.branch,
+          });
         }
       }
     }
@@ -3742,7 +3809,11 @@ export class Orchestrator {
     this.checkExperimentCompletion(taskId);
 
     const readyTaskIds = this.stateMachine.findNewlyReadyTasks(taskId);
-    console.log(`[orchestrator] handleCompleted "${taskId}": ${readyTaskIds.length} newly ready: [${readyTaskIds.join(', ')}]`);
+    this.logger.info('[orchestrator] handleCompleted', {
+      taskId,
+      newlyReadyCount: readyTaskIds.length,
+      readyTaskIds,
+    });
     const started = this.autoStartReadyTasks(readyTaskIds);
     started.push(...this.autoStartUnblockedTasks());
     started.push(...this.autoStartExternallyUnblockedReadyTasks());
@@ -3815,9 +3886,12 @@ export class Orchestrator {
     this.checkExperimentCompletion(taskId);
 
     const readyTaskIds = this.stateMachine.findNewlyReadyTasks(taskId);
-    console.log(
-      `[orchestrator] finalizeFailedTask "${taskId}" (${eventName}): ${readyTaskIds.length} newly ready: [${readyTaskIds.join(', ')}]`,
-    );
+    this.logger.info('[orchestrator] finalizeFailedTask', {
+      taskId,
+      eventName,
+      newlyReadyCount: readyTaskIds.length,
+      readyTaskIds,
+    });
     const started = this.autoStartReadyTasks(readyTaskIds);
     started.push(...this.autoStartUnblockedTasks());
     started.push(...this.autoStartExternallyUnblockedReadyTasks());
@@ -3881,7 +3955,9 @@ export class Orchestrator {
     const parentTask = this.stateGetTask(taskId);
     const wfId = parentTask?.config.workflowId;
     if (!wfId) {
-      console.warn(`[orchestrator] handleSpawnExperiments: task "${taskId}" has no workflowId; skipping`);
+      this.logger.warn('[orchestrator] handleSpawnExperiments: missing workflowId; skipping', {
+        taskId,
+      });
       return [];
     }
     const scopeLocal = (local: string) => scopePlanTaskId(wfId, local);
@@ -4015,7 +4091,9 @@ export class Orchestrator {
 
       // Unblock: if a blocked task's deps are all complete, it's genuinely ready
       if (task.status === 'blocked') {
-        console.log(`[orchestrator] autoStartReadyTasks: unblocking "${taskId}" (was blocked, deps now satisfied)`);
+        this.logger.info('[orchestrator] autoStartReadyTasks: unblocking blocked task', {
+          taskId,
+        });
         this.writeAndSync(taskId, { status: 'pending' });
       }
 
@@ -4183,15 +4261,22 @@ export class Orchestrator {
     const started: TaskState[] = [];
     const activeAttempts = this.countActivePersistedAttempts();
     let availableSlots = Math.max(0, this.maxConcurrency - activeAttempts);
-    console.log(
-      `[orchestrator] drainScheduler: begin active=${activeAttempts} maxConcurrency=${this.maxConcurrency} availableSlots=${availableSlots}`,
-    );
+    this.logger.info('[orchestrator] drainScheduler: begin', {
+      active: activeAttempts,
+      maxConcurrency: this.maxConcurrency,
+      availableSlots,
+    });
     let job = availableSlots > 0 ? this.scheduler.takeNext() : null;
     while (job && availableSlots > 0) {
       const task = this.stateGetTask(job.taskId);
-      console.log(`[orchestrator] drainScheduler: dequeued "${job.taskId}" actual status=${task?.status ?? 'NOT_FOUND'}`);
+      this.logger.info('[orchestrator] drainScheduler: dequeued', {
+        taskId: job.taskId,
+        actualStatus: task?.status ?? 'NOT_FOUND',
+      });
       if (!task || task.status !== 'pending') {
-        console.log(`[orchestrator] drainScheduler: SKIPPING "${job.taskId}" — not pending`);
+        this.logger.info('[orchestrator] drainScheduler: skipping non-pending task', {
+          taskId: job.taskId,
+        });
         job = this.scheduler.takeNext();
         continue;
       }
@@ -4232,9 +4317,12 @@ export class Orchestrator {
         changes,
       });
       started.push(updated);
-      console.log(
-        `[orchestrator] drainScheduler: started "${job.taskId}" attempt=${attemptId} phase=launching generation=${changes.execution?.generation ?? 'unknown'}`,
-      );
+      this.logger.info('[orchestrator] drainScheduler: started', {
+        taskId: job.taskId,
+        attemptId,
+        phase: 'launching',
+        generation: changes.execution?.generation ?? 'unknown',
+      });
 
       try {
         const existingAttempt = this.persistence.loadAttempt(attemptId);
@@ -4285,7 +4373,7 @@ export class Orchestrator {
       try {
         this.taskDispatcher?.(started);
       } catch (err) {
-        console.error('[orchestrator] taskDispatcher threw:', err);
+        this.logger.error('[orchestrator] taskDispatcher threw', { err });
       }
     }
     return started;
@@ -4301,24 +4389,34 @@ export class Orchestrator {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) {
-      console.log(`[orchestrator] markTaskRunningAfterLaunch: REJECT task="${taskId}" attempt=${attemptId} reason=not_found`);
+      this.logger.info('[orchestrator] markTaskRunningAfterLaunch: reject', {
+        taskId,
+        attemptId,
+        reason: 'not_found',
+      });
       this.clearQueuedSchedulerEntries(taskId, attemptId);
       return false;
     }
 
     const selectedAttemptId = task.execution.selectedAttemptId;
     if (selectedAttemptId && selectedAttemptId !== attemptId) {
-      console.log(
-        `[orchestrator] markTaskRunningAfterLaunch: REJECT task="${taskId}" attempt=${attemptId} reason=attempt_mismatch selected=${selectedAttemptId}`,
-      );
+      this.logger.info('[orchestrator] markTaskRunningAfterLaunch: reject', {
+        taskId,
+        attemptId,
+        reason: 'attempt_mismatch',
+        selectedAttemptId,
+      });
       this.clearQueuedSchedulerEntries(taskId, attemptId);
       return false;
     }
 
     if (task.status !== 'running' && task.status !== 'pending' && task.status !== 'fixing_with_ai') {
-      console.log(
-        `[orchestrator] markTaskRunningAfterLaunch: REJECT task="${taskId}" attempt=${attemptId} reason=invalid_status status=${task.status}`,
-      );
+      this.logger.info('[orchestrator] markTaskRunningAfterLaunch: reject', {
+        taskId,
+        attemptId,
+        reason: 'invalid_status',
+        status: task.status,
+      });
       this.clearQueuedSchedulerEntries(taskId, attemptId);
       return false;
     }
@@ -4349,9 +4447,11 @@ export class Orchestrator {
         taskId,
         changes,
       });
-      console.log(
-        `[orchestrator] markTaskRunningAfterLaunch: EXECUTING task="${taskId}" attempt=${attemptId} previousStatus=${task.status}`,
-      );
+      this.logger.info('[orchestrator] markTaskRunningAfterLaunch: executing', {
+        taskId,
+        attemptId,
+        previousStatus: task.status,
+      });
     }
 
     try {
@@ -4383,7 +4483,10 @@ export class Orchestrator {
       // best effort — do not fail launch-state transition due to attempt sync
     }
 
-    console.log(`[orchestrator] markTaskRunningAfterLaunch: OK task="${taskId}" attempt=${attemptId}`);
+    this.logger.info('[orchestrator] markTaskRunningAfterLaunch: ok', {
+      taskId,
+      attemptId,
+    });
     return true;
   }
 }


### PR DESCRIPTION
## Summary

This PR turns the new observability work into a single structured logging path instead of a mix of ad hoc `console.*` calls and partial startup diagnostics.

- `packages/workflow-core` now accepts an injected `Logger` and emits orchestrator lifecycle, scheduler, retry, approval, and stale-response events through structured logger calls instead of direct stdout/stderr writes.
- `packages/execution-engine` now accepts the same injected `Logger`, routes TaskRunner launch/merge/rebase/PR-polling diagnostics through it, and keeps a no-op logger fallback for tests and call sites that do not pass one yet.
- `packages/app` now embeds the build version and git SHA at build time, logs them on startup, and logs the fully merged effective `InvokerConfig` after redacting sensitive fields like R2 credentials and Docker secrets paths.

## Architecture

### Before

```mermaid
graph TD
    CFG[".invoker.json / env"]
    MAIN["packages/app/src/main.ts"]
    ORC["Orchestrator"]
    TR["TaskRunner"]
    CONS["console.* / process.stderr"]

    CFG --> MAIN
    MAIN -->|"partial startup logs"| CONS
    MAIN --> ORC
    MAIN --> TR
    ORC -->|"console.log / warn / error"| CONS
    TR -->|"console.log / warn / error"| CONS

    style CONS fill:#ffe0e0
```

### After

```mermaid
graph TD
    CFG[".invoker.json / env"]
    TSUP["tsup define<br/>__BUILD_VERSION__ + __BUILD_SHA__"]
    MAIN["packages/app/src/main.ts"]
    REDACT["redact sensitive config fields"]
    LOG["FileAndDbLogger<br/>structured events"]
    ORC["Orchestrator(logger)"]
    TR["TaskRunner(logger)"]

    CFG --> MAIN
    TSUP --> MAIN
    MAIN --> REDACT
    REDACT -->|"effective config"| LOG
    MAIN -->|"startup version + sha"| LOG
    MAIN --> ORC
    MAIN --> TR
    ORC -->|"structured lifecycle events"| LOG
    TR -->|"structured execution / merge events"| LOG

    style LOG fill:#e3f2fd
    style REDACT fill:#fff3cd
```

## Test Plan

- [x] `pnpm --filter @invoker/workflow-core test`
- [x] `pnpm --filter @invoker/execution-engine test`
- [x] `pnpm --filter @invoker/app build`
- [ ] `pnpm --filter @invoker/app test` currently fails in `src/__tests__/bundled-skills.test.ts` (`reports promptRecommended for packaged apps before skills are installed`), which does not overlap the logging/build-metadata changes in this branch

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No
