### PR TITLE
INV-118 Step 3: enable TaskPanel prompt double-click editing

### DIFF
--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -196,10 +196,10 @@ describe('headless→owner delegation', () => {
       );
 
       expect(delegated).toBe(true);
-      expect(ownerHandler).toHaveBeenCalledWith({
+      expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['set', 'prompt', 'wf-1/task-1', 'updated prompt text'],
         waitForApproval: undefined,
-      });
+      }));
     });
 
     it('delegates rebase with noTrack so owner can return before workflow settlement', async () => {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -475,6 +475,19 @@ export function App() {
     [invoker],
   );
 
+  // ── Edit task prompt ───────────────────────────────────────
+  const handleEditPrompt = useCallback(
+    async (taskId: string, newPrompt: string) => {
+      if (!invoker) return;
+      try {
+        await invoker.editTaskPrompt(taskId, newPrompt);
+      } catch (err) {
+        console.error('Failed to edit task prompt:', err);
+      }
+    },
+    [invoker],
+  );
+
   // ── Edit task executor type ───────────────────────────────
   const handleEditType = useCallback(
     async (taskId: string, executorType: string, remoteTargetId?: string) => {
@@ -651,6 +664,7 @@ export function App() {
               }}
               onSelectExperiment={openExperimentModal}
               onEditCommand={handleEditCommand}
+              onEditPrompt={handleEditPrompt}
               onEditType={handleEditType}
               onEditAgent={handleEditAgent}
               onSetExternalGatePolicies={handleSetExternalGatePolicies}

--- a/packages/ui/src/__tests__/task-panel-double-click.test.tsx
+++ b/packages/ui/src/__tests__/task-panel-double-click.test.tsx
@@ -140,7 +140,7 @@ describe('TaskPanel double-click editing', () => {
       expect(screen.queryByTestId('command-display')).not.toBeInTheDocument();
     });
 
-    it('does NOT enter edit mode on Claude tasks (prompt tasks)', () => {
+    it('does NOT enter command edit mode on Claude tasks (prompt tasks) even with onEditCommand', () => {
       const task = makeTask({ prompt: 'Write a test', status: 'pending' });
       render(
         <TaskPanel
@@ -156,8 +156,28 @@ describe('TaskPanel double-click editing', () => {
       const commandDisplay = screen.getByTestId('command-display');
       fireEvent.doubleClick(commandDisplay);
 
-      // Should not enter edit mode for prompt tasks
+      // Should not enter command edit mode for prompt tasks
       expect(screen.queryByTestId('edit-command-input')).not.toBeInTheDocument();
+    });
+
+    it('does NOT enter prompt edit mode when onEditPrompt is not provided', () => {
+      const task = makeTask({ prompt: 'Write a test', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditCommand={mockOnEditCommand}
+          // no onEditPrompt
+        />,
+      );
+
+      const commandDisplay = screen.getByTestId('command-display');
+      fireEvent.doubleClick(commandDisplay);
+
+      expect(screen.queryByTestId('edit-prompt-input')).not.toBeInTheDocument();
     });
   });
 
@@ -197,7 +217,7 @@ describe('TaskPanel double-click editing', () => {
       expect(commandDisplay).not.toHaveClass('cursor-pointer');
     });
 
-    it('applies cursor-text style to Claude task display', () => {
+    it('applies cursor-text style to Claude task display when onEditPrompt not provided', () => {
       const task = makeTask({ prompt: 'Test prompt', status: 'pending' });
       render(
         <TaskPanel
@@ -207,12 +227,32 @@ describe('TaskPanel double-click editing', () => {
           onReject={mockOnReject}
           onSelectExperiment={mockOnSelectExperiment}
           onEditCommand={mockOnEditCommand}
+          // no onEditPrompt
         />,
       );
 
       const commandDisplay = screen.getByTestId('command-display');
       expect(commandDisplay).toHaveClass('cursor-text');
       expect(commandDisplay).not.toHaveClass('cursor-pointer');
+    });
+
+    it('applies cursor-pointer style to editable prompt task display', () => {
+      const mockOnEditPrompt = vi.fn();
+      const task = makeTask({ prompt: 'Test prompt', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      const commandDisplay = screen.getByTestId('command-display');
+      expect(commandDisplay).toHaveClass('cursor-pointer');
+      expect(commandDisplay).not.toHaveClass('cursor-text');
     });
 
     it('applies hover border effect to editable command display', () => {
@@ -1358,6 +1398,223 @@ describe('TaskPanel double-click editing', () => {
         const impact = screen.getByTestId('gate-policy-offender-wf-1::__merge__-impact');
         expect(impact).toHaveTextContent('would unblock now');
       });
+    });
+  });
+
+  describe('Prompt task double-click editing', () => {
+    const mockOnEditPrompt = vi.fn();
+
+    beforeEach(() => {
+      mockOnEditPrompt.mockClear();
+    });
+
+    it('enters prompt edit mode when double-clicking prompt display with onEditPrompt provided', () => {
+      const task = makeTask({ prompt: 'Write a feature', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      const commandDisplay = screen.getByTestId('command-display');
+      fireEvent.doubleClick(commandDisplay);
+
+      expect(screen.getByTestId('edit-prompt-input')).toBeInTheDocument();
+      expect(screen.getByTestId('save-prompt-btn')).toBeInTheDocument();
+      expect(screen.getByTestId('cancel-prompt-edit-btn')).toBeInTheDocument();
+    });
+
+    it('does NOT enter prompt edit mode when task is running', () => {
+      const task = makeTask({ prompt: 'Write a feature', status: 'running' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      const commandDisplay = screen.getByTestId('command-display');
+      fireEvent.doubleClick(commandDisplay);
+
+      expect(screen.queryByTestId('edit-prompt-input')).not.toBeInTheDocument();
+    });
+
+    it('calls onEditPrompt (not onEditCommand) when saving a prompt edit', () => {
+      const task = makeTask({ prompt: 'Original prompt', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditCommand={mockOnEditCommand}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      // Double-click to enter prompt edit mode
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+
+      // Edit the prompt
+      const input = screen.getByTestId('edit-prompt-input');
+      fireEvent.change(input, { target: { value: 'Updated prompt' } });
+
+      // Save
+      fireEvent.click(screen.getByTestId('save-prompt-btn'));
+
+      expect(mockOnEditPrompt).toHaveBeenCalledWith('test-task-1', 'Updated prompt');
+      expect(mockOnEditCommand).not.toHaveBeenCalled();
+    });
+
+    it('allows canceling prompt edit without calling onEditPrompt', () => {
+      const task = makeTask({ prompt: 'Original prompt', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      // Double-click to enter prompt edit mode
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+
+      // Edit the prompt
+      const input = screen.getByTestId('edit-prompt-input');
+      fireEvent.change(input, { target: { value: 'Modified prompt' } });
+
+      // Cancel
+      fireEvent.click(screen.getByTestId('cancel-prompt-edit-btn'));
+
+      expect(mockOnEditPrompt).not.toHaveBeenCalled();
+      // Should show original prompt text again
+      expect(screen.getByTestId('command-display')).toHaveTextContent('Original prompt');
+    });
+
+    it('initializes prompt edit input with current prompt value', () => {
+      const task = makeTask({ prompt: 'Implement auth system', status: 'completed' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+
+      const input = screen.getByTestId('edit-prompt-input') as HTMLTextAreaElement;
+      expect(input.value).toBe('Implement auth system');
+    });
+
+    it('handles double-click on pending prompt tasks', () => {
+      const task = makeTask({ prompt: 'pending prompt', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      expect(screen.getByTestId('edit-prompt-input')).toBeInTheDocument();
+    });
+
+    it('handles double-click on completed prompt tasks', () => {
+      const task = makeTask({ prompt: 'completed prompt', status: 'completed' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      expect(screen.getByTestId('edit-prompt-input')).toBeInTheDocument();
+    });
+
+    it('handles double-click on failed prompt tasks', () => {
+      const task = makeTask({ prompt: 'failed prompt', status: 'failed' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      expect(screen.getByTestId('edit-prompt-input')).toBeInTheDocument();
+    });
+
+    it('blocks double-click on running prompt tasks', () => {
+      const task = makeTask({ prompt: 'running prompt', status: 'running' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      expect(screen.queryByTestId('edit-prompt-input')).not.toBeInTheDocument();
+    });
+
+    it('command task editing continues to work alongside prompt editing', () => {
+      const task = makeTask({ command: 'echo hello', status: 'pending' });
+      render(
+        <TaskPanel
+          task={task}
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+          onEditCommand={mockOnEditCommand}
+          onEditPrompt={mockOnEditPrompt}
+        />,
+      );
+
+      // Double-click enters command edit mode (not prompt edit)
+      fireEvent.doubleClick(screen.getByTestId('command-display'));
+      expect(screen.getByTestId('edit-command-input')).toBeInTheDocument();
+      expect(screen.queryByTestId('edit-prompt-input')).not.toBeInTheDocument();
+
+      // Save calls onEditCommand
+      fireEvent.change(screen.getByTestId('edit-command-input'), { target: { value: 'echo world' } });
+      fireEvent.click(screen.getByTestId('save-command-btn'));
+      expect(mockOnEditCommand).toHaveBeenCalledWith('test-task-1', 'echo world');
+      expect(mockOnEditPrompt).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -70,6 +70,7 @@ interface TaskPanelProps {
   onReject: (task: TaskState) => void;
   onSelectExperiment: (task: TaskState) => void;
   onEditCommand?: (taskId: string, newCommand: string) => void;
+  onEditPrompt?: (taskId: string, newPrompt: string) => void;
   onEditType?: (taskId: string, executorType: string, remoteTargetId?: string) => void;
   onEditAgent?: (taskId: string, agentName: string) => void;
   onSetExternalGatePolicies?: (taskId: string, updates: ExternalGatePolicyUpdate[]) => Promise<void>;
@@ -170,6 +171,7 @@ export function TaskPanel({
   onReject,
   onSelectExperiment,
   onEditCommand,
+  onEditPrompt,
   onEditType,
   onEditAgent,
   onSetExternalGatePolicies,
@@ -179,6 +181,8 @@ export function TaskPanel({
 }: TaskPanelProps) {
   const [isEditingCommand, setIsEditingCommand] = useState(false);
   const [editCommandValue, setEditCommandValue] = useState('');
+  const [isEditingPrompt, setIsEditingPrompt] = useState(false);
+  const [editPromptValue, setEditPromptValue] = useState('');
   const [branchValue, setBranchValue] = useState(baseBranch ?? '');
   const [showAdvanced, setShowAdvanced] = useState(true);
   const [isEditingGatePolicies, setIsEditingGatePolicies] = useState(false);
@@ -189,6 +193,8 @@ export function TaskPanel({
   useEffect(() => {
     setIsEditingCommand(false);
     setEditCommandValue(task?.config.command ?? '');
+    setIsEditingPrompt(false);
+    setEditPromptValue(task?.config.prompt ?? '');
     setBranchValue(baseBranch ?? '');
     setIsEditingGatePolicies(false);
     setIsSavingGatePolicies(false);
@@ -209,6 +215,7 @@ export function TaskPanel({
   }
 
   const canEditCommand = task.config.command !== undefined && task.status !== 'running' && onEditCommand;
+  const canEditPrompt = task.config.prompt !== undefined && task.status !== 'running' && onEditPrompt;
 
   const handleSaveCommand = () => {
     if (onEditCommand && editCommandValue !== task.config.command) {
@@ -220,6 +227,18 @@ export function TaskPanel({
   const handleCancelEdit = () => {
     setEditCommandValue(task.config.command ?? '');
     setIsEditingCommand(false);
+  };
+
+  const handleSavePrompt = () => {
+    if (onEditPrompt && editPromptValue !== task.config.prompt) {
+      onEditPrompt(task.id, editPromptValue);
+    }
+    setIsEditingPrompt(false);
+  };
+
+  const handleCancelPromptEdit = () => {
+    setEditPromptValue(task.config.prompt ?? '');
+    setIsEditingPrompt(false);
   };
 
   const visualStatus = getEffectiveVisualStatus(task.status, task.execution);
@@ -497,17 +516,48 @@ export function TaskPanel({
                 </button>
               </div>
             </div>
+          ) : isEditingPrompt && task.config.prompt !== undefined ? (
+            <div className="mt-2 space-y-2">
+              <textarea
+                value={editPromptValue}
+                onChange={(e) => setEditPromptValue(e.target.value)}
+                className="w-full rounded p-3 text-xs text-gray-300 bg-blue-900/20 border border-blue-500 focus:outline-none focus:border-blue-400 resize-y"
+                rows={3}
+                data-testid="edit-prompt-input"
+              />
+              <div className="flex gap-2">
+                <button
+                  onClick={handleSavePrompt}
+                  className="flex-1 px-3 py-1.5 bg-blue-600 hover:bg-blue-500 text-white rounded text-xs font-medium transition-colors"
+                  data-testid="save-prompt-btn"
+                >
+                  Save & Re-run
+                </button>
+                <button
+                  onClick={handleCancelPromptEdit}
+                  className="flex-1 px-3 py-1.5 bg-gray-600 hover:bg-gray-500 text-white rounded text-xs font-medium transition-colors"
+                  data-testid="cancel-prompt-edit-btn"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
           ) : (
             <div
               className={`mt-2 rounded p-3 text-xs select-text ${
                 task.config.prompt
-                  ? 'bg-blue-900/20 border border-blue-800 cursor-text'
+                  ? canEditPrompt
+                    ? 'bg-blue-900/20 border border-blue-800 cursor-pointer hover:border-blue-600 transition-colors'
+                    : 'bg-blue-900/20 border border-blue-800 cursor-text'
                   : canEditCommand
                     ? 'bg-gray-800 border border-gray-700 cursor-pointer hover:border-gray-600 transition-colors'
                     : 'bg-gray-800 border border-gray-700 cursor-text'
               }`}
               onDoubleClick={() => {
-                if (canEditCommand) {
+                if (task.config.prompt && canEditPrompt) {
+                  setEditPromptValue(task.config.prompt);
+                  setIsEditingPrompt(true);
+                } else if (canEditCommand) {
                   setEditCommandValue(task.config.command ?? '');
                   setIsEditingCommand(true);
                 }


### PR DESCRIPTION
## Summary

Enable prompt-task double-click editing in the renderer by wiring the UI callback into `TaskPanel` while preserving the existing command-task inline editor behavior.

## Architecture

### Before

```mermaid
graph TD
    TaskPanel[TaskPanel prompt row] --> ReadOnly[Prompt text is read-only]
```

### After

```mermaid
graph TD
    TaskPanel[TaskPanel prompt row] --> Editor[Inline prompt editor]
    Editor --> App[packages/ui/src/App.tsx callback]
    App --> Bridge[Existing app prompt-edit bridge]
```

## Test Plan

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/task-panel-double-click.test.tsx src/__tests__/app-launch.test.tsx`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #208