### PR TITLE
Enforce dependency-first layered decomposition in plan-to-invoker

### DIFF
--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -25,6 +25,10 @@ Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b 
 
 **Delegated task hints (best effort):** When authoring tasks, consider adding `Files:`, `Change types:`, and `Acceptance criteria:` blocks in each task `description` to help handoff to another agent—lists reflect what you know **at planning time** and can be updated (`TBD`, follow-on tasks) as scope grows. **Not** required for `skill-doctor` to pass. See `references/task-patterns.md` § *Delegated execution hints*.
 
+**Dependency-first layered decomposition (required for implementation plans):** For plans whose `onFinish` is not `none`, every implementation task must include `Layer:` and `Feature state:` headings in `description`. Use normalized layer names (`persistence`, `domain`, `transport`, `api`, `contact_surface`, `app_bridge`, `owner_delegation`, `ui_activation`, `app_regression`, `e2e_regression`, `ui`, `docs`) and feature state values (`active` or `dormant`). `dormant` tasks must still include `Acceptance criteria:` in `description`. Verify-only plans (`onFinish: none`) are exempt from this hard requirement.
+
+**Cross-layer dependency direction (required):** Dependency DAGs must flow from lower/foundational layers toward higher/integration layers. If a lower-layer task depends on a higher-layer task, mark an explicit exception in the task description with `Layer exception: allowed` and a rationale.
+
 **Bugfix repro:** For bug/regression plans, a shared `bash scripts/repro-<slug>.sh` (or the same `command:` before and after) is **strongly recommended**; **`skill-doctor` does not require it.** If the fix invalidates the original repro, use another explicit verification task. See `references/task-patterns.md` § *Bugfix repro*.
 
 **Invoker dogfooding rule:** When the target repo is Invoker itself (`EdbertChan/Invoker` or the upstream `Neko-Catpital-Labs/Invoker`), be explicit that GitHub PR publishing should use **Mergify Stacks** after the work is ready: keep `onFinish: pull_request` + `mergeMode: github`, then publish/update the resulting commit stack with `mergify stack push`. Do **not** generalize this to unrelated target repos; for example, `EdbertChan/test-playground` should keep normal PR flow unless that repo independently adopts Mergify Stacks. For the actual PR authoring/publication step after implementation work is ready, use the `make-pr` skill.
@@ -70,7 +74,7 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
    `bash skills/plan-to-invoker/scripts/validate-plan.sh <plan-file>`
 4. `step-lint-atomicity`
    `bash skills/plan-to-invoker/scripts/lint-task-atomicity.sh <plan-file>`  
-   Optional (warnings only, exit 0): append `--warn-delegation` for **best-effort** hints if `Files:` / `Change types:` / `Acceptance criteria:` are missing in descriptions.
+   Optional (warnings only, exit 0): append `--warn-delegation` for **best-effort** hints if `Files:` / `Change types:` / `Acceptance criteria:` are missing in descriptions. For implementation plans (`onFinish != none`), this step now hard-fails missing/invalid `Layer:` and `Feature state:` metadata and rejects invalid cross-layer dependency direction without `Layer exception: allowed`.
 5. `step-parse-verify-results`
    `bash skills/plan-to-invoker/scripts/parse-results.sh < /tmp/invoker-verify.txt`
 

--- a/skills/plan-to-invoker/fixtures/README.md
+++ b/skills/plan-to-invoker/fixtures/README.md
@@ -34,6 +34,7 @@ Positive fixtures demonstrate valid plan patterns:
 - **02-feature-implementation.yaml** - Standard implement → test → verify pattern
 - **03-multi-step-refactor-worktrees.yaml** - Multi-step refactor using worktrees
 - **04-large-refactor-pull-request.yaml** - Complex plan with diamond dependencies and `onFinish: pull_request`
+- **07-prompt-edit-layered-split-with-dormant.yaml** - Dependency-first layer split for prompt-edit bridge work, including a dormant activation slice
 
 All positive fixtures are extracted from `references/examples.md` sections 1-4.
 
@@ -49,6 +50,8 @@ Negative fixtures demonstrate anti-patterns and validation errors:
 - **anti-pattern-d-missing-dependencies.yaml** - Task missing dependencies field (missing_required_field)
 - **anti-pattern-e-no-verification.yaml** - Implementation without verification (policy violation)
 - **anti-pattern-f-dangerous-commands.yaml** - Dangerous commands (rm -rf, force push, etc.)
+- **anti-pattern-g-monolithic-prompt-edit-bridge.yaml** - Monolithic `wf-1777929074509-8`-shaped workflow missing required layer/state decomposition metadata (**fails `skill-doctor` lint, not YAML schema**)
+- **anti-pattern-h-layer-order-violation.yaml** - Lower architectural layer depends on a higher layer without `Layer exception: allowed` (**fails `skill-doctor` lint, not YAML schema**)
 
 ### Edge Cases (specific validation errors)
 

--- a/skills/plan-to-invoker/fixtures/negative/anti-pattern-g-monolithic-prompt-edit-bridge.yaml
+++ b/skills/plan-to-invoker/fixtures/negative/anti-pattern-g-monolithic-prompt-edit-bridge.yaml
@@ -1,0 +1,40 @@
+# Anti-Pattern G: Monolithic prompt-edit bridge workflow (wf-1777929074509-8 shape)
+# Source: dependency-first layered decomposition benchmark
+# Expected outcome: validate-plan passes schema, but skill-doctor fails lint-task-atomicity
+# due to missing Layer:/Feature state: metadata and poor review decomposition.
+
+name: "Anti-pattern: monolithic GUI prompt edit bridge"
+description: |
+  Mirrors the oversized shape of wf-1777929074509-8 as one implementation workflow.
+  This should now fail decomposition lint because implementation tasks must include
+  Layer and Feature state metadata and be split into reviewable dependency slices.
+onFinish: pull_request
+mergeMode: github
+repoUrl: https://github.com/EdbertChan/Invoker
+baseBranch: master
+featureBranch: plan/anti-pattern-monolithic-prompt-edit-bridge
+
+tasks:
+  - id: implement-entire-prompt-edit-stack
+    description: |
+      Add renderer callback wiring, IPC bridge registration, owner delegation behavior,
+      TaskPanel activation behavior, and all regressions in one large task.
+      Files:
+      - packages/app/src/main.ts
+      - packages/app/src/preload.ts
+      - packages/ui/src/components/TaskPanel.tsx
+      - packages/app/e2e/prompt-edit.spec.ts
+      Change types:
+      - modify
+      Acceptance criteria:
+      - cd packages/app && pnpm test exits 0.
+    prompt: |
+      Modify packages/app/src/main.ts, packages/app/src/preload.ts,
+      packages/ui/src/components/TaskPanel.tsx, and packages/app/e2e/prompt-edit.spec.ts.
+      Implement the entire GUI prompt-edit flow end to end in one task. Modify
+      the renderer callback surface, bridge it to IPC handlers, route through owner
+      delegation in the app layer, activate TaskPanel prompt editing UX, and add
+      both app-level and end-to-end regressions. Keep behavior aligned with the
+      existing editTaskCommand path and ensure recreate semantics remain correct.
+      Verify all changed tests pass and that command editing behavior is unchanged.
+    dependencies: []

--- a/skills/plan-to-invoker/fixtures/negative/anti-pattern-h-layer-order-violation.yaml
+++ b/skills/plan-to-invoker/fixtures/negative/anti-pattern-h-layer-order-violation.yaml
@@ -1,0 +1,42 @@
+# Anti-Pattern H: Invalid cross-layer dependency direction
+# Expected outcome: skill-doctor fails lint-task-atomicity with a layer ordering violation.
+
+name: "Anti-pattern: lower layer depends on higher layer"
+description: |
+  Demonstrates a dependency direction violation where a foundational layer task
+  depends on a higher integration layer task without an explicit exception.
+onFinish: pull_request
+mergeMode: github
+repoUrl: https://github.com/EdbertChan/Invoker
+baseBranch: master
+featureBranch: plan/anti-pattern-layer-order-violation
+
+tasks:
+  - id: ui-activation-setup
+    description: |
+      Prepare UI activation behavior for prompt editing.
+      Layer: ui_activation
+      Feature state: active
+      Acceptance criteria:
+      - Ensure UI activation scaffolding is ready for downstream integration.
+    prompt: |
+      Modify packages/ui/src/components/TaskPanel.tsx to prepare prompt-edit
+      activation behavior and ensure the change preserves command-task editing
+      interactions. This task must remain UI-focused and provide a stable higher
+      layer surface that other tasks can consume in later workflow slices.
+    dependencies: []
+
+  - id: domain-contract-adjustment
+    description: |
+      Adjust domain-layer prompt-edit contract after UI activation.
+      Layer: domain
+      Feature state: active
+      Acceptance criteria:
+      - Ensure domain contract updates align with prompt-edit orchestration.
+    prompt: |
+      Modify packages/app/src/headless-delegation.ts and packages/app/src/main.ts
+      to refine domain-facing prompt-edit contracts. Ensure the change maintains
+      recreate semantics and uses explicit acceptance language for deterministic
+      review, while intentionally depending on the UI task to trigger a layer
+      ordering lint violation in this fixture.
+    dependencies: [ui-activation-setup]

--- a/skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml
@@ -1,0 +1,101 @@
+# Positive fixture: Dependency-first layered decomposition for prompt-edit bridge work
+# Source: wf-1777929074509-8 benchmark split
+# Pattern: contact surface -> app bridge/delegation -> ui activation -> app+e2e regressions
+
+name: "Prompt edit layered split with dormant activation"
+description: |
+  Demonstrates review-oriented decomposition for a large prompt-edit change by
+  enforcing dependency-first layering and explicit dormant feature scaffolding.
+onFinish: pull_request
+mergeMode: github
+repoUrl: https://github.com/EdbertChan/Invoker
+baseBranch: master
+featureBranch: plan/prompt-edit-layered-split-with-dormant
+
+tasks:
+  - id: prompt-edit-contact-surface
+    description: |
+      Define the renderer contact surface for prompt editing without activating UI behavior.
+      Layer: contact_surface
+      Feature state: active
+      Files:
+      - packages/app/src/preload.ts
+      - packages/ui/src/types/window-invoker.d.ts
+      Change types:
+      - modify
+      Acceptance criteria:
+      - Ensure renderer types compile and expose a typed editTaskPrompt callback.
+    prompt: |
+      Modify packages/app/src/preload.ts and packages/ui/src/types/window-invoker.d.ts.
+      Update the renderer contract so prompt tasks can call editTaskPrompt through
+      the existing window.invoker surface. Modify the preload and type declaration
+      layers to mirror existing command-edit shapes, and ensure the callback
+      signature carries workflowId, taskId, and prompt text safely. The result
+      must keep existing command-edit contracts intact and avoid enabling UI
+      activation behavior yet; this task is contract-only.
+    dependencies: []
+
+  - id: app-bridge-and-owner-delegation
+    description: |
+      Add app-layer IPC bridge and owner delegation routing for prompt edits.
+      Layer: app_bridge
+      Feature state: active
+      Files:
+      - packages/app/src/main.ts
+      - packages/app/src/headless-delegation.ts
+      Change types:
+      - modify
+      Acceptance criteria:
+      - Ensure GUI-origin prompt edits route through owner-aware app handlers.
+    prompt: |
+      Modify packages/app/src/main.ts and packages/app/src/headless-delegation.ts.
+      In the app layer, register IPC handlers for invoker:edit-task-prompt and
+      connect them to the existing commandService.editTaskPrompt pathway so
+      recreate semantics stay authoritative. Reuse owner delegation behavior from
+      existing mutation routes and ensure the bridge can execute when GUI owner
+      mode is active. Keep this task scoped to bridge and delegation plumbing;
+      do not activate TaskPanel inline editing behavior yet.
+    dependencies: [prompt-edit-contact-surface]
+
+  - id: ui-prompt-editing-activation
+    description: |
+      Prepare TaskPanel prompt editing activation behind a dormant rollout marker.
+      Layer: ui_activation
+      Feature state: dormant
+      Files:
+      - packages/ui/src/components/TaskPanel.tsx
+      Change types:
+      - modify
+      Acceptance criteria:
+      - Ensure dormant prompt-edit activation path is wired but not default-enabled.
+    prompt: |
+      Modify packages/ui/src/components/TaskPanel.tsx.
+      Update TaskPanel prompt text to use the shared inline editing control path
+      in a dormant activation state. Reuse command-edit UX primitives so behavior
+      remains consistent, but keep activation gated so this workflow only lands
+      dormant scaffolding. Ensure save handlers call the prompt-edit bridge path
+      when activated later and preserve existing command task editing interactions.
+    dependencies: [app-bridge-and-owner-delegation]
+
+  - id: app-and-e2e-regressions
+    description: |
+      Add app-level and Playwright regressions proving prompt edit flow is stable.
+      Layer: e2e_regression
+      Feature state: active
+      Files:
+      - packages/app/src/__tests__/main.prompt-edit.test.ts
+      - packages/app/e2e/prompt-edit.spec.ts
+      Change types:
+      - create
+      - modify
+      Acceptance criteria:
+      - Ensure app-level and end-to-end prompt-edit regressions pass in CI-style runs.
+    prompt: |
+      Modify packages/app/src/__tests__/main.prompt-edit.test.ts and packages/app/e2e/prompt-edit.spec.ts.
+      Add regression coverage that exercises the GUI prompt-edit bridge end to end.
+      Include at least one app-layer test validating IPC-to-commandService routing,
+      and one Playwright scenario that recreates a prompt task edit through the
+      TaskPanel flow. The regression suite must validate recreate semantics and
+      confirm no command-edit regressions. Ensure test naming and setup are
+      deterministic so this workflow can be reviewed as the final proof layer.
+    dependencies: [ui-prompt-editing-activation]

--- a/skills/plan-to-invoker/references/examples.md
+++ b/skills/plan-to-invoker/references/examples.md
@@ -53,6 +53,8 @@ Complex plan with diamond dependencies. Uses `onFinish: pull_request` for manual
 - `fixtures/negative/anti-pattern-d-missing-dependencies.yaml` — Dependencies field is required
 - `fixtures/negative/anti-pattern-e-no-verification.yaml` — Implementation tasks need verification
 - `fixtures/negative/anti-pattern-f-dangerous-commands.yaml` — Avoid destructive commands (`rm -rf`, force push)
+- `fixtures/negative/anti-pattern-g-monolithic-prompt-edit-bridge.yaml` — Monolithic `wf-1777929074509-8`-style workflow missing dependency-first layered decomposition metadata
+- `fixtures/negative/anti-pattern-h-layer-order-violation.yaml` — Lower layer depends on higher layer without `Layer exception: allowed`
 
 All anti-patterns are validated by `scripts/test-fixtures.sh` with deterministic error detection.
 
@@ -110,6 +112,24 @@ When the source is a policy or architecture document with a decision table, the 
 
 ---
 
+## 9. Dependency-first layered decomposition with dormant support
+
+Use this pattern when a change is too large for a single reviewable workflow. For implementation plans (`onFinish != none`), include task-level `Layer:` and `Feature state:` metadata, wire dependencies in layer order, and keep dormant work explicit.
+
+**See positive fixture**: `fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml`
+**See negative fixture**: `fixtures/negative/anti-pattern-g-monolithic-prompt-edit-bridge.yaml`
+
+**Pattern**:
+- Break monolithic prompt-edit changes into review slices:
+  1. contact surface
+  2. app bridge / owner delegation
+  3. ui activation
+  4. app + e2e regressions
+- Use `Feature state: dormant` for planned-but-not-activated tasks, but still include `Acceptance criteria:`.
+- Use dependencies to enforce order; if a lower layer must depend on a higher layer, include `Layer exception: allowed` and rationale.
+
+---
+
 ## Summary
 
 **Positive patterns**:
@@ -119,12 +139,14 @@ When the source is a policy or architecture document with a decision table, the 
 - Large refactors → `onFinish: pull_request`, diamond DAGs
 - Invoker-on-Invoker PR publication → keep `mergeMode: github`, then use `mergify stack push` as the repo-specific publication step
 - Policy matrix / architecture docs → preserve row-level coverage with `coverage-map.json` and `stack-manifest.json`
+- Dependency-first layered decomposition → enforce `Layer:` + `Feature state:` metadata, preserve dependency direction, allow explicit dormant tasks
 
 **Validation enforces**:
 - Every prompt task must have verification command task
 - Use `pnpm test`, never `npx vitest run`
 - Dependencies field required (even if empty)
 - No dangerous commands without manual approval
+- For implementation plans: `Layer:` + `Feature state:` headings, allowed values, and layer-consistent dependency direction
 
 **References**:
 - Fixture tests: `scripts/test-fixtures.sh`

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -39,6 +39,52 @@ These are constraints, not guidelines. Violating them produces broken plans.
 - **Independent files** → tasks creating/modifying unrelated files.
 - **All verification tasks** → file-existence and grep checks are read-only, run them all in parallel — **except** the final regression task, which must depend on implementation tasks (see above).
 
+## Layered decomposition contract (hard requirement for implementation plans)
+
+For plans with `onFinish` set to `pull_request` or `merge`, each task `description` must include:
+
+1. **`Layer:`** one of:
+   - `persistence`
+   - `domain`
+   - `transport`
+   - `api`
+   - `contact_surface`
+   - `app_bridge`
+   - `owner_delegation`
+   - `ui_activation`
+   - `app_regression`
+   - `e2e_regression`
+   - `ui`
+   - `docs`
+2. **`Feature state:`** one of:
+   - `active`
+   - `dormant`
+
+`onFinish: none` verify-only plans are exempt.
+
+### Cross-layer direction
+
+- Dependencies should flow from lower/foundational layers to higher/integration layers.
+- A lower-layer task depending on a higher-layer task is rejected unless the task includes:
+  - `Layer exception: allowed`
+  - a short rationale in the same description block.
+
+### Dormant tasks
+
+- `Feature state: dormant` tasks are valid and expected for staged rollouts.
+- Dormant tasks must still include **`Acceptance criteria:`** so review and verification remain objective.
+
+### Review decomposition benchmark
+
+Large prompt-edit style changes should split into dependency-ordered layer workflows:
+
+1. `contact surface`
+2. `app bridge` and `owner delegation`
+3. `ui activation`
+4. `app` + `e2e` regressions
+
+This split maps directly to review slices and should not be collapsed into one monolithic workflow.
+
 ## Sizing
 
 - **Target**: 3-8 tasks per plan.

--- a/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
+++ b/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
@@ -22,7 +22,47 @@ fi
 
 awk -v warnDelegation="$warn_delegation" '
 function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
-function flush_task(    wc, and_count, valid_id, d) {
+function strip_quotes(s) { gsub(/["'\''"]/, "", s); return s }
+function parse_metadata(desc_lower,    tmp, parts) {
+  layer = ""
+  feature_state = ""
+  layer_exception_allowed = 0
+  has_acceptance_criteria = (desc_lower ~ /acceptance criteria:/)
+
+  tmp = desc_lower
+  sub(/^.*layer:[ \t]*/, "", tmp)
+  if (tmp != desc_lower) {
+    split(tmp, parts, /[^a-z0-9_]/)
+    layer = parts[1]
+  }
+
+  tmp = desc_lower
+  sub(/^.*feature state:[ \t]*/, "", tmp)
+  if (tmp != desc_lower) {
+    split(tmp, parts, /[^a-z0-9_]/)
+    feature_state = parts[1]
+  }
+
+  if (desc_lower ~ /layer exception:[ \t]*allowed/) {
+    layer_exception_allowed = 1
+  }
+}
+function layer_rank(layer_name) {
+  if (layer_name == "persistence") return 10
+  if (layer_name == "domain") return 20
+  if (layer_name == "transport") return 30
+  if (layer_name == "api") return 40
+  if (layer_name == "contact_surface") return 45
+  if (layer_name == "app_bridge") return 50
+  if (layer_name == "owner_delegation") return 60
+  if (layer_name == "ui_activation") return 70
+  if (layer_name == "app_regression") return 80
+  if (layer_name == "e2e_regression") return 90
+  if (layer_name == "ui") return 100
+  if (layer_name == "docs") return 110
+  return 0
+}
+function flush_task(    wc, and_count, valid_id, d, desc_lower, idx) {
   if (!in_task) return
 
   if (id == "") {
@@ -72,8 +112,29 @@ function flush_task(    wc, and_count, valid_id, d) {
     }
   }
 
+  desc_lower = tolower(desc)
+  parse_metadata(desc_lower)
+
+  if (enforce_layering == 1) {
+    if (layer == "") {
+      errors[++errn] = "Task \"" id "\" missing required \"Layer:\" heading in description (implementation plans require layer metadata)"
+    } else if (layer_rank(layer) == 0) {
+      errors[++errn] = "Task \"" id "\" has invalid Layer \"" layer "\"; expected one of: persistence, domain, transport, api, contact_surface, app_bridge, owner_delegation, ui_activation, app_regression, e2e_regression, ui, docs"
+    }
+
+    if (feature_state == "") {
+      errors[++errn] = "Task \"" id "\" missing required \"Feature state:\" heading in description (expected active or dormant)"
+    } else if (feature_state != "active" && feature_state != "dormant") {
+      errors[++errn] = "Task \"" id "\" has invalid Feature state \"" feature_state "\"; expected active or dormant"
+    }
+
+    if (feature_state == "dormant" && has_acceptance_criteria == 0) {
+      errors[++errn] = "Task \"" id "\" uses Feature state dormant but omits \"Acceptance criteria:\" in description"
+    }
+  }
+
   if (warnDelegation == 1 && desc != "") {
-    d = tolower(desc)
+    d = desc_lower
     if (d !~ /files:/) {
       warnings[++warnn] = "Delegation hint: task \"" id "\" description has no \"Files:\" heading (optional; best-effort)"
     }
@@ -84,33 +145,80 @@ function flush_task(    wc, and_count, valid_id, d) {
       warnings[++warnn] = "Delegation hint: task \"" id "\" description has no \"Acceptance criteria:\" heading (optional; best-effort)"
     }
   }
+
+  idx = ++taskn
+  task_ids[idx] = id
+  task_layers[idx] = layer
+  task_feature_states[idx] = feature_state
+  task_layer_exceptions[idx] = layer_exception_allowed
+  task_dependencies[idx] = dependencies_csv
+  task_id_to_index[id] = idx
 }
 
 BEGIN {
   in_task = 0
+  in_dep_block = 0
+  in_description_block = 0
   in_prompt_block = 0
   errn = 0
   warnn = 0
+  taskn = 0
+  on_finish = "pull_request"
+  enforce_layering = 1
 }
 
 {
   line = $0
 
+  if (!in_task && line ~ /^[[:space:]]*onFinish:[[:space:]]*/) {
+    on_finish = line
+    sub(/^[[:space:]]*onFinish:[[:space:]]*/, "", on_finish)
+    on_finish = trim(strip_quotes(on_finish))
+    enforce_layering = (tolower(on_finish) != "none")
+    next
+  }
+
+  if (in_description_block) {
+    # Note: mawk does not support {6,} bounded quantifiers; use explicit 6 spaces + *
+    if (line ~ /^[[:space:]][[:space:]][[:space:]][[:space:]][[:space:]][[:space:]]*[^[:space:]]/) {
+      desc = desc "\n" trim(line)
+      next
+    }
+    in_description_block = 0
+  }
+
+  if (in_dep_block) {
+    # Note: mawk does not support {6,} bounded quantifiers; use explicit 6 spaces + *
+    if (line ~ /^[[:space:]][[:space:]][[:space:]][[:space:]][[:space:]][[:space:]]*-[[:space:]]*[^[:space:]]/) {
+      dep = line
+      sub(/^[[:space:]][[:space:]][[:space:]][[:space:]][[:space:]][[:space:]]*-[[:space:]]*/, "", dep)
+      dep = trim(strip_quotes(dep))
+      if (dep != "") {
+        if (dependencies_csv != "") dependencies_csv = dependencies_csv ","
+        dependencies_csv = dependencies_csv dep
+      }
+      next
+    }
+    in_dep_block = 0
+  }
+
   if (line ~ /^[[:space:]]*-[[:space:]]+id:[[:space:]]*/) {
     flush_task()
     in_task = 1
+    in_dep_block = 0
+    in_description_block = 0
     in_prompt_block = 0
 
     id = line
     sub(/^[[:space:]]*-[[:space:]]+id:[[:space:]]*/, "", id)
-    gsub(/["'\''"]/, "", id)
-    id = trim(id)
+    id = trim(strip_quotes(id))
 
     desc = ""
     has_command = 0
     has_prompt = 0
     command_line = ""
     prompt_text = ""
+    dependencies_csv = ""
     next
   }
 
@@ -119,8 +227,11 @@ BEGIN {
   if (line ~ /^[[:space:]]+description:[[:space:]]*/) {
     desc = line
     sub(/^[[:space:]]+description:[[:space:]]*/, "", desc)
-    gsub(/["'\''"]/, "", desc)
-    desc = trim(desc)
+    desc = trim(strip_quotes(desc))
+    if (desc == "|" || desc == ">") {
+      desc = ""
+      in_description_block = 1
+    }
     next
   }
 
@@ -130,6 +241,28 @@ BEGIN {
     sub(/^[[:space:]]+command:[[:space:]]*/, "", command_line)
     command_line = trim(command_line)
     in_prompt_block = 0
+    next
+  }
+
+  if (line ~ /^[[:space:]]+dependencies:[[:space:]]*/) {
+    dep_line = line
+    sub(/^[[:space:]]+dependencies:[[:space:]]*/, "", dep_line)
+    dep_line = trim(dep_line)
+
+    if (dep_line == "" || dep_line == "|" || dep_line == ">") {
+      in_dep_block = 1
+    } else if (dep_line ~ /^\[[^]]*\]$/) {
+      gsub(/^\[/, "", dep_line)
+      gsub(/\]$/, "", dep_line)
+      split(dep_line, dep_parts, /,/)
+      for (k in dep_parts) {
+        dep = trim(strip_quotes(dep_parts[k]))
+        if (dep != "") {
+          if (dependencies_csv != "") dependencies_csv = dependencies_csv ","
+          dependencies_csv = dependencies_csv dep
+        }
+      }
+    }
     next
   }
 
@@ -143,8 +276,8 @@ BEGIN {
   }
 
   if (in_prompt_block) {
-    # Note: mawk does not support {4,} bounded quantifiers; use explicit 4 spaces + *
-    if (line ~ /^[[:space:]][[:space:]][[:space:]][[:space:]][[:space:]]*[^[:space:]]/) {
+    # Note: mawk does not support {6,} bounded quantifiers; use explicit 6 spaces + *
+    if (line ~ /^[[:space:]][[:space:]][[:space:]][[:space:]][[:space:]][[:space:]]*[^[:space:]]/) {
       prompt_text = prompt_text " " trim(line)
       next
     }
@@ -154,6 +287,28 @@ BEGIN {
 
 END {
   flush_task()
+
+  if (enforce_layering == 1) {
+    for (idx = 1; idx <= taskn; idx++) {
+      deps_csv = task_dependencies[idx]
+      if (deps_csv == "") continue
+      split(deps_csv, dep_ids, /,/)
+      for (didx in dep_ids) {
+        dep_id = trim(dep_ids[didx])
+        if (dep_id == "") continue
+        dep_index = task_id_to_index[dep_id]
+        if (dep_index == 0) continue
+        dep_layer = task_layers[dep_index]
+        cur_layer = task_layers[idx]
+        if (layer_rank(cur_layer) > 0 && layer_rank(dep_layer) > 0) {
+          if (layer_rank(cur_layer) < layer_rank(dep_layer) && task_layer_exceptions[idx] != 1) {
+            errors[++errn] = "Task \"" task_ids[idx] "\" layer ordering violation: lower layer \"" cur_layer "\" depends on higher layer \"" dep_layer "\" via dependency \"" dep_id "\" (add \"Layer exception: allowed\" with rationale to override)"
+          }
+        }
+      }
+    }
+  }
+
   for (w = 1; w <= warnn; w++) {
     print "Atomicity lint warning: " warnings[w] > "/dev/stderr"
   }

--- a/skills/plan-to-invoker/scripts/test-fixtures.sh
+++ b/skills/plan-to-invoker/scripts/test-fixtures.sh
@@ -16,6 +16,20 @@ fail() {
 
 test_count=0
 pass_count=0
+DOCTOR_NEGATIVE_FIXTURES=(
+  "anti-pattern-g-monolithic-prompt-edit-bridge.yaml"
+  "anti-pattern-h-layer-order-violation.yaml"
+)
+
+is_doctor_negative_fixture() {
+  local fixture_name="$1"
+  for candidate in "${DOCTOR_NEGATIVE_FIXTURES[@]}"; do
+    if [[ "$fixture_name" == "$candidate" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 run_test() {
   local test_name="$1"
@@ -91,6 +105,38 @@ test_negative_fixture() {
     return 1
   fi
 
+  return 0
+}
+
+test_doctor_negative_fixture() {
+  local fixture_path="$1"
+  local fixture_name="$(basename "$fixture_path")"
+  local output
+  local stderr_file
+  stderr_file="$(mktemp)"
+
+  set +e
+  output=$(bash "$REPO_ROOT/skills/plan-to-invoker/scripts/skill-doctor.sh" "$fixture_path" 2>"$stderr_file")
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Expected non-zero exit code from skill-doctor for $fixture_name, got 0" >&2
+    echo "Output: $output" >&2
+    echo "Errors: $(cat "$stderr_file")" >&2
+    rm -f "$stderr_file"
+    return 1
+  fi
+
+  if ! echo "$output" | jq -e '.allPassed == false and .firstFailedStep == "lint-task-atomicity"' &>/dev/null; then
+    echo "Expected firstFailedStep=lint-task-atomicity for $fixture_name" >&2
+    echo "Output: $output" >&2
+    echo "Errors: $(cat "$stderr_file")" >&2
+    rm -f "$stderr_file"
+    return 1
+  fi
+
+  rm -f "$stderr_file"
   return 0
 }
 
@@ -256,7 +302,12 @@ echo "========================================="
 # Test all negative fixtures (generic validation)
 for fixture in "$NEGATIVE_DIR"/*.yaml; do
   if [[ -f "$fixture" ]]; then
-    run_test "Negative: $(basename "$fixture")" test_negative_fixture "$fixture"
+    fixture_name="$(basename "$fixture")"
+    if is_doctor_negative_fixture "$fixture_name"; then
+      run_test "Negative (skill-doctor): $fixture_name" test_doctor_negative_fixture "$fixture"
+    else
+      run_test "Negative: $fixture_name" test_negative_fixture "$fixture"
+    fi
   fi
 done
 


### PR DESCRIPTION
## Summary

Enforces dependency-first layered decomposition for implementation plans in the `plan-to-invoker` skill so reviewers get smaller, architecture-aligned slices and explicit dormant feature handling.

This adds hard lint gates for required `Layer:` and `Feature state:` metadata, validates cross-layer dependency direction with explicit exceptions, and introduces benchmark fixtures that prove a monolithic `wf-1777929074509-8`-shaped plan fails while a 4-slice dependency-ordered split passes.

## Test Plan

- [x] `bash skills/plan-to-invoker/scripts/validate-plan.sh skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml`
- [x] `bash skills/plan-to-invoker/scripts/validate-plan.sh skills/plan-to-invoker/fixtures/negative/anti-pattern-g-monolithic-prompt-edit-bridge.yaml`
- [x] `bash skills/plan-to-invoker/scripts/skill-doctor.sh skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml`
- [x] `bash skills/plan-to-invoker/scripts/skill-doctor.sh skills/plan-to-invoker/fixtures/negative/anti-pattern-g-monolithic-prompt-edit-bridge.yaml`
- [x] `bash skills/plan-to-invoker/scripts/skill-doctor.sh skills/plan-to-invoker/fixtures/negative/anti-pattern-h-layer-order-violation.yaml`
- [x] `bash skills/plan-to-invoker/scripts/test-fixtures.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e5a681d2`
- Post-revert steps: Re-run `bash skills/plan-to-invoker/scripts/test-fixtures.sh` to confirm fixture expectations return to pre-change behavior.
- Data migration? No

Made with [Cursor](https://cursor.com)