### PR TITLE
UI Stable Selector Step 2: Queue relationship ids

### DIFF
--- a/packages/ui/src/__tests__/queue-view.test.tsx
+++ b/packages/ui/src/__tests__/queue-view.test.tsx
@@ -312,9 +312,11 @@ describe('QueueView', () => {
 
       await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
 
-      // The rels toggle buttons should be present (tasks have relationships)
-      const relButtons = screen.getAllByText(/rels/);
-      expect(relButtons.length).toBeGreaterThan(0);
+      // The rels toggle buttons should be present (tasks have relationships).
+      // task-a is in Action Queue; task-b and task-c are in Backlog.
+      expect(screen.getByTestId('queue-rels-toggle-action-wf-1/task-a')).toBeInTheDocument();
+      expect(screen.getByTestId('queue-rels-toggle-backlog-wf-1/task-b')).toBeInTheDocument();
+      expect(screen.getByTestId('queue-rels-toggle-backlog-wf-1/task-c')).toBeInTheDocument();
 
       // But no upstream/downstream labels should be visible (collapsed)
       expect(screen.queryByText('upstream:')).not.toBeInTheDocument();
@@ -441,7 +443,8 @@ describe('QueueView', () => {
       );
 
       await waitFor(() => expect(getQueueStatus).toHaveBeenCalled());
-      expect(screen.queryByText(/rels/)).not.toBeInTheDocument();
+      expect(screen.queryByTestId('queue-rels-toggle-action-wf-1/lone-task')).not.toBeInTheDocument();
+      expect(screen.queryByTestId('queue-rels-toggle-backlog-wf-1/lone-task')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/ui/src/components/QueueView.tsx
+++ b/packages/ui/src/components/QueueView.tsx
@@ -214,6 +214,7 @@ export function QueueView({ tasks, onTaskClick, onCancel, selectedTaskId }: Queu
                         className="text-xs text-gray-400 hover:text-gray-200 shrink-0"
                         aria-label={isExpanded ? 'Collapse relationships' : 'Expand relationships'}
                         aria-expanded={isExpanded}
+                        data-testid={`queue-rels-toggle-action-${job.taskId}`}
                       >
                         {isExpanded ? '▾' : '▸'} rels
                       </button>
@@ -314,6 +315,7 @@ export function QueueView({ tasks, onTaskClick, onCancel, selectedTaskId }: Queu
                         className="text-xs text-gray-400 hover:text-gray-200 shrink-0"
                         aria-label={isExpanded ? 'Collapse relationships' : 'Expand relationships'}
                         aria-expanded={isExpanded}
+                        data-testid={`queue-rels-toggle-backlog-${task.id}`}
                       >
                         {isExpanded ? '▾' : '▸'} rels
                       </button>


### PR DESCRIPTION
## Summary
Replace regex-based QueueView relationship-toggle selectors with stable ids so
tests do not depend on abbreviated `rels` text or chevron formatting. This
keeps the queue UI copy unchanged while tightening the selector contract.


---
UI Stable Selector Step 2: Queue relationship ids — 2 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1777499446891-8/add-queue-relationship-stable-ids | Add deterministic QueueView relationship-toggle ids and migrate queue-view tests. | completed |
| wf-1777499446891-8/verify-queue-relationship-selectors | Run the focused QueueView unit test lane after the selector migration. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1777499446891-8/add-queue-relationship-stable-ids — Add deterministic QueueView relationship-toggle ids and migrate queue-view tests.
packages/ui/src/__tests__/queue-view.test.tsx      | 11 +++---
 .../ui/src/__tests__/status-bar-click.test.tsx     | 40 ++++++++++------------
 packages/ui/src/components/QueueView.tsx           |  2 ++
 packages/ui/src/components/StatusBar.tsx           | 10 ++++++
 4 files changed, 38 insertions(+), 25 deletions(-)

### wf-1777499446891-8/verify-queue-relationship-selectors — Run the focused QueueView unit test lane after the selector migration.

</details>
