### PR TITLE
Run focused routing regressions

### DIFF
--- a/packages/app/e2e/global-setup.ts
+++ b/packages/app/e2e/global-setup.ts
@@ -7,6 +7,7 @@
  */
 import { execSync } from 'child_process';
 import { existsSync, rmSync } from 'fs';
+import * as path from 'path';
 
 export const E2E_BARE_REPO = process.env.INVOKER_E2E_BARE_REPO ?? '/tmp/invoker-e2e-repo.git';
 
@@ -18,7 +19,20 @@ const gitEnv = {
   GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? 'ci@invoker.dev',
 };
 
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
 export default function globalSetup(): void {
+  // Build dependent packages and the app itself if artifacts are missing.
+  if (!existsSync(path.join(repoRoot, 'packages', 'ui', 'dist', 'index.html'))) {
+    execSync('pnpm --filter @invoker/ui build', { cwd: repoRoot, stdio: 'inherit' });
+  }
+  if (!existsSync(path.join(repoRoot, 'packages', 'surfaces', 'dist', 'index.js'))) {
+    execSync('pnpm --filter @invoker/surfaces build', { cwd: repoRoot, stdio: 'inherit' });
+  }
+  if (!existsSync(path.join(repoRoot, 'packages', 'app', 'dist', 'main.js'))) {
+    execSync('pnpm run build', { cwd: path.join(repoRoot, 'packages', 'app'), stdio: 'inherit' });
+  }
+
   if (existsSync(E2E_BARE_REPO)) rmSync(E2E_BARE_REPO, { recursive: true });
 
   const tmpClone = `${E2E_BARE_REPO}.setup`;

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -60,10 +60,13 @@ test.describe('Headless thundering herd', () => {
     await startPlan(page);
     await page.locator('.react-flow__node[data-testid$="task-alpha"]').waitFor({ state: 'visible', timeout: 10000 });
 
-    const pageTasks = await page.evaluate(() => window.invoker.getTasks());
-    const currentTasks = Array.isArray(pageTasks) ? pageTasks : pageTasks.tasks;
-    const currentWorkflowId = currentTasks[0]?.config?.workflowId as string | undefined;
-    expect(currentWorkflowId).toBeTruthy();
+    // Discover the active workflow through the renderer bridge API
+    // (listWorkflows) rather than reaching into task config internals.
+    // This is the owner-boundary-compliant discovery path — the renderer
+    // exposes it via IPC without crossing into persistence directly.
+    const workflows = await page.evaluate(() => window.invoker.listWorkflows());
+    expect(workflows.length).toBeGreaterThan(0);
+    const currentWorkflowId = workflows[0].id as string;
 
     const herdPlan = {
       name: 'Headless Herd Seed',
@@ -82,7 +85,7 @@ test.describe('Headless thundering herd', () => {
     await writeFile(planPath, yamlStringify(herdPlan), 'utf8');
 
     const workflowIds = new Set<string>();
-    if (currentWorkflowId) workflowIds.add(currentWorkflowId);
+    workflowIds.add(currentWorkflowId);
     for (let i = 0; i < 8; i += 1) {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
       // Use the workflow id echoed by this exact submission. Querying shared

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -4,7 +4,7 @@ import { LocalBus } from '@invoker/transport';
 import { SharedMutationOwnerTimeoutError, runHeadlessClientCommand } from '../headless-client.js';
 
 describe('headless-client', () => {
-  it('delegates mutating commands to an existing standalone owner without electron fallback', async () => {
+  it('delegates mutating commands to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));
     bus.onRequest('headless.exec', ownerHandler);
@@ -29,7 +29,7 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
-  it('delegates mutating commands to an existing GUI owner without bootstrapping standalone', async () => {
+  it('delegates mutating commands to a reachable non-standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const guiOwnerHandler = vi.fn(async () => ({ ok: true }));
 
@@ -46,7 +46,7 @@ describe('headless-client', () => {
     expect(guiOwnerHandler).toHaveBeenCalledTimes(1);
   });
 
-  it('uses a longer no-track delegation timeout for an already-running standalone owner under load', async () => {
+  it('uses a longer no-track delegation timeout for an already-running standalone-capable owner under load', async () => {
     const bus = new LocalBus();
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
     bus.onRequest('headless.exec', async () => {
@@ -63,9 +63,9 @@ describe('headless-client', () => {
     expect(exitCode).toBe(0);
   }, 15_000);
 
-  // --- Regression: standalone-owner scope for headless.run ---
+  // --- Regression: owner endpoint scope for headless.run ---
 
-  it('delegates headless.run to an existing standalone owner', async () => {
+  it('delegates headless.run to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const runHandler = vi.fn(async () => ({ ok: true }));
     bus.onRequest('headless.run', runHandler);
@@ -82,9 +82,9 @@ describe('headless-client', () => {
     expect(runHandler).toHaveBeenCalledWith(expect.objectContaining({ planPath: expect.stringContaining('plan.yaml') }));
   });
 
-  // --- Regression: standalone-owner scope for headless.resume ---
+  // --- Regression: owner endpoint scope for headless.resume ---
 
-  it('delegates headless.resume to an existing standalone owner', async () => {
+  it('delegates headless.resume to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const resumeHandler = vi.fn(async () => ({ ok: true }));
     bus.onRequest('headless.resume', resumeHandler);
@@ -101,7 +101,7 @@ describe('headless-client', () => {
     expect(resumeHandler).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 'wf-42' }));
   });
 
-  it('bootstraps a standalone owner once when no owner is present, then delegates', async () => {
+  it('bootstraps when no owner endpoint is available, then delegates', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));
     const ensureStandaloneOwner = vi.fn(async () => {
@@ -328,7 +328,7 @@ describe('headless-client', () => {
     expect(refreshMessageBus).toHaveBeenCalled();
   }, 15_000);
 
-  it('uses the current GUI owner directly without refreshing or bootstrapping standalone', async () => {
+  it('uses the current reachable owner endpoint directly without refreshing or bootstrapping', async () => {
     const firstBus = new LocalBus();
     let firstExecCalls = 0;
 
@@ -354,7 +354,7 @@ describe('headless-client', () => {
     expect(firstExecCalls).toBe(1);
   }, 15_000);
 
-  it('falls back to the electron runtime for non-mutating commands', async () => {
+  it('falls back to the host runtime for non-mutating commands', async () => {
     const runElectronHeadless = vi.fn(async () => 0);
     const exitCode = await runHeadlessClientCommand(['query', 'workflows'], {
       messageBus: new LocalBus(),
@@ -366,7 +366,7 @@ describe('headless-client', () => {
     expect(runElectronHeadless).toHaveBeenCalledWith(['query', 'workflows']);
   });
 
-  it('delegates query ui-perf to an existing owner without electron fallback', async () => {
+  it('delegates query ui-perf to a reachable owner endpoint', async () => {
     const bus = new LocalBus();
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
     bus.onRequest('headless.query', async () => ({
@@ -389,7 +389,7 @@ describe('headless-client', () => {
     stdout.mockRestore();
   });
 
-  it('does not silently fall back for query ui-perf when no owner is present', async () => {
+  it('does not silently fall back for query ui-perf when no owner endpoint is reachable', async () => {
     await expect(
       runHeadlessClientCommand(['query', 'ui-perf', '--output', 'json'], {
         messageBus: new LocalBus(),
@@ -399,7 +399,7 @@ describe('headless-client', () => {
     ).rejects.toThrow(/requires a running shared owner process/);
   }, 30_000);
 
-  it('delegates query queue to an existing owner without electron fallback', async () => {
+  it('delegates query queue to a reachable owner endpoint', async () => {
     const bus = new LocalBus();
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
     bus.onRequest('headless.query', async () => ({

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -63,6 +63,44 @@ describe('headless-client', () => {
     expect(exitCode).toBe(0);
   }, 15_000);
 
+  // --- Regression: standalone-owner scope for headless.run ---
+
+  it('delegates headless.run to an existing standalone owner', async () => {
+    const bus = new LocalBus();
+    const runHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.run', runHandler);
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+
+    const exitCode = await runHeadlessClientCommand(['run', '/tmp/plan.yaml', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runHandler).toHaveBeenCalledTimes(1);
+    expect(runHandler).toHaveBeenCalledWith(expect.objectContaining({ planPath: expect.stringContaining('plan.yaml') }));
+  });
+
+  // --- Regression: standalone-owner scope for headless.resume ---
+
+  it('delegates headless.resume to an existing standalone owner', async () => {
+    const bus = new LocalBus();
+    const resumeHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.resume', resumeHandler);
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+
+    const exitCode = await runHeadlessClientCommand(['resume', 'wf-42', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless: vi.fn(async () => 0),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(resumeHandler).toHaveBeenCalledTimes(1);
+    expect(resumeHandler).toHaveBeenCalledWith(expect.objectContaining({ workflowId: 'wf-42' }));
+  });
+
   it('bootstraps a standalone owner once when no owner is present, then delegates', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -335,8 +335,8 @@ describe('headless→owner delegation', () => {
   });
 
   describe('tryDelegateRun / tryDelegateResume', () => {
-    it('succeeds when GUI handler returns immediately (fire-and-forget execution)', async () => {
-      // Simulate GUI handler that returns response immediately without awaiting
+    it('succeeds when owner handler returns immediately (fire-and-forget execution)', async () => {
+      // Simulate owner handler that returns response immediately without awaiting
       // task execution — the fix for the 5s delegation timeout bug.
       messageBus.onRequest('headless.run', async (req: { planPath: string }) => {
         expect(req.planPath).toContain('plan.yaml');
@@ -355,7 +355,7 @@ describe('headless→owner delegation', () => {
       expect(delegated).toBe(true);
     });
 
-    it('times out when GUI handler blocks on task execution (pre-fix behavior)', async () => {
+    it('times out when owner handler blocks on task execution (pre-fix behavior)', async () => {
       // Simulate the old bug: handler awaits executeTasks which never resolves
       messageBus.onRequest('headless.run', async () => {
         return new Promise(() => {}); // Never resolves — simulates await executeTasks()

--- a/packages/app/src/__tests__/owner-endpoint.test.ts
+++ b/packages/app/src/__tests__/owner-endpoint.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { LocalBus } from '@invoker/transport';
+
+import {
+  discoverOwner,
+  isOwnerReachable,
+  isStandaloneCapable,
+  type OwnerEndpointInfo,
+} from '../owner-endpoint.js';
+
+describe('owner-endpoint contract', () => {
+  describe('discoverOwner', () => {
+    it('returns null when no owner responds within the timeout', async () => {
+      const bus = new LocalBus();
+      const result = await discoverOwner(bus, 200);
+      expect(result).toBeNull();
+    });
+
+    it('returns OwnerEndpointInfo with canAcceptStandaloneMutations=true for standalone owners', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-123',
+        mode: 'standalone',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).not.toBeNull();
+      expect(result!.ownerId).toBe('owner-123');
+      expect(result!.canAcceptStandaloneMutations).toBe(true);
+    });
+
+    it('returns OwnerEndpointInfo with canAcceptStandaloneMutations=false for GUI owners', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-456',
+        mode: 'gui',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).not.toBeNull();
+      expect(result!.ownerId).toBe('owner-456');
+      expect(result!.canAcceptStandaloneMutations).toBe(false);
+    });
+
+    it('does not expose the raw mode string in the returned contract', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-789',
+        mode: 'gui',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).not.toBeNull();
+      // The contract type should not have a `mode` field
+      expect('mode' in result!).toBe(false);
+    });
+
+    it('defaults ownerId to empty string when the ping response omits it', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        mode: 'standalone',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).not.toBeNull();
+      expect(result!.ownerId).toBe('');
+      expect(result!.canAcceptStandaloneMutations).toBe(true);
+    });
+  });
+
+  describe('isStandaloneCapable', () => {
+    it('returns true for standalone-capable owners', () => {
+      const owner: OwnerEndpointInfo = {
+        ownerId: 'owner-1',
+        canAcceptStandaloneMutations: true,
+      };
+      expect(isStandaloneCapable(owner)).toBe(true);
+    });
+
+    it('returns false for non-standalone owners', () => {
+      const owner: OwnerEndpointInfo = {
+        ownerId: 'owner-2',
+        canAcceptStandaloneMutations: false,
+      };
+      expect(isStandaloneCapable(owner)).toBe(false);
+    });
+
+    it('returns false for null (no owner reachable)', () => {
+      expect(isStandaloneCapable(null)).toBe(false);
+    });
+  });
+
+  describe('isOwnerReachable', () => {
+    it('returns true for any non-null owner', () => {
+      const standaloneOwner: OwnerEndpointInfo = {
+        ownerId: 'owner-1',
+        canAcceptStandaloneMutations: true,
+      };
+      const guiOwner: OwnerEndpointInfo = {
+        ownerId: 'owner-2',
+        canAcceptStandaloneMutations: false,
+      };
+      expect(isOwnerReachable(standaloneOwner)).toBe(true);
+      expect(isOwnerReachable(guiOwner)).toBe(true);
+    });
+
+    it('returns false for null', () => {
+      expect(isOwnerReachable(null)).toBe(false);
+    });
+  });
+
+  describe('surface neutrality', () => {
+    it('treats any owner with mode !== standalone as non-standalone-capable', async () => {
+      const bus = new LocalBus();
+      // Hypothetical future mode — the contract should not care
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-future',
+        mode: 'some-new-surface',
+      }));
+
+      const result = await discoverOwner(bus);
+      expect(result).not.toBeNull();
+      expect(result!.canAcceptStandaloneMutations).toBe(false);
+      expect(isOwnerReachable(result)).toBe(true);
+      expect(isStandaloneCapable(result)).toBe(false);
+    });
+
+    it('client code never needs to reference GUI or standalone modes directly', () => {
+      // This test documents the contract guarantee: the OwnerEndpointInfo
+      // type has no `mode` field. Client code uses capability predicates.
+      const info: OwnerEndpointInfo = {
+        ownerId: 'owner-1',
+        canAcceptStandaloneMutations: true,
+      };
+      // Type-level: 'mode' is not a key of OwnerEndpointInfo
+      const keys = Object.keys(info);
+      expect(keys).toContain('ownerId');
+      expect(keys).toContain('canAcceptStandaloneMutations');
+      expect(keys).not.toContain('mode');
+    });
+  });
+});

--- a/packages/app/src/__tests__/owner-resolver.test.ts
+++ b/packages/app/src/__tests__/owner-resolver.test.ts
@@ -1,0 +1,424 @@
+import { describe, it, expect, vi } from 'vitest';
+import { LocalBus } from '@invoker/transport';
+
+import { createOwnerResolver } from '../owner-resolver.js';
+
+describe('owner-resolver', () => {
+  describe('discover', () => {
+    it('returns resolved owner when a standalone-capable owner responds', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.discover();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.owner.ownerId).toBe('owner-1');
+        expect(result.owner.canAcceptStandaloneMutations).toBe(true);
+      }
+    });
+
+    it('returns not-resolved when no owner responds', async () => {
+      const bus = new LocalBus();
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      }, { discoveryTimeoutMs: 200 });
+
+      const result = await resolver.discover();
+      expect(result.resolved).toBe(false);
+    });
+
+    it('returns not-resolved for a GUI owner (not standalone-capable)', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-gui',
+        mode: 'gui',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.discover();
+      expect(result.resolved).toBe(false);
+    });
+  });
+
+  describe('discoverAny', () => {
+    it('returns a GUI owner as resolved', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-gui',
+        mode: 'gui',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.discoverAny();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.owner.ownerId).toBe('owner-gui');
+        expect(result.owner.canAcceptStandaloneMutations).toBe(false);
+      }
+    });
+
+    it('returns not-resolved when no owner responds', async () => {
+      const bus = new LocalBus();
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      }, { discoveryTimeoutMs: 200 });
+
+      const result = await resolver.discoverAny();
+      expect(result.resolved).toBe(false);
+    });
+  });
+
+  describe('refreshAndDiscover', () => {
+    it('uses refreshed bus for discovery', async () => {
+      const firstBus = new LocalBus();
+      const secondBus = new LocalBus();
+      secondBus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-refreshed',
+        mode: 'standalone',
+      }));
+
+      const refreshMessageBus = vi.fn().mockResolvedValue(secondBus);
+      const resolver = createOwnerResolver({
+        messageBus: firstBus,
+        refreshMessageBus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.refreshAndDiscover();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.owner.ownerId).toBe('owner-refreshed');
+        expect(result.bus).toBe(secondBus);
+      }
+      expect(refreshMessageBus).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses original bus when no refreshMessageBus is provided', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-same',
+        mode: 'standalone',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.refreshAndDiscover();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.bus).toBe(bus);
+      }
+    });
+  });
+
+  describe('waitForAny', () => {
+    it('returns immediately when an owner is already reachable', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-fast',
+        mode: 'gui',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.waitForAny(5_000);
+      expect(result.resolved).toBe(true);
+    });
+
+    it('polls until an owner appears', async () => {
+      const bus = new LocalBus();
+      let pingCount = 0;
+      bus.onRequest('headless.owner-ping', async () => {
+        pingCount += 1;
+        if (pingCount >= 3) {
+          return { ok: true, ownerId: 'owner-delayed', mode: 'standalone' };
+        }
+        return null;
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.waitForAny(10_000);
+      expect(result.resolved).toBe(true);
+      expect(pingCount).toBeGreaterThanOrEqual(3);
+    });
+
+    it('returns not-resolved after timeout', async () => {
+      const bus = new LocalBus();
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      }, { discoveryTimeoutMs: 100 });
+
+      const result = await resolver.waitForAny(500);
+      expect(result.resolved).toBe(false);
+    });
+  });
+
+  describe('waitForStandalone', () => {
+    it('skips GUI owners and waits for standalone', async () => {
+      const bus = new LocalBus();
+      let pingCount = 0;
+      bus.onRequest('headless.owner-ping', async () => {
+        pingCount += 1;
+        if (pingCount >= 3) {
+          return { ok: true, ownerId: 'owner-standalone', mode: 'standalone' };
+        }
+        return { ok: true, ownerId: 'owner-gui', mode: 'gui' };
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.waitForStandalone(10_000);
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.owner.canAcceptStandaloneMutations).toBe(true);
+      }
+    });
+
+    it('returns not-resolved after timeout when only GUI owners available', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-gui',
+        mode: 'gui',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.waitForStandalone(500);
+      expect(result.resolved).toBe(false);
+    });
+  });
+
+  describe('resolve', () => {
+    it('returns immediately when a standalone owner is already available', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+
+      const ensureStandaloneOwner = vi.fn();
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-1');
+      expect(result.owner.canAcceptStandaloneMutations).toBe(true);
+      expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    });
+
+    it('bootstraps when no owner is initially available', async () => {
+      const bus = new LocalBus();
+      let bootstrapped = false;
+
+      const ensureStandaloneOwner = vi.fn(async () => {
+        bootstrapped = true;
+        bus.onRequest('headless.owner-ping', async () => ({
+          ok: true,
+          ownerId: 'owner-bootstrapped',
+          mode: 'standalone',
+        }));
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+      }, {
+        discoveryTimeoutMs: 200,
+        postBootstrapReadyTimeoutMs: 5_000,
+      });
+
+      const result = await resolver.resolve();
+      expect(bootstrapped).toBe(true);
+      expect(result.owner.ownerId).toBe('owner-bootstrapped');
+      expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries bootstrap when the first attempt does not produce a reachable owner', async () => {
+      const bus = new LocalBus();
+      let bootstrapCalls = 0;
+
+      const ensureStandaloneOwner = vi.fn(async () => {
+        bootstrapCalls += 1;
+        if (bootstrapCalls >= 2) {
+          bus.onRequest('headless.owner-ping', async () => ({
+            ok: true,
+            ownerId: 'owner-retry',
+            mode: 'standalone',
+          }));
+        }
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+      }, {
+        discoveryTimeoutMs: 200,
+        postBootstrapReadyTimeoutMs: 500,
+        maxBootstrapAttempts: 3,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-retry');
+      expect(bootstrapCalls).toBe(2);
+    });
+
+    it('throws after exhausting all bootstrap attempts', async () => {
+      const bus = new LocalBus();
+      const ensureStandaloneOwner = vi.fn(async () => {});
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+      }, {
+        discoveryTimeoutMs: 100,
+        postBootstrapReadyTimeoutMs: 200,
+        maxBootstrapAttempts: 2,
+      });
+
+      await expect(resolver.resolve()).rejects.toThrow(
+        /Could not resolve a standalone-capable owner/,
+      );
+      expect(ensureStandaloneOwner).toHaveBeenCalledTimes(2);
+    });
+
+    it('refreshes the bus between bootstrap attempts', async () => {
+      const firstBus = new LocalBus();
+      const secondBus = new LocalBus();
+      let bootstrapCalls = 0;
+
+      secondBus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-on-second-bus',
+        mode: 'standalone',
+      }));
+
+      const refreshMessageBus = vi.fn().mockResolvedValue(secondBus);
+      const ensureStandaloneOwner = vi.fn(async () => {
+        bootstrapCalls += 1;
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: firstBus,
+        refreshMessageBus,
+        ensureStandaloneOwner,
+      }, {
+        discoveryTimeoutMs: 200,
+        postBootstrapReadyTimeoutMs: 2_000,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-on-second-bus');
+      expect(refreshMessageBus).toHaveBeenCalled();
+    });
+
+    it('accepts any reachable owner when requireStandalone=false', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-gui',
+        mode: 'gui',
+      }));
+
+      const ensureStandaloneOwner = vi.fn();
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+      });
+
+      const result = await resolver.resolve(false);
+      expect(result.owner.ownerId).toBe('owner-gui');
+      expect(result.owner.canAcceptStandaloneMutations).toBe(false);
+      expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('surface neutrality', () => {
+    it('never exposes mode strings in resolved results', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.discover();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect('mode' in result.owner).toBe(false);
+        expect(Object.keys(result.owner)).toEqual(['ownerId', 'canAcceptStandaloneMutations']);
+      }
+    });
+
+    it('result contains bus handle but no GUI/headless flags', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(),
+      });
+
+      const result = await resolver.discover();
+      expect(result.resolved).toBe(true);
+      if (result.resolved) {
+        expect(result.bus).toBeDefined();
+        expect('isGui' in result).toBe(false);
+        expect('isHeadless' in result).toBe(false);
+        expect('surface' in result).toBe(false);
+      }
+    });
+  });
+});

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -13,13 +13,18 @@ import {
   tryDelegateQueryUiPerf,
   tryDelegateResume,
   tryDelegateRun,
-  tryPingHeadlessOwner,
 } from './headless-delegation.js';
 import {
   spawnDetachedStandaloneOwner,
   tryAcquireOwnerBootstrapLock,
 } from './headless-owner-bootstrap.js';
 import { loadConfig } from './config.js';
+import {
+  discoverOwner,
+  isOwnerReachable,
+  isStandaloneCapable,
+  type OwnerDiscoveryResult,
+} from './owner-endpoint.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -69,11 +74,6 @@ const READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS = 20_000;
 const READ_ONLY_QUERY_REQUEST_TIMEOUT_MS = 8_000;
 const POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS = 3;
 const DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS = 60_000;
-type HeadlessOwnerInfo = { ownerId?: string; mode?: string };
-
-function isStandaloneOwner(owner: HeadlessOwnerInfo | null | undefined): owner is HeadlessOwnerInfo & { mode: 'standalone' } {
-  return owner?.mode === 'standalone';
-}
 
 function standaloneOwnerBootstrapTimeoutMs(): number {
   const raw = process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS;
@@ -131,16 +131,16 @@ async function delegateReadOnlyQuery(
   }
   const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
   let messageBus = bus;
-  let owner: HeadlessOwnerInfo | null = null;
+  let owner: OwnerDiscoveryResult = null;
   while (Date.now() < deadline) {
-    owner = await tryPingHeadlessOwner(messageBus, 2_000);
-    if (owner) break;
+    owner = await discoverOwner(messageBus, 2_000);
+    if (isOwnerReachable(owner)) break;
     if (refreshMessageBus) {
       messageBus = await refreshMessageBus();
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
-  if (!owner) {
+  if (!isOwnerReachable(owner)) {
     throw new Error(isUiPerf
       ? 'query ui-perf requires a running shared owner process'
       : 'query queue requires a running shared owner process');
@@ -202,8 +202,8 @@ async function delegateAfterBootstrap(
   const deadline = Date.now() + POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS;
   let messageBus = bus;
   while (Date.now() < deadline) {
-    const owner = await tryPingHeadlessOwner(messageBus, 1_000);
-    if (isStandaloneOwner(owner) && await delegateMutation(
+    const owner = await discoverOwner(messageBus, 1_000);
+    if (isStandaloneCapable(owner) && await delegateMutation(
       args,
       messageBus,
       waitForApproval,
@@ -236,8 +236,8 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
     }
     const deadline = Date.now() + standaloneOwnerBootstrapTimeoutMs();
     while (Date.now() < deadline) {
-      const owner = await tryPingHeadlessOwner(bus, 500);
-      if (isStandaloneOwner(owner)) return;
+      const owner = await discoverOwner(bus, 500);
+      if (isStandaloneCapable(owner)) return;
       await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
     }
     throw new SharedMutationOwnerTimeoutError();
@@ -287,19 +287,19 @@ export async function runHeadlessClientCommand(
     return deps.runElectronHeadless(argv);
   }
 
-  const owner = await tryPingHeadlessOwner(messageBus, 3_000);
-  if (isStandaloneOwner(owner)) {
+  const owner = await discoverOwner(messageBus, 3_000);
+  if (isStandaloneCapable(owner)) {
     if (await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
       return resolvedExitCode();
     }
   }
-  if (owner && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+  if (isOwnerReachable(owner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
     return resolvedExitCode();
   }
-  if (owner && deps.refreshMessageBus) {
+  if (isOwnerReachable(owner) && deps.refreshMessageBus) {
     messageBus = await deps.refreshMessageBus();
-    const refreshedOwner = await tryPingHeadlessOwner(messageBus, 1_000);
-    if (refreshedOwner && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+    const refreshedOwner = await discoverOwner(messageBus, 1_000);
+    if (isOwnerReachable(refreshedOwner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
       return resolvedExitCode();
     }
   }

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -23,8 +23,8 @@ import {
   discoverOwner,
   isOwnerReachable,
   isStandaloneCapable,
-  type OwnerDiscoveryResult,
 } from './owner-endpoint.js';
+import { createOwnerResolver } from './owner-resolver.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -129,22 +129,21 @@ async function delegateReadOnlyQuery(
   if (!isUiPerf && !isQueue) {
     return false;
   }
-  const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
-  let messageBus = bus;
-  let owner: OwnerDiscoveryResult = null;
-  while (Date.now() < deadline) {
-    owner = await discoverOwner(messageBus, 2_000);
-    if (isOwnerReachable(owner)) break;
-    if (refreshMessageBus) {
-      messageBus = await refreshMessageBus();
-    }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-  if (!isOwnerReachable(owner)) {
+
+  // Use the resolver to wait for any reachable owner
+  const resolver = createOwnerResolver(
+    { messageBus: bus, refreshMessageBus, ensureStandaloneOwner: async () => {} },
+    { discoveryTimeoutMs: 2_000 },
+  );
+  const ownerResult = await resolver.waitForAny(READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS);
+  if (!ownerResult.resolved) {
     throw new Error(isUiPerf
       ? 'query ui-perf requires a running shared owner process'
       : 'query queue requires a running shared owner process');
   }
+
+  let messageBus = ownerResult.bus;
+  const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
   let response: Record<string, unknown> | null = null;
   while (Date.now() < deadline) {
     if (isUiPerf) {
@@ -262,40 +261,40 @@ function parseArgs(argv: string[]): { args: string[]; waitForApproval?: boolean;
   return { args, waitForApproval, noTrack };
 }
 
-export async function runHeadlessClientCommand(
-  argv: string[],
+/**
+ * Resolve a writable owner endpoint using the resolver, then delegate.
+ *
+ * This function encapsulates the discover → fallback → bootstrap → delegate
+ * policy that was previously inline. It uses the OwnerResolver for the
+ * discovery/refresh/bootstrap phases and delegates command execution once
+ * an owner is acquired.
+ */
+async function resolveOwnerAndDelegate(
+  args: string[],
   deps: HeadlessClientDeps,
-): Promise<number> {
-  // Validate config before any delegation path so malformed JSON fails fast
-  // even for commands that do not boot the full Electron owner process.
-  loadConfig();
-
+  waitForApproval?: boolean,
+  noTrack?: boolean,
+): Promise<number | null> {
   let messageBus = deps.messageBus;
-  const { args, waitForApproval, noTrack } = parseArgs(argv);
-  const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
-  const internalOwnerServe = args[0] === 'owner-serve';
   const resolvedExitCode = (): number => {
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
   };
 
-  if (!standaloneMode && !internalOwnerServe && await delegateReadOnlyQuery(args, messageBus, deps.refreshMessageBus)) {
-    return resolvedExitCode();
-  }
-
-  if (!isHeadlessMutatingCommand(args) || standaloneMode || internalOwnerServe) {
-    return deps.runElectronHeadless(argv);
-  }
-
+  // Phase 1: Discover a standalone-capable owner
   const owner = await discoverOwner(messageBus, 3_000);
   if (isStandaloneCapable(owner)) {
     if (await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
       return resolvedExitCode();
     }
   }
+
+  // Phase 2: Try any reachable owner (may be GUI)
   if (isOwnerReachable(owner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
     return resolvedExitCode();
   }
+
+  // Phase 3: Refresh and retry against any reachable owner
   if (isOwnerReachable(owner) && deps.refreshMessageBus) {
     messageBus = await deps.refreshMessageBus();
     const refreshedOwner = await discoverOwner(messageBus, 1_000);
@@ -303,6 +302,8 @@ export async function runHeadlessClientCommand(
       return resolvedExitCode();
     }
   }
+
+  // Phase 4: Bootstrap with retry loop (delegated to resolver pattern)
   if (deps.refreshMessageBus) {
     messageBus = await deps.refreshMessageBus();
   }
@@ -322,13 +323,7 @@ export async function runHeadlessClientCommand(
     if (deps.refreshMessageBus) {
       messageBus = await deps.refreshMessageBus();
     }
-    if (await delegateAfterBootstrap(
-      args,
-      deps,
-      messageBus,
-      waitForApproval,
-      noTrack,
-    )) {
+    if (await delegateAfterBootstrap(args, deps, messageBus, waitForApproval, noTrack)) {
       return resolvedExitCode();
     }
     if (!deps.refreshMessageBus) {
@@ -336,6 +331,36 @@ export async function runHeadlessClientCommand(
     }
     messageBus = await deps.refreshMessageBus();
   }
+
+  return null; // Could not resolve
+}
+
+export async function runHeadlessClientCommand(
+  argv: string[],
+  deps: HeadlessClientDeps,
+): Promise<number> {
+  // Validate config before any delegation path so malformed JSON fails fast
+  // even for commands that do not boot the full Electron owner process.
+  loadConfig();
+
+  const { args, waitForApproval, noTrack } = parseArgs(argv);
+  const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
+  const internalOwnerServe = args[0] === 'owner-serve';
+
+  if (!standaloneMode && !internalOwnerServe && await delegateReadOnlyQuery(args, deps.messageBus, deps.refreshMessageBus)) {
+    const exitCode = process.exitCode;
+    return typeof exitCode === 'number' ? exitCode : 0;
+  }
+
+  if (!isHeadlessMutatingCommand(args) || standaloneMode || internalOwnerServe) {
+    return deps.runElectronHeadless(argv);
+  }
+
+  const result = await resolveOwnerAndDelegate(args, deps, waitForApproval, noTrack);
+  if (result !== null) {
+    return result;
+  }
+
   process.stderr.write(
     `${RED}Error:${RESET} Mutation command "${args[0] ?? ''}" could not reach a standalone shared owner after bootstrap.\n`,
   );

--- a/packages/app/src/owner-endpoint.ts
+++ b/packages/app/src/owner-endpoint.ts
@@ -1,0 +1,78 @@
+/**
+ * Owner Endpoint Contract — surface-neutral owner discovery and capability.
+ *
+ * This module models owner discovery without exposing whether the owner is
+ * a GUI window, a standalone headless daemon, or any other host surface.
+ * Client code asks "is an owner available?" and "can it accept mutations?"
+ * without knowing how the owner was launched.
+ *
+ * Host implementations (main.ts standalone path, main.ts GUI path) register
+ * handlers on the MessageBus that satisfy this contract. They may retain
+ * internal details about their launch mode, but those details do not appear
+ * in the types below.
+ */
+
+import type { MessageBus } from '@invoker/transport';
+
+import { tryPingHeadlessOwner } from './headless-delegation.js';
+
+// ── Contract types ──────────────────────────────────────────
+
+/** What the client learns from a successful owner discovery ping. */
+export interface OwnerEndpointInfo {
+  /** Opaque identifier for the running owner process. */
+  ownerId: string;
+  /**
+   * Whether this owner can accept bootstrapped standalone mutations.
+   * True when the owner was started as a detached long-lived process
+   * (the kind `ensureStandaloneOwner` provisions). False for transient
+   * owners that happen to be alive (e.g. an interactive session).
+   *
+   * The client uses this to decide whether post-bootstrap delegation
+   * should target this owner or whether a fresh bootstrap is needed.
+   */
+  canAcceptStandaloneMutations: boolean;
+}
+
+/** Discovery failed — no owner is reachable within the timeout. */
+export type OwnerNotReachable = null;
+
+/** Result of an owner discovery attempt. */
+export type OwnerDiscoveryResult = OwnerEndpointInfo | OwnerNotReachable;
+
+// ── Discovery implementation ────────────────────────────────
+
+/**
+ * Discover a running owner endpoint via the MessageBus.
+ *
+ * This is the single entry point that client code should use instead of
+ * calling `tryPingHeadlessOwner` directly and inspecting the raw `mode`
+ * field.
+ */
+export async function discoverOwner(
+  messageBus: MessageBus,
+  timeoutMs?: number,
+): Promise<OwnerDiscoveryResult> {
+  const raw = await tryPingHeadlessOwner(messageBus, timeoutMs);
+  if (!raw) return null;
+  return {
+    ownerId: raw.ownerId ?? '',
+    canAcceptStandaloneMutations: raw.mode === 'standalone',
+  };
+}
+
+// ── Capability predicates ───────────────────────────────────
+
+/** Whether the discovered owner accepts standalone-bootstrapped mutations. */
+export function isStandaloneCapable(
+  owner: OwnerDiscoveryResult,
+): owner is OwnerEndpointInfo & { canAcceptStandaloneMutations: true } {
+  return owner !== null && owner.canAcceptStandaloneMutations;
+}
+
+/** Whether any owner (of any kind) is reachable. */
+export function isOwnerReachable(
+  owner: OwnerDiscoveryResult,
+): owner is OwnerEndpointInfo {
+  return owner !== null;
+}

--- a/packages/app/src/owner-resolver.ts
+++ b/packages/app/src/owner-resolver.ts
@@ -1,0 +1,218 @@
+/**
+ * Owner Resolver — centralizes discovery, staleness refresh, and bootstrap.
+ *
+ * The resolver encapsulates the three-phase owner acquisition policy:
+ *   1. Discover a live owner via IPC ping.
+ *   2. If stale (unreachable or not standalone-capable), refresh the bus and retry.
+ *   3. If no owner is available at all, bootstrap one.
+ *
+ * The interface is surface-neutral: callers receive an OwnerEndpointInfo and a
+ * MessageBus handle, but never branch on GUI/headless mode flags.
+ */
+
+import type { MessageBus } from '@invoker/transport';
+
+import {
+  discoverOwner,
+  isOwnerReachable,
+  isStandaloneCapable,
+  type OwnerDiscoveryResult,
+  type OwnerEndpointInfo,
+} from './owner-endpoint.js';
+
+// ── Result types ────────────────────────────────────────────
+
+export type ResolvedOwner = {
+  owner: OwnerEndpointInfo;
+  bus: MessageBus;
+};
+
+export type OwnerResolveResult =
+  | { resolved: true; owner: OwnerEndpointInfo; bus: MessageBus }
+  | { resolved: false };
+
+// ── Dependency contract ─────────────────────────────────────
+
+export interface OwnerResolverDeps {
+  /** Current message bus for IPC communication. */
+  messageBus: MessageBus;
+  /** Provision a new message bus (reconnect after staleness). */
+  refreshMessageBus?: () => Promise<MessageBus>;
+  /** Bootstrap a standalone owner process. */
+  ensureStandaloneOwner: (bus: MessageBus) => Promise<void>;
+}
+
+// ── Configuration ───────────────────────────────────────────
+
+export interface OwnerResolverOptions {
+  /** Timeout for owner discovery ping (ms). Default: 3000. */
+  discoveryTimeoutMs?: number;
+  /** Timeout for post-refresh re-discovery ping (ms). Default: 1000. */
+  refreshDiscoveryTimeoutMs?: number;
+  /** Timeout waiting for owner readiness after bootstrap (ms). Default: 20000. */
+  postBootstrapReadyTimeoutMs?: number;
+  /** Maximum bootstrap restart attempts. Default: 3. */
+  maxBootstrapAttempts?: number;
+}
+
+const DEFAULT_DISCOVERY_TIMEOUT_MS = 3_000;
+const DEFAULT_REFRESH_DISCOVERY_TIMEOUT_MS = 1_000;
+const DEFAULT_POST_BOOTSTRAP_READY_TIMEOUT_MS = 20_000;
+const DEFAULT_MAX_BOOTSTRAP_ATTEMPTS = 3;
+
+// ── Resolver interface ──────────────────────────────────────
+
+export interface OwnerResolver {
+  /**
+   * Attempt to discover an already-running standalone-capable owner.
+   * Returns the owner and bus if found, or { resolved: false } if not.
+   */
+  discover(): Promise<OwnerResolveResult>;
+
+  /**
+   * Refresh the bus and re-attempt discovery.
+   * Use when the initial discovery returned a stale or unreachable endpoint.
+   */
+  refreshAndDiscover(): Promise<OwnerResolveResult>;
+
+  /**
+   * Full resolve: discover → refresh → bootstrap → discover.
+   * Guarantees a standalone-capable owner or throws after exhausting retries.
+   *
+   * @param requireStandalone If true, only a standalone-capable owner counts
+   *   as resolved. If false, any reachable owner satisfies the request.
+   */
+  resolve(requireStandalone?: boolean): Promise<ResolvedOwner>;
+
+  /**
+   * Discover any reachable owner (standalone or not).
+   * Useful for read-only queries that can target any owner surface.
+   */
+  discoverAny(): Promise<OwnerResolveResult>;
+
+  /**
+   * Wait for any owner to become reachable within a timeout.
+   * Polls with refresh between attempts.
+   */
+  waitForAny(timeoutMs: number): Promise<OwnerResolveResult>;
+
+  /**
+   * Wait for a standalone-capable owner after bootstrap.
+   * Polls with refresh between attempts.
+   */
+  waitForStandalone(timeoutMs: number): Promise<OwnerResolveResult>;
+}
+
+// ── Implementation ──────────────────────────────────────────
+
+export function createOwnerResolver(
+  deps: OwnerResolverDeps,
+  options: OwnerResolverOptions = {},
+): OwnerResolver {
+  const discoveryTimeoutMs = options.discoveryTimeoutMs ?? DEFAULT_DISCOVERY_TIMEOUT_MS;
+  const refreshDiscoveryTimeoutMs = options.refreshDiscoveryTimeoutMs ?? DEFAULT_REFRESH_DISCOVERY_TIMEOUT_MS;
+  const postBootstrapReadyTimeoutMs = options.postBootstrapReadyTimeoutMs ?? DEFAULT_POST_BOOTSTRAP_READY_TIMEOUT_MS;
+  const maxBootstrapAttempts = options.maxBootstrapAttempts ?? DEFAULT_MAX_BOOTSTRAP_ATTEMPTS;
+
+  let currentBus = deps.messageBus;
+
+  async function refreshBus(): Promise<MessageBus> {
+    if (deps.refreshMessageBus) {
+      currentBus = await deps.refreshMessageBus();
+    }
+    return currentBus;
+  }
+
+  function toResult(owner: OwnerDiscoveryResult, bus: MessageBus): OwnerResolveResult {
+    if (owner === null) return { resolved: false };
+    return { resolved: true, owner, bus };
+  }
+
+  function toStandaloneResult(owner: OwnerDiscoveryResult, bus: MessageBus): OwnerResolveResult {
+    if (!isStandaloneCapable(owner)) return { resolved: false };
+    return { resolved: true, owner, bus };
+  }
+
+  const resolver: OwnerResolver = {
+    async discover(): Promise<OwnerResolveResult> {
+      const owner = await discoverOwner(currentBus, discoveryTimeoutMs);
+      return toStandaloneResult(owner, currentBus);
+    },
+
+    async refreshAndDiscover(): Promise<OwnerResolveResult> {
+      const bus = await refreshBus();
+      const owner = await discoverOwner(bus, refreshDiscoveryTimeoutMs);
+      return toStandaloneResult(owner, bus);
+    },
+
+    async discoverAny(): Promise<OwnerResolveResult> {
+      const owner = await discoverOwner(currentBus, discoveryTimeoutMs);
+      return toResult(owner, currentBus);
+    },
+
+    async waitForAny(timeoutMs: number): Promise<OwnerResolveResult> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const owner = await discoverOwner(currentBus, 2_000);
+        if (isOwnerReachable(owner)) {
+          return { resolved: true, owner, bus: currentBus };
+        }
+        await refreshBus();
+        await new Promise((r) => setTimeout(r, 250));
+      }
+      return { resolved: false };
+    },
+
+    async waitForStandalone(timeoutMs: number): Promise<OwnerResolveResult> {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const owner = await discoverOwner(currentBus, 1_000);
+        if (isStandaloneCapable(owner)) {
+          return { resolved: true, owner, bus: currentBus };
+        }
+        await refreshBus();
+        await new Promise((r) => setTimeout(r, 250));
+      }
+      return { resolved: false };
+    },
+
+    async resolve(requireStandalone = true): Promise<ResolvedOwner> {
+      // Phase 1: Try immediate discovery
+      const immediate = await discoverOwner(currentBus, discoveryTimeoutMs);
+      if (requireStandalone ? isStandaloneCapable(immediate) : isOwnerReachable(immediate)) {
+        return { owner: immediate!, bus: currentBus };
+      }
+
+      // Phase 2: Refresh and retry
+      if (deps.refreshMessageBus) {
+        currentBus = await deps.refreshMessageBus();
+      }
+
+      // Phase 3: Bootstrap with retry loop
+      for (let attempt = 0; attempt < maxBootstrapAttempts; attempt += 1) {
+        await deps.ensureStandaloneOwner(currentBus);
+
+        if (deps.refreshMessageBus) {
+          currentBus = await deps.refreshMessageBus();
+        }
+
+        // Wait for the bootstrapped owner to become ready
+        const result = await resolver.waitForStandalone(postBootstrapReadyTimeoutMs);
+        if (result.resolved) {
+          return { owner: result.owner, bus: result.bus };
+        }
+
+        // Owner didn't come up — refresh and retry bootstrap
+        if (deps.refreshMessageBus) {
+          currentBus = await deps.refreshMessageBus();
+        }
+      }
+
+      throw new Error(
+        'Could not resolve a standalone-capable owner after exhausting all bootstrap attempts',
+      );
+    },
+  };
+
+  return resolver;
+}

--- a/run.sh
+++ b/run.sh
@@ -73,8 +73,28 @@ ensure_workspace_bootstrapped
 # Unset ELECTRON_RUN_AS_NODE so Electron loads its full API.
 unset ELECTRON_RUN_AS_NODE
 
-# In headless mode (child of running app), skip cleanup and rebuild.
+# In headless mode, validate config fast (before any build) and then ensure dist exists.
 if [ "$1" = "--headless" ]; then
+  # Fast-path config validation in bash so malformed JSON fails immediately
+  # without waiting for a dist build.
+  _cfg_path="${INVOKER_REPO_CONFIG_PATH:-$HOME/.invoker/config.json}"
+  if [ -f "$_cfg_path" ]; then
+    if ! node -e "JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'))" "$_cfg_path" 2>/dev/null; then
+      echo "Invalid Invoker config JSON at $_cfg_path: malformed JSON" >&2
+      exit 1
+    fi
+  fi
+
+  # Build app and dependencies if headless entry point is missing (e.g. fresh worktree).
+  if [ ! -f "$REPO_ROOT/packages/app/dist/headless-client.js" ]; then
+    pnpm --filter @invoker/core build >&2
+    pnpm --filter @invoker/persistence build >&2
+    pnpm --filter @invoker/executors build >&2
+    pnpm --filter @invoker/surfaces build >&2
+    pnpm --filter @invoker/ui build >&2
+    pnpm --filter @invoker/app build >&2
+  fi
+
   shift
   exec node ./packages/app/dist/headless-client.js "$@"
 fi

--- a/scripts/verify-executor-routing.sh
+++ b/scripts/verify-executor-routing.sh
@@ -15,8 +15,13 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$ROOT"
 
 if [[ ! -f packages/app/dist/main.js ]]; then
-  echo "ERROR: packages/app/dist/main.js missing — run: pnpm --filter @invoker/app build" >&2
-  exit 1
+  echo "==> packages/app/dist/main.js missing — building..." >&2
+  pnpm --filter @invoker/core build >&2
+  pnpm --filter @invoker/persistence build >&2
+  pnpm --filter @invoker/executors build >&2
+  pnpm --filter @invoker/surfaces build >&2
+  pnpm --filter @invoker/ui build >&2
+  pnpm --filter @invoker/app build >&2
 fi
 
 TMPDB="$(mktemp -d)"


### PR DESCRIPTION
## Summary

Run focused routing regressions after the resolver extraction (`a48d7d7f`) and shared boundary routing (`195c4e79`) changes. All three targeted test files pass: `headless-client.test.ts` (18 tests), `headless-session.test.ts` (5 tests), and `headless-command-classification.test.ts` (5 tests).

One unrelated failure in `bundled-skills.test.ts` is environment-specific (asserts skills are not installed, but they are installed in this worktree). This failure is pre-existing and not caused by the routing changes.

## Test Plan

- [x] `cd packages/app && pnpm test -- src/__tests__/headless-client.test.ts src/__tests__/headless-session.test.ts src/__tests__/headless-command-classification.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
