### PR TITLE
Harden plan-to-invoker zero-context prompt gating

### DIFF
--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -7,6 +7,7 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 SKILL_DIR="$REPO_ROOT/.claude/skills/plan-to-invoker"
 SKILL_MD="$SKILL_DIR/SKILL.md"
 PLAYBOOK="$SKILL_DIR/playbooks/verify-then-build.md"
+TASK_PATTERNS="$SKILL_DIR/references/task-patterns.md"
 CURSOR_LINK="$REPO_ROOT/.cursor/skills/plan-to-invoker"
 CODEX_LINK="$HOME/.codex/skills/plan-to-invoker"
 
@@ -26,6 +27,7 @@ must_contain() {
 
 [[ -f "$SKILL_MD" ]] || fail "expected $SKILL_MD"
 [[ -f "$PLAYBOOK" ]] || fail "expected $PLAYBOOK"
+[[ -f "$TASK_PATTERNS" ]] || fail "expected $TASK_PATTERNS"
 
 # Cursor skill symlink points at canonical copy (optional but catches drift)
 if [[ -e "$CURSOR_LINK" ]]; then
@@ -62,6 +64,7 @@ must_contain "$SKILL_MD" "see playbook" "SKILL Execution must reference the play
 must_contain "$SKILL_MD" "Phase 1b" "SKILL must reference Phase 1b"
 must_contain "$SKILL_MD" "Policy-matrix documents" "SKILL must document policy-matrix coverage mode"
 must_contain "$SKILL_MD" "verify-noop" "SKILL must explain policy-matrix degradation checks"
+must_contain "$SKILL_MD" "zero-context executable" "SKILL must require zero-context executable prompt instructions"
 
 # Playbook — Phase 1a / 1b (three lanes) and anti-patterns
 must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must define Phase 1a"
@@ -71,6 +74,11 @@ must_contain "$PLAYBOOK" "pnpm test" "Playbook must document pnpm test for behav
 must_contain "$PLAYBOOK" "pnpm run test:all" "Playbook must document the final full-suite regression gate"
 must_contain "$PLAYBOOK" "Invoker is mandatory" "Playbook must warn when Invoker verification is mandatory"
 must_contain "$PLAYBOOK" "coverageItems" "Playbook must document row-level coverage for policy-matrix sources"
+must_contain "$PLAYBOOK" "assume no prior context" "Playbook must require zero-context prompt framing for implementation tasks"
+
+# Task patterns — strict prompt handoff requirements
+must_contain "$TASK_PATTERNS" "Assume zero context" "Task patterns must define zero-context prompt requirement"
+must_contain "$TASK_PATTERNS" "deterministic pass/fail expectations" "Task patterns must require deterministic prompt outcomes"
 
 echo "OK: plan-to-invoker skill contract checks passed"
 

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -23,7 +23,7 @@ Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b 
 
 **Policy-matrix documents:** When the source is an architecture or policy document with a decision table, exception rules, or cross-cutting invariants, you must preserve row-level coverage before authoring workflows. Do not stop at files/functions/packages; every required policy row must map to a workflow step or an explicit waiver.
 
-**Delegated task hints (best effort):** When authoring tasks, consider adding `Files:`, `Change types:`, and `Acceptance criteria:` blocks in each task `description` to help handoff to another agent—lists reflect what you know **at planning time** and can be updated (`TBD`, follow-on tasks) as scope grows. **Not** required for `skill-doctor` to pass. See `references/task-patterns.md` § *Delegated execution hints*.
+**Delegated task hints (hard requirement for implementation plans):** For plans with `onFinish != none`, every prompt task must include `Files:`, `Change types:`, and `Acceptance criteria:` sections in `description`. Prompt text must be zero-context executable: assume no prior chat knowledge, include deterministic pass/fail expectations, and keep instructions self-contained. Verify-only plans (`onFinish: none`) keep delegation hints advisory.
 
 **File-count sizing guidance (soft):** Treat any "about 10 files" guidance as a reviewability heuristic, not a hard constraint. Prefer smaller slices when practical, but allow broader edits when correctness, shared wiring, or coupled refactors require it.
 
@@ -61,7 +61,7 @@ bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>
 - `--source-file FILE` — run assumption and coverage checks against a separate source document
 - `--coverage-map FILE` — require row-to-workflow traceability for policy-matrix sources
 - `--stack-manifest FILE` — require coverage-map workflow labels to match a real authored workflow stack
-- `--warn-delegation` — pass advisory delegation-hint warnings from atomicity lint (no additional failures)
+- `--warn-delegation` — print extra advisory delegation-hint warnings from atomicity lint
 - `--verbose` — show detailed output from each sub-check
 - `--help` — show usage information
 
@@ -80,7 +80,7 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
    `bash skills/plan-to-invoker/scripts/validate-plan.sh <plan-file>`
 4. `step-lint-atomicity`
    `bash skills/plan-to-invoker/scripts/lint-task-atomicity.sh <plan-file>`  
-  Optional (warnings only, exit 0): append `--warn-delegation` for **best-effort** hints if `Files:` / `Change types:` / `Acceptance criteria:` are missing in descriptions. For implementation plans (`onFinish != none`), this step hard-fails missing/invalid `Layer:` and `Feature state:` metadata, missing required rationale headings in `description` on any task (`Goal`, `Motivation`, `Alternative considerations`/`Alternatives`, `Implementation details`/`Implementation`), missing required rationale headings in `prompt` for prompt tasks, invalid cross-layer dependency direction without `Layer exception: allowed`, and missing experiment-artifact handoff/cleanup contract when experiment tasks are present.
+  Optional: append `--warn-delegation` to print additional advisory hints. Atomicity lint always runs `--strict-delegation` inside `skill-doctor` and, for implementation plans (`onFinish != none`), hard-fails missing/invalid `Layer:` and `Feature state:` metadata, missing required rationale headings in `description` on any task (`Goal`, `Motivation`, `Alternative considerations`/`Alternatives`, `Implementation details`/`Implementation`), missing required rationale headings in `prompt` for prompt tasks, prompt tasks without `Files:`/`Change types:`/`Acceptance criteria:` description blocks, prompts missing zero-context execution framing, prompts missing deterministic pass/fail expectations, invalid cross-layer dependency direction without `Layer exception: allowed`, and missing experiment-artifact handoff/cleanup contract when experiment tasks are present.
 5. `step-parse-verify-results`
    `bash skills/plan-to-invoker/scripts/parse-results.sh < /tmp/invoker-verify.txt`
 

--- a/skills/plan-to-invoker/fixtures/negative/anti-pattern-j-zero-context-missing-metadata.yaml
+++ b/skills/plan-to-invoker/fixtures/negative/anti-pattern-j-zero-context-missing-metadata.yaml
@@ -1,0 +1,47 @@
+name: "Anti-pattern J: prompt lacks zero-context metadata contract"
+description: "Implementation plan where prompt task omits strict zero-context handoff fields."
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: git@github.com:example-org/acme-repo.git
+tasks:
+  - id: implement-runtime-flow
+    description: |
+      Goal:
+      - Implement deterministic runtime flow updates.
+      Motivation:
+      - Keep remote execution instructions explicit and reproducible.
+      Alternative considerations:
+      - Option A (chosen): targeted transport-layer update.
+      - Option B: broad refactor across unrelated modules.
+      Implementation details:
+      - Apply runtime-flow edits and preserve existing behavior contracts.
+      Layer: transport
+      Feature state: active
+    prompt: |
+      Goal:
+      - Implement deterministic runtime flow updates in task-runner.
+      Motivation:
+      - Keep execution behavior stable under delegation.
+      Alternative considerations:
+      - Option A (chosen): targeted update.
+      - Option B: broad refactor.
+      Implementation details:
+      - Update packages/execution-engine/src/task-runner.ts.
+      Acceptance criteria:
+      - Tests should pass.
+    dependencies: []
+  - id: final-regression
+    description: |
+      Goal:
+      - Run final full-suite regression gate.
+      Motivation:
+      - Ensure implementation updates remain stable.
+      Alternative considerations:
+      - Option A (chosen): full repository regression.
+      - Option B: package-only checks.
+      Implementation details:
+      - Execute root-level test gate after implementation task.
+      Layer: app_regression
+      Feature state: active
+    command: "pnpm run test:all"
+    dependencies: [implement-runtime-flow]

--- a/skills/plan-to-invoker/playbooks/verify-then-build.md
+++ b/skills/plan-to-invoker/playbooks/verify-then-build.md
@@ -147,6 +147,12 @@ Use verified facts + `references/task-patterns.md` to generate the implementatio
 
 Set `mergeMode: github` (GitHub PR / **GithubPR** merge gate) on the implementation YAML unless the user explicitly asked for `manual` or `automatic`.
 
+For prompt tasks in implementation plans, write instructions as if the remote executor has no chat history:
+
+- Include explicit zero-context framing (for example: "assume no prior context").
+- Include deterministic pass/fail expectations (`exit code 0`, expected output text, or explicit pass condition).
+- Keep `Files:`, `Change types:`, and `Acceptance criteria:` in each prompt-task description aligned with prompt instructions.
+
 For each failed verification:
 
 - Missing file → add a task to create it before tasks that reference it

--- a/skills/plan-to-invoker/references/efficacy-rubric.md
+++ b/skills/plan-to-invoker/references/efficacy-rubric.md
@@ -1,18 +1,19 @@
 # Plan-to-invoker efficacy — soft rubric
 
-Use this to judge whether skill and repo guidance are helping. **Scores are qualitative** unless you explicitly turn warnings into gates (not the default).
+Use this to judge whether skill and repo guidance are helping. Implementation-plan prompt self-containment is now enforced as a hard gate; this rubric focuses on efficacy and ergonomics beyond pass/fail.
 
 ## Tier A — Mechanical (CI)
 
 - `bash scripts/test-plan-to-invoker-skill.sh` exits 0.
 - `bash skills/plan-to-invoker/scripts/test-fixtures.sh` exits 0 (existing fixture contract unchanged).
 - `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan.yaml>` for representative plans.
-Reporting-only: `bash skills/plan-to-invoker/scripts/skill-doctor.sh --warn-delegation <plan.yaml>` then inspect stderr for delegation-hint warnings; **do not** require zero warnings to merge.
+- For implementation plans (`onFinish != none`), `skill-doctor` should fail prompt tasks missing `Files:`/`Change types:`/`Acceptance criteria:` blocks, zero-context prompt framing, or deterministic pass/fail expectations.
+- Optional advisory run: `bash skills/plan-to-invoker/scripts/skill-doctor.sh --warn-delegation <plan.yaml>` to surface non-blocking hint improvements.
 
-## Tier B — Hint coverage (sampled)
+## Tier B — Hint quality (sampled)
 
-- On **N** plans, note how many tasks include `Files:` / `Change types:` / `Acceptance criteria:` in `description`.
-- **Aspirational targets only** — not merge blockers.
+- On **N** plans, score whether `Files:` / `Change types:` / `Acceptance criteria:` blocks are accurate and useful (not just present).
+- Track false positives/negatives from strict lint to tune prompt quality without weakening hard constraints.
 
 ## Tier C — Golden prompts (before / after)
 
@@ -33,10 +34,10 @@ Checklist examples (binary where obvious, soft otherwise):
 ## Tier D — Second-agent stress
 
 - Execute from YAML alone; count clarifying questions and edits outside any listed paths.
-- Treat results as **signal to improve prompts**, not proof of lint violations (lists are best effort).
+- Treat results as **signal to improve prompts and lint heuristics**, not an excuse to remove strict zero-context safety rails.
 
 ## Related docs
 
 - `../SKILL.md`
 - `task-patterns.md` § *Delegated execution hints*, § *Bugfix repro*
-- `../scripts/lint-task-atomicity.sh --warn-delegation`
+- `../scripts/lint-task-atomicity.sh --strict-delegation --warn-delegation`

--- a/skills/plan-to-invoker/references/examples.md
+++ b/skills/plan-to-invoker/references/examples.md
@@ -56,16 +56,15 @@ Complex plan with diamond dependencies. Uses `onFinish: pull_request` for manual
 - `fixtures/negative/anti-pattern-g-monolithic-prompt-edit-bridge.yaml` — Monolithic `wf-1777929074509-8`-style workflow missing dependency-first layered decomposition metadata
 - `fixtures/negative/anti-pattern-h-layer-order-violation.yaml` — Lower layer depends on higher layer without `Layer exception: allowed`
 - `fixtures/negative/anti-pattern-i-final-regression-not-test-all.yaml` — Implementation plan ends without a terminal `pnpm run test:all` gate
+- `fixtures/negative/anti-pattern-j-zero-context-missing-metadata.yaml` — Prompt task omits strict zero-context handoff metadata required for implementation plans
 
 All anti-patterns are validated by `scripts/test-fixtures.sh` with deterministic error detection.
 
 ---
 
-## 6. Delegation hints and bugfix repro (documentation only)
+## 6. Delegation hints and bugfix repro
 
-**Not fixture-backed** — patterns for human-authored plans.
-
-**Delegation (best effort):** Tasks may include in `description`:
+**Delegation for implementation plans (`onFinish != none`) is required for prompt tasks.** Include in `description`:
 
 ```yaml
 description: |
@@ -74,7 +73,7 @@ description: |
   Acceptance criteria: cd packages/foo && pnpm test exits 0.
 ```
 
-Omit or use `TBD` under `Files:` when scope is unknown; revise tasks as the plan evolves. `skill-doctor` does **not** require these headings.
+`Files:`, `Change types:`, and `Acceptance criteria:` are strict gates for implementation-plan prompt tasks under `skill-doctor`. Verify-only plans (`onFinish: none`) keep these headings advisory.
 
 **Bugfix repro:** Prefer `bash scripts/repro-my-bug.sh` early (expect fail) and the **same** script in the final verify task when still valid—not required for validation to pass. See `references/task-patterns.md` § *Bugfix repro*.
 
@@ -149,6 +148,7 @@ Use this pattern when a change is too large for a single reviewable workflow. Fo
 - Dependencies field required (even if empty)
 - No dangerous commands without manual approval
 - For implementation plans: `Layer:` + `Feature state:` headings, allowed values, and layer-consistent dependency direction
+- For implementation-plan prompt tasks: `Files:` / `Change types:` / `Acceptance criteria:` headings in `description`, zero-context prompt framing, and deterministic pass/fail expectations
 
 **References**:
 - Fixture tests: `scripts/test-fixtures.sh`

--- a/skills/plan-to-invoker/references/schema.md
+++ b/skills/plan-to-invoker/references/schema.md
@@ -21,9 +21,9 @@ Source of truth: `packages/app/src/plan-parser.ts` (interfaces + validation, lin
 | Field | Type | Default | When to set |
 |-------|------|---------|-------------|
 | `id` | string | *required* | Always. Kebab-case, descriptive: `implement-auth-middleware`, `test-auth-middleware`. |
-| `description` | string | *required* | Always. What the task does and why. May include **optional** multi-line sections for handoff: `Files:`, `Change types:`, `Acceptance criteria:` (best-effort hints; see `references/task-patterns.md`). Not validated by `plan-parser.ts`. |
+| `description` | string | *required* | Always. What the task does and why. For implementation plans (`onFinish != none`), prompt tasks must include `Files:`, `Change types:`, and `Acceptance criteria:` headings for zero-context execution handoff. |
 | `command` | string | — | Task runs a shell command. Mutually exclusive with `prompt`. |
-| `prompt` | string | — | Task needs LLM reasoning. Include file paths, line numbers, specific instructions. Mutually exclusive with `command`. |
+| `prompt` | string | — | Task needs LLM reasoning. Include file paths, line numbers, specific instructions, zero-context execution framing ("assume no prior context"), and deterministic pass/fail expectations (`exit code 0`, expected output, or explicit pass condition). Mutually exclusive with `command`. |
 | `dependencies` | string[] | `[]` | Always include, even if empty. List task IDs that must complete first. |
 | `executorType` | `worktree` \| `docker` \| `ssh` | `worktree` | `worktree` for tasks that run in a git worktree (default). `docker` for isolated environments. `ssh` for remote execution via SSH targets. |
 | `remoteTargetId` | string | — | Required when `executorType: ssh`. Must match a key in `~/.invoker/config.json` `remoteTargets`. |

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -113,6 +113,8 @@ When writing `prompt` fields for LLM tasks:
 3. **State acceptance criteria**: `"The function should return a PlanDefinition object with..."`
 4. **Mention related files**: `"See packages/core/src/orchestrator.ts:102-124 for the PlanDefinition interface"`
 5. **Keep scope narrow**: one logical change per task, not "implement the entire feature"
+6. **Assume zero context**: include explicit phrasing such as "assume no prior context" or "zero-context execution".
+7. **Include deterministic pass/fail expectations**: require explicit outcomes like `exit code 0`, `exits 0`, or expected output text.
 
 ## Experiment artifact handoff templates (required when experiments are planned)
 
@@ -152,21 +154,21 @@ Example cleanup command:
   dependencies: [experiment-inv-123, implement-inv-123, verify-inv-123]
 ```
 
-## Delegated execution hints (best effort; not validated by default)
+## Delegated execution hints
 
-Planning often **misses files** or **adds scope** later. These headings in a task `description` are **recommended**, **revisable**, and **not** required for `skill-doctor` or `lint-task-atomicity.sh` to pass. Optional advisory output: `bash skills/plan-to-invoker/scripts/lint-task-atomicity.sh --warn-delegation <plan.yaml>`.
+Planning often **misses files** or **adds scope** later. For implementation plans (`onFinish != none`), prompt tasks are hard-gated and must include structured handoff metadata. For verify-only plans (`onFinish: none`), these headings stay advisory. Optional extra hints: `bash skills/plan-to-invoker/scripts/lint-task-atomicity.sh --warn-delegation <plan.yaml>`.
 
 File-count guidance (for example, aiming around 10 touched files in a task) is a **soft heuristic** for reviewability, not a hard limit. If correctness or shared wiring requires broader edits, allow the task to exceed that target and capture the rationale in `description`.
 
-**Suggested blocks** (in `description`, when helpful):
+For implementation plans (`onFinish != none`), prompt tasks are hard-gated by `skill-doctor`/atomicity lint and must include these blocks in `description`:
 
-1. **`Files:`** — Repo-relative paths known when the task was written; use `TBD` or "may grow" if unsure. **Not** an exhaustive contract—implementation may touch additional files; amend the plan or add tasks if so.
-2. **`Change types:`** — Per listed path: `create`, `modify`, `delete`, `rename`, `move`, `config-only`, `test-only`, `docs-only`, `generated`, or `none`—as **hints** only.
-3. **`Acceptance criteria:`** — Objective checks where possible (`cd … && pnpm test`, `grep -q`, exit codes). Vague text is acceptable when you cannot yet define a command; tighten in a follow-up plan revision.
+1. **`Files:`** — Repo-relative paths the executor must inspect/modify. Keep this synchronized with prompt instructions.
+2. **`Change types:`** — Per listed path: `create`, `modify`, `delete`, `rename`, `move`, `config-only`, `test-only`, `docs-only`, `generated`, or `none`.
+3. **`Acceptance criteria:`** — Objective deterministic checks with concrete pass/fail language.
 
-**`prompt` tasks:** The multiline `prompt` still carries the real instructions; the three blocks in `description` are a **skimmable summary** for handoff.
+**`prompt` tasks:** The multiline `prompt` must be self-contained for remote execution with no chat context. Include zero-context framing and deterministic expected outcomes directly in the prompt body.
 
-**`command` tasks:** Same optional pattern—helps executors see scope before running the shell line.
+**`command` tasks:** The same headings are still recommended; for verify-only plans they remain advisory.
 
 **Anti-patterns (soft):** Pretending the first draft file list is complete; skipping verification entirely; "manually test in the app" with no scripted or Playwright hook when automation is feasible.
 

--- a/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
+++ b/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
@@ -1,26 +1,40 @@
 #!/usr/bin/env bash
 # Enforce atomic + detailed task quality constraints for Invoker plans.
-# Usage: bash lint-task-atomicity.sh [--warn-delegation] <plan.yaml>
+# Usage: bash lint-task-atomicity.sh [--warn-delegation] [--strict-delegation] <plan.yaml>
 #
 # --warn-delegation  Print advisory warnings if task descriptions omit best-effort
 #                    delegation headings (Files: / Change types: / Acceptance criteria:).
 #                    Does not change exit code (still 0 if no hard errors). Optional.
+# --strict-delegation  For implementation plans (onFinish != none), fail prompt tasks
+#                    that are not self-contained for zero-context remote execution.
 set -euo pipefail
 
 warn_delegation=0
-if [[ "${1:-}" == "--warn-delegation" ]]; then
-  warn_delegation=1
-  shift
-fi
+strict_delegation=0
+while [[ $# -gt 0 ]]; do
+  case "${1:-}" in
+    --warn-delegation)
+      warn_delegation=1
+      shift
+      ;;
+    --strict-delegation)
+      strict_delegation=1
+      shift
+      ;;
+    *)
+      break
+      ;;
+  esac
+done
 
-file="${1:?Usage: lint-task-atomicity.sh [--warn-delegation] <plan.yaml>}"
+file="${1:?Usage: lint-task-atomicity.sh [--warn-delegation] [--strict-delegation] <plan.yaml>}"
 
 if [[ ! -f "$file" ]]; then
   echo "ERROR: File not found: $file" >&2
   exit 1
 fi
 
-awk -v warnDelegation="$warn_delegation" '
+awk -v warnDelegation="$warn_delegation" -v strictDelegation="$strict_delegation" '
 function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
 function strip_quotes(s) { gsub(/["'\''"]/, "", s); return s }
 function normalize_command(s) {
@@ -189,6 +203,23 @@ function flush_task(    wc, and_count, valid_id, d, desc_lower, idx) {
       }
       if (prompt_lower !~ /(^|[ \t])(implementation details|implementation):/) {
         errors[++errn] = "Task \"" id "\" prompt missing required \"Implementation details:\" (or \"Implementation:\") section for AI implementation tasks"
+      }
+      if (strictDelegation == 1) {
+        if (desc_lower !~ /(^|\n)[ \t]*files:/) {
+          errors[++errn] = "Task \"" id "\" prompt execution requires a \"Files:\" section in description for zero-context remote runners"
+        }
+        if (desc_lower !~ /(^|\n)[ \t]*change types:/) {
+          errors[++errn] = "Task \"" id "\" prompt execution requires a \"Change types:\" section in description for zero-context remote runners"
+        }
+        if (desc_lower !~ /(^|\n)[ \t]*acceptance criteria:/) {
+          errors[++errn] = "Task \"" id "\" prompt execution requires an \"Acceptance criteria:\" section in description for zero-context remote runners"
+        }
+        if (prompt_lower !~ /(assume no prior context|zero-context|zero context|no prior context)/) {
+          errors[++errn] = "Task \"" id "\" prompt must state zero-context execution expectations (for example: assume no prior context)"
+        }
+        if (prompt_lower !~ /(exit code 0|exits 0|pass condition|expected output)/) {
+          errors[++errn] = "Task \"" id "\" prompt must include deterministic pass/fail expectations (exit code 0, pass condition, or expected output)"
+        }
       }
     }
   }

--- a/skills/plan-to-invoker/scripts/skill-doctor.sh
+++ b/skills/plan-to-invoker/scripts/skill-doctor.sh
@@ -11,7 +11,7 @@
 #   --coverage-map FILE Validate row-to-workflow traceability for policy-matrix inputs
 #   --stack-manifest FILE Validate coverage-map workflow labels against a real authored stack manifest
 #   --verbose           Show detailed output from each sub-check
-#   --warn-delegation  Pass through to atomicity lint (advisory delegation-hint warnings only; no extra failures)
+#   --warn-delegation  Pass through to atomicity lint (prints advisory delegation-hint warnings)
 #
 # Exit codes:
 #   0 = all checks passed
@@ -302,16 +302,18 @@ fi
 
 # Check 4: Task atomicity linting (if not skipped)
 if [[ "$SKIP_ATOMICITY" == "false" ]]; then
+  atomicity_args=(--strict-delegation)
   if [[ "$WARN_DELEGATION" == "true" ]]; then
+    atomicity_args+=(--warn-delegation)
     run_check \
       "lint-task-atomicity" \
-      "Lint task atomicity and detail requirements (with delegation hints advisory)" \
-      bash "$SCRIPT_DIR/lint-task-atomicity.sh" --warn-delegation "$PLAN_FILE"
+      "Lint task atomicity and detail requirements (strict zero-context prompt gating + delegation warnings)" \
+      bash "$SCRIPT_DIR/lint-task-atomicity.sh" "${atomicity_args[@]}" "$PLAN_FILE"
   else
     run_check \
       "lint-task-atomicity" \
-      "Lint task atomicity and detail requirements" \
-      bash "$SCRIPT_DIR/lint-task-atomicity.sh" "$PLAN_FILE"
+      "Lint task atomicity and detail requirements (strict zero-context prompt gating)" \
+      bash "$SCRIPT_DIR/lint-task-atomicity.sh" "${atomicity_args[@]}" "$PLAN_FILE"
   fi
 fi
 

--- a/skills/plan-to-invoker/scripts/test-fixtures.sh
+++ b/skills/plan-to-invoker/scripts/test-fixtures.sh
@@ -21,6 +21,7 @@ DOCTOR_NEGATIVE_FIXTURES=(
   "anti-pattern-g-monolithic-prompt-edit-bridge.yaml"
   "anti-pattern-h-layer-order-violation.yaml"
   "anti-pattern-i-final-regression-not-test-all.yaml"
+  "anti-pattern-j-zero-context-missing-metadata.yaml"
 )
 
 is_doctor_negative_fixture() {
@@ -714,6 +715,144 @@ EOF
   fi
 }
 
+test_lint_strict_accepts_zero_context_prompt_contract() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: "Strict prompt contract pass"
+description: "Implementation plan with zero-context prompt contract"
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: git@github.com:example-org/acme-repo.git
+tasks:
+  - id: implement-runtime-flow
+    description: |
+      Goal:
+      - Implement deterministic runtime flow updates.
+      Motivation:
+      - Keep remote execution instructions explicit and reproducible.
+      Alternative considerations:
+      - Option A (chosen): apply targeted runtime updates.
+      - Option B: delay updates until a later refactor.
+      Implementation details:
+      - Apply runtime-flow edits and preserve current behavior contracts.
+      Layer: transport
+      Feature state: active
+      Files:
+      - packages/execution-engine/src/task-runner.ts
+      Change types:
+      - modify
+      Acceptance criteria:
+      - `cd packages/execution-engine && pnpm test` exits 0.
+    prompt: |
+      Goal:
+      - Implement deterministic runtime flow updates in task-runner.
+      Motivation:
+      - Ensure execution can succeed when delegated to a remote runner.
+      Alternative considerations:
+      - Option A (chosen): targeted updates in task-runner.
+      - Option B: broad refactor across unrelated modules.
+      Implementation details:
+      - Assume no prior context; read packages/execution-engine/src/task-runner.ts and apply the scoped runtime changes.
+      - Keep behavior deterministic and document expected output in task notes.
+      Acceptance criteria:
+      - Verify `cd packages/execution-engine && pnpm test` exits 0.
+      - Use exit code 0 as the pass condition.
+    dependencies: []
+  - id: final-regression
+    description: |
+      Goal:
+      - Run final full-suite regression gate.
+      Motivation:
+      - Ensure implementation updates remain stable.
+      Alternative considerations:
+      - Option A (chosen): full repository regression.
+      - Option B: package-only checks.
+      Implementation details:
+      - Execute root-level test gate after implementation task.
+      Layer: app_regression
+      Feature state: active
+    command: "pnpm run test:all"
+    dependencies: [implement-runtime-flow]
+EOF
+
+  bash "$LINT_SCRIPT" --strict-delegation "$temp_plan" >/dev/null
+}
+
+test_lint_strict_rejects_missing_zero_context_contract() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: "Strict prompt contract fail"
+description: "Implementation plan missing strict zero-context requirements"
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: git@github.com:example-org/acme-repo.git
+tasks:
+  - id: implement-runtime-flow
+    description: |
+      Goal:
+      - Implement deterministic runtime flow updates.
+      Motivation:
+      - Keep remote execution instructions explicit and reproducible.
+      Alternative considerations:
+      - Option A (chosen): apply targeted runtime updates.
+      - Option B: delay updates until a later refactor.
+      Implementation details:
+      - Apply runtime-flow edits and preserve current behavior contracts.
+      Layer: transport
+      Feature state: active
+    prompt: |
+      Goal:
+      - Implement deterministic runtime flow updates in task-runner.
+      Motivation:
+      - Ensure execution can succeed when delegated to a remote runner.
+      Alternative considerations:
+      - Option A (chosen): targeted updates in task-runner.
+      - Option B: broad refactor across unrelated modules.
+      Implementation details:
+      - Read packages/execution-engine/src/task-runner.ts and apply scoped changes.
+      Acceptance criteria:
+      - Verify tests pass.
+    dependencies: []
+  - id: final-regression
+    description: |
+      Goal:
+      - Run final full-suite regression gate.
+      Motivation:
+      - Ensure implementation updates remain stable.
+      Alternative considerations:
+      - Option A (chosen): full repository regression.
+      - Option B: package-only checks.
+      Implementation details:
+      - Execute root-level test gate after implementation task.
+      Layer: app_regression
+      Feature state: active
+    command: "pnpm run test:all"
+    dependencies: [implement-runtime-flow]
+EOF
+
+  local output
+  set +e
+  output=$(bash "$LINT_SCRIPT" --strict-delegation "$temp_plan" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Expected strict lint to reject missing zero-context prompt contract" >&2
+    return 1
+  fi
+
+  if ! grep -q 'requires a "Files:" section in description for zero-context remote runners' <<<"$output"; then
+    echo "Expected strict Files heading error, got: $output" >&2
+    return 1
+  fi
+}
+
 # Check dependencies
 if ! command -v jq &>/dev/null; then
   fail "jq is required for JSON parsing tests"
@@ -782,6 +921,8 @@ run_test "Lint: reject final gate missing dependencies" test_lint_rejects_final_
 run_test "Lint: reject missing design sections for prompt tasks" test_lint_requires_design_sections_for_prompt_tasks
 run_test "Lint: accept prompt tasks with design sections" test_lint_accepts_design_sections_for_prompt_tasks
 run_test "Lint: reject missing design sections for command tasks" test_lint_requires_design_sections_for_command_tasks
+run_test "Lint strict: accept zero-context prompt contract" test_lint_strict_accepts_zero_context_prompt_contract
+run_test "Lint strict: reject missing zero-context prompt contract" test_lint_strict_rejects_missing_zero_context_contract
 
 echo ""
 echo "========================================="


### PR DESCRIPTION
## Summary

Enforces zero-context prompt contracts in `plan-to-invoker` implementation plans so remote executors can run prompt tasks without chat history context.
Turns strict prompt self-containment into a submission gate by wiring `skill-doctor` to run atomicity lint with `--strict-delegation`, and updates docs/fixtures/tests to match.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert d30e940a`
- Post-revert steps: None
- Data migration? No
