### PR TITLE
[superseded] Add pool-aware plan parsing plumbing.

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -689,7 +689,7 @@ tasks:
       expect(() => parsePlan(yaml)).toThrow('executorType "docker" but is missing required field "dockerImage"');
     });
 
-    it('rejects executorType ssh without remoteTargetId', () => {
+    it('rejects executorType ssh without remoteTargetId or poolId', () => {
       const yaml = `
 name: SSH No Target
 repoUrl: git@github.com:test/repo.git
@@ -700,7 +700,7 @@ tasks:
     executorType: ssh
 `;
       expect(() => parsePlan(yaml)).toThrow(PlanParseError);
-      expect(() => parsePlan(yaml)).toThrow('executorType "ssh" but is missing required field "remoteTargetId"');
+      expect(() => parsePlan(yaml)).toThrow('executorType "ssh" but is missing required field "remoteTargetId" or "poolId"');
     });
 
     it('accepts executorType docker with dockerImage', () => {
@@ -733,6 +733,22 @@ tasks:
       const plan = parsePlan(yaml);
       expect(plan.tasks[0].executorType).toBe('ssh');
       expect(plan.tasks[0].remoteTargetId).toBe('prod-server-1');
+    });
+
+    it('accepts executorType ssh with poolId', () => {
+      const yaml = `
+name: SSH With Pool
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: deploy
+    description: Deploy via SSH pool
+    command: echo deploy
+    executorType: ssh
+    poolId: ssh-light
+`;
+      const plan = parsePlan(yaml);
+      expect(plan.tasks[0].executorType).toBe('ssh');
+      expect(plan.tasks[0].poolId).toBe('ssh-light');
     });
 
     it('accepts worktree executorType without docker or ssh fields', () => {

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -61,6 +61,7 @@ export interface RawPlanTask {
   executorType?: string;
   dockerImage?: string;
   remoteTargetId?: string;
+  poolId?: string;
   executionAgent?: string;
 }
 
@@ -331,9 +332,9 @@ export function parsePlan(yamlContent: string): PlanDefinition {
         `Task "${task.id}" has executorType "docker" but is missing required field "dockerImage"`,
       );
     }
-    if (resolvedExecutorType === 'ssh' && !task.remoteTargetId) {
+    if (resolvedExecutorType === 'ssh' && !task.remoteTargetId && !task.poolId) {
       throw new PlanParseError(
-        `Task "${task.id}" has executorType "ssh" but is missing required field "remoteTargetId"`,
+        `Task "${task.id}" has executorType "ssh" but is missing required field "remoteTargetId" or "poolId"`,
       );
     }
 
@@ -351,6 +352,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       executorType: resolvedExecutorType,
       dockerImage: task.dockerImage,
       remoteTargetId: task.remoteTargetId,
+      poolId: task.poolId,
       executionAgent: task.executionAgent?.trim() || undefined,
     };
   });


### PR DESCRIPTION
## Summary
Add pool-aware plan parsing updates so SSH tasks can use `poolId` during plan ingestion and validation.
This PR keeps routing behavior unchanged and focuses on parser-level support and tests.

## Architecture

### Before

```mermaid
flowchart LR
  yaml[Plan YAML task] --> parser[plan-parser]
  parser --> sshValidate[SSH requires remoteTargetId only]
```

### After

```mermaid
flowchart LR
  yaml[Plan YAML task] --> parser[plan-parser]
  parser --> sshValidate[SSH requires remoteTargetId or poolId]
  sshValidate --> taskConfig[TaskConfig carries pool destination]
```

## Test Plan
- [x] `cd packages/app && pnpm test -- src/__tests__/plan-parser.test.ts` (known pre-existing unhandled worker timeout still occurs)

## Revert Plan
- Safe to revert? Yes
- Revert command: `git revert bb2dcd6`
- Post-revert steps: None
- Data migration? No
