### PR TITLE
app: raise default max concurrency to 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Minimal example:
 
 ```json
 {
-  "maxConcurrency": 3,
+  "maxConcurrency": 6,
   "autoFixRetries": 3,
   "autoFixAgent": "claude",
   "remoteTargets": {

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -1,13 +1,14 @@
 {
   "comment": "Example Invoker configuration file",
   "description": "Default location: ~/.invoker/config.json. For repo-specific configs, set INVOKER_REPO_CONFIG_PATH when launching Invoker.",
+  "maxConcurrency": 6,
 
   "executors": {
     "worktree": {
       "comment": "WorktreeExecutor configuration",
       "cacheDir": "/home/user/.invoker/cache",
       "worktreeBaseDir": "/home/user/.invoker/worktrees",
-      "maxWorktrees": 5
+      "maxWorktrees": 6
     },
     "docker": {
       "comment": "DockerExecutor configuration"

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -539,7 +539,7 @@ test.describe('Visual proof capture', () => {
     ]);
     // Navigate to queue tab if there is one, or verify queue section is visible
     await page.getByRole('button', { name: 'Queue' }).click();
-    await expect(page.getByText('Running 1 / 3')).toBeVisible();
+    await expect(page.getByText('Running 1 / 6')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Action Queue (1)' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Backlog (3)' })).toBeVisible();
     await captureScreenshot(page, 'queue-view-concurrency');

--- a/packages/app/src/__tests__/execution-capacity.test.ts
+++ b/packages/app/src/__tests__/execution-capacity.test.ts
@@ -6,16 +6,16 @@ import {
 } from '../execution-capacity.js';
 
 describe('execution-capacity', () => {
-  it('caps configured concurrency at worktree capacity', () => {
-    expect(resolveEffectiveMaxConcurrency(26, 5)).toBe(5);
+  it('preserves configured concurrency without applying an artificial cap', () => {
+    expect(resolveEffectiveMaxConcurrency(26)).toBe(26);
   });
 
   it('preserves a lower configured concurrency', () => {
-    expect(resolveEffectiveMaxConcurrency(4, 5)).toBe(4);
+    expect(resolveEffectiveMaxConcurrency(4)).toBe(4);
   });
 
   it('falls back to safe defaults for invalid values', () => {
-    expect(resolveEffectiveMaxConcurrency(undefined, DEFAULT_WORKTREE_MAX_CONCURRENCY)).toBe(6);
-    expect(resolveEffectiveMaxConcurrency(0, 0)).toBe(6);
+    expect(resolveEffectiveMaxConcurrency(undefined)).toBe(DEFAULT_WORKTREE_MAX_CONCURRENCY);
+    expect(resolveEffectiveMaxConcurrency(0)).toBe(DEFAULT_WORKTREE_MAX_CONCURRENCY);
   });
 });

--- a/packages/app/src/__tests__/execution-capacity.test.ts
+++ b/packages/app/src/__tests__/execution-capacity.test.ts
@@ -15,7 +15,7 @@ describe('execution-capacity', () => {
   });
 
   it('falls back to safe defaults for invalid values', () => {
-    expect(resolveEffectiveMaxConcurrency(undefined, DEFAULT_WORKTREE_MAX_CONCURRENCY)).toBe(3);
-    expect(resolveEffectiveMaxConcurrency(0, 0)).toBe(3);
+    expect(resolveEffectiveMaxConcurrency(undefined, DEFAULT_WORKTREE_MAX_CONCURRENCY)).toBe(6);
+    expect(resolveEffectiveMaxConcurrency(0, 0)).toBe(6);
   });
 });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -47,7 +47,7 @@ export interface InvokerConfig {
   planningTimeoutSeconds?: number;
   /** Interval for heartbeat messages posted to Slack during planning in seconds. Default: 120 (2 minutes). Set to 0 to disable. */
   planningHeartbeatIntervalSeconds?: number;
-  /** Maximum number of tasks that can run concurrently. Default: 3. */
+  /** Maximum number of tasks that can run concurrently. Default: 6. */
   maxConcurrency?: number;
   /** Browser executable for opening external URLs (e.g. "firefox"). Default: Chrome. */
   browser?: string;

--- a/packages/app/src/execution-capacity.ts
+++ b/packages/app/src/execution-capacity.ts
@@ -1,5 +1,5 @@
-const DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY = 3;
-export const DEFAULT_WORKTREE_MAX_CONCURRENCY = 5;
+const DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY = 6;
+export const DEFAULT_WORKTREE_MAX_CONCURRENCY = 6;
 
 export function resolveEffectiveMaxConcurrency(
   configuredMaxConcurrency: number | undefined,

--- a/packages/app/src/execution-capacity.ts
+++ b/packages/app/src/execution-capacity.ts
@@ -1,19 +1,10 @@
 const DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY = 6;
-export const DEFAULT_WORKTREE_MAX_CONCURRENCY = 6;
+export const DEFAULT_WORKTREE_MAX_CONCURRENCY = DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY;
 
 export function resolveEffectiveMaxConcurrency(
   configuredMaxConcurrency: number | undefined,
-  worktreeMaxConcurrency: number = DEFAULT_WORKTREE_MAX_CONCURRENCY,
 ): number {
-  const normalizedConfigured =
-    Number.isInteger(configuredMaxConcurrency) && Number(configuredMaxConcurrency) > 0
-      ? Number(configuredMaxConcurrency)
-      : DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY;
-
-  const normalizedWorktreeMax =
-    Number.isInteger(worktreeMaxConcurrency) && Number(worktreeMaxConcurrency) > 0
-      ? Number(worktreeMaxConcurrency)
-      : DEFAULT_WORKTREE_MAX_CONCURRENCY;
-
-  return Math.min(normalizedConfigured, normalizedWorktreeMax);
+  return Number.isInteger(configuredMaxConcurrency) && Number(configuredMaxConcurrency) > 0
+    ? Number(configuredMaxConcurrency)
+    : DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY;
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -310,10 +310,7 @@ function getSafeInvokerConfigForLogging(config: InvokerConfig): Record<string, u
   return safeConfig;
 }
 
-const effectiveMaxConcurrency = resolveEffectiveMaxConcurrency(
-  invokerConfig.maxConcurrency,
-  DEFAULT_WORKTREE_MAX_CONCURRENCY,
-);
+const effectiveMaxConcurrency = resolveEffectiveMaxConcurrency(invokerConfig.maxConcurrency);
 
 async function maybeDelayWorkflowResumeForTest(): Promise<void> {
   if (process.env.NODE_ENV !== 'test') return;
@@ -418,7 +415,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     new WorktreeExecutor({
       worktreeBaseDir: path.resolve(invokerHomeRoot, 'worktrees'),
       cacheDir: path.resolve(invokerHomeRoot, 'repos'),
-      maxWorktrees: DEFAULT_WORKTREE_MAX_CONCURRENCY,
+      maxWorktrees: effectiveMaxConcurrency,
       agentRegistry: options?.executionAgentRegistry,
     }),
   );

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -22,6 +22,7 @@ import {
   spawnDetachedTerminal,
   type OpenTerminalResult,
 } from './terminal-external-launch.js';
+import { DEFAULT_WORKTREE_MAX_CONCURRENCY } from './execution-capacity.js';
 
 /** Persistence methods required to resolve terminal cwd / command for a task. */
 export interface OpenTerminalPersistence {
@@ -183,7 +184,7 @@ export async function openExternalTerminalForTask(
       const worktree = new WorktreeExecutor({
         worktreeBaseDir: path.resolve(invokerHome, 'worktrees'),
         cacheDir: path.resolve(invokerHome, 'repos'),
-        maxWorktrees: 5,
+        maxWorktrees: DEFAULT_WORKTREE_MAX_CONCURRENCY,
         agentRegistry: opts.executionAgentRegistry,
       });
       executorRegistry.register('worktree', worktree);

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -22,7 +22,7 @@ import {
   spawnDetachedTerminal,
   type OpenTerminalResult,
 } from './terminal-external-launch.js';
-import { DEFAULT_WORKTREE_MAX_CONCURRENCY } from './execution-capacity.js';
+import { resolveEffectiveMaxConcurrency } from './execution-capacity.js';
 
 /** Persistence methods required to resolve terminal cwd / command for a task. */
 export interface OpenTerminalPersistence {
@@ -181,10 +181,11 @@ export async function openExternalTerminalForTask(
       executor = docker;
     } else if (repairedMeta.executorType === 'worktree') {
       const invokerHome = path.resolve(homedir(), '.invoker');
+      const maxWorktrees = resolveEffectiveMaxConcurrency(loadConfig().maxConcurrency);
       const worktree = new WorktreeExecutor({
         worktreeBaseDir: path.resolve(invokerHome, 'worktrees'),
         cacheDir: path.resolve(invokerHome, 'repos'),
-        maxWorktrees: DEFAULT_WORKTREE_MAX_CONCURRENCY,
+        maxWorktrees,
         agentRegistry: opts.executionAgentRegistry,
       });
       executorRegistry.register('worktree', worktree);


### PR DESCRIPTION
## Summary

Raise Invoker's default task concurrency from 3 to 6 and align the worktree executor cap with that value.

This fixes the mismatch where a user config of `"maxConcurrency": 6` was already being read, but worktree-backed execution was still clamped to 5 internally. The PR also updates the example config and README to document the effective default.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/execution-capacity.test.ts src/__tests__/config.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 1a3c84638f525d72d263afc2f957ee1cc45846d1`
- Post-revert steps: Restart Invoker if it is running so the reverted concurrency cap is reloaded.
- Data migration? No
