### PR TITLE
PR authoring fallback Step 1: agent registry groundwork

### DIFF
--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -2,14 +2,18 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { AgentRegistry } from '../agent-registry.js';
 import type { ExecutionAgent } from '../agent.js';
 
-function makeExecutionAgent(name: string): ExecutionAgent {
+function makeExecutionAgent(name: string, opts?: {
+  bundledSkillRoot?: string;
+  bundledSkills?: readonly string[];
+}): ExecutionAgent {
   return {
     name,
     buildCommand: () => ({ cmd: name, args: [] }),
-    buildResumeArgs: (sessionId: string) => ['resume', sessionId],
+    buildResumeArgs: (sessionId: string) => ({ cmd: name, args: ['resume', sessionId] }),
     buildFixCommand: (prompt: string) => ({ cmd: name, args: ['fix', prompt] }),
-    parseSessionId: () => undefined,
     stdinMode: 'pipe',
+    ...(opts?.bundledSkillRoot !== undefined && { bundledSkillRoot: opts.bundledSkillRoot }),
+    ...(opts?.bundledSkills !== undefined && { bundledSkills: opts.bundledSkills }),
   };
 }
 
@@ -44,5 +48,82 @@ describe('AgentRegistry', () => {
     expect(() => registry.getOrThrow('cluade')).toThrow(
       'No execution agent registered with name "cluade". Available: [claude, codex]',
     );
+  });
+
+  describe('capability lookup', () => {
+    let prClaude: ExecutionAgent;
+    let prCodex: ExecutionAgent;
+    let noCapsAgent: ExecutionAgent;
+    let capRegistry: AgentRegistry;
+
+    beforeEach(() => {
+      capRegistry = new AgentRegistry();
+      prClaude = makeExecutionAgent('claude', {
+        bundledSkillRoot: '/home/user/.claude/skills',
+        bundledSkills: ['make-pr'],
+      });
+      prCodex = makeExecutionAgent('codex', {
+        bundledSkillRoot: '/home/user/.codex/skills',
+        bundledSkills: ['make-pr'],
+      });
+      noCapsAgent = makeExecutionAgent('bare-agent');
+      capRegistry.registerExecution(prClaude);
+      capRegistry.registerExecution(prCodex);
+      capRegistry.registerExecution(noCapsAgent);
+    });
+
+    it('getWithCapability returns the first agent registered with the skill', () => {
+      const agent = capRegistry.getWithCapability('make-pr');
+      expect(agent).toBe(prClaude);
+    });
+
+    it('getWithCapability is deterministic across repeated calls', () => {
+      const first = capRegistry.getWithCapability('make-pr');
+      const second = capRegistry.getWithCapability('make-pr');
+      expect(first).toBe(second);
+    });
+
+    it('getWithCapability returns undefined for unknown skills', () => {
+      expect(capRegistry.getWithCapability('deploy')).toBeUndefined();
+    });
+
+    it('getWithCapability skips agents without bundledSkills', () => {
+      // Register only an agent without capabilities
+      const minimal = new AgentRegistry();
+      minimal.registerExecution(noCapsAgent);
+      expect(minimal.getWithCapability('make-pr')).toBeUndefined();
+    });
+
+    it('listWithCapability returns all agents that bundle the skill', () => {
+      const agents = capRegistry.listWithCapability('make-pr');
+      expect(agents).toHaveLength(2);
+      expect(agents[0]).toBe(prClaude);
+      expect(agents[1]).toBe(prCodex);
+    });
+
+    it('listWithCapability returns empty array for unknown skills', () => {
+      expect(capRegistry.listWithCapability('deploy')).toEqual([]);
+    });
+
+    it('listWithCapability excludes agents without bundledSkills', () => {
+      const agents = capRegistry.listWithCapability('make-pr');
+      expect(agents).not.toContain(noCapsAgent);
+    });
+
+    it('bundledSkillRoot resolves only for PR-capable agents', () => {
+      // PR-capable agents expose their skill root
+      expect(prClaude.bundledSkillRoot).toBe('/home/user/.claude/skills');
+      expect(prCodex.bundledSkillRoot).toBe('/home/user/.codex/skills');
+      // Agent without capabilities has no skill root
+      expect(noCapsAgent.bundledSkillRoot).toBeUndefined();
+    });
+
+    it('registration order determines getWithCapability winner', () => {
+      // Register codex first in a fresh registry
+      const reversed = new AgentRegistry();
+      reversed.registerExecution(prCodex);
+      reversed.registerExecution(prClaude);
+      expect(reversed.getWithCapability('make-pr')).toBe(prCodex);
+    });
   });
 });

--- a/packages/execution-engine/src/agent-registry.ts
+++ b/packages/execution-engine/src/agent-registry.ts
@@ -81,4 +81,27 @@ export class AgentRegistry {
   listPlanning(): PlanningAgent[] {
     return [...this.planningAgents.values()];
   }
+
+  /**
+   * Return the first registered execution agent that bundles the given skill.
+   * Iteration order matches registration order (Map insertion order).
+   */
+  getWithCapability(skillName: string): ExecutionAgent | undefined {
+    for (const agent of this.executionAgents.values()) {
+      if (agent.bundledSkills?.includes(skillName)) return agent;
+    }
+    return undefined;
+  }
+
+  /**
+   * Return all registered execution agents that bundle the given skill.
+   * Order matches registration order.
+   */
+  listWithCapability(skillName: string): ExecutionAgent[] {
+    const result: ExecutionAgent[] = [];
+    for (const agent of this.executionAgents.values()) {
+      if (agent.bundledSkills?.includes(skillName)) result.push(agent);
+    }
+    return result;
+  }
 }

--- a/packages/execution-engine/src/agent.ts
+++ b/packages/execution-engine/src/agent.ts
@@ -22,6 +22,21 @@ export interface ExecutionAgent {
   readonly stdinMode: 'ignore' | 'pipe';
   /** Tail command for Linux terminal launch (e.g. 'exec_bash' or 'pause'). */
   readonly linuxTerminalTail?: 'exec_bash' | 'pause';
+
+  /**
+   * Root directory where this agent's bundled skills are installed.
+   * Example: ~/.claude/skills for the Claude agent.
+   * Undefined when the agent has no bundled skill support.
+   */
+  readonly bundledSkillRoot?: string;
+
+  /**
+   * Skill names this agent bundles (e.g. ['make-pr']).
+   * The registry uses this list for capability-based lookup.
+   * Each name corresponds to a subdirectory `invoker-{name}` under bundledSkillRoot.
+   */
+  readonly bundledSkills?: readonly string[];
+
   buildCommand(fullPrompt: string): AgentCommandSpec;
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] };
   /** Build a command spec for a fix/conflict-resolution prompt. */

--- a/packages/execution-engine/src/agents/claude-execution-agent.ts
+++ b/packages/execution-engine/src/agents/claude-execution-agent.ts
@@ -27,6 +27,8 @@ export class ClaudeExecutionAgent implements ExecutionAgent {
   readonly name = 'claude';
   readonly stdinMode = 'ignore' as const;
   readonly linuxTerminalTail = 'exec_bash' as const;
+  readonly bundledSkillRoot: string;
+  readonly bundledSkills = ['make-pr'] as const;
 
   private readonly command: string;
   private readonly fixCommand: string;
@@ -40,6 +42,7 @@ export class ClaudeExecutionAgent implements ExecutionAgent {
     this.configDir = config.configDir ?? join(homedir(), '.claude');
     this.containerHomePath = config.containerHomePath ?? '/home/invoker';
     this.apiKey = config.apiKey ?? process.env.ANTHROPIC_API_KEY ?? '';
+    this.bundledSkillRoot = join(this.configDir, 'skills');
   }
 
   buildCommand(fullPrompt: string): AgentCommandSpec {

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -10,6 +10,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 import type { ExecutionAgent, AgentCommandSpec } from '../agent.js';
 
 export interface CodexExecutionAgentConfig {
@@ -31,6 +33,8 @@ export class CodexExecutionAgent implements ExecutionAgent {
   readonly name = 'codex';
   readonly stdinMode = 'ignore' as const;
   readonly linuxTerminalTail = 'exec_bash' as const;
+  readonly bundledSkillRoot: string;
+  readonly bundledSkills = ['make-pr'] as const;
 
   private readonly command: string;
   private readonly fullAuto: boolean;
@@ -40,6 +44,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
     this.command = config.command ?? 'codex';
     this.bypassApprovalsAndSandbox = config.bypassApprovalsAndSandbox ?? true;
     this.fullAuto = config.fullAuto ?? true;
+    this.bundledSkillRoot = join(homedir(), '.codex', 'skills');
   }
 
   buildCommand(fullPrompt: string): AgentCommandSpec {


### PR DESCRIPTION
## Summary
Goal:
- Replace PR-authoring agent selection assumptions with explicit execution-agent capability metadata.

Motivation:
- `authorPrBodyWithSkill()` currently assumes a narrow installed-skill layout tied to specific agents.
- The fallback path needs a general AI registry so Codex, Claude, and future agents can participate without new hardcodes.

Implementation details:
- Extend execution-agent contracts so registered agents can advertise bundled `make-pr` support and resolve a concrete skill root.
- Add deterministic registry lookup helpers for "agents that can author PRs" and preserve stable iteration order for later fallback use.
- Lock the behavior down with focused execution-engine tests before downstream routing changes land.

Alternative considerations:
- Keep checking only `codex` and `claude` home-directory conventions.
- Infer capability from agent names or filesystem heuristics at every callsite.

Why this design is better:
- Registry-owned capability discovery keeps future AI integrations additive and localizes PR-authoring support in one contract.

Publication note:
- This targets Invoker itself; after the commit stack is ready, publish/update stacked PRs with `mergify stack push`.


---
PR authoring fallback Step 1: agent registry groundwork — 3 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1778265787376-5/define-pr-authoring-agent-capabilities | Goal:
- Extend execution-agent metadata and registry lookup for PR-authoring skill discovery.
Motivation:
- PR authoring needs a general capability contract rather than agent-name assumptions.
Alternative considerations:
- Keep hardcoded `codex` and `claude` lookup logic in the caller.
Implementation details:
- Add bundled skill capability metadata to execution agents and expose deterministic registry lookup helpers.
Layer: domain
Feature state: active
Files:
- packages/execution-engine/src/agent.ts
- packages/execution-engine/src/agent-registry.ts
- packages/execution-engine/src/agents/codex-execution-agent.ts
- packages/execution-engine/src/agents/claude-execution-agent.ts
- packages/execution-engine/src/__tests__/agent-registry.test.ts
Change types:
- modify
Acceptance criteria:
- Registered execution agents can advertise `make-pr` support through explicit metadata.
- The registry can resolve a usable bundled skill path and enumerate PR-capable agents in deterministic order.
 | completed |
| wf-1778265787376-5/verify-agent-registry-capabilities | Goal:
- Run focused execution-engine tests for capability discovery and current PR-authoring behavior.
Motivation:
- Registry groundwork should be proven before downstream merge-runner routing changes land.
Alternative considerations:
- Skip focused verification and rely only on the later full-suite gate.
Implementation details:
- Execute the narrow execution-engine lane covering registry capability tests and current PR-authoring callsites.
Layer: app_regression
Feature state: active
Files:
- packages/execution-engine/src/__tests__/agent-registry.test.ts
- packages/execution-engine/src/__tests__/task-runner.test.ts
Change types:
- none
Acceptance criteria:
- Focused execution-engine capability tests pass from the package test lane.
 | completed (passed) |
| wf-1778265787376-5/final-regression | Goal:
- Run the full repository test suite as the terminal regression gate.
Motivation:
- Capability-contract changes touch shared execution-engine wiring and need repo-wide regression coverage.
Alternative considerations:
- Stop after focused package tests only.
Implementation details:
- Run `pnpm run test:all` after the focused registry verification lane passes.
Layer: app_regression
Feature state: active
Files:
- none
Change types:
- none
Acceptance criteria:
- `pnpm run test:all` exits 0 after the registry groundwork lands.
 | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1778265787376-5/define-pr-authoring-agent-capabilities — Goal:
- Extend execution-agent metadata and registry lookup for PR-authoring skill discovery.
Motivation:
- PR authoring needs a general capability contract rather than agent-name assumptions.
Alternative considerations:
- Keep hardcoded `codex` and `claude` lookup logic in the caller.
Implementation details:
- Add bundled skill capability metadata to execution agents and expose deterministic registry lookup helpers.
Layer: domain
Feature state: active
Files:
- packages/execution-engine/src/agent.ts
- packages/execution-engine/src/agent-registry.ts
- packages/execution-engine/src/agents/codex-execution-agent.ts
- packages/execution-engine/src/agents/claude-execution-agent.ts
- packages/execution-engine/src/__tests__/agent-registry.test.ts
Change types:
- modify
Acceptance criteria:
- Registered execution agents can advertise `make-pr` support through explicit metadata.
- The registry can resolve a usable bundled skill path and enumerate PR-capable agents in deterministic order.

.../src/__tests__/agent-registry.test.ts           | 87 +++++++++++++++++++++-
 packages/execution-engine/src/agent-registry.ts    | 23 ++++++
 packages/execution-engine/src/agent.ts             | 15 ++++
 .../src/agents/claude-execution-agent.ts           |  3 +
 .../src/agents/codex-execution-agent.ts            |  5 ++
 5 files changed, 130 insertions(+), 3 deletions(-)

### wf-1778265787376-5/verify-agent-registry-capabilities — Goal:
- Run focused execution-engine tests for capability discovery and current PR-authoring behavior.
Motivation:
- Registry groundwork should be proven before downstream merge-runner routing changes land.
Alternative considerations:
- Skip focused verification and rely only on the later full-suite gate.
Implementation details:
- Execute the narrow execution-engine lane covering registry capability tests and current PR-authoring callsites.
Layer: app_regression
Feature state: active
Files:
- packages/execution-engine/src/__tests__/agent-registry.test.ts
- packages/execution-engine/src/__tests__/task-runner.test.ts
Change types:
- none
Acceptance criteria:
- Focused execution-engine capability tests pass from the package test lane.


### wf-1778265787376-5/final-regression — Goal:
- Run the full repository test suite as the terminal regression gate.
Motivation:
- Capability-contract changes touch shared execution-engine wiring and need repo-wide regression coverage.
Alternative considerations:
- Stop after focused package tests only.
Implementation details:
- Run `pnpm run test:all` after the focused registry verification lane passes.
Layer: app_regression
Feature state: active
Files:
- none
Change types:
- none
Acceptance criteria:
- `pnpm run test:all` exits 0 after the registry groundwork lands.


</details>
