### PR TITLE
app: fail fast on unresolved workspace runtime imports

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -53,7 +53,7 @@
     }
   },
   "scripts": {
-    "build": "tsup",
+    "build": "node scripts/verify-workspace-imports.cjs && tsup",
     "dist": "electron-builder --publish never",
     "dist:linux": "electron-builder --linux AppImage deb --publish never",
     "dist:mac": "electron-builder --mac dmg --publish never",

--- a/packages/app/scripts/verify-workspace-imports.cjs
+++ b/packages/app/scripts/verify-workspace-imports.cjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+
+const { createRequire } = require('node:module');
+const { readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const requireFromScript = createRequire(__filename);
+const packageRoot = join(__dirname, '..');
+const mainSourcePath = join(packageRoot, 'src', 'main.ts');
+const packageJsonPath = join(packageRoot, 'package.json');
+
+const mainSource = readFileSync(mainSourcePath, 'utf-8');
+const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+
+const declaredDependencies = new Set([
+  ...Object.keys(packageJson.dependencies ?? {}),
+  ...Object.keys(packageJson.devDependencies ?? {}),
+]);
+
+const invokerImportPattern = /from\s+['"](@invoker\/[^'"]+)['"]/g;
+const imports = new Set();
+
+for (const match of mainSource.matchAll(invokerImportPattern)) {
+  if (match[1]) {
+    imports.add(match[1]);
+  }
+}
+
+for (const specifier of imports) {
+  if (!declaredDependencies.has(specifier)) {
+    throw new Error(`Missing package.json dependency for ${specifier} imported in src/main.ts`);
+  }
+
+  try {
+    requireFromScript.resolve(specifier, { paths: [packageRoot] });
+  } catch {
+    throw new Error(
+      `Unresolvable workspace dependency ${specifier}. Run "pnpm install" at repo root to refresh workspace links.`,
+    );
+  }
+}

--- a/packages/app/src/__tests__/workspace-import-resolution.test.ts
+++ b/packages/app/src/__tests__/workspace-import-resolution.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+type AppPackageJson = {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+const require = createRequire(import.meta.url);
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const packageRoot = join(currentDir, '..', '..');
+const mainSourcePath = join(packageRoot, 'src', 'main.ts');
+const packageJsonPath = join(packageRoot, 'package.json');
+
+const mainSource = readFileSync(mainSourcePath, 'utf-8');
+const appPackageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8')) as AppPackageJson;
+
+function collectInvokerImports(sourceCode: string): string[] {
+  const invokerImportPattern = /from\s+['"](@invoker\/[^'"]+)['"]/g;
+  const imports = new Set<string>();
+
+  for (const match of sourceCode.matchAll(invokerImportPattern)) {
+    const specifier = match[1];
+    if (specifier) {
+      imports.add(specifier);
+    }
+  }
+
+  return [...imports].sort();
+}
+
+describe('workspace import resolution', () => {
+  const invokerImports = collectInvokerImports(mainSource);
+  const declaredDependencies = new Set([
+    ...Object.keys(appPackageJson.dependencies ?? {}),
+    ...Object.keys(appPackageJson.devDependencies ?? {}),
+  ]);
+
+  it('tracks invoker imports in src/main.ts', () => {
+    expect(invokerImports.length).toBeGreaterThan(0);
+  });
+
+  it('declares every @invoker/* import in package.json', () => {
+    for (const specifier of invokerImports) {
+      expect(declaredDependencies.has(specifier), `Missing dependency declaration for ${specifier}`).toBe(true);
+    }
+  });
+
+  it('resolves every @invoker/* import from package root', () => {
+    for (const specifier of invokerImports) {
+      expect(
+        () => require.resolve(specifier, { paths: [packageRoot] }),
+        `Unresolvable workspace dependency: ${specifier}. Run pnpm install to refresh workspace links.`,
+      ).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- document and guard the real failure mode: `@invoker/runtime-adapters` and `@invoker/runtime-service` can be declared in `packages/app/package.json` but still become unresolvable when workspace links in `packages/app/node_modules` are stale/missing
- add a prebuild guard (`packages/app/scripts/verify-workspace-imports.cjs`) that scans `src/main.ts` for `@invoker/*` imports, enforces declaration in `package.json`, and fails early with a clear remediation (`pnpm install`)
- add a regression test (`workspace-import-resolution.test.ts`) that enforces both dependency declaration and runtime resolution for all `@invoker/*` imports used by app main entrypoint

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workspace-import-resolution.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 3c379504`
- Post-revert steps: None
- Data migration? No
