### PR TITLE
Prefer origin refs for upstream branch merges

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -28,6 +28,7 @@ import {
   autoFixOnFailure,
   buildCancelInFlight,
   buildInvalidationDeps,
+  selectFailureRecoveryRoute,
 } from '../workflow-actions.js';
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -269,7 +270,7 @@ describe('rebaseAndRetry', () => {
       recreateWorkflowFromFreshBase: vi.fn(async () => tasks),
     };
     const persistence = {
-      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1 })),
+      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1, repoUrl: 'https://example/repo.git', baseBranch: 'master' })),
       updateWorkflow: vi.fn(),
     };
 
@@ -630,13 +631,79 @@ describe('finalizeAppliedFix', () => {
 });
 
 describe('autoFixOnFailure', () => {
+  it('routes startup merge conflicts without a workspace to workflow fresh-base recreate', async () => {
+    const started = [
+      makeRunningTask({ id: 'task-a', status: 'running', config: { workflowId: 'wf-1' } }),
+    ];
+    const mergeError = JSON.stringify({
+      type: 'merge_conflict',
+      failedBranch: 'experiment/foo',
+      conflictFiles: ['src/foo.ts'],
+    });
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: { autoFixAttempts: 0, error: mergeError },
+      })),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      recreateWorkflowFromFreshBase: vi.fn(async (_workflowId: string, options?: { refreshBase?: () => Promise<unknown> }) => {
+        await options?.refreshBase?.();
+        return started;
+      }),
+      retryTask: vi.fn(() => []),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+      loadWorkflow: vi.fn(() => ({
+        id: 'wf-1',
+        generation: 1,
+        repoUrl: 'https://example/repo.git',
+        baseBranch: 'master',
+      })),
+      updateWorkflow: vi.fn(),
+      logEvent: vi.fn(),
+    };
+    const taskExecutor = {
+      preparePoolForRebaseRetry: vi.fn().mockResolvedValue(undefined),
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn().mockResolvedValue(undefined),
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await autoFixOnFailure('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+      'wf-1',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
+    );
+    expect(taskExecutor.preparePoolForRebaseRetry).toHaveBeenCalledWith(
+      'wf-1',
+      'https://example/repo.git',
+      'master',
+    );
+    expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
+    expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
+    expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
+  });
+
   it('uses fixWithAgent for non-merge failures and restarts the task directly', async () => {
     const started = [makeRunningTask({ id: 'task-a', status: 'running' })];
     const orchestrator = {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => makeTask({
         status: 'failed',
-        execution: { autoFixAttempts: 0 },
+        execution: { autoFixAttempts: 0, error: 'boom' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
@@ -678,7 +745,7 @@ describe('autoFixOnFailure', () => {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => makeTask({
         status: 'failed',
-        execution: { autoFixAttempts: 0 },
+        execution: { autoFixAttempts: 0, error: mergeError, workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
@@ -720,7 +787,7 @@ describe('autoFixOnFailure', () => {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => makeTask({
         status: 'failed',
-        execution: { autoFixAttempts: 0 },
+        execution: { autoFixAttempts: 0, error: mergeError, workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
@@ -1009,7 +1076,7 @@ describe('autoFixOnFailure', () => {
       getTask: vi.fn(() => makeTask({
         status: 'failed',
         config: { workflowId: 'wf-1' },
-        execution: { autoFixAttempts: 0 },
+        execution: { autoFixAttempts: 0, error: mergeError, workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
@@ -1045,6 +1112,64 @@ describe('autoFixOnFailure', () => {
         selectedAgentSource: 'default',
       }),
     );
+  });
+});
+
+describe('selectFailureRecoveryRoute', () => {
+  it('treats executor startup merge-conflict text as a merge conflict', () => {
+    const route = selectFailureRecoveryRoute(
+      makeTask({
+        config: { workflowId: 'wf-1' },
+        execution: {},
+      }) as any,
+      'Executor startup failed (ssh): Merge conflict merging experiment/foo: packages/workflow-core/src/orchestrator.ts',
+    );
+
+    expect(route).toEqual({ kind: 'recreateWorkflowFromFreshBase', workflowId: 'wf-1' });
+  });
+
+  it('uses workflow fresh-base recreate for startup merge conflicts without a workspace', () => {
+    const route = selectFailureRecoveryRoute(
+      makeTask({
+        config: { workflowId: 'wf-1' },
+        execution: {},
+      }) as any,
+      JSON.stringify({
+        type: 'merge_conflict',
+        failedBranch: 'experiment/foo',
+        conflictFiles: ['src/foo.ts'],
+      }),
+    );
+
+    expect(route).toEqual({ kind: 'recreateWorkflowFromFreshBase', workflowId: 'wf-1' });
+  });
+
+  it('uses resolveConflict for merge conflicts when a workspace exists', () => {
+    const route = selectFailureRecoveryRoute(
+      makeTask({
+        config: { workflowId: 'wf-1' },
+        execution: { workspacePath: '/tmp/task-a' },
+      }) as any,
+      JSON.stringify({
+        type: 'merge_conflict',
+        failedBranch: 'experiment/foo',
+        conflictFiles: ['src/foo.ts'],
+      }),
+    );
+
+    expect(route).toEqual({ kind: 'resolveConflict' });
+  });
+
+  it('uses fixWithAgent for non-merge failures', () => {
+    const route = selectFailureRecoveryRoute(
+      makeTask({
+        config: { workflowId: 'wf-1' },
+        execution: {},
+      }) as any,
+      'boom',
+    );
+
+    expect(route).toEqual({ kind: 'fixWithAgent' });
   });
 });
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -35,8 +35,10 @@ import {
   rebaseAndRetry,
   resolveConflictAction,
   recreateWorkflow as sharedRecreateWorkflow,
+  recreateWorkflowFromFreshBase,
   recreateTask as sharedRecreateTask,
   forkWorkflow as sharedForkWorkflow,
+  selectFailureRecoveryRoute,
   setWorkflowMergeMode,
   finalizeAppliedFix,
 } from './workflow-actions.js';
@@ -1187,35 +1189,38 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
 
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
-  const { savedError } = deps.orchestrator.beginConflictResolution(taskId);
   const agent = (agentArg ?? 'claude').toLowerCase();
-  const isMergeConflictError = (() => {
-    const candidates = [
-      savedError,
-      savedError.trim(),
-      savedError.split('\n\n').at(-1)?.trim() ?? '',
-    ];
-    for (const candidate of candidates) {
-      if (!candidate) continue;
-      try {
-        const parsed = JSON.parse(candidate) as { type?: unknown };
-        if (parsed?.type === 'merge_conflict') return true;
-      } catch {
-        // ignore parse errors; this helper is best-effort
-      }
-    }
-    return false;
-  })();
+  const task = deps.orchestrator.getTask(taskId);
+  if (!task) throw new Error(`Task ${taskId} not found`);
+  const savedError = task.execution.error ?? '';
+  const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
   try {
-    const output = deps.persistence.getTaskOutput(taskId);
-    if (isMergeConflictError) {
-      // For merge_conflict failures, run the deterministic conflict resolver first,
-      // then gate rerun behind explicit approve/reject like normal fix flow.
-      await te.resolveConflict(taskId, savedError, agent);
-    } else {
-      await te.fixWithAgent(taskId, output, agent, savedError);
+    if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
+      const started = await recreateWorkflowFromFreshBase(recoveryRoute.workflowId, {
+        ...deps,
+        taskExecutor: te,
+      });
+      await finalizeMutationWithGlobalTopup({
+        orchestrator: deps.orchestrator,
+        taskExecutor: te,
+        logger: deps.logger,
+        context: 'headless.fix-with-agent',
+        started,
+      });
+      process.stdout.write(
+        `Startup merge conflict detected; recreated workflow ${recoveryRoute.workflowId} from a fresh base.\n`,
+      );
+      return;
     }
-    const result = await finalizeAppliedFix(taskId, savedError, {
+
+    const { savedError: persistedSavedError } = deps.orchestrator.beginConflictResolution(taskId);
+    const output = deps.persistence.getTaskOutput(taskId);
+    if (recoveryRoute.kind === 'resolveConflict') {
+      await te.resolveConflict(taskId, persistedSavedError, agent);
+    } else {
+      await te.fixWithAgent(taskId, output, agent, persistedSavedError);
+    }
+    const result = await finalizeAppliedFix(taskId, persistedSavedError, {
       orchestrator: deps.orchestrator,
       taskExecutor: te,
       autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
@@ -1235,7 +1240,9 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     deps.persistence.appendTaskOutput(taskId, `\n[Fix with AI] Failed: ${msg}`);
-    deps.orchestrator.revertConflictResolution(taskId, savedError, msg);
+    if (recoveryRoute.kind !== 'recreateWorkflowFromFreshBase') {
+      deps.orchestrator.revertConflictResolution(taskId, savedError, msg);
+    }
     await finalizeMutationWithGlobalTopup({
       orchestrator: deps.orchestrator,
       taskExecutor: te,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -111,7 +111,9 @@ import {
   rebaseAndRetry,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
+  recreateWorkflowFromFreshBase,
   resolveConflictAction,
+  selectFailureRecoveryRoute,
   selectExperiments as sharedSelectExperiments,
   setWorkflowMergeMode,
   finalizeAppliedFix,
@@ -1308,11 +1310,27 @@ if (isHeadless) {
       });
       logAutoFixDebug(taskId, 'dispatch-attempt-bumped', { attemptsBefore, attemptsAfter });
     }
-    const { savedError } = orchestrator.beginConflictResolution(taskId);
+    if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
+      persistence.appendTaskOutput(
+        taskId,
+        `\n[${source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI'}] Startup merge conflict detected; recreating workflow ${recoveryRoute.workflowId} from a fresh base.`,
+      );
+      return await recreateWorkflowFromFreshBase(recoveryRoute.workflowId, {
+        orchestrator,
+        persistence,
+        taskExecutor: requireTaskExecutor(),
+      });
+    }
+
+    const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
     try {
       const output = persistence.getTaskOutput(taskId);
-      await requireTaskExecutor().fixWithAgent(taskId, output, agentName, savedError);
-      const result = await finalizeAppliedFix(taskId, savedError, {
+      if (recoveryRoute.kind === 'resolveConflict') {
+        await requireTaskExecutor().resolveConflict(taskId, persistedSavedError, agentName);
+      } else {
+        await requireTaskExecutor().fixWithAgent(taskId, output, agentName, persistedSavedError);
+      }
+      const result = await finalizeAppliedFix(taskId, persistedSavedError, {
         orchestrator,
         taskExecutor: requireTaskExecutor(),
         autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
@@ -1322,7 +1340,7 @@ if (isHeadless) {
       const msg = err instanceof Error ? err.message : String(err);
       const errorLabel = source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`;
       persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
-      orchestrator.revertConflictResolution(taskId, savedError, msg);
+      orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
       throw err;
     }
   };

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -568,6 +568,11 @@ export async function finalizeAppliedFix(
 
 // ── Auto-fix helpers ─────────────────────────────────────────
 
+export type FailureRecoveryRoute =
+  | { kind: 'fixWithAgent' }
+  | { kind: 'resolveConflict' }
+  | { kind: 'recreateWorkflowFromFreshBase'; workflowId: string };
+
 function isMergeConflictError(error: string): boolean {
   for (const c of [error, error.trim(), error.split('\n\n').at(-1)?.trim() ?? '']) {
     if (!c) continue;
@@ -580,11 +585,36 @@ function isMergeConflictError(error: string): boolean {
         /* not parseable JSON tail */
       }
     }
-    if (c.includes('CONFLICT (') || c.includes('Automatic merge failed')) {
+    if (
+      c.includes('CONFLICT (') ||
+      c.includes('Automatic merge failed') ||
+      c.includes('Merge conflict merging ')
+    ) {
       return true;
     }
   }
   return false;
+}
+
+export function selectFailureRecoveryRoute(
+  task: TaskState,
+  savedError: string,
+): FailureRecoveryRoute {
+  if (!isMergeConflictError(savedError)) {
+    return { kind: 'fixWithAgent' };
+  }
+
+  const workspacePath = task.execution.workspacePath?.trim();
+  if (workspacePath) {
+    return { kind: 'resolveConflict' };
+  }
+
+  const workflowId = task.config.workflowId?.trim();
+  if (!workflowId) {
+    return { kind: 'resolveConflict' };
+  }
+
+  return { kind: 'recreateWorkflowFromFreshBase', workflowId };
 }
 
 function tailText(value: unknown, maxChars: number = 2000): string | undefined {
@@ -713,6 +743,8 @@ export async function autoFixOnFailure(
 
   const attempts = (task.execution.autoFixAttempts ?? 0) + 1;
   const max = orchestrator.getAutoFixRetryBudget(taskId);
+  const savedError = task.execution.error ?? '';
+  const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
   console.log(`[auto-fix] "${taskId}" attempt ${attempts}/${max}`);
   persistence.logEvent?.(taskId, 'debug.auto-fix', {
     phase: 'auto-fix-start',
@@ -727,14 +759,9 @@ export async function autoFixOnFailure(
   // Increment counter FIRST (before any delta can re-trigger)
   persistence.updateTask(taskId, { execution: { autoFixAttempts: attempts } });
 
-  const { savedError } = orchestrator.beginConflictResolution(taskId);
   const agentSelection = resolveAutoFixAgent(deps.getAutoFixAgent?.());
-  persistence.logEvent?.(taskId, 'debug.auto-fix', {
-    phase: 'auto-fix-begin-conflict-resolution',
-    savedErrorLength: savedError.length,
-  });
+  let persistedSavedError: string | undefined;
   try {
-    const output = persistence.getTaskOutput(taskId);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-agent-selected',
       configuredAutoFixAgent: agentSelection.configuredAutoFixAgent ?? null,
@@ -746,8 +773,7 @@ export async function autoFixOnFailure(
       taskId,
       `\n[Auto-fix Agent] selected=${agentSelection.selectedAgent} source=${agentSelection.selectedAgentSource} fallback=${agentSelection.fallbackChain}`,
     );
-    const useResolveConflict = isMergeConflictError(savedError);
-    const route = useResolveConflict ? 'resolveConflict' : 'fixWithAgent';
+    const route = recoveryRoute.kind;
     console.log(
       `[auto-fix-route] task="${taskId}" route=${route} agent=${agentSelection.selectedAgent} source=${agentSelection.selectedAgentSource}`,
     );
@@ -758,12 +784,42 @@ export async function autoFixOnFailure(
       selectedAgentSource: agentSelection.selectedAgentSource,
       configuredAutoFixAgent: agentSelection.configuredAutoFixAgent ?? null,
       fallbackChain: agentSelection.fallbackChain,
-      outputLength: output.length,
+      outputLength: recoveryRoute.kind === 'recreateWorkflowFromFreshBase'
+        ? null
+        : persistence.getTaskOutput(taskId).length,
     });
-    if (useResolveConflict) {
-      await taskExecutor.resolveConflict(taskId, savedError, agentSelection.selectedAgent);
+    if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
+      persistence.appendTaskOutput(
+        taskId,
+        `\n[Auto-fix] Startup merge conflict detected; recreating workflow ${recoveryRoute.workflowId} from a fresh base.`,
+      );
+      const started = await recreateWorkflowFromFreshBase(recoveryRoute.workflowId, {
+        orchestrator,
+        persistence,
+        taskExecutor,
+      });
+      const runnable = started.filter((candidate) => candidate.status === 'running');
+      persistence.logEvent?.(taskId, 'debug.auto-fix', {
+        phase: 'auto-fix-post-route-recreate-workflow',
+        workflowId: recoveryRoute.workflowId,
+        startedCount: started.length,
+        runnableCount: runnable.length,
+        startedStatuses: started.map((candidate) => candidate.status),
+      });
+      if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
+      return;
+    }
+
+    ({ savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId));
+    persistence.logEvent?.(taskId, 'debug.auto-fix', {
+      phase: 'auto-fix-begin-conflict-resolution',
+      savedErrorLength: persistedSavedError.length,
+    });
+    if (recoveryRoute.kind === 'resolveConflict') {
+      await taskExecutor.resolveConflict(taskId, persistedSavedError, agentSelection.selectedAgent);
     } else {
-      await taskExecutor.fixWithAgent(taskId, output, agentSelection.selectedAgent, savedError);
+      const output = persistence.getTaskOutput(taskId);
+      await taskExecutor.fixWithAgent(taskId, output, agentSelection.selectedAgent, persistedSavedError);
     }
     const postRouteStrategy = selectAutoFixPostRouteStrategy(task);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
@@ -775,7 +831,7 @@ export async function autoFixOnFailure(
         persistence,
         taskExecutor,
       });
-      const finalizeResult = await finalizeAppliedFix(taskId, savedError, {
+      const finalizeResult = await finalizeAppliedFix(taskId, persistedSavedError, {
         orchestrator,
         taskExecutor,
         autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
@@ -825,6 +881,8 @@ export async function autoFixOnFailure(
     }
     persistence.appendTaskOutput(taskId, `\n[Auto-fix] Agent failed (attempt ${attempts}/${max}): ${msg}`);
     const detailedMsg = diagnostics ? `${msg}\n\n${diagnostics}` : msg;
-    orchestrator.revertConflictResolution(taskId, savedError, detailedMsg);
+    if (persistedSavedError !== undefined) {
+      orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg);
+    }
   }
 }

--- a/packages/execution-engine/src/__tests__/branch-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-utils.test.ts
@@ -602,6 +602,60 @@ describe('bashMergeUpstreams', () => {
     // Dirty tracked+untracked state should be removed by pre-merge cleanup.
     expect(gitExec('git status --porcelain', wtDir)).toBe('');
   });
+
+  it('prefers origin refs over stale same-named local branches', async () => {
+    const originDir = join(repoDir, '..', `origin-${Date.now()}.git`);
+    const seedDir = join(repoDir, '..', `seed-${Date.now()}`);
+    const originalRepoDir = repoDir;
+
+    try {
+      execSync(`git init --bare "${originDir}"`);
+      execSync(`git clone "${originDir}" "${seedDir}"`, { stdio: 'ignore' });
+      gitExec('git config user.email "test@example.com"', seedDir);
+      gitExec('git config user.name "Test User"', seedDir);
+
+      writeFileSync(join(seedDir, 'shared.txt'), 'base\n');
+      gitExec('git add shared.txt && git commit -m "base"', seedDir);
+      gitExec('git branch -M master', seedDir);
+      gitExec('git push -u origin master', seedDir);
+
+      gitExec('git checkout -b dep', seedDir);
+      writeFileSync(join(seedDir, 'shared.txt'), 'dep-v1\n');
+      gitExec('git commit -am "dep v1"', seedDir);
+      gitExec('git push -u origin dep', seedDir);
+
+      execSync(`git worktree remove --force "${wtDir}"`, { cwd: repoDir });
+      rmSync(originalRepoDir, { recursive: true, force: true });
+
+      execSync(`git clone "${originDir}" "${originalRepoDir}"`, { stdio: 'ignore' });
+      repoDir = originalRepoDir;
+      gitExec('git config user.email "test@example.com"', repoDir);
+      gitExec('git config user.name "Test User"', repoDir);
+      gitExec('git checkout -b dep origin/dep', repoDir);
+      gitExec('git checkout master', repoDir);
+
+      wtDir = join(repoDir, '..', 'merge-wt-' + Date.now());
+      execSync(`git worktree add -b invoker/merge-test "${wtDir}" origin/master`, { cwd: repoDir });
+
+      gitExec('git checkout dep', seedDir);
+      writeFileSync(join(seedDir, 'shared.txt'), 'dep-v2\n');
+      gitExec('git commit -am "dep v2"', seedDir);
+      gitExec('git push --force origin dep', seedDir);
+
+      gitExec('git fetch origin', repoDir);
+
+      const script = bashMergeUpstreams({
+        worktreeDir: wtDir,
+        upstreamBranches: ['dep'],
+      });
+      await runBashLocal(script);
+
+      expect(readFileSync(join(wtDir, 'shared.txt'), 'utf-8')).toBe('dep-v2\n');
+    } finally {
+      rmSync(seedDir, { recursive: true, force: true });
+      rmSync(originDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -190,11 +190,13 @@ WT_DIR=${q(worktreeDir)}
 git -C "$WT_DIR" reset --hard HEAD >/dev/null 2>&1 || true
 git -C "$WT_DIR" clean -fd >/dev/null 2>&1 || true
 for upBranch in ${branches}; do
-  # Resolve: try bare name first, then origin/ prefix
-  if git -C "$WT_DIR" rev-parse --verify "$upBranch" >/dev/null 2>&1; then
-    upRef="$upBranch"
-  elif git -C "$WT_DIR" rev-parse --verify "origin/$upBranch" >/dev/null 2>&1; then
+  # Resolve: prefer fetched origin/<branch> over same-named local branches.
+  # Managed mirrors accumulate local experiment refs from prior runs; after a
+  # fetch, a stale local branch must not shadow a newer remote-tracking ref.
+  if git -C "$WT_DIR" rev-parse --verify "origin/$upBranch" >/dev/null 2>&1; then
     upRef="origin/$upBranch"
+  elif git -C "$WT_DIR" rev-parse --verify "$upBranch" >/dev/null 2>&1; then
+    upRef="$upBranch"
   else
     # Branch doesn't exist locally or on origin - skip gracefully
     echo "SKIPPED_MISSING_REF=$upBranch"


### PR DESCRIPTION
## Summary

Prefer `origin/<branch>` over same-named local branches when merging upstream task branches during executor startup. This prevents stale local experiment refs in managed mirrors from shadowing freshly fetched remote-tracking refs, which could make SSH startup merge the wrong dependency branch and report false merge conflicts.

Add a regression test around `bashMergeUpstreams` that reproduces the stale-local-vs-origin shadowing case and proves the merge uses the newer `origin/dep` content.

## Architecture

### Before

```mermaid
graph TD
    A[SSH bootstrap resolves base as origin/master] --> B[merge upstream task branches]
    B --> C[resolve bare branch name first]
    C --> D[stale local experiment ref can shadow origin/branch]
```

### After

```mermaid
graph TD
    A[SSH bootstrap resolves base as origin/master] --> B[merge upstream task branches]
    B --> C[resolve origin/branch first]
    C --> D[fetched remote-tracking ref wins over stale local ref]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- --run packages/execution-engine/src/__tests__/branch-utils.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert ec92f2ec`
- Post-revert steps: None
- Data migration? No
