### PR TITLE
Track poolId in invalidation metadata

### DIFF
--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -34,6 +34,7 @@ describe('MUTATION_POLICIES', () => {
     expect(MUTATION_POLICIES.prompt.action).toBe('recreateTask');
     expect(MUTATION_POLICIES.executionAgent.action).toBe('recreateTask');
     expect(MUTATION_POLICIES.runnerKind.action).toBe('retryTask');
+    expect(MUTATION_POLICIES.poolId.action).toBe('recreateTask');
     expect(MUTATION_POLICIES.poolMemberId.action).toBe('recreateTask');
     expect(MUTATION_POLICIES.selectedExperiment.action).toBe('recreateTask');
     expect(MUTATION_POLICIES.selectedExperimentSet.action).toBe('recreateTask');

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -31,6 +31,7 @@ export type MutationKey =
   | 'prompt'
   | 'executionAgent'
   | 'runnerKind'
+  | 'poolId'
   | 'poolMemberId'
   | 'selectedExperiment'
   | 'selectedExperimentSet'
@@ -47,6 +48,7 @@ export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>
   prompt:                { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   executionAgent:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   runnerKind:          { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
+  poolId:              { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   poolMemberId:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   selectedExperiment:    { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   selectedExperimentSet: { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },


### PR DESCRIPTION
## Summary

Track `poolId` in workflow invalidation mutation metadata so plan-level pool routing edits are treated as execution-spec changes and route through recreate-class invalidation.

Rebased on #491 after #490 and #491 became no-op stack layers against current `master`.

Depends on #491.

## Test Plan

- [x] `pnpm --dir packages/workflow-core test -- src/__tests__/invalidation-policy.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f4221d27`
- Post-revert steps: None
- Data migration? No
