### PR TITLE
Task delta revision step 2: main-process gap detection and authoritative recovery

### DIFF
--- a/packages/app/src/__tests__/delta-merge.test.ts
+++ b/packages/app/src/__tests__/delta-merge.test.ts
@@ -1,13 +1,17 @@
 /**
- * Tests for the delta-merge helper extracted from main.ts.
+ * Tests for the revision-aware delta-merge cache.
  *
- * Covers the out-of-order delta scenario: an `updated` delta arrives
- * for a task that has no prior `created` entry in the state map.
- * The fix fetches the task from the orchestrator fallback so the
- * update is not silently dropped.
+ * Covers:
+ * - created / removed deltas
+ * - updated deltas with correct revision continuity
+ * - revision gap → quarantine
+ * - unknown task → quarantine
+ * - quarantined task ignores further deltas until resolved
+ * - resolveQuarantine re-seeds the cache from authoritative data
+ * - TaskSnapshotCache bulk operations (set/get/clear/keys/delete)
  */
 import { describe, it, expect } from 'vitest';
-import { applyDelta, type TaskLookup } from '../delta-merge.js';
+import { applyDelta, resolveQuarantine, TaskSnapshotCache } from '../delta-merge.js';
 import type { TaskState, TaskDelta } from '@invoker/workflow-core';
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -21,163 +25,305 @@ function makeTask(id: string, overrides: Partial<TaskState> = {}): TaskState {
     createdAt: new Date('2025-01-01'),
     config: { workflowId: 'wf-1', command: `echo ${id}`, executorType: 'worktree' as const },
     execution: {},
+    revision: 1,
     ...overrides,
   } as TaskState;
 }
 
-function makeLookup(tasks: TaskState[]): TaskLookup {
-  return { getAllTasks: () => tasks };
-}
+// ── TaskSnapshotCache ────────────────────────────────────────
 
-// ── Tests ────────────────────────────────────────────────────
+describe('TaskSnapshotCache', () => {
+  it('set/get round-trips a snapshot and extracts revision', () => {
+    const cache = new TaskSnapshotCache();
+    const task = makeTask('t1', { revision: 3 });
+    cache.set('t1', JSON.stringify(task));
+
+    expect(cache.get('t1')).toBe(JSON.stringify(task));
+    expect(cache.getEntry('t1')?.revision).toBe(3);
+    expect(cache.getEntry('t1')?.quarantined).toBe(false);
+  });
+
+  it('has/delete/clear work as expected', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1')));
+    cache.set('t2', JSON.stringify(makeTask('t2')));
+
+    expect(cache.has('t1')).toBe(true);
+    cache.delete('t1');
+    expect(cache.has('t1')).toBe(false);
+
+    cache.clear();
+    expect(cache.has('t2')).toBe(false);
+  });
+
+  it('keys returns all task ids', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1')));
+    cache.set('t2', JSON.stringify(makeTask('t2')));
+
+    expect(new Set(cache.keys())).toEqual(new Set(['t1', 't2']));
+  });
+
+  it('defaults revision to 1 when task has no revision field', () => {
+    const cache = new TaskSnapshotCache();
+    const task = makeTask('t1');
+    // Simulate a legacy snapshot without revision
+    const legacy = { ...task } as Record<string, unknown>;
+    delete legacy.revision;
+    cache.set('t1', JSON.stringify(legacy));
+
+    expect(cache.getEntry('t1')?.revision).toBe(1);
+  });
+});
+
+// ── applyDelta ───────────────────────────────────────────────
 
 describe('applyDelta', () => {
   describe('created delta', () => {
-    it('stores the task snapshot', () => {
-      const stateMap = new Map<string, string>();
-      const task = makeTask('t1');
+    it('stores the task snapshot with revision', () => {
+      const cache = new TaskSnapshotCache();
+      const task = makeTask('t1', { revision: 2 });
       const delta: TaskDelta = { type: 'created', task };
 
-      applyDelta(delta, stateMap);
+      const result = applyDelta(delta, cache);
 
-      expect(stateMap.has('t1')).toBe(true);
-      const stored = JSON.parse(stateMap.get('t1')!);
+      expect(result.quarantined).toEqual([]);
+      expect(cache.has('t1')).toBe(true);
+      const stored = JSON.parse(cache.get('t1')!);
       expect(stored.id).toBe('t1');
       expect(stored.status).toBe('running');
+      expect(cache.getEntry('t1')?.revision).toBe(2);
     });
   });
 
-  describe('updated delta with prior created', () => {
-    it('merges changes onto existing snapshot', () => {
-      const stateMap = new Map<string, string>();
-      const task = makeTask('t1');
-      stateMap.set('t1', JSON.stringify(task));
+  describe('updated delta with matching previousRevision', () => {
+    it('merges changes and bumps revision', () => {
+      const cache = new TaskSnapshotCache();
+      const task = makeTask('t1', { revision: 1 });
+      cache.set('t1', JSON.stringify(task));
 
       const delta: TaskDelta = {
         type: 'updated',
         taskId: 't1',
         changes: { status: 'completed', execution: { exitCode: 0 } },
+        revision: 2,
+        previousRevision: 1,
       };
 
-      applyDelta(delta, stateMap);
+      const result = applyDelta(delta, cache);
 
-      const stored = JSON.parse(stateMap.get('t1')!);
+      expect(result.quarantined).toEqual([]);
+      const stored = JSON.parse(cache.get('t1')!);
       expect(stored.status).toBe('completed');
       expect(stored.execution.exitCode).toBe(0);
+      expect(stored.revision).toBe(2);
+      expect(cache.getEntry('t1')?.revision).toBe(2);
     });
-  });
 
-  describe('out-of-order: updated delta without prior created', () => {
-    it('seeds the task from orchestrator fallback and applies the update', () => {
-      const stateMap = new Map<string, string>();
-      const knownTask = makeTask('t1', { status: 'running' });
-      const lookup = makeLookup([knownTask]);
+    it('chains two sequential updates', () => {
+      const cache = new TaskSnapshotCache();
+      const task = makeTask('t1', { revision: 1 });
+      cache.set('t1', JSON.stringify(task));
 
-      // Simulate receiving an `updated` delta for t1 without a prior `created`.
-      const delta: TaskDelta = {
+      applyDelta({
         type: 'updated',
         taskId: 't1',
         changes: { status: 'completed', execution: { exitCode: 0 } },
-      };
+        revision: 2,
+        previousRevision: 1,
+      }, cache);
 
-      applyDelta(delta, stateMap, lookup);
-
-      // The task must be populated, not dropped.
-      expect(stateMap.has('t1')).toBe(true);
-      const stored = JSON.parse(stateMap.get('t1')!);
-      expect(stored.id).toBe('t1');
-      expect(stored.status).toBe('completed');
-      expect(stored.execution.exitCode).toBe(0);
-    });
-
-    it('applies a second updated delta on top of the first', () => {
-      const stateMap = new Map<string, string>();
-      const knownTask = makeTask('t1', { status: 'running' });
-      const lookup = makeLookup([knownTask]);
-
-      // First update: seeds from orchestrator.
-      const delta1: TaskDelta = {
-        type: 'updated',
-        taskId: 't1',
-        changes: { status: 'completed', execution: { exitCode: 0 } },
-      };
-      applyDelta(delta1, stateMap, lookup);
-
-      // Second update: merges on top of the first.
-      const delta2: TaskDelta = {
+      applyDelta({
         type: 'updated',
         taskId: 't1',
         changes: { execution: { error: 'test failure' } },
-      };
-      applyDelta(delta2, stateMap, lookup);
+        revision: 3,
+        previousRevision: 2,
+      }, cache);
 
-      const stored = JSON.parse(stateMap.get('t1')!);
+      const stored = JSON.parse(cache.get('t1')!);
       expect(stored.status).toBe('completed');
       expect(stored.execution.exitCode).toBe(0);
       expect(stored.execution.error).toBe('test failure');
+      expect(stored.revision).toBe(3);
+    });
+  });
+
+  describe('revision gap detection', () => {
+    it('quarantines when previousRevision does not match cached revision', () => {
+      const cache = new TaskSnapshotCache();
+      const task = makeTask('t1', { revision: 1 });
+      cache.set('t1', JSON.stringify(task));
+
+      const delta: TaskDelta = {
+        type: 'updated',
+        taskId: 't1',
+        changes: { status: 'completed' },
+        revision: 5,
+        previousRevision: 4, // gap: cached revision is 1, not 4
+      };
+
+      const result = applyDelta(delta, cache);
+
+      expect(result.quarantined).toEqual(['t1']);
+      expect(cache.isQuarantined('t1')).toBe(true);
+      // The snapshot should NOT have been updated
+      const stored = JSON.parse(cache.get('t1')!);
+      expect(stored.status).toBe('running');
+      expect(stored.revision).toBe(1);
     });
 
-    it('drops the update when task is unknown and no fallback available', () => {
-      const stateMap = new Map<string, string>();
+    it('quarantines when task is unknown (no prior created)', () => {
+      const cache = new TaskSnapshotCache();
 
       const delta: TaskDelta = {
         type: 'updated',
         taskId: 'unknown',
         changes: { status: 'completed' },
+        revision: 2,
+        previousRevision: 1,
       };
 
-      // No lookup provided — update should be silently dropped.
-      applyDelta(delta, stateMap);
+      const result = applyDelta(delta, cache);
 
-      expect(stateMap.has('unknown')).toBe(false);
+      expect(result.quarantined).toEqual(['unknown']);
     });
 
-    it('drops the update when task is not in orchestrator either', () => {
-      const stateMap = new Map<string, string>();
-      const lookup = makeLookup([]); // empty orchestrator
+    it('ignores deltas for quarantined tasks', () => {
+      const cache = new TaskSnapshotCache();
+      const task = makeTask('t1', { revision: 1 });
+      cache.set('t1', JSON.stringify(task));
 
-      const delta: TaskDelta = {
+      // First: trigger quarantine
+      applyDelta({
         type: 'updated',
-        taskId: 'ghost',
+        taskId: 't1',
+        changes: { status: 'failed' },
+        revision: 10,
+        previousRevision: 9,
+      }, cache);
+      expect(cache.isQuarantined('t1')).toBe(true);
+
+      // Second: another delta arrives while quarantined — should be ignored
+      const result = applyDelta({
+        type: 'updated',
+        taskId: 't1',
         changes: { status: 'completed' },
-      };
+        revision: 11,
+        previousRevision: 10,
+      }, cache);
 
-      applyDelta(delta, stateMap, lookup);
-
-      expect(stateMap.has('ghost')).toBe(false);
+      expect(result.quarantined).toEqual([]);
+      // Snapshot unchanged from original
+      const stored = JSON.parse(cache.get('t1')!);
+      expect(stored.status).toBe('running');
     });
   });
 
   describe('removed delta', () => {
-    it('removes the task from the state map', () => {
-      const stateMap = new Map<string, string>();
-      stateMap.set('t1', JSON.stringify(makeTask('t1')));
+    it('removes the task from the cache', () => {
+      const cache = new TaskSnapshotCache();
+      cache.set('t1', JSON.stringify(makeTask('t1')));
 
-      const delta: TaskDelta = { type: 'removed', taskId: 't1' };
+      const delta: TaskDelta = { type: 'removed', taskId: 't1', previousRevision: 1 };
 
-      applyDelta(delta, stateMap);
+      applyDelta(delta, cache);
 
-      expect(stateMap.has('t1')).toBe(false);
+      expect(cache.has('t1')).toBe(false);
     });
   });
 
   describe('config merging', () => {
     it('merges config changes without losing existing config fields', () => {
-      const stateMap = new Map<string, string>();
-      const task = makeTask('t1');
-      stateMap.set('t1', JSON.stringify(task));
+      const cache = new TaskSnapshotCache();
+      const task = makeTask('t1', { revision: 1 });
+      cache.set('t1', JSON.stringify(task));
 
       const delta: TaskDelta = {
         type: 'updated',
         taskId: 't1',
         changes: { config: { command: 'echo updated' } },
+        revision: 2,
+        previousRevision: 1,
       };
 
-      applyDelta(delta, stateMap);
+      applyDelta(delta, cache);
 
-      const stored = JSON.parse(stateMap.get('t1')!);
+      const stored = JSON.parse(cache.get('t1')!);
       expect(stored.config.command).toBe('echo updated');
       expect(stored.config.workflowId).toBe('wf-1');
     });
+  });
+});
+
+// ── resolveQuarantine ────────────────────────────────────────
+
+describe('resolveQuarantine', () => {
+  it('replaces quarantined entry with authoritative task', () => {
+    const cache = new TaskSnapshotCache();
+    const task = makeTask('t1', { revision: 1 });
+    cache.set('t1', JSON.stringify(task));
+
+    // Quarantine via gap
+    applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'completed' },
+      revision: 5,
+      previousRevision: 4,
+    }, cache);
+    expect(cache.isQuarantined('t1')).toBe(true);
+
+    // Resolve with authoritative state
+    const authoritative = makeTask('t1', { revision: 5, status: 'completed' });
+    resolveQuarantine(cache, 't1', authoritative);
+
+    expect(cache.isQuarantined('t1')).toBe(false);
+    expect(cache.getEntry('t1')?.revision).toBe(5);
+    const stored = JSON.parse(cache.get('t1')!);
+    expect(stored.status).toBe('completed');
+  });
+
+  it('removes entry when task no longer exists in persistence', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1')));
+
+    resolveQuarantine(cache, 't1', undefined);
+
+    expect(cache.has('t1')).toBe(false);
+  });
+
+  it('allows normal delta processing after recovery', () => {
+    const cache = new TaskSnapshotCache();
+    const task = makeTask('t1', { revision: 1 });
+    cache.set('t1', JSON.stringify(task));
+
+    // Quarantine
+    applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'failed' },
+      revision: 3,
+      previousRevision: 2,
+    }, cache);
+
+    // Resolve
+    const authoritative = makeTask('t1', { revision: 3, status: 'failed' });
+    resolveQuarantine(cache, 't1', authoritative);
+
+    // Now a delta with correct continuity should apply
+    const result = applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { execution: { exitCode: 1 } },
+      revision: 4,
+      previousRevision: 3,
+    }, cache);
+
+    expect(result.quarantined).toEqual([]);
+    const stored = JSON.parse(cache.get('t1')!);
+    expect(stored.status).toBe('failed');
+    expect(stored.execution.exitCode).toBe(1);
+    expect(stored.revision).toBe(4);
   });
 });

--- a/packages/app/src/__tests__/delta-merge.test.ts
+++ b/packages/app/src/__tests__/delta-merge.test.ts
@@ -1,10 +1,10 @@
 /**
- * Tests for the revision-aware delta-merge cache.
+ * Tests for the task-state-version-aware delta-merge cache.
  *
  * Covers:
  * - created / removed deltas
- * - updated deltas with correct revision continuity
- * - revision gap → quarantine
+ * - updated deltas with correct taskStateVersion continuity
+ * - taskStateVersion gap → quarantine
  * - unknown task → quarantine
  * - quarantined task ignores further deltas until resolved
  * - resolveQuarantine re-seeds the cache from authoritative data
@@ -28,7 +28,7 @@ function makeTask(id: string, overrides: Partial<TaskState> = {}): TaskState {
     createdAt: new Date('2025-01-01'),
     config: { workflowId: 'wf-1', command: `echo ${id}`, executorType: 'worktree' as const },
     execution: {},
-    revision: 1,
+    taskStateVersion: 1,
     ...overrides,
   } as TaskState;
 }
@@ -36,13 +36,13 @@ function makeTask(id: string, overrides: Partial<TaskState> = {}): TaskState {
 // ── TaskSnapshotCache ────────────────────────────────────────
 
 describe('TaskSnapshotCache', () => {
-  it('set/get round-trips a snapshot and extracts revision', () => {
+  it('set/get round-trips a snapshot and extracts taskStateVersion', () => {
     const cache = new TaskSnapshotCache();
-    const task = makeTask('t1', { revision: 3 });
+    const task = makeTask('t1', { taskStateVersion: 3 });
     cache.set('t1', JSON.stringify(task));
 
     expect(cache.get('t1')).toBe(JSON.stringify(task));
-    expect(cache.getEntry('t1')?.revision).toBe(3);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(3);
     expect(cache.getEntry('t1')?.quarantined).toBe(false);
   });
 
@@ -67,15 +67,15 @@ describe('TaskSnapshotCache', () => {
     expect(new Set(cache.keys())).toEqual(new Set(['t1', 't2']));
   });
 
-  it('defaults revision to 1 when task has no revision field', () => {
+  it('defaults taskStateVersion to 1 when task has no taskStateVersion field', () => {
     const cache = new TaskSnapshotCache();
     const task = makeTask('t1');
-    // Simulate a legacy snapshot without revision
+    // Simulate a legacy snapshot without taskStateVersion
     const legacy = { ...task } as Record<string, unknown>;
-    delete legacy.revision;
+    delete legacy.taskStateVersion;
     cache.set('t1', JSON.stringify(legacy));
 
-    expect(cache.getEntry('t1')?.revision).toBe(1);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(1);
   });
 });
 
@@ -83,9 +83,9 @@ describe('TaskSnapshotCache', () => {
 
 describe('applyDelta', () => {
   describe('created delta', () => {
-    it('stores the task snapshot with revision', () => {
+    it('stores the task snapshot with taskStateVersion', () => {
       const cache = new TaskSnapshotCache();
-      const task = makeTask('t1', { revision: 2 });
+      const task = makeTask('t1', { taskStateVersion: 2 });
       const delta: TaskDelta = { type: 'created', task };
 
       const result = applyDelta(delta, cache);
@@ -95,22 +95,22 @@ describe('applyDelta', () => {
       const stored = JSON.parse(cache.get('t1')!);
       expect(stored.id).toBe('t1');
       expect(stored.status).toBe('running');
-      expect(cache.getEntry('t1')?.revision).toBe(2);
+      expect(cache.getEntry('t1')?.taskStateVersion).toBe(2);
     });
   });
 
-  describe('updated delta with matching previousRevision', () => {
-    it('merges changes and bumps revision', () => {
+  describe('updated delta with matching previousTaskStateVersion', () => {
+    it('merges changes and bumps taskStateVersion', () => {
       const cache = new TaskSnapshotCache();
-      const task = makeTask('t1', { revision: 1 });
+      const task = makeTask('t1', { taskStateVersion: 1 });
       cache.set('t1', JSON.stringify(task));
 
       const delta: TaskDelta = {
         type: 'updated',
         taskId: 't1',
         changes: { status: 'completed', execution: { exitCode: 0 } },
-        revision: 2,
-        previousRevision: 1,
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
       };
 
       const result = applyDelta(delta, cache);
@@ -119,51 +119,51 @@ describe('applyDelta', () => {
       const stored = JSON.parse(cache.get('t1')!);
       expect(stored.status).toBe('completed');
       expect(stored.execution.exitCode).toBe(0);
-      expect(stored.revision).toBe(2);
-      expect(cache.getEntry('t1')?.revision).toBe(2);
+      expect(stored.taskStateVersion).toBe(2);
+      expect(cache.getEntry('t1')?.taskStateVersion).toBe(2);
     });
 
     it('chains two sequential updates', () => {
       const cache = new TaskSnapshotCache();
-      const task = makeTask('t1', { revision: 1 });
+      const task = makeTask('t1', { taskStateVersion: 1 });
       cache.set('t1', JSON.stringify(task));
 
       applyDelta({
         type: 'updated',
         taskId: 't1',
         changes: { status: 'completed', execution: { exitCode: 0 } },
-        revision: 2,
-        previousRevision: 1,
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
       }, cache);
 
       applyDelta({
         type: 'updated',
         taskId: 't1',
         changes: { execution: { error: 'test failure' } },
-        revision: 3,
-        previousRevision: 2,
+        taskStateVersion: 3,
+        previousTaskStateVersion: 2,
       }, cache);
 
       const stored = JSON.parse(cache.get('t1')!);
       expect(stored.status).toBe('completed');
       expect(stored.execution.exitCode).toBe(0);
       expect(stored.execution.error).toBe('test failure');
-      expect(stored.revision).toBe(3);
+      expect(stored.taskStateVersion).toBe(3);
     });
   });
 
-  describe('revision gap detection', () => {
-    it('quarantines when previousRevision does not match cached revision', () => {
+  describe('taskStateVersion gap detection', () => {
+    it('quarantines when previousTaskStateVersion does not match cached taskStateVersion', () => {
       const cache = new TaskSnapshotCache();
-      const task = makeTask('t1', { revision: 1 });
+      const task = makeTask('t1', { taskStateVersion: 1 });
       cache.set('t1', JSON.stringify(task));
 
       const delta: TaskDelta = {
         type: 'updated',
         taskId: 't1',
         changes: { status: 'completed' },
-        revision: 5,
-        previousRevision: 4, // gap: cached revision is 1, not 4
+        taskStateVersion: 5,
+        previousTaskStateVersion: 4, // gap: cached taskStateVersion is 1, not 4
       };
 
       const result = applyDelta(delta, cache);
@@ -173,7 +173,7 @@ describe('applyDelta', () => {
       // The snapshot should NOT have been updated
       const stored = JSON.parse(cache.get('t1')!);
       expect(stored.status).toBe('running');
-      expect(stored.revision).toBe(1);
+      expect(stored.taskStateVersion).toBe(1);
     });
 
     it('quarantines when task is unknown (no prior created)', () => {
@@ -183,8 +183,8 @@ describe('applyDelta', () => {
         type: 'updated',
         taskId: 'unknown',
         changes: { status: 'completed' },
-        revision: 2,
-        previousRevision: 1,
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
       };
 
       const result = applyDelta(delta, cache);
@@ -194,7 +194,7 @@ describe('applyDelta', () => {
 
     it('ignores deltas for quarantined tasks', () => {
       const cache = new TaskSnapshotCache();
-      const task = makeTask('t1', { revision: 1 });
+      const task = makeTask('t1', { taskStateVersion: 1 });
       cache.set('t1', JSON.stringify(task));
 
       // First: trigger quarantine
@@ -202,8 +202,8 @@ describe('applyDelta', () => {
         type: 'updated',
         taskId: 't1',
         changes: { status: 'failed' },
-        revision: 10,
-        previousRevision: 9,
+        taskStateVersion: 10,
+        previousTaskStateVersion: 9,
       }, cache);
       expect(cache.isQuarantined('t1')).toBe(true);
 
@@ -212,8 +212,8 @@ describe('applyDelta', () => {
         type: 'updated',
         taskId: 't1',
         changes: { status: 'completed' },
-        revision: 11,
-        previousRevision: 10,
+        taskStateVersion: 11,
+        previousTaskStateVersion: 10,
       }, cache);
 
       expect(result.quarantined).toEqual([]);
@@ -228,7 +228,7 @@ describe('applyDelta', () => {
       const cache = new TaskSnapshotCache();
       cache.set('t1', JSON.stringify(makeTask('t1')));
 
-      const delta: TaskDelta = { type: 'removed', taskId: 't1', previousRevision: 1 };
+      const delta: TaskDelta = { type: 'removed', taskId: 't1', previousTaskStateVersion: 1 };
 
       applyDelta(delta, cache);
 
@@ -239,15 +239,15 @@ describe('applyDelta', () => {
   describe('config merging', () => {
     it('merges config changes without losing existing config fields', () => {
       const cache = new TaskSnapshotCache();
-      const task = makeTask('t1', { revision: 1 });
+      const task = makeTask('t1', { taskStateVersion: 1 });
       cache.set('t1', JSON.stringify(task));
 
       const delta: TaskDelta = {
         type: 'updated',
         taskId: 't1',
         changes: { config: { command: 'echo updated' } },
-        revision: 2,
-        previousRevision: 1,
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
       };
 
       applyDelta(delta, cache);
@@ -264,7 +264,7 @@ describe('applyDelta', () => {
 describe('resolveQuarantine', () => {
   it('replaces quarantined entry with authoritative task', () => {
     const cache = new TaskSnapshotCache();
-    const task = makeTask('t1', { revision: 1 });
+    const task = makeTask('t1', { taskStateVersion: 1 });
     cache.set('t1', JSON.stringify(task));
 
     // Quarantine via gap
@@ -272,17 +272,17 @@ describe('resolveQuarantine', () => {
       type: 'updated',
       taskId: 't1',
       changes: { status: 'completed' },
-      revision: 5,
-      previousRevision: 4,
+      taskStateVersion: 5,
+      previousTaskStateVersion: 4,
     }, cache);
     expect(cache.isQuarantined('t1')).toBe(true);
 
     // Resolve with authoritative state
-    const authoritative = makeTask('t1', { revision: 5, status: 'completed' });
+    const authoritative = makeTask('t1', { taskStateVersion: 5, status: 'completed' });
     resolveQuarantine(cache, 't1', authoritative);
 
     expect(cache.isQuarantined('t1')).toBe(false);
-    expect(cache.getEntry('t1')?.revision).toBe(5);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(5);
     const stored = JSON.parse(cache.get('t1')!);
     expect(stored.status).toBe('completed');
   });
@@ -298,7 +298,7 @@ describe('resolveQuarantine', () => {
 
   it('allows normal delta processing after recovery', () => {
     const cache = new TaskSnapshotCache();
-    const task = makeTask('t1', { revision: 1 });
+    const task = makeTask('t1', { taskStateVersion: 1 });
     cache.set('t1', JSON.stringify(task));
 
     // Quarantine
@@ -306,12 +306,12 @@ describe('resolveQuarantine', () => {
       type: 'updated',
       taskId: 't1',
       changes: { status: 'failed' },
-      revision: 3,
-      previousRevision: 2,
+      taskStateVersion: 3,
+      previousTaskStateVersion: 2,
     }, cache);
 
     // Resolve
-    const authoritative = makeTask('t1', { revision: 3, status: 'failed' });
+    const authoritative = makeTask('t1', { taskStateVersion: 3, status: 'failed' });
     resolveQuarantine(cache, 't1', authoritative);
 
     // Now a delta with correct continuity should apply
@@ -319,15 +319,15 @@ describe('resolveQuarantine', () => {
       type: 'updated',
       taskId: 't1',
       changes: { execution: { exitCode: 1 } },
-      revision: 4,
-      previousRevision: 3,
+      taskStateVersion: 4,
+      previousTaskStateVersion: 3,
     }, cache);
 
     expect(result.quarantined).toEqual([]);
     const stored = JSON.parse(cache.get('t1')!);
     expect(stored.status).toBe('failed');
     expect(stored.execution.exitCode).toBe(1);
-    expect(stored.revision).toBe(4);
+    expect(stored.taskStateVersion).toBe(4);
   });
 });
 
@@ -364,22 +364,22 @@ function simulateMainProcessDeltaHandler(
 describe('gap recovery: unknown task → quarantine + authoritative reload', () => {
   it('unknown task triggers quarantine and sends authoritative snapshot to renderer', () => {
     const cache = new TaskSnapshotCache();
-    const authoritativeTask = makeTask('t1', { revision: 3, status: 'completed' });
+    const authoritativeTask = makeTask('t1', { taskStateVersion: 3, status: 'completed' });
     const persistence = { loadTask: (_id: string) => authoritativeTask };
 
     const delta: TaskDelta = {
       type: 'updated',
       taskId: 't1',
       changes: { status: 'running' },
-      revision: 4,
-      previousRevision: 3,
+      taskStateVersion: 4,
+      previousTaskStateVersion: 3,
     };
 
     const { rendererDeltas } = simulateMainProcessDeltaHandler(delta, cache, persistence);
 
     // Cache was recovered with authoritative state
     expect(cache.isQuarantined('t1')).toBe(false);
-    expect(cache.getEntry('t1')?.revision).toBe(3);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(3);
     const stored = JSON.parse(cache.get('t1')!);
     expect(stored.status).toBe('completed');
 
@@ -387,7 +387,7 @@ describe('gap recovery: unknown task → quarantine + authoritative reload', () 
     expect(rendererDeltas).toHaveLength(1);
     expect(rendererDeltas[0].type).toBe('created');
     expect((rendererDeltas[0] as { type: 'created'; task: TaskState }).task.id).toBe('t1');
-    expect((rendererDeltas[0] as { type: 'created'; task: TaskState }).task.revision).toBe(3);
+    expect((rendererDeltas[0] as { type: 'created'; task: TaskState }).task.taskStateVersion).toBe(3);
   });
 
   it('unknown task with no persistence record removes cache entry silently', () => {
@@ -398,8 +398,8 @@ describe('gap recovery: unknown task → quarantine + authoritative reload', () 
       type: 'updated',
       taskId: 'ghost',
       changes: { status: 'completed' },
-      revision: 2,
-      previousRevision: 1,
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
     };
 
     const { rendererDeltas } = simulateMainProcessDeltaHandler(delta, cache, persistence);
@@ -410,27 +410,27 @@ describe('gap recovery: unknown task → quarantine + authoritative reload', () 
   });
 });
 
-describe('gap recovery: revision gap → quarantine + authoritative reload', () => {
-  it('revision gap triggers quarantine and replaces stale cache with authoritative state', () => {
+describe('gap recovery: taskStateVersion gap → quarantine + authoritative reload', () => {
+  it('taskStateVersion gap triggers quarantine and replaces stale cache with authoritative state', () => {
     const cache = new TaskSnapshotCache();
-    // Cache has task at revision 2
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 2, status: 'running' })));
+    // Cache has task at taskStateVersion 2
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 2, status: 'running' })));
 
-    // Persistence has task at revision 7 (several revisions ahead)
+    // Persistence has task at taskStateVersion 7 (several revisions ahead)
     const authoritativeTask = makeTask('t1', {
-      revision: 7,
+      taskStateVersion: 7,
       status: 'completed',
       execution: { exitCode: 0 },
     });
     const persistence = { loadTask: (_id: string) => authoritativeTask };
 
-    // Delta arrives referencing revision 7 → 8, but cache is at 2
+    // Delta arrives referencing taskStateVersion 7 → 8, but cache is at 2
     const delta: TaskDelta = {
       type: 'updated',
       taskId: 't1',
       changes: { execution: { error: 'timeout' } },
-      revision: 8,
-      previousRevision: 7,
+      taskStateVersion: 8,
+      previousTaskStateVersion: 7,
     };
 
     const { rendererDeltas } = simulateMainProcessDeltaHandler(delta, cache, persistence);
@@ -438,7 +438,7 @@ describe('gap recovery: revision gap → quarantine + authoritative reload', () 
     // Cache was recovered: snapshot matches authoritative (rev 7), not the
     // stale rev-2 snapshot and not the gap delta's changes.
     expect(cache.isQuarantined('t1')).toBe(false);
-    expect(cache.getEntry('t1')?.revision).toBe(7);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(7);
     const stored = JSON.parse(cache.get('t1')!);
     expect(stored.status).toBe('completed');
     expect(stored.execution.exitCode).toBe(0);
@@ -448,28 +448,28 @@ describe('gap recovery: revision gap → quarantine + authoritative reload', () 
 
     // Renderer received authoritative snapshot
     expect(rendererDeltas).toHaveLength(1);
-    expect((rendererDeltas[0] as { type: 'created'; task: TaskState }).task.revision).toBe(7);
+    expect((rendererDeltas[0] as { type: 'created'; task: TaskState }).task.taskStateVersion).toBe(7);
   });
 
-  it('revision gap with single missed revision still quarantines', () => {
+  it('taskStateVersion gap with single missed taskStateVersion still quarantines', () => {
     const cache = new TaskSnapshotCache();
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 3 })));
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 3 })));
 
-    const authoritativeTask = makeTask('t1', { revision: 4, status: 'running' });
+    const authoritativeTask = makeTask('t1', { taskStateVersion: 4, status: 'running' });
     const persistence = { loadTask: (_id: string) => authoritativeTask };
 
-    // Delta has previousRevision: 4 but cache is at 3
+    // Delta has previousTaskStateVersion: 4 but cache is at 3
     const delta: TaskDelta = {
       type: 'updated',
       taskId: 't1',
       changes: { status: 'failed' },
-      revision: 5,
-      previousRevision: 4,
+      taskStateVersion: 5,
+      previousTaskStateVersion: 4,
     };
 
     const { rendererDeltas } = simulateMainProcessDeltaHandler(delta, cache, persistence);
 
-    expect(cache.getEntry('t1')?.revision).toBe(4);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(4);
     expect(rendererDeltas).toHaveLength(1);
   });
 });
@@ -477,15 +477,15 @@ describe('gap recovery: revision gap → quarantine + authoritative reload', () 
 describe('gap recovery: quarantined task ignores later deltas until reload completes', () => {
   it('burst of deltas during quarantine are all dropped; only authoritative state remains', () => {
     const cache = new TaskSnapshotCache();
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1, status: 'pending' })));
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 1, status: 'pending' })));
 
     // Step 1: Gap delta triggers quarantine (don't resolve yet)
     const gapResult = applyDelta({
       type: 'updated',
       taskId: 't1',
       changes: { status: 'running' },
-      revision: 5,
-      previousRevision: 4,
+      taskStateVersion: 5,
+      previousTaskStateVersion: 4,
     }, cache);
     expect(gapResult.quarantined).toEqual(['t1']);
     expect(cache.isQuarantined('t1')).toBe(true);
@@ -496,8 +496,8 @@ describe('gap recovery: quarantined task ignores later deltas until reload compl
         type: 'updated',
         taskId: 't1',
         changes: { status: `status-at-rev-${rev}` as TaskState['status'] },
-        revision: rev,
-        previousRevision: rev - 1,
+        taskStateVersion: rev,
+        previousTaskStateVersion: rev - 1,
       }, cache);
       expect(result.quarantined).toEqual([]);
     }
@@ -505,30 +505,30 @@ describe('gap recovery: quarantined task ignores later deltas until reload compl
     // Cache snapshot is unchanged from before quarantine
     const stored = JSON.parse(cache.get('t1')!);
     expect(stored.status).toBe('pending');
-    expect(stored.revision).toBe(1);
+    expect(stored.taskStateVersion).toBe(1);
     expect(cache.isQuarantined('t1')).toBe(true);
 
     // Step 3: Resolve with authoritative state
-    const authoritative = makeTask('t1', { revision: 10, status: 'completed' });
+    const authoritative = makeTask('t1', { taskStateVersion: 10, status: 'completed' });
     resolveQuarantine(cache, 't1', authoritative);
 
     expect(cache.isQuarantined('t1')).toBe(false);
-    expect(cache.getEntry('t1')?.revision).toBe(10);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(10);
     const final = JSON.parse(cache.get('t1')!);
     expect(final.status).toBe('completed');
   });
 
   it('quarantine flag survives multiple ignored deltas with different change shapes', () => {
     const cache = new TaskSnapshotCache();
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 1 })));
 
     // Trigger quarantine
     applyDelta({
       type: 'updated',
       taskId: 't1',
       changes: { status: 'failed' },
-      revision: 3,
-      previousRevision: 2,
+      taskStateVersion: 3,
+      previousTaskStateVersion: 2,
     }, cache);
 
     // Try config change — ignored
@@ -536,8 +536,8 @@ describe('gap recovery: quarantined task ignores later deltas until reload compl
       type: 'updated',
       taskId: 't1',
       changes: { config: { command: 'echo hacked' } },
-      revision: 4,
-      previousRevision: 3,
+      taskStateVersion: 4,
+      previousTaskStateVersion: 3,
     }, cache);
 
     // Try execution change — ignored
@@ -545,8 +545,8 @@ describe('gap recovery: quarantined task ignores later deltas until reload compl
       type: 'updated',
       taskId: 't1',
       changes: { execution: { exitCode: 99 } },
-      revision: 5,
-      previousRevision: 4,
+      taskStateVersion: 5,
+      previousTaskStateVersion: 4,
     }, cache);
 
     // Original snapshot preserved
@@ -560,9 +560,9 @@ describe('gap recovery: quarantined task ignores later deltas until reload compl
 describe('gap recovery: successful reload clears quarantine and allows next ordered delta', () => {
   it('post-recovery delta with correct continuity applies normally', () => {
     const cache = new TaskSnapshotCache();
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 1 })));
 
-    const authoritativeTask = makeTask('t1', { revision: 5, status: 'running' });
+    const authoritativeTask = makeTask('t1', { taskStateVersion: 5, status: 'running' });
     const persistence = { loadTask: (_id: string) => authoritativeTask };
 
     // Gap delta → quarantine → recovery
@@ -570,35 +570,35 @@ describe('gap recovery: successful reload clears quarantine and allows next orde
       type: 'updated',
       taskId: 't1',
       changes: { status: 'completed' },
-      revision: 6,
-      previousRevision: 5,
+      taskStateVersion: 6,
+      previousTaskStateVersion: 5,
     }, cache, persistence);
 
-    // Cache is now at authoritative revision 5, not quarantined
+    // Cache is now at authoritative taskStateVersion 5, not quarantined
     expect(cache.isQuarantined('t1')).toBe(false);
-    expect(cache.getEntry('t1')?.revision).toBe(5);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(5);
 
-    // Next delta with correct previousRevision=5 should apply
+    // Next delta with correct previousTaskStateVersion=5 should apply
     const result = applyDelta({
       type: 'updated',
       taskId: 't1',
       changes: { status: 'completed', execution: { exitCode: 0 } },
-      revision: 6,
-      previousRevision: 5,
+      taskStateVersion: 6,
+      previousTaskStateVersion: 5,
     }, cache);
 
     expect(result.quarantined).toEqual([]);
     const stored = JSON.parse(cache.get('t1')!);
     expect(stored.status).toBe('completed');
     expect(stored.execution.exitCode).toBe(0);
-    expect(stored.revision).toBe(6);
+    expect(stored.taskStateVersion).toBe(6);
   });
 
   it('post-recovery delta with wrong continuity re-quarantines', () => {
     const cache = new TaskSnapshotCache();
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 1 })));
 
-    const authoritativeTask = makeTask('t1', { revision: 5, status: 'running' });
+    const authoritativeTask = makeTask('t1', { taskStateVersion: 5, status: 'running' });
     const persistence = { loadTask: (_id: string) => authoritativeTask };
 
     // Gap delta → recovery (cache now at rev 5)
@@ -606,19 +606,19 @@ describe('gap recovery: successful reload clears quarantine and allows next orde
       type: 'updated',
       taskId: 't1',
       changes: { status: 'running' },
-      revision: 8,
-      previousRevision: 7,
+      taskStateVersion: 8,
+      previousTaskStateVersion: 7,
     }, cache, persistence);
 
-    expect(cache.getEntry('t1')?.revision).toBe(5);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(5);
 
     // A delta referencing rev 7 → 8 still doesn't match (cache is at 5)
     const result = applyDelta({
       type: 'updated',
       taskId: 't1',
       changes: { status: 'completed' },
-      revision: 8,
-      previousRevision: 7,
+      taskStateVersion: 8,
+      previousTaskStateVersion: 7,
     }, cache);
 
     expect(result.quarantined).toEqual(['t1']);
@@ -631,18 +631,18 @@ describe('gap recovery: successful reload clears quarantine and allows next orde
 describe('regression: out-of-order updates never merge from orchestrator memory', () => {
   it('a delta that skips revisions is rejected, not silently merged', () => {
     const cache = new TaskSnapshotCache();
-    // Task at revision 2 with status 'running'
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 2, status: 'running' })));
+    // Task at taskStateVersion 2 with status 'running'
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 2, status: 'running' })));
 
-    // Delta arrives claiming previousRevision: 5 → revision: 6.
+    // Delta arrives claiming previousTaskStateVersion: 5 → taskStateVersion: 6.
     // In the old best-effort system, this would have been merged anyway.
     // In the new system, it must quarantine.
     const result = applyDelta({
       type: 'updated',
       taskId: 't1',
       changes: { status: 'completed', execution: { exitCode: 0 } },
-      revision: 6,
-      previousRevision: 5,
+      taskStateVersion: 6,
+      previousTaskStateVersion: 5,
     }, cache);
 
     expect(result.quarantined).toEqual(['t1']);
@@ -650,37 +650,37 @@ describe('regression: out-of-order updates never merge from orchestrator memory'
     const stored = JSON.parse(cache.get('t1')!);
     expect(stored.status).toBe('running');
     expect(stored.execution).toEqual({});
-    expect(stored.revision).toBe(2);
+    expect(stored.taskStateVersion).toBe(2);
   });
 
-  it('a stale delta referencing an older revision is rejected, not merged', () => {
+  it('a stale delta referencing an older taskStateVersion is rejected, not merged', () => {
     const cache = new TaskSnapshotCache();
-    // Task has progressed to revision 5
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 5, status: 'completed' })));
+    // Task has progressed to taskStateVersion 5
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 5, status: 'completed' })));
 
-    // A stale delta arrives from an older revision window (rev 2 → 3)
+    // A stale delta arrives from an older taskStateVersion window (rev 2 → 3)
     const result = applyDelta({
       type: 'updated',
       taskId: 't1',
       changes: { status: 'running' },
-      revision: 3,
-      previousRevision: 2,
+      taskStateVersion: 3,
+      previousTaskStateVersion: 2,
     }, cache);
 
     expect(result.quarantined).toEqual(['t1']);
-    // Cache still shows revision 5, not downgraded
+    // Cache still shows taskStateVersion 5, not downgraded
     const stored = JSON.parse(cache.get('t1')!);
     expect(stored.status).toBe('completed');
-    expect(stored.revision).toBe(5);
+    expect(stored.taskStateVersion).toBe(5);
   });
 
   it('recovery always uses persistence, never the delta changes', () => {
     const cache = new TaskSnapshotCache();
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 2 })));
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 2 })));
 
     // The delta says status should be 'failed', but persistence says 'completed'
     const authoritativeTask = makeTask('t1', {
-      revision: 8,
+      taskStateVersion: 8,
       status: 'completed',
       execution: { exitCode: 0 },
     });
@@ -690,8 +690,8 @@ describe('regression: out-of-order updates never merge from orchestrator memory'
       type: 'updated',
       taskId: 't1',
       changes: { status: 'failed', execution: { error: 'crash' } },
-      revision: 9,
-      previousRevision: 8,
+      taskStateVersion: 9,
+      previousTaskStateVersion: 8,
     }, cache, persistence);
 
     // The cache must reflect persistence, NOT the delta's changes
@@ -699,7 +699,7 @@ describe('regression: out-of-order updates never merge from orchestrator memory'
     expect(stored.status).toBe('completed');
     expect(stored.execution.exitCode).toBe(0);
     expect(stored.execution.error).toBeUndefined();
-    expect(stored.revision).toBe(8);
+    expect(stored.taskStateVersion).toBe(8);
   });
 });
 
@@ -708,16 +708,16 @@ describe('regression: out-of-order updates never merge from orchestrator memory'
 describe('multi-task quarantine isolation', () => {
   it('quarantine on one task does not affect deltas for other tasks', () => {
     const cache = new TaskSnapshotCache();
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
-    cache.set('t2', JSON.stringify(makeTask('t2', { revision: 1 })));
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 1 })));
+    cache.set('t2', JSON.stringify(makeTask('t2', { taskStateVersion: 1 })));
 
     // Quarantine t1
     applyDelta({
       type: 'updated',
       taskId: 't1',
       changes: { status: 'failed' },
-      revision: 5,
-      previousRevision: 4,
+      taskStateVersion: 5,
+      previousTaskStateVersion: 4,
     }, cache);
     expect(cache.isQuarantined('t1')).toBe(true);
 
@@ -726,42 +726,42 @@ describe('multi-task quarantine isolation', () => {
       type: 'updated',
       taskId: 't2',
       changes: { status: 'completed', execution: { exitCode: 0 } },
-      revision: 2,
-      previousRevision: 1,
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
     }, cache);
 
     expect(result.quarantined).toEqual([]);
     expect(cache.isQuarantined('t2')).toBe(false);
     const stored = JSON.parse(cache.get('t2')!);
     expect(stored.status).toBe('completed');
-    expect(stored.revision).toBe(2);
+    expect(stored.taskStateVersion).toBe(2);
   });
 
   it('multiple tasks can be quarantined and recovered independently', () => {
     const cache = new TaskSnapshotCache();
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
-    cache.set('t2', JSON.stringify(makeTask('t2', { revision: 1 })));
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 1 })));
+    cache.set('t2', JSON.stringify(makeTask('t2', { taskStateVersion: 1 })));
 
     // Quarantine both
     applyDelta({
       type: 'updated',
       taskId: 't1',
       changes: { status: 'failed' },
-      revision: 5,
-      previousRevision: 4,
+      taskStateVersion: 5,
+      previousTaskStateVersion: 4,
     }, cache);
     applyDelta({
       type: 'updated',
       taskId: 't2',
       changes: { status: 'failed' },
-      revision: 3,
-      previousRevision: 2,
+      taskStateVersion: 3,
+      previousTaskStateVersion: 2,
     }, cache);
     expect(cache.isQuarantined('t1')).toBe(true);
     expect(cache.isQuarantined('t2')).toBe(true);
 
     // Recover t1 only
-    resolveQuarantine(cache, 't1', makeTask('t1', { revision: 5, status: 'completed' }));
+    resolveQuarantine(cache, 't1', makeTask('t1', { taskStateVersion: 5, status: 'completed' }));
     expect(cache.isQuarantined('t1')).toBe(false);
     expect(cache.isQuarantined('t2')).toBe(true);
 
@@ -770,15 +770,15 @@ describe('multi-task quarantine isolation', () => {
       type: 'updated',
       taskId: 't1',
       changes: { execution: { exitCode: 0 } },
-      revision: 6,
-      previousRevision: 5,
+      taskStateVersion: 6,
+      previousTaskStateVersion: 5,
     }, cache);
     const r2 = applyDelta({
       type: 'updated',
       taskId: 't2',
       changes: { execution: { exitCode: 1 } },
-      revision: 4,
-      previousRevision: 3,
+      taskStateVersion: 4,
+      previousTaskStateVersion: 3,
     }, cache);
 
     expect(r1.quarantined).toEqual([]);
@@ -788,7 +788,7 @@ describe('multi-task quarantine isolation', () => {
     expect(JSON.parse(cache.get('t2')!).execution).toEqual({});
 
     // Recover t2
-    resolveQuarantine(cache, 't2', makeTask('t2', { revision: 3, status: 'failed' }));
+    resolveQuarantine(cache, 't2', makeTask('t2', { taskStateVersion: 3, status: 'failed' }));
     expect(cache.isQuarantined('t2')).toBe(false);
   });
 });
@@ -800,68 +800,68 @@ describe('end-to-end recovery flow', () => {
     const cache = new TaskSnapshotCache();
 
     // Phase 1: Task created
-    applyDelta({ type: 'created', task: makeTask('t1', { revision: 1, status: 'pending' }) }, cache);
-    expect(cache.getEntry('t1')?.revision).toBe(1);
+    applyDelta({ type: 'created', task: makeTask('t1', { taskStateVersion: 1, status: 'pending' }) }, cache);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(1);
 
     // Phase 2: Normal updates (revisions 1→2→3)
     applyDelta({
       type: 'updated',
       taskId: 't1',
       changes: { status: 'running' },
-      revision: 2,
-      previousRevision: 1,
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
     }, cache);
     applyDelta({
       type: 'updated',
       taskId: 't1',
       changes: { execution: { generation: 2 } },
-      revision: 3,
-      previousRevision: 2,
+      taskStateVersion: 3,
+      previousTaskStateVersion: 2,
     }, cache);
-    expect(cache.getEntry('t1')?.revision).toBe(3);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(3);
 
     // Phase 3: Gap detected (delta refs rev 6 → 7, but cache is at 3)
     const persistence = {
       loadTask: (_id: string) =>
-        makeTask('t1', { revision: 6, status: 'running', execution: { generation: 3 } }),
+        makeTask('t1', { taskStateVersion: 6, status: 'running', execution: { generation: 3 } }),
     };
     const { rendererDeltas } = simulateMainProcessDeltaHandler({
       type: 'updated',
       taskId: 't1',
       changes: { status: 'completed' },
-      revision: 7,
-      previousRevision: 6,
+      taskStateVersion: 7,
+      previousTaskStateVersion: 6,
     }, cache, persistence);
 
     // Recovery happened
-    expect(cache.getEntry('t1')?.revision).toBe(6);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(6);
     expect(cache.isQuarantined('t1')).toBe(false);
     expect(rendererDeltas).toHaveLength(1);
 
-    // Phase 4: Resume normal deltas from recovered revision
+    // Phase 4: Resume normal deltas from recovered taskStateVersion
     applyDelta({
       type: 'updated',
       taskId: 't1',
       changes: { status: 'completed', execution: { exitCode: 0 } },
-      revision: 7,
-      previousRevision: 6,
+      taskStateVersion: 7,
+      previousTaskStateVersion: 6,
     }, cache);
-    expect(cache.getEntry('t1')?.revision).toBe(7);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(7);
 
     // Phase 5: Task removed
-    applyDelta({ type: 'removed', taskId: 't1', previousRevision: 7 }, cache);
+    applyDelta({ type: 'removed', taskId: 't1', previousTaskStateVersion: 7 }, cache);
     expect(cache.has('t1')).toBe(false);
   });
 
   it('concurrent gap recovery for two tasks in the same delta batch', () => {
     const cache = new TaskSnapshotCache();
-    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
-    cache.set('t2', JSON.stringify(makeTask('t2', { revision: 1 })));
+    cache.set('t1', JSON.stringify(makeTask('t1', { taskStateVersion: 1 })));
+    cache.set('t2', JSON.stringify(makeTask('t2', { taskStateVersion: 1 })));
 
     const persistence = {
       loadTask: (id: string) => {
-        if (id === 't1') return makeTask('t1', { revision: 5, status: 'completed' });
-        if (id === 't2') return makeTask('t2', { revision: 3, status: 'failed' });
+        if (id === 't1') return makeTask('t1', { taskStateVersion: 5, status: 'completed' });
+        if (id === 't2') return makeTask('t2', { taskStateVersion: 3, status: 'failed' });
         return undefined;
       },
     };
@@ -871,21 +871,21 @@ describe('end-to-end recovery flow', () => {
       type: 'updated',
       taskId: 't1',
       changes: { status: 'running' },
-      revision: 6,
-      previousRevision: 5,
+      taskStateVersion: 6,
+      previousTaskStateVersion: 5,
     }, cache, persistence);
 
     simulateMainProcessDeltaHandler({
       type: 'updated',
       taskId: 't2',
       changes: { status: 'running' },
-      revision: 4,
-      previousRevision: 3,
+      taskStateVersion: 4,
+      previousTaskStateVersion: 3,
     }, cache, persistence);
 
     // Both recovered independently to their authoritative states
-    expect(cache.getEntry('t1')?.revision).toBe(5);
-    expect(cache.getEntry('t2')?.revision).toBe(3);
+    expect(cache.getEntry('t1')?.taskStateVersion).toBe(5);
+    expect(cache.getEntry('t2')?.taskStateVersion).toBe(3);
     expect(JSON.parse(cache.get('t1')!).status).toBe('completed');
     expect(JSON.parse(cache.get('t2')!).status).toBe('failed');
   });

--- a/packages/app/src/__tests__/delta-merge.test.ts
+++ b/packages/app/src/__tests__/delta-merge.test.ts
@@ -9,6 +9,9 @@
  * - quarantined task ignores further deltas until resolved
  * - resolveQuarantine re-seeds the cache from authoritative data
  * - TaskSnapshotCache bulk operations (set/get/clear/keys/delete)
+ * - Regression: out-of-order updates never merge from orchestrator memory
+ * - Integration: full quarantine → persistence load → recovery → resume flow
+ * - Multi-task quarantine isolation
  */
 import { describe, it, expect } from 'vitest';
 import { applyDelta, resolveQuarantine, TaskSnapshotCache } from '../delta-merge.js';
@@ -325,5 +328,565 @@ describe('resolveQuarantine', () => {
     expect(stored.status).toBe('failed');
     expect(stored.execution.exitCode).toBe(1);
     expect(stored.revision).toBe(4);
+  });
+});
+
+// ── Gap recovery: main-process integration simulation ────────
+//
+// These tests simulate the recovery loop from main.ts (lines 2429-2437):
+//   1. applyDelta detects gap → returns quarantined IDs
+//   2. caller loads authoritative state from persistence (loadTask)
+//   3. resolveQuarantine re-seeds cache
+//   4. caller sends { type: 'created', task: authoritative } to renderer
+//
+// The mock persistence loader is a plain function, not a real SQLite
+// adapter, which keeps tests deterministic and fast.
+
+/** Simulates the main-process recovery loop from main.ts. */
+function simulateMainProcessDeltaHandler(
+  delta: TaskDelta,
+  cache: TaskSnapshotCache,
+  persistence: { loadTask: (id: string) => TaskState | undefined },
+): { rendererDeltas: TaskDelta[] } {
+  const rendererDeltas: TaskDelta[] = [];
+
+  const { quarantined } = applyDelta(delta, cache);
+  for (const taskId of quarantined) {
+    const authoritative = persistence.loadTask(taskId);
+    resolveQuarantine(cache, taskId, authoritative);
+    if (authoritative) {
+      rendererDeltas.push({ type: 'created', task: authoritative });
+    }
+  }
+  return { rendererDeltas };
+}
+
+describe('gap recovery: unknown task → quarantine + authoritative reload', () => {
+  it('unknown task triggers quarantine and sends authoritative snapshot to renderer', () => {
+    const cache = new TaskSnapshotCache();
+    const authoritativeTask = makeTask('t1', { revision: 3, status: 'completed' });
+    const persistence = { loadTask: (_id: string) => authoritativeTask };
+
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'running' },
+      revision: 4,
+      previousRevision: 3,
+    };
+
+    const { rendererDeltas } = simulateMainProcessDeltaHandler(delta, cache, persistence);
+
+    // Cache was recovered with authoritative state
+    expect(cache.isQuarantined('t1')).toBe(false);
+    expect(cache.getEntry('t1')?.revision).toBe(3);
+    const stored = JSON.parse(cache.get('t1')!);
+    expect(stored.status).toBe('completed');
+
+    // Renderer received the authoritative snapshot as a created delta
+    expect(rendererDeltas).toHaveLength(1);
+    expect(rendererDeltas[0].type).toBe('created');
+    expect((rendererDeltas[0] as { type: 'created'; task: TaskState }).task.id).toBe('t1');
+    expect((rendererDeltas[0] as { type: 'created'; task: TaskState }).task.revision).toBe(3);
+  });
+
+  it('unknown task with no persistence record removes cache entry silently', () => {
+    const cache = new TaskSnapshotCache();
+    const persistence = { loadTask: (_id: string) => undefined };
+
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: 'ghost',
+      changes: { status: 'completed' },
+      revision: 2,
+      previousRevision: 1,
+    };
+
+    const { rendererDeltas } = simulateMainProcessDeltaHandler(delta, cache, persistence);
+
+    expect(cache.has('ghost')).toBe(false);
+    // No renderer delta emitted for a task that doesn't exist in persistence
+    expect(rendererDeltas).toHaveLength(0);
+  });
+});
+
+describe('gap recovery: revision gap → quarantine + authoritative reload', () => {
+  it('revision gap triggers quarantine and replaces stale cache with authoritative state', () => {
+    const cache = new TaskSnapshotCache();
+    // Cache has task at revision 2
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 2, status: 'running' })));
+
+    // Persistence has task at revision 7 (several revisions ahead)
+    const authoritativeTask = makeTask('t1', {
+      revision: 7,
+      status: 'completed',
+      execution: { exitCode: 0 },
+    });
+    const persistence = { loadTask: (_id: string) => authoritativeTask };
+
+    // Delta arrives referencing revision 7 → 8, but cache is at 2
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: 't1',
+      changes: { execution: { error: 'timeout' } },
+      revision: 8,
+      previousRevision: 7,
+    };
+
+    const { rendererDeltas } = simulateMainProcessDeltaHandler(delta, cache, persistence);
+
+    // Cache was recovered: snapshot matches authoritative (rev 7), not the
+    // stale rev-2 snapshot and not the gap delta's changes.
+    expect(cache.isQuarantined('t1')).toBe(false);
+    expect(cache.getEntry('t1')?.revision).toBe(7);
+    const stored = JSON.parse(cache.get('t1')!);
+    expect(stored.status).toBe('completed');
+    expect(stored.execution.exitCode).toBe(0);
+    // The delta's changes (error: 'timeout') were NOT merged — the
+    // old best-effort orchestrator-memory merge is gone.
+    expect(stored.execution.error).toBeUndefined();
+
+    // Renderer received authoritative snapshot
+    expect(rendererDeltas).toHaveLength(1);
+    expect((rendererDeltas[0] as { type: 'created'; task: TaskState }).task.revision).toBe(7);
+  });
+
+  it('revision gap with single missed revision still quarantines', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 3 })));
+
+    const authoritativeTask = makeTask('t1', { revision: 4, status: 'running' });
+    const persistence = { loadTask: (_id: string) => authoritativeTask };
+
+    // Delta has previousRevision: 4 but cache is at 3
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'failed' },
+      revision: 5,
+      previousRevision: 4,
+    };
+
+    const { rendererDeltas } = simulateMainProcessDeltaHandler(delta, cache, persistence);
+
+    expect(cache.getEntry('t1')?.revision).toBe(4);
+    expect(rendererDeltas).toHaveLength(1);
+  });
+});
+
+describe('gap recovery: quarantined task ignores later deltas until reload completes', () => {
+  it('burst of deltas during quarantine are all dropped; only authoritative state remains', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1, status: 'pending' })));
+
+    // Step 1: Gap delta triggers quarantine (don't resolve yet)
+    const gapResult = applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'running' },
+      revision: 5,
+      previousRevision: 4,
+    }, cache);
+    expect(gapResult.quarantined).toEqual(['t1']);
+    expect(cache.isQuarantined('t1')).toBe(true);
+
+    // Step 2: Multiple deltas arrive while quarantined — all ignored
+    for (let rev = 6; rev <= 10; rev++) {
+      const result = applyDelta({
+        type: 'updated',
+        taskId: 't1',
+        changes: { status: `status-at-rev-${rev}` as TaskState['status'] },
+        revision: rev,
+        previousRevision: rev - 1,
+      }, cache);
+      expect(result.quarantined).toEqual([]);
+    }
+
+    // Cache snapshot is unchanged from before quarantine
+    const stored = JSON.parse(cache.get('t1')!);
+    expect(stored.status).toBe('pending');
+    expect(stored.revision).toBe(1);
+    expect(cache.isQuarantined('t1')).toBe(true);
+
+    // Step 3: Resolve with authoritative state
+    const authoritative = makeTask('t1', { revision: 10, status: 'completed' });
+    resolveQuarantine(cache, 't1', authoritative);
+
+    expect(cache.isQuarantined('t1')).toBe(false);
+    expect(cache.getEntry('t1')?.revision).toBe(10);
+    const final = JSON.parse(cache.get('t1')!);
+    expect(final.status).toBe('completed');
+  });
+
+  it('quarantine flag survives multiple ignored deltas with different change shapes', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
+
+    // Trigger quarantine
+    applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'failed' },
+      revision: 3,
+      previousRevision: 2,
+    }, cache);
+
+    // Try config change — ignored
+    applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { config: { command: 'echo hacked' } },
+      revision: 4,
+      previousRevision: 3,
+    }, cache);
+
+    // Try execution change — ignored
+    applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { execution: { exitCode: 99 } },
+      revision: 5,
+      previousRevision: 4,
+    }, cache);
+
+    // Original snapshot preserved
+    const stored = JSON.parse(cache.get('t1')!);
+    expect(stored.config.command).toBe('echo t1');
+    expect(stored.execution).toEqual({});
+    expect(stored.status).toBe('running');
+  });
+});
+
+describe('gap recovery: successful reload clears quarantine and allows next ordered delta', () => {
+  it('post-recovery delta with correct continuity applies normally', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
+
+    const authoritativeTask = makeTask('t1', { revision: 5, status: 'running' });
+    const persistence = { loadTask: (_id: string) => authoritativeTask };
+
+    // Gap delta → quarantine → recovery
+    simulateMainProcessDeltaHandler({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'completed' },
+      revision: 6,
+      previousRevision: 5,
+    }, cache, persistence);
+
+    // Cache is now at authoritative revision 5, not quarantined
+    expect(cache.isQuarantined('t1')).toBe(false);
+    expect(cache.getEntry('t1')?.revision).toBe(5);
+
+    // Next delta with correct previousRevision=5 should apply
+    const result = applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'completed', execution: { exitCode: 0 } },
+      revision: 6,
+      previousRevision: 5,
+    }, cache);
+
+    expect(result.quarantined).toEqual([]);
+    const stored = JSON.parse(cache.get('t1')!);
+    expect(stored.status).toBe('completed');
+    expect(stored.execution.exitCode).toBe(0);
+    expect(stored.revision).toBe(6);
+  });
+
+  it('post-recovery delta with wrong continuity re-quarantines', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
+
+    const authoritativeTask = makeTask('t1', { revision: 5, status: 'running' });
+    const persistence = { loadTask: (_id: string) => authoritativeTask };
+
+    // Gap delta → recovery (cache now at rev 5)
+    simulateMainProcessDeltaHandler({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'running' },
+      revision: 8,
+      previousRevision: 7,
+    }, cache, persistence);
+
+    expect(cache.getEntry('t1')?.revision).toBe(5);
+
+    // A delta referencing rev 7 → 8 still doesn't match (cache is at 5)
+    const result = applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'completed' },
+      revision: 8,
+      previousRevision: 7,
+    }, cache);
+
+    expect(result.quarantined).toEqual(['t1']);
+    expect(cache.isQuarantined('t1')).toBe(true);
+  });
+});
+
+// ── Regression: out-of-order updates must not merge from orchestrator memory ──
+
+describe('regression: out-of-order updates never merge from orchestrator memory', () => {
+  it('a delta that skips revisions is rejected, not silently merged', () => {
+    const cache = new TaskSnapshotCache();
+    // Task at revision 2 with status 'running'
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 2, status: 'running' })));
+
+    // Delta arrives claiming previousRevision: 5 → revision: 6.
+    // In the old best-effort system, this would have been merged anyway.
+    // In the new system, it must quarantine.
+    const result = applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'completed', execution: { exitCode: 0 } },
+      revision: 6,
+      previousRevision: 5,
+    }, cache);
+
+    expect(result.quarantined).toEqual(['t1']);
+    // The delta's changes must NOT appear in the cache
+    const stored = JSON.parse(cache.get('t1')!);
+    expect(stored.status).toBe('running');
+    expect(stored.execution).toEqual({});
+    expect(stored.revision).toBe(2);
+  });
+
+  it('a stale delta referencing an older revision is rejected, not merged', () => {
+    const cache = new TaskSnapshotCache();
+    // Task has progressed to revision 5
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 5, status: 'completed' })));
+
+    // A stale delta arrives from an older revision window (rev 2 → 3)
+    const result = applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'running' },
+      revision: 3,
+      previousRevision: 2,
+    }, cache);
+
+    expect(result.quarantined).toEqual(['t1']);
+    // Cache still shows revision 5, not downgraded
+    const stored = JSON.parse(cache.get('t1')!);
+    expect(stored.status).toBe('completed');
+    expect(stored.revision).toBe(5);
+  });
+
+  it('recovery always uses persistence, never the delta changes', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 2 })));
+
+    // The delta says status should be 'failed', but persistence says 'completed'
+    const authoritativeTask = makeTask('t1', {
+      revision: 8,
+      status: 'completed',
+      execution: { exitCode: 0 },
+    });
+    const persistence = { loadTask: (_id: string) => authoritativeTask };
+
+    simulateMainProcessDeltaHandler({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'failed', execution: { error: 'crash' } },
+      revision: 9,
+      previousRevision: 8,
+    }, cache, persistence);
+
+    // The cache must reflect persistence, NOT the delta's changes
+    const stored = JSON.parse(cache.get('t1')!);
+    expect(stored.status).toBe('completed');
+    expect(stored.execution.exitCode).toBe(0);
+    expect(stored.execution.error).toBeUndefined();
+    expect(stored.revision).toBe(8);
+  });
+});
+
+// ── Multi-task quarantine isolation ──────────────────────────
+
+describe('multi-task quarantine isolation', () => {
+  it('quarantine on one task does not affect deltas for other tasks', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
+    cache.set('t2', JSON.stringify(makeTask('t2', { revision: 1 })));
+
+    // Quarantine t1
+    applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'failed' },
+      revision: 5,
+      previousRevision: 4,
+    }, cache);
+    expect(cache.isQuarantined('t1')).toBe(true);
+
+    // t2 can still receive normal deltas
+    const result = applyDelta({
+      type: 'updated',
+      taskId: 't2',
+      changes: { status: 'completed', execution: { exitCode: 0 } },
+      revision: 2,
+      previousRevision: 1,
+    }, cache);
+
+    expect(result.quarantined).toEqual([]);
+    expect(cache.isQuarantined('t2')).toBe(false);
+    const stored = JSON.parse(cache.get('t2')!);
+    expect(stored.status).toBe('completed');
+    expect(stored.revision).toBe(2);
+  });
+
+  it('multiple tasks can be quarantined and recovered independently', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
+    cache.set('t2', JSON.stringify(makeTask('t2', { revision: 1 })));
+
+    // Quarantine both
+    applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'failed' },
+      revision: 5,
+      previousRevision: 4,
+    }, cache);
+    applyDelta({
+      type: 'updated',
+      taskId: 't2',
+      changes: { status: 'failed' },
+      revision: 3,
+      previousRevision: 2,
+    }, cache);
+    expect(cache.isQuarantined('t1')).toBe(true);
+    expect(cache.isQuarantined('t2')).toBe(true);
+
+    // Recover t1 only
+    resolveQuarantine(cache, 't1', makeTask('t1', { revision: 5, status: 'completed' }));
+    expect(cache.isQuarantined('t1')).toBe(false);
+    expect(cache.isQuarantined('t2')).toBe(true);
+
+    // t1 accepts deltas again; t2 still ignores
+    const r1 = applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { execution: { exitCode: 0 } },
+      revision: 6,
+      previousRevision: 5,
+    }, cache);
+    const r2 = applyDelta({
+      type: 'updated',
+      taskId: 't2',
+      changes: { execution: { exitCode: 1 } },
+      revision: 4,
+      previousRevision: 3,
+    }, cache);
+
+    expect(r1.quarantined).toEqual([]);
+    expect(r2.quarantined).toEqual([]); // ignored, not re-quarantined
+    expect(JSON.parse(cache.get('t1')!).execution.exitCode).toBe(0);
+    // t2's delta was silently ignored — execution unchanged
+    expect(JSON.parse(cache.get('t2')!).execution).toEqual({});
+
+    // Recover t2
+    resolveQuarantine(cache, 't2', makeTask('t2', { revision: 3, status: 'failed' }));
+    expect(cache.isQuarantined('t2')).toBe(false);
+  });
+});
+
+// ── End-to-end recovery flow ────────────────────────────────
+
+describe('end-to-end recovery flow', () => {
+  it('full lifecycle: create → update → gap → quarantine → recover → update → remove', () => {
+    const cache = new TaskSnapshotCache();
+
+    // Phase 1: Task created
+    applyDelta({ type: 'created', task: makeTask('t1', { revision: 1, status: 'pending' }) }, cache);
+    expect(cache.getEntry('t1')?.revision).toBe(1);
+
+    // Phase 2: Normal updates (revisions 1→2→3)
+    applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'running' },
+      revision: 2,
+      previousRevision: 1,
+    }, cache);
+    applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { execution: { generation: 2 } },
+      revision: 3,
+      previousRevision: 2,
+    }, cache);
+    expect(cache.getEntry('t1')?.revision).toBe(3);
+
+    // Phase 3: Gap detected (delta refs rev 6 → 7, but cache is at 3)
+    const persistence = {
+      loadTask: (_id: string) =>
+        makeTask('t1', { revision: 6, status: 'running', execution: { generation: 3 } }),
+    };
+    const { rendererDeltas } = simulateMainProcessDeltaHandler({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'completed' },
+      revision: 7,
+      previousRevision: 6,
+    }, cache, persistence);
+
+    // Recovery happened
+    expect(cache.getEntry('t1')?.revision).toBe(6);
+    expect(cache.isQuarantined('t1')).toBe(false);
+    expect(rendererDeltas).toHaveLength(1);
+
+    // Phase 4: Resume normal deltas from recovered revision
+    applyDelta({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'completed', execution: { exitCode: 0 } },
+      revision: 7,
+      previousRevision: 6,
+    }, cache);
+    expect(cache.getEntry('t1')?.revision).toBe(7);
+
+    // Phase 5: Task removed
+    applyDelta({ type: 'removed', taskId: 't1', previousRevision: 7 }, cache);
+    expect(cache.has('t1')).toBe(false);
+  });
+
+  it('concurrent gap recovery for two tasks in the same delta batch', () => {
+    const cache = new TaskSnapshotCache();
+    cache.set('t1', JSON.stringify(makeTask('t1', { revision: 1 })));
+    cache.set('t2', JSON.stringify(makeTask('t2', { revision: 1 })));
+
+    const persistence = {
+      loadTask: (id: string) => {
+        if (id === 't1') return makeTask('t1', { revision: 5, status: 'completed' });
+        if (id === 't2') return makeTask('t2', { revision: 3, status: 'failed' });
+        return undefined;
+      },
+    };
+
+    // Process two gap deltas sequentially (as main.ts does)
+    simulateMainProcessDeltaHandler({
+      type: 'updated',
+      taskId: 't1',
+      changes: { status: 'running' },
+      revision: 6,
+      previousRevision: 5,
+    }, cache, persistence);
+
+    simulateMainProcessDeltaHandler({
+      type: 'updated',
+      taskId: 't2',
+      changes: { status: 'running' },
+      revision: 4,
+      previousRevision: 3,
+    }, cache, persistence);
+
+    // Both recovered independently to their authoritative states
+    expect(cache.getEntry('t1')?.revision).toBe(5);
+    expect(cache.getEntry('t2')?.revision).toBe(3);
+    expect(JSON.parse(cache.get('t1')!).status).toBe('completed');
+    expect(JSON.parse(cache.get('t2')!).status).toBe('failed');
   });
 });

--- a/packages/app/src/delta-merge.ts
+++ b/packages/app/src/delta-merge.ts
@@ -1,51 +1,170 @@
 /**
- * Extracted delta-merge logic for `lastKnownTaskStates`.
+ * Revision-aware delta-merge logic for the main-process task snapshot cache.
  *
- * Applies a TaskDelta to the snapshot map, falling back to the
- * orchestrator when an `updated` delta arrives for an unknown task
- * (out-of-order delta — the `created` delta was missed).
+ * The cache tracks the last emitted snapshot, its revision, and whether a
+ * task is quarantined for recovery.  `updated` deltas only merge when
+ * `previousRevision` matches the cached revision; unknown tasks or revision
+ * gaps quarantine the task and trigger authoritative reload by id.
+ * Deltas for quarantined tasks are ignored until recovery finishes.
  */
 import type { TaskDelta, TaskState } from '@invoker/workflow-core';
 
-export interface TaskLookup {
-  getAllTasks(): TaskState[];
+// ── Cache entry ──────────────────────────────────────────────
+
+export interface CacheEntry {
+  snapshot: string;
+  revision: number;
+  quarantined: boolean;
+}
+
+// ── Authoritative loader (persistence by id) ────────────────
+
+export interface AuthoritativeTaskLoader {
+  loadTask(taskId: string): TaskState | undefined;
+}
+
+// ── Snapshot cache ───────────────────────────────────────────
+
+/**
+ * Revision-aware wrapper around the task snapshot map.
+ *
+ * Direct setters (`set`, `clear`, `delete`, `keys`) are exposed so
+ * existing call sites in main.ts that bulk-seed the cache continue to
+ * work unchanged.  The gap-detection logic lives in `applyDelta`.
+ */
+export class TaskSnapshotCache {
+  private readonly entries = new Map<string, CacheEntry>();
+
+  // ── Bulk operations (used by seedUiSnapshotCache, db-poll, etc.) ──
+
+  set(taskId: string, snapshot: string): void {
+    const task: TaskState = JSON.parse(snapshot);
+    this.entries.set(taskId, {
+      snapshot,
+      revision: task.revision ?? 1,
+      quarantined: false,
+    });
+  }
+
+  get(taskId: string): string | undefined {
+    const entry = this.entries.get(taskId);
+    return entry?.snapshot;
+  }
+
+  has(taskId: string): boolean {
+    return this.entries.has(taskId);
+  }
+
+  delete(taskId: string): boolean {
+    return this.entries.delete(taskId);
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  keys(): IterableIterator<string> {
+    return this.entries.keys();
+  }
+
+  /** Expose the raw entry for testing / inspection. */
+  getEntry(taskId: string): CacheEntry | undefined {
+    return this.entries.get(taskId);
+  }
+
+  isQuarantined(taskId: string): boolean {
+    return this.entries.get(taskId)?.quarantined === true;
+  }
+}
+
+// ── Delta application ────────────────────────────────────────
+
+export interface ApplyDeltaResult {
+  /** Task IDs that need authoritative reload from persistence. */
+  quarantined: string[];
 }
 
 /**
- * Apply a single TaskDelta to the lastKnownTaskStates map.
+ * Apply a single TaskDelta to the snapshot cache.
  *
- * @param delta       The incoming delta.
- * @param stateMap    Map of taskId → JSON-serialized TaskState snapshots.
- * @param taskLookup  Optional fallback to seed unknown tasks (e.g. orchestrator).
+ * Revision-aware semantics:
+ * - `created`: unconditionally stores the task snapshot and revision.
+ * - `updated` with matching `previousRevision`: merges changes, bumps
+ *   the cached revision to `delta.revision`.
+ * - `updated` with a revision gap or unknown task: quarantines the task
+ *   and returns its id in `result.quarantined`.
+ * - `removed`: deletes the cache entry.
+ * - Deltas targeting a quarantined task are silently ignored.
+ *
+ * @returns IDs of tasks that were quarantined and need authoritative reload.
  */
 export function applyDelta(
   delta: TaskDelta,
-  stateMap: Map<string, string>,
-  taskLookup?: TaskLookup,
-): void {
+  cache: TaskSnapshotCache,
+): ApplyDeltaResult {
+  const result: ApplyDeltaResult = { quarantined: [] };
+
   if (delta.type === 'created') {
-    stateMap.set(delta.task.id, JSON.stringify(delta.task));
-  } else if (delta.type === 'updated') {
-    let existing = stateMap.get(delta.taskId);
-    if (!existing && taskLookup) {
-      const task = taskLookup.getAllTasks().find(t => t.id === delta.taskId);
-      if (task) {
-        existing = JSON.stringify(task);
-        stateMap.set(delta.taskId, existing);
-      }
-    }
-    if (existing) {
-      const prev = JSON.parse(existing);
-      const { config: cfgChanges, execution: execChanges, ...topLevel } = delta.changes;
-      const task = {
-        ...prev,
-        ...topLevel,
-        config: { ...prev.config, ...cfgChanges },
-        execution: { ...prev.execution, ...execChanges },
-      };
-      stateMap.set(delta.taskId, JSON.stringify(task));
-    }
-  } else if (delta.type === 'removed') {
-    stateMap.delete(delta.taskId);
+    cache.set(delta.task.id, JSON.stringify(delta.task));
+    return result;
   }
+
+  if (delta.type === 'removed') {
+    cache.delete(delta.taskId);
+    return result;
+  }
+
+  // delta.type === 'updated'
+  const entry = cache.getEntry(delta.taskId);
+
+  // Quarantined tasks: ignore until recovery completes.
+  if (entry?.quarantined) {
+    return result;
+  }
+
+  // Unknown task or revision gap → quarantine.
+  if (!entry || entry.revision !== delta.previousRevision) {
+    // Mark as quarantined.  If the entry exists, keep its snapshot but
+    // flag it; if it doesn't, create a placeholder entry.
+    if (entry) {
+      entry.quarantined = true;
+    }
+    result.quarantined.push(delta.taskId);
+    return result;
+  }
+
+  // Revision matches — apply the merge.
+  const prev: TaskState = JSON.parse(entry.snapshot);
+  const { config: cfgChanges, execution: execChanges, ...topLevel } = delta.changes;
+  const merged = {
+    ...prev,
+    ...topLevel,
+    revision: delta.revision,
+    config: { ...prev.config, ...cfgChanges },
+    execution: { ...prev.execution, ...execChanges },
+  };
+  const snapshot = JSON.stringify(merged);
+  // Update the entry in-place to avoid extra map operations.
+  entry.snapshot = snapshot;
+  entry.revision = delta.revision;
+
+  return result;
+}
+
+/**
+ * Complete recovery for a quarantined task by replacing the cache entry
+ * with the authoritative snapshot from persistence.
+ *
+ * If `task` is undefined (task no longer exists), the cache entry is removed.
+ */
+export function resolveQuarantine(
+  cache: TaskSnapshotCache,
+  taskId: string,
+  task: TaskState | undefined,
+): void {
+  if (!task) {
+    cache.delete(taskId);
+    return;
+  }
+  cache.set(taskId, JSON.stringify(task));
 }

--- a/packages/app/src/delta-merge.ts
+++ b/packages/app/src/delta-merge.ts
@@ -1,10 +1,12 @@
 /**
- * Revision-aware delta-merge logic for the main-process task snapshot cache.
+ * Task-state-version-aware delta-merge logic for the main-process task
+ * snapshot cache.
  *
- * The cache tracks the last emitted snapshot, its revision, and whether a
+ * The cache tracks the last emitted snapshot, its taskStateVersion, and whether a
  * task is quarantined for recovery.  `updated` deltas only merge when
- * `previousRevision` matches the cached revision; unknown tasks or revision
- * gaps quarantine the task and trigger authoritative reload by id.
+ * `previousTaskStateVersion` matches the cached taskStateVersion; unknown
+ * tasks or task-state-version gaps quarantine the task and trigger
+ * authoritative reload by id.
  * Deltas for quarantined tasks are ignored until recovery finishes.
  */
 import type { TaskDelta, TaskState } from '@invoker/workflow-core';
@@ -13,7 +15,7 @@ import type { TaskDelta, TaskState } from '@invoker/workflow-core';
 
 export interface CacheEntry {
   snapshot: string;
-  revision: number;
+  taskStateVersion: number;
   quarantined: boolean;
 }
 
@@ -26,7 +28,7 @@ export interface AuthoritativeTaskLoader {
 // ── Snapshot cache ───────────────────────────────────────────
 
 /**
- * Revision-aware wrapper around the task snapshot map.
+ * Task-state-version-aware wrapper around the task snapshot map.
  *
  * Direct setters (`set`, `clear`, `delete`, `keys`) are exposed so
  * existing call sites in main.ts that bulk-seed the cache continue to
@@ -41,7 +43,7 @@ export class TaskSnapshotCache {
     const task: TaskState = JSON.parse(snapshot);
     this.entries.set(taskId, {
       snapshot,
-      revision: task.revision ?? 1,
+      taskStateVersion: task.taskStateVersion ?? 1,
       quarantined: false,
     });
   }
@@ -87,11 +89,11 @@ export interface ApplyDeltaResult {
 /**
  * Apply a single TaskDelta to the snapshot cache.
  *
- * Revision-aware semantics:
- * - `created`: unconditionally stores the task snapshot and revision.
- * - `updated` with matching `previousRevision`: merges changes, bumps
- *   the cached revision to `delta.revision`.
- * - `updated` with a revision gap or unknown task: quarantines the task
+ * Task-state-version-aware semantics:
+ * - `created`: unconditionally stores the task snapshot and taskStateVersion.
+ * - `updated` with matching `previousTaskStateVersion`: merges changes, bumps
+ *   the cached taskStateVersion to `delta.taskStateVersion`.
+ * - `updated` with a taskStateVersion gap or unknown task: quarantines the task
  *   and returns its id in `result.quarantined`.
  * - `removed`: deletes the cache entry.
  * - Deltas targeting a quarantined task are silently ignored.
@@ -122,8 +124,8 @@ export function applyDelta(
     return result;
   }
 
-  // Unknown task or revision gap → quarantine.
-  if (!entry || entry.revision !== delta.previousRevision) {
+  // Unknown task or taskStateVersion gap → quarantine.
+  if (!entry || entry.taskStateVersion !== delta.previousTaskStateVersion) {
     // Mark as quarantined.  If the entry exists, keep its snapshot but
     // flag it; if it doesn't, create a placeholder entry.
     if (entry) {
@@ -133,20 +135,20 @@ export function applyDelta(
     return result;
   }
 
-  // Revision matches — apply the merge.
+  // Task-state version matches — apply the merge.
   const prev: TaskState = JSON.parse(entry.snapshot);
   const { config: cfgChanges, execution: execChanges, ...topLevel } = delta.changes;
   const merged = {
     ...prev,
     ...topLevel,
-    revision: delta.revision,
+    taskStateVersion: delta.taskStateVersion,
     config: { ...prev.config, ...cfgChanges },
     execution: { ...prev.execution, ...execChanges },
   };
   const snapshot = JSON.stringify(merged);
   // Update the entry in-place to avoid extra map operations.
   entry.snapshot = snapshot;
-  entry.revision = delta.revision;
+  entry.taskStateVersion = delta.taskStateVersion;
 
   return result;
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2735,6 +2735,7 @@ if (isHeadless) {
     });
     ipcMain.handle('invoker:get-events', (_event, taskId: string) => persistence.getEvents(taskId));
     ipcMain.handle('invoker:get-status', () => orchestrator.getWorkflowStatus());
+    ipcMain.handle('invoker:get-task-by-id', (_event, taskId: string) => persistence.loadTask(taskId) ?? null);
     ipcMain.handle('invoker:get-task-output', (_event, taskId: string) => persistence.getTaskOutput(taskId));
 
     ipcMain.handle('invoker:get-output-chunks', (_event, taskId: string) => persistence.getOutputChunks(taskId));

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -122,7 +122,7 @@ import { collectSystemDiagnostics } from './system-diagnostics.js';
 import { installBundledSkills, resolveBundledSkillsStatus } from './bundled-skills.js';
 import { createRequire } from 'node:module';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
-import { applyDelta } from './delta-merge.js';
+import { applyDelta, resolveQuarantine, TaskSnapshotCache } from './delta-merge.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
@@ -1080,7 +1080,7 @@ if (isHeadless) {
   let dbPollInterval: ReturnType<typeof setInterval> | null = null;
   let activityPollInterval: ReturnType<typeof setInterval> | null = null;
   let uiPerfLogInterval: ReturnType<typeof setInterval> | null = null;
-  const lastKnownTaskStates = new Map<string, string>();
+  const lastKnownTaskStates = new TaskSnapshotCache();
   const deferredWorkflowLaunches = new Map<string, {
     timer: ReturnType<typeof setTimeout>;
     taskIds: string[];
@@ -2493,7 +2493,15 @@ if (isHeadless) {
         }
       }
 
-      applyDelta(d, lastKnownTaskStates, orchestrator);
+      const { quarantined } = applyDelta(d, lastKnownTaskStates);
+      for (const taskId of quarantined) {
+        logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
+        const authoritative = persistence.loadTask(taskId);
+        resolveQuarantine(lastKnownTaskStates, taskId, authoritative);
+        if (authoritative) {
+          sendTaskDeltaToRenderer({ type: 'created', task: authoritative });
+        }
+      }
     });
 
     uiPerfLogInterval = setInterval(() => {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -221,6 +221,10 @@ export const IpcChannels = {
     request: [];
     response: WorkflowStatus;
   },
+  'invoker:get-task-by-id': {} as {
+    request: [taskId: string];
+    response: TaskState | null;
+  },
   'invoker:get-task-output': {} as {
     request: [taskId: string];
     response: string;


### PR DESCRIPTION
## Summary

This PR replaces the Electron main-process fallback path for task deltas with
explicit revision continuity checks and authoritative reloads from persistence.

The DB remains the source of truth, but the main process still keeps an
in-memory task cache because the UI delta stream is the hot path: applying
contiguous updates from memory is much cheaper than reloading every task from
SQLite on every event. The cache exists to serve low-latency incremental UI
updates, not to define correctness.

On top of step 1's revisioned contracts, the main process now treats
`lastKnownTaskStates` as a synchronization cache instead of a source of truth.
Ordered deltas still apply fast, but cache misses and revision gaps now
quarantine the task, reload the authoritative record through IPC, and resume
from the recovered revision boundary.

## Architecture

### Before

```mermaid
graph TD
    A[Main process receives task delta] --> B[Best-effort merge into cached task]
    B --> C[Unknown or out-of-order state handled heuristically]
    C --> D[Renderer may continue from stale continuity]
```

### After

```mermaid
graph TD
    A[Main process receives task delta] --> B[Check revision continuity against cache]
    B -->|contiguous| C[Apply delta normally]
    B -->|gap or cache miss| D[Quarantine task]
    D --> E[Load authoritative task by id via IPC]
    E --> F[Publish recovered task from persisted source of truth]
```

## Test Plan

- [ ] `pnpm --filter @invoker/app test` not run here (`node_modules` missing)
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge_commit_sha>`
- Post-revert steps: None
- Data migration? No
