### PR TITLE
Recreate-with-Rebase Step 5: add headless and delegation parity

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1117,6 +1117,31 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
+        it('headless `recreate-with-rebase <wfId>` routes to orchestrator.recreateWorkflowFromFreshBase with workflowId directly', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['recreate-with-rebase', 'wf-1'], depsWithNoTrack);
+
+          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledTimes(1);
+          expect(
+            (mockDeps.orchestrator.recreateWorkflowFromFreshBase as any).mock.calls[0][0],
+          ).toBe('wf-1');
+          expect(preparePoolSpy).toHaveBeenCalledWith(
+            'wf-1',
+            'https://example/repo.git',
+            'main',
+          );
+
+          preparePoolSpy.mockRestore();
+        });
+
         it('headless `recreate <wfId>` routes to orchestrator.recreateWorkflow — NOT recreateWorkflowFromFreshBase (no upstream pool refresh)', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
           mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
@@ -1332,6 +1357,33 @@ describe('headless delegation enforcement', () => {
           );
           // The whole reason rebase is a separate cell from
           // recreate-workflow: it refreshes the upstream pool/base.
+          expect(preparePoolSpy).toHaveBeenCalledWith(
+            'wf-1',
+            'https://example/repo.git',
+            'main',
+          );
+          expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+          expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
+          expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
+          expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
+          expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
+          preparePoolSpy.mockRestore();
+        });
+
+        it('headless `recreate-with-rebase <wfId>` routes to orchestrator.recreateWorkflowFromFreshBase (only) — takes workflowId directly', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedHappyPath();
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['recreate-with-rebase', 'wf-1'], depsWithNoTrack);
+
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+            'wf-1',
+            expect.objectContaining({ refreshBase: expect.any(Function) }),
+          );
           expect(preparePoolSpy).toHaveBeenCalledWith(
             'wf-1',
             'https://example/repo.git',

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -67,6 +67,10 @@ describe('headless→owner delegation', () => {
       expect(delegationTimeoutMs(['rebase-and-retry', 'wf-1'], targetLookup)).toBe(60_000);
     });
 
+    it('uses 60s timeout for workflow-scoped recreate-with-rebase', () => {
+      expect(delegationTimeoutMs(['recreate-with-rebase', 'wf-1'], targetLookup)).toBe(60_000);
+    });
+
     it('uses 60s timeout for workflow-scoped restart', () => {
       expect(delegationTimeoutMs(['restart', 'wf-123'], targetLookup)).toBe(60_000);
     });
@@ -220,6 +224,25 @@ describe('headless→owner delegation', () => {
         waitForApproval: undefined,
       }));
     });
+
+    it('delegates recreate-with-rebase command to owner', async () => {
+      const ownerHandler = vi.fn(async () => ({ success: true }));
+      messageBus.onRequest('headless.exec', ownerHandler);
+
+      const delegated = await tryDelegateExec(
+        ['recreate-with-rebase', 'wf-1'],
+        messageBus,
+        undefined,
+        true,
+      );
+
+      expect(delegated).toBe(true);
+      expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
+        args: ['recreate-with-rebase', 'wf-1'],
+        noTrack: true,
+        waitForApproval: undefined,
+      }));
+    });
   });
 
   describe('fallback to standalone when owner is unavailable', () => {
@@ -255,6 +278,7 @@ describe('headless→owner delegation', () => {
     it.each([
       ['rebase', ['rebase', 'wf-1']],
       ['rebase-and-retry', ['rebase-and-retry', 'wf-1']],
+      ['recreate-with-rebase', ['recreate-with-rebase', 'wf-1']],
       ['restart workflow', ['restart', 'wf-123']],
     ])('keeps %s pending at 5s and only times out at 60s', async (_label, args) => {
       const delegatedPromise = tryDelegateExec(

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -121,7 +121,7 @@ export function isHeadlessMutatingCommand(args: string[]): boolean {
   }
 
   return [
-    'run', 'resume', 'retry', 'retry-task', 'recreate', 'recreate-task', 'rebase', 'fix', 'resolve-conflict',
+    'run', 'resume', 'retry', 'retry-task', 'recreate', 'recreate-task', 'rebase', 'recreate-with-rebase', 'fix', 'resolve-conflict',
     'detach-workflow',
     'migrate-compat',
     'rebase-and-retry',

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -56,7 +56,7 @@ export async function tryDelegateResume(
 }
 
 function usesExtendedDelegationTimeout(command: string): boolean {
-  return command === 'rebase' || command === 'rebase-and-retry' || command === 'restart';
+  return command === 'rebase' || command === 'rebase-and-retry' || command === 'recreate-with-rebase' || command === 'restart';
 }
 
 function looksLikeWorkflowId(target: unknown): boolean {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -34,6 +34,7 @@ import {
   approveTask,
   fixWithAgentAction,
   rebaseAndRetry,
+  recreateWithRebase,
   resolveConflictAction,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
@@ -708,6 +709,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       warnDeprecated('rebase-and-retry', 'rebase');
       await headlessRebaseAndRetry(args[1], deps);
       break;
+    case 'recreate-with-rebase':
+      await headlessRecreateWithRebase(args[1], deps);
+      break;
     case 'fix':
       await headlessFix(args[1], deps, args[2]);
       break;
@@ -1371,6 +1375,46 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
 
   const tasksStarted = runnable.length;
   process.stdout.write(`Rebase-and-retry: resetting workflow from current HEAD (${tasksStarted} task(s))\n`);
+}
+
+async function headlessRecreateWithRebase(workflowId: string, deps: HeadlessDeps): Promise<void> {
+  if (!workflowId) throw new Error('Missing arguments. Usage: --headless recreate-with-rebase <workflowId>');
+  await preemptWorkflowBeforeMutation(workflowId, {
+    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
+    logger: deps.logger,
+    context: 'headless.recreate-with-rebase',
+  });
+
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  const started = await recreateWithRebase(workflowId, { ...deps, taskExecutor: te });
+  const runnable = started.filter(t => t.status === 'running');
+  const { topup } = await dispatchStartedTasksWithGlobalTopup({
+    orchestrator: deps.orchestrator,
+    taskExecutor: te,
+    logger: deps.logger,
+    context: 'headless.recreate-with-rebase',
+    started,
+  });
+  if (runnable.length + topup.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: recreate-with-rebase accepted; exiting without tracking.\n');
+    autoFix.unsubscribe();
+    return;
+  }
+  await trackHeadlessWorkflow(workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
+  autoFix.unsubscribe();
+
+  const tasksStarted2 = runnable.length;
+  process.stdout.write(`Recreate-with-rebase: resetting workflow from fresh base (${tasksStarted2} task(s))\n`);
 }
 
 async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1834,7 +1834,7 @@ if (isHeadless) {
       case 'invoker:rebase-and-retry':
         return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
       case 'invoker:recreate-with-rebase':
-        return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['recreate-with-rebase', String(arg0)] } };
       case 'invoker:set-merge-mode':
         return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
       case 'invoker:approve-merge': {


### PR DESCRIPTION
## Summary

Expose `recreate-with-rebase` through the headless surface and owner-delegation translation so non-GUI callers can trigger the same workflow-scoped mutation.

This step keeps the GUI, headless, and delegated command surfaces aligned by routing the new action through the same command classification and translation path.

## Architecture

### Before

```mermaid
graph TD
    Headless[Headless and delegated commands] --> Legacy[rebase-and-retry aliases only]
    Legacy --> Main[Main-process workflow mutation path]
```

### After

```mermaid
graph TD
    Headless[Headless and delegated commands] --> Command[recreate-with-rebase command]
    Command --> Translate[Owner-delegation translation]
    Translate --> Main[Main-process workflow mutation path]
    Legacy[Existing aliases] --> Main
```

## Test Plan

- [ ] `cd packages/app && pnpm test -- --run src/__tests__/headless-delegation.test.ts src/__tests__/owner-delegation.test.ts` not rerun during stack publication

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #221