### PR TITLE
[DB OOM] throttle lease renewal writes in coordinator

### DIFF
--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -15,6 +15,14 @@ type InvalidationSignal = {
   reject: (error: unknown) => void;
 };
 
+function envMs(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
 class WorkflowMutationInvalidatedError extends Error {
   constructor(message: string) {
     super(message);
@@ -29,6 +37,14 @@ export class PersistedWorkflowMutationCoordinator {
   private readonly drainingWorkflows = new Set<string>();
   private readonly pendingDrainWorkflows = new Set<string>();
   private readonly leaseHeartbeatMs = Math.max(1_000, Math.floor(WORKFLOW_MUTATION_LEASE_MS / 3));
+  private readonly leaseRenewMinIntervalMs = Math.max(
+    500,
+    envMs('INVOKER_MUTATION_LEASE_RENEW_MIN_INTERVAL_MS', 2_000),
+  );
+  private readonly leaseRenewMinExpiryLeadMs = Math.max(
+    this.leaseHeartbeatMs,
+    envMs('INVOKER_MUTATION_LEASE_RENEW_MIN_EXPIRY_LEAD_MS', 12_000),
+  );
   private readonly maxConcurrentWorkflowDrains: number;
   private readonly enableTraceLogs: boolean;
   private activeWorkflowDrains = 0;
@@ -166,6 +182,8 @@ export class PersistedWorkflowMutationCoordinator {
         this.persistence.renewWorkflowMutationLease(workflowId, this.ownerId, {
           activeIntentId: intent.id,
           activeMutationKind: intent.channel,
+          minHeartbeatIntervalMs: this.leaseRenewMinIntervalMs,
+          minExpiryLeadMs: this.leaseRenewMinExpiryLeadMs,
         });
         await this.executeIntent(workflowId, intent);
         this.trace(`drain-finished workflow=${workflowId} intent=${intent.id} channel=${intent.channel}`);
@@ -184,6 +202,8 @@ export class PersistedWorkflowMutationCoordinator {
       this.persistence.renewWorkflowMutationLease(workflowId, this.ownerId, {
         activeIntentId: intent.id,
         activeMutationKind: intent.channel,
+        minHeartbeatIntervalMs: this.leaseRenewMinIntervalMs,
+        minExpiryLeadMs: this.leaseRenewMinExpiryLeadMs,
       });
     }, this.leaseHeartbeatMs);
     try {
@@ -209,7 +229,10 @@ export class PersistedWorkflowMutationCoordinator {
     } finally {
       clearInterval(leaseHeartbeat);
       this.runningIntentInvalidations.delete(intent.id);
-      this.persistence.renewWorkflowMutationLease(workflowId, this.ownerId);
+      this.persistence.renewWorkflowMutationLease(workflowId, this.ownerId, {
+        minHeartbeatIntervalMs: this.leaseRenewMinIntervalMs,
+        minExpiryLeadMs: this.leaseRenewMinExpiryLeadMs,
+      });
       this.inFlightPromises.delete(intent.id);
       this.enqueueStartedAtMs.delete(intent.id);
     }

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1964,7 +1964,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
   renewWorkflowMutationLease(
     workflowId: string,
     ownerId: string,
-    options?: { activeIntentId?: number; activeMutationKind?: string },
+    options?: {
+      activeIntentId?: number;
+      activeMutationKind?: string;
+      minHeartbeatIntervalMs?: number;
+      minExpiryLeadMs?: number;
+    },
   ): boolean {
     const lease = this.queryOne(
       'SELECT * FROM workflow_mutation_leases WHERE workflow_id = ?',
@@ -1974,8 +1979,31 @@ export class SQLiteAdapter implements PersistenceAdapter {
       return false;
     }
 
+    const nowMs = Date.now();
+    const nextIntentId = options?.activeIntentId ?? null;
+    const nextMutationKind = options?.activeMutationKind ?? null;
+    const sameIntent = String(lease.active_intent_id ?? '') === String(nextIntentId ?? '');
+    const sameKind = String(lease.active_mutation_kind ?? '') === String(nextMutationKind ?? '');
+    const lastHeartbeatMs = lease.last_heartbeat_at ? Date.parse(String(lease.last_heartbeat_at)) : 0;
+    const leaseExpiryMs = lease.lease_expires_at ? Date.parse(String(lease.lease_expires_at)) : 0;
+    const minHeartbeatIntervalMs = options?.minHeartbeatIntervalMs ?? 0;
+    const minExpiryLeadMs = options?.minExpiryLeadMs ?? 0;
+
+    if (
+      sameIntent &&
+      sameKind &&
+      minHeartbeatIntervalMs > 0 &&
+      Number.isFinite(lastHeartbeatMs) &&
+      lastHeartbeatMs > 0 &&
+      nowMs - lastHeartbeatMs < minHeartbeatIntervalMs &&
+      Number.isFinite(leaseExpiryMs) &&
+      leaseExpiryMs - nowMs > minExpiryLeadMs
+    ) {
+      return true;
+    }
+
     const now = new Date().toISOString();
-    const leaseExpiresAt = new Date(Date.now() + WORKFLOW_MUTATION_LEASE_MS).toISOString();
+    const leaseExpiresAt = new Date(nowMs + WORKFLOW_MUTATION_LEASE_MS).toISOString();
     this.execRun(
       `UPDATE workflow_mutation_leases
          SET active_intent_id = ?,

--- a/scripts/repro-workflow-mutation-oom.mjs
+++ b/scripts/repro-workflow-mutation-oom.mjs
@@ -88,21 +88,51 @@ function queryOne(db, sql, params = []) {
   return row;
 }
 
-function renewWorkflowMutationLease(db, workflowId, ownerId) {
+function renewWorkflowMutationLease(db, workflowId, ownerId, options = {}) {
   const lease = queryOne(
     db,
     'SELECT * FROM workflow_mutation_leases WHERE workflow_id = ?',
     [workflowId]
   );
-  if (!lease || String(lease.owner_id) !== ownerId) return false;
+  if (!lease || String(lease.owner_id) !== ownerId) return 'lost';
+  const nowMs = Date.now();
+  const nextIntentId = options.activeIntentId ?? null;
+  const nextMutationKind = options.activeMutationKind ?? null;
+  const sameIntent = String(lease.active_intent_id ?? '') === String(nextIntentId ?? '');
+  const sameKind = String(lease.active_mutation_kind ?? '') === String(nextMutationKind ?? '');
+  const lastHeartbeatMs = lease.last_heartbeat_at ? Date.parse(String(lease.last_heartbeat_at)) : 0;
+  const leaseExpiryMs = lease.lease_expires_at ? Date.parse(String(lease.lease_expires_at)) : 0;
+  const minHeartbeatIntervalMs = options.minHeartbeatIntervalMs ?? 0;
+  const minExpiryLeadMs = options.minExpiryLeadMs ?? 0;
+
+  if (
+    sameIntent &&
+    sameKind &&
+    minHeartbeatIntervalMs > 0 &&
+    Number.isFinite(lastHeartbeatMs) &&
+    lastHeartbeatMs > 0 &&
+    nowMs - lastHeartbeatMs < minHeartbeatIntervalMs &&
+    Number.isFinite(leaseExpiryMs) &&
+    leaseExpiryMs - nowMs > minExpiryLeadMs
+  ) {
+    return 'skipped';
+  }
+
   const now = new Date().toISOString();
   db.run(
     `UPDATE workflow_mutation_leases
        SET active_intent_id = ?, active_mutation_kind = ?, last_heartbeat_at = ?, lease_expires_at = ?
      WHERE workflow_id = ? AND owner_id = ?`,
-    [1, 'dispatch', now, now, workflowId, ownerId]
+    [
+      nextIntentId,
+      nextMutationKind,
+      now,
+      new Date(nowMs + 30000).toISOString(),
+      workflowId,
+      ownerId,
+    ]
   );
-  return true;
+  return 'updated';
 }
 
 function fillLargeTables(db, rows, payloadBytes) {
@@ -166,6 +196,8 @@ async function main() {
   const maxDbMb = envInt('REPRO_MAX_DB_MB', defaults.maxDbMb);
   const hardHeapLimitMb = envInt('REPRO_SQLITE_HARD_HEAP_LIMIT_MB', defaults.hardHeapLimitMb);
   const timeoutSec = envInt('REPRO_TIMEOUT_SEC', defaults.timeoutSec);
+  const leaseRenewMinIntervalMs = envInt('INVOKER_MUTATION_LEASE_RENEW_MIN_INTERVAL_MS', 2_000);
+  const leaseRenewMinExpiryLeadMs = envInt('INVOKER_MUTATION_LEASE_RENEW_MIN_EXPIRY_LEAD_MS', 12_000);
   const rootWorkflow = 'wf-1778141536943-7/post-fix-regression';
   const workflowId = 'wf-oom';
   const ownerId = 'owner-oom';
@@ -181,6 +213,7 @@ async function main() {
   let lastFlushAt = 0;
   let flushIntervalTotalMs = 0;
   let leaseRenewWrites = 0;
+  let leaseRenewUpdateWrites = 0;
   let seededIntentRows = 0;
   let failureReason = null;
 
@@ -188,7 +221,9 @@ async function main() {
   console.error(
     `[repro] mode=${mode} rowsPerCycle=${rowsPerCycle} payloadBytes=${payloadBytes} renewsPerCycle=${renewsPerCycle} maxCycles=${maxCycles} hardHeapLimitMb=${hardHeapLimitMb} maxDbMb=${maxDbMb} timeoutSec=${timeoutSec}`
   );
-  console.error(`[repro] flushDebounceMs=${flushDebounceMs} exportEvery=${exportEvery}`);
+  console.error(
+    `[repro] flushDebounceMs=${flushDebounceMs} exportEvery=${exportEvery} leaseRenewMinIntervalMs=${leaseRenewMinIntervalMs} leaseRenewMinExpiryLeadMs=${leaseRenewMinExpiryLeadMs}`
+  );
 
   db.run(`
     CREATE TABLE workflow_mutation_intents (
@@ -256,8 +291,14 @@ async function main() {
       seededIntentRows += rowsPerCycle;
       console.error(`[repro] cycle=${cycle} seeded rows; starting renew loop`);
       for (let i = 1; i <= renewsPerCycle; i += 1) {
-        renewWorkflowMutationLease(db, workflowId, ownerId);
+        const renewResult = renewWorkflowMutationLease(db, workflowId, ownerId, {
+          activeIntentId: 1,
+          activeMutationKind: 'dispatch',
+          minHeartbeatIntervalMs: leaseRenewMinIntervalMs,
+          minExpiryLeadMs: leaseRenewMinExpiryLeadMs,
+        });
         leaseRenewWrites += 1;
+        if (renewResult === 'updated') leaseRenewUpdateWrites += 1;
         db.run('INSERT INTO output_spool (task_id, offset, data) VALUES (?, ?, ?)', [
           'wf-oom/task',
           (cycle * renewsPerCycle) + i,
@@ -298,6 +339,9 @@ async function main() {
     const leaseRenewWritesPerSec = elapsedMs > 0
       ? Number(((leaseRenewWrites * 1000) / elapsedMs).toFixed(2))
       : 0;
+    const leaseRenewUpdateWritesPerSec = elapsedMs > 0
+      ? Number(((leaseRenewUpdateWrites * 1000) / elapsedMs).toFixed(2))
+      : 0;
     const mutationThroughputPerSec = elapsedMs > 0
       ? Number(((seededIntentRows * 1000) / elapsedMs).toFixed(2))
       : 0;
@@ -309,6 +353,8 @@ async function main() {
         meanFlushIntervalMs,
         leaseRenewWrites,
         leaseRenewWritesPerSec,
+        leaseRenewUpdateWrites,
+        leaseRenewUpdateWritesPerSec,
         seededIntentRows,
         mutationThroughputPerSec,
         failureReason,

--- a/scripts/run-oom-benchmark-matrix.mjs
+++ b/scripts/run-oom-benchmark-matrix.mjs
@@ -74,6 +74,7 @@ function runOne(mode, extraEnv = {}) {
     meanFlushIntervalMs: summary?.meanFlushIntervalMs ?? null,
     dbGrowthRateMbPerMin,
     leaseRenewWritesPerSec: summary?.leaseRenewWritesPerSec ?? 0,
+    leaseRenewUpdateWritesPerSec: summary?.leaseRenewUpdateWritesPerSec ?? summary?.leaseRenewWritesPerSec ?? 0,
     mutationThroughputPerSec: summary?.mutationThroughputPerSec ?? 0,
   };
   return { metrics, log };
@@ -86,10 +87,10 @@ function writeMarkdown(outPath, runLabel, commit, results) {
   lines.push(`- Commit: \`${commit}\``);
   lines.push(`- Generated: ${new Date().toISOString()}`);
   lines.push('');
-  lines.push('| mode | status | time-to-failure/completion (s) | peak RSS (MB) | peak external (MB) | flush count | mean flush interval (ms) | db growth (MB/min) | lease renew writes/sec | mutation throughput (intents/sec) |');
+  lines.push('| mode | status | time-to-failure/completion (s) | peak RSS (MB) | peak external (MB) | flush count | mean flush interval (ms) | db growth (MB/min) | lease renew update writes/sec | mutation throughput (intents/sec) |');
   lines.push('|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|');
   for (const r of results) {
-    lines.push(`| ${r.mode} | ${r.status} | ${r.elapsedSec} | ${r.peakRssMb} | ${r.peakExternalMb} | ${r.flushCount} | ${r.meanFlushIntervalMs ?? 'n/a'} | ${r.dbGrowthRateMbPerMin} | ${r.leaseRenewWritesPerSec} | ${r.mutationThroughputPerSec} |`);
+    lines.push(`| ${r.mode} | ${r.status} | ${r.elapsedSec} | ${r.peakRssMb} | ${r.peakExternalMb} | ${r.flushCount} | ${r.meanFlushIntervalMs ?? 'n/a'} | ${r.dbGrowthRateMbPerMin} | ${r.leaseRenewUpdateWritesPerSec} | ${r.mutationThroughputPerSec} |`);
   }
   lines.push('');
   lines.push('## Failure Reasons');


### PR DESCRIPTION
## Summary

Throttle lease renew persistence writes so heartbeats only update storage when freshness/expiry thresholds require it, reducing write amplification in the mutation coordinator.

## Architecture

### Before

```mermaid
flowchart TD
  heartbeatTick[HeartbeatTick]
  renewCall[RenewLease]
  updateRow[UpdateLeaseRow]
  flushPath[FlushPath]
  heartbeatTick --> renewCall --> updateRow --> flushPath
```

### After

```mermaid
flowchart TD
  heartbeatTick[HeartbeatTick]
  renewCall[RenewLease]
  throttleCheck[FreshnessAndExpiryCheck]
  updateRow[UpdateLeaseRow]
  skipWrite[SkipWrite]
  flushPath[FlushPath]
  heartbeatTick --> renewCall --> throttleCheck
  throttleCheck -->|writeNeeded| updateRow --> flushPath
  throttleCheck -->|stillFresh| skipWrite
```

## Comparison

- Other queue/coordinator systems (including those backed by native DB engines) commonly gate heartbeats to avoid unnecessary lease churn.
- Without gating, sql.js pays full write/export overhead even for semantically redundant renewals.
- This solution is proper because it preserves lease safety while collapsing renew update writes/sec from ~391 to ~0.5 in the benchmark.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- persisted-workflow-mutation-coordinator.test.ts`
- [x] `REPRO_TIMEOUT_SEC=20 node scripts/run-oom-benchmark-matrix.mjs step2-lease-throttle`

## Benchmark Results (safe mode, PR357 vs PR355)

| metric | baseline | step2 | delta |
|---|---:|---:|---:|
| time (s) | 20.14 | 20.10 | -0.04 |
| peak RSS (MB) | 582.8 | 564.3 | -18.5 |
| peak external (MB) | 521.5 | 490.3 | -31.2 |
| lease renew update writes/sec | 390.94 | 0.50 | -390.44 |
| flush count | 104 | 103 | -1 |
| db growth (MB/min) | 383.94 | 385.63 | +1.69 |

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 4ba2221`
- Post-revert steps: None.
- Data migration? No.
