### PR TITLE
Clarify plan file-count limits are soft heuristics

### DIFF
--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -107,8 +107,9 @@ Rules:
 1. Explore the codebase first (list directories, read key files). Then USE what you learned in your response — reference specific files, components, and patterns you found. Do NOT give generic responses that ignore the code you read.
 2. After exploring, generate the YAML plan directly. Do NOT ask clarifying questions unless absolutely necessary — prefer making reasonable assumptions based on the code you read.
 3. Keep plans focused — 3-8 tasks maximum.
-4. Each task should have either a \`command\` or a \`prompt\`, not both.
-5. Every step MUST be testable. Every implementation task MUST have a corresponding test task that verifies it works using a concrete, executable \`command\` (e.g. \`cd packages/protocol && pnpm test\`, \`git diff --name-only\`). The test command must produce a clear pass/fail exit code. Do NOT skip tests for any step. Do NOT use prompts for test tasks — use commands only.
+4. File-count guidance is a soft heuristic, not a hard validator gate. Prefer small reviewable slices (for example around 10 files per implementation task when practical), but exceed this when correctness or shared wiring requires broader edits.
+5. Each task should have either a \`command\` or a \`prompt\`, not both.
+6. Every step MUST be testable. Every implementation task MUST have a corresponding test task that verifies it works using a concrete, executable \`command\` (e.g. \`cd packages/protocol && pnpm test\`, \`git diff --name-only\`). The test command must produce a clear pass/fail exit code. Do NOT skip tests for any step. Do NOT use prompts for test tasks — use commands only.
    Test command rules:
    - ALWAYS cd into the package directory first: \`cd packages/<pkg> && pnpm test\`
    - To target a specific test file: \`cd packages/<pkg> && pnpm test -- src/__tests__/file.test.ts\`
@@ -116,11 +117,11 @@ Rules:
    - NEVER use \`npx vitest run\` — always use \`pnpm test\` which runs the package.json test script
    - If Invoker config auto-routes heavyweight commands, keep \`pnpm ...\` as a normal command unless the task must name a specific remote target
    - NEVER invent test file names. Verify the test file exists before referencing it in a command.
-6. Use meaningful task IDs (kebab-case).
-7. When ready, output the plan inside a \`\`\`yaml code block.
-8. Always include \`dependencies\` (even if empty array).
-9. After generating a plan, tell the user they can confirm execution by replying with "yes", "go", "execute", etc.
-10. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically when the user confirms.`;
+7. Use meaningful task IDs (kebab-case).
+8. When ready, output the plan inside a \`\`\`yaml code block.
+9. Always include \`dependencies\` (even if empty array).
+10. After generating a plan, tell the user they can confirm execution by replying with "yes", "go", "execute", etc.
+11. NEVER generate bash commands or shell scripts to execute plans. The orchestrator handles plan execution automatically when the user confirms.`;
 }
 
 // ── Dangerous Command Detection ─────────────────────────────

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -25,6 +25,8 @@ Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b 
 
 **Delegated task hints (best effort):** When authoring tasks, consider adding `Files:`, `Change types:`, and `Acceptance criteria:` blocks in each task `description` to help handoff to another agent—lists reflect what you know **at planning time** and can be updated (`TBD`, follow-on tasks) as scope grows. **Not** required for `skill-doctor` to pass. See `references/task-patterns.md` § *Delegated execution hints*.
 
+**File-count sizing guidance (soft):** Treat any "about 10 files" guidance as a reviewability heuristic, not a hard constraint. Prefer smaller slices when practical, but allow broader edits when correctness, shared wiring, or coupled refactors require it.
+
 **Dependency-first layered decomposition (required for implementation plans):** For plans whose `onFinish` is not `none`, every implementation task must include `Layer:` and `Feature state:` headings in `description`. Use normalized layer names (`persistence`, `domain`, `transport`, `api`, `contact_surface`, `app_bridge`, `owner_delegation`, `ui_activation`, `app_regression`, `e2e_regression`, `ui`, `docs`) and feature state values (`active` or `dormant`). `dormant` tasks must still include `Acceptance criteria:` in `description`. Verify-only plans (`onFinish: none`) are exempt from this hard requirement.
 
 **Cross-layer dependency direction (required):** Dependency DAGs must flow from lower/foundational layers toward higher/integration layers. If a lower-layer task depends on a higher-layer task, mark an explicit exception in the task description with `Layer exception: allowed` and a rationale.

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -117,6 +117,8 @@ When writing `prompt` fields for LLM tasks:
 
 Planning often **misses files** or **adds scope** later. These headings in a task `description` are **recommended**, **revisable**, and **not** required for `skill-doctor` or `lint-task-atomicity.sh` to pass. Optional advisory output: `bash skills/plan-to-invoker/scripts/lint-task-atomicity.sh --warn-delegation <plan.yaml>`.
 
+File-count guidance (for example, aiming around 10 touched files in a task) is a **soft heuristic** for reviewability, not a hard limit. If correctness or shared wiring requires broader edits, allow the task to exceed that target and capture the rationale in `description`.
+
 **Suggested blocks** (in `description`, when helpful):
 
 1. **`Files:`** — Repo-relative paths known when the task was written; use `TBD` or "may grow" if unsure. **Not** an exhaustive contract—implementation may touch additional files; amend the plan or add tasks if so.


### PR DESCRIPTION
## Summary

- Clarify in the plan conversation prompt that around-10-file sizing is a soft reviewability heuristic, not a hard constraint.
- Add matching language to the plan-to-invoker skill docs so delegated planning guidance stays consistent.
- Preserve existing hard validation gates while making file-count sizing explicitly advisory.

## Test Plan

- [x] `git diff --stat upstream/master...HEAD`
- [x] `pnpm test -- src/__tests__/plan-conversation.test.ts` *(fails in fresh worktree: `vitest: not found`; dependencies not installed yet)*
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-soft-file-heuristic.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 7e7489ad`
- Post-revert steps: None
- Data migration? No
