### PR TITLE
Centralize fix-with-agent recovery routing

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -24,6 +24,7 @@ import {
   editTaskType,
   selectExperiment,
   setWorkflowMergeMode,
+  fixWithAgentAction,
   finalizeAppliedFix,
   autoFixOnFailure,
   buildCancelInFlight,
@@ -1170,6 +1171,124 @@ describe('selectFailureRecoveryRoute', () => {
     );
 
     expect(route).toEqual({ kind: 'fixWithAgent' });
+  });
+});
+
+describe('fixWithAgentAction', () => {
+  it('dispatches plain failures to taskExecutor.fixWithAgent', async () => {
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: { error: 'boom' },
+      })),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn(),
+    };
+
+    const result = await fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      agentName: 'codex',
+    });
+
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'codex', 'boom');
+    expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom');
+    expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
+  });
+
+  it('dispatches merge conflicts with a workspace to taskExecutor.resolveConflict', async () => {
+    const mergeError = JSON.stringify({
+      type: 'merge_conflict',
+      failedBranch: 'experiment/foo',
+      conflictFiles: ['src/foo.ts'],
+    });
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: { error: mergeError, workspacePath: '/tmp/task-a' },
+      })),
+      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      getTaskOutput: vi.fn(),
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn(),
+      resolveConflict: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      agentName: 'claude',
+    });
+
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
+    expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError);
+    expect(result).toEqual({ kind: 'resolveConflict', autoApproved: false, started: [] });
+  });
+
+  it('dispatches startup merge conflicts without a workspace to workflow recreate', async () => {
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: {
+          error: 'Executor startup failed (ssh): Merge conflict merging experiment/foo: packages/workflow-core/src/orchestrator.ts',
+        },
+      })),
+      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 2 })),
+      updateWorkflow: vi.fn(),
+      recreateWorkflowFromFreshBase: vi.fn(() => [makeRunningTask({ id: 'task-a', status: 'running' })]),
+    };
+    const persistence = {
+      appendTaskOutput: vi.fn(),
+      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 2 })),
+      updateWorkflow: vi.fn(),
+    };
+    const taskExecutor = {
+      preparePoolForRebaseRetry: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      recreateOutputLabel: 'Fix with AI',
+    });
+
+    expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
+      'task-a',
+      expect.stringContaining('Startup merge conflict detected; recreating workflow wf-1 from a fresh base.'),
+    );
+    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 3 });
+    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith('wf-1', expect.any(Object));
+    expect(result).toEqual({
+      kind: 'recreateWorkflowFromFreshBase',
+      workflowId: 'wf-1',
+      started: [expect.objectContaining({ id: 'task-a', status: 'running' })],
+    });
   });
 });
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -32,15 +32,13 @@ import { backupPlan } from './plan-backup.js';
 import { startApiServer, type ApiServerDeps } from './api-server.js';
 import {
   approveTask,
+  fixWithAgentAction,
   rebaseAndRetry,
   resolveConflictAction,
   recreateWorkflow as sharedRecreateWorkflow,
-  recreateWorkflowFromFreshBase,
   recreateTask as sharedRecreateTask,
   forkWorkflow as sharedForkWorkflow,
-  selectFailureRecoveryRoute,
   setWorkflowMergeMode,
-  finalizeAppliedFix,
 } from './workflow-actions.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
@@ -1244,40 +1242,16 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
   const agent = (agentArg ?? 'claude').toLowerCase();
-  const task = deps.orchestrator.getTask(taskId);
-  if (!task) throw new Error(`Task ${taskId} not found`);
-  const savedError = task.execution.error ?? '';
-  const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
   try {
-    if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
-      const started = await recreateWorkflowFromFreshBase(recoveryRoute.workflowId, {
-        ...deps,
-        taskExecutor: te,
-      });
-      await finalizeMutationWithGlobalTopup({
-        orchestrator: deps.orchestrator,
-        taskExecutor: te,
-        logger: deps.logger,
-        context: 'headless.fix-with-agent',
-        started,
-      });
-      process.stdout.write(
-        `Startup merge conflict detected; recreated workflow ${recoveryRoute.workflowId} from a fresh base.\n`,
-      );
-      return;
-    }
-
-    const { savedError: persistedSavedError } = deps.orchestrator.beginConflictResolution(taskId);
-    const output = deps.persistence.getTaskOutput(taskId);
-    if (recoveryRoute.kind === 'resolveConflict') {
-      await te.resolveConflict(taskId, persistedSavedError, agent);
-    } else {
-      await te.fixWithAgent(taskId, output, agent, persistedSavedError);
-    }
-    const result = await finalizeAppliedFix(taskId, persistedSavedError, {
+    const result = await fixWithAgentAction(taskId, {
       orchestrator: deps.orchestrator,
+      persistence: deps.persistence,
       taskExecutor: te,
       autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
+    }, {
+      agentName: agent,
+      recreateOutputLabel: 'Fix with AI',
+      failureOutputLabel: 'Fix with AI',
     });
     await finalizeMutationWithGlobalTopup({
       orchestrator: deps.orchestrator,
@@ -1286,17 +1260,18 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
       context: 'headless.fix-with-agent',
       started: result.started,
     });
+    if (result.kind === 'recreateWorkflowFromFreshBase') {
+      process.stdout.write(
+        `Startup merge conflict detected; recreated workflow ${result.workflowId} from a fresh base.\n`,
+      );
+      return;
+    }
     process.stdout.write(
       result.autoApproved
         ? `Fix applied and auto-approved for task: ${taskId} (${agent}).\n`
         : `Fix applied for task: ${taskId} (${agent}). Use 'approve ${taskId}' or 'reject ${taskId}' to finalize.\n`,
     );
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    deps.persistence.appendTaskOutput(taskId, `\n[Fix with AI] Failed: ${msg}`);
-    if (recoveryRoute.kind !== 'recreateWorkflowFromFreshBase') {
-      deps.orchestrator.revertConflictResolution(taskId, savedError, msg);
-    }
     await finalizeMutationWithGlobalTopup({
       orchestrator: deps.orchestrator,
       taskExecutor: te,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -108,15 +108,14 @@ import {
 } from './headless.js';
 import {
   approveTask as sharedApproveTask,
+  fixWithAgentAction,
   rebaseAndRetry,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
-  recreateWorkflowFromFreshBase,
   resolveConflictAction,
   selectFailureRecoveryRoute,
   selectExperiments as sharedSelectExperiments,
   setWorkflowMergeMode,
-  finalizeAppliedFix,
 } from './workflow-actions.js';
 import { spawn, execSync } from 'node:child_process';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
@@ -1325,16 +1324,16 @@ if (isHeadless) {
     agentName?: string,
     source: 'ipc' | 'auto-fix' = 'ipc',
   ): Promise<TaskState[]> => {
-    logger.info(
-      `fix-with-agent: "${taskId}" agent=${agentName ?? 'claude'} source=${source} route=fixWithAgent`,
-      { module: 'ipc' },
-    );
     const task = orchestrator.getTask(taskId);
     if (!task) {
       throw new Error(`Task ${taskId} not found`);
     }
     const savedError = task.execution.error ?? '';
     const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
+    logger.info(
+      `fix-with-agent: "${taskId}" agent=${agentName ?? 'claude'} source=${source} route=${recoveryRoute.kind}`,
+      { module: 'ipc' },
+    );
 
     if (source === 'auto-fix') {
       const attemptsBefore = task?.execution.autoFixAttempts ?? 0;
@@ -1346,39 +1345,22 @@ if (isHeadless) {
       });
       logAutoFixDebug(taskId, 'dispatch-attempt-bumped', { attemptsBefore, attemptsAfter });
     }
-    if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
-      persistence.appendTaskOutput(
-        taskId,
-        `\n[${source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI'}] Startup merge conflict detected; recreating workflow ${recoveryRoute.workflowId} from a fresh base.`,
-      );
-      return await recreateWorkflowFromFreshBase(recoveryRoute.workflowId, {
+    const result = await fixWithAgentAction(
+      taskId,
+      {
         orchestrator,
         persistence,
         taskExecutor: requireTaskExecutor(),
-      });
-    }
-
-    const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
-    try {
-      const output = persistence.getTaskOutput(taskId);
-      if (recoveryRoute.kind === 'resolveConflict') {
-        await requireTaskExecutor().resolveConflict(taskId, persistedSavedError, agentName);
-      } else {
-        await requireTaskExecutor().fixWithAgent(taskId, output, agentName, persistedSavedError);
-      }
-      const result = await finalizeAppliedFix(taskId, persistedSavedError, {
-        orchestrator,
-        taskExecutor: requireTaskExecutor(),
         autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
-      });
-      return result.started;
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      const errorLabel = source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`;
-      persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
-      orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
-      throw err;
-    }
+      },
+      {
+        agentName,
+        recoveryRoute,
+        recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
+        failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`,
+      },
+    );
+    return result.started;
   };
 
   const scheduleAutoFix = (taskId: string): void => {

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -552,6 +552,65 @@ export async function resolveConflictAction(
   }
 }
 
+export type FixWithAgentActionResult =
+  | { kind: 'fixWithAgent' | 'resolveConflict'; autoApproved: boolean; started: TaskState[] }
+  | { kind: 'recreateWorkflowFromFreshBase'; workflowId: string; started: TaskState[] };
+
+export async function fixWithAgentAction(
+  taskId: string,
+  deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
+  options: {
+    agentName?: string;
+    recoveryRoute?: FailureRecoveryRoute;
+    recreateOutputLabel?: string;
+    failureOutputLabel?: string;
+  } = {},
+): Promise<FixWithAgentActionResult> {
+  const { orchestrator, persistence, taskExecutor } = deps;
+  const task = orchestrator.getTask(taskId);
+  if (!task) throw new Error(`Task ${taskId} not found`);
+
+  const savedError = task.execution.error ?? '';
+  const recoveryRoute = options.recoveryRoute ?? selectFailureRecoveryRoute(task, savedError);
+  if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
+    if (options.recreateOutputLabel) {
+      persistence.appendTaskOutput(
+        taskId,
+        `\n[${options.recreateOutputLabel}] Startup merge conflict detected; recreating workflow ${recoveryRoute.workflowId} from a fresh base.`,
+      );
+    }
+    const started = await recreateWorkflowFromFreshBase(recoveryRoute.workflowId, deps);
+    return {
+      kind: recoveryRoute.kind,
+      workflowId: recoveryRoute.workflowId,
+      started,
+    };
+  }
+
+  const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
+  try {
+    if (recoveryRoute.kind === 'resolveConflict') {
+      await taskExecutor.resolveConflict(taskId, persistedSavedError, options.agentName);
+    } else {
+      const output = persistence.getTaskOutput(taskId);
+      await taskExecutor.fixWithAgent(taskId, output, options.agentName, persistedSavedError);
+    }
+    const result = await finalizeAppliedFix(taskId, persistedSavedError, deps);
+    return {
+      kind: recoveryRoute.kind,
+      autoApproved: result.autoApproved,
+      started: result.started,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    const errorLabel = options.failureOutputLabel
+      ?? (recoveryRoute.kind === 'resolveConflict' ? 'Resolve Conflict' : `Fix with ${options.agentName ?? 'Claude'}`);
+    persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
+    orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
+    throw err;
+  }
+}
+
 export async function finalizeAppliedFix(
   taskId: string,
   savedError: string,


### PR DESCRIPTION
## Summary

This centralizes `fix-with-agent` recovery routing in a shared app-layer helper and removes the duplicated control flow from both the Electron main-process mutation handler and the headless fix path.

The functional goal is to keep all fix entrypoints on the same route-selection behavior for:
- plain task failures → `fixWithAgent`
- merge conflicts with a workspace → `resolveConflict`
- startup merge conflicts without a workspace → `recreateWorkflowFromFreshBase`

This also adds regression coverage for the shared dispatch behavior so a partial edit in one entrypoint cannot reintroduce the `recoveryRoute` drift that was observed locally.

Observed runtime proof from `/home/edbert-chan/.invoker/invoker.log` on May 5, 2026:

```text
2026-05-05T04:55:10.443Z fix-with-agent: "wf-1777949422604-4/run-app-e2e-regressions" agent=claude source=ipc route=fixWithAgent
2026-05-05T04:55:10.483Z fix-with-agent failed: ReferenceError: recoveryRoute is not defined
2026-05-05T04:55:10.484Z [auto-fix-debug] ... phase=schedule-dispatch-error ... "ReferenceError: recoveryRoute is not defined"
```

## Architecture

### Before

```mermaid
graph TD
    A[Task fails] --> B[Main.ts fix entrypoint]
    A --> C[Headless fix entrypoint]
    B --> D[Inline route selection + inline dispatch]
    C --> E[Inline route selection + inline dispatch]
    D --> F[fixWithAgent / resolveConflict / recreate workflow]
    E --> F
```

### After

```mermaid
graph TD
    A[Task fails] --> B[Main.ts fix entrypoint]
    A --> C[Headless fix entrypoint]
    B --> D[workflow-actions fixWithAgentAction]
    C --> D
    D --> E[selectFailureRecoveryRoute]
    E --> F[fixWithAgent / resolveConflict / recreate workflow]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 79010b4a`
- Post-revert steps: None
- Data migration? No
