### PR TITLE
PR 130 Architecture Step 4: Introduce neutral owner endpoint abstraction

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -4,7 +4,7 @@ import { LocalBus } from '@invoker/transport';
 import { SharedMutationOwnerTimeoutError, runHeadlessClientCommand } from '../headless-client.js';
 
 describe('headless-client', () => {
-  it('delegates mutating commands to an existing standalone owner without electron fallback', async () => {
+  it('delegates mutating commands to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));
     bus.onRequest('headless.exec', ownerHandler);
@@ -29,29 +29,43 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
-  it('delegates mutating commands to a GUI owner when it responds successfully', async () => {
+  it('delegates mutating commands to a reachable non-standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const guiOwnerHandler = vi.fn(async () => ({ ok: true }));
 
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
     bus.onRequest('headless.exec', guiOwnerHandler);
 
-    const ensureStandaloneOwner = vi.fn(async () => {});
-
     const exitCode = await runHeadlessClientCommand(['retry', 'wf-1', '--no-track'], {
       messageBus: bus,
-      ensureStandaloneOwner,
+      ensureStandaloneOwner: vi.fn(async () => {}),
       runElectronHeadless: vi.fn(async () => 0),
     });
 
     expect(exitCode).toBe(0);
     expect(guiOwnerHandler).toHaveBeenCalledTimes(1);
-    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
   });
 
-  // --- Regression: standalone-owner scope for headless.run ---
+  it('uses a longer no-track delegation timeout for an already-running standalone-capable owner under load', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+    bus.onRequest('headless.exec', async () => {
+      await new Promise((resolve) => setTimeout(resolve, 9_000));
+      return { ok: true };
+    });
 
-  it('delegates headless.run to an existing standalone owner', async () => {
+    const exitCode = await runHeadlessClientCommand(['retry', 'wf-1', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+  }, 15_000);
+
+  // --- Regression: owner endpoint scope for headless.run ---
+
+  it('delegates headless.run to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const runHandler = vi.fn(async () => ({ ok: true }));
     bus.onRequest('headless.run', runHandler);
@@ -68,29 +82,9 @@ describe('headless-client', () => {
     expect(runHandler).toHaveBeenCalledWith(expect.objectContaining({ planPath: expect.stringContaining('plan.yaml') }));
   });
 
-  it('delegates headless.run to a GUI owner when it responds successfully', async () => {
-    const bus = new LocalBus();
-    const guiRunHandler = vi.fn(async () => ({ ok: true }));
+  // --- Regression: owner endpoint scope for headless.resume ---
 
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    bus.onRequest('headless.run', guiRunHandler);
-
-    const ensureStandaloneOwner = vi.fn(async () => {});
-
-    const exitCode = await runHeadlessClientCommand(['run', '/tmp/plan.yaml', '--no-track'], {
-      messageBus: bus,
-      ensureStandaloneOwner,
-      runElectronHeadless: vi.fn(async () => 0),
-    });
-
-    expect(exitCode).toBe(0);
-    expect(guiRunHandler).toHaveBeenCalledTimes(1);
-    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
-  });
-
-  // --- Regression: standalone-owner scope for headless.resume ---
-
-  it('delegates headless.resume to an existing standalone owner', async () => {
+  it('delegates headless.resume to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const resumeHandler = vi.fn(async () => ({ ok: true }));
     bus.onRequest('headless.resume', resumeHandler);
@@ -107,27 +101,7 @@ describe('headless-client', () => {
     expect(resumeHandler).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 'wf-42' }));
   });
 
-  it('delegates headless.resume to a GUI owner when it responds successfully', async () => {
-    const bus = new LocalBus();
-    const guiResumeHandler = vi.fn(async () => ({ ok: true }));
-
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    bus.onRequest('headless.resume', guiResumeHandler);
-
-    const ensureStandaloneOwner = vi.fn(async () => {});
-
-    const exitCode = await runHeadlessClientCommand(['resume', 'wf-42', '--no-track'], {
-      messageBus: bus,
-      ensureStandaloneOwner,
-      runElectronHeadless: vi.fn(async () => 0),
-    });
-
-    expect(exitCode).toBe(0);
-    expect(guiResumeHandler).toHaveBeenCalledTimes(1);
-    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
-  });
-
-  it('bootstraps a standalone owner once when no owner is present, then delegates', async () => {
+  it('bootstraps when no owner endpoint is available, then delegates', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));
     const ensureStandaloneOwner = vi.fn(async () => {
@@ -171,6 +145,37 @@ describe('headless-client', () => {
     expect(ensureStandaloneOwner).toHaveBeenCalledWith(firstBus);
     expect(refreshMessageBus).toHaveBeenCalledTimes(2);
     expect(ownerHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the refreshed bus into bootstrap after an owner-timeout retry', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    let bootstrapCalls = 0;
+
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
+    secondBus.onRequest('headless.run', async () => ({ workflowId: 'wf-bootstrap', tasks: [] }));
+
+    const ensureStandaloneOwner = vi.fn(async (_bus?: unknown) => {
+      bootstrapCalls += 1;
+      if (bootstrapCalls === 1) {
+        throw new SharedMutationOwnerTimeoutError();
+      }
+    });
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValueOnce(secondBus)
+      .mockResolvedValue(secondBus);
+
+    const exitCode = await runHeadlessClientCommand(['run', '/tmp/plan.yaml', '--no-track'], {
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(1, secondBus);
+    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(2, secondBus);
   });
 
   it('uses a longer no-track delegation timeout after bootstrap under load', async () => {
@@ -323,49 +328,18 @@ describe('headless-client', () => {
     expect(refreshMessageBus).toHaveBeenCalled();
   }, 15_000);
 
-  it('delegates to a GUI owner when it responds to mutations', async () => {
-    const bus = new LocalBus();
-    let execCalls = 0;
-
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    bus.onRequest('headless.exec', async () => {
-      execCalls += 1;
-      return { ok: true };
-    });
-
-    const ensureStandaloneOwner = vi.fn(async () => {});
-
-    const exitCode = await runHeadlessClientCommand(['recreate', 'wf-3', '--no-track'], {
-      messageBus: bus,
-      ensureStandaloneOwner,
-      runElectronHeadless: vi.fn(async () => 0),
-    });
-
-    expect(exitCode).toBe(0);
-    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
-    expect(execCalls).toBe(1);
-  }, 15_000);
-
-  it('falls back to standalone owner when GUI owner delegation times out', async () => {
+  it('uses the current reachable owner endpoint directly without refreshing or bootstrapping', async () => {
     const firstBus = new LocalBus();
-    const secondBus = new LocalBus();
     let firstExecCalls = 0;
-    let secondExecCalls = 0;
 
     firstBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
     firstBus.onRequest('headless.exec', async () => {
       firstExecCalls += 1;
-      return await new Promise(() => {});
-    });
-
-    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
-    secondBus.onRequest('headless.exec', async () => {
-      secondExecCalls += 1;
       return { ok: true };
     });
 
     const ensureStandaloneOwner = vi.fn(async () => {});
-    const refreshMessageBus = vi.fn(async () => secondBus);
+    const refreshMessageBus = vi.fn(async () => firstBus);
 
     const exitCode = await runHeadlessClientCommand(['recreate', 'wf-3', '--no-track'], {
       messageBus: firstBus,
@@ -376,12 +350,11 @@ describe('headless-client', () => {
 
     expect(exitCode).toBe(0);
     expect(ensureStandaloneOwner).not.toHaveBeenCalled();
-    expect(refreshMessageBus).toHaveBeenCalled();
+    expect(refreshMessageBus).not.toHaveBeenCalled();
     expect(firstExecCalls).toBe(1);
-    expect(secondExecCalls).toBe(1);
-  }, 20_000);
+  }, 15_000);
 
-  it('falls back to the electron runtime for non-mutating commands', async () => {
+  it('falls back to the host runtime for non-mutating commands', async () => {
     const runElectronHeadless = vi.fn(async () => 0);
     const exitCode = await runHeadlessClientCommand(['query', 'workflows'], {
       messageBus: new LocalBus(),
@@ -393,7 +366,7 @@ describe('headless-client', () => {
     expect(runElectronHeadless).toHaveBeenCalledWith(['query', 'workflows']);
   });
 
-  it('delegates query ui-perf to an existing owner without electron fallback', async () => {
+  it('delegates query ui-perf to a reachable owner endpoint', async () => {
     const bus = new LocalBus();
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
     bus.onRequest('headless.query', async () => ({
@@ -416,7 +389,7 @@ describe('headless-client', () => {
     stdout.mockRestore();
   });
 
-  it('does not silently fall back for query ui-perf when no owner is present', async () => {
+  it('does not silently fall back for query ui-perf when no owner endpoint is reachable', async () => {
     await expect(
       runHeadlessClientCommand(['query', 'ui-perf', '--output', 'json'], {
         messageBus: new LocalBus(),
@@ -426,7 +399,7 @@ describe('headless-client', () => {
     ).rejects.toThrow(/requires a running shared owner process/);
   }, 30_000);
 
-  it('delegates query queue to an existing owner without electron fallback', async () => {
+  it('delegates query queue to a reachable owner endpoint', async () => {
     const bus = new LocalBus();
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
     bus.onRequest('headless.query', async () => ({

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -335,8 +335,8 @@ describe('headless→owner delegation', () => {
   });
 
   describe('tryDelegateRun / tryDelegateResume', () => {
-    it('succeeds when GUI handler returns immediately (fire-and-forget execution)', async () => {
-      // Simulate GUI handler that returns response immediately without awaiting
+    it('succeeds when owner handler returns immediately (fire-and-forget execution)', async () => {
+      // Simulate owner handler that returns response immediately without awaiting
       // task execution — the fix for the 5s delegation timeout bug.
       messageBus.onRequest('headless.run', async (req: { planPath: string }) => {
         expect(req.planPath).toContain('plan.yaml');
@@ -355,7 +355,7 @@ describe('headless→owner delegation', () => {
       expect(delegated).toBe(true);
     });
 
-    it('times out when GUI handler blocks on task execution (pre-fix behavior)', async () => {
+    it('times out when owner handler blocks on task execution (pre-fix behavior)', async () => {
       // Simulate the old bug: handler awaits executeTasks which never resolves
       messageBus.onRequest('headless.run', async () => {
         return new Promise(() => {}); // Never resolves — simulates await executeTasks()

--- a/packages/app/src/__tests__/owner-endpoint.test.ts
+++ b/packages/app/src/__tests__/owner-endpoint.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { LocalBus } from '@invoker/transport';
+
+import {
+  discoverOwner,
+  isOwnerReachable,
+  isStandaloneCapable,
+  type OwnerEndpointInfo,
+} from '../owner-endpoint.js';
+
+describe('owner-endpoint contract', () => {
+  describe('discoverOwner', () => {
+    it('returns null when no owner responds within the timeout', async () => {
+      const bus = new LocalBus();
+      const result = await discoverOwner(bus, 200);
+      expect(result).toBeNull();
+    });
+
+    it('returns OwnerEndpointInfo with canAcceptStandaloneMutations=true for standalone owners', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-123',
+        mode: 'standalone',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).not.toBeNull();
+      expect(result!.ownerId).toBe('owner-123');
+      expect(result!.canAcceptStandaloneMutations).toBe(true);
+    });
+
+    it('returns OwnerEndpointInfo with canAcceptStandaloneMutations=false for GUI owners', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-456',
+        mode: 'gui',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).not.toBeNull();
+      expect(result!.ownerId).toBe('owner-456');
+      expect(result!.canAcceptStandaloneMutations).toBe(false);
+    });
+
+    it('does not expose the raw mode string in the returned contract', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-789',
+        mode: 'gui',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).not.toBeNull();
+      // The contract type should not have a `mode` field
+      expect('mode' in result!).toBe(false);
+    });
+
+    it('defaults ownerId to empty string when the ping response omits it', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        mode: 'standalone',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).not.toBeNull();
+      expect(result!.ownerId).toBe('');
+      expect(result!.canAcceptStandaloneMutations).toBe(true);
+    });
+  });
+
+  describe('isStandaloneCapable', () => {
+    it('returns true for standalone-capable owners', () => {
+      const owner: OwnerEndpointInfo = {
+        ownerId: 'owner-1',
+        canAcceptStandaloneMutations: true,
+      };
+      expect(isStandaloneCapable(owner)).toBe(true);
+    });
+
+    it('returns false for non-standalone owners', () => {
+      const owner: OwnerEndpointInfo = {
+        ownerId: 'owner-2',
+        canAcceptStandaloneMutations: false,
+      };
+      expect(isStandaloneCapable(owner)).toBe(false);
+    });
+
+    it('returns false for null (no owner reachable)', () => {
+      expect(isStandaloneCapable(null)).toBe(false);
+    });
+  });
+
+  describe('isOwnerReachable', () => {
+    it('returns true for any non-null owner', () => {
+      const standaloneOwner: OwnerEndpointInfo = {
+        ownerId: 'owner-1',
+        canAcceptStandaloneMutations: true,
+      };
+      const guiOwner: OwnerEndpointInfo = {
+        ownerId: 'owner-2',
+        canAcceptStandaloneMutations: false,
+      };
+      expect(isOwnerReachable(standaloneOwner)).toBe(true);
+      expect(isOwnerReachable(guiOwner)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isOwnerReachable(null)).toBe(false);
+    });
+  });
+
+  describe('surface neutrality', () => {
+    it('treats any owner with mode !== standalone as non-standalone-capable', async () => {
+      const bus = new LocalBus();
+      // Hypothetical future mode — the contract should not care
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-future',
+        mode: 'some-new-surface',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).not.toBeNull();
+      expect(result!.canAcceptStandaloneMutations).toBe(false);
+      expect(isOwnerReachable(result)).toBe(true);
+      expect(isStandaloneCapable(result)).toBe(false);
+    });
+
+    it('client code never needs to reference GUI or standalone modes directly', () => {
+      // This test documents the contract guarantee: the OwnerEndpointInfo
+      // type has no `mode` field. Client code uses capability predicates.
+      const info: OwnerEndpointInfo = {
+        ownerId: 'owner-1',
+        canAcceptStandaloneMutations: true,
+      };
+      // Type-level: 'mode' is not a key of OwnerEndpointInfo
+      const keys = Object.keys(info);
+      expect(keys).toContain('ownerId');
+      expect(keys).toContain('canAcceptStandaloneMutations');
+      expect(keys).not.toContain('mode');
+    });
+  });
+});

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -13,13 +13,18 @@ import {
   tryDelegateQueryUiPerf,
   tryDelegateResume,
   tryDelegateRun,
-  tryPingHeadlessOwner,
 } from './headless-delegation.js';
 import {
   spawnDetachedStandaloneOwner,
   tryAcquireOwnerBootstrapLock,
 } from './headless-owner-bootstrap.js';
 import { loadConfig } from './config.js';
+import {
+  discoverOwner,
+  isOwnerReachable,
+  isStandaloneCapable,
+  type OwnerDiscoveryResult,
+} from './owner-endpoint.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -69,11 +74,6 @@ const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 8_000;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
 const DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS = 60_000;
-type HeadlessOwnerInfo = { ownerId?: string; mode?: string };
-
-function isStandaloneOwner(owner: HeadlessOwnerInfo | null | undefined): owner is HeadlessOwnerInfo & { mode: 'standalone' } {
-  return owner?.mode === 'standalone';
-}
 
 function standaloneOwnerBootstrapTimeoutMs(): number {
   const raw = process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS;
@@ -131,16 +131,16 @@ async function delegateReadOnlyQuery(
   }
   const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
   let messageBus = bus;
-  let owner: HeadlessOwnerInfo | null = null;
+  let owner: OwnerDiscoveryResult = null;
   while (Date.now() < deadline) {
-    owner = await tryPingHeadlessOwner(messageBus, 2_000);
-    if (owner) break;
+    owner = await discoverOwner(messageBus, 2_000);
+    if (isOwnerReachable(owner)) break;
     if (refreshMessageBus) {
       messageBus = await refreshMessageBus();
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
-  if (!owner) {
+  if (!isOwnerReachable(owner)) {
     throw new Error(isUiPerf
       ? 'query ui-perf requires a running shared owner process'
       : 'query queue requires a running shared owner process');
@@ -202,8 +202,8 @@ async function delegateAfterBootstrap(
   const deadline = Date.now() + POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS;
   let messageBus = bus;
   while (Date.now() < deadline) {
-    const owner = await tryPingHeadlessOwner(messageBus, 1_000);
-    if (isStandaloneOwner(owner) && await delegateMutation(
+    const owner = await discoverOwner(messageBus, 1_000);
+    if (isStandaloneCapable(owner) && await delegateMutation(
       args,
       messageBus,
       waitForApproval,
@@ -236,8 +236,8 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
     }
     const deadline = Date.now() + standaloneOwnerBootstrapTimeoutMs();
     while (Date.now() < deadline) {
-      const owner = await tryPingHeadlessOwner(bus, 500);
-      if (isStandaloneOwner(owner)) return;
+      const owner = await discoverOwner(bus, 500);
+      if (isStandaloneCapable(owner)) return;
       await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
     }
     throw new SharedMutationOwnerTimeoutError();
@@ -287,19 +287,19 @@ export async function runHeadlessClientCommand(
     return deps.runElectronHeadless(argv);
   }
 
-  const owner = await tryPingHeadlessOwner(messageBus, 3_000);
-  if (isStandaloneOwner(owner)) {
+  const owner = await discoverOwner(messageBus, 3_000);
+  if (isStandaloneCapable(owner)) {
     if (await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
       return resolvedExitCode();
     }
   }
-  if (owner && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+  if (isOwnerReachable(owner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
     return resolvedExitCode();
   }
-  if (owner && deps.refreshMessageBus) {
+  if (isOwnerReachable(owner) && deps.refreshMessageBus) {
     messageBus = await deps.refreshMessageBus();
-    const refreshedOwner = await tryPingHeadlessOwner(messageBus, 1_000);
-    if (refreshedOwner && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+    const refreshedOwner = await discoverOwner(messageBus, 1_000);
+    if (isOwnerReachable(refreshedOwner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
       return resolvedExitCode();
     }
   }

--- a/packages/app/src/owner-endpoint.ts
+++ b/packages/app/src/owner-endpoint.ts
@@ -1,0 +1,78 @@
+/**
+ * Owner Endpoint Contract — surface-neutral owner discovery and capability.
+ *
+ * This module models owner discovery without exposing whether the owner is
+ * a GUI window, a standalone headless daemon, or any other host surface.
+ * Client code asks "is an owner available?" and "can it accept mutations?"
+ * without knowing how the owner was launched.
+ *
+ * Host implementations (main.ts standalone path, main.ts GUI path) register
+ * handlers on the MessageBus that satisfy this contract. They may retain
+ * internal details about their launch mode, but those details do not appear
+ * in the types below.
+ */
+
+import type { MessageBus } from '@invoker/transport';
+
+import { tryPingHeadlessOwner } from './headless-delegation.js';
+
+// ── Contract types ──────────────────────────────────────────
+
+/** What the client learns from a successful owner discovery ping. */
+export interface OwnerEndpointInfo {
+  /** Opaque identifier for the running owner process. */
+  ownerId: string;
+  /**
+   * Whether this owner can accept bootstrapped standalone mutations.
+   * True when the owner was started as a detached long-lived process
+   * (the kind `ensureStandaloneOwner` provisions). False for transient
+   * owners that happen to be alive (e.g. an interactive session).
+   *
+   * The client uses this to decide whether post-bootstrap delegation
+   * should target this owner or whether a fresh bootstrap is needed.
+   */
+  canAcceptStandaloneMutations: boolean;
+}
+
+/** Discovery failed — no owner is reachable within the timeout. */
+export type OwnerNotReachable = null;
+
+/** Result of an owner discovery attempt. */
+export type OwnerDiscoveryResult = OwnerEndpointInfo | OwnerNotReachable;
+
+// ── Discovery implementation ────────────────────────────────
+
+/**
+ * Discover a running owner endpoint via the MessageBus.
+ *
+ * This is the single entry point that client code should use instead of
+ * calling `tryPingHeadlessOwner` directly and inspecting the raw `mode`
+ * field.
+ */
+export async function discoverOwner(
+  messageBus: MessageBus,
+  timeoutMs?: number,
+): Promise<OwnerDiscoveryResult> {
+  const raw = await tryPingHeadlessOwner(messageBus, timeoutMs);
+  if (!raw) return null;
+  return {
+    ownerId: raw.ownerId ?? '',
+    canAcceptStandaloneMutations: raw.mode === 'standalone',
+  };
+}
+
+// ── Capability predicates ───────────────────────────────────
+
+/** Whether the discovered owner accepts standalone-bootstrapped mutations. */
+export function isStandaloneCapable(
+  owner: OwnerDiscoveryResult,
+): owner is OwnerEndpointInfo & { canAcceptStandaloneMutations: true } {
+  return owner !== null && owner.canAcceptStandaloneMutations;
+}
+
+/** Whether any owner (of any kind) is reachable. */
+export function isOwnerReachable(
+  owner: OwnerDiscoveryResult,
+): owner is OwnerEndpointInfo {
+  return owner !== null;
+}


### PR DESCRIPTION
## Summary

This PR introduces a neutral owner-endpoint abstraction so callers stop caring
about whether the writable owner is hosted by a GUI process or a standalone
process. Instead of branching on surface-specific labels, the code now asks for
an owner endpoint with the capabilities it needs.

It also updates the focused owner discovery and delegation tests so the new
contract is pinned before the later resolver and terminology cleanup steps land.

## Architecture

### Before

```mermaid
graph TD
    A[headless-client and owner checks] --> B[ask whether owner is GUI or standalone]
    B --> C[callers make ownership policy decisions inline]
    C --> D[tests assert surface-specific behavior]
```

### After

```mermaid
graph TD
    A[headless-client and owner checks] --> B[resolve owner endpoint]
    B --> C[endpoint exposes writable capabilities]
    C --> D[callers use one neutral contract]
    D --> E[tests assert endpoint and capability behavior]
```

## Test Plan

- [ ] `pnpm test -- --run packages/app/src/__tests__/owner-endpoint.test.ts`
- [ ] `pnpm test -- --run packages/app/src/__tests__/owner-delegation.test.ts`
- [ ] `pnpm test -- --run packages/app/src/__tests__/headless-client.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 31d25196`
- Post-revert steps: Re-run the commands in the test plan to confirm the old surface-specific owner behavior is restored
- Data migration? No
