### PR TITLE
execution-engine: route intermediate branches via intermediateRepoUrl

### DIFF
--- a/docs/pr-branching-workflow.md
+++ b/docs/pr-branching-workflow.md
@@ -7,6 +7,19 @@ Default workflow:
 - Publish branches to `origin` (or another explicit publish remote).
 - Open PRs against `Neko-Catpital-Labs/Invoker`.
 
+## Invoker Plan Override
+
+Invoker plans may optionally set `intermediateRepoUrl`:
+
+```yaml
+repoUrl: https://github.com/Neko-Catpital-Labs/Invoker
+intermediateRepoUrl: https://github.com/your-org/invoker-intermediate
+```
+
+- Non-merge task branches (including reconciliation/rebase helper branches) are pushed to `intermediateRepoUrl`.
+- Merge-gate/final publish and PR creation continue to use `origin` from `repoUrl`.
+- If `intermediateRepoUrl` is omitted, all branch pushes remain `origin`-only.
+
 ## Rules
 
 - Do not rely on automatic fork-sync scripts before submission.

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -74,6 +74,19 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow('must have a "repoUrl" field');
   });
 
+  it('rejects blank intermediateRepoUrl', () => {
+    const yaml = `
+name: Blank Intermediate URL
+repoUrl: git@github.com:test/repo.git
+intermediateRepoUrl: "  "
+tasks:
+  - id: greet
+    description: Say hello
+    command: echo "Hello"
+`;
+    expect(() => parsePlan(yaml)).toThrow('Plan "intermediateRepoUrl" must be a non-empty string');
+  });
+
   it('parses valid YAML plan', () => {
     const yaml = `
 name: Hello World Test
@@ -89,6 +102,20 @@ tasks:
     expect(plan.tasks[0].id).toBe('greet');
     expect(plan.tasks[0].description).toBe('Say hello');
     expect(plan.tasks[0].command).toBe('echo "Hello, World!"');
+  });
+
+  it('parses optional intermediateRepoUrl', () => {
+    const yaml = `
+name: Intermediate Remote Plan
+repoUrl: git@github.com:test/repo.git
+intermediateRepoUrl: https://github.com/fork/repo.git
+tasks:
+  - id: greet
+    description: Say hello
+    command: echo "Hello, World!"
+`;
+    const plan = parsePlan(yaml);
+    expect(plan.intermediateRepoUrl).toBe('https://github.com/fork/repo.git');
   });
 
   it('parses plan with dependencies', () => {

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -74,6 +74,7 @@ export interface RawPlan {
   mergeMode?: string;
   reviewProvider?: string;
   repoUrl?: string;
+  intermediateRepoUrl?: string;
   executorType?: string;
   externalDependencies?: Array<{
     workflowId?: string;
@@ -266,6 +267,14 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       'Plan must have a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git).',
     );
   }
+  if (raw.intermediateRepoUrl !== undefined) {
+    if (typeof raw.intermediateRepoUrl !== 'string' || raw.intermediateRepoUrl.trim() === '') {
+      throw new PlanParseError(
+        'Plan "intermediateRepoUrl" must be a non-empty string when provided.',
+      );
+    }
+    raw.intermediateRepoUrl = raw.intermediateRepoUrl.trim();
+  }
 
   const defaultExecutorType = raw.executorType;
   const topLevelExternalDependencies = parseExternalDependencies('Plan', raw.externalDependencies);
@@ -355,6 +364,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     mergeMode,
     reviewProvider,
     repoUrl: raw.repoUrl,
+    intermediateRepoUrl: raw.intermediateRepoUrl,
     tasks,
   });
 }

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -22,6 +22,8 @@ export interface WorkRequestInputs {
   experimentResults?: ExperimentResult[];
   /** URL of the git repository to clone and work in via RepoPool. */
   repoUrl?: string;
+  /** Optional URL where non-merge intermediate branches are published. */
+  intermediateRepoUrl?: string;
   /** Feature branch name to create/checkout in the pooled worktree. */
   featureBranch?: string;
   /** Summaries from completed upstream dependencies, providing context for this task. */

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1124,12 +1124,13 @@ describe('SQLiteAdapter', () => {
   });
 
   describe('workflow merge config', () => {
-    it('saveWorkflow persists onFinish, baseBranch, and featureBranch', () => {
+    it('saveWorkflow persists onFinish, baseBranch, featureBranch, and intermediateRepoUrl', () => {
       const wf: Workflow = {
         ...testWorkflow,
         onFinish: 'merge',
         baseBranch: 'main',
         featureBranch: 'feat/test',
+        intermediateRepoUrl: 'https://github.com/fork/repo.git',
       };
       adapter.saveWorkflow(wf);
 
@@ -1138,6 +1139,7 @@ describe('SQLiteAdapter', () => {
       expect(loaded!.onFinish).toBe('merge');
       expect(loaded!.baseBranch).toBe('main');
       expect(loaded!.featureBranch).toBe('feat/test');
+      expect(loaded!.intermediateRepoUrl).toBe('https://github.com/fork/repo.git');
     });
 
     it('listWorkflows returns merge config fields', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -38,6 +38,7 @@ export interface Workflow {
   status: 'running' | 'completed' | 'failed';
   planFile?: string;
   repoUrl?: string;
+  intermediateRepoUrl?: string;
   branch?: string;
   onFinish?: 'none' | 'merge' | 'pull_request';
   baseBranch?: string;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -297,6 +297,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         status TEXT DEFAULT 'running',
         plan_file TEXT,
         repo_url TEXT,
+        intermediate_repo_url TEXT,
         branch TEXT,
         parent_remote TEXT,
         created_at TEXT DEFAULT (datetime('now')),
@@ -542,6 +543,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE tasks ADD COLUMN remote_target_id TEXT',
       'ALTER TABLE workflows ADD COLUMN description TEXT',
       'ALTER TABLE workflows ADD COLUMN visual_proof INTEGER',
+      'ALTER TABLE workflows ADD COLUMN intermediate_repo_url TEXT',
       // agent_session_id: new column for pluggable agent architecture
       'ALTER TABLE tasks ADD COLUMN agent_session_id TEXT',
       'ALTER TABLE attempts ADD COLUMN agent_session_id TEXT',
@@ -655,14 +657,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   saveWorkflow(workflow: Workflow): void {
     this.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, status, plan_file, repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, status, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, generation, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
       workflow.visualProof ? 1 : 0,
       workflow.status,
-      workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.branch ?? null,
+      workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
       workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
       workflow.mergeMode ?? null,
       workflow.reviewProvider ?? null,
@@ -1602,6 +1604,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       status: row.status,
       planFile: row.plan_file ?? undefined,
       repoUrl: row.repo_url ?? undefined,
+      intermediateRepoUrl: row.intermediate_repo_url ?? undefined,
       branch: row.branch ?? undefined,
       onFinish: row.on_finish ?? undefined,
       baseBranch: row.base_branch ?? undefined,

--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -1990,12 +1990,15 @@ describe('BaseExecutor.syncFromRemote', () => {
 describe('BaseExecutor.pushBranchToRemote', () => {
   let executor: TestExecutor;
   let originDir: string;
+  let intermediateDir: string;
   let cloneDir: string;
 
   beforeEach(() => {
     executor = new TestExecutor();
     originDir = mkdtempSync(join(tmpdir(), 'push-origin-'));
     execSync('git init --bare -b master', { cwd: originDir });
+    intermediateDir = mkdtempSync(join(tmpdir(), 'push-intermediate-'));
+    execSync('git init --bare -b master', { cwd: intermediateDir });
     cloneDir = mkdtempSync(join(tmpdir(), 'push-clone-'));
     execSync(`git clone ${originDir} .`, { cwd: cloneDir });
     execSync('git config user.email "test@test.com"', { cwd: cloneDir });
@@ -2007,6 +2010,7 @@ describe('BaseExecutor.pushBranchToRemote', () => {
 
   afterEach(() => {
     rmSync(originDir, { recursive: true, force: true });
+    rmSync(intermediateDir, { recursive: true, force: true });
     rmSync(cloneDir, { recursive: true, force: true });
   });
 
@@ -2035,6 +2039,20 @@ describe('BaseExecutor.pushBranchToRemote', () => {
     const err = await executor.testPushBranchToRemote(cloneDir, 'invoker/task-nopush');
     expect(err).toBeDefined();
     expect(typeof err).toBe('string');
+  });
+
+  it('pushes to intermediate remote when configured on request inputs', async () => {
+    execSync('git checkout -b invoker/task-intermediate', { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'intermediate.txt'), 'task result');
+    execSync('git add -A && git commit -m "task commit intermediate"', { cwd: cloneDir });
+
+    const req = makeRequest('task-intermediate', { intermediateRepoUrl: intermediateDir });
+    executor.registerTestEntry('exec-intermediate', req);
+    const pushErr = await executor.testPushBranchToRemote(cloneDir, 'invoker/task-intermediate', 'exec-intermediate');
+    expect(pushErr).toBeUndefined();
+
+    const remoteBranches = execSync('git branch', { cwd: intermediateDir }).toString();
+    expect(remoteBranches).toContain('invoker/task-intermediate');
   });
 });
 

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -345,6 +345,22 @@ describe('buildRecordAndPushScript', () => {
     expect(script).toContain(bashNormalizeTildePath());
   });
 
+  it('targets intermediate remote when pushRemoteUrl is provided', () => {
+    const script = buildRecordAndPushScript({
+      worktreePath: '~/worktree',
+      branch: 'branch',
+      commitMessageChanges: 'msg',
+      commitMessageEmpty: 'empty',
+      gitUserName: 'Invoker Bot',
+      gitUserEmail: 'invoker@local',
+      pushRemoteUrl: 'https://github.com/fork/repo.git',
+    });
+
+    expect(script).toContain('git remote set-url intermediate "$PUSH_URL"');
+    expect(script).toContain('git remote add intermediate "$PUSH_URL"');
+    expect(script).toContain('git push -u intermediate "$BR"');
+  });
+
   it('commits and pushes successfully without preconfigured git identity', () => {
     const root = mkdtempSync(join(tmpdir(), 'ssh-record-push-'));
     const source = join(root, 'source');

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -67,6 +67,7 @@ export class MergeConflictError extends Error {
 }
 
 export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor {
+  protected static readonly INTERMEDIATE_REMOTE_NAME = 'intermediate';
   abstract readonly type: string;
   protected entries = new Map<string, TEntry>();
   protected heartbeatIntervalMs: number;
@@ -596,7 +597,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     if (!commitHash) {
       return { error: 'commit approved fix failed' };
     }
-    const pushError = await this.pushBranchToRemote(cwd, branch);
+    const pushError = await this.pushBranchToRemote(cwd, branch, undefined, request.inputs.intermediateRepoUrl);
     if (pushError) {
       return { error: pushError };
     }
@@ -707,9 +708,36 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
    * Push task branch to remote after completion.
    * Returns `undefined` on success, or a short error message on failure (logged and echoed to the task stream).
    */
-  protected async pushBranchToRemote(cwd: string, branch: string, executionId?: string): Promise<string | undefined> {
+  protected async pushBranchToRemote(
+    cwd: string,
+    branch: string,
+    executionId?: string,
+    intermediateRepoUrlOverride?: string,
+  ): Promise<string | undefined> {
     try {
-      await this.execGitSimple(['push', '--force-with-lease', '-u', 'origin', branch], cwd);
+      const requestIntermediateRepoUrl = intermediateRepoUrlOverride ?? (executionId
+        ? this.entries.get(executionId)?.request.inputs.intermediateRepoUrl
+        : undefined);
+      const intermediateRepoUrl = requestIntermediateRepoUrl?.trim();
+      if (intermediateRepoUrl) {
+        try {
+          await this.execGitSimple(
+            ['remote', 'set-url', BaseExecutor.INTERMEDIATE_REMOTE_NAME, intermediateRepoUrl],
+            cwd,
+          );
+        } catch {
+          await this.execGitSimple(
+            ['remote', 'add', BaseExecutor.INTERMEDIATE_REMOTE_NAME, intermediateRepoUrl],
+            cwd,
+          );
+        }
+        await this.execGitSimple(
+          ['push', '--force-with-lease', '-u', BaseExecutor.INTERMEDIATE_REMOTE_NAME, branch],
+          cwd,
+        );
+      } else {
+        await this.execGitSimple(['push', '--force-with-lease', '-u', 'origin', branch], cwd);
+      }
       return undefined;
     } catch (err) {
       const msg = `[${this.type}] pushBranchToRemote failed for ${branch}: ${err}\n`;

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -209,7 +209,12 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
     await super.syncFromRemote(cwd, executionId);
   }
 
-  protected override async pushBranchToRemote(cwd: string, branch: string, executionId?: string): Promise<string | undefined> {
+  protected override async pushBranchToRemote(
+    cwd: string,
+    branch: string,
+    executionId?: string,
+    intermediateRepoUrlOverride?: string,
+  ): Promise<string | undefined> {
     try {
       await this.execGitSimple(['remote', 'get-url', 'origin'], cwd);
     } catch (err) {
@@ -220,9 +225,9 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
         if (executionId) this.emitOutput(executionId, msg);
         return undefined;
       }
-      return await super.pushBranchToRemote(cwd, branch, executionId);
+      return await super.pushBranchToRemote(cwd, branch, executionId, intermediateRepoUrlOverride);
     }
-    return await super.pushBranchToRemote(cwd, branch, executionId);
+    return await super.pushBranchToRemote(cwd, branch, executionId, intermediateRepoUrlOverride);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -217,6 +217,7 @@ export async function ensureLocalBranchForMerge(
   worktreeDir: string,
   branch: string,
   repoUrl?: string,
+  intermediateRepoUrl?: string,
 ): Promise<boolean> {
   let hadLocal = false;
   try {
@@ -238,6 +239,20 @@ export async function ensureLocalBranchForMerge(
     return true;
   } catch (err) {
     originErr = err;
+  }
+
+  const trimmedIntermediateRepoUrl = intermediateRepoUrl?.trim();
+  if (trimmedIntermediateRepoUrl) {
+    try {
+      await execGitInMergeSafe(
+        host,
+        ['fetch', trimmedIntermediateRepoUrl, `+refs/heads/${branch}:refs/heads/${branch}`],
+        worktreeDir,
+      );
+      return true;
+    } catch {
+      // Fall through to mirror fetch and final diagnostics.
+    }
   }
 
   const trimmedUrl = repoUrl?.trim();
@@ -617,7 +632,13 @@ export async function approveMergeImpl(
     const worktreeDir = await host.createMergeWorktree(baseBranch, 'approve-' + workflowId, workflow.repoUrl);
     try {
       mergeTrace('GIT_MERGE_SQUASH', { featureBranch, worktreeDir });
-      await ensureLocalBranchForMerge(host, worktreeDir, featureBranch, workflow.repoUrl);
+      await ensureLocalBranchForMerge(
+        host,
+        worktreeDir,
+        featureBranch,
+        workflow.repoUrl,
+        workflow.intermediateRepoUrl,
+      );
       await execGitInMergeSafe(host, ['merge', '--squash', featureBranch], worktreeDir);
       mergeTrace('GIT_COMMIT', { mergeMessage });
       const commitBody = fullSummary ? `${mergeMessage}\n\n${fullSummary}` : mergeMessage;
@@ -862,7 +883,13 @@ export async function publishAfterFixImpl(
         } catch { /* not an ancestor — needs merging */ }
 
         console.log(`[merge] Post-fix: merging task branch ${branch} → ${featureBranch}`);
-        const branchAvailable = await ensureLocalBranchForMerge(host, consolidateDir, branch, workflow?.repoUrl);
+        const branchAvailable = await ensureLocalBranchForMerge(
+          host,
+          consolidateDir,
+          branch,
+          workflow?.repoUrl,
+          workflow?.intermediateRepoUrl,
+        );
         if (!branchAvailable) {
           // Branch missing - skip gracefully if experiment branch
           if (branch.startsWith('experiment/')) {
@@ -1201,7 +1228,13 @@ export async function consolidateAndMergeImpl(
     let skippedCount = 0;
     for (const branch of taskBranches) {
       console.log(`[merge] Merging task branch: ${branch} → ${featureBranch}`);
-      const branchAvailable = await ensureLocalBranchForMerge(host, worktreeDir, branch, repoUrlForMerge);
+      const branchAvailable = await ensureLocalBranchForMerge(
+        host,
+        worktreeDir,
+        branch,
+        repoUrlForMerge,
+        workflowForMerge?.intermediateRepoUrl,
+      );
       if (!branchAvailable) {
         // Branch missing everywhere - check if already incorporated via ancestry
         console.log(`[merge] Branch ${branch} not found, checking if already incorporated...`);

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -500,6 +500,7 @@ echo ${payloadB64} | base64 -d | bash -se
       commitMessageEmpty: msgEmpty,
       gitUserName,
       gitUserEmail,
+      pushRemoteUrl: request.inputs.intermediateRepoUrl?.trim() || undefined,
     });
 
     try {

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -294,6 +294,7 @@ export interface GitRecordAndPushOpts {
   commitMessageEmpty: string;
   gitUserName: string;
   gitUserEmail: string;
+  pushRemoteUrl?: string;
 }
 
 /**
@@ -310,6 +311,7 @@ export function buildRecordAndPushScript(opts: GitRecordAndPushOpts): string {
   const emB = base64Encode(opts.commitMessageEmpty);
   const userNameB = base64Encode(opts.gitUserName);
   const userEmailB = base64Encode(opts.gitUserEmail);
+  const pushRemoteUrlB = base64Encode(opts.pushRemoteUrl ?? '');
 
   return `set -euo pipefail
 WT=$(echo ${wtB} | base64 -d)
@@ -329,7 +331,17 @@ else
 fi
 HASH=$(git rev-parse HEAD)
 BR=$(echo ${brB} | base64 -d)
-git push -u origin "$BR"
+PUSH_URL=$(echo ${pushRemoteUrlB} | base64 -d)
+if [ -n "$PUSH_URL" ]; then
+  if git remote get-url intermediate >/dev/null 2>&1; then
+    git remote set-url intermediate "$PUSH_URL"
+  else
+    git remote add intermediate "$PUSH_URL"
+  fi
+  git push -u intermediate "$BR"
+else
+  git push -u origin "$BR"
+fi
 printf "%s" "$HASH"
 `;
 }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -142,6 +142,7 @@ export interface TaskRunnerConfig {
 // ── TaskRunner ──────────────────────────────────────────
 
 export class TaskRunner {
+  private static readonly INTERMEDIATE_REMOTE_NAME = 'intermediate';
   /** @internal */ orchestrator: Orchestrator;
   /** @internal */ persistence: SQLiteAdapter;
   private executorRegistry: ExecutorRegistry;
@@ -441,6 +442,7 @@ export class TaskRunner {
     });
     const baseBranch = workflow?.baseBranch ?? this.defaultBranch;
     const repoUrl = workflow?.repoUrl;
+    const intermediateRepoUrl = workflow?.intermediateRepoUrl;
 
     // Persist the experiment branch as soon as the executor knows it — well
     // before `git worktree add` could leak a worktree without a recorded branch
@@ -479,6 +481,7 @@ export class TaskRunner {
         prompt: task.config.prompt,
         executionAgent: task.config.executionAgent?.trim() || DEFAULT_EXECUTION_AGENT,
         repoUrl,
+        intermediateRepoUrl,
         featureBranch: task.config.featureBranch,
         upstreamContext: upstreamContext.length > 0 ? upstreamContext : undefined,
         alternatives: alternatives.length > 0 ? alternatives : undefined,
@@ -874,6 +877,7 @@ export class TaskRunner {
       throw new Error(`Task ${task.id} has no branch for approved-fix publish`);
     }
 
+    const workflow = task.config.workflowId ? this.persistence.loadWorkflow?.(task.config.workflowId) : undefined;
     const request: WorkRequest = {
       requestId: randomUUID(),
       actionId: task.id,
@@ -884,6 +888,7 @@ export class TaskRunner {
         description: task.description,
         command: task.config.command,
         prompt: task.config.prompt,
+        intermediateRepoUrl: workflow?.intermediateRepoUrl,
       },
       callbackUrl: '',
       timestamps: {
@@ -1349,10 +1354,12 @@ export class TaskRunner {
       ?? await this.detectDefaultBranch();
 
     const reconWorkflowId = reconTask?.config.workflowId;
-    const reconRepoUrl =
+    const reconWorkflow =
       reconWorkflowId !== undefined && reconWorkflowId !== ''
-        ? this.persistence.loadWorkflow(reconWorkflowId)?.repoUrl
+        ? this.persistence.loadWorkflow(reconWorkflowId)
         : undefined;
+    const reconRepoUrl = reconWorkflow?.repoUrl;
+    const reconIntermediateRepoUrl = reconWorkflow?.intermediateRepoUrl;
 
     const worktreeDir = await this.createMergeWorktree(baseBranch, 'recon-' + reconTaskId, reconRepoUrl);
 
@@ -1370,13 +1377,12 @@ export class TaskRunner {
           throw new Error(`Experiment ${expId} has no branch`);
         }
         const b = expTask.execution.branch;
-        await ensureLocalBranchForMerge(this, worktreeDir, b, reconRepoUrl);
+        await ensureLocalBranchForMerge(this, worktreeDir, b, reconRepoUrl, reconIntermediateRepoUrl);
         const expMergeMsg = `Merge ${b} — ${expTask.description}`;
         await this.execGitIn(['merge', '--no-ff', '-m', expMergeMsg, b], worktreeDir);
       }
 
-      // Push reconciliation branch from clone to origin (GitHub)
-      await this.execGitIn(['push', '--force', 'origin', `${branchName}:refs/heads/${branchName}`], worktreeDir);
+      await this.pushBranchFromMergeWorktree(worktreeDir, branchName, reconIntermediateRepoUrl);
 
       const commit = await this.execGitIn(['rev-parse', 'HEAD'], worktreeDir);
       return { branch: branchName, commit };
@@ -1851,7 +1857,9 @@ export class TaskRunner {
       .filter((t) => t.config.workflowId === workflowId && t.status === 'completed' && t.execution.branch && !t.config.isMergeNode)
       .map((t) => t.execution.branch!);
 
-    const rebaseRepoUrl = this.persistence.loadWorkflow?.(workflowId)?.repoUrl;
+    const rebaseWorkflow = this.persistence.loadWorkflow?.(workflowId);
+    const rebaseRepoUrl = rebaseWorkflow?.repoUrl;
+    const rebaseIntermediateRepoUrl = rebaseWorkflow?.intermediateRepoUrl;
     const worktreeDir = await this.createMergeWorktree(baseBranch, 'rebase-' + workflowId, rebaseRepoUrl);
 
     const rebasedBranches: string[] = [];
@@ -1862,8 +1870,7 @@ export class TaskRunner {
         try {
           await this.execGitIn(['checkout', branch], worktreeDir);
           await this.execGitIn(['rebase', baseBranch], worktreeDir);
-          // Push rebased branch from clone to origin (GitHub)
-          await this.execGitIn(['push', '--force', 'origin', `${branch}:refs/heads/${branch}`], worktreeDir);
+          await this.pushBranchFromMergeWorktree(worktreeDir, branch, rebaseIntermediateRepoUrl);
           rebasedBranches.push(branch);
           this.logger.info(`[rebase] Successfully rebased ${branch} onto ${baseBranch}`);
         } catch (err) {
@@ -1882,6 +1889,34 @@ export class TaskRunner {
     } finally {
       await this.removeMergeWorktree(worktreeDir);
     }
+  }
+
+  private async pushBranchFromMergeWorktree(
+    worktreeDir: string,
+    branch: string,
+    intermediateRepoUrl?: string,
+  ): Promise<void> {
+    const trimmedIntermediateUrl = intermediateRepoUrl?.trim();
+    if (trimmedIntermediateUrl) {
+      try {
+        await this.execGitIn(
+          ['remote', 'set-url', TaskRunner.INTERMEDIATE_REMOTE_NAME, trimmedIntermediateUrl],
+          worktreeDir,
+        );
+      } catch {
+        await this.execGitIn(
+          ['remote', 'add', TaskRunner.INTERMEDIATE_REMOTE_NAME, trimmedIntermediateUrl],
+          worktreeDir,
+        );
+      }
+      await this.execGitIn(
+        ['push', '--force', TaskRunner.INTERMEDIATE_REMOTE_NAME, `${branch}:refs/heads/${branch}`],
+        worktreeDir,
+      );
+      return;
+    }
+
+    await this.execGitIn(['push', '--force', 'origin', `${branch}:refs/heads/${branch}`], worktreeDir);
   }
 
   /** @internal */ gitLogMessage(commitHash: string, cwd?: string): Promise<string> {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -156,6 +156,7 @@ export interface OrchestratorPersistence {
     createdAt: string;
     updatedAt: string;
     repoUrl?: string;
+    intermediateRepoUrl?: string;
     onFinish?: string;
     baseBranch?: string;
     featureBranch?: string;
@@ -196,6 +197,7 @@ export interface OrchestratorPersistence {
    */
   loadWorkflow?(workflowId: string): {
     repoUrl?: string;
+    intermediateRepoUrl?: string;
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
@@ -222,6 +224,7 @@ export interface PlanDefinition {
   mergeMode?: 'manual' | 'automatic' | 'external_review';
   reviewProvider?: string;
   repoUrl?: string;
+  intermediateRepoUrl?: string;
   tasks: Array<{
     id: string;
     description: string;
@@ -1326,6 +1329,7 @@ export class Orchestrator {
       visualProof: plan.visualProof,
       status: 'running',
       repoUrl: plan.repoUrl,
+      intermediateRepoUrl: plan.intermediateRepoUrl,
       onFinish: plan.onFinish,
       baseBranch: plan.baseBranch,
       featureBranch: plan.featureBranch,
@@ -3092,6 +3096,7 @@ export class Orchestrator {
       if (typeof m.description === 'string') baseSaveWf.description = m.description;
       if (typeof m.visualProof === 'boolean') baseSaveWf.visualProof = m.visualProof as boolean;
       if (typeof m.repoUrl === 'string') baseSaveWf.repoUrl = m.repoUrl;
+      if (typeof m.intermediateRepoUrl === 'string') baseSaveWf.intermediateRepoUrl = m.intermediateRepoUrl;
       if (typeof m.onFinish === 'string') baseSaveWf.onFinish = m.onFinish;
       if (typeof m.baseBranch === 'string') baseSaveWf.baseBranch = m.baseBranch;
       if (typeof m.featureBranch === 'string') baseSaveWf.featureBranch = m.featureBranch;

--- a/scripts/repro/repro-intermediate-repo-url-routing-local.sh
+++ b/scripts/repro/repro-intermediate-repo-url-routing-local.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+TMP_DIR="$(mktemp -d)"
+DB_DIR="$TMP_DIR/db"
+ORIGIN_BARE="$TMP_DIR/remotes/origin/Invoker.git"
+INTERMEDIATE_BARE="$TMP_DIR/remotes/intermediate/test-playground.git"
+SEED_REPO="$TMP_DIR/seed"
+PLAN_TMP="$TMP_DIR/plan.yaml"
+CFG_PATH="$TMP_DIR/config.json"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+mkdir -p "$TMP_DIR/remotes/origin" "$TMP_DIR/remotes/intermediate" "$DB_DIR"
+
+echo "[setup] creating isolated origin + intermediate remotes"
+git init --bare "$ORIGIN_BARE" >/dev/null
+git init --bare "$INTERMEDIATE_BARE" >/dev/null
+
+echo "[setup] seeding master in both remotes"
+git clone "$ORIGIN_BARE" "$SEED_REPO" >/dev/null
+git -C "$SEED_REPO" config user.email "test@example.com"
+git -C "$SEED_REPO" config user.name "test-user"
+echo "seed" > "$SEED_REPO/README.md"
+git -C "$SEED_REPO" add README.md
+git -C "$SEED_REPO" commit -m "seed" >/dev/null
+git -C "$SEED_REPO" push origin master >/dev/null
+git -C "$SEED_REPO" remote add intermediate "$INTERMEDIATE_BARE"
+git -C "$SEED_REPO" push intermediate master >/dev/null
+
+ORIGIN_MASTER_BEFORE="$(git --git-dir "$ORIGIN_BARE" rev-parse refs/heads/master)"
+INTERMEDIATE_MASTER_BEFORE="$(git --git-dir "$INTERMEDIATE_BARE" rev-parse refs/heads/master)"
+ORIGIN_URI="file://$ORIGIN_BARE"
+INTERMEDIATE_URI="file://$INTERMEDIATE_BARE"
+
+echo "[setup] writing custom plan with guaranteed file changes"
+cat > "$PLAN_TMP" <<EOF
+name: Intermediate Repo URL Local Proof
+repoUrl: $ORIGIN_URI
+intermediateRepoUrl: $INTERMEDIATE_URI
+onFinish: merge
+baseBranch: master
+featureBranch: plan/intermediate-routing-proof
+tasks:
+  - id: local-proof-a
+    description: add proof line A
+    command: |
+      echo "proof-a" >> ROUTING_PROOF.txt
+      git add ROUTING_PROOF.txt
+  - id: local-proof-b
+    description: add proof line B
+    dependencies: [local-proof-a]
+    command: |
+      echo "proof-b" >> ROUTING_PROOF.txt
+      git add ROUTING_PROOF.txt
+EOF
+
+cat > "$CFG_PATH" <<'JSON'
+{
+  "workspaceRoot": "/tmp",
+  "remoteTargets": []
+}
+JSON
+
+cd "$ROOT"
+echo "[run] executing headless plan"
+INVOKER_DB_DIR="$DB_DIR" \
+INVOKER_REPO_CONFIG_PATH="$CFG_PATH" \
+INVOKER_HEADLESS_STANDALONE=1 \
+./run.sh --headless run "$PLAN_TMP" >/dev/null
+
+TASKS_JSON="$(
+  INVOKER_DB_DIR="$DB_DIR" \
+  INVOKER_REPO_CONFIG_PATH="$CFG_PATH" \
+  INVOKER_HEADLESS_STANDALONE=1 \
+  ./run.sh --headless query tasks --output json
+)"
+
+TASKS_FILE="$TMP_DIR/tasks.json"
+printf '%s\n' "$TASKS_JSON" > "$TASKS_FILE"
+
+MERGE_ID="$(
+  python3 - <<'PY' "$TASKS_FILE"
+import json
+import sys
+
+tasks = json.loads(open(sys.argv[1], encoding="utf-8").read())
+merge = [t.get("id", "") for t in tasks if (t.get("config") or {}).get("isMergeNode", False)]
+print(merge[0] if merge else "")
+PY
+)"
+
+if [[ -z "$MERGE_ID" ]]; then
+  echo "FAIL: could not find merge gate task id in task records" >&2
+  exit 1
+fi
+
+NON_MERGE_BRANCHES="$(
+  python3 - <<'PY' "$TASKS_FILE"
+import json
+import sys
+
+tasks = json.loads(open(sys.argv[1], encoding="utf-8").read())
+branches = sorted({
+    (task.get("execution") or {}).get("branch", "")
+    for task in tasks
+    if not ((task.get("config") or {}).get("isMergeNode", False))
+})
+print("\n".join([b for b in branches if b]))
+PY
+)"
+
+if [[ -z "$NON_MERGE_BRANCHES" ]]; then
+  echo "FAIL: no non-merge task branches captured from execution records" >&2
+  exit 1
+fi
+
+echo "[run] approving merge gate to trigger final publish ($MERGE_ID)"
+INVOKER_DB_DIR="$DB_DIR" \
+INVOKER_REPO_CONFIG_PATH="$CFG_PATH" \
+INVOKER_HEADLESS_STANDALONE=1 \
+./run.sh --headless approve "$MERGE_ID" >/dev/null
+
+echo "[verify] non-merge branches route to intermediate only"
+FAIL=0
+while IFS= read -r branch; do
+  [[ -z "$branch" ]] && continue
+
+  set +e
+  git --git-dir "$INTERMEDIATE_BARE" show-ref --verify --quiet "refs/heads/$branch"
+  INTERMEDIATE_STATUS=$?
+  git --git-dir "$ORIGIN_BARE" show-ref --verify --quiet "refs/heads/$branch"
+  ORIGIN_STATUS=$?
+  set -e
+
+  echo "  branch=$branch intermediate=$INTERMEDIATE_STATUS origin=$ORIGIN_STATUS"
+  if [[ $INTERMEDIATE_STATUS -ne 0 || $ORIGIN_STATUS -eq 0 ]]; then
+    FAIL=1
+  fi
+done <<< "$NON_MERGE_BRANCHES"
+
+ORIGIN_MASTER_AFTER="$(git --git-dir "$ORIGIN_BARE" rev-parse refs/heads/master)"
+INTERMEDIATE_MASTER_AFTER="$(git --git-dir "$INTERMEDIATE_BARE" rev-parse refs/heads/master)"
+
+echo "[verify] final merge publish lands on origin/master only"
+echo "  origin/master:       $ORIGIN_MASTER_BEFORE -> $ORIGIN_MASTER_AFTER"
+echo "  intermediate/master: $INTERMEDIATE_MASTER_BEFORE -> $INTERMEDIATE_MASTER_AFTER"
+
+if [[ "$ORIGIN_MASTER_BEFORE" == "$ORIGIN_MASTER_AFTER" ]]; then
+  echo "FAIL: origin/master did not advance; expected merge-node publish to origin" >&2
+  exit 1
+fi
+
+if [[ "$INTERMEDIATE_MASTER_BEFORE" != "$INTERMEDIATE_MASTER_AFTER" ]]; then
+  echo "FAIL: intermediate/master changed; merge-node publish should not target intermediate" >&2
+  exit 1
+fi
+
+if [[ $FAIL -ne 0 ]]; then
+  echo "FAIL: one or more non-merge branches were not routed to intermediate-only" >&2
+  exit 1
+fi
+
+echo "PASS: non-merge branches pushed to intermediate, final merge publish pushed to origin"


### PR DESCRIPTION
## Summary
- add optional `intermediateRepoUrl` plan/workflow plumbing and persist it through parser, orchestrator, contracts, and sqlite storage
- route non-merge branch publish/fetch paths to `intermediateRepoUrl` when configured, while keeping merge-gate final publish and PR targeting on `origin`
- add regression coverage plus a local repro script proving intermediate-only non-merge branch routing and origin-only final merge publish

## Test plan
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/plan-parser.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/auto-commit.test.ts src/__tests__/ssh-git-exec.test.ts src/__tests__/bridge-orchestrator-executor.test.ts`
- [x] `scripts/repro/repro-intermediate-repo-url-routing-local.sh`

Made with [Cursor](https://cursor.com)