### PR TITLE
Stacked divergence remediation 05 subscriber error observability

### DIFF
--- a/packages/transport/src/__tests__/ipc-bus.test.ts
+++ b/packages/transport/src/__tests__/ipc-bus.test.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_REQUEST_DEADLINE_MS,
   MALFORMED_FRAME_RATE_LIMIT_MS,
   type MalformedFrameEvent,
+  type SubscriberErrorEvent,
 } from '../ipc-bus.js';
 import { TransportError, TransportErrorCode } from '../transport-error.js';
 
@@ -300,6 +301,57 @@ describe('IpcBus', () => {
 
     const result = await requester.request<number, number>('delayed-double', 5);
     expect(result).toBe(10);
+  });
+
+  // ---------------------------------------------------------------
+  // Subscriber error observability
+  // ---------------------------------------------------------------
+
+  it('emits subscriber error events without interrupting delivery to other subscribers', async () => {
+    const sock = tempSocketPath();
+    const events: SubscriberErrorEvent[] = [];
+    const bus = new IpcBus(sock, { onSubscriberError: (event) => events.push(event) });
+    buses.push(bus);
+    await bus.ready();
+
+    const received: string[] = [];
+    bus.subscribe('test', () => {
+      throw new Error('subscriber exploded');
+    });
+    bus.subscribe('test', (msg: string) => received.push(msg));
+
+    bus.publish('test', 'hello');
+
+    expect(received).toEqual(['hello']);
+    expect(events).toHaveLength(1);
+    expect(events[0].channel).toBe('test');
+    expect(events[0].error).toBe('subscriber exploded');
+    expect(events[0].timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('emits every subscriber error event even when failures happen back-to-back', async () => {
+    const sock = tempSocketPath();
+    const events: SubscriberErrorEvent[] = [];
+    const bus = new IpcBus(sock, { onSubscriberError: (event) => events.push(event) });
+    buses.push(bus);
+    await bus.ready();
+
+    bus.subscribe('test', () => {
+      throw new Error('first failure');
+    });
+    bus.subscribe('test', () => {
+      throw new Error('second failure');
+    });
+
+    bus.publish('test', 'hello');
+    bus.publish('test', 'again');
+
+    expect(events.map((event) => event.error)).toEqual([
+      'first failure',
+      'second failure',
+      'first failure',
+      'second failure',
+    ]);
   });
 
   // ---------------------------------------------------------------

--- a/packages/transport/src/ipc-bus.ts
+++ b/packages/transport/src/ipc-bus.ts
@@ -200,6 +200,23 @@ function isValidEnvelope(v: unknown): v is Envelope {
 }
 
 // ---------------------------------------------------------------------------
+// Subscriber-error observability
+// ---------------------------------------------------------------------------
+
+/** Structured event emitted when a subscriber handler throws. */
+export interface SubscriberErrorEvent {
+  /** ISO-8601 timestamp of the error. */
+  timestamp: string;
+  /** Channel the handler was subscribed to. */
+  channel: string;
+  /** Error message (no payload data to avoid leakage). */
+  error: string;
+}
+
+/** Callback signature for subscriber-error observers. */
+export type SubscriberErrorObserver = (event: SubscriberErrorEvent) => void;
+
+// ---------------------------------------------------------------------------
 // Default socket path
 // ---------------------------------------------------------------------------
 
@@ -217,6 +234,8 @@ export interface IpcBusOptions {
   /** Optional callback invoked when a malformed frame is received.
    *  Rate-limited to at most one call per {@link MALFORMED_FRAME_RATE_LIMIT_MS}. */
   onMalformedFrame?: MalformedFrameObserver;
+  /** Optional callback invoked when a subscriber handler throws. */
+  onSubscriberError?: SubscriberErrorObserver;
 }
 
 // ---------------------------------------------------------------------------
@@ -228,6 +247,7 @@ export class IpcBus implements MessageBus {
   private readonly allowServe: boolean;
   private readonly requestDeadlineMs: number;
   private readonly onMalformedFrame: MalformedFrameObserver | undefined;
+  private readonly onSubscriberError: SubscriberErrorObserver | undefined;
 
   // Local handler registries (same structure as LocalBus).
   private subscribers = new Map<string, Set<MessageHandler>>();
@@ -259,6 +279,7 @@ export class IpcBus implements MessageBus {
     this.allowServe = options.allowServe ?? true;
     this.requestDeadlineMs = options.requestDeadlineMs ?? DEFAULT_REQUEST_DEADLINE_MS;
     this.onMalformedFrame = options.onMalformedFrame;
+    this.onSubscriberError = options.onSubscriberError;
     this.readyPromise = new Promise<void>((r) => {
       this.resolveReady = r;
     });
@@ -416,10 +437,25 @@ export class IpcBus implements MessageBus {
     for (const handler of handlers) {
       try {
         handler(body);
-      } catch {
+      } catch (e) {
         // Swallow handler errors — same behaviour as LocalBus.
+        this.reportSubscriberError(
+          channel,
+          e instanceof Error ? e.message : String(e),
+        );
       }
     }
+  }
+
+  /** Emit a structured subscriber-error event for each thrown handler. */
+  private reportSubscriberError(channel: string, error: string): void {
+    if (!this.onSubscriberError) return;
+    const now = Date.now();
+    this.onSubscriberError({
+      timestamp: new Date(now).toISOString(),
+      channel,
+      error,
+    });
   }
 
   private async handleRequest(env: ReqEnvelope, source: Socket): Promise<void> {


### PR DESCRIPTION
## Summary

Preserve subscriber isolation while surfacing subscriber callback failures as structured transport events. The bus still protects other subscribers from one handler crashing, but local delivery failures stop disappearing silently.
## Architecture

### Before

```mermaid
graph TD
    A[Transport subscribers] --> B[silent subscriber exceptions]
    B --> C[Callers]
```

### After

```mermaid
graph TD
    A[Transport subscribers] --> B[observable subscriber error events]
    B --> C[Callers]
```

## Test Plan

- [ ] cd packages/transport && pnpm test exits 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #288