### PR TITLE
Fix strict merge-gate dependency defaults and chain enforcement

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -178,7 +178,7 @@ tasks:
 `;
     const plan = parsePlan(yaml);
     expect(plan.tasks[0].externalDependencies).toEqual([
-      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready' },
+      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
     ]);
   });
 
@@ -222,10 +222,10 @@ tasks:
 `;
     const plan = parsePlan(yaml);
     expect(plan.tasks[0].externalDependencies).toEqual([
-      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready' },
+      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
     ]);
     expect(plan.tasks[1].externalDependencies).toEqual([
-      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready' },
+      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
     ]);
     expect(plan.tasks[2].externalDependencies).toBeUndefined();
   });

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -171,11 +171,12 @@ function parseExternalDependencies(
       );
     }
     const taskId = dep.taskId?.trim() || '__merge__';
+    const defaultGatePolicy: 'completed' | 'review_ready' = taskId === '__merge__' ? 'completed' : 'review_ready';
     return {
       workflowId: dep.workflowId,
       taskId,
       requiredStatus: 'completed' as const,
-      gatePolicy: (dep.gatePolicy ?? 'review_ready') as 'completed' | 'review_ready',
+      gatePolicy: (dep.gatePolicy ?? defaultGatePolicy) as 'completed' | 'review_ready',
     };
   });
 }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1448,7 +1448,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(sid(orchestrator, 1, 'leaf-a'))!.status).toBe('running');
     });
 
