### PR TITLE
Bulk Delete-All Step 8: final integration verification

### DIFF
--- a/docs/bulk-delete-all-design.md
+++ b/docs/bulk-delete-all-design.md
@@ -1,0 +1,91 @@
+# Bulk Delete-All: Design Rationale and Release Notes
+
+## Problem
+
+The "Delete Workflow History" UI action triggers `deleteAllWorkflows()`, which publishes a `removed` TaskDelta for every task before returning. Each delta fires a React state update in the renderer. With N tasks, the UI processes N sequential map-copy operations on its task collection, producing O(N^2) total work. At scale (hundreds of tasks), this causes observable UI freezes.
+
+## Root Cause
+
+`Orchestrator.deleteAllWorkflows()` collects all tasks, purges the DB, clears the scheduler and in-memory state, then iterates every collected task to publish individual `removed` deltas via the message bus. The renderer subscribes to these deltas and performs a state update (immutable map copy) per delta. The quadratic cost comes from N deltas x O(N) state size per update.
+
+```
+orchestrator.deleteAllWorkflows()
+  → collects allTasks (N tasks)
+  → purges DB, scheduler, memory
+  → for each task: publish removed delta   ← N messages
+      → renderer receives delta
+      → renderer copies task map (size N)  ← O(N) per message
+  → total: O(N²) UI work
+```
+
+## Solution: Bulk Delete-All with Suppressed Deltas
+
+A new `invoker:delete-all-workflows-bulk` IPC channel routes through a dedicated code path that passes `{ publishRemovalDeltas: false }` to the orchestrator. The orchestrator skips per-task delta publication. The main process sends a single `invoker:workflows-changed` event instead, and the UI calls `clearTasks()` to reset state in O(1).
+
+### Architecture (layered bottom-up)
+
+| Layer | Package | Change |
+|-------|---------|--------|
+| Contract | `packages/contracts` | New `invoker:delete-all-workflows-bulk` channel (`request: [], response: void`) |
+| Domain | `packages/workflow-core` | `deleteAllWorkflows(options?)` accepts `{ publishRemovalDeltas?: boolean }`. Default `true` preserves legacy behavior. When `false`, skips `getAllTasks()` collection and delta loop entirely. |
+| App bridge | `packages/app` | New `deleteAllWorkflowsBulk()` action in `workflow-actions.ts`. Same lifecycle as legacy (snapshot → kill active → orchestrator purge) but passes suppression flag. |
+| IPC handler | `packages/app/main.ts` | Registered `invoker:delete-all-workflows-bulk` handler. After purge, sends `invoker:workflows-changed` with empty array. |
+| Coordinator | `packages/app` | `PersistedWorkflowMutationCoordinator` classifies bulk channel as `delete` fence, matching legacy preemption/eviction semantics. |
+| UI | `packages/ui` | `App.tsx` calls `invoker.deleteAllWorkflowsBulk()` instead of `invoker.deleteAllWorkflows()`. |
+
+### Why this design
+
+1. **No legacy breakage.** The original `deleteAllWorkflows()` path is untouched. Headless and programmatic callers keep existing behavior.
+2. **Minimal surface.** One new IPC channel, one new app action, one orchestrator option. No new state, no new persistence schema.
+3. **Explicit opt-in.** Bulk semantics require calling the bulk endpoint. No ambient behavior changes.
+4. **Fence parity.** The coordinator treats bulk delete identically to legacy delete for queue invalidation and preemption. No race conditions introduced.
+
+### Alternatives considered
+
+- **Renderer-side batching:** Batch deltas in the UI and apply once. Rejected because the main process still does O(N) IPC sends, and batching adds UI complexity without fixing the source.
+- **Mutate existing channel with a bulk flag:** Rejected because it creates implicit branching in existing handlers and makes behavior harder to audit.
+- **Post-publication suppression in app layer:** Rejected because it doesn't remove the core overhead — the orchestrator still collects all tasks and iterates.
+
+## Files Changed (14 files, +474 / -9 lines)
+
+### Production code
+- `packages/contracts/src/ipc-channels.ts` — new `invoker:delete-all-workflows-bulk` channel
+- `packages/workflow-core/src/orchestrator.ts` — `DeleteAllWorkflowsOptions` type, conditional delta suppression
+- `packages/app/src/workflow-actions.ts` — `deleteAllWorkflowsBulk()` action
+- `packages/app/src/main.ts` — IPC handler registration + headless routing
+- `packages/app/src/persisted-workflow-mutation-coordinator.ts` — delete-fence classification
+- `packages/ui/src/App.tsx` — callsite switch to bulk method
+
+### Tests
+- `packages/workflow-core/src/__tests__/orchestrator.test.ts` — legacy vs bulk delta assertions
+- `packages/app/src/__tests__/delete-all-lifecycle.test.ts` — app bridge lifecycle coverage
+- `packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts` — fence classification
+- `packages/ui/src/__tests__/delete-history-repro.test.ts` — UI delete reproduction
+- `packages/ui/src/__tests__/app-launch.test.tsx` — mock type coverage
+- `packages/ui/src/__tests__/helpers/mock-invoker.ts` — mock surface update
+
+### Scripts
+- `scripts/run-all-tests.sh` — test runner adjustments
+- `submit-plan.sh` — plan submission adjustments
+
+## Operational Guidance
+
+### For reviewers
+
+1. Verify the legacy `invoker:delete-all-workflows` path is untouched by checking that `deleteAllWorkflows()` (no options) still publishes deltas.
+2. Confirm the coordinator fence classification includes the bulk channel in both the `classifyMutationType` and `isPreemptive` predicates.
+3. Check that the headless routing maps `invoker:delete-all-workflows-bulk` to `delete-all` args, matching legacy headless behavior.
+
+### For maintainers
+
+- If adding new delete-like channels, update the coordinator's `classifyMutationType` and `isPreemptive` checks.
+- The `publishRemovalDeltas` option is domain-level. New callers that want silent bulk delete should use `{ publishRemovalDeltas: false }` and handle UI notification separately.
+- The legacy path remains the default. Removing the bulk path only requires deleting the bulk channel, action, handler, and reverting the UI callsite.
+
+### Revert plan
+
+Revert the UI callsite in `App.tsx` back to `invoker.deleteAllWorkflows()`. The remaining bulk infrastructure is additive and inert without callers. Full cleanup can follow separately.
+
+## PR Publication
+
+Invoker PR publication should use **Mergify Stacks** (`mergify stack push`) once workflow commits are ready. This preserves the stacked branch structure and enables incremental review of each workflow layer.

--- a/packages/app/src/__tests__/delete-all-lifecycle.test.ts
+++ b/packages/app/src/__tests__/delete-all-lifecycle.test.ts
@@ -12,7 +12,7 @@
 import { describe, it, expect, vi } from 'vitest';
 import type { Orchestrator } from '@invoker/workflow-core';
 import type { TaskRunner } from '@invoker/execution-engine';
-import { deleteAllWorkflows } from '../workflow-actions.js';
+import { deleteAllWorkflows, deleteAllWorkflowsBulk } from '../workflow-actions.js';
 
 vi.mock('../delete-all-snapshot.js', () => ({
   createDeleteAllSnapshot: () => '/tmp/fake-snapshot',
@@ -319,6 +319,144 @@ describe('delete-all lifecycle invariants', () => {
 
       expect(result.snapshotPath).toBe('/tmp/fake-snapshot');
       expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    });
+  });
+});
+
+describe('bulk delete-all lifecycle invariants', () => {
+  describe('process cleanup ordering', () => {
+    it('kills every running and fixing_with_ai task before calling orchestrator.deleteAllWorkflows', async () => {
+      const callOrder: string[] = [];
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [
+          makeTask({ id: 'wf-1/r1', status: 'running' }),
+          makeTask({ id: 'wf-1/f1', status: 'fixing_with_ai' }),
+          makeTask({ id: 'wf-1/r2', status: 'running' }),
+          makeTask({ id: 'wf-2/p1', status: 'pending' }),
+        ]),
+        deleteAllWorkflows: vi.fn(() => callOrder.push('deleteAll')),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn(async (id: string) => {
+          callOrder.push(`kill:${id}`);
+        }),
+      };
+
+      await deleteAllWorkflowsBulk({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+      });
+
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledTimes(3);
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('wf-1/r1');
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('wf-1/f1');
+      expect(taskExecutor.killActiveExecution).toHaveBeenCalledWith('wf-1/r2');
+
+      const deleteAllIdx = callOrder.indexOf('deleteAll');
+      const killIndices = callOrder
+        .map((entry, i) => (entry.startsWith('kill:') ? i : -1))
+        .filter((i) => i >= 0);
+      for (const killIdx of killIndices) {
+        expect(killIdx).toBeLessThan(deleteAllIdx);
+      }
+    });
+  });
+
+  describe('publishRemovalDeltas suppression', () => {
+    it('passes publishRemovalDeltas: false to orchestrator.deleteAllWorkflows', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => []),
+        deleteAllWorkflows: vi.fn(),
+      };
+
+      await deleteAllWorkflowsBulk({
+        orchestrator: orchestrator as unknown as Orchestrator,
+      });
+
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledWith({ publishRemovalDeltas: false });
+    });
+  });
+
+  describe('headless path (no taskExecutor)', () => {
+    it('skips process cleanup entirely when taskExecutor is absent', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [makeTask({ id: 'r1', status: 'running' })]),
+        deleteAllWorkflows: vi.fn(),
+      };
+
+      await deleteAllWorkflowsBulk({
+        orchestrator: orchestrator as unknown as Orchestrator,
+      });
+
+      expect(orchestrator.getAllTasks).not.toHaveBeenCalled();
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('snapshot lifecycle', () => {
+    it('returns snapshot path for bulk variant', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => []),
+        deleteAllWorkflows: vi.fn(),
+      };
+
+      const result = await deleteAllWorkflowsBulk({
+        orchestrator: orchestrator as unknown as Orchestrator,
+      });
+
+      expect(result.snapshotPath).toBe('/tmp/fake-snapshot');
+    });
+  });
+
+  describe('logger integration', () => {
+    it('logs bulk-specific messages when logger is provided', async () => {
+      const logger = {
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+      };
+      const orchestrator = {
+        getAllTasks: vi.fn(() => [
+          makeTask({ id: 'wf-1/t1', status: 'running' }),
+        ]),
+        deleteAllWorkflows: vi.fn(),
+      };
+      const taskExecutor = {
+        killActiveExecution: vi.fn().mockResolvedValue(undefined),
+      };
+
+      await deleteAllWorkflowsBulk({
+        orchestrator: orchestrator as unknown as Orchestrator,
+        taskExecutor: taskExecutor as unknown as TaskRunner,
+        logger: logger as any,
+      });
+
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('bulk'),
+        expect.objectContaining({ module: 'workflow' }),
+      );
+      expect(logger.info).toHaveBeenCalledWith(
+        expect.stringContaining('wf-1/t1'),
+        expect.objectContaining({ module: 'kill' }),
+      );
+    });
+  });
+
+  describe('parity with legacy delete-all', () => {
+    it('legacy variant does NOT pass publishRemovalDeltas: false', async () => {
+      const orchestrator = {
+        getAllTasks: vi.fn(() => []),
+        deleteAllWorkflows: vi.fn(),
+      };
+
+      await deleteAllWorkflows({
+        orchestrator: orchestrator as unknown as Orchestrator,
+      });
+
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledTimes(1);
+      // Legacy calls without options — defaults to publishRemovalDeltas: true
+      expect(orchestrator.deleteAllWorkflows).toHaveBeenCalledWith();
     });
   });
 });

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1097,4 +1097,101 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(evictedIntent?.error).toContain('queue fence');
     gate.resolve();
   });
+
+  // ── Bulk delete-all-workflows coordinator regression ────────────────
+
+  it('invalidates an older running workflow intent when internal bulk delete-all-workflows is enqueued', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
+
+    const deleteAllBulk = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:delete-all-workflows-bulk',
+      [],
+    );
+    await deleteAllBulk;
+    await expect(olderRunning).rejects.toThrow(/superseded by delete intent/i);
+
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intents.find((intent) => intent.id === 1)?.status).toBe('failed');
+    expect(intents.find((intent) => intent.id === 1)?.error).toContain('Superseded by delete intent #2');
+    expect(intents.find((intent) => intent.id === 2)?.status).toBe('completed');
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:delete-all-workflows-bulk:undefined',
+    ]);
+  });
+
+  it('evicts older queued workflow intents when internal bulk delete-all-workflows fence starts', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        order.push(`${channel}:${String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/blocker-task', null]);
+    void running.catch(() => {});
+    const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['old-queued']);
+    void olderQueued.catch(() => {});
+    const deleteAllBulk = coordinator.enqueue<void>('wf-1', 'high', 'invoker:delete-all-workflows-bulk', []);
+    const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['new-queued']);
+
+    await deleteAllBulk;
+    await newerQueued;
+    await expect(running).rejects.toThrow(/superseded by delete intent/i);
+    await expect(olderQueued).rejects.toThrow(/evicted/i);
+
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'invoker:delete-all-workflows-bulk:undefined',
+      'invoker:edit-task-agent:new-queued',
+    ]);
+  });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -119,6 +119,7 @@ import {
 import {
   approveTask as sharedApproveTask,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
+  deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
   fixWithAgentAction,
   rebaseAndRetry,
   recreateWithRebase,
@@ -1868,6 +1869,8 @@ if (isHeadless) {
       }
       case 'invoker:delete-all-workflows':
         return { channel: 'headless.exec', request: { args: ['delete-all'] } };
+      case 'invoker:delete-all-workflows-bulk':
+        return { channel: 'headless.exec', request: { args: ['delete-all'] } };
       case 'invoker:delete-workflow':
         return { channel: 'headless.exec', request: { args: ['delete', String(arg0)] } };
       case 'invoker:detach-workflow':
@@ -2785,6 +2788,18 @@ if (isHeadless) {
       logger.info('delete-all-workflows', { module: 'ipc' });
       assertDeleteAllEnabled();
       await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
+      taskHandles.clear();
+      lastKnownTaskStates.clear();
+      lastKnownWorkflowCount = 0;
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send('invoker:workflows-changed', []);
+      }
+    });
+
+    registerGuiMutationHandler('invoker:delete-all-workflows-bulk', async () => {
+      logger.info('delete-all-workflows-bulk', { module: 'ipc' });
+      assertDeleteAllEnabled();
+      await sharedDeleteAllWorkflowsBulk({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       taskHandles.clear();
       lastKnownTaskStates.clear();
       lastKnownWorkflowCount = 0;

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -329,7 +329,7 @@ export class PersistedWorkflowMutationCoordinator {
     ) {
       return 'recreate';
     }
-    if (channel === 'invoker:delete-workflow' || channel === 'invoker:delete-all-workflows') {
+    if (channel === 'invoker:delete-workflow' || channel === 'invoker:delete-all-workflows' || channel === 'invoker:delete-all-workflows-bulk') {
       return 'delete';
     }
     if (channel !== 'headless.exec') {
@@ -354,6 +354,7 @@ export class PersistedWorkflowMutationCoordinator {
       || intent.channel === 'invoker:recreate-with-rebase'
       || intent.channel === 'invoker:delete-workflow'
       || intent.channel === 'invoker:delete-all-workflows'
+      || intent.channel === 'invoker:delete-all-workflows-bulk'
     ) {
       return true;
     }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -213,6 +213,42 @@ export async function deleteAllWorkflows(
 }
 
 /**
+ * Bulk delete-all variant that suppresses per-task removal deltas.
+ *
+ * Identical lifecycle to {@link deleteAllWorkflows} (snapshot → kill →
+ * orchestrator purge) but passes `publishRemovalDeltas: false` so the
+ * orchestrator skips individual `removed` TaskDelta messages.  The
+ * caller is expected to notify the UI through a separate channel
+ * (e.g. `invoker:workflows-changed`).
+ */
+export async function deleteAllWorkflowsBulk(
+  deps: Pick<ActionDeps, 'logger' | 'orchestrator' | 'taskExecutor'>,
+): Promise<{ snapshotPath: string | null }> {
+  const snapshotPath = createDeleteAllSnapshot();
+  deps.logger?.info(
+    snapshotPath
+      ? `delete-all-workflows-bulk snapshot: ${snapshotPath}`
+      : 'delete-all-workflows-bulk snapshot skipped: DB file does not exist yet',
+    { module: 'workflow' },
+  );
+
+  const taskExecutor = deps.taskExecutor;
+  if (taskExecutor) {
+    const allTasks = deps.orchestrator.getAllTasks();
+    const active = allTasks.filter(
+      (t) => t.status === 'running' || t.status === 'fixing_with_ai',
+    );
+    for (const task of active) {
+      deps.logger?.info(`delete-all-bulk: killing active task "${task.id}"`, { module: 'kill' });
+      await taskExecutor.killActiveExecution(task.id);
+    }
+  }
+
+  deps.orchestrator.deleteAllWorkflows({ publishRemovalDeltas: false });
+  return { snapshotPath };
+}
+
+/**
  * Recreate a workflow from a refreshed upstream base — the chart's
  * `recreateWorkflowFromFreshBase` action
  * (`docs/architecture/task-invalidation-chart.md` rows

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -199,6 +199,10 @@ export const IpcChannels = {
     request: [];
     response: void;
   },
+  'invoker:delete-all-workflows-bulk': {} as {
+    request: [];
+    response: void;
+  },
   'invoker:delete-workflow': {} as {
     request: [workflowId: string];
     response: void;

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -419,7 +419,7 @@ export function App() {
     );
     if (!confirmed) return;
     try {
-      await invoker.deleteAllWorkflows();
+      await invoker.deleteAllWorkflowsBulk();
       clearTasks();
       setHasLoadedPlan(false);
       setHasStarted(false);

--- a/packages/ui/src/__tests__/app-launch.test.tsx
+++ b/packages/ui/src/__tests__/app-launch.test.tsx
@@ -77,6 +77,27 @@ describe('App launch (component)', () => {
     expect(screen.getByText('Select a task from the graph to view details')).toBeInTheDocument();
   });
 
+  it('Delete Workflow History (DB) button calls deleteAllWorkflowsBulk (not legacy deleteAllWorkflows)', async () => {
+    // Stub window.confirm to auto-accept
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<App />);
+
+    // Open utility dropdown
+    const utilityButton = screen.getByLabelText('Utility menu');
+    fireEvent.click(utilityButton);
+
+    // Click Delete Workflow History (DB)
+    const deleteButton = screen.getByText('Delete Workflow History (DB)');
+    fireEvent.click(deleteButton);
+
+    // Bulk variant must be called, legacy must NOT be called
+    expect(mock.api.deleteAllWorkflowsBulk).toHaveBeenCalledTimes(1);
+    expect(mock.api.deleteAllWorkflows).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
   it('opens System Setup automatically when packaged bundled skills need installation', async () => {
     mock.api.getSystemDiagnostics = vi.fn(async () => ({
       platform: 'linux',

--- a/packages/ui/src/__tests__/delete-history-repro.test.ts
+++ b/packages/ui/src/__tests__/delete-history-repro.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Regression reference: Delete Workflow History (DB) uses bulk delete-all.
+ *
+ * The "Delete Workflow History (DB)" button in the UI must call
+ * `deleteAllWorkflowsBulk` (not `deleteAllWorkflows`) so per-task removal
+ * deltas are suppressed and the UI is notified through the workflows-changed
+ * channel instead. This test verifies the contract at the mock API boundary.
+ *
+ * Related coordinator tests:
+ *   packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+ *     - "invalidates an older running workflow intent when internal bulk delete-all-workflows is enqueued"
+ *     - "evicts older queued workflow intents when internal bulk delete-all-workflows fence starts"
+ *
+ * Related lifecycle tests:
+ *   packages/app/src/__tests__/delete-all-lifecycle.test.ts
+ *     - "bulk delete-all lifecycle invariants" describe block
+ *
+ * Related orchestrator tests:
+ *   packages/workflow-core/src/__tests__/orchestrator.test.ts
+ *     - "deleteAllWorkflows bulk (publishRemovalDeltas: false)" describe block
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+
+describe('delete-history-repro regression reference', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('mock API exposes both deleteAllWorkflows and deleteAllWorkflowsBulk', () => {
+    expect(typeof mock.api.deleteAllWorkflows).toBe('function');
+    expect(typeof mock.api.deleteAllWorkflowsBulk).toBe('function');
+  });
+
+  it('deleteAllWorkflowsBulk is a distinct function from deleteAllWorkflows', () => {
+    expect(mock.api.deleteAllWorkflowsBulk).not.toBe(mock.api.deleteAllWorkflows);
+  });
+
+  it('deleteAllWorkflowsBulk resolves without error', async () => {
+    await expect(mock.api.deleteAllWorkflowsBulk()).resolves.not.toThrow();
+  });
+});

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -128,6 +128,7 @@ export function createMockInvoker(
     listWorkflows: vi.fn(async () => []),
     loadWorkflow: vi.fn(async () => ({ workflow: {}, tasks: [] })),
     deleteAllWorkflows: vi.fn(async () => {}),
+    deleteAllWorkflowsBulk: vi.fn(async () => {}),
     deleteWorkflow: vi.fn(async () => {}),
     cleanupWorktrees: vi.fn(async () => ({ removed: [], errors: [] })),
     recreateWorkflow: vi.fn(async () => {}),

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -8718,6 +8718,73 @@ describe('Orchestrator', () => {
     });
   });
 
+  describe('deleteAllWorkflows bulk (publishRemovalDeltas: false)', () => {
+    it('removes all tasks from memory without publishing removal deltas', () => {
+      orchestrator.loadPlan({
+        name: 'wf-bulk-1',
+        tasks: [{ id: 'b1', description: 'Task B1' }],
+      });
+      orchestrator.loadPlan({
+        name: 'wf-bulk-2',
+        tasks: [{ id: 'b2', description: 'Task B2' }],
+      });
+      expect(orchestrator.getAllTasks().length).toBeGreaterThan(0);
+      publishedDeltas = [];
+
+      orchestrator.deleteAllWorkflows({ publishRemovalDeltas: false });
+
+      expect(orchestrator.getAllTasks()).toHaveLength(0);
+      expect(orchestrator.getWorkflowIds()).toHaveLength(0);
+      const removedDeltas = publishedDeltas.filter((d) => d.type === 'removed');
+      expect(removedDeltas).toHaveLength(0);
+    });
+
+    it('clears persistence identically to legacy deleteAll', () => {
+      orchestrator.loadPlan({
+        name: 'wf-bulk-persist',
+        tasks: [{ id: 'bp1', description: 'Task' }],
+      });
+      expect(persistence.workflows.size).toBeGreaterThan(0);
+
+      orchestrator.deleteAllWorkflows({ publishRemovalDeltas: false });
+
+      expect(persistence.workflows.size).toBe(0);
+      expect(persistence.tasks.size).toBe(0);
+    });
+
+    it('orchestrator remains usable after bulk deleteAll', () => {
+      orchestrator.loadPlan({
+        name: 'wf-bulk-before',
+        tasks: [{ id: 'bold1', description: 'Old task' }],
+      });
+      orchestrator.deleteAllWorkflows({ publishRemovalDeltas: false });
+
+      orchestrator.loadPlan({
+        name: 'wf-bulk-after',
+        tasks: [{ id: 'bnew1', description: 'New task' }],
+      });
+      expect(orchestrator.getTask('bnew1')).toBeDefined();
+      expect(orchestrator.getWorkflowIds()).toHaveLength(1);
+    });
+
+    it('legacy deleteAll still publishes removal deltas (parity check)', () => {
+      orchestrator.loadPlan({
+        name: 'wf-legacy-parity',
+        tasks: [
+          { id: 'lp1', description: 'Task 1' },
+          { id: 'lp2', description: 'Task 2' },
+        ],
+      });
+      publishedDeltas = [];
+
+      orchestrator.deleteAllWorkflows();
+
+      const removedDeltas = publishedDeltas.filter((d) => d.type === 'removed');
+      // 2 tasks + 1 merge node = 3 removed deltas
+      expect(removedDeltas).toHaveLength(3);
+    });
+  });
+
   describe('blocked task unblocking', () => {
     it('throws when a persisted merge node has detached dependencies', () => {
       orchestrator.loadPlan({

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -214,6 +214,17 @@ export interface OrchestratorMessageBus {
 
 // ── Public Types ────────────────────────────────────────────
 
+/** Options for {@link Orchestrator.deleteAllWorkflows}. */
+export interface DeleteAllWorkflowsOptions {
+  /**
+   * When `true` (the default), a `removed` TaskDelta is published for every
+   * task before the method returns.  Set to `false` to skip per-task delta
+   * publication — useful for bulk callers that notify the UI through a
+   * separate channel.
+   */
+  publishRemovalDeltas?: boolean;
+}
+
 export interface PlanDefinition {
   name: string;
   description?: string;
@@ -3489,9 +3500,11 @@ export class Orchestrator {
    * Delete all workflows: DB first, then scheduler, memory, and publish removal deltas.
    * Follows the same DB→memory→publish pattern as writeAndSync().
    */
-  deleteAllWorkflows(): void {
+  deleteAllWorkflows(options?: DeleteAllWorkflowsOptions): void {
+    const { publishRemovalDeltas = true } = options ?? {};
+
     // 1. Collect all tasks before clearing (needed for deltas)
-    const allTasks = this.stateMachine.getAllTasks();
+    const allTasks = publishRemovalDeltas ? this.stateMachine.getAllTasks() : [];
 
     // 2. DB first
     this.persistence.deleteAllWorkflows?.();
@@ -3503,7 +3516,7 @@ export class Orchestrator {
     this.activeWorkflowIds.clear();
     this.stateMachine.clear();
 
-    // 5. Publish removal deltas
+    // 5. Publish removal deltas (skipped when publishRemovalDeltas is false)
     for (const task of allTasks) {
       this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildRemoveDelta(task));
     }

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -24,9 +24,15 @@ if [ "$EXTENDED" = "1" ] && [ "$DANGEROUS" = "1" ]; then
   MODE_KEY="dangerous"
 fi
 
-STATE_FILE="${INVOKER_TEST_ALL_STATE_FILE:-$ROOT/.git/invoker-test-all-state.tsv}"
+GIT_DIR="$(cd "$ROOT" && git rev-parse --git-dir)"
+# Resolve to absolute path if relative
+case "$GIT_DIR" in
+  /*) ;;
+  *)  GIT_DIR="$ROOT/$GIT_DIR" ;;
+esac
+STATE_FILE="${INVOKER_TEST_ALL_STATE_FILE:-$GIT_DIR/invoker-test-all-state.tsv}"
 RUN_ID="$(date +%Y%m%d-%H%M%S)-$$"
-LOG_ROOT="${ROOT}/.git/invoker-test-all-logs/${RUN_ID}"
+LOG_ROOT="${GIT_DIR}/invoker-test-all-logs/${RUN_ID}"
 mkdir -p "$(dirname "$STATE_FILE")" "$LOG_ROOT"
 touch "$STATE_FILE"
 

--- a/submit-plan.sh
+++ b/submit-plan.sh
@@ -37,21 +37,5 @@ if [ "$(uname)" = "Linux" ]; then
   export LIBGL_ALWAYS_SOFTWARE=1
 fi
 
-# Auto-build if dist/main.js is missing
-if [ ! -f packages/app/dist/main.js ]; then
-  echo "==> packages/app/dist/main.js missing — building..." >&2
-  pnpm --filter @invoker/app run build >&2
-fi
-
-# Rewrite repoUrl to file:// local checkout so plans work without network access
-PLAN_EFFECTIVE="$PLAN_FILE"
-if grep -q 'repoUrl:' "$PLAN_FILE" 2>/dev/null; then
-  PLAN_TMP="$(mktemp "${TMPDIR:-/tmp}/submit-plan.XXXXXX")"
-  trap 'rm -f "$PLAN_TMP"' EXIT
-  sed "s|repoUrl:.*|repoUrl: file://$REPO_ROOT|" "$PLAN_FILE" > "$PLAN_TMP"
-  PLAN_EFFECTIVE="$PLAN_TMP"
-fi
-
 echo "==> Submitting plan: $PLAN_FILE"
-export INVOKER_HEADLESS_STANDALONE=1
-./packages/app/node_modules/.bin/electron packages/app/dist/main.js $SANDBOX_FLAG --headless run "$PLAN_EFFECTIVE"
+./packages/app/node_modules/.bin/electron packages/app/dist/main.js $SANDBOX_FLAG --headless run "$PLAN_FILE"

--- a/submit-plan.sh
+++ b/submit-plan.sh
@@ -37,5 +37,21 @@ if [ "$(uname)" = "Linux" ]; then
   export LIBGL_ALWAYS_SOFTWARE=1
 fi
 
+# Auto-build if dist/main.js is missing
+if [ ! -f packages/app/dist/main.js ]; then
+  echo "==> packages/app/dist/main.js missing — building..." >&2
+  pnpm --filter @invoker/app run build >&2
+fi
+
+# Rewrite repoUrl to file:// local checkout so plans work without network access
+PLAN_EFFECTIVE="$PLAN_FILE"
+if grep -q 'repoUrl:' "$PLAN_FILE" 2>/dev/null; then
+  PLAN_TMP="$(mktemp "${TMPDIR:-/tmp}/submit-plan.XXXXXX")"
+  trap 'rm -f "$PLAN_TMP"' EXIT
+  sed "s|repoUrl:.*|repoUrl: file://$REPO_ROOT|" "$PLAN_FILE" > "$PLAN_TMP"
+  PLAN_EFFECTIVE="$PLAN_TMP"
+fi
+
 echo "==> Submitting plan: $PLAN_FILE"
-./packages/app/node_modules/.bin/electron packages/app/dist/main.js $SANDBOX_FLAG --headless run "$PLAN_FILE"
+export INVOKER_HEADLESS_STANDALONE=1
+./packages/app/node_modules/.bin/electron packages/app/dist/main.js $SANDBOX_FLAG --headless run "$PLAN_EFFECTIVE"


### PR DESCRIPTION
## Summary
Goal:
Perform final integrated verification across headless and full-suite lanes.

Motivation:
Confirm chain-wide readiness before merge and final stack publication.

Implementation details:
- run a headless verification lane for command-path confidence.
- capture release notes documenting rationale and operator guidance.
- run repo-wide final gate.

Alternative considerations:
- run only targeted tests.
- run full suite only without explicit headless verification.

Competing-design proof:
- compare diagnosis speed and residual risk from single-lane approaches.

Why this design is better:
Layered verification provides both focused confidence and broad regression coverage.

Intermediate publication path:
- Use EdbertChan/Invoker as the intermediate publication repository for stack visibility, then promote upstream in Neko-Catpital-Labs/Invoker.


---
Bulk Delete-All Step 8: final integration verification — 3 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1778193704774-9/run-headless-verification-lane | Layer: e2e_regression
Feature state: active
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Goal:
Verify non-UI command-path behavior remains healthy in final stack state.
Motivation:
Validate headless route confidence independently of renderer behavior.
Files:
- plans/verify-executor-routing-headless.yaml
Change types:
- execute headless verification lane to ensure non-UI command paths remain stable
Acceptance criteria:
- headless verification plan submission succeeds.
- no regression in delete-all command routing assumptions.
 | completed (passed) |
| wf-1778193704774-9/gather-release-notes | Layer: docs
Feature state: active
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Goal:
Document operational context and rollout guidance.
Motivation:
Preserve rationale and reviewer/operator instructions for this stack.
Prepare rollout notes covering bulk command behavior and stack publication.
 | completed |
| wf-1778193704774-9/post-fix-regression | Layer: e2e_regression
Feature state: active
Goal:
Define the outcome for `post-fix-regression`.
Motivation:
Preserve explicit rationale for reviewers and deterministic lint checks.
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Layer exception: allowed
Rationale: final release-note packaging (`docs`) is intentionally completed
before the terminal full-suite gate in this final integration workflow.
Final regression gate required for merge-ready implementation workflows.
 | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1778193704774-9/run-headless-verification-lane — Layer: e2e_regression
Feature state: active
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Goal:
Verify non-UI command-path behavior remains healthy in final stack state.
Motivation:
Validate headless route confidence independently of renderer behavior.
Files:
- plans/verify-executor-routing-headless.yaml
Change types:
- execute headless verification lane to ensure non-UI command paths remain stable
Acceptance criteria:
- headless verification plan submission succeeds.
- no regression in delete-all command routing assumptions.


### wf-1778193704774-9/gather-release-notes — Layer: docs
Feature state: active
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Goal:
Document operational context and rollout guidance.
Motivation:
Preserve rationale and reviewer/operator instructions for this stack.
Prepare rollout notes covering bulk command behavior and stack publication.

docs/bulk-delete-all-design.md                     |  91 ++++++++++++++
 .../app/src/__tests__/delete-all-lifecycle.test.ts | 140 ++++++++++++++++++++-
 ...persisted-workflow-mutation-coordinator.test.ts |  97 ++++++++++++++
 packages/app/src/main.ts                           |  15 +++
 .../src/persisted-workflow-mutation-coordinator.ts |   3 +-
 packages/app/src/workflow-actions.ts               |  36 ++++++
 packages/contracts/src/ipc-channels.ts             |   4 +
 packages/ui/src/App.tsx                            |   2 +-
 packages/ui/src/__tests__/app-launch.test.tsx      |  21 ++++
 .../ui/src/__tests__/delete-history-repro.test.ts  |  50 ++++++++
 packages/ui/src/__tests__/helpers/mock-invoker.ts  |   1 +
 .../src/__tests__/orchestrator.test.ts             |  67 ++++++++++
 packages/workflow-core/src/orchestrator.ts         |  19 ++-
 scripts/run-all-tests.sh                           |  10 +-
 submit-plan.sh                                     |  18 ++-
 15 files changed, 565 insertions(+), 9 deletions(-)

### wf-1778193704774-9/post-fix-regression — Layer: e2e_regression
Feature state: active
Goal:
Define the outcome for `post-fix-regression`.
Motivation:
Preserve explicit rationale for reviewers and deterministic lint checks.
Alternative considerations:
- Leave this rationale implicit in higher-level workflow text.
- Keep only command/prompt text without rationale headings.
Implementation details:
- Execute this task exactly as specified and verify listed acceptance criteria.
Layer exception: allowed
Rationale: final release-note packaging (`docs`) is intentionally completed
before the terminal full-suite gate in this final integration workflow.
Final regression gate required for merge-ready implementation workflows.


</details>
