### PR TITLE
Harden recreate/fix flows for startup merge conflicts

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -28,6 +28,7 @@ import {
   autoFixOnFailure,
   buildCancelInFlight,
   buildInvalidationDeps,
+  selectFailureRecoveryRoute,
 } from '../workflow-actions.js';
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -269,7 +270,7 @@ describe('rebaseAndRetry', () => {
       recreateWorkflowFromFreshBase: vi.fn(async () => tasks),
     };
     const persistence = {
-      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1 })),
+      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1, repoUrl: 'https://example/repo.git', baseBranch: 'master' })),
       updateWorkflow: vi.fn(),
     };
 
@@ -630,13 +631,79 @@ describe('finalizeAppliedFix', () => {
 });
 
 describe('autoFixOnFailure', () => {
+  it('routes startup merge conflicts without a workspace to workflow fresh-base recreate', async () => {
+    const started = [
+      makeRunningTask({ id: 'task-a', status: 'running', config: { workflowId: 'wf-1' } }),
+    ];
+    const mergeError = JSON.stringify({
+      type: 'merge_conflict',
+      failedBranch: 'experiment/foo',
+      conflictFiles: ['src/foo.ts'],
+    });
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: { autoFixAttempts: 0, error: mergeError },
+      })),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      recreateWorkflowFromFreshBase: vi.fn(async (_workflowId: string, options?: { refreshBase?: () => Promise<unknown> }) => {
+        await options?.refreshBase?.();
+        return started;
+      }),
+      retryTask: vi.fn(() => []),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+      loadWorkflow: vi.fn(() => ({
+        id: 'wf-1',
+        generation: 1,
+        repoUrl: 'https://example/repo.git',
+        baseBranch: 'master',
+      })),
+      updateWorkflow: vi.fn(),
+      logEvent: vi.fn(),
+    };
+    const taskExecutor = {
+      preparePoolForRebaseRetry: vi.fn().mockResolvedValue(undefined),
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn().mockResolvedValue(undefined),
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await autoFixOnFailure('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+      'wf-1',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
+    );
+    expect(taskExecutor.preparePoolForRebaseRetry).toHaveBeenCalledWith(
+      'wf-1',
+      'https://example/repo.git',
+      'master',
+    );
+    expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
+    expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
+    expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
+  });
+
   it('uses fixWithAgent for non-merge failures and restarts the task directly', async () => {
     const started = [makeRunningTask({ id: 'task-a', status: 'running' })];
     const orchestrator = {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => makeTask({
         status: 'failed',
-        execution: { autoFixAttempts: 0 },
+        execution: { autoFixAttempts: 0, error: 'boom' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
@@ -678,7 +745,7 @@ describe('autoFixOnFailure', () => {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => makeTask({
         status: 'failed',
-        execution: { autoFixAttempts: 0 },
+        execution: { autoFixAttempts: 0, error: mergeError, workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
@@ -720,7 +787,7 @@ describe('autoFixOnFailure', () => {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => makeTask({
         status: 'failed',
-        execution: { autoFixAttempts: 0 },
+        execution: { autoFixAttempts: 0, error: mergeError, workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
@@ -1009,7 +1076,7 @@ describe('autoFixOnFailure', () => {
       getTask: vi.fn(() => makeTask({
         status: 'failed',
         config: { workflowId: 'wf-1' },
-        execution: { autoFixAttempts: 0 },
+        execution: { autoFixAttempts: 0, error: mergeError, workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
@@ -1045,6 +1112,64 @@ describe('autoFixOnFailure', () => {
         selectedAgentSource: 'default',
       }),
     );
+  });
+});
+
+describe('selectFailureRecoveryRoute', () => {
+  it('treats executor startup merge-conflict text as a merge conflict', () => {
+    const route = selectFailureRecoveryRoute(
+      makeTask({
+        config: { workflowId: 'wf-1' },
+        execution: {},
+      }) as any,
+      'Executor startup failed (ssh): Merge conflict merging experiment/foo: packages/workflow-core/src/orchestrator.ts',
+    );
+
+    expect(route).toEqual({ kind: 'recreateWorkflowFromFreshBase', workflowId: 'wf-1' });
+  });
+
+  it('uses workflow fresh-base recreate for startup merge conflicts without a workspace', () => {
+    const route = selectFailureRecoveryRoute(
+      makeTask({
+        config: { workflowId: 'wf-1' },
+        execution: {},
+      }) as any,
+      JSON.stringify({
+        type: 'merge_conflict',
+        failedBranch: 'experiment/foo',
+        conflictFiles: ['src/foo.ts'],
+      }),
+    );
+
+    expect(route).toEqual({ kind: 'recreateWorkflowFromFreshBase', workflowId: 'wf-1' });
+  });
+
+  it('uses resolveConflict for merge conflicts when a workspace exists', () => {
+    const route = selectFailureRecoveryRoute(
+      makeTask({
+        config: { workflowId: 'wf-1' },
+        execution: { workspacePath: '/tmp/task-a' },
+      }) as any,
+      JSON.stringify({
+        type: 'merge_conflict',
+        failedBranch: 'experiment/foo',
+        conflictFiles: ['src/foo.ts'],
+      }),
+    );
+
+    expect(route).toEqual({ kind: 'resolveConflict' });
+  });
+
+  it('uses fixWithAgent for non-merge failures', () => {
+    const route = selectFailureRecoveryRoute(
+      makeTask({
+        config: { workflowId: 'wf-1' },
+        execution: {},
+      }) as any,
+      'boom',
+    );
+
+    expect(route).toEqual({ kind: 'fixWithAgent' });
   });
 });
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -35,8 +35,10 @@ import {
   rebaseAndRetry,
   resolveConflictAction,
   recreateWorkflow as sharedRecreateWorkflow,
+  recreateWorkflowFromFreshBase,
   recreateTask as sharedRecreateTask,
   forkWorkflow as sharedForkWorkflow,
+  selectFailureRecoveryRoute,
   setWorkflowMergeMode,
   finalizeAppliedFix,
 } from './workflow-actions.js';
@@ -1187,35 +1189,38 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
 
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
-  const { savedError } = deps.orchestrator.beginConflictResolution(taskId);
   const agent = (agentArg ?? 'claude').toLowerCase();
-  const isMergeConflictError = (() => {
-    const candidates = [
-      savedError,
-      savedError.trim(),
-      savedError.split('\n\n').at(-1)?.trim() ?? '',
-    ];
-    for (const candidate of candidates) {
-      if (!candidate) continue;
-      try {
-        const parsed = JSON.parse(candidate) as { type?: unknown };
-        if (parsed?.type === 'merge_conflict') return true;
-      } catch {
-        // ignore parse errors; this helper is best-effort
-      }
-    }
-    return false;
-  })();
+  const task = deps.orchestrator.getTask(taskId);
+  if (!task) throw new Error(`Task ${taskId} not found`);
+  const savedError = task.execution.error ?? '';
+  const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
   try {
-    const output = deps.persistence.getTaskOutput(taskId);
-    if (isMergeConflictError) {
-      // For merge_conflict failures, run the deterministic conflict resolver first,
-      // then gate rerun behind explicit approve/reject like normal fix flow.
-      await te.resolveConflict(taskId, savedError, agent);
-    } else {
-      await te.fixWithAgent(taskId, output, agent, savedError);
+    if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
+      const started = await recreateWorkflowFromFreshBase(recoveryRoute.workflowId, {
+        ...deps,
+        taskExecutor: te,
+      });
+      await finalizeMutationWithGlobalTopup({
+        orchestrator: deps.orchestrator,
+        taskExecutor: te,
+        logger: deps.logger,
+        context: 'headless.fix-with-agent',
+        started,
+      });
+      process.stdout.write(
+        `Startup merge conflict detected; recreated workflow ${recoveryRoute.workflowId} from a fresh base.\n`,
+      );
+      return;
     }
-    const result = await finalizeAppliedFix(taskId, savedError, {
+
+    const { savedError: persistedSavedError } = deps.orchestrator.beginConflictResolution(taskId);
+    const output = deps.persistence.getTaskOutput(taskId);
+    if (recoveryRoute.kind === 'resolveConflict') {
+      await te.resolveConflict(taskId, persistedSavedError, agent);
+    } else {
+      await te.fixWithAgent(taskId, output, agent, persistedSavedError);
+    }
+    const result = await finalizeAppliedFix(taskId, persistedSavedError, {
       orchestrator: deps.orchestrator,
       taskExecutor: te,
       autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
@@ -1235,7 +1240,9 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     deps.persistence.appendTaskOutput(taskId, `\n[Fix with AI] Failed: ${msg}`);
-    deps.orchestrator.revertConflictResolution(taskId, savedError, msg);
+    if (recoveryRoute.kind !== 'recreateWorkflowFromFreshBase') {
+      deps.orchestrator.revertConflictResolution(taskId, savedError, msg);
+    }
     await finalizeMutationWithGlobalTopup({
       orchestrator: deps.orchestrator,
       taskExecutor: te,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -111,7 +111,9 @@ import {
   rebaseAndRetry,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
+  recreateWorkflowFromFreshBase,
   resolveConflictAction,
+  selectFailureRecoveryRoute,
   selectExperiments as sharedSelectExperiments,
   setWorkflowMergeMode,
   finalizeAppliedFix,
@@ -1308,11 +1310,27 @@ if (isHeadless) {
       });
       logAutoFixDebug(taskId, 'dispatch-attempt-bumped', { attemptsBefore, attemptsAfter });
     }
-    const { savedError } = orchestrator.beginConflictResolution(taskId);
+    if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
+      persistence.appendTaskOutput(
+        taskId,
+        `\n[${source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI'}] Startup merge conflict detected; recreating workflow ${recoveryRoute.workflowId} from a fresh base.`,
+      );
+      return await recreateWorkflowFromFreshBase(recoveryRoute.workflowId, {
+        orchestrator,
+        persistence,
+        taskExecutor: requireTaskExecutor(),
+      });
+    }
+
+    const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
     try {
       const output = persistence.getTaskOutput(taskId);
-      await requireTaskExecutor().fixWithAgent(taskId, output, agentName, savedError);
-      const result = await finalizeAppliedFix(taskId, savedError, {
+      if (recoveryRoute.kind === 'resolveConflict') {
+        await requireTaskExecutor().resolveConflict(taskId, persistedSavedError, agentName);
+      } else {
+        await requireTaskExecutor().fixWithAgent(taskId, output, agentName, persistedSavedError);
+      }
+      const result = await finalizeAppliedFix(taskId, persistedSavedError, {
         orchestrator,
         taskExecutor: requireTaskExecutor(),
         autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
@@ -1322,7 +1340,7 @@ if (isHeadless) {
       const msg = err instanceof Error ? err.message : String(err);
       const errorLabel = source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`;
       persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
-      orchestrator.revertConflictResolution(taskId, savedError, msg);
+      orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
       throw err;
     }
   };

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1299,8 +1299,14 @@ if (isHeadless) {
       `fix-with-agent: "${taskId}" agent=${agentName ?? 'claude'} source=${source} route=fixWithAgent`,
       { module: 'ipc' },
     );
+    const task = orchestrator.getTask(taskId);
+    if (!task) {
+      throw new Error(`Task ${taskId} not found`);
+    }
+    const savedError = task.execution.error ?? '';
+    const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
+
     if (source === 'auto-fix') {
-      const task = orchestrator.getTask(taskId);
       const attemptsBefore = task?.execution.autoFixAttempts ?? 0;
       const attemptsAfter = attemptsBefore + 1;
       persistence.updateTask(taskId, {

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -568,6 +568,11 @@ export async function finalizeAppliedFix(
 
 // ── Auto-fix helpers ─────────────────────────────────────────
 
+export type FailureRecoveryRoute =
+  | { kind: 'fixWithAgent' }
+  | { kind: 'resolveConflict' }
+  | { kind: 'recreateWorkflowFromFreshBase'; workflowId: string };
+
 function isMergeConflictError(error: string): boolean {
   for (const c of [error, error.trim(), error.split('\n\n').at(-1)?.trim() ?? '']) {
     if (!c) continue;
@@ -580,11 +585,36 @@ function isMergeConflictError(error: string): boolean {
         /* not parseable JSON tail */
       }
     }
-    if (c.includes('CONFLICT (') || c.includes('Automatic merge failed')) {
+    if (
+      c.includes('CONFLICT (') ||
+      c.includes('Automatic merge failed') ||
+      c.includes('Merge conflict merging ')
+    ) {
       return true;
     }
   }
   return false;
+}
+
+export function selectFailureRecoveryRoute(
+  task: TaskState,
+  savedError: string,
+): FailureRecoveryRoute {
+  if (!isMergeConflictError(savedError)) {
+    return { kind: 'fixWithAgent' };
+  }
+
+  const workspacePath = task.execution.workspacePath?.trim();
+  if (workspacePath) {
+    return { kind: 'resolveConflict' };
+  }
+
+  const workflowId = task.config.workflowId?.trim();
+  if (!workflowId) {
+    return { kind: 'resolveConflict' };
+  }
+
+  return { kind: 'recreateWorkflowFromFreshBase', workflowId };
 }
 
 function tailText(value: unknown, maxChars: number = 2000): string | undefined {
@@ -713,6 +743,8 @@ export async function autoFixOnFailure(
 
   const attempts = (task.execution.autoFixAttempts ?? 0) + 1;
   const max = orchestrator.getAutoFixRetryBudget(taskId);
+  const savedError = task.execution.error ?? '';
+  const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
   console.log(`[auto-fix] "${taskId}" attempt ${attempts}/${max}`);
   persistence.logEvent?.(taskId, 'debug.auto-fix', {
     phase: 'auto-fix-start',
@@ -727,14 +759,9 @@ export async function autoFixOnFailure(
   // Increment counter FIRST (before any delta can re-trigger)
   persistence.updateTask(taskId, { execution: { autoFixAttempts: attempts } });
 
-  const { savedError } = orchestrator.beginConflictResolution(taskId);
   const agentSelection = resolveAutoFixAgent(deps.getAutoFixAgent?.());
-  persistence.logEvent?.(taskId, 'debug.auto-fix', {
-    phase: 'auto-fix-begin-conflict-resolution',
-    savedErrorLength: savedError.length,
-  });
+  let persistedSavedError: string | undefined;
   try {
-    const output = persistence.getTaskOutput(taskId);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-agent-selected',
       configuredAutoFixAgent: agentSelection.configuredAutoFixAgent ?? null,
@@ -746,8 +773,7 @@ export async function autoFixOnFailure(
       taskId,
       `\n[Auto-fix Agent] selected=${agentSelection.selectedAgent} source=${agentSelection.selectedAgentSource} fallback=${agentSelection.fallbackChain}`,
     );
-    const useResolveConflict = isMergeConflictError(savedError);
-    const route = useResolveConflict ? 'resolveConflict' : 'fixWithAgent';
+    const route = recoveryRoute.kind;
     console.log(
       `[auto-fix-route] task="${taskId}" route=${route} agent=${agentSelection.selectedAgent} source=${agentSelection.selectedAgentSource}`,
     );
@@ -758,12 +784,42 @@ export async function autoFixOnFailure(
       selectedAgentSource: agentSelection.selectedAgentSource,
       configuredAutoFixAgent: agentSelection.configuredAutoFixAgent ?? null,
       fallbackChain: agentSelection.fallbackChain,
-      outputLength: output.length,
+      outputLength: recoveryRoute.kind === 'recreateWorkflowFromFreshBase'
+        ? null
+        : persistence.getTaskOutput(taskId).length,
     });
-    if (useResolveConflict) {
-      await taskExecutor.resolveConflict(taskId, savedError, agentSelection.selectedAgent);
+    if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
+      persistence.appendTaskOutput(
+        taskId,
+        `\n[Auto-fix] Startup merge conflict detected; recreating workflow ${recoveryRoute.workflowId} from a fresh base.`,
+      );
+      const started = await recreateWorkflowFromFreshBase(recoveryRoute.workflowId, {
+        orchestrator,
+        persistence,
+        taskExecutor,
+      });
+      const runnable = started.filter((candidate) => candidate.status === 'running');
+      persistence.logEvent?.(taskId, 'debug.auto-fix', {
+        phase: 'auto-fix-post-route-recreate-workflow',
+        workflowId: recoveryRoute.workflowId,
+        startedCount: started.length,
+        runnableCount: runnable.length,
+        startedStatuses: started.map((candidate) => candidate.status),
+      });
+      if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
+      return;
+    }
+
+    ({ savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId));
+    persistence.logEvent?.(taskId, 'debug.auto-fix', {
+      phase: 'auto-fix-begin-conflict-resolution',
+      savedErrorLength: persistedSavedError.length,
+    });
+    if (recoveryRoute.kind === 'resolveConflict') {
+      await taskExecutor.resolveConflict(taskId, persistedSavedError, agentSelection.selectedAgent);
     } else {
-      await taskExecutor.fixWithAgent(taskId, output, agentSelection.selectedAgent, savedError);
+      const output = persistence.getTaskOutput(taskId);
+      await taskExecutor.fixWithAgent(taskId, output, agentSelection.selectedAgent, persistedSavedError);
     }
     const postRouteStrategy = selectAutoFixPostRouteStrategy(task);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
@@ -775,7 +831,7 @@ export async function autoFixOnFailure(
         persistence,
         taskExecutor,
       });
-      const finalizeResult = await finalizeAppliedFix(taskId, savedError, {
+      const finalizeResult = await finalizeAppliedFix(taskId, persistedSavedError, {
         orchestrator,
         taskExecutor,
         autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
@@ -825,6 +881,8 @@ export async function autoFixOnFailure(
     }
     persistence.appendTaskOutput(taskId, `\n[Auto-fix] Agent failed (attempt ${attempts}/${max}): ${msg}`);
     const detailedMsg = diagnostics ? `${msg}\n\n${diagnostics}` : msg;
-    orchestrator.revertConflictResolution(taskId, savedError, detailedMsg);
+    if (persistedSavedError !== undefined) {
+      orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg);
+    }
   }
 }

--- a/packages/execution-engine/src/__tests__/branch-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-utils.test.ts
@@ -602,6 +602,60 @@ describe('bashMergeUpstreams', () => {
     // Dirty tracked+untracked state should be removed by pre-merge cleanup.
     expect(gitExec('git status --porcelain', wtDir)).toBe('');
   });
+
+  it('prefers origin refs over stale same-named local branches', async () => {
+    const originDir = join(repoDir, '..', `origin-${Date.now()}.git`);
+    const seedDir = join(repoDir, '..', `seed-${Date.now()}`);
+    const originalRepoDir = repoDir;
+
+    try {
+      execSync(`git init --bare "${originDir}"`);
+      execSync(`git clone "${originDir}" "${seedDir}"`, { stdio: 'ignore' });
+      gitExec('git config user.email "test@example.com"', seedDir);
+      gitExec('git config user.name "Test User"', seedDir);
+
+      writeFileSync(join(seedDir, 'shared.txt'), 'base\n');
+      gitExec('git add shared.txt && git commit -m "base"', seedDir);
+      gitExec('git branch -M master', seedDir);
+      gitExec('git push -u origin master', seedDir);
+
+      gitExec('git checkout -b dep', seedDir);
+      writeFileSync(join(seedDir, 'shared.txt'), 'dep-v1\n');
+      gitExec('git commit -am "dep v1"', seedDir);
+      gitExec('git push -u origin dep', seedDir);
+
+      execSync(`git worktree remove --force "${wtDir}"`, { cwd: repoDir });
+      rmSync(originalRepoDir, { recursive: true, force: true });
+
+      execSync(`git clone "${originDir}" "${originalRepoDir}"`, { stdio: 'ignore' });
+      repoDir = originalRepoDir;
+      gitExec('git config user.email "test@example.com"', repoDir);
+      gitExec('git config user.name "Test User"', repoDir);
+      gitExec('git checkout -b dep origin/dep', repoDir);
+      gitExec('git checkout master', repoDir);
+
+      wtDir = join(repoDir, '..', 'merge-wt-' + Date.now());
+      execSync(`git worktree add -b invoker/merge-test "${wtDir}" origin/master`, { cwd: repoDir });
+
+      gitExec('git checkout dep', seedDir);
+      writeFileSync(join(seedDir, 'shared.txt'), 'dep-v2\n');
+      gitExec('git commit -am "dep v2"', seedDir);
+      gitExec('git push --force origin dep', seedDir);
+
+      gitExec('git fetch origin', repoDir);
+
+      const script = bashMergeUpstreams({
+        worktreeDir: wtDir,
+        upstreamBranches: ['dep'],
+      });
+      await runBashLocal(script);
+
+      expect(readFileSync(join(wtDir, 'shared.txt'), 'utf-8')).toBe('dep-v2\n');
+    } finally {
+      rmSync(seedDir, { recursive: true, force: true });
+      rmSync(originDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import { RepoPool, ResourceLimitError } from '../repo-pool.js';
 import { remoteFetchForPool } from '../remote-fetch-policy.js';
+import * as branchUtils from '../branch-utils.js';
 
 /**
  * Creates a temp git repo with an initial commit.
@@ -149,6 +150,49 @@ describe('RepoPool', () => {
     expect(currentBranch).toBe(branch);
 
     await poolWithExternalBase.destroyAll();
+  });
+
+  it('acquireWorktree: retries once when git reports target worktree path already exists', async () => {
+    const branch = 'experiment/race-already-exists';
+    const actionId = 'wf-race/task';
+    const poolWithExternalBase = new RepoPool({
+      cacheDir: tmpDir,
+      worktreeBaseDir: join(tmpDir, 'managed-worktrees'),
+    });
+    const targetPath = poolWithExternalBase.externalWorktreePath(localRepoUrl, branch);
+
+    const originalRunBashLocal = branchUtils.runBashLocal;
+    let shouldFailFirstAttempt = true;
+    const runBashSpy = vi
+      .spyOn(branchUtils, 'runBashLocal')
+      .mockImplementation(async (script, cwd) => {
+        if (shouldFailFirstAttempt) {
+          shouldFailFirstAttempt = false;
+          const error = new Error(
+            `bash exited with code 128: Preparing worktree (resetting branch '${branch}')\n` +
+              `fatal: '${targetPath}' already exists`,
+          );
+          (error as Error & { exitCode?: number }).exitCode = 128;
+          throw error;
+        }
+        return originalRunBashLocal(script, cwd);
+      });
+
+    try {
+      const acquired = await poolWithExternalBase.acquireWorktree(
+        localRepoUrl,
+        branch,
+        undefined,
+        actionId,
+        { forceFresh: true },
+      );
+      expect(acquired.worktreePath).toBe(targetPath);
+      expect(existsSync(join(acquired.worktreePath, '.git'))).toBe(true);
+      expect(runBashSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      runBashSpy.mockRestore();
+      await poolWithExternalBase.destroyAll();
+    }
   });
 
   it('softRelease: frees slot without removing worktree from disk', async () => {

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -190,11 +190,13 @@ WT_DIR=${q(worktreeDir)}
 git -C "$WT_DIR" reset --hard HEAD >/dev/null 2>&1 || true
 git -C "$WT_DIR" clean -fd >/dev/null 2>&1 || true
 for upBranch in ${branches}; do
-  # Resolve: try bare name first, then origin/ prefix
-  if git -C "$WT_DIR" rev-parse --verify "$upBranch" >/dev/null 2>&1; then
-    upRef="$upBranch"
-  elif git -C "$WT_DIR" rev-parse --verify "origin/$upBranch" >/dev/null 2>&1; then
+  # Resolve: prefer fetched origin/<branch> over same-named local branches.
+  # Managed mirrors accumulate local experiment refs from prior runs; after a
+  # fetch, a stale local branch must not shadow a newer remote-tracking ref.
+  if git -C "$WT_DIR" rev-parse --verify "origin/$upBranch" >/dev/null 2>&1; then
     upRef="origin/$upBranch"
+  elif git -C "$WT_DIR" rev-parse --verify "$upBranch" >/dev/null 2>&1; then
+    upRef="$upBranch"
   else
     # Branch doesn't exist locally or on origin - skip gracefully
     echo "SKIPPED_MISSING_REF=$upBranch"

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -207,6 +207,41 @@ export class RepoPool {
     }
   }
 
+  private isAlreadyExistsWorktreeError(err: unknown, worktreePath: string): boolean {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!message.includes('already exists')) return false;
+    if (message.includes(worktreePath)) return true;
+    const normalizedPath = canonicalPathForComparison(worktreePath);
+    return message.includes(normalizedPath);
+  }
+
+  private async runPreserveOrResetWithRecovery(
+    clonePath: string,
+    worktreePath: string,
+    branch: string,
+    base: string,
+  ): Promise<void> {
+    const script = bashPreserveOrReset({
+      repoDir: clonePath,
+      worktreeDir: worktreePath,
+      branch,
+      base,
+    });
+    try {
+      await runBashLocal(script, clonePath);
+      return;
+    } catch (err) {
+      if (!this.isAlreadyExistsWorktreeError(err, worktreePath)) {
+        throw err;
+      }
+      traceExecution(
+        `[RepoPool] runPreserveOrResetWithRecovery: retrying after pre-existing path branch=${branch} path=${worktreePath}`,
+      );
+      await this.reconcileStaleWorktreePath(clonePath, worktreePath);
+    }
+    await runBashLocal(script, clonePath);
+  }
+
   private async doEnsureClone(repoUrl: string): Promise<string> {
     const dir = this.cloneDir(repoUrl);
     if (existsSync(dir)) {
@@ -434,13 +469,12 @@ export class RepoPool {
         } catch {
           await this.reconcileLeakedTargetPath(clonePath, worktreePath, porcelain, branch);
           mkdirSync(worktreeParent, { recursive: true });
-          const script = bashPreserveOrReset({
-            repoDir: clonePath,
-            worktreeDir: worktreePath,
+          await this.runPreserveOrResetWithRecovery(
+            clonePath,
+            worktreePath,
             branch,
-            base: base ?? 'HEAD',
-          });
-          await runBashLocal(script, clonePath);
+            base ?? 'HEAD',
+          );
           effectivePath = worktreePath;
         }
         break;
@@ -452,15 +486,12 @@ export class RepoPool {
           }
         }
         mkdirSync(worktreeParent, { recursive: true });
-        {
-          const script = bashPreserveOrReset({
-            repoDir: clonePath,
-            worktreeDir: worktreePath,
-            branch,
-            base: base ?? 'HEAD',
-          });
-          await runBashLocal(script, clonePath);
-        }
+        await this.runPreserveOrResetWithRecovery(
+          clonePath,
+          worktreePath,
+          branch,
+          base ?? 'HEAD',
+        );
         effectivePath = worktreePath;
         break;
     }

--- a/scripts/repro-worktree-already-exists.sh
+++ b/scripts/repro-worktree-already-exists.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR/packages/execution-engine"
+pnpm exec vitest run src/__tests__/repo-pool.test.ts -t "acquireWorktree: retries once when git reports target worktree path already exists"


### PR DESCRIPTION
## Summary

- Route startup merge-conflict failures without a workspace through workflow fresh-base recreate, instead of trying fix-with-agent on a task that has no managed workspace yet.
- Prefer `origin/<branch>` over same-named local branches when merging upstream dependency branches, so stale local refs in mirrors cannot shadow fresher remote refs.
- Recover from `git worktree add` path-collision races by reconciling stale managed worktree paths and retrying once; add a regression test and a runnable repro script.

## Architecture

### Before

```mermaid
flowchart TD
  A[Task startup merge conflict] --> B[auto-fix route selection]
  B --> C[fix-with-agent attempted]
  C --> D[workspacePath undefined error]
```

### After

```mermaid
flowchart TD
  A[Task startup merge conflict] --> B[auto-fix route selection]
  B --> C[recreateWorkflowFromFreshBase]
  C --> E[new attempt with managed workspace]
  E --> F[normal execution or conflict-resolution path]
```

## Test Plan

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/repo-pool.test.ts`
- [x] `bash scripts/repro-worktree-already-exists.sh`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 46d46380`
- Post-revert steps: None.
- Data migration? No.

Made with [Cursor](https://cursor.com)