### PR TITLE
INV-118 Step 1: add prompt-edit IPC contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -290,6 +290,10 @@ export const IpcChannels = {
     request: [taskId: string, agentName: string];
     response: void;
   },
+  'invoker:edit-task-prompt': {} as {
+    request: [taskId: string, newPrompt: string];
+    response: void;
+  },
   'invoker:set-task-external-gate-policies': {} as {
     request: [taskId: string, updates: ExternalGatePolicyUpdate[]];
     response: void;


### PR DESCRIPTION
## Summary

Add the shared prompt-edit IPC surface without activating the feature in the app or renderer yet. This keeps the first workflow confined to the contracts layer while establishing the typed API that later layer-specific workflows will consume.

## Test Plan

- [x] `cd packages/contracts && pnpm exec vitest run src/__tests__/index.test.ts src/__tests__/validation.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No