### PR TITLE
Normalize recreate-with-rebase targets across all surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
     needs: build-artifacts
     runs-on: ubuntu-latest
     container:
-      image: ${{ env.PLAYWRIGHT_CONTAINER_IMAGE }}
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -214,7 +214,7 @@ jobs:
     needs: build-artifacts
     runs-on: ubuntu-latest
     container:
-      image: ${{ env.PLAYWRIGHT_CONTAINER_IMAGE }}
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 45
     strategy:
       fail-fast: false
@@ -283,7 +283,7 @@ jobs:
     needs: build-artifacts
     runs-on: ubuntu-latest
     container:
-      image: ${{ env.PLAYWRIGHT_CONTAINER_IMAGE }}
+      image: mcr.microsoft.com/playwright:v1.58.2-noble
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -884,6 +884,32 @@ describe('POST /api/workflows/:id/restart', () => {
   });
 });
 
+describe('POST /api/workflows/:id/rebase-and-retry', () => {
+  it('normalizes merge-node targets to the owning workflow before fresh-base recreate', async () => {
+    mocks.persistence.loadWorkflow = vi.fn((workflowId: string) => (
+      workflowId === 'wf-1' ? { id: 'wf-1', generation: 1 } : undefined
+    ));
+    mocks.persistence.loadTasks = vi.fn((workflowId: string) => (
+      workflowId === 'wf-1'
+        ? [makeTask({ id: '__merge__wf-1', config: { workflowId: 'wf-1', isMergeNode: true } })]
+        : []
+    ));
+    mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn(async () => [makeTask()]);
+
+    const res = await request(port, 'POST', '/api/workflows/__merge__wf-1/rebase-and-retry');
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.workflowId).toBe('wf-1');
+    expect(res.body.action).toBe('rebase_and_retried');
+    expect(mocks.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', expect.any(Object));
+    expect(mocks.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+      'wf-1',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
+    );
+  });
+});
+
 // Step 14 (`docs/architecture/task-invalidation-roadmap.md`,
 // chart "Topology inconsistency"): live-workflow topology
 // mutations now route through `Orchestrator.forkWorkflow` and
@@ -938,7 +964,7 @@ describe('POST /api/workflows/:id/recreate-with-rebase', () => {
 
   it('returns 404 when workflow not found', async () => {
     mocks.persistence.loadWorkflow.mockReturnValue(undefined);
-    const res = await request(port, 'POST', '/api/workflows/missing/recreate-with-rebase');
+    const res = await request(port, 'POST', '/api/workflows/wf-missing/recreate-with-rebase');
     expect(res.status).toBe(404);
     expect(res.body.error).toContain('not found');
   });

--- a/packages/app/src/__tests__/headless-command-classification.test.ts
+++ b/packages/app/src/__tests__/headless-command-classification.test.ts
@@ -12,6 +12,9 @@ describe('headless-command-classification', () => {
     loadWorkflow: (workflowId) => workflowId === 'wf-1' ? { id: workflowId } as any : undefined,
     listWorkflows: () => [{ id: 'wf-1' } as any, { id: 'wf-2' } as any],
     loadTasks: (workflowId) => {
+      if (workflowId === 'wf-1') {
+        return [{ id: '__merge__wf-1', config: { workflowId: 'wf-1', isMergeNode: true } }] as any;
+      }
       if (workflowId === 'wf-2') {
         return [{ id: 'wf-2/task-1' }] as any;
       }
@@ -46,6 +49,12 @@ describe('headless-command-classification', () => {
       kind: 'workflow',
       workflowId: 'wf-1',
     });
+    expect(resolveHeadlessTarget('__merge__wf-1', targetLookup)).toEqual({
+      kind: 'task',
+      workflowId: 'wf-1',
+      taskId: '__merge__wf-1',
+      resolvedTaskId: '__merge__wf-1',
+    });
     expect(resolveHeadlessTarget('wf-2/task-1', targetLookup)).toEqual({
       kind: 'task',
       workflowId: 'wf-2',
@@ -74,6 +83,7 @@ describe('headless-command-classification', () => {
   });
 
   it('throws when target workflow cannot be resolved', () => {
+    expect(resolveHeadlessTargetWorkflowId('__merge__wf-1', targetLookup)).toBe('wf-1');
     expect(() => resolveHeadlessTargetWorkflowId('missing-target', targetLookup)).toThrow(
       'Could not resolve headless target workflow for "missing-target"',
     );

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1010,13 +1010,21 @@ describe('headless delegation enforcement', () => {
             baseBranch: 'main',
           };
           mockDeps.persistence.listWorkflows = vi.fn(() => [wf]);
-          mockDeps.persistence.loadTasks = vi.fn(() => [{
-            id: 'wf-1/task-1',
-            status: 'failed',
-            config: { workflowId: 'wf-1' },
-            execution: {},
-          } as any]);
-          mockDeps.persistence.loadWorkflow = vi.fn(() => wf as any);
+          mockDeps.persistence.loadTasks = vi.fn(() => [
+            {
+              id: 'wf-1/task-1',
+              status: 'failed',
+              config: { workflowId: 'wf-1' },
+              execution: {},
+            } as any,
+            {
+              id: '__merge__wf-1',
+              status: 'review_ready',
+              config: { workflowId: 'wf-1' },
+              execution: {},
+            } as any,
+          ]);
+          mockDeps.persistence.loadWorkflow = vi.fn((id: string) => (id === 'wf-1' ? wf as any : null));
           mockDeps.persistence.updateWorkflow = vi.fn();
           mockDeps.orchestrator.syncFromDb = vi.fn();
           mockDeps.orchestrator.getTask = vi.fn((id: string) => {
@@ -1137,6 +1145,46 @@ describe('headless delegation enforcement', () => {
             'wf-1',
             'https://example/repo.git',
             'main',
+          );
+
+          preparePoolSpy.mockRestore();
+        });
+
+        it('headless `recreate-with-rebase <mergeTaskId>` normalizes to the owning workflow', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['recreate-with-rebase', '__merge__wf-1'], depsWithNoTrack);
+
+          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+            'wf-1',
+            expect.objectContaining({ refreshBase: expect.any(Function) }),
+          );
+
+          preparePoolSpy.mockRestore();
+        });
+
+        it('headless `recreate-with-rebase <taskId>` normalizes to the owning workflow', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['recreate-with-rebase', 'task-1'], depsWithNoTrack);
+
+          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+            'wf-1',
+            expect.objectContaining({ refreshBase: expect.any(Function) }),
           );
 
           preparePoolSpy.mockRestore();

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -25,6 +25,9 @@ describe('headless→owner delegation', () => {
       ),
       listWorkflows: () => [{ id: 'wf-1' } as any, { id: 'wf-123' } as any],
       loadTasks: (workflowId) => {
+        if (workflowId === 'wf-1') {
+          return [{ id: '__merge__wf-1' }] as any;
+        }
         if (workflowId === 'wf-123') {
           return [{ id: 'wf-123/task-1' }] as any;
         }

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -59,6 +59,7 @@ import {
   resolveConflictAction,
 } from './workflow-actions.js';
 import { executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 
 export interface ApiServerDeps {
   logger?: Logger;
@@ -431,8 +432,9 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       const wfRebaseAndRetryMatch = path.match(/^\/api\/workflows\/([^/]+)\/rebase-and-retry$/);
       if (method === 'POST' && (wfRecreateWithRebaseMatch || wfRebaseAndRetryMatch)) {
         const isLegacy = !!wfRebaseAndRetryMatch;
-        const workflowId = decodeURIComponent((wfRecreateWithRebaseMatch ?? wfRebaseAndRetryMatch)![1]);
+        const workflowTarget = decodeURIComponent((wfRecreateWithRebaseMatch ?? wfRebaseAndRetryMatch)![1]);
         try {
+          const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, persistence);
           const started = await sharedRecreateWorkflowFromFreshBase(workflowId, {
             orchestrator,
             persistence,

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -52,6 +52,7 @@ import {
   tryDelegateResume,
   tryDelegateRun,
 } from './headless-delegation.js';
+import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
@@ -703,14 +704,14 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'rebase':
       await headlessRebaseAndRetry(args[1], deps);
       break;
+    case 'recreate-with-rebase':
+      await headlessRecreateWithRebase(args[1], deps);
+      break;
 
     // Deprecated aliases
     case 'rebase-and-retry':
       warnDeprecated('rebase-and-retry', 'rebase');
       await headlessRebaseAndRetry(args[1], deps);
-      break;
-    case 'recreate-with-rebase':
-      await headlessRecreateWithRebase(args[1], deps);
       break;
     case 'fix':
       await headlessFix(args[1], deps, args[2]);
@@ -867,9 +868,9 @@ ${BOLD}Execute:${RESET}
   recreate <workflowId>                                Recreate workflow: wipe all state, new generation
   recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
   fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
-  rebase <taskId>                                     Refresh pool base + nuclear restart (task-scoped)
-  recreate-with-rebase <workflowId>                   Recreate workflow from fresh upstream base
   detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
+  rebase <taskId>                                     Refresh pool base + nuclear restart
+  recreate-with-rebase <workflowId|mergeTaskId|taskId> Recreate workflow from fresh upstream base
   fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
   resolve-conflict <taskId> [claude|codex]            Resolve merge conflict + restart
 
@@ -1378,8 +1379,9 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
   process.stdout.write(`Rebase-and-retry: resetting workflow from current HEAD (${tasksStarted} task(s))\n`);
 }
 
-async function headlessRecreateWithRebase(workflowId: string, deps: HeadlessDeps): Promise<void> {
-  if (!workflowId) throw new Error('Missing arguments. Usage: --headless recreate-with-rebase <workflowId>');
+async function headlessRecreateWithRebase(workflowTarget: string, deps: HeadlessDeps): Promise<void> {
+  if (!workflowTarget) throw new Error('Missing arguments. Usage: --headless recreate-with-rebase <workflowId|mergeTaskId|taskId>');
+  const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, deps.persistence);
   await preemptWorkflowBeforeMutation(workflowId, {
     preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
     logger: deps.logger,
@@ -1414,8 +1416,8 @@ async function headlessRecreateWithRebase(workflowId: string, deps: HeadlessDeps
   });
   autoFix.unsubscribe();
 
-  const tasksStarted2 = runnable.length;
-  process.stdout.write(`Recreate-with-rebase: resetting workflow from fresh base (${tasksStarted2} task(s))\n`);
+  const tasksStarted = runnable.length;
+  process.stdout.write(`Recreate-with-rebase: resetting workflow from fresh base (${tasksStarted} task(s))\n`);
 }
 
 async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -895,6 +895,8 @@ if (isHeadless) {
             case 'recreate':
             case 'cancel-workflow':
               return { workflowId: arg0 === undefined ? undefined : String(arg0), priority: 'high' };
+            case 'recreate-with-rebase':
+              return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'high' };
             case 'rebase':
             case 'cancel':
             case 'recreate-task':
@@ -1735,9 +1737,13 @@ if (isHeadless) {
     return { workflowId, tasks };
   }
 
+  function workflowIdForTargetArg(targetArg: unknown): string | undefined {
+    if (targetArg === undefined) return undefined;
+    return resolveHeadlessTargetWorkflowId(targetArg, persistence);
+  }
+
   function workflowIdForTaskArg(taskIdArg: unknown): string | undefined {
-    if (taskIdArg === undefined) return undefined;
-    return resolveHeadlessTargetWorkflowId(taskIdArg, persistence);
+    return workflowIdForTargetArg(taskIdArg);
   }
 
   function classifyHeadlessExecMutation(payload: HeadlessExecMutationPayload): {
@@ -1753,6 +1759,8 @@ if (isHeadless) {
       case 'recreate':
       case 'cancel-workflow':
         return { workflowId: arg0, priority: 'high' };
+      case 'recreate-with-rebase':
+        return { workflowId: workflowIdForTargetArg(arg0), priority: 'high' };
       case 'rebase':
       case 'cancel':
       case 'recreate-task':
@@ -3195,10 +3203,13 @@ if (isHeadless) {
 
     registerWorkflowScopedGuiMutationHandler(
       'invoker:recreate-with-rebase',
-      (workflowIdArg: unknown) => String(workflowIdArg),
+      (workflowIdArg: unknown) => workflowIdForTargetArg(workflowIdArg),
       'high',
       async (workflowIdArg: unknown) => {
-      const workflowId = String(workflowIdArg);
+      const workflowId = workflowIdForTargetArg(workflowIdArg);
+      if (!workflowId) {
+        throw new Error(`Could not resolve workflow for recreate-with-rebase target "${String(workflowIdArg)}"`);
+      }
       cancelDeferredWorkflowLaunch(workflowId, 'ipc.recreate-with-rebase');
       logger.info(`recreate-with-rebase: "${workflowId}"`, { module: 'ipc' });
       try {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -242,10 +242,10 @@ export function App() {
     }
   }, []);
 
-  const handleRecreateWithRebase = useCallback(async (taskId: string) => {
+  const handleRecreateWithRebase = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      const result = await window.invoker?.recreateWithRebase(taskId);
+      const result = await window.invoker?.recreateWithRebase(workflowId);
       if (result && !result.success) {
         console.error('Recreate with Rebase failed for some branches:', result.errors);
       }

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -35,6 +35,14 @@ const beta = makeUITask({
   workflowId: 'wf-1',
 });
 
+const merge = makeUITask({
+  id: '__merge__wf-1',
+  description: 'Review gate',
+  status: 'review_ready',
+  workflowId: 'wf-1',
+  isMergeNode: true,
+});
+
 const workflows: WorkflowMeta[] = [
   { id: 'wf-1', name: 'Test Workflow', status: 'running', baseBranch: 'master' },
 ];
@@ -51,9 +59,12 @@ describe('Context menu (component)', () => {
     mock.cleanup();
   });
 
-  async function setupAndRightClick(taskTestId = 'rf__node-task-alpha') {
+  async function setupAndRightClick(
+    taskTestId = 'rf__node-task-alpha',
+    tasks = [alpha, beta, merge],
+  ) {
     render(<App />);
-    act(() => mock.setTasks([alpha, beta], workflows));
+    act(() => mock.setTasks(tasks, workflows));
 
     await waitFor(() => {
       expect(screen.getByTestId(taskTestId)).toBeInTheDocument();
@@ -142,7 +153,7 @@ describe('Context menu (component)', () => {
   });
 
   it('Recreate with Rebase is visible and triggers distinct handler', async () => {
-    await setupAndRightClick();
+    await setupAndRightClick('rf__node-__merge__wf-1');
 
     await waitFor(() => {
       expect(screen.getByText('Recreate with Rebase')).toBeInTheDocument();
@@ -151,7 +162,7 @@ describe('Context menu (component)', () => {
     fireEvent.click(screen.getByText('Recreate with Rebase'));
 
     await waitFor(() => {
-      expect(mock.api.recreateWithRebase).toHaveBeenCalledWith('task-alpha');
+      expect(mock.api.recreateWithRebase).toHaveBeenCalledWith('wf-1');
       expect(screen.queryByText('Restart Task')).not.toBeInTheDocument();
     });
   });

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -23,7 +23,7 @@ interface ContextMenuProps {
   onReplace: (taskId: string) => void;
   onOpenTerminal: (taskId: string) => void;
   onRebaseAndRetry?: (taskId: string) => void;
-  onRecreateWithRebase?: (taskId: string) => void;
+  onRecreateWithRebase?: (workflowId: string) => void;
   onRetryWorkflow?: (workflowId: string) => void;
   onRecreateTask?: (taskId: string) => void;
   onRecreateWorkflow?: (workflowId: string) => void;
@@ -194,7 +194,7 @@ export function ContextMenu({
         onRebaseAndRetry?.(task.id);
         break;
       case 'onRecreateWithRebase':
-        onRecreateWithRebase?.(task.id);
+        onRecreateWithRebase?.(task.config.workflowId!);
         break;
       case 'onRetryWorkflow':
         onRetryWorkflow?.(task.config.workflowId!);


### PR DESCRIPTION
## Summary

Normalize `recreate-with-rebase` target handling across every surface that can trigger it.

This fixes the merge-node path where `Recreate with Rebase` could receive `__merge__wf-*` or a task id on some routes, fail to invalidate the owning workflow, and then error out trying to recreate a workflow that does not exist. The UI now sends the owning workflow id, and the app surfaces that still accept indirect targets normalize them back to the owning workflow before queueing, preemption, and recreate-from-fresh-base.

## Architecture

### Before

```mermaid
graph TD
    UI[UI merge-node action] -->|task.id / __merge__wf-*| IPC[IPC recreate-with-rebase]
    CLI[Headless/API delegated callers] -->|mixed target shapes| IPC
    IPC -->|treat arg as workflow id| Recreate[recreateWorkflowFromFreshBase]
    Recreate --> Fail[missing workflow / wrong invalidation]
```

### After

```mermaid
graph TD
    UI[UI merge-node action] -->|workflowId| IPC[IPC recreate-with-rebase]
    CLI[Headless/API/standalone callers] -->|workflowId or merge/task target| Normalize[shared target resolution]
    Normalize --> IPC
    IPC -->|workflow-scoped queue + preemption| Recreate[recreateWorkflowFromFreshBase]
    Recreate --> Rerun[workflow generation bump and rerun]
```

## Test Plan

- [x] `cd /tmp/invoker-pr-recreate-with-rebase-all-surfaces/packages/app && pnpm exec vitest run src/__tests__/headless-delegation.test.ts src/__tests__/headless-command-classification.test.ts src/__tests__/owner-delegation.test.ts src/__tests__/api-server.test.ts`
- [x] `cd /tmp/invoker-pr-recreate-with-rebase-all-surfaces/packages/ui && pnpm exec vitest run src/__tests__/context-menu-e2e.test.tsx`
- [x] `cd /home/edbert-chan/Invoker/packages/app && ./node_modules/.bin/electron dist/main.js --no-sandbox --headless recreate-with-rebase __merge__wf-1777407618343-4 --no-track`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 26375517`
- Post-revert steps: None
- Data migration? No
