### PR TITLE
Recreate-with-Rebase Step 6: add HTTP endpoint and docs alignment

### DIFF
--- a/docs/persistence-architecture-single-writer.md
+++ b/docs/persistence-architecture-single-writer.md
@@ -35,7 +35,7 @@ This table lists every mutating command path and how the owner-boundary contract
 | `invoker:recreate-workflow` | main.ts:1043 | N/A (owner) | `sharedRecreateWorkflow()` → persistence bump + orchestrator | |
 | `invoker:recreate-task` | main.ts:1060 | N/A (owner) | `sharedRecreateTask()` → persistence | |
 | `invoker:retry-workflow` | main.ts:1077 | N/A (owner) | `sharedRetryWorkflow()` → orchestrator | |
-| `invoker:rebase-and-retry` | main.ts:1094 | N/A (owner) | `rebaseAndRetry()` → persistence + orchestrator | |
+| `invoker:rebase-and-retry` | main.ts:1094 | N/A (owner) | `rebaseAndRetry()` → persistence + orchestrator | Deprecated alias; prefer `recreate-with-rebase` |
 | `invoker:set-merge-mode` | main.ts:1129 | N/A (owner) | `setWorkflowMergeMode()` → persistence.updateWorkflow | |
 | `invoker:approve-merge` | main.ts:1147 | N/A (owner) | `orchestrator.approve()` → persistence | |
 | `invoker:resolve-conflict` | main.ts:1182 | N/A (owner) | `resolveConflictAction()` → persistence + orchestrator | |
@@ -52,7 +52,7 @@ This table lists every mutating command path and how the owner-boundary contract
 | `restart` | headless.ts:707 | **Yes** (line 365) | `tryDelegateExec()` → IPC `headless.exec` OR standalone writable | Workflow-scoped `restart wf-…` delegates with a 60s timeout; task-scoped restart stays at 5s |
 | `recreate` | headless.ts:769 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
 | `recreate-task` | headless.ts:788 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
-| `rebase` | headless.ts:754 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | Workflow-scoped `rebase wf-…` and deprecated `rebase-and-retry wf-…` delegates use a 60s timeout; task-scoped rebase stays at 5s |
+| `rebase` / `recreate-with-rebase` | headless.ts:754 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | Workflow-scoped `recreate-with-rebase wf-…` (first-class) and deprecated `rebase-and-retry wf-…` delegates use a 60s timeout; task-scoped rebase stays at 5s |
 | `approve` | headless.ts:666 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
 | `reject` | headless.ts:681 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
 | `input` | headless.ts:688 | **Yes** (line 365) | `tryDelegateExec()` OR standalone writable | |
@@ -94,7 +94,7 @@ This table lists every mutating command path and how the owner-boundary contract
 | Component | File | Line(s) | Enforcement Mechanism |
 |-----------|------|---------|----------------------|
 | **GUI main process** | packages/app/src/main.ts | 605-613 | `initServices()` opens writable DB (no `readOnly` flag) |
-| **Headless delegation** | packages/app/src/main.ts, packages/app/src/headless-delegation.ts | 346-381, 14-65 | `tryDelegateRun()`, `tryDelegateResume()`, `tryDelegateExec()` send IPC request to owner; `run`, `resume`, and default `exec` delegation use 5s timeout, while workflow-scoped `rebase` / `rebase-and-retry` / `restart` use 60s before standalone fallback |
+| **Headless delegation** | packages/app/src/main.ts, packages/app/src/headless-delegation.ts | 346-381, 14-65 | `tryDelegateRun()`, `tryDelegateResume()`, `tryDelegateExec()` send IPC request to owner; `run`, `resume`, and default `exec` delegation use 5s timeout, while workflow-scoped `rebase` / `recreate-with-rebase` / `rebase-and-retry` / `restart` use 60s before standalone fallback |
 | **Headless standalone** | packages/app/src/main.ts | 386 | `initServices({ readOnly: isHeadlessReadOnlyCommand(cliArgs) })` — read-only for query commands, writable for standalone mutating commands (when `INVOKER_HEADLESS_STANDALONE=1` or no GUI) |
 | **SQLiteAdapter read-only gate** | packages/persistence/src/sqlite-adapter.ts | 113-117 | `ensureWritable()` throws if `readOnly: true` and a write is attempted |
 | **Delegation handlers (owner)** | packages/app/src/main.ts | 618-674 | `headless.run`, `headless.resume`, `headless.exec` IPC handlers receive delegated commands, execute via owner's writable orchestrator/persistence |
@@ -102,10 +102,10 @@ This table lists every mutating command path and how the owner-boundary contract
 ### Critical Guarantees
 
 1. **GUI always owns DB**: When GUI is running, `initServices()` (main.ts:605) opens writable persistence. All IPC handlers mutate via this owner instance.
-2. **Headless delegates by default**: When GUI is present, headless commands try delegation first. `run`, `resume`, and most `headless.exec` commands use a 5s timeout; workflow-scoped `rebase`, `rebase-and-retry`, and `restart` use 60s. Only if delegation fails (no GUI or timeout) does headless open its own writable DB.
+2. **Headless delegates by default**: When GUI is present, headless commands try delegation first. `run`, `resume`, and most `headless.exec` commands use a 5s timeout; workflow-scoped `rebase`, `recreate-with-rebase`, `rebase-and-retry`, and `restart` use 60s. Only if delegation fails (no GUI or timeout) does headless open its own writable DB.
 3. **Read-only commands never delegate**: `query` subcommands always open `readOnly: true` persistence (main.ts:386), never write.
 4. **Standalone escape hatch**: `INVOKER_HEADLESS_STANDALONE=1` skips delegation, allowing headless to own the DB (main.ts:348-349).
-5. **Delegation timeout prevents deadlock**: IPC delegation is bounded so headless does not hang if GUI is unresponsive. The default is 5s, with a 60s allowance for workflow-scoped `rebase`, `rebase-and-retry`, and `restart` command shapes in `headless.exec`.
+5. **Delegation timeout prevents deadlock**: IPC delegation is bounded so headless does not hang if GUI is unresponsive. The default is 5s, with a 60s allowance for workflow-scoped `rebase`, `recreate-with-rebase`, `rebase-and-retry`, and `restart` command shapes in `headless.exec`.
 
 ### Test Coverage
 

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -911,6 +911,39 @@ describe('POST /api/workflows/:id/fork', () => {
   });
 });
 
+describe('POST /api/workflows/:id/recreate-with-rebase', () => {
+  it('recreates workflow from fresh base', async () => {
+    mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn().mockResolvedValue([makeTask()]);
+    const res = await request(port, 'POST', '/api/workflows/wf-1/recreate-with-rebase');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.action).toBe('recreated_with_rebase');
+    expect(res.body.tasksStarted).toBe(1);
+    expect(res.body.deprecated).toBeUndefined();
+    expect(mocks.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+      'wf-1',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
+    );
+  });
+
+  it('rebase-and-retry still works as deprecated alias', async () => {
+    mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn().mockResolvedValue([makeTask()]);
+    const res = await request(port, 'POST', '/api/workflows/wf-1/rebase-and-retry');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.action).toBe('rebase_and_retried');
+    expect(res.body.deprecated).toBe(true);
+    expect(res.body.replacement).toBe('/api/workflows/:id/recreate-with-rebase');
+  });
+
+  it('returns 404 when workflow not found', async () => {
+    mocks.persistence.loadWorkflow.mockReturnValue(undefined);
+    const res = await request(port, 'POST', '/api/workflows/missing/recreate-with-rebase');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('not found');
+  });
+});
+
 describe('DELETE /api/workflows/:id', () => {
   it('deletes workflow', async () => {
     const res = await request(port, 'DELETE', '/api/workflows/wf-1');

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1117,6 +1117,31 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
+        it('headless `recreate-with-rebase <wfId>` routes to orchestrator.recreateWorkflowFromFreshBase with workflowId directly', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['recreate-with-rebase', 'wf-1'], depsWithNoTrack);
+
+          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledTimes(1);
+          expect(
+            (mockDeps.orchestrator.recreateWorkflowFromFreshBase as any).mock.calls[0][0],
+          ).toBe('wf-1');
+          expect(preparePoolSpy).toHaveBeenCalledWith(
+            'wf-1',
+            'https://example/repo.git',
+            'main',
+          );
+
+          preparePoolSpy.mockRestore();
+        });
+
         it('headless `recreate <wfId>` routes to orchestrator.recreateWorkflow — NOT recreateWorkflowFromFreshBase (no upstream pool refresh)', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
           mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
@@ -1332,6 +1357,33 @@ describe('headless delegation enforcement', () => {
           );
           // The whole reason rebase is a separate cell from
           // recreate-workflow: it refreshes the upstream pool/base.
+          expect(preparePoolSpy).toHaveBeenCalledWith(
+            'wf-1',
+            'https://example/repo.git',
+            'main',
+          );
+          expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+          expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
+          expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
+          expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
+          expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
+          preparePoolSpy.mockRestore();
+        });
+
+        it('headless `recreate-with-rebase <wfId>` routes to orchestrator.recreateWorkflowFromFreshBase (only) — takes workflowId directly', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedHappyPath();
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['recreate-with-rebase', 'wf-1'], depsWithNoTrack);
+
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+            'wf-1',
+            expect.objectContaining({ refreshBase: expect.any(Function) }),
+          );
           expect(preparePoolSpy).toHaveBeenCalledWith(
             'wf-1',
             'https://example/repo.git',

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -67,6 +67,10 @@ describe('headless→owner delegation', () => {
       expect(delegationTimeoutMs(['rebase-and-retry', 'wf-1'], targetLookup)).toBe(60_000);
     });
 
+    it('uses 60s timeout for workflow-scoped recreate-with-rebase', () => {
+      expect(delegationTimeoutMs(['recreate-with-rebase', 'wf-1'], targetLookup)).toBe(60_000);
+    });
+
     it('uses 60s timeout for workflow-scoped restart', () => {
       expect(delegationTimeoutMs(['restart', 'wf-123'], targetLookup)).toBe(60_000);
     });
@@ -220,6 +224,25 @@ describe('headless→owner delegation', () => {
         waitForApproval: undefined,
       }));
     });
+
+    it('delegates recreate-with-rebase command to owner', async () => {
+      const ownerHandler = vi.fn(async () => ({ success: true }));
+      messageBus.onRequest('headless.exec', ownerHandler);
+
+      const delegated = await tryDelegateExec(
+        ['recreate-with-rebase', 'wf-1'],
+        messageBus,
+        undefined,
+        true,
+      );
+
+      expect(delegated).toBe(true);
+      expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
+        args: ['recreate-with-rebase', 'wf-1'],
+        noTrack: true,
+        waitForApproval: undefined,
+      }));
+    });
   });
 
   describe('fallback to standalone when owner is unavailable', () => {
@@ -255,6 +278,7 @@ describe('headless→owner delegation', () => {
     it.each([
       ['rebase', ['rebase', 'wf-1']],
       ['rebase-and-retry', ['rebase-and-retry', 'wf-1']],
+      ['recreate-with-rebase', ['recreate-with-rebase', 'wf-1']],
       ['restart workflow', ['restart', 'wf-123']],
     ])('keeps %s pending at 5s and only times out at 60s', async (_label, args) => {
       const delegatedPromise = tryDelegateExec(

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -28,6 +28,7 @@
  *   POST   /api/tasks/:id/gate-policy  body: { updates: [{ workflowId, taskId?, gatePolicy }] }
  *   POST   /api/workflows/:id/detach  body: { upstreamWorkflowId }
  *   POST   /api/workflows/:id/restart
+ *   POST   /api/workflows/:id/recreate-with-rebase
  *   POST   /api/workflows/:id/cancel
  *   POST   /api/workflows/:id/merge-mode  body: { mode }
  *   DELETE /api/workflows/:id
@@ -426,9 +427,11 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      const wfRecreateWithRebaseMatch = path.match(/^\/api\/workflows\/([^/]+)\/recreate-with-rebase$/);
       const wfRebaseAndRetryMatch = path.match(/^\/api\/workflows\/([^/]+)\/rebase-and-retry$/);
-      if (method === 'POST' && wfRebaseAndRetryMatch) {
-        const workflowId = decodeURIComponent(wfRebaseAndRetryMatch[1]);
+      if (method === 'POST' && (wfRecreateWithRebaseMatch || wfRebaseAndRetryMatch)) {
+        const isLegacy = !!wfRebaseAndRetryMatch;
+        const workflowId = decodeURIComponent((wfRecreateWithRebaseMatch ?? wfRebaseAndRetryMatch)![1]);
         try {
           const started = await sharedRecreateWorkflowFromFreshBase(workflowId, {
             orchestrator,
@@ -442,14 +445,21 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             orchestrator,
             taskExecutor,
             logger: apiLogger,
-            context: 'api.workflows.rebase-and-retry',
+            context: isLegacy ? 'api.workflows.rebase-and-retry' : 'api.workflows.recreate-with-rebase',
             alreadyDispatched: runnable,
           });
+          if (isLegacy) {
+            res.setHeader(
+              'Deprecation',
+              'true; reason="Use /api/workflows/:id/recreate-with-rebase"',
+            );
+          }
           json(res, 200, {
             ok: true,
             workflowId,
-            action: 'rebase_and_retried',
+            action: isLegacy ? 'rebase_and_retried' : 'recreated_with_rebase',
             tasksStarted: runnable.length,
+            ...(isLegacy ? { deprecated: true, replacement: '/api/workflows/:id/recreate-with-rebase' } : {}),
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -121,7 +121,7 @@ export function isHeadlessMutatingCommand(args: string[]): boolean {
   }
 
   return [
-    'run', 'resume', 'retry', 'retry-task', 'recreate', 'recreate-task', 'rebase', 'fix', 'resolve-conflict',
+    'run', 'resume', 'retry', 'retry-task', 'recreate', 'recreate-task', 'rebase', 'recreate-with-rebase', 'fix', 'resolve-conflict',
     'detach-workflow',
     'migrate-compat',
     'rebase-and-retry',

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -56,7 +56,7 @@ export async function tryDelegateResume(
 }
 
 function usesExtendedDelegationTimeout(command: string): boolean {
-  return command === 'rebase' || command === 'rebase-and-retry' || command === 'restart';
+  return command === 'rebase' || command === 'rebase-and-retry' || command === 'recreate-with-rebase' || command === 'restart';
 }
 
 function looksLikeWorkflowId(target: unknown): boolean {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -34,6 +34,7 @@ import {
   approveTask,
   fixWithAgentAction,
   rebaseAndRetry,
+  recreateWithRebase,
   resolveConflictAction,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
@@ -708,6 +709,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       warnDeprecated('rebase-and-retry', 'rebase');
       await headlessRebaseAndRetry(args[1], deps);
       break;
+    case 'recreate-with-rebase':
+      await headlessRecreateWithRebase(args[1], deps);
+      break;
     case 'fix':
       await headlessFix(args[1], deps, args[2]);
       break;
@@ -1371,6 +1375,46 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
 
   const tasksStarted = runnable.length;
   process.stdout.write(`Rebase-and-retry: resetting workflow from current HEAD (${tasksStarted} task(s))\n`);
+}
+
+async function headlessRecreateWithRebase(workflowId: string, deps: HeadlessDeps): Promise<void> {
+  if (!workflowId) throw new Error('Missing arguments. Usage: --headless recreate-with-rebase <workflowId>');
+  await preemptWorkflowBeforeMutation(workflowId, {
+    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
+    logger: deps.logger,
+    context: 'headless.recreate-with-rebase',
+  });
+
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  const started = await recreateWithRebase(workflowId, { ...deps, taskExecutor: te });
+  const runnable = started.filter(t => t.status === 'running');
+  const { topup } = await dispatchStartedTasksWithGlobalTopup({
+    orchestrator: deps.orchestrator,
+    taskExecutor: te,
+    logger: deps.logger,
+    context: 'headless.recreate-with-rebase',
+    started,
+  });
+  if (runnable.length + topup.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: recreate-with-rebase accepted; exiting without tracking.\n');
+    autoFix.unsubscribe();
+    return;
+  }
+  await trackHeadlessWorkflow(workflowId, deps, {
+    hasBackgroundWork: autoFix.isBusy,
+    printSummary: false,
+    printTaskOutput: true,
+    setExitCodeOnFailure: false,
+  });
+  autoFix.unsubscribe();
+
+  const tasksStarted2 = runnable.length;
+  process.stdout.write(`Recreate-with-rebase: resetting workflow from fresh base (${tasksStarted2} task(s))\n`);
 }
 
 async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -867,8 +867,9 @@ ${BOLD}Execute:${RESET}
   recreate <workflowId>                                Recreate workflow: wipe all state, new generation
   recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
   fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
+  rebase <taskId>                                     Refresh pool base + nuclear restart (task-scoped)
+  recreate-with-rebase <workflowId>                   Recreate workflow from fresh upstream base
   detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
-  rebase <taskId>                                     Refresh pool base + nuclear restart
   fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
   resolve-conflict <taskId> [claude|codex]            Resolve merge conflict + restart
 
@@ -905,7 +906,7 @@ ${BOLD}Deprecated${RESET} (use new names above):
   edit → set command            edit-executor → set executor
   edit-agent → set agent        set-merge-mode → set merge-mode
   delete-workflow → delete
-  rebase-and-retry → rebase
+  rebase-and-retry → rebase (task) or recreate-with-rebase (workflow)
 
 ${BOLD}Options:${RESET}
   --wait-for-approval    Keep running until PR approval (use with 'run' or 'resume')

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1834,7 +1834,7 @@ if (isHeadless) {
       case 'invoker:rebase-and-retry':
         return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
       case 'invoker:recreate-with-rebase':
-        return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['recreate-with-rebase', String(arg0)] } };
       case 'invoker:set-merge-mode':
         return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
       case 'invoker:approve-merge': {


### PR DESCRIPTION
## Summary

Add an HTTP `recreate-with-rebase` workflow endpoint and align API/help documentation so the action is first-class across automation surfaces.

This step gives API clients the same capability already exposed in GUI and headless paths while keeping compatibility aliases intact and updating the persistence/docs wording to match the final surface area.

## Architecture

### Before

```mermaid
graph TD
    Clients[Automation clients] --> Headless[GUI or headless surfaces only]
    Headless --> Main[Workflow mutation path]
```

### After

```mermaid
graph TD
    Clients[Automation clients] --> API[POST /api/workflows/:id/recreate-with-rebase]
    API --> Main[Workflow mutation path]
    Docs[Help and architecture docs] --> API
    GUI[GUI and headless surfaces] --> Main
```

## Test Plan

- [ ] `cd packages/app && pnpm test -- --run src/__tests__/api-server.test.ts` not rerun during stack publication

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #222