### PR TITLE
Require test:all as final implementation-plan gate

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -456,6 +456,7 @@ describe('PlanConversation', () => {
     const prompt = mockSpawn.mock.calls[0][1][1] as string;
     expect(prompt).toContain('YAML task plan');
     expect(prompt).toContain('Hello');
+    expect(prompt).toContain('pnpm run test:all');
   });
 
   it('submittedPlanText is null before confirmation', async () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -111,10 +111,12 @@ Rules:
 5. Each task should have either a \`command\` or a \`prompt\`, not both.
 6. Every step MUST be testable. Every implementation task MUST have a corresponding test task that verifies it works using a concrete, executable \`command\` (e.g. \`cd packages/protocol && pnpm test\`, \`git diff --name-only\`). The test command must produce a clear pass/fail exit code. Do NOT skip tests for any step. Do NOT use prompts for test tasks — use commands only.
    Test command rules:
-   - ALWAYS cd into the package directory first: \`cd packages/<pkg> && pnpm test\`
+   - For focused package tests, ALWAYS cd into the package directory first: \`cd packages/<pkg> && pnpm test\`
    - To target a specific test file: \`cd packages/<pkg> && pnpm test -- src/__tests__/file.test.ts\`
    - NEVER run \`pnpm test <path>\` from the repo root — it runs \`pnpm -r test\` across all packages and the path will be wrong
    - NEVER use \`npx vitest run\` — always use \`pnpm test\` which runs the package.json test script
+   - For implementation plans (\`onFinish\` is not \`none\`), the FINAL task MUST be a \`command\` task that runs \`pnpm run test:all\` from the repo root
+   - That final \`pnpm run test:all\` task MUST depend on every earlier task so it is the terminal regression gate
    - If Invoker config auto-routes heavyweight commands, keep \`pnpm ...\` as a normal command unless the task must name a specific remote target
    - NEVER invent test file names. Verify the test file exists before referencing it in a command.
 7. Use meaningful task IDs (kebab-case).

--- a/plans/plan-to-invoker-deterministic-step-1-validator.yaml
+++ b/plans/plan-to-invoker-deterministic-step-1-validator.yaml
@@ -49,9 +49,11 @@ tasks:
       - add-validator-tests
 
   - id: post-fix-regression
-    description: "Run app package tests as post-fix regression"
-    command: "cd packages/app && pnpm test"
+    description: "Run the full repository test suite as post-fix regression"
+    command: "pnpm run test:all"
     executorType: ssh
     remoteTargetId: remote_digital_ocean_1
     dependencies:
+      - implement-typed-plan-validator
+      - add-validator-tests
       - run-plan-to-invoker-script-tests

--- a/plans/plan-to-invoker-deterministic-step-2-doctor.template.yaml
+++ b/plans/plan-to-invoker-deterministic-step-2-doctor.template.yaml
@@ -49,9 +49,11 @@ tasks:
       - wire-skill-doctor-into-skill-doc
 
   - id: post-fix-regression
-    description: "Run app package tests as post-fix regression"
-    command: "cd packages/app && pnpm test"
+    description: "Run the full repository test suite as post-fix regression"
+    command: "pnpm run test:all"
     executorType: ssh
     remoteTargetId: remote_digital_ocean_1
     dependencies:
+      - add-skill-doctor-script
+      - wire-skill-doctor-into-skill-doc
       - run-script-tests

--- a/plans/plan-to-invoker-deterministic-step-3-visual-proof-cli.template.yaml
+++ b/plans/plan-to-invoker-deterministic-step-3-visual-proof-cli.template.yaml
@@ -47,9 +47,11 @@ tasks:
       - update-visual-proof-skill-doc
 
   - id: post-fix-regression
-    description: "Run UI package tests as post-fix regression"
-    command: "cd packages/ui && pnpm test"
+    description: "Run the full repository test suite as post-fix regression"
+    command: "pnpm run test:all"
     executorType: ssh
     remoteTargetId: remote_digital_ocean_1
     dependencies:
+      - add-visual-proof-subcommands
+      - update-visual-proof-skill-doc
       - run-visual-proof-e2e

--- a/plans/plan-to-invoker-deterministic-step-4-fixtures.template.yaml
+++ b/plans/plan-to-invoker-deterministic-step-4-fixtures.template.yaml
@@ -40,9 +40,11 @@ tasks:
       - trim-reference-markdown
 
   - id: post-fix-regression
-    description: "Run app package tests as post-fix regression"
-    command: "cd packages/app && pnpm test"
+    description: "Run the full repository test suite as post-fix regression"
+    command: "pnpm run test:all"
     executorType: ssh
     remoteTargetId: remote_digital_ocean_1
     dependencies:
+      - convert-markdown-examples-to-fixtures
+      - trim-reference-markdown
       - run-plan-to-invoker-tests

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -56,6 +56,7 @@ must_contain "$SKILL_MD" "## Intended flow (do not skip steps)" "SKILL must docu
 must_contain "$SKILL_MD" "Runtime verification (Phase 1b)" "SKILL must require runtime behavioral verification"
 must_contain "$SKILL_MD" "Invoker headless" "SKILL must mention Invoker headless as a verification lane"
 must_contain "$SKILL_MD" "pnpm test" "SKILL must mention pnpm test for behavioral proof"
+must_contain "$SKILL_MD" "pnpm run test:all" "SKILL must require the final full-suite regression gate for implementation plans"
 must_contain "$SKILL_MD" "Grep-only checks" "SKILL must separate grep from behavioral verification"
 must_contain "$SKILL_MD" "see playbook" "SKILL Execution must reference the playbook"
 must_contain "$SKILL_MD" "Phase 1b" "SKILL must reference Phase 1b"
@@ -67,6 +68,7 @@ must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must defin
 must_contain "$PLAYBOOK" "### Phase 1b — Runtime verification" "Playbook must define runtime behavioral verification"
 must_contain "$PLAYBOOK" "Phase 1b-invoker" "Playbook must define Invoker headless verification lane"
 must_contain "$PLAYBOOK" "pnpm test" "Playbook must document pnpm test for behavioral verification"
+must_contain "$PLAYBOOK" "pnpm run test:all" "Playbook must document the final full-suite regression gate"
 must_contain "$PLAYBOOK" "Invoker is mandatory" "Playbook must warn when Invoker verification is mandatory"
 must_contain "$PLAYBOOK" "coverageItems" "Playbook must document row-level coverage for policy-matrix sources"
 

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -14,7 +14,7 @@ Minimal controller skill. Keep policy short here; use deterministic scripts and 
 
 1. Discuss scope/risk with the user.
 2. Phase 1a static analysis.
-3. Runtime verification (Phase 1b): run `pnpm test`, plus Invoker headless when applicable.
+3. Runtime verification (Phase 1b): run targeted `pnpm test`, plus Invoker headless when applicable.
 4. Generate implementation YAML from verified facts.
 5. Validate with deterministic scripts.
 6. Present plan and submit on confirmation.
@@ -111,6 +111,7 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
 - Unit/package lane: `cd packages/<pkg> && pnpm test`
 - Invoker headless lane: run `./submit-plan.sh plans/verify-<slug>.yaml` when flow involves orchestrator/executor/persistence/headless behavior
 - Visual proof lane when UI changes apply
+- Implementation-plan final gate: the last task in any plan with `onFinish != none` must run `pnpm run test:all` from the repo root and depend on every earlier task
 
 When Invoker config enables heavyweight command routing, keep `pnpm ...` commands in the plan as normal command tasks unless a specific remote target must be declared explicitly. Runtime config may auto-route those commands to SSH.
 

--- a/skills/plan-to-invoker/fixtures/README.md
+++ b/skills/plan-to-invoker/fixtures/README.md
@@ -34,7 +34,10 @@ Positive fixtures demonstrate valid plan patterns:
 - **02-feature-implementation.yaml** - Standard implement → test → verify pattern
 - **03-multi-step-refactor-worktrees.yaml** - Multi-step refactor using worktrees
 - **04-large-refactor-pull-request.yaml** - Complex plan with diamond dependencies and `onFinish: pull_request`
+- **05-ui-change-with-visual-proof.yaml** - UI workflow that pairs visual proof with a final full-suite regression gate
+- **06-invoker-dogfood-mergify-stack.yaml** - Invoker-on-Invoker PR publication example with a final full-suite regression gate
 - **07-prompt-edit-layered-split-with-dormant.yaml** - Dependency-first layer split for prompt-edit bridge work, including a dormant activation slice
+- Implementation fixtures with `onFinish != none` end with a final `pnpm run test:all` task
 
 All positive fixtures are extracted from `references/examples.md` sections 1-4.
 
@@ -52,6 +55,7 @@ Negative fixtures demonstrate anti-patterns and validation errors:
 - **anti-pattern-f-dangerous-commands.yaml** - Dangerous commands (rm -rf, force push, etc.)
 - **anti-pattern-g-monolithic-prompt-edit-bridge.yaml** - Monolithic `wf-1777929074509-8`-shaped workflow missing required layer/state decomposition metadata (**fails `skill-doctor` lint, not YAML schema**)
 - **anti-pattern-h-layer-order-violation.yaml** - Lower architectural layer depends on a higher layer without `Layer exception: allowed` (**fails `skill-doctor` lint, not YAML schema**)
+- **anti-pattern-i-final-regression-not-test-all.yaml** - Implementation workflow missing the terminal `pnpm run test:all` regression gate (**fails `skill-doctor` lint, not YAML schema**)
 
 ### Edge Cases (specific validation errors)
 

--- a/skills/plan-to-invoker/fixtures/negative/anti-pattern-i-final-regression-not-test-all.yaml
+++ b/skills/plan-to-invoker/fixtures/negative/anti-pattern-i-final-regression-not-test-all.yaml
@@ -1,0 +1,38 @@
+# Anti-Pattern I: Implementation plan without terminal full-suite regression
+# Expected outcome: validate-plan passes schema, but skill-doctor fails lint-task-atomicity
+# because implementation workflows must end with a `pnpm run test:all` task that
+# depends on every earlier task.
+
+name: "Anti-pattern: final regression is not full suite"
+description: |
+  Demonstrates an implementation workflow that incorrectly ends with a
+  package-scoped test command instead of the required full-suite gate.
+onFinish: pull_request
+mergeMode: github
+repoUrl: git@github.com:example-org/acme-repo.git
+baseBranch: master
+featureBranch: plan/anti-pattern-final-regression-not-test-all
+
+tasks:
+  - id: implement-surface
+    description: |
+      Add the renderer-facing mutation surface.
+      Layer: contact_surface
+      Feature state: active
+      Acceptance criteria:
+      - Ensure the contact surface exposes the new mutation contract.
+    prompt: |
+      Modify packages/foo/src/surface.ts so the renderer exposes a typed
+      mutation callback for the new workflow behavior. Ensure the implementation
+      preserves existing imports and keeps the contract compile-safe.
+    dependencies: []
+
+  - id: verify-package-tests
+    description: |
+      Re-run only the package-scoped tests.
+      Layer: e2e_regression
+      Feature state: active
+      Acceptance criteria:
+      - Ensure package-local tests still pass.
+    command: "cd packages/foo && pnpm test"
+    dependencies: [implement-surface]

--- a/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/02-feature-implementation.yaml
@@ -1,7 +1,7 @@
 # Feature Implementation Plan
 # Source: examples.md Section 2
 # Description: A plan that adds a feature using prompt tasks for implementation and command tasks for verification.
-# Shows the standard pattern: implement → test → verify.
+# Shows the standard pattern: implement → focused verification → final full-suite gate.
 #
 # Uses `onFinish: merge` (the default) to automatically merge changes into the base branch after all tasks complete.
 # Critical pattern: Every prompt task that modifies code MUST have a corresponding command task that runs tests to verify the change.
@@ -61,3 +61,8 @@ tasks:
     description: "Verify the package builds without errors"
     command: "cd packages/utils && pnpm build 2>&1"
     dependencies: [verify-tests-pass]
+
+  - id: final-regression
+    description: "Run the full repository test suite as the final regression gate"
+    command: "pnpm run test:all"
+    dependencies: [implement-formatter, write-tests, verify-tests-pass, verify-build]

--- a/skills/plan-to-invoker/fixtures/positive/03-multi-step-refactor-worktrees.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/03-multi-step-refactor-worktrees.yaml
@@ -67,3 +67,8 @@ tasks:
     description: "Run full config package test suite"
     command: "cd packages/config && pnpm test 2>&1"
     dependencies: [add-schema-types]
+
+  - id: final-regression
+    description: "Run the full repository test suite as the final regression gate"
+    command: "pnpm run test:all"
+    dependencies: [extract-validator, add-validator-tests, verify-validator, add-schema-types, verify-all-tests]

--- a/skills/plan-to-invoker/fixtures/positive/04-large-refactor-pull-request.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/04-large-refactor-pull-request.yaml
@@ -157,3 +157,8 @@ tasks:
     description: "Build all packages to verify no breakage"
     command: "pnpm build 2>&1"
     dependencies: [verify-core-tests]
+
+  - id: final-regression
+    description: "Run the full repository test suite as the final regression gate"
+    command: "pnpm run test:all"
+    dependencies: [scaffold-package, move-types, move-dag-utils, extract-action-graph, update-graph-index, refactor-state-machine, write-graph-tests, verify-graph-tests, verify-core-tests, verify-full-build]

--- a/skills/plan-to-invoker/fixtures/positive/05-ui-change-with-visual-proof.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/05-ui-change-with-visual-proof.yaml
@@ -64,6 +64,6 @@ tasks:
     dependencies: [fix-sidebar-transition, add-visual-proof-test]
 
   - id: verify-regression-suite
-    description: "Re-run UI unit tests as final regression gate"
-    command: "cd packages/ui && pnpm test 2>&1"
-    dependencies: [run-sidebar-unit-tests, capture-visual-proof]
+    description: "Run the full repository test suite as the final regression gate"
+    command: "pnpm run test:all"
+    dependencies: [add-visual-proof-test, fix-sidebar-transition, run-sidebar-unit-tests, capture-visual-proof]

--- a/skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/06-invoker-dogfood-mergify-stack.yaml
@@ -36,3 +36,8 @@ tasks:
     description: "Run the plan-to-invoker fixture tests"
     command: "bash skills/plan-to-invoker/scripts/test-fixtures.sh"
     dependencies: [update-dogfood-guidance]
+
+  - id: final-regression
+    description: "Run the full repository test suite as the final regression gate"
+    command: "pnpm run test:all"
+    dependencies: [update-dogfood-guidance, verify-skill-fixtures]

--- a/skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml
@@ -99,3 +99,17 @@ tasks:
       confirm no command-edit regressions. Ensure test naming and setup are
       deterministic so this workflow can be reviewed as the final proof layer.
     dependencies: [ui-prompt-editing-activation]
+
+  - id: final-regression
+    description: |
+      Run the full repository test suite as the terminal regression gate.
+      Layer: e2e_regression
+      Feature state: active
+      Files:
+      - none
+      Change types:
+      - none
+      Acceptance criteria:
+      - Ensure the full repository test suite passes after all prompt-edit slices land.
+    command: "pnpm run test:all"
+    dependencies: [prompt-edit-contact-surface, app-bridge-and-owner-delegation, ui-prompt-editing-activation, app-and-e2e-regressions]

--- a/skills/plan-to-invoker/playbooks/verify-then-build.md
+++ b/skills/plan-to-invoker/playbooks/verify-then-build.md
@@ -155,17 +155,17 @@ For each failed verification:
 
 ### Final verification task (required)
 
-The implementation plan **must** end with one or more **`command`** tasks that **re-run the same reproduction** used in Phase 1b:
+The implementation plan **must** end with a final **`command`** task that runs:
 
-- Same `cd packages/<pkg> && pnpm test -- <repro>` as in Phase 1b-unit, **or**
-- Same `./submit-plan.sh plans/verify-<slug>.yaml` or `bash scripts/verify-<slug>-invoker.sh` as in Phase 1b-invoker, **or**
-- A single script that runs both if the fix required both.
+- `pnpm run test:all`
 
-**Dependencies:** The final verification task **must depend on** every implementation task (`prompt` or `command`) that changes code or behavior for the fix — so it runs **after** the work, not in parallel.
+Use earlier tasks to re-run the focused repro from Phase 1b (`cd packages/<pkg> && pnpm test -- <repro>`, `./submit-plan.sh plans/verify-<slug>.yaml`, or both). The terminal gate for submitted implementation plans is always the full repo suite.
 
-**Naming:** `verify-fix-repro`, `regression-pnpm-test`, `regression-headless-verify`, etc.
+**Dependencies:** The final `pnpm run test:all` task **must depend on every earlier task** so it runs last as the terminal regression gate.
 
-**Anti-pattern:** Implementation plan with **no** final repro task — you cannot show the fix worked end-to-end.
+**Naming:** `final-regression`, `regression-test-all`, `final-test-suite`, etc.
+
+**Anti-pattern:** Implementation plan with **no** final `pnpm run test:all` task — you cannot show the submitted workflow passed the full suite end-to-end.
 
 ### Visual proof capture task (when `visualProof: true`)
 
@@ -193,4 +193,4 @@ Generate the implementation plan, validate with `scripts/validate-plan.sh`, pres
 - **Not cleaning up verification workflow** — Invoker may still have the verify plan running. Use `delete-all` before submitting implementation when needed.
 - **Trusting file paths from a plan without checking** — plans can reference moved, renamed, or deleted files. Verify first.
 - **Proceeding after verification failures without adjusting** — the whole point of Phase 1 is to inform Phase 2.
-- **Implementation plan without a final repro task** — cannot confirm the fix against the original failure mode.
+- **Implementation plan without a final `pnpm run test:all` task** — cannot confirm the submitted workflow passed the full suite.

--- a/skills/plan-to-invoker/references/examples.md
+++ b/skills/plan-to-invoker/references/examples.md
@@ -20,7 +20,7 @@ Standard pattern: **implement → test → verify**. Uses `onFinish: merge` to a
 
 **See**: `fixtures/positive/02-feature-implementation.yaml`
 
-**Pattern**: Every prompt task MUST have a corresponding command task to verify (tests, build, etc.).
+**Pattern**: Every prompt task MUST have a corresponding command task to verify, and implementation plans end with a final `pnpm run test:all` gate.
 
 ---
 
@@ -55,6 +55,7 @@ Complex plan with diamond dependencies. Uses `onFinish: pull_request` for manual
 - `fixtures/negative/anti-pattern-f-dangerous-commands.yaml` — Avoid destructive commands (`rm -rf`, force push)
 - `fixtures/negative/anti-pattern-g-monolithic-prompt-edit-bridge.yaml` — Monolithic `wf-1777929074509-8`-style workflow missing dependency-first layered decomposition metadata
 - `fixtures/negative/anti-pattern-h-layer-order-violation.yaml` — Lower layer depends on higher layer without `Layer exception: allowed`
+- `fixtures/negative/anti-pattern-i-final-regression-not-test-all.yaml` — Implementation plan ends without a terminal `pnpm run test:all` gate
 
 All anti-patterns are validated by `scripts/test-fixtures.sh` with deterministic error detection.
 
@@ -143,6 +144,7 @@ Use this pattern when a change is too large for a single reviewable workflow. Fo
 
 **Validation enforces**:
 - Every prompt task must have verification command task
+- Implementation plans must end with `pnpm run test:all` as the final regression gate
 - Use `pnpm test`, never `npx vitest run`
 - Dependencies field required (even if empty)
 - No dangerous commands without manual approval

--- a/skills/plan-to-invoker/references/schema.md
+++ b/skills/plan-to-invoker/references/schema.md
@@ -50,7 +50,7 @@ Source of truth: `packages/app/src/plan-parser.ts` (interfaces + validation, lin
 
 ## Implementation plans (convention)
 
-`plan-parser.ts` does not require a special field for this, but **implementation** YAML (not one-off verify-only plans) should reserve the **last** task for **post-fix regression**: a `command` task that re-runs the same reproduction used in Phase 1b (`pnpm test` target, `submit-plan.sh` verify plan, or `scripts/verify-*.sh`). That task depends on every implementation task that changes behavior. See `references/task-patterns.md` and `playbooks/verify-then-build.md` Phase 2.
+`plan-parser.ts` does not require a special field for this, but **implementation** YAML (not one-off verify-only plans) must reserve the **last** task for the terminal regression gate: a `command` task that runs `pnpm run test:all`. Keep focused package/headless repro commands earlier in the plan. The final `pnpm run test:all` task must depend on every earlier task so it runs last. See `references/task-patterns.md` and `playbooks/verify-then-build.md` Phase 2.
 
 ## Banned Patterns
 

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -8,6 +8,7 @@ Source of truth: `packages/surfaces/src/slack/plan-conversation.ts:100-116`
 |--------------------------|-----------|----------|
 | "Run tests" / "verify" / "check" | `command` | `cd packages/<pkg> && pnpm test` |
 | "Run specific test file" | `command` | `cd packages/<pkg> && pnpm test -- src/__tests__/file.test.ts` |
+| "Run final regression suite" | `command` | `pnpm run test:all` |
 | "Refactor X" / "Add feature Y" | `prompt` | Detailed instructions with file paths, line numbers, acceptance criteria |
 | "Build/compile" | `command` | `pnpm --filter @invoker/<pkg> build` |
 | "Build all" / "verify compilation" | `command` | `pnpm build` |
@@ -16,7 +17,7 @@ Source of truth: `packages/surfaces/src/slack/plan-conversation.ts:100-116`
 | "Lint / type-check" | `command` | `pnpm --filter @invoker/<pkg> lint` or `pnpm --filter @invoker/<pkg> typecheck` |
 | "Check file exists" | `command` | `test -f <path>` |
 | "Check pattern in file" | `command` | `grep -q '<pattern>' <path>` |
-| **Post-fix / regression** (re-run repro after implementation) | `command` | Same as Phase 1b: `cd packages/<pkg> && pnpm test -- <repro>` and/or `./submit-plan.sh plans/verify-<slug>.yaml` and/or `bash scripts/verify-<slug>-invoker.sh` — **must** match what proved the bug and the fix |
+| **Post-fix / regression** (final submitted-plan gate) | `command` | `pnpm run test:all` — keep focused repro commands earlier in the plan, but the final task for implementation plans must be the full-suite gate |
 | "Modify UI component" / "Fix layout" | `prompt` + `visualProof: true` | Set `visualProof: true` at plan level; include `description` |
 | **Add visual proof E2E test case** | `prompt` | Add a test to `packages/app/e2e/visual-proof.spec.ts` that sets up the exact UI state being changed and calls `captureScreenshot(page, '<plan-slug>-<state>')`. See `skills/visual-proof/SKILL.md`. |
 | **Capture visual proof (after)** | `command` | `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after` — depends on **all** implementation tasks |
@@ -31,13 +32,13 @@ These are constraints, not guidelines. Violating them produces broken plans.
 - **Test task** → depends on the implementation task it verifies.
 - **Build/compile check** → depends on all implementation tasks that change source.
 - **Integration test** → depends on all unit-level tasks it integrates.
-- **Final post-fix verification task** → depends on **every** `prompt` / `command` implementation task that is part of the fix. It runs **last** (after the code changes), not in parallel with them.
+- **Final regression task** → depends on **every earlier task** and runs **last** as `pnpm run test:all`.
 - **Visual proof capture task** → depends on **all** implementation tasks and the E2E test case task (it must run after code changes AND the new Playwright test exist).
 
 ### Can be parallel (no dependency needed)
 - **Independent packages** → tasks touching different packages with no cross-package imports.
 - **Independent files** → tasks creating/modifying unrelated files.
-- **All verification tasks** → file-existence and grep checks are read-only, run them all in parallel — **except** the final regression task, which must depend on implementation tasks (see above).
+- **All verification tasks** → file-existence and grep checks are read-only, run them all in parallel — **except** the final regression task, which must depend on every earlier task (see above).
 
 ## Layered decomposition contract (hard requirement for implementation plans)
 
@@ -146,7 +147,7 @@ See `SKILL.md` (bugfix repro blurb) and this repo’s `scripts/repro-*.sh` examp
 
 When writing `command` fields:
 
-1. **Always `cd` first**: `cd packages/<pkg> && pnpm test`, never `pnpm test` from root
+1. **Package tests must `cd` first**: `cd packages/<pkg> && pnpm test`; reserve root-level `pnpm run test:all` for the final implementation-plan regression gate
 2. **Use `&&` for sequential steps**: ensures early failure stops execution
 3. **Exit codes matter**: the command succeeds (exit 0) or fails (non-zero). Design accordingly.
 4. **No interactive commands**: everything must run non-interactively
@@ -196,16 +197,16 @@ tasks:
     command: "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after"
     dependencies: [fix-layout, add-visual-proof-test]
   - id: regression
-    description: "Final regression — re-run unit tests"
-    command: "cd packages/ui && pnpm test"
-    dependencies: [run-unit-tests, capture-visual-proof]
+    description: "Final regression — run the full repository test suite"
+    command: "pnpm run test:all"
+    dependencies: [add-visual-proof-test, fix-layout, run-unit-tests, capture-visual-proof]
 ```
 
 ## Anti-Patterns
 
 - **God task**: one `prompt` task that says "implement the whole feature" — split it up.
 - **Test-free plan**: every implementation task needs a corresponding verification. No exceptions.
-- **No final repro task**: implementation plans must end with a **command** task that re-runs the same reproduction as Phase 1b (`playbooks/verify-then-build.md` Phase 2).
+- **No final full-suite task**: implementation plans must end with a **command** task that runs `pnpm run test:all`.
 - **Circular dependencies**: task A depends on B, B depends on A — validator catches this but don't generate it.
 - **Phantom files**: referencing files that don't exist without a task to create them first.
 - **UI plan without visual proof tasks**: `visualProof: true` without the E2E test case task and capture task means no plan-specific screenshots are captured.

--- a/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
+++ b/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
@@ -23,6 +23,11 @@ fi
 awk -v warnDelegation="$warn_delegation" '
 function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
 function strip_quotes(s) { gsub(/["'\''"]/, "", s); return s }
+function normalize_command(s) {
+  s = trim(strip_quotes(s))
+  gsub(/[ \t]+/, " ", s)
+  return s
+}
 function parse_metadata(desc_lower,    tmp, parts) {
   layer = ""
   feature_state = ""
@@ -152,6 +157,8 @@ function flush_task(    wc, and_count, valid_id, d, desc_lower, idx) {
   task_feature_states[idx] = feature_state
   task_layer_exceptions[idx] = layer_exception_allowed
   task_dependencies[idx] = dependencies_csv
+  task_has_command[idx] = has_command
+  task_command_line[idx] = normalize_command(command_line)
   task_id_to_index[id] = idx
 }
 
@@ -305,6 +312,34 @@ END {
             errors[++errn] = "Task \"" task_ids[idx] "\" layer ordering violation: lower layer \"" cur_layer "\" depends on higher layer \"" dep_layer "\" via dependency \"" dep_id "\" (add \"Layer exception: allowed\" with rationale to override)"
           }
         }
+      }
+    }
+  }
+
+  if (enforce_layering == 1 && taskn > 0) {
+    final_idx = taskn
+    final_id = task_ids[final_idx]
+    final_command = task_command_line[final_idx]
+
+    if (task_has_command[final_idx] != 1) {
+      errors[++errn] = "Task \"" final_id "\" must be a command task because implementation plans require a final pnpm run test:all regression gate"
+    } else if (final_command != "pnpm run test:all") {
+      errors[++errn] = "Task \"" final_id "\" must be the final regression gate and run exactly \"pnpm run test:all\""
+    }
+
+    split(task_dependencies[final_idx], final_dep_ids, /,/)
+    delete final_dep_map
+    for (fdidx in final_dep_ids) {
+      dep_id = trim(final_dep_ids[fdidx])
+      if (dep_id != "") {
+        final_dep_map[dep_id] = 1
+      }
+    }
+
+    for (idx = 1; idx < final_idx; idx++) {
+      dep_id = task_ids[idx]
+      if (final_dep_map[dep_id] != 1) {
+        errors[++errn] = "Task \"" final_id "\" must depend on every earlier task; missing dependency on \"" dep_id "\""
       }
     }
   }

--- a/skills/plan-to-invoker/scripts/test-fixtures.sh
+++ b/skills/plan-to-invoker/scripts/test-fixtures.sh
@@ -8,6 +8,7 @@ VALIDATE_SCRIPT="$REPO_ROOT/skills/plan-to-invoker/scripts/validate-plan.sh"
 FIXTURES_DIR="$REPO_ROOT/skills/plan-to-invoker/fixtures"
 POSITIVE_DIR="$FIXTURES_DIR/positive"
 NEGATIVE_DIR="$FIXTURES_DIR/negative"
+LINT_SCRIPT="$REPO_ROOT/skills/plan-to-invoker/scripts/lint-task-atomicity.sh"
 
 fail() {
   echo "FAIL: $*" >&2
@@ -19,6 +20,7 @@ pass_count=0
 DOCTOR_NEGATIVE_FIXTURES=(
   "anti-pattern-g-monolithic-prompt-edit-bridge.yaml"
   "anti-pattern-h-layer-order-violation.yaml"
+  "anti-pattern-i-final-regression-not-test-all.yaml"
 )
 
 is_doctor_negative_fixture() {
@@ -266,6 +268,151 @@ test_stacked_basebranch_master() {
   return 0
 }
 
+test_lint_valid_final_test_all() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: "Valid final test-all gate"
+description: "Implementation plan with terminal full-suite regression"
+onFinish: pull_request
+mergeMode: github
+repoUrl: git@github.com:example-org/acme-repo.git
+tasks:
+  - id: implement-surface
+    description: |
+      Implement the contact surface wiring.
+      Layer: contact_surface
+      Feature state: active
+    prompt: |
+      Modify packages/foo/src/surface.ts and ensure the contract remains typed.
+      Acceptance criteria: ensure the new surface compiles and keeps existing imports intact.
+    dependencies: []
+  - id: add-regression-tests
+    description: |
+      Add regression coverage for the new surface.
+      Layer: app_regression
+      Feature state: active
+    prompt: |
+      Modify packages/foo/src/__tests__/surface.test.ts and ensure the regression covers the new path.
+      Acceptance criteria: verify the regression reproduces the new behavior deterministically.
+    dependencies: [implement-surface]
+  - id: final-regression
+    description: |
+      Run the repository test suite as the terminal regression gate.
+      Layer: e2e_regression
+      Feature state: active
+    command: "pnpm run test:all"
+    dependencies: [implement-surface, add-regression-tests]
+EOF
+
+  bash "$LINT_SCRIPT" "$temp_plan" >/dev/null
+}
+
+test_lint_rejects_non_test_all_final_gate() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: "Invalid final gate command"
+description: "Implementation plan with old package-scoped final regression"
+onFinish: pull_request
+mergeMode: github
+repoUrl: git@github.com:example-org/acme-repo.git
+tasks:
+  - id: implement-surface
+    description: |
+      Implement the contact surface wiring.
+      Layer: contact_surface
+      Feature state: active
+    prompt: |
+      Modify packages/foo/src/surface.ts and ensure the contract remains typed.
+      Acceptance criteria: ensure the new surface compiles and keeps existing imports intact.
+    dependencies: []
+  - id: final-regression
+    description: |
+      Re-run package tests only.
+      Layer: e2e_regression
+      Feature state: active
+    command: "cd packages/foo && pnpm test"
+    dependencies: [implement-surface]
+EOF
+
+  local output
+  set +e
+  output=$(bash "$LINT_SCRIPT" "$temp_plan" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Expected lint to reject non-test:all final gate" >&2
+    return 1
+  fi
+
+  if ! grep -q 'must be the final regression gate and run exactly "pnpm run test:all"' <<<"$output"; then
+    echo "Expected final gate command error, got: $output" >&2
+    return 1
+  fi
+}
+
+test_lint_rejects_final_gate_missing_dependencies() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: "Invalid final gate dependencies"
+description: "Implementation plan whose final regression does not depend on every earlier task"
+onFinish: pull_request
+mergeMode: github
+repoUrl: git@github.com:example-org/acme-repo.git
+tasks:
+  - id: implement-surface
+    description: |
+      Implement the contact surface wiring.
+      Layer: contact_surface
+      Feature state: active
+    prompt: |
+      Modify packages/foo/src/surface.ts and ensure the contract remains typed.
+      Acceptance criteria: ensure the new surface compiles and keeps existing imports intact.
+    dependencies: []
+  - id: add-regression-tests
+    description: |
+      Add regression coverage for the new surface.
+      Layer: app_regression
+      Feature state: active
+    prompt: |
+      Modify packages/foo/src/__tests__/surface.test.ts and ensure the regression covers the new path.
+      Acceptance criteria: verify the regression reproduces the new behavior deterministically.
+    dependencies: [implement-surface]
+  - id: final-regression
+    description: |
+      Run the repository test suite as the terminal regression gate.
+      Layer: e2e_regression
+      Feature state: active
+    command: "pnpm run test:all"
+    dependencies: [add-regression-tests]
+EOF
+
+  local output
+  set +e
+  output=$(bash "$LINT_SCRIPT" "$temp_plan" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Expected lint to reject missing final regression dependencies" >&2
+    return 1
+  fi
+
+  if ! grep -q 'must depend on every earlier task; missing dependency on "implement-surface"' <<<"$output"; then
+    echo "Expected missing dependency error, got: $output" >&2
+    return 1
+  fi
+}
+
 # Check dependencies
 if ! command -v jq &>/dev/null; then
   fail "jq is required for JSON parsing tests"
@@ -273,6 +420,10 @@ fi
 
 if [[ ! -f "$VALIDATE_SCRIPT" ]]; then
   fail "Validator script not found: $VALIDATE_SCRIPT"
+fi
+
+if [[ ! -f "$LINT_SCRIPT" ]]; then
+  fail "Lint script not found: $LINT_SCRIPT"
 fi
 
 if [[ ! -d "$POSITIVE_DIR" ]]; then
@@ -324,6 +475,9 @@ run_test "Edge: empty_required_field for tasks" test_edge_empty_tasks
 run_test "Edge: invalid_dependency_reference" test_edge_invalid_dependency
 run_test "Edge: unrendered_template_placeholder" test_unrendered_template_placeholder
 run_test "Edge: stacked_basebranch_default" test_stacked_basebranch_master
+run_test "Lint: valid final pnpm run test:all gate" test_lint_valid_final_test_all
+run_test "Lint: reject non-test:all final gate" test_lint_rejects_non_test_all_final_gate
+run_test "Lint: reject final gate missing dependencies" test_lint_rejects_final_gate_missing_dependencies
 
 echo ""
 echo "========================================="


### PR DESCRIPTION
## Summary

Require submitted implementation plans to end with `pnpm run test:all` instead of treating package-scoped `pnpm test` as the terminal verification step.

This updates the Slack planning prompt, adds a hard `lint-task-atomicity.sh` rule that rejects implementation plans whose last task is not exactly `pnpm run test:all`, and aligns the plan-to-invoker docs, example plans, and fixtures with that policy. It also adds negative coverage for the old behavior and direct lint tests for the new final-gate contract.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh`
- [x] `pnpm --filter @invoker/surfaces test -- src/__tests__/plan-conversation.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 446b46a5`
- Post-revert steps: None
- Data migration? No
