### PR TITLE
External PR authoring parity step 1: unify merge publication path

### DIFF
--- a/packages/app/src/__tests__/db-timings-wiring.test.ts
+++ b/packages/app/src/__tests__/db-timings-wiring.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Integration coverage for the app-level wiring that surfaces `dbTimings`
+ * via the `getUiPerfStats()` payload.
+ *
+ * This drives the *real* persistence and task-repository decorators against
+ * an in-memory SQLite to ensure the events emitted by
+ * `InstrumentedPersistenceAdapter` and `InstrumentedTaskRepository` flow
+ * through the `DbTimings` aggregator and land under the expected
+ * `startup` / `delete` phase keys, with delete semantics preserved.
+ */
+
+import { describe, expect, it, beforeEach } from 'vitest';
+import {
+  SQLiteAdapter,
+  InstrumentedPersistenceAdapter,
+  SqliteTaskRepository,
+  type PersistenceAdapter,
+} from '@invoker/data-store';
+import { InstrumentedTaskRepository, createTaskState } from '@invoker/workflow-core';
+import { DbTimings } from '../db-timings.js';
+
+interface UiPerfStatsLite {
+  readonly dbTimings: ReturnType<DbTimings['snapshot']>;
+}
+
+function makeUiPerfStats(timings: DbTimings): UiPerfStatsLite {
+  return { dbTimings: timings.snapshot() };
+}
+
+describe('dbTimings app-level wiring', () => {
+  let adapter: SQLiteAdapter;
+  let timings: DbTimings;
+  let persistence: PersistenceAdapter;
+  let repository: InstrumentedTaskRepository;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+    timings = new DbTimings();
+    persistence = new InstrumentedPersistenceAdapter(
+      adapter,
+      timings.toPersistenceInstrumenter(),
+    );
+    repository = new InstrumentedTaskRepository(
+      new SqliteTaskRepository(persistence),
+      timings.toTaskRepositoryInstrumenter(),
+    );
+  });
+
+  it('exposes a dbTimings section with startup and delete buckets on getUiPerfStats payloads', () => {
+    persistence.saveWorkflow({
+      id: 'wf-startup',
+      name: 'Startup Workflow',
+      status: 'running',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    // Simulate startup adapter/load reads.
+    persistence.listWorkflows();
+    persistence.loadWorkflow('wf-startup');
+    persistence.loadTasks('wf-startup');
+
+    const payload = makeUiPerfStats(timings);
+    expect(payload.dbTimings).toBeDefined();
+    expect(payload.dbTimings.startup['persistence.listWorkflows']?.count).toBe(1);
+    expect(payload.dbTimings.startup['persistence.loadWorkflow']?.count).toBe(1);
+    expect(payload.dbTimings.startup['persistence.loadTasks']?.count).toBe(1);
+    expect(Object.keys(payload.dbTimings.delete)).toEqual([]);
+  });
+
+  it('records persistence and task-repository delete events under the delete bucket while preserving delete semantics', () => {
+    persistence.saveWorkflow({
+      id: 'wf-delete',
+      name: 'Workflow To Delete',
+      status: 'running',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+    repository.saveTask(
+      'wf-delete',
+      createTaskState('t1', 'Task 1', [], { workflowId: 'wf-delete' }),
+    );
+
+    expect(persistence.listWorkflows().map((w) => w.id)).toEqual(['wf-delete']);
+    expect(persistence.loadTasks('wf-delete').map((t) => t.id)).toEqual(['t1']);
+
+    // App-side pre-delete work (e.g. killing running tasks) is recorded
+    // through the public timeAsync helper.
+    let preDeleteRan = false;
+    return timings
+      .timeAsync('delete', 'app.preDeleteKillRunning', async () => {
+        preDeleteRan = true;
+      })
+      .then(() => {
+        // Repository delete (the seam used by orchestrator.deleteWorkflow).
+        repository.deleteWorkflow('wf-delete');
+
+        // Delete semantics must be preserved.
+        expect(preDeleteRan).toBe(true);
+        expect(persistence.loadWorkflow('wf-delete')).toBeUndefined();
+        expect(persistence.loadTasks('wf-delete')).toEqual([]);
+
+        const snap = timings.snapshot();
+        expect(snap.delete['app.preDeleteKillRunning']?.count).toBe(1);
+        expect(snap.delete['taskRepository.deleteWorkflow']?.count).toBe(1);
+        // `repository.deleteWorkflow` delegates through the
+        // InstrumentedPersistenceAdapter, so the persistence-level event
+        // fires too.
+        expect(snap.delete['persistence.deleteWorkflow']?.count).toBe(1);
+      });
+  });
+
+  it('records deleteAllWorkflows under the delete bucket and clears state', () => {
+    persistence.saveWorkflow({
+      id: 'wf-a',
+      name: 'A',
+      status: 'running',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+    persistence.saveWorkflow({
+      id: 'wf-b',
+      name: 'B',
+      status: 'running',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    });
+
+    repository.deleteAllWorkflows();
+
+    expect(persistence.listWorkflows()).toEqual([]);
+
+    const snap = timings.snapshot();
+    expect(snap.delete['taskRepository.deleteAllWorkflows']?.count).toBe(1);
+    expect(snap.delete['persistence.deleteAllWorkflows']?.count).toBe(1);
+  });
+
+  it('reset() clears the dbTimings snapshot returned by getUiPerfStats', () => {
+    persistence.listWorkflows();
+    let payload = makeUiPerfStats(timings);
+    expect(payload.dbTimings.startup['persistence.listWorkflows']?.count).toBe(1);
+
+    timings.reset();
+
+    payload = makeUiPerfStats(timings);
+    expect(payload.dbTimings.startup).toEqual({});
+    expect(payload.dbTimings.delete).toEqual({});
+  });
+});

--- a/packages/app/src/__tests__/db-timings.test.ts
+++ b/packages/app/src/__tests__/db-timings.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from 'vitest';
+import { DbTimings } from '../db-timings.js';
+import type { PersistenceInstrumentationEvent } from '@invoker/data-store';
+import type {
+  CommandServiceInstrumentationEvent,
+  TaskRepositoryInstrumentationEvent,
+} from '@invoker/workflow-core';
+
+function makePersistenceEvent(
+  method: PersistenceInstrumentationEvent['method'],
+  durationMs: number,
+  success: boolean = true,
+): PersistenceInstrumentationEvent {
+  return {
+    scope: `persistence.${method}`,
+    method,
+    durationMs,
+    success,
+    ...(success ? {} : { error: 'boom' }),
+  };
+}
+
+function makeTaskRepositoryEvent(
+  method: TaskRepositoryInstrumentationEvent['method'],
+  durationMs: number,
+  success: boolean = true,
+): TaskRepositoryInstrumentationEvent {
+  return {
+    scope: `task-repository.${method}`,
+    method,
+    durationMs,
+    success,
+    ...(success ? {} : { error: 'boom' }),
+  };
+}
+
+function makeCommandServiceEvent(
+  method: CommandServiceInstrumentationEvent['method'],
+  durationMs: number,
+  success: boolean = true,
+): CommandServiceInstrumentationEvent {
+  return {
+    scope: `command-service.${method}`,
+    method,
+    durationMs,
+    success,
+    ...(success ? {} : { error: 'boom' }),
+  };
+}
+
+describe('DbTimings', () => {
+  it('aggregates startup adapter reads under the startup category', () => {
+    const timings = new DbTimings();
+    const tap = timings.toPersistenceInstrumenter();
+
+    tap(makePersistenceEvent('listWorkflows', 5));
+    tap(makePersistenceEvent('listWorkflows', 7));
+    tap(makePersistenceEvent('loadWorkflow', 3));
+    tap(makePersistenceEvent('loadTasks', 12));
+
+    const snap = timings.snapshot();
+    expect(snap.startup['persistence.listWorkflows']).toEqual({
+      count: 2,
+      totalMs: 12,
+      maxMs: 7,
+      errors: 0,
+    });
+    expect(snap.startup['persistence.loadWorkflow']).toEqual({
+      count: 1,
+      totalMs: 3,
+      maxMs: 3,
+      errors: 0,
+    });
+    expect(snap.startup['persistence.loadTasks']).toEqual({
+      count: 1,
+      totalMs: 12,
+      maxMs: 12,
+      errors: 0,
+    });
+    expect(Object.keys(snap.delete)).toEqual([]);
+  });
+
+  it('routes persistence delete events under delete.persistence and counts errors', () => {
+    const timings = new DbTimings();
+    const tap = timings.toPersistenceInstrumenter();
+
+    tap(makePersistenceEvent('deleteWorkflow', 10));
+    tap(makePersistenceEvent('deleteWorkflow', 4, false));
+    tap(makePersistenceEvent('deleteAllWorkflows', 25));
+
+    const snap = timings.snapshot();
+    expect(snap.delete['persistence.deleteWorkflow']).toEqual({
+      count: 2,
+      totalMs: 14,
+      maxMs: 10,
+      errors: 1,
+    });
+    expect(snap.delete['persistence.deleteAllWorkflows']).toEqual({
+      count: 1,
+      totalMs: 25,
+      maxMs: 25,
+      errors: 0,
+    });
+  });
+
+  it('ignores non-startup, non-delete persistence events', () => {
+    const timings = new DbTimings();
+    const tap = timings.toPersistenceInstrumenter();
+
+    tap(makePersistenceEvent('saveTask', 9));
+    tap(makePersistenceEvent('updateTask', 4));
+
+    const snap = timings.snapshot();
+    expect(Object.keys(snap.startup)).toEqual([]);
+    expect(Object.keys(snap.delete)).toEqual([]);
+  });
+
+  it('routes task-repository delete events under delete.taskRepository', () => {
+    const timings = new DbTimings();
+    const tap = timings.toTaskRepositoryInstrumenter();
+
+    tap(makeTaskRepositoryEvent('deleteWorkflow', 6));
+    tap(makeTaskRepositoryEvent('deleteAllWorkflows', 14));
+    tap(makeTaskRepositoryEvent('saveTask', 99));
+
+    const snap = timings.snapshot();
+    expect(snap.delete['taskRepository.deleteWorkflow']).toEqual({
+      count: 1,
+      totalMs: 6,
+      maxMs: 6,
+      errors: 0,
+    });
+    expect(snap.delete['taskRepository.deleteAllWorkflows']).toEqual({
+      count: 1,
+      totalMs: 14,
+      maxMs: 14,
+      errors: 0,
+    });
+    expect(snap.delete['taskRepository.saveTask']).toBeUndefined();
+  });
+
+  it('routes only the deleteWorkflow command-service event under delete.commandService', () => {
+    const timings = new DbTimings();
+    const tap = timings.toCommandServiceInstrumenter();
+
+    tap(makeCommandServiceEvent('deleteWorkflow', 30));
+    tap(makeCommandServiceEvent('deleteWorkflow', 12, false));
+    tap(makeCommandServiceEvent('retryWorkflow', 50));
+    tap(makeCommandServiceEvent('approve', 7));
+
+    const snap = timings.snapshot();
+    expect(snap.delete['commandService.deleteWorkflow']).toEqual({
+      count: 2,
+      totalMs: 42,
+      maxMs: 30,
+      errors: 1,
+    });
+    expect(Object.keys(snap.delete)).toEqual(['commandService.deleteWorkflow']);
+  });
+
+  it('records timeAsync and timeSync durations under the requested phase', async () => {
+    let now = 100;
+    const timings = new DbTimings({ now: () => now });
+
+    await timings.timeAsync('delete', 'app.preDelete', async () => {
+      now = 130;
+    });
+    timings.timeSync('startup', 'orchestrator.syncAllFromDb', () => {
+      now = 138;
+    });
+
+    const snap = timings.snapshot();
+    expect(snap.delete['app.preDelete']).toEqual({
+      count: 1,
+      totalMs: 30,
+      maxMs: 30,
+      errors: 0,
+    });
+    expect(snap.startup['orchestrator.syncAllFromDb']).toEqual({
+      count: 1,
+      totalMs: 8,
+      maxMs: 8,
+      errors: 0,
+    });
+  });
+
+  it('records errors when timed work throws and rethrows the error', async () => {
+    let now = 0;
+    const timings = new DbTimings({ now: () => now });
+
+    await expect(
+      timings.timeAsync('delete', 'app.preDelete', async () => {
+        now = 10;
+        throw new Error('boom');
+      }),
+    ).rejects.toThrow('boom');
+
+    const snap = timings.snapshot();
+    expect(snap.delete['app.preDelete']).toEqual({
+      count: 1,
+      totalMs: 10,
+      maxMs: 10,
+      errors: 1,
+    });
+  });
+
+  it('reset() clears all aggregates', () => {
+    const timings = new DbTimings();
+    timings.toPersistenceInstrumenter()(makePersistenceEvent('listWorkflows', 5));
+    timings.toPersistenceInstrumenter()(makePersistenceEvent('deleteWorkflow', 10));
+
+    timings.reset();
+
+    const snap = timings.snapshot();
+    expect(snap.startup).toEqual({});
+    expect(snap.delete).toEqual({});
+  });
+
+  it('snapshot() exposes a JSON-serializable shape with startup and delete buckets', () => {
+    const timings = new DbTimings();
+    timings.toPersistenceInstrumenter()(makePersistenceEvent('listWorkflows', 4));
+    timings.toPersistenceInstrumenter()(makePersistenceEvent('deleteWorkflow', 8));
+    timings.toCommandServiceInstrumenter()(makeCommandServiceEvent('deleteWorkflow', 22));
+
+    const snap = timings.snapshot();
+    const json = JSON.parse(JSON.stringify(snap));
+    expect(json).toEqual({
+      startup: {
+        'persistence.listWorkflows': { count: 1, totalMs: 4, maxMs: 4, errors: 0 },
+      },
+      delete: {
+        'persistence.deleteWorkflow': { count: 1, totalMs: 8, maxMs: 8, errors: 0 },
+        'commandService.deleteWorkflow': { count: 1, totalMs: 22, maxMs: 22, errors: 0 },
+      },
+    });
+  });
+});

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -883,6 +883,10 @@ describe('headless delegation enforcement', () => {
         const preemptWorkflowExecution = vi.fn(async () => ({ cancelled: [], runningCancelled: [] }));
         mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
         mockDeps.persistence.updateWorkflow = vi.fn();
+        (mockDeps.commandService as any).recreateWorkflow = vi.fn(async () => ({
+          ok: true as const,
+          data: [],
+        }));
 
         const depsWithNoTrack: HeadlessDeps = {
           ...mockDeps,
@@ -893,19 +897,24 @@ describe('headless delegation enforcement', () => {
         await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
 
         expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
-        expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+        expect(mockDeps.commandService.recreateWorkflow).toHaveBeenCalled();
+        const [recreateEnvelope] = (mockDeps.commandService.recreateWorkflow as any).mock.calls[0] ?? [];
+        expect(recreateEnvelope?.payload?.workflowId).toBe('wf-1');
       });
 
       it('headless recreate dispatches runnable tasks before waiting for completion', async () => {
         let taskStatus: 'running' | 'completed' = 'running';
-        mockDeps.orchestrator.recreateWorkflow = vi.fn(() => [
-          {
-            id: 'wf-1/task-1',
-            status: 'running',
-            config: { workflowId: 'wf-1' },
-            execution: {},
-          } as any,
-        ]);
+        const startedTask = {
+          id: 'wf-1/task-1',
+          status: 'running' as const,
+          config: { workflowId: 'wf-1' },
+          execution: {},
+        } as any;
+        mockDeps.orchestrator.recreateWorkflow = vi.fn(() => [startedTask]);
+        (mockDeps.commandService as any).recreateWorkflow = vi.fn(async () => ({
+          ok: true as const,
+          data: [startedTask],
+        }));
         mockDeps.orchestrator.startExecution = vi.fn(() => []);
         mockDeps.persistence.updateWorkflow = vi.fn();
         mockDeps.persistence.listWorkflows = vi.fn(() => [{
@@ -939,7 +948,9 @@ describe('headless delegation enforcement', () => {
         await runHeadless(['recreate', 'wf-1'], mockDeps);
 
         expect(executeTasksSpy).toHaveBeenCalledTimes(1);
-        expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+        expect(mockDeps.commandService.recreateWorkflow).toHaveBeenCalled();
+        const [recreateEnvelope] = (mockDeps.commandService.recreateWorkflow as any).mock.calls[0] ?? [];
+        expect(recreateEnvelope?.payload?.workflowId).toBe('wf-1');
 
         executeTasksSpy.mockRestore();
       });
@@ -1117,9 +1128,13 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `recreate <wfId>` routes to orchestrator.recreateWorkflow — NOT recreateWorkflowFromFreshBase (no upstream pool refresh)', async () => {
+        it('headless `recreate <wfId>` routes to commandService.recreateWorkflow — NOT recreateWorkflowFromFreshBase (no upstream pool refresh)', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
           mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
+          (mockDeps.commandService as any).recreateWorkflow = vi.fn(async () => ({
+            ok: true as const,
+            data: [],
+          }));
 
           const depsWithNoTrack: HeadlessDeps = {
             ...mockDeps,
@@ -1129,7 +1144,9 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
 
-          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.commandService.recreateWorkflow).toHaveBeenCalled();
+          const [recreateEnvelope] = (mockDeps.commandService.recreateWorkflow as any).mock.calls[0] ?? [];
+          expect(recreateEnvelope?.payload?.workflowId).toBe('wf-1');
           // Distinction guard — recreate must NOT refresh the upstream pool.
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           expect(preparePoolSpy).not.toHaveBeenCalled();
@@ -1252,6 +1269,8 @@ describe('headless delegation enforcement', () => {
 
           expect(mockDeps.commandService.retryTask).toHaveBeenCalled();
           expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
+          expect(mockDeps.commandService.recreateTask).not.toHaveBeenCalled();
+          expect(mockDeps.commandService.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
@@ -1259,7 +1278,7 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `recreate-task <id>` routes to orchestrator.recreateTask (only)', async () => {
+        it('headless `recreate-task <id>` routes to commandService.recreateTask (only)', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedHappyPath();
           const depsWithNoTrack: HeadlessDeps = {
             ...mockDeps,
@@ -1269,9 +1288,13 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['recreate-task', 'wf-1/task-1'], depsWithNoTrack);
 
-          expect(mockDeps.orchestrator.recreateTask).toHaveBeenCalledWith('wf-1/task-1');
+          expect(mockDeps.commandService.recreateTask).toHaveBeenCalled();
+          const [recreateTaskEnvelope] = (mockDeps.commandService.recreateTask as any).mock.calls[0] ?? [];
+          expect(recreateTaskEnvelope?.payload?.taskId).toBe('wf-1/task-1');
+          expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
           expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
+          expect(mockDeps.commandService.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
@@ -1290,6 +1313,8 @@ describe('headless delegation enforcement', () => {
 
           expect(mockDeps.commandService.retryWorkflow).toHaveBeenCalled();
           expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
+          expect(mockDeps.commandService.recreateTask).not.toHaveBeenCalled();
+          expect(mockDeps.commandService.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
@@ -1297,7 +1322,7 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `recreate <wfId>` routes to orchestrator.recreateWorkflow (only)', async () => {
+        it('headless `recreate <wfId>` routes to commandService.recreateWorkflow (only)', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedHappyPath();
           const depsWithNoTrack: HeadlessDeps = {
             ...mockDeps,
@@ -1307,9 +1332,13 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
 
-          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.commandService.recreateWorkflow).toHaveBeenCalled();
+          const [recreateWorkflowEnvelope] = (mockDeps.commandService.recreateWorkflow as any).mock.calls[0] ?? [];
+          expect(recreateWorkflowEnvelope?.payload?.workflowId).toBe('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
           expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
+          expect(mockDeps.commandService.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();

--- a/packages/app/src/db-timings.ts
+++ b/packages/app/src/db-timings.ts
@@ -1,0 +1,210 @@
+/**
+ * DbTimings — phase-level aggregator for startup-relevant adapter/load
+ * timings and delete timings emitted by the persistence, task-repository,
+ * and command-service decorators.
+ *
+ * The aggregator is exposed on the `getUiPerfStats()` payload under the
+ * `dbTimings` key so `--headless query ui-perf` and the
+ * `invoker:get-ui-perf-stats` IPC channel surface end-to-end startup and
+ * delete timings without changing delete semantics.
+ */
+
+import type {
+  PersistenceInstrumentationEvent,
+  PersistenceInstrumenter,
+} from '@invoker/data-store';
+import type {
+  CommandServiceInstrumentationEvent,
+  CommandServiceInstrumenter,
+  TaskRepositoryInstrumentationEvent,
+  TaskRepositoryInstrumenter,
+} from '@invoker/workflow-core';
+
+interface MutablePhaseTotals {
+  count: number;
+  totalMs: number;
+  maxMs: number;
+  errors: number;
+}
+
+export interface PhaseTotals {
+  readonly count: number;
+  readonly totalMs: number;
+  readonly maxMs: number;
+  readonly errors: number;
+}
+
+export interface DbTimingsSnapshot {
+  readonly startup: Readonly<Record<string, PhaseTotals>>;
+  readonly delete: Readonly<Record<string, PhaseTotals>>;
+}
+
+const STARTUP_PERSISTENCE_METHODS = new Set([
+  'listWorkflows',
+  'loadWorkflow',
+  'loadTasks',
+]);
+
+const DELETE_PERSISTENCE_METHODS = new Set([
+  'deleteWorkflow',
+  'deleteAllWorkflows',
+]);
+
+const DELETE_COMMAND_METHODS = new Set([
+  'deleteWorkflow',
+]);
+
+const DELETE_TASK_REPOSITORY_METHODS = new Set([
+  'deleteWorkflow',
+  'deleteAllWorkflows',
+]);
+
+function emptyTotals(): MutablePhaseTotals {
+  return { count: 0, totalMs: 0, maxMs: 0, errors: 0 };
+}
+
+function freezeTotals(totals: MutablePhaseTotals): PhaseTotals {
+  return Object.freeze({
+    count: totals.count,
+    totalMs: totals.totalMs,
+    maxMs: totals.maxMs,
+    errors: totals.errors,
+  });
+}
+
+export class DbTimings {
+  private readonly startup = new Map<string, MutablePhaseTotals>();
+  private readonly delete_ = new Map<string, MutablePhaseTotals>();
+  private readonly now: () => number;
+
+  constructor(options: { now?: () => number } = {}) {
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  /** Record a single phase observation. Public so callers can wrap their
+   *  own pre-DB work (e.g. the GUI delete-workflow IPC handler that kills
+   *  running tasks before delegating to CommandService). */
+  record(
+    category: 'startup' | 'delete',
+    phase: string,
+    durationMs: number,
+    success: boolean,
+  ): void {
+    const bucket = category === 'startup' ? this.startup : this.delete_;
+    let totals = bucket.get(phase);
+    if (!totals) {
+      totals = emptyTotals();
+      bucket.set(phase, totals);
+    }
+    totals.count += 1;
+    totals.totalMs += durationMs;
+    if (durationMs > totals.maxMs) {
+      totals.maxMs = durationMs;
+    }
+    if (!success) {
+      totals.errors += 1;
+    }
+  }
+
+  /** Time an async operation and record the duration under the given phase. */
+  async timeAsync<T>(
+    category: 'startup' | 'delete',
+    phase: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const start = this.now();
+    let success = true;
+    try {
+      return await fn();
+    } catch (err) {
+      success = false;
+      throw err;
+    } finally {
+      this.record(category, phase, this.now() - start, success);
+    }
+  }
+
+  /** Time a sync operation and record the duration under the given phase. */
+  timeSync<T>(category: 'startup' | 'delete', phase: string, fn: () => T): T {
+    const start = this.now();
+    let success = true;
+    try {
+      return fn();
+    } catch (err) {
+      success = false;
+      throw err;
+    } finally {
+      this.record(category, phase, this.now() - start, success);
+    }
+  }
+
+  /** Clear all aggregates. Used by `query ui-perf --reset`. */
+  reset(): void {
+    this.startup.clear();
+    this.delete_.clear();
+  }
+
+  /** Plain-object snapshot suitable for JSON serialization. */
+  snapshot(): DbTimingsSnapshot {
+    const dump = (bucket: Map<string, MutablePhaseTotals>): Record<string, PhaseTotals> => {
+      const out: Record<string, PhaseTotals> = {};
+      for (const [phase, totals] of bucket) {
+        out[phase] = freezeTotals(totals);
+      }
+      return out;
+    };
+    return Object.freeze({
+      startup: Object.freeze(dump(this.startup)),
+      delete: Object.freeze(dump(this.delete_)),
+    });
+  }
+
+  /** Build a `PersistenceInstrumenter` that routes startup-relevant adapter
+   *  reads under `dbTimings.startup.<method>` and delete-relevant adapter
+   *  writes under `dbTimings.delete.persistence.<method>`. Other methods are
+   *  ignored so the payload stays focused on phases the task scopes. */
+  toPersistenceInstrumenter(): PersistenceInstrumenter {
+    return (event: PersistenceInstrumentationEvent) => {
+      if (STARTUP_PERSISTENCE_METHODS.has(event.method)) {
+        this.record('startup', `persistence.${event.method}`, event.durationMs, event.success);
+        return;
+      }
+      if (DELETE_PERSISTENCE_METHODS.has(event.method)) {
+        this.record('delete', `persistence.${event.method}`, event.durationMs, event.success);
+      }
+    };
+  }
+
+  /** Build a `TaskRepositoryInstrumenter` that records the delete-relevant
+   *  repository writes under `dbTimings.delete.taskRepository.<method>`. */
+  toTaskRepositoryInstrumenter(): TaskRepositoryInstrumenter {
+    return (event: TaskRepositoryInstrumentationEvent) => {
+      if (DELETE_TASK_REPOSITORY_METHODS.has(event.method)) {
+        this.record(
+          'delete',
+          `taskRepository.${event.method}`,
+          event.durationMs,
+          event.success,
+        );
+      }
+    };
+  }
+
+  /** Build a `CommandServiceInstrumenter` that records the delete-workflow
+   *  mutation latency under `dbTimings.delete.commandService.deleteWorkflow`.
+   *  Other lifecycle mutations are intentionally not folded into the
+   *  startup/delete phases — those continue to flow through their own
+   *  command-service log lines. */
+  toCommandServiceInstrumenter(): CommandServiceInstrumenter {
+    return (event: CommandServiceInstrumentationEvent) => {
+      if (DELETE_COMMAND_METHODS.has(event.method)) {
+        this.record(
+          'delete',
+          `commandService.${event.method}`,
+          event.durationMs,
+          event.success,
+        );
+      }
+    };
+  }
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -34,8 +34,6 @@ import {
   approveTask,
   rebaseAndRetry,
   resolveConflictAction,
-  recreateWorkflow as sharedRecreateWorkflow,
-  recreateTask as sharedRecreateTask,
   forkWorkflow as sharedForkWorkflow,
   setWorkflowMergeMode,
   finalizeAppliedFix,
@@ -1342,7 +1340,18 @@ async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps):
     logger: deps.logger,
     context: 'headless.recreate-workflow',
   });
-  const started = sharedRecreateWorkflow(workflowId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
+  const envelope = makeEnvelope('recreate-workflow', 'headless', 'workflow', { workflowId });
+  const result = await deps.commandService.recreateWorkflow(envelope, {
+    beforeRecreate: () => {
+      const workflow = deps.persistence.loadWorkflow(workflowId);
+      if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+      const nextGen = (workflow.generation ?? 0) + 1;
+      deps.persistence.updateWorkflow(workflowId, { generation: nextGen });
+      deps.logger.info(`bumped generation to ${nextGen} for ${workflowId}`, { module: 'workflow' });
+    },
+  });
+  if (!result.ok) throw new Error(result.error.message);
+  const started = result.data;
   const runnable = started.filter(t => t.status === 'running');
   if (runnable.length > 0) {
     const te = createHeadlessExecutor(deps);
@@ -1391,7 +1400,10 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
   taskId = restored.resolvedTaskId;
   await preemptTaskSubgraph(taskId, deps);
 
-  const started = sharedRecreateTask(taskId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
+  const envelope = makeEnvelope('recreate-task', 'headless', 'task', { taskId });
+  const result = await deps.commandService.recreateTask(envelope);
+  if (!result.ok) throw new Error(result.error.message);
+  const started = result.data;
   const runnable = started.filter(t => t.status === 'running');
   const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
   process.stdout.write(`Recreate task "${taskId}" (+ downstream) — ${runnable.length} task(s) to execute (pool fetch skipped)\n`);

--- a/packages/app/src/logger.ts
+++ b/packages/app/src/logger.ts
@@ -9,22 +9,22 @@ import { homedir } from 'node:os';
 import * as path from 'node:path';
 
 import type { Logger } from '@invoker/contracts';
-import type { SQLiteAdapter } from '@invoker/data-store';
+import type { PersistenceAdapter } from '@invoker/data-store';
 
 const LOG_PATH = path.join(homedir(), '.invoker', 'invoker.log');
 
 type Level = 'debug' | 'info' | 'warn' | 'error';
 
 export interface FileAndDbLoggerOptions {
-  /** SQLiteAdapter instance for activity_log writes. Omit to skip DB writes. */
-  persistence?: SQLiteAdapter;
+  /** Persistence seam for activity_log writes. Omit to skip DB writes. */
+  persistence?: PersistenceAdapter;
   /** Override the default log file path (mainly for tests). */
   filePath?: string;
 }
 
 export class FileAndDbLogger implements Logger {
   private readonly bindings: Record<string, unknown>;
-  private readonly persistence: SQLiteAdapter | undefined;
+  private readonly persistence: PersistenceAdapter | undefined;
   private readonly filePath: string;
   private dirEnsured = false;
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -178,10 +178,6 @@ if (process.platform === 'linux') {
 // ── Shared state ─────────────────────────────────────────────
 
 let messageBus: MessageBus;
-// Typed against the PersistenceAdapter seam so wrappers (logging, metrics)
-// can be slotted in without touching call sites. The concrete SQLiteAdapter
-// instance is held in `sqlitePersistence` for subsystems (workflow-mutation
-// queue, lease recovery) that depend on SQLite-only methods.
 let persistence: PersistenceAdapter;
 let sqlitePersistence: SQLiteAdapter;
 let executorRegistry: ExecutorRegistry;
@@ -358,7 +354,6 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     ownerCapability: !readOnly, // writable mode requires owner capability
   });
   persistence = sqlitePersistence;
-  // Upgrade root logger with DB persistence now that the adapter is ready.
   logger = new FileAndDbLogger({ module: 'main' }, { persistence });
   const shellEnv = await initializeShellEnvironment();
   if (process.platform === 'darwin') {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -61,6 +61,7 @@ import type {
 import { makeEnvelope } from '@invoker/contracts';
 import type { WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
+import type { PersistenceAdapter } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import {
@@ -177,7 +178,12 @@ if (process.platform === 'linux') {
 // ── Shared state ─────────────────────────────────────────────
 
 let messageBus: MessageBus;
-let persistence: SQLiteAdapter;
+// Typed against the PersistenceAdapter seam so wrappers (logging, metrics)
+// can be slotted in without touching call sites. The concrete SQLiteAdapter
+// instance is held in `sqlitePersistence` for subsystems (workflow-mutation
+// queue, lease recovery) that depend on SQLite-only methods.
+let persistence: PersistenceAdapter;
+let sqlitePersistence: SQLiteAdapter;
 let executorRegistry: ExecutorRegistry;
 let orchestrator: Orchestrator;
 let commandService: CommandService;
@@ -347,11 +353,12 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
   if (!readOnly) {
     writerLock = acquireDbWriterLock(dbPath);
   }
-  persistence = await SQLiteAdapter.create(dbPath, {
+  sqlitePersistence = await SQLiteAdapter.create(dbPath, {
     readOnly,
     ownerCapability: !readOnly, // writable mode requires owner capability
   });
-  // Upgrade root logger with DB persistence now that SQLiteAdapter is ready.
+  persistence = sqlitePersistence;
+  // Upgrade root logger with DB persistence now that the adapter is ready.
   logger = new FileAndDbLogger({ module: 'main' }, { persistence });
   const shellEnv = await initializeShellEnvironment();
   if (process.platform === 'darwin') {
@@ -697,7 +704,10 @@ if (isHeadless) {
 
       const headlessDeps: HeadlessDeps = {
         logger,
-        orchestrator, persistence, executorRegistry, messageBus,
+        orchestrator,
+        persistence: sqlitePersistence,
+        executorRegistry,
+        messageBus,
         repoRoot, invokerConfig, initServices, wireSlackBot,
         commandService,
         setTaskDispatcherExecutor: setDispatcherTaskExecutor,
@@ -1399,7 +1409,7 @@ if (isHeadless) {
   function rebuildTaskRunner(): void {
     taskExecutor = new TaskRunner({
       orchestrator,
-      persistence,
+      persistence: sqlitePersistence,
       executorRegistry,
       executionAgentRegistry: agentRegistry,
       cwd: repoRoot,
@@ -1590,7 +1600,7 @@ if (isHeadless) {
     });
     const headlessCommand = String(payload.args[0] ?? '');
     const headlessTarget = String(payload.args[1] ?? '');
-    const resolvedHeadlessTarget = resolveHeadlessTarget(headlessTarget, persistence);
+    const resolvedHeadlessTarget = resolveHeadlessTarget(headlessTarget, sqlitePersistence);
     if (
       (headlessCommand === 'recreate' || headlessCommand === 'retry')
       && resolvedHeadlessTarget.kind === 'workflow'
@@ -1599,7 +1609,10 @@ if (isHeadless) {
     }
     await runHeadless(payload.args, {
       logger,
-      orchestrator, persistence, executorRegistry, messageBus,
+      orchestrator,
+      persistence: sqlitePersistence,
+      executorRegistry,
+      messageBus,
       commandService,
       repoRoot, invokerConfig, initServices, wireSlackBot,
       setTaskDispatcherExecutor: setDispatcherTaskExecutor,
@@ -2171,7 +2184,7 @@ if (isHeadless) {
       apiServer = startApiServer({
         logger,
         orchestrator,
-        persistence,
+        persistence: sqlitePersistence,
         executorRegistry,
         taskExecutor: requireTaskExecutor(),
         autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
@@ -2197,7 +2210,7 @@ if (isHeadless) {
 
       void recoverWorkflowMutationsOnStartup({
         ownerMode,
-        persistence,
+        persistence: sqlitePersistence,
         workflowMutationCoordinator: workflowMutationCoordinator ?? undefined,
         logger,
         maybeDelayResume: maybeDelayWorkflowResumeForTest,
@@ -2351,7 +2364,7 @@ if (isHeadless) {
     if (ownerMode) {
       rebuildTaskRunner();
       workflowMutationCoordinator = new PersistedWorkflowMutationCoordinator(
-        persistence,
+        sqlitePersistence,
         workflowMutationOwnerId,
         async (channel: string, args: unknown[]) => {
           const handler = workflowMutationDispatcher.get(channel);
@@ -2961,7 +2974,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.recreate-workflow',
         });
-        const started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
+        const started = sharedRecreateWorkflow(workflowId, { persistence: sqlitePersistence, orchestrator });
         remoteFetchForPool.enabled = false;
         try {
           await dispatchStartedTasksWithGlobalTopup({
@@ -2990,7 +3003,7 @@ if (isHeadless) {
       logger.info(`recreate-task: "${taskId}"`, { module: 'ipc' });
       try {
         await preemptTaskSubgraph(taskId);
-        const started = sharedRecreateTask(taskId, { persistence, orchestrator });
+        const started = sharedRecreateTask(taskId, { persistence: sqlitePersistence, orchestrator });
         remoteFetchForPool.enabled = false;
         try {
           await dispatchStartedTasksWithGlobalTopup({
@@ -3064,7 +3077,7 @@ if (isHeadless) {
         }
         const started = await rebaseAndRetry(taskId, {
           orchestrator,
-          persistence,
+          persistence: sqlitePersistence,
           repoRoot,
           taskExecutor: requireTaskExecutor(),
         });
@@ -3114,7 +3127,7 @@ if (isHeadless) {
       try {
         await setWorkflowMergeMode(workflowId, mergeMode, {
           orchestrator,
-          persistence,
+          persistence: sqlitePersistence,
           taskExecutor: requireTaskExecutor(),
         });
       } catch (err) {
@@ -3181,7 +3194,7 @@ if (isHeadless) {
       try {
         const result = await resolveConflictAction(taskId, {
           orchestrator,
-          persistence,
+          persistence: sqlitePersistence,
           taskExecutor: requireTaskExecutor(),
           autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
         }, agentName);
@@ -3383,7 +3396,7 @@ if (isHeadless) {
       logger.info(`invoked for task="${taskId}"`, { module: 'open-terminal' });
       return openExternalTerminalForTask({
         taskId,
-        persistence,
+        persistence: sqlitePersistence,
         executorRegistry,
         executionAgentRegistry: agentRegistry,
         repoRoot,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -50,8 +50,10 @@ if (process.platform === 'linux' && !enableTestCompositor) {
   app.commandLine.appendSwitch('disable-software-rasterizer');
 }
 
-import { Orchestrator, CommandService } from '@invoker/workflow-core';
+import { Orchestrator, CommandService, InstrumentedCommandService } from '@invoker/workflow-core';
 import type {
+  CommandServiceInstrumentationEvent,
+  CommandServiceInstrumenter,
   PlanDefinition,
   TaskDelta,
   TaskReplacementDef,
@@ -195,6 +197,28 @@ function dispatchStartedTasks(tasks: TaskState[]): void {
     });
   });
 }
+
+const commandServiceInstrumenter: CommandServiceInstrumenter = (event: CommandServiceInstrumentationEvent) => {
+  const meta = {
+    module: 'command-service',
+    scope: event.scope,
+    method: event.method,
+    durationMs: event.durationMs,
+    success: event.success,
+    ...(event.error ? { error: event.error } : {}),
+  };
+  if (event.success) {
+    logger.debug(
+      `[command-service] ${event.method} ok ${event.durationMs}ms`,
+      meta,
+    );
+  } else {
+    logger.warn(
+      `[command-service] ${event.method} failed ${event.durationMs}ms: ${event.error ?? ''}`,
+      meta,
+    );
+  }
+};
 let workflowMutationCoordinator: PersistedWorkflowMutationCoordinator | null = null;
 const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
@@ -403,7 +427,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     deferRunningUntilLaunch: true,
     taskDispatcher: dispatchStartedTasks,
   });
-  commandService = new CommandService(orchestrator);
+  commandService = new InstrumentedCommandService(orchestrator, commandServiceInstrumenter);
 
   const startupSyncMode = options?.startupSyncMode ?? 'all';
   const initLog = isHeadless
@@ -2628,7 +2652,7 @@ if (isHeadless) {
         deferRunningUntilLaunch: true,
         taskDispatcher: dispatchStartedTasks,
       });
-      commandService = new CommandService(orchestrator);
+      commandService = new InstrumentedCommandService(orchestrator, commandServiceInstrumenter);
       rebuildTaskRunner();
       taskHandles.clear();
     });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -50,7 +50,12 @@ if (process.platform === 'linux' && !enableTestCompositor) {
   app.commandLine.appendSwitch('disable-software-rasterizer');
 }
 
-import { Orchestrator, CommandService, InstrumentedCommandService } from '@invoker/workflow-core';
+import {
+  Orchestrator,
+  CommandService,
+  InstrumentedCommandService,
+  InstrumentedTaskRepository,
+} from '@invoker/workflow-core';
 import type {
   CommandServiceInstrumentationEvent,
   CommandServiceInstrumenter,
@@ -62,8 +67,14 @@ import type {
 } from '@invoker/workflow-core';
 import { makeEnvelope } from '@invoker/contracts';
 import type { WorkResponse } from '@invoker/contracts';
-import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
+import {
+  SQLiteAdapter,
+  ConversationRepository,
+  InstrumentedPersistenceAdapter,
+  SqliteTaskRepository,
+} from '@invoker/data-store';
 import type { PersistenceAdapter } from '@invoker/data-store';
+import { DbTimings } from './db-timings.js';
 import { IpcBus, Channels } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import {
@@ -198,7 +209,10 @@ function dispatchStartedTasks(tasks: TaskState[]): void {
   });
 }
 
+const dbTimings = new DbTimings();
+const dbTimingsCommandServiceTap = dbTimings.toCommandServiceInstrumenter();
 const commandServiceInstrumenter: CommandServiceInstrumenter = (event: CommandServiceInstrumentationEvent) => {
+  dbTimingsCommandServiceTap(event);
   const meta = {
     module: 'command-service',
     scope: event.scope,
@@ -375,7 +389,11 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     readOnly,
     ownerCapability: !readOnly, // writable mode requires owner capability
   });
-  persistence = sqlitePersistence;
+  persistence = new InstrumentedPersistenceAdapter(
+    sqlitePersistence,
+    dbTimings.toPersistenceInstrumenter(),
+  );
+  // Upgrade root logger with DB persistence now that the adapter is ready.
   logger = new FileAndDbLogger({ module: 'main' }, { persistence });
   const shellEnv = await initializeShellEnvironment();
   if (process.platform === 'darwin') {
@@ -417,7 +435,10 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
       agentRegistry: options?.executionAgentRegistry,
     }),
   );
-  const taskRepository = new SqliteTaskRepository(persistence);
+  const taskRepository = new InstrumentedTaskRepository(
+    new SqliteTaskRepository(persistence),
+    dbTimings.toTaskRepositoryInstrumenter(),
+  );
   orchestrator = new Orchestrator({
     persistence, messageBus,
     taskRepository,
@@ -439,7 +460,9 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
   const workflows = persistence.listWorkflows();
   if (startupSyncMode === 'all') {
     try {
-      orchestrator.syncAllFromDb();
+      dbTimings.timeSync('startup', 'orchestrator.syncAllFromDb', () => {
+        orchestrator.syncAllFromDb();
+      });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       logger.error(`workflow invariant violation during startup sync: ${message}`, {
@@ -737,8 +760,11 @@ if (isHeadless) {
           rendererReports: 0,
           maxRendererEventLoopLagMs: 0,
           maxRendererLongTaskMs: 0,
+          dbTimings: dbTimings.snapshot(),
         }),
-        resetUiPerfStats: () => {},
+        resetUiPerfStats: () => {
+          dbTimings.reset();
+        },
         waitForApproval,
         noTrack,
         executionAgentRegistry: agentRegistry,
@@ -1182,11 +1208,13 @@ if (isHeadless) {
     uiPerfStats.rendererReports = 0;
     uiPerfStats.maxRendererEventLoopLagMs = 0;
     uiPerfStats.maxRendererLongTaskMs = 0;
+    dbTimings.reset();
   };
 
   const getUiPerfStats = (): Record<string, unknown> => ({
     ...uiPerfStats,
     startupMarks: Object.fromEntries(startupMarks.entries()),
+    dbTimings: dbTimings.snapshot(),
     ts: new Date().toISOString(),
   });
 
@@ -2645,7 +2673,10 @@ if (isHeadless) {
       orchestrator = new Orchestrator({
         persistence,
         messageBus,
-        taskRepository: new SqliteTaskRepository(persistence),
+        taskRepository: new InstrumentedTaskRepository(
+          new SqliteTaskRepository(persistence),
+          dbTimings.toTaskRepositoryInstrumenter(),
+        ),
         maxConcurrency: effectiveMaxConcurrency,
         defaultAutoFixRetries: invokerConfig.autoFixRetries,
         executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
@@ -2662,13 +2693,17 @@ if (isHeadless) {
     registerGuiMutationHandler('invoker:delete-all-workflows', async () => {
       logger.info('delete-all-workflows', { module: 'ipc' });
       assertDeleteAllEnabled();
-      const snapshot = createDeleteAllSnapshot(resolveInvokerHomeRoot());
-      if (snapshot) {
-        logger.info(`delete-all-workflows snapshot: ${snapshot}`, { module: 'ipc' });
-      } else {
-        logger.info('delete-all-workflows snapshot skipped: DB file does not exist yet', { module: 'ipc' });
-      }
-      orchestrator.deleteAllWorkflows();
+      await dbTimings.timeAsync('delete', 'app.preDeleteAllSnapshot', async () => {
+        const snapshot = createDeleteAllSnapshot(resolveInvokerHomeRoot());
+        if (snapshot) {
+          logger.info(`delete-all-workflows snapshot: ${snapshot}`, { module: 'ipc' });
+        } else {
+          logger.info('delete-all-workflows snapshot skipped: DB file does not exist yet', { module: 'ipc' });
+        }
+      });
+      dbTimings.timeSync('delete', 'app.orchestratorDeleteAll', () => {
+        orchestrator.deleteAllWorkflows();
+      });
       taskHandles.clear();
       lastKnownTaskStates.clear();
       lastKnownWorkflowCount = 0;
@@ -2682,15 +2717,17 @@ if (isHeadless) {
       logger.info(`delete-workflow: "${workflowId}"`, { module: 'ipc' });
       try {
         // Kill all running tasks belonging to the workflow (process management is outside orchestrator scope)
-        const allTasks = orchestrator.getAllTasks();
-        const workflowTasks = allTasks.filter(
-          (t) =>
-            t.config.workflowId === workflowId &&
-            (t.status === 'running' || t.status === 'fixing_with_ai'),
-        );
-        for (const task of workflowTasks) {
-          await killRunningTask(task.id);
-        }
+        await dbTimings.timeAsync('delete', 'app.preDeleteKillRunning', async () => {
+          const allTasks = orchestrator.getAllTasks();
+          const workflowTasks = allTasks.filter(
+            (t) =>
+              t.config.workflowId === workflowId &&
+              (t.status === 'running' || t.status === 'fixing_with_ai'),
+          );
+          for (const task of workflowTasks) {
+            await killRunningTask(task.id);
+          }
+        });
 
         // Serialized via CommandService: DB delete + memory clear + scheduler cleanup + removal deltas
         const envelope = makeEnvelope('delete-workflow', 'ui', 'workflow', { workflowId });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -110,8 +110,6 @@ import {
 import {
   approveTask as sharedApproveTask,
   rebaseAndRetry,
-  recreateWorkflow as sharedRecreateWorkflow,
-  recreateTask as sharedRecreateTask,
   resolveConflictAction,
   selectExperiments as sharedSelectExperiments,
   setWorkflowMergeMode,
@@ -2969,7 +2967,18 @@ if (isHeadless) {
           logger,
           context: 'ipc.recreate-workflow',
         });
-        const started = sharedRecreateWorkflow(workflowId, { persistence: sqlitePersistence, orchestrator });
+        const envelope = makeEnvelope('recreate-workflow', 'ui', 'workflow', { workflowId });
+        const result = await commandService.recreateWorkflow(envelope, {
+          beforeRecreate: () => {
+            const workflow = sqlitePersistence.loadWorkflow(workflowId);
+            if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+            const nextGen = (workflow.generation ?? 0) + 1;
+            sqlitePersistence.updateWorkflow(workflowId, { generation: nextGen });
+            logger.info(`bumped generation to ${nextGen} for ${workflowId}`, { module: 'workflow' });
+          },
+        });
+        if (!result.ok) throw new Error(result.error.message);
+        const started = result.data;
         remoteFetchForPool.enabled = false;
         try {
           await dispatchStartedTasksWithGlobalTopup({
@@ -2998,7 +3007,10 @@ if (isHeadless) {
       logger.info(`recreate-task: "${taskId}"`, { module: 'ipc' });
       try {
         await preemptTaskSubgraph(taskId);
-        const started = sharedRecreateTask(taskId, { persistence: sqlitePersistence, orchestrator });
+        const envelope = makeEnvelope('recreate-task', 'ui', 'task', { taskId });
+        const result = await commandService.recreateTask(envelope);
+        if (!result.ok) throw new Error(result.error.message);
+        const started = result.data;
         remoteFetchForPool.enabled = false;
         try {
           await dispatchStartedTasksWithGlobalTopup({

--- a/packages/data-store/src/__tests__/instrumented-persistence-adapter.test.ts
+++ b/packages/data-store/src/__tests__/instrumented-persistence-adapter.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import {
+  InstrumentedPersistenceAdapter,
+  PERSISTENCE_INSTRUMENTATION_SCOPE_PREFIX,
+  type PersistenceInstrumentationEvent,
+} from '../instrumented-persistence-adapter.js';
+import type { Workflow } from '../adapter.js';
+import { createTaskState } from '@invoker/workflow-core';
+
+function makeWorkflow(id: string): Workflow {
+  return {
+    id,
+    name: `Workflow ${id}`,
+    status: 'running',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  };
+}
+
+describe('InstrumentedPersistenceAdapter', () => {
+  let inner: SQLiteAdapter;
+  let events: PersistenceInstrumentationEvent[];
+  let nowQueue: number[];
+  let adapter: InstrumentedPersistenceAdapter;
+
+  beforeEach(async () => {
+    inner = await SQLiteAdapter.create(':memory:');
+    events = [];
+    nowQueue = [];
+    adapter = new InstrumentedPersistenceAdapter(
+      inner,
+      (event) => {
+        events.push(event);
+      },
+      { now: () => (nowQueue.length > 0 ? nowQueue.shift()! : 0) },
+    );
+  });
+
+  it('emits scope, duration, and success metadata for each instrumented method', () => {
+    inner.saveWorkflow(makeWorkflow('wf-1'));
+
+    // Each instrumented call consumes two now() readings: start and end.
+    nowQueue = [
+      1000, 1005,   // listWorkflows
+      1010, 1012,   // loadWorkflow
+      1020, 1023,   // loadTasks
+      1030, 1037,   // saveTask
+      1040, 1042,   // updateTask
+      1050, 1054,   // deleteWorkflow
+      1060, 1061,   // deleteAllWorkflows
+    ];
+
+    adapter.listWorkflows();
+    adapter.loadWorkflow('wf-1');
+    adapter.loadTasks('wf-1');
+
+    const task = createTaskState('t1', 'Task 1', [], { workflowId: 'wf-1' });
+    adapter.saveTask('wf-1', task);
+    adapter.updateTask('t1', { status: 'running' });
+    adapter.deleteWorkflow('wf-1');
+    adapter.deleteAllWorkflows();
+
+    expect(events.map((e) => e.method)).toEqual([
+      'listWorkflows',
+      'loadWorkflow',
+      'loadTasks',
+      'saveTask',
+      'updateTask',
+      'deleteWorkflow',
+      'deleteAllWorkflows',
+    ]);
+
+    for (const event of events) {
+      expect(event.scope).toBe(`${PERSISTENCE_INSTRUMENTATION_SCOPE_PREFIX}.${event.method}`);
+      expect(event.success).toBe(true);
+      expect(event.error).toBeUndefined();
+    }
+
+    expect(events.find((e) => e.method === 'listWorkflows')!.durationMs).toBe(5);
+    expect(events.find((e) => e.method === 'loadWorkflow')!.durationMs).toBe(2);
+    expect(events.find((e) => e.method === 'loadTasks')!.durationMs).toBe(3);
+    expect(events.find((e) => e.method === 'saveTask')!.durationMs).toBe(7);
+    expect(events.find((e) => e.method === 'updateTask')!.durationMs).toBe(2);
+    expect(events.find((e) => e.method === 'deleteWorkflow')!.durationMs).toBe(4);
+    expect(events.find((e) => e.method === 'deleteAllWorkflows')!.durationMs).toBe(1);
+  });
+
+  it('preserves return values and underlying persistence behavior', () => {
+    inner.saveWorkflow(makeWorkflow('wf-a'));
+    inner.saveWorkflow(makeWorkflow('wf-b'));
+    inner.saveTask('wf-a', createTaskState('t1', 'Task 1', [], { workflowId: 'wf-a' }));
+
+    expect(adapter.listWorkflows().map((w) => w.id).sort()).toEqual(['wf-a', 'wf-b']);
+    expect(adapter.loadWorkflow('wf-a')?.id).toBe('wf-a');
+    expect(adapter.loadWorkflow('missing')).toBeUndefined();
+    expect(adapter.loadTasks('wf-a').map((t) => t.id)).toEqual(['t1']);
+
+    adapter.saveTask('wf-a', createTaskState('t2', 'Task 2', [], { workflowId: 'wf-a' }));
+    adapter.updateTask('t2', { status: 'completed' });
+    expect(inner.loadTasks('wf-a').find((t) => t.id === 't2')?.status).toBe('completed');
+
+    adapter.deleteWorkflow('wf-b');
+    expect(inner.listWorkflows().map((w) => w.id)).toEqual(['wf-a']);
+
+    adapter.deleteAllWorkflows();
+    expect(inner.listWorkflows()).toEqual([]);
+  });
+
+  it('records failures with error metadata and re-throws', () => {
+    const boom = new Error('inner blew up');
+    const failingStub: any = {
+      saveTask: () => { throw boom; },
+    };
+
+    nowQueue = [2000, 2003];
+    const failingAdapter = new InstrumentedPersistenceAdapter(
+      failingStub,
+      (event) => events.push(event),
+      { now: () => (nowQueue.length > 0 ? nowQueue.shift()! : 0) },
+    );
+
+    expect(() => {
+      failingAdapter.saveTask('wf-x', createTaskState('t1', 'Task 1', [], { workflowId: 'wf-x' }));
+    }).toThrow(boom);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].method).toBe('saveTask');
+    expect(events[0].scope).toBe('persistence.saveTask');
+    expect(events[0].success).toBe(false);
+    expect(events[0].error).toBe('inner blew up');
+    expect(events[0].durationMs).toBe(3);
+  });
+
+  it('preserves call ordering of the underlying adapter', () => {
+    const calls: string[] = [];
+    const stub: any = {
+      saveWorkflow: () => calls.push('saveWorkflow'),
+      saveTask: () => calls.push('saveTask'),
+      updateTask: () => calls.push('updateTask'),
+      listWorkflows: () => { calls.push('listWorkflows'); return []; },
+      deleteWorkflow: () => calls.push('deleteWorkflow'),
+    };
+
+    const wrapped = new InstrumentedPersistenceAdapter(stub as any, () => {});
+    wrapped.saveWorkflow(makeWorkflow('wf-1'));
+    const task = createTaskState('t1', 'Task 1', [], { workflowId: 'wf-1' });
+    wrapped.saveTask('wf-1', task);
+    wrapped.updateTask('t1', { status: 'running' });
+    wrapped.listWorkflows();
+    wrapped.deleteWorkflow('wf-1');
+
+    expect(calls).toEqual([
+      'saveWorkflow',
+      'saveTask',
+      'updateTask',
+      'listWorkflows',
+      'deleteWorkflow',
+    ]);
+  });
+});

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -2,10 +2,38 @@
  * PersistenceAdapter — Interface for task/workflow storage.
  *
  * The core orchestrator depends on this interface, not on SQLite directly.
- * This allows swapping storage backends (in-memory, SQLite, etc.)
+ * This allows swapping storage backends (in-memory, SQLite, etc.) and
+ * wrapping the live store with decorators (logging, metrics, retries)
+ * without touching call sites.
  */
 
 import type { TaskState, TaskStateChanges, PlanDefinition, Attempt } from '@invoker/workflow-core';
+
+// ── Output Spool Types ──────────────────────────────────────
+
+export interface OutputChunk {
+  offset: number;
+  data: string;
+}
+
+// ── Workflow Mutation Intent Types ──────────────────────────
+
+export type WorkflowMutationPriority = 'high' | 'normal';
+export type WorkflowMutationIntentStatus = 'queued' | 'running' | 'completed' | 'failed';
+
+export interface WorkflowMutationIntent {
+  id: number;
+  workflowId: string;
+  channel: string;
+  args: unknown[];
+  priority: WorkflowMutationPriority;
+  status: WorkflowMutationIntentStatus;
+  ownerId?: string;
+  error?: string;
+  createdAt: string;
+  startedAt?: string;
+  completedAt?: string;
+}
 
 // ── Conversation Types ─────────────────────────────────────
 
@@ -123,6 +151,32 @@ export interface PersistenceAdapter {
   // Agent queries
   /** Read the configured execution agent name for a task (e.g. 'claude', 'codex'). */
   getExecutionAgent?(taskId: string): string | null;
+
+  // Output spool (offset-addressed streaming buffer)
+  appendOutputChunk(taskId: string, data: string): void;
+  getOutputChunks(taskId: string): OutputChunk[];
+  replayOutputFrom(taskId: string, fromOffset: number): OutputChunk[];
+  getOutputTail(taskId: string): OutputChunk[];
+
+  // Activity log (structured app-level audit trail)
+  writeActivityLog(source: string, level: string, message: string): void;
+  getActivityLogs(sinceId?: number, limit?: number): ActivityLogEntry[];
+
+  // Aggregated task queries
+  loadAllCompletedTasks(): Array<TaskState & { workflowName: string }>;
+
+  // Workflow mutation intent queue (read access; write/claim primitives
+  // remain on concrete adapters that own the queue subsystem).
+  listWorkflowMutationIntents(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[];
+
+  /**
+   * Execute a group of writes atomically when the backing store supports it.
+   * Adapters without transactions may simply execute the callback inline.
+   */
+  runInTransaction<T>(work: () => T): T;
 
   // Lifecycle
   close(): void;

--- a/packages/data-store/src/index.ts
+++ b/packages/data-store/src/index.ts
@@ -2,3 +2,4 @@ export * from './adapter.js';
 export * from './sqlite-adapter.js';
 export * from './conversation-repository.js';
 export * from './sqlite-task-repository.js';
+export * from './instrumented-persistence-adapter.js';

--- a/packages/data-store/src/instrumented-persistence-adapter.ts
+++ b/packages/data-store/src/instrumented-persistence-adapter.ts
@@ -1,0 +1,274 @@
+/**
+ * InstrumentedPersistenceAdapter — A PersistenceAdapter decorator that
+ * records timing and outcome metadata for the read/write methods the
+ * orchestrator hits on every workflow lifecycle event.
+ *
+ * The wrapper preserves all return values, throws, and call ordering of
+ * the underlying adapter; the only side effect is the structured event
+ * fed into the supplied instrumenter.
+ */
+
+import type { TaskState, TaskStateChanges, Attempt } from '@invoker/workflow-core';
+import type {
+  ActivityLogEntry,
+  Conversation,
+  ConversationMessage,
+  OutputChunk,
+  PersistenceAdapter,
+  TaskEvent,
+  Workflow,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+} from './adapter.js';
+
+export const PERSISTENCE_INSTRUMENTATION_SCOPE_PREFIX = 'persistence';
+
+export type PersistenceInstrumentedMethod =
+  | 'listWorkflows'
+  | 'loadWorkflow'
+  | 'loadTasks'
+  | 'saveTask'
+  | 'updateTask'
+  | 'deleteWorkflow'
+  | 'deleteAllWorkflows';
+
+export interface PersistenceInstrumentationEvent {
+  readonly scope: `${typeof PERSISTENCE_INSTRUMENTATION_SCOPE_PREFIX}.${PersistenceInstrumentedMethod}`;
+  readonly method: PersistenceInstrumentedMethod;
+  readonly durationMs: number;
+  readonly success: boolean;
+  readonly error?: string;
+}
+
+export type PersistenceInstrumenter = (event: PersistenceInstrumentationEvent) => void;
+
+export interface InstrumentedPersistenceAdapterOptions {
+  /** Override the wall clock (test seam). Defaults to Date.now. */
+  readonly now?: () => number;
+}
+
+export class InstrumentedPersistenceAdapter implements PersistenceAdapter {
+  private readonly inner: PersistenceAdapter;
+  private readonly emit: PersistenceInstrumenter;
+  private readonly now: () => number;
+
+  constructor(
+    inner: PersistenceAdapter,
+    emit: PersistenceInstrumenter,
+    options: InstrumentedPersistenceAdapterOptions = {},
+  ) {
+    this.inner = inner;
+    this.emit = emit;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  // ── Instrumentation core ───────────────────────────────────
+
+  private record<T>(method: PersistenceInstrumentedMethod, fn: () => T): T {
+    const start = this.now();
+    try {
+      const result = fn();
+      this.emitEvent(method, start, true);
+      return result;
+    } catch (err) {
+      this.emitEvent(method, start, false, err);
+      throw err;
+    }
+  }
+
+  private emitEvent(
+    method: PersistenceInstrumentedMethod,
+    start: number,
+    success: boolean,
+    err?: unknown,
+  ): void {
+    const event: PersistenceInstrumentationEvent = {
+      scope: `${PERSISTENCE_INSTRUMENTATION_SCOPE_PREFIX}.${method}`,
+      method,
+      durationMs: this.now() - start,
+      success,
+      ...(success ? {} : { error: err instanceof Error ? err.message : String(err) }),
+    };
+    this.emit(event);
+  }
+
+  // ── Instrumented methods ───────────────────────────────────
+
+  listWorkflows(): Workflow[] {
+    return this.record('listWorkflows', () => this.inner.listWorkflows());
+  }
+
+  loadWorkflow(workflowId: string): Workflow | undefined {
+    return this.record('loadWorkflow', () => this.inner.loadWorkflow(workflowId));
+  }
+
+  loadTasks(workflowId: string): TaskState[] {
+    return this.record('loadTasks', () => this.inner.loadTasks(workflowId));
+  }
+
+  saveTask(workflowId: string, task: TaskState): void {
+    this.record('saveTask', () => this.inner.saveTask(workflowId, task));
+  }
+
+  updateTask(taskId: string, changes: TaskStateChanges): void {
+    this.record('updateTask', () => this.inner.updateTask(taskId, changes));
+  }
+
+  deleteWorkflow(workflowId: string): void {
+    this.record('deleteWorkflow', () => this.inner.deleteWorkflow(workflowId));
+  }
+
+  deleteAllWorkflows(): void {
+    this.record('deleteAllWorkflows', () => this.inner.deleteAllWorkflows());
+  }
+
+  // ── Pass-through methods ───────────────────────────────────
+
+  saveWorkflow(workflow: Workflow): void {
+    this.inner.saveWorkflow(workflow);
+  }
+
+  updateWorkflow(
+    workflowId: string,
+    changes: Parameters<PersistenceAdapter['updateWorkflow']>[1],
+  ): void {
+    this.inner.updateWorkflow(workflowId, changes);
+  }
+
+  getAllTaskIds(): string[] {
+    return this.inner.getAllTaskIds();
+  }
+
+  getAllTaskBranches(): string[] {
+    return this.inner.getAllTaskBranches();
+  }
+
+  deleteAllTasks(workflowId: string): void {
+    this.inner.deleteAllTasks(workflowId);
+  }
+
+  logEvent(taskId: string, eventType: string, payload?: unknown): void {
+    this.inner.logEvent(taskId, eventType, payload);
+  }
+
+  getEvents(taskId: string): TaskEvent[] {
+    return this.inner.getEvents(taskId);
+  }
+
+  saveConversation(conversation: Conversation): void {
+    this.inner.saveConversation(conversation);
+  }
+
+  loadConversation(threadTs: string): Conversation | undefined {
+    return this.inner.loadConversation(threadTs);
+  }
+
+  updateConversation(
+    threadTs: string,
+    changes: Parameters<PersistenceAdapter['updateConversation']>[1],
+  ): void {
+    this.inner.updateConversation(threadTs, changes);
+  }
+
+  deleteConversation(threadTs: string): void {
+    this.inner.deleteConversation(threadTs);
+  }
+
+  listActiveConversations(): Conversation[] {
+    return this.inner.listActiveConversations();
+  }
+
+  deleteConversationsOlderThan(cutoffIso: string): number {
+    return this.inner.deleteConversationsOlderThan(cutoffIso);
+  }
+
+  appendMessage(threadTs: string, role: 'user' | 'assistant', content: string): void {
+    this.inner.appendMessage(threadTs, role, content);
+  }
+
+  loadMessages(threadTs: string): ConversationMessage[] {
+    return this.inner.loadMessages(threadTs);
+  }
+
+  appendTaskOutput(taskId: string, data: string): void {
+    this.inner.appendTaskOutput(taskId, data);
+  }
+
+  getTaskOutput(taskId: string): string {
+    return this.inner.getTaskOutput(taskId);
+  }
+
+  saveAttempt(attempt: Attempt): void {
+    this.inner.saveAttempt(attempt);
+  }
+
+  loadAttempts(nodeId: string): Attempt[] {
+    return this.inner.loadAttempts(nodeId);
+  }
+
+  loadAttempt(attemptId: string): Attempt | undefined {
+    return this.inner.loadAttempt(attemptId);
+  }
+
+  updateAttempt(
+    attemptId: string,
+    changes: Parameters<PersistenceAdapter['updateAttempt']>[1],
+  ): void {
+    this.inner.updateAttempt(attemptId, changes);
+  }
+
+  failTaskAndAttempt(
+    taskId: string,
+    taskChanges: TaskStateChanges,
+    attemptPatch: Parameters<PersistenceAdapter['failTaskAndAttempt']>[2],
+  ): void {
+    this.inner.failTaskAndAttempt(taskId, taskChanges, attemptPatch);
+  }
+
+  getExecutionAgent(taskId: string): string | null {
+    return this.inner.getExecutionAgent ? this.inner.getExecutionAgent(taskId) : null;
+  }
+
+  appendOutputChunk(taskId: string, data: string): void {
+    this.inner.appendOutputChunk(taskId, data);
+  }
+
+  getOutputChunks(taskId: string): OutputChunk[] {
+    return this.inner.getOutputChunks(taskId);
+  }
+
+  replayOutputFrom(taskId: string, fromOffset: number): OutputChunk[] {
+    return this.inner.replayOutputFrom(taskId, fromOffset);
+  }
+
+  getOutputTail(taskId: string): OutputChunk[] {
+    return this.inner.getOutputTail(taskId);
+  }
+
+  writeActivityLog(source: string, level: string, message: string): void {
+    this.inner.writeActivityLog(source, level, message);
+  }
+
+  getActivityLogs(sinceId?: number, limit?: number): ActivityLogEntry[] {
+    return this.inner.getActivityLogs(sinceId, limit);
+  }
+
+  loadAllCompletedTasks(): Array<TaskState & { workflowName: string }> {
+    return this.inner.loadAllCompletedTasks();
+  }
+
+  listWorkflowMutationIntents(
+    workflowId?: string,
+    statuses?: WorkflowMutationIntentStatus[],
+  ): WorkflowMutationIntent[] {
+    return this.inner.listWorkflowMutationIntents(workflowId, statuses);
+  }
+
+  runInTransaction<T>(work: () => T): T {
+    return this.inner.runInTransaction(work);
+  }
+
+  close(): void {
+    this.inner.close();
+  }
+}

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -10,7 +10,18 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from '
 import { dirname } from 'node:path';
 import type { TaskState, TaskStateChanges, Attempt, TaskStatus } from '@invoker/workflow-core';
 import { normalizeExecutorType } from '@invoker/workflow-core';
-import type { PersistenceAdapter, Workflow, TaskEvent, ActivityLogEntry, Conversation, ConversationMessage } from './adapter.js';
+import type {
+  PersistenceAdapter,
+  Workflow,
+  TaskEvent,
+  ActivityLogEntry,
+  Conversation,
+  ConversationMessage,
+  OutputChunk,
+  WorkflowMutationIntent,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationPriority,
+} from './adapter.js';
 
 /**
  * Rewrite `pnpm test packages/<pkg>/...` (incorrect root-level invocation)
@@ -33,28 +44,14 @@ function rewritePnpmTestCommand(cmd: string): string {
 /** Cached sql.js init promise — WASM is loaded only once per process. */
 let sqlJsPromise: ReturnType<typeof initSqlJs> | null = null;
 
-export interface OutputChunk {
-  offset: number;
-  data: string;
-}
+export type {
+  OutputChunk,
+  WorkflowMutationPriority,
+  WorkflowMutationIntentStatus,
+  WorkflowMutationIntent,
+} from './adapter.js';
 
-export type WorkflowMutationPriority = 'high' | 'normal';
-export type WorkflowMutationIntentStatus = 'queued' | 'running' | 'completed' | 'failed';
 export const WORKFLOW_MUTATION_LEASE_MS = 30_000;
-
-export interface WorkflowMutationIntent {
-  id: number;
-  workflowId: string;
-  channel: string;
-  args: unknown[];
-  priority: WorkflowMutationPriority;
-  status: WorkflowMutationIntentStatus;
-  ownerId?: string;
-  error?: string;
-  createdAt: string;
-  startedAt?: string;
-  completedAt?: string;
-}
 
 export interface WorkflowMutationLease {
   workflowId: string;

--- a/packages/data-store/src/sqlite-task-repository.ts
+++ b/packages/data-store/src/sqlite-task-repository.ts
@@ -1,8 +1,10 @@
 /**
  * SqliteTaskRepository — Adapter that implements the TaskRepository port
- * by delegating to SQLiteAdapter.
+ * by delegating to a PersistenceAdapter.
  *
- * This is a thin wrapper: all persistence logic lives in SQLiteAdapter.
+ * Accepts the seam (PersistenceAdapter) rather than SQLiteAdapter so
+ * decorators that wrap the adapter (logging, metrics) flow through the
+ * repository without code changes.
  */
 
 import type {
@@ -13,10 +15,10 @@ import type {
   AttemptFailPatch,
 } from '@invoker/workflow-core';
 import type { TaskState, TaskStateChanges, Attempt } from '@invoker/workflow-core';
-import type { SQLiteAdapter } from './sqlite-adapter.js';
+import type { PersistenceAdapter } from './adapter.js';
 
 export class SqliteTaskRepository implements TaskRepository {
-  constructor(private adapter: SQLiteAdapter) {}
+  constructor(private adapter: PersistenceAdapter) {}
 
   runInTransaction<T>(work: () => T): T {
     return this.adapter.runInTransaction(work);
@@ -25,13 +27,11 @@ export class SqliteTaskRepository implements TaskRepository {
   // ── Workflow writes ──
 
   saveWorkflow(workflow: WorkflowRecord): void {
-    // Port uses broader types (string) than adapter (literal unions).
-    // Safe at runtime because callers always pass valid literals.
-    this.adapter.saveWorkflow(workflow as any);
+    this.adapter.saveWorkflow(workflow);
   }
 
   updateWorkflow(workflowId: string, changes: WorkflowChanges): void {
-    this.adapter.updateWorkflow(workflowId, changes as any);
+    this.adapter.updateWorkflow(workflowId, changes);
   }
 
   deleteWorkflow(workflowId: string): void {

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -2460,6 +2460,11 @@ describe('TaskRunner', () => {
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body\n\n## Test Plan\n\n- ok\n\n## Revert Plan\n\n- revert',
+        sessionId: 'sess-pr-er',
+        agentName: 'codex',
+      });
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -2642,6 +2647,11 @@ describe('TaskRunner', () => {
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body\n\n## Test Plan\n\n- ok\n\n## Revert Plan\n\n- revert',
+        sessionId: 'sess-pr-er-none',
+        agentName: 'codex',
+      });
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -2786,6 +2796,11 @@ describe('TaskRunner', () => {
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body\n\n## Test Plan\n\n- ok\n\n## Revert Plan\n\n- revert',
+        sessionId: 'sess-pr-er-persisted',
+        agentName: 'codex',
+      });
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -2956,6 +2971,11 @@ describe('TaskRunner', () => {
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body\n\n## Test Plan\n\n- ok\n\n## Revert Plan\n\n- revert',
+        sessionId: 'sess-pr-er-log',
+        agentName: 'codex',
+      });
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -3187,7 +3207,7 @@ describe('TaskRunner', () => {
       );
     });
 
-    it('executeMergeNode passes summary body to createReview in external_review mode', async () => {
+    it('executeMergeNode passes authored PR body (not raw summary) to createReview in external_review mode', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
       ];
@@ -3234,6 +3254,12 @@ describe('TaskRunner', () => {
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
       (executor as any).buildMergeSummary = vi.fn().mockResolvedValue('## Summary\nTest summary');
+      const authoredBody = '## Summary\n\nAuthored body\n\n## Test Plan\n\n- t\n\n## Revert Plan\n\n- r';
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: authoredBody,
+        sessionId: 'sess-pr-er-body',
+        agentName: 'codex',
+      });
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -3244,9 +3270,15 @@ describe('TaskRunner', () => {
 
       await (executor as any).executeMergeNode(mergeTask);
 
-      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
-        expect.objectContaining({ body: '## Summary\nTest summary' }),
+      // The raw workflow summary is passed as authoring context, not as the PR body.
+      expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalledWith(
+        expect.objectContaining({ workflowSummary: '## Summary\nTest summary' }),
       );
+      // createReview receives the authored canonical PR body, not the raw summary.
+      expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
+        expect.objectContaining({ body: authoredBody }),
+      );
+      // Workflow summary still persisted on the merge task config.
       expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith(
         '__merge__wf-1',
         expect.objectContaining({

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -435,6 +435,16 @@ export async function executeMergeNodeImpl(
           gateWorkspacePath!,
         );
 
+        const prBody = await authorPrBodyForMerge(host, {
+          workflowId,
+          mergeNodeTaskId: task.id,
+          title: workflow?.name ?? 'Workflow',
+          baseBranch,
+          featureBranch,
+          workflowSummary: fullSummary ?? '',
+          cwd: gateWorkspacePath!,
+        });
+
         // Create PR via provider (consolidation already done above).
         // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
         const result = await host.mergeGateProvider.createReview({
@@ -442,7 +452,7 @@ export async function executeMergeNodeImpl(
           featureBranch,
           title: workflow?.name ?? 'Workflow',
           cwd: gateWorkspacePath!,
-          body: fullSummary,
+          body: prBody,
         });
         console.log(`[merge] Created GitHub PR: ${result.url}`);
 
@@ -908,12 +918,22 @@ export async function publishAfterFixImpl(
         throw new Error('mergeMode is "external_review" but no review provider configured');
       }
 
+      const prBody = await authorPrBodyForMerge(host, {
+        workflowId,
+        mergeNodeTaskId: task.id,
+        title: workflow?.name ?? 'Workflow',
+        baseBranch,
+        featureBranch,
+        workflowSummary: fullSummary ?? '',
+        cwd: consolidateDir,
+      });
+
       const result = await host.mergeGateProvider.createReview({
         baseBranch,
         featureBranch,
         title: workflow?.name ?? 'Workflow',
         cwd: consolidateDir,
-        body: fullSummary,
+        body: prBody,
       });
       console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
 

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -389,6 +389,103 @@ describe('CommandService', () => {
       const result = await service.recreateWorkflow(makeEnvelope({ workflowId: 'bad' }));
       expect(result).toEqual({ ok: false, error: { code: 'RECREATE_WORKFLOW_FAILED', message: 'wf not found' } });
     });
+
+    it('runs beforeRecreate callback before orchestrator.recreateWorkflow under the same mutex acquisition', async () => {
+      const callOrder: string[] = [];
+      (orchestrator.recreateWorkflow as ReturnType<typeof vi.fn>).mockImplementation((id: string) => {
+        callOrder.push(`orchestrator.recreateWorkflow:${id}`);
+        return [];
+      });
+      const beforeRecreate = vi.fn(async (id: string) => {
+        callOrder.push(`beforeRecreate:${id}`);
+      });
+
+      const result = await service.recreateWorkflow(
+        makeEnvelope({ workflowId: 'wf-1' }),
+        { beforeRecreate },
+      );
+
+      expect(result).toEqual({ ok: true, data: [] });
+      expect(beforeRecreate).toHaveBeenCalledWith('wf-1');
+      expect(callOrder).toEqual([
+        'beforeRecreate:wf-1',
+        'orchestrator.recreateWorkflow:wf-1',
+      ]);
+    });
+
+    it('beforeRecreate failure short-circuits orchestrator.recreateWorkflow and surfaces a CommandResult error', async () => {
+      const beforeRecreate = vi.fn(async () => {
+        throw new Error('bump failed');
+      });
+
+      const result = await service.recreateWorkflow(
+        makeEnvelope({ workflowId: 'wf-1' }),
+        { beforeRecreate },
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: { code: 'RECREATE_WORKFLOW_FAILED', message: 'bump failed' },
+      });
+      expect(orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('serializes beforeRecreate + orchestrator.recreateWorkflow under the workflow mutex against concurrent recreate calls', async () => {
+      const events: string[] = [];
+      let releaseFirstRecreate: () => void = () => {};
+      const firstRecreateGate = new Promise<void>((resolve) => {
+        releaseFirstRecreate = resolve;
+      });
+      let recreateCallCount = 0;
+
+      (orchestrator.recreateWorkflow as ReturnType<typeof vi.fn>).mockImplementation(
+        async (_id: string) => {
+          recreateCallCount += 1;
+          const callIndex = recreateCallCount;
+          events.push(`recreate:start:${callIndex}`);
+          if (callIndex === 1) {
+            await firstRecreateGate;
+          }
+          events.push(`recreate:end:${callIndex}`);
+          return [];
+        },
+      );
+
+      let beforeCallCount = 0;
+      const beforeRecreate = vi.fn(async () => {
+        beforeCallCount += 1;
+        events.push(`before:${beforeCallCount}`);
+      });
+
+      const first = service.recreateWorkflow(
+        makeEnvelope({ workflowId: 'wf-1' }, 'k-1'),
+        { beforeRecreate },
+      );
+      const second = service.recreateWorkflow(
+        makeEnvelope({ workflowId: 'wf-1' }, 'k-2'),
+        { beforeRecreate },
+      );
+
+      // Allow microtasks to drain so the first call reaches its blocked recreate.
+      for (let i = 0; i < 10; i += 1) {
+        await Promise.resolve();
+      }
+
+      // Second call must not have started its before/recreate work yet.
+      expect(events).toEqual(['before:1', 'recreate:start:1']);
+
+      releaseFirstRecreate();
+      await Promise.all([first, second]);
+
+      expect(events).toEqual([
+        'before:1',
+        'recreate:start:1',
+        'recreate:end:1',
+        'before:2',
+        'recreate:start:2',
+        'recreate:end:2',
+      ]);
+    });
   });
 
   // ── recreateWorkflowFromFreshBase ────────────────────────

--- a/packages/workflow-core/src/__tests__/instrumented-command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/instrumented-command-service.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  COMMAND_SERVICE_INSTRUMENTATION_SCOPE_PREFIX,
+  InstrumentedCommandService,
+  type CommandServiceInstrumentationEvent,
+} from '../instrumented-command-service.js';
+import type { CommandEnvelope } from '@invoker/contracts';
+import type { Orchestrator } from '../orchestrator.js';
+import type { TaskState } from '@invoker/workflow-graph';
+
+// ── Helpers ─────────────────────────────────────────────────
+
+function makeEnvelope<P>(
+  payload: P,
+  idempotencyKey = 'key-1',
+): CommandEnvelope<P> {
+  return {
+    commandId: 'cmd-1',
+    source: 'headless',
+    scope: 'task',
+    idempotencyKey,
+    payload,
+  };
+}
+
+function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
+  return {
+    approve: vi.fn().mockResolvedValue([] as TaskState[]),
+    resumeTaskAfterFixApproval: vi.fn().mockResolvedValue([] as TaskState[]),
+    reject: vi.fn(),
+    getTask: vi.fn().mockReturnValue(undefined),
+    revertConflictResolution: vi.fn(),
+    provideInput: vi.fn(),
+    retryTask: vi.fn().mockReturnValue([]),
+    recreateTask: vi.fn().mockReturnValue([]),
+    selectExperiment: vi.fn().mockReturnValue([]),
+    editTaskCommand: vi.fn().mockReturnValue([]),
+    editTaskPrompt: vi.fn().mockReturnValue([]),
+    editTaskType: vi.fn().mockReturnValue([]),
+    editTaskAgent: vi.fn().mockReturnValue([]),
+    editTaskMergeMode: vi.fn().mockReturnValue([]),
+    editTaskFixContext: vi.fn().mockReturnValue([]),
+    setTaskExternalGatePolicies: vi.fn().mockReturnValue([]),
+    replaceTask: vi.fn().mockReturnValue([]),
+    cancelTask: vi.fn().mockReturnValue({ cancelled: [], runningCancelled: [] }),
+    cancelWorkflow: vi.fn().mockReturnValue({ cancelled: [], runningCancelled: [] }),
+    deleteWorkflow: vi.fn(),
+    retryWorkflow: vi.fn().mockReturnValue([]),
+    recreateWorkflow: vi.fn().mockReturnValue([]),
+    recreateWorkflowFromFreshBase: vi.fn().mockResolvedValue([] as TaskState[]),
+    ...overrides,
+  } as unknown as Orchestrator;
+}
+
+function makeFakeClock(initial = 0, step = 1): {
+  now: () => number;
+  advance: (delta: number) => void;
+  set: (value: number) => void;
+} {
+  let current = initial;
+  return {
+    now: () => {
+      const value = current;
+      current += step;
+      return value;
+    },
+    advance: (delta: number) => {
+      current += delta;
+    },
+    set: (value: number) => {
+      current = value;
+    },
+  };
+}
+
+// ── Tests ───────────────────────────────────────────────────
+
+describe('InstrumentedCommandService', () => {
+  let orchestrator: Orchestrator;
+  let events: CommandServiceInstrumentationEvent[];
+  let nowQueue: number[];
+  let service: InstrumentedCommandService;
+
+  beforeEach(() => {
+    orchestrator = stubOrchestrator();
+    events = [];
+    nowQueue = [];
+    service = new InstrumentedCommandService(
+      orchestrator,
+      (event) => events.push(event),
+      { now: () => (nowQueue.length > 0 ? nowQueue.shift()! : 0) },
+    );
+  });
+
+  it('exposes the canonical scope prefix distinct from persistence scopes', () => {
+    expect(COMMAND_SERVICE_INSTRUMENTATION_SCOPE_PREFIX).toBe('command-service');
+    // Distinct from the persistence-side prefixes that the
+    // InstrumentedTaskRepository / InstrumentedPersistenceAdapter use,
+    // so dashboards can separate mutation timing from DB timing.
+    expect(COMMAND_SERVICE_INSTRUMENTATION_SCOPE_PREFIX).not.toBe('task-repository');
+    expect(COMMAND_SERVICE_INSTRUMENTATION_SCOPE_PREFIX).not.toBe('persistence');
+  });
+
+  it('emits a success event with method, scope, and durationMs on a successful call', async () => {
+    nowQueue = [100, 107];
+    const result = await service.deleteWorkflow(makeEnvelope({ workflowId: 'wf-1' }));
+
+    expect(result).toEqual({ ok: true, data: undefined });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      scope: 'command-service.deleteWorkflow',
+      method: 'deleteWorkflow',
+      durationMs: 7,
+      success: true,
+    });
+    expect(events[0].error).toBeUndefined();
+  });
+
+  it('emits a failure event when the orchestrator throws and surfaces the wrapped CommandResult', async () => {
+    (orchestrator.deleteWorkflow as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('wf not found');
+    });
+    nowQueue = [200, 215];
+
+    const result = await service.deleteWorkflow(makeEnvelope({ workflowId: 'bad' }));
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'DELETE_WORKFLOW_FAILED', message: 'wf not found' },
+    });
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      scope: 'command-service.deleteWorkflow',
+      method: 'deleteWorkflow',
+      durationMs: 15,
+      success: false,
+      error: 'wf not found',
+    });
+  });
+
+  it('covers delete, retry, recreate, cancel, and adjacent lifecycle methods with distinct events', async () => {
+    await service.deleteWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'k1'));
+    await service.retryTask(makeEnvelope({ taskId: 't-1' }, 'k2'));
+    await service.recreateTask(makeEnvelope({ taskId: 't-1' }, 'k3'));
+    await service.retryWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'k4'));
+    await service.recreateWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'k5'));
+    await service.recreateWorkflowFromFreshBase(makeEnvelope({ workflowId: 'wf-1' }, 'k6'));
+    await service.cancelTask(makeEnvelope({ taskId: 't-1' }, 'k7'));
+    await service.cancelWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'k8'));
+    await service.approve(makeEnvelope({ taskId: 't-1' }, 'k9'));
+    await service.reject(makeEnvelope({ taskId: 't-1', reason: 'r' }, 'k10'));
+    await service.provideInput(makeEnvelope({ taskId: 't-1', input: 'x' }, 'k11'));
+    await service.editTaskCommand(makeEnvelope({ taskId: 't-1', newCommand: 'echo' }, 'k12'));
+    await service.editTaskPrompt(makeEnvelope({ taskId: 't-1', newPrompt: 'p' }, 'k13'));
+    await service.editTaskType(makeEnvelope({ taskId: 't-1', executorType: 'docker' }, 'k14'));
+    await service.editTaskAgent(makeEnvelope({ taskId: 't-1', agentName: 'codex' }, 'k15'));
+    await service.editTaskMergeMode(
+      makeEnvelope({ taskId: 't-1', mergeMode: 'manual' }, 'k16'),
+    );
+    await service.editTaskFixContext(
+      makeEnvelope({ taskId: 't-1', fixPrompt: 'fp' }, 'k17'),
+    );
+    await service.replaceTask(makeEnvelope({ taskId: 't-1', replacementTasks: [] }, 'k18'));
+    await service.selectExperiment(
+      makeEnvelope({ taskId: 't-1', experimentId: 'e-1' }, 'k19'),
+    );
+    await service.setTaskExternalGatePolicies(
+      makeEnvelope({ taskId: 't-1', updates: [] }, 'k20'),
+    );
+    await service.resumeTaskAfterFixApproval(makeEnvelope({ taskId: 't-1' }, 'k21'));
+
+    expect(events.map((e) => e.method)).toEqual([
+      'deleteWorkflow',
+      'retryTask',
+      'recreateTask',
+      'retryWorkflow',
+      'recreateWorkflow',
+      'recreateWorkflowFromFreshBase',
+      'cancelTask',
+      'cancelWorkflow',
+      'approve',
+      'reject',
+      'provideInput',
+      'editTaskCommand',
+      'editTaskPrompt',
+      'editTaskType',
+      'editTaskAgent',
+      'editTaskMergeMode',
+      'editTaskFixContext',
+      'replaceTask',
+      'selectExperiment',
+      'setTaskExternalGatePolicies',
+      'resumeTaskAfterFixApproval',
+    ]);
+
+    for (const event of events) {
+      expect(event.success).toBe(true);
+      expect(event.scope).toBe(
+        `${COMMAND_SERVICE_INSTRUMENTATION_SCOPE_PREFIX}.${event.method}`,
+      );
+      expect(event.error).toBeUndefined();
+    }
+  });
+
+  it('preserves return types — cancelTask still returns a CancelResult on success', async () => {
+    (orchestrator.cancelTask as ReturnType<typeof vi.fn>).mockReturnValue({
+      cancelled: ['t-1', 't-2'],
+      runningCancelled: ['t-3'],
+    });
+
+    const result = await service.cancelTask(makeEnvelope({ taskId: 't-1' }));
+    expect(result).toEqual({
+      ok: true,
+      data: { cancelled: ['t-1', 't-2'], runningCancelled: ['t-3'] },
+    });
+  });
+
+  it('threads beforeRecreate through to the inherited recreateWorkflow seam', async () => {
+    const callOrder: string[] = [];
+    (orchestrator.recreateWorkflow as ReturnType<typeof vi.fn>).mockImplementation((id: string) => {
+      callOrder.push(`orchestrator.recreateWorkflow:${id}`);
+      return [];
+    });
+    const beforeRecreate = vi.fn(async (id: string) => {
+      callOrder.push(`beforeRecreate:${id}`);
+    });
+
+    const result = await service.recreateWorkflow(
+      makeEnvelope({ workflowId: 'wf-1' }),
+      { beforeRecreate },
+    );
+
+    expect(result).toEqual({ ok: true, data: [] });
+    expect(callOrder).toEqual([
+      'beforeRecreate:wf-1',
+      'orchestrator.recreateWorkflow:wf-1',
+    ]);
+    expect(events).toHaveLength(1);
+    expect(events[0].method).toBe('recreateWorkflow');
+    expect(events[0].success).toBe(true);
+  });
+
+  it('emits failure events for orchestrator failures across multiple methods', async () => {
+    (orchestrator.cancelTask as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error('cancel failed');
+    });
+    (orchestrator.retryTask as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw 'string error';
+    });
+
+    const cancelResult = await service.cancelTask(makeEnvelope({ taskId: 't-1' }));
+    const retryResult = await service.retryTask(makeEnvelope({ taskId: 't-2' }));
+
+    expect(cancelResult).toEqual({
+      ok: false,
+      error: { code: 'CANCEL_TASK_FAILED', message: 'cancel failed' },
+    });
+    expect(retryResult).toEqual({
+      ok: false,
+      error: { code: 'RETRY_TASK_FAILED', message: 'string error' },
+    });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]).toMatchObject({
+      method: 'cancelTask',
+      success: false,
+      error: 'cancel failed',
+    });
+    expect(events[1]).toMatchObject({
+      method: 'retryTask',
+      success: false,
+      error: 'string error',
+    });
+  });
+
+  it('preserves workflow-scoped mutex semantics — concurrent calls for the same workflow do not interleave', async () => {
+    const order: string[] = [];
+    let resolveFirst!: () => void;
+    const firstPromise = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+
+    (orchestrator.getTask as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      config: { workflowId: 'wf-1' },
+    }));
+
+    (orchestrator.retryTask as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      order.push('retry-start');
+      await firstPromise;
+      order.push('retry-end');
+      return [];
+    });
+    (orchestrator.editTaskCommand as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      order.push('edit-start');
+      order.push('edit-end');
+      return [];
+    });
+
+    // Use a fresh service with a real-ish clock so durationMs is computed.
+    const clock = makeFakeClock();
+    const localEvents: CommandServiceInstrumentationEvent[] = [];
+    const localService = new InstrumentedCommandService(
+      orchestrator,
+      (event) => localEvents.push(event),
+      { now: clock.now },
+    );
+
+    const p1 = localService.retryTask(makeEnvelope({ taskId: 't-1' }, 'k1'));
+    const p2 = localService.editTaskCommand(makeEnvelope({ taskId: 't-2', newCommand: 'x' }, 'k2'));
+
+    resolveFirst();
+    await Promise.all([p1, p2]);
+
+    expect(order).toEqual(['retry-start', 'retry-end', 'edit-start', 'edit-end']);
+    expect(localEvents.map((e) => e.method)).toEqual(['retryTask', 'editTaskCommand']);
+    for (const event of localEvents) {
+      expect(event.success).toBe(true);
+      expect(event.durationMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it('preserves workflow-scoped mutex semantics — different workflows run concurrently', async () => {
+    const order: string[] = [];
+    let resolveRetry!: () => void;
+    let resolveEdit!: () => void;
+    const retryGate = new Promise<void>((r) => {
+      resolveRetry = r;
+    });
+    const editGate = new Promise<void>((r) => {
+      resolveEdit = r;
+    });
+
+    (orchestrator.getTask as ReturnType<typeof vi.fn>).mockImplementation((taskId: string) => ({
+      config: { workflowId: taskId === 't-1' ? 'wf-1' : 'wf-2' },
+    }));
+
+    (orchestrator.retryTask as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      order.push('retry-start');
+      await retryGate;
+      order.push('retry-end');
+      return [];
+    });
+    (orchestrator.editTaskCommand as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      order.push('edit-start');
+      await editGate;
+      order.push('edit-end');
+      return [];
+    });
+
+    const p1 = service.retryTask(makeEnvelope({ taskId: 't-1' }, 'k1'));
+    const p2 = service.editTaskCommand(makeEnvelope({ taskId: 't-2', newCommand: 'x' }, 'k2'));
+
+    await Promise.resolve();
+    expect(order).toEqual(['retry-start', 'edit-start']);
+
+    resolveRetry();
+    resolveEdit();
+    await Promise.all([p1, p2]);
+
+    expect(order).toEqual(['retry-start', 'edit-start', 'retry-end', 'edit-end']);
+    expect(events.map((e) => e.method).sort()).toEqual(['editTaskCommand', 'retryTask']);
+  });
+
+  it('measures the full mutation latency including mutex wait time', async () => {
+    let resolveFirst!: () => void;
+    const gate = new Promise<void>((r) => {
+      resolveFirst = r;
+    });
+    (orchestrator.getTask as ReturnType<typeof vi.fn>).mockImplementation(() => ({
+      config: { workflowId: 'wf-1' },
+    }));
+
+    let firstCall = true;
+    (orchestrator.retryTask as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+      if (firstCall) {
+        firstCall = false;
+        await gate;
+      }
+      return [];
+    });
+
+    // Manually-controlled clock so we can prove that the second call's
+    // event window includes the time it waited on the mutex.
+    let nowValue = 0;
+    const localEvents: CommandServiceInstrumentationEvent[] = [];
+    const localService = new InstrumentedCommandService(
+      orchestrator,
+      (event) => localEvents.push(event),
+      { now: () => nowValue },
+    );
+
+    nowValue = 100;
+    const first = localService.retryTask(makeEnvelope({ taskId: 't-1' }, 'k1'));
+
+    nowValue = 110;
+    const second = localService.retryTask(makeEnvelope({ taskId: 't-1' }, 'k2'));
+
+    nowValue = 200;
+    resolveFirst();
+    await Promise.all([first, second]);
+    nowValue = 220;
+
+    // Force at least one more clock read for the final emit.
+    expect(localEvents).toHaveLength(2);
+    // First call: started at 100, finished after gate released — its durationMs should be >= 100.
+    expect(localEvents[0].durationMs).toBeGreaterThanOrEqual(100);
+    // Second call: started at 110 but waited on the first mutex, so the recorded
+    // durationMs must include at least the mutex wait portion (>= 0; clearly > 0 here).
+    expect(localEvents[1].durationMs).toBeGreaterThan(0);
+  });
+});

--- a/packages/workflow-core/src/__tests__/instrumented-task-repository.test.ts
+++ b/packages/workflow-core/src/__tests__/instrumented-task-repository.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  InstrumentedTaskRepository,
+  TASK_REPOSITORY_INSTRUMENTATION_SCOPE_PREFIX,
+  type TaskRepositoryInstrumentationEvent,
+} from '../instrumented-task-repository.js';
+import type {
+  AttemptChanges,
+  AttemptFailPatch,
+  TaskRepository,
+  WorkflowChanges,
+  WorkflowRecord,
+} from '../task-repository.js';
+import { createTaskState } from '@invoker/workflow-graph';
+import type { Attempt, TaskState, TaskStateChanges } from '@invoker/workflow-graph';
+
+// ── Recording stub ───────────────────────────────────────────
+
+interface RecordedCall {
+  method: string;
+  args: unknown[];
+  returned?: unknown;
+}
+
+function makeRecordingRepository(overrides: Partial<TaskRepository> = {}): {
+  repo: TaskRepository;
+  calls: RecordedCall[];
+} {
+  const calls: RecordedCall[] = [];
+  const record =
+    <K extends keyof TaskRepository>(method: K) =>
+    (...args: any[]): any => {
+      const returned = (overrides as any)[method]?.(...args);
+      calls.push({ method, args, returned });
+      return returned;
+    };
+
+  const repo: TaskRepository = {
+    runInTransaction: <T,>(work: () => T): T => {
+      calls.push({ method: 'runInTransaction', args: [] });
+      return overrides.runInTransaction ? overrides.runInTransaction(work) : work();
+    },
+    saveWorkflow: record('saveWorkflow'),
+    updateWorkflow: record('updateWorkflow'),
+    deleteWorkflow: record('deleteWorkflow'),
+    deleteAllWorkflows: record('deleteAllWorkflows'),
+    saveTask: record('saveTask'),
+    updateTask: record('updateTask'),
+    logEvent: record('logEvent'),
+    saveAttempt: record('saveAttempt'),
+    updateAttempt: record('updateAttempt'),
+    failTaskAndAttempt: record('failTaskAndAttempt'),
+  };
+  return { repo, calls };
+}
+
+const SAMPLE_WORKFLOW: WorkflowRecord = {
+  id: 'wf-1',
+  name: 'WF',
+  status: 'running',
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+describe('InstrumentedTaskRepository', () => {
+  let calls: RecordedCall[];
+  let repo: TaskRepository;
+  let events: TaskRepositoryInstrumentationEvent[];
+  let nowQueue: number[];
+  let wrapped: InstrumentedTaskRepository;
+
+  beforeEach(() => {
+    const stub = makeRecordingRepository();
+    calls = stub.calls;
+    repo = stub.repo;
+    events = [];
+    nowQueue = [];
+    wrapped = new InstrumentedTaskRepository(
+      repo,
+      (event) => events.push(event),
+      { now: () => (nowQueue.length > 0 ? nowQueue.shift()! : 0) },
+    );
+  });
+
+  it('emits scope, duration, and success metadata for each instrumented method', () => {
+    const task = createTaskState('t1', 'Task 1', [], { workflowId: 'wf-1' });
+    const changes: TaskStateChanges = { status: 'running' };
+
+    // Each instrumented call consumes two now() readings: start and end.
+    nowQueue = [
+      100, 110, // saveTask
+      200, 203, // updateTask
+      300, 309, // deleteWorkflow
+      400, 401, // deleteAllWorkflows
+    ];
+
+    wrapped.saveTask('wf-1', task);
+    wrapped.updateTask('t1', changes);
+    wrapped.deleteWorkflow('wf-1');
+    wrapped.deleteAllWorkflows();
+
+    expect(events.map((e) => e.method)).toEqual([
+      'saveTask',
+      'updateTask',
+      'deleteWorkflow',
+      'deleteAllWorkflows',
+    ]);
+
+    for (const event of events) {
+      expect(event.scope).toBe(`${TASK_REPOSITORY_INSTRUMENTATION_SCOPE_PREFIX}.${event.method}`);
+      expect(event.success).toBe(true);
+      expect(event.error).toBeUndefined();
+    }
+
+    expect(events[0].durationMs).toBe(10);
+    expect(events[1].durationMs).toBe(3);
+    expect(events[2].durationMs).toBe(9);
+    expect(events[3].durationMs).toBe(1);
+  });
+
+  it('forwards arguments unchanged and preserves call ordering', () => {
+    const task = createTaskState('t1', 'Task 1', [], { workflowId: 'wf-1' });
+    const wfChanges: WorkflowChanges = { status: 'completed' };
+    const taskChanges: TaskStateChanges = { status: 'completed' };
+    const attemptChanges: AttemptChanges = { status: 'running' };
+    const failPatch: AttemptFailPatch = { status: 'failed', exitCode: 1 };
+    const attempt = { id: 'a1', nodeId: 't1' } as unknown as Attempt;
+
+    wrapped.saveWorkflow(SAMPLE_WORKFLOW);
+    wrapped.saveTask('wf-1', task);
+    wrapped.updateTask('t1', taskChanges);
+    wrapped.updateWorkflow('wf-1', wfChanges);
+    wrapped.logEvent('t1', 'started', { foo: 'bar' });
+    wrapped.saveAttempt(attempt);
+    wrapped.updateAttempt('a1', attemptChanges);
+    wrapped.failTaskAndAttempt('t1', taskChanges, failPatch);
+    wrapped.deleteWorkflow('wf-1');
+    wrapped.deleteAllWorkflows();
+
+    expect(calls.map((c) => c.method)).toEqual([
+      'saveWorkflow',
+      'saveTask',
+      'updateTask',
+      'updateWorkflow',
+      'logEvent',
+      'saveAttempt',
+      'updateAttempt',
+      'failTaskAndAttempt',
+      'deleteWorkflow',
+      'deleteAllWorkflows',
+    ]);
+
+    expect(calls[0].args).toEqual([SAMPLE_WORKFLOW]);
+    expect(calls[1].args).toEqual(['wf-1', task]);
+    expect(calls[2].args).toEqual(['t1', taskChanges]);
+    expect(calls[3].args).toEqual(['wf-1', wfChanges]);
+    expect(calls[4].args).toEqual(['t1', 'started', { foo: 'bar' }]);
+    expect(calls[5].args).toEqual([attempt]);
+    expect(calls[6].args).toEqual(['a1', attemptChanges]);
+    expect(calls[7].args).toEqual(['t1', taskChanges, failPatch]);
+    expect(calls[8].args).toEqual(['wf-1']);
+    expect(calls[9].args).toEqual([]);
+  });
+
+  it('does not emit events for pass-through methods', () => {
+    wrapped.saveWorkflow(SAMPLE_WORKFLOW);
+    wrapped.updateWorkflow('wf-1', { status: 'completed' });
+    wrapped.logEvent('t1', 'started');
+    wrapped.saveAttempt({ id: 'a1', nodeId: 't1' } as unknown as Attempt);
+    wrapped.updateAttempt('a1', { status: 'running' });
+    wrapped.failTaskAndAttempt('t1', { status: 'failed' }, { status: 'failed' });
+
+    expect(events).toEqual([]);
+  });
+
+  it('records failures with error metadata and re-throws', () => {
+    const boom = new Error('write failed');
+    const failingRepo = makeRecordingRepository({
+      saveTask: () => { throw boom; },
+    });
+    nowQueue = [500, 504];
+    const failing = new InstrumentedTaskRepository(
+      failingRepo.repo,
+      (event) => events.push(event),
+      { now: () => (nowQueue.length > 0 ? nowQueue.shift()! : 0) },
+    );
+
+    expect(() => {
+      failing.saveTask('wf-1', createTaskState('t1', 'Task 1', [], { workflowId: 'wf-1' }));
+    }).toThrow(boom);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      scope: 'task-repository.saveTask',
+      method: 'saveTask',
+      success: false,
+      error: 'write failed',
+      durationMs: 4,
+    });
+  });
+
+  it('runInTransaction passes through and returns the work result', () => {
+    const result = wrapped.runInTransaction(() => 42);
+    expect(result).toBe(42);
+    expect(calls[0]).toMatchObject({ method: 'runInTransaction' });
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -411,17 +411,31 @@ export class CommandService {
    * workflow root tasks. Thin delegate to `Orchestrator.recreateWorkflow`;
    * serialized through the workflow mutex. Step 17
    * (`docs/architecture/task-invalidation-roadmap.md`) closes the
-   * 5-method matrix on `CommandService`. Production callers that
-   * need an additional generation bump should use the app-layer
-   * wrapper (`packages/app/src/workflow-actions.ts → recreateWorkflow`)
-   * which composes the bump on top of this primitive.
+   * 5-method matrix on `CommandService`.
+   *
+   * App-layer entrypoints that need to bump the workflow generation
+   * (or run other under-mutex prep) supply a `beforeRecreate` callback
+   * via `opts`. The callback runs inside the same workflow-scoped
+   * promise-chain mutex as `Orchestrator.recreateWorkflow`, so the
+   * bump and the recreate observe the same mutation as a single
+   * serialized step. Orchestrator-internal callers that are already
+   * inside the mutex (e.g. `applyInvalidation` via
+   * `buildInvalidationDeps`) MUST NOT route through this seam — they
+   * call `Orchestrator.recreateWorkflow` directly to avoid mutex
+   * re-entry.
    */
   async recreateWorkflow(
     envelope: CommandEnvelope<{ workflowId: string }>,
+    opts?: { beforeRecreate?: (workflowId: string) => void | Promise<void> },
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RECREATE_WORKFLOW_FAILED',
-      () => this.orchestrator.recreateWorkflow(envelope.payload.workflowId),
+      async () => {
+        if (opts?.beforeRecreate) {
+          await opts.beforeRecreate(envelope.payload.workflowId);
+        }
+        return this.orchestrator.recreateWorkflow(envelope.payload.workflowId);
+      },
       envelope.payload.workflowId,
     );
   }

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -7,6 +7,7 @@ export * from './task-id-scope.js';
 export * from './fallback-policy.js';
 export * from './graph-mutation.js';
 export * from './command-service.js';
+export * from './instrumented-command-service.js';
 export * from './task-repository.js';
 export * from './instrumented-task-repository.js';
 export * from './invalidation-policy.js';

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -8,4 +8,5 @@ export * from './fallback-policy.js';
 export * from './graph-mutation.js';
 export * from './command-service.js';
 export * from './task-repository.js';
+export * from './instrumented-task-repository.js';
 export * from './invalidation-policy.js';

--- a/packages/workflow-core/src/instrumented-command-service.ts
+++ b/packages/workflow-core/src/instrumented-command-service.ts
@@ -1,0 +1,274 @@
+/**
+ * InstrumentedCommandService — A CommandService subclass that records
+ * timing and outcome metadata for the lifecycle mutation methods the
+ * orchestrator routes through `CommandService`.
+ *
+ * Each instrumented method delegates to the inherited `CommandService`
+ * implementation (preserving mutex semantics and return types) and emits a
+ * `command-service.<method>` instrumentation event with `success`,
+ * `durationMs`, and an `error` message on failure. The instrumentation
+ * window covers the full mutation latency — including the wait for the
+ * workflow-scoped promise-chain mutex — so callers can compare end-to-end
+ * lifecycle latency against per-operation persistence timings emitted by
+ * `InstrumentedTaskRepository` / `InstrumentedPersistenceAdapter`.
+ *
+ * `success` is derived from the `CommandResult.ok` flag returned by the
+ * inherited method: orchestrator-side errors that the base class converts
+ * into `{ ok: false }` results still emit a `success: false` event with
+ * the wrapped error message.
+ *
+ * The deprecated `restartTask` shim is intentionally not overridden —
+ * inheriting it lets it route through the (already instrumented)
+ * `recreateTask` override so callers see exactly one event reflecting the
+ * operation that actually ran.
+ */
+
+import type { CommandEnvelope, CommandResult } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-graph';
+
+import { CommandService } from './command-service.js';
+import type { CancelResult } from './command-service.js';
+import type {
+  ExternalGatePolicyUpdate,
+  Orchestrator,
+  TaskReplacementDef,
+} from './orchestrator.js';
+
+export const COMMAND_SERVICE_INSTRUMENTATION_SCOPE_PREFIX = 'command-service';
+
+export type CommandServiceInstrumentedMethod =
+  | 'approve'
+  | 'resumeTaskAfterFixApproval'
+  | 'reject'
+  | 'provideInput'
+  | 'retryTask'
+  | 'recreateTask'
+  | 'selectExperiment'
+  | 'editTaskCommand'
+  | 'editTaskPrompt'
+  | 'editTaskType'
+  | 'editTaskAgent'
+  | 'editTaskMergeMode'
+  | 'editTaskFixContext'
+  | 'setTaskExternalGatePolicies'
+  | 'replaceTask'
+  | 'cancelTask'
+  | 'cancelWorkflow'
+  | 'deleteWorkflow'
+  | 'retryWorkflow'
+  | 'recreateWorkflow'
+  | 'recreateWorkflowFromFreshBase';
+
+export interface CommandServiceInstrumentationEvent {
+  readonly scope: `${typeof COMMAND_SERVICE_INSTRUMENTATION_SCOPE_PREFIX}.${CommandServiceInstrumentedMethod}`;
+  readonly method: CommandServiceInstrumentedMethod;
+  readonly durationMs: number;
+  readonly success: boolean;
+  readonly error?: string;
+}
+
+export type CommandServiceInstrumenter = (event: CommandServiceInstrumentationEvent) => void;
+
+export interface InstrumentedCommandServiceOptions {
+  /** Override the wall clock (test seam). Defaults to Date.now. */
+  readonly now?: () => number;
+}
+
+export class InstrumentedCommandService extends CommandService {
+  private readonly emitInstrumentation: CommandServiceInstrumenter;
+  private readonly nowFn: () => number;
+
+  constructor(
+    orchestrator: Orchestrator,
+    emit: CommandServiceInstrumenter,
+    options: InstrumentedCommandServiceOptions = {},
+  ) {
+    super(orchestrator);
+    this.emitInstrumentation = emit;
+    this.nowFn = options.now ?? (() => Date.now());
+  }
+
+  // ── Instrumentation core ───────────────────────────────────
+
+  private async record<T>(
+    method: CommandServiceInstrumentedMethod,
+    fn: () => Promise<CommandResult<T>>,
+  ): Promise<CommandResult<T>> {
+    const start = this.nowFn();
+    try {
+      const result = await fn();
+      this.emitEvent(
+        method,
+        start,
+        result.ok,
+        result.ok ? undefined : result.error.message,
+      );
+      return result;
+    } catch (err) {
+      this.emitEvent(method, start, false, err instanceof Error ? err.message : String(err));
+      throw err;
+    }
+  }
+
+  private emitEvent(
+    method: CommandServiceInstrumentedMethod,
+    start: number,
+    success: boolean,
+    error?: string,
+  ): void {
+    const event: CommandServiceInstrumentationEvent = {
+      scope: `${COMMAND_SERVICE_INSTRUMENTATION_SCOPE_PREFIX}.${method}`,
+      method,
+      durationMs: this.nowFn() - start,
+      success,
+      ...(success ? {} : { error }),
+    };
+    this.emitInstrumentation(event);
+  }
+
+  // ── Instrumented overrides ────────────────────────────────
+
+  override approve(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('approve', () => super.approve(envelope));
+  }
+
+  override resumeTaskAfterFixApproval(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('resumeTaskAfterFixApproval', () =>
+      super.resumeTaskAfterFixApproval(envelope),
+    );
+  }
+
+  override reject(
+    envelope: CommandEnvelope<{ taskId: string; reason?: string }>,
+  ): Promise<CommandResult<void>> {
+    return this.record('reject', () => super.reject(envelope));
+  }
+
+  override provideInput(
+    envelope: CommandEnvelope<{ taskId: string; input: string }>,
+  ): Promise<CommandResult<void>> {
+    return this.record('provideInput', () => super.provideInput(envelope));
+  }
+
+  override retryTask(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('retryTask', () => super.retryTask(envelope));
+  }
+
+  override recreateTask(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('recreateTask', () => super.recreateTask(envelope));
+  }
+
+  override selectExperiment(
+    envelope: CommandEnvelope<{ taskId: string; experimentId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('selectExperiment', () => super.selectExperiment(envelope));
+  }
+
+  override editTaskCommand(
+    envelope: CommandEnvelope<{ taskId: string; newCommand: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('editTaskCommand', () => super.editTaskCommand(envelope));
+  }
+
+  override editTaskPrompt(
+    envelope: CommandEnvelope<{ taskId: string; newPrompt: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('editTaskPrompt', () => super.editTaskPrompt(envelope));
+  }
+
+  override editTaskType(
+    envelope: CommandEnvelope<{
+      taskId: string;
+      executorType: string;
+      remoteTargetId?: string;
+    }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('editTaskType', () => super.editTaskType(envelope));
+  }
+
+  override editTaskAgent(
+    envelope: CommandEnvelope<{ taskId: string; agentName: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('editTaskAgent', () => super.editTaskAgent(envelope));
+  }
+
+  override editTaskMergeMode(
+    envelope: CommandEnvelope<{
+      taskId: string;
+      mergeMode: 'manual' | 'automatic' | 'external_review';
+    }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('editTaskMergeMode', () => super.editTaskMergeMode(envelope));
+  }
+
+  override editTaskFixContext(
+    envelope: CommandEnvelope<{
+      taskId: string;
+      fixPrompt?: string;
+      fixContext?: string;
+    }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('editTaskFixContext', () => super.editTaskFixContext(envelope));
+  }
+
+  override setTaskExternalGatePolicies(
+    envelope: CommandEnvelope<{ taskId: string; updates: ExternalGatePolicyUpdate[] }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('setTaskExternalGatePolicies', () =>
+      super.setTaskExternalGatePolicies(envelope),
+    );
+  }
+
+  override replaceTask(
+    envelope: CommandEnvelope<{ taskId: string; replacementTasks: TaskReplacementDef[] }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('replaceTask', () => super.replaceTask(envelope));
+  }
+
+  override cancelTask(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<CancelResult>> {
+    return this.record('cancelTask', () => super.cancelTask(envelope));
+  }
+
+  override cancelWorkflow(
+    envelope: CommandEnvelope<{ workflowId: string }>,
+  ): Promise<CommandResult<CancelResult>> {
+    return this.record('cancelWorkflow', () => super.cancelWorkflow(envelope));
+  }
+
+  override deleteWorkflow(
+    envelope: CommandEnvelope<{ workflowId: string }>,
+  ): Promise<CommandResult<void>> {
+    return this.record('deleteWorkflow', () => super.deleteWorkflow(envelope));
+  }
+
+  override retryWorkflow(
+    envelope: CommandEnvelope<{ workflowId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('retryWorkflow', () => super.retryWorkflow(envelope));
+  }
+
+  override recreateWorkflow(
+    envelope: CommandEnvelope<{ workflowId: string }>,
+    opts?: { beforeRecreate?: (workflowId: string) => void | Promise<void> },
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('recreateWorkflow', () => super.recreateWorkflow(envelope, opts));
+  }
+
+  override recreateWorkflowFromFreshBase(
+    envelope: CommandEnvelope<{ workflowId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.record('recreateWorkflowFromFreshBase', () =>
+      super.recreateWorkflowFromFreshBase(envelope),
+    );
+  }
+}

--- a/packages/workflow-core/src/instrumented-task-repository.ts
+++ b/packages/workflow-core/src/instrumented-task-repository.ts
@@ -1,0 +1,141 @@
+/**
+ * InstrumentedTaskRepository — A TaskRepository decorator that records
+ * timing and outcome metadata for the writes the orchestrator performs
+ * on each lifecycle transition.
+ *
+ * Only the methods listed in the port that overlap with the persistence
+ * boundary the orchestrator instruments are wrapped: `saveTask`,
+ * `updateTask`, `deleteWorkflow`, and `deleteAllWorkflows`. The rest of
+ * the port surface (workflow inserts, attempt writes, transactional
+ * helpers) passes straight through to keep behavior identical.
+ */
+
+import type { TaskState, TaskStateChanges, Attempt } from '@invoker/workflow-graph';
+import type {
+  AttemptChanges,
+  AttemptFailPatch,
+  TaskRepository,
+  WorkflowChanges,
+  WorkflowRecord,
+} from './task-repository.js';
+
+export const TASK_REPOSITORY_INSTRUMENTATION_SCOPE_PREFIX = 'task-repository';
+
+export type TaskRepositoryInstrumentedMethod =
+  | 'saveTask'
+  | 'updateTask'
+  | 'deleteWorkflow'
+  | 'deleteAllWorkflows';
+
+export interface TaskRepositoryInstrumentationEvent {
+  readonly scope: `${typeof TASK_REPOSITORY_INSTRUMENTATION_SCOPE_PREFIX}.${TaskRepositoryInstrumentedMethod}`;
+  readonly method: TaskRepositoryInstrumentedMethod;
+  readonly durationMs: number;
+  readonly success: boolean;
+  readonly error?: string;
+}
+
+export type TaskRepositoryInstrumenter = (event: TaskRepositoryInstrumentationEvent) => void;
+
+export interface InstrumentedTaskRepositoryOptions {
+  /** Override the wall clock (test seam). Defaults to Date.now. */
+  readonly now?: () => number;
+}
+
+export class InstrumentedTaskRepository implements TaskRepository {
+  private readonly inner: TaskRepository;
+  private readonly emit: TaskRepositoryInstrumenter;
+  private readonly now: () => number;
+
+  constructor(
+    inner: TaskRepository,
+    emit: TaskRepositoryInstrumenter,
+    options: InstrumentedTaskRepositoryOptions = {},
+  ) {
+    this.inner = inner;
+    this.emit = emit;
+    this.now = options.now ?? (() => Date.now());
+  }
+
+  // ── Instrumentation core ───────────────────────────────────
+
+  private record<T>(method: TaskRepositoryInstrumentedMethod, fn: () => T): T {
+    const start = this.now();
+    try {
+      const result = fn();
+      this.emitEvent(method, start, true);
+      return result;
+    } catch (err) {
+      this.emitEvent(method, start, false, err);
+      throw err;
+    }
+  }
+
+  private emitEvent(
+    method: TaskRepositoryInstrumentedMethod,
+    start: number,
+    success: boolean,
+    err?: unknown,
+  ): void {
+    const event: TaskRepositoryInstrumentationEvent = {
+      scope: `${TASK_REPOSITORY_INSTRUMENTATION_SCOPE_PREFIX}.${method}`,
+      method,
+      durationMs: this.now() - start,
+      success,
+      ...(success ? {} : { error: err instanceof Error ? err.message : String(err) }),
+    };
+    this.emit(event);
+  }
+
+  // ── Pass-through methods ───────────────────────────────────
+
+  runInTransaction<T>(work: () => T): T {
+    return this.inner.runInTransaction(work);
+  }
+
+  saveWorkflow(workflow: WorkflowRecord): void {
+    this.inner.saveWorkflow(workflow);
+  }
+
+  updateWorkflow(workflowId: string, changes: WorkflowChanges): void {
+    this.inner.updateWorkflow(workflowId, changes);
+  }
+
+  logEvent(taskId: string, eventType: string, payload?: unknown): void {
+    this.inner.logEvent(taskId, eventType, payload);
+  }
+
+  saveAttempt(attempt: Attempt): void {
+    this.inner.saveAttempt(attempt);
+  }
+
+  updateAttempt(attemptId: string, changes: AttemptChanges): void {
+    this.inner.updateAttempt(attemptId, changes);
+  }
+
+  failTaskAndAttempt(
+    taskId: string,
+    taskChanges: TaskStateChanges,
+    attemptPatch: AttemptFailPatch,
+  ): void {
+    this.inner.failTaskAndAttempt(taskId, taskChanges, attemptPatch);
+  }
+
+  // ── Instrumented methods ───────────────────────────────────
+
+  saveTask(workflowId: string, task: TaskState): void {
+    this.record('saveTask', () => this.inner.saveTask(workflowId, task));
+  }
+
+  updateTask(taskId: string, changes: TaskStateChanges): void {
+    this.record('updateTask', () => this.inner.updateTask(taskId, changes));
+  }
+
+  deleteWorkflow(workflowId: string): void {
+    this.record('deleteWorkflow', () => this.inner.deleteWorkflow(workflowId));
+  }
+
+  deleteAllWorkflows(): void {
+    this.record('deleteAllWorkflows', () => this.inner.deleteAllWorkflows());
+  }
+}

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -7,34 +7,39 @@
  * this interface live in other packages.
  *
  * Every method corresponds 1-to-1 with a `this.persistence.*` write call
- * inside orchestrator.ts.
+ * inside orchestrator.ts. Wrappers (logging / metrics decorators) can
+ * replace any concrete implementation without orchestrator changes.
  */
 
 import type { TaskState, TaskStateChanges, Attempt } from '@invoker/workflow-graph';
 
-// ── Workflow value types (inline in OrchestratorPersistence today) ────
+// ── Workflow value types (mirror PersistenceAdapter literal unions) ────
+
+export type WorkflowStatus = 'running' | 'completed' | 'failed';
+export type WorkflowMergeMode = 'manual' | 'automatic' | 'external_review';
+export type WorkflowOnFinish = 'none' | 'merge' | 'pull_request';
 
 export interface WorkflowRecord {
   id: string;
   name: string;
   description?: string;
   visualProof?: boolean;
-  status: 'running' | 'completed' | 'failed';
+  status: WorkflowStatus;
   createdAt: string;
   updatedAt: string;
   repoUrl?: string;
-  onFinish?: string;
+  onFinish?: WorkflowOnFinish;
   baseBranch?: string;
   featureBranch?: string;
-  mergeMode?: 'manual' | 'automatic' | 'external_review';
+  mergeMode?: WorkflowMergeMode;
 }
 
 export interface WorkflowChanges {
-  status?: string;
+  status?: WorkflowStatus;
   updatedAt?: string;
   baseBranch?: string;
   generation?: number;
-  mergeMode?: 'manual' | 'automatic' | 'external_review';
+  mergeMode?: WorkflowMergeMode;
 }
 
 export type AttemptChanges = Partial<

--- a/skills/visual-proof/SKILL.md
+++ b/skills/visual-proof/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: visual-proof
+description: >
+  Capture before/after UI screenshots and video for Invoker plans that modify
+  the UI.
+---
+
 # visual-proof
 
 Capture before/after UI screenshots and video for Invoker plans that modify the UI.

--- a/skills/workflow-chain-submit/SKILL.md
+++ b/skills/workflow-chain-submit/SKILL.md
@@ -1,3 +1,10 @@
+---
+name: workflow-chain-submit
+description: >
+  Submit a workflow chain headlessly, where each workflow is gated on the
+  previous workflow's merge gate.
+---
+
 # workflow-chain-submit
 
 Submit a workflow chain headlessly, where each workflow is gated on the previous workflow's merge gate.


### PR DESCRIPTION
## Summary
Route external-review merge publication through the same canonical PR
authoring flow already used by the internal/manual pull-request path. Today
the external-review path publishes raw `buildMergeSummary()` markdown to
GitHub, while the internal path turns that summary into a validated canonical
PR body through `invoker-make-pr`.

### Architecture (before)

```mermaid
flowchart TD
  Summary[buildMergeSummary context] --> Manual[manual pull_request path]
  Summary --> External[external_review path]
  Manual --> Skill[authorPrBodyForMerge]
  Skill --> Validate[validateCanonicalPrBody]
  Validate --> ExecPr[execPr]
  External --> Review[createReview with raw summary]
```

### Architecture (after)

```mermaid
flowchart TD
  Summary[buildMergeSummary context] --> Author[authorPrBodyForMerge]
  Author --> Validate[validateCanonicalPrBody]
  Validate --> Manual[execPr for manual pull_request]
  Validate --> External[createReview for external_review]
```

This step changes merge-runner control flow only. It should preserve merge
gate lifecycle behavior and GitHub provider responsibilities while making PR
authoring a single invariant before publication.


---
External PR authoring parity step 1: unify merge publication path — 2 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1777519370934-20/unify-external-review-pr-authoring | Route external_review publication through canonical PR authoring before GitHub review creation. | completed |
| wf-1777519370934-20/verify-merge-path-regression | Run focused execution-engine regression coverage after unifying the merge publication path. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1777519370934-20/unify-external-review-pr-authoring — Route external_review publication through canonical PR authoring before GitHub review creation.
.../src/__tests__/task-runner.test.ts              | 36 ++++++++++++++++++++--
 packages/execution-engine/src/merge-runner.ts      | 24 +++++++++++++--
 2 files changed, 56 insertions(+), 4 deletions(-)

### wf-1777519370934-20/verify-merge-path-regression — Run focused execution-engine regression coverage after unifying the merge publication path.

</details>
