### PR TITLE
Add end-to-end diagnostics for headless chain submission

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -20,11 +20,11 @@ describe('headless-client', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(ownerHandler).toHaveBeenCalledWith({
+    expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
       args: ['retry', 'wf-1'],
       noTrack: true,
       waitForApproval: false,
-    });
+    }));
     expect(ensureStandaloneOwner).not.toHaveBeenCalled();
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1421,10 +1421,10 @@ describe('headless delegation enforcement', () => {
 
         // Verify delegation succeeded
         expect(delegated).toBe(true);
-        expect(ownerHandler).toHaveBeenCalledWith({
+        expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
           args: ['run', '/path/to/plan.yaml'],
           waitForApproval: undefined,
-        });
+        }));
       });
 
       it('delegates all mutation commands deterministically', async () => {

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -99,11 +99,11 @@ describe('headless→owner delegation', () => {
 
       // Verify delegation succeeded
       expect(delegated).toBe(true);
-      expect(ownerHandler).toHaveBeenCalledWith({
+      expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['run', '/path/to/plan.yaml'],
         noTrack: undefined,
         waitForApproval: undefined,
-      });
+      }));
     });
 
     it('delegates with waitForApproval flag', async () => {
@@ -112,10 +112,10 @@ describe('headless→owner delegation', () => {
 
       await tryDelegateExec(['approve', 'task-1'], messageBus, true);
 
-      expect(ownerHandler).toHaveBeenCalledWith({
+      expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['approve', 'task-1'],
         waitForApproval: true,
-      });
+      }));
     });
 
     it('delegates retry-task command to owner', async () => {
@@ -125,10 +125,10 @@ describe('headless→owner delegation', () => {
       const delegated = await tryDelegateExec(['retry-task', 'wf-1/task-1'], messageBus);
 
       expect(delegated).toBe(true);
-      expect(ownerHandler).toHaveBeenCalledWith({
+      expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['retry-task', 'wf-1/task-1'],
         waitForApproval: undefined,
-      });
+      }));
     });
 
     it('delegates resume command to owner', async () => {
@@ -138,10 +138,10 @@ describe('headless→owner delegation', () => {
       const delegated = await tryDelegateExec(['resume', 'wf-1'], messageBus);
 
       expect(delegated).toBe(true);
-      expect(ownerHandler).toHaveBeenCalledWith({
+      expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['resume', 'wf-1'],
         waitForApproval: undefined,
-      });
+      }));
     });
 
     it('delegates approve command to owner', async () => {
@@ -151,10 +151,10 @@ describe('headless→owner delegation', () => {
       const delegated = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
 
       expect(delegated).toBe(true);
-      expect(ownerHandler).toHaveBeenCalledWith({
+      expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['approve', 'wf-1/task-1'],
         waitForApproval: undefined,
-      });
+      }));
     });
 
     it('delegates reject command to owner', async () => {
@@ -164,10 +164,10 @@ describe('headless→owner delegation', () => {
       const delegated = await tryDelegateExec(['reject', 'wf-1/task-1', 'reason text'], messageBus);
 
       expect(delegated).toBe(true);
-      expect(ownerHandler).toHaveBeenCalledWith({
+      expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['reject', 'wf-1/task-1', 'reason text'],
         waitForApproval: undefined,
-      });
+      }));
     });
 
     it('delegates set command to owner', async () => {
@@ -180,10 +180,10 @@ describe('headless→owner delegation', () => {
       );
 
       expect(delegated).toBe(true);
-      expect(ownerHandler).toHaveBeenCalledWith({
+      expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['set', 'command', 'wf-1/task-1', 'new command'],
         waitForApproval: undefined,
-      });
+      }));
     });
 
     it('delegates rebase with noTrack so owner can return before workflow settlement', async () => {
@@ -198,11 +198,11 @@ describe('headless→owner delegation', () => {
       );
 
       expect(delegated).toBe(true);
-      expect(ownerHandler).toHaveBeenCalledWith({
+      expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['rebase', 'wf-1/task-1'],
         noTrack: true,
         waitForApproval: undefined,
-      });
+      }));
     });
   });
 

--- a/packages/app/src/db-writer-lock.ts
+++ b/packages/app/src/db-writer-lock.ts
@@ -26,12 +26,13 @@ export interface DbWriterLockResult {
  * @returns lock handle with a `release()` method.
  * @throws if another process already holds the lock.
  */
-export function acquireDbWriterLock(dbPath: string): DbWriterLockResult {
+export function acquireDbWriterLock(dbPath: string, callerContext?: string): DbWriterLockResult {
   const bypassed = process.env[ENV_BYPASS] === '1';
   const lockDir = `${dbPath}.lock`;
+  const callerTag = callerContext ? ` caller=${callerContext}` : '';
 
   if (bypassed) {
-    console.log(`[db-writer-lock] BYPASSED (${ENV_BYPASS}=1) — no exclusive lock acquired`);
+    console.log(`[db-writer-lock] BYPASSED (${ENV_BYPASS}=1) — no exclusive lock acquired${callerTag}`);
     return { acquired: true, bypassed: true, release: () => {} };
   }
 
@@ -51,9 +52,9 @@ export function acquireDbWriterLock(dbPath: string): DbWriterLockResult {
               process.kill(holderPid, 0); // signal 0 = check if alive
             } catch {
               // Holding process is dead — stale lock from a crash.
-              console.log(`[db-writer-lock] Stale lock from dead PID ${holderPid}, reclaiming`);
+              console.log(`[db-writer-lock] Stale lock from dead PID ${holderPid}, reclaiming${callerTag}`);
               rmSync(lockDir, { recursive: true, force: true });
-              return acquireDbWriterLock(dbPath);
+              return acquireDbWriterLock(dbPath, callerContext);
             }
           }
         } catch { /* best effort */ }
@@ -61,6 +62,7 @@ export function acquireDbWriterLock(dbPath: string): DbWriterLockResult {
       throw new Error(
         `[db-writer-lock] Cannot acquire writer lock for ${dbPath} — ` +
         `already held by PID ${holder}. ` +
+        `requested by${callerTag || ' <unknown>'}. ` +
         `If the previous process crashed, remove ${lockDir} manually.`,
       );
     }
@@ -72,7 +74,7 @@ export function acquireDbWriterLock(dbPath: string): DbWriterLockResult {
     writeFileSync(`${lockDir}/pid`, String(process.pid));
   } catch { /* non-fatal — lock is already held via mkdir */ }
 
-  console.log(`[db-writer-lock] Acquired exclusive writer lock (PID ${process.pid})`);
+  console.log(`[db-writer-lock] Acquired exclusive writer lock (PID ${process.pid})${callerTag}`);
 
   let released = false;
   const release = (): void => {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -29,6 +29,10 @@ import { createOwnerResolver } from './owner-resolver.js';
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
 
+function delegationClientLog(message: string): void {
+  process.stderr.write(`[headless-client] ${message}\n`);
+}
+
 function electronCommandArgs(args: string[]): string[] {
   const mainJs = resolve(__dirname, 'main.js');
   return [
@@ -106,6 +110,9 @@ async function delegateMutation(
     : command === 'run' || command === 'resume'
       ? 5_000
       : await resolveDelegationTimeoutMs(args);
+  delegationClientLog(
+    `delegateMutation command=${command ?? '<missing>'} timeoutMs=${timeoutMs} noTrack=${noTrack ? 'true' : 'false'} waitForApproval=${waitForApproval ? 'true' : 'false'}`,
+  );
   if (command === 'run') {
     const planPath = args[1];
     if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
@@ -198,10 +205,17 @@ async function delegateAfterBootstrap(
   waitForApproval?: boolean,
   noTrack?: boolean,
 ): Promise<boolean> {
+  const startedAt = Date.now();
+  delegationClientLog(`post-bootstrap delegation loop begin timeoutMs=${POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS}`);
   const deadline = Date.now() + POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS;
   let messageBus = bus;
+  let attempts = 0;
   while (Date.now() < deadline) {
+    attempts += 1;
     const owner = await discoverOwner(messageBus, 1_000);
+    delegationClientLog(
+      `post-bootstrap attempt=${attempts} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
+    );
     if (isStandaloneCapable(owner) && await delegateMutation(
       args,
       messageBus,
@@ -209,6 +223,7 @@ async function delegateAfterBootstrap(
       noTrack,
       noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
     )) {
+      delegationClientLog(`post-bootstrap delegation succeeded attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
       return true;
     }
     if (deps.refreshMessageBus) {
@@ -216,6 +231,7 @@ async function delegateAfterBootstrap(
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
+  delegationClientLog(`post-bootstrap delegation exhausted attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
   return false;
 }
 
@@ -229,19 +245,31 @@ export interface HeadlessClientDeps {
 async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void> {
   const invokerHomeRoot = resolveInvokerHomeRoot();
   const bootstrapLock = tryAcquireOwnerBootstrapLock(invokerHomeRoot);
+  const startedAt = Date.now();
+  delegationClientLog(`bootstrap begin lockAcquired=${bootstrapLock ? 'true' : 'false'} home=${invokerHomeRoot}`);
   try {
     if (bootstrapLock) {
+      delegationClientLog('bootstrap spawning detached standalone owner');
       spawnDetachedStandaloneOwner(resolve(__dirname, '..', '..', '..'));
     }
     const deadline = Date.now() + standaloneOwnerBootstrapTimeoutMs();
+    let attempts = 0;
     while (Date.now() < deadline) {
+      attempts += 1;
       const owner = await discoverOwner(bus, 500);
-      if (isStandaloneCapable(owner)) return;
+      if (isStandaloneCapable(owner)) {
+        delegationClientLog(
+          `bootstrap owner ready attempts=${attempts} elapsedMs=${Date.now() - startedAt} ownerId=${owner.ownerId}`,
+        );
+        return;
+      }
       await new Promise((resolveDelay) => setTimeout(resolveDelay, 200));
     }
+    delegationClientLog(`bootstrap timeout elapsedMs=${Date.now() - startedAt}`);
     throw new SharedMutationOwnerTimeoutError();
   } finally {
     bootstrapLock?.release();
+    delegationClientLog(`bootstrap end elapsedMs=${Date.now() - startedAt}`);
   }
 }
 
@@ -275,6 +303,8 @@ async function resolveOwnerAndDelegate(
   waitForApproval?: boolean,
   noTrack?: boolean,
 ): Promise<number | null> {
+  const startedAt = Date.now();
+  delegationClientLog(`resolveOwnerAndDelegate begin command=${args[0] ?? '<missing>'} noTrack=${noTrack ? 'true' : 'false'}`);
   let messageBus = deps.messageBus;
   const resolvedExitCode = (): number => {
     const exitCode = process.exitCode;
@@ -283,24 +313,41 @@ async function resolveOwnerAndDelegate(
 
   // Phase 1: Discover a standalone-capable owner
   const owner = await discoverOwner(messageBus, 3_000);
+  delegationClientLog(
+    `phase1 discover standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
+  );
   if (isStandaloneCapable(owner)) {
     if (await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+      delegationClientLog(`phase1 delegated successfully elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
+    delegationClientLog('phase1 owner found but delegation returned false');
   }
 
   // Phase 2: Try any reachable owner (may be non-standalone)
   if (isOwnerReachable(owner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+    delegationClientLog(`phase2 delegated to reachable owner ownerId=${owner.ownerId} elapsedMs=${Date.now() - startedAt}`);
     return resolvedExitCode();
+  }
+  if (isOwnerReachable(owner)) {
+    delegationClientLog(`phase2 reachable owner did not accept delegation ownerId=${owner.ownerId}`);
+  } else {
+    delegationClientLog('phase2 skipped: no reachable owner');
   }
 
   // Phase 3: Refresh and retry against any reachable owner
   if (isOwnerReachable(owner) && deps.refreshMessageBus) {
+    delegationClientLog('phase3 refreshing message bus');
     messageBus = await deps.refreshMessageBus();
     const refreshedOwner = await discoverOwner(messageBus, 1_000);
+    delegationClientLog(
+      `phase3 discover ownerReachable=${isOwnerReachable(refreshedOwner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(refreshedOwner) ? 'true' : 'false'} ownerId=${refreshedOwner?.ownerId ?? '<none>'}`,
+    );
     if (isOwnerReachable(refreshedOwner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+      delegationClientLog(`phase3 delegated successfully elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
+    delegationClientLog('phase3 delegation did not succeed');
   }
 
   // Phase 4: Bootstrap with retry loop (delegated to resolver pattern)
@@ -308,6 +355,7 @@ async function resolveOwnerAndDelegate(
     messageBus = await deps.refreshMessageBus();
   }
   for (let attempt = 0; attempt < POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS; attempt += 1) {
+    delegationClientLog(`phase4 bootstrap attempt=${attempt + 1}/${POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS}`);
     try {
       await deps.ensureStandaloneOwner(messageBus);
     } catch (err) {
@@ -317,6 +365,7 @@ async function resolveOwnerAndDelegate(
       if (!deps.refreshMessageBus) {
         throw err;
       }
+      delegationClientLog(`phase4 bootstrap timeout; refreshing bus and retrying attempt=${attempt + 1}`);
       messageBus = await deps.refreshMessageBus();
       await deps.ensureStandaloneOwner(messageBus);
     }
@@ -324,6 +373,7 @@ async function resolveOwnerAndDelegate(
       messageBus = await deps.refreshMessageBus();
     }
     if (await delegateAfterBootstrap(args, deps, messageBus, waitForApproval, noTrack)) {
+      delegationClientLog(`phase4 delegated successfully attempt=${attempt + 1} elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
     if (!deps.refreshMessageBus) {
@@ -332,6 +382,7 @@ async function resolveOwnerAndDelegate(
     messageBus = await deps.refreshMessageBus();
   }
 
+  delegationClientLog(`resolveOwnerAndDelegate failed after elapsedMs=${Date.now() - startedAt}`);
   return null; // Could not resolve
 }
 

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -15,6 +15,14 @@ type DelegateTrackingOptions = {
   timeoutMs?: number;
 };
 
+function delegationLog(message: string): void {
+  process.stderr.write(`[delegation] ${message}\n`);
+}
+
+function createTraceId(channel: string): string {
+  return `${channel}:${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2, 8)}`;
+}
+
 export async function tryDelegateRun(
   planPath: string,
   messageBus: MessageBus,
@@ -22,9 +30,10 @@ export async function tryDelegateRun(
   noTrack?: boolean,
   timeoutMs?: number,
 ): Promise<boolean> {
+  const traceId = createTraceId('headless.run');
   return tryDelegate(
     'headless.run',
-    { planPath: resolvePath(planPath) },
+    { planPath: resolvePath(planPath), traceId },
     messageBus,
     { waitForApproval, noTrack, timeoutMs: timeoutMs ?? 5_000 },
   );
@@ -37,9 +46,10 @@ export async function tryDelegateResume(
   noTrack?: boolean,
   timeoutMs?: number,
 ): Promise<boolean> {
+  const traceId = createTraceId('headless.resume');
   return tryDelegate(
     'headless.resume',
-    { workflowId },
+    { workflowId, traceId },
     messageBus,
     { waitForApproval, noTrack, timeoutMs: timeoutMs ?? 5_000 },
   );
@@ -85,9 +95,10 @@ export async function tryDelegateExec(
   timeoutMs?: number,
 ): Promise<boolean> {
   const resolvedTimeoutMs = timeoutMs ?? await resolveDelegationTimeoutMs(args);
+  const traceId = createTraceId('headless.exec');
   return tryDelegate(
     'headless.exec',
-    { args, waitForApproval, noTrack },
+    { args, waitForApproval, noTrack, traceId },
     messageBus,
     { waitForApproval, noTrack, timeoutMs: resolvedTimeoutMs },
   );
@@ -97,6 +108,7 @@ export async function tryPingHeadlessOwner(
   messageBus: MessageBus,
   timeoutMs = 1_000,
 ): Promise<{ ownerId?: string; mode?: string } | null> {
+  const traceId = createTraceId('headless.owner-ping');
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
@@ -105,16 +117,26 @@ export async function tryPingHeadlessOwner(
   });
 
   try {
+    const startedAt = Date.now();
+    delegationLog(`${traceId} send timeoutMs=${timeoutMs}`);
     const response = await Promise.race([
       messageBus.request('headless.owner-ping', {}),
       timeoutPromise,
     ]) as { ownerId?: string; mode?: string };
+    delegationLog(
+      `${traceId} response elapsedMs=${Date.now() - startedAt} ownerId=${response.ownerId ?? '<missing>'} mode=${response.mode ?? '<missing>'}`,
+    );
     return response;
   } catch (err) {
-    if (err === DELEGATION_TIMEOUT) return null;
-    if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+    if (err === DELEGATION_TIMEOUT) {
+      delegationLog(`${traceId} timeout timeoutMs=${timeoutMs}`);
       return null;
     }
+    if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+      delegationLog(`${traceId} no-handler`);
+      return null;
+    }
+    delegationLog(`${traceId} error ${(err instanceof Error ? err.message : String(err))}`);
     throw err;
   } finally {
     if (timeoutHandle) clearTimeout(timeoutHandle);
@@ -134,6 +156,7 @@ export async function tryDelegateQuery(
   payload: Record<string, unknown>,
   timeoutMs = 5_000,
 ): Promise<Record<string, unknown> | null> {
+  const traceId = createTraceId('headless.query');
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<typeof DELEGATION_TIMEOUT>((_, reject) => {
@@ -142,16 +165,24 @@ export async function tryDelegateQuery(
   });
 
   try {
+    const startedAt = Date.now();
+    delegationLog(`${traceId} send payload=${JSON.stringify(payload)} timeoutMs=${timeoutMs}`);
     const response = await Promise.race([
       messageBus.request('headless.query', payload),
       timeoutPromise,
     ]) as Record<string, unknown>;
+    delegationLog(`${traceId} response elapsedMs=${Date.now() - startedAt}`);
     return response;
   } catch (err) {
-    if (err === DELEGATION_TIMEOUT) return null;
-    if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+    if (err === DELEGATION_TIMEOUT) {
+      delegationLog(`${traceId} timeout timeoutMs=${timeoutMs}`);
       return null;
     }
+    if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+      delegationLog(`${traceId} no-handler`);
+      return null;
+    }
+    delegationLog(`${traceId} error ${(err instanceof Error ? err.message : String(err))}`);
     throw err;
   } finally {
     if (timeoutHandle) clearTimeout(timeoutHandle);
@@ -164,6 +195,7 @@ async function tryDelegate(
   messageBus: MessageBus,
   options: DelegateTrackingOptions,
 ): Promise<boolean> {
+  const traceId = (payload as { traceId?: string })?.traceId ?? createTraceId(channel);
   let targetWorkflowId: string | undefined;
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
   let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
@@ -174,17 +206,23 @@ async function tryDelegate(
 
   let response: { workflowId: string; tasks: TaskState[] } | { ok: true };
   try {
+    const startedAt = Date.now();
+    delegationLog(`${traceId} send channel=${channel} timeoutMs=${options.timeoutMs ?? 5_000}`);
     response = await Promise.race([
       messageBus.request<typeof payload, typeof response>(channel, payload),
       timeoutPromise,
     ]) as { workflowId: string; tasks: TaskState[] } | { ok: true };
+    delegationLog(`${traceId} response channel=${channel} elapsedMs=${Date.now() - startedAt}`);
   } catch (err) {
     if (err === DELEGATION_TIMEOUT) {
+      delegationLog(`${traceId} timeout channel=${channel} timeoutMs=${options.timeoutMs ?? 5_000}`);
       return false;
     }
     if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+      delegationLog(`${traceId} no-handler channel=${channel}`);
       return false;
     }
+    delegationLog(`${traceId} error channel=${channel} ${(err instanceof Error ? err.message : String(err))}`);
     throw err;
   } finally {
     if (timeoutHandle) clearTimeout(timeoutHandle);

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -122,7 +122,11 @@ export async function tryPingHeadlessOwner(
     const response = await Promise.race([
       messageBus.request('headless.owner-ping', {}),
       timeoutPromise,
-    ]) as { ownerId?: string; mode?: string };
+    ]) as { ownerId?: string; mode?: string } | null;
+    if (!response || typeof response !== 'object') {
+      delegationLog(`${traceId} response elapsedMs=${Date.now() - startedAt} ownerId=<missing> mode=<missing>`);
+      return null;
+    }
     delegationLog(
       `${traceId} response elapsedMs=${Date.now() - startedAt} ownerId=${response.ownerId ?? '<missing>'} mode=${response.mode ?? '<missing>'}`,
     );

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1585,7 +1585,7 @@ if (isHeadless) {
     return taskExecutor;
   }
 
-  async function executeHeadlessRun(payload: HeadlessRunMutationPayload): Promise<unknown> {
+  async function executeHeadlessRun(payload: HeadlessRunMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
     const { parsePlanFile } = await import('./plan-parser.js');
     const plan = await parsePlanFile(payload.planPath);
     taskHandles.clear();
@@ -1599,7 +1599,7 @@ if (isHeadless) {
     return { workflowId, tasks };
   }
 
-  async function executeHeadlessResume(payload: HeadlessResumeMutationPayload): Promise<unknown> {
+  async function executeHeadlessResume(payload: HeadlessResumeMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
     const { workflowId } = payload;
     orchestrator.syncFromDb(workflowId);
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -227,16 +227,19 @@ interface GuiMutationPayload {
 
 interface HeadlessRunMutationPayload {
   planPath: string;
+  traceId?: string;
 }
 
 interface HeadlessResumeMutationPayload {
   workflowId: string;
+  traceId?: string;
 }
 
 interface HeadlessExecMutationPayload {
   args: string[];
   waitForApproval?: boolean;
   noTrack?: boolean;
+  traceId?: string;
 }
 
 // Root logger: created early in initServices() once persistence is available.
@@ -345,7 +348,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
   const dbPath = path.join(invokerHomeRoot, 'invoker.db');
   ensureSqliteFlushDebounceForOwner(process.env, readOnly);
   if (!readOnly) {
-    writerLock = acquireDbWriterLock(dbPath);
+    writerLock = acquireDbWriterLock(dbPath, `main:initServices pid=${process.pid}`);
   }
   persistence = await SQLiteAdapter.create(dbPath, {
     readOnly,
@@ -954,8 +957,17 @@ if (isHeadless) {
 
         messageBus.onRequest('headless.run', async (req: unknown) => {
           noteStandaloneOwnerActivity();
-          const { planPath } = req as { planPath: string };
-          return executeStandaloneHeadlessRun({ planPath });
+          const { planPath, traceId } = req as { planPath: string; traceId?: string };
+          logger.info(
+            `headless.run received trace=${traceId ?? '<none>'} planPath="${planPath}" ownerId=${workflowMutationOwnerId} mode=standalone`,
+            { module: 'ipc-delegate' },
+          );
+          const result = await executeStandaloneHeadlessRun({ planPath });
+          logger.info(
+            `headless.run accepted trace=${traceId ?? '<none>'} workflow="${result.workflowId}" tasks=${result.tasks.length} mode=standalone`,
+            { module: 'ipc-delegate' },
+          );
+          return result;
         });
         messageBus.onRequest('headless.owner-ping', async () => {
           noteStandaloneOwnerActivity();
@@ -984,26 +996,44 @@ if (isHeadless) {
         });
         messageBus.onRequest('headless.resume', async (req: unknown) => {
           noteStandaloneOwnerActivity();
-          const { workflowId } = req as { workflowId: string };
-          return executeStandaloneHeadlessResume({ workflowId });
+          const { workflowId, traceId } = req as { workflowId: string; traceId?: string };
+          logger.info(
+            `headless.resume received trace=${traceId ?? '<none>'} workflowId="${workflowId}" ownerId=${workflowMutationOwnerId} mode=standalone`,
+            { module: 'ipc-delegate' },
+          );
+          const result = await executeStandaloneHeadlessResume({ workflowId });
+          logger.info(
+            `headless.resume accepted trace=${traceId ?? '<none>'} workflow="${result.workflowId}" tasks=${result.tasks.length} mode=standalone`,
+            { module: 'ipc-delegate' },
+          );
+          return result;
         });
         messageBus.onRequest('headless.exec', async (req: unknown) => {
           noteStandaloneOwnerActivity();
-          const { args, waitForApproval: delegatedWait, noTrack: delegatedNoTrack } =
-            req as { args: string[]; waitForApproval?: boolean; noTrack?: boolean };
+          const { args, waitForApproval: delegatedWait, noTrack: delegatedNoTrack, traceId } =
+            req as { args: string[]; waitForApproval?: boolean; noTrack?: boolean; traceId?: string };
           if (!Array.isArray(args) || args.length === 0) {
             throw new Error('Missing delegated headless command arguments');
           }
+          logger.info(
+            `headless.exec received trace=${traceId ?? '<none>'} args="${args.join(' ')}" ownerId=${workflowMutationOwnerId} mode=standalone`,
+            { module: 'ipc-delegate' },
+          );
           const payload: HeadlessExecMutationPayload = {
             args,
             waitForApproval: delegatedWait,
             noTrack: delegatedNoTrack,
+            traceId,
           };
           const { workflowId, priority } = classifyStandaloneHeadlessExecMutation(payload);
           if (delegatedNoTrack && workflowId && workflowMutationCoordinator) {
             const intentId = workflowMutationCoordinator.submit(workflowId, priority, 'headless.exec', [payload], {
               deferDrain: true,
             });
+            logger.info(
+              `headless.exec accepted trace=${traceId ?? '<none>'} workflow="${workflowId}" intent=${intentId} noTrack=true priority=${priority} mode=standalone`,
+              { module: 'ipc-delegate' },
+            );
             return { ok: true, intentId };
           }
           await runStandaloneWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => {
@@ -2410,28 +2440,48 @@ if (isHeadless) {
         throw new Error(`Unsupported headless query: ${String(kind)}`);
       });
       messageBus.onRequest('headless.run', async (req: unknown) => {
-        const { planPath } = req as { planPath: string };
-        logger.info(`headless.run: "${planPath}"`, { module: 'ipc-delegate' });
-        return executeHeadlessRun({ planPath });
+        const { planPath, traceId } = req as { planPath: string; traceId?: string };
+        logger.info(
+          `headless.run received trace=${traceId ?? '<none>'} planPath="${planPath}" ownerId=${workflowMutationOwnerId} mode=gui`,
+          { module: 'ipc-delegate' },
+        );
+        const result = await executeHeadlessRun({ planPath });
+        logger.info(
+          `headless.run accepted trace=${traceId ?? '<none>'} workflow="${result.workflowId}" tasks=${result.tasks.length} mode=gui`,
+          { module: 'ipc-delegate' },
+        );
+        return result;
       });
 
       messageBus.onRequest('headless.resume', async (req: unknown) => {
-        const { workflowId } = req as { workflowId: string };
-        logger.info(`headless.resume: "${workflowId}"`, { module: 'ipc-delegate' });
-        return executeHeadlessResume({ workflowId });
+        const { workflowId, traceId } = req as { workflowId: string; traceId?: string };
+        logger.info(
+          `headless.resume received trace=${traceId ?? '<none>'} workflowId="${workflowId}" ownerId=${workflowMutationOwnerId} mode=gui`,
+          { module: 'ipc-delegate' },
+        );
+        const result = await executeHeadlessResume({ workflowId });
+        logger.info(
+          `headless.resume accepted trace=${traceId ?? '<none>'} workflow="${result.workflowId}" tasks=${result.tasks.length} mode=gui`,
+          { module: 'ipc-delegate' },
+        );
+        return result;
       });
 
       messageBus.onRequest('headless.exec', async (req: unknown) => {
-        const { args, waitForApproval: delegatedWait, noTrack: delegatedNoTrack } =
-          req as { args: string[]; waitForApproval?: boolean; noTrack?: boolean };
+        const { args, waitForApproval: delegatedWait, noTrack: delegatedNoTrack, traceId } =
+          req as { args: string[]; waitForApproval?: boolean; noTrack?: boolean; traceId?: string };
         if (!Array.isArray(args) || args.length === 0) {
           throw new Error('Missing delegated headless command arguments');
         }
-        logger.info(`headless.exec: "${args.join(' ')}"`, { module: 'ipc-delegate' });
+        logger.info(
+          `headless.exec received trace=${traceId ?? '<none>'} args="${args.join(' ')}" ownerId=${workflowMutationOwnerId} mode=gui`,
+          { module: 'ipc-delegate' },
+        );
         const payload: HeadlessExecMutationPayload = {
           args,
           waitForApproval: delegatedWait,
           noTrack: delegatedNoTrack,
+          traceId,
         };
         const { workflowId, priority } = classifyHeadlessExecMutation(payload);
         if (delegatedNoTrack && workflowId && workflowMutationCoordinator) {
@@ -2439,7 +2489,7 @@ if (isHeadless) {
             deferDrain: true,
           });
           logger.info(
-            `headless.exec accepted workflow="${workflowId}" intent=${intentId} noTrack=true priority=${priority}`,
+            `headless.exec accepted trace=${traceId ?? '<none>'} workflow="${workflowId}" intent=${intentId} noTrack=true priority=${priority} mode=gui`,
             { module: 'ipc-delegate' },
           );
           return { ok: true, intentId };

--- a/scripts/submit-workflow-chain.sh
+++ b/scripts/submit-workflow-chain.sh
@@ -40,6 +40,15 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
+now_ms() {
+  date +%s%3N
+}
+
+log_chain() {
+  local msg="$1"
+  echo "[submit-workflow-chain] ${msg}"
+}
+
 resolve_abs() {
   local p="$1"
   cd "$(dirname "$p")" && pwd
@@ -87,25 +96,35 @@ matches_pattern() {
 resolve_persisted_workflow_id() {
   local workflow_name="$1"
   local wf_id=""
+  local start_ms
+  start_ms="$(now_ms)"
+  local attempt=0
   for _ in $(seq 1 30); do
+    attempt=$((attempt + 1))
     wf_id="$(
       ./run.sh --headless query workflows --output json 2>/dev/null \
         | extract_json_stream \
         | jq -r --arg n "$workflow_name" '[.[] | select(.name == $n)] | sort_by(.createdAt) | last | .id // empty'
     )"
     if [[ -n "$wf_id" ]]; then
+      log_chain "resolve_persisted_workflow_id name=\"$workflow_name\" found=\"$wf_id\" attempt=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
       printf '%s' "$wf_id"
       return 0
     fi
     sleep 0.2
   done
+  log_chain "resolve_persisted_workflow_id name=\"$workflow_name\" failed attempts=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
   return 1
 }
 
 resolve_workflow_feature_branch() {
   local workflow_id="$1"
   local feature_branch=""
+  local start_ms
+  start_ms="$(now_ms)"
+  local attempt=0
   for _ in $(seq 1 30); do
+    attempt=$((attempt + 1))
     feature_branch="$(
       ./run.sh --headless query workflows --output json 2>/dev/null \
         | extract_json_stream \
@@ -113,23 +132,31 @@ resolve_workflow_feature_branch() {
         | head -1
     )"
     if [[ -n "$feature_branch" ]]; then
+      log_chain "resolve_workflow_feature_branch workflowId=\"$workflow_id\" feature=\"$feature_branch\" attempt=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
       printf '%s' "$feature_branch"
       return 0
     fi
     sleep 0.2
   done
+  log_chain "resolve_workflow_feature_branch workflowId=\"$workflow_id\" failed attempts=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
   return 1
 }
 
 wait_for_external_merge_gate() {
   local workflow_id="$1"
   local merge_id="__merge__${workflow_id}"
+  local start_ms
+  start_ms="$(now_ms)"
+  local attempt=0
   for _ in $(seq 1 60); do
+    attempt=$((attempt + 1))
     if ./run.sh --headless query tasks --output json 2>/dev/null | extract_json_stream | jq -e --arg id "$merge_id" '.[] | select(.id == $id)' >/dev/null; then
+      log_chain "wait_for_external_merge_gate mergeTaskId=\"$merge_id\" found attempt=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
       return 0
     fi
     sleep 0.2
   done
+  log_chain "wait_for_external_merge_gate mergeTaskId=\"$merge_id\" timeout attempts=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
   return 1
 }
 
@@ -151,7 +178,10 @@ declare -a RENDERED_PLANS=()
 
 # Sync fork with upstream if any plan in the chain targets EdbertChan/Invoker.
 for p in "${INPUT_PLANS[@]}"; do
+  log_chain "sync-fork-upstream begin plan=\"$p\""
+  sync_start_ms="$(now_ms)"
   bash "$REPO_ROOT/scripts/sync-fork-upstream.sh" "$p" || true
+  log_chain "sync-fork-upstream end elapsedMs=$(( $(now_ms) - sync_start_ms ))"
   break  # only need to sync once; first plan determines the repo
 done
 
@@ -287,10 +317,13 @@ for i in "${!INPUT_PLANS[@]}"; do
   fi
 
   echo "Submitting workflow $((i+1)) (no track): $submit_plan"
+  run_start_ms="$(now_ms)"
+  log_chain "headless-run begin step=$((i+1)) plan=\"$submit_plan\" noTrack=true"
   _chain_out="$(mktemp "${TMPDIR:-/tmp}/invoker-chain-out$((i+1)).XXXXXX")"
   out_file="${_chain_out}.log"
   rm -f "$_chain_out"
   ./run.sh --headless run "$submit_plan" --no-track >"$out_file" 2>&1 || true
+  log_chain "headless-run end step=$((i+1)) elapsedMs=$(( $(now_ms) - run_start_ms )) out=\"$out_file\""
 
   printed_id="$(awk '/Workflow ID:/{print $3}' "$out_file" | tail -1)"
   delegated_id="$(sed -n 's/.*workflow: \(wf-[0-9]\+-[0-9]\+\).*/\1/p' "$out_file" | tail -1)"

--- a/scripts/submit-workflow-chain.sh
+++ b/scripts/submit-workflow-chain.sh
@@ -107,13 +107,13 @@ resolve_persisted_workflow_id() {
         | jq -r --arg n "$workflow_name" '[.[] | select(.name == $n)] | sort_by(.createdAt) | last | .id // empty'
     )"
     if [[ -n "$wf_id" ]]; then
-      log_chain "resolve_persisted_workflow_id name=\"$workflow_name\" found=\"$wf_id\" attempt=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
+      log_chain "resolve_persisted_workflow_id name=\"$workflow_name\" found=\"$wf_id\" attempt=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))" >&2
       printf '%s' "$wf_id"
       return 0
     fi
     sleep 0.2
   done
-  log_chain "resolve_persisted_workflow_id name=\"$workflow_name\" failed attempts=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
+  log_chain "resolve_persisted_workflow_id name=\"$workflow_name\" failed attempts=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))" >&2
   return 1
 }
 
@@ -132,13 +132,13 @@ resolve_workflow_feature_branch() {
         | head -1
     )"
     if [[ -n "$feature_branch" ]]; then
-      log_chain "resolve_workflow_feature_branch workflowId=\"$workflow_id\" feature=\"$feature_branch\" attempt=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
+      log_chain "resolve_workflow_feature_branch workflowId=\"$workflow_id\" feature=\"$feature_branch\" attempt=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))" >&2
       printf '%s' "$feature_branch"
       return 0
     fi
     sleep 0.2
   done
-  log_chain "resolve_workflow_feature_branch workflowId=\"$workflow_id\" failed attempts=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))"
+  log_chain "resolve_workflow_feature_branch workflowId=\"$workflow_id\" failed attempts=${attempt} elapsedMs=$(( $(now_ms) - start_ms ))" >&2
   return 1
 }
 

--- a/scripts/test-submit-workflow-chain.sh
+++ b/scripts/test-submit-workflow-chain.sh
@@ -7,7 +7,9 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 mkdir -p "$TMP_DIR/scripts" "$TMP_DIR/plans"
 cp "$ROOT/scripts/submit-workflow-chain.sh" "$TMP_DIR/scripts/submit-workflow-chain.sh"
+cp "$ROOT/scripts/sync-fork-upstream.sh" "$TMP_DIR/scripts/sync-fork-upstream.sh"
 chmod +x "$TMP_DIR/scripts/submit-workflow-chain.sh"
+chmod +x "$TMP_DIR/scripts/sync-fork-upstream.sh"
 
 cat > "$TMP_DIR/run.sh" <<'EOF'
 #!/usr/bin/env bash


### PR DESCRIPTION
## Summary
- add stage-duration instrumentation to `scripts/submit-workflow-chain.sh` so sync, submit, and polling loops are externally visible
- add detailed delegation lifecycle logging in headless client/delegation paths, including timeout/no-handler/error outcomes and per-request trace IDs
- log owner-side receipt/acceptance for `headless.run`, `headless.resume`, and `headless.exec`, and include caller context in DB writer-lock acquisition failures

## Test plan
- [x] Run lints on edited TypeScript files and confirm no diagnostics were introduced
- [ ] Rebuild/restart app and execute `submit-workflow-chain.sh` to validate end-to-end trace correlation in logs

Made with [Cursor](https://cursor.com)