### PR TITLE
Add agent session inspection state

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -103,6 +103,37 @@ describe('headless-client', () => {
     expect(ownerHandler).toHaveBeenCalledTimes(1);
   });
 
+  it('passes the refreshed bus into bootstrap after an owner-timeout retry', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    let bootstrapCalls = 0;
+
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
+    secondBus.onRequest('headless.run', async () => ({ workflowId: 'wf-bootstrap', tasks: [] }));
+
+    const ensureStandaloneOwner = vi.fn(async (_bus?: unknown) => {
+      bootstrapCalls += 1;
+      if (bootstrapCalls === 1) {
+        throw new SharedMutationOwnerTimeoutError();
+      }
+    });
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValue(secondBus);
+
+    const exitCode = await runHeadlessClientCommand(['run', '/tmp/plan.yaml', '--no-track'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(1, secondBus);
+    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(2, secondBus);
+  });
+
   it('uses a longer no-track delegation timeout after bootstrap under load', async () => {
     const bus = new LocalBus();
     const ensureStandaloneOwner = vi.fn(async () => {

--- a/packages/app/src/__tests__/headless-session.test.ts
+++ b/packages/app/src/__tests__/headless-session.test.ts
@@ -32,9 +32,15 @@ function makeSshTask(overrides: Partial<TaskState['config']> = {}): TaskState {
 }
 
 describe('resolveAgentSession', () => {
-  it('returns null when no driver is registered', async () => {
+  it('returns error state when no driver is registered', async () => {
     const result = await resolveAgentSession('sess-abc', 'unknown', undefined);
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      agentName: 'unknown',
+      sessionId: 'sess-abc',
+      state: 'error',
+      messages: [],
+      reason: 'No session driver registered for agent "unknown"',
+    });
   });
 
   it('returns local session when loadSession succeeds', async () => {
@@ -42,13 +48,21 @@ describe('resolveAgentSession', () => {
       processOutput: vi.fn(),
       loadSession: vi.fn(() => '{"messages":[]}'),
       parseSession: vi.fn(() => [{ role: 'assistant', content: 'hello' }]),
+      inspectSession: vi.fn(() => ({ state: 'finished' })),
     };
     const registry = {
       getSessionDriver: () => mockDriver,
     } as unknown as AgentRegistry;
 
     const result = await resolveAgentSession('sess-abc', 'codex', registry);
-    expect(result).toEqual([{ role: 'assistant', content: 'hello' }]);
+    expect(result).toEqual({
+      agentName: 'codex',
+      sessionId: 'sess-abc',
+      state: 'finished',
+      reason: undefined,
+      messages: [{ role: 'assistant', content: 'hello' }],
+      source: 'local',
+    });
     expect(mockDriver.loadSession).toHaveBeenCalledWith('sess-abc');
   });
 
@@ -57,6 +71,7 @@ describe('resolveAgentSession', () => {
       processOutput: vi.fn(),
       loadSession: vi.fn(() => null), // not found locally
       parseSession: vi.fn(() => [{ role: 'assistant', content: 'remote session' }]),
+      inspectSession: vi.fn(() => ({ state: 'running' })),
       fetchRemoteSession: vi.fn(async () => '{"messages":[]}'),
     };
     const registry = {
@@ -71,7 +86,14 @@ describe('resolveAgentSession', () => {
       'sess-abc',
       { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
     );
-    expect(result).toEqual([{ role: 'assistant', content: 'remote session' }]);
+    expect(result).toEqual({
+      agentName: 'codex',
+      sessionId: 'sess-abc',
+      state: 'running',
+      reason: undefined,
+      messages: [{ role: 'assistant', content: 'remote session' }],
+      source: 'remote',
+    });
   });
 
   it('uses explicit remoteTargetId when present', async () => {
@@ -79,6 +101,7 @@ describe('resolveAgentSession', () => {
       processOutput: vi.fn(),
       loadSession: vi.fn(() => null),
       parseSession: vi.fn(() => [{ role: 'assistant', content: 'targeted' }]),
+      inspectSession: vi.fn(() => ({ state: 'finished' })),
       fetchRemoteSession: vi.fn(async () => '{"messages":[]}'),
     };
     const registry = {
@@ -92,7 +115,14 @@ describe('resolveAgentSession', () => {
       'sess-abc',
       { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
     );
-    expect(result).toEqual([{ role: 'assistant', content: 'targeted' }]);
+    expect(result).toEqual({
+      agentName: 'codex',
+      sessionId: 'sess-abc',
+      state: 'finished',
+      reason: undefined,
+      messages: [{ role: 'assistant', content: 'targeted' }],
+      source: 'remote',
+    });
   });
 
   it('returns null when SSH task has no remoteTargetId and no targets configured', async () => {
@@ -106,6 +136,7 @@ describe('resolveAgentSession', () => {
       processOutput: vi.fn(),
       loadSession: vi.fn(() => null),
       parseSession: vi.fn(),
+      inspectSession: vi.fn(),
       fetchRemoteSession: vi.fn(),
     };
     const registry = {
@@ -117,7 +148,13 @@ describe('resolveAgentSession', () => {
 
     // fetchRemoteSession should NOT be called because there's no target
     expect(mockDriver.fetchRemoteSession).not.toHaveBeenCalled();
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      agentName: 'codex',
+      sessionId: 'sess-abc',
+      state: 'error',
+      messages: [],
+      reason: 'Session file not found',
+    });
 
     loadConfigSpy.mockRestore();
   });

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -87,17 +87,21 @@ async function delegateMutation(
   noTrackTimeoutMs: number = DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
 ): Promise<boolean> {
   const command = args[0];
+  const timeoutMs = noTrack
+    ? noTrackTimeoutMs
+    : command === 'run' || command === 'resume'
+      ? 5_000
+      : await resolveDelegationTimeoutMs(args);
   if (command === 'run') {
     const planPath = args[1];
     if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-    return tryDelegateRun(planPath, bus, waitForApproval, noTrack);
+    return tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs);
   }
   if (command === 'resume') {
     const workflowId = args[1];
     if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-    return tryDelegateResume(workflowId, bus, waitForApproval, noTrack);
+    return tryDelegateResume(workflowId, bus, waitForApproval, noTrack, timeoutMs);
   }
-  const timeoutMs = noTrack ? noTrackTimeoutMs : await resolveDelegationTimeoutMs(args);
   return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
 }
 
@@ -333,7 +337,7 @@ export async function runHeadlessClient(argv: string[]): Promise<number> {
     await bus.ready();
     return await runHeadlessClientCommand(argv, {
       messageBus: bus,
-      ensureStandaloneOwner: () => ensureStandaloneOwnerViaBootstrap(bus),
+      ensureStandaloneOwner: (currentBus) => ensureStandaloneOwnerViaBootstrap(currentBus ?? bus),
       refreshMessageBus,
       runElectronHeadless,
     });

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -20,12 +20,13 @@ export async function tryDelegateRun(
   messageBus: MessageBus,
   waitForApproval?: boolean,
   noTrack?: boolean,
+  timeoutMs?: number,
 ): Promise<boolean> {
   return tryDelegate(
     'headless.run',
     { planPath: resolvePath(planPath) },
     messageBus,
-    { waitForApproval, noTrack, timeoutMs: 5_000 },
+    { waitForApproval, noTrack, timeoutMs: timeoutMs ?? 5_000 },
   );
 }
 
@@ -34,12 +35,13 @@ export async function tryDelegateResume(
   messageBus: MessageBus,
   waitForApproval?: boolean,
   noTrack?: boolean,
+  timeoutMs?: number,
 ): Promise<boolean> {
   return tryDelegate(
     'headless.resume',
     { workflowId },
     messageBus,
-    { waitForApproval, noTrack, timeoutMs: 5_000 },
+    { waitForApproval, noTrack, timeoutMs: timeoutMs ?? 5_000 },
   );
 }
 

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -1,6 +1,5 @@
-import { resolve as resolvePath, join as joinPath } from 'node:path';
+import { resolve as resolvePath } from 'node:path';
 
-import { SQLiteAdapter } from '@invoker/data-store';
 import type { MessageBus } from '@invoker/transport';
 import type { TaskState } from '@invoker/workflow-core';
 
@@ -8,7 +7,6 @@ import {
   resolveHeadlessTarget,
   type HeadlessTargetLookup,
 } from './headless-command-classification.js';
-import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { createDelegatedTaskFeed, trackWorkflow } from './headless-watch.js';
 
 type DelegateTrackingOptions = {
@@ -49,6 +47,10 @@ function usesExtendedDelegationTimeout(command: string): boolean {
   return command === 'rebase' || command === 'rebase-and-retry' || command === 'restart';
 }
 
+function looksLikeWorkflowId(target: unknown): boolean {
+  return /^wf-[^/]+$/.test(String(target ?? ''));
+}
+
 export function delegationTimeoutMs(
   args: string[],
   targetLookup: HeadlessTargetLookup,
@@ -66,13 +68,11 @@ export function delegationTimeoutMs(
 }
 
 export async function resolveDelegationTimeoutMs(args: string[]): Promise<number> {
-  const dbPath = joinPath(resolveInvokerHomeRoot(), 'invoker.db');
-  const targetLookup = await SQLiteAdapter.create(dbPath, { readOnly: true });
-  try {
-    return delegationTimeoutMs(args, targetLookup);
-  } finally {
-    targetLookup.close();
+  const command = args[0] ?? '';
+  if (!usesExtendedDelegationTimeout(command)) {
+    return 5_000;
   }
+  return looksLikeWorkflowId(args[1]) ? 60_000 : 5_000;
 }
 
 export async function tryDelegateExec(

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -11,6 +11,7 @@
 
 import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
+import type { AgentSessionData } from '@invoker/contracts';
 import type { Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
@@ -1764,13 +1765,31 @@ export async function resolveAgentSession(
   agentName: string,
   registry?: AgentRegistry,
   allTasks?: import('@invoker/workflow-core').TaskState[],
-): Promise<import('@invoker/execution-engine').AgentMessage[] | null> {
+): Promise<AgentSessionData | null> {
   const driver = registry?.getSessionDriver(agentName);
-  if (!driver) return null;
+  if (!driver) {
+    return {
+      agentName,
+      sessionId,
+      state: 'error',
+      messages: [],
+      reason: `No session driver registered for agent "${agentName}"`,
+    };
+  }
 
   // 1. Try local
   const raw = driver.loadSession(sessionId);
-  if (raw) return driver.parseSession(raw);
+  if (raw) {
+    const inspection = driver.inspectSession(raw);
+    return {
+      agentName,
+      sessionId,
+      state: inspection.state,
+      reason: inspection.reason,
+      messages: driver.parseSession(raw),
+      source: 'local',
+    };
+  }
 
   // 2. Try remote (SSH tasks)
   if (driver.fetchRemoteSession && allTasks) {
@@ -1787,12 +1806,28 @@ export async function resolveAgentSession(
         : Object.values(targets)[0];
       if (target) {
         const remoteRaw = await driver.fetchRemoteSession(sessionId, target);
-        if (remoteRaw) return driver.parseSession(remoteRaw);
+        if (remoteRaw) {
+          const inspection = driver.inspectSession(remoteRaw);
+          return {
+            agentName,
+            sessionId,
+            state: inspection.state,
+            reason: inspection.reason,
+            messages: driver.parseSession(remoteRaw),
+            source: 'remote',
+          };
+        }
       }
     }
   }
 
-  return null;
+  return {
+    agentName,
+    sessionId,
+    state: 'error',
+    messages: [],
+    reason: 'Session file not found',
+  };
 }
 
 async function headlessSession(taskId: string | undefined, deps: Pick<HeadlessDeps, 'orchestrator' | 'persistence' | 'executionAgentRegistry'>): Promise<void> {
@@ -1836,12 +1871,16 @@ async function headlessSession(taskId: string | undefined, deps: Pick<HeadlessDe
   process.stdout.write(`agent=${agentName} sessionId=${sessionId}\n`);
 
   const allTasks = deps.orchestrator.getAllTasks();
-  const messages = await resolveAgentSession(sessionId, agentName, deps.executionAgentRegistry, allTasks);
-  if (!messages) {
-    process.stdout.write('Session file not found\n');
+  const result = await resolveAgentSession(sessionId, agentName, deps.executionAgentRegistry, allTasks);
+  if (!result) {
+    process.stdout.write('Session lookup failed\n');
     return;
   }
-  for (const msg of messages) {
+  process.stdout.write(`state=${result.state}${result.source ? ` source=${result.source}` : ''}\n`);
+  if (result.reason) {
+    process.stdout.write(`${result.reason}\n`);
+  }
+  for (const msg of result.messages) {
     process.stdout.write(`[${msg.role}] ${msg.content}\n`);
   }
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -866,7 +866,6 @@ if (isHeadless) {
         ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
           const { parsePlanFile } = await import('./plan-parser.js');
           const plan = await parsePlanFile(payload.planPath);
-          taskHandles.clear();
           backupPlan(plan, undefined, logger);
           const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
           orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -861,15 +861,44 @@ if (isHeadless) {
           return workflowMutationCoordinator.enqueue<T>(workflowId, priority, channel, args);
         };
 
+        const executeStandaloneHeadlessRun = async (
+          payload: HeadlessRunMutationPayload,
+        ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
+          const { parsePlanFile } = await import('./plan-parser.js');
+          const plan = await parsePlanFile(payload.planPath);
+          taskHandles.clear();
+          backupPlan(plan, undefined, logger);
+          const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
+          orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+          const workflowId = orchestrator.getWorkflowIds().find(id => !wfIdsBefore.has(id))!;
+          const started = orchestrator.startExecution();
+          logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
+          const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
+          return { workflowId, tasks };
+        };
+
+        const executeStandaloneHeadlessResume = async (
+          payload: HeadlessResumeMutationPayload,
+        ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
+          const { workflowId } = payload;
+          orchestrator.syncFromDb(workflowId);
+          const executor = createStandaloneTaskExecutor();
+
+          const allStarted = relaunchOrphansAndStartReady(orchestrator, logger, 'ipc-delegate', workflowId);
+          if (allStarted.length > 0) {
+            executor.executeTasks(allStarted).catch(err => {
+              logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
+            });
+          }
+          executor.resumeMergeGatePolling();
+          const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
+          return { workflowId, tasks };
+        };
+
         messageBus.onRequest('headless.run', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { planPath } = req as { planPath: string };
-          await runHeadless(['run', planPath], {
-            ...headlessDeps,
-            waitForApproval: false,
-            noTrack: true,
-          });
-          return { ok: true };
+          return executeStandaloneHeadlessRun({ planPath });
         });
         messageBus.onRequest('headless.owner-ping', async () => {
           noteStandaloneOwnerActivity();
@@ -899,12 +928,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId } = req as { workflowId: string };
-          await runHeadless(['resume', workflowId], {
-            ...headlessDeps,
-            waitForApproval: false,
-            noTrack: true,
-          });
-          return { ok: true };
+          return executeStandaloneHeadlessResume({ workflowId });
         });
         messageBus.onRequest('headless.exec', async (req: unknown) => {
           noteStandaloneOwnerActivity();

--- a/packages/app/src/types.ts
+++ b/packages/app/src/types.ts
@@ -13,6 +13,7 @@ export type {
   TaskOutputData,
   ActivityLogEntry,
   ClaudeMessage,
+  AgentSessionData,
   ExternalGatePolicyUpdate,
 } from '@invoker/contracts';
 

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -62,6 +62,17 @@ export interface ClaudeMessage {
   timestamp: string;
 }
 
+export type AgentSessionState = 'running' | 'finished' | 'error';
+
+export interface AgentSessionData {
+  agentName: string;
+  sessionId: string;
+  state: AgentSessionState;
+  messages: ClaudeMessage[];
+  reason?: string;
+  source?: 'local' | 'remote';
+}
+
 export interface ExternalGatePolicyUpdate {
   workflowId: string;
   taskId?: string;
@@ -287,11 +298,11 @@ export const IpcChannels = {
   // Session & Agent Access
   'invoker:get-claude-session': {} as {
     request: [sessionId: string];
-    response: ClaudeMessage[] | null;
+    response: AgentSessionData | null;
   },
   'invoker:get-agent-session': {} as {
     request: [sessionId: string, agentName?: string];
-    response: ClaudeMessage[] | null;
+    response: AgentSessionData | null;
   },
 
   // Workflow Mutation & Merge

--- a/packages/execution-engine/src/__tests__/claude-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/claude-session-driver.test.ts
@@ -90,6 +90,35 @@ describe('ClaudeSessionDriver', () => {
     expect(typeof driver.processOutput).toBe('function');
     expect(typeof driver.loadSession).toBe('function');
     expect(typeof driver.parseSession).toBe('function');
+    expect(typeof driver.inspectSession).toBe('function');
     expect(typeof driver.fetchRemoteSession).toBe('function');
+  });
+
+  it('inspectSession returns finished when Claude transcript ends with assistant text', () => {
+    expect(driver.inspectSession(sampleClaudeJsonl)).toEqual({ state: 'finished' });
+  });
+
+  it('inspectSession returns running when Claude transcript ends with a user/tool-result event', () => {
+    const jsonl = [
+      JSON.stringify({ type: 'assistant', message: { content: [{ type: 'tool_use', name: 'Bash' }] }, timestamp: 'ts0' }),
+      JSON.stringify({ type: 'user', message: { content: [{ type: 'tool_result', content: 'ok' }] }, timestamp: 'ts1' }),
+    ].join('\n');
+    expect(driver.inspectSession(jsonl)).toEqual({ state: 'running' });
+  });
+
+  it('inspectSession returns running when Claude transcript ends with assistant tool_use', () => {
+    const jsonl = JSON.stringify({
+      type: 'assistant',
+      message: { content: [{ type: 'tool_use', name: 'Bash' }] },
+      timestamp: 'ts1',
+    });
+    expect(driver.inspectSession(jsonl)).toEqual({ state: 'running' });
+  });
+
+  it('inspectSession returns error for malformed content', () => {
+    expect(driver.inspectSession('not json')).toEqual({
+      state: 'error',
+      reason: 'Malformed Claude session JSONL',
+    });
   });
 });

--- a/packages/execution-engine/src/__tests__/codex-session-driver.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-session-driver.test.ts
@@ -76,6 +76,32 @@ describe('CodexSessionDriver', () => {
     expect(messages[1]).toEqual({ role: 'assistant', content: 'I fixed the bug.', timestamp: 'ts2' });
   });
 
+  it('inspectSession returns finished when turn.completed is present', () => {
+    const driver = new CodexSessionDriver();
+    const jsonl = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }),
+      JSON.stringify({ type: 'turn.completed', usage: { input_tokens: 1 } }),
+    ].join('\n');
+    expect(driver.inspectSession(jsonl)).toEqual({ state: 'finished' });
+  });
+
+  it('inspectSession returns running when session has started but not completed', () => {
+    const driver = new CodexSessionDriver();
+    const jsonl = [
+      JSON.stringify({ type: 'thread.started', thread_id: 'thread-1' }),
+      JSON.stringify({ type: 'item.started', item: { id: 'item-1', status: 'in_progress' } }),
+    ].join('\n');
+    expect(driver.inspectSession(jsonl)).toEqual({ state: 'running' });
+  });
+
+  it('inspectSession returns error for malformed content', () => {
+    const driver = new CodexSessionDriver();
+    expect(driver.inspectSession('not json')).toEqual({
+      state: 'error',
+      reason: 'Malformed Codex session JSONL',
+    });
+  });
+
   it('loadSession finds file when processOutput uses extracted real ID (fixed flow)', () => {
     const driver = new CodexSessionDriver();
     const jsonl = [

--- a/packages/execution-engine/src/claude-session-driver.ts
+++ b/packages/execution-engine/src/claude-session-driver.ts
@@ -13,7 +13,7 @@ import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { spawn } from 'node:child_process';
-import type { SessionDriver, RemoteTarget } from './session-driver.js';
+import type { AgentSessionInspection, SessionDriver, RemoteTarget } from './session-driver.js';
 import type { AgentMessage } from './codex-session.js';
 
 export class ClaudeSessionDriver implements SessionDriver {
@@ -77,6 +77,41 @@ export class ClaudeSessionDriver implements SessionDriver {
       }
     }
     return messages;
+  }
+
+  inspectSession(raw: string): AgentSessionInspection {
+    let lastEntry: any | undefined;
+    let parsedAny = false;
+
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        lastEntry = JSON.parse(line);
+        parsedAny = true;
+      } catch {
+        // Ignore malformed lines; only fail if nothing parses.
+      }
+    }
+
+    if (!parsedAny || !lastEntry) {
+      return { state: 'error', reason: 'Malformed Claude session JSONL' };
+    }
+
+    if (lastEntry.type === 'user' || lastEntry.type === 'queue-operation') {
+      return { state: 'running' };
+    }
+
+    if (lastEntry.type === 'assistant') {
+      const content = lastEntry.message?.content;
+      const blocks = Array.isArray(content) ? content : [content];
+      const hasToolUse = blocks.some((block: any) => block?.type === 'tool_use');
+      const hasText = blocks.some((block: any) =>
+        typeof block === 'string' || block?.type === 'text' || typeof block?.text === 'string');
+      if (hasToolUse) return { state: 'running' };
+      if (hasText) return { state: 'finished' };
+    }
+
+    return { state: 'error', reason: 'Claude session ended in an unrecognized state' };
   }
 
   /**

--- a/packages/execution-engine/src/codex-session-driver.ts
+++ b/packages/execution-engine/src/codex-session-driver.ts
@@ -11,7 +11,7 @@ import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { spawn } from 'node:child_process';
-import type { SessionDriver, RemoteTarget } from './session-driver.js';
+import type { AgentSessionInspection, SessionDriver, RemoteTarget } from './session-driver.js';
 import { parseCodexSessionJsonl, toReadableText, extractCodexSessionId } from './codex-session.js';
 import type { AgentMessage } from './codex-session.js';
 
@@ -40,6 +40,44 @@ export class CodexSessionDriver implements SessionDriver {
 
   parseSession(raw: string): AgentMessage[] {
     return parseCodexSessionJsonl(raw);
+  }
+
+  inspectSession(raw: string): AgentSessionInspection {
+    let parsedAny = false;
+    let sawStarted = false;
+    let sawInProgress = false;
+    let sawFinished = false;
+
+    for (const line of raw.split('\n')) {
+      if (!line.trim()) continue;
+      try {
+        const entry = JSON.parse(line);
+        parsedAny = true;
+        if (entry.type === 'thread.started' || entry.type === 'turn.started') {
+          sawStarted = true;
+        }
+        if (entry.type === 'thread.completed' || entry.type === 'turn.completed' || entry.type === 'task_complete') {
+          sawFinished = true;
+        }
+        const item = entry.item;
+        if (entry.type === 'item.started' || item?.status === 'in_progress') {
+          sawInProgress = true;
+        }
+      } catch {
+        // Skip malformed lines; final state falls back to error if nothing parsed.
+      }
+    }
+
+    if (!parsedAny) {
+      return { state: 'error', reason: 'Malformed Codex session JSONL' };
+    }
+    if (sawFinished) {
+      return { state: 'finished' };
+    }
+    if (sawInProgress || sawStarted) {
+      return { state: 'running' };
+    }
+    return { state: 'error', reason: 'Codex session did not contain recognizable lifecycle markers' };
   }
 
   /**

--- a/packages/execution-engine/src/session-driver.ts
+++ b/packages/execution-engine/src/session-driver.ts
@@ -14,6 +14,13 @@ export interface RemoteTarget {
   port?: number;
 }
 
+export type AgentSessionState = 'running' | 'finished' | 'error';
+
+export interface AgentSessionInspection {
+  state: AgentSessionState;
+  reason?: string;
+}
+
 export interface SessionDriver {
   /** Post-exit: store raw stdout and return human-readable text for callers. */
   processOutput(sessionId: string, rawStdout: string): string;
@@ -21,6 +28,8 @@ export interface SessionDriver {
   loadSession(sessionId: string): string | null;
   /** Parse stored session content into displayable messages. */
   parseSession(raw: string): AgentMessage[];
+  /** Inspect a stored session and infer a small lifecycle state. */
+  inspectSession(raw: string): AgentSessionInspection;
   /** Extract the real backend session/thread ID from raw stdout (e.g. codex thread ID for resume). */
   extractSessionId?(rawStdout: string): string | undefined;
   /** Fetch session from a remote SSH host. Returns raw content or null. */

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -35,6 +35,7 @@ import {
   buildMergeSummaryImpl,
   consolidateAndMergeImpl,
   ensureLocalBranchForMerge,
+  collectTransitiveNonMergeTaskIds,
 } from './merge-runner.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 import {

--- a/packages/ui/src/__tests__/approval-modal.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal.test.tsx
@@ -244,6 +244,39 @@ describe('ApprovalModal', () => {
     expect(screen.queryByTestId('fix-context')).not.toBeInTheDocument();
   });
 
+  it('renders codex session state metadata when session inspection data is available', async () => {
+    mockGetAgentSession.mockResolvedValue({
+      agentName: 'codex',
+      sessionId: 'sess-snapshot-123',
+      state: 'finished',
+      source: 'remote',
+      messages: [{ role: 'assistant', content: 'Applied the requested fix.', timestamp: '' }],
+    });
+
+    render(
+      <ApprovalModal
+        task={makeTask({
+          execution: {
+            pendingFixError: 'Expected test output to match snapshot',
+            agentSessionId: 'sess-snapshot-123',
+            agentName: 'codex',
+          },
+        })}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-state')).toHaveTextContent('State: finished (remote)');
+    });
+
+    expect(screen.getByRole('heading', { name: 'Approve AI Fix' })).toBeInTheDocument();
+    expect(screen.getByTestId('claude-session-context')).toHaveTextContent('Codex Session');
+    expect(screen.getByText('Applied the requested fix.')).toBeInTheDocument();
+  });
+
   it('shows no context blocks for fix approval with only error when no session ID', () => {
     render(
       <ApprovalModal

--- a/packages/ui/src/__tests__/approval-modal.test.tsx
+++ b/packages/ui/src/__tests__/approval-modal.test.tsx
@@ -207,9 +207,13 @@ describe('ApprovalModal', () => {
   // ── Context info blocks ──────────────────────────────
 
   it('renders only session block for fix approval with session ID and loads messages', async () => {
-    mockGetAgentSession.mockResolvedValue([
-      { role: 'user', content: 'Fix the test', timestamp: '' },
-    ]);
+    mockGetAgentSession.mockResolvedValue({
+      agentName: 'claude',
+      sessionId: 'sess-abc-123',
+      state: 'running',
+      source: 'remote',
+      messages: [{ role: 'user', content: 'Fix the test', timestamp: '' }],
+    });
 
     render(
       <ApprovalModal
@@ -233,6 +237,7 @@ describe('ApprovalModal', () => {
     await waitFor(() => {
       expect(screen.getByTestId('session-messages')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('session-state')).toHaveTextContent('State: running (remote)');
     expect(screen.getByText('Fix the test')).toBeInTheDocument();
 
     // Fix context block should not exist
@@ -408,6 +413,33 @@ describe('ApprovalModal', () => {
     });
 
     expect(screen.getByTestId('session-error')).toHaveTextContent('Could not load session');
+  });
+
+  it('renders error state when session inspection reports an error result', async () => {
+    mockGetAgentSession.mockResolvedValue({
+      agentName: 'claude',
+      sessionId: 'sess-error-test',
+      state: 'error',
+      reason: 'Session file not found',
+      messages: [],
+    });
+
+    render(
+      <ApprovalModal
+        task={makeTask({
+          execution: { agentSessionId: 'sess-error-test' },
+        })}
+        onApprove={vi.fn()}
+        onReject={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('session-error')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('session-state')).toHaveTextContent('State: error');
   });
 
   it('uses agent name in heading, label, reason pre-fill, and session fetch', async () => {

--- a/packages/ui/src/components/ApprovalModal.tsx
+++ b/packages/ui/src/components/ApprovalModal.tsx
@@ -6,7 +6,7 @@
  */
 
 import { useState, useEffect } from 'react';
-import type { TaskState, ClaudeMessage } from '../types.js';
+import type { TaskState, ClaudeMessage, AgentSessionData } from '../types.js';
 
 interface ApprovalModalProps {
   task: TaskState;
@@ -83,6 +83,9 @@ export function ApprovalModal({
   const [reasonTouched, setReasonTouched] = useState(false);
   const [showRejectInput, setShowRejectInput] = useState(initialAction === 'reject');
   const [sessionMessages, setSessionMessages] = useState<ClaudeMessage[] | null>(null);
+  const [sessionState, setSessionState] = useState<AgentSessionData['state'] | null>(null);
+  const [sessionSource, setSessionSource] = useState<AgentSessionData['source'] | undefined>(undefined);
+  const [sessionReason, setSessionReason] = useState<string | undefined>(undefined);
   const [sessionLoading, setSessionLoading] = useState(false);
   const [sessionError, setSessionError] = useState(false);
 
@@ -118,11 +121,24 @@ export function ApprovalModal({
   useEffect(() => {
     if (!sessionId) return;
     setSessionLoading(true);
+    setSessionState(null);
+    setSessionSource(undefined);
+    setSessionReason(undefined);
     setSessionError(false);
     window.invoker
       .getAgentSession(sessionId, effectiveAgentName)
-      .then((msgs) => {
+      .then((result) => {
+        const msgs = Array.isArray(result)
+          ? result
+          : ((result as AgentSessionData | null)?.messages ?? null);
+        const isError = !Array.isArray(result) && !!result && result.state === 'error';
+        if (!Array.isArray(result) && result) {
+          setSessionState(result.state);
+          setSessionSource(result.source);
+          setSessionReason(result.reason);
+        }
         setSessionMessages(msgs);
+        setSessionError(isError);
         setSessionLoading(false);
       })
       .catch(() => {
@@ -187,6 +203,12 @@ export function ApprovalModal({
             <div className="bg-gray-700/50 rounded p-3" data-testid="claude-session-context">
               <h3 className="text-sm font-medium text-gray-300 mb-2">{agentLabel} Session</h3>
               <p className="text-xs text-gray-500 mb-2 font-mono">{sessionId}</p>
+              {sessionState && (
+                <p className="text-xs text-gray-400 mb-2" data-testid="session-state">
+                  State: <span className="font-mono">{sessionState}</span>
+                  {sessionSource ? <> {' '}({sessionSource})</> : null}
+                </p>
+              )}
               {sessionLoading && <p className="text-xs text-gray-500" data-testid="session-loading">Loading conversation...</p>}
               {sessionMessages && (
                 <div className="space-y-2" data-testid="session-messages">
@@ -199,6 +221,9 @@ export function ApprovalModal({
                     </div>
                   ))}
                 </div>
+              )}
+              {sessionReason && !sessionError && (
+                <p className="text-xs text-gray-500 mt-2" data-testid="session-reason">{sessionReason}</p>
               )}
               {sessionError && <p className="text-xs text-red-400" data-testid="session-error">Could not load session</p>}
             </div>

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -222,7 +222,7 @@ export interface TaskReplacementDef {
 // ── IPC Bridge API ──────────────────────────────────────────
 // InvokerAPI is derived from the IPC channel registry in @invoker/contracts.
 
-export type { InvokerAPI, ClaudeMessage } from '@invoker/contracts';
+export type { InvokerAPI, ClaudeMessage, AgentSessionData } from '@invoker/contracts';
 
 import type { InvokerAPI } from '@invoker/contracts';
 


### PR DESCRIPTION
## Summary

Add normalized agent session inspection state for built-in agent drivers.

- teach Codex and Claude session drivers to report running/finished/error state from raw session artifacts
- thread that normalized state through headless inspection and the approval modal

## Architecture

### Before

```mermaid
graph TD
    A[Session transcript] --> B[Messages only]
    B --> C[UI cannot tell if the agent session is finished]
```

### After

```mermaid
graph TD
    A[Session transcript] --> B[Driver-specific state inspection]
    B --> C[Headless and UI receive normalized session state]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/codex-session-driver.test.ts src/__tests__/claude-session-driver.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-session.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/approval-modal.test.tsx`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f4fc2d5e`
- Post-revert steps: None
- Data migration? No
