### PR TITLE
chore: add retention pruning for mutation history

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1506,7 +1506,7 @@ describe('headless delegation enforcement', () => {
         // Owner registers handler that accepts mutations
         const ownerHandler = vi.fn(async () => {
           // Owner has writable persistence and can execute
-          return { success: true, workflowId: 'wf-test' };
+          return { ok: true };
         });
         mockDeps.messageBus.onRequest('headless.exec', ownerHandler);
 
@@ -1529,7 +1529,7 @@ describe('headless delegation enforcement', () => {
 
       it('delegates all mutation commands deterministically', async () => {
         (mockDeps.persistence as any).readOnly = true;
-        const ownerHandler = vi.fn(async () => ({ success: true }));
+        const ownerHandler = vi.fn(async () => ({ ok: true }));
         mockDeps.messageBus.onRequest('headless.exec', ownerHandler);
 
         const { tryDelegateExec } = await import('../headless.js');

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1514,13 +1514,13 @@ describe('headless delegation enforcement', () => {
         const { tryDelegateExec } = await import('../headless.js');
 
         // Headless delegates mutation to owner
-        const delegated = await tryDelegateExec(
+        const outcome = await tryDelegateExec(
           ['run', '/path/to/plan.yaml'],
           mockDeps.messageBus
         );
 
-        // Verify delegation succeeded
-        expect(delegated).toBe(true);
+        // Verify delegation succeeded — outcome is a DelegationOutcome union
+        expect(outcome.kind).toBe('delegated');
         expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
           args: ['run', '/path/to/plan.yaml'],
           waitForApproval: undefined,
@@ -1543,8 +1543,8 @@ describe('headless delegation enforcement', () => {
         ];
 
         for (const cmd of mutationCommands) {
-          const delegated = await tryDelegateExec(cmd, mockDeps.messageBus);
-          expect(delegated).toBe(true);
+          const outcome = await tryDelegateExec(cmd, mockDeps.messageBus);
+          expect(outcome.kind).toBe('delegated');
         }
 
         expect(ownerHandler).toHaveBeenCalledTimes(mutationCommands.length);

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -94,9 +94,9 @@ describe('headless→owner delegation', () => {
   describe('successful delegation when owner is present', () => {
     it('delegates mutation command to owner via RPC', async () => {
       // Simulate owner process registering a handler
-      const ownerHandler = vi.fn(async (req: { args: string[] }) => {
+      const ownerHandler = vi.fn(async (_req: { args: string[] }) => {
         // Owner successfully executed the command
-        return { success: true, workflowId: 'wf-test' };
+        return { ok: true };
       });
 
       messageBus.onRequest('headless.exec', ownerHandler);
@@ -114,7 +114,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates with waitForApproval flag', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       await tryDelegateExec(['approve', 'task-1'], messageBus, true);
@@ -126,7 +126,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates retry-task command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(['retry-task', 'wf-1/task-1'], messageBus);
@@ -139,7 +139,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates resume command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(['resume', 'wf-1'], messageBus);
@@ -152,7 +152,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates approve command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
@@ -165,7 +165,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates reject command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(['reject', 'wf-1/task-1', 'reason text'], messageBus);
@@ -178,7 +178,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates set command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(
@@ -194,7 +194,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates set prompt to owner (prompt-edit bridge)', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(
@@ -210,7 +210,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates rebase with noTrack so owner can return before workflow settlement', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(
@@ -229,7 +229,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates recreate-with-rebase command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(
@@ -359,7 +359,7 @@ describe('headless→owner delegation', () => {
 
   describe('deterministic delegation behavior', () => {
     it('always delegates when owner is available (no race conditions)', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       // Run multiple delegations in sequence
@@ -431,6 +431,111 @@ describe('headless→owner delegation', () => {
       expect(outcome.kind).toBe('delegated');
       if (outcome.kind === 'delegated') {
         expect(outcome.workflowId).toBe('wf-existing');
+        expect(outcome.tasks).toHaveLength(1);
+      }
+    });
+  });
+
+  describe('protocol-error on malformed owner responses', () => {
+    it('returns protocol-error when owner returns null', async () => {
+      messageBus.onRequest('headless.exec', async () => null);
+
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('null');
+      }
+    });
+
+    it('returns protocol-error when owner returns a string', async () => {
+      messageBus.onRequest('headless.exec', async () => 'unexpected-string');
+
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('string');
+      }
+    });
+
+    it('returns protocol-error when owner returns a number', async () => {
+      messageBus.onRequest('headless.exec', async () => 42);
+
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('number');
+      }
+    });
+
+    it('returns protocol-error when response has workflowId but tasks is not an array', async () => {
+      messageBus.onRequest('headless.run', async () => ({
+        workflowId: 'wf-test',
+        tasks: 'not-an-array',
+      }));
+
+      const outcome = await tryDelegateRun('/plan.yaml', messageBus, false, true);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('tasks');
+        expect(outcome.message).toContain('expected array');
+      }
+    });
+
+    it('returns protocol-error when response has workflowId but tasks is missing', async () => {
+      messageBus.onRequest('headless.run', async () => ({
+        workflowId: 'wf-test',
+      }));
+
+      const outcome = await tryDelegateRun('/plan.yaml', messageBus, false, true);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('tasks');
+      }
+    });
+
+    it('returns protocol-error when response has neither workflowId nor ok', async () => {
+      messageBus.onRequest('headless.exec', async () => ({
+        success: true,
+        someOtherField: 123,
+      }));
+
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('neither workflowId');
+        expect(outcome.message).toContain('ok');
+      }
+    });
+
+    it('returns protocol-error when workflowId is a number instead of string', async () => {
+      messageBus.onRequest('headless.run', async () => ({
+        workflowId: 12345,
+        tasks: [],
+      }));
+
+      const outcome = await tryDelegateRun('/plan.yaml', messageBus, false, true);
+      // workflowId is not a string, so it doesn't match the workflow shape.
+      // And ok is not true, so it fails the fallback check too.
+      expect(outcome.kind).toBe('protocol-error');
+    });
+
+    it('accepts valid { ok: true } response as delegated', async () => {
+      messageBus.onRequest('headless.exec', async () => ({ ok: true }));
+
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      expect(outcome.kind).toBe('delegated');
+    });
+
+    it('accepts valid workflow response as delegated', async () => {
+      messageBus.onRequest('headless.run', async () => ({
+        workflowId: 'wf-valid',
+        tasks: [{ id: 'wf-valid/t1', status: 'running' }],
+      }));
+
+      const outcome = await tryDelegateRun('/plan.yaml', messageBus, false, true);
+      expect(outcome.kind).toBe('delegated');
+      if (outcome.kind === 'delegated') {
+        expect(outcome.workflowId).toBe('wf-valid');
         expect(outcome.tasks).toHaveLength(1);
       }
     });

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -102,10 +102,10 @@ describe('headless→owner delegation', () => {
       messageBus.onRequest('headless.exec', ownerHandler);
 
       // Headless process attempts to delegate
-      const delegated = await tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus);
+      const outcome = await tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus);
 
       // Verify delegation succeeded
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['run', '/path/to/plan.yaml'],
         noTrack: undefined,
@@ -129,9 +129,9 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(['retry-task', 'wf-1/task-1'], messageBus);
+      const outcome = await tryDelegateExec(['retry-task', 'wf-1/task-1'], messageBus);
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['retry-task', 'wf-1/task-1'],
         waitForApproval: undefined,
@@ -142,9 +142,9 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(['resume', 'wf-1'], messageBus);
+      const outcome = await tryDelegateExec(['resume', 'wf-1'], messageBus);
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['resume', 'wf-1'],
         waitForApproval: undefined,
@@ -155,9 +155,9 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['approve', 'wf-1/task-1'],
         waitForApproval: undefined,
@@ -168,9 +168,9 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(['reject', 'wf-1/task-1', 'reason text'], messageBus);
+      const outcome = await tryDelegateExec(['reject', 'wf-1/task-1', 'reason text'], messageBus);
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['reject', 'wf-1/task-1', 'reason text'],
         waitForApproval: undefined,
@@ -181,12 +181,12 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(
+      const outcome = await tryDelegateExec(
         ['set', 'command', 'wf-1/task-1', 'new command'],
         messageBus,
       );
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['set', 'command', 'wf-1/task-1', 'new command'],
         waitForApproval: undefined,
@@ -197,12 +197,12 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(
+      const outcome = await tryDelegateExec(
         ['set', 'prompt', 'wf-1/task-1', 'updated prompt text'],
         messageBus,
       );
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['set', 'prompt', 'wf-1/task-1', 'updated prompt text'],
         waitForApproval: undefined,
@@ -213,14 +213,14 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(
+      const outcome = await tryDelegateExec(
         ['rebase', 'wf-1/task-1'],
         messageBus,
         undefined,
         true,
       );
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['rebase', 'wf-1/task-1'],
         noTrack: true,
@@ -232,14 +232,14 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(
+      const outcome = await tryDelegateExec(
         ['recreate-with-rebase', 'wf-1'],
         messageBus,
         undefined,
         true,
       );
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['recreate-with-rebase', 'wf-1'],
         noTrack: true,
@@ -249,15 +249,15 @@ describe('headless→owner delegation', () => {
   });
 
   describe('fallback to standalone when owner is unavailable', () => {
-    it('returns false when no owner handler is registered', async () => {
+    it('returns no-handler outcome when no owner handler is registered', async () => {
       // No handler registered — no owner present
-      const delegated = await tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus);
+      const outcome = await tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus);
 
       // Should fall back to standalone mode
-      expect(delegated).toBe(false);
+      expect(outcome.kind).toBe('no-handler');
     });
 
-    it('returns false when delegation times out (owner unresponsive)', async () => {
+    it('returns timeout outcome when delegation times out (owner unresponsive)', async () => {
       vi.useFakeTimers();
       messageBus.onRequest('headless.exec', async () => new Promise(() => {}));
 
@@ -268,7 +268,8 @@ describe('headless→owner delegation', () => {
       expect(tracked.settled).toBe(false);
 
       await vi.advanceTimersByTimeAsync(1);
-      await expect(delegatedPromise).resolves.toBe(false);
+      const outcome = await delegatedPromise;
+      expect(outcome.kind).toBe('timeout');
     });
   });
 
@@ -300,7 +301,8 @@ describe('headless→owner delegation', () => {
       expect(tracked.settled).toBe(false);
 
       await vi.advanceTimersByTimeAsync(1);
-      await expect(delegatedPromise).resolves.toBe(false);
+      const outcome = await delegatedPromise;
+      expect(outcome.kind).toBe('timeout');
     });
 
     it.each([
@@ -320,7 +322,8 @@ describe('headless→owner delegation', () => {
       expect(tracked.settled).toBe(false);
 
       await vi.advanceTimersByTimeAsync(1);
-      await expect(delegatedPromise).resolves.toBe(false);
+      const outcome = await delegatedPromise;
+      expect(outcome.kind).toBe('timeout');
     });
   });
 
@@ -338,16 +341,16 @@ describe('headless→owner delegation', () => {
     });
 
     it('distinguishes between "no owner" and "owner error"', async () => {
-      // No handler = no owner (should return false)
+      // No handler = no owner (should return no-handler outcome)
       const noOwner = await tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus);
-      expect(noOwner).toBe(false);
+      expect(noOwner.kind).toBe('no-handler');
 
       // Handler registered = owner present
       messageBus.onRequest('headless.exec', async () => {
         throw new Error('Owner error');
       });
 
-      // Owner error should throw, not return false
+      // Owner error should throw, not return a non-delegated outcome
       await expect(tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus)).rejects.toThrow(
         'Owner error',
       );
@@ -361,8 +364,8 @@ describe('headless→owner delegation', () => {
 
       // Run multiple delegations in sequence
       for (let i = 0; i < 5; i++) {
-        const delegated = await tryDelegateExec(['approve', `task-${i}`], messageBus);
-        expect(delegated).toBe(true);
+        const outcome = await tryDelegateExec(['approve', `task-${i}`], messageBus);
+        expect(outcome.kind).toBe('delegated');
       }
 
       expect(ownerHandler).toHaveBeenCalledTimes(5);
@@ -371,8 +374,8 @@ describe('headless→owner delegation', () => {
     it('always falls back when owner is unavailable (no race conditions)', async () => {
       // Run multiple attempts with no owner
       for (let i = 0; i < 5; i++) {
-        const delegated = await tryDelegateExec(['approve', `task-${i}`], messageBus);
-        expect(delegated).toBe(false);
+        const outcome = await tryDelegateExec(['approve', `task-${i}`], messageBus);
+        expect(outcome.kind).toBe('no-handler');
       }
     });
   });
@@ -394,8 +397,12 @@ describe('headless→owner delegation', () => {
 
       // With noTrack=true, delegation returns after receiving the response
       // without waiting for task settlement.
-      const delegated = await tryDelegateRun('/path/to/plan.yaml', messageBus, false, true);
-      expect(delegated).toBe(true);
+      const outcome = await tryDelegateRun('/path/to/plan.yaml', messageBus, false, true);
+      expect(outcome.kind).toBe('delegated');
+      if (outcome.kind === 'delegated') {
+        expect(outcome.workflowId).toBe('wf-test-123');
+        expect(outcome.tasks).toHaveLength(1);
+      }
     });
 
     it('times out when owner handler blocks on task execution (pre-fix behavior)', async () => {
@@ -404,9 +411,9 @@ describe('headless→owner delegation', () => {
         return new Promise(() => {}); // Never resolves — simulates await executeTasks()
       });
 
-      const delegated = await tryDelegateRun('/path/to/plan.yaml', messageBus, false, true);
+      const outcome = await tryDelegateRun('/path/to/plan.yaml', messageBus, false, true);
       // Delegation fails because the 5s timeout fires before the handler responds
-      expect(delegated).toBe(false);
+      expect(outcome.kind).toBe('timeout');
     }, 10_000);
 
     it('resume handler returns immediately with fire-and-forget execution', async () => {
@@ -420,8 +427,12 @@ describe('headless→owner delegation', () => {
         };
       });
 
-      const delegated = await tryDelegateResume('wf-existing', messageBus, false, true);
-      expect(delegated).toBe(true);
+      const outcome = await tryDelegateResume('wf-existing', messageBus, false, true);
+      expect(outcome.kind).toBe('delegated');
+      if (outcome.kind === 'delegated') {
+        expect(outcome.workflowId).toBe('wf-existing');
+        expect(outcome.tasks).toHaveLength(1);
+      }
     });
   });
 });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -36,6 +36,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import type { Logger } from '@invoker/contracts';
+import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { ExecutorRegistry, TaskRunner } from '@invoker/execution-engine';
@@ -132,6 +133,19 @@ function serializeTask(task: any): any {
   return obj;
 }
 
+/** Map OrchestratorError codes to HTTP status codes. Falls back to 400. */
+const notFoundCodes: ReadonlySet<string> = new Set([
+  OrchestratorErrorCode.TASK_NOT_FOUND,
+  OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
+]);
+
+function httpStatusForError(err: unknown): number {
+  if (err instanceof OrchestratorError && notFoundCodes.has(err.code)) return 404;
+  // Fallback for errors not yet migrated to OrchestratorError.
+  if (err instanceof Error && err.message.includes('not found')) return 404;
+  return 400;
+}
+
 export function startApiServer(deps: ApiServerDeps): ApiServer {
   const {
     logger: apiLogger,
@@ -206,8 +220,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           json(res, 200, { ok: true, ...result });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          const statusCode = message.includes('not found') ? 404 : 400;
-          json(res, statusCode, { error: message });
+          json(res, httpStatusForError(err), { error: message });
         }
         return;
       }
@@ -467,8 +480,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          const statusCode = message.includes('not found') ? 404 : 400;
-          json(res, statusCode, { error: message });
+          json(res, httpStatusForError(err), { error: message });
         }
         return;
       }
@@ -495,8 +507,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          const statusCode = message.includes('not found') ? 404 : 400;
-          json(res, statusCode, { error: message });
+          json(res, httpStatusForError(err), { error: message });
         }
         return;
       }
@@ -518,8 +529,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           json(res, 200, { ok: true, ...result });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          const statusCode = message.includes('not found') ? 404 : 400;
-          json(res, statusCode, { error: message });
+          json(res, httpStatusForError(err), { error: message });
         }
         return;
       }

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -7,6 +7,7 @@ import type { MessageBus } from '@invoker/transport';
 import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { isHeadlessMutatingCommand } from './headless-command-classification.js';
 import {
+  isDelegated,
   resolveDelegationTimeoutMs,
   tryDelegateExec,
   tryDelegateQuery,
@@ -116,14 +117,14 @@ async function delegateMutation(
   if (command === 'run') {
     const planPath = args[1];
     if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-    return tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs);
+    return isDelegated(await tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs));
   }
   if (command === 'resume') {
     const workflowId = args[1];
     if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-    return tryDelegateResume(workflowId, bus, waitForApproval, noTrack, timeoutMs);
+    return isDelegated(await tryDelegateResume(workflowId, bus, waitForApproval, noTrack, timeoutMs));
   }
-  return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
+  return isDelegated(await tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs));
 }
 
 async function delegateReadOnlyQuery(

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -22,7 +22,8 @@ type DelegateTrackingOptions = {
 export type DelegationOutcome =
   | { kind: 'delegated'; workflowId?: string; tasks?: TaskState[] }
   | { kind: 'timeout' }
-  | { kind: 'no-handler' };
+  | { kind: 'no-handler' }
+  | { kind: 'protocol-error'; message: string };
 
 /** Type guard: returns true when the delegation was accepted by the owner. */
 export function isDelegated(outcome: DelegationOutcome): outcome is DelegationOutcome & { kind: 'delegated' } {
@@ -222,14 +223,14 @@ async function tryDelegate(
     timeoutHandle.unref?.();
   });
 
-  let response: { workflowId: string; tasks: TaskState[] } | { ok: true };
+  let raw: unknown;
   try {
     const startedAt = Date.now();
     delegationLog(`${traceId} send channel=${channel} timeoutMs=${options.timeoutMs ?? 5_000}`);
-    response = await Promise.race([
-      messageBus.request<typeof payload, typeof response>(channel, payload),
+    raw = await Promise.race([
+      messageBus.request(channel, payload),
       timeoutPromise,
-    ]) as { workflowId: string; tasks: TaskState[] } | { ok: true };
+    ]);
     delegationLog(`${traceId} response channel=${channel} elapsedMs=${Date.now() - startedAt}`);
   } catch (err) {
     if (err === DELEGATION_TIMEOUT) {
@@ -246,15 +247,44 @@ async function tryDelegate(
     if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
-  if ('workflowId' in response) {
-    targetWorkflowId = response.workflowId;
+  // ── Response-shape validation ──────────────────────────────────────────
+  // Owner handlers return one of two shapes:
+  //   1. { workflowId: string; tasks: TaskState[] }  — workflow-creating commands
+  //   2. { ok: true, ... }                           — mutation commands
+  // Anything else is a protocol violation.
+  if (raw == null || typeof raw !== 'object') {
+    const msg = `expected object response, got ${raw === null ? 'null' : typeof raw}`;
+    delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
+    return { kind: 'protocol-error', message: msg };
+  }
+
+  const response = raw as Record<string, unknown>;
+
+  const hasWorkflowId = 'workflowId' in response && typeof response.workflowId === 'string';
+  const hasOk = 'ok' in response && response.ok === true;
+
+  if (hasWorkflowId) {
+    if (!Array.isArray(response.tasks)) {
+      const msg = `response has workflowId but tasks is ${typeof response.tasks}, expected array`;
+      delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
+      return { kind: 'protocol-error', message: msg };
+    }
+  } else if (!hasOk) {
+    const keys = Object.keys(response).join(', ');
+    const msg = `response has neither workflowId (string) nor ok (true); keys: [${keys}]`;
+    delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
+    return { kind: 'protocol-error', message: msg };
+  }
+
+  if (hasWorkflowId) {
+    targetWorkflowId = response.workflowId as string;
     process.stdout.write(`Delegated to owner — workflow: ${targetWorkflowId}\n`);
   } else {
     process.stdout.write('Delegated to owner\n');
   }
 
-  const outcome: DelegationOutcome = 'workflowId' in response
-    ? { kind: 'delegated', workflowId: response.workflowId, tasks: response.tasks }
+  const outcome: DelegationOutcome = hasWorkflowId
+    ? { kind: 'delegated', workflowId: response.workflowId as string, tasks: response.tasks as TaskState[] }
     : { kind: 'delegated' };
 
   if (options.noTrack) {
@@ -262,11 +292,11 @@ async function tryDelegate(
     return outcome;
   }
 
-  if (!('workflowId' in response) || !Array.isArray(response.tasks)) {
+  if (!hasWorkflowId || !Array.isArray(response.tasks)) {
     return outcome;
   }
-  targetWorkflowId = response.workflowId;
-  const taskFeed = createDelegatedTaskFeed(messageBus, response.tasks, targetWorkflowId);
+  targetWorkflowId = response.workflowId as string;
+  const taskFeed = createDelegatedTaskFeed(messageBus, response.tasks as TaskState[], targetWorkflowId);
   await trackWorkflow({
     workflowId: targetWorkflowId,
     loadTasks: taskFeed.loadTasks,

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -1,6 +1,6 @@
 import { resolve as resolvePath } from 'node:path';
 
-import type { MessageBus } from '@invoker/transport';
+import { TransportError, TransportErrorCode, type MessageBus } from '@invoker/transport';
 import type { TaskState } from '@invoker/workflow-core';
 
 import {
@@ -136,7 +136,7 @@ export async function tryPingHeadlessOwner(
       delegationLog(`${traceId} timeout timeoutMs=${timeoutMs}`);
       return null;
     }
-    if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+    if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
       delegationLog(`${traceId} no-handler`);
       return null;
     }
@@ -182,7 +182,7 @@ export async function tryDelegateQuery(
       delegationLog(`${traceId} timeout timeoutMs=${timeoutMs}`);
       return null;
     }
-    if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+    if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
       delegationLog(`${traceId} no-handler`);
       return null;
     }
@@ -222,7 +222,7 @@ async function tryDelegate(
       delegationLog(`${traceId} timeout channel=${channel} timeoutMs=${options.timeoutMs ?? 5_000}`);
       return false;
     }
-    if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+    if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
       delegationLog(`${traceId} no-handler channel=${channel}`);
       return false;
     }

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -15,6 +15,20 @@ type DelegateTrackingOptions = {
   timeoutMs?: number;
 };
 
+// ---------------------------------------------------------------------------
+// DelegationOutcome — typed result union for delegation attempts
+// ---------------------------------------------------------------------------
+
+export type DelegationOutcome =
+  | { kind: 'delegated'; workflowId?: string; tasks?: TaskState[] }
+  | { kind: 'timeout' }
+  | { kind: 'no-handler' };
+
+/** Type guard: returns true when the delegation was accepted by the owner. */
+export function isDelegated(outcome: DelegationOutcome): outcome is DelegationOutcome & { kind: 'delegated' } {
+  return outcome.kind === 'delegated';
+}
+
 function delegationLog(message: string): void {
   process.stderr.write(`[delegation] ${message}\n`);
 }
@@ -29,7 +43,7 @@ export async function tryDelegateRun(
   waitForApproval?: boolean,
   noTrack?: boolean,
   timeoutMs?: number,
-): Promise<boolean> {
+): Promise<DelegationOutcome> {
   const traceId = createTraceId('headless.run');
   return tryDelegate(
     'headless.run',
@@ -45,7 +59,7 @@ export async function tryDelegateResume(
   waitForApproval?: boolean,
   noTrack?: boolean,
   timeoutMs?: number,
-): Promise<boolean> {
+): Promise<DelegationOutcome> {
   const traceId = createTraceId('headless.resume');
   return tryDelegate(
     'headless.resume',
@@ -93,7 +107,7 @@ export async function tryDelegateExec(
   waitForApproval?: boolean,
   noTrack?: boolean,
   timeoutMs?: number,
-): Promise<boolean> {
+): Promise<DelegationOutcome> {
   const resolvedTimeoutMs = timeoutMs ?? await resolveDelegationTimeoutMs(args);
   const traceId = createTraceId('headless.exec');
   return tryDelegate(
@@ -198,7 +212,7 @@ async function tryDelegate(
   payload: unknown,
   messageBus: MessageBus,
   options: DelegateTrackingOptions,
-): Promise<boolean> {
+): Promise<DelegationOutcome> {
   const traceId = (payload as { traceId?: string })?.traceId ?? createTraceId(channel);
   let targetWorkflowId: string | undefined;
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
@@ -220,11 +234,11 @@ async function tryDelegate(
   } catch (err) {
     if (err === DELEGATION_TIMEOUT) {
       delegationLog(`${traceId} timeout channel=${channel} timeoutMs=${options.timeoutMs ?? 5_000}`);
-      return false;
+      return { kind: 'timeout' };
     }
     if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
       delegationLog(`${traceId} no-handler channel=${channel}`);
-      return false;
+      return { kind: 'no-handler' };
     }
     delegationLog(`${traceId} error channel=${channel} ${(err instanceof Error ? err.message : String(err))}`);
     throw err;
@@ -239,13 +253,17 @@ async function tryDelegate(
     process.stdout.write('Delegated to owner\n');
   }
 
+  const outcome: DelegationOutcome = 'workflowId' in response
+    ? { kind: 'delegated', workflowId: response.workflowId, tasks: response.tasks }
+    : { kind: 'delegated' };
+
   if (options.noTrack) {
     process.stdout.write('--no-track enabled: delegated submission accepted; exiting without tracking.\n');
-    return true;
+    return outcome;
   }
 
   if (!('workflowId' in response) || !Array.isArray(response.tasks)) {
-    return true;
+    return outcome;
   }
   targetWorkflowId = response.workflowId;
   const taskFeed = createDelegatedTaskFeed(messageBus, response.tasks, targetWorkflowId);
@@ -259,5 +277,5 @@ async function tryDelegate(
     printTaskOutput: true,
     subscribeToChanges: taskFeed.subscribeToChanges,
   });
-  return true;
+  return outcome;
 }

--- a/packages/app/src/headless-transport.ts
+++ b/packages/app/src/headless-transport.ts
@@ -17,6 +17,7 @@ import type { MessageBus } from '@invoker/transport';
 
 import { isHeadlessMutatingCommand } from './headless-command-classification.js';
 import {
+  isDelegated,
   tryDelegateExec,
   tryDelegateRun,
   tryDelegateResume,
@@ -281,21 +282,21 @@ export class HeadlessTransport {
     if (command === 'run') {
       const planPath = args[1];
       if (!planPath) return false;
-      return tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs);
+      return isDelegated(await tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs));
     }
 
     if (command === 'resume') {
       const workflowId = args[1];
       if (!workflowId) return false;
-      return tryDelegateResume(
+      return isDelegated(await tryDelegateResume(
         workflowId,
         bus,
         waitForApproval,
         noTrack,
         timeoutMs,
-      );
+      ));
     }
 
-    return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
+    return isDelegated(await tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs));
   }
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -12,6 +12,7 @@
 import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
 import type { AgentSessionData } from '@invoker/contracts';
+import { OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
@@ -1656,6 +1657,13 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
   autoFix.unsubscribe();
 }
 
+/** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
+const preemptSkipCodes: ReadonlySet<string> = new Set([
+  OrchestratorErrorCode.TASK_NOT_FOUND,
+  OrchestratorErrorCode.TASK_ALREADY_TERMINAL,
+  OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
+]);
+
 async function preemptTaskSubgraph(taskId: string, deps: HeadlessDeps): Promise<void> {
   if (deps.preemptTaskSubgraph) {
     await deps.preemptTaskSubgraph(taskId);
@@ -1665,7 +1673,7 @@ async function preemptTaskSubgraph(taskId: string, deps: HeadlessDeps): Promise<
   const envelope = makeEnvelope('cancel-task', 'headless', 'task', { taskId });
   const result = await deps.commandService.cancelTask(envelope);
   if (!result.ok) {
-    if (result.error.code === 'CANCEL_TASK_FAILED') return;
+    if (preemptSkipCodes.has(result.error.code)) return;
     throw new Error(result.error.message);
   }
 }
@@ -1680,7 +1688,7 @@ async function preemptWorkflowExecution(workflowId: string, deps: HeadlessDeps):
   const envelope = makeEnvelope('cancel-workflow', 'headless', 'workflow', { workflowId });
   const result = await deps.commandService.cancelWorkflow(envelope);
   if (!result.ok) {
-    if (result.error.code === 'CANCEL_WORKFLOW_FAILED') return { cancelled: [], runningCancelled: [] };
+    if (preemptSkipCodes.has(result.error.code)) return { cancelled: [], runningCancelled: [] };
     throw new Error(result.error.message);
   }
   return result.data;

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1665,9 +1665,8 @@ async function preemptTaskSubgraph(taskId: string, deps: HeadlessDeps): Promise<
   const envelope = makeEnvelope('cancel-task', 'headless', 'task', { taskId });
   const result = await deps.commandService.cancelTask(envelope);
   if (!result.ok) {
-    const message = result.error.message;
-    if (message.includes('already completed') || message.includes('already stale')) return;
-    throw new Error(message);
+    if (result.error.code === 'CANCEL_TASK_FAILED') return;
+    throw new Error(result.error.message);
   }
 }
 
@@ -1681,9 +1680,8 @@ async function preemptWorkflowExecution(workflowId: string, deps: HeadlessDeps):
   const envelope = makeEnvelope('cancel-workflow', 'headless', 'workflow', { workflowId });
   const result = await deps.commandService.cancelWorkflow(envelope);
   if (!result.ok) {
-    const message = result.error.message;
-    if (message.includes('No tasks found for workflow')) return { cancelled: [], runningCancelled: [] };
-    throw new Error(message);
+    if (result.error.code === 'CANCEL_WORKFLOW_FAILED') return { cancelled: [], runningCancelled: [] };
+    throw new Error(result.error.message);
   }
   return result.data;
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -44,14 +44,6 @@ import {
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
 import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
-import {
-  delegationTimeoutMs,
-  resolveDelegationTimeoutMs,
-  tryDelegateExec,
-  tryDelegateQuery,
-  tryDelegateResume,
-  tryDelegateRun,
-} from './headless-delegation.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
@@ -60,12 +52,14 @@ import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
 export { bumpGenerationAndRecreate } from './workflow-actions.js';
 export {
   delegationTimeoutMs,
+  isDelegated,
   resolveDelegationTimeoutMs,
   tryDelegateExec,
   tryDelegateQuery,
   tryDelegateResume,
   tryDelegateRun,
 } from './headless-delegation.js';
+export type { DelegationOutcome } from './headless-delegation.js';
 
 // ── HeadlessDeps interface ───────────────────────────────────
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -61,7 +61,7 @@ import type {
 import { makeEnvelope } from '@invoker/contracts';
 import type { WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
-import { IpcBus, Channels } from '@invoker/transport';
+import { IpcBus, Channels, TransportError, TransportErrorCode } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import {
   ExecutorRegistry, TaskRunner,
@@ -1948,7 +1948,7 @@ if (isHeadless) {
       try {
         return await messageBus.request<typeof translated.request, TResult>(translated.channel, translated.request);
       } catch (err) {
-        if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+        if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
           throw new Error('No mutation owner is available');
         }
         throw err;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -58,7 +58,7 @@ import type {
   TaskState,
   TaskStateChanges,
 } from '@invoker/workflow-core';
-import { makeEnvelope } from '@invoker/contracts';
+import { makeEnvelope, CommandError } from '@invoker/contracts';
 import type { WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import { IpcBus, Channels, TransportError, TransportErrorCode } from '@invoker/transport';
@@ -1534,7 +1534,7 @@ if (isHeadless) {
   async function performCancelTask(taskId: string): Promise<{ cancelled: string[]; runningCancelled: string[] }> {
     const envelope = makeEnvelope('cancel-task', 'ui', 'task', { taskId });
     const cmdResult = await commandService.cancelTask(envelope);
-    if (!cmdResult.ok) throw new Error(cmdResult.error.message);
+    if (!cmdResult.ok) throw CommandError.fromResult(cmdResult.error);
     for (const id of cmdResult.data.runningCancelled) {
       await killRunningTask(id);
     }
@@ -1546,7 +1546,7 @@ if (isHeadless) {
     logger.info(`performCancelWorkflow begin workflow="${workflowId}"`, { module: 'kill' });
     const envelope = makeEnvelope('cancel-workflow', 'ui', 'workflow', { workflowId });
     const cmdResult = await commandService.cancelWorkflow(envelope);
-    if (!cmdResult.ok) throw new Error(cmdResult.error.message);
+    if (!cmdResult.ok) throw CommandError.fromResult(cmdResult.error);
     logger.info(
       `performCancelWorkflow commandService complete workflow="${workflowId}" cancelled=${cmdResult.data.cancelled.length} runningCancelled=${cmdResult.data.runningCancelled.length}`,
       { module: 'kill' },
@@ -1582,9 +1582,8 @@ if (isHeadless) {
     try {
       await performCancelTask(taskId);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.includes('already completed') || message.includes('already stale')) {
-        logger.info(`preemptTaskSubgraph skipped for "${taskId}": ${message}`, { module: 'ipc' });
+      if (err instanceof CommandError && err.code === 'CANCEL_TASK_FAILED') {
+        logger.info(`preemptTaskSubgraph skipped for "${taskId}": ${err.message}`, { module: 'ipc' });
         return;
       }
       throw err;
@@ -1598,9 +1597,8 @@ if (isHeadless) {
       logger.info(`preemptWorkflowExecution end for "${workflowId}"`, { module: 'ipc' });
       return result;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.includes('No tasks found for workflow')) {
-        logger.info(`preemptWorkflowExecution skipped for "${workflowId}": ${message}`, { module: 'ipc' });
+      if (err instanceof CommandError && err.code === 'CANCEL_WORKFLOW_FAILED') {
+        logger.info(`preemptWorkflowExecution skipped for "${workflowId}": ${err.message}`, { module: 'ipc' });
         return { cancelled: [], runningCancelled: [] };
       }
       throw err;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -50,7 +50,7 @@ if (process.platform === 'linux' && !enableTestCompositor) {
   app.commandLine.appendSwitch('disable-software-rasterizer');
 }
 
-import { Orchestrator, CommandService } from '@invoker/workflow-core';
+import { Orchestrator, CommandService, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type {
   PlanDefinition,
   TaskDelta,
@@ -1578,11 +1578,18 @@ if (isHeadless) {
     logger.info(`performDeleteWorkflow end workflow="${workflowId}"`, { module: 'kill' });
   }
 
+  /** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
+  const preemptSkipCodes: ReadonlySet<string> = new Set([
+    OrchestratorErrorCode.TASK_NOT_FOUND,
+    OrchestratorErrorCode.TASK_ALREADY_TERMINAL,
+    OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
+  ]);
+
   async function preemptTaskSubgraph(taskId: string): Promise<void> {
     try {
       await performCancelTask(taskId);
     } catch (err) {
-      if (err instanceof CommandError && err.code === 'CANCEL_TASK_FAILED') {
+      if (err instanceof CommandError && preemptSkipCodes.has(err.code)) {
         logger.info(`preemptTaskSubgraph skipped for "${taskId}": ${err.message}`, { module: 'ipc' });
         return;
       }
@@ -1597,7 +1604,7 @@ if (isHeadless) {
       logger.info(`preemptWorkflowExecution end for "${workflowId}"`, { module: 'ipc' });
       return result;
     } catch (err) {
-      if (err instanceof CommandError && err.code === 'CANCEL_WORKFLOW_FAILED') {
+      if (err instanceof CommandError && preemptSkipCodes.has(err.code)) {
         logger.info(`preemptWorkflowExecution skipped for "${workflowId}": ${err.message}`, { module: 'ipc' });
         return { cancelled: [], runningCancelled: [] };
       }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -96,6 +96,7 @@ import { backupPlan } from './plan-backup.js';
 import { startApiServer, type ApiServer } from './api-server.js';
 import {
   runHeadless,
+  isDelegated,
   tryDelegateRun,
   tryDelegateResume,
   resolveDelegationTimeoutMs,
@@ -635,14 +636,14 @@ if (isHeadless) {
         if (command === 'run') {
           const planPath = cliArgs[1];
           if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-          delegated = await tryDelegateRun(planPath, delegationBus, waitForApproval, noTrack);
+          delegated = isDelegated(await tryDelegateRun(planPath, delegationBus, waitForApproval, noTrack));
         } else if (command === 'resume') {
           const workflowId = cliArgs[1];
           if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-          delegated = await tryDelegateResume(workflowId, delegationBus, waitForApproval, noTrack);
+          delegated = isDelegated(await tryDelegateResume(workflowId, delegationBus, waitForApproval, noTrack));
         } else {
           const timeoutMs = noTrack ? undefined : await resolveDelegationTimeoutMs(cliArgs);
-          delegated = await tryDelegateExec(cliArgs, delegationBus, waitForApproval, noTrack, timeoutMs);
+          delegated = isDelegated(await tryDelegateExec(cliArgs, delegationBus, waitForApproval, noTrack, timeoutMs));
         }
 
         if (delegated) {

--- a/packages/contracts/src/command-envelope.ts
+++ b/packages/contracts/src/command-envelope.ts
@@ -17,6 +17,27 @@ export type CommandResult<T> =
   | { ok: false; error: { code: string; message: string } };
 
 /**
+ * CommandError — Structured error carrying a stable `code` from CommandResult.
+ *
+ * Thrown by bridge functions so callers can branch on `.code`
+ * instead of fragile message-string matching.
+ */
+export class CommandError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'CommandError';
+    this.code = code;
+  }
+
+  /** Create a CommandError from a failed CommandResult's error field. */
+  static fromResult(error: { code: string; message: string }): CommandError {
+    return new CommandError(error.code, error.message);
+  }
+}
+
+/**
  * Build a CommandEnvelope with an auto-generated idempotencyKey if none is provided.
  */
 export function makeEnvelope<P>(

--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -4,7 +4,13 @@ import { existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { IpcBus, DEFAULT_REQUEST_DEADLINE_MS } from '../ipc-bus.js';
+import { createConnection } from 'node:net';
+import {
+  IpcBus,
+  DEFAULT_REQUEST_DEADLINE_MS,
+  MALFORMED_FRAME_RATE_LIMIT_MS,
+  type MalformedFrameEvent,
+} from '../ipc-bus.js';
 import { TransportError, TransportErrorCode } from '../transport-error.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -918,6 +924,172 @@ ${minimalIpcBusJS}
     expect(messages.b.some((m: any) => m.received)).toBe(true);
     expect(messages.a.some((m: any) => m.error)).toBe(false);
   }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// Malformed-frame observability
+// ---------------------------------------------------------------------------
+
+describe('Malformed-frame observability', () => {
+  const buses: IpcBus[] = [];
+
+  afterEach(() => {
+    for (const bus of buses) {
+      bus.disconnect();
+    }
+    buses.length = 0;
+  });
+
+  /** Encode a raw length-prefixed frame from an arbitrary string payload. */
+  function encodeRaw(payload: string): Buffer {
+    const json = Buffer.from(payload, 'utf8');
+    const frame = Buffer.allocUnsafe(4 + json.length);
+    frame.writeUInt32BE(json.length, 0);
+    json.copy(frame, 4);
+    return frame;
+  }
+
+  /** Connect a raw socket to the given path and wait for it to be ready. */
+  function rawConnect(socketPath: string): Promise<import('node:net').Socket> {
+    return new Promise((resolve, reject) => {
+      const sock = createConnection({ path: socketPath }, () => resolve(sock));
+      sock.on('error', reject);
+    });
+  }
+
+  it('fires onMalformedFrame for invalid JSON', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    // Send a frame whose payload is not valid JSON.
+    const raw = rawConnect(sock);
+    const peer = await raw;
+    peer.write(encodeRaw('not-json{{{'));
+
+    await waitFor(() => events.length >= 1, 2000);
+    peer.destroy();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].reason).toBe('invalid_json');
+    expect(events[0].rawByteLength).toBe(Buffer.byteLength('not-json{{{', 'utf8'));
+    expect(events[0].droppedSinceLastReport).toBe(0);
+    expect(events[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('fires onMalformedFrame for valid JSON with invalid envelope shape', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    // Valid JSON but missing required envelope fields.
+    const raw = rawConnect(sock);
+    const peer = await raw;
+    peer.write(encodeRaw('{"kind":"pub"}'));
+
+    await waitFor(() => events.length >= 1, 2000);
+    peer.destroy();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].reason).toBe('invalid_envelope');
+  });
+
+  it('rate-limits malformed frame events', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    // Use rateLimitMs=0 would disable limiting; we rely on default.
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    const peer = await rawConnect(sock);
+
+    // Send many malformed frames rapidly — default rate limit is 1 s,
+    // so only the first should be emitted immediately.
+    for (let i = 0; i < 10; i++) {
+      peer.write(encodeRaw(`bad-json-${i}`));
+    }
+
+    // Wait for socket data to be processed.
+    await sleep(200);
+    peer.destroy();
+
+    // Exactly 1 event emitted due to rate limiting (the other 9 suppressed).
+    expect(events).toHaveLength(1);
+    expect(events[0].droppedSinceLastReport).toBe(0);
+  });
+
+  it('reports suppressed count after rate-limit window elapses', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    const peer = await rawConnect(sock);
+
+    // First burst — first frame emitted, rest suppressed.
+    for (let i = 0; i < 5; i++) {
+      peer.write(encodeRaw(`bad-${i}`));
+    }
+    await sleep(200);
+    expect(events).toHaveLength(1);
+
+    // Wait for rate-limit window to pass.
+    await sleep(MALFORMED_FRAME_RATE_LIMIT_MS + 100);
+
+    // Second malformed frame triggers a new event with suppressed count.
+    peer.write(encodeRaw('another-bad'));
+    await waitFor(() => events.length >= 2, 2000);
+    peer.destroy();
+
+    expect(events).toHaveLength(2);
+    // 4 frames were suppressed between the first and second emitted events.
+    expect(events[1].droppedSinceLastReport).toBe(4);
+  });
+
+  it('does not fire callback when no observer is provided', async () => {
+    const sock = tempSocketPath();
+    // No onMalformedFrame — should not throw.
+    const bus = new IpcBus(sock);
+    buses.push(bus);
+    await bus.ready();
+
+    const peer = await rawConnect(sock);
+    peer.write(encodeRaw('not-json'));
+    await sleep(200);
+    peer.destroy();
+
+    // If we get here without an unhandled exception, the test passes.
+    expect(true).toBe(true);
+  });
+
+  it('still delivers valid frames alongside malformed ones', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    const received: string[] = [];
+    bus.subscribe('test', (msg: string) => received.push(msg));
+
+    const peer = await rawConnect(sock);
+    // Send a malformed frame followed by a valid pub envelope.
+    const malformed = encodeRaw('garbage');
+    const valid = encodeRaw(JSON.stringify({ kind: 'pub', channel: 'test', body: 'hello' }));
+    peer.write(Buffer.concat([malformed, valid]));
+
+    await waitFor(() => received.length >= 1, 2000);
+    peer.destroy();
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(received).toEqual(['hello']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -4,7 +4,8 @@ import { existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { IpcBus } from '../ipc-bus.js';
+import { IpcBus, DEFAULT_REQUEST_DEADLINE_MS } from '../ipc-bus.js';
+import { TransportError, TransportErrorCode } from '../transport-error.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -293,6 +294,85 @@ describe('IpcBus', () => {
 
     const result = await requester.request<number, number>('delayed-double', 5);
     expect(result).toBe(10);
+  });
+
+  // ---------------------------------------------------------------
+  // Request deadline
+  // ---------------------------------------------------------------
+
+  it('rejects with REQUEST_TIMEOUT when no response arrives within the deadline', async () => {
+    const sock = tempSocketPath();
+
+    const server = new IpcBus(sock, { requestDeadlineMs: 100 });
+    buses.push(server);
+    await server.ready();
+
+    // Register a handler that never resolves.
+    server.onRequest('black-hole', () => new Promise(() => {}));
+
+    const client = new IpcBus(sock, { requestDeadlineMs: 100 });
+    buses.push(client);
+    await client.ready();
+    await sleep(50);
+
+    try {
+      await client.request('black-hole', {});
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.REQUEST_TIMEOUT);
+      expect((err as TransportError).message).toContain('black-hole');
+      expect((err as TransportError).message).toContain('100ms');
+    }
+  });
+
+  it('does not timeout when response arrives before the deadline', async () => {
+    const sock = tempSocketPath();
+
+    const server = new IpcBus(sock, { requestDeadlineMs: 500 });
+    buses.push(server);
+    await server.ready();
+
+    server.onRequest<number, number>('fast', (n) => n + 1);
+
+    const client = new IpcBus(sock, { requestDeadlineMs: 500 });
+    buses.push(client);
+    await client.ready();
+    await sleep(50);
+
+    const result = await client.request<number, number>('fast', 41);
+    expect(result).toBe(42);
+  });
+
+  it('disconnect rejects with DISCONNECTED, not REQUEST_TIMEOUT', async () => {
+    const sock = tempSocketPath();
+
+    const server = new IpcBus(sock, { requestDeadlineMs: 2000 });
+    buses.push(server);
+    await server.ready();
+
+    server.onRequest('never-reply', () => new Promise(() => {}));
+
+    const client = new IpcBus(sock, { requestDeadlineMs: 2000 });
+    buses.push(client);
+    await client.ready();
+    await sleep(50);
+
+    const requestPromise = client.request('never-reply', {});
+    await sleep(20);
+    client.disconnect();
+
+    try {
+      await requestPromise;
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.DISCONNECTED);
+    }
+  });
+
+  it('exports DEFAULT_REQUEST_DEADLINE_MS as 30000', () => {
+    expect(DEFAULT_REQUEST_DEADLINE_MS).toBe(30_000);
   });
 
   // ---------------------------------------------------------------

--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -371,6 +371,22 @@ describe('IpcBus', () => {
     }
   });
 
+  it('rejects immediately with NO_HANDLER when no local handler and no peers', async () => {
+    const sock = tempSocketPath();
+
+    const bus = createBus(sock);
+    await bus.ready();
+
+    try {
+      await bus.request('unhandled-channel', { data: 1 });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.NO_HANDLER);
+      expect((err as TransportError).message).toContain('unhandled-channel');
+    }
+  });
+
   it('exports DEFAULT_REQUEST_DEADLINE_MS as 30000', () => {
     expect(DEFAULT_REQUEST_DEADLINE_MS).toBe(30_000);
   });

--- a/packages/transport/src/__tests__/transport-error.test.ts
+++ b/packages/transport/src/__tests__/transport-error.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+import { TransportError, TransportErrorCode } from '../transport-error.js';
+import { LocalBus } from '../local-bus.js';
+import { IpcBus } from '../ipc-bus.js';
+
+function tempSocketPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'transport-error-test-'));
+  return join(dir, 'test.sock');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe('TransportError', () => {
+  it('is an instance of Error', () => {
+    const err = new TransportError(TransportErrorCode.NO_HANDLER, 'test');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(TransportError);
+  });
+
+  it('carries the code and message fields', () => {
+    const err = new TransportError(TransportErrorCode.DISCONNECTED, 'bus gone');
+    expect(err.code).toBe('DISCONNECTED');
+    expect(err.message).toBe('bus gone');
+    expect(err.name).toBe('TransportError');
+  });
+
+  it('exposes all expected error codes', () => {
+    expect(TransportErrorCode.NO_HANDLER).toBe('NO_HANDLER');
+    expect(TransportErrorCode.DISCONNECTED).toBe('DISCONNECTED');
+    expect(TransportErrorCode.HANDLER_ERROR).toBe('HANDLER_ERROR');
+  });
+});
+
+describe('LocalBus typed error codes', () => {
+  let bus: LocalBus;
+
+  beforeEach(() => {
+    bus = new LocalBus();
+  });
+
+  it('throws TransportError with NO_HANDLER when no handler registered', async () => {
+    try {
+      await bus.request('missing-channel', {});
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.NO_HANDLER);
+      expect((err as TransportError).message).toContain('missing-channel');
+    }
+  });
+});
+
+describe('IpcBus typed error codes', () => {
+  const buses: IpcBus[] = [];
+
+  function createBus(socketPath: string, opts?: { allowServe?: boolean }): IpcBus {
+    const bus = new IpcBus(socketPath, opts);
+    buses.push(bus);
+    return bus;
+  }
+
+  afterEach(() => {
+    for (const bus of buses) {
+      bus.disconnect();
+    }
+    buses.length = 0;
+  });
+
+  it('rejects with TransportError NO_HANDLER for unhandled cross-instance request', async () => {
+    const sock = tempSocketPath();
+    const server = createBus(sock);
+    await server.ready();
+
+    const client = createBus(sock);
+    await client.ready();
+    await sleep(50);
+
+    try {
+      await client.request('no-such-channel', {});
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.NO_HANDLER);
+    }
+  });
+
+  it('rejects with TransportError HANDLER_ERROR when handler throws', async () => {
+    const sock = tempSocketPath();
+    const server = createBus(sock);
+    await server.ready();
+
+    server.onRequest('failing', () => {
+      throw new Error('handler boom');
+    });
+
+    const client = createBus(sock);
+    await client.ready();
+    await sleep(50);
+
+    try {
+      await client.request('failing', {});
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.HANDLER_ERROR);
+      expect((err as TransportError).message).toBe('handler boom');
+    }
+  });
+
+  it('rejects with TransportError DISCONNECTED on disconnect', async () => {
+    const sock = tempSocketPath();
+    const server = createBus(sock);
+    await server.ready();
+
+    // Register a handler that never resolves, keeping the request pending
+    server.onRequest('slow-channel', () => new Promise(() => {}));
+
+    const client = createBus(sock);
+    await client.ready();
+    await sleep(50);
+
+    // Start a request that will pend forever, then disconnect the client
+    const requestPromise = client.request('slow-channel', {});
+    // Allow the request envelope to reach the server
+    await sleep(20);
+    client.disconnect();
+
+    try {
+      await requestPromise;
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.DISCONNECTED);
+    }
+  });
+
+  it('preserves TransportError code through handler that throws TransportError', async () => {
+    const sock = tempSocketPath();
+    const server = createBus(sock);
+    await server.ready();
+
+    server.onRequest('custom-error', () => {
+      throw new TransportError(TransportErrorCode.NO_HANDLER, 'custom no handler');
+    });
+
+    const client = createBus(sock);
+    await client.ready();
+    await sleep(50);
+
+    try {
+      await client.request('custom-error', {});
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.NO_HANDLER);
+      expect((err as TransportError).message).toBe('custom no handler');
+    }
+  });
+});

--- a/packages/transport/src/__tests__/transport-error.test.ts
+++ b/packages/transport/src/__tests__/transport-error.test.ts
@@ -34,6 +34,7 @@ describe('TransportError', () => {
     expect(TransportErrorCode.NO_HANDLER).toBe('NO_HANDLER');
     expect(TransportErrorCode.DISCONNECTED).toBe('DISCONNECTED');
     expect(TransportErrorCode.HANDLER_ERROR).toBe('HANDLER_ERROR');
+    expect(TransportErrorCode.REQUEST_TIMEOUT).toBe('REQUEST_TIMEOUT');
   });
 });
 

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -1,3 +1,4 @@
 export * from './message-bus.js';
 export * from './local-bus.js';
 export * from './ipc-bus.js';
+export * from './transport-error.js';

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -200,6 +200,33 @@ function isValidEnvelope(v: unknown): v is Envelope {
 }
 
 // ---------------------------------------------------------------------------
+// Subscriber-error observability
+// ---------------------------------------------------------------------------
+
+/** Structured event emitted when a subscriber handler throws. */
+export interface SubscriberErrorEvent {
+  /** ISO-8601 timestamp of the error. */
+  timestamp: string;
+  /** Channel the handler was subscribed to. */
+  channel: string;
+  /** Error message (no payload data to avoid leakage). */
+  error: string;
+  /** Number of handler errors suppressed since the last emitted event
+   *  (0 when every error is reported; >0 when rate-limited). */
+  droppedSinceLastReport: number;
+}
+
+/** Callback signature for subscriber-error observers. */
+export type SubscriberErrorObserver = (event: SubscriberErrorEvent) => void;
+
+/**
+ * Default minimum interval (ms) between emitted subscriber-error events.
+ * Errors that occur faster are counted but not reported until the window
+ * elapses (token-bucket with capacity 1).
+ */
+export const SUBSCRIBER_ERROR_RATE_LIMIT_MS = 1_000;
+
+// ---------------------------------------------------------------------------
 // Default socket path
 // ---------------------------------------------------------------------------
 
@@ -217,6 +244,9 @@ export interface IpcBusOptions {
   /** Optional callback invoked when a malformed frame is received.
    *  Rate-limited to at most one call per {@link MALFORMED_FRAME_RATE_LIMIT_MS}. */
   onMalformedFrame?: MalformedFrameObserver;
+  /** Optional callback invoked when a subscriber handler throws.
+   *  Rate-limited to at most one call per {@link SUBSCRIBER_ERROR_RATE_LIMIT_MS}. */
+  onSubscriberError?: SubscriberErrorObserver;
 }
 
 // ---------------------------------------------------------------------------
@@ -228,6 +258,12 @@ export class IpcBus implements MessageBus {
   private readonly allowServe: boolean;
   private readonly requestDeadlineMs: number;
   private readonly onMalformedFrame: MalformedFrameObserver | undefined;
+  private readonly onSubscriberError: SubscriberErrorObserver | undefined;
+
+  /** Timestamp (ms) of the last emitted subscriber-error event. */
+  private subscriberErrorLastEmitMs = 0;
+  /** Count of subscriber errors suppressed by rate-limiting since last emit. */
+  private subscriberErrorSuppressedCount = 0;
 
   // Local handler registries (same structure as LocalBus).
   private subscribers = new Map<string, Set<MessageHandler>>();
@@ -259,6 +295,7 @@ export class IpcBus implements MessageBus {
     this.allowServe = options.allowServe ?? true;
     this.requestDeadlineMs = options.requestDeadlineMs ?? DEFAULT_REQUEST_DEADLINE_MS;
     this.onMalformedFrame = options.onMalformedFrame;
+    this.onSubscriberError = options.onSubscriberError;
     this.readyPromise = new Promise<void>((r) => {
       this.resolveReady = r;
     });
@@ -416,10 +453,33 @@ export class IpcBus implements MessageBus {
     for (const handler of handlers) {
       try {
         handler(body);
-      } catch {
+      } catch (e) {
         // Swallow handler errors — same behaviour as LocalBus.
+        this.reportSubscriberError(
+          channel,
+          e instanceof Error ? e.message : String(e),
+        );
       }
     }
+  }
+
+  /** Emit a subscriber-error event, respecting the rate limit. */
+  private reportSubscriberError(channel: string, error: string): void {
+    if (!this.onSubscriberError) return;
+    const now = Date.now();
+    if (now - this.subscriberErrorLastEmitMs < SUBSCRIBER_ERROR_RATE_LIMIT_MS) {
+      this.subscriberErrorSuppressedCount++;
+      return;
+    }
+    this.subscriberErrorLastEmitMs = now;
+    const droppedSinceLastReport = this.subscriberErrorSuppressedCount;
+    this.subscriberErrorSuppressedCount = 0;
+    this.onSubscriberError({
+      timestamp: new Date(now).toISOString(),
+      channel,
+      error,
+      droppedSinceLastReport,
+    });
   }
 
   private async handleRequest(env: ReqEnvelope, source: Socket): Promise<void> {

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -24,7 +24,7 @@
  * { kind: "pub",     channel: string, body: unknown }                  — publish
  * { kind: "req",     channel: string, body: unknown, reqId: string }   — request
  * { kind: "res",     channel: string, body: unknown, reqId: string }   — response
- * { kind: "err",     channel: string, message: string, reqId: string } — error response
+ * { kind: "err",     channel: string, code: string, message: string, reqId: string } — error response
  * ```
  *
  * The `kind` field maps 1:1 to a future gRPC `oneof` message type.
@@ -43,6 +43,7 @@ import type {
   RequestHandler,
   Unsubscribe,
 } from './message-bus.js';
+import { TransportError, TransportErrorCode } from './transport-error.js';
 
 // ---------------------------------------------------------------------------
 // Wire envelope types
@@ -71,6 +72,7 @@ interface ResEnvelope {
 interface ErrEnvelope {
   kind: 'err';
   channel: string;
+  code: TransportErrorCode;
   message: string;
   reqId: string;
 }
@@ -348,6 +350,7 @@ export class IpcBus implements MessageBus {
       const errEnv: ErrEnvelope = {
         kind: 'err',
         channel: env.channel,
+        code: TransportErrorCode.NO_HANDLER,
         message: `No request handler registered for channel: ${env.channel}`,
         reqId: env.reqId,
       };
@@ -367,6 +370,7 @@ export class IpcBus implements MessageBus {
       const errEnv: ErrEnvelope = {
         kind: 'err',
         channel: env.channel,
+        code: e instanceof TransportError ? e.code : TransportErrorCode.HANDLER_ERROR,
         message: e instanceof Error ? e.message : String(e),
         reqId: env.reqId,
       };
@@ -381,7 +385,7 @@ export class IpcBus implements MessageBus {
       if (env.kind === 'res') {
         pending.resolve(env.body);
       } else {
-        pending.reject(new Error(env.message));
+        pending.reject(new TransportError(env.code ?? TransportErrorCode.HANDLER_ERROR, env.message));
       }
       return;
     }
@@ -399,7 +403,7 @@ export class IpcBus implements MessageBus {
     }
 
     relay.awaiting.delete(source);
-    const noHandlerError = env.message === `No request handler registered for channel: ${relay.channel}`;
+    const noHandlerError = env.code === TransportErrorCode.NO_HANDLER;
     if (!noHandlerError || relay.awaiting.size === 0) {
       this.relayedRequests.delete(env.reqId);
       this.sendToSocket(relay.source, env);
@@ -505,7 +509,7 @@ export class IpcBus implements MessageBus {
 
     // Reject all pending requests.
     for (const [, pending] of this.pendingRequests) {
-      pending.reject(new Error('IpcBus disconnected'));
+      pending.reject(new TransportError(TransportErrorCode.DISCONNECTED, 'IpcBus disconnected'));
     }
     this.pendingRequests.clear();
 

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -130,8 +130,14 @@ class FrameDecoder {
 export const DEFAULT_SOCKET_PATH =
   process.env.INVOKER_IPC_SOCKET || join(homedir(), '.invoker', 'ipc-transport.sock');
 
+/** Default request deadline in milliseconds (30 s). */
+export const DEFAULT_REQUEST_DEADLINE_MS = 30_000;
+
 export interface IpcBusOptions {
   allowServe?: boolean;
+  /** Maximum time in ms a request may wait for a response before being
+   *  rejected with `REQUEST_TIMEOUT`.  Defaults to {@link DEFAULT_REQUEST_DEADLINE_MS}. */
+  requestDeadlineMs?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -141,6 +147,7 @@ export interface IpcBusOptions {
 export class IpcBus implements MessageBus {
   private readonly socketPath: string;
   private readonly allowServe: boolean;
+  private readonly requestDeadlineMs: number;
 
   // Local handler registries (same structure as LocalBus).
   private subscribers = new Map<string, Set<MessageHandler>>();
@@ -160,7 +167,7 @@ export class IpcBus implements MessageBus {
   private nextReqId = 0;
   private pendingRequests = new Map<
     string,
-    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+    { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
   >();
   private relayedRequests = new Map<
     string,
@@ -170,6 +177,7 @@ export class IpcBus implements MessageBus {
   constructor(socketPath: string = DEFAULT_SOCKET_PATH, options: IpcBusOptions = {}) {
     this.socketPath = socketPath;
     this.allowServe = options.allowServe ?? true;
+    this.requestDeadlineMs = options.requestDeadlineMs ?? DEFAULT_REQUEST_DEADLINE_MS;
     this.readyPromise = new Promise<void>((r) => {
       this.resolveReady = r;
     });
@@ -381,6 +389,7 @@ export class IpcBus implements MessageBus {
   private handleResponse(env: ResEnvelope | ErrEnvelope, source: Socket): void {
     const pending = this.pendingRequests.get(env.reqId);
     if (pending) {
+      clearTimeout(pending.timer);
       this.pendingRequests.delete(env.reqId);
       if (env.kind === 'res') {
         pending.resolve(env.body);
@@ -488,9 +497,20 @@ export class IpcBus implements MessageBus {
     const env: ReqEnvelope = { kind: 'req', channel, body: message, reqId };
 
     return new Promise<Res>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pendingRequests.delete(reqId)) {
+          reject(new TransportError(
+            TransportErrorCode.REQUEST_TIMEOUT,
+            `Request on channel "${channel}" timed out after ${this.requestDeadlineMs}ms`,
+          ));
+        }
+      }, this.requestDeadlineMs);
+      timer.unref?.();
+
       this.pendingRequests.set(reqId, {
         resolve: resolve as (v: unknown) => void,
         reject,
+        timer,
       });
       // Send to all peers — only the one with a handler will reply.
       this.sendToAll(env);
@@ -507,8 +527,9 @@ export class IpcBus implements MessageBus {
     this.subscribers.clear();
     this.requestHandlers.clear();
 
-    // Reject all pending requests.
+    // Reject all pending requests and clear their deadline timers.
     for (const [, pending] of this.pendingRequests) {
+      clearTimeout(pending.timer);
       pending.reject(new TransportError(TransportErrorCode.DISCONNECTED, 'IpcBus disconnected'));
     }
     this.pendingRequests.clear();

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -493,6 +493,15 @@ export class IpcBus implements MessageBus {
     // Forward to a peer (first available).
     await this.readyPromise;
 
+    // If no peers are connected, reject immediately — no one can handle this.
+    const livePeers = [...this.peers].filter((p) => !p.destroyed);
+    if (livePeers.length === 0) {
+      throw new TransportError(
+        TransportErrorCode.NO_HANDLER,
+        `No request handler registered for channel: ${channel}`,
+      );
+    }
+
     const reqId = String(this.nextReqId++);
     const env: ReqEnvelope = { kind: 'req', channel, body: message, reqId };
 

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -92,6 +92,33 @@ function encode(env: Envelope): Buffer {
   return frame;
 }
 
+// ---------------------------------------------------------------------------
+// Malformed-frame observability
+// ---------------------------------------------------------------------------
+
+/** Structured event emitted when a frame fails to decode. */
+export interface MalformedFrameEvent {
+  /** ISO-8601 timestamp of the drop. */
+  timestamp: string;
+  /** Why the frame was rejected. */
+  reason: 'invalid_json' | 'invalid_envelope';
+  /** Byte length of the raw JSON payload that failed. */
+  rawByteLength: number;
+  /** Number of malformed frames dropped since the last emitted event
+   *  (0 when every drop is reported; >0 when rate-limited). */
+  droppedSinceLastReport: number;
+}
+
+/** Callback signature for malformed-frame observers. */
+export type MalformedFrameObserver = (event: MalformedFrameEvent) => void;
+
+/**
+ * Default minimum interval (ms) between emitted malformed-frame events.
+ * Events that arrive faster are counted but not reported until the window
+ * elapses (token-bucket with capacity 1).
+ */
+export const MALFORMED_FRAME_RATE_LIMIT_MS = 1_000;
+
 /**
  * Streaming decoder for length-prefixed JSON frames.
  *
@@ -100,10 +127,23 @@ function encode(env: Envelope): Buffer {
  */
 class FrameDecoder {
   private buf = Buffer.alloc(0);
-  private onEnvelope: (env: Envelope) => void;
+  private readonly onEnvelope: (env: Envelope) => void;
+  private readonly onMalformed: MalformedFrameObserver | undefined;
+  private readonly rateLimitMs: number;
 
-  constructor(onEnvelope: (env: Envelope) => void) {
+  /** Timestamp (ms) of the last emitted malformed-frame event. */
+  private lastEmitMs = 0;
+  /** Count of drops suppressed by rate-limiting since last emit. */
+  private suppressedCount = 0;
+
+  constructor(
+    onEnvelope: (env: Envelope) => void,
+    onMalformed?: MalformedFrameObserver,
+    rateLimitMs: number = MALFORMED_FRAME_RATE_LIMIT_MS,
+  ) {
     this.onEnvelope = onEnvelope;
+    this.onMalformed = onMalformed;
+    this.rateLimitMs = rateLimitMs;
   }
 
   push(chunk: Buffer): void {
@@ -115,12 +155,48 @@ class FrameDecoder {
       const json = this.buf.subarray(4, 4 + len).toString('utf8');
       this.buf = this.buf.subarray(4 + len);
       try {
-        this.onEnvelope(JSON.parse(json) as Envelope);
+        const parsed: unknown = JSON.parse(json);
+        if (!isValidEnvelope(parsed)) {
+          this.reportMalformed('invalid_envelope', Buffer.byteLength(json, 'utf8'));
+          continue;
+        }
+        this.onEnvelope(parsed);
       } catch {
-        // Malformed frame — skip silently (no payload logging).
+        this.reportMalformed('invalid_json', Buffer.byteLength(json, 'utf8'));
       }
     }
   }
+
+  /** Emit a malformed-frame event, respecting the rate limit. */
+  private reportMalformed(reason: MalformedFrameEvent['reason'], rawByteLength: number): void {
+    if (!this.onMalformed) return;
+    const now = Date.now();
+    if (now - this.lastEmitMs < this.rateLimitMs) {
+      this.suppressedCount++;
+      return;
+    }
+    this.lastEmitMs = now;
+    const droppedSinceLastReport = this.suppressedCount;
+    this.suppressedCount = 0;
+    this.onMalformed({
+      timestamp: new Date(now).toISOString(),
+      reason,
+      rawByteLength,
+      droppedSinceLastReport,
+    });
+  }
+}
+
+/** Type guard: returns true when the value has a valid envelope shape. */
+function isValidEnvelope(v: unknown): v is Envelope {
+  if (typeof v !== 'object' || v === null) return false;
+  const obj = v as Record<string, unknown>;
+  const kind = obj.kind;
+  if (kind === 'pub') return typeof obj.channel === 'string';
+  if (kind === 'req') return typeof obj.channel === 'string' && typeof obj.reqId === 'string';
+  if (kind === 'res') return typeof obj.channel === 'string' && typeof obj.reqId === 'string';
+  if (kind === 'err') return typeof obj.channel === 'string' && typeof obj.reqId === 'string' && typeof obj.code === 'string';
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -138,6 +214,9 @@ export interface IpcBusOptions {
   /** Maximum time in ms a request may wait for a response before being
    *  rejected with `REQUEST_TIMEOUT`.  Defaults to {@link DEFAULT_REQUEST_DEADLINE_MS}. */
   requestDeadlineMs?: number;
+  /** Optional callback invoked when a malformed frame is received.
+   *  Rate-limited to at most one call per {@link MALFORMED_FRAME_RATE_LIMIT_MS}. */
+  onMalformedFrame?: MalformedFrameObserver;
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +227,7 @@ export class IpcBus implements MessageBus {
   private readonly socketPath: string;
   private readonly allowServe: boolean;
   private readonly requestDeadlineMs: number;
+  private readonly onMalformedFrame: MalformedFrameObserver | undefined;
 
   // Local handler registries (same structure as LocalBus).
   private subscribers = new Map<string, Set<MessageHandler>>();
@@ -178,6 +258,7 @@ export class IpcBus implements MessageBus {
     this.socketPath = socketPath;
     this.allowServe = options.allowServe ?? true;
     this.requestDeadlineMs = options.requestDeadlineMs ?? DEFAULT_REQUEST_DEADLINE_MS;
+    this.onMalformedFrame = options.onMalformedFrame;
     this.readyPromise = new Promise<void>((r) => {
       this.resolveReady = r;
     });
@@ -287,7 +368,10 @@ export class IpcBus implements MessageBus {
       return;
     }
     this.peers.add(sock);
-    const decoder = new FrameDecoder((env) => this.handleEnvelope(env, sock));
+    const decoder = new FrameDecoder(
+      (env) => this.handleEnvelope(env, sock),
+      this.onMalformedFrame,
+    );
     sock.on('data', (chunk: Buffer) => decoder.push(chunk));
     sock.on('close', () => {
       this.peers.delete(sock);

--- a/packages/transport/src/local-bus.ts
+++ b/packages/transport/src/local-bus.ts
@@ -10,6 +10,7 @@ import type {
   RequestHandler,
   Unsubscribe,
 } from './message-bus.js';
+import { TransportError, TransportErrorCode } from './transport-error.js';
 
 export class LocalBus implements MessageBus {
   private subscribers = new Map<string, Set<MessageHandler>>();
@@ -49,7 +50,10 @@ export class LocalBus implements MessageBus {
   async request<Req, Res>(channel: string, message: Req): Promise<Res> {
     const handler = this.requestHandlers.get(channel);
     if (!handler) {
-      throw new Error(`No request handler registered for channel: ${channel}`);
+      throw new TransportError(
+        TransportErrorCode.NO_HANDLER,
+        `No request handler registered for channel: ${channel}`,
+      );
     }
     return handler(message) as Promise<Res>;
   }

--- a/packages/transport/src/transport-error.ts
+++ b/packages/transport/src/transport-error.ts
@@ -1,0 +1,33 @@
+/**
+ * TransportErrorCode — Stable error codes for the IPC bus error envelope.
+ *
+ * These codes replace message-string matching for control flow.
+ * Consumers (delegation layer, API bridge) switch on `code` instead of
+ * parsing `.message`.
+ */
+export const TransportErrorCode = {
+  /** No handler is registered for the requested channel. */
+  NO_HANDLER: 'NO_HANDLER',
+  /** The IPC bus has been disconnected. */
+  DISCONNECTED: 'DISCONNECTED',
+  /** The request handler threw an unclassified error. */
+  HANDLER_ERROR: 'HANDLER_ERROR',
+} as const;
+
+export type TransportErrorCode = (typeof TransportErrorCode)[keyof typeof TransportErrorCode];
+
+/**
+ * TransportError — Structured error carrying a stable `code` field.
+ *
+ * Thrown by IpcBus and LocalBus so callers can branch on `.code`
+ * without fragile message-string matching.
+ */
+export class TransportError extends Error {
+  readonly code: TransportErrorCode;
+
+  constructor(code: TransportErrorCode, message: string) {
+    super(message);
+    this.name = 'TransportError';
+    this.code = code;
+  }
+}

--- a/packages/transport/src/transport-error.ts
+++ b/packages/transport/src/transport-error.ts
@@ -12,6 +12,8 @@ export const TransportErrorCode = {
   DISCONNECTED: 'DISCONNECTED',
   /** The request handler threw an unclassified error. */
   HANDLER_ERROR: 'HANDLER_ERROR',
+  /** The request exceeded its deadline without receiving a response. */
+  REQUEST_TIMEOUT: 'REQUEST_TIMEOUT',
 } as const;
 
 export type TransportErrorCode = (typeof TransportErrorCode)[keyof typeof TransportErrorCode];

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CommandService } from '../command-service.js';
+import { OrchestratorError } from '../orchestrator.js';
 import type { CommandEnvelope } from '@invoker/contracts';
 import type { Orchestrator } from '../orchestrator.js';
 import type { TaskState } from '@invoker/workflow-graph';
@@ -292,12 +293,20 @@ describe('CommandService', () => {
       expect(orchestrator.cancelTask).toHaveBeenCalledWith('t-1');
     });
 
-    it('returns error on exception', async () => {
+    it('returns typed error code from OrchestratorError', async () => {
       (orchestrator.cancelTask as ReturnType<typeof vi.fn>).mockImplementation(() => {
-        throw new Error('not found');
+        throw new OrchestratorError('TASK_NOT_FOUND', 'Task "bad" not found');
       });
       const result = await service.cancelTask(makeEnvelope({ taskId: 'bad' }));
-      expect(result).toEqual({ ok: false, error: { code: 'CANCEL_TASK_FAILED', message: 'not found' } });
+      expect(result).toEqual({ ok: false, error: { code: 'TASK_NOT_FOUND', message: 'Task "bad" not found' } });
+    });
+
+    it('returns generic error code for plain Error', async () => {
+      (orchestrator.cancelTask as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error('unexpected');
+      });
+      const result = await service.cancelTask(makeEnvelope({ taskId: 'bad' }));
+      expect(result).toEqual({ ok: false, error: { code: 'CANCEL_TASK_FAILED', message: 'unexpected' } });
     });
   });
 
@@ -311,7 +320,15 @@ describe('CommandService', () => {
       expect(orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1');
     });
 
-    it('returns error on exception', async () => {
+    it('returns typed error code from OrchestratorError', async () => {
+      (orchestrator.cancelWorkflow as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new OrchestratorError('WORKFLOW_NOT_FOUND', 'No tasks found for workflow bad');
+      });
+      const result = await service.cancelWorkflow(makeEnvelope({ workflowId: 'bad' }));
+      expect(result).toEqual({ ok: false, error: { code: 'WORKFLOW_NOT_FOUND', message: 'No tasks found for workflow bad' } });
+    });
+
+    it('returns generic error code for plain Error', async () => {
       (orchestrator.cancelWorkflow as ReturnType<typeof vi.fn>).mockImplementation(() => {
         throw new Error('wf not found');
       });

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CommandEnvelope, CommandResult } from '@invoker/contracts';
+import { OrchestratorError } from './orchestrator.js';
 import type { Orchestrator, ExternalGatePolicyUpdate, TaskReplacementDef } from './orchestrator.js';
 import type { TaskState } from '@invoker/workflow-graph';
 
@@ -473,10 +474,11 @@ export class CommandService {
       const data = await this.serializeForWorkflow(workflowId, fn);
       return { ok: true, data };
     } catch (err) {
+      const code = err instanceof OrchestratorError ? err.code : errorCode;
       return {
         ok: false,
         error: {
-          code: errorCode,
+          code,
           message: err instanceof Error ? err.message : String(err),
         },
       };

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -33,6 +33,24 @@ function mergeTrace(tag: string, data: Record<string, unknown>): void {
   } catch { /* best effort */ }
 }
 
+// ── Typed domain error codes ────────────────────────────────────
+export const OrchestratorErrorCode = {
+  TASK_NOT_FOUND: 'TASK_NOT_FOUND',
+  TASK_ALREADY_TERMINAL: 'TASK_ALREADY_TERMINAL',
+  WORKFLOW_NOT_FOUND: 'WORKFLOW_NOT_FOUND',
+} as const;
+
+export type OrchestratorErrorCode = (typeof OrchestratorErrorCode)[keyof typeof OrchestratorErrorCode];
+
+export class OrchestratorError extends Error {
+  readonly code: OrchestratorErrorCode;
+  constructor(code: OrchestratorErrorCode, message: string) {
+    super(message);
+    this.name = 'OrchestratorError';
+    this.code = code;
+  }
+}
+
 function isActiveForInvalidation(status: TaskStatus): boolean {
   return (
     status === 'running' ||
@@ -3587,11 +3605,11 @@ export class Orchestrator {
     this.refreshFromDb();
 
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task "${taskId}" not found`);
+    if (!task) throw new OrchestratorError('TASK_NOT_FOUND', `Task "${taskId}" not found`);
 
     const terminal = new Set(['completed', 'stale']);
     if (terminal.has(task.status)) {
-      throw new Error(`Task "${taskId}" is already ${task.status}`);
+      throw new OrchestratorError('TASK_ALREADY_TERMINAL', `Task "${taskId}" is already ${task.status}`);
     }
 
     // Find all transitive dependents, skipping completed/stale
@@ -3663,7 +3681,7 @@ export class Orchestrator {
       (t) => t.config.workflowId === workflowId,
     );
     if (allTasks.length === 0) {
-      throw new Error(`No tasks found for workflow ${workflowId}`);
+      throw new OrchestratorError('WORKFLOW_NOT_FOUND', `No tasks found for workflow ${workflowId}`);
     }
 
     const cancellable = new Set([


### PR DESCRIPTION
## Summary

Add owner-side retention pruning for completed mutation intents and output spool rows to keep persistence growth bounded over long runtimes.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- persisted-workflow-mutation-coordinator.test.ts`
- [x] `REPRO_TIMEOUT_SEC=20 node scripts/run-oom-benchmark-matrix.mjs step3-retention-pruning`

## Benchmark Results (PR3 vs PR2)

| metric (safe) | PR2 | PR3 | delta |
|---|---:|---:|---:|
| peak RSS (MB) | 564.3 | 564.0 | -0.3 |
| peak external (MB) | 490.3 | 490.3 | 0.0 |
| db growth (MB/min) | 385.63 | 382.63 | -3.0 |

Details: `benchmarks/oom/step3-retention-pruning-summary.md`.

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert b5b9cbf4`
- Post-revert steps: None.
- Data migration? No.
