### PR TITLE
Fix visual proof PR summary capture

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -2745,6 +2745,125 @@ describe('TaskRunner', () => {
       );
     });
 
+    it('reproduces wf-1778431030512-12 visual-proof markdown in the merge-gate PR body', async () => {
+      const cwd = createTempWorkspace();
+      mkdirSync(join(cwd, 'scripts'), { recursive: true });
+      mkdirSync(join(cwd, 'mock-wt'), { recursive: true });
+      writeFileSync(join(cwd, 'scripts', 'ui-visual-proof.sh'), `#!/usr/bin/env bash
+set -euo pipefail
+label=""
+output_dir=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --label) label="$2"; shift 2 ;;
+    --output-dir) output_dir="$2"; shift 2 ;;
+    *) echo "Unknown option: $1" >&2; exit 64 ;;
+  esac
+done
+if [[ -z "$label" || -z "$output_dir" ]]; then
+  echo "missing visual proof args" >&2
+  exit 64
+fi
+mkdir -p "$output_dir/$label"
+printf 'png' > "$output_dir/$label/merge-gate-no-inline-approve.png"
+printf 'png' > "$output_dir/$label/task-panel.png"
+printf 'video' > "$output_dir/$label/walkthrough.webm"
+echo "$output_dir/$label"
+`);
+      writeFileSync(join(cwd, 'scripts', 'upload-pr-images.mjs'), `const out = {};
+for (const file of process.argv.slice(2)) {
+  const name = file.split('/').pop();
+  out[name] = 'https://img.example.test/' + name;
+}
+console.log(JSON.stringify(out));
+`);
+
+      const workflowId = 'wf-1778431030512-12';
+      const taskId = 'fix-visual-proof-pr-summary-repro';
+      const mergeTaskId = `__merge__${workflowId}`;
+      const allTasks = [
+        makeTask({
+          id: taskId,
+          description: 'Add regression repro for failed visual-proof PR summary path',
+          status: 'completed',
+          config: { workflowId },
+          execution: { branch: 'experiment-wf-1778431030512-12-fix-visual-proof-pr-summary-repro' },
+        }),
+      ];
+      const mergeTask = makeTask({
+        id: mergeTaskId,
+        status: 'running',
+        dependencies: [taskId],
+        config: { isMergeNode: true, workflowId },
+      });
+      const orchestrator = {
+        getTask: (id: string) => id === mergeTaskId ? mergeTask : allTasks.find(t => t.id === id),
+        getAllTasks: () => [...allTasks, mergeTask],
+        handleWorkerResponse: vi.fn(() => []),
+        setTaskAwaitingApproval: vi.fn(),
+      };
+      const persistence = {
+        loadWorkflow: () => ({
+          id: workflowId,
+          name: 'Fix visual-proof PR summary repro',
+          description: 'Regression workflow for PR #276 missing visual-proof markdown',
+          onFinish: 'merge',
+          mergeMode: 'external_review',
+          baseBranch: 'master',
+          featureBranch: 'experiment/wf-1778431030512-12-visual-proof-pr-summary',
+          visualProof: true,
+        }),
+        updateTask: vi.fn(),
+      };
+      const mergeGateProvider = {
+        createReview: vi.fn().mockResolvedValue({
+          url: 'https://github.com/invoker/invoker/pull/276',
+          identifier: 'invoker/invoker#276',
+        }),
+      };
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd,
+        callbacks: { onComplete: vi.fn() },
+        mergeGateProvider: mergeGateProvider as any,
+      });
+
+      const gitCalls: string[][] = [];
+      (executor as any).execGitIn = async (args: string[], _dir: string) => {
+        gitCalls.push([...args]);
+        if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') return 'abc123';
+        if (args[0] === 'rev-parse') return 'feature-sha';
+        if (args[0] === 'merge-base' && args[1] === '--is-ancestor') throw new Error('not ancestor');
+        return '';
+      };
+      (executor as any).execGitReadonly = async (args: string[]) => {
+        if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        return '';
+      };
+      (executor as any).createMergeWorktree = vi.fn().mockResolvedValue(join(cwd, 'mock-wt'));
+      (executor as any).removeMergeWorktree = vi.fn();
+      (executor as any).gitDiffStat = vi.fn().mockResolvedValue(' packages/execution-engine/src/task-runner.ts | 20 +++++');
+      (executor as any).startPrPolling = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockImplementation(async (args: any) => ({
+        body: `## Summary\n\n${args.workflowSummary}\n\n${args.structuredContext?.visualProofMarkdown ?? ''}`,
+        sessionId: 'sess-wf-1778431030512-12',
+        agentName: 'codex',
+      }));
+
+      await (executor as any).executeMergeNode(mergeTask);
+
+      expect(gitCalls.some(c => c[0] === 'push')).toBe(true);
+      expect(mergeGateProvider.createReview).toHaveBeenCalledTimes(1);
+      const providerBody = mergeGateProvider.createReview.mock.calls[0][0].body;
+      expect(providerBody).toContain('## Visual Proof');
+      expect(providerBody).toContain('merge-gate-no-inline-approve.png');
+      expect(providerBody).toContain('![before](https://img.example.test/before--merge-gate-no-inline-approve.png)');
+      expect(providerBody).toContain('![after](https://img.example.test/after--merge-gate-no-inline-approve.png)');
+    });
+
     it('executeMergeNode goes to awaiting_approval when mergeMode=manual and onFinish=none', async () => {
       const orchestrator = {
         getTask: () => null,

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1043,56 +1043,78 @@ export class TaskRunner {
         await this.removeMergeWorktree(wtDir);
       }
 
-      // Upload and build markdown
-      const states = ['empty-state', 'dag-loaded', 'task-running', 'task-complete', 'task-panel'];
+      // Upload and build markdown from files that exist in both before/after captures.
+      const beforeDir = resolve(outputDir, 'before');
+      const afterDir = resolve(outputDir, 'after');
+      const beforePngs = new Set(readdirSync(beforeDir).filter((f) => f.endsWith('.png')));
+      const afterPngs = new Set(readdirSync(afterDir).filter((f) => f.endsWith('.png')));
+      const states = [...beforePngs].filter((f) => afterPngs.has(f)).sort();
+
       mkdirSync(resolve(homedir(), '.invoker'), { recursive: true });
       const tmpDir = mkdtempSync(resolve(homedir(), '.invoker', 'vp-'));
-      for (const mode of ['before', 'after']) {
-        for (const f of readdirSync(resolve(outputDir, mode))) {
-          copyFileSync(resolve(outputDir, mode, f), resolve(tmpDir, `${mode}--${f}`));
+      try {
+        for (const mode of ['before', 'after']) {
+          for (const f of readdirSync(resolve(outputDir, mode))) {
+            copyFileSync(resolve(outputDir, mode, f), resolve(tmpDir, `${mode}--${f}`));
+          }
         }
-      }
 
-      const uploadResult = await new Promise<string>((resolveP, reject) => {
-        const files = readdirSync(tmpDir).map(f => resolve(tmpDir, f));
-        const child = spawn('node', [resolve(this.cwd, 'scripts/upload-pr-images.mjs'), ...files], {
-          cwd: this.cwd,
-          stdio: ['ignore', 'pipe', 'pipe'],
+        const uploadResult = await new Promise<string>((resolveP, reject) => {
+          const files = readdirSync(tmpDir).map(f => resolve(tmpDir, f));
+          const child = spawn('node', [resolve(this.cwd, 'scripts/upload-pr-images.mjs'), ...files], {
+            cwd: this.cwd,
+            stdio: ['ignore', 'pipe', 'pipe'],
+          });
+          let stdout = '';
+          let stderr = '';
+          child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+          child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+          child.on('error', (err) => reject(err));
+          child.on('close', (code) => {
+            if (code !== 0) reject(new Error(`Upload failed (exit ${code}): ${stderr}`));
+            else resolveP(stdout.trim());
+          });
         });
-        let stdout = '';
-        child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
-        child.on('error', (err) => reject(err));
-        child.on('close', (code) => {
-          if (code !== 0) reject(new Error(`Upload failed (exit ${code})`));
-          else resolveP(stdout.trim());
-        });
-      });
 
-      rmSync(tmpDir, { recursive: true, force: true });
+        const urlMap = JSON.parse(uploadResult);
+        const lines: string[] = ['## Visual Proof', ''];
+        if (states.length === 0) {
+          lines.push('> Warning: visual proof capture completed, but no matching before/after PNG pairs were found.', '');
+        }
+        for (const filename of states) {
+          const stateName = filename
+            .replace(/\.png$/i, '')
+            .replace(/-/g, ' ')
+            .replace(/\b\w/g, c => c.toUpperCase());
+          const beforeUrl = urlMap[`before--${filename}`] ?? '';
+          const afterUrl = urlMap[`after--${filename}`] ?? '';
+          lines.push(`<details open>`, `<summary>${stateName}</summary>`, '',
+            '| Before | After |', '|--------|-------|',
+            `| ![before](${beforeUrl}) | ![after](${afterUrl}) |`, '', '</details>', '');
+        }
+        const beforeVideo = urlMap['before--walkthrough.webm'] ?? '';
+        const afterVideo = urlMap['after--walkthrough.webm'] ?? '';
+        if (beforeVideo || afterVideo) {
+          lines.push('<details>', '<summary>Video Walkthroughs</summary>', '',
+            `- [Before walkthrough](${beforeVideo})`, `- [After walkthrough](${afterVideo})`,
+            '', '</details>');
+        }
 
-      const urlMap = JSON.parse(uploadResult);
-      const lines: string[] = ['## Visual Proof', ''];
-      for (const state of states) {
-        const stateName = state.replace(/-/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
-        const beforeUrl = urlMap[`before--${state}.png`] ?? '';
-        const afterUrl = urlMap[`after--${state}.png`] ?? '';
-        lines.push(`<details open>`, `<summary>${stateName}</summary>`, '',
-          '| Before | After |', '|--------|-------|',
-          `| ![before](${beforeUrl}) | ![after](${afterUrl}) |`, '', '</details>', '');
+        return lines.join('\n');
+      } finally {
+        rmSync(tmpDir, { recursive: true, force: true });
       }
-      const beforeVideo = urlMap['before--walkthrough.webm'] ?? '';
-      const afterVideo = urlMap['after--walkthrough.webm'] ?? '';
-      lines.push('<details>', '<summary>Video Walkthroughs</summary>', '',
-        `- [Before walkthrough](${beforeVideo})`, `- [After walkthrough](${afterVideo})`,
-        '', '</details>');
-
-      return lines.join('\n');
     } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
       this.logger.warn('[visual-proof] Capture failed (non-blocking)', {
-        error: err instanceof Error ? err.message : String(err),
+        error: message,
         err,
       });
-      return undefined;
+      return [
+        '## Visual Proof',
+        '',
+        `> Warning: visual proof capture failed and screenshots could not be attached. ${message}`,
+      ].join('\n');
     }
   }
 

--- a/scripts/ui-visual-proof.sh
+++ b/scripts/ui-visual-proof.sh
@@ -55,7 +55,7 @@ SUBCOMMAND=""
 
 usage() {
   sed -n '3,/^$/p' "$0" | sed 's/^# \?//'
-  exit 1
+  exit "${1:-1}"
 }
 
 check_prerequisite_ffmpeg() {
@@ -254,8 +254,8 @@ while [[ $# -gt 0 ]]; do
     --spec)       SPEC="$2"; shift 2 ;;
     --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
     --label)      SUBCOMMAND="capture-$2"; shift 2 ;;
-    --help|-h)    usage ;;
-    *)            echo "Unknown option: $1" >&2; usage ;;
+    --help|-h)    usage 0 ;;
+    *)            echo "Unknown option: $1" >&2; usage 1 ;;
   esac
 done
 
@@ -279,10 +279,10 @@ case "$SUBCOMMAND" in
     ;;
   "")
     echo "[visual-proof] ERROR: Missing subcommand. Use one of: capture-before, capture-after, validate, compare, embed" >&2
-    usage
+    usage 1
     ;;
   *)
     echo "[visual-proof] ERROR: Unknown subcommand: $SUBCOMMAND" >&2
