### PR TITLE
Fix intent cancellation Step 3: SSH startup lineage guards

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
@@ -145,4 +145,104 @@ describe('SSH worktree metadata repro', () => {
       }),
     }));
   });
+
+  it('blocks stale SSH startup-failure writes when the selected attempt has advanced', async () => {
+    const oldOwnerPath =
+      '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-bc7a0b71';
+    const oldBranch = 'experiment/wf-1/test-execution-engine-b68b146f';
+    const oldAttemptId = 'attempt-old-stale';
+    const newAttemptId = 'attempt-new-live';
+
+    const failingExecutor = {
+      type: 'ssh',
+      start: vi.fn().mockRejectedValue(Object.assign(
+        new Error(
+          'SSH remote script failed (exit=128)\n' +
+            `STDERR:\nPreparing worktree (checking out '${oldBranch}')\n` +
+            `fatal: '${oldBranch}' is already used by worktree at '${oldOwnerPath}'\n`,
+        ),
+        {
+          workspacePath: oldOwnerPath,
+          branch: oldBranch,
+        },
+      )),
+      onComplete: vi.fn(),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+
+    // Task as it was when the SSH launch started.
+    const startingTask = makeTask({
+      id: 'wf-1/test-execution-engine',
+      config: { command: 'pnpm test', executorType: 'ssh' },
+      execution: { selectedAttemptId: oldAttemptId, generation: 0 },
+    });
+
+    // Task as it appears to the orchestrator after the lineage advanced.
+    const liveTask = makeTask({
+      id: 'wf-1/test-execution-engine',
+      config: { command: 'pnpm test', executorType: 'ssh' },
+      execution: { selectedAttemptId: newAttemptId, generation: 1 },
+    });
+
+    const updateSpy = vi.fn();
+    const appendTaskOutputSpy = vi.fn();
+    const updateAttemptSpy = vi.fn();
+    const handleResponseSpy = vi.fn();
+    const onOutputSpy = vi.fn();
+    const onLaunchFailedSpy = vi.fn();
+
+    const runner = new TaskRunner({
+      orchestrator: {
+        getTask: () => liveTask,
+        getAllTasks: () => [liveTask],
+        handleWorkerResponse: handleResponseSpy,
+      } as any,
+      persistence: {
+        updateTask: updateSpy,
+        appendTaskOutput: appendTaskOutputSpy,
+        updateAttempt: updateAttemptSpy,
+      } as any,
+      executorRegistry: {
+        getDefault: () => failingExecutor,
+        get: () => failingExecutor,
+        getAll: () => [failingExecutor],
+      } as any,
+      cwd: '/tmp',
+      callbacks: { onOutput: onOutputSpy, onLaunchFailed: onLaunchFailedSpy },
+    });
+
+    await runner.executeTask(startingTask);
+
+    // Live task row must NOT be mutated with the old attempt's workspace/branch
+    expect(updateSpy).not.toHaveBeenCalledWith(
+      'wf-1/test-execution-engine',
+      expect.objectContaining({
+        execution: expect.objectContaining({ workspacePath: oldOwnerPath }),
+      }),
+    );
+    expect(updateSpy).not.toHaveBeenCalledWith(
+      'wf-1/test-execution-engine',
+      expect.objectContaining({
+        execution: expect.objectContaining({ branch: oldBranch }),
+      }),
+    );
+    // Live output stream is left alone so the new attempt's UI is not polluted
+    expect(appendTaskOutputSpy).not.toHaveBeenCalled();
+    expect(onOutputSpy).not.toHaveBeenCalled();
+    // onLaunchFailed must not clear the new launch's launching state
+    expect(onLaunchFailedSpy).not.toHaveBeenCalled();
+    // No failed WorkResponse is emitted against the newer attempt
+    expect(handleResponseSpy).not.toHaveBeenCalled();
+    // Diagnostics survive on the old attempt row for post-mortem
+    expect(updateAttemptSpy).toHaveBeenCalledWith(
+      oldAttemptId,
+      expect.objectContaining({
+        status: 'failed',
+        error: expect.stringContaining('Executor startup failed (ssh)'),
+      }),
+    );
+  });
 });

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -926,6 +926,10 @@ describe('TaskRunner', () => {
     it('suppresses metadata write and failed response when selectedAttemptId has advanced', async () => {
       const handleWorkerResponse = vi.fn();
       const updateTask = vi.fn();
+      const appendTaskOutput = vi.fn();
+      const updateAttempt = vi.fn();
+      const onOutput = vi.fn();
+      const onLaunchFailed = vi.fn();
       // Orchestrator returns a task whose selectedAttemptId has moved forward
       const orchestrator = {
         getTask: () => makeTask({
@@ -952,9 +956,10 @@ describe('TaskRunner', () => {
 
       const runner = new TaskRunner({
         orchestrator: orchestrator as any,
-        persistence: { updateTask } as any,
+        persistence: { updateTask, appendTaskOutput, updateAttempt } as any,
         executorRegistry: registry as any,
         cwd: '/tmp',
+        callbacks: { onOutput, onLaunchFailed },
       });
 
       // Task was launched with attempt-1 but orchestrator now shows attempt-2
@@ -975,17 +980,32 @@ describe('TaskRunner', () => {
       );
       // Failed WorkResponse must NOT be emitted
       expect(handleWorkerResponse).not.toHaveBeenCalled();
+      // Live task output must NOT be mutated by the stale launch
+      expect(appendTaskOutput).not.toHaveBeenCalled();
+      expect(onOutput).not.toHaveBeenCalled();
+      // onLaunchFailed must NOT clear the new attempt's launching state
+      expect(onLaunchFailed).not.toHaveBeenCalled();
+      // Diagnostics are routed to the attempt row (attempt-scoped)
+      expect(updateAttempt).toHaveBeenCalledWith(
+        'attempt-1',
+        expect.objectContaining({
+          status: 'failed',
+          error: expect.stringContaining('SSH connection refused'),
+        }),
+      );
     });
 
     it('suppresses metadata write and failed response when generation has advanced', async () => {
       const handleWorkerResponse = vi.fn();
       const updateTask = vi.fn();
+      const appendTaskOutput = vi.fn();
+      const updateAttempt = vi.fn();
       // Orchestrator returns a task whose generation has bumped
       const orchestrator = {
         getTask: () => makeTask({
           id: 'stale-gen',
           status: 'running',
-          execution: { generation: 2 },
+          execution: { selectedAttemptId: 'attempt-gen', generation: 2 },
         }),
         handleWorkerResponse,
       };
@@ -1006,7 +1026,7 @@ describe('TaskRunner', () => {
 
       const runner = new TaskRunner({
         orchestrator: orchestrator as any,
-        persistence: { updateTask } as any,
+        persistence: { updateTask, appendTaskOutput, updateAttempt } as any,
         executorRegistry: registry as any,
         cwd: '/tmp',
       });
@@ -1015,7 +1035,7 @@ describe('TaskRunner', () => {
         id: 'stale-gen',
         status: 'running',
         config: { command: 'echo hi', executorType: 'ssh' as any },
-        execution: { generation: 1 },
+        execution: { selectedAttemptId: 'attempt-gen', generation: 1 },
       });
       await runner.executeTask(task);
 
@@ -1027,6 +1047,16 @@ describe('TaskRunner', () => {
         }),
       );
       expect(handleWorkerResponse).not.toHaveBeenCalled();
+      // Live task output must NOT receive the stale launch's error message
+      expect(appendTaskOutput).not.toHaveBeenCalled();
+      // Diagnostics get persisted to the attempt row instead
+      expect(updateAttempt).toHaveBeenCalledWith(
+        'attempt-gen',
+        expect.objectContaining({
+          status: 'failed',
+          error: expect.stringContaining('provision failed'),
+        }),
+      );
     });
 
     it('still persists metadata and emits response when lineage is current', async () => {
@@ -1091,6 +1121,8 @@ describe('TaskRunner', () => {
     it('suppresses both inner metadata and outer response when lineage is stale throughout', async () => {
       const handleWorkerResponse = vi.fn();
       const updateTask = vi.fn();
+      const appendTaskOutput = vi.fn();
+      const updateAttempt = vi.fn();
       const orchestrator = {
         getTask: () => makeTask({
           id: 'inner-stale',
@@ -1117,7 +1149,7 @@ describe('TaskRunner', () => {
 
       const runner = new TaskRunner({
         orchestrator: orchestrator as any,
-        persistence: { updateTask } as any,
+        persistence: { updateTask, appendTaskOutput, updateAttempt } as any,
         executorRegistry: registry as any,
         cwd: '/tmp',
       });
@@ -1138,6 +1170,16 @@ describe('TaskRunner', () => {
         }),
       );
       expect(handleWorkerResponse).not.toHaveBeenCalled();
+      // No live-task output mutation when stale
+      expect(appendTaskOutput).not.toHaveBeenCalled();
+      // Diagnostics still preserved on the old attempt row
+      expect(updateAttempt).toHaveBeenCalledWith(
+        'attempt-old',
+        expect.objectContaining({
+          status: 'failed',
+          error: expect.stringContaining('timeout'),
+        }),
+      );
     });
   });
 

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -571,38 +571,56 @@ export class TaskRunner {
     } catch (err) {
       const meta = err as StartupFailureMetadata;
       const startupErrorMessage = `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}\n`;
-      this.callbacks.onOutput?.(task.id, startupErrorMessage);
-      try {
-        this.persistence.appendTaskOutput(task.id, startupErrorMessage);
-      } catch {
-        // Preserve the original startup failure if output persistence also fails.
-      }
-      // Only persist startup-failure metadata when the launch is still
-      // current.  If the task has moved to a newer attempt or generation
-      // (e.g. via recreate-task), writing old workspace/branch metadata
-      // would corrupt the live attempt's state.
-      if (
-        (meta.workspacePath || meta.branch || meta.agentSessionId || meta.containerId)
-        && !this.isLaunchStale(task.id, attemptId, task.execution.generation ?? 0)
-      ) {
-        const execution: Record<string, string> = {};
-        if (meta.workspacePath) execution.workspacePath = meta.workspacePath;
-        if (meta.branch) execution.branch = meta.branch;
-        if (meta.agentSessionId) {
-          execution.agentSessionId = meta.agentSessionId;
-          execution.lastAgentSessionId = meta.agentSessionId;
+      // Compute staleness once: if the task has advanced past this attempt
+      // (e.g. via recreate-task), every live-task write below would clobber
+      // the newer attempt's state.  Stale diagnostics are instead routed
+      // to the attempt row, which is attempt-scoped and append-only from
+      // the perspective of the new attempt.
+      const launchStale = this.isLaunchStale(task.id, attemptId, startGeneration);
+      if (launchStale) {
+        this.logger.warn(
+          `[TaskRunner] stale executor startup-failure for task=${task.id} attemptId=${attemptId}; routing diagnostics to attempt row`,
+        );
+        try {
+          this.persistence.updateAttempt?.(attemptId, {
+            status: 'failed',
+            error: startupErrorMessage.trimEnd(),
+            completedAt: new Date(),
+          } as any);
+        } catch (attemptErr) {
+          traceExecution(
+            `${RESTART_TO_BRANCH_TRACE} task=${task.id} attempt=${attemptId} stale startup error attempt persist failed: ${attemptErr instanceof Error ? attemptErr.message : String(attemptErr)}`,
+          );
         }
-        if (meta.containerId) execution.containerId = meta.containerId;
-        this.persistence.updateTask(task.id, {
-          config: { executorType: executor.type as ExecutorType },
-          execution: execution as any,
-        });
+      } else {
+        this.callbacks.onOutput?.(task.id, startupErrorMessage);
+        try {
+          this.persistence.appendTaskOutput(task.id, startupErrorMessage);
+        } catch {
+          // Preserve the original startup failure if output persistence also fails.
+        }
+        if (meta.workspacePath || meta.branch || meta.agentSessionId || meta.containerId) {
+          const execution: Record<string, string> = {};
+          if (meta.workspacePath) execution.workspacePath = meta.workspacePath;
+          if (meta.branch) execution.branch = meta.branch;
+          if (meta.agentSessionId) {
+            execution.agentSessionId = meta.agentSessionId;
+            execution.lastAgentSessionId = meta.agentSessionId;
+          }
+          if (meta.containerId) execution.containerId = meta.containerId;
+          this.persistence.updateTask(task.id, {
+            config: { executorType: executor.type as ExecutorType },
+            execution: execution as any,
+          });
+        }
       }
       const wrapped = new Error(
         `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}`,
         { cause: err },
       );
-      this.callbacks.onLaunchFailed?.(task.id, wrapped, executor);
+      if (!launchStale) {
+        this.callbacks.onLaunchFailed?.(task.id, wrapped, executor);
+      }
       throw wrapped;
     } finally {
       clearInterval(preStartHeartbeatTimer);


### PR DESCRIPTION
## Summary

Hardens execution-engine startup failure persistence so stale SSH launches cannot reattach old `workspacePath` / `branch` metadata, or emit a failed response, against a task whose selected attempt has already advanced. Without this guard, an attempt-1 SSH startup that fails after the task has moved to attempt-2 can overwrite the live task row with the previous worktree owner path, which then collides with the next launch.

The fix makes `TaskRunner` startup-failure persistence attempt-aware: it captures the originating attempt id, performs a lineage check before any write-back, and scopes diagnostics away from the live task row when the lineage is stale. Coverage is added for stale failure-response suppression on newer lineages, including a targeted SSH worktree-metadata repro.

This is Step 3 of the intent-cancellation hardening series; it composes with Step 1 (workflow mutation cancellation) and Step 2 (fix-flow lineage guards) by extending the same "no late writes onto a newer lineage" invariant down into the executor startup path.

## Architecture

### Before

```mermaid
graph TD
    A[SSH start fails on attempt-1] --> B[TaskRunner persists failure]
    B --> C[Write workspacePath / branch / failed response to live task row]
    C --> D{Task already on attempt-2?}
    D -->|Yes| E[Stale metadata clobbers live row<br/>Next SSH launch collides on old worktree owner path]
    D -->|No| F[OK]
```

### After

```mermaid
graph TD
    A[SSH start fails on attempt-1] --> B[TaskRunner captures starting attempt lineage]
    B --> C{Lineage still current?}
    C -->|No| D[Suppress failed response<br/>Scope diagnostics off the live task row<br/>No metadata write-back]
    C -->|Yes| E[Persist failure to live task row as before]
```

## Test Plan

- [ ] `cd packages/execution-engine && pnpm test -- task-runner`
- [ ] `cd packages/execution-engine && pnpm test -- ssh-worktree-metadata-repro`
- [ ] `cd packages/app && pnpm test -- workflow-actions`
- [ ] `cd packages/workflow-core && pnpm test -- orchestrator`
- [ ] `pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None. Reverting restores the prior write-through startup-failure path; no persisted schema or migration changed.
- Data migration? No