### PR TITLE
INV-118 Step 2: route prompt edits through app owner bridge

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -682,6 +682,32 @@ describe('POST /api/tasks/:id/edit-prompt', () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Missing "prompt"');
   });
+
+  it('only dispatches running tasks returned by editTaskPrompt', async () => {
+    const running = makeTask({
+      id: 'task-1',
+      status: 'running',
+      execution: { selectedAttemptId: 'attempt-1' },
+    });
+    const pending = makeTask({
+      id: 'task-2',
+      status: 'pending',
+      execution: {},
+    });
+    mocks.orchestrator.editTaskPrompt.mockReturnValue([running, pending]);
+
+    const res = await request(port, 'POST', '/api/tasks/task-1/edit-prompt', { prompt: 'new prompt' });
+    expect(res.status).toBe(200);
+    expect(res.body.tasksStarted).toBe(1);
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledWith([running]);
+  });
+
+  it('does not call editTaskCommand when editing prompt', async () => {
+    await request(port, 'POST', '/api/tasks/task-1/edit-prompt', { prompt: 'new prompt' });
+    expect(mocks.orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-1', 'new prompt');
+    expect(mocks.orchestrator.editTaskCommand).not.toHaveBeenCalled();
+  });
 });
 
 describe('POST /api/tasks/:id/edit-type', () => {

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -186,6 +186,22 @@ describe('headless→owner delegation', () => {
       }));
     });
 
+    it('delegates set prompt to owner (prompt-edit bridge)', async () => {
+      const ownerHandler = vi.fn(async () => ({ success: true }));
+      messageBus.onRequest('headless.exec', ownerHandler);
+
+      const delegated = await tryDelegateExec(
+        ['set', 'prompt', 'wf-1/task-1', 'updated prompt text'],
+        messageBus,
+      );
+
+      expect(delegated).toBe(true);
+      expect(ownerHandler).toHaveBeenCalledWith({
+        args: ['set', 'prompt', 'wf-1/task-1', 'updated prompt text'],
+        waitForApproval: undefined,
+      });
+    });
+
     it('delegates rebase with noTrack so owner can return before workflow settlement', async () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1866,6 +1866,8 @@ if (isHeadless) {
           : { channel: 'headless.exec', request: { args: ['fix', String(arg0), String(arg1)] } };
       case 'invoker:edit-task-command':
         return { channel: 'headless.exec', request: { args: ['set', 'command', String(arg0), String(arg1)] } };
+      case 'invoker:edit-task-prompt':
+        return { channel: 'headless.exec', request: { args: ['set', 'prompt', String(arg0), String(arg1)] } };
       case 'invoker:edit-task-type':
         return { channel: 'headless.exec', request: { args: ['set', 'executor', String(arg0), String(arg1)] } };
       case 'invoker:edit-task-agent':
@@ -3348,6 +3350,27 @@ if (isHeadless) {
         });
       } catch (err) {
         logger.error(`edit-task-command failed: ${err}`, { module: 'ipc' });
+        throw err;
+      }
+    });
+
+    registerGuiMutationHandler('invoker:edit-task-prompt', async (taskIdArg: unknown, newPromptArg: unknown) => {
+      const taskId = String(taskIdArg);
+      const newPrompt = String(newPromptArg);
+      logger.info(`edit-task-prompt: "${taskId}" → "${newPrompt}"`, { module: 'ipc' });
+      try {
+        const envelope = makeEnvelope('edit-task-prompt', 'ui', 'task', { taskId, newPrompt });
+        const result = await commandService.editTaskPrompt(envelope);
+        if (!result.ok) throw new Error(result.error.message);
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.edit-task-prompt',
+          started: result.data,
+        });
+      } catch (err) {
+        logger.error(`edit-task-prompt failed: ${err}`, { module: 'ipc' });
         throw err;
       }
     });


### PR DESCRIPTION
## Summary

Route prompt-edit mutations through the app owner bridge so owner and non-owner execution paths share the existing `commandService.editTaskPrompt` semantics without enabling renderer affordances yet.

## Architecture

### Before

```mermaid
graph TD
    Request[Prompt edit request] --> Missing[No app-layer prompt-edit bridge]
```

### After

```mermaid
graph TD
    Request[Prompt edit request] --> Main[packages/app/src/main.ts]
    Main -->|non-owner| Headless[headless.exec set prompt]
    Main -->|owner| CommandService[commandService.editTaskPrompt]
```

## Test Plan

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/api-server.test.ts src/__tests__/owner-delegation.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No