### PR TITLE
Fix intent cancellation Step 5: repro and regression verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,8 @@ jobs:
             command: bash scripts/test-suites/required/10-vitest-workspace.sh
           - name: Submit Workflow Chain
             command: bash scripts/test-suites/required/15-submit-workflow-chain.sh
+          - name: Fix Intent Repros
+            command: bash scripts/test-suites/required/23-fix-intent-repros.sh
 
     name: required-fast / ${{ matrix.name }}
 

--- a/packages/app/src/__tests__/resolve-conflict-action.test.ts
+++ b/packages/app/src/__tests__/resolve-conflict-action.test.ts
@@ -12,6 +12,7 @@ import { resolveConflictAction } from '../workflow-actions.js';
 
 describe('resolveConflictAction', () => {
   let orchestrator: {
+    getTask: ReturnType<typeof vi.fn>;
     beginConflictResolution: ReturnType<typeof vi.fn>;
     setFixAwaitingApproval: ReturnType<typeof vi.fn>;
     revertConflictResolution: ReturnType<typeof vi.fn>;
@@ -26,6 +27,11 @@ describe('resolveConflictAction', () => {
 
   beforeEach(() => {
     orchestrator = {
+      getTask: vi.fn(() => ({
+        id: 'task-a',
+        status: 'fixing_with_ai',
+        execution: { selectedAttemptId: 'att-1', generation: 1 },
+      })),
       beginConflictResolution: vi.fn(() => ({ savedError: 'saved-err' })),
       setFixAwaitingApproval: vi.fn(),
       revertConflictResolution: vi.fn(),
@@ -52,8 +58,10 @@ describe('resolveConflictAction', () => {
 
   it('auto-approves after conflict resolution when configured', async () => {
     const approve = vi.fn(async () => [{ id: 'task-a', status: 'completed', config: {}, execution: {} }]);
+    const getTask = orchestrator.getTask;
     orchestrator = {
       ...orchestrator,
+      getTask,
       approve,
     };
     const taskExecutorWithApprove = {

--- a/packages/app/src/__tests__/shutdown-diagnostic.test.ts
+++ b/packages/app/src/__tests__/shutdown-diagnostic.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+import {
+  persistShutdownDiagnostic,
+  SHUTDOWN_DIAGNOSTIC_TAIL_CHARS,
+  type ShutdownDiagnosticDb,
+} from '../shutdown-diagnostic.js';
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id: 'task-1',
+    description: 'test task',
+    status: 'running',
+    dependencies: [],
+    createdAt: new Date(),
+    config: {},
+    execution: {},
+    ...overrides,
+  } as TaskState;
+}
+
+function makeDb(tailData: string[] = []): ShutdownDiagnosticDb & { appended: string[] } {
+  const appended: string[] = [];
+  return {
+    appended,
+    getOutputTail: () => tailData.map((d, i) => ({ data: d, offset: i })),
+    appendTaskOutput: (_taskId: string, data: string) => {
+      appended.push(data);
+    },
+  };
+}
+
+describe('persistShutdownDiagnostic', () => {
+  it('appends a diagnostic block with status', () => {
+    const task = makeTask({ status: 'running' });
+    const db = makeDb();
+
+    persistShutdownDiagnostic(task, db);
+
+    expect(db.appended).toHaveLength(1);
+    const output = db.appended[0];
+    expect(output).toContain('[Shutdown Diagnostic]');
+    expect(output).toContain('status=running');
+    expect(output).toContain('--- end shutdown diagnostic ---');
+  });
+
+  it('includes execution error when present', () => {
+    const task = makeTask({
+      status: 'running',
+      execution: { error: 'npm test failed with exit code 1' },
+    });
+    const db = makeDb();
+
+    persistShutdownDiagnostic(task, db);
+
+    const output = db.appended[0];
+    expect(output).toContain('error=npm test failed with exit code 1');
+  });
+
+  it('includes exitCode when present', () => {
+    const task = makeTask({
+      status: 'running',
+      execution: { exitCode: 42 },
+    });
+    const db = makeDb();
+
+    persistShutdownDiagnostic(task, db);
+
+    const output = db.appended[0];
+    expect(output).toContain('exitCode=42');
+  });
+
+  it('includes recent output tail from spool', () => {
+    const task = makeTask();
+    const db = makeDb(['line 1\n', 'line 2\n', 'FAIL src/foo.test.ts\n']);
+
+    persistShutdownDiagnostic(task, db);
+
+    const output = db.appended[0];
+    expect(output).toContain('--- recent output tail ---');
+    expect(output).toContain('line 1');
+    expect(output).toContain('line 2');
+    expect(output).toContain('FAIL src/foo.test.ts');
+  });
+
+  it('truncates output tail exceeding the character limit', () => {
+    const task = makeTask();
+    const longChunk = 'x'.repeat(SHUTDOWN_DIAGNOSTIC_TAIL_CHARS + 500);
+    const db = makeDb([longChunk]);
+
+    persistShutdownDiagnostic(task, db);
+
+    const output = db.appended[0];
+    expect(output).toContain('...');
+    // The tail portion should be at most SHUTDOWN_DIAGNOSTIC_TAIL_CHARS long
+    const tailStart = output.indexOf('--- recent output tail ---');
+    const tailEnd = output.indexOf('--- end shutdown diagnostic ---');
+    const tailSection = output.slice(tailStart, tailEnd);
+    // 3 for '...' prefix + SHUTDOWN_DIAGNOSTIC_TAIL_CHARS + header line
+    expect(tailSection.length).toBeLessThan(SHUTDOWN_DIAGNOSTIC_TAIL_CHARS + 200);
+  });
+
+  it('omits output tail section when spool is empty', () => {
+    const task = makeTask();
+    const db = makeDb([]);
+
+    persistShutdownDiagnostic(task, db);
+
+    const output = db.appended[0];
+    expect(output).not.toContain('--- recent output tail ---');
+    expect(output).toContain('[Shutdown Diagnostic]');
+    expect(output).toContain('--- end shutdown diagnostic ---');
+  });
+
+  it('flushes pending output before capturing tail', () => {
+    const task = makeTask();
+    const flushOrder: string[] = [];
+    const db = makeDb(['flushed data\n']);
+    const origAppend = db.appendTaskOutput.bind(db);
+    db.appendTaskOutput = (taskId: string, data: string) => {
+      flushOrder.push('append');
+      origAppend(taskId, data);
+    };
+    const flushPendingOutput = (taskId: string) => {
+      flushOrder.push(`flush:${taskId}`);
+    };
+
+    persistShutdownDiagnostic(task, db, { flushPendingOutput });
+
+    expect(flushOrder[0]).toBe('flush:task-1');
+    expect(flushOrder[1]).toBe('append');
+  });
+
+  it('does not throw when db.appendTaskOutput fails', () => {
+    const task = makeTask();
+    const db: ShutdownDiagnosticDb = {
+      getOutputTail: () => [],
+      appendTaskOutput: () => {
+        throw new Error('DB write failed');
+      },
+    };
+
+    expect(() => persistShutdownDiagnostic(task, db)).not.toThrow();
+  });
+
+  it('does not throw when db.getOutputTail fails', () => {
+    const db: ShutdownDiagnosticDb = {
+      getOutputTail: () => {
+        throw new Error('DB read failed');
+      },
+      appendTaskOutput: vi.fn(),
+    };
+
+    expect(() => persistShutdownDiagnostic(makeTask(), db)).not.toThrow();
+  });
+
+  it('handles fixing_with_ai status', () => {
+    const task = makeTask({ status: 'fixing_with_ai' as any });
+    const db = makeDb();
+
+    persistShutdownDiagnostic(task, db);
+
+    const output = db.appended[0];
+    expect(output).toContain('status=fixing_with_ai');
+  });
+});

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -33,6 +33,10 @@ import {
   buildInvalidationDeps,
   selectFailureRecoveryRoute,
   deleteAllWorkflows,
+  resolveConflictAction,
+  StaleLineageError,
+  captureTaskLineage,
+  assertLineageCurrent,
 } from '../workflow-actions.js';
 
 vi.mock('../delete-all-snapshot.js', () => ({
@@ -935,44 +939,39 @@ describe('autoFixOnFailure', () => {
     const started = [
       makeRunningTask({ id: 'merge-a', config: { workflowId: 'wf-1', isMergeNode: true } }),
     ];
-    const getTask = vi
-      .fn()
-      .mockReturnValueOnce(makeTask({
+    // The getTask mock is driven by a state machine that tracks which
+    // phase the auto-fix flow is in.  Each phase may call getTask
+    // multiple times (entry check, lineage capture, lineage assert,
+    // approveTask, post-finalize).  We use a phase counter that
+    // advances at known transition points (beginConflictResolution
+    // and setFixAwaitingApproval) to keep return values consistent.
+    let phase = 0;
+    const phases: Record<string, unknown>[] = [
+      // Phase 0: entry check + lineage capture (cycle 1)
+      { status: 'failed', execution: { autoFixAttempts: 0, workspacePath: '/tmp/merge-a', selectedAttemptId: 'att-1', generation: 1 } },
+      // Phase 1: after fix returns, lineage check + finalize + approveTask (cycle 1)
+      { status: 'awaiting_approval', execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a', pendingFixError: 'boom', selectedAttemptId: 'att-1', generation: 1 } },
+      // Phase 2: post-finalize check — task re-failed after publish
+      { status: 'failed', execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a', error: 'Post-fix PR prep failed: conflict', selectedAttemptId: 'att-1', generation: 1 } },
+      // Phase 3: inline retry entry + lineage capture (cycle 2)
+      { status: 'failed', execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a', selectedAttemptId: 'att-3', generation: 3 } },
+      // Phase 4: after fix returns, lineage check + finalize + approveTask (cycle 2)
+      { status: 'awaiting_approval', execution: { autoFixAttempts: 2, workspacePath: '/tmp/merge-a', pendingFixError: 'boom', selectedAttemptId: 'att-3', generation: 3 } },
+    ];
+    const getTask = vi.fn(() => {
+      const idx = Math.min(phase, phases.length - 1);
+      return makeTask({
         id: 'merge-a',
-        status: 'failed',
         config: { workflowId: 'wf-1', isMergeNode: true },
-        execution: { autoFixAttempts: 0, workspacePath: '/tmp/merge-a' },
-      }))
-      .mockReturnValueOnce(makeTask({
-        id: 'merge-a',
-        status: 'awaiting_approval',
-        config: { workflowId: 'wf-1', isMergeNode: true },
-        execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a', pendingFixError: 'boom' },
-      }))
-      .mockReturnValueOnce(makeTask({
-        id: 'merge-a',
-        status: 'failed',
-        config: { workflowId: 'wf-1', isMergeNode: true },
-        execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a', error: 'Post-fix PR prep failed: conflict' },
-      }))
-      .mockReturnValueOnce(makeTask({
-        id: 'merge-a',
-        status: 'failed',
-        config: { workflowId: 'wf-1', isMergeNode: true },
-        execution: { autoFixAttempts: 1, workspacePath: '/tmp/merge-a' },
-      }))
-      .mockReturnValueOnce(makeTask({
-        id: 'merge-a',
-        status: 'awaiting_approval',
-        config: { workflowId: 'wf-1', isMergeNode: true },
-        execution: { autoFixAttempts: 2, workspacePath: '/tmp/merge-a', pendingFixError: 'boom' },
-      }))
-      .mockReturnValue(makeTask({
-        id: 'merge-a',
-        status: 'awaiting_approval',
-        config: { workflowId: 'wf-1', isMergeNode: true },
-        execution: { autoFixAttempts: 2, workspacePath: '/tmp/merge-a', pendingFixError: 'boom' },
-      }));
+        ...phases[idx],
+      });
+    });
+    // Advance phase at key transition points
+    const origBeginConflictResolution = vi.fn(() => {
+      phase++;
+      return { savedError: 'boom' };
+    });
+    const origSetFixAwaitingApproval = vi.fn(() => { phase++; });
     const shouldAutoFix = vi
       .fn()
       .mockReturnValueOnce(true)
@@ -983,9 +982,9 @@ describe('autoFixOnFailure', () => {
       shouldAutoFix,
       getTask,
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginConflictResolution: origBeginConflictResolution,
       retryTask: vi.fn(() => []),
-      setFixAwaitingApproval: vi.fn(),
+      setFixAwaitingApproval: origSetFixAwaitingApproval,
       approve: vi.fn().mockResolvedValue(started),
       resumeTaskAfterFixApproval: vi.fn().mockResolvedValue(started),
       revertConflictResolution: vi.fn(),
@@ -2006,5 +2005,495 @@ describe('deleteAllWorkflows', () => {
     });
 
     expect(result.snapshotPath).toBe('/tmp/fake-snapshot');
+  });
+});
+
+// ── Lineage guard unit tests ──────────────────────────────────
+
+describe('captureTaskLineage', () => {
+  it('captures selectedAttemptId and generation from task', () => {
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        execution: { selectedAttemptId: 'att-1', generation: 3 },
+      })),
+    };
+    const snapshot = captureTaskLineage('task-a', orchestrator as unknown as Orchestrator);
+    expect(snapshot).toEqual({
+      taskId: 'task-a',
+      selectedAttemptId: 'att-1',
+      generation: 3,
+    });
+  });
+
+  it('defaults generation to 0 when task has no generation', () => {
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({ execution: {} })),
+    };
+    const snapshot = captureTaskLineage('task-a', orchestrator as unknown as Orchestrator);
+    expect(snapshot.generation).toBe(0);
+    expect(snapshot.selectedAttemptId).toBeUndefined();
+  });
+});
+
+describe('assertLineageCurrent', () => {
+  it('does nothing when lineage matches and signal is not aborted', () => {
+    const snapshot = { taskId: 'task-a', selectedAttemptId: 'att-1', generation: 3 };
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        execution: { selectedAttemptId: 'att-1', generation: 3 },
+      })),
+    };
+    expect(() => {
+      assertLineageCurrent(snapshot, orchestrator as unknown as Orchestrator);
+    }).not.toThrow();
+  });
+
+  it('throws StaleLineageError when selectedAttemptId changes', () => {
+    const snapshot = { taskId: 'task-a', selectedAttemptId: 'att-1', generation: 3 };
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        execution: { selectedAttemptId: 'att-2', generation: 3 },
+      })),
+    };
+    expect(() => {
+      assertLineageCurrent(snapshot, orchestrator as unknown as Orchestrator);
+    }).toThrow(StaleLineageError);
+  });
+
+  it('throws StaleLineageError when generation changes', () => {
+    const snapshot = { taskId: 'task-a', selectedAttemptId: 'att-1', generation: 3 };
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        execution: { selectedAttemptId: 'att-1', generation: 4 },
+      })),
+    };
+    expect(() => {
+      assertLineageCurrent(snapshot, orchestrator as unknown as Orchestrator);
+    }).toThrow(StaleLineageError);
+  });
+
+  it('throws StaleLineageError when signal is aborted', () => {
+    const snapshot = { taskId: 'task-a', selectedAttemptId: 'att-1', generation: 3 };
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        execution: { selectedAttemptId: 'att-1', generation: 3 },
+      })),
+    };
+    const ac = new AbortController();
+    ac.abort(new Error('superseded'));
+    expect(() => {
+      assertLineageCurrent(snapshot, orchestrator as unknown as Orchestrator, ac.signal);
+    }).toThrow(StaleLineageError);
+  });
+});
+
+describe('fixWithAgentAction lineage guard', () => {
+  it('throws StaleLineageError when lineage changes during async fix', async () => {
+    let fixCallCount = 0;
+    const orchestrator = {
+      getTask: vi.fn(() => {
+        fixCallCount++;
+        // First call: entry point reads task
+        // Second call: lineage capture after beginConflictResolution
+        // Third call: lineage check after async fix returns (lineage changed)
+        if (fixCallCount <= 2) {
+          return makeTask({
+            status: 'failed',
+            config: { workflowId: 'wf-1' },
+            execution: { error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+          });
+        }
+        // After fix returns, lineage has advanced
+        return makeTask({
+          status: 'pending',
+          config: { workflowId: 'wf-1' },
+          execution: { selectedAttemptId: 'att-2', generation: 6 },
+        });
+      }),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn(),
+    };
+
+    await expect(fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    })).rejects.toThrow(StaleLineageError);
+
+    // Should NOT have called setFixAwaitingApproval (the late write)
+    expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
+    // Should NOT have called revertConflictResolution either
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+  });
+
+  it('throws StaleLineageError when signal is aborted during async fix', async () => {
+    const ac = new AbortController();
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: { error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+      })),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn(async () => {
+        // Abort happens during the fix
+        ac.abort(new Error('Superseded by recreate'));
+      }),
+      resolveConflict: vi.fn(),
+    };
+
+    await expect(fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      signal: ac.signal,
+    })).rejects.toThrow(StaleLineageError);
+
+    expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+  });
+
+  it('skips revertConflictResolution when lineage changed and fix threw', async () => {
+    let getTaskCallCount = 0;
+    const orchestrator = {
+      getTask: vi.fn(() => {
+        getTaskCallCount++;
+        if (getTaskCallCount <= 2) {
+          return makeTask({
+            status: 'failed',
+            config: { workflowId: 'wf-1' },
+            execution: { error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+          });
+        }
+        // Lineage changed during fix
+        return makeTask({
+          status: 'pending',
+          config: { workflowId: 'wf-1' },
+          execution: { selectedAttemptId: 'att-2', generation: 6 },
+        });
+      }),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockRejectedValue(new Error('agent crashed')),
+      resolveConflict: vi.fn(),
+    };
+
+    await expect(fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    })).rejects.toThrow('agent crashed');
+
+    // revertConflictResolution must NOT be called when lineage is stale
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+  });
+
+  it('proceeds normally when lineage is current', async () => {
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: { error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+      })),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn(),
+    };
+
+    const result = await fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    // Normal path should proceed
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom');
+    expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
+  });
+});
+
+describe('resolveConflictAction lineage guard', () => {
+  it('throws StaleLineageError when lineage changes during conflict resolution', async () => {
+    let getTaskCallCount = 0;
+    const mergeError = JSON.stringify({
+      type: 'merge_conflict',
+      failedBranch: 'experiment/foo',
+      conflictFiles: ['src/foo.ts'],
+    });
+    const orchestrator = {
+      getTask: vi.fn(() => {
+        getTaskCallCount++;
+        if (getTaskCallCount <= 1) {
+          return makeTask({
+            status: 'fixing_with_ai',
+            config: { workflowId: 'wf-1' },
+            execution: { error: mergeError, selectedAttemptId: 'att-1', generation: 5 },
+          });
+        }
+        // Lineage changed
+        return makeTask({
+          status: 'pending',
+          config: { workflowId: 'wf-1' },
+          execution: { selectedAttemptId: 'att-2', generation: 6 },
+        });
+      }),
+      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      resolveConflict: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(resolveConflictAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    })).rejects.toThrow(StaleLineageError);
+
+    expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+  });
+
+  it('skips revertConflictResolution when lineage changed and resolution threw', async () => {
+    let getTaskCallCount = 0;
+    const orchestrator = {
+      getTask: vi.fn(() => {
+        getTaskCallCount++;
+        if (getTaskCallCount <= 1) {
+          return makeTask({
+            status: 'fixing_with_ai',
+            config: { workflowId: 'wf-1' },
+            execution: { selectedAttemptId: 'att-1', generation: 5 },
+          });
+        }
+        return makeTask({
+          status: 'pending',
+          config: { workflowId: 'wf-1' },
+          execution: { selectedAttemptId: 'att-2', generation: 6 },
+        });
+      }),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'merge err' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      resolveConflict: vi.fn().mockRejectedValue(new Error('resolution failed')),
+    };
+
+    await expect(resolveConflictAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    })).rejects.toThrow('resolution failed');
+
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+  });
+});
+
+describe('autoFixOnFailure lineage guard', () => {
+  it('throws StaleLineageError when lineage changes after async fix', async () => {
+    let getTaskCallCount = 0;
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => {
+        getTaskCallCount++;
+        if (getTaskCallCount <= 2) {
+          return makeTask({
+            status: 'failed',
+            config: { workflowId: 'wf-1' },
+            execution: { autoFixAttempts: 0, error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+          });
+        }
+        // Lineage advanced after fix returned
+        return makeTask({
+          status: 'pending',
+          config: { workflowId: 'wf-1' },
+          execution: { selectedAttemptId: 'att-2', generation: 6 },
+        });
+      }),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      setFixAwaitingApproval: vi.fn(),
+      retryTask: vi.fn(() => []),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+      logEvent: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn(),
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(autoFixOnFailure('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    })).rejects.toThrow(StaleLineageError);
+
+    expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
+    expect(orchestrator.retryTask).not.toHaveBeenCalled();
+  });
+
+  it('skips revertConflictResolution on failure when lineage changed', async () => {
+    let getTaskCallCount = 0;
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => {
+        getTaskCallCount++;
+        if (getTaskCallCount <= 2) {
+          return makeTask({
+            status: 'failed',
+            config: { workflowId: 'wf-1' },
+            execution: { autoFixAttempts: 0, error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+          });
+        }
+        return makeTask({
+          status: 'pending',
+          config: { workflowId: 'wf-1' },
+          execution: { selectedAttemptId: 'att-2', generation: 6 },
+        });
+      }),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      setFixAwaitingApproval: vi.fn(),
+      retryTask: vi.fn(() => []),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+      logEvent: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockRejectedValue(new Error('agent crashed')),
+      resolveConflict: vi.fn(),
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(autoFixOnFailure('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    })).rejects.toThrow('agent crashed');
+
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+  });
+
+  it('throws StaleLineageError when signal is aborted during auto-fix', async () => {
+    const ac = new AbortController();
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: { autoFixAttempts: 0, error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+      })),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      setFixAwaitingApproval: vi.fn(),
+      retryTask: vi.fn(() => []),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+      logEvent: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn(async () => {
+        ac.abort(new Error('Superseded by recreate'));
+      }),
+      resolveConflict: vi.fn(),
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(autoFixOnFailure('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+      signal: ac.signal,
+    })).rejects.toThrow(StaleLineageError);
+
+    expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
+    expect(orchestrator.retryTask).not.toHaveBeenCalled();
+  });
+});
+
+describe('finalizeAppliedFix lineage guard', () => {
+  it('throws StaleLineageError when signal is aborted before finalize', async () => {
+    const ac = new AbortController();
+    ac.abort(new Error('superseded'));
+    const orchestrator = {
+      setFixAwaitingApproval: vi.fn(),
+    };
+
+    await expect(finalizeAppliedFix('task-a', 'saved-error', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: {} as TaskRunner,
+    }, ac.signal)).rejects.toThrow(StaleLineageError);
+
+    expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
+  });
+
+  it('proceeds normally when signal is not aborted', async () => {
+    const ac = new AbortController();
+    const orchestrator = {
+      setFixAwaitingApproval: vi.fn(),
+    };
+
+    const result = await finalizeAppliedFix('task-a', 'saved-error', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: {} as TaskRunner,
+    }, ac.signal);
+
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-error');
+    expect(result).toEqual({ autoApproved: false, started: [] });
   });
 });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -97,6 +97,8 @@ export interface HeadlessDeps {
   isStandaloneOwnerIdle?: () => boolean;
   getBundledSkillsStatus?: () => BundledSkillsStatus;
   installBundledSkills?: (mode?: BundledSkillsInstallMode) => BundledSkillsStatus;
+  /** Abort signal from the workflow mutation coordinator, if running inside a coordinated mutation. */
+  signal?: AbortSignal;
   runtimeServices?: RuntimeServices;
 }
 
@@ -1543,6 +1545,7 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
       agentName: agent,
       recreateOutputLabel: 'Fix with AI',
       failureOutputLabel: 'Fix with AI',
+      signal: deps.signal,
     });
     await finalizeMutationWithGlobalTopup({
       orchestrator: deps.orchestrator,
@@ -1589,7 +1592,7 @@ async function headlessResolveConflict(taskId: string, deps: HeadlessDeps, agent
       ...deps,
       taskExecutor: te,
       autoApproveAIFixes: deps.invokerConfig.autoApproveAIFixes,
-    }, agent);
+    }, agent, deps.signal);
     await finalizeMutationWithGlobalTopup({
       orchestrator: deps.orchestrator,
       taskExecutor: te,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -212,6 +212,13 @@ function dispatchStartedTasks(tasks: TaskState[]): void {
 }
 let workflowMutationCoordinator: PersistedWorkflowMutationCoordinator | null = null;
 const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+/**
+ * The mutation context for the currently executing workflow mutation.
+ * Set by the coordinator dispatch callback before invoking the handler,
+ * cleared afterward. Allows fix-with-agent and conflict-resolution
+ * handlers to read the AbortSignal without changing every handler signature.
+ */
+let activeMutationContext: import('./persisted-workflow-mutation-coordinator.js').WorkflowMutationContext | undefined;
 let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
 let writerLock: DbWriterLockResult | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
@@ -1068,6 +1075,7 @@ if (isHeadless) {
               ...headlessDeps,
               waitForApproval: delegatedWait,
               noTrack: delegatedNoTrack,
+              signal: activeMutationContext?.signal,
             });
           });
           return { ok: true };
@@ -1384,6 +1392,7 @@ if (isHeadless) {
         recoveryRoute,
         recreateOutputLabel: source === 'auto-fix' ? 'Auto-fix' : 'Fix with AI',
         failureOutputLabel: source === 'auto-fix' ? 'Auto-fix' : `Fix with ${agentName ?? 'Claude'}`,
+        signal: activeMutationContext?.signal,
       },
     );
     return result.started;
@@ -1696,6 +1705,7 @@ if (isHeadless) {
       orchestrator, persistence, executorRegistry, messageBus,
       commandService,
       repoRoot, invokerConfig, initServices, wireSlackBot,
+      signal: activeMutationContext?.signal,
       setTaskDispatcherExecutor: setDispatcherTaskExecutor,
       cancelTask: (taskId: string) => performCancelTask(taskId),
       cancelWorkflow: (workflowId: string) => performCancelWorkflow(workflowId),
@@ -2462,12 +2472,17 @@ if (isHeadless) {
       workflowMutationCoordinator = new PersistedWorkflowMutationCoordinator(
         persistence,
         workflowMutationOwnerId,
-        async (channel: string, args: unknown[], _context) => {
+        async (channel: string, args: unknown[], context) => {
           const handler = workflowMutationDispatcher.get(channel);
           if (!handler) {
             throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
           }
-          return handler(...args);
+          activeMutationContext = context;
+          try {
+            return await handler(...args);
+          } finally {
+            activeMutationContext = undefined;
+          }
         },
         { maxConcurrentWorkflowDrains },
       );
@@ -3399,7 +3414,7 @@ if (isHeadless) {
           persistence,
           taskExecutor: requireTaskExecutor(),
           autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
-        }, agentName);
+        }, agentName, activeMutationContext?.signal);
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -147,6 +147,7 @@ import { computeDeferredLaunchTiming } from './deferred-runnable.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
 import { listOpenFixIntentsForTask } from './auto-fix-intents.js';
+import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 
 declare const __BUILD_SHA__: string | undefined;
 declare const __BUILD_VERSION__: string | undefined;
@@ -1093,6 +1094,7 @@ if (isHeadless) {
       if (ownsHeadlessShutdown && orchestrator) {
         for (const task of orchestrator.getAllTasks()) {
           if (task.status === 'running' || task.status === 'fixing_with_ai') {
+            if (persistence) persistShutdownDiagnostic(task, persistence);
             orchestrator.handleWorkerResponse({
               requestId: `quit-${task.id}`,
               actionId: task.id,
@@ -3692,6 +3694,11 @@ if (isHeadless) {
       if (orchestrator) {
         for (const task of orchestrator.getAllTasks()) {
           if (task.status === 'running' || task.status === 'fixing_with_ai') {
+            if (persistence) {
+              persistShutdownDiagnostic(task, persistence, {
+                flushPendingOutput: flushTaskOutput,
+              });
+            }
             orchestrator.handleWorkerResponse({
               requestId: `quit-${task.id}`,
               actionId: task.id,

--- a/packages/app/src/shutdown-diagnostic.ts
+++ b/packages/app/src/shutdown-diagnostic.ts
@@ -1,0 +1,51 @@
+import type { TaskState } from '@invoker/workflow-core';
+
+export interface ShutdownDiagnosticDb {
+  getOutputTail(taskId: string): Array<{ data: string }>;
+  appendTaskOutput(taskId: string, data: string): void;
+}
+
+/** Max characters of recent output tail included in shutdown diagnostics. */
+export const SHUTDOWN_DIAGNOSTIC_TAIL_CHARS = 4_000;
+
+/**
+ * Persist a compact diagnostic block into durable task output so that
+ * post-mortem inspection retains concrete context instead of collapsing
+ * to "Application quit".
+ *
+ * Called from both headless and GUI shutdown paths before the synthetic
+ * failure response is emitted.
+ */
+export function persistShutdownDiagnostic(
+  task: TaskState,
+  db: ShutdownDiagnosticDb,
+  opts?: { flushPendingOutput?: (taskId: string) => void },
+): void {
+  try {
+    // Flush any buffered output so the spool is up-to-date.
+    opts?.flushPendingOutput?.(task.id);
+
+    // Gather the most recent output tail from the output spool.
+    const tailChunks = db.getOutputTail(task.id);
+    let tail = tailChunks.map(c => c.data).join('');
+    if (tail.length > SHUTDOWN_DIAGNOSTIC_TAIL_CHARS) {
+      tail = '...' + tail.slice(tail.length - SHUTDOWN_DIAGNOSTIC_TAIL_CHARS);
+    }
+
+    const parts: string[] = ['\n[Shutdown Diagnostic]'];
+    parts.push(`status=${task.status}`);
+    if (task.execution.error) {
+      parts.push(`error=${task.execution.error}`);
+    }
+    if (task.execution.exitCode !== undefined && task.execution.exitCode !== null) {
+      parts.push(`exitCode=${task.execution.exitCode}`);
+    }
+    if (tail) {
+      parts.push(`--- recent output tail ---\n${tail}`);
+    }
+    parts.push('--- end shutdown diagnostic ---\n');
+    db.appendTaskOutput(task.id, parts.join('\n'));
+  } catch {
+    // Best-effort: don't let diagnostic persistence block shutdown.
+  }
+}

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -20,6 +20,72 @@ import type { TaskRunner } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 
+// ── Lineage guard ─────────────────────────────────────────────
+
+/**
+ * Thrown when a fix-with-agent or conflict-resolution mutation discovers
+ * that the task lineage has changed since the mutation started (e.g. a
+ * recreate-task moved the selectedAttemptId forward while the async fix
+ * was in flight). Callers should treat this as a no-op: the task state
+ * has already moved on and the late result must be discarded.
+ */
+export class StaleLineageError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'StaleLineageError';
+  }
+}
+
+/** Snapshot of task identity captured at mutation entry. */
+export interface TaskLineageSnapshot {
+  taskId: string;
+  selectedAttemptId: string | undefined;
+  generation: number;
+}
+
+/**
+ * Capture the current lineage for a task.
+ */
+export function captureTaskLineage(
+  taskId: string,
+  orchestrator: Pick<Orchestrator, 'getTask'>,
+): TaskLineageSnapshot {
+  const task = orchestrator.getTask(taskId);
+  return {
+    taskId,
+    selectedAttemptId: task?.execution.selectedAttemptId,
+    generation: task?.execution.generation ?? 0,
+  };
+}
+
+/**
+ * Assert that the task lineage has not changed since the snapshot and
+ * that the abort signal (if any) has not fired.  Throws
+ * `StaleLineageError` on mismatch.
+ */
+export function assertLineageCurrent(
+  snapshot: TaskLineageSnapshot,
+  orchestrator: Pick<Orchestrator, 'getTask'>,
+  signal?: AbortSignal,
+): void {
+  if (signal?.aborted) {
+    throw new StaleLineageError(
+      `Fix mutation for ${snapshot.taskId} aborted: ${signal.reason instanceof Error ? signal.reason.message : String(signal.reason ?? 'unknown')}`,
+    );
+  }
+  const current = captureTaskLineage(snapshot.taskId, orchestrator);
+  if (
+    current.selectedAttemptId !== snapshot.selectedAttemptId
+    || current.generation !== snapshot.generation
+  ) {
+    throw new StaleLineageError(
+      `Task ${snapshot.taskId} lineage changed during fix mutation `
+      + `(attempt ${snapshot.selectedAttemptId} → ${current.selectedAttemptId}, `
+      + `gen ${snapshot.generation} → ${current.generation})`,
+    );
+  }
+}
+
 // ── Deps interfaces ──────────────────────────────────────────
 
 export interface ActionDeps {
@@ -644,15 +710,24 @@ export async function resolveConflictAction(
   taskId: string,
   deps: Pick<ActionDeps, 'orchestrator' | 'persistence' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
   agentName?: string,
+  signal?: AbortSignal,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
   const { orchestrator, persistence, taskExecutor } = deps;
   const { savedError } = orchestrator.beginConflictResolution(taskId);
+  const lineage = captureTaskLineage(taskId, orchestrator);
   try {
     await taskExecutor.resolveConflict(taskId, savedError, agentName);
-    return await finalizeAppliedFix(taskId, savedError, deps);
+    assertLineageCurrent(lineage, orchestrator, signal);
+    return await finalizeAppliedFix(taskId, savedError, deps, signal);
   } catch (err) {
+    if (err instanceof StaleLineageError) throw err;
     const msg = err instanceof Error ? err.message : String(err);
     persistence.appendTaskOutput(taskId, `\n[Resolve Conflict] Failed: ${msg}`);
+    try {
+      assertLineageCurrent(lineage, orchestrator, signal);
+    } catch {
+      throw err;
+    }
     orchestrator.revertConflictResolution(taskId, savedError, msg);
     throw err;
   }
@@ -670,6 +745,7 @@ export async function fixWithAgentAction(
     recoveryRoute?: FailureRecoveryRoute;
     recreateOutputLabel?: string;
     failureOutputLabel?: string;
+    signal?: AbortSignal;
   } = {},
 ): Promise<FixWithAgentActionResult> {
   const { orchestrator, persistence, taskExecutor } = deps;
@@ -694,6 +770,7 @@ export async function fixWithAgentAction(
   }
 
   const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
+  const lineage = captureTaskLineage(taskId, orchestrator);
   try {
     if (recoveryRoute.kind === 'resolveConflict') {
       await taskExecutor.resolveConflict(taskId, persistedSavedError, options.agentName);
@@ -701,17 +778,24 @@ export async function fixWithAgentAction(
       const output = persistence.getTaskOutput(taskId);
       await taskExecutor.fixWithAgent(taskId, output, options.agentName, persistedSavedError);
     }
-    const result = await finalizeAppliedFix(taskId, persistedSavedError, deps);
+    assertLineageCurrent(lineage, orchestrator, options.signal);
+    const result = await finalizeAppliedFix(taskId, persistedSavedError, deps, options.signal);
     return {
       kind: recoveryRoute.kind,
       autoApproved: result.autoApproved,
       started: result.started,
     };
   } catch (err) {
+    if (err instanceof StaleLineageError) throw err;
     const msg = err instanceof Error ? err.message : String(err);
     const errorLabel = options.failureOutputLabel
       ?? (recoveryRoute.kind === 'resolveConflict' ? 'Resolve Conflict' : `Fix with ${options.agentName ?? 'Claude'}`);
     persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
+    try {
+      assertLineageCurrent(lineage, orchestrator, options.signal);
+    } catch {
+      throw err;
+    }
     orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
     throw err;
   }
@@ -721,7 +805,13 @@ export async function finalizeAppliedFix(
   taskId: string,
   savedError: string,
   deps: Pick<ActionDeps, 'orchestrator' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
+  signal?: AbortSignal,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
+  if (signal?.aborted) {
+    throw new StaleLineageError(
+      `Fix mutation for ${taskId} aborted before finalize: ${signal.reason instanceof Error ? signal.reason.message : String(signal.reason ?? 'unknown')}`,
+    );
+  }
   deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
   if (!deps.autoApproveAIFixes) {
     return { autoApproved: false, started: [] };
@@ -897,6 +987,7 @@ export async function autoFixOnFailure(
     taskExecutor: TaskRunner;
     getAutoFixAgent?: () => string | undefined;
     getAutoApproveAIFixes?: () => boolean | undefined;
+    signal?: AbortSignal;
   },
   inlineRetryDepth = 0,
 ): Promise<void> {
@@ -926,6 +1017,7 @@ export async function autoFixOnFailure(
 
   const agentSelection = resolveAutoFixAgent(deps.getAutoFixAgent?.());
   let persistedSavedError: string | undefined;
+  let lineage: TaskLineageSnapshot | undefined;
   try {
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-agent-selected',
@@ -976,6 +1068,7 @@ export async function autoFixOnFailure(
     }
 
     ({ savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId));
+    lineage = captureTaskLineage(taskId, orchestrator);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-begin-conflict-resolution',
       savedErrorLength: persistedSavedError.length,
@@ -986,6 +1079,7 @@ export async function autoFixOnFailure(
       const output = persistence.getTaskOutput(taskId);
       await taskExecutor.fixWithAgent(taskId, output, agentSelection.selectedAgent, persistedSavedError);
     }
+    assertLineageCurrent(lineage, orchestrator, deps.signal);
     const postRouteStrategy = selectAutoFixPostRouteStrategy(task);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-post-route-strategy-selected',
@@ -1000,7 +1094,7 @@ export async function autoFixOnFailure(
         orchestrator,
         taskExecutor,
         autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
-      });
+      }, deps.signal);
       persistence.logEvent?.(taskId, 'debug.auto-fix', {
         phase: 'auto-fix-post-route-finalize',
         autoApproved: finalizeResult.autoApproved,
@@ -1019,6 +1113,7 @@ export async function autoFixOnFailure(
       }
       return;
     }
+    assertLineageCurrent(lineage, orchestrator, deps.signal);
     const started = orchestrator.retryTask(taskId);
     const runnable = started.filter(t => t.status === 'running');
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
@@ -1029,6 +1124,7 @@ export async function autoFixOnFailure(
     });
     if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
   } catch (err) {
+    if (err instanceof StaleLineageError) throw err;
     const msg = err instanceof Error ? err.message : String(err);
     const diagnostics = formatAutoFixDiagnostics(err);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
@@ -1047,6 +1143,13 @@ export async function autoFixOnFailure(
     persistence.appendTaskOutput(taskId, `\n[Auto-fix] Agent failed (attempt ${attempts}/${max}): ${msg}`);
     const detailedMsg = diagnostics ? `${msg}\n\n${diagnostics}` : msg;
     if (persistedSavedError !== undefined) {
+      if (lineage) {
+        try {
+          assertLineageCurrent(lineage, orchestrator, deps.signal);
+        } catch {
+          throw err;
+        }
+      }
       orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg);
     }
   }

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -922,6 +922,225 @@ describe('TaskRunner', () => {
     });
   });
 
+  describe('stale startup-failure lineage guard', () => {
+    it('suppresses metadata write and failed response when selectedAttemptId has advanced', async () => {
+      const handleWorkerResponse = vi.fn();
+      const updateTask = vi.fn();
+      // Orchestrator returns a task whose selectedAttemptId has moved forward
+      const orchestrator = {
+        getTask: () => makeTask({
+          id: 'stale-1',
+          status: 'running',
+          execution: { selectedAttemptId: 'attempt-2', generation: 0 },
+        }),
+        handleWorkerResponse,
+      };
+      const startupErr: any = new Error('SSH connection refused');
+      startupErr.workspacePath = '/tmp/stale-worktree';
+      startupErr.branch = 'experiment/stale-branch';
+      const throwingExecutor = {
+        type: 'ssh',
+        start: async () => { throw startupErr; },
+        onOutput: () => () => {},
+        onComplete: () => () => {},
+      };
+      const registry = {
+        getDefault: () => throwingExecutor,
+        get: () => throwingExecutor,
+        getAll: () => [throwingExecutor],
+      };
+
+      const runner = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: { updateTask } as any,
+        executorRegistry: registry as any,
+        cwd: '/tmp',
+      });
+
+      // Task was launched with attempt-1 but orchestrator now shows attempt-2
+      const task = makeTask({
+        id: 'stale-1',
+        status: 'running',
+        config: { command: 'echo hi', executorType: 'ssh' as any },
+        execution: { selectedAttemptId: 'attempt-1', generation: 0 },
+      });
+      await runner.executeTask(task);
+
+      // Startup-failure metadata must NOT be persisted
+      expect(updateTask).not.toHaveBeenCalledWith(
+        'stale-1',
+        expect.objectContaining({
+          execution: expect.objectContaining({ workspacePath: '/tmp/stale-worktree' }),
+        }),
+      );
+      // Failed WorkResponse must NOT be emitted
+      expect(handleWorkerResponse).not.toHaveBeenCalled();
+    });
+
+    it('suppresses metadata write and failed response when generation has advanced', async () => {
+      const handleWorkerResponse = vi.fn();
+      const updateTask = vi.fn();
+      // Orchestrator returns a task whose generation has bumped
+      const orchestrator = {
+        getTask: () => makeTask({
+          id: 'stale-gen',
+          status: 'running',
+          execution: { generation: 2 },
+        }),
+        handleWorkerResponse,
+      };
+      const startupErr: any = new Error('provision failed');
+      startupErr.workspacePath = '/tmp/old-worktree';
+      startupErr.branch = 'experiment/old-branch';
+      const throwingExecutor = {
+        type: 'ssh',
+        start: async () => { throw startupErr; },
+        onOutput: () => () => {},
+        onComplete: () => () => {},
+      };
+      const registry = {
+        getDefault: () => throwingExecutor,
+        get: () => throwingExecutor,
+        getAll: () => [throwingExecutor],
+      };
+
+      const runner = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: { updateTask } as any,
+        executorRegistry: registry as any,
+        cwd: '/tmp',
+      });
+
+      const task = makeTask({
+        id: 'stale-gen',
+        status: 'running',
+        config: { command: 'echo hi', executorType: 'ssh' as any },
+        execution: { generation: 1 },
+      });
+      await runner.executeTask(task);
+
+      // Metadata must not be written for the old generation
+      expect(updateTask).not.toHaveBeenCalledWith(
+        'stale-gen',
+        expect.objectContaining({
+          execution: expect.objectContaining({ workspacePath: '/tmp/old-worktree' }),
+        }),
+      );
+      expect(handleWorkerResponse).not.toHaveBeenCalled();
+    });
+
+    it('still persists metadata and emits response when lineage is current', async () => {
+      const handleWorkerResponse = vi.fn();
+      const updateTask = vi.fn();
+      // Orchestrator returns a task with matching lineage
+      const orchestrator = {
+        getTask: () => makeTask({
+          id: 'current-1',
+          status: 'running',
+          execution: { selectedAttemptId: 'attempt-1', generation: 0 },
+        }),
+        handleWorkerResponse,
+      };
+      const startupErr: any = new Error('git clone failed');
+      startupErr.workspacePath = '/tmp/current-worktree';
+      startupErr.branch = 'experiment/current-branch';
+      const throwingExecutor = {
+        type: 'ssh',
+        start: async () => { throw startupErr; },
+        onOutput: () => () => {},
+        onComplete: () => () => {},
+      };
+      const registry = {
+        getDefault: () => throwingExecutor,
+        get: () => throwingExecutor,
+        getAll: () => [throwingExecutor],
+      };
+
+      const runner = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: { updateTask } as any,
+        executorRegistry: registry as any,
+        cwd: '/tmp',
+      });
+
+      const task = makeTask({
+        id: 'current-1',
+        status: 'running',
+        config: { command: 'echo hi', executorType: 'ssh' as any },
+        execution: { selectedAttemptId: 'attempt-1', generation: 0 },
+      });
+      await runner.executeTask(task);
+
+      // Metadata SHOULD be persisted when lineage is current
+      expect(updateTask).toHaveBeenCalledWith('current-1', {
+        config: { executorType: 'ssh' },
+        execution: {
+          workspacePath: '/tmp/current-worktree',
+          branch: 'experiment/current-branch',
+        },
+      });
+      // Failed WorkResponse SHOULD be emitted
+      expect(handleWorkerResponse).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actionId: 'current-1',
+          status: 'failed',
+        }),
+      );
+    });
+
+    it('suppresses both inner metadata and outer response when lineage is stale throughout', async () => {
+      const handleWorkerResponse = vi.fn();
+      const updateTask = vi.fn();
+      const orchestrator = {
+        getTask: () => makeTask({
+          id: 'inner-stale',
+          status: 'running',
+          execution: { selectedAttemptId: 'attempt-new', generation: 0 },
+        }),
+        handleWorkerResponse,
+      };
+      const startupErr: any = new Error('timeout');
+      startupErr.workspacePath = '/tmp/inner-stale-ws';
+      startupErr.branch = 'experiment/inner-stale';
+      startupErr.agentSessionId = 'sess-old';
+      const throwingExecutor = {
+        type: 'ssh',
+        start: async () => { throw startupErr; },
+        onOutput: () => () => {},
+        onComplete: () => () => {},
+      };
+      const registry = {
+        getDefault: () => throwingExecutor,
+        get: () => throwingExecutor,
+        getAll: () => [throwingExecutor],
+      };
+
+      const runner = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: { updateTask } as any,
+        executorRegistry: registry as any,
+        cwd: '/tmp',
+      });
+
+      const task = makeTask({
+        id: 'inner-stale',
+        status: 'running',
+        config: { command: 'echo hi', executorType: 'ssh' as any },
+        execution: { selectedAttemptId: 'attempt-old', generation: 0 },
+      });
+      await runner.executeTask(task);
+
+      // Neither inner metadata nor outer response should be written
+      expect(updateTask).not.toHaveBeenCalledWith(
+        'inner-stale',
+        expect.objectContaining({
+          execution: expect.objectContaining({ workspacePath: '/tmp/inner-stale-ws' }),
+        }),
+      );
+      expect(handleWorkerResponse).not.toHaveBeenCalled();
+    });
+  });
+
   describe('upstream branch metadata guard', () => {
     it('fails task when a completed worktree dep has no branch', async () => {
       const tasks = new Map<string, TaskState>();

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -305,11 +305,35 @@ export class TaskRunner {
    * 5. Wire output/completion callbacks
    * 6. On completion → feed response to orchestrator → auto-execute newly ready tasks
    */
+  /**
+   * Check whether the task lineage has moved past the attempt that was
+   * captured at launch time.  Returns `true` when the current
+   * `selectedAttemptId` or `generation` no longer matches, meaning any
+   * persistence from this launch would overwrite a newer attempt's data.
+   */
+  private isLaunchStale(
+    taskId: string,
+    attemptId: string,
+    startGeneration: number,
+  ): boolean {
+    const current = this.orchestrator.getTask(taskId);
+    // If the task is no longer visible to the orchestrator we cannot
+    // confirm the lineage advanced — fall through to the normal failure
+    // path rather than silently suppressing the error.
+    if (!current) return false;
+    const currentAttempt = current.execution.selectedAttemptId;
+    const currentGeneration = current.execution.generation ?? 0;
+    if (currentAttempt !== undefined && currentAttempt !== attemptId) return true;
+    if (currentGeneration !== startGeneration) return true;
+    return false;
+  }
+
   async executeTask(task: TaskState): Promise<void> {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} TaskRunner.executeTask BEGIN taskId=${task.id} isMergeNode=${Boolean(task.config.isMergeNode)} status=${task.status}`,
     );
     const attemptId = this.resolveAttemptIdForStart(task);
+    const startGeneration = task.execution.generation ?? 0;
     if (this.launchingAttemptIds.has(attemptId) || this.activeExecutions.has(attemptId)) {
       traceExecution(
         `[TaskRunner] executeTask skipping duplicate launch for task=${task.id} attempt=${attemptId}`,
@@ -325,6 +349,18 @@ export class TaskRunner {
       if (cause instanceof ResourceLimitError) {
         traceExecution(`[TaskRunner] executeTask deferred for task=${task.id}: ${cause.message}`);
         this.orchestrator.deferTask(task.id);
+        return;
+      }
+
+      // Guard: if the task lineage has advanced past this attempt, the
+      // startup failure belongs to a superseded launch.  Drop the
+      // metadata write and the failed WorkResponse so we don't clobber
+      // the live attempt's state.
+      if (this.isLaunchStale(task.id, attemptId, startGeneration)) {
+        this.logger.warn(
+          `[TaskRunner] suppressing stale startup-failure metadata/response for task=${task.id} attemptId=${attemptId}`,
+        );
+        await this.cleanupPerTaskDockerExecutor(task);
         return;
       }
 
@@ -451,8 +487,11 @@ export class TaskRunner {
     // on the attempt row. Reconciliation paths can then observe the branch
     // even if the executor crashes mid-startup.
     let branchPersistedEarly = false;
+    const startGeneration = task.execution.generation ?? 0;
     const onBranchResolved = (branch: string): void => {
       if (!branch || branchPersistedEarly) return;
+      // Skip if the task has moved to a newer attempt/generation.
+      if (this.isLaunchStale(task.id, attemptId, startGeneration)) return;
       branchPersistedEarly = true;
       try {
         this.persistence.updateAttempt?.(attemptId, { branch } as any);
@@ -538,7 +577,14 @@ export class TaskRunner {
       } catch {
         // Preserve the original startup failure if output persistence also fails.
       }
-      if (meta.workspacePath || meta.branch || meta.agentSessionId || meta.containerId) {
+      // Only persist startup-failure metadata when the launch is still
+      // current.  If the task has moved to a newer attempt or generation
+      // (e.g. via recreate-task), writing old workspace/branch metadata
+      // would corrupt the live attempt's state.
+      if (
+        (meta.workspacePath || meta.branch || meta.agentSessionId || meta.containerId)
+        && !this.isLaunchStale(task.id, attemptId, task.execution.generation ?? 0)
+      ) {
         const execution: Record<string, string> = {};
         if (meta.workspacePath) execution.workspacePath = meta.workspacePath;
         if (meta.branch) execution.branch = meta.branch;

--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -1621,6 +1621,7 @@ run_query_storm_during_tracked_fix() {
 run_same_workflow_tracked_fix_vs_recreate() {
   local workflow_count="$1"
   local operation_burst="$2"
+  local seed_timeout_seconds=120
   invoker_e2e_init
   trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
   cd "$INVOKER_E2E_REPO_ROOT"
@@ -1639,7 +1640,7 @@ run_same_workflow_tracked_fix_vs_recreate() {
   target_workflow="${target_info%%|*}"
   target_task="$target_workflow/root"
   echo "seed tracked fix/recreate target: $target_workflow"
-  ov_wait_task_status "$target_task" failed 30
+  ov_wait_task_status "$target_task" failed "$seed_timeout_seconds"
 
   local -a filler_workflows=()
   local idx info workflow_id
@@ -1647,7 +1648,7 @@ run_same_workflow_tracked_fix_vs_recreate() {
     info="$(ov_submit_workflow fail "same-workflow-fix-recreate-filler-$idx" "" no-track)"
     workflow_id="${info%%|*}"
     filler_workflows+=("$workflow_id")
-    ov_wait_task_status "$workflow_id/root" failed 30
+    ov_wait_task_status "$workflow_id/root" failed "$seed_timeout_seconds"
   done
 
   echo "==> overload: starting tracked fix against same-workflow recreate pressure"
@@ -1847,6 +1848,7 @@ run_fixing_with_ai_visibility() {
 run_owner_restart_loop_during_tracked_recreate_task() {
   local workflow_count="$1"
   local operation_burst="$2"
+  local seed_timeout_seconds=120
   invoker_e2e_init
   trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
   cd "$INVOKER_E2E_REPO_ROOT"
@@ -1865,7 +1867,7 @@ run_owner_restart_loop_during_tracked_recreate_task() {
   target_workflow="${target_info%%|*}"
   target_task="$target_workflow/root"
   echo "seed tracked recreate-task target: $target_workflow"
-  ov_wait_task_status "$target_task" failed 30
+  ov_wait_task_status "$target_task" failed "$seed_timeout_seconds"
 
   local -a fail_workflows=()
   local -a approval_workflows=()
@@ -1874,13 +1876,13 @@ run_owner_restart_loop_during_tracked_recreate_task() {
     info="$(ov_submit_workflow fail "restart-loop-tracked-recreate-task-neighbor-fail-$idx" "" no-track)"
     workflow_id="${info%%|*}"
     fail_workflows+=("$workflow_id")
-    ov_wait_task_status "$workflow_id/root" failed 30
+    ov_wait_task_status "$workflow_id/root" failed "$seed_timeout_seconds"
   done
   for idx in $(seq 1 2); do
     info="$(ov_submit_workflow approval "restart-loop-tracked-recreate-task-neighbor-approval-$idx" "" no-track)"
     workflow_id="${info%%|*}"
     approval_workflows+=("$workflow_id")
-    ov_wait_task_status "$workflow_id/approve-me" awaiting_approval 30
+    ov_wait_task_status "$workflow_id/approve-me" awaiting_approval "$seed_timeout_seconds"
   done
 
   echo "==> overload: starting tracked recreate-task before owner restart loop"

--- a/scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh
+++ b/scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh
@@ -1,0 +1,159 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION=""
+KEEP_ARTIFACTS=0
+TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-120}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh --expect bug|fixed [--keep-artifacts]
+
+What it proves:
+  Race 1 — Fix-intent cancellation:
+    A running `invoker:fix-with-agent` mutation receives an AbortSignal when a
+    higher-priority `invoker:recreate-task` preempts it, preventing stale fix
+    side-effects from writing back to the database after the task has moved on.
+
+  Race 2 — Stale SSH startup-failure metadata:
+    When an SSH executor's startup failure returns after `selectedAttemptId` or
+    `generation` has advanced, the stale `workspacePath` and `branch` metadata
+    must NOT be persisted to the live task row.
+
+Exit codes:
+  0  observed behavior matches --expect
+  1  observed behavior does not match --expect
+  2  repro setup or assertion was invalid / unexpected
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --keep-artifacts)
+      KEEP_ARTIFACTS=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  echo "repro: --expect requires bug|fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-fix-intent-stale-ssh.XXXXXX")"
+LOG_FIX_INTENT="$TMP_DIR/fix-intent-cancellation.log"
+LOG_STALE_SSH="$TMP_DIR/stale-ssh-metadata.log"
+
+cleanup() {
+  if [[ "$KEEP_ARTIFACTS" != "1" ]]; then
+    rm -rf "$TMP_DIR" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+die() {
+  echo "repro: $*" >&2
+  exit 2
+}
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+require_cmd pnpm
+require_cmd timeout
+
+cd "$ROOT_DIR"
+
+# ── Race 1: Fix-intent cancellation ────────────────────────────────────
+# Proves the AbortSignal fires when recreate-task preempts fix-with-agent.
+echo "==> repro: Race 1 — fix-intent cancellation"
+
+set +e
+timeout "$TIMEOUT_SECONDS" \
+  pnpm --filter @invoker/app exec vitest run \
+    --reporter verbose \
+    -t "aborts the dispatch AbortSignal when recreate-task preempts a running fix mutation" \
+    src/__tests__/persisted-workflow-mutation-coordinator.test.ts \
+  >"$LOG_FIX_INTENT" 2>&1
+FIX_INTENT_STATUS=$?
+set -e
+
+FIX_INTENT_OBSERVED=""
+if [[ "$FIX_INTENT_STATUS" -eq 0 ]]; then
+  FIX_INTENT_OBSERVED="fixed"
+else
+  FIX_INTENT_OBSERVED="bug"
+fi
+
+echo "fix_intent_exit   : $FIX_INTENT_STATUS"
+echo "fix_intent_observed : $FIX_INTENT_OBSERVED"
+
+# ── Race 2: Stale SSH startup-failure metadata ─────────────────────────
+# Proves stale metadata is NOT persisted when selectedAttemptId has advanced.
+echo "==> repro: Race 2 — stale SSH startup-failure metadata"
+
+set +e
+timeout "$TIMEOUT_SECONDS" \
+  pnpm --filter @invoker/execution-engine exec vitest run \
+    --reporter verbose \
+    -t "suppresses metadata write and failed response when selectedAttemptId has advanced" \
+    src/__tests__/task-runner.test.ts \
+  >"$LOG_STALE_SSH" 2>&1
+STALE_SSH_STATUS=$?
+set -e
+
+STALE_SSH_OBSERVED=""
+if [[ "$STALE_SSH_STATUS" -eq 0 ]]; then
+  STALE_SSH_OBSERVED="fixed"
+else
+  STALE_SSH_OBSERVED="bug"
+fi
+
+echo "stale_ssh_exit      : $STALE_SSH_STATUS"
+echo "stale_ssh_observed  : $STALE_SSH_OBSERVED"
+
+# ── Aggregate result ──────────────────────────────────────────────────
+echo "==> repro summary"
+
+OVERALL=""
+if [[ "$FIX_INTENT_OBSERVED" == "fixed" && "$STALE_SSH_OBSERVED" == "fixed" ]]; then
+  OVERALL="fixed"
+else
+  OVERALL="bug"
+fi
+
+echo "race1_fix_intent  : $FIX_INTENT_OBSERVED"
+echo "race2_stale_ssh   : $STALE_SSH_OBSERVED"
+echo "overall_observed  : $OVERALL"
+echo "expected          : $EXPECTATION"
+echo "artifacts         : $TMP_DIR"
+
+if [[ "$OVERALL" != "$EXPECTATION" ]]; then
+  echo "==> repro mismatch"
+  echo "--- fix-intent log ---" >&2
+  cat "$LOG_FIX_INTENT" >&2 || true
+  echo "--- stale-ssh log ---" >&2
+  cat "$LOG_STALE_SSH" >&2 || true
+  exit 1
+fi
+
+echo "==> repro matched expectation"
+exit 0

--- a/scripts/repro/repro-fix-intent-cancellation-stack.sh
+++ b/scripts/repro/repro-fix-intent-cancellation-stack.sh
@@ -20,9 +20,23 @@ What it proves:
     preempted and stale SSH startup-failure metadata is suppressed on newer
     lineages.
 
-This wrapper runs both committed repros:
+  Scenario 3 — Stale late completion after reset:
+    A stale task completion must be rejected after `recreate` or `retry-task`
+    resets the workflow lineage.
+
+  Scenario 4 — Same-workflow tracked-fix vs recreate:
+    A tracked fix must not retain authority over a same-workflow recreate
+    request under overload churn.
+
+  Scenario 5 — Owner restart loop during tracked recreate-task:
+    Recreate-task authority must survive repeated owner restart churn.
+
+This wrapper runs the committed repros for that stack:
   - scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
   - scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh
+  - scripts/repro/repro-stale-late-completion-after-reset.sh
+  - scripts/repro/repro-same-workflow-tracked-fix-vs-recreate.sh
+  - scripts/repro/repro-owner-restart-loop-during-tracked-recreate-task.sh
 EOF
 }
 
@@ -58,14 +72,18 @@ cd "$ROOT_DIR"
 
 queue_args=()
 shared_args=(--expect "$EXPECTATION")
+late_completion_args=()
 if [[ "$EXPECTATION" == "bug" ]]; then
   queue_args+=(--expect-bug)
+  late_completion_args+=(--expect-bug)
 else
   queue_args+=(--expect-fixed)
+  late_completion_args+=(--expect-fixed)
 fi
 if [[ "$KEEP_ARTIFACTS" == "1" ]]; then
   queue_args+=(--keep-temp)
   shared_args+=(--keep-artifacts)
+  late_completion_args+=(--keep-temp)
 fi
 
 echo "==> stack repro: Scenario 1 — recreate-task queue authority"
@@ -76,4 +94,24 @@ echo "==> stack repro: Scenario 2 — fix-intent cancellation and stale SSH meta
 bash scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh "${shared_args[@]}"
 
 echo
+echo "==> stack repro: Scenario 3 — stale late completion after reset"
+bash scripts/repro/repro-stale-late-completion-after-reset.sh --mode=both "${late_completion_args[@]}"
+
+echo
+if [[ "$EXPECTATION" == "fixed" ]]; then
+  echo "==> stack repro: Scenario 4 — same-workflow tracked-fix vs recreate"
+  bash scripts/repro/repro-same-workflow-tracked-fix-vs-recreate.sh
+
+  echo
+  echo "==> stack repro: Scenario 5 — owner restart loop during tracked recreate-task"
+  bash scripts/repro/repro-owner-restart-loop-during-tracked-recreate-task.sh
+
+  echo
+else
+  echo "==> stack repro: skipping fixed-only overload scenarios for --expect bug"
+  echo "skipped: repro-same-workflow-tracked-fix-vs-recreate.sh"
+  echo "skipped: repro-owner-restart-loop-during-tracked-recreate-task.sh"
+  echo
+fi
+
 echo "==> stack repro matched expectation"

--- a/scripts/repro/repro-fix-intent-cancellation-stack.sh
+++ b/scripts/repro/repro-fix-intent-cancellation-stack.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION=""
+KEEP_ARTIFACTS=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-fix-intent-cancellation-stack.sh --expect bug|fixed [--keep-artifacts]
+
+What it proves:
+  Scenario 1 — Recreate-task queue authority:
+    A higher-priority `recreate-task` must preempt an older running workflow
+    mutation instead of remaining queued behind it.
+
+  Scenario 2 — Fix-intent cancellation + stale SSH metadata:
+    The focused shared repro proves the running fix mutation is aborted when
+    preempted and stale SSH startup-failure metadata is suppressed on newer
+    lineages.
+
+This wrapper runs both committed repros:
+  - scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
+  - scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --keep-artifacts)
+      KEEP_ARTIFACTS=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  echo "repro: --expect requires bug|fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+cd "$ROOT_DIR"
+
+queue_args=()
+shared_args=(--expect "$EXPECTATION")
+if [[ "$EXPECTATION" == "bug" ]]; then
+  queue_args+=(--expect-bug)
+else
+  queue_args+=(--expect-fixed)
+fi
+if [[ "$KEEP_ARTIFACTS" == "1" ]]; then
+  queue_args+=(--keep-temp)
+  shared_args+=(--keep-artifacts)
+fi
+
+echo "==> stack repro: Scenario 1 — recreate-task queue authority"
+bash scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh "${queue_args[@]}"
+
+echo
+echo "==> stack repro: Scenario 2 — fix-intent cancellation and stale SSH metadata"
+bash scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh "${shared_args[@]}"
+
+echo
+echo "==> stack repro matched expectation"

--- a/scripts/repro/repro-recreate-blocked-by-running-workflow-mutation.sh
+++ b/scripts/repro/repro-recreate-blocked-by-running-workflow-mutation.sh
@@ -176,6 +176,7 @@ set -e
 WORKFLOW_ID="$(
   {
     sed -n 's/^Workflow ID: //p' "$SUBMIT_STDOUT"
+    sed -n 's/^Delegated to owner .*workflow: //p' "$SUBMIT_STDOUT"
     sed -n 's/^Delegated to GUI .*workflow: //p' "$SUBMIT_STDOUT"
   } | head -n1
 )"

--- a/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
+++ b/scripts/repro/repro-recreate-task-blocked-by-running-workflow-mutation.sh
@@ -196,6 +196,7 @@ set -e
 WORKFLOW_ID="$(
   {
     sed -n 's/^Workflow ID: //p' "$SUBMIT_STDOUT"
+    sed -n 's/^Delegated to owner .*workflow: //p' "$SUBMIT_STDOUT"
     sed -n 's/^Delegated to GUI .*workflow: //p' "$SUBMIT_STDOUT"
   } | head -n1
 )"

--- a/scripts/repro/repro-stale-late-completion-after-reset.sh
+++ b/scripts/repro/repro-stale-late-completion-after-reset.sh
@@ -101,6 +101,7 @@ submit_workflow_with_retry() {
     WORKFLOW_ID="$(
       {
         sed -n 's/^Workflow ID: //p' "$SUBMIT_STDOUT"
+        sed -n 's/^Delegated to owner .*workflow: //p' "$SUBMIT_STDOUT"
         sed -n 's/^Delegated to GUI .*workflow: //p' "$SUBMIT_STDOUT"
       } | head -n1
     )"

--- a/scripts/test-suites/README.md
+++ b/scripts/test-suites/README.md
@@ -56,6 +56,7 @@ The orchestrator is **`scripts/run-all-tests.sh`**, invoked as **`pnpm run test:
   - `required/20-e2e-dry-run.sh`: `case-1.*`
   - `required/21-e2e-dry-run-downstream.sh`: `case-2.*`
   - `required/22-e2e-dry-run-github.sh`: `case-4.*`
+  - `required/23-fix-intent-repros.sh`: fix-intent cancellation, stale-lineage, and recreate authority repro bundle
   - `optional/32-e2e-chaos.sh`: generated local + GUI-owner chaos matrix
   - `optional/33-e2e-chaos-overload.sh`: generated overload chaos suite for saturation and mixed-operation storms
   - `optional/30-e2e-ssh.sh`: `case-3.1` to `case-3.3`

--- a/scripts/test-suites/required/23-fix-intent-repros.sh
+++ b/scripts/test-suites/required/23-fix-intent-repros.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Blocking repro bundle for the fix-intent cancellation / stale-lineage stack.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+export REPRO_TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-180}"
+export INVOKER_REPRO_TIMEOUT_SECONDS="${INVOKER_REPRO_TIMEOUT_SECONDS:-600}"
+
+exec xvfb-run --auto-servernum \
+  bash "$ROOT/scripts/repro/repro-fix-intent-cancellation-stack.sh" --expect fixed


### PR DESCRIPTION
## Summary

This verification step adds a stack-level repro bundle that runs the recreate-task queue-authority scenario, the focused shared stale-lineage repro, the stale late-completion reset repro, and the two overload scenarios for tracked-fix versus recreate authority.

It also promotes that repro bundle onto the required CI surface so the scenario-level regressions block merges alongside the focused package checks and the final full-suite gate.

## Test Plan

- [ ] `bash scripts/repro/repro-fix-intent-cancellation-stack.sh --expect fixed`
- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/persisted-workflow-mutation-coordinator.test.ts`
- [ ] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-worktree-metadata-repro.test.ts`
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No
