### PR TITLE
Prefer fresh origin refs for merge worktrees

### DIFF
--- a/packages/execution-engine/src/__tests__/create-merge-worktree.test.ts
+++ b/packages/execution-engine/src/__tests__/create-merge-worktree.test.ts
@@ -201,7 +201,7 @@ describe('createMergeWorktree isolation (real git)', { timeout: 30_000 }, () => 
     await executor.removeMergeWorktree(clonePath);
   });
 
-  it('clone resolves baseBranch from origin when host local master is behind', async () => {
+  it('prefers freshly fetched origin base over stale local base branch', async () => {
     const sandbox = createSandbox();
     root = sandbox.root;
 
@@ -231,7 +231,15 @@ describe('createMergeWorktree isolation (real git)', { timeout: 30_000 }, () => 
     const clonePath = await executor.createMergeWorktree('master', 'test-stale', sandbox.bare);
 
     const cloneOrigin = git(clonePath, 'remote get-url origin');
+    const cloneHeadSha = git(clonePath, 'rev-parse HEAD');
+    const cloneLocalMasterSha = git(clonePath, 'rev-parse master');
+    const cloneOriginMasterSha = git(clonePath, 'rev-parse origin/master');
+
     expect(cloneOrigin).toBe(sandbox.bare);
+    expect(cloneLocalMasterSha).toBe(hostMasterSha);
+    expect(cloneOriginMasterSha).toBe(remoteMasterSha);
+    expect(cloneHeadSha).toBe(remoteMasterSha);
+    expect(cloneHeadSha).not.toBe(hostMasterSha);
 
     await executor.removeMergeWorktree(clonePath);
   });

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1184,13 +1184,13 @@ export class TaskRunner {
       }
     };
 
-    const candidates = [
+    const candidates = Array.from(new Set([
+      `refs/remotes/${remoteName}/${baseRef}`,
+      `${remoteName}/${baseRef}`,
       normalizedRef,
       strippedRemoteRef,
       `refs/heads/${strippedRemoteRef}`,
-      `refs/remotes/origin/${strippedRemoteRef}`,
-      `origin/${strippedRemoteRef}`,
-    ];
+    ]));
 
     let refSha: string | undefined;
     for (const candidate of candidates) {

--- a/scripts/repro/repro-create-merge-worktree-stale-base.sh
+++ b/scripts/repro/repro-create-merge-worktree-stale-base.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Repro script: createMergeWorktree resolves stale local base refs before fresh origin refs.
+#
+# This runs the real-git execution-engine test that sets up:
+#   1. a bare remote,
+#   2. a host clone whose local master is stale,
+#   3. a direct remote-only push to master,
+#   4. TaskRunner.createMergeWorktree('master', ...).
+#
+# Broken behavior:
+#   clone HEAD follows the stale local master from the clone source.
+#
+# Correct behavior:
+#   clone HEAD follows the freshly fetched origin/master.
+#
+# Usage:
+#   bash scripts/repro/repro-create-merge-worktree-stale-base.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TEST_NAME="prefers freshly fetched origin base over stale local base branch"
+
+cd "$REPO_ROOT/packages/execution-engine"
+pnpm exec vitest run src/__tests__/create-merge-worktree.test.ts -t "$TEST_NAME"


### PR DESCRIPTION
## Summary

Prefer freshly fetched `origin/<base>` refs over stale local branch refs when `createMergeWorktree()` resolves the base commit for a merge clone.

Add a real-git regression assertion for the stale-host-base case and a bash repro script that exercises the same `createMergeWorktree()` path.

## Test Plan

- [x] `bash scripts/repro/repro-create-merge-worktree-stale-base.sh`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/create-merge-worktree.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0f09e8a4`
- Post-revert steps: None
- Data migration? No
