### PR TITLE
Reduce Large Files Step 3: orchestrator.ts decomposition

### DIFF
--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -200,7 +200,7 @@ export interface ExecutionResourceLeaseReleaseRow {
 export type TaskLaunchReadiness =
   | { ready: true; task: TaskState }
   | { ready: false; reason: string; task?: TaskState };
-type LaunchReadinessOptions = { bypassLocalDependencyReadiness?: boolean };
+export type LaunchReadinessOptions = { bypassLocalDependencyReadiness?: boolean };
 
 export interface OrchestratorPersistence {
   saveWorkflow(workflow: {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -80,6 +80,29 @@ import {
   assertMergeExperimentDependenciesInvariantImpl,
 } from './graph-mutation.js';
 import type { GraphMutationHost } from './graph-mutation.js';
+import {
+  autoStartReadyTasksImpl,
+  enqueueIfNotScheduledImpl,
+  autoStartExternallyUnblockedReadyTasksImpl,
+  autoStartUnblockedTasksImpl,
+  getTaskLaunchReadinessImpl,
+  areLocalDependenciesSatisfiedImpl,
+  getLocalDependencyBlockerImpl,
+  drainSchedulerImpl,
+} from './orchestrator/scheduler-domain.js';
+import type { SchedulerDomainHost } from './orchestrator/scheduler-domain.js';
+import {
+  handleCompletedImpl,
+  finalizeFailedTaskImpl,
+  handleReviewReadyImpl,
+  handleFailedImpl,
+  handleNeedsInputImpl,
+  handleSpawnExperimentsImpl,
+  handleSelectExperimentImpl,
+  checkExperimentCompletionImpl,
+  checkWorkflowCompletionImpl,
+} from './orchestrator/transitions.js';
+import type { TransitionHost } from './orchestrator/transitions.js';
 import { buildPlanLocalToScopedIdMap, scopePlanTaskId } from './task-id-scope.js';
 import type { TaskRepository } from './task-repository.js';
 import {
@@ -4260,106 +4283,7 @@ export class Orchestrator {
     taskId: string,
     parsed: Extract<ParsedResponse, { type: 'completed' }>,
   ): TaskState[] {
-    const task = this.stateGetTask(taskId);
-    const needsApproval = task?.config.requiresManualApproval === true;
-
-    const execution: {
-      exitCode: number;
-      completedAt: Date;
-      commit?: string;
-      agentSessionId?: string;
-      agentName?: string;
-      lastAgentSessionId?: string;
-      lastAgentName?: string;
-      branch?: string;
-      reviewUrl?: string;
-      reviewId?: string;
-      reviewStatus?: string;
-    } = {
-      exitCode: parsed.exitCode,
-      completedAt: new Date(),
-    };
-    if (parsed.commitHash !== undefined) {
-      execution.commit = parsed.commitHash;
-    }
-    if (parsed.agentSessionId !== undefined) {
-      execution.agentSessionId = parsed.agentSessionId;
-      execution.lastAgentSessionId = parsed.agentSessionId;
-      execution.lastAgentName = parsed.agentName ?? task?.execution.agentName ?? task?.execution.lastAgentName;
-    }
-    if (parsed.agentName !== undefined) {
-      execution.agentName = parsed.agentName;
-      execution.lastAgentName = parsed.agentName;
-    }
-    if (parsed.branch !== undefined) {
-      execution.branch = parsed.branch;
-    }
-    if (parsed.reviewUrl !== undefined) {
-      execution.reviewUrl = parsed.reviewUrl;
-    }
-    if (parsed.reviewId !== undefined) {
-      execution.reviewId = parsed.reviewId;
-    }
-    if (parsed.reviewStatus !== undefined) {
-      execution.reviewStatus = parsed.reviewStatus;
-    }
-
-    const changes: TaskStateChanges = {
-      status: needsApproval ? 'awaiting_approval' : 'completed',
-      config: { summary: parsed.summary },
-      execution,
-    };
-    const completedUpdated = this.writeAndSync(taskId, changes);
-    const delta: TaskDelta = this.buildUpdateDelta(task!, completedUpdated, changes);
-    const eventName = needsApproval ? 'task.awaiting_approval' : 'task.completed';
-    this.persistence.logEvent?.(taskId, eventName, changes);
-    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
-
-    // Dual-write: update current selected attempt to completed (best-effort)
-    try {
-      const currentAttemptId = this.stateGetTask(taskId)?.execution.selectedAttemptId;
-      const currentAttempt = currentAttemptId ? this.persistence.loadAttempt(currentAttemptId) : undefined;
-      if (currentAttempt && currentAttempt.status === 'running') {
-        this.taskRepository.updateAttempt(currentAttempt.id, {
-          status: needsApproval ? 'needs_input' : 'completed',
-          exitCode: parsed.exitCode,
-          completedAt: new Date(),
-          ...(parsed.commitHash !== undefined ? { commit: parsed.commitHash } : {}),
-          ...(parsed.agentSessionId !== undefined ? { agentSessionId: parsed.agentSessionId } : {}),
-        });
-      }
-    } catch { /* best effort */ }
-
-    // If task requires manual approval, don't trigger downstream tasks yet
-    if (needsApproval) return [];
-
-    this.checkExperimentCompletion(taskId);
-
-    const readyTaskIds = this.stateMachine.findNewlyReadyTasks(taskId);
-    this.logger.info('[orchestrator] handleCompleted', {
-      taskId,
-      newlyReadyCount: readyTaskIds.length,
-      readyTaskIds,
-    });
-    const started = this.autoStartReadyTasks(readyTaskIds);
-    started.push(...this.autoStartUnblockedTasks());
-    started.push(...this.autoStartExternallyUnblockedReadyTasks());
-
-    // Re-enqueue deferred tasks now that a slot freed up
-    if (this.deferredTaskIds.size > 0) {
-      for (const id of this.deferredTaskIds) {
-        const t = this.stateGetTask(id);
-        if (t && t.status === 'pending') {
-          const attemptId = this.ensureCurrentPendingAttempt(t);
-          this.scheduler.enqueue({ taskId: id, attemptId, priority: 0 });
-        }
-      }
-      this.deferredTaskIds.clear();
-      started.push(...this.drainScheduler());
-    }
-
-    this.checkWorkflowCompletion();
-    return started;
+    return handleCompletedImpl(this as unknown as TransitionHost, taskId, parsed);
   }
 
   /**
@@ -4379,199 +4303,42 @@ export class Orchestrator {
     },
     eventName: string,
   ): TaskState[] {
-    const existing = this.stateGetTask(taskId);
-    if (!existing) {
-      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `finalizeFailedTask: task ${taskId} not found in graph`);
-    }
-
-    const changes: TaskStateChanges = {
-      status: 'failed',
-      execution: {
-        ...executionFields,
-        completedAt: new Date(),
-      },
-    };
-
-    // Atomic write for task + attempt via repository
-    this.taskRepository.failTaskAndAttempt(taskId, changes, {
-      status: 'failed',
-      exitCode: executionFields.exitCode,
-      error: executionFields.error,
-      completedAt: new Date(),
-    });
-
-    // Sync to in-memory state (same pattern as writeAndSync)
-    const updated: TaskState = {
-      ...existing,
-      status: 'failed',
-      execution: { ...existing.execution, ...changes.execution },
-      taskStateVersion: existing.taskStateVersion + 1,
-    };
-    this.stateMachine.restoreTask(updated);
-
-    const delta: TaskDelta = this.buildUpdateDelta(existing, updated, changes);
-    this.persistence.logEvent?.(taskId, eventName, changes);
-    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
-
-    this.checkExperimentCompletion(taskId);
-
-    const readyTaskIds = this.stateMachine.findNewlyReadyTasks(taskId);
-    this.logger.info('[orchestrator] finalizeFailedTask', {
-      taskId,
-      eventName,
-      newlyReadyCount: readyTaskIds.length,
-      readyTaskIds,
-    });
-    const started = this.autoStartReadyTasks(readyTaskIds);
-    started.push(...this.autoStartUnblockedTasks());
-    started.push(...this.autoStartExternallyUnblockedReadyTasks());
-
-    // Re-enqueue deferred tasks now that a slot freed up
-    if (this.deferredTaskIds.size > 0) {
-      for (const id of this.deferredTaskIds) {
-        const t = this.stateGetTask(id);
-        if (t && t.status === 'pending') {
-          const attemptId = this.ensureCurrentPendingAttempt(t);
-          this.scheduler.enqueue({ taskId: id, attemptId, priority: 0 });
-        }
-      }
-      this.deferredTaskIds.clear();
-      started.push(...this.drainScheduler());
-    }
-
-    this.checkWorkflowCompletion();
-    return started;
+    return finalizeFailedTaskImpl(this as unknown as TransitionHost, taskId, executionFields, eventName);
   }
 
   private handleReviewReady(
     taskId: string,
     parsed: Extract<ParsedResponse, { type: 'review_ready' }>,
   ): TaskState[] {
-    const changes: TaskStateChanges = {
-      config: { summary: parsed.summary },
-      execution: {
-        exitCode: parsed.exitCode,
-        branch: parsed.branch,
-        reviewUrl: parsed.reviewUrl,
-        reviewId: parsed.reviewId,
-        reviewStatus: parsed.reviewStatus,
-        reviewGate: parsed.reviewGate,
-      },
-    };
-    this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', changes);
-
-    const started = this.autoStartUnblockedTasks();
-    started.push(...this.autoStartExternallyUnblockedReadyTasks());
-    this.checkWorkflowCompletion();
-    return started;
+    return handleReviewReadyImpl(this as unknown as TransitionHost, taskId, parsed);
   }
 
   private handleFailed(
     taskId: string,
     parsed: Extract<ParsedResponse, { type: 'failed' }>,
   ): TaskState[] {
-    const mergeConflict = parseMergeConflictError(parsed.error);
-    return this.finalizeFailedTask(
-      taskId,
-      {
-        exitCode: parsed.exitCode,
-        error: parsed.error,
-        agentName: parsed.agentName,
-        lastAgentName: parsed.agentName,
-        mergeConflict,
-      },
-      'task.failed',
-    );
+    return handleFailedImpl(this as unknown as TransitionHost, taskId, parsed);
   }
 
   private handleNeedsInput(
     taskId: string,
     parsed: Extract<ParsedResponse, { type: 'needs_input' }>,
   ): TaskState[] {
-    const changes: TaskStateChanges = {
-      status: 'needs_input',
-      execution: { inputPrompt: parsed.prompt },
-    };
-    const needsInputBefore = this.stateGetTask(taskId)!;
-    const needsInputUpdated = this.writeAndSync(taskId, changes);
-    const currentAttemptId = needsInputUpdated.execution.selectedAttemptId;
-    if (currentAttemptId) {
-      this.taskRepository.updateAttempt(currentAttemptId, { status: 'needs_input' });
-    }
-    const delta: TaskDelta = this.buildUpdateDelta(needsInputBefore, needsInputUpdated, changes);
-    this.persistence.logEvent?.(taskId, 'task.needs_input', changes);
-    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
-    return [];
+    return handleNeedsInputImpl(this as unknown as TransitionHost, taskId, parsed);
   }
 
   private handleSpawnExperiments(
     taskId: string,
     parsed: Extract<ParsedResponse, { type: 'spawn_experiments' }>,
   ): TaskState[] {
-    const parentTask = this.stateGetTask(taskId);
-    const wfId = parentTask?.config.workflowId;
-    if (!wfId) {
-      this.logger.warn('[orchestrator] handleSpawnExperiments: missing workflowId; skipping', {
-        taskId,
-      });
-      return [];
-    }
-    const scopeLocal = (local: string) => scopePlanTaskId(wfId, local);
-
-    const experimentTasks: GraphMutationNodeDef[] = parsed.variants.map((v) => ({
-      id: scopeLocal(v.id),
-      description: v.description ?? `Experiment: ${v.id}`,
-      dependencies: [taskId],
-      workflowId: wfId,
-      parentTask: taskId,
-      experimentPrompt: v.prompt,
-      prompt: v.prompt,
-      command: v.command,
-      runnerKind: parentTask?.config.runnerKind,
-    }));
-
-    const reconciliationId = `${taskId}-reconciliation`;
-    const newNodes: GraphMutationNodeDef[] = [
-      ...experimentTasks,
-      {
-        id: reconciliationId,
-        description: `Review and select winning experiment for ${taskId}`,
-        dependencies: experimentTasks.map((t) => t.id),
-        workflowId: wfId,
-        parentTask: taskId,
-        isReconciliation: true,
-        requiresManualApproval: true,
-      },
-    ];
-
-    const wf =
-      wfId && typeof this.persistence.loadWorkflow === 'function'
-        ? this.persistence.loadWorkflow(wfId)
-        : undefined;
-    const pivotBranch =
-      wf && typeof (wf as { baseBranch?: string }).baseBranch === 'string'
-        ? (wf as { baseBranch: string }).baseBranch.trim()
-        : '';
-    const sourceChanges =
-      pivotBranch !== '' ? { execution: { branch: pivotBranch } } : undefined;
-
-    this.applyGraphMutation({
-      sourceNodeId: taskId,
-      sourceDisposition: 'complete',
-      sourceChanges,
-      newNodes,
-      outputNodeId: reconciliationId,
-    });
-
-    const readyIds = experimentTasks.map((t) => t.id);
-    return this.autoStartReadyTasks(readyIds);
+    return handleSpawnExperimentsImpl(this as unknown as TransitionHost, taskId, parsed);
   }
 
   private handleSelectExperiment(
     taskId: string,
     parsed: Extract<ParsedResponse, { type: 'select_experiment' }>,
   ): TaskState[] {
-    return this.selectExperiment(taskId, parsed.experimentId);
+    return handleSelectExperimentImpl(this as unknown as TransitionHost, taskId, parsed);
   }
 
   // ── Private: Graph Mutation Primitive ─────────────────────
@@ -4592,130 +4359,19 @@ export class Orchestrator {
   // ── Private: Helpers ──────────────────────────────────────
 
   private checkExperimentCompletion(taskId: string): void {
-    for (const recon of this.stateMachine.getAllTasks()) {
-      if (!recon.config.isReconciliation) continue;
-      if (
-        recon.status === 'needs_input' ||
-        recon.status === 'completed' ||
-        recon.status === 'running' ||
-        recon.status === 'fixing_with_ai'
-      ) {
-        continue;
-      }
-      if (!recon.dependencies.includes(taskId)) continue;
-
-      const allReported = recon.dependencies.every((depId) => {
-        const dep = this.stateGetTask(depId);
-        return dep && (dep.status === 'completed' || dep.status === 'failed');
-      });
-
-      if (allReported) {
-        const experimentResults = recon.dependencies.map((depId) => {
-          const dep = this.stateGetTask(depId)!;
-          return {
-            id: depId,
-            status: (dep.status === 'completed' ? 'completed' : 'failed') as 'completed' | 'failed',
-            summary: dep.config.summary,
-            exitCode: dep.execution.exitCode,
-          };
-        });
-
-        // Persist results only; reconciliation stays pending until the scheduler runs it.
-        // TaskRunner then acquires a worktree and emits `needs_input` (open-terminal cwd).
-        const reconChanges: TaskStateChanges = {
-          execution: { experimentResults },
-        };
-        const reconUpdated = this.writeAndSync(recon.id, reconChanges);
-        const delta: TaskDelta = this.buildUpdateDelta(recon, reconUpdated, reconChanges);
-        this.persistence.logEvent?.(recon.id, 'task.experiment_results_recorded', reconChanges);
-        this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
-      }
-    }
+    checkExperimentCompletionImpl(this as unknown as TransitionHost, taskId);
   }
 
   private checkWorkflowCompletion(): void {
-    for (const wfId of this.activeWorkflowIds) {
-      this.touchWorkflow(wfId);
-    }
+    checkWorkflowCompletionImpl(this as unknown as TransitionHost);
   }
 
   private autoStartReadyTasks(taskIds: string[], priority: number = 0, opts?: LaunchReadinessOptions): TaskState[] {
-    for (const taskId of taskIds) {
-      let task = this.stateGetTask(taskId);
-      if (!task) continue;
-      if (this.getExternalDependencyBlocker(task) !== undefined) continue;
-
-      // Unblock: if a blocked task's deps are all complete, it's genuinely ready
-      if (task.status === 'blocked') {
-        this.logger.info('[orchestrator] autoStartReadyTasks: unblocking blocked task', {
-          taskId,
-        });
-        this.replaceSelectedAttempt(task, { status: 'pending' });
-        this.writeAndSync(taskId, {
-          status: 'pending',
-          execution: {
-            startedAt: undefined,
-            completedAt: undefined,
-            lastHeartbeatAt: undefined,
-            launchStartedAt: undefined,
-            launchCompletedAt: undefined,
-            phase: undefined,
-          },
-        });
-        task = this.stateGetTask(taskId);
-        if (!task) continue;
-      }
-
-      this.enqueueIfNotScheduled(taskId, priority, opts);
-    }
-
-    return this.drainScheduler();
+    return autoStartReadyTasksImpl(this as unknown as SchedulerDomainHost, taskIds, priority, opts);
   }
 
   private enqueueIfNotScheduled(taskId: string, priority: number = 0, opts?: LaunchReadinessOptions): void {
-    const task = this.stateGetTask(taskId);
-    if (!task) return;
-    if (this.getExternalDependencyBlocker(task) !== undefined) return;
-
-    const attemptId = this.ensureCurrentPendingAttempt(task);
-    const currentAttempt = this.loadAttemptById(attemptId);
-    if ((currentAttempt?.queuePriority ?? 0) !== priority) {
-      this.taskRepository.updateAttempt(attemptId, { queuePriority: priority });
-    }
-    // A task can be force-set back to blocked/pending by recovery logic while
-    // still carrying a stale selectedAttemptId from an older run. Only skip
-    // re-enqueue when the task is actually active.
-    if (
-      (task.status === 'running' || task.status === 'fixing_with_ai') &&
-      task.execution.selectedAttemptId === attemptId &&
-      this.isAttemptLeaseActive(currentAttempt)
-    ) {
-      return;
-    }
-    const queuedJob = this.scheduler
-      .getQueuedJobs()
-      .find((job) => job.attemptId === attemptId || job.taskId === taskId);
-    if (queuedJob) {
-      const shouldReplaceQueuedJob =
-        priority > queuedJob.priority ||
-        (opts?.bypassLocalDependencyReadiness === true && !queuedJob.bypassLocalDependencyReadiness);
-      if (shouldReplaceQueuedJob) {
-        this.scheduler.removeJob(queuedJob.attemptId ?? queuedJob.taskId);
-        this.scheduler.enqueue({
-          taskId,
-          attemptId,
-          priority: Math.max(priority, queuedJob.priority),
-          ...(opts?.bypassLocalDependencyReadiness ? { bypassLocalDependencyReadiness: true } : {}),
-        });
-      }
-      return;
-    }
-    this.scheduler.enqueue({
-      taskId,
-      attemptId,
-      priority,
-      ...(opts?.bypassLocalDependencyReadiness ? { bypassLocalDependencyReadiness: true } : {}),
-    });
+    enqueueIfNotScheduledImpl(this as unknown as SchedulerDomainHost, taskId, priority, opts);
   }
 
   /**
@@ -4737,83 +4393,23 @@ export class Orchestrator {
    * moving an upstream gate out of `running`.
    */
   autoStartExternallyUnblockedReadyTasks(): TaskState[] {
-    const started = this.autoStartUnblockedTasks();
-    const readyTasks = this.stateMachine
-      .getReadyTasks()
-      .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
-
-    for (const task of readyTasks) {
-      this.enqueueIfNotScheduled(task.id);
-    }
-    started.push(...this.drainScheduler());
-    return started;
+    return autoStartExternallyUnblockedReadyTasksImpl(this as unknown as SchedulerDomainHost);
   }
 
   private autoStartUnblockedTasks(): TaskState[] {
-    for (const task of this.stateMachine.getAllTasks()) {
-      if (task.status !== 'blocked') continue;
-      if (!this.areLocalDependenciesSatisfied(task)) continue;
-      if (this.getExternalDependencyBlocker(task) !== undefined) continue;
-
-      this.replaceSelectedAttempt(task, { status: 'pending' });
-      this.writeAndSync(task.id, {
-        status: 'pending',
-        execution: {
-          blockedBy: undefined,
-          startedAt: undefined,
-          completedAt: undefined,
-          lastHeartbeatAt: undefined,
-          launchStartedAt: undefined,
-          launchCompletedAt: undefined,
-          phase: undefined,
-        },
-      });
-      this.enqueueIfNotScheduled(task.id);
-    }
-    return this.drainScheduler();
+    return autoStartUnblockedTasksImpl(this as unknown as SchedulerDomainHost);
   }
 
   getTaskLaunchReadiness(taskId: string, opts?: LaunchReadinessOptions): TaskLaunchReadiness {
-    this.refreshFromDb();
-    const task = this.stateGetTask(taskId);
-    if (!task) {
-      return { ready: false, reason: `task ${taskId} not found` };
-    }
-    if (task.status !== 'pending') {
-      return { ready: false, reason: `task status is ${task.status}`, task };
-    }
-
-    if (!opts?.bypassLocalDependencyReadiness) {
-      const localBlocker = this.getLocalDependencyBlocker(task);
-      if (localBlocker) {
-        return { ready: false, reason: localBlocker, task };
-      }
-    }
-
-    const externalBlocker = this.getExternalDependencyBlocker(task);
-    if (externalBlocker) {
-      return { ready: false, reason: externalBlocker, task };
-    }
-
-    return { ready: true, task };
+    return getTaskLaunchReadinessImpl(this as unknown as SchedulerDomainHost, taskId, opts);
   }
 
   private areLocalDependenciesSatisfied(task: TaskState): boolean {
-    return this.getLocalDependencyBlocker(task) === undefined;
+    return areLocalDependenciesSatisfiedImpl(this as unknown as SchedulerDomainHost, task);
   }
 
   private getLocalDependencyBlocker(task: TaskState): string | undefined {
-    for (const depId of task.dependencies) {
-      const dep = this.stateGetTask(depId);
-      if (!dep) return `missing dependency ${depId}`;
-      const satisfied = task.config?.isReconciliation
-        ? dep.status === 'completed' || dep.status === 'failed' || dep.status === 'closed' || dep.status === 'stale'
-        : dep.status === 'completed' || dep.status === 'stale';
-      if (!satisfied) {
-        return `waiting on ${depId} (${dep.status})`;
-      }
-    }
-    return undefined;
+    return getLocalDependencyBlockerImpl(this as unknown as SchedulerDomainHost, task);
   }
 
   private externalDependencyDisplayId(workflowId: string, taskId?: string): string {
@@ -5139,163 +4735,7 @@ export class Orchestrator {
 
   /** Drain the scheduler queue, starting tasks that fit the concurrency limit. */
   private drainScheduler(): TaskState[] {
-    const started: TaskState[] = [];
-    const activeAttempts = this.countActivePersistedAttempts();
-    let availableSlots = Math.max(0, this.maxConcurrency - activeAttempts);
-    this.logger.info('[orchestrator] drainScheduler: begin', {
-      active: activeAttempts,
-      maxConcurrency: this.maxConcurrency,
-      availableSlots,
-    });
-    let job = availableSlots > 0 ? this.scheduler.takeNext() : null;
-    while (job && availableSlots > 0) {
-      const readiness = this.getTaskLaunchReadiness(job.taskId, {
-        bypassLocalDependencyReadiness: job.bypassLocalDependencyReadiness,
-      });
-      this.logger.info('[orchestrator] drainScheduler: dequeued', {
-        taskId: job.taskId,
-        actualStatus: readiness.task?.status ?? 'NOT_FOUND',
-      });
-      if (!readiness.ready) {
-        this.logger.info('[orchestrator] drainScheduler: skipping non-ready task', {
-          taskId: job.taskId,
-          reason: readiness.reason,
-        });
-        job = this.scheduler.takeNext();
-        continue;
-      }
-      const task = readiness.task;
-
-      const now = new Date();
-      let attemptId = job.attemptId ?? this.ensureCurrentPendingAttempt(task);
-      let currentAttempt = this.loadAttemptById(attemptId);
-      if (!currentAttempt || isDiscardedAttempt(currentAttempt)) {
-        attemptId = this.ensureCurrentPendingAttempt(task);
-        currentAttempt = this.loadAttemptById(attemptId);
-      }
-      if (!currentAttempt || isDiscardedAttempt(currentAttempt)) {
-        this.logger.info('[orchestrator] drainScheduler: skipping non-runnable attempt', {
-          taskId: job.taskId,
-          attemptId,
-          attemptStatus: currentAttempt?.status ?? 'missing',
-        });
-        job = this.scheduler.takeNext();
-        continue;
-      }
-      let launchAttemptId = attemptId;
-      const selectedTask = this.stateGetTask(job.taskId) ?? task;
-      if (selectedTask.execution.selectedAttemptId !== attemptId) {
-        this.writeAndSync(job.taskId, { execution: { selectedAttemptId: attemptId } });
-      }
-      let claimSucceeded = false;
-      const claimPatch = this.deferRunningUntilLaunch
-        ? {
-            status: 'claimed' as const,
-            claimedAt: now,
-            lastHeartbeatAt: now,
-            leaseExpiresAt: nextLeaseExpiry(now),
-          }
-        : {
-            status: 'running' as const,
-            claimedAt: currentAttempt?.claimedAt ?? now,
-            startedAt: now,
-            lastHeartbeatAt: now,
-            leaseExpiresAt: nextLeaseExpiry(now),
-          };
-      claimSucceeded = this.taskRepository.claimAttemptForLaunch?.(attemptId, claimPatch, now)
-        ?? !this.isAttemptLeaseActive(currentAttempt, now.getTime());
-      if (claimSucceeded && !this.taskRepository.claimAttemptForLaunch) {
-        this.taskRepository.updateAttempt(attemptId, claimPatch);
-      }
-      if (!claimSucceeded) {
-        this.logger.info('[orchestrator] drainScheduler: skipping already-claimed attempt', {
-          taskId: job.taskId,
-          attemptId,
-        });
-        job = availableSlots > 0 ? this.scheduler.takeNext() : null;
-        continue;
-      }
-
-      const changes: TaskStateChanges = this.deferRunningUntilLaunch
-        ? {
-            status: 'pending',
-            execution: {
-              selectedAttemptId: launchAttemptId,
-              generation: this.getExecutionGeneration(task),
-              lastHeartbeatAt: now,
-              phase: 'launching',
-              launchStartedAt: now,
-              launchCompletedAt: undefined,
-            },
-          }
-        : {
-            status: 'running',
-            execution: {
-              selectedAttemptId: launchAttemptId,
-              generation: this.getExecutionGeneration(task),
-              startedAt: now,
-              lastHeartbeatAt: now,
-              phase: 'launching',
-              launchStartedAt: now,
-              launchCompletedAt: undefined,
-            },
-          };
-      const updated = this.writeAndSync(job.taskId, changes);
-      this.persistence.logEvent?.(
-        job.taskId,
-        this.deferRunningUntilLaunch ? 'task.launch_claimed' : 'task.running',
-        changes,
-      );
-      if (
-        typeof this.persistence.enqueueLaunchDispatch === 'function'
-        && task.config.workflowId
-      ) {
-        try {
-          const dispatch = this.persistence.enqueueLaunchDispatch({
-            taskId: job.taskId,
-            attemptId: launchAttemptId,
-            workflowId: task.config.workflowId,
-            generation: this.getExecutionGeneration(task),
-          });
-          this.persistence.logEvent?.(job.taskId, 'task.dispatch_enqueued', {
-            ...changes,
-            dispatchId: dispatch.id,
-            attemptId: launchAttemptId,
-            workflowId: task.config.workflowId,
-            generation: this.getExecutionGeneration(task),
-            state: dispatch.state,
-            priority: dispatch.priority,
-          });
-          this.logger.info('[orchestrator] drainScheduler: launch dispatch enqueued', {
-            taskId: job.taskId,
-            attemptId: launchAttemptId,
-            workflowId: task.config.workflowId,
-            generation: this.getExecutionGeneration(task),
-            dispatchId: dispatch.id,
-            state: dispatch.state,
-            priority: dispatch.priority,
-          });
-        } catch (err) {
-          this.logger.warn('[orchestrator] drainScheduler: enqueueLaunchDispatch failed', {
-            taskId: job.taskId,
-            attemptId: launchAttemptId,
-            error: err instanceof Error ? err.message : String(err),
-          });
-        }
-      }
-      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
-      started.push(updated);
-      this.logger.info('[orchestrator] drainScheduler: started', {
-        taskId: job.taskId,
-        attemptId: launchAttemptId,
-        phase: 'launching',
-        generation: changes.execution?.generation ?? 'unknown',
-      });
-
-      availableSlots -= 1;
-      job = availableSlots > 0 ? this.scheduler.takeNext() : null;
-    }
-    return started;
+    return drainSchedulerImpl(this as unknown as SchedulerDomainHost);
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -26,7 +26,6 @@ import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
 import type { Logger, WorkResponse } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import { normalizeRunnerKind } from '@invoker/workflow-graph';
-import { parseMergeConflictError } from './merge-conflict-error.js';
 import {
   buildExecutorRoutedPayload,
   buildHeavyweightRoutingRules,
@@ -103,6 +102,19 @@ import {
   checkWorkflowCompletionImpl,
 } from './orchestrator/transitions.js';
 import type { TransitionHost } from './orchestrator/transitions.js';
+import {
+  buildTaskUpdateDelta,
+  buildTaskRemoveDelta,
+} from './orchestrator/events.js';
+import {
+  recreateWorkflowFromFreshBaseImpl,
+  getKnownFreshBaseCommitImpl,
+  beginConflictResolutionImpl,
+  beginAutoFixSessionImpl,
+  revertConflictResolutionImpl,
+  getMergeNodeImpl,
+} from './orchestrator/merge.js';
+import type { MergeHost } from './orchestrator/merge.js';
 import { buildPlanLocalToScopedIdMap, scopePlanTaskId } from './task-id-scope.js';
 import type { TaskRepository } from './task-repository.js';
 import {
@@ -170,7 +182,6 @@ const RECREATE_RESET_CHANGES: TaskStateChanges = {
   },
 };
 
-const FIX_FAILURE_PREFIX_RE = /^\[Fix with (?:Claude|Agent) failed\] [^\n]*\n\n/;
 const TRACE_PERSIST_SYNC = process.env.INVOKER_TRACE_PERSIST_SYNC === '1';
 const TRACE_WORKER_RESPONSE = process.env.INVOKER_TRACE_WORKER_RESPONSE === '1';
 const noopLogger: Logger = {
@@ -180,10 +191,6 @@ const noopLogger: Logger = {
   error() {},
   child() { return noopLogger; },
 };
-
-function stripFixFailureWrapper(errorText: string): string {
-  return errorText.replace(FIX_FAILURE_PREFIX_RE, '');
-}
 
 function nextLeaseExpiry(from: Date): Date {
   return new Date(from.getTime() + ATTEMPT_LEASE_MS);
@@ -779,24 +786,14 @@ export class Orchestrator {
    * returned by writeAndSync.
    */
   private buildUpdateDelta(before: TaskState, after: TaskState, changes: TaskStateChanges): TaskDelta {
-    return {
-      type: 'updated',
-      taskId: after.id,
-      changes,
-      taskStateVersion: after.taskStateVersion,
-      previousTaskStateVersion: before.taskStateVersion,
-    };
+    return buildTaskUpdateDelta(before, after, changes);
   }
 
   /**
    * Build a 'removed' TaskDelta with the task's last known task-state version.
    */
   private buildRemoveDelta(task: TaskState): TaskDelta {
-    return {
-      type: 'removed',
-      taskId: task.id,
-      previousTaskStateVersion: task.taskStateVersion,
-    };
+    return buildTaskRemoveDelta(task);
   }
 
   private touchWorkflow(workflowId: string): void {
@@ -2649,26 +2646,7 @@ export class Orchestrator {
       ) => Promise<{ commit?: string; branch?: string } | undefined | void>;
     },
   ): Promise<TaskState[]> {
-    if (options?.refreshBase) {
-      const fresh = await options.refreshBase(workflowId);
-      if (fresh && typeof fresh === 'object') {
-        if (typeof fresh.commit === 'string' && fresh.commit.length > 0) {
-          this.knownFreshBaseCommits.set(workflowId, fresh.commit);
-          this.logger.info('[orchestrator] recreateWorkflowFromFreshBase fresh base commit', {
-            workflowId,
-            freshBaseCommit: fresh.commit.slice(0, 12),
-          });
-        }
-        if (typeof fresh.branch === 'string' && fresh.branch.length > 0 && this.persistence.updateWorkflow) {
-          this.persistence.updateWorkflow(workflowId, { baseBranch: fresh.branch });
-          this.logger.info('[orchestrator] recreateWorkflowFromFreshBase fresh base branch', {
-            workflowId,
-            freshBaseBranch: fresh.branch,
-          });
-        }
-      }
-    }
-    return this.recreateWorkflow(workflowId);
+    return recreateWorkflowFromFreshBaseImpl(this as unknown as MergeHost, workflowId, options);
   }
 
   /**
@@ -2684,7 +2662,7 @@ export class Orchestrator {
    * prove the fresh-base step actually advanced.
    */
   getKnownFreshBaseCommit(workflowId: string): string | undefined {
-    return this.knownFreshBaseCommits.get(workflowId);
+    return getKnownFreshBaseCommitImpl(this as unknown as MergeHost, workflowId);
   }
 
   /**
@@ -2693,51 +2671,7 @@ export class Orchestrator {
    * Returns the saved error string so the caller can revert on failure.
    */
   beginConflictResolution(taskId: string, expectedLineage?: TaskLineageExpectation): { savedError: string } {
-    this.refreshFromDb();
-    const task = this.stateGetTask(taskId);
-    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-    if (!this.taskMatchesLineageExpectation(task, expectedLineage)) {
-      throw new Error(`Task ${taskId} lineage is stale for conflict resolution start`);
-    }
-    if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
-
-    const savedError = task.execution.error ?? '';
-    const startedAt = new Date();
-
-    const id = task.id;
-    const changes: TaskStateChanges = {
-      status: 'fixing_with_ai',
-      execution: {
-        error: undefined,
-        exitCode: undefined,
-        completedAt: undefined,
-        mergeConflict: undefined,
-        isFixingWithAI: false,
-        startedAt,
-        lastHeartbeatAt: startedAt,
-      },
-    };
-    const changesWithGeneration = this.withBumpedExecutionGeneration(task, changes);
-    const conflictUpdated = this.writeAndSync(taskId, changesWithGeneration);
-    const attemptId = this.replaceSelectedAttempt(task);
-    this.taskRepository.updateAttempt(attemptId, {
-      status: 'running',
-      startedAt,
-      lastHeartbeatAt: startedAt,
-      branch: task.execution.branch,
-      commit: task.execution.commit,
-      workspacePath: task.execution.workspacePath,
-      agentSessionId: task.execution.agentSessionId,
-      containerId: task.execution.containerId,
-      mergeConflict: undefined,
-      error: undefined,
-      exitCode: undefined,
-    });
-    const delta: TaskDelta = this.buildUpdateDelta(task, conflictUpdated, changesWithGeneration);
-    this.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
-    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
-
-    return { savedError };
+    return beginConflictResolutionImpl(this as unknown as MergeHost, taskId, expectedLineage);
   }
 
   /**
@@ -2749,55 +2683,7 @@ export class Orchestrator {
     taskId: string,
     opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
   ): { savedError: string } {
-    this.refreshFromDb();
-    const task = this.stateGetTask(taskId);
-    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-    if (!this.taskMatchesLineageExpectation(task, opts.expectedLineage)) {
-      throw new Error(`Task ${taskId} lineage is stale for auto-fix start`);
-    }
-    if (
-      task.status !== 'failed' &&
-      task.status !== 'review_ready' &&
-      task.status !== 'awaiting_approval'
-    ) {
-      throw new Error(`Task ${taskId} is not in an auto-fixable state (status: ${task.status})`);
-    }
-
-    const savedError = opts.savedError ?? task.execution.error ?? '';
-    const startedAt = new Date();
-    const id = task.id;
-    const changes: TaskStateChanges = {
-      status: 'fixing_with_ai',
-      execution: {
-        error: undefined,
-        exitCode: undefined,
-        completedAt: undefined,
-        mergeConflict: undefined,
-        isFixingWithAI: false,
-        startedAt,
-        lastHeartbeatAt: startedAt,
-      },
-    };
-    const changesWithGeneration = this.withBumpedExecutionGeneration(task, changes);
-    const updated = this.writeAndSync(id, changesWithGeneration);
-    const attemptId = this.replaceSelectedAttempt(task);
-    this.taskRepository.updateAttempt(attemptId, {
-      status: 'running',
-      startedAt,
-      lastHeartbeatAt: startedAt,
-      branch: task.execution.branch,
-      commit: task.execution.commit,
-      workspacePath: task.execution.workspacePath,
-      agentSessionId: task.execution.agentSessionId,
-      containerId: task.execution.containerId,
-      mergeConflict: undefined,
-      error: undefined,
-      exitCode: undefined,
-    });
-    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changesWithGeneration);
-    this.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
-    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
-    return { savedError };
+    return beginAutoFixSessionImpl(this as unknown as MergeHost, taskId, opts);
   }
 
   /**
@@ -2810,40 +2696,7 @@ export class Orchestrator {
     fixError?: string,
     expectedLineage?: TaskLineageExpectation,
   ): void {
-    this.refreshFromDb();
-    const task = this.stateGetTask(taskId);
-    if (!task) {
-      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
-    }
-    if (!this.taskMatchesLineageExpectation(task, expectedLineage)) return;
-    const id = task.id;
-
-    const normalizedSavedError = stripFixFailureWrapper(savedError);
-    const mergeConflict = parseMergeConflictError(normalizedSavedError);
-
-    const displayError = fixError
-      ? `[Fix with Agent failed] ${fixError}\n\n${normalizedSavedError}`
-      : savedError;
-    const completedAt = new Date();
-    const changes: TaskStateChanges = {
-      status: 'failed',
-      execution: {
-        error: displayError,
-        mergeConflict,
-        isFixingWithAI: false,
-        completedAt,
-      },
-    };
-    const revertUpdated = this.writeAndSync(taskId, changes);
-    this.updateSelectedAttempt(taskId, {
-      status: 'failed',
-      error: displayError,
-      mergeConflict,
-      completedAt,
-    });
-    const delta: TaskDelta = this.buildUpdateDelta(task, revertUpdated, changes);
-    this.persistence.logEvent?.(id, 'task.failed', changes);
-    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+    revertConflictResolutionImpl(this as unknown as MergeHost, taskId, savedError, fixError, expectedLineage);
   }
 
   /**
@@ -4010,9 +3863,7 @@ export class Orchestrator {
    * Find the terminal merge node for a given workflow.
    */
   getMergeNode(workflowId: string): TaskState | undefined {
-    return this.stateMachine.getAllTasks().find(
-      (t) => t.config.workflowId === workflowId && t.config.isMergeNode,
-    );
+    return getMergeNodeImpl(this as unknown as MergeHost, workflowId);
   }
 
   getWorkflowStatus(workflowId?: string): {

--- a/packages/workflow-core/src/orchestrator/events.ts
+++ b/packages/workflow-core/src/orchestrator/events.ts
@@ -1,0 +1,56 @@
+/**
+ * Extracted event-publication domain.
+ *
+ * Centralizes the `task.delta` event contract: the channel constant, the
+ * `TaskDelta` builders, and the MessageBus publish helper. The Orchestrator
+ * and the other extracted domains (scheduler, transitions, merge) build and
+ * publish deltas through these functions, keeping the delta payload shape and
+ * channel name defined in exactly one place (see `graph-mutation.ts` for the
+ * same host-delegation pattern).
+ *
+ * Behavior is intentionally identical to the previous in-class helpers:
+ * the `updated`/`removed` payload fields, task-state continuity metadata, and
+ * the `task.delta` channel are preserved exactly so the TASK_DELTA publication
+ * contract stays stable.
+ */
+
+import type { TaskState, TaskDelta, TaskStateChanges } from '@invoker/workflow-graph';
+import type { OrchestratorMessageBus } from '../orchestrator.js';
+
+/** Channel on which all task deltas are published. */
+export const TASK_DELTA_CHANNEL = 'task.delta';
+
+/**
+ * Build an 'updated' TaskDelta with task-state continuity metadata.
+ * `before` is the task state before the mutation, `after` is the state
+ * returned by writeAndSync.
+ */
+export function buildTaskUpdateDelta(
+  before: TaskState,
+  after: TaskState,
+  changes: TaskStateChanges,
+): TaskDelta {
+  return {
+    type: 'updated',
+    taskId: after.id,
+    changes,
+    taskStateVersion: after.taskStateVersion,
+    previousTaskStateVersion: before.taskStateVersion,
+  };
+}
+
+/**
+ * Build a 'removed' TaskDelta with the task's last known task-state version.
+ */
+export function buildTaskRemoveDelta(task: TaskState): TaskDelta {
+  return {
+    type: 'removed',
+    taskId: task.id,
+    previousTaskStateVersion: task.taskStateVersion,
+  };
+}
+
+/** Publish a task delta on the canonical `task.delta` channel. */
+export function publishTaskDelta(messageBus: OrchestratorMessageBus, delta: TaskDelta): void {
+  messageBus.publish(TASK_DELTA_CHANNEL, delta);
+}

--- a/packages/workflow-core/src/orchestrator/merge.ts
+++ b/packages/workflow-core/src/orchestrator/merge.ts
@@ -1,0 +1,288 @@
+/**
+ * Extracted merge / conflict-resolution domain.
+ *
+ * These functions implement the merge-experiment lifecycle that lives on the
+ * orchestrator rather than in the graph layer: the fresh-base recreate flow,
+ * the AI conflict-resolution / auto-fix session transitions, and merge-node
+ * lookup. They run as standalone functions operating on a `MergeHost`, with
+ * the Orchestrator delegating to them for API compatibility (see
+ * `graph-mutation.ts` for the same host-delegation pattern; the structural
+ * merge-leaf invariants stay in `graph-mutation.ts`).
+ *
+ * Behavior is intentionally identical to the previous in-class methods: write
+ * order, attempt dual-writes, event names, and delta publication are preserved
+ * exactly so merge/experiment behavior and the TASK_DELTA contract stay stable.
+ */
+
+import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '@invoker/workflow-graph';
+import type { Logger } from '@invoker/contracts';
+import { parseMergeConflictError } from '../merge-conflict-error.js';
+import type { TaskStateMachine } from '../state-machine.js';
+import type { TaskRepository } from '../task-repository.js';
+import {
+  OrchestratorError,
+  OrchestratorErrorCode,
+} from '../orchestrator.js';
+import type {
+  OrchestratorPersistence,
+  TaskLineageExpectation,
+} from '../orchestrator.js';
+import { buildTaskUpdateDelta, publishTaskDelta } from './events.js';
+
+const FIX_FAILURE_PREFIX_RE = /^\[Fix with (?:Claude|Agent) failed\] [^\n]*\n\n/;
+
+function stripFixFailureWrapper(errorText: string): string {
+  return errorText.replace(FIX_FAILURE_PREFIX_RE, '');
+}
+
+// ── Host Interface ──────────────────────────────────────────
+
+/**
+ * Subset of Orchestrator that the merge functions need.
+ * Keeps the extracted functions decoupled from the full Orchestrator class.
+ */
+export interface MergeHost {
+  readonly stateMachine: TaskStateMachine;
+  readonly persistence: OrchestratorPersistence;
+  readonly messageBus: { publish<T>(channel: string, message: T): void };
+  readonly logger: Logger;
+  readonly taskRepository: TaskRepository;
+  readonly knownFreshBaseCommits: Map<string, string>;
+
+  refreshFromDb(): void;
+  stateGetTask(taskId: string): TaskState | undefined;
+  taskMatchesLineageExpectation(task: TaskState, expected?: TaskLineageExpectation): boolean;
+  withBumpedExecutionGeneration(task: TaskState, changes: TaskStateChanges): TaskStateChanges;
+  writeAndSync(
+    taskId: string,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): TaskState;
+  replaceSelectedAttempt(
+    task: TaskState,
+    opts?: Partial<Omit<Attempt, 'id' | 'nodeId' | 'createdAt'>>,
+    writeOpts?: { skipWorkflowStatusSync?: boolean },
+  ): string;
+  updateSelectedAttempt(
+    taskId: string,
+    changes: Partial<
+      Pick<
+        Attempt,
+        | 'status'
+        | 'claimedAt'
+        | 'startedAt'
+        | 'completedAt'
+        | 'exitCode'
+        | 'error'
+        | 'lastHeartbeatAt'
+        | 'leaseExpiresAt'
+        | 'branch'
+        | 'commit'
+        | 'summary'
+        | 'workspacePath'
+        | 'agentSessionId'
+        | 'containerId'
+        | 'mergeConflict'
+      >
+    >,
+  ): void;
+  buildUpdateDelta(before: TaskState, after: TaskState, changes: TaskStateChanges): TaskDelta;
+  recreateWorkflow(workflowId: string): TaskState[];
+}
+
+// ── Extracted Functions ─────────────────────────────────────
+
+export async function recreateWorkflowFromFreshBaseImpl(
+  host: MergeHost,
+  workflowId: string,
+  options?: {
+    refreshBase?: (
+      workflowId: string,
+    ) => Promise<{ commit?: string; branch?: string } | undefined | void>;
+  },
+): Promise<TaskState[]> {
+  if (options?.refreshBase) {
+    const fresh = await options.refreshBase(workflowId);
+    if (fresh && typeof fresh === 'object') {
+      if (typeof fresh.commit === 'string' && fresh.commit.length > 0) {
+        host.knownFreshBaseCommits.set(workflowId, fresh.commit);
+        host.logger.info('[orchestrator] recreateWorkflowFromFreshBase fresh base commit', {
+          workflowId,
+          freshBaseCommit: fresh.commit.slice(0, 12),
+        });
+      }
+      if (typeof fresh.branch === 'string' && fresh.branch.length > 0 && host.persistence.updateWorkflow) {
+        host.persistence.updateWorkflow(workflowId, { baseBranch: fresh.branch });
+        host.logger.info('[orchestrator] recreateWorkflowFromFreshBase fresh base branch', {
+          workflowId,
+          freshBaseBranch: fresh.branch,
+        });
+      }
+    }
+  }
+  return host.recreateWorkflow(workflowId);
+}
+
+export function getKnownFreshBaseCommitImpl(host: MergeHost, workflowId: string): string | undefined {
+  return host.knownFreshBaseCommits.get(workflowId);
+}
+
+export function beginConflictResolutionImpl(
+  host: MergeHost,
+  taskId: string,
+  expectedLineage?: TaskLineageExpectation,
+): { savedError: string } {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+  if (!host.taskMatchesLineageExpectation(task, expectedLineage)) {
+    throw new Error(`Task ${taskId} lineage is stale for conflict resolution start`);
+  }
+  if (task.status !== 'failed') throw new Error(`Task ${taskId} is not failed (status: ${task.status})`);
+
+  const savedError = task.execution.error ?? '';
+  const startedAt = new Date();
+
+  const id = task.id;
+  const changes: TaskStateChanges = {
+    status: 'fixing_with_ai',
+    execution: {
+      error: undefined,
+      exitCode: undefined,
+      completedAt: undefined,
+      mergeConflict: undefined,
+      isFixingWithAI: false,
+      startedAt,
+      lastHeartbeatAt: startedAt,
+    },
+  };
+  const changesWithGeneration = host.withBumpedExecutionGeneration(task, changes);
+  const conflictUpdated = host.writeAndSync(taskId, changesWithGeneration);
+  const attemptId = host.replaceSelectedAttempt(task);
+  host.taskRepository.updateAttempt(attemptId, {
+    status: 'running',
+    startedAt,
+    lastHeartbeatAt: startedAt,
+    branch: task.execution.branch,
+    commit: task.execution.commit,
+    workspacePath: task.execution.workspacePath,
+    agentSessionId: task.execution.agentSessionId,
+    containerId: task.execution.containerId,
+    mergeConflict: undefined,
+    error: undefined,
+    exitCode: undefined,
+  });
+  const delta: TaskDelta = host.buildUpdateDelta(task, conflictUpdated, changesWithGeneration);
+  host.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
+  publishTaskDelta(host.messageBus, delta);
+
+  return { savedError };
+}
+
+export function beginAutoFixSessionImpl(
+  host: MergeHost,
+  taskId: string,
+  opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
+): { savedError: string } {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+  if (!host.taskMatchesLineageExpectation(task, opts.expectedLineage)) {
+    throw new Error(`Task ${taskId} lineage is stale for auto-fix start`);
+  }
+  if (
+    task.status !== 'failed' &&
+    task.status !== 'review_ready' &&
+    task.status !== 'awaiting_approval'
+  ) {
+    throw new Error(`Task ${taskId} is not in an auto-fixable state (status: ${task.status})`);
+  }
+
+  const savedError = opts.savedError ?? task.execution.error ?? '';
+  const startedAt = new Date();
+  const id = task.id;
+  const changes: TaskStateChanges = {
+    status: 'fixing_with_ai',
+    execution: {
+      error: undefined,
+      exitCode: undefined,
+      completedAt: undefined,
+      mergeConflict: undefined,
+      isFixingWithAI: false,
+      startedAt,
+      lastHeartbeatAt: startedAt,
+    },
+  };
+  const changesWithGeneration = host.withBumpedExecutionGeneration(task, changes);
+  const updated = host.writeAndSync(id, changesWithGeneration);
+  const attemptId = host.replaceSelectedAttempt(task);
+  host.taskRepository.updateAttempt(attemptId, {
+    status: 'running',
+    startedAt,
+    lastHeartbeatAt: startedAt,
+    branch: task.execution.branch,
+    commit: task.execution.commit,
+    workspacePath: task.execution.workspacePath,
+    agentSessionId: task.execution.agentSessionId,
+    containerId: task.execution.containerId,
+    mergeConflict: undefined,
+    error: undefined,
+    exitCode: undefined,
+  });
+  const delta: TaskDelta = host.buildUpdateDelta(task, updated, changesWithGeneration);
+  host.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
+  publishTaskDelta(host.messageBus, delta);
+  return { savedError };
+}
+
+export function revertConflictResolutionImpl(
+  host: MergeHost,
+  taskId: string,
+  savedError: string,
+  fixError?: string,
+  expectedLineage?: TaskLineageExpectation,
+): void {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) {
+    throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+  }
+  if (!host.taskMatchesLineageExpectation(task, expectedLineage)) return;
+  const id = task.id;
+
+  const normalizedSavedError = stripFixFailureWrapper(savedError);
+  const mergeConflict = parseMergeConflictError(normalizedSavedError);
+
+  const displayError = fixError
+    ? `[Fix with Agent failed] ${fixError}\n\n${normalizedSavedError}`
+    : savedError;
+  const completedAt = new Date();
+  const changes: TaskStateChanges = {
+    status: 'failed',
+    execution: {
+      error: displayError,
+      mergeConflict,
+      isFixingWithAI: false,
+      completedAt,
+    },
+  };
+  const revertUpdated = host.writeAndSync(taskId, changes);
+  host.updateSelectedAttempt(taskId, {
+    status: 'failed',
+    error: displayError,
+    mergeConflict,
+    completedAt,
+  });
+  const delta: TaskDelta = host.buildUpdateDelta(task, revertUpdated, changes);
+  host.persistence.logEvent?.(id, 'task.failed', changes);
+  publishTaskDelta(host.messageBus, delta);
+}
+
+/**
+ * Find the terminal merge node for a given workflow.
+ */
+export function getMergeNodeImpl(host: MergeHost, workflowId: string): TaskState | undefined {
+  return host.stateMachine.getAllTasks().find(
+    (t) => t.config.workflowId === workflowId && t.config.isMergeNode,
+  );
+}

--- a/packages/workflow-core/src/orchestrator/scheduler-domain.ts
+++ b/packages/workflow-core/src/orchestrator/scheduler-domain.ts
@@ -1,0 +1,405 @@
+/**
+ * Extracted scheduler domain.
+ *
+ * These functions implement ready-task scheduling and launch dispatch as
+ * standalone functions that operate on a `SchedulerDomainHost`. The
+ * Orchestrator delegates to them, keeping the methods on the class for API
+ * compatibility (see `graph-mutation.ts` for the same host-delegation
+ * pattern).
+ *
+ * Behavior is intentionally identical to the previous in-class methods:
+ * dependency-readiness checks, priority enqueue, and the `task_launch_dispatch`
+ * outbox handoff in `drainScheduler` are preserved exactly.
+ */
+
+import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '@invoker/workflow-graph';
+import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
+import type { Logger } from '@invoker/contracts';
+import { isDiscardedAttempt } from '../attempt-policy.js';
+import type { TaskStateMachine } from '../state-machine.js';
+import type { TaskScheduler } from '../scheduler.js';
+import type { TaskRepository } from '../task-repository.js';
+import type {
+  OrchestratorPersistence,
+  OrchestratorMessageBus,
+  TaskLaunchReadiness,
+  LaunchReadinessOptions,
+} from '../orchestrator.js';
+
+const TASK_DELTA_CHANNEL = 'task.delta';
+
+function nextLeaseExpiry(from: Date): Date {
+  return new Date(from.getTime() + ATTEMPT_LEASE_MS);
+}
+
+// ── Host Interface ──────────────────────────────────────────
+
+/**
+ * Subset of Orchestrator that the scheduler-domain functions need.
+ * Keeps the extracted functions decoupled from the full Orchestrator class.
+ */
+export interface SchedulerDomainHost {
+  readonly stateMachine: TaskStateMachine;
+  readonly scheduler: TaskScheduler;
+  readonly persistence: OrchestratorPersistence;
+  readonly messageBus: OrchestratorMessageBus;
+  readonly logger: Logger;
+  readonly taskRepository: TaskRepository;
+  readonly maxConcurrency: number;
+  readonly deferRunningUntilLaunch: boolean;
+
+  refreshFromDb(): void;
+  stateGetTask(taskId: string): TaskState | undefined;
+  writeAndSync(
+    taskId: string,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): TaskState;
+  buildUpdateDelta(before: TaskState, after: TaskState, changes: TaskStateChanges): TaskDelta;
+  replaceSelectedAttempt(
+    task: TaskState,
+    opts?: Partial<Omit<Attempt, 'id' | 'nodeId' | 'createdAt'>>,
+    writeOpts?: { skipWorkflowStatusSync?: boolean },
+  ): string;
+  ensureCurrentPendingAttempt(task: TaskState): string;
+  loadAttemptById(attemptId: string | undefined): Attempt | undefined;
+  isAttemptLeaseActive(attempt: Attempt | undefined, now?: number): boolean;
+  countActivePersistedAttempts(now?: number): number;
+  getExecutionGeneration(task: TaskState | undefined): number;
+  getExternalDependencyBlocker(task: TaskState): string | undefined;
+}
+
+// ── Extracted Functions ─────────────────────────────────────
+
+export function autoStartReadyTasksImpl(
+  host: SchedulerDomainHost,
+  taskIds: string[],
+  priority: number = 0,
+  opts?: LaunchReadinessOptions,
+): TaskState[] {
+  for (const taskId of taskIds) {
+    let task = host.stateGetTask(taskId);
+    if (!task) continue;
+    if (host.getExternalDependencyBlocker(task) !== undefined) continue;
+
+    // Unblock: if a blocked task's deps are all complete, it's genuinely ready
+    if (task.status === 'blocked') {
+      host.logger.info('[orchestrator] autoStartReadyTasks: unblocking blocked task', {
+        taskId,
+      });
+      host.replaceSelectedAttempt(task, { status: 'pending' });
+      host.writeAndSync(taskId, {
+        status: 'pending',
+        execution: {
+          startedAt: undefined,
+          completedAt: undefined,
+          lastHeartbeatAt: undefined,
+          launchStartedAt: undefined,
+          launchCompletedAt: undefined,
+          phase: undefined,
+        },
+      });
+      task = host.stateGetTask(taskId);
+      if (!task) continue;
+    }
+
+    enqueueIfNotScheduledImpl(host, taskId, priority, opts);
+  }
+
+  return drainSchedulerImpl(host);
+}
+
+export function enqueueIfNotScheduledImpl(
+  host: SchedulerDomainHost,
+  taskId: string,
+  priority: number = 0,
+  opts?: LaunchReadinessOptions,
+): void {
+  const task = host.stateGetTask(taskId);
+  if (!task) return;
+  if (host.getExternalDependencyBlocker(task) !== undefined) return;
+
+  const attemptId = host.ensureCurrentPendingAttempt(task);
+  const currentAttempt = host.loadAttemptById(attemptId);
+  if ((currentAttempt?.queuePriority ?? 0) !== priority) {
+    host.taskRepository.updateAttempt(attemptId, { queuePriority: priority });
+  }
+  // A task can be force-set back to blocked/pending by recovery logic while
+  // still carrying a stale selectedAttemptId from an older run. Only skip
+  // re-enqueue when the task is actually active.
+  if (
+    (task.status === 'running' || task.status === 'fixing_with_ai') &&
+    task.execution.selectedAttemptId === attemptId &&
+    host.isAttemptLeaseActive(currentAttempt)
+  ) {
+    return;
+  }
+  const queuedJob = host.scheduler
+    .getQueuedJobs()
+    .find((job) => job.attemptId === attemptId || job.taskId === taskId);
+  if (queuedJob) {
+    const shouldReplaceQueuedJob =
+      priority > queuedJob.priority ||
+      (opts?.bypassLocalDependencyReadiness === true && !queuedJob.bypassLocalDependencyReadiness);
+    if (shouldReplaceQueuedJob) {
+      host.scheduler.removeJob(queuedJob.attemptId ?? queuedJob.taskId);
+      host.scheduler.enqueue({
+        taskId,
+        attemptId,
+        priority: Math.max(priority, queuedJob.priority),
+        ...(opts?.bypassLocalDependencyReadiness ? { bypassLocalDependencyReadiness: true } : {}),
+      });
+    }
+    return;
+  }
+  host.scheduler.enqueue({
+    taskId,
+    attemptId,
+    priority,
+    ...(opts?.bypassLocalDependencyReadiness ? { bypassLocalDependencyReadiness: true } : {}),
+  });
+}
+
+export function autoStartExternallyUnblockedReadyTasksImpl(host: SchedulerDomainHost): TaskState[] {
+  const started = autoStartUnblockedTasksImpl(host);
+  const readyTasks = host.stateMachine
+    .getReadyTasks()
+    .filter((task) => host.getExternalDependencyBlocker(task) === undefined);
+
+  for (const task of readyTasks) {
+    enqueueIfNotScheduledImpl(host, task.id);
+  }
+  started.push(...drainSchedulerImpl(host));
+  return started;
+}
+
+export function autoStartUnblockedTasksImpl(host: SchedulerDomainHost): TaskState[] {
+  for (const task of host.stateMachine.getAllTasks()) {
+    if (task.status !== 'blocked') continue;
+    if (!areLocalDependenciesSatisfiedImpl(host, task)) continue;
+    if (host.getExternalDependencyBlocker(task) !== undefined) continue;
+
+    host.replaceSelectedAttempt(task, { status: 'pending' });
+    host.writeAndSync(task.id, {
+      status: 'pending',
+      execution: {
+        blockedBy: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        lastHeartbeatAt: undefined,
+        launchStartedAt: undefined,
+        launchCompletedAt: undefined,
+        phase: undefined,
+      },
+    });
+    enqueueIfNotScheduledImpl(host, task.id);
+  }
+  return drainSchedulerImpl(host);
+}
+
+export function getTaskLaunchReadinessImpl(
+  host: SchedulerDomainHost,
+  taskId: string,
+  opts?: LaunchReadinessOptions,
+): TaskLaunchReadiness {
+  host.refreshFromDb();
+  const task = host.stateGetTask(taskId);
+  if (!task) {
+    return { ready: false, reason: `task ${taskId} not found` };
+  }
+  if (task.status !== 'pending') {
+    return { ready: false, reason: `task status is ${task.status}`, task };
+  }
+
+  if (!opts?.bypassLocalDependencyReadiness) {
+    const localBlocker = getLocalDependencyBlockerImpl(host, task);
+    if (localBlocker) {
+      return { ready: false, reason: localBlocker, task };
+    }
+  }
+
+  const externalBlocker = host.getExternalDependencyBlocker(task);
+  if (externalBlocker) {
+    return { ready: false, reason: externalBlocker, task };
+  }
+
+  return { ready: true, task };
+}
+
+export function areLocalDependenciesSatisfiedImpl(host: SchedulerDomainHost, task: TaskState): boolean {
+  return getLocalDependencyBlockerImpl(host, task) === undefined;
+}
+
+export function getLocalDependencyBlockerImpl(host: SchedulerDomainHost, task: TaskState): string | undefined {
+  for (const depId of task.dependencies) {
+    const dep = host.stateGetTask(depId);
+    if (!dep) return `missing dependency ${depId}`;
+    const satisfied = task.config?.isReconciliation
+      ? dep.status === 'completed' || dep.status === 'failed' || dep.status === 'closed' || dep.status === 'stale'
+      : dep.status === 'completed' || dep.status === 'stale';
+    if (!satisfied) {
+      return `waiting on ${depId} (${dep.status})`;
+    }
+  }
+  return undefined;
+}
+
+export function drainSchedulerImpl(host: SchedulerDomainHost): TaskState[] {
+  const started: TaskState[] = [];
+  const activeAttempts = host.countActivePersistedAttempts();
+  let availableSlots = Math.max(0, host.maxConcurrency - activeAttempts);
+  host.logger.info('[orchestrator] drainScheduler: begin', {
+    active: activeAttempts,
+    maxConcurrency: host.maxConcurrency,
+    availableSlots,
+  });
+  let job = availableSlots > 0 ? host.scheduler.takeNext() : null;
+  while (job && availableSlots > 0) {
+    const readiness = getTaskLaunchReadinessImpl(host, job.taskId, {
+      bypassLocalDependencyReadiness: job.bypassLocalDependencyReadiness,
+    });
+    host.logger.info('[orchestrator] drainScheduler: dequeued', {
+      taskId: job.taskId,
+      actualStatus: readiness.task?.status ?? 'NOT_FOUND',
+    });
+    if (!readiness.ready) {
+      host.logger.info('[orchestrator] drainScheduler: skipping non-ready task', {
+        taskId: job.taskId,
+        reason: readiness.reason,
+      });
+      job = host.scheduler.takeNext();
+      continue;
+    }
+    const task = readiness.task;
+
+    const now = new Date();
+    let attemptId = job.attemptId ?? host.ensureCurrentPendingAttempt(task);
+    let currentAttempt = host.loadAttemptById(attemptId);
+    if (!currentAttempt || isDiscardedAttempt(currentAttempt)) {
+      attemptId = host.ensureCurrentPendingAttempt(task);
+      currentAttempt = host.loadAttemptById(attemptId);
+    }
+    if (!currentAttempt || isDiscardedAttempt(currentAttempt)) {
+      host.logger.info('[orchestrator] drainScheduler: skipping non-runnable attempt', {
+        taskId: job.taskId,
+        attemptId,
+        attemptStatus: currentAttempt?.status ?? 'missing',
+      });
+      job = host.scheduler.takeNext();
+      continue;
+    }
+    let launchAttemptId = attemptId;
+    const selectedTask = host.stateGetTask(job.taskId) ?? task;
+    if (selectedTask.execution.selectedAttemptId !== attemptId) {
+      host.writeAndSync(job.taskId, { execution: { selectedAttemptId: attemptId } });
+    }
+    let claimSucceeded = false;
+    const claimPatch = host.deferRunningUntilLaunch
+      ? {
+          status: 'claimed' as const,
+          claimedAt: now,
+          lastHeartbeatAt: now,
+          leaseExpiresAt: nextLeaseExpiry(now),
+        }
+      : {
+          status: 'running' as const,
+          claimedAt: currentAttempt?.claimedAt ?? now,
+          startedAt: now,
+          lastHeartbeatAt: now,
+          leaseExpiresAt: nextLeaseExpiry(now),
+        };
+    claimSucceeded = host.taskRepository.claimAttemptForLaunch?.(attemptId, claimPatch, now)
+      ?? !host.isAttemptLeaseActive(currentAttempt, now.getTime());
+    if (claimSucceeded && !host.taskRepository.claimAttemptForLaunch) {
+      host.taskRepository.updateAttempt(attemptId, claimPatch);
+    }
+    if (!claimSucceeded) {
+      host.logger.info('[orchestrator] drainScheduler: skipping already-claimed attempt', {
+        taskId: job.taskId,
+        attemptId,
+      });
+      job = availableSlots > 0 ? host.scheduler.takeNext() : null;
+      continue;
+    }
+
+    const changes: TaskStateChanges = host.deferRunningUntilLaunch
+      ? {
+          status: 'pending',
+          execution: {
+            selectedAttemptId: launchAttemptId,
+            generation: host.getExecutionGeneration(task),
+            lastHeartbeatAt: now,
+            phase: 'launching',
+            launchStartedAt: now,
+            launchCompletedAt: undefined,
+          },
+        }
+      : {
+          status: 'running',
+          execution: {
+            selectedAttemptId: launchAttemptId,
+            generation: host.getExecutionGeneration(task),
+            startedAt: now,
+            lastHeartbeatAt: now,
+            phase: 'launching',
+            launchStartedAt: now,
+            launchCompletedAt: undefined,
+          },
+        };
+    const updated = host.writeAndSync(job.taskId, changes);
+    host.persistence.logEvent?.(
+      job.taskId,
+      host.deferRunningUntilLaunch ? 'task.launch_claimed' : 'task.running',
+      changes,
+    );
+    if (
+      typeof host.persistence.enqueueLaunchDispatch === 'function'
+      && task.config.workflowId
+    ) {
+      try {
+        const dispatch = host.persistence.enqueueLaunchDispatch({
+          taskId: job.taskId,
+          attemptId: launchAttemptId,
+          workflowId: task.config.workflowId,
+          generation: host.getExecutionGeneration(task),
+        });
+        host.persistence.logEvent?.(job.taskId, 'task.dispatch_enqueued', {
+          ...changes,
+          dispatchId: dispatch.id,
+          attemptId: launchAttemptId,
+          workflowId: task.config.workflowId,
+          generation: host.getExecutionGeneration(task),
+          state: dispatch.state,
+          priority: dispatch.priority,
+        });
+        host.logger.info('[orchestrator] drainScheduler: launch dispatch enqueued', {
+          taskId: job.taskId,
+          attemptId: launchAttemptId,
+          workflowId: task.config.workflowId,
+          generation: host.getExecutionGeneration(task),
+          dispatchId: dispatch.id,
+          state: dispatch.state,
+          priority: dispatch.priority,
+        });
+      } catch (err) {
+        host.logger.warn('[orchestrator] drainScheduler: enqueueLaunchDispatch failed', {
+          taskId: job.taskId,
+          attemptId: launchAttemptId,
+          error: err instanceof Error ? err.message : String(err),
+        });
+      }
+    }
+    host.messageBus.publish(TASK_DELTA_CHANNEL, host.buildUpdateDelta(task, updated, changes));
+    started.push(updated);
+    host.logger.info('[orchestrator] drainScheduler: started', {
+      taskId: job.taskId,
+      attemptId: launchAttemptId,
+      phase: 'launching',
+      generation: changes.execution?.generation ?? 'unknown',
+    });
+
+    availableSlots -= 1;
+    job = availableSlots > 0 ? host.scheduler.takeNext() : null;
+  }
+  return started;
+}

--- a/packages/workflow-core/src/orchestrator/transitions.ts
+++ b/packages/workflow-core/src/orchestrator/transitions.ts
@@ -1,0 +1,456 @@
+/**
+ * Extracted transition domain.
+ *
+ * These functions implement worker-response state transitions (completed,
+ * failed, review_ready, needs_input, spawn/select experiments) and the
+ * post-transition completion checks as standalone functions operating on a
+ * `TransitionHost`. The Orchestrator delegates to them, keeping the methods on
+ * the class for API compatibility (see `graph-mutation.ts` for the same
+ * host-delegation pattern).
+ *
+ * Behavior is intentionally identical to the previous in-class methods: write
+ * order, attempt dual-writes, event names, delta publication, and the
+ * downstream auto-start / deferred re-enqueue sequence are preserved exactly.
+ */
+
+import type { TaskState, TaskDelta, TaskStateChanges } from '@invoker/workflow-graph';
+import type { Logger } from '@invoker/contracts';
+import type { ParsedResponse } from '../response-handler.js';
+import { scopePlanTaskId } from '../task-id-scope.js';
+import { parseMergeConflictError } from '../merge-conflict-error.js';
+import type { TaskStateMachine } from '../state-machine.js';
+import type { TaskScheduler } from '../scheduler.js';
+import type { TaskRepository } from '../task-repository.js';
+import {
+  OrchestratorError,
+  OrchestratorErrorCode,
+} from '../orchestrator.js';
+import type {
+  GraphMutation,
+  GraphMutationNodeDef,
+  OrchestratorPersistence,
+  OrchestratorMessageBus,
+  TaskLineageExpectation,
+  LaunchReadinessOptions,
+} from '../orchestrator.js';
+
+const TASK_DELTA_CHANNEL = 'task.delta';
+
+// ── Host Interface ──────────────────────────────────────────
+
+/**
+ * Subset of Orchestrator that the transition functions need.
+ * Keeps the extracted functions decoupled from the full Orchestrator class.
+ */
+export interface TransitionHost {
+  readonly stateMachine: TaskStateMachine;
+  readonly scheduler: TaskScheduler;
+  readonly persistence: OrchestratorPersistence;
+  readonly messageBus: OrchestratorMessageBus;
+  readonly logger: Logger;
+  readonly taskRepository: TaskRepository;
+  readonly deferredTaskIds: Set<string>;
+  readonly activeWorkflowIds: Set<string>;
+
+  stateGetTask(taskId: string): TaskState | undefined;
+  writeAndSync(
+    taskId: string,
+    changes: TaskStateChanges,
+    opts?: { skipWorkflowStatusSync?: boolean },
+  ): TaskState;
+  buildUpdateDelta(before: TaskState, after: TaskState, changes: TaskStateChanges): TaskDelta;
+  ensureCurrentPendingAttempt(task: TaskState): string;
+  touchWorkflow(workflowId: string): void;
+  setTaskApprovalStatus(
+    taskId: string,
+    status: 'awaiting_approval' | 'review_ready',
+    eventName: 'task.awaiting_approval' | 'task.review_ready',
+    additionalChanges?: TaskStateChanges,
+    expectedLineage?: TaskLineageExpectation,
+  ): void;
+  applyGraphMutation(mutation: GraphMutation): TaskDelta[];
+  selectExperiment(taskId: string, experimentId: string): TaskState[];
+
+  // Scheduler-domain entrypoints (kept as Orchestrator methods that delegate
+  // to scheduler-domain.ts); transitions trigger downstream work through them.
+  autoStartReadyTasks(taskIds: string[], priority?: number, opts?: LaunchReadinessOptions): TaskState[];
+  autoStartUnblockedTasks(): TaskState[];
+  autoStartExternallyUnblockedReadyTasks(): TaskState[];
+  drainScheduler(): TaskState[];
+}
+
+// ── Extracted Functions ─────────────────────────────────────
+
+export function handleCompletedImpl(
+  host: TransitionHost,
+  taskId: string,
+  parsed: Extract<ParsedResponse, { type: 'completed' }>,
+): TaskState[] {
+  const task = host.stateGetTask(taskId);
+  const needsApproval = task?.config.requiresManualApproval === true;
+
+  const execution: {
+    exitCode: number;
+    completedAt: Date;
+    commit?: string;
+    agentSessionId?: string;
+    agentName?: string;
+    lastAgentSessionId?: string;
+    lastAgentName?: string;
+    branch?: string;
+    reviewUrl?: string;
+    reviewId?: string;
+    reviewStatus?: string;
+  } = {
+    exitCode: parsed.exitCode,
+    completedAt: new Date(),
+  };
+  if (parsed.commitHash !== undefined) {
+    execution.commit = parsed.commitHash;
+  }
+  if (parsed.agentSessionId !== undefined) {
+    execution.agentSessionId = parsed.agentSessionId;
+    execution.lastAgentSessionId = parsed.agentSessionId;
+    execution.lastAgentName = parsed.agentName ?? task?.execution.agentName ?? task?.execution.lastAgentName;
+  }
+  if (parsed.agentName !== undefined) {
+    execution.agentName = parsed.agentName;
+    execution.lastAgentName = parsed.agentName;
+  }
+  if (parsed.branch !== undefined) {
+    execution.branch = parsed.branch;
+  }
+  if (parsed.reviewUrl !== undefined) {
+    execution.reviewUrl = parsed.reviewUrl;
+  }
+  if (parsed.reviewId !== undefined) {
+    execution.reviewId = parsed.reviewId;
+  }
+  if (parsed.reviewStatus !== undefined) {
+    execution.reviewStatus = parsed.reviewStatus;
+  }
+
+  const changes: TaskStateChanges = {
+    status: needsApproval ? 'awaiting_approval' : 'completed',
+    config: { summary: parsed.summary },
+    execution,
+  };
+  const completedUpdated = host.writeAndSync(taskId, changes);
+  const delta: TaskDelta = host.buildUpdateDelta(task!, completedUpdated, changes);
+  const eventName = needsApproval ? 'task.awaiting_approval' : 'task.completed';
+  host.persistence.logEvent?.(taskId, eventName, changes);
+  host.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+
+  // Dual-write: update current selected attempt to completed (best-effort)
+  try {
+    const currentAttemptId = host.stateGetTask(taskId)?.execution.selectedAttemptId;
+    const currentAttempt = currentAttemptId ? host.persistence.loadAttempt(currentAttemptId) : undefined;
+    if (currentAttempt && currentAttempt.status === 'running') {
+      host.taskRepository.updateAttempt(currentAttempt.id, {
+        status: needsApproval ? 'needs_input' : 'completed',
+        exitCode: parsed.exitCode,
+        completedAt: new Date(),
+        ...(parsed.commitHash !== undefined ? { commit: parsed.commitHash } : {}),
+        ...(parsed.agentSessionId !== undefined ? { agentSessionId: parsed.agentSessionId } : {}),
+      });
+    }
+  } catch { /* best effort */ }
+
+  // If task requires manual approval, don't trigger downstream tasks yet
+  if (needsApproval) return [];
+
+  checkExperimentCompletionImpl(host, taskId);
+
+  const readyTaskIds = host.stateMachine.findNewlyReadyTasks(taskId);
+  host.logger.info('[orchestrator] handleCompleted', {
+    taskId,
+    newlyReadyCount: readyTaskIds.length,
+    readyTaskIds,
+  });
+  const started = host.autoStartReadyTasks(readyTaskIds);
+  started.push(...host.autoStartUnblockedTasks());
+  started.push(...host.autoStartExternallyUnblockedReadyTasks());
+
+  // Re-enqueue deferred tasks now that a slot freed up
+  if (host.deferredTaskIds.size > 0) {
+    for (const id of host.deferredTaskIds) {
+      const t = host.stateGetTask(id);
+      if (t && t.status === 'pending') {
+        const attemptId = host.ensureCurrentPendingAttempt(t);
+        host.scheduler.enqueue({ taskId: id, attemptId, priority: 0 });
+      }
+    }
+    host.deferredTaskIds.clear();
+    started.push(...host.drainScheduler());
+  }
+
+  checkWorkflowCompletionImpl(host);
+  return started;
+}
+
+/**
+ * Marks a task as failed, writes to DB atomically (task + attempt), logs event,
+ * publishes delta, checks for newly ready tasks, and returns newly started tasks.
+ */
+export function finalizeFailedTaskImpl(
+  host: TransitionHost,
+  taskId: string,
+  executionFields: {
+    exitCode?: number;
+    error?: string;
+    agentName?: string;
+    lastAgentName?: string;
+    protocolErrorCode?: string;
+    protocolErrorMessage?: string;
+    mergeConflict?: { failedBranch: string; conflictFiles: string[] };
+  },
+  eventName: string,
+): TaskState[] {
+  const existing = host.stateGetTask(taskId);
+  if (!existing) {
+    throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `finalizeFailedTask: task ${taskId} not found in graph`);
+  }
+
+  const changes: TaskStateChanges = {
+    status: 'failed',
+    execution: {
+      ...executionFields,
+      completedAt: new Date(),
+    },
+  };
+
+  // Atomic write for task + attempt via repository
+  host.taskRepository.failTaskAndAttempt(taskId, changes, {
+    status: 'failed',
+    exitCode: executionFields.exitCode,
+    error: executionFields.error,
+    completedAt: new Date(),
+  });
+
+  // Sync to in-memory state (same pattern as writeAndSync)
+  const updated: TaskState = {
+    ...existing,
+    status: 'failed',
+    execution: { ...existing.execution, ...changes.execution },
+    taskStateVersion: existing.taskStateVersion + 1,
+  };
+  host.stateMachine.restoreTask(updated);
+
+  const delta: TaskDelta = host.buildUpdateDelta(existing, updated, changes);
+  host.persistence.logEvent?.(taskId, eventName, changes);
+  host.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+
+  checkExperimentCompletionImpl(host, taskId);
+
+  const readyTaskIds = host.stateMachine.findNewlyReadyTasks(taskId);
+  host.logger.info('[orchestrator] finalizeFailedTask', {
+    taskId,
+    eventName,
+    newlyReadyCount: readyTaskIds.length,
+    readyTaskIds,
+  });
+  const started = host.autoStartReadyTasks(readyTaskIds);
+  started.push(...host.autoStartUnblockedTasks());
+  started.push(...host.autoStartExternallyUnblockedReadyTasks());
+
+  // Re-enqueue deferred tasks now that a slot freed up
+  if (host.deferredTaskIds.size > 0) {
+    for (const id of host.deferredTaskIds) {
+      const t = host.stateGetTask(id);
+      if (t && t.status === 'pending') {
+        const attemptId = host.ensureCurrentPendingAttempt(t);
+        host.scheduler.enqueue({ taskId: id, attemptId, priority: 0 });
+      }
+    }
+    host.deferredTaskIds.clear();
+    started.push(...host.drainScheduler());
+  }
+
+  checkWorkflowCompletionImpl(host);
+  return started;
+}
+
+export function handleReviewReadyImpl(
+  host: TransitionHost,
+  taskId: string,
+  parsed: Extract<ParsedResponse, { type: 'review_ready' }>,
+): TaskState[] {
+  const changes: TaskStateChanges = {
+    config: { summary: parsed.summary },
+    execution: {
+      exitCode: parsed.exitCode,
+      branch: parsed.branch,
+      reviewUrl: parsed.reviewUrl,
+      reviewId: parsed.reviewId,
+      reviewStatus: parsed.reviewStatus,
+      reviewGate: parsed.reviewGate,
+    },
+  };
+  host.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', changes);
+
+  const started = host.autoStartUnblockedTasks();
+  started.push(...host.autoStartExternallyUnblockedReadyTasks());
+  checkWorkflowCompletionImpl(host);
+  return started;
+}
+
+export function handleFailedImpl(
+  host: TransitionHost,
+  taskId: string,
+  parsed: Extract<ParsedResponse, { type: 'failed' }>,
+): TaskState[] {
+  const mergeConflict = parseMergeConflictError(parsed.error);
+  return finalizeFailedTaskImpl(
+    host,
+    taskId,
+    {
+      exitCode: parsed.exitCode,
+      error: parsed.error,
+      agentName: parsed.agentName,
+      lastAgentName: parsed.agentName,
+      mergeConflict,
+    },
+    'task.failed',
+  );
+}
+
+export function handleNeedsInputImpl(
+  host: TransitionHost,
+  taskId: string,
+  parsed: Extract<ParsedResponse, { type: 'needs_input' }>,
+): TaskState[] {
+  const changes: TaskStateChanges = {
+    status: 'needs_input',
+    execution: { inputPrompt: parsed.prompt },
+  };
+  const needsInputBefore = host.stateGetTask(taskId)!;
+  const needsInputUpdated = host.writeAndSync(taskId, changes);
+  const currentAttemptId = needsInputUpdated.execution.selectedAttemptId;
+  if (currentAttemptId) {
+    host.taskRepository.updateAttempt(currentAttemptId, { status: 'needs_input' });
+  }
+  const delta: TaskDelta = host.buildUpdateDelta(needsInputBefore, needsInputUpdated, changes);
+  host.persistence.logEvent?.(taskId, 'task.needs_input', changes);
+  host.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+  return [];
+}
+
+export function handleSpawnExperimentsImpl(
+  host: TransitionHost,
+  taskId: string,
+  parsed: Extract<ParsedResponse, { type: 'spawn_experiments' }>,
+): TaskState[] {
+  const parentTask = host.stateGetTask(taskId);
+  const wfId = parentTask?.config.workflowId;
+  if (!wfId) {
+    host.logger.warn('[orchestrator] handleSpawnExperiments: missing workflowId; skipping', {
+      taskId,
+    });
+    return [];
+  }
+  const scopeLocal = (local: string) => scopePlanTaskId(wfId, local);
+
+  const experimentTasks: GraphMutationNodeDef[] = parsed.variants.map((v) => ({
+    id: scopeLocal(v.id),
+    description: v.description ?? `Experiment: ${v.id}`,
+    dependencies: [taskId],
+    workflowId: wfId,
+    parentTask: taskId,
+    experimentPrompt: v.prompt,
+    prompt: v.prompt,
+    command: v.command,
+    runnerKind: parentTask?.config.runnerKind,
+  }));
+
+  const reconciliationId = `${taskId}-reconciliation`;
+  const newNodes: GraphMutationNodeDef[] = [
+    ...experimentTasks,
+    {
+      id: reconciliationId,
+      description: `Review and select winning experiment for ${taskId}`,
+      dependencies: experimentTasks.map((t) => t.id),
+      workflowId: wfId,
+      parentTask: taskId,
+      isReconciliation: true,
+      requiresManualApproval: true,
+    },
+  ];
+
+  const wf =
+    wfId && typeof host.persistence.loadWorkflow === 'function'
+      ? host.persistence.loadWorkflow(wfId)
+      : undefined;
+  const pivotBranch =
+    wf && typeof (wf as { baseBranch?: string }).baseBranch === 'string'
+      ? (wf as { baseBranch: string }).baseBranch.trim()
+      : '';
+  const sourceChanges =
+    pivotBranch !== '' ? { execution: { branch: pivotBranch } } : undefined;
+
+  host.applyGraphMutation({
+    sourceNodeId: taskId,
+    sourceDisposition: 'complete',
+    sourceChanges,
+    newNodes,
+    outputNodeId: reconciliationId,
+  });
+
+  const readyIds = experimentTasks.map((t) => t.id);
+  return host.autoStartReadyTasks(readyIds);
+}
+
+export function handleSelectExperimentImpl(
+  host: TransitionHost,
+  taskId: string,
+  parsed: Extract<ParsedResponse, { type: 'select_experiment' }>,
+): TaskState[] {
+  return host.selectExperiment(taskId, parsed.experimentId);
+}
+
+export function checkExperimentCompletionImpl(host: TransitionHost, taskId: string): void {
+  for (const recon of host.stateMachine.getAllTasks()) {
+    if (!recon.config.isReconciliation) continue;
+    if (
+      recon.status === 'needs_input' ||
+      recon.status === 'completed' ||
+      recon.status === 'running' ||
+      recon.status === 'fixing_with_ai'
+    ) {
+      continue;
+    }
+    if (!recon.dependencies.includes(taskId)) continue;
+
+    const allReported = recon.dependencies.every((depId) => {
+      const dep = host.stateGetTask(depId);
+      return dep && (dep.status === 'completed' || dep.status === 'failed');
+    });
+
+    if (allReported) {
+      const experimentResults = recon.dependencies.map((depId) => {
+        const dep = host.stateGetTask(depId)!;
+        return {
+          id: depId,
+          status: (dep.status === 'completed' ? 'completed' : 'failed') as 'completed' | 'failed',
+          summary: dep.config.summary,
+          exitCode: dep.execution.exitCode,
+        };
+      });
+
+      // Persist results only; reconciliation stays pending until the scheduler runs it.
+      // TaskRunner then acquires a worktree and emits `needs_input` (open-terminal cwd).
+      const reconChanges: TaskStateChanges = {
+        execution: { experimentResults },
+      };
+      const reconUpdated = host.writeAndSync(recon.id, reconChanges);
+      const delta: TaskDelta = host.buildUpdateDelta(recon, reconUpdated, reconChanges);
+      host.persistence.logEvent?.(recon.id, 'task.experiment_results_recorded', reconChanges);
+      host.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+    }
+  }
+}
+
+export function checkWorkflowCompletionImpl(host: TransitionHost): void {
+  for (const wfId of host.activeWorkflowIds) {
+    host.touchWorkflow(wfId);
+  }
+}


### PR DESCRIPTION
## Summary

`Orchestrator` now routes scheduling, transition, merge, experiment, and task-delta publication work through domain collaborators.

The public `Orchestrator` API stays stable while the large class becomes a thinner coordinator.

Runtime settling fixes keep the full repository gate passing after the decomposition.

<details>
<summary>Review metadata</summary>

Review Claim: Approve routing orchestration through domain collaborators without changing workflow lifecycle contracts.

Review Lane: behavior

Review Unit: routing

Safety Invariant: Existing orchestrator tests and the full repository test gate passed after the decomposition.

Slice Rationale: This is the final domain slice for reducing `orchestrator.ts` before smaller follow-up edits.

</details>

## Non-goals

- This does not change plan schema, task-delta payload shapes, or `Orchestrator` public method signatures.
- This does not add migrations or alter persisted workflow data.
- This does not intentionally change scheduling semantics, merge selection rules, or task-delta ordering.

## Architecture

### Before

```mermaid
graph TD
    O["Orchestrator"]
    O --> S["Inline scheduler dispatch"]
    O --> T["Inline task transitions"]
    O --> M["Inline merge and experiment paths"]
    O --> E["Inline task-delta publication"]
    S --> B["Message bus and persistence"]
    T --> B
    M --> B
    E --> B
```

### After

```mermaid
graph TD
    O["Orchestrator coordinator"]
    O --> SH["Scheduler domain host"]
    O --> TH["Transition domain host"]
    O --> MH["Merge experiment domain host"]
    O --> EH["Event domain host"]
    SH --> S["scheduler-domain.ts"]
    TH --> T["transition-domain.ts"]
    MH --> M["merge-domain.ts"]
    EH --> E["event-domain.ts"]
    S --> B["Message bus and persistence"]
    T --> B
    M --> B
    E --> B
```

## Test Plan

- [x] `cd packages/workflow-core && pnpm test -- src/__tests__/orchestrator.test.ts`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert -m 1 da94e09aa`
- Post-revert steps: None
- Data migration? No