### PR TITLE
Reduce Large Files Step 1: baseline and guardrails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,8 @@ jobs:
             command: pnpm run check:deps
           - name: Required Package Builds
             command: pnpm run check:required-builds
+          - name: Large File Guardrail
+            command: pnpm run check:large-files
           - name: TypeScript Types
             command: pnpm run check:types
 
@@ -109,6 +111,7 @@ jobs:
           - name: Guardrails
             command: |
               bash scripts/test-suites/required/05-delete-all-prod-db-guard.sh
+              bash scripts/test-suites/required/06-large-file-guardrail.sh
               bash scripts/test-suites/required/07-invalid-config-json.sh
               bash scripts/test-suites/required/15-owner-boundary-policy.sh
               bash scripts/test-suites/required/50-verify-executor-routing.sh

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "check:required-builds": "bash scripts/required-builds.sh",
     "check:deps": "depcruise packages --config .dependency-cruiser.js",
     "check:types": "tsc -p tsconfig.typecheck.json",
-    "check:all": "pnpm run check:deps && pnpm run check:types && pnpm run check:required-builds && bash scripts/check-owner-boundary.sh",
+    "check:large-files": "node scripts/check-large-files.mjs",
+    "check:all": "pnpm run check:deps && pnpm run check:types && pnpm run check:required-builds && pnpm run check:large-files && bash scripts/check-owner-boundary.sh",
     "lint": "pnpm run check:all"
   },
   "pnpm": {

--- a/scripts/check-large-files.mjs
+++ b/scripts/check-large-files.mjs
@@ -1,0 +1,188 @@
+#!/usr/bin/env node
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+
+const DEFAULT_MAX_LINES = 5500;
+const SOURCE_EXTENSIONS = new Set(['.cjs', '.js', '.jsx', '.mjs', '.ts', '.tsx']);
+const IGNORED_DIRS = new Set([
+  '.git',
+  '.next',
+  'build',
+  'coverage',
+  'dist',
+  'e2e',
+  'fixtures',
+  'node_modules',
+  'out',
+  '__generated__',
+  '__tests__',
+]);
+const IGNORED_FILES = new Set([
+  'npm-shrinkwrap.json',
+  'package-lock.json',
+  'pnpm-lock.yaml',
+  'yarn.lock',
+]);
+
+function usage() {
+  console.error('Usage: node scripts/check-large-files.mjs [--root <path>] [--max-lines <count>]');
+}
+
+function parseArgs(argv) {
+  let root = process.cwd();
+  let maxLines = Number.parseInt(process.env.INVOKER_MAX_SOURCE_LINES || '', 10);
+  if (!Number.isFinite(maxLines)) {
+    maxLines = DEFAULT_MAX_LINES;
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--root') {
+      root = argv[index + 1];
+      index += 1;
+    } else if (arg.startsWith('--root=')) {
+      root = arg.slice('--root='.length);
+    } else if (arg === '--max-lines') {
+      maxLines = Number.parseInt(argv[index + 1] || '', 10);
+      index += 1;
+    } else if (arg.startsWith('--max-lines=')) {
+      maxLines = Number.parseInt(arg.slice('--max-lines='.length), 10);
+    } else if (arg === '--help' || arg === '-h') {
+      usage();
+      process.exit(0);
+    } else {
+      console.error(`[large-files] Unknown argument: ${arg}`);
+      usage();
+      process.exit(2);
+    }
+  }
+
+  if (!root || !Number.isInteger(maxLines) || maxLines < 1) {
+    usage();
+    process.exit(2);
+  }
+
+  return {
+    root: path.resolve(root),
+    maxLines,
+  };
+}
+
+function pathExists(filePath) {
+  try {
+    statSync(filePath);
+    return true;
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      return false;
+    }
+    throw error;
+  }
+}
+
+function isGeneratedOrBuildArtifact(filePath) {
+  const basename = path.basename(filePath);
+  return (
+    IGNORED_FILES.has(basename) ||
+    basename.endsWith('.d.ts') ||
+    basename.includes('.gen.') ||
+    basename.includes('.generated.')
+  );
+}
+
+function isProductionSource(filePath) {
+  const basename = path.basename(filePath);
+  const ext = path.extname(basename);
+  return (
+    SOURCE_EXTENSIONS.has(ext) &&
+    !isGeneratedOrBuildArtifact(filePath) &&
+    !basename.includes('.test.') &&
+    !basename.includes('.spec.') &&
+    !basename.includes('.stories.')
+  );
+}
+
+function countLines(filePath) {
+  const content = readFileSync(filePath);
+  if (content.length === 0) {
+    return 0;
+  }
+
+  let lines = 0;
+  for (const byte of content) {
+    if (byte === 10) {
+      lines += 1;
+    }
+  }
+
+  return content[content.length - 1] === 10 ? lines : lines + 1;
+}
+
+function walk(dir, visit) {
+  const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name));
+
+  for (const entry of entries) {
+    const entryPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (!IGNORED_DIRS.has(entry.name)) {
+        walk(entryPath, visit);
+      }
+      continue;
+    }
+
+    if (entry.isFile()) {
+      visit(entryPath);
+    }
+  }
+}
+
+function sourceRoots(root) {
+  const roots = [];
+  const topLevelSrc = path.join(root, 'src');
+  if (pathExists(topLevelSrc)) {
+    roots.push(topLevelSrc);
+  }
+
+  const packagesRoot = path.join(root, 'packages');
+  if (pathExists(packagesRoot)) {
+    const packageDirs = readdirSync(packagesRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && !IGNORED_DIRS.has(entry.name))
+      .map((entry) => path.join(packagesRoot, entry.name, 'src'))
+      .filter(pathExists);
+    roots.push(...packageDirs);
+  }
+
+  return roots.sort((a, b) => a.localeCompare(b));
+}
+
+const { root, maxLines } = parseArgs(process.argv.slice(2));
+const violations = [];
+
+for (const sourceRoot of sourceRoots(root)) {
+  walk(sourceRoot, (filePath) => {
+    if (!isProductionSource(filePath)) {
+      return;
+    }
+
+    const lines = countLines(filePath);
+    if (lines > maxLines) {
+      violations.push({
+        path: path.relative(root, filePath),
+        lines,
+      });
+    }
+  });
+}
+
+violations.sort((a, b) => a.path.localeCompare(b.path));
+
+if (violations.length > 0) {
+  console.error(`[large-files] ${violations.length} production source file(s) exceed ${maxLines} lines:`);
+  for (const violation of violations) {
+    console.error(`[large-files] ${violation.path}: ${violation.lines} lines`);
+  }
+  process.exit(1);
+}
+
+console.log(`[large-files] Checked production source files; all are <= ${maxLines} lines.`);

--- a/scripts/run-all-tests.sh
+++ b/scripts/run-all-tests.sh
@@ -60,16 +60,16 @@ declare -a SUITES=()
 expected_executed_for_mode() {
   case "$MODE_KEY" in
     required)
-      printf '16'
+      printf '17'
       ;;
     extended)
-      printf '23'
+      printf '24'
       ;;
     dangerous)
       if [ "${#SKIPPED_UNAVAILABLE[@]}" -eq 1 ] && [ "${SKIPPED_UNAVAILABLE[0]}" = "dangerous/10-docker-comprehensive.sh" ]; then
-        printf '23'
-      else
         printf '24'
+      else
+        printf '25'
       fi
       ;;
   esac
@@ -121,7 +121,7 @@ suite_name() {
 
 is_parallel_safe() {
   case "$(suite_relpath "$1")" in
-    required/05-delete-all-prod-db-guard.sh|required/07-invalid-config-json.sh|required/10-vitest-workspace.sh|required/15-owner-boundary-policy.sh|required/15-submit-workflow-chain.sh|required/20-e2e-dry-run.sh|required/21-e2e-dry-run-downstream.sh|required/22-e2e-dry-run-github.sh|required/50-verify-executor-routing.sh|optional/40-playwright-app.sh|optional/60-worktree-provisioning.sh|optional/70-ui-visual-proof-validate.sh)
+    required/05-delete-all-prod-db-guard.sh|required/06-large-file-guardrail.sh|required/07-invalid-config-json.sh|required/10-vitest-workspace.sh|required/15-owner-boundary-policy.sh|required/15-submit-workflow-chain.sh|required/20-e2e-dry-run.sh|required/21-e2e-dry-run-downstream.sh|required/22-e2e-dry-run-github.sh|required/50-verify-executor-routing.sh|optional/40-playwright-app.sh|optional/60-worktree-provisioning.sh|optional/70-ui-visual-proof-validate.sh)
       return 0
       ;;
     *)

--- a/scripts/test-suites/required/06-large-file-guardrail.sh
+++ b/scripts/test-suites/required/06-large-file-guardrail.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Deterministic large-file guardrail proof.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+node "$ROOT/scripts/check-large-files.mjs"
+
+TMP_ROOT="$(mktemp -d)"
+trap 'rm -rf "$TMP_ROOT"' EXIT
+
+mkdir -p "$TMP_ROOT/packages/example/src" "$TMP_ROOT/packages/example/dist"
+
+for _ in 1 2 3 4 5 6; do
+  printf 'export const oversized = true;\n'
+done > "$TMP_ROOT/packages/example/src/oversized.ts"
+
+for _ in 1 2 3 4 5 6 7 8; do
+  printf 'export const ignoredBuildArtifact = true;\n'
+done > "$TMP_ROOT/packages/example/dist/ignored-build-artifact.ts"
+
+printf 'lockfile content is ignored\n' > "$TMP_ROOT/pnpm-lock.yaml"
+
+if node "$ROOT/scripts/check-large-files.mjs" --root "$TMP_ROOT" --max-lines 5 >"$TMP_ROOT/stdout.log" 2>"$TMP_ROOT/stderr.log"; then
+  echo "[large-files] Expected oversized production source to fail the guardrail" >&2
+  exit 1
+fi
+
+if ! grep -F "packages/example/src/oversized.ts: 6 lines" "$TMP_ROOT/stderr.log" >/dev/null; then
+  echo "[large-files] Oversized production source was not reported deterministically" >&2
+  cat "$TMP_ROOT/stderr.log" >&2
+  exit 1
+fi
+
+if grep -F "ignored-build-artifact.ts" "$TMP_ROOT/stderr.log" >/dev/null; then
+  echo "[large-files] Build artifact was incorrectly scanned" >&2
+  cat "$TMP_ROOT/stderr.log" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a deterministic large-file guardrail for production source files before decomposition work begins.

The new `scripts/check-large-files.mjs` scans package source roots, excludes generated/build/test artifacts, and fails when production source files exceed the configured line threshold. The guardrail is wired into `pnpm lint`, `pnpm run check:all`, CI validation, and the required test-suite lane, with a focused proof that oversized production files fail while ignored artifacts stay out of scope.

## Test Plan

- [x] `pnpm lint`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No