### PR TITLE
SaaS ladder 1a runtime service skeleton

### DIFF
--- a/packages/runtime-service/package.json
+++ b/packages/runtime-service/package.json
@@ -17,6 +17,9 @@
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },
+  "dependencies": {
+    "@invoker/runtime-domain": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^25.3.3",
     "tsup": "^8.0.0",

--- a/packages/runtime-service/src/__tests__/composition.test.ts
+++ b/packages/runtime-service/src/__tests__/composition.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  composeRuntimeServices,
+  type RuntimeServiceDeps,
+  type RuntimeServices,
+} from '../composition.js';
+import { AttachmentResult } from '@invoker/runtime-domain';
+
+function stubDeps(): RuntimeServiceDeps {
+  return {
+    workspaceProbe: { probeWorkspace: async () => ({}) },
+    containerProbe: { probeContainer: async () => ({}) },
+    sessionProbe: { probeSession: async () => ({}) },
+    terminalLauncher: {
+      launchTerminal: async () => ({ result: AttachmentResult.Attached }),
+    },
+  };
+}
+
+describe('composition shell', () => {
+  describe('composeRuntimeServices', () => {
+    it('passes through workspaceProbe unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.workspaceProbe).toBe(deps.workspaceProbe);
+    });
+
+    it('passes through containerProbe unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.containerProbe).toBe(deps.containerProbe);
+    });
+
+    it('passes through sessionProbe unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.sessionProbe).toBe(deps.sessionProbe);
+    });
+
+    it('passes through terminalLauncher unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.terminalLauncher).toBe(deps.terminalLauncher);
+    });
+
+    it('returns a frozen object that rejects mutation', () => {
+      const services = composeRuntimeServices(stubDeps());
+      expect(Object.isFrozen(services)).toBe(true);
+      expect(() => {
+        (services as unknown as Record<string, unknown>).workspaceProbe = {};
+      }).toThrow();
+    });
+
+    it('exposes exactly the four expected keys', () => {
+      const services = composeRuntimeServices(stubDeps());
+      const keys = Object.keys(services).sort();
+      expect(keys).toEqual([
+        'containerProbe',
+        'sessionProbe',
+        'terminalLauncher',
+        'workspaceProbe',
+      ]);
+    });
+
+    it('satisfies the RuntimeServices type contract', () => {
+      const services: RuntimeServices = composeRuntimeServices(stubDeps());
+      expect(services.workspaceProbe.probeWorkspace).toBeTypeOf('function');
+      expect(services.containerProbe.probeContainer).toBeTypeOf('function');
+      expect(services.sessionProbe.probeSession).toBeTypeOf('function');
+      expect(services.terminalLauncher.launchTerminal).toBeTypeOf('function');
+    });
+
+    it('produces independent instances per call', () => {
+      const deps1 = stubDeps();
+      const deps2 = stubDeps();
+      const s1 = composeRuntimeServices(deps1);
+      const s2 = composeRuntimeServices(deps2);
+      expect(s1).not.toBe(s2);
+      expect(s1.workspaceProbe).not.toBe(s2.workspaceProbe);
+    });
+  });
+});

--- a/packages/runtime-service/src/__tests__/index.test.ts
+++ b/packages/runtime-service/src/__tests__/index.test.ts
@@ -1,7 +1,32 @@
 import { describe, it, expect } from 'vitest';
+import { composeRuntimeServices } from '../index.js';
+import type { RuntimeServiceDeps, RuntimeServices } from '../index.js';
+import { AttachmentResult } from '@invoker/runtime-domain';
 
-describe('package structure', () => {
-  it('should export from index', () => {
-    expect(true).toBe(true);
+function stubDeps(): RuntimeServiceDeps {
+  return {
+    workspaceProbe: { probeWorkspace: async () => ({}) },
+    containerProbe: { probeContainer: async () => ({}) },
+    sessionProbe: { probeSession: async () => ({}) },
+    terminalLauncher: {
+      launchTerminal: async () => ({ result: AttachmentResult.Attached }),
+    },
+  };
+}
+
+describe('composeRuntimeServices', () => {
+  it('returns a RuntimeServices object with all ports', () => {
+    const deps = stubDeps();
+    const services: RuntimeServices = composeRuntimeServices(deps);
+
+    expect(services.workspaceProbe).toBe(deps.workspaceProbe);
+    expect(services.containerProbe).toBe(deps.containerProbe);
+    expect(services.sessionProbe).toBe(deps.sessionProbe);
+    expect(services.terminalLauncher).toBe(deps.terminalLauncher);
+  });
+
+  it('returns a frozen object', () => {
+    const services = composeRuntimeServices(stubDeps());
+    expect(Object.isFrozen(services)).toBe(true);
   });
 });

--- a/packages/runtime-service/src/composition.ts
+++ b/packages/runtime-service/src/composition.ts
@@ -1,0 +1,54 @@
+/**
+ * Runtime composition shell — a typed container that bundles runtime
+ * domain ports into a single `RuntimeServices` facade.
+ *
+ * Consumers call `composeRuntimeServices(deps)` with concrete adapter
+ * implementations; this module never instantiates adapters itself, so
+ * app wiring stays in the application layer.
+ */
+
+import type {
+  WorkspaceProbe,
+  ContainerProbe,
+  SessionProbe,
+  TerminalLauncher,
+} from '@invoker/runtime-domain';
+
+// ── Dependency slot ────────────────────────────────────────
+
+/** Ports that callers must supply to compose the runtime services. */
+export interface RuntimeServiceDeps {
+  workspaceProbe: WorkspaceProbe;
+  containerProbe: ContainerProbe;
+  sessionProbe: SessionProbe;
+  terminalLauncher: TerminalLauncher;
+}
+
+// ── Public facade ──────────────────────────────────────────
+
+/** Unified read-only view of the composed runtime services. */
+export interface RuntimeServices {
+  readonly workspaceProbe: WorkspaceProbe;
+  readonly containerProbe: ContainerProbe;
+  readonly sessionProbe: SessionProbe;
+  readonly terminalLauncher: TerminalLauncher;
+}
+
+// ── Factory ────────────────────────────────────────────────
+
+/**
+ * Compose runtime services from concrete port implementations.
+ *
+ * Returns a frozen `RuntimeServices` object. No adapter instantiation
+ * happens here — callers provide fully constructed adapters.
+ */
+export function composeRuntimeServices(
+  deps: RuntimeServiceDeps,
+): RuntimeServices {
+  return Object.freeze({
+    workspaceProbe: deps.workspaceProbe,
+    containerProbe: deps.containerProbe,
+    sessionProbe: deps.sessionProbe,
+    terminalLauncher: deps.terminalLauncher,
+  });
+}

--- a/packages/runtime-service/src/index.ts
+++ b/packages/runtime-service/src/index.ts
@@ -1,1 +1,7 @@
 // @invoker/runtime-service - Runtime application services and use cases
+
+export {
+  composeRuntimeServices,
+  type RuntimeServiceDeps,
+  type RuntimeServices,
+} from './composition.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,10 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
   packages/runtime-service:
+    dependencies:
+      '@invoker/runtime-domain':
+        specifier: workspace:*
+        version: link:../runtime-domain
     devDependencies:
       '@types/node':
         specifier: ^25.3.3


### PR DESCRIPTION
## Summary

Creates the initial runtime-service composition skeleton as a standalone
foundation without wiring app entrypoints yet.

## Architecture

### Before

```mermaid
graph TD
    App[App startup] --> Local[Local composition code]
    Headless[Headless startup] --> Local
    Api[Future API surface] --> Local
```

### After

```mermaid
graph TD
    Shell[Runtime-service composition shell] --> Ports[Typed runtime ports]
    App -. future adoption .-> Shell
    Headless -. future adoption .-> Shell
    Api -. future adoption .-> Shell
```

## Test Plan

- [ ] runtime-service tests pass with exit code 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No