### PR TITLE
PR authoring fallback Step 2: shared authoring pipeline

### DIFF
--- a/packages/execution-engine/src/__tests__/agent-registry.test.ts
+++ b/packages/execution-engine/src/__tests__/agent-registry.test.ts
@@ -2,14 +2,18 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { AgentRegistry } from '../agent-registry.js';
 import type { ExecutionAgent } from '../agent.js';
 
-function makeExecutionAgent(name: string): ExecutionAgent {
+function makeExecutionAgent(name: string, opts?: {
+  bundledSkillRoot?: string;
+  bundledSkills?: readonly string[];
+}): ExecutionAgent {
   return {
     name,
     buildCommand: () => ({ cmd: name, args: [] }),
-    buildResumeArgs: (sessionId: string) => ['resume', sessionId],
+    buildResumeArgs: (sessionId: string) => ({ cmd: name, args: ['resume', sessionId] }),
     buildFixCommand: (prompt: string) => ({ cmd: name, args: ['fix', prompt] }),
-    parseSessionId: () => undefined,
     stdinMode: 'pipe',
+    ...(opts?.bundledSkillRoot !== undefined && { bundledSkillRoot: opts.bundledSkillRoot }),
+    ...(opts?.bundledSkills !== undefined && { bundledSkills: opts.bundledSkills }),
   };
 }
 
@@ -44,5 +48,82 @@ describe('AgentRegistry', () => {
     expect(() => registry.getOrThrow('cluade')).toThrow(
       'No execution agent registered with name "cluade". Available: [claude, codex]',
     );
+  });
+
+  describe('capability lookup', () => {
+    let prClaude: ExecutionAgent;
+    let prCodex: ExecutionAgent;
+    let noCapsAgent: ExecutionAgent;
+    let capRegistry: AgentRegistry;
+
+    beforeEach(() => {
+      capRegistry = new AgentRegistry();
+      prClaude = makeExecutionAgent('claude', {
+        bundledSkillRoot: '/home/user/.claude/skills',
+        bundledSkills: ['make-pr'],
+      });
+      prCodex = makeExecutionAgent('codex', {
+        bundledSkillRoot: '/home/user/.codex/skills',
+        bundledSkills: ['make-pr'],
+      });
+      noCapsAgent = makeExecutionAgent('bare-agent');
+      capRegistry.registerExecution(prClaude);
+      capRegistry.registerExecution(prCodex);
+      capRegistry.registerExecution(noCapsAgent);
+    });
+
+    it('getWithCapability returns the first agent registered with the skill', () => {
+      const agent = capRegistry.getWithCapability('make-pr');
+      expect(agent).toBe(prClaude);
+    });
+
+    it('getWithCapability is deterministic across repeated calls', () => {
+      const first = capRegistry.getWithCapability('make-pr');
+      const second = capRegistry.getWithCapability('make-pr');
+      expect(first).toBe(second);
+    });
+
+    it('getWithCapability returns undefined for unknown skills', () => {
+      expect(capRegistry.getWithCapability('deploy')).toBeUndefined();
+    });
+
+    it('getWithCapability skips agents without bundledSkills', () => {
+      // Register only an agent without capabilities
+      const minimal = new AgentRegistry();
+      minimal.registerExecution(noCapsAgent);
+      expect(minimal.getWithCapability('make-pr')).toBeUndefined();
+    });
+
+    it('listWithCapability returns all agents that bundle the skill', () => {
+      const agents = capRegistry.listWithCapability('make-pr');
+      expect(agents).toHaveLength(2);
+      expect(agents[0]).toBe(prClaude);
+      expect(agents[1]).toBe(prCodex);
+    });
+
+    it('listWithCapability returns empty array for unknown skills', () => {
+      expect(capRegistry.listWithCapability('deploy')).toEqual([]);
+    });
+
+    it('listWithCapability excludes agents without bundledSkills', () => {
+      const agents = capRegistry.listWithCapability('make-pr');
+      expect(agents).not.toContain(noCapsAgent);
+    });
+
+    it('bundledSkillRoot resolves only for PR-capable agents', () => {
+      // PR-capable agents expose their skill root
+      expect(prClaude.bundledSkillRoot).toBe('/home/user/.claude/skills');
+      expect(prCodex.bundledSkillRoot).toBe('/home/user/.codex/skills');
+      // Agent without capabilities has no skill root
+      expect(noCapsAgent.bundledSkillRoot).toBeUndefined();
+    });
+
+    it('registration order determines getWithCapability winner', () => {
+      // Register codex first in a fresh registry
+      const reversed = new AgentRegistry();
+      reversed.registerExecution(prCodex);
+      reversed.registerExecution(prClaude);
+      expect(reversed.getWithCapability('make-pr')).toBe(prCodex);
+    });
   });
 });

--- a/packages/execution-engine/src/__tests__/pr-authoring.test.ts
+++ b/packages/execution-engine/src/__tests__/pr-authoring.test.ts
@@ -1,0 +1,168 @@
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it, expect, afterEach } from 'vitest';
+
+import {
+  buildCanonicalPrBody,
+  resolveSkillPathViaAgent,
+  validateCanonicalPrBody,
+} from '../pr-authoring.js';
+import type { ExecutionAgent } from '../agent.js';
+
+// ── Helpers ──────────────────────────────────────────────
+
+function makeAgent(name: string, opts?: {
+  bundledSkillRoot?: string;
+  bundledSkills?: readonly string[];
+}): ExecutionAgent {
+  return {
+    name,
+    stdinMode: 'ignore',
+    buildCommand: () => ({ cmd: name, args: [] }),
+    buildResumeArgs: () => ({ cmd: name, args: [] }),
+    ...(opts?.bundledSkillRoot !== undefined && { bundledSkillRoot: opts.bundledSkillRoot }),
+    ...(opts?.bundledSkills !== undefined && { bundledSkills: opts.bundledSkills }),
+  };
+}
+
+const tempDirs: string[] = [];
+function createTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'pr-authoring-test-'));
+  tempDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ── buildCanonicalPrBody ─────────────────────────────────
+
+describe('buildCanonicalPrBody', () => {
+  it('produces a valid canonical body with workflow summary only', () => {
+    const body = buildCanonicalPrBody({
+      title: 'Add feature X',
+      workflowSummary: 'Implemented feature X for better UX.',
+    });
+
+    expect(body).toContain('## Summary');
+    expect(body).toContain('Implemented feature X for better UX.');
+    expect(body).toContain('## Test Plan');
+    expect(body).toContain('Manual verification required');
+    expect(body).toContain('## Revert Plan');
+
+    const errors = validateCanonicalPrBody(body);
+    expect(errors).toEqual([]);
+  });
+
+  it('uses workflowDescription from structured context when present', () => {
+    const body = buildCanonicalPrBody({
+      title: 'Refactor Y',
+      workflowSummary: 'fallback summary',
+      structuredContext: {
+        workflowDescription: 'Structured description of refactoring Y.',
+        tasks: [],
+      },
+    });
+
+    expect(body).toContain('Structured description of refactoring Y.');
+    expect(body).not.toContain('fallback summary');
+  });
+
+  it('includes completed verification commands in test plan', () => {
+    const body = buildCanonicalPrBody({
+      title: 'Add tests',
+      workflowSummary: 'Added test coverage.',
+      structuredContext: {
+        tasks: [
+          { taskId: 't1', description: 'Run unit tests', status: 'completed', command: 'pnpm test' },
+          { taskId: 't2', description: 'Run lint', status: 'completed', command: 'pnpm lint' },
+          { taskId: 't3', description: 'Skipped task', status: 'skipped', command: 'pnpm e2e' },
+        ],
+      },
+    });
+
+    expect(body).toContain('- [x] `pnpm test` — Run unit tests');
+    expect(body).toContain('- [x] `pnpm lint` — Run lint');
+    expect(body).not.toContain('pnpm e2e');
+  });
+
+  it('preserves visual proof markdown verbatim', () => {
+    const visualProof = '## Visual Proof\n\n| Before | After |\n|--------|-------|\n| ![b](b.png) | ![a](a.png) |';
+    const body = buildCanonicalPrBody({
+      title: 'UI change',
+      workflowSummary: 'Updated the UI.',
+      structuredContext: {
+        tasks: [],
+        visualProofMarkdown: visualProof,
+      },
+    });
+
+    expect(body).toContain(visualProof);
+  });
+
+  it('canonical body passes validation', () => {
+    const body = buildCanonicalPrBody({
+      title: 'Anything',
+      workflowSummary: 'Any summary.',
+      structuredContext: {
+        tasks: [
+          { taskId: 't1', description: 'build', status: 'completed', command: 'pnpm build' },
+        ],
+        visualProofMarkdown: '## Visual Proof\nscreenshots here',
+      },
+    });
+
+    const errors = validateCanonicalPrBody(body);
+    expect(errors).toEqual([]);
+  });
+});
+
+// ── resolveSkillPathViaAgent ─────────────────────────────
+
+describe('resolveSkillPathViaAgent', () => {
+  it('resolves skill from agent bundledSkillRoot when SKILL.md exists', () => {
+    const tmpDir = createTempDir();
+    const skillDir = join(tmpDir, 'invoker-make-pr');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '# make-pr\n');
+
+    const agent = makeAgent('custom-agent', { bundledSkillRoot: tmpDir });
+    const result = resolveSkillPathViaAgent(agent, 'make-pr');
+    expect(result).toBe(skillDir);
+  });
+
+  it('returns null when bundledSkillRoot exists but SKILL.md is missing', () => {
+    const tmpDir = createTempDir();
+    mkdirSync(join(tmpDir, 'invoker-make-pr'), { recursive: true });
+    // No SKILL.md
+
+    const agent = makeAgent('custom-agent', { bundledSkillRoot: tmpDir });
+    const result = resolveSkillPathViaAgent(agent, 'make-pr');
+    expect(result).toBeNull();
+  });
+
+  it('falls back to name-based resolution for agents without bundledSkillRoot', () => {
+    const agent = makeAgent('unknown-agent');
+    const result = resolveSkillPathViaAgent(agent, 'make-pr');
+    // unknown-agent is not claude or codex, so name-based resolution returns null
+    expect(result).toBeNull();
+  });
+
+  it('prefers bundledSkillRoot over name-based resolution', () => {
+    const tmpDir = createTempDir();
+    const skillDir = join(tmpDir, 'invoker-make-pr');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '# make-pr\n');
+
+    // Agent named 'claude' but with custom bundledSkillRoot
+    const agent = makeAgent('claude', { bundledSkillRoot: tmpDir });
+    const result = resolveSkillPathViaAgent(agent, 'make-pr');
+    expect(result).toBe(skillDir);
+  });
+});

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -5955,6 +5955,19 @@ describe('TaskRunner', () => {
       writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
 
       try {
+        const codexAgent = {
+          name: 'codex',
+          stdinMode: 'ignore',
+          linuxTerminalTail: 'exec_bash',
+          bundledSkillRoot: join(tempHome, '.codex', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => ({
+            cmd: 'node',
+            args: ['-e', 'process.stdout.write("## Summary\\n\\nAuthored\\n\\n## Test Plan\\n\\n- [x] `pnpm test`\\n\\n## Revert Plan\\n\\n- Safe to revert? Yes\\n- Revert command: `git revert <sha>`\\n- Post-revert steps: None\\n- Data migration? No\\n")'],
+            sessionId: 'sess-pr-body',
+          }),
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
         const executor = new TaskRunner({
           orchestrator: {
             getTask: () => null,
@@ -5963,18 +5976,10 @@ describe('TaskRunner', () => {
           persistence: {} as any,
           executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
           executionAgentRegistry: {
-            getOrThrow: vi.fn().mockReturnValue({
-              name: 'codex',
-              stdinMode: 'ignore',
-              linuxTerminalTail: 'exec_bash',
-              buildCommand: () => ({
-                cmd: 'node',
-                args: ['-e', 'process.stdout.write("## Summary\\n\\nAuthored\\n\\n## Test Plan\\n\\n- [x] `pnpm test`\\n\\n## Revert Plan\\n\\n- Safe to revert? Yes\\n- Revert command: `git revert <sha>`\\n- Post-revert steps: None\\n- Data migration? No\\n")'],
-                sessionId: 'sess-pr-body',
-              }),
-              buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
-            }),
+            get: (name: string) => name === 'codex' ? codexAgent : undefined,
+            getOrThrow: vi.fn().mockReturnValue(codexAgent),
             getSessionDriver: vi.fn().mockReturnValue(undefined),
+            listWithCapability: vi.fn().mockReturnValue([codexAgent]),
           } as any,
           cwd: '/tmp',
         });
@@ -5998,7 +6003,7 @@ describe('TaskRunner', () => {
       }
     });
 
-    it('authorPrBodyWithSkill fails closed when the authored body is invalid', async () => {
+    it('authorPrBodyWithSkill falls back to canonical body when authored body is invalid and no other agents available', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;
       process.env.HOME = tempHome;
@@ -6006,6 +6011,19 @@ describe('TaskRunner', () => {
       writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
 
       try {
+        const codexAgent = {
+          name: 'codex',
+          stdinMode: 'ignore',
+          linuxTerminalTail: 'exec_bash',
+          bundledSkillRoot: join(tempHome, '.codex', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => ({
+            cmd: 'node',
+            args: ['-e', 'process.stdout.write("## Summary\\n\\nOnly summary")'],
+            sessionId: 'sess-invalid-pr',
+          }),
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
         const executor = new TaskRunner({
           orchestrator: {
             getTask: () => null,
@@ -6014,30 +6032,223 @@ describe('TaskRunner', () => {
           persistence: {} as any,
           executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
           executionAgentRegistry: {
-            getOrThrow: vi.fn().mockReturnValue({
-              name: 'codex',
-              stdinMode: 'ignore',
-              linuxTerminalTail: 'exec_bash',
-              buildCommand: () => ({
-                cmd: 'node',
-                args: ['-e', 'process.stdout.write("## Summary\\n\\nOnly summary")'],
-                sessionId: 'sess-invalid-pr',
-              }),
-              buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
-            }),
+            get: (name: string) => name === 'codex' ? codexAgent : undefined,
+            getOrThrow: vi.fn().mockReturnValue(codexAgent),
             getSessionDriver: vi.fn().mockReturnValue(undefined),
+            listWithCapability: vi.fn().mockReturnValue([codexAgent]),
           } as any,
           cwd: '/tmp',
+          logger: createMockLogger(),
         });
 
-        await expect((executor as any).authorPrBodyWithSkill({
+        // With fallback, invalid AI body triggers canonical fallback instead of throwing
+        const result = await (executor as any).authorPrBodyWithSkill({
           workflowId: 'wf-1',
           title: 'Test Workflow',
           baseBranch: 'master',
           featureBranch: 'plan/feature',
           workflowSummary: '## Summary\nSource summary',
           cwd: '/tmp',
-        })).rejects.toThrow('PR body authored via invoker-make-pr is invalid');
+        });
+
+        expect(result.agentName).toBe('canonical');
+        expect(result.sessionId).toBe('canonical-fallback');
+        expect(result.body).toContain('## Summary');
+        expect(result.body).toContain('## Test Plan');
+        expect(result.body).toContain('## Revert Plan');
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
+    it('authorPrBodyWithSkill falls back to second agent when first fails', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+
+      // Only set up codex skill (not claude) — so claude fails skill resolution
+      mkdirSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.codex', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const claudeAgent = {
+          name: 'claude',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.claude', 'skills'), // no SKILL.md here
+          bundledSkills: ['make-pr'],
+          buildCommand: () => ({
+            cmd: 'node',
+            args: ['-e', 'process.exit(1)'],
+            sessionId: 'sess-claude-fail',
+          }),
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+        const codexAgent = {
+          name: 'codex',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.codex', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => ({
+            cmd: 'node',
+            args: ['-e', 'process.stdout.write("## Summary\\n\\nFallback body\\n\\n## Test Plan\\n\\n- [x] `pnpm test`\\n\\n## Revert Plan\\n\\n- Safe to revert? Yes\\n- Revert command: `git revert <sha>`\\n- Post-revert steps: None\\n- Data migration? No\\n")'],
+            sessionId: 'sess-codex-ok',
+          }),
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: {
+            getTask: () => null,
+            getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-1', executionAgent: 'claude' } })],
+          } as any,
+          persistence: {} as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          executionAgentRegistry: {
+            get: (name: string) => name === 'claude' ? claudeAgent : name === 'codex' ? codexAgent : undefined,
+            getOrThrow: (name: string) => {
+              if (name === 'claude') return claudeAgent;
+              if (name === 'codex') return codexAgent;
+              throw new Error(`Unknown agent: ${name}`);
+            },
+            getSessionDriver: vi.fn().mockReturnValue(undefined),
+            listWithCapability: vi.fn().mockReturnValue([claudeAgent, codexAgent]),
+          } as any,
+          cwd: '/tmp',
+          logger: createMockLogger(),
+        });
+
+        const result = await (executor as any).authorPrBodyWithSkill({
+          workflowId: 'wf-1',
+          title: 'Fallback Test',
+          baseBranch: 'master',
+          featureBranch: 'plan/fallback',
+          workflowSummary: '## Summary\nFallback test',
+          cwd: '/tmp',
+        });
+
+        expect(result.agentName).toBe('codex');
+        expect(result.body).toContain('## Summary');
+        expect(result.body).toContain('## Test Plan');
+        expect(result.body).toContain('## Revert Plan');
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
+    it('authorPrBodyWithSkill emits canonical body when all agents fail', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+
+      // No skill directories at all
+      try {
+        const claudeAgent = {
+          name: 'claude',
+          stdinMode: 'ignore',
+          bundledSkills: ['make-pr'],
+          buildCommand: () => ({ cmd: 'node', args: ['-e', 'process.exit(1)'], sessionId: 'x' }),
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: {
+            getTask: () => null,
+            getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-1', executionAgent: 'claude' } })],
+          } as any,
+          persistence: {} as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          executionAgentRegistry: {
+            get: (name: string) => name === 'claude' ? claudeAgent : undefined,
+            getOrThrow: vi.fn().mockReturnValue(claudeAgent),
+            getSessionDriver: vi.fn().mockReturnValue(undefined),
+            listWithCapability: vi.fn().mockReturnValue([claudeAgent]),
+          } as any,
+          cwd: '/tmp',
+          logger: createMockLogger(),
+        });
+
+        const result = await (executor as any).authorPrBodyWithSkill({
+          workflowId: 'wf-1',
+          title: 'Canonical Test',
+          baseBranch: 'master',
+          featureBranch: 'plan/canonical',
+          workflowSummary: 'Canonical summary content.',
+          structuredContext: {
+            tasks: [
+              { taskId: 't1', description: 'Run tests', status: 'completed', command: 'pnpm test' },
+            ],
+            visualProofMarkdown: '## Visual Proof\nscreenshots here',
+          },
+          cwd: '/tmp',
+        });
+
+        expect(result.agentName).toBe('canonical');
+        expect(result.sessionId).toBe('canonical-fallback');
+        expect(result.body).toContain('## Summary');
+        expect(result.body).toContain('## Test Plan');
+        expect(result.body).toContain('## Revert Plan');
+        expect(result.body).toContain('pnpm test');
+        expect(result.body).toContain('## Visual Proof');
+      } finally {
+        if (originalHome === undefined) delete process.env.HOME;
+        else process.env.HOME = originalHome;
+      }
+    });
+
+    it('authorPrBodyWithSkill deduplicates preferred agent in fallback chain', async () => {
+      const tempHome = createTempWorkspace();
+      const originalHome = process.env.HOME;
+      process.env.HOME = tempHome;
+      mkdirSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr'), { recursive: true });
+      writeFileSync(join(tempHome, '.claude', 'skills', 'invoker-make-pr', 'SKILL.md'), '# make-pr\n');
+
+      try {
+        const claudeAgent = {
+          name: 'claude',
+          stdinMode: 'ignore',
+          bundledSkillRoot: join(tempHome, '.claude', 'skills'),
+          bundledSkills: ['make-pr'],
+          buildCommand: () => ({
+            cmd: 'node',
+            args: ['-e', 'process.stdout.write("## Summary\\n\\nOK\\n\\n## Test Plan\\n\\n- [x] `pnpm test`\\n\\n## Revert Plan\\n\\n- Safe to revert? Yes\\n- Revert command: `git revert <sha>`\\n- Post-revert steps: None\\n- Data migration? No\\n")'],
+            sessionId: 'sess-dedup',
+          }),
+          buildResumeArgs: () => ({ cmd: 'node', args: ['-e', ''] }),
+        };
+
+        const getOrThrow = vi.fn().mockReturnValue(claudeAgent);
+
+        const executor = new TaskRunner({
+          orchestrator: {
+            getTask: () => null,
+            getAllTasks: () => [makeTask({ id: 't1', config: { workflowId: 'wf-1', executionAgent: 'claude' } })],
+          } as any,
+          persistence: {} as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          executionAgentRegistry: {
+            get: () => claudeAgent,
+            getOrThrow,
+            getSessionDriver: vi.fn().mockReturnValue(undefined),
+            listWithCapability: vi.fn().mockReturnValue([claudeAgent]),
+          } as any,
+          cwd: '/tmp',
+          logger: createMockLogger(),
+        });
+
+        const result = await (executor as any).authorPrBodyWithSkill({
+          workflowId: 'wf-1',
+          title: 'Dedup Test',
+          baseBranch: 'master',
+          featureBranch: 'plan/dedup',
+          workflowSummary: '## Summary\nDedup test',
+          cwd: '/tmp',
+        });
+
+        // Claude should succeed on first try — no duplicate attempts
+        expect(result.agentName).toBe('claude');
+        expect(result.body).toContain('## Summary');
       } finally {
         if (originalHome === undefined) delete process.env.HOME;
         else process.env.HOME = originalHome;

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -2460,6 +2460,11 @@ describe('TaskRunner', () => {
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body',
+        sessionId: 'sess-pr-ext',
+        agentName: 'codex',
+      });
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -2483,13 +2488,22 @@ describe('TaskRunner', () => {
       const commitCall = gitCalls.find(c => c[0] === 'commit');
       expect(commitCall).toBeUndefined();
 
-      // Should create a PR via mergeGateProvider (using the gate clone dir, not host.cwd)
+      // Should route through shared PR-authoring helper
+      expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Test Workflow',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        cwd: '/tmp/mock-wt',
+      }));
+
+      // Should create a PR via mergeGateProvider with authored body
       expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
         expect.objectContaining({
           baseBranch: 'master',
           featureBranch: 'plan/feature',
           title: 'Test Workflow',
           cwd: '/tmp/mock-wt',
+          body: '## Summary\n\nAuthored body',
         }),
       );
 
@@ -2642,6 +2656,11 @@ describe('TaskRunner', () => {
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body',
+        sessionId: 'sess-pr-ext2',
+        agentName: 'codex',
+      });
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -2651,6 +2670,9 @@ describe('TaskRunner', () => {
       });
 
       await (executor as any).executeMergeNode(mergeTask);
+
+      // Should route through shared PR-authoring helper
+      expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalled();
 
       // Should create a PR via mergeGateProvider
       expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
@@ -2721,6 +2743,11 @@ describe('TaskRunner', () => {
       (executor as any).createMergeWorktree = createMergeWorktreeSpy;
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body',
+        sessionId: 'sess-pr-ext3',
+        agentName: 'codex',
+      });
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -2786,6 +2813,11 @@ describe('TaskRunner', () => {
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body',
+        sessionId: 'sess-pr-ext4',
+        agentName: 'codex',
+      });
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -2956,6 +2988,11 @@ describe('TaskRunner', () => {
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body',
+        sessionId: 'sess-pr-ext5',
+        agentName: 'codex',
+      });
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -3021,6 +3058,11 @@ describe('TaskRunner', () => {
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body',
+        sessionId: 'sess-pr-ext6',
+        agentName: 'codex',
+      });
 
       const consolidateSpy = vi.spyOn(executor as any, 'consolidateAndMerge');
 
@@ -3187,7 +3229,7 @@ describe('TaskRunner', () => {
       );
     });
 
-    it('executeMergeNode passes summary body to createReview in external_review mode', async () => {
+    it('executeMergeNode passes authored body to createReview in external_review mode', async () => {
       const allTasks = [
         makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
       ];
@@ -3234,6 +3276,11 @@ describe('TaskRunner', () => {
       (executor as any).removeMergeWorktree = async () => {};
       (executor as any).startPrPolling = vi.fn();
       (executor as any).buildMergeSummary = vi.fn().mockResolvedValue('## Summary\nTest summary');
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored PR body from summary',
+        sessionId: 'sess-pr-ext7',
+        agentName: 'codex',
+      });
 
       const mergeTask = makeTask({
         id: '__merge__wf-1',
@@ -3244,8 +3291,17 @@ describe('TaskRunner', () => {
 
       await (executor as any).executeMergeNode(mergeTask);
 
+      // Should route through shared PR-authoring helper with the summary as input
+      expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workflowSummary: '## Summary\nTest summary',
+          cwd: '/tmp/mock-wt',
+        }),
+      );
+
+      // createReview receives the authored body, not the raw summary
       expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
-        expect.objectContaining({ body: '## Summary\nTest summary' }),
+        expect.objectContaining({ body: '## Summary\n\nAuthored PR body from summary' }),
       );
       expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith(
         '__merge__wf-1',
@@ -6539,13 +6595,22 @@ describe('TaskRunner', () => {
       const hostCalls = gitCalls.filter((c) => c.dir === '/tmp/host');
       expect(hostCalls).toHaveLength(0);
 
-      // PR created via mergeGateProvider (using gate clone dir, not host.cwd)
+      // Should route through shared PR-authoring helper
+      expect((executor as any).authorPrBodyWithSkill).toHaveBeenCalledWith(expect.objectContaining({
+        title: 'Test Workflow',
+        baseBranch: 'master',
+        featureBranch: 'plan/feature',
+        cwd: '/tmp/gate-clone',
+      }));
+
+      // PR created via mergeGateProvider with authored body (not raw summary)
       expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
         expect.objectContaining({
           baseBranch: 'master',
           featureBranch: 'plan/feature',
           title: 'Test Workflow',
           cwd: '/tmp/gate-clone',
+          body: '## Summary\n\nPublished body',
         }),
       );
 

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -6253,6 +6253,44 @@ describe('TaskRunner', () => {
       }
     });
 
+    it('authorPrBodyWithSkill emits canonical body when no execution agent registry is configured', async () => {
+      const logger = createMockLogger();
+      const executor = new TaskRunner({
+        orchestrator: {
+          getTask: () => null,
+          getAllTasks: () => [],
+        } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+        logger,
+      });
+
+      const result = await (executor as any).authorPrBodyWithSkill({
+        workflowId: 'wf-1',
+        title: 'Canonical Test',
+        baseBranch: 'master',
+        featureBranch: 'plan/canonical',
+        workflowSummary: 'Canonical summary content.',
+        structuredContext: {
+          tasks: [
+            { taskId: 't1', description: 'Run tests', status: 'completed', command: 'pnpm test' },
+          ],
+        },
+        cwd: '/tmp',
+      });
+
+      expect(result.agentName).toBe('canonical');
+      expect(result.sessionId).toBe('canonical-fallback');
+      expect(result.body).toContain('## Summary');
+      expect(result.body).toContain('## Test Plan');
+      expect(result.body).toContain('## Revert Plan');
+      expect(result.body).toContain('pnpm test');
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[pr-authoring] executionAgentRegistry missing, using canonical fallback PR body.',
+      );
+    });
+
     it('authorPrBodyWithSkill deduplicates preferred agent in fallback chain', async () => {
       const tempHome = createTempWorkspace();
       const originalHome = process.env.HOME;

--- a/packages/execution-engine/src/agent-registry.ts
+++ b/packages/execution-engine/src/agent-registry.ts
@@ -81,4 +81,27 @@ export class AgentRegistry {
   listPlanning(): PlanningAgent[] {
     return [...this.planningAgents.values()];
   }
+
+  /**
+   * Return the first registered execution agent that bundles the given skill.
+   * Iteration order matches registration order (Map insertion order).
+   */
+  getWithCapability(skillName: string): ExecutionAgent | undefined {
+    for (const agent of this.executionAgents.values()) {
+      if (agent.bundledSkills?.includes(skillName)) return agent;
+    }
+    return undefined;
+  }
+
+  /**
+   * Return all registered execution agents that bundle the given skill.
+   * Order matches registration order.
+   */
+  listWithCapability(skillName: string): ExecutionAgent[] {
+    const result: ExecutionAgent[] = [];
+    for (const agent of this.executionAgents.values()) {
+      if (agent.bundledSkills?.includes(skillName)) result.push(agent);
+    }
+    return result;
+  }
 }

--- a/packages/execution-engine/src/agent.ts
+++ b/packages/execution-engine/src/agent.ts
@@ -22,6 +22,21 @@ export interface ExecutionAgent {
   readonly stdinMode: 'ignore' | 'pipe';
   /** Tail command for Linux terminal launch (e.g. 'exec_bash' or 'pause'). */
   readonly linuxTerminalTail?: 'exec_bash' | 'pause';
+
+  /**
+   * Root directory where this agent's bundled skills are installed.
+   * Example: ~/.claude/skills for the Claude agent.
+   * Undefined when the agent has no bundled skill support.
+   */
+  readonly bundledSkillRoot?: string;
+
+  /**
+   * Skill names this agent bundles (e.g. ['make-pr']).
+   * The registry uses this list for capability-based lookup.
+   * Each name corresponds to a subdirectory `invoker-{name}` under bundledSkillRoot.
+   */
+  readonly bundledSkills?: readonly string[];
+
   buildCommand(fullPrompt: string): AgentCommandSpec;
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] };
   /** Build a command spec for a fix/conflict-resolution prompt. */

--- a/packages/execution-engine/src/agents/claude-execution-agent.ts
+++ b/packages/execution-engine/src/agents/claude-execution-agent.ts
@@ -27,6 +27,8 @@ export class ClaudeExecutionAgent implements ExecutionAgent {
   readonly name = 'claude';
   readonly stdinMode = 'ignore' as const;
   readonly linuxTerminalTail = 'exec_bash' as const;
+  readonly bundledSkillRoot: string;
+  readonly bundledSkills = ['make-pr'] as const;
 
   private readonly command: string;
   private readonly fixCommand: string;
@@ -40,6 +42,7 @@ export class ClaudeExecutionAgent implements ExecutionAgent {
     this.configDir = config.configDir ?? join(homedir(), '.claude');
     this.containerHomePath = config.containerHomePath ?? '/home/invoker';
     this.apiKey = config.apiKey ?? process.env.ANTHROPIC_API_KEY ?? '';
+    this.bundledSkillRoot = join(this.configDir, 'skills');
   }
 
   buildCommand(fullPrompt: string): AgentCommandSpec {

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -10,6 +10,8 @@
  */
 
 import { randomUUID } from 'node:crypto';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
 import type { ExecutionAgent, AgentCommandSpec } from '../agent.js';
 
 export interface CodexExecutionAgentConfig {
@@ -31,6 +33,8 @@ export class CodexExecutionAgent implements ExecutionAgent {
   readonly name = 'codex';
   readonly stdinMode = 'ignore' as const;
   readonly linuxTerminalTail = 'exec_bash' as const;
+  readonly bundledSkillRoot: string;
+  readonly bundledSkills = ['make-pr'] as const;
 
   private readonly command: string;
   private readonly fullAuto: boolean;
@@ -40,6 +44,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
     this.command = config.command ?? 'codex';
     this.bypassApprovalsAndSandbox = config.bypassApprovalsAndSandbox ?? true;
     this.fullAuto = config.fullAuto ?? true;
+    this.bundledSkillRoot = join(homedir(), '.codex', 'skills');
   }
 
   buildCommand(fullPrompt: string): AgentCommandSpec {

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -18,6 +18,7 @@ import type { TaskRunnerCallbacks } from './task-runner.js';
 import type { MergeGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
+import type { PrAuthoringContext, PrAuthoringTaskEntry } from './pr-authoring.js';
 
 // ── Trace logging ────────────────────────────────────────
 
@@ -157,6 +158,7 @@ export interface MergeRunnerHost {
     baseBranch: string;
     featureBranch: string;
     workflowSummary: string;
+    structuredContext?: PrAuthoringContext;
     cwd: string;
   }): Promise<{ body: string; sessionId: string; agentName: string }>;
   detectDefaultBranch(): Promise<string>;
@@ -191,6 +193,7 @@ async function authorPrBodyForMerge(
     baseBranch: string;
     featureBranch: string;
     workflowSummary: string;
+    structuredContext?: PrAuthoringContext;
     cwd: string;
   },
 ): Promise<string> {
@@ -202,6 +205,62 @@ async function authorPrBodyForMerge(
     `[merge] Authored PR body via ${authored.agentName} skill session=${authored.sessionId}`,
   );
   return authored.body;
+}
+
+/**
+ * Build structured PR-authoring context from workflow tasks.
+ * This carries per-task evidence (verification commands, file-change summaries)
+ * alongside the free-form summary string for richer PR bodies.
+ */
+export async function buildPrAuthoringContext(
+  host: MergeRunnerHost,
+  workflowId: string,
+  visualProofMarkdown?: string,
+): Promise<PrAuthoringContext> {
+  const allTasks = host.orchestrator.getAllTasks();
+  const workflowTasks = allTasks.filter(
+    (t) => t.config.workflowId === workflowId && !t.config.isMergeNode,
+  );
+
+  const workflow = host.persistence.loadWorkflow(workflowId);
+
+  // Resolve pool mirror path so gitDiffStat runs against the correct repo
+  const mirrorCwd = workflow?.repoUrl && host.ensureRepoMirrorPath
+    ? await host.ensureRepoMirrorPath(workflow.repoUrl)
+    : undefined;
+
+  const tasks: PrAuthoringTaskEntry[] = [];
+  for (const t of workflowTasks) {
+    const status: PrAuthoringTaskEntry['status'] =
+      t.status === 'completed' ? 'completed'
+        : t.status === 'failed' ? 'failed'
+          : 'skipped';
+
+    let fileChangeSummary: string | undefined;
+    if (t.status === 'completed' && t.execution.branch) {
+      try {
+        const stat = await host.gitDiffStat(t.execution.branch, mirrorCwd ?? undefined);
+        if (stat) fileChangeSummary = stat;
+      } catch {
+        // Silently skip if git diff fails
+      }
+    }
+
+    tasks.push({
+      taskId: t.id,
+      description: t.description,
+      status,
+      command: t.config.command ?? undefined,
+      fileChangeSummary,
+    });
+  }
+
+  return {
+    workflowName: workflow?.name,
+    workflowDescription: workflow?.description,
+    tasks,
+    visualProofMarkdown,
+  };
 }
 
 /**
@@ -615,13 +674,16 @@ export async function approveMergeImpl(
   const summary = await host.buildMergeSummary(workflowId);
   let fullSummary = summary;
   const visualProof = workflow.visualProof ?? false;
+  let vpMarkdownCapture: string | undefined;
   if (visualProof && host.runVisualProofCapture) {
     const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
     const vpMarkdown = await host.runVisualProofCapture(baseBranch, featureBranch!, slug, workflow.repoUrl);
     if (vpMarkdown) {
+      vpMarkdownCapture = vpMarkdown;
       fullSummary = summary + '\n\n' + vpMarkdown;
     }
   }
+  const structuredContext = await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture);
   const mergeMessage = workflow.name ?? 'Workflow';
 
   // Clean up the persistent gate worktree created by executeMergeNodeImpl
@@ -673,6 +735,7 @@ export async function approveMergeImpl(
         baseBranch,
         featureBranch,
         workflowSummary: fullSummary ?? '',
+        structuredContext,
         cwd: worktreeDir,
       });
       const reviewUrl = await host.execPr(baseBranch, featureBranch, mergeMessage, prBody, worktreeDir);
@@ -923,10 +986,12 @@ export async function publishAfterFixImpl(
     await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], consolidateDir);
 
     let fullSummary = summary;
+    let vpMarkdownCapture2: string | undefined;
     if (visualProof && host.runVisualProofCapture) {
       const slug = featureBranch.replace(/\//g, '-');
       const vpMarkdown = await host.runVisualProofCapture(baseBranch, featureBranch, slug, workflow?.repoUrl);
       if (vpMarkdown) {
+        vpMarkdownCapture2 = vpMarkdown;
         fullSummary = (summary ?? '') + '\n\n' + vpMarkdown;
       }
     }
@@ -967,6 +1032,9 @@ export async function publishAfterFixImpl(
 
     // manual mode with pull_request onFinish
     if (onFinish === 'pull_request') {
+      const structuredCtx = workflowId
+        ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture2)
+        : undefined;
       const prBody = await authorPrBodyForMerge(host, {
         workflowId,
         mergeNodeTaskId: task.id,
@@ -974,6 +1042,7 @@ export async function publishAfterFixImpl(
         baseBranch,
         featureBranch,
         workflowSummary: fullSummary ?? '',
+        structuredContext: structuredCtx,
         cwd: consolidateDir,
       });
       const reviewUrl = await host.execPr(baseBranch, featureBranch, workflow?.name ?? 'Workflow', prBody, consolidateDir);
@@ -1300,6 +1369,9 @@ export async function consolidateAndMergeImpl(
     } else if (onFinish === 'pull_request') {
       // Push feature branch directly to origin (GitHub) from the clone
       await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
+      const structuredCtx3 = workflowId
+        ? await buildPrAuthoringContext(host, workflowId)
+        : undefined;
       const prBody = await authorPrBodyForMerge(host, {
         workflowId,
         mergeNodeTaskId,
@@ -1307,6 +1379,7 @@ export async function consolidateAndMergeImpl(
         baseBranch,
         featureBranch,
         workflowSummary: body ?? '',
+        structuredContext: structuredCtx3,
         cwd: worktreeDir,
       });
       const reviewUrl = await host.execPr(baseBranch, featureBranch, workflowName ?? 'Workflow', prBody, worktreeDir);

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -495,10 +495,12 @@ export async function executeMergeNodeImpl(
         }
 
         let fullSummary = summary;
+        let vpMarkdownCapture: string | undefined;
         if (visualProof && host.runVisualProofCapture) {
           const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
           const vpMarkdown = await host.runVisualProofCapture(baseBranch, featureBranch!, slug, workflow?.repoUrl);
           if (vpMarkdown) {
+            vpMarkdownCapture = vpMarkdown;
             fullSummary = (summary ?? '') + '\n\n' + vpMarkdown;
           }
         }
@@ -510,6 +512,21 @@ export async function executeMergeNodeImpl(
           gateWorkspacePath!,
         );
 
+        // Route through shared PR-authoring helper for consistent PR bodies.
+        const structuredCtx = workflowId
+          ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture)
+          : undefined;
+        const prBody = await authorPrBodyForMerge(host, {
+          workflowId,
+          mergeNodeTaskId: task.id,
+          title: workflow?.name ?? 'Workflow',
+          baseBranch,
+          featureBranch: featureBranch!,
+          workflowSummary: fullSummary ?? '',
+          structuredContext: structuredCtx,
+          cwd: gateWorkspacePath!,
+        });
+
         // Create PR via provider (consolidation already done above).
         // Use the gate clone dir so gh CLI resolves the correct GitHub remote.
         const result = await host.mergeGateProvider.createReview({
@@ -517,7 +534,7 @@ export async function executeMergeNodeImpl(
           featureBranch,
           title: workflow?.name ?? 'Workflow',
           cwd: gateWorkspacePath!,
-          body: fullSummary,
+          body: prBody,
         });
         console.log(`[merge] Created GitHub PR: ${result.url}`);
 
@@ -1001,12 +1018,27 @@ export async function publishAfterFixImpl(
         throw new Error('mergeMode is "external_review" but no review provider configured');
       }
 
+      // Route through shared PR-authoring helper for consistent PR bodies.
+      const structuredCtxReview = workflowId
+        ? await buildPrAuthoringContext(host, workflowId, vpMarkdownCapture2)
+        : undefined;
+      const prBodyReview = await authorPrBodyForMerge(host, {
+        workflowId,
+        mergeNodeTaskId: task.id,
+        title: workflow?.name ?? 'Workflow',
+        baseBranch,
+        featureBranch,
+        workflowSummary: fullSummary ?? '',
+        structuredContext: structuredCtxReview,
+        cwd: consolidateDir,
+      });
+
       const result = await host.mergeGateProvider.createReview({
         baseBranch,
         featureBranch,
         title: workflow?.name ?? 'Workflow',
         cwd: consolidateDir,
-        body: fullSummary,
+        body: prBodyReview,
       });
       console.log(`[merge] Post-fix: created/updated GitHub PR: ${result.url}`);
 

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -8,6 +8,36 @@ import type { ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
 import { cleanElectronEnv } from './process-utils.js';
 
+// ── Structured PR-authoring context ──────────────────────
+
+/** Per-task evidence carried through PR authoring. */
+export interface PrAuthoringTaskEntry {
+  taskId: string;
+  description: string;
+  status: 'completed' | 'failed' | 'skipped';
+  /** Shell command executed for command-type tasks. */
+  command?: string;
+  /** Per-task file-change summary (e.g. `git diff --stat` output). */
+  fileChangeSummary?: string;
+}
+
+/**
+ * Structured context that supplements the free-form `workflowSummary` string
+ * with machine-readable evidence for PR body authoring.
+ *
+ * Both AI-authored and deterministic-fallback paths can consume this.
+ */
+export interface PrAuthoringContext {
+  /** Workflow name (human-readable). */
+  workflowName?: string;
+  /** Workflow description from plan YAML. */
+  workflowDescription?: string;
+  /** Per-task entries with verification evidence. */
+  tasks: PrAuthoringTaskEntry[];
+  /** Visual-proof markdown block (screenshots / video walkthrough). */
+  visualProofMarkdown?: string;
+}
+
 const REQUIRED_SECTIONS = ['## Summary', '## Test Plan', '## Revert Plan'] as const;
 const DISCOURAGED_HEADINGS = ['## Testing', '## Notes'] as const;
 const DEFAULT_MAX_INLINE_PROMPT_BYTES = 64 * 1024;
@@ -116,8 +146,9 @@ export function buildMakePrPrompt(args: {
   baseBranch: string;
   featureBranch: string;
   workflowSummary: string;
+  structuredContext?: PrAuthoringContext;
 }): string {
-  return [
+  const lines = [
     `You are authoring the GitHub PR body for the branch "${args.featureBranch}" targeting "${args.baseBranch}".`,
     '',
     `Use the installed skill "invoker-make-pr" at: ${args.skillPath}`,
@@ -137,7 +168,41 @@ export function buildMakePrPrompt(args: {
     '```md',
     args.workflowSummary.trim(),
     '```',
-  ].join('\n');
+  ];
+
+  const ctx = args.structuredContext;
+  if (ctx) {
+    lines.push('');
+    lines.push('Structured workflow evidence (use to enrich your PR body):');
+    lines.push('');
+
+    const commandTasks = ctx.tasks.filter((t) => t.command && t.status === 'completed');
+    if (commandTasks.length > 0) {
+      lines.push('Executed verification commands:');
+      for (const t of commandTasks) {
+        lines.push(`- \`${t.command}\` — ${t.description} (${t.status})`);
+      }
+      lines.push('');
+    }
+
+    const withFiles = ctx.tasks.filter((t) => t.fileChangeSummary);
+    if (withFiles.length > 0) {
+      lines.push('File-change summaries:');
+      for (const t of withFiles) {
+        lines.push(`### ${t.taskId} — ${t.description}`);
+        lines.push(t.fileChangeSummary!);
+        lines.push('');
+      }
+    }
+
+    if (ctx.visualProofMarkdown) {
+      lines.push('Visual proof (include verbatim in PR body if present):');
+      lines.push(ctx.visualProofMarkdown);
+      lines.push('');
+    }
+  }
+
+  return lines.join('\n');
 }
 
 export function spawnAgentPrAuthorViaRegistry(

--- a/packages/execution-engine/src/pr-authoring.ts
+++ b/packages/execution-engine/src/pr-authoring.ts
@@ -140,6 +140,71 @@ export function resolveInstalledSkillPathForAgent(agentName: string, skillName: 
   return existsSync(join(skillDir, 'SKILL.md')) ? skillDir : null;
 }
 
+/**
+ * Resolve skill path using the agent's own `bundledSkillRoot` metadata.
+ * Falls back to `resolveInstalledSkillPathForAgent` for agents without metadata.
+ */
+export function resolveSkillPathViaAgent(agent: ExecutionAgent, skillName: string): string | null {
+  if (agent.bundledSkillRoot) {
+    const skillDir = join(agent.bundledSkillRoot, `invoker-${skillName}`);
+    if (existsSync(join(skillDir, 'SKILL.md'))) return skillDir;
+  }
+  return resolveInstalledSkillPathForAgent(agent.name, skillName);
+}
+
+/**
+ * Build a deterministic canonical PR body from structured context.
+ * Used as the no-AI escape hatch when all agent-authored attempts fail.
+ */
+export function buildCanonicalPrBody(args: {
+  title: string;
+  workflowSummary: string;
+  structuredContext?: PrAuthoringContext;
+}): string {
+  const lines: string[] = [];
+
+  // ## Summary
+  lines.push('## Summary');
+  lines.push('');
+  if (args.structuredContext?.workflowDescription) {
+    lines.push(args.structuredContext.workflowDescription);
+  } else {
+    lines.push(args.workflowSummary.trim());
+  }
+  lines.push('');
+
+  // ## Test Plan
+  lines.push('## Test Plan');
+  lines.push('');
+  const ctx = args.structuredContext;
+  const commandTasks = ctx?.tasks.filter((t) => t.command && t.status === 'completed') ?? [];
+  if (commandTasks.length > 0) {
+    for (const t of commandTasks) {
+      lines.push(`- [x] \`${t.command}\` — ${t.description}`);
+    }
+  } else {
+    lines.push('- [ ] Manual verification required');
+  }
+  lines.push('');
+
+  // ## Revert Plan
+  lines.push('## Revert Plan');
+  lines.push('');
+  lines.push('- Safe to revert? Yes');
+  lines.push('- Revert command: `git revert <sha>`');
+  lines.push('- Post-revert steps: None');
+  lines.push('- Data migration? No');
+  lines.push('');
+
+  // Visual proof (preserve verbatim if present)
+  if (ctx?.visualProofMarkdown) {
+    lines.push(ctx.visualProofMarkdown);
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd();
+}
+
 export function buildMakePrPrompt(args: {
   skillPath: string;
   title: string;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -45,8 +45,9 @@ import {
 } from './conflict-resolver.js';
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import {
+  buildCanonicalPrBody,
   buildMakePrPrompt,
-  resolveInstalledSkillPathForAgent,
+  resolveSkillPathViaAgent,
   spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
   type PrAuthoringContext,
@@ -1586,35 +1587,87 @@ export class TaskRunner {
       throw new Error('executionAgentRegistry is required for authorPrBodyWithSkill');
     }
 
-    const agentName = this.resolvePrAuthoringAgentName(args.workflowId, args.mergeNodeTaskId);
-    const skillPath = resolveInstalledSkillPathForAgent(agentName, 'make-pr');
-    if (!skillPath) {
-      throw new Error(
-        `Required bundled skill "invoker-make-pr" is not installed for agent "${agentName}".`,
-      );
+    // Build the ordered agent fallback chain:
+    // 1. Preferred agent from workflow tasks
+    // 2. Remaining PR-capable agents in stable registry order
+    const preferredName = this.resolvePrAuthoringAgentName(args.workflowId, args.mergeNodeTaskId);
+    const prCapableAgents = this.executionAgentRegistry.listWithCapability('make-pr');
+    const orderedAgents = this.buildAgentFallbackOrder(preferredName, prCapableAgents);
+
+    const errors: string[] = [];
+    for (const agent of orderedAgents) {
+      const skillPath = resolveSkillPathViaAgent(agent, 'make-pr');
+      if (!skillPath) {
+        errors.push(`${agent.name}: skill "invoker-make-pr" not installed`);
+        continue;
+      }
+
+      const driver = this.executionAgentRegistry.getSessionDriver(agent.name);
+      const prompt = buildMakePrPrompt({
+        skillPath,
+        title: args.title,
+        baseBranch: args.baseBranch,
+        featureBranch: args.featureBranch,
+        workflowSummary: args.workflowSummary,
+        structuredContext: args.structuredContext,
+      });
+
+      try {
+        const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
+        const validationErrors = validateCanonicalPrBody(result.body);
+        if (validationErrors.length > 0) {
+          errors.push(
+            `${agent.name}: invalid PR body — ${validationErrors.join('; ')}`,
+          );
+          continue;
+        }
+        return { body: result.body, sessionId: result.sessionId, agentName: agent.name };
+      } catch (err) {
+        errors.push(
+          `${agent.name}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
-    const agent = this.executionAgentRegistry.getOrThrow(agentName);
-    const driver = this.executionAgentRegistry.getSessionDriver(agentName);
-    const prompt = buildMakePrPrompt({
-      skillPath,
+    // No AI agent succeeded — emit deterministic canonical PR body
+    this.logger.warn(
+      `[pr-authoring] All AI agents failed for PR authoring, using canonical fallback. Errors: ${errors.join(' | ')}`,
+    );
+    const canonicalBody = buildCanonicalPrBody({
       title: args.title,
-      baseBranch: args.baseBranch,
-      featureBranch: args.featureBranch,
       workflowSummary: args.workflowSummary,
       structuredContext: args.structuredContext,
     });
-    const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
-    const validationErrors = validateCanonicalPrBody(result.body);
-    if (validationErrors.length > 0) {
-      throw new Error(
-        [
-          `PR body authored via invoker-make-pr is invalid for agent "${agentName}".`,
-          ...validationErrors.map((error) => `- ${error}`),
-        ].join('\n'),
-      );
+    return { body: canonicalBody, sessionId: 'canonical-fallback', agentName: 'canonical' };
+  }
+
+  /**
+   * Build the ordered fallback list: preferred agent first, then remaining
+   * PR-capable agents in stable registry order, deduplicated.
+   */
+  private buildAgentFallbackOrder(
+    preferredName: string,
+    prCapableAgents: import('./agent.js').ExecutionAgent[],
+  ): import('./agent.js').ExecutionAgent[] {
+    const seen = new Set<string>();
+    const ordered: import('./agent.js').ExecutionAgent[] = [];
+
+    // Preferred agent first (may or may not be in prCapableAgents)
+    const preferred = this.executionAgentRegistry?.get(preferredName);
+    if (preferred) {
+      seen.add(preferred.name);
+      ordered.push(preferred);
     }
-    return { body: result.body, sessionId: result.sessionId, agentName };
+
+    // Remaining PR-capable agents in registration order
+    for (const agent of prCapableAgents) {
+      if (!seen.has(agent.name)) {
+        seen.add(agent.name);
+        ordered.push(agent);
+      }
+    }
+
+    return ordered;
   }
 
   private resolvePrAuthoringAgentName(workflowId?: string, mergeNodeTaskId?: string): string {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -49,6 +49,7 @@ import {
   resolveInstalledSkillPathForAgent,
   spawnAgentPrAuthorViaRegistry,
   validateCanonicalPrBody,
+  type PrAuthoringContext,
 } from './pr-authoring.js';
 
 /** Keeps `lastHeartbeatAt` fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). Matches BaseExecutor default heartbeat cadence. */
@@ -1578,6 +1579,7 @@ export class TaskRunner {
     baseBranch: string;
     featureBranch: string;
     workflowSummary: string;
+    structuredContext?: PrAuthoringContext;
     cwd: string;
   }): Promise<{ body: string; sessionId: string; agentName: string }> {
     if (!this.executionAgentRegistry) {
@@ -1600,6 +1602,7 @@ export class TaskRunner {
       baseBranch: args.baseBranch,
       featureBranch: args.featureBranch,
       workflowSummary: args.workflowSummary,
+      structuredContext: args.structuredContext,
     });
     const result = await spawnAgentPrAuthorViaRegistry(prompt, args.cwd, agent, driver);
     const validationErrors = validateCanonicalPrBody(result.body);

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1584,7 +1584,15 @@ export class TaskRunner {
     cwd: string;
   }): Promise<{ body: string; sessionId: string; agentName: string }> {
     if (!this.executionAgentRegistry) {
-      throw new Error('executionAgentRegistry is required for authorPrBodyWithSkill');
+      this.logger.warn(
+        '[pr-authoring] executionAgentRegistry missing, using canonical fallback PR body.',
+      );
+      const canonicalBody = buildCanonicalPrBody({
+        title: args.title,
+        workflowSummary: args.workflowSummary,
+        structuredContext: args.structuredContext,
+      });
+      return { body: canonicalBody, sessionId: 'canonical-fallback', agentName: 'canonical' };
     }
 
     // Build the ordered agent fallback chain:


### PR DESCRIPTION
## Summary
Goal:
- Route normal PR publication and `external_review` PR creation through one shared PR-authoring pipeline with registry-based fallback.

Motivation:
- The current `external_review` path can bypass `make-pr` skill authoring and send merge-summary text directly to GitHub.
- UI-test-heavy workflows need richer PR bodies that preserve architecture/code-flow sections, executed UI verification commands, and visual-proof markdown when it exists.

Architecture:
```mermaid
flowchart LR
  MergeRunner[merge-runner PR creation paths]
  SharedAuthor[shared PR authoring entrypoint]
  TaskRunner[TaskRunner authorPrBodyWithSkill]
  AgentRegistry[execution agent registry]
  Fallback[deterministic canonical fallback]
  ReviewProvider[GitHub review provider]
  MergeRunner --> SharedAuthor
  SharedAuthor --> TaskRunner
  TaskRunner --> AgentRegistry
  TaskRunner --> Fallback
  SharedAuthor --> ReviewProvider
```

Code flow:
```mermaid
sequenceDiagram
  participant MR as merge-runner
  participant TS as task-runner
  participant AR as agent registry
  participant AI as PR-capable agent
  participant FB as deterministic fallback
  MR->>TS: authorPrBodyWithSkill(context)
  TS->>AR: list PR-capable agents
  AR-->>TS: preferred + fallback order
  TS->>AI: run invoker-make-pr
  AI-->>TS: authored PR body or failure
  TS->>FB: build canonical body when needed
  TS-->>MR: validated PR body
```

Alternative considerations:
- Keep separate authoring logic for `pull_request` and `external_review`.
- Fail PR creation outright when the preferred AI author is unavailable.

Why this design is better:
- A single pipeline keeps PR-body behavior consistent across merge modes and provides deterministic no-AI behavior instead of silent degradation.

Publication note:
- This targets Invoker itself; after the commit stack is ready, publish/update stacked PRs with `mergify stack push`.


---
PR authoring fallback Step 2: shared authoring pipeline — 5 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1778265819840-6/enrich-pr-authoring-context | Goal:
- Add structured PR-authoring context for workflow summaries, verification commands, and visual proof.
Motivation:
- The shared authoring pipeline needs richer inputs than a single summary string to preserve UI-test evidence and visual proof.
Alternative considerations:
- Keep passing only one free-form workflow summary string into PR authoring.
Implementation details:
- Introduce structured context that carries workflow/task metadata, executed verification commands, and optional visual-proof markdown.
Layer: domain
Feature state: active
Files:
- packages/execution-engine/src/pr-authoring.ts
- packages/execution-engine/src/task-runner.ts
Change types:
- modify
Acceptance criteria:
- PR authoring can consume workflow/task metadata, executed verification commands, and optional visual-proof markdown as structured inputs.
 | completed |
| wf-1778265819840-6/add-multi-agent-pr-authoring-fallback | Goal:
- Implement preferred-agent selection, registry fallback, and deterministic canonical PR-body fallback.
Motivation:
- PR creation should not fail or silently degrade just because one AI author is unavailable.
Alternative considerations:
- Attempt only the preferred agent and abort PR authoring when it fails.
Implementation details:
- Resolve the preferred workflow agent first, then fall back across remaining registered PR-capable agents, then emit a canonical no-AI body.
Layer: api
Feature state: active
Files:
- packages/execution-engine/src/task-runner.ts
- packages/execution-engine/src/pr-authoring.ts
- packages/execution-engine/src/__tests__/task-runner.test.ts
Change types:
- modify
Acceptance criteria:
- Preferred workflow agent is attempted first.
- Other registered `make-pr` agents are attempted deterministically on failure.
- A no-AI fallback still emits a canonical PR body with `Summary`, `Test Plan`, and `Revert Plan`.
 | completed |
| wf-1778265819840-6/route-external-review-through-shared-authoring | Goal:
- Remove direct-summary PR creation in `external_review` and reuse the shared authoring pipeline everywhere.
Motivation:
- `external_review` currently risks bypassing `make-pr` authoring and dropping architecture or UI-test detail.
Alternative considerations:
- Keep the merge path and post-fix path on separate authoring implementations.
Implementation details:
- Update merge-runner PR creation callsites so both `external_review` branches call the shared authoring helper before review-provider creation.
Layer: api
Feature state: active
Files:
- packages/execution-engine/src/merge-runner.ts
- packages/execution-engine/src/__tests__/task-runner.test.ts
Change types:
- modify
Acceptance criteria:
- `external_review` PR creation and post-fix publication both call the shared PR-authoring path before `createReview`.
 | completed |
| wf-1778265819840-6/verify-shared-pr-authoring-pipeline | Goal:
- Run focused execution-engine regressions for PR authoring and `external_review` routing.
Motivation:
- The shared authoring pipeline should be proven before broader stack hardening lands.
Alternative considerations:
- Rely only on the final full-suite gate for feedback.
Implementation details:
- Execute the focused task-runner and merge-gate-provider regression lane after the routing changes land.
Layer: app_regression
Feature state: active
Files:
- packages/execution-engine/src/__tests__/task-runner.test.ts
- packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
Change types:
- none
Acceptance criteria:
- Focused execution-engine tests pass for shared PR authoring and review-provider routing.
 | completed (passed) |
| wf-1778265819840-6/final-regression | Goal:
- Run the full repository test suite as the terminal regression gate.
Motivation:
- Shared PR-authoring touches core execution-engine merge behavior and needs repo-wide confirmation.
Alternative considerations:
- Stop after focused execution-engine tests only.
Implementation details:
- Run `pnpm run test:all` after context enrichment, fallback logic, and merge-runner routing land.
Layer: app_regression
Feature state: active
Files:
- none
Change types:
- none
Acceptance criteria:
- `pnpm run test:all` exits 0 after the shared PR-authoring pipeline lands.
 | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1778265819840-6/enrich-pr-authoring-context — Goal:
- Add structured PR-authoring context for workflow summaries, verification commands, and visual proof.
Motivation:
- The shared authoring pipeline needs richer inputs than a single summary string to preserve UI-test evidence and visual proof.
Alternative considerations:
- Keep passing only one free-form workflow summary string into PR authoring.
Implementation details:
- Introduce structured context that carries workflow/task metadata, executed verification commands, and optional visual-proof markdown.
Layer: domain
Feature state: active
Files:
- packages/execution-engine/src/pr-authoring.ts
- packages/execution-engine/src/task-runner.ts
Change types:
- modify
Acceptance criteria:
- PR authoring can consume workflow/task metadata, executed verification commands, and optional visual-proof markdown as structured inputs.

.../src/__tests__/agent-registry.test.ts           | 87 +++++++++++++++++++++-
 packages/execution-engine/src/agent-registry.ts    | 23 ++++++
 packages/execution-engine/src/agent.ts             | 15 ++++
 .../src/agents/claude-execution-agent.ts           |  3 +
 .../src/agents/codex-execution-agent.ts            |  5 ++
 packages/execution-engine/src/merge-runner.ts      | 73 ++++++++++++++++++
 packages/execution-engine/src/pr-authoring.ts      | 69 ++++++++++++++++-
 packages/execution-engine/src/task-runner.ts       |  3 +
 8 files changed, 273 insertions(+), 5 deletions(-)

### wf-1778265819840-6/add-multi-agent-pr-authoring-fallback — Goal:
- Implement preferred-agent selection, registry fallback, and deterministic canonical PR-body fallback.
Motivation:
- PR creation should not fail or silently degrade just because one AI author is unavailable.
Alternative considerations:
- Attempt only the preferred agent and abort PR authoring when it fails.
Implementation details:
- Resolve the preferred workflow agent first, then fall back across remaining registered PR-capable agents, then emit a canonical no-AI body.
Layer: api
Feature state: active
Files:
- packages/execution-engine/src/task-runner.ts
- packages/execution-engine/src/pr-authoring.ts
- packages/execution-engine/src/__tests__/task-runner.test.ts
Change types:
- modify
Acceptance criteria:
- Preferred workflow agent is attempted first.
- Other registered `make-pr` agents are attempted deterministically on failure.
- A no-AI fallback still emits a canonical PR body with `Summary`, `Test Plan`, and `Revert Plan`.

.../src/__tests__/agent-registry.test.ts           |  87 ++++++-
 .../src/__tests__/pr-authoring.test.ts             | 168 +++++++++++++
 .../src/__tests__/task-runner.test.ts              | 261 +++++++++++++++++++--
 packages/execution-engine/src/agent-registry.ts    |  23 ++
 packages/execution-engine/src/agent.ts             |  15 ++
 .../src/agents/claude-execution-agent.ts           |   3 +
 .../src/agents/codex-execution-agent.ts            |   5 +
 packages/execution-engine/src/merge-runner.ts      |  73 ++++++
 packages/execution-engine/src/pr-authoring.ts      | 134 ++++++++++-
 packages/execution-engine/src/task-runner.ts       | 102 ++++++--
 10 files changed, 818 insertions(+), 53 deletions(-)

### wf-1778265819840-6/route-external-review-through-shared-authoring — Goal:
- Remove direct-summary PR creation in `external_review` and reuse the shared authoring pipeline everywhere.
Motivation:
- `external_review` currently risks bypassing `make-pr` authoring and dropping architecture or UI-test detail.
Alternative considerations:
- Keep the merge path and post-fix path on separate authoring implementations.
Implementation details:
- Update merge-runner PR creation callsites so both `external_review` branches call the shared authoring helper before review-provider creation.
Layer: api
Feature state: active
Files:
- packages/execution-engine/src/merge-runner.ts
- packages/execution-engine/src/__tests__/task-runner.test.ts
Change types:
- modify
Acceptance criteria:
- `external_review` PR creation and post-fix publication both call the shared PR-authoring path before `createReview`.

.../src/__tests__/agent-registry.test.ts           |  87 +++++-
 .../src/__tests__/pr-authoring.test.ts             | 168 +++++++++++
 .../src/__tests__/task-runner.test.ts              | 334 +++++++++++++++++++--
 packages/execution-engine/src/agent-registry.ts    |  23 ++
 packages/execution-engine/src/agent.ts             |  15 +
 .../src/agents/claude-execution-agent.ts           |   3 +
 .../src/agents/codex-execution-agent.ts            |   5 +
 packages/execution-engine/src/merge-runner.ts      | 109 ++++++-
 packages/execution-engine/src/pr-authoring.ts      | 134 ++++++++-
 packages/execution-engine/src/task-runner.ts       | 102 +++++--
 10 files changed, 921 insertions(+), 59 deletions(-)

### wf-1778265819840-6/verify-shared-pr-authoring-pipeline — Goal:
- Run focused execution-engine regressions for PR authoring and `external_review` routing.
Motivation:
- The shared authoring pipeline should be proven before broader stack hardening lands.
Alternative considerations:
- Rely only on the final full-suite gate for feedback.
Implementation details:
- Execute the focused task-runner and merge-gate-provider regression lane after the routing changes land.
Layer: app_regression
Feature state: active
Files:
- packages/execution-engine/src/__tests__/task-runner.test.ts
- packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
Change types:
- none
Acceptance criteria:
- Focused execution-engine tests pass for shared PR authoring and review-provider routing.


### wf-1778265819840-6/final-regression — Goal:
- Run the full repository test suite as the terminal regression gate.
Motivation:
- Shared PR-authoring touches core execution-engine merge behavior and needs repo-wide confirmation.
Alternative considerations:
- Stop after focused execution-engine tests only.
Implementation details:
- Run `pnpm run test:all` after context enrichment, fallback logic, and merge-runner routing land.
Layer: app_regression
Feature state: active
Files:
- none
Change types:
- none
Acceptance criteria:
- `pnpm run test:all` exits 0 after the shared PR-authoring pipeline lands.


</details>
