### PR TITLE
Fix orphaned executing tasks missing completion signals

### DIFF
--- a/packages/app/e2e/launching-stall-watchdog.spec.ts
+++ b/packages/app/e2e/launching-stall-watchdog.spec.ts
@@ -133,4 +133,106 @@ base.describe('Launch stall watchdog', () => {
       }
     }
   });
+
+  base('fails stuck executing task without execution handle', async () => {
+    const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-executing-watchdog-'));
+    const configPath = path.join(testDir, 'e2e-config.json');
+    writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
+
+    try {
+      const app = await electron.launch({
+        args: launchArgs(),
+        env: {
+          ...process.env,
+          NODE_ENV: 'test',
+          INVOKER_DB_DIR: testDir,
+          INVOKER_ALLOW_DELETE_ALL: '1',
+          INVOKER_REPO_CONFIG_PATH: configPath,
+          INVOKER_EXECUTING_STALL_TIMEOUT_MS: '3000',
+          INVOKER_STARTUP_POLL_DELAY_MS: '0',
+        },
+      });
+      const page = await app.firstWindow();
+      await waitForInvoker(page);
+      await page.evaluate(() => window.invoker.reportUiPerf?.('startup_graph_visible', {}));
+
+      await page.evaluate(async () => {
+        await window.invoker.clear();
+        await window.invoker.deleteAllWorkflows();
+      });
+      await page.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(WATCHDOG_PLAN));
+
+      const initial = await page.evaluate(() => window.invoker.getTasks(true));
+      const initialTasks = Array.isArray(initial) ? initial : initial.tasks;
+      const stalled = findTask(initialTasks, 'stall-task');
+      expect(stalled).toBeDefined();
+
+      const settleDeadline = Date.now() + 10_000;
+      while (Date.now() < settleDeadline) {
+        const snapshot = await page.evaluate(() => window.invoker.getTasks(true));
+        const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
+        const current = findTask(tasks, 'stall-task');
+        if (current && current.status !== 'running') break;
+        await page.waitForTimeout(250);
+      }
+
+      const staleTs = new Date(Date.now() - 30_000).toISOString();
+      await injectTaskStates(page, [{
+        taskId: stalled!.id,
+        changes: {
+          status: 'running',
+          execution: {
+            phase: 'executing',
+            generation: 0,
+            startedAt: staleTs,
+            lastHeartbeatAt: staleTs,
+            selectedAttemptId: `${stalled!.id}-attempt`,
+          },
+        },
+      }]);
+
+      const deadline = Date.now() + 15_000;
+      let stalledTask: any | undefined;
+      while (Date.now() < deadline) {
+        const snapshot = await page.evaluate(() => window.invoker.getTasks(true));
+        const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
+        stalledTask = findTask(tasks, 'stall-task');
+        if (
+          stalledTask?.status === 'failed'
+          && /^Execution stalled: task remained in running\/executing for \d+s without a live execution handle and no completion signal from executor \(.+\)\.$/.test(stalledTask.execution?.error ?? '')
+        ) {
+          break;
+        }
+        await page.waitForTimeout(250);
+      }
+      expect(stalledTask, 'stalled task should remain visible in task list').toBeDefined();
+      expect(stalledTask?.status).toBe('failed');
+      expect(stalledTask?.execution?.error ?? '').toMatch(
+        /^Execution stalled: task remained in running\/executing for \d+s without a live execution handle and no completion signal from executor \(.+\)\.$/,
+      );
+
+      const logsDeadline = Date.now() + 30_000;
+      let sawExecutingStallLog = false;
+      while (Date.now() < logsDeadline) {
+        const logs = await page.evaluate(() => window.invoker.getActivityLogs());
+        sawExecutingStallLog = logs.some(
+          (entry: any) =>
+            entry.source === 'db-poll'
+            && typeof entry.message === 'string'
+            && entry.message.includes('[executing-stall] forcing failure for')
+            && entry.message.includes('stall-task')
+            && entry.message.includes('Execution stalled: task remained in running/executing'),
+        );
+        if (sawExecutingStallLog) break;
+        await page.waitForTimeout(250);
+      }
+      expect(sawExecutingStallLog).toBe(true);
+
+      await app.close();
+    } finally {
+      if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    }
+  });
 });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1163,14 +1163,14 @@ if (isHeadless) {
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
   const traceDbPollPerTask = process.env.INVOKER_TRACE_DB_POLL === '1';
   const traceTaskOutput = process.env.INVOKER_TRACE_TASK_OUTPUT === '1';
-  const runningHeartbeatTopupMs = Number.parseInt(
-    process.env.INVOKER_RUNNING_HEARTBEAT_TOPUP_MS ?? '30000',
-    10,
-  ) || 30000;
   const launchingStallTimeoutMs = Number.parseInt(
     process.env.INVOKER_LAUNCHING_STALL_TIMEOUT_MS ?? '60000',
     10,
   ) || 60000;
+  const executingStallTimeoutMs = Number.parseInt(
+    process.env.INVOKER_EXECUTING_STALL_TIMEOUT_MS ?? '180000',
+    10,
+  ) || 180000;
   const uiPerfStats = {
     mainDeltaToUi: 0,
     dbPollCreated: 0,
@@ -1499,6 +1499,8 @@ if (isHeadless) {
         },
         onComplete: (taskId, response) => {
           flushTaskOutput(taskId);
+          launchingTasks.delete(taskId);
+          taskHandles.delete(taskId);
           logger.info(
             `Task "${taskId}" completion callback received (status: ${response.status}, generation: ${response.executionGeneration}, exitCode: ${response.outputs.exitCode ?? 'none'})`,
             { module: 'exec' },
@@ -2338,24 +2340,12 @@ if (isHeadless) {
                 let task = loadedTask;
                 const now = new Date();
                 const previousHeartbeat = parseExecutionDate(task.execution.lastHeartbeatAt);
+                const selectedAttempt = task.execution.selectedAttemptId
+                  ? persistence.loadAttempt?.(task.execution.selectedAttemptId)
+                  : undefined;
+                const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
 
                 if (task.status === 'running') {
-                  if (!previousHeartbeat || now.getTime() - previousHeartbeat.getTime() >= runningHeartbeatTopupMs) {
-                    persistence.updateTask(task.id, { execution: { lastHeartbeatAt: now } });
-                    messageBus.publish(Channels.TASK_DELTA, {
-                      type: 'updated' as const,
-                      taskId: task.id,
-                      changes: { execution: { lastHeartbeatAt: now } },
-                    });
-                    task = {
-                      ...task,
-                      execution: {
-                        ...task.execution,
-                        lastHeartbeatAt: now,
-                      },
-                    };
-                  }
-
                   const launchStartedAt = parseExecutionDate(task.execution.launchStartedAt)
                     ?? parseExecutionDate(task.execution.startedAt);
                   const launchAgeMs = launchStartedAt ? now.getTime() - launchStartedAt.getTime() : 0;
@@ -2393,6 +2383,57 @@ if (isHeadless) {
                       );
                       void requireTaskExecutor().executeTasks(runnableAfterFailure).catch((err) => {
                         logger.error(`[launch-stall] executeTasks failed after failing "${task.id}": ${err instanceof Error ? err.stack ?? err.message : String(err)}`, { module: 'db-poll' });
+                      });
+                    }
+                    continue;
+                  }
+
+                  const executingStartedAt = parseExecutionDate(task.execution.startedAt);
+                  const executingAgeMs = executingStartedAt ? now.getTime() - executingStartedAt.getTime() : 0;
+                  const heartbeatStale =
+                    !previousHeartbeat || now.getTime() - previousHeartbeat.getTime() >= executingStallTimeoutMs;
+                  const leaseExpired = !!leaseExpiresAt && leaseExpiresAt.getTime() < now.getTime();
+                  const executingStalled =
+                    task.execution.phase === 'executing'
+                    && executingStartedAt !== undefined
+                    && executingAgeMs >= executingStallTimeoutMs
+                    && (leaseExpired || heartbeatStale);
+
+                  if (executingStalled) {
+                    const staleReason = leaseExpired ? 'attempt lease expired' : 'executor heartbeat stale';
+                    const executingError =
+                      `Execution stalled: task remained in running/executing for ${Math.floor(executingAgeMs / 1000)}s ` +
+                      `without a live execution handle and no completion signal from executor (${staleReason}).`;
+                    logger.info(
+                      `[executing-stall] detected task="${task.id}" phase=${task.execution.phase} executingAgeMs=${executingAgeMs} ` +
+                        `handlePresent=${taskHandles.has(task.id)} leaseExpired=${leaseExpired} heartbeatStale=${heartbeatStale}`,
+                      { module: 'db-poll' },
+                    );
+                    const failedResponse: WorkResponse = {
+                      requestId: `executing-stall-${task.id}-${now.getTime()}`,
+                      actionId: task.id,
+                      attemptId: task.execution.selectedAttemptId,
+                      executionGeneration: task.execution.generation ?? 0,
+                      status: 'failed',
+                      outputs: {
+                        exitCode: 1,
+                        error: executingError,
+                      },
+                    };
+                    logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
+                    const startedAfterFailure = orchestrator.handleWorkerResponse(failedResponse);
+                    const runnableAfterFailure = startedAfterFailure.filter((candidate) => candidate.status === 'running');
+                    if (runnableAfterFailure.length > 0) {
+                      logger.info(
+                        `[executing-stall] dispatching ${runnableAfterFailure.length} task(s) started after failing "${task.id}"`,
+                        { module: 'db-poll' },
+                      );
+                      void requireTaskExecutor().executeTasks(runnableAfterFailure).catch((err) => {
+                        logger.error(
+                          `[executing-stall] executeTasks failed after failing "${task.id}": ` +
+                            `${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+                          { module: 'db-poll' },
+                        );
                       });
                     }
                     continue;

--- a/scripts/repro/repro-missing-completion-after-remote-exit.sh
+++ b/scripts/repro/repro-missing-completion-after-remote-exit.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION="bug"
+MIN_STALE_SECONDS="${MIN_STALE_SECONDS:-600}"
+EXECUTOR_FILTER="${EXECUTOR_FILTER:-ssh}"
+STRICT_MODE="${STRICT_MODE:-0}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-missing-completion-after-remote-exit.sh \
+    [--expect bug|fixed] [--min-stale-seconds N] [--executor ssh|all] [--strict]
+
+What it checks:
+  Detects tasks that look orphaned after remote execution ended:
+    - task status is running
+    - task phase is executing
+    - task age >= min-stale-seconds
+    - no matching process found on any configured SSH remote
+    - no terminal audit event (failed/completed/review_ready/awaiting_approval)
+      after the current attempt started
+  By default only `executorType=ssh` tasks are considered.
+  Use --strict to print per-task proof (remote checks + last terminal event).
+
+Exit codes:
+  0  observed behavior matches --expect
+  1  observed behavior does not match --expect
+  2  invalid args or tooling/runtime error
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --min-stale-seconds)
+      MIN_STALE_SECONDS="${2:-}"
+      shift 2
+      ;;
+    --executor)
+      EXECUTOR_FILTER="${2:-}"
+      shift 2
+      ;;
+    --strict)
+      STRICT_MODE=1
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  echo "repro: --expect requires bug|fixed" >&2
+  exit 2
+fi
+
+if ! [[ "$MIN_STALE_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "repro: --min-stale-seconds must be an integer >= 0" >&2
+  exit 2
+fi
+
+if [[ "$EXECUTOR_FILTER" != "ssh" && "$EXECUTOR_FILTER" != "all" ]]; then
+  echo "repro: --executor requires ssh|all" >&2
+  exit 2
+fi
+
+command -v python3 >/dev/null 2>&1 || { echo "repro: missing python3" >&2; exit 2; }
+command -v ssh >/dev/null 2>&1 || { echo "repro: missing ssh" >&2; exit 2; }
+
+cd "$ROOT_DIR"
+
+python3 - "$EXPECTATION" "$MIN_STALE_SECONDS" "$EXECUTOR_FILTER" "$STRICT_MODE" <<'PY'
+import json
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+EXPECT = sys.argv[1]
+MIN_STALE = int(sys.argv[2])
+EXEC_FILTER = sys.argv[3]
+STRICT_MODE = sys.argv[4] == "1"
+ROOT = Path("/Users/edbertchan/Documents/GitHub/Invoker")
+SSH_KEY = Path.home() / ".ssh" / "id_ed25519"
+CONFIG_PATH = Path.home() / ".invoker" / "config.json"
+
+
+def run(cmd: str) -> str:
+    p = subprocess.run(cmd, cwd=ROOT, shell=True, text=True, capture_output=True)
+    if p.returncode != 0:
+        raise RuntimeError((p.stderr or p.stdout).strip() or f"command failed: {cmd}")
+    return p.stdout
+
+
+def parse_last_json_object(output: str) -> dict:
+    for line in reversed(output.splitlines()):
+        s = line.strip()
+        if s.startswith("{") and s.endswith("}"):
+            try:
+                return json.loads(s)
+            except json.JSONDecodeError:
+                continue
+    raise RuntimeError("could not parse json object from command output")
+
+
+def parse_jsonl_events(output: str) -> list[dict]:
+    rows: list[dict] = []
+    for line in output.splitlines():
+        s = line.strip()
+        if not (s.startswith("{") and '"eventType"' in s and '"taskId"' in s):
+            continue
+        try:
+            rows.append(json.loads(s))
+        except json.JSONDecodeError:
+            continue
+    return rows
+
+
+def parse_iso(ts: Optional[str]) -> Optional[datetime]:
+    if not ts:
+        return None
+    try:
+        return datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def parse_audit_created_at(ts: Optional[str]) -> Optional[datetime]:
+    if not ts:
+        return None
+    try:
+        return datetime.strptime(ts, "%Y-%m-%d %H:%M:%S").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def load_remote_hosts() -> list[tuple[str, str, str]]:
+    if not CONFIG_PATH.exists():
+        return []
+    cfg = json.loads(CONFIG_PATH.read_text())
+    targets = (cfg.get("remoteTargets") or {})
+    out: list[tuple[str, str, str]] = []
+    for target_id, target in targets.items():
+        host = (target or {}).get("host")
+        user = (target or {}).get("user")
+        if host and user:
+            out.append((target_id, host, user))
+    return out
+
+
+def collect_remote_ps(hosts: list[tuple[str, str, str]]) -> dict[str, dict]:
+    by_target: dict[str, dict] = {}
+    for target_id, host, user in hosts:
+        cmd = (
+            f"ssh -i {json.dumps(str(SSH_KEY))} "
+            f"{json.dumps(f'{user}@{host}')} "
+            f"{json.dumps('ps -eo pid,etimes,args')}"
+        )
+        p = subprocess.run(cmd, shell=True, text=True, capture_output=True)
+        by_target[target_id] = {
+            "ok": p.returncode == 0,
+            "stdout": p.stdout if p.returncode == 0 else "",
+            "error": (p.stderr or "").strip(),
+        }
+    return by_target
+
+
+queue_obj = parse_last_json_object(run("./run.sh --headless query queue --output json"))
+running = queue_obj.get("running", [])
+
+remote_hosts = load_remote_hosts()
+remote_ps = collect_remote_ps(remote_hosts)
+
+now = datetime.now(timezone.utc)
+suspects: list[dict] = []
+considered: list[dict] = []
+
+terminal_events = {"task.failed", "task.completed", "task.review_ready", "task.awaiting_approval"}
+
+for row in running:
+    task_id = row.get("taskId")
+    attempt_id = row.get("attemptId")
+    if not task_id:
+        continue
+
+    task_obj = parse_last_json_object(run(f"./run.sh --headless query task {task_id} --output json"))
+    status = task_obj.get("status")
+    execution = task_obj.get("execution") or {}
+    phase = execution.get("phase")
+    started_at = parse_iso(execution.get("startedAt"))
+    age_s = int((now - started_at).total_seconds()) if started_at else -1
+    executor_type = (task_obj.get("config") or {}).get("executorType")
+
+    # Only judge stale remote-command-like paths.
+    if status != "running" or phase != "executing" or age_s < MIN_STALE:
+        continue
+    if EXEC_FILTER == "ssh" and executor_type != "ssh":
+        continue
+
+    # Check remote process match by task/attempt token.
+    task_match_targets: list[str] = []
+    attempt_token = ""
+    if isinstance(attempt_id, str) and attempt_id:
+        attempt_token = attempt_id.split("-a")[-1][:10]
+    remote_matches: list[dict] = []
+    remote_failures: list[str] = []
+    checked_targets: list[str] = []
+    for target_id, remote_result in remote_ps.items():
+        checked_targets.append(target_id)
+        if not remote_result.get("ok"):
+            remote_failures.append(target_id)
+            continue
+        ps_out = remote_result.get("stdout") or ""
+        if task_id in ps_out:
+            task_match_targets.append(target_id)
+            remote_matches.append({"target": target_id, "matchBy": "taskId"})
+            continue
+        if attempt_id and attempt_id in ps_out:
+            task_match_targets.append(target_id)
+            remote_matches.append({"target": target_id, "matchBy": "attemptId"})
+            continue
+        if attempt_token and attempt_token in ps_out:
+            task_match_targets.append(target_id)
+            remote_matches.append({"target": target_id, "matchBy": "attemptToken"})
+            continue
+
+    # Check for terminal event after this attempt started.
+    events = parse_jsonl_events(run(f"./run.sh --headless query audit {task_id} --output jsonl"))
+    terminal_after_start = False
+    terminal_after_start_event: Optional[dict] = None
+    last_terminal_event: Optional[dict] = None
+    if started_at:
+        for ev in events:
+            if ev.get("eventType") not in terminal_events:
+                continue
+            ev_at = parse_audit_created_at(ev.get("createdAt"))
+            if ev_at and (
+                last_terminal_event is None
+                or ev_at > (parse_audit_created_at(last_terminal_event.get("createdAt")) or datetime.min.replace(tzinfo=timezone.utc))
+            ):
+                last_terminal_event = ev
+            if ev_at and ev_at >= started_at:
+                terminal_after_start = True
+                terminal_after_start_event = ev
+                break
+
+    if not task_match_targets and not terminal_after_start:
+        suspects.append(
+            {
+                "taskId": task_id,
+                "attemptId": attempt_id or "",
+                "executorType": executor_type or "",
+                "ageSeconds": age_s,
+                "startedAt": execution.get("startedAt") or "",
+                "lastHeartbeatAt": execution.get("lastHeartbeatAt") or "",
+                "checkedTargets": checked_targets,
+                "remoteFailures": remote_failures,
+                "remoteMatches": remote_matches,
+                "lastTerminalEvent": last_terminal_event or {},
+                "terminalAfterStartEvent": terminal_after_start_event or {},
+            }
+        )
+    if STRICT_MODE:
+        considered.append(
+            {
+                "taskId": task_id,
+                "attemptId": attempt_id or "",
+                "executorType": executor_type or "",
+                "ageSeconds": age_s,
+                "startedAt": execution.get("startedAt") or "",
+                "lastHeartbeatAt": execution.get("lastHeartbeatAt") or "",
+                "checkedTargets": checked_targets,
+                "remoteFailures": remote_failures,
+                "remoteMatches": remote_matches,
+                "lastTerminalEvent": last_terminal_event or {},
+                "terminalAfterStartEvent": terminal_after_start_event or {},
+                "isSuspect": (not task_match_targets and not terminal_after_start),
+            }
+        )
+
+print("repro-summary:")
+print(f"  running_tasks_total: {len(running)}")
+print(f"  stale_threshold_s : {MIN_STALE}")
+print(f"  executor_filter   : {EXEC_FILTER}")
+print(f"  configured_remotes: {len(remote_hosts)}")
+print(f"  strict_mode       : {str(STRICT_MODE).lower()}")
+if STRICT_MODE:
+    print(f"  considered_tasks  : {len(considered)}")
+print(f"  suspects          : {len(suspects)}")
+
+if suspects:
+    print("")
+    print("suspects (running/executing, no remote process match, no terminal event after start):")
+    print("task_id\tage_s\texecutor\tstarted_at\tlast_heartbeat\tattempt_id")
+    for s in suspects:
+        print(
+            f"{s['taskId']}\t{s['ageSeconds']}\t{s['executorType']}\t"
+            f"{s['startedAt']}\t{s['lastHeartbeatAt']}\t{s['attemptId']}"
+        )
+
+if STRICT_MODE and suspects:
+    print("")
+    print("strict-evidence:")
+    for s in suspects:
+        print(f"- task_id: {s['taskId']}")
+        print(f"  attempt_id: {s['attemptId']}")
+        print(f"  executor: {s['executorType']}")
+        print(f"  age_seconds: {s['ageSeconds']}")
+        print(f"  started_at: {s['startedAt']}")
+        print(f"  last_heartbeat_at: {s['lastHeartbeatAt']}")
+        print(f"  remote_targets_checked: {','.join(s['checkedTargets']) if s['checkedTargets'] else '<none>'}")
+        print(f"  remote_targets_unreachable: {','.join(s['remoteFailures']) if s['remoteFailures'] else '<none>'}")
+        if s["remoteMatches"]:
+            print("  remote_match: " + ",".join([f"{m['target']}({m['matchBy']})" for m in s["remoteMatches"]]))
+        else:
+            print("  remote_match: <none>")
+        lte = s.get("lastTerminalEvent") or {}
+        if lte:
+            print(f"  last_terminal_event: {lte.get('eventType')} at {lte.get('createdAt')}")
+        else:
+            print("  last_terminal_event: <none>")
+        ate = s.get("terminalAfterStartEvent") or {}
+        if ate:
+            print(f"  terminal_event_after_start: {ate.get('eventType')} at {ate.get('createdAt')}")
+        else:
+            print("  terminal_event_after_start: <none>")
+
+observed = "bug" if suspects else "fixed"
+print("")
+print(f"observed: {observed}")
+print(f"expect  : {EXPECT}")
+
+if observed != EXPECT:
+    sys.exit(1)
+PY


### PR DESCRIPTION
## Summary
- stop `db-poll` from synthetically rewriting `execution.lastHeartbeatAt` for every running task, so stale/orphaned executions are no longer masked as live
- add an executing-phase stall watchdog in the app main process that force-fails stale `running/executing` attempts when completion never arrives
- clear stale in-memory task handles on completion and add an e2e watchdog test for executing-phase stalls plus a strict SSH repro script for field verification

## Test plan
- [x] `cd packages/app && pnpm build`
- [x] `cd packages/app && pnpm exec playwright test launching-stall-watchdog.spec.ts`
- [x] `bash scripts/repro/repro-missing-completion-after-remote-exit.sh --expect fixed --executor ssh --strict` (after owner restart)
- [ ] `cd packages/app && pnpm test` *(currently reports existing unrelated Vitest worker timeout: `Timeout calling \"onTaskUpdate\"` despite all test files passing)*


Made with [Cursor](https://cursor.com)