-    usage
+    usage 1
     ;;
 esac

--- a/scripts/ui-visual-proof.sh
+++ b/scripts/ui-visual-proof.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 #   compare           Generate diff images and video (requires ffmpeg)
 #   embed             Generate markdown with embedded base64 images
 #   --spec <file>     Playwright spec file for capture-before/after (default: visual-proof.spec.ts)
+#   --output-dir <dir> Output root for visual proof artifacts (default: packages/app/e2e/visual-proof)
 #
 # Subcommand details:
 #   capture-before:
@@ -48,6 +49,7 @@ set -euo pipefail
 #     └── walkthrough.webm
 
 SPEC="visual-proof.spec.ts"
+OUTPUT_DIR="packages/app/e2e/visual-proof"
 RESULTS_DIR="packages/app/e2e/test-results"
 SUBCOMMAND=""
 
@@ -138,21 +140,21 @@ run_capture() {
 
 subcommand_capture_before() {
   echo "[visual-proof] Running capture-before..." >&2
-  run_capture "before" "packages/app/e2e/visual-proof" "${SPEC}" false
+  run_capture "before" "${OUTPUT_DIR}" "${SPEC}" false
 }
 
 subcommand_capture_after() {
   echo "[visual-proof] Running capture-after..." >&2
-  run_capture "after" "packages/app/e2e/visual-proof" "${SPEC}" false
+  run_capture "after" "${OUTPUT_DIR}" "${SPEC}" false
 }
 
 subcommand_compare() {
   echo "[visual-proof] Running compare..." >&2
   check_prerequisite_ffmpeg
 
-  local before_dir="packages/app/e2e/visual-proof/before"
-  local after_dir="packages/app/e2e/visual-proof/after"
-  local diff_dir="packages/app/e2e/visual-proof/diff"
+  local before_dir="${OUTPUT_DIR}/before"
+  local after_dir="${OUTPUT_DIR}/after"
+  local diff_dir="${OUTPUT_DIR}/diff"
 
   check_artifacts "$before_dir" || exit 1
   check_artifacts "$after_dir" || exit 1
@@ -205,9 +207,9 @@ subcommand_compare() {
 subcommand_embed() {
   echo "[visual-proof] Running embed..." >&2
 
-  local before_dir="packages/app/e2e/visual-proof/before"
-  local after_dir="packages/app/e2e/visual-proof/after"
-  local output_md="packages/app/e2e/visual-proof/EMBED.md"
+  local before_dir="${OUTPUT_DIR}/before"
+  local after_dir="${OUTPUT_DIR}/after"
+  local output_md="${OUTPUT_DIR}/EMBED.md"
 
   check_artifacts "$before_dir" || exit 1
   check_artifacts "$after_dir" || exit 1
@@ -250,6 +252,7 @@ fi
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --spec)       SPEC="$2"; shift 2 ;;
+    --output-dir) OUTPUT_DIR="$2"; shift 2 ;;
     --label)      SUBCOMMAND="capture-$2"; shift 2 ;;
     --help|-h)    usage ;;
     *)            echo "Unknown option: $1" >&2; usage ;;


