### PR TITLE
Stacked divergence remediation 20 delete all process shutdown policy

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -32,7 +32,12 @@ import {
   buildCancelInFlight,
   buildInvalidationDeps,
   selectFailureRecoveryRoute,
+  deleteAllWorkflows,
 } from '../workflow-actions.js';
+
+vi.mock('../delete-all-snapshot.js', () => ({
+  createDeleteAllSnapshot: () => '/tmp/fake-snapshot',
+}));
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -1942,5 +1947,64 @@ describe('buildInvalidationDeps', () => {
     expect(orchestrator.cancelTask.mock.invocationCallOrder[0]).toBeLessThan(
       taskExecutor.killActiveExecution.mock.invocationCallOrder[0],
     );
+  });
+});
+
+describe('deleteAllWorkflows', () => {
+  it('kills running and fixing_with_ai tasks before purging', async () => {
+    const orchestrator = {
+      getAllTasks: vi.fn(() => [
+        makeTask({ id: 'r1', status: 'running' }),
+        makeTask({ id: 'f1', status: 'fixing_with_ai' }),
+        makeTask({ id: 'p1', status: 'pending' }),
+        makeTask({ id: 'c1', status: 'completed' }),
+      ]),
+      deleteAllWorkflows: vi.fn(),
+    };
+    const taskExecutor = {
+      killActiveExecution: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await deleteAllWorkflows({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    // Only running and fixing_with_ai tasks should be killed
+    expect(taskExecutor.killActiveExecution).toHaveBeenCalledTimes(2);
+    expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('r1');
+    expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('f1');
+    // Kills happen before deleteAllWorkflows
+    expect(taskExecutor.killActiveExecution.mock.invocationCallOrder[0]).toBeLessThan(
+      orchestrator.deleteAllWorkflows.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('proceeds without killing when taskExecutor is not provided', async () => {
+    const orchestrator = {
+      getAllTasks: vi.fn(() => [makeTask({ id: 'r1', status: 'running' })]),
+      deleteAllWorkflows: vi.fn(),
+    };
+
+    await deleteAllWorkflows({
+      orchestrator: orchestrator as unknown as Orchestrator,
+    });
+
+    expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    // getAllTasks should not be called when there's no taskExecutor
+    expect(orchestrator.getAllTasks).not.toHaveBeenCalled();
+  });
+
+  it('returns snapshot path from createDeleteAllSnapshot', async () => {
+    const orchestrator = {
+      getAllTasks: vi.fn(() => []),
+      deleteAllWorkflows: vi.fn(),
+    };
+
+    const result = await deleteAllWorkflows({
+      orchestrator: orchestrator as unknown as Orchestrator,
+    });
+
+    expect(result.snapshotPath).toBe('/tmp/fake-snapshot');
   });
 });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -759,7 +759,7 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'delete-all':
       assertDeleteAllEnabled();
       {
-        const { snapshotPath } = sharedDeleteAllWorkflows({
+        const { snapshotPath } = await sharedDeleteAllWorkflows({
           logger: deps.logger,
           orchestrator: deps.orchestrator,
         });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2838,7 +2838,7 @@ if (isHeadless) {
     registerGuiMutationHandler('invoker:delete-all-workflows', async () => {
       logger.info('delete-all-workflows', { module: 'ipc' });
       assertDeleteAllEnabled();
-      sharedDeleteAllWorkflows({ logger, orchestrator });
+      await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
       lastKnownTaskStates.clear();
       lastKnownWorkflowCount = 0;

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -171,16 +171,18 @@ export function cancelWorkflow(
  * share a single code path:
  *
  *   1. Create a DB snapshot (safety net — callers can abort on failure).
- *   2. Delegate to `orchestrator.deleteAllWorkflows()` which handles
+ *   2. Kill all running/fixing_with_ai executor processes so no
+ *      orphaned child processes survive the purge.
+ *   3. Delegate to `orchestrator.deleteAllWorkflows()` which handles
  *      DB purge → scheduler kill → memory clear → removal deltas.
  *
  * Returns the snapshot path (or null when the DB file does not yet
  * exist) so callers can log it through their own channel (stderr,
  * structured logger, etc.).
  */
-export function deleteAllWorkflows(
-  deps: Pick<ActionDeps, 'logger' | 'orchestrator'>,
-): { snapshotPath: string | null } {
+export async function deleteAllWorkflows(
+  deps: Pick<ActionDeps, 'logger' | 'orchestrator' | 'taskExecutor'>,
+): Promise<{ snapshotPath: string | null }> {
   const snapshotPath = createDeleteAllSnapshot();
   deps.logger?.info(
     snapshotPath
@@ -188,6 +190,23 @@ export function deleteAllWorkflows(
       : 'delete-all-workflows snapshot skipped: DB file does not exist yet',
     { module: 'workflow' },
   );
+
+  // Kill executor processes for all running/fixing_with_ai tasks before
+  // the destructive purge.  Process management is outside orchestrator
+  // scope (same convention as performDeleteWorkflow in main.ts), so we
+  // handle it here in the shared bridge.
+  const taskExecutor = deps.taskExecutor;
+  if (taskExecutor) {
+    const allTasks = deps.orchestrator.getAllTasks();
+    const active = allTasks.filter(
+      (t) => t.status === 'running' || t.status === 'fixing_with_ai',
+    );
+    for (const task of active) {
+      deps.logger?.info(`delete-all: killing active task "${task.id}"`, { module: 'kill' });
+      await taskExecutor.killActiveExecution(task.id);
+    }
+  }
+
   deps.orchestrator.deleteAllWorkflows();
   return { snapshotPath };
 }


### PR DESCRIPTION
## Summary

Define the process-shutdown policy that must run before delete-all proceeds, and enforce it in the shared workflow actions, headless, and main entrypoints. The goal is to prevent destructive bulk deletion from leaving running or fixing executions orphaned.
## Architecture

### Before

```mermaid
graph TD
    DeleteAll[Delete-all mutation] --> Shutdown[Implicit process shutdown behavior]
    Shutdown --> Process[Runtime processes]
```

### After

```mermaid
graph TD
    DeleteAll --> Policy[Explicit shutdown policy]
    Policy --> Process
    Policy --> Queue[Coordinated workflow cleanup]
```

## Test Plan

- [ ] cd packages/app && pnpm test exits 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #329