### PR TITLE
fix(execution-engine): use direct merge dependencies only

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
-import { collectTransitiveNonMergeTaskIds } from '../merge-runner.js';
+import { collectDirectNonMergeTaskIds } from '../merge-runner.js';
 import { SshExecutor } from '../ssh-executor.js';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
@@ -491,8 +491,8 @@ describe('TaskRunner', () => {
     await done;
   });
 
-  describe('collectTransitiveNonMergeTaskIds', () => {
-    it('walks backwards from merge deps to include intermediate tasks', () => {
+  describe('collectDirectNonMergeTaskIds', () => {
+    it('returns only direct non-merge dependencies', () => {
       const tasks = new Map<string, TaskState>();
       tasks.set('verify-ui-tests', makeTask({ id: 'verify-ui-tests', dependencies: [] }));
       tasks.set('distinguish', makeTask({ id: 'distinguish', dependencies: ['verify-ui-tests'] }));
@@ -501,11 +501,11 @@ describe('TaskRunner', () => {
         dependencies: ['distinguish'],
         config: { isMergeNode: true },
       });
-      const ids = collectTransitiveNonMergeTaskIds(merge, (id) => tasks.get(id));
-      expect([...ids].sort()).toEqual(['distinguish', 'verify-ui-tests']);
+      const ids = collectDirectNonMergeTaskIds(merge, (id) => tasks.get(id));
+      expect([...ids].sort()).toEqual(['distinguish']);
     });
 
-    it('stops at merge nodes in the dependency chain', () => {
+    it('excludes direct dependencies that are merge nodes', () => {
       const tasks = new Map<string, TaskState>();
       tasks.set('a', makeTask({ id: 'a', dependencies: [] }));
       const innerMerge = makeTask({ id: '__merge__inner', dependencies: ['a'], config: { isMergeNode: true } });
@@ -516,7 +516,7 @@ describe('TaskRunner', () => {
         dependencies: ['b'],
         config: { isMergeNode: true },
       });
-      const ids = collectTransitiveNonMergeTaskIds(rootMerge, (id) => tasks.get(id));
+      const ids = collectDirectNonMergeTaskIds(rootMerge, (id) => tasks.get(id));
       expect([...ids].sort()).toEqual(['b']);
     });
   });
@@ -4948,7 +4948,7 @@ describe('TaskRunner', () => {
       await expect(executor.executeTask(tasks.get('__merge__wf-1')!)).resolves.toBeUndefined();
     });
 
-    it('merges the full linear chain when merge gate depends only on the tip task', async () => {
+    it('merges only direct dependency branches when merge gate depends on the tip task', async () => {
       const tasks = new Map<string, TaskState>();
       tasks.set('A', makeTask({ id: 'A', status: 'completed', config: { workflowId: 'wf-1' }, execution: { branch: 'invoker/A' } }));
       tasks.set('B', makeTask({ id: 'B', status: 'completed', dependencies: ['A'], config: { workflowId: 'wf-1' }, execution: { branch: 'invoker/B' } }));
@@ -5002,10 +5002,10 @@ describe('TaskRunner', () => {
 
       await executor.executeTask(tasks.get('__merge__wf-1')!);
 
-      expect(mergedBranches.sort()).toEqual(['invoker/A', 'invoker/B', 'invoker/C', 'invoker/D']);
+      expect(mergedBranches.sort()).toEqual(['invoker/D']);
     });
 
-    it('includes parallel workflow leaves even when merge.dependencies omits one leaf', async () => {
+    it('does not include sibling leaves omitted from merge.dependencies', async () => {
       const tasks = new Map<string, TaskState>();
       tasks.set('verify-ui-tests', makeTask({
         id: 'verify-ui-tests',
@@ -5076,10 +5076,10 @@ describe('TaskRunner', () => {
 
       await executor.executeTask(tasks.get('__merge__wf-par')!);
 
-      expect(mergedBranches.sort()).toEqual(['experiment/distinguish-par', 'experiment/verify-par']);
+      expect(mergedBranches.sort()).toEqual(['experiment/distinguish-par']);
     });
 
-    it('merges transitive upstream branches when merge gate depends only on the final leaf', async () => {
+    it('does not merge transitive upstream branches when merge gate depends on final leaf', async () => {
       const tasks = new Map<string, TaskState>();
       tasks.set('verify-ui-tests', makeTask({
         id: 'verify-ui-tests',
@@ -5152,10 +5152,10 @@ describe('TaskRunner', () => {
       await executor.executeTask(tasks.get('__merge__wf-chain')!);
 
       expect(mergedBranches).toContain('experiment/distinguish-aa');
-      expect(mergedBranches).toContain('experiment/verify-ce05');
+      expect(mergedBranches).not.toContain('experiment/verify-ce05');
     });
 
-    it('forked leaves: merges only leaf branches from merge gate deps', async () => {
+    it('forked graph: merges only direct merge gate dependencies', async () => {
       const tasks = new Map<string, TaskState>();
       // A -> B -> D, A -> C -> E. Merge gate depends on [D, E]
       tasks.set('A', makeTask({ id: 'A', status: 'completed', config: { workflowId: 'wf-2' }, execution: { branch: 'invoker/A' } }));
@@ -5210,11 +5210,7 @@ describe('TaskRunner', () => {
 
       await executor.executeTask(tasks.get('__merge__wf-2')!);
 
-      // Transitive closure from leaves D,E includes fork ancestors A,B,C
       expect(mergedBranches.sort()).toEqual([
-        'invoker/A',
-        'invoker/B',
-        'invoker/C',
         'invoker/D',
         'invoker/E',
       ]);

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -370,16 +370,18 @@ export function collectTransitiveNonMergeTaskIds(
   return out;
 }
 
-/** Leaf tasks in a workflow (same semantics as reconcileMergeLeaves / findLeafTaskIds). */
-function findLeafTaskIdsInWorkflow(allTasks: TaskState[], workflowId: string): string[] {
-  const wf = allTasks.filter(
-    (t) => t.config.workflowId === workflowId && !t.config.isMergeNode && t.status !== 'stale',
-  );
-  const dependedOn = new Set<string>();
-  for (const t of wf) {
-    for (const d of t.dependencies) dependedOn.add(d);
+/** Direct non-merge dependencies of a merge node (no transitive expansion). */
+export function collectDirectNonMergeTaskIds(
+  mergeTask: TaskState,
+  getTask: (id: string) => TaskState | undefined,
+): Set<string> {
+  const out = new Set<string>();
+  for (const id of mergeTask.dependencies) {
+    const t = getTask(id);
+    if (!t || t.config.isMergeNode) continue;
+    out.add(id);
   }
-  return wf.filter((t) => !dependedOn.has(t.id)).map((t) => t.id);
+  return out;
 }
 
 // ── Extracted functions ──────────────────────────────────
@@ -912,10 +914,7 @@ export async function publishAfterFixImpl(
     if (task.id && workflowId) {
       const mergeT = allTasks.find((x) => x.id === task.id && x.config.isMergeNode);
       if (mergeT) {
-        allowedTaskIds = collectTransitiveNonMergeTaskIds(mergeT, (id) => host.orchestrator.getTask(id));
-        for (const lid of findLeafTaskIdsInWorkflow(allTasks, workflowId)) {
-          allowedTaskIds.add(lid);
-        }
+        allowedTaskIds = collectDirectNonMergeTaskIds(mergeT, (id) => host.orchestrator.getTask(id));
       }
     }
     const taskBranches = allTasks
@@ -1300,10 +1299,7 @@ export async function consolidateAndMergeImpl(
     if (mergeNodeTaskId && workflowId) {
       const mergeT = allTasks.find((x) => x.id === mergeNodeTaskId && x.config.isMergeNode);
       if (mergeT) {
-        allowedTaskIds = collectTransitiveNonMergeTaskIds(mergeT, (id) => host.orchestrator.getTask(id));
-        for (const lid of findLeafTaskIdsInWorkflow(allTasks, workflowId)) {
-          allowedTaskIds.add(lid);
-        }
+        allowedTaskIds = collectDirectNonMergeTaskIds(mergeT, (id) => host.orchestrator.getTask(id));
         console.log(
           `[merge] consolidation task set (${allowedTaskIds.size} ids): ${[...allowedTaskIds].sort().join(', ')}`,
         );
@@ -1311,7 +1307,6 @@ export async function consolidateAndMergeImpl(
           workflowId,
           mergeNodeTaskId,
           ids: [...allowedTaskIds].sort(),
-          leafIds: findLeafTaskIdsInWorkflow(allTasks, workflowId),
         });
       }
     }

--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -1634,8 +1634,12 @@ run_same_workflow_tracked_fix_vs_recreate() {
   local operation_burst="$2"
   # Under CI chaos, post-exit `git push` can contend with many concurrent clones/fetches
   # and occasionally approach SSH-level stalls before succeeding or erroring out.
-  # Keep this above the worst-case `INVOKER_GIT_NETWORK_TIMEOUT_MS` budget plus agent/setup slack.
-  local seed_timeout_seconds=240
+  # Derive this from network git timeout and keep ample slack for queue/load variance.
+  local git_network_timeout_ms="${INVOKER_GIT_NETWORK_TIMEOUT_MS:-120000}"
+  local seed_timeout_seconds=360
+  if [[ "$git_network_timeout_ms" =~ ^[0-9]+$ ]] && [ "$git_network_timeout_ms" -gt 0 ]; then
+    seed_timeout_seconds="$(( (git_network_timeout_ms + 999) / 1000 + 240 ))"
+  fi
   invoker_e2e_init
   trap 'ov_stop_owner; rm -rf "${OVERLOAD_TMP_DIR:-}" >/dev/null 2>&1 || true; invoker_e2e_cleanup' RETURN
   cd "$INVOKER_E2E_REPO_ROOT"


### PR DESCRIPTION
## Summary
- switch merge gate consolidation selection to direct non-merge dependencies only (no transitive expansion, no workflow leaf union)
- apply the same direct-only selection in both `consolidateAndMergeImpl` and `publishAfterFixImpl`
- update merge-selection tests in `task-runner.test.ts` to enforce direct-only behavior

## Test plan
- [x] `cd packages/execution-engine && corepack pnpm test` *(fails on one existing unrelated test: `ssh-worktree-metadata-repro.test.ts` path-format assertion)*
- [x] `export PATH="/opt/homebrew/opt/node@22/bin:/opt/homebrew/bin:$PATH" && corepack pnpm run test:all` (passes)

Made with [Cursor](https://cursor.com)