### PR TITLE
Cost Query Step 3: join context and rollups (replacement v2)

### DIFF
--- a/packages/app/src/__tests__/cost-rollup.test.ts
+++ b/packages/app/src/__tests__/cost-rollup.test.ts
@@ -1,0 +1,430 @@
+import { describe, it, expect } from 'vitest';
+import type { SessionUsageEvent } from '@invoker/execution-engine';
+import type { NormalizedCostEvent } from '@invoker/contracts';
+import {
+  attributeSessionUsage,
+  groupCostEvents,
+  buildAttributionContext,
+  resolveSessionId,
+  resolveAgentName,
+  deriveSource,
+  serializeGroupedRollup,
+  type AttributionContext,
+  type CostTaskInfo,
+} from '../cost-rollup.js';
+
+// ── Fixture Helpers ────────────────────────────────────────
+
+function makeUsageEvent(overrides: Partial<SessionUsageEvent> = {}): SessionUsageEvent {
+  return {
+    eventId: 'evt-1',
+    timestamp: '2025-01-15T10:00:00Z',
+    model: 'gpt-4o',
+    inputTokens: 100,
+    outputTokens: 50,
+    cachedTokens: 10,
+    totalTokens: 150,
+    confidence: 'exact',
+    ...overrides,
+  };
+}
+
+function makeContext(overrides: Partial<AttributionContext> = {}): AttributionContext {
+  return {
+    workflowId: 'wf-1',
+    taskId: 'wf-1/task-a',
+    attemptId: 'wf-1/task-a-latest',
+    executorType: 'worktree',
+    agentSessionId: 'sess-abc',
+    agentName: 'codex',
+    source: 'openai',
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<{
+  eventId: string;
+  workflowId: string;
+  taskId: string;
+  agentName: string;
+  model: string;
+  timestamp: string;
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+  totalTokens: number;
+  confidence: 'exact' | 'estimated' | 'unknown';
+  estimatedCostUsd: number;
+}> = {}): NormalizedCostEvent {
+  const {
+    eventId = 'evt-1',
+    workflowId = 'wf-1',
+    taskId = 'wf-1/task-a',
+    agentName = 'codex',
+    model = 'gpt-4o',
+    timestamp = '2025-01-15T10:00:00Z',
+    inputTokens = 100,
+    outputTokens = 50,
+    cachedTokens = 10,
+    totalTokens = 150,
+    confidence = 'exact',
+    estimatedCostUsd = 0.005,
+  } = overrides;
+
+  return {
+    identity: {
+      eventId,
+      agentSessionId: 'sess-abc',
+      agentName,
+      source: agentName === 'claude' ? 'anthropic' : 'openai',
+    },
+    attribution: {
+      workflowId,
+      taskId,
+      attemptId: `${taskId}-latest`,
+      executorType: 'worktree',
+    },
+    usage: { inputTokens, outputTokens, cachedTokens, totalTokens },
+    pricing: { model, pricingVersion: '0', estimatedCostUsd, confidence },
+    timestamp,
+  };
+}
+
+// ── attributeSessionUsage ──────────────────────────────────
+
+describe('attributeSessionUsage', () => {
+  it('maps session events to normalized events with attribution', () => {
+    const events = [
+      makeUsageEvent({ eventId: 'evt-1', inputTokens: 100, outputTokens: 50 }),
+      makeUsageEvent({ eventId: 'evt-2', inputTokens: 200, outputTokens: 80 }),
+    ];
+    const ctx = makeContext();
+    const result = attributeSessionUsage(events, ctx);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].identity.eventId).toBe('evt-1');
+    expect(result[0].identity.agentSessionId).toBe('sess-abc');
+    expect(result[0].identity.agentName).toBe('codex');
+    expect(result[0].attribution.workflowId).toBe('wf-1');
+    expect(result[0].attribution.taskId).toBe('wf-1/task-a');
+    expect(result[0].usage.inputTokens).toBe(100);
+    expect(result[1].usage.inputTokens).toBe(200);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(attributeSessionUsage([], makeContext())).toEqual([]);
+  });
+
+  it('uses "unknown" for missing model', () => {
+    const events = [makeUsageEvent({ model: '' })];
+    const result = attributeSessionUsage(events, makeContext());
+    expect(result[0].pricing.model).toBe('unknown');
+  });
+});
+
+// ── groupCostEvents ────────────────────────────────────────
+
+describe('groupCostEvents', () => {
+  it('groups by single dimension', () => {
+    const events = [
+      makeEvent({ agentName: 'claude', eventId: 'e1' }),
+      makeEvent({ agentName: 'codex', eventId: 'e2' }),
+      makeEvent({ agentName: 'claude', eventId: 'e3' }),
+    ];
+    const groups = groupCostEvents(events, ['agent']);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].dimensions.agent).toBe('claude');
+    expect(groups[0].rollup.eventCount).toBe(2);
+    expect(groups[1].dimensions.agent).toBe('codex');
+    expect(groups[1].rollup.eventCount).toBe(1);
+  });
+
+  it('groups by multiple dimensions', () => {
+    const events = [
+      makeEvent({ agentName: 'claude', model: 'opus-4', eventId: 'e1' }),
+      makeEvent({ agentName: 'claude', model: 'sonnet-4', eventId: 'e2' }),
+      makeEvent({ agentName: 'codex', model: 'gpt-4o', eventId: 'e3' }),
+    ];
+    const groups = groupCostEvents(events, ['agent', 'model']);
+
+    expect(groups).toHaveLength(3);
+    // Sorted lexicographically by composite key
+    expect(groups[0].groupKey).toBe('claude|opus-4');
+    expect(groups[1].groupKey).toBe('claude|sonnet-4');
+    expect(groups[2].groupKey).toBe('codex|gpt-4o');
+  });
+
+  it('produces deterministic output across repeated calls', () => {
+    const events = [
+      makeEvent({ workflowId: 'wf-2', taskId: 'wf-2/b', agentName: 'codex', eventId: 'e1' }),
+      makeEvent({ workflowId: 'wf-1', taskId: 'wf-1/a', agentName: 'claude', eventId: 'e2' }),
+      makeEvent({ workflowId: 'wf-2', taskId: 'wf-2/a', agentName: 'claude', eventId: 'e3' }),
+      makeEvent({ workflowId: 'wf-1', taskId: 'wf-1/b', agentName: 'codex', eventId: 'e4' }),
+    ];
+
+    const run1 = groupCostEvents(events, ['workflow', 'task', 'agent']);
+    const run2 = groupCostEvents(events, ['workflow', 'task', 'agent']);
+    const run3 = groupCostEvents([...events].reverse(), ['workflow', 'task', 'agent']);
+
+    // Same input → identical output
+    expect(run1.map(g => g.groupKey)).toEqual(run2.map(g => g.groupKey));
+    // Reversed input → same sorted output
+    expect(run1.map(g => g.groupKey)).toEqual(run3.map(g => g.groupKey));
+    // Rollups match
+    expect(run1.map(g => g.rollup)).toEqual(run3.map(g => g.rollup));
+  });
+
+  it('groups by day dimension using ISO date prefix', () => {
+    const events = [
+      makeEvent({ timestamp: '2025-01-15T10:00:00Z', eventId: 'e1' }),
+      makeEvent({ timestamp: '2025-01-15T18:00:00Z', eventId: 'e2' }),
+      makeEvent({ timestamp: '2025-01-16T09:00:00Z', eventId: 'e3' }),
+    ];
+    const groups = groupCostEvents(events, ['day']);
+
+    expect(groups).toHaveLength(2);
+    expect(groups[0].dimensions.day).toBe('2025-01-15');
+    expect(groups[0].rollup.eventCount).toBe(2);
+    expect(groups[1].dimensions.day).toBe('2025-01-16');
+    expect(groups[1].rollup.eventCount).toBe(1);
+  });
+
+  it('handles missing timestamp gracefully', () => {
+    const events = [makeEvent({ timestamp: '', eventId: 'e1' })];
+    const groups = groupCostEvents(events, ['day']);
+    expect(groups[0].dimensions.day).toBe('unknown');
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(groupCostEvents([])).toEqual([]);
+  });
+
+  it('tracks unknown confidence and missing usage in rollups', () => {
+    const events = [
+      makeEvent({ confidence: 'unknown', totalTokens: 0, eventId: 'e1' }),
+      makeEvent({ confidence: 'exact', totalTokens: 100, eventId: 'e2' }),
+    ];
+    const groups = groupCostEvents(events, ['workflow']);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].rollup.unknownConfidenceCount).toBe(1);
+    expect(groups[0].rollup.missingUsageCount).toBe(1);
+    expect(groups[0].rollup.eventCount).toBe(2);
+  });
+
+  it('defaults to all dimensions when none specified', () => {
+    const events = [makeEvent({ eventId: 'e1' })];
+    const groups = groupCostEvents(events);
+
+    expect(groups).toHaveLength(1);
+    // Key should contain all 5 dimension values
+    const parts = groups[0].groupKey.split('|');
+    expect(parts).toHaveLength(5);
+    expect(groups[0].dimensions).toHaveProperty('workflow');
+    expect(groups[0].dimensions).toHaveProperty('task');
+    expect(groups[0].dimensions).toHaveProperty('agent');
+    expect(groups[0].dimensions).toHaveProperty('model');
+    expect(groups[0].dimensions).toHaveProperty('day');
+  });
+
+  it('aggregates token counts correctly within groups', () => {
+    const events = [
+      makeEvent({ inputTokens: 100, outputTokens: 50, cachedTokens: 10, totalTokens: 150, estimatedCostUsd: 0.005, eventId: 'e1' }),
+      makeEvent({ inputTokens: 200, outputTokens: 80, cachedTokens: 20, totalTokens: 280, estimatedCostUsd: 0.010, eventId: 'e2' }),
+    ];
+    const groups = groupCostEvents(events, ['workflow']);
+
+    expect(groups[0].rollup.inputTokens).toBe(300);
+    expect(groups[0].rollup.outputTokens).toBe(130);
+    expect(groups[0].rollup.cachedTokens).toBe(30);
+    expect(groups[0].rollup.totalTokens).toBe(430);
+    expect(groups[0].rollup.totalCostUsd).toBeCloseTo(0.015, 6);
+  });
+});
+
+// ── Competing Design Proof ─────────────────────────────────
+
+describe('competing design proof: deterministic grouped outputs without provider branching', () => {
+  it('multi-provider events roll up identically regardless of input order', () => {
+    const anthropicEvent = makeEvent({
+      eventId: 'a1', agentName: 'claude', model: 'opus-4',
+      inputTokens: 500, outputTokens: 200, totalTokens: 700,
+      estimatedCostUsd: 0.025,
+    });
+    const openaiEvent = makeEvent({
+      eventId: 'o1', agentName: 'codex', model: 'gpt-4o',
+      inputTokens: 300, outputTokens: 100, totalTokens: 400,
+      estimatedCostUsd: 0.010,
+    });
+
+    const forwardGroups = groupCostEvents([anthropicEvent, openaiEvent], ['agent']);
+    const reverseGroups = groupCostEvents([openaiEvent, anthropicEvent], ['agent']);
+
+    // Output is sorted by key, not input order
+    expect(forwardGroups.map(g => g.groupKey)).toEqual(reverseGroups.map(g => g.groupKey));
+    expect(forwardGroups.map(g => g.rollup)).toEqual(reverseGroups.map(g => g.rollup));
+
+    // No provider-specific branching: both groups have same shape
+    expect(forwardGroups[0].rollup).toHaveProperty('inputTokens');
+    expect(forwardGroups[0].rollup).toHaveProperty('totalCostUsd');
+    expect(forwardGroups[1].rollup).toHaveProperty('inputTokens');
+    expect(forwardGroups[1].rollup).toHaveProperty('totalCostUsd');
+  });
+
+  it('JSON serialization is deterministic', () => {
+    const events = [
+      makeEvent({ eventId: 'e1', agentName: 'claude', workflowId: 'wf-1', taskId: 'wf-1/a' }),
+      makeEvent({ eventId: 'e2', agentName: 'codex', workflowId: 'wf-1', taskId: 'wf-1/b' }),
+      makeEvent({ eventId: 'e3', agentName: 'claude', workflowId: 'wf-2', taskId: 'wf-2/a' }),
+    ];
+
+    const groups1 = groupCostEvents(events, ['workflow', 'agent']);
+    const groups2 = groupCostEvents([...events].reverse(), ['workflow', 'agent']);
+
+    const json1 = JSON.stringify(groups1.map(serializeGroupedRollup));
+    const json2 = JSON.stringify(groups2.map(serializeGroupedRollup));
+    expect(json1).toBe(json2);
+  });
+});
+
+// ── Session ID Resolution ──────────────────────────────────
+
+describe('resolveSessionId', () => {
+  it('prefers agentSessionId', () => {
+    expect(resolveSessionId({
+      id: 't1', workflowId: 'wf-1', executorType: 'worktree',
+      agentSessionId: 'current', lastAgentSessionId: 'previous',
+    })).toBe('current');
+  });
+
+  it('falls back to lastAgentSessionId', () => {
+    expect(resolveSessionId({
+      id: 't1', workflowId: 'wf-1', executorType: 'worktree',
+      lastAgentSessionId: 'previous',
+    })).toBe('previous');
+  });
+
+  it('returns undefined when neither is available', () => {
+    expect(resolveSessionId({
+      id: 't1', workflowId: 'wf-1', executorType: 'worktree',
+    })).toBeUndefined();
+  });
+});
+
+// ── Agent Name Resolution ──────────────────────────────────
+
+describe('resolveAgentName', () => {
+  it('prefers agentName', () => {
+    expect(resolveAgentName({
+      id: 't1', workflowId: 'wf-1', executorType: 'worktree',
+      agentName: 'codex', lastAgentName: 'claude',
+    })).toBe('codex');
+  });
+
+  it('falls back to lastAgentName', () => {
+    expect(resolveAgentName({
+      id: 't1', workflowId: 'wf-1', executorType: 'worktree',
+      lastAgentName: 'codex',
+    })).toBe('codex');
+  });
+
+  it('defaults to claude', () => {
+    expect(resolveAgentName({
+      id: 't1', workflowId: 'wf-1', executorType: 'worktree',
+    })).toBe('claude');
+  });
+});
+
+// ── Source Derivation ──────────────────────────────────────
+
+describe('deriveSource', () => {
+  it('maps claude to anthropic', () => {
+    expect(deriveSource('claude')).toBe('anthropic');
+  });
+
+  it('maps codex to openai', () => {
+    expect(deriveSource('codex')).toBe('openai');
+  });
+
+  it('returns unknown for unrecognized agents', () => {
+    expect(deriveSource('custom-agent')).toBe('unknown');
+  });
+});
+
+// ── buildAttributionContext ────────────────────────────────
+
+describe('buildAttributionContext', () => {
+  it('builds context from task info with agentSessionId', () => {
+    const task: CostTaskInfo = {
+      id: 'wf-1/task-a',
+      workflowId: 'wf-1',
+      executorType: 'worktree',
+      agentSessionId: 'sess-123',
+      agentName: 'codex',
+    };
+    const ctx = buildAttributionContext(task);
+    expect(ctx).toEqual({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      attemptId: 'wf-1/task-a-latest',
+      executorType: 'worktree',
+      agentSessionId: 'sess-123',
+      agentName: 'codex',
+      source: 'openai',
+    });
+  });
+
+  it('returns undefined when no session ID is available', () => {
+    const task: CostTaskInfo = {
+      id: 'wf-1/task-a',
+      workflowId: 'wf-1',
+      executorType: 'worktree',
+    };
+    expect(buildAttributionContext(task)).toBeUndefined();
+  });
+
+  it('falls back to lastAgentSessionId and lastAgentName', () => {
+    const task: CostTaskInfo = {
+      id: 'wf-1/task-a',
+      workflowId: 'wf-1',
+      executorType: 'ssh',
+      lastAgentSessionId: 'sess-old',
+      lastAgentName: 'claude',
+    };
+    const ctx = buildAttributionContext(task);
+    expect(ctx?.agentSessionId).toBe('sess-old');
+    expect(ctx?.agentName).toBe('claude');
+    expect(ctx?.source).toBe('anthropic');
+  });
+
+  it('defaults executorType to worktree when empty', () => {
+    const task: CostTaskInfo = {
+      id: 'wf-1/task-a',
+      workflowId: 'wf-1',
+      executorType: '',
+      agentSessionId: 'sess-123',
+    };
+    const ctx = buildAttributionContext(task);
+    expect(ctx?.executorType).toBe('worktree');
+  });
+});
+
+// ── serializeGroupedRollup ─────────────────────────────────
+
+describe('serializeGroupedRollup', () => {
+  it('flattens group into JSON-safe object', () => {
+    const events = [makeEvent({ eventId: 'e1', estimatedCostUsd: 0.005 })];
+    const groups = groupCostEvents(events, ['workflow']);
+    const serialized = serializeGroupedRollup(groups[0]);
+
+    expect(serialized.groupKey).toBe('wf-1');
+    expect(serialized.dimensions).toEqual({ workflow: 'wf-1' });
+    expect(serialized.eventCount).toBe(1);
+    expect(serialized.totalCostUsd).toBeCloseTo(0.005, 6);
+
+    // Valid JSON
+    const json = JSON.stringify(serialized);
+    expect(() => JSON.parse(json)).not.toThrow();
+  });
+});

--- a/packages/app/src/__tests__/headless-query-costs.test.ts
+++ b/packages/app/src/__tests__/headless-query-costs.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { runHeadless } from '../headless.js';
+import type { HeadlessDeps } from '../headless.js';
+import type { Orchestrator, CommandService, TaskState } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import type { MessageBus } from '@invoker/transport';
+import { LocalBus } from '@invoker/transport';
+import type { AgentRegistry } from '@invoker/execution-engine';
+
+const noopLogger = {
+  debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn(),
+  child: vi.fn(function () { return noopLogger; }),
+};
+
+function makeWorkflow(id: string, status: 'completed' | 'failed' | 'running') {
+  return { id, name: `Workflow ${id}`, status, createdAt: '2025-01-01T00:00:00Z', updatedAt: '2025-01-01T00:01:00Z' };
+}
+
+function makeTask(wfId: string, taskSuffix: string, overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id: `${wfId}/${taskSuffix}`,
+    description: `Task ${taskSuffix}`,
+    status: 'completed',
+    dependencies: [],
+    createdAt: new Date(),
+    config: {
+      workflowId: wfId,
+      isMergeNode: false,
+      executorType: 'worktree',
+      ...((overrides.config ?? {}) as any),
+    },
+    execution: {
+      agentSessionId: `sess-${wfId}-${taskSuffix}`,
+      agentName: 'codex',
+      ...((overrides.execution ?? {}) as any),
+    },
+    ...overrides,
+  } as unknown as TaskState;
+}
+
+/** Fake JSONL content that extractCodexUsage can parse. */
+function makeSessionRaw(turns: Array<{ input: number; output: number; cached?: number }>) {
+  return turns.map((t, i) => JSON.stringify({
+    type: 'turn.completed',
+    usage: {
+      input_tokens: t.input,
+      output_tokens: t.output,
+      cache_read_input_tokens: t.cached ?? 0,
+      total_tokens: t.input + t.output,
+    },
+  })).join('\n');
+}
+
+describe('headless query costs', () => {
+  let mockDeps: HeadlessDeps;
+  let stdoutSpy: any;
+
+  const tasksForWf1 = [
+    makeTask('wf-1', 'task-a'),
+    makeTask('wf-1', 'task-b'),
+  ];
+
+  const sessionData = new Map<string, string>([
+    ['sess-wf-1-task-a', makeSessionRaw([{ input: 100, output: 50 }, { input: 200, output: 80 }])],
+    ['sess-wf-1-task-b', makeSessionRaw([{ input: 300, output: 120 }])],
+  ]);
+
+  const mockDriver = {
+    processOutput: vi.fn(),
+    loadSession: vi.fn((sessionId: string) => sessionData.get(sessionId) ?? null),
+    parseSession: vi.fn(() => []),
+    inspectSession: vi.fn(() => ({ state: 'finished' as const })),
+    extractUsage: vi.fn((raw: string) => {
+      const lines = raw.split('\n').filter(Boolean);
+      return lines.map((line, i) => {
+        const entry = JSON.parse(line);
+        const u = entry.usage;
+        return {
+          eventId: `codex-turn-${i}`,
+          timestamp: '',
+          model: '',
+          inputTokens: u.input_tokens ?? 0,
+          outputTokens: u.output_tokens ?? 0,
+          cachedTokens: u.cache_read_input_tokens ?? 0,
+          totalTokens: u.total_tokens ?? 0,
+          confidence: 'exact' as const,
+        };
+      });
+    }),
+  };
+
+  beforeEach(() => {
+    mockDeps = {
+      logger: noopLogger as any,
+      orchestrator: {} as Orchestrator,
+      persistence: {
+        readOnly: false,
+        listWorkflows: vi.fn(() => [makeWorkflow('wf-1', 'completed')]),
+        loadTasks: vi.fn(() => []),
+      } as unknown as SQLiteAdapter,
+      commandService: {} as CommandService,
+      executorRegistry: {} as any,
+      executionAgentRegistry: {
+        getSessionDriver: vi.fn(() => mockDriver),
+      } as unknown as AgentRegistry,
+      messageBus: new LocalBus() as MessageBus,
+      repoRoot: '/fake/repo',
+      invokerConfig: {} as any,
+      initServices: vi.fn(async () => {}),
+      wireSlackBot: vi.fn(async () => ({})),
+    };
+    mockDeps.orchestrator.syncFromDb = vi.fn();
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => tasksForWf1 as any);
+    stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  it('resolves without error', async () => {
+    await expect(runHeadless(['query', 'costs'], mockDeps)).resolves.toBeUndefined();
+  });
+
+  it('outputs grouped rollups in JSON format', async () => {
+    await runHeadless(['query', 'costs', '--output', 'json'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+
+    expect(parsed.groups).toBeDefined();
+    expect(parsed.total).toBeDefined();
+    expect(parsed.events).toBeDefined();
+    expect(parsed.total.eventCount).toBe(3); // 2 turns from task-a + 1 from task-b
+    expect(parsed.total.inputTokens).toBe(600); // 100 + 200 + 300
+    expect(parsed.total.outputTokens).toBe(250); // 50 + 80 + 120
+  });
+
+  it('outputs events in JSONL format', async () => {
+    await runHeadless(['query', 'costs', '--output', 'jsonl'], mockDeps);
+    const lines = stdoutSpy.mock.calls.map(c => (c[0] as string).trim()).filter(Boolean);
+    expect(lines).toHaveLength(3);
+
+    for (const line of lines) {
+      const parsed = JSON.parse(line);
+      expect(parsed).toHaveProperty('eventId');
+      expect(parsed).toHaveProperty('inputTokens');
+      expect(parsed).toHaveProperty('workflowId');
+    }
+  });
+
+  it('outputs compact label format', async () => {
+    await runHeadless(['query', 'costs', '--output', 'label'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    expect(output).toMatch(/\d+ tokens \$[\d.]+/);
+  });
+
+  it('filters by workflow', async () => {
+    await runHeadless(['query', 'costs', '--workflow', 'wf-1', '--output', 'json'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.total.eventCount).toBe(3);
+  });
+
+  it('outputs "No cost data" when no sessions exist', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [
+      makeTask('wf-1', 'task-c', { execution: {} }),
+    ] as any);
+
+    await runHeadless(['query', 'costs'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    expect(output).toContain('No cost data');
+  });
+
+  it('produces deterministic JSON output across repeated runs', async () => {
+    await runHeadless(['query', 'costs', '--output', 'json'], mockDeps);
+    const output1 = stdoutSpy.mock.calls[0][0] as string;
+
+    stdoutSpy.mockClear();
+    await runHeadless(['query', 'costs', '--output', 'json'], mockDeps);
+    const output2 = stdoutSpy.mock.calls[0][0] as string;
+
+    expect(output1).toBe(output2);
+  });
+
+  it('skips tasks without session drivers', async () => {
+    (mockDeps.executionAgentRegistry as any).getSessionDriver = vi.fn(() => undefined);
+
+    await runHeadless(['query', 'costs'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    expect(output).toContain('No cost data');
+  });
+
+  it('skips tasks whose driver lacks extractUsage', async () => {
+    (mockDeps.executionAgentRegistry as any).getSessionDriver = vi.fn(() => ({
+      ...mockDriver,
+      extractUsage: undefined,
+    }));
+
+    await runHeadless(['query', 'costs'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    expect(output).toContain('No cost data');
+  });
+});

--- a/packages/app/src/cost-rollup.ts
+++ b/packages/app/src/cost-rollup.ts
@@ -1,0 +1,224 @@
+/**
+ * Cost Rollup — Pure attribution joins and deterministic grouped aggregation.
+ *
+ * Takes session-local usage events and attaches workflow/task/attempt context,
+ * then groups and rolls up by configurable dimensions.
+ *
+ * All functions are pure: no I/O, no side-effects, deterministic output order.
+ */
+
+import type { NormalizedCostEvent, CostRollup } from '@invoker/contracts';
+import { rollUpCostEvents } from '@invoker/contracts';
+import type { SessionUsageEvent } from '@invoker/execution-engine';
+
+// ── Attribution Context ────────────────────────────────────
+
+/** Context needed to attribute session usage events to a workflow/task. */
+export interface AttributionContext {
+  readonly workflowId: string;
+  readonly taskId: string;
+  readonly attemptId: string;
+  readonly executorType: string;
+  readonly agentSessionId: string;
+  readonly agentName: string;
+  readonly source: string;
+}
+
+// ── Attribution Join ───────────────────────────────────────
+
+/**
+ * Map session-local usage events to fully-attributed NormalizedCostEvents.
+ *
+ * Each SessionUsageEvent carries only session-scoped data (tokens, model, confidence).
+ * This function attaches the workflow/task/attempt context from the caller.
+ */
+export function attributeSessionUsage(
+  events: readonly SessionUsageEvent[],
+  ctx: AttributionContext,
+): NormalizedCostEvent[] {
+  return events.map((e) => ({
+    identity: {
+      eventId: e.eventId,
+      agentSessionId: ctx.agentSessionId,
+      agentName: ctx.agentName,
+      source: ctx.source,
+    },
+    attribution: {
+      workflowId: ctx.workflowId,
+      taskId: ctx.taskId,
+      attemptId: ctx.attemptId,
+      executorType: ctx.executorType,
+    },
+    usage: {
+      inputTokens: e.inputTokens,
+      outputTokens: e.outputTokens,
+      cachedTokens: e.cachedTokens,
+      totalTokens: e.totalTokens,
+    },
+    pricing: {
+      model: e.model || 'unknown',
+      pricingVersion: '0',
+      estimatedCostUsd: 0,
+      confidence: e.confidence,
+    },
+    timestamp: e.timestamp,
+  }));
+}
+
+// ── Grouping Dimensions ────────────────────────────────────
+
+/** Supported group-by dimensions. */
+export type CostGroupDimension = 'workflow' | 'task' | 'agent' | 'model' | 'day';
+
+/** All supported dimensions for reference. */
+export const ALL_DIMENSIONS: readonly CostGroupDimension[] = [
+  'workflow', 'task', 'agent', 'model', 'day',
+] as const;
+
+/** Extract a group key value from an event for a given dimension. */
+function dimensionKey(event: NormalizedCostEvent, dim: CostGroupDimension): string {
+  switch (dim) {
+    case 'workflow': return event.attribution.workflowId;
+    case 'task':     return event.attribution.taskId;
+    case 'agent':    return event.identity.agentName;
+    case 'model':    return event.pricing.model;
+    case 'day':      return event.timestamp.slice(0, 10) || 'unknown';
+  }
+}
+
+// ── Grouped Rollup ─────────────────────────────────────────
+
+/** A single entry in the grouped rollup output. */
+export interface GroupedCostRollup {
+  /** The composite group key (e.g. "wf-1|task-a|claude"). */
+  readonly groupKey: string;
+  /** Individual dimension values in the same order as the dimensions array. */
+  readonly dimensions: Record<CostGroupDimension, string>;
+  /** Aggregated rollup for this group. */
+  readonly rollup: CostRollup;
+}
+
+/**
+ * Group events by the specified dimensions and produce deterministic rollups.
+ *
+ * Output is sorted by composite group key (lexicographic) so repeated runs
+ * produce identical ordering. Within each group, events are rolled up using
+ * the standard immutable accumulator from @invoker/contracts.
+ *
+ * @param events - Normalized cost events to group.
+ * @param dimensions - Dimensions to group by (default: all).
+ * @returns Sorted array of grouped rollups.
+ */
+export function groupCostEvents(
+  events: readonly NormalizedCostEvent[],
+  dimensions: readonly CostGroupDimension[] = ALL_DIMENSIONS,
+): GroupedCostRollup[] {
+  // Build groups
+  const groups = new Map<string, { dims: Record<CostGroupDimension, string>; events: NormalizedCostEvent[] }>();
+
+  for (const event of events) {
+    const keyParts: string[] = [];
+    const dims = {} as Record<CostGroupDimension, string>;
+    for (const dim of dimensions) {
+      const val = dimensionKey(event, dim);
+      dims[dim] = val;
+      keyParts.push(val);
+    }
+    const compositeKey = keyParts.join('|');
+
+    let group = groups.get(compositeKey);
+    if (!group) {
+      group = { dims, events: [] };
+      groups.set(compositeKey, group);
+    }
+    group.events.push(event);
+  }
+
+  // Sort by composite key for deterministic output
+  const sortedKeys = [...groups.keys()].sort();
+
+  return sortedKeys.map((key) => {
+    const group = groups.get(key)!;
+    return {
+      groupKey: key,
+      dimensions: group.dims,
+      rollup: rollUpCostEvents(group.events),
+    };
+  });
+}
+
+// ── Convenience: collect events for all tasks in a workflow ─
+
+/** Minimal task shape needed for cost extraction. */
+export interface CostTaskInfo {
+  readonly id: string;
+  readonly workflowId: string;
+  readonly executorType: string;
+  readonly agentSessionId?: string;
+  readonly lastAgentSessionId?: string;
+  readonly agentName?: string;
+  readonly lastAgentName?: string;
+}
+
+/**
+ * Resolve session ID with deterministic fallback:
+ * 1. agentSessionId (current execution)
+ * 2. lastAgentSessionId (previous execution)
+ * Returns undefined if neither is available.
+ */
+export function resolveSessionId(task: CostTaskInfo): string | undefined {
+  return task.agentSessionId ?? task.lastAgentSessionId ?? undefined;
+}
+
+/**
+ * Resolve agent name with deterministic fallback:
+ * 1. agentName (current execution)
+ * 2. lastAgentName (previous execution)
+ * 3. 'claude' (default)
+ */
+export function resolveAgentName(task: CostTaskInfo): string {
+  return task.agentName ?? task.lastAgentName ?? 'claude';
+}
+
+/**
+ * Derive the provider source from agent name.
+ * Maps known agents to their provider; defaults to 'unknown'.
+ */
+export function deriveSource(agentName: string): string {
+  switch (agentName) {
+    case 'claude': return 'anthropic';
+    case 'codex':  return 'openai';
+    default:       return 'unknown';
+  }
+}
+
+/**
+ * Build an AttributionContext from a task info record.
+ * Returns undefined if no session ID is available.
+ */
+export function buildAttributionContext(task: CostTaskInfo): AttributionContext | undefined {
+  const sessionId = resolveSessionId(task);
+  if (!sessionId) return undefined;
+
+  const agentName = resolveAgentName(task);
+  return {
+    workflowId: task.workflowId,
+    taskId: task.id,
+    attemptId: `${task.id}-latest`,
+    executorType: task.executorType || 'worktree',
+    agentSessionId: sessionId,
+    agentName,
+    source: deriveSource(agentName),
+  };
+}
+
+/**
+ * Serialize a GroupedCostRollup to a plain JSON-safe object.
+ */
+export function serializeGroupedRollup(group: GroupedCostRollup): Record<string, unknown> {
+  return {
+    groupKey: group.groupKey,
+    dimensions: { ...group.dimensions },
+    ...group.rollup,
+  };
+}

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -7,6 +7,7 @@
 import type { TaskState, TaskStatus } from '@invoker/workflow-core';
 import type { TaskEvent, Workflow } from '@invoker/data-store';
 import type { NormalizedCostEvent, CostRollup } from '@invoker/contracts';
+import type { GroupedCostRollup } from './cost-rollup.js';
 
 // ── ANSI Color Codes ─────────────────────────────────────────
 
@@ -385,6 +386,39 @@ export function formatCostRollup(rollup: CostRollup): string {
   }
   if (rollup.missingUsageCount > 0) {
     lines.push(`  ${RED}Missing usage       ${rollup.missingUsageCount}${RESET}`);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Format grouped cost rollups as a table-like block.
+ *
+ * Each group gets a header line with dimension values, followed by
+ * a compact rollup summary.
+ */
+export function formatGroupedCostRollups(groups: GroupedCostRollup[]): string {
+  if (groups.length === 0) {
+    return `${DIM}No cost data available.${RESET}`;
+  }
+
+  const lines: string[] = [];
+  lines.push(`${BOLD}Cost rollup (${groups.length} group${groups.length === 1 ? '' : 's'})${RESET}`);
+  lines.push('');
+
+  for (const group of groups) {
+    const dimParts = Object.entries(group.dimensions)
+      .map(([k, v]) => `${k}=${v}`)
+      .join(' ');
+    const r = group.rollup;
+    const cost = `$${r.totalCostUsd.toFixed(4)}`;
+    const warnings: string[] = [];
+    if (r.unknownConfidenceCount > 0) warnings.push(`${YELLOW}${r.unknownConfidenceCount} unknown${RESET}`);
+    if (r.missingUsageCount > 0) warnings.push(`${RED}${r.missingUsageCount} missing${RESET}`);
+    const warnSuffix = warnings.length > 0 ? ` (${warnings.join(', ')})` : '';
+
+    lines.push(`  ${BOLD}${dimParts}${RESET}`);
+    lines.push(`    ${r.eventCount} events — ${r.totalTokens.toLocaleString()} tokens — ${BOLD}${cost}${RESET}${warnSuffix}`);
   }
 
   return lines.join('\n');

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -361,7 +361,7 @@ export function parseQueryFlags(args: string[]): QueryFlags {
 async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|audit|session|ui-perf>');
+    throw new Error('Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|audit|session|costs|ui-perf>');
   }
   const flags = parseQueryFlags(args.slice(1));
 
@@ -580,8 +580,113 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
       }
       break;
     }
+    case 'costs': {
+      await headlessCosts(flags, deps);
+      break;
+    }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, ui-perf, stats`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, costs, ui-perf, stats`);
+  }
+}
+
+// ── Cost Query ──────────────────────────────────────────────
+
+async function headlessCosts(
+  flags: QueryFlags,
+  deps: Pick<HeadlessDeps, 'orchestrator' | 'persistence' | 'executionAgentRegistry'>,
+): Promise<void> {
+  const {
+    formatGroupedCostRollups, formatCostRollup,
+    serializeCostEvent,
+    formatAsJson,
+  } = await import('./formatter.js');
+  const {
+    attributeSessionUsage, groupCostEvents, buildAttributionContext,
+    serializeGroupedRollup,
+  } = await import('./cost-rollup.js');
+  const { rollUpCostEvents } = await import('@invoker/contracts');
+
+  // Determine target workflow
+  const workflowFilter = flags.workflow ?? flags.positional[0];
+  const workflows = deps.persistence.listWorkflows();
+  if (workflows.length === 0) {
+    process.stdout.write('No workflows found.\n');
+    return;
+  }
+
+  const targetWorkflows = workflowFilter
+    ? workflows.filter(wf => wf.id === workflowFilter)
+    : workflows;
+
+  if (workflowFilter && targetWorkflows.length === 0) {
+    throw new Error(`Workflow "${workflowFilter}" not found.`);
+  }
+
+  // Collect all NormalizedCostEvents across tasks
+  const allEvents: import('@invoker/contracts').NormalizedCostEvent[] = [];
+
+  for (const wf of targetWorkflows) {
+    deps.orchestrator.syncFromDb(wf.id);
+    const tasks = deps.orchestrator.getAllTasks().filter(
+      t => t.config.workflowId === wf.id && !t.config.isMergeNode,
+    );
+
+    for (const task of tasks) {
+      const ctx = buildAttributionContext({
+        id: task.id,
+        workflowId: wf.id,
+        executorType: task.config.executorType ?? 'worktree',
+        agentSessionId: task.execution.agentSessionId,
+        lastAgentSessionId: task.execution.lastAgentSessionId,
+        agentName: task.execution.agentName,
+        lastAgentName: task.execution.lastAgentName,
+      });
+      if (!ctx) continue;
+
+      // Extract usage from session driver
+      const agentName = ctx.agentName;
+      const driver = deps.executionAgentRegistry?.getSessionDriver(agentName);
+      if (!driver?.extractUsage) continue;
+
+      const raw = driver.loadSession(ctx.agentSessionId);
+      if (!raw) continue;
+
+      const usageEvents = driver.extractUsage(raw);
+      const attributed = attributeSessionUsage(usageEvents, ctx);
+      allEvents.push(...attributed);
+    }
+  }
+
+  if (allEvents.length === 0) {
+    process.stdout.write('No cost data available.\n');
+    return;
+  }
+
+  // Group by all dimensions and output
+  const grouped = groupCostEvents(allEvents);
+  const totalRollup = rollUpCostEvents(allEvents);
+
+  switch (flags.output) {
+    case 'label':
+      process.stdout.write(`${totalRollup.totalTokens} tokens $${totalRollup.totalCostUsd.toFixed(4)}\n`);
+      break;
+    case 'json':
+      process.stdout.write(formatAsJson({
+        groups: grouped.map(serializeGroupedRollup),
+        total: totalRollup,
+        events: allEvents.map(serializeCostEvent),
+      }) + '\n');
+      break;
+    case 'jsonl':
+      for (const event of allEvents) {
+        process.stdout.write(JSON.stringify(serializeCostEvent(event)) + '\n');
+      }
+      break;
+    default:
+      process.stdout.write(formatGroupedCostRollups(grouped) + '\n');
+      process.stdout.write('\n');
+      process.stdout.write(formatCostRollup(totalRollup) + '\n');
+      break;
   }
 }
 


### PR DESCRIPTION
## Summary
Goal:
- Attribute usage events to task/workflow context and produce deterministic
  rollups for automation and scripting.

Motivation:
- Without deterministic joins and grouping rules, cost analytics become
  non-repeatable and hard to trust.

Alternatives considered:
- Option A (chosen): app-layer rollups from normalized events.
- Option B: DB materialized rollup tables/views.

Why chosen:
- App-layer rollups allow faster iteration with simpler correctness tests
  before schema persistence requirements stabilize.

Implementation contract:
- Join order: agentSessionId -> lastAgentSessionId -> event-log fallback.
- Deterministic sort for output stability.
- Aggregate tokens as integers and costs as decimal sums.
- Track unknownConfidenceCount and missingUsageCount.


---
Cost Query Step 3: join context and rollups (replacement v2) — 3 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1778194309068-14/implement-cost-rollups | Layer: app_bridge
Feature state: active
Goal:
- Attribute usage to workflow/task/attempt and produce deterministic aggregates.
Motivation:
- Cost analytics must be repeatable and comparable across reruns and filters.
Alternative considerations:
- Option A (chosen): app-layer rollups from normalized events
- Option B: DB materialized rollup tables/views
Chosen design rationale:
- Faster iteration and easier correctness debugging before persistence semantics stabilize.
Implementation details:
- Join precedence: agentSessionId -> lastAgentSessionId -> event-log fallback.
- Deterministic ordering and stable grouping for workflow/task/agent/model/day.
- Track unknownConfidenceCount and missingUsageCount in totals.
Acceptance criteria:
- Per-task and per-workflow rollups are deterministic.
- Grouping dimensions (agent/model) work with stable output fields.
 | completed |
| wf-1778194309068-14/run-rollup-tests | Layer: app_regression
Feature state: active
Goal:
- Verify rollup attribution and aggregation behavior in app package tests.
Motivation:
- Detect determinism and grouping regressions before full-suite execution.
Alternative considerations:
- Option A (chosen): focused app test lane.
- Option B: skip focused tests and rely on full-suite gate.
Implementation details:
- Execute app package tests immediately after rollup implementation.
Acceptance criteria:
- New rollup unit tests and affected app tests pass.
 | completed (passed) |
| wf-1778194309068-14/post-fix-regression | Layer: app_regression
Feature state: active
Goal:
- Run terminal full-repo regression gate for rollup layer changes.
Motivation:
- Ensure downstream packages remain stable with new rollup behavior.
Alternative considerations:
- Option A (chosen): full repository suite.
- Option B: app-only test coverage.
Implementation details:
- Execute `pnpm run test:all` after focused rollup lane.
Acceptance criteria:
- Full repository regression passes.
 | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1778194309068-14/implement-cost-rollups — Layer: app_bridge
Feature state: active
Goal:
- Attribute usage to workflow/task/attempt and produce deterministic aggregates.
Motivation:
- Cost analytics must be repeatable and comparable across reruns and filters.
Alternative considerations:
- Option A (chosen): app-layer rollups from normalized events
- Option B: DB materialized rollup tables/views
Chosen design rationale:
- Faster iteration and easier correctness debugging before persistence semantics stabilize.
Implementation details:
- Join precedence: agentSessionId -> lastAgentSessionId -> event-log fallback.
- Deterministic ordering and stable grouping for workflow/task/agent/model/day.
- Track unknownConfidenceCount and missingUsageCount in totals.
Acceptance criteria:
- Per-task and per-workflow rollups are deterministic.
- Grouping dimensions (agent/model) work with stable output fields.

packages/app/src/__tests__/cost-rollup.test.ts     | 430 +++++++++++++++++++++
 .../app/src/__tests__/headless-query-costs.test.ts | 203 ++++++++++
 packages/app/src/cost-rollup.ts                    | 224 +++++++++++
 packages/app/src/formatter.ts                      |  99 +++++
 packages/app/src/headless.ts                       | 109 +++++-
 .../contracts/src/__tests__/cost-types.test.ts     | 416 ++++++++++++++++++++
 packages/contracts/src/cost-types.ts               | 136 +++++++
 packages/contracts/src/index.ts                    |   1 +
 .../src/__tests__/claude-session-driver.test.ts    | 123 ++++++
 .../src/__tests__/codex-session-driver.test.ts     |  42 ++
 .../src/__tests__/codex-session.test.ts            | 142 ++++++-
 .../execution-engine/src/claude-session-driver.ts  |  46 ++-
 .../execution-engine/src/codex-session-driver.ts   |   8 +-
 packages/execution-engine/src/codex-session.ts     |  86 +++++
 packages/execution-engine/src/session-driver.ts    |  28 ++
 scripts/run-all-tests.sh                           |  10 +-
 16 files changed, 2095 insertions(+), 8 deletions(-)

### wf-1778194309068-14/run-rollup-tests — Layer: app_regression
Feature state: active
Goal:
- Verify rollup attribution and aggregation behavior in app package tests.
Motivation:
- Detect determinism and grouping regressions before full-suite execution.
Alternative considerations:
- Option A (chosen): focused app test lane.
- Option B: skip focused tests and rely on full-suite gate.
Implementation details:
- Execute app package tests immediately after rollup implementation.
Acceptance criteria:
- New rollup unit tests and affected app tests pass.


### wf-1778194309068-14/post-fix-regression — Layer: app_regression
Feature state: active
Goal:
- Run terminal full-repo regression gate for rollup layer changes.
Motivation:
- Ensure downstream packages remain stable with new rollup behavior.
Alternative considerations:
- Option A (chosen): full repository suite.
- Option B: app-only test coverage.
Implementation details:
- Execute `pnpm run test:all` after focused rollup lane.
Acceptance criteria:
- Full repository regression passes.


</details>
