### PR TITLE
Fix SSH heartbeat stalls during post-close finalization

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -30,6 +30,7 @@ function createMockProcess(): ChildProcess & EventEmitter {
   (proc as any).stdin = { write: vi.fn(), end: vi.fn() };
   (proc as any).pid = 12345;
   (proc as any).killed = false;
+  (proc as any).exitCode = null;
   proc.kill = vi.fn().mockReturnValue(true);
 
   return proc;
@@ -847,6 +848,41 @@ describe('SshExecutor entry lifecycle', () => {
     expect((ssh as any).entries.size).toBe(0);
 
     await expect(ssh.destroyAll()).resolves.toBeUndefined();
+  });
+
+  it('keeps heartbeats alive while close finalization is pending', async () => {
+    const request = makeRequest({
+      inputs: {
+        command: 'echo hello',
+        repoUrl: 'git@github.com:test/repo.git',
+      },
+    });
+    (ssh as any).heartbeatIntervalMs = 20;
+    const finalizeDeferred = createDeferred<{ commitHash?: string; error?: string }>();
+    vi.spyOn(ssh as any, 'remoteGitRecordAndPush').mockImplementation(() => finalizeDeferred.promise);
+
+    const handle = await ssh.start(request);
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    (sshProcess as any).exitCode = 0;
+
+    let heartbeatCount = 0;
+    let completed = false;
+    ssh.onHeartbeat(handle, () => {
+      heartbeatCount += 1;
+    });
+    ssh.onComplete(handle, () => {
+      completed = true;
+    });
+
+    sshProcess.emit('close', 0, null);
+    await new Promise((r) => setTimeout(r, 80));
+
+    expect(completed).toBe(false);
+    expect(heartbeatCount).toBeGreaterThan(0);
+
+    finalizeDeferred.resolve({ commitHash: 'abc123' });
+    await new Promise((r) => setTimeout(r, 80));
+    expect(completed).toBe(true);
   });
 
   it('preserves stdout on execRemoteCapture error (Bug #4)', async () => {

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -33,6 +33,12 @@ export interface BaseEntry {
   heartbeatTimer?: ReturnType<typeof setInterval>;
   /** Timestamp when the heartbeat was started, for max duration enforcement. */
   heartbeatStartedAt?: number;
+  /**
+   * True while the child process has already closed but completion is intentionally
+   * deferred (for example, remote finalize/push). Keeps heartbeats alive so the
+   * orchestrator lease does not expire in this post-close window.
+   */
+  finalizingAfterClose?: boolean;
 }
 
 export interface ClaudeSessionParams {
@@ -187,6 +193,10 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
       }
 
       if (child.exitCode !== null || child.killed) {
+        if (entry.finalizingAfterClose) {
+          this.emitHeartbeat(executionId);
+          return;
+        }
         clearInterval(entry.heartbeatTimer);
         entry.heartbeatTimer = undefined;
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -585,83 +585,99 @@ echo ${payloadB64} | base64 -d | bash -se
       void (async () => {
         const exitCode = code ?? (signal ? 1 : 0);
         const e = this.entries.get(executionId);
-        if (e) e.completed = true;
-
-        let status: 'completed' | 'failed' = exitCode === 0 ? 'completed' : 'failed';
-        let mappedError: string | undefined;
-        if (exitCode === 30) {
-          mappedError = 'Upstream branch missing on remote clone';
-        } else if (exitCode === 31) {
-          const output = e?.outputBuffer.join('') ?? '';
-          const branchMatch = output.match(/MERGE_CONFLICT_BRANCH=(.+)/);
-          const filesSection = output.match(/MERGE_CONFLICT_FILES:\n([\s\S]*?)(?:\n\[Ssh|$)/);
-          const branch = branchMatch?.[1]?.trim() ?? 'unknown';
-          const files = filesSection?.[1]?.trim() ?? '(see task output)';
-          mappedError = `Merge conflict merging upstream branch "${branch}" on remote.\nConflicting files:\n${files}`;
-        }
-
-        let commitHash: string | undefined;
-
-        if (finalizeRemote) {
-          this.emitOutput(executionId, '[SshExecutor] Recording task result and pushing branch on remote...\n');
-          const fin = await this.remoteGitRecordAndPush(
-            executionId,
-            request,
-            finalizeRemote.worktreePath,
-            finalizeRemote.branch,
-            exitCode,
-          );
-          if (fin.commitHash) commitHash = fin.commitHash;
-          if (fin.error) {
-            this.emitOutput(executionId, `[SshExecutor] ${fin.error}\n`);
-            if (exitCode === 0) status = 'failed';
-            mappedError = fin.error;
+        if (e) e.finalizingAfterClose = true;
+        try {
+          let status: 'completed' | 'failed' = exitCode === 0 ? 'completed' : 'failed';
+          let mappedError: string | undefined;
+          if (exitCode === 30) {
+            mappedError = 'Upstream branch missing on remote clone';
+          } else if (exitCode === 31) {
+            const output = e?.outputBuffer.join('') ?? '';
+            const branchMatch = output.match(/MERGE_CONFLICT_BRANCH=(.+)/);
+            const filesSection = output.match(/MERGE_CONFLICT_FILES:\n([\s\S]*?)(?:\n\[Ssh|$)/);
+            const branch = branchMatch?.[1]?.trim() ?? 'unknown';
+            const files = filesSection?.[1]?.trim() ?? '(see task output)';
+            mappedError = `Merge conflict merging upstream branch "${branch}" on remote.\nConflicting files:\n${files}`;
           }
-        }
 
-        // When the command fails but no specific error was mapped (exit 30/31),
-        // capture the tail of the output buffer so the UI shows what went wrong.
-        if (!mappedError && exitCode !== 0 && e) {
-          const allOutput = e.outputBuffer.join('');
-          const lines = allOutput.split('\n');
-          const tail = lines.slice(-50).join('\n').trim();
-          if (tail) {
-            mappedError = tail.length > 3000 ? tail.slice(-3000) : tail;
-          }
-        }
+          let commitHash: string | undefined;
 
-        // Replace local UUID with real backend session/thread ID for resume,
-        // then store session locally via driver (matches worktree-executor pattern).
-        if (entry.agentSessionId && this.agentRegistry) {
-          const agentName = request.inputs.executionAgent ?? 'claude';
-          const driver = this.agentRegistry.getSessionDriver(agentName);
-          const rawOutput = e?.outputBuffer.join('') ?? '';
-          const realId = driver?.extractSessionId?.(rawOutput);
-          if (realId) {
-            entry.agentSessionId = realId;
+          if (finalizeRemote) {
+            this.emitOutput(executionId, '[SshExecutor] Recording task result and pushing branch on remote...\n');
+            const fin = await this.remoteGitRecordAndPush(
+              executionId,
+              request,
+              finalizeRemote.worktreePath,
+              finalizeRemote.branch,
+              exitCode,
+            );
+            if (fin.commitHash) commitHash = fin.commitHash;
+            if (fin.error) {
+              this.emitOutput(executionId, `[SshExecutor] ${fin.error}\n`);
+              if (exitCode === 0) status = 'failed';
+              mappedError = fin.error;
+            }
           }
-          if (driver) {
-            driver.processOutput(entry.agentSessionId!, rawOutput);
-          }
-        }
 
-        const finalExitCode = status === 'failed' && exitCode === 0 ? 1 : exitCode;
-        const response: WorkResponse = {
-          requestId: request.requestId,
-          actionId: request.actionId,
-          executionGeneration: request.executionGeneration,
-          status,
-          outputs: {
-            exitCode: finalExitCode,
-            commitHash,
-            agentSessionId: entry.agentSessionId,
-            ...(mappedError ? { error: mappedError } : {}),
-            ...(finalizeRemote && commitHash
-              ? { summary: `branch=${finalizeRemote.branch} commit=${commitHash}` }
-              : {}),
-          },
-        };
-        this.emitComplete(executionId, response);
+          // When the command fails but no specific error was mapped (exit 30/31),
+          // capture the tail of the output buffer so the UI shows what went wrong.
+          if (!mappedError && exitCode !== 0 && e) {
+            const allOutput = e.outputBuffer.join('');
+            const lines = allOutput.split('\n');
+            const tail = lines.slice(-50).join('\n').trim();
+            if (tail) {
+              mappedError = tail.length > 3000 ? tail.slice(-3000) : tail;
+            }
+          }
+
+          // Replace local UUID with real backend session/thread ID for resume,
+          // then store session locally via driver (matches worktree-executor pattern).
+          if (entry.agentSessionId && this.agentRegistry) {
+            const agentName = request.inputs.executionAgent ?? 'claude';
+            const driver = this.agentRegistry.getSessionDriver(agentName);
+            const rawOutput = e?.outputBuffer.join('') ?? '';
+            const realId = driver?.extractSessionId?.(rawOutput);
+            if (realId) {
+              entry.agentSessionId = realId;
+            }
+            if (driver) {
+              driver.processOutput(entry.agentSessionId!, rawOutput);
+            }
+          }
+
+          const finalExitCode = status === 'failed' && exitCode === 0 ? 1 : exitCode;
+          const response: WorkResponse = {
+            requestId: request.requestId,
+            actionId: request.actionId,
+            executionGeneration: request.executionGeneration,
+            status,
+            outputs: {
+              exitCode: finalExitCode,
+              commitHash,
+              agentSessionId: entry.agentSessionId,
+              ...(mappedError ? { error: mappedError } : {}),
+              ...(finalizeRemote && commitHash
+                ? { summary: `branch=${finalizeRemote.branch} commit=${commitHash}` }
+                : {}),
+            },
+          };
+          if (e) e.finalizingAfterClose = false;
+          this.emitComplete(executionId, response);
+        } catch (err) {
+          if (e) e.finalizingAfterClose = false;
+          const response: WorkResponse = {
+            requestId: request.requestId,
+            actionId: request.actionId,
+            executionGeneration: request.executionGeneration,
+            status: 'failed',
+            outputs: {
+              exitCode: exitCode === 0 ? 1 : exitCode,
+              agentSessionId: entry.agentSessionId,
+              error: err instanceof Error ? (err.stack ?? err.message) : String(err),
+            },
+          };
+          this.emitComplete(executionId, response);
+        }
       })();
     });
 

--- a/scripts/repro/repro-heartbeat-timeout-after-close-finalize-hang.sh
+++ b/scripts/repro/repro-heartbeat-timeout-after-close-finalize-hang.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+# Repro: heartbeats stop after child close while completion is delayed.
+#
+# This models the SSH executor close-path shape:
+# - Child process exits quickly.
+# - Entry is marked completed immediately in close handler.
+# - Post-exit finalize work hangs (record/push).
+# - Heartbeat timer stops, so watchdog sees stale heartbeat and fails task.
+#
+# Usage:
+#   bash scripts/repro/repro-heartbeat-timeout-after-close-finalize-hang.sh
+#
+set -euo pipefail
+
+python3 - <<'PY'
+from __future__ import annotations
+
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+
+HEARTBEAT_INTERVAL_S = 0.5
+WATCHDOG_TIMEOUT_S = 3.0
+FINALIZE_HANG_S = 4.5
+
+
+@dataclass
+class Entry:
+    completed: bool = False
+    last_heartbeat: float = 0.0
+    completion_emitted: bool = False
+    child_closed: bool = False
+
+
+entry = Entry(last_heartbeat=time.monotonic())
+lock = threading.Lock()
+events: list[str] = []
+
+
+def log(msg: str) -> None:
+    now = time.monotonic()
+    events.append(f"{now:.3f} {msg}")
+
+
+def heartbeat_loop(proc: subprocess.Popen[str]) -> None:
+    while True:
+        time.sleep(HEARTBEAT_INTERVAL_S)
+        with lock:
+            if entry.completed:
+                log("heartbeat_loop: stop (entry.completed=true)")
+                return
+            if proc.poll() is not None:
+                # Mirrors BaseExecutor.startHeartbeat orphan fallback.
+                log("heartbeat_loop: child exited before completion; would emit orphan failure")
+                entry.completion_emitted = True
+                return
+            entry.last_heartbeat = time.monotonic()
+            log("heartbeat")
+
+
+def close_handler(proc: subprocess.Popen[str]) -> None:
+    proc.wait()
+    with lock:
+        entry.child_closed = True
+        # Mirrors ssh-executor close callback: mark completed before finalize.
+        entry.completed = True
+        log("close_handler: child closed; mark completed=true; start finalize")
+    # Simulate hanging remoteGitRecordAndPush.
+    time.sleep(FINALIZE_HANG_S)
+    with lock:
+        entry.completion_emitted = True
+        log("close_handler: finalize done; emit completion")
+
+
+proc = subprocess.Popen(["bash", "-lc", "exit 0"], text=True)
+threading.Thread(target=heartbeat_loop, args=(proc,), daemon=True).start()
+threading.Thread(target=close_handler, args=(proc,), daemon=True).start()
+
+start = time.monotonic()
+watchdog_fired = False
+while time.monotonic() - start < WATCHDOG_TIMEOUT_S + 2.0:
+    time.sleep(0.1)
+    with lock:
+        heartbeat_age = time.monotonic() - entry.last_heartbeat
+        handle_present = True  # Entry/handle still exists until completion callback.
+        if (not entry.completion_emitted) and handle_present and heartbeat_age >= WATCHDOG_TIMEOUT_S:
+            log(
+                "watchdog: STALL "
+                f"(handlePresent={handle_present} completion={entry.completion_emitted} "
+                f"heartbeatAge={heartbeat_age:.2f}s)"
+            )
+            watchdog_fired = True
+            break
+
+print("=== Repro timeline ===")
+for line in events:
+    print(line)
+
+print("\n=== Result ===")
+if watchdog_fired:
+    print(
+        "PASS: reproduced heartbeat timeout while handle remained present and completion was pending."
+    )
+    raise SystemExit(0)
+
+print("FAIL: watchdog did not fire; adjust timing constants.")
+raise SystemExit(1)
+PY


### PR DESCRIPTION
## Summary

Fixes a false stall path in SSH execution where the close callback marked an entry completed before completion was emitted. This kept long finalize/push work from heartbeating and caused watchdog-driven `running/executing` failures even when the task handle was still present.

## Architecture

### Before

```mermaid
flowchart TD
  childClose["SSH child close event"] --> markCompleted["entry.completed = true"]
  markCompleted --> stopHeartbeat["BaseExecutor heartbeat timer stops"]
  stopHeartbeat --> finalizeWait["await remoteGitRecordAndPush"]
  finalizeWait --> emitComplete["emitComplete response"]
  stopHeartbeat --> watchdog["App executing-stall watchdog"]
  watchdog --> forcedFail["Forced failed response"]
```

### After

```mermaid
flowchart TD
  childClose["SSH child close event"] --> markFinalizing["entry.finalizingAfterClose = true"]
  markFinalizing --> keepHeartbeat["BaseExecutor keeps emitting heartbeat while finalizing"]
  keepHeartbeat --> finalizeWait["await remoteGitRecordAndPush"]
  finalizeWait --> clearFinalizing["entry.finalizingAfterClose = false"]
  clearFinalizing --> emitComplete["emitComplete response"]
```

## Test Plan

- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/ssh-executor.test.ts`
- [x] `bash scripts/repro/repro-heartbeat-timeout-after-close-finalize-hang.sh`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 1ea933b`
- Post-revert steps: Re-run `cd packages/execution-engine && pnpm exec vitest run src/__tests__/ssh-executor.test.ts`.
- Data migration? No.
