### PR TITLE
INV-118 Step 2: enable TaskPanel prompt double-click editing

### DIFF
--- a/packages/ui/src/__tests__/task-panel-double-click.test.tsx
+++ b/packages/ui/src/__tests__/task-panel-double-click.test.tsx
@@ -19,6 +19,7 @@ function makeTask(overrides: Partial<TaskState> & { command?: string; prompt?: s
 
 describe('TaskPanel double-click editing', () => {
   const mockOnEditCommand = vi.fn();
+  const mockOnEditPrompt = vi.fn();
   const mockOnProvideInput = vi.fn();
   const mockOnApprove = vi.fn();
   const mockOnReject = vi.fn();
@@ -1348,6 +1349,337 @@ describe('TaskPanel double-click editing', () => {
       await waitFor(() => {
         expect(screen.getByText(/would unblock now/)).toBeInTheDocument();
       });
+    });
+  });
+
+  describe('Prompt double-click editing', () => {
+    it('enters edit mode when double-clicking prompt display with onEditPrompt provided', () => {
+      const task = makeTask({ prompt: 'Write a test', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      const commandDisplay = screen.getByTestId('command-display');
+      fireEvent.doubleClick(commandDisplay);
+
+      expect(screen.getByTestId('edit-prompt-input')).toBeInTheDocument();
+      expect(screen.getByTestId('save-prompt-btn')).toBeInTheDocument();
+      expect(screen.getByTestId('cancel-prompt-edit-btn')).toBeInTheDocument();
+    });
+
+    it('does NOT enter prompt edit mode when task is running', () => {
+      const task = makeTask({ prompt: 'Write a test', status: 'running' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      const commandDisplay = screen.getByTestId('command-display');
+      fireEvent.doubleClick(commandDisplay);
+
+      expect(screen.queryByTestId('edit-prompt-input')).not.toBeInTheDocument();
+    });
+
+    it('does NOT enter prompt edit mode when onEditPrompt is not provided', () => {
+      const task = makeTask({ prompt: 'Write a test', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          // no onEditPrompt
+        />,
+      );
+
+      const commandDisplay = screen.getByTestId('command-display');
+      fireEvent.doubleClick(commandDisplay);
+
+      expect(screen.queryByTestId('edit-prompt-input')).not.toBeInTheDocument();
+    });
+
+    it('initializes prompt edit textarea with current prompt value', () => {
+      const task = makeTask({ prompt: 'Refactor the auth module', status: 'completed' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+
+      const textarea = screen.getByTestId('edit-prompt-input') as HTMLTextAreaElement;
+      expect(textarea.value).toBe('Refactor the auth module');
+    });
+
+    it('calls onEditPrompt with new value on save', () => {
+      const task = makeTask({ prompt: 'Original prompt', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      fireEvent.change(screen.getByTestId('edit-prompt-input'), { target: { value: 'Updated prompt' } });
+      fireEvent.click(screen.getByTestId('save-prompt-btn'));
+
+      expect(mockOnEditPrompt).toHaveBeenCalledWith('test-task-1', 'Updated prompt');
+    });
+
+    it('does not call onEditPrompt when saving unchanged prompt', () => {
+      const task = makeTask({ prompt: 'Same prompt', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      // Don't change the value, just save
+      fireEvent.click(screen.getByTestId('save-prompt-btn'));
+
+      expect(mockOnEditPrompt).not.toHaveBeenCalled();
+    });
+
+    it('reverts prompt and exits edit mode on cancel', () => {
+      const task = makeTask({ prompt: 'Original prompt', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      fireEvent.change(screen.getByTestId('edit-prompt-input'), { target: { value: 'Modified prompt' } });
+      fireEvent.click(screen.getByTestId('cancel-prompt-edit-btn'));
+
+      expect(mockOnEditPrompt).not.toHaveBeenCalled();
+      expect(screen.queryByTestId('edit-prompt-input')).not.toBeInTheDocument();
+      expect(screen.getByTestId('command-display')).toHaveTextContent('Original prompt');
+    });
+
+    it('enters prompt edit mode on pending tasks', () => {
+      const task = makeTask({ prompt: 'Pending prompt', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      expect(screen.getByTestId('edit-prompt-input')).toBeInTheDocument();
+    });
+
+    it('enters prompt edit mode on completed tasks', () => {
+      const task = makeTask({ prompt: 'Completed prompt', status: 'completed' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      expect(screen.getByTestId('edit-prompt-input')).toBeInTheDocument();
+    });
+
+    it('enters prompt edit mode on failed tasks', () => {
+      const task = makeTask({ prompt: 'Failed prompt', status: 'failed' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      expect(screen.getByTestId('edit-prompt-input')).toBeInTheDocument();
+    });
+
+    it('prioritizes prompt edit over command edit when task has both', () => {
+      const task = makeTask({ prompt: 'AI prompt', command: 'echo test', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditCommand={mockOnEditCommand}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      // Display should show prompt text (not command)
+      const display = screen.getByTestId('command-display');
+      expect(display).toHaveTextContent('AI prompt');
+
+      // Double-click should open prompt editor, not command editor
+      fireEvent.doubleClick(display);
+      expect(screen.getByTestId('edit-prompt-input')).toBeInTheDocument();
+      expect(screen.queryByTestId('edit-command-input')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Prompt visual hints', () => {
+    it('applies cursor-pointer style to editable prompt display', () => {
+      const task = makeTask({ prompt: 'Test prompt', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      const display = screen.getByTestId('command-display');
+      expect(display).toHaveClass('cursor-pointer');
+    });
+
+    it('applies hover border effect to editable prompt display', () => {
+      const task = makeTask({ prompt: 'Test prompt', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      const display = screen.getByTestId('command-display');
+      expect(display).toHaveClass('hover:border-blue-600');
+      expect(display).toHaveClass('transition-colors');
+    });
+
+    it('applies cursor-text when prompt task is running (not editable)', () => {
+      const task = makeTask({ prompt: 'Running prompt', status: 'running' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      const display = screen.getByTestId('command-display');
+      expect(display).toHaveClass('cursor-text');
+      expect(display).not.toHaveClass('cursor-pointer');
+    });
+
+    it('applies cursor-text when onEditPrompt not provided', () => {
+      const task = makeTask({ prompt: 'Test prompt', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          // no onEditPrompt
+        />,
+      );
+
+      const display = screen.getByTestId('command-display');
+      expect(display).toHaveClass('cursor-text');
+      expect(display).not.toHaveClass('cursor-pointer');
+    });
+  });
+
+  describe('Command-task editing still works unchanged', () => {
+    it('command tasks still enter command edit mode on double-click', () => {
+      const task = makeTask({ command: 'echo test', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditCommand={mockOnEditCommand}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      expect(screen.getByTestId('edit-command-input')).toBeInTheDocument();
+      expect(screen.queryByTestId('edit-prompt-input')).not.toBeInTheDocument();
+    });
+
+    it('command save still calls onEditCommand', () => {
+      const task = makeTask({ command: 'echo old', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditCommand={mockOnEditCommand}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      fireEvent.change(screen.getByTestId('edit-command-input'), { target: { value: 'echo new' } });
+      fireEvent.click(screen.getByTestId('save-command-btn'));
+
+      expect(mockOnEditCommand).toHaveBeenCalledWith('test-task-1', 'echo new');
+      expect(mockOnEditPrompt).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
## Summary
Make TaskPanel prompt text use the same inline double-click editor pattern as
command tasks, now that the renderer has a prompt-edit bridge.

```text
Before
[TaskPanel displayed task text]
       |
       +--> command text -> double-click -> inline editor -> save
       |
       +--> prompt text  -> double-click blocked

After this step
[TaskPanel displayed task text]
       |
       v
  [shared inline editor state]
       |
   +---+---+
   |       |
   v       v
[save command]   [save prompt]
```

This step is intentionally UI-focused. It should reuse the existing inline
editor surface and preserve current command-task behavior while enabling the
same interaction for prompt tasks in the TaskPanel only.


---
INV-118 Step 2: enable TaskPanel prompt double-click editing — 2 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1777929144758-9/enable-taskpanel-prompt-double-click-editing | Make prompt text editable by TaskPanel double-click in packages/ui/src/components/TaskPanel.tsx and packages/ui/src/__tests__/task-panel-double-click.test.tsx while preserving the existing command-task inline editor. Files: those two UI files. Change types: edit-state refactor, prompt-save routing, unit-test updates. Acceptance criteria: double-clicking displayed prompt text enters edit mode when prompt editing is available, saving calls the prompt callback instead of the command callback, running tasks remain non-editable, and existing command-task behavior still passes. | completed |
| wf-1777929144758-9/verify-taskpanel-prompt-double-click | Run the focused UI regression command for packages/ui/src/__tests__/task-panel-double-click.test.tsx to verify TaskPanel double-click editing still works for command and prompt task content. Files: packages/ui/src/__tests__/task-panel-double-click.test.tsx. Change types: execute focused UI regression command. Acceptance criteria: that test file passes. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1777929144758-9/enable-taskpanel-prompt-double-click-editing — Make prompt text editable by TaskPanel double-click in packages/ui/src/components/TaskPanel.tsx and packages/ui/src/__tests__/task-panel-double-click.test.tsx while preserving the existing command-task inline editor. Files: those two UI files. Change types: edit-state refactor, prompt-save routing, unit-test updates. Acceptance criteria: double-clicking displayed prompt text enters edit mode when prompt editing is available, saving calls the prompt callback instead of the command callback, running tasks remain non-editable, and existing command-task behavior still passes.
.../approve-fix-modal-with-session-log.png         | Bin 81499 -> 70953 bytes
 .../context-menu-failed-organization.png           | Bin 74850 -> 72713 bytes
 .../queue-action-surface-hardening.png             | Bin 0 -> 88203 bytes
 .../queue-relationships-expanded-context.png       | Bin 0 -> 66088 bytes
 .../queue-semantics-action-states.png              | Bin 0 -> 87313 bytes
 .../queue-view-concurrency.png                     | Bin 56862 -> 53137 bytes
 .../terminate-wording-task-vs-workflow.png         | Bin 0 -> 77252 bytes
 packages/app/e2e/visual-proof.spec.ts              | 188 ++++++++-
 packages/app/src/__tests__/auto-fix-gating.test.ts |   8 +
 packages/app/src/__tests__/headless-client.test.ts |  38 +-
 .../headless-command-classification.test.ts        |  19 +
 packages/app/src/auto-fix-gating.ts                |   3 +-
 packages/app/src/headless-client.ts                |   5 +-
 .../app/src/headless-command-classification.ts     |  25 ++
 packages/app/src/main.ts                           |  23 ++
 packages/contracts/src/ipc-channels.ts             |   4 +
 .../src/__tests__/task-runner.test.ts              | 406 ++++++++++++++++++
 packages/execution-engine/src/task-runner.ts       |  10 +-
 packages/ui/src/App.tsx                            |  16 +-
 packages/ui/src/__tests__/queue-view.test.tsx      | 452 ++++++++++++++++++++-
 ...
 34 files changed, 1903 insertions(+), 136 deletions(-)

### wf-1777929144758-9/verify-taskpanel-prompt-double-click — Run the focused UI regression command for packages/ui/src/__tests__/task-panel-double-click.test.tsx to verify TaskPanel double-click editing still works for command and prompt task content. Files: packages/ui/src/__tests__/task-panel-double-click.test.tsx. Change types: execute focused UI regression command. Acceptance criteria: that test file passes.

</details>
