### PR TITLE
Fix intent cancellation Step 2: fix flow lineage guards (regression gated v2)

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -2207,11 +2207,6 @@ describe('fixWithAgentAction lineage guard', () => {
     const orchestrator = {
       getTask: vi.fn(() => {
         fixCallCount++;
-        // First call: entry point reads task
-        // Second call: entry lineage capture
-        // Third call: post-begin lineage capture
-        // Fourth call: pre-agent lineage checkpoint
-        // Fifth call: lineage check after async fix returns (lineage changed)
         if (fixCallCount <= 4) {
           return makeTask({
             status: 'failed',

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -2208,9 +2208,11 @@ describe('fixWithAgentAction lineage guard', () => {
       getTask: vi.fn(() => {
         fixCallCount++;
         // First call: entry point reads task
-        // Second call: lineage capture after beginConflictResolution
-        // Third call: lineage check after async fix returns (lineage changed)
-        if (fixCallCount <= 2) {
+        // Second call: entry lineage capture
+        // Third call: post-begin lineage capture
+        // Fourth call: pre-agent lineage checkpoint
+        // Fifth call: lineage check after async fix returns (lineage changed)
+        if (fixCallCount <= 4) {
           return makeTask({
             status: 'failed',
             config: { workflowId: 'wf-1' },
@@ -2290,7 +2292,7 @@ describe('fixWithAgentAction lineage guard', () => {
     const orchestrator = {
       getTask: vi.fn(() => {
         getTaskCallCount++;
-        if (getTaskCallCount <= 2) {
+        if (getTaskCallCount <= 4) {
           return makeTask({
             status: 'failed',
             config: { workflowId: 'wf-1' },
@@ -2321,10 +2323,11 @@ describe('fixWithAgentAction lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
-    })).rejects.toThrow('agent crashed');
+    })).rejects.toThrow(StaleLineageError);
 
     // revertConflictResolution must NOT be called when lineage is stale
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
 
   it('proceeds normally when lineage is current', async () => {
@@ -2370,7 +2373,7 @@ describe('resolveConflictAction lineage guard', () => {
     const orchestrator = {
       getTask: vi.fn(() => {
         getTaskCallCount++;
-        if (getTaskCallCount <= 1) {
+        if (getTaskCallCount <= 3) {
           return makeTask({
             status: 'fixing_with_ai',
             config: { workflowId: 'wf-1' },
@@ -2410,7 +2413,7 @@ describe('resolveConflictAction lineage guard', () => {
     const orchestrator = {
       getTask: vi.fn(() => {
         getTaskCallCount++;
-        if (getTaskCallCount <= 1) {
+        if (getTaskCallCount <= 3) {
           return makeTask({
             status: 'fixing_with_ai',
             config: { workflowId: 'wf-1' },
@@ -2438,9 +2441,13 @@ describe('resolveConflictAction lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
-    })).rejects.toThrow('resolution failed');
+    })).rejects.toThrow(StaleLineageError);
 
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalledWith(
+      'task-a',
+      expect.stringContaining('[Auto-fix] Agent failed'),
+    );
   });
 });
 
@@ -2451,7 +2458,7 @@ describe('autoFixOnFailure lineage guard', () => {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => {
         getTaskCallCount++;
-        if (getTaskCallCount <= 2) {
+        if (getTaskCallCount <= 4) {
           return makeTask({
             status: 'failed',
             config: { workflowId: 'wf-1' },
@@ -2505,7 +2512,7 @@ describe('autoFixOnFailure lineage guard', () => {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => {
         getTaskCallCount++;
-        if (getTaskCallCount <= 2) {
+        if (getTaskCallCount <= 4) {
           return makeTask({
             status: 'failed',
             config: { workflowId: 'wf-1' },
@@ -2546,9 +2553,13 @@ describe('autoFixOnFailure lineage guard', () => {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor: taskExecutor as unknown as TaskRunner,
-    })).rejects.toThrow('agent crashed');
+    })).rejects.toThrow(StaleLineageError);
 
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
+    expect(persistence.appendTaskOutput).not.toHaveBeenCalledWith(
+      'task-a',
+      expect.stringContaining('[Auto-fix] Agent failed'),
+    );
   });
 
   it('throws StaleLineageError when signal is aborted during auto-fix', async () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -140,6 +140,7 @@ import {
   selectFailureRecoveryRoute,
   selectExperiments as sharedSelectExperiments,
   setWorkflowMergeMode,
+  StaleLineageError,
 } from './workflow-actions.js';
 import { spawn, execSync } from 'node:child_process';
 import { resolveTaskTerminalSpec } from './open-terminal-for-task.js';
@@ -1650,6 +1651,10 @@ function createEmbeddedTerminalBackendFromConfig(
         logAutoFixDebug(taskId, 'schedule-dispatch-finished');
       })
       .catch((err) => {
+        if (err instanceof StaleLineageError) {
+          logger.info(`auto-fix discarded stale result for "${taskId}": ${err.message}`, { module: 'auto-fix' });
+          return;
+        }
         logAutoFixDebug(taskId, 'schedule-dispatch-error', {
           error: err instanceof Error ? err.stack ?? err.message : String(err),
         });
@@ -3739,6 +3744,10 @@ function createEmbeddedTerminalBackendFromConfig(
           scopedTaskIds: [taskId],
         });
       } catch (err) {
+        if (err instanceof StaleLineageError) {
+          logger.info(`resolve-conflict discarded stale result for "${taskId}": ${err.message}`, { module: 'ipc' });
+          return;
+        }
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
@@ -3771,6 +3780,10 @@ function createEmbeddedTerminalBackendFromConfig(
           scopedTaskIds: [taskId],
         });
       } catch (err) {
+        if (err instanceof StaleLineageError) {
+          logger.info(`fix-with-agent discarded stale result for "${taskId}": ${err.message}`, { module: 'ipc' });
+          return;
+        }
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -798,21 +798,21 @@ export async function resolveConflictAction(
   signal?: AbortSignal,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
   const { orchestrator, persistence, taskExecutor } = deps;
+  const entryLineage = captureTaskLineage(taskId, orchestrator);
+  assertLineageCurrent(entryLineage, orchestrator, signal);
   const { savedError } = orchestrator.beginConflictResolution(taskId);
   const lineage = captureTaskLineage(taskId, orchestrator);
   try {
+    assertLineageCurrent(lineage, orchestrator, signal);
     await taskExecutor.resolveConflict(taskId, savedError, agentName);
     assertLineageCurrent(lineage, orchestrator, signal);
-    return await finalizeAppliedFix(taskId, savedError, deps, signal);
+    return await finalizeAppliedFix(taskId, savedError, deps, signal, lineage);
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
     const msg = err instanceof Error ? err.message : String(err);
+    assertLineageCurrent(lineage, orchestrator, signal);
     persistence.appendTaskOutput(taskId, `\n[Resolve Conflict] Failed: ${msg}`);
-    try {
-      assertLineageCurrent(lineage, orchestrator, signal);
-    } catch {
-      throw err;
-    }
+    assertLineageCurrent(lineage, orchestrator, signal);
     orchestrator.revertConflictResolution(taskId, savedError, msg);
     throw err;
   }
@@ -854,9 +854,12 @@ export async function fixWithAgentAction(
     };
   }
 
+  const entryLineage = captureTaskLineage(taskId, orchestrator);
+  assertLineageCurrent(entryLineage, orchestrator, options.signal);
   const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
   const lineage = captureTaskLineage(taskId, orchestrator);
   try {
+    assertLineageCurrent(lineage, orchestrator, options.signal);
     if (recoveryRoute.kind === 'resolveConflict') {
       await taskExecutor.resolveConflict(taskId, persistedSavedError, options.agentName);
     } else {
@@ -864,7 +867,7 @@ export async function fixWithAgentAction(
       await taskExecutor.fixWithAgent(taskId, output, options.agentName, persistedSavedError);
     }
     assertLineageCurrent(lineage, orchestrator, options.signal);
-    const result = await finalizeAppliedFix(taskId, persistedSavedError, deps, options.signal);
+    const result = await finalizeAppliedFix(taskId, persistedSavedError, deps, options.signal, lineage);
     return {
       kind: recoveryRoute.kind,
       autoApproved: result.autoApproved,
@@ -875,12 +878,9 @@ export async function fixWithAgentAction(
     const msg = err instanceof Error ? err.message : String(err);
     const errorLabel = options.failureOutputLabel
       ?? (recoveryRoute.kind === 'resolveConflict' ? 'Resolve Conflict' : `Fix with ${options.agentName ?? 'Claude'}`);
+    assertLineageCurrent(lineage, orchestrator, options.signal);
     persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
-    try {
-      assertLineageCurrent(lineage, orchestrator, options.signal);
-    } catch {
-      throw err;
-    }
+    assertLineageCurrent(lineage, orchestrator, options.signal);
     orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
     throw err;
   }
@@ -891,17 +891,20 @@ export async function finalizeAppliedFix(
   savedError: string,
   deps: Pick<ActionDeps, 'orchestrator' | 'autoApproveAIFixes'> & { taskExecutor: TaskRunner },
   signal?: AbortSignal,
+  lineage?: TaskLineageSnapshot,
 ): Promise<{ autoApproved: boolean; started: TaskState[] }> {
   if (signal?.aborted) {
     throw new StaleLineageError(
       `Fix mutation for ${taskId} aborted before finalize: ${signal.reason instanceof Error ? signal.reason.message : String(signal.reason ?? 'unknown')}`,
     );
   }
+  if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
   deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
   if (!deps.autoApproveAIFixes) {
     return { autoApproved: false, started: [] };
   }
 
+  if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
   const { started } = await approveTask(taskId, deps);
   return { autoApproved: true, started };
 }
@@ -1026,8 +1029,14 @@ async function recordFixedIntegrationAnchor(
   deps: {
     persistence: SQLiteAdapter;
     taskExecutor: TaskRunner;
+    orchestrator?: Pick<Orchestrator, 'getTask'>;
+    lineage?: TaskLineageSnapshot;
+    signal?: AbortSignal;
   },
 ): Promise<void> {
+  if (deps.lineage && deps.orchestrator) {
+    assertLineageCurrent(deps.lineage, deps.orchestrator, deps.signal);
+  }
   const workspacePath = task.execution.workspacePath?.trim();
   if (!workspacePath) {
     deps.persistence.logEvent?.(taskId, 'debug.auto-fix', {
@@ -1038,6 +1047,9 @@ async function recordFixedIntegrationAnchor(
   }
   try {
     const fixedIntegrationSha = (await deps.taskExecutor.execGitIn(['rev-parse', 'HEAD'], workspacePath)).trim();
+    if (deps.lineage && deps.orchestrator) {
+      assertLineageCurrent(deps.lineage, deps.orchestrator, deps.signal);
+    }
     const fixedIntegrationRecordedAt = new Date();
     deps.persistence.updateTask(taskId, {
       execution: {
@@ -1052,6 +1064,7 @@ async function recordFixedIntegrationAnchor(
       workspacePath,
     });
   } catch (err) {
+    if (err instanceof StaleLineageError) throw err;
     deps.persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-fixed-anchor-failed',
       workspacePath,
@@ -1082,6 +1095,8 @@ export async function autoFixOnFailure(
   const task = orchestrator.getTask(taskId);
   if (!task || task.status !== 'failed') return;
 
+  const entryLineage = captureTaskLineage(taskId, orchestrator);
+  assertLineageCurrent(entryLineage, orchestrator, deps.signal);
   const attempts = (task.execution.autoFixAttempts ?? 0) + 1;
   const max = orchestrator.getAutoFixRetryBudget(taskId);
   const savedError = task.execution.error ?? '';
@@ -1169,6 +1184,7 @@ export async function autoFixOnFailure(
 
     ({ savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId));
     lineage = captureTaskLineage(taskId, orchestrator);
+    assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-begin-conflict-resolution',
       savedErrorLength: persistedSavedError.length,
@@ -1189,12 +1205,16 @@ export async function autoFixOnFailure(
       await recordFixedIntegrationAnchor(taskId, task, {
         persistence,
         taskExecutor,
+        orchestrator,
+        lineage,
+        signal: deps.signal,
       });
+      assertLineageCurrent(lineage, orchestrator, deps.signal);
       const finalizeResult = await finalizeAppliedFix(taskId, persistedSavedError, {
         orchestrator,
         taskExecutor,
         autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
-      }, deps.signal);
+      }, deps.signal, lineage);
       persistence.logEvent?.(taskId, 'debug.auto-fix', {
         phase: 'auto-fix-post-route-finalize',
         autoApproved: finalizeResult.autoApproved,
@@ -1227,6 +1247,7 @@ export async function autoFixOnFailure(
     if (err instanceof StaleLineageError) throw err;
     const msg = err instanceof Error ? err.message : String(err);
     const diagnostics = formatAutoFixDiagnostics(err);
+    if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-route-failed',
       errorType: err instanceof Error ? err.name : typeof err,
@@ -1243,13 +1264,7 @@ export async function autoFixOnFailure(
     persistence.appendTaskOutput(taskId, `\n[Auto-fix] Agent failed (attempt ${attempts}/${max}): ${msg}`);
     const detailedMsg = diagnostics ? `${msg}\n\n${diagnostics}` : msg;
     if (persistedSavedError !== undefined) {
-      if (lineage) {
-        try {
-          assertLineageCurrent(lineage, orchestrator, deps.signal);
-        } catch {
-          throw err;
-        }
-      }
+      if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
       orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg);
     }
   }
@@ -1335,6 +1350,11 @@ export async function autoFixOnReviewGateFailure(
   if (attempts > max) return;
 
   assertReviewGateTriggerCurrent(trigger, orchestrator);
+  if (deps.signal?.aborted) {
+    throw new StaleLineageError(
+      `Review-gate CI auto-fix for ${trigger.taskId} aborted: ${deps.signal.reason instanceof Error ? deps.signal.reason.message : String(deps.signal.reason ?? 'unknown')}`,
+    );
+  }
   persistence.updateTask(trigger.taskId, { execution: { autoFixAttempts: attempts } });
   const savedError = formatReviewGateCiSavedError(trigger);
   const fixContext = formatReviewGateCiFixContext(trigger);
@@ -1343,8 +1363,16 @@ export async function autoFixOnReviewGateFailure(
   let persistedSavedError: string | undefined;
   let lineage: TaskLineageSnapshot | undefined;
   try {
-    ({ savedError: persistedSavedError } = orchestrator.beginAutoFixSession(trigger.taskId, { savedError }));
+    ({ savedError: persistedSavedError } = orchestrator.beginAutoFixSession(trigger.taskId, {
+      savedError,
+      expectedLineage: {
+        taskId: trigger.taskId,
+        selectedAttemptId: trigger.selectedAttemptId,
+        generation: trigger.generation,
+      },
+    }));
     lineage = captureTaskLineage(trigger.taskId, orchestrator);
+    assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.logEvent?.(trigger.taskId, 'debug.auto-fix', {
       phase: 'review-gate-ci-auto-fix-start',
       reviewId: trigger.reviewId,
@@ -1363,12 +1391,19 @@ export async function autoFixOnReviewGateFailure(
     assertLineageCurrent(lineage, orchestrator, deps.signal);
     const latest = orchestrator.getTask(trigger.taskId);
     if (!latest) throw new StaleLineageError(`Review-gate CI auto-fix task ${trigger.taskId} disappeared`);
-    await recordFixedIntegrationAnchor(trigger.taskId, latest, { persistence, taskExecutor });
+    await recordFixedIntegrationAnchor(trigger.taskId, latest, {
+      persistence,
+      taskExecutor,
+      orchestrator,
+      lineage,
+      signal: deps.signal,
+    });
+    assertLineageCurrent(lineage, orchestrator, deps.signal);
     const finalizeResult = await finalizeAppliedFix(trigger.taskId, persistedSavedError, {
       orchestrator,
       taskExecutor,
       autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
-    }, deps.signal);
+    }, deps.signal, lineage);
     persistence.logEvent?.(trigger.taskId, 'debug.auto-fix', {
       phase: 'review-gate-ci-auto-fix-finalize',
       autoApproved: finalizeResult.autoApproved,
@@ -1377,6 +1412,7 @@ export async function autoFixOnReviewGateFailure(
   } catch (err) {
     if (err instanceof StaleLineageError) throw err;
     const msg = err instanceof Error ? err.message : String(err);
+    if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.appendTaskOutput(
       trigger.taskId,
       `\n[Review Gate Auto-fix] Agent failed (attempt ${attempts}/${max}): ${msg}`,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -749,6 +749,12 @@ export interface OrchestratorConfig {
 
 // ── Orchestrator ────────────────────────────────────────────
 
+export interface TaskLineageExpectation {
+  taskId?: string;
+  selectedAttemptId?: string;
+  generation?: number;
+}
+
 export class Orchestrator {
   private static readonly EXPEDITED_PRIORITY = 100;
 
@@ -1829,10 +1835,15 @@ export class Orchestrator {
     this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', additionalChanges);
   }
 
-  setFixAwaitingApproval(taskId: string, originalError: string): void {
+  setFixAwaitingApproval(
+    taskId: string,
+    originalError: string,
+    expectedLineage?: TaskLineageExpectation,
+  ): void {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    if (!this.taskMatchesLineageExpectation(task, expectedLineage)) return;
     const tid = task.id;
     if (task.status !== 'running' && task.status !== 'fixing_with_ai') {
       throw new Error(`Task ${tid} is not running or fixing with AI (status: ${task.status})`);
@@ -2759,10 +2770,13 @@ export class Orchestrator {
    * Clears terminal failure fields on the row so SQLite does not show stale error/exit/completed.
    * Returns the saved error string so the caller can revert on failure.
    */
-  beginConflictResolution(taskId: string): { savedError: string } {
+  beginConflictResolution(taskId: string, expectedLineage?: TaskLineageExpectation): { savedError: string } {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    if (!this.taskMatchesLineageExpectation(task, expectedLineage)) {
+      throw new Error(`Task ${taskId} lineage is stale for conflict resolution start`);
+    }
     if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
 
     const savedError = task.execution.error ?? '';
@@ -2809,10 +2823,16 @@ export class Orchestrator {
    * gate state. Review-gate CI failures use this path because the merge task
    * may still be review_ready/awaiting_approval while the PR checks are red.
    */
-  beginAutoFixSession(taskId: string, opts: { savedError?: string } = {}): { savedError: string } {
+  beginAutoFixSession(
+    taskId: string,
+    opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
+  ): { savedError: string } {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    if (!this.taskMatchesLineageExpectation(task, opts.expectedLineage)) {
+      throw new Error(`Task ${taskId} lineage is stale for auto-fix start`);
+    }
     if (
       task.status !== 'failed' &&
       task.status !== 'review_ready' &&
@@ -2862,12 +2882,18 @@ export class Orchestrator {
    * Revert a conflict resolution attempt: restore the task to failed
    * with its original error and re-parsed mergeConflict field.
    */
-  revertConflictResolution(taskId: string, savedError: string, fixError?: string): void {
+  revertConflictResolution(
+    taskId: string,
+    savedError: string,
+    fixError?: string,
+    expectedLineage?: TaskLineageExpectation,
+  ): void {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) {
       throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     }
+    if (!this.taskMatchesLineageExpectation(task, expectedLineage)) return;
     const id = task.id;
 
     const normalizedSavedError = stripFixFailureWrapper(savedError);
@@ -3951,6 +3977,14 @@ export class Orchestrator {
     if (t0) return t0;
     const alt = this.bareToScopedIfUnique(taskId);
     return alt ? sm.getTask(alt) : undefined;
+  }
+
+  private taskMatchesLineageExpectation(task: TaskState, expected?: TaskLineageExpectation): boolean {
+    if (!expected) return true;
+    if (expected.taskId !== undefined && expected.taskId !== task.id) return false;
+    if (expected.selectedAttemptId !== task.execution.selectedAttemptId) return false;
+    if (expected.generation !== undefined && expected.generation !== (task.execution.generation ?? 0)) return false;
+    return true;
   }
 
   getTask(taskId: string): TaskState | undefined {


### PR DESCRIPTION
## Summary

Prevents stale fix attempts from mutating a task after the user or workflow has already moved that task to a newer attempt or generation.

The bug this solves is a race in fix-with-agent, conflict-resolution, auto-fix, and review-gate auto-fix flows: an older async agent run can finish after a retry, recreate, cancellation, or newer selected attempt, then write approval state, task output, branch metadata, or conflict-resolution cleanup onto the newer task.

This PR captures task lineage before entering the async fix path, re-checks it before and after async boundaries, and makes finalize/revert/anchor side effects no-op or throw `StaleLineageError` when the result belongs to an obsolete lineage. It also removes inline explanatory comments from the updated workflow-actions test code.

## Architecture

### Before

An async fix result only knew the task id. If task `task-a` was retried or recreated while the agent was still running, the old result could still call finalize or revert against the same task id and corrupt the newer attempt.

```mermaid
sequenceDiagram
    participant User as User / workflow retry
    participant Fix as Old fix attempt<br/>task-a gen 1
    participant Agent as Async agent work
    participant Orc as Orchestrator
    participant New as Current task<br/>task-a gen 2

    Fix->>Orc: beginConflictResolution(task-a)
    Fix->>Agent: run fix work
    User->>Orc: retry / recreate / select newer attempt
    Orc->>New: task-a now points at gen 2
    Agent-->>Fix: old gen 1 result returns late
    Fix->>Orc: setFixAwaitingApproval(task-a)
    Fix->>Orc: or revertConflictResolution(task-a)
    Orc->>New: stale write lands on gen 2
```

### After

Fix flows carry the expected task lineage: task id, selected attempt id, generation, and abort state. Every persistence boundary checks that the current task still matches that lineage before writing. A late result from generation 1 is discarded instead of mutating generation 2.

```mermaid
sequenceDiagram
    participant User as User / workflow retry
    participant Fix as Old fix attempt<br/>task-a gen 1
    participant Agent as Async agent work
    participant Orc as Orchestrator
    participant New as Current task<br/>task-a gen 2

    Fix->>Orc: capture lineage(task-a, attempt x, gen 1)
    Fix->>Orc: beginConflictResolution(expected lineage)
    Fix->>Agent: run fix work
    User->>Orc: retry / recreate / select newer attempt
    Orc->>New: task-a now points at gen 2
    Agent-->>Fix: old gen 1 result returns late
    Fix->>Orc: assertLineageCurrent(expected lineage)
    Orc-->>Fix: StaleLineageError
    Fix-->>New: no output / approval / branch / revert write
```

## Test Plan

- [x] `pnpm run test:all`
- [ ] `pnpm --filter @invoker/app test -- workflow-actions` (blocked in this merge clone: `vitest` not found because `node_modules` is missing)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert -m 1 <merge-sha-for-this-pr>`
- Post-revert steps: None
- Data migration? No
