### PR TITLE
Fix intent cancellation Step 4: durable failure diagnostics

### DIFF
--- a/packages/app/src/__tests__/shutdown-diagnostic.test.ts
+++ b/packages/app/src/__tests__/shutdown-diagnostic.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
+import type { TaskFailureDiagnosticOptions } from '@invoker/data-store';
 import {
   persistShutdownDiagnostic,
   SHUTDOWN_DIAGNOSTIC_TAIL_CHARS,
@@ -19,29 +20,48 @@ function makeTask(overrides: Partial<TaskState> = {}): TaskState {
   } as TaskState;
 }
 
-function makeDb(tailData: string[] = []): ShutdownDiagnosticDb & { appended: string[] } {
-  const appended: string[] = [];
+interface RecordingDb extends ShutdownDiagnosticDb {
+  calls: Array<{ taskId: string; opts: TaskFailureDiagnosticOptions }>;
+}
+
+function makeDb(): RecordingDb {
+  const calls: Array<{ taskId: string; opts: TaskFailureDiagnosticOptions }> = [];
   return {
-    appended,
-    getOutputTail: () => tailData.map((d, i) => ({ data: d, offset: i })),
-    appendTaskOutput: (_taskId: string, data: string) => {
-      appended.push(data);
+    calls,
+    appendFailureDiagnostic: (taskId, opts) => {
+      calls.push({ taskId, opts });
     },
   };
 }
 
 describe('persistShutdownDiagnostic', () => {
-  it('appends a diagnostic block with status', () => {
+  it('delegates to appendFailureDiagnostic with the task status', () => {
     const task = makeTask({ status: 'running' });
     const db = makeDb();
 
     persistShutdownDiagnostic(task, db);
 
-    expect(db.appended).toHaveLength(1);
-    const output = db.appended[0];
-    expect(output).toContain('[Shutdown Diagnostic]');
-    expect(output).toContain('status=running');
-    expect(output).toContain('--- end shutdown diagnostic ---');
+    expect(db.calls).toHaveLength(1);
+    expect(db.calls[0].taskId).toBe('task-1');
+    expect(db.calls[0].opts.status).toBe('running');
+  });
+
+  it('defaults the diagnostic reason to "app-shutdown"', () => {
+    const db = makeDb();
+    persistShutdownDiagnostic(makeTask(), db);
+    expect(db.calls[0].opts.reason).toBe('app-shutdown');
+  });
+
+  it('propagates an explicit reason override', () => {
+    const db = makeDb();
+    persistShutdownDiagnostic(makeTask(), db, { reason: 'forced-stop' });
+    expect(db.calls[0].opts.reason).toBe('forced-stop');
+  });
+
+  it('forwards the synthetic shutdown message verbatim', () => {
+    const db = makeDb();
+    persistShutdownDiagnostic(makeTask(), db, { message: 'Application quit' });
+    expect(db.calls[0].opts.message).toBe('Application quit');
   });
 
   it('includes execution error when present', () => {
@@ -53,8 +73,7 @@ describe('persistShutdownDiagnostic', () => {
 
     persistShutdownDiagnostic(task, db);
 
-    const output = db.appended[0];
-    expect(output).toContain('error=npm test failed with exit code 1');
+    expect(db.calls[0].opts.error).toBe('npm test failed with exit code 1');
   });
 
   it('includes exitCode when present', () => {
@@ -66,89 +85,33 @@ describe('persistShutdownDiagnostic', () => {
 
     persistShutdownDiagnostic(task, db);
 
-    const output = db.appended[0];
-    expect(output).toContain('exitCode=42');
+    expect(db.calls[0].opts.exitCode).toBe(42);
   });
 
-  it('includes recent output tail from spool', () => {
-    const task = makeTask();
-    const db = makeDb(['line 1\n', 'line 2\n', 'FAIL src/foo.test.ts\n']);
-
-    persistShutdownDiagnostic(task, db);
-
-    const output = db.appended[0];
-    expect(output).toContain('--- recent output tail ---');
-    expect(output).toContain('line 1');
-    expect(output).toContain('line 2');
-    expect(output).toContain('FAIL src/foo.test.ts');
+  it('requests inline output tail with the standard char limit', () => {
+    const db = makeDb();
+    persistShutdownDiagnostic(makeTask(), db);
+    expect(db.calls[0].opts.includeOutputTail).toBe(true);
+    expect(db.calls[0].opts.tailCharLimit).toBe(SHUTDOWN_DIAGNOSTIC_TAIL_CHARS);
   });
 
-  it('truncates output tail exceeding the character limit', () => {
-    const task = makeTask();
-    const longChunk = 'x'.repeat(SHUTDOWN_DIAGNOSTIC_TAIL_CHARS + 500);
-    const db = makeDb([longChunk]);
-
-    persistShutdownDiagnostic(task, db);
-
-    const output = db.appended[0];
-    expect(output).toContain('...');
-    // The tail portion should be at most SHUTDOWN_DIAGNOSTIC_TAIL_CHARS long
-    const tailStart = output.indexOf('--- recent output tail ---');
-    const tailEnd = output.indexOf('--- end shutdown diagnostic ---');
-    const tailSection = output.slice(tailStart, tailEnd);
-    // 3 for '...' prefix + SHUTDOWN_DIAGNOSTIC_TAIL_CHARS + header line
-    expect(tailSection.length).toBeLessThan(SHUTDOWN_DIAGNOSTIC_TAIL_CHARS + 200);
-  });
-
-  it('omits output tail section when spool is empty', () => {
-    const task = makeTask();
-    const db = makeDb([]);
-
-    persistShutdownDiagnostic(task, db);
-
-    const output = db.appended[0];
-    expect(output).not.toContain('--- recent output tail ---');
-    expect(output).toContain('[Shutdown Diagnostic]');
-    expect(output).toContain('--- end shutdown diagnostic ---');
-  });
-
-  it('flushes pending output before capturing tail', () => {
-    const task = makeTask();
-    const flushOrder: string[] = [];
-    const db = makeDb(['flushed data\n']);
-    const origAppend = db.appendTaskOutput.bind(db);
-    db.appendTaskOutput = (taskId: string, data: string) => {
-      flushOrder.push('append');
-      origAppend(taskId, data);
-    };
-    const flushPendingOutput = (taskId: string) => {
-      flushOrder.push(`flush:${taskId}`);
-    };
-
-    persistShutdownDiagnostic(task, db, { flushPendingOutput });
-
-    expect(flushOrder[0]).toBe('flush:task-1');
-    expect(flushOrder[1]).toBe('append');
-  });
-
-  it('does not throw when db.appendTaskOutput fails', () => {
-    const task = makeTask();
+  it('flushes pending output before delegating to the adapter', () => {
+    const order: string[] = [];
     const db: ShutdownDiagnosticDb = {
-      getOutputTail: () => [],
-      appendTaskOutput: () => {
+      appendFailureDiagnostic: () => order.push('appendFailureDiagnostic'),
+    };
+    const flushPendingOutput = (taskId: string) => order.push(`flush:${taskId}`);
+
+    persistShutdownDiagnostic(makeTask(), db, { flushPendingOutput });
+
+    expect(order).toEqual(['flush:task-1', 'appendFailureDiagnostic']);
+  });
+
+  it('does not throw when appendFailureDiagnostic fails', () => {
+    const db: ShutdownDiagnosticDb = {
+      appendFailureDiagnostic: () => {
         throw new Error('DB write failed');
       },
-    };
-
-    expect(() => persistShutdownDiagnostic(task, db)).not.toThrow();
-  });
-
-  it('does not throw when db.getOutputTail fails', () => {
-    const db: ShutdownDiagnosticDb = {
-      getOutputTail: () => {
-        throw new Error('DB read failed');
-      },
-      appendTaskOutput: vi.fn(),
     };
 
     expect(() => persistShutdownDiagnostic(makeTask(), db)).not.toThrow();
@@ -160,7 +123,6 @@ describe('persistShutdownDiagnostic', () => {
 
     persistShutdownDiagnostic(task, db);
 
-    const output = db.appended[0];
-    expect(output).toContain('status=fixing_with_ai');
+    expect(db.calls[0].opts.status).toBe('fixing_with_ai');
   });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1094,7 +1094,12 @@ if (isHeadless) {
       if (ownsHeadlessShutdown && orchestrator) {
         for (const task of orchestrator.getAllTasks()) {
           if (task.status === 'running' || task.status === 'fixing_with_ai') {
-            if (persistence) persistShutdownDiagnostic(task, persistence);
+            if (persistence) {
+              persistShutdownDiagnostic(task, persistence, {
+                reason: 'app-shutdown',
+                message: 'Application quit',
+              });
+            }
             orchestrator.handleWorkerResponse({
               requestId: `quit-${task.id}`,
               actionId: task.id,
@@ -3697,6 +3702,8 @@ if (isHeadless) {
             if (persistence) {
               persistShutdownDiagnostic(task, persistence, {
                 flushPendingOutput: flushTaskOutput,
+                reason: 'app-shutdown',
+                message: 'Application quit',
               });
             }
             orchestrator.handleWorkerResponse({

--- a/packages/app/src/shutdown-diagnostic.ts
+++ b/packages/app/src/shutdown-diagnostic.ts
@@ -1,12 +1,17 @@
 import type { TaskState } from '@invoker/workflow-core';
-
-export interface ShutdownDiagnosticDb {
-  getOutputTail(taskId: string): Array<{ data: string }>;
-  appendTaskOutput(taskId: string, data: string): void;
-}
+import type { TaskFailureDiagnosticOptions } from '@invoker/data-store';
 
 /** Max characters of recent output tail included in shutdown diagnostics. */
 export const SHUTDOWN_DIAGNOSTIC_TAIL_CHARS = 4_000;
+
+/**
+ * Minimal slice of the persistence adapter used by the shutdown-diagnostic
+ * helper. Declared as a structural interface so tests can pass a lightweight
+ * mock without instantiating SQLiteAdapter.
+ */
+export interface ShutdownDiagnosticDb {
+  appendFailureDiagnostic(taskId: string, opts: TaskFailureDiagnosticOptions): void;
+}
 
 /**
  * Persist a compact diagnostic block into durable task output so that
@@ -19,32 +24,35 @@ export const SHUTDOWN_DIAGNOSTIC_TAIL_CHARS = 4_000;
 export function persistShutdownDiagnostic(
   task: TaskState,
   db: ShutdownDiagnosticDb,
-  opts?: { flushPendingOutput?: (taskId: string) => void },
+  opts?: {
+    flushPendingOutput?: (taskId: string) => void;
+    /**
+     * Short identifier for the diagnostic reason — defaults to "app-shutdown".
+     * Headless and GUI shutdown paths use the same default so durable output
+     * keeps a single recognizable marker for synthetic shutdown failures.
+     */
+    reason?: string;
+    /**
+     * Concrete supplementary message to embed verbatim. The synthetic
+     * shutdown handler sets this to the user-visible reason
+     * (e.g. "Application quit") so the diagnostic block records why the
+     * task was collapsed even when {@link TaskState.execution.error} is
+     * empty.
+     */
+    message?: string;
+  },
 ): void {
   try {
-    // Flush any buffered output so the spool is up-to-date.
     opts?.flushPendingOutput?.(task.id);
-
-    // Gather the most recent output tail from the output spool.
-    const tailChunks = db.getOutputTail(task.id);
-    let tail = tailChunks.map(c => c.data).join('');
-    if (tail.length > SHUTDOWN_DIAGNOSTIC_TAIL_CHARS) {
-      tail = '...' + tail.slice(tail.length - SHUTDOWN_DIAGNOSTIC_TAIL_CHARS);
-    }
-
-    const parts: string[] = ['\n[Shutdown Diagnostic]'];
-    parts.push(`status=${task.status}`);
-    if (task.execution.error) {
-      parts.push(`error=${task.execution.error}`);
-    }
-    if (task.execution.exitCode !== undefined && task.execution.exitCode !== null) {
-      parts.push(`exitCode=${task.execution.exitCode}`);
-    }
-    if (tail) {
-      parts.push(`--- recent output tail ---\n${tail}`);
-    }
-    parts.push('--- end shutdown diagnostic ---\n');
-    db.appendTaskOutput(task.id, parts.join('\n'));
+    db.appendFailureDiagnostic(task.id, {
+      reason: opts?.reason ?? 'app-shutdown',
+      status: task.status,
+      error: task.execution.error,
+      exitCode: task.execution.exitCode ?? undefined,
+      message: opts?.message,
+      includeOutputTail: true,
+      tailCharLimit: SHUTDOWN_DIAGNOSTIC_TAIL_CHARS,
+    });
   } catch {
     // Best-effort: don't let diagnostic persistence block shutdown.
   }

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -915,6 +915,132 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  // ── Failure Diagnostic Block ────────────────────────────
+
+  describe('appendFailureDiagnostic', () => {
+    function seedTask(): void {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1', { status: 'running' }));
+    }
+
+    it('appends a compact diagnostic block to durable task output', () => {
+      seedTask();
+
+      adapter.appendFailureDiagnostic('t1', {
+        reason: 'app-shutdown',
+        status: 'running',
+        error: 'npm test failed with exit code 1',
+        exitCode: 1,
+        message: 'Application quit',
+      });
+
+      const output = adapter.getTaskOutput('t1');
+      expect(output).toContain('[Failure Diagnostic]');
+      expect(output).toContain('reason=app-shutdown');
+      expect(output).toContain('status=running');
+      expect(output).toContain('error=npm test failed with exit code 1');
+      expect(output).toContain('exitCode=1');
+      expect(output).toContain('message=Application quit');
+      expect(output).toContain('--- end failure diagnostic ---');
+    });
+
+    it('preserves the synthetic shutdown message even when execution.error is empty', () => {
+      seedTask();
+
+      adapter.appendFailureDiagnostic('t1', {
+        reason: 'app-shutdown',
+        status: 'running',
+        message: 'Application quit',
+      });
+
+      const output = adapter.getTaskOutput('t1');
+      expect(output).toContain('reason=app-shutdown');
+      expect(output).toContain('message=Application quit');
+      expect(output).not.toContain('error=');
+      expect(output).not.toContain('exitCode=');
+    });
+
+    it('inlines the recent output tail from the spool when available', () => {
+      seedTask();
+      adapter.appendOutputChunk('t1', 'pre-failure log line\n');
+      adapter.appendOutputChunk('t1', 'FAIL src/foo.test.ts > does the thing\n');
+
+      adapter.appendFailureDiagnostic('t1', {
+        reason: 'executor-startup',
+        status: 'running',
+        error: 'Executor startup failed (worktree): provision failed',
+      });
+
+      const output = adapter.getTaskOutput('t1');
+      expect(output).toContain('--- recent output tail ---');
+      expect(output).toContain('pre-failure log line');
+      expect(output).toContain('FAIL src/foo.test.ts');
+    });
+
+    it('truncates the tail to the configured character limit with a leading ellipsis', () => {
+      seedTask();
+      const longChunk = 'x'.repeat(5_000);
+      adapter.appendOutputChunk('t1', longChunk);
+
+      adapter.appendFailureDiagnostic('t1', {
+        reason: 'app-shutdown',
+        status: 'running',
+        tailCharLimit: 1_000,
+      });
+
+      const output = adapter.getTaskOutput('t1');
+      const start = output.indexOf('--- recent output tail ---');
+      const end = output.indexOf('--- end failure diagnostic ---');
+      expect(start).toBeGreaterThanOrEqual(0);
+      expect(end).toBeGreaterThan(start);
+      const tailSection = output.slice(start, end);
+      expect(tailSection).toContain('...');
+      // tail header + 3-char ellipsis + truncated tail + trailing newline
+      expect(tailSection.length).toBeLessThan(1_000 + 200);
+    });
+
+    it('omits the tail section when includeOutputTail is false', () => {
+      seedTask();
+      adapter.appendOutputChunk('t1', 'spool content that should be ignored\n');
+
+      adapter.appendFailureDiagnostic('t1', {
+        reason: 'app-shutdown',
+        status: 'running',
+        includeOutputTail: false,
+      });
+
+      const output = adapter.getTaskOutput('t1');
+      expect(output).toContain('[Failure Diagnostic]');
+      expect(output).not.toContain('--- recent output tail ---');
+      expect(output).not.toContain('spool content that should be ignored');
+    });
+
+    it('coexists with the coarse terminal error written by the task row', () => {
+      // Simulate the real shutdown sequence: diagnostic block first, then the
+      // synthetic terminal error written via the task-state path.
+      seedTask();
+      adapter.appendFailureDiagnostic('t1', {
+        reason: 'app-shutdown',
+        status: 'running',
+        error: 'npm test failed with exit code 1',
+        message: 'Application quit',
+      });
+      adapter.updateTask('t1', {
+        status: 'failed',
+        execution: { error: 'Application quit', exitCode: 1 },
+      });
+
+      // Coarse terminal error is recorded on the task row…
+      const row = adapter.loadTask('t1');
+      expect(row?.status).toBe('failed');
+      expect(row?.execution.error).toBe('Application quit');
+      // …but durable output retains the concrete pre-shutdown context.
+      const output = adapter.getTaskOutput('t1');
+      expect(output).toContain('error=npm test failed with exit code 1');
+      expect(output).toContain('message=Application quit');
+    });
+  });
+
   // ── Conversations ──────────────────────────────────────
 
   function makeConversation(threadTs: string, overrides: Partial<Conversation> = {}): Conversation {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -66,6 +66,38 @@ export interface ActivityLogEntry {
   message: string;
 }
 
+/**
+ * Structured options for a failure-diagnostic block appended to task_output.
+ *
+ * The block is intentionally human-readable and append-only: it does not
+ * mutate the task row, so post-mortem inspection always sees the coarse
+ * terminal error state (e.g. "Application quit") next to the concrete
+ * diagnostics captured at the moment the failure was synthesized.
+ */
+export interface TaskFailureDiagnosticOptions {
+  /** Short identifier for the failure path — e.g. "app-shutdown" or "executor-startup". */
+  reason: string;
+  /** Task status observed at the moment the diagnostic was captured. */
+  status?: string;
+  /** Concrete error/stderr message captured from the executor or task state. */
+  error?: string;
+  /** Optional executor exit code, if known. */
+  exitCode?: number | null;
+  /**
+   * Concrete supplementary message (e.g. the synthetic shutdown reason
+   * "Application quit") to include verbatim so future readers know what
+   * collapsed the task to its terminal state.
+   */
+  message?: string;
+  /**
+   * Whether to read the recent spool tail and inline it into the block.
+   * Defaults to true. The tail is truncated to {@link tailCharLimit} chars.
+   */
+  includeOutputTail?: boolean;
+  /** Maximum tail size in characters. Defaults to 4_000. */
+  tailCharLimit?: number;
+}
+
 export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: Workflow): void;
@@ -106,6 +138,15 @@ export interface PersistenceAdapter {
   // Task output (stdout/stderr persistence)
   appendTaskOutput(taskId: string, data: string): void;
   getTaskOutput(taskId: string): string;
+
+  /**
+   * Append a compact failure-diagnostic block to durable task output.
+   * Used by synthetic owner-shutdown and executor startup-failure paths so
+   * post-mortem retrieval keeps concrete details (status, error, exit code,
+   * recent output tail) alongside the coarse terminal error state recorded
+   * on the task row.
+   */
+  appendFailureDiagnostic(taskId: string, opts: TaskFailureDiagnosticOptions): void;
 
   // Attempts
   saveAttempt(attempt: Attempt): void;

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -10,7 +10,15 @@ import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from '
 import { dirname } from 'node:path';
 import type { TaskState, TaskStateChanges, Attempt, TaskStatus } from '@invoker/workflow-core';
 import { normalizeExecutorType } from '@invoker/workflow-core';
-import type { PersistenceAdapter, Workflow, TaskEvent, ActivityLogEntry, Conversation, ConversationMessage } from './adapter.js';
+import type {
+  PersistenceAdapter,
+  Workflow,
+  TaskEvent,
+  ActivityLogEntry,
+  Conversation,
+  ConversationMessage,
+  TaskFailureDiagnosticOptions,
+} from './adapter.js';
 
 /**
  * Rewrite `pnpm test packages/<pkg>/...` (incorrect root-level invocation)
@@ -1386,6 +1394,31 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return rows.map((r) => r.data).join('');
   }
 
+  /**
+   * Append a compact failure-diagnostic block to durable task output so
+   * post-mortem readers see concrete details next to the coarse terminal
+   * error state on the task row. Best-effort: read/write errors are
+   * swallowed so a diagnostic-write failure never blocks the shutdown or
+   * failure-handling flow that called us.
+   */
+  appendFailureDiagnostic(taskId: string, opts: TaskFailureDiagnosticOptions): void {
+    try {
+      const block = formatFailureDiagnosticBlock({
+        reason: opts.reason,
+        status: opts.status,
+        error: opts.error,
+        exitCode: opts.exitCode ?? undefined,
+        message: opts.message,
+        tail: opts.includeOutputTail === false
+          ? ''
+          : readTrimmedSpoolTail(this, taskId, opts.tailCharLimit ?? DEFAULT_DIAGNOSTIC_TAIL_CHARS),
+      });
+      this.appendTaskOutput(taskId, block);
+    } catch {
+      // Diagnostics are advisory; never propagate a write failure.
+    }
+  }
+
   // ── Output Spool ────────────────────────────────────────
 
   appendOutputChunk(taskId: string, data: string): void {
@@ -2126,5 +2159,51 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'DELETE FROM workflow_mutation_leases WHERE workflow_id = ?',
       [workflowId],
     );
+  }
+}
+
+/** Default char cap for the recent-output tail inlined into a diagnostic block. */
+export const DEFAULT_DIAGNOSTIC_TAIL_CHARS = 4_000;
+
+interface FormatFailureDiagnosticInput {
+  reason: string;
+  status?: string;
+  error?: string;
+  exitCode?: number;
+  message?: string;
+  tail: string;
+}
+
+/**
+ * Build a compact, human-readable failure-diagnostic block. Exported so
+ * other callers (e.g. helpers wrapping different failure paths) can share
+ * the same format without depending on the SQLiteAdapter instance.
+ */
+export function formatFailureDiagnosticBlock(input: FormatFailureDiagnosticInput): string {
+  const parts: string[] = ['\n[Failure Diagnostic]'];
+  parts.push(`reason=${input.reason}`);
+  if (input.status) parts.push(`status=${input.status}`);
+  if (input.error) parts.push(`error=${input.error}`);
+  if (input.exitCode !== undefined && input.exitCode !== null) {
+    parts.push(`exitCode=${input.exitCode}`);
+  }
+  if (input.message) parts.push(`message=${input.message}`);
+  if (input.tail) {
+    parts.push(`--- recent output tail ---\n${input.tail}`);
+  }
+  parts.push('--- end failure diagnostic ---\n');
+  return parts.join('\n');
+}
+
+function readTrimmedSpoolTail(adapter: SQLiteAdapter, taskId: string, charLimit: number): string {
+  try {
+    const chunks = adapter.getOutputTail(taskId);
+    let tail = chunks.map(c => c.data).join('');
+    if (tail.length > charLimit) {
+      tail = '...' + tail.slice(tail.length - charLimit);
+    }
+    return tail;
+  } catch {
+    return '';
   }
 }


### PR DESCRIPTION
## Summary

After Step 3's SSH startup lineage guards eliminate stale metadata writes, the surviving failure paths still collapsed durable post-mortem context to a generic `Application quit` line. This change preserves the concrete startup and synthetic owner-shutdown details by routing both paths through a single durable diagnostic-append API.

- Adds `PersistenceAdapter.appendFailureDiagnostic(taskId, opts)` with a structured `TaskFailureDiagnosticOptions` contract (reason, status, error, exit code, supplementary message, optional output tail).
- Implements it on `SQLiteAdapter` via a shared `formatFailureDiagnosticBlock` helper that emits a compact, append-only `[Failure Diagnostic]` block; reads of the recent spool tail are best-effort and swallowed so diagnostics never block the failure-handling flow.
- Rewrites `persistShutdownDiagnostic` to delegate to the adapter and accept `reason` / `message` so synthetic shutdowns embed `app-shutdown` + `Application quit` verbatim instead of relying on `task.execution.error` being populated.
- Updates both headless shutdown sites in `main.ts` (foreground GUI shutdown and headless-owner shutdown) to pass the explicit `reason` / `message`.
- Task status semantics are unchanged — only durable `task_output` gains the structured diagnostic block.

## Architecture

The shutdown-diagnostic helper previously formatted the diagnostic block in the app layer and called the adapter's generic `appendTaskOutput` / `getOutputTail` primitives. After this change, the format and tail-reading logic live in `data-store`, behind a single `appendFailureDiagnostic` entry point that synthetic-failure callers share.

### Before

```mermaid
graph TD
    A[main.ts shutdown handler] --> B[persistShutdownDiagnostic]
    B --> C[db.getOutputTail]
    B --> D[format block in app layer]
    D --> E[db.appendTaskOutput]
    C --> D
```

### After

```mermaid
graph TD
    A[main.ts shutdown handler<br/>reason=app-shutdown<br/>message=Application quit] --> B[persistShutdownDiagnostic]
    B --> F[PersistenceAdapter.appendFailureDiagnostic]
    F --> G[SQLiteAdapter: readTrimmedSpoolTail]
    F --> H[formatFailureDiagnosticBlock]
    G --> H
    H --> I[appendTaskOutput]
```

## Test Plan

- [ ] `cd packages/data-store && pnpm test -- sqlite-adapter`
- [ ] `cd packages/app && pnpm test -- shutdown-diagnostic`
- [ ] `cd packages/app && pnpm test -- workflow-actions`
- [ ] `node scripts/validate-pr-body.mjs --body-file <this-body>`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 52022362 c74ad01d`
- Post-revert steps: None — shutdown diagnostics fall back to the prior app-layer formatter; `task_output` simply stops gaining the new `[Failure Diagnostic]` block.
- Data migration? No — `appendFailureDiagnostic` only appends to the existing `task_output` spool; no schema or row-shape changes.