### PR TITLE
Stacked divergence remediation 24 remove message includes not found

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -7,6 +7,7 @@
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import http from 'node:http';
 import { startApiServer, type ApiServer } from '../api-server.js';
+import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -972,7 +973,7 @@ describe('POST /api/workflows/:id/fork', () => {
 
   it('returns an error status when forkWorkflow throws', async () => {
     mocks.orchestrator.forkWorkflow.mockImplementationOnce(() => {
-      throw new Error('Workflow missing not found');
+      throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, 'Workflow missing not found');
     });
     const res = await request(port, 'POST', '/api/workflows/missing/fork');
     expect(res.status).toBe(404);
@@ -1024,7 +1025,7 @@ describe('DELETE /api/workflows/:id', () => {
   });
 
   it('returns 404 when workflow not found', async () => {
-    mocks.deleteWorkflow.mockRejectedValue(new Error('workflow not found'));
+    mocks.deleteWorkflow.mockRejectedValue(new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, 'workflow not found'));
     const res = await request(port, 'DELETE', '/api/workflows/missing');
     expect(res.status).toBe(404);
     expect(res.body.error).toBe('workflow not found');

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -160,8 +160,6 @@ function httpStatusForError(err: unknown): number {
   }
   if (err instanceof PlanConflictError) return 409;
   if (err instanceof TopologyForkRequired) return 409;
-  // Fallback for errors not yet migrated to OrchestratorError.
-  if (err instanceof Error && err.message.includes('not found')) return 404;
   return 400;
 }
 

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -14,6 +14,7 @@ import type {
   InvalidationScope,
   TaskState,
 } from '@invoker/workflow-core';
+import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
@@ -47,7 +48,7 @@ export function bumpGenerationAndRecreate(
 ): TaskState[] {
   const { persistence, orchestrator } = deps;
   const workflow = persistence.loadWorkflow(workflowId);
-  if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
   const nextGen = (workflow.generation ?? 0) + 1;
   persistence.updateWorkflow(workflowId, { generation: nextGen });
   deps.logger?.info(`bumped generation to ${nextGen} for ${workflowId}`, { module: 'workflow' });
@@ -257,7 +258,7 @@ export async function recreateWorkflowFromFreshBase(
   deps: ActionDeps,
 ): Promise<TaskState[]> {
   const workflow = deps.persistence.loadWorkflow(workflowId);
-  if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
   const nextGen = (workflow.generation ?? 0) + 1;
   deps.persistence.updateWorkflow(workflowId, { generation: nextGen });
   deps.logger?.info(
@@ -323,7 +324,7 @@ export async function rebaseAndRetry(
   deps: ActionDeps,
 ): Promise<TaskState[]> {
   const task = deps.orchestrator.getTask(taskId);
-  if (!task?.config.workflowId) throw new Error(`Task ${taskId} not found or has no workflow`);
+  if (!task?.config.workflowId) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found or has no workflow`);
   const workflowId = task.config.workflowId;
   deps.logger?.info(
     `rebaseAndRetry: taskId=${taskId} workflowId=${workflowId} → recreateWorkflowFromFreshBase (Step 12 delegate)`,
@@ -637,7 +638,7 @@ export async function fixWithAgentAction(
 ): Promise<FixWithAgentActionResult> {
   const { orchestrator, persistence, taskExecutor } = deps;
   const task = orchestrator.getTask(taskId);
-  if (!task) throw new Error(`Task ${taskId} not found`);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
   const savedError = task.execution.error ?? '';
   const recoveryRoute = options.recoveryRoute ?? selectFailureRecoveryRoute(task, savedError);

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -12,6 +12,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import type { Orchestrator } from '@invoker/workflow-core';
+import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { cleanElectronEnv } from './process-utils.js';
 import type { ExecutionAgent } from './agent.js';
@@ -172,7 +173,7 @@ export async function resolveConflictImpl(
     hasSavedError: savedError !== undefined,
   });
   const task = host.orchestrator.getTask(taskId);
-  if (!task) throw new Error(`Task ${taskId} not found`);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
   if (task.status !== 'failed' && task.status !== 'running' && task.status !== 'fixing_with_ai') {
     throw new Error(`Task ${taskId} is not in a resolvable state (status: ${task.status})`);
   }
@@ -444,7 +445,7 @@ export async function fixWithAgentImpl(
     outputLength: taskOutput.length,
   });
   const task = host.orchestrator.getTask(taskId);
-  if (!task) throw new Error(`Task ${taskId} not found`);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
   if (task.status !== 'failed' && task.status !== 'running' && task.status !== 'fixing_with_ai') {
     throw new Error(`Task ${taskId} is not in a fixable state (status: ${task.status})`);
   }

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -11,6 +11,7 @@ import { homedir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 
 import type { Orchestrator, TaskState, TaskStateChanges } from '@invoker/workflow-core';
+import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkResponse } from '@invoker/contracts';
 import type { TaskRunnerCallbacks } from './task-runner.js';
@@ -584,7 +585,7 @@ export async function approveMergeImpl(
 ): Promise<void> {
   mergeTrace('APPROVE_MERGE_ENTER', { workflowId });
   const workflow = host.persistence.loadWorkflow(workflowId);
-  if (!workflow) throw new Error(`Workflow ${workflowId} not found`);
+  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
 
   const onFinish = workflow.onFinish ?? 'none';
   const baseBranch = workflow.baseBranch ?? host.defaultBranch ?? await host.detectDefaultBranch();

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -723,7 +723,7 @@ export class Orchestrator {
   ): TaskState {
     const existing = this.stateGetTask(taskId);
     if (!existing) {
-      throw new Error(`writeAndSync: task ${taskId} not found in graph`);
+      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `writeAndSync: task ${taskId} not found in graph`);
     }
     const id = existing.id;
     this.taskRepository.updateTask(id, changes);
@@ -1598,7 +1598,7 @@ export class Orchestrator {
   setFixAwaitingApproval(taskId: string, originalError: string): void {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     const tid = task.id;
     if (task.status !== 'running' && task.status !== 'fixing_with_ai') {
       throw new Error(`Task ${tid} is not running or fixing with AI (status: ${task.status})`);
@@ -2013,7 +2013,7 @@ export class Orchestrator {
   retryTask(taskId: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     const id = task.id;
 
     // Step 18 (`docs/architecture/task-invalidation-roadmap.md`,
@@ -2213,7 +2213,7 @@ export class Orchestrator {
   recreateTask(taskId: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
     const rootId = task.id;
 
@@ -2486,7 +2486,7 @@ export class Orchestrator {
   beginConflictResolution(taskId: string): { savedError: string } {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
 
     const savedError = task.execution.error ?? '';
@@ -2536,7 +2536,7 @@ export class Orchestrator {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) {
-      throw new Error(`Task ${taskId} not found`);
+      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     }
     const id = task.id;
 
@@ -2571,7 +2571,7 @@ export class Orchestrator {
   editTaskCommand(taskId: string, newCommand: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot edit merge node ${taskId}`);
 
     if (task.status === 'running' || task.status === 'fixing_with_ai') {
@@ -2591,7 +2591,7 @@ export class Orchestrator {
     editTaskPrompt(taskId: string, newPrompt: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot edit merge node ${taskId}`);
 
     if (task.status === 'running' || task.status === 'fixing_with_ai') {
@@ -2611,7 +2611,7 @@ export class Orchestrator {
     editTaskType(taskId: string, executorType: string, remoteTargetId?: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot change executor type of merge node ${taskId}`);
 
     const effectiveType = normalizeExecutorType(executorType) ?? executorType;
@@ -2660,7 +2660,7 @@ export class Orchestrator {
     editTaskAgent(taskId: string, agentName: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot change execution agent of merge node ${taskId}`);
 
     if (task.status === 'running' || task.status === 'fixing_with_ai') {
@@ -2769,7 +2769,7 @@ export class Orchestrator {
   ): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (!task.config.isMergeNode) {
       throw new Error(`Task ${taskId} is not a merge node`);
     }
@@ -2906,7 +2906,7 @@ export class Orchestrator {
   ): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) {
       throw new Error(`Cannot edit fix context of merge node ${taskId}`);
     }
@@ -3005,7 +3005,7 @@ export class Orchestrator {
   setTaskExternalGatePolicies(taskId: string, updates: ExternalGatePolicyUpdate[]): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.status === 'running' || task.status === 'fixing_with_ai') {
       throw new Error(`Cannot edit running task ${taskId}`);
     }
@@ -3065,7 +3065,7 @@ export class Orchestrator {
       .getAllTasks()
       .filter((t) => t.config.workflowId === workflowId);
     if (sourceTasks.length === 0) {
-      throw new Error(`forkWorkflow: workflow ${workflowId} not found (no tasks)`);
+      throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `forkWorkflow: workflow ${workflowId} not found (no tasks)`);
     }
 
     this.cancelWorkflow(workflowId);
@@ -3189,7 +3189,7 @@ export class Orchestrator {
   replaceTask(taskId: string, replacementTasks: TaskReplacementDef[]): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
-    if (!task) throw new Error(`Task ${taskId} not found`);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.status === 'running' || task.status === 'fixing_with_ai') throw new Error(`Cannot replace running task ${taskId}`);
     if (replacementTasks.length === 0) throw new Error('Must provide at least one replacement task');
 
@@ -3924,7 +3924,7 @@ export class Orchestrator {
   ): TaskState[] {
     const existing = this.stateGetTask(taskId);
     if (!existing) {
-      throw new Error(`finalizeFailedTask: task ${taskId} not found in graph`);
+      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `finalizeFailedTask: task ${taskId} not found in graph`);
     }
 
     const changes: TaskStateChanges = {
@@ -4364,7 +4364,7 @@ export class Orchestrator {
       (task) => task.config.workflowId === workflowId,
     );
     if (targetTasks.length === 0) {
-      throw new Error(`Workflow ${workflowId} not found`);
+      throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
     }
 
     let removedDependency = false;


### PR DESCRIPTION
## Summary

Remove remaining `message.includes('not found')` style HTTP mapping and replace it with typed domain-error handling through the API and workflow stack. Not-found and related response cases become resilient to wording changes in lower-layer error messages.
## Architecture

### Before

```mermaid
graph TD
    A[Remove flows] --> B[message-substring not-found checks]
    B --> C[Callers]
```

### After

```mermaid
graph TD
    A[Remove flows] --> B[typed not-found handling without message parsing]
    B --> C[Callers]
```

## Test Plan

- [ ] cd packages/app && pnpm test exits 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #333