### PR TITLE
[superseded] Track pool destination in workflow invalidation metadata.

### DIFF
--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -32,6 +32,7 @@ export type MutationKey =
   | 'executionAgent'
   | 'executorType'
   | 'remoteTargetId'
+  | 'poolId'
   | 'selectedExperiment'
   | 'selectedExperimentSet'
   | 'mergeMode'
@@ -48,6 +49,7 @@ export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>
   executionAgent:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   executorType:          { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
   remoteTargetId:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
+  poolId:                { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   selectedExperiment:    { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   selectedExperimentSet: { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   mergeMode:             { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },


### PR DESCRIPTION
## Summary
Track `poolId` in workflow invalidation mutation metadata so retry/recreate/invalidation logic preserves pool routing context.
This keeps invalidation behavior consistent for pool-routed SSH tasks.

## Architecture

### Before

```mermaid
flowchart LR
  taskState[Task state] --> mutationKey[Invalidation mutation key]
  mutationKey --> policy[Invalidation policy]
```

### After

```mermaid
flowchart LR
  taskState[Task state with poolId] --> mutationKey[Invalidation mutation key includes poolId]
  mutationKey --> policy[Invalidation policy]
  policy --> rerun[Rerun preserves pool destination context]
```

## Test Plan
- [x] `cd packages/workflow-core && pnpm test -- src/__tests__/orchestrator.test.ts`

## Revert Plan
- Safe to revert? Yes
- Revert command: `git revert cffaf11`
- Post-revert steps: None
- Data migration? No