-    it('workflow-level external dependency defaults to review_ready and starts on awaiting_approval', () => {
+    it('workflow-level external dependency defaults to completed and stays pending on awaiting_approval', () => {
       orchestrator.loadPlan({
         name: 'prereq-workflow',
         tasks: [{ id: 'verify-control-plane-regression', description: 'Prereq task' }],
@@ -1473,8 +1473,8 @@ describe('Orchestrator', () => {
       orchestrator.setTaskAwaitingApproval(prereqMergeId);
 
       const afterMergeAwaitingApproval = orchestrator.startExecution();
-      expect(afterMergeAwaitingApproval.map((t) => t.id)).toContain(sid(orchestrator, 1, 'leaf-a'));
-      expect(orchestrator.getTask(sid(orchestrator, 1, 'leaf-a'))!.status).toBe('running');
+      expect(afterMergeAwaitingApproval.map((t) => t.id)).not.toContain(sid(orchestrator, 1, 'leaf-a'));
+      expect(orchestrator.getTask(sid(orchestrator, 1, 'leaf-a'))!.status).toBe('pending');
     });
 
     it('review_ready merge-gate dependency starts downstream when upstream is awaiting_approval', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1263,7 +1263,7 @@ export class Orchestrator {
           workflowId: dep.workflowId,
           taskId: dep.taskId,
           requiredStatus: dep.requiredStatus ?? 'completed',
-          gatePolicy: dep.gatePolicy ?? 'review_ready',
+          gatePolicy: dep.gatePolicy ?? this.defaultExternalGatePolicy(dep.taskId),
         })) ?? [];
       const baseConfig = {
         workflowId,
@@ -3048,7 +3048,7 @@ export class Orchestrator {
     const nextDeps = deps.map((dep): ExternalDependency => {
       const update = byKey.get(keyOf(dep.workflowId, dep.taskId));
       if (!update) return dep;
-      const current = dep.gatePolicy ?? 'review_ready';
+      const current = dep.gatePolicy ?? this.defaultExternalGatePolicy(dep.taskId);
       if (current === update.gatePolicy) return dep;
       changed += 1;
       return { ...dep, gatePolicy: update.gatePolicy };
@@ -4311,6 +4311,11 @@ export class Orchestrator {
     return `${workflowId}/${normalizedTaskId}`;
   }
 
+  private defaultExternalGatePolicy(taskId?: string): 'completed' | 'review_ready' {
+    const normalizedTaskId = taskId?.trim() || '__merge__';
+    return normalizedTaskId === '__merge__' ? 'completed' : 'review_ready';
+  }
+
   private findExternalDependencyTask(workflowId: string, taskId?: string): TaskState | undefined {
     const normalizedTaskId = taskId?.trim() || '__merge__';
     if (normalizedTaskId === '__merge__') {
@@ -4335,7 +4340,7 @@ export class Orchestrator {
         return `missing prerequisite ${depDisplayId}`;
       }
       const required = dep.requiredStatus ?? 'completed';
-      const gatePolicy = dep.gatePolicy ?? 'review_ready';
+      const gatePolicy = dep.gatePolicy ?? this.defaultExternalGatePolicy(dep.taskId);
       const isMergeGateDep = (dep.taskId?.trim() || '__merge__') === '__merge__';
       const satisfied =
         prerequisite.status === required

--- a/scripts/repro/repro-downstream-continues-after-upstream-merge-fail.sh
+++ b/scripts/repro/repro-downstream-continues-after-upstream-merge-fail.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# Repro: downstream workflow can continue even if upstream merge gate is not completed
+# when cross-workflow dependency uses gatePolicy=review_ready.
+#
+# This script runs two cases against an isolated DB + local temp git repo:
+#  1) review_ready: downstream starts before upstream merge gate reaches completed.
+#  2) completed: downstream stays pending until upstream merge gate reaches completed.
+#
+# Usage:
+#   bash scripts/repro/repro-downstream-continues-after-upstream-merge-fail.sh
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-merge-gate.XXXXXX")"
+DB_DIR="$TMP_ROOT/db"
+PLAN_DIR="$TMP_ROOT/plans"
+REPO_DIR="$TMP_ROOT/repo"
+LOG_DIR="$TMP_ROOT/logs"
+RUN_ID="${REPRO_MERGE_GATE_RUN_ID:-$(date +%Y%m%d%H%M%S)}"
+
+cleanup() {
+  local ec=$?
+  rm -rf "$TMP_ROOT"
+  return "$ec"
+}
+trap cleanup EXIT
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required command: $1" >&2
+    exit 1
+  }
+}
+
+require_cmd git
+require_cmd jq
+
+mkdir -p "$DB_DIR" "$PLAN_DIR" "$LOG_DIR"
+
+export INVOKER_HEADLESS_STANDALONE=1
+export INVOKER_DB_DIR="$DB_DIR"
+export INVOKER_ALLOW_DELETE_ALL=1
+
+extract_json_stream() {
+  awk '
+    BEGIN { started = 0 }
+    {
+      if (!started) {
+        if ($0 ~ /^[[:space:]]*[\[{]/ && $0 !~ /^\[init\]/ && $0 !~ /^\[deprecated\]/) {
+          started = 1
+          print
+        }
+      } else {
+        print
+      }
+    }
+  '
+}
+
+headless() {
+  (
+    cd "$ROOT"
+    ./run.sh --headless "$@"
+  )
+}
+
+query_tasks_json() {
+  headless query tasks --output json 2>/dev/null | extract_json_stream
+}
+
+query_workflows_json() {
+  headless query workflows --output json 2>/dev/null | extract_json_stream
+}
+
+resolve_workflow_id_by_name() {
+  local workflow_name="$1"
+  for _ in $(seq 1 120); do
+    local id
+    id="$(
+      query_workflows_json |
+        jq -r --arg name "$workflow_name" '[.[] | select(.name == $name)] | sort_by(.createdAt) | last | .id // empty'
+    )"
+    if [[ -n "$id" ]]; then
+      printf '%s' "$id"
+      return 0
+    fi
+    sleep 0.25
+  done
+  return 1
+}
+
+submit_plan_and_resolve_workflow_id() {
+  local plan_path="$1"
+  local workflow_name="$2"
+  local log_path="$3"
+  python3 - "$ROOT" "$plan_path" "$log_path" <<'PY'
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+plan_path = sys.argv[2]
+log_path = Path(sys.argv[3])
+cmd = ["./run.sh", "--headless", "run", plan_path]
+
+with log_path.open("w", encoding="utf-8") as f:
+    try:
+        subprocess.run(
+            cmd,
+            cwd=root,
+            stdout=f,
+            stderr=subprocess.STDOUT,
+            check=False,
+            timeout=45,
+        )
+    except subprocess.TimeoutExpired:
+        f.write("\n[repro] submit command timed out after 45s\n")
+PY
+  local workflow_id
+  workflow_id="$(resolve_workflow_id_by_name "$workflow_name" || true)"
+  if [[ -z "$workflow_id" ]]; then
+    echo "failed to resolve workflow id for name: $workflow_name" >&2
+    echo "--- submit log ($log_path) ---" >&2
+    cat "$log_path" >&2
+    return 1
+  fi
+  printf '%s' "$workflow_id"
+}
+
+wait_workflow_exists() {
+  local workflow_id="$1"
+  for _ in $(seq 1 120); do
+    if query_workflows_json | jq -e --arg id "$workflow_id" '.[] | select(.id == $id)' >/dev/null; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "workflow did not appear: $workflow_id" >&2
+  return 1
+}
+
+wait_for_task_status() {
+  local task_id="$1"
+  local expected="$2"
+  for _ in $(seq 1 300); do
+    local status
+    status="$(task_status "$task_id")"
+    if [[ "$status" == "$expected" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+  echo "task $task_id did not reach $expected" >&2
+  headless query task "$task_id" --output json >&2 || true
+  return 1
+}
+
+wait_for_any_status() {
+  local task_id="$1"
+  shift
+  for _ in $(seq 1 300); do
+    local status
+    status="$(task_status "$task_id")"
+    for candidate in "$@"; do
+      if [[ "$status" == "$candidate" ]]; then
+        printf '%s' "$status"
+        return 0
+      fi
+    done
+    sleep 0.25
+  done
+  echo "task $task_id did not reach any target status: $*" >&2
+  return 1
+}
+
+task_status() {
+  local task_id="$1"
+  headless query task "$task_id" 2>/dev/null | tr -d '\r' | tail -1
+}
+
+create_temp_repo() {
+  mkdir -p "$REPO_DIR"
+  (
+    cd "$REPO_DIR"
+    git init -q
+    git checkout -q -b main
+    printf '%s\n' "# merge-gate repro" > README.md
+    printf '%s\n' '{"name":"merge-gate-repro","version":"1.0.0","private":true}' > package.json
+    git add README.md package.json
+    git -c user.name='repro' -c user.email='repro@example.com' commit -q -m 'init repro repo'
+  )
+}
+
+write_upstream_plan() {
+  local plan_path="$1"
+  cat > "$plan_path" <<EOF
+name: "repro-upstream-${RUN_ID}"
+description: "Upstream workflow that reaches merge gate review."
+repoUrl: "file://${REPO_DIR}"
+baseBranch: main
+onFinish: merge
+mergeMode: manual
+tasks:
+  - id: upstream-task
+    description: "Create upstream marker"
+    command: "printf '%s\n' upstream-${RUN_ID} >> README.md"
+    dependencies: []
+EOF
+}
+
+write_downstream_plan() {
+  local plan_path="$1"
+  local upstream_workflow_id="$2"
+  local gate_policy="$3"
+  cat > "$plan_path" <<EOF
+name: "repro-downstream-${gate_policy}-${RUN_ID}"
+description: "Downstream workflow gated on upstream merge task."
+repoUrl: "file://${REPO_DIR}"
+baseBranch: main
+onFinish: none
+mergeMode: manual
+tasks:
+  - id: downstream-task
+    description: "Long-running task so we can observe dependency gating"
+    command: "sleep 12"
+    dependencies: []
+    externalDependencies:
+      - workflowId: "${upstream_workflow_id}"
+        taskId: "__merge__"
+        requiredStatus: completed
+        gatePolicy: ${gate_policy}
+EOF
+}
+
+run_case() {
+  local gate_policy="$1"
+  local upstream_plan="$PLAN_DIR/upstream-${gate_policy}.yaml"
+  local downstream_plan="$PLAN_DIR/downstream-${gate_policy}.yaml"
+  local upstream_name="repro-upstream-${RUN_ID}"
+  local downstream_name="repro-downstream-${gate_policy}-${RUN_ID}"
+
+  echo "==> case: gatePolicy=${gate_policy}"
+  write_upstream_plan "$upstream_plan"
+  local upstream_wf
+  upstream_wf="$(
+    submit_plan_and_resolve_workflow_id \
+      "$upstream_plan" \
+      "$upstream_name" \
+      "$LOG_DIR/upstream-${gate_policy}.log"
+  )"
+  wait_workflow_exists "$upstream_wf"
+
+  local upstream_merge="__merge__${upstream_wf}"
+  local upstream_leaf="${upstream_wf}/upstream-task"
+  wait_for_task_status "$upstream_leaf" "completed"
+  local merge_ready_status
+  merge_ready_status="$(wait_for_any_status "$upstream_merge" "review_ready" "awaiting_approval")"
+  echo "   upstream merge gate reached: ${merge_ready_status}"
+
+  write_downstream_plan "$downstream_plan" "$upstream_wf" "$gate_policy"
+  local downstream_wf
+  downstream_wf="$(
+    submit_plan_and_resolve_workflow_id \
+      "$downstream_plan" \
+      "$downstream_name" \
+      "$LOG_DIR/downstream-${gate_policy}.log"
+  )"
+  wait_workflow_exists "$downstream_wf"
+
+  local downstream_task="${downstream_wf}/downstream-task"
+  if [[ "$gate_policy" == "review_ready" ]]; then
+    local started_status
+    started_status="$(wait_for_any_status "$downstream_task" "running" "completed")"
+    echo "   downstream started under review_ready dependency: ${started_status}"
+  else
+    sleep 2
+    local pending_status
+    pending_status="$(task_status "$downstream_task")"
+    echo "   downstream status before upstream completion: ${pending_status}"
+    if [[ "$pending_status" != "pending" ]]; then
+      echo "expected downstream to remain pending for gatePolicy=completed, got ${pending_status}" >&2
+      return 1
+    fi
+  fi
+
+  local upstream_merge_after
+  upstream_merge_after="$(task_status "$upstream_merge")"
+  local downstream_after
+  downstream_after="$(task_status "$downstream_task")"
+  echo "   upstream merge gate status now: ${upstream_merge_after}"
+  echo "   downstream status now: ${downstream_after}"
+
+  if [[ "$gate_policy" == "review_ready" ]]; then
+    if [[ "$upstream_merge_after" == "completed" ]]; then
+      echo "expected upstream merge gate to still be non-completed for review_ready case" >&2
+      return 1
+    fi
+    if [[ "$downstream_after" == "pending" || "$downstream_after" == "blocked" ]]; then
+      echo "expected downstream to continue under review_ready before upstream completion" >&2
+      return 1
+    fi
+  else
+    if [[ "$upstream_merge_after" != "review_ready" && "$upstream_merge_after" != "awaiting_approval" ]]; then
+      echo "expected upstream merge gate to remain review_ready/awaiting_approval for completed policy case" >&2
+      return 1
+    fi
+    if [[ "$downstream_after" != "pending" ]]; then
+      echo "expected downstream to stay pending under completed policy before upstream completion, got ${downstream_after}" >&2
+      return 1
+    fi
+  fi
+
+  echo "   result: PASS gatePolicy=${gate_policy}"
+}
+
+create_temp_repo
+headless delete-all >/dev/null 2>&1 || true
+
+run_case "review_ready"
+run_case "completed"
+
+echo
+echo "PASS repro-downstream-continues-after-upstream-merge-fail"

--- a/scripts/submit-workflow-chain.sh
+++ b/scripts/submit-workflow-chain.sh
@@ -41,7 +41,10 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 now_ms() {
-  date +%s%3N
+  python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
 }
 
 log_chain() {
@@ -91,6 +94,82 @@ matches_pattern() {
   else
     grep -E -q "$pattern" "$file"
   fi
+}
+
+validate_upstream_dependency_fields() {
+  local file="$1"
+  local upstream_id="$2"
+  local gate_policy="$3"
+  awk -v upid="$upstream_id" -v expected_gate="$gate_policy" '
+    function normalize(v) {
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", v)
+      gsub(/^"|"$/, "", v)
+      return v
+    }
+    function validate_current_dep() {
+      if (!in_dep || !dep_is_upstream) return
+      found_upstream=1
+      if (normalize(dep_taskId) != "__merge__" || normalize(dep_requiredStatus) != "completed" || normalize(dep_gatePolicy) != expected_gate) {
+        invalid_upstream=1
+      }
+    }
+    BEGIN {
+      in_ext=0
+      in_dep=0
+      dep_is_upstream=0
+      dep_taskId=""
+      dep_requiredStatus=""
+      dep_gatePolicy=""
+      found_upstream=0
+      invalid_upstream=0
+    }
+    {
+      line=$0
+      if (line ~ /^[^[:space:]]/ && line !~ /^externalDependencies:[[:space:]]*$/) {
+        validate_current_dep()
+        in_ext=0
+        in_dep=0
+        dep_is_upstream=0
+        next
+      }
+      if (line ~ /^[[:space:]]*externalDependencies:[[:space:]]*$/) {
+        validate_current_dep()
+        in_ext=1
+        in_dep=0
+        dep_is_upstream=0
+        next
+      }
+      if (in_ext && line ~ /^[[:space:]]*-[[:space:]]*workflowId:[[:space:]]*/) {
+        validate_current_dep()
+        in_dep=1
+        dep_taskId=""
+        dep_requiredStatus=""
+        dep_gatePolicy=""
+        split(line, parts, "workflowId:")
+        dep_is_upstream=(normalize(parts[2]) == upid)
+        next
+      }
+      if (in_ext && in_dep && dep_is_upstream && line ~ /^[[:space:]]*taskId:[[:space:]]*/) {
+        split(line, parts, "taskId:")
+        dep_taskId=parts[2]
+        next
+      }
+      if (in_ext && in_dep && dep_is_upstream && line ~ /^[[:space:]]*requiredStatus:[[:space:]]*/) {
+        split(line, parts, "requiredStatus:")
+        dep_requiredStatus=parts[2]
+        next
+      }
+      if (in_ext && in_dep && dep_is_upstream && line ~ /^[[:space:]]*gatePolicy:[[:space:]]*/) {
+        split(line, parts, "gatePolicy:")
+        dep_gatePolicy=parts[2]
+        next
+      }
+    }
+    END {
+      validate_current_dep()
+      if (!found_upstream || invalid_upstream) exit 1
+    }
+  ' "$file"
 }
 
 resolve_persisted_workflow_id() {
@@ -288,12 +367,8 @@ for i in "${!INPUT_PLANS[@]}"; do
       echo "Rendered plan missing upstream workflow dependency '${prev_wf_id}': $submit_plan" >&2
       exit 1
     fi
-    if ! matches_pattern "taskId:[[:space:]]*\"__merge__\"" "$submit_plan"; then
-      echo "Rendered plan missing enforced merge-gate taskId '__merge__': $submit_plan" >&2
-      exit 1
-    fi
-    if ! matches_pattern "^[[:space:]]*gatePolicy:[[:space:]]*${GATE_POLICY}$" "$submit_plan"; then
-      echo "Rendered plan missing enforced gatePolicy '${GATE_POLICY}': $submit_plan" >&2
+    if ! validate_upstream_dependency_fields "$submit_plan" "$prev_wf_id" "$GATE_POLICY"; then
+      echo "Rendered plan did not enforce strict upstream merge dependency fields for '${prev_wf_id}' (taskId=__merge__, requiredStatus=completed, gatePolicy=${GATE_POLICY}): $submit_plan" >&2
       exit 1
     fi
 

--- a/scripts/test-submit-workflow-chain.sh
+++ b/scripts/test-submit-workflow-chain.sh
@@ -108,6 +108,10 @@ tasks:
       - workflowId: "__UPSTREAM_WORKFLOW_ID__"
         taskId: "leaf-task"
         requiredStatus: completed
+      - workflowId: "wf-static"
+        taskId: "__merge__"
+        requiredStatus: completed
+        gatePolicy: review_ready
 EOF
 
 cat > "$TMP_DIR/plans/c.yaml" <<'EOF'
@@ -143,6 +147,8 @@ grep -q "workflowId: \"$wf1\"" "$rp2"
 grep -q 'taskId: "__merge__"' "$rp2"
 grep -q '^ *gatePolicy: completed$' "$rp2"
 grep -q '^baseBranch: feature/a$' "$rp2"
+grep -q 'workflowId: "wf-static"' "$rp2"
+grep -q '^ *gatePolicy: review_ready$' "$rp2"
 
 grep -q "workflowId: \"$wf2\"" "$rp3"
 grep -q 'taskId: "__merge__"' "$rp3"

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -109,6 +109,7 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
      Use when submitting an entire dependency chain at once.
      `./scripts/submit-workflow-chain.sh [--gate-policy completed|review_ready] <plan1.yaml> <plan2.template.yaml> ...`
      The chain script handles: template rendering, baseBranch rewrite, merge-gate injection, sequential submission. For Invoker-on-Invoker work only, publish the resulting GitHub PR stack with `mergify stack push` once the chain's commits are prepared.
+     Strict default: when `--gate-policy` is omitted, chain submission enforces `taskId: "__merge__"` + `requiredStatus: completed` + `gatePolicy: completed` for upstream workflow dependencies.
 
 ## Runtime verification (Phase 1b)
 

--- a/skills/workflow-chain-submit/SKILL.md
+++ b/skills/workflow-chain-submit/SKILL.md
@@ -30,7 +30,9 @@ Each template after the first must contain:
 ```yaml
 externalDependencies:
   - workflowId: "__UPSTREAM_WORKFLOW_ID__"
+    taskId: "__merge__"
     requiredStatus: completed
+    gatePolicy: completed
 ```
 
 ## Command


### PR DESCRIPTION
## Summary

Default merge-gate external dependencies to `gatePolicy: completed` when policy is omitted, while preserving explicit `review_ready` behavior as an opt-in. Harden chain submission validation so upstream dependency rendering always enforces `taskId: \"__merge__\"`, `requiredStatus: completed`, and the expected gate policy.

## Architecture

### Before

```mermaid
flowchart TD
  planYaml[Plan YAML merge dependency]
  parserDefault[Parser default gatePolicy review_ready]
  orchestratorDefault[Orchestrator default gatePolicy review_ready]
  mergeGate[Upstream merge task review_ready]
  downstream[Downstream task]

  planYaml --> parserDefault
  parserDefault --> orchestratorDefault
  orchestratorDefault --> mergeGate
  mergeGate --> downstream
```

### After

```mermaid
flowchart TD
  planYaml[Plan YAML merge dependency]
  parserDefault[Parser default gatePolicy completed for merge deps]
  orchestratorDefault[Orchestrator default gatePolicy completed for merge deps]
  mergeGate[Upstream merge task review_ready]
  downstream[Downstream task]
  explicitReviewReady[Explicit gatePolicy review_ready]

  planYaml --> parserDefault
  parserDefault --> orchestratorDefault
  orchestratorDefault --> mergeGate
  mergeGate -.blocked until completed.-> downstream
  explicitReviewReady --> downstream
```

## Test Plan

- [x] `cd packages/workflow-core && pnpm test`
- [ ] `cd packages/app && pnpm test` (suite passes tests but exits non-zero due existing Vitest unhandled worker timeout: `Timeout calling \"onTaskUpdate\"`)
- [x] `bash scripts/test-submit-workflow-chain.sh`
- [x] `bash scripts/repro/repro-downstream-continues-after-upstream-merge-fail.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert db62b3f`
- Post-revert steps: Re-run `cd packages/workflow-core && pnpm test` and `bash scripts/test-submit-workflow-chain.sh`
- Data migration? No

Made with [Cursor](https://cursor.com)