### PR TITLE
test(e2e): align chaos harness git network cap with pollers

### DIFF
--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -6,6 +6,15 @@ cd "$ROOT"
 # shellcheck disable=SC1091
 source "$ROOT/scripts/e2e-dry-run/lib/common.sh"
 
+# Headless chaos polls for terminal task states within tight windows (often 120s).
+# Product default for network git is 15 minutes; a stalled fetch/push can keep tasks
+# in a non-terminal state longer than those pollers. Unless the caller already set
+# `INVOKER_GIT_NETWORK_TIMEOUT_MS` (including `0` for unbounded), use a 120s cap so
+# failures surface quickly and repros stay deterministic on slow networks.
+if [ -z "${INVOKER_GIT_NETWORK_TIMEOUT_MS:-}" ]; then
+  export INVOKER_GIT_NETWORK_TIMEOUT_MS=120000
+fi
+
 MODE="${INVOKER_CHAOS_OVERLOAD_MODE:-deterministic}"
 SCENARIO_FILTER="${INVOKER_CHAOS_OVERLOAD_SCENARIO:-}"
 CASE_TIMEOUT_SECONDS="${INVOKER_CHAOS_OVERLOAD_TIMEOUT_SECONDS:-1200}"
@@ -420,8 +429,8 @@ ov_submit_workflow() {
   local submit_mode="${4:-no-track}"
   local plan_path
   local log_path
-  plan_path="$(mktemp "${TMPDIR:-/tmp}/invoker-overload-plan.XXXXXX.yaml")"
-  log_path="$(mktemp "${TMPDIR:-/tmp}/invoker-overload-submit.XXXXXX.log")"
+  plan_path="$(mktemp "${TMPDIR:-/tmp}/invoker-overload-plan.XXXXXX")"
+  log_path="$(mktemp "${TMPDIR:-/tmp}/invoker-overload-submit.XXXXXX")"
   ov_generate_plan "$plan_path" "$kind" "$label" "$marker_path"
   if [ "$submit_mode" = "track" ]; then
     invoker_e2e_submit_plan_capture "$plan_path" "$log_path" >/dev/null
@@ -477,6 +486,7 @@ ov_start_owner() {
     setsid env \
       INVOKER_HEADLESS_STANDALONE=1 \
       INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS=600000 \
+      INVOKER_GIT_NETWORK_TIMEOUT_MS="${INVOKER_GIT_NETWORK_TIMEOUT_MS:-120000}" \
       LIBGL_ALWAYS_SOFTWARE="${LIBGL_ALWAYS_SOFTWARE:-1}" \
       "$electron_bin" $sandbox_flag "$main_js" --headless owner-serve \
       >"${OVERLOAD_TMP_DIR}/owner-serve.log" 2>&1 &
@@ -484,6 +494,7 @@ ov_start_owner() {
     env \
       INVOKER_HEADLESS_STANDALONE=1 \
       INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS=600000 \
+      INVOKER_GIT_NETWORK_TIMEOUT_MS="${INVOKER_GIT_NETWORK_TIMEOUT_MS:-120000}" \
       LIBGL_ALWAYS_SOFTWARE="${LIBGL_ALWAYS_SOFTWARE:-1}" \
       "$electron_bin" $sandbox_flag "$main_js" --headless owner-serve \
       >"${OVERLOAD_TMP_DIR}/owner-serve.log" 2>&1 &

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -79,7 +79,8 @@ invoker_e2e_init() {
   export INVOKER_DB_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-db.XXXXXX")"
   export INVOKER_IPC_SOCKET="${INVOKER_IPC_SOCKET:-$INVOKER_DB_DIR/ipc-transport.sock}"
   export INVOKER_E2E_MARKER_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-marker.XXXXXX")"
-  export INVOKER_REPO_CONFIG_PATH="$(mktemp "${TMPDIR:-/tmp}/invoker-e2e-config.XXXXXX.json")"
+  # Template must end with XXXXXX (suffix after X breaks BSD mktemp and can flake).
+  export INVOKER_REPO_CONFIG_PATH="$(mktemp "${TMPDIR:-/tmp}/invoker-e2e-config.XXXXXX")"
   printf '{\n  "autoFixRetries": 0\n}\n' > "$INVOKER_REPO_CONFIG_PATH"
   local stubdir
   stubdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-stub.XXXXXX")"


### PR DESCRIPTION
## Summary

Follow-up to [#435](https://github.com/Neko-Catpital-Labs/Invoker/pull/435): chaos and e2e harness scripts poll for terminal task states on tight windows (often 120s), while the product default `INVOKER_GIT_NETWORK_TIMEOUT_MS` remains 15 minutes. Without an explicit harness default, stalled `git fetch` / `git push` can keep tasks non-terminal far longer than those pollers.

This change defaults `INVOKER_GIT_NETWORK_TIMEOUT_MS` to **120000** for `scripts/e2e-chaos/run-overload.sh` when unset, passes it into the headless `owner-serve` process alongside existing `env` overrides, and fixes **BSD/macOS `mktemp`** templates where characters after `XXXXXX` break `mktemp` (e2e repo config path; overload plan/submit temp paths).

## Test Plan

- [ ] `bash -n scripts/e2e-chaos/run-overload.sh`
- [ ] `bash -n scripts/e2e-dry-run/lib/common.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No
