### PR TITLE
Recreate-with-Rebase Step 4: add UI action

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -327,6 +327,101 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
+  it('evicts older queued workflow intents when recreate-with-rebase fence starts', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/blocker-task', null]);
+    void running.catch(() => {});
+    const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['old-queued']);
+    void olderQueued.catch(() => {});
+    const recreateWithRebase = coordinator.enqueue<void>('wf-1', 'high', 'invoker:recreate-with-rebase', ['wf-1']);
+    const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['new-queued']);
+
+    await recreateWithRebase;
+    await newerQueued;
+    await expect(running).rejects.toThrow(/superseded by recreate intent/i);
+    await expect(olderQueued).rejects.toThrow(/evicted/i);
+
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:recreate-with-rebase:wf-1',
+      'invoker:edit-task-agent:new-queued',
+    ]);
+  });
+
+  it('invalidates an older running workflow intent when recreate-with-rebase is enqueued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const recreateWithRebase = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:recreate-with-rebase',
+      ['wf-1'],
+    );
+    await recreateWithRebase;
+    await expect(olderRunning).rejects.toThrow(/superseded by recreate intent/i);
+
+    const intentsAfterRecreate = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intentsAfterRecreate.find((intent) => intent.id === 1)?.status).toBe('failed');
+    expect(intentsAfterRecreate.find((intent) => intent.id === 1)?.error).toContain('Superseded by recreate intent #2');
+    expect(intentsAfterRecreate.find((intent) => intent.id === 2)?.status).toBe('completed');
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:recreate-with-rebase:wf-1',
+    ]);
+  });
+
   it('evicts older queued workflow intents when retry-workflow fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -16,6 +16,7 @@ import {
   retryTask,
   retryWorkflow,
   recreateWorkflowFromFreshBase,
+  recreateWithRebase,
   rebaseAndRetry,
   approveTask,
   rejectTask,
@@ -302,6 +303,60 @@ describe('rebaseAndRetry', () => {
         persistence: persistence as unknown as SQLiteAdapter,
       }),
     ).rejects.toThrow('Task missing-task not found or has no workflow');
