### PR TITLE
Fix fixing-with-AI Step 1: skip auto-fix without workspace

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -769,7 +769,7 @@ describe('autoFixOnFailure', () => {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => makeTask({
         status: 'failed',
-        execution: { autoFixAttempts: 0, error: 'boom' },
+        execution: { autoFixAttempts: 0, error: 'boom', workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
@@ -798,6 +798,55 @@ describe('autoFixOnFailure', () => {
     expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
     expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
+  });
+
+  it('skips auto-fix when workspacePath is missing for non-recreate routes', async () => {
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        execution: { autoFixAttempts: 0, error: 'boom' },
+      })),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      retryTask: vi.fn(() => []),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+      logEvent: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn().mockResolvedValue(undefined),
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await autoFixOnFailure('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
+    expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
+    expect(orchestrator.retryTask).not.toHaveBeenCalled();
+    expect(persistence.logEvent).toHaveBeenCalledWith(
+      'task-a',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'auto-fix-skip-no-workspace',
+        route: 'fixWithAgent',
+      }),
+    );
+    expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
+      'task-a',
+      expect.stringContaining('[Auto-fix] Auto-fix skipped: task "task-a" has no valid workspacePath'),
+    );
   });
 
   it('uses resolveConflict for merge-conflict errors and restarts the task directly', async () => {
@@ -1036,7 +1085,7 @@ describe('autoFixOnFailure', () => {
       getTask: vi.fn(() => makeTask({
         status: 'failed',
         config: { workflowId: 'wf-1', executionAgent: 'claude' },
-        execution: { autoFixAttempts: 0 },
+        execution: { autoFixAttempts: 0, workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
@@ -1086,7 +1135,7 @@ describe('autoFixOnFailure', () => {
       getTask: vi.fn(() => makeTask({
         status: 'failed',
         config: { workflowId: 'wf-1', executionAgent: 'codex' },
-        execution: { autoFixAttempts: 0 },
+        execution: { autoFixAttempts: 0, workspacePath: '/tmp/task-a' },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
@@ -2341,7 +2390,13 @@ describe('autoFixOnFailure lineage guard', () => {
           return makeTask({
             status: 'failed',
             config: { workflowId: 'wf-1' },
-            execution: { autoFixAttempts: 0, error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+            execution: {
+              autoFixAttempts: 0,
+              error: 'boom',
+              selectedAttemptId: 'att-1',
+              generation: 5,
+              workspacePath: '/tmp/task-a',
+            },
           });
         }
         // Lineage advanced after fix returned
@@ -2389,7 +2444,13 @@ describe('autoFixOnFailure lineage guard', () => {
           return makeTask({
             status: 'failed',
             config: { workflowId: 'wf-1' },
-            execution: { autoFixAttempts: 0, error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+            execution: {
+              autoFixAttempts: 0,
+              error: 'boom',
+              selectedAttemptId: 'att-1',
+              generation: 5,
+              workspacePath: '/tmp/task-a',
+            },
           });
         }
         return makeTask({
@@ -2432,7 +2493,13 @@ describe('autoFixOnFailure lineage guard', () => {
       getTask: vi.fn(() => makeTask({
         status: 'failed',
         config: { workflowId: 'wf-1' },
-        execution: { autoFixAttempts: 0, error: 'boom', selectedAttemptId: 'att-1', generation: 5 },
+        execution: {
+          autoFixAttempts: 0,
+          error: 'boom',
+          selectedAttemptId: 'att-1',
+          generation: 5,
+          workspacePath: '/tmp/task-a',
+        },
       })),
       getAutoFixRetryBudget: vi.fn(() => 3),
       beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -1067,6 +1067,21 @@ export async function autoFixOnFailure(
       return;
     }
 
+    const workspacePath = task.execution.workspacePath?.trim();
+    if (!workspacePath) {
+      const skipReason =
+        `Auto-fix skipped: task "${taskId}" has no valid workspacePath; `
+        + `run recreate-task or recreate-workflow first.`;
+      persistence.logEvent?.(taskId, 'debug.auto-fix', {
+        phase: 'auto-fix-skip-no-workspace',
+        route: recoveryRoute.kind,
+        attempts,
+        maxRetries: max,
+      });
+      persistence.appendTaskOutput(taskId, `\n[Auto-fix] ${skipReason}`);
+      return;
+    }
+
     ({ savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId));
     lineage = captureTaskLineage(taskId, orchestrator);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {


### PR DESCRIPTION
## Summary

When a task fails without a valid `workspacePath`, auto-fix was still trying to run an AI fix path that cannot succeed.

This PR adds a guard in `autoFixOnFailure` to stop early in that case. Instead of attempting `fixWithAgent`, it now:
- logs a clear `debug.auto-fix` event (`auto-fix-skip-no-workspace`), and
- appends a user-visible output message telling the operator to recreate the task/workflow first.

This makes "Fix with AI" behavior explicit and prevents noisy retries on unrecoverable inputs.

## Test Plan

- [x] `PATH="/opt/homebrew/opt/node@22/bin:$PATH" npm exec pnpm -- test -- "src/__tests__/workflow-actions.test.ts"`
- [x] `PATH="/opt/homebrew/opt/node@22/bin:$PATH" bash scripts/repro/repro-launching-stall.sh`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert b78c5c7`
- Post-revert steps: None.
- Data migration? No.
