### PR TITLE
Stacked divergence remediation 14 API reject command path

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -641,6 +641,40 @@ describe('POST /api/tasks/:id/reject', () => {
     expect(mocks.orchestrator.cancelTask).not.toHaveBeenCalled();
     expect(mocks.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
   });
+
+  it('uses rejectTaskAction when provided', async () => {
+    const rejectTaskAction = vi.fn().mockResolvedValue(undefined);
+    const isolatedApi = startApiServer({
+      orchestrator: mocks.orchestrator as any,
+      persistence: mocks.persistence as any,
+      executorRegistry: mocks.executorRegistry as any,
+      taskExecutor: mocks.taskExecutor as any,
+      rejectTaskAction,
+      cancelTask: mocks.cancelTask,
+      cancelWorkflow: mocks.cancelWorkflow,
+      killRunningTask: mocks.killRunningTask,
+      deleteWorkflow: mocks.deleteWorkflow,
+      detachWorkflow: mocks.detachWorkflow,
+    });
+    await new Promise<void>((resolve) => {
+      if (isolatedApi.server.listening) {
+        resolve();
+      } else {
+        isolatedApi.server.on('listening', resolve);
+      }
+    });
+    const addr = isolatedApi.server.address();
+    const isolatedPort = typeof addr === 'object' && addr ? addr.port : isolatedApi.port;
+
+    try {
+      const res = await request(isolatedPort, 'POST', '/api/tasks/task-1/reject', { reason: 'bad' });
+      expect(res.status).toBe(200);
+      expect(rejectTaskAction).toHaveBeenCalledWith('task-1', 'bad');
+      expect(mocks.orchestrator.reject).not.toHaveBeenCalled();
+    } finally {
+      await isolatedApi.close();
+    }
+  });
 });
 
 describe('POST /api/tasks/:id/input', () => {

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -70,6 +70,7 @@ export interface ApiServerDeps {
   taskExecutor: TaskRunner;
   autoApproveAIFixes?: boolean;
   approveTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
+  rejectTaskAction?: (taskId: string, reason?: string) => Promise<void>;
   killRunningTask?: (taskId: string) => Promise<void>;
   cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
   cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
@@ -156,6 +157,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     taskExecutor,
     autoApproveAIFixes,
     approveTaskAction,
+    rejectTaskAction,
     killRunningTask,
     cancelTask,
     cancelWorkflow,
@@ -374,7 +376,11 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               reason = parsed.reason;
             } catch { /* not JSON, ignore */ }
           }
-          sharedRejectTask(taskId, { orchestrator }, reason);
+          if (rejectTaskAction) {
+            await rejectTaskAction(taskId, reason);
+          } else {
+            sharedRejectTask(taskId, { orchestrator }, reason);
+          }
           json(res, 200, { ok: true, taskId, action: 'rejected', reason });
         } catch (err) {
           json(res, 400, { error: err instanceof Error ? err.message : String(err) });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2306,6 +2306,14 @@ if (isHeadless) {
             return { started };
           });
         },
+        rejectTaskAction: async (taskId: string, reason?: string) => {
+          const workflowId = orchestrator.getTask(taskId)?.config.workflowId;
+          await runWorkflowMutation(workflowId, 'normal', 'api:reject-task', [taskId, reason], async () => {
+            const envelope = makeEnvelope('reject', 'surface', 'task', { taskId, reason });
+            const result = await commandService.reject(envelope);
+            if (!result.ok) throw new Error(result.error.message);
+          });
+        },
         killRunningTask,
         cancelTask: performCancelTask,
         cancelWorkflow: performCancelWorkflow,
@@ -2495,6 +2503,13 @@ if (isHeadless) {
       });
       workflowMutationDispatcher.set('api:approve-task', async (taskIdArg: unknown) => {
         await performSharedApproveTask(String(taskIdArg), 'api');
+      });
+      workflowMutationDispatcher.set('api:reject-task', async (taskIdArg: unknown, reasonArg?: unknown) => {
+        const taskId = String(taskIdArg);
+        const reason = reasonArg === undefined ? undefined : String(reasonArg);
+        const envelope = makeEnvelope('reject', 'surface', 'task', { taskId, reason });
+        const result = await commandService.reject(envelope);
+        if (!result.ok) throw new Error(result.error.message);
       });
       workflowMutationDispatcher.set('surface:approve-task', async (taskIdArg: unknown) => {
         await performSharedApproveTask(String(taskIdArg), 'surface');


### PR DESCRIPTION
## Summary

Move API reject handling onto the shared command and facade path instead of bespoke API-side orchestration. Reject mutations now follow the same routing and error-handling rules as the other surfaces.
## Architecture

### Before

```mermaid
graph TD
    A[API reject command] --> B[reject-specific API path]
    B --> C[workflow reject mutation]
```

### After

```mermaid
graph TD
    A[API reject command] --> B[shared lifecycle bridge]
    B --> C[workflow reject mutation]
```

## Test Plan

- [ ] cd packages/app && pnpm test exits 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #323