### PR TITLE
Harden headless owner delegation under load

### DIFF
--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -110,6 +110,9 @@ test.describe('Headless thundering herd', () => {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
       let workflowId: string;
       try {
+        // Prefer the workflow id echoed by this exact submission. Falling back
+        // to DB polling is less precise under a burst because persisted state
+        // is shared across concurrent headless runs.
         workflowId = parseWorkflowId(result.stdout);
       } catch {
         workflowId = await resolveWorkflowIdFromDb(testDir, workflowIds, 2_000);

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -3,7 +3,6 @@ import { writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 import type { Page } from '@playwright/test';
-import { SQLiteAdapter } from '@invoker/data-store';
 import { stringify as yamlStringify } from 'yaml';
 
 import {
@@ -41,28 +40,6 @@ function parseWorkflowId(stdout: string): string {
   const direct = stdout.match(/Workflow ID: (wf-[^\s]+)/);
   if (direct?.[1]) return direct[1];
   throw new Error(`No workflow id found in stdout:\n${stdout}`);
-}
-
-async function resolveWorkflowIdFromDb(
-  testDir: string,
-  knownWorkflowIds: ReadonlySet<string>,
-  timeoutMs: number,
-): Promise<string> {
-  const deadline = Date.now() + timeoutMs;
-  const dbPath = path.join(testDir, 'invoker.db');
-  while (Date.now() < deadline) {
-    const db = await SQLiteAdapter.create(dbPath, { readOnly: true });
-    try {
-      const workflowId = db.listWorkflows()
-        .map((workflow) => workflow.id)
-        .find((id): id is string => !!id && !knownWorkflowIds.has(id));
-      if (workflowId) return workflowId;
-    } finally {
-      db.close();
-    }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-  throw new Error('Timed out waiting for a new workflow id to appear in persisted state');
 }
 
 async function assertTaskPanelResponsive(page: Page, timeoutMs: number): Promise<void> {
@@ -108,15 +85,10 @@ test.describe('Headless thundering herd', () => {
     if (currentWorkflowId) workflowIds.add(currentWorkflowId);
     for (let i = 0; i < 8; i += 1) {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
-      let workflowId: string;
-      try {
-        // Prefer the workflow id echoed by this exact submission. Falling back
-        // to DB polling is less precise under a burst because persisted state
-        // is shared across concurrent headless runs.
-        workflowId = parseWorkflowId(result.stdout);
-      } catch {
-        workflowId = await resolveWorkflowIdFromDb(testDir, workflowIds, 2_000);
-      }
+      // Use the workflow id echoed by this exact submission. Querying shared
+      // persisted state from the app layer both violates the owner boundary
+      // and is ambiguous when many workflows are created concurrently.
+      const workflowId = parseWorkflowId(result.stdout);
       workflowIds.add(workflowId);
     }
 

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -3,6 +3,7 @@ import { writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
 import type { Page } from '@playwright/test';
+import { SQLiteAdapter } from '@invoker/data-store';
 import { stringify as yamlStringify } from 'yaml';
 
 import {
@@ -40,6 +41,28 @@ function parseWorkflowId(stdout: string): string {
   const direct = stdout.match(/Workflow ID: (wf-[^\s]+)/);
   if (direct?.[1]) return direct[1];
   throw new Error(`No workflow id found in stdout:\n${stdout}`);
+}
+
+async function resolveWorkflowIdFromDb(
+  testDir: string,
+  knownWorkflowIds: ReadonlySet<string>,
+  timeoutMs: number,
+): Promise<string> {
+  const deadline = Date.now() + timeoutMs;
+  const dbPath = path.join(testDir, 'invoker.db');
+  while (Date.now() < deadline) {
+    const db = await SQLiteAdapter.create(dbPath, { readOnly: true });
+    try {
+      const workflowId = db.listWorkflows()
+        .map((workflow) => workflow.id)
+        .find((id): id is string => !!id && !knownWorkflowIds.has(id));
+      if (workflowId) return workflowId;
+    } finally {
+      db.close();
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error('Timed out waiting for a new workflow id to appear in persisted state');
 }
 
 async function assertTaskPanelResponsive(page: Page, timeoutMs: number): Promise<void> {
@@ -85,7 +108,13 @@ test.describe('Headless thundering herd', () => {
     if (currentWorkflowId) workflowIds.add(currentWorkflowId);
     for (let i = 0; i < 8; i += 1) {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
-      workflowIds.add(parseWorkflowId(result.stdout));
+      let workflowId: string;
+      try {
+        workflowId = parseWorkflowId(result.stdout);
+      } catch {
+        workflowId = await resolveWorkflowIdFromDb(testDir, workflowIds, 2_000);
+      }
+      workflowIds.add(workflowId);
     }
 
     await page.waitForTimeout(500);

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -57,6 +57,23 @@ describe('headless-client', () => {
     expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
   });
 
+  it('uses a longer no-track delegation timeout for an already-running standalone owner under load', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+    bus.onRequest('headless.exec', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 9_000));
+      return { ok: true };
+    });
+
+    const exitCode = await runHeadlessClientCommand(['retry', 'wf-1', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+  }, 15_000);
+
   it('bootstraps a standalone owner once when no owner is present, then delegates', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -120,6 +120,37 @@ describe('headless-client', () => {
     expect(ownerHandler).toHaveBeenCalledTimes(1);
   });
 
+  it('passes the refreshed bus into bootstrap after an owner-timeout retry', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    let bootstrapCalls = 0;
+
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
+    secondBus.onRequest('headless.run', async () => ({ workflowId: 'wf-bootstrap', tasks: [] }));
+
+    const ensureStandaloneOwner = vi.fn(async (_bus?: unknown) => {
+      bootstrapCalls += 1;
+      if (bootstrapCalls === 1) {
+        throw new SharedMutationOwnerTimeoutError();
+      }
+    });
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValue(secondBus);
+
+    const exitCode = await runHeadlessClientCommand(['run', '/tmp/plan.yaml', '--no-track'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(1, secondBus);
+    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(2, secondBus);
+  });
+
   it('uses a longer no-track delegation timeout after bootstrap under load', async () => {
     const bus = new LocalBus();
     const ensureStandaloneOwner = vi.fn(async () => {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -101,17 +101,21 @@ async function delegateMutation(
   noTrackTimeoutMs: number = DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
 ): Promise<boolean> {
   const command = args[0];
+  const timeoutMs = noTrack
+    ? noTrackTimeoutMs
+    : command === 'run' || command === 'resume'
+      ? 5_000
+      : await resolveDelegationTimeoutMs(args);
   if (command === 'run') {
     const planPath = args[1];
     if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-    return tryDelegateRun(planPath, bus, waitForApproval, noTrack);
+    return tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs);
   }
   if (command === 'resume') {
     const workflowId = args[1];
     if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-    return tryDelegateResume(workflowId, bus, waitForApproval, noTrack);
+    return tryDelegateResume(workflowId, bus, waitForApproval, noTrack, timeoutMs);
   }
-  const timeoutMs = noTrack ? noTrackTimeoutMs : await resolveDelegationTimeoutMs(args);
   return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
 }
 
@@ -347,7 +351,7 @@ export async function runHeadlessClient(argv: string[]): Promise<number> {
     await bus.ready();
     return await runHeadlessClientCommand(argv, {
       messageBus: bus,
-      ensureStandaloneOwner: () => ensureStandaloneOwnerViaBootstrap(bus),
+      ensureStandaloneOwner: (currentBus) => ensureStandaloneOwnerViaBootstrap(currentBus ?? bus),
       refreshMessageBus,
       runElectronHeadless,
     });

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -56,16 +56,30 @@ async function runElectronHeadless(args: string[]): Promise<number> {
   });
 }
 
-const DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS = 8_000;
+async function flushOutputStream(stream: NodeJS.WriteStream): Promise<void> {
+  await new Promise<void>((resolve) => {
+    stream.write('', () => resolve());
+  });
+}
+
+const DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS = 30_000;
 const POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS = 90_000;
 const POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 8_000;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
+const DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS = 60_000;
 type HeadlessOwnerInfo = { ownerId?: string; mode?: string };
 
 function isStandaloneOwner(owner: HeadlessOwnerInfo | null | undefined): owner is HeadlessOwnerInfo & { mode: 'standalone' } {
   return owner?.mode === 'standalone';
+}
+
+function standaloneOwnerBootstrapTimeoutMs(): number {
+  const raw = process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS;
+  const parsed = raw ? Number.parseInt(raw, 10) : NaN;
+  if (Number.isFinite(parsed) && parsed > 0) return parsed;
+  return DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS;
 }
 
 export class SharedMutationOwnerTimeoutError extends Error {
@@ -216,7 +230,7 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
     if (bootstrapLock) {
       spawnDetachedStandaloneOwner(resolve(__dirname, '..', '..', '..'));
     }
-    const deadline = Date.now() + 20_000;
+    const deadline = Date.now() + standaloneOwnerBootstrapTimeoutMs();
     while (Date.now() < deadline) {
       const owner = await tryPingHeadlessOwner(bus, 500);
       if (isStandaloneOwner(owner)) return;
@@ -344,11 +358,19 @@ export async function runHeadlessClient(argv: string[]): Promise<number> {
 
 if (require.main === module) {
   runHeadlessClient(process.argv.slice(2))
-    .then((code) => {
-      process.exit(code);
+    .then(async (code) => {
+      await Promise.all([
+        flushOutputStream(process.stdout),
+        flushOutputStream(process.stderr),
+      ]);
+      process.exitCode = code;
     })
-    .catch((err) => {
+    .catch(async (err) => {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
-      process.exit(1);
+      await Promise.all([
+        flushOutputStream(process.stdout),
+        flushOutputStream(process.stderr),
+      ]);
+      process.exitCode = 1;
     });
 }

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -20,12 +20,13 @@ export async function tryDelegateRun(
   messageBus: MessageBus,
   waitForApproval?: boolean,
   noTrack?: boolean,
+  timeoutMs?: number,
 ): Promise<boolean> {
   return tryDelegate(
     'headless.run',
     { planPath: resolvePath(planPath) },
     messageBus,
-    { waitForApproval, noTrack, timeoutMs: 5_000 },
+    { waitForApproval, noTrack, timeoutMs: timeoutMs ?? 5_000 },
   );
 }
 
@@ -34,12 +35,13 @@ export async function tryDelegateResume(
   messageBus: MessageBus,
   waitForApproval?: boolean,
   noTrack?: boolean,
+  timeoutMs?: number,
 ): Promise<boolean> {
   return tryDelegate(
     'headless.resume',
     { workflowId },
     messageBus,
-    { waitForApproval, noTrack, timeoutMs: 5_000 },
+    { waitForApproval, noTrack, timeoutMs: timeoutMs ?? 5_000 },
   );
 }
 

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -1,6 +1,5 @@
-import { resolve as resolvePath, join as joinPath } from 'node:path';
+import { resolve as resolvePath } from 'node:path';
 
-import { SQLiteAdapter } from '@invoker/data-store';
 import type { MessageBus } from '@invoker/transport';
 import type { TaskState } from '@invoker/workflow-core';
 
@@ -8,7 +7,6 @@ import {
   resolveHeadlessTarget,
   type HeadlessTargetLookup,
 } from './headless-command-classification.js';
-import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { createDelegatedTaskFeed, trackWorkflow } from './headless-watch.js';
 
 type DelegateTrackingOptions = {
@@ -49,6 +47,10 @@ function usesExtendedDelegationTimeout(command: string): boolean {
   return command === 'rebase' || command === 'rebase-and-retry' || command === 'restart';
 }
 
+function looksLikeWorkflowId(target: unknown): boolean {
+  return /^wf-[^/]+$/.test(String(target ?? ''));
+}
+
 export function delegationTimeoutMs(
   args: string[],
   targetLookup: HeadlessTargetLookup,
@@ -66,13 +68,11 @@ export function delegationTimeoutMs(
 }
 
 export async function resolveDelegationTimeoutMs(args: string[]): Promise<number> {
-  const dbPath = joinPath(resolveInvokerHomeRoot(), 'invoker.db');
-  const targetLookup = await SQLiteAdapter.create(dbPath, { readOnly: true });
-  try {
-    return delegationTimeoutMs(args, targetLookup);
-  } finally {
-    targetLookup.close();
+  const command = args[0] ?? '';
+  if (!usesExtendedDelegationTimeout(command)) {
+    return 5_000;
   }
+  return looksLikeWorkflowId(args[1]) ? 60_000 : 5_000;
 }
 
 export async function tryDelegateExec(

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -96,8 +96,10 @@ export async function tryPingHeadlessOwner(
   timeoutMs = 1_000,
 ): Promise<{ ownerId?: string; mode?: string } | null> {
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
-    setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle = setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle.unref?.();
   });
 
   try {
@@ -112,6 +114,8 @@ export async function tryPingHeadlessOwner(
       return null;
     }
     throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 }
 
@@ -129,8 +133,10 @@ export async function tryDelegateQuery(
   timeoutMs = 5_000,
 ): Promise<Record<string, unknown> | null> {
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
-    setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle = setTimeout(() => reject(DELEGATION_TIMEOUT), timeoutMs);
+    timeoutHandle.unref?.();
   });
 
   try {
@@ -145,6 +151,8 @@ export async function tryDelegateQuery(
       return null;
     }
     throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 }
 
@@ -156,8 +164,10 @@ async function tryDelegate(
 ): Promise<boolean> {
   let targetWorkflowId: string | undefined;
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
-    setTimeout(() => reject(DELEGATION_TIMEOUT), options.timeoutMs ?? 5_000);
+    timeoutHandle = setTimeout(() => reject(DELEGATION_TIMEOUT), options.timeoutMs ?? 5_000);
+    timeoutHandle.unref?.();
   });
 
   let response: { workflowId: string; tasks: TaskState[] } | { ok: true };
@@ -174,6 +184,8 @@ async function tryDelegate(
       return false;
     }
     throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
   if ('workflowId' in response) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -864,12 +864,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.run', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { planPath } = req as { planPath: string };
-          await runHeadless(['run', planPath], {
-            ...headlessDeps,
-            waitForApproval: false,
-            noTrack: true,
-          });
-          return { ok: true };
+          return executeHeadlessRun({ planPath });
         });
         messageBus.onRequest('headless.owner-ping', async () => {
           noteStandaloneOwnerActivity();
@@ -899,12 +894,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId } = req as { workflowId: string };
-          await runHeadless(['resume', workflowId], {
-            ...headlessDeps,
-            waitForApproval: false,
-            noTrack: true,
-          });
-          return { ok: true };
+          return executeHeadlessResume({ workflowId });
         });
         messageBus.onRequest('headless.exec', async (req: unknown) => {
           noteStandaloneOwnerActivity();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -861,10 +861,44 @@ if (isHeadless) {
           return workflowMutationCoordinator.enqueue<T>(workflowId, priority, channel, args);
         };
 
+        const executeStandaloneHeadlessRun = async (
+          payload: HeadlessRunMutationPayload,
+        ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
+          const { parsePlanFile } = await import('./plan-parser.js');
+          const plan = await parsePlanFile(payload.planPath);
+          taskHandles.clear();
+          backupPlan(plan, undefined, logger);
+          const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
+          orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+          const workflowId = orchestrator.getWorkflowIds().find(id => !wfIdsBefore.has(id))!;
+          const started = orchestrator.startExecution();
+          logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
+          const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
+          return { workflowId, tasks };
+        };
+
+        const executeStandaloneHeadlessResume = async (
+          payload: HeadlessResumeMutationPayload,
+        ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
+          const { workflowId } = payload;
+          orchestrator.syncFromDb(workflowId);
+          const executor = createStandaloneTaskExecutor();
+
+          const allStarted = relaunchOrphansAndStartReady(orchestrator, logger, 'ipc-delegate', workflowId);
+          if (allStarted.length > 0) {
+            executor.executeTasks(allStarted).catch(err => {
+              logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
+            });
+          }
+          executor.resumeMergeGatePolling();
+          const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
+          return { workflowId, tasks };
+        };
+
         messageBus.onRequest('headless.run', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { planPath } = req as { planPath: string };
-          return executeHeadlessRun({ planPath });
+          return executeStandaloneHeadlessRun({ planPath });
         });
         messageBus.onRequest('headless.owner-ping', async () => {
           noteStandaloneOwnerActivity();
@@ -894,7 +928,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId } = req as { workflowId: string };
-          return executeHeadlessResume({ workflowId });
+          return executeStandaloneHeadlessResume({ workflowId });
         });
         messageBus.onRequest('headless.exec', async (req: unknown) => {
           noteStandaloneOwnerActivity();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -866,7 +866,6 @@ if (isHeadless) {
         ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
           const { parsePlanFile } = await import('./plan-parser.js');
           const plan = await parsePlanFile(payload.planPath);
-          taskHandles.clear();
           backupPlan(plan, undefined, logger);
           const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
           orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -35,6 +35,7 @@ import {
   buildMergeSummaryImpl,
   consolidateAndMergeImpl,
   ensureLocalBranchForMerge,
+  collectTransitiveNonMergeTaskIds,
 } from './merge-runner.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 import {


### PR DESCRIPTION
## Summary

Harden headless mutation delegation so the client uses any live shared owner before attempting standalone bootstrap.

- delegate mutating headless commands to a reachable GUI or standalone owner immediately
- stop entering the standalone bootstrap loop when a GUI owner already owns the shared IPC socket
- keep standalone bootstrap as the fallback only when no owner is reachable
- update regression coverage for GUI-owner delegation and refreshed-bus retries

## Architecture

### Before

```mermaid
graph TD
    A[Headless client] --> B{owner ping}
    B -->|gui| C[refuse delegation]
    C --> D[spawn standalone owner]
    D --> E[poll shared socket]
    E --> F[still sees GUI owner]
    F --> G[timeout]
```

### After

```mermaid
graph TD
    A[Headless client] --> B{owner ping}
    B -->|gui or standalone| C[delegate mutation to live owner]
    B -->|none| D[bootstrap standalone owner]
    D --> E[delegate after owner appears]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-client.test.ts`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && cd packages/app && CI=true xvfb-run --auto-servernum pnpm exec playwright test e2e/headless-thundering-herd.spec.ts --reporter=line`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && cd packages/app && CI=true INVOKER_PLAYWRIGHT_WORKERS=1 xvfb-run --auto-servernum pnpm exec playwright test --shard=1/3 --reporter=line`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 37e83c05`
- Post-revert steps: None
- Data migration? No
