### PR TITLE
PR 130 Architecture Step 6: Cleanup owner terminology and document broker model

### DIFF
--- a/docs/architecture-owner-broker-model.md
+++ b/docs/architecture-owner-broker-model.md
@@ -1,0 +1,126 @@
+# Architecture: Owner-Broker Model
+
+## Overview
+
+Invoker uses a single-writer owner model for database consistency. One process
+(the **owner**) holds writable access to SQLite. All other processes
+(**clients**) delegate mutations via IPC or open the database read-only.
+
+Ownership is a **control-plane concept**, not a GUI/headless policy choice.
+Any host surface—Electron GUI, headless CLI daemon, future TUI—can be the
+owner. Client code never branches on how the owner was launched; it queries
+capability predicates instead.
+
+## Key Insight
+
+```
+┌──────────────────────────────────────────────────────┐
+│                   Owner Process                       │
+│  (single writer — may be GUI, standalone daemon,     │
+│   or any future surface)                             │
+│                                                      │
+│  ┌────────────┐  ┌──────────────┐  ┌────────────┐   │
+│  │ Persistence│  │ Orchestrator │  │ IPC Handler│   │
+│  │ (writable) │  │              │  │            │   │
+│  └────────────┘  └──────────────┘  └────────────┘   │
+└──────────────────────────┬───────────────────────────┘
+                           │ IPC (MessageBus)
+          ┌────────────────┼────────────────┐
+          │                │                │
+    ┌─────▼─────┐   ┌─────▼─────┐   ┌─────▼─────┐
+    │  Client A │   │  Client B │   │  Client C │
+    │ (CLI run) │   │ (CLI query│   │ (future   │
+    │ delegates │   │  read-only│   │  surface) │
+    │ mutations │   │  DB open) │   │           │
+    └───────────┘   └───────────┘   └───────────┘
+```
+
+## Modules
+
+| Module | Role | Key export |
+|--------|------|------------|
+| `owner-endpoint.ts` | Contract layer — defines what an owner looks like | `discoverOwner()`, `isStandaloneCapable()`, `isOwnerReachable()` |
+| `owner-resolver.ts` | Resolution policy — discover, refresh, bootstrap | `createOwnerResolver()`, `OwnerResolver` interface |
+| `headless-client.ts` | CLI entry point — routes commands | `runHeadlessClient()` |
+| `headless-delegation.ts` | IPC transport — send commands to owner | `tryDelegateRun()`, `tryDelegateExec()`, `tryDelegateQuery()` |
+| `headless-owner-bootstrap.ts` | Lifecycle — spawn detached owner | `spawnDetachedStandaloneOwner()`, `tryAcquireOwnerBootstrapLock()` |
+
+## Command Routing
+
+Three categories determine how a command reaches persistence:
+
+### 1. Read-only queries
+
+```
+CLI → open DB with readOnly:true → return results
+```
+
+No delegation needed. Examples: `query workflows`, `query tasks`, `query audit`.
+
+### 2. Standard mutations (default 5 s delegation timeout)
+
+```
+CLI → discoverOwner() → delegate via IPC → owner executes → response
+      (if no owner: bootstrap standalone → retry)
+```
+
+Examples: `run`, `approve`, `reject`, `cancel`.
+
+### 3. Workflow-scoped mutations (60 s delegation timeout)
+
+Same routing as standard mutations, with an extended timeout because the
+owner may be mid-operation (rebase, restart, recreate at workflow scope).
+
+## Owner Resolution: Three Phases
+
+`owner-resolver.ts` encapsulates a three-phase acquisition policy:
+
+1. **Discover** — ping for a live owner via `discoverOwner()`.
+2. **Refresh** — if no reply, reconnect the message bus and retry.
+3. **Bootstrap** — if still unreachable, acquire a lock and spawn a
+   standalone owner process, then poll until it responds to pings.
+
+Clients call `resolver.resolve()` and receive either a `ResolvedOwner`
+(bus handle + endpoint info) or a failure. The resolver handles retries,
+timeouts, and lock contention internally.
+
+## Capability Predicates (Not Mode Flags)
+
+The contract layer exposes two predicates. Client code uses these instead
+of inspecting raw `mode` strings:
+
+| Predicate | Meaning |
+|-----------|---------|
+| `isOwnerReachable(result)` | An owner responded to ping (any surface) |
+| `isStandaloneCapable(result)` | Owner accepts delegated mutations from peers |
+
+This means adding a new surface (e.g., a TUI) requires no changes to client
+routing logic—only the new surface must respond to `headless.owner-ping`
+with appropriate capability flags.
+
+## Where New Routing Logic Belongs
+
+| Change | File |
+|--------|------|
+| New capability predicate | `owner-endpoint.ts` |
+| New resolution strategy (e.g., cluster mode) | `owner-resolver.ts` |
+| New CLI command that mutates | `headless-client.ts` (add delegation call) |
+| New IPC channel or delegation shape | `headless-delegation.ts` |
+| New owner spawn mechanism | `headless-owner-bootstrap.ts` |
+| New surface (host implementation) | New entry in `main.ts` or equivalent; must handle `headless.owner-ping` |
+
+## Design Principles
+
+1. **Single writer.** Exactly one process writes to SQLite at any time.
+2. **Delegate before bootstrap.** Always try IPC delegation first.
+3. **Capability over mode.** Never branch on launch mode; use predicates.
+4. **Bounded recovery.** Finite timeouts, capped retries, lock-protected
+   bootstrap prevents thundering herd.
+5. **Host neutrality.** The owner contract is the same regardless of which
+   surface implements it. GUI, headless daemon, and future surfaces are
+   interchangeable behind `OwnerEndpointInfo`.
+
+## Related Documents
+
+- [Persistence Architecture: Single-Writer Boundary](persistence-architecture-single-writer.md) —
+  enforcement details, implementation map, CI policy checks.

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -29,12 +29,12 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
-  it('delegates mutating commands to an existing GUI owner without bootstrapping standalone', async () => {
+  it('delegates mutating commands to an existing non-standalone owner without bootstrapping', async () => {
     const bus = new LocalBus();
-    const guiOwnerHandler = vi.fn(async () => ({ ok: true }));
+    const ownerHandler = vi.fn(async () => ({ ok: true }));
 
     bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    bus.onRequest('headless.exec', guiOwnerHandler);
+    bus.onRequest('headless.exec', ownerHandler);
 
     const exitCode = await runHeadlessClientCommand(['retry', 'wf-1', '--no-track'], {
       messageBus: bus,
@@ -43,7 +43,7 @@ describe('headless-client', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(guiOwnerHandler).toHaveBeenCalledTimes(1);
+    expect(ownerHandler).toHaveBeenCalledTimes(1);
   });
 
   it('uses a longer no-track delegation timeout for an already-running standalone owner under load', async () => {
@@ -327,7 +327,7 @@ describe('headless-client', () => {
     expect(refreshMessageBus).toHaveBeenCalled();
   }, 15_000);
 
-  it('uses the current GUI owner directly without refreshing or bootstrapping standalone', async () => {
+  it('uses the current non-standalone owner directly without refreshing or bootstrapping', async () => {
     const firstBus = new LocalBus();
     let firstExecCalls = 0;
 

--- a/packages/app/src/__tests__/owner-endpoint.test.ts
+++ b/packages/app/src/__tests__/owner-endpoint.test.ts
@@ -30,7 +30,7 @@ describe('owner-endpoint contract', () => {
       expect(result!.canAcceptStandaloneMutations).toBe(true);
     });
 
-    it('returns OwnerEndpointInfo with canAcceptStandaloneMutations=false for GUI owners', async () => {
+    it('returns OwnerEndpointInfo with canAcceptStandaloneMutations=false for non-standalone owners', async () => {
       const bus = new LocalBus();
       bus.onRequest('headless.owner-ping', async () => ({
         ok: true,
@@ -100,12 +100,12 @@ describe('owner-endpoint contract', () => {
         ownerId: 'owner-1',
         canAcceptStandaloneMutations: true,
       };
-      const guiOwner: OwnerEndpointInfo = {
+      const transientOwner: OwnerEndpointInfo = {
         ownerId: 'owner-2',
         canAcceptStandaloneMutations: false,
       };
       expect(isOwnerReachable(standaloneOwner)).toBe(true);
-      expect(isOwnerReachable(guiOwner)).toBe(true);
+      expect(isOwnerReachable(transientOwner)).toBe(true);
     });
 
     it('returns false for null', () => {
@@ -130,7 +130,7 @@ describe('owner-endpoint contract', () => {
       expect(isStandaloneCapable(result)).toBe(false);
     });
 
-    it('client code never needs to reference GUI or standalone modes directly', () => {
+    it('client code uses capability predicates instead of raw mode strings', () => {
       // This test documents the contract guarantee: the OwnerEndpointInfo
       // type has no `mode` field. Client code uses capability predicates.
       const info: OwnerEndpointInfo = {

--- a/packages/app/src/__tests__/owner-resolver.test.ts
+++ b/packages/app/src/__tests__/owner-resolver.test.ts
@@ -37,7 +37,7 @@ describe('owner-resolver', () => {
       expect(result.resolved).toBe(false);
     });
 
-    it('returns not-resolved for a GUI owner (not standalone-capable)', async () => {
+    it('returns not-resolved for a non-standalone owner', async () => {
       const bus = new LocalBus();
       bus.onRequest('headless.owner-ping', async () => ({
         ok: true,
@@ -56,7 +56,7 @@ describe('owner-resolver', () => {
   });
 
   describe('discoverAny', () => {
-    it('returns a GUI owner as resolved', async () => {
+    it('returns a non-standalone owner as resolved', async () => {
       const bus = new LocalBus();
       bus.onRequest('headless.owner-ping', async () => ({
         ok: true,
@@ -188,7 +188,7 @@ describe('owner-resolver', () => {
   });
 
   describe('waitForStandalone', () => {
-    it('skips GUI owners and waits for standalone', async () => {
+    it('skips non-standalone owners and waits for a standalone-capable one', async () => {
       const bus = new LocalBus();
       let pingCount = 0;
       bus.onRequest('headless.owner-ping', async () => {
@@ -211,7 +211,7 @@ describe('owner-resolver', () => {
       }
     });
 
-    it('returns not-resolved after timeout when only GUI owners available', async () => {
+    it('returns not-resolved after timeout when only non-standalone owners available', async () => {
       const bus = new LocalBus();
       bus.onRequest('headless.owner-ping', async () => ({
         ok: true,
@@ -398,7 +398,7 @@ describe('owner-resolver', () => {
       }
     });
 
-    it('result contains bus handle but no GUI/headless flags', async () => {
+    it('result contains bus handle but no surface-specific mode flags', async () => {
       const bus = new LocalBus();
       bus.onRequest('headless.owner-ping', async () => ({
         ok: true,

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -62,7 +62,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(order).toEqual(['mut:running-normal', 'mut:queued-high', 'mut:queued-normal']);
   });
 
-  it('evicts older queued workflow intents when a headless recreate fence starts', async () => {
+  it('evicts older queued workflow intents when a delegated recreate fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({
@@ -180,7 +180,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     gate.resolve();
   });
 
-  it('invalidates an older running workflow intent when GUI recreate-task is enqueued', async () => {
+  it('invalidates an older running workflow intent when internal recreate-task is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({
@@ -284,7 +284,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('evicts older queued workflow intents when GUI recreate-task fence starts', async () => {
+  it('evicts older queued workflow intents when internal recreate-task fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -289,7 +289,7 @@ async function resolveOwnerAndDelegate(
     }
   }
 
-  // Phase 2: Try any reachable owner (may be GUI)
+  // Phase 2: Try any reachable owner (may be non-standalone)
   if (isOwnerReachable(owner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
     return resolvedExitCode();
   }

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -198,7 +198,7 @@ async function tryDelegate(
   }
 
   if (options.noTrack) {
-    process.stdout.write('[headless] --no-track enabled: delegated submission accepted; exiting without tracking.\n');
+    process.stdout.write('--no-track enabled: delegated submission accepted; exiting without tracking.\n');
     return true;
   }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -621,7 +621,7 @@ if (isHeadless) {
     if (mutatingMode && !standaloneMode) {
       // Delegating headless commands must never become the IPC server.
       // Otherwise a transient submitter can steal the transport socket away
-      // from the actual GUI/standalone mutation owner.
+      // from the actual shared mutation owner.
       const delegationBus = new IpcBus(undefined, { allowServe: false });
       try {
         await delegationBus.ready();
@@ -641,7 +641,7 @@ if (isHeadless) {
         }
 
         if (delegated) {
-          // Successfully delegated to GUI
+          // Successfully delegated to owner
           delegationBus.disconnect();
           process.exit(process.exitCode ?? 0);
           return; // Guard: process.exit() may not halt in Electron async context
@@ -651,9 +651,9 @@ if (isHeadless) {
         delegationBus.disconnect();
         if (!standaloneMode) {
           process.stderr.write(
-            `${RED}Error:${RESET} Mutation command "${command}" requires an owner process (GUI or standalone headless).\n` +
+            `${RED}Error:${RESET} Mutation command "${command}" requires a running owner process.\n` +
             `\n${BOLD}Options:${RESET}\n` +
-            `  1. Start the GUI process first: ${BOLD}electron dist/main.js${RESET}\n` +
+            `  1. Start the interactive process: ${BOLD}electron dist/main.js${RESET}\n` +
             `  2. Run in standalone mode: ${BOLD}INVOKER_HEADLESS_STANDALONE=1 electron dist/main.js --headless ${cliArgs.join(' ')}${RESET}\n` +
             `\nStandalone mode opens a writable database. Only use it when no other process is accessing the database.\n`
           );
@@ -846,7 +846,7 @@ if (isHeadless) {
             return undefined;
           }
           default:
-            throw new Error(`Unsupported GUI mutation for standalone owner: ${payload.channel}`);
+            throw new Error(`Unsupported internal mutation for standalone owner: ${payload.channel}`);
         }
       };
 
@@ -2371,13 +2371,13 @@ if (isHeadless) {
         { maxConcurrentWorkflowDrains },
       );
     } else {
-      logger.info('GUI launched in follower mode; mutation execution is delegated to the current owner', {
+      logger.info('Launched in follower mode; mutation execution is delegated to the current owner', {
         module: 'init',
       });
     }
 
-    // ── IPC Delegation Handlers — headless → GUI ────────────────
-    // Headless processes delegate write-heavy commands to the GUI process via IpcBus.
+    // ── IPC Delegation Handlers — peer → owner ────────────────
+    // Peer processes delegate write-heavy commands to the owner process via IpcBus.
     if (ownerMode) {
       workflowMutationDispatcher.set('headless.exec', async (payloadArg: unknown) => {
         return executeHeadlessExec(payloadArg as HeadlessExecMutationPayload);

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -1,5 +1,5 @@
 /**
- * Shared logic for opening an external OS terminal for a persisted task (GUI IPC + headless CLI).
+ * Shared logic for opening an external OS terminal for a persisted task.
  */
 
 import type { Logger } from '@invoker/contracts';
@@ -45,7 +45,7 @@ export interface OpenExternalTerminalForTaskOptions {
   executorRegistry: ExecutorRegistry;
   executionAgentRegistry?: AgentRegistry;
   repoRoot: string;
-  /** Shown when task status is `running` (GUI vs headless wording). */
+  /** Shown when task status is `running`. */
   runningTaskReason?: string;
   logger?: Logger;
 }

--- a/packages/app/src/owner-endpoint.ts
+++ b/packages/app/src/owner-endpoint.ts
@@ -1,12 +1,12 @@
 /**
  * Owner Endpoint Contract — surface-neutral owner discovery and capability.
  *
- * This module models owner discovery without exposing whether the owner is
- * a GUI window, a standalone headless daemon, or any other host surface.
+ * This module models owner discovery without exposing the host surface
+ * that launched the owner (interactive window, standalone daemon, etc.).
  * Client code asks "is an owner available?" and "can it accept mutations?"
  * without knowing how the owner was launched.
  *
- * Host implementations (main.ts standalone path, main.ts GUI path) register
+ * Host implementations (main.ts standalone path, main.ts interactive path) register
  * handlers on the MessageBus that satisfy this contract. They may retain
  * internal details about their launch mode, but those details do not appear
  * in the types below.

--- a/packages/app/src/owner-resolver.ts
+++ b/packages/app/src/owner-resolver.ts
@@ -7,7 +7,7 @@
  *   3. If no owner is available at all, bootstrap one.
  *
  * The interface is surface-neutral: callers receive an OwnerEndpointInfo and a
- * MessageBus handle, but never branch on GUI/headless mode flags.
+ * MessageBus handle, but never branch on host-specific mode flags.
  */
 
 import type { MessageBus } from '@invoker/transport';


### PR DESCRIPTION
## Summary

Clean up the remaining surface-specific owner wording in the app-facing code and
add a dedicated architecture note for the owner-broker model.

This keeps the runtime behavior aligned with the step-5 resolver work while
making the contributor-facing terminology consistent: callers talk about owner
endpoints and capabilities instead of GUI-owner versus standalone-owner labels,
and the broker responsibilities now live in a single reference doc.

## Architecture

### Before

```mermaid
graph TD
    A[App call sites and tests] --> B[Mixed GUI-owner and standalone-owner terms]
    C[Contributor trying to extend routing] --> D[Architecture spread across code and older docs]
```

### After

```mermaid
graph TD
    A[App call sites and tests] --> B[Surface-neutral owner endpoint terminology]
    C[Contributor extending routing] --> D[docs/architecture-owner-broker-model.md]
    D --> E[Broker responsibilities and routing guidance]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/owner-endpoint.test.ts src/__tests__/owner-resolver.test.ts src/__tests__/persisted-workflow-mutation-coordinator.test.ts`
- [ ] `timeout 45s pnpm --filter @invoker/app exec vitest run src/__tests__/headless-client.test.ts` timed out after repeated delegated-owner output and did not emit a final Vitest summary

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0aeb6282 a35fb586`
- Post-revert steps: Re-run the passing Vitest command above and spot-check owner-facing copy in the changed app entry points
- Data migration? No
