### PR TITLE
Fix duplicate task launch claims

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -714,7 +714,7 @@ describe('headless delegation enforcement', () => {
 
         await expect(runHeadless(['approve', 'wf-1/task-a'], mockDeps)).resolves.toBeUndefined();
 
-        expect(executeTasksSpy).toHaveBeenCalledTimes(2);
+        expect(executeTasksSpy).toHaveBeenCalledTimes(1);
         expect(mockDeps.orchestrator.getReadyTasks).toHaveBeenCalled();
 
         executeTasksSpy.mockRestore();

--- a/packages/app/src/__tests__/orphan-relaunch.test.ts
+++ b/packages/app/src/__tests__/orphan-relaunch.test.ts
@@ -37,7 +37,6 @@ describe('relaunchOrphansAndStartReady', () => {
     return new Orchestrator({
       persistence,
       messageBus: new InMemoryBus(),
-      taskDispatcher: () => {},
     });
   }
 

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -486,7 +486,7 @@ describe('approveTask', () => {
     expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
-  it('commits approved fixes before completing non-merge approvals', async () => {
+  it('commits approved fixes and returns non-merge launch claims for the caller to dispatch', async () => {
     const started = [makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } })];
     const approvedTask = makeTask({
       id: 'task-a',
@@ -505,18 +505,19 @@ describe('approveTask', () => {
       executeTasks: vi.fn(),
     };
 
-    await approveTask('task-a', {
+    const result = await approveTask('task-a', {
       orchestrator: orchestrator as unknown as Orchestrator,
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
+    expect(result.started).toBe(started);
     expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(approvedTask);
     expect(orchestrator.approve).toHaveBeenCalledWith('task-a');
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
   });
 
-  it('commits then resumes merge-conflict fixed tasks', async () => {
+  it('commits then returns resumed merge-conflict launch claims for the caller to dispatch', async () => {
     const started = [makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } })];
     const approvedTask = makeTask({
       id: 'task-a',
@@ -539,15 +540,16 @@ describe('approveTask', () => {
       executeTasks: vi.fn(),
     };
 
-    await approveTask('task-a', {
+    const result = await approveTask('task-a', {
       orchestrator: orchestrator as unknown as Orchestrator,
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
+    expect(result.started).toBe(started);
     expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(approvedTask);
     expect(orchestrator.resumeTaskAfterFixApproval).toHaveBeenCalledWith('task-a');
     expect(orchestrator.approve).not.toHaveBeenCalled();
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 
@@ -626,7 +628,7 @@ describe('finalizeAppliedFix', () => {
     expect(orchestrator.approve).not.toHaveBeenCalled();
   });
 
-  it('auto-approves and executes runnable tasks when enabled', async () => {
+  it('auto-approves and returns runnable tasks when enabled', async () => {
     const started = [
       makeRunningTask({ id: 'task-a', config: { workflowId: 'wf-1' } }),
     ];
@@ -657,7 +659,7 @@ describe('finalizeAppliedFix', () => {
     expect(taskExecutor.commitApprovedFix).toHaveBeenCalledWith(
       expect.objectContaining({ id: 'task-a' }),
     );
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(taskExecutor.publishAfterFix).not.toHaveBeenCalled();
   });
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -78,7 +78,6 @@ export interface HeadlessDeps {
   invokerConfig: InvokerConfig;
   initServices: () => Promise<void>;
   executionAgentRegistry?: AgentRegistry;
-  setTaskDispatcherExecutor?: (executor: Pick<TaskRunner, 'executeTasks'> | null) => void;
   wireSlackBot: (deps: {
     executor: TaskRunner;
     logFn: (source: string, level: string, message: string) => void;
@@ -210,7 +209,6 @@ export function createHeadlessExecutor(
       ...callbackOverrides,
     },
   });
-  deps.setTaskDispatcherExecutor?.(executor);
   return executor;
 }
 
@@ -1308,12 +1306,25 @@ async function headlessRun(
   if (currentWorkflowId) process.stdout.write(`Workflow ID: ${currentWorkflowId}\n`);
 
   const started = orchestrator.startExecution();
-  void started;
 
   if (noTrack) {
+    if (started.length > 0) {
+      void Promise.resolve()
+        .then(() => taskExecutor.executeTasks(started))
+        .catch((err) => {
+          deps.logger.error(
+            `background no-track run failed for ${currentWorkflowId ?? 'unknown'}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+            { module: 'headless' },
+          );
+        });
+    }
     process.stdout.write('[headless] --no-track enabled: submission accepted; exiting without tracking.\n');
     await api.close().catch(() => {});
     return;
+  }
+
+  if (started.length > 0) {
+    await taskExecutor.executeTasks(started);
   }
 
   if (currentWorkflowId) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -197,20 +197,6 @@ let executorRegistry: ExecutorRegistry;
 let orchestrator: Orchestrator;
 let commandService: CommandService;
 let runtimeServices: RuntimeServices;
-let dispatcherTaskExecutor: Pick<TaskRunner, 'executeTasks'> | null = null;
-
-function setDispatcherTaskExecutor(executor: Pick<TaskRunner, 'executeTasks'> | null): void {
-  dispatcherTaskExecutor = executor;
-}
-
-function dispatchStartedTasks(tasks: TaskState[]): void {
-  if (tasks.length === 0 || !dispatcherTaskExecutor) return;
-  void dispatcherTaskExecutor.executeTasks(tasks).catch((err) => {
-    logger.error(`[dispatcher] executeTasks failed: ${err instanceof Error ? err.stack ?? err.message : String(err)}`, {
-      module: 'dispatch',
-    });
-  });
-}
 let workflowMutationCoordinator: PersistedWorkflowMutationCoordinator | null = null;
 const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 /**
@@ -436,7 +422,6 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     defaultAutoFixRetries: invokerConfig.autoFixRetries,
     executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
     deferRunningUntilLaunch: true,
-    taskDispatcher: dispatchStartedTasks,
   });
   commandService = new CommandService(orchestrator);
 
@@ -587,6 +572,7 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
         orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
         const started = orchestrator.startExecution();
         deps.logFn('trace', 'info', `slackBot: startExecution returned ${started.length} tasks: [${started.map((t: any) => t.id).join(', ')}]`);
+        await deps.executor.executeTasks(started);
         break;
       }
     }
@@ -735,7 +721,6 @@ if (isHeadless) {
         orchestrator, persistence, executorRegistry, messageBus,
         repoRoot, invokerConfig, initServices, wireSlackBot,
         commandService,
-        setTaskDispatcherExecutor: setDispatcherTaskExecutor,
         getUiPerfStats: () => ({
           ts: new Date().toISOString(),
           mainDeltaToUi: 0,
@@ -757,7 +742,6 @@ if (isHeadless) {
 
       const createStandaloneTaskExecutor = (): TaskRunner => {
         const executor = createHeadlessExecutor(headlessDeps);
-        setDispatcherTaskExecutor(executor);
         wireHeadlessApproveHook(headlessDeps, executor);
         return executor;
       };
@@ -766,7 +750,6 @@ if (isHeadless) {
         const { parsePlanFile } = await import('./plan-parser.js');
         const plan = await parsePlanFile(payload.planPath);
         const executor = createStandaloneTaskExecutor();
-        void executor;
         backupPlan(plan, undefined, logger);
         const wfIdsBefore = new Set(orchestrator.getWorkflowIds());
         orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
@@ -775,6 +758,7 @@ if (isHeadless) {
           throw new Error(`Failed to resolve workflow id for delegated plan: ${payload.planPath}`);
         }
         const started = orchestrator.startExecution();
+        await executor.executeTasks(started);
         logger.info(`standalone started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
         const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
         return { workflowId, tasks };
@@ -782,9 +766,10 @@ if (isHeadless) {
 
       const executeStandaloneHeadlessResume = async (payload: HeadlessResumeMutationPayload): Promise<unknown> => {
         const { workflowId } = payload;
-        createStandaloneTaskExecutor();
+        const executor = createStandaloneTaskExecutor();
         orchestrator.syncFromDb(workflowId);
         const started = relaunchOrphansAndStartReady(orchestrator, logger, 'standalone-ipc-delegate', workflowId);
+        await executor.executeTasks(started);
         logger.info(`standalone resumed ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
         const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
         return { workflowId, tasks };
@@ -967,6 +952,7 @@ if (isHeadless) {
           orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
           const workflowId = orchestrator.getWorkflowIds().find(id => !wfIdsBefore.has(id))!;
           const started = orchestrator.startExecution();
+          await createStandaloneTaskExecutor().executeTasks(started);
           logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
           const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
           return { workflowId, tasks };
@@ -1138,7 +1124,6 @@ if (isHeadless) {
   const agentRegistry = registerBuiltinAgents();
   let mainWindow: BrowserWindow | null = null;
   let taskExecutor: TaskRunner | null = null;
-  setDispatcherTaskExecutor(null);
   let apiServer: ApiServer | null = null;
   let ownerMode = true;
   const taskHandles = new Map<string, { handle: ExecutorHandle; executor: Executor }>();
@@ -1541,7 +1526,6 @@ if (isHeadless) {
         },
       },
     });
-    setDispatcherTaskExecutor(taskExecutor);
     wireApproveHook();
   }
 
@@ -1669,6 +1653,7 @@ if (isHeadless) {
     orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
     const workflowId = orchestrator.getWorkflowIds().find(id => !wfIdsBefore.has(id))!;
     const started = orchestrator.startExecution();
+    await requireTaskExecutor().executeTasks(started);
     logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
     const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
     return { workflowId, tasks };
@@ -1708,7 +1693,6 @@ if (isHeadless) {
       commandService,
       repoRoot, invokerConfig, initServices, wireSlackBot,
       signal: activeMutationContext?.signal,
-      setTaskDispatcherExecutor: setDispatcherTaskExecutor,
       cancelTask: (taskId: string) => performCancelTask(taskId),
       cancelWorkflow: (workflowId: string) => performCancelWorkflow(workflowId),
       waitForApproval: payload.waitForApproval,
@@ -2407,7 +2391,9 @@ if (isHeadless) {
                         `[launch-stall] dispatching ${runnableAfterFailure.length} task(s) started after failing "${task.id}"`,
                         { module: 'db-poll' },
                       );
-                      dispatchStartedTasks(runnableAfterFailure);
+                      void requireTaskExecutor().executeTasks(runnableAfterFailure).catch((err) => {
+                        logger.error(`[launch-stall] executeTasks failed after failing "${task.id}": ${err instanceof Error ? err.stack ?? err.message : String(err)}`, { module: 'db-poll' });
+                      });
                     }
                     continue;
                   }
@@ -2800,7 +2786,6 @@ if (isHeadless) {
         defaultAutoFixRetries: invokerConfig.autoFixRetries,
         executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
         deferRunningUntilLaunch: true,
-        taskDispatcher: dispatchStartedTasks,
       });
       commandService = new CommandService(orchestrator);
       rebuildTaskRunner();

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -152,12 +152,6 @@ export async function approveTask(
     for (const task of postFixMerge) {
       await deps.taskExecutor.publishAfterFix(task);
     }
-    const runnable = started.filter(
-      (t) => t.status === 'running' && !(t.config.isMergeNode && t.id === taskId),
-    );
-    if (runnable.length > 0) {
-      await deps.taskExecutor.executeTasks(runnable);
-    }
   }
   return { approvedTask: task, started, fixedTask };
 }

--- a/packages/data-store/src/__tests__/attempt-persistence.test.ts
+++ b/packages/data-store/src/__tests__/attempt-persistence.test.ts
@@ -89,6 +89,35 @@ describe('Attempt persistence', () => {
     expect(loaded.commit).toBe('def456');
   });
 
+  it('claimAttemptForLaunch only claims pending or expired attempts', () => {
+    const pending = createAttempt('taskA', { status: 'pending' });
+    adapter.saveAttempt(pending);
+
+    const now = new Date('2026-05-12T00:00:00Z');
+    const leaseExpiresAt = new Date('2026-05-12T00:05:00Z');
+    expect(adapter.claimAttemptForLaunch(pending.id, {
+      status: 'claimed',
+      claimedAt: now,
+      lastHeartbeatAt: now,
+      leaseExpiresAt,
+    }, now)).toBe(true);
+    expect(adapter.loadAttempt(pending.id)?.status).toBe('claimed');
+
+    expect(adapter.claimAttemptForLaunch(pending.id, {
+      status: 'claimed',
+      claimedAt: new Date('2026-05-12T00:01:00Z'),
+      lastHeartbeatAt: new Date('2026-05-12T00:01:00Z'),
+      leaseExpiresAt: new Date('2026-05-12T00:06:00Z'),
+    }, new Date('2026-05-12T00:01:00Z'))).toBe(false);
+
+    expect(adapter.claimAttemptForLaunch(pending.id, {
+      status: 'claimed',
+      claimedAt: new Date('2026-05-12T00:06:00Z'),
+      lastHeartbeatAt: new Date('2026-05-12T00:06:00Z'),
+      leaseExpiresAt: new Date('2026-05-12T00:11:00Z'),
+    }, new Date('2026-05-12T00:06:00Z'))).toBe(true);
+  });
+
   it('merge conflict JSON round-trip', () => {
     const attempt = createAttempt('taskA', {
       mergeConflict: {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1554,6 +1554,47 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.execRun(`UPDATE attempts SET ${setClauses.join(', ')} WHERE id = ?`, values);
   }
 
+  claimAttemptForLaunch(
+    attemptId: string,
+    changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'queuePriority'>>,
+    now: Date,
+  ): boolean {
+    const setClauses: string[] = [];
+    const values: any[] = [];
+
+    if (changes.status !== undefined) { setClauses.push('status = ?'); values.push(changes.status); }
+    if (changes.claimedAt !== undefined) { setClauses.push('claimed_at = ?'); values.push(changes.claimedAt instanceof Date ? changes.claimedAt.toISOString() : changes.claimedAt ?? null); }
+    if (changes.startedAt !== undefined) { setClauses.push('started_at = ?'); values.push(changes.startedAt instanceof Date ? changes.startedAt.toISOString() : changes.startedAt ?? null); }
+    if (changes.lastHeartbeatAt !== undefined) { setClauses.push('last_heartbeat_at = ?'); values.push(changes.lastHeartbeatAt instanceof Date ? changes.lastHeartbeatAt.toISOString() : changes.lastHeartbeatAt ?? null); }
+    if (changes.leaseExpiresAt !== undefined) { setClauses.push('lease_expires_at = ?'); values.push(changes.leaseExpiresAt instanceof Date ? changes.leaseExpiresAt.toISOString() : changes.leaseExpiresAt ?? null); }
+    if (changes.queuePriority !== undefined) { setClauses.push('queue_priority = ?'); values.push(changes.queuePriority); }
+
+    if (setClauses.length === 0) return false;
+    values.push(attemptId, now.toISOString());
+    this.ensureWritable();
+    this.db.run(
+      `UPDATE attempts SET ${setClauses.join(', ')}
+       WHERE id = ?
+         AND (
+           status = 'pending'
+           OR (
+             status IN ('claimed', 'running')
+             AND lease_expires_at IS NOT NULL
+             AND lease_expires_at <= ?
+           )
+         )`,
+      values,
+    );
+    const claimed = this.db.getRowsModified() > 0;
+    if (claimed) {
+      this.dirty = true;
+      if (this.writeTransactionDepth === 0) {
+        this.scheduleFlush();
+      }
+    }
+    return claimed;
+  }
+
   failTaskAndAttempt(
     taskId: string,
     taskChanges: TaskStateChanges,

--- a/packages/data-store/src/sqlite-task-repository.ts
+++ b/packages/data-store/src/sqlite-task-repository.ts
@@ -66,6 +66,10 @@ export class SqliteTaskRepository implements TaskRepository {
     this.adapter.updateAttempt(attemptId, changes);
   }
 
+  claimAttemptForLaunch(attemptId: string, changes: AttemptChanges, now: Date): boolean {
+    return this.adapter.claimAttemptForLaunch(attemptId, changes, now);
+  }
+
   failTaskAndAttempt(
     taskId: string,
     taskChanges: TaskStateChanges,

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -21,9 +21,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
 
   updateWorkflow(workflowId: string, changes: { status?: string }): void {
     const existing = this.workflows.get(workflowId);
-    if (existing && changes.status !== undefined) {
-      existing.status = changes.status;
-    }
+    if (existing && changes.status !== undefined) existing.status = changes.status;
   }
 
   saveTask(workflowId: string, task: TaskState): void {
@@ -70,10 +68,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
     return undefined;
   }
 
-  updateAttempt(
-    attemptId: string,
-    changes: Partial<Pick<Attempt, 'status' | 'claimedAt' | 'startedAt' | 'completedAt' | 'exitCode' | 'error' | 'lastHeartbeatAt' | 'leaseExpiresAt' | 'branch' | 'commit' | 'summary' | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>,
-  ): void {
+  updateAttempt(attemptId: string, changes: Partial<Attempt>): void {
     for (const attempts of this.attempts.values()) {
       const idx = attempts.findIndex((attempt) => attempt.id === attemptId);
       if (idx >= 0) {
@@ -108,15 +103,11 @@ function makeResponse(
   };
 }
 
-function makeOrchestrator(taskDispatcher?: (tasks: TaskState[]) => void): {
-  orchestrator: Orchestrator;
-  persistence: InMemoryPersistence;
-} {
+function makeOrchestrator(): { orchestrator: Orchestrator; persistence: InMemoryPersistence } {
   const persistence = new InMemoryPersistence();
   const orchestrator = new Orchestrator({
     persistence,
     messageBus: new InMemoryBus(),
-    taskDispatcher,
     maxConcurrency: 4,
   });
   return { orchestrator, persistence };
@@ -124,9 +115,7 @@ function makeOrchestrator(taskDispatcher?: (tasks: TaskState[]) => void): {
 
 function taskIdBySuffix(orchestrator: Orchestrator, suffix: string): string {
   const task = orchestrator.getAllTasks().find((item) => item.id.endsWith(`/${suffix}`));
-  if (!task) {
-    throw new Error(`Task with suffix "${suffix}" not found`);
-  }
+  if (!task) throw new Error(`Task with suffix "${suffix}" not found`);
   return task.id;
 }
 
@@ -135,17 +124,16 @@ function respondForTask(
   taskId: string,
   status: WorkResponse['status'],
   exitCode = 0,
-): void {
+): TaskState[] {
   const generation = orchestrator.getTask(taskId)?.execution.generation ?? 0;
-  orchestrator.handleWorkerResponse(makeResponse(taskId, status, generation, exitCode));
+  return orchestrator.handleWorkerResponse(makeResponse(taskId, status, generation, exitCode));
 }
 
-describe('Orchestrator taskDispatcher', () => {
-  it('startExecution dispatches each started task exactly once', () => {
-    const dispatched: string[] = [];
-    const { orchestrator } = makeOrchestrator((tasks) => tasks.forEach((task) => dispatched.push(task.id)));
+describe('Orchestrator launch claims', () => {
+  it('startExecution returns each started task exactly once', () => {
+    const { orchestrator } = makeOrchestrator();
     const plan: PlanDefinition = {
-      name: 'dispatcher-start',
+      name: 'claim-start',
       onFinish: 'none',
       tasks: [
         { id: 't1', description: 'first', command: 'echo one' },
@@ -153,22 +141,44 @@ describe('Orchestrator taskDispatcher', () => {
       ],
     };
 
-    const started = orchestrator.startExecution();
-    expect(started).toHaveLength(0);
+    expect(orchestrator.startExecution()).toHaveLength(0);
 
     orchestrator.loadPlan(plan);
-    const startedAfterLoad = orchestrator.startExecution();
+    const started = orchestrator.startExecution();
 
-    expect(startedAfterLoad).toHaveLength(2);
-    expect(dispatched).toHaveLength(2);
-    expect(new Set(dispatched).size).toBe(2);
+    expect(started).toHaveLength(2);
+    expect(new Set(started.map((task) => task.id)).size).toBe(2);
   });
 
-  it('dispatches tasks for restart/retry/recreate entrypoints', () => {
-    const dispatched: string[] = [];
-    const { orchestrator } = makeOrchestrator((tasks) => tasks.forEach((task) => dispatched.push(task.id)));
+  it('does not supersede an active launch claim when scheduling repeats', () => {
+    const { orchestrator, persistence } = makeOrchestrator();
     orchestrator.loadPlan({
-      name: 'dispatcher-retry-paths',
+      name: 'claim-repeat',
+      onFinish: 'none',
+      tasks: [{ id: 't1', description: 'first', command: 'echo one' }],
+    });
+
+    const [started] = orchestrator.startExecution();
+    const attemptId = started!.execution.selectedAttemptId!;
+    const leaseExpiresAt = new Date(Date.now() + 60_000);
+    persistence.updateAttempt(attemptId, {
+      status: 'claimed',
+      claimedAt: new Date(),
+      lastHeartbeatAt: new Date(),
+      leaseExpiresAt,
+    });
+    persistence.updateTask(started!.id, { status: 'pending' });
+    orchestrator.syncAllFromDb();
+
+    expect(orchestrator.startExecution()).toHaveLength(0);
+    expect(persistence.loadAttempt(attemptId)?.status).toBe('claimed');
+    expect(persistence.loadAttempt(attemptId)?.leaseExpiresAt).toEqual(leaseExpiresAt);
+  });
+
+  it('returns launch claims for restart/retry/recreate entrypoints', () => {
+    const { orchestrator } = makeOrchestrator();
+    orchestrator.loadPlan({
+      name: 'claim-retry-paths',
       onFinish: 'none',
       tasks: [{ id: 't1', description: 'one', command: 'exit 1' }],
     });
@@ -179,47 +189,40 @@ describe('Orchestrator taskDispatcher', () => {
     orchestrator.startExecution();
     respondForTask(orchestrator, taskId, 'failed', 1);
 
-    dispatched.length = 0;
-    orchestrator.retryTask(taskId);
-    expect(dispatched).toEqual([taskId]);
+    let started = orchestrator.retryTask(taskId);
+    expect(started.map((task) => task.id)).toEqual([taskId]);
 
     respondForTask(orchestrator, taskId, 'failed', 1);
-    dispatched.length = 0;
-    orchestrator.retryWorkflow(workflowId);
-    expect(dispatched).toEqual([taskId]);
+    started = orchestrator.retryWorkflow(workflowId);
+    expect(started.map((task) => task.id)).toEqual([taskId]);
 
     respondForTask(orchestrator, taskId, 'failed', 1);
-    dispatched.length = 0;
-    orchestrator.recreateTask(taskId);
-    expect(dispatched).toEqual([taskId]);
+    started = orchestrator.recreateTask(taskId);
+    expect(started.map((task) => task.id)).toEqual([taskId]);
 
     respondForTask(orchestrator, taskId, 'failed', 1);
-    dispatched.length = 0;
-    orchestrator.recreateWorkflow(workflowId);
-    expect(dispatched).toEqual([taskId]);
-
+    started = orchestrator.recreateWorkflow(workflowId);
+    expect(started.map((task) => task.id)).toEqual([taskId]);
   });
 
-  it('resumeWorkflow dispatches persisted pending tasks', () => {
-    const dispatched: string[] = [];
-    const { orchestrator } = makeOrchestrator((tasks) => tasks.forEach((task) => dispatched.push(task.id)));
+  it('resumeWorkflow returns persisted pending launch claims', () => {
+    const { orchestrator } = makeOrchestrator();
     orchestrator.loadPlan({
-      name: 'dispatcher-resume',
+      name: 'claim-resume',
       onFinish: 'none',
       tasks: [{ id: 't1', description: 'one', command: 'echo one' }],
     });
     const workflowId = orchestrator.getWorkflowIds()[0]!;
     const taskId = taskIdBySuffix(orchestrator, 't1');
 
-    orchestrator.resumeWorkflow(workflowId);
-    expect(dispatched).toEqual([taskId]);
+    const started = orchestrator.resumeWorkflow(workflowId);
+    expect(started.map((task) => task.id)).toEqual([taskId]);
   });
 
-  it('dispatches downstream tasks from handleWorkerResponse and approval cascades', async () => {
-    const dispatched: string[] = [];
-    const { orchestrator, persistence } = makeOrchestrator((tasks) => tasks.forEach((task) => dispatched.push(task.id)));
+  it('returns downstream launch claims from worker completion and approval cascades', async () => {
+    const { orchestrator, persistence } = makeOrchestrator();
     orchestrator.loadPlan({
-      name: 'dispatcher-cascade',
+      name: 'claim-cascade',
       onFinish: 'none',
       tasks: [
         { id: 'prepare', description: 'prepare', command: 'echo prepare' },
@@ -235,28 +238,12 @@ describe('Orchestrator taskDispatcher', () => {
     const approvalDownstreamId = taskIdBySuffix(orchestrator, 'approval-downstream');
 
     orchestrator.startExecution();
-    dispatched.length = 0;
-    respondForTask(orchestrator, prepareId, 'completed', 0);
-    expect(dispatched).toContain(downstreamId);
+    const startedAfterPrepare = respondForTask(orchestrator, prepareId, 'completed', 0);
+    expect(startedAfterPrepare.map((task) => task.id)).toContain(downstreamId);
 
     persistence.updateTask(approvalRootId, { status: 'awaiting_approval' });
     orchestrator.syncAllFromDb();
-    dispatched.length = 0;
-    await orchestrator.approve(approvalRootId);
-    expect(dispatched).toContain(approvalDownstreamId);
-  });
-
-  it('keeps behavior unchanged when taskDispatcher is not configured', () => {
-    const { orchestrator } = makeOrchestrator();
-    orchestrator.loadPlan({
-      name: 'dispatcher-optional',
-      onFinish: 'none',
-      tasks: [{ id: 't1', description: 'one', command: 'echo one' }],
-    });
-
-    const started = orchestrator.startExecution();
-    expect(started).toHaveLength(1);
-    expect(started[0]?.status).toBe('running');
-    expect(started[0]?.execution.phase).toBe('launching');
+    const startedAfterApprove = await orchestrator.approve(approvalRootId);
+    expect(startedAfterApprove.map((task) => task.id)).toContain(approvalDownstreamId);
   });
 });

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1052,7 +1052,7 @@ export class Orchestrator {
     now: number = Date.now(),
   ): boolean {
     if (attempt && this.isAttemptLeaseActive(attempt, now)) {
-      return task.status === 'running' || task.status === 'fixing_with_ai';
+      return task.status === 'pending' || task.status === 'running' || task.status === 'fixing_with_ai';
     }
 
     return task.status === 'running' || task.status === 'fixing_with_ai';
@@ -4193,7 +4193,6 @@ export class Orchestrator {
             startedAt: undefined,
             completedAt: undefined,
             lastHeartbeatAt: undefined,
-            leaseExpiresAt: undefined,
             launchStartedAt: undefined,
             launchCompletedAt: undefined,
             phase: undefined,
@@ -4284,7 +4283,6 @@ export class Orchestrator {
           startedAt: undefined,
           completedAt: undefined,
           lastHeartbeatAt: undefined,
-          leaseExpiresAt: undefined,
           launchStartedAt: undefined,
           launchCompletedAt: undefined,
           phase: undefined,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -587,8 +587,6 @@ export interface OrchestratorConfig {
   logger?: Logger;
   /** Optional; defaults to an adapter wrapping `persistence`. */
   taskRepository?: TaskRepository;
-  /** Optional callback for fire-and-forget task dispatch when tasks enter running/launching. */
-  taskDispatcher?: (tasks: TaskState[]) => void;
   maxConcurrency?: number;
   /** Default auto-fix retry budget for older tasks missing persisted per-task config. */
   defaultAutoFixRetries?: number;
@@ -624,7 +622,6 @@ export class Orchestrator {
   private readonly messageBus: OrchestratorMessageBus;
   private readonly logger: Logger;
   private readonly taskRepository: TaskRepository;
-  private readonly taskDispatcher?: (tasks: TaskState[]) => void;
   private readonly maxConcurrency: number;
   private readonly executorRoutingRules: ExecutorRoutingRule[];
   private readonly heavyweightCommandRouting?: HeavyweightCommandRoutingPolicy;
@@ -688,7 +685,6 @@ export class Orchestrator {
     this.messageBus = config.messageBus;
     this.logger = config.logger ?? noopLogger;
     this.taskRepository = config.taskRepository ?? taskRepositoryFromPersistence(config.persistence);
-    this.taskDispatcher = config.taskDispatcher;
     this.executorRoutingRules = config.executorRoutingRules ?? [];
     this.heavyweightCommandRouting = config.heavyweightCommandRouting;
     this.availableRemoteTargetIds = new Set(config.availableRemoteTargetIds ?? []);
@@ -899,7 +895,11 @@ export class Orchestrator {
           workflowsToSync.add(current.config.workflowId);
         }
 
-        const shouldReset = forceResetIds.has(id) || current.status !== 'pending';
+        const selectedAttempt = this.getSelectedAttempt(current);
+        const shouldReset =
+          forceResetIds.has(id)
+          || current.status !== 'pending'
+          || this.isAttemptLeaseActive(selectedAttempt);
         this.deferredTaskIds.delete(id);
         if (!shouldReset) {
           this.clearQueuedSchedulerEntries(id, current.execution.selectedAttemptId);
@@ -1052,7 +1052,7 @@ export class Orchestrator {
     now: number = Date.now(),
   ): boolean {
     if (attempt && this.isAttemptLeaseActive(attempt, now)) {
-      return task.status === 'running' || task.status === 'fixing_with_ai';
+      return task.status === 'pending' || task.status === 'running' || task.status === 'fixing_with_ai';
     }
 
     return task.status === 'running' || task.status === 'fixing_with_ai';
@@ -4205,12 +4205,7 @@ export class Orchestrator {
       this.taskRepository.updateAttempt(attemptId, { queuePriority: priority });
     }
     if (task.execution.selectedAttemptId === attemptId && this.isAttemptLeaseActive(currentAttempt)) {
-      if (this.isTaskExecutionActive(task, currentAttempt)) {
-        return;
-      }
-      try {
-        this.taskRepository.updateAttempt(attemptId, { status: 'superseded' });
-      } catch { /* best effort */ }
+      return;
     }
     const queuedJob = this.scheduler
       .getQueuedJobs()
@@ -4476,24 +4471,63 @@ export class Orchestrator {
 
       const now = new Date();
       const attemptId = job.attemptId ?? this.ensureCurrentPendingAttempt(task);
+      let launchAttemptId = attemptId;
       if (task.execution.selectedAttemptId !== attemptId) {
         this.writeAndSync(job.taskId, { execution: { selectedAttemptId: attemptId } });
       }
+      let claimSucceeded = false;
       const currentAttempt = this.loadAttemptById(attemptId);
-      if (this.isAttemptLeaseActive(currentAttempt, now.getTime())) {
-        if (this.isTaskExecutionActive(task, currentAttempt, now.getTime())) {
-          job = availableSlots > 0 ? this.scheduler.takeNext() : null;
-          continue;
+      const claimPatch = this.deferRunningUntilLaunch
+        ? {
+            status: 'claimed' as const,
+            claimedAt: now,
+            lastHeartbeatAt: now,
+            leaseExpiresAt: nextLeaseExpiry(now),
+          }
+        : {
+            status: 'running' as const,
+            claimedAt: currentAttempt?.claimedAt ?? now,
+            startedAt: now,
+            lastHeartbeatAt: now,
+            leaseExpiresAt: nextLeaseExpiry(now),
+          };
+      if (!currentAttempt) {
+        const upstreamAttemptIds = task.dependencies
+          .map(depId => this.stateGetTask(depId)?.execution.selectedAttemptId)
+          .filter((id): id is string => !!id);
+        const attempt = createAttempt(job.taskId, {
+          status: 'pending',
+          upstreamAttemptIds,
+        });
+        this.taskRepository.saveAttempt(attempt);
+        if (task.execution.selectedAttemptId !== attempt.id) {
+          this.writeAndSync(job.taskId, { execution: { selectedAttemptId: attempt.id } });
         }
-        try {
-          this.taskRepository.updateAttempt(attemptId, { status: 'superseded' });
-        } catch { /* best effort */ }
+        launchAttemptId = attempt.id;
+        claimSucceeded = this.taskRepository.claimAttemptForLaunch?.(attempt.id, claimPatch, now) ?? true;
+        if (claimSucceeded && !this.taskRepository.claimAttemptForLaunch) {
+          this.taskRepository.updateAttempt(attempt.id, claimPatch);
+        }
+      } else {
+        claimSucceeded = this.taskRepository.claimAttemptForLaunch?.(attemptId, claimPatch, now)
+          ?? !this.isAttemptLeaseActive(currentAttempt, now.getTime());
+        if (claimSucceeded && !this.taskRepository.claimAttemptForLaunch) {
+          this.taskRepository.updateAttempt(attemptId, claimPatch);
+        }
+      }
+      if (!claimSucceeded) {
+        this.logger.info('[orchestrator] drainScheduler: skipping already-claimed attempt', {
+          taskId: job.taskId,
+          attemptId,
+        });
+        job = availableSlots > 0 ? this.scheduler.takeNext() : null;
+        continue;
       }
 
       const changes: TaskStateChanges = {
         status: 'running',
         execution: {
-          selectedAttemptId: attemptId,
+          selectedAttemptId: launchAttemptId,
           generation: this.getExecutionGeneration(task),
           startedAt: now,
           lastHeartbeatAt: now,
@@ -4508,62 +4542,13 @@ export class Orchestrator {
       started.push(updated);
       this.logger.info('[orchestrator] drainScheduler: started', {
         taskId: job.taskId,
-        attemptId,
+        attemptId: launchAttemptId,
         phase: 'launching',
         generation: changes.execution?.generation ?? 'unknown',
       });
 
-      try {
-        const existingAttempt = this.persistence.loadAttempt(attemptId);
-        if (existingAttempt) {
-          this.taskRepository.updateAttempt(attemptId, this.deferRunningUntilLaunch
-            ? {
-                status: 'claimed',
-                claimedAt: now,
-                lastHeartbeatAt: now,
-                leaseExpiresAt: nextLeaseExpiry(now),
-              }
-            : {
-                status: 'running',
-                claimedAt: existingAttempt.claimedAt ?? now,
-                startedAt: now,
-                lastHeartbeatAt: now,
-                leaseExpiresAt: nextLeaseExpiry(now),
-              });
-        } else {
-          const upstreamAttemptIds = task.dependencies
-            .map(depId => this.stateGetTask(depId)?.execution.selectedAttemptId)
-            .filter((id): id is string => !!id);
-          const attempt = createAttempt(job.taskId, this.deferRunningUntilLaunch
-            ? {
-                status: 'claimed',
-                claimedAt: now,
-                lastHeartbeatAt: now,
-                leaseExpiresAt: nextLeaseExpiry(now),
-                upstreamAttemptIds,
-              }
-            : {
-                status: 'running',
-                claimedAt: now,
-                startedAt: now,
-                lastHeartbeatAt: now,
-                leaseExpiresAt: nextLeaseExpiry(now),
-                upstreamAttemptIds,
-              });
-          this.taskRepository.saveAttempt(attempt);
-          this.writeAndSync(job.taskId, { execution: { selectedAttemptId: attempt.id } });
-        }
-      } catch { /* best effort — never break existing flow */ }
-
       availableSlots -= 1;
       job = availableSlots > 0 ? this.scheduler.takeNext() : null;
-    }
-    if (started.length > 0) {
-      try {
-        this.taskDispatcher?.(started);
-      } catch (err) {
-        this.logger.error('[orchestrator] taskDispatcher threw', { err });
-      }
     }
     return started;
   }

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1052,7 +1052,7 @@ export class Orchestrator {
     now: number = Date.now(),
   ): boolean {
     if (attempt && this.isAttemptLeaseActive(attempt, now)) {
-      return task.status === 'pending' || task.status === 'running' || task.status === 'fixing_with_ai';
+      return task.status === 'running' || task.status === 'fixing_with_ai';
     }
 
     return task.status === 'running' || task.status === 'fixing_with_ai';
@@ -4177,7 +4177,7 @@ export class Orchestrator {
 
   private autoStartReadyTasks(taskIds: string[], priority: number = 0): TaskState[] {
     for (const taskId of taskIds) {
-      const task = this.stateGetTask(taskId);
+      let task = this.stateGetTask(taskId);
       if (!task) continue;
       if (this.getExternalDependencyBlocker(task) !== undefined) continue;
 
@@ -4186,7 +4186,21 @@ export class Orchestrator {
         this.logger.info('[orchestrator] autoStartReadyTasks: unblocking blocked task', {
           taskId,
         });
-        this.writeAndSync(taskId, { status: 'pending' });
+        this.replaceSelectedAttempt(task, { status: 'pending' });
+        this.writeAndSync(taskId, {
+          status: 'pending',
+          execution: {
+            startedAt: undefined,
+            completedAt: undefined,
+            lastHeartbeatAt: undefined,
+            leaseExpiresAt: undefined,
+            launchStartedAt: undefined,
+            launchCompletedAt: undefined,
+            phase: undefined,
+          },
+        });
+        task = this.stateGetTask(taskId);
+        if (!task) continue;
       }
 
       this.enqueueIfNotScheduled(taskId, priority);
@@ -4204,7 +4218,14 @@ export class Orchestrator {
     if ((currentAttempt?.queuePriority ?? 0) !== priority) {
       this.taskRepository.updateAttempt(attemptId, { queuePriority: priority });
     }
-    if (task.execution.selectedAttemptId === attemptId && this.isAttemptLeaseActive(currentAttempt)) {
+    // A task can be force-set back to blocked/pending by recovery logic while
+    // still carrying a stale selectedAttemptId from an older run. Only skip
+    // re-enqueue when the task is actually active.
+    if (
+      (task.status === 'running' || task.status === 'fixing_with_ai') &&
+      task.execution.selectedAttemptId === attemptId &&
+      this.isAttemptLeaseActive(currentAttempt)
+    ) {
       return;
     }
     const queuedJob = this.scheduler
@@ -4256,7 +4277,19 @@ export class Orchestrator {
       if (!this.areLocalDependenciesSatisfied(task)) continue;
       if (this.getExternalDependencyBlocker(task) !== undefined) continue;
 
-      this.writeAndSync(task.id, { status: 'pending' });
+      this.replaceSelectedAttempt(task, { status: 'pending' });
+      this.writeAndSync(task.id, {
+        status: 'pending',
+        execution: {
+          startedAt: undefined,
+          completedAt: undefined,
+          lastHeartbeatAt: undefined,
+          leaseExpiresAt: undefined,
+          launchStartedAt: undefined,
+          launchCompletedAt: undefined,
+          phase: undefined,
+        },
+      });
       this.enqueueIfNotScheduled(task.id);
     }
     return this.drainScheduler();

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -106,6 +106,12 @@ export interface TaskRepository {
   updateAttempt(attemptId: string, changes: AttemptChanges): void;
 
   /**
+   * Atomically claim an attempt for launch. Returns false when another
+   * dispatcher already owns an active claim for the same attempt.
+   */
+  claimAttemptForLaunch?(attemptId: string, changes: AttemptChanges, now: Date): boolean;
+
+  /**
    * Atomically fail a task and its latest attempt in a single
    * transaction. Implementations that lack transactional support may
    * fall back to sequential `updateTask` + `updateAttempt` calls.

--- a/scripts/test-docker-comprehensive.sh
+++ b/scripts/test-docker-comprehensive.sh
@@ -202,11 +202,51 @@ task_container_id() {
   sqlite3 "$DB_PATH" "SELECT container_id FROM tasks WHERE id = '$1' OR id LIKE '%/' || '$1' ORDER BY id DESC LIMIT 1;" 2>/dev/null || echo ""
 }
 
+wait_for_task_terminal() {
+  local task_id="$1"
+  local timeout_secs="${2:-300}"
+  local start_ts now elapsed status
+  start_ts=$(date +%s)
+
+  while true; do
+    status=$(task_status "$task_id")
+    case "$status" in
+      completed|failed|needs_input|awaiting_approval|review_ready|blocked|stale|cancelled)
+        return 0
+        ;;
+    esac
+
+    now=$(date +%s)
+    elapsed=$((now - start_ts))
+    if [ "$elapsed" -ge "$timeout_secs" ]; then
+      fail "$task_id did not reach terminal status within ${timeout_secs}s (last status=$status)"
+      return 1
+    fi
+    sleep 1
+  done
+}
+
 # ── Step 4: Validate each task ──────────────────────────────
 
 echo -e "${BOLD}========================================${NC}"
 echo -e "${BOLD}  Task Results${NC}"
 echo -e "${BOLD}========================================${NC}"
+
+echo ""
+echo "==> Waiting for all docker test tasks to settle"
+ALL_TASKS=(
+  docker-no-image
+  docker-cmd-exit-1
+  docker-cmd-crash
+  docker-cmd-ok
+  docker-cmd-output
+  docker-concurrent-a
+  docker-concurrent-b
+  docker-concurrent-c
+)
+for TASK_ID in "${ALL_TASKS[@]}"; do
+  wait_for_task_terminal "$TASK_ID"
+done
 
 # --- docker-no-image: should fail with "No such image" ---
 echo ""


### PR DESCRIPTION
## Summary

Fix duplicate task launch by making scheduler startup a durable claim instead of a callback side effect.

- Remove the orchestrator `taskDispatcher` callback path so `drainScheduler()` only returns launch claims.
- Add `TaskRepository.claimAttemptForLaunch()` and SQLite-backed conditional attempt claiming.
- Treat pending tasks with active claimed attempts as active launch work, so repeated scheduler drains do not recreate the same worktree branch.
- Move dispatch responsibility to the app/headless/global-topup bridge and keep approve actions returning launch claims for their caller to dispatch.

## Architecture

### Before

```mermaid
graph TD
    A[Mutation or start path] --> B[drainScheduler]
    B --> C[Mark task launching]
    B --> D[taskDispatcher callback]
    A --> E[Caller dispatches returned started tasks]
    D --> F[TaskRunner.executeTasks]
    E --> F
    F --> G[git worktree add -B]
```

### After

```mermaid
graph TD
    A[Mutation or start path] --> B[drainScheduler]
    B --> C{claimAttemptForLaunch}
    C -->|won pending or expired claim| D[Mark task launching]
    C -->|active claim exists| E[Skip launch]
    D --> F[Return launch claim]
    F --> G[App or global-topup bridge]
    G --> H[TaskRunner.executeTasks]
    H --> I[git worktree add -B]
```

## Test Plan

- [x] `PATH=/opt/homebrew/opt/node@22/bin:/opt/homebrew/Cellar/node@22/22.22.2_2/lib/node_modules/corepack/shims:$PATH pnpm exec tsc -p tsconfig.typecheck.json --noEmit`
- [x] `PATH=/opt/homebrew/opt/node@22/bin:/opt/homebrew/Cellar/node@22/22.22.2_2/lib/node_modules/corepack/shims:$PATH pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts src/__tests__/global-topup.test.ts src/__tests__/orphan-relaunch.test.ts src/__tests__/app-layer-handoff-repro.test.ts`
- [x] `PATH=/opt/homebrew/opt/node@22/bin:/opt/homebrew/Cellar/node@22/22.22.2_2/lib/node_modules/corepack/shims:$PATH pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator-dispatcher.test.ts`
- [x] `PATH=/opt/homebrew/opt/node@22/bin:/opt/homebrew/Cellar/node@22/22.22.2_2/lib/node_modules/corepack/shims:$PATH pnpm --filter @invoker/data-store exec vitest run src/__tests__/attempt-persistence.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert ec64781`
- Post-revert steps: Re-run focused scheduler/app dispatch tests.
- Data migration? No
