### PR TITLE
Add pool-aware plan parsing and task type plumbing.

### DIFF
--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -25,6 +25,7 @@
       "user": "deploy",
       "sshKeyPath": "/home/user/.ssh/id_staging",
       "port": 22,
+      "maxConcurrentTasks": 1,
       "managedWorkspaces": true,
       "remoteInvokerHome": "~/.invoker",
       "provisionCommand": "pnpm install --frozen-lockfile"
@@ -35,21 +36,32 @@
       "user": "deploy",
       "sshKeyPath": "/home/user/.ssh/id_build_b",
       "port": 22,
+      "maxConcurrentTasks": 1,
       "managedWorkspaces": true,
       "remoteInvokerHome": "~/.invoker",
       "provisionCommand": "pnpm install --frozen-lockfile"
     }
   },
 
-  "heavyweightCommandRouting": {
-    "comment": "Auto-route heavyweight shell commands like pnpm test to a remote target",
-    "remoteTargetId": "staging-server",
-    "matchers": [
-      {
-        "regex": "\\bpnpm(?:\\s|$)"
-      }
-    ]
+  "executionPools": {
+    "ssh-light": {
+      "comment": "Pool routes tasks across both SSH machines with shared queue/drain semantics",
+      "type": "ssh",
+      "members": ["staging-server", "build-server-b"],
+      "selectionStrategy": "roundRobin",
+      "maxConcurrentTasksPerMember": 1
+    }
   },
+
+  "executorRoutingRules": [
+    {
+      "comment": "Route pnpm commands to ssh-light pool",
+      "regex": "\\bpnpm(?:\\s|$)",
+      "executorType": "ssh",
+      "poolId": "ssh-light",
+      "strategy": "route"
+    }
+  ],
 
   "autoFixRetries": 3,
   "autoApproveAIFixes": true,

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -137,17 +137,60 @@ describe('loadConfig', () => {
     expect(config.imageStorage).toEqual(imageStorage);
   });
 
-  it('reads heavyweightCommandRouting from user config', () => {
-    const heavyweightCommandRouting = {
-      remoteTargetId: 'ci-box',
-      matchers: [{ regex: '\\bpnpm(?:\\s|$)' }],
-    };
+  it('reads executorRoutingRules route strategy from user config', () => {
+    const executorRoutingRules = [{
+      regex: '\\bpnpm(?:\\s|$)',
+      executorType: 'ssh',
+      poolId: 'ssh-light',
+      strategy: 'route',
+    }];
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),
-      JSON.stringify({ heavyweightCommandRouting }),
+      JSON.stringify({ executorRoutingRules }),
     );
     const config = loadConfig();
-    expect(config.heavyweightCommandRouting).toEqual(heavyweightCommandRouting);
+    expect(config.executorRoutingRules).toEqual(executorRoutingRules);
+  });
+
+  it('reads remote target maxConcurrentTasks from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({
+        remoteTargets: {
+          ci1: {
+            host: '10.0.0.1',
+            user: 'invoker',
+            sshKeyPath: '/tmp/key',
+            maxConcurrentTasks: 2,
+          },
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.remoteTargets?.ci1?.maxConcurrentTasks).toBe(2);
+  });
+
+  it('reads executionPools from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({
+        executionPools: {
+          'ssh-light': {
+            type: 'ssh',
+            members: ['remote-1', 'remote-2'],
+            selectionStrategy: 'roundRobin',
+            maxConcurrentTasksPerMember: 1,
+          },
+        },
+      }),
+    );
+    const config = loadConfig();
+    expect(config.executionPools?.['ssh-light']).toEqual({
+      type: 'ssh',
+      members: ['remote-1', 'remote-2'],
+      selectionStrategy: 'roundRobin',
+      maxConcurrentTasksPerMember: 1,
+    });
   });
 
 });

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -689,7 +689,7 @@ tasks:
       expect(() => parsePlan(yaml)).toThrow('executorType "docker" but is missing required field "dockerImage"');
     });
 
-    it('rejects executorType ssh without remoteTargetId', () => {
+    it('rejects executorType ssh without remoteTargetId or poolId', () => {
       const yaml = `
 name: SSH No Target
 repoUrl: git@github.com:test/repo.git
@@ -700,7 +700,7 @@ tasks:
     executorType: ssh
 `;
       expect(() => parsePlan(yaml)).toThrow(PlanParseError);
-      expect(() => parsePlan(yaml)).toThrow('executorType "ssh" but is missing required field "remoteTargetId"');
+      expect(() => parsePlan(yaml)).toThrow('executorType "ssh" but is missing required field "remoteTargetId" or "poolId"');
     });
 
     it('accepts executorType docker with dockerImage', () => {
@@ -733,6 +733,22 @@ tasks:
       const plan = parsePlan(yaml);
       expect(plan.tasks[0].executorType).toBe('ssh');
       expect(plan.tasks[0].remoteTargetId).toBe('prod-server-1');
+    });
+
+    it('accepts executorType ssh with poolId', () => {
+      const yaml = `
+name: SSH With Pool
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: deploy
+    description: Deploy via SSH pool
+    command: echo deploy
+    executorType: ssh
+    poolId: ssh-light
+`;
+      const plan = parsePlan(yaml);
+      expect(plan.tasks[0].executorType).toBe('ssh');
+      expect(plan.tasks[0].poolId).toBe('ssh-light');
     });
 
     it('accepts worktree executorType without docker or ssh fields', () => {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -100,19 +100,43 @@ export interface InvokerConfig {
      * Only used in managed mode. Default: pnpm install --frozen-lockfile
      */
     provisionCommand?: string;
+    /**
+     * Max concurrent tasks allowed on this target when used inside an execution pool.
+     * Default for pooled SSH members: 1.
+     */
+    maxConcurrentTasks?: number;
   }>;
   /**
-   * Config-owned routing policy for heavyweight shell commands.
-   * Matching tasks are auto-routed to the configured executor/target at plan submission time.
-   * Default matcher set for v1 is any command invoking `pnpm`.
+   * Named execution pools used by routing rules.
+   * Pools provide shared queue + drain semantics with per-member capacity limits.
+   */
+  executionPools?: Record<string, {
+    /** Pool executor substrate. */
+    type: 'worktree' | 'ssh';
+    /**
+     * Member IDs:
+     * - ssh pools: remote target IDs from `remoteTargets`
+     * - worktree pools: logical member IDs (for example ["local"])
+     */
+    members: string[];
+    /** Member selection strategy for available capacity. Default: roundRobin */
+    selectionStrategy?: 'roundRobin' | 'leastLoaded';
+    /** Fallback per-member cap when member-specific capacity is not set. */
+    maxConcurrentTasksPerMember?: number;
+  }>;
+  /**
+   * Deprecated compatibility alias for routing rules with `strategy: "route"`.
+   * Prefer `executorRoutingRules` for all command-routing policies.
    */
   heavyweightCommandRouting?: {
     /** Set false to disable heavyweight auto-routing without deleting the config block. */
     enabled?: boolean;
     /** Destination executor type. Default: "ssh". */
     executorType?: string;
-    /** Required destination remote target ID for heavyweight commands. */
-    remoteTargetId: string;
+    /** Destination remote target ID (legacy mode). */
+    remoteTargetId?: string;
+    /** Destination execution pool ID. */
+    poolId?: string;
     /** Optional command matchers; defaults to matching any `pnpm` invocation. */
     matchers?: Array<{
       pattern?: string;
@@ -120,19 +144,17 @@ export interface InvokerConfig {
     }>;
   };
   /**
-   * Pattern-based rules that enforce task execution environment conformance.
-   * When a rule matches a task command, the orchestrator validates that the task's
-   * executorType and remoteTargetId explicitly declared in the plan YAML match the
-   * rule's requirements. Rules do NOT fill in omitted fields — they enforce conformance.
-   * First matching rule wins.
+   * Pattern-based command routing rules.
    *
-   * Each rule may specify:
-   *   - `pattern`: substring matched against the task command (like utilizationRules)
-   *   - `regex`: compiled with `new RegExp(regex)` and tested against the command
+   * Rule strategies:
+   * - `enforce` (default): require matching tasks to already declare the same executor/destination.
+   * - `route`: auto-apply executor/destination when omitted; reject explicit conflicts.
+   *
+   * First matching rule wins per strategy bucket:
+   * - first matching `route` rule is applied
+   * - then first matching `enforce` rule validates the effective routing
    *
    * If both `pattern` and `regex` are present, a rule matches if either matches.
-   * Tasks with commands matching a rule MUST explicitly declare the required executorType
-   * and remoteTargetId in the plan YAML, or plan loading will fail with a validation error.
    * Only applies to tasks that have a command (not prompt-only tasks).
    */
   executorRoutingRules?: Array<{
@@ -142,8 +164,12 @@ export interface InvokerConfig {
     regex?: string;
     /** Required executor type for matching commands (e.g. "ssh", "docker", "worktree"). */
     executorType: string;
-    /** Required remote target ID for matching commands; must correspond to an entry in remoteTargets. */
-    remoteTargetId: string;
+    /** Required remote target ID for matching commands (legacy mode). */
+    remoteTargetId?: string;
+    /** Required execution pool ID for matching commands. */
+    poolId?: string;
+    /** Routing strategy. Defaults to "enforce". */
+    strategy?: 'enforce' | 'route';
   }>;
 }
 

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -61,6 +61,7 @@ export interface RawPlanTask {
   executorType?: string;
   dockerImage?: string;
   remoteTargetId?: string;
+  poolId?: string;
   executionAgent?: string;
 }
 
@@ -331,9 +332,9 @@ export function parsePlan(yamlContent: string): PlanDefinition {
         `Task "${task.id}" has executorType "docker" but is missing required field "dockerImage"`,
       );
     }
-    if (resolvedExecutorType === 'ssh' && !task.remoteTargetId) {
+    if (resolvedExecutorType === 'ssh' && !task.remoteTargetId && !task.poolId) {
       throw new PlanParseError(
-        `Task "${task.id}" has executorType "ssh" but is missing required field "remoteTargetId"`,
+        `Task "${task.id}" has executorType "ssh" but is missing required field "remoteTargetId" or "poolId"`,
       );
     }
 
@@ -351,6 +352,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       executorType: resolvedExecutorType,
       dockerImage: task.dockerImage,
       remoteTargetId: task.remoteTargetId,
+      poolId: task.poolId,
       executionAgent: task.executionAgent?.trim() || undefined,
     };
   });

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -36,6 +36,7 @@ export interface TaskConfig {
   readonly executorType?: string;
   readonly dockerImage?: string;
   readonly remoteTargetId?: string;
+  readonly poolId?: string;
   readonly autoFix?: boolean;
   readonly isMergeNode?: boolean;
   readonly summary?: string;

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1086,6 +1086,46 @@ describe('Orchestrator', () => {
         }).toThrow('requires remoteTargetId="prod-server"');
       });
 
+      it('validates matching rule with poolId destination', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          executorRoutingRules: [
+            { pattern: 'pnpm test', executorType: 'ssh', poolId: 'ssh-light' },
+          ],
+          availablePoolIds: ['ssh-light'],
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'pool-routing-test',
+          tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test', executorType: 'ssh', poolId: 'ssh-light' }],
+        });
+
+        const task = routedOrchestrator.getTask('t1');
+        expect(task!.config.executorType).toBe('ssh');
+        expect(task!.config.poolId).toBe('ssh-light');
+      });
+
+      it('throws when matching pool rule task omits poolId', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          executorRoutingRules: [
+            { pattern: 'pnpm test', executorType: 'ssh', poolId: 'ssh-light' },
+          ],
+          availablePoolIds: ['ssh-light'],
+        });
+
+        expect(() => {
+          routedOrchestrator.loadPlan({
+            name: 'missing-pool',
+            tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test', executorType: 'ssh' }],
+          });
+        }).toThrow('requires poolId="ssh-light"');
+      });
+
       it('merge node always has executorType merge regardless of routing rules', () => {
         const routedOrchestrator = new Orchestrator({
           persistence: new InMemoryPersistence(),
@@ -1106,19 +1146,19 @@ describe('Orchestrator', () => {
         expect(mergeNode!.config.executorType).toBe('merge');
       });
 
-      it('auto-routes pnpm test to heavyweight SSH target when executor is omitted', () => {
+      it('auto-routes pnpm test to SSH target with route strategy when executor is omitted', () => {
         const routedOrchestrator = new Orchestrator({
           persistence: new InMemoryPersistence(),
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
-          heavyweightCommandRouting: {
-            remoteTargetId: 'ci-box',
-          },
+          executorRoutingRules: [
+            { regex: '\\bpnpm(?:\\s|$)', executorType: 'ssh', remoteTargetId: 'ci-box', strategy: 'route' },
+          ],
           availableRemoteTargetIds: ['ci-box'],
         });
 
         routedOrchestrator.loadPlan({
-          name: 'heavyweight-routing-test',
+          name: 'route-strategy-test',
           tasks: [{ id: 't1', description: 'Run tests', command: 'cd packages/app && pnpm test' }],
         });
 
@@ -1127,73 +1167,73 @@ describe('Orchestrator', () => {
         expect(task!.config.remoteTargetId).toBe('ci-box');
       });
 
-      it('auto-routes pnpm install to heavyweight SSH target when executor is omitted', () => {
+      it('auto-routes matching command to configured poolId with route strategy', () => {
         const routedOrchestrator = new Orchestrator({
           persistence: new InMemoryPersistence(),
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
-          heavyweightCommandRouting: {
-            remoteTargetId: 'ci-box',
-          },
-          availableRemoteTargetIds: ['ci-box'],
+          executorRoutingRules: [
+            { regex: '\\bpnpm(?:\\s|$)', executorType: 'ssh', poolId: 'ssh-light', strategy: 'route' },
+          ],
+          availablePoolIds: ['ssh-light'],
         });
 
         routedOrchestrator.loadPlan({
-          name: 'heavyweight-install-routing-test',
-          tasks: [{ id: 't1', description: 'Install deps', command: 'pnpm install --frozen-lockfile' }],
+          name: 'route-strategy-pool-test',
+          tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test' }],
         });
 
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.executorType).toBe('ssh');
-        expect(task!.config.remoteTargetId).toBe('ci-box');
+        expect(task!.config.poolId).toBe('ssh-light');
       });
 
-      it('throws when heavyweight command explicitly declares conflicting local executor', () => {
+      it('throws when route strategy command explicitly declares conflicting executor', () => {
         const routedOrchestrator = new Orchestrator({
           persistence: new InMemoryPersistence(),
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
-          heavyweightCommandRouting: {
-            remoteTargetId: 'ci-box',
-          },
+          executorRoutingRules: [
+            { regex: '\\bpnpm(?:\\s|$)', executorType: 'ssh', remoteTargetId: 'ci-box', strategy: 'route' },
+          ],
           availableRemoteTargetIds: ['ci-box'],
         });
 
         expect(() => {
           routedOrchestrator.loadPlan({
-            name: 'heavyweight-conflict-test',
+            name: 'route-strategy-conflict-test',
             tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test', executorType: 'worktree' }],
           });
-        }).toThrow('matched heavyweight command routing');
+        }).toThrow('matched routing rule');
       });
 
-      it('throws when heavyweight command routing target is not configured', () => {
+      it('throws when route strategy target pool is not configured', () => {
         const routedOrchestrator = new Orchestrator({
           persistence: new InMemoryPersistence(),
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
-          heavyweightCommandRouting: {
-            remoteTargetId: 'ci-box',
-          },
-          availableRemoteTargetIds: [],
+          executorRoutingRules: [
+            { regex: '\\bpnpm(?:\\s|$)', executorType: 'ssh', poolId: 'ssh-light', strategy: 'route' },
+          ],
+          availablePoolIds: [],
         });
 
         expect(() => {
           routedOrchestrator.loadPlan({
-            name: 'heavyweight-missing-target',
+            name: 'route-strategy-missing-target',
             tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test' }],
           });
-        }).toThrow('no remoteTargets are configured');
+        }).toThrow('no executionPools are configured');
       });
 
-      it('leaves non-matching commands unchanged under heavyweight routing', () => {
+      it('leaves non-matching commands unchanged under route strategy', () => {
         const routedOrchestrator = new Orchestrator({
           persistence: new InMemoryPersistence(),
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
-          heavyweightCommandRouting: {
-            remoteTargetId: 'ci-box',
-          },
+          executorRoutingRules: [
+            { regex: '\\bpnpm(?:\\s|$)', executorType: 'ssh', remoteTargetId: 'ci-box', strategy: 'route' },
+          ],
           availableRemoteTargetIds: ['ci-box'],
         });
 
@@ -1205,6 +1245,27 @@ describe('Orchestrator', () => {
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.executorType).toBe('worktree');
         expect(task!.config.remoteTargetId).toBeUndefined();
+      });
+
+      it('keeps heavyweightCommandRouting as compatibility alias to route strategy', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          heavyweightCommandRouting: {
+            poolId: 'ssh-light',
+          },
+          availablePoolIds: ['ssh-light'],
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'heavyweight-compatibility-test',
+          tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test' }],
+        });
+
+        const task = routedOrchestrator.getTask('t1');
+        expect(task!.config.executorType).toBe('ssh');
+        expect(task!.config.poolId).toBe('ssh-light');
       });
     });
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -255,6 +255,7 @@ export interface PlanDefinition {
     executorType?: string;
     dockerImage?: string;
     remoteTargetId?: string;
+    poolId?: string;
     executionAgent?: string;
   }>;
 }
@@ -378,7 +379,7 @@ export interface ExternalGatePolicyUpdate {
 /**
  * A single routing rule that validates task execution environment against command patterns.
  * When a rule matches a task command, the orchestrator validates that the task's
- * executorType and remoteTargetId conform to the rule's requirements.
+ * executorType and destination (remoteTargetId or poolId) conform to the rule's requirements.
  */
 export interface ExecutorRoutingRule {
   /** Substring to match against the task command. */
@@ -387,8 +388,16 @@ export interface ExecutorRoutingRule {
   regex?: string;
   /** Required executor type for matching commands (e.g. "ssh", "docker", "worktree"). */
   executorType: string;
-  /** Required remote target ID for matching commands; must correspond to an entry in remoteTargets. */
-  remoteTargetId: string;
+  /** Required remote target ID for matching commands (legacy mode). */
+  remoteTargetId?: string;
+  /** Required execution pool ID for matching commands. */
+  poolId?: string;
+  /**
+   * Rule behavior:
+   * - enforce (default): task must already declare matching executor/destination
+   * - route: auto-apply rule executor/destination when omitted, and reject conflicts
+   */
+  strategy?: 'enforce' | 'route';
 }
 
 export interface CommandRoutingMatcher {
@@ -399,7 +408,8 @@ export interface CommandRoutingMatcher {
 export interface HeavyweightCommandRoutingPolicy {
   enabled?: boolean;
   executorType?: string;
-  remoteTargetId: string;
+  remoteTargetId?: string;
+  poolId?: string;
   matchers?: CommandRoutingMatcher[];
 }
 
@@ -407,78 +417,146 @@ const DEFAULT_HEAVYWEIGHT_COMMAND_MATCHERS: CommandRoutingMatcher[] = [
   { regex: '\\bpnpm(?:\\s|$)' },
 ];
 
-function findMatchingCommandRoutingMatcher(
+function validateRoutingDestinationShape(
+  taskId: string,
   command: string,
-  matchers: CommandRoutingMatcher[],
-): CommandRoutingMatcher | undefined {
-  for (const matcher of matchers) {
-    const patternMatch = matcher.pattern !== undefined && command.includes(matcher.pattern);
-    const regexMatch = matcher.regex !== undefined && new RegExp(matcher.regex).test(command);
-    if (patternMatch || regexMatch) {
-      return matcher;
-    }
+  sourceLabel: string,
+  remoteTargetId: string | undefined,
+  poolId: string | undefined,
+): void {
+  if (remoteTargetId && poolId) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
+      'but config must set exactly one destination: remoteTargetId or poolId.',
+    );
   }
-  return undefined;
 }
 
-function resolveHeavyweightCommandRouting(
+function validateRoutingDestinationAvailability(
   taskId: string,
-  command: string | undefined,
-  planExecutorType: string | undefined,
-  planRemoteTargetId: string | undefined,
-  policy: HeavyweightCommandRoutingPolicy | undefined,
+  command: string,
+  sourceLabel: string,
+  remoteTargetId: string | undefined,
+  poolId: string | undefined,
   availableRemoteTargetIds: Set<string>,
-): { executorType?: string; remoteTargetId?: string } | undefined {
-  if (!command || !policy || policy.enabled === false) {
-    return undefined;
+  availablePoolIds: Set<string>,
+): void {
+  if (remoteTargetId) {
+    if (availableRemoteTargetIds.size > 0 && !availableRemoteTargetIds.has(remoteTargetId)) {
+      throw new Error(
+        `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
+        `but config remoteTargetId="${remoteTargetId}" is not defined in remoteTargets.`,
+      );
+    }
+    if (availableRemoteTargetIds.size === 0) {
+      throw new Error(
+        `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
+        'but no remoteTargets are configured.',
+      );
+    }
+  }
+
+  if (poolId) {
+    if (availablePoolIds.size > 0 && !availablePoolIds.has(poolId)) {
+      throw new Error(
+        `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
+        `but config poolId="${poolId}" is not defined in executionPools.`,
+      );
+    }
+    if (availablePoolIds.size === 0) {
+      throw new Error(
+        `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
+        'but no executionPools are configured.',
+      );
+    }
+  }
+}
+
+function buildHeavyweightRoutingRules(
+  taskId: string,
+  policy: HeavyweightCommandRoutingPolicy | undefined,
+): ExecutorRoutingRule[] {
+  if (!policy || policy.enabled === false) {
+    return [];
   }
 
   const matchers = policy.matchers?.length ? policy.matchers : DEFAULT_HEAVYWEIGHT_COMMAND_MATCHERS;
-  const matched = findMatchingCommandRoutingMatcher(command, matchers);
-  if (!matched) {
-    return undefined;
-  }
-
-  const policyExecutorType = normalizeExecutorType(policy.executorType) ?? 'ssh';
-  if (policyExecutorType !== 'ssh') {
+  if (policy.remoteTargetId && policy.poolId) {
     throw new Error(
-      `Task "${taskId}" with command "${command}" matched heavyweight command routing, ` +
-      `but config executorType="${policyExecutorType}" is unsupported. Expected "ssh".`,
+      `Task "${taskId}" matched heavyweight command routing, ` +
+      'but config must set exactly one destination: remoteTargetId or poolId.',
+    );
+  }
+  if (!policy.remoteTargetId && !policy.poolId) {
+    throw new Error(
+      `Task "${taskId}" matched heavyweight command routing, ` +
+      'but config is missing destination: set remoteTargetId or poolId.',
     );
   }
 
-  if (availableRemoteTargetIds.size > 0 && !availableRemoteTargetIds.has(policy.remoteTargetId)) {
+  const executorType = normalizeExecutorType(policy.executorType) ?? 'ssh';
+  if (executorType !== 'ssh') {
     throw new Error(
-      `Task "${taskId}" with command "${command}" matched heavyweight command routing, ` +
-      `but config remoteTargetId="${policy.remoteTargetId}" is not defined in remoteTargets.`,
+      `Task "${taskId}" matched heavyweight command routing, ` +
+      `but config executorType="${executorType}" is unsupported. Expected "ssh".`,
     );
   }
 
-  if (availableRemoteTargetIds.size === 0) {
-    throw new Error(
-      `Task "${taskId}" with command "${command}" matched heavyweight command routing, ` +
-      `but no remoteTargets are configured.`,
-    );
-  }
-
-  const normalizedPlanType = normalizeExecutorType(planExecutorType) ?? 'worktree';
-  if (planExecutorType !== undefined && normalizedPlanType !== policyExecutorType) {
-    throw new Error(
-      `Task "${taskId}" with command "${command}" matched heavyweight command routing and must use ` +
-      `executorType="${policyExecutorType}", but plan declares executorType="${normalizedPlanType}"`,
-    );
-  }
-
-  if (planRemoteTargetId !== undefined && planRemoteTargetId !== policy.remoteTargetId) {
-    throw new Error(
-      `Task "${taskId}" with command "${command}" matched heavyweight command routing and must use ` +
-      `remoteTargetId="${policy.remoteTargetId}", but plan declares remoteTargetId="${planRemoteTargetId}"`,
-    );
-  }
-
-  return {
-    executorType: policyExecutorType,
+  return matchers.map((matcher) => ({
+    pattern: matcher.pattern,
+    regex: matcher.regex,
+    executorType,
     remoteTargetId: policy.remoteTargetId,
+    poolId: policy.poolId,
+    strategy: 'route',
+  }));
+}
+
+function applyRoutingRule(
+  taskId: string,
+  command: string,
+  planExecutorType: string | undefined,
+  planRemoteTargetId: string | undefined,
+  planPoolId: string | undefined,
+  rule: ExecutorRoutingRule,
+  sourceLabel: string,
+  availableRemoteTargetIds: Set<string>,
+  availablePoolIds: Set<string>,
+): { executorType?: string; remoteTargetId?: string; poolId?: string } | undefined {
+  const normalizedRuleType = normalizeExecutorType(rule.executorType) ?? rule.executorType;
+  validateRoutingDestinationShape(taskId, command, sourceLabel, rule.remoteTargetId, rule.poolId);
+  validateRoutingDestinationAvailability(
+    taskId,
+    command,
+    sourceLabel,
+    rule.remoteTargetId,
+    rule.poolId,
+    availableRemoteTargetIds,
+    availablePoolIds,
+  );
+  const normalizedPlanType = normalizeExecutorType(planExecutorType) ?? 'worktree';
+  if (planExecutorType !== undefined && normalizedPlanType !== normalizedRuleType) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched ${sourceLabel} and must use ` +
+      `executorType="${normalizedRuleType}", but plan declares executorType="${normalizedPlanType}"`,
+    );
+  }
+  if (rule.remoteTargetId && planRemoteTargetId !== undefined && planRemoteTargetId !== rule.remoteTargetId) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched ${sourceLabel} and must use ` +
+      `remoteTargetId="${rule.remoteTargetId}", but plan declares remoteTargetId="${planRemoteTargetId}"`,
+    );
+  }
+  if (rule.poolId && planPoolId !== undefined && planPoolId !== rule.poolId) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched ${sourceLabel} and must use ` +
+      `poolId="${rule.poolId}", but plan declares poolId="${planPoolId}"`,
+    );
+  }
+  return {
+    executorType: normalizedRuleType,
+    remoteTargetId: rule.remoteTargetId ?? planRemoteTargetId,
+    poolId: rule.poolId ?? planPoolId,
   };
 }
 
@@ -513,6 +591,7 @@ export function assertExecutorRoutingConforms(
   command: string | undefined,
   planExecutorType: string | undefined,
   planRemoteTargetId: string | undefined,
+  planPoolId: string | undefined,
   rules: ExecutorRoutingRule[],
 ): void {
   if (!command || rules.length === 0) {
@@ -522,6 +601,13 @@ export function assertExecutorRoutingConforms(
   const matchingRule = findMatchingExecutorRoutingRule(command, rules);
   if (!matchingRule) {
     return;
+  }
+
+  if (matchingRule.remoteTargetId && matchingRule.poolId) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched an invalid routing rule: ` +
+      'rule must set exactly one destination (remoteTargetId or poolId).',
+    );
   }
 
   // Normalize both plan and rule executorType the same way createTaskState does
@@ -535,12 +621,76 @@ export function assertExecutorRoutingConforms(
     );
   }
 
-  if (planRemoteTargetId !== matchingRule.remoteTargetId) {
+  if (matchingRule.remoteTargetId && planRemoteTargetId !== matchingRule.remoteTargetId) {
     throw new Error(
       `Task "${taskId}" with command "${command}" requires remoteTargetId="${matchingRule.remoteTargetId}" ` +
       `but plan declares remoteTargetId="${planRemoteTargetId ?? '(undefined)'}"`
     );
   }
+  if (matchingRule.poolId && planPoolId !== matchingRule.poolId) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" requires poolId="${matchingRule.poolId}" ` +
+      `but plan declares poolId="${planPoolId ?? '(undefined)'}"`
+    );
+  }
+}
+
+function resolveExecutorRouting(
+  taskId: string,
+  command: string | undefined,
+  planExecutorType: string | undefined,
+  planRemoteTargetId: string | undefined,
+  planPoolId: string | undefined,
+  rules: ExecutorRoutingRule[],
+  availableRemoteTargetIds: Set<string>,
+  availablePoolIds: Set<string>,
+): { executorType?: string; remoteTargetId?: string; poolId?: string } {
+  if (!command || rules.length === 0) {
+    return {
+      executorType: planExecutorType,
+      remoteTargetId: planRemoteTargetId,
+      poolId: planPoolId,
+    };
+  }
+
+  let effectiveExecutorType = planExecutorType;
+  let effectiveRemoteTargetId = planRemoteTargetId;
+  let effectivePoolId = planPoolId;
+
+  const routingRules = rules.filter((rule) => (rule.strategy ?? 'enforce') === 'route');
+  const matchingRoutingRule = findMatchingExecutorRoutingRule(command, routingRules);
+  if (matchingRoutingRule) {
+    const routed = applyRoutingRule(
+      taskId,
+      command,
+      effectiveExecutorType,
+      effectiveRemoteTargetId,
+      effectivePoolId,
+      matchingRoutingRule,
+      'routing rule',
+      availableRemoteTargetIds,
+      availablePoolIds,
+    );
+    effectiveExecutorType = routed?.executorType ?? effectiveExecutorType;
+    effectiveRemoteTargetId = routed?.remoteTargetId ?? effectiveRemoteTargetId;
+    effectivePoolId = routed?.poolId ?? effectivePoolId;
+  }
+
+  const enforcementRules = rules.filter((rule) => (rule.strategy ?? 'enforce') === 'enforce');
+  assertExecutorRoutingConforms(
+    taskId,
+    command,
+    effectiveExecutorType,
+    effectiveRemoteTargetId,
+    effectivePoolId,
+    enforcementRules,
+  );
+
+  return {
+    executorType: effectiveExecutorType,
+    remoteTargetId: effectiveRemoteTargetId,
+    poolId: effectivePoolId,
+  };
 }
 
 /**
@@ -593,13 +743,19 @@ export interface OrchestratorConfig {
   /**
    * Rules that validate task execution environment against command patterns.
    * When loading a plan, the orchestrator validates that tasks with commands matching
-   * a rule have the required executorType and remoteTargetId specified in the plan.
+   * a rule have the required executorType and destination (remoteTargetId or poolId)
+   * specified in the plan.
    */
   executorRoutingRules?: ExecutorRoutingRule[];
-  /** Config-owned routing for heavyweight commands (for example `pnpm ...`). */
+  /**
+   * Deprecated compatibility alias for config-owned heavyweight command routing.
+   * Internally translated into executorRoutingRules with strategy="route".
+   */
   heavyweightCommandRouting?: HeavyweightCommandRoutingPolicy;
   /** Valid SSH remote target IDs available at plan submission time. */
   availableRemoteTargetIds?: string[];
+  /** Valid execution pool IDs available at plan submission time. */
+  availablePoolIds?: string[];
   /**
    * When true, keep tasks persisted as `pending` until the executor confirms
    * startup success, then transition to `running`.
@@ -624,8 +780,8 @@ export class Orchestrator {
   private readonly taskRepository: TaskRepository;
   private readonly maxConcurrency: number;
   private readonly executorRoutingRules: ExecutorRoutingRule[];
-  private readonly heavyweightCommandRouting?: HeavyweightCommandRoutingPolicy;
   private readonly availableRemoteTargetIds: Set<string>;
+  private readonly availablePoolIds: Set<string>;
   private readonly defaultAutoFixRetries: number;
   private readonly deferRunningUntilLaunch: boolean;
 
@@ -685,9 +841,12 @@ export class Orchestrator {
     this.messageBus = config.messageBus;
     this.logger = config.logger ?? noopLogger;
     this.taskRepository = config.taskRepository ?? taskRepositoryFromPersistence(config.persistence);
-    this.executorRoutingRules = config.executorRoutingRules ?? [];
-    this.heavyweightCommandRouting = config.heavyweightCommandRouting;
+    this.executorRoutingRules = [
+      ...(config.executorRoutingRules ?? []),
+      ...buildHeavyweightRoutingRules('config', config.heavyweightCommandRouting),
+    ];
     this.availableRemoteTargetIds = new Set(config.availableRemoteTargetIds ?? []);
+    this.availablePoolIds = new Set(config.availablePoolIds ?? []);
     this.defaultAutoFixRetries = Math.min(Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0)), 10);
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
 
@@ -1230,25 +1389,19 @@ export class Orchestrator {
 
     const validatedTasks: TaskState[] = [];
     for (const taskDef of plan.tasks) {
-      const resolvedHeavyweightRouting = resolveHeavyweightCommandRouting(
+      const resolvedRouting = resolveExecutorRouting(
         taskDef.id,
         taskDef.command,
         taskDef.executorType,
         taskDef.remoteTargetId,
-        this.heavyweightCommandRouting,
-        this.availableRemoteTargetIds,
-      );
-      const effectiveExecutorType = resolvedHeavyweightRouting?.executorType ?? taskDef.executorType;
-      const effectiveRemoteTargetId = resolvedHeavyweightRouting?.remoteTargetId ?? taskDef.remoteTargetId;
-
-      // Validate executor routing conformance for tasks with commands
-      assertExecutorRoutingConforms(
-        taskDef.id,
-        taskDef.command,
-        effectiveExecutorType,
-        effectiveRemoteTargetId,
+        taskDef.poolId,
         this.executorRoutingRules,
+        this.availableRemoteTargetIds,
+        this.availablePoolIds,
       );
+      const effectiveExecutorType = resolvedRouting.executorType;
+      const effectiveRemoteTargetId = resolvedRouting.remoteTargetId;
+      const effectivePoolId = resolvedRouting.poolId;
 
       const scopedId = localToScoped.get(taskDef.id)!;
       const scopedDeps = (taskDef.dependencies ?? []).map((dep) => {
@@ -1275,6 +1428,7 @@ export class Orchestrator {
         featureBranch: taskDef.featureBranch,
         executionAgent: taskDef.executionAgent,
         externalDependencies,
+        poolId: effectivePoolId,
       } as const;
       const executorType = normalizeExecutorType(effectiveExecutorType) ?? 'worktree';
       let taskConfig: TaskConfig;
@@ -3292,6 +3446,7 @@ export class Orchestrator {
         command: rt.command,
         prompt: rt.prompt,
         executionAgent: rt.executionAgent ?? task.config.executionAgent,
+        poolId: task.config.poolId,
       } as const;
       // Replacement tasks inherit executor config from the parent task.
       // The switch narrows the config so TS accepts the correct variant.

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -45,6 +45,8 @@ export interface BaseTaskConfig {
   readonly externalDependencies?: readonly ExternalDependency[];
   /** Remote target identifier for executor routing. Primarily used by SSH executors but can be set on any task via routing rules. */
   readonly remoteTargetId?: string;
+  /** Execution pool identifier for shared queue/drain scheduling across substrates. */
+  readonly poolId?: string;
   /**
    * Fix-session prompt override carried on the failed task across the
    * `failed` → `fixing_with_ai` → `failed` cycle (Step 10 of the


### PR DESCRIPTION
This introduces poolId-aware SSH plan validation and carries pool destination metadata through graph task types for downstream routing.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #496