### PR TITLE
Plan stale fix-intent cancellation and SSH metadata hardening workflow

### DIFF
--- a/plans/fix-intent-cancellation-stale-ssh-metadata.yaml
+++ b/plans/fix-intent-cancellation-stale-ssh-metadata.yaml
@@ -1,0 +1,247 @@
+name: "Harden fix intent cancellation and stale SSH metadata writes"
+description: |
+  Hardens the final-regression failure path proven by the shared repro: a
+  superseded `invoker:fix-with-agent` mutation can keep running its async side
+  effect after `recreate-task`, and a stale SSH startup failure can write old
+  `workspacePath` / `branch` metadata back onto the live task row after the
+  selected attempt has already advanced.
+
+  The workflow fixes both races as a linked lineage/cancellation problem rather
+  than a one-off recreate patch. It also preserves concrete startup and
+  synthetic shutdown diagnostics in durable task output so later investigation
+  does not collapse to `Application quit`.
+
+  Publication intent: publish intermediate/helper branches to the fork and
+  target the final PR gate at the parent repo.
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: https://github.com/Neko-Catpital-Labs/Invoker
+intermediateRepoUrl: https://github.com/EdbertChan/Invoker
+baseBranch: master
+featureBranch: plan/fix-intent-cancellation-stale-ssh-metadata
+
+tasks:
+  - id: harden-workflow-mutation-cancellation
+    description: |
+      Goal:
+      Make workflow-mutation invalidation cancellation-aware so recreate/delete fences stop superseded async fix work instead of only marking the persisted intent failed.
+      Motivation:
+      The shared repro proved the old `invoker:fix-with-agent` mutation still runs its side effect after `invoker:recreate-task` completes, which leaves stale writes possible even when the queue correctly transfers authority.
+      Alternative considerations:
+      Special-casing only `recreate-task` would leave the same late-write bug class on other hard-preempt fences such as recreate-with-rebase and delete workflows.
+      Implementation details:
+      Extend the workflow-mutation dispatch contract to include cancellation context, propagate invalidation through PersistedWorkflowMutationCoordinator, and preserve existing queue semantics for non-preempted mutations.
+      Layer: app_bridge
+      Feature state: active
+      Files:
+      - packages/app/src/persisted-workflow-mutation-coordinator.ts
+      - packages/app/src/workflow-mutation-coordinator.ts
+      - packages/app/src/workflow-preemption.ts
+      - packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+      Change types:
+      - modify
+      Acceptance criteria:
+      - Coordinator coverage proves superseded fix mutations are aborted when recreate/delete fences preempt them.
+    prompt: |
+      Goal:
+      Make workflow-mutation invalidation cancellation-aware so recreate/delete fences stop superseded async fix work instead of only marking the persisted intent failed.
+      Motivation:
+      The shared repro proved the old `invoker:fix-with-agent` mutation still runs its side effect after `invoker:recreate-task` completes, which leaves stale writes possible even when the queue correctly transfers authority.
+      Alternative considerations:
+      Special-casing only `recreate-task` would leave the same late-write bug class on other hard-preempt fences such as recreate-with-rebase and delete workflows.
+      Implementation details:
+      Modify packages/app/src/persisted-workflow-mutation-coordinator.ts, packages/app/src/workflow-mutation-coordinator.ts, packages/app/src/workflow-preemption.ts, and related tests. Extend the internal dispatch contract so running mutations receive cancellation context with an AbortSignal plus identifying metadata. When the coordinator invalidates a running fix-like mutation because a recreate/delete-class fence takes authority, abort the running context immediately while keeping the persisted intent failure reason and queue ordering intact for non-preempted mutations. Add targeted tests proving recreate/delete fences abort superseded fix work and do not regress non-preempted queue behavior.
+      Acceptance criteria:
+      - Ensure coordinator tests prove superseded fix mutations are aborted when recreate/delete fences preempt them.
+    dependencies: []
+
+  - id: guard-fix-with-agent-late-writes
+    description: |
+      Goal:
+      Make fix-with-agent and conflict-resolution flows discard late results once the task lineage or cancellation state is stale.
+      Motivation:
+      Even with coordinator aborts, correctness still requires every late fix result to no-op when the task has moved to a newer selected attempt or generation.
+      Alternative considerations:
+      Relying on best-effort process termination alone is insufficient because remote or agent work can still return after invalidation.
+      Implementation details:
+      Capture the starting lineage for fix/resolve flows, add explicit stale/aborted checkpoints around async fix and persistence boundaries, and prevent awaiting-approval or revert side effects from writing onto a newer lineage.
+      Layer: owner_delegation
+      Feature state: active
+      Files:
+      - packages/app/src/workflow-actions.ts
+      - packages/app/src/main.ts
+      - packages/workflow-core/src/orchestrator.ts
+      - packages/app/src/__tests__/workflow-actions.test.ts
+      Change types:
+      - modify
+      Acceptance criteria:
+      - Stale or aborted fix results do not update task output, fix approval state, branch metadata, or conflict-resolution cleanup on a newer attempt lineage.
+    prompt: |
+      Goal:
+      Make fix-with-agent and conflict-resolution flows discard late results once the task lineage or cancellation state is stale.
+      Motivation:
+      Even with coordinator aborts, correctness still requires every late fix result to no-op when the task has moved to a newer selected attempt or generation.
+      Alternative considerations:
+      Relying on best-effort process termination alone is insufficient because remote or agent work can still return after invalidation.
+      Implementation details:
+      Modify packages/app/src/workflow-actions.ts, packages/app/src/main.ts, packages/workflow-core/src/orchestrator.ts, and related tests. At mutation entry, capture taskId, selectedAttemptId, and execution generation. Add lineage/cancellation checkpoints before conflict-resolution start, after async fix returns, before persistence updates, before awaiting-approval transitions, and before revert cleanup. If the mutation is aborted or the current task lineage no longer matches the starting lineage, exit without changing task state, output, agent-session metadata, branch/workspace metadata, or approval state. Cover both the normal fix-with-agent path and representative resolve-conflict cleanup paths in tests.
+      Acceptance criteria:
+      - Ensure stale or aborted fix results do not update task output, fix approval state, branch metadata, or conflict-resolution cleanup on a newer attempt lineage.
+    dependencies: [harden-workflow-mutation-cancellation]
+
+  - id: guard-stale-startup-failure-metadata
+    description: |
+      Goal:
+      Prevent stale SSH startup failures from reattaching old workspace and branch metadata to a task after the selected attempt has advanced.
+      Motivation:
+      The repro proved TaskRunner can write old `workspacePath` / `branch` metadata and a failed response from attempt-1 after the task already moved to attempt-2.
+      Alternative considerations:
+      Keeping the stale metadata write and only cleaning it later would still allow the next SSH launch to collide on the wrong worktree owner path.
+      Implementation details:
+      Make executor startup-failure persistence attempt-aware, scope stale diagnostics away from the live task row, and add coverage for stale failure-response suppression on newer lineages.
+      Layer: owner_delegation
+      Feature state: active
+      Files:
+      - packages/execution-engine/src/task-runner.ts
+      - packages/execution-engine/src/__tests__/task-runner.test.ts
+      - packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+      Change types:
+      - modify
+      Acceptance criteria:
+      - Stale SSH startup failures do not overwrite live task execution metadata or emit a failed response against a newer selected attempt.
+    prompt: |
+      Goal:
+      Prevent stale SSH startup failures from reattaching old workspace and branch metadata to a task after the selected attempt has advanced.
+      Motivation:
+      The repro proved TaskRunner can write old `workspacePath` / `branch` metadata and a failed response from attempt-1 after the task already moved to attempt-2.
+      Alternative considerations:
+      Keeping the stale metadata write and only cleaning it later would still allow the next SSH launch to collide on the wrong worktree owner path.
+      Implementation details:
+      Modify packages/execution-engine/src/task-runner.ts and the adjacent tests. Add a current-lineage guard around executor startup-failure persistence so stale launches cannot write old branch/workspace metadata or emit a failed worker response against the newer selected attempt. Preserve useful diagnostics for the stale launch through an append-only or attempt-scoped path rather than mutating the live task row. Update or extend targeted task-runner and SSH repro coverage to prove the stale metadata write is blocked.
+      Acceptance criteria:
+      - Ensure stale SSH startup failures do not overwrite live task execution metadata or emit a failed response against a newer selected attempt.
+    dependencies: [guard-fix-with-agent-late-writes]
+
+  - id: persist-concrete-failure-diagnostics
+    description: |
+      Goal:
+      Preserve concrete startup and synthetic shutdown failure details in durable task output instead of collapsing later inspection to `Application quit`.
+      Motivation:
+      The original final-regression investigation lost the actual failing test/startup details because durable output did not retain the concrete failure context.
+      Alternative considerations:
+      Leaving diagnostics only in transient executor buffers would keep the same observability gap even after the lineage bugs are fixed.
+      Implementation details:
+      Route startup-failure and owner-shutdown diagnostic tails through the durable output append path used by the UI and API, while keeping task status semantics unchanged.
+      Layer: app_bridge
+      Feature state: active
+      Layer exception: allowed
+      Layer exception rationale:
+      This observability hardening intentionally depends on the owner-delegation stale-lineage guard so durable diagnostics reflect the post-fix failure path rather than the pre-fix stale metadata write behavior.
+      Files:
+      - packages/app/src/main.ts
+      - packages/data-store/src/sqlite-adapter.ts
+      - packages/app/src/__tests__/main*.test.ts
+      Change types:
+      - modify
+      Acceptance criteria:
+      - Durable task output retains concrete startup/shutdown diagnostics alongside the coarse terminal error state.
+    prompt: |
+      Goal:
+      Preserve concrete startup and synthetic shutdown failure details in durable task output instead of collapsing later inspection to `Application quit`.
+      Motivation:
+      The original final-regression investigation lost the actual failing test/startup details because durable output did not retain the concrete failure context.
+      Alternative considerations:
+      Leaving diagnostics only in transient executor buffers would keep the same observability gap even after the lineage bugs are fixed.
+      Implementation details:
+      Modify packages/app/src/main.ts, packages/data-store/src/sqlite-adapter.ts, and the closest relevant tests. Ensure synthetic owner-shutdown failures and executor startup failures append a compact diagnostic block to the durable task output path used for persisted retrieval, including recent output tail or concrete startup stderr/message where available. Keep the task status model unchanged; this task is an observability hardening change, not a new lifecycle state.
+    dependencies: [guard-stale-startup-failure-metadata]
+
+  - id: verify-shared-repro-fixed
+    description: |
+      Goal:
+      Re-run the shared repro in fixed mode to prove the specific stale-fix and stale-SSH race conditions are closed end to end.
+      Motivation:
+      Full-suite green alone would not prove the exact races demonstrated by the proof artifacts are gone.
+      Alternative considerations:
+      Relying only on newly added broad tests without the shared repro would weaken continuity with the investigation evidence already captured.
+      Implementation details:
+      Execute the shared repro in fixed mode after all implementation tasks complete.
+      Layer: app_regression
+      Feature state: active
+      Files:
+      - scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh
+      Change types:
+      - none
+      Acceptance criteria:
+      - Shared repro exits 0 with `--expect fixed`.
+    command: "bash scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh --expect fixed"
+    dependencies: [harden-workflow-mutation-cancellation, guard-fix-with-agent-late-writes, guard-stale-startup-failure-metadata, persist-concrete-failure-diagnostics]
+
+  - id: verify-app-coordinator-regression
+    description: |
+      Goal:
+      Re-run the focused app-layer coordinator regression covering workflow-mutation invalidation after the fix lands.
+      Motivation:
+      The shared repro proves the end-to-end bug class, but the app-layer coordinator test provides tighter regression coverage around the invalidation path being hardened.
+      Alternative considerations:
+      Relying only on the shared repro would make it harder to localize future regressions to the coordinator layer.
+      Implementation details:
+      Run the focused app package test that covers persisted workflow-mutation invalidation after the implementation tasks and shared repro succeed.
+      Layer: app_regression
+      Feature state: active
+      Files:
+      - packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+      Change types:
+      - none
+      Acceptance criteria:
+      - Focused app coordinator regression exits 0.
+    command: "cd packages/app && pnpm test -- src/__tests__/persisted-workflow-mutation-coordinator.test.ts"
+    executorType: ssh
+    remoteTargetId: remote_digital_ocean_1
+    dependencies: [verify-shared-repro-fixed]
+
+  - id: verify-execution-engine-ssh-repro
+    description: |
+      Goal:
+      Re-run the focused execution-engine SSH worktree metadata regression after the fix lands.
+      Motivation:
+      The shared repro proves the end-to-end bug class, but the execution-engine repro test provides tighter regression coverage around the TaskRunner and SSH metadata path being hardened.
+      Alternative considerations:
+      Relying only on the shared repro would make it harder to localize future regressions to the execution-engine lineage guard.
+      Implementation details:
+      Run the focused execution-engine package test that covers the SSH worktree metadata repro after the implementation tasks and shared repro succeed.
+      Layer: app_regression
+      Feature state: active
+      Files:
+      - packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+      Change types:
+      - none
+      Acceptance criteria:
+      - Focused execution-engine SSH metadata repro exits 0.
+    command: "cd packages/execution-engine && pnpm test -- src/__tests__/ssh-worktree-metadata-repro.test.ts"
+    executorType: ssh
+    remoteTargetId: remote_digital_ocean_1
+    dependencies: [verify-shared-repro-fixed]
+
+  - id: final-regression
+    description: |
+      Goal:
+      Run the full repository test suite as the terminal regression gate after the hardening and focused repro checks land.
+      Motivation:
+      This workflow is changing coordinator, app, persistence, and execution-engine behavior, so the submitted plan must end with the repo-wide gate rather than only package-local verification.
+      Alternative considerations:
+      Stopping at focused regression tests would leave cross-package integration and final-regression behavior unverified.
+      Implementation details:
+      Run the repository-wide `pnpm run test:all` suite after every earlier implementation and focused verification task has completed successfully.
+      Layer: e2e_regression
+      Feature state: active
+      Files:
+      - none
+      Change types:
+      - none
+      Acceptance criteria:
+      - `pnpm run test:all` exits 0 after all earlier workflow tasks complete.
+    command: "pnpm run test:all"
+    executorType: ssh
+    remoteTargetId: remote_digital_ocean_1
+    dependencies: [harden-workflow-mutation-cancellation, guard-fix-with-agent-late-writes, guard-stale-startup-failure-metadata, persist-concrete-failure-diagnostics, verify-shared-repro-fixed, verify-app-coordinator-regression, verify-execution-engine-ssh-repro]

--- a/scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh
+++ b/scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh
@@ -1,0 +1,335 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION=""
+KEEP_ARTIFACTS=0
+TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-180}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh --expect bug|fixed [--keep-artifacts]
+
+What it proves:
+  1. A running `invoker:fix-with-agent` workflow mutation can be invalidated by
+     `invoker:recreate-task`, yet the underlying async fix side effect still runs afterward.
+  2. A stale SSH executor startup failure can write old `workspacePath` / `branch`
+     metadata back onto the task row even after `selectedAttemptId` has moved to a
+     fresh attempt.
+  3. The existing SSH worktree collision proof still reproduces the
+     `already used by worktree at ...` git failure signature.
+
+Exit codes:
+  0  observed behavior matches --expect
+  1  observed behavior does not match --expect
+  2  repro setup or assertion was invalid / unexpected
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --keep-artifacts)
+      KEEP_ARTIFACTS=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  echo "repro: --expect requires bug|fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "repro: missing required command: $1" >&2
+    exit 2
+  }
+}
+
+require_cmd pnpm
+require_cmd timeout
+require_cmd git
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-fix-intent.XXXXXX")"
+HELPER_TEST="$(mktemp "$ROOT_DIR/packages/app/src/__tests__/tmp-repro-fix-intent.XXXXXX.test.ts")"
+HELPER_LOG="$TMP_DIR/helper-vitest.log"
+SSH_REPRO_LOG="$TMP_DIR/ssh-worktree-vitest.log"
+PROOF_FIX_INTENT="$TMP_DIR/proof-fix-intent.json"
+PROOF_STALE_METADATA="$TMP_DIR/proof-stale-startup-metadata.json"
+
+cleanup() {
+  rm -f "$HELPER_TEST" 2>/dev/null || true
+  if [[ "$KEEP_ARTIFACTS" != "1" ]]; then
+    rm -rf "$TMP_DIR" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+cat > "$HELPER_TEST" <<EOF
+import { describe, expect, it, vi } from 'vitest';
+import { existsSync, writeFileSync } from 'node:fs';
+import { setTimeout as delay } from 'node:timers/promises';
+import { SQLiteAdapter } from '${ROOT_DIR}/packages/data-store/src/sqlite-adapter.ts';
+import { PersistedWorkflowMutationCoordinator } from '${ROOT_DIR}/packages/app/src/persisted-workflow-mutation-coordinator.ts';
+import { TaskRunner } from '${ROOT_DIR}/packages/execution-engine/src/task-runner.ts';
+
+async function waitFor(check: () => boolean, label: string, timeoutMs = 2000): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (check()) return;
+    await delay(10);
+  }
+  throw new Error(\`Timed out waiting for \${label}\`);
+}
+
+describe('fix intent invalidation + stale startup metadata repro', () => {
+  it('proves invalidating a running fix intent does not cancel the underlying side effect', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const order: string[] = [];
+    let recreateResolvedAt = 0;
+    let sideEffectAt = 0;
+
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        if (channel === 'invoker:fix-with-agent') {
+          order.push('fix:start');
+          await delay(120);
+          sideEffectAt = Date.now();
+          order.push('fix:side-effect');
+          writeFileSync('${PROOF_FIX_INTENT}', JSON.stringify({
+            order,
+            recreateResolvedAt,
+            sideEffectAt,
+            args,
+          }, null, 2));
+          return;
+        }
+        if (channel === 'invoker:recreate-task') {
+          order.push('recreate');
+          recreateResolvedAt = Date.now();
+          return;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', 'claude'],
+    );
+    await waitFor(
+      () => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1,
+      'running fix intent',
+    );
+
+    const recreateTask = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:recreate-task',
+      ['wf-1/target-task'],
+    );
+    await recreateTask;
+    await expect(olderRunning).rejects.toThrow(/superseded by recreate intent/i);
+
+    await waitFor(
+      () => existsSync('${PROOF_FIX_INTENT}'),
+      'post-invalidation fix side effect',
+    );
+
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intents.find((intent) => intent.id === 1)?.status).toBe('failed');
+    expect(intents.find((intent) => intent.id === 2)?.status).toBe('completed');
+    expect(order).toEqual(['fix:start', 'recreate', 'fix:side-effect']);
+    expect(sideEffectAt).toBeGreaterThan(recreateResolvedAt);
+  });
+
+  it('proves stale SSH startup-failure metadata is written back after selectedAttemptId moves forward', async () => {
+    const ownerPath = '/home/invoker/.invoker/worktrees/f19efd3eabc6/experiment-wf-1-task-old-attempt';
+    const oldBranch = 'experiment/wf-1/task/old-attempt';
+
+    const task: any = {
+      id: 'wf-1/task',
+      description: 'repro task',
+      status: 'running',
+      dependencies: [],
+      createdAt: new Date(),
+      config: {
+        command: 'pnpm test',
+        executorType: 'ssh',
+      },
+      execution: {
+        generation: 7,
+        selectedAttemptId: 'attempt-1',
+      },
+    };
+
+    let rejectStart: ((error: unknown) => void) | undefined;
+    const updateCalls: Array<{ id: string; changes: any }> = [];
+    const responses: any[] = [];
+
+    const failingExecutor = {
+      type: 'ssh',
+      start: vi.fn().mockImplementation(() => new Promise((_resolve, reject) => {
+        rejectStart = reject;
+      })),
+      onComplete: vi.fn(),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+
+    const runner = new TaskRunner({
+      orchestrator: {
+        getTask: () => task,
+        getAllTasks: () => [task],
+        handleWorkerResponse: (response: any) => {
+          responses.push(response);
+          return [];
+        },
+      } as any,
+      persistence: {
+        updateTask: (id: string, changes: any) => {
+          updateCalls.push({ id, changes });
+        },
+        appendTaskOutput: vi.fn(),
+        updateAttempt: vi.fn(),
+      } as any,
+      executorRegistry: {
+        getDefault: () => failingExecutor,
+        get: (type: string) => type === 'ssh' ? failingExecutor : undefined,
+        getAll: () => [failingExecutor],
+        register: vi.fn(),
+      } as any,
+      cwd: '/tmp',
+    });
+
+    const executePromise = runner.executeTask(task);
+    await waitFor(() => typeof rejectStart === 'function', 'executor.start invocation');
+
+    task.execution.selectedAttemptId = 'attempt-2';
+    task.status = 'pending';
+
+    rejectStart!(Object.assign(
+      new Error(
+        "SSH remote script failed (exit=128)\\n" +
+          "STDERR:\\n" +
+          "fatal: 'experiment/wf-1/task/old-attempt' is already used by worktree at '" + ownerPath + "'\\n",
+      ),
+      {
+        workspacePath: ownerPath,
+        branch: oldBranch,
+      },
+    ));
+
+    await executePromise;
+
+    const staleMetadataWrite = updateCalls.find((call) =>
+      call.id === 'wf-1/task'
+      && call.changes?.execution?.workspacePath === ownerPath
+      && call.changes?.execution?.branch === oldBranch,
+    );
+
+    writeFileSync('${PROOF_STALE_METADATA}', JSON.stringify({
+      selectedAttemptIdAfterRecreate: task.execution.selectedAttemptId,
+      taskStatusAfterRecreate: task.status,
+      staleMetadataWrite,
+      failureResponse: responses[0],
+    }, null, 2));
+
+    expect(task.execution.selectedAttemptId).toBe('attempt-2');
+    expect(staleMetadataWrite).toBeTruthy();
+    expect(responses[0]?.attemptId).toBe('attempt-1');
+  });
+});
+EOF
+
+cd "$ROOT_DIR"
+
+echo "==> repro: helper proof (intent invalidation + stale startup metadata)"
+set +e
+timeout "$TIMEOUT_SECONDS" \
+  pnpm --filter @invoker/app exec vitest run "$HELPER_TEST" \
+  >"$HELPER_LOG" 2>&1
+HELPER_STATUS=$?
+set -e
+
+if [[ "$HELPER_STATUS" -ne 0 ]]; then
+  OBSERVED="fixed"
+else
+  OBSERVED="bug"
+fi
+
+echo "helper_observed : $OBSERVED"
+echo "expected        : $EXPECTATION"
+
+echo "==> repro: existing SSH worktree collision proof"
+set +e
+timeout "$TIMEOUT_SECONDS" \
+  pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-worktree-metadata-repro.test.ts \
+  >"$SSH_REPRO_LOG" 2>&1
+SSH_REPRO_STATUS=$?
+set -e
+
+if [[ "$SSH_REPRO_STATUS" -ne 0 ]]; then
+  echo "repro: existing ssh-worktree-metadata-repro test failed unexpectedly" >&2
+  cat "$SSH_REPRO_LOG" >&2 || true
+  exit 2
+fi
+
+echo "==> repro summary"
+echo "artifacts         : $TMP_DIR"
+echo "helper_vitest_log : $HELPER_LOG"
+echo "ssh_vitest_log    : $SSH_REPRO_LOG"
+echo "proof_fix_intent  : $PROOF_FIX_INTENT"
+echo "proof_stale_meta  : $PROOF_STALE_METADATA"
+
+if [[ -f "$PROOF_FIX_INTENT" ]]; then
+  echo
+  echo "-- proof: invalidated fix side effect --"
+  cat "$PROOF_FIX_INTENT"
+fi
+
+if [[ -f "$PROOF_STALE_METADATA" ]]; then
+  echo
+  echo "-- proof: stale startup metadata write --"
+  cat "$PROOF_STALE_METADATA"
+fi
+
+if [[ "$OBSERVED" != "$EXPECTATION" ]]; then
+  echo
+  echo "==> repro mismatch"
+  cat "$HELPER_LOG" >&2 || true
+  exit 1
+fi
+
+echo
+echo "==> repro matched expectation"
+exit 0


### PR DESCRIPTION
## Summary

Adds a dedicated repro script proving the stale `fix-with-agent` cancellation and stale SSH startup-metadata write bugs, and adds a validated Invoker implementation plan to harden both races together.

The plan is authored for the live runtime, not just the skill docs: it uses `mergeMode: external_review`, routes intermediate workflow branches to `origin` via `intermediateRepoUrl`, targets the parent repo via `repoUrl`, and marks the `pnpm` verification tasks with the required SSH executor metadata.

The plan has already been submitted to Invoker as `wf-1778294569476-2`.

## Test Plan

- [x] `bash scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh --expect bug --keep-artifacts`
- [x] `bash skills/plan-to-invoker/scripts/skill-doctor.sh --warn-delegation plans/fix-intent-cancellation-stale-ssh-metadata.yaml`
- [x] `./submit-plan.sh plans/fix-intent-cancellation-stale-ssh-metadata.yaml`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 8fe838bb`
- Post-revert steps: None
- Data migration? No
