### PR TITLE
Cost Query Attempt Attribution via Persisted Attempts

### DIFF
--- a/packages/app/src/__tests__/cost-rollup.test.ts
+++ b/packages/app/src/__tests__/cost-rollup.test.ts
@@ -33,7 +33,7 @@ function makeContext(overrides: Partial<AttributionContext> = {}): AttributionCo
   return {
     workflowId: 'wf-1',
     taskId: 'wf-1/task-a',
-    attemptId: 'wf-1/task-a-latest',
+    attemptId: 'attempt-1',
     runnerKind: 'worktree',
     agentSessionId: 'sess-abc',
     agentName: 'codex',
@@ -81,7 +81,7 @@ function makeEvent(overrides: Partial<{
     attribution: {
       workflowId,
       taskId,
-      attemptId: `${taskId}-latest`,
+      attemptId: 'attempt-1',
       runnerKind: 'worktree',
     },
     usage: { inputTokens, outputTokens, cachedTokens, totalTokens },
@@ -363,11 +363,11 @@ describe('buildAttributionContext', () => {
       agentSessionId: 'sess-123',
       agentName: 'codex',
     };
-    const ctx = buildAttributionContext(task);
+    const ctx = buildAttributionContext(task, 'attempt-123');
     expect(ctx).toEqual({
       workflowId: 'wf-1',
       taskId: 'wf-1/task-a',
-      attemptId: 'wf-1/task-a-latest',
+      attemptId: 'attempt-123',
       runnerKind: 'worktree',
       agentSessionId: 'sess-123',
       agentName: 'codex',
@@ -381,7 +381,7 @@ describe('buildAttributionContext', () => {
       workflowId: 'wf-1',
       runnerKind: 'worktree',
     };
-    expect(buildAttributionContext(task)).toBeUndefined();
+    expect(buildAttributionContext(task, 'attempt-123')).toBeUndefined();
   });
 
   it('falls back to lastAgentSessionId and lastAgentName', () => {
@@ -392,7 +392,7 @@ describe('buildAttributionContext', () => {
       lastAgentSessionId: 'sess-old',
       lastAgentName: 'claude',
     };
-    const ctx = buildAttributionContext(task);
+    const ctx = buildAttributionContext(task, 'attempt-older');
     expect(ctx?.agentSessionId).toBe('sess-old');
     expect(ctx?.agentName).toBe('claude');
     expect(ctx?.source).toBe('anthropic');
@@ -405,8 +405,18 @@ describe('buildAttributionContext', () => {
       runnerKind: '',
       agentSessionId: 'sess-123',
     };
-    const ctx = buildAttributionContext(task);
+    const ctx = buildAttributionContext(task, 'attempt-123');
     expect(ctx?.runnerKind).toBe('worktree');
+  });
+
+  it('returns undefined when attempt ID is empty', () => {
+    const task: CostTaskInfo = {
+      id: 'wf-1/task-a',
+      workflowId: 'wf-1',
+      runnerKind: 'worktree',
+      agentSessionId: 'sess-123',
+    };
+    expect(buildAttributionContext(task, '')).toBeUndefined();
   });
 });
 

--- a/packages/app/src/__tests__/cost-rollup.test.ts
+++ b/packages/app/src/__tests__/cost-rollup.test.ts
@@ -375,6 +375,27 @@ describe('buildAttributionContext', () => {
     });
   });
 
+  it('uses the caller-provided persisted session identity when supplied', () => {
+    const task: CostTaskInfo = {
+      id: 'wf-1/task-a',
+      workflowId: 'wf-1',
+      runnerKind: 'worktree',
+      agentSessionId: 'sess-current',
+      lastAgentSessionId: 'sess-old',
+      agentName: 'codex',
+    };
+    const ctx = buildAttributionContext(task, 'attempt-persisted', 'sess-persisted');
+    expect(ctx).toEqual({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      attemptId: 'attempt-persisted',
+      runnerKind: 'worktree',
+      agentSessionId: 'sess-persisted',
+      agentName: 'codex',
+      source: 'openai',
+    });
+  });
+
   it('returns undefined when no session ID is available', () => {
     const task: CostTaskInfo = {
       id: 'wf-1/task-a',

--- a/packages/app/src/__tests__/headless-query-cost.test.ts
+++ b/packages/app/src/__tests__/headless-query-cost.test.ts
@@ -12,6 +12,11 @@ const noopLogger = {
   child: vi.fn(function () { return noopLogger; }),
 };
 
+const attemptsByTaskId = new Map<string, Array<{ id: string; agentSessionId?: string }>>([
+  ['wf-1/task-a', [{ id: 'wf-1/task-a-attempt-1', agentSessionId: 'sess-wf-1-task-a' }]],
+  ['wf-1/task-b', [{ id: 'wf-1/task-b-attempt-1', agentSessionId: 'sess-wf-1-task-b' }]],
+]);
+
 function makeWorkflow(id: string, status: 'completed' | 'failed' | 'running') {
   return { id, name: `Workflow ${id}`, status, createdAt: '2025-01-01T00:00:00Z', updatedAt: '2025-01-01T00:01:00Z' };
 }
@@ -96,6 +101,7 @@ describe('headless query cost', () => {
         readOnly: false,
         listWorkflows: vi.fn(() => [makeWorkflow('wf-1', 'completed')]),
         loadTasks: vi.fn(() => []),
+        loadAttempts: vi.fn((taskId: string) => attemptsByTaskId.get(taskId) ?? []),
       } as unknown as SQLiteAdapter,
       commandService: {} as CommandService,
       executorRegistry: {} as any,
@@ -252,6 +258,7 @@ describe('headless query cost-events', () => {
         readOnly: false,
         listWorkflows: vi.fn(() => [makeWorkflow('wf-1', 'completed')]),
         loadTasks: vi.fn(() => []),
+        loadAttempts: vi.fn((taskId: string) => attemptsByTaskId.get(taskId) ?? []),
       } as unknown as SQLiteAdapter,
       commandService: {} as CommandService,
       executorRegistry: {} as any,
@@ -290,9 +297,15 @@ describe('headless query cost-events', () => {
       expect(event).toHaveProperty('outputTokens');
       expect(event).toHaveProperty('workflowId');
       expect(event).toHaveProperty('taskId');
+      expect(event).toHaveProperty('attemptId');
       expect(event).toHaveProperty('model');
       expect(event).toHaveProperty('confidence');
     }
+    expect(parsed.map((event: any) => event.attemptId)).toEqual([
+      'wf-1/task-a-attempt-1',
+      'wf-1/task-a-attempt-1',
+      'wf-1/task-b-attempt-1',
+    ]);
   });
 
   it('outputs events in JSONL format (one per line)', async () => {
@@ -356,6 +369,25 @@ describe('headless query cost-events', () => {
     const output2 = stdoutSpy.mock.calls[0][0] as string;
 
     expect(output1).toBe(output2);
+  });
+
+  it('uses selectedAttemptId when no exact persisted session match exists', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [
+      makeTask('wf-1', 'task-a', {
+        execution: {
+          selectedAttemptId: 'wf-1/task-a-selected',
+        } as any,
+      }),
+    ] as any);
+    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+      { id: 'wf-1/task-a-older', agentSessionId: 'sess-older' },
+      { id: 'wf-1/task-a-selected', agentSessionId: 'sess-wf-1-task-a' },
+    ]);
+
+    await runHeadless(['query', 'cost-events', '--output', 'json'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed[0].attemptId).toBe('wf-1/task-a-selected');
   });
 
   it('supports JSONL piping without special handling', async () => {

--- a/packages/app/src/__tests__/headless-query-cost.test.ts
+++ b/packages/app/src/__tests__/headless-query-cost.test.ts
@@ -210,6 +210,54 @@ describe('headless query cost', () => {
 
     expect(output1).toBe(output2);
   });
+
+  it('loads the exact persisted attempt session before selectedAttemptId for query cost', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [
+      makeTask('wf-1', 'task-a', {
+        execution: {
+          agentSessionId: 'sess-wf-1-task-a',
+          selectedAttemptId: 'wf-1/task-a-selected',
+        } as any,
+      }),
+    ] as any);
+    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+      { id: 'wf-1/task-a-selected', agentSessionId: 'sess-stale' },
+      { id: 'wf-1/task-a-exact', agentSessionId: 'sess-wf-1-task-a' },
+    ]);
+
+    await runHeadless(['query', 'cost', '--output', 'json'], mockDeps);
+
+    expect(mockDriver.loadSession).toHaveBeenCalledWith('sess-wf-1-task-a');
+    expect(mockDriver.loadSession).not.toHaveBeenCalledWith('sess-stale');
+
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.totals.eventCount).toBe(2);
+  });
+
+  it('falls back to the latest persisted attempt session for query cost when no selected attempt exists', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [
+      makeTask('wf-1', 'task-b', {
+        execution: {
+          agentSessionId: undefined,
+          selectedAttemptId: undefined,
+        } as any,
+      }),
+    ] as any);
+    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+      { id: 'wf-1/task-b-older', agentSessionId: 'sess-old-b' },
+      { id: 'wf-1/task-b-latest', agentSessionId: 'sess-wf-1-task-b' },
+    ]);
+
+    await runHeadless(['query', 'cost', '--output', 'json'], mockDeps);
+
+    expect(mockDriver.loadSession).toHaveBeenCalledWith('sess-wf-1-task-b');
+    expect(mockDriver.loadSession).not.toHaveBeenCalledWith('sess-old-b');
+
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.totals.eventCount).toBe(1);
+  });
 });
 
 describe('headless query cost-events', () => {
@@ -375,6 +423,7 @@ describe('headless query cost-events', () => {
     mockDeps.orchestrator.getAllTasks = vi.fn(() => [
       makeTask('wf-1', 'task-a', {
         execution: {
+          agentName: 'codex',
           selectedAttemptId: 'wf-1/task-a-selected',
         } as any,
       }),
@@ -388,6 +437,110 @@ describe('headless query cost-events', () => {
     const output = stdoutSpy.mock.calls[0][0] as string;
     const parsed = JSON.parse(output);
     expect(parsed[0].attemptId).toBe('wf-1/task-a-selected');
+  });
+
+  it('prefers an exact persisted agentSessionId match before selectedAttemptId', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [
+      makeTask('wf-1', 'task-a', {
+        execution: {
+          agentSessionId: 'sess-wf-1-task-a',
+          selectedAttemptId: 'wf-1/task-a-selected',
+        } as any,
+      }),
+    ] as any);
+    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+      { id: 'wf-1/task-a-selected', agentSessionId: 'sess-stale' },
+      { id: 'wf-1/task-a-exact', agentSessionId: 'sess-wf-1-task-a' },
+    ]);
+
+    await runHeadless(['query', 'cost-events', '--output', 'json'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.map((event: any) => event.attemptId)).toEqual([
+      'wf-1/task-a-exact',
+      'wf-1/task-a-exact',
+    ]);
+  });
+
+  it('falls back to the latest persisted attempt when no selected attempt is available', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [
+      makeTask('wf-1', 'task-b', {
+        execution: {
+          agentSessionId: undefined,
+          selectedAttemptId: undefined,
+        } as any,
+      }),
+    ] as any);
+    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+      { id: 'wf-1/task-b-older', agentSessionId: 'sess-old-b' },
+      { id: 'wf-1/task-b-latest', agentSessionId: 'sess-wf-1-task-b' },
+    ]);
+
+    await runHeadless(['query', 'cost-events', '--output', 'json'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.map((event: any) => event.attemptId)).toEqual([
+      'wf-1/task-b-latest',
+    ]);
+  });
+
+  it('serializes resolved persisted attempt IDs deterministically', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [
+      makeTask('wf-1', 'task-a', {
+        execution: {
+          agentName: 'codex',
+          selectedAttemptId: 'wf-1/task-a-selected',
+        } as any,
+      }),
+    ] as any);
+    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+      { id: 'wf-1/task-a-older', agentSessionId: 'sess-older' },
+      { id: 'wf-1/task-a-selected', agentSessionId: 'sess-wf-1-task-a' },
+    ]);
+
+    await runHeadless(['query', 'cost-events', '--output', 'json'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+
+    expect(output).toBe(JSON.stringify([
+      {
+        eventId: 'codex-turn-0',
+        agentSessionId: 'sess-wf-1-task-a',
+        agentName: 'codex',
+        source: 'openai',
+        workflowId: 'wf-1',
+        taskId: 'wf-1/task-a',
+        attemptId: 'wf-1/task-a-selected',
+        runnerKind: 'worktree',
+        inputTokens: 100,
+        outputTokens: 50,
+        cachedTokens: 0,
+        totalTokens: 150,
+        model: 'gpt-4o',
+        pricingVersion: '0',
+        estimatedCostUsd: 0,
+        confidence: 'exact',
+        timestamp: '2025-01-01T00:00:00Z',
+      },
+      {
+        eventId: 'codex-turn-1',
+        agentSessionId: 'sess-wf-1-task-a',
+        agentName: 'codex',
+        source: 'openai',
+        workflowId: 'wf-1',
+        taskId: 'wf-1/task-a',
+        attemptId: 'wf-1/task-a-selected',
+        runnerKind: 'worktree',
+        inputTokens: 200,
+        outputTokens: 80,
+        cachedTokens: 0,
+        totalTokens: 280,
+        model: 'gpt-4o',
+        pricingVersion: '0',
+        estimatedCostUsd: 0,
+        confidence: 'exact',
+        timestamp: '2025-01-01T00:00:00Z',
+      },
+    ]) + '\n');
   });
 
   it('supports JSONL piping without special handling', async () => {

--- a/packages/app/src/__tests__/headless-query-costs.test.ts
+++ b/packages/app/src/__tests__/headless-query-costs.test.ts
@@ -12,6 +12,11 @@ const noopLogger = {
   child: vi.fn(function () { return noopLogger; }),
 };
 
+const attemptsByTaskId = new Map<string, Array<{ id: string; agentSessionId?: string }>>([
+  ['wf-1/task-a', [{ id: 'wf-1/task-a-attempt-1', agentSessionId: 'sess-wf-1-task-a' }]],
+  ['wf-1/task-b', [{ id: 'wf-1/task-b-attempt-1', agentSessionId: 'sess-wf-1-task-b' }]],
+]);
+
 function makeWorkflow(id: string, status: 'completed' | 'failed' | 'running') {
   return { id, name: `Workflow ${id}`, status, createdAt: '2025-01-01T00:00:00Z', updatedAt: '2025-01-01T00:01:00Z' };
 }
@@ -97,6 +102,7 @@ describe('headless query costs', () => {
         readOnly: false,
         listWorkflows: vi.fn(() => [makeWorkflow('wf-1', 'completed')]),
         loadTasks: vi.fn(() => []),
+        loadAttempts: vi.fn((taskId: string) => attemptsByTaskId.get(taskId) ?? []),
       } as unknown as SQLiteAdapter,
       commandService: {} as CommandService,
       executorRegistry: {} as any,
@@ -133,6 +139,11 @@ describe('headless query costs', () => {
     expect(parsed.total.eventCount).toBe(3); // 2 turns from task-a + 1 from task-b
     expect(parsed.total.inputTokens).toBe(600); // 100 + 200 + 300
     expect(parsed.total.outputTokens).toBe(250); // 50 + 80 + 120
+    expect(parsed.events.map((event: any) => event.attemptId)).toEqual([
+      'wf-1/task-a-attempt-1',
+      'wf-1/task-a-attempt-1',
+      'wf-1/task-b-attempt-1',
+    ]);
   });
 
   it('outputs events in JSONL format', async () => {
@@ -180,6 +191,65 @@ describe('headless query costs', () => {
     const output2 = stdoutSpy.mock.calls[0][0] as string;
 
     expect(output1).toBe(output2);
+  });
+
+  it('prefers an exact persisted agentSessionId match before selectedAttemptId', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [
+      makeTask('wf-1', 'task-a', {
+        execution: {
+          agentSessionId: 'sess-wf-1-task-a',
+          selectedAttemptId: 'wf-1/task-a-selected',
+        } as any,
+      }),
+    ] as any);
+    (mockDeps.persistence.loadAttempts as any) = vi.fn(() => [
+      { id: 'wf-1/task-a-selected', agentSessionId: 'sess-stale' },
+      { id: 'wf-1/task-a-exact', agentSessionId: 'sess-wf-1-task-a' },
+    ]);
+
+    await runHeadless(['query', 'costs', '--output', 'json'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.events[0].attemptId).toBe('wf-1/task-a-exact');
+  });
+
+  it('falls back to selectedAttemptId, then to the latest persisted attempt', async () => {
+    mockDeps.orchestrator.getAllTasks = vi.fn(() => [
+      makeTask('wf-1', 'task-a', {
+        execution: {
+          selectedAttemptId: 'wf-1/task-a-selected',
+        } as any,
+      }),
+      makeTask('wf-1', 'task-b', {
+        execution: {
+          agentSessionId: 'sess-wf-1-task-b',
+        } as any,
+      }),
+    ] as any);
+    (mockDeps.persistence.loadAttempts as any) = vi.fn((taskId: string) => {
+      if (taskId === 'wf-1/task-a') {
+        return [
+          { id: 'wf-1/task-a-older', agentSessionId: 'sess-old' },
+          { id: 'wf-1/task-a-selected', agentSessionId: 'sess-wf-1-task-a' },
+        ];
+      }
+      if (taskId === 'wf-1/task-b') {
+        return [
+          { id: 'wf-1/task-b-older', agentSessionId: 'sess-old-b' },
+          { id: 'wf-1/task-b-latest', agentSessionId: 'sess-wf-1-task-b' },
+        ];
+      }
+      return [];
+    });
+
+    await runHeadless(['query', 'costs', '--output', 'json'], mockDeps);
+    const output = stdoutSpy.mock.calls[0][0] as string;
+    const parsed = JSON.parse(output);
+    expect(parsed.events.map((event: any) => event.attemptId)).toEqual([
+      'wf-1/task-a-selected',
+      'wf-1/task-a-selected',
+      'wf-1/task-b-latest',
+    ]);
   });
 
   it('skips tasks without session drivers', async () => {

--- a/packages/app/src/cost-rollup.ts
+++ b/packages/app/src/cost-rollup.ts
@@ -193,18 +193,22 @@ export function deriveSource(agentName: string): string {
 }
 
 /**
- * Build an AttributionContext from a task info record.
+ * Build an AttributionContext from a task info record plus a caller-selected attempt ID.
  * Returns undefined if no session ID is available.
  */
-export function buildAttributionContext(task: CostTaskInfo): AttributionContext | undefined {
-  const sessionId = resolveSessionId(task);
+export function buildAttributionContext(
+  task: CostTaskInfo,
+  attemptId: string,
+  sessionId: string | undefined = resolveSessionId(task),
+): AttributionContext | undefined {
+  if (!attemptId) return undefined;
   if (!sessionId) return undefined;
 
   const agentName = resolveAgentName(task);
   return {
     workflowId: task.workflowId,
     taskId: task.id,
-    attemptId: `${task.id}-latest`,
+    attemptId,
     runnerKind: task.runnerKind || 'worktree',
     agentSessionId: sessionId,
     agentName,

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -13,7 +13,7 @@ import type { BundledSkillsInstallMode, BundledSkillsStatus, Logger } from '@inv
 import { makeEnvelope } from '@invoker/contracts';
 import type { AgentSessionData } from '@invoker/contracts';
 import { OrchestratorErrorCode } from '@invoker/workflow-core';
-import type { Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
+import type { Attempt, Orchestrator, CommandService, TaskDelta, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { Channels } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
@@ -622,61 +622,11 @@ async function headlessCosts(
     formatAsJson,
   } = await import('./formatter.js');
   const {
-    attributeSessionUsage, groupCostEvents, buildAttributionContext,
+    groupCostEvents,
     serializeGroupedRollup,
   } = await import('./cost-rollup.js');
   const { rollUpCostEvents } = await import('@invoker/contracts');
-
-  // Determine target workflow
-  const workflowFilter = flags.workflow ?? flags.positional[0];
-  const workflows = deps.persistence.listWorkflows();
-  if (workflows.length === 0) {
-    process.stdout.write('No workflows found.\n');
-    return;
-  }
-
-  const targetWorkflows = workflowFilter
-    ? workflows.filter(wf => wf.id === workflowFilter)
-    : workflows;
-
-  if (workflowFilter && targetWorkflows.length === 0) {
-    throw new Error(`Workflow "${workflowFilter}" not found.`);
-  }
-
-  // Collect all NormalizedCostEvents across tasks
-  const allEvents: import('@invoker/contracts').NormalizedCostEvent[] = [];
-
-  for (const wf of targetWorkflows) {
-    deps.orchestrator.syncFromDb(wf.id);
-    const tasks = deps.orchestrator.getAllTasks().filter(
-      t => t.config.workflowId === wf.id && !t.config.isMergeNode,
-    );
-
-    for (const task of tasks) {
-      const ctx = buildAttributionContext({
-        id: task.id,
-        workflowId: wf.id,
-        runnerKind: task.config.runnerKind ?? 'worktree',
-        agentSessionId: task.execution.agentSessionId,
-        lastAgentSessionId: task.execution.lastAgentSessionId,
-        agentName: task.execution.agentName,
-        lastAgentName: task.execution.lastAgentName,
-      });
-      if (!ctx) continue;
-
-      // Extract usage from session driver
-      const agentName = ctx.agentName;
-      const driver = deps.executionAgentRegistry?.getSessionDriver(agentName);
-      if (!driver?.extractUsage) continue;
-
-      const raw = driver.loadSession(ctx.agentSessionId);
-      if (!raw) continue;
-
-      const usageEvents = driver.extractUsage(raw);
-      const attributed = attributeSessionUsage(usageEvents, ctx);
-      allEvents.push(...attributed);
-    }
-  }
+  const allEvents = await collectCostEvents(flags, deps);
 
   if (allEvents.length === 0) {
     process.stdout.write('No cost data available.\n');
@@ -715,6 +665,25 @@ async function headlessCosts(
 
 type CostQueryDeps = Pick<HeadlessDeps, 'orchestrator' | 'persistence' | 'executionAgentRegistry'>;
 
+function resolveCostAttributionAttempt(
+  task: TaskState,
+  attempts: readonly Attempt[],
+): Attempt | undefined {
+  const sessionId = task.execution.agentSessionId?.trim();
+  if (sessionId) {
+    const exactSessionAttempt = attempts.find((attempt) => attempt.agentSessionId?.trim() === sessionId);
+    if (exactSessionAttempt) return exactSessionAttempt;
+  }
+
+  const selectedAttemptId = task.execution.selectedAttemptId?.trim();
+  if (selectedAttemptId) {
+    const selectedAttempt = attempts.find((attempt) => attempt.id === selectedAttemptId);
+    if (selectedAttempt) return selectedAttempt;
+  }
+
+  return attempts.at(-1);
+}
+
 async function collectCostEvents(
   flags: QueryFlags,
   deps: CostQueryDeps,
@@ -742,6 +711,8 @@ async function collectCostEvents(
     );
 
     for (const task of tasks) {
+      const attempts = deps.persistence.loadAttempts(task.id);
+      const attributedAttempt = resolveCostAttributionAttempt(task, attempts);
       const ctx = buildAttributionContext({
         id: task.id,
         workflowId: wf.id,
@@ -750,7 +721,7 @@ async function collectCostEvents(
         lastAgentSessionId: task.execution.lastAgentSessionId,
         agentName: task.execution.agentName,
         lastAgentName: task.execution.lastAgentName,
-      });
+      }, attributedAttempt?.id ?? task.execution.selectedAttemptId?.trim() ?? task.id, attributedAttempt?.agentSessionId?.trim());
       if (!ctx) continue;
 
       const agentName = ctx.agentName;


### PR DESCRIPTION
## Summary

Fix AI task cost attribution to the actual execution.

AI task cost exports previously used a fake `${task.id}-latest` attempt ID, so usage from agent sessions lost the execution identity needed for joins and auditability. Resolve the attempt ID from the session that produced the usage, with selected/latest attempt fallbacks only when there is no exact session match.

## Architecture

### Before

```mermaid
graph TD
    A[Headless cost query] --> B[Build attribution in cost-rollup]
    B --> C[Synthesize task-id-latest attemptId]
    C --> D[Load agent session]
    D --> E[Export cost totals and events]
```

### After

```mermaid
graph TD
    A[Headless cost query] --> B[Load persisted attempts for task]
    B --> C{Resolve attempt}
    C -->|agentSessionId match| D[Exact persisted attempt]
    C -->|selectedAttemptId| E[Selected persisted attempt]
    C -->|fallback| F[Latest persisted attempt]
    D --> G[Build attribution in cost-rollup]
    E --> G
    F --> G
    G --> H[Load resolved agent session]
    H --> I[Export cost totals and events with persisted attemptId]
```

## Test Plan

- [x] `cd packages/app && pnpm test -- src/__tests__/cost-rollup.test.ts src/__tests__/headless-query-cost.test.ts`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: Re-run the focused cost query tests and `pnpm run test:all`
- Data migration? No
