### PR TITLE
PR 130 CI Step 1: Fix standalone-owner TypeScript scope errors

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -63,6 +63,44 @@ describe('headless-client', () => {
     expect(exitCode).toBe(0);
   }, 15_000);
 
+  // --- Regression: standalone-owner scope for headless.run ---
+
+  it('delegates headless.run to an existing standalone owner', async () => {
+    const bus = new LocalBus();
+    const runHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.run', runHandler);
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+
+    const exitCode = await runHeadlessClientCommand(['run', '/tmp/plan.yaml', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runHandler).toHaveBeenCalledTimes(1);
+    expect(runHandler).toHaveBeenCalledWith(expect.objectContaining({ planPath: expect.stringContaining('plan.yaml') }));
+  });
+
+  // --- Regression: standalone-owner scope for headless.resume ---
+
+  it('delegates headless.resume to an existing standalone owner', async () => {
+    const bus = new LocalBus();
+    const resumeHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.resume', resumeHandler);
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+
+    const exitCode = await runHeadlessClientCommand(['resume', 'wf-42', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(resumeHandler).toHaveBeenCalledTimes(1);
+    expect(resumeHandler).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 'wf-42' }));
+  });
+
   it('bootstraps a standalone owner once when no owner is present, then delegates', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));


### PR DESCRIPTION
## Summary

This PR adds focused tests for one specific headless-owner behavior. It makes
sure `headless.run` and `headless.resume` keep working through the standalone
owner path, so the later PRs in the PR 130 stack have a stable base to build
on.

## Architecture

### Before

```mermaid
graph TD
    A[standalone-owner run/resume behavior] --> B[covered only indirectly]
    B --> C[typecheck and broader flows catch regressions late]
```

### After

```mermaid
graph TD
    A[standalone-owner run/resume behavior] --> B[headless-client regression tests]
    B --> C[explicit coverage for run]
    B --> D[explicit coverage for resume]
    C --> E[later routing and herd PRs build on a pinned contract]
    D --> E
```

## Test Plan

- [ ] `pnpm run check:types`
- [ ] `pnpm test -- --run packages/app/src/__tests__/headless-client.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 9922d34dc3abc6efd5ca13fe827083737f111243`
- Post-revert steps: Re-run `pnpm run check:types` and `pnpm test -- --run packages/app/src/__tests__/headless-client.test.ts`
- Data migration? No
