### PR TITLE
Add explicit detach workflow flow

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -102,6 +102,7 @@ function createMocks() {
         started: [makeTask({ id: `${workflowId}-fork/task-1`, config: { workflowId: `${workflowId}-fork` } })],
       })),
       deleteWorkflow: vi.fn(),
+      detachWorkflow: vi.fn(),
       getQueueStatus: vi.fn(() => ({
         maxConcurrency: 4,
         runningCount: 1,
@@ -926,6 +927,24 @@ describe('DELETE /api/workflows/:id', () => {
     const res = await request(port, 'DELETE', '/api/workflows/missing');
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('workflow not found');
+  });
+});
+
+describe('POST /api/workflows/:id/detach', () => {
+  it('detaches workflow from one upstream workflow', async () => {
+    const res = await request(port, 'POST', '/api/workflows/wf-1/detach', {
+      upstreamWorkflowId: 'wf-0',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.action).toBe('detached');
+    expect(mocks.orchestrator.detachWorkflow).toHaveBeenCalledWith('wf-1', 'wf-0');
+  });
+
+  it('returns 400 when upstreamWorkflowId is missing', async () => {
+    const res = await request(port, 'POST', '/api/workflows/wf-1/detach', {});
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('Missing "upstreamWorkflowId"');
   });
 });
 

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -26,6 +26,7 @@
  *   POST   /api/tasks/:id/edit-type    body: { executorType, remoteTargetId? }
  *   POST   /api/tasks/:id/edit-agent   body: { agent }
  *   POST   /api/tasks/:id/gate-policy  body: { updates: [{ workflowId, taskId?, gatePolicy }] }
+ *   POST   /api/workflows/:id/detach  body: { upstreamWorkflowId }
  *   POST   /api/workflows/:id/restart
  *   POST   /api/workflows/:id/cancel
  *   POST   /api/workflows/:id/merge-mode  body: { mode }
@@ -663,6 +664,30 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         try {
           orchestrator.deleteWorkflow(workflowId);
           json(res, 200, { ok: true, workflowId, action: 'deleted' });
+        } catch (err) {
+          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+        }
+        return;
+      }
+
+      // POST /api/workflows/:id/detach
+      const wfDetachMatch = path.match(/^\/api\/workflows\/([^/]+)\/detach$/);
+      if (method === 'POST' && wfDetachMatch) {
+        const workflowId = decodeURIComponent(wfDetachMatch[1]);
+        try {
+          const body = await readBody(req);
+          const { upstreamWorkflowId } = JSON.parse(body);
+          if (!upstreamWorkflowId) {
+            json(res, 400, { error: 'Missing "upstreamWorkflowId" in request body' });
+            return;
+          }
+          orchestrator.detachWorkflow(workflowId, String(upstreamWorkflowId));
+          json(res, 200, {
+            ok: true,
+            workflowId,
+            upstreamWorkflowId,
+            action: 'detached',
+          });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });
         }

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -122,6 +122,7 @@ export function isHeadlessMutatingCommand(args: string[]): boolean {
 
   return [
     'run', 'resume', 'retry', 'retry-task', 'recreate', 'recreate-task', 'rebase', 'fix', 'resolve-conflict',
+    'detach-workflow',
     'migrate-compat',
     'rebase-and-retry',
     'approve', 'reject', 'input', 'select',

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -696,6 +696,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'fork-workflow':
       await headlessForkWorkflow(args[1], deps);
       break;
+    case 'detach-workflow':
+      await headlessDetachWorkflow(args[1], args[2], deps);
+      break;
     case 'rebase':
       await headlessRebaseAndRetry(args[1], deps);
       break;
@@ -860,6 +863,7 @@ ${BOLD}Execute:${RESET}
   recreate <workflowId>                                Recreate workflow: wipe all state, new generation
   recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
   fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
+  detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
   rebase <taskId>                                     Refresh pool base + nuclear restart
   fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
   resolve-conflict <taskId> [claude|codex]            Resolve merge conflict + restart
@@ -2053,6 +2057,27 @@ async function headlessDeleteWorkflow(workflowId: string, deps: Pick<HeadlessDep
   const result = await deps.commandService.deleteWorkflow(envelope);
   if (!result.ok) throw new Error(result.error.message);
   process.stdout.write(`Deleted workflow: ${workflowId}\n`);
+}
+
+async function headlessDetachWorkflow(
+  workflowId: string,
+  upstreamWorkflowId: string,
+  deps: Pick<HeadlessDeps, 'commandService'>,
+): Promise<void> {
+  if (!workflowId || !upstreamWorkflowId) {
+    throw new Error(
+      'Missing arguments. Usage: --headless detach-workflow <workflowId> <upstreamWorkflowId>',
+    );
+  }
+  const envelope = makeEnvelope('detach-workflow', 'headless', 'workflow', {
+    workflowId,
+    upstreamWorkflowId,
+  });
+  const result = await deps.commandService.detachWorkflow(envelope);
+  if (!result.ok) throw new Error(result.error.message);
+  process.stdout.write(
+    `Detached workflow ${workflowId} from upstream workflow ${upstreamWorkflowId}\n`,
+  );
 }
 
 /**

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1806,6 +1806,8 @@ if (isHeadless) {
         return { channel: 'headless.exec', request: { args: ['delete-all'] } };
       case 'invoker:delete-workflow':
         return { channel: 'headless.exec', request: { args: ['delete', String(arg0)] } };
+      case 'invoker:detach-workflow':
+        return { channel: 'headless.exec', request: { args: ['detach-workflow', String(arg0), String(arg1)] } };
       case 'invoker:provide-input':
         return { channel: 'headless.exec', request: { args: ['input', String(arg0), String(arg1)] } };
       case 'invoker:approve':
@@ -2761,6 +2763,31 @@ if (isHeadless) {
         throw err;
       }
     });
+
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:detach-workflow',
+      (workflowIdArg: unknown) => String(workflowIdArg),
+      'high',
+      async (workflowIdArg: unknown, upstreamWorkflowIdArg: unknown) => {
+        const workflowId = String(workflowIdArg);
+        const upstreamWorkflowId = String(upstreamWorkflowIdArg);
+        logger.info(
+          `detach-workflow: workflow="${workflowId}" upstream="${upstreamWorkflowId}"`,
+          { module: 'ipc' },
+        );
+        try {
+          const envelope = makeEnvelope('detach-workflow', 'ui', 'workflow', {
+            workflowId,
+            upstreamWorkflowId,
+          });
+          const result = await commandService.detachWorkflow(envelope);
+          if (!result.ok) throw new Error(result.error.message);
+        } catch (err) {
+          logger.error(`detach-workflow failed: ${err}`, { module: 'ipc' });
+          throw err;
+        }
+      },
+    );
 
     ipcMain.handle('invoker:load-workflow', (_event, workflowId: string) => {
       logger.info(`load-workflow: "${workflowId}"`, { module: 'ipc' });

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -38,6 +38,7 @@ function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
     cancelTask: vi.fn().mockReturnValue({ cancelled: [], runningCancelled: [] }),
     cancelWorkflow: vi.fn().mockReturnValue({ cancelled: [], runningCancelled: [] }),
     deleteWorkflow: vi.fn(),
+    detachWorkflow: vi.fn(),
     retryWorkflow: vi.fn().mockReturnValue([]),
     recreateWorkflow: vi.fn().mockReturnValue([]),
     recreateWorkflowFromFreshBase: vi.fn().mockResolvedValue([] as TaskState[]),
@@ -334,6 +335,29 @@ describe('CommandService', () => {
       });
       const result = await service.deleteWorkflow(makeEnvelope({ workflowId: 'bad' }));
       expect(result).toEqual({ ok: false, error: { code: 'DELETE_WORKFLOW_FAILED', message: 'wf not found' } });
+    });
+  });
+
+  describe('detachWorkflow', () => {
+    it('delegates to orchestrator.detachWorkflow', async () => {
+      const result = await service.detachWorkflow(
+        makeEnvelope({ workflowId: 'wf-1', upstreamWorkflowId: 'wf-0' }),
+      );
+      expect(result).toEqual({ ok: true, data: undefined });
+      expect(orchestrator.detachWorkflow).toHaveBeenCalledWith('wf-1', 'wf-0');
+    });
+
+    it('returns error on exception', async () => {
+      (orchestrator.detachWorkflow as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error('detach failed');
+      });
+      const result = await service.detachWorkflow(
+        makeEnvelope({ workflowId: 'wf-1', upstreamWorkflowId: 'wf-0' }),
+      );
+      expect(result).toEqual({
+        ok: false,
+        error: { code: 'DETACH_WORKFLOW_FAILED', message: 'detach failed' },
+      });
     });
   });
 

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -16,6 +16,8 @@ class InMemoryPersistence implements OrchestratorPersistence {
     createdAt: string;
     updatedAt: string;
     repoUrl?: string;
+    baseBranch?: string;
+    featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
   }>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
@@ -28,6 +30,8 @@ class InMemoryPersistence implements OrchestratorPersistence {
     name: string;
     status: string;
     repoUrl?: string;
+    baseBranch?: string;
+    featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
   }): void {
     const now = new Date().toISOString();
@@ -37,6 +41,8 @@ class InMemoryPersistence implements OrchestratorPersistence {
       // (Step 5 `editTaskType` → ssh) keep passing without each
       // plan having to spell out a remote URL.
       repoUrl: workflow.repoUrl ?? 'memory://test-repo',
+      baseBranch: workflow.baseBranch,
+      featureBranch: workflow.featureBranch,
       createdAt: (workflow as any).createdAt ?? now,
       updatedAt: (workflow as any).updatedAt ?? now,
     });
@@ -47,6 +53,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
     changes: {
       status?: string;
       updatedAt?: string;
+      baseBranch?: string;
       mergeMode?: 'manual' | 'automatic' | 'external_review';
     },
   ): void {
@@ -58,16 +65,25 @@ class InMemoryPersistence implements OrchestratorPersistence {
     if (wf && changes.mergeMode !== undefined) {
       wf.mergeMode = changes.mergeMode;
     }
+    if (wf && changes.baseBranch !== undefined) {
+      wf.baseBranch = changes.baseBranch;
+    }
   }
 
   loadWorkflow(workflowId: string): {
     repoUrl?: string;
     baseBranch?: string;
+    featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
   } | undefined {
     const wf = this.workflows.get(workflowId);
     if (!wf) return undefined;
-    return { repoUrl: wf.repoUrl, mergeMode: wf.mergeMode };
+    return {
+      repoUrl: wf.repoUrl,
+      baseBranch: wf.baseBranch,
+      featureBranch: wf.featureBranch,
+      mergeMode: wf.mergeMode,
+    };
   }
 
   saveTask(workflowId: string, task: TaskState): void {
@@ -1597,9 +1613,11 @@ describe('Orchestrator', () => {
       expect(deps.find((d) => d.workflowId === wfB)!.gatePolicy).toBe('review_ready');
     });
 
-    it('repro: deleting upstream workflow blocks downstream external dependency on restart', () => {
+    it('repro: deleting upstream workflow detaches downstream external dependency on restart', () => {
       orchestrator.loadPlan({
         name: 'upstream-workflow',
+        baseBranch: 'master',
+        featureBranch: 'feature/upstream',
         tasks: [{ id: 'verify', description: 'upstream prerequisite' }],
       });
       const upstreamTaskId = sid(orchestrator, 0, 'verify');
@@ -1607,6 +1625,8 @@ describe('Orchestrator', () => {
 
       orchestrator.loadPlan({
         name: 'downstream-workflow',
+        baseBranch: 'feature/upstream',
+        featureBranch: 'feature/downstream',
         tasks: [
           {
             id: 'wait-for-upstream',
@@ -1616,6 +1636,7 @@ describe('Orchestrator', () => {
         ],
       });
       const downstreamTaskId = sid(orchestrator, 1, 'wait-for-upstream');
+      const downstreamWfId = downstreamTaskId.split('/')[0]!;
 
       orchestrator.startExecution();
       expect(orchestrator.getTask(downstreamTaskId)!.status).toBe('pending');
@@ -1627,9 +1648,10 @@ describe('Orchestrator', () => {
 
       const restarted = orchestrator.retryTask(downstreamTaskId);
       expect(restarted.map((t) => t.id)).toContain(downstreamTaskId);
-      expect(orchestrator.getTask(downstreamTaskId)!.status).toBe('blocked');
-      expect(orchestrator.getTask(downstreamTaskId)!.execution.blockedBy).toContain('missing prerequisite');
-      expect(orchestrator.getTask(downstreamTaskId)!.config.externalDependencies).toHaveLength(1);
+      expect(orchestrator.getTask(downstreamTaskId)!.status).toBe('running');
+      expect(orchestrator.getTask(downstreamTaskId)!.config.externalDependencies).toBeUndefined();
+      expect(persistence.getTaskEntry(downstreamTaskId)!.task.config.externalDependencies).toBeUndefined();
+      expect(persistence.loadWorkflow(downstreamWfId)!.baseBranch).toBe('master');
     });
 
     it('persists status changes to DB', () => {
@@ -8473,9 +8495,11 @@ describe('Orchestrator', () => {
       expect(orchestrator.getAllTasks()).toHaveLength(0);
     });
 
-    it('blocks downstream tasks whose external dependency points at deleted workflow', () => {
+    it('detaches direct dependents when deleting a workflow', () => {
       orchestrator.loadPlan({
         name: 'upstream-delete-target',
+        baseBranch: 'master',
+        featureBranch: 'feature/upstream-delete-target',
         tasks: [{ id: 'verify', description: 'upstream prerequisite' }],
       });
       const upstreamTaskId = sid(orchestrator, 0, 'verify');
@@ -8483,6 +8507,8 @@ describe('Orchestrator', () => {
 
       orchestrator.loadPlan({
         name: 'downstream-external-dependent',
+        baseBranch: 'feature/upstream-delete-target',
+        featureBranch: 'feature/downstream-external-dependent',
         tasks: [
           {
             id: 'wait-for-upstream',
@@ -8498,8 +8524,130 @@ describe('Orchestrator', () => {
       orchestrator.deleteWorkflow(upstreamWfId);
 
       const downstream = orchestrator.getTask(downstreamTaskId)!;
-      expect(downstream.status).toBe('blocked');
-      expect(downstream.execution.blockedBy).toContain(`missing prerequisite __merge__${upstreamWfId}`);
+      expect(downstream.status).toBe('pending');
+      expect(downstream.execution.blockedBy).toBeUndefined();
+      expect(downstream.config.externalDependencies).toBeUndefined();
+      expect(persistence.loadWorkflow(downstreamTaskId.split('/')[0]!)!.baseBranch).toBe('master');
+    });
+  });
+
+  describe('detachWorkflow', () => {
+    it('removes only the selected upstream edge, rewrites baseBranch, and voids descendants to pending', () => {
+      orchestrator.loadPlan({
+        name: 'upstream-a',
+        baseBranch: 'master',
+        featureBranch: 'feature/upstream-a',
+        tasks: [{ id: 'verify-a', description: 'upstream A prerequisite' }],
+      });
+      const upstreamAWfId = sid(orchestrator, 0, 'verify-a').split('/')[0]!;
+
+      orchestrator.loadPlan({
+        name: 'upstream-b',
+        baseBranch: 'master',
+        featureBranch: 'feature/upstream-b',
+        tasks: [{ id: 'verify-b', description: 'upstream B prerequisite' }],
+      });
+      const upstreamBWfId = sid(orchestrator, 1, 'verify-b').split('/')[0]!;
+
+      orchestrator.loadPlan({
+        name: 'target-workflow',
+        baseBranch: 'feature/upstream-a',
+        featureBranch: 'feature/target-workflow',
+        tasks: [
+          {
+            id: 'wait-for-upstreams',
+            description: 'target waits for two upstream workflows',
+            externalDependencies: [
+              { workflowId: upstreamAWfId, gatePolicy: 'review_ready' },
+              { workflowId: upstreamBWfId, gatePolicy: 'review_ready' },
+            ],
+          },
+        ],
+      });
+      const targetTaskId = sid(orchestrator, 2, 'wait-for-upstreams');
+      const targetWfId = targetTaskId.split('/')[0]!;
+
+      orchestrator.loadPlan({
+        name: 'child-workflow',
+        baseBranch: 'feature/target-workflow',
+        featureBranch: 'feature/child-workflow',
+        tasks: [
+          {
+            id: 'child-leaf',
+            description: 'child waits on target workflow',
+            externalDependencies: [{ workflowId: targetWfId, gatePolicy: 'review_ready' }],
+          },
+        ],
+      });
+      const childTaskId = sid(orchestrator, 3, 'child-leaf');
+
+      orchestrator.detachWorkflow(targetWfId, upstreamAWfId);
+
+      const targetTask = orchestrator.getTask(targetTaskId)!;
+      expect(targetTask.status).toBe('pending');
+      expect(targetTask.config.externalDependencies).toEqual([
+        { workflowId: upstreamBWfId, requiredStatus: 'completed', gatePolicy: 'review_ready' },
+      ]);
+      expect(persistence.loadWorkflow(targetWfId)!.baseBranch).toBe('master');
+
+      const childTask = orchestrator.getTask(childTaskId)!;
+      expect(childTask.status).toBe('pending');
+      expect(childTask.config.externalDependencies).toEqual([
+        { workflowId: targetWfId, requiredStatus: 'completed', gatePolicy: 'review_ready' },
+      ]);
+    });
+
+    it('voids a running target workflow and its descendants back to pending without auto-starting them', () => {
+      orchestrator.loadPlan({
+        name: 'upstream-runtime',
+        baseBranch: 'master',
+        featureBranch: 'feature/upstream-runtime',
+        tasks: [{ id: 'verify-runtime', description: 'upstream runtime prerequisite' }],
+      });
+      const upstreamTaskId = sid(orchestrator, 0, 'verify-runtime');
+      const upstreamWfId = upstreamTaskId.split('/')[0]!;
+      const upstreamMergeId = `__merge__${upstreamWfId}`;
+
+      orchestrator.loadPlan({
+        name: 'target-runtime',
+        baseBranch: 'feature/upstream-runtime',
+        featureBranch: 'feature/target-runtime',
+        tasks: [
+          {
+            id: 'wait-for-runtime-upstream',
+            description: 'target waits on one upstream workflow',
+            externalDependencies: [{ workflowId: upstreamWfId, gatePolicy: 'review_ready' }],
+          },
+        ],
+      });
+      const targetTaskId = sid(orchestrator, 1, 'wait-for-runtime-upstream');
+      const targetWfId = targetTaskId.split('/')[0]!;
+
+      orchestrator.loadPlan({
+        name: 'target-runtime-child',
+        baseBranch: 'feature/target-runtime',
+        featureBranch: 'feature/target-runtime-child',
+        tasks: [
+          {
+            id: 'child-runtime',
+            description: 'child waits on target runtime workflow',
+            externalDependencies: [{ workflowId: targetWfId, gatePolicy: 'review_ready' }],
+          },
+        ],
+      });
+      const childTaskId = sid(orchestrator, 2, 'child-runtime');
+
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(makeResponse({ actionId: upstreamTaskId, status: 'completed' }));
+      orchestrator.setTaskAwaitingApproval(upstreamMergeId);
+      orchestrator.approve(upstreamMergeId);
+      expect(orchestrator.getTask(targetTaskId)!.status).toBe('running');
+
+      orchestrator.detachWorkflow(targetWfId, upstreamWfId);
+
+      expect(orchestrator.getTask(targetTaskId)!.status).toBe('pending');
+      expect(orchestrator.getTask(targetTaskId)!.config.externalDependencies).toBeUndefined();
+      expect(orchestrator.getTask(childTaskId)!.status).toBe('pending');
     });
   });
 

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -380,7 +380,20 @@ export class CommandService {
     return this.executeCommand<void>(
       'DELETE_WORKFLOW_FAILED',
       () => this.orchestrator.deleteWorkflow(envelope.payload.workflowId),
-      envelope.payload.workflowId,
+      undefined,
+    );
+  }
+
+  async detachWorkflow(
+    envelope: CommandEnvelope<{ workflowId: string; upstreamWorkflowId: string }>,
+  ): Promise<CommandResult<void>> {
+    return this.executeCommand<void>(
+      'DETACH_WORKFLOW_FAILED',
+      () => this.orchestrator.detachWorkflow(
+        envelope.payload.workflowId,
+        envelope.payload.upstreamWorkflowId,
+      ),
+      undefined,
     );
   }
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -179,6 +179,7 @@ export interface OrchestratorPersistence {
   loadWorkflow?(workflowId: string): {
     repoUrl?: string;
     baseBranch?: string;
+    featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
   } | undefined;
   /** Delete a single workflow and its tasks from the DB. */
@@ -622,6 +623,32 @@ export class Orchestrator {
    * (wired by `packages/app/src/workflow-actions.ts → recreateWorkflowFromFreshBase`).
    */
   private knownFreshBaseCommits = new Map<string, string>();
+
+  private static readonly DETACH_RESET_CHANGES: TaskStateChanges = {
+    status: 'pending',
+    config: { summary: undefined },
+    execution: {
+      autoFixAttempts: 0,
+      blockedBy: undefined,
+      startedAt: undefined,
+      completedAt: undefined,
+      error: undefined,
+      exitCode: undefined,
+      pendingFixError: undefined,
+      inputPrompt: undefined,
+      lastHeartbeatAt: undefined,
+      isFixingWithAI: false,
+      reviewUrl: undefined,
+      reviewId: undefined,
+      reviewStatus: undefined,
+      reviewProviderId: undefined,
+      fixedIntegrationSha: undefined,
+      fixedIntegrationRecordedAt: undefined,
+      fixedIntegrationSource: undefined,
+      agentSessionId: undefined,
+      containerId: undefined,
+    },
+  };
 
   constructor(config: OrchestratorConfig) {
     this.maxConcurrency = config.maxConcurrency ?? 3;
@@ -3373,38 +3400,49 @@ export class Orchestrator {
    * Follows the same DB→memory→publish pattern as writeAndSync().
    */
   deleteWorkflow(workflowId: string): void {
-    // 1. Collect affected tasks before DB delete (needed for deltas and scheduler cleanup)
+    this.syncAllFromDb();
+
+    const deletedWorkflow = this.persistence.loadWorkflow?.(workflowId);
+
+    // 1. Detach direct dependents before the delete so they inherit the
+    // deleted workflow's parent branch instead of becoming permanently blocked
+    // on a missing prerequisite.
+    const directDependents = this.collectDirectDependentWorkflowIds(workflowId);
+    for (const dependentWorkflowId of directDependents) {
+      this.detachWorkflowInternal(dependentWorkflowId, workflowId, {
+        upstreamWorkflow: deletedWorkflow,
+      });
+    }
+
+    // 2. Collect affected tasks before DB delete (needed for deltas and scheduler cleanup)
     const affectedTasks = this.stateMachine.getAllTasks().filter(
       (t) => t.config.workflowId === workflowId,
     );
 
-    // 2. DB first — single source of truth
+    // 3. DB first — single source of truth
     this.persistence.deleteWorkflow?.(workflowId);
 
-    // 3. Clean scheduler: free slots for all tasks in this workflow
+    // 4. Clean scheduler: free slots for all tasks in this workflow
     for (const task of affectedTasks) {
       this.clearQueuedSchedulerEntries(task.id, task.execution.selectedAttemptId);
     }
 
-    // 4. Clear memory and reload remaining workflows
-    this.activeWorkflowIds.delete(workflowId);
-    this.stateMachine.clear();
-    for (const wfId of this.activeWorkflowIds) {
-      const tasks = this.persistence.loadTasks(wfId);
-      for (const task of tasks) {
-        this.stateMachine.restoreTask(task);
-      }
-    }
-
-    // 5. Any surviving tasks that depended on this workflow externally can no
-    // longer make progress; mark them blocked with an explicit reason.
-    this.blockTasksMissingDeletedExternalWorkflow(workflowId);
+    // 5. Reload all surviving workflows from the DB so the cache reflects the
+    // detach edits plus the workflow removal.
+    this.syncAllFromDb();
 
     // 6. Publish removal deltas — drives UI cache cleanup via messageBus subscriber
     for (const task of affectedTasks) {
       const delta: TaskDelta = { type: 'removed', taskId: task.id };
       this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
     }
+  }
+
+  detachWorkflow(workflowId: string, upstreamWorkflowId: string): void {
+    this.syncAllFromDb();
+    this.detachWorkflowInternal(workflowId, upstreamWorkflowId, {
+      upstreamWorkflow: this.persistence.loadWorkflow?.(upstreamWorkflowId),
+    });
   }
 
   /**
@@ -4234,25 +4272,130 @@ export class Orchestrator {
     return undefined;
   }
 
-  private blockTasksMissingDeletedExternalWorkflow(deletedWorkflowId: string): void {
-    const tasks = this.stateMachine.getAllTasks();
-    for (const task of tasks) {
-      if (task.status !== 'pending' && task.status !== 'blocked') continue;
+  private collectWorkflowDependencyEdges(): Map<string, Set<string>> {
+    const edges = new Map<string, Set<string>>();
+    for (const task of this.stateMachine.getAllTasks()) {
+      const workflowId = task.config.workflowId;
+      if (!workflowId) continue;
+      for (const dep of task.config.externalDependencies ?? []) {
+        let dependents = edges.get(dep.workflowId);
+        if (!dependents) {
+          dependents = new Set<string>();
+          edges.set(dep.workflowId, dependents);
+        }
+        dependents.add(workflowId);
+      }
+    }
+    return edges;
+  }
+
+  private collectDirectDependentWorkflowIds(workflowId: string): string[] {
+    return Array.from(this.collectWorkflowDependencyEdges().get(workflowId) ?? []);
+  }
+
+  private collectDownstreamWorkflowIds(rootWorkflowId: string): string[] {
+    const edges = this.collectWorkflowDependencyEdges();
+    const seen = new Set<string>();
+    const queue = [rootWorkflowId];
+    const descendants: string[] = [];
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      for (const dependentWorkflowId of edges.get(current) ?? []) {
+        if (dependentWorkflowId === rootWorkflowId || seen.has(dependentWorkflowId)) continue;
+        seen.add(dependentWorkflowId);
+        descendants.push(dependentWorkflowId);
+        queue.push(dependentWorkflowId);
+      }
+    }
+    return descendants;
+  }
+
+  private detachWorkflowInternal(
+    workflowId: string,
+    upstreamWorkflowId: string,
+    opts?: {
+      upstreamWorkflow?: {
+        baseBranch?: string;
+        featureBranch?: string;
+      };
+    },
+  ): void {
+    if (workflowId === upstreamWorkflowId) {
+      throw new Error(`Cannot detach workflow ${workflowId} from itself`);
+    }
+
+    const targetTasks = this.stateMachine.getAllTasks().filter(
+      (task) => task.config.workflowId === workflowId,
+    );
+    if (targetTasks.length === 0) {
+      throw new Error(`Workflow ${workflowId} not found`);
+    }
+
+    let removedDependency = false;
+    for (const task of targetTasks) {
       const deps = task.config.externalDependencies ?? [];
-      if (!deps.some((dep) => dep.workflowId === deletedWorkflowId)) continue;
+      const nextDeps = deps.filter((dep) => dep.workflowId !== upstreamWorkflowId);
+      if (nextDeps.length === deps.length) continue;
 
-      const blocker = this.getExternalDependencyBlocker(task);
-      if (blocker === undefined) continue;
-
+      removedDependency = true;
       const changes: TaskStateChanges = {
-        status: 'blocked',
-        execution: { blockedBy: blocker },
+        config: { externalDependencies: nextDeps.length > 0 ? nextDeps : undefined },
       };
       this.writeAndSync(task.id, changes);
-      this.scheduler.removeJob(task.id);
-      const delta: TaskDelta = { type: 'updated', taskId: task.id, changes };
-      this.persistence.logEvent?.(task.id, 'task.blocked', changes);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+      this.persistence.logEvent?.(task.id, 'task.external_dependency_detached', {
+        workflowId,
+        upstreamWorkflowId,
+      });
+      this.messageBus.publish(TASK_DELTA_CHANNEL, {
+        type: 'updated',
+        taskId: task.id,
+        changes,
+      });
+    }
+
+    if (!removedDependency) {
+      throw new Error(
+        `Workflow ${workflowId} does not depend on upstream workflow ${upstreamWorkflowId}`,
+      );
+    }
+
+    const upstreamFeatureBranch = opts?.upstreamWorkflow?.featureBranch?.trim();
+    const upstreamBaseBranch = opts?.upstreamWorkflow?.baseBranch?.trim();
+    const targetWorkflow = this.persistence.loadWorkflow?.(workflowId);
+    const targetBaseBranch = targetWorkflow?.baseBranch?.trim();
+    if (
+      upstreamFeatureBranch
+      && upstreamBaseBranch
+      && targetBaseBranch
+      && targetBaseBranch === upstreamFeatureBranch
+    ) {
+      this.taskRepository.updateWorkflow(workflowId, { baseBranch: upstreamBaseBranch });
+    }
+
+    const affectedWorkflowIds = [workflowId, ...this.collectDownstreamWorkflowIds(workflowId)];
+    for (const affectedWorkflowId of affectedWorkflowIds) {
+      this.cancelActiveBeforeInvalidation('workflow', affectedWorkflowId);
+    }
+
+    const affectedTaskIds = affectedWorkflowIds.flatMap((affectedWorkflowId) =>
+      this.stateMachine
+        .getAllTasks()
+        .filter((task) => task.config.workflowId === affectedWorkflowId)
+        .map((task) => task.id),
+    );
+    const forceResetIds = new Set(affectedTaskIds);
+    const { affectedIds } = this.resetSubgraphToPending(
+      affectedTaskIds,
+      Orchestrator.DETACH_RESET_CHANGES,
+      { forceResetIds },
+    );
+
+    for (const taskId of affectedIds) {
+      this.persistence.logEvent?.(taskId, 'task.workflow_detached', {
+        workflowId,
+        upstreamWorkflowId,
+        affectedWorkflowIds,
+      });
     }
   }
 


### PR DESCRIPTION
## Summary

Add a first-class workflow detach mutation that removes one explicit upstream workflow dependency, rewrites branch ancestry when the detached parent supplied the base branch, and voids the target workflow plus all transitive downstream workflows back to `pending`.

Update workflow deletion to use that detach behavior on direct dependents before deleting the parent workflow so deleting an upstream workflow no longer leaves stale external-gate blockers behind.

Expose detach through the workflow command service, headless CLI, HTTP API, and app IPC surface, and add regression coverage for detach semantics and delete-as-detach behavior.

## Architecture

### Before

```mermaid
graph TD
    A[Delete upstream workflow] --> B[Leave downstream external dependency in place]
    B --> C[Block downstream tasks on missing prerequisite]
    C --> D[User cannot choose retry or recreate from a clean pending state]
```

### After

```mermaid
graph TD
    A[Detach target from one upstream workflow] --> B[Remove matching external dependency]
    B --> C[Rewrite target baseBranch when detached parent supplied branch ancestry]
    C --> D[Void target workflow and transitive downstream workflows to pending]
    E[Delete upstream workflow] --> F[Detach direct dependents first]
    F --> G[Delete workflow without leaving stale external blockers]
```

## Test Plan

- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts src/__tests__/command-service.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/api-server.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec tsc -p tsconfig.json --noEmit`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 5739f38a`
- Post-revert steps: None
- Data migration? No
