### PR TITLE
Delegate query workflows to a live owner

### DIFF
--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -353,8 +353,53 @@ describe('headless-client', () => {
     expect(firstExecCalls).toBe(1);
   }, 15_000);
 
-  it('falls back to the host runtime for non-mutating commands', async () => {
+  it('falls back to the host runtime for read-only commands that are not owner-delegated', async () => {
     const runElectronHeadless = vi.fn(async () => 0);
+    const exitCode = await runHeadlessClientCommand(['query', 'audit', 'wf-1/task-1'], {
+      messageBus: new LocalBus(),
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runElectronHeadless).toHaveBeenCalledWith(['query', 'audit', 'wf-1/task-1']);
+  });
+
+  it('delegates query workflows to a reachable owner endpoint', async () => {
+    const bus = new LocalBus();
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
+    bus.onRequest('headless.query', async () => ({
+      workflows: [
+        {
+          id: 'wf-1',
+          name: 'example',
+          status: 'running',
+          createdAt: '2026-05-08T00:00:00.000Z',
+          updatedAt: '2026-05-08T00:00:00.000Z',
+        },
+      ],
+    }));
+
+    const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const runElectronHeadless = vi.fn(async () => 0);
+
+    const exitCode = await runHeadlessClientCommand(['query', 'workflows', '--output', 'json'], {
+      messageBus: bus,
+      ensureStandaloneOwner: vi.fn(async () => {}),
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+    expect(stdout).toHaveBeenCalledWith(
+      '[{"id":"wf-1","name":"example","status":"running","createdAt":"2026-05-08T00:00:00.000Z","updatedAt":"2026-05-08T00:00:00.000Z"}]\n',
+    );
+    stdout.mockRestore();
+  });
+
+  it('falls back to the host runtime for query workflows when no owner is reachable', async () => {
+    const runElectronHeadless = vi.fn(async () => 0);
+
     const exitCode = await runHeadlessClientCommand(['query', 'workflows'], {
       messageBus: new LocalBus(),
       ensureStandaloneOwner: vi.fn(async () => {}),

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -136,7 +136,8 @@ async function delegateReadOnlyQuery(
 ): Promise<boolean> {
   const isUiPerf = args[0] === 'query' && args[1] === 'ui-perf';
   const isQueue = (args[0] === 'query' && args[1] === 'queue') || args[0] === 'queue';
-  if (!isUiPerf && !isQueue) {
+  const isWorkflows = args[0] === 'query' && args[1] === 'workflows';
+  if (!isUiPerf && !isQueue && !isWorkflows) {
     return false;
   }
 
@@ -145,20 +146,34 @@ async function delegateReadOnlyQuery(
     { messageBus: bus, refreshMessageBus, ensureStandaloneOwner: async () => {} },
     { discoveryTimeoutMs: 2_000 },
   );
-  const ownerResult = await resolver.waitForAny(READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS);
+  const ownerReadyTimeoutMs = isWorkflows ? 2_000 : READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
+  const ownerResult = await resolver.waitForAny(ownerReadyTimeoutMs);
   if (!ownerResult.resolved) {
-    throw new Error(isUiPerf
-      ? 'query ui-perf requires a running shared owner process'
-      : 'query queue requires a running shared owner process');
+    if (isWorkflows) {
+      return false;
+    }
+    throw new Error(
+      isUiPerf
+        ? 'query ui-perf requires a running shared owner process'
+        : 'query queue requires a running shared owner process',
+    );
   }
 
   let messageBus = ownerResult.bus;
-  const deadline = Date.now() + READ_ONLY_QUERY_OWNER_READY_TIMEOUT_MS;
+  const deadline = Date.now() + ownerReadyTimeoutMs;
   let response: Record<string, unknown> | null = null;
   while (Date.now() < deadline) {
     if (isUiPerf) {
       const reset = args.includes('--reset');
       response = await tryDelegateQueryUiPerf(messageBus, reset, READ_ONLY_QUERY_REQUEST_TIMEOUT_MS);
+    } else if (isWorkflows) {
+      const statusIndex = args.indexOf('--status');
+      const status = statusIndex >= 0 ? args[statusIndex + 1] : undefined;
+      response = await tryDelegateQuery(
+        messageBus,
+        { kind: 'workflows', status },
+        READ_ONLY_QUERY_REQUEST_TIMEOUT_MS,
+      );
     } else {
       response = await tryDelegateQuery(messageBus, { kind: 'queue' }, READ_ONLY_QUERY_REQUEST_TIMEOUT_MS);
     }
@@ -169,12 +184,35 @@ async function delegateReadOnlyQuery(
     await new Promise((resolve) => setTimeout(resolve, 250));
   }
   if (!response) {
-    throw new Error(isUiPerf
-      ? 'Live owner is present but did not serve ui-perf query'
-      : 'Live owner is present but did not serve queue query');
+    if (isWorkflows) {
+      return false;
+    }
+    throw new Error(
+      isUiPerf
+        ? 'Live owner is present but did not serve ui-perf query'
+        : 'Live owner is present but did not serve queue query',
+    );
   }
   if (isUiPerf) {
     process.stdout.write(`${JSON.stringify(response)}\n`);
+    return true;
+  }
+  if (isWorkflows) {
+    const outputIndex = args.indexOf('--output');
+    const output = outputIndex >= 0 ? args[outputIndex + 1] : undefined;
+    const workflows = Array.isArray(response.workflows)
+      ? response.workflows as Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string }>
+      : [];
+    const { formatAsJson, formatAsJsonl, formatAsLabel, formatWorkflowList } = await import('./formatter.js');
+    if (output === 'json') {
+      process.stdout.write(`${formatAsJson(workflows)}\n`);
+    } else if (output === 'jsonl') {
+      process.stdout.write(`${formatAsJsonl(workflows)}\n`);
+    } else if (output === 'label') {
+      process.stdout.write(`${formatAsLabel(workflows)}\n`);
+    } else {
+      process.stdout.write(`${formatWorkflowList(workflows)}\n`);
+    }
     return true;
   }
   const outputIndex = args.indexOf('--output');

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1006,7 +1006,7 @@ if (isHeadless) {
         });
         messageBus.onRequest('headless.query', async (req: unknown) => {
           noteStandaloneOwnerActivity();
-          const { kind, reset } = req as { kind?: string; reset?: boolean };
+          const { kind, reset, status } = req as { kind?: string; reset?: boolean; status?: string };
           if (kind === 'ui-perf') {
             if (reset) {
               headlessDeps.resetUiPerfStats?.();
@@ -1018,6 +1018,13 @@ if (isHeadless) {
           }
           if (kind === 'queue') {
             return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+          }
+          if (kind === 'workflows') {
+            let workflows = persistence.listWorkflows();
+            if (status) {
+              workflows = workflows.filter((workflow) => workflow.status === status);
+            }
+            return { workflows };
           }
           throw new Error(`Unsupported headless query: ${String(kind)}`);
         });
@@ -2502,7 +2509,7 @@ if (isHeadless) {
         mode: 'gui',
       }));
       messageBus.onRequest('headless.query', async (req: unknown) => {
-        const { kind, reset } = req as { kind?: string; reset?: boolean };
+        const { kind, reset, status } = req as { kind?: string; reset?: boolean; status?: string };
         if (kind === 'ui-perf') {
           if (reset) {
             resetUiPerfStats();
@@ -2514,6 +2521,13 @@ if (isHeadless) {
         }
         if (kind === 'queue') {
           return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+        }
+        if (kind === 'workflows') {
+          let workflows = persistence.listWorkflows();
+          if (status) {
+            workflows = workflows.filter((workflow) => workflow.status === status);
+          }
+          return { workflows };
         }
         throw new Error(`Unsupported headless query: ${String(kind)}`);
       });


### PR DESCRIPTION
## Summary

Route `./run.sh --headless query workflows` through an already-running owner when one is available instead of always launching a second Electron process.

Add `headless.query` support for workflow listings on both GUI and standalone owners, format the delegated response in `headless-client`, and keep the existing local fallback when no owner is running.

Shorten the no-owner wait for this fallback path so `query workflows` returns quickly instead of sitting on the shared-owner timeout before launching the local read-only runtime.

## Architecture

### Before

```mermaid
graph TD
    CLI[headless-client query workflows] --> Local[spawn local Electron read-only process]
    GUI[Running GUI owner] -. unused .-> Query[workflow listing]
```

### After

```mermaid
graph TD
    CLI[headless-client query workflows] --> Ping[probe for running owner]
    Ping -->|owner reachable| Owner[GUI or standalone owner headless.query]
    Ping -->|no owner| Local[spawn local Electron read-only process]
    Owner --> Query[workflow listing from persistence]
```

## Test Plan

- [x] `./node_modules/.bin/vitest run src/__tests__/headless-client.test.ts --config vitest.config.ts -t "query workflows"`
- [x] `pnpm build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f09c31564e92949d3a79b42fe1426a9b2f32646b`
- Post-revert steps: None
- Data migration? No
