### PR TITLE
transport: fix DTS build and enforce required CI build

### DIFF
--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -6,9 +6,9 @@
   "types": "src/index.ts",
   "exports": {
     ".": {
+      "types": "./src/index.ts",
       "import": "./src/index.ts",
-      "require": "./src/index.ts",
-      "types": "./src/index.ts"
+      "require": "./src/index.ts"
     }
   },
   "scripts": {

--- a/packages/transport/tsup.config.ts
+++ b/packages/transport/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   format: ['esm'],
   dts: {
     compilerOptions: {
+      composite: false,
       module: 'NodeNext',
       moduleResolution: 'NodeNext',
       types: ['node'],

--- a/scripts/required-builds.sh
+++ b/scripts/required-builds.sh
@@ -5,3 +5,4 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT"
 
 pnpm --filter @invoker/surfaces build
+pnpm --filter @invoker/transport build


### PR DESCRIPTION
## Summary

- Fix `@invoker/transport` declaration generation by disabling `composite` in tsup DTS compiler options so `pnpm --filter @invoker/transport build` no longer fails with TS6307.
- Reorder the `exports` map in `packages/transport/package.json` to put `types` first, removing the tsup warning about an unreachable `types` condition.
- Add `pnpm --filter @invoker/transport build` to `scripts/required-builds.sh` so CI required-build checks execute this package build path.

## Test Plan

- [x] `pnpm --filter @invoker/transport build`
- [x] `bash scripts/required-builds.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 2547ea60`
- Post-revert steps: None
- Data migration? No
