### PR TITLE
Fix intent cancellation Step 2: fix flow lineage guards

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -2172,11 +2172,10 @@ describe('fixWithAgentAction lineage guard', () => {
   });
 
   it('skips revertConflictResolution when lineage changed and fix threw', async () => {
-    let getTaskCallCount = 0;
+    let fixCalled = false;
     const orchestrator = {
       getTask: vi.fn(() => {
-        getTaskCallCount++;
-        if (getTaskCallCount <= 2) {
+        if (!fixCalled) {
           return makeTask({
             status: 'failed',
             config: { workflowId: 'wf-1' },
@@ -2199,7 +2198,10 @@ describe('fixWithAgentAction lineage guard', () => {
       appendTaskOutput: vi.fn(),
     };
     const taskExecutor = {
-      fixWithAgent: vi.fn().mockRejectedValue(new Error('agent crashed')),
+      fixWithAgent: vi.fn().mockImplementation(async () => {
+        fixCalled = true;
+        throw new Error('agent crashed');
+      }),
       resolveConflict: vi.fn(),
     };
 
@@ -2292,11 +2294,10 @@ describe('resolveConflictAction lineage guard', () => {
   });
 
   it('skips revertConflictResolution when lineage changed and resolution threw', async () => {
-    let getTaskCallCount = 0;
+    let resolveCalled = false;
     const orchestrator = {
       getTask: vi.fn(() => {
-        getTaskCallCount++;
-        if (getTaskCallCount <= 1) {
+        if (!resolveCalled) {
           return makeTask({
             status: 'fixing_with_ai',
             config: { workflowId: 'wf-1' },
@@ -2317,7 +2318,10 @@ describe('resolveConflictAction lineage guard', () => {
       appendTaskOutput: vi.fn(),
     };
     const taskExecutor = {
-      resolveConflict: vi.fn().mockRejectedValue(new Error('resolution failed')),
+      resolveConflict: vi.fn().mockImplementation(async () => {
+        resolveCalled = true;
+        throw new Error('resolution failed');
+      }),
     };
 
     await expect(resolveConflictAction('task-a', {
@@ -2380,12 +2384,11 @@ describe('autoFixOnFailure lineage guard', () => {
   });
 
   it('skips revertConflictResolution on failure when lineage changed', async () => {
-    let getTaskCallCount = 0;
+    let fixCalled = false;
     const orchestrator = {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => {
-        getTaskCallCount++;
-        if (getTaskCallCount <= 2) {
+        if (!fixCalled) {
           return makeTask({
             status: 'failed',
             config: { workflowId: 'wf-1' },
@@ -2411,7 +2414,10 @@ describe('autoFixOnFailure lineage guard', () => {
       logEvent: vi.fn(),
     };
     const taskExecutor = {
-      fixWithAgent: vi.fn().mockRejectedValue(new Error('agent crashed')),
+      fixWithAgent: vi.fn().mockImplementation(async () => {
+        fixCalled = true;
+        throw new Error('agent crashed');
+      }),
       resolveConflict: vi.fn(),
       executeTasks: vi.fn().mockResolvedValue(undefined),
     };
@@ -2495,5 +2501,188 @@ describe('finalizeAppliedFix lineage guard', () => {
 
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-error');
     expect(result).toEqual({ autoApproved: false, started: [] });
+  });
+});
+
+describe('fix lineage guard entry and persistence checkpoints', () => {
+  it('resolveConflictAction: does not mutate orchestrator state when signal is already aborted at entry', async () => {
+    const ac = new AbortController();
+    ac.abort(new Error('superseded-before-entry'));
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: { error: 'merge err', selectedAttemptId: 'att-1', generation: 5 },
+      })),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'merge err' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      resolveConflict: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(resolveConflictAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, undefined, ac.signal)).rejects.toThrow(StaleLineageError);
+
+    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
+    expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
+  });
+
+  it('fixWithAgentAction: does not mutate orchestrator state when signal is already aborted at entry', async () => {
+    const ac = new AbortController();
+    ac.abort(new Error('superseded-before-entry'));
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: { error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+      })),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn(),
+    };
+
+    await expect(fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      signal: ac.signal,
+    })).rejects.toThrow(StaleLineageError);
+
+    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
+    expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
+  });
+
+  it('fixWithAgentAction: does not append stale failure output when lineage drifted during async fix', async () => {
+    let fixCalled = false;
+    let getTaskCallCount = 0;
+    const orchestrator = {
+      getTask: vi.fn(() => {
+        getTaskCallCount++;
+        if (!fixCalled) {
+          return makeTask({
+            status: 'failed',
+            config: { workflowId: 'wf-1' },
+            execution: { error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+          });
+        }
+        return makeTask({
+          status: 'pending',
+          config: { workflowId: 'wf-1' },
+          execution: { selectedAttemptId: 'att-2', generation: 6 },
+        });
+      }),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockImplementation(async () => {
+        fixCalled = true;
+        throw new Error('agent crashed');
+      }),
+      resolveConflict: vi.fn(),
+    };
+
+    await expect(fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    })).rejects.toThrow('agent crashed');
+
+    expect(getTaskCallCount).toBeGreaterThan(0);
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+  });
+
+  it('resolveConflictAction: does not append stale failure output when lineage drifted during conflict resolution', async () => {
+    let resolveCalled = false;
+    const orchestrator = {
+      getTask: vi.fn(() => {
+        if (!resolveCalled) {
+          return makeTask({
+            status: 'failed',
+            config: { workflowId: 'wf-1' },
+            execution: { error: 'merge err', selectedAttemptId: 'att-1', generation: 5 },
+          });
+        }
+        return makeTask({
+          status: 'pending',
+          config: { workflowId: 'wf-1' },
+          execution: { selectedAttemptId: 'att-2', generation: 6 },
+        });
+      }),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'merge err' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      resolveConflict: vi.fn().mockImplementation(async () => {
+        resolveCalled = true;
+        throw new Error('resolution failed');
+      }),
+    };
+
+    await expect(resolveConflictAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    })).rejects.toThrow('resolution failed');
+
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
+    expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+  });
+
+  it('finalizeAppliedFix: short-circuits when lineage drifts before awaiting-approval transition', async () => {
+    const ac = new AbortController();
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        status: 'pending',
+        config: { workflowId: 'wf-1' },
+        execution: { selectedAttemptId: 'att-2', generation: 6 },
+      })),
+      setFixAwaitingApproval: vi.fn(),
+    };
+    const lineageSnapshot = {
+      taskId: 'task-a',
+      selectedAttemptId: 'att-1',
+      generation: 5,
+    };
+
+    await expect(finalizeAppliedFix('task-a', 'saved-error', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      taskExecutor: {} as TaskRunner,
+    }, ac.signal, lineageSnapshot)).rejects.toThrow(StaleLineageError);
+
+    expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
   });
 });

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -45,11 +45,20 @@ export interface TaskLineageSnapshot {
 
 /**
  * Capture the current lineage for a task.
+ *
+ * Prefers the orchestrator's `getTaskLineage` seam when available so
+ * lineage capture has a single source of truth in the orchestrator
+ * contract; falls back to `getTask` for callers that mock only the
+ * narrow surface.
  */
 export function captureTaskLineage(
   taskId: string,
-  orchestrator: Pick<Orchestrator, 'getTask'>,
+  orchestrator: Pick<Orchestrator, 'getTask'> & Partial<Pick<Orchestrator, 'getTaskLineage'>>,
 ): TaskLineageSnapshot {
+  if (typeof orchestrator.getTaskLineage === 'function') {
+    const snap = orchestrator.getTaskLineage(taskId);
+    if (snap) return snap;
+  }
   const task = orchestrator.getTask(taskId);
   return {
     taskId,
@@ -713,21 +722,22 @@ export async function resolveConflictAction(
   signal?: AbortSignal,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
   const { orchestrator, persistence, taskExecutor } = deps;
-  const { savedError } = orchestrator.beginConflictResolution(taskId);
   const lineage = captureTaskLineage(taskId, orchestrator);
+  assertLineageCurrent(lineage, orchestrator, signal);
+  const { savedError } = orchestrator.beginConflictResolution(taskId);
   try {
     await taskExecutor.resolveConflict(taskId, savedError, agentName);
     assertLineageCurrent(lineage, orchestrator, signal);
-    return await finalizeAppliedFix(taskId, savedError, deps, signal);
+    return await finalizeAppliedFix(taskId, savedError, deps, signal, lineage);
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
-    const msg = err instanceof Error ? err.message : String(err);
-    persistence.appendTaskOutput(taskId, `\n[Resolve Conflict] Failed: ${msg}`);
     try {
       assertLineageCurrent(lineage, orchestrator, signal);
     } catch {
       throw err;
     }
+    const msg = err instanceof Error ? err.message : String(err);
+    persistence.appendTaskOutput(taskId, `\n[Resolve Conflict] Failed: ${msg}`);
     orchestrator.revertConflictResolution(taskId, savedError, msg);
     throw err;
   }
@@ -752,6 +762,9 @@ export async function fixWithAgentAction(
   const task = orchestrator.getTask(taskId);
   if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
 
+  const lineage = captureTaskLineage(taskId, orchestrator);
+  assertLineageCurrent(lineage, orchestrator, options.signal);
+
   const savedError = task.execution.error ?? '';
   const recoveryRoute = options.recoveryRoute ?? selectFailureRecoveryRoute(task, savedError);
   if (recoveryRoute.kind === 'recreateWorkflowFromFreshBase') {
@@ -770,7 +783,6 @@ export async function fixWithAgentAction(
   }
 
   const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
-  const lineage = captureTaskLineage(taskId, orchestrator);
   try {
     if (recoveryRoute.kind === 'resolveConflict') {
       await taskExecutor.resolveConflict(taskId, persistedSavedError, options.agentName);
@@ -779,7 +791,7 @@ export async function fixWithAgentAction(
       await taskExecutor.fixWithAgent(taskId, output, options.agentName, persistedSavedError);
     }
     assertLineageCurrent(lineage, orchestrator, options.signal);
-    const result = await finalizeAppliedFix(taskId, persistedSavedError, deps, options.signal);
+    const result = await finalizeAppliedFix(taskId, persistedSavedError, deps, options.signal, lineage);
     return {
       kind: recoveryRoute.kind,
       autoApproved: result.autoApproved,
@@ -787,15 +799,15 @@ export async function fixWithAgentAction(
     };
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
-    const msg = err instanceof Error ? err.message : String(err);
-    const errorLabel = options.failureOutputLabel
-      ?? (recoveryRoute.kind === 'resolveConflict' ? 'Resolve Conflict' : `Fix with ${options.agentName ?? 'Claude'}`);
-    persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
     try {
       assertLineageCurrent(lineage, orchestrator, options.signal);
     } catch {
       throw err;
     }
+    const msg = err instanceof Error ? err.message : String(err);
+    const errorLabel = options.failureOutputLabel
+      ?? (recoveryRoute.kind === 'resolveConflict' ? 'Resolve Conflict' : `Fix with ${options.agentName ?? 'Claude'}`);
+    persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
     orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
     throw err;
   }
@@ -806,8 +818,11 @@ export async function finalizeAppliedFix(
   savedError: string,
   deps: Pick<ActionDeps, 'orchestrator' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
   signal?: AbortSignal,
+  lineage?: TaskLineageSnapshot,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
-  if (signal?.aborted) {
+  if (lineage) {
+    assertLineageCurrent(lineage, deps.orchestrator, signal);
+  } else if (signal?.aborted) {
     throw new StaleLineageError(
       `Fix mutation for ${taskId} aborted before finalize: ${signal.reason instanceof Error ? signal.reason.message : String(signal.reason ?? 'unknown')}`,
     );
@@ -997,6 +1012,9 @@ export async function autoFixOnFailure(
   const task = orchestrator.getTask(taskId);
   if (!task || task.status !== 'failed') return;
 
+  const entryLineage = captureTaskLineage(taskId, orchestrator);
+  assertLineageCurrent(entryLineage, orchestrator, deps.signal);
+
   const attempts = (task.execution.autoFixAttempts ?? 0) + 1;
   const max = orchestrator.getAutoFixRetryBudget(taskId);
   const savedError = task.execution.error ?? '';
@@ -1067,6 +1085,7 @@ export async function autoFixOnFailure(
       return;
     }
 
+    assertLineageCurrent(entryLineage, orchestrator, deps.signal);
     ({ savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId));
     lineage = captureTaskLineage(taskId, orchestrator);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
@@ -1094,7 +1113,7 @@ export async function autoFixOnFailure(
         orchestrator,
         taskExecutor,
         autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
-      }, deps.signal);
+      }, deps.signal, lineage);
       persistence.logEvent?.(taskId, 'debug.auto-fix', {
         phase: 'auto-fix-post-route-finalize',
         autoApproved: finalizeResult.autoApproved,
@@ -1125,6 +1144,13 @@ export async function autoFixOnFailure(
     if (runnable.length > 0) await taskExecutor.executeTasks(runnable);
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
+    const guardLineage = lineage ?? entryLineage;
+    let lineageStillCurrent = true;
+    try {
+      assertLineageCurrent(guardLineage, orchestrator, deps.signal);
+    } catch {
+      lineageStillCurrent = false;
+    }
     const msg = err instanceof Error ? err.message : String(err);
     const diagnostics = formatAutoFixDiagnostics(err);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
@@ -1136,20 +1162,17 @@ export async function autoFixOnFailure(
       selectedAgentSource: agentSelection.selectedAgentSource,
       fallbackChain: agentSelection.fallbackChain,
       diagnostics: diagnostics ?? null,
+      lineageStale: !lineageStillCurrent,
     });
+    if (!lineageStillCurrent) {
+      throw err;
+    }
     if (diagnostics) {
       persistence.appendTaskOutput(taskId, `\n[Auto-fix Diagnostics]\n${diagnostics}`);
     }
     persistence.appendTaskOutput(taskId, `\n[Auto-fix] Agent failed (attempt ${attempts}/${max}): ${msg}`);
     const detailedMsg = diagnostics ? `${msg}\n\n${diagnostics}` : msg;
     if (persistedSavedError !== undefined) {
-      if (lineage) {
-        try {
-          assertLineageCurrent(lineage, orchestrator, deps.signal);
-        } catch {
-          throw err;
-        }
-      }
       orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg);
     }
   }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -729,6 +729,25 @@ describe('Orchestrator', () => {
 
   // ── loadPlan ────────────────────────────────────────────
 
+  describe('getTaskLineage', () => {
+    it('returns selectedAttemptId and generation for an existing task', () => {
+      orchestrator.loadPlan({
+        name: 'lineage-test',
+        tasks: [{ id: 't1', description: 'First task' }],
+      });
+      const t1 = orchestrator.getTask('t1')!;
+      const lineage = orchestrator.getTaskLineage(t1.id);
+      expect(lineage).toBeDefined();
+      expect(lineage!.taskId).toBe(t1.id);
+      expect(lineage!.selectedAttemptId).toBe(t1.execution.selectedAttemptId);
+      expect(lineage!.generation).toBe(t1.execution.generation ?? 0);
+    });
+
+    it('returns undefined for an unknown task id', () => {
+      expect(orchestrator.getTaskLineage('does-not-exist')).toBeUndefined();
+    });
+  });
+
   describe('loadPlan', () => {
     it('creates tasks with correct dependencies', () => {
       const plan: PlanDefinition = {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3553,6 +3553,25 @@ export class Orchestrator {
     return this.stateGetTask(taskId);
   }
 
+  /**
+   * Snapshot of a task's lineage identity (selected attempt id +
+   * execution generation). Used by fix-with-agent / conflict-resolution
+   * flows to detect late writes when async fix work returns after the
+   * task has moved to a new attempt or generation. Returns `undefined`
+   * when the task is not known to the orchestrator.
+   */
+  getTaskLineage(
+    taskId: string,
+  ): { taskId: string; selectedAttemptId: string | undefined; generation: number } | undefined {
+    const task = this.stateGetTask(taskId);
+    if (!task) return undefined;
+    return {
+      taskId,
+      selectedAttemptId: task.execution.selectedAttemptId,
+      generation: task.execution.generation ?? 0,
+    };
+  }
+
   getAutoFixRetryBudget(taskId: string): number {
     return this.defaultAutoFixRetries;
   }


### PR DESCRIPTION
Based on the skill and the actual diff, here's the PR body:

## Summary

Adds stale-lineage and cancellation guards around `fixWithAgentAction`, `resolveConflictAction`, `finalizeAppliedFix`, and `autoFixOnFailure` so late async fix results no-op when the task has moved to a newer selected attempt or execution generation. Stacks on top of the Step 1 workflow-mutation cancellation contract, which only aborted in-flight mutations — this step closes the remaining write paths (task output, fix approval state, branch metadata, conflict-resolution revert) against stale lineage.

Key changes:
- `Orchestrator.getTaskLineage(taskId)` is a new seam that returns `{ taskId, selectedAttemptId, generation }` so lineage capture has a single source of truth.
- `captureTaskLineage` now prefers `getTaskLineage` when available and falls back to `getTask` for narrowly mocked callers.
- `fixWithAgentAction` and `autoFixOnFailure` assert lineage on entry, before `beginConflictResolution`, and pass the captured lineage into `finalizeAppliedFix`.
- `resolveConflictAction` captures lineage before `beginConflictResolution` and asserts it before any persistence side effects.
- Error paths re-check lineage before appending output or calling `revertConflictResolution`; `autoFixOnFailure` now records `lineageStale` in its debug event and rethrows without writing when stale.
- `finalizeAppliedFix` accepts an optional `lineage` and asserts it instead of only checking `signal.aborted`.

## Architecture

### Before

```mermaid
graph TD
    A[fixWithAgentAction / resolveConflictAction] --> B[beginConflictResolution]
    B --> C[captureTaskLineage]
    C --> D[taskExecutor.fixWithAgent / resolveConflict]
    D --> E{lineage check}
    E -->|current| F[finalizeAppliedFix: signal.aborted only]
    E -->|stale| G[StaleLineageError]
    D -->|throws| H[appendTaskOutput + revertConflictResolution]
    H --> I[rethrow]
```

### After

```mermaid
graph TD
    A[fixWithAgentAction / resolveConflictAction] --> A1[captureTaskLineage via getTaskLineage]
    A1 --> A2{lineage check on entry}
    A2 -->|stale| G[StaleLineageError]
    A2 -->|current| B[beginConflictResolution]
    B --> D[taskExecutor.fixWithAgent / resolveConflict]
    D --> E{lineage check post-exec}
    E -->|stale| G
    E -->|current| F[finalizeAppliedFix with lineage assertion]
    D -->|throws| H{lineage still current?}
    H -->|no| I[rethrow without writes]
    H -->|yes| J[appendTaskOutput + revertConflictResolution]
    J --> I
```

## Test Plan

- [ ] `cd packages/app && pnpm test -- workflow-actions`
- [ ] `cd packages/workflow-core && pnpm test -- orchestrator`
- [ ] `pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None. Reverting restores the Step 1 behavior where late fix results could still write to a superseded lineage; pair with reverting Step 1 only if rolling back the full intent-cancellation series.
- Data migration? No