### PR TITLE
Stacked divergence remediation 12 API detach command path

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -75,6 +75,7 @@ let mocks: {
   cancelWorkflow: ReturnType<typeof vi.fn>;
   killRunningTask: ReturnType<typeof vi.fn>;
   deleteWorkflow: ReturnType<typeof vi.fn>;
+  detachWorkflow: ReturnType<typeof vi.fn>;
 };
 
 function createMocks() {
@@ -131,6 +132,7 @@ function createMocks() {
     cancelWorkflow: vi.fn().mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] }),
     killRunningTask: vi.fn().mockResolvedValue(undefined),
     deleteWorkflow: vi.fn().mockResolvedValue(undefined),
+    detachWorkflow: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -147,6 +149,7 @@ beforeAll(async () => {
     cancelWorkflow: mocks.cancelWorkflow,
     killRunningTask: mocks.killRunningTask,
     deleteWorkflow: mocks.deleteWorkflow,
+    detachWorkflow: mocks.detachWorkflow,
   });
   // Wait for the server to start listening
   await new Promise<void>((resolve) => {
@@ -176,6 +179,7 @@ beforeEach(() => {
   mocks.cancelWorkflow.mockClear();
   mocks.killRunningTask.mockClear();
   mocks.deleteWorkflow.mockClear();
+  mocks.detachWorkflow.mockClear();
 
   // Re-apply default return values after clear
   mocks.orchestrator.getWorkflowStatus.mockReturnValue({ total: 1, completed: 0, failed: 0, running: 1, pending: 0 });
@@ -1001,7 +1005,7 @@ describe('POST /api/workflows/:id/detach', () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('detached');
-    expect(mocks.orchestrator.detachWorkflow).toHaveBeenCalledWith('wf-1', 'wf-0');
+    expect(mocks.detachWorkflow).toHaveBeenCalledWith('wf-1', 'wf-0');
   });
 
   it('returns 400 when upstreamWorkflowId is missing', async () => {

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -74,6 +74,7 @@ export interface ApiServerDeps {
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   deleteWorkflow: (workflowId: string) => Promise<void>;
+  detachWorkflow: (workflowId: string, upstreamWorkflowId: string) => Promise<void>;
 }
 
 export interface ApiServer {
@@ -159,6 +160,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     cancelTask,
     cancelWorkflow,
     deleteWorkflow,
+    detachWorkflow,
   } = deps;
   const port = parseInt(process.env.INVOKER_API_PORT ?? '4100', 10);
 
@@ -705,7 +707,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "upstreamWorkflowId" in request body' });
             return;
           }
-          orchestrator.detachWorkflow(workflowId, String(upstreamWorkflowId));
+          await detachWorkflow(workflowId, String(upstreamWorkflowId));
           json(res, 200, {
             ok: true,
             workflowId,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1601,6 +1601,14 @@ if (isHeadless) {
     logger.info(`performDeleteWorkflow end workflow="${workflowId}"`, { module: 'kill' });
   }
 
+  async function performDetachWorkflow(workflowId: string, upstreamWorkflowId: string): Promise<void> {
+    logger.info(`performDetachWorkflow begin workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
+    const envelope = makeEnvelope('detach-workflow', 'ui', 'workflow', { workflowId, upstreamWorkflowId });
+    const result = await commandService.detachWorkflow(envelope);
+    if (!result.ok) throw new Error(result.error.message);
+    logger.info(`performDetachWorkflow end workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
+  }
+
   /** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
   const preemptSkipCodes: ReadonlySet<string> = new Set([
     OrchestratorErrorCode.TASK_NOT_FOUND,
@@ -2303,6 +2311,7 @@ if (isHeadless) {
         cancelTask: performCancelTask,
         cancelWorkflow: performCancelWorkflow,
         deleteWorkflow: performDeleteWorkflow,
+        detachWorkflow: performDetachWorkflow,
       });
       recordStartupMark('api-server.started');
 


### PR DESCRIPTION
## Summary

Route API detach through the command-path mutation flow rather than direct orchestrator wiring. That brings detach under the same envelope, mutation routing, and response semantics already used by the other runtime surfaces, and closes the last divergent runtime path in this remediation stack.
## Architecture

### Before

```mermaid
graph TD
    A[API detach command] --> B[detach-specific API path]
    B --> C[workflow detach mutation]
```

### After

```mermaid
graph TD
    A[API detach command] --> B[shared lifecycle bridge]
    B --> C[workflow detach mutation]
```

## Test Plan

- [ ] cd packages/app && pnpm test exits 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #321