### PR TITLE
SaaS ladder 2c dormant runtime api bridge

### DIFF
--- a/packages/runtime-service/src/composition.ts
+++ b/packages/runtime-service/src/composition.ts
@@ -14,6 +14,16 @@ import type {
   TerminalLauncher,
 } from '@invoker/runtime-domain';
 
+// ── Dormant bridge hook ──────────────────────────────────────
+
+/**
+ * Callback invoked when the dormant runtime bridge is enabled.
+ * Receives the composed services for external wiring (e.g. IPC,
+ * message bus, or cross-process relay). The hook is a no-op slot:
+ * the bridge is dormant unless the caller explicitly opts in.
+ */
+export type DormantBridgeHook = (services: RuntimeServices) => void;
+
 // ── Dependency slot ────────────────────────────────────────
 
 /** Ports that callers must supply to compose the runtime services. */
@@ -22,6 +32,18 @@ export interface RuntimeServiceDeps {
   containerProbe: ContainerProbe;
   sessionProbe: SessionProbe;
   terminalLauncher: TerminalLauncher;
+
+  /**
+   * When `true`, the dormant bridge hook fires after composition.
+   * Defaults to `false` — active behavior is unchanged.
+   */
+  enableDormantBridge?: boolean;
+
+  /**
+   * Optional callback invoked only when `enableDormantBridge` is `true`.
+   * Ignored otherwise.
+   */
+  dormantBridgeHook?: DormantBridgeHook;
 }
 
 // ── Public facade ──────────────────────────────────────────
@@ -45,12 +67,18 @@ export interface RuntimeServices {
 export function composeRuntimeServices(
   deps: RuntimeServiceDeps,
 ): RuntimeServices {
-  return Object.freeze({
+  const services = Object.freeze({
     workspaceProbe: deps.workspaceProbe,
     containerProbe: deps.containerProbe,
     sessionProbe: deps.sessionProbe,
     terminalLauncher: deps.terminalLauncher,
   });
+
+  if (deps.enableDormantBridge === true && deps.dormantBridgeHook) {
+    deps.dormantBridgeHook(services);
+  }
+
+  return services;
 }
 
 // ── Headless startup composition ──────────────────────────

--- a/packages/svc-api/src/__tests__/runtime-bridge-dormant.test.ts
+++ b/packages/svc-api/src/__tests__/runtime-bridge-dormant.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import type { Server } from 'node:http';
+import { startServer } from '../server.js';
+
+/** Close a server, ignoring errors if already closed. */
+function closeServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+describe('dormant bridge guard — startServer', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (server) {
+      await closeServer(server);
+      server = undefined;
+    }
+  });
+
+  it('does not invoke the hook when enableDormantBridge is omitted', async () => {
+    const hook = vi.fn();
+    server = await startServer({ port: 0, host: '127.0.0.1', dormantBridgeHook: hook });
+
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke the hook when enableDormantBridge is false', async () => {
+    const hook = vi.fn();
+    server = await startServer({
+      port: 0,
+      host: '127.0.0.1',
+      enableDormantBridge: false,
+      dormantBridgeHook: hook,
+    });
+
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when enableDormantBridge is true but no hook is provided', async () => {
+    server = await startServer({ port: 0, host: '127.0.0.1', enableDormantBridge: true });
+
+    const addr = server.address();
+    expect(addr).not.toBeNull();
+  });
+
+  it('invokes the hook with the server when explicitly opted in', async () => {
+    const hook = vi.fn();
+    server = await startServer({
+      port: 0,
+      host: '127.0.0.1',
+      enableDormantBridge: true,
+      dormantBridgeHook: hook,
+    });
+
+    expect(hook).toHaveBeenCalledTimes(1);
+    expect(hook).toHaveBeenCalledWith(server);
+  });
+
+  it('does not alter active /health behavior when bridge is enabled', async () => {
+    const hook = vi.fn();
+    server = await startServer({
+      port: 0,
+      host: '127.0.0.1',
+      enableDormantBridge: true,
+      dormantBridgeHook: hook,
+    });
+
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') throw new Error('not listening');
+
+    const res = await fetch(`http://127.0.0.1:${addr.port}/health`);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ status: 'ok' });
+  });
+});

--- a/packages/svc-api/src/server.ts
+++ b/packages/svc-api/src/server.ts
@@ -3,6 +3,20 @@ import { createServer, type IncomingMessage, type ServerResponse } from 'node:ht
 export interface ServerOptions {
   port: number;
   host?: string;
+
+  /**
+   * When `true`, the dormant bridge hook fires after the server starts
+   * listening. Defaults to `false` — active behavior is unchanged.
+   */
+  enableDormantBridge?: boolean;
+
+  /**
+   * Optional callback invoked only when `enableDormantBridge` is `true`.
+   * Receives the running server instance for external wiring (e.g.
+   * attaching a runtime service bridge or cross-process relay).
+   * Ignored when `enableDormantBridge` is not `true`.
+   */
+  dormantBridgeHook?: (server: ReturnType<typeof createServer>) => void;
 }
 
 export type RequestHandler = (
@@ -53,6 +67,9 @@ export function startServer(
   return new Promise((resolve, reject) => {
     server.once('error', reject);
     server.listen(port, host, () => {
+      if (options.enableDormantBridge === true && options.dormantBridgeHook) {
+        options.dormantBridgeHook(server);
+      }
       resolve(server);
     });
   });


### PR DESCRIPTION
## Summary

Adds dormant runtime-service to svc-api bridge hooks without changing defaults.

## Architecture

### Before

```mermaid
graph TD
    SvcApi[svc-api server] --> Active[Active hello/health flow]
    Active --> Runtime[Runtime service]
```

### After

```mermaid
graph TD
    SvcApi --> Active
    Active --> Runtime
    Bridge[Dormant runtime bridge hook] -. disabled by default .-> Runtime
```

## Test Plan

- [ ] runtime-service and svc-api tests pass with exit code 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No