### PR TITLE
Bulk Delete-All Step 5: mutation coordinator delete fence

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -119,6 +119,7 @@ import {
 import {
   approveTask as sharedApproveTask,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
+  deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
   fixWithAgentAction,
   rebaseAndRetry,
   recreateWithRebase,
@@ -1868,6 +1869,8 @@ if (isHeadless) {
       }
       case 'invoker:delete-all-workflows':
         return { channel: 'headless.exec', request: { args: ['delete-all'] } };
+      case 'invoker:delete-all-workflows-bulk':
+        return { channel: 'headless.exec', request: { args: ['delete-all'] } };
       case 'invoker:delete-workflow':
         return { channel: 'headless.exec', request: { args: ['delete', String(arg0)] } };
       case 'invoker:detach-workflow':
@@ -2785,6 +2788,18 @@ if (isHeadless) {
       logger.info('delete-all-workflows', { module: 'ipc' });
       assertDeleteAllEnabled();
       await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
+      taskHandles.clear();
+      lastKnownTaskStates.clear();
+      lastKnownWorkflowCount = 0;
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('invoker:workflows-changed', []);
+      }
+    });
+
+    registerGuiMutationHandler('invoker:delete-all-workflows-bulk', async () => {
+      logger.info('delete-all-workflows-bulk', { module: 'ipc' });
+      assertDeleteAllEnabled();
+      await sharedDeleteAllWorkflowsBulk({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
       lastKnownTaskStates.clear();
       lastKnownWorkflowCount = 0;

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -329,7 +329,7 @@ export class PersistedWorkflowMutationCoordinator {
     ) {
       return 'recreate';
     }
-    if (channel === 'invoker:delete-workflow' || channel === 'invoker:delete-all-workflows') {
+    if (channel === 'invoker:delete-workflow' || channel === 'invoker:delete-all-workflows' || channel === 'invoker:delete-all-workflows-bulk') {
       return 'delete';
     }
     if (channel !== 'headless.exec') {
@@ -354,6 +354,7 @@ export class PersistedWorkflowMutationCoordinator {
       || intent.channel === 'invoker:recreate-with-rebase'
       || intent.channel === 'invoker:delete-workflow'
       || intent.channel === 'invoker:delete-all-workflows'
+      || intent.channel === 'invoker:delete-all-workflows-bulk'
     ) {
       return true;
     }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -213,6 +213,42 @@ export async function deleteAllWorkflows(
 }
 
 /**
+ * Bulk delete-all variant that suppresses per-task removal deltas.
+ *
+ * Identical lifecycle to {@link deleteAllWorkflows} (snapshot → kill →
+ * orchestrator purge) but passes `publishRemovalDeltas: false` so the
+ * orchestrator skips individual `removed` TaskDelta messages.  The
+ * caller is expected to notify the UI through a separate channel
+ * (e.g. `invoker:workflows-changed`).
+ */
+export async function deleteAllWorkflowsBulk(
+  deps: Pick<ActionDeps, 'logger' | 'orchestrator' | 'taskExecutor'>,
+): Promise<{ snapshotPath: string | null }> {
+  const snapshotPath = createDeleteAllSnapshot();
+  deps.logger?.info(
+    snapshotPath
+      ? `delete-all-workflows-bulk snapshot: ${snapshotPath}`
+      : 'delete-all-workflows-bulk snapshot skipped: DB file does not exist yet',
+    { module: 'workflow' },
+  );
+
+  const taskExecutor = deps.taskExecutor;
+  if (taskExecutor) {
+    const allTasks = deps.orchestrator.getAllTasks();
+    const active = allTasks.filter(
+      (t) => t.status === 'running' || t.status === 'fixing_with_ai',
+    );
+    for (const task of active) {
+      deps.logger?.info(`delete-all-bulk: killing active task "${task.id}"`, { module: 'kill' });
+      await taskExecutor.killActiveExecution(task.id);
+    }
+  }
+
+  deps.orchestrator.deleteAllWorkflows({ publishRemovalDeltas: false });
+  return { snapshotPath };
+}
+
+/**
  * Recreate a workflow from a refreshed upstream base — the chart's
  * `recreateWorkflowFromFreshBase` action
  * (`docs/architecture/task-invalidation-chart.md` rows

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -199,6 +199,10 @@ export const IpcChannels = {
     request: [];
     response: void;
   },
+  'invoker:delete-all-workflows-bulk': {} as {
+    request: [];
+    response: void;
+  },
   'invoker:delete-workflow': {} as {
     request: [workflowId: string];
     response: void;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -419,7 +419,7 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await invoker.deleteAllWorkflows();
+      await invoker.deleteAllWorkflowsBulk();
       clearTasks();
       setHasLoadedPlan(false);
       setHasStarted(false);

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -128,6 +128,7 @@ export function createMockInvoker(
     listWorkflows: vi.fn(async () => []),
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),
     deleteAllWorkflows: vi.fn(async () => {}),
+    deleteAllWorkflowsBulk: vi.fn(async () => {}),
     deleteWorkflow: vi.fn(async () => {}),
     cleanupWorktrees: vi.fn(async () => ({ removed: [], errors: [] })),
     recreateWorkflow: vi.fn(async () => {}),

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -214,6 +214,17 @@ export interface OrchestratorMessageBus {
 
 // ── Public Types ────────────────────────────────────────────
 
+/** Options for {@link Orchestrator.deleteAllWorkflows}. */
+export interface DeleteAllWorkflowsOptions {
+  /**
+   * When `true` (the default), a `removed` TaskDelta is published for every
+   * task before the method returns.  Set to `false` to skip per-task delta
+   * publication — useful for bulk callers that notify the UI through a
+   * separate channel.
+   */
+  publishRemovalDeltas?: boolean;
+}
+
 export interface PlanDefinition {
   name: string;
   description?: string;
@@ -3489,9 +3500,11 @@ export class Orchestrator {
    * Delete all workflows: DB first, then scheduler, memory, and publish removal deltas.
    * Follows the same DB→memory→publish pattern as writeAndSync().
    */
-  deleteAllWorkflows(): void {
+  deleteAllWorkflows(options?: DeleteAllWorkflowsOptions): void {
+    const { publishRemovalDeltas = true } = options ?? {};
+
     // 1. Collect all tasks before clearing (needed for deltas)
-    const allTasks = this.stateMachine.getAllTasks();
+    const allTasks = publishRemovalDeltas ? this.stateMachine.getAllTasks() : [];
 
     // 2. DB first
     this.persistence.deleteAllWorkflows?.();
@@ -3503,7 +3516,7 @@ export class Orchestrator {
     this.activeWorkflowIds.clear();
     this.stateMachine.clear();
 
-    // 5. Publish removal deltas
+    // 5. Publish removal deltas (skipped when publishRemovalDeltas is false)
     for (const task of allTasks) {
       this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildRemoveDelta(task));
     }

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -24,9 +24,15 @@ if [ "$EXTENDED" = "1" ] && [ "$DANGEROUS" = "1" ]; then
   MODE_KEY="dangerous"
 fi
 
-STATE_FILE="${INVOKER_TEST_ALL_STATE_FILE:-$ROOT/.git/invoker-test-all-state.tsv}"
+GIT_DIR="$(cd "$ROOT" && git rev-parse --git-dir)"
+# Resolve to absolute path if relative
+case "$GIT_DIR" in
+  /*) ;;
+  *)  GIT_DIR="$ROOT/$GIT_DIR" ;;
+esac
+STATE_FILE="${INVOKER_TEST_ALL_STATE_FILE:-$GIT_DIR/invoker-test-all-state.tsv}"
 RUN_ID="$(date +%Y%m%d-%H%M%S)-$$"
-LOG_ROOT="${ROOT}/.git/invoker-test-all-logs/${RUN_ID}"
+LOG_ROOT="${GIT_DIR}/invoker-test-all-logs/${RUN_ID}"
 mkdir -p "$(dirname "$STATE_FILE")" "$LOG_ROOT"
 touch "$STATE_FILE"
 


### PR DESCRIPTION
## Summary
Goal:
Preserve mutation queue safety semantics for the new bulk delete-all channel.

Motivation:
Ensure bulk delete-all is classified as a delete fence so preemption and
eviction behavior matches legacy destructive operations.

Implementation details:
- include bulk channel in delete-fence predicate.
- keep existing queue ordering and lease semantics unchanged.

Alternative considerations:
- assume channel inheritance with no explicit classifier update.
- redesign coordinator around new metadata taxonomy in this same change.

Competing-design proof:
- verify no-update path fails to guarantee deterministic invalidation parity.
- compare scope/risk of full redesign versus targeted inclusion.

Why this design is better:
Explicit classifier update is low-risk, deterministic, and scoped to this bugfix.

Intermediate publication path:
- Use EdbertChan/Invoker as the intermediate publication repository for stack visibility, then promote upstream in Neko-Catpital-Labs/Invoker.


---
Bulk Delete-All Step 5: mutation coordinator delete fence — 3 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1778193696486-6/classify-bulk-channel-as-delete-fence | Layer: owner_delegation
Feature state: active
Goal:
Preserve queue invalidation and preemption semantics for bulk delete-all.
Motivation:
Treat bulk delete-all exactly like legacy delete-all in coordinator fencing.
Implementation details:
- update delete-fence channel classification in coordinator logic.
Alternative considerations:
- no-op classifier update.
- generic coordinator metadata rewrite.
Competing-design proof:
- validate race/parity coverage for channel inclusion.
Why this design is better:
- smallest scoped change that enforces deterministic behavior.
Files:
- packages/app/src/workflow-mutation-coordinator.ts
Change types:
- include bulk delete-all IPC channel in delete-fence predicate
- preserve preemption/eviction semantics during queue mutations
Acceptance criteria:
- bulk delete-all mutation is treated as delete-fence by coordinator logic.
- queue ordering and cancellation behavior match legacy delete-all semantics.
 | completed |
| wf-1778193696486-6/verify-coordinator-tests | Layer: app_regression
Feature state: active
Goal:
Define the outcome for `verify-coordinator-tests`.
Motivation:
Preserve explicit rationale for reviewers and deterministic lint checks.
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Validate queue/delete-fence behavior.
 | completed (passed) |
| wf-1778193696486-6/post-fix-regression | Layer: app_regression
Feature state: active
Goal:
Define the outcome for `post-fix-regression`.
Motivation:
Preserve explicit rationale for reviewers and deterministic lint checks.
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Final regression gate required for merge-ready implementation workflows.
 | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1778193696486-6/classify-bulk-channel-as-delete-fence — Layer: owner_delegation
Feature state: active
Goal:
Preserve queue invalidation and preemption semantics for bulk delete-all.
Motivation:
Treat bulk delete-all exactly like legacy delete-all in coordinator fencing.
Implementation details:
- update delete-fence channel classification in coordinator logic.
Alternative considerations:
- no-op classifier update.
- generic coordinator metadata rewrite.
Competing-design proof:
- validate race/parity coverage for channel inclusion.
Why this design is better:
- smallest scoped change that enforces deterministic behavior.
Files:
- packages/app/src/workflow-mutation-coordinator.ts
Change types:
- include bulk delete-all IPC channel in delete-fence predicate
- preserve preemption/eviction semantics during queue mutations
Acceptance criteria:
- bulk delete-all mutation is treated as delete-fence by coordinator logic.
- queue ordering and cancellation behavior match legacy delete-all semantics.

packages/app/src/main.ts                           | 15 +++++++++
 .../src/persisted-workflow-mutation-coordinator.ts |  3 +-
 packages/app/src/workflow-actions.ts               | 36 ++++++++++++++++++++++
 packages/contracts/src/ipc-channels.ts             |  4 +++
 packages/ui/src/App.tsx                            |  2 +-
 packages/ui/src/__tests__/helpers/mock-invoker.ts  |  1 +
 packages/workflow-core/src/orchestrator.ts         | 19 ++++++++++--
 scripts/run-all-tests.sh                           | 10 ++++--
 8 files changed, 83 insertions(+), 7 deletions(-)

### wf-1778193696486-6/verify-coordinator-tests — Layer: app_regression
Feature state: active
Goal:
Define the outcome for `verify-coordinator-tests`.
Motivation:
Preserve explicit rationale for reviewers and deterministic lint checks.
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Validate queue/delete-fence behavior.


### wf-1778193696486-6/post-fix-regression — Layer: app_regression
Feature state: active
Goal:
Define the outcome for `post-fix-regression`.
Motivation:
Preserve explicit rationale for reviewers and deterministic lint checks.
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Final regression gate required for merge-ready implementation workflows.


</details>
