### PR TITLE
Recreate-with-Rebase Step 2: wire app action and main handler

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -16,6 +16,7 @@ import {
   retryTask,
   retryWorkflow,
   recreateWorkflowFromFreshBase,
+  recreateWithRebase,
   rebaseAndRetry,
   approveTask,
   rejectTask,
@@ -302,6 +303,60 @@ describe('rebaseAndRetry', () => {
         persistence: persistence as unknown as SQLiteAdapter,
       }),
     ).rejects.toThrow('Task missing-task not found or has no workflow');
+  });
+});
+
+describe('recreateWithRebase', () => {
+  it('delegates directly to recreateWorkflowFromFreshBase with the provided workflowId', async () => {
+    const tasks = [makeRunningTask()];
+    const orchestrator = {
+      recreateWorkflowFromFreshBase: vi.fn(async (_id: string, opts?: { refreshBase?: () => Promise<unknown> }) => {
+        await opts?.refreshBase?.();
+        return tasks;
+      }),
+    };
+    const persistence = {
+      loadWorkflow: vi.fn(() => ({
+        id: 'wf-1',
+        generation: 2,
+        repoUrl: 'https://example/repo.git',
+        baseBranch: 'main',
+      })),
+      updateWorkflow: vi.fn(),
+    };
+    const taskExecutor = {
+      preparePoolForRebaseRetry: vi.fn(async () => undefined),
+    } as unknown as TaskRunner;
+
+    const result = await recreateWithRebase('wf-1', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor,
+    });
+
+    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 3 });
+    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+      'wf-1',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
+    );
+    expect(taskExecutor.preparePoolForRebaseRetry).toHaveBeenCalledWith(
+      'wf-1',
+      'https://example/repo.git',
+      'main',
+    );
+    expect(result).toBe(tasks);
+  });
+
+  it('throws when workflow not found', async () => {
+    const orchestrator = { recreateWorkflowFromFreshBase: vi.fn(async () => []) };
+    const persistence = { loadWorkflow: vi.fn(() => undefined), updateWorkflow: vi.fn() };
+
+    await expect(
+      recreateWithRebase('missing', {
+        orchestrator: orchestrator as unknown as Orchestrator,
+        persistence: persistence as unknown as SQLiteAdapter,
+      }),
+    ).rejects.toThrow('Workflow missing not found');
   });
 });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -110,6 +110,7 @@ import {
   approveTask as sharedApproveTask,
   fixWithAgentAction,
   rebaseAndRetry,
+  recreateWithRebase,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
   resolveConflictAction,
@@ -1830,6 +1831,8 @@ if (isHeadless) {
         return { channel: 'headless.exec', request: { args: ['retry', String(arg0)] } };
       case 'invoker:rebase-and-retry':
         return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
+      case 'invoker:recreate-with-rebase':
+        return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
       case 'invoker:set-merge-mode':
         return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
       case 'invoker:approve-merge': {
@@ -3158,6 +3161,40 @@ if (isHeadless) {
         });
       } catch (err) {
         logger.error(`rebase-and-retry failed: ${err}`, { module: 'ipc' });
+        throw err;
+      }
+      },
+    );
+
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:recreate-with-rebase',
+      (workflowIdArg: unknown) => String(workflowIdArg),
+      'high',
+      async (workflowIdArg: unknown) => {
+      const workflowId = String(workflowIdArg);
+      cancelDeferredWorkflowLaunch(workflowId, 'ipc.recreate-with-rebase');
+      logger.info(`recreate-with-rebase: "${workflowId}"`, { module: 'ipc' });
+      try {
+        await preemptWorkflowBeforeMutation(workflowId, {
+          preemptWorkflowExecution,
+          logger,
+          context: 'ipc.recreate-with-rebase',
+        });
+        const started = await recreateWithRebase(workflowId, {
+          orchestrator,
+          persistence,
+          repoRoot,
+          taskExecutor: requireTaskExecutor(),
+        });
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.recreate-with-rebase',
+          started,
+        });
+      } catch (err) {
+        logger.error(`recreate-with-rebase failed: ${err}`, { module: 'ipc' });
         throw err;
       }
       },

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -239,6 +239,26 @@ export async function recreateWorkflowFromFreshBase(
 }
 
 /**
+ * Recreate a workflow from a fresh upstream base — workflow-scoped
+ * entry point for the `invoker:recreate-with-rebase` IPC channel.
+ *
+ * This is the direct workflow-id counterpart of `rebaseAndRetry`
+ * (which performs a `taskId → workflowId` translation first). Both
+ * delegate to `recreateWorkflowFromFreshBase` for the actual
+ * pool-refresh + generation-bump + DAG reset.
+ */
+export async function recreateWithRebase(
+  workflowId: string,
+  deps: ActionDeps,
+): Promise<TaskState[]> {
+  deps.logger?.info(
+    `recreateWithRebase: workflowId=${workflowId} → recreateWorkflowFromFreshBase`,
+    { module: 'agent-session-trace' },
+  );
+  return recreateWorkflowFromFreshBase(workflowId, deps);
+}
+
+/**
  * Rebase-and-retry: refresh the pool mirror / origin base, remove managed
  * experiment/invoker branches in that mirror, bump generation, and restart the DAG.
  *

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -330,6 +330,10 @@ export const IpcChannels = {
     request: [mergeTaskId: string];
     response: RebaseAndRetryResult;
   },
+  'invoker:recreate-with-rebase': {} as {
+    request: [workflowId: string];
+    response: RebaseAndRetryResult;
+  },
   'invoker:set-merge-branch': {} as {
     request: [workflowId: string, baseBranch: string];
     response: void;

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -134,6 +134,7 @@ export function createMockInvoker(
     recreateTask: vi.fn(async () => {}),
     retryWorkflow: vi.fn(async () => {}),
     rebaseAndRetry: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
+    recreateWithRebase: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
     setMergeBranch: vi.fn(async () => {}),
     approveMerge: vi.fn(async () => {}),
     resolveConflict: vi.fn(async () => {}),


### PR DESCRIPTION
## Summary

Wire the new `recreate-with-rebase` contract through app workflow actions and the main-process IPC handler by delegating to `recreateWorkflowFromFreshBase`.

This step keeps the mutation logic centralized in the existing recreate implementation while making the new transport contract callable from the app layer.

## Architecture

### Before

```mermaid
graph TD
    Renderer["Renderer action"] --> Legacy["retry-with-rebase workflow action"]
    Legacy --> Main["Main-process mutation handler"]
```

### After

```mermaid
graph TD
    Renderer["Renderer action"] --> Action["workflow-actions recreateWithRebase"]
    Action --> IPC["invoker:recreate-with-rebase"]
    IPC --> Main["Main-process handler"]
    Main --> Core["recreateWorkflowFromFreshBase"]
    Legacy["retry-with-rebase"] --> Core
```

## Test Plan

- [ ] `cd packages/app && pnpm test -- --run src/__tests__/workflow-actions.test.ts` not rerun during stack publication

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #218