### PR TITLE
[DB OOM] add retention pruning for mutation history

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -212,6 +212,7 @@ function dispatchStartedTasks(tasks: TaskState[]): void {
 let workflowMutationCoordinator: PersistedWorkflowMutationCoordinator | null = null;
 const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
+let retentionPruneInterval: ReturnType<typeof setInterval> | null = null;
 let writerLock: DbWriterLockResult | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
 const appProcessStartedAt = Date.now();
@@ -233,6 +234,17 @@ function resolveMaxConcurrentWorkflowDrains(): number {
 }
 
 const maxConcurrentWorkflowDrains = resolveMaxConcurrentWorkflowDrains();
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (Number.isInteger(parsed) && parsed > 0) {
+    return parsed;
+  }
+  process.stderr.write(`[retention] ignoring invalid ${name}=\"${raw}\", using ${fallback}\n`);
+  return fallback;
+}
 
 interface GuiMutationPayload {
   channel: string;
@@ -395,6 +407,37 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
       hourlyBackupInterval.unref?.();
       logger.info(`hourly snapshots enabled (interval=${hourlyMs}ms)`, { module: 'backup' });
     }
+  }
+  if (!readOnly && !retentionPruneInterval) {
+    const pruneIntervalMs = readPositiveIntEnv('INVOKER_RETENTION_PRUNE_INTERVAL_MS', 5 * 60 * 1000);
+    const maxCompletedIntents = readPositiveIntEnv('INVOKER_RETENTION_MAX_COMPLETED_INTENTS', 20_000);
+    const maxOutputRows = readPositiveIntEnv('INVOKER_RETENTION_MAX_OUTPUT_ROWS', 300_000);
+    const runRetentionPrune = () => {
+      try {
+        const pruned = persistence.pruneWorkflowMutationHistory({
+          maxCompletedIntents,
+          maxOutputRows,
+        });
+        if (pruned.deletedIntents > 0 || pruned.deletedOutputRows > 0) {
+          logger.info(
+            `retention prune removed intents=${pruned.deletedIntents} outputRows=${pruned.deletedOutputRows}`,
+            { module: 'retention' },
+          );
+        }
+      } catch (err) {
+        logger.error(
+          `retention prune failed: ${err instanceof Error ? err.message : String(err)}`,
+          { module: 'retention' },
+        );
+      }
+    };
+    runRetentionPrune();
+    retentionPruneInterval = setInterval(runRetentionPrune, pruneIntervalMs);
+    retentionPruneInterval.unref?.();
+    logger.info(
+      `retention prune enabled (interval=${pruneIntervalMs}ms completedIntents=${maxCompletedIntents} outputRows=${maxOutputRows})`,
+      { module: 'retention' },
+    );
   }
   // Compose runtime services from persistence-backed adapters.
   // Headless startup routes through composeHeadlessStartup so the
@@ -3655,6 +3698,10 @@ if (isHeadless) {
       if (hourlyBackupInterval) {
         clearInterval(hourlyBackupInterval);
         hourlyBackupInterval = null;
+      }
+      if (retentionPruneInterval) {
+        clearInterval(retentionPruneInterval);
+        retentionPruneInterval = null;
       }
       if (executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -15,6 +15,14 @@ type InvalidationSignal = {
   reject: (error: unknown) => void;
 };
 
+function envMs(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
 class WorkflowMutationInvalidatedError extends Error {
   constructor(message: string) {
     super(message);
@@ -29,6 +37,14 @@ export class PersistedWorkflowMutationCoordinator {
   private readonly drainingWorkflows = new Set<string>();
   private readonly pendingDrainWorkflows = new Set<string>();
   private readonly leaseHeartbeatMs = Math.max(1_000, Math.floor(WORKFLOW_MUTATION_LEASE_MS / 3));
+  private readonly leaseRenewMinIntervalMs = Math.max(
+    500,
+    envMs('INVOKER_MUTATION_LEASE_RENEW_MIN_INTERVAL_MS', 2_000),
+  );
+  private readonly leaseRenewMinExpiryLeadMs = Math.max(
+    this.leaseHeartbeatMs,
+    envMs('INVOKER_MUTATION_LEASE_RENEW_MIN_EXPIRY_LEAD_MS', 12_000),
+  );
   private readonly maxConcurrentWorkflowDrains: number;
   private readonly enableTraceLogs: boolean;
   private activeWorkflowDrains = 0;
@@ -166,6 +182,8 @@ export class PersistedWorkflowMutationCoordinator {
         this.persistence.renewWorkflowMutationLease(workflowId, this.ownerId, {
           activeIntentId: intent.id,
           activeMutationKind: intent.channel,
+          minHeartbeatIntervalMs: this.leaseRenewMinIntervalMs,
+          minExpiryLeadMs: this.leaseRenewMinExpiryLeadMs,
         });
         await this.executeIntent(workflowId, intent);
         this.trace(`drain-finished workflow=${workflowId} intent=${intent.id} channel=${intent.channel}`);
@@ -184,6 +202,8 @@ export class PersistedWorkflowMutationCoordinator {
       this.persistence.renewWorkflowMutationLease(workflowId, this.ownerId, {
         activeIntentId: intent.id,
         activeMutationKind: intent.channel,
+        minHeartbeatIntervalMs: this.leaseRenewMinIntervalMs,
+        minExpiryLeadMs: this.leaseRenewMinExpiryLeadMs,
       });
     }, this.leaseHeartbeatMs);
     try {
@@ -209,7 +229,10 @@ export class PersistedWorkflowMutationCoordinator {
     } finally {
       clearInterval(leaseHeartbeat);
       this.runningIntentInvalidations.delete(intent.id);
-      this.persistence.renewWorkflowMutationLease(workflowId, this.ownerId);
+      this.persistence.renewWorkflowMutationLease(workflowId, this.ownerId, {
+        minHeartbeatIntervalMs: this.leaseRenewMinIntervalMs,
+        minExpiryLeadMs: this.leaseRenewMinExpiryLeadMs,
+      });
       this.inFlightPromises.delete(intent.id);
       this.enqueueStartedAtMs.delete(intent.id);
     }

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2048,6 +2048,47 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return workflowIds.length;
   }
 
+  pruneWorkflowMutationHistory(options?: { maxCompletedIntents?: number; maxOutputRows?: number }): {
+    deletedIntents: number;
+    deletedOutputRows: number;
+  } {
+    const maxCompletedIntents = Math.max(0, Math.floor(options?.maxCompletedIntents ?? 0));
+    const maxOutputRows = Math.max(0, Math.floor(options?.maxOutputRows ?? 0));
+    let deletedIntents = 0;
+    let deletedOutputRows = 0;
+
+    if (maxCompletedIntents > 0) {
+      this.execRun(
+        `DELETE FROM workflow_mutation_intents
+         WHERE id IN (
+           SELECT id
+           FROM workflow_mutation_intents
+           WHERE status IN ('completed', 'failed')
+           ORDER BY id DESC
+           LIMIT -1 OFFSET ?
+         )`,
+        [maxCompletedIntents],
+      );
+      deletedIntents = this.db.getRowsModified();
+    }
+
+    if (maxOutputRows > 0) {
+      this.execRun(
+        `DELETE FROM output_spool
+         WHERE id IN (
+           SELECT id
+           FROM output_spool
+           ORDER BY id DESC
+           LIMIT -1 OFFSET ?
+         )`,
+        [maxOutputRows],
+      );
+      deletedOutputRows = this.db.getRowsModified();
+    }
+
+    return { deletedIntents, deletedOutputRows };
+  }
+
   completeWorkflowMutationIntent(id: number): void {
     this.execRun(
       `UPDATE workflow_mutation_intents

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1964,7 +1964,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
   renewWorkflowMutationLease(
     workflowId: string,
     ownerId: string,
-    options?: { activeIntentId?: number; activeMutationKind?: string },
+    options?: {
+      activeIntentId?: number;
+      activeMutationKind?: string;
+      minHeartbeatIntervalMs?: number;
+      minExpiryLeadMs?: number;
+    },
   ): boolean {
     const lease = this.queryOne(
       'SELECT * FROM workflow_mutation_leases WHERE workflow_id = ?',
@@ -1974,8 +1979,31 @@ export class SQLiteAdapter implements PersistenceAdapter {
       return false;
     }
 
+    const nowMs = Date.now();
+    const nextIntentId = options?.activeIntentId ?? null;
+    const nextMutationKind = options?.activeMutationKind ?? null;
+    const sameIntent = String(lease.active_intent_id ?? '') === String(nextIntentId ?? '');
+    const sameKind = String(lease.active_mutation_kind ?? '') === String(nextMutationKind ?? '');
+    const lastHeartbeatMs = lease.last_heartbeat_at ? Date.parse(String(lease.last_heartbeat_at)) : 0;
+    const leaseExpiryMs = lease.lease_expires_at ? Date.parse(String(lease.lease_expires_at)) : 0;
+    const minHeartbeatIntervalMs = options?.minHeartbeatIntervalMs ?? 0;
+    const minExpiryLeadMs = options?.minExpiryLeadMs ?? 0;
+
+    if (
+      sameIntent &&
+      sameKind &&
+      minHeartbeatIntervalMs > 0 &&
+      Number.isFinite(lastHeartbeatMs) &&
+      lastHeartbeatMs > 0 &&
+      nowMs - lastHeartbeatMs < minHeartbeatIntervalMs &&
+      Number.isFinite(leaseExpiryMs) &&
+      leaseExpiryMs - nowMs > minExpiryLeadMs
+    ) {
+      return true;
+    }
+
     const now = new Date().toISOString();
-    const leaseExpiresAt = new Date(Date.now() + WORKFLOW_MUTATION_LEASE_MS).toISOString();
+    const leaseExpiresAt = new Date(nowMs + WORKFLOW_MUTATION_LEASE_MS).toISOString();
     this.execRun(
       `UPDATE workflow_mutation_leases
          SET active_intent_id = ?,

--- a/scripts/repro-workflow-mutation-oom.mjs
+++ b/scripts/repro-workflow-mutation-oom.mjs
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const MB = 1024 * 1024;
+const VALID_MODES = new Set(['safe', 'sandbox']);
+
+function envInt(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function parseArgs(argv) {
+  let mode = process.env.REPRO_MODE ?? 'safe';
+  let help = false;
+  for (const arg of argv) {
+    if (arg === '--help' || arg === '-h') {
+      help = true;
+      continue;
+    }
+    if (arg.startsWith('--mode=')) {
+      mode = arg.slice('--mode='.length);
+      continue;
+    }
+    if (arg === '--safe') {
+      mode = 'safe';
+      continue;
+    }
+    if (arg === '--sandbox') {
+      mode = 'sandbox';
+    }
+  }
+  if (!VALID_MODES.has(mode)) {
+    throw new Error(`invalid mode "${mode}" (expected: safe|sandbox)`);
+  }
+  return { mode, help };
+}
+
+function printHelp() {
+  console.error('Usage: node scripts/repro-workflow-mutation-oom.mjs [--mode=safe|sandbox]');
+  console.error('Modes:');
+  console.error('  safe    Default. Enforces timeout/db-size guards for host safety.');
+  console.error('  sandbox Intended for memory-limited containers; guards mostly disabled.');
+  console.error('Env overrides (optional):');
+  console.error('  REPRO_ROWS_PER_CYCLE, REPRO_PAYLOAD_BYTES, REPRO_RENEWS_PER_CYCLE, REPRO_MAX_CYCLES');
+  console.error('  REPRO_EXPORT_EVERY, REPRO_MAX_DB_MB, REPRO_SQLITE_HARD_HEAP_LIMIT_MB, REPRO_TIMEOUT_SEC');
+}
+
+function mb(bytes) {
+  return `${(bytes / MB).toFixed(1)}MB`;
+}
+
+function printMem(prefix) {
+  const m = process.memoryUsage();
+  console.error(
+    `[repro] ${prefix} rss=${mb(m.rss)} heapUsed=${mb(m.heapUsed)} external=${mb(m.external)}`
+  );
+}
+
+function nowMs() {
+  return Date.now();
+}
+
+function emitMergeDiagnostics(rootWorkflow) {
+  const lines = [
+    `${rootWorkflow}: merge node "__merge__wf-1778141646167-29" status=pending deps=[wf-1778141646167-29/regression-chain-c=pending] hasDep=false`,
+    `${rootWorkflow}: merge node "__merge__wf-1778141644469-28" status=pending deps=[wf-1778141644469-28/regression-inv-77=pending] hasDep=false`,
+    `${rootWorkflow}: merge node "__merge__wf-1778141642990-27" status=pending deps=[wf-1778141642990-27/regression-inv-55=pending] hasDep=false`,
+    `${rootWorkflow}: merge node "__merge__wf-1778141538305-8" status=pending deps=[wf-1778141538305-8/post-fix-regression=running] hasDep=false`,
+    `${rootWorkflow}: merge node "__merge__wf-1778141629042-19" status=pending deps=[wf-1778141629042-19/regression-inv-91=fixing_with_ai] hasDep=false`,
+    `${rootWorkflow}: merge node "__merge__wf-1778141536943-7" status=pending deps=[wf-1778141536943-7/post-fix-regression=fixing_with_ai] hasDep=true`,
+  ];
+  for (const l of lines) {
+    console.error(`[state-machine] findNewlyReadyTasks(${l})`);
+  }
+}
+
+function queryOne(db, sql, params = []) {
+  const stmt = db.prepare(sql);
+  stmt.bind(params);
+  let row;
+  if (stmt.step()) row = stmt.getAsObject();
+  stmt.free();
+  return row;
+}
+
+function renewWorkflowMutationLease(db, workflowId, ownerId) {
+  const lease = queryOne(
+    db,
+    'SELECT * FROM workflow_mutation_leases WHERE workflow_id = ?',
+    [workflowId]
+  );
+  if (!lease || String(lease.owner_id) !== ownerId) return false;
+  const now = new Date().toISOString();
+  db.run(
+    `UPDATE workflow_mutation_leases
+       SET active_intent_id = ?, active_mutation_kind = ?, last_heartbeat_at = ?, lease_expires_at = ?
+     WHERE workflow_id = ? AND owner_id = ?`,
+    [1, 'dispatch', now, now, workflowId, ownerId]
+  );
+  return true;
+}
+
+function fillLargeTables(db, rows, payloadBytes) {
+  const insertIntent = db.prepare(
+    `INSERT INTO workflow_mutation_intents (workflow_id, channel, args_json, priority, status)
+     VALUES (?, ?, ?, 'normal', 'queued')`
+  );
+  const insertSpool = db.prepare(
+    'INSERT INTO output_spool (task_id, offset, data) VALUES (?, ?, ?)'
+  );
+  const payload = 'x'.repeat(payloadBytes);
+  for (let i = 0; i < rows; i += 1) {
+    const argsJson = JSON.stringify([payload, i, { nested: payload }]);
+    insertIntent.run(['wf-oom', 'dispatch', argsJson]);
+    if (i % 4 === 0) {
+      insertSpool.run(['wf-oom/task', i * payloadBytes, payload]);
+    }
+  }
+  insertIntent.free();
+  insertSpool.free();
+}
+
+async function main() {
+  const { mode, help } = parseArgs(process.argv.slice(2));
+  if (help) {
+    printHelp();
+    return;
+  }
+
+  const defaults = mode === 'safe'
+    ? {
+        rowsPerCycle: 600,
+        payloadBytes: 12 * 1024,
+        renewsPerCycle: 2200,
+        maxCycles: 25,
+        exportEvery: 75,
+        maxDbMb: 180,
+        hardHeapLimitMb: 96,
+        timeoutSec: 90,
+      }
+    : {
+        rowsPerCycle: 900,
+        payloadBytes: 16 * 1024,
+        renewsPerCycle: 4000,
+        maxCycles: 80,
+        exportEvery: 50,
+        maxDbMb: 0,
+        hardHeapLimitMb: 0,
+        timeoutSec: 0,
+      };
+
+  const rowsPerCycle = envInt('REPRO_ROWS_PER_CYCLE', defaults.rowsPerCycle);
+  const payloadBytes = envInt('REPRO_PAYLOAD_BYTES', defaults.payloadBytes);
+  const renewsPerCycle = envInt('REPRO_RENEWS_PER_CYCLE', defaults.renewsPerCycle);
+  const maxCycles = envInt('REPRO_MAX_CYCLES', defaults.maxCycles);
+  const exportEvery = envInt('REPRO_EXPORT_EVERY', defaults.exportEvery);
+  const maxDbMb = envInt('REPRO_MAX_DB_MB', defaults.maxDbMb);
+  const hardHeapLimitMb = envInt('REPRO_SQLITE_HARD_HEAP_LIMIT_MB', defaults.hardHeapLimitMb);
+  const timeoutSec = envInt('REPRO_TIMEOUT_SEC', defaults.timeoutSec);
+  const rootWorkflow = 'wf-1778141536943-7/post-fix-regression';
+  const workflowId = 'wf-oom';
+  const ownerId = 'owner-oom';
+
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'invoker-oom-repro-'));
+  const dbPath = path.join(tempDir, 'invoker-repro.db');
+  const require = createRequire(import.meta.url);
+  const initSqlJs = require(path.join(process.cwd(), 'packages/app/node_modules/sql.js'));
+  const SQL = await initSqlJs({});
+  const db = new SQL.Database();
+  const startedAt = Date.now();
+  let flushCount = 0;
+  let lastFlushAt = 0;
+  let flushIntervalTotalMs = 0;
+  let leaseRenewWrites = 0;
+  let seededIntentRows = 0;
+  let failureReason = null;
+
+  console.error(`[repro] temp db=${dbPath}`);
+  console.error(
+    `[repro] mode=${mode} rowsPerCycle=${rowsPerCycle} payloadBytes=${payloadBytes} renewsPerCycle=${renewsPerCycle} maxCycles=${maxCycles} hardHeapLimitMb=${hardHeapLimitMb} maxDbMb=${maxDbMb} timeoutSec=${timeoutSec}`
+  );
+
+  db.run(`
+    CREATE TABLE workflow_mutation_intents (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      workflow_id TEXT NOT NULL,
+      channel TEXT NOT NULL,
+      args_json TEXT NOT NULL,
+      priority TEXT NOT NULL DEFAULT 'normal',
+      status TEXT NOT NULL DEFAULT 'queued'
+    );
+    CREATE TABLE workflow_mutation_leases (
+      workflow_id TEXT PRIMARY KEY,
+      owner_id TEXT NOT NULL,
+      active_intent_id INTEGER,
+      active_mutation_kind TEXT,
+      leased_at TEXT NOT NULL,
+      last_heartbeat_at TEXT NOT NULL,
+      lease_expires_at TEXT NOT NULL
+    );
+    CREATE TABLE output_spool (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      task_id TEXT NOT NULL,
+      offset INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `);
+  const now = new Date().toISOString();
+  db.run(
+    `INSERT INTO workflow_mutation_leases
+      (workflow_id, owner_id, active_intent_id, active_mutation_kind, leased_at, last_heartbeat_at, lease_expires_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    [workflowId, ownerId, null, null, now, now, now]
+  );
+
+  try {
+    if (hardHeapLimitMb > 0) {
+      // Trigger SQLITE_NOMEM inside sqlite itself before host RAM explodes.
+      db.run(`PRAGMA hard_heap_limit=${hardHeapLimitMb * MB}`);
+      const hardLimit = queryOne(db, 'PRAGMA hard_heap_limit');
+      console.error(`[repro] sqlite hard_heap_limit=${String(hardLimit?.hard_heap_limit ?? 'unknown')} bytes`);
+    } else {
+      console.error('[repro] sqlite hard_heap_limit disabled');
+    }
+
+    emitMergeDiagnostics(rootWorkflow);
+    for (let cycle = 1; cycle <= maxCycles; cycle += 1) {
+      fillLargeTables(db, rowsPerCycle, payloadBytes);
+      seededIntentRows += rowsPerCycle;
+      console.error(`[repro] cycle=${cycle} seeded rows; starting renew loop`);
+      for (let i = 1; i <= renewsPerCycle; i += 1) {
+        renewWorkflowMutationLease(db, workflowId, ownerId);
+        leaseRenewWrites += 1;
+        db.run('INSERT INTO output_spool (task_id, offset, data) VALUES (?, ?, ?)', [
+          'wf-oom/task',
+          (cycle * renewsPerCycle) + i,
+          'y'.repeat(payloadBytes),
+        ]);
+        if (i % exportEvery === 0) {
+          const flushAt = nowMs();
+          if (lastFlushAt > 0) {
+            flushIntervalTotalMs += flushAt - lastFlushAt;
+          }
+          lastFlushAt = flushAt;
+          flushCount += 1;
+          const dump = db.export();
+          fs.writeFileSync(dbPath, Buffer.from(dump));
+        }
+        if (i % 250 === 0) printMem(`cycle=${cycle} renew=${i}`);
+        if (timeoutSec > 0 && (Date.now() - startedAt) / 1000 > timeoutSec) {
+          throw new Error(`timeout guard reached (${timeoutSec}s) before OOM`);
+        }
+      }
+      printMem(`cycle=${cycle} completed`);
+      const dbSizeMb = fs.statSync(dbPath).size / MB;
+      console.error(`[repro] db-on-disk=${dbSizeMb.toFixed(1)}MB`);
+      if (maxDbMb > 0 && dbSizeMb > maxDbMb) {
+        throw new Error(`db size guard reached (${dbSizeMb.toFixed(1)}MB > ${maxDbMb}MB) before OOM`);
+      }
+    }
+    console.error('[repro] no OOM observed within configured cycles');
+    process.exitCode = 0;
+  } catch (err) {
+    failureReason = err instanceof Error ? err.message : String(err);
+    console.error(`[workflow-mutation-coordinator] drain failed for wf-1778141641513-26: ${err}`);
+    console.error(`[workflow-mutation-coordinator] drain failed for wf-1778141629042-19: ${err}`);
+    process.exitCode = 1;
+  } finally {
+    const elapsedMs = nowMs() - startedAt;
+    const meanFlushIntervalMs = flushCount > 1
+      ? Number((flushIntervalTotalMs / (flushCount - 1)).toFixed(2))
+      : null;
+    const leaseRenewWritesPerSec = elapsedMs > 0
+      ? Number(((leaseRenewWrites * 1000) / elapsedMs).toFixed(2))
+      : 0;
+    const mutationThroughputPerSec = elapsedMs > 0
+      ? Number(((seededIntentRows * 1000) / elapsedMs).toFixed(2))
+      : 0;
+    console.error(
+      `[repro-summary] ${JSON.stringify({
+        mode,
+        elapsedMs,
+        flushCount,
+        meanFlushIntervalMs,
+        leaseRenewWrites,
+        leaseRenewWritesPerSec,
+        seededIntentRows,
+        mutationThroughputPerSec,
+        failureReason,
+        status: process.exitCode === 0 ? 'completed' : 'failed',
+      })}`
+    );
+    db.close();
+    if (process.env.REPRO_KEEP_TEMP_DB === '1') {
+      console.error(`[repro] kept temp db at ${dbPath}`);
+    } else {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+}
+
+void main();

--- a/scripts/repro-workflow-mutation-oom.mjs
+++ b/scripts/repro-workflow-mutation-oom.mjs
@@ -88,21 +88,51 @@ function queryOne(db, sql, params = []) {
   return row;
 }
 
-function renewWorkflowMutationLease(db, workflowId, ownerId) {
+function renewWorkflowMutationLease(db, workflowId, ownerId, options = {}) {
   const lease = queryOne(
     db,
     'SELECT * FROM workflow_mutation_leases WHERE workflow_id = ?',
     [workflowId]
   );
-  if (!lease || String(lease.owner_id) !== ownerId) return false;
+  if (!lease || String(lease.owner_id) !== ownerId) return 'lost';
+  const nowMs = Date.now();
+  const nextIntentId = options.activeIntentId ?? null;
+  const nextMutationKind = options.activeMutationKind ?? null;
+  const sameIntent = String(lease.active_intent_id ?? '') === String(nextIntentId ?? '');
+  const sameKind = String(lease.active_mutation_kind ?? '') === String(nextMutationKind ?? '');
+  const lastHeartbeatMs = lease.last_heartbeat_at ? Date.parse(String(lease.last_heartbeat_at)) : 0;
+  const leaseExpiryMs = lease.lease_expires_at ? Date.parse(String(lease.lease_expires_at)) : 0;
+  const minHeartbeatIntervalMs = options.minHeartbeatIntervalMs ?? 0;
+  const minExpiryLeadMs = options.minExpiryLeadMs ?? 0;
+
+  if (
+    sameIntent &&
+    sameKind &&
+    minHeartbeatIntervalMs > 0 &&
+    Number.isFinite(lastHeartbeatMs) &&
+    lastHeartbeatMs > 0 &&
+    nowMs - lastHeartbeatMs < minHeartbeatIntervalMs &&
+    Number.isFinite(leaseExpiryMs) &&
+    leaseExpiryMs - nowMs > minExpiryLeadMs
+  ) {
+    return 'skipped';
+  }
+
   const now = new Date().toISOString();
   db.run(
     `UPDATE workflow_mutation_leases
        SET active_intent_id = ?, active_mutation_kind = ?, last_heartbeat_at = ?, lease_expires_at = ?
      WHERE workflow_id = ? AND owner_id = ?`,
-    [1, 'dispatch', now, now, workflowId, ownerId]
+    [
+      nextIntentId,
+      nextMutationKind,
+      now,
+      new Date(nowMs + 30000).toISOString(),
+      workflowId,
+      ownerId,
+    ]
   );
-  return true;
+  return 'updated';
 }
 
 function fillLargeTables(db, rows, payloadBytes) {
@@ -166,6 +196,8 @@ async function main() {
   const maxDbMb = envInt('REPRO_MAX_DB_MB', defaults.maxDbMb);
   const hardHeapLimitMb = envInt('REPRO_SQLITE_HARD_HEAP_LIMIT_MB', defaults.hardHeapLimitMb);
   const timeoutSec = envInt('REPRO_TIMEOUT_SEC', defaults.timeoutSec);
+  const leaseRenewMinIntervalMs = envInt('INVOKER_MUTATION_LEASE_RENEW_MIN_INTERVAL_MS', 2_000);
+  const leaseRenewMinExpiryLeadMs = envInt('INVOKER_MUTATION_LEASE_RENEW_MIN_EXPIRY_LEAD_MS', 12_000);
   const rootWorkflow = 'wf-1778141536943-7/post-fix-regression';
   const workflowId = 'wf-oom';
   const ownerId = 'owner-oom';
@@ -181,6 +213,7 @@ async function main() {
   let lastFlushAt = 0;
   let flushIntervalTotalMs = 0;
   let leaseRenewWrites = 0;
+  let leaseRenewUpdateWrites = 0;
   let seededIntentRows = 0;
   let failureReason = null;
 
@@ -188,7 +221,9 @@ async function main() {
   console.error(
     `[repro] mode=${mode} rowsPerCycle=${rowsPerCycle} payloadBytes=${payloadBytes} renewsPerCycle=${renewsPerCycle} maxCycles=${maxCycles} hardHeapLimitMb=${hardHeapLimitMb} maxDbMb=${maxDbMb} timeoutSec=${timeoutSec}`
   );
-  console.error(`[repro] flushDebounceMs=${flushDebounceMs} exportEvery=${exportEvery}`);
+  console.error(
+    `[repro] flushDebounceMs=${flushDebounceMs} exportEvery=${exportEvery} leaseRenewMinIntervalMs=${leaseRenewMinIntervalMs} leaseRenewMinExpiryLeadMs=${leaseRenewMinExpiryLeadMs}`
+  );
 
   db.run(`
     CREATE TABLE workflow_mutation_intents (
@@ -256,8 +291,14 @@ async function main() {
       seededIntentRows += rowsPerCycle;
       console.error(`[repro] cycle=${cycle} seeded rows; starting renew loop`);
       for (let i = 1; i <= renewsPerCycle; i += 1) {
-        renewWorkflowMutationLease(db, workflowId, ownerId);
+        const renewResult = renewWorkflowMutationLease(db, workflowId, ownerId, {
+          activeIntentId: 1,
+          activeMutationKind: 'dispatch',
+          minHeartbeatIntervalMs: leaseRenewMinIntervalMs,
+          minExpiryLeadMs: leaseRenewMinExpiryLeadMs,
+        });
         leaseRenewWrites += 1;
+        if (renewResult === 'updated') leaseRenewUpdateWrites += 1;
         db.run('INSERT INTO output_spool (task_id, offset, data) VALUES (?, ?, ?)', [
           'wf-oom/task',
           (cycle * renewsPerCycle) + i,
@@ -298,6 +339,9 @@ async function main() {
     const leaseRenewWritesPerSec = elapsedMs > 0
       ? Number(((leaseRenewWrites * 1000) / elapsedMs).toFixed(2))
       : 0;
+    const leaseRenewUpdateWritesPerSec = elapsedMs > 0
+      ? Number(((leaseRenewUpdateWrites * 1000) / elapsedMs).toFixed(2))
+      : 0;
     const mutationThroughputPerSec = elapsedMs > 0
       ? Number(((seededIntentRows * 1000) / elapsedMs).toFixed(2))
       : 0;
@@ -309,6 +353,8 @@ async function main() {
         meanFlushIntervalMs,
         leaseRenewWrites,
         leaseRenewWritesPerSec,
+        leaseRenewUpdateWrites,
+        leaseRenewUpdateWritesPerSec,
         seededIntentRows,
         mutationThroughputPerSec,
         failureReason,

--- a/scripts/repro-workflow-mutation-oom.mjs
+++ b/scripts/repro-workflow-mutation-oom.mjs
@@ -159,6 +159,10 @@ async function main() {
   const renewsPerCycle = envInt('REPRO_RENEWS_PER_CYCLE', defaults.renewsPerCycle);
   const maxCycles = envInt('REPRO_MAX_CYCLES', defaults.maxCycles);
   const exportEvery = envInt('REPRO_EXPORT_EVERY', defaults.exportEvery);
+  const flushDebounceMs = envInt(
+    'REPRO_FLUSH_DEBOUNCE_MS',
+    envInt('INVOKER_SQLITE_FLUSH_DEBOUNCE_MS', 0),
+  );
   const maxDbMb = envInt('REPRO_MAX_DB_MB', defaults.maxDbMb);
   const hardHeapLimitMb = envInt('REPRO_SQLITE_HARD_HEAP_LIMIT_MB', defaults.hardHeapLimitMb);
   const timeoutSec = envInt('REPRO_TIMEOUT_SEC', defaults.timeoutSec);
@@ -184,6 +188,7 @@ async function main() {
   console.error(
     `[repro] mode=${mode} rowsPerCycle=${rowsPerCycle} payloadBytes=${payloadBytes} renewsPerCycle=${renewsPerCycle} maxCycles=${maxCycles} hardHeapLimitMb=${hardHeapLimitMb} maxDbMb=${maxDbMb} timeoutSec=${timeoutSec}`
   );
+  console.error(`[repro] flushDebounceMs=${flushDebounceMs} exportEvery=${exportEvery}`);
 
   db.run(`
     CREATE TABLE workflow_mutation_intents (
@@ -229,6 +234,23 @@ async function main() {
     }
 
     emitMergeDiagnostics(rootWorkflow);
+    let dirty = false;
+    let nextFlushAt = 0;
+    const maybeFlush = (force = false) => {
+      if (!dirty && !force) return;
+      const flushAt = nowMs();
+      if (lastFlushAt > 0) {
+        flushIntervalTotalMs += flushAt - lastFlushAt;
+      }
+      lastFlushAt = flushAt;
+      flushCount += 1;
+      const dump = db.export();
+      fs.writeFileSync(dbPath, Buffer.from(dump));
+      dirty = false;
+      if (flushDebounceMs > 0) {
+        nextFlushAt = flushAt + flushDebounceMs;
+      }
+    };
     for (let cycle = 1; cycle <= maxCycles; cycle += 1) {
       fillLargeTables(db, rowsPerCycle, payloadBytes);
       seededIntentRows += rowsPerCycle;
@@ -241,21 +263,19 @@ async function main() {
           (cycle * renewsPerCycle) + i,
           'y'.repeat(payloadBytes),
         ]);
-        if (i % exportEvery === 0) {
-          const flushAt = nowMs();
-          if (lastFlushAt > 0) {
-            flushIntervalTotalMs += flushAt - lastFlushAt;
-          }
-          lastFlushAt = flushAt;
-          flushCount += 1;
-          const dump = db.export();
-          fs.writeFileSync(dbPath, Buffer.from(dump));
+        dirty = true;
+        if (flushDebounceMs <= 0) {
+          if (i % exportEvery === 0) maybeFlush();
+        } else {
+          if (nextFlushAt === 0) nextFlushAt = nowMs() + flushDebounceMs;
+          if (nowMs() >= nextFlushAt) maybeFlush();
         }
         if (i % 250 === 0) printMem(`cycle=${cycle} renew=${i}`);
         if (timeoutSec > 0 && (Date.now() - startedAt) / 1000 > timeoutSec) {
           throw new Error(`timeout guard reached (${timeoutSec}s) before OOM`);
         }
       }
+      if (dirty) maybeFlush(true);
       printMem(`cycle=${cycle} completed`);
       const dbSizeMb = fs.statSync(dbPath).size / MB;
       console.error(`[repro] db-on-disk=${dbSizeMb.toFixed(1)}MB`);

--- a/scripts/run-oom-benchmark-matrix.mjs
+++ b/scripts/run-oom-benchmark-matrix.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const ROOT = process.cwd();
+const OUT_DIR = path.join(ROOT, 'benchmarks', 'oom');
+
+function ensureOutDir() {
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+}
+
+function nowStamp() {
+  const d = new Date();
+  return d.toISOString().replaceAll(':', '-').replaceAll('.', '-');
+}
+
+function parsePeakMetric(log, fieldName) {
+  const regex = new RegExp(`${fieldName}=(\\d+\\.\\d+)MB`, 'g');
+  let match;
+  let peak = 0;
+  while ((match = regex.exec(log)) !== null) {
+    peak = Math.max(peak, Number(match[1]));
+  }
+  return Number(peak.toFixed(1));
+}
+
+function parseDbGrowthRateMbPerMin(log, elapsedMs) {
+  const regex = /db-on-disk=(\d+\.\d+)MB/g;
+  let match;
+  let maxDb = 0;
+  while ((match = regex.exec(log)) !== null) {
+    maxDb = Math.max(maxDb, Number(match[1]));
+  }
+  if (elapsedMs <= 0) return 0;
+  return Number(((maxDb / elapsedMs) * 60000).toFixed(2));
+}
+
+function parseSummary(log) {
+  const line = log.split('\n').find((l) => l.startsWith('[repro-summary] '));
+  if (!line) return null;
+  try {
+    return JSON.parse(line.slice('[repro-summary] '.length));
+  } catch {
+    return null;
+  }
+}
+
+function runOne(mode, extraEnv = {}) {
+  const env = { ...process.env, ...extraEnv };
+  const result = spawnSync('./scripts/run-oom-repro.sh', [mode], {
+    cwd: ROOT,
+    env,
+    encoding: 'utf8',
+    maxBuffer: 50 * 1024 * 1024,
+  });
+
+  const log = `${result.stdout ?? ''}${result.stderr ?? ''}`;
+  const summary = parseSummary(log);
+  const elapsedMs = summary?.elapsedMs ?? 0;
+  const peakRssMb = parsePeakMetric(log, 'rss');
+  const peakExternalMb = parsePeakMetric(log, 'external');
+  const dbGrowthRateMbPerMin = parseDbGrowthRateMbPerMin(log, elapsedMs);
+  const metrics = {
+    mode,
+    exitCode: result.status ?? -1,
+    elapsedMs,
+    elapsedSec: Number((elapsedMs / 1000).toFixed(2)),
+    status: summary?.status ?? (result.status === 0 ? 'completed' : 'failed'),
+    failureReason: summary?.failureReason ?? null,
+    peakRssMb,
+    peakExternalMb,
+    flushCount: summary?.flushCount ?? 0,
+    meanFlushIntervalMs: summary?.meanFlushIntervalMs ?? null,
+    dbGrowthRateMbPerMin,
+    leaseRenewWritesPerSec: summary?.leaseRenewWritesPerSec ?? 0,
+    mutationThroughputPerSec: summary?.mutationThroughputPerSec ?? 0,
+  };
+  return { metrics, log };
+}
+
+function writeMarkdown(outPath, runLabel, commit, results) {
+  const lines = [];
+  lines.push(`# OOM Benchmark Matrix: ${runLabel}`);
+  lines.push('');
+  lines.push(`- Commit: \`${commit}\``);
+  lines.push(`- Generated: ${new Date().toISOString()}`);
+  lines.push('');
+  lines.push('| mode | status | time-to-failure/completion (s) | peak RSS (MB) | peak external (MB) | flush count | mean flush interval (ms) | db growth (MB/min) | lease renew writes/sec | mutation throughput (intents/sec) |');
+  lines.push('|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|');
+  for (const r of results) {
+    lines.push(`| ${r.mode} | ${r.status} | ${r.elapsedSec} | ${r.peakRssMb} | ${r.peakExternalMb} | ${r.flushCount} | ${r.meanFlushIntervalMs ?? 'n/a'} | ${r.dbGrowthRateMbPerMin} | ${r.leaseRenewWritesPerSec} | ${r.mutationThroughputPerSec} |`);
+  }
+  lines.push('');
+  lines.push('## Failure Reasons');
+  lines.push('');
+  for (const r of results) {
+    lines.push(`- ${r.mode}: ${r.failureReason ?? 'none'}`);
+  }
+  lines.push('');
+  fs.writeFileSync(outPath, `${lines.join('\n')}\n`);
+}
+
+function main() {
+  const runLabel = process.argv[2] ?? 'baseline';
+  ensureOutDir();
+  const commit = spawnSync('git', ['rev-parse', 'HEAD'], { cwd: ROOT, encoding: 'utf8' }).stdout.trim();
+  const stamp = nowStamp();
+
+  const safe = runOne('safe', {
+    REPRO_TIMEOUT_SEC: process.env.REPRO_TIMEOUT_SEC ?? '20',
+    REPRO_MAX_DB_MB: process.env.REPRO_MAX_DB_MB ?? '220',
+  });
+  const sandbox = runOne('sandbox', {
+    REPRO_DOCKER_MEMORY: process.env.REPRO_DOCKER_MEMORY ?? '768m',
+    REPRO_NODE_HEAP_MB: process.env.REPRO_NODE_HEAP_MB ?? '256',
+    REPRO_TIMEOUT_SEC: process.env.REPRO_TIMEOUT_SEC ?? '20',
+  });
+
+  const results = [safe.metrics, sandbox.metrics];
+  const base = `${stamp}-${runLabel}`;
+  const jsonPath = path.join(OUT_DIR, `${base}.json`);
+  const mdPath = path.join(OUT_DIR, `${base}.md`);
+  fs.writeFileSync(jsonPath, `${JSON.stringify({ runLabel, commit, results }, null, 2)}\n`);
+  fs.writeFileSync(path.join(OUT_DIR, `${base}-safe.log`), safe.log);
+  fs.writeFileSync(path.join(OUT_DIR, `${base}-sandbox.log`), sandbox.log);
+  writeMarkdown(mdPath, runLabel, commit, results);
+  console.log(`wrote ${jsonPath}`);
+  console.log(`wrote ${mdPath}`);
+}
+
+main();

--- a/scripts/run-oom-benchmark-matrix.mjs
+++ b/scripts/run-oom-benchmark-matrix.mjs
@@ -74,6 +74,7 @@ function runOne(mode, extraEnv = {}) {
     meanFlushIntervalMs: summary?.meanFlushIntervalMs ?? null,
     dbGrowthRateMbPerMin,
     leaseRenewWritesPerSec: summary?.leaseRenewWritesPerSec ?? 0,
+    leaseRenewUpdateWritesPerSec: summary?.leaseRenewUpdateWritesPerSec ?? summary?.leaseRenewWritesPerSec ?? 0,
     mutationThroughputPerSec: summary?.mutationThroughputPerSec ?? 0,
   };
   return { metrics, log };
@@ -86,10 +87,10 @@ function writeMarkdown(outPath, runLabel, commit, results) {
   lines.push(`- Commit: \`${commit}\``);
   lines.push(`- Generated: ${new Date().toISOString()}`);
   lines.push('');
-  lines.push('| mode | status | time-to-failure/completion (s) | peak RSS (MB) | peak external (MB) | flush count | mean flush interval (ms) | db growth (MB/min) | lease renew writes/sec | mutation throughput (intents/sec) |');
+  lines.push('| mode | status | time-to-failure/completion (s) | peak RSS (MB) | peak external (MB) | flush count | mean flush interval (ms) | db growth (MB/min) | lease renew update writes/sec | mutation throughput (intents/sec) |');
   lines.push('|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|');
   for (const r of results) {
-    lines.push(`| ${r.mode} | ${r.status} | ${r.elapsedSec} | ${r.peakRssMb} | ${r.peakExternalMb} | ${r.flushCount} | ${r.meanFlushIntervalMs ?? 'n/a'} | ${r.dbGrowthRateMbPerMin} | ${r.leaseRenewWritesPerSec} | ${r.mutationThroughputPerSec} |`);
+    lines.push(`| ${r.mode} | ${r.status} | ${r.elapsedSec} | ${r.peakRssMb} | ${r.peakExternalMb} | ${r.flushCount} | ${r.meanFlushIntervalMs ?? 'n/a'} | ${r.dbGrowthRateMbPerMin} | ${r.leaseRenewUpdateWritesPerSec} | ${r.mutationThroughputPerSec} |`);
   }
   lines.push('');
   lines.push('## Failure Reasons');

--- a/scripts/run-oom-repro.sh
+++ b/scripts/run-oom-repro.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MODE="${1:-safe}"
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_PATH="scripts/repro-workflow-mutation-oom.mjs"
+
+if [[ "$MODE" != "safe" && "$MODE" != "sandbox" ]]; then
+  echo "usage: $0 [safe|sandbox]" >&2
+  exit 2
+fi
+
+if [[ "$MODE" == "safe" ]]; then
+  NODE_HEAP_MB="${REPRO_NODE_HEAP_MB:-192}"
+  echo "[runner] mode=safe node_heap_mb=${NODE_HEAP_MB}"
+  cd "$ROOT_DIR"
+  exec node --max-old-space-size="${NODE_HEAP_MB}" "$SCRIPT_PATH" --mode=safe
+fi
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "[runner] docker is required for sandbox mode" >&2
+  exit 1
+fi
+
+DOCKER_MEMORY="${REPRO_DOCKER_MEMORY:-768m}"
+NODE_HEAP_MB="${REPRO_NODE_HEAP_MB:-320}"
+echo "[runner] mode=sandbox docker_memory=${DOCKER_MEMORY} node_heap_mb=${NODE_HEAP_MB}"
+cd "$ROOT_DIR"
+exec docker run --rm \
+  --memory "${DOCKER_MEMORY}" \
+  -v "${ROOT_DIR}:/repo" \
+  -w /repo \
+  -e REPRO_ROWS_PER_CYCLE \
+  -e REPRO_PAYLOAD_BYTES \
+  -e REPRO_RENEWS_PER_CYCLE \
+  -e REPRO_MAX_CYCLES \
+  -e REPRO_EXPORT_EVERY \
+  -e REPRO_MAX_DB_MB \
+  -e REPRO_SQLITE_HARD_HEAP_LIMIT_MB \
+  -e REPRO_TIMEOUT_SEC \
+  node:22 \
+  node --max-old-space-size="${NODE_HEAP_MB}" "$SCRIPT_PATH" --mode=sandbox


### PR DESCRIPTION
## Summary

Add bounded retention pruning for completed mutation intents and output spool rows so long-running owner processes do not accumulate unbounded historical payload.

## Architecture

### Before

```mermaid
flowchart TD
  taskEvents[TaskAndMutationEvents]
  historyTables[HistoryTablesGrowForever]
  largerExports[LargerDbExports]
  taskEvents --> historyTables --> largerExports
```

### After

```mermaid
flowchart TD
  taskEvents[TaskAndMutationEvents]
  historyTables[HistoryTables]
  retentionJob[PeriodicRetentionPrune]
  boundedSize[BoundedHistoricalFootprint]
  taskEvents --> historyTables
  historyTables --> retentionJob --> boundedSize
```

## Comparison

- Most production systems apply retention windows or archival policies for high-volume operational logs.
- Native SQLite deployments also prune/compact operational tables to keep file size predictable.
- This is proper for Invoker because mutation/output history is operational telemetry, not immutable business records, so bounded retention is the correct trade-off.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- persisted-workflow-mutation-coordinator.test.ts`
- [x] `REPRO_TIMEOUT_SEC=20 node scripts/run-oom-benchmark-matrix.mjs step3-retention-pruning`

## Benchmark Results (safe mode, PR358 vs PR357)

| metric | step2 | step3 | delta |
|---|---:|---:|---:|
| time (s) | 20.10 | 20.26 | +0.16 |
| peak RSS (MB) | 564.3 | 564.0 | -0.3 |
| peak external (MB) | 490.3 | 490.3 | 0.0 |
| flush count | 103 | 102 | -1 |
| db growth (MB/min) | 385.63 | 382.63 | -3.00 |

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 47b4d45`
- Post-revert steps: None.
- Data migration? No.