### PR TITLE
Fix Codex conversion IPC option ordering

### DIFF
--- a/scripts/convert-claude-to-codex.sh
+++ b/scripts/convert-claude-to-codex.sh
@@ -50,7 +50,25 @@ headless_query() {
 
 # Helper: mutating command (stderr preserved for debugging real failures)
 headless_mutation() {
-  node "$IPC_HELPER" exec -- "$@"
+  local ipc_args=()
+  local headless_args=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --no-track|--wait-for-approval)
+        ipc_args+=("$1")
+        shift
+        ;;
+      --timeout-ms)
+        ipc_args+=("$1" "$2")
+        shift 2
+        ;;
+      *)
+        headless_args+=("$1")
+        shift
+        ;;
+    esac
+  done
+  node "$IPC_HELPER" exec "${ipc_args[@]}" -- "${headless_args[@]}"
 }
 
 # Helper: extract workflow IDs (filter Electron init noise)


### PR DESCRIPTION
## Summary

Fix `scripts/convert-claude-to-codex.sh` so IPC-level options such as `--no-track` are passed before the `--` separator to `scripts/headless-ipc.js`.

This keeps the headless command payload as `set agent <task> codex` instead of accidentally sending `--no-track` to the Invoker command parser as an unknown command.

## Test Plan

- [x] `bash -n scripts/convert-claude-to-codex.sh`
- [x] Live validation in the main worktree: reran `bash scripts/convert-claude-to-codex.sh`; after the fix it converted 130 tasks successfully and the rerun reported 131 skipped/already Codex with 0 failures.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Avoid using `scripts/convert-claude-to-codex.sh` with IPC delegation until the option ordering is fixed again.
- Data migration? No
