### PR TITLE
Adopt upstream-first routing and add DAG origin E2E

### DIFF
--- a/docs/pr-branching-workflow.md
+++ b/docs/pr-branching-workflow.md
@@ -1,23 +1,28 @@
-# PR Branching Workflow (Parent Remote)
+# PR Branching Workflow (Upstream First)
 
-Use this workflow when your repo has both `origin` (your writable fork) and a read-only parent remote. The parent remote defaults to `upstream`, but any remote name can be used.
+Default workflow:
+
+- Clone the canonical repository directly (for Invoker: `https://github.com/Neko-Catpital-Labs/Invoker`).
+- Create branches from your canonical base remote.
+- Publish branches to `origin` (or another explicit publish remote).
+- Open PRs against `Neko-Catpital-Labs/Invoker`.
 
 ## Rules
 
-- Never push working branches to the parent remote.
-- Push branches to `origin` only.
-- Create PR branches from `<parentRemote>/<baseBranch>`, not `origin/<baseBranch>`.
-- Open PRs targeting the parent repository base branch.
+- Do not rely on automatic fork-sync scripts before submission.
+- Keep base and publish remotes explicit when they differ.
+- Create PR branches from `<baseRemote>/<baseBranch>`.
+- Push branches to `<publishRemote>` and target the canonical repository base branch in PRs.
 
 ## Clean PR Flow
 
-1. Create branch from parent remote:
+1. Create branch from base remote:
 
 ```bash
-bash scripts/create-clean-pr-branch.sh --parent-remote upstream --base-ref master pr/<name> [commit ...]
+bash scripts/create-clean-pr-branch.sh --base-remote origin --publish-remote origin --base-ref master pr/<name> [commit ...]
 ```
 
-2. Push to fork:
+2. Push branch:
 
 ```bash
 git push -u origin pr/<name>
@@ -37,4 +42,8 @@ node scripts/validate-pr-body.mjs --body-file /tmp/my-pr.md
 node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-pr.md
 ```
 
-By default, tools in this workflow use `upstream` as the parent remote. Override it when your team uses a different remote name.
+## Migrating Existing Fork-First Clones
+
+- Stop using `scripts/sync-fork-upstream.sh` for branch freshness.
+- Set your base remote explicitly when creating branches.
+- If your repo keeps a separate publish remote, pass it via `--publish-remote`.

--- a/scripts/create-clean-pr-branch.sh
+++ b/scripts/create-clean-pr-branch.sh
@@ -1,18 +1,29 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Create a PR branch rooted at parent remote + base branch and optionally cherry-pick commits.
+# Create a PR branch rooted at base remote + base branch and optionally cherry-pick commits.
 # Usage:
-#   bash scripts/create-clean-pr-branch.sh [--parent-remote <name>] [--base-ref <branch>] <branch-name> [commit ...]
+#   bash scripts/create-clean-pr-branch.sh [--base-remote <name>] [--publish-remote <name>] [--base-ref <branch>] <branch-name> [commit ...]
 
-PARENT_REMOTE="upstream"
+BASE_REMOTE="origin"
+PUBLISH_REMOTE="origin"
 BASE_REF="master"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --base-remote)
+      [[ $# -ge 2 ]] || { echo "--base-remote requires a value" >&2; exit 2; }
+      BASE_REMOTE="$2"
+      shift 2
+      ;;
+    --publish-remote)
+      [[ $# -ge 2 ]] || { echo "--publish-remote requires a value" >&2; exit 2; }
+      PUBLISH_REMOTE="$2"
+      shift 2
+      ;;
     --parent-remote)
       [[ $# -ge 2 ]] || { echo "--parent-remote requires a value" >&2; exit 2; }
-      PARENT_REMOTE="$2"
+      BASE_REMOTE="$2"
       shift 2
       ;;
     --base-ref)
@@ -21,7 +32,8 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --help|-h)
-      echo "Usage: $0 [--parent-remote <name>] [--base-ref <branch>] <branch-name> [commit ...]" >&2
+      echo "Usage: $0 [--base-remote <name>] [--publish-remote <name>] [--base-ref <branch>] <branch-name> [commit ...]" >&2
+      echo "Compatibility alias: --parent-remote <name> (maps to --base-remote)." >&2
       exit 0
       ;;
     --*)
@@ -35,7 +47,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: $0 [--parent-remote <name>] [--base-ref <branch>] <branch-name> [commit ...]" >&2
+  echo "Usage: $0 [--base-remote <name>] [--publish-remote <name>] [--base-ref <branch>] <branch-name> [commit ...]" >&2
   exit 2
 fi
 
@@ -47,24 +59,24 @@ if git show-ref --verify --quiet "refs/heads/${BRANCH_NAME}"; then
   exit 1
 fi
 
-if ! git remote get-url "${PARENT_REMOTE}" >/dev/null 2>&1; then
-  echo "Missing parent remote '${PARENT_REMOTE}'." >&2
+if ! git remote get-url "${BASE_REMOTE}" >/dev/null 2>&1; then
+  echo "Missing base remote '${BASE_REMOTE}'." >&2
   echo "Add it first (example):" >&2
-  echo "  git remote add ${PARENT_REMOTE} <parent-repo-url>" >&2
+  echo "  git remote add ${BASE_REMOTE} <repo-url>" >&2
   exit 1
 fi
 
-if ! git remote get-url origin >/dev/null 2>&1; then
-  echo "Missing remote 'origin'." >&2
+if ! git remote get-url "${PUBLISH_REMOTE}" >/dev/null 2>&1; then
+  echo "Missing publish remote '${PUBLISH_REMOTE}'." >&2
   exit 1
 fi
 
 echo "==> Fetching remotes"
-git fetch "${PARENT_REMOTE}" "${BASE_REF}" --prune
-git fetch origin --prune
+git fetch "${BASE_REMOTE}" "${BASE_REF}" --prune
+git fetch "${PUBLISH_REMOTE}" --prune
 
-echo "==> Creating branch ${BRANCH_NAME} from ${PARENT_REMOTE}/${BASE_REF}"
-git switch -c "${BRANCH_NAME}" "${PARENT_REMOTE}/${BASE_REF}"
+echo "==> Creating branch ${BRANCH_NAME} from ${BASE_REMOTE}/${BASE_REF}"
+git switch -c "${BRANCH_NAME}" "${BASE_REMOTE}/${BASE_REF}"
 
 if [[ $# -gt 0 ]]; then
   echo "==> Cherry-picking commits"
@@ -74,7 +86,7 @@ fi
 echo ""
 echo "Branch ready: ${BRANCH_NAME}"
 echo "Next:"
-echo "  git push -u origin ${BRANCH_NAME}"
+echo "  git push -u ${PUBLISH_REMOTE} ${BRANCH_NAME}"
 echo "  cp scripts/pr-body-template.md /tmp/my-pr.md"
 echo "  \$EDITOR /tmp/my-pr.md"
 echo "  node scripts/validate-pr-body.mjs --body-file /tmp/my-pr.md"

--- a/scripts/submit-workflow-chain.sh
+++ b/scripts/submit-workflow-chain.sh
@@ -176,15 +176,6 @@ declare -a CHAIN_BASE_BRANCHES=()
 declare -a CHAIN_FEATURE_BRANCHES=()
 declare -a RENDERED_PLANS=()
 
-# Sync fork with upstream if any plan in the chain targets EdbertChan/Invoker.
-for p in "${INPUT_PLANS[@]}"; do
-  log_chain "sync-fork-upstream begin plan=\"$p\""
-  sync_start_ms="$(now_ms)"
-  bash "$REPO_ROOT/scripts/sync-fork-upstream.sh" "$p" || true
-  log_chain "sync-fork-upstream end elapsedMs=$(( $(now_ms) - sync_start_ms ))"
-  break  # only need to sync once; first plan determines the repo
-done
-
 prev_wf_id=""
 prev_wf_feature_branch=""
 

--- a/scripts/sync-fork-upstream.sh
+++ b/scripts/sync-fork-upstream.sh
@@ -1,16 +1,12 @@
 #!/usr/bin/env bash
 #
-# Sync EdbertChan/Invoker (origin) with Neko-Catpital-Labs/Invoker (upstream).
+# Deprecated compatibility wrapper for the retired fork-sync flow.
 #
-# Called by submit-plan.sh and submit-workflow-chain.sh before submitting
-# plans whose repoUrl points to EdbertChan/Invoker.
+# This script intentionally performs no git mutations.
+# It remains for callers that may still invoke it directly.
 #
 # Usage:
 #   bash scripts/sync-fork-upstream.sh <plan.yaml>
-#
-# If the plan's repoUrl matches EdbertChan/Invoker (case-insensitive),
-# fetches upstream/master and pushes it to origin/master so the fork
-# stays in sync. No-ops if the plan targets a different repo.
 #
 set -euo pipefail
 
@@ -20,48 +16,9 @@ if [[ $# -lt 1 ]]; then
 fi
 
 PLAN_FILE="$1"
-
 if [[ ! -f "$PLAN_FILE" ]]; then
   echo "sync-fork-upstream: plan file not found: $PLAN_FILE" >&2
   exit 1
 fi
 
-# Extract repoUrl from plan YAML (simple grep; avoids YAML parser dependency).
-REPO_URL="$(awk '/^repoUrl:[[:space:]]*/ {
-  line=$0
-  sub(/^repoUrl:[[:space:]]*/, "", line)
-  gsub(/^"|"$/, "", line)
-  print line
-  exit
-}' "$PLAN_FILE")"
-
-if [[ -z "${REPO_URL:-}" ]]; then
-  # No repoUrl in plan — nothing to sync.
-  exit 0
-fi
-
-# Check if repoUrl matches EdbertChan/Invoker (case-insensitive).
-if ! echo "$REPO_URL" | grep -iq 'EdbertChan/Invoker'; then
-  exit 0
-fi
-
-echo "==> Plan targets EdbertChan/Invoker — syncing fork with upstream"
-
-# Verify upstream remote exists.
-if ! git remote get-url upstream >/dev/null 2>&1; then
-  echo "sync-fork-upstream: 'upstream' remote not configured. Adding it." >&2
-  git remote add upstream https://github.com/Neko-Catpital-Labs/Invoker.git
-fi
-
-# Fetch upstream master and merge into local master.
-# Merge (not rebase) so fork-specific commits are never dropped.
-git fetch upstream master
-if git merge-base --is-ancestor upstream/master HEAD; then
-  echo "==> Fork already up-to-date with upstream"
-else
-  echo "==> Merging upstream/master into fork"
-  git merge upstream/master --no-edit -m "Merge upstream/master into fork"
-fi
-git push origin master
-
-echo "==> Fork synced: origin/master merged with upstream/master"
+echo "sync-fork-upstream: deprecated; no action taken."

--- a/scripts/test-create-clean-pr-branch.sh
+++ b/scripts/test-create-clean-pr-branch.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+CANONICAL_REPO="$TMP_DIR/canonical.git"
+PUBLISH_REPO="$TMP_DIR/publish.git"
+WORK_REPO="$TMP_DIR/work"
+
+git init --bare "$CANONICAL_REPO" >/dev/null
+git init --bare "$PUBLISH_REPO" >/dev/null
+
+git clone "$CANONICAL_REPO" "$WORK_REPO" >/dev/null
+git -C "$WORK_REPO" remote add publish "$PUBLISH_REPO"
+
+git -C "$WORK_REPO" config user.email "test@example.com"
+git -C "$WORK_REPO" config user.name "test-user"
+echo "seed" > "$WORK_REPO/README.md"
+git -C "$WORK_REPO" add README.md
+git -C "$WORK_REPO" commit -m "seed" >/dev/null
+git -C "$WORK_REPO" push origin master >/dev/null
+git -C "$WORK_REPO" push publish master >/dev/null
+
+out_explicit="$(
+  cd "$WORK_REPO"
+  bash "$ROOT/scripts/create-clean-pr-branch.sh" \
+    --base-remote origin \
+    --publish-remote publish \
+    --base-ref master \
+    pr/explicit
+)"
+
+[[ "$(git -C "$WORK_REPO" rev-parse --abbrev-ref HEAD)" == "pr/explicit" ]] || {
+  echo "expected current branch pr/explicit"
+  exit 1
+}
+printf '%s' "$out_explicit" | rg -q 'git push -u publish pr/explicit'
+
+git -C "$WORK_REPO" switch master >/dev/null
+
+out_alias="$(
+  cd "$WORK_REPO"
+  bash "$ROOT/scripts/create-clean-pr-branch.sh" \
+    --parent-remote origin \
+    --publish-remote publish \
+    --base-ref master \
+    pr/alias
+)"
+
+[[ "$(git -C "$WORK_REPO" rev-parse --abbrev-ref HEAD)" == "pr/alias" ]] || {
+  echo "expected current branch pr/alias"
+  exit 1
+}
+printf '%s' "$out_alias" | rg -q 'git push -u publish pr/alias'
+
+echo "PASS: create-clean-pr-branch supports upstream-first remotes and alias"

--- a/scripts/test-e2e-dag-origin-routing.sh
+++ b/scripts/test-e2e-dag-origin-routing.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PLAN_SRC="$ROOT/plans/e2e-dry-run/group2-multi-task/2.3-parallel-success.yaml"
+
+if [[ ! -f "$PLAN_SRC" ]]; then
+  echo "Missing plan fixture: $PLAN_SRC" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d)"
+DB_DIR="$TMP_DIR/db"
+UPSTREAM_BARE="$TMP_DIR/remotes/upstream/Invoker.git"
+ORIGIN_BARE="$TMP_DIR/remotes/origin/Invoker.git"
+SEED_REPO="$TMP_DIR/seed"
+PLAN_TMP="$TMP_DIR/plan.yaml"
+CFG_PATH="$TMP_DIR/config.json"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/remotes/upstream" "$TMP_DIR/remotes/origin" "$DB_DIR"
+
+# Create isolated remotes to validate branch routing behavior.
+git init --bare "$UPSTREAM_BARE" >/dev/null
+git init --bare "$ORIGIN_BARE" >/dev/null
+
+# Seed both remotes with the same master baseline.
+git clone "$UPSTREAM_BARE" "$SEED_REPO" >/dev/null
+git -C "$SEED_REPO" config user.email "test@example.com"
+git -C "$SEED_REPO" config user.name "test-user"
+echo "seed" > "$SEED_REPO/README.md"
+git -C "$SEED_REPO" add README.md
+git -C "$SEED_REPO" commit -m "seed" >/dev/null
+git -C "$SEED_REPO" push origin master >/dev/null
+git -C "$SEED_REPO" remote add fork "$ORIGIN_BARE"
+git -C "$SEED_REPO" push fork master >/dev/null
+
+# Route plan execution pushes to origin remote.
+python3 - <<'PY' "$PLAN_SRC" "$PLAN_TMP" "$ORIGIN_BARE"
+import pathlib
+import sys
+
+src = pathlib.Path(sys.argv[1]).read_text(encoding="utf-8")
+dst = pathlib.Path(sys.argv[2])
+origin_uri = pathlib.Path(sys.argv[3]).as_uri()
+
+out = []
+for line in src.splitlines():
+    if line.lstrip().startswith("repoUrl:"):
+        out.append(f"repoUrl: {origin_uri}")
+    else:
+        out.append(line)
+
+dst.write_text("\n".join(out) + "\n", encoding="utf-8")
+PY
+
+cat > "$CFG_PATH" <<'JSON'
+{
+  "workspaceRoot": "/tmp",
+  "remoteTargets": []
+}
+JSON
+
+cd "$ROOT"
+INVOKER_DB_DIR="$DB_DIR" \
+INVOKER_REPO_CONFIG_PATH="$CFG_PATH" \
+INVOKER_HEADLESS_STANDALONE=1 \
+./run.sh --headless run "$PLAN_TMP" >/dev/null
+
+TASKS_JSON="$(
+  INVOKER_DB_DIR="$DB_DIR" \
+  INVOKER_REPO_CONFIG_PATH="$CFG_PATH" \
+  INVOKER_HEADLESS_STANDALONE=1 \
+  ./run.sh --headless query tasks --output json
+)"
+
+TASKS_FILE="$TMP_DIR/tasks.json"
+printf '%s\n' "$TASKS_JSON" > "$TASKS_FILE"
+
+BRANCHES="$(
+  python3 - <<'PY' "$TASKS_FILE"
+import json
+import sys
+
+tasks = json.loads(open(sys.argv[1], encoding="utf-8").read())
+branches = sorted({
+    (task.get("execution") or {}).get("branch", "")
+    for task in tasks
+    if "/e2e-g223-task" in ((task.get("execution") or {}).get("branch") or "")
+})
+print("\n".join([b for b in branches if b]))
+PY
+)"
+
+if [[ -z "$BRANCHES" ]]; then
+  echo "FAIL: no DAG task branches were captured from execution records" >&2
+  exit 1
+fi
+
+FAIL=0
+while IFS= read -r branch; do
+  [[ -z "$branch" ]] && continue
+
+  set +e
+  git --git-dir "$ORIGIN_BARE" show-ref --verify --quiet "refs/heads/$branch"
+  ORIGIN_STATUS=$?
+  git --git-dir "$UPSTREAM_BARE" show-ref --verify --quiet "refs/heads/$branch"
+  UPSTREAM_STATUS=$?
+  set -e
+
+  echo "branch=$branch origin=$ORIGIN_STATUS upstream=$UPSTREAM_STATUS"
+
+  # Must exist in origin and must not exist in upstream.
+  if [[ $ORIGIN_STATUS -ne 0 || $UPSTREAM_STATUS -eq 0 ]]; then
+    FAIL=1
+  fi
+done <<< "$BRANCHES"
+
+if [[ $FAIL -ne 0 ]]; then
+  echo "FAIL: expected all DAG task branches only on origin (not upstream)" >&2
+  exit 1
+fi
+
+echo "PASS: DAG task branches are pushed to origin and absent from upstream"

--- a/scripts/test-submit-workflow-chain.sh
+++ b/scripts/test-submit-workflow-chain.sh
@@ -7,9 +7,7 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 
 mkdir -p "$TMP_DIR/scripts" "$TMP_DIR/plans"
 cp "$ROOT/scripts/submit-workflow-chain.sh" "$TMP_DIR/scripts/submit-workflow-chain.sh"
-cp "$ROOT/scripts/sync-fork-upstream.sh" "$TMP_DIR/scripts/sync-fork-upstream.sh"
 chmod +x "$TMP_DIR/scripts/submit-workflow-chain.sh"
-chmod +x "$TMP_DIR/scripts/sync-fork-upstream.sh"
 
 cat > "$TMP_DIR/run.sh" <<'EOF'
 #!/usr/bin/env bash

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -2,7 +2,7 @@
 name: make-pr
 description: >
   Create or update a pull request in this repo using the preferred PR schema,
-  parent-remote branch workflow, and repo-specific publication rules. Trigger
+  upstream-first branch workflow, and repo-specific publication rules. Trigger
   when asked to make a PR, update a PR body, prepare PR text, or publish a
   stacked PR branch.
 ---
@@ -15,7 +15,7 @@ Use this skill when the work is already done and the user wants a PR created, up
 
 - PR title/body authoring for Invoker
 - The preferred PR section schema
-- Parent-remote branch/PR workflow (`origin` fork + `upstream` parent)
+- Upstream-first branch/PR workflow (explicit base and publish remotes)
 - Repo-specific publication rules:
   - Invoker-on-Invoker stacks may use `mergify stack push`
   - unrelated target repos should keep their own normal PR workflow unless they independently use Mergify Stacks
@@ -66,9 +66,9 @@ Do not default to a lightweight `## Summary / ## Testing / ## Notes` PR body. Th
 
 Preferred repo-local flow:
 
-1. Make sure the branch is based from the parent remote, not the fork.
+1. Make sure the branch is based from the canonical base remote.
    Reference: `docs/pr-branching-workflow.md`
-2. Push the working branch to `origin`.
+2. Push the working branch to the configured publish remote (typically `origin`).
 3. Start from the canonical template and validate it:
 
 ```bash
@@ -91,13 +91,14 @@ node scripts/create-pr.mjs --title "<title>" --base master --body-file /tmp/my-p
 
 This script handles local image path upload/injection when configured.
 
-## Parent-remote workflow
+## Upstream-first workflow
 
-Use the parent repository as the PR target and `origin` as the push remote.
+Use the canonical repository as the PR target and an explicit publish remote (typically `origin`) for branch publication.
 
-- Never push working branches to the parent remote.
-- Create branches from `upstream/<base>` (or the configured parent remote), not `origin/<base>`.
-- Open PRs against the parent repository base branch.
+- Do not depend on fork-sync scripts before PR creation.
+- Create branches from `<baseRemote>/<base>` (for example `origin/master` when `origin` is the canonical clone remote).
+- Push branches to the chosen publish remote.
+- Open PRs against the canonical repository base branch.
 
 Reference:
 

--- a/submit-plan.sh
+++ b/submit-plan.sh
@@ -37,8 +37,5 @@ if [ "$(uname)" = "Linux" ]; then
   export LIBGL_ALWAYS_SOFTWARE=1
 fi
 
-# Sync fork with upstream if plan targets EdbertChan/Invoker.
-bash "$REPO_ROOT/scripts/sync-fork-upstream.sh" "$PLAN_FILE" || true
-
 echo "==> Submitting plan: $PLAN_FILE"
 ./packages/app/node_modules/.bin/electron packages/app/dist/main.js $SANDBOX_FLAG --headless run "$PLAN_FILE"


### PR DESCRIPTION
## Summary

- Removes implicit fork synchronization from submission entrypoints so workflows no longer mutate fork/default branches before execution.
- Updates clean-branch tooling to an upstream-first model with explicit `--base-remote` and `--publish-remote` controls, while preserving `--parent-remote` as a compatibility alias.
- Aligns docs and PR skill guidance to the new remote model and adds focused regression coverage, including a DAG E2E check that task branches publish to `origin` and do not appear on `upstream`.

## Test Plan

- [x] `bash scripts/test-submit-workflow-chain.sh`
- [x] `bash scripts/test-create-clean-pr-branch.sh`
- [x] `bash scripts/test-e2e-dag-origin-routing.sh`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert f6106271`
- Post-revert steps: None.
- Data migration? No.
