### PR TITLE
Add missing frontmatter to bundled skill docs

### DIFF
--- a/skills/visual-proof/SKILL.md
+++ b/skills/visual-proof/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: visual-proof
+description: >
+  Capture before/after UI screenshots and video for Invoker plans that modify
+  the UI.
+---
+
 # visual-proof
 
 Capture before/after UI screenshots and video for Invoker plans that modify the UI.

--- a/skills/workflow-chain-submit/SKILL.md
+++ b/skills/workflow-chain-submit/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: workflow-chain-submit
+description: >
+  Submit a workflow chain headlessly, where each workflow is gated on the
+  previous workflow's merge gate.
+---
+
 # workflow-chain-submit
 
 Submit a workflow chain headlessly, where each workflow is gated on the previous workflow's merge gate.


### PR DESCRIPTION
## Summary

Add the missing YAML frontmatter blocks to the canonical bundled skill docs for `visual-proof` and `workflow-chain-submit` so bundled installs expose valid `SKILL.md` metadata to Codex, Claude, and Cursor.

## Test Plan

- [x] `./run.sh --install-skills`
- [x] `sed -n '1,10p' ~/.codex/skills/invoker-visual-proof/SKILL.md`
- [x] `sed -n '1,10p' ~/.codex/skills/invoker-workflow-chain-submit/SKILL.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 5f781b97`
- Post-revert steps: Re-run `./run.sh --install-skills` if you need the installed bundled skill copies reverted too.
- Data migration? No
