### PR TITLE
Stacked divergence remediation 04 malformed frame observability

### DIFF
--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -4,7 +4,13 @@ import { existsSync, mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { spawn } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import { IpcBus, DEFAULT_REQUEST_DEADLINE_MS } from '../ipc-bus.js';
+import { createConnection } from 'node:net';
+import {
+  IpcBus,
+  DEFAULT_REQUEST_DEADLINE_MS,
+  MALFORMED_FRAME_RATE_LIMIT_MS,
+  type MalformedFrameEvent,
+} from '../ipc-bus.js';
 import { TransportError, TransportErrorCode } from '../transport-error.js';
 
 const __filename = fileURLToPath(import.meta.url);
@@ -918,6 +924,172 @@ ${minimalIpcBusJS}
     expect(messages.b.some((m: any) => m.received)).toBe(true);
     expect(messages.a.some((m: any) => m.error)).toBe(false);
   }, 10000);
+});
+
+// ---------------------------------------------------------------------------
+// Malformed-frame observability
+// ---------------------------------------------------------------------------
+
+describe('Malformed-frame observability', () => {
+  const buses: IpcBus[] = [];
+
+  afterEach(() => {
+    for (const bus of buses) {
+      bus.disconnect();
+    }
+    buses.length = 0;
+  });
+
+  /** Encode a raw length-prefixed frame from an arbitrary string payload. */
+  function encodeRaw(payload: string): Buffer {
+    const json = Buffer.from(payload, 'utf8');
+    const frame = Buffer.allocUnsafe(4 + json.length);
+    frame.writeUInt32BE(json.length, 0);
+    json.copy(frame, 4);
+    return frame;
+  }
+
+  /** Connect a raw socket to the given path and wait for it to be ready. */
+  function rawConnect(socketPath: string): Promise<import('node:net').Socket> {
+    return new Promise((resolve, reject) => {
+      const sock = createConnection({ path: socketPath }, () => resolve(sock));
+      sock.on('error', reject);
+    });
+  }
+
+  it('fires onMalformedFrame for invalid JSON', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    // Send a frame whose payload is not valid JSON.
+    const raw = rawConnect(sock);
+    const peer = await raw;
+    peer.write(encodeRaw('not-json{{{'));
+
+    await waitFor(() => events.length >= 1, 2000);
+    peer.destroy();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].reason).toBe('invalid_json');
+    expect(events[0].rawByteLength).toBe(Buffer.byteLength('not-json{{{', 'utf8'));
+    expect(events[0].droppedSinceLastReport).toBe(0);
+    expect(events[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('fires onMalformedFrame for valid JSON with invalid envelope shape', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    // Valid JSON but missing required envelope fields.
+    const raw = rawConnect(sock);
+    const peer = await raw;
+    peer.write(encodeRaw('{"kind":"pub"}'));
+
+    await waitFor(() => events.length >= 1, 2000);
+    peer.destroy();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].reason).toBe('invalid_envelope');
+  });
+
+  it('rate-limits malformed frame events', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    // Use rateLimitMs=0 would disable limiting; we rely on default.
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    const peer = await rawConnect(sock);
+
+    // Send many malformed frames rapidly — default rate limit is 1 s,
+    // so only the first should be emitted immediately.
+    for (let i = 0; i < 10; i++) {
+      peer.write(encodeRaw(`bad-json-${i}`));
+    }
+
+    // Wait for socket data to be processed.
+    await sleep(200);
+    peer.destroy();
+
+    // Exactly 1 event emitted due to rate limiting (the other 9 suppressed).
+    expect(events).toHaveLength(1);
+    expect(events[0].droppedSinceLastReport).toBe(0);
+  });
+
+  it('reports suppressed count after rate-limit window elapses', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    const peer = await rawConnect(sock);
+
+    // First burst — first frame emitted, rest suppressed.
+    for (let i = 0; i < 5; i++) {
+      peer.write(encodeRaw(`bad-${i}`));
+    }
+    await sleep(200);
+    expect(events).toHaveLength(1);
+
+    // Wait for rate-limit window to pass.
+    await sleep(MALFORMED_FRAME_RATE_LIMIT_MS + 100);
+
+    // Second malformed frame triggers a new event with suppressed count.
+    peer.write(encodeRaw('another-bad'));
+    await waitFor(() => events.length >= 2, 2000);
+    peer.destroy();
+
+    expect(events).toHaveLength(2);
+    // 4 frames were suppressed between the first and second emitted events.
+    expect(events[1].droppedSinceLastReport).toBe(4);
+  });
+
+  it('does not fire callback when no observer is provided', async () => {
+    const sock = tempSocketPath();
+    // No onMalformedFrame — should not throw.
+    const bus = new IpcBus(sock);
+    buses.push(bus);
+    await bus.ready();
+
+    const peer = await rawConnect(sock);
+    peer.write(encodeRaw('not-json'));
+    await sleep(200);
+    peer.destroy();
+
+    // If we get here without an unhandled exception, the test passes.
+    expect(true).toBe(true);
+  });
+
+  it('still delivers valid frames alongside malformed ones', async () => {
+    const sock = tempSocketPath();
+    const events: MalformedFrameEvent[] = [];
+    const bus = new IpcBus(sock, { onMalformedFrame: (e) => events.push(e) });
+    buses.push(bus);
+    await bus.ready();
+
+    const received: string[] = [];
+    bus.subscribe('test', (msg: string) => received.push(msg));
+
+    const peer = await rawConnect(sock);
+    // Send a malformed frame followed by a valid pub envelope.
+    const malformed = encodeRaw('garbage');
+    const valid = encodeRaw(JSON.stringify({ kind: 'pub', channel: 'test', body: 'hello' }));
+    peer.write(Buffer.concat([malformed, valid]));
+
+    await waitFor(() => received.length >= 1, 2000);
+    peer.destroy();
+
+    expect(events.length).toBeGreaterThanOrEqual(1);
+    expect(received).toEqual(['hello']);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -92,6 +92,33 @@ function encode(env: Envelope): Buffer {
   return frame;
 }
 
+// ---------------------------------------------------------------------------
+// Malformed-frame observability
+// ---------------------------------------------------------------------------
+
+/** Structured event emitted when a frame fails to decode. */
+export interface MalformedFrameEvent {
+  /** ISO-8601 timestamp of the drop. */
+  timestamp: string;
+  /** Why the frame was rejected. */
+  reason: 'invalid_json' | 'invalid_envelope';
+  /** Byte length of the raw JSON payload that failed. */
+  rawByteLength: number;
+  /** Number of malformed frames dropped since the last emitted event
+   *  (0 when every drop is reported; >0 when rate-limited). */
+  droppedSinceLastReport: number;
+}
+
+/** Callback signature for malformed-frame observers. */
+export type MalformedFrameObserver = (event: MalformedFrameEvent) => void;
+
+/**
+ * Default minimum interval (ms) between emitted malformed-frame events.
+ * Events that arrive faster are counted but not reported until the window
+ * elapses (token-bucket with capacity 1).
+ */
+export const MALFORMED_FRAME_RATE_LIMIT_MS = 1_000;
+
 /**
  * Streaming decoder for length-prefixed JSON frames.
  *
@@ -100,10 +127,23 @@ function encode(env: Envelope): Buffer {
  */
 class FrameDecoder {
   private buf = Buffer.alloc(0);
-  private onEnvelope: (env: Envelope) => void;
+  private readonly onEnvelope: (env: Envelope) => void;
+  private readonly onMalformed: MalformedFrameObserver | undefined;
+  private readonly rateLimitMs: number;
 
-  constructor(onEnvelope: (env: Envelope) => void) {
+  /** Timestamp (ms) of the last emitted malformed-frame event. */
+  private lastEmitMs = 0;
+  /** Count of drops suppressed by rate-limiting since last emit. */
+  private suppressedCount = 0;
+
+  constructor(
+    onEnvelope: (env: Envelope) => void,
+    onMalformed?: MalformedFrameObserver,
+    rateLimitMs: number = MALFORMED_FRAME_RATE_LIMIT_MS,
+  ) {
     this.onEnvelope = onEnvelope;
+    this.onMalformed = onMalformed;
+    this.rateLimitMs = rateLimitMs;
   }
 
   push(chunk: Buffer): void {
@@ -115,12 +155,48 @@ class FrameDecoder {
       const json = this.buf.subarray(4, 4 + len).toString('utf8');
       this.buf = this.buf.subarray(4 + len);
       try {
-        this.onEnvelope(JSON.parse(json) as Envelope);
+        const parsed: unknown = JSON.parse(json);
+        if (!isValidEnvelope(parsed)) {
+          this.reportMalformed('invalid_envelope', Buffer.byteLength(json, 'utf8'));
+          continue;
+        }
+        this.onEnvelope(parsed);
       } catch {
-        // Malformed frame — skip silently (no payload logging).
+        this.reportMalformed('invalid_json', Buffer.byteLength(json, 'utf8'));
       }
     }
   }
+
+  /** Emit a malformed-frame event, respecting the rate limit. */
+  private reportMalformed(reason: MalformedFrameEvent['reason'], rawByteLength: number): void {
+    if (!this.onMalformed) return;
+    const now = Date.now();
+    if (now - this.lastEmitMs < this.rateLimitMs) {
+      this.suppressedCount++;
+      return;
+    }
+    this.lastEmitMs = now;
+    const droppedSinceLastReport = this.suppressedCount;
+    this.suppressedCount = 0;
+    this.onMalformed({
+      timestamp: new Date(now).toISOString(),
+      reason,
+      rawByteLength,
+      droppedSinceLastReport,
+    });
+  }
+}
+
+/** Type guard: returns true when the value has a valid envelope shape. */
+function isValidEnvelope(v: unknown): v is Envelope {
+  if (typeof v !== 'object' || v === null) return false;
+  const obj = v as Record<string, unknown>;
+  const kind = obj.kind;
+  if (kind === 'pub') return typeof obj.channel === 'string';
+  if (kind === 'req') return typeof obj.channel === 'string' && typeof obj.reqId === 'string';
+  if (kind === 'res') return typeof obj.channel === 'string' && typeof obj.reqId === 'string';
+  if (kind === 'err') return typeof obj.channel === 'string' && typeof obj.reqId === 'string' && typeof obj.code === 'string';
+  return false;
 }
 
 // ---------------------------------------------------------------------------
@@ -138,6 +214,9 @@ export interface IpcBusOptions {
   /** Maximum time in ms a request may wait for a response before being
    *  rejected with `REQUEST_TIMEOUT`.  Defaults to {@link DEFAULT_REQUEST_DEADLINE_MS}. */
   requestDeadlineMs?: number;
+  /** Optional callback invoked when a malformed frame is received.
+   *  Rate-limited to at most one call per {@link MALFORMED_FRAME_RATE_LIMIT_MS}. */
+  onMalformedFrame?: MalformedFrameObserver;
 }
 
 // ---------------------------------------------------------------------------
@@ -148,6 +227,7 @@ export class IpcBus implements MessageBus {
   private readonly socketPath: string;
   private readonly allowServe: boolean;
   private readonly requestDeadlineMs: number;
+  private readonly onMalformedFrame: MalformedFrameObserver | undefined;
 
   // Local handler registries (same structure as LocalBus).
   private subscribers = new Map<string, Set<MessageHandler>>();
@@ -178,6 +258,7 @@ export class IpcBus implements MessageBus {
     this.socketPath = socketPath;
     this.allowServe = options.allowServe ?? true;
     this.requestDeadlineMs = options.requestDeadlineMs ?? DEFAULT_REQUEST_DEADLINE_MS;
+    this.onMalformedFrame = options.onMalformedFrame;
     this.readyPromise = new Promise<void>((r) => {
       this.resolveReady = r;
     });
@@ -287,7 +368,10 @@ export class IpcBus implements MessageBus {
       return;
     }
     this.peers.add(sock);
-    const decoder = new FrameDecoder((env) => this.handleEnvelope(env, sock));
+    const decoder = new FrameDecoder(
+      (env) => this.handleEnvelope(env, sock),
+      this.onMalformedFrame,
+    );
     sock.on('data', (chunk: Buffer) => decoder.push(chunk));
     sock.on('close', () => {
       this.peers.delete(sock);


### PR DESCRIPTION
## Summary

Add rate-limited malformed-frame observability to the IPC bus so decode failures are counted and surfaced without leaking payload contents. Invalid JSON or invalid envelope traffic becomes diagnosable while preserving the existing drop behavior for malformed input.
## Architecture

### Before

```mermaid
graph TD
    A[IPC frame parsing] --> B[opaque malformed-frame failures]
    B --> C[Callers]
```

### After

```mermaid
graph TD
    A[IPC frame parsing] --> B[observable malformed-frame diagnostics]
    B --> C[Callers]
```

## Test Plan

- [ ] cd packages/transport && pnpm test exits 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #287