### PR TITLE
Headless Step 2: Make headless-ipc.js a thin wrapper

### DIFF
--- a/packages/app/src/__tests__/headless-transport.test.ts
+++ b/packages/app/src/__tests__/headless-transport.test.ts
@@ -1,0 +1,496 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LocalBus } from '@invoker/transport';
+
+import {
+  HeadlessTransport,
+  type HeadlessTransportDeps,
+} from '../headless-transport.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDeps(overrides: Partial<HeadlessTransportDeps> = {}): HeadlessTransportDeps {
+  return {
+    messageBus: new LocalBus(),
+    ...overrides,
+  };
+}
+
+/** Register a standalone owner on the given bus. */
+function registerStandaloneOwner(
+  bus: LocalBus,
+  execHandler: (req: unknown) => Promise<unknown> = async () => ({ ok: true }),
+): void {
+  bus.onRequest('headless.owner-ping', async () => ({
+    ok: true,
+    ownerId: 'owner-standalone',
+    mode: 'standalone',
+  }));
+  bus.onRequest('headless.exec', execHandler);
+  bus.onRequest('headless.run', async (req: unknown) => {
+    const { planPath } = req as { planPath: string };
+    return { workflowId: `wf-${planPath}`, tasks: [] };
+  });
+  bus.onRequest('headless.resume', async (req: unknown) => {
+    const { workflowId } = req as { workflowId: string };
+    return { workflowId, tasks: [] };
+  });
+}
+
+/** Register a GUI owner on the given bus. */
+function registerGuiOwner(bus: LocalBus): void {
+  bus.onRequest('headless.owner-ping', async () => ({
+    ok: true,
+    ownerId: 'owner-gui',
+    mode: 'gui',
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HeadlessTransport', () => {
+  // =========================================================================
+  // resolveOwnerMode
+  // =========================================================================
+
+  describe('resolveOwnerMode', () => {
+    it('returns "standalone" when a standalone owner responds', async () => {
+      const bus = new LocalBus();
+      registerStandaloneOwner(bus);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      expect(await transport.resolveOwnerMode()).toBe('standalone');
+    });
+
+    it('returns "gui" when a GUI owner responds', async () => {
+      const bus = new LocalBus();
+      registerGuiOwner(bus);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      expect(await transport.resolveOwnerMode()).toBe('gui');
+    });
+
+    it('returns "none" when no owner responds', async () => {
+      const transport = new HeadlessTransport(makeDeps());
+
+      expect(await transport.resolveOwnerMode()).toBe('none');
+    });
+  });
+
+  // =========================================================================
+  // exec — standalone mode (owner already running)
+  // =========================================================================
+
+  describe('exec (standalone owner present)', () => {
+    it('delegates a mutating command to the standalone owner', async () => {
+      const bus = new LocalBus();
+      const execHandler = vi.fn(async () => ({ ok: true }));
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const result = await transport.exec(['retry', 'wf-1'], { noTrack: true });
+
+      expect(result.ok).toBe(true);
+      expect(result.args).toEqual(['retry', 'wf-1']);
+      expect(execHandler).toHaveBeenCalledWith(expect.objectContaining({
+        args: ['retry', 'wf-1'],
+        noTrack: true,
+        waitForApproval: undefined,
+      }));
+    });
+
+    it('delegates "run" via the headless.run channel', async () => {
+      const bus = new LocalBus();
+      const runHandler = vi.fn(async () => ({
+        workflowId: 'wf-new',
+        tasks: [],
+      }));
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+      bus.onRequest('headless.run', runHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const result = await transport.exec(
+        ['run', '/tmp/plan.yaml'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(runHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ planPath: expect.stringContaining('plan.yaml') }),
+      );
+    });
+
+    it('delegates "resume" via the headless.resume channel', async () => {
+      const bus = new LocalBus();
+      const resumeHandler = vi.fn(async () => ({
+        workflowId: 'wf-42',
+        tasks: [],
+      }));
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+      bus.onRequest('headless.resume', resumeHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const result = await transport.exec(
+        ['resume', 'wf-42'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(resumeHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ workflowId: 'wf-42' }),
+      );
+    });
+
+    it('returns ok: false when a mutating command has no plan path', async () => {
+      const bus = new LocalBus();
+      registerStandaloneOwner(bus);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      // "run" with no plan path — delegation fails gracefully
+      const result = await transport.exec(['run'], { noTrack: true });
+
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // exec — shared-owner mode (GUI owner, then bootstrap standalone)
+  // =========================================================================
+
+  describe('exec (shared-owner / GUI owner mode)', () => {
+    it('skips GUI owner for mutations and bootstraps a standalone owner', async () => {
+      const firstBus = new LocalBus();
+      const secondBus = new LocalBus();
+
+      registerGuiOwner(firstBus);
+      registerStandaloneOwner(secondBus);
+
+      const ensureStandaloneOwner = vi.fn(async () => {});
+      const refreshMessageBus = vi.fn(async () => secondBus);
+
+      const transport = new HeadlessTransport(makeDeps({
+        messageBus: firstBus,
+        ensureStandaloneOwner,
+        refreshMessageBus,
+      }));
+
+      const result = await transport.exec(
+        ['retry', 'wf-1'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(true);
+      // The transport should have refreshed the bus after seeing the GUI owner
+      // and then either found a standalone via refresh or bootstrapped one.
+      expect(refreshMessageBus).toHaveBeenCalled();
+    });
+
+    it('bootstraps a standalone owner when no owner is present', async () => {
+      const emptyBus = new LocalBus();
+      const ownerBus = new LocalBus();
+      registerStandaloneOwner(ownerBus);
+
+      const ensureStandaloneOwner = vi.fn(async () => {});
+      const refreshMessageBus = vi.fn(async () => ownerBus);
+
+      const transport = new HeadlessTransport(makeDeps({
+        messageBus: emptyBus,
+        ensureStandaloneOwner,
+        refreshMessageBus,
+      }));
+
+      const result = await transport.exec(
+        ['recreate', 'wf-5'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(ensureStandaloneOwner).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // exec — read-only commands
+  // =========================================================================
+
+  describe('exec (read-only commands)', () => {
+    it('falls back to local executor for read-only commands', async () => {
+      const execLocal = vi.fn(async () => 0);
+      const transport = new HeadlessTransport(makeDeps({ execLocal }));
+
+      const result = await transport.exec(['list']);
+
+      expect(result.ok).toBe(true);
+      expect(execLocal).toHaveBeenCalledWith(['list']);
+    });
+
+    it('returns ok: false for read-only commands with no local executor', async () => {
+      const transport = new HeadlessTransport(makeDeps());
+
+      const result = await transport.exec(['query', 'workflows']);
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/no local executor/i);
+    });
+
+    it('captures local executor non-zero exit as ok: false', async () => {
+      const execLocal = vi.fn(async () => 1);
+      const transport = new HeadlessTransport(makeDeps({ execLocal }));
+
+      const result = await transport.exec(['status']);
+
+      expect(result.ok).toBe(false);
+      expect(result.response).toEqual({ exitCode: 1 });
+    });
+  });
+
+  // =========================================================================
+  // exec — error handling
+  // =========================================================================
+
+  describe('exec (error handling)', () => {
+    it('captures delegation errors as ok: false with an error message', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+      bus.onRequest('headless.exec', async () => {
+        throw new Error('owner crashed');
+      });
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const result = await transport.exec(
+        ['retry', 'wf-broken'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/owner crashed/);
+    });
+
+    it('captures bootstrap errors as ok: false', async () => {
+      const emptyBus = new LocalBus();
+      const ensureStandaloneOwner = vi.fn(async () => {
+        throw new Error('bootstrap failed');
+      });
+      const transport = new HeadlessTransport(makeDeps({
+        messageBus: emptyBus,
+        ensureStandaloneOwner,
+      }));
+
+      const result = await transport.exec(
+        ['retry', 'wf-1'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/bootstrap failed/);
+    });
+  });
+
+  // =========================================================================
+  // batchExec
+  // =========================================================================
+
+  describe('batchExec', () => {
+    it('executes multiple commands sequentially by default', async () => {
+      const bus = new LocalBus();
+      const callOrder: string[] = [];
+      const execHandler = vi.fn(async (req: unknown) => {
+        const { args } = req as { args: string[] };
+        callOrder.push(args.join(' '));
+        return { ok: true };
+      });
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const results = await transport.batchExec(
+        [
+          { args: ['retry', 'wf-1'] },
+          { args: ['retry', 'wf-2'] },
+          { args: ['retry', 'wf-3'] },
+        ],
+        { noTrack: true },
+      );
+
+      expect(results).toHaveLength(3);
+      expect(results.every((r) => r.ok)).toBe(true);
+      expect(callOrder).toEqual(['retry wf-1', 'retry wf-2', 'retry wf-3']);
+    });
+
+    it('executes commands in parallel when parallel > 1', async () => {
+      const bus = new LocalBus();
+      let concurrency = 0;
+      let maxConcurrency = 0;
+      const execHandler = vi.fn(async () => {
+        concurrency += 1;
+        maxConcurrency = Math.max(maxConcurrency, concurrency);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        concurrency -= 1;
+        return { ok: true };
+      });
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const results = await transport.batchExec(
+        [
+          { args: ['retry', 'wf-1'] },
+          { args: ['retry', 'wf-2'] },
+          { args: ['retry', 'wf-3'] },
+          { args: ['retry', 'wf-4'] },
+        ],
+        { noTrack: true, parallel: 3 },
+      );
+
+      expect(results).toHaveLength(4);
+      expect(results.every((r) => r.ok)).toBe(true);
+      // With 4 items and parallel=3, at least 2 should run concurrently
+      expect(maxConcurrency).toBeGreaterThanOrEqual(2);
+    });
+
+    it('returns results in input order regardless of completion order', async () => {
+      const bus = new LocalBus();
+      const delays = [30, 10, 20];
+      let callIndex = 0;
+      const execHandler = vi.fn(async (req: unknown) => {
+        const delay = delays[callIndex] ?? 0;
+        callIndex += 1;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        const { args } = req as { args: string[] };
+        return { ok: true, id: args[1] };
+      });
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const results = await transport.batchExec(
+        [
+          { args: ['retry', 'wf-a'] },
+          { args: ['retry', 'wf-b'] },
+          { args: ['retry', 'wf-c'] },
+        ],
+        { noTrack: true, parallel: 3 },
+      );
+
+      expect(results[0].args).toEqual(['retry', 'wf-a']);
+      expect(results[1].args).toEqual(['retry', 'wf-b']);
+      expect(results[2].args).toEqual(['retry', 'wf-c']);
+    });
+
+    it('isolates failures so one bad command does not abort the batch', async () => {
+      const bus = new LocalBus();
+      let callCount = 0;
+      const execHandler = vi.fn(async () => {
+        callCount += 1;
+        if (callCount === 2) {
+          throw new Error('owner rejected command');
+        }
+        return { ok: true };
+      });
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const results = await transport.batchExec(
+        [
+          { args: ['retry', 'wf-1'] },
+          { args: ['retry', 'wf-2'] },
+          { args: ['retry', 'wf-3'] },
+        ],
+        { noTrack: true },
+      );
+
+      expect(results[0].ok).toBe(true);
+      expect(results[1].ok).toBe(false);
+      expect(results[1].error).toMatch(/owner rejected command/);
+      expect(results[2].ok).toBe(true);
+    });
+
+    it('returns empty results for empty input', async () => {
+      const transport = new HeadlessTransport(makeDeps());
+
+      const results = await transport.batchExec([], { noTrack: true });
+
+      expect(results).toEqual([]);
+    });
+
+    it('clamps parallel to 1 when given 0', async () => {
+      const bus = new LocalBus();
+      const callOrder: number[] = [];
+      let callIndex = 0;
+      const execHandler = vi.fn(async () => {
+        callOrder.push(callIndex);
+        callIndex += 1;
+        return { ok: true };
+      });
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const results = await transport.batchExec(
+        [{ args: ['retry', 'wf-1'] }, { args: ['retry', 'wf-2'] }],
+        { noTrack: true, parallel: 0 },
+      );
+
+      expect(results).toHaveLength(2);
+      // With parallel=0 clamped to 1, calls are strictly sequential
+      expect(callOrder).toEqual([0, 1]);
+    });
+  });
+
+  // =========================================================================
+  // Transport decision: IPC vs standalone
+  // =========================================================================
+
+  describe('transport decision centralisation', () => {
+    it('never delegates read-only commands to the owner', async () => {
+      const bus = new LocalBus();
+      const execHandler = vi.fn(async () => ({ ok: true }));
+      registerStandaloneOwner(bus, execHandler);
+      const execLocal = vi.fn(async () => 0);
+
+      const transport = new HeadlessTransport(makeDeps({
+        messageBus: bus,
+        execLocal,
+      }));
+
+      await transport.exec(['list']);
+      await transport.exec(['status']);
+      await transport.exec(['query', 'workflows']);
+
+      // read-only commands should go to local executor, not IPC
+      expect(execHandler).not.toHaveBeenCalled();
+      expect(execLocal).toHaveBeenCalledTimes(3);
+    });
+
+    it('always delegates mutating commands via IPC when an owner is available', async () => {
+      const bus = new LocalBus();
+      const execHandler = vi.fn(async () => ({ ok: true }));
+      registerStandaloneOwner(bus, execHandler);
+      const execLocal = vi.fn(async () => 0);
+
+      const transport = new HeadlessTransport(makeDeps({
+        messageBus: bus,
+        execLocal,
+      }));
+
+      await transport.exec(['retry', 'wf-1'], { noTrack: true });
+      await transport.exec(['approve', 'wf-1/task-1'], { noTrack: true });
+      await transport.exec(['cancel', 'wf-1/task-1'], { noTrack: true });
+
+      // All mutating commands should go via IPC
+      expect(execHandler).toHaveBeenCalledTimes(3);
+      expect(execLocal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/app/src/delta-merge.ts
+++ b/packages/app/src/delta-merge.ts
@@ -11,14 +11,9 @@
  */
 import type { TaskDelta, TaskState } from '@invoker/workflow-core';
 
-interface VersionedTaskState extends TaskState {
+type SnapshotTaskState = Omit<TaskState, 'taskStateVersion'> & {
   taskStateVersion?: number;
-}
-
-interface VersionedUpdatedTaskDelta extends Extract<TaskDelta, { type: 'updated' }> {
-  taskStateVersion?: number;
-  previousTaskStateVersion?: number;
-}
+};
 
 // ── Cache entry ──────────────────────────────────────────────
 
@@ -49,7 +44,7 @@ export class TaskSnapshotCache {
   // ── Bulk operations (used by seedUiSnapshotCache, db-poll, etc.) ──
 
   set(taskId: string, snapshot: string): void {
-    const task = JSON.parse(snapshot) as VersionedTaskState;
+    const task = JSON.parse(snapshot) as SnapshotTaskState;
     this.entries.set(taskId, {
       snapshot,
       taskStateVersion: task.taskStateVersion ?? 1,
@@ -126,7 +121,6 @@ export function applyDelta(
   }
 
   // delta.type === 'updated'
-  const versionedDelta = delta as VersionedUpdatedTaskDelta;
   const entry = cache.getEntry(delta.taskId);
 
   // Quarantined tasks: ignore until recovery completes.
@@ -135,7 +129,7 @@ export function applyDelta(
   }
 
   // Unknown task or taskStateVersion gap → quarantine.
-  if (!entry || entry.taskStateVersion !== versionedDelta.previousTaskStateVersion) {
+  if (!entry || entry.taskStateVersion !== delta.previousTaskStateVersion) {
     // Mark as quarantined.  If the entry exists, keep its snapshot but
     // flag it; if it doesn't, create a placeholder entry.
     if (entry) {
@@ -146,19 +140,19 @@ export function applyDelta(
   }
 
   // Task-state version matches — apply the merge.
-  const prev = JSON.parse(entry.snapshot) as VersionedTaskState;
+  const prev = JSON.parse(entry.snapshot) as SnapshotTaskState;
   const { config: cfgChanges, execution: execChanges, ...topLevel } = delta.changes;
   const merged = {
     ...prev,
     ...topLevel,
-    taskStateVersion: versionedDelta.taskStateVersion,
+    taskStateVersion: delta.taskStateVersion,
     config: { ...prev.config, ...cfgChanges },
     execution: { ...prev.execution, ...execChanges },
   };
   const snapshot = JSON.stringify(merged);
   // Update the entry in-place to avoid extra map operations.
   entry.snapshot = snapshot;
-  entry.taskStateVersion = versionedDelta.taskStateVersion ?? entry.taskStateVersion;
+  entry.taskStateVersion = delta.taskStateVersion;
 
   return result;
 }

--- a/packages/app/src/headless-transport.ts
+++ b/packages/app/src/headless-transport.ts
@@ -1,0 +1,301 @@
+/**
+ * HeadlessTransport — Single entry-point for headless command execution.
+ *
+ * Centralises the IPC-vs-standalone decision so callers don't need to know
+ * whether an owner process is reachable, whether IPC delegation should be
+ * attempted, or how to batch commands over the message bus.
+ *
+ * Two public methods:
+ *   exec()      — execute a single headless command
+ *   batchExec() — execute multiple commands with optional parallelism
+ *
+ * The transport resolves the owner mode once and reuses it for the lifetime
+ * of the instance.
+ */
+
+import type { MessageBus } from '@invoker/transport';
+
+import { isHeadlessMutatingCommand } from './headless-command-classification.js';
+import {
+  tryDelegateExec,
+  tryDelegateRun,
+  tryDelegateResume,
+  tryPingHeadlessOwner,
+} from './headless-delegation.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface HeadlessExecOptions {
+  /** If true, delegated submission exits without tracking workflow progress. */
+  noTrack?: boolean;
+  /** If true, wait for human approval before starting execution. */
+  waitForApproval?: boolean;
+  /** Per-request timeout in ms (default: 30 000). */
+  timeoutMs?: number;
+}
+
+export interface HeadlessExecResult {
+  /** The args that were executed. */
+  args: string[];
+  /** Whether the execution succeeded. */
+  ok: boolean;
+  /** Response payload from the owner (when delegated). */
+  response?: unknown;
+  /** Error message (only when ok === false). */
+  error?: string;
+}
+
+export interface HeadlessBatchOptions extends HeadlessExecOptions {
+  /** Number of concurrent workers for batch execution (default: 1). */
+  parallel?: number;
+}
+
+export type OwnerMode = 'standalone' | 'gui' | 'none';
+
+export interface HeadlessTransportDeps {
+  messageBus: MessageBus;
+  /**
+   * Optional callback to refresh the message bus connection.
+   * Useful when the underlying IPC socket reconnects.
+   */
+  refreshMessageBus?: () => Promise<MessageBus>;
+  /**
+   * Callback to ensure a standalone owner is running.
+   * Called when a mutating command arrives with no reachable owner.
+   */
+  ensureStandaloneOwner?: (bus?: MessageBus) => Promise<void>;
+  /**
+   * Callback to execute a command locally (e.g. via electron).
+   * Called for read-only commands in standalone mode, or when IPC
+   * delegation is not appropriate.
+   */
+  execLocal?: (args: string[]) => Promise<number>;
+}
+
+// ---------------------------------------------------------------------------
+// Default timeout
+// ---------------------------------------------------------------------------
+
+const DEFAULT_EXEC_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// HeadlessTransport
+// ---------------------------------------------------------------------------
+
+export class HeadlessTransport {
+  private deps: HeadlessTransportDeps;
+  private messageBus: MessageBus;
+
+  constructor(deps: HeadlessTransportDeps) {
+    this.deps = deps;
+    this.messageBus = deps.messageBus;
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /**
+   * Execute a single headless command.
+   *
+   * The transport decides whether to delegate via IPC or execute locally:
+   *   - Mutating commands are always delegated to a standalone owner.
+   *   - Read-only commands are delegated if an owner is present, otherwise
+   *     executed locally via `deps.execLocal`.
+   */
+  async exec(
+    args: string[],
+    options: HeadlessExecOptions = {},
+  ): Promise<HeadlessExecResult> {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS;
+    try {
+      const delegated = await this.tryDelegate(args, {
+        ...options,
+        timeoutMs,
+      });
+      if (delegated) {
+        return { args, ok: true, response: delegated.response };
+      }
+      // Delegation was not possible/applicable — run locally.
+      if (this.deps.execLocal) {
+        const exitCode = await this.deps.execLocal(args);
+        return { args, ok: exitCode === 0, response: { exitCode } };
+      }
+      return {
+        args,
+        ok: false,
+        error: 'No owner available and no local executor configured',
+      };
+    } catch (err) {
+      return {
+        args,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  /**
+   * Execute multiple headless commands with optional parallelism.
+   *
+   * Each command is independently dispatched via `exec()`, so failures in
+   * one command do not abort the batch.
+   *
+   * Returns results in the same order as the input items.
+   */
+  async batchExec(
+    items: Array<{ args: string[] }>,
+    options: HeadlessBatchOptions = {},
+  ): Promise<HeadlessExecResult[]> {
+    const parallel = Math.max(1, options.parallel ?? 1);
+    const results: HeadlessExecResult[] = new Array(items.length);
+    let nextIndex = 0;
+
+    const worker = async (): Promise<void> => {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+        if (index >= items.length) return;
+        results[index] = await this.exec(items[index].args, options);
+      }
+    };
+
+    const workerCount = Math.min(parallel, items.length);
+    await Promise.all(
+      Array.from({ length: workerCount }, () => worker()),
+    );
+    return results;
+  }
+
+  /**
+   * Probe the current owner mode without executing any command.
+   *
+   * Returns 'standalone', 'gui', or 'none'.
+   */
+  async resolveOwnerMode(): Promise<OwnerMode> {
+    const owner = await tryPingHeadlessOwner(this.messageBus, 2_000);
+    if (!owner) return 'none';
+    if (owner.mode === 'standalone') return 'standalone';
+    if (owner.mode === 'gui') return 'gui';
+    return 'none';
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal
+  // -----------------------------------------------------------------------
+
+  /**
+   * Attempt IPC delegation. Returns `{ response }` on success, or `null`
+   * if delegation was not possible (no owner, timeout, etc.).
+   */
+  private async tryDelegate(
+    args: string[],
+    options: HeadlessExecOptions,
+  ): Promise<{ response: unknown } | null> {
+    const { noTrack, waitForApproval, timeoutMs } = options;
+    const command = args[0] ?? '';
+
+    // Always try to delegate mutating commands via IPC.
+    if (isHeadlessMutatingCommand(args)) {
+      return this.delegateMutating(args, command, {
+        noTrack,
+        waitForApproval,
+        timeoutMs,
+      });
+    }
+
+    // Read-only: try delegation, fall back to local.
+    return null;
+  }
+
+  private async delegateMutating(
+    args: string[],
+    command: string,
+    options: HeadlessExecOptions,
+  ): Promise<{ response: unknown } | null> {
+    const { noTrack, waitForApproval, timeoutMs } = options;
+    let bus = this.messageBus;
+
+    // Check for an existing standalone owner.
+    const owner = await tryPingHeadlessOwner(bus, 2_000);
+    if (owner?.mode === 'standalone') {
+      const ok = await this.dispatchToOwner(
+        args,
+        command,
+        bus,
+        { noTrack, waitForApproval, timeoutMs },
+      );
+      if (ok) return { response: { delegated: true } };
+    }
+
+    // If a GUI owner responded (not standalone), refresh and look for a
+    // standalone owner (the GUI cannot handle mutations).
+    if (owner && owner.mode !== 'standalone' && this.deps.refreshMessageBus) {
+      bus = await this.deps.refreshMessageBus();
+      this.messageBus = bus;
+      const refreshed = await tryPingHeadlessOwner(bus, 1_000);
+      if (refreshed?.mode === 'standalone') {
+        const ok = await this.dispatchToOwner(
+          args,
+          command,
+          bus,
+          { noTrack, waitForApproval, timeoutMs },
+        );
+        if (ok) return { response: { delegated: true } };
+      }
+    }
+
+    // No standalone owner reachable — bootstrap one if possible.
+    if (this.deps.ensureStandaloneOwner) {
+      if (this.deps.refreshMessageBus) {
+        bus = await this.deps.refreshMessageBus();
+        this.messageBus = bus;
+      }
+      await this.deps.ensureStandaloneOwner(bus);
+      if (this.deps.refreshMessageBus) {
+        bus = await this.deps.refreshMessageBus();
+        this.messageBus = bus;
+      }
+      const ok = await this.dispatchToOwner(
+        args,
+        command,
+        bus,
+        { noTrack, waitForApproval, timeoutMs },
+      );
+      if (ok) return { response: { delegated: true } };
+    }
+
+    return null;
+  }
+
+  private async dispatchToOwner(
+    args: string[],
+    command: string,
+    bus: MessageBus,
+    options: HeadlessExecOptions,
+  ): Promise<boolean> {
+    const { noTrack, waitForApproval, timeoutMs } = options;
+
+    if (command === 'run') {
+      const planPath = args[1];
+      if (!planPath) return false;
+      return tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs);
+    }
+
+    if (command === 'resume') {
+      const workflowId = args[1];
+      if (!workflowId) return false;
+      return tryDelegateResume(
+        workflowId,
+        bus,
+        waitForApproval,
+        noTrack,
+        timeoutMs,
+      );
+    }
+
+    return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
+  }
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2152,7 +2152,7 @@ if (isHeadless) {
     lastKnownWorkflowCount = workflows.length;
     if (mainWindow && !mainWindow.isDestroyed()) {
       for (const removedTaskId of previousTaskIds) {
-        sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId });
+        sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
       }
       mainWindow.webContents.send('invoker:workflows-changed', workflows);
     }
@@ -2647,10 +2647,15 @@ if (isHeadless) {
         'invoker:inject-task-states',
         async (_event, updates: Array<{ taskId: string; changes: TaskStateChanges }>) => {
           for (const { taskId, changes } of updates) {
+            const before = orchestrator.getTask(taskId);
             const previousSnapshot = lastKnownTaskStates.get(taskId);
             const previousTaskStateVersion = previousSnapshot
-              ? ((JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion ?? 1)
-              : 1;
+              ? (
+                  (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
+                  ?? before?.taskStateVersion
+                  ?? 1
+                )
+              : (before?.taskStateVersion ?? 0);
             persistence.updateTask(taskId, changes);
             messageBus.publish(Channels.TASK_DELTA, {
               type: 'updated',
@@ -2845,7 +2850,7 @@ if (isHeadless) {
         }
         if (mainWindow && !mainWindow.isDestroyed()) {
           for (const removedTaskId of previousTaskIds) {
-            sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId });
+            sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
           }
           mainWindow.webContents.send('invoker:workflows-changed', workflows);
         }

--- a/packages/data-store/src/__tests__/migrate-gate-policy.test.ts
+++ b/packages/data-store/src/__tests__/migrate-gate-policy.test.ts
@@ -36,6 +36,7 @@ describe('migrateGatePolicyApprovedToCompleted', () => {
       createdAt: new Date(),
       config: {},
       execution: {},
+      taskStateVersion: 1,
       ...overrides,
     };
   }

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -35,6 +35,7 @@ describe('SQLiteAdapter', () => {
       createdAt: new Date(),
       config: {},
       execution: {},
+      taskStateVersion: 1,
       ...overrides,
     };
   }
@@ -77,6 +78,83 @@ describe('SQLiteAdapter', () => {
 
       loaded = adapter.loadTasks('wf-1');
       expect(loaded[0].execution.generation).toBe(5);
+    });
+  });
+
+  describe('task-state version persistence', () => {
+    it('saves task-state version 1 for new tasks and round-trips it', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      const loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBe(1);
+    });
+
+    it('preserves a custom task-state version value on save', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1', { taskStateVersion: 5 }));
+
+      const loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBe(5);
+    });
+
+    it('increments task-state version atomically on every updateTask call', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      adapter.updateTask('t1', { status: 'running' });
+      let loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBe(2);
+
+      adapter.updateTask('t1', { status: 'completed' });
+      loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBe(3);
+    });
+
+    it('increments task-state version even for execution-only updates', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      adapter.updateTask('t1', { execution: { startedAt: new Date() } });
+      const loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBe(2);
+    });
+
+    it('defaults to task-state version 1 for existing rows without the column', async () => {
+      // The migration adds task_state_version with DEFAULT 1, so any
+      // pre-existing rows that lack the column will get taskStateVersion = 1 on
+      // load.
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      const loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBeGreaterThanOrEqual(1);
+    });
+
+    it('loadTask returns authoritative single task by id', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      adapter.saveTask('wf-1', makeTask('t2'));
+
+      const task = adapter.loadTask('t1');
+      expect(task).toBeDefined();
+      expect(task!.id).toBe('t1');
+      expect(task!.taskStateVersion).toBe(1);
+    });
+
+    it('loadTask returns undefined for missing task', () => {
+      expect(adapter.loadTask('nonexistent')).toBeUndefined();
+    });
+
+    it('loadTask reflects task-state version after updates', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      adapter.updateTask('t1', { status: 'running' });
+      adapter.updateTask('t1', { status: 'completed' });
+
+      const task = adapter.loadTask('t1');
+      expect(task!.taskStateVersion).toBe(3);
     });
   });
 

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -76,6 +76,8 @@ export interface PersistenceAdapter {
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   loadTasks(workflowId: string): TaskState[];
+  /** Authoritative single-task read by ID, suitable for recovery workflows. */
+  loadTask(taskId: string): TaskState | undefined;
   getAllTaskIds(): string[];
   getAllTaskBranches(): string[];
   deleteAllTasks(workflowId: string): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -564,6 +564,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE attempts ADD COLUMN queue_priority INTEGER NOT NULL DEFAULT 0',
       'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
       'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
+      'ALTER TABLE tasks ADD COLUMN task_state_version INTEGER NOT NULL DEFAULT 1',
     ];
     for (const sql of migrations) {
       try {
@@ -735,7 +736,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
         remote_target_id,
         docker_image,
         execution_agent,
-        agent_name
+        agent_name,
+        task_state_version
       ) VALUES (
         ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?, ?, ?, ?, ?, ?,
@@ -751,6 +753,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ?, ?, ?, ?,
         ?, ?,
         ?, ?, ?, ?,
+        ?,
         ?,
         ?,
         ?,
@@ -810,6 +813,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       cfg.dockerImage ?? null,
       cfg.executionAgent ?? null,
       exec.agentName ?? null,
+      task.taskStateVersion ?? 1,
     ]);
   }
 
@@ -950,6 +954,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
     if (setClauses.length === 0) return;
 
+    // Atomically bump task-state version with every mutation
+    setClauses.push('task_state_version = task_state_version + 1');
+
     if (changes.execution && 'workspacePath' in changes.execution) {
       try {
         const row = this.queryOne(
@@ -982,6 +989,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
   loadTasks(workflowId: string): TaskState[] {
     const rows = this.queryAll('SELECT * FROM tasks WHERE workflow_id = ?', [workflowId]);
     return rows.map((row) => this.reconcileTaskFromSelectedAttempt(this.rowToTask(row)));
+  }
+
+  loadTask(taskId: string): TaskState | undefined {
+    const row = this.queryOne('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!row) return undefined;
+    return this.reconcileTaskFromSelectedAttempt(this.rowToTask(row));
   }
 
   getAllTaskIds(): string[] {
@@ -1670,6 +1683,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         selectedAttemptId: row.selected_attempt_id ?? undefined,
         autoFixAttempts: row.auto_fix_attempts ?? undefined,
       },
+      taskStateVersion: row.task_state_version ?? 1,
     };
   }
 

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -106,6 +106,7 @@ export interface TaskState {
   readonly createdAt: Date;
   readonly config: TaskConfig;
   readonly execution: TaskExecution;
+  readonly taskStateVersion: number;
 }
 
 export interface ExperimentVariant {
@@ -135,8 +136,8 @@ export interface TaskStateChanges {
 
 export type TaskDelta =
   | { readonly type: 'created'; readonly task: TaskState }
-  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges }
-  | { readonly type: 'removed'; readonly taskId: string };
+  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number }
+  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number };
 
 // ── Task Create Options (alias for TaskConfig) ──────────────
 
@@ -158,6 +159,7 @@ export function createTaskState(
     createdAt: new Date(),
     config: { ...options },
     execution: { generation: 0 },
+    taskStateVersion: 1,
   };
 }
 

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -126,6 +126,7 @@ export interface TaskState {
   readonly createdAt: Date;
   readonly config: TaskConfig;
   readonly execution: TaskExecution;
+  readonly taskStateVersion: number;
 }
 
 // ── Task State Changes ──────────────────────────────────────
@@ -142,8 +143,8 @@ export interface TaskStateChanges {
 
 export type TaskDelta =
   | { readonly type: 'created'; readonly task: TaskState }
-  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges }
-  | { readonly type: 'removed'; readonly taskId: string };
+  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number }
+  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number };
 
 // ── Workflow Metadata ────────────────────────────────────────
 

--- a/packages/workflow-core/src/graph-mutation.ts
+++ b/packages/workflow-core/src/graph-mutation.ts
@@ -117,11 +117,13 @@ export function reconcileMergeLeavesImpl(host: GraphMutationHost, workflowId: st
     status: 'pending',
     execution: {},
   };
-  host.writeAndSync(mergeNode.id, changes);
+  const updated = host.writeAndSync(mergeNode.id, changes);
   host.messageBus.publish(TASK_DELTA_CHANNEL, {
     type: 'updated',
     taskId: mergeNode.id,
     changes,
+    taskStateVersion: updated.taskStateVersion,
+    previousTaskStateVersion: mergeNode.taskStateVersion,
   });
 }
 
@@ -147,8 +149,8 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
       dep === mutation.sourceNodeId ? mutation.outputNodeId : dep,
     );
     const remapChanges: TaskStateChanges = { dependencies: newDeps };
-    host.writeAndSync(task.id, remapChanges);
-    const delta: TaskDelta = { type: 'updated', taskId: task.id, changes: remapChanges };
+    const remapped = host.writeAndSync(task.id, remapChanges);
+    const delta: TaskDelta = { type: 'updated', taskId: task.id, changes: remapChanges, taskStateVersion: remapped.taskStateVersion, previousTaskStateVersion: task.taskStateVersion };
     host.messageBus.publish(TASK_DELTA_CHANNEL, delta);
     allDeltas.push(delta);
   }
@@ -165,11 +167,14 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
     config: { ...baseChanges.config, ...mutation.sourceChanges?.config },
     execution: { ...baseChanges.execution, ...mutation.sourceChanges?.execution },
   } as TaskStateChanges;
-  host.writeAndSync(mutation.sourceNodeId, sourceChanges);
+  const sourceTaskBefore = host.stateMachine.getTask(mutation.sourceNodeId);
+  const updatedSource = host.writeAndSync(mutation.sourceNodeId, sourceChanges);
   const sourceDelta: TaskDelta = {
     type: 'updated',
     taskId: mutation.sourceNodeId,
     changes: sourceChanges,
+    taskStateVersion: updatedSource.taskStateVersion,
+    previousTaskStateVersion: sourceTaskBefore?.taskStateVersion ?? 0,
   };
   host.persistence.logEvent?.(
     mutation.sourceNodeId,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -717,6 +717,7 @@ export class Orchestrator {
       // value preserves the correct executorType discriminant from existing.config.
       config: { ...existing.config, ...changes.config } as TaskConfig,
       execution: { ...existing.execution, ...changes.execution },
+      taskStateVersion: existing.taskStateVersion + 1,
     };
     if (process.env.NODE_ENV !== 'test' && TRACE_PERSIST_SYNC) {
       const ex = updated.execution;
@@ -738,6 +739,32 @@ export class Orchestrator {
       this.syncWorkflowStatus(existing.config.workflowId);
     }
     return updated;
+  }
+
+  /**
+   * Build an 'updated' TaskDelta with task-state continuity metadata.
+   * `before` is the task state before the mutation, `after` is the state
+   * returned by writeAndSync.
+   */
+  private buildUpdateDelta(before: TaskState, after: TaskState, changes: TaskStateChanges): TaskDelta {
+    return {
+      type: 'updated',
+      taskId: after.id,
+      changes,
+      taskStateVersion: after.taskStateVersion,
+      previousTaskStateVersion: before.taskStateVersion,
+    };
+  }
+
+  /**
+   * Build a 'removed' TaskDelta with the task's last known task-state version.
+   */
+  private buildRemoveDelta(task: TaskState): TaskDelta {
+    return {
+      type: 'removed',
+      taskId: task.id,
+      previousTaskStateVersion: task.taskStateVersion,
+    };
   }
 
   private syncWorkflowStatus(workflowId: string): void {
@@ -848,15 +875,11 @@ export class Orchestrator {
         }
 
         const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
-        this.writeAndSync(id, changesWithGeneration, { skipWorkflowStatusSync: true });
+        const updated = this.writeAndSync(id, changesWithGeneration, { skipWorkflowStatusSync: true });
         const priorAttemptId = current.execution.selectedAttemptId;
         this.replaceSelectedAttempt(current, {}, { skipWorkflowStatusSync: true });
         this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
-        pendingTaskDeltas.push({
-          type: 'updated',
-          taskId: id,
-          changes: changesWithGeneration,
-        });
+        pendingTaskDeltas.push(this.buildUpdateDelta(current, updated, changesWithGeneration));
 
         this.clearQueuedSchedulerEntries(id, priorAttemptId);
       }
@@ -947,13 +970,9 @@ export class Orchestrator {
         status: 'failed',
         execution: { error, completedAt },
       };
-      this.writeAndSync(t.id, changes);
+      const updated = this.writeAndSync(t.id, changes);
       this.persistence.logEvent?.(t.id, 'task.cancelled', changes);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, {
-        type: 'updated',
-        taskId: t.id,
-        changes,
-      });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(t, updated, changes));
       this.deferredTaskIds.delete(t.id);
       this.clearQueuedSchedulerEntries(t.id, t.execution.selectedAttemptId);
       cancelled.push(t.id);
@@ -1468,11 +1487,11 @@ export class Orchestrator {
     const id = task.id;
 
     const changes: TaskStateChanges = { status: 'running', execution: { inputPrompt: undefined } };
-    this.writeAndSync(id, changes);
+    const updated = this.writeAndSync(id, changes);
     if (task.execution.selectedAttemptId) {
       this.taskRepository.updateAttempt(task.execution.selectedAttemptId, { status: 'running' });
     }
-    const delta: TaskDelta = { type: 'updated', taskId: id, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(id, 'task.running', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
@@ -1527,7 +1546,7 @@ export class Orchestrator {
         },
       );
     }
-    this.writeAndSync(id, changes);
+    const updated = this.writeAndSync(id, changes);
     this.updateSelectedAttempt(id, {
       status: 'needs_input',
       completedAt: changes.execution?.completedAt,
@@ -1537,7 +1556,7 @@ export class Orchestrator {
       ...(changes.execution?.workspacePath !== undefined ? { workspacePath: changes.execution.workspacePath } : {}),
       ...(keepAgentSessionId !== undefined ? { agentSessionId: keepAgentSessionId } : {}),
     });
-    const delta: TaskDelta = { type: 'updated', taskId: id, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(id, eventName, changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
@@ -1596,13 +1615,13 @@ export class Orchestrator {
       taskId: tid,
       execution: changes.execution,
     });
-    this.writeAndSync(tid, changes);
+    const updated = this.writeAndSync(tid, changes);
     this.updateSelectedAttempt(tid, {
       status: 'needs_input',
       error: originalError,
       agentSessionId: task.execution.agentSessionId,
     });
-    const delta: TaskDelta = { type: 'updated', taskId: tid, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(tid, 'task.awaiting_approval', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
@@ -1648,12 +1667,12 @@ export class Orchestrator {
       status: 'completed',
       execution: { completedAt: new Date() },
     };
-    this.writeAndSync(taskId, changes);
+    const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
       status: 'completed',
       completedAt: changes.execution?.completedAt,
     });
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(taskId, 'task.completed', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
     mergeTrace('APPROVE_DONE', { taskId });
@@ -1697,13 +1716,13 @@ export class Orchestrator {
       status: 'running',
       execution: { pendingFixError: undefined, startedAt: now, lastHeartbeatAt: now },
     };
-    this.writeAndSync(taskId, changes);
+    const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
       status: 'running',
       startedAt: now,
       lastHeartbeatAt: now,
     });
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(taskId, 'task.running', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
     return [this.stateGetTask(taskId)!];
@@ -1721,13 +1740,13 @@ export class Orchestrator {
       status: 'failed',
       execution: { error: reason ?? 'Rejected', completedAt: new Date() },
     };
-    this.writeAndSync(taskId, changes);
+    const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
       status: 'failed',
       error: reason ?? 'Rejected',
       completedAt: changes.execution?.completedAt,
     });
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(taskId, 'task.failed', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -1848,14 +1867,14 @@ export class Orchestrator {
         commit: winner?.execution.commit,
       },
     };
-    this.writeAndSync(reconId, changes);
+    const reconUpdated = this.writeAndSync(reconId, changes);
     this.updateSelectedAttempt(reconId, {
       status: 'completed',
       completedAt: changes.execution?.completedAt,
       branch: winner?.execution.branch,
       commit: winner?.execution.commit,
     });
-    const delta: TaskDelta = { type: 'updated', taskId: reconId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, reconUpdated, changes);
     this.persistence.logEvent?.(reconId, 'task.completed', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -1931,14 +1950,14 @@ export class Orchestrator {
         commit: combinedCommit,
       },
     };
-    this.writeAndSync(reconId, changes);
+    const reconUpdated = this.writeAndSync(reconId, changes);
     this.updateSelectedAttempt(reconId, {
       status: 'completed',
       completedAt: changes.execution?.completedAt,
       branch: combinedBranch,
       commit: combinedCommit,
     });
-    const delta: TaskDelta = { type: 'updated', taskId: reconId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, reconUpdated, changes);
     this.persistence.logEvent?.(reconId, 'task.completed', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -2063,8 +2082,8 @@ export class Orchestrator {
             status: 'blocked',
             execution: { blockedBy: blocker },
           };
-          this.writeAndSync(id, blockedChanges);
-          const blockedDelta: TaskDelta = { type: 'updated', taskId: id, changes: blockedChanges };
+          const blockedUpdated = this.writeAndSync(id, blockedChanges);
+          const blockedDelta: TaskDelta = this.buildUpdateDelta(current, blockedUpdated, blockedChanges);
           this.persistence.logEvent?.(id, 'task.blocked', blockedChanges);
           this.messageBus.publish(TASK_DELTA_CHANNEL, blockedDelta);
           return [this.stateGetTask(id)!];
@@ -2222,11 +2241,11 @@ export class Orchestrator {
       const current = this.stateGetTask(id);
       if (!current) continue;
       const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
-      this.writeAndSync(id, changesWithGeneration);
+      const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
       const priorAttemptId = current.execution.selectedAttemptId;
       this.replaceSelectedAttempt(current);
       this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, { type: 'updated', taskId: id, changes: changesWithGeneration });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(current, recreateUpdated, changesWithGeneration));
 
       this.deferredTaskIds.delete(id);
       this.clearQueuedSchedulerEntries(id, priorAttemptId);
@@ -2316,12 +2335,12 @@ export class Orchestrator {
       const after = this.writeAndSync(task.id, changesWithGeneration);
       const priorAttemptId = task.execution.selectedAttemptId;
       this.replaceSelectedAttempt(task);
-      this.logger.info('[agent-session-trace] recreateWorkflow: after writeAndSync', {
-        taskId: task.id,
-        agentSessionId: after.execution.agentSessionId ?? 'null',
-        containerId: after.execution.containerId ?? 'null',
-      });
-      const delta: TaskDelta = { type: 'updated', taskId: task.id, changes: changesWithGeneration };
+    this.logger.info('[agent-session-trace] recreateWorkflow: after writeAndSync', {
+      taskId: task.id,
+      agentSessionId: after.execution.agentSessionId ?? 'null',
+      containerId: after.execution.containerId ?? 'null',
+    });
+      const delta: TaskDelta = this.buildUpdateDelta(task, after, changesWithGeneration);
       this.persistence.logEvent?.(task.id, 'task.pending', changesWithGeneration);
       this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
       this.clearQueuedSchedulerEntries(task.id, priorAttemptId);
@@ -2469,7 +2488,7 @@ export class Orchestrator {
       },
     };
     const changesWithGeneration = this.withBumpedExecutionGeneration(task, changes);
-    this.writeAndSync(taskId, changesWithGeneration);
+    const conflictUpdated = this.writeAndSync(taskId, changesWithGeneration);
     const attemptId = this.replaceSelectedAttempt(task);
     this.taskRepository.updateAttempt(attemptId, {
       status: 'running',
@@ -2484,7 +2503,7 @@ export class Orchestrator {
       error: undefined,
       exitCode: undefined,
     });
-    const delta: TaskDelta = { type: 'updated', taskId: id, changes: changesWithGeneration };
+    const delta: TaskDelta = this.buildUpdateDelta(task, conflictUpdated, changesWithGeneration);
     this.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -2519,14 +2538,14 @@ export class Orchestrator {
         completedAt,
       },
     };
-    this.writeAndSync(taskId, changes);
+    const revertUpdated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
       status: 'failed',
       error: displayError,
       mergeConflict,
       completedAt,
     });
-    const delta: TaskDelta = { type: 'updated', taskId: id, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, revertUpdated, changes);
     this.persistence.logEvent?.(id, 'task.failed', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
@@ -2542,8 +2561,9 @@ export class Orchestrator {
     }
 
     const cmdChanges: TaskStateChanges = { config: { command: newCommand } };
-    this.writeAndSync(taskId, cmdChanges);
-    const cmdDelta: TaskDelta = { type: 'updated', taskId, changes: cmdChanges };
+    const cmdBefore = this.stateGetTask(taskId)!;
+    const cmdUpdated = this.writeAndSync(taskId, cmdChanges);
+    const cmdDelta: TaskDelta = this.buildUpdateDelta(cmdBefore, cmdUpdated, cmdChanges);
     this.persistence.logEvent?.(taskId, 'task.updated', cmdChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, cmdDelta);
 
@@ -2561,8 +2581,9 @@ export class Orchestrator {
     }
 
     const promptChanges: TaskStateChanges = { config: { prompt: newPrompt } };
-    this.writeAndSync(taskId, promptChanges);
-    const promptDelta: TaskDelta = { type: 'updated', taskId, changes: promptChanges };
+    const promptBefore = this.stateGetTask(taskId)!;
+    const promptUpdated = this.writeAndSync(taskId, promptChanges);
+    const promptDelta: TaskDelta = this.buildUpdateDelta(promptBefore, promptUpdated, promptChanges);
     this.persistence.logEvent?.(taskId, 'task.updated', promptChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, promptDelta);
 
@@ -2609,8 +2630,9 @@ export class Orchestrator {
       configPatch.remoteTargetId = undefined;
     }
     const typeChanges: TaskStateChanges = { config: configPatch };
-    this.writeAndSync(taskId, typeChanges);
-    const typeDelta: TaskDelta = { type: 'updated', taskId, changes: typeChanges };
+    const typeBefore = this.stateGetTask(taskId)!;
+    const typeUpdated = this.writeAndSync(taskId, typeChanges);
+    const typeDelta: TaskDelta = this.buildUpdateDelta(typeBefore, typeUpdated, typeChanges);
     this.persistence.logEvent?.(taskId, 'task.updated', typeChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, typeDelta);
 
@@ -2628,8 +2650,9 @@ export class Orchestrator {
     }
 
     const agentChanges: TaskStateChanges = { config: { executionAgent: agentName } };
-    this.writeAndSync(taskId, agentChanges);
-    const agentDelta: TaskDelta = { type: 'updated', taskId, changes: agentChanges };
+    const agentBefore = this.stateGetTask(taskId)!;
+    const agentUpdated = this.writeAndSync(taskId, agentChanges);
+    const agentDelta: TaskDelta = this.buildUpdateDelta(agentBefore, agentUpdated, agentChanges);
     this.persistence.logEvent?.(taskId, 'task.updated', agentChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, agentDelta);
 
@@ -2903,12 +2926,9 @@ export class Orchestrator {
     if (hasPromptKey) configPatch.fixPrompt = patch.fixPrompt;
     if (hasContextKey) configPatch.fixContext = patch.fixContext;
     const fixContextChanges: TaskStateChanges = { config: configPatch };
-    this.writeAndSync(taskId, fixContextChanges);
-    const fixContextDelta: TaskDelta = {
-      type: 'updated',
-      taskId,
-      changes: fixContextChanges,
-    };
+    const fixBefore = this.stateGetTask(taskId)!;
+    const fixUpdated = this.writeAndSync(taskId, fixContextChanges);
+    const fixContextDelta: TaskDelta = this.buildUpdateDelta(fixBefore, fixUpdated, fixContextChanges);
     this.persistence.logEvent?.(taskId, 'task.updated', fixContextChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, fixContextDelta);
 
@@ -3006,8 +3026,8 @@ export class Orchestrator {
     const policyChanges: TaskStateChanges = {
       config: { externalDependencies: nextDeps },
     };
-    this.writeAndSync(taskId, policyChanges);
-    const policyDelta: TaskDelta = { type: 'updated', taskId, changes: policyChanges };
+    const policyUpdated = this.writeAndSync(taskId, policyChanges);
+    const policyDelta: TaskDelta = this.buildUpdateDelta(task, policyUpdated, policyChanges);
     this.persistence.logEvent?.(taskId, 'task.external_dependency_policy_updated', {
       updates,
       changed,
@@ -3207,24 +3227,22 @@ export class Orchestrator {
       (t) => !!t.config.isMergeNode,
     );
     for (const id of descendantIds) {
+      const staleBefore = this.stateGetTask(id);
+      if (!staleBefore) continue;
       const staleChanges: TaskStateChanges = { status: 'stale' };
-      this.writeAndSync(id, staleChanges);
+      const staleUpdated = this.writeAndSync(id, staleChanges);
       this.updateSelectedAttempt(id, { status: 'superseded' });
       this.persistence.logEvent?.(id, 'task.stale', staleChanges);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, {
-        type: 'updated', taskId: id, changes: staleChanges,
-      });
-      const current = this.stateGetTask(id);
-      this.clearQueuedSchedulerEntries(id, current?.execution.selectedAttemptId);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(staleBefore, staleUpdated, staleChanges));
+      this.clearQueuedSchedulerEntries(id, staleBefore.execution.selectedAttemptId);
     }
+    const sourceBefore = this.stateGetTask(sourceId)!;
     const sourceChanges: TaskStateChanges = { status: 'stale' };
-    this.writeAndSync(sourceId, sourceChanges);
+    const sourceUpdated = this.writeAndSync(sourceId, sourceChanges);
     this.updateSelectedAttempt(sourceId, { status: 'superseded' });
     this.persistence.logEvent?.(sourceId, 'task.stale', sourceChanges);
-    this.messageBus.publish(TASK_DELTA_CHANNEL, {
-      type: 'updated', taskId: sourceId, changes: sourceChanges,
-    });
-    this.clearQueuedSchedulerEntries(sourceId, this.stateGetTask(sourceId)?.execution.selectedAttemptId);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(sourceBefore, sourceUpdated, sourceChanges));
+    this.clearQueuedSchedulerEntries(sourceId, sourceBefore.execution.selectedAttemptId);
 
     // 2. Create replacement tasks
     for (const rt of replacementTasks) {
@@ -3433,8 +3451,7 @@ export class Orchestrator {
 
     // 6. Publish removal deltas — drives UI cache cleanup via messageBus subscriber
     for (const task of affectedTasks) {
-      const delta: TaskDelta = { type: 'removed', taskId: task.id };
-      this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildRemoveDelta(task));
     }
   }
 
@@ -3465,8 +3482,7 @@ export class Orchestrator {
 
     // 5. Publish removal deltas
     for (const task of allTasks) {
-      const delta: TaskDelta = { type: 'removed', taskId: task.id };
-      this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildRemoveDelta(task));
     }
   }
 
@@ -3619,13 +3635,13 @@ export class Orchestrator {
         status: 'failed',
         execution: { error: errorMsg, completedAt: new Date() },
       };
-      this.writeAndSync(id, changes);
+      const cancelUpdated = this.writeAndSync(id, changes);
       this.updateSelectedAttempt(id, {
         status: 'failed',
         error: errorMsg,
         completedAt: changes.execution?.completedAt,
       });
-      const delta: TaskDelta = { type: 'updated', taskId: id, changes };
+      const delta: TaskDelta = this.buildUpdateDelta(t, cancelUpdated, changes);
       this.persistence.logEvent?.(id, 'task.cancelled', changes);
       this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -3682,14 +3698,14 @@ export class Orchestrator {
           completedAt: new Date(),
         },
       };
-      this.writeAndSync(id, changes);
+      const wfCancelUpdated = this.writeAndSync(id, changes);
       this.updateSelectedAttempt(id, {
         status: 'failed',
         error: 'Cancelled by user (workflow)',
         completedAt: changes.execution?.completedAt,
       });
       this.persistence.logEvent?.(id, 'task.cancelled', changes);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, { type: 'updated', taskId: id, changes });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, wfCancelUpdated, changes));
       cancelled.push(id);
     }
 
@@ -3712,8 +3728,8 @@ export class Orchestrator {
       status: 'pending',
       execution: { startedAt: undefined, lastHeartbeatAt: undefined },
     };
-    this.writeAndSync(id, changes);
-    const delta: TaskDelta = { type: 'updated', taskId: id, changes };
+    const deferUpdated = this.writeAndSync(id, changes);
+    const delta: TaskDelta = this.buildUpdateDelta(task, deferUpdated, changes);
     this.persistence.logEvent?.(id, 'task.deferred', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -3820,8 +3836,8 @@ export class Orchestrator {
       config: { summary: parsed.summary },
       execution,
     };
-    this.writeAndSync(taskId, changes);
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const completedUpdated = this.writeAndSync(taskId, changes);
+    const delta: TaskDelta = this.buildUpdateDelta(task!, completedUpdated, changes);
     const eventName = needsApproval ? 'task.awaiting_approval' : 'task.completed';
     this.persistence.logEvent?.(taskId, eventName, changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
@@ -3914,10 +3930,11 @@ export class Orchestrator {
       ...existing,
       status: 'failed',
       execution: { ...existing.execution, ...changes.execution },
+      taskStateVersion: existing.taskStateVersion + 1,
     };
     this.stateMachine.restoreTask(updated);
 
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(existing, updated, changes);
     this.persistence.logEvent?.(taskId, eventName, changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -3975,12 +3992,13 @@ export class Orchestrator {
       status: 'needs_input',
       execution: { inputPrompt: parsed.prompt },
     };
-    this.writeAndSync(taskId, changes);
-    const currentAttemptId = this.stateGetTask(taskId)?.execution.selectedAttemptId;
+    const needsInputBefore = this.stateGetTask(taskId)!;
+    const needsInputUpdated = this.writeAndSync(taskId, changes);
+    const currentAttemptId = needsInputUpdated.execution.selectedAttemptId;
     if (currentAttemptId) {
       this.taskRepository.updateAttempt(currentAttemptId, { status: 'needs_input' });
     }
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(needsInputBefore, needsInputUpdated, changes);
     this.persistence.logEvent?.(taskId, 'task.needs_input', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
     return [];
@@ -4107,8 +4125,8 @@ export class Orchestrator {
         const reconChanges: TaskStateChanges = {
           execution: { experimentResults },
         };
-        this.writeAndSync(recon.id, reconChanges);
-        const delta: TaskDelta = { type: 'updated', taskId: recon.id, changes: reconChanges };
+        const reconUpdated = this.writeAndSync(recon.id, reconChanges);
+        const delta: TaskDelta = this.buildUpdateDelta(recon, reconUpdated, reconChanges);
         this.persistence.logEvent?.(recon.id, 'task.experiment_results_recorded', reconChanges);
         this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
       }
@@ -4341,16 +4359,12 @@ export class Orchestrator {
       const changes: TaskStateChanges = {
         config: { externalDependencies: nextDeps.length > 0 ? nextDeps : undefined },
       };
-      this.writeAndSync(task.id, changes);
+      const updated = this.writeAndSync(task.id, changes);
       this.persistence.logEvent?.(task.id, 'task.external_dependency_detached', {
         workflowId,
         upstreamWorkflowId,
       });
-      this.messageBus.publish(TASK_DELTA_CHANNEL, {
-        type: 'updated',
-        taskId: task.id,
-        changes,
-      });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
     }
 
     if (!removedDependency) {
@@ -4454,11 +4468,7 @@ export class Orchestrator {
       };
       const updated = this.writeAndSync(job.taskId, changes);
       this.persistence.logEvent?.(job.taskId, 'task.running', changes);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, {
-        type: 'updated',
-        taskId: job.taskId,
-        changes,
-      });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
       started.push(updated);
       this.logger.info('[orchestrator] drainScheduler: started', {
         taskId: job.taskId,
@@ -4583,13 +4593,9 @@ export class Orchestrator {
           }
         : { execution: baseExecution };
 
-      this.writeAndSync(taskId, changes);
+      const launchUpdated = this.writeAndSync(taskId, changes);
       this.persistence.logEvent?.(taskId, 'task.running', changes);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, {
-        type: 'updated',
-        taskId,
-        changes,
-      });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, launchUpdated, changes));
       this.logger.info('[orchestrator] markTaskRunningAfterLaunch: executing', {
         taskId,
         attemptId,

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -152,7 +152,7 @@ export interface TaskState {
   readonly createdAt: Date;
   readonly config: TaskConfig;
   readonly execution: TaskExecution;
-  readonly taskStateVersion?: number;
+  readonly taskStateVersion: number;
 }
 
 export interface ExperimentVariant {
@@ -182,14 +182,8 @@ export interface TaskStateChanges {
 
 export type TaskDelta =
   | { readonly type: 'created'; readonly task: TaskState }
-  | {
-      readonly type: 'updated';
-      readonly taskId: string;
-      readonly changes: TaskStateChanges;
-      readonly previousTaskStateVersion?: number;
-      readonly taskStateVersion?: number;
-    }
-  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion?: number };
+  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number }
+  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number };
 
 // ── Task Create Options (alias for TaskConfig) ──────────────
 
@@ -218,6 +212,7 @@ export function createTaskState(
     createdAt: resolveInitialTaskTimestamp(),
     config: { ...options },
     execution: { generation: 0 },
+    taskStateVersion: 1,
   };
 }
 

--- a/run.sh
+++ b/run.sh
@@ -96,6 +96,12 @@ if [ "$1" = "--headless" ]; then
   fi
 
   shift
+  # Build @invoker/app on-demand when dist/headless-client.js is missing
+  # (e.g. fresh worktree that only ran pnpm install).
+  if [ ! -f "$REPO_ROOT/packages/app/dist/headless-client.js" ]; then
+    echo "Building @invoker/app (headless-client.js missing)..." >&2
+    pnpm --filter @invoker/app build >&2
+  fi
   exec node ./packages/app/dist/headless-client.js "$@"
 fi
 

--- a/scripts/headless-ipc.js
+++ b/scripts/headless-ipc.js
@@ -1,10 +1,26 @@
 #!/usr/bin/env node
-const { createConnection } = require('node:net');
-const { homedir } = require('node:os');
+/**
+ * Thin CLI wrapper around the shared IPC transport.
+ *
+ * Keeps CLI parsing and JSON / JSONL output.
+ * Transport policy lives in @invoker/transport (IpcBus) — this script
+ * only creates a client-only bus and delegates exec requests through it.
+ *
+ * Standalone mode: when no IPC server is reachable the script falls back
+ * to spawning the headless-client process directly, so a shared socket is
+ * not required.
+ */
+const { execFileSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
 const path = require('node:path');
 
-const DEFAULT_SOCKET_PATH =
-  process.env.INVOKER_IPC_SOCKET || path.join(homedir(), '.invoker', 'ipc-transport.sock');
+const REPO_ROOT = path.resolve(__dirname, '..');
+const TRANSPORT_DIST = path.join(REPO_ROOT, 'packages', 'transport', 'dist', 'index.js');
+const HEADLESS_CLIENT_DIST = path.join(REPO_ROOT, 'packages', 'app', 'dist', 'headless-client.js');
+
+// ---------------------------------------------------------------------------
+// EPIPE handling — keep output clean when piped to head / grep / etc.
+// ---------------------------------------------------------------------------
 
 for (const stream of [process.stdout, process.stderr]) {
   stream.on('error', (error) => {
@@ -15,25 +31,16 @@ for (const stream of [process.stdout, process.stderr]) {
   });
 }
 
+// ---------------------------------------------------------------------------
+// CLI parsing (unchanged contract)
+// ---------------------------------------------------------------------------
+
 function usage() {
   console.error(
     'Usage:\n' +
     '  node scripts/headless-ipc.js exec [--no-track] [--wait-for-approval] [--timeout-ms N] -- <headless args...>\n' +
     '  node scripts/headless-ipc.js batch-exec [--no-track] [--wait-for-approval] [--timeout-ms N] [--parallel N] < commands.jsonl',
   );
-}
-
-function withTimeout(promise, timeoutMs) {
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return promise;
-  }
-  return Promise.race([
-    promise,
-    new Promise((_, reject) => {
-      const timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
-      timer.unref?.();
-    }),
-  ]);
 }
 
 function parseCli(argv) {
@@ -84,121 +91,24 @@ function parseCli(argv) {
   return { mode, noTrack, waitForApproval, parallel, timeoutMs, args };
 }
 
-function encodeEnvelope(envelope) {
-  const json = Buffer.from(JSON.stringify(envelope), 'utf8');
-  const frame = Buffer.allocUnsafe(4 + json.length);
-  frame.writeUInt32BE(json.length, 0);
-  json.copy(frame, 4);
-  return frame;
+// ---------------------------------------------------------------------------
+// Timeout helper
+// ---------------------------------------------------------------------------
+
+function withTimeout(promise, timeoutMs) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return promise;
+  }
+  let timer;
+  const timeoutPromise = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timer));
 }
 
-class FrameDecoder {
-  constructor(onEnvelope) {
-    this.buf = Buffer.alloc(0);
-    this.onEnvelope = onEnvelope;
-  }
-
-  push(chunk) {
-    this.buf = Buffer.concat([this.buf, chunk]);
-    while (this.buf.length >= 4) {
-      const len = this.buf.readUInt32BE(0);
-      if (this.buf.length < 4 + len) {
-        break;
-      }
-      const json = this.buf.subarray(4, 4 + len).toString('utf8');
-      this.buf = this.buf.subarray(4 + len);
-      this.onEnvelope(JSON.parse(json));
-    }
-  }
-}
-
-class HeadlessIpcClient {
-  constructor(socketPath = DEFAULT_SOCKET_PATH) {
-    this.socketPath = socketPath;
-    this.nextReqId = 0;
-    this.pending = new Map();
-    this.socket = null;
-    this.decoder = new FrameDecoder((envelope) => this.handleEnvelope(envelope));
-  }
-
-  async connect() {
-    if (this.socket) {
-      return;
-    }
-    this.socket = await new Promise((resolve, reject) => {
-      const socket = createConnection({ path: this.socketPath });
-      const cleanup = () => {
-        socket.off('connect', handleConnect);
-        socket.off('error', handleError);
-      };
-      const handleConnect = () => {
-        cleanup();
-        resolve(socket);
-      };
-      const handleError = (error) => {
-        cleanup();
-        reject(error);
-      };
-      socket.once('connect', handleConnect);
-      socket.once('error', handleError);
-    });
-
-    this.socket.on('data', (chunk) => this.decoder.push(chunk));
-    this.socket.on('error', (error) => {
-      this.rejectAll(error);
-    });
-    this.socket.on('close', () => {
-      this.rejectAll(new Error('IPC socket closed'));
-      this.socket = null;
-    });
-  }
-
-  handleEnvelope(envelope) {
-    if (envelope.kind !== 'res' && envelope.kind !== 'err') {
-      return;
-    }
-    const pending = this.pending.get(envelope.reqId);
-    if (!pending) {
-      return;
-    }
-    this.pending.delete(envelope.reqId);
-    if (envelope.kind === 'err') {
-      pending.reject(new Error(envelope.message));
-      return;
-    }
-    pending.resolve(envelope.body);
-  }
-
-  rejectAll(error) {
-    for (const { reject } of this.pending.values()) {
-      reject(error);
-    }
-    this.pending.clear();
-  }
-
-  async request(channel, body) {
-    await this.connect();
-    const reqId = `req-${this.nextReqId += 1}`;
-    const response = new Promise((resolve, reject) => {
-      this.pending.set(reqId, { resolve, reject });
-    });
-    this.socket.write(encodeEnvelope({
-      kind: 'req',
-      channel,
-      body,
-      reqId,
-    }));
-    return response;
-  }
-
-  disconnect() {
-    if (!this.socket) {
-      return;
-    }
-    this.socket.destroy();
-    this.socket = null;
-  }
-}
+// ---------------------------------------------------------------------------
+// Stdin reader (for batch-exec)
+// ---------------------------------------------------------------------------
 
 async function readStdinLines() {
   const chunks = [];
@@ -208,13 +118,56 @@ async function readStdinLines() {
   return Buffer.concat(chunks).toString('utf8').split('\n').map((line) => line.trim()).filter(Boolean);
 }
 
-async function requestExec(client, item, options) {
+// ---------------------------------------------------------------------------
+// Transport — load IpcBus from the shared transport dist
+// ---------------------------------------------------------------------------
+
+async function loadTransport() {
+  if (!existsSync(TRANSPORT_DIST)) {
+    return null;
+  }
+  const mod = await import(TRANSPORT_DIST);
+  return mod;
+}
+
+async function createBus(transport) {
+  const bus = new transport.IpcBus(undefined, { allowServe: false });
+  await bus.ready();
+  return bus;
+}
+
+// ---------------------------------------------------------------------------
+// Standalone fallback — spawn headless-client directly (no socket needed)
+// ---------------------------------------------------------------------------
+
+function execStandalone(args) {
+  if (!existsSync(HEADLESS_CLIENT_DIST)) {
+    throw new Error(
+      `Standalone mode requires a built headless-client at ${HEADLESS_CLIENT_DIST}.\n` +
+      'Run: pnpm --filter @invoker/app build',
+    );
+  }
+  try {
+    execFileSync(process.execPath, [HEADLESS_CLIENT_DIST, ...args], {
+      stdio: ['inherit', 'inherit', 'inherit'],
+    });
+    return 0;
+  } catch (err) {
+    return err.status ?? 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request execution via the shared bus
+// ---------------------------------------------------------------------------
+
+async function requestExec(bus, item, options) {
   const payload = {
     args: item.args,
     noTrack: options.noTrack,
     waitForApproval: options.waitForApproval,
   };
-  const response = await withTimeout(client.request('headless.exec', payload), options.timeoutMs);
+  const response = await withTimeout(bus.request('headless.exec', payload), options.timeoutMs);
   return {
     ...item,
     ok: true,
@@ -222,20 +175,45 @@ async function requestExec(client, item, options) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
 async function main() {
   const options = parseCli(process.argv.slice(2));
-  const client = new HeadlessIpcClient();
+
+  // Try to load the shared transport module.
+  const transport = await loadTransport();
+  if (!transport) {
+    // No built transport — fall back to standalone mode for exec.
+    if (options.mode === 'exec') {
+      const cliArgs = [];
+      if (options.noTrack) cliArgs.push('--no-track');
+      if (options.waitForApproval) cliArgs.push('--wait-for-approval');
+      cliArgs.push(...options.args);
+      process.exitCode = execStandalone(cliArgs);
+      return;
+    }
+    throw new Error(
+      'batch-exec requires the shared transport module.\n' +
+      'Build the transport package: cd packages/transport && pnpm build',
+    );
+  }
+
+  // Create a client-only IPC bus (no server election).
+  const bus = await createBus(transport);
 
   try {
     if (options.mode === 'exec') {
       if (options.args.length === 0) {
         throw new Error('Missing headless args for exec');
       }
-      const result = await requestExec(client, { args: options.args }, options);
+      const result = await requestExec(bus, { args: options.args }, options);
       process.stdout.write(`${JSON.stringify(result)}\n`);
       return;
     }
 
+    // batch-exec
     const lines = await readStdinLines();
     const items = lines.map((line) => {
       const parsed = JSON.parse(line);
@@ -260,7 +238,7 @@ async function main() {
         }
         const item = items[index];
         try {
-          const result = await requestExec(client, item, options);
+          const result = await requestExec(bus, item, options);
           process.stdout.write(`${JSON.stringify(result)}\n`);
         } catch (error) {
           process.stdout.write(`${JSON.stringify({
@@ -274,7 +252,7 @@ async function main() {
 
     await Promise.all(Array.from({ length: Math.min(parallel, items.length) }, () => worker()));
   } finally {
-    client.disconnect();
+    bus.disconnect();
   }
 }
 


### PR DESCRIPTION
## Summary

This PR introduces `packages/app/src/headless-transport.ts` as the shared app-side transport for headless command execution. It centralizes owner-mode detection, mutation delegation, local fallback, and batch execution so `scripts/headless-ipc.js` becomes a thin CLI wrapper and `run.sh` can route through the same transport contract.

## Architecture

### Before

```mermaid
graph TD
    A[CLI caller] --> B[scripts/headless-ipc.js]
    B --> C[Inline owner detection and delegation rules]
    C --> D[Inline local execution and batch handling]
```

### After

```mermaid
graph TD
    A[CLI caller] --> B[HeadlessTransport]
    B --> C[Resolve owner mode once]
    C --> D[Delegate mutating commands via owner transport]
    C --> E[Run local fallback when delegation is not applicable]
    B --> F[Serve single-command and batch-exec entry points]
    G[scripts/headless-ipc.js and run.sh] --> B
```

## Test Plan

- [x] `bash scripts/e2e-dry-run/cases/case-2.14-standalone-timeout-deadlock-guard.sh && bash scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh`
- [x] `node -c scripts/headless-ipc.js`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>` or `git revert <squash-commit-sha>` after merge
- Post-revert steps: Re-run the standalone dry-run regressions above if later stack steps stay open
- Data migration? No
