### PR TITLE
Pending review gate target repo UI

### DIFF
--- a/packages/app/e2e/pending-review-gate-target-repo.proof.spec.ts
+++ b/packages/app/e2e/pending-review-gate-target-repo.proof.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, captureScreenshot } from './fixtures/electron-app.js';
+import { stringify as yamlStringify } from 'yaml';
+
+const REVIEW_GATE_PROOF_PLAN = {
+  name: 'Pending review gate target repo proof',
+  repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker',
+  onFinish: 'pull_request' as const,
+  mergeMode: 'external_review' as const,
+  tasks: [
+    {
+      id: 'review-gate-proof-task',
+      description: 'Single task to generate merge gate',
+      command: 'echo proof',
+      dependencies: [] as string[],
+    },
+  ],
+};
+
+test('pending review gate target repo row', async ({ page }) => {
+  await page.evaluate((yaml) => window.invoker.loadPlan(yaml), yamlStringify(REVIEW_GATE_PROOF_PLAN));
+  await page.locator('.react-flow__node[data-testid$="review-gate-proof-task"]').first().waitFor({ state: 'visible', timeout: 15000 });
+
+  const mergeGateTaskId = await page.evaluate(async () => {
+    const result = await window.invoker.getTasks();
+    const tasks = Array.isArray(result) ? result : result.tasks;
+    const mergeTask = tasks.find((task: { id: string }) => task.id.includes('__merge__'));
+    return mergeTask?.id ?? null;
+  });
+  expect(mergeGateTaskId).toBeTruthy();
+
+  const mergeGateNode = page.locator(`.react-flow__node[data-testid="${mergeGateTaskId}"], .react-flow__node[data-testid$="${mergeGateTaskId}"]`).first();
+  await expect(mergeGateNode).toBeVisible({ timeout: 15000 });
+  await mergeGateNode.click();
+
+  await page.evaluate(
+    async ({ taskId }) => {
+      await window.invoker.injectTaskStates?.([
+        {
+          taskId,
+          changes: {
+            status: 'review_ready',
+            execution: { reviewUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/398' },
+          },
+        },
+      ]);
+    },
+    { taskId: mergeGateTaskId },
+  );
+  await page.waitForTimeout(200);
+
+  await expect(page.getByRole('heading', { name: /Review gate for/i })).toBeVisible();
+  await expect(page.getByText('Review link')).toBeVisible();
+  await expect(page.getByTestId('pr-url-link')).toContainText('Neko-Catpital-Labs/Invoker/pull/398');
+
+  await captureScreenshot(page, 'pending-review-gate-target-repo');
+});

--- a/packages/app/e2e/pending-review-gate-target-repo.proof.spec.ts
+++ b/packages/app/e2e/pending-review-gate-target-repo.proof.spec.ts
@@ -4,6 +4,7 @@ import { stringify as yamlStringify } from 'yaml';
 const REVIEW_GATE_PROOF_PLAN = {
   name: 'Pending review gate target repo proof',
   repoUrl: 'https://github.com/Neko-Catpital-Labs/Invoker',
+  baseBranch: 'master',
   onFinish: 'pull_request' as const,
   mergeMode: 'external_review' as const,
   tasks: [
@@ -27,30 +28,23 @@ test('pending review gate target repo row', async ({ page }) => {
     return mergeTask?.id ?? null;
   });
   expect(mergeGateTaskId).toBeTruthy();
+  const workflowId = String(mergeGateTaskId).replace('__merge__', '');
+  await page.evaluate(
+    async ({ workflowId: wf }) => {
+      await window.invoker.setMergeBranch(wf, 'master');
+    },
+    { workflowId },
+  );
 
   const mergeGateNode = page.locator(`.react-flow__node[data-testid="${mergeGateTaskId}"], .react-flow__node[data-testid$="${mergeGateTaskId}"]`).first();
   await expect(mergeGateNode).toBeVisible({ timeout: 15000 });
   await mergeGateNode.click();
 
-  await page.evaluate(
-    async ({ taskId }) => {
-      await window.invoker.injectTaskStates?.([
-        {
-          taskId,
-          changes: {
-            status: 'review_ready',
-            execution: { reviewUrl: 'https://github.com/Neko-Catpital-Labs/Invoker/pull/398' },
-          },
-        },
-      ]);
-    },
-    { taskId: mergeGateTaskId },
-  );
-  await page.waitForTimeout(200);
-
   await expect(page.getByRole('heading', { name: /Review gate for/i })).toBeVisible();
-  await expect(page.getByText('Review link')).toBeVisible();
-  await expect(page.getByTestId('pr-url-link')).toContainText('Neko-Catpital-Labs/Invoker/pull/398');
+  await expect(page.getByText('Target Branch')).toBeVisible();
+  await expect(page.getByTestId('target-branch-input')).toHaveValue('master');
+  await expect(page.getByText('PR target repo')).toBeVisible();
+  await expect(page.getByText('github.com/Neko-Catpital-Labs/Invoker')).toBeVisible();
 
   await captureScreenshot(page, 'pending-review-gate-target-repo');
 });

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -33,6 +33,8 @@ export interface WorkflowMeta {
   featureBranch?: string;
   onFinish?: string;
   mergeMode?: string;
+  repoUrl?: string;
+  intermediateRepoUrl?: string;
 }
 
 export interface WorkflowStatus {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -667,6 +667,7 @@ export function App() {
               task={selectedTask}
               allTasks={tasks}
               baseBranch={selectedTask?.config.workflowId ? workflows.get(selectedTask.config.workflowId)?.baseBranch : undefined}
+              workflowRepoUrl={selectedTask?.config.workflowId ? workflows.get(selectedTask.config.workflowId)?.repoUrl : undefined}
               mergeMode={selectedTask?.config.workflowId ? workflows.get(selectedTask.config.workflowId)?.mergeMode : undefined}
               remoteTargets={remoteTargets}
               executionAgents={executionAgents}

--- a/packages/ui/src/__tests__/task-panel-double-click.test.tsx
+++ b/packages/ui/src/__tests__/task-panel-double-click.test.tsx
@@ -915,6 +915,87 @@ describe('TaskPanel double-click editing', () => {
     });
   });
 
+  describe('PR target repo display for pending merge gates', () => {
+    it('renders normalized repo text for pending merge gate with SSH workflow repo URL', () => {
+      const task = makeTask({
+        status: 'pending',
+        config: { isMergeNode: true, workflowId: 'wf-1' } as TaskState['config'],
+      });
+      render(
+        <TaskPanel
+          task={task}
+          workflowRepoUrl="git@github.com:owner/repo.git"
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+        />,
+      );
+
+      expect(screen.getByTestId('pr-target-repo')).toBeInTheDocument();
+      expect(screen.getByText('github.com/owner/repo')).toBeInTheDocument();
+    });
+
+    it('renders normalized repo text for pending merge gate with HTTPS workflow repo URL', () => {
+      const task = makeTask({
+        status: 'pending',
+        config: { isMergeNode: true, workflowId: 'wf-1' } as TaskState['config'],
+      });
+      render(
+        <TaskPanel
+          task={task}
+          workflowRepoUrl="https://github.com/owner/repo.git"
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+        />,
+      );
+
+      expect(screen.getByTestId('pr-target-repo')).toBeInTheDocument();
+      expect(screen.getByText('github.com/owner/repo')).toBeInTheDocument();
+    });
+
+    it('does not render PR target repo when reviewUrl already exists', () => {
+      const task = makeTask({
+        status: 'pending',
+        config: { isMergeNode: true, workflowId: 'wf-1' } as TaskState['config'],
+        execution: { reviewUrl: 'https://github.com/owner/repo/pull/42' } as TaskState['execution'],
+      });
+      render(
+        <TaskPanel
+          task={task}
+          workflowRepoUrl="git@github.com:owner/repo.git"
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+        />,
+      );
+
+      expect(screen.queryByTestId('pr-target-repo')).not.toBeInTheDocument();
+    });
+
+    it('does not render PR target repo when merge gate is not pending', () => {
+      const task = makeTask({
+        status: 'awaiting_approval',
+        config: { isMergeNode: true, workflowId: 'wf-1' } as TaskState['config'],
+      });
+      render(
+        <TaskPanel
+          task={task}
+          workflowRepoUrl="git@github.com:owner/repo.git"
+          onProvideInput={mockOnProvideInput}
+          onApprove={mockOnApprove}
+          onReject={mockOnReject}
+          onSelectExperiment={mockOnSelectExperiment}
+        />,
+      );
+
+      expect(screen.queryByTestId('pr-target-repo')).not.toBeInTheDocument();
+    });
+  });
+
   describe('Execution agent selector', () => {
     const mockOnEditAgent = vi.fn();
 

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -413,7 +413,7 @@ export function TaskPanel({
       {task.config.isMergeNode && task.status === 'pending' && !task.execution?.reviewUrl && workflowRepoUrl && (
         <div className="flex items-center justify-between" data-testid="pr-target-repo">
           <span className="text-sm text-gray-400">PR target repo</span>
-          <span className="text-xs font-mono text-gray-200 truncate max-w-[200px]" title={workflowRepoUrl}>
+          <span className="text-xs font-mono text-gray-200 break-all whitespace-normal text-right max-w-[260px]" title={workflowRepoUrl}>
             {formatRepoUrl(workflowRepoUrl)}
           </span>
         </div>

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -63,6 +63,7 @@ interface TaskPanelProps {
   task: TaskState | null;
   allTasks?: Map<string, TaskState>;
   baseBranch?: string;
+  workflowRepoUrl?: string;
   remoteTargets?: string[];
   executionAgents?: string[];
   onProvideInput: (task: TaskState) => void;
@@ -96,6 +97,25 @@ function effectiveExecutorSelectValue(task: TaskState): string {
   }
   if (task.config.executorType) return task.config.executorType;
   return 'worktree';
+}
+
+/**
+ * Format a repo URL for display. Handles GitHub HTTPS and SSH patterns,
+ * falling back to host/path for other URLs.
+ */
+function formatRepoUrl(url: string): string {
+  // SSH: git@github.com:org/repo.git
+  const sshMatch = url.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
+  if (sshMatch) return `${sshMatch[1]}/${sshMatch[2]}`;
+
+  // HTTPS: https://github.com/org/repo.git or https://github.com/org/repo
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname.replace(/^\//, '').replace(/\.git$/, '');
+    return `${parsed.host}/${path}`;
+  } catch {
+    return url;
+  }
 }
 
 function HeartbeatTimingSection({ task, formatDate: fmtDate }: { task: TaskState; formatDate: (d?: Date | string) => string }) {
@@ -164,6 +184,7 @@ export function TaskPanel({
   task,
   allTasks,
   baseBranch,
+  workflowRepoUrl,
   remoteTargets,
   executionAgents,
   onProvideInput,
@@ -384,6 +405,16 @@ export function TaskPanel({
           <span className="text-sm text-gray-400">Review Status</span>
           <span className="text-xs text-gray-200" data-testid="pr-status-text">
             {task.execution.reviewStatus}
+          </span>
+        </div>
+      )}
+
+      {/* PR target repo (pending merge gates without a review URL yet) */}
+      {task.config.isMergeNode && task.status === 'pending' && !task.execution?.reviewUrl && workflowRepoUrl && (
+        <div className="flex items-center justify-between" data-testid="pr-target-repo">
+          <span className="text-sm text-gray-400">PR target repo</span>
+          <span className="text-xs font-mono text-gray-200 truncate max-w-[200px]" title={workflowRepoUrl}>
+            {formatRepoUrl(workflowRepoUrl)}
           </span>
         </div>
       )}

--- a/packages/ui/src/components/TaskPanel.tsx
+++ b/packages/ui/src/components/TaskPanel.tsx
@@ -392,7 +392,7 @@ export function TaskPanel({
             href={task.execution.reviewUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="text-xs font-mono text-blue-400 hover:text-blue-300 underline truncate max-w-[200px]"
+            className="text-xs font-mono text-blue-400 hover:text-blue-300 underline break-all whitespace-normal text-right max-w-[260px]"
             title={task.execution.reviewUrl}
             data-testid="pr-url-link"
           >

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -156,6 +156,8 @@ export interface WorkflowMeta {
   featureBranch?: string;
   onFinish?: string;
   mergeMode?: string;
+  repoUrl?: string;
+  intermediateRepoUrl?: string;
   reviewProvider?: string;
 }
 


### PR DESCRIPTION
## Summary

This PR exposes the merge gate target repository in the pending state so users can see where a pull request will be opened before a review URL exists.

- Add optional `repoUrl` and `intermediateRepoUrl` fields to shared workflow metadata types so the UI can read repository metadata without relying on untyped properties.
- Thread the selected workflow's `repoUrl` from `App` into `TaskPanel`.
- Render a `PR target repo` row for pending merge-gate tasks when a workflow repo URL is available and no review URL has been created yet.
- Normalize GitHub SSH and HTTPS remotes into a readable `host/owner/repo` display while falling back to the raw URL for anything else.
- Add focused `TaskPanel` UI regressions covering SSH normalization, HTTPS normalization, and non-display once a review URL exists or the merge gate leaves the pending state.

## Architecture

### Before

```mermaid
graph TD
    WM["Workflow metadata at runtime\nrepoUrl available but not typed"]
    APP["App selection state"]
    TP["TaskPanel"]
    REVIEW["Review URL row"]

    WM --> APP
    APP --> TP
    REVIEW --> TP

    TP -->|pending merge gate with no review URL| HIDE["No target repo shown"]

    style HIDE fill:#ffcdd2
```

### After

```mermaid
graph TD
    WM["WorkflowMeta\nrepoUrl + intermediateRepoUrl typed"]
    APP["App selection state"]
    TP["TaskPanel"]
    FORMAT["formatRepoUrl()"]
    ROW["PR target repo row"]
    REVIEW["Review URL row"]

    WM --> APP
    APP -->|workflowRepoUrl| TP
    TP --> FORMAT
    FORMAT --> ROW
    REVIEW --> TP

    TP -->|pending merge gate + no review URL + repoUrl present| ROW

    style WM fill:#e8f5e9
    style ROW fill:#e3f2fd
```

### Code Flow

```mermaid
sequenceDiagram
    participant Store as workflows map
    participant App as App selection state
    participant Panel as TaskPanel
    participant Format as formatRepoUrl()

    Store-->>App: WorkflowMeta.repoUrl
    App->>Panel: workflowRepoUrl prop
    Panel->>Panel: check isMergeNode && status == pending
    Panel->>Panel: check !execution.reviewUrl
    Panel->>Format: normalize repo URL
    Format-->>Panel: host/owner/repo
    Panel-->>Panel: render PR target repo row
```

## Visual Proof

Pending review gate side panel with the new `PR target repo` row:

![Pending review gate target repo](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260509-465284/pending-review-gate-target-repo.png)

## Test Plan

- [x] Follow-up: proof now keeps the merge gate pending (no forced `review_ready`) and shows `Target Branch` + `PR target repo` on the selected review gate (`656f0d3b`).
- [x] Follow-up: refreshed visual proof with a screenshot that selects the merge review gate (not `wf-test-1/task-alpha`) and shows the PR repo (`00a84365`).
- [x] Follow-up: remove review-link truncation so long `owner/repo/...` text is fully visible (`b2bf4f36`).
- [x] `cd packages/ui && pnpm test -- src/__tests__/task-panel-double-click.test.tsx`
- [x] `cd packages/app && pnpm exec playwright test e2e/pending-review-gate-target-repo.proof.spec.ts --reporter=line`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec pending-review-gate-target-repo.proof.spec.ts`
- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-398-visual.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No