### PR TITLE
Run comprehensive CI suites on schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [master, main]
   pull_request:
+  schedule:
+    - cron: '17 9 * * *'
   workflow_dispatch:
 
 concurrency:
@@ -108,8 +110,6 @@ jobs:
             command: bash scripts/test-suites/required/10-vitest-workspace.sh
           - name: Submit Workflow Chain
             command: bash scripts/test-suites/required/15-submit-workflow-chain.sh
-          - name: Fix Intent Repros
-            command: bash scripts/test-suites/required/23-fix-intent-repros.sh
 
     name: required-fast / ${{ matrix.name }}
 
@@ -154,6 +154,55 @@ jobs:
 
       - name: Run suite group
         run: ${{ matrix.command }}
+
+  scheduled-repros:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: build-artifacts
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    name: scheduled / Fix Intent Repros
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: app-build-dist
+          path: /tmp/invoker-build-artifacts
+
+      - name: Extract build artifacts
+        run: tar -xzf /tmp/invoker-build-artifacts/app-build-dist.tgz -C .
+
+      - name: Configure git identity and HTTPS auth
+        run: |
+          git config --global user.name "CI Bot"
+          git config --global user.email "ci@invoker.dev"
+          git config --global url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "git@github.com:"
+          git config --global --add url."https://x-access-token:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+          git update-ref refs/heads/main refs/remotes/origin/master || true
+          git update-ref refs/remotes/origin/main refs/remotes/origin/master || true
+
+      - name: Install Playwright system dependencies
+        run: pnpm --filter @invoker/app exec playwright install --with-deps
+
+      - name: Run fix-intent repro bundle
+        run: bash scripts/test-suites/required/23-fix-intent-repros.sh
 
   dry-run:
     needs: build-artifacts
@@ -399,6 +448,7 @@ jobs:
         run: ${{ matrix.command }}
 
   docker:
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: build-artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -448,7 +448,6 @@ jobs:
         run: ${{ matrix.command }}
 
   docker:
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: build-artifacts
     runs-on: ubuntu-latest
     timeout-minutes: 60

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -27,7 +27,6 @@ queue_rules:
       - check-success = ssh / shard-31
       - check-success = optional / Worktree Provisioning
       - check-success = optional / Visual Proof Validate
-      - check-success = docker / comprehensive
 
   - name: admin-bypass
     merge_method: squash
@@ -52,7 +51,6 @@ queue_rules:
       - check-success = ssh / shard-31
       - check-success = optional / Worktree Provisioning
       - check-success = optional / Visual Proof Validate
-      - check-success = docker / comprehensive
 
 pull_request_rules:
   - name: autoqueue approved PRs to master

--- a/packages/execution-engine/src/__tests__/docker-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/docker-executor.test.ts
@@ -240,6 +240,51 @@ describe('DockerExecutor', () => {
     expect(handle.branch).toMatch(/^experiment\/action-1\/g\d+\.t\d+\.a[a-z0-9_-]*-[0-9a-f]{8}$/);
   });
 
+  it('keeps docker exec routing scoped per overlapping async task', async () => {
+    const execRemoteCaptureMock = (executor as any).execRemoteCapture as ReturnType<typeof vi.fn>;
+    const routedCalls: Array<{ containerId: string; script: string }> = [];
+
+    execRemoteCaptureMock.mockImplementation(async (containerId: string, script: string) => {
+      routedCalls.push({ containerId, script });
+      await new Promise((resolve) => setTimeout(resolve, 1));
+      return '';
+    });
+
+    const runScopedGitAndShell = async (
+      containerId: string,
+      marker: string,
+      delayMs: number,
+    ) => (executor as any).containerContext.run(containerId, async () => {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      await (executor as any).execGitSimple(['status', '--short'], '/app');
+      await (executor as any).runBash(`echo ${marker}`, '/app');
+    });
+
+    await Promise.all([
+      runScopedGitAndShell('container-a', 'from-a', 10),
+      runScopedGitAndShell('container-b', 'from-b', 0),
+    ]);
+
+    expect(routedCalls).toEqual([
+      expect.objectContaining({
+        containerId: 'container-b',
+        script: expect.stringContaining('git \'status\' \'--short\''),
+      }),
+      expect.objectContaining({
+        containerId: 'container-b',
+        script: 'echo from-b',
+      }),
+      expect.objectContaining({
+        containerId: 'container-a',
+        script: expect.stringContaining('git \'status\' \'--short\''),
+      }),
+      expect.objectContaining({
+        containerId: 'container-a',
+        script: 'echo from-a',
+      }),
+    ]);
+  });
+
   // -------------------------------------------------------------------------
   // Task execution via docker exec CLI
   // -------------------------------------------------------------------------

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -183,6 +183,64 @@ describe('TaskRunner', () => {
     );
   });
 
+  it('dispatches newly ready tasks after executor startup failure', async () => {
+    const failedTask = makeTask({
+      id: 'docker-no-image',
+      status: 'running',
+      config: { command: 'echo never', executorType: 'docker' },
+      execution: { selectedAttemptId: 'docker-no-image-a1' },
+    });
+    const newlyReady = makeTask({
+      id: 'docker-concurrent-b',
+      status: 'running',
+      config: { command: 'sleep 2 && echo done', executorType: 'docker' },
+      execution: { selectedAttemptId: 'docker-concurrent-b-a1' },
+    });
+
+    const handleWorkerResponse = vi.fn(() => [newlyReady]);
+    const failingExecutor = {
+      type: 'docker',
+      start: vi.fn(async () => {
+        throw new Error('No such image: invoker-nonexistent-image:v999');
+      }),
+      onComplete: vi.fn(),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+
+    const runner = new TaskRunner({
+      orchestrator: {
+        getTask: (id: string) => id === failedTask.id ? failedTask : newlyReady,
+        handleWorkerResponse,
+      } as any,
+      persistence: {
+        updateTask: vi.fn(),
+        updateAttempt: vi.fn(),
+        appendTaskOutput: vi.fn(),
+      } as any,
+      executorRegistry: {
+        getDefault: () => failingExecutor,
+        get: () => failingExecutor,
+        getAll: () => [failingExecutor],
+        deregister: vi.fn(),
+      } as any,
+      cwd: '/tmp',
+    });
+    const executeTasksSpy = vi.spyOn(runner, 'executeTasks').mockResolvedValue(undefined);
+
+    await runner.executeTask(failedTask);
+
+    expect(handleWorkerResponse).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actionId: 'docker-no-image',
+        status: 'failed',
+      }),
+    );
+    expect(executeTasksSpy).toHaveBeenCalledWith([newlyReady]);
+  });
+
   it('deduplicates concurrent launches for the same attempt', async () => {
     let completeCallback: ((response: WorkResponse) => void) | undefined;
     const start = vi.fn().mockImplementation(async (request: any) => ({

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
@@ -111,8 +112,16 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
   /** Lazily-resolved dockerode instance. Null until first use. */
   private dockerInstance: any | null = null;
 
-  /** Container ID for the current task (set after container.start()). */
-  private activeContainerId: string | null = null;
+  /**
+   * Container ID bound to the current async task lifecycle.
+   *
+   * DockerExecutor can run multiple tasks concurrently. A single mutable
+   * "active container" field makes BaseExecutor git/finalization helpers race:
+   * task A can start git work, task B overwrites the field, then task A's next
+   * git command runs in task B's container. AsyncLocalStorage keeps each
+   * overlapping start/finalize path pinned to its own container.
+   */
+  private readonly containerContext = new AsyncLocalStorage<string>();
 
   constructor(config: DockerExecutorConfig) {
     super();
@@ -136,25 +145,26 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
     cwd: string,
     opts?: { signal?: AbortSignal },
   ): Promise<string> {
-    if (!this.activeContainerId) return super.execGitSimple(args, cwd, opts);
+    const containerId = this.containerContext.getStore();
+    if (!containerId) return super.execGitSimple(args, cwd, opts);
     const escapedArgs = args.map(a => shellEscape(a)).join(' ');
     const script = `cd ${shellEscape(cwd)} && git ${escapedArgs}`;
-    return this.execRemoteCapture(script, opts);
+    return this.execRemoteCapture(containerId, script, opts);
   }
 
   protected override runBash(script: string, _cwd: string): Promise<string> {
-    return this.execRemoteCapture(script);
+    const containerId = this.containerContext.getStore();
+    if (!containerId) {
+      return Promise.reject(new Error('runBash called with no active Docker container context'));
+    }
+    return this.execRemoteCapture(containerId, script);
   }
 
   /**
    * Run a bash script inside the active container via CLI. Inherits the
    * image's declared user.
    */
-  private execRemoteCapture(script: string, opts?: { signal?: AbortSignal }): Promise<string> {
-    const containerId = this.activeContainerId;
-    if (!containerId) {
-      return Promise.reject(new Error('execRemoteCapture called with no active container'));
-    }
+  private execRemoteCapture(containerId: string, script: string, opts?: { signal?: AbortSignal }): Promise<string> {
     return new Promise((resolve, reject) => {
       const child = spawn('docker', [
         'exec', '-i', containerId, 'bash', '-s',
@@ -351,114 +361,115 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
       emit(`${TAG} Container failed to start: ${errMsg}`);
       throw new Error(`Docker container failed to start: ${errMsg}`);
     }
-    this.activeContainerId = container.id;
     emit(`${TAG} Container started`);
 
-    // -- Git setup (reuses BaseExecutor methods via overridden execGitSimple + runBash) --
-    await this.syncFromRemote(CONTAINER_CWD, executionId);
+    return await this.containerContext.run(container.id, async () => {
+      // -- Git setup (reuses BaseExecutor methods via overridden execGitSimple + runBash) --
+      await this.syncFromRemote(CONTAINER_CWD, executionId);
 
-    const baseRef = request.inputs.baseBranch ?? 'HEAD';
-    const baseHead = (await this.execGitSimple(['rev-parse', baseRef], CONTAINER_CWD)).trim();
-    const upstreamCommits = (request.inputs.upstreamContext ?? [])
-      .map(c => c.commitHash)
-      .filter((h): h is string => !!h);
-    const contentHash = computeContentHash(
-      request.actionId,
-      request.inputs.command,
-      request.inputs.prompt,
-      upstreamCommits,
-      baseHead,
-    );
-    const branchName = buildExperimentBranchName(
-      request.actionId,
-      request.inputs.lifecycleTag ?? '',
-      contentHash,
-    );
-    // Persist the branch on the attempt row before any branch-creating git
-    // operation runs. If the container or git step crashes mid-startup, the
-    // attempt still records which branch it was about to use so leftover
-    // state can be reconciled.
-    try {
-      request.onBranchResolved?.(branchName);
-    } catch {
-      // Best-effort early persistence; the post-start path persists the
-      // same value again.
-    }
-    const baseBranch = request.inputs.upstreamBranches?.[0]
-      ?? request.inputs.baseBranch
-      ?? 'HEAD';
+      const baseRef = request.inputs.baseBranch ?? 'HEAD';
+      const baseHead = (await this.execGitSimple(['rev-parse', baseRef], CONTAINER_CWD)).trim();
+      const upstreamCommits = (request.inputs.upstreamContext ?? [])
+        .map(c => c.commitHash)
+        .filter((h): h is string => !!h);
+      const contentHash = computeContentHash(
+        request.actionId,
+        request.inputs.command,
+        request.inputs.prompt,
+        upstreamCommits,
+        baseHead,
+      );
+      const branchName = buildExperimentBranchName(
+        request.actionId,
+        request.inputs.lifecycleTag ?? '',
+        contentHash,
+      );
+      // Persist the branch on the attempt row before any branch-creating git
+      // operation runs. If the container or git step crashes mid-startup, the
+      // attempt still records which branch it was about to use so leftover
+      // state can be reconciled.
+      try {
+        request.onBranchResolved?.(branchName);
+      } catch {
+        // Best-effort early persistence; the post-start path persists the
+        // same value again.
+      }
+      const baseBranch = request.inputs.upstreamBranches?.[0]
+        ?? request.inputs.baseBranch
+        ?? 'HEAD';
 
-    await this.setupTaskBranch(CONTAINER_CWD, request, handle, {
-      branchName,
-      base: baseBranch,
-    });
-    entry.branch = handle.branch;
-
-    // -- No-command tasks: complete immediately after branch setup --
-    if (!request.inputs.command && !request.inputs.prompt) {
-      await this.handleProcessExit(executionId, request, CONTAINER_CWD, 0, {
-        branch: handle.branch,
+      await this.setupTaskBranch(CONTAINER_CWD, request, handle, {
+        branchName,
+        base: baseBranch,
       });
-      return handle;
-    }
+      entry.branch = handle.branch;
 
-    // -- Spawn task command via docker exec CLI --
-    const taskCmd = `cd ${shellEscape(CONTAINER_CWD)} && exec ${cmd} ${cmdArgs.map(a => shellEscape(a)).join(' ')}`;
-    const child = spawn('docker', [
-      'exec', '-i', container.id, 'bash', '-c', taskCmd,
-    ], {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      detached: true,
-      env: cleanElectronEnv(),
-    });
-
-    entry.process = child;
-
-    child.on('error', (err) => {
-      emit(`${TAG} task process spawn error: ${err.message}`);
-      const response: WorkResponse = {
-        requestId: request.requestId,
-        actionId: request.actionId,
-        executionGeneration: request.executionGeneration,
-        status: 'failed',
-        outputs: {
-          exitCode: 1,
-          error: `Failed to spawn docker exec: ${err.message}`,
-        },
-      };
-      this.emitComplete(executionId, response);
-    });
-
-    child.stdout?.on('data', (chunk: Buffer) => {
-      this.emitOutput(executionId, chunk.toString());
-    });
-
-    child.stderr?.on('data', (chunk: Buffer) => {
-      this.emitOutput(executionId, chunk.toString());
-    });
-
-    child.on('close', (code, signal) => {
-      void (async () => {
-        const exitCode = code ?? (signal ? 1 : 0);
-
-        await this.handleProcessExit(executionId, request, CONTAINER_CWD, exitCode, {
-          signal,
+      // -- No-command tasks: complete immediately after branch setup --
+      if (!request.inputs.command && !request.inputs.prompt) {
+        await this.handleProcessExit(executionId, request, CONTAINER_CWD, 0, {
           branch: handle.branch,
-          agentSessionId: entry.agentSessionId,
         });
+        return handle;
+      }
 
-        // Stop the idle container after git finalize completes
-        try {
-          const c = docker.getContainer(container.id);
-          await c.stop({ t: CONTAINER_STOP_TIMEOUT_S });
-        } catch {
-          // Container may already be stopped
-        }
-      })();
+      // -- Spawn task command via docker exec CLI --
+      const taskCmd = `cd ${shellEscape(CONTAINER_CWD)} && exec ${cmd} ${cmdArgs.map(a => shellEscape(a)).join(' ')}`;
+      const child = spawn('docker', [
+        'exec', '-i', container.id, 'bash', '-c', taskCmd,
+      ], {
+        stdio: ['pipe', 'pipe', 'pipe'],
+        detached: true,
+        env: cleanElectronEnv(),
+      });
+
+      entry.process = child;
+
+      child.on('error', (err) => {
+        emit(`${TAG} task process spawn error: ${err.message}`);
+        const response: WorkResponse = {
+          requestId: request.requestId,
+          actionId: request.actionId,
+          executionGeneration: request.executionGeneration,
+          status: 'failed',
+          outputs: {
+            exitCode: 1,
+            error: `Failed to spawn docker exec: ${err.message}`,
+          },
+        };
+        this.emitComplete(executionId, response);
+      });
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        this.emitOutput(executionId, chunk.toString());
+      });
+
+      child.stderr?.on('data', (chunk: Buffer) => {
+        this.emitOutput(executionId, chunk.toString());
+      });
+
+      child.on('close', (code, signal) => {
+        void this.containerContext.run(container.id, async () => {
+          const exitCode = code ?? (signal ? 1 : 0);
+
+          await this.handleProcessExit(executionId, request, CONTAINER_CWD, exitCode, {
+            signal,
+            branch: handle.branch,
+            agentSessionId: entry.agentSessionId,
+          });
+
+          // Stop the idle container after git finalize completes
+          try {
+            const c = docker.getContainer(container.id);
+            await c.stop({ t: CONTAINER_STOP_TIMEOUT_S });
+          } catch {
+            // Container may already be stopped
+          }
+        });
+      });
+
+      this.startHeartbeat(executionId, child);
+      return handle;
     });
-
-    this.startHeartbeat(executionId, child);
-    return handle;
   }
 
   async kill(handle: ExecutorHandle): Promise<void> {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -395,7 +395,10 @@ export class TaskRunner {
         },
       };
       this.callbacks.onComplete?.(task.id, response);
-      this.orchestrator.handleWorkerResponse(response);
+      const newlyStarted = this.orchestrator.handleWorkerResponse(response) ?? [];
+      if (newlyStarted.length > 0) {
+        this.executeTasks(newlyStarted);
+      }
     } finally {
       this.launchingAttemptIds.delete(attemptId);
     }


### PR DESCRIPTION
## Summary
- move the comprehensive Fix Intent Repros suite out of required PR CI and into scheduled/manual CI
- gate Docker comprehensive on scheduled/manual CI so PR checks stay focused on the fast required surface
- fix DockerExecutor concurrent task routing by replacing the shared active container field with async-scoped container context
- fix TaskRunner startup-failure dispatch so newly ready tasks returned after a provisioning failure are actually launched
- add regression tests for Docker async container routing and startup-failure downstream dispatch

## Verification
- `pnpm exec tsc -p tsconfig.typecheck.json --pretty false`
- `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts -t "dispatches newly ready tasks after executor startup failure"`
- `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/docker-executor.test.ts -t "keeps docker exec routing scoped"`
- `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts src/__tests__/docker-executor.test.ts`
- `pnpm --filter @invoker/app build`
- `bash scripts/build-agent-base-image.sh`
- `docker build -t invoker-agent:latest scripts/fixtures/hello-world-agent`
- `bash scripts/test-suites/dangerous/10-docker-comprehensive.sh` → 25 passed, 0 failed, 0 skipped
- `pnpm --filter @invoker/execution-engine build` currently fails on pre-existing declaration-build `TS6307` file-list errors unrelated to this change
