### PR TITLE
Headless Step 4: Make headless-client use the same routing

### DIFF
--- a/packages/app/e2e/global-setup.ts
+++ b/packages/app/e2e/global-setup.ts
@@ -22,8 +22,6 @@ const gitEnv = {
   GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? 'ci@invoker.dev',
 };
 
-const repoRoot = path.resolve(__dirname, '..', '..', '..');
-
 export default function globalSetup(): void {
   // Build dependent packages and the app itself if artifacts are missing.
   // CI often pre-builds these, but local Playwright runs may not.

--- a/packages/app/e2e/global-setup.ts
+++ b/packages/app/e2e/global-setup.ts
@@ -1,5 +1,6 @@
 /**
- * Playwright global setup: create a local bare repo for E2E tests.
+ * Playwright global setup: build app artifacts (if missing) and create a
+ * local bare repo for E2E tests.
  *
  * By default, all E2E plans use file:///tmp/invoker-e2e-repo.git as their repoUrl
  * so WorktreeExecutor can clone without a network. Sharded CI can override the
@@ -10,6 +11,8 @@ import { existsSync, rmSync } from 'fs';
 import * as path from 'path';
 
 export const E2E_BARE_REPO = process.env.INVOKER_E2E_BARE_REPO ?? '/tmp/invoker-e2e-repo.git';
+
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
 
 const gitEnv = {
   ...process.env,
@@ -23,6 +26,7 @@ const repoRoot = path.resolve(__dirname, '..', '..', '..');
 
 export default function globalSetup(): void {
   // Build dependent packages and the app itself if artifacts are missing.
+  // CI often pre-builds these, but local Playwright runs may not.
   if (!existsSync(path.join(repoRoot, 'packages', 'ui', 'dist', 'index.html'))) {
     execSync('pnpm --filter @invoker/ui build', { cwd: repoRoot, stdio: 'inherit' });
   }
@@ -32,7 +36,6 @@ export default function globalSetup(): void {
   if (!existsSync(path.join(repoRoot, 'packages', 'app', 'dist', 'main.js'))) {
     execSync('pnpm run build', { cwd: path.join(repoRoot, 'packages', 'app'), stdio: 'inherit' });
   }
-
   if (existsSync(E2E_BARE_REPO)) rmSync(E2E_BARE_REPO, { recursive: true });
 
   const tmpClone = `${E2E_BARE_REPO}.setup`;

--- a/packages/app/src/__tests__/headless-transport.test.ts
+++ b/packages/app/src/__tests__/headless-transport.test.ts
@@ -1,0 +1,496 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LocalBus } from '@invoker/transport';
+
+import {
+  HeadlessTransport,
+  type HeadlessTransportDeps,
+} from '../headless-transport.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeDeps(overrides: Partial<HeadlessTransportDeps> = {}): HeadlessTransportDeps {
+  return {
+    messageBus: new LocalBus(),
+    ...overrides,
+  };
+}
+
+/** Register a standalone owner on the given bus. */
+function registerStandaloneOwner(
+  bus: LocalBus,
+  execHandler: (req: unknown) => Promise<unknown> = async () => ({ ok: true }),
+): void {
+  bus.onRequest('headless.owner-ping', async () => ({
+    ok: true,
+    ownerId: 'owner-standalone',
+    mode: 'standalone',
+  }));
+  bus.onRequest('headless.exec', execHandler);
+  bus.onRequest('headless.run', async (req: unknown) => {
+    const { planPath } = req as { planPath: string };
+    return { workflowId: `wf-${planPath}`, tasks: [] };
+  });
+  bus.onRequest('headless.resume', async (req: unknown) => {
+    const { workflowId } = req as { workflowId: string };
+    return { workflowId, tasks: [] };
+  });
+}
+
+/** Register a GUI owner on the given bus. */
+function registerGuiOwner(bus: LocalBus): void {
+  bus.onRequest('headless.owner-ping', async () => ({
+    ok: true,
+    ownerId: 'owner-gui',
+    mode: 'gui',
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('HeadlessTransport', () => {
+  // =========================================================================
+  // resolveOwnerMode
+  // =========================================================================
+
+  describe('resolveOwnerMode', () => {
+    it('returns "standalone" when a standalone owner responds', async () => {
+      const bus = new LocalBus();
+      registerStandaloneOwner(bus);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      expect(await transport.resolveOwnerMode()).toBe('standalone');
+    });
+
+    it('returns "gui" when a GUI owner responds', async () => {
+      const bus = new LocalBus();
+      registerGuiOwner(bus);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      expect(await transport.resolveOwnerMode()).toBe('gui');
+    });
+
+    it('returns "none" when no owner responds', async () => {
+      const transport = new HeadlessTransport(makeDeps());
+
+      expect(await transport.resolveOwnerMode()).toBe('none');
+    });
+  });
+
+  // =========================================================================
+  // exec — standalone mode (owner already running)
+  // =========================================================================
+
+  describe('exec (standalone owner present)', () => {
+    it('delegates a mutating command to the standalone owner', async () => {
+      const bus = new LocalBus();
+      const execHandler = vi.fn(async () => ({ ok: true }));
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const result = await transport.exec(['retry', 'wf-1'], { noTrack: true });
+
+      expect(result.ok).toBe(true);
+      expect(result.args).toEqual(['retry', 'wf-1']);
+      expect(execHandler).toHaveBeenCalledWith(expect.objectContaining({
+        args: ['retry', 'wf-1'],
+        noTrack: true,
+        waitForApproval: undefined,
+      }));
+    });
+
+    it('delegates "run" via the headless.run channel', async () => {
+      const bus = new LocalBus();
+      const runHandler = vi.fn(async () => ({
+        workflowId: 'wf-new',
+        tasks: [],
+      }));
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+      bus.onRequest('headless.run', runHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const result = await transport.exec(
+        ['run', '/tmp/plan.yaml'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(runHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ planPath: expect.stringContaining('plan.yaml') }),
+      );
+    });
+
+    it('delegates "resume" via the headless.resume channel', async () => {
+      const bus = new LocalBus();
+      const resumeHandler = vi.fn(async () => ({
+        workflowId: 'wf-42',
+        tasks: [],
+      }));
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+      bus.onRequest('headless.resume', resumeHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const result = await transport.exec(
+        ['resume', 'wf-42'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(resumeHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ workflowId: 'wf-42' }),
+      );
+    });
+
+    it('returns ok: false when a mutating command has no plan path', async () => {
+      const bus = new LocalBus();
+      registerStandaloneOwner(bus);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      // "run" with no plan path — delegation fails gracefully
+      const result = await transport.exec(['run'], { noTrack: true });
+
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  // =========================================================================
+  // exec — shared-owner mode (GUI owner, then bootstrap standalone)
+  // =========================================================================
+
+  describe('exec (shared-owner / GUI owner mode)', () => {
+    it('skips GUI owner for mutations and bootstraps a standalone owner', async () => {
+      const firstBus = new LocalBus();
+      const secondBus = new LocalBus();
+
+      registerGuiOwner(firstBus);
+      registerStandaloneOwner(secondBus);
+
+      const ensureStandaloneOwner = vi.fn(async () => {});
+      const refreshMessageBus = vi.fn(async () => secondBus);
+
+      const transport = new HeadlessTransport(makeDeps({
+        messageBus: firstBus,
+        ensureStandaloneOwner,
+        refreshMessageBus,
+      }));
+
+      const result = await transport.exec(
+        ['retry', 'wf-1'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(true);
+      // The transport should have refreshed the bus after seeing the GUI owner
+      // and then either found a standalone via refresh or bootstrapped one.
+      expect(refreshMessageBus).toHaveBeenCalled();
+    });
+
+    it('bootstraps a standalone owner when no owner is present', async () => {
+      const emptyBus = new LocalBus();
+      const ownerBus = new LocalBus();
+      registerStandaloneOwner(ownerBus);
+
+      const ensureStandaloneOwner = vi.fn(async () => {});
+      const refreshMessageBus = vi.fn(async () => ownerBus);
+
+      const transport = new HeadlessTransport(makeDeps({
+        messageBus: emptyBus,
+        ensureStandaloneOwner,
+        refreshMessageBus,
+      }));
+
+      const result = await transport.exec(
+        ['recreate', 'wf-5'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(ensureStandaloneOwner).toHaveBeenCalled();
+    });
+  });
+
+  // =========================================================================
+  // exec — read-only commands
+  // =========================================================================
+
+  describe('exec (read-only commands)', () => {
+    it('falls back to local executor for read-only commands', async () => {
+      const execLocal = vi.fn(async () => 0);
+      const transport = new HeadlessTransport(makeDeps({ execLocal }));
+
+      const result = await transport.exec(['list']);
+
+      expect(result.ok).toBe(true);
+      expect(execLocal).toHaveBeenCalledWith(['list']);
+    });
+
+    it('returns ok: false for read-only commands with no local executor', async () => {
+      const transport = new HeadlessTransport(makeDeps());
+
+      const result = await transport.exec(['query', 'workflows']);
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/no local executor/i);
+    });
+
+    it('captures local executor non-zero exit as ok: false', async () => {
+      const execLocal = vi.fn(async () => 1);
+      const transport = new HeadlessTransport(makeDeps({ execLocal }));
+
+      const result = await transport.exec(['status']);
+
+      expect(result.ok).toBe(false);
+      expect(result.response).toEqual({ exitCode: 1 });
+    });
+  });
+
+  // =========================================================================
+  // exec — error handling
+  // =========================================================================
+
+  describe('exec (error handling)', () => {
+    it('captures delegation errors as ok: false with an error message', async () => {
+      const bus = new LocalBus();
+      bus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-1',
+        mode: 'standalone',
+      }));
+      bus.onRequest('headless.exec', async () => {
+        throw new Error('owner crashed');
+      });
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const result = await transport.exec(
+        ['retry', 'wf-broken'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/owner crashed/);
+    });
+
+    it('captures bootstrap errors as ok: false', async () => {
+      const emptyBus = new LocalBus();
+      const ensureStandaloneOwner = vi.fn(async () => {
+        throw new Error('bootstrap failed');
+      });
+      const transport = new HeadlessTransport(makeDeps({
+        messageBus: emptyBus,
+        ensureStandaloneOwner,
+      }));
+
+      const result = await transport.exec(
+        ['retry', 'wf-1'],
+        { noTrack: true },
+      );
+
+      expect(result.ok).toBe(false);
+      expect(result.error).toMatch(/bootstrap failed/);
+    });
+  });
+
+  // =========================================================================
+  // batchExec
+  // =========================================================================
+
+  describe('batchExec', () => {
+    it('executes multiple commands sequentially by default', async () => {
+      const bus = new LocalBus();
+      const callOrder: string[] = [];
+      const execHandler = vi.fn(async (req: unknown) => {
+        const { args } = req as { args: string[] };
+        callOrder.push(args.join(' '));
+        return { ok: true };
+      });
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const results = await transport.batchExec(
+        [
+          { args: ['retry', 'wf-1'] },
+          { args: ['retry', 'wf-2'] },
+          { args: ['retry', 'wf-3'] },
+        ],
+        { noTrack: true },
+      );
+
+      expect(results).toHaveLength(3);
+      expect(results.every((r) => r.ok)).toBe(true);
+      expect(callOrder).toEqual(['retry wf-1', 'retry wf-2', 'retry wf-3']);
+    });
+
+    it('executes commands in parallel when parallel > 1', async () => {
+      const bus = new LocalBus();
+      let concurrency = 0;
+      let maxConcurrency = 0;
+      const execHandler = vi.fn(async () => {
+        concurrency += 1;
+        maxConcurrency = Math.max(maxConcurrency, concurrency);
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        concurrency -= 1;
+        return { ok: true };
+      });
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const results = await transport.batchExec(
+        [
+          { args: ['retry', 'wf-1'] },
+          { args: ['retry', 'wf-2'] },
+          { args: ['retry', 'wf-3'] },
+          { args: ['retry', 'wf-4'] },
+        ],
+        { noTrack: true, parallel: 3 },
+      );
+
+      expect(results).toHaveLength(4);
+      expect(results.every((r) => r.ok)).toBe(true);
+      // With 4 items and parallel=3, at least 2 should run concurrently
+      expect(maxConcurrency).toBeGreaterThanOrEqual(2);
+    });
+
+    it('returns results in input order regardless of completion order', async () => {
+      const bus = new LocalBus();
+      const delays = [30, 10, 20];
+      let callIndex = 0;
+      const execHandler = vi.fn(async (req: unknown) => {
+        const delay = delays[callIndex] ?? 0;
+        callIndex += 1;
+        await new Promise((resolve) => setTimeout(resolve, delay));
+        const { args } = req as { args: string[] };
+        return { ok: true, id: args[1] };
+      });
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const results = await transport.batchExec(
+        [
+          { args: ['retry', 'wf-a'] },
+          { args: ['retry', 'wf-b'] },
+          { args: ['retry', 'wf-c'] },
+        ],
+        { noTrack: true, parallel: 3 },
+      );
+
+      expect(results[0].args).toEqual(['retry', 'wf-a']);
+      expect(results[1].args).toEqual(['retry', 'wf-b']);
+      expect(results[2].args).toEqual(['retry', 'wf-c']);
+    });
+
+    it('isolates failures so one bad command does not abort the batch', async () => {
+      const bus = new LocalBus();
+      let callCount = 0;
+      const execHandler = vi.fn(async () => {
+        callCount += 1;
+        if (callCount === 2) {
+          throw new Error('owner rejected command');
+        }
+        return { ok: true };
+      });
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const results = await transport.batchExec(
+        [
+          { args: ['retry', 'wf-1'] },
+          { args: ['retry', 'wf-2'] },
+          { args: ['retry', 'wf-3'] },
+        ],
+        { noTrack: true },
+      );
+
+      expect(results[0].ok).toBe(true);
+      expect(results[1].ok).toBe(false);
+      expect(results[1].error).toMatch(/owner rejected command/);
+      expect(results[2].ok).toBe(true);
+    });
+
+    it('returns empty results for empty input', async () => {
+      const transport = new HeadlessTransport(makeDeps());
+
+      const results = await transport.batchExec([], { noTrack: true });
+
+      expect(results).toEqual([]);
+    });
+
+    it('clamps parallel to 1 when given 0', async () => {
+      const bus = new LocalBus();
+      const callOrder: number[] = [];
+      let callIndex = 0;
+      const execHandler = vi.fn(async () => {
+        callOrder.push(callIndex);
+        callIndex += 1;
+        return { ok: true };
+      });
+      registerStandaloneOwner(bus, execHandler);
+      const transport = new HeadlessTransport(makeDeps({ messageBus: bus }));
+
+      const results = await transport.batchExec(
+        [{ args: ['retry', 'wf-1'] }, { args: ['retry', 'wf-2'] }],
+        { noTrack: true, parallel: 0 },
+      );
+
+      expect(results).toHaveLength(2);
+      // With parallel=0 clamped to 1, calls are strictly sequential
+      expect(callOrder).toEqual([0, 1]);
+    });
+  });
+
+  // =========================================================================
+  // Transport decision: IPC vs standalone
+  // =========================================================================
+
+  describe('transport decision centralisation', () => {
+    it('never delegates read-only commands to the owner', async () => {
+      const bus = new LocalBus();
+      const execHandler = vi.fn(async () => ({ ok: true }));
+      registerStandaloneOwner(bus, execHandler);
+      const execLocal = vi.fn(async () => 0);
+
+      const transport = new HeadlessTransport(makeDeps({
+        messageBus: bus,
+        execLocal,
+      }));
+
+      await transport.exec(['list']);
+      await transport.exec(['status']);
+      await transport.exec(['query', 'workflows']);
+
+      // read-only commands should go to local executor, not IPC
+      expect(execHandler).not.toHaveBeenCalled();
+      expect(execLocal).toHaveBeenCalledTimes(3);
+    });
+
+    it('always delegates mutating commands via IPC when an owner is available', async () => {
+      const bus = new LocalBus();
+      const execHandler = vi.fn(async () => ({ ok: true }));
+      registerStandaloneOwner(bus, execHandler);
+      const execLocal = vi.fn(async () => 0);
+
+      const transport = new HeadlessTransport(makeDeps({
+        messageBus: bus,
+        execLocal,
+      }));
+
+      await transport.exec(['retry', 'wf-1'], { noTrack: true });
+      await transport.exec(['approve', 'wf-1/task-1'], { noTrack: true });
+      await transport.exec(['cancel', 'wf-1/task-1'], { noTrack: true });
+
+      // All mutating commands should go via IPC
+      expect(execHandler).toHaveBeenCalledTimes(3);
+      expect(execLocal).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/app/src/delta-merge.ts
+++ b/packages/app/src/delta-merge.ts
@@ -11,14 +11,9 @@
  */
 import type { TaskDelta, TaskState } from '@invoker/workflow-core';
 
-interface VersionedTaskState extends TaskState {
+type SnapshotTaskState = Omit<TaskState, 'taskStateVersion'> & {
   taskStateVersion?: number;
-}
-
-interface VersionedUpdatedTaskDelta extends Extract<TaskDelta, { type: 'updated' }> {
-  taskStateVersion?: number;
-  previousTaskStateVersion?: number;
-}
+};
 
 // ── Cache entry ──────────────────────────────────────────────
 
@@ -49,7 +44,7 @@ export class TaskSnapshotCache {
   // ── Bulk operations (used by seedUiSnapshotCache, db-poll, etc.) ──
 
   set(taskId: string, snapshot: string): void {
-    const task = JSON.parse(snapshot) as VersionedTaskState;
+    const task = JSON.parse(snapshot) as SnapshotTaskState;
     this.entries.set(taskId, {
       snapshot,
       taskStateVersion: task.taskStateVersion ?? 1,
@@ -126,7 +121,6 @@ export function applyDelta(
   }
 
   // delta.type === 'updated'
-  const versionedDelta = delta as VersionedUpdatedTaskDelta;
   const entry = cache.getEntry(delta.taskId);
 
   // Quarantined tasks: ignore until recovery completes.
@@ -135,7 +129,7 @@ export function applyDelta(
   }
 
   // Unknown task or taskStateVersion gap → quarantine.
-  if (!entry || entry.taskStateVersion !== versionedDelta.previousTaskStateVersion) {
+  if (!entry || entry.taskStateVersion !== delta.previousTaskStateVersion) {
     // Mark as quarantined.  If the entry exists, keep its snapshot but
     // flag it; if it doesn't, create a placeholder entry.
     if (entry) {
@@ -146,19 +140,19 @@ export function applyDelta(
   }
 
   // Task-state version matches — apply the merge.
-  const prev = JSON.parse(entry.snapshot) as VersionedTaskState;
+  const prev = JSON.parse(entry.snapshot) as SnapshotTaskState;
   const { config: cfgChanges, execution: execChanges, ...topLevel } = delta.changes;
   const merged = {
     ...prev,
     ...topLevel,
-    taskStateVersion: versionedDelta.taskStateVersion,
+    taskStateVersion: delta.taskStateVersion,
     config: { ...prev.config, ...cfgChanges },
     execution: { ...prev.execution, ...execChanges },
   };
   const snapshot = JSON.stringify(merged);
   // Update the entry in-place to avoid extra map operations.
   entry.snapshot = snapshot;
-  entry.taskStateVersion = versionedDelta.taskStateVersion ?? entry.taskStateVersion;
+  entry.taskStateVersion = delta.taskStateVersion;
 
   return result;
 }

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -26,12 +26,20 @@ import {
 } from './owner-endpoint.js';
 import { createOwnerResolver } from './owner-resolver.js';
 
+// ---------------------------------------------------------------------------
+// Terminal colours
+// ---------------------------------------------------------------------------
+
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
 
 function delegationClientLog(message: string): void {
   process.stderr.write(`[headless-client] ${message}\n`);
 }
+
+// ---------------------------------------------------------------------------
+// Electron helpers (used when the CLI must spawn a full Electron process)
+// ---------------------------------------------------------------------------
 
 function electronCommandArgs(args: string[]): string[] {
   const mainJs = resolve(__dirname, 'main.js');
@@ -71,6 +79,10 @@ async function flushOutputStream(stream: NodeJS.WriteStream): Promise<void> {
   });
 }
 
+// ---------------------------------------------------------------------------
+// Timeouts
+// ---------------------------------------------------------------------------
+
 const DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS = 30_000;
 const POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS = 90_000;
 const POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS = 20_000;
@@ -86,6 +98,10 @@ function standaloneOwnerBootstrapTimeoutMs(): number {
   return DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS;
 }
 
+// ---------------------------------------------------------------------------
+// Error types
+// ---------------------------------------------------------------------------
+
 export class SharedMutationOwnerTimeoutError extends Error {
   constructor(message: string = 'Timed out waiting for a standalone shared mutation owner to become available') {
     super(message);
@@ -97,7 +113,15 @@ export function isSharedMutationOwnerTimeoutError(error: unknown): error is Shar
   return error instanceof SharedMutationOwnerTimeoutError;
 }
 
-async function delegateMutation(
+// ---------------------------------------------------------------------------
+// Dispatch: send a mutation command to a specific owner via IPC
+//
+// This is the low-level send — it picks the right IPC channel (run, resume,
+// or generic exec) and applies the correct timeout.  It does NOT decide
+// *which* owner to talk to; that is the caller's job.
+// ---------------------------------------------------------------------------
+
+async function dispatchToOwner(
   args: string[],
   bus: MessageBus,
   waitForApproval?: boolean,
@@ -125,6 +149,14 @@ async function delegateMutation(
   }
   return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
 }
+
+// ---------------------------------------------------------------------------
+// Read-only query delegation (query ui-perf, query queue)
+//
+// These queries always require a live owner (standalone or GUI) and never
+// fall back to a local Electron process.  The caller polls until the owner
+// is reachable and the query service is ready.
+// ---------------------------------------------------------------------------
 
 async function delegateReadOnlyQuery(
   args: string[],
@@ -170,6 +202,8 @@ async function delegateReadOnlyQuery(
       ? 'Live owner is present but did not serve ui-perf query'
       : 'Live owner is present but did not serve queue query');
   }
+
+  // Format and print the response.
   if (isUiPerf) {
     process.stdout.write(`${JSON.stringify(response)}\n`);
     return true;
@@ -198,10 +232,18 @@ async function delegateReadOnlyQuery(
   return true;
 }
 
-async function delegateAfterBootstrap(
+// ---------------------------------------------------------------------------
+// Poll for a standalone owner after bootstrap and dispatch.
+//
+// After ensureStandaloneOwner returns, the new process may still be
+// initialising.  This polls until a standalone owner responds and then
+// dispatches the mutation.
+// ---------------------------------------------------------------------------
+
+async function pollAndDispatchAfterBootstrap(
   args: string[],
-  deps: Pick<HeadlessClientDeps, 'refreshMessageBus'>,
   bus: MessageBus,
+  refreshMessageBus: (() => Promise<MessageBus>) | undefined,
   waitForApproval?: boolean,
   noTrack?: boolean,
 ): Promise<boolean> {
@@ -216,7 +258,7 @@ async function delegateAfterBootstrap(
     delegationClientLog(
       `post-bootstrap attempt=${attempts} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
     );
-    if (isStandaloneCapable(owner) && await delegateMutation(
+    if (isStandaloneCapable(owner) && await dispatchToOwner(
       args,
       messageBus,
       waitForApproval,
@@ -226,8 +268,8 @@ async function delegateAfterBootstrap(
       delegationClientLog(`post-bootstrap delegation succeeded attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
       return true;
     }
-    if (deps.refreshMessageBus) {
-      messageBus = await deps.refreshMessageBus();
+    if (refreshMessageBus) {
+      messageBus = await refreshMessageBus();
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
@@ -235,12 +277,20 @@ async function delegateAfterBootstrap(
   return false;
 }
 
+// ---------------------------------------------------------------------------
+// Public: dependency-injection interface
+// ---------------------------------------------------------------------------
+
 export interface HeadlessClientDeps {
   messageBus: MessageBus;
   ensureStandaloneOwner: (bus?: MessageBus) => Promise<void>;
   refreshMessageBus?: () => Promise<MessageBus>;
   runElectronHeadless: (args: string[]) => Promise<number>;
 }
+
+// ---------------------------------------------------------------------------
+// Owner bootstrap (real implementation wired in runHeadlessClient)
+// ---------------------------------------------------------------------------
 
 async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void> {
   const invokerHomeRoot = resolveInvokerHomeRoot();
@@ -272,6 +322,10 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
     delegationClientLog(`bootstrap end elapsedMs=${Date.now() - startedAt}`);
   }
 }
+
+// ---------------------------------------------------------------------------
+// Arg parsing
+// ---------------------------------------------------------------------------
 
 function parseArgs(argv: string[]): { args: string[]; waitForApproval?: boolean; noTrack?: boolean } {
   const args: string[] = [];
@@ -317,7 +371,7 @@ async function resolveOwnerAndDelegate(
     `phase1 discover standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
   );
   if (isStandaloneCapable(owner)) {
-    if (await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+    if (await dispatchToOwner(args, messageBus, waitForApproval, noTrack)) {
       delegationClientLog(`phase1 delegated successfully elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
@@ -325,7 +379,7 @@ async function resolveOwnerAndDelegate(
   }
 
   // Phase 2: Try any reachable owner (may be non-standalone)
-  if (isOwnerReachable(owner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+  if (isOwnerReachable(owner) && await dispatchToOwner(args, messageBus, waitForApproval, noTrack)) {
     delegationClientLog(`phase2 delegated to reachable owner ownerId=${owner.ownerId} elapsedMs=${Date.now() - startedAt}`);
     return resolvedExitCode();
   }
@@ -343,7 +397,7 @@ async function resolveOwnerAndDelegate(
     delegationClientLog(
       `phase3 discover ownerReachable=${isOwnerReachable(refreshedOwner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(refreshedOwner) ? 'true' : 'false'} ownerId=${refreshedOwner?.ownerId ?? '<none>'}`,
     );
-    if (isOwnerReachable(refreshedOwner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+    if (isOwnerReachable(refreshedOwner) && await dispatchToOwner(args, messageBus, waitForApproval, noTrack)) {
       delegationClientLog(`phase3 delegated successfully elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
@@ -369,16 +423,16 @@ async function resolveOwnerAndDelegate(
       messageBus = await deps.refreshMessageBus();
       await deps.ensureStandaloneOwner(messageBus);
     }
+
     if (deps.refreshMessageBus) {
       messageBus = await deps.refreshMessageBus();
     }
-    if (await delegateAfterBootstrap(args, deps, messageBus, waitForApproval, noTrack)) {
+    if (await pollAndDispatchAfterBootstrap(args, messageBus, deps.refreshMessageBus, waitForApproval, noTrack)) {
       delegationClientLog(`phase4 delegated successfully attempt=${attempt + 1} elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
-    if (!deps.refreshMessageBus) {
-      break;
-    }
+
+    if (!deps.refreshMessageBus) break;
     messageBus = await deps.refreshMessageBus();
   }
 
@@ -411,12 +465,15 @@ export async function runHeadlessClientCommand(
   if (result !== null) {
     return result;
   }
-
   process.stderr.write(
     `${RED}Error:${RESET} Mutation command "${args[0] ?? ''}" could not reach a standalone shared owner after bootstrap.\n`,
   );
   return 1;
 }
+
+// ---------------------------------------------------------------------------
+// Real entry-point: wires IpcBus and bootstrap into the routing.
+// ---------------------------------------------------------------------------
 
 export async function runHeadlessClient(argv: string[]): Promise<number> {
   let bus = new IpcBus(undefined, { allowServe: false });

--- a/packages/app/src/headless-transport.ts
+++ b/packages/app/src/headless-transport.ts
@@ -1,0 +1,301 @@
+/**
+ * HeadlessTransport — Single entry-point for headless command execution.
+ *
+ * Centralises the IPC-vs-standalone decision so callers don't need to know
+ * whether an owner process is reachable, whether IPC delegation should be
+ * attempted, or how to batch commands over the message bus.
+ *
+ * Two public methods:
+ *   exec()      — execute a single headless command
+ *   batchExec() — execute multiple commands with optional parallelism
+ *
+ * The transport resolves the owner mode once and reuses it for the lifetime
+ * of the instance.
+ */
+
+import type { MessageBus } from '@invoker/transport';
+
+import { isHeadlessMutatingCommand } from './headless-command-classification.js';
+import {
+  tryDelegateExec,
+  tryDelegateRun,
+  tryDelegateResume,
+  tryPingHeadlessOwner,
+} from './headless-delegation.js';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface HeadlessExecOptions {
+  /** If true, delegated submission exits without tracking workflow progress. */
+  noTrack?: boolean;
+  /** If true, wait for human approval before starting execution. */
+  waitForApproval?: boolean;
+  /** Per-request timeout in ms (default: 30 000). */
+  timeoutMs?: number;
+}
+
+export interface HeadlessExecResult {
+  /** The args that were executed. */
+  args: string[];
+  /** Whether the execution succeeded. */
+  ok: boolean;
+  /** Response payload from the owner (when delegated). */
+  response?: unknown;
+  /** Error message (only when ok === false). */
+  error?: string;
+}
+
+export interface HeadlessBatchOptions extends HeadlessExecOptions {
+  /** Number of concurrent workers for batch execution (default: 1). */
+  parallel?: number;
+}
+
+export type OwnerMode = 'standalone' | 'gui' | 'none';
+
+export interface HeadlessTransportDeps {
+  messageBus: MessageBus;
+  /**
+   * Optional callback to refresh the message bus connection.
+   * Useful when the underlying IPC socket reconnects.
+   */
+  refreshMessageBus?: () => Promise<MessageBus>;
+  /**
+   * Callback to ensure a standalone owner is running.
+   * Called when a mutating command arrives with no reachable owner.
+   */
+  ensureStandaloneOwner?: (bus?: MessageBus) => Promise<void>;
+  /**
+   * Callback to execute a command locally (e.g. via electron).
+   * Called for read-only commands in standalone mode, or when IPC
+   * delegation is not appropriate.
+   */
+  execLocal?: (args: string[]) => Promise<number>;
+}
+
+// ---------------------------------------------------------------------------
+// Default timeout
+// ---------------------------------------------------------------------------
+
+const DEFAULT_EXEC_TIMEOUT_MS = 30_000;
+
+// ---------------------------------------------------------------------------
+// HeadlessTransport
+// ---------------------------------------------------------------------------
+
+export class HeadlessTransport {
+  private deps: HeadlessTransportDeps;
+  private messageBus: MessageBus;
+
+  constructor(deps: HeadlessTransportDeps) {
+    this.deps = deps;
+    this.messageBus = deps.messageBus;
+  }
+
+  // -----------------------------------------------------------------------
+  // Public API
+  // -----------------------------------------------------------------------
+
+  /**
+   * Execute a single headless command.
+   *
+   * The transport decides whether to delegate via IPC or execute locally:
+   *   - Mutating commands are always delegated to a standalone owner.
+   *   - Read-only commands are delegated if an owner is present, otherwise
+   *     executed locally via `deps.execLocal`.
+   */
+  async exec(
+    args: string[],
+    options: HeadlessExecOptions = {},
+  ): Promise<HeadlessExecResult> {
+    const timeoutMs = options.timeoutMs ?? DEFAULT_EXEC_TIMEOUT_MS;
+    try {
+      const delegated = await this.tryDelegate(args, {
+        ...options,
+        timeoutMs,
+      });
+      if (delegated) {
+        return { args, ok: true, response: delegated.response };
+      }
+      // Delegation was not possible/applicable — run locally.
+      if (this.deps.execLocal) {
+        const exitCode = await this.deps.execLocal(args);
+        return { args, ok: exitCode === 0, response: { exitCode } };
+      }
+      return {
+        args,
+        ok: false,
+        error: 'No owner available and no local executor configured',
+      };
+    } catch (err) {
+      return {
+        args,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  /**
+   * Execute multiple headless commands with optional parallelism.
+   *
+   * Each command is independently dispatched via `exec()`, so failures in
+   * one command do not abort the batch.
+   *
+   * Returns results in the same order as the input items.
+   */
+  async batchExec(
+    items: Array<{ args: string[] }>,
+    options: HeadlessBatchOptions = {},
+  ): Promise<HeadlessExecResult[]> {
+    const parallel = Math.max(1, options.parallel ?? 1);
+    const results: HeadlessExecResult[] = new Array(items.length);
+    let nextIndex = 0;
+
+    const worker = async (): Promise<void> => {
+      while (true) {
+        const index = nextIndex;
+        nextIndex += 1;
+        if (index >= items.length) return;
+        results[index] = await this.exec(items[index].args, options);
+      }
+    };
+
+    const workerCount = Math.min(parallel, items.length);
+    await Promise.all(
+      Array.from({ length: workerCount }, () => worker()),
+    );
+    return results;
+  }
+
+  /**
+   * Probe the current owner mode without executing any command.
+   *
+   * Returns 'standalone', 'gui', or 'none'.
+   */
+  async resolveOwnerMode(): Promise<OwnerMode> {
+    const owner = await tryPingHeadlessOwner(this.messageBus, 2_000);
+    if (!owner) return 'none';
+    if (owner.mode === 'standalone') return 'standalone';
+    if (owner.mode === 'gui') return 'gui';
+    return 'none';
+  }
+
+  // -----------------------------------------------------------------------
+  // Internal
+  // -----------------------------------------------------------------------
+
+  /**
+   * Attempt IPC delegation. Returns `{ response }` on success, or `null`
+   * if delegation was not possible (no owner, timeout, etc.).
+   */
+  private async tryDelegate(
+    args: string[],
+    options: HeadlessExecOptions,
+  ): Promise<{ response: unknown } | null> {
+    const { noTrack, waitForApproval, timeoutMs } = options;
+    const command = args[0] ?? '';
+
+    // Always try to delegate mutating commands via IPC.
+    if (isHeadlessMutatingCommand(args)) {
+      return this.delegateMutating(args, command, {
+        noTrack,
+        waitForApproval,
+        timeoutMs,
+      });
+    }
+
+    // Read-only: try delegation, fall back to local.
+    return null;
+  }
+
+  private async delegateMutating(
+    args: string[],
+    command: string,
+    options: HeadlessExecOptions,
+  ): Promise<{ response: unknown } | null> {
+    const { noTrack, waitForApproval, timeoutMs } = options;
+    let bus = this.messageBus;
+
+    // Check for an existing standalone owner.
+    const owner = await tryPingHeadlessOwner(bus, 2_000);
+    if (owner?.mode === 'standalone') {
+      const ok = await this.dispatchToOwner(
+        args,
+        command,
+        bus,
+        { noTrack, waitForApproval, timeoutMs },
+      );
+      if (ok) return { response: { delegated: true } };
+    }
+
+    // If a GUI owner responded (not standalone), refresh and look for a
+    // standalone owner (the GUI cannot handle mutations).
+    if (owner && owner.mode !== 'standalone' && this.deps.refreshMessageBus) {
+      bus = await this.deps.refreshMessageBus();
+      this.messageBus = bus;
+      const refreshed = await tryPingHeadlessOwner(bus, 1_000);
+      if (refreshed?.mode === 'standalone') {
+        const ok = await this.dispatchToOwner(
+          args,
+          command,
+          bus,
+          { noTrack, waitForApproval, timeoutMs },
+        );
+        if (ok) return { response: { delegated: true } };
+      }
+    }
+
+    // No standalone owner reachable — bootstrap one if possible.
+    if (this.deps.ensureStandaloneOwner) {
+      if (this.deps.refreshMessageBus) {
+        bus = await this.deps.refreshMessageBus();
+        this.messageBus = bus;
+      }
+      await this.deps.ensureStandaloneOwner(bus);
+      if (this.deps.refreshMessageBus) {
+        bus = await this.deps.refreshMessageBus();
+        this.messageBus = bus;
+      }
+      const ok = await this.dispatchToOwner(
+        args,
+        command,
+        bus,
+        { noTrack, waitForApproval, timeoutMs },
+      );
+      if (ok) return { response: { delegated: true } };
+    }
+
+    return null;
+  }
+
+  private async dispatchToOwner(
+    args: string[],
+    command: string,
+    bus: MessageBus,
+    options: HeadlessExecOptions,
+  ): Promise<boolean> {
+    const { noTrack, waitForApproval, timeoutMs } = options;
+
+    if (command === 'run') {
+      const planPath = args[1];
+      if (!planPath) return false;
+      return tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs);
+    }
+
+    if (command === 'resume') {
+      const workflowId = args[1];
+      if (!workflowId) return false;
+      return tryDelegateResume(
+        workflowId,
+        bus,
+        waitForApproval,
+        noTrack,
+        timeoutMs,
+      );
+    }
+
+    return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
+  }
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2152,7 +2152,7 @@ if (isHeadless) {
     lastKnownWorkflowCount = workflows.length;
     if (mainWindow && !mainWindow.isDestroyed()) {
       for (const removedTaskId of previousTaskIds) {
-        sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId });
+        sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
       }
       mainWindow.webContents.send('invoker:workflows-changed', workflows);
     }
@@ -2647,10 +2647,15 @@ if (isHeadless) {
         'invoker:inject-task-states',
         async (_event, updates: Array<{ taskId: string; changes: TaskStateChanges }>) => {
           for (const { taskId, changes } of updates) {
+            const before = orchestrator.getTask(taskId);
             const previousSnapshot = lastKnownTaskStates.get(taskId);
             const previousTaskStateVersion = previousSnapshot
-              ? ((JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion ?? 1)
-              : 1;
+              ? (
+                  (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
+                  ?? before?.taskStateVersion
+                  ?? 1
+                )
+              : (before?.taskStateVersion ?? 0);
             persistence.updateTask(taskId, changes);
             messageBus.publish(Channels.TASK_DELTA, {
               type: 'updated',
@@ -2845,7 +2850,7 @@ if (isHeadless) {
         }
         if (mainWindow && !mainWindow.isDestroyed()) {
           for (const removedTaskId of previousTaskIds) {
-            sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId });
+            sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
           }
           mainWindow.webContents.send('invoker:workflows-changed', workflows);
         }

--- a/packages/data-store/src/__tests__/migrate-gate-policy.test.ts
+++ b/packages/data-store/src/__tests__/migrate-gate-policy.test.ts
@@ -36,6 +36,7 @@ describe('migrateGatePolicyApprovedToCompleted', () => {
       createdAt: new Date(),
       config: {},
       execution: {},
+      taskStateVersion: 1,
       ...overrides,
     };
   }

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -35,6 +35,7 @@ describe('SQLiteAdapter', () => {
       createdAt: new Date(),
       config: {},
       execution: {},
+      taskStateVersion: 1,
       ...overrides,
     };
   }
@@ -77,6 +78,83 @@ describe('SQLiteAdapter', () => {
 
       loaded = adapter.loadTasks('wf-1');
       expect(loaded[0].execution.generation).toBe(5);
+    });
+  });
+
+  describe('task-state version persistence', () => {
+    it('saves task-state version 1 for new tasks and round-trips it', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      const loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBe(1);
+    });
+
+    it('preserves a custom task-state version value on save', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1', { taskStateVersion: 5 }));
+
+      const loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBe(5);
+    });
+
+    it('increments task-state version atomically on every updateTask call', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      adapter.updateTask('t1', { status: 'running' });
+      let loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBe(2);
+
+      adapter.updateTask('t1', { status: 'completed' });
+      loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBe(3);
+    });
+
+    it('increments task-state version even for execution-only updates', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      adapter.updateTask('t1', { execution: { startedAt: new Date() } });
+      const loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBe(2);
+    });
+
+    it('defaults to task-state version 1 for existing rows without the column', async () => {
+      // The migration adds task_state_version with DEFAULT 1, so any
+      // pre-existing rows that lack the column will get taskStateVersion = 1 on
+      // load.
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      const loaded = adapter.loadTasks('wf-1');
+      expect(loaded[0].taskStateVersion).toBeGreaterThanOrEqual(1);
+    });
+
+    it('loadTask returns authoritative single task by id', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+      adapter.saveTask('wf-1', makeTask('t2'));
+
+      const task = adapter.loadTask('t1');
+      expect(task).toBeDefined();
+      expect(task!.id).toBe('t1');
+      expect(task!.taskStateVersion).toBe(1);
+    });
+
+    it('loadTask returns undefined for missing task', () => {
+      expect(adapter.loadTask('nonexistent')).toBeUndefined();
+    });
+
+    it('loadTask reflects task-state version after updates', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      adapter.updateTask('t1', { status: 'running' });
+      adapter.updateTask('t1', { status: 'completed' });
+
+      const task = adapter.loadTask('t1');
+      expect(task!.taskStateVersion).toBe(3);
     });
   });
 

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -76,6 +76,8 @@ export interface PersistenceAdapter {
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   loadTasks(workflowId: string): TaskState[];
+  /** Authoritative single-task read by ID, suitable for recovery workflows. */
+  loadTask(taskId: string): TaskState | undefined;
   getAllTaskIds(): string[];
   getAllTaskBranches(): string[];
   deleteAllTasks(workflowId: string): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -564,6 +564,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE attempts ADD COLUMN queue_priority INTEGER NOT NULL DEFAULT 0',
       'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
       'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
+      'ALTER TABLE tasks ADD COLUMN task_state_version INTEGER NOT NULL DEFAULT 1',
     ];
     for (const sql of migrations) {
       try {
@@ -735,7 +736,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
         remote_target_id,
         docker_image,
         execution_agent,
-        agent_name
+        agent_name,
+        task_state_version
       ) VALUES (
         ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?, ?, ?, ?, ?, ?,
@@ -751,6 +753,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         ?, ?, ?, ?,
         ?, ?,
         ?, ?, ?, ?,
+        ?,
         ?,
         ?,
         ?,
@@ -810,6 +813,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       cfg.dockerImage ?? null,
       cfg.executionAgent ?? null,
       exec.agentName ?? null,
+      task.taskStateVersion ?? 1,
     ]);
   }
 
@@ -950,6 +954,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
     if (setClauses.length === 0) return;
 
+    // Atomically bump task-state version with every mutation
+    setClauses.push('task_state_version = task_state_version + 1');
+
     if (changes.execution && 'workspacePath' in changes.execution) {
       try {
         const row = this.queryOne(
@@ -982,6 +989,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
   loadTasks(workflowId: string): TaskState[] {
     const rows = this.queryAll('SELECT * FROM tasks WHERE workflow_id = ?', [workflowId]);
     return rows.map((row) => this.reconcileTaskFromSelectedAttempt(this.rowToTask(row)));
+  }
+
+  loadTask(taskId: string): TaskState | undefined {
+    const row = this.queryOne('SELECT * FROM tasks WHERE id = ?', [taskId]);
+    if (!row) return undefined;
+    return this.reconcileTaskFromSelectedAttempt(this.rowToTask(row));
   }
 
   getAllTaskIds(): string[] {
@@ -1670,6 +1683,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         selectedAttemptId: row.selected_attempt_id ?? undefined,
         autoFixAttempts: row.auto_fix_attempts ?? undefined,
       },
+      taskStateVersion: row.task_state_version ?? 1,
     };
   }
 

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -106,6 +106,7 @@ export interface TaskState {
   readonly createdAt: Date;
   readonly config: TaskConfig;
   readonly execution: TaskExecution;
+  readonly taskStateVersion: number;
 }
 
 export interface ExperimentVariant {
@@ -135,8 +136,8 @@ export interface TaskStateChanges {
 
 export type TaskDelta =
   | { readonly type: 'created'; readonly task: TaskState }
-  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges }
-  | { readonly type: 'removed'; readonly taskId: string };
+  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number }
+  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number };
 
 // ── Task Create Options (alias for TaskConfig) ──────────────
 
@@ -158,6 +159,7 @@ export function createTaskState(
     createdAt: new Date(),
     config: { ...options },
     execution: { generation: 0 },
+    taskStateVersion: 1,
   };
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -740,7 +740,7 @@ export function App() {
         <ContextMenu
           x={contextMenu.x}
           y={contextMenu.y}
-          task={contextMenu.task}
+          task={tasks.get(contextMenu.task.id) ?? contextMenu.task}
           onRestart={handleRestartTask}
           onReplace={handleReplaceTask}
           onOpenTerminal={handleOpenTerminal}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -126,6 +126,7 @@ export interface TaskState {
   readonly createdAt: Date;
   readonly config: TaskConfig;
   readonly execution: TaskExecution;
+  readonly taskStateVersion: number;
 }
 
 // ── Task State Changes ──────────────────────────────────────
@@ -142,8 +143,8 @@ export interface TaskStateChanges {
 
 export type TaskDelta =
   | { readonly type: 'created'; readonly task: TaskState }
-  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges }
-  | { readonly type: 'removed'; readonly taskId: string };
+  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number }
+  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number };
 
 // ── Workflow Metadata ────────────────────────────────────────
 

--- a/packages/workflow-core/src/graph-mutation.ts
+++ b/packages/workflow-core/src/graph-mutation.ts
@@ -117,11 +117,13 @@ export function reconcileMergeLeavesImpl(host: GraphMutationHost, workflowId: st
     status: 'pending',
     execution: {},
   };
-  host.writeAndSync(mergeNode.id, changes);
+  const updated = host.writeAndSync(mergeNode.id, changes);
   host.messageBus.publish(TASK_DELTA_CHANNEL, {
     type: 'updated',
     taskId: mergeNode.id,
     changes,
+    taskStateVersion: updated.taskStateVersion,
+    previousTaskStateVersion: mergeNode.taskStateVersion,
   });
 }
 
@@ -147,8 +149,8 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
       dep === mutation.sourceNodeId ? mutation.outputNodeId : dep,
     );
     const remapChanges: TaskStateChanges = { dependencies: newDeps };
-    host.writeAndSync(task.id, remapChanges);
-    const delta: TaskDelta = { type: 'updated', taskId: task.id, changes: remapChanges };
+    const remapped = host.writeAndSync(task.id, remapChanges);
+    const delta: TaskDelta = { type: 'updated', taskId: task.id, changes: remapChanges, taskStateVersion: remapped.taskStateVersion, previousTaskStateVersion: task.taskStateVersion };
     host.messageBus.publish(TASK_DELTA_CHANNEL, delta);
     allDeltas.push(delta);
   }
@@ -165,11 +167,14 @@ export function applyGraphMutationImpl(host: GraphMutationHost, mutation: GraphM
     config: { ...baseChanges.config, ...mutation.sourceChanges?.config },
     execution: { ...baseChanges.execution, ...mutation.sourceChanges?.execution },
   } as TaskStateChanges;
-  host.writeAndSync(mutation.sourceNodeId, sourceChanges);
+  const sourceTaskBefore = host.stateMachine.getTask(mutation.sourceNodeId);
+  const updatedSource = host.writeAndSync(mutation.sourceNodeId, sourceChanges);
   const sourceDelta: TaskDelta = {
     type: 'updated',
     taskId: mutation.sourceNodeId,
     changes: sourceChanges,
+    taskStateVersion: updatedSource.taskStateVersion,
+    previousTaskStateVersion: sourceTaskBefore?.taskStateVersion ?? 0,
   };
   host.persistence.logEvent?.(
     mutation.sourceNodeId,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -717,6 +717,7 @@ export class Orchestrator {
       // value preserves the correct executorType discriminant from existing.config.
       config: { ...existing.config, ...changes.config } as TaskConfig,
       execution: { ...existing.execution, ...changes.execution },
+      taskStateVersion: existing.taskStateVersion + 1,
     };
     if (process.env.NODE_ENV !== 'test' && TRACE_PERSIST_SYNC) {
       const ex = updated.execution;
@@ -738,6 +739,32 @@ export class Orchestrator {
       this.syncWorkflowStatus(existing.config.workflowId);
     }
     return updated;
+  }
+
+  /**
+   * Build an 'updated' TaskDelta with task-state continuity metadata.
+   * `before` is the task state before the mutation, `after` is the state
+   * returned by writeAndSync.
+   */
+  private buildUpdateDelta(before: TaskState, after: TaskState, changes: TaskStateChanges): TaskDelta {
+    return {
+      type: 'updated',
+      taskId: after.id,
+      changes,
+      taskStateVersion: after.taskStateVersion,
+      previousTaskStateVersion: before.taskStateVersion,
+    };
+  }
+
+  /**
+   * Build a 'removed' TaskDelta with the task's last known task-state version.
+   */
+  private buildRemoveDelta(task: TaskState): TaskDelta {
+    return {
+      type: 'removed',
+      taskId: task.id,
+      previousTaskStateVersion: task.taskStateVersion,
+    };
   }
 
   private syncWorkflowStatus(workflowId: string): void {
@@ -848,15 +875,11 @@ export class Orchestrator {
         }
 
         const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
-        this.writeAndSync(id, changesWithGeneration, { skipWorkflowStatusSync: true });
+        const updated = this.writeAndSync(id, changesWithGeneration, { skipWorkflowStatusSync: true });
         const priorAttemptId = current.execution.selectedAttemptId;
         this.replaceSelectedAttempt(current, {}, { skipWorkflowStatusSync: true });
         this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
-        pendingTaskDeltas.push({
-          type: 'updated',
-          taskId: id,
-          changes: changesWithGeneration,
-        });
+        pendingTaskDeltas.push(this.buildUpdateDelta(current, updated, changesWithGeneration));
 
         this.clearQueuedSchedulerEntries(id, priorAttemptId);
       }
@@ -947,13 +970,9 @@ export class Orchestrator {
         status: 'failed',
         execution: { error, completedAt },
       };
-      this.writeAndSync(t.id, changes);
+      const updated = this.writeAndSync(t.id, changes);
       this.persistence.logEvent?.(t.id, 'task.cancelled', changes);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, {
-        type: 'updated',
-        taskId: t.id,
-        changes,
-      });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(t, updated, changes));
       this.deferredTaskIds.delete(t.id);
       this.clearQueuedSchedulerEntries(t.id, t.execution.selectedAttemptId);
       cancelled.push(t.id);
@@ -1468,11 +1487,11 @@ export class Orchestrator {
     const id = task.id;
 
     const changes: TaskStateChanges = { status: 'running', execution: { inputPrompt: undefined } };
-    this.writeAndSync(id, changes);
+    const updated = this.writeAndSync(id, changes);
     if (task.execution.selectedAttemptId) {
       this.taskRepository.updateAttempt(task.execution.selectedAttemptId, { status: 'running' });
     }
-    const delta: TaskDelta = { type: 'updated', taskId: id, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(id, 'task.running', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
@@ -1527,7 +1546,7 @@ export class Orchestrator {
         },
       );
     }
-    this.writeAndSync(id, changes);
+    const updated = this.writeAndSync(id, changes);
     this.updateSelectedAttempt(id, {
       status: 'needs_input',
       completedAt: changes.execution?.completedAt,
@@ -1537,7 +1556,7 @@ export class Orchestrator {
       ...(changes.execution?.workspacePath !== undefined ? { workspacePath: changes.execution.workspacePath } : {}),
       ...(keepAgentSessionId !== undefined ? { agentSessionId: keepAgentSessionId } : {}),
     });
-    const delta: TaskDelta = { type: 'updated', taskId: id, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(id, eventName, changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
@@ -1596,13 +1615,13 @@ export class Orchestrator {
       taskId: tid,
       execution: changes.execution,
     });
-    this.writeAndSync(tid, changes);
+    const updated = this.writeAndSync(tid, changes);
     this.updateSelectedAttempt(tid, {
       status: 'needs_input',
       error: originalError,
       agentSessionId: task.execution.agentSessionId,
     });
-    const delta: TaskDelta = { type: 'updated', taskId: tid, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(tid, 'task.awaiting_approval', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
@@ -1648,12 +1667,12 @@ export class Orchestrator {
       status: 'completed',
       execution: { completedAt: new Date() },
     };
-    this.writeAndSync(taskId, changes);
+    const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
       status: 'completed',
       completedAt: changes.execution?.completedAt,
     });
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(taskId, 'task.completed', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
     mergeTrace('APPROVE_DONE', { taskId });
@@ -1697,13 +1716,13 @@ export class Orchestrator {
       status: 'running',
       execution: { pendingFixError: undefined, startedAt: now, lastHeartbeatAt: now },
     };
-    this.writeAndSync(taskId, changes);
+    const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
       status: 'running',
       startedAt: now,
       lastHeartbeatAt: now,
     });
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(taskId, 'task.running', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
     return [this.stateGetTask(taskId)!];
@@ -1721,13 +1740,13 @@ export class Orchestrator {
       status: 'failed',
       execution: { error: reason ?? 'Rejected', completedAt: new Date() },
     };
-    this.writeAndSync(taskId, changes);
+    const updated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
       status: 'failed',
       error: reason ?? 'Rejected',
       completedAt: changes.execution?.completedAt,
     });
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changes);
     this.persistence.logEvent?.(taskId, 'task.failed', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -1848,14 +1867,14 @@ export class Orchestrator {
         commit: winner?.execution.commit,
       },
     };
-    this.writeAndSync(reconId, changes);
+    const reconUpdated = this.writeAndSync(reconId, changes);
     this.updateSelectedAttempt(reconId, {
       status: 'completed',
       completedAt: changes.execution?.completedAt,
       branch: winner?.execution.branch,
       commit: winner?.execution.commit,
     });
-    const delta: TaskDelta = { type: 'updated', taskId: reconId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, reconUpdated, changes);
     this.persistence.logEvent?.(reconId, 'task.completed', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -1931,14 +1950,14 @@ export class Orchestrator {
         commit: combinedCommit,
       },
     };
-    this.writeAndSync(reconId, changes);
+    const reconUpdated = this.writeAndSync(reconId, changes);
     this.updateSelectedAttempt(reconId, {
       status: 'completed',
       completedAt: changes.execution?.completedAt,
       branch: combinedBranch,
       commit: combinedCommit,
     });
-    const delta: TaskDelta = { type: 'updated', taskId: reconId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, reconUpdated, changes);
     this.persistence.logEvent?.(reconId, 'task.completed', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -2063,8 +2082,8 @@ export class Orchestrator {
             status: 'blocked',
             execution: { blockedBy: blocker },
           };
-          this.writeAndSync(id, blockedChanges);
-          const blockedDelta: TaskDelta = { type: 'updated', taskId: id, changes: blockedChanges };
+          const blockedUpdated = this.writeAndSync(id, blockedChanges);
+          const blockedDelta: TaskDelta = this.buildUpdateDelta(current, blockedUpdated, blockedChanges);
           this.persistence.logEvent?.(id, 'task.blocked', blockedChanges);
           this.messageBus.publish(TASK_DELTA_CHANNEL, blockedDelta);
           return [this.stateGetTask(id)!];
@@ -2222,11 +2241,11 @@ export class Orchestrator {
       const current = this.stateGetTask(id);
       if (!current) continue;
       const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
-      this.writeAndSync(id, changesWithGeneration);
+      const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
       const priorAttemptId = current.execution.selectedAttemptId;
       this.replaceSelectedAttempt(current);
       this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, { type: 'updated', taskId: id, changes: changesWithGeneration });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(current, recreateUpdated, changesWithGeneration));
 
       this.deferredTaskIds.delete(id);
       this.clearQueuedSchedulerEntries(id, priorAttemptId);
@@ -2316,12 +2335,12 @@ export class Orchestrator {
       const after = this.writeAndSync(task.id, changesWithGeneration);
       const priorAttemptId = task.execution.selectedAttemptId;
       this.replaceSelectedAttempt(task);
-      this.logger.info('[agent-session-trace] recreateWorkflow: after writeAndSync', {
-        taskId: task.id,
-        agentSessionId: after.execution.agentSessionId ?? 'null',
-        containerId: after.execution.containerId ?? 'null',
-      });
-      const delta: TaskDelta = { type: 'updated', taskId: task.id, changes: changesWithGeneration };
+    this.logger.info('[agent-session-trace] recreateWorkflow: after writeAndSync', {
+      taskId: task.id,
+      agentSessionId: after.execution.agentSessionId ?? 'null',
+      containerId: after.execution.containerId ?? 'null',
+    });
+      const delta: TaskDelta = this.buildUpdateDelta(task, after, changesWithGeneration);
       this.persistence.logEvent?.(task.id, 'task.pending', changesWithGeneration);
       this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
       this.clearQueuedSchedulerEntries(task.id, priorAttemptId);
@@ -2469,7 +2488,7 @@ export class Orchestrator {
       },
     };
     const changesWithGeneration = this.withBumpedExecutionGeneration(task, changes);
-    this.writeAndSync(taskId, changesWithGeneration);
+    const conflictUpdated = this.writeAndSync(taskId, changesWithGeneration);
     const attemptId = this.replaceSelectedAttempt(task);
     this.taskRepository.updateAttempt(attemptId, {
       status: 'running',
@@ -2484,7 +2503,7 @@ export class Orchestrator {
       error: undefined,
       exitCode: undefined,
     });
-    const delta: TaskDelta = { type: 'updated', taskId: id, changes: changesWithGeneration };
+    const delta: TaskDelta = this.buildUpdateDelta(task, conflictUpdated, changesWithGeneration);
     this.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -2519,14 +2538,14 @@ export class Orchestrator {
         completedAt,
       },
     };
-    this.writeAndSync(taskId, changes);
+    const revertUpdated = this.writeAndSync(taskId, changes);
     this.updateSelectedAttempt(taskId, {
       status: 'failed',
       error: displayError,
       mergeConflict,
       completedAt,
     });
-    const delta: TaskDelta = { type: 'updated', taskId: id, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(task, revertUpdated, changes);
     this.persistence.logEvent?.(id, 'task.failed', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
@@ -2542,8 +2561,9 @@ export class Orchestrator {
     }
 
     const cmdChanges: TaskStateChanges = { config: { command: newCommand } };
-    this.writeAndSync(taskId, cmdChanges);
-    const cmdDelta: TaskDelta = { type: 'updated', taskId, changes: cmdChanges };
+    const cmdBefore = this.stateGetTask(taskId)!;
+    const cmdUpdated = this.writeAndSync(taskId, cmdChanges);
+    const cmdDelta: TaskDelta = this.buildUpdateDelta(cmdBefore, cmdUpdated, cmdChanges);
     this.persistence.logEvent?.(taskId, 'task.updated', cmdChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, cmdDelta);
 
@@ -2561,8 +2581,9 @@ export class Orchestrator {
     }
 
     const promptChanges: TaskStateChanges = { config: { prompt: newPrompt } };
-    this.writeAndSync(taskId, promptChanges);
-    const promptDelta: TaskDelta = { type: 'updated', taskId, changes: promptChanges };
+    const promptBefore = this.stateGetTask(taskId)!;
+    const promptUpdated = this.writeAndSync(taskId, promptChanges);
+    const promptDelta: TaskDelta = this.buildUpdateDelta(promptBefore, promptUpdated, promptChanges);
     this.persistence.logEvent?.(taskId, 'task.updated', promptChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, promptDelta);
 
@@ -2609,8 +2630,9 @@ export class Orchestrator {
       configPatch.remoteTargetId = undefined;
     }
     const typeChanges: TaskStateChanges = { config: configPatch };
-    this.writeAndSync(taskId, typeChanges);
-    const typeDelta: TaskDelta = { type: 'updated', taskId, changes: typeChanges };
+    const typeBefore = this.stateGetTask(taskId)!;
+    const typeUpdated = this.writeAndSync(taskId, typeChanges);
+    const typeDelta: TaskDelta = this.buildUpdateDelta(typeBefore, typeUpdated, typeChanges);
     this.persistence.logEvent?.(taskId, 'task.updated', typeChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, typeDelta);
 
@@ -2628,8 +2650,9 @@ export class Orchestrator {
     }
 
     const agentChanges: TaskStateChanges = { config: { executionAgent: agentName } };
-    this.writeAndSync(taskId, agentChanges);
-    const agentDelta: TaskDelta = { type: 'updated', taskId, changes: agentChanges };
+    const agentBefore = this.stateGetTask(taskId)!;
+    const agentUpdated = this.writeAndSync(taskId, agentChanges);
+    const agentDelta: TaskDelta = this.buildUpdateDelta(agentBefore, agentUpdated, agentChanges);
     this.persistence.logEvent?.(taskId, 'task.updated', agentChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, agentDelta);
 
@@ -2903,12 +2926,9 @@ export class Orchestrator {
     if (hasPromptKey) configPatch.fixPrompt = patch.fixPrompt;
     if (hasContextKey) configPatch.fixContext = patch.fixContext;
     const fixContextChanges: TaskStateChanges = { config: configPatch };
-    this.writeAndSync(taskId, fixContextChanges);
-    const fixContextDelta: TaskDelta = {
-      type: 'updated',
-      taskId,
-      changes: fixContextChanges,
-    };
+    const fixBefore = this.stateGetTask(taskId)!;
+    const fixUpdated = this.writeAndSync(taskId, fixContextChanges);
+    const fixContextDelta: TaskDelta = this.buildUpdateDelta(fixBefore, fixUpdated, fixContextChanges);
     this.persistence.logEvent?.(taskId, 'task.updated', fixContextChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, fixContextDelta);
 
@@ -3006,8 +3026,8 @@ export class Orchestrator {
     const policyChanges: TaskStateChanges = {
       config: { externalDependencies: nextDeps },
     };
-    this.writeAndSync(taskId, policyChanges);
-    const policyDelta: TaskDelta = { type: 'updated', taskId, changes: policyChanges };
+    const policyUpdated = this.writeAndSync(taskId, policyChanges);
+    const policyDelta: TaskDelta = this.buildUpdateDelta(task, policyUpdated, policyChanges);
     this.persistence.logEvent?.(taskId, 'task.external_dependency_policy_updated', {
       updates,
       changed,
@@ -3207,24 +3227,22 @@ export class Orchestrator {
       (t) => !!t.config.isMergeNode,
     );
     for (const id of descendantIds) {
+      const staleBefore = this.stateGetTask(id);
+      if (!staleBefore) continue;
       const staleChanges: TaskStateChanges = { status: 'stale' };
-      this.writeAndSync(id, staleChanges);
+      const staleUpdated = this.writeAndSync(id, staleChanges);
       this.updateSelectedAttempt(id, { status: 'superseded' });
       this.persistence.logEvent?.(id, 'task.stale', staleChanges);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, {
-        type: 'updated', taskId: id, changes: staleChanges,
-      });
-      const current = this.stateGetTask(id);
-      this.clearQueuedSchedulerEntries(id, current?.execution.selectedAttemptId);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(staleBefore, staleUpdated, staleChanges));
+      this.clearQueuedSchedulerEntries(id, staleBefore.execution.selectedAttemptId);
     }
+    const sourceBefore = this.stateGetTask(sourceId)!;
     const sourceChanges: TaskStateChanges = { status: 'stale' };
-    this.writeAndSync(sourceId, sourceChanges);
+    const sourceUpdated = this.writeAndSync(sourceId, sourceChanges);
     this.updateSelectedAttempt(sourceId, { status: 'superseded' });
     this.persistence.logEvent?.(sourceId, 'task.stale', sourceChanges);
-    this.messageBus.publish(TASK_DELTA_CHANNEL, {
-      type: 'updated', taskId: sourceId, changes: sourceChanges,
-    });
-    this.clearQueuedSchedulerEntries(sourceId, this.stateGetTask(sourceId)?.execution.selectedAttemptId);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(sourceBefore, sourceUpdated, sourceChanges));
+    this.clearQueuedSchedulerEntries(sourceId, sourceBefore.execution.selectedAttemptId);
 
     // 2. Create replacement tasks
     for (const rt of replacementTasks) {
@@ -3433,8 +3451,7 @@ export class Orchestrator {
 
     // 6. Publish removal deltas — drives UI cache cleanup via messageBus subscriber
     for (const task of affectedTasks) {
-      const delta: TaskDelta = { type: 'removed', taskId: task.id };
-      this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildRemoveDelta(task));
     }
   }
 
@@ -3465,8 +3482,7 @@ export class Orchestrator {
 
     // 5. Publish removal deltas
     for (const task of allTasks) {
-      const delta: TaskDelta = { type: 'removed', taskId: task.id };
-      this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildRemoveDelta(task));
     }
   }
 
@@ -3619,13 +3635,13 @@ export class Orchestrator {
         status: 'failed',
         execution: { error: errorMsg, completedAt: new Date() },
       };
-      this.writeAndSync(id, changes);
+      const cancelUpdated = this.writeAndSync(id, changes);
       this.updateSelectedAttempt(id, {
         status: 'failed',
         error: errorMsg,
         completedAt: changes.execution?.completedAt,
       });
-      const delta: TaskDelta = { type: 'updated', taskId: id, changes };
+      const delta: TaskDelta = this.buildUpdateDelta(t, cancelUpdated, changes);
       this.persistence.logEvent?.(id, 'task.cancelled', changes);
       this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -3682,14 +3698,14 @@ export class Orchestrator {
           completedAt: new Date(),
         },
       };
-      this.writeAndSync(id, changes);
+      const wfCancelUpdated = this.writeAndSync(id, changes);
       this.updateSelectedAttempt(id, {
         status: 'failed',
         error: 'Cancelled by user (workflow)',
         completedAt: changes.execution?.completedAt,
       });
       this.persistence.logEvent?.(id, 'task.cancelled', changes);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, { type: 'updated', taskId: id, changes });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, wfCancelUpdated, changes));
       cancelled.push(id);
     }
 
@@ -3712,8 +3728,8 @@ export class Orchestrator {
       status: 'pending',
       execution: { startedAt: undefined, lastHeartbeatAt: undefined },
     };
-    this.writeAndSync(id, changes);
-    const delta: TaskDelta = { type: 'updated', taskId: id, changes };
+    const deferUpdated = this.writeAndSync(id, changes);
+    const delta: TaskDelta = this.buildUpdateDelta(task, deferUpdated, changes);
     this.persistence.logEvent?.(id, 'task.deferred', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -3820,8 +3836,8 @@ export class Orchestrator {
       config: { summary: parsed.summary },
       execution,
     };
-    this.writeAndSync(taskId, changes);
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const completedUpdated = this.writeAndSync(taskId, changes);
+    const delta: TaskDelta = this.buildUpdateDelta(task!, completedUpdated, changes);
     const eventName = needsApproval ? 'task.awaiting_approval' : 'task.completed';
     this.persistence.logEvent?.(taskId, eventName, changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
@@ -3914,10 +3930,11 @@ export class Orchestrator {
       ...existing,
       status: 'failed',
       execution: { ...existing.execution, ...changes.execution },
+      taskStateVersion: existing.taskStateVersion + 1,
     };
     this.stateMachine.restoreTask(updated);
 
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(existing, updated, changes);
     this.persistence.logEvent?.(taskId, eventName, changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
@@ -3975,12 +3992,13 @@ export class Orchestrator {
       status: 'needs_input',
       execution: { inputPrompt: parsed.prompt },
     };
-    this.writeAndSync(taskId, changes);
-    const currentAttemptId = this.stateGetTask(taskId)?.execution.selectedAttemptId;
+    const needsInputBefore = this.stateGetTask(taskId)!;
+    const needsInputUpdated = this.writeAndSync(taskId, changes);
+    const currentAttemptId = needsInputUpdated.execution.selectedAttemptId;
     if (currentAttemptId) {
       this.taskRepository.updateAttempt(currentAttemptId, { status: 'needs_input' });
     }
-    const delta: TaskDelta = { type: 'updated', taskId, changes };
+    const delta: TaskDelta = this.buildUpdateDelta(needsInputBefore, needsInputUpdated, changes);
     this.persistence.logEvent?.(taskId, 'task.needs_input', changes);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
     return [];
@@ -4107,8 +4125,8 @@ export class Orchestrator {
         const reconChanges: TaskStateChanges = {
           execution: { experimentResults },
         };
-        this.writeAndSync(recon.id, reconChanges);
-        const delta: TaskDelta = { type: 'updated', taskId: recon.id, changes: reconChanges };
+        const reconUpdated = this.writeAndSync(recon.id, reconChanges);
+        const delta: TaskDelta = this.buildUpdateDelta(recon, reconUpdated, reconChanges);
         this.persistence.logEvent?.(recon.id, 'task.experiment_results_recorded', reconChanges);
         this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
       }
@@ -4341,16 +4359,12 @@ export class Orchestrator {
       const changes: TaskStateChanges = {
         config: { externalDependencies: nextDeps.length > 0 ? nextDeps : undefined },
       };
-      this.writeAndSync(task.id, changes);
+      const updated = this.writeAndSync(task.id, changes);
       this.persistence.logEvent?.(task.id, 'task.external_dependency_detached', {
         workflowId,
         upstreamWorkflowId,
       });
-      this.messageBus.publish(TASK_DELTA_CHANNEL, {
-        type: 'updated',
-        taskId: task.id,
-        changes,
-      });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
     }
 
     if (!removedDependency) {
@@ -4454,11 +4468,7 @@ export class Orchestrator {
       };
       const updated = this.writeAndSync(job.taskId, changes);
       this.persistence.logEvent?.(job.taskId, 'task.running', changes);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, {
-        type: 'updated',
-        taskId: job.taskId,
-        changes,
-      });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
       started.push(updated);
       this.logger.info('[orchestrator] drainScheduler: started', {
         taskId: job.taskId,
@@ -4583,13 +4593,9 @@ export class Orchestrator {
           }
         : { execution: baseExecution };
 
-      this.writeAndSync(taskId, changes);
+      const launchUpdated = this.writeAndSync(taskId, changes);
       this.persistence.logEvent?.(taskId, 'task.running', changes);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, {
-        type: 'updated',
-        taskId,
-        changes,
-      });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, launchUpdated, changes));
       this.logger.info('[orchestrator] markTaskRunningAfterLaunch: executing', {
         taskId,
         attemptId,

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -152,7 +152,7 @@ export interface TaskState {
   readonly createdAt: Date;
   readonly config: TaskConfig;
   readonly execution: TaskExecution;
-  readonly taskStateVersion?: number;
+  readonly taskStateVersion: number;
 }
 
 export interface ExperimentVariant {
@@ -182,14 +182,8 @@ export interface TaskStateChanges {
 
 export type TaskDelta =
   | { readonly type: 'created'; readonly task: TaskState }
-  | {
-      readonly type: 'updated';
-      readonly taskId: string;
-      readonly changes: TaskStateChanges;
-      readonly previousTaskStateVersion?: number;
-      readonly taskStateVersion?: number;
-    }
-  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion?: number };
+  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number }
+  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number };
 
 // ── Task Create Options (alias for TaskConfig) ──────────────
 
@@ -218,6 +212,7 @@ export function createTaskState(
     createdAt: resolveInitialTaskTimestamp(),
     config: { ...options },
     execution: { generation: 0 },
+    taskStateVersion: 1,
   };
 }
 

--- a/run.sh
+++ b/run.sh
@@ -96,6 +96,12 @@ if [ "$1" = "--headless" ]; then
   fi
 
   shift
+  # Build @invoker/app on-demand when dist/headless-client.js is missing
+  # (e.g. fresh worktree that only ran pnpm install).
+  if [ ! -f "$REPO_ROOT/packages/app/dist/headless-client.js" ]; then
+    echo "Building @invoker/app (headless-client.js missing)..." >&2
+    pnpm --filter @invoker/app build >&2
+  fi
   exec node ./packages/app/dist/headless-client.js "$@"
 fi
 

--- a/scripts/headless-ipc.js
+++ b/scripts/headless-ipc.js
@@ -1,10 +1,26 @@
 #!/usr/bin/env node
-const { createConnection } = require('node:net');
-const { homedir } = require('node:os');
+/**
+ * Thin CLI wrapper around the shared IPC transport.
+ *
+ * Keeps CLI parsing and JSON / JSONL output.
+ * Transport policy lives in @invoker/transport (IpcBus) — this script
+ * only creates a client-only bus and delegates exec requests through it.
+ *
+ * Standalone mode: when no IPC server is reachable the script falls back
+ * to spawning the headless-client process directly, so a shared socket is
+ * not required.
+ */
+const { execFileSync } = require('node:child_process');
+const { existsSync } = require('node:fs');
 const path = require('node:path');
 
-const DEFAULT_SOCKET_PATH =
-  process.env.INVOKER_IPC_SOCKET || path.join(homedir(), '.invoker', 'ipc-transport.sock');
+const REPO_ROOT = path.resolve(__dirname, '..');
+const TRANSPORT_DIST = path.join(REPO_ROOT, 'packages', 'transport', 'dist', 'index.js');
+const HEADLESS_CLIENT_DIST = path.join(REPO_ROOT, 'packages', 'app', 'dist', 'headless-client.js');
+
+// ---------------------------------------------------------------------------
+// EPIPE handling — keep output clean when piped to head / grep / etc.
+// ---------------------------------------------------------------------------
 
 for (const stream of [process.stdout, process.stderr]) {
   stream.on('error', (error) => {
@@ -15,25 +31,16 @@ for (const stream of [process.stdout, process.stderr]) {
   });
 }
 
+// ---------------------------------------------------------------------------
+// CLI parsing (unchanged contract)
+// ---------------------------------------------------------------------------
+
 function usage() {
   console.error(
     'Usage:\n' +
     '  node scripts/headless-ipc.js exec [--no-track] [--wait-for-approval] [--timeout-ms N] -- <headless args...>\n' +
     '  node scripts/headless-ipc.js batch-exec [--no-track] [--wait-for-approval] [--timeout-ms N] [--parallel N] < commands.jsonl',
   );
-}
-
-function withTimeout(promise, timeoutMs) {
-  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
-    return promise;
-  }
-  return Promise.race([
-    promise,
-    new Promise((_, reject) => {
-      const timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
-      timer.unref?.();
-    }),
-  ]);
 }
 
 function parseCli(argv) {
@@ -84,121 +91,24 @@ function parseCli(argv) {
   return { mode, noTrack, waitForApproval, parallel, timeoutMs, args };
 }
 
-function encodeEnvelope(envelope) {
-  const json = Buffer.from(JSON.stringify(envelope), 'utf8');
-  const frame = Buffer.allocUnsafe(4 + json.length);
-  frame.writeUInt32BE(json.length, 0);
-  json.copy(frame, 4);
-  return frame;
+// ---------------------------------------------------------------------------
+// Timeout helper
+// ---------------------------------------------------------------------------
+
+function withTimeout(promise, timeoutMs) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+    return promise;
+  }
+  let timer;
+  const timeoutPromise = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${timeoutMs}ms`)), timeoutMs);
+  });
+  return Promise.race([promise, timeoutPromise]).finally(() => clearTimeout(timer));
 }
 
-class FrameDecoder {
-  constructor(onEnvelope) {
-    this.buf = Buffer.alloc(0);
-    this.onEnvelope = onEnvelope;
-  }
-
-  push(chunk) {
-    this.buf = Buffer.concat([this.buf, chunk]);
-    while (this.buf.length >= 4) {
-      const len = this.buf.readUInt32BE(0);
-      if (this.buf.length < 4 + len) {
-        break;
-      }
-      const json = this.buf.subarray(4, 4 + len).toString('utf8');
-      this.buf = this.buf.subarray(4 + len);
-      this.onEnvelope(JSON.parse(json));
-    }
-  }
-}
-
-class HeadlessIpcClient {
-  constructor(socketPath = DEFAULT_SOCKET_PATH) {
-    this.socketPath = socketPath;
-    this.nextReqId = 0;
-    this.pending = new Map();
-    this.socket = null;
-    this.decoder = new FrameDecoder((envelope) => this.handleEnvelope(envelope));
-  }
-
-  async connect() {
-    if (this.socket) {
-      return;
-    }
-    this.socket = await new Promise((resolve, reject) => {
-      const socket = createConnection({ path: this.socketPath });
-      const cleanup = () => {
-        socket.off('connect', handleConnect);
-        socket.off('error', handleError);
-      };
-      const handleConnect = () => {
-        cleanup();
-        resolve(socket);
-      };
-      const handleError = (error) => {
-        cleanup();
-        reject(error);
-      };
-      socket.once('connect', handleConnect);
-      socket.once('error', handleError);
-    });
-
-    this.socket.on('data', (chunk) => this.decoder.push(chunk));
-    this.socket.on('error', (error) => {
-      this.rejectAll(error);
-    });
-    this.socket.on('close', () => {
-      this.rejectAll(new Error('IPC socket closed'));
-      this.socket = null;
-    });
-  }
-
-  handleEnvelope(envelope) {
-    if (envelope.kind !== 'res' && envelope.kind !== 'err') {
-      return;
-    }
-    const pending = this.pending.get(envelope.reqId);
-    if (!pending) {
-      return;
-    }
-    this.pending.delete(envelope.reqId);
-    if (envelope.kind === 'err') {
-      pending.reject(new Error(envelope.message));
-      return;
-    }
-    pending.resolve(envelope.body);
-  }
-
-  rejectAll(error) {
-    for (const { reject } of this.pending.values()) {
-      reject(error);
-    }
-    this.pending.clear();
-  }
-
-  async request(channel, body) {
-    await this.connect();
-    const reqId = `req-${this.nextReqId += 1}`;
-    const response = new Promise((resolve, reject) => {
-      this.pending.set(reqId, { resolve, reject });
-    });
-    this.socket.write(encodeEnvelope({
-      kind: 'req',
-      channel,
-      body,
-      reqId,
-    }));
-    return response;
-  }
-
-  disconnect() {
-    if (!this.socket) {
-      return;
-    }
-    this.socket.destroy();
-    this.socket = null;
-  }
-}
+// ---------------------------------------------------------------------------
+// Stdin reader (for batch-exec)
+// ---------------------------------------------------------------------------
 
 async function readStdinLines() {
   const chunks = [];
@@ -208,13 +118,56 @@ async function readStdinLines() {
   return Buffer.concat(chunks).toString('utf8').split('\n').map((line) => line.trim()).filter(Boolean);
 }
 
-async function requestExec(client, item, options) {
+// ---------------------------------------------------------------------------
+// Transport — load IpcBus from the shared transport dist
+// ---------------------------------------------------------------------------
+
+async function loadTransport() {
+  if (!existsSync(TRANSPORT_DIST)) {
+    return null;
+  }
+  const mod = await import(TRANSPORT_DIST);
+  return mod;
+}
+
+async function createBus(transport) {
+  const bus = new transport.IpcBus(undefined, { allowServe: false });
+  await bus.ready();
+  return bus;
+}
+
+// ---------------------------------------------------------------------------
+// Standalone fallback — spawn headless-client directly (no socket needed)
+// ---------------------------------------------------------------------------
+
+function execStandalone(args) {
+  if (!existsSync(HEADLESS_CLIENT_DIST)) {
+    throw new Error(
+      `Standalone mode requires a built headless-client at ${HEADLESS_CLIENT_DIST}.\n` +
+      'Run: pnpm --filter @invoker/app build',
+    );
+  }
+  try {
+    execFileSync(process.execPath, [HEADLESS_CLIENT_DIST, ...args], {
+      stdio: ['inherit', 'inherit', 'inherit'],
+    });
+    return 0;
+  } catch (err) {
+    return err.status ?? 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Request execution via the shared bus
+// ---------------------------------------------------------------------------
+
+async function requestExec(bus, item, options) {
   const payload = {
     args: item.args,
     noTrack: options.noTrack,
     waitForApproval: options.waitForApproval,
   };
-  const response = await withTimeout(client.request('headless.exec', payload), options.timeoutMs);
+  const response = await withTimeout(bus.request('headless.exec', payload), options.timeoutMs);
   return {
     ...item,
     ok: true,
@@ -222,20 +175,45 @@ async function requestExec(client, item, options) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
 async function main() {
   const options = parseCli(process.argv.slice(2));
-  const client = new HeadlessIpcClient();
+
+  // Try to load the shared transport module.
+  const transport = await loadTransport();
+  if (!transport) {
+    // No built transport — fall back to standalone mode for exec.
+    if (options.mode === 'exec') {
+      const cliArgs = [];
+      if (options.noTrack) cliArgs.push('--no-track');
+      if (options.waitForApproval) cliArgs.push('--wait-for-approval');
+      cliArgs.push(...options.args);
+      process.exitCode = execStandalone(cliArgs);
+      return;
+    }
+    throw new Error(
+      'batch-exec requires the shared transport module.\n' +
+      'Build the transport package: cd packages/transport && pnpm build',
+    );
+  }
+
+  // Create a client-only IPC bus (no server election).
+  const bus = await createBus(transport);
 
   try {
     if (options.mode === 'exec') {
       if (options.args.length === 0) {
         throw new Error('Missing headless args for exec');
       }
-      const result = await requestExec(client, { args: options.args }, options);
+      const result = await requestExec(bus, { args: options.args }, options);
       process.stdout.write(`${JSON.stringify(result)}\n`);
       return;
     }
 
+    // batch-exec
     const lines = await readStdinLines();
     const items = lines.map((line) => {
       const parsed = JSON.parse(line);
@@ -260,7 +238,7 @@ async function main() {
         }
         const item = items[index];
         try {
-          const result = await requestExec(client, item, options);
+          const result = await requestExec(bus, item, options);
           process.stdout.write(`${JSON.stringify(result)}\n`);
         } catch (error) {
           process.stdout.write(`${JSON.stringify({
@@ -274,7 +252,7 @@ async function main() {
 
     await Promise.all(Array.from({ length: Math.min(parallel, items.length) }, () => worker()));
   } finally {
-    client.disconnect();
+    bus.disconnect();
   }
 }
 

--- a/scripts/headless-lib.sh
+++ b/scripts/headless-lib.sh
@@ -1,0 +1,205 @@
+#!/usr/bin/env bash
+# Shared helpers for bulk headless scripts.
+#
+# Source this file at the top of any bulk headless script:
+#   source "$(dirname "$0")/headless-lib.sh"
+#
+# Provides:
+#   Variables  — REPO_ROOT, RUNNER, ELECTRON, MAIN, IPC_HELPER,
+#                STANDALONE_MODE, SANDBOX_FLAG
+#   Functions  — headless_query, headless_mutation, headless_workflow_ids,
+#                headless_task_ids, run_with_optional_timeout,
+#                batch_dispatch, parse_batch_results, count_results
+#
+# The caller must set -euo pipefail before sourcing.
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RUNNER="$REPO_ROOT/run.sh"
+ELECTRON="$REPO_ROOT/packages/app/node_modules/.bin/electron"
+MAIN="$REPO_ROOT/packages/app/dist/main.js"
+IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
+STANDALONE_MODE="${INVOKER_HEADLESS_STANDALONE:-0}"
+
+# ---------------------------------------------------------------------------
+# Electron sandbox detection (Linux)
+# ---------------------------------------------------------------------------
+
+unset ELECTRON_RUN_AS_NODE
+SANDBOX_FLAG=""
+if [ "$(uname)" = "Linux" ]; then
+  SANDBOX_BIN="$REPO_ROOT/node_modules/.pnpm/electron@*/node_modules/electron/dist/chrome-sandbox"
+  # shellcheck disable=SC2086
+  if ! stat -c '%U:%a' $SANDBOX_BIN 2>/dev/null | grep -q '^root:4755$'; then
+    SANDBOX_FLAG="--no-sandbox"
+  fi
+  export LIBGL_ALWAYS_SOFTWARE=1
+fi
+
+# ---------------------------------------------------------------------------
+# Core transport helpers
+# ---------------------------------------------------------------------------
+
+# Read-only Electron query (stderr suppressed for clean parsing).
+headless_query() {
+  # shellcheck disable=SC2086
+  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
+}
+
+# Mutating command — delegates to the owner (standalone or IPC).
+headless_mutation() {
+  if [ "$STANDALONE_MODE" = "1" ]; then
+    "$RUNNER" --headless "$@"
+    return $?
+  fi
+  node "$IPC_HELPER" exec -- "$@"
+}
+
+# Extract workflow IDs (label format) from a query.
+headless_workflow_ids() {
+  headless_query "$@" | grep -E '^wf-[0-9]+-[0-9]+$' || true
+}
+
+# Extract task IDs (contains /) from a query.
+headless_task_ids() {
+  headless_query "$@" | grep '/' || true
+}
+
+# ---------------------------------------------------------------------------
+# Timeout wrapper (used by rebase-retry-all.sh)
+# ---------------------------------------------------------------------------
+
+run_with_optional_timeout() {
+  local seconds="$1"
+  shift
+  if [ "$seconds" -le 0 ]; then
+    "$@"
+    return $?
+  fi
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$seconds" "$@"
+    return $?
+  fi
+  if command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$seconds" "$@"
+    return $?
+  fi
+  if command -v python3 >/dev/null 2>&1; then
+    python3 - "$seconds" "$@" <<'PY'
+import subprocess
+import sys
+
+timeout = int(sys.argv[1])
+cmd = sys.argv[2:]
+
+try:
+    completed = subprocess.run(cmd, timeout=timeout, check=False)
+    sys.exit(completed.returncode)
+except subprocess.TimeoutExpired:
+    print(f"Timed out after {timeout}s: {' '.join(cmd)}", file=sys.stderr)
+    sys.exit(124)
+PY
+    return $?
+  fi
+  echo "ERROR: timeout(1), gtimeout, and python3 are unavailable; cannot enforce per-command timeout." >&2
+  return 127
+}
+
+# ---------------------------------------------------------------------------
+# Batch dispatch (fire-and-forget mode)
+# ---------------------------------------------------------------------------
+
+# batch_dispatch COMMANDS_FILE RESULT_FILE LOG_DIR PARALLELISM [EXTRA_BATCH_ARGS...]
+#
+# In standalone mode:  loops over COMMANDS_FILE, runs each serially via
+#                      headless_mutation, writes results to RESULT_FILE.
+# In shared-owner mode: pipes COMMANDS_FILE through `headless-ipc.js batch-exec`,
+#                       then parses JSONL output into per-workflow logs and
+#                       RESULT_FILE.
+#
+# COMMANDS_FILE format: one JSON object per line with "label", "workflowId", "args".
+# RESULT_FILE format:   <workflowId>\t<SUCCEEDED|FAILED>  per line.
+batch_dispatch() {
+  local commands_file="$1"
+  local result_file="$2"
+  local log_dir="$3"
+  local parallelism="$4"
+  shift 4
+  local extra_batch_args=("$@")
+
+  if [ "$STANDALONE_MODE" = "1" ]; then
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      local wf_id args_json
+      wf_id="$(printf '%s' "$line" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("workflowId","unknown"))')"
+      args_json="$(printf '%s' "$line" | python3 -c 'import json,sys; print(" ".join(json.load(sys.stdin).get("args",[])))')"
+      # shellcheck disable=SC2086
+      if headless_mutation --no-track $args_json > "$log_dir/${wf_id}.log" 2>&1; then
+        printf "%s\tSUCCEEDED\n" "$wf_id" >> "$result_file"
+      else
+        printf "%s\tFAILED\n" "$wf_id" >> "$result_file"
+      fi
+    done < "$commands_file"
+  else
+    local output_jsonl
+    output_jsonl="$(mktemp -t batch-output.XXXXXX)"
+    node "$IPC_HELPER" batch-exec --no-track --parallel "$parallelism" \
+      "${extra_batch_args[@]}" < "$commands_file" > "$output_jsonl"
+    parse_batch_results "$output_jsonl" "$result_file" "$log_dir"
+    rm -f "$output_jsonl"
+  fi
+}
+
+# parse_batch_results OUTPUT_JSONL RESULT_FILE LOG_DIR
+#
+# Reads JSONL output from batch-exec, writes per-workflow log files and a
+# tab-separated result file.
+parse_batch_results() {
+  local output_jsonl="$1"
+  local result_file="$2"
+  local log_dir="$3"
+
+  python3 - "$result_file" "$log_dir" "$output_jsonl" <<'PY'
+import json
+import pathlib
+import sys
+
+result_file = pathlib.Path(sys.argv[1])
+log_dir = pathlib.Path(sys.argv[2])
+output_jsonl = pathlib.Path(sys.argv[3])
+
+for raw in output_jsonl.read_text(encoding="utf-8").splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    item = json.loads(raw)
+    workflow_id = item.get("workflowId") or item.get("label") or "unknown"
+    (log_dir / f"{workflow_id}.log").write_text(raw + "\n", encoding="utf-8")
+    with result_file.open("a", encoding="utf-8") as handle:
+        handle.write(f"{workflow_id}\t{'SUCCEEDED' if item.get('ok') else 'FAILED'}\n")
+PY
+}
+
+# count_results RESULT_FILE
+#
+# Reads a tab-separated result file and prints three numbers to stdout:
+#   <succeeded> <failed> <skipped>
+count_results() {
+  local result_file="$1"
+  local succeeded=0
+  local failed=0
+  local skipped=0
+
+  while IFS=$'\t' read -r _id result; do
+    case "$result" in
+      SUCCEEDED) succeeded=$((succeeded + 1)) ;;
+      FAILED)    failed=$((failed + 1)) ;;
+      SKIPPED)   skipped=$((skipped + 1)) ;;
+    esac
+  done < "$result_file"
+
+  printf '%d %d %d\n' "$succeeded" "$failed" "$skipped"
+}

--- a/scripts/rebase-retry-all.sh
+++ b/scripts/rebase-retry-all.sh
@@ -1,15 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Detect repo root
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
+# shellcheck source=scripts/headless-lib.sh
+source "$(dirname "$0")/headless-lib.sh"
 
-# Set Electron paths
-ELECTRON="$REPO_ROOT/packages/app/node_modules/.bin/electron"
-MAIN="$REPO_ROOT/packages/app/dist/main.js"
-
+# ---------------------------------------------------------------------------
 # Parse arguments
+# ---------------------------------------------------------------------------
+
 DRY_RUN=false
 STATUS_FILTER=""
 PARALLELISM=""
@@ -19,7 +17,6 @@ RECOVER_STALE=true
 STALE_THRESHOLD_SECONDS=900
 STALE_RECOVERY_RETRIES=12
 STALE_RECOVERY_RETRY_DELAY_SECONDS=5
-STANDALONE_MODE="${INVOKER_HEADLESS_STANDALONE:-0}"
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -74,75 +71,9 @@ if [ "$STANDALONE_MODE" = "1" ]; then
   COMMAND_TIMEOUT_SECONDS=0
 fi
 
-# Handle Linux Electron sandbox detection
-unset ELECTRON_RUN_AS_NODE
-SANDBOX_FLAG=""
-if [ "$(uname)" = "Linux" ]; then
-  SANDBOX_BIN="$REPO_ROOT/node_modules/.pnpm/electron@*/node_modules/electron/dist/chrome-sandbox"
-  if ! stat -c '%U:%a' $SANDBOX_BIN 2>/dev/null | grep -q '^root:4755$'; then
-    SANDBOX_FLAG="--no-sandbox"
-  fi
-  export LIBGL_ALWAYS_SOFTWARE=1
-fi
-
-# Helper functions
-# Read-only queries remain quiet; mutating commands delegate to the current owner
-# so workflow-scoped mutations can run in parallel lanes.
-run_with_optional_timeout() {
-  local seconds="$1"
-  shift
-  if [ "$seconds" -le 0 ]; then
-    "$@"
-    return $?
-  fi
-  if command -v timeout >/dev/null 2>&1; then
-    timeout "$seconds" "$@"
-    return $?
-  fi
-  if command -v gtimeout >/dev/null 2>&1; then
-    gtimeout "$seconds" "$@"
-    return $?
-  fi
-  if command -v python3 >/dev/null 2>&1; then
-    python3 - "$seconds" "$@" <<'PY'
-import subprocess
-import sys
-
-timeout = int(sys.argv[1])
-cmd = sys.argv[2:]
-
-try:
-    completed = subprocess.run(cmd, timeout=timeout, check=False)
-    sys.exit(completed.returncode)
-except subprocess.TimeoutExpired:
-    print(f"Timed out after {timeout}s: {' '.join(cmd)}", file=sys.stderr)
-    sys.exit(124)
-PY
-    return $?
-  fi
-  echo "ERROR: timeout(1), gtimeout, and python3 are unavailable; cannot enforce per-command timeout." >&2
-  return 127
-}
-
-headless_query() {
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
-}
-
-headless_mutation() {
-  if [ "$STANDALONE_MODE" = "1" ]; then
-    "$REPO_ROOT/run.sh" --headless "$@"
-    return $?
-  fi
-  node "$IPC_HELPER" exec -- "$@"
-}
-
-headless_workflow_ids() {
-  headless_query "$@" | grep -E '^wf-[0-9]+-[0-9]+$' || true
-}
-
-headless_task_ids() {
-  headless_query "$@" | grep '/' || true
-}
+# ---------------------------------------------------------------------------
+# Stale recovery helpers (unique to rebase-retry)
+# ---------------------------------------------------------------------------
 
 find_stale_workflow_ids() {
   local wf_id=""
@@ -201,7 +132,10 @@ resume_stale_workflow() {
   return 1
 }
 
-# Query workflow IDs
+# ---------------------------------------------------------------------------
+# Query workflows
+# ---------------------------------------------------------------------------
+
 QUERY_ARGS=(query workflows --output label)
 if [ -n "$STATUS_FILTER" ]; then
   QUERY_ARGS+=(--status "$STATUS_FILTER")
@@ -229,6 +163,10 @@ if [ "$FOLLOW" = false ]; then
   echo "Note: fire-and-forget dispatches all workflows immediately; --parallel is enforced with --follow." >&2
 fi
 
+# ---------------------------------------------------------------------------
+# Stale recovery phase
+# ---------------------------------------------------------------------------
+
 if [ "$RECOVER_STALE" = true ]; then
   STALE_WF_IDS="$(find_stale_workflow_ids)"
   if [ -n "$STALE_WF_IDS" ]; then
@@ -250,12 +188,19 @@ if [ "$RECOVER_STALE" = true ]; then
   fi
 fi
 
+# ---------------------------------------------------------------------------
 # Initialize counters
+# ---------------------------------------------------------------------------
+
 SUCCEEDED=0
 FAILED=0
 SKIPPED=0
 DISPATCHED=0
 LAUNCH_FAILED=0
+
+# ---------------------------------------------------------------------------
+# Follow mode — background jobs with bounded parallelism
+# ---------------------------------------------------------------------------
 
 if [ "$FOLLOW" = true ]; then
   process_one_workflow() {
@@ -334,14 +279,7 @@ if [ "$FOLLOW" = true ]; then
     wait "$pid" || true
   done
 
-  while IFS=$'\t' read -r _wf result; do
-    case "$result" in
-      SUCCEEDED) SUCCEEDED=$((SUCCEEDED + 1)) ;;
-      FAILED) FAILED=$((FAILED + 1)) ;;
-      SKIPPED) SKIPPED=$((SKIPPED + 1)) ;;
-    esac
-  done < "$RESULTS_FILE"
-
+  read -r SUCCEEDED FAILED SKIPPED < <(count_results "$RESULTS_FILE")
   rm -f "$RESULTS_FILE"
 
   echo "" >&2
@@ -354,11 +292,15 @@ if [ "$FOLLOW" = true ]; then
   if [ "$FAILED" -ne 0 ]; then
     exit 1
   fi
+
+# ---------------------------------------------------------------------------
+# Fire-and-forget mode — batch dispatch
+# ---------------------------------------------------------------------------
+
 else
   LOG_DIR="$(mktemp -d -t rebase-retry-all-logs.XXXXXX)"
   RESULT_FILE="$(mktemp -t rebase-retry-all-results.XXXXXX)"
   COMMANDS_FILE="$(mktemp -t rebase-retry-all-commands.XXXXXX)"
-  OUTPUT_JSONL="$(mktemp -t rebase-retry-all-output.XXXXXX)"
 
   IDX=0
   while IFS= read -r WF_ID; do
@@ -384,52 +326,18 @@ else
     echo "  queued log=$log_file" >&2
   done <<< "$WORKFLOW_IDS"
 
-  BATCH_ARGS=(batch-exec --no-track --parallel "$PARALLELISM")
-  if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ]; then
-    BATCH_ARGS+=(--timeout-ms "$((COMMAND_TIMEOUT_SECONDS * 1000))")
-  fi
-  if [ "$STANDALONE_MODE" = "1" ]; then
-    while IFS= read -r WF_ID; do
-      [ -z "$WF_ID" ] && continue
-      task_id="$(headless_task_ids query tasks --workflow "$WF_ID" --no-merge --output label | head -1)"
-      [ -z "$task_id" ] && continue
-      if headless_mutation --no-track rebase "$task_id" > "$LOG_DIR/${WF_ID}.log" 2>&1; then
-        printf "%s\tSUCCEEDED\n" "$WF_ID" >> "$RESULT_FILE"
-      else
-        printf "%s\tFAILED\n" "$WF_ID" >> "$RESULT_FILE"
-      fi
-    done <<< "$WORKFLOW_IDS"
-  else
-    node "$IPC_HELPER" "${BATCH_ARGS[@]}" < "$COMMANDS_FILE" > "$OUTPUT_JSONL"
-    python3 - "$RESULT_FILE" "$LOG_DIR" "$OUTPUT_JSONL" <<'PY'
-import json
-import pathlib
-import sys
-
-result_file = pathlib.Path(sys.argv[1])
-log_dir = pathlib.Path(sys.argv[2])
-output_jsonl = pathlib.Path(sys.argv[3])
-
-for raw in output_jsonl.read_text(encoding="utf-8").splitlines():
-    raw = raw.strip()
-    if not raw:
-        continue
-    item = json.loads(raw)
-    workflow_id = item.get("workflowId") or item.get("label") or "unknown"
-    (log_dir / f"{workflow_id}.log").write_text(raw + "\n", encoding="utf-8")
-    with result_file.open("a", encoding="utf-8") as handle:
-        handle.write(f"{workflow_id}\t{'SUCCEEDED' if item.get('ok') else 'FAILED'}\n")
-PY
+  if [ "$DRY_RUN" = false ] && [ -s "$COMMANDS_FILE" ]; then
+    EXTRA_BATCH_ARGS=()
+    if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ]; then
+      EXTRA_BATCH_ARGS+=(--timeout-ms "$((COMMAND_TIMEOUT_SECONDS * 1000))")
+    fi
+    batch_dispatch "$COMMANDS_FILE" "$RESULT_FILE" "$LOG_DIR" "$PARALLELISM" "${EXTRA_BATCH_ARGS[@]}"
   fi
   rm -f "$COMMANDS_FILE"
-  rm -f "$OUTPUT_JSONL"
 
-  while IFS=$'\t' read -r _wf result; do
-    case "$result" in
-      SUCCEEDED) DISPATCHED=$((DISPATCHED + 1)) ;;
-      FAILED) LAUNCH_FAILED=$((LAUNCH_FAILED + 1)) ;;
-    esac
-  done < "$RESULT_FILE"
+  if [ -s "$RESULT_FILE" ]; then
+    read -r DISPATCHED LAUNCH_FAILED _ < <(count_results "$RESULT_FILE")
+  fi
   rm -f "$RESULT_FILE"
 
   echo "" >&2

--- a/scripts/recreate-all.sh
+++ b/scripts/recreate-all.sh
@@ -12,18 +12,18 @@
 #   bash scripts/recreate-all.sh --follow              # wait for completion (default is fire-and-forget)
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-RUNNER="$REPO_ROOT/run.sh"
-ELECTRON="$REPO_ROOT/packages/app/node_modules/.bin/electron"
-MAIN="$REPO_ROOT/packages/app/dist/main.js"
-IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
-STANDALONE_MODE="${INVOKER_HEADLESS_STANDALONE:-0}"
+# shellcheck source=scripts/headless-lib.sh
+source "$(dirname "$0")/headless-lib.sh"
 
+# ---------------------------------------------------------------------------
 # Parse args
+# ---------------------------------------------------------------------------
+
 DRY_RUN=false
 STATUS_FILTER=""
 PARALLELISM=""
 FOLLOW=false
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run) DRY_RUN=true; shift ;;
@@ -39,39 +39,10 @@ if [[ -n "$PARALLELISM" ]] && ! [[ "$PARALLELISM" =~ ^[1-9][0-9]*$ ]]; then
   exit 1
 fi
 
-# Electron sandbox detection
-unset ELECTRON_RUN_AS_NODE
-SANDBOX_FLAG=""
-if [ "$(uname)" = "Linux" ]; then
-  SANDBOX_BIN="$REPO_ROOT/node_modules/.pnpm/electron@*/node_modules/electron/dist/chrome-sandbox"
-  # shellcheck disable=SC2086
-  if ! stat -c '%U:%a' $SANDBOX_BIN 2>/dev/null | grep -q '^root:4755$'; then
-    SANDBOX_FLAG="--no-sandbox"
-  fi
-  export LIBGL_ALWAYS_SOFTWARE=1
-fi
+# ---------------------------------------------------------------------------
+# Query workflows
+# ---------------------------------------------------------------------------
 
-# Helper: read-only query command (stderr hidden to keep parsing clean)
-headless_query() {
-  # shellcheck disable=SC2086
-  "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" 2>/dev/null
-}
-
-# Helper: mutating command delegated to the current owner (GUI or standalone headless)
-headless_mutation() {
-  if [[ "$STANDALONE_MODE" = "1" ]]; then
-    "$RUNNER" --headless "$@"
-    return $?
-  fi
-  node "$IPC_HELPER" exec -- "$@"
-}
-
-# Helper: extract workflow IDs from label output.
-headless_workflow_ids() {
-  headless_query "$@" | grep -E '^wf-[0-9]+-[0-9]+$' || true
-}
-
-# Query workflow IDs via CLI
 QUERY_ARGS=(query workflows --output label)
 if [[ -n "$STATUS_FILTER" ]]; then
   QUERY_ARGS+=(--status "$STATUS_FILTER")
@@ -84,7 +55,6 @@ if [[ -z "$WORKFLOWS" ]]; then
   exit 0
 fi
 
-# Count workflows
 TOTAL=$(echo "$WORKFLOWS" | wc -l | tr -d ' ')
 if [[ -z "$PARALLELISM" ]]; then
   PARALLELISM="$TOTAL"
@@ -96,6 +66,10 @@ if ! $FOLLOW; then
   echo "Note: fire-and-forget dispatches all workflows immediately; --parallel is enforced with --follow."
 fi
 echo ""
+
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
 
 IDX=0
 FAILED=0
@@ -109,6 +83,11 @@ if $DRY_RUN; then
     echo "         (dry-run) would run: recreate $WF_ID"
     echo ""
   done <<< "$WORKFLOWS"
+
+# ---------------------------------------------------------------------------
+# Follow mode — background jobs with bounded parallelism
+# ---------------------------------------------------------------------------
+
 elif $FOLLOW; then
   RESULTS_FILE="$(mktemp -t recreate-all-results.XXXXXX)"
   PIDS=()
@@ -153,21 +132,17 @@ elif $FOLLOW; then
     wait "$pid" || true
   done
 
-  while IFS=$'\t' read -r _wf result; do
-    case "$result" in
-      SUCCEEDED) SUCCEEDED=$((SUCCEEDED + 1)) ;;
-      FAILED) FAILED=$((FAILED + 1)) ;;
-    esac
-  done < "$RESULTS_FILE"
-
+  read -r SUCCEEDED FAILED _ < <(count_results "$RESULTS_FILE")
   rm -f "$RESULTS_FILE"
+
+# ---------------------------------------------------------------------------
+# Fire-and-forget mode — batch dispatch
+# ---------------------------------------------------------------------------
+
 else
   LOG_DIR="$(mktemp -d -t recreate-all-logs.XXXXXX)"
-  DISPATCHED=0
-  LAUNCH_FAILED=0
   RESULT_FILE="$(mktemp -t recreate-all-results.XXXXXX)"
   COMMANDS_FILE="$(mktemp -t recreate-all-commands.XXXXXX)"
-  OUTPUT_JSONL="$(mktemp -t recreate-all-output.XXXXXX)"
 
   while IFS= read -r WF_ID; do
     [[ -z "$WF_ID" ]] && continue
@@ -176,48 +151,16 @@ else
     echo "[dispatch $IDX/$TOTAL] $WF_ID log=$LOG_DIR/${WF_ID}.log"
   done <<< "$WORKFLOWS"
 
-  if [[ "$STANDALONE_MODE" = "1" ]]; then
-    while IFS= read -r WF_ID; do
-      [[ -z "$WF_ID" ]] && continue
-      if headless_mutation --no-track recreate "$WF_ID" > "$LOG_DIR/${WF_ID}.log" 2>&1; then
-        printf "%s\tSUCCEEDED\n" "$WF_ID" >> "$RESULT_FILE"
-      else
-        printf "%s\tFAILED\n" "$WF_ID" >> "$RESULT_FILE"
-      fi
-    done <<< "$WORKFLOWS"
-  else
-    node "$IPC_HELPER" batch-exec --no-track --parallel "$PARALLELISM" < "$COMMANDS_FILE" > "$OUTPUT_JSONL"
-    python3 - "$RESULT_FILE" "$LOG_DIR" "$OUTPUT_JSONL" <<'PY'
-import json
-import pathlib
-import sys
-
-result_file = pathlib.Path(sys.argv[1])
-log_dir = pathlib.Path(sys.argv[2])
-output_jsonl = pathlib.Path(sys.argv[3])
-
-for raw in output_jsonl.read_text(encoding="utf-8").splitlines():
-    raw = raw.strip()
-    if not raw:
-        continue
-    item = json.loads(raw)
-    workflow_id = item.get("workflowId") or item.get("label") or "unknown"
-    (log_dir / f"{workflow_id}.log").write_text(raw + "\n", encoding="utf-8")
-    with result_file.open("a", encoding="utf-8") as handle:
-        handle.write(f"{workflow_id}\t{'SUCCEEDED' if item.get('ok') else 'FAILED'}\n")
-PY
-  fi
+  batch_dispatch "$COMMANDS_FILE" "$RESULT_FILE" "$LOG_DIR" "$PARALLELISM"
   rm -f "$COMMANDS_FILE"
-  rm -f "$OUTPUT_JSONL"
 
-  while IFS=$'\t' read -r _wf result; do
-    case "$result" in
-      SUCCEEDED) DISPATCHED=$((DISPATCHED + 1)) ;;
-      FAILED) LAUNCH_FAILED=$((LAUNCH_FAILED + 1)) ;;
-    esac
-  done < "$RESULT_FILE"
+  read -r DISPATCHED LAUNCH_FAILED _ < <(count_results "$RESULT_FILE")
   rm -f "$RESULT_FILE"
 fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
 
 echo "---"
 if $DRY_RUN; then

--- a/scripts/retry-failed-and-pending-all-workflows.sh
+++ b/scripts/retry-failed-and-pending-all-workflows.sh
@@ -13,9 +13,12 @@
 #   bash scripts/retry-failed-and-pending-all-workflows.sh --follow
 set -euo pipefail
 
-REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
-RUNNER="$REPO_ROOT/run.sh"
-IPC_HELPER="$REPO_ROOT/scripts/headless-ipc.js"
+# shellcheck source=scripts/headless-lib.sh
+source "$(dirname "$0")/headless-lib.sh"
+
+# ---------------------------------------------------------------------------
+# Parse args
+# ---------------------------------------------------------------------------
 
 DRY_RUN=false
 STATUS_FILTER=""
@@ -65,6 +68,10 @@ if [[ ! -x "$RUNNER" ]]; then
   exit 1
 fi
 
+# ---------------------------------------------------------------------------
+# Query workflows
+# ---------------------------------------------------------------------------
+
 WORKFLOWS_JSON="$("$RUNNER" --headless query workflows --output json)"
 
 WORKFLOWS="$(
@@ -103,6 +110,10 @@ echo "Parallelism: $PARALLELISM"
 echo "Follow mode: $FOLLOW"
 echo ""
 
+# ---------------------------------------------------------------------------
+# Dry-run
+# ---------------------------------------------------------------------------
+
 if $DRY_RUN; then
   IDX=0
   while IFS= read -r WF_ID; do
@@ -116,11 +127,20 @@ if $DRY_RUN; then
   echo "---"
   echo "Dry run complete. $TOTAL workflow(s) would be retried."
   exit 0
-else
-  FAILED=0
-  SUCCEEDED=0
-  DISPATCHED=0
-  IDX=0
+fi
+
+# ---------------------------------------------------------------------------
+# Follow mode — background jobs with bounded parallelism
+# ---------------------------------------------------------------------------
+
+FAILED=0
+SUCCEEDED=0
+IDX=0
+
+if $FOLLOW; then
+  RESULTS_FILE="$(mktemp -t retry-failed-results.XXXXXX)"
+  PIDS=()
+  LOG_DIR="$(mktemp -d -t retry-failed-logs.XXXXXX)"
 
   launch_one_workflow() {
     local wf_id="$1"
@@ -129,11 +149,7 @@ else
     local code=0
 
     set +e
-    if [[ "${INVOKER_HEADLESS_STANDALONE:-0}" = "1" ]]; then
-      cmd_out="$("$RUNNER" --headless --no-track retry "$wf_id" 2>&1)"
-    else
-      cmd_out="$(node "$IPC_HELPER" exec --no-track -- retry "$wf_id" 2>&1)"
-    fi
+    cmd_out="$(headless_mutation --no-track retry "$wf_id" 2>&1)"
     code=$?
     set -e
 
@@ -148,115 +164,64 @@ else
     return "$code"
   }
 
-  if $FOLLOW; then
-    RESULTS_FILE="$(mktemp -t retry-failed-results.XXXXXX)"
-    PIDS=()
-    LOG_DIR="$(mktemp -d -t retry-failed-logs.XXXXXX)"
+  while IFS= read -r WF_ID; do
+    [[ -z "$WF_ID" ]] && continue
+    IDX=$((IDX + 1))
+    echo "[queue $IDX/$TOTAL] $WF_ID"
+    log_file="$LOG_DIR/${WF_ID}.log"
+    (
+      if launch_one_workflow "$WF_ID" "$log_file"; then
+        printf "%s\tSUCCEEDED\n" "$WF_ID" >> "$RESULTS_FILE"
+      else
+        printf "%s\tFAILED\n" "$WF_ID" >> "$RESULTS_FILE"
+      fi
+      cat "$log_file"
+      echo ""
+    ) &
+    PIDS+=("$!")
 
-    while IFS= read -r WF_ID; do
-      [[ -z "$WF_ID" ]] && continue
-      IDX=$((IDX + 1))
-      echo "[queue $IDX/$TOTAL] $WF_ID"
-      log_file="$LOG_DIR/${WF_ID}.log"
-      (
-        if launch_one_workflow "$WF_ID" "$log_file"; then
-          printf "%s\tSUCCEEDED\n" "$WF_ID" >> "$RESULTS_FILE"
-        else
-          printf "%s\tFAILED\n" "$WF_ID" >> "$RESULTS_FILE"
-        fi
-        cat "$log_file"
-        echo ""
-      ) &
-      PIDS+=("$!")
-
-      while [[ "$(jobs -pr | wc -l | tr -d ' ')" -ge "$PARALLELISM" ]]; do
-        sleep 0.2
-      done
-    done <<<"$WORKFLOWS"
-
-    for pid in "${PIDS[@]}"; do
-      wait "$pid" || true
+    while [[ "$(jobs -pr | wc -l | tr -d ' ')" -ge "$PARALLELISM" ]]; do
+      sleep 0.2
     done
+  done <<<"$WORKFLOWS"
 
-    while IFS=$'\t' read -r _wf result; do
-      case "$result" in
-        SUCCEEDED) SUCCEEDED=$((SUCCEEDED + 1)) ;;
-        FAILED) FAILED=$((FAILED + 1)) ;;
-      esac
-    done < "$RESULTS_FILE"
+  for pid in "${PIDS[@]}"; do
+    wait "$pid" || true
+  done
 
-    rm -f "$RESULTS_FILE"
-  else
-    LOG_DIR="$(mktemp -d -t retry-failed-logs.XXXXXX)"
-    RESULT_FILE="$(mktemp -t retry-failed-results.XXXXXX)"
-    COMMANDS_FILE="$(mktemp -t retry-failed-commands.XXXXXX)"
-    OUTPUT_JSONL="$(mktemp -t retry-failed-output.XXXXXX)"
-    while IFS= read -r WF_ID; do
-      [[ -z "$WF_ID" ]] && continue
-      IDX=$((IDX + 1))
-      printf '{"label":"%s","workflowId":"%s","args":["retry","%s"]}\n' "$WF_ID" "$WF_ID" "$WF_ID" >> "$COMMANDS_FILE"
-      echo "[dispatch $IDX/$TOTAL] $WF_ID log=$LOG_DIR/${WF_ID}.log"
-    done <<<"$WORKFLOWS"
+  read -r SUCCEEDED FAILED _ < <(count_results "$RESULTS_FILE")
+  rm -f "$RESULTS_FILE"
 
-    if [[ "${INVOKER_HEADLESS_STANDALONE:-0}" = "1" ]]; then
-      while IFS= read -r WF_ID; do
-        [[ -z "$WF_ID" ]] && continue
-        if "$RUNNER" --headless --no-track retry "$WF_ID" > "$LOG_DIR/${WF_ID}.log" 2>&1; then
-          printf "%s\tSUCCEEDED\n" "$WF_ID" >> "$RESULT_FILE"
-          DISPATCHED=$((DISPATCHED + 1))
-        else
-          printf "%s\tFAILED\n" "$WF_ID" >> "$RESULT_FILE"
-        fi
-      done <<<"$WORKFLOWS"
-    else
-      node "$IPC_HELPER" batch-exec --no-track --parallel "$PARALLELISM" < "$COMMANDS_FILE" > "$OUTPUT_JSONL"
-    fi
-    if [[ "${INVOKER_HEADLESS_STANDALONE:-0}" != "1" ]]; then
-    python3 - "$RESULT_FILE" "$LOG_DIR" "$OUTPUT_JSONL" <<'PY'
-import json
-import pathlib
-import sys
+# ---------------------------------------------------------------------------
+# Fire-and-forget mode — batch dispatch
+# ---------------------------------------------------------------------------
 
-result_file = pathlib.Path(sys.argv[1])
-log_dir = pathlib.Path(sys.argv[2])
-output_jsonl = pathlib.Path(sys.argv[3])
+else
+  LOG_DIR="$(mktemp -d -t retry-failed-logs.XXXXXX)"
+  RESULT_FILE="$(mktemp -t retry-failed-results.XXXXXX)"
+  COMMANDS_FILE="$(mktemp -t retry-failed-commands.XXXXXX)"
 
-for raw in output_jsonl.read_text(encoding="utf-8").splitlines():
-    raw = raw.strip()
-    if not raw:
-        continue
-    item = json.loads(raw)
-    workflow_id = item.get("workflowId") or item.get("label") or "unknown"
-    log_path = log_dir / f"{workflow_id}.log"
-    with log_path.open("w", encoding="utf-8") as handle:
-        handle.write(raw + "\n")
-    with result_file.open("a", encoding="utf-8") as handle:
-        handle.write(f"{workflow_id}\t{'SUCCEEDED' if item.get('ok') else 'FAILED'}\n")
-PY
-    fi
-    rm -f "$COMMANDS_FILE"
-    rm -f "$OUTPUT_JSONL"
+  while IFS= read -r WF_ID; do
+    [[ -z "$WF_ID" ]] && continue
+    IDX=$((IDX + 1))
+    printf '{"label":"%s","workflowId":"%s","args":["retry","%s"]}\n' "$WF_ID" "$WF_ID" "$WF_ID" >> "$COMMANDS_FILE"
+    echo "[dispatch $IDX/$TOTAL] $WF_ID log=$LOG_DIR/${WF_ID}.log"
+  done <<<"$WORKFLOWS"
 
-    while IFS=$'\t' read -r _wf result; do
-      case "$result" in
-        SUCCEEDED)
-          if [[ "${INVOKER_HEADLESS_STANDALONE:-0}" != "1" ]]; then
-            DISPATCHED=$((DISPATCHED + 1))
-          fi
-          ;;
-        FAILED)
-          FAILED=$((FAILED + 1))
-          ;;
-      esac
-    done < "$RESULT_FILE"
-    rm -f "$RESULT_FILE"
-  fi
+  batch_dispatch "$COMMANDS_FILE" "$RESULT_FILE" "$LOG_DIR" "$PARALLELISM"
+  rm -f "$COMMANDS_FILE"
+
+  read -r SUCCEEDED FAILED _ < <(count_results "$RESULT_FILE")
+  DISPATCHED="$SUCCEEDED"
+  rm -f "$RESULT_FILE"
 fi
 
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
 echo "---"
-if $DRY_RUN; then
-  :
-elif $FOLLOW; then
+if $FOLLOW; then
   echo "Done. $SUCCEEDED succeeded, $FAILED failed out of $TOTAL."
   if [[ "$FAILED" -ne 0 ]]; then
     exit 1


### PR DESCRIPTION
## Summary

This PR aligns `packages/app/src/headless-client.ts` with the shared transport routing contract. Read-only queries now require a live owner, non-mutating and standalone flows stay on the Electron path, and mutating commands first try the current owner before bootstrapping a standalone owner. It also makes Playwright global setup build app artifacts when `dist/main.js` is missing and resolves queue context-menu actions in `packages/ui/src/App.tsx` against the latest task object.

## Architecture

### Before

```mermaid
graph TD
    A[headless-client command] --> B[Mixed routing branches]
    B --> C[Query handling with separate owner checks]
    B --> D[Mutation handling with duplicated dispatch and bootstrap logic]
    E[Playwright setup] --> F[Assumes dist/main.js already exists]
    G[Queue context action] --> H[May use stale task object]
```

### After

```mermaid
graph TD
    A[headless-client command] --> B{Shared transport routing policy}
    B -->|Read-only query| C[Delegate to any live owner]
    B -->|Non-mutating or standalone| D[Run Electron directly]
    B -->|Mutating command| E[Try current owner]
    E --> F[Bootstrap standalone owner only when needed]
    G[Playwright setup] --> I[Build app artifacts if dist/main.js is missing]
    J[Queue context action] --> K[Resolve against latest task object]
```

## Test Plan

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/headless-client.test.ts src/__tests__/owner-delegation.test.ts`
- [x] `bash scripts/e2e-dry-run/cases/case-2.14-standalone-timeout-deadlock-guard.sh && bash scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh`
- [x] `cd packages/app && CI=true INVOKER_PLAYWRIGHT_WORKERS=1 xvfb-run --auto-servernum pnpm exec playwright test e2e/headless-thundering-herd.spec.ts --reporter=line`
- [x] `cd packages/app && CI=true INVOKER_PLAYWRIGHT_WORKERS=1 xvfb-run --auto-servernum pnpm exec playwright test --shard=1/3 --reporter=line`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>` or `git revert <squash-commit-sha>` after merge
- Post-revert steps: Re-run the routing and Playwright regressions above if the stack stays open
- Data migration? No
