### PR TITLE
UI Stable Selector Step 3: Task panel gate summary ids

### DIFF
--- a/packages/ui/src/__tests__/task-panel-double-click.test.tsx
+++ b/packages/ui/src/__tests__/task-panel-double-click.test.tsx
@@ -1161,9 +1161,11 @@ describe('TaskPanel double-click editing', () => {
       );
 
       expect(screen.getByText('Gate Policy')).toBeInTheDocument();
-      expect(screen.getByText(/All 1 gate satisfied/)).toBeInTheDocument();
-      expect(screen.queryByTestId(/gate-policy-offender/)).not.toBeInTheDocument();
-      expect(screen.getByText(/1 satisfied gate/)).toBeInTheDocument();
+      const summary = screen.getByTestId('gate-policy-summary');
+      expect(summary).toHaveTextContent('All 1 gate satisfied');
+      expect(screen.queryByTestId(/^gate-policy-offender-\d+$/)).not.toBeInTheDocument();
+      const satisfiedToggle = screen.getByTestId('gate-policy-satisfied-toggle');
+      expect(satisfiedToggle).toHaveTextContent('1 satisfied gate');
     });
 
     it('shows amber summary and one offender card when one gate is blocking', () => {
@@ -1190,8 +1192,9 @@ describe('TaskPanel double-click editing', () => {
         />,
       );
 
-      expect(screen.getByText(/1 gate blocking/)).toBeInTheDocument();
-      const offenderRow = screen.getByTestId(/gate-policy-offender/);
+      const summary = screen.getByTestId('gate-policy-summary');
+      expect(summary).toHaveTextContent('1 gate blocking');
+      const offenderRow = screen.getByTestId('gate-policy-offender-0');
       expect(offenderRow).toBeInTheDocument();
       const workflowName = offenderRow.querySelector('.text-red-300');
       expect(workflowName).toBeInTheDocument();
@@ -1234,7 +1237,9 @@ describe('TaskPanel double-click editing', () => {
       expect(screen.queryByText('__merge__wf-3')).not.toBeInTheDocument();
 
       // Click disclosure to expand
-      fireEvent.click(screen.getByText(/2 satisfied gates/));
+      const satisfiedToggle = screen.getByTestId('gate-policy-satisfied-toggle');
+      expect(satisfiedToggle).toHaveTextContent('2 satisfied gates');
+      fireEvent.click(satisfiedToggle);
 
       // Now satisfied rows should be visible
       expect(screen.getByText('__merge__wf-2')).toBeInTheDocument();
@@ -1305,9 +1310,11 @@ describe('TaskPanel double-click editing', () => {
         />,
       );
 
-      const offenderRows = screen.getAllByTestId(/gate-policy-offender/);
+      const offenderRows = screen.getAllByTestId(/^gate-policy-offender-\d+$/);
       expect(offenderRows.length).toBeGreaterThan(0);
-      expect(screen.getAllByText(/Mixed thresholds/).length).toBeGreaterThan(0);
+      const mixedThresholdEls = screen.getAllByTestId(/^gate-policy-offender-\d+-mixed-threshold$/);
+      expect(mixedThresholdEls.length).toBeGreaterThan(0);
+      expect(mixedThresholdEls[0]).toHaveTextContent('Mixed thresholds');
       const workflowName = offenderRows[0].querySelector('.text-red-300');
       expect(workflowName).toBeInTheDocument();
     });
@@ -1346,7 +1353,8 @@ describe('TaskPanel double-click editing', () => {
 
       // Check for impact text
       await waitFor(() => {
-        expect(screen.getByText(/would unblock now/)).toBeInTheDocument();
+        const impact = screen.getByTestId('gate-policy-offender-0-impact');
+        expect(impact).toHaveTextContent('would unblock now');
       });
     });
   });

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -657,7 +657,10 @@ export function TaskPanel({
             </div>
 
             {/* Summary line */}
-            <div className={`text-xs font-medium ${offenderCount > 0 ? 'text-amber-300' : 'text-emerald-300'}`}>
+            <div
+              className={`text-xs font-medium ${offenderCount > 0 ? 'text-amber-300' : 'text-emerald-300'}`}
+              data-testid="gate-policy-summary"
+            >
               {offenderCount > 0 ? (
                 <>⚠ {offenderCount} gate{offenderCount === 1 ? '' : 's'} {offenderCount === 1 ? 'blocking' : 'need attention'}</>
               ) : (
@@ -733,7 +736,7 @@ export function TaskPanel({
                       </div>
 
                       {hasMixedPolicy ? (
-                        <div className="text-xs text-gray-400 ml-4">
+                        <div className="text-xs text-gray-400 ml-4" data-testid={`gate-policy-offender-${index}-mixed-threshold`}>
                           <div>Mixed thresholds across {group.length} dep{group.length === 1 ? '' : 's'}</div>
                           {!isEditingGatePolicies && <div className="mt-0.5">Unblock at <span className="text-amber-400">⚠ mixed</span></div>}
                         </div>
@@ -766,7 +769,11 @@ export function TaskPanel({
                                 <span className="text-gray-300">{formatStatusLabel(draftPolicy as TaskStatus)}</span>
                               </>
                             )}
-                            {impactText && <span className="text-gray-400 ml-1">{impactText}</span>}
+                            {impactText && (
+                              <span className="text-gray-400 ml-1" data-testid={`gate-policy-offender-${index}-impact`}>
+                                {impactText}
+                              </span>
+                            )}
                           </div>
                         </div>
                       )}
@@ -782,6 +789,7 @@ export function TaskPanel({
                 <button
                   onClick={() => setIsSatisfiedListExpanded(!isSatisfiedListExpanded)}
                   className="text-xs text-gray-400 hover:text-gray-300 w-full text-left"
+                  data-testid="gate-policy-satisfied-toggle"
                 >
                   {effectiveExpanded ? '▾' : '▸'} {satisfied.length} satisfied gate{satisfied.length === 1 ? '' : 's'}
                 </button>


### PR DESCRIPTION
## Summary
Replace regex-based TaskPanel gate-summary selectors with stable ids for
summary, disclosure, mixed-threshold, and impact text surfaces. This removes
test coupling to dynamic counts and pluralized copy.


---
UI Stable Selector Step 3: Task panel gate summary ids — 2 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1777499517214-9/add-taskpanel-gate-summary-ids | Add deterministic TaskPanel gate-summary ids and migrate gate-summary tests. | completed |
| wf-1777499517214-9/verify-taskpanel-gate-summary-selectors | Run the focused TaskPanel gate-summary unit test lane after the selector migration. | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1777499517214-9/add-taskpanel-gate-summary-ids — Add deterministic TaskPanel gate-summary ids and migrate gate-summary tests.
packages/ui/src/__tests__/queue-view.test.tsx      | 11 +++---
 .../ui/src/__tests__/status-bar-click.test.tsx     | 40 ++++++++++------------
 .../src/__tests__/task-panel-double-click.test.tsx | 26 +++++++++-----
 packages/ui/src/components/QueueView.tsx           |  2 ++
 packages/ui/src/components/StatusBar.tsx           | 10 ++++++
 packages/ui/src/components/TaskPanel.tsx           | 14 ++++++--
 6 files changed, 66 insertions(+), 37 deletions(-)

### wf-1777499517214-9/verify-taskpanel-gate-summary-selectors — Run the focused TaskPanel gate-summary unit test lane after the selector migration.

</details>
