### PR TITLE
SaaS ladder 2b svc api hello health

### DIFF
--- a/packages/svc-api/src/__tests__/server-endpoints.test.ts
+++ b/packages/svc-api/src/__tests__/server-endpoints.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import type { Server } from 'node:http';
+import { request } from 'node:http';
+import { createApiServer } from '../server.js';
+
+/** Send an HTTP request to a running server and return { statusCode, headers, body }. */
+function httpRequest(
+  server: Server,
+  path: string,
+  method = 'GET',
+): Promise<{ statusCode: number; headers: Record<string, string | string[] | undefined>; body: string }> {
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') {
+    throw new Error('server not listening on a TCP address');
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = request(
+      { hostname: '127.0.0.1', port: addr.port, method, path },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            headers: res.headers,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}
+
+describe('endpoint contracts', () => {
+  let server: Server;
+
+  beforeAll(async () => {
+    server = createApiServer();
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+    });
+  });
+
+  describe('GET /health', () => {
+    it('returns 200 with { status: "ok" }', async () => {
+      const { statusCode, headers, body } = await httpRequest(server, '/health');
+
+      expect(statusCode).toBe(200);
+      expect(headers['content-type']).toBe('application/json');
+      expect(JSON.parse(body)).toEqual({ status: 'ok' });
+    });
+  });
+
+  describe('GET /hello', () => {
+    it('returns 200 with { message: "hello" }', async () => {
+      const { statusCode, headers, body } = await httpRequest(server, '/hello');
+
+      expect(statusCode).toBe(200);
+      expect(headers['content-type']).toBe('application/json');
+      expect(JSON.parse(body)).toEqual({ message: 'hello' });
+    });
+  });
+
+  describe('method not allowed', () => {
+    it('returns 405 for POST /health', async () => {
+      const { statusCode, headers, body } = await httpRequest(server, '/health', 'POST');
+
+      expect(statusCode).toBe(405);
+      expect(headers['content-type']).toBe('application/json');
+      expect(JSON.parse(body)).toEqual({ error: 'Method Not Allowed' });
+    });
+
+    it('returns 405 for POST /hello', async () => {
+      const { statusCode, headers, body } = await httpRequest(server, '/hello', 'POST');
+
+      expect(statusCode).toBe(405);
+      expect(headers['content-type']).toBe('application/json');
+      expect(JSON.parse(body)).toEqual({ error: 'Method Not Allowed' });
+    });
+  });
+
+  describe('unknown path', () => {
+    it('returns 404 for GET /unknown', async () => {
+      const { statusCode, headers, body } = await httpRequest(server, '/unknown');
+
+      expect(statusCode).toBe(404);
+      expect(headers['content-type']).toBe('application/json');
+      expect(JSON.parse(body)).toEqual({ error: 'Not Found' });
+    });
+  });
+});

--- a/packages/svc-api/src/__tests__/server-scaffold.test.ts
+++ b/packages/svc-api/src/__tests__/server-scaffold.test.ts
@@ -4,7 +4,7 @@ import { request } from 'node:http';
 import { createApiServer, startServer } from '../server.js';
 
 /** Send a GET request to a running server and return { statusCode, body }. */
-function httpGet(server: Server): Promise<{ statusCode: number; body: string }> {
+function httpGet(server: Server, path = '/health'): Promise<{ statusCode: number; body: string }> {
   const addr = server.address();
   if (!addr || typeof addr === 'string') {
     throw new Error('server not listening on a TCP address');
@@ -12,7 +12,7 @@ function httpGet(server: Server): Promise<{ statusCode: number; body: string }> 
 
   return new Promise((resolve, reject) => {
     const req = request(
-      { hostname: '127.0.0.1', port: addr.port, method: 'GET', path: '/' },
+      { hostname: '127.0.0.1', port: addr.port, method: 'GET', path },
       (res) => {
         const chunks: Buffer[] = [];
         res.on('data', (chunk) => chunks.push(chunk));

--- a/packages/svc-api/src/index.ts
+++ b/packages/svc-api/src/index.ts
@@ -2,6 +2,7 @@
 
 export {
   createApiServer,
+  defaultHandler,
   startServer,
   type RequestHandler,
   type ServerOptions,

--- a/packages/svc-api/src/server.ts
+++ b/packages/svc-api/src/server.ts
@@ -10,9 +10,31 @@ export type RequestHandler = (
   res: ServerResponse,
 ) => void;
 
-const defaultHandler: RequestHandler = (_req, res) => {
-  res.writeHead(200, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify({ status: 'ok' }));
+function sendJson(res: ServerResponse, statusCode: number, body: unknown): void {
+  res.writeHead(statusCode, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+export const defaultHandler: RequestHandler = (req, res) => {
+  const method = req.method ?? '';
+  const url = req.url ?? '/';
+
+  if (method !== 'GET') {
+    sendJson(res, 405, { error: 'Method Not Allowed' });
+    return;
+  }
+
+  if (url === '/health') {
+    sendJson(res, 200, { status: 'ok' });
+    return;
+  }
+
+  if (url === '/hello') {
+    sendJson(res, 200, { message: 'hello' });
+    return;
+  }
+
+  sendJson(res, 404, { error: 'Not Found' });
 };
 
 export function createApiServer(


### PR DESCRIPTION
## Summary

Adds stable /health and /hello endpoint contracts on top of svc-api scaffold.

## Architecture

### Before

```mermaid
graph TD
    A[HTTP clients] --> B[placeholder API surface]
    B --> C[runtime-backed server process]
```

### After

```mermaid
graph TD
    A[HTTP clients] --> B[svc-api hello/health handlers]
    B --> C[runtime-backed server process]
```

## Test Plan

- [ ] svc-api tests pass with exit code 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #293