### PR TITLE
Batch headless workflow scripts over IPC

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -103,6 +103,37 @@ describe('headless-client', () => {
     expect(ownerHandler).toHaveBeenCalledTimes(1);
   });
 
+  it('passes the refreshed bus into bootstrap after an owner-timeout retry', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    let bootstrapCalls = 0;
+
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
+    secondBus.onRequest('headless.run', async () => ({ workflowId: 'wf-bootstrap', tasks: [] }));
+
+    const ensureStandaloneOwner = vi.fn(async (_bus?: unknown) => {
+      bootstrapCalls += 1;
+      if (bootstrapCalls === 1) {
+        throw new SharedMutationOwnerTimeoutError();
+      }
+    });
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValue(secondBus);
+
+    const exitCode = await runHeadlessClientCommand(['run', '/tmp/plan.yaml', '--no-track'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(1, secondBus);
+    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(2, secondBus);
+  });
+
   it('uses a longer no-track delegation timeout after bootstrap under load', async () => {
     const bus = new LocalBus();
     const ensureStandaloneOwner = vi.fn(async () => {

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -417,6 +417,49 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(adapter.listWorkflowMutationIntents('wf-1', ['completed'])).toHaveLength(2);
   });
 
+  it('requeues interrupted fix-with-agent workflow mutations on restart', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const firstGate = deferred();
+    const owner1Order: string[] = [];
+    const owner1 = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        owner1Order.push(`${channel}:${String(args[0])}`);
+        await firstGate.promise;
+      },
+    );
+
+    void owner1.enqueue<void>('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/task-fail', 'claude']);
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const owner2Order: string[] = [];
+    const owner2 = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-2',
+      async (channel, args) => {
+        owner2Order.push(`${channel}:${String(args[0])}`);
+      },
+    );
+
+    adapter.requeueExpiredWorkflowMutationLeases(new Date(Date.now() + 60_000));
+    await owner2.resumePending();
+
+    expect(owner1Order).toEqual(['invoker:fix-with-agent:wf-1/task-fail']);
+    expect(owner2Order).toEqual(['invoker:fix-with-agent:wf-1/task-fail']);
+    expect(adapter.listWorkflowMutationIntents('wf-1', ['queued', 'running'])).toEqual([]);
+    expect(adapter.listWorkflowMutationIntents('wf-1', ['completed'])).toHaveLength(1);
+  });
+
   it('does not let another owner steal a live workflow lease', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/app/src/__tests__/workflow-mutation-startup.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-startup.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Logger } from '@invoker/contracts';
+import { recoverWorkflowMutationsOnStartup } from '../workflow-mutation-startup.js';
+
+function makeLogger() {
+  return {
+    info: vi.fn(),
+    error: vi.fn(),
+  } as unknown as Logger & { info: ReturnType<typeof vi.fn>; error: ReturnType<typeof vi.fn> };
+}
+
+describe('recoverWorkflowMutationsOnStartup', () => {
+  it('requeues and resumes pending mutations for owner startup without env gating', async () => {
+    const persistence = {
+      requeueExpiredWorkflowMutationLeases: vi.fn(),
+    };
+    const workflowMutationCoordinator = {
+      resumePending: vi.fn(async () => {}),
+    };
+    const maybeDelayResume = vi.fn(async () => {});
+    const logger = makeLogger();
+
+    await recoverWorkflowMutationsOnStartup({
+      ownerMode: true,
+      persistence,
+      workflowMutationCoordinator,
+      logger,
+      maybeDelayResume,
+    });
+
+    expect(persistence.requeueExpiredWorkflowMutationLeases).toHaveBeenCalledTimes(1);
+    expect(maybeDelayResume).toHaveBeenCalledTimes(1);
+    expect(workflowMutationCoordinator.resumePending).toHaveBeenCalledTimes(1);
+    expect(logger.info).toHaveBeenCalledWith('requeued expired workflow mutation leases on startup', { module: 'init' });
+    expect(logger.info).toHaveBeenCalledWith('resuming pending workflow mutations on startup', { module: 'init' });
+    expect(logger.info).toHaveBeenCalledWith('workflow mutation recovery finished on startup', { module: 'init' });
+  });
+
+  it('does nothing in follower mode', async () => {
+    const persistence = {
+      requeueExpiredWorkflowMutationLeases: vi.fn(),
+    };
+    const workflowMutationCoordinator = {
+      resumePending: vi.fn(async () => {}),
+    };
+    const logger = makeLogger();
+
+    await recoverWorkflowMutationsOnStartup({
+      ownerMode: false,
+      persistence,
+      workflowMutationCoordinator,
+      logger,
+    });
+
+    expect(persistence.requeueExpiredWorkflowMutationLeases).not.toHaveBeenCalled();
+    expect(workflowMutationCoordinator.resumePending).not.toHaveBeenCalled();
+    expect(logger.info).not.toHaveBeenCalled();
+    expect(logger.error).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -87,17 +87,21 @@ async function delegateMutation(
   noTrackTimeoutMs: number = DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
 ): Promise<boolean> {
   const command = args[0];
+  const timeoutMs = noTrack
+    ? noTrackTimeoutMs
+    : command === 'run' || command === 'resume'
+      ? 5_000
+      : await resolveDelegationTimeoutMs(args);
   if (command === 'run') {
     const planPath = args[1];
     if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-    return tryDelegateRun(planPath, bus, waitForApproval, noTrack);
+    return tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs);
   }
   if (command === 'resume') {
     const workflowId = args[1];
     if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-    return tryDelegateResume(workflowId, bus, waitForApproval, noTrack);
+    return tryDelegateResume(workflowId, bus, waitForApproval, noTrack, timeoutMs);
   }
-  const timeoutMs = noTrack ? noTrackTimeoutMs : await resolveDelegationTimeoutMs(args);
   return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
 }
 
@@ -333,7 +337,7 @@ export async function runHeadlessClient(argv: string[]): Promise<number> {
     await bus.ready();
     return await runHeadlessClientCommand(argv, {
       messageBus: bus,
-      ensureStandaloneOwner: () => ensureStandaloneOwnerViaBootstrap(bus),
+      ensureStandaloneOwner: (currentBus) => ensureStandaloneOwnerViaBootstrap(currentBus ?? bus),
       refreshMessageBus,
       runElectronHeadless,
     });

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -20,12 +20,13 @@ export async function tryDelegateRun(
   messageBus: MessageBus,
   waitForApproval?: boolean,
   noTrack?: boolean,
+  timeoutMs?: number,
 ): Promise<boolean> {
   return tryDelegate(
     'headless.run',
     { planPath: resolvePath(planPath) },
     messageBus,
-    { waitForApproval, noTrack, timeoutMs: 5_000 },
+    { waitForApproval, noTrack, timeoutMs: timeoutMs ?? 5_000 },
   );
 }
 
@@ -34,12 +35,13 @@ export async function tryDelegateResume(
   messageBus: MessageBus,
   waitForApproval?: boolean,
   noTrack?: boolean,
+  timeoutMs?: number,
 ): Promise<boolean> {
   return tryDelegate(
     'headless.resume',
     { workflowId },
     messageBus,
-    { waitForApproval, noTrack, timeoutMs: 5_000 },
+    { waitForApproval, noTrack, timeoutMs: timeoutMs ?? 5_000 },
   );
 }
 

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -1,6 +1,5 @@
-import { resolve as resolvePath, join as joinPath } from 'node:path';
+import { resolve as resolvePath } from 'node:path';
 
-import { SQLiteAdapter } from '@invoker/data-store';
 import type { MessageBus } from '@invoker/transport';
 import type { TaskState } from '@invoker/workflow-core';
 
@@ -8,7 +7,6 @@ import {
   resolveHeadlessTarget,
   type HeadlessTargetLookup,
 } from './headless-command-classification.js';
-import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { createDelegatedTaskFeed, trackWorkflow } from './headless-watch.js';
 
 type DelegateTrackingOptions = {
@@ -49,6 +47,10 @@ function usesExtendedDelegationTimeout(command: string): boolean {
   return command === 'rebase' || command === 'rebase-and-retry' || command === 'restart';
 }
 
+function looksLikeWorkflowId(target: unknown): boolean {
+  return /^wf-[^/]+$/.test(String(target ?? ''));
+}
+
 export function delegationTimeoutMs(
   args: string[],
   targetLookup: HeadlessTargetLookup,
@@ -66,13 +68,11 @@ export function delegationTimeoutMs(
 }
 
 export async function resolveDelegationTimeoutMs(args: string[]): Promise<number> {
-  const dbPath = joinPath(resolveInvokerHomeRoot(), 'invoker.db');
-  const targetLookup = await SQLiteAdapter.create(dbPath, { readOnly: true });
-  try {
-    return delegationTimeoutMs(args, targetLookup);
-  } finally {
-    targetLookup.close();
+  const command = args[0] ?? '';
+  if (!usesExtendedDelegationTimeout(command)) {
+    return 5_000;
   }
+  return looksLikeWorkflowId(args[1]) ? 60_000 : 5_000;
 }
 
 export async function tryDelegateExec(

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -890,6 +890,40 @@ if (isHeadless) {
           return workflowMutationCoordinator.enqueue<T>(workflowId, priority, channel, args);
         };
 
+        const executeStandaloneHeadlessRun = async (
+          payload: HeadlessRunMutationPayload,
+        ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
+          const { parsePlanFile } = await import('./plan-parser.js');
+          const plan = await parsePlanFile(payload.planPath);
+          taskHandles.clear();
+          backupPlan(plan, undefined, logger);
+          const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
+          orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+          const workflowId = orchestrator.getWorkflowIds().find(id => !wfIdsBefore.has(id))!;
+          const started = orchestrator.startExecution();
+          logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
+          const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
+          return { workflowId, tasks };
+        };
+
+        const executeStandaloneHeadlessResume = async (
+          payload: HeadlessResumeMutationPayload,
+        ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
+          const { workflowId } = payload;
+          orchestrator.syncFromDb(workflowId);
+          const executor = createStandaloneTaskExecutor();
+
+          const allStarted = relaunchOrphansAndStartReady(orchestrator, logger, 'ipc-delegate', workflowId);
+          if (allStarted.length > 0) {
+            executor.executeTasks(allStarted).catch(err => {
+              logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
+            });
+          }
+          executor.resumeMergeGatePolling();
+          const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
+          return { workflowId, tasks };
+        };
+
         messageBus.onRequest('headless.run', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { planPath } = req as { planPath: string };

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2169,7 +2169,7 @@ if (isHeadless) {
       void recoverWorkflowMutationsOnStartup({
         ownerMode,
         persistence,
-        workflowMutationCoordinator,
+        workflowMutationCoordinator: workflowMutationCoordinator ?? undefined,
         logger,
         maybeDelayResume: maybeDelayWorkflowResumeForTest,
       });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -895,7 +895,6 @@ if (isHeadless) {
         ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
           const { parsePlanFile } = await import('./plan-parser.js');
           const plan = await parsePlanFile(payload.planPath);
-          taskHandles.clear();
           backupPlan(plan, undefined, logger);
           const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
           orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -127,6 +127,7 @@ import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
+import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
 import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
 import { computeDeferredLaunchTiming } from './deferred-runnable.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
@@ -696,6 +697,34 @@ if (isHeadless) {
         return executor;
       };
 
+      const executeStandaloneHeadlessRun = async (payload: HeadlessRunMutationPayload): Promise<unknown> => {
+        const { parsePlanFile } = await import('./plan-parser.js');
+        const plan = await parsePlanFile(payload.planPath);
+        const executor = createStandaloneTaskExecutor();
+        void executor;
+        backupPlan(plan, undefined, logger);
+        const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
+        orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
+        const workflowId = orchestrator.getWorkflowIds().find((id) => !wfIdsBefore.has(id));
+        if (!workflowId) {
+          throw new Error(`Failed to resolve workflow id for delegated plan: ${payload.planPath}`);
+        }
+        const started = orchestrator.startExecution();
+        logger.info(`standalone started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
+        const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
+        return { workflowId, tasks };
+      };
+
+      const executeStandaloneHeadlessResume = async (payload: HeadlessResumeMutationPayload): Promise<unknown> => {
+        const { workflowId } = payload;
+        createStandaloneTaskExecutor();
+        orchestrator.syncFromDb(workflowId);
+        const started = relaunchOrphansAndStartReady(orchestrator, logger, 'standalone-ipc-delegate', workflowId);
+        logger.info(`standalone resumed ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
+        const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
+        return { workflowId, tasks };
+      };
+
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
         switch (payload.channel) {
           case 'invoker:load-plan': {
@@ -864,12 +893,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.run', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { planPath } = req as { planPath: string };
-          await runHeadless(['run', planPath], {
-            ...headlessDeps,
-            waitForApproval: false,
-            noTrack: true,
-          });
-          return { ok: true };
+          return executeStandaloneHeadlessRun({ planPath });
         });
         messageBus.onRequest('headless.owner-ping', async () => {
           noteStandaloneOwnerActivity();
@@ -899,12 +923,7 @@ if (isHeadless) {
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
           const { workflowId } = req as { workflowId: string };
-          await runHeadless(['resume', workflowId], {
-            ...headlessDeps,
-            waitForApproval: false,
-            noTrack: true,
-          });
-          return { ok: true };
+          return executeStandaloneHeadlessResume({ workflowId });
         });
         messageBus.onRequest('headless.exec', async (req: unknown) => {
           noteStandaloneOwnerActivity();
@@ -2114,34 +2133,13 @@ if (isHeadless) {
       });
       recordStartupMark('api-server.started');
 
-      if (ownerMode && workflowMutationCoordinator) {
-        try {
-          persistence.requeueExpiredWorkflowMutationLeases();
-          logger.info('requeued expired workflow mutation leases on startup', { module: 'init' });
-        } catch (err) {
-          logger.error(
-            `requeueExpiredWorkflowMutationLeases failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-            { module: 'init' },
-          );
-        }
-        if (process.env.INVOKER_RESUME_WORKFLOW_MUTATIONS_ON_STARTUP === '1') {
-          void (async () => {
-            try {
-              await maybeDelayWorkflowResumeForTest();
-              await workflowMutationCoordinator.resumePending();
-            } catch (err) {
-              logger.error(
-                `resumePending failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-                { module: 'init' },
-              );
-            }
-          })();
-        } else {
-          logger.info('startup workflow mutation drain deferred; queued intents remain durable until explicit activity', {
-            module: 'init',
-          });
-        }
-      }
+      void recoverWorkflowMutationsOnStartup({
+        ownerMode,
+        persistence,
+        workflowMutationCoordinator,
+        logger,
+        maybeDelayResume: maybeDelayWorkflowResumeForTest,
+      });
 
       startSlackBot(requireTaskExecutor(), taskHandles).catch((err) => {
         logger.info(`Not started: ${err instanceof Error ? err.message : String(err)}`, { module: 'slack' });

--- a/packages/app/src/workflow-mutation-startup.ts
+++ b/packages/app/src/workflow-mutation-startup.ts
@@ -1,0 +1,46 @@
+import type { Logger } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
+
+type RecoveryDeps = {
+  ownerMode: boolean;
+  persistence: Pick<SQLiteAdapter, 'requeueExpiredWorkflowMutationLeases'>;
+  workflowMutationCoordinator?: Pick<PersistedWorkflowMutationCoordinator, 'resumePending'>;
+  logger: Logger;
+  maybeDelayResume?: () => Promise<void>;
+};
+
+export async function recoverWorkflowMutationsOnStartup({
+  ownerMode,
+  persistence,
+  workflowMutationCoordinator,
+  logger,
+  maybeDelayResume,
+}: RecoveryDeps): Promise<void> {
+  if (!ownerMode || !workflowMutationCoordinator) {
+    return;
+  }
+
+  try {
+    persistence.requeueExpiredWorkflowMutationLeases();
+    logger.info('requeued expired workflow mutation leases on startup', { module: 'init' });
+  } catch (err) {
+    logger.error(
+      `requeueExpiredWorkflowMutationLeases failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+      { module: 'init' },
+    );
+    return;
+  }
+
+  try {
+    await maybeDelayResume?.();
+    logger.info('resuming pending workflow mutations on startup', { module: 'init' });
+    await workflowMutationCoordinator.resumePending();
+    logger.info('workflow mutation recovery finished on startup', { module: 'init' });
+  } catch (err) {
+    logger.error(
+      `resumePending failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+      { module: 'init' },
+    );
+  }
+}

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -35,6 +35,7 @@ import {
   buildMergeSummaryImpl,
   consolidateAndMergeImpl,
   ensureLocalBranchForMerge,
+  collectTransitiveNonMergeTaskIds,
 } from './merge-runner.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 import {

--- a/scripts/auto-select-reconciliation-refactor.sh
+++ b/scripts/auto-select-reconciliation-refactor.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RUNNER="$REPO_ROOT/run.sh"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 LOCK_FILE="${TMPDIR:-/tmp}/invoker-auto-select-reconciliation-refactor.lock"
 
 if [[ ! -x "$RUNNER" ]]; then
@@ -71,7 +72,7 @@ while IFS=$'\t' read -r recon_id experiment_id; do
   [[ -z "$recon_id" || -z "$experiment_id" ]] && continue
   attempts=$((attempts + 1))
   echo "Selecting experiment '$experiment_id' for reconciliation node '$recon_id'..."
-  if "$RUNNER" --headless select "$recon_id" "$experiment_id" --no-track; then
+  if node "$IPC_HELPER" exec --no-track -- select "$recon_id" "$experiment_id"; then
     success=$((success + 1))
   else
     failed=$((failed + 1))

--- a/scripts/convert-claude-to-codex.sh
+++ b/scripts/convert-claude-to-codex.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ELECTRON="$REPO_ROOT/packages/app/node_modules/.bin/electron"
 MAIN="$REPO_ROOT/packages/app/dist/main.js"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 
 # Parse args
 DRY_RUN=false
@@ -49,8 +50,7 @@ headless_query() {
 
 # Helper: mutating command (stderr preserved for debugging real failures)
 headless_mutation() {
-  # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@"
+  node "$IPC_HELPER" exec -- "$@"
 }
 
 # Helper: extract workflow IDs (filter Electron init noise)

--- a/scripts/headless-ipc.js
+++ b/scripts/headless-ipc.js
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
+const { createConnection } = require('node:net');
+const { homedir } = require('node:os');
 const path = require('node:path');
 
-const repoRoot = path.resolve(__dirname, '..');
-const { IpcBus } = require(path.join(repoRoot, 'packages', 'transport', 'dist'));
+const DEFAULT_SOCKET_PATH =
+  process.env.INVOKER_IPC_SOCKET || path.join(homedir(), '.invoker', 'ipc-transport.sock');
 
 for (const stream of [process.stdout, process.stderr]) {
   stream.on('error', (error) => {
@@ -82,6 +84,122 @@ function parseCli(argv) {
   return { mode, noTrack, waitForApproval, parallel, timeoutMs, args };
 }
 
+function encodeEnvelope(envelope) {
+  const json = Buffer.from(JSON.stringify(envelope), 'utf8');
+  const frame = Buffer.allocUnsafe(4 + json.length);
+  frame.writeUInt32BE(json.length, 0);
+  json.copy(frame, 4);
+  return frame;
+}
+
+class FrameDecoder {
+  constructor(onEnvelope) {
+    this.buf = Buffer.alloc(0);
+    this.onEnvelope = onEnvelope;
+  }
+
+  push(chunk) {
+    this.buf = Buffer.concat([this.buf, chunk]);
+    while (this.buf.length >= 4) {
+      const len = this.buf.readUInt32BE(0);
+      if (this.buf.length < 4 + len) {
+        break;
+      }
+      const json = this.buf.subarray(4, 4 + len).toString('utf8');
+      this.buf = this.buf.subarray(4 + len);
+      this.onEnvelope(JSON.parse(json));
+    }
+  }
+}
+
+class HeadlessIpcClient {
+  constructor(socketPath = DEFAULT_SOCKET_PATH) {
+    this.socketPath = socketPath;
+    this.nextReqId = 0;
+    this.pending = new Map();
+    this.socket = null;
+    this.decoder = new FrameDecoder((envelope) => this.handleEnvelope(envelope));
+  }
+
+  async connect() {
+    if (this.socket) {
+      return;
+    }
+    this.socket = await new Promise((resolve, reject) => {
+      const socket = createConnection({ path: this.socketPath });
+      const cleanup = () => {
+        socket.off('connect', handleConnect);
+        socket.off('error', handleError);
+      };
+      const handleConnect = () => {
+        cleanup();
+        resolve(socket);
+      };
+      const handleError = (error) => {
+        cleanup();
+        reject(error);
+      };
+      socket.once('connect', handleConnect);
+      socket.once('error', handleError);
+    });
+
+    this.socket.on('data', (chunk) => this.decoder.push(chunk));
+    this.socket.on('error', (error) => {
+      this.rejectAll(error);
+    });
+    this.socket.on('close', () => {
+      this.rejectAll(new Error('IPC socket closed'));
+      this.socket = null;
+    });
+  }
+
+  handleEnvelope(envelope) {
+    if (envelope.kind !== 'res' && envelope.kind !== 'err') {
+      return;
+    }
+    const pending = this.pending.get(envelope.reqId);
+    if (!pending) {
+      return;
+    }
+    this.pending.delete(envelope.reqId);
+    if (envelope.kind === 'err') {
+      pending.reject(new Error(envelope.message));
+      return;
+    }
+    pending.resolve(envelope.body);
+  }
+
+  rejectAll(error) {
+    for (const { reject } of this.pending.values()) {
+      reject(error);
+    }
+    this.pending.clear();
+  }
+
+  async request(channel, body) {
+    await this.connect();
+    const reqId = `req-${this.nextReqId += 1}`;
+    const response = new Promise((resolve, reject) => {
+      this.pending.set(reqId, { resolve, reject });
+    });
+    this.socket.write(encodeEnvelope({
+      kind: 'req',
+      channel,
+      body,
+      reqId,
+    }));
+    return response;
+  }
+
+  disconnect() {
+    if (!this.socket) {
+      return;
+    }
+    this.socket.destroy();
+    this.socket = null;
+  }
+}
+
 async function readStdinLines() {
   const chunks = [];
   for await (const chunk of process.stdin) {
@@ -90,13 +208,13 @@ async function readStdinLines() {
   return Buffer.concat(chunks).toString('utf8').split('\n').map((line) => line.trim()).filter(Boolean);
 }
 
-async function requestExec(bus, item, options) {
+async function requestExec(client, item, options) {
   const payload = {
     args: item.args,
     noTrack: options.noTrack,
     waitForApproval: options.waitForApproval,
   };
-  const response = await withTimeout(bus.request('headless.exec', payload), options.timeoutMs);
+  const response = await withTimeout(client.request('headless.exec', payload), options.timeoutMs);
   return {
     ...item,
     ok: true,
@@ -106,15 +224,14 @@ async function requestExec(bus, item, options) {
 
 async function main() {
   const options = parseCli(process.argv.slice(2));
-  const bus = new IpcBus(undefined, { allowServe: false });
-  await bus.ready();
+  const client = new HeadlessIpcClient();
 
   try {
     if (options.mode === 'exec') {
       if (options.args.length === 0) {
         throw new Error('Missing headless args for exec');
       }
-      const result = await requestExec(bus, { args: options.args }, options);
+      const result = await requestExec(client, { args: options.args }, options);
       process.stdout.write(`${JSON.stringify(result)}\n`);
       return;
     }
@@ -143,7 +260,7 @@ async function main() {
         }
         const item = items[index];
         try {
-          const result = await requestExec(bus, item, options);
+          const result = await requestExec(client, item, options);
           process.stdout.write(`${JSON.stringify(result)}\n`);
         } catch (error) {
           process.stdout.write(`${JSON.stringify({
@@ -157,7 +274,7 @@ async function main() {
 
     await Promise.all(Array.from({ length: Math.min(parallel, items.length) }, () => worker()));
   } finally {
-    bus.disconnect();
+    client.disconnect();
   }
 }
 

--- a/scripts/headless-ipc.js
+++ b/scripts/headless-ipc.js
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const { IpcBus } = require(path.join(repoRoot, 'packages', 'transport', 'dist'));
+
+for (const stream of [process.stdout, process.stderr]) {
+  stream.on('error', (error) => {
+    if (error && error.code === 'EPIPE') {
+      process.exit(0);
+    }
+    throw error;
+  });
+}
+
+function usage() {
+  console.error(
+    'Usage:\n' +
+    '  node scripts/headless-ipc.js exec [--no-track] [--wait-for-approval] [--timeout-ms N] -- <headless args...>\n' +
+    '  node scripts/headless-ipc.js batch-exec [--no-track] [--wait-for-approval] [--timeout-ms N] [--parallel N] < commands.jsonl',
+  );
+}
+
+function withTimeout(promise, timeoutMs) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return promise;
+  }
+  return Promise.race([
+    promise,
+    new Promise((_, reject) => {
+      const timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+      timer.unref?.();
+    }),
+  ]);
+}
+
+function parseCli(argv) {
+  const mode = argv[0];
+  if (mode !== 'exec' && mode !== 'batch-exec') {
+    usage();
+    process.exit(2);
+  }
+
+  let noTrack = false;
+  let waitForApproval = false;
+  let parallel = 1;
+  let timeoutMs = 30_000;
+  const args = [];
+  let afterDoubleDash = false;
+
+  for (let i = 1; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (afterDoubleDash) {
+      args.push(token);
+      continue;
+    }
+    if (token === '--') {
+      afterDoubleDash = true;
+      continue;
+    }
+    if (token === '--no-track') {
+      noTrack = true;
+      continue;
+    }
+    if (token === '--wait-for-approval') {
+      waitForApproval = true;
+      continue;
+    }
+    if (token === '--parallel') {
+      parallel = Number.parseInt(argv[i + 1] ?? '', 10);
+      i += 1;
+      continue;
+    }
+    if (token === '--timeout-ms') {
+      timeoutMs = Number.parseInt(argv[i + 1] ?? '', 10);
+      i += 1;
+      continue;
+    }
+    args.push(token);
+  }
+
+  return { mode, noTrack, waitForApproval, parallel, timeoutMs, args };
+}
+
+async function readStdinLines() {
+  const chunks = [];
+  for await (const chunk of process.stdin) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks).toString('utf8').split('\n').map((line) => line.trim()).filter(Boolean);
+}
+
+async function requestExec(bus, item, options) {
+  const payload = {
+    args: item.args,
+    noTrack: options.noTrack,
+    waitForApproval: options.waitForApproval,
+  };
+  const response = await withTimeout(bus.request('headless.exec', payload), options.timeoutMs);
+  return {
+    ...item,
+    ok: true,
+    response,
+  };
+}
+
+async function main() {
+  const options = parseCli(process.argv.slice(2));
+  const bus = new IpcBus(undefined, { allowServe: false });
+  await bus.ready();
+
+  try {
+    if (options.mode === 'exec') {
+      if (options.args.length === 0) {
+        throw new Error('Missing headless args for exec');
+      }
+      const result = await requestExec(bus, { args: options.args }, options);
+      process.stdout.write(`${JSON.stringify(result)}\n`);
+      return;
+    }
+
+    const lines = await readStdinLines();
+    const items = lines.map((line) => {
+      const parsed = JSON.parse(line);
+      if (Array.isArray(parsed)) {
+        return { args: parsed };
+      }
+      if (!parsed || !Array.isArray(parsed.args)) {
+        throw new Error(`Invalid batch item: ${line}`);
+      }
+      return parsed;
+    });
+
+    let nextIndex = 0;
+    const parallel = Math.max(1, Number.isFinite(options.parallel) ? options.parallel : 1);
+
+    async function worker() {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+        if (index >= items.length) {
+          return;
+        }
+        const item = items[index];
+        try {
+          const result = await requestExec(bus, item, options);
+          process.stdout.write(`${JSON.stringify(result)}\n`);
+        } catch (error) {
+          process.stdout.write(`${JSON.stringify({
+            ...item,
+            ok: false,
+            error: error instanceof Error ? error.message : String(error),
+          })}\n`);
+        }
+      }
+    }
+
+    await Promise.all(Array.from({ length: Math.min(parallel, items.length) }, () => worker()));
+  } finally {
+    bus.disconnect();
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack ?? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/rebase-retry-all.sh
+++ b/scripts/rebase-retry-all.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # Detect repo root
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 
 # Set Electron paths
 ELECTRON="$REPO_ROOT/packages/app/node_modules/.bin/electron"
@@ -128,8 +129,7 @@ headless_query() {
 }
 
 headless_mutation() {
-  # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@"
+  node "$IPC_HELPER" exec -- "$@"
 }
 
 headless_workflow_ids() {
@@ -285,14 +285,14 @@ if [ "$FOLLOW" = true ]; then
     if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ]; then
       set +e
       cmd_out="$(
-        run_with_optional_timeout "$COMMAND_TIMEOUT_SECONDS" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless --no-track rebase "$task_id" 2>&1
+        run_with_optional_timeout "$COMMAND_TIMEOUT_SECONDS" node "$IPC_HELPER" exec --no-track -- rebase "$task_id" 2>&1
       )"
       cmd_status=$?
       set -e
     else
       set +e
       cmd_out="$(
-        headless_mutation --no-track rebase "$task_id" 2>&1
+        node "$IPC_HELPER" exec --no-track -- rebase "$task_id" 2>&1
       )"
       cmd_status=$?
       set -e
@@ -352,27 +352,9 @@ if [ "$FOLLOW" = true ]; then
   fi
 else
   LOG_DIR="$(mktemp -d -t rebase-retry-all-logs.XXXXXX)"
-  TIMEOUT_TOOL=""
-  if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ]; then
-    if command -v timeout >/dev/null 2>&1; then
-      TIMEOUT_TOOL="timeout"
-    elif command -v gtimeout >/dev/null 2>&1; then
-      TIMEOUT_TOOL="gtimeout"
-    else
-      echo "WARNING: timeout/gtimeout unavailable; fire-and-forget mode will run without per-command timeout." >&2
-    fi
-  fi
-
-  launch_detached() {
-    local log_file="$1"
-    shift
-    if command -v setsid >/dev/null 2>&1; then
-      setsid "$@" >"$log_file" 2>&1 < /dev/null &
-    else
-      nohup "$@" >"$log_file" 2>&1 < /dev/null &
-    fi
-    echo "$!"
-  }
+  RESULT_FILE="$(mktemp -t rebase-retry-all-results.XXXXXX)"
+  COMMANDS_FILE="$(mktemp -t rebase-retry-all-commands.XXXXXX)"
+  OUTPUT_JSONL="$(mktemp -t rebase-retry-all-output.XXXXXX)"
 
   IDX=0
   while IFS= read -r WF_ID; do
@@ -394,22 +376,44 @@ else
     fi
 
     log_file="$LOG_DIR/${WF_ID}.log"
-    if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ] && [ -n "$TIMEOUT_TOOL" ]; then
-      # shellcheck disable=SC2086
-      pid="$(launch_detached "$log_file" "$TIMEOUT_TOOL" "$COMMAND_TIMEOUT_SECONDS" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless --no-track rebase "$task_id")" || pid=""
-    else
-      # shellcheck disable=SC2086
-      pid="$(launch_detached "$log_file" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless --no-track rebase "$task_id")" || pid=""
-    fi
-
-    if [ -n "$pid" ]; then
-      echo "  dispatched pid=$pid log=$log_file" >&2
-      DISPATCHED=$((DISPATCHED + 1))
-    else
-      echo "  failed to dispatch" >&2
-      LAUNCH_FAILED=$((LAUNCH_FAILED + 1))
-    fi
+    printf '{"label":"%s","workflowId":"%s","taskId":"%s","args":["rebase","%s"]}\n' "$WF_ID" "$WF_ID" "$task_id" "$task_id" >> "$COMMANDS_FILE"
+    echo "  queued log=$log_file" >&2
   done <<< "$WORKFLOW_IDS"
+
+  BATCH_ARGS=(batch-exec --no-track --parallel "$PARALLELISM")
+  if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ]; then
+    BATCH_ARGS+=(--timeout-ms "$((COMMAND_TIMEOUT_SECONDS * 1000))")
+  fi
+  node "$IPC_HELPER" "${BATCH_ARGS[@]}" < "$COMMANDS_FILE" > "$OUTPUT_JSONL"
+  python3 - "$RESULT_FILE" "$LOG_DIR" "$OUTPUT_JSONL" <<'PY'
+import json
+import pathlib
+import sys
+
+result_file = pathlib.Path(sys.argv[1])
+log_dir = pathlib.Path(sys.argv[2])
+output_jsonl = pathlib.Path(sys.argv[3])
+
+for raw in output_jsonl.read_text(encoding="utf-8").splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    item = json.loads(raw)
+    workflow_id = item.get("workflowId") or item.get("label") or "unknown"
+    (log_dir / f"{workflow_id}.log").write_text(raw + "\n", encoding="utf-8")
+    with result_file.open("a", encoding="utf-8") as handle:
+        handle.write(f"{workflow_id}\t{'SUCCEEDED' if item.get('ok') else 'FAILED'}\n")
+PY
+  rm -f "$COMMANDS_FILE"
+  rm -f "$OUTPUT_JSONL"
+
+  while IFS=$'\t' read -r _wf result; do
+    case "$result" in
+      SUCCEEDED) DISPATCHED=$((DISPATCHED + 1)) ;;
+      FAILED) LAUNCH_FAILED=$((LAUNCH_FAILED + 1)) ;;
+    esac
+  done < "$RESULT_FILE"
+  rm -f "$RESULT_FILE"
 
   echo "" >&2
   echo "Summary (fire-and-forget):" >&2

--- a/scripts/recreate-all.sh
+++ b/scripts/recreate-all.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ELECTRON="$REPO_ROOT/packages/app/node_modules/.bin/electron"
 MAIN="$REPO_ROOT/packages/app/dist/main.js"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 
 # Parse args
 DRY_RUN=false
@@ -56,8 +57,7 @@ headless_query() {
 
 # Helper: mutating command delegated to the current owner (GUI or standalone headless)
 headless_mutation() {
-  # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@"
+  node "$IPC_HELPER" exec -- "$@"
 }
 
 # Helper: extract workflow IDs from label output.
@@ -159,32 +159,47 @@ else
   LOG_DIR="$(mktemp -d -t recreate-all-logs.XXXXXX)"
   DISPATCHED=0
   LAUNCH_FAILED=0
-
-  launch_detached() {
-    local log_file="$1"
-    shift
-    if command -v setsid >/dev/null 2>&1; then
-      setsid "$@" >"$log_file" 2>&1 < /dev/null &
-    else
-      nohup "$@" >"$log_file" 2>&1 < /dev/null &
-    fi
-    echo "$!"
-  }
+  RESULT_FILE="$(mktemp -t recreate-all-results.XXXXXX)"
+  COMMANDS_FILE="$(mktemp -t recreate-all-commands.XXXXXX)"
+  OUTPUT_JSONL="$(mktemp -t recreate-all-output.XXXXXX)"
 
   while IFS= read -r WF_ID; do
     [[ -z "$WF_ID" ]] && continue
     IDX=$((IDX + 1))
-    log_file="$LOG_DIR/${WF_ID}.log"
-    # shellcheck disable=SC2086
-    pid="$(launch_detached "$log_file" "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless recreate "$WF_ID")" || pid=""
-    if [[ -n "$pid" ]]; then
-      echo "[dispatch $IDX/$TOTAL] $WF_ID pid=$pid log=$log_file"
-      DISPATCHED=$((DISPATCHED + 1))
-    else
-      echo "[dispatch $IDX/$TOTAL] $WF_ID FAILED_TO_START"
-      LAUNCH_FAILED=$((LAUNCH_FAILED + 1))
-    fi
+    printf '{"label":"%s","workflowId":"%s","args":["recreate","%s"]}\n' "$WF_ID" "$WF_ID" "$WF_ID" >> "$COMMANDS_FILE"
+    echo "[dispatch $IDX/$TOTAL] $WF_ID log=$LOG_DIR/${WF_ID}.log"
   done <<< "$WORKFLOWS"
+
+  node "$IPC_HELPER" batch-exec --no-track --parallel "$PARALLELISM" < "$COMMANDS_FILE" > "$OUTPUT_JSONL"
+  python3 - "$RESULT_FILE" "$LOG_DIR" "$OUTPUT_JSONL" <<'PY'
+import json
+import pathlib
+import sys
+
+result_file = pathlib.Path(sys.argv[1])
+log_dir = pathlib.Path(sys.argv[2])
+output_jsonl = pathlib.Path(sys.argv[3])
+
+for raw in output_jsonl.read_text(encoding="utf-8").splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    item = json.loads(raw)
+    workflow_id = item.get("workflowId") or item.get("label") or "unknown"
+    (log_dir / f"{workflow_id}.log").write_text(raw + "\n", encoding="utf-8")
+    with result_file.open("a", encoding="utf-8") as handle:
+        handle.write(f"{workflow_id}\t{'SUCCEEDED' if item.get('ok') else 'FAILED'}\n")
+PY
+  rm -f "$COMMANDS_FILE"
+  rm -f "$OUTPUT_JSONL"
+
+  while IFS=$'\t' read -r _wf result; do
+    case "$result" in
+      SUCCEEDED) DISPATCHED=$((DISPATCHED + 1)) ;;
+      FAILED) LAUNCH_FAILED=$((LAUNCH_FAILED + 1)) ;;
+    esac
+  done < "$RESULT_FILE"
+  rm -f "$RESULT_FILE"
 fi
 
 echo "---"

--- a/scripts/recreate-failed-tasks.sh
+++ b/scripts/recreate-failed-tasks.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# Recreate the earliest non-completed tasks in each workflow.
+#
+# For each selected workflow, query all tasks, ignore completed ones for
+# selection purposes, and recreate the pending/failed tasks that are closest to
+# the start of the DAG: tasks whose dependencies are all completed.
+#
+# This keeps the script intentionally explicit rather than DRY with the retry
+# scripts.
+#
+# Usage:
+#   bash scripts/recreate-failed-tasks.sh
+#   bash scripts/recreate-failed-tasks.sh --dry-run
+#   bash scripts/recreate-failed-tasks.sh --status failed
+#   bash scripts/recreate-failed-tasks.sh --workflow wf-123
+#   bash scripts/recreate-failed-tasks.sh --parallel 2
+#   bash scripts/recreate-failed-tasks.sh --follow
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ELECTRON="$REPO_ROOT/packages/app/node_modules/.bin/electron"
+MAIN="$REPO_ROOT/packages/app/dist/main.js"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
+
+DRY_RUN=false
+STATUS_FILTER=""
+WORKFLOW_FILTER=""
+PARALLELISM=""
+FOLLOW=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --follow)
+      FOLLOW=true
+      shift
+      ;;
+    --status)
+      STATUS_FILTER="${2:-}"
+      if [[ -z "$STATUS_FILTER" ]]; then
+        echo "Missing value for --status" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --workflow)
+      WORKFLOW_FILTER="${2:-}"
+      if [[ -z "$WORKFLOW_FILTER" ]]; then
+        echo "Missing value for --workflow" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --parallel)
+      PARALLELISM="${2:-}"
+      if [[ -z "$PARALLELISM" ]]; then
+        echo "Missing value for --parallel" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      echo "Usage: $0 [--dry-run] [--follow] [--status <workflow-status>] [--workflow <id>] [--parallel <n>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -n "$PARALLELISM" ]] && ! [[ "$PARALLELISM" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid --parallel value: $PARALLELISM (expected integer >= 1)" >&2
+  exit 1
+fi
+
+unset ELECTRON_RUN_AS_NODE
+SANDBOX_FLAG=""
+if [ "$(uname)" = "Linux" ]; then
+  SANDBOX_BIN="$REPO_ROOT/node_modules/.pnpm/electron@*/node_modules/electron/dist/chrome-sandbox"
+  # shellcheck disable=SC2086
+  if ! stat -c '%U:%a' $SANDBOX_BIN 2>/dev/null | grep -q '^root:4755$'; then
+    SANDBOX_FLAG="--no-sandbox"
+  fi
+  export LIBGL_ALWAYS_SOFTWARE=1
+fi
+
+headless_query() {
+  # shellcheck disable=SC2086
+  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
+}
+
+headless_mutation() {
+  node "$IPC_HELPER" exec -- "$@"
+}
+
+headless_workflow_ids() {
+  headless_query "$@" | grep -E '^wf-[0-9]+-[0-9]+$' || true
+}
+
+QUERY_ARGS=(query workflows --output label)
+if [[ -n "$STATUS_FILTER" ]]; then
+  QUERY_ARGS+=(--status "$STATUS_FILTER")
+fi
+
+WORKFLOWS="$(headless_workflow_ids "${QUERY_ARGS[@]}")"
+if [[ -n "$WORKFLOW_FILTER" ]]; then
+  WORKFLOWS="$(printf '%s\n' "$WORKFLOWS" | grep -Fx "$WORKFLOW_FILTER" || true)"
+fi
+
+if [[ -z "$WORKFLOWS" ]]; then
+  echo "No workflows found."
+  exit 0
+fi
+
+TARGETS_FILE="$(mktemp -t recreate-failed-tasks.targets.XXXXXX)"
+RESULTS_FILE=""
+cleanup() {
+  rm -f "$TARGETS_FILE"
+  if [[ -n "$RESULTS_FILE" ]]; then
+    rm -f "$RESULTS_FILE"
+  fi
+}
+trap cleanup EXIT
+
+while IFS= read -r WF_ID; do
+  [[ -z "$WF_ID" ]] && continue
+  TASKS_JSONL="$(headless_query query tasks --workflow "$WF_ID" --output jsonl | grep '^{' || true)"
+  [[ -z "$TASKS_JSONL" ]] && continue
+
+  WORKFLOW_TASKS_JSONL="$TASKS_JSONL" python3 - "$WF_ID" <<'PY' >> "$TARGETS_FILE"
+import json
+import os
+import sys
+
+workflow_id = sys.argv[1]
+raw = os.environ.get("WORKFLOW_TASKS_JSONL", "").strip()
+if not raw:
+    raise SystemExit(0)
+
+tasks = [json.loads(line) for line in raw.splitlines() if line.strip()]
+task_by_id = {task["id"]: task for task in tasks if task.get("id")}
+selected_statuses = {"pending", "failed"}
+
+for task in tasks:
+    task_id = task.get("id")
+    if not task_id:
+        continue
+    if task.get("status") not in selected_statuses:
+        continue
+
+    deps = task.get("dependencies", [])
+    if all((task_by_id.get(dep_id) or {}).get("status") == "completed" for dep_id in deps):
+        print(f"{workflow_id}\t{task_id}")
+PY
+done <<< "$WORKFLOWS"
+
+if [[ ! -s "$TARGETS_FILE" ]]; then
+  echo "No pending/failed frontier tasks found."
+  exit 0
+fi
+
+WORKFLOW_IDS="$(cut -f1 "$TARGETS_FILE" | awk '!seen[$0]++')"
+WORKFLOW_COUNT="$(printf '%s\n' "$WORKFLOW_IDS" | wc -l | tr -d ' ')"
+TARGET_COUNT="$(wc -l < "$TARGETS_FILE" | tr -d ' ')"
+
+if [[ -z "$PARALLELISM" ]]; then
+  PARALLELISM=1
+fi
+
+echo "Found $TARGET_COUNT frontier task(s) across $WORKFLOW_COUNT workflow(s)."
+echo "Parallelism: $PARALLELISM"
+echo "Follow mode: $FOLLOW"
+echo ""
+
+if $DRY_RUN; then
+  IDX=0
+  while IFS= read -r WF_ID; do
+    [[ -z "$WF_ID" ]] && continue
+    IDX=$((IDX + 1))
+    echo "[$IDX/$WORKFLOW_COUNT] $WF_ID"
+    while IFS=$'\t' read -r TARGET_WF TASK_ID; do
+      [[ "$TARGET_WF" == "$WF_ID" ]] || continue
+      echo "         (dry-run) would run: recreate-task $TASK_ID"
+    done < "$TARGETS_FILE"
+    echo ""
+  done <<< "$WORKFLOW_IDS"
+
+  echo "---"
+  echo "Dry run complete. $TARGET_COUNT frontier task(s) would be recreated."
+  exit 0
+fi
+
+launch_one_workflow() {
+  local wf_id="$1"
+  local log_file="$2"
+  local failed=0
+  local task_id=""
+  local cmd_out=""
+  local code=0
+
+  : > "$log_file"
+  while IFS=$'\t' read -r TARGET_WF TASK_ID; do
+    [[ "$TARGET_WF" == "$wf_id" ]] || continue
+    task_id="$TASK_ID"
+
+    {
+      echo "[$wf_id] recreate-task $task_id"
+      set +e
+      cmd_out="$(headless_mutation --no-track recreate-task "$task_id" 2>&1)"
+      code=$?
+      set -e
+      printf "%s\n" "$cmd_out"
+      if [[ "$code" -eq 0 ]]; then
+        echo "[$wf_id] OK $task_id"
+      else
+        echo "[$wf_id] FAILED $task_id (exit $code)"
+        failed=1
+      fi
+      echo ""
+    } >> "$log_file"
+  done < "$TARGETS_FILE"
+
+  if [[ "$failed" -eq 0 ]]; then
+    echo "[$wf_id] OK"
+    return 0
+  fi
+
+  echo "[$wf_id] FAILED"
+  return 1
+}
+
+FAILED=0
+SUCCEEDED=0
+IDX=0
+
+if $FOLLOW; then
+  RESULTS_FILE="$(mktemp -t recreate-failed-tasks-results.XXXXXX)"
+  LOG_DIR="$(mktemp -d -t recreate-failed-tasks-logs.XXXXXX)"
+  PIDS=()
+
+  while IFS= read -r WF_ID; do
+    [[ -z "$WF_ID" ]] && continue
+    IDX=$((IDX + 1))
+    echo "[queue $IDX/$WORKFLOW_COUNT] $WF_ID"
+    log_file="$LOG_DIR/${WF_ID}.log"
+    (
+      if launch_one_workflow "$WF_ID" "$log_file"; then
+        printf "%s\tSUCCEEDED\n" "$WF_ID" >> "$RESULTS_FILE"
+      else
+        printf "%s\tFAILED\n" "$WF_ID" >> "$RESULTS_FILE"
+      fi
+      cat "$log_file"
+    ) &
+    PIDS+=("$!")
+
+    while [[ "$(jobs -pr | wc -l | tr -d ' ')" -ge "$PARALLELISM" ]]; do
+      sleep 0.2
+    done
+  done <<< "$WORKFLOW_IDS"
+
+  for pid in "${PIDS[@]}"; do
+    wait "$pid" || true
+  done
+
+  while IFS=$'\t' read -r _wf result; do
+    case "$result" in
+      SUCCEEDED) SUCCEEDED=$((SUCCEEDED + 1)) ;;
+      FAILED) FAILED=$((FAILED + 1)) ;;
+    esac
+  done < "$RESULTS_FILE"
+else
+  LOG_DIR="$(mktemp -d -t recreate-failed-tasks-logs.XXXXXX)"
+  DISPATCHED=0
+  RESULTS_FILE="$(mktemp -t recreate-failed-tasks-results.XXXXXX)"
+  PIDS=()
+
+  while IFS= read -r WF_ID; do
+    [[ -z "$WF_ID" ]] && continue
+    IDX=$((IDX + 1))
+    log_file="$LOG_DIR/${WF_ID}.log"
+    (
+      if launch_one_workflow "$WF_ID" "$log_file"; then
+        printf "%s\tSUCCEEDED\n" "$WF_ID" >> "$RESULTS_FILE"
+      else
+        printf "%s\tFAILED\n" "$WF_ID" >> "$RESULTS_FILE"
+      fi
+    ) &
+    PIDS+=("$!")
+    echo "[dispatch $IDX/$WORKFLOW_COUNT] $WF_ID log=$log_file"
+
+    while [[ "$(jobs -pr | wc -l | tr -d ' ')" -ge "$PARALLELISM" ]]; do
+      sleep 0.2
+    done
+  done <<< "$WORKFLOW_IDS"
+
+  for pid in "${PIDS[@]}"; do
+    wait "$pid" || true
+  done
+
+  while IFS=$'\t' read -r _wf result; do
+    case "$result" in
+      SUCCEEDED)
+        DISPATCHED=$((DISPATCHED + 1))
+        ;;
+      FAILED)
+        FAILED=$((FAILED + 1))
+        ;;
+    esac
+  done < "$RESULTS_FILE"
+fi
+
+echo "---"
+if $FOLLOW; then
+  echo "Done. $SUCCEEDED succeeded, $FAILED failed out of $WORKFLOW_COUNT."
+  echo "Logs: $LOG_DIR"
+  if [[ "$FAILED" -ne 0 ]]; then
+    exit 1
+  fi
+else
+  echo "Submitted $DISPATCHED workflow(s) with bounded concurrency. Logs: $LOG_DIR"
+  if [[ "$FAILED" -ne 0 ]]; then
+    echo "$FAILED workflow(s) failed to submit."
+    exit 1
+  fi
+fi

--- a/scripts/retry-all.sh
+++ b/scripts/retry-all.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Retry every workflow via the existing workflow-scope retry script.
+# This intentionally does not do any rebase/fresh-base work.
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+exec bash "$REPO_ROOT/scripts/retry-failed-and-pending-all-workflows.sh" "$@"

--- a/scripts/retry-failed-and-pending-all-workflows.sh
+++ b/scripts/retry-failed-and-pending-all-workflows.sh
@@ -15,6 +15,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RUNNER="$REPO_ROOT/run.sh"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
 
 DRY_RUN=false
 STATUS_FILTER=""
@@ -118,6 +119,7 @@ if $DRY_RUN; then
 else
   FAILED=0
   SUCCEEDED=0
+  DISPATCHED=0
   IDX=0
 
   launch_one_workflow() {
@@ -127,7 +129,7 @@ else
     local code=0
 
     set +e
-    cmd_out="$("$RUNNER" --headless retry "$wf_id" --no-track 2>&1)"
+    cmd_out="$(node "$IPC_HELPER" exec --no-track -- retry "$wf_id" 2>&1)"
     code=$?
     set -e
 
@@ -182,32 +184,40 @@ else
     rm -f "$RESULTS_FILE"
   else
     LOG_DIR="$(mktemp -d -t retry-failed-logs.XXXXXX)"
-    DISPATCHED=0
-    PIDS=()
     RESULT_FILE="$(mktemp -t retry-failed-results.XXXXXX)"
-
+    COMMANDS_FILE="$(mktemp -t retry-failed-commands.XXXXXX)"
+    OUTPUT_JSONL="$(mktemp -t retry-failed-output.XXXXXX)"
     while IFS= read -r WF_ID; do
       [[ -z "$WF_ID" ]] && continue
       IDX=$((IDX + 1))
-      log_file="$LOG_DIR/${WF_ID}.log"
-      (
-        if launch_one_workflow "$WF_ID" "$log_file"; then
-          printf "%s\tSUCCEEDED\n" "$WF_ID" >> "$RESULT_FILE"
-        else
-          printf "%s\tFAILED\n" "$WF_ID" >> "$RESULT_FILE"
-        fi
-      ) &
-      PIDS+=("$!")
-      echo "[dispatch $IDX/$TOTAL] $WF_ID log=$log_file"
-
-      while [[ "$(jobs -pr | wc -l | tr -d ' ')" -ge "$PARALLELISM" ]]; do
-        sleep 0.2
-      done
+      printf '{"label":"%s","workflowId":"%s","args":["retry","%s"]}\n' "$WF_ID" "$WF_ID" "$WF_ID" >> "$COMMANDS_FILE"
+      echo "[dispatch $IDX/$TOTAL] $WF_ID log=$LOG_DIR/${WF_ID}.log"
     done <<<"$WORKFLOWS"
 
-    for pid in "${PIDS[@]}"; do
-      wait "$pid" || true
-    done
+    node "$IPC_HELPER" batch-exec --no-track --parallel "$PARALLELISM" < "$COMMANDS_FILE" > "$OUTPUT_JSONL"
+    python3 - "$RESULT_FILE" "$LOG_DIR" "$OUTPUT_JSONL" <<'PY'
+import json
+import pathlib
+import sys
+
+result_file = pathlib.Path(sys.argv[1])
+log_dir = pathlib.Path(sys.argv[2])
+output_jsonl = pathlib.Path(sys.argv[3])
+
+for raw in output_jsonl.read_text(encoding="utf-8").splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    item = json.loads(raw)
+    workflow_id = item.get("workflowId") or item.get("label") or "unknown"
+    log_path = log_dir / f"{workflow_id}.log"
+    with log_path.open("w", encoding="utf-8") as handle:
+        handle.write(raw + "\n")
+    with result_file.open("a", encoding="utf-8") as handle:
+        handle.write(f"{workflow_id}\t{'SUCCEEDED' if item.get('ok') else 'FAILED'}\n")
+PY
+    rm -f "$COMMANDS_FILE"
+    rm -f "$OUTPUT_JSONL"
 
     while IFS=$'\t' read -r _wf result; do
       case "$result" in


### PR DESCRIPTION
## Summary

Batch headless workflow mutation scripts over direct IPC instead of spawning a fresh client per workflow, and always recover expired workflow mutations on owner startup. That startup recovery matters because workflow mutations are durable control-plane operations: if the owner crashes mid-retry, recreate, approve, or fix-with-agent, persistence can still contain a stale running intent and half-updated workflow state. On the next owner start, we now requeue expired leases and resume pending mutations so workflows do not stay stranded until manual intervention.

## Architecture

### Before

```mermaid
graph TD
    A[Bulk retry script] --> B[Spawn one headless client per workflow]
    B --> C[High overhead and brittle owner delegation]
    D[Owner restart] --> E[Expired mutation may stay queued]
```

### After

```mermaid
graph TD
    A[Bulk retry script] --> B[Batch IPC submissions to shared owner]
    B --> C[Lower per-workflow overhead]
    D[Owner restart] --> E[Expired mutation leases are resumed]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/persisted-workflow-mutation-coordinator.test.ts src/__tests__/workflow-mutation-startup.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 32fcd038`
- Post-revert steps: None
- Data migration? No
