### PR TITLE
SaaS ladder 2a svc api package scaffold

### DIFF
--- a/packages/app/src/__tests__/headless-runtime-bridge.test.ts
+++ b/packages/app/src/__tests__/headless-runtime-bridge.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Regression tests for the headless → runtime-service bridge.
+ *
+ * Verifies that `composeHeadlessStartup` correctly routes through
+ * `composeRuntimeServices` from `@invoker/runtime-service`, producing
+ * a frozen `RuntimeServices` facade with owner-delegation parity.
+ *
+ * Upstream: wf-1778055155540-3/wire-headless-to-runtime-service (ce3006a6)
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  composeHeadlessStartup,
+  composeRuntimeServices,
+  type RuntimeServiceDeps,
+  type RuntimeServices,
+} from '@invoker/runtime-service';
+
+// ── Stub factories ───────────────────────────────────────────
+
+/** Minimal deps matching the adapter shape used in headless.ts. */
+function stubDeps(): RuntimeServiceDeps {
+  return {
+    workspaceProbe: { probeWorkspace: async () => ({}) },
+    containerProbe: { probeContainer: async () => ({}) },
+    sessionProbe: { probeSession: async () => ({}) },
+    terminalLauncher: {
+      launchTerminal: async () => ({ result: 'attached' }) as any,
+    },
+  };
+}
+
+// ── Bridge wiring correctness ────────────────────────────────
+
+describe('headless → runtime-service bridge', () => {
+  describe('adapter identity pass-through', () => {
+    it('workspaceProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.workspaceProbe).toBe(deps.workspaceProbe);
+    });
+
+    it('containerProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.containerProbe).toBe(deps.containerProbe);
+    });
+
+    it('sessionProbe adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.sessionProbe).toBe(deps.sessionProbe);
+    });
+
+    it('terminalLauncher adapter is the same object after composition', () => {
+      const deps = stubDeps();
+      const services = composeHeadlessStartup(deps);
+      expect(services.terminalLauncher).toBe(deps.terminalLauncher);
+    });
+  });
+
+  describe('facade immutability', () => {
+    it('composed object is frozen', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(Object.isFrozen(services)).toBe(true);
+    });
+
+    it('assigning to a property throws', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(() => {
+        (services as unknown as Record<string, unknown>).workspaceProbe = {};
+      }).toThrow();
+    });
+
+    it('deleting a property throws', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(() => {
+        delete (services as unknown as Record<string, unknown>).workspaceProbe;
+      }).toThrow();
+    });
+
+    it('adding a new property throws', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(() => {
+        (services as unknown as Record<string, unknown>).extra = true;
+      }).toThrow();
+    });
+  });
+
+  describe('facade shape', () => {
+    it('exposes exactly the four expected keys', () => {
+      const services = composeHeadlessStartup(stubDeps());
+      expect(Object.keys(services).sort()).toEqual([
+        'containerProbe',
+        'sessionProbe',
+        'terminalLauncher',
+        'workspaceProbe',
+      ]);
+    });
+
+    it('satisfies the RuntimeServices type contract', () => {
+      const services: RuntimeServices = composeHeadlessStartup(stubDeps());
+      expect(services.workspaceProbe.probeWorkspace).toBeTypeOf('function');
+      expect(services.containerProbe.probeContainer).toBeTypeOf('function');
+      expect(services.sessionProbe.probeSession).toBeTypeOf('function');
+      expect(services.terminalLauncher.launchTerminal).toBeTypeOf('function');
+    });
+  });
+
+  describe('owner-delegation parity with composeRuntimeServices', () => {
+    it('produces an equivalent facade to composeRuntimeServices', () => {
+      const deps = stubDeps();
+      const headless = composeHeadlessStartup(deps);
+      const main = composeRuntimeServices(deps);
+      // Same adapter references wired through both paths
+      expect(headless.workspaceProbe).toBe(main.workspaceProbe);
+      expect(headless.containerProbe).toBe(main.containerProbe);
+      expect(headless.sessionProbe).toBe(main.sessionProbe);
+      expect(headless.terminalLauncher).toBe(main.terminalLauncher);
+    });
+
+    it('both paths produce frozen facades', () => {
+      const deps = stubDeps();
+      expect(Object.isFrozen(composeHeadlessStartup(deps))).toBe(true);
+      expect(Object.isFrozen(composeRuntimeServices(deps))).toBe(true);
+    });
+
+    it('both paths expose the same keys', () => {
+      const deps = stubDeps();
+      const headlessKeys = Object.keys(composeHeadlessStartup(deps)).sort();
+      const mainKeys = Object.keys(composeRuntimeServices(deps)).sort();
+      expect(headlessKeys).toEqual(mainKeys);
+    });
+  });
+
+  describe('deterministic behavior', () => {
+    it('independent calls produce distinct facade objects', () => {
+      const s1 = composeHeadlessStartup(stubDeps());
+      const s2 = composeHeadlessStartup(stubDeps());
+      expect(s1).not.toBe(s2);
+    });
+
+    it('same deps produce facades with identical adapter references', () => {
+      const deps = stubDeps();
+      const s1 = composeHeadlessStartup(deps);
+      const s2 = composeHeadlessStartup(deps);
+      expect(s1.workspaceProbe).toBe(s2.workspaceProbe);
+      expect(s1.containerProbe).toBe(s2.containerProbe);
+      expect(s1.sessionProbe).toBe(s2.sessionProbe);
+      expect(s1.terminalLauncher).toBe(s2.terminalLauncher);
+    });
+
+    it('different deps produce facades with different adapter references', () => {
+      const s1 = composeHeadlessStartup(stubDeps());
+      const s2 = composeHeadlessStartup(stubDeps());
+      expect(s1.workspaceProbe).not.toBe(s2.workspaceProbe);
+      expect(s1.containerProbe).not.toBe(s2.containerProbe);
+    });
+  });
+
+  describe('adapter method delegation', () => {
+    it('probeWorkspace delegates through the composed facade', async () => {
+      const expected = { workspacePath: '/headless/workspace' };
+      const deps = stubDeps();
+      deps.workspaceProbe.probeWorkspace = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.workspaceProbe.probeWorkspace('task-h1');
+      expect(result).toBe(expected);
+    });
+
+    it('probeContainer delegates through the composed facade', async () => {
+      const expected = { containerId: 'ctr-headless' };
+      const deps = stubDeps();
+      deps.containerProbe.probeContainer = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.containerProbe.probeContainer('task-h1');
+      expect(result).toBe(expected);
+    });
+
+    it('probeSession delegates through the composed facade', async () => {
+      const expected = { agentName: 'headless-agent', sessionId: 's-h1' };
+      const deps = stubDeps();
+      deps.sessionProbe.probeSession = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.sessionProbe.probeSession('task-h1');
+      expect(result).toBe(expected);
+    });
+
+    it('launchTerminal delegates through the composed facade', async () => {
+      const expected = { result: 'attached' } as any;
+      const deps = stubDeps();
+      deps.terminalLauncher.launchTerminal = async () => expected;
+      const services = composeHeadlessStartup(deps);
+      const result = await services.terminalLauncher.launchTerminal({
+        taskId: 'task-h1',
+        workspacePath: '/tmp/headless-ws',
+      });
+      expect(result).toBe(expected);
+    });
+  });
+});

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -56,6 +56,7 @@ import { resolveHeadlessTargetWorkflowId } from './headless-command-classificati
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
+import type { RuntimeServices } from '@invoker/runtime-service';
 
 export { bumpGenerationAndRecreate } from './workflow-actions.js';
 export {
@@ -100,6 +101,7 @@ export interface HeadlessDeps {
   isStandaloneOwnerIdle?: () => boolean;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
   installBundledSkills?: (mode?: BundledSkillsInstallMode) => BundledSkillsStatus;
+  runtimeServices?: RuntimeServices;
 }
 
 // ── ANSI Helpers ─────────────────────────────────────────────

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -69,7 +69,7 @@ import {
   SessionProbeAdapter,
   TerminalLauncherAdapter,
 } from '@invoker/runtime-adapters';
-import { composeRuntimeServices } from '@invoker/runtime-service';
+import { composeRuntimeServices, composeHeadlessStartup } from '@invoker/runtime-service';
 import type { RuntimeServices } from '@invoker/runtime-service';
 import type { MessageBus } from '@invoker/transport';
 import {
@@ -398,12 +398,17 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     }
   }
   // Compose runtime services from persistence-backed adapters.
-  runtimeServices = composeRuntimeServices({
+  // Headless startup routes through composeHeadlessStartup so the
+  // headless path has an explicit composition entry point.
+  const runtimeServiceDeps = {
     workspaceProbe: new WorkspaceProbeAdapter(persistence),
     containerProbe: new ContainerProbeAdapter(persistence),
     sessionProbe: new SessionProbeAdapter(persistence),
     terminalLauncher: new TerminalLauncherAdapter(),
-  });
+  };
+  runtimeServices = isHeadless
+    ? composeHeadlessStartup(runtimeServiceDeps)
+    : composeRuntimeServices(runtimeServiceDeps);
 
   executorRegistry = new ExecutorRegistry();
   executorRegistry.register(
@@ -739,6 +744,7 @@ if (isHeadless) {
         executionAgentRegistry: agentRegistry,
         getBundledSkillsStatus,
         installBundledSkills: installPackagedSkills,
+        runtimeServices,
       };
 
       const createStandaloneTaskExecutor = (): TaskRunner => {

--- a/packages/runtime-service/src/composition.ts
+++ b/packages/runtime-service/src/composition.ts
@@ -52,3 +52,22 @@ export function composeRuntimeServices(
     terminalLauncher: deps.terminalLauncher,
   });
 }
+
+// ── Headless startup composition ──────────────────────────
+
+/**
+ * Compose runtime services for the headless startup path.
+ *
+ * Delegates to `composeRuntimeServices` with the same port contracts,
+ * making the headless entry point an explicit routing target rather
+ * than an implicit consumer of a module-level variable.
+ *
+ * Owner/delegation behavior is unaffected — this function only
+ * composes the runtime-domain ports; orchestration and task dispatch
+ * remain the caller's responsibility.
+ */
+export function composeHeadlessStartup(
+  deps: RuntimeServiceDeps,
+): RuntimeServices {
+  return composeRuntimeServices(deps);
+}

--- a/packages/runtime-service/src/index.ts
+++ b/packages/runtime-service/src/index.ts
@@ -2,6 +2,7 @@
 
 export {
   composeRuntimeServices,
+  composeHeadlessStartup,
   type RuntimeServiceDeps,
   type RuntimeServices,
 } from './composition.js';

--- a/packages/svc-api/package.json
+++ b/packages/svc-api/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@invoker/svc-api",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "require": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "clean": "rm -rf dist"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.3",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/svc-api/src/__tests__/server-scaffold.test.ts
+++ b/packages/svc-api/src/__tests__/server-scaffold.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import type { Server } from 'node:http';
+import { request } from 'node:http';
+import { createApiServer, startServer } from '../server.js';
+
+/** Send a GET request to a running server and return { statusCode, body }. */
+function httpGet(server: Server): Promise<{ statusCode: number; body: string }> {
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') {
+    throw new Error('server not listening on a TCP address');
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = request(
+      { hostname: '127.0.0.1', port: addr.port, method: 'GET', path: '/' },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+/** Close a server, ignoring errors if already closed. */
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+describe('createApiServer', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await closeServer(server);
+      server = undefined;
+    }
+  });
+
+  it('returns an http.Server instance', () => {
+    server = createApiServer();
+    expect(server).toBeDefined();
+    expect(typeof server.listen).toBe('function');
+    expect(typeof server.close).toBe('function');
+  });
+
+  it('uses the default handler that returns { status: "ok" }', async () => {
+    server = createApiServer();
+
+    await new Promise<void>((resolve) => {
+      server!.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    const { statusCode, body } = await httpGet(server);
+    expect(statusCode).toBe(200);
+    expect(JSON.parse(body)).toEqual({ status: 'ok' });
+  });
+
+  it('accepts a custom handler', async () => {
+    server = createApiServer((_req, res) => {
+      res.writeHead(201, { 'Content-Type': 'text/plain' });
+      res.end('custom');
+    });
+
+    await new Promise<void>((resolve) => {
+      server!.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    const { statusCode, body } = await httpGet(server);
+    expect(statusCode).toBe(201);
+    expect(body).toBe('custom');
+  });
+});
+
+describe('startServer', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await closeServer(server);
+      server = undefined;
+    }
+  });
+
+  it('resolves with a listening server on the requested port', async () => {
+    server = await startServer({ port: 0, host: '127.0.0.1' });
+    const addr = server.address();
+
+    expect(addr).not.toBeNull();
+    expect(typeof addr).toBe('object');
+    if (typeof addr === 'object' && addr) {
+      expect(addr.port).toBeGreaterThan(0);
+    }
+  });
+
+  it('serves responses through the default handler after start', async () => {
+    server = await startServer({ port: 0, host: '127.0.0.1' });
+    const { statusCode, body } = await httpGet(server);
+
+    expect(statusCode).toBe(200);
+    expect(JSON.parse(body)).toEqual({ status: 'ok' });
+  });
+
+  it('serves responses through a custom handler when provided', async () => {
+    server = await startServer({ port: 0, host: '127.0.0.1' }, (_req, res) => {
+      res.writeHead(418, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ tea: 'pot' }));
+    });
+
+    const { statusCode, body } = await httpGet(server);
+    expect(statusCode).toBe(418);
+    expect(JSON.parse(body)).toEqual({ tea: 'pot' });
+  });
+
+  it('defaults host to 0.0.0.0 when omitted', async () => {
+    server = await startServer({ port: 0 });
+    const addr = server.address();
+
+    expect(addr).not.toBeNull();
+    if (typeof addr === 'object' && addr) {
+      expect(addr.address).toBe('0.0.0.0');
+    }
+  });
+});

--- a/packages/svc-api/src/index.ts
+++ b/packages/svc-api/src/index.ts
@@ -1,0 +1,8 @@
+// @invoker/svc-api - HTTP API service scaffold
+
+export {
+  createApiServer,
+  startServer,
+  type RequestHandler,
+  type ServerOptions,
+} from './server.js';

--- a/packages/svc-api/src/server.ts
+++ b/packages/svc-api/src/server.ts
@@ -1,0 +1,37 @@
+import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+
+export interface ServerOptions {
+  port: number;
+  host?: string;
+}
+
+export type RequestHandler = (
+  req: IncomingMessage,
+  res: ServerResponse,
+) => void;
+
+const defaultHandler: RequestHandler = (_req, res) => {
+  res.writeHead(200, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify({ status: 'ok' }));
+};
+
+export function createApiServer(
+  handler: RequestHandler = defaultHandler,
+): ReturnType<typeof createServer> {
+  return createServer(handler);
+}
+
+export function startServer(
+  options: ServerOptions,
+  handler?: RequestHandler,
+): Promise<ReturnType<typeof createServer>> {
+  const server = createApiServer(handler);
+  const { port, host = '0.0.0.0' } = options;
+
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(port, host, () => {
+      resolve(server);
+    });
+  });
+}

--- a/packages/svc-api/tsconfig.json
+++ b/packages/svc-api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/svc-api/vitest.config.ts
+++ b/packages/svc-api/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import sharedConfig from '../../vitest.shared.ts';
+
+export default mergeConfig(sharedConfig, defineConfig({
+  test: {
+    exclude: ['node_modules/**', 'dist/**'],
+  },
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -347,6 +347,21 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
 
+  packages/svc-api:
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.3
+        version: 25.3.3
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
+
   packages/test-kit:
     dependencies:
       '@invoker/contracts':


### PR DESCRIPTION
## Summary

Introduces a minimal svc-api workspace package scaffold after runtime bridge work.

## Architecture

### Before

```mermaid
graph TD
    Clients[HTTP clients] -. no service package .-> Repo[Repository root]
    Repo --> Runtime[Runtime service only]
```

### After

```mermaid
graph TD
    Clients --> Package[svc-api package scaffold]
    Package --> Server[Server entry and test seams]
    Server -. future handlers .-> Runtime
```

## Test Plan

- [ ] svc-api tests pass with exit code 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #292