### PR TITLE
PR 130 Architecture Step 5: Route surfaces through owner resolver

### DIFF
--- a/packages/app/src/__tests__/owner-resolver.test.ts
+++ b/packages/app/src/__tests__/owner-resolver.test.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LocalBus } from '@invoker/transport';
+
+import { createOwnerResolver } from '../owner-resolver.js';
+
+describe('owner-resolver', () => {
+  describe('discover', () => {
+    it('returns resolved owner when a standalone-capable owner responds', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.discover();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.owner.ownerId).toBe('owner-1');
+        expect(result.owner.canAcceptStandaloneMutations).toBe(true);
+      }
+    });
+
+    it('returns not-resolved when no owner responds', async () => {
+      const bus = new LocalBus();
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      }, { discoveryTimeoutMs: 200 });
+
+      const result = await resolver.discover();
+      expect(result.resolved).toBe(false);
+    });
+
+    it('returns not-resolved for a GUI owner (not standalone-capable)', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-gui',
+        mode: 'gui',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.discover();
+      expect(result.resolved).toBe(false);
+    });
+  });
+
+  describe('discoverAny', () => {
+    it('returns a GUI owner as resolved', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-gui',
+        mode: 'gui',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.discoverAny();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.owner.ownerId).toBe('owner-gui');
+        expect(result.owner.canAcceptStandaloneMutations).toBe(false);
+      }
+    });
+
+    it('returns not-resolved when no owner responds', async () => {
+      const bus = new LocalBus();
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      }, { discoveryTimeoutMs: 200 });
+
+      const result = await resolver.discoverAny();
+      expect(result.resolved).toBe(false);
+    });
+  });
+
+  describe('refreshAndDiscover', () => {
+    it('uses refreshed bus for discovery', async () => {
+      const firstBus = new LocalBus();
+      const secondBus = new LocalBus();
+      secondBus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-refreshed',
+        mode: 'standalone',
+      }));
+
+      const refreshMessageBus = vi.fn().mockResolvedValue(secondBus);
+      const resolver = createOwnerResolver({
+        messageBus: firstBus,
+        refreshMessageBus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.refreshAndDiscover();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.owner.ownerId).toBe('owner-refreshed');
+        expect(result.bus).toBe(secondBus);
+      }
+      expect(refreshMessageBus).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses original bus when no refreshMessageBus is provided', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-same',
+        mode: 'standalone',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.refreshAndDiscover();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.bus).toBe(bus);
+      }
+    });
+  });
+
+  describe('waitForAny', () => {
+    it('returns immediately when an owner is already reachable', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-fast',
+        mode: 'gui',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.waitForAny(5_000);
+      expect(result.resolved).toBe(true);
+    });
+
+    it('polls until an owner appears', async () => {
+      const bus = new LocalBus();
+      let pingCount = 0;
+      bus.onRequest('headless.owner-ping', async () => {
+        pingCount += 1;
+        if (pingCount >= 3) {
+          return { ok: true, ownerId: 'owner-delayed', mode: 'standalone' };
+        }
+        return null;
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.waitForAny(10_000);
+      expect(result.resolved).toBe(true);
+      expect(pingCount).toBeGreaterThanOrEqual(3);
+    });
+
+    it('returns not-resolved after timeout', async () => {
+      const bus = new LocalBus();
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      }, { discoveryTimeoutMs: 100 });
+
+      const result = await resolver.waitForAny(500);
+      expect(result.resolved).toBe(false);
+    });
+  });
+
+  describe('waitForStandalone', () => {
+    it('skips GUI owners and waits for standalone', async () => {
+      const bus = new LocalBus();
+      let pingCount = 0;
+      bus.onRequest('headless.owner-ping', async () => {
+        pingCount += 1;
+        if (pingCount >= 3) {
+          return { ok: true, ownerId: 'owner-standalone', mode: 'standalone' };
+        }
+        return { ok: true, ownerId: 'owner-gui', mode: 'gui' };
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.waitForStandalone(10_000);
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.owner.canAcceptStandaloneMutations).toBe(true);
+      }
+    });
+
+    it('returns not-resolved after timeout when only GUI owners available', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-gui',
+        mode: 'gui',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.waitForStandalone(500);
+      expect(result.resolved).toBe(false);
+    });
+  });
+
+  describe('resolve', () => {
+    it('returns immediately when a standalone owner is already available', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+
+      const ensureStandaloneOwner = vi.fn();
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-1');
+      expect(result.owner.canAcceptStandaloneMutations).toBe(true);
+      expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    });
+
+    it('bootstraps when no owner is initially available', async () => {
+      const bus = new LocalBus();
+      let bootstrapped = false;
+
+      const ensureStandaloneOwner = vi.fn(async () => {
+        bootstrapped = true;
+        bus.onRequest('headless.owner-ping', async () => ({
+          ok: true,
+          ownerId: 'owner-bootstrapped',
+          mode: 'standalone',
+        }));
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+      }, {
+        discoveryTimeoutMs: 200,
+        postBootstrapReadyTimeoutMs: 5_000,
+      });
+
+      const result = await resolver.resolve();
+      expect(bootstrapped).toBe(true);
+      expect(result.owner.ownerId).toBe('owner-bootstrapped');
+      expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries bootstrap when the first attempt does not produce a reachable owner', async () => {
+      const bus = new LocalBus();
+      let bootstrapCalls = 0;
+
+      const ensureStandaloneOwner = vi.fn(async () => {
+        bootstrapCalls += 1;
+        if (bootstrapCalls >= 2) {
+          bus.onRequest('headless.owner-ping', async () => ({
+            ok: true,
+            ownerId: 'owner-retry',
+            mode: 'standalone',
+          }));
+        }
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+      }, {
+        discoveryTimeoutMs: 200,
+        postBootstrapReadyTimeoutMs: 500,
+        maxBootstrapAttempts: 3,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-retry');
+      expect(bootstrapCalls).toBe(2);
+    });
+
+    it('throws after exhausting all bootstrap attempts', async () => {
+      const bus = new LocalBus();
+      const ensureStandaloneOwner = vi.fn(async () => {});
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+      }, {
+        discoveryTimeoutMs: 100,
+        postBootstrapReadyTimeoutMs: 200,
+        maxBootstrapAttempts: 2,
+      });
+
+      await expect(resolver.resolve()).rejects.toThrow(
+        /Could not resolve a standalone-capable owner/,
+      );
+      expect(ensureStandaloneOwner).toHaveBeenCalledTimes(2);
+    });
+
+    it('refreshes the bus between bootstrap attempts', async () => {
+      const firstBus = new LocalBus();
+      const secondBus = new LocalBus();
+      let bootstrapCalls = 0;
+
+      secondBus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-on-second-bus',
+        mode: 'standalone',
+      }));
+
+      const refreshMessageBus = vi.fn().mockResolvedValue(secondBus);
+      const ensureStandaloneOwner = vi.fn(async () => {
+        bootstrapCalls += 1;
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: firstBus,
+        refreshMessageBus,
+        ensureStandaloneOwner,
+      }, {
+        discoveryTimeoutMs: 200,
+        postBootstrapReadyTimeoutMs: 2_000,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-on-second-bus');
+      expect(refreshMessageBus).toHaveBeenCalled();
+    });
+
+    it('accepts any reachable owner when requireStandalone=false', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-gui',
+        mode: 'gui',
+      }));
+
+      const ensureStandaloneOwner = vi.fn();
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+      });
+
+      const result = await resolver.resolve(false);
+      expect(result.owner.ownerId).toBe('owner-gui');
+      expect(result.owner.canAcceptStandaloneMutations).toBe(false);
+      expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('surface neutrality', () => {
+    it('never exposes mode strings in resolved results', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.discover();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect('mode' in result.owner).toBe(false);
+        expect(Object.keys(result.owner)).toEqual(['ownerId', 'canAcceptStandaloneMutations']);
+      }
+    });
+
+    it('result contains bus handle but no GUI/headless flags', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.discover();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.bus).toBeDefined();
+        expect('isGui' in result).toBe(false);
+        expect('isHeadless' in result).toBe(false);
+        expect('surface' in result).toBe(false);
+      }
+    });
+  });
+});

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -23,8 +23,8 @@ import {
   discoverOwner,
   isOwnerReachable,
   isStandaloneCapable,
-  type OwnerDiscoveryResult,
 } from './owner-endpoint.js';
+import { createOwnerResolver } from './owner-resolver.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -129,22 +129,21 @@ async function delegateReadOnlyQuery(
   if (!isUiPerf && !isQueue) {
     return false;
   }
-  const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
-  let messageBus = bus;
-  let owner: OwnerDiscoveryResult = null;
-  while (Date.now() < deadline) {
-    owner = await discoverOwner(messageBus, 2_000);
-    if (isOwnerReachable(owner)) break;
-    if (refreshMessageBus) {
-      messageBus = await refreshMessageBus();
-    }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-  if (!isOwnerReachable(owner)) {
+
+  // Use the resolver to wait for any reachable owner
+  const resolver = createOwnerResolver(
+    { messageBus: bus, refreshMessageBus, ensureStandaloneOwner: async () => {} },
+    { discoveryTimeoutMs: 2_000 },
+  );
+  const ownerResult = await resolver.waitForAny(READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS);
+  if (!ownerResult.resolved) {
     throw new Error(isUiPerf
       ? 'query ui-perf requires a running shared owner process'
       : 'query queue requires a running shared owner process');
   }
+
+  let messageBus = ownerResult.bus;
+  const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
   let response: Record<string, unknown> | null = null;
   while (Date.now() < deadline) {
     if (isUiPerf) {
@@ -262,40 +261,40 @@ function parseArgs(argv: string[]): { args: string[]; waitForApproval?: boolean;
   return { args, waitForApproval, noTrack };
 }
 
-export async function runHeadlessClientCommand(
-  argv: string[],
+/**
+ * Resolve a writable owner endpoint using the resolver, then delegate.
+ *
+ * This function encapsulates the discover → fallback → bootstrap → delegate
+ * policy that was previously inline. It uses the OwnerResolver for the
+ * discovery/refresh/bootstrap phases and delegates command execution once
+ * an owner is acquired.
+ */
+async function resolveOwnerAndDelegate(
+  args: string[],
   deps: HeadlessClientDeps,
-): Promise<number> {
-  // Validate config before any delegation path so malformed JSON fails fast
-  // even for commands that do not boot the full Electron owner process.
-  loadConfig();
-
+  waitForApproval?: boolean,
+  noTrack?: boolean,
+): Promise<number | null> {
   let messageBus = deps.messageBus;
-  const { args, waitForApproval, noTrack } = parseArgs(argv);
-  const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
-  const internalOwnerServe = args[0] === 'owner-serve';
   const resolvedExitCode = (): number => {
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
   };
 
-  if (!standaloneMode && !internalOwnerServe && await delegateReadOnlyQuery(args, messageBus, deps.refreshMessageBus)) {
-    return resolvedExitCode();
-  }
-
-  if (!isHeadlessMutatingCommand(args) || standaloneMode || internalOwnerServe) {
-    return deps.runElectronHeadless(argv);
-  }
-
+  // Phase 1: Discover a standalone-capable owner
   const owner = await discoverOwner(messageBus, 3_000);
   if (isStandaloneCapable(owner)) {
     if (await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
       return resolvedExitCode();
     }
   }
+
+  // Phase 2: Try any reachable owner (may be GUI)
   if (isOwnerReachable(owner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
     return resolvedExitCode();
   }
+
+  // Phase 3: Refresh and retry against any reachable owner
   if (isOwnerReachable(owner) && deps.refreshMessageBus) {
     messageBus = await deps.refreshMessageBus();
     const refreshedOwner = await discoverOwner(messageBus, 1_000);
@@ -303,6 +302,8 @@ export async function runHeadlessClientCommand(
       return resolvedExitCode();
     }
   }
+
+  // Phase 4: Bootstrap with retry loop (delegated to resolver pattern)
   if (deps.refreshMessageBus) {
     messageBus = await deps.refreshMessageBus();
   }
@@ -322,13 +323,7 @@ export async function runHeadlessClientCommand(
     if (deps.refreshMessageBus) {
       messageBus = await deps.refreshMessageBus();
     }
-    if (await delegateAfterBootstrap(
-      args,
-      deps,
-      messageBus,
-      waitForApproval,
-      noTrack,
-    )) {
+    if (await delegateAfterBootstrap(args, deps, messageBus, waitForApproval, noTrack)) {
       return resolvedExitCode();
     }
     if (!deps.refreshMessageBus) {
@@ -336,6 +331,36 @@ export async function runHeadlessClientCommand(
     }
     messageBus = await deps.refreshMessageBus();
   }
+
+  return null; // Could not resolve
+}
+
+export async function runHeadlessClientCommand(
+  argv: string[],
+  deps: HeadlessClientDeps,
+): Promise<number> {
+  // Validate config before any delegation path so malformed JSON fails fast
+  // even for commands that do not boot the full Electron owner process.
+  loadConfig();
+
+  const { args, waitForApproval, noTrack } = parseArgs(argv);
+  const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
+  const internalOwnerServe = args[0] === 'owner-serve';
+
+  if (!standaloneMode && !internalOwnerServe && await delegateReadOnlyQuery(args, deps.messageBus, deps.refreshMessageBus)) {
+    const exitCode = process.exitCode;
+    return typeof exitCode === 'number' ? exitCode : 0;
+  }
+
+  if (!isHeadlessMutatingCommand(args) || standaloneMode || internalOwnerServe) {
+    return deps.runElectronHeadless(argv);
+  }
+
+  const result = await resolveOwnerAndDelegate(args, deps, waitForApproval, noTrack);
+  if (result !== null) {
+    return result;
+  }
+
   process.stderr.write(
     `${RED}Error:${RESET} Mutation command "${args[0] ?? ''}" could not reach a standalone shared owner after bootstrap.\n`,
   );

--- a/packages/app/src/owner-resolver.ts
+++ b/packages/app/src/owner-resolver.ts
@@ -1,0 +1,218 @@
+/**
+ * Owner Resolver — centralizes discovery, staleness refresh, and bootstrap.
+ *
+ * The resolver encapsulates the three-phase owner acquisition policy:
+ *   1. Discover a live owner via IPC ping.
+ *   2. If stale (unreachable or not standalone-capable), refresh the bus and retry.
+ *   3. If no owner is available at all, bootstrap one.
+ *
+ * The interface is surface-neutral: callers receive an OwnerEndpointInfo and a
+ * MessageBus handle, but never branch on GUI/headless mode flags.
+ */
+
+import type { MessageBus } from '@invoker/transport';
+
+import {
+  discoverOwner,
+  isOwnerReachable,
+  isStandaloneCapable,
+  type OwnerDiscoveryResult,
+  type OwnerEndpointInfo,
+} from './owner-endpoint.js';
+
+// ── Result types ────────────────────────────────────────────
+
+export type ResolvedOwner = {
+  owner: OwnerEndpointInfo;
+  bus: MessageBus;
+};
+
+export type OwnerResolveResult =
+  | { resolved: true; owner: OwnerEndpointInfo; bus: MessageBus }
+  | { resolved: false };
+
+// ── Dependency contract ─────────────────────────────────────
+
+export interface OwnerResolverDeps {
+  /** Current message bus for IPC communication. */
+  messageBus: MessageBus;
+  /** Provision a new message bus (reconnect after staleness). */
+  refreshMessageBus?: () => Promise<MessageBus>;
+  /** Bootstrap a standalone owner process. */
+  ensureStandaloneOwner: (bus: MessageBus) => Promise<void>;
+}
+
+// ── Configuration ───────────────────────────────────────────
+
+export interface OwnerResolverOptions {
+  /** Timeout for owner discovery ping (ms). Default: 3000. */
+  discoveryTimeoutMs?: number;
+  /** Timeout for post-refresh re-discovery ping (ms). Default: 1000. */
+  refreshDiscoveryTimeoutMs?: number;
+  /** Timeout waiting for owner readiness after bootstrap (ms). Default: 20000. */
+  postBootstrapReadyTimeoutMs?: number;
+  /** Maximum bootstrap restart attempts. Default: 3. */
+  maxBootstrapAttempts?: number;
+}
+
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 3_000;
+const DEFAULT_REFRESH_DISCOVERY_TIMEOUT_MS = 1_000;
+const DEFAULT_POST_BOOTSTRAP_READY_TIMEOUT_MS = 20_000;
+const DEFAULT_MAX_BOOTSTRAP_ATTEMPTS = 3;
+
+// ── Resolver interface ──────────────────────────────────────
+
+export interface OwnerResolver {
+  /**
+   * Attempt to discover an already-running standalone-capable owner.
+   * Returns the owner and bus if found, or { resolved: false } if not.
+   */
+  discover(): Promise<OwnerResolveResult>;
+
+  /**
+   * Refresh the bus and re-attempt discovery.
+   * Use when the initial discovery returned a stale or unreachable endpoint.
+   */
+  refreshAndDiscover(): Promise<OwnerResolveResult>;
+
+  /**
+   * Full resolve: discover → refresh → bootstrap → discover.
+   * Guarantees a standalone-capable owner or throws after exhausting retries.
+   *
+   * @param requireStandalone If true, only a standalone-capable owner counts
+   *   as resolved. If false, any reachable owner satisfies the request.
+   */
+  resolve(requireStandalone?: boolean): Promise<ResolvedOwner>;
+
+  /**
+   * Discover any reachable owner (standalone or not).
+   * Useful for read-only queries that can target any owner surface.
+   */
+  discoverAny(): Promise<OwnerResolveResult>;
+
+  /**
+   * Wait for any owner to become reachable within a timeout.
+   * Polls with refresh between attempts.
+   */
+  waitForAny(timeoutMs: number): Promise<OwnerResolveResult>;
+
+  /**
+   * Wait for a standalone-capable owner after bootstrap.
+   * Polls with refresh between attempts.
+   */
+  waitForStandalone(timeoutMs: number): Promise<OwnerResolveResult>;
+}
+
+// ── Implementation ──────────────────────────────────────────
+
+export function createOwnerResolver(
+  deps: OwnerResolverDeps,
+  options: OwnerResolverOptions = {},
+): OwnerResolver {
+  const discoveryTimeoutMs = options.discoveryTimeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
+  const refreshDiscoveryTimeoutMs = options.refreshDiscoveryTimeoutMs ?? DEFAULT_REFRESH_DISCOVERY_TIMEOUT_MS;
+  const postBootstrapReadyTimeoutMs = options.postBootstrapReadyTimeoutMs ?? DEFAULT_POST_BOOTSTRAP_READY_TIMEOUT_MS;
+  const maxBootstrapAttempts = options.maxBootstrapAttempts ?? DEFAULT_MAX_BOOTSTRAP_ATTEMPTS;
+
+  let currentBus = deps.messageBus;
+
+  async function refreshBus(): Promise<MessageBus> {
+    if (deps.refreshMessageBus) {
+      currentBus = await deps.refreshMessageBus();
+    }
+    return currentBus;
+  }
+
+  function toResult(owner: OwnerDiscoveryResult, bus: MessageBus): OwnerResolveResult {
+    if (owner === null) return { resolved: false };
+    return { resolved: true, owner, bus };
+  }
+
+  function toStandaloneResult(owner: OwnerDiscoveryResult, bus: MessageBus): OwnerResolveResult {
+    if (!isStandaloneCapable(owner)) return { resolved: false };
+    return { resolved: true, owner, bus };
+  }
+
+  const resolver: OwnerResolver = {
+    async discover(): Promise<OwnerResolveResult> {
+      const owner = await discoverOwner(currentBus, discoveryTimeoutMs);
+      return toStandaloneResult(owner, currentBus);
+    },
+
+    async refreshAndDiscover(): Promise<OwnerResolveResult> {
+      const bus = await refreshBus();
+      const owner = await discoverOwner(bus, refreshDiscoveryTimeoutMs);
+      return toStandaloneResult(owner, bus);
+    },
+
+    async discoverAny(): Promise<OwnerResolveResult> {
+      const owner = await discoverOwner(currentBus, discoveryTimeoutMs);
+      return toResult(owner, currentBus);
+    },
+
+    async waitForAny(timeoutMs: number): Promise<OwnerResolveResult> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const owner = await discoverOwner(currentBus, 2_000);
+        if (isOwnerReachable(owner)) {
+          return { resolved: true, owner, bus: currentBus };
+        }
+        await refreshBus();
+        await new Promise((r) => setTimeout(r, 250));
+      }
+      return { resolved: false };
+    },
+
+    async waitForStandalone(timeoutMs: number): Promise<OwnerResolveResult> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const owner = await discoverOwner(currentBus, 1_000);
+        if (isStandaloneCapable(owner)) {
+          return { resolved: true, owner, bus: currentBus };
+        }
+        await refreshBus();
+        await new Promise((r) => setTimeout(r, 250));
+      }
+      return { resolved: false };
+    },
+
+    async resolve(requireStandalone = true): Promise<ResolvedOwner> {
+      // Phase 1: Try immediate discovery
+      const immediate = await discoverOwner(currentBus, discoveryTimeoutMs);
+      if (requireStandalone ? isStandaloneCapable(immediate) : isOwnerReachable(immediate)) {
+        return { owner: immediate!, bus: currentBus };
+      }
+
+      // Phase 2: Refresh and retry
+      if (deps.refreshMessageBus) {
+        currentBus = await deps.refreshMessageBus();
+      }
+
+      // Phase 3: Bootstrap with retry loop
+      for (let attempt = 0; attempt < maxBootstrapAttempts; attempt += 1) {
+        await deps.ensureStandaloneOwner(currentBus);
+
+        if (deps.refreshMessageBus) {
+          currentBus = await deps.refreshMessageBus();
+        }
+
+        // Wait for the bootstrapped owner to become ready
+        const result = await resolver.waitForStandalone(postBootstrapReadyTimeoutMs);
+        if (result.resolved) {
+          return { owner: result.owner, bus: result.bus };
+        }
+
+        // Owner didn't come up — refresh and retry bootstrap
+        if (deps.refreshMessageBus) {
+          currentBus = await deps.refreshMessageBus();
+        }
+      }
+
+      throw new Error(
+        'Could not resolve a standalone-capable owner after exhausting all bootstrap attempts',
+      );
+    },
+  };
+
+  return resolver;
+}


### PR DESCRIPTION
## Summary

This PR moves the ownership logic out of ad hoc caller code and into a shared
owner resolver. Both headless and GUI-triggered flows now go through the same
resolver and broker boundary instead of making ownership and bootstrap decisions
inline.

That gives the app one place to decide how to find or start a writable owner,
and it adds focused resolver tests so the new control flow is pinned.

## Architecture

### Before

```mermaid
graph TD
    A[GUI-triggered flow] --> B[inline owner lookup logic]
    C[headless-triggered flow] --> D[separate inline owner lookup logic]
    B --> E[caller-specific bootstrap behavior]
    D --> E
```

### After

```mermaid
graph TD
    A[GUI-triggered flow] --> B[shared owner resolver]
    C[headless-triggered flow] --> B
    B --> D[shared broker and bootstrap boundary]
    D --> E[resolved writable owner]
    E --> F[focused resolver regression tests]
```

## Test Plan

- [ ] `pnpm test -- --run packages/app/src/__tests__/owner-resolver.test.ts`
- [ ] `pnpm test -- --run packages/app/src/__tests__/headless-client.test.ts`
- [ ] `pnpm test -- --run packages/app/src/__tests__/owner-delegation.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 6e27a272`
- Post-revert steps: Re-run the commands in the test plan to confirm owner resolution falls back to the previous inline paths
- Data migration? No
