### PR TITLE
Stacked divergence remediation 25 workflow mutation facade extraction

### DIFF
--- a/packages/app/src/__tests__/workflow-mutation-facade.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-facade.test.ts
@@ -1,0 +1,302 @@
+/**
+ * Unit tests for WorkflowMutationFacade.
+ *
+ * Verifies that the facade correctly wires shared actions to the
+ * dispatch + topup lifecycle.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Orchestrator } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { TaskRunner } from '@invoker/execution-engine';
+import { WorkflowMutationFacade, type WorkflowMutationFacadeDeps } from '../workflow-mutation-facade.js';
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeTask(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'task-a',
+    status: 'pending' as const,
+    description: 'test task',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { workflowId: 'wf-1' },
+    execution: {},
+    ...overrides,
+  };
+}
+
+function makeRunningTask(overrides: Record<string, unknown> = {}) {
+  return makeTask({ status: 'running', ...overrides });
+}
+
+function makeDeps(overrides: Partial<WorkflowMutationFacadeDeps> = {}): WorkflowMutationFacadeDeps {
+  return {
+    orchestrator: {
+      retryTask: vi.fn(() => [makeRunningTask()]),
+      recreateTask: vi.fn(() => [makeRunningTask()]),
+      cancelTask: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: [] })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: ['task-a'], runningCancelled: ['task-a'] })),
+      deleteWorkflow: vi.fn(),
+      detachWorkflow: vi.fn(),
+      forkWorkflow: vi.fn(() => ({
+        forkedWorkflowId: 'wf-fork',
+        sourceWorkflowId: 'wf-1',
+        started: [makeRunningTask({ id: 'fork-t1' })],
+      })),
+      editTaskCommand: vi.fn(() => [makeRunningTask()]),
+      editTaskPrompt: vi.fn(() => [makeRunningTask()]),
+      editTaskType: vi.fn(() => [makeRunningTask()]),
+      editTaskAgent: vi.fn(() => [makeRunningTask()]),
+      setTaskExternalGatePolicies: vi.fn(() => []),
+      selectExperiment: vi.fn(() => [makeRunningTask()]),
+      approve: vi.fn(async () => [makeRunningTask()]),
+      reject: vi.fn(),
+      provideInput: vi.fn(),
+      getTask: vi.fn(),
+      getAllTasks: vi.fn(() => []),
+      startExecution: vi.fn(() => []),
+      retryWorkflow: vi.fn(() => [makeRunningTask()]),
+      recreateWorkflow: vi.fn(() => [makeRunningTask()]),
+    } as unknown as Orchestrator,
+    persistence: {
+      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1 })),
+      updateWorkflow: vi.fn(),
+      loadTasks: vi.fn(() => []),
+    } as unknown as SQLiteAdapter,
+    taskExecutor: {
+      executeTasks: vi.fn(),
+      killActiveExecution: vi.fn(),
+    } as unknown as TaskRunner,
+    ...overrides,
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe('WorkflowMutationFacade', () => {
+  let deps: WorkflowMutationFacadeDeps;
+  let facade: WorkflowMutationFacade;
+
+  beforeEach(() => {
+    deps = makeDeps();
+    facade = new WorkflowMutationFacade(deps);
+  });
+
+  describe('retryTask', () => {
+    it('calls orchestrator.retryTask and dispatches runnable tasks', async () => {
+      const result = await facade.retryTask('task-a');
+
+      expect(deps.orchestrator.retryTask).toHaveBeenCalledWith('task-a');
+      expect(result.started).toHaveLength(1);
+      expect(result.started[0].status).toBe('running');
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+    });
+  });
+
+  describe('recreateTask', () => {
+    it('calls orchestrator.recreateTask and dispatches runnable tasks', async () => {
+      const result = await facade.recreateTask('task-a');
+
+      expect(deps.orchestrator.recreateTask).toHaveBeenCalledWith('task-a');
+      expect(result.started).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+    });
+  });
+
+  describe('editTaskCommand', () => {
+    it('calls orchestrator.editTaskCommand and dispatches runnable tasks', async () => {
+      const result = await facade.editTaskCommand('task-a', 'new-cmd');
+
+      expect(deps.orchestrator.editTaskCommand).toHaveBeenCalledWith('task-a', 'new-cmd');
+      expect(result.started).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+    });
+  });
+
+  describe('editTaskPrompt', () => {
+    it('calls orchestrator.editTaskPrompt and dispatches runnable tasks', async () => {
+      const result = await facade.editTaskPrompt('task-a', 'new prompt');
+
+      expect(deps.orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-a', 'new prompt');
+      expect(result.started).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+    });
+  });
+
+  describe('editTaskType', () => {
+    it('calls orchestrator.editTaskType with optional remoteTargetId', async () => {
+      const result = await facade.editTaskType('task-a', 'docker', 'remote-1');
+
+      expect(deps.orchestrator.editTaskType).toHaveBeenCalledWith('task-a', 'docker', 'remote-1');
+      expect(result.started).toHaveLength(1);
+    });
+  });
+
+  describe('editTaskAgent', () => {
+    it('calls orchestrator.editTaskAgent and dispatches', async () => {
+      const result = await facade.editTaskAgent('task-a', 'claude');
+
+      expect(deps.orchestrator.editTaskAgent).toHaveBeenCalledWith('task-a', 'claude');
+      expect(result.started).toHaveLength(1);
+    });
+  });
+
+  describe('selectExperiment', () => {
+    it('calls orchestrator.selectExperiment', async () => {
+      const result = await facade.selectExperiment('task-a', 'exp-1');
+
+      expect(deps.orchestrator.selectExperiment).toHaveBeenCalledWith('task-a', 'exp-1');
+      expect(result.started).toHaveLength(1);
+    });
+  });
+
+  describe('cancelTask', () => {
+    it('calls orchestrator.cancelTask and kills running cancellations', async () => {
+      const killFn = vi.fn();
+      deps = makeDeps({
+        killRunningTask: killFn,
+        orchestrator: {
+          ...deps.orchestrator,
+          cancelTask: vi.fn(() => ({
+            cancelled: ['task-a'],
+            runningCancelled: ['task-a'],
+          })),
+          startExecution: vi.fn(() => []),
+        } as unknown as Orchestrator,
+      });
+      facade = new WorkflowMutationFacade(deps);
+
+      const result = await facade.cancelTask('task-a');
+
+      expect(result.cancelled).toEqual(['task-a']);
+      expect(result.runningCancelled).toEqual(['task-a']);
+      expect(killFn).toHaveBeenCalledWith('task-a');
+    });
+  });
+
+  describe('cancelWorkflow', () => {
+    it('calls orchestrator.cancelWorkflow and kills running cancellations', async () => {
+      const killFn = vi.fn();
+      deps = makeDeps({
+        killRunningTask: killFn,
+        orchestrator: {
+          ...deps.orchestrator,
+          cancelWorkflow: vi.fn(() => ({
+            cancelled: ['task-a'],
+            runningCancelled: ['task-a'],
+          })),
+          startExecution: vi.fn(() => []),
+        } as unknown as Orchestrator,
+      });
+      facade = new WorkflowMutationFacade(deps);
+
+      const result = await facade.cancelWorkflow('wf-1');
+
+      expect(result.cancelled).toEqual(['task-a']);
+      expect(killFn).toHaveBeenCalledWith('task-a');
+    });
+  });
+
+  describe('deleteWorkflow', () => {
+    it('kills active tasks then calls orchestrator.deleteWorkflow', async () => {
+      const killFn = vi.fn();
+      deps = makeDeps({
+        killRunningTask: killFn,
+        orchestrator: {
+          ...deps.orchestrator,
+          getAllTasks: vi.fn(() => [
+            makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } }),
+            makeTask({ id: 'task-b', status: 'completed', config: { workflowId: 'wf-1' } }),
+          ]),
+        } as unknown as Orchestrator,
+      });
+      facade = new WorkflowMutationFacade(deps);
+
+      await facade.deleteWorkflow('wf-1');
+
+      expect(killFn).toHaveBeenCalledWith('task-a');
+      expect(killFn).not.toHaveBeenCalledWith('task-b');
+      expect(deps.orchestrator.deleteWorkflow).toHaveBeenCalledWith('wf-1');
+    });
+  });
+
+  describe('detachWorkflow', () => {
+    it('calls orchestrator.detachWorkflow', async () => {
+      await facade.detachWorkflow('wf-child', 'wf-parent');
+
+      expect(deps.orchestrator.detachWorkflow).toHaveBeenCalledWith('wf-child', 'wf-parent');
+    });
+  });
+
+  describe('forkWorkflow', () => {
+    it('forks and dispatches runnable tasks', async () => {
+      const result = await facade.forkWorkflow('wf-1');
+
+      expect(deps.orchestrator.forkWorkflow).toHaveBeenCalledWith('wf-1');
+      expect(result.forkedWorkflowId).toBe('wf-fork');
+      expect(result.sourceWorkflowId).toBe('wf-1');
+      expect(result.runnable).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+    });
+  });
+
+  describe('rejectTask', () => {
+    it('calls orchestrator.reject with reason', () => {
+      facade.rejectTask('task-a', 'bad output');
+
+      expect(deps.orchestrator.reject).toHaveBeenCalledWith('task-a', 'bad output');
+    });
+
+    it('reverts conflict resolution when task has pendingFixError', () => {
+      const task = makeTask({
+        execution: { pendingFixError: 'merge conflict' },
+      });
+      (deps.orchestrator.getTask as ReturnType<typeof vi.fn>).mockReturnValue(task);
+      (deps.orchestrator as any).revertConflictResolution = vi.fn();
+
+      facade.rejectTask('task-a');
+
+      expect((deps.orchestrator as any).revertConflictResolution).toHaveBeenCalledWith(
+        'task-a',
+        'merge conflict',
+      );
+    });
+  });
+
+  describe('provideInput', () => {
+    it('calls orchestrator.provideInput', () => {
+      facade.provideInput('task-a', 'user answer');
+
+      expect(deps.orchestrator.provideInput).toHaveBeenCalledWith('task-a', 'user answer');
+    });
+  });
+
+  describe('setTaskExternalGatePolicies', () => {
+    it('calls orchestrator.setTaskExternalGatePolicies', async () => {
+      const updates = [{ workflowId: 'wf-1', gatePolicy: 'completed' as const }];
+      await facade.setTaskExternalGatePolicies('task-a', updates);
+
+      expect(deps.orchestrator.setTaskExternalGatePolicies).toHaveBeenCalledWith('task-a', updates);
+    });
+  });
+
+  describe('recreateWorkflow', () => {
+    it('bumps generation and calls orchestrator.recreateWorkflow', async () => {
+      const result = await facade.recreateWorkflow('wf-1');
+
+      expect(deps.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
+      expect(deps.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 2 });
+      expect(deps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+      expect(result.started).toHaveLength(1);
+    });
+  });
+
+  describe('retryWorkflow', () => {
+    it('calls orchestrator.retryWorkflow and dispatches', async () => {
+      const result = await facade.retryWorkflow('wf-1');
+
+      expect(deps.orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
+      expect(result.started).toHaveLength(1);
+    });
+  });
+});

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -45,6 +45,7 @@ import {
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { ExecutorRegistry, TaskRunner } from '@invoker/execution-engine';
+import type { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
   approveTask as sharedApproveTask,
   recreateWorkflow as sharedRecreateWorkflow,
@@ -74,6 +75,8 @@ export interface ApiServerDeps {
   executorRegistry: ExecutorRegistry;
   taskExecutor: TaskRunner;
   autoApproveAIFixes?: boolean;
+  /** When provided, write endpoints delegate to the facade for mutation + dispatch + topup. */
+  mutations?: WorkflowMutationFacade;
   approveTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
   rejectTaskAction?: (taskId: string, reason?: string) => Promise<void>;
   retryTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
@@ -175,6 +178,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     executorRegistry,
     taskExecutor,
     autoApproveAIFixes,
+    mutations,
     approveTaskAction,
     rejectTaskAction,
     retryTaskAction,
@@ -234,16 +238,21 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && cancelMatch) {
         const taskId = decodeURIComponent(cancelMatch[1]);
         try {
-          const result = cancelTask
-            ? await cancelTask(taskId)
-            : orchestrator.cancelTask(taskId);
-          await finalizeMutationWithGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: 'api.tasks.cancel',
-          });
-          json(res, 200, { ok: true, ...result });
+          if (mutations) {
+            const result = await mutations.cancelTask(taskId);
+            json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
+          } else {
+            const result = cancelTask
+              ? await cancelTask(taskId)
+              : orchestrator.cancelTask(taskId);
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: 'api.tasks.cancel',
+            });
+            json(res, 200, { ok: true, ...result });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -257,11 +266,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const isLegacy = !!restartMatch;
         const taskId = decodeURIComponent((retryMatch ?? restartMatch)![1]);
         try {
-          await killRunningTask?.(taskId);
           let started: TaskState[];
           if (retryTaskAction) {
             ({ started } = await retryTaskAction(taskId));
+          } else if (mutations) {
+            await killRunningTask?.(taskId);
+            const result = await mutations.retryTask(taskId);
+            started = result.started;
           } else {
+            await killRunningTask?.(taskId);
             const result = sharedRetryTask(taskId, { orchestrator });
             started = result;
             await finalizeMutationWithGlobalTopup({
@@ -297,16 +310,22 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const taskId = decodeURIComponent(recreateTaskMatch[1]);
         try {
           await killRunningTask?.(taskId);
-          const started = sharedRecreateTask(taskId, { orchestrator, persistence });
-          await finalizeMutationWithGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: 'api.tasks.recreate',
-            started: started.filter(t => t.status === 'running'),
-          });
-          const tasksStarted = started.filter(t => t.status === 'running').length;
-          json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
+          if (mutations) {
+            const result = await mutations.recreateTask(taskId);
+            const tasksStarted = result.runnable.length;
+            json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
+          } else {
+            const started = sharedRecreateTask(taskId, { orchestrator, persistence });
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: 'api.tasks.recreate',
+              started: started.filter(t => t.status === 'running'),
+            });
+            const tasksStarted = started.filter(t => t.status === 'running').length;
+            json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -326,28 +345,32 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               agent = parsed.agent;
             } catch { /* not JSON, ignore */ }
           }
-          try {
-            const result = await resolveConflictAction(taskId, {
-              orchestrator,
-              persistence,
-              taskExecutor,
-              autoApproveAIFixes,
-            }, agent);
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.tasks.resolve-conflict',
-              started: result.started,
-            });
-          } catch (err) {
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.tasks.resolve-conflict.failure',
-            });
-            throw err;
+          if (mutations) {
+            await mutations.resolveConflict(taskId, agent);
+          } else {
+            try {
+              const result = await resolveConflictAction(taskId, {
+                orchestrator,
+                persistence,
+                taskExecutor,
+                autoApproveAIFixes,
+              }, agent);
+              await finalizeMutationWithGlobalTopup({
+                orchestrator,
+                taskExecutor,
+                logger: apiLogger,
+                context: 'api.tasks.resolve-conflict',
+                started: result.started,
+              });
+            } catch (err) {
+              await finalizeMutationWithGlobalTopup({
+                orchestrator,
+                taskExecutor,
+                logger: apiLogger,
+                context: 'api.tasks.resolve-conflict.failure',
+              });
+              throw err;
+            }
           }
           json(res, 200, {
             ok: true,
@@ -368,6 +391,8 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         try {
           if (approveTaskAction) {
             await approveTaskAction(taskId);
+          } else if (mutations) {
+            await mutations.approveTask(taskId);
           } else {
             const result = await sharedApproveTask(taskId, {
               orchestrator,
@@ -403,6 +428,8 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           }
           if (rejectTaskAction) {
             await rejectTaskAction(taskId, reason);
+          } else if (mutations) {
+            mutations.rejectTask(taskId, reason);
           } else {
             sharedRejectTask(taskId, { orchestrator }, reason);
           }
@@ -426,14 +453,20 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const isLegacy = !!wfRestartMatch;
         const workflowId = decodeURIComponent((wfRecreateMatch ?? wfRestartMatch)![1]);
         try {
-          const started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
-          await finalizeMutationWithGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: isLegacy ? 'api.workflows.restart' : 'api.workflows.recreate',
-            started: started.filter(t => t.status === 'running'),
-          });
+          let started: TaskState[];
+          if (mutations) {
+            const result = await mutations.recreateWorkflow(workflowId);
+            started = result.started;
+          } else {
+            started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: isLegacy ? 'api.workflows.restart' : 'api.workflows.recreate',
+              started: started.filter(t => t.status === 'running'),
+            });
+          }
           if (isLegacy) {
             res.setHeader(
               'Deprecation',
@@ -461,6 +494,9 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           let started: TaskState[];
           if (retryWorkflowAction) {
             ({ started } = await retryWorkflowAction(workflowId));
+          } else if (mutations) {
+            const result = await mutations.retryWorkflow(workflowId);
+            started = result.started;
           } else {
             const result = sharedRetryWorkflow(workflowId, { orchestrator });
             started = result;
@@ -490,6 +526,9 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           let started: TaskState[];
           if (recreateWithRebaseAction) {
             ({ started } = await recreateWithRebaseAction(workflowId));
+          } else if (mutations) {
+            const result = await mutations.recreateWorkflowFromFreshBase(workflowId);
+            started = result.started;
           } else {
             const result = await sharedRecreateWorkflowFromFreshBase(workflowId, {
               orchestrator,
@@ -530,22 +569,32 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && wfForkMatch) {
         const workflowId = decodeURIComponent(wfForkMatch[1]);
         try {
-          const result = sharedForkWorkflow(workflowId, { orchestrator, logger: apiLogger });
-          const runnable = result.started.filter((t) => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          await executeGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: 'api.workflows.fork',
-            alreadyDispatched: runnable,
-          });
-          json(res, 200, {
-            ok: true,
-            sourceWorkflowId: result.sourceWorkflowId,
-            forkedWorkflowId: result.forkedWorkflowId,
-            tasksStarted: runnable.length,
-          });
+          if (mutations) {
+            const result = await mutations.forkWorkflow(workflowId);
+            json(res, 200, {
+              ok: true,
+              sourceWorkflowId: result.sourceWorkflowId,
+              forkedWorkflowId: result.forkedWorkflowId,
+              tasksStarted: result.runnable.length,
+            });
+          } else {
+            const result = sharedForkWorkflow(workflowId, { orchestrator, logger: apiLogger });
+            const runnable = result.started.filter((t) => t.status === 'running');
+            await taskExecutor.executeTasks(runnable);
+            await executeGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: 'api.workflows.fork',
+              alreadyDispatched: runnable,
+            });
+            json(res, 200, {
+              ok: true,
+              sourceWorkflowId: result.sourceWorkflowId,
+              forkedWorkflowId: result.forkedWorkflowId,
+              tasksStarted: runnable.length,
+            });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -557,16 +606,21 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && wfCancelMatch) {
         const workflowId = decodeURIComponent(wfCancelMatch[1]);
         try {
-          const result = cancelWorkflow
-            ? await cancelWorkflow(workflowId)
-            : sharedCancelWorkflow(workflowId, { orchestrator });
-          await finalizeMutationWithGlobalTopup({
-            orchestrator,
-            taskExecutor,
-            logger: apiLogger,
-            context: 'api.workflows.cancel',
-          });
-          json(res, 200, { ok: true, ...result });
+          if (mutations) {
+            const result = await mutations.cancelWorkflow(workflowId);
+            json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
+          } else {
+            const result = cancelWorkflow
+              ? await cancelWorkflow(workflowId)
+              : sharedCancelWorkflow(workflowId, { orchestrator });
+            await finalizeMutationWithGlobalTopup({
+              orchestrator,
+              taskExecutor,
+              logger: apiLogger,
+              context: 'api.workflows.cancel',
+            });
+            json(res, 200, { ok: true, ...result });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -609,7 +663,11 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "text" in request body' });
             return;
           }
-          sharedProvideInput(taskId, text, { orchestrator });
+          if (mutations) {
+            mutations.provideInput(taskId, text);
+          } else {
+            sharedProvideInput(taskId, text, { orchestrator });
+          }
           json(res, 200, { ok: true, taskId, action: 'input_provided' });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -628,10 +686,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "command" in request body' });
             return;
           }
-          const started = sharedEditTaskCommand(taskId, command, { orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: runnable.length });
+          if (mutations) {
+            const result = await mutations.editTaskCommand(taskId, command);
+            json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: result.runnable.length });
+          } else {
+            const started = sharedEditTaskCommand(taskId, command, { orchestrator });
+            const runnable = started.filter(t => t.status === 'running');
+            await taskExecutor.executeTasks(runnable);
+            json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: runnable.length });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -648,10 +711,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "prompt" in request body' });
             return;
           }
-          const started = sharedEditTaskPrompt(taskId, prompt, { orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: runnable.length });
+          if (mutations) {
+            const result = await mutations.editTaskPrompt(taskId, prompt);
+            json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: result.runnable.length });
+          } else {
+            const started = sharedEditTaskPrompt(taskId, prompt, { orchestrator });
+            const runnable = started.filter(t => t.status === 'running');
+            await taskExecutor.executeTasks(runnable);
+            json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: runnable.length });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -668,10 +736,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "executorType" in request body' });
             return;
           }
-          const started = sharedEditTaskType(taskId, executorType, { orchestrator }, remoteTargetId);
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: runnable.length });
+          if (mutations) {
+            const result = await mutations.editTaskType(taskId, executorType, remoteTargetId);
+            json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: result.runnable.length });
+          } else {
+            const started = sharedEditTaskType(taskId, executorType, { orchestrator }, remoteTargetId);
+            const runnable = started.filter(t => t.status === 'running');
+            await taskExecutor.executeTasks(runnable);
+            json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: runnable.length });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -688,10 +761,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "agent" in request body' });
             return;
           }
-          const started = sharedEditTaskAgent(taskId, agent, { orchestrator });
-          const runnable = started.filter(t => t.status === 'running');
-          await taskExecutor.executeTasks(runnable);
-          json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: runnable.length });
+          if (mutations) {
+            const result = await mutations.editTaskAgent(taskId, agent);
+            json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: result.runnable.length });
+          } else {
+            const started = sharedEditTaskAgent(taskId, agent, { orchestrator });
+            const runnable = started.filter(t => t.status === 'running');
+            await taskExecutor.executeTasks(runnable);
+            json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: runnable.length });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -710,10 +788,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing non-empty "updates" array in request body' });
             return;
           }
-          const started = sharedSetTaskExternalGatePolicies(taskId, updates, { orchestrator });
-          const runnable = started.filter((t) => t.status === 'running');
-          if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
-          json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: runnable.length });
+          if (mutations) {
+            const result = await mutations.setTaskExternalGatePolicies(taskId, updates);
+            json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: result.runnable.length });
+          } else {
+            const started = sharedSetTaskExternalGatePolicies(taskId, updates, { orchestrator });
+            const runnable = started.filter((t) => t.status === 'running');
+            if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
+            json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: runnable.length });
+          }
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -768,7 +851,11 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "mode" in request body' });
             return;
           }
-          await sharedSetWorkflowMergeMode(workflowId, mode, { orchestrator, persistence, taskExecutor });
+          if (mutations) {
+            await mutations.setWorkflowMergeMode(workflowId, mode);
+          } else {
+            await sharedSetWorkflowMergeMode(workflowId, mode, { orchestrator, persistence, taskExecutor });
+          }
           json(res, 200, { ok: true, workflowId, action: 'merge_mode_set', mode });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -1,0 +1,420 @@
+/**
+ * WorkflowMutationFacade — Single entry point for mutation + dispatch + topup.
+ *
+ * Each entrypoint (api-server, headless, main) duplicates the same
+ * post-mutation lifecycle:
+ *
+ *   1. Call a shared action (workflow-actions.ts)
+ *   2. Filter runnable tasks from `started`
+ *   3. Execute runnable tasks via taskExecutor
+ *   4. Run global topup to fill scheduler capacity
+ *
+ * This facade encapsulates that lifecycle. Callers invoke a single
+ * method and receive a structured result. The facade does NOT own
+ * request parsing, error mapping, or response formatting — those
+ * remain in the entrypoint layer.
+ */
+
+import type { Logger } from '@invoker/contracts';
+import type { Orchestrator, ExternalGatePolicyUpdate, TaskState } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { TaskRunner } from '@invoker/execution-engine';
+import {
+  approveTask as sharedApproveTask,
+  rejectTask as sharedRejectTask,
+  provideInput as sharedProvideInput,
+  retryTask as sharedRetryTask,
+  retryWorkflow as sharedRetryWorkflow,
+  recreateWorkflow as sharedRecreateWorkflow,
+  recreateTask as sharedRecreateTask,
+  recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
+  recreateWithRebase as sharedRecreateWithRebase,
+  rebaseAndRetry as sharedRebaseAndRetry,
+  cancelWorkflow as sharedCancelWorkflow,
+  forkWorkflow as sharedForkWorkflow,
+  editTaskCommand as sharedEditTaskCommand,
+  editTaskPrompt as sharedEditTaskPrompt,
+  editTaskType as sharedEditTaskType,
+  editTaskAgent as sharedEditTaskAgent,
+  setTaskExternalGatePolicies as sharedSetTaskExternalGatePolicies,
+  setWorkflowMergeMode as sharedSetWorkflowMergeMode,
+  selectExperiment as sharedSelectExperiment,
+  selectExperiments as sharedSelectExperiments,
+  resolveConflictAction as sharedResolveConflictAction,
+  fixWithAgentAction as sharedFixWithAgentAction,
+  deleteAllWorkflows as sharedDeleteAllWorkflows,
+  type FailureRecoveryRoute,
+  type FixWithAgentActionResult,
+  type ActionDeps,
+} from './workflow-actions.js';
+import {
+  dispatchStartedTasksWithGlobalTopup,
+  executeGlobalTopup,
+} from './global-topup.js';
+
+// ── Result types ─────────────────────────────────────────────
+
+export interface MutationResult {
+  started: TaskState[];
+  runnable: TaskState[];
+  topup: TaskState[];
+}
+
+export interface ApproveMutationResult extends MutationResult {
+  approvedTask?: TaskState;
+  fixedTask: boolean;
+}
+
+export interface CancelMutationResult {
+  cancelled: string[];
+  runningCancelled: string[];
+  topup: TaskState[];
+}
+
+export interface ForkMutationResult extends MutationResult {
+  forkedWorkflowId: string;
+  sourceWorkflowId: string;
+}
+
+export interface DeleteAllResult {
+  snapshotPath: string | null;
+}
+
+export interface FixMutationResult extends MutationResult {
+  detail: FixWithAgentActionResult;
+}
+
+export interface ResolveConflictMutationResult extends MutationResult {
+  autoApproved: boolean;
+}
+
+// ── Facade deps ──────────────────────────────────────────────
+
+export interface WorkflowMutationFacadeDeps {
+  logger?: Logger;
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  taskExecutor: TaskRunner;
+  autoApproveAIFixes?: boolean;
+  /** Optional pre-kill hook for active task executions. */
+  killRunningTask?: (taskId: string) => Promise<void>;
+}
+
+// ── Facade ───────────────────────────────────────────────────
+
+/**
+ * Encapsulates the "mutate → filter runnable → execute → topup"
+ * lifecycle shared by all entrypoints.
+ */
+export class WorkflowMutationFacade {
+  constructor(private readonly deps: WorkflowMutationFacadeDeps) {}
+
+  // ── Task-scoped mutations ────────────────────────────────
+
+  async approveTask(taskId: string): Promise<ApproveMutationResult> {
+    const { orchestrator, taskExecutor } = this.deps;
+    const result = await sharedApproveTask(taskId, { orchestrator, taskExecutor });
+    const { runnable, topup } = await this.dispatchWithTopup(
+      result.started,
+      'facade.approve-task',
+    );
+    return {
+      approvedTask: result.approvedTask,
+      fixedTask: result.fixedTask,
+      started: result.started,
+      runnable,
+      topup,
+    };
+  }
+
+  rejectTask(taskId: string, reason?: string): void {
+    sharedRejectTask(taskId, { orchestrator: this.deps.orchestrator }, reason);
+  }
+
+  provideInput(taskId: string, text: string): void {
+    sharedProvideInput(taskId, text, { orchestrator: this.deps.orchestrator });
+  }
+
+  async retryTask(taskId: string): Promise<MutationResult> {
+    const started = sharedRetryTask(taskId, { orchestrator: this.deps.orchestrator });
+    return this.finalizeWithTopup(started, 'facade.retry-task');
+  }
+
+  async recreateTask(taskId: string): Promise<MutationResult> {
+    const started = sharedRecreateTask(taskId, {
+      orchestrator: this.deps.orchestrator,
+      persistence: this.deps.persistence,
+    });
+    return this.finalizeWithTopup(started, 'facade.recreate-task');
+  }
+
+  async selectExperiment(taskId: string, experimentId: string): Promise<MutationResult> {
+    const started = sharedSelectExperiment(taskId, experimentId, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.select-experiment');
+  }
+
+  async selectExperiments(taskId: string, experimentIds: string[]): Promise<MutationResult> {
+    const started = await sharedSelectExperiments(taskId, experimentIds, {
+      orchestrator: this.deps.orchestrator,
+      taskExecutor: this.deps.taskExecutor,
+    });
+    return this.finalizeWithTopup(started, 'facade.select-experiments');
+  }
+
+  async editTaskCommand(taskId: string, newCommand: string): Promise<MutationResult> {
+    const started = sharedEditTaskCommand(taskId, newCommand, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.edit-task-command');
+  }
+
+  async editTaskPrompt(taskId: string, newPrompt: string): Promise<MutationResult> {
+    const started = sharedEditTaskPrompt(taskId, newPrompt, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.edit-task-prompt');
+  }
+
+  async editTaskType(
+    taskId: string,
+    executorType: string,
+    remoteTargetId?: string,
+  ): Promise<MutationResult> {
+    const started = sharedEditTaskType(
+      taskId,
+      executorType,
+      { orchestrator: this.deps.orchestrator },
+      remoteTargetId,
+    );
+    return this.finalizeWithTopup(started, 'facade.edit-task-type');
+  }
+
+  async editTaskAgent(taskId: string, agentName: string): Promise<MutationResult> {
+    const started = sharedEditTaskAgent(taskId, agentName, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.edit-task-agent');
+  }
+
+  async setTaskExternalGatePolicies(
+    taskId: string,
+    updates: ExternalGatePolicyUpdate[],
+  ): Promise<MutationResult> {
+    const started = sharedSetTaskExternalGatePolicies(taskId, updates, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.set-gate-policy');
+  }
+
+  async cancelTask(taskId: string): Promise<CancelMutationResult> {
+    const result = this.deps.orchestrator.cancelTask(taskId);
+    if (this.deps.killRunningTask) {
+      for (const id of result.runningCancelled) {
+        await this.deps.killRunningTask(id);
+      }
+    }
+    const topup = await this.topupOnly('facade.cancel-task');
+    return { ...result, topup };
+  }
+
+  // ── Workflow-scoped mutations ────────────────────────────
+
+  async retryWorkflow(workflowId: string): Promise<MutationResult> {
+    const started = sharedRetryWorkflow(workflowId, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.retry-workflow');
+  }
+
+  async recreateWorkflow(workflowId: string): Promise<MutationResult> {
+    const started = sharedRecreateWorkflow(workflowId, {
+      logger: this.deps.logger,
+      persistence: this.deps.persistence,
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.recreate-workflow');
+  }
+
+  async recreateWorkflowFromFreshBase(workflowId: string): Promise<MutationResult> {
+    const started = await sharedRecreateWorkflowFromFreshBase(workflowId, this.actionDeps());
+    return this.finalizeWithTopup(started, 'facade.recreate-from-fresh-base');
+  }
+
+  async recreateWithRebase(workflowId: string): Promise<MutationResult> {
+    const started = await sharedRecreateWithRebase(workflowId, this.actionDeps());
+    return this.finalizeWithTopup(started, 'facade.recreate-with-rebase');
+  }
+
+  async rebaseAndRetry(taskId: string): Promise<MutationResult> {
+    const started = await sharedRebaseAndRetry(taskId, this.actionDeps());
+    return this.finalizeWithTopup(started, 'facade.rebase-and-retry');
+  }
+
+  async cancelWorkflow(workflowId: string): Promise<CancelMutationResult> {
+    const result = sharedCancelWorkflow(workflowId, {
+      orchestrator: this.deps.orchestrator,
+    });
+    if (this.deps.killRunningTask) {
+      for (const id of result.runningCancelled) {
+        await this.deps.killRunningTask(id);
+      }
+    }
+    const topup = await this.topupOnly('facade.cancel-workflow');
+    return { ...result, topup };
+  }
+
+  async deleteWorkflow(workflowId: string): Promise<void> {
+    // Kill active tasks before delete (process management is outside orchestrator scope)
+    if (this.deps.killRunningTask) {
+      const allTasks = this.deps.orchestrator.getAllTasks();
+      const active = allTasks.filter(
+        (t) =>
+          t.config.workflowId === workflowId &&
+          (t.status === 'running' || t.status === 'fixing_with_ai'),
+      );
+      for (const task of active) {
+        await this.deps.killRunningTask(task.id);
+      }
+    }
+    this.deps.orchestrator.deleteWorkflow(workflowId);
+  }
+
+  async deleteAllWorkflows(): Promise<DeleteAllResult> {
+    return sharedDeleteAllWorkflows({
+      logger: this.deps.logger,
+      orchestrator: this.deps.orchestrator,
+      taskExecutor: this.deps.taskExecutor,
+    });
+  }
+
+  async detachWorkflow(workflowId: string, upstreamWorkflowId: string): Promise<void> {
+    this.deps.orchestrator.detachWorkflow(workflowId, upstreamWorkflowId);
+  }
+
+  async forkWorkflow(workflowId: string): Promise<ForkMutationResult> {
+    const result = sharedForkWorkflow(workflowId, {
+      orchestrator: this.deps.orchestrator,
+      logger: this.deps.logger,
+    });
+    const runnable = result.started.filter((t) => t.status === 'running');
+    await this.deps.taskExecutor.executeTasks(runnable);
+    const topup = await this.topupOnly('facade.fork-workflow');
+    return {
+      forkedWorkflowId: result.forkedWorkflowId,
+      sourceWorkflowId: result.sourceWorkflowId,
+      started: result.started,
+      runnable,
+      topup,
+    };
+  }
+
+  async setWorkflowMergeMode(workflowId: string, mergeMode: string): Promise<void> {
+    await sharedSetWorkflowMergeMode(workflowId, mergeMode, {
+      orchestrator: this.deps.orchestrator,
+      persistence: this.deps.persistence,
+      taskExecutor: this.deps.taskExecutor,
+    });
+  }
+
+  // ── AI-driven mutations ──────────────────────────────────
+
+  async resolveConflict(
+    taskId: string,
+    agentName?: string,
+  ): Promise<ResolveConflictMutationResult> {
+    const result = await sharedResolveConflictAction(
+      taskId,
+      {
+        orchestrator: this.deps.orchestrator,
+        persistence: this.deps.persistence,
+        taskExecutor: this.deps.taskExecutor,
+        autoApproveAIFixes: this.deps.autoApproveAIFixes,
+      },
+      agentName,
+    );
+    const { runnable, topup } = await this.dispatchWithTopup(
+      result.started,
+      'facade.resolve-conflict',
+    );
+    return {
+      autoApproved: result.autoApproved,
+      started: result.started,
+      runnable,
+      topup,
+    };
+  }
+
+  async fixWithAgent(
+    taskId: string,
+    options: {
+      agentName?: string;
+      recoveryRoute?: FailureRecoveryRoute;
+      recreateOutputLabel?: string;
+      failureOutputLabel?: string;
+    } = {},
+  ): Promise<FixMutationResult> {
+    const detail = await sharedFixWithAgentAction(
+      taskId,
+      {
+        orchestrator: this.deps.orchestrator,
+        persistence: this.deps.persistence,
+        taskExecutor: this.deps.taskExecutor,
+        autoApproveAIFixes: this.deps.autoApproveAIFixes,
+      },
+      options,
+    );
+    const started =
+      detail.kind === 'recreateWorkflowFromFreshBase'
+        ? detail.started
+        : detail.started;
+    const { runnable, topup } = await this.dispatchWithTopup(
+      started,
+      'facade.fix-with-agent',
+    );
+    return { detail, started, runnable, topup };
+  }
+
+  // ── Internal helpers ─────────────────────────────────────
+
+  private actionDeps(): ActionDeps {
+    return {
+      logger: this.deps.logger,
+      orchestrator: this.deps.orchestrator,
+      persistence: this.deps.persistence,
+      taskExecutor: this.deps.taskExecutor,
+      autoApproveAIFixes: this.deps.autoApproveAIFixes,
+    };
+  }
+
+  private async dispatchWithTopup(
+    started: TaskState[],
+    context: string,
+  ): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
+    return dispatchStartedTasksWithGlobalTopup({
+      orchestrator: this.deps.orchestrator,
+      taskExecutor: this.deps.taskExecutor,
+      logger: this.deps.logger,
+      context,
+      started,
+    });
+  }
+
+  private async finalizeWithTopup(
+    started: TaskState[],
+    context: string,
+  ): Promise<MutationResult> {
+    const { runnable, topup } = await this.dispatchWithTopup(started, context);
+    return { started, runnable, topup };
+  }
+
+  private async topupOnly(context: string): Promise<TaskState[]> {
+    return executeGlobalTopup({
+      orchestrator: this.deps.orchestrator,
+      taskExecutor: this.deps.taskExecutor,
+      logger: this.deps.logger,
+      context,
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Extract a dedicated workflow mutation facade from `api-server` so mutation orchestration logic can be shared and tested independently of a specific surface. This creates the seam that later layers use to converge main, headless, and API mutation behavior.
## Architecture

### Before

```mermaid
graph TD
    Api[API surface] --> Direct[Direct mutation helpers]
    Headless[Headless surface] --> Direct
    Main[Main process] --> Direct
```

### After

```mermaid
graph TD
    Api --> Facade[Workflow mutation facade]
    Headless --> Facade
    Main --> Facade
    Facade --> Bridges[Shared lifecycle and retry bridges]
```

## Test Plan

- [ ] cd packages/app && pnpm test exits 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #334