### PR TITLE
Stacked divergence remediation 26 main headless API facade adoption

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -3,10 +3,14 @@
  *
  * Starts a real HTTP server on an ephemeral port with fully mocked deps.
  * Uses Node's built-in http module to send requests and assert responses.
+ *
+ * All write endpoints route through a WorkflowMutationFacade instance
+ * which wraps the mocked orchestrator, persistence, and taskExecutor.
  */
 import { describe, it, expect, vi, beforeAll, afterAll, beforeEach } from 'vitest';
 import http from 'node:http';
 import { startApiServer, type ApiServer } from '../api-server.js';
+import { WorkflowMutationFacade } from '../workflow-mutation-facade.js';
 import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -72,8 +76,6 @@ let mocks: {
   persistence: Record<string, ReturnType<typeof vi.fn>>;
   executorRegistry: Record<string, ReturnType<typeof vi.fn>>;
   taskExecutor: Record<string, ReturnType<typeof vi.fn>>;
-  cancelTask: ReturnType<typeof vi.fn>;
-  cancelWorkflow: ReturnType<typeof vi.fn>;
   killRunningTask: ReturnType<typeof vi.fn>;
   deleteWorkflow: ReturnType<typeof vi.fn>;
   detachWorkflow: ReturnType<typeof vi.fn>;
@@ -112,6 +114,10 @@ function createMocks() {
         running: [{ taskId: 'task-1', description: 'test' }],
         queued: [],
       })),
+      cancelWorkflow: vi.fn(() => ({
+        cancelled: ['task-1'],
+        runningCancelled: ['task-1'],
+      })),
     },
     persistence: {
       listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'test', generation: 1 }]),
@@ -129,12 +135,19 @@ function createMocks() {
       fixWithAgent: vi.fn().mockResolvedValue(undefined),
       commitApprovedFix: vi.fn().mockResolvedValue(undefined),
     },
-    cancelTask: vi.fn().mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] }),
-    cancelWorkflow: vi.fn().mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] }),
     killRunningTask: vi.fn().mockResolvedValue(undefined),
     deleteWorkflow: vi.fn().mockResolvedValue(undefined),
     detachWorkflow: vi.fn().mockResolvedValue(undefined),
   };
+}
+
+function buildFacade(m: typeof mocks) {
+  return new WorkflowMutationFacade({
+    orchestrator: m.orchestrator as any,
+    persistence: m.persistence as any,
+    taskExecutor: m.taskExecutor as any,
+    killRunningTask: m.killRunningTask,
+  });
 }
 
 beforeAll(async () => {
@@ -145,10 +158,7 @@ beforeAll(async () => {
     orchestrator: mocks.orchestrator as any,
     persistence: mocks.persistence as any,
     executorRegistry: mocks.executorRegistry as any,
-    taskExecutor: mocks.taskExecutor as any,
-    cancelTask: mocks.cancelTask,
-    cancelWorkflow: mocks.cancelWorkflow,
-    killRunningTask: mocks.killRunningTask,
+    mutations: buildFacade(mocks),
     deleteWorkflow: mocks.deleteWorkflow,
     detachWorkflow: mocks.detachWorkflow,
   });
@@ -176,8 +186,6 @@ beforeEach(() => {
       if (typeof fn === 'function' && 'mockClear' in fn) fn.mockClear();
     }
   }
-  mocks.cancelTask.mockClear();
-  mocks.cancelWorkflow.mockClear();
   mocks.killRunningTask.mockClear();
   mocks.deleteWorkflow.mockClear();
   mocks.detachWorkflow.mockClear();
@@ -195,6 +203,7 @@ beforeEach(() => {
   mocks.orchestrator.editTaskType.mockReturnValue([makeTask()]);
   mocks.orchestrator.setTaskExternalGatePolicies.mockReturnValue([makeTask()]);
   mocks.orchestrator.cancelTask.mockReturnValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
+  mocks.orchestrator.cancelWorkflow.mockReturnValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
   mocks.orchestrator.getQueueStatus.mockReturnValue({
     maxConcurrency: 4, runningCount: 1,
     running: [{ taskId: 'task-1', description: 'test' }], queued: [],
@@ -204,8 +213,6 @@ beforeEach(() => {
   mocks.persistence.loadTasks.mockReturnValue([]);
   mocks.persistence.getEvents.mockReturnValue([{ taskId: 'task-1', eventType: 'started', timestamp: '2024-01-01' }]);
   mocks.persistence.getTaskOutput.mockReturnValue('hello world output');
-  mocks.cancelTask.mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
-  mocks.cancelWorkflow.mockResolvedValue({ cancelled: ['task-1'], runningCancelled: ['task-1'] });
   mocks.killRunningTask.mockResolvedValue(undefined);
   mocks.deleteWorkflow.mockResolvedValue(undefined);
   mocks.taskExecutor.executeTasks.mockResolvedValue(undefined);
@@ -313,92 +320,32 @@ describe('GET /api/tasks/:id/output', () => {
 // ── Write endpoints ──────────────────────────────────────────
 
 describe('POST /api/tasks/:id/cancel', () => {
-  it('cancels task via cancelTask callback', async () => {
+  it('cancels task via facade', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/cancel');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(mocks.cancelTask).toHaveBeenCalledWith('task-1');
+    expect(mocks.orchestrator.cancelTask).toHaveBeenCalledWith('task-1');
     expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
-  });
-
-  it('falls back to orchestrator.cancelTask when callback not provided', async () => {
-    // Create a server without cancelTask callback
-    const noCancelMocks = createMocks();
-    const noCancelApi = startApiServer({
-      orchestrator: noCancelMocks.orchestrator as any,
-      persistence: noCancelMocks.persistence as any,
-      executorRegistry: noCancelMocks.executorRegistry as any,
-      taskExecutor: noCancelMocks.taskExecutor as any,
-      killRunningTask: noCancelMocks.killRunningTask,
-      // no cancelTask
-    });
-    await new Promise<void>((resolve) => {
-      if (noCancelApi.server.listening) resolve();
-      else noCancelApi.server.on('listening', resolve);
-    });
-    const noCancelPort = (noCancelApi.server.address() as any).port;
-
-    try {
-      const res = await request(noCancelPort, 'POST', '/api/tasks/task-1/cancel');
-      expect(res.status).toBe(200);
-      expect(res.body.ok).toBe(true);
-      expect(noCancelMocks.orchestrator.cancelTask).toHaveBeenCalledWith('task-1');
-      expect(noCancelMocks.orchestrator.startExecution).toHaveBeenCalled();
-    } finally {
-      await noCancelApi.close();
-    }
   });
 });
 
 describe('POST /api/workflows/:id/cancel', () => {
-  it('cancels workflow via cancelWorkflow callback', async () => {
+  it('cancels workflow via facade', async () => {
     const res = await request(port, 'POST', '/api/workflows/wf-1/cancel');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(mocks.cancelWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(mocks.orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1');
     expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
-  });
-
-  it('falls back to shared cancelWorkflow when callback not provided', async () => {
-    const noCancelMocks = createMocks();
-    noCancelMocks.orchestrator.cancelWorkflow = vi.fn(() => ({
-      cancelled: ['task-1'],
-      runningCancelled: ['task-1'],
-    }));
-    const noCancelApi = startApiServer({
-      orchestrator: noCancelMocks.orchestrator as any,
-      persistence: noCancelMocks.persistence as any,
-      executorRegistry: noCancelMocks.executorRegistry as any,
-      taskExecutor: noCancelMocks.taskExecutor as any,
-      killRunningTask: noCancelMocks.killRunningTask,
-      // no cancelWorkflow
-    });
-    await new Promise<void>((resolve) => {
-      if (noCancelApi.server.listening) resolve();
-      else noCancelApi.server.on('listening', resolve);
-    });
-    const noCancelPort = (noCancelApi.server.address() as any).port;
-
-    try {
-      const res = await request(noCancelPort, 'POST', '/api/workflows/wf-1/cancel');
-      expect(res.status).toBe(200);
-      expect(res.body.ok).toBe(true);
-      expect(noCancelMocks.orchestrator.cancelWorkflow).toHaveBeenCalledWith('wf-1');
-      expect(noCancelMocks.orchestrator.startExecution).toHaveBeenCalled();
-    } finally {
-      await noCancelApi.close();
-    }
   });
 });
 
 describe('POST /api/tasks/:id/restart', () => {
-  it('restarts task via shared retryTask', async () => {
+  it('restarts task via facade retryTask', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/restart');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('restarted');
     expect(mocks.orchestrator.retryTask).toHaveBeenCalledWith('task-1');
-    expect(mocks.killRunningTask).toHaveBeenCalledWith('task-1');
   });
 
   it('returns 400 on error', async () => {
@@ -454,7 +401,7 @@ describe('POST /api/tasks/:id/restart', () => {
 });
 
 describe('POST /api/tasks/:id/approve', () => {
-  it('approves task', async () => {
+  it('approves task via facade', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/approve');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
@@ -499,15 +446,7 @@ describe('POST /api/tasks/:id/approve', () => {
     expect(res.body.error).toBe('not awaiting approval');
   });
 
-  // Step 16 (`docs/architecture/task-invalidation-roadmap.md`,
-  // chart row "Approve or reject fix"): the api-server's
-  // approve POST is the chart's **second** non-invalidating
-  // surface (alongside `gate-policy` from Step 15). It MUST
-  // route to `Orchestrator.approve` (or `resumeTaskAfterFixApproval`
-  // / `commitApprovedFix` for the fix branch) and MUST NOT
-  // trigger any retry/recreate spy on the orchestrator. By the
-  // time approve runs the task is already terminal — cancel
-  // here would also be a generation-bumping mistake.
+  // Step 16: approve POST does not trigger retry/recreate/cancel routes
   it('Step 16: approve POST does not trigger retry/recreate/cancel routes', async () => {
     mocks.orchestrator.recreateTask = vi.fn();
     mocks.orchestrator.recreateWorkflow = vi.fn();
@@ -523,38 +462,6 @@ describe('POST /api/tasks/:id/approve', () => {
     expect(mocks.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
     expect(mocks.orchestrator.cancelTask).not.toHaveBeenCalled();
     expect(mocks.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('uses approveTaskAction when provided', async () => {
-    const approveTaskAction = vi.fn().mockResolvedValue({ started: [] });
-    const isolatedApi = startApiServer({
-      orchestrator: mocks.orchestrator as any,
-      persistence: mocks.persistence as any,
-      executorRegistry: mocks.executorRegistry as any,
-      taskExecutor: mocks.taskExecutor as any,
-      approveTaskAction,
-      cancelTask: mocks.cancelTask,
-      cancelWorkflow: mocks.cancelWorkflow,
-      killRunningTask: mocks.killRunningTask,
-    });
-    await new Promise<void>((resolve) => {
-      if (isolatedApi.server.listening) {
-        resolve();
-      } else {
-        isolatedApi.server.on('listening', resolve);
-      }
-    });
-    const addr = isolatedApi.server.address();
-    const isolatedPort = typeof addr === 'object' && addr ? addr.port : isolatedApi.port;
-
-    try {
-      const res = await request(isolatedPort, 'POST', '/api/tasks/task-1/approve');
-      expect(res.status).toBe(200);
-      expect(approveTaskAction).toHaveBeenCalledWith('task-1');
-      expect(mocks.orchestrator.approve).not.toHaveBeenCalled();
-    } finally {
-      await isolatedApi.close();
-    }
   });
 });
 
@@ -592,16 +499,7 @@ describe('POST /api/tasks/:id/reject', () => {
     expect(mocks.orchestrator.reject).not.toHaveBeenCalled();
   });
 
-  // Step 16 (`docs/architecture/task-invalidation-roadmap.md`,
-  // chart row "Approve or reject fix"): the api-server's
-  // reject POST is the revert-class half of the second
-  // non-invalidating surface (alongside Step 15's gate-policy
-  // POST). It MUST route to `Orchestrator.reject` (or
-  // `revertConflictResolution` for the fix-flow branch) and
-  // MUST NOT trigger any retry/recreate/cancel spy on the
-  // orchestrator. By the time reject runs the task is already
-  // terminal — invalidating would be a generation-bumping
-  // mistake.
+  // Step 16: reject POST does not trigger retry/recreate/cancel routes (non-fix path)
   it('Step 16: reject POST does not trigger retry/recreate/cancel routes (non-fix path)', async () => {
     mocks.orchestrator.recreateTask = vi.fn();
     mocks.orchestrator.recreateWorkflow = vi.fn();
@@ -641,40 +539,6 @@ describe('POST /api/tasks/:id/reject', () => {
     expect(mocks.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
     expect(mocks.orchestrator.cancelTask).not.toHaveBeenCalled();
     expect(mocks.orchestrator.cancelWorkflow).not.toHaveBeenCalled();
-  });
-
-  it('uses rejectTaskAction when provided', async () => {
-    const rejectTaskAction = vi.fn().mockResolvedValue(undefined);
-    const isolatedApi = startApiServer({
-      orchestrator: mocks.orchestrator as any,
-      persistence: mocks.persistence as any,
-      executorRegistry: mocks.executorRegistry as any,
-      taskExecutor: mocks.taskExecutor as any,
-      rejectTaskAction,
-      cancelTask: mocks.cancelTask,
-      cancelWorkflow: mocks.cancelWorkflow,
-      killRunningTask: mocks.killRunningTask,
-      deleteWorkflow: mocks.deleteWorkflow,
-      detachWorkflow: mocks.detachWorkflow,
-    });
-    await new Promise<void>((resolve) => {
-      if (isolatedApi.server.listening) {
-        resolve();
-      } else {
-        isolatedApi.server.on('listening', resolve);
-      }
-    });
-    const addr = isolatedApi.server.address();
-    const isolatedPort = typeof addr === 'object' && addr ? addr.port : isolatedApi.port;
-
-    try {
-      const res = await request(isolatedPort, 'POST', '/api/tasks/task-1/reject', { reason: 'bad' });
-      expect(res.status).toBe(200);
-      expect(rejectTaskAction).toHaveBeenCalledWith('task-1', 'bad');
-      expect(mocks.orchestrator.reject).not.toHaveBeenCalled();
-    } finally {
-      await isolatedApi.close();
-    }
   });
 });
 
@@ -718,7 +582,7 @@ describe('POST /api/tasks/:id/edit-prompt', () => {
     expect(res.body.action).toBe('prompt_edited');
     expect(mocks.orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-1', 'do the thing');
     expect(mocks.orchestrator.editTaskCommand).not.toHaveBeenCalled();
-    // Endpoint dispatches any newly-runnable tasks via the executor.
+    // Facade dispatches any newly-runnable tasks via the executor.
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
   });
 
@@ -779,7 +643,7 @@ describe('POST /api/tasks/:id/edit-type', () => {
     expect(res.body.error).toContain('Missing "executorType"');
   });
 
-  it('forwards a remoteTargetId-only change (host change) so the orchestrator can take the recreate-class branch', async () => {
+  it('forwards a remoteTargetId-only change (host change)', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/edit-type', {
       executorType: 'ssh',
       remoteTargetId: 'remote-b',
@@ -787,11 +651,6 @@ describe('POST /api/tasks/:id/edit-type', () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('type_edited');
-    // Both args are forwarded — `Orchestrator.editTaskType` uses them
-    // to compute the host-key and pick the recreate-class fork
-    // (see `MUTATION_POLICIES.remoteTargetId` and orchestrator unit
-    // coverage). No new public surface; the recreate-vs-retry choice
-    // is internal.
     expect(mocks.orchestrator.editTaskType).toHaveBeenCalledWith('task-1', 'ssh', 'remote-b');
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
   });
@@ -806,7 +665,7 @@ describe('POST /api/tasks/:id/edit-agent', () => {
     expect(mocks.orchestrator.editTaskAgent).toHaveBeenCalledWith('task-1', 'codex');
     expect(mocks.orchestrator.editTaskCommand).not.toHaveBeenCalled();
     expect(mocks.orchestrator.editTaskPrompt).not.toHaveBeenCalled();
-    // Endpoint dispatches any newly-runnable tasks via the executor.
+    // Facade dispatches any newly-runnable tasks via the executor.
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
   });
 
@@ -840,12 +699,7 @@ describe('POST /api/tasks/:id/gate-policy', () => {
     expect(res.body.error).toContain('Missing non-empty "updates" array');
   });
 
-  // Step 15 (`docs/architecture/task-invalidation-roadmap.md`,
-  // chart row "Change external gate policy"): the api-server's
-  // gate-policy POST is the chart's intentional non-invalidating
-  // surface. It MUST route to `setTaskExternalGatePolicies` and
-  // MUST NOT trigger any retry/recreate spy on the orchestrator.
-  // This pins the cross-cutting contract at the http boundary.
+  // Step 15: gate-policy POST does not trigger retry/recreate routes
   it('Step 15: gate-policy POST does not trigger retry/recreate routes', async () => {
     mocks.orchestrator.recreateTask = vi.fn();
     mocks.orchestrator.recreateWorkflow = vi.fn();
@@ -869,7 +723,7 @@ describe('POST /api/tasks/:id/gate-policy', () => {
 });
 
 describe('POST /api/workflows/:id/restart', () => {
-  it('restarts workflow via shared function', async () => {
+  it('restarts workflow via facade recreateWorkflow', async () => {
     mocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask()]);
     const res = await request(port, 'POST', '/api/workflows/wf-1/restart');
     expect(res.status).toBe(200);
@@ -954,14 +808,9 @@ describe('POST /api/workflows/:id/rebase-and-retry', () => {
   });
 });
 
-// Step 14 (`docs/architecture/task-invalidation-roadmap.md`,
-// chart "Topology inconsistency"): live-workflow topology
-// mutations now route through `Orchestrator.forkWorkflow` and
-// surfaces expose an explicit `fork` verb. The api-server
-// returns both the source and forked workflow ids so callers
-// can follow the new workflow.
+// Step 14: live-workflow topology mutations route through Orchestrator.forkWorkflow
 describe('POST /api/workflows/:id/fork', () => {
-  it('forks the workflow via shared forkWorkflow and returns both ids', async () => {
+  it('forks the workflow via facade and returns both ids', async () => {
     const res = await request(port, 'POST', '/api/workflows/wf-1/fork');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
@@ -1015,7 +864,7 @@ describe('POST /api/workflows/:id/recreate-with-rebase', () => {
 });
 
 describe('DELETE /api/workflows/:id', () => {
-  it('deletes workflow via shared deleteWorkflow bridge', async () => {
+  it('deletes workflow via deleteWorkflow callback', async () => {
     const res = await request(port, 'DELETE', '/api/workflows/wf-1');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -4,6 +4,9 @@
  * Binds to 127.0.0.1 only (no external access). Default port 4100,
  * configurable via INVOKER_API_PORT env var.
  *
+ * All write endpoints delegate to a WorkflowMutationFacade instance
+ * which encapsulates the mutation → dispatch → topup lifecycle.
+ *
  * Read endpoints:
  *   GET  /api/health
  *   GET  /api/status
@@ -42,30 +45,10 @@ import {
   PlanConflictError,
   TopologyForkRequired,
 } from '@invoker/workflow-core';
-import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+import type { Orchestrator } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { ExecutorRegistry, TaskRunner } from '@invoker/execution-engine';
+import type { ExecutorRegistry } from '@invoker/execution-engine';
 import type { WorkflowMutationFacade } from './workflow-mutation-facade.js';
-import {
-  approveTask as sharedApproveTask,
-  recreateWorkflow as sharedRecreateWorkflow,
-  recreateTask as sharedRecreateTask,
-  recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
-  forkWorkflow as sharedForkWorkflow,
-  cancelWorkflow as sharedCancelWorkflow,
-  retryTask as sharedRetryTask,
-  retryWorkflow as sharedRetryWorkflow,
-  rejectTask as sharedRejectTask,
-  provideInput as sharedProvideInput,
-  editTaskCommand as sharedEditTaskCommand,
-  editTaskPrompt as sharedEditTaskPrompt,
-  editTaskType as sharedEditTaskType,
-  editTaskAgent as sharedEditTaskAgent,
-  setTaskExternalGatePolicies as sharedSetTaskExternalGatePolicies,
-  setWorkflowMergeMode as sharedSetWorkflowMergeMode,
-  resolveConflictAction,
-} from './workflow-actions.js';
-import { executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 
 export interface ApiServerDeps {
@@ -73,18 +56,8 @@ export interface ApiServerDeps {
   orchestrator: Orchestrator;
   persistence: SQLiteAdapter;
   executorRegistry: ExecutorRegistry;
-  taskExecutor: TaskRunner;
-  autoApproveAIFixes?: boolean;
-  /** When provided, write endpoints delegate to the facade for mutation + dispatch + topup. */
-  mutations?: WorkflowMutationFacade;
-  approveTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
-  rejectTaskAction?: (taskId: string, reason?: string) => Promise<void>;
-  retryTaskAction?: (taskId: string) => Promise<{ started: TaskState[] }>;
-  retryWorkflowAction?: (workflowId: string) => Promise<{ started: TaskState[] }>;
-  recreateWithRebaseAction?: (workflowId: string) => Promise<{ started: TaskState[] }>;
-  killRunningTask?: (taskId: string) => Promise<void>;
-  cancelTask?: (taskId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
-  cancelWorkflow?: (workflowId: string) => Promise<{ cancelled: string[]; runningCancelled: string[] }>;
+  /** All write endpoints delegate to the facade for mutation + dispatch + topup. */
+  mutations: WorkflowMutationFacade;
   deleteWorkflow: (workflowId: string) => Promise<void>;
   detachWorkflow: (workflowId: string, upstreamWorkflowId: string) => Promise<void>;
 }
@@ -175,18 +148,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
     logger: apiLogger,
     orchestrator,
     persistence,
-    executorRegistry,
-    taskExecutor,
-    autoApproveAIFixes,
     mutations,
-    approveTaskAction,
-    rejectTaskAction,
-    retryTaskAction,
-    retryWorkflowAction,
-    recreateWithRebaseAction,
-    killRunningTask,
-    cancelTask,
-    cancelWorkflow,
     deleteWorkflow,
     detachWorkflow,
   } = deps;
@@ -238,65 +200,33 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && cancelMatch) {
         const taskId = decodeURIComponent(cancelMatch[1]);
         try {
-          if (mutations) {
-            const result = await mutations.cancelTask(taskId);
-            json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
-          } else {
-            const result = cancelTask
-              ? await cancelTask(taskId)
-              : orchestrator.cancelTask(taskId);
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.tasks.cancel',
-            });
-            json(res, 200, { ok: true, ...result });
-          }
+          const result = await mutations.cancelTask(taskId);
+          json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
 
-      // POST /api/tasks/:id/retry
+      // POST /api/tasks/:id/retry  (legacy: /api/tasks/:id/restart)
       const retryMatch = path.match(/^\/api\/tasks\/([^/]+)\/retry$/);
       const restartMatch = path.match(/^\/api\/tasks\/([^/]+)\/restart$/);
       if (method === 'POST' && (retryMatch || restartMatch)) {
         const isLegacy = !!restartMatch;
         const taskId = decodeURIComponent((retryMatch ?? restartMatch)![1]);
         try {
-          let started: TaskState[];
-          if (retryTaskAction) {
-            ({ started } = await retryTaskAction(taskId));
-          } else if (mutations) {
-            await killRunningTask?.(taskId);
-            const result = await mutations.retryTask(taskId);
-            started = result.started;
-          } else {
-            await killRunningTask?.(taskId);
-            const result = sharedRetryTask(taskId, { orchestrator });
-            started = result;
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: isLegacy ? 'api.tasks.restart' : 'api.tasks.retry',
-              started: result.filter(t => t.status === 'running'),
-            });
-          }
+          const result = await mutations.retryTask(taskId);
           if (isLegacy) {
             res.setHeader(
               'Deprecation',
               'true; reason="Use /api/tasks/:id/retry or /api/tasks/:id/recreate"',
             );
           }
-          const tasksStarted = started.filter(t => t.status === 'running').length;
           json(res, 200, {
             ok: true,
             taskId,
             action: isLegacy ? 'restarted' : 'retried',
-            tasksStarted,
+            tasksStarted: result.runnable.length,
             ...(isLegacy ? { deprecated: true, replacement: '/api/tasks/:id/retry' } : {}),
           });
         } catch (err) {
@@ -305,27 +235,13 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      // POST /api/tasks/:id/recreate
       const recreateTaskMatch = path.match(/^\/api\/tasks\/([^/]+)\/recreate$/);
       if (method === 'POST' && recreateTaskMatch) {
         const taskId = decodeURIComponent(recreateTaskMatch[1]);
         try {
-          await killRunningTask?.(taskId);
-          if (mutations) {
-            const result = await mutations.recreateTask(taskId);
-            const tasksStarted = result.runnable.length;
-            json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
-          } else {
-            const started = sharedRecreateTask(taskId, { orchestrator, persistence });
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.tasks.recreate',
-              started: started.filter(t => t.status === 'running'),
-            });
-            const tasksStarted = started.filter(t => t.status === 'running').length;
-            json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted });
-          }
+          const result = await mutations.recreateTask(taskId);
+          json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -345,38 +261,12 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               agent = parsed.agent;
             } catch { /* not JSON, ignore */ }
           }
-          if (mutations) {
-            await mutations.resolveConflict(taskId, agent);
-          } else {
-            try {
-              const result = await resolveConflictAction(taskId, {
-                orchestrator,
-                persistence,
-                taskExecutor,
-                autoApproveAIFixes,
-              }, agent);
-              await finalizeMutationWithGlobalTopup({
-                orchestrator,
-                taskExecutor,
-                logger: apiLogger,
-                context: 'api.tasks.resolve-conflict',
-                started: result.started,
-              });
-            } catch (err) {
-              await finalizeMutationWithGlobalTopup({
-                orchestrator,
-                taskExecutor,
-                logger: apiLogger,
-                context: 'api.tasks.resolve-conflict.failure',
-              });
-              throw err;
-            }
-          }
+          const result = await mutations.resolveConflict(taskId, agent);
           json(res, 200, {
             ok: true,
             taskId,
             action: 'resolve_conflict',
-            status: autoApproveAIFixes ? 'auto_approved' : 'awaiting_approval',
+            status: result.autoApproved ? 'auto_approved' : 'awaiting_approval',
           });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -389,23 +279,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && approveMatch) {
         const taskId = decodeURIComponent(approveMatch[1]);
         try {
-          if (approveTaskAction) {
-            await approveTaskAction(taskId);
-          } else if (mutations) {
-            await mutations.approveTask(taskId);
-          } else {
-            const result = await sharedApproveTask(taskId, {
-              orchestrator,
-              taskExecutor,
-            });
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.tasks.approve',
-              started: result.started,
-            });
-          }
+          await mutations.approveTask(taskId);
           json(res, 200, { ok: true, taskId, action: 'approved' });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -426,13 +300,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
               reason = parsed.reason;
             } catch { /* not JSON, ignore */ }
           }
-          if (rejectTaskAction) {
-            await rejectTaskAction(taskId, reason);
-          } else if (mutations) {
-            mutations.rejectTask(taskId, reason);
-          } else {
-            sharedRejectTask(taskId, { orchestrator }, reason);
-          }
+          mutations.rejectTask(taskId, reason);
           json(res, 200, { ok: true, taskId, action: 'rejected', reason });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -447,33 +315,21 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      // POST /api/workflows/:id/recreate  (legacy: /api/workflows/:id/restart)
       const wfRecreateMatch = path.match(/^\/api\/workflows\/([^/]+)\/recreate$/);
       const wfRestartMatch = path.match(/^\/api\/workflows\/([^/]+)\/restart$/);
       if (method === 'POST' && (wfRecreateMatch || wfRestartMatch)) {
         const isLegacy = !!wfRestartMatch;
         const workflowId = decodeURIComponent((wfRecreateMatch ?? wfRestartMatch)![1]);
         try {
-          let started: TaskState[];
-          if (mutations) {
-            const result = await mutations.recreateWorkflow(workflowId);
-            started = result.started;
-          } else {
-            started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: isLegacy ? 'api.workflows.restart' : 'api.workflows.recreate',
-              started: started.filter(t => t.status === 'running'),
-            });
-          }
+          const result = await mutations.recreateWorkflow(workflowId);
           if (isLegacy) {
             res.setHeader(
               'Deprecation',
               'true; reason="Use /api/workflows/:id/recreate"',
             );
           }
-          const tasksStarted = started.filter(t => t.status === 'running').length;
+          const tasksStarted = result.started.filter(t => t.status === 'running').length;
           json(res, 200, {
             ok: true,
             workflowId,
@@ -487,28 +343,13 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      // POST /api/workflows/:id/retry
       const wfRetryMatch = path.match(/^\/api\/workflows\/([^/]+)\/retry$/);
       if (method === 'POST' && wfRetryMatch) {
         const workflowId = decodeURIComponent(wfRetryMatch[1]);
         try {
-          let started: TaskState[];
-          if (retryWorkflowAction) {
-            ({ started } = await retryWorkflowAction(workflowId));
-          } else if (mutations) {
-            const result = await mutations.retryWorkflow(workflowId);
-            started = result.started;
-          } else {
-            const result = sharedRetryWorkflow(workflowId, { orchestrator });
-            started = result;
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.workflows.retry',
-              started: result.filter(t => t.status === 'running'),
-            });
-          }
-          const tasksStarted = started.filter(t => t.status === 'running').length;
+          const result = await mutations.retryWorkflow(workflowId);
+          const tasksStarted = result.started.filter(t => t.status === 'running').length;
           json(res, 200, { ok: true, workflowId, action: 'retried', tasksStarted });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -516,6 +357,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      // POST /api/workflows/:id/recreate-with-rebase  (legacy: /api/workflows/:id/rebase-and-retry)
       const wfRecreateWithRebaseMatch = path.match(/^\/api\/workflows\/([^/]+)\/recreate-with-rebase$/);
       const wfRebaseAndRetryMatch = path.match(/^\/api\/workflows\/([^/]+)\/rebase-and-retry$/);
       if (method === 'POST' && (wfRecreateWithRebaseMatch || wfRebaseAndRetryMatch)) {
@@ -523,35 +365,14 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const workflowTarget = decodeURIComponent((wfRecreateWithRebaseMatch ?? wfRebaseAndRetryMatch)![1]);
         try {
           const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, persistence);
-          let started: TaskState[];
-          if (recreateWithRebaseAction) {
-            ({ started } = await recreateWithRebaseAction(workflowId));
-          } else if (mutations) {
-            const result = await mutations.recreateWorkflowFromFreshBase(workflowId);
-            started = result.started;
-          } else {
-            const result = await sharedRecreateWorkflowFromFreshBase(workflowId, {
-              orchestrator,
-              persistence,
-              taskExecutor,
-              logger: apiLogger,
-            });
-            started = result;
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: isLegacy ? 'api.workflows.rebase-and-retry' : 'api.workflows.recreate-with-rebase',
-              started: result.filter(t => t.status === 'running'),
-            });
-          }
+          const result = await mutations.recreateWorkflowFromFreshBase(workflowId);
           if (isLegacy) {
             res.setHeader(
               'Deprecation',
               'true; reason="Use /api/workflows/:id/recreate-with-rebase"',
             );
           }
-          const tasksStarted = started.filter(t => t.status === 'running').length;
+          const tasksStarted = result.started.filter(t => t.status === 'running').length;
           json(res, 200, {
             ok: true,
             workflowId,
@@ -565,36 +386,18 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      // POST /api/workflows/:id/fork
       const wfForkMatch = path.match(/^\/api\/workflows\/([^/]+)\/fork$/);
       if (method === 'POST' && wfForkMatch) {
         const workflowId = decodeURIComponent(wfForkMatch[1]);
         try {
-          if (mutations) {
-            const result = await mutations.forkWorkflow(workflowId);
-            json(res, 200, {
-              ok: true,
-              sourceWorkflowId: result.sourceWorkflowId,
-              forkedWorkflowId: result.forkedWorkflowId,
-              tasksStarted: result.runnable.length,
-            });
-          } else {
-            const result = sharedForkWorkflow(workflowId, { orchestrator, logger: apiLogger });
-            const runnable = result.started.filter((t) => t.status === 'running');
-            await taskExecutor.executeTasks(runnable);
-            await executeGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.workflows.fork',
-              alreadyDispatched: runnable,
-            });
-            json(res, 200, {
-              ok: true,
-              sourceWorkflowId: result.sourceWorkflowId,
-              forkedWorkflowId: result.forkedWorkflowId,
-              tasksStarted: runnable.length,
-            });
-          }
+          const result = await mutations.forkWorkflow(workflowId);
+          json(res, 200, {
+            ok: true,
+            sourceWorkflowId: result.sourceWorkflowId,
+            forkedWorkflowId: result.forkedWorkflowId,
+            tasksStarted: result.runnable.length,
+          });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -606,21 +409,8 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
       if (method === 'POST' && wfCancelMatch) {
         const workflowId = decodeURIComponent(wfCancelMatch[1]);
         try {
-          if (mutations) {
-            const result = await mutations.cancelWorkflow(workflowId);
-            json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
-          } else {
-            const result = cancelWorkflow
-              ? await cancelWorkflow(workflowId)
-              : sharedCancelWorkflow(workflowId, { orchestrator });
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor,
-              logger: apiLogger,
-              context: 'api.workflows.cancel',
-            });
-            json(res, 200, { ok: true, ...result });
-          }
+          const result = await mutations.cancelWorkflow(workflowId);
+          json(res, 200, { ok: true, cancelled: result.cancelled, runningCancelled: result.runningCancelled });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -663,11 +453,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "text" in request body' });
             return;
           }
-          if (mutations) {
-            mutations.provideInput(taskId, text);
-          } else {
-            sharedProvideInput(taskId, text, { orchestrator });
-          }
+          mutations.provideInput(taskId, text);
           json(res, 200, { ok: true, taskId, action: 'input_provided' });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
@@ -686,21 +472,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "command" in request body' });
             return;
           }
-          if (mutations) {
-            const result = await mutations.editTaskCommand(taskId, command);
-            json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: result.runnable.length });
-          } else {
-            const started = sharedEditTaskCommand(taskId, command, { orchestrator });
-            const runnable = started.filter(t => t.status === 'running');
-            await taskExecutor.executeTasks(runnable);
-            json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: runnable.length });
-          }
+          const result = await mutations.editTaskCommand(taskId, command);
+          json(res, 200, { ok: true, taskId, action: 'command_edited', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
 
+      // POST /api/tasks/:id/edit-prompt
       const editPromptMatch = path.match(/^\/api\/tasks\/([^/]+)\/edit-prompt$/);
       if (method === 'POST' && editPromptMatch) {
         const taskId = decodeURIComponent(editPromptMatch[1]);
@@ -711,21 +491,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "prompt" in request body' });
             return;
           }
-          if (mutations) {
-            const result = await mutations.editTaskPrompt(taskId, prompt);
-            json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: result.runnable.length });
-          } else {
-            const started = sharedEditTaskPrompt(taskId, prompt, { orchestrator });
-            const runnable = started.filter(t => t.status === 'running');
-            await taskExecutor.executeTasks(runnable);
-            json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: runnable.length });
-          }
+          const result = await mutations.editTaskPrompt(taskId, prompt);
+          json(res, 200, { ok: true, taskId, action: 'prompt_edited', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
 
+      // POST /api/tasks/:id/edit-type
       const editTypeMatch = path.match(/^\/api\/tasks\/([^/]+)\/edit-type$/);
       if (method === 'POST' && editTypeMatch) {
         const taskId = decodeURIComponent(editTypeMatch[1]);
@@ -736,21 +510,15 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "executorType" in request body' });
             return;
           }
-          if (mutations) {
-            const result = await mutations.editTaskType(taskId, executorType, remoteTargetId);
-            json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: result.runnable.length });
-          } else {
-            const started = sharedEditTaskType(taskId, executorType, { orchestrator }, remoteTargetId);
-            const runnable = started.filter(t => t.status === 'running');
-            await taskExecutor.executeTasks(runnable);
-            json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: runnable.length });
-          }
+          const result = await mutations.editTaskType(taskId, executorType, remoteTargetId);
+          json(res, 200, { ok: true, taskId, action: 'type_edited', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
         return;
       }
 
+      // POST /api/tasks/:id/edit-agent
       const editAgentMatch = path.match(/^\/api\/tasks\/([^/]+)\/edit-agent$/);
       if (method === 'POST' && editAgentMatch) {
         const taskId = decodeURIComponent(editAgentMatch[1]);
@@ -761,15 +529,8 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "agent" in request body' });
             return;
           }
-          if (mutations) {
-            const result = await mutations.editTaskAgent(taskId, agent);
-            json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: result.runnable.length });
-          } else {
-            const started = sharedEditTaskAgent(taskId, agent, { orchestrator });
-            const runnable = started.filter(t => t.status === 'running');
-            await taskExecutor.executeTasks(runnable);
-            json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: runnable.length });
-          }
+          const result = await mutations.editTaskAgent(taskId, agent);
+          json(res, 200, { ok: true, taskId, action: 'agent_edited', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -788,15 +549,8 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing non-empty "updates" array in request body' });
             return;
           }
-          if (mutations) {
-            const result = await mutations.setTaskExternalGatePolicies(taskId, updates);
-            json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: result.runnable.length });
-          } else {
-            const started = sharedSetTaskExternalGatePolicies(taskId, updates, { orchestrator });
-            const runnable = started.filter((t) => t.status === 'running');
-            if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
-            json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: runnable.length });
-          }
+          const result = await mutations.setTaskExternalGatePolicies(taskId, updates);
+          json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }
@@ -851,11 +605,7 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "mode" in request body' });
             return;
           }
-          if (mutations) {
-            await mutations.setWorkflowMergeMode(workflowId, mode);
-          } else {
-            await sharedSetWorkflowMergeMode(workflowId, mode, { orchestrator, persistence, taskExecutor });
-          }
+          await mutations.setWorkflowMergeMode(workflowId, mode);
           json(res, 200, { ok: true, workflowId, action: 'merge_mode_set', mode });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -29,7 +29,8 @@ import {
 } from '@invoker/execution-engine';
 import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from './config.js';
 import { backupPlan } from './plan-backup.js';
-import { startApiServer, type ApiServerDeps } from './api-server.js';
+import { startApiServer } from './api-server.js';
+import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
   approveTask,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
@@ -111,30 +112,19 @@ function headlessHeartbeat(taskId: string, deps: Pick<HeadlessDeps, 'persistence
   try { deps.persistence.updateTask(taskId, { execution: { lastHeartbeatAt: now } }); } catch { /* db locked */ }
 }
 
-function buildHeadlessApiCancelHooks(
+function buildHeadlessApiServerDeps(
   deps: HeadlessDeps,
   taskExecutor: TaskRunner,
-): Pick<ApiServerDeps, 'cancelTask' | 'cancelWorkflow' | 'killRunningTask' | 'deleteWorkflow'> {
+): { mutations: WorkflowMutationFacade; deleteWorkflow: (id: string) => Promise<void>; detachWorkflow: (id: string, upstreamId: string) => Promise<void> } {
   return {
-    killRunningTask: (taskId: string) => taskExecutor.killActiveExecution(taskId),
-    cancelTask: async (taskId: string) => {
-      const envelope = makeEnvelope('cancel-task', 'headless', 'task', { taskId });
-      const cmdResult = await deps.commandService.cancelTask(envelope);
-      if (!cmdResult.ok) throw new Error(cmdResult.error.message);
-      for (const id of cmdResult.data.runningCancelled) {
-        await taskExecutor.killActiveExecution(id);
-      }
-      return cmdResult.data;
-    },
-    cancelWorkflow: async (workflowId: string) => {
-      const envelope = makeEnvelope('cancel-workflow', 'headless', 'workflow', { workflowId });
-      const cmdResult = await deps.commandService.cancelWorkflow(envelope);
-      if (!cmdResult.ok) throw new Error(cmdResult.error.message);
-      for (const id of cmdResult.data.runningCancelled) {
-        await taskExecutor.killActiveExecution(id);
-      }
-      return cmdResult.data;
-    },
+    mutations: new WorkflowMutationFacade({
+      logger: deps.logger,
+      orchestrator: deps.orchestrator,
+      persistence: deps.persistence,
+      taskExecutor,
+      autoApproveAIFixes: deps.invokerConfig?.autoApproveAIFixes,
+      killRunningTask: (taskId: string) => taskExecutor.killActiveExecution(taskId),
+    }),
     deleteWorkflow: async (workflowId: string) => {
       const allTasks = deps.orchestrator.getAllTasks();
       const workflowTasks = allTasks.filter(
@@ -147,6 +137,11 @@ function buildHeadlessApiCancelHooks(
       }
       const envelope = makeEnvelope('delete-workflow', 'headless', 'workflow', { workflowId });
       const cmdResult = await deps.commandService.deleteWorkflow(envelope);
+      if (!cmdResult.ok) throw new Error(cmdResult.error.message);
+    },
+    detachWorkflow: async (workflowId: string, upstreamWorkflowId: string) => {
+      const envelope = makeEnvelope('detach-workflow', 'headless', 'workflow', { workflowId, upstreamWorkflowId });
+      const cmdResult = await deps.commandService.detachWorkflow(envelope);
       if (!cmdResult.ok) throw new Error(cmdResult.error.message);
     },
   };
@@ -1015,17 +1010,13 @@ async function headlessRun(
   const taskExecutor = createHeadlessExecutor(deps);
   wireHeadlessApproveHook(deps, taskExecutor);
   const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
-  const approveTaskAction = buildHeadlessApproveAction(deps, taskExecutor);
 
   const api = startApiServer({
     logger: deps.logger,
     orchestrator,
     persistence: deps.persistence,
     executorRegistry: deps.executorRegistry,
-    taskExecutor,
-    autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
-    approveTaskAction,
-    ...buildHeadlessApiCancelHooks(deps, taskExecutor),
+    ...buildHeadlessApiServerDeps(deps, taskExecutor),
   });
 
   const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
@@ -1071,17 +1062,13 @@ async function headlessResume(
   const taskExecutor = createHeadlessExecutor(deps);
   wireHeadlessApproveHook(deps, taskExecutor);
   const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
-  const approveTaskAction = buildHeadlessApproveAction(deps, taskExecutor);
 
   const api = startApiServer({
     logger: deps.logger,
     orchestrator,
     persistence: deps.persistence,
     executorRegistry: deps.executorRegistry,
-    taskExecutor,
-    autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
-    approveTaskAction,
-    ...buildHeadlessApiCancelHooks(deps, taskExecutor),
+    ...buildHeadlessApiServerDeps(deps, taskExecutor),
   });
 
   orchestrator.syncFromDb(workflowId);
@@ -2345,16 +2332,13 @@ async function headlessSlack(deps: HeadlessDeps): Promise<void> {
     },
   });
   wireHeadlessApproveHook(deps, taskExecutor);
-  const approveTaskAction = buildHeadlessApproveAction(deps, taskExecutor);
 
   const api = startApiServer({
     logger: deps.logger,
     orchestrator,
     persistence,
     executorRegistry: deps.executorRegistry,
-    taskExecutor,
-    approveTaskAction,
-    ...buildHeadlessApiCancelHooks(deps, taskExecutor),
+    ...buildHeadlessApiServerDeps(deps, taskExecutor),
   });
 
   const slack = await wireSlackBot({

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -102,6 +102,7 @@ import {
 import { backupPlan } from './plan-backup.js';
 // applyPlanDefinitionDefaults removed — parsePlan() applies defaults internally
 import { startApiServer, type ApiServer } from './api-server.js';
+import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
   runHeadless,
   isDelegated,
@@ -2290,66 +2291,14 @@ if (isHeadless) {
         orchestrator,
         persistence,
         executorRegistry,
-        taskExecutor: requireTaskExecutor(),
-        autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
-        approveTaskAction: async (taskId: string) => {
-          const workflowId = orchestrator.getTask(taskId)?.config.workflowId;
-          return runWorkflowMutation(workflowId, 'normal', 'api:approve-task', [taskId], async () => {
-            const { started } = await performSharedApproveTask(taskId, 'api');
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor: requireTaskExecutor(),
-              logger,
-              context: 'api.tasks.approve',
-              started,
-            });
-            return { started };
-          });
-        },
-        rejectTaskAction: async (taskId: string, reason?: string) => {
-          const workflowId = orchestrator.getTask(taskId)?.config.workflowId;
-          await runWorkflowMutation(workflowId, 'normal', 'api:reject-task', [taskId, reason], async () => {
-            const envelope = makeEnvelope('reject', 'surface', 'task', { taskId, reason });
-            const result = await commandService.reject(envelope);
-            if (!result.ok) throw new Error(result.error.message);
-          });
-        },
-        retryWorkflowAction: async (workflowId: string) => {
-          return runWorkflowMutation(workflowId, 'normal', 'api:retry-workflow', [workflowId], async () => {
-            const envelope = makeEnvelope('retry-workflow', 'surface', 'workflow', { workflowId });
-            const result = await commandService.retryWorkflow(envelope);
-            if (!result.ok) throw new Error(result.error.message);
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor: requireTaskExecutor(),
-              logger,
-              context: 'api.workflows.retry',
-              started: result.data.filter(t => t.status === 'running'),
-            });
-            return { started: result.data };
-          });
-        },
-        recreateWithRebaseAction: async (workflowId: string) => {
-          return runWorkflowMutation(workflowId, 'high', 'api:recreate-with-rebase', [workflowId], async () => {
-            const started = await recreateWithRebase(workflowId, {
-              orchestrator,
-              persistence,
-              taskExecutor: requireTaskExecutor(),
-              logger,
-            });
-            await finalizeMutationWithGlobalTopup({
-              orchestrator,
-              taskExecutor: requireTaskExecutor(),
-              logger,
-              context: 'api.workflows.recreate-with-rebase',
-              started: started.filter(t => t.status === 'running'),
-            });
-            return { started };
-          });
-        },
-        killRunningTask,
-        cancelTask: performCancelTask,
-        cancelWorkflow: performCancelWorkflow,
+        mutations: new WorkflowMutationFacade({
+          logger,
+          orchestrator,
+          persistence,
+          taskExecutor: requireTaskExecutor(),
+          autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+          killRunningTask,
+        }),
         deleteWorkflow: performDeleteWorkflow,
         detachWorkflow: performDetachWorkflow,
       });


### PR DESCRIPTION
## Summary

Adopt the workflow mutation facade across `main.ts`, `headless.ts`, and `api-server.ts`, and delete the obsolete surface-specific orchestration branches it replaces. After this layer, the major mutation entry surfaces all route through the same coordination seam.
## Architecture

### Before

```mermaid
graph TD
    Main[Main process] --> Mixed[Mixed direct and facade mutations]
    Headless[Headless surface] --> Mixed
    Api[API surface] --> Mixed
```

### After

```mermaid
graph TD
    Main --> Facade[Workflow mutation facade]
    Headless --> Facade
    Api --> Facade
    Facade --> Bridges[Shared mutation bridges]
```

## Test Plan

- [ ] cd packages/app && pnpm test exits 0.
- [ ] No additional local test rerun during PR body update

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #335