### PR TITLE
Add Electron UI perf CI lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,6 +280,64 @@ jobs:
             packages/app/test-results
           if-no-files-found: ignore
 
+  electron-ui-perf:
+    needs: build-artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: electron-ui-perf
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: app-build-dist
+          path: /tmp/invoker-build-artifacts
+
+      - name: Extract build artifacts
+        run: tar -xzf /tmp/invoker-build-artifacts/app-build-dist.tgz -C .
+
+      - name: Configure git identity for E2E repos
+        run: |
+          git config --global user.name "CI Bot"
+          git config --global user.email "ci@invoker.dev"
+
+      - name: Install Playwright system dependencies
+        run: pnpm --filter @invoker/app exec playwright install --with-deps
+
+      - name: Run Electron UI perf harness
+        env:
+          INVOKER_PLAYWRIGHT_RUN_LABEL: ci-electron-ui-perf
+          INVOKER_PLAYWRIGHT_WORKERS: '1'
+          INVOKER_PLAYWRIGHT_ARGS: --reporter=line
+        run: bash scripts/test-suites/optional/41-electron-ui-perf.sh
+
+      - name: Upload Electron UI perf artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: electron-ui-perf-artifacts
+          path: |
+            .git/playwright-artifacts
+            packages/app/test-results
+          if-no-files-found: ignore
+
   ssh:
     needs: build-artifacts
     runs-on: ubuntu-latest

--- a/packages/app/e2e/electron-ui-perf-harness.spec.ts
+++ b/packages/app/e2e/electron-ui-perf-harness.spec.ts
@@ -1,0 +1,24 @@
+import { expect, test } from './fixtures/electron-app.js';
+import { createElectronUiPerfHarness } from './fixtures/ui-perf.js';
+
+test('electron UI perf harness can seed a graph, reset stats, and measure drag frames', async ({ page }) => {
+  const perf = createElectronUiPerfHarness(page);
+
+  await perf.seedLinearGraph({ workflowCount: 6, tasksPerWorkflow: 5 });
+  await perf.waitForGraphReady();
+
+  const reset = await perf.resetPerfStats();
+  expect(reset.rendererReports).toBe(0);
+
+  const before = await perf.graphViewport().evaluate((el) => getComputedStyle(el).transform);
+  const drag = await perf.measureViewportDrag({ steps: 60, stepDelayMs: 8 });
+  const after = await perf.graphViewport().evaluate((el) => getComputedStyle(el).transform);
+
+  expect(after).not.toBe(before);
+  expect(drag.frames).toBeGreaterThan(20);
+  expect(drag.avgMs).toBeGreaterThan(0);
+  expect(drag.maxMs).toBeGreaterThanOrEqual(drag.p95Ms);
+
+  const stats = await perf.getPerfStats();
+  expect(stats.ts).toBeTruthy();
+});

--- a/packages/app/e2e/fixtures/ui-perf.ts
+++ b/packages/app/e2e/fixtures/ui-perf.ts
@@ -1,0 +1,189 @@
+import type { Page, Locator } from '@playwright/test';
+import { stringify as yamlStringify } from 'yaml';
+
+import type { UiPerfStats } from '@invoker/contracts';
+
+import { E2E_REPO_URL } from './electron-app.js';
+
+export interface ElectronGraphSeedOptions {
+  workflowCount?: number;
+  tasksPerWorkflow?: number;
+}
+
+export interface DragFrameStats {
+  frames: number;
+  avgMs: number;
+  p50Ms: number;
+  p95Ms: number;
+  maxMs: number;
+  over16Ms: number;
+  over33Ms: number;
+  over50Ms: number;
+}
+
+export interface ElectronUiPerfHarness {
+  dagRoot(): Locator;
+  graphPane(): Locator;
+  graphViewport(): Locator;
+  seedLinearGraph(options?: ElectronGraphSeedOptions): Promise<void>;
+  waitForGraphReady(): Promise<void>;
+  resetPerfStats(): Promise<UiPerfStats>;
+  getPerfStats(): Promise<UiPerfStats>;
+  setGraphStyleOverride(css: string): Promise<void>;
+  clearGraphStyleOverride(): Promise<void>;
+  measureViewportDrag(options?: {
+    steps?: number;
+    stepDelayMs?: number;
+    startXPct?: number;
+    endXPct?: number;
+    yPct?: number;
+  }): Promise<DragFrameStats>;
+}
+
+function buildLinearPlan(workflowIndex: number, tasksPerWorkflow: number) {
+  return {
+    name: `UI Perf Plan ${workflowIndex}`,
+    repoUrl: E2E_REPO_URL,
+    onFinish: 'none' as const,
+    tasks: Array.from({ length: tasksPerWorkflow }, (_, taskIndex) => ({
+      id: `task-${workflowIndex}-${taskIndex}`,
+      description: `Task ${workflowIndex}-${taskIndex}`,
+      command: `echo task-${workflowIndex}-${taskIndex}`,
+      dependencies: taskIndex === 0 ? [] : [`task-${workflowIndex}-${taskIndex - 1}`],
+    })),
+  };
+}
+
+function summarizeFrameTimes(samples: number[]): DragFrameStats {
+  const sorted = [...samples].sort((a, b) => a - b);
+  const avg = samples.reduce((sum, value) => sum + value, 0) / samples.length;
+  const pick = (p: number) => sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))];
+  return {
+    frames: samples.length,
+    avgMs: Number(avg.toFixed(2)),
+    p50Ms: Number(pick(0.5).toFixed(2)),
+    p95Ms: Number(pick(0.95).toFixed(2)),
+    maxMs: Number(sorted[sorted.length - 1].toFixed(2)),
+    over16Ms: samples.filter((value) => value > 16.7).length,
+    over33Ms: samples.filter((value) => value > 33.3).length,
+    over50Ms: samples.filter((value) => value > 50).length,
+  };
+}
+
+export function createElectronUiPerfHarness(page: Page): ElectronUiPerfHarness {
+  const dagRoot = () => page.getByTestId('task-dag-root');
+  const graphPane = () => page.locator('.react-flow__pane').first();
+  const graphViewport = () => page.locator('.react-flow__viewport').first();
+
+  return {
+    dagRoot,
+    graphPane,
+    graphViewport,
+
+    async seedLinearGraph(options = {}): Promise<void> {
+      const workflowCount = options.workflowCount ?? 20;
+      const tasksPerWorkflow = options.tasksPerWorkflow ?? 7;
+      for (let workflowIndex = 0; workflowIndex < workflowCount; workflowIndex += 1) {
+        await page.evaluate(async (planText) => {
+          await window.invoker.loadPlan(planText);
+        }, yamlStringify(buildLinearPlan(workflowIndex, tasksPerWorkflow)));
+      }
+    },
+
+    async waitForGraphReady(): Promise<void> {
+      await dagRoot().waitFor({ state: 'visible', timeout: 10000 });
+      await page.locator('.react-flow__node').first().waitFor({ state: 'visible', timeout: 10000 });
+      await page.waitForTimeout(300);
+      await page.evaluate(() =>
+        new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))
+      );
+    },
+
+    async resetPerfStats(): Promise<UiPerfStats> {
+      return await page.evaluate(async () => await window.invoker.resetUiPerfStats());
+    },
+
+    async getPerfStats(): Promise<UiPerfStats> {
+      return await page.evaluate(async () => await window.invoker.getUiPerfStats());
+    },
+
+    async setGraphStyleOverride(css: string): Promise<void> {
+      await page.evaluate((nextCss) => {
+        const id = 'electron-ui-perf-style-override';
+        let style = document.getElementById(id);
+        if (!style) {
+          style = document.createElement('style');
+          style.id = id;
+          document.head.appendChild(style);
+        }
+        style.textContent = nextCss;
+      }, css);
+    },
+
+    async clearGraphStyleOverride(): Promise<void> {
+      await page.evaluate(() => {
+        document.getElementById('electron-ui-perf-style-override')?.remove();
+      });
+    },
+
+    async measureViewportDrag(options = {}): Promise<DragFrameStats> {
+      const pane = graphPane();
+      const box = await pane.boundingBox();
+      if (!box) {
+        throw new Error('React Flow pane is not visible');
+      }
+
+      const steps = options.steps ?? 120;
+      const stepDelayMs = options.stepDelayMs ?? 8;
+      const startXPct = options.startXPct ?? 0.72;
+      const endXPct = options.endXPct ?? 0.28;
+      const yPct = options.yPct ?? 0.45;
+
+      await page.evaluate(() => {
+        (window as typeof window & {
+          __electronUiPerfDragBench?: { active: boolean; last: number; samples: number[] };
+        }).__electronUiPerfDragBench = { active: true, last: 0, samples: [] };
+
+        const tick = (ts: number) => {
+          const state = (window as typeof window & {
+            __electronUiPerfDragBench?: { active: boolean; last: number; samples: number[] };
+          }).__electronUiPerfDragBench;
+          if (!state?.active) return;
+          if (state.last) state.samples.push(ts - state.last);
+          state.last = ts;
+          requestAnimationFrame(tick);
+        };
+
+        requestAnimationFrame(tick);
+      });
+
+      const startX = box.x + box.width * startXPct;
+      const endX = box.x + box.width * endXPct;
+      const y = box.y + box.height * yPct;
+      await page.mouse.move(startX, y);
+      await page.mouse.down();
+      for (let step = 1; step <= steps; step += 1) {
+        const x = startX + ((endX - startX) * step) / steps;
+        await page.mouse.move(x, y, { steps: 1 });
+        await page.waitForTimeout(stepDelayMs);
+      }
+      await page.mouse.up();
+      await page.waitForTimeout(150);
+
+      const samples = await page.evaluate(() => {
+        const state = (window as typeof window & {
+          __electronUiPerfDragBench?: { active: boolean; last: number; samples: number[] };
+        }).__electronUiPerfDragBench;
+        if (!state) return [];
+        state.active = false;
+        return state.samples;
+      });
+
+      if (samples.length === 0) {
+        throw new Error('No drag frame samples were recorded');
+      }
+
+      return summarizeFrameTimes(samples);
+    },
+  };
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2946,6 +2946,12 @@ if (isHeadless) {
     ipcMain.handle('invoker:get-ui-perf-stats', () => ({
       ...getUiPerfStats(),
     }));
+    ipcMain.handle('invoker:reset-ui-perf-stats', () => {
+      resetUiPerfStats();
+      return {
+        ...getUiPerfStats(),
+      };
+    });
 
     registerWorkflowScopedGuiMutationHandler(
       'invoker:recreate-workflow',

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -165,6 +165,18 @@ export interface SystemDiagnostics {
   bundledSkills?: BundledSkillsStatus;
 }
 
+export interface UiPerfStats {
+  ts: string;
+  mainDeltaToUi: number;
+  dbPollCreated: number;
+  dbPollUpdatedAsCreated: number;
+  dbPollUpdatedAsUpdated: number;
+  rendererReports: number;
+  maxRendererEventLoopLagMs: number;
+  maxRendererLongTaskMs: number;
+  startupMarks?: Record<string, number>;
+}
+
 // ── Invoke Channel Registry ─────────────────────────────────
 // Each key is the channel name string; value is { request, response }.
 // `request` is a tuple of the arguments passed after the channel name.
@@ -374,7 +386,11 @@ export const IpcChannels = {
   },
   'invoker:get-ui-perf-stats': {} as {
     request: [];
-    response: Record<string, unknown>;
+    response: UiPerfStats;
+  },
+  'invoker:reset-ui-perf-stats': {} as {
+    request: [];
+    response: UiPerfStats;
   },
   'invoker:get-activity-logs': {} as {
     request: [];

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -380,7 +380,11 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
   }
 
   return (
-    <div className="h-full w-full" style={{ minHeight: '300px' }}>
+    <div
+      className="h-full w-full"
+      style={{ minHeight: '300px' }}
+      data-testid="task-dag-root"
+    >
       <ReactFlow
         nodes={rfNodes}
         edges={edges}

--- a/scripts/test-suites/optional/40-playwright-app.sh
+++ b/scripts/test-suites/optional/40-playwright-app.sh
@@ -30,12 +30,19 @@ elif [ -n "${INVOKER_PLAYWRIGHT_SHARD_INDEX:-}" ] && [ -n "${INVOKER_PLAYWRIGHT_
 fi
 RUN_LABEL="$(sanitize_label "$RUN_LABEL")"
 
-ARTIFACT_ROOT="$ROOT/.git/playwright-artifacts/$RUN_LABEL"
+GIT_DIR="$(git rev-parse --git-dir)"
+ARTIFACT_ROOT="$GIT_DIR/playwright-artifacts/$RUN_LABEL"
 mkdir -p "$ARTIFACT_ROOT"
 
 export INVOKER_E2E_BARE_REPO="${INVOKER_E2E_BARE_REPO:-/tmp/invoker-e2e-repo-${RUN_LABEL}.git}"
 
-exec pnpm --filter @invoker/app exec xvfb-run --auto-servernum playwright test \
-  --output "$ARTIFACT_ROOT/test-results" \
-  "${PLAYWRIGHT_ARGS[@]}" \
-  "$@"
+PLAYWRIGHT_CMD=(pnpm --filter @invoker/app exec playwright test
+  --output "$ARTIFACT_ROOT/test-results"
+  "${PLAYWRIGHT_ARGS[@]}"
+  "$@")
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec pnpm --filter @invoker/app exec xvfb-run --auto-servernum "${PLAYWRIGHT_CMD[@]:4}"
+fi
+
+exec "${PLAYWRIGHT_CMD[@]}"

--- a/scripts/test-suites/optional/41-electron-ui-perf.sh
+++ b/scripts/test-suites/optional/41-electron-ui-perf.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+exec bash scripts/test-suites/optional/40-playwright-app.sh \
+  packages/app/e2e/electron-ui-perf-harness.spec.ts \
+  "$@"


### PR DESCRIPTION
## Summary

Adds a dedicated Electron UI perf CI lane that runs the new harness spec in isolation.

This updates the optional Playwright app runner to store artifacts correctly from worktrees and to fall back cleanly when `xvfb-run` is unavailable, then wires a new `electron-ui-perf` job into GitHub Actions.

## Test Plan

- [x] `bash scripts/test-suites/optional/41-electron-ui-perf.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 85f0833f`
- Post-revert steps: None
- Data migration? No

Depends-On: #182
