### PR TITLE
Add synthetic review-base and landing stack publication

### DIFF
--- a/docs/pr-branching-workflow.md
+++ b/docs/pr-branching-workflow.md
@@ -38,3 +38,17 @@ node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-p
 ```
 
 By default, tools in this workflow use `upstream` as the parent remote. Override it when your team uses a different remote name.
+
+## Invoker Review Stacks
+
+Invoker-on-Invoker review publication now has two distinct lanes:
+
+- `publish-review-stack <workflowId>` creates a synthetic `review-base/<root-workflow-id>` branch and publishes a Mergify review stack on top of that fork-point base. This keeps stale workflow histories reviewable even when `upstream/master` has moved on.
+- `publish-landing-stack <workflowId>` rebuilds the same workflow chain on current `upstream/master` and publishes the mergeable landing stack that Mergify can queue against `master`.
+
+Why this split exists:
+
+- GitHub review diffs are computed from actual branch ancestry, not intent.
+- A stale workflow branch can contain the right logical change but still show a noisy PR against current `master`.
+- The synthetic review base preserves the old fork point for human review.
+- The landing stack reapplies the reviewed delta onto fresh `upstream/master` for mergeability.

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -32,11 +32,13 @@ describe('applyPlanDefinitionDefaults', () => {
     const plan = applyPlanDefinitionDefaults({
       name: 'X',
       baseBranch: 'develop',
+      parentRemote: ' upstream ',
       featureBranch: 'feat/x',
       onFinish: 'merge',
       tasks: [{ id: 'a', description: 'd', command: 'echo' }],
     });
     expect(plan.baseBranch).toBe('develop');
+    expect(plan.parentRemote).toBe('upstream');
     expect(plan.featureBranch).toBe('feat/x');
     expect(plan.onFinish).toBe('merge');
   });
@@ -78,6 +80,7 @@ tasks:
     const yaml = `
 name: Hello World Test
 repoUrl: git@github.com:test/repo.git
+parentRemote: upstream
 tasks:
   - id: greet
     description: Say hello
@@ -85,6 +88,7 @@ tasks:
 `;
     const plan = parsePlan(yaml);
     expect(plan.name).toBe('Hello World Test');
+    expect(plan.parentRemote).toBe('upstream');
     expect(plan.tasks).toHaveLength(1);
     expect(plan.tasks[0].id).toBe('greet');
     expect(plan.tasks[0].description).toBe('Say hello');

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -27,6 +27,8 @@
  *   POST   /api/tasks/:id/edit-agent   body: { agent }
  *   POST   /api/tasks/:id/gate-policy  body: { updates: [{ workflowId, taskId?, gatePolicy }] }
  *   POST   /api/workflows/:id/restart
+ *   POST   /api/workflows/:id/publish-review-stack
+ *   POST   /api/workflows/:id/publish-landing-stack
  *   POST   /api/workflows/:id/cancel
  *   POST   /api/workflows/:id/merge-mode  body: { mode }
  *   DELETE /api/workflows/:id
@@ -482,6 +484,32 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           const message = err instanceof Error ? err.message : String(err);
           const statusCode = message.includes('not found') ? 404 : 400;
           json(res, statusCode, { error: message });
+        }
+        return;
+      }
+
+      const wfPublishReviewMatch = path.match(/^\/api\/workflows\/([^/]+)\/publish-review-stack$/);
+      if (method === 'POST' && wfPublishReviewMatch) {
+        const workflowId = decodeURIComponent(wfPublishReviewMatch[1]);
+        try {
+          const result = await taskExecutor.publishReviewStack(workflowId);
+          json(res, 200, { ok: true, workflowId, action: 'published_review_stack', reviewUrl: result.reviewUrl });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          json(res, message.includes('not found') ? 404 : 400, { error: message });
+        }
+        return;
+      }
+
+      const wfPublishLandingMatch = path.match(/^\/api\/workflows\/([^/]+)\/publish-landing-stack$/);
+      if (method === 'POST' && wfPublishLandingMatch) {
+        const workflowId = decodeURIComponent(wfPublishLandingMatch[1]);
+        try {
+          const result = await taskExecutor.publishLandingStack(workflowId);
+          json(res, 200, { ok: true, workflowId, action: 'published_landing_stack', landingUrl: result.landingUrl });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          json(res, message.includes('not found') ? 404 : 400, { error: message });
         }
         return;
       }

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -259,9 +259,16 @@ export function serializeWorkflow(wf: Workflow): Record<string, unknown> {
     ...(wf.branch != null && { branch: wf.branch }),
     ...(wf.onFinish != null && { onFinish: wf.onFinish }),
     ...(wf.baseBranch != null && { baseBranch: wf.baseBranch }),
+    ...(wf.parentRemote != null && { parentRemote: wf.parentRemote }),
     ...(wf.featureBranch != null && { featureBranch: wf.featureBranch }),
     ...(wf.mergeMode != null && { mergeMode: wf.mergeMode }),
     ...(wf.reviewProvider != null && { reviewProvider: wf.reviewProvider }),
+    ...(wf.publicationState != null && { publicationState: wf.publicationState }),
+    ...(wf.reviewBaseSha != null && { reviewBaseSha: wf.reviewBaseSha }),
+    ...(wf.reviewBaseBranch != null && { reviewBaseBranch: wf.reviewBaseBranch }),
+    ...(wf.reviewPrUrl != null && { reviewPrUrl: wf.reviewPrUrl }),
+    ...(wf.landingBaseSha != null && { landingBaseSha: wf.landingBaseSha }),
+    ...(wf.landingPrUrl != null && { landingPrUrl: wf.landingPrUrl }),
     ...(wf.generation != null && { generation: wf.generation }),
   };
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -699,6 +699,12 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'rebase':
       await headlessRebaseAndRetry(args[1], deps);
       break;
+    case 'publish-review-stack':
+      await headlessPublishReviewStack(args[1], deps);
+      break;
+    case 'publish-landing-stack':
+      await headlessPublishLandingStack(args[1], deps);
+      break;
 
     // Deprecated aliases
     case 'rebase-and-retry':
@@ -861,6 +867,8 @@ ${BOLD}Execute:${RESET}
   recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
   fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
   rebase <taskId>                                     Refresh pool base + nuclear restart
+  publish-review-stack <workflowId>                   Publish synthetic review-base stack for Invoker review
+  publish-landing-stack <workflowId>                  Publish upstream/master landing stack for Invoker review
   fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
   resolve-conflict <taskId> [claude|codex]            Resolve merge conflict + restart
 
@@ -1367,6 +1375,20 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
 
   const tasksStarted = runnable.length;
   process.stdout.write(`Rebase-and-retry: resetting workflow from current HEAD (${tasksStarted} task(s))\n`);
+}
+
+async function headlessPublishReviewStack(workflowId: string, deps: HeadlessDeps): Promise<void> {
+  if (!workflowId) throw new Error('Missing workflowId. Usage: --headless publish-review-stack <workflowId>');
+  const te = createHeadlessExecutor(deps);
+  const result = await te.publishReviewStack(workflowId);
+  process.stdout.write(`Review stack published for ${workflowId}: ${result.reviewUrl}\n`);
+}
+
+async function headlessPublishLandingStack(workflowId: string, deps: HeadlessDeps): Promise<void> {
+  if (!workflowId) throw new Error('Missing workflowId. Usage: --headless publish-landing-stack <workflowId>');
+  const te = createHeadlessExecutor(deps);
+  const result = await te.publishLandingStack(workflowId);
+  process.stdout.write(`Landing stack published for ${workflowId}: ${result.landingUrl}\n`);
 }
 
 async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -314,6 +314,30 @@ export interface HeadlessAutoFixController {
   isBusy: () => boolean;
 }
 
+type HeadlessFormatterModule = Awaited<typeof import('./formatter.js')>;
+
+type OutputMode = QueryFlags['output'];
+
+type OutputRendererMap<T> = {
+  [K in OutputMode]: (value: T) => string;
+};
+
+type HeadlessQueryHandler = (
+  flags: QueryFlags,
+  deps: HeadlessDeps,
+  formatter: HeadlessFormatterModule,
+) => Promise<void>;
+
+type HeadlessSubcommandHandler = {
+  readonly run: (args: string[], deps: HeadlessDeps) => Promise<void>;
+  readonly aliases?: readonly string[];
+};
+
+type HeadlessCommandHandler = {
+  readonly run: (args: string[], deps: HeadlessDeps) => Promise<void>;
+  readonly aliases?: readonly string[];
+};
+
 export function parseQueryFlags(args: string[]): QueryFlags {
   const flags: QueryFlags = { output: 'text', positional: [] };
   let i = 0;
@@ -348,37 +372,79 @@ export function parseQueryFlags(args: string[]): QueryFlags {
   return flags;
 }
 
-// ── Query Router ────────────────────────────────────────────
-
-async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> {
-  const subCommand = args[0];
-  if (!subCommand) {
-    throw new Error('Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|audit|session|ui-perf>');
+function createHandlerRegistry<T extends { readonly aliases?: readonly string[] }>(
+  entries: Record<string, T>,
+): Record<string, T> {
+  const registry: Record<string, T> = {};
+  for (const [name, handler] of Object.entries(entries)) {
+    registry[name] = handler;
+    for (const alias of handler.aliases ?? []) {
+      registry[alias] = handler;
+    }
   }
-  const flags = parseQueryFlags(args.slice(1));
+  return registry;
+}
 
-  const {
-    formatWorkflowList, formatTaskStatus, formatWorkflowStatus,
-    formatEventLog, formatQueueStatus, formatWorkflowStats,
-    serializeWorkflow, serializeTask, serializeEvent,
-    formatAsLabel, formatAsJson, formatAsJsonl,
-  } = await import('./formatter.js');
+async function loadHeadlessFormatter(): Promise<HeadlessFormatterModule> {
+  return import('./formatter.js');
+}
 
-  switch (subCommand) {
-    case 'workflows': {
+function writeRenderedOutput<T>(
+  output: OutputMode,
+  value: T,
+  renderers: OutputRendererMap<T>,
+): void {
+  process.stdout.write(renderers[output](value));
+}
+
+function resolveRegisteredHandler<T>(
+  registry: Record<string, T>,
+  name: string | undefined,
+  missingMessage: string,
+  unknownMessage: (name: string) => string,
+): T {
+  if (!name) {
+    throw new Error(missingMessage);
+  }
+  const handler = registry[name];
+  if (!handler) {
+    throw new Error(unknownMessage(name));
+  }
+  return handler;
+}
+
+const DEFAULT_UI_PERF_STATS = {
+  ownerMode: 'local',
+  ts: '',
+  mainDeltaToUi: 0,
+  dbPollCreated: 0,
+  dbPollUpdatedAsCreated: 0,
+  dbPollUpdatedAsUpdated: 0,
+  rendererReports: 0,
+  maxRendererEventLoopLagMs: 0,
+  maxRendererLongTaskMs: 0,
+};
+
+const headlessQueryHandlers = createHandlerRegistry<{
+  readonly run: HeadlessQueryHandler;
+  readonly aliases?: readonly string[];
+}>({
+  workflows: {
+    run: async (flags, deps, formatter) => {
       let workflows = deps.persistence.listWorkflows();
       if (flags.status) {
         workflows = workflows.filter(wf => wf.status === flags.status);
       }
-      switch (flags.output) {
-        case 'label': process.stdout.write(formatAsLabel(workflows) + '\n'); break;
-        case 'json':  process.stdout.write(formatAsJson(workflows.map(serializeWorkflow)) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl(workflows.map(serializeWorkflow)) + '\n'); break;
-        default:      process.stdout.write(formatWorkflowList(workflows) + '\n'); break;
-      }
-      break;
-    }
-    case 'tasks': {
+      writeRenderedOutput(flags.output, workflows, {
+        text: (value) => formatter.formatWorkflowList(value) + '\n',
+        label: (value) => formatter.formatAsLabel(value) + '\n',
+        json: (value) => formatter.formatAsJson(value.map(formatter.serializeWorkflow)) + '\n',
+        jsonl: (value) => formatter.formatAsJsonl(value.map(formatter.serializeWorkflow)) + '\n',
+      });
+    },
+  },
+  tasks: {
+    run: async (flags, deps, formatter) => {
       const { orchestrator, persistence } = deps;
       const workflows = persistence.listWorkflows();
       if (workflows.length === 0) {
@@ -386,12 +452,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
         return;
       }
 
-      // Support both:
-      //   query tasks --workflow <id>
-      //   query tasks <workflowId>
       const workflowFilter = flags.workflow ?? flags.positional[0];
-
-      // Load tasks from specific workflow or latest
       const targetWorkflows = workflowFilter
         ? workflows.filter(wf => wf.id === workflowFilter)
         : [workflows[0]];
@@ -402,13 +463,10 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
 
       let allTasks: import('@invoker/workflow-core').TaskState[] = [];
       for (const wf of targetWorkflows) {
-        // Query must stay read-only: sync graph from DB without starting/restarting tasks.
         orchestrator.syncFromDb(wf.id);
-        // Filter by workflow ID — the orchestrator may have loaded other workflows during init.
         allTasks.push(...orchestrator.getAllTasks().filter(t => t.config.workflowId === wf.id));
       }
 
-      // Apply filters
       if (flags.status) {
         allTasks = allTasks.filter(t => t.status === flags.status);
       }
@@ -416,110 +474,98 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
         allTasks = allTasks.filter(t => !t.config.isMergeNode);
       }
 
-      switch (flags.output) {
-        case 'label': process.stdout.write(formatAsLabel(allTasks) + '\n'); break;
-        case 'json':  process.stdout.write(formatAsJson(allTasks.map(serializeTask)) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl(allTasks.map(serializeTask)) + '\n'); break;
-        default: {
-          for (const task of allTasks) process.stdout.write(formatTaskStatus(task) + '\n');
+      writeRenderedOutput(flags.output, allTasks, {
+        text: (value) => {
+          const lines = value.map((task) => formatter.formatTaskStatus(task));
           const status = orchestrator.getWorkflowStatus();
-          process.stdout.write(`\n${formatWorkflowStatus(status)}\n`);
-          break;
-        }
-      }
-      break;
-    }
-    case 'task': {
+          const prefix = lines.length > 0 ? `${lines.join('\n')}\n\n` : '\n';
+          return `${prefix}${formatter.formatWorkflowStatus(status)}\n`;
+        },
+        label: (value) => formatter.formatAsLabel(value) + '\n',
+        json: (value) => formatter.formatAsJson(value.map(formatter.serializeTask)) + '\n',
+        jsonl: (value) => formatter.formatAsJsonl(value.map(formatter.serializeTask)) + '\n',
+      });
+    },
+  },
+  task: {
+    run: async (flags, deps, formatter) => {
       const taskId = flags.positional[0];
       if (!taskId) throw new Error('Usage: --headless query task <taskId>');
       const resolved = restoreWorkflowForTask(taskId, deps).resolvedTaskId;
       const task = deps.orchestrator.getTask(resolved);
       if (!task) throw new Error(`Task "${taskId}" not found`);
 
-      switch (flags.output) {
-        case 'label': process.stdout.write(task.id + '\n'); break;
-        case 'json':  process.stdout.write(formatAsJson(serializeTask(task)) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl([serializeTask(task)]) + '\n'); break;
-        default:      process.stdout.write(task.status + '\n'); break;
-      }
-      break;
-    }
-    case 'queue': {
+      writeRenderedOutput(flags.output, task, {
+        text: (value) => value.status + '\n',
+        label: (value) => value.id + '\n',
+        json: (value) => formatter.formatAsJson(formatter.serializeTask(value)) + '\n',
+        jsonl: (value) => formatter.formatAsJsonl([formatter.serializeTask(value)]) + '\n',
+      });
+    },
+  },
+  queue: {
+    run: async (flags, deps, formatter) => {
       const workflows = deps.persistence.listWorkflows();
       for (const workflow of workflows) {
         deps.orchestrator.syncFromDb(workflow.id);
       }
       const status = deps.orchestrator.getQueueStatus();
 
-      switch (flags.output) {
-        case 'label': {
-          const ids = [...status.running.map(t => t.taskId), ...status.queued.map(t => t.taskId)];
-          process.stdout.write(ids.join('\n') + '\n');
-          break;
-        }
-        case 'json':  process.stdout.write(formatAsJson(status) + '\n'); break;
-        case 'jsonl': {
-          for (const t of status.running) process.stdout.write(JSON.stringify({ ...t, state: 'running' }) + '\n');
-          for (const t of status.queued) process.stdout.write(JSON.stringify({ ...t, state: 'queued' }) + '\n');
-          break;
-        }
-        default: process.stdout.write(formatQueueStatus(status) + '\n'); break;
-      }
-      break;
-    }
-    case 'audit': {
+      writeRenderedOutput(flags.output, status, {
+        text: (value) => formatter.formatQueueStatus(value) + '\n',
+        label: (value) => [...value.running.map(t => t.taskId), ...value.queued.map(t => t.taskId)].join('\n') + '\n',
+        json: (value) => formatter.formatAsJson(value) + '\n',
+        jsonl: (value) => {
+          const lines = [
+            ...value.running.map(t => JSON.stringify({ ...t, state: 'running' })),
+            ...value.queued.map(t => JSON.stringify({ ...t, state: 'queued' })),
+          ];
+          return lines.length > 0 ? `${lines.join('\n')}\n` : '';
+        },
+      });
+    },
+  },
+  audit: {
+    run: async (flags, deps, formatter) => {
       const taskId = flags.positional[0];
       if (!taskId) throw new Error('Usage: --headless query audit <taskId>');
       const events = deps.persistence.getEvents(taskId);
 
-      switch (flags.output) {
-        case 'label': process.stdout.write(events.map(e => `${e.taskId}:${e.eventType}`).join('\n') + '\n'); break;
-        case 'json':  process.stdout.write(formatAsJson(events.map(serializeEvent)) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl(events.map(serializeEvent)) + '\n'); break;
-        default:      process.stdout.write(formatEventLog(events) + '\n'); break;
-      }
-      break;
-    }
-    case 'session': {
+      writeRenderedOutput(flags.output, events, {
+        text: (value) => formatter.formatEventLog(value) + '\n',
+        label: (value) => value.map(e => `${e.taskId}:${e.eventType}`).join('\n') + '\n',
+        json: (value) => formatter.formatAsJson(value.map(formatter.serializeEvent)) + '\n',
+        jsonl: (value) => formatter.formatAsJsonl(value.map(formatter.serializeEvent)) + '\n',
+      });
+    },
+  },
+  session: {
+    run: async (flags, deps) => {
       const taskId = flags.positional[0];
       if (!taskId) throw new Error('Usage: --headless query session <taskId>');
-      // For non-text output, we'd need structured session data.
-      // For now, session only supports text output; other formats fall through to text.
       await headlessSession(taskId, deps);
-      break;
-    }
-    case 'ui-perf': {
+    },
+  },
+  'ui-perf': {
+    run: async (flags, deps, formatter) => {
       if (flags.reset) {
         deps.resetUiPerfStats?.();
       }
       const stats = deps.getUiPerfStats?.() ?? {
-        ownerMode: 'local',
+        ...DEFAULT_UI_PERF_STATS,
         ts: new Date().toISOString(),
-        mainDeltaToUi: 0,
-        dbPollCreated: 0,
-        dbPollUpdatedAsCreated: 0,
-        dbPollUpdatedAsUpdated: 0,
-        rendererReports: 0,
-        maxRendererEventLoopLagMs: 0,
-        maxRendererLongTaskMs: 0,
       };
-      switch (flags.output) {
-        case 'label':
-          process.stdout.write(String((stats as Record<string, unknown>).maxRendererEventLoopLagMs ?? 0) + '\n');
-          break;
-        case 'json':
-          process.stdout.write(formatAsJson(stats) + '\n');
-          break;
-        case 'jsonl':
-          process.stdout.write(formatAsJsonl([stats]) + '\n');
-          break;
-        default:
-          process.stdout.write(`${JSON.stringify(stats, null, 2)}\n`);
-          break;
-      }
-      break;
-    }
-    case 'stats': {
+
+      writeRenderedOutput(flags.output, stats, {
+        text: (value) => `${JSON.stringify(value, null, 2)}\n`,
+        label: (value) => String((value as Record<string, unknown>).maxRendererEventLoopLagMs ?? 0) + '\n',
+        json: (value) => formatter.formatAsJson(value) + '\n',
+        jsonl: (value) => formatter.formatAsJsonl([value]) + '\n',
+      });
+    },
+  },
+  stats: {
+    run: async (flags, deps, formatter) => {
       const { orchestrator, persistence } = deps;
       const workflows = persistence.listWorkflows();
 
@@ -528,9 +574,6 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
       const running = workflows.filter(w => w.status === 'running').length;
       const terminal = completed + failed;
       const successRate = terminal > 0 ? (completed / terminal) * 100 : 0;
-
-      // Average duration across workflows that have both timestamps.
-      // startedAt/completedAt are added by the workflow-duration feature; guard for older DBs.
       const durations = (workflows as Array<typeof workflows[0] & { startedAt?: string; completedAt?: string }>)
         .filter(w => w.startedAt && w.completedAt)
         .map(w => new Date(w.completedAt!).getTime() - new Date(w.startedAt!).getTime());
@@ -538,7 +581,6 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
         ? durations.reduce((a, b) => a + b, 0) / durations.length
         : null;
 
-      // Most-failed task descriptions across all workflows
       const failCounts = new Map<string, number>();
       for (const wf of workflows) {
         orchestrator.syncFromDb(wf.id);
@@ -564,55 +606,69 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
         mostFailedTasks,
       };
 
-      switch (flags.output) {
-        case 'label': process.stdout.write(`${successRate.toFixed(1)}%\n`); break;
-        case 'json':  process.stdout.write(formatAsJson(stats) + '\n'); break;
-        case 'jsonl': process.stdout.write(formatAsJsonl([stats]) + '\n'); break;
-        default:      process.stdout.write(formatWorkflowStats(stats) + '\n'); break;
-      }
-      break;
-    }
-    default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, ui-perf, stats`);
-  }
+      writeRenderedOutput(flags.output, stats, {
+        text: (value) => formatter.formatWorkflowStats(value) + '\n',
+        label: (value) => `${value.successRate.toFixed(1)}%\n`,
+        json: (value) => formatter.formatAsJson(value) + '\n',
+        jsonl: (value) => formatter.formatAsJsonl([value]) + '\n',
+      });
+    },
+  },
+});
+
+const headlessSetHandlers = createHandlerRegistry<HeadlessSubcommandHandler>({
+  command: {
+    run: async (args, deps) => headlessEdit(args[1], args.slice(2).join(' '), deps),
+  },
+  prompt: {
+    run: async (args, deps) => headlessEditPrompt(args[1], args.slice(2).join(' '), deps),
+  },
+  executor: {
+    run: async (args, deps) => headlessEditExecutor(args[1], args[2], deps),
+  },
+  agent: {
+    run: async (args, deps) => headlessEditAgent(args[1], args[2], deps),
+  },
+  'merge-mode': {
+    run: async (args, deps) => headlessSetMergeMode(args[1], args[2], deps),
+  },
+  'fix-prompt': {
+    run: async (args, deps) => headlessSetFixContext(args[1], { fixPrompt: args.slice(2).join(' ') }, deps),
+  },
+  'fix-context': {
+    run: async (args, deps) => headlessSetFixContext(args[1], { fixContext: args.slice(2).join(' ') }, deps),
+  },
+  'gate-policy': {
+    run: async (args, deps) => headlessSetGatePolicy(args.slice(1), deps),
+  },
+});
+
+// ── Query Router ────────────────────────────────────────────
+
+async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> {
+  const subCommand = args[0];
+  const handler = resolveRegisteredHandler(
+    headlessQueryHandlers,
+    subCommand,
+    'Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|audit|session|ui-perf>',
+    (name) => `Unknown query sub-command: "${name}". Use: workflows, tasks, task, queue, audit, session, ui-perf, stats`,
+  );
+  const flags = parseQueryFlags(args.slice(1));
+  const formatter = await loadHeadlessFormatter();
+  await handler.run(flags, deps, formatter);
 }
 
 // ── Set Router ──────────────────────────────────────────────
 
 async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0];
-  if (!subCommand) {
-    throw new Error('Missing set sub-command. Usage: --headless set <command|executor|agent|merge-mode|gate-policy>');
-  }
-
-  switch (subCommand) {
-    case 'command':
-      await headlessEdit(args[1], args.slice(2).join(' '), deps);
-      break;
-    case 'prompt':
-      await headlessEditPrompt(args[1], args.slice(2).join(' '), deps);
-      break;
-    case 'executor':
-      await headlessEditExecutor(args[1], args[2], deps);
-      break;
-    case 'agent':
-      await headlessEditAgent(args[1], args[2], deps);
-      break;
-    case 'merge-mode':
-      await headlessSetMergeMode(args[1], args[2], deps);
-      break;
-    case 'fix-prompt':
-      await headlessSetFixContext(args[1], { fixPrompt: args.slice(2).join(' ') }, deps);
-      break;
-    case 'fix-context':
-      await headlessSetFixContext(args[1], { fixContext: args.slice(2).join(' ') }, deps);
-      break;
-    case 'gate-policy':
-      await headlessSetGatePolicy(args.slice(1), deps);
-      break;
-    default:
-      throw new Error(`Unknown set sub-command: "${subCommand}". Use: command, prompt, executor, agent, merge-mode, fix-prompt, fix-context, gate-policy`);
-  }
+  const handler = resolveRegisteredHandler(
+    headlessSetHandlers,
+    subCommand,
+    'Missing set sub-command. Usage: --headless set <command|executor|agent|merge-mode|gate-policy>',
+    (name) => `Unknown set sub-command: "${name}". Use: command, prompt, executor, agent, merge-mode, fix-prompt, fix-context, gate-policy`,
+  );
+  await handler.run(args, deps);
 }
 
 async function headlessMigrateCompatibility(deps: HeadlessDeps): Promise<void> {
@@ -640,185 +696,209 @@ async function headlessInstallSkills(
   }
 }
 
-// ── Headless Command Router ──────────────────────────────────
-
-export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<void> {
-  const command = args[0];
-
-  switch (command) {
-    case 'owner-serve':
-      await headlessOwnerServe(deps);
-      break;
-    // ── New grouped commands ──
-    case 'query':
-      await headlessQuery(args.slice(1), deps);
-      break;
-    case 'set':
-      await headlessSet(args.slice(1), deps);
-      break;
-    case 'migrate-compat':
-      await headlessMigrateCompatibility(deps);
-      break;
-    case 'install-skills':
-      await headlessInstallSkills(
-        args[1] === 'reinstall' || args[1] === 'update' ? args[1] : 'install',
-        deps,
-      );
-      break;
-    case 'watch':
-      await headlessWatch(args[1], deps);
-      break;
-
-    // ── Execute (unchanged) ──
-    case 'run':
-      await headlessRun(args[1], deps, deps.waitForApproval, deps.noTrack);
-      break;
-    case 'resume':
-      await headlessResume(args[1], deps, deps.waitForApproval, deps.noTrack);
-      break;
-    case 'retry':
-      await headlessRetryWorkflow(args[1], deps);
-      break;
-    case 'retry-task':
-      await headlessRetryTask(args[1], deps);
-      break;
-    case 'recreate':
-      await headlessRecreateWorkflow(args[1], deps);
-      break;
-    case 'recreate-task':
-      await headlessRecreateTask(args[1], deps);
-      break;
-    case 'replace-task':
+const headlessCommandHandlers = createHandlerRegistry<HeadlessCommandHandler>({
+  'owner-serve': {
+    run: async (_args, deps) => headlessOwnerServe(deps),
+  },
+  query: {
+    run: async (args, deps) => headlessQuery(args.slice(1), deps),
+  },
+  set: {
+    run: async (args, deps) => headlessSet(args.slice(1), deps),
+  },
+  'migrate-compat': {
+    run: async (_args, deps) => headlessMigrateCompatibility(deps),
+  },
+  'install-skills': {
+    run: async (args, deps) => headlessInstallSkills(
+      args[1] === 'reinstall' || args[1] === 'update' ? args[1] : 'install',
+      deps,
+    ),
+  },
+  watch: {
+    run: async (args, deps) => headlessWatch(args[1], deps),
+  },
+  run: {
+    run: async (args, deps) => headlessRun(args[1], deps, deps.waitForApproval, deps.noTrack),
+  },
+  resume: {
+    run: async (args, deps) => headlessResume(args[1], deps, deps.waitForApproval, deps.noTrack),
+  },
+  retry: {
+    run: async (args, deps) => headlessRetryWorkflow(args[1], deps),
+  },
+  'retry-task': {
+    run: async (args, deps) => headlessRetryTask(args[1], deps),
+  },
+  recreate: {
+    run: async (args, deps) => headlessRecreateWorkflow(args[1], deps),
+  },
+  'recreate-task': {
+    run: async (args, deps) => headlessRecreateTask(args[1], deps),
+  },
+  'replace-task': {
+    run: async () => {
       throw new Error(
         'Headless replace-task is disabled because it is not a safe supported CLI flow. ' +
         'Use the UI replace-task flow instead.',
       );
-    case 'fork-workflow':
-      await headlessForkWorkflow(args[1], deps);
-      break;
-    case 'rebase':
-      await headlessRebaseAndRetry(args[1], deps);
-      break;
-    case 'publish-review-stack':
-      await headlessPublishReviewStack(args[1], deps);
-      break;
-    case 'publish-landing-stack':
-      await headlessPublishLandingStack(args[1], deps);
-      break;
-
-    // Deprecated aliases
-    case 'rebase-and-retry':
+    },
+  },
+  'fork-workflow': {
+    run: async (args, deps) => headlessForkWorkflow(args[1], deps),
+  },
+  rebase: {
+    run: async (args, deps) => headlessRebaseAndRetry(args[1], deps),
+  },
+  'rebase-and-retry': {
+    run: async (args, deps) => {
       warnDeprecated('rebase-and-retry', 'rebase');
       await headlessRebaseAndRetry(args[1], deps);
-      break;
-    case 'fix':
-      await headlessFix(args[1], deps, args[2]);
-      break;
-    case 'resolve-conflict':
-      await headlessResolveConflict(args[1], deps, args[2]);
-      break;
-
-    // ── Respond (unchanged) ──
-    case 'approve':
-      await headlessApprove(args[1], deps);
-      break;
-    case 'reject':
-      await headlessReject(args[1], deps, args.slice(2).join(' ') || undefined);
-      break;
-    case 'input':
-      await headlessInput(args[1], args.slice(2).join(' '), deps);
-      break;
-    case 'select':
-      await headlessSelect(args[1], args[2], deps);
-      break;
-
-    // ── Lifecycle (unchanged) ──
-    case 'cancel':
-      await headlessCancel(args[1], deps);
-      break;
-    case 'cancel-workflow':
-      await headlessCancelWorkflow(args[1], deps);
-      break;
-    case 'delete':
-    case 'delete-workflow':
-      await headlessDeleteWorkflow(args[1], deps);
-      break;
-    case 'delete-all':
+    },
+  },
+  'publish-review-stack': {
+    run: async (args, deps) => headlessPublishReviewStack(args[1], deps),
+  },
+  'publish-landing-stack': {
+    run: async (args, deps) => headlessPublishLandingStack(args[1], deps),
+  },
+  fix: {
+    run: async (args, deps) => headlessFix(args[1], deps, args[2]),
+  },
+  'resolve-conflict': {
+    run: async (args, deps) => headlessResolveConflict(args[1], deps, args[2]),
+  },
+  approve: {
+    run: async (args, deps) => headlessApprove(args[1], deps),
+  },
+  reject: {
+    run: async (args, deps) => headlessReject(args[1], deps, args.slice(2).join(' ') || undefined),
+  },
+  input: {
+    run: async (args, deps) => headlessInput(args[1], args.slice(2).join(' '), deps),
+  },
+  select: {
+    run: async (args, deps) => headlessSelect(args[1], args[2], deps),
+  },
+  cancel: {
+    run: async (args, deps) => headlessCancel(args[1], deps),
+  },
+  'cancel-workflow': {
+    run: async (args, deps) => headlessCancelWorkflow(args[1], deps),
+  },
+  delete: {
+    run: async (args, deps) => headlessDeleteWorkflow(args[1], deps),
+    aliases: ['delete-workflow'],
+  },
+  'delete-all': {
+    run: async (_args, deps) => {
       assertDeleteAllEnabled();
-      {
-        const snapshot = createDeleteAllSnapshot();
-        if (snapshot) {
-          process.stderr.write(`[headless] delete-all snapshot: ${snapshot}\n`);
-        } else {
-          process.stderr.write('[headless] delete-all snapshot skipped: DB file does not exist yet\n');
-        }
+      const snapshot = createDeleteAllSnapshot();
+      if (snapshot) {
+        process.stderr.write(`[headless] delete-all snapshot: ${snapshot}\n`);
+      } else {
+        process.stderr.write('[headless] delete-all snapshot skipped: DB file does not exist yet\n');
       }
       deps.orchestrator.deleteAllWorkflows();
       process.stdout.write('All workflows deleted.\n');
-      break;
-    case 'open-terminal':
-      await headlessOpenTerminal(args[1], deps);
-      break;
-    case 'slack':
-      await headlessSlack(deps);
-      break;
-    case 'query-select':
-      await headlessQuerySelect(args[1], deps);
-      break;
-
-    // ── Deprecated aliases → query ──
-    case 'list':
+    },
+  },
+  'open-terminal': {
+    run: async (args, deps) => headlessOpenTerminal(args[1], deps),
+  },
+  slack: {
+    run: async (_args, deps) => headlessSlack(deps),
+  },
+  'query-select': {
+    run: async (args, deps) => headlessQuerySelect(args[1], deps),
+  },
+  list: {
+    run: async (args, deps) => {
       warnDeprecated('list', 'query workflows');
       await headlessQuery(['workflows', ...args.slice(1)], deps);
-      break;
-    case 'status':
+    },
+  },
+  status: {
+    run: async (args, deps) => {
       warnDeprecated('status', 'query tasks');
       await headlessQuery(['tasks', ...args.slice(1)], deps);
-      break;
-    case 'task-status':
+    },
+  },
+  'task-status': {
+    run: async (args, deps) => {
       warnDeprecated('task-status', 'query task');
       await headlessQuery(['task', ...args.slice(1)], deps);
-      break;
-    case 'queue':
+    },
+  },
+  queue: {
+    run: async (args, deps) => {
       warnDeprecated('queue', 'query queue');
       await headlessQuery(['queue', ...args.slice(1)], deps);
-      break;
-    case 'audit':
+    },
+  },
+  audit: {
+    run: async (args, deps) => {
       warnDeprecated('audit', 'query audit');
       await headlessQuery(['audit', ...args.slice(1)], deps);
-      break;
-    case 'session':
+    },
+  },
+  session: {
+    run: async (args, deps) => {
       warnDeprecated('session', 'query session');
       await headlessQuery(['session', ...args.slice(1)], deps);
-      break;
-
-    // ── Deprecated aliases → set ──
-    case 'edit':
+    },
+  },
+  edit: {
+    run: async (args, deps) => {
       warnDeprecated('edit', 'set command');
       await headlessSet(['command', ...args.slice(1)], deps);
-      break;
-    case 'edit-executor':
-    case 'edit-type':
-      warnDeprecated(command, 'set executor');
+    },
+  },
+  'edit-executor': {
+    run: async (args, deps) => {
+      warnDeprecated('edit-executor', 'set executor');
       await headlessSet(['executor', ...args.slice(1)], deps);
-      break;
-    case 'edit-agent':
+    },
+  },
+  'edit-type': {
+    run: async (args, deps) => {
+      warnDeprecated('edit-type', 'set executor');
+      await headlessSet(['executor', ...args.slice(1)], deps);
+    },
+  },
+  'edit-agent': {
+    run: async (args, deps) => {
       warnDeprecated('edit-agent', 'set agent');
       await headlessSet(['agent', ...args.slice(1)], deps);
-      break;
-    case 'set-merge-mode':
+    },
+  },
+  'set-merge-mode': {
+    run: async (args, deps) => {
       warnDeprecated('set-merge-mode', 'set merge-mode');
       await headlessSet(['merge-mode', ...args.slice(1)], deps);
-      break;
+    },
+  },
+  '--help': {
+    run: async () => printHeadlessUsage(),
+    aliases: ['-h'],
+  },
+});
 
-    case '--help':
-    case '-h':
-    case undefined:
-      printHeadlessUsage();
-      break;
-    default:
-      throw new Error(`Unknown command: ${command}. Run with --help for usage.`);
+// ── Headless Command Router ──────────────────────────────────
+
+export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<void> {
+  const command = args[0];
+  if (!command) {
+    printHeadlessUsage();
+    return;
   }
+  const handler = resolveRegisteredHandler(
+    headlessCommandHandlers,
+    command,
+    'Missing command. Run with --help for usage.',
+    (name) => `Unknown command: ${name}. Run with --help for usage.`,
+  );
+  await handler.run(args, deps);
 }
 
 async function headlessOwnerServe(deps: Pick<HeadlessDeps, 'isStandaloneOwnerIdle'>): Promise<void> {

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -31,6 +31,9 @@ export function applyPlanDefinitionDefaults(plan: PlanDefinition): PlanDefinitio
     ...plan,
     onFinish: plan.onFinish ?? 'pull_request',
     baseBranch: resolveDefaultBaseBranch(plan),
+    parentRemote: typeof plan.parentRemote === 'string' && plan.parentRemote.trim() !== ''
+      ? plan.parentRemote.trim()
+      : undefined,
     featureBranch,
   };
 }
@@ -70,6 +73,7 @@ export interface RawPlan {
   visualProof?: boolean;
   onFinish?: string;
   baseBranch?: string;
+  parentRemote?: string;
   featureBranch?: string;
   mergeMode?: string;
   reviewProvider?: string;
@@ -351,6 +355,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     visualProof: raw.visualProof,
     onFinish,
     baseBranch: raw.baseBranch,
+    parentRemote: raw.parentRemote,
     featureBranch: raw.featureBranch,
     mergeMode,
     reviewProvider,

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -54,6 +54,32 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  describe('workflow publication metadata', () => {
+    it('round-trips parentRemote and publication fields', () => {
+      adapter.saveWorkflow({
+        ...testWorkflow,
+        parentRemote: 'upstream',
+        reviewProvider: 'github',
+        publicationState: 'review_published',
+        reviewBaseSha: 'abc123',
+        reviewBaseBranch: 'review-base/wf-1',
+        reviewPrUrl: 'https://github.com/example/repo/pull/1',
+        landingBaseSha: 'def456',
+        landingPrUrl: 'https://github.com/example/repo/pull/2',
+      });
+
+      const loaded = adapter.loadWorkflow('wf-1');
+      expect(loaded?.parentRemote).toBe('upstream');
+      expect(loaded?.reviewProvider).toBe('github');
+      expect(loaded?.publicationState).toBe('review_published');
+      expect(loaded?.reviewBaseSha).toBe('abc123');
+      expect(loaded?.reviewBaseBranch).toBe('review-base/wf-1');
+      expect(loaded?.reviewPrUrl).toBe('https://github.com/example/repo/pull/1');
+      expect(loaded?.landingBaseSha).toBe('def456');
+      expect(loaded?.landingPrUrl).toBe('https://github.com/example/repo/pull/2');
+    });
+  });
+
   describe('updateTask', () => {
     it('persists partial changes', () => {
       adapter.saveWorkflow(testWorkflow);

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -41,9 +41,16 @@ export interface Workflow {
   branch?: string;
   onFinish?: 'none' | 'merge' | 'pull_request';
   baseBranch?: string;
+  parentRemote?: string;
   featureBranch?: string;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
   reviewProvider?: string;
+  publicationState?: 'unpublished' | 'review_published' | 'landing_published' | 'landing_stale';
+  reviewBaseSha?: string;
+  reviewBaseBranch?: string;
+  reviewPrUrl?: string;
+  landingBaseSha?: string;
+  landingPrUrl?: string;
   generation?: number;
   createdAt: string;
   updatedAt: string;
@@ -68,7 +75,24 @@ export interface ActivityLogEntry {
 export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: Workflow): void;
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'status' | 'updatedAt' | 'baseBranch' | 'generation' | 'mergeMode'>>): void;
+  updateWorkflow(
+    workflowId: string,
+    changes: Partial<Pick<
+      Workflow,
+      | 'status'
+      | 'updatedAt'
+      | 'baseBranch'
+      | 'generation'
+      | 'mergeMode'
+      | 'parentRemote'
+      | 'publicationState'
+      | 'reviewBaseSha'
+      | 'reviewBaseBranch'
+      | 'reviewPrUrl'
+      | 'landingBaseSha'
+      | 'landingPrUrl'
+    >>,
+  ): void;
   loadWorkflow(workflowId: string): Workflow | undefined;
   listWorkflows(): Workflow[];
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -299,6 +299,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
         repo_url TEXT,
         branch TEXT,
         parent_remote TEXT,
+        review_provider TEXT,
+        publication_state TEXT,
+        review_base_sha TEXT,
+        review_base_branch TEXT,
+        review_pr_url TEXT,
+        landing_base_sha TEXT,
+        landing_pr_url TEXT,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       );
@@ -521,6 +528,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE workflows ADD COLUMN parent_remote TEXT',
       'ALTER TABLE workflows ADD COLUMN feature_branch TEXT',
       'ALTER TABLE workflows ADD COLUMN generation INTEGER DEFAULT 0',
+      'ALTER TABLE workflows ADD COLUMN review_provider TEXT',
+      'ALTER TABLE workflows ADD COLUMN publication_state TEXT',
+      'ALTER TABLE workflows ADD COLUMN review_base_sha TEXT',
+      'ALTER TABLE workflows ADD COLUMN review_base_branch TEXT',
+      'ALTER TABLE workflows ADD COLUMN review_pr_url TEXT',
+      'ALTER TABLE workflows ADD COLUMN landing_base_sha TEXT',
+      'ALTER TABLE workflows ADD COLUMN landing_pr_url TEXT',
       'ALTER TABLE tasks ADD COLUMN last_heartbeat_at TEXT',
       'ALTER TABLE tasks ADD COLUMN experiment_prompt TEXT',
       'ALTER TABLE tasks ADD COLUMN auto_fix INTEGER DEFAULT 0',
@@ -654,23 +668,51 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   saveWorkflow(workflow: Workflow): void {
     this.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, status, plan_file, repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (
+        id, name, description, visual_proof, status, plan_file, repo_url, branch,
+        on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider,
+        publication_state, review_base_sha, review_base_branch, review_pr_url, landing_base_sha, landing_pr_url,
+        generation, created_at, updated_at
+      )
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
       workflow.visualProof ? 1 : 0,
       workflow.status,
       workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.branch ?? null,
-      workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
+      workflow.onFinish ?? null, workflow.baseBranch ?? null, workflow.parentRemote ?? null, workflow.featureBranch ?? null,
       workflow.mergeMode ?? null,
       workflow.reviewProvider ?? null,
+      workflow.publicationState ?? null,
+      workflow.reviewBaseSha ?? null,
+      workflow.reviewBaseBranch ?? null,
+      workflow.reviewPrUrl ?? null,
+      workflow.landingBaseSha ?? null,
+      workflow.landingPrUrl ?? null,
       workflow.generation ?? 0,
       workflow.createdAt, workflow.updatedAt,
     ]);
   }
 
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'status' | 'updatedAt' | 'baseBranch' | 'generation' | 'mergeMode'>>): void {
+  updateWorkflow(
+    workflowId: string,
+    changes: Partial<Pick<
+      Workflow,
+      | 'status'
+      | 'updatedAt'
+      | 'baseBranch'
+      | 'generation'
+      | 'mergeMode'
+      | 'parentRemote'
+      | 'publicationState'
+      | 'reviewBaseSha'
+      | 'reviewBaseBranch'
+      | 'reviewPrUrl'
+      | 'landingBaseSha'
+      | 'landingPrUrl'
+    >>,
+  ): void {
     const setClauses: string[] = [];
     const values: unknown[] = [];
     if (changes.status !== undefined) {
@@ -681,6 +723,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
       setClauses.push('base_branch = ?');
       values.push(changes.baseBranch);
     }
+    if (changes.parentRemote !== undefined) {
+      setClauses.push('parent_remote = ?');
+      values.push(changes.parentRemote);
+    }
     if (changes.generation !== undefined) {
       setClauses.push('generation = ?');
       values.push(changes.generation);
@@ -688,6 +734,30 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if (changes.mergeMode !== undefined) {
       setClauses.push('merge_mode = ?');
       values.push(changes.mergeMode);
+    }
+    if (changes.publicationState !== undefined) {
+      setClauses.push('publication_state = ?');
+      values.push(changes.publicationState);
+    }
+    if (changes.reviewBaseSha !== undefined) {
+      setClauses.push('review_base_sha = ?');
+      values.push(changes.reviewBaseSha);
+    }
+    if (changes.reviewBaseBranch !== undefined) {
+      setClauses.push('review_base_branch = ?');
+      values.push(changes.reviewBaseBranch);
+    }
+    if (changes.reviewPrUrl !== undefined) {
+      setClauses.push('review_pr_url = ?');
+      values.push(changes.reviewPrUrl);
+    }
+    if (changes.landingBaseSha !== undefined) {
+      setClauses.push('landing_base_sha = ?');
+      values.push(changes.landingBaseSha);
+    }
+    if (changes.landingPrUrl !== undefined) {
+      setClauses.push('landing_pr_url = ?');
+      values.push(changes.landingPrUrl);
     }
     setClauses.push('updated_at = ?');
     values.push(changes.updatedAt ?? new Date().toISOString());
@@ -1592,9 +1662,16 @@ export class SQLiteAdapter implements PersistenceAdapter {
       branch: row.branch ?? undefined,
       onFinish: row.on_finish ?? undefined,
       baseBranch: row.base_branch ?? undefined,
+      parentRemote: row.parent_remote ?? undefined,
       featureBranch: row.feature_branch ?? undefined,
       mergeMode: row.merge_mode ?? undefined,
       reviewProvider: row.review_provider ?? undefined,
+      publicationState: row.publication_state ?? undefined,
+      reviewBaseSha: row.review_base_sha ?? undefined,
+      reviewBaseBranch: row.review_base_branch ?? undefined,
+      reviewPrUrl: row.review_pr_url ?? undefined,
+      landingBaseSha: row.landing_base_sha ?? undefined,
+      landingPrUrl: row.landing_pr_url ?? undefined,
       generation: row.generation ?? 0,
       createdAt: row.created_at,
       updatedAt: row.updated_at,

--- a/packages/execution-engine/src/__tests__/invoker-stack-publisher.test.ts
+++ b/packages/execution-engine/src/__tests__/invoker-stack-publisher.test.ts
@@ -1,0 +1,241 @@
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { execFileSync, execSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+import { publishInvokerStack, shouldUseInvokerSyntheticReview } from '../invoker-stack-publisher.js';
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function saveTask(
+  adapter: SQLiteAdapter,
+  workflowId: string,
+  id: string,
+  externalWorkflowId?: string,
+): void {
+  const task: TaskState = {
+    id,
+    description: id,
+    status: 'completed',
+    dependencies: [],
+    createdAt: new Date(),
+    config: externalWorkflowId
+      ? {
+          workflowId,
+          externalDependencies: [{ workflowId: externalWorkflowId, taskId: '__merge__', requiredStatus: 'completed' }],
+        }
+      : { workflowId },
+    execution: {},
+  };
+  adapter.saveTask(workflowId, task);
+}
+
+describe('invoker-stack-publisher', () => {
+  let rootDir: string;
+  let upstreamBare: string;
+  let originBare: string;
+  let hostClone: string;
+  let tempPaths: string[] = [];
+  let oldPath: string | undefined;
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    rootDir = mkdtempSync(join(tmpdir(), 'invoker-stack-publisher-'));
+    upstreamBare = join(rootDir, 'upstream.git');
+    originBare = join(rootDir, 'origin.git');
+    hostClone = join(rootDir, 'host');
+    oldPath = process.env.PATH;
+
+    const seed = join(rootDir, 'seed');
+    mkdirSync(seed, { recursive: true });
+    git(rootDir, 'init', seed);
+    git(seed, 'config', 'user.name', 'Test User');
+    git(seed, 'config', 'user.email', 'test@example.com');
+    writeFileSync(join(seed, 'README.md'), 'base\n', 'utf8');
+    git(seed, 'add', 'README.md');
+    git(seed, 'commit', '-m', 'base');
+    const baseSha = git(seed, 'rev-parse', 'HEAD');
+    git(seed, 'branch', '-M', 'master');
+    git(rootDir, 'clone', '--bare', seed, upstreamBare);
+    git(rootDir, 'clone', '--bare', seed, originBare);
+
+    git(rootDir, 'clone', originBare, hostClone);
+    git(hostClone, 'remote', 'add', 'upstream', upstreamBare);
+    git(hostClone, 'config', 'user.name', 'Test User');
+    git(hostClone, 'config', 'user.email', 'test@example.com');
+
+    const upstreamWork = join(rootDir, 'upstream-work');
+    git(rootDir, 'clone', upstreamBare, upstreamWork);
+    git(upstreamWork, 'config', 'user.name', 'Test User');
+    git(upstreamWork, 'config', 'user.email', 'test@example.com');
+    writeFileSync(join(upstreamWork, 'UPSTREAM.txt'), 'new head\n', 'utf8');
+    git(upstreamWork, 'add', 'UPSTREAM.txt');
+    git(upstreamWork, 'commit', '-m', 'upstream head');
+    git(upstreamWork, 'push', 'origin', 'HEAD:master');
+
+    git(hostClone, 'fetch', 'upstream', 'master');
+    git(hostClone, 'checkout', '-B', 'plan/step-1', baseSha);
+    writeFileSync(join(hostClone, 'step1.txt'), 'step1\n', 'utf8');
+    git(hostClone, 'add', 'step1.txt');
+    git(hostClone, 'commit', '-m', 'Review Step 1');
+    git(hostClone, 'push', '-u', 'origin', 'plan/step-1');
+
+    git(hostClone, 'checkout', '-B', 'plan/step-2', 'plan/step-1');
+    writeFileSync(join(hostClone, 'step2.txt'), 'step2\n', 'utf8');
+    git(hostClone, 'add', 'step2.txt');
+    git(hostClone, 'commit', '-m', 'Review Step 2');
+    git(hostClone, 'push', '-u', 'origin', 'plan/step-2');
+
+    const binDir = join(rootDir, 'bin');
+    mkdirSync(binDir, { recursive: true });
+    const mergifyStub = join(binDir, 'mergify');
+    const ghStub = join(binDir, 'gh');
+    writeFileSync(mergifyStub, `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "stack" ] && [ "$2" = "setup" ]; then
+  exit 0
+fi
+if [ "$1" = "stack" ] && [ "$2" = "push" ]; then
+  repo="Neko-Catpital-Labs/Invoker"
+  branch="$(git branch --show-current)"
+  root="\${branch#*/}"
+  if [[ "$branch" == review-stack/* ]]; then
+    base="review-base/$root"
+    range="$base..HEAD"
+  else
+    base="master"
+    range="origin/master..HEAD"
+  fi
+  git push --force origin "$branch:$branch" >/dev/null 2>&1
+  mapfile -t subjects < <(git log --reverse --format=%s "$range")
+  json="["
+  idx=0
+  for title in "\${subjects[@]}"; do
+    number=$((100 + idx))
+    if [ $idx -eq 0 ]; then
+      baseRef="$base"
+    else
+      baseRef="stack/$root/$((idx-1))"
+    fi
+    headRef="stack/$root/$idx"
+    json="$json{\\"number\\":$number,\\"title\\":\\"$title\\",\\"url\\":\\"https://github.com/$repo/pull/$number\\",\\"baseRefName\\":\\"$baseRef\\",\\"headRefName\\":\\"$headRef\\"},"
+    echo "https://github.com/$repo/pull/$number"
+    idx=$((idx+1))
+  done
+  json="\${json%,}]"
+  mkdir -p .git
+  printf '%s' "$json" > .git/fake-mergify-prs.json
+  exit 0
+fi
+echo "unexpected mergify invocation: $*" >&2
+exit 1
+`, { mode: 0o755 });
+    writeFileSync(ghStub, `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "pr" ] && [ "$2" = "list" ]; then
+  title=""
+  while [ $# -gt 0 ]; do
+    if [ "$1" = "--search" ]; then
+      title="$2"
+      shift 2
+      continue
+    fi
+    shift
+  done
+  title="\${title#in:title \\"}"
+  title="\${title%\\"}"
+  python3 - "$title" <<'PY'
+import json, sys
+from pathlib import Path
+title = sys.argv[1]
+data = json.loads(Path('.git/fake-mergify-prs.json').read_text())
+filtered = [row for row in data if row["title"] == title]
+print(json.dumps(filtered))
+PY
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 1
+`, { mode: 0o755 });
+    process.env.PATH = `${binDir}:${oldPath ?? ''}`;
+
+    adapter = await SQLiteAdapter.create(':memory:');
+    const now = new Date().toISOString();
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'Review Step 1',
+      status: 'running',
+      repoUrl: 'https://github.com/EdbertChan/Invoker',
+      baseBranch: 'master',
+      parentRemote: 'upstream',
+      featureBranch: 'plan/step-1',
+      createdAt: now,
+      updatedAt: now,
+    });
+    adapter.saveWorkflow({
+      id: 'wf-2',
+      name: 'Review Step 2',
+      status: 'running',
+      repoUrl: 'https://github.com/EdbertChan/Invoker',
+      baseBranch: 'plan/step-1',
+      parentRemote: 'upstream',
+      featureBranch: 'plan/step-2',
+      createdAt: now,
+      updatedAt: now,
+    });
+    saveTask(adapter, 'wf-1', 'wf-1/root');
+    saveTask(adapter, 'wf-2', 'wf-2/root', 'wf-1');
+  });
+
+  afterEach(() => {
+    process.env.PATH = oldPath;
+    adapter.close();
+    rmSync(rootDir, { recursive: true, force: true });
+    for (const path of tempPaths) rmSync(path, { recursive: true, force: true });
+    tempPaths = [];
+  });
+
+  it('detects Invoker workflows and publishes review/landing stacks against the correct bases', async () => {
+    const host = {
+      persistence: adapter,
+      defaultBranch: 'master',
+      cwd: hostClone,
+      execGitReadonly: async (args: string[], cwd?: string) => git(cwd ?? hostClone, ...args),
+      buildMergeSummary: async (workflowId: string) => `Summary for ${workflowId}`,
+      authorPrBodyWithSkill: async ({ title }: { title: string }) => ({
+        body: `## Summary\n\nBody for ${title}\n\n## Test Plan\n\n- [ ] simulated\n\n## Revert Plan\n\n- Safe to revert? Yes\n- Revert command: \`git revert <sha>\`\n- Post-revert steps: None\n- Data migration? No`,
+        sessionId: 'sess',
+        agentName: 'codex',
+      }),
+    };
+
+    await expect(shouldUseInvokerSyntheticReview(host as any, 'wf-2')).resolves.toBe(true);
+
+    const review = await publishInvokerStack(host as any, 'wf-2', 'review');
+    expect(review.prs).toHaveLength(2);
+    expect(review.prs[0].baseRefName).toBe('review-base/wf-1');
+    expect(review.prs[1].baseRefName).toBe('stack/wf-1/0');
+    expect(adapter.loadWorkflow('wf-2')?.reviewPrUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker/pull/101');
+
+    const landing = await publishInvokerStack(host as any, 'wf-2', 'landing');
+    expect(landing.prs).toHaveLength(2);
+    expect(landing.prs[0].baseRefName).toBe('master');
+    expect(landing.prs[1].baseRefName).toBe('stack/wf-1/0');
+    expect(adapter.loadWorkflow('wf-2')?.landingPrUrl).toBe('https://github.com/Neko-Catpital-Labs/Invoker/pull/101');
+
+    const inspect = join(rootDir, 'inspect');
+    git(rootDir, 'clone', upstreamBare, inspect);
+    tempPaths.push(inspect);
+    git(inspect, 'fetch', 'origin', 'review-base/wf-1', 'review-stack/wf-1', 'landing-stack/wf-1');
+    expect(git(inspect, 'rev-parse', 'origin/review-base/wf-1')).toBe(review.reviewBaseSha);
+    const reviewTree = git(inspect, 'show', 'origin/review-stack/wf-1:step2.txt');
+    const landingTree = git(inspect, 'show', 'origin/landing-stack/wf-1:step2.txt');
+    expect(reviewTree).toContain('step2');
+    expect(landingTree).toContain('step2');
+  });
+});

--- a/packages/execution-engine/src/__tests__/review-publication-service.test.ts
+++ b/packages/execution-engine/src/__tests__/review-publication-service.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  publishInvokerStackMock,
+  shouldUseInvokerSyntheticReviewMock,
+} = vi.hoisted(() => ({
+  publishInvokerStackMock: vi.fn(),
+  shouldUseInvokerSyntheticReviewMock: vi.fn(),
+}));
+
+vi.mock('../invoker-stack-publisher.js', () => ({
+  publishInvokerStack: publishInvokerStackMock,
+  shouldUseInvokerSyntheticReview: shouldUseInvokerSyntheticReviewMock,
+}));
+
+import { publishReview, type ReviewPublicationHost } from '../review-publication-service.js';
+
+function makeHost(overrides: Partial<ReviewPublicationHost> = {}): ReviewPublicationHost {
+  return {
+    persistence: { loadWorkflow: vi.fn() } as any,
+    defaultBranch: 'master',
+    cwd: '/tmp/repo',
+    execGitReadonly: vi.fn(),
+    buildMergeSummary: vi.fn(),
+    execPr: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('review-publication-service', () => {
+  beforeEach(() => {
+    publishInvokerStackMock.mockReset();
+    shouldUseInvokerSyntheticReviewMock.mockReset();
+  });
+
+  it('uses synthetic Invoker stack publication when eligible', async () => {
+    shouldUseInvokerSyntheticReviewMock.mockResolvedValue(true);
+    publishInvokerStackMock.mockResolvedValue({
+      prs: [
+        {
+          workflowId: 'wf-1',
+          url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/123',
+          number: 123,
+        },
+      ],
+    });
+    const provider = { createReview: vi.fn(), checkApproval: vi.fn(), name: 'github' };
+    const host = makeHost({ mergeGateProvider: provider as any });
+
+    const result = await publishReview(host, {
+      kind: 'external_review',
+      workflowId: 'wf-1',
+      baseBranch: 'master',
+      featureBranch: 'feature',
+      title: 'Title',
+      cwd: '/tmp/repo',
+      body: 'body',
+    });
+
+    expect(result).toEqual({
+      url: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/123',
+      identifier: '123',
+    });
+    expect(provider.createReview).not.toHaveBeenCalled();
+  });
+
+  it('uses the review provider for normal external review publication', async () => {
+    shouldUseInvokerSyntheticReviewMock.mockResolvedValue(false);
+    const provider = {
+      createReview: vi.fn().mockResolvedValue({
+        url: 'https://github.com/example/repo/pull/77',
+        identifier: '77',
+      }),
+      checkApproval: vi.fn(),
+      name: 'github',
+    };
+    const host = makeHost({ mergeGateProvider: provider as any });
+
+    const result = await publishReview(host, {
+      kind: 'external_review',
+      workflowId: 'wf-2',
+      baseBranch: 'master',
+      featureBranch: 'feature',
+      title: 'Title',
+      cwd: '/tmp/repo',
+      body: 'body',
+    });
+
+    expect(provider.createReview).toHaveBeenCalledWith({
+      baseBranch: 'master',
+      featureBranch: 'feature',
+      title: 'Title',
+      cwd: '/tmp/repo',
+      body: 'body',
+    });
+    expect(result).toEqual({
+      url: 'https://github.com/example/repo/pull/77',
+      identifier: '77',
+    });
+  });
+
+  it('uses authored PR bodies for normal pull request publication', async () => {
+    shouldUseInvokerSyntheticReviewMock.mockResolvedValue(false);
+    const execPr = vi.fn().mockResolvedValue('https://github.com/example/repo/pull/88');
+    const authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+      body: '## Summary\n\nBody',
+      sessionId: 'sess-1',
+      agentName: 'codex',
+    });
+    const host = makeHost({
+      execPr,
+      authorPrBodyWithSkill,
+    });
+
+    const result = await publishReview(host, {
+      kind: 'pull_request',
+      workflowId: 'wf-3',
+      mergeNodeTaskId: '__merge__wf-3',
+      baseBranch: 'master',
+      featureBranch: 'feature',
+      title: 'Title',
+      cwd: '/tmp/repo',
+      workflowSummary: 'summary',
+    });
+
+    expect(authorPrBodyWithSkill).toHaveBeenCalledWith({
+      workflowId: 'wf-3',
+      mergeNodeTaskId: '__merge__wf-3',
+      title: 'Title',
+      baseBranch: 'master',
+      featureBranch: 'feature',
+      workflowSummary: 'summary',
+      cwd: '/tmp/repo',
+    });
+    expect(execPr).toHaveBeenCalledWith(
+      'master',
+      'feature',
+      'Title',
+      '## Summary\n\nBody',
+      '/tmp/repo',
+    );
+    expect(result).toEqual({
+      url: 'https://github.com/example/repo/pull/88',
+    });
+  });
+});

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -17,6 +17,7 @@ export * from './repo-pool.js';
 export * from './registry.js';
 export * from './task-runner.js';
 export * from './merge-runner.js';
+export * from './review-publication-service.js';
 export * from './conflict-resolver.js';
 export * from './merge-gate-provider.js';
 export * from './github-merge-gate-provider.js';

--- a/packages/execution-engine/src/invoker-stack-publisher.ts
+++ b/packages/execution-engine/src/invoker-stack-publisher.ts
@@ -1,0 +1,373 @@
+import { spawn } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+
+import type { SQLiteAdapter } from '@invoker/data-store';
+
+export type InvokerPublicationMode = 'review' | 'landing';
+
+export interface InvokerPublicationHost {
+  readonly persistence: SQLiteAdapter;
+  readonly defaultBranch: string | undefined;
+  readonly cwd: string;
+
+  execGitReadonly(args: string[], cwd?: string): Promise<string>;
+  buildMergeSummary(workflowId: string): Promise<string>;
+  authorPrBodyWithSkill?(args: {
+    workflowId?: string;
+    mergeNodeTaskId?: string;
+    title: string;
+    baseBranch: string;
+    featureBranch: string;
+    workflowSummary: string;
+    cwd: string;
+  }): Promise<{ body: string; sessionId: string; agentName: string }>;
+}
+
+type WorkflowRecord = NonNullable<ReturnType<SQLiteAdapter['loadWorkflow']>>;
+
+type PublicationStep = {
+  workflowId: string;
+  mergeNodeTaskId: string;
+  workflow: WorkflowRecord;
+  title: string;
+  summary: string;
+  prBody: string;
+  sourceBaseRef: string;
+  sourceFeatureRef: string;
+};
+
+type PublishedPr = {
+  workflowId: string;
+  title: string;
+  url: string;
+  number: number;
+  baseRefName: string;
+  headRefName: string;
+};
+
+export type PublishedInvokerStack = {
+  mode: InvokerPublicationMode;
+  rootWorkflowId: string;
+  reviewBaseSha: string;
+  reviewBaseBranch?: string;
+  landingBaseSha?: string;
+  prs: PublishedPr[];
+};
+
+const INVOKER_REPO_RE = /(?:EdbertChan|Neko-Catpital-Labs)\/Invoker(?:\.git)?\/?$/i;
+
+function isInvokerRepoUrl(url: string | undefined): boolean {
+  return Boolean(url && INVOKER_REPO_RE.test(url));
+}
+
+function parseGitHubRepoSlug(url: string): string {
+  const trimmed = url.trim().replace(/\.git$/i, '').replace(/\/+$/, '');
+  const sshMatch = trimmed.match(/[:/]([^/:]+\/[^/]+)$/);
+  if (!sshMatch) {
+    throw new Error(`Cannot derive GitHub repo slug from remote URL: ${url}`);
+  }
+  return sshMatch[1];
+}
+
+function normalizeParentRemoteName(parentRemote: string | undefined): string {
+  const normalized = parentRemote?.trim();
+  return normalized ? normalized : 'upstream';
+}
+
+function defaultPrBody(summary: string): string {
+  const trimmed = summary.trim() || 'Invoker publication update.';
+  return [
+    '## Summary',
+    '',
+    trimmed,
+    '',
+    '## Test Plan',
+    '',
+    '- [ ] Not run (publication-only path)',
+    '',
+    '## Revert Plan',
+    '',
+    '- Safe to revert? Yes',
+    '- Revert command: `git revert <sha>`',
+    '- Post-revert steps: None',
+    '- Data migration? No',
+  ].join('\n');
+}
+
+async function execCmd(
+  cmd: string,
+  args: string[],
+  cwd: string,
+  extraEnv?: Record<string, string>,
+  trim = true,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, ...extraEnv },
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk: Buffer) => { stdout += chunk.toString(); });
+    child.stderr?.on('data', (chunk: Buffer) => { stderr += chunk.toString(); });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve(trim ? stdout.trim() : stdout);
+        return;
+      }
+      reject(new Error(`${cmd} ${args.join(' ')} failed (code ${code}): ${stderr.trim()}${stdout.trim() ? `\n${stdout.trim()}` : ''}`));
+    });
+  });
+}
+
+async function execGit(args: string[], cwd: string): Promise<string> {
+  return execCmd('git', args, cwd);
+}
+
+function collectStackWorkflowIds(persistence: SQLiteAdapter, workflowId: string): string[] {
+  const parentIds = new Set<string>();
+  for (const task of persistence.loadTasks(workflowId)) {
+    if (task.config.isMergeNode) continue;
+    if ((task.dependencies?.length ?? 0) > 0) continue;
+    for (const dep of task.config.externalDependencies ?? []) {
+      if (dep.taskId === '__merge__') {
+        parentIds.add(dep.workflowId);
+      }
+    }
+  }
+  if (parentIds.size > 1) {
+    throw new Error(`Workflow ${workflowId} has multiple upstream workflow gates; synthetic review stack requires a linear chain.`);
+  }
+  const parentId = [...parentIds][0];
+  if (!parentId) return [workflowId];
+  return [...collectStackWorkflowIds(persistence, parentId), workflowId];
+}
+
+async function buildPublicationSteps(
+  host: InvokerPublicationHost,
+  workflowId: string,
+  targetBaseBranch: string,
+): Promise<{ rootWorkflowId: string; rootWorkflow: WorkflowRecord; steps: PublicationStep[] }> {
+  const workflowIds = collectStackWorkflowIds(host.persistence, workflowId);
+  const rootWorkflowId = workflowIds[0];
+  const rootWorkflow = host.persistence.loadWorkflow(rootWorkflowId);
+  if (!rootWorkflow) throw new Error(`Workflow ${rootWorkflowId} not found`);
+  const steps: PublicationStep[] = [];
+
+  for (let index = 0; index < workflowIds.length; index++) {
+    const currentWorkflowId = workflowIds[index];
+    const workflow = host.persistence.loadWorkflow(currentWorkflowId);
+    if (!workflow) throw new Error(`Workflow ${currentWorkflowId} not found`);
+    if (!workflow.featureBranch) throw new Error(`Workflow ${currentWorkflowId} has no featureBranch`);
+    const summary = await host.buildMergeSummary(currentWorkflowId);
+    const prBody = host.authorPrBodyWithSkill
+      ? (await host.authorPrBodyWithSkill({
+          workflowId: currentWorkflowId,
+          mergeNodeTaskId: `__merge__${currentWorkflowId}`,
+          title: workflow.name,
+          baseBranch: targetBaseBranch,
+          featureBranch: workflow.featureBranch,
+          workflowSummary: summary,
+          cwd: host.cwd,
+        })).body
+      : defaultPrBody(summary);
+    steps.push({
+      workflowId: currentWorkflowId,
+      mergeNodeTaskId: `__merge__${currentWorkflowId}`,
+      workflow,
+      title: workflow.name,
+      summary,
+      prBody,
+      sourceBaseRef: index === 0 ? '' : steps[index - 1].workflow.featureBranch!,
+      sourceFeatureRef: workflow.featureBranch,
+    });
+  }
+
+  return { rootWorkflowId, rootWorkflow, steps };
+}
+
+function extractPublishedPrUrls(output: string): string[] {
+  return [...new Set((output.match(/https:\/\/github\.com\/[^\s]+\/pull\/\d+/g) ?? []))];
+}
+
+async function loadPublishedPrs(repoSlug: string, cwd: string, expectedTitles: string[]): Promise<PublishedPr[]> {
+  const pulls = new Map<string, PublishedPr>();
+  for (const title of expectedTitles) {
+    const list = await execCmd('gh', [
+      'pr', 'list',
+      '--repo', repoSlug,
+      '--search', `in:title "${title}"`,
+      '--state', 'open',
+      '--json', 'number,title,url,baseRefName,headRefName',
+      '--limit', '20',
+    ], cwd);
+    const parsed = JSON.parse(list || '[]') as Array<{
+      number: number;
+      title: string;
+      url: string;
+      baseRefName: string;
+      headRefName: string;
+    }>;
+    for (const pr of parsed) {
+      if (expectedTitles.includes(pr.title)) {
+        pulls.set(pr.title, { workflowId: '', ...pr });
+      }
+    }
+  }
+  return [...pulls.values()];
+}
+
+async function applyDiffAsCommit(
+  cloneDir: string,
+  sourceBaseRef: string,
+  sourceFeatureRef: string,
+  title: string,
+  body: string,
+): Promise<void> {
+  const patchPath = join(cloneDir, '.invoker-step.patch');
+  const patch = sourceBaseRef
+    ? await execCmd('git', ['diff', '--binary', `${sourceBaseRef}..${sourceFeatureRef}`], cloneDir, undefined, false)
+    : '';
+  if (patch.trim()) {
+    writeFileSync(patchPath, patch, 'utf8');
+    await execGit(['apply', '--index', '--3way', patchPath], cloneDir);
+  }
+  const msgPath = join(cloneDir, '.invoker-step-message.txt');
+  writeFileSync(msgPath, `${title}\n\n${body.trim()}\n`, 'utf8');
+  await execGit(['commit', '--allow-empty', '-F', msgPath], cloneDir);
+}
+
+async function configureAuthor(cloneDir: string, host: InvokerPublicationHost): Promise<void> {
+  const userName = (
+    process.env.GIT_AUTHOR_NAME
+    ?? (await host.execGitReadonly(['config', '--get', 'user.name']).catch(() => 'EdbertChan')).trim()
+  ) || 'EdbertChan';
+  const userEmail = (
+    process.env.GIT_AUTHOR_EMAIL
+    ?? (await host.execGitReadonly(['config', '--get', 'user.email']).catch(() => 'edbert@example.com')).trim()
+  ) || 'edbert@example.com';
+  await execGit(['config', 'user.name', userName], cloneDir);
+  await execGit(['config', 'user.email', userEmail], cloneDir);
+}
+
+export async function shouldUseInvokerSyntheticReview(
+  host: InvokerPublicationHost,
+  workflowId: string,
+): Promise<boolean> {
+  const workflow = host.persistence.loadWorkflow(workflowId);
+  if (!workflow) return false;
+  if (isInvokerRepoUrl(workflow.repoUrl)) return true;
+  const parentRemote = normalizeParentRemoteName(workflow.parentRemote);
+  try {
+    const remoteUrl = await host.execGitReadonly(['remote', 'get-url', parentRemote], host.cwd);
+    return isInvokerRepoUrl(remoteUrl);
+  } catch {
+    return false;
+  }
+}
+
+export async function publishInvokerStack(
+  host: InvokerPublicationHost,
+  workflowId: string,
+  mode: InvokerPublicationMode,
+): Promise<PublishedInvokerStack> {
+  const workflow = host.persistence.loadWorkflow(workflowId);
+  if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+
+  const parentRemote = normalizeParentRemoteName(workflow.parentRemote);
+  const sourceRemote = 'origin';
+  const targetRemoteUrl = (await host.execGitReadonly(['remote', 'get-url', parentRemote], host.cwd)).trim();
+  const sourceRemoteUrl = (await host.execGitReadonly(['remote', 'get-url', sourceRemote], host.cwd)).trim();
+  const repoSlug = isInvokerRepoUrl(targetRemoteUrl)
+    ? parseGitHubRepoSlug(targetRemoteUrl)
+    : workflow.repoUrl
+      ? parseGitHubRepoSlug(workflow.repoUrl)
+      : parseGitHubRepoSlug(sourceRemoteUrl);
+
+  const initialBaseBranch = workflow.baseBranch ?? host.defaultBranch ?? 'master';
+  const { rootWorkflowId, rootWorkflow, steps } = await buildPublicationSteps(host, workflowId, initialBaseBranch);
+  const targetBaseBranch = rootWorkflow.baseBranch ?? host.defaultBranch ?? 'master';
+  const rootFeatureRef = steps[0].workflow.featureBranch!;
+
+  const cloneDir = mkdtempSync(join(tmpdir(), `invoker-stack-${mode}-`));
+  try {
+    await execCmd('git', ['clone', targetRemoteUrl, cloneDir], host.cwd);
+    await configureAuthor(cloneDir, host);
+    await execCmd('mergify', ['stack', 'setup'], cloneDir);
+    await execGit(['remote', 'add', 'source', sourceRemoteUrl], cloneDir);
+    await execGit(['fetch', 'origin', targetBaseBranch], cloneDir);
+    await execGit(['fetch', 'source', rootFeatureRef], cloneDir);
+    for (const step of steps.slice(1)) {
+      await execGit(['fetch', 'source', step.sourceFeatureRef], cloneDir);
+      await execGit(['fetch', 'source', step.sourceBaseRef], cloneDir);
+    }
+
+    const targetBaseSha = (await execGit(['rev-parse', `origin/${targetBaseBranch}`], cloneDir)).trim();
+    const reviewBaseSha = (await execGit(['merge-base', `source/${rootFeatureRef}`, `origin/${targetBaseBranch}`], cloneDir)).trim();
+    const reviewBaseBranch = `review-base/${rootWorkflowId}`;
+    const stackBranch = `${mode === 'review' ? 'review-stack' : 'landing-stack'}/${rootWorkflowId}`;
+
+    if (mode === 'review') {
+      await execGit(['branch', '-f', reviewBaseBranch, reviewBaseSha], cloneDir);
+      await execGit(['push', '--force', 'origin', `${reviewBaseBranch}:${reviewBaseBranch}`], cloneDir);
+      await execGit(['switch', '-C', stackBranch, reviewBaseBranch], cloneDir);
+      steps[0].sourceBaseRef = reviewBaseSha;
+    } else {
+      await execGit(['switch', '-C', stackBranch, `origin/${targetBaseBranch}`], cloneDir);
+      steps[0].sourceBaseRef = reviewBaseSha;
+    }
+
+    for (const step of steps) {
+      await applyDiffAsCommit(
+        cloneDir,
+        step.sourceBaseRef.startsWith('source/') || /^[0-9a-f]{40}$/i.test(step.sourceBaseRef)
+          ? step.sourceBaseRef
+          : `source/${step.sourceBaseRef}`,
+        `source/${step.sourceFeatureRef}`,
+        step.title,
+        step.prBody,
+      );
+    }
+
+    const pushOutput = await execCmd('mergify', ['stack', 'push'], cloneDir);
+    const pushUrls = extractPublishedPrUrls(pushOutput);
+    if (pushUrls.length === 0) {
+      throw new Error(`mergify stack push created no PR URLs for ${workflowId}`);
+    }
+
+    const publishedByTitle = new Map(
+      (await loadPublishedPrs(repoSlug, cloneDir, steps.map((step) => step.title)))
+        .map((pr) => [pr.title, pr]),
+    );
+    const prs: PublishedPr[] = [];
+    for (const step of steps) {
+      const pr = publishedByTitle.get(step.title);
+      if (!pr) {
+        throw new Error(`Could not resolve published PR metadata for step "${step.title}"`);
+      }
+      prs.push({ ...pr, workflowId: step.workflowId });
+      host.persistence.updateWorkflow(step.workflowId, {
+        parentRemote,
+        publicationState: mode === 'review' ? 'review_published' : 'landing_published',
+        reviewBaseSha,
+        ...(mode === 'review' ? { reviewBaseBranch, reviewPrUrl: pr.url } : {}),
+        ...(mode === 'landing' ? { landingBaseSha: targetBaseSha, landingPrUrl: pr.url } : {}),
+      });
+    }
+
+    return {
+      mode,
+      rootWorkflowId,
+      reviewBaseSha,
+      ...(mode === 'review' ? { reviewBaseBranch } : {}),
+      ...(mode === 'landing' ? { landingBaseSha: targetBaseSha } : {}),
+      prs,
+    };
+  } finally {
+    rmSync(cloneDir, { recursive: true, force: true });
+  }
+}

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -17,10 +17,7 @@ import type { TaskRunnerCallbacks } from './task-runner.js';
 import type { MergeGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
-import {
-  publishInvokerStack,
-  shouldUseInvokerSyntheticReview,
-} from './invoker-stack-publisher.js';
+import { publishReview } from './review-publication-service.js';
 
 // ── Trace logging ────────────────────────────────────────
 
@@ -419,10 +416,6 @@ export async function executeMergeNodeImpl(
         return;
       }
       if (mergeMode === 'external_review') {
-        if (!host.mergeGateProvider) {
-          throw new Error('mergeMode is "external_review" but no review provider configured');
-        }
-
         let fullSummary = summary;
         if (visualProof && host.runVisualProofCapture) {
           const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
@@ -439,26 +432,15 @@ export async function executeMergeNodeImpl(
           gateWorkspacePath!,
         );
 
-        // Create PR via provider (consolidation already done above).
-        // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
-        const result = await (async () => {
-          if (workflowId && await shouldUseInvokerSyntheticReview(host, workflowId)) {
-            const published = await publishInvokerStack(host, workflowId, 'review');
-            const current = published.prs.find((pr) => pr.workflowId === workflowId);
-            if (!current) throw new Error(`No published review PR found for workflow ${workflowId}`);
-            return {
-              url: current.url,
-              identifier: `${current.number}`,
-            };
-          }
-          return host.mergeGateProvider!.createReview({
-            baseBranch,
-            featureBranch,
-            title: workflow?.name ?? 'Workflow',
-            cwd: gateWorkspacePath!,
-            body: fullSummary,
-          });
-        })();
+        const result = await publishReview(host, {
+          kind: 'external_review',
+          workflowId,
+          baseBranch,
+          featureBranch,
+          title: workflow?.name ?? 'Workflow',
+          cwd: gateWorkspacePath!,
+          body: fullSummary,
+        });
         console.log(`[merge] Created GitHub PR: ${result.url}`);
 
         const prResponse: WorkResponse = {
@@ -478,6 +460,9 @@ export async function executeMergeNodeImpl(
           `[merge-gate-workspace] setTaskReviewReady path=external_review ` +
             `task=${task.id} gateWorkspacePath=${gateWorkspacePath ?? 'NULL'}`,
         );
+        if (!result.identifier) {
+          throw new Error(`Review publication did not return an identifier for workflow ${workflowId}`);
+        }
         setMergeGateReviewReady(host, task.id, {
           config: { executorType: 'worktree', summary },
           execution: {
@@ -659,23 +644,17 @@ export async function approveMergeImpl(
       mergeTrace('GIT_PUSH', { featureBranch, worktreeDir });
       // Push feature branch directly to origin (GitHub) from the clone
       await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
-      const reviewUrl = await (
-        workflowId && await shouldUseInvokerSyntheticReview(host, workflowId)
-          ? publishInvokerStack(host, workflowId, 'review').then((published) => {
-              const current = published.prs.find((pr) => pr.workflowId === workflowId);
-              if (!current) throw new Error(`No published review PR found for workflow ${workflowId}`);
-              return current.url;
-            })
-          : authorPrBodyForMerge(host, {
-              workflowId,
-              mergeNodeTaskId: mergeTaskId,
-              title: mergeMessage,
-              baseBranch,
-              featureBranch,
-              workflowSummary: fullSummary ?? '',
-              cwd: worktreeDir,
-            }).then((prBody) => host.execPr(baseBranch, featureBranch, mergeMessage, prBody, worktreeDir))
-      );
+      const review = await publishReview(host, {
+        kind: 'pull_request',
+        workflowId,
+        mergeNodeTaskId: mergeTaskId,
+        title: mergeMessage,
+        baseBranch,
+        featureBranch,
+        workflowSummary: fullSummary ?? '',
+        cwd: worktreeDir,
+      });
+      const reviewUrl = review.url;
       mergeTrace('PR_CREATED', { featureBranch, baseBranch, reviewUrl });
       console.log(`[merge] Approved: created pull request ${reviewUrl}`);
       host.persistence.updateTask(mergeTaskId, {
@@ -926,32 +905,20 @@ export async function publishAfterFixImpl(
     }
 
     if (mergeMode === 'external_review') {
-      if (!host.mergeGateProvider) {
-        throw new Error('mergeMode is "external_review" but no review provider configured');
-      }
-
-      const result = await (
-        workflowId && await shouldUseInvokerSyntheticReview(host, workflowId)
-          ? publishInvokerStack(host, workflowId, 'review').then((published) => {
-              const current = published.prs.find((pr) => pr.workflowId === workflowId);
-              if (!current) throw new Error(`No published review PR found for workflow ${workflowId}`);
-              return {
-                url: current.url,
-                identifier: `${current.number}`,
-              };
-            })
-          : host.mergeGateProvider.createReview({
-              baseBranch,
-              featureBranch,
-              title: workflow?.name ?? 'Workflow',
-              cwd: consolidateDir,
-              body: fullSummary,
-            })
-      );
+      const result = await publishReview(host, {
+        kind: 'external_review',
+        workflowId,
+        baseBranch,
+        featureBranch,
+        title: workflow?.name ?? 'Workflow',
+        cwd: consolidateDir,
+        body: fullSummary,
+      });
       console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
 
-
-
+      if (!result.identifier) {
+        throw new Error(`Review publication did not return an identifier for workflow ${workflowId}`);
+      }
       setMergeGateReviewReady(host, task.id, {
         config: { executorType: 'worktree', summary },
         execution: {
@@ -972,23 +939,17 @@ export async function publishAfterFixImpl(
 
     // manual mode with pull_request onFinish
     if (onFinish === 'pull_request') {
-      const reviewUrl = await (
-        workflowId && await shouldUseInvokerSyntheticReview(host, workflowId)
-          ? publishInvokerStack(host, workflowId, 'review').then((published) => {
-              const current = published.prs.find((pr) => pr.workflowId === workflowId);
-              if (!current) throw new Error(`No published review PR found for workflow ${workflowId}`);
-              return current.url;
-            })
-          : authorPrBodyForMerge(host, {
-              workflowId,
-              mergeNodeTaskId: task.id,
-              title: workflow?.name ?? 'Workflow',
-              baseBranch,
-              featureBranch,
-              workflowSummary: fullSummary ?? '',
-              cwd: consolidateDir,
-            }).then((prBody) => host.execPr(baseBranch, featureBranch, workflow?.name ?? 'Workflow', prBody, consolidateDir))
-      );
+      const review = await publishReview(host, {
+        kind: 'pull_request',
+        workflowId,
+        mergeNodeTaskId: task.id,
+        title: workflow?.name ?? 'Workflow',
+        baseBranch,
+        featureBranch,
+        workflowSummary: fullSummary ?? '',
+        cwd: consolidateDir,
+      });
+      const reviewUrl = review.url;
       console.log(`[merge] Post-fix: created pull request ${reviewUrl}`);
       host.persistence.updateTask(task.id, {
         config: { summary },

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -17,6 +17,10 @@ import type { TaskRunnerCallbacks } from './task-runner.js';
 import type { MergeGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
+import {
+  publishInvokerStack,
+  shouldUseInvokerSyntheticReview,
+} from './invoker-stack-publisher.js';
 
 // ── Trace logging ────────────────────────────────────────
 
@@ -437,13 +441,24 @@ export async function executeMergeNodeImpl(
 
         // Create PR via provider (consolidation already done above).
         // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
-        const result = await host.mergeGateProvider.createReview({
-          baseBranch,
-          featureBranch,
-          title: workflow?.name ?? 'Workflow',
-          cwd: gateWorkspacePath!,
-          body: fullSummary,
-        });
+        const result = await (async () => {
+          if (workflowId && await shouldUseInvokerSyntheticReview(host, workflowId)) {
+            const published = await publishInvokerStack(host, workflowId, 'review');
+            const current = published.prs.find((pr) => pr.workflowId === workflowId);
+            if (!current) throw new Error(`No published review PR found for workflow ${workflowId}`);
+            return {
+              url: current.url,
+              identifier: `${current.number}`,
+            };
+          }
+          return host.mergeGateProvider!.createReview({
+            baseBranch,
+            featureBranch,
+            title: workflow?.name ?? 'Workflow',
+            cwd: gateWorkspacePath!,
+            body: fullSummary,
+          });
+        })();
         console.log(`[merge] Created GitHub PR: ${result.url}`);
 
         const prResponse: WorkResponse = {
@@ -644,16 +659,23 @@ export async function approveMergeImpl(
       mergeTrace('GIT_PUSH', { featureBranch, worktreeDir });
       // Push feature branch directly to origin (GitHub) from the clone
       await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
-      const prBody = await authorPrBodyForMerge(host, {
-        workflowId,
-        mergeNodeTaskId: mergeTaskId,
-        title: mergeMessage,
-        baseBranch,
-        featureBranch,
-        workflowSummary: fullSummary ?? '',
-        cwd: worktreeDir,
-      });
-      const reviewUrl = await host.execPr(baseBranch, featureBranch, mergeMessage, prBody, worktreeDir);
+      const reviewUrl = await (
+        workflowId && await shouldUseInvokerSyntheticReview(host, workflowId)
+          ? publishInvokerStack(host, workflowId, 'review').then((published) => {
+              const current = published.prs.find((pr) => pr.workflowId === workflowId);
+              if (!current) throw new Error(`No published review PR found for workflow ${workflowId}`);
+              return current.url;
+            })
+          : authorPrBodyForMerge(host, {
+              workflowId,
+              mergeNodeTaskId: mergeTaskId,
+              title: mergeMessage,
+              baseBranch,
+              featureBranch,
+              workflowSummary: fullSummary ?? '',
+              cwd: worktreeDir,
+            }).then((prBody) => host.execPr(baseBranch, featureBranch, mergeMessage, prBody, worktreeDir))
+      );
       mergeTrace('PR_CREATED', { featureBranch, baseBranch, reviewUrl });
       console.log(`[merge] Approved: created pull request ${reviewUrl}`);
       host.persistence.updateTask(mergeTaskId, {
@@ -908,13 +930,24 @@ export async function publishAfterFixImpl(
         throw new Error('mergeMode is "external_review" but no review provider configured');
       }
 
-      const result = await host.mergeGateProvider.createReview({
-        baseBranch,
-        featureBranch,
-        title: workflow?.name ?? 'Workflow',
-        cwd: consolidateDir,
-        body: fullSummary,
-      });
+      const result = await (
+        workflowId && await shouldUseInvokerSyntheticReview(host, workflowId)
+          ? publishInvokerStack(host, workflowId, 'review').then((published) => {
+              const current = published.prs.find((pr) => pr.workflowId === workflowId);
+              if (!current) throw new Error(`No published review PR found for workflow ${workflowId}`);
+              return {
+                url: current.url,
+                identifier: `${current.number}`,
+              };
+            })
+          : host.mergeGateProvider.createReview({
+              baseBranch,
+              featureBranch,
+              title: workflow?.name ?? 'Workflow',
+              cwd: consolidateDir,
+              body: fullSummary,
+            })
+      );
       console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
 
 
@@ -939,16 +972,23 @@ export async function publishAfterFixImpl(
 
     // manual mode with pull_request onFinish
     if (onFinish === 'pull_request') {
-      const prBody = await authorPrBodyForMerge(host, {
-        workflowId,
-        mergeNodeTaskId: task.id,
-        title: workflow?.name ?? 'Workflow',
-        baseBranch,
-        featureBranch,
-        workflowSummary: fullSummary ?? '',
-        cwd: consolidateDir,
-      });
-      const reviewUrl = await host.execPr(baseBranch, featureBranch, workflow?.name ?? 'Workflow', prBody, consolidateDir);
+      const reviewUrl = await (
+        workflowId && await shouldUseInvokerSyntheticReview(host, workflowId)
+          ? publishInvokerStack(host, workflowId, 'review').then((published) => {
+              const current = published.prs.find((pr) => pr.workflowId === workflowId);
+              if (!current) throw new Error(`No published review PR found for workflow ${workflowId}`);
+              return current.url;
+            })
+          : authorPrBodyForMerge(host, {
+              workflowId,
+              mergeNodeTaskId: task.id,
+              title: workflow?.name ?? 'Workflow',
+              baseBranch,
+              featureBranch,
+              workflowSummary: fullSummary ?? '',
+              cwd: consolidateDir,
+            }).then((prBody) => host.execPr(baseBranch, featureBranch, workflow?.name ?? 'Workflow', prBody, consolidateDir))
+      );
       console.log(`[merge] Post-fix: created pull request ${reviewUrl}`);
       host.persistence.updateTask(task.id, {
         config: { summary },

--- a/packages/execution-engine/src/review-publication-service.ts
+++ b/packages/execution-engine/src/review-publication-service.ts
@@ -1,0 +1,112 @@
+import type { MergeGateProvider } from './merge-gate-provider.js';
+import {
+  publishInvokerStack,
+  shouldUseInvokerSyntheticReview,
+  type InvokerPublicationHost,
+} from './invoker-stack-publisher.js';
+
+export interface ReviewPublicationHost extends InvokerPublicationHost {
+  readonly mergeGateProvider?: MergeGateProvider;
+
+  execPr(baseBranch: string, featureBranch: string, title: string, body?: string, cwd?: string): Promise<string>;
+}
+
+export type ReviewPublicationResult = {
+  url: string;
+  identifier?: string;
+};
+
+export type ReviewPublicationRequest =
+  | {
+      kind: 'external_review';
+      workflowId?: string;
+      baseBranch: string;
+      featureBranch: string;
+      title: string;
+      cwd: string;
+      body?: string;
+    }
+  | {
+      kind: 'pull_request';
+      workflowId?: string;
+      mergeNodeTaskId?: string;
+      baseBranch: string;
+      featureBranch: string;
+      title: string;
+      cwd: string;
+      workflowSummary: string;
+    };
+
+async function publishInvokerSyntheticReview(
+  host: ReviewPublicationHost,
+  workflowId: string | undefined,
+): Promise<ReviewPublicationResult | null> {
+  if (!workflowId || !(await shouldUseInvokerSyntheticReview(host, workflowId))) {
+    return null;
+  }
+  const published = await publishInvokerStack(host, workflowId, 'review');
+  const current = published.prs.find((pr) => pr.workflowId === workflowId);
+  if (!current) {
+    throw new Error(`No published review PR found for workflow ${workflowId}`);
+  }
+  return {
+    url: current.url,
+    identifier: `${current.number}`,
+  };
+}
+
+async function authorPrBody(
+  host: ReviewPublicationHost,
+  request: Extract<ReviewPublicationRequest, { kind: 'pull_request' }>,
+): Promise<string> {
+  if (!host.authorPrBodyWithSkill) {
+    throw new Error('authorPrBodyWithSkill is required for merge PR authoring');
+  }
+  const authored = await host.authorPrBodyWithSkill({
+    workflowId: request.workflowId,
+    mergeNodeTaskId: request.mergeNodeTaskId,
+    title: request.title,
+    baseBranch: request.baseBranch,
+    featureBranch: request.featureBranch,
+    workflowSummary: request.workflowSummary,
+    cwd: request.cwd,
+  });
+  console.log(
+    `[merge] Authored PR body via ${authored.agentName} skill session=${authored.sessionId}`,
+  );
+  return authored.body;
+}
+
+export async function publishReview(
+  host: ReviewPublicationHost,
+  request: ReviewPublicationRequest,
+): Promise<ReviewPublicationResult> {
+  const synthetic = await publishInvokerSyntheticReview(host, request.workflowId);
+  if (synthetic) {
+    return synthetic;
+  }
+
+  if (request.kind === 'external_review') {
+    if (!host.mergeGateProvider) {
+      throw new Error('mergeMode is "external_review" but no review provider configured');
+    }
+    return host.mergeGateProvider.createReview({
+      baseBranch: request.baseBranch,
+      featureBranch: request.featureBranch,
+      title: request.title,
+      cwd: request.cwd,
+      body: request.body,
+    });
+  }
+
+  const prBody = await authorPrBody(host, request);
+  return {
+    url: await host.execPr(
+      request.baseBranch,
+      request.featureBranch,
+      request.title,
+      prBody,
+      request.cwd,
+    ),
+  };
+}

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -50,6 +50,10 @@ import {
   spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
 } from './pr-authoring.js';
+import {
+  publishInvokerStack,
+  shouldUseInvokerSyntheticReview,
+} from './invoker-stack-publisher.js';
 
 /** Keeps `lastHeartbeatAt` fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). Matches BaseExecutor default heartbeat cadence. */
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -926,6 +930,26 @@ export class TaskRunner {
 
   async buildMergeSummary(workflowId: string): Promise<string> {
     return buildMergeSummaryImpl(this, workflowId);
+  }
+
+  async publishReviewStack(workflowId: string): Promise<{ reviewUrl: string }> {
+    if (!(await shouldUseInvokerSyntheticReview(this, workflowId))) {
+      throw new Error(`Workflow ${workflowId} is not eligible for Invoker synthetic review publication`);
+    }
+    const published = await publishInvokerStack(this, workflowId, 'review');
+    const current = published.prs.find((pr) => pr.workflowId === workflowId);
+    if (!current) throw new Error(`No review PR found for workflow ${workflowId}`);
+    return { reviewUrl: current.url };
+  }
+
+  async publishLandingStack(workflowId: string): Promise<{ landingUrl: string }> {
+    if (!(await shouldUseInvokerSyntheticReview(this, workflowId))) {
+      throw new Error(`Workflow ${workflowId} is not eligible for Invoker landing publication`);
+    }
+    const published = await publishInvokerStack(this, workflowId, 'landing');
+    const current = published.prs.find((pr) => pr.workflowId === workflowId);
+    if (!current) throw new Error(`No landing PR found for workflow ${workflowId}`);
+    return { landingUrl: current.url };
   }
 
   private async commitApprovedMergeFix(task: TaskState): Promise<void> {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -140,10 +140,31 @@ export interface OrchestratorPersistence {
     repoUrl?: string;
     onFinish?: string;
     baseBranch?: string;
+    parentRemote?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    reviewProvider?: string;
+    publicationState?: 'unpublished' | 'review_published' | 'landing_published' | 'landing_stale';
+    reviewBaseSha?: string;
+    reviewBaseBranch?: string;
+    reviewPrUrl?: string;
+    landingBaseSha?: string;
+    landingPrUrl?: string;
   }): void;
-  updateWorkflow?(workflowId: string, changes: { status?: string; updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' }): void;
+  updateWorkflow?(workflowId: string, changes: {
+    status?: string;
+    updatedAt?: string;
+    baseBranch?: string;
+    generation?: number;
+    mergeMode?: 'manual' | 'automatic' | 'external_review';
+    parentRemote?: string;
+    publicationState?: 'unpublished' | 'review_published' | 'landing_published' | 'landing_stale';
+    reviewBaseSha?: string;
+    reviewBaseBranch?: string;
+    reviewPrUrl?: string;
+    landingBaseSha?: string;
+    landingPrUrl?: string;
+  }): void;
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
@@ -179,6 +200,9 @@ export interface OrchestratorPersistence {
   loadWorkflow?(workflowId: string): {
     repoUrl?: string;
     baseBranch?: string;
+    parentRemote?: string;
+    featureBranch?: string;
+    reviewProvider?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
   } | undefined;
   /** Delete a single workflow and its tasks from the DB. */
@@ -199,6 +223,7 @@ export interface PlanDefinition {
   visualProof?: boolean;
   onFinish?: 'none' | 'merge' | 'pull_request';
   baseBranch?: string;
+  parentRemote?: string;
   featureBranch?: string;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
   reviewProvider?: string;
@@ -1264,8 +1289,10 @@ export class Orchestrator {
       repoUrl: plan.repoUrl,
       onFinish: plan.onFinish,
       baseBranch: plan.baseBranch,
+      parentRemote: plan.parentRemote,
       featureBranch: plan.featureBranch,
       mergeMode: plan.mergeMode,
+      reviewProvider: plan.reviewProvider,
       createdAt,
       updatedAt: createdAt,
     });
@@ -3029,7 +3056,9 @@ export class Orchestrator {
       if (typeof m.repoUrl === 'string') baseSaveWf.repoUrl = m.repoUrl;
       if (typeof m.onFinish === 'string') baseSaveWf.onFinish = m.onFinish;
       if (typeof m.baseBranch === 'string') baseSaveWf.baseBranch = m.baseBranch;
+      if (typeof m.parentRemote === 'string') baseSaveWf.parentRemote = m.parentRemote;
       if (typeof m.featureBranch === 'string') baseSaveWf.featureBranch = m.featureBranch;
+      if (typeof m.reviewProvider === 'string') baseSaveWf.reviewProvider = m.reviewProvider;
       if (m.mergeMode === 'manual' || m.mergeMode === 'automatic' || m.mergeMode === 'external_review') {
         baseSaveWf.mergeMode = m.mergeMode;
       }

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -25,8 +25,16 @@ export interface WorkflowRecord {
   repoUrl?: string;
   onFinish?: string;
   baseBranch?: string;
+  parentRemote?: string;
   featureBranch?: string;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
+  reviewProvider?: string;
+  publicationState?: 'unpublished' | 'review_published' | 'landing_published' | 'landing_stale';
+  reviewBaseSha?: string;
+  reviewBaseBranch?: string;
+  reviewPrUrl?: string;
+  landingBaseSha?: string;
+  landingPrUrl?: string;
 }
 
 export interface WorkflowChanges {
@@ -35,6 +43,13 @@ export interface WorkflowChanges {
   baseBranch?: string;
   generation?: number;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
+  parentRemote?: string;
+  publicationState?: 'unpublished' | 'review_published' | 'landing_published' | 'landing_stale';
+  reviewBaseSha?: string;
+  reviewBaseBranch?: string;
+  reviewPrUrl?: string;
+  landingBaseSha?: string;
+  landingPrUrl?: string;
 }
 
 export type AttemptChanges = Partial<

--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -9,6 +9,7 @@
  * Options:
  *   --title <t>        PR title (required)
  *   --base <b>         Base branch (required)
+ *   --head <h>         Head ref or fork-qualified head (defaults automatically)
  *   --body-file <f>    Read PR body from file
  *   --body <text>      Inline PR body
  *   --update <num>     Update existing PR instead of creating new
@@ -110,6 +111,7 @@ function usage() {
 Options:
   --title <t>        PR title (required)
   --base <b>         Base branch (required)
+  --head <h>         Head ref or fork-qualified head (defaults automatically)
   --body-file <f>    Read PR body from file
   --body <text>      Inline PR body
   --update <num>     Update existing PR number instead of creating new
@@ -125,7 +127,7 @@ PR body schema:
 
 function parseArgs() {
   const args = process.argv.slice(2);
-  const parsed = { title: '', base: '', body: '', bodyFile: '', update: '', dryRun: false };
+  const parsed = { title: '', base: '', head: '', body: '', bodyFile: '', update: '', dryRun: false };
 
   for (let i = 0; i < args.length; i++) {
     switch (args[i]) {
@@ -133,6 +135,7 @@ function parseArgs() {
       case '--dry-run': parsed.dryRun = true; break;
       case '--title': parsed.title = args[++i] || ''; break;
       case '--base': parsed.base = args[++i] || ''; break;
+      case '--head': parsed.head = args[++i] || ''; break;
       case '--body': parsed.body = args[++i] || ''; break;
       case '--body-file': parsed.bodyFile = args[++i] || ''; break;
       case '--update': parsed.update = args[++i] || ''; break;
@@ -225,15 +228,24 @@ async function injectImages(body, dryRun) {
 
 // ── Git + GitHub helpers ────────────────────────────────────────────────────
 
+function parseGithubNwo(url) {
+  const match = url.trim().match(/github\.com[:/]([^/]+\/[^/.]+)(?:\.git)?\/?$/i);
+  return match?.[1] ?? null;
+}
+
+function getRemoteNwo(remote) {
+  try {
+    const url = execSync(`git remote get-url ${remote}`, { encoding: 'utf-8' }).trim();
+    return parseGithubNwo(url);
+  } catch {
+    return null;
+  }
+}
+
 function getRepoNwo() {
   // Prefer parent remote (fork workflow: PRs target parent, not the fork)
-  try {
-    const url = execSync(`git remote get-url ${DEFAULT_PARENT_REMOTE}`, { encoding: 'utf-8' }).trim();
-    const match = url.match(/github\.com[:/]([^/]+\/[^/.]+)/);
-    if (match) return match[1];
-  } catch {
-    // No parent remote; fall back to gh default
-  }
+  const parentNwo = getRemoteNwo(DEFAULT_PARENT_REMOTE);
+  if (parentNwo) return parentNwo;
   return execSync('gh repo view --json nameWithOwner -q .nameWithOwner', { encoding: 'utf-8' }).trim();
 }
 
@@ -248,6 +260,18 @@ function gitPush(dryRun) {
 
 function getCurrentBranch() {
   return execSync('git branch --show-current', { encoding: 'utf-8' }).trim();
+}
+
+function resolveHeadRef(explicitHead, targetNwo) {
+  const trimmed = explicitHead.trim();
+  if (trimmed) return trimmed;
+
+  const branch = getCurrentBranch();
+  const originNwo = getRemoteNwo('origin');
+  if (!originNwo || originNwo === targetNwo) return branch;
+
+  const [originOwner] = originNwo.split('/');
+  return `${originOwner}:${branch}`;
 }
 
 function hasRemote(name) {
@@ -320,11 +344,11 @@ function assertCleanPrBase(baseBranch) {
   );
 }
 
-async function createPr(nwo, title, base, body, dryRun) {
-  const head = getCurrentBranch();
+async function createPr(nwo, title, head, base, body, dryRun) {
+  const printableHead = head;
 
   if (dryRun) {
-    console.error(`[dry-run] Would create PR: "${title}" (${head} → ${base})`);
+    console.error(`[dry-run] Would create PR: "${title}" (${printableHead} → ${base})`);
     console.error(`[dry-run] Body length: ${body.length} chars`);
     return 'https://DRY-RUN/pull/0';
   }
@@ -379,12 +403,13 @@ async function main() {
 
   // Create or update PR
   const nwo = args.dryRun ? 'OWNER/REPO' : getRepoNwo();
+  const head = resolveHeadRef(args.head, nwo);
   let prUrl;
 
   if (args.update) {
     prUrl = await updatePr(nwo, args.update, args.title, body, args.dryRun);
   } else {
-    prUrl = await createPr(nwo, args.title, args.base, body, args.dryRun);
+    prUrl = await createPr(nwo, args.title, head, args.base, body, args.dryRun);
   }
 
   // Print PR URL to stdout (only useful output to stdout)


### PR DESCRIPTION
## Summary

Add an Invoker-only synthetic review publication path so stale workflow branches can produce clean stacked review PRs without being manually restacked first.

Persist the workflow publication metadata needed to track both review and landing publication, and add explicit headless/API commands for publishing each lane.

Refactor the switch-heavy headless CLI routing into command and subcommand registries, and replace repeated merge-runner publication branching with a shared review publication service.

Keep the actual mergeable lane separate by rebuilding the same stack onto fresh `upstream/master`, so review diffs stay clean while landing still targets real `master`.

Teach `scripts/create-pr.mjs` to resolve fork-qualified heads automatically, so upstream PRs can be created and updated through the same repo-local PR flow as other Invoker changes.

## Architecture

### Before

```mermaid
flowchart TD
    A[Workflow feature branches<br/>may still fork from old master] --> B[Merge node publish]
    B --> C[Direct PR creation against master]
    C --> D[GitHub diff includes stale history]
    D --> E[Manual restack or rebase needed before review is clean]

    F[runHeadless] --> G[switch command]
    G --> H[query]
    G --> I[set]
    H --> J[switch subcommand]
    J --> K[switch output mode]

    L[merge-runner paths] --> M[repeated if Invoker synthetic]
    M --> N[publishInvokerStack or provider/execPr]
```

### After

```mermaid
flowchart TD
    A[Workflow feature branches<br/>may still fork from old master] --> B[Invoker stack publisher]
    B --> C[Compute merge-base with upstream/master]
    C --> D[Create review-base/<root-workflow-id>]
    D --> E[Rebuild synthetic review stack]
    E --> F[Mergify stacked PRs for human review]
    B --> G[Rebuild landing stack on fresh upstream/master]
    G --> H[Mergify mergeable stack targeting real master]

    I[runHeadless] --> J[command registry]
    J --> K[query registry]
    J --> L[set registry]
    K --> M[shared output renderer map]

    N[merge-runner paths] --> O[review publication service]
    O --> P[synthetic Invoker strategy]
    O --> Q[default provider or execPr strategy]

    R[create-pr.mjs] --> S[Resolve origin owner plus branch]
    S --> T[Create or update parent-repo PR]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-delegation.test.ts src/__tests__/headless-query-stats.test.ts src/__tests__/headless-watch.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/review-publication-service.test.ts src/__tests__/invoker-stack-publisher.test.ts src/__tests__/publish-after-fix.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/plan-parser.test.ts`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `node scripts/create-pr.mjs --title "Add synthetic review-base and landing stack publication" --base master --body-file .tmp-pr-body-synthetic-review-base.md --dry-run`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
