### PR TITLE
Stacked divergence remediation 28 architecture docs and guardrails

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -104,6 +104,133 @@ When adding a new package:
 3. Add the package to the appropriate layer in this document
 4. Run `pnpm run check:all` to verify compliance
 
+## Mutation Boundary Policy
+
+All state-changing operations enter the system through one of three surfaces: UI (Electron IPC), API server (HTTP on 127.0.0.1:4100), and headless CLI. Every surface routes mutations through the same shared boundary — `WorkflowMutationFacade` (`packages/app/src/workflow-mutation-facade.ts`).
+
+### The mutation funnel
+
+```
+┌─────────────────────────────────────────────────┐
+│  Entry Surfaces                                 │
+│  UI (IPC)  │  API (HTTP)  │  Headless (CLI)     │
+└──────┬──────────┬──────────────┬────────────────┘
+       └──────────┼──────────────┘
+                  ▼
+       WorkflowMutationFacade
+       (mutate → filter runnable → execute → topup)
+                  │
+                  ▼
+       Shared Actions  (workflow-actions.ts)
+                  │
+                  ▼
+       CommandService  (workflow-local mutex)
+                  │
+                  ▼
+       Orchestrator  (domain state machine → persistence)
+```
+
+### Invariants
+
+1. **Single entry point.** No surface calls `Orchestrator` directly for mutations. All mutations go through `WorkflowMutationFacade`, which encapsulates the post-mutation lifecycle: call shared action → filter runnable tasks → dispatch via `TaskRunner` → run global topup.
+2. **Serialized mutations.** `CommandService` enforces a per-workflow promise-chain mutex. Concurrent mutations on the same workflow are queued, never interleaved. Different workflows may execute in parallel.
+3. **Command envelope.** Every mutation is wrapped in a `CommandEnvelope<P>` (`packages/contracts/src/command-envelope.ts`) carrying `commandId`, `source` (`'ui' | 'headless' | 'surface'`), `scope` (`'workflow' | 'task'`), `idempotencyKey`, and a typed `payload`.
+4. **No side doors.** New mutation paths must route through the facade. Direct `SQLiteAdapter` writes from new code paths are forbidden (enforced by `bash scripts/check-owner-boundary.sh`).
+
+### Adding a new mutation
+
+1. Add the orchestrator primitive in `packages/workflow-core/src/orchestrator.ts`.
+2. Add the shared action in `packages/app/src/workflow-actions.ts`.
+3. Add the facade method in `packages/app/src/workflow-mutation-facade.ts`, using `finalizeWithTopup` or `dispatchWithTopup`.
+4. Wire the facade method in each surface: `api-server.ts`, `headless.ts`, `main.ts`.
+5. Add a `CommandService` method if the mutation needs envelope-based routing.
+6. Add parity tests (see "Surface Parity Requirements" below).
+
+## Typed Error Contracts
+
+Errors crossing package or process boundaries carry a stable `code` field. Callers branch on the code, never on the message string.
+
+### Error types by layer
+
+| Layer | Type | Package | Codes |
+|-------|------|---------|-------|
+| 0 | `TransportError` | `@invoker/transport` | `NO_HANDLER`, `DISCONNECTED`, `HANDLER_ERROR`, `REQUEST_TIMEOUT` |
+| 0 | `CommandError` | `@invoker/contracts` | Stable string from `CommandResult.error.code` |
+| 1 | `OrchestratorError` | `@invoker/workflow-core` | `TASK_NOT_FOUND`, `TASK_ALREADY_TERMINAL`, `WORKFLOW_NOT_FOUND` |
+| 1 | `PlanConflictError` | `@invoker/workflow-core` | (conflict detection with `conflictingTaskIds`) |
+| 1 | `TopologyForkRequired` | `@invoker/workflow-core` | (signals immutable topology constraint) |
+| 3 | `MergeConflictError` | `@invoker/execution-engine` | (carries `failedBranch`, `conflictFiles`) |
+
+### CommandResult contract
+
+`CommandService` methods return `CommandResult<T>`, a discriminated union:
+
+```typescript
+type CommandResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: { code: string; message: string } };
+```
+
+Callers pattern-match on `result.ok`. No try-catch required at the call site.
+
+### HTTP status mapping
+
+The API server maps domain errors to HTTP status codes in `httpStatusForError()`:
+
+| Domain error | HTTP status |
+|---|---|
+| `OrchestratorError` with `TASK_NOT_FOUND` or `WORKFLOW_NOT_FOUND` | 404 |
+| `OrchestratorError` with `TASK_ALREADY_TERMINAL` | 409 |
+| `PlanConflictError` | 409 |
+| `TopologyForkRequired` | 409 |
+| All other errors | 400 |
+| Unhandled exceptions | 500 |
+
+Error responses use the shape `{ error: "<message>" }`.
+
+### Rules for new error types
+
+1. Define a typed error class with a `code` field (string literal or enum).
+2. Place it in the lowest-layer package where it originates.
+3. Never throw raw `Error` across package boundaries — wrap in a typed error.
+4. Add HTTP status mapping in `api-server.ts` `httpStatusForError()` if the error can reach the API surface.
+5. Add a test that the error code propagates through `CommandService` as `{ ok: false, error: { code } }`.
+
+## Surface Parity Requirements
+
+Every mutation must produce equivalent behavior across all three entry surfaces (UI, API, headless). This is enforced by the parity regression test suite (`packages/app/src/__tests__/parity-regression.test.ts`).
+
+### What "parity" means
+
+1. **Facade dispatch+topup lifecycle.** Every mutation method filters runnable tasks, dispatches via `TaskRunner`, and calls `startExecution` for global topup. The result shape is `{ started, runnable, topup }`.
+2. **API server → facade wiring.** Each HTTP write endpoint calls the correct facade method and returns a structured result.
+3. **Headless → CommandService routing.** Each CLI verb delegates to the corresponding `CommandService` method (not directly to `Orchestrator`).
+4. **CommandService → Orchestrator mutex.** Each command service method calls the correct orchestrator primitive under the workflow-scoped mutex.
+5. **Cross-surface isolation.** A mutation verb on one surface never accidentally triggers an unrelated mutation path.
+
+### Parity test groups
+
+The parity tests cover 5 dimensions:
+
+| Group | What it verifies |
+|-------|------------------|
+| Facade lifecycle | `started` → filter `runnable` → `executeTasks` → `startExecution` → topup dedup |
+| API wiring | HTTP endpoint → facade method → orchestrator call → 200 `{ ok: true }` |
+| CommandService routing | Envelope → correct orchestrator primitive → `{ ok: true }` |
+| Mutex serialization | Same-workflow mutations serialize; different-workflow mutations interleave |
+| Cross-surface isolation | `retryTask` does not trigger `recreateTask`; `approve` does not trigger `reject`; etc. |
+
+### Adding a new endpoint: parity checklist
+
+When adding a new mutation endpoint:
+
+- [ ] Wire the endpoint in all three surfaces (`api-server.ts`, `headless.ts`, `main.ts`) through `WorkflowMutationFacade`.
+- [ ] Add a facade lifecycle test: verify `started`, `runnable`, `topup` shape.
+- [ ] Add an API wiring test: verify HTTP verb + path → facade method → 200.
+- [ ] Add a CommandService routing test: verify envelope → orchestrator primitive → `{ ok: true }`.
+- [ ] Add cross-surface isolation assertions: verify the new mutation does not trigger unrelated mutations.
+- [ ] Run `pnpm test` in `packages/app` and `packages/workflow-core` to confirm all parity tests pass.
+
 ## Migration Notes
 
 This architecture was established during the package reorganization effort (workflow wf-1775366106244-5). The layered architecture prevents cycles and makes the system easier to understand and maintain.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,18 @@ For anything that touches the workflow database, use the headless commands (`pnp
 
 "I tested it mentally" is not a verification. PRs should describe what was actually run — `pnpm test`, `pnpm run check:all`, a specific headless command, a reproduced workflow — not what was reasoned about. If a behavior can't be exercised by a command, that's usually a sign the boundary it lives behind is too informal.
 
+### 7. Route mutations through the facade
+
+Every state-changing operation must go through `WorkflowMutationFacade`. The facade owns the post-mutation lifecycle: dispatch runnable tasks, run global topup, return a structured result. Adding a mutation that calls `Orchestrator` directly from a surface handler bypasses serialization, topup, and parity guarantees. See [ARCHITECTURE.md § Mutation Boundary Policy](ARCHITECTURE.md#mutation-boundary-policy) for the full invariant list.
+
+### 8. Use typed error codes, not message strings
+
+Errors that cross package boundaries must carry a stable `code` field. Callers branch on `error.code`, never parse `error.message`. New error types must be a class with a `code` property, placed in the lowest-layer package where the error originates. If the error can reach the API surface, add an HTTP status mapping in `httpStatusForError()`. See [ARCHITECTURE.md § Typed Error Contracts](ARCHITECTURE.md#typed-error-contracts).
+
+### 9. Maintain surface parity for new endpoints
+
+New mutation endpoints must be wired through all three surfaces (UI IPC, API HTTP, headless CLI) and covered by parity regression tests. The parity suite verifies that facade lifecycle, API wiring, CommandService routing, mutex serialization, and cross-surface isolation all hold. See [ARCHITECTURE.md § Surface Parity Requirements](ARCHITECTURE.md#surface-parity-requirements) for the checklist.
+
 ## What "code change" means here
 
 Because Invoker treats code changes as the output of a workflow, contributions to Invoker are themselves a small example of what Invoker orchestrates. A few practical implications:
@@ -57,7 +69,9 @@ Before requesting review, please confirm:
 
 - [ ] The change respects the layer rules in [ARCHITECTURE.md](ARCHITECTURE.md) (`pnpm run check:all` passes).
 - [ ] Tests pass (`pnpm test`, or `pnpm run test:all` for broader coverage).
-- [ ] Any new mutation goes through the existing command path; no direct DB writes from new code paths.
+- [ ] Any new mutation goes through `WorkflowMutationFacade`; no direct DB writes from new code paths.
+- [ ] Any new mutation endpoint is wired in all three surfaces (UI, API, headless) with parity tests.
+- [ ] Any new error type crossing a package boundary carries a typed `code` field, not just a message string.
 - [ ] Any new persisted field is reflected in types under `packages/workflow-graph/src/types.ts` and `packages/contracts/`.
 - [ ] The PR description names the verification commands you actually ran.
 - [ ] User-visible behavior changes are documented (in the README, in `docs/`, or in the relevant package README — wherever the existing description lives).

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import http from 'node:http';
 import { startApiServer, type ApiServer } from '../api-server.js';
+import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -972,7 +973,7 @@ describe('POST /api/workflows/:id/fork', () => {
 
   it('returns an error status when forkWorkflow throws', async () => {
     mocks.orchestrator.forkWorkflow.mockImplementationOnce(() => {
-      throw new Error('Workflow missing not found');
+      throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, 'Workflow missing not found');
     });
     const res = await request(port, 'POST', '/api/workflows/missing/fork');
     expect(res.status).toBe(404);
@@ -1024,7 +1025,7 @@ describe('DELETE /api/workflows/:id', () => {
   });
 
   it('returns 404 when workflow not found', async () => {
-    mocks.deleteWorkflow.mockRejectedValue(new Error('workflow not found'));
+    mocks.deleteWorkflow.mockRejectedValue(new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, 'workflow not found'));
     const res = await request(port, 'DELETE', '/api/workflows/missing');
     expect(res.status).toBe(404);
     expect(res.body.error).toBe('workflow not found');

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -3,10 +3,14 @@
  *
  * Starts a real HTTP server on an ephemeral port with fully mocked deps.
  * Uses Node's built-in http module to send requests and assert responses.
+ *
+ * All write endpoints route through a WorkflowMutationFacade instance
+ * which wraps the mocked orchestrator, persistence, and taskExecutor.
  */
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import http from 'node:http';
 import { startApiServer, type ApiServer } from '../api-server.js';
+import { WorkflowMutationFacade } from '../workflow-mutation-facade.js';
 import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -72,8 +76,6 @@ let mocks: {
   persistence: Record<string, ReturnType<typeof vi.fn>>;
   executorRegistry: Record<string, ReturnType<typeof vi.fn>>;
   taskExecutor: Record<string, ReturnType<typeof vi.fn>>;
-  cancelTask: ReturnType<typeof vi.fn>;
-  cancelWorkflow: ReturnType<typeof vi.fn>;
   killRunningTask: ReturnType<typeof vi.fn>;
   deleteWorkflow: ReturnType<typeof vi.fn>;
   detachWorkflow: ReturnType<typeof vi.fn>;
@@ -112,6 +114,10 @@ function createMocks() {
         running: [{ taskId: 'task-1', description: 'test' }],
         queued: [],
       })),
+      cancelWorkflow: vi.fn(() => ({
+        cancelled: ['task-1'],
+        runningCancelled: ['task-1'],
+      })),
     },
     persistence: {
       listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'test', generation: 1 }]),
@@ -129,12 +135,19 @@ function createMocks() {
       fixWithAgent: vi.fn().mockResolvedValue(undefined),
       commitApprovedFix: vi.fn().mockResolvedValue(undefined),
     },
-    cancelTask: vi.fn().mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] }),
-    cancelWorkflow: vi.fn().mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] }),
     killRunningTask: vi.fn().mockResolvedValue(undefined),
     deleteWorkflow: vi.fn().mockResolvedValue(undefined),
     detachWorkflow: vi.fn().mockResolvedValue(undefined),
   };
+}
+
+function buildFacade(m: typeof mocks) {
+  return new WorkflowMutationFacade({
+    orchestrator: m.orchestrator as any,
+    persistence: m.persistence as any,
+    taskExecutor: m.taskExecutor as any,
+    killRunningTask: m.killRunningTask,
+  });
 }
 
 beforeAll(async () => {
@@ -145,10 +158,7 @@ beforeAll(async () => {
     orchestrator: mocks.orchestrator as any,
     persistence: mocks.persistence as any,
     executorRegistry: mocks.executorRegistry as any,
-    taskExecutor: mocks.taskExecutor as any,
-    cancelTask: mocks.cancelTask,
-    cancelWorkflow: mocks.cancelWorkflow,
-    killRunningTask: mocks.killRunningTask,
+    mutations: buildFacade(mocks),
     deleteWorkflow: mocks.deleteWorkflow,
     detachWorkflow: mocks.detachWorkflow,
   });
@@ -176,8 +186,6 @@ beforeEach(() => {
       if (typeof fn === 'function' && 'mockClear' in fn) fn.mockClear();
     }
   }
-  mocks.cancelTask.mockClear();
-  mocks.cancelWorkflow.mockClear();
   mocks.killRunningTask.mockClear();
   mocks.deleteWorkflow.mockClear();
   mocks.detachWorkflow.mockClear();
@@ -195,6 +203,7 @@ beforeEach(() => {
   mocks.orchestrator.editTaskType.mockReturnValue([makeTask()]);
   mocks.orchestrator.setTaskExternalGatePolicies.mockReturnValue([makeTask()]);
   mocks.orchestrator.cancelTask.mockReturnValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
+  mocks.orchestrator.cancelWorkflow.mockReturnValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
   mocks.orchestrator.getQueueStatus.mockReturnValue({
     maxConcurrency: 4, runningCount: 1,
     running: [{ taskId: 'task-1', description: 'test' }], queued: [],
@@ -204,8 +213,6 @@ beforeEach(() => {
   mocks.persistence.loadTasks.mockReturnValue([]);
   mocks.persistence.getEvents.mockReturnValue([{ taskId: 'task-1', eventType: 'started', timestamp: '2024-01-01' }]);
   mocks.persistence.getTaskOutput.mockReturnValue('hello world output');
-  mocks.cancelTask.mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
-  mocks.cancelWorkflow.mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
   mocks.killRunningTask.mockResolvedValue(undefined);
   mocks.deleteWorkflow.mockResolvedValue(undefined);
   mocks.taskExecutor.executeTasks.mockResolvedValue(undefined);
@@ -313,92 +320,32 @@ describe('GET /api/tasks/:id/output', () => {
 // ── Write endpoints ──────────────────────────────────────────
 
 describe('POST /api/tasks/:id/cancel', () => {
-  it('cancels task via cancelTask callback', async () => {
+  it('cancels task via facade', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/cancel');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(mocks.cancelTask).toHaveBeenCalledWith('task-1');
+    expect(mocks.orchestrator.cancelTask).toHaveBeenCalledWith('task-1');
     expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
-  });
-
-  it('falls back to orchestrator.cancelTask when callback not provided', async () => {
-    // Create a server without cancelTask callback
-    const noCancelMocks = createMocks();
-    const noCancelApi = startApiServer({
-      orchestrator: noCancelMocks.orchestrator as any,
-      persistence: noCancelMocks.persistence as any,
-      executorRegistry: noCancelMocks.executorRegistry as any,
-      taskExecutor: noCancelMocks.taskExecutor as any,
-      killRunningTask: noCancelMocks.killRunningTask,
-      // no cancelTask
-    });
-    await new Promise<void>((resolve) => {
-      if (noCancelApi.server.listening) resolve();
-      else noCancelApi.server.on('listening', resolve);
-    });
-    const noCancelPort = (noCancelApi.server.address() as any).port;
-
-    try {
-      const res = await request(noCancelPort, 'POST', '/api/tasks/task-1/cancel');
-      expect(res.status).toBe(200);
-      expect(res.body.ok).toBe(true);
-      expect(noCancelMocks.orchestrator.cancelTask).toHaveBeenCalledWith('task-1');
-      expect(noCancelMocks.orchestrator.startExecution).toHaveBeenCalled();
-    } finally {
-      await noCancelApi.close();
-    }
   });
 });
 
 describe('POST /api/workflows/:id/cancel', () => {
-  it('cancels workflow via cancelWorkflow callback', async () => {
+  it('cancels workflow via facade', async () => {
     const res = await request(port, 'POST', '/api/workflows/wf-1/cancel');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(mocks.cancelWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(mocks.orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1');
     expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
-  });
-
-  it('falls back to shared cancelWorkflow when callback not provided', async () => {
-    const noCancelMocks = createMocks();
-    noCancelMocks.orchestrator.cancelWorkflow = vi.fn(() => ({
-      cancelled: ['task-1'],
-      runningCancelled: ['task-1'],
-    }));
-    const noCancelApi = startApiServer({
-      orchestrator: noCancelMocks.orchestrator as any,
-      persistence: noCancelMocks.persistence as any,
-      executorRegistry: noCancelMocks.executorRegistry as any,
-      taskExecutor: noCancelMocks.taskExecutor as any,
-      killRunningTask: noCancelMocks.killRunningTask,
-      // no cancelWorkflow
-    });
-    await new Promise<void>((resolve) => {
-      if (noCancelApi.server.listening) resolve();
-      else noCancelApi.server.on('listening', resolve);
-    });
-    const noCancelPort = (noCancelApi.server.address() as any).port;
-
-    try {
-      const res = await request(noCancelPort, 'POST', '/api/workflows/wf-1/cancel');
-      expect(res.status).toBe(200);
-      expect(res.body.ok).toBe(true);
-      expect(noCancelMocks.orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1');
-      expect(noCancelMocks.orchestrator.startExecution).toHaveBeenCalled();
-    } finally {
-      await noCancelApi.close();
-    }
   });
 });
 
 describe('POST /api/tasks/:id/restart', () => {
-  it('restarts task via shared retryTask', async () => {
+  it('restarts task via facade retryTask', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/restart');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('restarted');
     expect(mocks.orchestrator.retryTask).toHaveBeenCalledWith('task-1');
-    expect(mocks.killRunningTask).toHaveBeenCalledWith('task-1');
   });
 
   it('returns 400 on error', async () => {
@@ -454,7 +401,7 @@ describe('POST /api/tasks/:id/restart', () => {
 });
 
 describe('POST /api/tasks/:id/approve', () => {
-  it('approves task', async () => {
+  it('approves task via facade', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/approve');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
@@ -499,15 +446,7 @@ describe('POST /api/tasks/:id/approve', () => {
     expect(res.body.error).toBe('not awaiting approval');
   });
 
-  // Step 16 (`docs/architecture/task-invalidation-roadmap.md`,
-  // chart row "Approve or reject fix"): the api-server's
-  // approve POST is the chart's **second** non-invalidating
-  // surface (alongside `gate-policy` from Step 15). It MUST
-  // route to `Orchestrator.approve` (or `resumeTaskAfterFixApproval`
-  // / `commitApprovedFix` for the fix branch) and MUST NOT
-  // trigger any retry/recreate spy on the orchestrator. By the
-  // time approve runs the task is already terminal — cancel
-  // here would also be a generation-bumping mistake.
+  // Step 16: approve POST does not trigger retry/recreate/cancel routes
   it('Step 16: approve POST does not trigger retry/recreate/cancel routes', async () => {
     mocks.orchestrator.recreateTask = vi.fn();
     mocks.orchestrator.recreateWorkflow = vi.fn();
@@ -523,38 +462,6 @@ describe('POST /api/tasks/:id/approve', () => {
     expect(mocks.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
     expect(mocks.orchestrator.cancelTask).not.toHaveBeenCalled();
     expect(mocks.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('uses approveTaskAction when provided', async () => {
-    const approveTaskAction = vi.fn().mockResolvedValue({ started: [] });
-    const isolatedApi = startApiServer({
-      orchestrator: mocks.orchestrator as any,
-      persistence: mocks.persistence as any,
-      executorRegistry: mocks.executorRegistry as any,
-      taskExecutor: mocks.taskExecutor as any,
-      approveTaskAction,
-      cancelTask: mocks.cancelTask,
-      cancelWorkflow: mocks.cancelWorkflow,
-      killRunningTask: mocks.killRunningTask,
-    });
-    await new Promise<void>((resolve) => {
-      if (isolatedApi.server.listening) {
-        resolve();
-      } else {
-        isolatedApi.server.on('listening', resolve);
-      }
-    });
-    const addr = isolatedApi.server.address();
-    const isolatedPort = typeof addr === 'object' && addr ? addr.port : isolatedApi.port;
-
-    try {
-      const res = await request(isolatedPort, 'POST', '/api/tasks/task-1/approve');
-      expect(res.status).toBe(200);
-      expect(approveTaskAction).toHaveBeenCalledWith('task-1');
-      expect(mocks.orchestrator.approve).not.toHaveBeenCalled();
-    } finally {
-      await isolatedApi.close();
-    }
   });
 });
 
@@ -592,16 +499,7 @@ describe('POST /api/tasks/:id/reject', () => {
     expect(mocks.orchestrator.reject).not.toHaveBeenCalled();
   });
 
-  // Step 16 (`docs/architecture/task-invalidation-roadmap.md`,
-  // chart row "Approve or reject fix"): the api-server's
-  // reject POST is the revert-class half of the second
-  // non-invalidating surface (alongside Step 15's gate-policy
-  // POST). It MUST route to `Orchestrator.reject` (or
-  // `revertConflictResolution` for the fix-flow branch) and
-  // MUST NOT trigger any retry/recreate/cancel spy on the
-  // orchestrator. By the time reject runs the task is already
-  // terminal — invalidating would be a generation-bumping
-  // mistake.
+  // Step 16: reject POST does not trigger retry/recreate/cancel routes (non-fix path)
   it('Step 16: reject POST does not trigger retry/recreate/cancel routes (non-fix path)', async () => {
     mocks.orchestrator.recreateTask = vi.fn();
     mocks.orchestrator.recreateWorkflow = vi.fn();
@@ -641,40 +539,6 @@ describe('POST /api/tasks/:id/reject', () => {
     expect(mocks.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
     expect(mocks.orchestrator.cancelTask).not.toHaveBeenCalled();
     expect(mocks.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('uses rejectTaskAction when provided', async () => {
-    const rejectTaskAction = vi.fn().mockResolvedValue(undefined);
-    const isolatedApi = startApiServer({
-      orchestrator: mocks.orchestrator as any,
-      persistence: mocks.persistence as any,
-      executorRegistry: mocks.executorRegistry as any,
-      taskExecutor: mocks.taskExecutor as any,
-      rejectTaskAction,
-      cancelTask: mocks.cancelTask,
-      cancelWorkflow: mocks.cancelWorkflow,
-      killRunningTask: mocks.killRunningTask,
-      deleteWorkflow: mocks.deleteWorkflow,
-      detachWorkflow: mocks.detachWorkflow,
-    });
-    await new Promise<void>((resolve) => {
-      if (isolatedApi.server.listening) {
-        resolve();
-      } else {
-        isolatedApi.server.on('listening', resolve);
-      }
-    });
-    const addr = isolatedApi.server.address();
-    const isolatedPort = typeof addr === 'object' && addr ? addr.port : isolatedApi.port;
-
-    try {
-      const res = await request(isolatedPort, 'POST', '/api/tasks/task-1/reject', { reason: 'bad' });
-      expect(res.status).toBe(200);
-      expect(rejectTaskAction).toHaveBeenCalledWith('task-1', 'bad');
-      expect(mocks.orchestrator.reject).not.toHaveBeenCalled();
-    } finally {
-      await isolatedApi.close();
-    }
   });
 });
 
@@ -718,7 +582,7 @@ describe('POST /api/tasks/:id/edit-prompt', () => {
     expect(res.body.action).toBe('prompt_edited');
     expect(mocks.orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-1', 'do the thing');
     expect(mocks.orchestrator.editTaskCommand).not.toHaveBeenCalled();
-    // Endpoint dispatches any newly-runnable tasks via the executor.
+    // Facade dispatches any newly-runnable tasks via the executor.
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
   });
 
@@ -779,7 +643,7 @@ describe('POST /api/tasks/:id/edit-type', () => {
     expect(res.body.error).toContain('Missing "executorType"');
   });
 
-  it('forwards a remoteTargetId-only change (host change) so the orchestrator can take the recreate-class branch', async () => {
+  it('forwards a remoteTargetId-only change (host change)', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/edit-type', {
       executorType: 'ssh',
       remoteTargetId: 'remote-b',
@@ -787,11 +651,6 @@ describe('POST /api/tasks/:id/edit-type', () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('type_edited');
-    // Both args are forwarded — `Orchestrator.editTaskType` uses them
-    // to compute the host-key and pick the recreate-class fork
-    // (see `MUTATION_POLICIES.remoteTargetId` and orchestrator unit
-    // coverage). No new public surface; the recreate-vs-retry choice
-    // is internal.
     expect(mocks.orchestrator.editTaskType).toHaveBeenCalledWith('task-1', 'ssh', 'remote-b');
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
   });
@@ -806,7 +665,7 @@ describe('POST /api/tasks/:id/edit-agent', () => {
     expect(mocks.orchestrator.editTaskAgent).toHaveBeenCalledWith('task-1', 'codex');
     expect(mocks.orchestrator.editTaskCommand).not.toHaveBeenCalled();
     expect(mocks.orchestrator.editTaskPrompt).not.toHaveBeenCalled();
-    // Endpoint dispatches any newly-runnable tasks via the executor.
+    // Facade dispatches any newly-runnable tasks via the executor.
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
   });
 
@@ -840,12 +699,7 @@ describe('POST /api/tasks/:id/gate-policy', () => {
     expect(res.body.error).toContain('Missing non-empty "updates" array');
   });
 
-  // Step 15 (`docs/architecture/task-invalidation-roadmap.md`,
-  // chart row "Change external gate policy"): the api-server's
-  // gate-policy POST is the chart's intentional non-invalidating
-  // surface. It MUST route to `setTaskExternalGatePolicies` and
-  // MUST NOT trigger any retry/recreate spy on the orchestrator.
-  // This pins the cross-cutting contract at the http boundary.
+  // Step 15: gate-policy POST does not trigger retry/recreate routes
   it('Step 15: gate-policy POST does not trigger retry/recreate routes', async () => {
     mocks.orchestrator.recreateTask = vi.fn();
     mocks.orchestrator.recreateWorkflow = vi.fn();
@@ -869,7 +723,7 @@ describe('POST /api/tasks/:id/gate-policy', () => {
 });
 
 describe('POST /api/workflows/:id/restart', () => {
-  it('restarts workflow via shared function', async () => {
+  it('restarts workflow via facade recreateWorkflow', async () => {
     mocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask()]);
     const res = await request(port, 'POST', '/api/workflows/wf-1/restart');
     expect(res.status).toBe(200);
@@ -954,14 +808,9 @@ describe('POST /api/workflows/:id/rebase-and-retry', () => {
   });
 });
 
-// Step 14 (`docs/architecture/task-invalidation-roadmap.md`,
-// chart "Topology inconsistency"): live-workflow topology
-// mutations now route through `Orchestrator.forkWorkflow` and
-// surfaces expose an explicit `fork` verb. The api-server
-// returns both the source and forked workflow ids so callers
-// can follow the new workflow.
+// Step 14: live-workflow topology mutations route through Orchestrator.forkWorkflow
 describe('POST /api/workflows/:id/fork', () => {
-  it('forks the workflow via shared forkWorkflow and returns both ids', async () => {
+  it('forks the workflow via facade and returns both ids', async () => {
     const res = await request(port, 'POST', '/api/workflows/wf-1/fork');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
@@ -1015,7 +864,7 @@ describe('POST /api/workflows/:id/recreate-with-rebase', () => {
 });
 
 describe('DELETE /api/workflows/:id', () => {
-  it('deletes workflow via shared deleteWorkflow bridge', async () => {
+  it('deletes workflow via deleteWorkflow callback', async () => {
     const res = await request(port, 'DELETE', '/api/workflows/wf-1');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -75,6 +75,7 @@ let mocks: {
   cancelWorkflow: ReturnType<typeof vi.fn>;
   killRunningTask: ReturnType<typeof vi.fn>;
   deleteWorkflow: ReturnType<typeof vi.fn>;
+  detachWorkflow: ReturnType<typeof vi.fn>;
 };
 
 function createMocks() {
@@ -131,6 +132,7 @@ function createMocks() {
     cancelWorkflow: vi.fn().mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] }),
     killRunningTask: vi.fn().mockResolvedValue(undefined),
     deleteWorkflow: vi.fn().mockResolvedValue(undefined),
+    detachWorkflow: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -147,6 +149,7 @@ beforeAll(async () => {
     cancelWorkflow: mocks.cancelWorkflow,
     killRunningTask: mocks.killRunningTask,
     deleteWorkflow: mocks.deleteWorkflow,
+    detachWorkflow: mocks.detachWorkflow,
   });
   // Wait for the server to start listening
   await new Promise<void>((resolve) => {
@@ -176,6 +179,7 @@ beforeEach(() => {
   mocks.cancelWorkflow.mockClear();
   mocks.killRunningTask.mockClear();
   mocks.deleteWorkflow.mockClear();
+  mocks.detachWorkflow.mockClear();
 
   // Re-apply default return values after clear
   mocks.orchestrator.getWorkflowStatus.mockReturnValue({ total: 1, completed: 0, failed: 0, running: 1, pending: 0 });
@@ -1001,7 +1005,7 @@ describe('POST /api/workflows/:id/detach', () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('detached');
-    expect(mocks.orchestrator.detachWorkflow).toHaveBeenCalledWith('wf-1', 'wf-0');
+    expect(mocks.detachWorkflow).toHaveBeenCalledWith('wf-1', 'wf-0');
   });
 
   it('returns 400 when upstreamWorkflowId is missing', async () => {

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -641,6 +641,40 @@ describe('POST /api/tasks/:id/reject', () => {
     expect(mocks.orchestrator.cancelTask).not.toHaveBeenCalled();
     expect(mocks.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
   });
+
+  it('uses rejectTaskAction when provided', async () => {
+    const rejectTaskAction = vi.fn().mockResolvedValue(undefined);
+    const isolatedApi = startApiServer({
+      orchestrator: mocks.orchestrator as any,
+      persistence: mocks.persistence as any,
+      executorRegistry: mocks.executorRegistry as any,
+      taskExecutor: mocks.taskExecutor as any,
+      rejectTaskAction,
+      cancelTask: mocks.cancelTask,
+      cancelWorkflow: mocks.cancelWorkflow,
+      killRunningTask: mocks.killRunningTask,
+      deleteWorkflow: mocks.deleteWorkflow,
+      detachWorkflow: mocks.detachWorkflow,
+    });
+    await new Promise<void>((resolve) => {
+      if (isolatedApi.server.listening) {
+        resolve();
+      } else {
+        isolatedApi.server.on('listening', resolve);
+      }
+    });
+    const addr = isolatedApi.server.address();
+    const isolatedPort = typeof addr === 'object' && addr ? addr.port : isolatedApi.port;
+
+    try {
+      const res = await request(isolatedPort, 'POST', '/api/tasks/task-1/reject', { reason: 'bad' });
+      expect(res.status).toBe(200);
+      expect(rejectTaskAction).toHaveBeenCalledWith('task-1', 'bad');
+      expect(mocks.orchestrator.reject).not.toHaveBeenCalled();
+    } finally {
+      await isolatedApi.close();
+    }
+  });
 });
 
 describe('POST /api/tasks/:id/input', () => {

--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -898,10 +898,10 @@ describe('POST /api/workflows/:id/restart', () => {
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
   });
 
-  it('returns 400 on error', async () => {
+  it('returns 404 when workflow not found', async () => {
     mocks.persistence.loadWorkflow.mockReturnValue(undefined);
     const res = await request(port, 'POST', '/api/workflows/missing/restart');
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(404);
     expect(res.body.error).toContain('not found');
   });
 
@@ -1023,10 +1023,10 @@ describe('DELETE /api/workflows/:id', () => {
     expect(mocks.orchestrator.deleteWorkflow).not.toHaveBeenCalled();
   });
 
-  it('returns 400 on error', async () => {
+  it('returns 404 when workflow not found', async () => {
     mocks.deleteWorkflow.mockRejectedValue(new Error('workflow not found'));
     const res = await request(port, 'DELETE', '/api/workflows/missing');
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(404);
     expect(res.body.error).toBe('workflow not found');
   });
 });

--- a/packages/app/src/__tests__/delete-all-lifecycle.test.ts
+++ b/packages/app/src/__tests__/delete-all-lifecycle.test.ts
@@ -1,0 +1,324 @@
+/**
+ * Regression tests for delete-all lifecycle invariants.
+ *
+ * Validates:
+ *   1. Process cleanup — active tasks killed before orchestrator purge.
+ *   2. Task/workflow state parity — DB, memory, and scheduler are empty
+ *      after delete-all completes.
+ *   3. Removal delta publishing — one removal delta per pre-existing task.
+ *   4. Ordering — DB purge → scheduler kill → memory clear → deltas.
+ *   5. Headless path — no process kill when taskExecutor is absent.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import type { Orchestrator } from '@invoker/workflow-core';
+import type { TaskRunner } from '@invoker/execution-engine';
+import { deleteAllWorkflows } from '../workflow-actions.js';
+
+vi.mock('../delete-all-snapshot.js', () => ({
+  createDeleteAllSnapshot: () => '/tmp/fake-snapshot',
+}));
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'task-a',
+    status: 'pending' as const,
+    description: 'test task',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { workflowId: 'wf-1' },
+    execution: {},
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe('delete-all lifecycle invariants', () => {
+  describe('process cleanup ordering', () => {
+    it('kills every running and fixing_with_ai task before calling orchestrator.deleteAllWorkflows', async () => {
+      const callOrder: string[] = [];
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [
+          makeTask({ id: 'wf-1/r1', status: 'running' }),
+          makeTask({ id: 'wf-1/f1', status: 'fixing_with_ai' }),
+          makeTask({ id: 'wf-1/r2', status: 'running' }),
+          makeTask({ id: 'wf-2/p1', status: 'pending' }),
+          makeTask({ id: 'wf-2/c1', status: 'completed' }),
+          makeTask({ id: 'wf-2/fail1', status: 'failed' }),
+        ]),
+        deleteAllWorkflows: vi.fn(() => callOrder.push('deleteAll')),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn(async (id: string) => {
+          callOrder.push(`kill:${id}`);
+        }),
+      };
+
+      await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+      });
+
+      // Only running and fixing_with_ai tasks are killed
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledTimes(3);
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('wf-1/r1');
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('wf-1/f1');
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('wf-1/r2');
+
+      // Every kill must precede the orchestrator purge
+      const deleteAllIdx = callOrder.indexOf('deleteAll');
+      const killIndices = callOrder
+        .map((entry, i) => (entry.startsWith('kill:') ? i : -1))
+        .filter((i) => i >= 0);
+
+      expect(killIndices.length).toBe(3);
+      for (const killIdx of killIndices) {
+        expect(killIdx).toBeLessThan(deleteAllIdx);
+      }
+    });
+
+    it('does not kill pending, completed, or failed tasks', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [
+          makeTask({ id: 'wf-1/p1', status: 'pending' }),
+          makeTask({ id: 'wf-1/c1', status: 'completed' }),
+          makeTask({ id: 'wf-1/fail1', status: 'failed' }),
+          makeTask({ id: 'wf-1/cancel1', status: 'cancelled' }),
+          makeTask({ id: 'wf-1/await1', status: 'awaiting_approval' }),
+        ]),
+        deleteAllWorkflows: vi.fn(),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+      });
+
+      expect(taskExecutor.killActiveExecution).not.toHaveBeenCalled();
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('task/workflow state parity', () => {
+    it('calls orchestrator.deleteAllWorkflows exactly once regardless of task count', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [
+          makeTask({ id: 'wf-1/t1', status: 'running' }),
+          makeTask({ id: 'wf-1/t2', status: 'running' }),
+          makeTask({ id: 'wf-2/t1', status: 'running' }),
+        ]),
+        deleteAllWorkflows: vi.fn(),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+      });
+
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    });
+
+    it('succeeds with zero tasks (empty state)', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => []),
+        deleteAllWorkflows: vi.fn(),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+      });
+
+      expect(taskExecutor.killActiveExecution).not.toHaveBeenCalled();
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('headless path (no taskExecutor)', () => {
+    it('skips process cleanup entirely when taskExecutor is absent', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [makeTask({ id: 'r1', status: 'running' })]),
+        deleteAllWorkflows: vi.fn(),
+      };
+
+      await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        // taskExecutor intentionally omitted
+      });
+
+      // getAllTasks should not be called when no taskExecutor
+      expect(orchestrator.getAllTasks).not.toHaveBeenCalled();
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns snapshot path even when taskExecutor is absent', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => []),
+        deleteAllWorkflows: vi.fn(),
+      };
+
+      const result = await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+      });
+
+      expect(result.snapshotPath).toBe('/tmp/fake-snapshot');
+    });
+  });
+
+  describe('snapshot lifecycle', () => {
+    it('creates snapshot before any kill or purge operation', async () => {
+      const callOrder: string[] = [];
+      const orchestrator = {
+        getAllTasks: vi.fn(() => {
+          callOrder.push('getAllTasks');
+          return [makeTask({ id: 'r1', status: 'running' })];
+        }),
+        deleteAllWorkflows: vi.fn(() => callOrder.push('deleteAll')),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn(async () => callOrder.push('kill')),
+      };
+
+      const result = await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+      });
+
+      // Snapshot is returned (created before any other operation in the function)
+      expect(result.snapshotPath).toBe('/tmp/fake-snapshot');
+
+      // The operations happen in order: getAllTasks → kill → deleteAll
+      expect(callOrder).toEqual(['getAllTasks', 'kill', 'deleteAll']);
+    });
+  });
+
+  describe('multi-workflow coverage', () => {
+    it('kills active tasks across multiple workflows', async () => {
+      const killedIds: string[] = [];
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [
+          makeTask({ id: 'wf-1/t1', status: 'running', config: { workflowId: 'wf-1' } }),
+          makeTask({ id: 'wf-1/t2', status: 'pending', config: { workflowId: 'wf-1' } }),
+          makeTask({ id: 'wf-2/t1', status: 'fixing_with_ai', config: { workflowId: 'wf-2' } }),
+          makeTask({ id: 'wf-2/t2', status: 'completed', config: { workflowId: 'wf-2' } }),
+          makeTask({ id: 'wf-3/t1', status: 'running', config: { workflowId: 'wf-3' } }),
+        ]),
+        deleteAllWorkflows: vi.fn(),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn(async (id: string) => killedIds.push(id)),
+      };
+
+      await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+      });
+
+      // Active tasks from all workflows are killed
+      expect(killedIds).toEqual(['wf-1/t1', 'wf-2/t1', 'wf-3/t1']);
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('kill error resilience', () => {
+    it('continues killing remaining tasks when one kill fails', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [
+          makeTask({ id: 'wf-1/t1', status: 'running' }),
+          makeTask({ id: 'wf-1/t2', status: 'running' }),
+          makeTask({ id: 'wf-1/t3', status: 'running' }),
+        ]),
+        deleteAllWorkflows: vi.fn(),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn()
+          .mockResolvedValueOnce(undefined)
+          .mockRejectedValueOnce(new Error('kill failed for t2'))
+          .mockResolvedValueOnce(undefined),
+      };
+
+      // Should reject because the kill throws
+      await expect(
+        deleteAllWorkflows({
+          orchestrator: orchestrator as unknown as Orchestrator,
+          taskExecutor: taskExecutor as unknown as TaskRunner,
+        }),
+      ).rejects.toThrow('kill failed for t2');
+
+      // First kill succeeded, second threw, third was never reached
+      // (sequential awaiting — the loop stops at the first rejection)
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('logger integration', () => {
+    it('logs each killed task id when logger is provided', async () => {
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [
+          makeTask({ id: 'wf-1/t1', status: 'running' }),
+          makeTask({ id: 'wf-1/t2', status: 'fixing_with_ai' }),
+        ]),
+        deleteAllWorkflows: vi.fn(),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+        logger: logger as any,
+      });
+
+      // Snapshot log
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('snapshot'),
+        expect.objectContaining({ module: 'workflow' }),
+      );
+      // Per-task kill logs
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('wf-1/t1'),
+        expect.objectContaining({ module: 'kill' }),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('wf-1/t2'),
+        expect.objectContaining({ module: 'kill' }),
+      );
+    });
+
+    it('succeeds without logger (optional logging)', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [makeTask({ id: 'r1', status: 'running' })]),
+        deleteAllWorkflows: vi.fn(),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn().mockResolvedValue(undefined),
+      };
+
+      // No logger provided — should not throw
+      const result = await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+      });
+
+      expect(result.snapshotPath).toBe('/tmp/fake-snapshot');
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1506,7 +1506,7 @@ describe('headless delegation enforcement', () => {
         // Owner registers handler that accepts mutations
         const ownerHandler = vi.fn(async () => {
           // Owner has writable persistence and can execute
-          return { success: true, workflowId: 'wf-test' };
+          return { ok: true };
         });
         mockDeps.messageBus.onRequest('headless.exec', ownerHandler);
 
@@ -1529,7 +1529,7 @@ describe('headless delegation enforcement', () => {
 
       it('delegates all mutation commands deterministically', async () => {
         (mockDeps.persistence as any).readOnly = true;
-        const ownerHandler = vi.fn(async () => ({ success: true }));
+        const ownerHandler = vi.fn(async () => ({ ok: true }));
         mockDeps.messageBus.onRequest('headless.exec', ownerHandler);
 
         const { tryDelegateExec } = await import('../headless.js');

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1614,31 +1614,40 @@ describe('headless delegation enforcement', () => {
     });
   });
 
-  describe('delete-workflow shared bridge', () => {
-    it('headless delete-workflow uses deleteWorkflow dep when available', async () => {
-      const deleteWorkflow = vi.fn().mockResolvedValue(undefined);
+  describe('delete-workflow lifecycle bridge', () => {
+    it('headless delete-workflow always routes through commandService.deleteWorkflow', async () => {
       mockDeps.commandService.deleteWorkflow = vi.fn(async () => ({ ok: true as const, data: undefined })) as any;
-      const depsWithDelete: HeadlessDeps = {
-        ...mockDeps,
-        deleteWorkflow,
-      } as HeadlessDeps;
+      mockDeps.commandService.cancelWorkflow = vi.fn(async () => ({
+        ok: true as const,
+        data: { cancelled: [], runningCancelled: [] },
+      }));
 
-      await runHeadless(['delete-workflow', 'wf-1'], depsWithDelete);
-
-      expect(deleteWorkflow).toHaveBeenCalledWith('wf-1');
-      expect(mockDeps.commandService.deleteWorkflow).not.toHaveBeenCalled();
-    });
-
-    it('headless delete falls back to commandService when deleteWorkflow dep is not provided', async () => {
-      mockDeps.commandService.deleteWorkflow = vi.fn(async () => ({ ok: true as const, data: undefined })) as any;
-      const depsWithoutDelete: HeadlessDeps = {
-        ...mockDeps,
-        deleteWorkflow: undefined,
-      } as HeadlessDeps;
-
-      await runHeadless(['delete', 'wf-1'], depsWithoutDelete);
+      await runHeadless(['delete-workflow', 'wf-1'], mockDeps);
 
       expect(mockDeps.commandService.deleteWorkflow).toHaveBeenCalled();
+    });
+
+    it('headless delete preempts running tasks before commandService.deleteWorkflow', async () => {
+      const callOrder: string[] = [];
+      const preemptWorkflowExecution = vi.fn(async () => {
+        callOrder.push('preempt');
+        return { cancelled: ['wf-1/task-1'], runningCancelled: ['wf-1/task-1'] };
+      });
+      mockDeps.commandService.deleteWorkflow = vi.fn(async () => {
+        callOrder.push('delete');
+        return { ok: true as const, data: undefined };
+      }) as any;
+
+      const depsWithPreempt: HeadlessDeps = {
+        ...mockDeps,
+        preemptWorkflowExecution,
+      } as HeadlessDeps;
+
+      await runHeadless(['delete', 'wf-1'], depsWithPreempt);
+
+      expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+      expect(mockDeps.commandService.deleteWorkflow).toHaveBeenCalled();
+      expect(callOrder).toEqual(['preempt', 'delete']);
     });
   });
 });

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1514,13 +1514,13 @@ describe('headless delegation enforcement', () => {
         const { tryDelegateExec } = await import('../headless.js');
 
         // Headless delegates mutation to owner
-        const delegated = await tryDelegateExec(
+        const outcome = await tryDelegateExec(
           ['run', '/path/to/plan.yaml'],
           mockDeps.messageBus
         );
 
-        // Verify delegation succeeded
-        expect(delegated).toBe(true);
+        // Verify delegation succeeded — outcome is a DelegationOutcome union
+        expect(outcome.kind).toBe('delegated');
         expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
           args: ['run', '/path/to/plan.yaml'],
           waitForApproval: undefined,
@@ -1543,8 +1543,8 @@ describe('headless delegation enforcement', () => {
         ];
 
         for (const cmd of mutationCommands) {
-          const delegated = await tryDelegateExec(cmd, mockDeps.messageBus);
-          expect(delegated).toBe(true);
+          const outcome = await tryDelegateExec(cmd, mockDeps.messageBus);
+          expect(outcome.kind).toBe('delegated');
         }
 
         expect(ownerHandler).toHaveBeenCalledTimes(mutationCommands.length);

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -94,9 +94,9 @@ describe('headless→owner delegation', () => {
   describe('successful delegation when owner is present', () => {
     it('delegates mutation command to owner via RPC', async () => {
       // Simulate owner process registering a handler
-      const ownerHandler = vi.fn(async (req: { args: string[] }) => {
+      const ownerHandler = vi.fn(async (_req: { args: string[] }) => {
         // Owner successfully executed the command
-        return { success: true, workflowId: 'wf-test' };
+        return { ok: true };
       });
 
       messageBus.onRequest('headless.exec', ownerHandler);
@@ -114,7 +114,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates with waitForApproval flag', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       await tryDelegateExec(['approve', 'task-1'], messageBus, true);
@@ -126,7 +126,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates retry-task command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(['retry-task', 'wf-1/task-1'], messageBus);
@@ -139,7 +139,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates resume command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(['resume', 'wf-1'], messageBus);
@@ -152,7 +152,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates approve command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
@@ -165,7 +165,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates reject command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(['reject', 'wf-1/task-1', 'reason text'], messageBus);
@@ -178,7 +178,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates set command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(
@@ -194,7 +194,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates set prompt to owner (prompt-edit bridge)', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(
@@ -210,7 +210,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates rebase with noTrack so owner can return before workflow settlement', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(
@@ -229,7 +229,7 @@ describe('headless→owner delegation', () => {
     });
 
     it('delegates recreate-with-rebase command to owner', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(
@@ -359,7 +359,7 @@ describe('headless→owner delegation', () => {
 
   describe('deterministic delegation behavior', () => {
     it('always delegates when owner is available (no race conditions)', async () => {
-      const ownerHandler = vi.fn(async () => ({ success: true }));
+      const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       // Run multiple delegations in sequence
@@ -431,6 +431,111 @@ describe('headless→owner delegation', () => {
       expect(outcome.kind).toBe('delegated');
       if (outcome.kind === 'delegated') {
         expect(outcome.workflowId).toBe('wf-existing');
+        expect(outcome.tasks).toHaveLength(1);
+      }
+    });
+  });
+
+  describe('protocol-error on malformed owner responses', () => {
+    it('returns protocol-error when owner returns null', async () => {
+      messageBus.onRequest('headless.exec', async () => null);
+
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('null');
+      }
+    });
+
+    it('returns protocol-error when owner returns a string', async () => {
+      messageBus.onRequest('headless.exec', async () => 'unexpected-string');
+
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('string');
+      }
+    });
+
+    it('returns protocol-error when owner returns a number', async () => {
+      messageBus.onRequest('headless.exec', async () => 42);
+
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('number');
+      }
+    });
+
+    it('returns protocol-error when response has workflowId but tasks is not an array', async () => {
+      messageBus.onRequest('headless.run', async () => ({
+        workflowId: 'wf-test',
+        tasks: 'not-an-array',
+      }));
+
+      const outcome = await tryDelegateRun('/plan.yaml', messageBus, false, true);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('tasks');
+        expect(outcome.message).toContain('expected array');
+      }
+    });
+
+    it('returns protocol-error when response has workflowId but tasks is missing', async () => {
+      messageBus.onRequest('headless.run', async () => ({
+        workflowId: 'wf-test',
+      }));
+
+      const outcome = await tryDelegateRun('/plan.yaml', messageBus, false, true);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('tasks');
+      }
+    });
+
+    it('returns protocol-error when response has neither workflowId nor ok', async () => {
+      messageBus.onRequest('headless.exec', async () => ({
+        success: true,
+        someOtherField: 123,
+      }));
+
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      expect(outcome.kind).toBe('protocol-error');
+      if (outcome.kind === 'protocol-error') {
+        expect(outcome.message).toContain('neither workflowId');
+        expect(outcome.message).toContain('ok');
+      }
+    });
+
+    it('returns protocol-error when workflowId is a number instead of string', async () => {
+      messageBus.onRequest('headless.run', async () => ({
+        workflowId: 12345,
+        tasks: [],
+      }));
+
+      const outcome = await tryDelegateRun('/plan.yaml', messageBus, false, true);
+      // workflowId is not a string, so it doesn't match the workflow shape.
+      // And ok is not true, so it fails the fallback check too.
+      expect(outcome.kind).toBe('protocol-error');
+    });
+
+    it('accepts valid { ok: true } response as delegated', async () => {
+      messageBus.onRequest('headless.exec', async () => ({ ok: true }));
+
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      expect(outcome.kind).toBe('delegated');
+    });
+
+    it('accepts valid workflow response as delegated', async () => {
+      messageBus.onRequest('headless.run', async () => ({
+        workflowId: 'wf-valid',
+        tasks: [{ id: 'wf-valid/t1', status: 'running' }],
+      }));
+
+      const outcome = await tryDelegateRun('/plan.yaml', messageBus, false, true);
+      expect(outcome.kind).toBe('delegated');
+      if (outcome.kind === 'delegated') {
+        expect(outcome.workflowId).toBe('wf-valid');
         expect(outcome.tasks).toHaveLength(1);
       }
     });

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -102,10 +102,10 @@ describe('headless→owner delegation', () => {
       messageBus.onRequest('headless.exec', ownerHandler);
 
       // Headless process attempts to delegate
-      const delegated = await tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus);
+      const outcome = await tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus);
 
       // Verify delegation succeeded
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['run', '/path/to/plan.yaml'],
         noTrack: undefined,
@@ -129,9 +129,9 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(['retry-task', 'wf-1/task-1'], messageBus);
+      const outcome = await tryDelegateExec(['retry-task', 'wf-1/task-1'], messageBus);
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['retry-task', 'wf-1/task-1'],
         waitForApproval: undefined,
@@ -142,9 +142,9 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(['resume', 'wf-1'], messageBus);
+      const outcome = await tryDelegateExec(['resume', 'wf-1'], messageBus);
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['resume', 'wf-1'],
         waitForApproval: undefined,
@@ -155,9 +155,9 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
+      const outcome = await tryDelegateExec(['approve', 'wf-1/task-1'], messageBus);
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['approve', 'wf-1/task-1'],
         waitForApproval: undefined,
@@ -168,9 +168,9 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(['reject', 'wf-1/task-1', 'reason text'], messageBus);
+      const outcome = await tryDelegateExec(['reject', 'wf-1/task-1', 'reason text'], messageBus);
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['reject', 'wf-1/task-1', 'reason text'],
         waitForApproval: undefined,
@@ -181,12 +181,12 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(
+      const outcome = await tryDelegateExec(
         ['set', 'command', 'wf-1/task-1', 'new command'],
         messageBus,
       );
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['set', 'command', 'wf-1/task-1', 'new command'],
         waitForApproval: undefined,
@@ -197,12 +197,12 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(
+      const outcome = await tryDelegateExec(
         ['set', 'prompt', 'wf-1/task-1', 'updated prompt text'],
         messageBus,
       );
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['set', 'prompt', 'wf-1/task-1', 'updated prompt text'],
         waitForApproval: undefined,
@@ -213,14 +213,14 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(
+      const outcome = await tryDelegateExec(
         ['rebase', 'wf-1/task-1'],
         messageBus,
         undefined,
         true,
       );
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['rebase', 'wf-1/task-1'],
         noTrack: true,
@@ -232,14 +232,14 @@ describe('headless→owner delegation', () => {
       const ownerHandler = vi.fn(async () => ({ success: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
-      const delegated = await tryDelegateExec(
+      const outcome = await tryDelegateExec(
         ['recreate-with-rebase', 'wf-1'],
         messageBus,
         undefined,
         true,
       );
 
-      expect(delegated).toBe(true);
+      expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
         args: ['recreate-with-rebase', 'wf-1'],
         noTrack: true,
@@ -249,15 +249,15 @@ describe('headless→owner delegation', () => {
   });
 
   describe('fallback to standalone when owner is unavailable', () => {
-    it('returns false when no owner handler is registered', async () => {
+    it('returns no-handler outcome when no owner handler is registered', async () => {
       // No handler registered — no owner present
-      const delegated = await tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus);
+      const outcome = await tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus);
 
       // Should fall back to standalone mode
-      expect(delegated).toBe(false);
+      expect(outcome.kind).toBe('no-handler');
     });
 
-    it('returns false when delegation times out (owner unresponsive)', async () => {
+    it('returns timeout outcome when delegation times out (owner unresponsive)', async () => {
       vi.useFakeTimers();
       messageBus.onRequest('headless.exec', async () => new Promise(() => {}));
 
@@ -268,7 +268,8 @@ describe('headless→owner delegation', () => {
       expect(tracked.settled).toBe(false);
 
       await vi.advanceTimersByTimeAsync(1);
-      await expect(delegatedPromise).resolves.toBe(false);
+      const outcome = await delegatedPromise;
+      expect(outcome.kind).toBe('timeout');
     });
   });
 
@@ -300,7 +301,8 @@ describe('headless→owner delegation', () => {
       expect(tracked.settled).toBe(false);
 
       await vi.advanceTimersByTimeAsync(1);
-      await expect(delegatedPromise).resolves.toBe(false);
+      const outcome = await delegatedPromise;
+      expect(outcome.kind).toBe('timeout');
     });
 
     it.each([
@@ -320,7 +322,8 @@ describe('headless→owner delegation', () => {
       expect(tracked.settled).toBe(false);
 
       await vi.advanceTimersByTimeAsync(1);
-      await expect(delegatedPromise).resolves.toBe(false);
+      const outcome = await delegatedPromise;
+      expect(outcome.kind).toBe('timeout');
     });
   });
 
@@ -338,16 +341,16 @@ describe('headless→owner delegation', () => {
     });
 
     it('distinguishes between "no owner" and "owner error"', async () => {
-      // No handler = no owner (should return false)
+      // No handler = no owner (should return no-handler outcome)
       const noOwner = await tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus);
-      expect(noOwner).toBe(false);
+      expect(noOwner.kind).toBe('no-handler');
 
       // Handler registered = owner present
       messageBus.onRequest('headless.exec', async () => {
         throw new Error('Owner error');
       });
 
-      // Owner error should throw, not return false
+      // Owner error should throw, not return a non-delegated outcome
       await expect(tryDelegateExec(['run', '/path/to/plan.yaml'], messageBus)).rejects.toThrow(
         'Owner error',
       );
@@ -361,8 +364,8 @@ describe('headless→owner delegation', () => {
 
       // Run multiple delegations in sequence
       for (let i = 0; i < 5; i++) {
-        const delegated = await tryDelegateExec(['approve', `task-${i}`], messageBus);
-        expect(delegated).toBe(true);
+        const outcome = await tryDelegateExec(['approve', `task-${i}`], messageBus);
+        expect(outcome.kind).toBe('delegated');
       }
 
       expect(ownerHandler).toHaveBeenCalledTimes(5);
@@ -371,8 +374,8 @@ describe('headless→owner delegation', () => {
     it('always falls back when owner is unavailable (no race conditions)', async () => {
       // Run multiple attempts with no owner
       for (let i = 0; i < 5; i++) {
-        const delegated = await tryDelegateExec(['approve', `task-${i}`], messageBus);
-        expect(delegated).toBe(false);
+        const outcome = await tryDelegateExec(['approve', `task-${i}`], messageBus);
+        expect(outcome.kind).toBe('no-handler');
       }
     });
   });
@@ -394,8 +397,12 @@ describe('headless→owner delegation', () => {
 
       // With noTrack=true, delegation returns after receiving the response
       // without waiting for task settlement.
-      const delegated = await tryDelegateRun('/path/to/plan.yaml', messageBus, false, true);
-      expect(delegated).toBe(true);
+      const outcome = await tryDelegateRun('/path/to/plan.yaml', messageBus, false, true);
+      expect(outcome.kind).toBe('delegated');
+      if (outcome.kind === 'delegated') {
+        expect(outcome.workflowId).toBe('wf-test-123');
+        expect(outcome.tasks).toHaveLength(1);
+      }
     });
 
     it('times out when owner handler blocks on task execution (pre-fix behavior)', async () => {
@@ -404,9 +411,9 @@ describe('headless→owner delegation', () => {
         return new Promise(() => {}); // Never resolves — simulates await executeTasks()
       });
 
-      const delegated = await tryDelegateRun('/path/to/plan.yaml', messageBus, false, true);
+      const outcome = await tryDelegateRun('/path/to/plan.yaml', messageBus, false, true);
       // Delegation fails because the 5s timeout fires before the handler responds
-      expect(delegated).toBe(false);
+      expect(outcome.kind).toBe('timeout');
     }, 10_000);
 
     it('resume handler returns immediately with fire-and-forget execution', async () => {
@@ -420,8 +427,12 @@ describe('headless→owner delegation', () => {
         };
       });
 
-      const delegated = await tryDelegateResume('wf-existing', messageBus, false, true);
-      expect(delegated).toBe(true);
+      const outcome = await tryDelegateResume('wf-existing', messageBus, false, true);
+      expect(outcome.kind).toBe('delegated');
+      if (outcome.kind === 'delegated') {
+        expect(outcome.workflowId).toBe('wf-existing');
+        expect(outcome.tasks).toHaveLength(1);
+      }
     });
   });
 });

--- a/packages/app/src/__tests__/parity-regression.test.ts
+++ b/packages/app/src/__tests__/parity-regression.test.ts
@@ -1,0 +1,810 @@
+/**
+ * Parity regression tests spanning API, UI bridge (facade), headless
+ * delegation, and command-service mutation behavior.
+ *
+ * These tests verify the invariant that all three entry surfaces
+ * (api-server HTTP, headless CLI, command-service) route mutations
+ * through the same WorkflowMutationFacade dispatch+topup lifecycle
+ * and produce structurally equivalent results.
+ *
+ * Test groups:
+ *   1. Facade dispatch+topup lifecycle — every mutation method
+ *      filters runnable tasks, dispatches via taskExecutor, then
+ *      calls startExecution for global topup with deduplication.
+ *   2. API server → facade wiring — HTTP endpoints call the correct
+ *      facade method and return the structured result.
+ *   3. Headless → commandService routing — headless CLI verbs
+ *      delegate to the right commandService method (not directly
+ *      to orchestrator).
+ *   4. CommandService → orchestrator mutex serialization — each
+ *      command service method calls the correct orchestrator
+ *      primitive under the workflow-scoped mutex.
+ *   5. Cross-surface isolation — mutation verbs on one surface
+ *      never accidentally trigger unrelated mutation paths.
+ */
+import { describe, it, expect, vi, beforeEach, afterAll, beforeAll } from 'vitest';
+import http from 'node:http';
+import { WorkflowMutationFacade, type WorkflowMutationFacadeDeps } from '../workflow-mutation-facade.js';
+import { startApiServer, type ApiServer } from '../api-server.js';
+import { CommandService } from '@invoker/workflow-core';
+import type { CommandEnvelope } from '@invoker/contracts';
+
+// ── Shared helpers ──────────────────────────────────────────
+
+function makeTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'task-1',
+    status: 'running' as const,
+    description: 'test task',
+    dependencies: [],
+    createdAt: new Date('2024-01-01T00:00:00Z'),
+    config: { workflowId: 'wf-1' },
+    execution: {},
+    ...overrides,
+  };
+}
+
+function makePendingTask(overrides: Record<string, unknown> = {}) {
+  return makeTask({ status: 'pending', ...overrides });
+}
+
+function httpRequest(
+  port: number,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; body: any }> {
+  return new Promise((resolve, reject) => {
+    const payload = body ? JSON.stringify(body) : undefined;
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path,
+        method,
+        headers: payload
+          ? { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(payload) }
+          : {},
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c) => chunks.push(c));
+        res.on('end', () => {
+          const raw = Buffer.concat(chunks).toString();
+          let parsed: any;
+          try {
+            parsed = JSON.parse(raw);
+          } catch {
+            parsed = raw;
+          }
+          resolve({ status: res.statusCode!, body: parsed });
+        });
+      },
+    );
+    req.on('error', reject);
+    if (payload) req.write(payload);
+    req.end();
+  });
+}
+
+function makeFacadeDeps(overrides: Partial<WorkflowMutationFacadeDeps> = {}): WorkflowMutationFacadeDeps {
+  return {
+    orchestrator: {
+      retryTask: vi.fn(() => [makeTask()]),
+      recreateTask: vi.fn(() => [makeTask()]),
+      retryWorkflow: vi.fn(() => [makeTask()]),
+      recreateWorkflow: vi.fn(() => [makeTask()]),
+      cancelTask: vi.fn(() => ({ cancelled: ['task-1'], runningCancelled: ['task-1'] })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: ['task-1'], runningCancelled: ['task-1'] })),
+      deleteWorkflow: vi.fn(),
+      detachWorkflow: vi.fn(),
+      forkWorkflow: vi.fn(() => ({
+        forkedWorkflowId: 'wf-fork',
+        sourceWorkflowId: 'wf-1',
+        started: [makeTask({ id: 'fork-t1' })],
+      })),
+      editTaskCommand: vi.fn(() => [makeTask()]),
+      editTaskPrompt: vi.fn(() => [makeTask()]),
+      editTaskType: vi.fn(() => [makeTask()]),
+      editTaskAgent: vi.fn(() => [makeTask()]),
+      setTaskExternalGatePolicies: vi.fn(() => []),
+      selectExperiment: vi.fn(() => [makeTask()]),
+      approve: vi.fn(async () => [makeTask()]),
+      reject: vi.fn(),
+      provideInput: vi.fn(),
+      getTask: vi.fn(() => makeTask()),
+      getAllTasks: vi.fn(() => []),
+      startExecution: vi.fn(() => []),
+    } as any,
+    persistence: {
+      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1 })),
+      updateWorkflow: vi.fn(),
+      loadTasks: vi.fn(() => []),
+    } as any,
+    taskExecutor: {
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+      publishAfterFix: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn().mockResolvedValue(undefined),
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      commitApprovedFix: vi.fn().mockResolvedValue(undefined),
+      killActiveExecution: vi.fn().mockResolvedValue(undefined),
+    } as any,
+    killRunningTask: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+// ── 1. Facade dispatch+topup lifecycle parity ───────────────
+
+describe('Parity: facade dispatch+topup lifecycle', () => {
+  let deps: WorkflowMutationFacadeDeps;
+  let facade: WorkflowMutationFacade;
+
+  beforeEach(() => {
+    deps = makeFacadeDeps();
+    facade = new WorkflowMutationFacade(deps);
+  });
+
+  /**
+   * Every mutation that returns a MutationResult must follow the same
+   * lifecycle: call orchestrator → filter runnable → executeTasks →
+   * startExecution (topup) → return { started, runnable, topup }.
+   */
+  const mutationCases: Array<{
+    name: string;
+    invoke: (f: WorkflowMutationFacade) => Promise<any>;
+    orchestratorMethod: string;
+  }> = [
+    { name: 'retryTask', invoke: (f) => f.retryTask('task-1'), orchestratorMethod: 'retryTask' },
+    { name: 'recreateTask', invoke: (f) => f.recreateTask('task-1'), orchestratorMethod: 'recreateTask' },
+    { name: 'editTaskCommand', invoke: (f) => f.editTaskCommand('task-1', 'echo ok'), orchestratorMethod: 'editTaskCommand' },
+    { name: 'editTaskPrompt', invoke: (f) => f.editTaskPrompt('task-1', 'do it'), orchestratorMethod: 'editTaskPrompt' },
+    { name: 'editTaskType', invoke: (f) => f.editTaskType('task-1', 'docker'), orchestratorMethod: 'editTaskType' },
+    { name: 'editTaskAgent', invoke: (f) => f.editTaskAgent('task-1', 'codex'), orchestratorMethod: 'editTaskAgent' },
+    { name: 'selectExperiment', invoke: (f) => f.selectExperiment('task-1', 'exp-1'), orchestratorMethod: 'selectExperiment' },
+    { name: 'retryWorkflow', invoke: (f) => f.retryWorkflow('wf-1'), orchestratorMethod: 'retryWorkflow' },
+    { name: 'recreateWorkflow', invoke: (f) => f.recreateWorkflow('wf-1'), orchestratorMethod: 'recreateWorkflow' },
+  ];
+
+  for (const { name, invoke, orchestratorMethod } of mutationCases) {
+    it(`${name}: follows dispatch+topup lifecycle and returns MutationResult shape`, async () => {
+      const result = await invoke(facade);
+
+      // Correct orchestrator method was called
+      expect((deps.orchestrator as any)[orchestratorMethod]).toHaveBeenCalled();
+
+      // Runnable tasks dispatched via executor
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+
+      // Global topup invoked (startExecution)
+      expect(deps.orchestrator.startExecution).toHaveBeenCalled();
+
+      // Result has the canonical MutationResult shape
+      expect(result).toHaveProperty('started');
+      expect(result).toHaveProperty('runnable');
+      expect(result).toHaveProperty('topup');
+      expect(Array.isArray(result.started)).toBe(true);
+      expect(Array.isArray(result.runnable)).toBe(true);
+      expect(Array.isArray(result.topup)).toBe(true);
+    });
+  }
+
+  it('all mutations filter non-running tasks from dispatch', async () => {
+    // Orchestrator returns a mix of running and pending tasks
+    const mixed = [makeTask({ id: 't1', status: 'running' }), makePendingTask({ id: 't2' })];
+    (deps.orchestrator as any).retryTask.mockReturnValue(mixed);
+    facade = new WorkflowMutationFacade(deps);
+
+    const result = await facade.retryTask('task-1');
+
+    // Only the running task should be dispatched
+    expect(result.runnable).toHaveLength(1);
+    expect(result.runnable[0].id).toBe('t1');
+    expect(deps.taskExecutor.executeTasks).toHaveBeenCalledWith([
+      expect.objectContaining({ id: 't1', status: 'running' }),
+    ]);
+  });
+
+  it('topup deduplicates tasks already dispatched in scoped phase', async () => {
+    const scoped = makeTask({
+      id: 'task-1',
+      execution: { selectedAttemptId: 'attempt-1' },
+    });
+    (deps.orchestrator as any).retryTask.mockReturnValue([scoped]);
+    // Global topup returns the same attempt
+    (deps.orchestrator as any).startExecution.mockReturnValue([
+      makeTask({ id: 'task-1', execution: { selectedAttemptId: 'attempt-1' } }),
+    ]);
+    facade = new WorkflowMutationFacade(deps);
+
+    const result = await facade.retryTask('task-1');
+
+    // Scoped dispatch happens, but topup should NOT re-dispatch
+    expect(deps.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
+    expect(result.topup).toHaveLength(0);
+  });
+
+  it('topup dispatches genuinely new tasks from global pool', async () => {
+    const scoped = makeTask({
+      id: 'task-1',
+      execution: { selectedAttemptId: 'attempt-1' },
+    });
+    const topupTask = makeTask({
+      id: 'wf-2/task-9',
+      config: { workflowId: 'wf-2' },
+      execution: { selectedAttemptId: 'attempt-9' },
+    });
+    (deps.orchestrator as any).retryTask.mockReturnValue([scoped]);
+    (deps.orchestrator as any).startExecution.mockReturnValue([topupTask]);
+    facade = new WorkflowMutationFacade(deps);
+
+    const result = await facade.retryTask('task-1');
+
+    // Two dispatch calls: scoped + topup
+    expect(deps.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
+    expect(result.topup).toHaveLength(1);
+    expect(result.topup[0].id).toBe('wf-2/task-9');
+  });
+});
+
+// ── 2. Cancel mutations: topup-only lifecycle ───────────────
+
+describe('Parity: cancel mutations follow topup-only lifecycle', () => {
+  let deps: WorkflowMutationFacadeDeps;
+  let facade: WorkflowMutationFacade;
+
+  beforeEach(() => {
+    deps = makeFacadeDeps();
+    facade = new WorkflowMutationFacade(deps);
+  });
+
+  it('cancelTask: kills running tasks, runs topup, returns CancelMutationResult', async () => {
+    const result = await facade.cancelTask('task-1');
+
+    expect(deps.orchestrator.cancelTask).toHaveBeenCalledWith('task-1');
+    expect(deps.killRunningTask).toHaveBeenCalledWith('task-1');
+    expect(deps.orchestrator.startExecution).toHaveBeenCalled();
+    expect(result).toHaveProperty('cancelled');
+    expect(result).toHaveProperty('runningCancelled');
+    expect(result).toHaveProperty('topup');
+  });
+
+  it('cancelWorkflow: kills running tasks, runs topup, returns CancelMutationResult', async () => {
+    const result = await facade.cancelWorkflow('wf-1');
+
+    expect(deps.orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(deps.killRunningTask).toHaveBeenCalledWith('task-1');
+    expect(deps.orchestrator.startExecution).toHaveBeenCalled();
+    expect(result).toHaveProperty('cancelled');
+    expect(result).toHaveProperty('runningCancelled');
+    expect(result).toHaveProperty('topup');
+  });
+});
+
+// ── 3. API → facade wiring parity ──────────────────────────
+
+describe('Parity: API endpoints wire to facade methods', () => {
+  let api: ApiServer;
+  let port: number;
+  let mocks: ReturnType<typeof createApiMocks>;
+
+  function createApiMocks() {
+    const m = {
+      orchestrator: {
+        getWorkflowStatus: vi.fn(() => ({ total: 1, completed: 0, failed: 0, running: 1, pending: 0 })),
+        getAllTasks: vi.fn(() => [makeTask()]),
+        startExecution: vi.fn(() => []),
+        getTask: vi.fn(() => makeTask()),
+        approve: vi.fn().mockResolvedValue([]),
+        reject: vi.fn(),
+        revertConflictResolution: vi.fn(),
+        provideInput: vi.fn(),
+        beginConflictResolution: vi.fn(() => ({ savedError: 'saved-error' })),
+        setFixAwaitingApproval: vi.fn(),
+        retryTask: vi.fn(() => [makeTask()]),
+        recreateTask: vi.fn(() => [makeTask()]),
+        editTaskCommand: vi.fn(() => [makeTask()]),
+        editTaskPrompt: vi.fn(() => [makeTask()]),
+        editTaskType: vi.fn(() => [makeTask()]),
+        editTaskAgent: vi.fn(() => [makeTask()]),
+        setTaskExternalGatePolicies: vi.fn(() => [makeTask()]),
+        cancelTask: vi.fn(() => ({ cancelled: ['task-1'], runningCancelled: ['task-1'] })),
+        cancelWorkflow: vi.fn(() => ({ cancelled: ['task-1'], runningCancelled: ['task-1'] })),
+        forkWorkflow: vi.fn(() => ({
+          sourceWorkflowId: 'wf-1',
+          forkedWorkflowId: 'wf-1-fork',
+          started: [makeTask({ id: 'wf-1-fork/task-1', config: { workflowId: 'wf-1-fork' } })],
+        })),
+        deleteWorkflow: vi.fn(),
+        detachWorkflow: vi.fn(),
+        getQueueStatus: vi.fn(() => ({
+          maxConcurrency: 4, runningCount: 1,
+          running: [{ taskId: 'task-1', description: 'test' }], queued: [],
+        })),
+        recreateWorkflow: vi.fn(() => [makeTask()]),
+      },
+      persistence: {
+        listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'test', generation: 1 }]),
+        loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1 })),
+        updateWorkflow: vi.fn(),
+        loadTasks: vi.fn(() => []),
+        getEvents: vi.fn(() => []),
+        getTaskOutput: vi.fn(() => 'output'),
+      },
+      executorRegistry: {},
+      taskExecutor: {
+        executeTasks: vi.fn().mockResolvedValue(undefined),
+        publishAfterFix: vi.fn().mockResolvedValue(undefined),
+        resolveConflict: vi.fn().mockResolvedValue(undefined),
+        fixWithAgent: vi.fn().mockResolvedValue(undefined),
+        commitApprovedFix: vi.fn().mockResolvedValue(undefined),
+      },
+      killRunningTask: vi.fn().mockResolvedValue(undefined),
+      deleteWorkflow: vi.fn().mockResolvedValue(undefined),
+      detachWorkflow: vi.fn().mockResolvedValue(undefined),
+    };
+    return m;
+  }
+
+  beforeAll(async () => {
+    mocks = createApiMocks();
+    const facade = new WorkflowMutationFacade({
+      orchestrator: mocks.orchestrator as any,
+      persistence: mocks.persistence as any,
+      taskExecutor: mocks.taskExecutor as any,
+      killRunningTask: mocks.killRunningTask,
+    });
+    process.env.INVOKER_API_PORT = '0';
+    api = startApiServer({
+      orchestrator: mocks.orchestrator as any,
+      persistence: mocks.persistence as any,
+      executorRegistry: mocks.executorRegistry as any,
+      mutations: facade,
+      deleteWorkflow: mocks.deleteWorkflow,
+      detachWorkflow: mocks.detachWorkflow,
+    });
+    await new Promise<void>((resolve) => {
+      if (api.server.listening) resolve();
+      else api.server.on('listening', resolve);
+    });
+    const addr = api.server.address();
+    port = typeof addr === 'object' && addr ? addr.port : api.port;
+  });
+
+  afterAll(async () => {
+    await api.close();
+    delete process.env.INVOKER_API_PORT;
+  });
+
+  beforeEach(() => {
+    for (const group of [mocks.orchestrator, mocks.persistence, mocks.taskExecutor]) {
+      for (const fn of Object.values(group)) {
+        if (typeof fn === 'function' && 'mockClear' in fn) fn.mockClear();
+      }
+    }
+    mocks.killRunningTask.mockClear();
+    mocks.deleteWorkflow.mockClear();
+    mocks.detachWorkflow.mockClear();
+
+    // Re-apply default return values
+    mocks.orchestrator.retryTask.mockReturnValue([makeTask()]);
+    mocks.orchestrator.editTaskCommand.mockReturnValue([makeTask()]);
+    mocks.orchestrator.editTaskPrompt.mockReturnValue([makeTask()]);
+    mocks.orchestrator.editTaskType.mockReturnValue([makeTask()]);
+    mocks.orchestrator.editTaskAgent.mockReturnValue([makeTask()]);
+    mocks.orchestrator.setTaskExternalGatePolicies.mockReturnValue([makeTask()]);
+    mocks.orchestrator.approve.mockResolvedValue([]);
+    mocks.orchestrator.startExecution.mockReturnValue([]);
+    mocks.orchestrator.cancelTask.mockReturnValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
+    mocks.orchestrator.cancelWorkflow.mockReturnValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
+    mocks.orchestrator.getTask.mockReturnValue(makeTask());
+    mocks.orchestrator.recreateWorkflow.mockReturnValue([makeTask()]);
+    mocks.persistence.loadWorkflow.mockReturnValue({ id: 'wf-1', generation: 1 });
+    mocks.taskExecutor.executeTasks.mockResolvedValue(undefined);
+    mocks.killRunningTask.mockResolvedValue(undefined);
+    mocks.deleteWorkflow.mockResolvedValue(undefined);
+    mocks.detachWorkflow.mockResolvedValue(undefined);
+    mocks.orchestrator.forkWorkflow.mockReturnValue({
+      sourceWorkflowId: 'wf-1',
+      forkedWorkflowId: 'wf-1-fork',
+      started: [makeTask({ id: 'wf-1-fork/task-1', config: { workflowId: 'wf-1-fork' } })],
+    });
+  });
+
+  /**
+   * Each API write endpoint must:
+   *   1. Route to the correct orchestrator method (via facade)
+   *   2. Trigger executeTasks for runnable work
+   *   3. Trigger startExecution for global topup
+   *   4. Return 200 with { ok: true }
+   */
+  const apiWriteCases: Array<{
+    name: string;
+    method: string;
+    path: string;
+    body?: unknown;
+    orchestratorMethod: string;
+    expectTopup: boolean;
+  }> = [
+    { name: 'POST /api/tasks/:id/restart', method: 'POST', path: '/api/tasks/task-1/restart', orchestratorMethod: 'retryTask', expectTopup: true },
+    { name: 'POST /api/tasks/:id/edit', method: 'POST', path: '/api/tasks/task-1/edit', body: { command: 'echo ok' }, orchestratorMethod: 'editTaskCommand', expectTopup: true },
+    { name: 'POST /api/tasks/:id/edit-prompt', method: 'POST', path: '/api/tasks/task-1/edit-prompt', body: { prompt: 'do it' }, orchestratorMethod: 'editTaskPrompt', expectTopup: true },
+    { name: 'POST /api/tasks/:id/edit-type', method: 'POST', path: '/api/tasks/task-1/edit-type', body: { executorType: 'docker' }, orchestratorMethod: 'editTaskType', expectTopup: true },
+    { name: 'POST /api/tasks/:id/edit-agent', method: 'POST', path: '/api/tasks/task-1/edit-agent', body: { agent: 'codex' }, orchestratorMethod: 'editTaskAgent', expectTopup: true },
+    { name: 'POST /api/tasks/:id/cancel', method: 'POST', path: '/api/tasks/task-1/cancel', orchestratorMethod: 'cancelTask', expectTopup: true },
+    { name: 'POST /api/workflows/:id/cancel', method: 'POST', path: '/api/workflows/wf-1/cancel', orchestratorMethod: 'cancelWorkflow', expectTopup: true },
+    { name: 'POST /api/workflows/:id/fork', method: 'POST', path: '/api/workflows/wf-1/fork', orchestratorMethod: 'forkWorkflow', expectTopup: true },
+  ];
+
+  for (const { name, method, path, body, orchestratorMethod, expectTopup } of apiWriteCases) {
+    it(`${name}: routes through facade to ${orchestratorMethod}, triggers dispatch+topup`, async () => {
+      const res = await httpRequest(port, method, path, body);
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect((mocks.orchestrator as any)[orchestratorMethod]).toHaveBeenCalled();
+      if (expectTopup) {
+        expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
+      }
+    });
+  }
+
+  it('POST /api/tasks/:id/approve routes through facade approveTask', async () => {
+    const res = await httpRequest(port, 'POST', '/api/tasks/task-1/approve');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(mocks.orchestrator.approve).toHaveBeenCalledWith('task-1');
+    expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
+  });
+
+  it('POST /api/tasks/:id/reject routes through facade rejectTask', async () => {
+    const res = await httpRequest(port, 'POST', '/api/tasks/task-1/reject', { reason: 'bad' });
+    expect(res.status).toBe(200);
+    expect(mocks.orchestrator.reject).toHaveBeenCalledWith('task-1', 'bad');
+  });
+
+  it('POST /api/tasks/:id/input routes through facade provideInput', async () => {
+    const res = await httpRequest(port, 'POST', '/api/tasks/task-1/input', { text: 'yes' });
+    expect(res.status).toBe(200);
+    expect(mocks.orchestrator.provideInput).toHaveBeenCalledWith('task-1', 'yes');
+  });
+
+  it('POST /api/workflows/:id/restart routes through facade recreateWorkflow', async () => {
+    const res = await httpRequest(port, 'POST', '/api/workflows/wf-1/restart');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(mocks.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(mocks.persistence.updateWorkflow).toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateWorkflow).toHaveBeenCalled();
+  });
+});
+
+// ── 4. CommandService → orchestrator parity ─────────────────
+
+describe('Parity: CommandService routes to correct orchestrator primitives', () => {
+  let orchestrator: Record<string, ReturnType<typeof vi.fn>>;
+  let commandService: CommandService;
+
+  beforeEach(() => {
+    orchestrator = {
+      getTask: vi.fn(() => makeTask()),
+      approve: vi.fn(async () => [makeTask()]),
+      resumeTaskAfterFixApproval: vi.fn(async () => []),
+      reject: vi.fn(),
+      revertConflictResolution: vi.fn(),
+      provideInput: vi.fn(),
+      retryTask: vi.fn(() => [makeTask()]),
+      recreateTask: vi.fn(() => [makeTask()]),
+      retryWorkflow: vi.fn(() => [makeTask()]),
+      recreateWorkflow: vi.fn(() => [makeTask()]),
+      recreateWorkflowFromFreshBase: vi.fn(() => []),
+      cancelTask: vi.fn(() => ({ cancelled: ['task-1'], runningCancelled: [] })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: ['task-1'], runningCancelled: ['task-1'] })),
+      deleteWorkflow: vi.fn(),
+      detachWorkflow: vi.fn(),
+      editTaskCommand: vi.fn(() => [makeTask()]),
+      editTaskPrompt: vi.fn(() => [makeTask()]),
+      editTaskType: vi.fn(() => [makeTask()]),
+      editTaskAgent: vi.fn(() => [makeTask()]),
+      editTaskMergeMode: vi.fn(() => [makeTask()]),
+      editTaskFixContext: vi.fn(() => [makeTask()]),
+      selectExperiment: vi.fn(() => [makeTask()]),
+      setTaskExternalGatePolicies: vi.fn(() => []),
+      replaceTask: vi.fn(() => []),
+    };
+    commandService = new CommandService(orchestrator as any);
+  });
+
+  function envelope<T>(payload: T): CommandEnvelope<T> {
+    return {
+      commandId: 'test-cmd',
+      source: 'headless',
+      scope: 'task',
+      idempotencyKey: 'test-key',
+      payload,
+    };
+  }
+
+  const commandCases: Array<{
+    name: string;
+    invoke: (cs: CommandService) => Promise<any>;
+    orchestratorMethod: string;
+    args?: any[];
+  }> = [
+    { name: 'approve', invoke: (cs) => cs.approve(envelope({ taskId: 'task-1' })), orchestratorMethod: 'approve' },
+    { name: 'retryTask', invoke: (cs) => cs.retryTask(envelope({ taskId: 'task-1' })), orchestratorMethod: 'retryTask' },
+    { name: 'recreateTask', invoke: (cs) => cs.recreateTask(envelope({ taskId: 'task-1' })), orchestratorMethod: 'recreateTask' },
+    { name: 'retryWorkflow', invoke: (cs) => cs.retryWorkflow(envelope({ workflowId: 'wf-1' })), orchestratorMethod: 'retryWorkflow' },
+    { name: 'recreateWorkflow', invoke: (cs) => cs.recreateWorkflow(envelope({ workflowId: 'wf-1' })), orchestratorMethod: 'recreateWorkflow' },
+    { name: 'recreateWorkflowFromFreshBase', invoke: (cs) => cs.recreateWorkflowFromFreshBase(envelope({ workflowId: 'wf-1' })), orchestratorMethod: 'recreateWorkflowFromFreshBase' },
+    { name: 'cancelTask', invoke: (cs) => cs.cancelTask(envelope({ taskId: 'task-1' })), orchestratorMethod: 'cancelTask' },
+    { name: 'cancelWorkflow', invoke: (cs) => cs.cancelWorkflow(envelope({ workflowId: 'wf-1' })), orchestratorMethod: 'cancelWorkflow' },
+    { name: 'deleteWorkflow', invoke: (cs) => cs.deleteWorkflow(envelope({ workflowId: 'wf-1' })), orchestratorMethod: 'deleteWorkflow' },
+    { name: 'detachWorkflow', invoke: (cs) => cs.detachWorkflow(envelope({ workflowId: 'wf-1', upstreamWorkflowId: 'wf-0' })), orchestratorMethod: 'detachWorkflow' },
+    { name: 'editTaskCommand', invoke: (cs) => cs.editTaskCommand(envelope({ taskId: 'task-1', newCommand: 'echo ok' })), orchestratorMethod: 'editTaskCommand' },
+    { name: 'editTaskPrompt', invoke: (cs) => cs.editTaskPrompt(envelope({ taskId: 'task-1', newPrompt: 'do it' })), orchestratorMethod: 'editTaskPrompt' },
+    { name: 'editTaskType', invoke: (cs) => cs.editTaskType(envelope({ taskId: 'task-1', executorType: 'docker' })), orchestratorMethod: 'editTaskType' },
+    { name: 'editTaskAgent', invoke: (cs) => cs.editTaskAgent(envelope({ taskId: 'task-1', agentName: 'codex' })), orchestratorMethod: 'editTaskAgent' },
+    { name: 'editTaskMergeMode', invoke: (cs) => cs.editTaskMergeMode(envelope({ taskId: 'task-1', mergeMode: 'automatic' as const })), orchestratorMethod: 'editTaskMergeMode' },
+    { name: 'selectExperiment', invoke: (cs) => cs.selectExperiment(envelope({ taskId: 'task-1', experimentId: 'exp-1' })), orchestratorMethod: 'selectExperiment' },
+    { name: 'setTaskExternalGatePolicies', invoke: (cs) => cs.setTaskExternalGatePolicies(envelope({ taskId: 'task-1', updates: [] })), orchestratorMethod: 'setTaskExternalGatePolicies' },
+  ];
+
+  for (const { name, invoke, orchestratorMethod } of commandCases) {
+    it(`${name}: routes to orchestrator.${orchestratorMethod} and returns { ok: true }`, async () => {
+      const result = await invoke(commandService);
+
+      expect(result.ok).toBe(true);
+      expect(orchestrator[orchestratorMethod]).toHaveBeenCalled();
+    });
+  }
+
+  it('reject routes to orchestrator.reject when no pendingFixError', async () => {
+    orchestrator.getTask.mockReturnValue(makeTask({ execution: {} }));
+    const result = await commandService.reject(envelope({ taskId: 'task-1', reason: 'bad' }));
+
+    expect(result.ok).toBe(true);
+    expect(orchestrator.reject).toHaveBeenCalledWith('task-1', 'bad');
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+  });
+
+  it('reject routes to revertConflictResolution when pendingFixError exists', async () => {
+    orchestrator.getTask.mockReturnValue(
+      makeTask({ execution: { pendingFixError: 'merge conflict' } }),
+    );
+    const result = await commandService.reject(envelope({ taskId: 'task-1' }));
+
+    expect(result.ok).toBe(true);
+    expect(orchestrator.revertConflictResolution).toHaveBeenCalledWith('task-1', 'merge conflict');
+    expect(orchestrator.reject).not.toHaveBeenCalled();
+  });
+
+  it('restartTask (deprecated) delegates to recreateTask', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = await commandService.restartTask(envelope({ taskId: 'task-1' }));
+
+    expect(result.ok).toBe(true);
+    expect(orchestrator.recreateTask).toHaveBeenCalledWith('task-1');
+    expect(orchestrator.retryTask).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('all commands wrap OrchestratorError into { ok: false }', async () => {
+    const { OrchestratorError, OrchestratorErrorCode } = await import('@invoker/workflow-core');
+    orchestrator.retryTask.mockImplementation(() => {
+      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, 'Task not found');
+    });
+
+    const result = await commandService.retryTask(envelope({ taskId: 'missing' }));
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.message).toContain('not found');
+    }
+  });
+});
+
+// ── 5. Cross-surface isolation ──────────────────────────────
+
+describe('Parity: cross-surface mutation isolation', () => {
+  let deps: WorkflowMutationFacadeDeps;
+  let facade: WorkflowMutationFacade;
+
+  beforeEach(() => {
+    deps = makeFacadeDeps();
+    // Add extra methods to detect cross-contamination
+    (deps.orchestrator as any).recreateTask = vi.fn(() => []);
+    (deps.orchestrator as any).recreateWorkflow = vi.fn(() => []);
+    (deps.orchestrator as any).recreateWorkflowFromFreshBase = vi.fn(async () => []);
+    facade = new WorkflowMutationFacade(deps);
+  });
+
+  it('retryTask does not trigger recreateTask or recreateWorkflow', async () => {
+    await facade.retryTask('task-1');
+
+    expect(deps.orchestrator.retryTask).toHaveBeenCalled();
+    expect((deps.orchestrator as any).recreateTask).not.toHaveBeenCalled();
+    expect((deps.orchestrator as any).recreateWorkflow).not.toHaveBeenCalled();
+    expect(deps.orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(deps.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('recreateTask does not trigger retryTask or cancelTask', async () => {
+    await facade.recreateTask('task-1');
+
+    expect((deps.orchestrator as any).recreateTask).toHaveBeenCalled();
+    expect(deps.orchestrator.retryTask).not.toHaveBeenCalled();
+    expect(deps.orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(deps.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('cancelTask does not trigger retryTask or recreateTask', async () => {
+    await facade.cancelTask('task-1');
+
+    expect(deps.orchestrator.cancelTask).toHaveBeenCalled();
+    expect(deps.orchestrator.retryTask).not.toHaveBeenCalled();
+    expect((deps.orchestrator as any).recreateTask).not.toHaveBeenCalled();
+    expect((deps.orchestrator as any).recreateWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('forkWorkflow does not trigger retryWorkflow or recreateWorkflow', async () => {
+    await facade.forkWorkflow('wf-1');
+
+    expect(deps.orchestrator.forkWorkflow).toHaveBeenCalled();
+    expect(deps.orchestrator.retryWorkflow).not.toHaveBeenCalled();
+    expect((deps.orchestrator as any).recreateWorkflow).not.toHaveBeenCalled();
+    expect(deps.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('editTaskCommand does not trigger editTaskPrompt or editTaskAgent', async () => {
+    await facade.editTaskCommand('task-1', 'echo ok');
+
+    expect(deps.orchestrator.editTaskCommand).toHaveBeenCalled();
+    expect(deps.orchestrator.editTaskPrompt).not.toHaveBeenCalled();
+    expect(deps.orchestrator.editTaskAgent).not.toHaveBeenCalled();
+    expect(deps.orchestrator.editTaskType).not.toHaveBeenCalled();
+  });
+
+  it('editTaskPrompt does not trigger editTaskCommand or editTaskAgent', async () => {
+    await facade.editTaskPrompt('task-1', 'do it');
+
+    expect(deps.orchestrator.editTaskPrompt).toHaveBeenCalled();
+    expect(deps.orchestrator.editTaskCommand).not.toHaveBeenCalled();
+    expect(deps.orchestrator.editTaskAgent).not.toHaveBeenCalled();
+  });
+
+  it('approveTask does not trigger reject, retry, or cancel', async () => {
+    await facade.approveTask('task-1');
+
+    expect(deps.orchestrator.approve).toHaveBeenCalled();
+    expect(deps.orchestrator.reject).not.toHaveBeenCalled();
+    expect(deps.orchestrator.retryTask).not.toHaveBeenCalled();
+    expect((deps.orchestrator as any).recreateTask).not.toHaveBeenCalled();
+    expect(deps.orchestrator.cancelTask).not.toHaveBeenCalled();
+    expect(deps.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('rejectTask does not trigger approve, retry, or cancel', () => {
+    facade.rejectTask('task-1', 'bad output');
+
+    expect(deps.orchestrator.reject).toHaveBeenCalled();
+    expect(deps.orchestrator.approve).not.toHaveBeenCalled();
+    expect(deps.orchestrator.retryTask).not.toHaveBeenCalled();
+    expect((deps.orchestrator as any).recreateTask).not.toHaveBeenCalled();
+    expect(deps.orchestrator.cancelTask).not.toHaveBeenCalled();
+  });
+});
+
+// ── 6. CommandService mutex serialization ───────────────────
+
+describe('Parity: CommandService serializes concurrent mutations', () => {
+  function testEnvelope<T>(payload: T): CommandEnvelope<T> {
+    return {
+      commandId: 'test-cmd',
+      source: 'headless',
+      scope: 'task',
+      idempotencyKey: `key-${Math.random()}`,
+      payload,
+    };
+  }
+
+  it('serializes two mutations on the same workflow sequentially', async () => {
+    const callOrder: string[] = [];
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask()),
+      retryTask: vi.fn(async () => {
+        callOrder.push('retry-start');
+        await new Promise((r) => setTimeout(r, 50));
+        callOrder.push('retry-end');
+        return [makeTask()];
+      }),
+      editTaskCommand: vi.fn(async () => {
+        callOrder.push('edit-start');
+        callOrder.push('edit-end');
+        return [makeTask()];
+      }),
+    };
+    const cs = new CommandService(orchestrator as any);
+
+    const [r1, r2] = await Promise.all([
+      cs.retryTask(testEnvelope({ taskId: 'task-1' })),
+      cs.editTaskCommand(testEnvelope({ taskId: 'task-1', newCommand: 'echo' })),
+    ]);
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    // The second mutation should start AFTER the first finishes
+    expect(callOrder.indexOf('retry-end')).toBeLessThan(callOrder.indexOf('edit-start'));
+  });
+
+  it('allows mutations on different workflows to interleave', async () => {
+    const callOrder: string[] = [];
+    const orchestrator = {
+      getTask: vi.fn((id: string) =>
+        makeTask({ id, config: { workflowId: id.split('/')[0] || 'wf-unknown' } }),
+      ),
+      retryTask: vi.fn(async (taskId: string) => {
+        const wf = taskId.split('/')[0];
+        callOrder.push(`${wf}-retry-start`);
+        await new Promise((r) => setTimeout(r, 50));
+        callOrder.push(`${wf}-retry-end`);
+        return [makeTask({ id: taskId, config: { workflowId: wf } })];
+      }),
+    };
+    const cs = new CommandService(orchestrator as any);
+
+    await Promise.all([
+      cs.retryTask(testEnvelope({ taskId: 'wf-1/task-1' })),
+      cs.retryTask(testEnvelope({ taskId: 'wf-2/task-1' })),
+    ]);
+
+    // Both should start before either finishes (parallel execution)
+    const wf1Start = callOrder.indexOf('wf-1-retry-start');
+    const wf2Start = callOrder.indexOf('wf-2-retry-start');
+    const wf1End = callOrder.indexOf('wf-1-retry-end');
+    const wf2End = callOrder.indexOf('wf-2-retry-end');
+
+    // Both start indices should exist before both end indices
+    expect(Math.max(wf1Start, wf2Start)).toBeLessThan(Math.min(wf1End, wf2End));
+  });
+});
+
+// ── 7. deleteWorkflow + detachWorkflow surface parity ───────
+
+describe('Parity: deleteWorkflow kills active tasks before delete', () => {
+  it('facade deleteWorkflow kills running tasks then calls orchestrator.deleteWorkflow', async () => {
+    const killFn = vi.fn();
+    const deps = makeFacadeDeps({
+      killRunningTask: killFn,
+      orchestrator: {
+        ...makeFacadeDeps().orchestrator,
+        getAllTasks: vi.fn(() => [
+          makeTask({ id: 'task-a', config: { workflowId: 'wf-1' } }),
+          makeTask({ id: 'task-b', status: 'completed', config: { workflowId: 'wf-1' } }),
+          makeTask({ id: 'task-c', status: 'fixing_with_ai', config: { workflowId: 'wf-1' } }),
+        ]),
+        deleteWorkflow: vi.fn(),
+      } as any,
+    });
+    const facade = new WorkflowMutationFacade(deps);
+
+    await facade.deleteWorkflow('wf-1');
+
+    // Kills running and fixing_with_ai, not completed
+    expect(killFn).toHaveBeenCalledWith('task-a');
+    expect(killFn).toHaveBeenCalledWith('task-c');
+    expect(killFn).not.toHaveBeenCalledWith('task-b');
+    expect(deps.orchestrator.deleteWorkflow).toHaveBeenCalledWith('wf-1');
+  });
+});
+
+describe('Parity: detachWorkflow passes through to orchestrator', () => {
+  it('facade detachWorkflow calls orchestrator.detachWorkflow with both ids', async () => {
+    const deps = makeFacadeDeps();
+    const facade = new WorkflowMutationFacade(deps);
+
+    await facade.detachWorkflow('wf-child', 'wf-parent');
+
+    expect(deps.orchestrator.detachWorkflow).toHaveBeenCalledWith('wf-child', 'wf-parent');
+  });
+});

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -894,4 +894,207 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(evictedIntent?.error).toContain('queue fence');
     gate.resolve();
   });
+
+  it('invalidates an older running workflow intent when internal delete-all-workflows is enqueued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const deleteAll = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:delete-all-workflows',
+      [],
+    );
+    await deleteAll;
+    await expect(olderRunning).rejects.toThrow(/superseded by delete intent/i);
+
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intents.find((intent) => intent.id === 1)?.status).toBe('failed');
+    expect(intents.find((intent) => intent.id === 1)?.error).toContain('Superseded by delete intent #2');
+    expect(intents.find((intent) => intent.id === 2)?.status).toBe('completed');
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:delete-all-workflows:undefined',
+    ]);
+  });
+
+  it('evicts older queued workflow intents when internal delete-all-workflows fence starts', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/blocker-task', null]);
+    void running.catch(() => {});
+    const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['old-queued']);
+    void olderQueued.catch(() => {});
+    const deleteAll = coordinator.enqueue<void>('wf-1', 'high', 'invoker:delete-all-workflows', []);
+    const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['new-queued']);
+
+    await deleteAll;
+    await newerQueued;
+    await expect(running).rejects.toThrow(/superseded by delete intent/i);
+    await expect(olderQueued).rejects.toThrow(/evicted/i);
+
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:delete-all-workflows:undefined',
+      'invoker:edit-task-agent:new-queued',
+    ]);
+  });
+
+  it('invalidates an older running workflow intent when delegated headless delete-all is enqueued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (_channel, args) => {
+        const payload = args[0] as { args?: string[] } | undefined;
+        const command = payload?.args?.join(' ') ?? String(args[0]);
+        order.push(command);
+        if (command.includes('hold-work')) {
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'headless.exec',
+      [{ args: ['set', 'command', 'wf-1/task-0', 'hold-work'] }],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const deleteAllExec = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'headless.exec',
+      [{ args: ['delete-all'] }],
+    );
+    await deleteAllExec;
+    await expect(olderRunning).rejects.toThrow(/superseded by delete intent/i);
+
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intents.find((intent) => intent.id === 1)?.status).toBe('failed');
+    expect(intents.find((intent) => intent.id === 1)?.error).toContain('Superseded by delete intent #2');
+    expect(intents.find((intent) => intent.id === 2)?.status).toBe('completed');
+    expect(order).toEqual([
+      'set command wf-1/task-0 hold-work',
+      'delete-all',
+    ]);
+  });
+
+  it('evicts older queued workflow intents when delegated headless delete-all fence starts', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (_channel, args) => {
+        const payload = args[0] as { args?: string[] } | undefined;
+        const command = payload?.args?.join(' ') ?? 'unknown';
+        order.push(command);
+        if (command.includes('hold-work')) {
+          await gate.promise;
+        }
+      },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'headless.exec', [{ args: ['set', 'command', 'wf-1/task-0', 'hold-work'] }]);
+    void running.catch(() => {});
+    const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'headless.exec', [{ args: ['set', 'agent', 'wf-1/task-1', 'codex'] }]);
+    void olderQueued.catch(() => {});
+    const deleteAllFence = coordinator.enqueue<void>('wf-1', 'high', 'headless.exec', [{ args: ['delete-all'] }]);
+    const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'headless.exec', [{ args: ['set', 'agent', 'wf-1/task-2', 'claude'] }]);
+
+    await Promise.resolve();
+    await deleteAllFence;
+    await newerQueued;
+    await expect(running).rejects.toThrow(/superseded by delete intent/i);
+    await expect(olderQueued).rejects.toThrow(/evicted/i);
+
+    expect(order).toEqual([
+      'set command wf-1/task-0 hold-work',
+      'delete-all',
+      'set agent wf-1/task-2 claude',
+    ]);
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    const evictedIntent = intents.find((intent) => Array.isArray(intent.args) && JSON.stringify(intent.args).includes('wf-1/task-1'));
+    const invalidatedIntent = intents.find((intent) => intent.id === 1);
+    expect(invalidatedIntent?.status).toBe('failed');
+    expect(invalidatedIntent?.error).toContain('Superseded by delete intent #3');
+    expect(evictedIntent?.status).toBe('failed');
+    expect(evictedIntent?.error).toContain('queue fence');
+    gate.resolve();
+  });
 });

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -32,7 +32,12 @@ import {
   buildCancelInFlight,
   buildInvalidationDeps,
   selectFailureRecoveryRoute,
+  deleteAllWorkflows,
 } from '../workflow-actions.js';
+
+vi.mock('../delete-all-snapshot.js', () => ({
+  createDeleteAllSnapshot: () => '/tmp/fake-snapshot',
+}));
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -1942,5 +1947,64 @@ describe('buildInvalidationDeps', () => {
     expect(orchestrator.cancelTask.mock.invocationCallOrder[0]).toBeLessThan(
       taskExecutor.killActiveExecution.mock.invocationCallOrder[0],
     );
+  });
+});
+
+describe('deleteAllWorkflows', () => {
+  it('kills running and fixing_with_ai tasks before purging', async () => {
+    const orchestrator = {
+      getAllTasks: vi.fn(() => [
+        makeTask({ id: 'r1', status: 'running' }),
+        makeTask({ id: 'f1', status: 'fixing_with_ai' }),
+        makeTask({ id: 'p1', status: 'pending' }),
+        makeTask({ id: 'c1', status: 'completed' }),
+      ]),
+      deleteAllWorkflows: vi.fn(),
+    };
+    const taskExecutor = {
+      killActiveExecution: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await deleteAllWorkflows({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    // Only running and fixing_with_ai tasks should be killed
+    expect(taskExecutor.killActiveExecution).toHaveBeenCalledTimes(2);
+    expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('r1');
+    expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('f1');
+    // Kills happen before deleteAllWorkflows
+    expect(taskExecutor.killActiveExecution.mock.invocationCallOrder[0]).toBeLessThan(
+      orchestrator.deleteAllWorkflows.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('proceeds without killing when taskExecutor is not provided', async () => {
+    const orchestrator = {
+      getAllTasks: vi.fn(() => [makeTask({ id: 'r1', status: 'running' })]),
+      deleteAllWorkflows: vi.fn(),
+    };
+
+    await deleteAllWorkflows({
+      orchestrator: orchestrator as unknown as Orchestrator,
+    });
+
+    expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    // getAllTasks should not be called when there's no taskExecutor
+    expect(orchestrator.getAllTasks).not.toHaveBeenCalled();
+  });
+
+  it('returns snapshot path from createDeleteAllSnapshot', async () => {
+    const orchestrator = {
+      getAllTasks: vi.fn(() => []),
+      deleteAllWorkflows: vi.fn(),
+    };
+
+    const result = await deleteAllWorkflows({
+      orchestrator: orchestrator as unknown as Orchestrator,
+    });
+
+    expect(result.snapshotPath).toBe('/tmp/fake-snapshot');
   });
 });

--- a/packages/app/src/__tests__/workflow-mutation-facade.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-facade.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Unit tests for WorkflowMutationFacade.
+ *
+ * Verifies that the facade correctly wires shared actions to the
+ * dispatch + topup lifecycle.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Orchestrator } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { TaskRunner } from '@invoker/execution-engine';
+import { WorkflowMutationFacade, type WorkflowMutationFacadeDeps } from '../workflow-mutation-facade.js';
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'task-a',
+    status: 'pending' as const,
+    description: 'test task',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { workflowId: 'wf-1' },
+    execution: {},
+    ...overrides,
+  };
+}
+
+function makeRunningTask(overrides: Record<string, unknown> = {}) {
+  return makeTask({ status: 'running', ...overrides });
+}
+
+function makeDeps(overrides: Partial<WorkflowMutationFacadeDeps> = {}): WorkflowMutationFacadeDeps {
+  return {
+    orchestrator: {
+      retryTask: vi.fn(() => [makeRunningTask()]),
+      recreateTask: vi.fn(() => [makeRunningTask()]),
+      cancelTask: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: [] })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: ['task-a'] })),
+      deleteWorkflow: vi.fn(),
+      detachWorkflow: vi.fn(),
+      forkWorkflow: vi.fn(() => ({
+        forkedWorkflowId: 'wf-fork',
+        sourceWorkflowId: 'wf-1',
+        started: [makeRunningTask({ id: 'fork-t1' })],
+      })),
+      editTaskCommand: vi.fn(() => [makeRunningTask()]),
+      editTaskPrompt: vi.fn(() => [makeRunningTask()]),
+      editTaskType: vi.fn(() => [makeRunningTask()]),
+      editTaskAgent: vi.fn(() => [makeRunningTask()]),
+      setTaskExternalGatePolicies: vi.fn(() => []),
+      selectExperiment: vi.fn(() => [makeRunningTask()]),
+      approve: vi.fn(async () => [makeRunningTask()]),
+      reject: vi.fn(),
+      provideInput: vi.fn(),
+      getTask: vi.fn(),
+      getAllTasks: vi.fn(() => []),
+      startExecution: vi.fn(() => []),
+      retryWorkflow: vi.fn(() => [makeRunningTask()]),
+      recreateWorkflow: vi.fn(() => [makeRunningTask()]),
+    } as unknown as Orchestrator,
+    persistence: {
+      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1 })),
+      updateWorkflow: vi.fn(),
+      loadTasks: vi.fn(() => []),
+    } as unknown as SQLiteAdapter,
+    taskExecutor: {
+      executeTasks: vi.fn(),
+      killActiveExecution: vi.fn(),
+    } as unknown as TaskRunner,
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe('WorkflowMutationFacade', () => {
+  let deps: WorkflowMutationFacadeDeps;
+  let facade: WorkflowMutationFacade;
+
+  beforeEach(() => {
+    deps = makeDeps();
+    facade = new WorkflowMutationFacade(deps);
+  });
+
+  describe('retryTask', () => {
+    it('calls orchestrator.retryTask and dispatches runnable tasks', async () => {
+      const result = await facade.retryTask('task-a');
+
+      expect(deps.orchestrator.retryTask).toHaveBeenCalledWith('task-a');
+      expect(result.started).toHaveLength(1);
+      expect(result.started[0].status).toBe('running');
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+    });
+  });
+
+  describe('recreateTask', () => {
+    it('calls orchestrator.recreateTask and dispatches runnable tasks', async () => {
+      const result = await facade.recreateTask('task-a');
+
+      expect(deps.orchestrator.recreateTask).toHaveBeenCalledWith('task-a');
+      expect(result.started).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+    });
+  });
+
+  describe('editTaskCommand', () => {
+    it('calls orchestrator.editTaskCommand and dispatches runnable tasks', async () => {
+      const result = await facade.editTaskCommand('task-a', 'new-cmd');
+
+      expect(deps.orchestrator.editTaskCommand).toHaveBeenCalledWith('task-a', 'new-cmd');
+      expect(result.started).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+    });
+  });
+
+  describe('editTaskPrompt', () => {
+    it('calls orchestrator.editTaskPrompt and dispatches runnable tasks', async () => {
+      const result = await facade.editTaskPrompt('task-a', 'new prompt');
+
+      expect(deps.orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-a', 'new prompt');
+      expect(result.started).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+    });
+  });
+
+  describe('editTaskType', () => {
+    it('calls orchestrator.editTaskType with optional remoteTargetId', async () => {
+      const result = await facade.editTaskType('task-a', 'docker', 'remote-1');
+
+      expect(deps.orchestrator.editTaskType).toHaveBeenCalledWith('task-a', 'docker', 'remote-1');
+      expect(result.started).toHaveLength(1);
+    });
+  });
+
+  describe('editTaskAgent', () => {
+    it('calls orchestrator.editTaskAgent and dispatches', async () => {
+      const result = await facade.editTaskAgent('task-a', 'claude');
+
+      expect(deps.orchestrator.editTaskAgent).toHaveBeenCalledWith('task-a', 'claude');
+      expect(result.started).toHaveLength(1);
+    });
+  });
+
+  describe('selectExperiment', () => {
+    it('calls orchestrator.selectExperiment', async () => {
+      const result = await facade.selectExperiment('task-a', 'exp-1');
+
+      expect(deps.orchestrator.selectExperiment).toHaveBeenCalledWith('task-a', 'exp-1');
+      expect(result.started).toHaveLength(1);
+    });
+  });
+
+  describe('cancelTask', () => {
+    it('calls orchestrator.cancelTask and kills running cancellations', async () => {
+      const killFn = vi.fn();
+      deps = makeDeps({
+        killRunningTask: killFn,
+        orchestrator: {
+          ...deps.orchestrator,
+          cancelTask: vi.fn(() => ({
+            cancelled: ['task-a'],
+            runningCancelled: ['task-a'],
+          })),
+          startExecution: vi.fn(() => []),
+        } as unknown as Orchestrator,
+      });
+      facade = new WorkflowMutationFacade(deps);
+
+      const result = await facade.cancelTask('task-a');
+
+      expect(result.cancelled).toEqual(['task-a']);
+      expect(result.runningCancelled).toEqual(['task-a']);
+      expect(killFn).toHaveBeenCalledWith('task-a');
+    });
+  });
+
+  describe('cancelWorkflow', () => {
+    it('calls orchestrator.cancelWorkflow and kills running cancellations', async () => {
+      const killFn = vi.fn();
+      deps = makeDeps({
+        killRunningTask: killFn,
+        orchestrator: {
+          ...deps.orchestrator,
+          cancelWorkflow: vi.fn(() => ({
+            cancelled: ['task-a'],
+            runningCancelled: ['task-a'],
+          })),
+          startExecution: vi.fn(() => []),
+        } as unknown as Orchestrator,
+      });
+      facade = new WorkflowMutationFacade(deps);
+
+      const result = await facade.cancelWorkflow('wf-1');
+
+      expect(result.cancelled).toEqual(['task-a']);
+      expect(killFn).toHaveBeenCalledWith('task-a');
+    });
+  });
+
+  describe('deleteWorkflow', () => {
+    it('kills active tasks then calls orchestrator.deleteWorkflow', async () => {
+      const killFn = vi.fn();
+      deps = makeDeps({
+        killRunningTask: killFn,
+        orchestrator: {
+          ...deps.orchestrator,
+          getAllTasks: vi.fn(() => [
+            makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } }),
+            makeTask({ id: 'task-b', status: 'completed', config: { workflowId: 'wf-1' } }),
+          ]),
+        } as unknown as Orchestrator,
+      });
+      facade = new WorkflowMutationFacade(deps);
+
+      await facade.deleteWorkflow('wf-1');
+
+      expect(killFn).toHaveBeenCalledWith('task-a');
+      expect(killFn).not.toHaveBeenCalledWith('task-b');
+      expect(deps.orchestrator.deleteWorkflow).toHaveBeenCalledWith('wf-1');
+    });
+  });
+
+  describe('detachWorkflow', () => {
+    it('calls orchestrator.detachWorkflow', async () => {
+      await facade.detachWorkflow('wf-child', 'wf-parent');
+
+      expect(deps.orchestrator.detachWorkflow).toHaveBeenCalledWith('wf-child', 'wf-parent');
+    });
+  });
+
+  describe('forkWorkflow', () => {
+    it('forks and dispatches runnable tasks', async () => {
+      const result = await facade.forkWorkflow('wf-1');
+
+      expect(deps.orchestrator.forkWorkflow).toHaveBeenCalledWith('wf-1');
+      expect(result.forkedWorkflowId).toBe('wf-fork');
+      expect(result.sourceWorkflowId).toBe('wf-1');
+      expect(result.runnable).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+    });
+  });
+
+  describe('rejectTask', () => {
+    it('calls orchestrator.reject with reason', () => {
+      facade.rejectTask('task-a', 'bad output');
+
+      expect(deps.orchestrator.reject).toHaveBeenCalledWith('task-a', 'bad output');
+    });
+
+    it('reverts conflict resolution when task has pendingFixError', () => {
+      const task = makeTask({
+        execution: { pendingFixError: 'merge conflict' },
+      });
+      (deps.orchestrator.getTask as ReturnType<typeof vi.fn>).mockReturnValue(task);
+      (deps.orchestrator as any).revertConflictResolution = vi.fn();
+
+      facade.rejectTask('task-a');
+
+      expect((deps.orchestrator as any).revertConflictResolution).toHaveBeenCalledWith(
+        'task-a',
+        'merge conflict',
+      );
+    });
+  });
+
+  describe('provideInput', () => {
+    it('calls orchestrator.provideInput', () => {
+      facade.provideInput('task-a', 'user answer');
+
+      expect(deps.orchestrator.provideInput).toHaveBeenCalledWith('task-a', 'user answer');
+    });
+  });
+
+  describe('setTaskExternalGatePolicies', () => {
+    it('calls orchestrator.setTaskExternalGatePolicies', async () => {
+      const updates = [{ workflowId: 'wf-1', gatePolicy: 'completed' as const }];
+      await facade.setTaskExternalGatePolicies('task-a', updates);
+
+      expect(deps.orchestrator.setTaskExternalGatePolicies).toHaveBeenCalledWith('task-a', updates);
+    });
+  });
+
+  describe('recreateWorkflow', () => {
+    it('bumps generation and calls orchestrator.recreateWorkflow', async () => {
+      const result = await facade.recreateWorkflow('wf-1');
+
+      expect(deps.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
+      expect(deps.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 2 });
+      expect(deps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+      expect(result.started).toHaveLength(1);
+    });
+  });
+
+  describe('retryWorkflow', () => {
+    it('calls orchestrator.retryWorkflow and dispatches', async () => {
+      const result = await facade.retryWorkflow('wf-1');
+
+      expect(deps.orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
+      expect(result.started).toHaveLength(1);
+    });
+  });
+});

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -73,7 +73,7 @@ export interface ApiServerDeps {
   killRunningTask?: (taskId: string) => Promise<void>;
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
-  deleteWorkflow?: (workflowId: string) => Promise<void>;
+  deleteWorkflow: (workflowId: string) => Promise<void>;
 }
 
 export interface ApiServer {
@@ -686,11 +686,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'DELETE' && wfDeleteMatch) {
         const workflowId = decodeURIComponent(wfDeleteMatch[1]);
         try {
-          if (deleteWorkflow) {
-            await deleteWorkflow(workflowId);
-          } else {
-            orchestrator.deleteWorkflow(workflowId);
-          }
+          await deleteWorkflow(workflowId);
           json(res, 200, { ok: true, workflowId, action: 'deleted' });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -160,8 +160,6 @@ function httpStatusForError(err: unknown): number {
   }
   if (err instanceof PlanConflictError) return 409;
   if (err instanceof TopologyForkRequired) return 409;
-  // Fallback for errors not yet migrated to OrchestratorError.
-  if (err instanceof Error && err.message.includes('not found')) return 404;
   return 400;
 }
 

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -74,6 +74,7 @@ export interface ApiServerDeps {
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   deleteWorkflow: (workflowId: string) => Promise<void>;
+  detachWorkflow: (workflowId: string, upstreamWorkflowId: string) => Promise<void>;
 }
 
 export interface ApiServer {
@@ -159,6 +160,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     cancelTask,
     cancelWorkflow,
     deleteWorkflow,
+    detachWorkflow,
   } = deps;
   const port = parseInt(process.env.INVOKER_API_PORT ?? '4100', 10);
 
@@ -705,7 +707,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "upstreamWorkflowId" in request body' });
             return;
           }
-          orchestrator.detachWorkflow(workflowId, String(upstreamWorkflowId));
+          await detachWorkflow(workflowId, String(upstreamWorkflowId));
           json(res, 200, {
             ok: true,
             workflowId,

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -70,6 +70,7 @@ export interface ApiServerDeps {
   taskExecutor: TaskRunner;
   autoApproveAIFixes?: boolean;
   approveTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
+  rejectTaskAction?: (taskId: string, reason?: string) => Promise<void>;
   killRunningTask?: (taskId: string) => Promise<void>;
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
@@ -156,6 +157,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     taskExecutor,
     autoApproveAIFixes,
     approveTaskAction,
+    rejectTaskAction,
     killRunningTask,
     cancelTask,
     cancelWorkflow,
@@ -374,7 +376,11 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               reason = parsed.reason;
             } catch { /* not JSON, ignore */ }
           }
-          sharedRejectTask(taskId, { orchestrator }, reason);
+          if (rejectTaskAction) {
+            await rejectTaskAction(taskId, reason);
+          } else {
+            sharedRejectTask(taskId, { orchestrator }, reason);
+          }
           json(res, 200, { ok: true, taskId, action: 'rejected', reason });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -36,7 +36,12 @@
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import type { Logger } from '@invoker/contracts';
-import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
+import {
+  OrchestratorError,
+  OrchestratorErrorCode,
+  PlanConflictError,
+  TopologyForkRequired,
+} from '@invoker/workflow-core';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { ExecutorRegistry, TaskRunner } from '@invoker/execution-engine';
@@ -138,17 +143,30 @@ function serializeTask(task: any): any {
   return obj;
 }
 
-/** Map OrchestratorError codes to HTTP status codes. Falls back to 400. */
+/** Map domain errors to HTTP status codes. Falls back to 400. */
 const notFoundCodes: ReadonlySet<string> = new Set([
   OrchestratorErrorCode.TASK_NOT_FOUND,
   OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
 ]);
 
+const conflictCodes: ReadonlySet<string> = new Set([
+  OrchestratorErrorCode.TASK_ALREADY_TERMINAL,
+]);
+
 function httpStatusForError(err: unknown): number {
-  if (err instanceof OrchestratorError && notFoundCodes.has(err.code)) return 404;
+  if (err instanceof OrchestratorError) {
+    if (notFoundCodes.has(err.code)) return 404;
+    if (conflictCodes.has(err.code)) return 409;
+  }
+  if (err instanceof PlanConflictError) return 409;
+  if (err instanceof TopologyForkRequired) return 409;
   // Fallback for errors not yet migrated to OrchestratorError.
   if (err instanceof Error && err.message.includes('not found')) return 404;
   return 400;
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 export function startApiServer(deps: ApiServerDeps): ApiServer {
@@ -229,8 +247,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           });
           json(res, 200, { ok: true, ...result });
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          json(res, httpStatusForError(err), { error: message });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -272,7 +289,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             ...(isLegacy ? { deprecated: true, replacement: '/api/tasks/:id/retry' } : {}),
           });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -293,7 +310,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           const tasksStarted = started.filter(t => t.status === 'running').length;
           json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -341,7 +358,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             status: autoApproveAIFixes ? 'auto_approved' : 'awaiting_approval',
           });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -368,7 +385,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           }
           json(res, 200, { ok: true, taskId, action: 'approved' });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -393,7 +410,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           }
           json(res, 200, { ok: true, taskId, action: 'rejected', reason });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -434,7 +451,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             ...(isLegacy ? { deprecated: true, replacement: '/api/workflows/:id/recreate' } : {}),
           });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -460,7 +477,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           const tasksStarted = started.filter(t => t.status === 'running').length;
           json(res, 200, { ok: true, workflowId, action: 'retried', tasksStarted });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -506,8 +523,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             ...(isLegacy ? { deprecated: true, replacement: '/api/workflows/:id/recreate-with-rebase' } : {}),
           });
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          json(res, httpStatusForError(err), { error: message });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -533,8 +549,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             tasksStarted: runnable.length,
           });
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          json(res, httpStatusForError(err), { error: message });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -555,8 +570,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           });
           json(res, 200, { ok: true, ...result });
         } catch (err) {
-          const message = err instanceof Error ? err.message : String(err);
-          json(res, httpStatusForError(err), { error: message });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -600,7 +614,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           sharedProvideInput(taskId, text, { orchestrator });
           json(res, 200, { ok: true, taskId, action: 'input_provided' });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -621,7 +635,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           await taskExecutor.executeTasks(runnable);
           json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: runnable.length });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -641,7 +655,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           await taskExecutor.executeTasks(runnable);
           json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: runnable.length });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -661,7 +675,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           await taskExecutor.executeTasks(runnable);
           json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: runnable.length });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -681,7 +695,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           await taskExecutor.executeTasks(runnable);
           json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: runnable.length });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -703,7 +717,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
           json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: runnable.length });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -716,7 +730,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           await deleteWorkflow(workflowId);
           json(res, 200, { ok: true, workflowId, action: 'deleted' });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -740,7 +754,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             action: 'detached',
           });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
@@ -759,7 +773,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           await sharedSetWorkflowMergeMode(workflowId, mode, { orchestrator, persistence, taskExecutor });
           json(res, 200, { ok: true, workflowId, action: 'merge_mode_set', mode });
         } catch (err) {
-          json(res, 400, { error: err instanceof Error ? err.message : String(err) });
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -45,6 +45,7 @@ import {
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { ExecutorRegistry, TaskRunner } from '@invoker/execution-engine';
+import type { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
   approveTask as sharedApproveTask,
   recreateWorkflow as sharedRecreateWorkflow,
@@ -74,6 +75,8 @@ export interface ApiServerDeps {
   executorRegistry: ExecutorRegistry;
   taskExecutor: TaskRunner;
   autoApproveAIFixes?: boolean;
+  /** When provided, write endpoints delegate to the facade for mutation + dispatch + topup. */
+  mutations?: WorkflowMutationFacade;
   approveTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
   rejectTaskAction?: (taskId: string, reason?: string) => Promise<void>;
   retryTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
@@ -175,6 +178,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     executorRegistry,
     taskExecutor,
     autoApproveAIFixes,
+    mutations,
     approveTaskAction,
     rejectTaskAction,
     retryTaskAction,
@@ -234,16 +238,21 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && cancelMatch) {
         const taskId = decodeURIComponent(cancelMatch[1]);
         try {
-          const result = cancelTask
-            ? await cancelTask(taskId)
-            : orchestrator.cancelTask(taskId);
-          await finalizeMutationWithGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: 'api.tasks.cancel',
-          });
-          json(res, 200, { ok: true, ...result });
+          if (mutations) {
+            const result = await mutations.cancelTask(taskId);
+            json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
+          } else {
+            const result = cancelTask
+              ? await cancelTask(taskId)
+              : orchestrator.cancelTask(taskId);
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: 'api.tasks.cancel',
+            });
+            json(res, 200, { ok: true, ...result });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -257,11 +266,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const isLegacy = !!restartMatch;
         const taskId = decodeURIComponent((retryMatch ?? restartMatch)![1]);
         try {
-          await killRunningTask?.(taskId);
           let started: TaskState[];
           if (retryTaskAction) {
             ({ started } = await retryTaskAction(taskId));
+          } else if (mutations) {
+            await killRunningTask?.(taskId);
+            const result = await mutations.retryTask(taskId);
+            started = result.started;
           } else {
+            await killRunningTask?.(taskId);
             const result = sharedRetryTask(taskId, { orchestrator });
             started = result;
             await finalizeMutationWithGlobalTopup({
@@ -297,16 +310,22 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const taskId = decodeURIComponent(recreateTaskMatch[1]);
         try {
           await killRunningTask?.(taskId);
-          const started = sharedRecreateTask(taskId, { orchestrator, persistence });
-          await finalizeMutationWithGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: 'api.tasks.recreate',
-            started: started.filter(t => t.status === 'running'),
-          });
-          const tasksStarted = started.filter(t => t.status === 'running').length;
-          json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
+          if (mutations) {
+            const result = await mutations.recreateTask(taskId);
+            const tasksStarted = result.runnable.length;
+            json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
+          } else {
+            const started = sharedRecreateTask(taskId, { orchestrator, persistence });
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: 'api.tasks.recreate',
+              started: started.filter(t => t.status === 'running'),
+            });
+            const tasksStarted = started.filter(t => t.status === 'running').length;
+            json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -326,28 +345,32 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               agent = parsed.agent;
             } catch { /* not JSON, ignore */ }
           }
-          try {
-            const result = await resolveConflictAction(taskId, {
-              orchestrator,
-              persistence,
-              taskExecutor,
-              autoApproveAIFixes,
-            }, agent);
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.tasks.resolve-conflict',
-              started: result.started,
-            });
-          } catch (err) {
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.tasks.resolve-conflict.failure',
-            });
-            throw err;
+          if (mutations) {
+            await mutations.resolveConflict(taskId, agent);
+          } else {
+            try {
+              const result = await resolveConflictAction(taskId, {
+                orchestrator,
+                persistence,
+                taskExecutor,
+                autoApproveAIFixes,
+              }, agent);
+              await finalizeMutationWithGlobalTopup({
+                orchestrator,
+                taskExecutor,
+                logger: apiLogger,
+                context: 'api.tasks.resolve-conflict',
+                started: result.started,
+              });
+            } catch (err) {
+              await finalizeMutationWithGlobalTopup({
+                orchestrator,
+                taskExecutor,
+                logger: apiLogger,
+                context: 'api.tasks.resolve-conflict.failure',
+              });
+              throw err;
+            }
           }
           json(res, 200, {
             ok: true,
@@ -368,6 +391,8 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         try {
           if (approveTaskAction) {
             await approveTaskAction(taskId);
+          } else if (mutations) {
+            await mutations.approveTask(taskId);
           } else {
             const result = await sharedApproveTask(taskId, {
               orchestrator,
@@ -403,6 +428,8 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           }
           if (rejectTaskAction) {
             await rejectTaskAction(taskId, reason);
+          } else if (mutations) {
+            mutations.rejectTask(taskId, reason);
           } else {
             sharedRejectTask(taskId, { orchestrator }, reason);
           }
@@ -426,14 +453,20 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const isLegacy = !!wfRestartMatch;
         const workflowId = decodeURIComponent((wfRecreateMatch ?? wfRestartMatch)![1]);
         try {
-          const started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
-          await finalizeMutationWithGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: isLegacy ? 'api.workflows.restart' : 'api.workflows.recreate',
-            started: started.filter(t => t.status === 'running'),
-          });
+          let started: TaskState[];
+          if (mutations) {
+            const result = await mutations.recreateWorkflow(workflowId);
+            started = result.started;
+          } else {
+            started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: isLegacy ? 'api.workflows.restart' : 'api.workflows.recreate',
+              started: started.filter(t => t.status === 'running'),
+            });
+          }
           if (isLegacy) {
             res.setHeader(
               'Deprecation',
@@ -461,6 +494,9 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           let started: TaskState[];
           if (retryWorkflowAction) {
             ({ started } = await retryWorkflowAction(workflowId));
+          } else if (mutations) {
+            const result = await mutations.retryWorkflow(workflowId);
+            started = result.started;
           } else {
             const result = sharedRetryWorkflow(workflowId, { orchestrator });
             started = result;
@@ -490,6 +526,9 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           let started: TaskState[];
           if (recreateWithRebaseAction) {
             ({ started } = await recreateWithRebaseAction(workflowId));
+          } else if (mutations) {
+            const result = await mutations.recreateWorkflowFromFreshBase(workflowId);
+            started = result.started;
           } else {
             const result = await sharedRecreateWorkflowFromFreshBase(workflowId, {
               orchestrator,
@@ -530,22 +569,32 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && wfForkMatch) {
         const workflowId = decodeURIComponent(wfForkMatch[1]);
         try {
-          const result = sharedForkWorkflow(workflowId, { orchestrator, logger: apiLogger });
-          const runnable = result.started.filter((t) => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          await executeGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: 'api.workflows.fork',
-            alreadyDispatched: runnable,
-          });
-          json(res, 200, {
-            ok: true,
-            sourceWorkflowId: result.sourceWorkflowId,
-            forkedWorkflowId: result.forkedWorkflowId,
-            tasksStarted: runnable.length,
-          });
+          if (mutations) {
+            const result = await mutations.forkWorkflow(workflowId);
+            json(res, 200, {
+              ok: true,
+              sourceWorkflowId: result.sourceWorkflowId,
+              forkedWorkflowId: result.forkedWorkflowId,
+              tasksStarted: result.runnable.length,
+            });
+          } else {
+            const result = sharedForkWorkflow(workflowId, { orchestrator, logger: apiLogger });
+            const runnable = result.started.filter((t) => t.status === 'running');
+            await taskExecutor.executeTasks(runnable);
+            await executeGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: 'api.workflows.fork',
+              alreadyDispatched: runnable,
+            });
+            json(res, 200, {
+              ok: true,
+              sourceWorkflowId: result.sourceWorkflowId,
+              forkedWorkflowId: result.forkedWorkflowId,
+              tasksStarted: runnable.length,
+            });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -557,16 +606,21 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && wfCancelMatch) {
         const workflowId = decodeURIComponent(wfCancelMatch[1]);
         try {
-          const result = cancelWorkflow
-            ? await cancelWorkflow(workflowId)
-            : sharedCancelWorkflow(workflowId, { orchestrator });
-          await finalizeMutationWithGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: 'api.workflows.cancel',
-          });
-          json(res, 200, { ok: true, ...result });
+          if (mutations) {
+            const result = await mutations.cancelWorkflow(workflowId);
+            json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
+          } else {
+            const result = cancelWorkflow
+              ? await cancelWorkflow(workflowId)
+              : sharedCancelWorkflow(workflowId, { orchestrator });
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: 'api.workflows.cancel',
+            });
+            json(res, 200, { ok: true, ...result });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -609,7 +663,11 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "text" in request body' });
             return;
           }
-          sharedProvideInput(taskId, text, { orchestrator });
+          if (mutations) {
+            mutations.provideInput(taskId, text);
+          } else {
+            sharedProvideInput(taskId, text, { orchestrator });
+          }
           json(res, 200, { ok: true, taskId, action: 'input_provided' });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -628,10 +686,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "command" in request body' });
             return;
           }
-          const started = sharedEditTaskCommand(taskId, command, { orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: runnable.length });
+          if (mutations) {
+            const result = await mutations.editTaskCommand(taskId, command);
+            json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: result.runnable.length });
+          } else {
+            const started = sharedEditTaskCommand(taskId, command, { orchestrator });
+            const runnable = started.filter(t => t.status === 'running');
+            await taskExecutor.executeTasks(runnable);
+            json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: runnable.length });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -648,10 +711,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "prompt" in request body' });
             return;
           }
-          const started = sharedEditTaskPrompt(taskId, prompt, { orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: runnable.length });
+          if (mutations) {
+            const result = await mutations.editTaskPrompt(taskId, prompt);
+            json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: result.runnable.length });
+          } else {
+            const started = sharedEditTaskPrompt(taskId, prompt, { orchestrator });
+            const runnable = started.filter(t => t.status === 'running');
+            await taskExecutor.executeTasks(runnable);
+            json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: runnable.length });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -668,10 +736,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "executorType" in request body' });
             return;
           }
-          const started = sharedEditTaskType(taskId, executorType, { orchestrator }, remoteTargetId);
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: runnable.length });
+          if (mutations) {
+            const result = await mutations.editTaskType(taskId, executorType, remoteTargetId);
+            json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: result.runnable.length });
+          } else {
+            const started = sharedEditTaskType(taskId, executorType, { orchestrator }, remoteTargetId);
+            const runnable = started.filter(t => t.status === 'running');
+            await taskExecutor.executeTasks(runnable);
+            json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: runnable.length });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -688,10 +761,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "agent" in request body' });
             return;
           }
-          const started = sharedEditTaskAgent(taskId, agent, { orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: runnable.length });
+          if (mutations) {
+            const result = await mutations.editTaskAgent(taskId, agent);
+            json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: result.runnable.length });
+          } else {
+            const started = sharedEditTaskAgent(taskId, agent, { orchestrator });
+            const runnable = started.filter(t => t.status === 'running');
+            await taskExecutor.executeTasks(runnable);
+            json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: runnable.length });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -710,10 +788,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing non-empty "updates" array in request body' });
             return;
           }
-          const started = sharedSetTaskExternalGatePolicies(taskId, updates, { orchestrator });
-          const runnable = started.filter((t) => t.status === 'running');
-          if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
-          json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: runnable.length });
+          if (mutations) {
+            const result = await mutations.setTaskExternalGatePolicies(taskId, updates);
+            json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: result.runnable.length });
+          } else {
+            const started = sharedSetTaskExternalGatePolicies(taskId, updates, { orchestrator });
+            const runnable = started.filter((t) => t.status === 'running');
+            if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
+            json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: runnable.length });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -768,7 +851,11 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "mode" in request body' });
             return;
           }
-          await sharedSetWorkflowMergeMode(workflowId, mode, { orchestrator, persistence, taskExecutor });
+          if (mutations) {
+            await mutations.setWorkflowMergeMode(workflowId, mode);
+          } else {
+            await sharedSetWorkflowMergeMode(workflowId, mode, { orchestrator, persistence, taskExecutor });
+          }
           json(res, 200, { ok: true, workflowId, action: 'merge_mode_set', mode });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -73,6 +73,7 @@ export interface ApiServerDeps {
   rejectTaskAction?: (taskId: string, reason?: string) => Promise<void>;
   retryTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
   retryWorkflowAction?: (workflowId: string) => Promise<{ started: TaskState[] }>;
+  recreateWithRebaseAction?: (workflowId: string) => Promise<{ started: TaskState[] }>;
   killRunningTask?: (taskId: string) => Promise<void>;
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
@@ -162,6 +163,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     rejectTaskAction,
     retryTaskAction,
     retryWorkflowAction,
+    recreateWithRebaseAction,
     killRunningTask,
     cancelTask,
     cancelWorkflow,
@@ -470,19 +472,25 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const workflowTarget = decodeURIComponent((wfRecreateWithRebaseMatch ?? wfRebaseAndRetryMatch)![1]);
         try {
           const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, persistence);
-          const started = await sharedRecreateWorkflowFromFreshBase(workflowId, {
-            orchestrator,
-            persistence,
-            taskExecutor,
-            logger: apiLogger,
-          });
-          await finalizeMutationWithGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: isLegacy ? 'api.workflows.rebase-and-retry' : 'api.workflows.recreate-with-rebase',
-            started: started.filter(t => t.status === 'running'),
-          });
+          let started: TaskState[];
+          if (recreateWithRebaseAction) {
+            ({ started } = await recreateWithRebaseAction(workflowId));
+          } else {
+            const result = await sharedRecreateWorkflowFromFreshBase(workflowId, {
+              orchestrator,
+              persistence,
+              taskExecutor,
+              logger: apiLogger,
+            });
+            started = result;
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: isLegacy ? 'api.workflows.rebase-and-retry' : 'api.workflows.recreate-with-rebase',
+              started: result.filter(t => t.status === 'running'),
+            });
+          }
           if (isLegacy) {
             res.setHeader(
               'Deprecation',

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -36,6 +36,7 @@
 
 import { createServer, type IncomingMessage, type ServerResponse, type Server } from 'node:http';
 import type { Logger } from '@invoker/contracts';
+import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { ExecutorRegistry, TaskRunner } from '@invoker/execution-engine';
@@ -132,6 +133,19 @@ function serializeTask(task: any): any {
   return obj;
 }
 
+/** Map OrchestratorError codes to HTTP status codes. Falls back to 400. */
+const notFoundCodes: ReadonlySet<string> = new Set([
+  OrchestratorErrorCode.TASK_NOT_FOUND,
+  OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
+]);
+
+function httpStatusForError(err: unknown): number {
+  if (err instanceof OrchestratorError && notFoundCodes.has(err.code)) return 404;
+  // Fallback for errors not yet migrated to OrchestratorError.
+  if (err instanceof Error && err.message.includes('not found')) return 404;
+  return 400;
+}
+
 export function startApiServer(deps: ApiServerDeps): ApiServer {
   const {
     logger: apiLogger,
@@ -206,8 +220,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           json(res, 200, { ok: true, ...result });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          const statusCode = message.includes('not found') ? 404 : 400;
-          json(res, statusCode, { error: message });
+          json(res, httpStatusForError(err), { error: message });
         }
         return;
       }
@@ -467,8 +480,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          const statusCode = message.includes('not found') ? 404 : 400;
-          json(res, statusCode, { error: message });
+          json(res, httpStatusForError(err), { error: message });
         }
         return;
       }
@@ -495,8 +507,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          const statusCode = message.includes('not found') ? 404 : 400;
-          json(res, statusCode, { error: message });
+          json(res, httpStatusForError(err), { error: message });
         }
         return;
       }
@@ -518,8 +529,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           json(res, 200, { ok: true, ...result });
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
-          const statusCode = message.includes('not found') ? 404 : 400;
-          json(res, statusCode, { error: message });
+          json(res, httpStatusForError(err), { error: message });
         }
         return;
       }

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -4,6 +4,9 @@
  * Binds to 127.0.0.1 only (no external access). Default port 4100,
  * configurable via INVOKER_API_PORT env var.
  *
+ * All write endpoints delegate to a WorkflowMutationFacade instance
+ * which encapsulates the mutation → dispatch → topup lifecycle.
+ *
  * Read endpoints:
  *   GET  /api/health
  *   GET  /api/status
@@ -42,30 +45,10 @@ import {
   PlanConflictError,
   TopologyForkRequired,
 } from '@invoker/workflow-core';
-import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+import type { Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { ExecutorRegistry, TaskRunner } from '@invoker/execution-engine';
+import type { ExecutorRegistry } from '@invoker/execution-engine';
 import type { WorkflowMutationFacade } from './workflow-mutation-facade.js';
-import {
-  approveTask as sharedApproveTask,
-  recreateWorkflow as sharedRecreateWorkflow,
-  recreateTask as sharedRecreateTask,
-  recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
-  forkWorkflow as sharedForkWorkflow,
-  cancelWorkflow as sharedCancelWorkflow,
-  retryTask as sharedRetryTask,
-  retryWorkflow as sharedRetryWorkflow,
-  rejectTask as sharedRejectTask,
-  provideInput as sharedProvideInput,
-  editTaskCommand as sharedEditTaskCommand,
-  editTaskPrompt as sharedEditTaskPrompt,
-  editTaskType as sharedEditTaskType,
-  editTaskAgent as sharedEditTaskAgent,
-  setTaskExternalGatePolicies as sharedSetTaskExternalGatePolicies,
-  setWorkflowMergeMode as sharedSetWorkflowMergeMode,
-  resolveConflictAction,
-} from './workflow-actions.js';
-import { executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 
 export interface ApiServerDeps {
@@ -73,18 +56,8 @@ export interface ApiServerDeps {
   orchestrator: Orchestrator;
   persistence: SQLiteAdapter;
   executorRegistry: ExecutorRegistry;
-  taskExecutor: TaskRunner;
-  autoApproveAIFixes?: boolean;
-  /** When provided, write endpoints delegate to the facade for mutation + dispatch + topup. */
-  mutations?: WorkflowMutationFacade;
-  approveTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
-  rejectTaskAction?: (taskId: string, reason?: string) => Promise<void>;
-  retryTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
-  retryWorkflowAction?: (workflowId: string) => Promise<{ started: TaskState[] }>;
-  recreateWithRebaseAction?: (workflowId: string) => Promise<{ started: TaskState[] }>;
-  killRunningTask?: (taskId: string) => Promise<void>;
-  cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
-  cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
+  /** All write endpoints delegate to the facade for mutation + dispatch + topup. */
+  mutations: WorkflowMutationFacade;
   deleteWorkflow: (workflowId: string) => Promise<void>;
   detachWorkflow: (workflowId: string, upstreamWorkflowId: string) => Promise<void>;
 }
@@ -175,18 +148,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     logger: apiLogger,
     orchestrator,
     persistence,
-    executorRegistry,
-    taskExecutor,
-    autoApproveAIFixes,
     mutations,
-    approveTaskAction,
-    rejectTaskAction,
-    retryTaskAction,
-    retryWorkflowAction,
-    recreateWithRebaseAction,
-    killRunningTask,
-    cancelTask,
-    cancelWorkflow,
     deleteWorkflow,
     detachWorkflow,
   } = deps;
@@ -238,65 +200,33 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && cancelMatch) {
         const taskId = decodeURIComponent(cancelMatch[1]);
         try {
-          if (mutations) {
-            const result = await mutations.cancelTask(taskId);
-            json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
-          } else {
-            const result = cancelTask
-              ? await cancelTask(taskId)
-              : orchestrator.cancelTask(taskId);
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.tasks.cancel',
-            });
-            json(res, 200, { ok: true, ...result });
-          }
+          const result = await mutations.cancelTask(taskId);
+          json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
 
-      // POST /api/tasks/:id/retry
+      // POST /api/tasks/:id/retry  (legacy: /api/tasks/:id/restart)
       const retryMatch = path.match(/^\/api\/tasks\/([^/]+)\/retry$/);
       const restartMatch = path.match(/^\/api\/tasks\/([^/]+)\/restart$/);
       if (method === 'POST' && (retryMatch || restartMatch)) {
         const isLegacy = !!restartMatch;
         const taskId = decodeURIComponent((retryMatch ?? restartMatch)![1]);
         try {
-          let started: TaskState[];
-          if (retryTaskAction) {
-            ({ started } = await retryTaskAction(taskId));
-          } else if (mutations) {
-            await killRunningTask?.(taskId);
-            const result = await mutations.retryTask(taskId);
-            started = result.started;
-          } else {
-            await killRunningTask?.(taskId);
-            const result = sharedRetryTask(taskId, { orchestrator });
-            started = result;
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: isLegacy ? 'api.tasks.restart' : 'api.tasks.retry',
-              started: result.filter(t => t.status === 'running'),
-            });
-          }
+          const result = await mutations.retryTask(taskId);
           if (isLegacy) {
             res.setHeader(
               'Deprecation',
               'true; reason="Use /api/tasks/:id/retry or /api/tasks/:id/recreate"',
             );
           }
-          const tasksStarted = started.filter(t => t.status === 'running').length;
           json(res, 200, {
             ok: true,
             taskId,
             action: isLegacy ? 'restarted' : 'retried',
-            tasksStarted,
+            tasksStarted: result.runnable.length,
             ...(isLegacy ? { deprecated: true, replacement: '/api/tasks/:id/retry' } : {}),
           });
         } catch (err) {
@@ -305,27 +235,13 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      // POST /api/tasks/:id/recreate
       const recreateTaskMatch = path.match(/^\/api\/tasks\/([^/]+)\/recreate$/);
       if (method === 'POST' && recreateTaskMatch) {
         const taskId = decodeURIComponent(recreateTaskMatch[1]);
         try {
-          await killRunningTask?.(taskId);
-          if (mutations) {
-            const result = await mutations.recreateTask(taskId);
-            const tasksStarted = result.runnable.length;
-            json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
-          } else {
-            const started = sharedRecreateTask(taskId, { orchestrator, persistence });
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.tasks.recreate',
-              started: started.filter(t => t.status === 'running'),
-            });
-            const tasksStarted = started.filter(t => t.status === 'running').length;
-            json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
-          }
+          const result = await mutations.recreateTask(taskId);
+          json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -345,38 +261,12 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               agent = parsed.agent;
             } catch { /* not JSON, ignore */ }
           }
-          if (mutations) {
-            await mutations.resolveConflict(taskId, agent);
-          } else {
-            try {
-              const result = await resolveConflictAction(taskId, {
-                orchestrator,
-                persistence,
-                taskExecutor,
-                autoApproveAIFixes,
-              }, agent);
-              await finalizeMutationWithGlobalTopup({
-                orchestrator,
-                taskExecutor,
-                logger: apiLogger,
-                context: 'api.tasks.resolve-conflict',
-                started: result.started,
-              });
-            } catch (err) {
-              await finalizeMutationWithGlobalTopup({
-                orchestrator,
-                taskExecutor,
-                logger: apiLogger,
-                context: 'api.tasks.resolve-conflict.failure',
-              });
-              throw err;
-            }
-          }
+          const result = await mutations.resolveConflict(taskId, agent);
           json(res, 200, {
             ok: true,
             taskId,
             action: 'resolve_conflict',
-            status: autoApproveAIFixes ? 'auto_approved' : 'awaiting_approval',
+            status: result.autoApproved ? 'auto_approved' : 'awaiting_approval',
           });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -389,23 +279,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && approveMatch) {
         const taskId = decodeURIComponent(approveMatch[1]);
         try {
-          if (approveTaskAction) {
-            await approveTaskAction(taskId);
-          } else if (mutations) {
-            await mutations.approveTask(taskId);
-          } else {
-            const result = await sharedApproveTask(taskId, {
-              orchestrator,
-              taskExecutor,
-            });
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.tasks.approve',
-              started: result.started,
-            });
-          }
+          await mutations.approveTask(taskId);
           json(res, 200, { ok: true, taskId, action: 'approved' });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -426,13 +300,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               reason = parsed.reason;
             } catch { /* not JSON, ignore */ }
           }
-          if (rejectTaskAction) {
-            await rejectTaskAction(taskId, reason);
-          } else if (mutations) {
-            mutations.rejectTask(taskId, reason);
-          } else {
-            sharedRejectTask(taskId, { orchestrator }, reason);
-          }
+          mutations.rejectTask(taskId, reason);
           json(res, 200, { ok: true, taskId, action: 'rejected', reason });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -447,33 +315,21 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      // POST /api/workflows/:id/recreate  (legacy: /api/workflows/:id/restart)
       const wfRecreateMatch = path.match(/^\/api\/workflows\/([^/]+)\/recreate$/);
       const wfRestartMatch = path.match(/^\/api\/workflows\/([^/]+)\/restart$/);
       if (method === 'POST' && (wfRecreateMatch || wfRestartMatch)) {
         const isLegacy = !!wfRestartMatch;
         const workflowId = decodeURIComponent((wfRecreateMatch ?? wfRestartMatch)![1]);
         try {
-          let started: TaskState[];
-          if (mutations) {
-            const result = await mutations.recreateWorkflow(workflowId);
-            started = result.started;
-          } else {
-            started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: isLegacy ? 'api.workflows.restart' : 'api.workflows.recreate',
-              started: started.filter(t => t.status === 'running'),
-            });
-          }
+          const result = await mutations.recreateWorkflow(workflowId);
           if (isLegacy) {
             res.setHeader(
               'Deprecation',
               'true; reason="Use /api/workflows/:id/recreate"',
             );
           }
-          const tasksStarted = started.filter(t => t.status === 'running').length;
+          const tasksStarted = result.started.filter(t => t.status === 'running').length;
           json(res, 200, {
             ok: true,
             workflowId,
@@ -487,28 +343,13 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      // POST /api/workflows/:id/retry
       const wfRetryMatch = path.match(/^\/api\/workflows\/([^/]+)\/retry$/);
       if (method === 'POST' && wfRetryMatch) {
         const workflowId = decodeURIComponent(wfRetryMatch[1]);
         try {
-          let started: TaskState[];
-          if (retryWorkflowAction) {
-            ({ started } = await retryWorkflowAction(workflowId));
-          } else if (mutations) {
-            const result = await mutations.retryWorkflow(workflowId);
-            started = result.started;
-          } else {
-            const result = sharedRetryWorkflow(workflowId, { orchestrator });
-            started = result;
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.workflows.retry',
-              started: result.filter(t => t.status === 'running'),
-            });
-          }
-          const tasksStarted = started.filter(t => t.status === 'running').length;
+          const result = await mutations.retryWorkflow(workflowId);
+          const tasksStarted = result.started.filter(t => t.status === 'running').length;
           json(res, 200, { ok: true, workflowId, action: 'retried', tasksStarted });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -516,6 +357,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      // POST /api/workflows/:id/recreate-with-rebase  (legacy: /api/workflows/:id/rebase-and-retry)
       const wfRecreateWithRebaseMatch = path.match(/^\/api\/workflows\/([^/]+)\/recreate-with-rebase$/);
       const wfRebaseAndRetryMatch = path.match(/^\/api\/workflows\/([^/]+)\/rebase-and-retry$/);
       if (method === 'POST' && (wfRecreateWithRebaseMatch || wfRebaseAndRetryMatch)) {
@@ -523,35 +365,14 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const workflowTarget = decodeURIComponent((wfRecreateWithRebaseMatch ?? wfRebaseAndRetryMatch)![1]);
         try {
           const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, persistence);
-          let started: TaskState[];
-          if (recreateWithRebaseAction) {
-            ({ started } = await recreateWithRebaseAction(workflowId));
-          } else if (mutations) {
-            const result = await mutations.recreateWorkflowFromFreshBase(workflowId);
-            started = result.started;
-          } else {
-            const result = await sharedRecreateWorkflowFromFreshBase(workflowId, {
-              orchestrator,
-              persistence,
-              taskExecutor,
-              logger: apiLogger,
-            });
-            started = result;
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: isLegacy ? 'api.workflows.rebase-and-retry' : 'api.workflows.recreate-with-rebase',
-              started: result.filter(t => t.status === 'running'),
-            });
-          }
+          const result = await mutations.recreateWorkflowFromFreshBase(workflowId);
           if (isLegacy) {
             res.setHeader(
               'Deprecation',
               'true; reason="Use /api/workflows/:id/recreate-with-rebase"',
             );
           }
-          const tasksStarted = started.filter(t => t.status === 'running').length;
+          const tasksStarted = result.started.filter(t => t.status === 'running').length;
           json(res, 200, {
             ok: true,
             workflowId,
@@ -565,36 +386,18 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      // POST /api/workflows/:id/fork
       const wfForkMatch = path.match(/^\/api\/workflows\/([^/]+)\/fork$/);
       if (method === 'POST' && wfForkMatch) {
         const workflowId = decodeURIComponent(wfForkMatch[1]);
         try {
-          if (mutations) {
-            const result = await mutations.forkWorkflow(workflowId);
-            json(res, 200, {
-              ok: true,
-              sourceWorkflowId: result.sourceWorkflowId,
-              forkedWorkflowId: result.forkedWorkflowId,
-              tasksStarted: result.runnable.length,
-            });
-          } else {
-            const result = sharedForkWorkflow(workflowId, { orchestrator, logger: apiLogger });
-            const runnable = result.started.filter((t) => t.status === 'running');
-            await taskExecutor.executeTasks(runnable);
-            await executeGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.workflows.fork',
-              alreadyDispatched: runnable,
-            });
-            json(res, 200, {
-              ok: true,
-              sourceWorkflowId: result.sourceWorkflowId,
-              forkedWorkflowId: result.forkedWorkflowId,
-              tasksStarted: runnable.length,
-            });
-          }
+          const result = await mutations.forkWorkflow(workflowId);
+          json(res, 200, {
+            ok: true,
+            sourceWorkflowId: result.sourceWorkflowId,
+            forkedWorkflowId: result.forkedWorkflowId,
+            tasksStarted: result.runnable.length,
+          });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -606,21 +409,8 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && wfCancelMatch) {
         const workflowId = decodeURIComponent(wfCancelMatch[1]);
         try {
-          if (mutations) {
-            const result = await mutations.cancelWorkflow(workflowId);
-            json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
-          } else {
-            const result = cancelWorkflow
-              ? await cancelWorkflow(workflowId)
-              : sharedCancelWorkflow(workflowId, { orchestrator });
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.workflows.cancel',
-            });
-            json(res, 200, { ok: true, ...result });
-          }
+          const result = await mutations.cancelWorkflow(workflowId);
+          json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -663,11 +453,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "text" in request body' });
             return;
           }
-          if (mutations) {
-            mutations.provideInput(taskId, text);
-          } else {
-            sharedProvideInput(taskId, text, { orchestrator });
-          }
+          mutations.provideInput(taskId, text);
           json(res, 200, { ok: true, taskId, action: 'input_provided' });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -686,21 +472,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "command" in request body' });
             return;
           }
-          if (mutations) {
-            const result = await mutations.editTaskCommand(taskId, command);
-            json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: result.runnable.length });
-          } else {
-            const started = sharedEditTaskCommand(taskId, command, { orchestrator });
-            const runnable = started.filter(t => t.status === 'running');
-            await taskExecutor.executeTasks(runnable);
-            json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: runnable.length });
-          }
+          const result = await mutations.editTaskCommand(taskId, command);
+          json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
 
+      // POST /api/tasks/:id/edit-prompt
       const editPromptMatch = path.match(/^\/api\/tasks\/([^/]+)\/edit-prompt$/);
       if (method === 'POST' && editPromptMatch) {
         const taskId = decodeURIComponent(editPromptMatch[1]);
@@ -711,21 +491,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "prompt" in request body' });
             return;
           }
-          if (mutations) {
-            const result = await mutations.editTaskPrompt(taskId, prompt);
-            json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: result.runnable.length });
-          } else {
-            const started = sharedEditTaskPrompt(taskId, prompt, { orchestrator });
-            const runnable = started.filter(t => t.status === 'running');
-            await taskExecutor.executeTasks(runnable);
-            json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: runnable.length });
-          }
+          const result = await mutations.editTaskPrompt(taskId, prompt);
+          json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
 
+      // POST /api/tasks/:id/edit-type
       const editTypeMatch = path.match(/^\/api\/tasks\/([^/]+)\/edit-type$/);
       if (method === 'POST' && editTypeMatch) {
         const taskId = decodeURIComponent(editTypeMatch[1]);
@@ -736,21 +510,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "executorType" in request body' });
             return;
           }
-          if (mutations) {
-            const result = await mutations.editTaskType(taskId, executorType, remoteTargetId);
-            json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: result.runnable.length });
-          } else {
-            const started = sharedEditTaskType(taskId, executorType, { orchestrator }, remoteTargetId);
-            const runnable = started.filter(t => t.status === 'running');
-            await taskExecutor.executeTasks(runnable);
-            json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: runnable.length });
-          }
+          const result = await mutations.editTaskType(taskId, executorType, remoteTargetId);
+          json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
 
+      // POST /api/tasks/:id/edit-agent
       const editAgentMatch = path.match(/^\/api\/tasks\/([^/]+)\/edit-agent$/);
       if (method === 'POST' && editAgentMatch) {
         const taskId = decodeURIComponent(editAgentMatch[1]);
@@ -761,15 +529,8 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "agent" in request body' });
             return;
           }
-          if (mutations) {
-            const result = await mutations.editTaskAgent(taskId, agent);
-            json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: result.runnable.length });
-          } else {
-            const started = sharedEditTaskAgent(taskId, agent, { orchestrator });
-            const runnable = started.filter(t => t.status === 'running');
-            await taskExecutor.executeTasks(runnable);
-            json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: runnable.length });
-          }
+          const result = await mutations.editTaskAgent(taskId, agent);
+          json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -788,15 +549,8 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing non-empty "updates" array in request body' });
             return;
           }
-          if (mutations) {
-            const result = await mutations.setTaskExternalGatePolicies(taskId, updates);
-            json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: result.runnable.length });
-          } else {
-            const started = sharedSetTaskExternalGatePolicies(taskId, updates, { orchestrator });
-            const runnable = started.filter((t) => t.status === 'running');
-            if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
-            json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: runnable.length });
-          }
+          const result = await mutations.setTaskExternalGatePolicies(taskId, updates);
+          json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -851,11 +605,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "mode" in request body' });
             return;
           }
-          if (mutations) {
-            await mutations.setWorkflowMergeMode(workflowId, mode);
-          } else {
-            await sharedSetWorkflowMergeMode(workflowId, mode, { orchestrator, persistence, taskExecutor });
-          }
+          await mutations.setWorkflowMergeMode(workflowId, mode);
           json(res, 200, { ok: true, workflowId, action: 'merge_mode_set', mode });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -281,16 +281,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         try {
           await killRunningTask?.(taskId);
           const started = sharedRecreateTask(taskId, { orchestrator, persistence });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          await executeGlobalTopup({
+          await finalizeMutationWithGlobalTopup({
             orchestrator,
             taskExecutor,
             logger: apiLogger,
             context: 'api.tasks.recreate',
-            alreadyDispatched: runnable,
+            started: started.filter(t => t.status === 'running'),
           });
-          json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted: runnable.length });
+          const tasksStarted = started.filter(t => t.status === 'running').length;
+          json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });
         }
@@ -411,14 +410,12 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const workflowId = decodeURIComponent((wfRecreateMatch ?? wfRestartMatch)![1]);
         try {
           const started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          await executeGlobalTopup({
+          await finalizeMutationWithGlobalTopup({
             orchestrator,
             taskExecutor,
             logger: apiLogger,
             context: isLegacy ? 'api.workflows.restart' : 'api.workflows.recreate',
-            alreadyDispatched: runnable,
+            started: started.filter(t => t.status === 'running'),
           });
           if (isLegacy) {
             res.setHeader(
@@ -426,11 +423,12 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               'true; reason="Use /api/workflows/:id/recreate"',
             );
           }
+          const tasksStarted = started.filter(t => t.status === 'running').length;
           json(res, 200, {
             ok: true,
             workflowId,
             action: isLegacy ? 'restarted' : 'recreated',
-            tasksStarted: runnable.length,
+            tasksStarted,
             ...(isLegacy ? { deprecated: true, replacement: '/api/workflows/:id/recreate' } : {}),
           });
         } catch (err) {
@@ -478,14 +476,12 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             taskExecutor,
             logger: apiLogger,
           });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          await executeGlobalTopup({
+          await finalizeMutationWithGlobalTopup({
             orchestrator,
             taskExecutor,
             logger: apiLogger,
             context: isLegacy ? 'api.workflows.rebase-and-retry' : 'api.workflows.recreate-with-rebase',
-            alreadyDispatched: runnable,
+            started: started.filter(t => t.status === 'running'),
           });
           if (isLegacy) {
             res.setHeader(
@@ -493,11 +489,12 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               'true; reason="Use /api/workflows/:id/recreate-with-rebase"',
             );
           }
+          const tasksStarted = started.filter(t => t.status === 'running').length;
           json(res, 200, {
             ok: true,
             workflowId,
             action: isLegacy ? 'rebase_and_retried' : 'recreated_with_rebase',
-            tasksStarted: runnable.length,
+            tasksStarted,
             ...(isLegacy ? { deprecated: true, replacement: '/api/workflows/:id/recreate-with-rebase' } : {}),
           });
         } catch (err) {

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -72,6 +72,7 @@ export interface ApiServerDeps {
   approveTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
   rejectTaskAction?: (taskId: string, reason?: string) => Promise<void>;
   retryTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
+  retryWorkflowAction?: (workflowId: string) => Promise<{ started: TaskState[] }>;
   killRunningTask?: (taskId: string) => Promise<void>;
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
@@ -160,6 +161,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     approveTaskAction,
     rejectTaskAction,
     retryTaskAction,
+    retryWorkflowAction,
     killRunningTask,
     cancelTask,
     cancelWorkflow,
@@ -441,17 +443,22 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && wfRetryMatch) {
         const workflowId = decodeURIComponent(wfRetryMatch[1]);
         try {
-          const started = sharedRetryWorkflow(workflowId, { orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          await executeGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: 'api.workflows.retry',
-            alreadyDispatched: runnable,
-          });
-          json(res, 200, { ok: true, workflowId, action: 'retried', tasksStarted: runnable.length });
+          let started: TaskState[];
+          if (retryWorkflowAction) {
+            ({ started } = await retryWorkflowAction(workflowId));
+          } else {
+            const result = sharedRetryWorkflow(workflowId, { orchestrator });
+            started = result;
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: 'api.workflows.retry',
+              started: result.filter(t => t.status === 'running'),
+            });
+          }
+          const tasksStarted = started.filter(t => t.status === 'running').length;
+          json(res, 200, { ok: true, workflowId, action: 'retried', tasksStarted });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });
         }

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -71,6 +71,7 @@ export interface ApiServerDeps {
   autoApproveAIFixes?: boolean;
   approveTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
   rejectTaskAction?: (taskId: string, reason?: string) => Promise<void>;
+  retryTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
   killRunningTask?: (taskId: string) => Promise<void>;
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
@@ -158,6 +159,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     autoApproveAIFixes,
     approveTaskAction,
     rejectTaskAction,
+    retryTaskAction,
     killRunningTask,
     cancelTask,
     cancelWorkflow,
@@ -237,27 +239,32 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const taskId = decodeURIComponent((retryMatch ?? restartMatch)![1]);
         try {
           await killRunningTask?.(taskId);
-          const started = sharedRetryTask(taskId, { orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          await executeGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: isLegacy ? 'api.tasks.restart' : 'api.tasks.retry',
-            alreadyDispatched: runnable,
-          });
+          let started: TaskState[];
+          if (retryTaskAction) {
+            ({ started } = await retryTaskAction(taskId));
+          } else {
+            const result = sharedRetryTask(taskId, { orchestrator });
+            started = result;
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: isLegacy ? 'api.tasks.restart' : 'api.tasks.retry',
+              started: result.filter(t => t.status === 'running'),
+            });
+          }
           if (isLegacy) {
             res.setHeader(
               'Deprecation',
               'true; reason="Use /api/tasks/:id/retry or /api/tasks/:id/recreate"',
             );
           }
+          const tasksStarted = started.filter(t => t.status === 'running').length;
           json(res, 200, {
             ok: true,
             taskId,
             action: isLegacy ? 'restarted' : 'retried',
-            tasksStarted: runnable.length,
+            tasksStarted,
             ...(isLegacy ? { deprecated: true, replacement: '/api/tasks/:id/retry' } : {}),
           });
         } catch (err) {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -7,6 +7,7 @@ import type { MessageBus } from '@invoker/transport';
 import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { isHeadlessMutatingCommand } from './headless-command-classification.js';
 import {
+  isDelegated,
   resolveDelegationTimeoutMs,
   tryDelegateExec,
   tryDelegateQuery,
@@ -116,14 +117,14 @@ async function delegateMutation(
   if (command === 'run') {
     const planPath = args[1];
     if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-    return tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs);
+    return isDelegated(await tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs));
   }
   if (command === 'resume') {
     const workflowId = args[1];
     if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-    return tryDelegateResume(workflowId, bus, waitForApproval, noTrack, timeoutMs);
+    return isDelegated(await tryDelegateResume(workflowId, bus, waitForApproval, noTrack, timeoutMs));
   }
-  return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
+  return isDelegated(await tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs));
 }
 
 async function delegateReadOnlyQuery(

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -7,13 +7,13 @@ import type { MessageBus } from '@invoker/transport';
 import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { isHeadlessMutatingCommand } from './headless-command-classification.js';
 import {
-  isDelegated,
   resolveDelegationTimeoutMs,
   tryDelegateExec,
   tryDelegateQuery,
   tryDelegateQueryUiPerf,
   tryDelegateResume,
   tryDelegateRun,
+  type DelegationOutcome,
 } from './headless-delegation.js';
 import {
   spawnDetachedStandaloneOwner,
@@ -104,7 +104,7 @@ async function delegateMutation(
   waitForApproval?: boolean,
   noTrack?: boolean,
   noTrackTimeoutMs: number = DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
-): Promise<boolean> {
+): Promise<DelegationOutcome> {
   const command = args[0];
   const timeoutMs = noTrack
     ? noTrackTimeoutMs
@@ -117,14 +117,14 @@ async function delegateMutation(
   if (command === 'run') {
     const planPath = args[1];
     if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-    return isDelegated(await tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs));
+    return tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs);
   }
   if (command === 'resume') {
     const workflowId = args[1];
     if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-    return isDelegated(await tryDelegateResume(workflowId, bus, waitForApproval, noTrack, timeoutMs));
+    return tryDelegateResume(workflowId, bus, waitForApproval, noTrack, timeoutMs);
   }
-  return isDelegated(await tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs));
+  return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
 }
 
 async function delegateReadOnlyQuery(
@@ -205,27 +205,37 @@ async function delegateAfterBootstrap(
   bus: MessageBus,
   waitForApproval?: boolean,
   noTrack?: boolean,
-): Promise<boolean> {
+): Promise<DelegationOutcome> {
   const startedAt = Date.now();
   delegationClientLog(`post-bootstrap delegation loop begin timeoutMs=${POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS}`);
   const deadline = Date.now() + POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS;
   let messageBus = bus;
   let attempts = 0;
+  let lastOutcome: DelegationOutcome = { kind: 'no-handler' };
   while (Date.now() < deadline) {
     attempts += 1;
     const owner = await discoverOwner(messageBus, 1_000);
     delegationClientLog(
       `post-bootstrap attempt=${attempts} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
     );
-    if (isStandaloneCapable(owner) && await delegateMutation(
-      args,
-      messageBus,
-      waitForApproval,
-      noTrack,
-      noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
-    )) {
-      delegationClientLog(`post-bootstrap delegation succeeded attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
-      return true;
+    if (isStandaloneCapable(owner)) {
+      const outcome = await delegateMutation(
+        args,
+        messageBus,
+        waitForApproval,
+        noTrack,
+        noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
+      );
+      lastOutcome = outcome;
+      if (outcome.kind === 'delegated') {
+        delegationClientLog(`post-bootstrap delegation succeeded attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
+        return outcome;
+      }
+      if (outcome.kind === 'protocol-error') {
+        delegationClientLog(`post-bootstrap protocol-error attempts=${attempts} message=${outcome.message}`);
+        return outcome;
+      }
+      // timeout or no-handler: retry after refresh
     }
     if (deps.refreshMessageBus) {
       messageBus = await deps.refreshMessageBus();
@@ -233,7 +243,7 @@ async function delegateAfterBootstrap(
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   delegationClientLog(`post-bootstrap delegation exhausted attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
-  return false;
+  return lastOutcome;
 }
 
 export interface HeadlessClientDeps {
@@ -294,9 +304,13 @@ function parseArgs(argv: string[]): { args: string[]; waitForApproval?: boolean;
  * Resolve a writable owner endpoint using the resolver, then delegate.
  *
  * This function encapsulates the discover → fallback → bootstrap → delegate
- * policy that was previously inline. It uses the OwnerResolver for the
- * discovery/refresh/bootstrap phases and delegates command execution once
- * an owner is acquired.
+ * policy. Each phase consumes the typed DelegationOutcome to decide its
+ * branch behavior:
+ *
+ *   - delegated     → success, return exit code
+ *   - protocol-error → fail fast (owner responded but shape is invalid)
+ *   - timeout        → owner may be overloaded, retry after refresh
+ *   - no-handler     → no owner process registered, skip to bootstrap
  */
 async function resolveOwnerAndDelegate(
   args: string[],
@@ -312,26 +326,37 @@ async function resolveOwnerAndDelegate(
     return typeof exitCode === 'number' ? exitCode : 0;
   };
 
-  // Phase 1: Discover a standalone-capable owner
+  // Phase 1: Discover a standalone-capable owner and delegate
   const owner = await discoverOwner(messageBus, 3_000);
   delegationClientLog(
     `phase1 discover standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
   );
   if (isStandaloneCapable(owner)) {
-    if (await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
+    const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
+    delegationClientLog(`phase1 outcome=${outcome.kind}`);
+    if (outcome.kind === 'delegated') {
       delegationClientLog(`phase1 delegated successfully elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
-    delegationClientLog('phase1 owner found but delegation returned false');
+    if (outcome.kind === 'protocol-error') {
+      delegationClientLog(`phase1 protocol-error: ${outcome.message}`);
+      return null;
+    }
+    // timeout or no-handler: fall through to next phase
   }
 
   // Phase 2: Try any reachable owner (may be non-standalone)
-  if (isOwnerReachable(owner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
-    delegationClientLog(`phase2 delegated to reachable owner ownerId=${owner.ownerId} elapsedMs=${Date.now() - startedAt}`);
-    return resolvedExitCode();
-  }
   if (isOwnerReachable(owner)) {
-    delegationClientLog(`phase2 reachable owner did not accept delegation ownerId=${owner.ownerId}`);
+    const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
+    delegationClientLog(`phase2 outcome=${outcome.kind} ownerId=${owner.ownerId}`);
+    if (outcome.kind === 'delegated') {
+      delegationClientLog(`phase2 delegated to reachable owner elapsedMs=${Date.now() - startedAt}`);
+      return resolvedExitCode();
+    }
+    if (outcome.kind === 'protocol-error') {
+      delegationClientLog(`phase2 protocol-error: ${outcome.message}`);
+      return null;
+    }
   } else {
     delegationClientLog('phase2 skipped: no reachable owner');
   }
@@ -344,14 +369,22 @@ async function resolveOwnerAndDelegate(
     delegationClientLog(
       `phase3 discover ownerReachable=${isOwnerReachable(refreshedOwner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(refreshedOwner) ? 'true' : 'false'} ownerId=${refreshedOwner?.ownerId ?? '<none>'}`,
     );
-    if (isOwnerReachable(refreshedOwner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
-      delegationClientLog(`phase3 delegated successfully elapsedMs=${Date.now() - startedAt}`);
-      return resolvedExitCode();
+    if (isOwnerReachable(refreshedOwner)) {
+      const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
+      delegationClientLog(`phase3 outcome=${outcome.kind}`);
+      if (outcome.kind === 'delegated') {
+        delegationClientLog(`phase3 delegated successfully elapsedMs=${Date.now() - startedAt}`);
+        return resolvedExitCode();
+      }
+      if (outcome.kind === 'protocol-error') {
+        delegationClientLog(`phase3 protocol-error: ${outcome.message}`);
+        return null;
+      }
     }
     delegationClientLog('phase3 delegation did not succeed');
   }
 
-  // Phase 4: Bootstrap with retry loop (delegated to resolver pattern)
+  // Phase 4: Bootstrap with bounded retry loop
   if (deps.refreshMessageBus) {
     messageBus = await deps.refreshMessageBus();
   }
@@ -373,10 +406,17 @@ async function resolveOwnerAndDelegate(
     if (deps.refreshMessageBus) {
       messageBus = await deps.refreshMessageBus();
     }
-    if (await delegateAfterBootstrap(args, deps, messageBus, waitForApproval, noTrack)) {
+    const outcome = await delegateAfterBootstrap(args, deps, messageBus, waitForApproval, noTrack);
+    delegationClientLog(`phase4 post-bootstrap outcome=${outcome.kind} attempt=${attempt + 1}`);
+    if (outcome.kind === 'delegated') {
       delegationClientLog(`phase4 delegated successfully attempt=${attempt + 1} elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
+    if (outcome.kind === 'protocol-error') {
+      delegationClientLog(`phase4 protocol-error attempt=${attempt + 1}: ${outcome.message}`);
+      return null;
+    }
+    // timeout or no-handler: retry next bootstrap attempt
     if (!deps.refreshMessageBus) {
       break;
     }

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -22,7 +22,8 @@ type DelegateTrackingOptions = {
 export type DelegationOutcome =
   | { kind: 'delegated'; workflowId?: string; tasks?: TaskState[] }
   | { kind: 'timeout' }
-  | { kind: 'no-handler' };
+  | { kind: 'no-handler' }
+  | { kind: 'protocol-error'; message: string };
 
 /** Type guard: returns true when the delegation was accepted by the owner. */
 export function isDelegated(outcome: DelegationOutcome): outcome is DelegationOutcome & { kind: 'delegated' } {
@@ -222,14 +223,14 @@ async function tryDelegate(
     timeoutHandle.unref?.();
   });
 
-  let response: { workflowId: string; tasks: TaskState[] } | { ok: true };
+  let raw: unknown;
   try {
     const startedAt = Date.now();
     delegationLog(`${traceId} send channel=${channel} timeoutMs=${options.timeoutMs ?? 5_000}`);
-    response = await Promise.race([
-      messageBus.request<typeof payload, typeof response>(channel, payload),
+    raw = await Promise.race([
+      messageBus.request(channel, payload),
       timeoutPromise,
-    ]) as { workflowId: string; tasks: TaskState[] } | { ok: true };
+    ]);
     delegationLog(`${traceId} response channel=${channel} elapsedMs=${Date.now() - startedAt}`);
   } catch (err) {
     if (err === DELEGATION_TIMEOUT) {
@@ -246,15 +247,44 @@ async function tryDelegate(
     if (timeoutHandle) clearTimeout(timeoutHandle);
   }
 
-  if ('workflowId' in response) {
-    targetWorkflowId = response.workflowId;
+  // ── Response-shape validation ──────────────────────────────────────────
+  // Owner handlers return one of two shapes:
+  //   1. { workflowId: string; tasks: TaskState[] }  — workflow-creating commands
+  //   2. { ok: true, ... }                           — mutation commands
+  // Anything else is a protocol violation.
+  if (raw == null || typeof raw !== 'object') {
+    const msg = `expected object response, got ${raw === null ? 'null' : typeof raw}`;
+    delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
+    return { kind: 'protocol-error', message: msg };
+  }
+
+  const response = raw as Record<string, unknown>;
+
+  const hasWorkflowId = 'workflowId' in response && typeof response.workflowId === 'string';
+  const hasOk = 'ok' in response && response.ok === true;
+
+  if (hasWorkflowId) {
+    if (!Array.isArray(response.tasks)) {
+      const msg = `response has workflowId but tasks is ${typeof response.tasks}, expected array`;
+      delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
+      return { kind: 'protocol-error', message: msg };
+    }
+  } else if (!hasOk) {
+    const keys = Object.keys(response).join(', ');
+    const msg = `response has neither workflowId (string) nor ok (true); keys: [${keys}]`;
+    delegationLog(`${traceId} protocol-error channel=${channel} ${msg}`);
+    return { kind: 'protocol-error', message: msg };
+  }
+
+  if (hasWorkflowId) {
+    targetWorkflowId = response.workflowId as string;
     process.stdout.write(`Delegated to owner — workflow: ${targetWorkflowId}\n`);
   } else {
     process.stdout.write('Delegated to owner\n');
   }
 
-  const outcome: DelegationOutcome = 'workflowId' in response
-    ? { kind: 'delegated', workflowId: response.workflowId, tasks: response.tasks }
+  const outcome: DelegationOutcome = hasWorkflowId
+    ? { kind: 'delegated', workflowId: response.workflowId as string, tasks: response.tasks as TaskState[] }
     : { kind: 'delegated' };
 
   if (options.noTrack) {
@@ -262,11 +292,11 @@ async function tryDelegate(
     return outcome;
   }
 
-  if (!('workflowId' in response) || !Array.isArray(response.tasks)) {
+  if (!hasWorkflowId || !Array.isArray(response.tasks)) {
     return outcome;
   }
-  targetWorkflowId = response.workflowId;
-  const taskFeed = createDelegatedTaskFeed(messageBus, response.tasks, targetWorkflowId);
+  targetWorkflowId = response.workflowId as string;
+  const taskFeed = createDelegatedTaskFeed(messageBus, response.tasks as TaskState[], targetWorkflowId);
   await trackWorkflow({
     workflowId: targetWorkflowId,
     loadTasks: taskFeed.loadTasks,

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -1,6 +1,6 @@
 import { resolve as resolvePath } from 'node:path';
 
-import type { MessageBus } from '@invoker/transport';
+import { TransportError, TransportErrorCode, type MessageBus } from '@invoker/transport';
 import type { TaskState } from '@invoker/workflow-core';
 
 import {
@@ -136,7 +136,7 @@ export async function tryPingHeadlessOwner(
       delegationLog(`${traceId} timeout timeoutMs=${timeoutMs}`);
       return null;
     }
-    if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+    if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
       delegationLog(`${traceId} no-handler`);
       return null;
     }
@@ -182,7 +182,7 @@ export async function tryDelegateQuery(
       delegationLog(`${traceId} timeout timeoutMs=${timeoutMs}`);
       return null;
     }
-    if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+    if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
       delegationLog(`${traceId} no-handler`);
       return null;
     }
@@ -222,7 +222,7 @@ async function tryDelegate(
       delegationLog(`${traceId} timeout channel=${channel} timeoutMs=${options.timeoutMs ?? 5_000}`);
       return false;
     }
-    if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+    if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
       delegationLog(`${traceId} no-handler channel=${channel}`);
       return false;
     }

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -15,6 +15,20 @@ type DelegateTrackingOptions = {
   timeoutMs?: number;
 };
 
+// ---------------------------------------------------------------------------
+// DelegationOutcome — typed result union for delegation attempts
+// ---------------------------------------------------------------------------
+
+export type DelegationOutcome =
+  | { kind: 'delegated'; workflowId?: string; tasks?: TaskState[] }
+  | { kind: 'timeout' }
+  | { kind: 'no-handler' };
+
+/** Type guard: returns true when the delegation was accepted by the owner. */
+export function isDelegated(outcome: DelegationOutcome): outcome is DelegationOutcome & { kind: 'delegated' } {
+  return outcome.kind === 'delegated';
+}
+
 function delegationLog(message: string): void {
   process.stderr.write(`[delegation] ${message}\n`);
 }
@@ -29,7 +43,7 @@ export async function tryDelegateRun(
   waitForApproval?: boolean,
   noTrack?: boolean,
   timeoutMs?: number,
-): Promise<boolean> {
+): Promise<DelegationOutcome> {
   const traceId = createTraceId('headless.run');
   return tryDelegate(
     'headless.run',
@@ -45,7 +59,7 @@ export async function tryDelegateResume(
   waitForApproval?: boolean,
   noTrack?: boolean,
   timeoutMs?: number,
-): Promise<boolean> {
+): Promise<DelegationOutcome> {
   const traceId = createTraceId('headless.resume');
   return tryDelegate(
     'headless.resume',
@@ -93,7 +107,7 @@ export async function tryDelegateExec(
   waitForApproval?: boolean,
   noTrack?: boolean,
   timeoutMs?: number,
-): Promise<boolean> {
+): Promise<DelegationOutcome> {
   const resolvedTimeoutMs = timeoutMs ?? await resolveDelegationTimeoutMs(args);
   const traceId = createTraceId('headless.exec');
   return tryDelegate(
@@ -198,7 +212,7 @@ async function tryDelegate(
   payload: unknown,
   messageBus: MessageBus,
   options: DelegateTrackingOptions,
-): Promise<boolean> {
+): Promise<DelegationOutcome> {
   const traceId = (payload as { traceId?: string })?.traceId ?? createTraceId(channel);
   let targetWorkflowId: string | undefined;
   const DELEGATION_TIMEOUT = Symbol('delegation-timeout');
@@ -220,11 +234,11 @@ async function tryDelegate(
   } catch (err) {
     if (err === DELEGATION_TIMEOUT) {
       delegationLog(`${traceId} timeout channel=${channel} timeoutMs=${options.timeoutMs ?? 5_000}`);
-      return false;
+      return { kind: 'timeout' };
     }
     if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
       delegationLog(`${traceId} no-handler channel=${channel}`);
-      return false;
+      return { kind: 'no-handler' };
     }
     delegationLog(`${traceId} error channel=${channel} ${(err instanceof Error ? err.message : String(err))}`);
     throw err;
@@ -239,13 +253,17 @@ async function tryDelegate(
     process.stdout.write('Delegated to owner\n');
   }
 
+  const outcome: DelegationOutcome = 'workflowId' in response
+    ? { kind: 'delegated', workflowId: response.workflowId, tasks: response.tasks }
+    : { kind: 'delegated' };
+
   if (options.noTrack) {
     process.stdout.write('--no-track enabled: delegated submission accepted; exiting without tracking.\n');
-    return true;
+    return outcome;
   }
 
   if (!('workflowId' in response) || !Array.isArray(response.tasks)) {
-    return true;
+    return outcome;
   }
   targetWorkflowId = response.workflowId;
   const taskFeed = createDelegatedTaskFeed(messageBus, response.tasks, targetWorkflowId);
@@ -259,5 +277,5 @@ async function tryDelegate(
     printTaskOutput: true,
     subscribeToChanges: taskFeed.subscribeToChanges,
   });
-  return true;
+  return outcome;
 }

--- a/packages/app/src/headless-transport.ts
+++ b/packages/app/src/headless-transport.ts
@@ -17,6 +17,7 @@ import type { MessageBus } from '@invoker/transport';
 
 import { isHeadlessMutatingCommand } from './headless-command-classification.js';
 import {
+  isDelegated,
   tryDelegateExec,
   tryDelegateRun,
   tryDelegateResume,
@@ -281,21 +282,21 @@ export class HeadlessTransport {
     if (command === 'run') {
       const planPath = args[1];
       if (!planPath) return false;
-      return tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs);
+      return isDelegated(await tryDelegateRun(planPath, bus, waitForApproval, noTrack, timeoutMs));
     }
 
     if (command === 'resume') {
       const workflowId = args[1];
       if (!workflowId) return false;
-      return tryDelegateResume(
+      return isDelegated(await tryDelegateResume(
         workflowId,
         bus,
         waitForApproval,
         noTrack,
         timeoutMs,
-      );
+      ));
     }
 
-    return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
+    return isDelegated(await tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs));
   }
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -12,6 +12,7 @@
 import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@invoker/contracts';
 import { makeEnvelope } from '@invoker/contracts';
 import type { AgentSessionData } from '@invoker/contracts';
+import { OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
@@ -1656,6 +1657,13 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
   autoFix.unsubscribe();
 }
 
+/** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
+const preemptSkipCodes: ReadonlySet<string> = new Set([
+  OrchestratorErrorCode.TASK_NOT_FOUND,
+  OrchestratorErrorCode.TASK_ALREADY_TERMINAL,
+  OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
+]);
+
 async function preemptTaskSubgraph(taskId: string, deps: HeadlessDeps): Promise<void> {
   if (deps.preemptTaskSubgraph) {
     await deps.preemptTaskSubgraph(taskId);
@@ -1665,7 +1673,7 @@ async function preemptTaskSubgraph(taskId: string, deps: HeadlessDeps): Promise<
   const envelope = makeEnvelope('cancel-task', 'headless', 'task', { taskId });
   const result = await deps.commandService.cancelTask(envelope);
   if (!result.ok) {
-    if (result.error.code === 'CANCEL_TASK_FAILED') return;
+    if (preemptSkipCodes.has(result.error.code)) return;
     throw new Error(result.error.message);
   }
 }
@@ -1680,7 +1688,7 @@ async function preemptWorkflowExecution(workflowId: string, deps: HeadlessDeps):
   const envelope = makeEnvelope('cancel-workflow', 'headless', 'workflow', { workflowId });
   const result = await deps.commandService.cancelWorkflow(envelope);
   if (!result.ok) {
-    if (result.error.code === 'CANCEL_WORKFLOW_FAILED') return { cancelled: [], runningCancelled: [] };
+    if (preemptSkipCodes.has(result.error.code)) return { cancelled: [], runningCancelled: [] };
     throw new Error(result.error.message);
   }
   return result.data;

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1665,9 +1665,8 @@ async function preemptTaskSubgraph(taskId: string, deps: HeadlessDeps): Promise<
   const envelope = makeEnvelope('cancel-task', 'headless', 'task', { taskId });
   const result = await deps.commandService.cancelTask(envelope);
   if (!result.ok) {
-    const message = result.error.message;
-    if (message.includes('already completed') || message.includes('already stale')) return;
-    throw new Error(message);
+    if (result.error.code === 'CANCEL_TASK_FAILED') return;
+    throw new Error(result.error.message);
   }
 }
 
@@ -1681,9 +1680,8 @@ async function preemptWorkflowExecution(workflowId: string, deps: HeadlessDeps):
   const envelope = makeEnvelope('cancel-workflow', 'headless', 'workflow', { workflowId });
   const result = await deps.commandService.cancelWorkflow(envelope);
   if (!result.ok) {
-    const message = result.error.message;
-    if (message.includes('No tasks found for workflow')) return { cancelled: [], runningCancelled: [] };
-    throw new Error(message);
+    if (result.error.code === 'CANCEL_WORKFLOW_FAILED') return { cancelled: [], runningCancelled: [] };
+    throw new Error(result.error.message);
   }
   return result.data;
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -757,7 +757,7 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'delete-all':
       assertDeleteAllEnabled();
       {
-        const { snapshotPath } = sharedDeleteAllWorkflows({
+        const { snapshotPath } = await sharedDeleteAllWorkflows({
           logger: deps.logger,
           orchestrator: deps.orchestrator,
         });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -29,7 +29,8 @@ import {
 } from '@invoker/execution-engine';
 import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from './config.js';
 import { backupPlan } from './plan-backup.js';
-import { startApiServer, type ApiServerDeps } from './api-server.js';
+import { startApiServer } from './api-server.js';
+import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
   approveTask,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
@@ -109,30 +110,19 @@ function headlessHeartbeat(taskId: string, deps: Pick<HeadlessDeps, 'persistence
   try { deps.persistence.updateTask(taskId, { execution: { lastHeartbeatAt: now } }); } catch { /* db locked */ }
 }
 
-function buildHeadlessApiCancelHooks(
+function buildHeadlessApiServerDeps(
   deps: HeadlessDeps,
   taskExecutor: TaskRunner,
-): Pick<ApiServerDeps, 'cancelTask' | 'cancelWorkflow' | 'killRunningTask' | 'deleteWorkflow'> {
+): { mutations: WorkflowMutationFacade; deleteWorkflow: (id: string) => Promise<void>; detachWorkflow: (id: string, upstreamId: string) => Promise<void> } {
   return {
-    killRunningTask: (taskId: string) => taskExecutor.killActiveExecution(taskId),
-    cancelTask: async (taskId: string) => {
-      const envelope = makeEnvelope('cancel-task', 'headless', 'task', { taskId });
-      const cmdResult = await deps.commandService.cancelTask(envelope);
-      if (!cmdResult.ok) throw new Error(cmdResult.error.message);
-      for (const id of cmdResult.data.runningCancelled) {
-        await taskExecutor.killActiveExecution(id);
-      }
-      return cmdResult.data;
-    },
-    cancelWorkflow: async (workflowId: string) => {
-      const envelope = makeEnvelope('cancel-workflow', 'headless', 'workflow', { workflowId });
-      const cmdResult = await deps.commandService.cancelWorkflow(envelope);
-      if (!cmdResult.ok) throw new Error(cmdResult.error.message);
-      for (const id of cmdResult.data.runningCancelled) {
-        await taskExecutor.killActiveExecution(id);
-      }
-      return cmdResult.data;
-    },
+    mutations: new WorkflowMutationFacade({
+      logger: deps.logger,
+      orchestrator: deps.orchestrator,
+      persistence: deps.persistence,
+      taskExecutor,
+      autoApproveAIFixes: deps.invokerConfig?.autoApproveAIFixes,
+      killRunningTask: (taskId: string) => taskExecutor.killActiveExecution(taskId),
+    }),
     deleteWorkflow: async (workflowId: string) => {
       const allTasks = deps.orchestrator.getAllTasks();
       const workflowTasks = allTasks.filter(
@@ -145,6 +135,11 @@ function buildHeadlessApiCancelHooks(
       }
       const envelope = makeEnvelope('delete-workflow', 'headless', 'workflow', { workflowId });
       const cmdResult = await deps.commandService.deleteWorkflow(envelope);
+      if (!cmdResult.ok) throw new Error(cmdResult.error.message);
+    },
+    detachWorkflow: async (workflowId: string, upstreamWorkflowId: string) => {
+      const envelope = makeEnvelope('detach-workflow', 'headless', 'workflow', { workflowId, upstreamWorkflowId });
+      const cmdResult = await deps.commandService.detachWorkflow(envelope);
       if (!cmdResult.ok) throw new Error(cmdResult.error.message);
     },
   };
@@ -1013,17 +1008,13 @@ async function headlessRun(
   const taskExecutor = createHeadlessExecutor(deps);
   wireHeadlessApproveHook(deps, taskExecutor);
   const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
-  const approveTaskAction = buildHeadlessApproveAction(deps, taskExecutor);
 
   const api = startApiServer({
     logger: deps.logger,
     orchestrator,
     persistence: deps.persistence,
     executorRegistry: deps.executorRegistry,
-    taskExecutor,
-    autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
-    approveTaskAction,
-    ...buildHeadlessApiCancelHooks(deps, taskExecutor),
+    ...buildHeadlessApiServerDeps(deps, taskExecutor),
   });
 
   const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
@@ -1069,17 +1060,13 @@ async function headlessResume(
   const taskExecutor = createHeadlessExecutor(deps);
   wireHeadlessApproveHook(deps, taskExecutor);
   const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
-  const approveTaskAction = buildHeadlessApproveAction(deps, taskExecutor);
 
   const api = startApiServer({
     logger: deps.logger,
     orchestrator,
     persistence: deps.persistence,
     executorRegistry: deps.executorRegistry,
-    taskExecutor,
-    autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
-    approveTaskAction,
-    ...buildHeadlessApiCancelHooks(deps, taskExecutor),
+    ...buildHeadlessApiServerDeps(deps, taskExecutor),
   });
 
   orchestrator.syncFromDb(workflowId);
@@ -2343,16 +2330,13 @@ async function headlessSlack(deps: HeadlessDeps): Promise<void> {
     },
   });
   wireHeadlessApproveHook(deps, taskExecutor);
-  const approveTaskAction = buildHeadlessApproveAction(deps, taskExecutor);
 
   const api = startApiServer({
     logger: deps.logger,
     orchestrator,
     persistence,
     executorRegistry: deps.executorRegistry,
-    taskExecutor,
-    approveTaskAction,
-    ...buildHeadlessApiCancelHooks(deps, taskExecutor),
+    ...buildHeadlessApiServerDeps(deps, taskExecutor),
   });
 
   const slack = await wireSlackBot({

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -44,14 +44,6 @@ import {
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
 import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
-import {
-  delegationTimeoutMs,
-  resolveDelegationTimeoutMs,
-  tryDelegateExec,
-  tryDelegateQuery,
-  tryDelegateResume,
-  tryDelegateRun,
-} from './headless-delegation.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
@@ -60,12 +52,14 @@ import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
 export { bumpGenerationAndRecreate } from './workflow-actions.js';
 export {
   delegationTimeoutMs,
+  isDelegated,
   resolveDelegationTimeoutMs,
   tryDelegateExec,
   tryDelegateQuery,
   tryDelegateResume,
   tryDelegateRun,
 } from './headless-delegation.js';
+export type { DelegationOutcome } from './headless-delegation.js';
 
 // ── HeadlessDeps interface ───────────────────────────────────
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -15,7 +15,6 @@ import type { AgentSessionData } from '@invoker/contracts';
 import { OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import { Channels } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import {
@@ -33,6 +32,7 @@ import { backupPlan } from './plan-backup.js';
 import { startApiServer, type ApiServerDeps } from './api-server.js';
 import {
   approveTask,
+  deleteAllWorkflows as sharedDeleteAllWorkflows,
   fixWithAgentAction,
   rebaseAndRetry,
   recreateWithRebase,
@@ -757,14 +757,16 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'delete-all':
       assertDeleteAllEnabled();
       {
-        const snapshot = createDeleteAllSnapshot();
-        if (snapshot) {
-          process.stderr.write(`[headless] delete-all snapshot: ${snapshot}\n`);
+        const { snapshotPath } = sharedDeleteAllWorkflows({
+          logger: deps.logger,
+          orchestrator: deps.orchestrator,
+        });
+        if (snapshotPath) {
+          process.stderr.write(`[headless] delete-all snapshot: ${snapshotPath}\n`);
         } else {
           process.stderr.write('[headless] delete-all snapshot skipped: DB file does not exist yet\n');
         }
       }
-      deps.orchestrator.deleteAllWorkflows();
       process.stdout.write('All workflows deleted.\n');
       break;
     case 'open-terminal':

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -89,7 +89,6 @@ export interface HeadlessDeps {
   preemptWorkflowExecution?: (workflowId: string) => Promise<WorkflowCancelResult>;
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
-  deleteWorkflow?: (workflowId: string) => Promise<void>;
   waitForApproval?: boolean;
   noTrack?: boolean;
   isStandaloneOwnerIdle?: () => boolean;
@@ -2113,13 +2112,11 @@ async function headlessOpenTerminal(taskId: string, deps: HeadlessDeps): Promise
   }
 }
 
-async function headlessDeleteWorkflow(workflowId: string, deps: Pick<HeadlessDeps, 'commandService' | 'deleteWorkflow'>): Promise<void> {
+async function headlessDeleteWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {
   if (!workflowId) throw new Error('Missing workflowId. Usage: --headless delete-workflow <workflowId>');
-  if (deps.deleteWorkflow) {
-    await deps.deleteWorkflow(workflowId);
-    process.stdout.write(`Deleted workflow: ${workflowId}\n`);
-    return;
-  }
+  // Preempt running tasks (kill processes + cancel) — matches owner-mode bridge contract
+  await preemptWorkflowExecution(workflowId, deps);
+  // Serialized via CommandService: DB delete + memory clear + scheduler cleanup + removal deltas
   const envelope = makeEnvelope('delete-workflow', 'headless', 'workflow', { workflowId });
   const result = await deps.commandService.deleteWorkflow(envelope);
   if (!result.ok) throw new Error(result.error.message);

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -113,7 +113,7 @@ function headlessHeartbeat(taskId: string, deps: Pick<HeadlessDeps, 'persistence
 function buildHeadlessApiCancelHooks(
   deps: HeadlessDeps,
   taskExecutor: TaskRunner,
-): Pick<ApiServerDeps, 'cancelTask' | 'cancelWorkflow' | 'killRunningTask'> {
+): Pick<ApiServerDeps, 'cancelTask' | 'cancelWorkflow' | 'killRunningTask' | 'deleteWorkflow'> {
   return {
     killRunningTask: (taskId: string) => taskExecutor.killActiveExecution(taskId),
     cancelTask: async (taskId: string) => {
@@ -133,6 +133,20 @@ function buildHeadlessApiCancelHooks(
         await taskExecutor.killActiveExecution(id);
       }
       return cmdResult.data;
+    },
+    deleteWorkflow: async (workflowId: string) => {
+      const allTasks = deps.orchestrator.getAllTasks();
+      const workflowTasks = allTasks.filter(
+        (t) =>
+          t.config.workflowId === workflowId &&
+          (t.status === 'running' || t.status === 'fixing_with_ai'),
+      );
+      for (const task of workflowTasks) {
+        await taskExecutor.killActiveExecution(task.id);
+      }
+      const envelope = makeEnvelope('delete-workflow', 'headless', 'workflow', { workflowId });
+      const cmdResult = await deps.commandService.deleteWorkflow(envelope);
+      if (!cmdResult.ok) throw new Error(cmdResult.error.message);
     },
   };
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -81,7 +81,6 @@ import {
   resolveEffectiveMaxConcurrency,
 } from './execution-capacity.js';
 import {
-  createDeleteAllSnapshot,
   createHourlySnapshot,
   resolveInvokerHomeRoot,
 } from './delete-all-snapshot.js';
@@ -109,6 +108,7 @@ import {
 } from './headless.js';
 import {
   approveTask as sharedApproveTask,
+  deleteAllWorkflows as sharedDeleteAllWorkflows,
   fixWithAgentAction,
   rebaseAndRetry,
   recreateWithRebase,
@@ -2815,13 +2815,7 @@ if (isHeadless) {
     registerGuiMutationHandler('invoker:delete-all-workflows', async () => {
       logger.info('delete-all-workflows', { module: 'ipc' });
       assertDeleteAllEnabled();
-      const snapshot = createDeleteAllSnapshot(resolveInvokerHomeRoot());
-      if (snapshot) {
-        logger.info(`delete-all-workflows snapshot: ${snapshot}`, { module: 'ipc' });
-      } else {
-        logger.info('delete-all-workflows snapshot skipped: DB file does not exist yet', { module: 'ipc' });
-      }
-      orchestrator.deleteAllWorkflows();
+      sharedDeleteAllWorkflows({ logger, orchestrator });
       taskHandles.clear();
       lastKnownTaskStates.clear();
       lastKnownWorkflowCount = 0;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1677,7 +1677,6 @@ if (isHeadless) {
       setTaskDispatcherExecutor: setDispatcherTaskExecutor,
       cancelTask: (taskId: string) => performCancelTask(taskId),
       cancelWorkflow: (workflowId: string) => performCancelWorkflow(workflowId),
-      deleteWorkflow: (workflowId: string) => performDeleteWorkflow(workflowId),
       waitForApproval: payload.waitForApproval,
       noTrack: payload.noTrack,
       preemptTaskSubgraph: (taskId: string) => preemptTaskSubgraph(taskId),

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -61,7 +61,7 @@ import type {
 import { makeEnvelope } from '@invoker/contracts';
 import type { WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
-import { IpcBus, Channels } from '@invoker/transport';
+import { IpcBus, Channels, TransportError, TransportErrorCode } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import {
   ExecutorRegistry, TaskRunner,
@@ -1948,7 +1948,7 @@ if (isHeadless) {
       try {
         return await messageBus.request<typeof translated.request, TResult>(translated.channel, translated.request);
       } catch (err) {
-        if (err instanceof Error && err.message.includes('No request handler registered for channel')) {
+        if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
           throw new Error('No mutation owner is available');
         }
         throw err;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2283,6 +2283,14 @@ if (isHeadless) {
             return { started };
           });
         },
+        rejectTaskAction: async (taskId: string, reason?: string) => {
+          const workflowId = orchestrator.getTask(taskId)?.config.workflowId;
+          await runWorkflowMutation(workflowId, 'normal', 'api:reject-task', [taskId, reason], async () => {
+            const envelope = makeEnvelope('reject', 'surface', 'task', { taskId, reason });
+            const result = await commandService.reject(envelope);
+            if (!result.ok) throw new Error(result.error.message);
+          });
+        },
         killRunningTask,
         cancelTask: performCancelTask,
         cancelWorkflow: performCancelWorkflow,
@@ -2472,6 +2480,13 @@ if (isHeadless) {
       });
       workflowMutationDispatcher.set('api:approve-task', async (taskIdArg: unknown) => {
         await performSharedApproveTask(String(taskIdArg), 'api');
+      });
+      workflowMutationDispatcher.set('api:reject-task', async (taskIdArg: unknown, reasonArg?: unknown) => {
+        const taskId = String(taskIdArg);
+        const reason = reasonArg === undefined ? undefined : String(reasonArg);
+        const envelope = makeEnvelope('reject', 'surface', 'task', { taskId, reason });
+        const result = await commandService.reject(envelope);
+        if (!result.ok) throw new Error(result.error.message);
       });
       workflowMutationDispatcher.set('surface:approve-task', async (taskIdArg: unknown) => {
         await performSharedApproveTask(String(taskIdArg), 'surface');

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1578,6 +1578,14 @@ if (isHeadless) {
     logger.info(`performDeleteWorkflow end workflow="${workflowId}"`, { module: 'kill' });
   }
 
+  async function performDetachWorkflow(workflowId: string, upstreamWorkflowId: string): Promise<void> {
+    logger.info(`performDetachWorkflow begin workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
+    const envelope = makeEnvelope('detach-workflow', 'ui', 'workflow', { workflowId, upstreamWorkflowId });
+    const result = await commandService.detachWorkflow(envelope);
+    if (!result.ok) throw new Error(result.error.message);
+    logger.info(`performDetachWorkflow end workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
+  }
+
   /** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
   const preemptSkipCodes: ReadonlySet<string> = new Set([
     OrchestratorErrorCode.TASK_NOT_FOUND,
@@ -2280,6 +2288,7 @@ if (isHeadless) {
         cancelTask: performCancelTask,
         cancelWorkflow: performCancelWorkflow,
         deleteWorkflow: performDeleteWorkflow,
+        detachWorkflow: performDetachWorkflow,
       });
       recordStartupMark('api-server.started');
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -58,7 +58,7 @@ import type {
   TaskState,
   TaskStateChanges,
 } from '@invoker/workflow-core';
-import { makeEnvelope } from '@invoker/contracts';
+import { makeEnvelope, CommandError } from '@invoker/contracts';
 import type { WorkResponse } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
 import { IpcBus, Channels, TransportError, TransportErrorCode } from '@invoker/transport';
@@ -1534,7 +1534,7 @@ if (isHeadless) {
   async function performCancelTask(taskId: string): Promise<{ cancelled: string[]; runningCancelled: string[] }> {
     const envelope = makeEnvelope('cancel-task', 'ui', 'task', { taskId });
     const cmdResult = await commandService.cancelTask(envelope);
-    if (!cmdResult.ok) throw new Error(cmdResult.error.message);
+    if (!cmdResult.ok) throw CommandError.fromResult(cmdResult.error);
     for (const id of cmdResult.data.runningCancelled) {
       await killRunningTask(id);
     }
@@ -1546,7 +1546,7 @@ if (isHeadless) {
     logger.info(`performCancelWorkflow begin workflow="${workflowId}"`, { module: 'kill' });
     const envelope = makeEnvelope('cancel-workflow', 'ui', 'workflow', { workflowId });
     const cmdResult = await commandService.cancelWorkflow(envelope);
-    if (!cmdResult.ok) throw new Error(cmdResult.error.message);
+    if (!cmdResult.ok) throw CommandError.fromResult(cmdResult.error);
     logger.info(
       `performCancelWorkflow commandService complete workflow="${workflowId}" cancelled=${cmdResult.data.cancelled.length} runningCancelled=${cmdResult.data.runningCancelled.length}`,
       { module: 'kill' },
@@ -1582,9 +1582,8 @@ if (isHeadless) {
     try {
       await performCancelTask(taskId);
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.includes('already completed') || message.includes('already stale')) {
-        logger.info(`preemptTaskSubgraph skipped for "${taskId}": ${message}`, { module: 'ipc' });
+      if (err instanceof CommandError && err.code === 'CANCEL_TASK_FAILED') {
+        logger.info(`preemptTaskSubgraph skipped for "${taskId}": ${err.message}`, { module: 'ipc' });
         return;
       }
       throw err;
@@ -1598,9 +1597,8 @@ if (isHeadless) {
       logger.info(`preemptWorkflowExecution end for "${workflowId}"`, { module: 'ipc' });
       return result;
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (message.includes('No tasks found for workflow')) {
-        logger.info(`preemptWorkflowExecution skipped for "${workflowId}": ${message}`, { module: 'ipc' });
+      if (err instanceof CommandError && err.code === 'CANCEL_WORKFLOW_FAILED') {
+        logger.info(`preemptWorkflowExecution skipped for "${workflowId}": ${err.message}`, { module: 'ipc' });
         return { cancelled: [], runningCancelled: [] };
       }
       throw err;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2291,6 +2291,21 @@ if (isHeadless) {
             if (!result.ok) throw new Error(result.error.message);
           });
         },
+        retryWorkflowAction: async (workflowId: string) => {
+          return runWorkflowMutation(workflowId, 'normal', 'api:retry-workflow', [workflowId], async () => {
+            const envelope = makeEnvelope('retry-workflow', 'surface', 'workflow', { workflowId });
+            const result = await commandService.retryWorkflow(envelope);
+            if (!result.ok) throw new Error(result.error.message);
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor: requireTaskExecutor(),
+              logger,
+              context: 'api.workflows.retry',
+              started: result.data.filter(t => t.status === 'running'),
+            });
+            return { started: result.data };
+          });
+        },
         killRunningTask,
         cancelTask: performCancelTask,
         cancelWorkflow: performCancelWorkflow,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -93,6 +93,7 @@ import {
 import { backupPlan } from './plan-backup.js';
 // applyPlanDefinitionDefaults removed — parsePlan() applies defaults internally
 import { startApiServer, type ApiServer } from './api-server.js';
+import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
   runHeadless,
   isDelegated,
@@ -2267,66 +2268,14 @@ if (isHeadless) {
         orchestrator,
         persistence,
         executorRegistry,
-        taskExecutor: requireTaskExecutor(),
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
-        approveTaskAction: async (taskId: string) => {
-          const workflowId = orchestrator.getTask(taskId)?.config.workflowId;
-          return runWorkflowMutation(workflowId, 'normal', 'api:approve-task', [taskId], async () => {
-            const { started } = await performSharedApproveTask(taskId, 'api');
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor: requireTaskExecutor(),
-              logger,
-              context: 'api.tasks.approve',
-              started,
-            });
-            return { started };
-          });
-        },
-        rejectTaskAction: async (taskId: string, reason?: string) => {
-          const workflowId = orchestrator.getTask(taskId)?.config.workflowId;
-          await runWorkflowMutation(workflowId, 'normal', 'api:reject-task', [taskId, reason], async () => {
-            const envelope = makeEnvelope('reject', 'surface', 'task', { taskId, reason });
-            const result = await commandService.reject(envelope);
-            if (!result.ok) throw new Error(result.error.message);
-          });
-        },
-        retryWorkflowAction: async (workflowId: string) => {
-          return runWorkflowMutation(workflowId, 'normal', 'api:retry-workflow', [workflowId], async () => {
-            const envelope = makeEnvelope('retry-workflow', 'surface', 'workflow', { workflowId });
-            const result = await commandService.retryWorkflow(envelope);
-            if (!result.ok) throw new Error(result.error.message);
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor: requireTaskExecutor(),
-              logger,
-              context: 'api.workflows.retry',
-              started: result.data.filter(t => t.status === 'running'),
-            });
-            return { started: result.data };
-          });
-        },
-        recreateWithRebaseAction: async (workflowId: string) => {
-          return runWorkflowMutation(workflowId, 'high', 'api:recreate-with-rebase', [workflowId], async () => {
-            const started = await recreateWithRebase(workflowId, {
-              orchestrator,
-              persistence,
-              taskExecutor: requireTaskExecutor(),
-              logger,
-            });
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor: requireTaskExecutor(),
-              logger,
-              context: 'api.workflows.recreate-with-rebase',
-              started: started.filter(t => t.status === 'running'),
-            });
-            return { started };
-          });
-        },
-        killRunningTask,
-        cancelTask: performCancelTask,
-        cancelWorkflow: performCancelWorkflow,
+        mutations: new WorkflowMutationFacade({
+          logger,
+          orchestrator,
+          persistence,
+          taskExecutor: requireTaskExecutor(),
+          autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+          killRunningTask,
+        }),
         deleteWorkflow: performDeleteWorkflow,
         detachWorkflow: performDetachWorkflow,
       });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -50,7 +50,7 @@ if (process.platform === 'linux' && !enableTestCompositor) {
   app.commandLine.appendSwitch('disable-software-rasterizer');
 }
 
-import { Orchestrator, CommandService } from '@invoker/workflow-core';
+import { Orchestrator, CommandService, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type {
   PlanDefinition,
   TaskDelta,
@@ -1578,11 +1578,18 @@ if (isHeadless) {
     logger.info(`performDeleteWorkflow end workflow="${workflowId}"`, { module: 'kill' });
   }
 
+  /** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
+  const preemptSkipCodes: ReadonlySet<string> = new Set([
+    OrchestratorErrorCode.TASK_NOT_FOUND,
+    OrchestratorErrorCode.TASK_ALREADY_TERMINAL,
+    OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
+  ]);
+
   async function preemptTaskSubgraph(taskId: string): Promise<void> {
     try {
       await performCancelTask(taskId);
     } catch (err) {
-      if (err instanceof CommandError && err.code === 'CANCEL_TASK_FAILED') {
+      if (err instanceof CommandError && preemptSkipCodes.has(err.code)) {
         logger.info(`preemptTaskSubgraph skipped for "${taskId}": ${err.message}`, { module: 'ipc' });
         return;
       }
@@ -1597,7 +1604,7 @@ if (isHeadless) {
       logger.info(`preemptWorkflowExecution end for "${workflowId}"`, { module: 'ipc' });
       return result;
     } catch (err) {
-      if (err instanceof CommandError && err.code === 'CANCEL_WORKFLOW_FAILED') {
+      if (err instanceof CommandError && preemptSkipCodes.has(err.code)) {
         logger.info(`preemptWorkflowExecution skipped for "${workflowId}": ${err.message}`, { module: 'ipc' });
         return { cancelled: [], runningCancelled: [] };
       }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2815,7 +2815,7 @@ if (isHeadless) {
     registerGuiMutationHandler('invoker:delete-all-workflows', async () => {
       logger.info('delete-all-workflows', { module: 'ipc' });
       assertDeleteAllEnabled();
-      sharedDeleteAllWorkflows({ logger, orchestrator });
+      await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
       lastKnownTaskStates.clear();
       lastKnownWorkflowCount = 0;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -96,6 +96,7 @@ import { backupPlan } from './plan-backup.js';
 import { startApiServer, type ApiServer } from './api-server.js';
 import {
   runHeadless,
+  isDelegated,
   tryDelegateRun,
   tryDelegateResume,
   resolveDelegationTimeoutMs,
@@ -635,14 +636,14 @@ if (isHeadless) {
         if (command === 'run') {
           const planPath = cliArgs[1];
           if (!planPath) throw new Error('Missing plan file. Usage: --headless run <plan.yaml>');
-          delegated = await tryDelegateRun(planPath, delegationBus, waitForApproval, noTrack);
+          delegated = isDelegated(await tryDelegateRun(planPath, delegationBus, waitForApproval, noTrack));
         } else if (command === 'resume') {
           const workflowId = cliArgs[1];
           if (!workflowId) throw new Error('Missing workflowId. Usage: --headless resume <id>');
-          delegated = await tryDelegateResume(workflowId, delegationBus, waitForApproval, noTrack);
+          delegated = isDelegated(await tryDelegateResume(workflowId, delegationBus, waitForApproval, noTrack));
         } else {
           const timeoutMs = noTrack ? undefined : await resolveDelegationTimeoutMs(cliArgs);
-          delegated = await tryDelegateExec(cliArgs, delegationBus, waitForApproval, noTrack, timeoutMs);
+          delegated = isDelegated(await tryDelegateExec(cliArgs, delegationBus, waitForApproval, noTrack, timeoutMs));
         }
 
         if (delegated) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2306,6 +2306,24 @@ if (isHeadless) {
             return { started: result.data };
           });
         },
+        recreateWithRebaseAction: async (workflowId: string) => {
+          return runWorkflowMutation(workflowId, 'high', 'api:recreate-with-rebase', [workflowId], async () => {
+            const started = await recreateWithRebase(workflowId, {
+              orchestrator,
+              persistence,
+              taskExecutor: requireTaskExecutor(),
+              logger,
+            });
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor: requireTaskExecutor(),
+              logger,
+              context: 'api.workflows.recreate-with-rebase',
+              started: started.filter(t => t.status === 'running'),
+            });
+            return { started };
+          });
+        },
         killRunningTask,
         cancelTask: performCancelTask,
         cancelWorkflow: performCancelWorkflow,

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -306,7 +306,7 @@ export class PersistedWorkflowMutationCoordinator {
     ) {
       return 'recreate';
     }
-    if (channel === 'invoker:delete-workflow') {
+    if (channel === 'invoker:delete-workflow' || channel === 'invoker:delete-all-workflows') {
       return 'delete';
     }
     if (channel !== 'headless.exec') {
@@ -317,7 +317,7 @@ export class PersistedWorkflowMutationCoordinator {
     if (rawArgs[0] === 'recreate' || rawArgs[0] === 'recreate-task') {
       return 'recreate';
     }
-    if (rawArgs[0] === 'delete' || rawArgs[0] === 'delete-workflow') {
+    if (rawArgs[0] === 'delete' || rawArgs[0] === 'delete-workflow' || rawArgs[0] === 'delete-all') {
       return 'delete';
     }
     return null;
@@ -330,6 +330,7 @@ export class PersistedWorkflowMutationCoordinator {
       || intent.channel === 'invoker:recreate-task'
       || intent.channel === 'invoker:recreate-with-rebase'
       || intent.channel === 'invoker:delete-workflow'
+      || intent.channel === 'invoker:delete-all-workflows'
     ) {
       return true;
     }
@@ -343,7 +344,7 @@ export class PersistedWorkflowMutationCoordinator {
     if (command === 'recreate-task') {
       return true;
     }
-    if (command === 'delete' || command === 'delete-workflow') {
+    if (command === 'delete' || command === 'delete-workflow' || command === 'delete-all') {
       return true;
     }
     const isWorkflowId = /^wf-[^/]+$/.test(target);

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -17,6 +17,7 @@ import type {
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
+import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 
 // ── Deps interfaces ──────────────────────────────────────────
 
@@ -160,6 +161,35 @@ export function cancelWorkflow(
   deps: Pick<ActionDeps, 'orchestrator'>,
 ): { cancelled: string[]; runningCancelled: string[] } {
   return deps.orchestrator.cancelWorkflow(workflowId);
+}
+
+/**
+ * Shared delete-all lifecycle bridge.
+ *
+ * Centralizes mutation ordering for the destructive delete-all
+ * operation so both main (GUI IPC) and headless (CLI) entrypoints
+ * share a single code path:
+ *
+ *   1. Create a DB snapshot (safety net — callers can abort on failure).
+ *   2. Delegate to `orchestrator.deleteAllWorkflows()` which handles
+ *      DB purge → scheduler kill → memory clear → removal deltas.
+ *
+ * Returns the snapshot path (or null when the DB file does not yet
+ * exist) so callers can log it through their own channel (stderr,
+ * structured logger, etc.).
+ */
+export function deleteAllWorkflows(
+  deps: Pick<ActionDeps, 'logger' | 'orchestrator'>,
+): { snapshotPath: string | null } {
+  const snapshotPath = createDeleteAllSnapshot();
+  deps.logger?.info(
+    snapshotPath
+      ? `delete-all-workflows snapshot: ${snapshotPath}`
+      : 'delete-all-workflows snapshot skipped: DB file does not exist yet',
+    { module: 'workflow' },
+  );
+  deps.orchestrator.deleteAllWorkflows();
+  return { snapshotPath };
 }
 
 /**

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -171,16 +171,18 @@ export function cancelWorkflow(
  * share a single code path:
  *
  *   1. Create a DB snapshot (safety net — callers can abort on failure).
- *   2. Delegate to `orchestrator.deleteAllWorkflows()` which handles
+ *   2. Kill all running/fixing_with_ai executor processes so no
+ *      orphaned child processes survive the purge.
+ *   3. Delegate to `orchestrator.deleteAllWorkflows()` which handles
  *      DB purge → scheduler kill → memory clear → removal deltas.
  *
  * Returns the snapshot path (or null when the DB file does not yet
  * exist) so callers can log it through their own channel (stderr,
  * structured logger, etc.).
  */
-export function deleteAllWorkflows(
-  deps: Pick<ActionDeps, 'logger' | 'orchestrator'>,
-): { snapshotPath: string | null } {
+export async function deleteAllWorkflows(
+  deps: Pick<ActionDeps, 'logger' | 'orchestrator' | 'taskExecutor'>,
+): Promise<{ snapshotPath: string | null }> {
   const snapshotPath = createDeleteAllSnapshot();
   deps.logger?.info(
     snapshotPath
@@ -188,6 +190,23 @@ export function deleteAllWorkflows(
       : 'delete-all-workflows snapshot skipped: DB file does not exist yet',
     { module: 'workflow' },
   );
+
+  // Kill executor processes for all running/fixing_with_ai tasks before
+  // the destructive purge.  Process management is outside orchestrator
+  // scope (same convention as performDeleteWorkflow in main.ts), so we
+  // handle it here in the shared bridge.
+  const taskExecutor = deps.taskExecutor;
+  if (taskExecutor) {
+    const allTasks = deps.orchestrator.getAllTasks();
+    const active = allTasks.filter(
+      (t) => t.status === 'running' || t.status === 'fixing_with_ai',
+    );
+    for (const task of active) {
+      deps.logger?.info(`delete-all: killing active task "${task.id}"`, { module: 'kill' });
+      await taskExecutor.killActiveExecution(task.id);
+    }
+  }
+
   deps.orchestrator.deleteAllWorkflows();
   return { snapshotPath };
 }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -14,6 +14,7 @@ import type {
   InvalidationScope,
   TaskState,
 } from '@invoker/workflow-core';
+import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
@@ -47,7 +48,7 @@ export function bumpGenerationAndRecreate(
 ): TaskState[] {
   const { persistence, orchestrator } = deps;
   const workflow = persistence.loadWorkflow(workflowId);
-  if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
   const nextGen = (workflow.generation ?? 0) + 1;
   persistence.updateWorkflow(workflowId, { generation: nextGen });
   deps.logger?.info(`bumped generation to ${nextGen} for ${workflowId}`, { module: 'workflow' });
@@ -257,7 +258,7 @@ export async function recreateWorkflowFromFreshBase(
   deps: ActionDeps,
 ): Promise<TaskState[]> {
   const workflow = deps.persistence.loadWorkflow(workflowId);
-  if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
   const nextGen = (workflow.generation ?? 0) + 1;
   deps.persistence.updateWorkflow(workflowId, { generation: nextGen });
   deps.logger?.info(
@@ -323,7 +324,7 @@ export async function rebaseAndRetry(
   deps: ActionDeps,
 ): Promise<TaskState[]> {
   const task = deps.orchestrator.getTask(taskId);
-  if (!task?.config.workflowId) throw new Error(`Task ${taskId} not found or has no workflow`);
+  if (!task?.config.workflowId) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found or has no workflow`);
   const workflowId = task.config.workflowId;
   deps.logger?.info(
     `rebaseAndRetry: taskId=${taskId} workflowId=${workflowId} → recreateWorkflowFromFreshBase (Step 12 delegate)`,
@@ -637,7 +638,7 @@ export async function fixWithAgentAction(
 ): Promise<FixWithAgentActionResult> {
   const { orchestrator, persistence, taskExecutor } = deps;
   const task = orchestrator.getTask(taskId);
-  if (!task) throw new Error(`Task ${taskId} not found`);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
   const savedError = task.execution.error ?? '';
   const recoveryRoute = options.recoveryRoute ?? selectFailureRecoveryRoute(task, savedError);

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -1,0 +1,420 @@
+/**
+ * WorkflowMutationFacade — Single entry point for mutation + dispatch + topup.
+ *
+ * Each entrypoint (api-server, headless, main) duplicates the same
+ * post-mutation lifecycle:
+ *
+ *   1. Call a shared action (workflow-actions.ts)
+ *   2. Filter runnable tasks from `started`
+ *   3. Execute runnable tasks via taskExecutor
+ *   4. Run global topup to fill scheduler capacity
+ *
+ * This facade encapsulates that lifecycle. Callers invoke a single
+ * method and receive a structured result. The facade does NOT own
+ * request parsing, error mapping, or response formatting — those
+ * remain in the entrypoint layer.
+ */
+
+import type { Logger } from '@invoker/contracts';
+import type { Orchestrator, ExternalGatePolicyUpdate, TaskState } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { TaskRunner } from '@invoker/execution-engine';
+import {
+  approveTask as sharedApproveTask,
+  rejectTask as sharedRejectTask,
+  provideInput as sharedProvideInput,
+  retryTask as sharedRetryTask,
+  retryWorkflow as sharedRetryWorkflow,
+  recreateWorkflow as sharedRecreateWorkflow,
+  recreateTask as sharedRecreateTask,
+  recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
+  recreateWithRebase as sharedRecreateWithRebase,
+  rebaseAndRetry as sharedRebaseAndRetry,
+  cancelWorkflow as sharedCancelWorkflow,
+  forkWorkflow as sharedForkWorkflow,
+  editTaskCommand as sharedEditTaskCommand,
+  editTaskPrompt as sharedEditTaskPrompt,
+  editTaskType as sharedEditTaskType,
+  editTaskAgent as sharedEditTaskAgent,
+  setTaskExternalGatePolicies as sharedSetTaskExternalGatePolicies,
+  setWorkflowMergeMode as sharedSetWorkflowMergeMode,
+  selectExperiment as sharedSelectExperiment,
+  selectExperiments as sharedSelectExperiments,
+  resolveConflictAction as sharedResolveConflictAction,
+  fixWithAgentAction as sharedFixWithAgentAction,
+  deleteAllWorkflows as sharedDeleteAllWorkflows,
+  type FailureRecoveryRoute,
+  type FixWithAgentActionResult,
+  type ActionDeps,
+} from './workflow-actions.js';
+import {
+  dispatchStartedTasksWithGlobalTopup,
+  executeGlobalTopup,
+} from './global-topup.js';
+
+// ── Result types ─────────────────────────────────────────────
+
+export interface MutationResult {
+  started: TaskState[];
+  runnable: TaskState[];
+  topup: TaskState[];
+}
+
+export interface ApproveMutationResult extends MutationResult {
+  approvedTask?: TaskState;
+  fixedTask: boolean;
+}
+
+export interface CancelMutationResult {
+  cancelled: string[];
+  runningCancelled: string[];
+  topup: TaskState[];
+}
+
+export interface ForkMutationResult extends MutationResult {
+  forkedWorkflowId: string;
+  sourceWorkflowId: string;
+}
+
+export interface DeleteAllResult {
+  snapshotPath: string | null;
+}
+
+export interface FixMutationResult extends MutationResult {
+  detail: FixWithAgentActionResult;
+}
+
+export interface ResolveConflictMutationResult extends MutationResult {
+  autoApproved: boolean;
+}
+
+// ── Facade deps ──────────────────────────────────────────────
+
+export interface WorkflowMutationFacadeDeps {
+  logger?: Logger;
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  taskExecutor: TaskRunner;
+  autoApproveAIFixes?: boolean;
+  /** Optional pre-kill hook for active task executions. */
+  killRunningTask?: (taskId: string) => Promise<void>;
+}
+
+// ── Facade ───────────────────────────────────────────────────
+
+/**
+ * Encapsulates the "mutate → filter runnable → execute → topup"
+ * lifecycle shared by all entrypoints.
+ */
+export class WorkflowMutationFacade {
+  constructor(private readonly deps: WorkflowMutationFacadeDeps) {}
+
+  // ── Task-scoped mutations ────────────────────────────────
+
+  async approveTask(taskId: string): Promise<ApproveMutationResult> {
+    const { orchestrator, taskExecutor } = this.deps;
+    const result = await sharedApproveTask(taskId, { orchestrator, taskExecutor });
+    const { runnable, topup } = await this.dispatchWithTopup(
+      result.started,
+      'facade.approve-task',
+    );
+    return {
+      approvedTask: result.approvedTask,
+      fixedTask: result.fixedTask,
+      started: result.started,
+      runnable,
+      topup,
+    };
+  }
+
+  rejectTask(taskId: string, reason?: string): void {
+    sharedRejectTask(taskId, { orchestrator: this.deps.orchestrator }, reason);
+  }
+
+  provideInput(taskId: string, text: string): void {
+    sharedProvideInput(taskId, text, { orchestrator: this.deps.orchestrator });
+  }
+
+  async retryTask(taskId: string): Promise<MutationResult> {
+    const started = sharedRetryTask(taskId, { orchestrator: this.deps.orchestrator });
+    return this.finalizeWithTopup(started, 'facade.retry-task');
+  }
+
+  async recreateTask(taskId: string): Promise<MutationResult> {
+    const started = sharedRecreateTask(taskId, {
+      orchestrator: this.deps.orchestrator,
+      persistence: this.deps.persistence,
+    });
+    return this.finalizeWithTopup(started, 'facade.recreate-task');
+  }
+
+  async selectExperiment(taskId: string, experimentId: string): Promise<MutationResult> {
+    const started = sharedSelectExperiment(taskId, experimentId, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.select-experiment');
+  }
+
+  async selectExperiments(taskId: string, experimentIds: string[]): Promise<MutationResult> {
+    const started = await sharedSelectExperiments(taskId, experimentIds, {
+      orchestrator: this.deps.orchestrator,
+      taskExecutor: this.deps.taskExecutor,
+    });
+    return this.finalizeWithTopup(started, 'facade.select-experiments');
+  }
+
+  async editTaskCommand(taskId: string, newCommand: string): Promise<MutationResult> {
+    const started = sharedEditTaskCommand(taskId, newCommand, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.edit-task-command');
+  }
+
+  async editTaskPrompt(taskId: string, newPrompt: string): Promise<MutationResult> {
+    const started = sharedEditTaskPrompt(taskId, newPrompt, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.edit-task-prompt');
+  }
+
+  async editTaskType(
+    taskId: string,
+    executorType: string,
+    remoteTargetId?: string,
+  ): Promise<MutationResult> {
+    const started = sharedEditTaskType(
+      taskId,
+      executorType,
+      { orchestrator: this.deps.orchestrator },
+      remoteTargetId,
+    );
+    return this.finalizeWithTopup(started, 'facade.edit-task-type');
+  }
+
+  async editTaskAgent(taskId: string, agentName: string): Promise<MutationResult> {
+    const started = sharedEditTaskAgent(taskId, agentName, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.edit-task-agent');
+  }
+
+  async setTaskExternalGatePolicies(
+    taskId: string,
+    updates: ExternalGatePolicyUpdate[],
+  ): Promise<MutationResult> {
+    const started = sharedSetTaskExternalGatePolicies(taskId, updates, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.set-gate-policy');
+  }
+
+  async cancelTask(taskId: string): Promise<CancelMutationResult> {
+    const result = this.deps.orchestrator.cancelTask(taskId);
+    if (this.deps.killRunningTask) {
+      for (const id of result.runningCancelled) {
+        await this.deps.killRunningTask(id);
+      }
+    }
+    const topup = await this.topupOnly('facade.cancel-task');
+    return { ...result, topup };
+  }
+
+  // ── Workflow-scoped mutations ────────────────────────────
+
+  async retryWorkflow(workflowId: string): Promise<MutationResult> {
+    const started = sharedRetryWorkflow(workflowId, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.retry-workflow');
+  }
+
+  async recreateWorkflow(workflowId: string): Promise<MutationResult> {
+    const started = sharedRecreateWorkflow(workflowId, {
+      logger: this.deps.logger,
+      persistence: this.deps.persistence,
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.recreate-workflow');
+  }
+
+  async recreateWorkflowFromFreshBase(workflowId: string): Promise<MutationResult> {
+    const started = await sharedRecreateWorkflowFromFreshBase(workflowId, this.actionDeps());
+    return this.finalizeWithTopup(started, 'facade.recreate-from-fresh-base');
+  }
+
+  async recreateWithRebase(workflowId: string): Promise<MutationResult> {
+    const started = await sharedRecreateWithRebase(workflowId, this.actionDeps());
+    return this.finalizeWithTopup(started, 'facade.recreate-with-rebase');
+  }
+
+  async rebaseAndRetry(taskId: string): Promise<MutationResult> {
+    const started = await sharedRebaseAndRetry(taskId, this.actionDeps());
+    return this.finalizeWithTopup(started, 'facade.rebase-and-retry');
+  }
+
+  async cancelWorkflow(workflowId: string): Promise<CancelMutationResult> {
+    const result = sharedCancelWorkflow(workflowId, {
+      orchestrator: this.deps.orchestrator,
+    });
+    if (this.deps.killRunningTask) {
+      for (const id of result.runningCancelled) {
+        await this.deps.killRunningTask(id);
+      }
+    }
+    const topup = await this.topupOnly('facade.cancel-workflow');
+    return { ...result, topup };
+  }
+
+  async deleteWorkflow(workflowId: string): Promise<void> {
+    // Kill active tasks before delete (process management is outside orchestrator scope)
+    if (this.deps.killRunningTask) {
+      const allTasks = this.deps.orchestrator.getAllTasks();
+      const active = allTasks.filter(
+        (t) =>
+          t.config.workflowId === workflowId &&
+          (t.status === 'running' || t.status === 'fixing_with_ai'),
+      );
+      for (const task of active) {
+        await this.deps.killRunningTask(task.id);
+      }
+    }
+    this.deps.orchestrator.deleteWorkflow(workflowId);
+  }
+
+  async deleteAllWorkflows(): Promise<DeleteAllResult> {
+    return sharedDeleteAllWorkflows({
+      logger: this.deps.logger,
+      orchestrator: this.deps.orchestrator,
+      taskExecutor: this.deps.taskExecutor,
+    });
+  }
+
+  async detachWorkflow(workflowId: string, upstreamWorkflowId: string): Promise<void> {
+    this.deps.orchestrator.detachWorkflow(workflowId, upstreamWorkflowId);
+  }
+
+  async forkWorkflow(workflowId: string): Promise<ForkMutationResult> {
+    const result = sharedForkWorkflow(workflowId, {
+      orchestrator: this.deps.orchestrator,
+      logger: this.deps.logger,
+    });
+    const runnable = result.started.filter((t) => t.status === 'running');
+    await this.deps.taskExecutor.executeTasks(runnable);
+    const topup = await this.topupOnly('facade.fork-workflow');
+    return {
+      forkedWorkflowId: result.forkedWorkflowId,
+      sourceWorkflowId: result.sourceWorkflowId,
+      started: result.started,
+      runnable,
+      topup,
+    };
+  }
+
+  async setWorkflowMergeMode(workflowId: string, mergeMode: string): Promise<void> {
+    await sharedSetWorkflowMergeMode(workflowId, mergeMode, {
+      orchestrator: this.deps.orchestrator,
+      persistence: this.deps.persistence,
+      taskExecutor: this.deps.taskExecutor,
+    });
+  }
+
+  // ── AI-driven mutations ──────────────────────────────────
+
+  async resolveConflict(
+    taskId: string,
+    agentName?: string,
+  ): Promise<ResolveConflictMutationResult> {
+    const result = await sharedResolveConflictAction(
+      taskId,
+      {
+        orchestrator: this.deps.orchestrator,
+        persistence: this.deps.persistence,
+        taskExecutor: this.deps.taskExecutor,
+        autoApproveAIFixes: this.deps.autoApproveAIFixes,
+      },
+      agentName,
+    );
+    const { runnable, topup } = await this.dispatchWithTopup(
+      result.started,
+      'facade.resolve-conflict',
+    );
+    return {
+      autoApproved: result.autoApproved,
+      started: result.started,
+      runnable,
+      topup,
+    };
+  }
+
+  async fixWithAgent(
+    taskId: string,
+    options: {
+      agentName?: string;
+      recoveryRoute?: FailureRecoveryRoute;
+      recreateOutputLabel?: string;
+      failureOutputLabel?: string;
+    } = {},
+  ): Promise<FixMutationResult> {
+    const detail = await sharedFixWithAgentAction(
+      taskId,
+      {
+        orchestrator: this.deps.orchestrator,
+        persistence: this.deps.persistence,
+        taskExecutor: this.deps.taskExecutor,
+        autoApproveAIFixes: this.deps.autoApproveAIFixes,
+      },
+      options,
+    );
+    const started =
+      detail.kind === 'recreateWorkflowFromFreshBase'
+        ? detail.started
+        : detail.started;
+    const { runnable, topup } = await this.dispatchWithTopup(
+      started,
+      'facade.fix-with-agent',
+    );
+    return { detail, started, runnable, topup };
+  }
+
+  // ── Internal helpers ─────────────────────────────────────
+
+  private actionDeps(): ActionDeps {
+    return {
+      logger: this.deps.logger,
+      orchestrator: this.deps.orchestrator,
+      persistence: this.deps.persistence,
+      taskExecutor: this.deps.taskExecutor,
+      autoApproveAIFixes: this.deps.autoApproveAIFixes,
+    };
+  }
+
+  private async dispatchWithTopup(
+    started: TaskState[],
+    context: string,
+  ): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
+    return dispatchStartedTasksWithGlobalTopup({
+      orchestrator: this.deps.orchestrator,
+      taskExecutor: this.deps.taskExecutor,
+      logger: this.deps.logger,
+      context,
+      started,
+    });
+  }
+
+  private async finalizeWithTopup(
+    started: TaskState[],
+    context: string,
+  ): Promise<MutationResult> {
+    const { runnable, topup } = await this.dispatchWithTopup(started, context);
+    return { started, runnable, topup };
+  }
+
+  private async topupOnly(context: string): Promise<TaskState[]> {
+    return executeGlobalTopup({
+      orchestrator: this.deps.orchestrator,
+      taskExecutor: this.deps.taskExecutor,
+      logger: this.deps.logger,
+      context,
+    });
+  }
+}

--- a/packages/contracts/src/command-envelope.ts
+++ b/packages/contracts/src/command-envelope.ts
@@ -17,6 +17,27 @@ export type CommandResult<T> =
   | { ok: false; error: { code: string; message: string } };
 
 /**
+ * CommandError — Structured error carrying a stable `code` from CommandResult.
+ *
+ * Thrown by bridge functions so callers can branch on `.code`
+ * instead of fragile message-string matching.
+ */
+export class CommandError extends Error {
+  readonly code: string;
+
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'CommandError';
+    this.code = code;
+  }
+
+  /** Create a CommandError from a failed CommandResult's error field. */
+  static fromResult(error: { code: string; message: string }): CommandError {
+    return new CommandError(error.code, error.message);
+  }
+}
+
+/**
  * Build a CommandEnvelope with an auto-generated idempotencyKey if none is provided.
  */
 export function makeEnvelope<P>(

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import type { Orchestrator } from '@invoker/workflow-core';
+import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { cleanElectronEnv } from './process-utils.js';
 import type { ExecutionAgent } from './agent.js';
@@ -172,7 +173,7 @@ export async function resolveConflictImpl(
     hasSavedError: savedError !== undefined,
   });
   const task = host.orchestrator.getTask(taskId);
-  if (!task) throw new Error(`Task ${taskId} not found`);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
   if (task.status !== 'failed' && task.status !== 'running' && task.status !== 'fixing_with_ai') {
     throw new Error(`Task ${taskId} is not in a resolvable state (status: ${task.status})`);
   }
@@ -444,7 +445,7 @@ export async function fixWithAgentImpl(
     outputLength: taskOutput.length,
   });
   const task = host.orchestrator.getTask(taskId);
-  if (!task) throw new Error(`Task ${taskId} not found`);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
   if (task.status !== 'failed' && task.status !== 'running' && task.status !== 'fixing_with_ai') {
     throw new Error(`Task ${taskId} is not in a fixable state (status: ${task.status})`);
   }

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -11,6 +11,7 @@ import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 
 import type { Orchestrator, TaskState, TaskStateChanges } from '@invoker/workflow-core';
+import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkResponse } from '@invoker/contracts';
 import type { TaskRunnerCallbacks } from './task-runner.js';
@@ -584,7 +585,7 @@ export async function approveMergeImpl(
 ): Promise<void> {
   mergeTrace('APPROVE_MERGE_ENTER', { workflowId });
   const workflow = host.persistence.loadWorkflow(workflowId);
-  if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
 
   const onFinish = workflow.onFinish ?? 'none';
   const baseBranch = workflow.baseBranch ?? host.defaultBranch ?? await host.detectDefaultBranch();

--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -4,7 +4,13 @@ import { existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { IpcBus, DEFAULT_REQUEST_DEADLINE_MS } from '../ipc-bus.js';
+import { createConnection } from 'node:net';
+import {
+  IpcBus,
+  DEFAULT_REQUEST_DEADLINE_MS,
+  MALFORMED_FRAME_RATE_LIMIT_MS,
+  type MalformedFrameEvent,
+} from '../ipc-bus.js';
 import { TransportError, TransportErrorCode } from '../transport-error.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -918,6 +924,172 @@ ${minimalIpcBusJS}
     expect(messages.b.some((m: any) => m.received)).toBe(true);
     expect(messages.a.some((m: any) => m.error)).toBe(false);
   }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// Malformed-frame observability
+// ---------------------------------------------------------------------------
+
+describe('Malformed-frame observability', () => {
+  const buses: IpcBus[] = [];
+
+  afterEach(() => {
+    for (const bus of buses) {
+      bus.disconnect();
+    }
+    buses.length = 0;
+  });
+
+  /** Encode a raw length-prefixed frame from an arbitrary string payload. */
+  function encodeRaw(payload: string): Buffer {
+    const json = Buffer.from(payload, 'utf8');
+    const frame = Buffer.allocUnsafe(4 + json.length);
+    frame.writeUInt32BE(json.length, 0);
+    json.copy(frame, 4);
+    return frame;
+  }
+
+  /** Connect a raw socket to the given path and wait for it to be ready. */
+  function rawConnect(socketPath: string): Promise<import('node:net').Socket> {
+    return new Promise((resolve, reject) => {
+      const sock = createConnection({ path: socketPath }, () => resolve(sock));
+      sock.on('error', reject);
+    });
+  }
+
+  it('fires onMalformedFrame for invalid JSON', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    // Send a frame whose payload is not valid JSON.
+    const raw = rawConnect(sock);
+    const peer = await raw;
+    peer.write(encodeRaw('not-json{{{'));
+
+    await waitFor(() => events.length >= 1, 2000);
+    peer.destroy();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].reason).toBe('invalid_json');
+    expect(events[0].rawByteLength).toBe(Buffer.byteLength('not-json{{{', 'utf8'));
+    expect(events[0].droppedSinceLastReport).toBe(0);
+    expect(events[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('fires onMalformedFrame for valid JSON with invalid envelope shape', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    // Valid JSON but missing required envelope fields.
+    const raw = rawConnect(sock);
+    const peer = await raw;
+    peer.write(encodeRaw('{"kind":"pub"}'));
+
+    await waitFor(() => events.length >= 1, 2000);
+    peer.destroy();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].reason).toBe('invalid_envelope');
+  });
+
+  it('rate-limits malformed frame events', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    // Use rateLimitMs=0 would disable limiting; we rely on default.
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    const peer = await rawConnect(sock);
+
+    // Send many malformed frames rapidly — default rate limit is 1 s,
+    // so only the first should be emitted immediately.
+    for (let i = 0; i < 10; i++) {
+      peer.write(encodeRaw(`bad-json-${i}`));
+    }
+
+    // Wait for socket data to be processed.
+    await sleep(200);
+    peer.destroy();
+
+    // Exactly 1 event emitted due to rate limiting (the other 9 suppressed).
+    expect(events).toHaveLength(1);
+    expect(events[0].droppedSinceLastReport).toBe(0);
+  });
+
+  it('reports suppressed count after rate-limit window elapses', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    const peer = await rawConnect(sock);
+
+    // First burst — first frame emitted, rest suppressed.
+    for (let i = 0; i < 5; i++) {
+      peer.write(encodeRaw(`bad-${i}`));
+    }
+    await sleep(200);
+    expect(events).toHaveLength(1);
+
+    // Wait for rate-limit window to pass.
+    await sleep(MALFORMED_FRAME_RATE_LIMIT_MS + 100);
+
+    // Second malformed frame triggers a new event with suppressed count.
+    peer.write(encodeRaw('another-bad'));
+    await waitFor(() => events.length >= 2, 2000);
+    peer.destroy();
+
+    expect(events).toHaveLength(2);
+    // 4 frames were suppressed between the first and second emitted events.
+    expect(events[1].droppedSinceLastReport).toBe(4);
+  });
+
+  it('does not fire callback when no observer is provided', async () => {
+    const sock = tempSocketPath();
+    // No onMalformedFrame — should not throw.
+    const bus = new IpcBus(sock);
+    buses.push(bus);
+    await bus.ready();
+
+    const peer = await rawConnect(sock);
+    peer.write(encodeRaw('not-json'));
+    await sleep(200);
+    peer.destroy();
+
+    // If we get here without an unhandled exception, the test passes.
+    expect(true).toBe(true);
+  });
+
+  it('still delivers valid frames alongside malformed ones', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    const received: string[] = [];
+    bus.subscribe('test', (msg: string) => received.push(msg));
+
+    const peer = await rawConnect(sock);
+    // Send a malformed frame followed by a valid pub envelope.
+    const malformed = encodeRaw('garbage');
+    const valid = encodeRaw(JSON.stringify({ kind: 'pub', channel: 'test', body: 'hello' }));
+    peer.write(Buffer.concat([malformed, valid]));
+
+    await waitFor(() => received.length >= 1, 2000);
+    peer.destroy();
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(received).toEqual(['hello']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -4,7 +4,8 @@ import { existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { IpcBus } from '../ipc-bus.js';
+import { IpcBus, DEFAULT_REQUEST_DEADLINE_MS } from '../ipc-bus.js';
+import { TransportError, TransportErrorCode } from '../transport-error.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -293,6 +294,85 @@ describe('IpcBus', () => {
 
     const result = await requester.request<number, number>('delayed-double', 5);
     expect(result).toBe(10);
+  });
+
+  // ---------------------------------------------------------------
+  // Request deadline
+  // ---------------------------------------------------------------
+
+  it('rejects with REQUEST_TIMEOUT when no response arrives within the deadline', async () => {
+    const sock = tempSocketPath();
+
+    const server = new IpcBus(sock, { requestDeadlineMs: 100 });
+    buses.push(server);
+    await server.ready();
+
+    // Register a handler that never resolves.
+    server.onRequest('black-hole', () => new Promise(() => {}));
+
+    const client = new IpcBus(sock, { requestDeadlineMs: 100 });
+    buses.push(client);
+    await client.ready();
+    await sleep(50);
+
+    try {
+      await client.request('black-hole', {});
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.REQUEST_TIMEOUT);
+      expect((err as TransportError).message).toContain('black-hole');
+      expect((err as TransportError).message).toContain('100ms');
+    }
+  });
+
+  it('does not timeout when response arrives before the deadline', async () => {
+    const sock = tempSocketPath();
+
+    const server = new IpcBus(sock, { requestDeadlineMs: 500 });
+    buses.push(server);
+    await server.ready();
+
+    server.onRequest<number, number>('fast', (n) => n + 1);
+
+    const client = new IpcBus(sock, { requestDeadlineMs: 500 });
+    buses.push(client);
+    await client.ready();
+    await sleep(50);
+
+    const result = await client.request<number, number>('fast', 41);
+    expect(result).toBe(42);
+  });
+
+  it('disconnect rejects with DISCONNECTED, not REQUEST_TIMEOUT', async () => {
+    const sock = tempSocketPath();
+
+    const server = new IpcBus(sock, { requestDeadlineMs: 2000 });
+    buses.push(server);
+    await server.ready();
+
+    server.onRequest('never-reply', () => new Promise(() => {}));
+
+    const client = new IpcBus(sock, { requestDeadlineMs: 2000 });
+    buses.push(client);
+    await client.ready();
+    await sleep(50);
+
+    const requestPromise = client.request('never-reply', {});
+    await sleep(20);
+    client.disconnect();
+
+    try {
+      await requestPromise;
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.DISCONNECTED);
+    }
+  });
+
+  it('exports DEFAULT_REQUEST_DEADLINE_MS as 30000', () => {
+    expect(DEFAULT_REQUEST_DEADLINE_MS).toBe(30_000);
   });
 
   // ---------------------------------------------------------------

--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -371,6 +371,22 @@ describe('IpcBus', () => {
     }
   });
 
+  it('rejects immediately with NO_HANDLER when no local handler and no peers', async () => {
+    const sock = tempSocketPath();
+
+    const bus = createBus(sock);
+    await bus.ready();
+
+    try {
+      await bus.request('unhandled-channel', { data: 1 });
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.NO_HANDLER);
+      expect((err as TransportError).message).toContain('unhandled-channel');
+    }
+  });
+
   it('exports DEFAULT_REQUEST_DEADLINE_MS as 30000', () => {
     expect(DEFAULT_REQUEST_DEADLINE_MS).toBe(30_000);
   });

--- a/packages/transport/src/__tests__/transport-error.test.ts
+++ b/packages/transport/src/__tests__/transport-error.test.ts
@@ -1,0 +1,165 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { join } from 'node:path';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+
+import { TransportError, TransportErrorCode } from '../transport-error.js';
+import { LocalBus } from '../local-bus.js';
+import { IpcBus } from '../ipc-bus.js';
+
+function tempSocketPath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'transport-error-test-'));
+  return join(dir, 'test.sock');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+describe('TransportError', () => {
+  it('is an instance of Error', () => {
+    const err = new TransportError(TransportErrorCode.NO_HANDLER, 'test');
+    expect(err).toBeInstanceOf(Error);
+    expect(err).toBeInstanceOf(TransportError);
+  });
+
+  it('carries the code and message fields', () => {
+    const err = new TransportError(TransportErrorCode.DISCONNECTED, 'bus gone');
+    expect(err.code).toBe('DISCONNECTED');
+    expect(err.message).toBe('bus gone');
+    expect(err.name).toBe('TransportError');
+  });
+
+  it('exposes all expected error codes', () => {
+    expect(TransportErrorCode.NO_HANDLER).toBe('NO_HANDLER');
+    expect(TransportErrorCode.DISCONNECTED).toBe('DISCONNECTED');
+    expect(TransportErrorCode.HANDLER_ERROR).toBe('HANDLER_ERROR');
+  });
+});
+
+describe('LocalBus typed error codes', () => {
+  let bus: LocalBus;
+
+  beforeEach(() => {
+    bus = new LocalBus();
+  });
+
+  it('throws TransportError with NO_HANDLER when no handler registered', async () => {
+    try {
+      await bus.request('missing-channel', {});
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.NO_HANDLER);
+      expect((err as TransportError).message).toContain('missing-channel');
+    }
+  });
+});
+
+describe('IpcBus typed error codes', () => {
+  const buses: IpcBus[] = [];
+
+  function createBus(socketPath: string, opts?: { allowServe?: boolean }): IpcBus {
+    const bus = new IpcBus(socketPath, opts);
+    buses.push(bus);
+    return bus;
+  }
+
+  afterEach(() => {
+    for (const bus of buses) {
+      bus.disconnect();
+    }
+    buses.length = 0;
+  });
+
+  it('rejects with TransportError NO_HANDLER for unhandled cross-instance request', async () => {
+    const sock = tempSocketPath();
+    const server = createBus(sock);
+    await server.ready();
+
+    const client = createBus(sock);
+    await client.ready();
+    await sleep(50);
+
+    try {
+      await client.request('no-such-channel', {});
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.NO_HANDLER);
+    }
+  });
+
+  it('rejects with TransportError HANDLER_ERROR when handler throws', async () => {
+    const sock = tempSocketPath();
+    const server = createBus(sock);
+    await server.ready();
+
+    server.onRequest('failing', () => {
+      throw new Error('handler boom');
+    });
+
+    const client = createBus(sock);
+    await client.ready();
+    await sleep(50);
+
+    try {
+      await client.request('failing', {});
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.HANDLER_ERROR);
+      expect((err as TransportError).message).toBe('handler boom');
+    }
+  });
+
+  it('rejects with TransportError DISCONNECTED on disconnect', async () => {
+    const sock = tempSocketPath();
+    const server = createBus(sock);
+    await server.ready();
+
+    // Register a handler that never resolves, keeping the request pending
+    server.onRequest('slow-channel', () => new Promise(() => {}));
+
+    const client = createBus(sock);
+    await client.ready();
+    await sleep(50);
+
+    // Start a request that will pend forever, then disconnect the client
+    const requestPromise = client.request('slow-channel', {});
+    // Allow the request envelope to reach the server
+    await sleep(20);
+    client.disconnect();
+
+    try {
+      await requestPromise;
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.DISCONNECTED);
+    }
+  });
+
+  it('preserves TransportError code through handler that throws TransportError', async () => {
+    const sock = tempSocketPath();
+    const server = createBus(sock);
+    await server.ready();
+
+    server.onRequest('custom-error', () => {
+      throw new TransportError(TransportErrorCode.NO_HANDLER, 'custom no handler');
+    });
+
+    const client = createBus(sock);
+    await client.ready();
+    await sleep(50);
+
+    try {
+      await client.request('custom-error', {});
+      expect.fail('should have thrown');
+    } catch (err) {
+      expect(err).toBeInstanceOf(TransportError);
+      expect((err as TransportError).code).toBe(TransportErrorCode.NO_HANDLER);
+      expect((err as TransportError).message).toBe('custom no handler');
+    }
+  });
+});

--- a/packages/transport/src/__tests__/transport-error.test.ts
+++ b/packages/transport/src/__tests__/transport-error.test.ts
@@ -34,6 +34,7 @@ describe('TransportError', () => {
     expect(TransportErrorCode.NO_HANDLER).toBe('NO_HANDLER');
     expect(TransportErrorCode.DISCONNECTED).toBe('DISCONNECTED');
     expect(TransportErrorCode.HANDLER_ERROR).toBe('HANDLER_ERROR');
+    expect(TransportErrorCode.REQUEST_TIMEOUT).toBe('REQUEST_TIMEOUT');
   });
 });
 

--- a/packages/transport/src/index.ts
+++ b/packages/transport/src/index.ts
@@ -1,3 +1,4 @@
 export * from './message-bus.js';
 export * from './local-bus.js';
 export * from './ipc-bus.js';
+export * from './transport-error.js';

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -200,6 +200,33 @@ function isValidEnvelope(v: unknown): v is Envelope {
 }
 
 // ---------------------------------------------------------------------------
+// Subscriber-error observability
+// ---------------------------------------------------------------------------
+
+/** Structured event emitted when a subscriber handler throws. */
+export interface SubscriberErrorEvent {
+  /** ISO-8601 timestamp of the error. */
+  timestamp: string;
+  /** Channel the handler was subscribed to. */
+  channel: string;
+  /** Error message (no payload data to avoid leakage). */
+  error: string;
+  /** Number of handler errors suppressed since the last emitted event
+   *  (0 when every error is reported; >0 when rate-limited). */
+  droppedSinceLastReport: number;
+}
+
+/** Callback signature for subscriber-error observers. */
+export type SubscriberErrorObserver = (event: SubscriberErrorEvent) => void;
+
+/**
+ * Default minimum interval (ms) between emitted subscriber-error events.
+ * Errors that occur faster are counted but not reported until the window
+ * elapses (token-bucket with capacity 1).
+ */
+export const SUBSCRIBER_ERROR_RATE_LIMIT_MS = 1_000;
+
+// ---------------------------------------------------------------------------
 // Default socket path
 // ---------------------------------------------------------------------------
 
@@ -217,6 +244,9 @@ export interface IpcBusOptions {
   /** Optional callback invoked when a malformed frame is received.
    *  Rate-limited to at most one call per {@link MALFORMED_FRAME_RATE_LIMIT_MS}. */
   onMalformedFrame?: MalformedFrameObserver;
+  /** Optional callback invoked when a subscriber handler throws.
+   *  Rate-limited to at most one call per {@link SUBSCRIBER_ERROR_RATE_LIMIT_MS}. */
+  onSubscriberError?: SubscriberErrorObserver;
 }
 
 // ---------------------------------------------------------------------------
@@ -228,6 +258,12 @@ export class IpcBus implements MessageBus {
   private readonly allowServe: boolean;
   private readonly requestDeadlineMs: number;
   private readonly onMalformedFrame: MalformedFrameObserver | undefined;
+  private readonly onSubscriberError: SubscriberErrorObserver | undefined;
+
+  /** Timestamp (ms) of the last emitted subscriber-error event. */
+  private subscriberErrorLastEmitMs = 0;
+  /** Count of subscriber errors suppressed by rate-limiting since last emit. */
+  private subscriberErrorSuppressedCount = 0;
 
   // Local handler registries (same structure as LocalBus).
   private subscribers = new Map<string, Set<MessageHandler>>();
@@ -259,6 +295,7 @@ export class IpcBus implements MessageBus {
     this.allowServe = options.allowServe ?? true;
     this.requestDeadlineMs = options.requestDeadlineMs ?? DEFAULT_REQUEST_DEADLINE_MS;
     this.onMalformedFrame = options.onMalformedFrame;
+    this.onSubscriberError = options.onSubscriberError;
     this.readyPromise = new Promise<void>((r) => {
       this.resolveReady = r;
     });
@@ -416,10 +453,33 @@ export class IpcBus implements MessageBus {
     for (const handler of handlers) {
       try {
         handler(body);
-      } catch {
+      } catch (e) {
         // Swallow handler errors — same behaviour as LocalBus.
+        this.reportSubscriberError(
+          channel,
+          e instanceof Error ? e.message : String(e),
+        );
       }
     }
+  }
+
+  /** Emit a subscriber-error event, respecting the rate limit. */
+  private reportSubscriberError(channel: string, error: string): void {
+    if (!this.onSubscriberError) return;
+    const now = Date.now();
+    if (now - this.subscriberErrorLastEmitMs < SUBSCRIBER_ERROR_RATE_LIMIT_MS) {
+      this.subscriberErrorSuppressedCount++;
+      return;
+    }
+    this.subscriberErrorLastEmitMs = now;
+    const droppedSinceLastReport = this.subscriberErrorSuppressedCount;
+    this.subscriberErrorSuppressedCount = 0;
+    this.onSubscriberError({
+      timestamp: new Date(now).toISOString(),
+      channel,
+      error,
+      droppedSinceLastReport,
+    });
   }
 
   private async handleRequest(env: ReqEnvelope, source: Socket): Promise<void> {

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -24,7 +24,7 @@
  * { kind: "pub",     channel: string, body: unknown }                  — publish
  * { kind: "req",     channel: string, body: unknown, reqId: string }   — request
  * { kind: "res",     channel: string, body: unknown, reqId: string }   — response
- * { kind: "err",     channel: string, message: string, reqId: string } — error response
+ * { kind: "err",     channel: string, code: string, message: string, reqId: string } — error response
  * ```
  *
  * The `kind` field maps 1:1 to a future gRPC `oneof` message type.
@@ -43,6 +43,7 @@ import type {
   RequestHandler,
   Unsubscribe,
 } from './message-bus.js';
+import { TransportError, TransportErrorCode } from './transport-error.js';
 
 // ---------------------------------------------------------------------------
 // Wire envelope types
@@ -71,6 +72,7 @@ interface ResEnvelope {
 interface ErrEnvelope {
   kind: 'err';
   channel: string;
+  code: TransportErrorCode;
   message: string;
   reqId: string;
 }
@@ -348,6 +350,7 @@ export class IpcBus implements MessageBus {
       const errEnv: ErrEnvelope = {
         kind: 'err',
         channel: env.channel,
+        code: TransportErrorCode.NO_HANDLER,
         message: `No request handler registered for channel: ${env.channel}`,
         reqId: env.reqId,
       };
@@ -367,6 +370,7 @@ export class IpcBus implements MessageBus {
       const errEnv: ErrEnvelope = {
         kind: 'err',
         channel: env.channel,
+        code: e instanceof TransportError ? e.code : TransportErrorCode.HANDLER_ERROR,
         message: e instanceof Error ? e.message : String(e),
         reqId: env.reqId,
       };
@@ -381,7 +385,7 @@ export class IpcBus implements MessageBus {
       if (env.kind === 'res') {
         pending.resolve(env.body);
       } else {
-        pending.reject(new Error(env.message));
+        pending.reject(new TransportError(env.code ?? TransportErrorCode.HANDLER_ERROR, env.message));
       }
       return;
     }
@@ -399,7 +403,7 @@ export class IpcBus implements MessageBus {
     }
 
     relay.awaiting.delete(source);
-    const noHandlerError = env.message === `No request handler registered for channel: ${relay.channel}`;
+    const noHandlerError = env.code === TransportErrorCode.NO_HANDLER;
     if (!noHandlerError || relay.awaiting.size === 0) {
       this.relayedRequests.delete(env.reqId);
       this.sendToSocket(relay.source, env);
@@ -505,7 +509,7 @@ export class IpcBus implements MessageBus {
 
     // Reject all pending requests.
     for (const [, pending] of this.pendingRequests) {
-      pending.reject(new Error('IpcBus disconnected'));
+      pending.reject(new TransportError(TransportErrorCode.DISCONNECTED, 'IpcBus disconnected'));
     }
     this.pendingRequests.clear();
 

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -130,8 +130,14 @@ class FrameDecoder {
 export const DEFAULT_SOCKET_PATH =
   process.env.INVOKER_IPC_SOCKET || join(homedir(), '.invoker', 'ipc-transport.sock');
 
+/** Default request deadline in milliseconds (30 s). */
+export const DEFAULT_REQUEST_DEADLINE_MS = 30_000;
+
 export interface IpcBusOptions {
   allowServe?: boolean;
+  /** Maximum time in ms a request may wait for a response before being
+   *  rejected with `REQUEST_TIMEOUT`.  Defaults to {@link DEFAULT_REQUEST_DEADLINE_MS}. */
+  requestDeadlineMs?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -141,6 +147,7 @@ export interface IpcBusOptions {
 export class IpcBus implements MessageBus {
   private readonly socketPath: string;
   private readonly allowServe: boolean;
+  private readonly requestDeadlineMs: number;
 
   // Local handler registries (same structure as LocalBus).
   private subscribers = new Map<string, Set<MessageHandler>>();
@@ -160,7 +167,7 @@ export class IpcBus implements MessageBus {
   private nextReqId = 0;
   private pendingRequests = new Map<
     string,
-    { resolve: (v: unknown) => void; reject: (e: Error) => void }
+    { resolve: (v: unknown) => void; reject: (e: Error) => void; timer: ReturnType<typeof setTimeout> }
   >();
   private relayedRequests = new Map<
     string,
@@ -170,6 +177,7 @@ export class IpcBus implements MessageBus {
   constructor(socketPath: string = DEFAULT_SOCKET_PATH, options: IpcBusOptions = {}) {
     this.socketPath = socketPath;
     this.allowServe = options.allowServe ?? true;
+    this.requestDeadlineMs = options.requestDeadlineMs ?? DEFAULT_REQUEST_DEADLINE_MS;
     this.readyPromise = new Promise<void>((r) => {
       this.resolveReady = r;
     });
@@ -381,6 +389,7 @@ export class IpcBus implements MessageBus {
   private handleResponse(env: ResEnvelope | ErrEnvelope, source: Socket): void {
     const pending = this.pendingRequests.get(env.reqId);
     if (pending) {
+      clearTimeout(pending.timer);
       this.pendingRequests.delete(env.reqId);
       if (env.kind === 'res') {
         pending.resolve(env.body);
@@ -488,9 +497,20 @@ export class IpcBus implements MessageBus {
     const env: ReqEnvelope = { kind: 'req', channel, body: message, reqId };
 
     return new Promise<Res>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        if (this.pendingRequests.delete(reqId)) {
+          reject(new TransportError(
+            TransportErrorCode.REQUEST_TIMEOUT,
+            `Request on channel "${channel}" timed out after ${this.requestDeadlineMs}ms`,
+          ));
+        }
+      }, this.requestDeadlineMs);
+      timer.unref?.();
+
       this.pendingRequests.set(reqId, {
         resolve: resolve as (v: unknown) => void,
         reject,
+        timer,
       });
       // Send to all peers — only the one with a handler will reply.
       this.sendToAll(env);
@@ -507,8 +527,9 @@ export class IpcBus implements MessageBus {
     this.subscribers.clear();
     this.requestHandlers.clear();
 
-    // Reject all pending requests.
+    // Reject all pending requests and clear their deadline timers.
     for (const [, pending] of this.pendingRequests) {
+      clearTimeout(pending.timer);
       pending.reject(new TransportError(TransportErrorCode.DISCONNECTED, 'IpcBus disconnected'));
     }
     this.pendingRequests.clear();

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -493,6 +493,15 @@ export class IpcBus implements MessageBus {
     // Forward to a peer (first available).
     await this.readyPromise;
 
+    // If no peers are connected, reject immediately — no one can handle this.
+    const livePeers = [...this.peers].filter((p) => !p.destroyed);
+    if (livePeers.length === 0) {
+      throw new TransportError(
+        TransportErrorCode.NO_HANDLER,
+        `No request handler registered for channel: ${channel}`,
+      );
+    }
+
     const reqId = String(this.nextReqId++);
     const env: ReqEnvelope = { kind: 'req', channel, body: message, reqId };
 

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -92,6 +92,33 @@ function encode(env: Envelope): Buffer {
   return frame;
 }
 
+// ---------------------------------------------------------------------------
+// Malformed-frame observability
+// ---------------------------------------------------------------------------
+
+/** Structured event emitted when a frame fails to decode. */
+export interface MalformedFrameEvent {
+  /** ISO-8601 timestamp of the drop. */
+  timestamp: string;
+  /** Why the frame was rejected. */
+  reason: 'invalid_json' | 'invalid_envelope';
+  /** Byte length of the raw JSON payload that failed. */
+  rawByteLength: number;
+  /** Number of malformed frames dropped since the last emitted event
+   *  (0 when every drop is reported; >0 when rate-limited). */
+  droppedSinceLastReport: number;
+}
+
+/** Callback signature for malformed-frame observers. */
+export type MalformedFrameObserver = (event: MalformedFrameEvent) => void;
+
+/**
+ * Default minimum interval (ms) between emitted malformed-frame events.
+ * Events that arrive faster are counted but not reported until the window
+ * elapses (token-bucket with capacity 1).
+ */
+export const MALFORMED_FRAME_RATE_LIMIT_MS = 1_000;
+
 /**
  * Streaming decoder for length-prefixed JSON frames.
  *
@@ -100,10 +127,23 @@ function encode(env: Envelope): Buffer {
  */
 class FrameDecoder {
   private buf = Buffer.alloc(0);
-  private onEnvelope: (env: Envelope) => void;
+  private readonly onEnvelope: (env: Envelope) => void;
+  private readonly onMalformed: MalformedFrameObserver | undefined;
+  private readonly rateLimitMs: number;
 
-  constructor(onEnvelope: (env: Envelope) => void) {
+  /** Timestamp (ms) of the last emitted malformed-frame event. */
+  private lastEmitMs = 0;
+  /** Count of drops suppressed by rate-limiting since last emit. */
+  private suppressedCount = 0;
+
+  constructor(
+    onEnvelope: (env: Envelope) => void,
+    onMalformed?: MalformedFrameObserver,
+    rateLimitMs: number = MALFORMED_FRAME_RATE_LIMIT_MS,
+  ) {
     this.onEnvelope = onEnvelope;
+    this.onMalformed = onMalformed;
+    this.rateLimitMs = rateLimitMs;
   }
 
   push(chunk: Buffer): void {
@@ -115,12 +155,48 @@ class FrameDecoder {
       const json = this.buf.subarray(4, 4 + len).toString('utf8');
       this.buf = this.buf.subarray(4 + len);
       try {
-        this.onEnvelope(JSON.parse(json) as Envelope);
+        const parsed: unknown = JSON.parse(json);
+        if (!isValidEnvelope(parsed)) {
+          this.reportMalformed('invalid_envelope', Buffer.byteLength(json, 'utf8'));
+          continue;
+        }
+        this.onEnvelope(parsed);
       } catch {
-        // Malformed frame — skip silently (no payload logging).
+        this.reportMalformed('invalid_json', Buffer.byteLength(json, 'utf8'));
       }
     }
   }
+
+  /** Emit a malformed-frame event, respecting the rate limit. */
+  private reportMalformed(reason: MalformedFrameEvent['reason'], rawByteLength: number): void {
+    if (!this.onMalformed) return;
+    const now = Date.now();
+    if (now - this.lastEmitMs < this.rateLimitMs) {
+      this.suppressedCount++;
+      return;
+    }
+    this.lastEmitMs = now;
+    const droppedSinceLastReport = this.suppressedCount;
+    this.suppressedCount = 0;
+    this.onMalformed({
+      timestamp: new Date(now).toISOString(),
+      reason,
+      rawByteLength,
+      droppedSinceLastReport,
+    });
+  }
+}
+
+/** Type guard: returns true when the value has a valid envelope shape. */
+function isValidEnvelope(v: unknown): v is Envelope {
+  if (typeof v !== 'object' || v === null) return false;
+  const obj = v as Record<string, unknown>;
+  const kind = obj.kind;
+  if (kind === 'pub') return typeof obj.channel === 'string';
+  if (kind === 'req') return typeof obj.channel === 'string' && typeof obj.reqId === 'string';
+  if (kind === 'res') return typeof obj.channel === 'string' && typeof obj.reqId === 'string';
+  if (kind === 'err') return typeof obj.channel === 'string' && typeof obj.reqId === 'string' && typeof obj.code === 'string';
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -138,6 +214,9 @@ export interface IpcBusOptions {
   /** Maximum time in ms a request may wait for a response before being
    *  rejected with `REQUEST_TIMEOUT`.  Defaults to {@link DEFAULT_REQUEST_DEADLINE_MS}. */
   requestDeadlineMs?: number;
+  /** Optional callback invoked when a malformed frame is received.
+   *  Rate-limited to at most one call per {@link MALFORMED_FRAME_RATE_LIMIT_MS}. */
+  onMalformedFrame?: MalformedFrameObserver;
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +227,7 @@ export class IpcBus implements MessageBus {
   private readonly socketPath: string;
   private readonly allowServe: boolean;
   private readonly requestDeadlineMs: number;
+  private readonly onMalformedFrame: MalformedFrameObserver | undefined;
 
   // Local handler registries (same structure as LocalBus).
   private subscribers = new Map<string, Set<MessageHandler>>();
@@ -178,6 +258,7 @@ export class IpcBus implements MessageBus {
     this.socketPath = socketPath;
     this.allowServe = options.allowServe ?? true;
     this.requestDeadlineMs = options.requestDeadlineMs ?? DEFAULT_REQUEST_DEADLINE_MS;
+    this.onMalformedFrame = options.onMalformedFrame;
     this.readyPromise = new Promise<void>((r) => {
       this.resolveReady = r;
     });
@@ -287,7 +368,10 @@ export class IpcBus implements MessageBus {
       return;
     }
     this.peers.add(sock);
-    const decoder = new FrameDecoder((env) => this.handleEnvelope(env, sock));
+    const decoder = new FrameDecoder(
+      (env) => this.handleEnvelope(env, sock),
+      this.onMalformedFrame,
+    );
     sock.on('data', (chunk: Buffer) => decoder.push(chunk));
     sock.on('close', () => {
       this.peers.delete(sock);

--- a/packages/transport/src/local-bus.ts
+++ b/packages/transport/src/local-bus.ts
@@ -10,6 +10,7 @@ import type {
   RequestHandler,
   Unsubscribe,
 } from './message-bus.js';
+import { TransportError, TransportErrorCode } from './transport-error.js';
 
 export class LocalBus implements MessageBus {
   private subscribers = new Map<string, Set<MessageHandler>>();
@@ -49,7 +50,10 @@ export class LocalBus implements MessageBus {
   async request<Req, Res>(channel: string, message: Req): Promise<Res> {
     const handler = this.requestHandlers.get(channel);
     if (!handler) {
-      throw new Error(`No request handler registered for channel: ${channel}`);
+      throw new TransportError(
+        TransportErrorCode.NO_HANDLER,
+        `No request handler registered for channel: ${channel}`,
+      );
     }
     return handler(message) as Promise<Res>;
   }

--- a/packages/transport/src/transport-error.ts
+++ b/packages/transport/src/transport-error.ts
@@ -1,0 +1,33 @@
+/**
+ * TransportErrorCode — Stable error codes for the IPC bus error envelope.
+ *
+ * These codes replace message-string matching for control flow.
+ * Consumers (delegation layer, API bridge) switch on `code` instead of
+ * parsing `.message`.
+ */
+export const TransportErrorCode = {
+  /** No handler is registered for the requested channel. */
+  NO_HANDLER: 'NO_HANDLER',
+  /** The IPC bus has been disconnected. */
+  DISCONNECTED: 'DISCONNECTED',
+  /** The request handler threw an unclassified error. */
+  HANDLER_ERROR: 'HANDLER_ERROR',
+} as const;
+
+export type TransportErrorCode = (typeof TransportErrorCode)[keyof typeof TransportErrorCode];
+
+/**
+ * TransportError — Structured error carrying a stable `code` field.
+ *
+ * Thrown by IpcBus and LocalBus so callers can branch on `.code`
+ * without fragile message-string matching.
+ */
+export class TransportError extends Error {
+  readonly code: TransportErrorCode;
+
+  constructor(code: TransportErrorCode, message: string) {
+    super(message);
+    this.name = 'TransportError';
+    this.code = code;
+  }
+}

--- a/packages/transport/src/transport-error.ts
+++ b/packages/transport/src/transport-error.ts
@@ -12,6 +12,8 @@ export const TransportErrorCode = {
   DISCONNECTED: 'DISCONNECTED',
   /** The request handler threw an unclassified error. */
   HANDLER_ERROR: 'HANDLER_ERROR',
+  /** The request exceeded its deadline without receiving a response. */
+  REQUEST_TIMEOUT: 'REQUEST_TIMEOUT',
 } as const;
 
 export type TransportErrorCode = (typeof TransportErrorCode)[keyof typeof TransportErrorCode];

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { CommandService } from '../command-service.js';
+import { OrchestratorError } from '../orchestrator.js';
 import type { CommandEnvelope } from '@invoker/contracts';
 import type { Orchestrator } from '../orchestrator.js';
 import type { TaskState } from '@invoker/workflow-graph';
@@ -292,12 +293,20 @@ describe('CommandService', () => {
       expect(orchestrator.cancelTask).toHaveBeenCalledWith('t-1');
     });
 
-    it('returns error on exception', async () => {
+    it('returns typed error code from OrchestratorError', async () => {
       (orchestrator.cancelTask as ReturnType<typeof vi.fn>).mockImplementation(() => {
-        throw new Error('not found');
+        throw new OrchestratorError('TASK_NOT_FOUND', 'Task "bad" not found');
       });
       const result = await service.cancelTask(makeEnvelope({ taskId: 'bad' }));
-      expect(result).toEqual({ ok: false, error: { code: 'CANCEL_TASK_FAILED', message: 'not found' } });
+      expect(result).toEqual({ ok: false, error: { code: 'TASK_NOT_FOUND', message: 'Task "bad" not found' } });
+    });
+
+    it('returns generic error code for plain Error', async () => {
+      (orchestrator.cancelTask as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new Error('unexpected');
+      });
+      const result = await service.cancelTask(makeEnvelope({ taskId: 'bad' }));
+      expect(result).toEqual({ ok: false, error: { code: 'CANCEL_TASK_FAILED', message: 'unexpected' } });
     });
   });
 
@@ -311,7 +320,15 @@ describe('CommandService', () => {
       expect(orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1');
     });
 
-    it('returns error on exception', async () => {
+    it('returns typed error code from OrchestratorError', async () => {
+      (orchestrator.cancelWorkflow as ReturnType<typeof vi.fn>).mockImplementation(() => {
+        throw new OrchestratorError('WORKFLOW_NOT_FOUND', 'No tasks found for workflow bad');
+      });
+      const result = await service.cancelWorkflow(makeEnvelope({ workflowId: 'bad' }));
+      expect(result).toEqual({ ok: false, error: { code: 'WORKFLOW_NOT_FOUND', message: 'No tasks found for workflow bad' } });
+    });
+
+    it('returns generic error code for plain Error', async () => {
       (orchestrator.cancelWorkflow as ReturnType<typeof vi.fn>).mockImplementation(() => {
         throw new Error('wf not found');
       });

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -6,6 +6,7 @@
  */
 
 import type { CommandEnvelope, CommandResult } from '@invoker/contracts';
+import { OrchestratorError } from './orchestrator.js';
 import type { Orchestrator, ExternalGatePolicyUpdate, TaskReplacementDef } from './orchestrator.js';
 import type { TaskState } from '@invoker/workflow-graph';
 
@@ -473,10 +474,11 @@ export class CommandService {
       const data = await this.serializeForWorkflow(workflowId, fn);
       return { ok: true, data };
     } catch (err) {
+      const code = err instanceof OrchestratorError ? err.code : errorCode;
       return {
         ok: false,
         error: {
-          code: errorCode,
+          code,
           message: err instanceof Error ? err.message : String(err),
         },
       };

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -723,7 +723,7 @@ export class Orchestrator {
   ): TaskState {
     const existing = this.stateGetTask(taskId);
     if (!existing) {
-      throw new Error(`writeAndSync: task ${taskId} not found in graph`);
+      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `writeAndSync: task ${taskId} not found in graph`);
     }
     const id = existing.id;
     this.taskRepository.updateTask(id, changes);
@@ -1598,7 +1598,7 @@ export class Orchestrator {
   setFixAwaitingApproval(taskId: string, originalError: string): void {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     const tid = task.id;
     if (task.status !== 'running' && task.status !== 'fixing_with_ai') {
       throw new Error(`Task ${tid} is not running or fixing with AI (status: ${task.status})`);
@@ -2013,7 +2013,7 @@ export class Orchestrator {
   retryTask(taskId: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     const id = task.id;
 
     // Step 18 (`docs/architecture/task-invalidation-roadmap.md`,
@@ -2213,7 +2213,7 @@ export class Orchestrator {
   recreateTask(taskId: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
     const rootId = task.id;
 
@@ -2486,7 +2486,7 @@ export class Orchestrator {
   beginConflictResolution(taskId: string): { savedError: string } {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
 
     const savedError = task.execution.error ?? '';
@@ -2536,7 +2536,7 @@ export class Orchestrator {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) {
-      throw new Error(`Task ${taskId} not found`);
+      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     }
     const id = task.id;
 
@@ -2571,7 +2571,7 @@ export class Orchestrator {
   editTaskCommand(taskId: string, newCommand: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot edit merge node ${taskId}`);
 
     if (task.status === 'running' || task.status === 'fixing_with_ai') {
@@ -2591,7 +2591,7 @@ export class Orchestrator {
     editTaskPrompt(taskId: string, newPrompt: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot edit merge node ${taskId}`);
 
     if (task.status === 'running' || task.status === 'fixing_with_ai') {
@@ -2611,7 +2611,7 @@ export class Orchestrator {
     editTaskType(taskId: string, executorType: string, remoteTargetId?: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot change executor type of merge node ${taskId}`);
 
     const effectiveType = normalizeExecutorType(executorType) ?? executorType;
@@ -2660,7 +2660,7 @@ export class Orchestrator {
     editTaskAgent(taskId: string, agentName: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot change execution agent of merge node ${taskId}`);
 
     if (task.status === 'running' || task.status === 'fixing_with_ai') {
@@ -2769,7 +2769,7 @@ export class Orchestrator {
   ): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (!task.config.isMergeNode) {
       throw new Error(`Task ${taskId} is not a merge node`);
     }
@@ -2906,7 +2906,7 @@ export class Orchestrator {
   ): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) {
       throw new Error(`Cannot edit fix context of merge node ${taskId}`);
     }
@@ -3005,7 +3005,7 @@ export class Orchestrator {
   setTaskExternalGatePolicies(taskId: string, updates: ExternalGatePolicyUpdate[]): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.status === 'running' || task.status === 'fixing_with_ai') {
       throw new Error(`Cannot edit running task ${taskId}`);
     }
@@ -3065,7 +3065,7 @@ export class Orchestrator {
       .getAllTasks()
       .filter((t) => t.config.workflowId === workflowId);
     if (sourceTasks.length === 0) {
-      throw new Error(`forkWorkflow: workflow ${workflowId} not found (no tasks)`);
+      throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `forkWorkflow: workflow ${workflowId} not found (no tasks)`);
     }
 
     this.cancelWorkflow(workflowId);
@@ -3189,7 +3189,7 @@ export class Orchestrator {
   replaceTask(taskId: string, replacementTasks: TaskReplacementDef[]): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.status === 'running' || task.status === 'fixing_with_ai') throw new Error(`Cannot replace running task ${taskId}`);
     if (replacementTasks.length === 0) throw new Error('Must provide at least one replacement task');
 
@@ -3924,7 +3924,7 @@ export class Orchestrator {
   ): TaskState[] {
     const existing = this.stateGetTask(taskId);
     if (!existing) {
-      throw new Error(`finalizeFailedTask: task ${taskId} not found in graph`);
+      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `finalizeFailedTask: task ${taskId} not found in graph`);
     }
 
     const changes: TaskStateChanges = {
@@ -4364,7 +4364,7 @@ export class Orchestrator {
       (task) => task.config.workflowId === workflowId,
     );
     if (targetTasks.length === 0) {
-      throw new Error(`Workflow ${workflowId} not found`);
+      throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
     }
 
     let removedDependency = false;

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -33,6 +33,24 @@ function mergeTrace(tag: string, data: Record<string, unknown>): void {
   } catch { /* best effort */ }
 }
 
+// ── Typed domain error codes ────────────────────────────────────
+export const OrchestratorErrorCode = {
+  TASK_NOT_FOUND: 'TASK_NOT_FOUND',
+  TASK_ALREADY_TERMINAL: 'TASK_ALREADY_TERMINAL',
+  WORKFLOW_NOT_FOUND: 'WORKFLOW_NOT_FOUND',
+} as const;
+
+export type OrchestratorErrorCode = (typeof OrchestratorErrorCode)[keyof typeof OrchestratorErrorCode];
+
+export class OrchestratorError extends Error {
+  readonly code: OrchestratorErrorCode;
+  constructor(code: OrchestratorErrorCode, message: string) {
+    super(message);
+    this.name = 'OrchestratorError';
+    this.code = code;
+  }
+}
+
 function isActiveForInvalidation(status: TaskStatus): boolean {
   return (
     status === 'running' ||
@@ -3587,11 +3605,11 @@ export class Orchestrator {
     this.refreshFromDb();
 
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task "${taskId}" not found`);
+    if (!task) throw new OrchestratorError('TASK_NOT_FOUND', `Task "${taskId}" not found`);
 
     const terminal = new Set(['completed', 'stale']);
     if (terminal.has(task.status)) {
-      throw new Error(`Task "${taskId}" is already ${task.status}`);
+      throw new OrchestratorError('TASK_ALREADY_TERMINAL', `Task "${taskId}" is already ${task.status}`);
     }
 
     // Find all transitive dependents, skipping completed/stale
@@ -3663,7 +3681,7 @@ export class Orchestrator {
       (t) => t.config.workflowId === workflowId,
     );
     if (allTasks.length === 0) {
-      throw new Error(`No tasks found for workflow ${workflowId}`);
+      throw new OrchestratorError('WORKFLOW_NOT_FOUND', `No tasks found for workflow ${workflowId}`);
     }
 
     const cancellable = new Set([


### PR DESCRIPTION
## Summary

Document mutation-boundary and typed-error invariants so future changes do not
reintroduce fallback divergence.

## Architecture

### Before

```mermaid
graph TD
    Contributors[Contributors] --> Implicit[Implicit mutation and error conventions]
    Implicit --> Code[Cross-surface code changes]
```

### After

```mermaid
graph TD
    Contributors --> Docs[Architecture docs and contribution guardrails]
    Docs --> Facade[Mutation facade and typed error policy]
    Docs --> Tests[Parity expectations]
```

## Test Plan

- [ ] pnpm test exits 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #281