### PR TITLE
UI Stable Selector Step 1: Status bar ids

### DIFF
--- a/packages/ui/src/__tests__/status-bar-click.test.tsx
+++ b/packages/ui/src/__tests__/status-bar-click.test.tsx
@@ -35,7 +35,7 @@ describe('StatusBar click behavior', () => {
         />,
       );
 
-      const completedLabel = screen.getByText(/Completed:/);
+      const completedLabel = screen.getByTestId('status-bar-pill-completed');
       fireEvent.click(completedLabel);
 
       // Should fire immediately (no delay)
@@ -58,7 +58,7 @@ describe('StatusBar click behavior', () => {
         />,
       );
 
-      const runningLabel = screen.getByText(/Running:/);
+      const runningLabel = screen.getByTestId('status-bar-pill-running');
       fireEvent.click(runningLabel, { ctrlKey: true });
 
       expect(mockOnStatusClick).toHaveBeenCalledTimes(1);
@@ -79,7 +79,7 @@ describe('StatusBar click behavior', () => {
         />,
       );
 
-      const failedLabel = screen.getByText(/Failed:/);
+      const failedLabel = screen.getByTestId('status-bar-pill-failed');
       fireEvent.click(failedLabel, { metaKey: true });
 
       expect(mockOnStatusClick).toHaveBeenCalledTimes(1);
@@ -103,16 +103,16 @@ describe('StatusBar click behavior', () => {
         />,
       );
 
-      fireEvent.click(screen.getByText(/Completed:/));
+      fireEvent.click(screen.getByTestId('status-bar-pill-completed'));
       expect(mockOnStatusClick).toHaveBeenCalledWith('completed', expect.any(Object));
 
-      fireEvent.click(screen.getByText(/Running:/));
+      fireEvent.click(screen.getByTestId('status-bar-pill-running'));
       expect(mockOnStatusClick).toHaveBeenCalledWith('running', expect.any(Object));
 
-      fireEvent.click(screen.getByText(/Failed:/));
+      fireEvent.click(screen.getByTestId('status-bar-pill-failed'));
       expect(mockOnStatusClick).toHaveBeenCalledWith('failed', expect.any(Object));
 
-      fireEvent.click(screen.getByText(/Pending:/));
+      fireEvent.click(screen.getByTestId('status-bar-pill-pending'));
       expect(mockOnStatusClick).toHaveBeenCalledWith('pending', expect.any(Object));
 
       expect(mockOnStatusClick).toHaveBeenCalledTimes(4);
@@ -132,7 +132,7 @@ describe('StatusBar click behavior', () => {
         />,
       );
 
-      const inputLabel = screen.getByText(/Input:/);
+      const inputLabel = screen.getByTestId('status-bar-pill-needs_input');
       fireEvent.click(inputLabel);
 
       expect(mockOnStatusClick).toHaveBeenCalledWith('needs_input', expect.any(Object));
@@ -150,7 +150,7 @@ describe('StatusBar click behavior', () => {
         />,
       );
 
-      const approvalLabel = screen.getByText(/Approval:/);
+      const approvalLabel = screen.getByTestId('status-bar-pill-awaiting_approval');
       fireEvent.click(approvalLabel);
 
       expect(mockOnStatusClick).toHaveBeenCalledWith('awaiting_approval', expect.any(Object));
@@ -168,7 +168,7 @@ describe('StatusBar click behavior', () => {
         />,
       );
 
-      const blockedLabel = screen.getByText(/Blocked:/);
+      const blockedLabel = screen.getByTestId('status-bar-pill-blocked');
       fireEvent.click(blockedLabel);
 
       expect(mockOnStatusClick).toHaveBeenCalledWith('blocked', expect.any(Object));
@@ -183,7 +183,7 @@ describe('StatusBar click behavior', () => {
 
       render(<StatusBar tasks={tasks} />);
 
-      const completedLabel = screen.getByText(/Completed:/);
+      const completedLabel = screen.getByTestId('status-bar-pill-completed');
       fireEvent.click(completedLabel);
 
       // Should not crash
@@ -202,7 +202,7 @@ describe('StatusBar click behavior', () => {
         />,
       );
 
-      const completedLabel = screen.getByText(/Completed:/);
+      const completedLabel = screen.getByTestId('status-bar-pill-completed');
 
       // Click multiple times rapidly
       fireEvent.click(completedLabel);
@@ -225,7 +225,7 @@ describe('StatusBar click behavior', () => {
         />,
       );
 
-      const completedLabel = screen.getByText(/Completed:/);
+      const completedLabel = screen.getByTestId('status-bar-pill-completed');
 
       // Double-click should just fire two separate single clicks
       fireEvent.doubleClick(completedLabel);
@@ -246,7 +246,7 @@ describe('StatusBar click behavior', () => {
 
       const activeFilters = new Set(['completed']);
 
-      const { container } = render(
+      render(
         <StatusBar
           tasks={tasks}
           activeFilters={activeFilters}
@@ -254,17 +254,15 @@ describe('StatusBar click behavior', () => {
         />,
       );
 
-      // Query the clickable spans directly by their stable color classes
-      // (getByText can return the container div instead of the span)
-      const completedSpan = container.querySelector('.text-green-300\\/70');
-      const runningSpan = container.querySelector('.text-blue-300\\/70');
+      const completedSpan = screen.getByTestId('status-bar-pill-completed');
+      const runningSpan = screen.getByTestId('status-bar-pill-running');
 
       // Active filter should have ring styling
-      expect(completedSpan?.className).toContain('ring-1');
-      expect(completedSpan?.className).toContain('ring-current');
+      expect(completedSpan.className).toContain('ring-1');
+      expect(completedSpan.className).toContain('ring-current');
 
       // Inactive filter should be dimmed
-      expect(runningSpan?.className).toContain('opacity-60');
+      expect(runningSpan.className).toContain('opacity-60');
     });
   });
 });

--- a/packages/ui/src/components/StatusBar.tsx
+++ b/packages/ui/src/components/StatusBar.tsx
@@ -84,24 +84,28 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
         Total: <span className="text-gray-100 font-medium">{total}</span>
       </span>
       <span
+        data-testid="status-bar-pill-completed"
         className={`text-green-300/70 ${filterClass('completed')}`}
         onClick={(e) => onStatusClick?.('completed', e)}
       >
         Completed: <span className="font-medium">{completed}</span>
       </span>
       <span
+        data-testid="status-bar-pill-running"
         className={`text-blue-300/70 ${filterClass('running')}`}
         onClick={(e) => onStatusClick?.('running', e)}
       >
         Running: <span className="font-medium">{running}</span>
       </span>
       <span
+        data-testid="status-bar-pill-failed"
         className={`text-red-300/70 ${filterClass('failed')}`}
         onClick={(e) => onStatusClick?.('failed', e)}
       >
         Failed: <span className="font-medium">{failed}</span>
       </span>
       <span
+        data-testid="status-bar-pill-pending"
         className={`text-gray-300/70 ${filterClass('pending')}`}
         onClick={(e) => onStatusClick?.('pending', e)}
       >
@@ -109,6 +113,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       </span>
       {needsInput > 0 && (
         <span
+          data-testid="status-bar-pill-needs_input"
           className={`text-cyan-300/70 ${filterClass('needs_input')}`}
           onClick={(e) => onStatusClick?.('needs_input', e)}
         >
@@ -117,6 +122,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       )}
       {reviewReady > 0 && (
         <span
+          data-testid="status-bar-pill-review_ready"
           className={`text-sky-300/70 ${filterClass('review_ready')}`}
           onClick={(e) => onStatusClick?.('review_ready', e)}
         >
@@ -125,6 +131,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       )}
       {awaitingApproval > 0 && (
         <span
+          data-testid="status-bar-pill-awaiting_approval"
           className={`text-purple-300/70 ${filterClass('awaiting_approval')}`}
           onClick={(e) => onStatusClick?.('awaiting_approval', e)}
         >
@@ -133,6 +140,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       )}
       {blocked > 0 && (
         <span
+          data-testid="status-bar-pill-blocked"
           className={`text-gray-400/70 ${filterClass('blocked')}`}
           onClick={(e) => onStatusClick?.('blocked', e)}
         >
@@ -141,6 +149,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       )}
       {fixing > 0 && (
         <span
+          data-testid="status-bar-pill-fixing_with_ai"
           className={`text-orange-300/70 ${filterClass('fixing_with_ai')}`}
           onClick={(e) => onStatusClick?.('fixing_with_ai', e)}
         >
@@ -149,6 +158,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       )}
       {fixApproval > 0 && (
         <span
+          data-testid="status-bar-pill-fix_approval"
           className={`text-fuchsia-300/70 ${filterClass('fix_approval')}`}
           onClick={(e) => onStatusClick?.('fix_approval', e)}
         >


### PR DESCRIPTION
## Summary
Replace regex-based status-bar selectors with stable UI ids for the status
pills that drive filtering. This keeps the visible copy unchanged while
making both unit tests and downstream E2E selectors independent of dynamic
counts.


---
UI Stable Selector Step 1: Status bar ids — 2 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1777499398203-7/add-statusbar-stable-ids | Add deterministic StatusBar pill ids and migrate the status-bar click tests. | completed |
| wf-1777499398203-7/verify-statusbar-selectors | Run the focused StatusBar unit test lane after the selector migration. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1777499398203-7/add-statusbar-stable-ids — Add deterministic StatusBar pill ids and migrate the status-bar click tests.
.../ui/src/__tests__/status-bar-click.test.tsx     | 40 ++++++++++------------
 packages/ui/src/components/StatusBar.tsx           | 10 ++++++
 2 files changed, 29 insertions(+), 21 deletions(-)

### wf-1777499398203-7/verify-statusbar-selectors — Run the focused StatusBar unit test lane after the selector migration.

</details>
