### PR TITLE
SaaS ladder 1a runtime service skeleton

### DIFF
--- a/packages/app/e2e/global-setup.ts
+++ b/packages/app/e2e/global-setup.ts
@@ -1,6 +1,5 @@
 /**
- * Playwright global setup: build app artifacts (if missing) and create a
- * local bare repo for E2E tests.
+ * Playwright global setup: create a local bare repo for E2E tests.
  *
  * By default, all E2E plans use file:///tmp/invoker-e2e-repo.git as their repoUrl
  * so WorktreeExecutor can clone without a network. Sharded CI can override the
@@ -12,8 +11,6 @@ import * as path from 'path';
 
 export const E2E_BARE_REPO = process.env.INVOKER_E2E_BARE_REPO ?? '/tmp/invoker-e2e-repo.git';
 
-const repoRoot = path.resolve(__dirname, '..', '..', '..');
-
 const gitEnv = {
   ...process.env,
   GIT_AUTHOR_NAME: process.env.GIT_AUTHOR_NAME ?? 'Invoker E2E',
@@ -22,9 +19,10 @@ const gitEnv = {
   GIT_COMMITTER_EMAIL: process.env.GIT_COMMITTER_EMAIL ?? 'ci@invoker.dev',
 };
 
+const repoRoot = path.resolve(__dirname, '..', '..', '..');
+
 export default function globalSetup(): void {
   // Build dependent packages and the app itself if artifacts are missing.
-  // CI often pre-builds these, but local Playwright runs may not.
   if (!existsSync(path.join(repoRoot, 'packages', 'ui', 'dist', 'index.html'))) {
     execSync('pnpm --filter @invoker/ui build', { cwd: repoRoot, stdio: 'inherit' });
   }
@@ -34,6 +32,7 @@ export default function globalSetup(): void {
   if (!existsSync(path.join(repoRoot, 'packages', 'app', 'dist', 'main.js'))) {
     execSync('pnpm run build', { cwd: path.join(repoRoot, 'packages', 'app'), stdio: 'inherit' });
   }
+
   if (existsSync(E2E_BARE_REPO)) rmSync(E2E_BARE_REPO, { recursive: true });
 
   const tmpClone = `${E2E_BARE_REPO}.setup`;

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -26,20 +26,12 @@ import {
 } from './owner-endpoint.js';
 import { createOwnerResolver } from './owner-resolver.js';
 
-// ---------------------------------------------------------------------------
-// Terminal colours
-// ---------------------------------------------------------------------------
-
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
 
 function delegationClientLog(message: string): void {
   process.stderr.write(`[headless-client] ${message}\n`);
 }
-
-// ---------------------------------------------------------------------------
-// Electron helpers (used when the CLI must spawn a full Electron process)
-// ---------------------------------------------------------------------------
 
 function electronCommandArgs(args: string[]): string[] {
   const mainJs = resolve(__dirname, 'main.js');
@@ -79,10 +71,6 @@ async function flushOutputStream(stream: NodeJS.WriteStream): Promise<void> {
   });
 }
 
-// ---------------------------------------------------------------------------
-// Timeouts
-// ---------------------------------------------------------------------------
-
 const DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS = 30_000;
 const POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS = 90_000;
 const POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS = 20_000;
@@ -98,10 +86,6 @@ function standaloneOwnerBootstrapTimeoutMs(): number {
   return DEFAULT_STANDALONE_OWNER_BOOTSTRAP_TIMEOUT_MS;
 }
 
-// ---------------------------------------------------------------------------
-// Error types
-// ---------------------------------------------------------------------------
-
 export class SharedMutationOwnerTimeoutError extends Error {
   constructor(message: string = 'Timed out waiting for a standalone shared mutation owner to become available') {
     super(message);
@@ -113,15 +97,7 @@ export function isSharedMutationOwnerTimeoutError(error: unknown): error is Shar
   return error instanceof SharedMutationOwnerTimeoutError;
 }
 
-// ---------------------------------------------------------------------------
-// Dispatch: send a mutation command to a specific owner via IPC
-//
-// This is the low-level send — it picks the right IPC channel (run, resume,
-// or generic exec) and applies the correct timeout.  It does NOT decide
-// *which* owner to talk to; that is the caller's job.
-// ---------------------------------------------------------------------------
-
-async function dispatchToOwner(
+async function delegateMutation(
   args: string[],
   bus: MessageBus,
   waitForApproval?: boolean,
@@ -149,14 +125,6 @@ async function dispatchToOwner(
   }
   return tryDelegateExec(args, bus, waitForApproval, noTrack, timeoutMs);
 }
-
-// ---------------------------------------------------------------------------
-// Read-only query delegation (query ui-perf, query queue)
-//
-// These queries always require a live owner (standalone or GUI) and never
-// fall back to a local Electron process.  The caller polls until the owner
-// is reachable and the query service is ready.
-// ---------------------------------------------------------------------------
 
 async function delegateReadOnlyQuery(
   args: string[],
@@ -202,8 +170,6 @@ async function delegateReadOnlyQuery(
       ? 'Live owner is present but did not serve ui-perf query'
       : 'Live owner is present but did not serve queue query');
   }
-
-  // Format and print the response.
   if (isUiPerf) {
     process.stdout.write(`${JSON.stringify(response)}\n`);
     return true;
@@ -232,18 +198,10 @@ async function delegateReadOnlyQuery(
   return true;
 }
 
-// ---------------------------------------------------------------------------
-// Poll for a standalone owner after bootstrap and dispatch.
-//
-// After ensureStandaloneOwner returns, the new process may still be
-// initialising.  This polls until a standalone owner responds and then
-// dispatches the mutation.
-// ---------------------------------------------------------------------------
-
-async function pollAndDispatchAfterBootstrap(
+async function delegateAfterBootstrap(
   args: string[],
+  deps: Pick<HeadlessClientDeps, 'refreshMessageBus'>,
   bus: MessageBus,
-  refreshMessageBus: (() => Promise<MessageBus>) | undefined,
   waitForApproval?: boolean,
   noTrack?: boolean,
 ): Promise<boolean> {
@@ -258,7 +216,7 @@ async function pollAndDispatchAfterBootstrap(
     delegationClientLog(
       `post-bootstrap attempt=${attempts} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
     );
-    if (isStandaloneCapable(owner) && await dispatchToOwner(
+    if (isStandaloneCapable(owner) && await delegateMutation(
       args,
       messageBus,
       waitForApproval,
@@ -268,8 +226,8 @@ async function pollAndDispatchAfterBootstrap(
       delegationClientLog(`post-bootstrap delegation succeeded attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
       return true;
     }
-    if (refreshMessageBus) {
-      messageBus = await refreshMessageBus();
+    if (deps.refreshMessageBus) {
+      messageBus = await deps.refreshMessageBus();
     }
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
@@ -277,20 +235,12 @@ async function pollAndDispatchAfterBootstrap(
   return false;
 }
 
-// ---------------------------------------------------------------------------
-// Public: dependency-injection interface
-// ---------------------------------------------------------------------------
-
 export interface HeadlessClientDeps {
   messageBus: MessageBus;
   ensureStandaloneOwner: (bus?: MessageBus) => Promise<void>;
   refreshMessageBus?: () => Promise<MessageBus>;
   runElectronHeadless: (args: string[]) => Promise<number>;
 }
-
-// ---------------------------------------------------------------------------
-// Owner bootstrap (real implementation wired in runHeadlessClient)
-// ---------------------------------------------------------------------------
 
 async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void> {
   const invokerHomeRoot = resolveInvokerHomeRoot();
@@ -322,10 +272,6 @@ async function ensureStandaloneOwnerViaBootstrap(bus: MessageBus): Promise<void>
     delegationClientLog(`bootstrap end elapsedMs=${Date.now() - startedAt}`);
   }
 }
-
-// ---------------------------------------------------------------------------
-// Arg parsing
-// ---------------------------------------------------------------------------
 
 function parseArgs(argv: string[]): { args: string[]; waitForApproval?: boolean; noTrack?: boolean } {
   const args: string[] = [];
@@ -371,7 +317,7 @@ async function resolveOwnerAndDelegate(
     `phase1 discover standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
   );
   if (isStandaloneCapable(owner)) {
-    if (await dispatchToOwner(args, messageBus, waitForApproval, noTrack)) {
+    if (await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
       delegationClientLog(`phase1 delegated successfully elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
@@ -379,7 +325,7 @@ async function resolveOwnerAndDelegate(
   }
 
   // Phase 2: Try any reachable owner (may be non-standalone)
-  if (isOwnerReachable(owner) && await dispatchToOwner(args, messageBus, waitForApproval, noTrack)) {
+  if (isOwnerReachable(owner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
     delegationClientLog(`phase2 delegated to reachable owner ownerId=${owner.ownerId} elapsedMs=${Date.now() - startedAt}`);
     return resolvedExitCode();
   }
@@ -397,7 +343,7 @@ async function resolveOwnerAndDelegate(
     delegationClientLog(
       `phase3 discover ownerReachable=${isOwnerReachable(refreshedOwner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(refreshedOwner) ? 'true' : 'false'} ownerId=${refreshedOwner?.ownerId ?? '<none>'}`,
     );
-    if (isOwnerReachable(refreshedOwner) && await dispatchToOwner(args, messageBus, waitForApproval, noTrack)) {
+    if (isOwnerReachable(refreshedOwner) && await delegateMutation(args, messageBus, waitForApproval, noTrack)) {
       delegationClientLog(`phase3 delegated successfully elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
@@ -423,16 +369,16 @@ async function resolveOwnerAndDelegate(
       messageBus = await deps.refreshMessageBus();
       await deps.ensureStandaloneOwner(messageBus);
     }
-
     if (deps.refreshMessageBus) {
       messageBus = await deps.refreshMessageBus();
     }
-    if (await pollAndDispatchAfterBootstrap(args, messageBus, deps.refreshMessageBus, waitForApproval, noTrack)) {
+    if (await delegateAfterBootstrap(args, deps, messageBus, waitForApproval, noTrack)) {
       delegationClientLog(`phase4 delegated successfully attempt=${attempt + 1} elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
-
-    if (!deps.refreshMessageBus) break;
+    if (!deps.refreshMessageBus) {
+      break;
+    }
     messageBus = await deps.refreshMessageBus();
   }
 
@@ -465,15 +411,12 @@ export async function runHeadlessClientCommand(
   if (result !== null) {
     return result;
   }
+
   process.stderr.write(
     `${RED}Error:${RESET} Mutation command "${args[0] ?? ''}" could not reach a standalone shared owner after bootstrap.\n`,
   );
   return 1;
 }
-
-// ---------------------------------------------------------------------------
-// Real entry-point: wires IpcBus and bootstrap into the routing.
-// ---------------------------------------------------------------------------
 
 export async function runHeadlessClient(argv: string[]): Promise<number> {
   let bus = new IpcBus(undefined, { allowServe: false });

--- a/packages/runtime-service/package.json
+++ b/packages/runtime-service/package.json
@@ -17,6 +17,9 @@
     "test:watch": "vitest",
     "clean": "rm -rf dist"
   },
+  "dependencies": {
+    "@invoker/runtime-domain": "workspace:*"
+  },
   "devDependencies": {
     "@types/node": "^25.3.3",
     "tsup": "^8.0.0",

--- a/packages/runtime-service/src/__tests__/composition.test.ts
+++ b/packages/runtime-service/src/__tests__/composition.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import {
+  composeRuntimeServices,
+  type RuntimeServiceDeps,
+  type RuntimeServices,
+} from '../composition.js';
+import { AttachmentResult } from '@invoker/runtime-domain';
+
+function stubDeps(): RuntimeServiceDeps {
+  return {
+    workspaceProbe: { probeWorkspace: async () => ({}) },
+    containerProbe: { probeContainer: async () => ({}) },
+    sessionProbe: { probeSession: async () => ({}) },
+    terminalLauncher: {
+      launchTerminal: async () => ({ result: AttachmentResult.Attached }),
+    },
+  };
+}
+
+describe('composition shell', () => {
+  describe('composeRuntimeServices', () => {
+    it('passes through workspaceProbe unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.workspaceProbe).toBe(deps.workspaceProbe);
+    });
+
+    it('passes through containerProbe unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.containerProbe).toBe(deps.containerProbe);
+    });
+
+    it('passes through sessionProbe unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.sessionProbe).toBe(deps.sessionProbe);
+    });
+
+    it('passes through terminalLauncher unchanged', () => {
+      const deps = stubDeps();
+      const services = composeRuntimeServices(deps);
+      expect(services.terminalLauncher).toBe(deps.terminalLauncher);
+    });
+
+    it('returns a frozen object that rejects mutation', () => {
+      const services = composeRuntimeServices(stubDeps());
+      expect(Object.isFrozen(services)).toBe(true);
+      expect(() => {
+        (services as unknown as Record<string, unknown>).workspaceProbe = {};
+      }).toThrow();
+    });
+
+    it('exposes exactly the four expected keys', () => {
+      const services = composeRuntimeServices(stubDeps());
+      const keys = Object.keys(services).sort();
+      expect(keys).toEqual([
+        'containerProbe',
+        'sessionProbe',
+        'terminalLauncher',
+        'workspaceProbe',
+      ]);
+    });
+
+    it('satisfies the RuntimeServices type contract', () => {
+      const services: RuntimeServices = composeRuntimeServices(stubDeps());
+      expect(services.workspaceProbe.probeWorkspace).toBeTypeOf('function');
+      expect(services.containerProbe.probeContainer).toBeTypeOf('function');
+      expect(services.sessionProbe.probeSession).toBeTypeOf('function');
+      expect(services.terminalLauncher.launchTerminal).toBeTypeOf('function');
+    });
+
+    it('produces independent instances per call', () => {
+      const deps1 = stubDeps();
+      const deps2 = stubDeps();
+      const s1 = composeRuntimeServices(deps1);
+      const s2 = composeRuntimeServices(deps2);
+      expect(s1).not.toBe(s2);
+      expect(s1.workspaceProbe).not.toBe(s2.workspaceProbe);
+    });
+  });
+});

--- a/packages/runtime-service/src/__tests__/index.test.ts
+++ b/packages/runtime-service/src/__tests__/index.test.ts
@@ -1,7 +1,32 @@
 import { describe, it, expect } from 'vitest';
+import { composeRuntimeServices } from '../index.js';
+import type { RuntimeServiceDeps, RuntimeServices } from '../index.js';
+import { AttachmentResult } from '@invoker/runtime-domain';
 
-describe('package structure', () => {
-  it('should export from index', () => {
-    expect(true).toBe(true);
+function stubDeps(): RuntimeServiceDeps {
+  return {
+    workspaceProbe: { probeWorkspace: async () => ({}) },
+    containerProbe: { probeContainer: async () => ({}) },
+    sessionProbe: { probeSession: async () => ({}) },
+    terminalLauncher: {
+      launchTerminal: async () => ({ result: AttachmentResult.Attached }),
+    },
+  };
+}
+
+describe('composeRuntimeServices', () => {
+  it('returns a RuntimeServices object with all ports', () => {
+    const deps = stubDeps();
+    const services: RuntimeServices = composeRuntimeServices(deps);
+
+    expect(services.workspaceProbe).toBe(deps.workspaceProbe);
+    expect(services.containerProbe).toBe(deps.containerProbe);
+    expect(services.sessionProbe).toBe(deps.sessionProbe);
+    expect(services.terminalLauncher).toBe(deps.terminalLauncher);
+  });
+
+  it('returns a frozen object', () => {
+    const services = composeRuntimeServices(stubDeps());
+    expect(Object.isFrozen(services)).toBe(true);
   });
 });

--- a/packages/runtime-service/src/composition.ts
+++ b/packages/runtime-service/src/composition.ts
@@ -1,0 +1,54 @@
+/**
+ * Runtime composition shell — a typed container that bundles runtime
+ * domain ports into a single `RuntimeServices` facade.
+ *
+ * Consumers call `composeRuntimeServices(deps)` with concrete adapter
+ * implementations; this module never instantiates adapters itself, so
+ * app wiring stays in the application layer.
+ */
+
+import type {
+  WorkspaceProbe,
+  ContainerProbe,
+  SessionProbe,
+  TerminalLauncher,
+} from '@invoker/runtime-domain';
+
+// ── Dependency slot ────────────────────────────────────────
+
+/** Ports that callers must supply to compose the runtime services. */
+export interface RuntimeServiceDeps {
+  workspaceProbe: WorkspaceProbe;
+  containerProbe: ContainerProbe;
+  sessionProbe: SessionProbe;
+  terminalLauncher: TerminalLauncher;
+}
+
+// ── Public facade ──────────────────────────────────────────
+
+/** Unified read-only view of the composed runtime services. */
+export interface RuntimeServices {
+  readonly workspaceProbe: WorkspaceProbe;
+  readonly containerProbe: ContainerProbe;
+  readonly sessionProbe: SessionProbe;
+  readonly terminalLauncher: TerminalLauncher;
+}
+
+// ── Factory ────────────────────────────────────────────────
+
+/**
+ * Compose runtime services from concrete port implementations.
+ *
+ * Returns a frozen `RuntimeServices` object. No adapter instantiation
+ * happens here — callers provide fully constructed adapters.
+ */
+export function composeRuntimeServices(
+  deps: RuntimeServiceDeps,
+): RuntimeServices {
+  return Object.freeze({
+    workspaceProbe: deps.workspaceProbe,
+    containerProbe: deps.containerProbe,
+    sessionProbe: deps.sessionProbe,
+    terminalLauncher: deps.terminalLauncher,
+  });
+}

--- a/packages/runtime-service/src/index.ts
+++ b/packages/runtime-service/src/index.ts
@@ -1,1 +1,7 @@
 // @invoker/runtime-service - Runtime application services and use cases
+
+export {
+  composeRuntimeServices,
+  type RuntimeServiceDeps,
+  type RuntimeServices,
+} from './composition.js';

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -740,7 +740,7 @@ export function App() {
         <ContextMenu
           x={contextMenu.x}
           y={contextMenu.y}
-          task={tasks.get(contextMenu.task.id) ?? contextMenu.task}
+          task={contextMenu.task}
           onRestart={handleRestartTask}
           onReplace={handleReplaceTask}
           onOpenTerminal={handleOpenTerminal}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,6 +277,10 @@ importers:
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
   packages/runtime-service:
+    dependencies:
+      '@invoker/runtime-domain':
+        specifier: workspace:*
+        version: link:../runtime-domain
     devDependencies:
       '@types/node':
         specifier: ^25.3.3


### PR DESCRIPTION
## Summary

Creates the initial runtime-service composition skeleton as a standalone
foundation without wiring app entrypoints yet.

## Architecture

### Before

```mermaid
graph TD
    App[App startup] --> Local[Local composition code]
    Headless[Headless startup] --> Local
    Api[Future API surface] --> Local
```

### After

```mermaid
graph TD
    Shell[Runtime-service composition shell] --> Ports[Typed runtime ports]
    App -. future adoption .-> Shell
    Headless -. future adoption .-> Shell
    Api -. future adoption .-> Shell
```

## Test Plan

- [ ] runtime-service tests pass with exit code 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No