### PR TITLE
Reduce DAG visual effects and add perf guard tests

### DIFF
--- a/packages/ui/src/__tests__/task-dag-perf-guard.test.ts
+++ b/packages/ui/src/__tests__/task-dag-perf-guard.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const taskNodeSource = readFileSync(
+  resolve(__dirname, '..', 'components', 'TaskNode.tsx'),
+  'utf-8',
+);
+const mergeGateNodeSource = readFileSync(
+  resolve(__dirname, '..', 'components', 'MergeGateNode.tsx'),
+  'utf-8',
+);
+const bundledEdgeSource = readFileSync(
+  resolve(__dirname, '..', 'components', 'BundledEdge.tsx'),
+  'utf-8',
+);
+const cssSource = readFileSync(
+  resolve(__dirname, '..', 'index.css'),
+  'utf-8',
+);
+
+describe('TaskDAG perf guard', () => {
+  it('keeps task cards free of heavy box shadows', () => {
+    expect(taskNodeSource).not.toContain('shadow-[0_6px_24px_rgba(0,0,0,0.28)]');
+    expect(taskNodeSource).not.toContain('shadow-[0_0_0_1px_rgba(255,255,255,0.25),0_10px_30px_rgba(0,0,0,0.38)]');
+    expect(mergeGateNodeSource).not.toContain('shadow-[0_6px_24px_rgba(0,0,0,0.28)]');
+    expect(mergeGateNodeSource).not.toContain('shadow-[0_0_0_1px_rgba(255,255,255,0.25),0_10px_30px_rgba(0,0,0,0.38)]');
+  });
+
+  it('does not reintroduce edge hover filters or stroke transitions', () => {
+    expect(bundledEdgeSource).not.toContain('transition:');
+    expect(bundledEdgeSource).not.toContain('drop-shadow');
+  });
+
+  it('keeps the graph subtree in reduced-effects mode', () => {
+    expect(cssSource).toContain('.task-dag-perf-optimized');
+    expect(cssSource).toContain('animation: none !important;');
+    expect(cssSource).toContain('transition: none !important;');
+    expect(cssSource).toContain('filter: none !important;');
+  });
+
+  it('does not restore legacy edge-flow or pulse keyframes', () => {
+    expect(cssSource).not.toContain('@keyframes edge-flow');
+    expect(cssSource).not.toContain('@keyframes pulse-strong');
+    expect(cssSource).not.toContain('will-change: transform, opacity, filter');
+  });
+});

--- a/packages/ui/src/components/BundledEdge.tsx
+++ b/packages/ui/src/components/BundledEdge.tsx
@@ -77,8 +77,6 @@ export function BundledEdge({
     ...style,
     stroke: currentStroke,
     strokeWidth: currentWidth,
-    transition: 'stroke 0.2s ease, stroke-width 0.2s ease, opacity 0.2s ease',
-    filter: hovered ? `drop-shadow(0 0 4px ${currentStroke}40)` : undefined,
   };
 
   const label = data?.label;

--- a/packages/ui/src/components/MergeGateNode.tsx
+++ b/packages/ui/src/components/MergeGateNode.tsx
@@ -97,7 +97,7 @@ export function MergeGateNode({ data }: MergeGateNodeProps) {
 
   return (
     <div
-      className={`relative w-[264px] rounded-2xl border border-dashed px-5 py-4 transition-[opacity,box-shadow,border-color] duration-75 shadow-[0_6px_24px_rgba(0,0,0,0.28)] ${colors.bg} ${colors.border} ${selected ? 'ring-2 ring-white/90 ring-offset-2 ring-offset-gray-950 shadow-[0_0_0_1px_rgba(255,255,255,0.25),0_10px_30px_rgba(0,0,0,0.38)]' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : ''}`}
+      className={`relative w-[264px] rounded-2xl border border-dashed px-5 py-4 transition-[opacity,border-color] duration-75 ${colors.bg} ${colors.border} ${selected ? 'ring-2 ring-white/90 ring-offset-2 ring-offset-gray-950' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : ''}`}
       title={label}
       data-selected={selected ? 'true' : 'false'}
     >

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -381,7 +381,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
 
   return (
     <div
-      className="h-full w-full"
+      className="h-full w-full task-dag-perf-optimized"
       style={{ minHeight: '300px' }}
       data-testid="task-dag-root"
     >

--- a/packages/ui/src/components/TaskNode.tsx
+++ b/packages/ui/src/components/TaskNode.tsx
@@ -56,7 +56,7 @@ export function TaskNode({ data }: TaskNodeProps) {
 
   return (
     <div
-      className={`relative w-[264px] rounded-2xl border px-5 py-4 transition-[opacity,box-shadow,border-color] duration-75 shadow-[0_6px_24px_rgba(0,0,0,0.28)] ${colors.bg} ${colors.border} ${selected ? 'ring-2 ring-white/90 ring-offset-2 ring-offset-gray-950 shadow-[0_0_0_1px_rgba(255,255,255,0.25),0_10px_30px_rgba(0,0,0,0.38)]' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
+      className={`relative w-[264px] rounded-2xl border px-5 py-4 transition-[opacity,border-color] duration-75 ${colors.bg} ${colors.border} ${selected ? 'ring-2 ring-white/90 ring-offset-2 ring-offset-gray-950' : ''} ${dimmed ? 'opacity-20 pointer-events-none' : isStale ? 'opacity-50' : ''}`}
       title={task.id}
       data-selected={selected ? 'true' : 'false'}
     >

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -4,45 +4,21 @@
 
 /* ── Edge styling for TaskDAG ──────────────────────────────── */
 
-/* Smooth transitions on edge paths */
-.react-flow__edge-path {
-  transition: stroke 0.2s ease, stroke-width 0.2s ease;
+/* Keep viewport interaction cheap by disabling expensive subtree effects. */
+.task-dag-perf-optimized,
+.task-dag-perf-optimized * {
+  animation: none !important;
+  transition: none !important;
+  filter: none !important;
 }
 
-.react-flow__edge {
-  transition: opacity 0.2s ease;
-}
-
-/* Animated running edges: dashed flow animation */
+/* Running edges keep the dashed treatment, but avoid per-frame dash animation. */
 .react-flow__edge.animated .react-flow__edge-path {
   stroke-dasharray: 8 4;
-  animation: edge-flow 0.8s linear infinite;
-}
-
-@keyframes edge-flow {
-  to {
-    stroke-dashoffset: -12;
-  }
-}
-
-/* Stronger pulse for DAG node status rails/dots */
-@keyframes pulse-strong {
-  0%,
-  100% {
-    opacity: 1;
-    transform: scale(1);
-    filter: brightness(1);
-  }
-  50% {
-    opacity: 0.75;
-    transform: scale(1.08);
-    filter: brightness(1.35);
-  }
 }
 
 .pulse-strong {
-  animation: pulse-strong 1s ease-in-out infinite;
-  will-change: transform, opacity, filter;
+  opacity: 0.92;
 }
 
 /* Hover cursor on edge group */

--- a/scripts/test-suites/optional/41-electron-ui-perf.sh
+++ b/scripts/test-suites/optional/41-electron-ui-perf.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"
 
+export INVOKER_PLAYWRIGHT_WORKERS="${INVOKER_PLAYWRIGHT_WORKERS:-1}"
+
 exec bash scripts/test-suites/optional/40-playwright-app.sh \
-  packages/app/e2e/electron-ui-perf-harness.spec.ts \
+  packages/app/e2e/electron-ui-perf-*.spec.ts \
   "$@"


### PR DESCRIPTION
## Summary

Reduces expensive visual effects in the workflow DAG during viewport interaction and adds a guard test that locks in the cheaper styling choices.

The graph branch removes heavy node shadows, edge drop shadows, and subtree-wide animation or filter effects from the Electron DAG surface, while keeping the existing graph behavior and adding a source-level test that prevents those expensive styles from being reintroduced accidentally.

## Test Plan

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/task-dag-perf-guard.test.ts`
- [x] `bash scripts/test-suites/optional/41-electron-ui-perf.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 862bfb22`
- Post-revert steps: None
- Data migration? No

Depends-On: #183
