### PR TITLE
Retry reset semantics should match recreate immediacy

### DIFF
--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -397,18 +397,22 @@ describe('Flow 2: restart task', () => {
     h = createTestHarness();
   });
 
-  it('restarting a completed task resets it and re-executes', () => {
+  it('task-scope retry resets the target and downstream invalidated subgraph immediately', () => {
     h.loadAndStart(LINEAR_PLAN);
     h.completeTask('A');
 
     expect(h.getTask('A')!.status).toBe('completed');
     expect(h.getTask('B')!.status).toBe('running');
+    expect(h.getTask('C')!.status).toBe('pending');
 
-    // Restart A — B is running (not blocked), so retryTask only resets A
+    // Retry A while B is already executing from A's old output.
     h.orchestrator.retryTask('A');
 
-    // A should be running (no deps, auto-started)
+    // Retry now matches recreate-style task scope: A restarts immediately and
+    // the downstream subgraph is invalidated right away.
     expect(h.getTask('A')!.status).toBe('running');
+    expect(h.getTask('B')!.status).toBe('pending');
+    expect(h.getTask('C')!.status).toBe('pending');
   });
 
   it('restarting a failed task allows downstream cascade', () => {
@@ -777,6 +781,33 @@ describe('Flow 6: content-addressable branch names', () => {
       expect(t.execution?.branch).toBeUndefined();
       expect(t.execution?.workspacePath).toBeUndefined();
     }
+  });
+
+  it('retryWorkflow matches recreate-style reset scope but preserves branch/workspace lineage', () => {
+    h.loadAndStart(PARALLEL_PLAN);
+
+    h.completeTask('A');
+    h.completeTask('B');
+    h.persistence.updateTask('A', {
+      execution: { branch: 'experiment/A-abc12345', workspacePath: '/tmp/worktrees/exec-A', commit: 'commit-a' },
+    });
+    h.persistence.updateTask('B', {
+      execution: { branch: 'experiment/B-def67890', workspacePath: '/tmp/worktrees/exec-B', commit: 'commit-b' },
+    });
+    (h.orchestrator as any).refreshFromDb();
+
+    expect(h.getTask('C')!.status).toBe('running');
+    h.orchestrator.retryWorkflow(h.orchestrator.getWorkflowIds()[0]!);
+
+    expect(['pending', 'running']).toContain(h.getTask('A')!.status);
+    expect(['pending', 'running']).toContain(h.getTask('B')!.status);
+    expect(h.getTask('C')!.status).toBe('pending');
+    expect(h.getTask('A')!.execution.branch).toBe('experiment/A-abc12345');
+    expect(h.getTask('A')!.execution.workspacePath).toBe('/tmp/worktrees/exec-A');
+    expect(h.getTask('A')!.execution.commit).toBeUndefined();
+    expect(h.getTask('B')!.execution.branch).toBe('experiment/B-def67890');
+    expect(h.getTask('B')!.execution.workspacePath).toBe('/tmp/worktrees/exec-B');
+    expect(h.getTask('B')!.execution.commit).toBeUndefined();
   });
 
   it('recreateWorkflow resets tasks so re-execution gets fresh branches', () => {

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1160,6 +1160,61 @@ describe('headless delegation enforcement', () => {
 
           preparePoolSpy.mockRestore();
         });
+
+        it('keeps retry, recreate, and rebase on distinct workflow-reset routes', async () => {
+          const preemptWorkflowExecution = vi.fn(async () => ({ cancelled: [], runningCancelled: [] }));
+          mockDeps.commandService.retryWorkflow = vi.fn(async () => ({ ok: true as const, data: [] }));
+          mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
+          mockDeps.orchestrator.recreateWorkflowFromFreshBase = vi.fn(async () => []);
+          mockDeps.persistence.loadWorkflow = vi.fn(() => ({
+            id: 'wf-1',
+            name: 'wf-1',
+            status: 'running' as const,
+            generation: 2,
+            repoUrl: 'https://example/repo.git',
+            baseBranch: 'main',
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          }));
+          mockDeps.persistence.listWorkflows = vi.fn(() => [{
+            id: 'wf-1',
+            name: 'wf-1',
+            status: 'running' as const,
+            generation: 2,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          }]);
+          mockDeps.persistence.loadTasks = vi.fn(() => [{
+            id: 'wf-1/task-1',
+            status: 'failed',
+            config: { workflowId: 'wf-1' },
+            execution: {},
+          } as any]);
+          mockDeps.orchestrator.getTask = vi.fn(() => ({
+            id: 'wf-1/task-1',
+            status: 'failed',
+            config: { workflowId: 'wf-1' },
+            execution: {},
+          } as any));
+          mockDeps.persistence.updateWorkflow = vi.fn();
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['retry', 'wf-1'], depsWithNoTrack);
+          await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
+          await runHeadless(['rebase', 'task-1'], depsWithNoTrack).catch(() => undefined);
+
+          expect(mockDeps.commandService.retryWorkflow).toHaveBeenCalledWith(expect.any(Object));
+          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+            'wf-1',
+            expect.objectContaining({ refreshBase: expect.any(Function) }),
+          );
+        });
       });
 
       // Step 17 (`docs/architecture/task-invalidation-roadmap.md`,

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -193,12 +193,15 @@ describe('retryWorkflow', () => {
   it('calls orchestrator.retryWorkflow and returns result', () => {
     const tasks = [makeRunningTask()];
     const orchestrator = { retryWorkflow: vi.fn(() => tasks) };
+    const persistence = { updateWorkflow: vi.fn() };
 
     const result = retryWorkflow('wf-1', {
       orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
     });
 
     expect(orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(persistence.updateWorkflow).not.toHaveBeenCalled();
     expect(result).toBe(tasks);
   });
 });
@@ -1327,6 +1330,7 @@ describe('buildInvalidationDeps', () => {
     await deps.retryWorkflow('wf-1');
 
     expect(orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(persistence.updateWorkflow).not.toHaveBeenCalled();
   });
 
   it('routes recreateWorkflow through bumpGenerationAndRecreate', async () => {
@@ -1389,6 +1393,38 @@ describe('buildInvalidationDeps', () => {
     expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledTimes(1);
     expect(orchestrator.recreateWorkflowFromFreshBase.mock.calls[0]?.[0]).toBe('wf-1');
     expect(result).toHaveLength(1);
+  });
+
+  it('keeps the three workflow-scope reset tiers distinct', async () => {
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      recreateWorkflowFromFreshBase: vi.fn(async () => [makeRunningTask({ id: 'task-a' })]),
+    };
+    const persistence = makePersistence();
+    persistence.loadWorkflow = vi
+      .fn()
+      .mockReturnValueOnce({ id: 'wf-1', generation: 0 })
+      .mockReturnValueOnce({ id: 'wf-1', generation: 1, repoUrl: 'https://example/repo.git', baseBranch: 'main' });
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
+    await deps.retryWorkflow('wf-1');
+    await deps.recreateWorkflow('wf-1');
+    await deps.recreateWorkflowFromFreshBase!('wf-1');
+
+    expect(orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+      'wf-1',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
+    );
+    expect(persistence.updateWorkflow.mock.calls).toEqual([
+      ['wf-1', { generation: 1 }],
+      ['wf-1', { generation: 2 }],
+    ]);
   });
 
   it('recreateWorkflowFromFreshBase wire still calls orchestrator method when no taskExecutor is supplied', async () => {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1521,7 +1521,7 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
     { module: 'headless' },
   );
 
-  process.stdout.write(`Retry workflow "${workflowId}" — ${dispatchable.length} task(s) to execute (completed tasks preserved)\n`);
+  process.stdout.write(`Retry workflow "${workflowId}" — ${dispatchable.length} task(s) to execute (full workflow reset applied)\n`);
   if (dispatchable.length === 0) return;
 
   if (deps.noTrack) {

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -164,40 +164,53 @@ describe('Orchestrator taskDispatcher', () => {
     expect(new Set(dispatched).size).toBe(2);
   });
 
-  it('dispatches tasks for restart/retry/recreate entrypoints', () => {
+  it('dispatches recreate-style immediate reset scope for retry/recreate workflow entrypoints', () => {
     const dispatched: string[] = [];
     const { orchestrator } = makeOrchestrator((tasks) => tasks.forEach((task) => dispatched.push(task.id)));
     orchestrator.loadPlan({
       name: 'dispatcher-retry-paths',
       onFinish: 'none',
-      tasks: [{ id: 't1', description: 'one', command: 'exit 1' }],
+      tasks: [
+        { id: 'root-ok', description: 'completed root', command: 'echo ok' },
+        { id: 'root-fail', description: 'failed root', command: 'exit 1' },
+        { id: 'join', description: 'downstream join', command: 'echo join', dependencies: ['root-ok', 'root-fail'] },
+      ],
     });
 
-    const taskId = taskIdBySuffix(orchestrator, 't1');
+    const completedRootId = taskIdBySuffix(orchestrator, 'root-ok');
+    const failedRootId = taskIdBySuffix(orchestrator, 'root-fail');
+    const joinId = taskIdBySuffix(orchestrator, 'join');
     const workflowId = orchestrator.getWorkflowIds()[0]!;
 
     orchestrator.startExecution();
-    respondForTask(orchestrator, taskId, 'failed', 1);
+    respondForTask(orchestrator, completedRootId, 'completed', 0);
+    respondForTask(orchestrator, failedRootId, 'failed', 1);
 
     dispatched.length = 0;
-    orchestrator.retryTask(taskId);
-    expect(dispatched).toEqual([taskId]);
+    orchestrator.retryTask(completedRootId);
+    expect(dispatched).toEqual([completedRootId]);
 
-    respondForTask(orchestrator, taskId, 'failed', 1);
+    respondForTask(orchestrator, completedRootId, 'completed', 0);
+    expect(orchestrator.getTask(joinId)?.status).toBe('pending');
     dispatched.length = 0;
     orchestrator.retryWorkflow(workflowId);
-    expect(dispatched).toEqual([taskId]);
+    expect(dispatched).toEqual(expect.arrayContaining([completedRootId, failedRootId]));
+    expect(dispatched).toHaveLength(2);
+    expect(orchestrator.getTask(joinId)?.status).toBe('pending');
 
-    respondForTask(orchestrator, taskId, 'failed', 1);
+    respondForTask(orchestrator, completedRootId, 'completed', 0);
+    respondForTask(orchestrator, failedRootId, 'failed', 1);
     dispatched.length = 0;
-    orchestrator.recreateTask(taskId);
-    expect(dispatched).toEqual([taskId]);
+    orchestrator.recreateTask(completedRootId);
+    expect(dispatched).toEqual([completedRootId]);
 
-    respondForTask(orchestrator, taskId, 'failed', 1);
+    respondForTask(orchestrator, completedRootId, 'completed', 0);
+    respondForTask(orchestrator, failedRootId, 'failed', 1);
     dispatched.length = 0;
     orchestrator.recreateWorkflow(workflowId);
-    expect(dispatched).toEqual([taskId]);
-
+    expect(dispatched).toEqual(expect.arrayContaining([completedRootId, failedRootId]));
+    expect(dispatched).toHaveLength(2);
+    expect(orchestrator.getTask(joinId)?.status).toBe('pending');
   });
 
   it('resumeWorkflow dispatches persisted pending tasks', () => {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5151,7 +5151,7 @@ describe('Orchestrator', () => {
       expect(persistence.loadTasksCalls).not.toContain(wfB);
     });
 
-    it('preserves completed tasks and resets failed tasks', () => {
+    it('resets every task in the workflow immediately, including previously completed roots', () => {
       const p = new InMemoryPersistence();
       const b = new InMemoryBus();
       const wfId = 'wf-retry-1';
@@ -5178,42 +5178,45 @@ describe('Orchestrator', () => {
 
       const started = o.retryWorkflow(wfId);
 
-      // A should stay completed
+      // Workflow-scope retry now matches recreate-style reset scope:
+      // even previously completed roots reset immediately.
       const a = o.getTask('a')!;
-      expect(a.status).toBe('completed');
+      expect(a.status).toBe('running');
       expect(a.execution.branch).toBe('br-a');
+      expect(a.execution.commit).toBe('abc');
 
-      // B should be reset (and auto-started since it has no deps)
+      // B is also retried immediately because it is a ready root.
       const bTask = o.getTask('b')!;
       expect(bTask.status).toBe('running');
       expect(bTask.execution.error).toBeUndefined();
+      expect(bTask.execution.branch).toBe('br-b');
 
-      // Merge should be reset to pending (waiting on B)
+      // Merge resets too, but waits for the fresh root executions.
       const merge = o.getTask(`__merge__${wfId}`)!;
       expect(merge.status).toBe('pending');
 
-      // Only B should be in the started list
+      // Both roots were restarted immediately.
+      expect(started.some(t => t.id === 'a')).toBe(true);
       expect(started.some(t => t.id === 'b')).toBe(true);
-      expect(started.some(t => t.id === 'a')).toBe(false);
     });
 
-    it('differs from recreate: retry preserves completed roots while recreate resets them', () => {
+    it('matches recreate-style immediacy/scope but keeps lineage that recreate wipes', () => {
       const wfId = 'wf-retry-vs-recreate';
       const seed = (p: InMemoryPersistence): void => {
         p.saveTask(wfId, {
           id: 'a', description: 'Task A', status: 'completed',
           dependencies: [], createdAt: new Date(),
-          config: { workflowId: wfId }, execution: { exitCode: 0, branch: 'br-a', commit: 'abc' },
+          config: { workflowId: wfId }, execution: { exitCode: 0, branch: 'br-a', commit: 'abc', workspacePath: '/wt/a' },
         });
         p.saveTask(wfId, {
           id: 'b', description: 'Task B', status: 'failed',
           dependencies: [], createdAt: new Date(),
-          config: { workflowId: wfId }, execution: { exitCode: 1, error: 'boom', branch: 'br-b' },
+          config: { workflowId: wfId }, execution: { exitCode: 1, error: 'boom', branch: 'br-b', commit: 'def', workspacePath: '/wt/b' },
         });
         p.saveTask(wfId, {
           id: `__merge__${wfId}`, description: 'Merge gate', status: 'completed',
           dependencies: ['a', 'b'], createdAt: new Date(),
-          config: { workflowId: wfId, isMergeNode: true }, execution: {},
+          config: { workflowId: wfId, isMergeNode: true }, execution: { branch: 'merge-br', commit: 'merge-1', workspacePath: '/wt/merge' },
         });
       };
 
@@ -5233,18 +5236,40 @@ describe('Orchestrator', () => {
       recreateOrchestrator.recreateWorkflow(wfId);
 
       const retryA = retryOrchestrator.getTask('a')!;
+      const retryB = retryOrchestrator.getTask('b')!;
+      const retryMerge = retryOrchestrator.getTask(`__merge__${wfId}`)!;
       const recreateA = recreateOrchestrator.getTask('a')!;
+      const recreateB = recreateOrchestrator.getTask('b')!;
+      const recreateMerge = recreateOrchestrator.getTask(`__merge__${wfId}`)!;
 
-      expect(retryA.status).toBe('completed');
+      expect(['running', 'pending']).toContain(retryA.status);
       expect(retryA.execution.branch).toBe('br-a');
       expect(retryA.execution.commit).toBe('abc');
+      expect(retryA.execution.workspacePath).toBe('/wt/a');
+      expect(['running', 'pending']).toContain(retryB.status);
+      expect(retryB.execution.branch).toBe('br-b');
+      expect(retryB.execution.commit).toBe('def');
+      expect(retryB.execution.workspacePath).toBe('/wt/b');
+      expect(retryMerge.status).toBe('pending');
+      expect(retryMerge.execution.branch).toBe('merge-br');
+      expect(retryMerge.execution.commit).toBe('merge-1');
+      expect(retryMerge.execution.workspacePath).toBe('/wt/merge');
 
       expect(['running', 'pending']).toContain(recreateA.status);
+      expect(['running', 'pending']).toContain(recreateB.status);
+      expect(recreateMerge.status).toBe('pending');
       expect(recreateA.execution.branch).toBeUndefined();
       expect(recreateA.execution.commit).toBeUndefined();
+      expect(recreateA.execution.workspacePath).toBeUndefined();
+      expect(recreateB.execution.branch).toBeUndefined();
+      expect(recreateB.execution.commit).toBeUndefined();
+      expect(recreateB.execution.workspacePath).toBeUndefined();
+      expect(recreateMerge.execution.branch).toBeUndefined();
+      expect(recreateMerge.execution.commit).toBeUndefined();
+      expect(recreateMerge.execution.workspacePath).toBeUndefined();
     });
 
-    it('resets merge node even when leaf tasks are all completed', () => {
+    it('resets merge node and completed leaves together when the workflow is retried', () => {
       const p = new InMemoryPersistence();
       const b = new InMemoryBus();
       const wfId = 'wf-retry-merge';
@@ -5267,8 +5292,9 @@ describe('Orchestrator', () => {
       o.retryWorkflow(wfId);
 
       const merge = o.getTask(`__merge__${wfId}`)!;
-      // Merge should be running since its only dep (a) is completed
-      expect(merge.status).toBe('running');
+      // Retry resets the completed leaf too, so merge waits on the new run.
+      expect(o.getTask('a')!.status).toBe('running');
+      expect(merge.status).toBe('pending');
     });
 
     it('cancels running tasks before resetting them', () => {
@@ -5322,7 +5348,7 @@ describe('Orchestrator', () => {
       }
     });
 
-    it('handles all-completed workflow (no resets needed)', () => {
+    it('retries an all-completed workflow by resetting it to a fresh execution round', () => {
       const p = new InMemoryPersistence();
       const b = new InMemoryBus();
       const wfId = 'wf-retry-allcomplete';
@@ -5342,10 +5368,9 @@ describe('Orchestrator', () => {
       o.syncFromDb(wfId);
 
       const started = o.retryWorkflow(wfId);
-      // No tasks should be started (all already complete, nothing to retry)
-      // Merge node gets reset to pending (always), but no ready tasks should start it
-      // because leaf task 'a' is completed → merge becomes ready → merge starts
-      expect(started.length).toBeGreaterThanOrEqual(0);
+      expect(o.getTask('a')!.status).toBe('running');
+      expect(o.getTask(`__merge__${wfId}`)!.status).toBe('pending');
+      expect(started.some((task) => task.id === 'a')).toBe(true);
     });
 
     it('resets blocked tasks to pending', () => {
@@ -5374,10 +5399,12 @@ describe('Orchestrator', () => {
 
       const started = o.retryWorkflow(wfId);
 
-      // B was blocked but its dep (A) is completed → should become running
+      // A is retried immediately, so B remains pending until A completes again.
+      expect(o.getTask('a')!.status).toBe('running');
       const bTask = o.getTask('b')!;
-      expect(bTask.status).toBe('running');
-      expect(started.some(t => t.id === 'b')).toBe(true);
+      expect(bTask.status).toBe('pending');
+      expect(started.some(t => t.id === 'a')).toBe(true);
+      expect(started.some(t => t.id === 'b')).toBe(false);
     });
 
     it('cascades correctly: B depends on A(completed), C depends on B(failed)', () => {
@@ -5411,12 +5438,13 @@ describe('Orchestrator', () => {
 
       const started = o.retryWorkflow(wfId);
 
-      // A stays completed
-      expect(o.getTask('a')!.status).toBe('completed');
+      // Workflow-scope retry restarts the root immediately.
+      expect(o.getTask('a')!.status).toBe('running');
+      expect(started.some(t => t.id === 'a')).toBe(true);
 
-      // B should start (dep A is complete)
-      expect(o.getTask('b')!.status).toBe('running');
-      expect(started.some(t => t.id === 'b')).toBe(true);
+      // B waits for the rerun of A.
+      expect(o.getTask('b')!.status).toBe('pending');
+      expect(started.some(t => t.id === 'b')).toBe(false);
 
       // C should be pending (dep B is not yet complete)
       expect(o.getTask('c')!.status).toBe('pending');
@@ -5457,8 +5485,8 @@ describe('Orchestrator', () => {
 
       o.retryWorkflow(wfId);
 
-      expect(o.getTask('a')!.status).toBe('completed');
-      expect(o.getTask('b')!.status).toBe('running');
+      expect(o.getTask('a')!.status).toBe('running');
+      expect(o.getTask('b')!.status).toBe('pending');
       expect(o.getTask('c')!.status).toBe('pending');
       expect(o.getTask(`__merge__${wfId}`)!.status).toBe('pending');
     });
@@ -5550,13 +5578,13 @@ describe('Orchestrator', () => {
 
       const started = o.retryWorkflow(wfId);
 
-      expect(o.getTask('add-eslint-disable-comments')!.status).toBe('completed');
-
+      expect(o.getTask('add-eslint-disable-comments')!.status).toBe('running');
       const verifyLint = o.getTask('verify-lint-passes')!;
-      expect(verifyLint.status).toBe('running');
+      expect(verifyLint.status).toBe('pending');
       expect(verifyLint.execution.pendingFixError).toBeUndefined();
       expect(verifyLint.execution.isFixingWithAI).toBeFalsy();
-      expect(started.some((t) => t.id === 'verify-lint-passes')).toBe(true);
+      expect(started.some((t) => t.id === 'add-eslint-disable-comments')).toBe(true);
+      expect(started.some((t) => t.id === 'verify-lint-passes')).toBe(false);
 
       expect(o.getTask('verify-check-all')!.status).toBe('pending');
       expect(o.getTask(`__merge__${wfId}`)!.status).toBe('pending');
@@ -5600,11 +5628,12 @@ describe('Orchestrator', () => {
 
       const started = o.retryWorkflow(wfId);
 
-      expect(o.getTask('root')!.status).toBe('completed');
-      expect(o.getTask('needs-approval')!.status).toBe('running');
+      expect(o.getTask('root')!.status).toBe('running');
+      expect(o.getTask('needs-approval')!.status).toBe('pending');
       expect(o.getTask('needs-approval')!.execution.pendingFixError).toBeUndefined();
       expect(o.getTask('descendant')!.status).toBe('pending');
-      expect(started.some((t) => t.id === 'needs-approval')).toBe(true);
+      expect(started.some((t) => t.id === 'root')).toBe(true);
+      expect(started.some((t) => t.id === 'needs-approval')).toBe(false);
     });
 
     it('retries persisted auto-fix experiment descendants like normal tasks', () => {
@@ -5758,8 +5787,8 @@ describe('Orchestrator', () => {
       });
     }
 
-    describe('retryWorkflow preserves lineage and bumps per-task execution generation', () => {
-      it('keeps branch/workspacePath on the reset task', () => {
+    describe('retryWorkflow preserves lineage while matching recreate-style workflow reset scope', () => {
+      it('keeps branch/workspacePath on every immediately reset task', () => {
         const p = new InMemoryPersistence();
         const b = new InMemoryBus();
         const wfId = 'wf-step12-retry-lineage';
@@ -5769,7 +5798,12 @@ describe('Orchestrator', () => {
 
         o.retryWorkflow(wfId);
 
+        const aTask = o.getTask('a')!;
         const bTask = o.getTask('b')!;
+        expect(['running', 'pending']).toContain(aTask.status);
+        expect(aTask.execution.branch).toBe('br-a');
+        expect(aTask.execution.workspacePath).toBe('/wt/a');
+        expect(aTask.execution.commit).toBe('aaa');
         expect(bTask.execution.branch).toBe('br-b');
         expect(bTask.execution.workspacePath).toBe('/wt/b');
         expect(bTask.execution.commit).toBe('bbb');
@@ -6235,6 +6269,33 @@ describe('Orchestrator', () => {
       expect(staleGenerationResult).toEqual([]);
       expect(orchestrator.getTask(taskId)?.execution.selectedAttemptId).toBe(activeAttemptId);
       expect(orchestrator.getTask(taskId)?.status).toBe('running');
+    });
+
+    it('clears queued stale scheduler entries when retry refreshes the selected attempt', () => {
+      orchestrator.loadPlan({
+        name: 'retry-stale-queue-clear',
+        tasks: [{ id: 't1', description: 'Task 1' }],
+      });
+      orchestrator.startExecution();
+
+      const taskId = sid(orchestrator, 0, 't1');
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: taskId, status: 'failed', outputs: { exitCode: 1, error: 'boom' } }),
+      );
+
+      const staleAttemptId = orchestrator.getTask(taskId)!.execution.selectedAttemptId!;
+      const scheduler = (orchestrator as any).scheduler;
+      scheduler.enqueue({ taskId, attemptId: staleAttemptId, priority: 0 });
+      expect(scheduler.getQueuedJobs().some((job: { attemptId?: string }) => job.attemptId === staleAttemptId)).toBe(true);
+
+      orchestrator.retryWorkflow(orchestrator.getWorkflowIds()[0]!);
+
+      const activeAttemptId = orchestrator.getTask(taskId)!.execution.selectedAttemptId!;
+      expect(activeAttemptId).not.toBe(staleAttemptId);
+      expect(
+        scheduler.getQueuedJobs().some((job: { attemptId?: string }) => job.attemptId === staleAttemptId),
+      ).toBe(false);
+      expect(orchestrator.getQueueStatus().queued.some((job) => job.attemptId === staleAttemptId)).toBe(false);
     });
 
     it('recreateWorkflow selects a fresh persisted attempt for recreated tasks', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1952,8 +1952,13 @@ export class Orchestrator {
       `[agent-session-trace] retryTask: before writeAndSync task="${id}" agentSessionId=${t0.execution.agentSessionId ?? 'null'} ` +
         '(reset clears agentSessionId/containerId; branch/workspacePath unchanged)',
     );
+    const retryScopeIds = this.collectSubgraphTaskIds([id]);
     const { affectedIds } = this.resetSubgraphToPending([id], resetChanges, {
-      forceResetIds: new Set([id]),
+      // Retry now matches recreateTask reset timing/scope: every task in
+      // the invalidated subgraph gets a fresh pending-state reset
+      // immediately, while retry-specific lineage fields remain intact via
+      // the narrower reset payload above.
+      forceResetIds: new Set(retryScopeIds),
     });
     const afterRt = this.stateGetTask(id)!;
     console.log(

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2048,8 +2048,10 @@ export class Orchestrator {
         lastHeartbeatAt: undefined,
         agentSessionId: undefined,
         containerId: undefined,
-        // Preserve branch/commit/workspacePath/review lineage; retry is now
+        commit: undefined,
+        // Preserve branch/workspacePath/review lineage; retry is now
         // recreate-style in scope/timing, not lineage wiping.
+        // commit is cleared so re-execution records a fresh commit hash.
       },
     };
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2008,9 +2008,9 @@ export class Orchestrator {
   }
 
   /**
-   * Incremental retry: reset only failed/stuck tasks to pending, preserve completed.
-   * Merge nodes are always reset (they depend on all leaf tasks).
-   * After reset, startExecution() finds newly-ready tasks via getReadyNodes().
+   * Workflow-scoped retry now resets the entire workflow immediately like
+   * recreateWorkflow, but preserves retry lineage metadata such as
+   * branch/commit/workspacePath for every task.
    */
   retryWorkflow(workflowId: string): TaskState[] {
     const retryStartMs = Date.now();
@@ -2034,16 +2034,6 @@ export class Orchestrator {
       (t) => t.config.workflowId === workflowId,
     );
 
-    const retryStatuses = new Set([
-      'failed',
-      'needs_input',
-      'blocked',
-      'stale',
-      'fixing_with_ai',
-      'awaiting_approval',
-      'review_ready',
-    ]);
-
     const resetChanges: TaskStateChanges = {
       status: 'pending',
       config: { summary: undefined },
@@ -2055,24 +2045,27 @@ export class Orchestrator {
         exitCode: undefined,
         pendingFixError: undefined,
         isFixingWithAI: false,
-        // Preserve branch/commit/workspacePath — they contain valid work context
-        // Only clear error-related and timing fields
+        lastHeartbeatAt: undefined,
+        agentSessionId: undefined,
+        containerId: undefined,
+        // Preserve branch/commit/workspacePath/review lineage; retry is now
+        // recreate-style in scope/timing, not lineage wiping.
       },
     };
 
-    const retryRootIds = allTasks
-      .filter((task) => retryStatuses.has(task.status))
-      .map((task) => task.id);
-    const { affectedIds } = this.resetSubgraphToPending(retryRootIds, resetChanges);
+    const workflowTaskIds = allTasks.map((task) => task.id);
+    const { affectedIds } = this.resetSubgraphToPending(workflowTaskIds, resetChanges, {
+      forceResetIds: new Set(workflowTaskIds),
+    });
     const afterResetMs = Date.now();
 
     console.log(
       `[orchestrator] retryWorkflow invalidation: workflow=${workflowId} ` +
-      `roots=[${retryRootIds.join(', ')}] affected=${affectedIds.length}`,
+      `resetMode=full-workflow-immediate affected=${affectedIds.length}`,
     );
     console.log(
       `[orchestrator] retryWorkflow: reset ${affectedIds.length}/${allTasks.length} tasks for ${workflowId} ` +
-        `(roots=${retryRootIds.length}, preserved completed outside invalidated subgraphs)`,
+        '(entire workflow reset immediately; retry lineage preserved)',
     );
 
     const readyIds = this.stateMachine

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2048,10 +2048,8 @@ export class Orchestrator {
         lastHeartbeatAt: undefined,
         agentSessionId: undefined,
         containerId: undefined,
-        commit: undefined,
-        // Preserve branch/workspacePath/review lineage; retry is now
+        // Preserve branch/commit/workspacePath/review lineage; retry is now
         // recreate-style in scope/timing, not lineage wiping.
-        // commit is cleared so re-execution records a fresh commit hash.
       },
     };
 

--- a/packages/workflow-graph/src/dag.ts
+++ b/packages/workflow-graph/src/dag.ts
@@ -45,9 +45,10 @@ export function topologicalSort(tasks: TaskState[]): TaskState[] {
   }
 
   const sorted: TaskState[] = [];
+  let queueHead = 0;
 
-  while (queue.length > 0) {
-    const id = queue.shift()!;
+  while (queueHead < queue.length) {
+    const id = queue[queueHead++];
     sorted.push(taskMap.get(id)!);
 
     for (const neighbor of adjacency.get(id)!) {


### PR DESCRIPTION
## Summary
Change Invoker retry semantics so retry behaves like recreate in reset scope and timing, while still remaining a retry-class action.
Today workflow retry is explicitly incremental: it preserves completed tasks outside invalidated failed-root subgraphs, which is why bulk retry does not make an entire workflow immediately pending again. The desired behavior is that retry instantly resets the relevant scope to `pending`, just like recreate, so operators can rely on immediate visible reset semantics from the UI, headless retry, and bulk retry scripts.

Preserve retry lineage where it matters: keep branch and workspace metadata instead of doing recreate's full lineage wipe, and do not upgrade retry into fresh-base rebase semantics. The implementation must also ensure queued or in-flight retry-scope mutations cannot keep stale work alive after the retry reset lands.

This repository is Invoker itself, so keep `onFinish: pull_request` with `mergeMode: external_review`; after implementation commits are ready, publish/update the resulting stack with `mergify stack push`.


---
Retry reset semantics should match recreate immediacy — 6 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1777324024407-4/add-retry-regression-coverage | Add deterministic regression coverage for recreate-style retry reset semantics across workflow-core and app surfaces. | completed |
| wf-1777324024407-4/implement-task-retry-reset | Change task-scope retry to reset immediately like recreate while preserving retry lineage metadata. | completed |
| wf-1777324024407-4/implement-workflow-retry-reset | Change workflow-scope retry to reset the entire workflow immediately like recreate while preserving retry lineage metadata. | completed |
| wf-1777324024407-4/run-workflow-core-tests | Run the workflow-core package test suite after changing retry reset semantics. | completed (passed) |
| wf-1777324024407-4/run-app-retry-tests | Run targeted app retry and headless tests that verify retry command-surface and dispatch behavior. | completed (passed) |
| wf-1777324024407-4/rerun-postfix-retry-surface | Re-run retry-focused workflow-core tests as final post-fix verification of recreate-style reset behavior. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1777324024407-4/add-retry-regression-coverage — Add deterministic regression coverage for recreate-style retry reset semantics across workflow-core and app surfaces.
.../__tests__/bridge-orchestrator-executor.test.ts |  37 +++++-
 .../app/src/__tests__/headless-delegation.test.ts  |  55 ++++++++
 .../app/src/__tests__/workflow-actions.test.ts     |  36 ++++++
 .../src/__tests__/orchestrator-dispatcher.test.ts  |  41 +++---
 .../src/__tests__/orchestrator.test.ts             | 139 +++++++++++++++------
 5 files changed, 252 insertions(+), 56 deletions(-)

### wf-1777324024407-4/implement-task-retry-reset — Change task-scope retry to reset immediately like recreate while preserving retry lineage metadata.
.../__tests__/bridge-orchestrator-executor.test.ts |  37 +++++-
 .../app/src/__tests__/headless-delegation.test.ts  |  55 ++++++++
 .../app/src/__tests__/workflow-actions.test.ts     |  36 ++++++
 .../src/__tests__/orchestrator-dispatcher.test.ts  |  41 +++---
 .../src/__tests__/orchestrator.test.ts             | 139 +++++++++++++++------
 packages/workflow-core/src/orchestrator.ts         |   7 +-
 6 files changed, 258 insertions(+), 57 deletions(-)

### wf-1777324024407-4/implement-workflow-retry-reset — Change workflow-scope retry to reset the entire workflow immediately like recreate while preserving retry lineage metadata.
.../__tests__/bridge-orchestrator-executor.test.ts |  37 +++++-
 .../app/src/__tests__/headless-delegation.test.ts  |  55 ++++++++
 .../app/src/__tests__/workflow-actions.test.ts     |  36 ++++++
 packages/app/src/headless.ts                       |   2 +-
 .../src/__tests__/orchestrator-dispatcher.test.ts  |  41 +++---
 .../src/__tests__/orchestrator.test.ts             | 139 +++++++++++++++------
 packages/workflow-core/src/orchestrator.ts         |  42 +++----
 7 files changed, 273 insertions(+), 79 deletions(-)

### wf-1777324024407-4/run-workflow-core-tests — Run the workflow-core package test suite after changing retry reset semantics.

### wf-1777324024407-4/run-app-retry-tests — Run targeted app retry and headless tests that verify retry command-surface and dispatch behavior.

### wf-1777324024407-4/rerun-postfix-retry-surface — Re-run retry-focused workflow-core tests as final post-fix verification of recreate-style reset behavior.

</details>
