### PR TITLE
Bulk Delete-All Step 7: visual proof capture

### DIFF
--- a/packages/app/src/__tests__/delete-all-lifecycle.test.ts
+++ b/packages/app/src/__tests__/delete-all-lifecycle.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Orchestrator } from '@invoker/workflow-core';
 import type { TaskRunner } from '@invoker/execution-engine';
-import { deleteAllWorkflows } from '../workflow-actions.js';
+import { deleteAllWorkflows, deleteAllWorkflowsBulk } from '../workflow-actions.js';
 
 vi.mock('../delete-all-snapshot.js', () => ({
   createDeleteAllSnapshot: () => '/tmp/fake-snapshot',
@@ -319,6 +319,144 @@ describe('delete-all lifecycle invariants', () => {
 
       expect(result.snapshotPath).toBe('/tmp/fake-snapshot');
       expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('bulk delete-all lifecycle invariants', () => {
+  describe('process cleanup ordering', () => {
+    it('kills every running and fixing_with_ai task before calling orchestrator.deleteAllWorkflows', async () => {
+      const callOrder: string[] = [];
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [
+          makeTask({ id: 'wf-1/r1', status: 'running' }),
+          makeTask({ id: 'wf-1/f1', status: 'fixing_with_ai' }),
+          makeTask({ id: 'wf-1/r2', status: 'running' }),
+          makeTask({ id: 'wf-2/p1', status: 'pending' }),
+        ]),
+        deleteAllWorkflows: vi.fn(() => callOrder.push('deleteAll')),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn(async (id: string) => {
+          callOrder.push(`kill:${id}`);
+        }),
+      };
+
+      await deleteAllWorkflowsBulk({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+      });
+
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledTimes(3);
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('wf-1/r1');
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('wf-1/f1');
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('wf-1/r2');
+
+      const deleteAllIdx = callOrder.indexOf('deleteAll');
+      const killIndices = callOrder
+        .map((entry, i) => (entry.startsWith('kill:') ? i : -1))
+        .filter((i) => i >= 0);
+      for (const killIdx of killIndices) {
+        expect(killIdx).toBeLessThan(deleteAllIdx);
+      }
+    });
+  });
+
+  describe('publishRemovalDeltas suppression', () => {
+    it('passes publishRemovalDeltas: false to orchestrator.deleteAllWorkflows', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => []),
+        deleteAllWorkflows: vi.fn(),
+      };
+
+      await deleteAllWorkflowsBulk({
+        orchestrator: orchestrator as unknown as Orchestrator,
+      });
+
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledWith({ publishRemovalDeltas: false });
+    });
+  });
+
+  describe('headless path (no taskExecutor)', () => {
+    it('skips process cleanup entirely when taskExecutor is absent', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [makeTask({ id: 'r1', status: 'running' })]),
+        deleteAllWorkflows: vi.fn(),
+      };
+
+      await deleteAllWorkflowsBulk({
+        orchestrator: orchestrator as unknown as Orchestrator,
+      });
+
+      expect(orchestrator.getAllTasks).not.toHaveBeenCalled();
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('snapshot lifecycle', () => {
+    it('returns snapshot path for bulk variant', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => []),
+        deleteAllWorkflows: vi.fn(),
+      };
+
+      const result = await deleteAllWorkflowsBulk({
+        orchestrator: orchestrator as unknown as Orchestrator,
+      });
+
+      expect(result.snapshotPath).toBe('/tmp/fake-snapshot');
+    });
+  });
+
+  describe('logger integration', () => {
+    it('logs bulk-specific messages when logger is provided', async () => {
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [
+          makeTask({ id: 'wf-1/t1', status: 'running' }),
+        ]),
+        deleteAllWorkflows: vi.fn(),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await deleteAllWorkflowsBulk({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+        logger: logger as any,
+      });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('bulk'),
+        expect.objectContaining({ module: 'workflow' }),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('wf-1/t1'),
+        expect.objectContaining({ module: 'kill' }),
+      );
+    });
+  });
+
+  describe('parity with legacy delete-all', () => {
+    it('legacy variant does NOT pass publishRemovalDeltas: false', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => []),
+        deleteAllWorkflows: vi.fn(),
+      };
+
+      await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+      });
+
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+      // Legacy calls without options — defaults to publishRemovalDeltas: true
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledWith();
     });
   });
 });

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1097,4 +1097,101 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(evictedIntent?.error).toContain('queue fence');
     gate.resolve();
   });
+
+  // ── Bulk delete-all-workflows coordinator regression ────────────────
+
+  it('invalidates an older running workflow intent when internal bulk delete-all-workflows is enqueued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const deleteAllBulk = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:delete-all-workflows-bulk',
+      [],
+    );
+    await deleteAllBulk;
+    await expect(olderRunning).rejects.toThrow(/superseded by delete intent/i);
+
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intents.find((intent) => intent.id === 1)?.status).toBe('failed');
+    expect(intents.find((intent) => intent.id === 1)?.error).toContain('Superseded by delete intent #2');
+    expect(intents.find((intent) => intent.id === 2)?.status).toBe('completed');
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:delete-all-workflows-bulk:undefined',
+    ]);
+  });
+
+  it('evicts older queued workflow intents when internal bulk delete-all-workflows fence starts', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/blocker-task', null]);
+    void running.catch(() => {});
+    const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['old-queued']);
+    void olderQueued.catch(() => {});
+    const deleteAllBulk = coordinator.enqueue<void>('wf-1', 'high', 'invoker:delete-all-workflows-bulk', []);
+    const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['new-queued']);
+
+    await deleteAllBulk;
+    await newerQueued;
+    await expect(running).rejects.toThrow(/superseded by delete intent/i);
+    await expect(olderQueued).rejects.toThrow(/evicted/i);
+
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:delete-all-workflows-bulk:undefined',
+      'invoker:edit-task-agent:new-queued',
+    ]);
+  });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -119,6 +119,7 @@ import {
 import {
   approveTask as sharedApproveTask,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
+  deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
   fixWithAgentAction,
   rebaseAndRetry,
   recreateWithRebase,
@@ -1868,6 +1869,8 @@ if (isHeadless) {
       }
       case 'invoker:delete-all-workflows':
         return { channel: 'headless.exec', request: { args: ['delete-all'] } };
+      case 'invoker:delete-all-workflows-bulk':
+        return { channel: 'headless.exec', request: { args: ['delete-all'] } };
       case 'invoker:delete-workflow':
         return { channel: 'headless.exec', request: { args: ['delete', String(arg0)] } };
       case 'invoker:detach-workflow':
@@ -2785,6 +2788,18 @@ if (isHeadless) {
       logger.info('delete-all-workflows', { module: 'ipc' });
       assertDeleteAllEnabled();
       await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
+      taskHandles.clear();
+      lastKnownTaskStates.clear();
+      lastKnownWorkflowCount = 0;
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('invoker:workflows-changed', []);
+      }
+    });
+
+    registerGuiMutationHandler('invoker:delete-all-workflows-bulk', async () => {
+      logger.info('delete-all-workflows-bulk', { module: 'ipc' });
+      assertDeleteAllEnabled();
+      await sharedDeleteAllWorkflowsBulk({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
       lastKnownTaskStates.clear();
       lastKnownWorkflowCount = 0;

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -329,7 +329,7 @@ export class PersistedWorkflowMutationCoordinator {
     ) {
       return 'recreate';
     }
-    if (channel === 'invoker:delete-workflow' || channel === 'invoker:delete-all-workflows') {
+    if (channel === 'invoker:delete-workflow' || channel === 'invoker:delete-all-workflows' || channel === 'invoker:delete-all-workflows-bulk') {
       return 'delete';
     }
     if (channel !== 'headless.exec') {
@@ -354,6 +354,7 @@ export class PersistedWorkflowMutationCoordinator {
       || intent.channel === 'invoker:recreate-with-rebase'
       || intent.channel === 'invoker:delete-workflow'
       || intent.channel === 'invoker:delete-all-workflows'
+      || intent.channel === 'invoker:delete-all-workflows-bulk'
     ) {
       return true;
     }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -213,6 +213,42 @@ export async function deleteAllWorkflows(
 }
 
 /**
+ * Bulk delete-all variant that suppresses per-task removal deltas.
+ *
+ * Identical lifecycle to {@link deleteAllWorkflows} (snapshot → kill →
+ * orchestrator purge) but passes `publishRemovalDeltas: false` so the
+ * orchestrator skips individual `removed` TaskDelta messages.  The
+ * caller is expected to notify the UI through a separate channel
+ * (e.g. `invoker:workflows-changed`).
+ */
+export async function deleteAllWorkflowsBulk(
+  deps: Pick<ActionDeps, 'logger' | 'orchestrator' | 'taskExecutor'>,
+): Promise<{ snapshotPath: string | null }> {
+  const snapshotPath = createDeleteAllSnapshot();
+  deps.logger?.info(
+    snapshotPath
+      ? `delete-all-workflows-bulk snapshot: ${snapshotPath}`
+      : 'delete-all-workflows-bulk snapshot skipped: DB file does not exist yet',
+    { module: 'workflow' },
+  );
+
+  const taskExecutor = deps.taskExecutor;
+  if (taskExecutor) {
+    const allTasks = deps.orchestrator.getAllTasks();
+    const active = allTasks.filter(
+      (t) => t.status === 'running' || t.status === 'fixing_with_ai',
+    );
+    for (const task of active) {
+      deps.logger?.info(`delete-all-bulk: killing active task "${task.id}"`, { module: 'kill' });
+      await taskExecutor.killActiveExecution(task.id);
+    }
+  }
+
+  deps.orchestrator.deleteAllWorkflows({ publishRemovalDeltas: false });
+  return { snapshotPath };
+}
+
+/**
  * Recreate a workflow from a refreshed upstream base — the chart's
  * `recreateWorkflowFromFreshBase` action
  * (`docs/architecture/task-invalidation-chart.md` rows

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -199,6 +199,10 @@ export const IpcChannels = {
     request: [];
     response: void;
   },
+  'invoker:delete-all-workflows-bulk': {} as {
+    request: [];
+    response: void;
+  },
   'invoker:delete-workflow': {} as {
     request: [workflowId: string];
     response: void;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -419,7 +419,7 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await invoker.deleteAllWorkflows();
+      await invoker.deleteAllWorkflowsBulk();
       clearTasks();
       setHasLoadedPlan(false);
       setHasStarted(false);

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -77,6 +77,27 @@ describe('App launch (component)', () => {
     expect(screen.getByText('Select a task from the graph to view details')).toBeInTheDocument();
   });
 
+  it('Delete Workflow History (DB) button calls deleteAllWorkflowsBulk (not legacy deleteAllWorkflows)', async () => {
+    // Stub window.confirm to auto-accept
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<App />);
+
+    // Open utility dropdown
+    const utilityButton = screen.getByLabelText('Utility menu');
+    fireEvent.click(utilityButton);
+
+    // Click Delete Workflow History (DB)
+    const deleteButton = screen.getByText('Delete Workflow History (DB)');
+    fireEvent.click(deleteButton);
+
+    // Bulk variant must be called, legacy must NOT be called
+    expect(mock.api.deleteAllWorkflowsBulk).toHaveBeenCalledTimes(1);
+    expect(mock.api.deleteAllWorkflows).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
   it('opens System Setup automatically when packaged bundled skills need installation', async () => {
     mock.api.getSystemDiagnostics = vi.fn(async () => ({
       platform: 'linux',

--- a/packages/ui/src/__tests__/delete-history-repro.test.ts
+++ b/packages/ui/src/__tests__/delete-history-repro.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression reference: Delete Workflow History (DB) uses bulk delete-all.
+ *
+ * The "Delete Workflow History (DB)" button in the UI must call
+ * `deleteAllWorkflowsBulk` (not `deleteAllWorkflows`) so per-task removal
+ * deltas are suppressed and the UI is notified through the workflows-changed
+ * channel instead. This test verifies the contract at the mock API boundary.
+ *
+ * Related coordinator tests:
+ *   packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+ *     - "invalidates an older running workflow intent when internal bulk delete-all-workflows is enqueued"
+ *     - "evicts older queued workflow intents when internal bulk delete-all-workflows fence starts"
+ *
+ * Related lifecycle tests:
+ *   packages/app/src/__tests__/delete-all-lifecycle.test.ts
+ *     - "bulk delete-all lifecycle invariants" describe block
+ *
+ * Related orchestrator tests:
+ *   packages/workflow-core/src/__tests__/orchestrator.test.ts
+ *     - "deleteAllWorkflows bulk (publishRemovalDeltas: false)" describe block
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+describe('delete-history-repro regression reference', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('mock API exposes both deleteAllWorkflows and deleteAllWorkflowsBulk', () => {
+    expect(typeof mock.api.deleteAllWorkflows).toBe('function');
+    expect(typeof mock.api.deleteAllWorkflowsBulk).toBe('function');
+  });
+
+  it('deleteAllWorkflowsBulk is a distinct function from deleteAllWorkflows', () => {
+    expect(mock.api.deleteAllWorkflowsBulk).not.toBe(mock.api.deleteAllWorkflows);
+  });
+
+  it('deleteAllWorkflowsBulk resolves without error', async () => {
+    await expect(mock.api.deleteAllWorkflowsBulk()).resolves.not.toThrow();
+  });
+});

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -128,6 +128,7 @@ export function createMockInvoker(
     listWorkflows: vi.fn(async () => []),
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),
     deleteAllWorkflows: vi.fn(async () => {}),
+    deleteAllWorkflowsBulk: vi.fn(async () => {}),
     deleteWorkflow: vi.fn(async () => {}),
     cleanupWorktrees: vi.fn(async () => ({ removed: [], errors: [] })),
     recreateWorkflow: vi.fn(async () => {}),

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -8718,6 +8718,73 @@ describe('Orchestrator', () => {
     });
   });
 
+  describe('deleteAllWorkflows bulk (publishRemovalDeltas: false)', () => {
+    it('removes all tasks from memory without publishing removal deltas', () => {
+      orchestrator.loadPlan({
+        name: 'wf-bulk-1',
+        tasks: [{ id: 'b1', description: 'Task B1' }],
+      });
+      orchestrator.loadPlan({
+        name: 'wf-bulk-2',
+        tasks: [{ id: 'b2', description: 'Task B2' }],
+      });
+      expect(orchestrator.getAllTasks().length).toBeGreaterThan(0);
+      publishedDeltas = [];
+
+      orchestrator.deleteAllWorkflows({ publishRemovalDeltas: false });
+
+      expect(orchestrator.getAllTasks()).toHaveLength(0);
+      expect(orchestrator.getWorkflowIds()).toHaveLength(0);
+      const removedDeltas = publishedDeltas.filter((d) => d.type === 'removed');
+      expect(removedDeltas).toHaveLength(0);
+    });
+
+    it('clears persistence identically to legacy deleteAll', () => {
+      orchestrator.loadPlan({
+        name: 'wf-bulk-persist',
+        tasks: [{ id: 'bp1', description: 'Task' }],
+      });
+      expect(persistence.workflows.size).toBeGreaterThan(0);
+
+      orchestrator.deleteAllWorkflows({ publishRemovalDeltas: false });
+
+      expect(persistence.workflows.size).toBe(0);
+      expect(persistence.tasks.size).toBe(0);
+    });
+
+    it('orchestrator remains usable after bulk deleteAll', () => {
+      orchestrator.loadPlan({
+        name: 'wf-bulk-before',
+        tasks: [{ id: 'bold1', description: 'Old task' }],
+      });
+      orchestrator.deleteAllWorkflows({ publishRemovalDeltas: false });
+
+      orchestrator.loadPlan({
+        name: 'wf-bulk-after',
+        tasks: [{ id: 'bnew1', description: 'New task' }],
+      });
+      expect(orchestrator.getTask('bnew1')).toBeDefined();
+      expect(orchestrator.getWorkflowIds()).toHaveLength(1);
+    });
+
+    it('legacy deleteAll still publishes removal deltas (parity check)', () => {
+      orchestrator.loadPlan({
+        name: 'wf-legacy-parity',
+        tasks: [
+          { id: 'lp1', description: 'Task 1' },
+          { id: 'lp2', description: 'Task 2' },
+        ],
+      });
+      publishedDeltas = [];
+
+      orchestrator.deleteAllWorkflows();
+
+      const removedDeltas = publishedDeltas.filter((d) => d.type === 'removed');
+      // 2 tasks + 1 merge node = 3 removed deltas
+      expect(removedDeltas).toHaveLength(3);
+    });
+  });
+
   describe('blocked task unblocking', () => {
     it('throws when a persisted merge node has detached dependencies', () => {
       orchestrator.loadPlan({

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -214,6 +214,17 @@ export interface OrchestratorMessageBus {
 
 // ── Public Types ────────────────────────────────────────────
 
+/** Options for {@link Orchestrator.deleteAllWorkflows}. */
+export interface DeleteAllWorkflowsOptions {
+  /**
+   * When `true` (the default), a `removed` TaskDelta is published for every
+   * task before the method returns.  Set to `false` to skip per-task delta
+   * publication — useful for bulk callers that notify the UI through a
+   * separate channel.
+   */
+  publishRemovalDeltas?: boolean;
+}
+
 export interface PlanDefinition {
   name: string;
   description?: string;
@@ -3489,9 +3500,11 @@ export class Orchestrator {
    * Delete all workflows: DB first, then scheduler, memory, and publish removal deltas.
    * Follows the same DB→memory→publish pattern as writeAndSync().
    */
-  deleteAllWorkflows(): void {
+  deleteAllWorkflows(options?: DeleteAllWorkflowsOptions): void {
+    const { publishRemovalDeltas = true } = options ?? {};
+
     // 1. Collect all tasks before clearing (needed for deltas)
-    const allTasks = this.stateMachine.getAllTasks();
+    const allTasks = publishRemovalDeltas ? this.stateMachine.getAllTasks() : [];
 
     // 2. DB first
     this.persistence.deleteAllWorkflows?.();
@@ -3503,7 +3516,7 @@ export class Orchestrator {
     this.activeWorkflowIds.clear();
     this.stateMachine.clear();
 
-    // 5. Publish removal deltas
+    // 5. Publish removal deltas (skipped when publishRemovalDeltas is false)
     for (const task of allTasks) {
       this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildRemoveDelta(task));
     }

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -24,9 +24,15 @@ if [ "$EXTENDED" = "1" ] && [ "$DANGEROUS" = "1" ]; then
   MODE_KEY="dangerous"
 fi
 
-STATE_FILE="${INVOKER_TEST_ALL_STATE_FILE:-$ROOT/.git/invoker-test-all-state.tsv}"
+GIT_DIR="$(cd "$ROOT" && git rev-parse --git-dir)"
+# Resolve to absolute path if relative
+case "$GIT_DIR" in
+  /*) ;;
+  *)  GIT_DIR="$ROOT/$GIT_DIR" ;;
+esac
+STATE_FILE="${INVOKER_TEST_ALL_STATE_FILE:-$GIT_DIR/invoker-test-all-state.tsv}"
 RUN_ID="$(date +%Y%m%d-%H%M%S)-$$"
-LOG_ROOT="${ROOT}/.git/invoker-test-all-logs/${RUN_ID}"
+LOG_ROOT="${GIT_DIR}/invoker-test-all-logs/${RUN_ID}"
 mkdir -p "$(dirname "$STATE_FILE")" "$LOG_ROOT"
 touch "$STATE_FILE"
 


### PR DESCRIPTION
## Summary
Goal:
Produce reviewer-facing visual evidence for UI delete-history behavior before and after.

Motivation:
Demonstrate that bulk-path activation preserves UX while reducing perceived stall risk.

Implementation details:
- capture before/after visuals via deterministic proof script.
- run targeted UI smoke lanes that touch key interaction surfaces.

Alternative considerations:
- rely only on automated tests without visuals.
- capture visuals without accompanying smoke checks.

Competing-design proof:
- compare reviewer confidence and debuggability for visual+smoke versus single-lane approaches.

Why this design is better:
Visual artifacts plus tests create stronger release and review evidence.

Intermediate publication path:
- Use EdbertChan/Invoker as the intermediate publication repository for stack visibility, then promote upstream in Neko-Catpital-Labs/Invoker.


---
Bulk Delete-All Step 7: visual proof capture — 3 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1778193701835-8/capture-visual-proof-before-after | Layer: e2e_regression
Feature state: active
Goal:
Capture deterministic before/after proof artifacts for delete-history UX.
Motivation:
Provide audit-friendly evidence that complements behavioral tests.
Implementation details:
- run proof script for `before` and `after` labels.
Alternative considerations:
- screenshot-only without script orchestration.
- script-only without preserving artifact references.
Competing-design proof:
- verify script path yields reproducible artifacts and review traceability.
Why this design is better:
- deterministic artifact generation and repeatability.
Files:
- scripts/ui-visual-proof.sh
- artifacts/visual-proof/**
Change types:
- capture before/after screenshots or recordings for delete-history flow
- store artifacts and references in workflow notes
Acceptance criteria:
- before and after captures are both generated.
- captures clearly show delete-history trigger and post-delete settled UI state.
 | completed (passed) |
| wf-1778193701835-8/verify-ui-smoke-tests | Layer: e2e_regression
Feature state: active
Goal:
Define the outcome for `verify-ui-smoke-tests`.
Motivation:
Preserve explicit rationale for reviewers and deterministic lint checks.
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Execute UI smoke tests for high-risk touchpoints.
 | completed (passed) |
| wf-1778193701835-8/post-fix-regression | Layer: e2e_regression
Feature state: active
Goal:
Define the outcome for `post-fix-regression`.
Motivation:
Preserve explicit rationale for reviewers and deterministic lint checks.
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Final regression gate required for merge-ready implementation workflows.
 | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1778193701835-8/capture-visual-proof-before-after — Layer: e2e_regression
Feature state: active
Goal:
Capture deterministic before/after proof artifacts for delete-history UX.
Motivation:
Provide audit-friendly evidence that complements behavioral tests.
Implementation details:
- run proof script for `before` and `after` labels.
Alternative considerations:
- screenshot-only without script orchestration.
- script-only without preserving artifact references.
Competing-design proof:
- verify script path yields reproducible artifacts and review traceability.
Why this design is better:
- deterministic artifact generation and repeatability.
Files:
- scripts/ui-visual-proof.sh
- artifacts/visual-proof/**
Change types:
- capture before/after screenshots or recordings for delete-history flow
- store artifacts and references in workflow notes
Acceptance criteria:
- before and after captures are both generated.
- captures clearly show delete-history trigger and post-delete settled UI state.


### wf-1778193701835-8/verify-ui-smoke-tests — Layer: e2e_regression
Feature state: active
Goal:
Define the outcome for `verify-ui-smoke-tests`.
Motivation:
Preserve explicit rationale for reviewers and deterministic lint checks.
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Execute UI smoke tests for high-risk touchpoints.


### wf-1778193701835-8/post-fix-regression — Layer: e2e_regression
Feature state: active
Goal:
Define the outcome for `post-fix-regression`.
Motivation:
Preserve explicit rationale for reviewers and deterministic lint checks.
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Final regression gate required for merge-ready implementation workflows.


</details>
