### PR TITLE
Fix SSH orphaned-task liveness and transport failure handling

### DIFF
--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -27,7 +27,8 @@
       "port": 22,
       "managedWorkspaces": true,
       "remoteInvokerHome": "~/.invoker",
-      "provisionCommand": "pnpm install --frozen-lockfile"
+      "provisionCommand": "pnpm install --frozen-lockfile",
+      "remoteHeartbeatIntervalSeconds": 30
     },
     "build-server-b": {
       "comment": "Second SSH target for running different tasks on a different host",
@@ -37,7 +38,8 @@
       "port": 22,
       "managedWorkspaces": true,
       "remoteInvokerHome": "~/.invoker",
-      "provisionCommand": "pnpm install --frozen-lockfile"
+      "provisionCommand": "pnpm install --frozen-lockfile",
+      "remoteHeartbeatIntervalSeconds": 30
     }
   },
 

--- a/docs/remote-ssh-targets.md
+++ b/docs/remote-ssh-targets.md
@@ -23,7 +23,8 @@ If you want to use a repo-specific config file, launch Invoker with `INVOKER_REP
       "sshKeyPath": "/home/user/.ssh/id_staging",
       "managedWorkspaces": true,
       "remoteInvokerHome": "~/.invoker",
-      "provisionCommand": "pnpm install --frozen-lockfile"
+      "provisionCommand": "pnpm install --frozen-lockfile",
+      "remoteHeartbeatIntervalSeconds": 30
     },
     "staging-server-b": {
       "host": "192.168.1.101",
@@ -32,7 +33,8 @@ If you want to use a repo-specific config file, launch Invoker with `INVOKER_REP
       "port": 22,
       "managedWorkspaces": true,
       "remoteInvokerHome": "~/.invoker",
-      "provisionCommand": "pnpm install --frozen-lockfile"
+      "provisionCommand": "pnpm install --frozen-lockfile",
+      "remoteHeartbeatIntervalSeconds": 30
     }
   }
 }
@@ -49,6 +51,7 @@ If you want to use a repo-specific config file, launch Invoker with `INVOKER_REP
 | `managedWorkspaces` | boolean | no | When true, Invoker clones/fetches the repo and manages per-task worktrees on the remote host |
 | `remoteInvokerHome` | string | no | Base directory used by managed remote workspaces (default: `~/.invoker`) |
 | `provisionCommand` | string | no | Command run after worktree creation in managed mode |
+| `remoteHeartbeatIntervalSeconds` | number | no | Interval (seconds) for SSH remote workload heartbeat markers used by executing-stall detection (default: `30`) |
 
 ## Multiple SSH Targets
 

--- a/packages/app/e2e/launching-stall-watchdog.spec.ts
+++ b/packages/app/e2e/launching-stall-watchdog.spec.ts
@@ -235,4 +235,103 @@ base.describe('Launch stall watchdog', () => {
       }
     }
   });
+
+  base('fails SSH executing task when remote workload heartbeat is stale', async () => {
+    const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-ssh-executing-watchdog-'));
+    const configPath = path.join(testDir, 'e2e-config.json');
+    writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
+
+    try {
+      const app = await electron.launch({
+        args: launchArgs(),
+        env: {
+          ...process.env,
+          NODE_ENV: 'test',
+          INVOKER_DB_DIR: testDir,
+          INVOKER_ALLOW_DELETE_ALL: '1',
+          INVOKER_REPO_CONFIG_PATH: configPath,
+          INVOKER_EXECUTING_STALL_TIMEOUT_MS: '3000',
+          INVOKER_STARTUP_POLL_DELAY_MS: '0',
+        },
+      });
+      const page = await app.firstWindow();
+      await waitForInvoker(page);
+      await page.evaluate(() => window.invoker.reportUiPerf?.('startup_graph_visible', {}));
+
+      await page.evaluate(async () => {
+        await window.invoker.clear();
+        await window.invoker.deleteAllWorkflows();
+      });
+      await page.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(WATCHDOG_PLAN));
+
+      const initial = await page.evaluate(() => window.invoker.getTasks(true));
+      const initialTasks = Array.isArray(initial) ? initial : initial.tasks;
+      const stalled = findTask(initialTasks, 'stall-task');
+      expect(stalled).toBeDefined();
+
+      const settleDeadline = Date.now() + 10_000;
+      while (Date.now() < settleDeadline) {
+        const snapshot = await page.evaluate(() => window.invoker.getTasks(true));
+        const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
+        const current = findTask(tasks, 'stall-task');
+        if (current && current.status !== 'running') break;
+        await page.waitForTimeout(250);
+      }
+
+      const staleTs = new Date(Date.now() - 30_000).toISOString();
+      const freshTs = new Date(Date.now() - 500).toISOString();
+      await injectTaskStates(page, [{
+        taskId: stalled!.id,
+        changes: {
+          status: 'running',
+          config: {
+            executorType: 'ssh',
+            remoteTargetId: 'remote_digital_ocean_1',
+          },
+          execution: {
+            phase: 'executing',
+            generation: 0,
+            startedAt: staleTs,
+            // Transport heartbeat is fresh.
+            lastHeartbeatAt: freshTs,
+            // Workload heartbeat is stale.
+            remoteHeartbeatAt: staleTs,
+            selectedAttemptId: `${stalled!.id}-attempt`,
+          },
+        },
+      }]);
+
+      const postInjectSnapshot = await page.evaluate(() => window.invoker.getTasks(true));
+      const postInjectTasks = Array.isArray(postInjectSnapshot) ? postInjectSnapshot : postInjectSnapshot.tasks;
+      const postInjectTask = findTask(postInjectTasks, 'stall-task');
+      expect(postInjectTask?.config?.executorType).toBe('ssh');
+
+      const deadline = Date.now() + 15_000;
+      let stalledTask: any | undefined;
+      while (Date.now() < deadline) {
+        const snapshot = await page.evaluate(() => window.invoker.getTasks(true));
+        const tasks = Array.isArray(snapshot) ? snapshot : snapshot.tasks;
+        stalledTask = findTask(tasks, 'stall-task');
+        if (
+          stalledTask?.status === 'failed'
+          && /^Execution stalled: task remained in running\/executing for \d+s without a live execution handle and no completion signal from executor \(remote workload heartbeat stale\)\.$/.test(stalledTask.execution?.error ?? '')
+        ) {
+          break;
+        }
+        await page.waitForTimeout(250);
+      }
+
+      expect(stalledTask, 'stalled task should remain visible in task list').toBeDefined();
+      expect(stalledTask?.status).toBe('failed');
+      expect(stalledTask?.execution?.error ?? '').toMatch(
+        /^Execution stalled: task remained in running\/executing for \d+s without a live execution handle and no completion signal from executor \(remote workload heartbeat stale\)\.$/,
+      );
+
+      await app.close();
+    } finally {
+      if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    }
+  });
 });

--- a/packages/app/src/__tests__/executing-stall.test.ts
+++ b/packages/app/src/__tests__/executing-stall.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { evaluateExecutingStall } from '../executing-stall.js';
+
+describe('evaluateExecutingStall', () => {
+  const now = new Date('2026-05-13T08:00:00.000Z');
+  const timeoutMs = 120_000;
+  const startedAt = new Date(now.getTime() - 5 * 60_000);
+
+  it('treats stale remote heartbeat as stalled for SSH tasks', () => {
+    const result = evaluateExecutingStall({
+      now,
+      phase: 'executing',
+      executorType: 'ssh',
+      executingStartedAt: startedAt,
+      executorHeartbeatAt: new Date(now.getTime() - 10_000),
+      remoteHeartbeatAt: new Date(now.getTime() - 4 * 60_000),
+      executingStallTimeoutMs: timeoutMs,
+    });
+
+    expect(result.executingStalled).toBe(true);
+    expect(result.staleReason).toBe('remote workload heartbeat stale');
+  });
+
+  it('keeps SSH task healthy when remote heartbeat is fresh', () => {
+    const result = evaluateExecutingStall({
+      now,
+      phase: 'executing',
+      executorType: 'ssh',
+      executingStartedAt: startedAt,
+      executorHeartbeatAt: new Date(now.getTime() - 4 * 60_000),
+      remoteHeartbeatAt: new Date(now.getTime() - 20_000),
+      executingStallTimeoutMs: timeoutMs,
+    });
+
+    expect(result.executingStalled).toBe(false);
+    expect(result.heartbeatStale).toBe(false);
+  });
+
+  it('uses executor heartbeat for non-SSH tasks', () => {
+    const result = evaluateExecutingStall({
+      now,
+      phase: 'executing',
+      executorType: 'worktree',
+      executingStartedAt: startedAt,
+      executorHeartbeatAt: new Date(now.getTime() - 4 * 60_000),
+      remoteHeartbeatAt: new Date(now.getTime() - 20_000),
+      executingStallTimeoutMs: timeoutMs,
+    });
+
+    expect(result.executingStalled).toBe(true);
+    expect(result.staleReason).toBe('executor heartbeat stale');
+  });
+
+  it('prioritizes lease expiration as the stale reason', () => {
+    const result = evaluateExecutingStall({
+      now,
+      phase: 'executing',
+      executorType: 'ssh',
+      executingStartedAt: startedAt,
+      remoteHeartbeatAt: new Date(now.getTime() - 5_000),
+      leaseExpiresAt: new Date(now.getTime() - 1_000),
+      executingStallTimeoutMs: timeoutMs,
+    });
+
+    expect(result.executingStalled).toBe(true);
+    expect(result.staleReason).toBe('attempt lease expired');
+  });
+});

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -100,6 +100,11 @@ export interface InvokerConfig {
      * Only used in managed mode. Default: pnpm install --frozen-lockfile
      */
     provisionCommand?: string;
+    /**
+     * Remote workload heartbeat interval (seconds) emitted by the SSH payload wrapper.
+     * Used for SSH executing-stall liveness checks. Default: 30.
+     */
+    remoteHeartbeatIntervalSeconds?: number;
   }>;
   /**
    * Config-owned routing policy for heavyweight shell commands.

--- a/packages/app/src/executing-stall.ts
+++ b/packages/app/src/executing-stall.ts
@@ -1,0 +1,57 @@
+import type { ExecutorType } from '@invoker/workflow-core';
+
+export interface ExecutingStallEvaluationInput {
+  now: Date;
+  phase?: 'launching' | 'executing';
+  executorType?: ExecutorType;
+  executingStartedAt?: Date;
+  leaseExpiresAt?: Date;
+  executorHeartbeatAt?: Date;
+  remoteHeartbeatAt?: Date;
+  executingStallTimeoutMs: number;
+}
+
+export interface ExecutingStallEvaluation {
+  heartbeatStale: boolean;
+  leaseExpired: boolean;
+  executingStalled: boolean;
+  staleReason: string;
+}
+
+export function evaluateExecutingStall(input: ExecutingStallEvaluationInput): ExecutingStallEvaluation {
+  const {
+    now,
+    phase,
+    executorType,
+    executingStartedAt,
+    leaseExpiresAt,
+    executorHeartbeatAt,
+    remoteHeartbeatAt,
+    executingStallTimeoutMs,
+  } = input;
+  const heartbeatSource = executorType === 'ssh'
+    ? (remoteHeartbeatAt ?? executorHeartbeatAt)
+    : executorHeartbeatAt;
+  const heartbeatStale =
+    !heartbeatSource || now.getTime() - heartbeatSource.getTime() >= executingStallTimeoutMs;
+  const leaseExpired = !!leaseExpiresAt && leaseExpiresAt.getTime() < now.getTime();
+  const executingAgeMs = executingStartedAt ? now.getTime() - executingStartedAt.getTime() : 0;
+  const executingStalled =
+    phase === 'executing'
+    && executingStartedAt !== undefined
+    && executingAgeMs >= executingStallTimeoutMs
+    && (leaseExpired || heartbeatStale);
+
+  const staleReason = leaseExpired
+    ? 'attempt lease expired'
+    : executorType === 'ssh'
+    ? 'remote workload heartbeat stale'
+    : 'executor heartbeat stale';
+
+  return {
+    heartbeatStale,
+    leaseExpired,
+    executingStalled,
+    staleReason,
+  };
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -146,6 +146,7 @@ import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutati
 import { computeDeferredLaunchTiming } from './deferred-runnable.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
+import { evaluateExecutingStall } from './executing-stall.js';
 import { listOpenFixIntentsForTask } from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
 
@@ -2344,6 +2345,7 @@ if (isHeadless) {
                   ? persistence.loadAttempt?.(task.execution.selectedAttemptId)
                   : undefined;
                 const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
+                const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
 
                 if (task.status === 'running') {
                   const launchStartedAt = parseExecutionDate(task.execution.launchStartedAt)
@@ -2390,17 +2392,18 @@ if (isHeadless) {
 
                   const executingStartedAt = parseExecutionDate(task.execution.startedAt);
                   const executingAgeMs = executingStartedAt ? now.getTime() - executingStartedAt.getTime() : 0;
-                  const heartbeatStale =
-                    !previousHeartbeat || now.getTime() - previousHeartbeat.getTime() >= executingStallTimeoutMs;
-                  const leaseExpired = !!leaseExpiresAt && leaseExpiresAt.getTime() < now.getTime();
-                  const executingStalled =
-                    task.execution.phase === 'executing'
-                    && executingStartedAt !== undefined
-                    && executingAgeMs >= executingStallTimeoutMs
-                    && (leaseExpired || heartbeatStale);
+                  const { heartbeatStale, leaseExpired, executingStalled, staleReason } = evaluateExecutingStall({
+                    now,
+                    phase: task.execution.phase,
+                    executorType: task.config.executorType,
+                    executingStartedAt,
+                    leaseExpiresAt,
+                    executorHeartbeatAt: previousHeartbeat,
+                    remoteHeartbeatAt: remoteHeartbeat,
+                    executingStallTimeoutMs,
+                  });
 
                   if (executingStalled) {
-                    const staleReason = leaseExpired ? 'attempt lease expired' : 'executor heartbeat stale';
                     const executingError =
                       `Execution stalled: task remained in running/executing for ${Math.floor(executingAgeMs / 1000)}s ` +
                       `without a live execution handle and no completion signal from executor (${staleReason}).`;

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -885,6 +885,82 @@ describe('SshExecutor entry lifecycle', () => {
     expect(completed).toBe(true);
   });
 
+  it('filters remote heartbeat markers from output and emits heartbeat events', async () => {
+    const request = makeRequest({
+      inputs: {
+        command: 'echo hello',
+        repoUrl: 'git@github.com:test/repo.git',
+      },
+    });
+
+    const handle = await ssh.start(request);
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    const outputChunks: string[] = [];
+    let heartbeatCount = 0;
+    ssh.onOutput(handle, (chunk) => outputChunks.push(chunk));
+    ssh.onHeartbeat(handle, () => {
+      heartbeatCount += 1;
+    });
+
+    (sshProcess.stdout as any).emit('data', Buffer.from('__INVOKER_REMOTE_HEARTBEAT__ 100\nhello\n'));
+    (sshProcess.stdout as any).emit('data', Buffer.from('__INVOKER_REMOTE_HEARTBEAT__ 101\nworld'));
+    sshProcess.emit('close', 0, null);
+
+    await new Promise((r) => setTimeout(r, 80));
+    expect(heartbeatCount).toBe(2);
+    expect(outputChunks.join('')).toContain('hello\n');
+    expect(outputChunks.join('')).toContain('world');
+    expect(outputChunks.join('')).not.toContain('__INVOKER_REMOTE_HEARTBEAT__');
+  });
+
+  it('maps SSH exit 255 broken pipe into deterministic transport error', async () => {
+    const request = makeRequest({
+      inputs: {
+        command: 'echo hello',
+        repoUrl: 'git@github.com:test/repo.git',
+      },
+    });
+
+    const handle = await ssh.start(request);
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    const completion = new Promise<any>((resolve) => {
+      ssh.onComplete(handle, (response) => resolve(response));
+    });
+
+    (sshProcess.stderr as any).emit('data', Buffer.from('client_loop: send disconnect: Broken pipe\n'));
+    sshProcess.emit('close', 255, null);
+
+    const response = await completion;
+    expect(response.status).toBe('failed');
+    expect(response.outputs.exitCode).toBe(255);
+    expect(response.outputs.error).toContain('broken pipe');
+  });
+
+  it('includes SSH transport timeout/keepalive options in spawned SSH args', async () => {
+    const ssh2 = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+    }) as any;
+
+    const pending = ssh2.runBash('echo ready', '/tmp');
+    await new Promise((r) => setImmediate(r));
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    (sshProcess.stdout as any).emit('data', Buffer.from('ready\n'));
+    sshProcess.emit('close', 0, null);
+    await pending;
+
+    const childProcessMod = await import('node:child_process');
+    const spawnMock = childProcessMod.spawn as unknown as ReturnType<typeof vi.fn>;
+    const firstCallArgs = spawnMock.mock.calls[spawnMock.mock.calls.length - 1]?.[1] as string[];
+    expect(firstCallArgs).toEqual(expect.arrayContaining([
+      '-o', 'ConnectTimeout=15',
+      '-o', 'ServerAliveInterval=30',
+      '-o', 'ServerAliveCountMax=3',
+      '-o', 'BatchMode=yes',
+    ]));
+  });
+
   it('preserves stdout on execRemoteCapture error (Bug #4)', async () => {
     const ssh2 = new SshExecutor({
       host: 'localhost',

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -961,6 +961,43 @@ describe('SshExecutor entry lifecycle', () => {
     ]));
   });
 
+  it('uses configured remote heartbeat interval from SSH target config', async () => {
+    const ssh2 = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+      remoteHeartbeatIntervalSeconds: 11,
+    }) as any;
+
+    vi.spyOn(ssh2, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123def456abc123def456abc123def456abc1';
+      }
+      if (script.includes('printf %s \"$HOME\"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+    vi.spyOn(ssh2, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    await ssh2.start(makeRequest({
+      actionType: 'command',
+      inputs: {
+        command: 'echo heartbeat',
+        description: 'test',
+        repoUrl: 'git@github.com:owner/repo.git',
+      },
+    }));
+
+    const proc = spawnedProcesses[spawnedProcesses.length - 1];
+    expect(proc).toBeDefined();
+    const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
+    const script = writeMock.mock.calls[0]![0] as string;
+    expect(script).toContain('INVOKER_HEARTBEAT_INTERVAL_SECONDS=11');
+    proc.emit('close', 0, null);
+    await new Promise((r) => setTimeout(r, 50));
+  });
+
   it('preserves stdout on execRemoteCapture error (Bug #4)', async () => {
     const ssh2 = new SshExecutor({
       host: 'localhost',

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -9303,4 +9303,93 @@ console.log(JSON.stringify(out));
       expect(validateCanonicalPrBody(body)).toEqual([]);
     });
   });
+
+  describe('SSH heartbeat persistence metadata', () => {
+    it('stores remote workload heartbeat metadata for SSH executors', async () => {
+      const runningTask = makeTask({
+        id: 'task-ssh-heartbeat',
+        status: 'running',
+        config: {
+          workflowId: 'wf-1',
+          executorType: 'ssh',
+          command: 'echo hi',
+          remoteTargetId: 'remote-1',
+        },
+        execution: { generation: 0, selectedAttemptId: 'attempt-ssh-1' },
+      });
+
+      const updateTask = vi.fn();
+      const updateAttempt = vi.fn();
+      const heartbeatCallbacks = new Map<string, (taskId: string) => void>();
+      const completeCallbacks = new Map<string, (response: any) => void>();
+      const sshExecutor = {
+        type: 'ssh',
+        start: vi.fn(async () => ({
+          executionId: 'exec-ssh-1',
+          taskId: runningTask.id,
+          workspacePath: '/tmp/ws',
+        })),
+        onOutput: vi.fn((_handle: unknown, _cb: (chunk: string) => void) => () => {}),
+        onHeartbeat: vi.fn((_handle: unknown, cb: (taskId: string) => void) => {
+          heartbeatCallbacks.set(runningTask.id, cb);
+          return () => {};
+        }),
+        onComplete: vi.fn((_handle: unknown, cb: (response: any) => void) => {
+          completeCallbacks.set(runningTask.id, cb);
+          return () => {};
+        }),
+      } as any;
+
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: vi.fn((id: string) => (id === runningTask.id ? runningTask : undefined)),
+          getAllTasks: vi.fn(() => [runningTask]),
+          markTaskRunningAfterLaunch: vi.fn(() => true),
+          handleWorkerResponse: vi.fn(() => []),
+        } as any,
+        persistence: {
+          loadWorkflow: vi.fn(() => ({ id: 'wf-1', repoUrl: 'git@github.com:owner/repo.git' })),
+          updateTask,
+          updateAttempt,
+          appendTaskOutput: vi.fn(),
+        } as any,
+        executorRegistry: {
+          getDefault: vi.fn(() => sshExecutor),
+          get: vi.fn((type: string) => (type === 'ssh' ? sshExecutor : null)),
+          getAll: vi.fn(() => []),
+        } as any,
+        cwd: '/tmp',
+        callbacks: { onHeartbeat: vi.fn() },
+      });
+
+      const pending = runner.executeTask(runningTask);
+      await new Promise((resolve) => setImmediate(resolve));
+      heartbeatCallbacks.get(runningTask.id)?.(runningTask.id);
+      completeCallbacks.get(runningTask.id)?.({
+        requestId: 'req-done',
+        actionId: runningTask.id,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+      await pending;
+
+      expect(updateTask).toHaveBeenCalledWith(
+        runningTask.id,
+        expect.objectContaining({
+          execution: expect.objectContaining({
+            lastHeartbeatAt: expect.any(Date),
+            remoteHeartbeatAt: expect.any(Date),
+            heartbeatSource: 'remote_workload',
+          }),
+        }),
+      );
+      expect(updateAttempt).toHaveBeenCalledWith(
+        'attempt-ssh-1',
+        expect.objectContaining({
+          lastHeartbeatAt: expect.any(Date),
+          leaseExpiresAt: expect.any(Date),
+        }),
+      );
+    });
+  });
 });

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -41,6 +41,10 @@ export interface BaseEntry {
   finalizingAfterClose?: boolean;
 }
 
+interface HeartbeatOptions {
+  emitIntervalHeartbeat?: boolean;
+}
+
 export interface ClaudeSessionParams {
   sessionId: string;
   cliArgs: string[];
@@ -179,9 +183,14 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
    * Start a periodic heartbeat that detects orphaned processes: the child
    * has exited but the close handler failed to fire completion.
    */
-  protected startHeartbeat(executionId: string, child: ChildProcess): void {
+  protected startHeartbeat(
+    executionId: string,
+    child: ChildProcess,
+    opts: HeartbeatOptions = {},
+  ): void {
     const entry = this.entries.get(executionId);
     if (!entry) return;
+    const emitIntervalHeartbeat = opts.emitIntervalHeartbeat ?? true;
 
     entry.heartbeatStartedAt = Date.now();
 
@@ -232,7 +241,9 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         return;
       }
 
-      this.emitHeartbeat(executionId);
+      if (emitIntervalHeartbeat) {
+        this.emitHeartbeat(executionId);
+      }
     }, this.heartbeatIntervalMs);
   }
 

--- a/packages/execution-engine/src/claude-session-driver.ts
+++ b/packages/execution-engine/src/claude-session-driver.ts
@@ -15,6 +15,7 @@ import { homedir } from 'node:os';
 import { spawn } from 'node:child_process';
 import type { AgentSessionInspection, SessionDriver, SessionUsageEvent, RemoteTarget } from './session-driver.js';
 import type { AgentMessage } from './codex-session.js';
+import { buildSshConnectionArgs } from './ssh-transport-options.js';
 
 export class ClaudeSessionDriver implements SessionDriver {
   /**
@@ -166,11 +167,12 @@ export class ClaudeSessionDriver implements SessionDriver {
     return new Promise((resolve) => {
       const script = `find ~/.claude/projects -name '${sessionId}.jsonl' -print -quit 2>/dev/null | head -1 | xargs cat 2>/dev/null`;
       const sshArgs = [
-        '-i', target.sshKeyPath,
-        '-p', String(target.port ?? 22),
-        '-o', 'StrictHostKeyChecking=accept-new',
-        '-o', 'BatchMode=yes',
-        `${target.user}@${target.host}`,
+        ...buildSshConnectionArgs({
+          sshKeyPath: target.sshKeyPath,
+          port: target.port,
+          user: target.user,
+          host: target.host,
+        }, { batchMode: true }),
         script,
       ];
       const child = spawn('ssh', sshArgs, { stdio: ['ignore', 'pipe', 'pipe'] });

--- a/packages/execution-engine/src/codex-session-driver.ts
+++ b/packages/execution-engine/src/codex-session-driver.ts
@@ -14,6 +14,7 @@ import { spawn } from 'node:child_process';
 import type { AgentSessionInspection, SessionDriver, SessionUsageEvent, RemoteTarget } from './session-driver.js';
 import { parseCodexSessionJsonl, toReadableText, extractCodexSessionId, extractCodexUsage } from './codex-session.js';
 import type { AgentMessage } from './codex-session.js';
+import { buildSshConnectionArgs } from './ssh-transport-options.js';
 
 export class CodexSessionDriver implements SessionDriver {
   private getStorageDir(): string {
@@ -92,11 +93,12 @@ export class CodexSessionDriver implements SessionDriver {
     return new Promise((resolve) => {
       const script = `cat ~/.invoker/agent-sessions/${sessionId}.jsonl 2>/dev/null`;
       const sshArgs = [
-        '-i', target.sshKeyPath,
-        '-p', String(target.port ?? 22),
-        '-o', 'StrictHostKeyChecking=accept-new',
-        '-o', 'BatchMode=yes',
-        `${target.user}@${target.host}`,
+        ...buildSshConnectionArgs({
+          sshKeyPath: target.sshKeyPath,
+          port: target.port,
+          user: target.user,
+          host: target.host,
+        }, { batchMode: true }),
         script,
       ];
       const child = spawn('ssh', sshArgs, { stdio: ['ignore', 'pipe', 'pipe'] });

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -19,6 +19,7 @@ import type { ExecutionAgent } from './agent.js';
 import type { SessionDriver } from './session-driver.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { buildWorktreeListScript, createSshRemoteScriptError } from './ssh-git-exec.js';
+import { buildSshConnectionArgs } from './ssh-transport-options.js';
 import { findManagedWorktreeForBranch } from './worktree-discovery.js';
 
 // ── Host interface ───────────────────────────────────────
@@ -619,11 +620,12 @@ eval "$(echo "${agentCmdB64}" | base64 -d)"
 `;
 
   const sshArgs = [
-    '-i', target.sshKeyPath,
-    '-p', String(target.port ?? 22),
-    '-o', 'StrictHostKeyChecking=accept-new',
-    '-o', 'BatchMode=yes',
-    `${target.user}@${target.host}`,
+    ...buildSshConnectionArgs({
+      sshKeyPath: target.sshKeyPath,
+      port: target.port,
+      user: target.user,
+      host: target.host,
+    }, { batchMode: true }),
     'bash', '-s',
   ];
 
@@ -728,11 +730,12 @@ export function spawnAgentFixViaRegistry(
 
 function execRemoteSsh(target: RemoteTargetConfig, script: string, phase?: string): Promise<string> {
   const sshArgs = [
-    '-i', target.sshKeyPath,
-    '-p', String(target.port ?? 22),
-    '-o', 'StrictHostKeyChecking=accept-new',
-    '-o', 'BatchMode=yes',
-    `${target.user}@${target.host}`,
+    ...buildSshConnectionArgs({
+      sshKeyPath: target.sshKeyPath,
+      port: target.port,
+      user: target.user,
+      host: target.host,
+    }, { batchMode: true }),
     'bash', '-s',
   ];
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -12,6 +12,7 @@ import { DEFAULT_WORKTREE_PROVISION_COMMAND } from './default-worktree-provision
 import type { AgentRegistry } from './agent-registry.js';
 import { computeRepoUrlHash, sanitizeBranchForPath } from './git-utils.js';
 import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
+import { buildSshConnectionArgs } from './ssh-transport-options.js';
 import {
   shellPosixSingleQuote as sshGitShellQuote,
   base64Encode as sshGitB64,
@@ -69,6 +70,8 @@ interface SshEntry extends BaseEntry {
  */
 export class SshExecutor extends BaseExecutor<SshEntry> {
   readonly type = 'ssh';
+  private static readonly REMOTE_HEARTBEAT_MARKER = '__INVOKER_REMOTE_HEARTBEAT__';
+  private static readonly DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS = 30;
 
   private readonly host: string;
   private readonly user: string;
@@ -94,23 +97,60 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   }
 
   private buildSshArgs(): string[] {
-    return [
-      '-i', this.sshKeyPath,
-      '-p', String(this.port),
-      '-o', 'StrictHostKeyChecking=accept-new',
-      '-o', 'BatchMode=yes',
-      `${this.user}@${this.host}`,
-    ];
+    return buildSshConnectionArgs({
+      sshKeyPath: this.sshKeyPath,
+      port: this.port,
+      user: this.user,
+      host: this.host,
+    }, { batchMode: true });
   }
 
   /** SSH args without `BatchMode` so `-t` / interactive sessions work for external Terminal.app. */
   private buildSshArgsInteractive(): string[] {
-    return [
-      '-i', this.sshKeyPath,
-      '-p', String(this.port),
-      '-o', 'StrictHostKeyChecking=accept-new',
-      `${this.user}@${this.host}`,
-    ];
+    return buildSshConnectionArgs({
+      sshKeyPath: this.sshKeyPath,
+      port: this.port,
+      user: this.user,
+      host: this.host,
+    }, { batchMode: false });
+  }
+
+  private getRemoteHeartbeatIntervalSeconds(): number {
+    const raw = process.env.INVOKER_SSH_REMOTE_HEARTBEAT_INTERVAL_SECONDS?.trim();
+    if (!raw) return SshExecutor.DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS;
+    const parsed = Number.parseInt(raw, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) {
+      return SshExecutor.DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS;
+    }
+    return parsed;
+  }
+
+  private buildPayloadExecutionScript(payloadB64: string): string {
+    const intervalSeconds = this.getRemoteHeartbeatIntervalSeconds();
+    return `(
+  echo ${payloadB64} | base64 -d | bash -se
+) &
+PAYLOAD_PID=$!
+INVOKER_HEARTBEAT_MARKER=${this.shellQuote(SshExecutor.REMOTE_HEARTBEAT_MARKER)}
+INVOKER_HEARTBEAT_INTERVAL_SECONDS=${intervalSeconds}
+printf '%s %s\\n' "$INVOKER_HEARTBEAT_MARKER" "$(date +%s)"
+(
+  while kill -0 "$PAYLOAD_PID" 2>/dev/null; do
+    sleep "$INVOKER_HEARTBEAT_INTERVAL_SECONDS"
+    kill -0 "$PAYLOAD_PID" 2>/dev/null || break
+    printf '%s %s\\n' "$INVOKER_HEARTBEAT_MARKER" "$(date +%s)"
+  done
+) &
+HEARTBEAT_PID=$!
+if wait "$PAYLOAD_PID"; then
+  PAYLOAD_EXIT=0
+else
+  PAYLOAD_EXIT=$?
+fi
+kill "$HEARTBEAT_PID" >/dev/null 2>&1 || true
+wait "$HEARTBEAT_PID" 2>/dev/null || true
+exit "$PAYLOAD_EXIT"
+`;
   }
 
   private buildRemoteCommand(): string[] {
@@ -277,7 +317,7 @@ elif [[ "\${WT:0:2}" == '~/' ]]; then
 fi
 cd "$WT"
 echo "[SshExecutor BYO] Running task in user-provided workspace: $WT"
-echo ${payloadB64} | base64 -d | bash -se
+${this.buildPayloadExecutionScript(payloadB64)}
 `;
 
     return this.spawnSshRemoteStdin(executionId, request, handle, runScript, agentSessionId, undefined);
@@ -454,7 +494,7 @@ cd "$WT"
 echo "[SshExecutor] Provisioning remote worktree with: ${this.provisionCommand.slice(0, 50)}..."
 eval "$(echo ${provB64} | base64 -d)"
 echo "[SshExecutor] Running task payload..."
-echo ${payloadB64} | base64 -d | bash -se
+${this.buildPayloadExecutionScript(payloadB64)}
 `;
 
     return this.spawnSshRemoteStdin(executionId, request, handle, runScript, agentSessionId, {
@@ -475,6 +515,55 @@ echo ${payloadB64} | base64 -d | bash -se
     if (handle.agentSessionId) (wrapped as any).agentSessionId = handle.agentSessionId;
     if (handle.containerId) (wrapped as any).containerId = handle.containerId;
     return wrapped;
+  }
+
+  private processOutputChunk(
+    executionId: string,
+    chunk: string,
+    streamState: { remainder: string },
+  ): void {
+    const full = streamState.remainder + chunk;
+    const lines = full.split('\n');
+    streamState.remainder = lines.pop() ?? '';
+    for (const line of lines) {
+      if (line.startsWith(SshExecutor.REMOTE_HEARTBEAT_MARKER)) {
+        this.emitHeartbeat(executionId);
+        continue;
+      }
+      this.emitOutput(executionId, `${line}\n`);
+    }
+  }
+
+  private flushOutputRemainder(executionId: string, streamState: { remainder: string }): void {
+    if (!streamState.remainder) return;
+    if (streamState.remainder.startsWith(SshExecutor.REMOTE_HEARTBEAT_MARKER)) {
+      this.emitHeartbeat(executionId);
+    } else {
+      this.emitOutput(executionId, streamState.remainder);
+    }
+    streamState.remainder = '';
+  }
+
+  private mapSshTransportError(
+    exitCode: number,
+    stderrOutput: string,
+    bufferedOutput: string,
+  ): string | undefined {
+    if (exitCode !== 255) return undefined;
+    const haystack = `${stderrOutput}\n${bufferedOutput}`.toLowerCase();
+    if (haystack.includes('broken pipe')) {
+      return 'SSH transport failed (exit 255): broken pipe while streaming remote task output.';
+    }
+    if (haystack.includes('connection timed out')) {
+      return 'SSH transport failed (exit 255): connection timed out.';
+    }
+    if (haystack.includes('operation timed out')) {
+      return 'SSH transport failed (exit 255): SSH operation timed out.';
+    }
+    if (haystack.includes('connection reset')) {
+      return 'SSH transport failed (exit 255): connection reset by peer.';
+    }
+    return 'SSH transport failed (exit 255): remote session terminated unexpectedly.';
   }
 
   /**
@@ -573,31 +662,41 @@ echo ${payloadB64} | base64 -d | bash -se
       handle.agentSessionId = agentSessionId;
     }
 
+    let stderrOutput = '';
+    const stdoutState = { remainder: '' };
+    const stderrState = { remainder: '' };
+
     child.stdout?.on('data', (chunk: Buffer) => {
-      this.emitOutput(executionId, chunk.toString());
+      this.processOutputChunk(executionId, chunk.toString(), stdoutState);
     });
 
     child.stderr?.on('data', (chunk: Buffer) => {
-      this.emitOutput(executionId, chunk.toString());
+      const text = chunk.toString();
+      stderrOutput += text;
+      this.processOutputChunk(executionId, text, stderrState);
     });
 
     child.on('close', (code, signal) => {
       void (async () => {
+        this.flushOutputRemainder(executionId, stdoutState);
+        this.flushOutputRemainder(executionId, stderrState);
         const exitCode = code ?? (signal ? 1 : 0);
         const e = this.entries.get(executionId);
         if (e) e.finalizingAfterClose = true;
         try {
           let status: 'completed' | 'failed' = exitCode === 0 ? 'completed' : 'failed';
           let mappedError: string | undefined;
+          const output = e?.outputBuffer.join('') ?? '';
           if (exitCode === 30) {
             mappedError = 'Upstream branch missing on remote clone';
           } else if (exitCode === 31) {
-            const output = e?.outputBuffer.join('') ?? '';
             const branchMatch = output.match(/MERGE_CONFLICT_BRANCH=(.+)/);
             const filesSection = output.match(/MERGE_CONFLICT_FILES:\n([\s\S]*?)(?:\n\[Ssh|$)/);
             const branch = branchMatch?.[1]?.trim() ?? 'unknown';
             const files = filesSection?.[1]?.trim() ?? '(see task output)';
             mappedError = `Merge conflict merging upstream branch "${branch}" on remote.\nConflicting files:\n${files}`;
+          } else {
+            mappedError = this.mapSshTransportError(exitCode, stderrOutput, output);
           }
 
           let commitHash: string | undefined;
@@ -681,7 +780,7 @@ echo ${payloadB64} | base64 -d | bash -se
       })();
     });
 
-    this.startHeartbeat(executionId, child);
+    this.startHeartbeat(executionId, child, { emitIntervalHeartbeat: false });
     return handle;
   }
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -53,6 +53,11 @@ export interface SshExecutorConfig {
    * Only used in managed mode. Default: pnpm install --frozen-lockfile
    */
   provisionCommand?: string;
+  /**
+   * Remote workload heartbeat interval (seconds) emitted by the SSH payload wrapper.
+   * Default: 30.
+   */
+  remoteHeartbeatIntervalSeconds?: number;
 }
 
 interface SshEntry extends BaseEntry {
@@ -81,6 +86,7 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   private readonly managedWorkspaces: boolean;
   private readonly remoteInvokerHome: string;
   private readonly provisionCommand: string;
+  private readonly remoteHeartbeatIntervalSeconds: number;
   private readonly remotePath: string;
 
   constructor(config: SshExecutorConfig) {
@@ -93,6 +99,13 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     this.managedWorkspaces = config.managedWorkspaces ?? false;
     this.remoteInvokerHome = config.remoteInvokerHome ?? '~/.invoker';
     this.provisionCommand = config.provisionCommand ?? DEFAULT_WORKTREE_PROVISION_COMMAND;
+    const configuredRemoteHeartbeatInterval = config.remoteHeartbeatIntervalSeconds;
+    this.remoteHeartbeatIntervalSeconds =
+      typeof configuredRemoteHeartbeatInterval === 'number'
+      && Number.isFinite(configuredRemoteHeartbeatInterval)
+      && configuredRemoteHeartbeatInterval > 0
+        ? configuredRemoteHeartbeatInterval
+        : SshExecutor.DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS;
     this.remotePath = process.env.PATH ?? '';
   }
 
@@ -115,18 +128,8 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     }, { batchMode: false });
   }
 
-  private getRemoteHeartbeatIntervalSeconds(): number {
-    const raw = process.env.INVOKER_SSH_REMOTE_HEARTBEAT_INTERVAL_SECONDS?.trim();
-    if (!raw) return SshExecutor.DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS;
-    const parsed = Number.parseInt(raw, 10);
-    if (!Number.isFinite(parsed) || parsed <= 0) {
-      return SshExecutor.DEFAULT_REMOTE_HEARTBEAT_INTERVAL_SECONDS;
-    }
-    return parsed;
-  }
-
   private buildPayloadExecutionScript(payloadB64: string): string {
-    const intervalSeconds = this.getRemoteHeartbeatIntervalSeconds();
+    const intervalSeconds = this.remoteHeartbeatIntervalSeconds;
     return `(
   echo ${payloadB64} | base64 -d | bash -se
 ) &

--- a/packages/execution-engine/src/ssh-transport-options.ts
+++ b/packages/execution-engine/src/ssh-transport-options.ts
@@ -1,0 +1,53 @@
+export interface SshTargetConnection {
+  sshKeyPath: string;
+  port?: number;
+  user: string;
+  host: string;
+}
+
+const DEFAULT_CONNECT_TIMEOUT_SECONDS = 15;
+const DEFAULT_SERVER_ALIVE_INTERVAL_SECONDS = 30;
+const DEFAULT_SERVER_ALIVE_COUNT_MAX = 3;
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+export function buildSshTransportOptions(opts: { batchMode: boolean }): string[] {
+  const connectTimeout = readPositiveIntEnv(
+    'INVOKER_SSH_CONNECT_TIMEOUT_SECONDS',
+    DEFAULT_CONNECT_TIMEOUT_SECONDS,
+  );
+  const serverAliveInterval = readPositiveIntEnv(
+    'INVOKER_SSH_SERVER_ALIVE_INTERVAL_SECONDS',
+    DEFAULT_SERVER_ALIVE_INTERVAL_SECONDS,
+  );
+  const serverAliveCountMax = readPositiveIntEnv(
+    'INVOKER_SSH_SERVER_ALIVE_COUNT_MAX',
+    DEFAULT_SERVER_ALIVE_COUNT_MAX,
+  );
+
+  return [
+    '-o', 'StrictHostKeyChecking=accept-new',
+    '-o', `ConnectTimeout=${connectTimeout}`,
+    '-o', `ServerAliveInterval=${serverAliveInterval}`,
+    '-o', `ServerAliveCountMax=${serverAliveCountMax}`,
+    ...(opts.batchMode ? ['-o', 'BatchMode=yes'] : []),
+  ];
+}
+
+export function buildSshConnectionArgs(
+  target: SshTargetConnection,
+  opts: { batchMode: boolean },
+): string[] {
+  return [
+    '-i', target.sshKeyPath,
+    '-p', String(target.port ?? 22),
+    ...buildSshTransportOptions({ batchMode: opts.batchMode }),
+    `${target.user}@${target.host}`,
+  ];
+}

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -130,6 +130,7 @@ export interface TaskRunnerConfig {
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
     provisionCommand?: string;
+    remoteHeartbeatIntervalSeconds?: number;
   }>;
   /** Docker execution environment configuration from .invoker.json. */
   dockerConfig?: {
@@ -155,7 +156,7 @@ export class TaskRunner {
   /** @internal */ mergeGateProvider?: MergeGateProvider;
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
   private activePrPollers = new Map<string, ReturnType<typeof setInterval>>();
-  private getRemoteTargets: () => Record<string, { host: string; user: string; sshKeyPath: string; port?: number; managedWorkspaces?: boolean; remoteInvokerHome?: string; provisionCommand?: string }>;
+  private getRemoteTargets: () => Record<string, { host: string; user: string; sshKeyPath: string; port?: number; managedWorkspaces?: boolean; remoteInvokerHome?: string; provisionCommand?: string; remoteHeartbeatIntervalSeconds?: number }>;
   private dockerConfig: { imageName?: string; secretsFile?: string };
   private executionAgentRegistry?: AgentRegistry;
   private logger: Logger;
@@ -848,6 +849,7 @@ export class TaskRunner {
           managedWorkspaces: target.managedWorkspaces,
           remoteInvokerHome: target.remoteInvokerHome,
           provisionCommand: target.provisionCommand,
+          remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
         });
         const cacheKey = `${targetId}|${configFingerprint}`;
 
@@ -874,6 +876,7 @@ export class TaskRunner {
           managedWorkspaces: target.managedWorkspaces,
           remoteInvokerHome: target.remoteInvokerHome,
           provisionCommand: target.provisionCommand,
+          remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
         });
 
         this.sshExecutorCache.set(cacheKey, ssh);
@@ -1802,6 +1805,8 @@ export class TaskRunner {
     port?: number;
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
+    provisionCommand?: string;
+    remoteHeartbeatIntervalSeconds?: number;
   } | undefined {
     return this.getRemoteTargets()[targetId];
   }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -690,9 +690,18 @@ export class TaskRunner {
     // Wire heartbeat
     executor.onHeartbeat(handle, () => {
       const now = new Date();
+      const isRemoteWorkloadHeartbeat = executor.type === 'ssh';
       this.persistence.updateAttempt?.(attemptId, {
         lastHeartbeatAt: now,
         leaseExpiresAt: nextLeaseExpiry(now),
+      } as any);
+      this.persistence.updateTask(task.id, {
+        execution: {
+          lastHeartbeatAt: now,
+          ...(isRemoteWorkloadHeartbeat
+            ? { remoteHeartbeatAt: now, heartbeatSource: 'remote_workload' as const }
+            : { heartbeatSource: 'executor' as const }),
+        },
       } as any);
       this.callbacks.onHeartbeat?.(task.id);
     });

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -97,6 +97,7 @@ export interface ExternalDependency {
 // Never copied when cloning. Reset on restart.
 
 export type TaskRunPhase = 'launching' | 'executing';
+export type TaskHeartbeatSource = 'executor' | 'remote_workload';
 
 export interface TaskExecution {
   readonly generation?: number;
@@ -109,6 +110,8 @@ export interface TaskExecution {
   readonly startedAt?: Date;
   readonly completedAt?: Date;
   readonly lastHeartbeatAt?: Date;
+  readonly remoteHeartbeatAt?: Date;
+  readonly heartbeatSource?: TaskHeartbeatSource;
   readonly actionRequestId?: string;
   readonly branch?: string;
   readonly commit?: string;


### PR DESCRIPTION
## Summary

This hardens SSH execution liveness so tasks fail explicitly instead of stalling when the remote workload dies while the SSH transport remains alive.
It adds transport keepalive/timeout defaults, switches SSH heartbeat semantics to remote workload heartbeat markers, updates executing-stall evaluation for SSH tasks, and adds regression/e2e coverage for stale-heartbeat failure paths.
A follow-up change moves SSH remote heartbeat interval tuning from `INVOKER_SSH_REMOTE_HEARTBEAT_INTERVAL_SECONDS` to per-target config (`remoteTargets.<id>.remoteHeartbeatIntervalSeconds`) so behavior is explicit in checked config instead of process env.

## Architecture

### Before

```mermaid
flowchart LR
  A[Local SSH child alive] --> B[Periodic executor heartbeat]
  B --> C[Task remains running/executing]
  C --> D[Remote payload may already be dead]
```

### After

```mermaid
flowchart LR
  A[Remote payload process] --> B[Emits __INVOKER_REMOTE_HEARTBEAT__ markers]
  B --> C[SshExecutor emits heartbeat events from markers]
  C --> D[TaskRunner persists remoteHeartbeatAt]
  D --> E[App executing-stall watchdog evaluates remote freshness for SSH]
  E --> F[Deterministic failed state instead of stall]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts -t "filters remote heartbeat markers|maps SSH exit 255|includes SSH transport timeout"`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts -t "SSH heartbeat persistence metadata"`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/executing-stall.test.ts`
- [x] `cd packages/app && pnpm exec playwright test --grep "fails SSH executing task when remote workload heartbeat is stale"`
- [x] `bash scripts/repro/repro-missing-completion-after-remote-exit.sh --expect fixed --min-stale-seconds 300 --executor ssh --strict`
- [x] `bash scripts/repro/repro-ssh-orphan-for-task.sh "wf-1778431095371-43/regression-inv-63"`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts src/__tests__/task-runner.test.ts -t "remoteTargetsProvider|uses configured remote heartbeat interval"`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 82b039d`
- Post-revert steps: Re-run the heartbeat-config regression and SSH watchdog tests above to verify env-var-based interval handling is restored.
- Data migration? No.

Made with [Cursor](https://cursor.com)
