### PR TITLE
Normalize workflow lifecycle queue-jump semantics

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -74,6 +74,7 @@ let mocks: {
   cancelTask: ReturnType<typeof vi.fn>;
   cancelWorkflow: ReturnType<typeof vi.fn>;
   killRunningTask: ReturnType<typeof vi.fn>;
+  deleteWorkflow: ReturnType<typeof vi.fn>;
 };
 
 function createMocks() {
@@ -129,6 +130,7 @@ function createMocks() {
     cancelTask: vi.fn().mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] }),
     cancelWorkflow: vi.fn().mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] }),
     killRunningTask: vi.fn().mockResolvedValue(undefined),
+    deleteWorkflow: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -144,6 +146,7 @@ beforeAll(async () => {
     cancelTask: mocks.cancelTask,
     cancelWorkflow: mocks.cancelWorkflow,
     killRunningTask: mocks.killRunningTask,
+    deleteWorkflow: mocks.deleteWorkflow,
   });
   // Wait for the server to start listening
   await new Promise<void>((resolve) => {
@@ -172,6 +175,7 @@ beforeEach(() => {
   mocks.cancelTask.mockClear();
   mocks.cancelWorkflow.mockClear();
   mocks.killRunningTask.mockClear();
+  mocks.deleteWorkflow.mockClear();
 
   // Re-apply default return values after clear
   mocks.orchestrator.getWorkflowStatus.mockReturnValue({ total: 1, completed: 0, failed: 0, running: 1, pending: 0 });
@@ -198,6 +202,7 @@ beforeEach(() => {
   mocks.cancelTask.mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
   mocks.cancelWorkflow.mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
   mocks.killRunningTask.mockResolvedValue(undefined);
+  mocks.deleteWorkflow.mockResolvedValue(undefined);
   mocks.taskExecutor.executeTasks.mockResolvedValue(undefined);
   mocks.taskExecutor.publishAfterFix.mockResolvedValue(undefined);
   mocks.taskExecutor.resolveConflict.mockResolvedValue(undefined);
@@ -945,18 +950,17 @@ describe('POST /api/workflows/:id/recreate-with-rebase', () => {
 });
 
 describe('DELETE /api/workflows/:id', () => {
-  it('deletes workflow', async () => {
+  it('deletes workflow via shared deleteWorkflow bridge', async () => {
     const res = await request(port, 'DELETE', '/api/workflows/wf-1');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('deleted');
-    expect(mocks.orchestrator.deleteWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(mocks.deleteWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(mocks.orchestrator.deleteWorkflow).not.toHaveBeenCalled();
   });
 
   it('returns 400 on error', async () => {
-    mocks.orchestrator.deleteWorkflow.mockImplementation(() => {
-      throw new Error('workflow not found');
-    });
+    mocks.deleteWorkflow.mockRejectedValue(new Error('workflow not found'));
     const res = await request(port, 'DELETE', '/api/workflows/missing');
     expect(res.status).toBe(400);
     expect(res.body.error).toBe('workflow not found');

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1565,4 +1565,32 @@ describe('headless delegation enforcement', () => {
       expect(mockDeps.commandService.cancelTask).not.toHaveBeenCalled();
     });
   });
+
+  describe('delete-workflow shared bridge', () => {
+    it('headless delete-workflow uses deleteWorkflow dep when available', async () => {
+      const deleteWorkflow = vi.fn().mockResolvedValue(undefined);
+      mockDeps.commandService.deleteWorkflow = vi.fn(async () => ({ ok: true as const, data: undefined })) as any;
+      const depsWithDelete: HeadlessDeps = {
+        ...mockDeps,
+        deleteWorkflow,
+      } as HeadlessDeps;
+
+      await runHeadless(['delete-workflow', 'wf-1'], depsWithDelete);
+
+      expect(deleteWorkflow).toHaveBeenCalledWith('wf-1');
+      expect(mockDeps.commandService.deleteWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('headless delete falls back to commandService when deleteWorkflow dep is not provided', async () => {
+      mockDeps.commandService.deleteWorkflow = vi.fn(async () => ({ ok: true as const, data: undefined })) as any;
+      const depsWithoutDelete: HeadlessDeps = {
+        ...mockDeps,
+        deleteWorkflow: undefined,
+      } as HeadlessDeps;
+
+      await runHeadless(['delete', 'wf-1'], depsWithoutDelete);
+
+      expect(mockDeps.commandService.deleteWorkflow).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -691,4 +691,207 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(adapter.listWorkflowMutationIntents(undefined, ['completed'])).toHaveLength(4);
     expect(maxActive).toBe(2);
   });
+
+  it('invalidates an older running workflow intent when internal delete-workflow is enqueued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const deleteWf = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:delete-workflow',
+      ['wf-1'],
+    );
+    await deleteWf;
+    await expect(olderRunning).rejects.toThrow(/superseded by delete intent/i);
+
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intents.find((intent) => intent.id === 1)?.status).toBe('failed');
+    expect(intents.find((intent) => intent.id === 1)?.error).toContain('Superseded by delete intent #2');
+    expect(intents.find((intent) => intent.id === 2)?.status).toBe('completed');
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:delete-workflow:wf-1',
+    ]);
+  });
+
+  it('evicts older queued workflow intents when internal delete-workflow fence starts', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/blocker-task', null]);
+    void running.catch(() => {});
+    const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['old-queued']);
+    void olderQueued.catch(() => {});
+    const deleteWf = coordinator.enqueue<void>('wf-1', 'high', 'invoker:delete-workflow', ['wf-1']);
+    const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['new-queued']);
+
+    await deleteWf;
+    await newerQueued;
+    await expect(running).rejects.toThrow(/superseded by delete intent/i);
+    await expect(olderQueued).rejects.toThrow(/evicted/i);
+
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:delete-workflow:wf-1',
+      'invoker:edit-task-agent:new-queued',
+    ]);
+  });
+
+  it('invalidates an older running workflow intent when delegated headless delete is enqueued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (_channel, args) => {
+        const payload = args[0] as { args?: string[] } | undefined;
+        const command = payload?.args?.join(' ') ?? String(args[0]);
+        order.push(command);
+        if (command.includes('hold-work')) {
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'headless.exec',
+      [{ args: ['set', 'command', 'wf-1/task-0', 'hold-work'] }],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const deleteExec = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'headless.exec',
+      [{ args: ['delete', 'wf-1'] }],
+    );
+    await deleteExec;
+    await expect(olderRunning).rejects.toThrow(/superseded by delete intent/i);
+
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intents.find((intent) => intent.id === 1)?.status).toBe('failed');
+    expect(intents.find((intent) => intent.id === 1)?.error).toContain('Superseded by delete intent #2');
+    expect(intents.find((intent) => intent.id === 2)?.status).toBe('completed');
+    expect(order).toEqual([
+      'set command wf-1/task-0 hold-work',
+      'delete wf-1',
+    ]);
+  });
+
+  it('evicts older queued workflow intents when delegated headless delete fence starts', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (_channel, args) => {
+        const payload = args[0] as { args?: string[] } | undefined;
+        const command = payload?.args?.join(' ') ?? 'unknown';
+        order.push(command);
+        if (command.includes('hold-work')) {
+          await gate.promise;
+        }
+      },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'headless.exec', [{ args: ['set', 'command', 'wf-1/task-0', 'hold-work'] }]);
+    void running.catch(() => {});
+    const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'headless.exec', [{ args: ['set', 'agent', 'wf-1/task-1', 'codex'] }]);
+    void olderQueued.catch(() => {});
+    const deleteFence = coordinator.enqueue<void>('wf-1', 'high', 'headless.exec', [{ args: ['delete', 'wf-1'] }]);
+    const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'headless.exec', [{ args: ['set', 'agent', 'wf-1/task-2', 'claude'] }]);
+
+    await Promise.resolve();
+    await deleteFence;
+    await newerQueued;
+    await expect(running).rejects.toThrow(/superseded by delete intent/i);
+    await expect(olderQueued).rejects.toThrow(/evicted/i);
+
+    expect(order).toEqual([
+      'set command wf-1/task-0 hold-work',
+      'delete wf-1',
+      'set agent wf-1/task-2 claude',
+    ]);
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    const evictedIntent = intents.find((intent) => Array.isArray(intent.args) && JSON.stringify(intent.args).includes('wf-1/task-1'));
+    const invalidatedIntent = intents.find((intent) => intent.id === 1);
+    expect(invalidatedIntent?.status).toBe('failed');
+    expect(invalidatedIntent?.error).toContain('Superseded by delete intent #3');
+    expect(evictedIntent?.status).toBe('failed');
+    expect(evictedIntent?.error).toContain('queue fence');
+    gate.resolve();
+  });
 });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -71,6 +71,7 @@ export interface ApiServerDeps {
   killRunningTask?: (taskId: string) => Promise<void>;
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
+  deleteWorkflow?: (workflowId: string) => Promise<void>;
 }
 
 export interface ApiServer {
@@ -142,6 +143,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     killRunningTask,
     cancelTask,
     cancelWorkflow,
+    deleteWorkflow,
   } = deps;
   const port = parseInt(process.env.INVOKER_API_PORT ?? '4100', 10);
 
@@ -672,7 +674,11 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'DELETE' && wfDeleteMatch) {
         const workflowId = decodeURIComponent(wfDeleteMatch[1]);
         try {
-          orchestrator.deleteWorkflow(workflowId);
+          if (deleteWorkflow) {
+            await deleteWorkflow(workflowId);
+          } else {
+            orchestrator.deleteWorkflow(workflowId);
+          }
           json(res, 200, { ok: true, workflowId, action: 'deleted' });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -93,6 +93,7 @@ export interface HeadlessDeps {
   preemptWorkflowExecution?: (workflowId: string) => Promise<WorkflowCancelResult>;
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
+  deleteWorkflow?: (workflowId: string) => Promise<void>;
   waitForApproval?: boolean;
   noTrack?: boolean;
   isStandaloneOwnerIdle?: () => boolean;
@@ -2096,8 +2097,13 @@ async function headlessOpenTerminal(taskId: string, deps: HeadlessDeps): Promise
   }
 }
 
-async function headlessDeleteWorkflow(workflowId: string, deps: Pick<HeadlessDeps, 'commandService'>): Promise<void> {
+async function headlessDeleteWorkflow(workflowId: string, deps: Pick<HeadlessDeps, 'commandService' | 'deleteWorkflow'>): Promise<void> {
   if (!workflowId) throw new Error('Missing workflowId. Usage: --headless delete-workflow <workflowId>');
+  if (deps.deleteWorkflow) {
+    await deps.deleteWorkflow(workflowId);
+    process.stdout.write(`Deleted workflow: ${workflowId}\n`);
+    return;
+  }
   const envelope = makeEnvelope('delete-workflow', 'headless', 'workflow', { workflowId });
   const result = await deps.commandService.deleteWorkflow(envelope);
   if (!result.ok) throw new Error(result.error.message);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1556,6 +1556,25 @@ if (isHeadless) {
     return cmdResult.data;
   }
 
+  async function performDeleteWorkflow(workflowId: string): Promise<void> {
+    logger.info(`performDeleteWorkflow begin workflow="${workflowId}"`, { module: 'kill' });
+    // Kill all running tasks belonging to the workflow (process management is outside orchestrator scope)
+    const allTasks = orchestrator.getAllTasks();
+    const workflowTasks = allTasks.filter(
+      (t) =>
+        t.config.workflowId === workflowId &&
+        (t.status === 'running' || t.status === 'fixing_with_ai'),
+    );
+    for (const task of workflowTasks) {
+      await killRunningTask(task.id);
+    }
+    // Serialized via CommandService: DB delete + memory clear + scheduler cleanup + removal deltas
+    const envelope = makeEnvelope('delete-workflow', 'ui', 'workflow', { workflowId });
+    const result = await commandService.deleteWorkflow(envelope);
+    if (!result.ok) throw new Error(result.error.message);
+    logger.info(`performDeleteWorkflow end workflow="${workflowId}"`, { module: 'kill' });
+  }
+
   async function preemptTaskSubgraph(taskId: string): Promise<void> {
     try {
       await performCancelTask(taskId);
@@ -1642,6 +1661,7 @@ if (isHeadless) {
       setTaskDispatcherExecutor: setDispatcherTaskExecutor,
       cancelTask: (taskId: string) => performCancelTask(taskId),
       cancelWorkflow: (workflowId: string) => performCancelWorkflow(workflowId),
+      deleteWorkflow: (workflowId: string) => performDeleteWorkflow(workflowId),
       waitForApproval: payload.waitForApproval,
       noTrack: payload.noTrack,
       preemptTaskSubgraph: (taskId: string) => preemptTaskSubgraph(taskId),
@@ -2245,6 +2265,7 @@ if (isHeadless) {
         killRunningTask,
         cancelTask: performCancelTask,
         cancelWorkflow: performCancelWorkflow,
+        deleteWorkflow: performDeleteWorkflow,
       });
       recordStartupMark('api-server.started');
 
@@ -2742,21 +2763,7 @@ if (isHeadless) {
         const workflowId = String(workflowIdArg);
         logger.info(`delete-workflow: "${workflowId}"`, { module: 'ipc' });
         try {
-          // Kill all running tasks belonging to the workflow (process management is outside orchestrator scope)
-          const allTasks = orchestrator.getAllTasks();
-          const workflowTasks = allTasks.filter(
-            (t) =>
-              t.config.workflowId === workflowId &&
-              (t.status === 'running' || t.status === 'fixing_with_ai'),
-          );
-          for (const task of workflowTasks) {
-            await killRunningTask(task.id);
-          }
-
-          // Serialized via CommandService: DB delete + memory clear + scheduler cleanup + removal deltas
-          const envelope = makeEnvelope('delete-workflow', 'ui', 'workflow', { workflowId });
-          const result = await commandService.deleteWorkflow(envelope);
-          if (!result.ok) throw new Error(result.error.message);
+          await performDeleteWorkflow(workflowId);
 
           // Update workflow count and send workflows-changed
           const workflows = persistence.listWorkflows();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1752,6 +1752,8 @@ if (isHeadless) {
         return { workflowId: workflowIdForTaskArg(arg0), priority: 'high' };
       case 'recreate':
       case 'cancel-workflow':
+      case 'delete':
+      case 'delete-workflow':
         return { workflowId: arg0, priority: 'high' };
       case 'rebase':
       case 'cancel':
@@ -2732,37 +2734,42 @@ if (isHeadless) {
       }
     });
 
-    registerGuiMutationHandler('invoker:delete-workflow', async (workflowIdArg: unknown) => {
-      const workflowId = String(workflowIdArg);
-      logger.info(`delete-workflow: "${workflowId}"`, { module: 'ipc' });
-      try {
-        // Kill all running tasks belonging to the workflow (process management is outside orchestrator scope)
-        const allTasks = orchestrator.getAllTasks();
-        const workflowTasks = allTasks.filter(
-          (t) =>
-            t.config.workflowId === workflowId &&
-            (t.status === 'running' || t.status === 'fixing_with_ai'),
-        );
-        for (const task of workflowTasks) {
-          await killRunningTask(task.id);
-        }
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:delete-workflow',
+      (workflowIdArg: unknown) => String(workflowIdArg),
+      'high',
+      async (workflowIdArg: unknown) => {
+        const workflowId = String(workflowIdArg);
+        logger.info(`delete-workflow: "${workflowId}"`, { module: 'ipc' });
+        try {
+          // Kill all running tasks belonging to the workflow (process management is outside orchestrator scope)
+          const allTasks = orchestrator.getAllTasks();
+          const workflowTasks = allTasks.filter(
+            (t) =>
+              t.config.workflowId === workflowId &&
+              (t.status === 'running' || t.status === 'fixing_with_ai'),
+          );
+          for (const task of workflowTasks) {
+            await killRunningTask(task.id);
+          }
 
-        // Serialized via CommandService: DB delete + memory clear + scheduler cleanup + removal deltas
-        const envelope = makeEnvelope('delete-workflow', 'ui', 'workflow', { workflowId });
-        const result = await commandService.deleteWorkflow(envelope);
-        if (!result.ok) throw new Error(result.error.message);
+          // Serialized via CommandService: DB delete + memory clear + scheduler cleanup + removal deltas
+          const envelope = makeEnvelope('delete-workflow', 'ui', 'workflow', { workflowId });
+          const result = await commandService.deleteWorkflow(envelope);
+          if (!result.ok) throw new Error(result.error.message);
 
-        // Update workflow count and send workflows-changed
-        const workflows = persistence.listWorkflows();
-        lastKnownWorkflowCount = workflows.length;
-        if (mainWindow && !mainWindow.isDestroyed()) {
-          mainWindow.webContents.send('invoker:workflows-changed', workflows);
+          // Update workflow count and send workflows-changed
+          const workflows = persistence.listWorkflows();
+          lastKnownWorkflowCount = workflows.length;
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send('invoker:workflows-changed', workflows);
+          }
+        } catch (err) {
+          logger.error(`delete-workflow failed: ${err}`, { module: 'ipc' });
+          throw err;
         }
-      } catch (err) {
-        logger.error(`delete-workflow failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
-    });
+      },
+    );
 
     registerWorkflowScopedGuiMutationHandler(
       'invoker:detach-workflow',

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -275,7 +275,8 @@ export class PersistedWorkflowMutationCoordinator {
     channel: string,
     args: unknown[],
   ): void {
-    if (!this.isHardPreemptingRecreateIntent(channel, args)) {
+    const fenceKind = this.hardPreemptFenceKind(channel, args);
+    if (!fenceKind) {
       return;
     }
     const activeLease = this.persistence.listWorkflowMutationLeases()
@@ -288,25 +289,38 @@ export class PersistedWorkflowMutationCoordinator {
     if (!activeIntent || activeIntent.status !== 'running') {
       return;
     }
-    const reason = `Superseded by recreate intent #${newIntentId}`;
+    const reason = `Superseded by ${fenceKind} intent #${newIntentId}`;
     this.persistence.failWorkflowMutationIntent(activeIntentId, reason);
     const invalidation = this.runningIntentInvalidations.get(activeIntentId);
     invalidation?.reject(new WorkflowMutationInvalidatedError(reason));
     process.stderr.write(
-      `[workflow-mutation-coordinator] invalidated running intent ${activeIntentId} for ${workflowId} via recreate#${newIntentId}\n`,
+      `[workflow-mutation-coordinator] invalidated running intent ${activeIntentId} for ${workflowId} via ${fenceKind}#${newIntentId}\n`,
     );
   }
 
-  private isHardPreemptingRecreateIntent(channel: string, args: unknown[]): boolean {
-    if (channel === 'invoker:recreate-workflow' || channel === 'invoker:recreate-task' || channel === 'invoker:recreate-with-rebase') {
-      return true;
+  private hardPreemptFenceKind(channel: string, args: unknown[]): string | null {
+    if (
+      channel === 'invoker:recreate-workflow'
+      || channel === 'invoker:recreate-task'
+      || channel === 'invoker:recreate-with-rebase'
+    ) {
+      return 'recreate';
+    }
+    if (channel === 'invoker:delete-workflow') {
+      return 'delete';
     }
     if (channel !== 'headless.exec') {
-      return false;
+      return null;
     }
     const payload = args[0] as { args?: unknown[] } | undefined;
     const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
-    return rawArgs[0] === 'recreate' || rawArgs[0] === 'recreate-task';
+    if (rawArgs[0] === 'recreate' || rawArgs[0] === 'recreate-task') {
+      return 'recreate';
+    }
+    if (rawArgs[0] === 'delete' || rawArgs[0] === 'delete-workflow') {
+      return 'delete';
+    }
+    return null;
   }
 
   private isWorkflowQueueFenceIntent(intent: WorkflowMutationIntent): boolean {
@@ -315,6 +329,7 @@ export class PersistedWorkflowMutationCoordinator {
       || intent.channel === 'invoker:recreate-workflow'
       || intent.channel === 'invoker:recreate-task'
       || intent.channel === 'invoker:recreate-with-rebase'
+      || intent.channel === 'invoker:delete-workflow'
     ) {
       return true;
     }
@@ -326,6 +341,9 @@ export class PersistedWorkflowMutationCoordinator {
     const command = typeof rawArgs[0] === 'string' ? rawArgs[0] : '';
     const target = typeof rawArgs[1] === 'string' ? rawArgs[1] : '';
     if (command === 'recreate-task') {
+      return true;
+    }
+    if (command === 'delete' || command === 'delete-workflow') {
       return true;
     }
     const isWorkflowId = /^wf-[^/]+$/.test(target);

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -336,6 +336,64 @@ describe('CommandService', () => {
       const result = await service.deleteWorkflow(makeEnvelope({ workflowId: 'bad' }));
       expect(result).toEqual({ ok: false, error: { code: 'DELETE_WORKFLOW_FAILED', message: 'wf not found' } });
     });
+
+    it('serializes on workflowId (workflow-scoped, not global)', async () => {
+      const order: string[] = [];
+      let resolveDelete!: () => void;
+      const deleteGate = new Promise<void>(r => { resolveDelete = r; });
+
+      (orchestrator.deleteWorkflow as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        order.push('delete-start');
+        await deleteGate;
+        order.push('delete-end');
+      });
+      (orchestrator.cancelWorkflow as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        order.push('cancel');
+        return { cancelled: [], runningCancelled: [] };
+      });
+
+      // Same workflow: deleteWorkflow and cancelWorkflow must serialize
+      const pDelete = service.deleteWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'k1'));
+      const pCancel = service.cancelWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'k2'));
+
+      // Let delete complete
+      resolveDelete();
+      await Promise.all([pDelete, pCancel]);
+
+      // cancel must wait for delete to finish (same workflow mutex)
+      expect(order).toEqual(['delete-start', 'delete-end', 'cancel']);
+    });
+
+    it('does not block operations on a different workflow', async () => {
+      const order: string[] = [];
+      let resolveDelete!: () => void;
+      const deleteGate = new Promise<void>(r => { resolveDelete = r; });
+
+      (orchestrator.deleteWorkflow as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+        order.push('delete-start');
+        await deleteGate;
+        order.push('delete-end');
+      });
+      (orchestrator.cancelWorkflow as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        order.push('cancel');
+        return { cancelled: [], runningCancelled: [] };
+      });
+
+      // Different workflows: should run concurrently
+      const pDelete = service.deleteWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'k1'));
+      const pCancel = service.cancelWorkflow(makeEnvelope({ workflowId: 'wf-2' }, 'k2'));
+
+      // cancel on wf-2 should proceed without waiting for delete on wf-1
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(order).toContain('cancel');
+      expect(order).toContain('delete-start');
+      expect(order).not.toContain('delete-end');
+
+      resolveDelete();
+      await Promise.all([pDelete, pCancel]);
+      expect(order).toEqual(['delete-start', 'cancel', 'delete-end']);
+    });
   });
 
   describe('detachWorkflow', () => {

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -380,7 +380,7 @@ export class CommandService {
     return this.executeCommand<void>(
       'DELETE_WORKFLOW_FAILED',
       () => this.orchestrator.deleteWorkflow(envelope.payload.workflowId),
-      undefined,
+      envelope.payload.workflowId,
     );
   }
 


### PR DESCRIPTION
## Summary

Routes `delete-workflow` through the same workflow-scoped lifecycle machinery as cancel and recreate instead of letting it bypass queue coordination in some control planes.

The branch makes three linked changes: `CommandService.deleteWorkflow` now serializes on the target workflow instead of the global lane, the persisted workflow mutation coordinator treats delete as a queue-jump fence that can preempt or evict same-workflow mutations, and the app surfaces reuse a shared delete bridge that kills active workflow tasks before issuing the delete.

This keeps GUI, delegated headless, and HTTP API delete behavior aligned and closes the remaining gap where `DELETE /api/workflows/:id` could skip the coordinated delete path.

## Architecture

### Before

```mermaid
graph TD
    A[GUI / Headless / API delete request]
    B[Mixed routing paths]
    C[Direct orchestrator delete in some surfaces]
    D[Global command-service delete lane]
    E[Workflow-local mutation queue]

    A --> B
    B --> C
    B --> D
    B --> E
```

### After

```mermaid
graph TD
    A[GUI / Headless / API delete request]
    B[Shared delete bridge]
    C[Kill active workflow tasks]
    D[Workflow-scoped mutation coordinator]
    E[Workflow-local CommandService.deleteWorkflow]

    A --> B
    B --> C
    C --> D
    D --> E
```

## Test Plan

- [x] `pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert ae287577`
- Post-revert steps: None
- Data migration? No
