### PR TITLE
Default workflow-chain submission to completed gate policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ permissions:
 env:
   CI: true
   NODE_VERSION: '22'
-  PLAYWRIGHT_CONTAINER_IMAGE: mcr.microsoft.com/playwright:v1.58.2-noble
 
 jobs:
   build-artifacts:

--- a/packages/execution-engine/src/__tests__/plan-base-remote.test.ts
+++ b/packages/execution-engine/src/__tests__/plan-base-remote.test.ts
@@ -86,6 +86,14 @@ describe('plan-base-remote', () => {
     expect(resolved).toBe(upstreamHead);
   });
 
+  it('resolvePlanBaseRevision falls back to origin/HEAD when the requested branch is missing', async () => {
+    const runGit = runGitFactory(mirror);
+    const headCommit = (await runGit(['rev-parse', '--verify', 'origin/master^{commit}'])).trim();
+
+    const resolved = (await resolvePlanBaseRevision(runGit, 'main')).trim();
+    expect(resolved).toBe(headCommit);
+  });
+
   it('resolvePreferredTrackingRemote always returns origin', async () => {
     const runGit = runGitFactory(mirror);
     execSync(`git remote add upstream "${upstream}"`, { cwd: mirror });

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -314,11 +314,15 @@ describe('buildRecordAndPushScript', () => {
       branch: 'experiment/task-123-abc',
       commitMessageChanges: 'invoker: task-123 — make changes',
       commitMessageEmpty: 'invoker: task-123\n\nExit code: 0',
+      gitUserName: 'Invoker Bot',
+      gitUserEmail: 'invoker@local',
     });
 
     expect(script).toContain('set -euo pipefail');
     expect(script).toContain('WT=$(echo');
     expect(script).toContain('base64 -d)');
+    expect(script).toContain('git config user.name');
+    expect(script).toContain('git config user.email');
     expect(script).toContain('git add -A');
     expect(script).toContain('if git diff --cached --quiet');
     expect(script).toContain('git commit --allow-empty -F');
@@ -334,9 +338,59 @@ describe('buildRecordAndPushScript', () => {
       branch: 'branch',
       commitMessageChanges: 'msg',
       commitMessageEmpty: 'empty',
+      gitUserName: 'Invoker Bot',
+      gitUserEmail: 'invoker@local',
     });
 
     expect(script).toContain(bashNormalizeTildePath());
+  });
+
+  it('commits and pushes successfully without preconfigured git identity', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-record-push-'));
+    const source = join(root, 'source');
+    const bare = join(root, 'remote.git');
+    const clone = join(root, 'clone');
+
+    mkdirSync(source, { recursive: true });
+    execSync('git init -b master', { cwd: source, stdio: 'ignore' });
+    writeFileSync(join(source, 'README.md'), 'seed\n');
+    execSync('git add README.md', { cwd: source, stdio: 'ignore' });
+    execSync('git -c user.name="Seed User" -c user.email="seed@example.com" commit -m "seed"', {
+      cwd: source,
+      stdio: 'ignore',
+    });
+    execSync(`git clone --bare ${JSON.stringify(source)} ${JSON.stringify(bare)}`, { stdio: 'ignore' });
+    execSync(`git clone ${JSON.stringify(bare)} ${JSON.stringify(clone)}`, { stdio: 'ignore' });
+    execSync('git checkout -b experiment/test-branch', { cwd: clone, stdio: 'ignore' });
+    writeFileSync(join(clone, 'result.txt'), 'ok\n');
+
+    const script = buildRecordAndPushScript({
+      worktreePath: clone,
+      branch: 'experiment/test-branch',
+      commitMessageChanges: 'invoker: record remote result',
+      commitMessageEmpty: 'invoker: record remote empty result',
+      gitUserName: 'Remote CI Bot',
+      gitUserEmail: 'remote-ci@example.com',
+    });
+
+    execFileSync('bash', ['-lc', script], {
+      env: {
+        ...process.env,
+        HOME: mkdtempSync(join(tmpdir(), 'ssh-record-push-home-')),
+      },
+      stdio: 'ignore',
+    });
+
+    const authorName = execSync('git log -1 --format=%an', { cwd: clone }).toString().trim();
+    const authorEmail = execSync('git log -1 --format=%ae', { cwd: clone }).toString().trim();
+    const pushedHead = execSync(`git --git-dir=${JSON.stringify(bare)} rev-parse refs/heads/experiment/test-branch`)
+      .toString()
+      .trim();
+    const localHead = execSync('git rev-parse HEAD', { cwd: clone }).toString().trim();
+
+    expect(authorName).toBe('Remote CI Bot');
+    expect(authorEmail).toBe('remote-ci@example.com');
+    expect(pushedHead).toBe(localHead);
   });
 });
 

--- a/packages/execution-engine/src/plan-base-remote.ts
+++ b/packages/execution-engine/src/plan-base-remote.ts
@@ -17,6 +17,16 @@ async function tryResolveCommit(runGit: GitExec, refExpr: string): Promise<strin
   }
 }
 
+async function tryResolveOriginHeadCommit(runGit: GitExec): Promise<string | undefined> {
+  try {
+    const originHeadRef = (await runGit(['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD'])).trim();
+    if (!originHeadRef) return undefined;
+    return await tryResolveCommit(runGit, `${originHeadRef}^{commit}`);
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Fetch a single branch from origin into refs/remotes/origin/<baseBranch>.
  */
@@ -106,6 +116,7 @@ export function shouldResolveViaOriginTracking(ref: string): boolean {
 /**
  * Resolve base ref to a full commit SHA for computeContentHash / worktree base.
  * For short branch names and legacy remote-qualified refs, uses origin/<branch>.
+ * When the requested branch is absent after sync, fall back to origin/HEAD when available.
  */
 export async function resolvePlanBaseRevision(
   runGit: GitExec,
@@ -144,6 +155,8 @@ export async function resolvePlanBaseRevision(
     if (originAfterSync) return originAfterSync;
     const localAfterSync = await tryResolveCommit(runGit, localExpr);
     if (localAfterSync) return localAfterSync;
+    const originHeadFallback = await tryResolveOriginHeadCommit(runGit);
+    if (originHeadFallback) return originHeadFallback;
 
     throw new Error(
       `Unable to resolve base ref "${r}" as ${originExpr} or ${localExpr}. ` +

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -490,12 +490,16 @@ echo ${payloadB64} | base64 -d | bash -se
   ): Promise<{ commitHash?: string; error?: string }> {
     const msgChanges = this.buildCommitMessage(request);
     const msgEmpty = this.buildResultCommitMessage(request, commandExitCode);
+    const gitUserName = process.env.GIT_AUTHOR_NAME ?? process.env.GIT_COMMITTER_NAME ?? 'Invoker Bot';
+    const gitUserEmail = process.env.GIT_AUTHOR_EMAIL ?? process.env.GIT_COMMITTER_EMAIL ?? 'invoker@local';
 
     const recordScript = buildRecordAndPushScript({
       worktreePath,
       branch,
       commitMessageChanges: msgChanges,
       commitMessageEmpty: msgEmpty,
+      gitUserName,
+      gitUserEmail,
     });
 
     try {

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -292,6 +292,8 @@ export interface GitRecordAndPushOpts {
   branch: string;
   commitMessageChanges: string;
   commitMessageEmpty: string;
+  gitUserName: string;
+  gitUserEmail: string;
 }
 
 /**
@@ -306,11 +308,15 @@ export function buildRecordAndPushScript(opts: GitRecordAndPushOpts): string {
   const brB = base64Encode(opts.branch);
   const chB = base64Encode(opts.commitMessageChanges);
   const emB = base64Encode(opts.commitMessageEmpty);
+  const userNameB = base64Encode(opts.gitUserName);
+  const userEmailB = base64Encode(opts.gitUserEmail);
 
   return `set -euo pipefail
 WT=$(echo ${wtB} | base64 -d)
 ${bashNormalizeTildePath()}
 cd "$WT"
+git config user.name "$(echo ${userNameB} | base64 -d)"
+git config user.email "$(echo ${userEmailB} | base64 -d)"
 git add -A
 M=$(mktemp)
 trap 'rm -f "$M"' EXIT

--- a/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
+++ b/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
@@ -41,7 +41,21 @@ generation_for_workflow() {
   local wf_id="$1"
   invoker_e2e_run_headless query workflows --output jsonl \
     | grep '^{' \
-    | jq -sr --arg wf "$wf_id" '.[] | select(.id==$wf) | .generation'
+    | python3 -c '
+import json
+import sys
+
+wf_id = sys.argv[1]
+generation = ""
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    row = json.loads(line)
+    if row.get("id") == wf_id:
+        generation = str(row.get("generation", ""))
+print(generation)
+' "$wf_id"
 }
 
 GEN_BEFORE="$(generation_for_workflow "$WF_ID")"

--- a/scripts/e2e-dry-run/cases/case-2.14-standalone-timeout-deadlock-guard.sh
+++ b/scripts/e2e-dry-run/cases/case-2.14-standalone-timeout-deadlock-guard.sh
@@ -81,14 +81,32 @@ fi
 STALE_RUNNING="$(
   invoker_e2e_run_headless query tasks --output jsonl \
     | grep '^{' \
-    | jq -r '
-      select(.status=="running")
-      | ((.execution.lastHeartbeatAt // .execution.startedAt // "1970-01-01T00:00:00Z")
-          | sub("\\.[0-9]+Z$"; "Z")
-          | fromdateiso8601) as $hb
-      | select((now - $hb) > 15)
-      | .id
-    '
+    | python3 -c '
+import datetime as dt
+import json
+import sys
+
+now = dt.datetime.now(dt.timezone.utc)
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    row = json.loads(line)
+    if row.get("status") != "running":
+        continue
+    execution = row.get("execution") or {}
+    stamp = execution.get("lastHeartbeatAt") or execution.get("startedAt") or "1970-01-01T00:00:00Z"
+    stamp = stamp.replace(" ", "T")
+    if "." in stamp and stamp.endswith("Z"):
+        stamp = stamp.split(".", 1)[0] + "Z"
+    if stamp.endswith("Z"):
+        stamp = stamp[:-1] + "+00:00"
+    hb = dt.datetime.fromisoformat(stamp)
+    if hb.tzinfo is None:
+        hb = hb.replace(tzinfo=dt.timezone.utc)
+    if (now - hb).total_seconds() > 15:
+        print(row.get("id", ""))
+'
 )"
 if [ -n "$STALE_RUNNING" ]; then
   echo "FAIL case 2.14: found stale running task(s) after guarded rebase-retry-all"

--- a/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
+++ b/scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh
@@ -13,6 +13,7 @@ unset INVOKER_DB_DIR
 TMP_HOME="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-home.XXXXXX")"
 export HOME="$TMP_HOME"
 mkdir -p "$HOME/.invoker"
+git config --global --add safe.directory "$REPO_ROOT"
 export INVOKER_REPO_CONFIG_PATH="$(mktemp "${TMPDIR:-/tmp}/invoker-e2e-config.XXXXXX.json")"
 printf '{\n  "autoFixRetries": 1\n}\n' > "$INVOKER_REPO_CONFIG_PATH"
 

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -50,6 +50,13 @@ invoker_e2e_ensure_branch_aliases() {
   )
 }
 
+invoker_e2e_allow_repo_git_ops() {
+  (
+    cd "$INVOKER_E2E_REPO_ROOT"
+    git config --global --add safe.directory "$INVOKER_E2E_REPO_ROOT" >/dev/null 2>&1 || true
+  )
+}
+
 invoker_e2e_init() {
   # Preserve caller PATH so cleanup can fully restore shell state.
   if [ -z "${INVOKER_E2E_ORIGINAL_PATH:-}" ]; then
@@ -82,6 +89,8 @@ invoker_e2e_init() {
   ln -sf "$INVOKER_E2E_ROOT/fixtures/codex-marker.sh" "$stubdir/codex"
   chmod +x "$INVOKER_E2E_ROOT/fixtures/codex-marker.sh" 2>/dev/null || true
   export PATH="$stubdir:$PATH"
+  invoker_e2e_allow_repo_git_ops
+  invoker_e2e_ensure_branch_aliases
 }
 
 invoker_e2e_kill_owned_headless_processes() {
@@ -168,7 +177,6 @@ invoker_e2e_cleanup() {
 }
 
 invoker_e2e_ensure_app_built() {
-  invoker_e2e_ensure_branch_aliases
   local app_dist="$INVOKER_E2E_REPO_ROOT/packages/app/dist/main.js"
   local ui_dist="$INVOKER_E2E_REPO_ROOT/packages/ui/dist/index.html"
   local build_lock_dir="$INVOKER_E2E_REPO_ROOT/.git/invoker-e2e-build.lock"

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -25,11 +25,21 @@ invoker_e2e_ensure_branch_aliases() {
     head_sha="$(git rev-parse HEAD 2>/dev/null || true)"
     [ -n "$head_sha" ] || return 0
 
+    # GitHub Actions PR checkouts can be detached and omit both main/master refs.
+    # The dry-run plans clone this checkout via file:// and expect a resolvable base.
+    if ! git show-ref --verify --quiet refs/heads/main && ! git show-ref --verify --quiet refs/heads/master; then
+      git update-ref refs/heads/main "$head_sha" >/dev/null 2>&1 || true
+      git update-ref refs/heads/master "$head_sha" >/dev/null 2>&1 || true
+    fi
     if git show-ref --verify --quiet refs/heads/master && ! git show-ref --verify --quiet refs/heads/main; then
       git update-ref refs/heads/main "$head_sha" >/dev/null 2>&1 || true
     fi
     if git show-ref --verify --quiet refs/heads/main && ! git show-ref --verify --quiet refs/heads/master; then
       git update-ref refs/heads/master "$head_sha" >/dev/null 2>&1 || true
+    fi
+    if ! git show-ref --verify --quiet refs/remotes/origin/main && ! git show-ref --verify --quiet refs/remotes/origin/master; then
+      git update-ref refs/remotes/origin/main "$head_sha" >/dev/null 2>&1 || true
+      git update-ref refs/remotes/origin/master "$head_sha" >/dev/null 2>&1 || true
     fi
     if git show-ref --verify --quiet refs/remotes/origin/master && ! git show-ref --verify --quiet refs/remotes/origin/main; then
       git update-ref refs/remotes/origin/main refs/remotes/origin/master >/dev/null 2>&1 || true

--- a/scripts/e2e-ssh/lib/ssh-common.sh
+++ b/scripts/e2e-ssh/lib/ssh-common.sh
@@ -26,6 +26,10 @@ _INVOKER_E2E_SSH_TAG="invoker-e2e-ssh-$$"
 # Temp directory for SSH key pair and config.
 _INVOKER_E2E_SSH_TMPDIR=""
 
+# SSH login user and passwd-backed home directory used by sshd.
+_INVOKER_E2E_SSH_USER=""
+_INVOKER_E2E_SSH_HOME=""
+
 # --------------------------------------------------------------------------- #
 # Test if sshd is listening on localhost port 22 (3s timeout).
 # Only checks TCP reachability — auth is tested later after key setup.
@@ -35,24 +39,44 @@ invoker_e2e_ssh_available() {
   timeout 3 bash -c 'echo > /dev/tcp/localhost/22' 2>/dev/null
 }
 
+invoker_e2e_ssh_resolve_home() {
+  local user="$1"
+  local resolved_home=""
+  if command -v getent >/dev/null 2>&1; then
+    resolved_home="$(getent passwd "$user" | cut -d: -f6)"
+  fi
+  if [ -z "$resolved_home" ]; then
+    resolved_home="$(eval "printf '%s' ~$user")"
+  fi
+  printf '%s\n' "$resolved_home"
+}
+
 # --------------------------------------------------------------------------- #
 # Generate temp ed25519 key pair, add public key to authorized_keys.
 # --------------------------------------------------------------------------- #
 invoker_e2e_ssh_setup_keys() {
   _INVOKER_E2E_SSH_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-ssh.XXXXXX")"
   local keyfile="$_INVOKER_E2E_SSH_TMPDIR/id_ed25519"
+  _INVOKER_E2E_SSH_USER="$(whoami)"
+  _INVOKER_E2E_SSH_HOME="$(invoker_e2e_ssh_resolve_home "$_INVOKER_E2E_SSH_USER")"
+
+  if [ -z "$_INVOKER_E2E_SSH_HOME" ]; then
+    echo "ERROR: unable to resolve passwd home for SSH user '$_INVOKER_E2E_SSH_USER'." >&2
+    return 1
+  fi
 
   # -C sets the comment field to our PID-tagged identifier for cleanup.
   ssh-keygen -t ed25519 -f "$keyfile" -N "" -C "$_INVOKER_E2E_SSH_TAG" -q
 
-  # Ensure ~/.ssh/authorized_keys exists with correct permissions.
-  mkdir -p ~/.ssh
-  chmod 700 ~/.ssh
-  touch ~/.ssh/authorized_keys
-  chmod 600 ~/.ssh/authorized_keys
+  # sshd reads authorized_keys from the account's passwd home, which may differ
+  # from $HOME inside CI containers.
+  mkdir -p "$_INVOKER_E2E_SSH_HOME/.ssh"
+  chmod 700 "$_INVOKER_E2E_SSH_HOME/.ssh"
+  touch "$_INVOKER_E2E_SSH_HOME/.ssh/authorized_keys"
+  chmod 600 "$_INVOKER_E2E_SSH_HOME/.ssh/authorized_keys"
 
   # Append public key (comment already contains tag).
-  cat "${keyfile}.pub" >> ~/.ssh/authorized_keys
+  cat "${keyfile}.pub" >> "$_INVOKER_E2E_SSH_HOME/.ssh/authorized_keys"
 
   export INVOKER_E2E_SSH_KEY="$keyfile"
 }
@@ -61,10 +85,11 @@ invoker_e2e_ssh_setup_keys() {
 # Remove temp key from authorized_keys, delete temp dir.
 # --------------------------------------------------------------------------- #
 invoker_e2e_ssh_cleanup_keys() {
-  if [ -n "${_INVOKER_E2E_SSH_TAG:-}" ] && [ -f ~/.ssh/authorized_keys ]; then
-    grep -v "$_INVOKER_E2E_SSH_TAG" ~/.ssh/authorized_keys > ~/.ssh/authorized_keys.tmp || true
-    mv ~/.ssh/authorized_keys.tmp ~/.ssh/authorized_keys
-    chmod 600 ~/.ssh/authorized_keys
+  local authorized_keys="${_INVOKER_E2E_SSH_HOME:-}/.ssh/authorized_keys"
+  if [ -n "${_INVOKER_E2E_SSH_TAG:-}" ] && [ -f "$authorized_keys" ]; then
+    grep -v "$_INVOKER_E2E_SSH_TAG" "$authorized_keys" > "${authorized_keys}.tmp" || true
+    mv "${authorized_keys}.tmp" "$authorized_keys"
+    chmod 600 "$authorized_keys"
   fi
   rm -rf "${_INVOKER_E2E_SSH_TMPDIR:-}" 2>/dev/null || true
 }
@@ -74,8 +99,6 @@ invoker_e2e_ssh_cleanup_keys() {
 # --------------------------------------------------------------------------- #
 invoker_e2e_ssh_write_config() {
   local config_file="$_INVOKER_E2E_SSH_TMPDIR/invoker-config.json"
-  local current_user
-  current_user="$(whoami)"
   local remote_home
   local provision_cmd
   remote_home="$_INVOKER_E2E_SSH_TMPDIR/remote-invoker-home"
@@ -86,7 +109,7 @@ invoker_e2e_ssh_write_config() {
   "remoteTargets": {
     "localhost-e2e": {
       "host": "localhost",
-      "user": "$current_user",
+      "user": "$_INVOKER_E2E_SSH_USER",
       "sshKeyPath": "$INVOKER_E2E_SSH_KEY",
       "port": 22,
       "managedWorkspaces": true,
@@ -113,7 +136,7 @@ invoker_e2e_ssh_init() {
            -o ConnectTimeout=5 \
            -o StrictHostKeyChecking=no \
            -i "$INVOKER_E2E_SSH_KEY" \
-           "$(whoami)@localhost" true 2>/dev/null; then
+           "$_INVOKER_E2E_SSH_USER@localhost" true 2>/dev/null; then
     echo "ERROR: SSH to localhost with generated key failed. Aborting." >&2
     invoker_e2e_ssh_cleanup_keys
     return 1
@@ -124,7 +147,7 @@ invoker_e2e_ssh_init() {
            -o ConnectTimeout=5 \
            -o StrictHostKeyChecking=no \
            -i "$INVOKER_E2E_SSH_KEY" \
-           "$(whoami)@localhost" "env PATH='$PATH' pnpm --version" >/dev/null 2>&1; then
+           "$_INVOKER_E2E_SSH_USER@localhost" "env PATH='$PATH' pnpm --version" >/dev/null 2>&1; then
     echo "ERROR: 'pnpm' not found in non-interactive SSH session PATH." >&2
     invoker_e2e_ssh_cleanup_keys
     return 1

--- a/scripts/submit-workflow-chain.sh
+++ b/scripts/submit-workflow-chain.sh
@@ -14,11 +14,11 @@
 #   externalDependencies:
 #     - workflowId: "__UPSTREAM_WORKFLOW_ID__"
 #       requiredStatus: completed
-#       gatePolicy: review_ready
+#       gatePolicy: completed
 #
 set -euo pipefail
 
-GATE_POLICY="review_ready"
+GATE_POLICY="completed"
 if [[ "${1:-}" == "--gate-policy" ]]; then
   GATE_POLICY="${2:-}"
   shift 2

--- a/scripts/test-submit-workflow-chain.sh
+++ b/scripts/test-submit-workflow-chain.sh
@@ -143,12 +143,12 @@ rp3="$(printf '%s\n' "$out" | sed -n 's/^RENDERED_PLAN=//p' | sed -n '2p')"
 
 grep -q "workflowId: \"$wf1\"" "$rp2"
 grep -q 'taskId: "__merge__"' "$rp2"
-grep -q '^ *gatePolicy: review_ready$' "$rp2"
+grep -q '^ *gatePolicy: completed$' "$rp2"
 grep -q '^baseBranch: feature/a$' "$rp2"
 
 grep -q "workflowId: \"$wf2\"" "$rp3"
 grep -q 'taskId: "__merge__"' "$rp3"
-grep -q '^ *gatePolicy: review_ready$' "$rp3"
+grep -q '^ *gatePolicy: completed$' "$rp3"
 grep -q '^baseBranch: feature/b$' "$rp3"
 
 out_rr="$(

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -103,7 +103,7 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
      5. If the target repo is Invoker itself, publish/update the resulting PR stack with `mergify stack push` after submission-side commits are ready.
 10b. `step-submit-chain` (batch stacking, multiple template plans)
      Use when submitting an entire dependency chain at once.
-     `./scripts/submit-workflow-chain.sh [--gate-policy approved|review_ready] <plan1.yaml> <plan2.template.yaml> ...`
+     `./scripts/submit-workflow-chain.sh [--gate-policy completed|review_ready] <plan1.yaml> <plan2.template.yaml> ...`
      The chain script handles: template rendering, baseBranch rewrite, merge-gate injection, sequential submission. For Invoker-on-Invoker work only, publish the resulting GitHub PR stack with `mergify stack push` once the chain's commits are prepared.
 
 ## Runtime verification (Phase 1b)

--- a/skills/workflow-chain-submit/SKILL.md
+++ b/skills/workflow-chain-submit/SKILL.md
@@ -51,7 +51,7 @@ The script prints:
 
 - Uses `--no-track` so submissions return without waiting for full execution.
 - Resolves each submitted workflow ID from persisted workflows by `name` to avoid transient ID races.
-- `--gate-policy approved|review_ready` controls cross-workflow merge-gate readiness:
-  - `review_ready` (default): downstream can start once upstream merge gate is `review_ready`, `awaiting_approval`, or `completed`.
-  - `approved`: downstream waits for upstream merge gate `completed`.
+- `--gate-policy completed|review_ready` controls cross-workflow merge-gate readiness:
+  - `completed` (default): downstream waits for upstream merge gate `completed`.
+  - `review_ready`: downstream can start once upstream merge gate is `review_ready`, `awaiting_approval`, or `completed`.
 - This skill manages Invoker workflow stacking, not GitHub PR publication policy. If the target repo is Invoker itself, publish/update the resulting GitHub PR stack with `mergify stack push` once the branch commits are ready. If the target repo is something else (for example `EdbertChan/test-playground`), keep normal PR flow unless that repo independently uses Mergify Stacks.


### PR DESCRIPTION
## Summary

Change workflow-chain submission to default external merge-gate dependencies to `completed` instead of `review_ready`.

This keeps downstream workflows blocked until the upstream merge gate is fully completed unless the caller explicitly opts into `--gate-policy review_ready`.

The change updates the headless chain submit script, its regression test, and the skill docs that describe the supported gate-policy behavior.

## Test Plan

- [x] `bash scripts/test-submit-workflow-chain.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 7b5619e2`
- Post-revert steps: None
- Data migration? No
