### PR TITLE
Review Strategy Split Step 2: runtime model cutover

### DIFF
--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestHarness, type TestHarness, InMemoryBus, InMemoryPersistence, MockGit } from '@invoker/test-kit';
 import { Orchestrator, type PlanDefinition, type TaskState } from '@invoker/workflow-core';
-import { TaskRunner, ExecutorRegistry, type MergeGateProvider } from '@invoker/execution-engine';
+import { TaskRunner, ExecutorRegistry, ReviewProviderRegistry, type MergeGateProvider } from '@invoker/execution-engine';
 import { setWorkflowMergeMode } from '../workflow-actions.js';
 import { executeGlobalTopup } from '../global-topup.js';
 
@@ -1162,7 +1162,7 @@ const MANUAL_MERGE_ONFINISH_NONE_PLAN: PlanDefinition = {
 
 describe('Flow 9c: set-merge-mode external_review', () => {
   const mockMergeGate: MergeGateProvider = {
-    name: 'mock',
+    name: 'github',
     createReview: async () => ({
       url: 'https://github.com/owner/repo/pull/99',
       identifier: 'owner/repo#99',
@@ -1175,8 +1175,14 @@ describe('Flow 9c: set-merge-mode external_review', () => {
     }),
   };
 
+  function mockRegistry(): ReviewProviderRegistry {
+    const registry = new ReviewProviderRegistry();
+    registry.register(mockMergeGate);
+    return registry;
+  }
+
   it('switching manual gate to external_review creates PR metadata and persists external_review', async () => {
-    const h = createTestHarness({ mergeGateProvider: mockMergeGate });
+    const h = createTestHarness({ reviewProviderRegistry: mockRegistry() });
     h.loadAndStart(MANUAL_MERGE_ONFINISH_NONE_PLAN);
     h.completeTask('A');
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -187,7 +187,6 @@ export function createHeadlessExecutor(
       secretsFile: resolveSecretsFilePath(deps.invokerConfig),
     },
     remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
-    mergeGateProvider: new GitHubMergeGateProvider(),
     reviewProviderRegistry: (() => {
       const registry = new ReviewProviderRegistry();
       registry.register(new GitHubMergeGateProvider());

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1470,7 +1470,6 @@ if (isHeadless) {
         secretsFile: resolveSecretsFilePath(invokerConfig),
       },
       remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
-      mergeGateProvider: new GitHubMergeGateProvider(),
       reviewProviderRegistry: (() => {
         const registry = new ReviewProviderRegistry();
         registry.register(new GitHubMergeGateProvider());

--- a/packages/execution-engine/src/__tests__/publication-strategy-router.test.ts
+++ b/packages/execution-engine/src/__tests__/publication-strategy-router.test.ts
@@ -22,20 +22,12 @@ describe('resolvePublicationProvider', () => {
       expect(result).toBe(github);
     });
 
-    it('resolves from fallback when registry has no github provider', () => {
+    it('throws when registry has no github provider', () => {
       const registry = new ReviewProviderRegistry();
-      const fallback = makeFakeProvider('github');
 
-      const result = resolvePublicationProvider('github_pr', registry, fallback);
-      expect(result).toBe(fallback);
-    });
-
-    it('resolves from fallback even with a different provider name for github_pr', () => {
-      const registry = new ReviewProviderRegistry();
-      const fallback = makeFakeProvider('custom-gh');
-
-      const result = resolvePublicationProvider('github_pr', registry, fallback);
-      expect(result).toBe(fallback);
+      expect(() => resolvePublicationProvider('github_pr', registry)).toThrow(
+        /No provider registered for publication strategy "github_pr"/,
+      );
     });
 
     it('defaults to github_pr when strategy is undefined', () => {
@@ -45,13 +37,6 @@ describe('resolvePublicationProvider', () => {
 
       const result = resolvePublicationProvider(undefined, registry);
       expect(result).toBe(github);
-    });
-
-    it('defaults to github_pr with fallback when strategy is undefined', () => {
-      const fallback = makeFakeProvider('github');
-
-      const result = resolvePublicationProvider(undefined, undefined, fallback);
-      expect(result).toBe(fallback);
     });
   });
 
@@ -73,19 +58,10 @@ describe('resolvePublicationProvider', () => {
       );
     });
 
-    it('throws when registry is undefined and fallback is a different provider', () => {
-      const fallback = makeFakeProvider('github');
-
-      expect(() => resolvePublicationProvider('mergify_stack', undefined, fallback)).toThrow(
+    it('throws when registry is undefined', () => {
+      expect(() => resolvePublicationProvider('mergify_stack', undefined)).toThrow(
         /No provider registered for publication strategy "mergify_stack"/,
       );
-    });
-
-    it('resolves from fallback when fallback name matches mergify_stack', () => {
-      const fallback = makeFakeProvider('mergify_stack');
-
-      const result = resolvePublicationProvider('mergify_stack', undefined, fallback);
-      expect(result).toBe(fallback);
     });
   });
 
@@ -107,21 +83,8 @@ describe('resolvePublicationProvider', () => {
     });
   });
 
-  describe('registry precedence over fallback', () => {
-    it('prefers registry provider over fallback', () => {
-      const registry = new ReviewProviderRegistry();
-      const registryProvider = makeFakeProvider('github');
-      const fallback = makeFakeProvider('github');
-      registry.register(registryProvider);
-
-      const result = resolvePublicationProvider('github_pr', registry, fallback);
-      expect(result).toBe(registryProvider);
-      expect(result).not.toBe(fallback);
-    });
-  });
-
-  describe('no registry and no fallback', () => {
-    it('throws when both registry and fallback are undefined', () => {
+  describe('no registry', () => {
+    it('throws when registry is undefined', () => {
       expect(() => resolvePublicationProvider('github_pr', undefined)).toThrow(
         /No provider registered/,
       );
@@ -184,13 +147,8 @@ describe('resolvePublicationProvider', () => {
       const github = makeFakeProvider('github');
       registry.register(github);
 
-      // Also provide a fallback (legacy pattern)
-      const fallback = makeFakeProvider('github');
-
-      // Strategy resolution should prefer registry over fallback
-      const provider = resolvePublicationProvider('github_pr', registry, fallback);
+      const provider = resolvePublicationProvider('github_pr', registry);
       expect(provider).toBe(github);
-      expect(provider).not.toBe(fallback);
     });
 
     it('undefined strategy defaults to github_pr and resolves registered github provider', () => {

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
 import { collectTransitiveNonMergeTaskIds } from '../merge-runner.js';
 import { SshExecutor } from '../ssh-executor.js';
+import { ReviewProviderRegistry } from '../review-provider-registry.js';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
 import { EventEmitter } from 'events';
@@ -93,6 +94,13 @@ function createMockLogger(): Logger {
   };
   (logger.child as any).mockReturnValue(logger);
   return logger;
+}
+
+/** Wraps a mock merge-gate provider in a ReviewProviderRegistry for TaskRunner. */
+function wrapInRegistry(provider: Record<string, any>): ReviewProviderRegistry {
+  const registry = new ReviewProviderRegistry();
+  registry.register({ name: 'github', ...provider } as any);
+  return registry;
 }
 
 const tempWorkspaces: string[] = [];
@@ -2444,7 +2452,7 @@ describe('TaskRunner', () => {
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
         callbacks: { onComplete },
-        mergeGateProvider: mergeGateProvider as any,
+        reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
       });
 
       const gitCalls: string[][] = [];
@@ -2483,7 +2491,7 @@ describe('TaskRunner', () => {
       const commitCall = gitCalls.find(c => c[0] === 'commit');
       expect(commitCall).toBeUndefined();
 
-      // Should create a PR via mergeGateProvider (using the gate clone dir, not host.cwd)
+      // Should create a PR via review provider (using the gate clone dir, not host.cwd)
       expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
         expect.objectContaining({
           baseBranch: 'master',
@@ -2628,7 +2636,7 @@ describe('TaskRunner', () => {
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
         callbacks: { onComplete },
-        mergeGateProvider: mergeGateProvider as any,
+        reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
       });
 
       (executor as any).execGitReadonly = async (args: string[], cwd?: string) => {
@@ -2652,7 +2660,7 @@ describe('TaskRunner', () => {
 
       await (executor as any).executeMergeNode(mergeTask);
 
-      // Should create a PR via mergeGateProvider
+      // Should create a PR via review provider
       expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
         expect.objectContaining({
           baseBranch: 'master',
@@ -2709,7 +2717,7 @@ describe('TaskRunner', () => {
         persistence: persistence as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
-        mergeGateProvider: mergeGateProvider as any,
+        reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
       });
 
       (executor as any).execGitReadonly = async (args: string[]) => {
@@ -2772,7 +2780,7 @@ describe('TaskRunner', () => {
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
         callbacks: { onComplete },
-        mergeGateProvider: mergeGateProvider as any,
+        reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
       });
 
       (executor as any).execGitReadonly = async (args: string[], cwd?: string) => {
@@ -2942,7 +2950,7 @@ describe('TaskRunner', () => {
         persistence: persistence as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
-        mergeGateProvider: mergeGateProvider as any,
+        reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
       });
 
       (executor as any).execGitReadonly = async (args: string[], cwd?: string) => {
@@ -3007,7 +3015,7 @@ describe('TaskRunner', () => {
         persistence: persistence as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
-        mergeGateProvider: mergeGateProvider as any,
+        reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
       });
 
       (executor as any).execGitReadonly = async (args: string[], cwd?: string) => {
@@ -3219,7 +3227,7 @@ describe('TaskRunner', () => {
         persistence: persistence as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
-        mergeGateProvider: mergeGateProvider as any,
+        reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
       });
 
       (executor as any).execGitReadonly = async (args: string[], cwd?: string) => {
@@ -3397,7 +3405,7 @@ describe('TaskRunner', () => {
         persistence: persistence as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
-        mergeGateProvider: mergeGateProvider as any,
+        reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
       });
 
       // Simulate active poller by adding to activePrPollers map
@@ -3449,7 +3457,7 @@ describe('TaskRunner', () => {
         persistence: persistence as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
-        mergeGateProvider: mergeGateProvider as any,
+        reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
       });
 
       // Simulate active poller
@@ -3484,7 +3492,7 @@ describe('TaskRunner', () => {
         persistence: persistence as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp',
-        mergeGateProvider: mergeGateProvider as any,
+        reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
       });
 
       await executor.checkPrApprovalNow('task-with-no-poller');
@@ -3493,7 +3501,7 @@ describe('TaskRunner', () => {
       expect(persistence.updateTask).not.toHaveBeenCalled();
     });
 
-    it('is no-op when no mergeGateProvider and no registry', async () => {
+    it('is no-op when no registry', async () => {
       const orchestrator = {
         getTask: vi.fn((id: string) => ({
           id,
@@ -3561,7 +3569,7 @@ describe('TaskRunner', () => {
           persistence: persistence as any,
           executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
           cwd: '/runner-base-cwd',
-          mergeGateProvider: mergeGateProvider as any,
+          reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
         });
 
         (executor as any).activePrPollers.set('task-ws', setInterval(() => {}, 1000));
@@ -3601,7 +3609,7 @@ describe('TaskRunner', () => {
           persistence: persistence as any,
           executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
           cwd: '/runner-base-cwd',
-          mergeGateProvider: mergeGateProvider as any,
+          reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
         });
 
         (executor as any).activePrPollers.set('task-no-ws', setInterval(() => {}, 1000));
@@ -3644,7 +3652,7 @@ describe('TaskRunner', () => {
           persistence: persistence as any,
           executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
           cwd: '/runner-base-cwd',
-          mergeGateProvider: mergeGateProvider as any,
+          reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
         });
 
         const interval = setInterval(() => {}, 1000);
@@ -3696,7 +3704,7 @@ describe('TaskRunner', () => {
           persistence: persistence as any,
           executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
           cwd: '/runner-base-cwd',
-          mergeGateProvider: mergeGateProvider as any,
+          reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
         });
 
         await executor.checkMergeGateStatuses();
@@ -3735,7 +3743,7 @@ describe('TaskRunner', () => {
           persistence: persistence as any,
           executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
           cwd: '/runner-base-cwd',
-          mergeGateProvider: mergeGateProvider as any,
+          reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
         });
 
         await executor.checkMergeGateStatuses();
@@ -3777,7 +3785,7 @@ describe('TaskRunner', () => {
           persistence: persistence as any,
           executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
           cwd: '/runner-base-cwd',
-          mergeGateProvider: mergeGateProvider as any,
+          reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
         });
 
         await executor.checkMergeGateStatuses();
@@ -3822,7 +3830,7 @@ describe('TaskRunner', () => {
             persistence: persistence as any,
             executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
             cwd: '/runner-base-cwd',
-            mergeGateProvider: mergeGateProvider as any,
+            reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
           });
 
           (executor as any).startPrPolling('poll-task', 'owner/repo#300', 'wf-1');
@@ -3866,7 +3874,7 @@ describe('TaskRunner', () => {
             persistence: persistence as any,
             executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
             cwd: '/runner-base-cwd',
-            mergeGateProvider: mergeGateProvider as any,
+            reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
           });
 
           (executor as any).startPrPolling('poll-task-no-ws', 'owner/repo#301', 'wf-1');
@@ -3913,7 +3921,7 @@ describe('TaskRunner', () => {
             persistence: persistence as any,
             executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
             cwd: '/runner-base-cwd',
-            mergeGateProvider: mergeGateProvider as any,
+            reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
           });
 
           (executor as any).startPrPolling('poll-approved', 'owner/repo#302', 'wf-1');
@@ -6267,7 +6275,7 @@ describe('TaskRunner', () => {
         persistence: persistence as any,
         executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
         cwd: '/tmp/host',
-        mergeGateProvider: mergeGateProvider as any,
+        reviewProviderRegistry: wrapInRegistry(mergeGateProvider),
       });
 
       (executor as any).execGitReadonly = async (args: string[]) => {
@@ -6338,7 +6346,7 @@ describe('TaskRunner', () => {
       const hostCalls = gitCalls.filter((c) => c.dir === '/tmp/host');
       expect(hostCalls).toHaveLength(0);
 
-      // PR created via mergeGateProvider (using gate clone dir, not host.cwd)
+      // PR created via review provider (using gate clone dir, not host.cwd)
       expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
         expect.objectContaining({
           baseBranch: 'master',

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -15,7 +15,6 @@ import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkResponse } from '@invoker/contracts';
 import type { TaskRunnerCallbacks } from './task-runner.js';
-import type { MergeGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 import { resolvePublicationProvider } from './publication-strategy-router.js';
@@ -142,7 +141,6 @@ export interface MergeRunnerHost {
   readonly defaultBranch: string | undefined;
   readonly callbacks: TaskRunnerCallbacks;
   readonly cwd: string;
-  readonly mergeGateProvider?: MergeGateProvider;
   readonly reviewProviderRegistry?: ReviewProviderRegistry;
 
   execGitReadonly(args: string[], cwd?: string): Promise<string>;
@@ -436,7 +434,6 @@ export async function executeMergeNodeImpl(
         const reviewProvider = resolvePublicationProvider(
           publicationStrategy,
           host.reviewProviderRegistry,
-          host.mergeGateProvider,
         );
 
         let fullSummary = summary;
@@ -940,7 +937,6 @@ export async function publishAfterFixImpl(
       const reviewProvider = resolvePublicationProvider(
         publicationStrategy,
         host.reviewProviderRegistry,
-        host.mergeGateProvider,
       );
 
       const result = await reviewProvider.createReview({

--- a/packages/execution-engine/src/publication-strategy-router.ts
+++ b/packages/execution-engine/src/publication-strategy-router.ts
@@ -34,15 +34,12 @@ export type PublicationStrategyKey = 'github_pr' | 'mergify_stack';
  *
  * @param strategy    The workflow-level strategy key (defaults to `'github_pr'`).
  * @param registry    Provider registry to look up the concrete implementation.
- * @param fallback    Optional provider to use when the registry has no match
- *                    (e.g. the legacy `mergeGateProvider` singleton on TaskRunner).
  * @returns           The resolved provider.
  * @throws            When no provider can be resolved for the strategy.
  */
 export function resolvePublicationProvider(
   strategy: string | undefined,
   registry: ReviewProviderRegistry | undefined,
-  fallback?: MergeGateProvider,
 ): MergeGateProvider {
   const effectiveStrategy = strategy ?? 'github_pr';
   const providerName = STRATEGY_TO_PROVIDER[effectiveStrategy];
@@ -54,24 +51,9 @@ export function resolvePublicationProvider(
     );
   }
 
-  // Try registry first.
   if (registry) {
     const provider = registry.get(providerName);
     if (provider) return provider;
-  }
-
-  // Fall back to the legacy singleton when the registry has no match
-  // and the strategy maps to the same provider the fallback represents.
-  if (fallback && fallback.name === providerName) {
-    return fallback;
-  }
-
-  // When the fallback is a different provider (or absent) and the strategy
-  // is the default `github_pr`, still accept the fallback. This preserves
-  // backward compatibility for callers that only set `mergeGateProvider`
-  // without populating the registry.
-  if (fallback && effectiveStrategy === 'github_pr') {
-    return fallback;
   }
 
   throw new Error(

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -115,7 +115,6 @@ export interface TaskRunnerConfig {
   /** Default branch from config (e.g. "master"). Falls back to git heuristic if unset. */
   defaultBranch?: string;
   callbacks?: TaskRunnerCallbacks;
-  mergeGateProvider?: MergeGateProvider;
   reviewProviderRegistry?: ReviewProviderRegistry;
   /**
    * Provider that returns remote SSH targets keyed by target ID.
@@ -151,7 +150,6 @@ export class TaskRunner {
   private maxWorktreesPerRepo: number;
   /** @internal */ defaultBranch: string | undefined;
   /** @internal */ callbacks: TaskRunnerCallbacks;
-  /** @internal */ mergeGateProvider?: MergeGateProvider;
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
   private activePrPollers = new Map<string, ReturnType<typeof setInterval>>();
   private getRemoteTargets: () => Record<string, { host: string; user: string; sshKeyPath: string; port?: number; managedWorkspaces?: boolean; remoteInvokerHome?: string; provisionCommand?: string }>;
@@ -223,7 +221,6 @@ export class TaskRunner {
     this.maxWorktreesPerRepo = config.maxWorktreesPerRepo ?? 5;
     this.defaultBranch = config.defaultBranch;
     this.callbacks = config.callbacks ?? {};
-    this.mergeGateProvider = config.mergeGateProvider;
     this.reviewProviderRegistry = config.reviewProviderRegistry;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
     this.dockerConfig = config.dockerConfig ?? {};
@@ -1436,14 +1433,13 @@ export class TaskRunner {
 
   /**
    * Resolve the review provider for a workflow using the publication strategy router.
-   * Falls back to the legacy `mergeGateProvider` singleton for backward compatibility.
-   * Returns `undefined` when no provider can be resolved (no registry and no fallback).
+   * Returns `undefined` when no provider can be resolved (no registry).
    */
   private resolveReviewProviderForWorkflow(workflowId: string | undefined): MergeGateProvider | undefined {
     const workflow = workflowId ? this.persistence.loadWorkflow(workflowId) : undefined;
     const strategy = workflow?.publicationStrategy;
     try {
-      return resolvePublicationProvider(strategy, this.reviewProviderRegistry, this.mergeGateProvider);
+      return resolvePublicationProvider(strategy, this.reviewProviderRegistry);
     } catch {
       // No provider available for this strategy — return undefined so callers can skip gracefully.
       return undefined;

--- a/packages/test-kit/src/test-harness.ts
+++ b/packages/test-kit/src/test-harness.ts
@@ -1,5 +1,5 @@
 import { Orchestrator, type PlanDefinition, type TaskState } from '@invoker/workflow-core';
-import { TaskRunner, ExecutorRegistry, type MergeGateProvider } from '@invoker/execution-engine';
+import { TaskRunner, ExecutorRegistry, type ReviewProviderRegistry } from '@invoker/execution-engine';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { Executor, ExecutorHandle, PersistedTaskMeta, TerminalSpec } from '@invoker/execution-engine';
 import { InMemoryPersistence } from './in-memory-persistence.js';
@@ -84,7 +84,7 @@ export interface TestHarness {
  */
 export function createTestHarness(opts?: {
   maxConcurrency?: number;
-  mergeGateProvider?: MergeGateProvider;
+  reviewProviderRegistry?: ReviewProviderRegistry;
 }): TestHarness {
   const persistence = new InMemoryPersistence();
   const bus = new InMemoryBus();
@@ -102,7 +102,7 @@ export function createTestHarness(opts?: {
     persistence: persistence as any,
     executorRegistry,
     cwd: '/tmp/test-harness',
-    mergeGateProvider: opts?.mergeGateProvider,
+    reviewProviderRegistry: opts?.reviewProviderRegistry,
   });
 
   const git = new MockGit();


### PR DESCRIPTION
## Summary
This is stack PR 2/4 for the review-strategy split. It cuts workflow-core and execution-engine runtime behavior over to the explicit review-publication and approval model, and removes legacy `mergeGateProvider` fallback wiring.

It verifies the runtime cut with focused `packages/workflow-core` and `packages/execution-engine` test lanes plus a full `pnpm run test:all` regression pass.

---
Review Strategy Split Step 2: runtime model cutover — 4 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1778297986912-3/implement-runtime-model-cutover | Layer: domain
Feature state: active
Goal:
- Cut runtime review publication and approval behavior over to the explicit split model and remove legacy provider fallback wiring.
Motivation:
- The old runtime path smears review publication, approval behavior, and provider lookup across overlapping concepts, making future changes hard to reason about.
Alternative considerations:
- Option A: rename fields only while keeping the existing fallback/router behavior.
- Option B: bundle runtime changes together with parser/UI terminology work.
Implementation details:
- Update workflow-core and execution-engine so external review publication and polling key off explicit review metadata, and approval behavior keys off approval semantics.
- Remove `mergeGateProvider` fallback construction and require provider resolution through the registry/strategy path only.
- Reject incompatible review/finish-mode combinations instead of silently tolerating mixed models.
Files:
- packages/workflow-core/src/orchestrator.ts
- packages/execution-engine/src/merge-runner.ts
- packages/execution-engine/src/task-runner.ts
- packages/execution-engine/src/review-provider-registry.ts
- packages/execution-engine/src/publication-strategy-router.ts
- packages/app/src/main.ts
- packages/app/src/headless.ts
- packages/test-kit/src/test-harness.ts
Change types:
- modify
- delete
Acceptance criteria:
- External review creation and polling are driven only by the explicit split runtime model.
- `mergeGateProvider` fallback wiring is removed from runtime construction and resolution.
- Runtime tests cover approval, rejection, and provider lookup behavior on the cutover path.
 | completed |
| wf-1778297986912-3/verify-workflow-core-runtime-lane | Layer: app_regression
Feature state: active
Goal:
- Verify workflow-core behavior after the runtime cutover.
Motivation:
- Core approval/review state transitions should fail independently from execution-engine wiring if the runtime split is wrong.
Alternative considerations:
- Option A: rely only on execution-engine tests.
- Option B: defer isolation to the final full-suite gate.
Implementation details:
- Run the workflow-core package tests after runtime refactoring.
Acceptance criteria:
- `cd packages/workflow-core && pnpm test` exits 0.
 | completed (passed) |
| wf-1778297986912-3/verify-execution-engine-runtime-lane | Layer: app_regression
Feature state: active
Goal:
- Verify execution-engine provider resolution and review polling after the runtime cutover.
Motivation:
- Provider lookup and merge-gate polling are the runtime seams most likely to regress during the split.
Alternative considerations:
- Option A: rely only on workflow-core coverage.
- Option B: wait for app/UI integration tests later in the chain.
Implementation details:
- Run the execution-engine package tests after provider fallback removal.
Acceptance criteria:
- `cd packages/execution-engine && pnpm test` exits 0.
 | completed (passed) |
| wf-1778297986912-3/post-fix-regression | Layer: app_regression
Feature state: active
Goal:
- Run the terminal full-repository regression gate for the runtime cutover.
Motivation:
- Runtime refactors can break integration points outside workflow-core and execution-engine.
Alternative considerations:
- Option A: stop after focused package lanes.
- Option B: rely on a later stacked workflow's full-suite gate only.
Implementation details:
- Execute `pnpm run test:all` after the focused runtime lanes pass.
Acceptance criteria:
- `pnpm run test:all` exits 0.
 | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1778297986912-3/implement-runtime-model-cutover — Layer: domain
Feature state: active
Goal:
- Cut runtime review publication and approval behavior over to the explicit split model and remove legacy provider fallback wiring.
Motivation:
- The old runtime path smears review publication, approval behavior, and provider lookup across overlapping concepts, making future changes hard to reason about.
Alternative considerations:
- Option A: rename fields only while keeping the existing fallback/router behavior.
- Option B: bundle runtime changes together with parser/UI terminology work.
Implementation details:
- Update workflow-core and execution-engine so external review publication and polling key off explicit review metadata, and approval behavior keys off approval semantics.
- Remove `mergeGateProvider` fallback construction and require provider resolution through the registry/strategy path only.
- Reject incompatible review/finish-mode combinations instead of silently tolerating mixed models.
Files:
- packages/workflow-core/src/orchestrator.ts
- packages/execution-engine/src/merge-runner.ts
- packages/execution-engine/src/task-runner.ts
- packages/execution-engine/src/review-provider-registry.ts
- packages/execution-engine/src/publication-strategy-router.ts
- packages/app/src/main.ts
- packages/app/src/headless.ts
- packages/test-kit/src/test-harness.ts
Change types:
- modify
- delete
Acceptance criteria:
- External review creation and polling are driven only by the explicit split runtime model.
- `mergeGateProvider` fallback wiring is removed from runtime construction and resolution.
- Runtime tests cover approval, rejection, and provider lookup behavior on the cutover path.

.../ci-triggers/2026-05-06-master-healthcheck.md   |   1 +
 .github/workflows/ci.yml                           |  33 +-
 .mergify.yml                                       |  36 ++
 ARCHITECTURE.md                                    | 127 +++++
 CONTRIBUTING.md                                    |  16 +-
 README.md                                          |   4 +-
 docs/architecture-owner-broker-model.md            | 126 +++++
 docs/invoker-config-example.json                   |   3 +-
 docs/mergify-stack-lifecycle-poc.md                | 573 +++++++++++++++++++++
 docs/persistence-architecture-single-writer.md     |  10 +-
 docs/pr-branching-workflow.md                      |  58 ++-
 package.json                                       |   4 +-
 .../approve-fix-modal-with-session-log.png         | Bin 81499 -> 70953 bytes
 .../context-menu-danger-separator-fallback.png     | Bin 78345 -> 78043 bytes
 .../context-menu-failed-organization.png           | Bin 74850 -> 73606 bytes
 .../queue-action-surface-hardening.png             | Bin 0 -> 88203 bytes
 .../queue-relationships-expanded-context.png       | Bin 0 -> 66088 bytes
 .../queue-semantics-action-states.png              | Bin 0 -> 87313 bytes
 .../queue-view-concurrency.png                     | Bin 56862 -> 53137 bytes
 .../terminate-wording-task-vs-workflow.png         | Bin 0 -> 77252 bytes
 ...
 248 files changed, 19785 insertions(+), 2393 deletions(-)

### wf-1778297986912-3/verify-workflow-core-runtime-lane — Layer: app_regression
Feature state: active
Goal:
- Verify workflow-core behavior after the runtime cutover.
Motivation:
- Core approval/review state transitions should fail independently from execution-engine wiring if the runtime split is wrong.
Alternative considerations:
- Option A: rely only on execution-engine tests.
- Option B: defer isolation to the final full-suite gate.
Implementation details:
- Run the workflow-core package tests after runtime refactoring.
Acceptance criteria:
- `cd packages/workflow-core && pnpm test` exits 0.


### wf-1778297986912-3/verify-execution-engine-runtime-lane — Layer: app_regression
Feature state: active
Goal:
- Verify execution-engine provider resolution and review polling after the runtime cutover.
Motivation:
- Provider lookup and merge-gate polling are the runtime seams most likely to regress during the split.
Alternative considerations:
- Option A: rely only on workflow-core coverage.
- Option B: wait for app/UI integration tests later in the chain.
Implementation details:
- Run the execution-engine package tests after provider fallback removal.
Acceptance criteria:
- `cd packages/execution-engine && pnpm test` exits 0.


### wf-1778297986912-3/post-fix-regression — Layer: app_regression
Feature state: active
Goal:
- Run the terminal full-repository regression gate for the runtime cutover.
Motivation:
- Runtime refactors can break integration points outside workflow-core and execution-engine.
Alternative considerations:
- Option A: stop after focused package lanes.
- Option B: rely on a later stacked workflow's full-suite gate only.
Implementation details:
- Execute `pnpm run test:all` after the focused runtime lanes pass.
Acceptance criteria:
- `pnpm run test:all` exits 0.


</details>