### PR TITLE
Recreate-with-Rebase Step 1: add transport contract

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -330,6 +330,10 @@ export const IpcChannels = {
     request: [mergeTaskId: string];
     response: RebaseAndRetryResult;
   },
+  'invoker:recreate-with-rebase': {} as {
+    request: [workflowId: string];
+    response: RebaseAndRetryResult;
+  },
   'invoker:set-merge-branch': {} as {
     request: [workflowId: string, baseBranch: string];
     response: void;

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -134,6 +134,7 @@ export function createMockInvoker(
     recreateTask: vi.fn(async () => {}),
     retryWorkflow: vi.fn(async () => {}),
     rebaseAndRetry: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
+    recreateWithRebase: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
     setMergeBranch: vi.fn(async () => {}),
     approveMerge: vi.fn(async () => {}),
     resolveConflict: vi.fn(async () => {}),


### PR DESCRIPTION
## Summary

Introduce a workflow-scoped `recreate-with-rebase` transport contract and derived renderer typings without changing the existing retry-with-rebase behavior yet.

This step creates the named IPC surface that later app, UI, headless, and HTTP layers will call. It keeps the legacy rebase-and-retry path intact so downstream steps can switch call sites incrementally.

## Architecture

### Before

```mermaid
graph TD
    UI[Renderer and mocks] --> Legacy[retry-with-rebase only]
    Legacy --> Main[Main-process workflow mutation path]
```

### After

```mermaid
graph TD
    UI[Renderer and mocks] --> Contract[invoker:recreate-with-rebase IPC contract]
    Contract --> Main[Main-process workflow mutation path]
    UI --> Legacy[existing retry-with-rebase path remains available]
```

## Test Plan

- [ ] `cd packages/contracts && pnpm test` not rerun during stack publication
- [ ] `cd packages/ui && pnpm test` not rerun during stack publication

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No