### PR TITLE
Review Strategy Split Step 3: parser and headless surface rename

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -899,26 +899,35 @@ describe('POST /api/workflows/:id/detach', () => {
   });
 });
 
-describe('POST /api/workflows/:id/merge-mode', () => {
-  it('sets merge mode', async () => {
-    const res = await request(port, 'POST', '/api/workflows/wf-1/merge-mode', { mode: 'automatic' });
+describe('POST /api/workflows/:id/review-mode', () => {
+  it('sets review mode via canonical endpoint', async () => {
+    const res = await request(port, 'POST', '/api/workflows/wf-1/review-mode', { mode: 'automatic' });
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(res.body.action).toBe('merge_mode_set');
+    expect(res.body.action).toBe('review_mode_set');
     expect(res.body.mode).toBe('automatic');
     expect(mocks.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { mergeMode: 'automatic' });
   });
 
   it('returns 400 when mode is missing', async () => {
-    const res = await request(port, 'POST', '/api/workflows/wf-1/merge-mode', {});
+    const res = await request(port, 'POST', '/api/workflows/wf-1/review-mode', {});
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Missing "mode"');
   });
 
   it('returns 400 on invalid mode', async () => {
-    const res = await request(port, 'POST', '/api/workflows/wf-1/merge-mode', { mode: 'invalid' });
+    const res = await request(port, 'POST', '/api/workflows/wf-1/review-mode', { mode: 'invalid' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Invalid mergeMode');
+  });
+
+  it('deprecated merge-mode alias still works with deprecation header', async () => {
+    const res = await request(port, 'POST', '/api/workflows/wf-1/merge-mode', { mode: 'automatic' });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.action).toBe('merge_mode_set');
+    expect(res.body.deprecated).toBe(true);
+    expect(res.body.replacement).toBe('/api/workflows/:id/review-mode');
   });
 });
 

--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createTestHarness, type TestHarness, InMemoryBus, InMemoryPersistence, MockGit } from '@invoker/test-kit';
 import { Orchestrator, type PlanDefinition, type TaskState } from '@invoker/workflow-core';
 import { TaskRunner, ExecutorRegistry, ReviewProviderRegistry, type MergeGateProvider } from '@invoker/execution-engine';
-import { setWorkflowMergeMode } from '../workflow-actions.js';
+import { setWorkflowReviewMode } from '../workflow-actions.js';
 import { executeGlobalTopup } from '../global-topup.js';
 
 // ── Shared Plans ────────────────────────────────────────────
@@ -1160,7 +1160,7 @@ const MANUAL_MERGE_ONFINISH_NONE_PLAN: PlanDefinition = {
 
 // ── Flow 9c: UI external_review merge mode ───────────────────
 
-describe('Flow 9c: set-merge-mode external_review', () => {
+describe('Flow 9c: set-review-mode external_review', () => {
   const mockMergeGate: MergeGateProvider = {
     name: 'github',
     createReview: async () => ({
@@ -1191,7 +1191,7 @@ describe('Flow 9c: set-merge-mode external_review', () => {
     await h.executor.executeTasks([h.getTask(mergeId)!]);
     expect(h.getTask(mergeId)!.status).toBe('review_ready');
 
-    await setWorkflowMergeMode(wfId, 'external_review', {
+    await setWorkflowReviewMode(wfId, 'external_review', {
       orchestrator: h.orchestrator,
       persistence: h.persistence,
       taskExecutor: h.executor,

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -428,6 +428,20 @@ tasks:
     expect(() => parsePlan(yaml)).toThrow('Plan-level "autoFixRetries" is no longer supported');
   });
 
+  it('rejects legacy mergeGateProvider key', () => {
+    const yaml = `
+name: Legacy Provider
+repoUrl: git@github.com:test/repo.git
+mergeGateProvider: github
+tasks:
+  - id: t1
+    description: "Task"
+    command: "echo hi"
+`;
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow('"mergeGateProvider" is no longer supported');
+  });
+
   it('rejects task-level autoFix', () => {
     const yaml = `
 name: AutoFix Task Level

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -25,7 +25,7 @@ import {
   editTaskPrompt,
   editTaskType,
   selectExperiment,
-  setWorkflowMergeMode,
+  setWorkflowReviewMode,
   fixWithAgentAction,
   finalizeAppliedFix,
   autoFixOnFailure,
@@ -1431,7 +1431,7 @@ describe('selectExperiment', () => {
   });
 });
 
-describe('setWorkflowMergeMode', () => {
+describe('setWorkflowReviewMode', () => {
   // These tests pin the wrapper's two branches:
   //   - merge node present  -> `orchestrator.editTaskMergeMode`
   //   - merge node absent   -> direct `persistence.updateWorkflow`
@@ -1459,7 +1459,7 @@ describe('setWorkflowMergeMode', () => {
   });
 
   it('routes through orchestrator.editTaskMergeMode with the canonical mode when a merge node exists', async () => {
-    await setWorkflowMergeMode('wf-1', 'external_review', {
+    await setWorkflowReviewMode('wf-1', 'external_review', {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
@@ -1472,7 +1472,7 @@ describe('setWorkflowMergeMode', () => {
   });
 
   it('executes runnable tasks returned by the orchestrator', async () => {
-    await setWorkflowMergeMode('wf-1', 'automatic', {
+    await setWorkflowReviewMode('wf-1', 'automatic', {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
@@ -1485,7 +1485,7 @@ describe('setWorkflowMergeMode', () => {
   it('does not execute when the orchestrator returns no runnable tasks (e.g. same-mode no-op)', async () => {
     orchestrator.editTaskMergeMode.mockReturnValueOnce([]);
 
-    await setWorkflowMergeMode('wf-1', 'manual', {
+    await setWorkflowReviewMode('wf-1', 'manual', {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
@@ -1498,7 +1498,7 @@ describe('setWorkflowMergeMode', () => {
   it('falls back to a direct persistence write when no merge node exists (no-merge-gate workflow)', async () => {
     persistence.loadTasks.mockReturnValue([makeTask({ id: 'task-a', status: 'completed' })]);
 
-    await setWorkflowMergeMode('wf-1', 'manual', {
+    await setWorkflowReviewMode('wf-1', 'manual', {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
@@ -1511,7 +1511,7 @@ describe('setWorkflowMergeMode', () => {
 
   it('throws on invalid merge mode', async () => {
     await expect(
-      setWorkflowMergeMode('wf-1', 'invalid', {
+      setWorkflowReviewMode('wf-1', 'invalid', {
         orchestrator: orchestrator as unknown as Orchestrator,
         persistence: persistence as unknown as SQLiteAdapter,
         taskExecutor: taskExecutor as unknown as TaskRunner,

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -33,7 +33,7 @@
  *   POST   /api/workflows/:id/restart
  *   POST   /api/workflows/:id/recreate-with-rebase
  *   POST   /api/workflows/:id/cancel
- *   POST   /api/workflows/:id/merge-mode  body: { mode }
+ *   POST   /api/workflows/:id/review-mode body: { mode }
  *   DELETE /api/workflows/:id
  */
 
@@ -594,10 +594,13 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
-      // POST /api/workflows/:id/merge-mode
+      // POST /api/workflows/:id/review-mode  (canonical)
+      // POST /api/workflows/:id/merge-mode   (deprecated alias)
+      const wfReviewModeMatch = path.match(/^\/api\/workflows\/([^/]+)\/review-mode$/);
       const wfMergeModeMatch = path.match(/^\/api\/workflows\/([^/]+)\/merge-mode$/);
-      if (method === 'POST' && wfMergeModeMatch) {
-        const workflowId = decodeURIComponent(wfMergeModeMatch[1]);
+      if (method === 'POST' && (wfReviewModeMatch || wfMergeModeMatch)) {
+        const isLegacy = !!wfMergeModeMatch;
+        const workflowId = decodeURIComponent((wfReviewModeMatch ?? wfMergeModeMatch)![1]);
         try {
           const body = await readBody(req);
           const { mode } = JSON.parse(body);
@@ -605,8 +608,20 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "mode" in request body' });
             return;
           }
-          await mutations.setWorkflowMergeMode(workflowId, mode);
-          json(res, 200, { ok: true, workflowId, action: 'merge_mode_set', mode });
+          if (isLegacy) {
+            res.setHeader(
+              'Deprecation',
+              'true; reason="Use /api/workflows/:id/review-mode"',
+            );
+          }
+          await mutations.setWorkflowReviewMode(workflowId, mode);
+          json(res, 200, {
+            ok: true,
+            workflowId,
+            action: isLegacy ? 'merge_mode_set' : 'review_mode_set',
+            mode,
+            ...(isLegacy ? { deprecated: true, replacement: '/api/workflows/:id/review-mode' } : {}),
+          });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -109,7 +109,7 @@ export function isHeadlessMutatingCommand(args: string[]): boolean {
 
   if (command === 'set') {
     const sub = args[1];
-    return ['command', 'executor', 'agent', 'merge-mode', 'gate-policy'].includes(sub ?? '');
+    return ['command', 'executor', 'agent', 'review-mode', 'merge-mode', 'gate-policy'].includes(sub ?? '');
   }
 
   if (['list', 'status', 'task-status', 'queue', 'audit', 'session', 'query-select', 'watch'].includes(command)) {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -41,7 +41,7 @@ import {
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
   forkWorkflow as sharedForkWorkflow,
-  setWorkflowMergeMode,
+  setWorkflowReviewMode,
 } from './workflow-actions.js';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
@@ -589,7 +589,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
 async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing set sub-command. Usage: --headless set <command|executor|agent|merge-mode|gate-policy>');
+    throw new Error('Missing set sub-command. Usage: --headless set <command|executor|agent|review-mode|gate-policy>');
   }
 
   switch (subCommand) {
@@ -605,8 +605,12 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
     case 'agent':
       await headlessEditAgent(args[1], args[2], deps);
       break;
+    case 'review-mode':
+      await headlessSetReviewMode(args[1], args[2], deps);
+      break;
     case 'merge-mode':
-      await headlessSetMergeMode(args[1], args[2], deps);
+      warnDeprecated('set merge-mode', 'set review-mode');
+      await headlessSetReviewMode(args[1], args[2], deps);
       break;
     case 'fix-prompt':
       await headlessSetFixContext(args[1], { fixPrompt: args.slice(2).join(' ') }, deps);
@@ -618,7 +622,7 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
       await headlessSetGatePolicy(args.slice(1), deps);
       break;
     default:
-      throw new Error(`Unknown set sub-command: "${subCommand}". Use: command, prompt, executor, agent, merge-mode, fix-prompt, fix-context, gate-policy`);
+      throw new Error(`Unknown set sub-command: "${subCommand}". Use: command, prompt, executor, agent, review-mode, fix-prompt, fix-context, gate-policy`);
   }
 }
 
@@ -816,8 +820,8 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessSet(['agent', ...args.slice(1)], deps);
       break;
     case 'set-merge-mode':
-      warnDeprecated('set-merge-mode', 'set merge-mode');
-      await headlessSet(['merge-mode', ...args.slice(1)], deps);
+      warnDeprecated('set-merge-mode', 'set review-mode');
+      await headlessSet(['review-mode', ...args.slice(1)], deps);
       break;
 
     case '--help':
@@ -893,7 +897,7 @@ ${BOLD}Configure:${RESET}
   set prompt <taskId> <text>                          Edit task prompt and re-run
   set executor <taskId> <type> [remoteTargetId]       Change executor type (worktree|docker|ssh)
   set agent <taskId> <agent>                          Change execution agent (claude|codex)
-  set merge-mode <workflowId> <mode>                  manual | automatic | external_review
+  set review-mode <workflowId> <mode>                  manual | automatic | external_review
   set fix-prompt <taskId> <text>                      Update fix-session prompt and retry
   set fix-context <taskId> <text>                     Update fix-session context and retry
   set gate-policy <taskId> <wfId> [depTaskId] <policy>
@@ -912,7 +916,7 @@ ${BOLD}Deprecated${RESET} (use new names above):
   list → query workflows       status → query tasks       task-status → query task
   queue → query queue           audit → query audit         session → query session
   edit → set command            edit-executor → set executor
-  edit-agent → set agent        set-merge-mode → set merge-mode
+  edit-agent → set agent        set-merge-mode → set review-mode
   delete-workflow → delete
   rebase-and-retry → rebase (task) or recreate-with-rebase (workflow)
 
@@ -2147,9 +2151,9 @@ async function headlessDetachWorkflow(
 }
 
 /**
- * Headless `set merge-mode` — **retry-class** invalidation route per
+ * Headless `set review-mode` — **retry-class** invalidation route per
  * Step 9 of `docs/architecture/task-invalidation-roadmap.md` (chart
- * Decision Table row "Change merge mode";
+ * Decision Table row "Change review mode";
  * `MUTATION_POLICIES.mergeMode` → `retryTask` / task scope, scoped
  * to the merge node). Mirrors the Step 5 `set type` headless pattern
  * (retry-class, preserves branch / workspacePath lineage) rather
@@ -2165,25 +2169,23 @@ async function headlessDetachWorkflow(
  * `retryTask` compatibility wire — see `MUTATION_POLICIES.mergeMode`
  * and `buildInvalidationDeps`).
  *
- * The CLI argument is still a workflow id (matches the legacy
- * `set-merge-mode <workflowId> <mode>` surface and the
- * `invoker:set-merge-mode` IPC). `mergeMode` is normalized at the
- * app boundary because that concerns UI/CLI input parsing, not the
- * chart's invalidation routing. The merge-task-id translation
- * (`workflowId → __merge__<workflowId>`) happens here because the
- * orchestrator seam speaks merge-node task ids. When the workflow
- * has no merge node (degenerate workflows that opted out of a merge
- * gate) we persist the new mode directly via the shared
- * `setWorkflowMergeMode` action — there is nothing to retry.
+ * The CLI argument is a workflow id. The `mergeMode` value is
+ * normalized at the app boundary because that concerns UI/CLI input
+ * parsing, not the chart's invalidation routing. The merge-task-id
+ * translation (`workflowId → __merge__<workflowId>`) happens here
+ * because the orchestrator seam speaks merge-node task ids. When the
+ * workflow has no merge node (degenerate workflows that opted out of
+ * a merge gate) we persist the new mode directly via the shared
+ * `setWorkflowReviewMode` action — there is nothing to retry.
  */
-async function headlessSetMergeMode(
+async function headlessSetReviewMode(
   workflowId: string,
   mergeMode: string,
   deps: HeadlessDeps,
 ): Promise<void> {
   if (!workflowId || !mergeMode) {
     throw new Error(
-      'Missing arguments. Usage: --headless set-merge-mode <workflowId> <manual|automatic|external_review>',
+      'Missing arguments. Usage: --headless set review-mode <workflowId> <manual|automatic|external_review>',
     );
   }
   const normalized = normalizeMergeModeForPersistence(mergeMode);
@@ -2192,13 +2194,13 @@ async function headlessSetMergeMode(
   const mergeTask = tasks.find((t) => t.config.isMergeNode);
   if (!mergeTask) {
     const taskExecutor = createHeadlessExecutor(deps);
-    await setWorkflowMergeMode(workflowId, normalized, {
+    await setWorkflowReviewMode(workflowId, normalized, {
       orchestrator: deps.orchestrator,
       persistence: deps.persistence,
       taskExecutor,
     });
     const wf = deps.persistence.loadWorkflow(workflowId);
-    process.stdout.write(`Merge mode updated for ${workflowId}: ${wf?.mergeMode ?? '?'}\n`);
+    process.stdout.write(`Review mode updated for ${workflowId}: ${wf?.mergeMode ?? '?'}\n`);
     return;
   }
 
@@ -2217,7 +2219,7 @@ async function headlessSetMergeMode(
     await taskExecutor.executeTasks(runnable);
   }
   const wf = deps.persistence.loadWorkflow(workflowId);
-  process.stdout.write(`Merge mode updated for ${workflowId}: ${wf?.mergeMode ?? '?'}\n`);
+  process.stdout.write(`Review mode updated for ${workflowId}: ${wf?.mergeMode ?? '?'}\n`);
 }
 
 /**

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -22,7 +22,7 @@
  *   electron dist/main.js --headless edit-executor <taskId> <executorType>
  *   electron dist/main.js --headless edit-agent <taskId> <claude|codex>
  *   electron dist/main.js --headless cancel <taskId>
- *   electron dist/main.js --headless set-merge-mode <workflowId> <mode>
+ *   electron dist/main.js --headless set review-mode <workflowId> <mode>
  *   electron dist/main.js --headless queue
  *   electron dist/main.js --headless audit <taskId>
  *   electron dist/main.js --headless install-skills
@@ -127,7 +127,7 @@ import {
   resolveConflictAction,
   selectFailureRecoveryRoute,
   selectExperiments as sharedSelectExperiments,
-  setWorkflowMergeMode,
+  setWorkflowReviewMode,
 } from './workflow-actions.js';
 import { spawn, execSync } from 'node:child_process';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
@@ -1898,8 +1898,8 @@ if (isHeadless) {
         return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
       case 'invoker:recreate-with-rebase':
         return { channel: 'headless.exec', request: { args: ['recreate-with-rebase', String(arg0)] } };
-      case 'invoker:set-merge-mode':
-        return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
+      case 'invoker:set-review-mode':
+        return { channel: 'headless.exec', request: { args: ['set', 'review-mode', String(arg0), String(arg1)] } };
       case 'invoker:approve-merge': {
         const workflowId = String(arg0);
         const mergeTask = persistence.loadTasks(workflowId).find((task) => task.config.isMergeNode);
@@ -3306,18 +3306,18 @@ if (isHeadless) {
       }
     });
 
-    registerGuiMutationHandler('invoker:set-merge-mode', async (workflowIdArg: unknown, mergeModeArg: unknown) => {
+    registerGuiMutationHandler('invoker:set-review-mode', async (workflowIdArg: unknown, mergeModeArg: unknown) => {
       const workflowId = String(workflowIdArg);
       const mergeMode = String(mergeModeArg);
-      logger.info(`set-merge-mode: workflow="${workflowId}" → "${mergeMode}"`, { module: 'ipc' });
+      logger.info(`set-review-mode: workflow="${workflowId}" → "${mergeMode}"`, { module: 'ipc' });
       try {
-        await setWorkflowMergeMode(workflowId, mergeMode, {
+        await setWorkflowReviewMode(workflowId, mergeMode, {
           orchestrator,
           persistence,
           taskExecutor: requireTaskExecutor(),
         });
       } catch (err) {
-        logger.error(`set-merge-mode failed: ${err}`, { module: 'ipc' });
+        logger.error(`set-review-mode failed: ${err}`, { module: 'ipc' });
         throw err;
       }
       const workflows = persistence.listWorkflows();

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -231,6 +231,13 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     );
   }
 
+  // Reject legacy "mergeGateProvider" key — replaced by "reviewProvider" + "publicationStrategy".
+  if (hasOwn(raw as object, 'mergeGateProvider')) {
+    throw new PlanParseError(
+      '"mergeGateProvider" is no longer supported. Use "reviewProvider" (e.g. "github") and "publicationStrategy" (e.g. "github_pr" or "mergify_stack") instead.',
+    );
+  }
+
   // Validate onFinish
   const validOnFinishValues = ['none', 'merge', 'pull_request'] as const;
   if (raw.onFinish !== undefined && !validOnFinishValues.includes(raw.onFinish as any)) {

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -491,10 +491,10 @@ export async function selectExperiments(
  * Same sequence as GUI `invoker:resolve-conflict` and headless `resolve-conflict`.
  */
 /**
- * Persist merge mode and re-run the merge node — **retry-class**
+ * Persist review mode and re-run the merge node — **retry-class**
  * invalidation route per Step 9 of
  * `docs/architecture/task-invalidation-roadmap.md` and the Decision
- * Table row "Change merge mode" in
+ * Table row "Change review mode" in
  * `docs/architecture/task-invalidation-chart.md`
  * (`MUTATION_POLICIES.mergeMode` → `retryTask` / task scope, scoped
  * to the merge node).
@@ -525,8 +525,8 @@ export async function selectExperiments(
  *
  * This wrapper deliberately stays a thin async delegate to keep the
  * public surface (`(workflowId, mergeMode, deps)` returning `void`)
- * backward compatible for IPC handlers (`invoker:set-merge-mode`),
- * the api-server (`POST /api/workflows/:id/merge-mode`), and Slack
+ * backward compatible for IPC handlers (`invoker:set-review-mode`),
+ * the api-server (`POST /api/workflows/:id/review-mode`), and Slack
  * surfaces. The merge-task-id translation (`workflowId → mergeNodeId`)
  * happens here because callers speak workflow ids; the orchestrator
  * speaks merge-node task ids. When the workflow has no merge node
@@ -539,7 +539,7 @@ export async function selectExperiments(
  * Cancel-first is enforced inside the orchestrator method — this
  * wrapper MUST NOT add a parallel cancel call.
  */
-export async function setWorkflowMergeMode(
+export async function setWorkflowReviewMode(
   workflowId: string,
   mergeMode: string,
   deps: Pick<ActionDeps, 'orchestrator' | 'persistence'> & { taskExecutor: TaskRunner },

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -37,7 +37,7 @@ import {
   editTaskType as sharedEditTaskType,
   editTaskAgent as sharedEditTaskAgent,
   setTaskExternalGatePolicies as sharedSetTaskExternalGatePolicies,
-  setWorkflowMergeMode as sharedSetWorkflowMergeMode,
+  setWorkflowReviewMode as sharedSetWorkflowReviewMode,
   selectExperiment as sharedSelectExperiment,
   selectExperiments as sharedSelectExperiments,
   resolveConflictAction as sharedResolveConflictAction,
@@ -310,8 +310,8 @@ export class WorkflowMutationFacade {
     };
   }
 
-  async setWorkflowMergeMode(workflowId: string, mergeMode: string): Promise<void> {
-    await sharedSetWorkflowMergeMode(workflowId, mergeMode, {
+  async setWorkflowReviewMode(workflowId: string, mergeMode: string): Promise<void> {
+    await sharedSetWorkflowReviewMode(workflowId, mergeMode, {
       orchestrator: this.deps.orchestrator,
       persistence: this.deps.persistence,
       taskExecutor: this.deps.taskExecutor,

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -338,7 +338,7 @@ export const IpcChannels = {
     request: [workflowId: string, baseBranch: string];
     response: void;
   },
-  'invoker:set-merge-mode': {} as {
+  'invoker:set-review-mode': {} as {
     request: [workflowId: string, mergeMode: string];
     response: void;
   },

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -682,7 +682,7 @@ export function App() {
               onEditAgent={handleEditAgent}
               onSetExternalGatePolicies={handleSetExternalGatePolicies}
               onSetMergeBranch={invoker?.setMergeBranch}
-              onSetMergeMode={invoker?.setMergeMode}
+              onSetMergeMode={invoker?.setReviewMode}
             />
           </div>
         </div>

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -139,7 +139,7 @@ export function createMockInvoker(
     approveMerge: vi.fn(async () => {}),
     resolveConflict: vi.fn(async () => {}),
     fixWithAgent: vi.fn(async () => {}),
-    setMergeMode: vi.fn(async () => {}),
+    setReviewMode: vi.fn(async () => {}),
     checkPrStatuses: vi.fn(async () => {}),
     cancelTask: vi.fn(async () => ({ cancelled: [], runningCancelled: [] })),
     cancelWorkflow: vi.fn(async () => ({ cancelled: [], runningCancelled: [] })),


### PR DESCRIPTION
## Summary
This is stack PR 3/4 for the review-strategy split. It renames parser, CLI, API, IPC, formatter, and serialized app surfaces to the new review/approval vocabulary so authoring and mutation boundaries match the runtime model.

It verifies the surface rename with focused `packages/app` coverage plus a full `pnpm run test:all` regression pass before the UI/docs slice stacks on top.

---
Review Strategy Split Step 3: parser and headless surface rename — 3 tasks completed, 0 failed, 0 skipped

<details>
<summary>Task breakdown</summary>

| Task | Description | Status |
|------|-------------|--------|
| wf-1778297990799-4/implement-parser-and-headless-surface-rename | Layer: transport
Feature state: active
Goal:
- Rename parser, CLI, headless, API, IPC, and formatter surfaces to the split review/approval vocabulary.
Motivation:
- Once runtime behavior has moved, operator-facing surfaces must stop accepting or emitting legacy names to avoid reintroducing ambiguity.
Alternative considerations:
- Option A: keep alias parsing and deprecated CLI/API names for compatibility.
- Option B: bundle surface rename together with UI/docs cleanup.
Implementation details:
- Update parsing, normalization, serialized workflow output, API/headless mutation commands, IPC naming, and formatter output to use the split review/approval model consistently.
- Keep non-review finish behavior as its own explicit path rather than smearing it back into renamed review metadata.
Files:
- packages/app/src/plan-parser.ts
- packages/app/src/merge-mode.ts
- packages/app/src/headless.ts
- packages/app/src/main.ts
- packages/app/src/api-server.ts
- packages/app/src/workflow-actions.ts
- packages/app/src/workflow-mutation-facade.ts
- packages/app/src/headless-command-classification.ts
- packages/app/src/formatter.ts
- packages/contracts/src/ipc-channels.ts
Change types:
- modify
- rename
- delete
Acceptance criteria:
- Legacy config keys are rejected by parser and mutation surfaces.
- Headless/API/formatter output uses the renamed review/approval fields consistently.
- App-layer tests cover parser validation and mutation behavior on the renamed surface.
 | completed |
| wf-1778297990799-4/verify-app-surface-lane | Layer: app_regression
Feature state: active
Goal:
- Verify parser and headless/app-bridge behavior after the surface rename.
Motivation:
- Surface-level regressions are easier to isolate in the app package before UI/docs work lands.
Alternative considerations:
- Option A: rely only on later UI or full-suite verification.
- Option B: inspect serialized output manually instead of running focused tests.
Implementation details:
- Run the app package tests after the surface rename.
Acceptance criteria:
- `cd packages/app && pnpm test` exits 0.
 | completed (passed) |
| wf-1778297990799-4/post-fix-regression | Layer: app_regression
Feature state: active
Goal:
- Run the terminal full-repository regression gate for the app-surface rename.
Motivation:
- Transport/API/IPC surface changes can break integration points outside the app package.
Alternative considerations:
- Option A: stop after app package tests.
- Option B: rely on the next stacked workflow's full-suite gate only.
Implementation details:
- Execute `pnpm run test:all` after the focused app lane passes.
Acceptance criteria:
- `pnpm run test:all` exits 0.
 | completed (passed) |

</details>

<details>
<summary>File changes per task</summary>

### wf-1778297990799-4/implement-parser-and-headless-surface-rename — Layer: transport
Feature state: active
Goal:
- Rename parser, CLI, headless, API, IPC, and formatter surfaces to the split review/approval vocabulary.
Motivation:
- Once runtime behavior has moved, operator-facing surfaces must stop accepting or emitting legacy names to avoid reintroducing ambiguity.
Alternative considerations:
- Option A: keep alias parsing and deprecated CLI/API names for compatibility.
- Option B: bundle surface rename together with UI/docs cleanup.
Implementation details:
- Update parsing, normalization, serialized workflow output, API/headless mutation commands, IPC naming, and formatter output to use the split review/approval model consistently.
- Keep non-review finish behavior as its own explicit path rather than smearing it back into renamed review metadata.
Files:
- packages/app/src/plan-parser.ts
- packages/app/src/merge-mode.ts
- packages/app/src/headless.ts
- packages/app/src/main.ts
- packages/app/src/api-server.ts
- packages/app/src/workflow-actions.ts
- packages/app/src/workflow-mutation-facade.ts
- packages/app/src/headless-command-classification.ts
- packages/app/src/formatter.ts
- packages/contracts/src/ipc-channels.ts
Change types:
- modify
- rename
- delete
Acceptance criteria:
- Legacy config keys are rejected by parser and mutation surfaces.
- Headless/API/formatter output uses the renamed review/approval fields consistently.
- App-layer tests cover parser validation and mutation behavior on the renamed surface.

.../ci-triggers/2026-05-06-master-healthcheck.md   |   1 +
 .github/workflows/ci.yml                           |  33 +-
 .mergify.yml                                       |  36 ++
 ARCHITECTURE.md                                    | 127 +++++
 CONTRIBUTING.md                                    |  16 +-
 README.md                                          |   4 +-
 docs/architecture-owner-broker-model.md            | 126 +++++
 docs/invoker-config-example.json                   |   3 +-
 docs/mergify-stack-lifecycle-poc.md                | 573 +++++++++++++++++++++
 docs/persistence-architecture-single-writer.md     |  10 +-
 docs/pr-branching-workflow.md                      |  58 ++-
 package.json                                       |   4 +-
 .../approve-fix-modal-with-session-log.png         | Bin 81499 -> 70953 bytes
 .../context-menu-danger-separator-fallback.png     | Bin 78345 -> 78043 bytes
 .../context-menu-failed-organization.png           | Bin 74850 -> 73606 bytes
 .../queue-action-surface-hardening.png             | Bin 0 -> 88203 bytes
 .../queue-relationships-expanded-context.png       | Bin 0 -> 66088 bytes
 .../queue-semantics-action-states.png              | Bin 0 -> 87313 bytes
 .../queue-view-concurrency.png                     | Bin 56862 -> 53137 bytes
 .../terminate-wording-task-vs-workflow.png         | Bin 0 -> 77252 bytes
 ...
 248 files changed, 19895 insertions(+), 2456 deletions(-)

### wf-1778297990799-4/verify-app-surface-lane — Layer: app_regression
Feature state: active
Goal:
- Verify parser and headless/app-bridge behavior after the surface rename.
Motivation:
- Surface-level regressions are easier to isolate in the app package before UI/docs work lands.
Alternative considerations:
- Option A: rely only on later UI or full-suite verification.
- Option B: inspect serialized output manually instead of running focused tests.
Implementation details:
- Run the app package tests after the surface rename.
Acceptance criteria:
- `cd packages/app && pnpm test` exits 0.


### wf-1778297990799-4/post-fix-regression — Layer: app_regression
Feature state: active
Goal:
- Run the terminal full-repository regression gate for the app-surface rename.
Motivation:
- Transport/API/IPC surface changes can break integration points outside the app package.
Alternative considerations:
- Option A: stop after app package tests.
- Option B: rely on the next stacked workflow's full-suite gate only.
Implementation details:
- Execute `pnpm run test:all` after the focused app lane passes.
Acceptance criteria:
- `pnpm run test:all` exits 0.


</details>