### PR DESCRIPTION
## Summary

Fix visual-proof automation for merge-gate PR creation so workflows with `visualProof: true` capture before/after screenshots, upload every matching PNG state, and append the generated `## Visual Proof` markdown to the external-review PR body.

The regression covers the failed `wf-1778431030512-12` shape with mocked `git push`, `gh`, and PR-provider operations. It verifies the PR body includes the uploaded plan-specific screenshot markdown for `merge-gate-no-inline-approve.png` while blocking real remote side effects.

## Architecture

### Before

```mermaid
graph TD
    A[Merge-gate task visualProof true] --> B[runVisualProofCapture]
    B --> C[scripts/ui-visual-proof.sh capture-before --output-dir temp]
    C --> D[Script rejects unsupported option]
    D --> E[Capture returns no markdown]
    E --> F[External-review PR body has no Visual Proof section]
```

### After

```mermaid
graph TD
    A[Merge-gate task visualProof true] --> B[runVisualProofCapture]
    B --> C[scripts/ui-visual-proof.sh capture-before --output-dir temp]
    B --> D[scripts/ui-visual-proof.sh capture-after --output-dir temp]
    C --> E[temp before PNGs]
    D --> F[temp after PNGs]
    E --> G[Discover all matching states]
    F --> G
    G --> H[Upload images and render Visual Proof markdown]
    H --> I[External-review PR body includes uploaded screenshots]
```

## Test Plan

- [x] `cd packages/execution-engine && pnpm test`
- [x] `bash scripts/ui-visual-proof.sh --help`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: Re-run `pnpm run test:all` after reverting.
- Data migration? No