### PR TITLE
SaaS ladder 2c dormant runtime api bridge

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -67,6 +67,8 @@
     "@invoker/execution-engine": "workspace:*",
     "@invoker/data-store": "workspace:*",
     "@invoker/contracts": "workspace:*",
+    "@invoker/runtime-adapters": "workspace:*",
+    "@invoker/runtime-service": "workspace:*",
     "@invoker/surfaces": "workspace:*",
     "@invoker/transport": "workspace:*",
     "@slack/bolt": "^4.6.0",

--- a/packages/app/src/__tests__/headless-runtime-bridge.test.ts
+++ b/packages/app/src/__tests__/headless-runtime-bridge.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Regression tests for the headless → runtime-service bridge.
+ *
+ * Verifies that `composeHeadlessStartup` correctly routes through
+ * `composeRuntimeServices` from `@invoker/runtime-service`, producing
+ * a frozen `RuntimeServices` facade with owner-delegation parity.
+ *
+ * Upstream: wf-1778055155540-3/wire-headless-to-runtime-service (ce3006a6)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  composeHeadlessStartup,
+  composeRuntimeServices,
+  type RuntimeServiceDeps,
+  type RuntimeServices,
+} from '@invoker/runtime-service';
+
+// ── Stub factories ───────────────────────────────────────────
+
+/** Minimal deps matching the adapter shape used in headless.ts. */
+function stubDeps(): RuntimeServiceDeps {
+  return {
+    workspaceProbe: { probeWorkspace: async () => ({}) },
+    containerProbe: { probeContainer: async () => ({}) },
+    sessionProbe: { probeSession: async () => ({}) },
+    terminalLauncher: {
+      launchTerminal: async () => ({ result: 'attached' }) as any,
+    },
+  };
+}
+
+// ── Bridge wiring correctness ────────────────────────────────
+
+describe('headless → runtime-service bridge', () => {
+  describe('adapter identity pass-through', () => {
+    it('workspaceProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.workspaceProbe).toBe(deps.workspaceProbe);
+    });
+
+    it('containerProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.containerProbe).toBe(deps.containerProbe);
+    });
+
+    it('sessionProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.sessionProbe).toBe(deps.sessionProbe);
+    });
+
+    it('terminalLauncher adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.terminalLauncher).toBe(deps.terminalLauncher);
+    });
+  });
+
+  describe('facade immutability', () => {
+    it('composed object is frozen', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(Object.isFrozen(services)).toBe(true);
+    });
+
+    it('assigning to a property throws', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(() => {
+        (services as unknown as Record<string, unknown>).workspaceProbe = {};
+      }).toThrow();
+    });
+
+    it('deleting a property throws', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(() => {
+        delete (services as unknown as Record<string, unknown>).workspaceProbe;
+      }).toThrow();
+    });
+
+    it('adding a new property throws', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(() => {
+        (services as unknown as Record<string, unknown>).extra = true;
+      }).toThrow();
+    });
+  });
+
+  describe('facade shape', () => {
+    it('exposes exactly the four expected keys', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(Object.keys(services).sort()).toEqual([
+        'containerProbe',
+        'sessionProbe',
+        'terminalLauncher',
+        'workspaceProbe',
+      ]);
+    });
+
+    it('satisfies the RuntimeServices type contract', () => {
+      const services: RuntimeServices = composeHeadlessStartup(stubDeps());
+      expect(services.workspaceProbe.probeWorkspace).toBeTypeOf('function');
+      expect(services.containerProbe.probeContainer).toBeTypeOf('function');
+      expect(services.sessionProbe.probeSession).toBeTypeOf('function');
+      expect(services.terminalLauncher.launchTerminal).toBeTypeOf('function');
+    });
+  });
+
+  describe('owner-delegation parity with composeRuntimeServices', () => {
+    it('produces an equivalent facade to composeRuntimeServices', () => {
+      const deps = stubDeps();
+      const headless = composeHeadlessStartup(deps);
+      const main = composeRuntimeServices(deps);
+      // Same adapter references wired through both paths
+      expect(headless.workspaceProbe).toBe(main.workspaceProbe);
+      expect(headless.containerProbe).toBe(main.containerProbe);
+      expect(headless.sessionProbe).toBe(main.sessionProbe);
+      expect(headless.terminalLauncher).toBe(main.terminalLauncher);
+    });
+
+    it('both paths produce frozen facades', () => {
+      const deps = stubDeps();
+      expect(Object.isFrozen(composeHeadlessStartup(deps))).toBe(true);
+      expect(Object.isFrozen(composeRuntimeServices(deps))).toBe(true);
+    });
+
+    it('both paths expose the same keys', () => {
+      const deps = stubDeps();
+      const headlessKeys = Object.keys(composeHeadlessStartup(deps)).sort();
+      const mainKeys = Object.keys(composeRuntimeServices(deps)).sort();
+      expect(headlessKeys).toEqual(mainKeys);
+    });
+  });
+
+  describe('deterministic behavior', () => {
+    it('independent calls produce distinct facade objects', () => {
+      const s1 = composeHeadlessStartup(stubDeps());
+      const s2 = composeHeadlessStartup(stubDeps());
+      expect(s1).not.toBe(s2);
+    });
+
+    it('same deps produce facades with identical adapter references', () => {
+      const deps = stubDeps();
+      const s1 = composeHeadlessStartup(deps);
+      const s2 = composeHeadlessStartup(deps);
+      expect(s1.workspaceProbe).toBe(s2.workspaceProbe);
+      expect(s1.containerProbe).toBe(s2.containerProbe);
+      expect(s1.sessionProbe).toBe(s2.sessionProbe);
+      expect(s1.terminalLauncher).toBe(s2.terminalLauncher);
+    });
+
+    it('different deps produce facades with different adapter references', () => {
+      const s1 = composeHeadlessStartup(stubDeps());
+      const s2 = composeHeadlessStartup(stubDeps());
+      expect(s1.workspaceProbe).not.toBe(s2.workspaceProbe);
+      expect(s1.containerProbe).not.toBe(s2.containerProbe);
+    });
+  });
+
+  describe('adapter method delegation', () => {
+    it('probeWorkspace delegates through the composed facade', async () => {
+      const expected = { workspacePath: '/headless/workspace' };
+      const deps = stubDeps();
+      deps.workspaceProbe.probeWorkspace = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.workspaceProbe.probeWorkspace('task-h1');
+      expect(result).toBe(expected);
+    });
+
+    it('probeContainer delegates through the composed facade', async () => {
+      const expected = { containerId: 'ctr-headless' };
+      const deps = stubDeps();
+      deps.containerProbe.probeContainer = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.containerProbe.probeContainer('task-h1');
+      expect(result).toBe(expected);
+    });
+
+    it('probeSession delegates through the composed facade', async () => {
+      const expected = { agentName: 'headless-agent', sessionId: 's-h1' };
+      const deps = stubDeps();
+      deps.sessionProbe.probeSession = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.sessionProbe.probeSession('task-h1');
+      expect(result).toBe(expected);
+    });
+
+    it('launchTerminal delegates through the composed facade', async () => {
+      const expected = { result: 'attached' } as any;
+      const deps = stubDeps();
+      deps.terminalLauncher.launchTerminal = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.terminalLauncher.launchTerminal({
+        taskId: 'task-h1',
+        workspacePath: '/tmp/headless-ws',
+      });
+      expect(result).toBe(expected);
+    });
+  });
+});

--- a/packages/app/src/__tests__/main-runtime-bridge.test.ts
+++ b/packages/app/src/__tests__/main-runtime-bridge.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Regression tests for the main → runtime-service bridge.
+ *
+ * Verifies that app main startup correctly routes through
+ * `composeRuntimeServices` from `@invoker/runtime-service`, and that
+ * the resulting `RuntimeServices` facade behaves deterministically.
+ *
+ * Upstream: wf-1778055150679-2/wire-main-to-runtime-service (5b2cefa0)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  composeRuntimeServices,
+  type RuntimeServiceDeps,
+  type RuntimeServices,
+} from '@invoker/runtime-service';
+
+// ── Stub factories ───────────────────────────────────────────
+
+/** Minimal deps matching the adapter shape used in main.ts. */
+function stubDeps(): RuntimeServiceDeps {
+  return {
+    workspaceProbe: { probeWorkspace: async () => ({}) },
+    containerProbe: { probeContainer: async () => ({}) },
+    sessionProbe: { probeSession: async () => ({}) },
+    terminalLauncher: {
+      launchTerminal: async () => ({ result: 'attached' }) as any,
+    },
+  };
+}
+
+// ── Bridge wiring correctness ────────────────────────────────
+
+describe('main → runtime-service bridge', () => {
+  describe('adapter identity pass-through', () => {
+    it('workspaceProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.workspaceProbe).toBe(deps.workspaceProbe);
+    });
+
+    it('containerProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.containerProbe).toBe(deps.containerProbe);
+    });
+
+    it('sessionProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.sessionProbe).toBe(deps.sessionProbe);
+    });
+
+    it('terminalLauncher adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.terminalLauncher).toBe(deps.terminalLauncher);
+    });
+  });
+
+  describe('facade immutability', () => {
+    it('composed object is frozen', () => {
+      const services = composeRuntimeServices(stubDeps());
+      expect(Object.isFrozen(services)).toBe(true);
+    });
+
+    it('assigning to a property throws', () => {
+      const services = composeRuntimeServices(stubDeps());
+      expect(() => {
+        (services as unknown as Record<string, unknown>).workspaceProbe = {};
+      }).toThrow();
+    });
+
+    it('deleting a property throws', () => {
+      const services = composeRuntimeServices(stubDeps());
+      expect(() => {
+        delete (services as unknown as Record<string, unknown>).workspaceProbe;
+      }).toThrow();
+    });
+
+    it('adding a new property throws', () => {
+      const services = composeRuntimeServices(stubDeps());
+      expect(() => {
+        (services as unknown as Record<string, unknown>).extra = true;
+      }).toThrow();
+    });
+  });
+
+  describe('facade shape', () => {
+    it('exposes exactly the four expected keys', () => {
+      const services = composeRuntimeServices(stubDeps());
+      expect(Object.keys(services).sort()).toEqual([
+        'containerProbe',
+        'sessionProbe',
+        'terminalLauncher',
+        'workspaceProbe',
+      ]);
+    });
+
+    it('satisfies the RuntimeServices type contract', () => {
+      const services: RuntimeServices = composeRuntimeServices(stubDeps());
+      expect(services.workspaceProbe.probeWorkspace).toBeTypeOf('function');
+      expect(services.containerProbe.probeContainer).toBeTypeOf('function');
+      expect(services.sessionProbe.probeSession).toBeTypeOf('function');
+      expect(services.terminalLauncher.launchTerminal).toBeTypeOf('function');
+    });
+  });
+
+  describe('deterministic behavior', () => {
+    it('independent calls produce distinct facade objects', () => {
+      const s1 = composeRuntimeServices(stubDeps());
+      const s2 = composeRuntimeServices(stubDeps());
+      expect(s1).not.toBe(s2);
+    });
+
+    it('same deps produce facades with identical adapter references', () => {
+      const deps = stubDeps();
+      const s1 = composeRuntimeServices(deps);
+      const s2 = composeRuntimeServices(deps);
+      expect(s1.workspaceProbe).toBe(s2.workspaceProbe);
+      expect(s1.containerProbe).toBe(s2.containerProbe);
+      expect(s1.sessionProbe).toBe(s2.sessionProbe);
+      expect(s1.terminalLauncher).toBe(s2.terminalLauncher);
+    });
+
+    it('different deps produce facades with different adapter references', () => {
+      const s1 = composeRuntimeServices(stubDeps());
+      const s2 = composeRuntimeServices(stubDeps());
+      expect(s1.workspaceProbe).not.toBe(s2.workspaceProbe);
+      expect(s1.containerProbe).not.toBe(s2.containerProbe);
+    });
+  });
+
+  describe('adapter method delegation', () => {
+    it('probeWorkspace delegates through the composed facade', async () => {
+      const expected = { workspacePath: '/test/path' };
+      const deps = stubDeps();
+      deps.workspaceProbe.probeWorkspace = async () => expected;
+      const services = composeRuntimeServices(deps);
+      const result = await services.workspaceProbe.probeWorkspace('task-1');
+      expect(result).toBe(expected);
+    });
+
+    it('probeContainer delegates through the composed facade', async () => {
+      const expected = { containerId: 'ctr-abc' };
+      const deps = stubDeps();
+      deps.containerProbe.probeContainer = async () => expected;
+      const services = composeRuntimeServices(deps);
+      const result = await services.containerProbe.probeContainer('task-1');
+      expect(result).toBe(expected);
+    });
+
+    it('probeSession delegates through the composed facade', async () => {
+      const expected = { agentName: 'claude', sessionId: 's-123' };
+      const deps = stubDeps();
+      deps.sessionProbe.probeSession = async () => expected;
+      const services = composeRuntimeServices(deps);
+      const result = await services.sessionProbe.probeSession('task-1');
+      expect(result).toBe(expected);
+    });
+
+    it('launchTerminal delegates through the composed facade', async () => {
+      const expected = { result: 'attached' } as any;
+      const deps = stubDeps();
+      deps.terminalLauncher.launchTerminal = async () => expected;
+      const services = composeRuntimeServices(deps);
+      const result = await services.terminalLauncher.launchTerminal({
+        taskId: 'task-1',
+        workspacePath: '/tmp/ws',
+      });
+      expect(result).toBe(expected);
+    });
+  });
+});

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -56,6 +56,7 @@ import { resolveHeadlessTargetWorkflowId } from './headless-command-classificati
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
+import type { RuntimeServices } from '@invoker/runtime-service';
 
 export { bumpGenerationAndRecreate } from './workflow-actions.js';
 export {
@@ -100,6 +101,7 @@ export interface HeadlessDeps {
   isStandaloneOwnerIdle?: () => boolean;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
   installBundledSkills?: (mode?: BundledSkillsInstallMode) => BundledSkillsStatus;
+  runtimeServices?: RuntimeServices;
 }
 
 // ── ANSI Helpers ─────────────────────────────────────────────

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -68,7 +68,7 @@ import {
   SessionProbeAdapter,
   TerminalLauncherAdapter,
 } from '@invoker/runtime-adapters';
-import { composeRuntimeServices } from '@invoker/runtime-service';
+import { composeRuntimeServices, composeHeadlessStartup } from '@invoker/runtime-service';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import type { MessageBus } from '@invoker/transport';
 import {
@@ -398,12 +398,17 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     }
   }
   // Compose runtime services from persistence-backed adapters.
-  runtimeServices = composeRuntimeServices({
+  // Headless startup routes through composeHeadlessStartup so the
+  // headless path has an explicit composition entry point.
+  const runtimeServiceDeps = {
     workspaceProbe: new WorkspaceProbeAdapter(persistence),
     containerProbe: new ContainerProbeAdapter(persistence),
     sessionProbe: new SessionProbeAdapter(persistence),
     terminalLauncher: new TerminalLauncherAdapter(),
-  });
+  };
+  runtimeServices = isHeadless
+    ? composeHeadlessStartup(runtimeServiceDeps)
+    : composeRuntimeServices(runtimeServiceDeps);
 
   executorRegistry = new ExecutorRegistry();
   executorRegistry.register(
@@ -739,6 +744,7 @@ if (isHeadless) {
         executionAgentRegistry: agentRegistry,
         getBundledSkillsStatus,
         installBundledSkills: installPackagedSkills,
+        runtimeServices,
       };
 
       const createStandaloneTaskExecutor = (): TaskRunner => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -62,6 +62,14 @@ import { makeEnvelope } from '@invoker/contracts';
 import type { WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import { IpcBus, Channels } from '@invoker/transport';
+import {
+  WorkspaceProbeAdapter,
+  ContainerProbeAdapter,
+  SessionProbeAdapter,
+  TerminalLauncherAdapter,
+} from '@invoker/runtime-adapters';
+import { composeRuntimeServices } from '@invoker/runtime-service';
+import type { RuntimeServices } from '@invoker/runtime-service';
 import type { MessageBus } from '@invoker/transport';
 import {
   ExecutorRegistry, TaskRunner,
@@ -183,6 +191,7 @@ let persistence: SQLiteAdapter;
 let executorRegistry: ExecutorRegistry;
 let orchestrator: Orchestrator;
 let commandService: CommandService;
+let runtimeServices: RuntimeServices;
 let dispatcherTaskExecutor: Pick<TaskRunner, 'executeTasks'> | null = null;
 
 function setDispatcherTaskExecutor(executor: Pick<TaskRunner, 'executeTasks'> | null): void {
@@ -388,6 +397,14 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
       logger.info(`hourly snapshots enabled (interval=${hourlyMs}ms)`, { module: 'backup' });
     }
   }
+  // Compose runtime services from persistence-backed adapters.
+  runtimeServices = composeRuntimeServices({
+    workspaceProbe: new WorkspaceProbeAdapter(persistence),
+    containerProbe: new ContainerProbeAdapter(persistence),
+    sessionProbe: new SessionProbeAdapter(persistence),
+    terminalLauncher: new TerminalLauncherAdapter(),
+  });
+
   executorRegistry = new ExecutorRegistry();
   executorRegistry.register(
     'worktree',

--- a/packages/runtime-service/package.json
+++ b/packages/runtime-service/package.json
@@ -17,6 +17,9 @@
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },
+  "dependencies": {
+    "@invoker/runtime-domain": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^25.3.3",
     "tsup": "^8.0.0",

--- a/packages/runtime-service/src/__tests__/composition.test.ts
+++ b/packages/runtime-service/src/__tests__/composition.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  composeRuntimeServices,
+  type RuntimeServiceDeps,
+  type RuntimeServices,
+} from '../composition.js';
+import { AttachmentResult } from '@invoker/runtime-domain';
+
+function stubDeps(): RuntimeServiceDeps {
+  return {
+    workspaceProbe: { probeWorkspace: async () => ({}) },
+    containerProbe: { probeContainer: async () => ({}) },
+    sessionProbe: { probeSession: async () => ({}) },
+    terminalLauncher: {
+      launchTerminal: async () => ({ result: AttachmentResult.Attached }),
+    },
+  };
+}
+
+describe('composition shell', () => {
+  describe('composeRuntimeServices', () => {
+    it('passes through workspaceProbe unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.workspaceProbe).toBe(deps.workspaceProbe);
+    });
+
+    it('passes through containerProbe unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.containerProbe).toBe(deps.containerProbe);
+    });
+
+    it('passes through sessionProbe unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.sessionProbe).toBe(deps.sessionProbe);
+    });
+
+    it('passes through terminalLauncher unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.terminalLauncher).toBe(deps.terminalLauncher);
+    });
+
+    it('returns a frozen object that rejects mutation', () => {
+      const services = composeRuntimeServices(stubDeps());
+      expect(Object.isFrozen(services)).toBe(true);
+      expect(() => {
+        (services as unknown as Record<string, unknown>).workspaceProbe = {};
+      }).toThrow();
+    });
+
+    it('exposes exactly the four expected keys', () => {
+      const services = composeRuntimeServices(stubDeps());
+      const keys = Object.keys(services).sort();
+      expect(keys).toEqual([
+        'containerProbe',
+        'sessionProbe',
+        'terminalLauncher',
+        'workspaceProbe',
+      ]);
+    });
+
+    it('satisfies the RuntimeServices type contract', () => {
+      const services: RuntimeServices = composeRuntimeServices(stubDeps());
+      expect(services.workspaceProbe.probeWorkspace).toBeTypeOf('function');
+      expect(services.containerProbe.probeContainer).toBeTypeOf('function');
+      expect(services.sessionProbe.probeSession).toBeTypeOf('function');
+      expect(services.terminalLauncher.launchTerminal).toBeTypeOf('function');
+    });
+
+    it('produces independent instances per call', () => {
+      const deps1 = stubDeps();
+      const deps2 = stubDeps();
+      const s1 = composeRuntimeServices(deps1);
+      const s2 = composeRuntimeServices(deps2);
+      expect(s1).not.toBe(s2);
+      expect(s1.workspaceProbe).not.toBe(s2.workspaceProbe);
+    });
+  });
+});

--- a/packages/runtime-service/src/__tests__/index.test.ts
+++ b/packages/runtime-service/src/__tests__/index.test.ts
@@ -1,7 +1,32 @@
 import { describe, it, expect } from 'vitest';
+import { composeRuntimeServices } from '../index.js';
+import type { RuntimeServiceDeps, RuntimeServices } from '../index.js';
+import { AttachmentResult } from '@invoker/runtime-domain';
 
-describe('package structure', () => {
-  it('should export from index', () => {
-    expect(true).toBe(true);
+function stubDeps(): RuntimeServiceDeps {
+  return {
+    workspaceProbe: { probeWorkspace: async () => ({}) },
+    containerProbe: { probeContainer: async () => ({}) },
+    sessionProbe: { probeSession: async () => ({}) },
+    terminalLauncher: {
+      launchTerminal: async () => ({ result: AttachmentResult.Attached }),
+    },
+  };
+}
+
+describe('composeRuntimeServices', () => {
+  it('returns a RuntimeServices object with all ports', () => {
+    const deps = stubDeps();
+    const services: RuntimeServices = composeRuntimeServices(deps);
+
+    expect(services.workspaceProbe).toBe(deps.workspaceProbe);
+    expect(services.containerProbe).toBe(deps.containerProbe);
+    expect(services.sessionProbe).toBe(deps.sessionProbe);
+    expect(services.terminalLauncher).toBe(deps.terminalLauncher);
+  });
+
+  it('returns a frozen object', () => {
+    const services = composeRuntimeServices(stubDeps());
+    expect(Object.isFrozen(services)).toBe(true);
   });
 });

--- a/packages/runtime-service/src/composition.ts
+++ b/packages/runtime-service/src/composition.ts
@@ -52,3 +52,22 @@ export function composeRuntimeServices(
     terminalLauncher: deps.terminalLauncher,
   });
 }
+
+// ── Headless startup composition ──────────────────────────
+
+/**
+ * Compose runtime services for the headless startup path.
+ *
+ * Delegates to `composeRuntimeServices` with the same port contracts,
+ * making the headless entry point an explicit routing target rather
+ * than an implicit consumer of a module-level variable.
+ *
+ * Owner/delegation behavior is unaffected — this function only
+ * composes the runtime-domain ports; orchestration and task dispatch
+ * remain the caller's responsibility.
+ */
+export function composeHeadlessStartup(
+  deps: RuntimeServiceDeps,
+): RuntimeServices {
+  return composeRuntimeServices(deps);
+}

--- a/packages/runtime-service/src/composition.ts
+++ b/packages/runtime-service/src/composition.ts
@@ -1,0 +1,54 @@
+/**
+ * Runtime composition shell — a typed container that bundles runtime
+ * domain ports into a single `RuntimeServices` facade.
+ *
+ * Consumers call `composeRuntimeServices(deps)` with concrete adapter
+ * implementations; this module never instantiates adapters itself, so
+ * app wiring stays in the application layer.
+ */
+
+import type {
+  WorkspaceProbe,
+  ContainerProbe,
+  SessionProbe,
+  TerminalLauncher,
+} from '@invoker/runtime-domain';
+
+// ── Dependency slot ────────────────────────────────────────
+
+/** Ports that callers must supply to compose the runtime services. */
+export interface RuntimeServiceDeps {
+  workspaceProbe: WorkspaceProbe;
+  containerProbe: ContainerProbe;
+  sessionProbe: SessionProbe;
+  terminalLauncher: TerminalLauncher;
+}
+
+// ── Public facade ──────────────────────────────────────────
+
+/** Unified read-only view of the composed runtime services. */
+export interface RuntimeServices {
+  readonly workspaceProbe: WorkspaceProbe;
+  readonly containerProbe: ContainerProbe;
+  readonly sessionProbe: SessionProbe;
+  readonly terminalLauncher: TerminalLauncher;
+}
+
+// ── Factory ────────────────────────────────────────────────
+
+/**
+ * Compose runtime services from concrete port implementations.
+ *
+ * Returns a frozen `RuntimeServices` object. No adapter instantiation
+ * happens here — callers provide fully constructed adapters.
+ */
+export function composeRuntimeServices(
+  deps: RuntimeServiceDeps,
+): RuntimeServices {
+  return Object.freeze({
+    workspaceProbe: deps.workspaceProbe,
+    containerProbe: deps.containerProbe,
+    sessionProbe: deps.sessionProbe,
+    terminalLauncher: deps.terminalLauncher,
+  });
+}

--- a/packages/runtime-service/src/composition.ts
+++ b/packages/runtime-service/src/composition.ts
@@ -14,6 +14,16 @@ import type {
   TerminalLauncher,
 } from '@invoker/runtime-domain';
 
+// ── Dormant bridge hook ──────────────────────────────────────
+
+/**
+ * Callback invoked when the dormant runtime bridge is enabled.
+ * Receives the composed services for external wiring (e.g. IPC,
+ * message bus, or cross-process relay). The hook is a no-op slot:
+ * the bridge is dormant unless the caller explicitly opts in.
+ */
+export type DormantBridgeHook = (services: RuntimeServices) => void;
+
 // ── Dependency slot ────────────────────────────────────────
 
 /** Ports that callers must supply to compose the runtime services. */
@@ -22,6 +32,18 @@ export interface RuntimeServiceDeps {
   containerProbe: ContainerProbe;
   sessionProbe: SessionProbe;
   terminalLauncher: TerminalLauncher;
+
+  /**
+   * When `true`, the dormant bridge hook fires after composition.
+   * Defaults to `false` — active behavior is unchanged.
+   */
+  enableDormantBridge?: boolean;
+
+  /**
+   * Optional callback invoked only when `enableDormantBridge` is `true`.
+   * Ignored otherwise.
+   */
+  dormantBridgeHook?: DormantBridgeHook;
 }
 
 // ── Public facade ──────────────────────────────────────────
@@ -45,12 +67,18 @@ export interface RuntimeServices {
 export function composeRuntimeServices(
   deps: RuntimeServiceDeps,
 ): RuntimeServices {
-  return Object.freeze({
+  const services = Object.freeze({
     workspaceProbe: deps.workspaceProbe,
     containerProbe: deps.containerProbe,
     sessionProbe: deps.sessionProbe,
     terminalLauncher: deps.terminalLauncher,
   });
+
+  if (deps.enableDormantBridge === true && deps.dormantBridgeHook) {
+    deps.dormantBridgeHook(services);
+  }
+
+  return services;
 }
 
 // ── Headless startup composition ──────────────────────────

--- a/packages/runtime-service/src/index.ts
+++ b/packages/runtime-service/src/index.ts
@@ -2,6 +2,7 @@
 
 export {
   composeRuntimeServices,
+  composeHeadlessStartup,
   type RuntimeServiceDeps,
   type RuntimeServices,
 } from './composition.js';

--- a/packages/runtime-service/src/index.ts
+++ b/packages/runtime-service/src/index.ts
@@ -1,1 +1,7 @@
 // @invoker/runtime-service - Runtime application services and use cases
+
+export {
+  composeRuntimeServices,
+  type RuntimeServiceDeps,
+  type RuntimeServices,
+} from './composition.js';

--- a/packages/svc-api/package.json
+++ b/packages/svc-api/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@invoker/svc-api",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "require": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.3",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/svc-api/src/__tests__/runtime-bridge-dormant.test.ts
+++ b/packages/svc-api/src/__tests__/runtime-bridge-dormant.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Server } from 'node:http';
+import { startServer } from '../server.js';
+
+/** Close a server, ignoring errors if already closed. */
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+describe('dormant bridge guard — startServer', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await closeServer(server);
+      server = undefined;
+    }
+  });
+
+  it('does not invoke the hook when enableDormantBridge is omitted', async () => {
+    const hook = vi.fn();
+    server = await startServer({ port: 0, host: '127.0.0.1', dormantBridgeHook: hook });
+
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke the hook when enableDormantBridge is false', async () => {
+    const hook = vi.fn();
+    server = await startServer({
+      port: 0,
+      host: '127.0.0.1',
+      enableDormantBridge: false,
+      dormantBridgeHook: hook,
+    });
+
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when enableDormantBridge is true but no hook is provided', async () => {
+    server = await startServer({ port: 0, host: '127.0.0.1', enableDormantBridge: true });
+
+    const addr = server.address();
+    expect(addr).not.toBeNull();
+  });
+
+  it('invokes the hook with the server when explicitly opted in', async () => {
+    const hook = vi.fn();
+    server = await startServer({
+      port: 0,
+      host: '127.0.0.1',
+      enableDormantBridge: true,
+      dormantBridgeHook: hook,
+    });
+
+    expect(hook).toHaveBeenCalledTimes(1);
+    expect(hook).toHaveBeenCalledWith(server);
+  });
+
+  it('does not alter active /health behavior when bridge is enabled', async () => {
+    const hook = vi.fn();
+    server = await startServer({
+      port: 0,
+      host: '127.0.0.1',
+      enableDormantBridge: true,
+      dormantBridgeHook: hook,
+    });
+
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('not listening');
+
+    const res = await fetch(`http://127.0.0.1:${addr.port}/health`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok' });
+  });
+});

--- a/packages/svc-api/src/__tests__/server-endpoints.test.ts
+++ b/packages/svc-api/src/__tests__/server-endpoints.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Server } from 'node:http';
+import { request } from 'node:http';
+import { createApiServer } from '../server.js';
+
+/** Send an HTTP request to a running server and return { statusCode, headers, body }. */
+function httpRequest(
+  server: Server,
+  path: string,
+  method = 'GET',
+): Promise<{ statusCode: number; headers: Record<string, string | string[] | undefined>; body: string }> {
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') {
+    throw new Error('server not listening on a TCP address');
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = request(
+      { hostname: '127.0.0.1', port: addr.port, method, path },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('endpoint contracts', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    server = createApiServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  describe('GET /health', () => {
+    it('returns 200 with { status: "ok" }', async () => {
+      const { statusCode, headers, body } = await httpRequest(server, '/health');
+
+      expect(statusCode).toBe(200);
+      expect(headers['content-type']).toBe('application/json');
+      expect(JSON.parse(body)).toEqual({ status: 'ok' });
+    });
+  });
+
+  describe('GET /hello', () => {
+    it('returns 200 with { message: "hello" }', async () => {
+      const { statusCode, headers, body } = await httpRequest(server, '/hello');
+
+      expect(statusCode).toBe(200);
+      expect(headers['content-type']).toBe('application/json');
+      expect(JSON.parse(body)).toEqual({ message: 'hello' });
+    });
+  });
+
+  describe('method not allowed', () => {
+    it('returns 405 for POST /health', async () => {
+      const { statusCode, headers, body } = await httpRequest(server, '/health', 'POST');
+
+      expect(statusCode).toBe(405);
+      expect(headers['content-type']).toBe('application/json');
+      expect(JSON.parse(body)).toEqual({ error: 'Method Not Allowed' });
+    });
+
+    it('returns 405 for POST /hello', async () => {
+      const { statusCode, headers, body } = await httpRequest(server, '/hello', 'POST');
+
+      expect(statusCode).toBe(405);
+      expect(headers['content-type']).toBe('application/json');
+      expect(JSON.parse(body)).toEqual({ error: 'Method Not Allowed' });
+    });
+  });
+
+  describe('unknown path', () => {
+    it('returns 404 for GET /unknown', async () => {
+      const { statusCode, headers, body } = await httpRequest(server, '/unknown');
+
+      expect(statusCode).toBe(404);
+      expect(headers['content-type']).toBe('application/json');
+      expect(JSON.parse(body)).toEqual({ error: 'Not Found' });
+    });
+  });
+});

--- a/packages/svc-api/src/__tests__/server-scaffold.test.ts
+++ b/packages/svc-api/src/__tests__/server-scaffold.test.ts
@@ -4,7 +4,7 @@ import { request } from 'node:http';
 import { createApiServer, startServer } from '../server.js';
 
 /** Send a GET request to a running server and return { statusCode, body }. */
-function httpGet(server: Server): Promise<{ statusCode: number; body: string }> {
+function httpGet(server: Server, path = '/health'): Promise<{ statusCode: number; body: string }> {
   const addr = server.address();
   if (!addr || typeof addr === 'string') {
     throw new Error('server not listening on a TCP address');
@@ -12,7 +12,7 @@ function httpGet(server: Server): Promise<{ statusCode: number; body: string }> 
 
   return new Promise((resolve, reject) => {
     const req = request(
-      { hostname: '127.0.0.1', port: addr.port, method: 'GET', path: '/' },
+      { hostname: '127.0.0.1', port: addr.port, method: 'GET', path },
       (res) => {
         const chunks: Buffer[] = [];
         res.on('data', (chunk) => chunks.push(chunk));

--- a/packages/svc-api/src/__tests__/server-scaffold.test.ts
+++ b/packages/svc-api/src/__tests__/server-scaffold.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import type { Server } from 'node:http';
+import { request } from 'node:http';
+import { createApiServer, startServer } from '../server.js';
+
+/** Send a GET request to a running server and return { statusCode, body }. */
+function httpGet(server: Server): Promise<{ statusCode: number; body: string }> {
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') {
+    throw new Error('server not listening on a TCP address');
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = request(
+      { hostname: '127.0.0.1', port: addr.port, method: 'GET', path: '/' },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/** Close a server, ignoring errors if already closed. */
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+describe('createApiServer', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await closeServer(server);
+      server = undefined;
+    }
+  });
+
+  it('returns an http.Server instance', () => {
+    server = createApiServer();
+    expect(server).toBeDefined();
+    expect(typeof server.listen).toBe('function');
+    expect(typeof server.close).toBe('function');
+  });
+
+  it('uses the default handler that returns { status: "ok" }', async () => {
+    server = createApiServer();
+
+    await new Promise<void>((resolve) => {
+      server!.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    const { statusCode, body } = await httpGet(server);
+    expect(statusCode).toBe(200);
+    expect(JSON.parse(body)).toEqual({ status: 'ok' });
+  });
+
+  it('accepts a custom handler', async () => {
+    server = createApiServer((_req, res) => {
+      res.writeHead(201, { 'Content-Type': 'text/plain' });
+      res.end('custom');
+    });
+
+    await new Promise<void>((resolve) => {
+      server!.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    const { statusCode, body } = await httpGet(server);
+    expect(statusCode).toBe(201);
+    expect(body).toBe('custom');
+  });
+});
+
+describe('startServer', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await closeServer(server);
+      server = undefined;
+    }
+  });
+
+  it('resolves with a listening server on the requested port', async () => {
+    server = await startServer({ port: 0, host: '127.0.0.1' });
+    const addr = server.address();
+
+    expect(addr).not.toBeNull();
+    expect(typeof addr).toBe('object');
+    if (typeof addr === 'object' && addr) {
+      expect(addr.port).toBeGreaterThan(0);
+    }
+  });
+
+  it('serves responses through the default handler after start', async () => {
+    server = await startServer({ port: 0, host: '127.0.0.1' });
+    const { statusCode, body } = await httpGet(server);
+
+    expect(statusCode).toBe(200);
+    expect(JSON.parse(body)).toEqual({ status: 'ok' });
+  });
+
+  it('serves responses through a custom handler when provided', async () => {
+    server = await startServer({ port: 0, host: '127.0.0.1' }, (_req, res) => {
+      res.writeHead(418, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ tea: 'pot' }));
+    });
+
+    const { statusCode, body } = await httpGet(server);
+    expect(statusCode).toBe(418);
+    expect(JSON.parse(body)).toEqual({ tea: 'pot' });
+  });
+
+  it('defaults host to 0.0.0.0 when omitted', async () => {
+    server = await startServer({ port: 0 });
+    const addr = server.address();
+
+    expect(addr).not.toBeNull();
+    if (typeof addr === 'object' && addr) {
+      expect(addr.address).toBe('0.0.0.0');
+    }
+  });
+});

--- a/packages/svc-api/src/index.ts
+++ b/packages/svc-api/src/index.ts
@@ -2,6 +2,7 @@
 
 export {
   createApiServer,
+  defaultHandler,
   startServer,
   type RequestHandler,
   type ServerOptions,

--- a/packages/svc-api/src/index.ts
+++ b/packages/svc-api/src/index.ts
@@ -1,0 +1,8 @@
+// @invoker/svc-api - HTTP API service scaffold
+
+export {
+  createApiServer,
+  startServer,
+  type RequestHandler,
+  type ServerOptions,
+} from './server.js';

--- a/packages/svc-api/src/server.ts
+++ b/packages/svc-api/src/server.ts
@@ -1,0 +1,37 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+
+export interface ServerOptions {
+  port: number;
+  host?: string;
+}
+
+export type RequestHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+) => void;
+
+const defaultHandler: RequestHandler = (_req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ status: 'ok' }));
+};
+
+export function createApiServer(
+  handler: RequestHandler = defaultHandler,
+): ReturnType<typeof createServer> {
+  return createServer(handler);
+}
+
+export function startServer(
+  options: ServerOptions,
+  handler?: RequestHandler,
+): Promise<ReturnType<typeof createServer>> {
+  const server = createApiServer(handler);
+  const { port, host = '0.0.0.0' } = options;
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => {
+      resolve(server);
+    });
+  });
+}

--- a/packages/svc-api/src/server.ts
+++ b/packages/svc-api/src/server.ts
@@ -10,9 +10,31 @@ export type RequestHandler = (
   res: ServerResponse,
 ) => void;
 
-const defaultHandler: RequestHandler = (_req, res) => {
-  res.writeHead(200, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify({ status: 'ok' }));
+function sendJson(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+export const defaultHandler: RequestHandler = (req, res) => {
+  const method = req.method ?? '';
+  const url = req.url ?? '/';
+
+  if (method !== 'GET') {
+    sendJson(res, 405, { error: 'Method Not Allowed' });
+    return;
+  }
+
+  if (url === '/health') {
+    sendJson(res, 200, { status: 'ok' });
+    return;
+  }
+
+  if (url === '/hello') {
+    sendJson(res, 200, { message: 'hello' });
+    return;
+  }
+
+  sendJson(res, 404, { error: 'Not Found' });
 };
 
 export function createApiServer(

--- a/packages/svc-api/src/server.ts
+++ b/packages/svc-api/src/server.ts
@@ -3,6 +3,20 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 export interface ServerOptions {
   port: number;
   host?: string;
+
+  /**
+   * When `true`, the dormant bridge hook fires after the server starts
+   * listening. Defaults to `false` — active behavior is unchanged.
+   */
+  enableDormantBridge?: boolean;
+
+  /**
+   * Optional callback invoked only when `enableDormantBridge` is `true`.
+   * Receives the running server instance for external wiring (e.g.
+   * attaching a runtime service bridge or cross-process relay).
+   * Ignored when `enableDormantBridge` is not `true`.
+   */
+  dormantBridgeHook?: (server: ReturnType<typeof createServer>) => void;
 }
 
 export type RequestHandler = (
@@ -53,6 +67,9 @@ export function startServer(
   return new Promise((resolve, reject) => {
     server.once('error', reject);
     server.listen(port, host, () => {
+      if (options.enableDormantBridge === true && options.dormantBridgeHook) {
+        options.dormantBridgeHook(server);
+      }
       resolve(server);
     });
   });

--- a/packages/svc-api/tsconfig.json
+++ b/packages/svc-api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/svc-api/vitest.config.ts
+++ b/packages/svc-api/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import sharedConfig from '../../vitest.shared.ts';
+
+export default mergeConfig(sharedConfig, defineConfig({
+  test: {
+    exclude: ['node_modules/**', 'dist/**'],
+  },
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,12 @@ importers:
       '@invoker/execution-engine':
         specifier: workspace:*
         version: link:../execution-engine
+      '@invoker/runtime-adapters':
+        specifier: workspace:*
+        version: link:../runtime-adapters
+      '@invoker/runtime-service':
+        specifier: workspace:*
+        version: link:../runtime-service
       '@invoker/surfaces':
         specifier: workspace:*
         version: link:../surfaces

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,10 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
   packages/runtime-service:
+    dependencies:
+      '@invoker/runtime-domain':
+        specifier: workspace:*
+        version: link:../runtime-domain
     devDependencies:
       '@types/node':
         specifier: ^25.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,21 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
+  packages/svc-api:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.3
+        version: 25.3.3
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
+
   packages/test-kit:
     dependencies:
       '@invoker/contracts':


### PR DESCRIPTION
## Summary

Adds dormant runtime-service to svc-api bridge hooks without changing defaults.

## Architecture

### Before

```mermaid
graph TD
    SvcApi[svc-api server] --> Active[Active hello/health flow]
    Active --> Runtime[Runtime service]
```

### After

```mermaid
graph TD
    SvcApi --> Active
    Active --> Runtime
    Bridge[Dormant runtime bridge hook] -. disabled by default .-> Runtime
```

## Test Plan

- [ ] runtime-service and svc-api tests pass with exit code 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #250