### PR TITLE
Stabilize same-workflow chaos seed timeout

### DIFF
--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -1866,7 +1866,7 @@ run_fixing_with_ai_visibility() {
 run_owner_restart_loop_during_tracked_recreate_task() {
   local workflow_count="$1"
   local operation_burst="$2"
-  local seed_timeout_seconds=120
+  local seed_timeout_seconds=180
   invoker_e2e_init
   trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
   cd "$INVOKER_E2E_REPO_ROOT"


### PR DESCRIPTION
## Summary

Stabilizes the `required-fast / Fix Intent Repros` chaos scenario by increasing the seed fail-workflow terminal wait from 120s to 180s in the same-workflow recreate overload paths.
This keeps the assertion behavior intact while reducing false timeouts under CI startup contention.

## Test Plan

- [x] Inspect failing run logs for `required-fast / Fix Intent Repros` and confirm timeout source (`TIMEOUT: ... expected status='failed' ... after 120s`).
- [ ] Verify CI passes on this PR (especially `required-fast / Fix Intent Repros`).

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 974120de`
- Post-revert steps: None
- Data migration? No
