### PR TITLE
fix(auto-fix): natively classify infra/provisioning failures

### DIFF
--- a/packages/app/src/__tests__/auto-fix-gating.test.ts
+++ b/packages/app/src/__tests__/auto-fix-gating.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { shouldSkipAutoFixForError } from '../auto-fix-gating.js';
+import { shouldSkipAutoFixForError, shouldSkipAutoFixForFailure } from '../auto-fix-gating.js';
 
 describe('auto-fix-gating', () => {
   it('does not skip auto-fix for non-string errors', () => {
@@ -32,5 +32,19 @@ describe('auto-fix-gating', () => {
     expect(shouldSkipAutoFixForError('cancelled by user')).toBe(false);
     expect(shouldSkipAutoFixForError('Cancel')).toBe(false);
     expect(shouldSkipAutoFixForError('Not Cancelled: warning only')).toBe(false);
+  });
+
+  it('skips auto-fix for infra provisioning failures via native failure info', () => {
+    expect(shouldSkipAutoFixForFailure({
+      error: 'Worktree provisioning failed',
+      failureInfo: { category: 'infra', stage: 'provisioning' },
+    })).toBe(true);
+  });
+
+  it('does not skip auto-fix for task-execution failures with failure info', () => {
+    expect(shouldSkipAutoFixForFailure({
+      error: 'tests failed',
+      failureInfo: { category: 'task', stage: 'execution' },
+    })).toBe(false);
   });
 });

--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -14,7 +14,7 @@ describe('wireHeadlessAutoFix', () => {
     wireHeadlessAutoFix(
       {
         messageBus,
-        orchestrator: { shouldAutoFix } as any,
+        orchestrator: { shouldAutoFix, getTask: vi.fn(() => undefined) } as any,
         persistence: {} as any,
       },
       {} as any,

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -802,6 +802,57 @@ describe('autoFixOnFailure', () => {
     expect(taskExecutor.executeTasks).toHaveBeenCalledWith(started);
   });
 
+  it('skips auto-fix for infra provisioning failures with native failure info', async () => {
+    const orchestrator = {
+      shouldAutoFix: vi.fn(() => true),
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        execution: {
+          autoFixAttempts: 0,
+          error: 'Worktree provisioning failed',
+          failureInfo: { category: 'infra', stage: 'provisioning', retryable: true },
+        },
+      })),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginConflictResolution: vi.fn(),
+      retryTask: vi.fn(() => []),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'test output'),
+      appendTaskOutput: vi.fn(),
+      logEvent: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      resolveConflict: vi.fn().mockResolvedValue(undefined),
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await autoFixOnFailure('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    });
+
+    expect(orchestrator.beginConflictResolution).not.toHaveBeenCalled();
+    expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
+    expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
+    expect(persistence.logEvent).toHaveBeenCalledWith(
+      'task-a',
+      'debug.auto-fix',
+      expect.objectContaining({
+        phase: 'auto-fix-skip-infra-failure',
+      }),
+    );
+    expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
+      'task-a',
+      expect.stringContaining('infrastructure provisioning/setup failure'),
+    );
+  });
+
   it('skips auto-fix when workspacePath is missing for non-recreate routes', async () => {
     const orchestrator = {
       shouldAutoFix: vi.fn(() => true),

--- a/packages/app/src/auto-fix-gating.ts
+++ b/packages/app/src/auto-fix-gating.ts
@@ -5,3 +5,21 @@ export function shouldSkipAutoFixForError(errorText: unknown): boolean {
   return errorText.startsWith('Cancelled by user') || errorText.startsWith('Cancelled:')
     || errorText.startsWith('Terminated by user') || errorText.startsWith('Terminated:');
 }
+
+type FailureInfoLike = {
+  category?: unknown;
+  stage?: unknown;
+};
+
+type FailureSnapshot = {
+  error?: unknown;
+  failureInfo?: FailureInfoLike;
+};
+
+export function shouldSkipAutoFixForFailure(snapshot: FailureSnapshot | undefined): boolean {
+  if (!snapshot) return false;
+  if (shouldSkipAutoFixForError(snapshot.error)) return true;
+  const category = typeof snapshot.failureInfo?.category === 'string' ? snapshot.failureInfo.category : undefined;
+  const stage = typeof snapshot.failureInfo?.stage === 'string' ? snapshot.failureInfo.stage : undefined;
+  return category === 'infra' && (stage === 'provisioning' || stage === 'setup_branch');
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -47,6 +47,7 @@ import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
 import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { shouldSkipAutoFixForFailure } from './auto-fix-gating.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
@@ -253,12 +254,19 @@ export function wireHeadlessAutoFix(
 
   const unsubscribe = deps.messageBus.subscribe<TaskDelta>(Channels.TASK_DELTA, (delta) => {
     if (delta.type !== 'updated' || delta.changes.status !== 'failed') return;
+    const latestTask = deps.orchestrator.getTask(delta.taskId);
+    const shouldSkip = shouldSkipAutoFixForFailure({
+      error: delta.changes.execution?.error ?? latestTask?.execution.error,
+      failureInfo: delta.changes.execution?.failureInfo ?? latestTask?.execution.failureInfo,
+    });
     const inProgress = autoFixInProgress.has(delta.taskId);
     const shouldAutoFix = deps.orchestrator.shouldAutoFix(delta.taskId);
-    logHeadlessAutoFixDebug(delta.taskId, 'delta-failed', { shouldAutoFix, inProgress });
-    if (inProgress || !shouldAutoFix) {
+    logHeadlessAutoFixDebug(delta.taskId, 'delta-failed', { shouldAutoFix, inProgress, shouldSkip });
+    if (inProgress || !shouldAutoFix || shouldSkip) {
       logHeadlessAutoFixDebug(delta.taskId, 'schedule-skip', {
-        reason: !shouldAutoFix ? 'shouldAutoFix-false' : 'already-in-progress',
+        reason: shouldSkip
+          ? 'skip-by-failure-classification'
+          : (!shouldAutoFix ? 'shouldAutoFix-false' : 'already-in-progress'),
       });
       return;
     }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -137,7 +137,7 @@ import { installBundledSkills, resolveBundledSkillsStatus } from './bundled-skil
 import { createRequire } from 'node:module';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
 import { applyDelta, resolveQuarantine, TaskSnapshotCache } from './delta-merge.js';
-import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
+import { shouldSkipAutoFixForFailure } from './auto-fix-gating.js';
 import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
@@ -2625,13 +2625,17 @@ if (isHeadless) {
         ? d.taskId
         : undefined;
       if (d.type === 'updated' && d.changes.status === 'failed') {
-        const cancellationError = shouldSkipAutoFixForError(d.changes.execution?.error);
+        const latestTask = orchestrator.getTask(d.taskId);
+        const skipAutoFix = shouldSkipAutoFixForFailure({
+          error: d.changes.execution?.error ?? latestTask?.execution.error,
+          failureInfo: d.changes.execution?.failureInfo ?? latestTask?.execution.failureInfo,
+        });
         const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(d.taskId);
         logAutoFixDebug(d.taskId, 'delta-failed', {
-          shouldSkipForCancellation: cancellationError,
+          shouldSkipForCancellation: skipAutoFix,
           shouldAutoFixFromOrchestrator,
         });
-        if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
+        if (!skipAutoFix && shouldAutoFixFromOrchestrator && deltaTaskId) {
           logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
           scheduleAutoFix(deltaTaskId);
         }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -19,6 +19,7 @@ import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
+import { shouldSkipAutoFixForFailure } from './auto-fix-gating.js';
 
 // ── Lineage guard ─────────────────────────────────────────────
 
@@ -990,6 +991,20 @@ export async function autoFixOnFailure(
 
   const task = orchestrator.getTask(taskId);
   if (!task || task.status !== 'failed') return;
+  if (shouldSkipAutoFixForFailure({
+    error: task.execution.error,
+    failureInfo: task.execution.failureInfo,
+  })) {
+    persistence.logEvent?.(taskId, 'debug.auto-fix', {
+      phase: 'auto-fix-skip-infra-failure',
+      failureInfo: task.execution.failureInfo ?? null,
+    });
+    persistence.appendTaskOutput(
+      taskId,
+      '\n[Auto-fix] Auto-fix skipped: infrastructure provisioning/setup failure requires manual retry or recreate.',
+    );
+    return;
+  }
 
   const attempts = (task.execution.autoFixAttempts ?? 0) + 1;
   const max = orchestrator.getAutoFixRetryBudget(taskId);

--- a/packages/contracts/src/__tests__/validation.test.ts
+++ b/packages/contracts/src/__tests__/validation.test.ts
@@ -50,6 +50,24 @@ describe('validateWorkResponse', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('accepts a valid failureInfo payload', () => {
+    const result = validateWorkResponse({
+      ...baseResponse,
+      status: 'failed',
+      outputs: {
+        exitCode: 1,
+        error: 'provision failed',
+        failureInfo: {
+          category: 'infra',
+          stage: 'provisioning',
+          retryable: true,
+          reasonCode: 'WORKTREE_PROVISION_FAILED',
+        },
+      },
+    });
+    expect(result.valid).toBe(true);
+  });
+
   it('accepts an optional attemptId on WorkResponse', () => {
     const result = validateWorkResponse({ ...baseResponse, attemptId: 'task-1-a1' });
     expect(result.valid).toBe(true);
@@ -183,6 +201,42 @@ describe('validateWorkResponse', () => {
       const result = validateWorkResponse({ requestId: 'r', actionId: 'a', executionGeneration: 0, status: 'completed', outputs: [] });
       expect(result.valid).toBe(false);
       expect(result.error).toBe('outputs is required and must be an object');
+    });
+
+    it('rejects non-object outputs.failureInfo', () => {
+      const result = validateWorkResponse({
+        requestId: 'r',
+        actionId: 'a',
+        executionGeneration: 0,
+        status: 'failed',
+        outputs: { error: 'boom', failureInfo: 'infra' },
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error).toBe('outputs.failureInfo, if provided, must be an object');
+    });
+
+    it('rejects unknown outputs.failureInfo.category', () => {
+      const result = validateWorkResponse({
+        requestId: 'r',
+        actionId: 'a',
+        executionGeneration: 0,
+        status: 'failed',
+        outputs: { error: 'boom', failureInfo: { category: 'network', stage: 'provisioning' } },
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('outputs.failureInfo.category must be one of');
+    });
+
+    it('rejects unknown outputs.failureInfo.stage', () => {
+      const result = validateWorkResponse({
+        requestId: 'r',
+        actionId: 'a',
+        executionGeneration: 0,
+        status: 'failed',
+        outputs: { error: 'boom', failureInfo: { category: 'infra', stage: 'bootstrap' } },
+      });
+      expect(result.valid).toBe(false);
+      expect(result.error).toContain('outputs.failureInfo.stage must be one of');
     });
 
     it('rejects spawn_experiments with missing dagMutation', () => {

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -90,9 +90,20 @@ export type ResponseStatus =
   | 'spawn_experiments'
   | 'select_experiment';
 
+export type FailureCategory = 'infra' | 'task' | 'agent' | 'unknown';
+export type FailureStage = 'provisioning' | 'setup_branch' | 'execution' | 'unknown';
+
+export interface FailureInfo {
+  category: FailureCategory;
+  stage: FailureStage;
+  retryable?: boolean;
+  reasonCode?: string;
+}
+
 export interface WorkResponseOutputs {
   exitCode?: number;
   error?: string;
+  failureInfo?: FailureInfo;
   summary?: string;
   commitHash?: string;
   agentSessionId?: string;

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -80,6 +80,27 @@ export function validateWorkResponse(res: unknown): ValidationResult {
   if (!r.outputs || typeof r.outputs !== 'object' || Array.isArray(r.outputs)) {
     return { valid: false, error: 'outputs is required and must be an object' };
   }
+  const outputs = r.outputs as Record<string, unknown>;
+  if (outputs.failureInfo !== undefined) {
+    if (!outputs.failureInfo || typeof outputs.failureInfo !== 'object' || Array.isArray(outputs.failureInfo)) {
+      return { valid: false, error: 'outputs.failureInfo, if provided, must be an object' };
+    }
+    const failureInfo = outputs.failureInfo as Record<string, unknown>;
+    const validFailureCategories = ['infra', 'task', 'agent', 'unknown'];
+    if (!validFailureCategories.includes(failureInfo.category as string)) {
+      return { valid: false, error: `outputs.failureInfo.category must be one of: ${validFailureCategories.join(', ')}` };
+    }
+    const validFailureStages = ['provisioning', 'setup_branch', 'execution', 'unknown'];
+    if (!validFailureStages.includes(failureInfo.stage as string)) {
+      return { valid: false, error: `outputs.failureInfo.stage must be one of: ${validFailureStages.join(', ')}` };
+    }
+    if (failureInfo.retryable !== undefined && typeof failureInfo.retryable !== 'boolean') {
+      return { valid: false, error: 'outputs.failureInfo.retryable, if provided, must be a boolean' };
+    }
+    if (failureInfo.reasonCode !== undefined && typeof failureInfo.reasonCode !== 'string') {
+      return { valid: false, error: 'outputs.failureInfo.reasonCode, if provided, must be a string' };
+    }
+  }
 
   // spawn_experiments requires dagMutation.spawnExperiments
   if (r.status === 'spawn_experiments') {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -336,6 +336,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
         error TEXT,
         protocol_error_code TEXT,
         protocol_error_message TEXT,
+        failure_category TEXT,
+        failure_stage TEXT,
+        failure_retryable INTEGER,
+        failure_reason_code TEXT,
         input_prompt TEXT,
         external_dependencies TEXT,
 
@@ -582,6 +586,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE tasks ADD COLUMN fixed_integration_sha TEXT',
       'ALTER TABLE tasks ADD COLUMN fixed_integration_recorded_at TEXT',
       'ALTER TABLE tasks ADD COLUMN fixed_integration_source TEXT',
+      'ALTER TABLE tasks ADD COLUMN failure_category TEXT',
+      'ALTER TABLE tasks ADD COLUMN failure_stage TEXT',
+      'ALTER TABLE tasks ADD COLUMN failure_retryable INTEGER',
+      'ALTER TABLE tasks ADD COLUMN failure_reason_code TEXT',
       'ALTER TABLE attempts ADD COLUMN queue_priority INTEGER NOT NULL DEFAULT 0',
       'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
       'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
@@ -739,7 +747,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.execRun(`
       INSERT OR REPLACE INTO tasks (
         id, workflow_id, description, status, blocked_by, dependencies,
-        command, prompt, experiment_prompt, exit_code, error, protocol_error_code, protocol_error_message, input_prompt, external_dependencies,
+        command, prompt, experiment_prompt, exit_code, error, protocol_error_code, protocol_error_message, failure_category, failure_stage, failure_retryable, failure_reason_code, input_prompt, external_dependencies,
         summary, problem, approach, test_plan, repro_command,
         branch, commit_hash, fixed_integration_sha, fixed_integration_recorded_at, fixed_integration_source, parent_task,
         pivot, experiment_variants, is_reconciliation, selected_experiment,
@@ -761,7 +769,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         task_state_version
       ) VALUES (
         ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?, ?,
         ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?,
@@ -787,7 +795,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
       exec.blockedBy ?? null,
       JSON.stringify(task.dependencies),
       cfg.command ?? null, cfg.prompt ?? null, cfg.experimentPrompt ?? null,
-      exec.exitCode ?? null, exec.error ?? null, exec.protocolErrorCode ?? null, exec.protocolErrorMessage ?? null, exec.inputPrompt ?? null,
+      exec.exitCode ?? null, exec.error ?? null, exec.protocolErrorCode ?? null, exec.protocolErrorMessage ?? null,
+      exec.failureInfo?.category ?? null, exec.failureInfo?.stage ?? null,
+      exec.failureInfo?.retryable === undefined ? null : (exec.failureInfo.retryable ? 1 : 0),
+      exec.failureInfo?.reasonCode ?? null,
+      exec.inputPrompt ?? null,
       cfg.externalDependencies ? JSON.stringify(cfg.externalDependencies) : null,
       cfg.summary ?? null, cfg.problem ?? null, cfg.approach ?? null,
       cfg.testPlan ?? null, cfg.reproCommand ?? null,
@@ -970,6 +982,22 @@ export class SQLiteAdapter implements PersistenceAdapter {
           setClauses.push(`${col} = ?`);
           values.push((changes.execution as any)[key] ? 1 : 0);
         }
+      }
+      if ('failureInfo' in changes.execution) {
+        const failureInfo = (changes.execution as any).failureInfo as {
+          category?: string;
+          stage?: string;
+          retryable?: boolean;
+          reasonCode?: string;
+        } | undefined;
+        setClauses.push('failure_category = ?');
+        values.push(failureInfo?.category ?? null);
+        setClauses.push('failure_stage = ?');
+        values.push(failureInfo?.stage ?? null);
+        setClauses.push('failure_retryable = ?');
+        values.push(failureInfo?.retryable === undefined ? null : (failureInfo.retryable ? 1 : 0));
+        setClauses.push('failure_reason_code = ?');
+        values.push(failureInfo?.reasonCode ?? null);
       }
     }
 
@@ -1715,6 +1743,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
         error: row.error ?? undefined,
         protocolErrorCode: row.protocol_error_code ?? undefined,
         protocolErrorMessage: row.protocol_error_message ?? undefined,
+        failureInfo: row.failure_category || row.failure_stage || row.failure_reason_code || (row.failure_retryable !== null && row.failure_retryable !== undefined)
+          ? {
+              category: row.failure_category ?? 'unknown',
+              stage: row.failure_stage ?? 'unknown',
+              retryable: row.failure_retryable === null || row.failure_retryable === undefined ? undefined : row.failure_retryable === 1,
+              reasonCode: row.failure_reason_code ?? undefined,
+            }
+          : undefined,
         startedAt: row.started_at ? new Date(row.started_at) : undefined,
         completedAt: row.completed_at ? new Date(row.completed_at) : undefined,
         lastHeartbeatAt: row.last_heartbeat_at ? new Date(row.last_heartbeat_at) : undefined,

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -1,7 +1,7 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { accessSync, constants } from 'node:fs';
 import { normalize } from 'node:path';
-import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import type { FailureInfo, WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import { killProcessGroup, cleanElectronEnv, SIGKILL_TIMEOUT_MS } from './process-utils.js';
@@ -452,7 +452,10 @@ elif [[ "\${WT:0:2}" == '~/' ]]; then
 fi
 cd "$WT"
 echo "[SshExecutor] Provisioning remote worktree with: ${this.provisionCommand.slice(0, 50)}..."
-eval "$(echo ${provB64} | base64 -d)"
+if ! eval "$(echo ${provB64} | base64 -d)"; then
+  echo "__INVOKER_FAILURE_STAGE=provisioning"
+  exit 239
+fi
 echo "[SshExecutor] Running task payload..."
 echo ${payloadB64} | base64 -d | bash -se
 `;
@@ -589,6 +592,7 @@ echo ${payloadB64} | base64 -d | bash -se
 
         let status: 'completed' | 'failed' = exitCode === 0 ? 'completed' : 'failed';
         let mappedError: string | undefined;
+        let failureInfo: FailureInfo | undefined;
         if (exitCode === 30) {
           mappedError = 'Upstream branch missing on remote clone';
         } else if (exitCode === 31) {
@@ -598,6 +602,14 @@ echo ${payloadB64} | base64 -d | bash -se
           const branch = branchMatch?.[1]?.trim() ?? 'unknown';
           const files = filesSection?.[1]?.trim() ?? '(see task output)';
           mappedError = `Merge conflict merging upstream branch "${branch}" on remote.\nConflicting files:\n${files}`;
+        } else if (exitCode === 239) {
+          mappedError = 'Remote worktree provisioning failed';
+          failureInfo = {
+            category: 'infra',
+            stage: 'provisioning',
+            retryable: true,
+            reasonCode: 'SSH_PROVISION_FAILED',
+          };
         }
 
         let commitHash: string | undefined;
@@ -656,6 +668,7 @@ echo ${payloadB64} | base64 -d | bash -se
             commitHash,
             agentSessionId: entry.agentSessionId,
             ...(mappedError ? { error: mappedError } : {}),
+            ...(failureInfo ? { failureInfo } : {}),
             ...(finalizeRemote && commitHash
               ? { summary: `branch=${finalizeRemote.branch} commit=${commitHash}` }
               : {}),

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -14,7 +14,7 @@ import { homedir } from 'node:os';
 import { scopePlanTaskId } from '@invoker/workflow-core';
 import type { Orchestrator, TaskState, ExperimentVariant, ExecutorType } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
+import type { FailureInfo, WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
 import type { Executor, ExecutorHandle } from './executor.js';
 import { BaseExecutor } from './base-executor.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
@@ -64,6 +64,20 @@ type StartupFailureMetadata = {
   agentSessionId?: string;
   containerId?: string;
 };
+
+function classifyFailureInfoFromError(err: unknown): FailureInfo {
+  const phaseRaw = (err as { phase?: unknown })?.phase;
+  const phase = typeof phaseRaw === 'string' ? phaseRaw : undefined;
+  const stage: FailureInfo['stage'] = phase === 'provisioning' || phase === 'setup_branch'
+    ? phase
+    : 'unknown';
+  return {
+    category: 'infra',
+    stage,
+    retryable: true,
+    reasonCode: stage === 'provisioning' ? 'PROVISIONING_FAILED' : stage === 'setup_branch' ? 'SETUP_BRANCH_FAILED' : 'EXECUTOR_STARTUP_FAILED',
+  };
+}
 
 type ActiveExecutionHandle = ExecutorHandle & { attemptId?: string };
 type ActiveExecutionEntry = {
@@ -392,6 +406,7 @@ export class TaskRunner {
         outputs: {
           exitCode: 1,
           error: err instanceof Error ? (err.stack ?? err.message) : String(err),
+          failureInfo: classifyFailureInfoFromError(err),
         },
       };
       this.callbacks.onComplete?.(task.id, response);

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -355,6 +355,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       const startupErr = err instanceof Error ? err : new Error(String(err));
       (startupErr as Error & { workspacePath?: string; branch?: string }).workspacePath = acquired.worktreePath;
       (startupErr as Error & { workspacePath?: string; branch?: string }).branch = acquired.branch;
+      (startupErr as Error & { phase?: string }).phase = 'provisioning';
       throw startupErr;
     }
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3936,6 +3936,7 @@ export class Orchestrator {
       error?: string;
       protocolErrorCode?: string;
       protocolErrorMessage?: string;
+      failureInfo?: TaskExecution['failureInfo'];
       mergeConflict?: { failedBranch: string; conflictFiles: string[] };
     },
     eventName: string,
@@ -4014,6 +4015,7 @@ export class Orchestrator {
       {
         exitCode: parsed.exitCode,
         error: parsed.error,
+        failureInfo: parsed.failureInfo,
         mergeConflict,
       },
       'task.failed',

--- a/packages/workflow-core/src/response-handler.ts
+++ b/packages/workflow-core/src/response-handler.ts
@@ -6,7 +6,7 @@
  * the Orchestrator what writes to make.
  */
 
-import type { WorkResponse } from '@invoker/contracts';
+import type { FailureInfo, WorkResponse } from '@invoker/contracts';
 import { validateWorkResponse } from '@invoker/contracts';
 
 /** Plan-local id segment for experiment id prefixing (strip `${workflowId}/` when present). */
@@ -42,6 +42,7 @@ export type ParsedResponse =
       taskId: string;
       exitCode: number;
       error?: string;
+      failureInfo?: FailureInfo;
     }
   | {
       type: 'needs_input';
@@ -92,6 +93,7 @@ export class ResponseHandler {
           taskId: actionId,
           exitCode: outputs.exitCode ?? 1,
           error: outputs.error,
+          failureInfo: outputs.failureInfo,
         };
 
       case 'needs_input':

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -97,6 +97,15 @@ export interface ExternalDependency {
 // Never copied when cloning. Reset on restart.
 
 export type TaskRunPhase = 'launching' | 'executing';
+export type TaskFailureCategory = 'infra' | 'task' | 'agent' | 'unknown';
+export type TaskFailureStage = 'provisioning' | 'setup_branch' | 'execution' | 'unknown';
+
+export interface TaskFailureInfo {
+  readonly category: TaskFailureCategory;
+  readonly stage: TaskFailureStage;
+  readonly retryable?: boolean;
+  readonly reasonCode?: string;
+}
 
 export interface TaskExecution {
   readonly generation?: number;
@@ -106,6 +115,7 @@ export interface TaskExecution {
   readonly error?: string;
   readonly protocolErrorCode?: string;
   readonly protocolErrorMessage?: string;
+  readonly failureInfo?: TaskFailureInfo;
   readonly startedAt?: Date;
   readonly completedAt?: Date;
   readonly lastHeartbeatAt?: Date;


### PR DESCRIPTION
## Summary

- Add native failure classification (`category`, `stage`, `retryable`, `reasonCode`) to failed executor responses and persist it on task execution state.
- Classify startup/provisioning failures in worktree/ssh/task-runner paths as infra failures instead of relying on free-form error text.
- Gate GUI/headless/workflow auto-fix dispatch using structured failure metadata so provisioning/setup infra failures skip AI auto-fix and stop looping.

## Architecture

### Before

```mermaid
flowchart TD
  executorFail["Executor failure"] --> response["WorkResponse.outputs.error (string)"]
  response --> orchestrator["Orchestrator marks task failed"]
  orchestrator --> delta["TASK_DELTA failed"]
  delta --> autoFixGate["Auto-fix gate (cancellation string check only)"]
  autoFixGate --> fixAgent["fix with AI"]
```

### After

```mermaid
flowchart TD
  executorFail["Executor failure"] --> classify["failureInfo (category/stage/retryable/reasonCode)"]
  classify --> response["WorkResponse.outputs.failureInfo + error"]
  response --> persist["Orchestrator + SQLite persist failureInfo"]
  persist --> delta["TASK_DELTA failed"]
  delta --> autoFixGate["Auto-fix gate (failureInfo + cancellation)"]
  autoFixGate -->|"infra + provisioning/setup"| skip["skip AI auto-fix"]
  autoFixGate -->|"other failures"| fixAgent["fix with AI"]
```

## Test Plan

- [x] `pnpm --filter @invoker/contracts test`
- [x] `pnpm --filter @invoker/data-store test`
- [x] `pnpm --filter @invoker/workflow-core test`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts src/__tests__/ssh-executor.test.ts src/__tests__/worktree-executor.test.ts --maxWorkers=1`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/auto-fix-gating.test.ts src/__tests__/headless-autofix.test.ts src/__tests__/workflow-actions.test.ts --maxWorkers=1`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 08bf066`
- Post-revert steps: None.
- Data migration? No. Added columns are additive and can remain unused after revert.
