### PR TITLE
Stacked divergence remediation 21 mutation fence delete all contract

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -894,4 +894,207 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(evictedIntent?.error).toContain('queue fence');
     gate.resolve();
   });
+
+  it('invalidates an older running workflow intent when internal delete-all-workflows is enqueued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const deleteAll = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:delete-all-workflows',
+      [],
+    );
+    await deleteAll;
+    await expect(olderRunning).rejects.toThrow(/superseded by delete intent/i);
+
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intents.find((intent) => intent.id === 1)?.status).toBe('failed');
+    expect(intents.find((intent) => intent.id === 1)?.error).toContain('Superseded by delete intent #2');
+    expect(intents.find((intent) => intent.id === 2)?.status).toBe('completed');
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:delete-all-workflows:undefined',
+    ]);
+  });
+
+  it('evicts older queued workflow intents when internal delete-all-workflows fence starts', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/blocker-task', null]);
+    void running.catch(() => {});
+    const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['old-queued']);
+    void olderQueued.catch(() => {});
+    const deleteAll = coordinator.enqueue<void>('wf-1', 'high', 'invoker:delete-all-workflows', []);
+    const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['new-queued']);
+
+    await deleteAll;
+    await newerQueued;
+    await expect(running).rejects.toThrow(/superseded by delete intent/i);
+    await expect(olderQueued).rejects.toThrow(/evicted/i);
+
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:delete-all-workflows:undefined',
+      'invoker:edit-task-agent:new-queued',
+    ]);
+  });
+
+  it('invalidates an older running workflow intent when delegated headless delete-all is enqueued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (_channel, args) => {
+        const payload = args[0] as { args?: string[] } | undefined;
+        const command = payload?.args?.join(' ') ?? String(args[0]);
+        order.push(command);
+        if (command.includes('hold-work')) {
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'headless.exec',
+      [{ args: ['set', 'command', 'wf-1/task-0', 'hold-work'] }],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const deleteAllExec = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'headless.exec',
+      [{ args: ['delete-all'] }],
+    );
+    await deleteAllExec;
+    await expect(olderRunning).rejects.toThrow(/superseded by delete intent/i);
+
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intents.find((intent) => intent.id === 1)?.status).toBe('failed');
+    expect(intents.find((intent) => intent.id === 1)?.error).toContain('Superseded by delete intent #2');
+    expect(intents.find((intent) => intent.id === 2)?.status).toBe('completed');
+    expect(order).toEqual([
+      'set command wf-1/task-0 hold-work',
+      'delete-all',
+    ]);
+  });
+
+  it('evicts older queued workflow intents when delegated headless delete-all fence starts', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (_channel, args) => {
+        const payload = args[0] as { args?: string[] } | undefined;
+        const command = payload?.args?.join(' ') ?? 'unknown';
+        order.push(command);
+        if (command.includes('hold-work')) {
+          await gate.promise;
+        }
+      },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'headless.exec', [{ args: ['set', 'command', 'wf-1/task-0', 'hold-work'] }]);
+    void running.catch(() => {});
+    const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'headless.exec', [{ args: ['set', 'agent', 'wf-1/task-1', 'codex'] }]);
+    void olderQueued.catch(() => {});
+    const deleteAllFence = coordinator.enqueue<void>('wf-1', 'high', 'headless.exec', [{ args: ['delete-all'] }]);
+    const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'headless.exec', [{ args: ['set', 'agent', 'wf-1/task-2', 'claude'] }]);
+
+    await Promise.resolve();
+    await deleteAllFence;
+    await newerQueued;
+    await expect(running).rejects.toThrow(/superseded by delete intent/i);
+    await expect(olderQueued).rejects.toThrow(/evicted/i);
+
+    expect(order).toEqual([
+      'set command wf-1/task-0 hold-work',
+      'delete-all',
+      'set agent wf-1/task-2 claude',
+    ]);
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    const evictedIntent = intents.find((intent) => Array.isArray(intent.args) && JSON.stringify(intent.args).includes('wf-1/task-1'));
+    const invalidatedIntent = intents.find((intent) => intent.id === 1);
+    expect(invalidatedIntent?.status).toBe('failed');
+    expect(invalidatedIntent?.error).toContain('Superseded by delete intent #3');
+    expect(evictedIntent?.status).toBe('failed');
+    expect(evictedIntent?.error).toContain('queue fence');
+    gate.resolve();
+  });
 });

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -306,7 +306,7 @@ export class PersistedWorkflowMutationCoordinator {
     ) {
       return 'recreate';
     }
-    if (channel === 'invoker:delete-workflow') {
+    if (channel === 'invoker:delete-workflow' || channel === 'invoker:delete-all-workflows') {
       return 'delete';
     }
     if (channel !== 'headless.exec') {
@@ -317,7 +317,7 @@ export class PersistedWorkflowMutationCoordinator {
     if (rawArgs[0] === 'recreate' || rawArgs[0] === 'recreate-task') {
       return 'recreate';
     }
-    if (rawArgs[0] === 'delete' || rawArgs[0] === 'delete-workflow') {
+    if (rawArgs[0] === 'delete' || rawArgs[0] === 'delete-workflow' || rawArgs[0] === 'delete-all') {
       return 'delete';
     }
     return null;
@@ -330,6 +330,7 @@ export class PersistedWorkflowMutationCoordinator {
       || intent.channel === 'invoker:recreate-task'
       || intent.channel === 'invoker:recreate-with-rebase'
       || intent.channel === 'invoker:delete-workflow'
+      || intent.channel === 'invoker:delete-all-workflows'
     ) {
       return true;
     }
@@ -343,7 +344,7 @@ export class PersistedWorkflowMutationCoordinator {
     if (command === 'recreate-task') {
       return true;
     }
-    if (command === 'delete' || command === 'delete-workflow') {
+    if (command === 'delete' || command === 'delete-workflow' || command === 'delete-all') {
       return true;
     }
     const isWorkflowId = /^wf-[^/]+$/.test(target);


### PR DESCRIPTION
## Summary

Teach the persisted workflow mutation coordinator about delete-all as a fenced mutation intent so it participates in queue ordering and drain coordination explicitly. Bulk destructive work no longer bypasses the same serialization guarantees used for workflow-scoped operations.
## Architecture

### Before

```mermaid
graph TD
    A[Delete-all mutation callers] --> B[unfenced delete-all mutation path]
    B --> C[coordinated delete-all execution]
```

### After

```mermaid
graph TD
    A[Delete-all mutation callers] --> B[delete-all mutation fence]
    B --> C[coordinated delete-all execution]
```

## Test Plan

- [ ] cd packages/app && pnpm test exits 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #330