### PR TITLE
Fix intent cancellation Step 1: workflow mutation cancellation hardening

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { SQLiteAdapter } from '@invoker/data-store';
-import { PersistedWorkflowMutationCoordinator } from '../persisted-workflow-mutation-coordinator.js';
+import { PersistedWorkflowMutationCoordinator, type WorkflowMutationContext } from '../persisted-workflow-mutation-coordinator.js';
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
   let resolve = () => {};
@@ -1193,5 +1193,280 @@ describe('PersistedWorkflowMutationCoordinator', () => {
       'invoker:delete-all-workflows-bulk:undefined',
       'invoker:edit-task-agent:new-queued',
     ]);
+  });
+
+  // ── Cancellation-aware AbortSignal tests ─────────────────────────────
+
+  it('aborts the dispatch AbortSignal when recreate-task preempts a running fix mutation', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    let capturedContext: WorkflowMutationContext | undefined;
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, _args, context) => {
+        if (channel === 'invoker:fix-with-agent') {
+          capturedContext = context;
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => capturedContext !== undefined);
+
+    expect(capturedContext).toBeDefined();
+    expect(capturedContext!.signal.aborted).toBe(false);
+    expect(capturedContext!.workflowId).toBe('wf-1');
+    expect(capturedContext!.intentId).toBe(1);
+
+    const recreateTask = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:recreate-task',
+      ['wf-1/target-task'],
+    );
+    await recreateTask;
+
+    expect(capturedContext!.signal.aborted).toBe(true);
+    await expect(olderRunning).rejects.toThrow(/superseded by recreate intent/i);
+  });
+
+  it('aborts the dispatch AbortSignal when delete-workflow preempts a running fix mutation', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    let capturedContext: WorkflowMutationContext | undefined;
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, _args, context) => {
+        if (channel === 'invoker:fix-with-agent') {
+          capturedContext = context;
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => capturedContext !== undefined);
+
+    expect(capturedContext!.signal.aborted).toBe(false);
+
+    const deleteWf = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:delete-workflow',
+      ['wf-1'],
+    );
+    await deleteWf;
+
+    expect(capturedContext!.signal.aborted).toBe(true);
+    await expect(olderRunning).rejects.toThrow(/superseded by delete intent/i);
+  });
+
+  it('aborts the dispatch AbortSignal when recreate-with-rebase preempts a running fix mutation', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    let capturedContext: WorkflowMutationContext | undefined;
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, _args, context) => {
+        if (channel === 'invoker:fix-with-agent') {
+          capturedContext = context;
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => capturedContext !== undefined);
+
+    expect(capturedContext!.signal.aborted).toBe(false);
+
+    const recreateRebase = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:recreate-with-rebase',
+      ['wf-1'],
+    );
+    await recreateRebase;
+
+    expect(capturedContext!.signal.aborted).toBe(true);
+    await expect(olderRunning).rejects.toThrow(/superseded by recreate intent/i);
+  });
+
+  it('does not abort the dispatch AbortSignal for non-preempted mutations that complete normally', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    let signalAbortedDuringDispatch = false;
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (_channel, _args, context) => {
+        signalAbortedDuringDispatch = context.signal.aborted;
+      },
+    );
+
+    await coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/task', null],
+    );
+
+    expect(signalAbortedDuringDispatch).toBe(false);
+    const intents = adapter.listWorkflowMutationIntents('wf-1');
+    expect(intents[0]?.status).toBe('completed');
+  });
+
+  it('abort signal reason is a WorkflowMutationInvalidatedError when preempted', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    let capturedContext: WorkflowMutationContext | undefined;
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, _args, context) => {
+        if (channel === 'invoker:fix-with-agent') {
+          capturedContext = context;
+          await gate.promise;
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => capturedContext !== undefined);
+
+    coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:delete-all-workflows-bulk',
+      [],
+    );
+
+    await waitFor(() => capturedContext!.signal.aborted);
+    const reason = capturedContext!.signal.reason;
+    expect(reason).toBeInstanceOf(Error);
+    expect((reason as Error).name).toBe('WorkflowMutationInvalidatedError');
+    expect((reason as Error).message).toContain('Superseded by delete');
+  });
+
+  it('dispatch handler can observe abort during long-running work and stop early', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    let iterationsBeforeAbort = 0;
+    const gate = deferred();
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, _args, context) => {
+        if (channel === 'invoker:fix-with-agent') {
+          // Simulate long-running work that checks signal
+          while (!context.signal.aborted) {
+            iterationsBeforeAbort += 1;
+            await new Promise((r) => setTimeout(r, 0));
+          }
+          gate.resolve();
+        }
+      },
+    );
+
+    const olderRunning = coordinator.enqueue<void>(
+      'wf-1',
+      'normal',
+      'invoker:fix-with-agent',
+      ['wf-1/blocker-task', null],
+    );
+    void olderRunning.catch(() => {});
+    await waitFor(() => iterationsBeforeAbort > 0);
+
+    const recreateTask = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'invoker:recreate-task',
+      ['wf-1/target-task'],
+    );
+    await gate.promise;
+    await recreateTask;
+
+    expect(iterationsBeforeAbort).toBeGreaterThan(0);
+    await expect(olderRunning).rejects.toThrow(/superseded by recreate intent/i);
   });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2462,7 +2462,7 @@ if (isHeadless) {
       workflowMutationCoordinator = new PersistedWorkflowMutationCoordinator(
         persistence,
         workflowMutationOwnerId,
-        async (channel: string, args: unknown[]) => {
+        async (channel: string, args: unknown[], _context) => {
           const handler = workflowMutationDispatcher.get(channel);
           if (!handler) {
             throw new Error(`No workflow mutation dispatcher registered for ${channel}`);

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -13,6 +13,13 @@ type Deferred<T> = {
 type InvalidationSignal = {
   promise: Promise<never>;
   reject: (error: unknown) => void;
+  abortController: AbortController;
+};
+
+export type WorkflowMutationContext = {
+  signal: AbortSignal;
+  intentId: number;
+  workflowId: string;
 };
 
 function envMs(name: string, fallback: number): number {
@@ -53,7 +60,7 @@ export class PersistedWorkflowMutationCoordinator {
   constructor(
     private readonly persistence: SQLiteAdapter,
     private readonly ownerId: string,
-    private readonly dispatch: (channel: string, args: unknown[]) => Promise<unknown>,
+    private readonly dispatch: (channel: string, args: unknown[], context: WorkflowMutationContext) => Promise<unknown>,
     options?: { maxConcurrentWorkflowDrains?: number },
   ) {
     this.maxConcurrentWorkflowDrains = Math.max(1, options?.maxConcurrentWorkflowDrains ?? 1);
@@ -208,7 +215,12 @@ export class PersistedWorkflowMutationCoordinator {
     }, this.leaseHeartbeatMs);
     try {
       this.evictQueuedWorkflowIntentsForFence(workflowId, intent);
-      const dispatchPromise = Promise.resolve(this.dispatch(intent.channel, intent.args));
+      const mutationContext: WorkflowMutationContext = {
+        signal: invalidation.abortController.signal,
+        intentId: intent.id,
+        workflowId,
+      };
+      const dispatchPromise = Promise.resolve(this.dispatch(intent.channel, intent.args, mutationContext));
       void dispatchPromise.catch(() => {});
       const result = await Promise.race([
         dispatchPromise,
@@ -228,6 +240,7 @@ export class PersistedWorkflowMutationCoordinator {
       deferred?.reject(error);
     } finally {
       clearInterval(leaseHeartbeat);
+      invalidation.abortController.abort();
       this.runningIntentInvalidations.delete(intent.id);
       this.persistence.renewWorkflowMutationLease(workflowId, this.ownerId, {
         minHeartbeatIntervalMs: this.leaseRenewMinIntervalMs,
@@ -284,9 +297,11 @@ export class PersistedWorkflowMutationCoordinator {
     const promise = new Promise<never>((_, r) => {
       reject = r;
     });
+    const abortController = new AbortController();
     const entry: InvalidationSignal = {
       reject,
       promise,
+      abortController,
     };
     this.runningIntentInvalidations.set(intentId, entry);
     return entry;
@@ -315,6 +330,7 @@ export class PersistedWorkflowMutationCoordinator {
     const reason = `Superseded by ${fenceKind} intent #${newIntentId}`;
     this.persistence.failWorkflowMutationIntent(activeIntentId, reason);
     const invalidation = this.runningIntentInvalidations.get(activeIntentId);
+    invalidation?.abortController.abort(new WorkflowMutationInvalidatedError(reason));
     invalidation?.reject(new WorkflowMutationInvalidatedError(reason));
     process.stderr.write(
       `[workflow-mutation-coordinator] invalidated running intent ${activeIntentId} for ${workflowId} via ${fenceKind}#${newIntentId}\n`,


### PR DESCRIPTION
## Summary

This step makes workflow-mutation execution cancellation-aware so higher-priority fences can stop a superseded fix mutation before it writes back stale state.

It threads an `AbortSignal` through the persisted mutation coordinator, invalidates older running intents when recreate/delete work preempts them, and adds focused coordinator coverage for the preemption path.

## Architecture

### Before

```mermaid
graph TD
    A[Queued fix mutation] --> B[Coordinator dispatches handler]
    C[Recreate or delete fence] --> D[Intent is marked stale in persistence]
    B --> E[In-flight handler keeps running]
    E --> F[Late side effects can still write]
```

### After

```mermaid
graph TD
    A[Queued fix mutation] --> B[Coordinator dispatches handler with AbortSignal]
    C[Recreate or delete fence] --> D[Coordinator invalidates older running intent]
    D --> E[AbortSignal fires in the handler]
    E --> F[Superseded work exits before late writes]
```

## Test Plan

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/persisted-workflow-mutation-coordinator.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No