+  });
+});
+
+describe('recreateWithRebase', () => {
+  it('delegates directly to recreateWorkflowFromFreshBase with the provided workflowId', async () => {
+    const tasks = [makeRunningTask()];
+    const orchestrator = {
+      recreateWorkflowFromFreshBase: vi.fn(async (_id: string, opts?: { refreshBase?: () => Promise<unknown> }) => {
+        await opts?.refreshBase?.();
+        return tasks;
+      }),
+    };
+    const persistence = {
+      loadWorkflow: vi.fn(() => ({
+        id: 'wf-1',
+        generation: 2,
+        repoUrl: 'https://example/repo.git',
+        baseBranch: 'main',
+      })),
+      updateWorkflow: vi.fn(),
+    };
+    const taskExecutor = {
+      preparePoolForRebaseRetry: vi.fn(async () => undefined),
+    } as unknown as TaskRunner;
+
+    const result = await recreateWithRebase('wf-1', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor,
+    });
+
+    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 3 });
+    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+      'wf-1',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
+    );
+    expect(taskExecutor.preparePoolForRebaseRetry).toHaveBeenCalledWith(
+      'wf-1',
+      'https://example/repo.git',
+      'main',
+    );
+    expect(result).toBe(tasks);
+  });
+
+  it('throws when workflow not found', async () => {
+    const orchestrator = { recreateWorkflowFromFreshBase: vi.fn(async () => []) };
+    const persistence = { loadWorkflow: vi.fn(() => undefined), updateWorkflow: vi.fn() };
+
+    await expect(
+      recreateWithRebase('missing', {
+        orchestrator: orchestrator as unknown as Orchestrator,
+        persistence: persistence as unknown as SQLiteAdapter,
+      }),
+    ).rejects.toThrow('Workflow missing not found');
   });
 });
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -110,6 +110,7 @@ import {
   approveTask as sharedApproveTask,
   fixWithAgentAction,
   rebaseAndRetry,
+  recreateWithRebase,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
   resolveConflictAction,
@@ -1830,6 +1831,8 @@ if (isHeadless) {
         return { channel: 'headless.exec', request: { args: ['retry', String(arg0)] } };
       case 'invoker:rebase-and-retry':
         return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
+      case 'invoker:recreate-with-rebase':
+        return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
       case 'invoker:set-merge-mode':
         return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
       case 'invoker:approve-merge': {
@@ -3158,6 +3161,40 @@ if (isHeadless) {
         });
       } catch (err) {
         logger.error(`rebase-and-retry failed: ${err}`, { module: 'ipc' });
+        throw err;
+      }
+      },
+    );
+
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:recreate-with-rebase',
+      (workflowIdArg: unknown) => String(workflowIdArg),
+      'high',
+      async (workflowIdArg: unknown) => {
+      const workflowId = String(workflowIdArg);
+      cancelDeferredWorkflowLaunch(workflowId, 'ipc.recreate-with-rebase');
+      logger.info(`recreate-with-rebase: "${workflowId}"`, { module: 'ipc' });
+      try {
+        await preemptWorkflowBeforeMutation(workflowId, {
+          preemptWorkflowExecution,
+          logger,
+          context: 'ipc.recreate-with-rebase',
+        });
+        const started = await recreateWithRebase(workflowId, {
+          orchestrator,
+          persistence,
+          repoRoot,
+          taskExecutor: requireTaskExecutor(),
+        });
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.recreate-with-rebase',
+          started,
+        });
+      } catch (err) {
+        logger.error(`recreate-with-rebase failed: ${err}`, { module: 'ipc' });
         throw err;
       }
       },

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -298,7 +298,7 @@ export class PersistedWorkflowMutationCoordinator {
   }
 
   private isHardPreemptingRecreateIntent(channel: string, args: unknown[]): boolean {
-    if (channel === 'invoker:recreate-workflow' || channel === 'invoker:recreate-task') {
+    if (channel === 'invoker:recreate-workflow' || channel === 'invoker:recreate-task' || channel === 'invoker:recreate-with-rebase') {
       return true;
     }
     if (channel !== 'headless.exec') {
@@ -314,6 +314,7 @@ export class PersistedWorkflowMutationCoordinator {
       intent.channel === 'invoker:retry-workflow'
       || intent.channel === 'invoker:recreate-workflow'
       || intent.channel === 'invoker:recreate-task'
+      || intent.channel === 'invoker:recreate-with-rebase'
     ) {
       return true;
     }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -239,6 +239,26 @@ export async function recreateWorkflowFromFreshBase(
 }
 
 /**
+ * Recreate a workflow from a fresh upstream base — workflow-scoped
+ * entry point for the `invoker:recreate-with-rebase` IPC channel.
+ *
+ * This is the direct workflow-id counterpart of `rebaseAndRetry`
+ * (which performs a `taskId → workflowId` translation first). Both
+ * delegate to `recreateWorkflowFromFreshBase` for the actual
+ * pool-refresh + generation-bump + DAG reset.
+ */
+export async function recreateWithRebase(
+  workflowId: string,
+  deps: ActionDeps,
+): Promise<TaskState[]> {
+  deps.logger?.info(
+    `recreateWithRebase: workflowId=${workflowId} → recreateWorkflowFromFreshBase`,
+    { module: 'agent-session-trace' },
+  );
+  return recreateWorkflowFromFreshBase(workflowId, deps);
+}
+
+/**
  * Rebase-and-retry: refresh the pool mirror / origin base, remove managed
  * experiment/invoker branches in that mirror, bump generation, and restart the DAG.
  *

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -330,6 +330,10 @@ export const IpcChannels = {
     request: [mergeTaskId: string];
     response: RebaseAndRetryResult;
   },
+  'invoker:recreate-with-rebase': {} as {
+    request: [workflowId: string];
+    response: RebaseAndRetryResult;
+  },
   'invoker:set-merge-branch': {} as {
     request: [workflowId: string, baseBranch: string];
     response: void;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -242,6 +242,18 @@ export function App() {
     }
   }, []);
 
+  const handleRecreateWithRebase = useCallback(async (taskId: string) => {
+    setContextMenu(null);
+    try {
+      const result = await window.invoker?.recreateWithRebase(taskId);
+      if (result && !result.success) {
+        console.error('Recreate with Rebase failed for some branches:', result.errors);
+      }
+    } catch (err) {
+      console.error('Recreate with Rebase failed:', err);
+    }
+  }, []);
+
   const handleRetryWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
@@ -733,6 +745,7 @@ export function App() {
           onReplace={handleReplaceTask}
           onOpenTerminal={handleOpenTerminal}
           onRebaseAndRetry={handleRebaseAndRetry}
+          onRecreateWithRebase={handleRecreateWithRebase}
           onRetryWorkflow={handleRetryWorkflow}
           onRecreateTask={handleRecreateTask}
           onRecreateWorkflow={handleRecreateWorkflow}

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -141,6 +141,21 @@ describe('Context menu (component)', () => {
     });
   });
 
+  it('Recreate with Rebase is visible and triggers distinct handler', async () => {
+    await setupAndRightClick();
+
+    await waitFor(() => {
+      expect(screen.getByText('Recreate with Rebase')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Recreate with Rebase'));
+
+    await waitFor(() => {
+      expect(mock.api.recreateWithRebase).toHaveBeenCalledWith('task-alpha');
+      expect(screen.queryByText('Restart Task')).not.toBeInTheDocument();
+    });
+  });
+
   it('shows and triggers Recreate from Task', async () => {
     await setupAndRightClick();
 

--- a/packages/ui/src/__tests__/context-menu.test.ts
+++ b/packages/ui/src/__tests__/context-menu.test.ts
@@ -122,7 +122,7 @@ describe('ContextMenu getMenuItems', () => {
       const task = makeTask({ status: 'failed', workflowId: 'wf-1' });
       const items = getMenuItems(task);
 
-      const workflowItemIds = ['rebase-retry', 'retry-workflow', 'recreate-task', 'recreate-workflow', 'cancel-workflow', 'delete-workflow'];
+      const workflowItemIds = ['rebase-retry', 'recreate-rebase', 'retry-workflow', 'recreate-task', 'recreate-workflow', 'cancel-workflow', 'delete-workflow'];
       workflowItemIds.forEach((id) => {
         const item = items.find((i) => i.id === id);
         expect(item).toBeDefined();
@@ -165,6 +165,58 @@ describe('ContextMenu getMenuItems', () => {
 
       const rebaseItem = items.find((item) => item.id === 'rebase-retry');
       expect(rebaseItem).toBeUndefined();
+    });
+  });
+
+  describe('Recreate with Rebase visibility', () => {
+    it('is visible for any task with a workflowId', () => {
+      const task = makeTask({ id: 'regular-task', status: 'failed', workflowId: 'wf-1' });
+      const items = getMenuItems(task);
+
+      const item = items.find((i) => i.id === 'recreate-rebase');
+      expect(item).toBeDefined();
+      expect(item?.enabled).toBe(true);
+      expect(item?.action).toBe('onRecreateWithRebase');
+    });
+
+    it('is visible for merge nodes with a workflowId', () => {
+      const task = makeTask({ id: '__merge__wf-1', status: 'failed', isMergeNode: true, workflowId: 'wf-1' });
+      const items = getMenuItems(task);
+
+      const item = items.find((i) => i.id === 'recreate-rebase');
+      expect(item).toBeDefined();
+      expect(item?.enabled).toBe(true);
+    });
+
+    it('is visible regardless of task status', () => {
+      for (const status of ['pending', 'running', 'completed', 'failed'] as const) {
+        const task = makeTask({ id: 'task-1', status, workflowId: 'wf-1' });
+        const items = getMenuItems(task);
+
+        const item = items.find((i) => i.id === 'recreate-rebase');
+        expect(item).toBeDefined();
+      }
+    });
+
+    it('is hidden for tasks without a workflowId', () => {
+      const task = makeTask({ id: 'orphan-task', status: 'failed' });
+      const items = getMenuItems(task);
+
+      const item = items.find((i) => i.id === 'recreate-rebase');
+      expect(item).toBeUndefined();
+    });
+
+    it('is distinct from rebase-retry', () => {
+      const task = makeTask({ status: 'failed', workflowId: 'wf-1' });
+      const items = getMenuItems(task);
+
+      const rebaseRetry = items.find((i) => i.id === 'rebase-retry');
+      const recreateRebase = items.find((i) => i.id === 'recreate-rebase');
+
+      expect(rebaseRetry).toBeDefined();
+      expect(recreateRebase).toBeDefined();
+      expect(rebaseRetry?.action).toBe('onRebaseAndRetry');
+      expect(recreateRebase?.action).toBe('onRecreateWithRebase');
     });
   });
 

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -134,6 +134,7 @@ export function createMockInvoker(
     recreateTask: vi.fn(async () => {}),
     retryWorkflow: vi.fn(async () => {}),
     rebaseAndRetry: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
+    recreateWithRebase: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
     setMergeBranch: vi.fn(async () => {}),
     approveMerge: vi.fn(async () => {}),
     resolveConflict: vi.fn(async () => {}),

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -23,6 +23,7 @@ interface ContextMenuProps {
   onReplace: (taskId: string) => void;
   onOpenTerminal: (taskId: string) => void;
   onRebaseAndRetry?: (taskId: string) => void;
+  onRecreateWithRebase?: (taskId: string) => void;
   onRetryWorkflow?: (workflowId: string) => void;
   onRecreateTask?: (taskId: string) => void;
   onRecreateWorkflow?: (workflowId: string) => void;
@@ -41,6 +42,7 @@ export function ContextMenu({
   onReplace,
   onOpenTerminal,
   onRebaseAndRetry,
+  onRecreateWithRebase,
   onRetryWorkflow,
   onRecreateTask,
   onRecreateWorkflow,
@@ -61,6 +63,7 @@ export function ContextMenu({
   // Filter items based on available handlers
   const availableItems = items.filter((item) => {
     if (item.action === 'onRebaseAndRetry' && !onRebaseAndRetry) return false;
+    if (item.action === 'onRecreateWithRebase' && !onRecreateWithRebase) return false;
     if (item.action === 'onRetryWorkflow' && !onRetryWorkflow) return false;
     if (item.action === 'onRecreateTask' && !onRecreateTask) return false;
     if (item.action === 'onRecreateWorkflow' && !onRecreateWorkflow) return false;
@@ -189,6 +192,9 @@ export function ContextMenu({
         break;
       case 'onRebaseAndRetry':
         onRebaseAndRetry?.(task.id);
+        break;
+      case 'onRecreateWithRebase':
+        onRecreateWithRebase?.(task.id);
         break;
       case 'onRetryWorkflow':
         onRetryWorkflow?.(task.config.workflowId!);

--- a/packages/ui/src/lib/context-menu-items.ts
+++ b/packages/ui/src/lib/context-menu-items.ts
@@ -121,6 +121,14 @@ export function getMenuItems(
     });
 
     items.push({
+      id: 'recreate-rebase',
+      label: 'Recreate with Rebase',
+      enabled: true,
+      action: 'onRecreateWithRebase',
+      variant: 'warning',
+    });
+
+    items.push({
       id: 'retry-workflow',
       label: 'Retry',
       enabled: true,


### PR DESCRIPTION
## Summary

Add a dedicated UI action for Recreate with Rebase while preserving the existing Retry with Rebase entrypoint.

This step separates the two user intents in the renderer and context menu so recreate semantics become discoverable without overloading the retry action.

## Architecture

### Before

```mermaid
graph TD
    Menu[Workflow context menu] --> Retry[Retry with Rebase]
    Retry --> Renderer[Single renderer handler]
```

### After

```mermaid
graph TD
    Menu[Workflow context menu] --> Retry[Retry with Rebase]
    Menu --> Recreate[Recreate with Rebase]
    Retry --> Renderer[Existing retry handler]
    Recreate --> Renderer[Dedicated recreate handler]
```

## Test Plan

- [ ] `cd packages/ui && pnpm test -- --run src/__tests__/context-menu.test.ts src/__tests__/context-menu-e2e.test.tsx` not rerun during stack publication

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #220