### PR TITLE
INV-118 Step 3: add end-to-end prompt edit regressions

### DIFF
--- a/packages/app/e2e/edit-task-prompt.spec.ts
+++ b/packages/app/e2e/edit-task-prompt.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * E2E: Edit a prompt task's prompt via the TaskPanel UI.
+ *
+ * Verifies that double-clicking the prompt display → changing it → Save & Re-run
+ * causes the task to restart with the new prompt (recreate semantics) and
+ * downstream tasks are invalidated in place.
+ */
+
+import { test, expect, loadPlan, startPlan, waitForTaskStatus, E2E_REPO_URL } from './fixtures/electron-app.js';
+import type { Page } from '@playwright/test';
+
+function findTaskByIdSuffix(tasks: Array<any>, taskId: string) {
+  return tasks.find((t) => t.id === taskId || t.id.endsWith(`/${taskId}`));
+}
+
+async function selectTaskAndWaitForDisplay(page: Page, taskSuffix: string): Promise<void> {
+  const node = page.locator(`.react-flow__node[data-testid$="/${taskSuffix}"]`);
+  const commandDisplay = page.locator('[data-testid="command-display"]');
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await node.click();
+    try {
+      await expect(commandDisplay).toBeVisible({ timeout: 3000 });
+      return;
+    } catch (err) {
+      if (attempt === 2) throw err;
+    }
+  }
+}
+
+const EDIT_PROMPT_PLAN = {
+  name: 'E2E Edit Prompt Plan',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'task-setup',
+      description: 'Setup task that passes',
+      command: 'echo setup-ok',
+      dependencies: [],
+    },
+    {
+      id: 'task-prompt',
+      description: 'Prompt task to edit',
+      prompt: 'do the old thing',
+      dependencies: ['task-setup'],
+    },
+    {
+      id: 'task-downstream',
+      description: 'Downstream task',
+      command: 'echo downstream',
+      dependencies: ['task-prompt'],
+    },
+  ],
+};
+
+test.describe('Edit task prompt', () => {
+  test('edit a completed prompt task via TaskPanel, verify re-run with new prompt', async ({ page }) => {
+    await loadPlan(page, EDIT_PROMPT_PLAN);
+    await startPlan(page);
+
+    // Wait for all tasks to complete (prompt task uses stub claude that exits 0)
+    await waitForTaskStatus(page, 'task-setup', 'completed');
+    await waitForTaskStatus(page, 'task-prompt', 'completed');
+
+    // Click the prompt task node to select it
+    await selectTaskAndWaitForDisplay(page, 'task-prompt');
+
+    // Double-click the command-display (shows prompt text for prompt tasks)
+    const commandDisplay = page.locator('[data-testid="command-display"]');
+    await commandDisplay.dblclick();
+
+    // The prompt textarea should appear with the old prompt
+    const textarea = page.locator('[data-testid="edit-prompt-input"]');
+    await expect(textarea).toBeVisible({ timeout: 2000 });
+    const oldValue = await textarea.inputValue();
+    expect(oldValue).toBe('do the old thing');
+
+    // Clear and type the new prompt
+    await textarea.fill('do the new thing');
+
+    // Click Save & Re-run
+    const saveBtn = page.locator('[data-testid="save-prompt-btn"]');
+    await expect(saveBtn).toBeVisible();
+    await saveBtn.click();
+
+    // Task should now re-run and complete with the new prompt
+    await waitForTaskStatus(page, 'task-prompt', 'completed', 15000);
+
+    // Verify prompt was updated in task config
+    const result = await page.evaluate(() => window.invoker.getTasks());
+    const tasks = Array.isArray(result) ? result : result.tasks;
+    const editedTask = findTaskByIdSuffix(tasks, 'task-prompt');
+    expect(editedTask?.config?.prompt).toBe('do the new thing');
+    expect(editedTask?.status).toBe('completed');
+  });
+
+  test('editing a completed prompt task invalidates downstream subtree in place (recreate semantics)', async ({ page }) => {
+    await loadPlan(page, EDIT_PROMPT_PLAN);
+    await startPlan(page);
+
+    // Wait for entire chain to complete
+    await waitForTaskStatus(page, 'task-setup', 'completed');
+    await waitForTaskStatus(page, 'task-prompt', 'completed');
+    await waitForTaskStatus(page, 'task-downstream', 'completed');
+
+    // Capture downstream task state before edit
+    const beforeEditResult = await page.evaluate(() => window.invoker.getTasks());
+    const beforeEditTasks = Array.isArray(beforeEditResult) ? beforeEditResult : beforeEditResult.tasks;
+    const beforeEditDownstream = findTaskByIdSuffix(beforeEditTasks, 'task-downstream');
+    expect(beforeEditDownstream).toBeDefined();
+    const beforeGeneration = beforeEditDownstream?.execution?.generation ?? 0;
+
+    // Click the prompt task to select it
+    await selectTaskAndWaitForDisplay(page, 'task-prompt');
+
+    // Double-click → edit → save
+    const commandDisplay = page.locator('[data-testid="command-display"]');
+    await commandDisplay.dblclick();
+    const textarea = page.locator('[data-testid="edit-prompt-input"]');
+    await textarea.fill('updated prompt');
+
+    const saveBtn = page.locator('[data-testid="save-prompt-btn"]');
+    await saveBtn.click();
+
+    // Prompt task should re-run and complete
+    await waitForTaskStatus(page, 'task-prompt', 'completed', 15000);
+
+    // Wait for downstream task to be re-executed with a bumped generation
+    await page.waitForFunction(
+      ({ taskId, generation }) => window.invoker.getTasks().then((result) => {
+        const tasks = Array.isArray(result) ? result : result.tasks;
+        const child = tasks.find((t) => t.id === taskId || t.id.endsWith(`/${taskId}`));
+        return Boolean(child && (child.execution?.generation ?? 0) > generation);
+      }),
+      { taskId: 'task-downstream', generation: beforeGeneration },
+      { timeout: 15000 },
+    );
+
+    // Verify downstream was invalidated in place (same ID, bumped generation, no fork)
+    const result = await page.evaluate(() => window.invoker.getTasks());
+    const tasks = Array.isArray(result) ? result : result.tasks;
+    const downstreamTask = findTaskByIdSuffix(tasks, 'task-downstream');
+    expect(downstreamTask).toBeDefined();
+    expect(downstreamTask?.id).toBe(beforeEditDownstream.id);
+    expect(downstreamTask?.execution?.generation).toBeGreaterThan(beforeGeneration);
+    expect(['pending', 'running', 'completed']).toContain(downstreamTask?.status);
+    // No forked copy created
+    expect(tasks.find((t: any) => !t.id.endsWith('/task-downstream') && t.description === 'Downstream task')).toBeUndefined();
+  });
+});

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -133,8 +133,23 @@ export const TEST_PLAN = {
   ],
 };
 
+/** Minimal plan shape accepted by loadPlan (command OR prompt per task). */
+export type LoadablePlan = {
+  name: string;
+  repoUrl?: string;
+  onFinish: 'none' | 'merge' | 'pull_request';
+  tasks: Array<{
+    id: string;
+    description: string;
+    command?: string;
+    prompt?: string;
+    dependencies?: string[];
+    experimentVariants?: Array<{ id: string; description: string; command: string }>;
+  }>;
+};
+
 /** Load a plan into the running app via the IPC bridge and wait for DAG to render. */
-export async function loadPlan(page: Page, plan: typeof TEST_PLAN): Promise<void> {
+export async function loadPlan(page: Page, plan: LoadablePlan): Promise<void> {
   const planYaml = yamlStringify(plan);
   await page.evaluate((p) => window.invoker.loadPlan(p), planYaml);
   await page.locator(`.react-flow__node[data-testid$="${plan.tasks[0].id}"]`).first().waitFor({ state: 'visible', timeout: 10000 });

--- a/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
+++ b/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
@@ -58,6 +58,33 @@ describe('app-layer handoff repros', () => {
     expect(h.getTask('A')!.status).toBe('completed');
   });
 
+  it('edit-task-prompt launches restarted task and persists workspacePath', async () => {
+    const PROMPT_PLAN: PlanDefinition = {
+      name: 'Prompt Handoff Repro',
+      onFinish: 'none',
+      tasks: [
+        { id: 'A', description: 'Prompt task', prompt: 'do the old thing' },
+        { id: 'B', description: 'Downstream', command: 'echo b', dependencies: ['A'] },
+      ],
+    };
+    h.loadAndStart(PROMPT_PLAN);
+    h.completeTask('A');
+    h.completeTask('B');
+
+    // Edit A's prompt — recreate semantics should invalidate B
+    const started = h.orchestrator.editTaskPrompt('A', 'do the new thing');
+    expect(started.some((task) => task.id.endsWith('/A') && task.status === 'running')).toBe(true);
+    expect(h.getTask('A')!.config.prompt).toBe('do the new thing');
+    expect(h.getTask('A')!.execution.workspacePath).toBeUndefined();
+    // B should have been invalidated (reset to pending) by the recreate
+    expect(h.getTask('B')!.status).toBe('pending');
+
+    await dispatchStarted(h, started, 'test.edit-task-prompt');
+
+    expect(h.getTask('A')!.execution.workspacePath).toBe('/tmp/mock-worktree');
+    expect(h.getTask('A')!.status).toBe('completed');
+  });
+
   it('edit-task-type launches restarted task and persists workspacePath', async () => {
     h.loadAndStart(LINEAR_PLAN);
     h.failTask('A', 'broken');

--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -515,6 +515,41 @@ describe('Flow 4: edit/fork mutations', () => {
     expect(h.getAllTasks().find((t) => t.id.endsWith('/C-v2'))).toBeUndefined();
   });
 
+  it('editTaskPrompt restarts prompt task in-place and invalidates downstream (recreate semantics)', () => {
+    const PROMPT_PLAN: PlanDefinition = {
+      name: 'Prompt Edit Plan',
+      onFinish: 'none',
+      tasks: [
+        { id: 'A', description: 'Prompt task', prompt: 'do the old thing' },
+        { id: 'B', description: 'Downstream', command: 'echo b', dependencies: ['A'] },
+        { id: 'C', description: 'Leaf task', command: 'echo c', dependencies: ['B'] },
+      ],
+    };
+
+    h.loadAndStart(PROMPT_PLAN);
+    h.completeTask('A');
+    h.completeTask('B');
+    h.completeTask('C');
+
+    const beforeGen = h.getTask('A')!.execution.generation;
+
+    // Edit A's prompt — should restart A in-place and invalidate downstream
+    h.orchestrator.editTaskPrompt('A', 'do the new thing');
+
+    const a = h.getTask('A')!;
+    expect(a.status === 'pending' || a.status === 'running').toBe(true);
+    expect(a.config.prompt).toBe('do the new thing');
+    expect(a.execution.generation).toBeGreaterThan(beforeGen ?? 0);
+
+    // Downstream tasks are invalidated (recreate, not retry)
+    expect(h.getTask('B')!.status).toBe('pending');
+    expect(h.getTask('C')!.status).toBe('pending');
+
+    // No forked copies
+    expect(h.getAllTasks().find((t) => t.id.endsWith('/A-v2'))).toBeUndefined();
+    expect(h.getAllTasks().find((t) => t.id.endsWith('/B-v2'))).toBeUndefined();
+  });
+
   it('editTaskType does NOT fork subtree', () => {
     h.loadAndStart(LINEAR_PLAN);
     h.completeTask('A');

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -21,6 +21,7 @@ import {
   rejectTask,
   provideInput,
   editTaskCommand,
+  editTaskPrompt,
   editTaskType,
   selectExperiment,
   setWorkflowMergeMode,
@@ -1058,6 +1059,20 @@ describe('editTaskCommand', () => {
     });
 
     expect(orchestrator.editTaskCommand).toHaveBeenCalledWith('task-a', 'npm test');
+    expect(result).toBe(tasks);
+  });
+});
+
+describe('editTaskPrompt', () => {
+  it('calls orchestrator.editTaskPrompt and returns result', () => {
+    const tasks = [makeRunningTask()];
+    const orchestrator = { editTaskPrompt: vi.fn(() => tasks) };
+
+    const result = editTaskPrompt('task-a', 'do the thing', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+    });
+
+    expect(orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-a', 'do the thing');
     expect(result).toBe(tasks);
   });
 });


### PR DESCRIPTION
## Summary
Add the remaining regression proof for prompt editing: app-layer coverage for
the GUI path and Playwright coverage for the recreated prompt-task flow.

```text
Final architecture
[TaskPanel prompt text]
      -> [shared inline editor]
      -> [App handleEditPrompt]
      -> [IPC prompt-edit bridge]
      -> [commandService.editTaskPrompt]
      -> [orchestrator.editTaskPrompt]
      -> [recreateTask]

Regression proof added here
- app-layer GUI-path test
- Playwright prompt-edit flow
- workflow-core invalidation regression
```

This step is intentionally verification-heavy so the final PR makes the
recreate semantics explicit and keeps the user-visible behavior covered end to
end.


---
INV-118 Step 3: add end-to-end prompt edit regressions — 3 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1777929155816-10/add-prompt-edit-regression-coverage | Extend app-layer and end-to-end regression coverage in packages/app so the prompt-edit GUI path proves recreate semantics. Files: the closest GUI or IPC regression tests under packages/app/src/__tests__/ plus packages/app/e2e/edit-task-command.spec.ts or a sibling Playwright spec. Change types: GUI-path regression tests and prompt-task E2E coverage. Acceptance criteria: at least one app-layer test proves invoker:edit-task-prompt reaches editTaskPrompt and dispatches started tasks, and an E2E test verifies a prompt task reruns with updated prompt config after TaskPanel double-click editing. | completed |
| wf-1777929155816-10/verify-app-prompt-edit-regressions | Run the focused app regression command for packages/app/src/__tests__/api-server.test.ts to verify prompt-edit IPC and API behavior used by the GUI mutation flow. Files: packages/app/src/__tests__/api-server.test.ts. Change types: execute focused app regression command. Acceptance criteria: that test file passes. | completed (passed) |
| wf-1777929155816-10/verify-workflow-core-prompt-invalidation | Run the focused workflow-core regression command for packages/workflow-core/src/__tests__/edit-task-prompt-invalidation.test.ts to verify prompt edits still use recreate-task invalidation semantics underneath the UI flow. Files: packages/workflow-core/src/__tests__/edit-task-prompt-invalidation.test.ts. Change types: execute focused workflow-core regression command. Acceptance criteria: that test file passes. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1777929155816-10/add-prompt-edit-regression-coverage — Extend app-layer and end-to-end regression coverage in packages/app so the prompt-edit GUI path proves recreate semantics. Files: the closest GUI or IPC regression tests under packages/app/src/__tests__/ plus packages/app/e2e/edit-task-command.spec.ts or a sibling Playwright spec. Change types: GUI-path regression tests and prompt-task E2E coverage. Acceptance criteria: at least one app-layer test proves invoker:edit-task-prompt reaches editTaskPrompt and dispatches started tasks, and an E2E test verifies a prompt task reruns with updated prompt config after TaskPanel double-click editing.
.../approve-fix-modal-with-session-log.png         | Bin 81499 -> 70953 bytes
 .../context-menu-failed-organization.png           | Bin 74850 -> 72713 bytes
 .../queue-action-surface-hardening.png             | Bin 0 -> 88203 bytes
 .../queue-relationships-expanded-context.png       | Bin 0 -> 66088 bytes
 .../queue-semantics-action-states.png              | Bin 0 -> 87313 bytes
 .../queue-view-concurrency.png                     | Bin 56862 -> 53137 bytes
 .../terminate-wording-task-vs-workflow.png         | Bin 0 -> 77252 bytes
 packages/app/e2e/edit-task-prompt.spec.ts          | 150 ++++++++++++++++
 packages/app/e2e/fixtures/electron-app.ts          |  17 +-
 packages/app/e2e/visual-proof.spec.ts              | 188 ++++++++++++++++++++-
 .../src/__tests__/app-layer-handoff-repro.test.ts  |  27 +++
 packages/app/src/__tests__/auto-fix-gating.test.ts |   8 +
 .../__tests__/bridge-orchestrator-executor.test.ts |  35 ++++
 packages/app/src/__tests__/headless-client.test.ts |  38 +----
 .../headless-command-classification.test.ts        |  19 +++
 .../app/src/__tests__/workflow-actions.test.ts     |  15 ++
 packages/app/src/auto-fix-gating.ts                |   3 +-
 packages/app/src/headless-client.ts                |   5 +-
 .../app/src/headless-command-classification.ts     |  25 +++
 packages/app/src/main.ts                           |  23 +++
 ...
 39 files changed, 2146 insertions(+), 137 deletions(-)

### wf-1777929155816-10/verify-app-prompt-edit-regressions — Run the focused app regression command for packages/app/src/__tests__/api-server.test.ts to verify prompt-edit IPC and API behavior used by the GUI mutation flow. Files: packages/app/src/__tests__/api-server.test.ts. Change types: execute focused app regression command. Acceptance criteria: that test file passes.

### wf-1777929155816-10/verify-workflow-core-prompt-invalidation — Run the focused workflow-core regression command for packages/workflow-core/src/__tests__/edit-task-prompt-invalidation.test.ts to verify prompt edits still use recreate-task invalidation semantics underneath the UI flow. Files: packages/workflow-core/src/__tests__/edit-task-prompt-invalidation.test.ts. Change types: execute focused workflow-core regression command. Acceptance criteria: that test file passes.

</details>
