### PR TITLE
SaaS ladder 3c dormant web auth and final regression

### DIFF
--- a/packages/web-app/src/__tests__/feature-flags.test.ts
+++ b/packages/web-app/src/__tests__/feature-flags.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+describe('feature-flags', () => {
+  describe('default values', () => {
+    it('AUTH_ENABLED is false by default', async () => {
+      const { featureFlags } = await import('../feature-flags');
+      expect(featureFlags.AUTH_ENABLED).toBe(false);
+    });
+
+    it('featureFlags object has only AUTH_ENABLED key', async () => {
+      const { featureFlags } = await import('../feature-flags');
+      expect(Object.keys(featureFlags)).toEqual(['AUTH_ENABLED']);
+    });
+  });
+
+  describe('auth placeholder gate in init()', () => {
+    beforeEach(() => {
+      document.body.innerHTML = '<div id="app"></div>';
+      vi.restoreAllMocks();
+      vi.resetModules();
+    });
+
+    function getApp() {
+      return document.getElementById('app')!;
+    }
+
+    it('shows auth placeholder when AUTH_ENABLED is true', async () => {
+      vi.doMock('../feature-flags', () => ({
+        featureFlags: { AUTH_ENABLED: true },
+      }));
+      const { init } = await import('../main');
+      globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+
+      init(getApp());
+
+      const app = getApp();
+      expect(app.textContent).toBe('Auth: not implemented');
+      expect(app.dataset.state).toBe('auth-placeholder');
+    });
+
+    it('does not call fetch when AUTH_ENABLED is true', async () => {
+      vi.doMock('../feature-flags', () => ({
+        featureFlags: { AUTH_ENABLED: true },
+      }));
+      const { init } = await import('../main');
+      globalThis.fetch = vi.fn().mockReturnValue(new Promise(() => {}));
+
+      init(getApp());
+
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+
+    it('proceeds to hello-world flow when AUTH_ENABLED is false', async () => {
+      vi.doMock('../feature-flags', () => ({
+        featureFlags: { AUTH_ENABLED: false },
+      }));
+      const { init } = await import('../main');
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ message: 'hello' }),
+      });
+
+      init(getApp());
+
+      const app = getApp();
+      expect(app.textContent).toBe('Loading…');
+      expect(app.dataset.state).toBe('loading');
+      expect(globalThis.fetch).toHaveBeenCalled();
+    });
+
+    it('hello-world flow resolves to success when AUTH_ENABLED is false', async () => {
+      vi.doMock('../feature-flags', () => ({
+        featureFlags: { AUTH_ENABLED: false },
+      }));
+      const { init } = await import('../main');
+      globalThis.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ message: 'hello' }),
+      });
+
+      init(getApp());
+      await new Promise((r) => setTimeout(r, 0));
+
+      const app = getApp();
+      expect(app.textContent).toBe('hello');
+      expect(app.dataset.state).toBe('success');
+    });
+  });
+});

--- a/packages/web-app/src/feature-flags.ts
+++ b/packages/web-app/src/feature-flags.ts
@@ -1,0 +1,4 @@
+export const featureFlags = {
+  /** When true, show auth placeholder instead of hello-world. Default: off. */
+  AUTH_ENABLED: false,
+} as const;

--- a/packages/web-app/src/main.ts
+++ b/packages/web-app/src/main.ts
@@ -1,6 +1,13 @@
 import { createApiClient } from './api-client';
+import { featureFlags } from './feature-flags';
 
 export function init(app: HTMLElement = document.getElementById('app')!) {
+  if (featureFlags.AUTH_ENABLED) {
+    app.textContent = 'Auth: not implemented';
+    app.dataset.state = 'auth-placeholder';
+    return;
+  }
+
   app.textContent = 'Loading…';
   app.dataset.state = 'loading';
 


### PR DESCRIPTION
## Summary

Adds dormant web auth placeholder and runs final regression lane for hello-world SaaS proof.

## Architecture

### Before

```mermaid
graph TD
    Browser --> Hello[Hello-world web flow]
    Hello --> Api[svc-api hello/health endpoints]
```

### After

```mermaid
graph TD
    Browser --> Hello
    Hello --> Api
    Auth[Dormant auth placeholder] -. off by default .-> Hello
```

## Test Plan

- [ ] svc-api and web-app tests pass with exit code 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #297