### PR TITLE
SaaS ladder 1c headless runtime bridge

### DIFF
--- a/packages/app/src/__tests__/headless-runtime-bridge.test.ts
+++ b/packages/app/src/__tests__/headless-runtime-bridge.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Regression tests for the headless → runtime-service bridge.
+ *
+ * Verifies that `composeHeadlessStartup` correctly routes through
+ * `composeRuntimeServices` from `@invoker/runtime-service`, producing
+ * a frozen `RuntimeServices` facade with owner-delegation parity.
+ *
+ * Upstream: wf-1778055155540-3/wire-headless-to-runtime-service (ce3006a6)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  composeHeadlessStartup,
+  composeRuntimeServices,
+  type RuntimeServiceDeps,
+  type RuntimeServices,
+} from '@invoker/runtime-service';
+
+// ── Stub factories ───────────────────────────────────────────
+
+/** Minimal deps matching the adapter shape used in headless.ts. */
+function stubDeps(): RuntimeServiceDeps {
+  return {
+    workspaceProbe: { probeWorkspace: async () => ({}) },
+    containerProbe: { probeContainer: async () => ({}) },
+    sessionProbe: { probeSession: async () => ({}) },
+    terminalLauncher: {
+      launchTerminal: async () => ({ result: 'attached' }) as any,
+    },
+  };
+}
+
+// ── Bridge wiring correctness ────────────────────────────────
+
+describe('headless → runtime-service bridge', () => {
+  describe('adapter identity pass-through', () => {
+    it('workspaceProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.workspaceProbe).toBe(deps.workspaceProbe);
+    });
+
+    it('containerProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.containerProbe).toBe(deps.containerProbe);
+    });
+
+    it('sessionProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.sessionProbe).toBe(deps.sessionProbe);
+    });
+
+    it('terminalLauncher adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.terminalLauncher).toBe(deps.terminalLauncher);
+    });
+  });
+
+  describe('facade immutability', () => {
+    it('composed object is frozen', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(Object.isFrozen(services)).toBe(true);
+    });
+
+    it('assigning to a property throws', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(() => {
+        (services as unknown as Record<string, unknown>).workspaceProbe = {};
+      }).toThrow();
+    });
+
+    it('deleting a property throws', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(() => {
+        delete (services as unknown as Record<string, unknown>).workspaceProbe;
+      }).toThrow();
+    });
+
+    it('adding a new property throws', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(() => {
+        (services as unknown as Record<string, unknown>).extra = true;
+      }).toThrow();
+    });
+  });
+
+  describe('facade shape', () => {
+    it('exposes exactly the four expected keys', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(Object.keys(services).sort()).toEqual([
+        'containerProbe',
+        'sessionProbe',
+        'terminalLauncher',
+        'workspaceProbe',
+      ]);
+    });
+
+    it('satisfies the RuntimeServices type contract', () => {
+      const services: RuntimeServices = composeHeadlessStartup(stubDeps());
+      expect(services.workspaceProbe.probeWorkspace).toBeTypeOf('function');
+      expect(services.containerProbe.probeContainer).toBeTypeOf('function');
+      expect(services.sessionProbe.probeSession).toBeTypeOf('function');
+      expect(services.terminalLauncher.launchTerminal).toBeTypeOf('function');
+    });
+  });
+
+  describe('owner-delegation parity with composeRuntimeServices', () => {
+    it('produces an equivalent facade to composeRuntimeServices', () => {
+      const deps = stubDeps();
+      const headless = composeHeadlessStartup(deps);
+      const main = composeRuntimeServices(deps);
+      // Same adapter references wired through both paths
+      expect(headless.workspaceProbe).toBe(main.workspaceProbe);
+      expect(headless.containerProbe).toBe(main.containerProbe);
+      expect(headless.sessionProbe).toBe(main.sessionProbe);
+      expect(headless.terminalLauncher).toBe(main.terminalLauncher);
+    });
+
+    it('both paths produce frozen facades', () => {
+      const deps = stubDeps();
+      expect(Object.isFrozen(composeHeadlessStartup(deps))).toBe(true);
+      expect(Object.isFrozen(composeRuntimeServices(deps))).toBe(true);
+    });
+
+    it('both paths expose the same keys', () => {
+      const deps = stubDeps();
+      const headlessKeys = Object.keys(composeHeadlessStartup(deps)).sort();
+      const mainKeys = Object.keys(composeRuntimeServices(deps)).sort();
+      expect(headlessKeys).toEqual(mainKeys);
+    });
+  });
+
+  describe('deterministic behavior', () => {
+    it('independent calls produce distinct facade objects', () => {
+      const s1 = composeHeadlessStartup(stubDeps());
+      const s2 = composeHeadlessStartup(stubDeps());
+      expect(s1).not.toBe(s2);
+    });
+
+    it('same deps produce facades with identical adapter references', () => {
+      const deps = stubDeps();
+      const s1 = composeHeadlessStartup(deps);
+      const s2 = composeHeadlessStartup(deps);
+      expect(s1.workspaceProbe).toBe(s2.workspaceProbe);
+      expect(s1.containerProbe).toBe(s2.containerProbe);
+      expect(s1.sessionProbe).toBe(s2.sessionProbe);
+      expect(s1.terminalLauncher).toBe(s2.terminalLauncher);
+    });
+
+    it('different deps produce facades with different adapter references', () => {
+      const s1 = composeHeadlessStartup(stubDeps());
+      const s2 = composeHeadlessStartup(stubDeps());
+      expect(s1.workspaceProbe).not.toBe(s2.workspaceProbe);
+      expect(s1.containerProbe).not.toBe(s2.containerProbe);
+    });
+  });
+
+  describe('adapter method delegation', () => {
+    it('probeWorkspace delegates through the composed facade', async () => {
+      const expected = { workspacePath: '/headless/workspace' };
+      const deps = stubDeps();
+      deps.workspaceProbe.probeWorkspace = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.workspaceProbe.probeWorkspace('task-h1');
+      expect(result).toBe(expected);
+    });
+
+    it('probeContainer delegates through the composed facade', async () => {
+      const expected = { containerId: 'ctr-headless' };
+      const deps = stubDeps();
+      deps.containerProbe.probeContainer = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.containerProbe.probeContainer('task-h1');
+      expect(result).toBe(expected);
+    });
+
+    it('probeSession delegates through the composed facade', async () => {
+      const expected = { agentName: 'headless-agent', sessionId: 's-h1' };
+      const deps = stubDeps();
+      deps.sessionProbe.probeSession = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.sessionProbe.probeSession('task-h1');
+      expect(result).toBe(expected);
+    });
+
+    it('launchTerminal delegates through the composed facade', async () => {
+      const expected = { result: 'attached' } as any;
+      const deps = stubDeps();
+      deps.terminalLauncher.launchTerminal = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.terminalLauncher.launchTerminal({
+        taskId: 'task-h1',
+        workspacePath: '/tmp/headless-ws',
+      });
+      expect(result).toBe(expected);
+    });
+  });
+});

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -56,6 +56,7 @@ import { resolveHeadlessTargetWorkflowId } from './headless-command-classificati
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
+import type { RuntimeServices } from '@invoker/runtime-service';
 
 export { bumpGenerationAndRecreate } from './workflow-actions.js';
 export {
@@ -100,6 +101,7 @@ export interface HeadlessDeps {
   isStandaloneOwnerIdle?: () => boolean;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
   installBundledSkills?: (mode?: BundledSkillsInstallMode) => BundledSkillsStatus;
+  runtimeServices?: RuntimeServices;
 }
 
 // ── ANSI Helpers ─────────────────────────────────────────────

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -69,7 +69,7 @@ import {
   SessionProbeAdapter,
   TerminalLauncherAdapter,
 } from '@invoker/runtime-adapters';
-import { composeRuntimeServices } from '@invoker/runtime-service';
+import { composeRuntimeServices, composeHeadlessStartup } from '@invoker/runtime-service';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import type { MessageBus } from '@invoker/transport';
 import {
@@ -398,12 +398,17 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     }
   }
   // Compose runtime services from persistence-backed adapters.
-  runtimeServices = composeRuntimeServices({
+  // Headless startup routes through composeHeadlessStartup so the
+  // headless path has an explicit composition entry point.
+  const runtimeServiceDeps = {
     workspaceProbe: new WorkspaceProbeAdapter(persistence),
     containerProbe: new ContainerProbeAdapter(persistence),
     sessionProbe: new SessionProbeAdapter(persistence),
     terminalLauncher: new TerminalLauncherAdapter(),
-  });
+  };
+  runtimeServices = isHeadless
+    ? composeHeadlessStartup(runtimeServiceDeps)
+    : composeRuntimeServices(runtimeServiceDeps);
 
   executorRegistry = new ExecutorRegistry();
   executorRegistry.register(
@@ -739,6 +744,7 @@ if (isHeadless) {
         executionAgentRegistry: agentRegistry,
         getBundledSkillsStatus,
         installBundledSkills: installPackagedSkills,
+        runtimeServices,
       };
 
       const createStandaloneTaskExecutor = (): TaskRunner => {

--- a/packages/runtime-service/src/composition.ts
+++ b/packages/runtime-service/src/composition.ts
@@ -52,3 +52,22 @@ export function composeRuntimeServices(
     terminalLauncher: deps.terminalLauncher,
   });
 }
+
+// ── Headless startup composition ──────────────────────────
+
+/**
+ * Compose runtime services for the headless startup path.
+ *
+ * Delegates to `composeRuntimeServices` with the same port contracts,
+ * making the headless entry point an explicit routing target rather
+ * than an implicit consumer of a module-level variable.
+ *
+ * Owner/delegation behavior is unaffected — this function only
+ * composes the runtime-domain ports; orchestration and task dispatch
+ * remain the caller's responsibility.
+ */
+export function composeHeadlessStartup(
+  deps: RuntimeServiceDeps,
+): RuntimeServices {
+  return composeRuntimeServices(deps);
+}

--- a/packages/runtime-service/src/index.ts
+++ b/packages/runtime-service/src/index.ts
@@ -2,6 +2,7 @@
 
 export {
   composeRuntimeServices,
+  composeHeadlessStartup,
   type RuntimeServiceDeps,
   type RuntimeServices,
 } from './composition.js';


### PR DESCRIPTION
## Summary

Wires headless startup through runtime-service composition after app-main bridge.

## Architecture

### Before

```mermaid
graph TD
    A[Headless startup] --> B[headless-owned startup wiring]
    B --> C[runtime ports]
```

### After

```mermaid
graph TD
    A[Headless startup] --> B[runtime-service composition shell]
    B --> C[runtime ports]
```

## Test Plan

- [ ] app tests pass with exit code 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #291