### PR TITLE
Fix GitHub merge gate completion to wait for merge

### DIFF
--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -238,4 +238,75 @@ describe('GitHubMergeGateProvider', () => {
       })).rejects.toThrow('parseable origin GitHub remote');
     });
   });
+
+  describe('checkApproval', () => {
+    it('treats a merged PR as approved with statusText "Merged"', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'MERGED',
+            reviewDecision: 'APPROVED',
+            url: 'https://github.com/owner/repo/pull/1',
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '1', cwd: '/tmp/repo' });
+
+      expect(result.approved).toBe(true);
+      expect(result.rejected).toBe(false);
+      expect(result.statusText).toBe('Merged');
+    });
+
+    it('treats an open approved PR as non-terminal with statusText "Approved, awaiting merge"', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: 'APPROVED',
+            url: 'https://github.com/owner/repo/pull/2',
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '2', cwd: '/tmp/repo' });
+
+      expect(result.approved).toBe(false);
+      expect(result.rejected).toBe(false);
+      expect(result.statusText).toBe('Approved, awaiting merge');
+    });
+
+    it('treats a closed non-merged PR as terminal with statusText "Closed"', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'CLOSED',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/3',
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '3', cwd: '/tmp/repo' });
+
+      expect(result.approved).toBe(false);
+      expect(result.rejected).toBe(true);
+      expect(result.statusText).toBe('Closed');
+    });
+  });
 });

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -3420,7 +3420,7 @@ describe('TaskRunner', () => {
       (executor as any).activePrPollers.delete('task-1');
     });
 
-    it('approved external_review PR auto-completes a review_ready merge gate', async () => {
+    it('merged PR auto-completes a review_ready merge gate', async () => {
       const orchestrator = {
         getTask: vi.fn((id: string) => ({
           id,
@@ -3436,7 +3436,7 @@ describe('TaskRunner', () => {
         checkApproval: vi.fn().mockResolvedValue({
           approved: true,
           rejected: false,
-          statusText: 'Approved',
+          statusText: 'Merged',
           url: 'https://github.com/owner/repo/pull/42',
         }),
       };
@@ -3456,12 +3456,60 @@ describe('TaskRunner', () => {
       await executor.checkPrApprovalNow('task-1');
 
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
-        execution: { reviewStatus: 'Approved' },
+        execution: { reviewStatus: 'Merged' },
       });
       expect(orchestrator.approve).toHaveBeenCalledWith('task-1');
 
       // Should stop polling after approval
       expect((executor as any).activePrPollers.has('task-1')).toBe(false);
+    });
+
+    it('approved-but-open PR updates persistence without completing the gate', async () => {
+      const orchestrator = {
+        getTask: vi.fn((id: string) => ({
+          id,
+          status: 'review_ready',
+          execution: { reviewId: 'owner/repo#42' },
+        })),
+        approve: vi.fn(),
+      };
+      const persistence = {
+        updateTask: vi.fn(),
+      };
+      const mergeGateProvider = {
+        checkApproval: vi.fn().mockResolvedValue({
+          approved: false,
+          rejected: false,
+          statusText: 'Approved, awaiting merge',
+          url: 'https://github.com/owner/repo/pull/42',
+        }),
+      };
+
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+        mergeGateProvider: mergeGateProvider as any,
+      });
+
+      // Simulate active poller
+      const interval = setInterval(() => {}, 1000);
+      (executor as any).activePrPollers.set('task-1', interval);
+
+      await executor.checkPrApprovalNow('task-1');
+
+      expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
+        execution: { reviewStatus: 'Approved, awaiting merge' },
+      });
+      expect(orchestrator.approve).not.toHaveBeenCalled();
+
+      // Should continue polling since PR is still open
+      expect((executor as any).activePrPollers.has('task-1')).toBe(true);
+
+      // Clean up interval
+      clearInterval((executor as any).activePrPollers.get('task-1'));
+      (executor as any).activePrPollers.delete('task-1');
     });
 
     it('is no-op when no active poller', async () => {
@@ -3607,7 +3655,7 @@ describe('TaskRunner', () => {
         (executor as any).activePrPollers.delete('task-no-ws');
       });
 
-      it('approved PR with workspacePath triggers orchestrator.approve', async () => {
+      it('merged PR with workspacePath triggers orchestrator.approve', async () => {
         const orchestrator = {
           getTask: vi.fn((id: string) => ({
             id,
@@ -3624,7 +3672,7 @@ describe('TaskRunner', () => {
           checkApproval: vi.fn().mockResolvedValue({
             approved: true,
             rejected: false,
-            statusText: 'Approved',
+            statusText: 'Merged',
             url: 'https://github.com/owner/repo/pull/101',
           }),
         };
@@ -3647,7 +3695,7 @@ describe('TaskRunner', () => {
           cwd: '/workspace/approved-worktree',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('task-approved', {
-          execution: { reviewStatus: 'Approved' },
+          execution: { reviewStatus: 'Merged' },
         });
         expect(orchestrator.approve).toHaveBeenCalledWith('task-approved');
         expect((executor as any).activePrPollers.has('task-approved')).toBe(false);
@@ -3736,7 +3784,7 @@ describe('TaskRunner', () => {
         });
       });
 
-      it('approved status with workspacePath triggers orchestrator.approve', async () => {
+      it('merged status with workspacePath triggers orchestrator.approve', async () => {
         const allTasks = [
           makeTask({
             id: 'merge-approved',
@@ -3758,7 +3806,7 @@ describe('TaskRunner', () => {
           checkApproval: vi.fn().mockResolvedValue({
             approved: true,
             rejected: false,
-            statusText: 'Approved',
+            statusText: 'Merged',
           }),
         };
 
@@ -3777,9 +3825,55 @@ describe('TaskRunner', () => {
           cwd: '/workspace/approved-gate',
         });
         expect(persistence.updateTask).toHaveBeenCalledWith('merge-approved', {
-          execution: { reviewStatus: 'Approved' },
+          execution: { reviewStatus: 'Merged' },
         });
         expect(orchestrator.approve).toHaveBeenCalledWith('merge-approved');
+      });
+
+      it('approved-but-open PR updates persistence without completing the gate', async () => {
+        const allTasks = [
+          makeTask({
+            id: 'merge-open-approved',
+            status: 'review_ready',
+            config: { isMergeNode: true },
+            execution: {
+              reviewId: 'owner/repo#203',
+              workspacePath: '/workspace/open-approved-gate',
+            },
+          }),
+        ];
+        const orchestrator = {
+          getTask: (id: string) => allTasks.find(t => t.id === id),
+          getAllTasks: () => allTasks,
+          approve: vi.fn(),
+        };
+        const persistence = { updateTask: vi.fn() };
+        const mergeGateProvider = {
+          checkApproval: vi.fn().mockResolvedValue({
+            approved: false,
+            rejected: false,
+            statusText: 'Approved, awaiting merge',
+          }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: persistence as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/runner-base-cwd',
+          mergeGateProvider: mergeGateProvider as any,
+        });
+
+        await executor.checkMergeGateStatuses();
+
+        expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+          identifier: 'owner/repo#203',
+          cwd: '/workspace/open-approved-gate',
+        });
+        expect(persistence.updateTask).toHaveBeenCalledWith('merge-open-approved', {
+          execution: { reviewStatus: 'Approved, awaiting merge' },
+        });
+        expect(orchestrator.approve).not.toHaveBeenCalled();
       });
     });
 
@@ -3875,7 +3969,7 @@ describe('TaskRunner', () => {
         }
       });
 
-      it('poll with workspacePath triggers orchestrator.approve on approval', async () => {
+      it('poll with workspacePath triggers orchestrator.approve on merged PR', async () => {
         vi.useFakeTimers();
         try {
           const orchestrator = {
@@ -3894,7 +3988,7 @@ describe('TaskRunner', () => {
             checkApproval: vi.fn().mockResolvedValue({
               approved: true,
               rejected: false,
-              statusText: 'Approved',
+              statusText: 'Merged',
             }),
           };
 
@@ -3915,10 +4009,63 @@ describe('TaskRunner', () => {
             cwd: '/workspace/poll-approved',
           });
           expect(persistence.updateTask).toHaveBeenCalledWith('poll-approved', {
-            execution: { reviewStatus: 'Approved' },
+            execution: { reviewStatus: 'Merged' },
           });
           expect(orchestrator.approve).toHaveBeenCalledWith('poll-approved');
           expect((executor as any).activePrPollers.has('poll-approved')).toBe(false);
+        } finally {
+          vi.useRealTimers();
+        }
+      });
+
+      it('poll with approved-but-open PR updates persistence without completing gate', async () => {
+        vi.useFakeTimers();
+        try {
+          const orchestrator = {
+            getTask: vi.fn((id: string) => ({
+              id,
+              status: 'review_ready',
+              execution: {
+                reviewId: 'owner/repo#303',
+                workspacePath: '/workspace/poll-open-approved',
+              },
+            })),
+            approve: vi.fn(),
+          };
+          const persistence = { updateTask: vi.fn() };
+          const mergeGateProvider = {
+            checkApproval: vi.fn().mockResolvedValue({
+              approved: false,
+              rejected: false,
+              statusText: 'Approved, awaiting merge',
+            }),
+          };
+
+          const executor = new TaskRunner({
+            orchestrator: orchestrator as any,
+            persistence: persistence as any,
+            executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+            cwd: '/runner-base-cwd',
+            mergeGateProvider: mergeGateProvider as any,
+          });
+
+          (executor as any).startPrPolling('poll-open-approved', 'owner/repo#303', 'wf-1');
+
+          await vi.advanceTimersByTimeAsync(30_000);
+
+          expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
+            identifier: 'owner/repo#303',
+            cwd: '/workspace/poll-open-approved',
+          });
+          expect(persistence.updateTask).toHaveBeenCalledWith('poll-open-approved', {
+            execution: { reviewStatus: 'Approved, awaiting merge' },
+          });
+          expect(orchestrator.approve).not.toHaveBeenCalled();
+          // Should continue polling
+          expect((executor as any).activePrPollers.has('poll-open-approved')).toBe(true);
+
+          // Cleanup
+          (executor as any).stopPrPolling('poll-open-approved');
         } finally {
           vi.useRealTimers();
         }

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -85,14 +85,14 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       url: string;
     };
 
-    const approved = data.reviewDecision === 'APPROVED' || data.state === 'MERGED';
+    const approved = data.state === 'MERGED';
     const rejected = data.state === 'CLOSED' || data.reviewDecision === 'CHANGES_REQUESTED';
 
     let statusText: string;
     if (data.state === 'MERGED') {
       statusText = 'Merged';
     } else if (data.reviewDecision === 'APPROVED') {
-      statusText = 'Approved';
+      statusText = 'Approved, awaiting merge';
     } else if (data.reviewDecision === 'CHANGES_REQUESTED') {
       statusText = 'Changes requested';
     } else if (data.state === 'CLOSED') {


### PR DESCRIPTION
## Summary

Fix the GitHub merge-gate approval check so a workflow only completes after the pull request is actually merged.

Open pull requests with an approved review now stay pending with the status `Approved, awaiting merge` instead of being treated as landed. The execution-engine regression tests were updated to cover merged, approved-but-open, and closed pull request states so the provider and task runner agree on the new completion behavior.

## Test Plan

- [x] `pnpm test`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merged-commit-sha>`
- Post-revert steps: None
- Data migration? No
