### PR TITLE
Recreate-with-Rebase Step 3: add queue fence and preemption semantics

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -327,6 +327,101 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
+  it('evicts older queued workflow intents when recreate-with-rebase fence starts', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/blocker-task', null]);
+    void running.catch(() => {});
+    const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['old-queued']);
+    void olderQueued.catch(() => {});
+    const recreateWithRebase = coordinator.enqueue<void>('wf-1', 'high', 'invoker:recreate-with-rebase', ['wf-1']);
+    const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['new-queued']);
+
+    await recreateWithRebase;
+    await newerQueued;
+    await expect(running).rejects.toThrow(/superseded by recreate intent/i);
+    await expect(olderQueued).rejects.toThrow(/evicted/i);
+
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:recreate-with-rebase:wf-1',
+      'invoker:edit-task-agent:new-queued',
+    ]);
+  });
+
+  it('invalidates an older running workflow intent when recreate-with-rebase is enqueued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const recreateWithRebase = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:recreate-with-rebase',
+      ['wf-1'],
+    );
+    await recreateWithRebase;
+    await expect(olderRunning).rejects.toThrow(/superseded by recreate intent/i);
+
+    const intentsAfterRecreate = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intentsAfterRecreate.find((intent) => intent.id === 1)?.status).toBe('failed');
+    expect(intentsAfterRecreate.find((intent) => intent.id === 1)?.error).toContain('Superseded by recreate intent #2');
+    expect(intentsAfterRecreate.find((intent) => intent.id === 2)?.status).toBe('completed');
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:recreate-with-rebase:wf-1',
+    ]);
+  });
+
   it('evicts older queued workflow intents when retry-workflow fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -16,6 +16,7 @@ import {
   retryTask,
   retryWorkflow,
   recreateWorkflowFromFreshBase,
+  recreateWithRebase,
   rebaseAndRetry,
   approveTask,
   rejectTask,
@@ -302,6 +303,60 @@ describe('rebaseAndRetry', () => {
         persistence: persistence as unknown as SQLiteAdapter,
       }),
     ).rejects.toThrow('Task missing-task not found or has no workflow');
