### PR TITLE
Reduce Large Files Step 2: main.ts decomposition

### DIFF
--- a/packages/app/src/__tests__/app-bootstrap.test.ts
+++ b/packages/app/src/__tests__/app-bootstrap.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  configureEarlyElectronApp,
+  registerGuiLifecycleHandlers,
+  runElectronReadyBootstrap,
+  startGuiModeBootstrap,
+} from '../bootstrap/app-bootstrap.js';
+
+function createCommandLineRecorder() {
+  const switches: string[] = [];
+  return {
+    switches,
+    commandLine: {
+      appendSwitch: (value: string) => {
+        switches.push(value);
+      },
+    },
+  };
+}
+
+describe('app-bootstrap', () => {
+  it('applies Linux startup switches before later bootstrap work', () => {
+    const recorder = createCommandLineRecorder();
+    const disableHardwareAcceleration = vi.fn();
+    const app = {
+      disableHardwareAcceleration,
+      commandLine: recorder.commandLine,
+      name: '',
+    };
+
+    configureEarlyElectronApp({
+      app,
+      platform: 'linux',
+      enableTestCompositor: false,
+    });
+
+    expect(disableHardwareAcceleration).toHaveBeenCalledTimes(1);
+    expect(app.name).toBe('invoker');
+    expect(recorder.switches).toEqual([
+      'no-sandbox',
+      'no-zygote',
+      'disable-dev-shm-usage',
+      'disable-gpu',
+      'disable-gpu-compositing',
+      'disable-gpu-sandbox',
+      'disable-software-rasterizer',
+      'class',
+    ]);
+  });
+
+  it('runs ready bootstrap only after Electron readiness resolves', async () => {
+    const order: string[] = [];
+    let resolveReady!: () => void;
+    const ready = new Promise<void>((resolve) => {
+      resolveReady = resolve;
+    });
+    const run = vi.fn(async () => {
+      order.push('run');
+    });
+
+    runElectronReadyBootstrap({
+      app: {
+        whenReady: () => {
+          order.push('whenReady');
+          return ready;
+        },
+      },
+      run,
+      onError: vi.fn(),
+    });
+
+    expect(order).toEqual(['whenReady']);
+    resolveReady();
+    await ready;
+    await vi.waitFor(() => expect(run).toHaveBeenCalledTimes(1));
+    expect(order).toEqual(['whenReady', 'run']);
+  });
+
+  it('preserves GUI single-instance ordering outside tests', () => {
+    const order: string[] = [];
+    startGuiModeBootstrap({
+      app: {
+        requestSingleInstanceLock: () => {
+          order.push('lock');
+          return true;
+        },
+        quit: () => {
+          order.push('quit');
+        },
+      },
+      isTest: false,
+      setupGuiMode: () => {
+        order.push('setup');
+      },
+    });
+
+    expect(order).toEqual(['lock', 'setup']);
+  });
+
+  it('skips the single-instance lock in tests', () => {
+    const requestSingleInstanceLock = vi.fn(() => true);
+    const setupGuiMode = vi.fn();
+
+    startGuiModeBootstrap({
+      app: {
+        requestSingleInstanceLock,
+        quit: vi.fn(),
+      },
+      isTest: true,
+      setupGuiMode,
+    });
+
+    expect(requestSingleInstanceLock).not.toHaveBeenCalled();
+    expect(setupGuiMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('registers lifecycle handlers without changing event names', () => {
+    const handlers = new Map<string, unknown>();
+    registerGuiLifecycleHandlers(
+      {
+        on: (eventName: string, handler: unknown) => {
+          handlers.set(eventName, handler);
+          return undefined as never;
+        },
+      },
+      {
+        onWindowAllClosed: vi.fn(),
+        onBeforeQuit: vi.fn(),
+      },
+    );
+
+    expect([...handlers.keys()]).toEqual(['window-all-closed', 'before-quit']);
+  });
+});

--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -1,0 +1,183 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IpcMain } from 'electron';
+import { TransportError, TransportErrorCode } from '@invoker/transport';
+import {
+  registerBootstrapStateIpc,
+  registerGuiMutationHandler,
+  registerWorkflowScopedGuiMutationHandler,
+  type GuiMutationRegistrationContext,
+  type WorkflowScopedGuiMutationRegistrationContext,
+} from '../ipc/ipc-registration.js';
+import type { WorkflowMutationPriority } from '../workflow-mutation-coordinator.js';
+
+type HandleHandler = (_event: unknown, ...args: unknown[]) => Promise<unknown>;
+type OnHandler = (event: { returnValue?: unknown }) => void;
+
+function createFakeIpcMain() {
+  const handleHandlers = new Map<string, HandleHandler>();
+  const onHandlers = new Map<string, OnHandler>();
+  const ipcMain = {
+    handle: (channel: string, handler: HandleHandler) => {
+      handleHandlers.set(channel, handler);
+    },
+    on: (channel: string, handler: OnHandler) => {
+      onHandlers.set(channel, handler);
+    },
+  } as unknown as IpcMain;
+  return { ipcMain, handleHandlers, onHandlers };
+}
+
+describe('ipc-registration', () => {
+  it('runs mutation handlers locally in owner mode and records the channel', async () => {
+    const { ipcMain, handleHandlers } = createFakeIpcMain();
+    const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+    const handler = vi.fn(async (value: unknown) => `owner:${String(value)}`);
+
+    registerGuiMutationHandler(
+      {
+        ipcMain,
+        getOwnerMode: () => true,
+        getMessageBus: () => ({ request: vi.fn() }),
+        translateGuiMutationToHeadless: vi.fn(),
+        guiMutationHandlers,
+      },
+      'invoker:test',
+      handler,
+    );
+
+    await expect(handleHandlers.get('invoker:test')?.({}, 'a')).resolves.toBe('owner:a');
+    expect(handler).toHaveBeenCalledWith('a');
+    expect(guiMutationHandlers.get('invoker:test')).toBe(handler);
+  });
+
+  it('delegates mutation handlers through the translated headless route in follower mode', async () => {
+    const { ipcMain, handleHandlers } = createFakeIpcMain();
+    const request = vi.fn(async (channel: string, payload: unknown) => ({
+      channel,
+      payload,
+    }));
+
+    registerGuiMutationHandler(
+      {
+        ipcMain,
+        getOwnerMode: () => false,
+        getMessageBus: () => ({ request }),
+        translateGuiMutationToHeadless: ({ channel, args }) => ({
+          channel: 'headless.exec',
+          request: { source: channel, args },
+        }),
+      },
+      'invoker:approve',
+      vi.fn(async () => 'local'),
+    );
+
+    await expect(handleHandlers.get('invoker:approve')?.({}, 'task-1')).resolves.toEqual({
+      channel: 'headless.exec',
+      payload: { source: 'invoker:approve', args: ['task-1'] },
+    });
+    expect(request).toHaveBeenCalledWith('headless.exec', {
+      source: 'invoker:approve',
+      args: ['task-1'],
+    });
+  });
+
+  it('preserves the no-owner error when follower delegation has no handler', async () => {
+    const { ipcMain, handleHandlers } = createFakeIpcMain();
+
+    registerGuiMutationHandler(
+      {
+        ipcMain,
+        getOwnerMode: () => false,
+        getMessageBus: () => ({
+          request: async () => {
+            throw new TransportError(TransportErrorCode.NO_HANDLER, 'missing');
+          },
+        }),
+        translateGuiMutationToHeadless: () => ({ channel: 'headless.exec', request: {} }),
+      },
+      'invoker:cancel-task',
+      vi.fn(async () => 'local'),
+    );
+
+    await expect(handleHandlers.get('invoker:cancel-task')?.({}, 'task-1')).rejects.toThrow(
+      'No mutation owner is available',
+    );
+  });
+
+  it('registers workflow-scoped handlers with the same dispatcher and enqueue shape', async () => {
+    const { ipcMain, handleHandlers } = createFakeIpcMain();
+    const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+    const calls: Array<{
+      workflowId: string | undefined;
+      priority: WorkflowMutationPriority;
+      channel: string;
+      args: unknown[];
+    }> = [];
+    const context: WorkflowScopedGuiMutationRegistrationContext = {
+      ipcMain,
+      getOwnerMode: () => true,
+      getMessageBus: () => ({ request: vi.fn() }),
+      translateGuiMutationToHeadless: vi.fn(),
+      workflowMutationDispatcher,
+      runWorkflowMutation: async (workflowId, priority, channel, args, op) => {
+        calls.push({ workflowId, priority, channel, args });
+        return op();
+      },
+    };
+    const handler = vi.fn(async (taskId: unknown) => `done:${String(taskId)}`);
+
+    registerWorkflowScopedGuiMutationHandler(
+      context,
+      'invoker:restart-task',
+      (taskId) => `workflow-for-${String(taskId)}`,
+      'high',
+      handler,
+    );
+
+    await expect(handleHandlers.get('invoker:restart-task')?.({}, 'task-1')).resolves.toBe('done:task-1');
+    expect(workflowMutationDispatcher.has('invoker:restart-task')).toBe(true);
+    await expect(workflowMutationDispatcher.get('invoker:restart-task')?.('task-2')).resolves.toBe('done:task-2');
+    expect(calls).toEqual([
+      {
+        workflowId: 'workflow-for-task-1',
+        priority: 'high',
+        channel: 'invoker:restart-task',
+        args: ['task-1'],
+      },
+    ]);
+  });
+
+  it('registers bootstrap sync IPC with unchanged payload fields', () => {
+    const { ipcMain, onHandlers } = createFakeIpcMain();
+    const recordStartupDuration = vi.fn();
+    registerBootstrapStateIpc({
+      ipcMain,
+      getTasks: () => [{ id: 'task-1' } as any],
+      getWorkflows: () => [{ id: 'workflow-1' }],
+      getInitialWorkflowId: () => 'workflow-1',
+      appStartedAtEpochMs: 123,
+      getTaskDeltaStreamSequence: () => 7,
+      recordStartupDuration,
+    });
+
+    const event: { returnValue?: unknown } = {};
+    onHandlers.get('invoker:get-bootstrap-state-sync')?.(event);
+
+    expect(event.returnValue).toEqual({
+      tasks: [{ id: 'task-1' }],
+      workflows: [{ id: 'workflow-1' }],
+      initialWorkflowId: 'workflow-1',
+      appStartedAtEpochMs: 123,
+      streamSequence: 7,
+    });
+    expect(recordStartupDuration).toHaveBeenCalledWith(
+      'bootstrap-ipc.serialize-return',
+      expect.any(Number),
+      expect.objectContaining({
+        taskCount: 1,
+        workflowCount: 1,
+        jsonSizeBytes: expect.any(Number),
+      }),
+    );
+  });
+});

--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -1,0 +1,237 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Channels } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+import { autoFixOnReviewGateFailure } from '../workflow-actions.js';
+import { loadConfig, resolveSecretsFilePath } from '../config.js';
+import {
+  rebuildTaskRunner,
+  requireWiredTaskRunner,
+} from '../execution/task-runner-wiring.js';
+
+const taskRunnerConstructor = vi.fn();
+const gitHubMergeGateProviderConstructor = vi.fn();
+const reviewProviderRegistryRegister = vi.fn();
+
+vi.mock('@invoker/execution-engine', () => {
+  class MockTaskRunner {
+    config: unknown;
+    approveMerge = vi.fn(async () => undefined);
+    executeTasks = vi.fn(async () => undefined);
+
+    constructor(config: unknown) {
+      this.config = config;
+      taskRunnerConstructor(config, this);
+    }
+  }
+
+  class MockGitHubMergeGateProvider {
+    constructor() {
+      gitHubMergeGateProviderConstructor();
+    }
+  }
+
+  class MockReviewProviderRegistry {
+    register(provider: unknown) {
+      reviewProviderRegistryRegister(provider);
+    }
+  }
+
+  return {
+    TaskRunner: MockTaskRunner,
+    GitHubMergeGateProvider: MockGitHubMergeGateProvider,
+    ReviewProviderRegistry: MockReviewProviderRegistry,
+  };
+});
+
+vi.mock('../workflow-actions.js', () => ({
+  autoFixOnReviewGateFailure: vi.fn(async () => undefined),
+}));
+
+vi.mock('../config.js', () => ({
+  loadConfig: vi.fn(() => ({
+    remoteTargets: { remote: { host: 'host' } },
+    executionPools: { pool: { members: [] } },
+    autoFixAgent: 'codex',
+    autoApproveAIFixes: true,
+  })),
+  resolveSecretsFilePath: vi.fn(() => '/tmp/secrets.env'),
+}));
+
+function createLogger() {
+  return {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  };
+}
+
+describe('task-runner-wiring', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('constructs TaskRunner and preserves callback side effects', () => {
+    let currentRunner: any = null;
+    let latestRunner: any = null;
+    const taskHandles = new Map();
+    const logger = createLogger();
+    const publishTaskHeartbeat = vi.fn();
+    const orchestrator = {
+      getTask: vi.fn(() => ({
+        status: 'running',
+        execution: { generation: 2, lastHeartbeatAt: new Date(Date.now() - 1000) },
+      })),
+      setBeforeApproveHook: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      loadWorkflow: vi.fn(),
+    };
+
+    const runner = rebuildTaskRunner({
+      orchestrator: orchestrator as any,
+      persistence: persistence as any,
+      executorRegistry: {} as any,
+      executionAgentRegistry: {} as any,
+      repoRoot: '/repo',
+      invokerConfig: {
+        defaultBranch: 'main',
+        docker: { imageName: 'image' },
+        autoFixCi: true,
+      },
+      logger: logger as any,
+      taskHandles,
+      enqueueTaskOutput: vi.fn(),
+      flushTaskOutput: vi.fn(),
+      publishTaskHeartbeat,
+      assertFatalExecutionCapacity: vi.fn(),
+      getTaskRunner: () => currentRunner,
+      setTaskRunner: (value) => { currentRunner = value; },
+      setLatestTaskExecutor: (value) => { latestRunner = value; },
+    });
+
+    expect(currentRunner).toBe(runner);
+    expect(latestRunner).toBe(runner);
+    expect(resolveSecretsFilePath).toHaveBeenCalledWith(expect.objectContaining({ defaultBranch: 'main' }));
+    expect(gitHubMergeGateProviderConstructor).toHaveBeenCalledTimes(2);
+    expect(reviewProviderRegistryRegister).toHaveBeenCalledTimes(1);
+
+    const config = taskRunnerConstructor.mock.calls[0]?.[0] as any;
+    expect(config.cwd).toBe('/repo');
+    expect(config.dockerConfig).toEqual({ imageName: 'image', secretsFile: '/tmp/secrets.env' });
+    expect(config.remoteTargetsProvider()).toEqual({ remote: { host: 'host' } });
+    expect(config.executionPoolsProvider()).toEqual({ pool: { members: [] } });
+    expect(loadConfig).toHaveBeenCalledTimes(2);
+
+    config.callbacks.onOutput('task-1', 'chunk');
+    expect(taskRunnerConstructor.mock.calls[0]?.[0].callbacks.onOutput).toBe(config.callbacks.onOutput);
+
+    const handle = { executionId: 'exec-1', workspacePath: '/repo/wt', branch: 'feature' };
+    const executor = { type: 'worktree' };
+    config.callbacks.onSpawned('task-1', handle, executor);
+    expect(taskHandles.get('task-1')).toEqual({ handle, executor });
+
+    config.callbacks.onComplete('task-1', {
+      status: 'completed',
+      executionGeneration: 2,
+      outputs: { exitCode: 0 },
+    });
+    expect(taskHandles.has('task-1')).toBe(false);
+
+    config.callbacks.onHeartbeat('task-1');
+    expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
+      execution: { lastHeartbeatAt: expect.any(Date) },
+    });
+    expect(publishTaskHeartbeat).toHaveBeenCalledWith('task-1', expect.any(Date));
+  });
+
+  it('keeps review-gate auto-fix and approve hook routed through the current TaskRunner', async () => {
+    let currentRunner: any = null;
+    const orchestrator = {
+      getTask: vi.fn(),
+      setBeforeApproveHook: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      loadWorkflow: vi.fn(() => ({ mergeMode: 'local' })),
+    };
+
+    rebuildTaskRunner({
+      orchestrator: orchestrator as any,
+      persistence: persistence as any,
+      executorRegistry: {} as any,
+      repoRoot: '/repo',
+      invokerConfig: { autoFixCi: true },
+      logger: createLogger() as any,
+      taskHandles: new Map(),
+      enqueueTaskOutput: vi.fn(),
+      flushTaskOutput: vi.fn(),
+      publishTaskHeartbeat: vi.fn(),
+      assertFatalExecutionCapacity: vi.fn(),
+      getTaskRunner: () => currentRunner,
+      setTaskRunner: (value) => { currentRunner = value; },
+      setLatestTaskExecutor: vi.fn(),
+    });
+
+    const config = taskRunnerConstructor.mock.calls[0]?.[0] as any;
+    await config.onReviewGateCiFailure({ taskId: 'merge-task' });
+    expect(autoFixOnReviewGateFailure).toHaveBeenCalledWith(
+      { taskId: 'merge-task' },
+      expect.objectContaining({ taskExecutor: currentRunner }),
+    );
+
+    const approveHook = orchestrator.setBeforeApproveHook.mock.calls[0]?.[0];
+    const mergeTask = {
+      config: { isMergeNode: true, workflowId: 'wf-1' },
+      execution: {},
+    } as TaskState;
+    await approveHook(mergeTask);
+    expect(currentRunner.approveMerge).toHaveBeenCalledWith('wf-1');
+
+    persistence.loadWorkflow.mockReturnValueOnce({ mergeMode: 'external_review' });
+    await approveHook(mergeTask);
+    expect(currentRunner.approveMerge).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws the existing follower-mode execution error before dispatch', () => {
+    expect(() => requireWiredTaskRunner(() => null)).toThrow(
+      'Mutation execution is unavailable in read-only follower mode',
+    );
+  });
+
+  it('documents task dispatch through the wired TaskRunner executeTasks method', async () => {
+    const runner = requireWiredTaskRunner(() => ({
+      executeTasks: vi.fn(async () => undefined),
+    } as any));
+    await runner.executeTasks([{ id: 'task-1' }] as any);
+    expect(runner.executeTasks).toHaveBeenCalledWith([{ id: 'task-1' }]);
+  });
+
+  it('uses the unchanged heartbeat task-delta channel shape', () => {
+    const published: Array<{ channel: string; payload: unknown }> = [];
+    const publishTaskHeartbeat = (taskId: string, lastHeartbeatAt: Date): void => {
+      published.push({
+        channel: Channels.TASK_DELTA,
+        payload: {
+          type: 'updated' as const,
+          taskId,
+          changes: { execution: { lastHeartbeatAt } },
+        },
+      });
+    };
+    const at = new Date();
+
+    publishTaskHeartbeat('task-1', at);
+
+    expect(published).toEqual([
+      {
+        channel: Channels.TASK_DELTA,
+        payload: {
+          type: 'updated',
+          taskId: 'task-1',
+          changes: { execution: { lastHeartbeatAt: at } },
+        },
+      },
+    ]);
+  });
+});

--- a/packages/app/src/__tests__/window-lifecycle.test.ts
+++ b/packages/app/src/__tests__/window-lifecycle.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  registerMainWindowActivateHandler,
+  registerMainWindowSecondInstanceHandler,
+} from '../window/window-lifecycle.js';
+
+vi.mock('electron', () => ({
+  BrowserWindow: {
+    getAllWindows: () => [],
+  },
+  nativeImage: {
+    createFromPath: () => ({ isEmpty: () => true }),
+  },
+  shell: {
+    openExternal: vi.fn(),
+  },
+}));
+
+describe('window-lifecycle', () => {
+  it('focuses the existing window on second-instance without changing the event name', () => {
+    const handlers = new Map<string, (...args: unknown[]) => void>();
+    const window = {
+      isMinimized: vi.fn(() => true),
+      restore: vi.fn(),
+      focus: vi.fn(),
+    };
+
+    registerMainWindowSecondInstanceHandler({
+      app: {
+        on: (eventName: string, handler: (...args: unknown[]) => void) => {
+          handlers.set(eventName, handler);
+          return undefined as never;
+        },
+      },
+      getMainWindow: () => window as any,
+    });
+
+    handlers.get('second-instance')?.();
+
+    expect([...handlers.keys()]).toEqual(['second-instance']);
+    expect(window.restore).toHaveBeenCalledTimes(1);
+    expect(window.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it('recreates the main window on activate only when no BrowserWindow exists', () => {
+    const handlers = new Map<string, (...args: unknown[]) => void>();
+    const createWindow = vi.fn();
+    const browserWindow = {
+      getAllWindows: vi.fn(() => []),
+    };
+
+    registerMainWindowActivateHandler({
+      app: {
+        on: (eventName: string, handler: (...args: unknown[]) => void) => {
+          handlers.set(eventName, handler);
+          return undefined as never;
+        },
+      },
+      createWindow,
+      browserWindow,
+    });
+
+    handlers.get('activate')?.();
+    expect(createWindow).toHaveBeenCalledTimes(1);
+
+    browserWindow.getAllWindows.mockReturnValueOnce([{}]);
+    handlers.get('activate')?.();
+    expect(createWindow).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/bootstrap/app-bootstrap.ts
+++ b/packages/app/src/bootstrap/app-bootstrap.ts
@@ -1,0 +1,76 @@
+import type { App } from 'electron';
+
+export interface EarlyElectronAppOptions {
+  app: Pick<App, 'disableHardwareAcceleration' | 'commandLine' | 'name'>;
+  platform?: NodeJS.Platform;
+  enableTestCompositor: boolean;
+}
+
+export function configureEarlyElectronApp(options: EarlyElectronAppOptions): void {
+  const platform = options.platform ?? process.platform;
+
+  // Prevent desktop-wide freezes on Linux (Chromium GPU + X11/Wayland compositors).
+  // Defense-in-depth: API-level disable, command-line flags, and env var (LIBGL_ALWAYS_SOFTWARE).
+  if (platform === 'linux' && !options.enableTestCompositor) {
+    options.app.disableHardwareAcceleration();
+    options.app.commandLine.appendSwitch('no-sandbox');
+    options.app.commandLine.appendSwitch('no-zygote');
+    options.app.commandLine.appendSwitch('disable-dev-shm-usage');
+    options.app.commandLine.appendSwitch('disable-gpu');
+    options.app.commandLine.appendSwitch('disable-gpu-compositing');
+    options.app.commandLine.appendSwitch('disable-gpu-sandbox');
+    options.app.commandLine.appendSwitch('disable-software-rasterizer');
+  }
+
+  // Set app name early so Electron uses "invoker" as WM_CLASS (X11) and app_id (Wayland).
+  // --class tells Chromium to set WM_CLASS explicitly, preventing GNOME from
+  // grouping Invoker with other Electron apps (e.g. Slack).
+  options.app.name = 'invoker';
+  if (platform === 'linux') {
+    options.app.commandLine.appendSwitch('class', 'invoker');
+  }
+}
+
+export interface ElectronReadyBootstrapOptions {
+  app: Pick<App, 'whenReady'>;
+  run: () => Promise<void>;
+  onError: (err: unknown) => void;
+}
+
+export function runElectronReadyBootstrap(options: ElectronReadyBootstrapOptions): void {
+  options.app.whenReady().then(options.run).catch(options.onError);
+}
+
+export interface GuiModeBootstrapOptions {
+  app: Pick<App, 'requestSingleInstanceLock' | 'quit'>;
+  isTest: boolean;
+  setupGuiMode: () => void;
+}
+
+export function startGuiModeBootstrap(options: GuiModeBootstrapOptions): void {
+  if (options.isTest) {
+    options.setupGuiMode();
+    return;
+  }
+
+  const gotTheLock = options.app.requestSingleInstanceLock();
+  if (!gotTheLock) {
+    options.app.quit();
+    return;
+  }
+
+  options.setupGuiMode();
+}
+
+export interface GuiLifecycleHandlers {
+  onWindowAllClosed: () => void;
+  onBeforeQuit: (event: { preventDefault: () => void }) => void | Promise<void>;
+}
+
+export function registerGuiLifecycleHandlers(
+  app: Pick<App, 'on'>,
+  handlers: GuiLifecycleHandlers,
+): void {
+  app.on('window-all-closed', handlers.onWindowAllClosed);
+  app.on('before-quit', handlers.onBeforeQuit);
+}

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -1,0 +1,143 @@
+import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+import type { SQLiteAdapter } from '@invoker/data-store';
+import {
+  GitHubMergeGateProvider,
+  ReviewProviderRegistry,
+  TaskRunner,
+  type AgentRegistry,
+  type Executor,
+  type ExecutorHandle,
+  type ExecutorRegistry,
+} from '@invoker/execution-engine';
+import type { Logger } from '@invoker/contracts';
+import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from '../config.js';
+import { autoFixOnReviewGateFailure } from '../workflow-actions.js';
+
+export type TaskHandleMap = Map<string, { handle: ExecutorHandle; executor: Executor }>;
+
+export interface TaskRunnerWiringDeps {
+  orchestrator: Orchestrator;
+  persistence: SQLiteAdapter;
+  executorRegistry: ExecutorRegistry;
+  executionAgentRegistry?: AgentRegistry;
+  repoRoot: string;
+  invokerConfig: InvokerConfig;
+  logger: Logger;
+  taskHandles: TaskHandleMap;
+  enqueueTaskOutput: (taskId: string, data: string) => void;
+  flushTaskOutput: (taskId: string) => void;
+  publishTaskHeartbeat: (taskId: string, lastHeartbeatAt: Date) => void;
+  assertFatalExecutionCapacity: (label: string) => void;
+  getTaskRunner: () => TaskRunner | null;
+  setTaskRunner: (taskRunner: TaskRunner) => void;
+  setLatestTaskExecutor: (taskRunner: TaskRunner) => void;
+}
+
+export function requireWiredTaskRunner(getTaskRunner: () => TaskRunner | null): TaskRunner {
+  const taskRunner = getTaskRunner();
+  if (!taskRunner) {
+    throw new Error('Mutation execution is unavailable in read-only follower mode');
+  }
+  return taskRunner;
+}
+
+export function wireTaskRunnerApproveHook(deps: Pick<
+  TaskRunnerWiringDeps,
+  'orchestrator' | 'persistence' | 'getTaskRunner'
+>): void {
+  deps.orchestrator.setBeforeApproveHook(async (task: TaskState) => {
+    if (task.config.isMergeNode && task.config.workflowId && task.execution.pendingFixError === undefined) {
+      const workflow = deps.persistence.loadWorkflow(task.config.workflowId);
+      if (workflow?.mergeMode === 'external_review') return;
+      await requireWiredTaskRunner(deps.getTaskRunner).approveMerge(task.config.workflowId);
+    }
+  });
+}
+
+export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
+  const taskRunner = new TaskRunner({
+    orchestrator: deps.orchestrator,
+    persistence: deps.persistence,
+    executorRegistry: deps.executorRegistry,
+    executionAgentRegistry: deps.executionAgentRegistry,
+    cwd: deps.repoRoot,
+    defaultBranch: deps.invokerConfig.defaultBranch,
+    dockerConfig: {
+      imageName: deps.invokerConfig.docker?.imageName,
+      secretsFile: resolveSecretsFilePath(deps.invokerConfig),
+    },
+    remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
+    executionPoolsProvider: () => loadConfig().executionPools ?? {},
+    onReviewGateCiFailure: deps.invokerConfig.autoFixCi
+      ? async (trigger) => {
+          const currentTaskExecutor = deps.getTaskRunner();
+          if (!currentTaskExecutor) {
+            throw new Error('Task executor is not initialized for review-gate CI auto-fix');
+          }
+          await autoFixOnReviewGateFailure(trigger, {
+            orchestrator: deps.orchestrator,
+            persistence: deps.persistence,
+            taskExecutor: currentTaskExecutor,
+            getAutoFixAgent: () => loadConfig().autoFixAgent,
+            getAutoApproveAIFixes: () => loadConfig().autoApproveAIFixes,
+          });
+        }
+      : undefined,
+    mergeGateProvider: new GitHubMergeGateProvider(),
+    reviewProviderRegistry: (() => {
+      const registry = new ReviewProviderRegistry();
+      registry.register(new GitHubMergeGateProvider());
+      return registry;
+    })(),
+    callbacks: {
+      onOutput: (taskId, data) => {
+        deps.enqueueTaskOutput(taskId, data);
+      },
+      onLaunchFailed: (taskId, error, executor) => {
+        deps.assertFatalExecutionCapacity(`launch failed ${taskId}`);
+        deps.logger.error(
+          `Task "${taskId}" launch failed before spawn (executor: ${executor.type}): ${error.message}`,
+          { module: 'exec' },
+        );
+      },
+      onSpawned: (taskId, handle, executor) => {
+        deps.flushTaskOutput(taskId);
+        deps.logger.info(
+          `Task "${taskId}" spawned (handle: ${handle.executionId}, executor: ${executor.type}, workspace: ${handle.workspacePath ?? 'none'}, branch: ${handle.branch ?? 'none'})`,
+          { module: 'exec' },
+        );
+        deps.taskHandles.set(taskId, { handle, executor });
+        deps.assertFatalExecutionCapacity(`spawned ${taskId}`);
+      },
+      onComplete: (taskId, response) => {
+        deps.flushTaskOutput(taskId);
+        deps.taskHandles.delete(taskId);
+        deps.assertFatalExecutionCapacity(`complete ${taskId}`);
+        deps.logger.info(
+          `Task "${taskId}" completion callback received (status: ${response.status}, generation: ${response.executionGeneration}, exitCode: ${response.outputs.exitCode ?? 'none'})`,
+          { module: 'exec' },
+        );
+      },
+      onHeartbeat: (taskId) => {
+        const now = new Date();
+        const task = deps.orchestrator.getTask(taskId);
+        const previousHeartbeat = task?.execution.lastHeartbeatAt instanceof Date
+          ? task.execution.lastHeartbeatAt
+          : task?.execution.lastHeartbeatAt
+            ? new Date(task.execution.lastHeartbeatAt)
+            : undefined;
+        const heartbeatGapMs = previousHeartbeat ? now.getTime() - previousHeartbeat.getTime() : undefined;
+        try { deps.persistence.updateTask(taskId, { execution: { lastHeartbeatAt: now } }); } catch { /* db locked */ }
+        deps.publishTaskHeartbeat(taskId, now);
+        deps.logger.info(
+          `Heartbeat for "${taskId}" (status: ${task?.status ?? 'unknown'}, generation: ${task?.execution.generation ?? 'unknown'}, gapMs: ${heartbeatGapMs ?? 'first'})`,
+          { module: 'heartbeat' },
+        );
+      },
+    },
+  });
+  deps.setTaskRunner(taskRunner);
+  deps.setLatestTaskExecutor(taskRunner);
+  wireTaskRunnerApproveHook(deps);
+  return taskRunner;
+}

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -1,0 +1,112 @@
+import type { IpcMain } from 'electron';
+import { TransportError, TransportErrorCode } from '@invoker/transport';
+import type { MessageBus } from '@invoker/transport';
+import type { TaskState } from '@invoker/workflow-core';
+import type { WorkflowMutationPriority } from '../workflow-mutation-coordinator.js';
+
+export interface GuiMutationPayload {
+  channel: string;
+  args: unknown[];
+}
+
+export type TranslatedGuiMutation =
+  | { channel: string; request: unknown }
+  | null;
+
+export interface GuiMutationRegistrationContext {
+  ipcMain: IpcMain;
+  getOwnerMode: () => boolean;
+  getMessageBus: () => Pick<MessageBus, 'request'>;
+  translateGuiMutationToHeadless: (payload: GuiMutationPayload) => TranslatedGuiMutation;
+  guiMutationHandlers?: Map<string, (...args: unknown[]) => Promise<unknown>>;
+}
+
+export function registerGuiMutationHandler<TResult = unknown>(
+  context: GuiMutationRegistrationContext,
+  channel: string,
+  handler: (...args: unknown[]) => Promise<TResult>,
+): void {
+  context.guiMutationHandlers?.set(channel, handler as (...args: unknown[]) => Promise<unknown>);
+  context.ipcMain.handle(channel, async (_event, ...args: unknown[]) => {
+    if (context.getOwnerMode()) {
+      return handler(...args);
+    }
+    const translated = context.translateGuiMutationToHeadless({ channel, args });
+    if (!translated) {
+      throw new Error(`No owner delegation route is available for ${channel}`);
+    }
+    try {
+      return await context.getMessageBus().request<typeof translated.request, TResult>(
+        translated.channel,
+        translated.request,
+      );
+    } catch (err) {
+      if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
+        throw new Error('No mutation owner is available');
+      }
+      throw err;
+    }
+  });
+}
+
+export interface WorkflowScopedGuiMutationRegistrationContext extends GuiMutationRegistrationContext {
+  workflowMutationDispatcher: Map<string, (...args: unknown[]) => Promise<unknown>>;
+  runWorkflowMutation: <T>(
+    workflowId: string | undefined,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+    op: () => Promise<T>,
+  ) => Promise<T>;
+}
+
+export function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
+  context: WorkflowScopedGuiMutationRegistrationContext,
+  channel: string,
+  resolveWorkflowId: (...args: unknown[]) => string | undefined,
+  priority: WorkflowMutationPriority,
+  handler: (...args: unknown[]) => Promise<TResult>,
+): void {
+  context.workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
+  registerGuiMutationHandler(context, channel, async (...args: unknown[]) => {
+    const workflowId = resolveWorkflowId(...args);
+    return context.runWorkflowMutation(workflowId, priority, channel, args, () => handler(...args));
+  });
+}
+
+export interface BootstrapStateIpcContext {
+  ipcMain: Pick<IpcMain, 'on'>;
+  getTasks: () => TaskState[];
+  getWorkflows: () => unknown[];
+  getInitialWorkflowId: () => string | null;
+  appStartedAtEpochMs: number;
+  getTaskDeltaStreamSequence: () => number;
+  recordStartupDuration: (
+    phase: string,
+    startedAtMs: number,
+    extra?: Record<string, unknown>,
+  ) => void;
+}
+
+export function registerBootstrapStateIpc(context: BootstrapStateIpcContext): void {
+  context.ipcMain.on('invoker:get-bootstrap-state-sync', (event) => {
+    const startedAtMs = Date.now();
+    const tasks = context.getTasks();
+    const workflows = context.getWorkflows();
+    const streamSequence = context.getTaskDeltaStreamSequence();
+    const payload = {
+      tasks,
+      workflows,
+      initialWorkflowId: context.getInitialWorkflowId(),
+      appStartedAtEpochMs: context.appStartedAtEpochMs,
+      streamSequence,
+    };
+    const jsonSizeBytes = Buffer.byteLength(JSON.stringify(payload), 'utf8');
+    context.recordStartupDuration('bootstrap-ipc.serialize-return', startedAtMs, {
+      taskCount: tasks.length,
+      workflowCount: workflows.length,
+      jsonSizeBytes,
+    });
+    event.returnValue = payload;
+  });
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -32,9 +32,9 @@
  * Using the same Electron binary for both modes provides a consistent runtime.
  */
 
-import { app, BrowserWindow, ipcMain, nativeImage, shell } from 'electron';
+import { app, ipcMain, type BrowserWindow } from 'electron';
 import * as path from 'node:path';
-import { existsSync, mkdirSync } from 'node:fs';
+import { mkdirSync } from 'node:fs';
 import {
   configureEarlyElectronApp,
   registerGuiLifecycleHandlers,
@@ -71,12 +71,11 @@ import type { RuntimeServices } from '@invoker/runtime-service';
 import type { MessageBus } from '@invoker/transport';
 import {
   ExecutorRegistry, TaskRunner,
-  DockerExecutor, WorktreeExecutor, SshExecutor, GitHubMergeGateProvider, ReviewProviderRegistry,
+  WorktreeExecutor,
   initializeShellEnvironment,
   RESTART_TO_BRANCH_TRACE,
   remoteFetchForPool,
   registerBuiltinAgents,
-  type Executor, type ExecutorHandle,
 } from '@invoker/execution-engine';
 import type { Logger } from '@invoker/contracts';
 import { FileAndDbLogger } from './logger.js';
@@ -84,7 +83,6 @@ import type { TaskOutputData } from './types.js';
 import {
   loadConfig,
   resolveEmbeddedTerminalBackendConfig,
-  resolveSecretsFilePath,
   type EmbeddedTerminalBackendConfig,
   type InvokerConfig,
 } from './config.js';
@@ -123,7 +121,6 @@ import {
 } from './headless.js';
 import {
   approveTask as sharedApproveTask,
-  autoFixOnReviewGateFailure,
   buildInvalidationDeps,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
@@ -138,7 +135,7 @@ import {
   setWorkflowMergeMode,
   StaleLineageError,
 } from './workflow-actions.js';
-import { spawn, execSync } from 'node:child_process';
+import { execSync } from 'node:child_process';
 import { resolveTaskTerminalSpec } from './open-terminal-for-task.js';
 import {
   createBashTerminalBackend,
@@ -191,6 +188,16 @@ import {
   type HeadlessBatchExecRequest,
   type HeadlessExecMutationPayload,
 } from './headless-batch-exec.js';
+import {
+  rebuildTaskRunner as rebuildTaskRunnerWiring,
+  requireWiredTaskRunner,
+  type TaskHandleMap,
+} from './execution/task-runner-wiring.js';
+import {
+  createMainWindow,
+  registerMainWindowActivateHandler,
+  registerMainWindowSecondInstanceHandler,
+} from './window/window-lifecycle.js';
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -1260,7 +1267,7 @@ function createEmbeddedTerminalBackendFromConfig(
   let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
   let apiServer: ApiServer | null = null;
   let ownerMode = true;
-  const taskHandles = new Map<string, { handle: ExecutorHandle; executor: Executor }>();
+  const taskHandles: TaskHandleMap = new Map();
   const embeddedTerminalManager = new EmbeddedTerminalManager({
     backend: createEmbeddedTerminalBackendFromConfig(resolveEmbeddedTerminalBackendConfig(invokerConfig)),
   });
@@ -1678,111 +1685,34 @@ function createEmbeddedTerminalBackendFromConfig(
     }
   }
 
-  // Focus existing window when a second instance is launched
-  app.on('second-instance', () => {
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.focus();
-    }
+  registerMainWindowSecondInstanceHandler({
+    app,
+    getMainWindow: () => mainWindow,
   });
 
   function rebuildTaskRunner(): void {
-    taskExecutor = new TaskRunner({
+    rebuildTaskRunnerWiring({
       orchestrator,
       persistence,
       executorRegistry,
       executionAgentRegistry: agentRegistry,
-      cwd: repoRoot,
-      defaultBranch: invokerConfig.defaultBranch,
-      dockerConfig: {
-        imageName: invokerConfig.docker?.imageName,
-        secretsFile: resolveSecretsFilePath(invokerConfig),
+      repoRoot,
+      invokerConfig,
+      logger,
+      taskHandles,
+      enqueueTaskOutput,
+      flushTaskOutput,
+      publishTaskHeartbeat: (taskId, lastHeartbeatAt) => {
+        messageBus.publish(Channels.TASK_DELTA, {
+          type: 'updated' as const,
+          taskId,
+          changes: { execution: { lastHeartbeatAt } },
+        });
       },
-      remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
-      executionPoolsProvider: () => loadConfig().executionPools ?? {},
-      onReviewGateCiFailure: invokerConfig.autoFixCi
-        ? async (trigger) => {
-            const currentTaskExecutor = taskExecutor;
-            if (!currentTaskExecutor) {
-              throw new Error('Task executor is not initialized for review-gate CI auto-fix');
-            }
-            await autoFixOnReviewGateFailure(trigger, {
-              orchestrator,
-              persistence,
-              taskExecutor: currentTaskExecutor,
-              getAutoFixAgent: () => loadConfig().autoFixAgent,
-              getAutoApproveAIFixes: () => loadConfig().autoApproveAIFixes,
-            });
-          }
-        : undefined,
-      mergeGateProvider: new GitHubMergeGateProvider(),
-      reviewProviderRegistry: (() => {
-        const registry = new ReviewProviderRegistry();
-        registry.register(new GitHubMergeGateProvider());
-        return registry;
-      })(),
-      callbacks: {
-        onOutput: (taskId, data) => {
-          enqueueTaskOutput(taskId, data);
-        },
-        onLaunchFailed: (taskId, error, executor) => {
-          assertFatalExecutionCapacity(`launch failed ${taskId}`);
-          logger.error(
-            `Task "${taskId}" launch failed before spawn (executor: ${executor.type}): ${error.message}`,
-            { module: 'exec' },
-          );
-        },
-        onSpawned: (taskId, handle, executor) => {
-          flushTaskOutput(taskId);
-          logger.info(
-            `Task "${taskId}" spawned (handle: ${handle.executionId}, executor: ${executor.type}, workspace: ${handle.workspacePath ?? 'none'}, branch: ${handle.branch ?? 'none'})`,
-            { module: 'exec' },
-          );
-          taskHandles.set(taskId, { handle, executor });
-          assertFatalExecutionCapacity(`spawned ${taskId}`);
-        },
-        onComplete: (taskId, response) => {
-          flushTaskOutput(taskId);
-          taskHandles.delete(taskId);
-          assertFatalExecutionCapacity(`complete ${taskId}`);
-          logger.info(
-            `Task "${taskId}" completion callback received (status: ${response.status}, generation: ${response.executionGeneration}, exitCode: ${response.outputs.exitCode ?? 'none'})`,
-            { module: 'exec' },
-          );
-        },
-        onHeartbeat: (taskId) => {
-          const now = new Date();
-          const task = orchestrator.getTask(taskId);
-          const previousHeartbeat = task?.execution.lastHeartbeatAt instanceof Date
-            ? task.execution.lastHeartbeatAt
-            : task?.execution.lastHeartbeatAt
-              ? new Date(task.execution.lastHeartbeatAt)
-              : undefined;
-          const heartbeatGapMs = previousHeartbeat ? now.getTime() - previousHeartbeat.getTime() : undefined;
-          try { persistence.updateTask(taskId, { execution: { lastHeartbeatAt: now } }); } catch { /* db locked */ }
-          messageBus.publish(Channels.TASK_DELTA, {
-            type: 'updated' as const,
-            taskId,
-            changes: { execution: { lastHeartbeatAt: now } },
-          });
-          logger.info(
-            `Heartbeat for "${taskId}" (status: ${task?.status ?? 'unknown'}, generation: ${task?.execution.generation ?? 'unknown'}, gapMs: ${heartbeatGapMs ?? 'first'})`,
-            { module: 'heartbeat' },
-          );
-        },
-      },
-    });
-    latestTaskExecutor = taskExecutor;
-    wireApproveHook();
-  }
-
-  function wireApproveHook(): void {
-    orchestrator.setBeforeApproveHook(async (task) => {
-      if (task.config.isMergeNode && task.config.workflowId && task.execution.pendingFixError === undefined) {
-        const workflow = persistence.loadWorkflow(task.config.workflowId);
-        if (workflow?.mergeMode === "external_review") return; // external review is the merge mechanism
-        await requireTaskExecutor().approveMerge(task.config.workflowId);
-      }
+      assertFatalExecutionCapacity,
+      getTaskRunner: () => taskExecutor,
+      setTaskRunner: (runner) => { taskExecutor = runner; },
+      setLatestTaskExecutor: (runner) => { latestTaskExecutor = runner; },
     });
   }
 
@@ -1886,10 +1816,7 @@ function createEmbeddedTerminalBackendFromConfig(
   }
 
   function requireTaskExecutor(): TaskRunner {
-    if (!taskExecutor) {
-      throw new Error('Mutation execution is unavailable in read-only follower mode');
-    }
-    return taskExecutor;
+    return requireWiredTaskRunner(() => taskExecutor);
   }
 
   async function executeHeadlessRun(payload: HeadlessRunMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
@@ -2254,116 +2181,16 @@ function createEmbeddedTerminalBackendFromConfig(
   }
 
   function createWindow(): void {
-    recordStartupMark('createWindow.begin');
-    const iconPath = path.join(__dirname, 'assets', 'icons', 'png', '256x256.png');
-    const icon = nativeImage.createFromPath(iconPath);
-    mainWindow = new BrowserWindow({
-      width: 1200,
-      height: 800,
-      ...(hideE2eWindow ? { x: -32000, y: -32000, skipTaskbar: true } : {}),
-      // Show explicitly after load/timeout rather than relying on Electron's
-      // implicit initial map behavior, which has regressed on some Linux/X11
-      // sessions and leaves the BrowserWindow unmapped.
-      show: false,
-      webPreferences: {
-        preload: path.join(__dirname, 'preload.js'),
-        contextIsolation: true,
-        nodeIntegration: false,
-        sandbox: false,
-      },
-      icon: !icon.isEmpty() && process.platform !== 'darwin' ? icon : undefined,
-      title: 'Invoker',
-    });
-
-    // BrowserWindow icons matter on Windows/Linux. macOS uses the bundle icon.
-    if (process.platform !== 'darwin') {
-      if (!icon.isEmpty()) mainWindow.setIcon(icon);
-    }
-
-    const devUrl = process.env.VITE_DEV_SERVER_URL;
-    if (devUrl) {
-      mainWindow.loadURL(devUrl);
-    } else {
-      const packagedUiPath = path.join(__dirname, 'ui', 'index.html');
-      const repoUiPath = path.join(__dirname, '..', '..', 'ui', 'dist', 'index.html');
-      const uiDistPath = existsSync(packagedUiPath) ? packagedUiPath : repoUiPath;
-      mainWindow.loadFile(uiDistPath).catch(() => {
-        mainWindow?.loadURL(
-          `data:text/html,<html><body style="background:#1a1a2e;color:#eee;font-family:system-ui;padding:2rem"><h1>Invoker</h1><p>UI not built yet. Run: <code>pnpm --filter @invoker/ui build</code></p></body></html>`,
-        );
-      });
-    }
-
-    mainWindow.webContents.on('did-finish-load', () => {
-      logger.info('main window did-finish-load', { module: 'window' });
-      recordStartupMark('window.did-finish-load');
-    });
-
-    mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
-      logger.error(
-        `main window did-fail-load: code=${errorCode} desc=${errorDescription} url=${validatedURL}`,
-        { module: 'window' },
-      );
-    });
-
-    mainWindow.webContents.on('render-process-gone', (_event, details) => {
-      logger.error(
-        `main window render-process-gone: reason=${details.reason} exitCode=${details.exitCode}`,
-        { module: 'window' },
-      );
-    });
-
-    const shouldShowWindow = process.env.NODE_ENV !== 'test' || enableTestCompositor;
-    if (shouldShowWindow) {
-      let showTriggered = false;
-      const showWindow = (): void => {
-        if (!mainWindow || mainWindow.isDestroyed() || showTriggered) return;
-        showTriggered = true;
-        logger.info('main window show()', { module: 'window' });
-        recordStartupMark('window.show');
-        if (hideE2eWindow) {
-          mainWindow.showInactive();
-        } else {
-          mainWindow.show();
-          mainWindow.focus();
-        }
-        uiInteractive = true;
-        recordStartupMark('ui.interactive');
-        startDeferredStartupWork();
-      };
-
-      mainWindow.once('ready-to-show', showWindow);
-      setTimeout(showWindow, 1500).unref?.();
-    } else {
-      uiInteractive = true;
-      recordStartupMark('ui.interactive');
-      startDeferredStartupWork();
-    }
-
-    mainWindow.on('closed', () => {
-      logger.info('main window closed', { module: 'window' });
-      mainWindow = null;
-    });
-
-    mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-      if (url.startsWith('https://') || url.startsWith('http://')) {
-        const browserCmd = invokerConfig.browser;
-        if (browserCmd) {
-          spawn(browserCmd, [url], { detached: true, stdio: 'ignore' }).unref();
-        } else {
-          const chromeCmd: [string, string[]] = process.platform === 'darwin'
-            ? ['open', ['-a', 'Google Chrome', url]]
-            : process.platform === 'win32'
-              ? ['cmd', ['/c', 'start', 'chrome', url]]
-              : ['google-chrome', [url]];
-          try {
-            spawn(chromeCmd[0], chromeCmd[1], { detached: true, stdio: 'ignore' }).unref();
-          } catch {
-            shell.openExternal(url);
-          }
-        }
-      }
-      return { action: 'deny' as const };
+    createMainWindow({
+      appRootDir: __dirname,
+      invokerConfig,
+      logger,
+      hideE2eWindow,
+      enableTestCompositor,
+      recordStartupMark,
+      setUiInteractive: (value) => { uiInteractive = value; },
+      startDeferredStartupWork,
+      setMainWindow: (window) => { mainWindow = window; },
     });
   }
 
@@ -4028,10 +3855,9 @@ function createEmbeddedTerminalBackendFromConfig(
     createWindow();
     recordStartupMark('createWindow.end');
 
-    app.on('activate', () => {
-      if (BrowserWindow.getAllWindows().length === 0) {
-        createWindow();
-      }
+    registerMainWindowActivateHandler({
+      app,
+      createWindow,
     });
   };
 
@@ -4110,7 +3936,7 @@ function createEmbeddedTerminalBackendFromConfig(
   // ── Slack Bot (embedded in GUI process) ──────────────────
   async function startSlackBot(
     executor: TaskRunner,
-    handles: Map<string, { handle: ExecutorHandle; executor: Executor }>,
+    handles: TaskHandleMap,
   ): Promise<void> {
     const logFn = (source: string, level: string, message: string) => {
       const logMethod = level === 'error' ? 'error' : level === 'warn' ? 'warn' : 'info';

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -35,22 +35,17 @@
 import { app, BrowserWindow, ipcMain, nativeImage, shell } from 'electron';
 import * as path from 'node:path';
 import { existsSync, mkdirSync } from 'node:fs';
+import {
+  configureEarlyElectronApp,
+  registerGuiLifecycleHandlers,
+  runElectronReadyBootstrap,
+  startGuiModeBootstrap,
+} from './bootstrap/app-bootstrap.js';
 
 const enableTestCompositor = process.env.INVOKER_E2E_ENABLE_COMPOSITOR === '1' || Boolean(process.env.CAPTURE_MODE);
 const hideE2eWindow = process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_HIDE_WINDOW !== '0';
 
-// Prevent desktop-wide freezes on Linux (Chromium GPU + X11/Wayland compositors).
-// Defense-in-depth: API-level disable, command-line flags, and env var (LIBGL_ALWAYS_SOFTWARE).
-if (process.platform === 'linux' && !enableTestCompositor) {
-  app.disableHardwareAcceleration();
-  app.commandLine.appendSwitch('no-sandbox');
-  app.commandLine.appendSwitch('no-zygote');
-  app.commandLine.appendSwitch('disable-dev-shm-usage');
-  app.commandLine.appendSwitch('disable-gpu');
-  app.commandLine.appendSwitch('disable-gpu-compositing');
-  app.commandLine.appendSwitch('disable-gpu-sandbox');
-  app.commandLine.appendSwitch('disable-software-rasterizer');
-}
+configureEarlyElectronApp({ app, enableTestCompositor });
 
 import { Orchestrator, CommandService, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type {
@@ -64,7 +59,7 @@ import { makeEnvelope, CommandError } from '@invoker/contracts';
 import type { WorkResponse } from '@invoker/contracts';
 import { resolveRepoRoot } from '@invoker/contracts';
 import { SQLiteAdapter, ConversationRepository, SqliteTaskRepository } from '@invoker/data-store';
-import { IpcBus, Channels, TransportError, TransportErrorCode } from '@invoker/transport';
+import { IpcBus, Channels } from '@invoker/transport';
 import {
   WorkspaceProbeAdapter,
   ContainerProbeAdapter,
@@ -181,6 +176,14 @@ import {
   resolveActionDiagnosticsStallThresholdMs,
 } from './action-graph-diagnostics.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
+import {
+  registerBootstrapStateIpc,
+  registerGuiMutationHandler as registerGuiMutationIpcHandler,
+  registerWorkflowScopedGuiMutationHandler as registerWorkflowScopedGuiMutationIpcHandler,
+  type GuiMutationPayload,
+  type GuiMutationRegistrationContext,
+  type WorkflowScopedGuiMutationRegistrationContext,
+} from './ipc/ipc-registration.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
 import {
@@ -227,14 +230,6 @@ if (noTrack) {
   cliArgs = [...cliArgs.slice(0, noTrackIndex), ...cliArgs.slice(noTrackIndex + 1)];
 }
 
-// Set app name early so Electron uses "invoker" as WM_CLASS (X11) and app_id (Wayland).
-// --class tells Chromium to set WM_CLASS explicitly, preventing GNOME from
-// grouping Invoker with other Electron apps (e.g. Slack).
-app.name = 'invoker';
-if (process.platform === 'linux') {
-  app.commandLine.appendSwitch('class', 'invoker');
-}
-
 // ── Shared state ─────────────────────────────────────────────
 
 let messageBus: MessageBus;
@@ -261,11 +256,6 @@ let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
 let writerLock: DbWriterLockResult | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
 const appProcessStartedAt = Date.now();
-
-interface GuiMutationPayload {
-  channel: string;
-  args: unknown[];
-}
 
 interface HeadlessRunMutationPayload {
   planPath: string;
@@ -687,7 +677,7 @@ const RED = '\x1b[31m';
 // ══════════════════════════════════════════════════════════════
 
 if (isHeadless) {
-  app.whenReady().then(async () => {
+  const runHeadlessMain = async (): Promise<void> => {
     const agentRegistry = registerBuiltinAgents();
     const command = cliArgs[0];
     const readOnlyMode = isHeadlessReadOnlyCommand(cliArgs);
@@ -1231,24 +1221,25 @@ if (isHeadless) {
       if (messageBus) messageBus.disconnect();
     }
     process.exit(exitCode);
-  }).catch((err) => {
-    process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
+  };
+
+  runElectronReadyBootstrap({
+    app,
+    run: runHeadlessMain,
+    onError: (err) => {
+      process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    },
   });
 } else {
   // ══════════════════════════════════════════════════════════════
   // GUI MODE
   // ══════════════════════════════════════════════════════════════
-  if (process.env.NODE_ENV !== 'test') {
-    const gotTheLock = app.requestSingleInstanceLock();
-    if (!gotTheLock) {
-      app.quit();
-    } else {
-      setupGuiMode();
-    }
-  } else {
-    setupGuiMode();
-  }
+  startGuiModeBootstrap({
+    app,
+    isTest: process.env.NODE_ENV === 'test',
+    setupGuiMode,
+  });
 }
 
 // ══════════════════════════════════════════════════════════════
@@ -2226,28 +2217,25 @@ function createEmbeddedTerminalBackendFromConfig(
     });
   }
 
+  const guiMutationRegistrationContext: GuiMutationRegistrationContext = {
+    ipcMain,
+    getOwnerMode: () => ownerMode,
+    getMessageBus: () => messageBus,
+    translateGuiMutationToHeadless,
+    guiMutationHandlers,
+  };
+
+  const workflowScopedGuiMutationRegistrationContext: WorkflowScopedGuiMutationRegistrationContext = {
+    ...guiMutationRegistrationContext,
+    workflowMutationDispatcher,
+    runWorkflowMutation,
+  };
+
   function registerGuiMutationHandler<TResult = unknown>(
     channel: string,
     handler: (...args: unknown[]) => Promise<TResult>,
   ): void {
-    guiMutationHandlers.set(channel, handler as (...args: unknown[]) => Promise<unknown>);
-    ipcMain.handle(channel, async (_event, ...args: unknown[]) => {
-      if (ownerMode) {
-        return handler(...args);
-      }
-      const translated = translateGuiMutationToHeadless({ channel, args });
-      if (!translated) {
-        throw new Error(`No owner delegation route is available for ${channel}`);
-      }
-      try {
-        return await messageBus.request<typeof translated.request, TResult>(translated.channel, translated.request);
-      } catch (err) {
-        if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
-          throw new Error('No mutation owner is available');
-        }
-        throw err;
-      }
-    });
+    registerGuiMutationIpcHandler(guiMutationRegistrationContext, channel, handler);
   }
 
   function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
@@ -2256,11 +2244,13 @@ function createEmbeddedTerminalBackendFromConfig(
     priority: WorkflowMutationPriority,
     handler: (...args: unknown[]) => Promise<TResult>,
   ): void {
-    workflowMutationDispatcher.set(channel, (...args: unknown[]) => handler(...args));
-    registerGuiMutationHandler(channel, async (...args: unknown[]) => {
-      const workflowId = resolveWorkflowId(...args);
-      return runWorkflowMutation(workflowId, priority, channel, args, () => handler(...args));
-    });
+    registerWorkflowScopedGuiMutationIpcHandler(
+      workflowScopedGuiMutationRegistrationContext,
+      channel,
+      resolveWorkflowId,
+      priority,
+      handler,
+    );
   }
 
   function createWindow(): void {
@@ -2699,7 +2689,7 @@ function createEmbeddedTerminalBackendFromConfig(
     }, 0);
   }
 
-  app.whenReady().then(async () => {
+  const runGuiReadyBootstrap = async (): Promise<void> => {
     recordStartupMark('app.whenReady');
     ownerMode = true;
     try {
@@ -2955,25 +2945,14 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     // Register IPC handlers
-    ipcMain.on('invoker:get-bootstrap-state-sync', (event) => {
-      const startedAtMs = Date.now();
-      const tasks = orchestrator.getAllTasks();
-      const workflows = listWorkflowsByStartupRecency();
-      const streamSequence = getTaskDeltaStreamSequence();
-      const payload = {
-        tasks,
-        workflows,
-        initialWorkflowId: startupWorkflowId,
-        appStartedAtEpochMs: appProcessStartedAt,
-        streamSequence,
-      };
-      const jsonSizeBytes = Buffer.byteLength(JSON.stringify(payload), 'utf8');
-      recordStartupDuration('bootstrap-ipc.serialize-return', startedAtMs, {
-        taskCount: tasks.length,
-        workflowCount: workflows.length,
-        jsonSizeBytes,
-      });
-      event.returnValue = payload;
+    registerBootstrapStateIpc({
+      ipcMain,
+      getTasks: () => orchestrator.getAllTasks(),
+      getWorkflows: () => listWorkflowsByStartupRecency(),
+      getInitialWorkflowId: () => startupWorkflowId,
+      appStartedAtEpochMs: appProcessStartedAt,
+      getTaskDeltaStreamSequence,
+      recordStartupDuration,
     });
     registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
       const planText = String(planTextArg);
@@ -4054,71 +4033,78 @@ function createEmbeddedTerminalBackendFromConfig(
         createWindow();
       }
     });
-  }).catch((err) => {
-    process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
-    app.quit();
-  });
+  };
 
-  app.on('window-all-closed', () => {
-    logger.info('window-all-closed', { module: 'window' });
-    if (process.platform !== 'darwin') {
+  runElectronReadyBootstrap({
+    app,
+    run: runGuiReadyBootstrap,
+    onError: (err) => {
+      process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
       app.quit();
-    }
+    },
   });
 
   let isQuitting = false;
-  app.on('before-quit', async (event) => {
-    if (isQuitting) return;
-    isQuitting = true;
-    logger.info('before-quit begin', { module: 'process' });
-    event.preventDefault();
-
-    const safetyTimer = setTimeout(() => {
-      console.error('[quit] Cleanup timed out after 10s, forcing exit');
-      process.exit(1);
-    }, 10_000);
-
-    try {
-      if (apiServer) await apiServer.close().catch(() => {});
-      reviewGateStatusWorker?.stop();
-      reviewGateStatusWorker = null;
-      if (dbPollInterval) clearInterval(dbPollInterval);
-      if (activityPollInterval) clearInterval(activityPollInterval);
-      if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);
-      if (hourlyBackupInterval) {
-        clearInterval(hourlyBackupInterval);
-        hourlyBackupInterval = null;
+  registerGuiLifecycleHandlers(app, {
+    onWindowAllClosed: () => {
+      logger.info('window-all-closed', { module: 'window' });
+      if (process.platform !== 'darwin') {
+        app.quit();
       }
-      embeddedTerminalManager.closeAll();
-      if (executorRegistry) {
-        await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
-      }
-      if (orchestrator) {
-        for (const task of orchestrator.getAllTasks()) {
-          if (task.status === 'running' || task.status === 'fixing_with_ai') {
-            if (persistence) {
-              persistShutdownDiagnostic(task, persistence, {
-                flushPendingOutput: flushTaskOutput,
+    },
+    onBeforeQuit: async (event) => {
+      if (isQuitting) return;
+      isQuitting = true;
+      logger.info('before-quit begin', { module: 'process' });
+      event.preventDefault();
+
+      const safetyTimer = setTimeout(() => {
+        console.error('[quit] Cleanup timed out after 10s, forcing exit');
+        process.exit(1);
+      }, 10_000);
+
+      try {
+        if (apiServer) await apiServer.close().catch(() => {});
+        reviewGateStatusWorker?.stop();
+        reviewGateStatusWorker = null;
+        if (dbPollInterval) clearInterval(dbPollInterval);
+        if (activityPollInterval) clearInterval(activityPollInterval);
+        if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);
+        if (hourlyBackupInterval) {
+          clearInterval(hourlyBackupInterval);
+          hourlyBackupInterval = null;
+        }
+        embeddedTerminalManager.closeAll();
+        if (executorRegistry) {
+          await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
+        }
+        if (orchestrator) {
+          for (const task of orchestrator.getAllTasks()) {
+            if (task.status === 'running' || task.status === 'fixing_with_ai') {
+              if (persistence) {
+                persistShutdownDiagnostic(task, persistence, {
+                  flushPendingOutput: flushTaskOutput,
+                });
+              }
+              orchestrator.handleWorkerResponse({
+                requestId: `quit-${task.id}`,
+                actionId: task.id,
+                executionGeneration: task.execution.generation ?? 0,
+                status: 'failed',
+                outputs: { exitCode: 1, error: 'Application quit' },
               });
             }
-            orchestrator.handleWorkerResponse({
-              requestId: `quit-${task.id}`,
-              actionId: task.id,
-              executionGeneration: task.execution.generation ?? 0,
-              status: 'failed',
-              outputs: { exitCode: 1, error: 'Application quit' },
-            });
           }
         }
+        if (persistence) persistence.close();
+        if (writerLock) writerLock.release();
+        if (messageBus) messageBus.disconnect();
+      } finally {
+        clearTimeout(safetyTimer);
+        logger.info('before-quit end -> app.exit(0)', { module: 'process' });
+        app.exit(0);
       }
-      if (persistence) persistence.close();
-      if (writerLock) writerLock.release();
-      if (messageBus) messageBus.disconnect();
-    } finally {
-      clearTimeout(safetyTimer);
-      logger.info('before-quit end -> app.exit(0)', { module: 'process' });
-      app.exit(0);
-    }
+    },
   });
 
   // ── Slack Bot (embedded in GUI process) ──────────────────

--- a/packages/app/src/window/window-lifecycle.ts
+++ b/packages/app/src/window/window-lifecycle.ts
@@ -1,0 +1,166 @@
+import { BrowserWindow, nativeImage, shell, type App } from 'electron';
+import { existsSync } from 'node:fs';
+import * as path from 'node:path';
+import { spawn } from 'node:child_process';
+import type { Logger } from '@invoker/contracts';
+import type { InvokerConfig } from '../config.js';
+
+export interface MainWindowLifecycleDeps {
+  appRootDir: string;
+  invokerConfig: InvokerConfig;
+  logger: Logger;
+  hideE2eWindow: boolean;
+  enableTestCompositor: boolean;
+  recordStartupMark: (phase: string, extra?: Record<string, unknown>) => void;
+  setUiInteractive: (uiInteractive: boolean) => void;
+  startDeferredStartupWork: () => void;
+  setMainWindow: (window: BrowserWindow | null) => void;
+}
+
+export interface MainWindowSecondInstanceDeps {
+  app: Pick<App, 'on'>;
+  getMainWindow: () => BrowserWindow | null;
+}
+
+export interface MainWindowActivateDeps {
+  app: Pick<App, 'on'>;
+  createWindow: () => void;
+  browserWindow?: Pick<typeof BrowserWindow, 'getAllWindows'>;
+}
+
+export function registerMainWindowSecondInstanceHandler(deps: MainWindowSecondInstanceDeps): void {
+  deps.app.on('second-instance', () => {
+    const mainWindow = deps.getMainWindow();
+    if (mainWindow) {
+      if (mainWindow.isMinimized()) mainWindow.restore();
+      mainWindow.focus();
+    }
+  });
+}
+
+export function registerMainWindowActivateHandler(deps: MainWindowActivateDeps): void {
+  const browserWindow = deps.browserWindow ?? BrowserWindow;
+  deps.app.on('activate', () => {
+    if (browserWindow.getAllWindows().length === 0) {
+      deps.createWindow();
+    }
+  });
+}
+
+export function createMainWindow(deps: MainWindowLifecycleDeps): BrowserWindow {
+  deps.recordStartupMark('createWindow.begin');
+  const iconPath = path.join(deps.appRootDir, 'assets', 'icons', 'png', '256x256.png');
+  const icon = nativeImage.createFromPath(iconPath);
+  const mainWindow = new BrowserWindow({
+    width: 1200,
+    height: 800,
+    ...(deps.hideE2eWindow ? { x: -32000, y: -32000, skipTaskbar: true } : {}),
+    // Show explicitly after load/timeout rather than relying on Electron's
+    // implicit initial map behavior, which has regressed on some Linux/X11
+    // sessions and leaves the BrowserWindow unmapped.
+    show: false,
+    webPreferences: {
+      preload: path.join(deps.appRootDir, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+    },
+    icon: !icon.isEmpty() && process.platform !== 'darwin' ? icon : undefined,
+    title: 'Invoker',
+  });
+  deps.setMainWindow(mainWindow);
+
+  // BrowserWindow icons matter on Windows/Linux. macOS uses the bundle icon.
+  if (process.platform !== 'darwin') {
+    if (!icon.isEmpty()) mainWindow.setIcon(icon);
+  }
+
+  const devUrl = process.env.VITE_DEV_SERVER_URL;
+  if (devUrl) {
+    mainWindow.loadURL(devUrl);
+  } else {
+    const packagedUiPath = path.join(deps.appRootDir, 'ui', 'index.html');
+    const repoUiPath = path.join(deps.appRootDir, '..', '..', 'ui', 'dist', 'index.html');
+    const uiDistPath = existsSync(packagedUiPath) ? packagedUiPath : repoUiPath;
+    mainWindow.loadFile(uiDistPath).catch(() => {
+      if (mainWindow.isDestroyed()) return;
+      mainWindow.loadURL(
+        `data:text/html,<html><body style="background:#1a1a2e;color:#eee;font-family:system-ui;padding:2rem"><h1>Invoker</h1><p>UI not built yet. Run: <code>pnpm --filter @invoker/ui build</code></p></body></html>`,
+      );
+    });
+  }
+
+  mainWindow.webContents.on('did-finish-load', () => {
+    deps.logger.info('main window did-finish-load', { module: 'window' });
+    deps.recordStartupMark('window.did-finish-load');
+  });
+
+  mainWindow.webContents.on('did-fail-load', (_event, errorCode, errorDescription, validatedURL) => {
+    deps.logger.error(
+      `main window did-fail-load: code=${errorCode} desc=${errorDescription} url=${validatedURL}`,
+      { module: 'window' },
+    );
+  });
+
+  mainWindow.webContents.on('render-process-gone', (_event, details) => {
+    deps.logger.error(
+      `main window render-process-gone: reason=${details.reason} exitCode=${details.exitCode}`,
+      { module: 'window' },
+    );
+  });
+
+  const shouldShowWindow = process.env.NODE_ENV !== 'test' || deps.enableTestCompositor;
+  if (shouldShowWindow) {
+    let showTriggered = false;
+    const showWindow = (): void => {
+      if (mainWindow.isDestroyed() || showTriggered) return;
+      showTriggered = true;
+      deps.logger.info('main window show()', { module: 'window' });
+      deps.recordStartupMark('window.show');
+      if (deps.hideE2eWindow) {
+        mainWindow.showInactive();
+      } else {
+        mainWindow.show();
+        mainWindow.focus();
+      }
+      deps.setUiInteractive(true);
+      deps.recordStartupMark('ui.interactive');
+      deps.startDeferredStartupWork();
+    };
+
+    mainWindow.once('ready-to-show', showWindow);
+    setTimeout(showWindow, 1500).unref?.();
+  } else {
+    deps.setUiInteractive(true);
+    deps.recordStartupMark('ui.interactive');
+    deps.startDeferredStartupWork();
+  }
+
+  mainWindow.on('closed', () => {
+    deps.logger.info('main window closed', { module: 'window' });
+    deps.setMainWindow(null);
+  });
+
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (url.startsWith('https://') || url.startsWith('http://')) {
+      const browserCmd = deps.invokerConfig.browser;
+      if (browserCmd) {
+        spawn(browserCmd, [url], { detached: true, stdio: 'ignore' }).unref();
+      } else {
+        const chromeCmd: [string, string[]] = process.platform === 'darwin'
+          ? ['open', ['-a', 'Google Chrome', url]]
+          : process.platform === 'win32'
+            ? ['cmd', ['/c', 'start', 'chrome', url]]
+            : ['google-chrome', [url]];
+        try {
+          spawn(chromeCmd[0], chromeCmd[1], { detached: true, stdio: 'ignore' }).unref();
+        } catch {
+          shell.openExternal(url);
+        }
+      }
+    }
+    return { action: 'deny' as const };
+  });
+
+  return mainWindow;
+}


### PR DESCRIPTION
## Summary

`main.ts` is now a thinner Electron composition root for GUI and headless startup.

Bootstrap, IPC registration, BrowserWindow lifecycle, and TaskRunner wiring moved into focused app modules with typed dependency bags.

External IPC channels and execution contracts stay unchanged while the callsite surface in `main.ts` shrinks.

New tests cover extracted startup, IPC delegation, runner callbacks, and window lifecycle behavior.

## Architecture

### Before

```mermaid
graph TD
    MAIN["packages/app/src/main.ts"]
    APP["Electron app lifecycle"]
    IPC["IPC handler registration"]
    WINDOW["BrowserWindow lifecycle"]
    RUNNER["TaskRunner construction and callbacks"]
    SERVICES["Runtime services and workflow state"]

    MAIN --> APP
    MAIN --> IPC
    MAIN --> WINDOW
    MAIN --> RUNNER
    MAIN --> SERVICES
    IPC --> SERVICES
    RUNNER --> SERVICES
```

### After

```mermaid
graph TD
    MAIN["main.ts composition root"]
    BOOT["bootstrap/app-bootstrap.ts"]
    IPCREG["ipc/ipc-registration.ts"]
    WINDOW["window/window-lifecycle.ts"]
    RUNNER["execution/task-runner-wiring.ts"]
    ELECTRON["Electron app and BrowserWindow"]
    SERVICES["Runtime services and workflow state"]

    MAIN --> BOOT
    MAIN --> IPCREG
    MAIN --> WINDOW
    MAIN --> RUNNER
    BOOT --> ELECTRON
    IPCREG --> SERVICES
    WINDOW --> ELECTRON
    RUNNER --> SERVICES
```

## Test Plan

- [x] `cd packages/app && pnpm test -- src/__tests__/bridge-orchestrator-executor.test.ts`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No