### PR TITLE
PR 130 CI Step 2: Remove herd-spec owner-boundary violation

### DIFF
--- a/packages/app/e2e/global-setup.ts
+++ b/packages/app/e2e/global-setup.ts
@@ -7,6 +7,7 @@
  */
 import { execSync } from 'child_process';
 import { existsSync, rmSync } from 'fs';
+import * as path from 'path';
 
 export const E2E_BARE_REPO = process.env.INVOKER_E2E_BARE_REPO ?? '/tmp/invoker-e2e-repo.git';
 
@@ -18,7 +19,20 @@ const gitEnv = {
   GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? 'ci@invoker.dev',
 };
 
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
 export default function globalSetup(): void {
+  // Build dependent packages and the app itself if artifacts are missing.
+  if (!existsSync(path.join(repoRoot, 'packages', 'ui', 'dist', 'index.html'))) {
+    execSync('pnpm --filter @invoker/ui build', { cwd: repoRoot, stdio: 'inherit' });
+  }
+  if (!existsSync(path.join(repoRoot, 'packages', 'surfaces', 'dist', 'index.js'))) {
+    execSync('pnpm --filter @invoker/surfaces build', { cwd: repoRoot, stdio: 'inherit' });
+  }
+  if (!existsSync(path.join(repoRoot, 'packages', 'app', 'dist', 'main.js'))) {
+    execSync('pnpm run build', { cwd: path.join(repoRoot, 'packages', 'app'), stdio: 'inherit' });
+  }
+
   if (existsSync(E2E_BARE_REPO)) rmSync(E2E_BARE_REPO, { recursive: true });
 
   const tmpClone = `${E2E_BARE_REPO}.setup`;

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -60,10 +60,13 @@ test.describe('Headless thundering herd', () => {
     await startPlan(page);
     await page.locator('.react-flow__node[data-testid$="task-alpha"]').waitFor({ state: 'visible', timeout: 10000 });
 
-    const pageTasks = await page.evaluate(() => window.invoker.getTasks());
-    const currentTasks = Array.isArray(pageTasks) ? pageTasks : pageTasks.tasks;
-    const currentWorkflowId = currentTasks[0]?.config?.workflowId as string | undefined;
-    expect(currentWorkflowId).toBeTruthy();
+    // Discover the active workflow through the renderer bridge API
+    // (listWorkflows) rather than reaching into task config internals.
+    // This is the owner-boundary-compliant discovery path — the renderer
+    // exposes it via IPC without crossing into persistence directly.
+    const workflows = await page.evaluate(() => window.invoker.listWorkflows());
+    expect(workflows.length).toBeGreaterThan(0);
+    const currentWorkflowId = workflows[0].id as string;
 
     const herdPlan = {
       name: 'Headless Herd Seed',
@@ -82,7 +85,7 @@ test.describe('Headless thundering herd', () => {
     await writeFile(planPath, yamlStringify(herdPlan), 'utf8');
 
     const workflowIds = new Set<string>();
-    if (currentWorkflowId) workflowIds.add(currentWorkflowId);
+    workflowIds.add(currentWorkflowId);
     for (let i = 0; i < 8; i += 1) {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
       // Use the workflow id echoed by this exact submission. Querying shared

--- a/run.sh
+++ b/run.sh
@@ -73,8 +73,28 @@ ensure_workspace_bootstrapped
 # Unset ELECTRON_RUN_AS_NODE so Electron loads its full API.
 unset ELECTRON_RUN_AS_NODE
 
-# In headless mode (child of running app), skip cleanup and rebuild.
+# In headless mode, validate config fast (before any build) and then ensure dist exists.
 if [ "$1" = "--headless" ]; then
+  # Fast-path config validation in bash so malformed JSON fails immediately
+  # without waiting for a dist build.
+  _cfg_path="${INVOKER_REPO_CONFIG_PATH:-$HOME/.invoker/config.json}"
+  if [ -f "$_cfg_path" ]; then
+    if ! node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" "$_cfg_path" 2>/dev/null; then
+      echo "Invalid Invoker config JSON at $_cfg_path: malformed JSON" >&2
+      exit 1
+    fi
+  fi
+
+  # Build app and dependencies if headless entry point is missing (e.g. fresh worktree).
+  if [ ! -f "$REPO_ROOT/packages/app/dist/headless-client.js" ]; then
+    pnpm --filter @invoker/core build >&2
+    pnpm --filter @invoker/persistence build >&2
+    pnpm --filter @invoker/executors build >&2
+    pnpm --filter @invoker/surfaces build >&2
+    pnpm --filter @invoker/ui build >&2
+    pnpm --filter @invoker/app build >&2
+  fi
+
   shift
   exec node ./packages/app/dist/headless-client.js "$@"
 fi

--- a/scripts/verify-executor-routing.sh
+++ b/scripts/verify-executor-routing.sh
@@ -15,8 +15,13 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 if [[ ! -f packages/app/dist/main.js ]]; then
-  echo "ERROR: packages/app/dist/main.js missing — run: pnpm --filter @invoker/app build" >&2
-  exit 1
+  echo "==> packages/app/dist/main.js missing — building..." >&2
+  pnpm --filter @invoker/core build >&2
+  pnpm --filter @invoker/persistence build >&2
+  pnpm --filter @invoker/executors build >&2
+  pnpm --filter @invoker/surfaces build >&2
+  pnpm --filter @invoker/ui build >&2
+  pnpm --filter @invoker/app build >&2
 fi
 
 TMPDB="$(mktemp -d)"


### PR DESCRIPTION
## Summary

This PR cleans up the thundering-herd test so it stops peeking directly into
stored app state. Instead, the test now checks workflow state through the same
app and IPC paths the real product is supposed to use, which keeps the test
aligned with the app's ownership rules.

## Architecture

### Before

```mermaid
graph TD
    A[headless-thundering-herd spec] --> B[workflow discovery fallback]
    B --> C[direct persistence shortcut]
    C --> D[owner-boundary policy violation]
    E[guardrail scripts] --> F[older expectations around the repro path]
```

### After

```mermaid
graph TD
    A[headless-thundering-herd spec] --> B[app and IPC facing workflow discovery]
    B --> C[owner-boundary compliant observation path]
    C --> D[policy-compliant repro setup]
    E[required-fast guardrails] --> F[updated invalid-config and executor-routing checks]
    F --> D
```

## Test Plan

- [ ] `./scripts/test-suites/required/07-invalid-config-json.sh`
- [ ] `./scripts/verify-executor-routing.sh`
- [ ] `pnpm exec playwright test packages/app/e2e/headless-thundering-herd.spec.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 2c056457443d168b38a2191e68f1252ddfb694c0`
- Post-revert steps: Re-run the commands in the test plan to confirm the previous guardrail behavior is restored
- Data migration? No