+  });
+});
+
+describe('recreateWithRebase', () => {
+  it('delegates directly to recreateWorkflowFromFreshBase with the provided workflowId', async () => {
+    const tasks = [makeRunningTask()];
+    const orchestrator = {
+      recreateWorkflowFromFreshBase: vi.fn(async (_id: string, opts?: { refreshBase?: () => Promise<unknown> }) => {
+        await opts?.refreshBase?.();
+        return tasks;
+      }),
+    };
+    const persistence = {
+      loadWorkflow: vi.fn(() => ({
+        id: 'wf-1',
+        generation: 2,
+        repoUrl: 'https://example/repo.git',
+        baseBranch: 'main',
+      })),
+      updateWorkflow: vi.fn(),
+    };
+    const taskExecutor = {
+      preparePoolForRebaseRetry: vi.fn(async () => undefined),
+    } as unknown as TaskRunner;
+
+    const result = await recreateWithRebase('wf-1', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor,
+    });
+
+    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 3 });
+    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+      'wf-1',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
+    );
+    expect(taskExecutor.preparePoolForRebaseRetry).toHaveBeenCalledWith(
+      'wf-1',
+      'https://example/repo.git',
+      'main',
+    );
+    expect(result).toBe(tasks);
+  });
+
+  it('throws when workflow not found', async () => {
+    const orchestrator = { recreateWorkflowFromFreshBase: vi.fn(async () => []) };
+    const persistence = { loadWorkflow: vi.fn(() => undefined), updateWorkflow: vi.fn() };
+
+    await expect(
+      recreateWithRebase('missing', {
+        orchestrator: orchestrator as unknown as Orchestrator,
+        persistence: persistence as unknown as SQLiteAdapter,
+      }),
+    ).rejects.toThrow('Workflow missing not found');
   });
 });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -110,6 +110,7 @@ import {
   approveTask as sharedApproveTask,
   fixWithAgentAction,
   rebaseAndRetry,
+  recreateWithRebase,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
   resolveConflictAction,
@@ -1830,6 +1831,8 @@ if (isHeadless) {
         return { channel: 'headless.exec', request: { args: ['retry', String(arg0)] } };
       case 'invoker:rebase-and-retry':
         return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
+      case 'invoker:recreate-with-rebase':
+        return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
       case 'invoker:set-merge-mode':
         return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
       case 'invoker:approve-merge': {
@@ -3158,6 +3161,40 @@ if (isHeadless) {
         });
       } catch (err) {
         logger.error(`rebase-and-retry failed: ${err}`, { module: 'ipc' });
+        throw err;
+      }
+      },
+    );
+
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:recreate-with-rebase',
+      (workflowIdArg: unknown) => String(workflowIdArg),
+      'high',
+      async (workflowIdArg: unknown) => {
+      const workflowId = String(workflowIdArg);
+      cancelDeferredWorkflowLaunch(workflowId, 'ipc.recreate-with-rebase');
+      logger.info(`recreate-with-rebase: "${workflowId}"`, { module: 'ipc' });
+      try {
+        await preemptWorkflowBeforeMutation(workflowId, {
+          preemptWorkflowExecution,
+          logger,
+          context: 'ipc.recreate-with-rebase',
+        });
+        const started = await recreateWithRebase(workflowId, {
+          orchestrator,
+          persistence,
+          repoRoot,
+          taskExecutor: requireTaskExecutor(),
+        });
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.recreate-with-rebase',
+          started,
+        });
+      } catch (err) {
+        logger.error(`recreate-with-rebase failed: ${err}`, { module: 'ipc' });
         throw err;
       }
       },

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -298,7 +298,7 @@ export class PersistedWorkflowMutationCoordinator {
   }
 
   private isHardPreemptingRecreateIntent(channel: string, args: unknown[]): boolean {
-    if (channel === 'invoker:recreate-workflow' || channel === 'invoker:recreate-task') {
+    if (channel === 'invoker:recreate-workflow' || channel === 'invoker:recreate-task' || channel === 'invoker:recreate-with-rebase') {
       return true;
     }
     if (channel !== 'headless.exec') {
@@ -314,6 +314,7 @@ export class PersistedWorkflowMutationCoordinator {
       intent.channel === 'invoker:retry-workflow'
       || intent.channel === 'invoker:recreate-workflow'
       || intent.channel === 'invoker:recreate-task'
+      || intent.channel === 'invoker:recreate-with-rebase'
     ) {
       return true;
     }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -239,6 +239,26 @@ export async function recreateWorkflowFromFreshBase(
 }
 
 /**
+ * Recreate a workflow from a fresh upstream base — workflow-scoped
+ * entry point for the `invoker:recreate-with-rebase` IPC channel.
+ *
+ * This is the direct workflow-id counterpart of `rebaseAndRetry`
+ * (which performs a `taskId → workflowId` translation first). Both
+ * delegate to `recreateWorkflowFromFreshBase` for the actual
+ * pool-refresh + generation-bump + DAG reset.
+ */
+export async function recreateWithRebase(
+  workflowId: string,
+  deps: ActionDeps,
+): Promise<TaskState[]> {
+  deps.logger?.info(
+    `recreateWithRebase: workflowId=${workflowId} → recreateWorkflowFromFreshBase`,
+    { module: 'agent-session-trace' },
+  );
+  return recreateWorkflowFromFreshBase(workflowId, deps);
+}
+
+/**
  * Rebase-and-retry: refresh the pool mirror / origin base, remove managed
  * experiment/invoker branches in that mirror, bump generation, and restart the DAG.
  *

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -330,6 +330,10 @@ export const IpcChannels = {
     request: [mergeTaskId: string];
     response: RebaseAndRetryResult;
   },
+  'invoker:recreate-with-rebase': {} as {
+    request: [workflowId: string];
+    response: RebaseAndRetryResult;
+  },
   'invoker:set-merge-branch': {} as {
     request: [workflowId: string, baseBranch: string];
     response: void;

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -134,6 +134,7 @@ export function createMockInvoker(
     recreateTask: vi.fn(async () => {}),
     retryWorkflow: vi.fn(async () => {}),
     rebaseAndRetry: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
+    recreateWithRebase: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
     setMergeBranch: vi.fn(async () => {}),
     approveMerge: vi.fn(async () => {}),
     resolveConflict: vi.fn(async () => {}),


### PR DESCRIPTION
## Summary

Classify `recreate-with-rebase` as a recreate-class mutation so it follows the same queue fencing and running-intent invalidation rules as other recreate flows.

This step makes the coordinator treat the new action as mutually exclusive with in-flight workflow mutations instead of letting it bypass existing mutation ordering guarantees.

## Architecture

### Before

```mermaid
graph TD
    Mutation[recreate-with-rebase request] --> Queue[Mutation coordinator]
    Queue --> Gap[No recreate-class fence classification]
    Gap --> Risk[Can bypass existing recreate queue semantics]
```

### After

```mermaid
graph TD
    Mutation[recreate-with-rebase request] --> Queue[Mutation coordinator]
    Queue --> Fence[Recreate-class queue fence]
    Fence --> Invalidate[Running-intent invalidation]
    Invalidate --> Ordered[Same ordering semantics as recreate flows]
```

## Test Plan

- [ ] `cd packages/app && pnpm test -- --run src/__tests__/persisted-workflow-mutation-coordinator.test.ts` not rerun during stack publication

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #219