### PR TITLE
Add mixed-member pool scheduling and enforce member exclusivity.

### DIFF
--- a/docs/remote-ssh-targets.md
+++ b/docs/remote-ssh-targets.md
@@ -6,7 +6,7 @@ Execute Invoker tasks on remote machines via SSH key-based authentication.
 
 The SSH executor (`executorType: ssh`) runs task commands on remote hosts over SSH. Authentication is exclusively key-based — no password auth or `sshpass` dependency is required.
 
-Each remote target is defined in the Invoker config with a host, user, and path to an SSH private key. Tasks reference targets by ID.
+Each remote target is defined in the Invoker config with a host, user, and path to an SSH private key. Tasks route through `poolId` only.
 
 ## Configuration
 
@@ -41,8 +41,11 @@ If you want to use a repo-specific config file, launch Invoker with `INVOKER_REP
   },
   "executionPools": {
     "ssh-light": {
-      "type": "ssh",
-      "members": ["staging-server", "staging-server-b"],
+      "members": [
+        { "type": "ssh", "id": "staging-server" },
+        { "type": "ssh", "id": "staging-server-b" },
+        { "type": "worktree", "id": "local-fallback", "maxConcurrentTasks": 2 }
+      ],
       "selectionStrategy": "roundRobin",
       "maxConcurrentTasksPerMember": 1
     }
@@ -68,8 +71,7 @@ If you want to use a repo-specific config file, launch Invoker with `INVOKER_REP
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `type` | `"ssh"` \| `"worktree"` | yes | Pool substrate |
-| `members` | string[] | yes | Member IDs (SSH pools use `remoteTargets` keys) |
+| `members` | array | yes | Member objects: `{ "type": "ssh" \| "worktree", "id": "<member-id>" }` |
 | `selectionStrategy` | `"roundRobin"` \| `"leastLoaded"` | no | Member selection strategy (default: `roundRobin`) |
 | `maxConcurrentTasksPerMember` | number | no | Fallback per-member cap when target-level cap is not set |
 
@@ -81,8 +83,10 @@ Use `executorRoutingRules` with `strategy: "route"` to auto-assign matching comm
 {
   "executionPools": {
     "ssh-light": {
-      "type": "ssh",
-      "members": ["staging-server", "staging-server-b"],
+      "members": [
+        { "type": "ssh", "id": "staging-server" },
+        { "type": "ssh", "id": "staging-server-b" }
+      ],
       "selectionStrategy": "roundRobin",
       "maxConcurrentTasksPerMember": 1
     }
@@ -123,10 +127,11 @@ tasks:
 Queue semantics are shared across pools:
 - if all members are at capacity, new tasks wait in that pool queue;
 - when a member frees a slot, the next queued task is launched automatically.
+- members cannot be shared across pools (for example, the same `ssh:<id>` cannot appear in two pools).
 
 ## Usage in Plans
 
-Reference a remote target in a plan YAML task:
+Reference a pool in plan YAML tasks:
 
 ```yaml
 name: "Deploy to staging"
@@ -137,14 +142,14 @@ tasks:
     description: "Verify staging server is reachable"
     command: "echo 'OK'; uptime; df -h"
     executorType: ssh
-    remoteTargetId: staging-server
+    poolId: ssh-light
     dependencies: []
 
   - id: run-migrations
     description: "Run database migrations on staging"
     command: "cd /opt/app && ./migrate.sh"
     executorType: ssh
-    remoteTargetId: staging-server
+    poolId: ssh-light
     dependencies:
       - health-check
 ```
@@ -153,15 +158,15 @@ tasks:
 
 - `executorType: ssh` — selects the SSH executor
 - `poolId: <id>` — routes through a named pool in `executionPools`
-- `remoteTargetId: <id>` — legacy direct-target routing (still supported)
+- `remoteTargetId` is no longer accepted in plan YAML.
 
-At least one destination is required for SSH tasks: `poolId` or `remoteTargetId`.
+`poolId` is required for SSH tasks.
 
 ## How It Works
 
-1. The plan parser reads `executorType` and `remoteTargetId` from YAML and carries them through to `TaskConfig`.
-2. When `TaskRunner.selectExecutor()` sees `executorType: ssh`, it looks up the `remoteTargetId` in the `remoteTargets` config map.
-3. An `SshExecutor` instance is created with the target's connection details.
+1. The plan parser reads `executorType` and `poolId` from YAML.
+2. TaskRunner acquires a member slot from the selected pool (shared queue/drain).
+3. If the selected member is SSH, an `SshExecutor` instance is resolved from `remoteTargets`.
 4. The runner spawns: `ssh -i <keyPath> -p <port> -o StrictHostKeyChecking=accept-new -o BatchMode=yes user@host <command>`
 5. For `claude` action types, the Claude CLI command is shell-quoted and executed remotely.
 
@@ -190,5 +195,5 @@ bash scripts/verify-digitalocean-e2e.sh
 ## Security Notes
 
 - SSH keys must never be committed to the repository. The `sshKeyPath` field is a local filesystem path, not the key content.
-- The `remoteTargetId` stored in the task config and SQLite database is a non-secret alias — it contains no credentials.
+- Selected pool-member IDs stored in runtime task metadata are non-secret aliases; credentials remain only in local config.
 - `BatchMode=yes` ensures SSH never falls back to interactive password prompts.

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -7841,7 +7841,7 @@ console.log(JSON.stringify(out));
         config: { executorType: 'ssh' },
       });
 
-      expect(() => executor.selectExecutor(task)).toThrow('has executorType=ssh but no remoteTargetId');
+      expect(() => executor.selectExecutor(task)).toThrow('resolved to executorType=ssh but no pool member target was assigned');
     });
 
     it('throws when remoteTargetId does not exist in config', () => {
@@ -7887,8 +7887,7 @@ console.log(JSON.stringify(out));
         }),
         executionPoolsProvider: () => ({
           'ssh-light': {
-            type: 'ssh',
-            members: ['remote-a'],
+            members: [{ type: 'ssh', id: 'remote-a' }],
             selectionStrategy: 'roundRobin',
           },
         }),
@@ -7924,8 +7923,10 @@ console.log(JSON.stringify(out));
         }),
         executionPoolsProvider: () => ({
           'ssh-light': {
-            type: 'ssh',
-            members: ['remote-a', 'remote-b'],
+            members: [
+              { type: 'ssh', id: 'remote-a' },
+              { type: 'ssh', id: 'remote-b' },
+            ],
             selectionStrategy: 'roundRobin',
           },
         }),
@@ -7939,6 +7940,26 @@ console.log(JSON.stringify(out));
       const second = await (runner as any).acquirePoolSlot(task);
       expect(first.memberId).toBe('remote-a');
       expect(second.memberId).toBe('remote-b');
+    });
+
+    it('rejects shared members across different pools', async () => {
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'remote-a': { host: 'a', user: 'u', sshKeyPath: 'k', maxConcurrentTasks: 1 },
+        }),
+        executionPoolsProvider: () => ({
+          'pool-a': { members: [{ type: 'ssh', id: 'remote-a' }] },
+          'pool-b': { members: [{ type: 'ssh', id: 'remote-a' }] },
+        }),
+      });
+
+      expect(() =>
+        (runner as any).getOrBuildPoolState('pool-a'),
+      ).toThrow('Members may only belong to one pool.');
     });
   });
 
@@ -8029,7 +8050,7 @@ console.log(JSON.stringify(out));
         config: {
           command: 'echo test',
           executorType: 'ssh',
-          remoteTargetId: 'remote-1',
+          poolId: 'ssh-pool',
         },
       });
 
@@ -8050,6 +8071,12 @@ console.log(JSON.stringify(out));
           getAll: () => [managedSshExecutor],
         } as any,
         cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'remote-1': { host: 'ssh', user: 'u', sshKeyPath: 'k' },
+        }),
+        executionPoolsProvider: () => ({
+          'ssh-pool': { members: [{ type: 'ssh', id: 'remote-1' }] },
+        }),
       });
 
       await executor.executeTask(task);
@@ -8089,7 +8116,7 @@ console.log(JSON.stringify(out));
       const task = makeTask({
         id: 'task-failed',
         status: 'pending',
-        config: { command: 'echo test', executorType: 'ssh' },
+        config: { command: 'echo test', executorType: 'ssh', poolId: 'ssh-pool' },
       });
 
       const updateSpy = vi.fn();
@@ -8110,6 +8137,12 @@ console.log(JSON.stringify(out));
           getAll: () => [failingExecutor],
         } as any,
         cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'remote-1': { host: 'ssh', user: 'u', sshKeyPath: 'k' },
+        }),
+        executionPoolsProvider: () => ({
+          'ssh-pool': { members: [{ type: 'ssh', id: 'remote-1' }] },
+        }),
       });
 
       await executor.executeTask(task);
@@ -8227,7 +8260,7 @@ console.log(JSON.stringify(out));
       const task = makeTask({
         id: 'byo-task-1',
         status: 'pending',
-        config: { command: 'pwd', executorType: 'ssh' },
+        config: { command: 'pwd', executorType: 'ssh', poolId: 'ssh-pool' },
       });
 
       const updateSpy = vi.fn();
@@ -8247,6 +8280,12 @@ console.log(JSON.stringify(out));
           getAll: () => [byoExecutor],
         } as any,
         cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'remote-1': { host: 'ssh', user: 'u', sshKeyPath: 'k' },
+        }),
+        executionPoolsProvider: () => ({
+          'ssh-pool': { members: [{ type: 'ssh', id: 'remote-1' }] },
+        }),
       });
 
       await executor.executeTask(task);

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -86,9 +86,14 @@ interface RemoteTargetConfig {
   maxConcurrentTasks?: number;
 }
 
-export interface ExecutionPoolConfig {
+export interface ExecutionPoolMemberConfig {
   type: 'ssh' | 'worktree';
-  members: string[];
+  id: string;
+  maxConcurrentTasks?: number;
+}
+
+export interface ExecutionPoolConfig {
+  members: ExecutionPoolMemberConfig[];
   selectionStrategy?: SelectionStrategy;
   maxConcurrentTasksPerMember?: number;
 }
@@ -101,9 +106,9 @@ interface PoolAssignment {
 
 interface PoolState {
   poolId: string;
-  type: 'ssh' | 'worktree';
   strategy: SelectionStrategy;
   members: string[];
+  memberTypes: Map<string, 'ssh' | 'worktree'>;
   capacities: Map<string, number>;
   active: Map<string, number>;
   rrCursor: number;
@@ -318,17 +323,36 @@ export class TaskRunner {
     return undefined;
   }
 
+  private validatePoolMemberUniqueness(pools: Record<string, ExecutionPoolConfig>): void {
+    const seen = new Map<string, string>();
+    for (const [poolId, pool] of Object.entries(pools)) {
+      for (const member of pool.members ?? []) {
+        const key = `${member.type}:${member.id}`;
+        const owner = seen.get(key);
+        if (owner && owner !== poolId) {
+          throw new Error(
+            `Execution pool member "${key}" is shared by pools "${owner}" and "${poolId}". ` +
+            'Members may only belong to one pool.',
+          );
+        }
+        seen.set(key, poolId);
+      }
+    }
+  }
+
   private buildPoolState(poolId: string, pool: ExecutionPoolConfig): PoolState {
     const capacities = new Map<string, number>();
     const active = new Map<string, number>();
+    const memberTypes = new Map<string, 'ssh' | 'worktree'>();
     const remoteTargets = this.getRemoteTargets();
     const fallbackCap = pool.maxConcurrentTasksPerMember && pool.maxConcurrentTasksPerMember > 0
       ? Math.floor(pool.maxConcurrentTasksPerMember)
       : 1;
 
-    for (const memberId of pool.members) {
+    for (const member of pool.members) {
+      const memberId = member.id;
       let cap = fallbackCap;
-      if (pool.type === 'ssh') {
+      if (member.type === 'ssh') {
         const target = remoteTargets[memberId];
         if (!target) {
           throw new Error(
@@ -336,19 +360,24 @@ export class TaskRunner {
             `Available: [${Object.keys(remoteTargets).join(', ')}]`,
           );
         }
-        cap = target.maxConcurrentTasks && target.maxConcurrentTasks > 0
-          ? Math.floor(target.maxConcurrentTasks)
-          : fallbackCap;
+        cap = member.maxConcurrentTasks && member.maxConcurrentTasks > 0
+          ? Math.floor(member.maxConcurrentTasks)
+          : (target.maxConcurrentTasks && target.maxConcurrentTasks > 0
+            ? Math.floor(target.maxConcurrentTasks)
+            : fallbackCap);
+      } else if (member.maxConcurrentTasks && member.maxConcurrentTasks > 0) {
+        cap = Math.floor(member.maxConcurrentTasks);
       }
+      memberTypes.set(memberId, member.type);
       capacities.set(memberId, cap);
       active.set(memberId, 0);
     }
 
     return {
       poolId,
-      type: pool.type,
       strategy: pool.selectionStrategy ?? 'roundRobin',
-      members: [...pool.members],
+      members: pool.members.map((m) => m.id),
+      memberTypes,
       capacities,
       active,
       rrCursor: 0,
@@ -358,6 +387,7 @@ export class TaskRunner {
 
   private getOrBuildPoolState(poolId: string): PoolState {
     const pools = this.getExecutionPools();
+    this.validatePoolMemberUniqueness(pools);
     const pool = pools[poolId];
     if (!pool) {
       throw new Error(
@@ -367,6 +397,14 @@ export class TaskRunner {
     }
     if (!Array.isArray(pool.members) || pool.members.length === 0) {
       throw new Error(`Execution pool "${poolId}" must define a non-empty members array.`);
+    }
+    for (const member of pool.members) {
+      if (!member?.id || (member.type !== 'ssh' && member.type !== 'worktree')) {
+        throw new Error(
+          `Execution pool "${poolId}" has invalid member. ` +
+          'Each member must include { type: "ssh" | "worktree", id: string }.',
+        );
+      }
     }
     const existing = this.poolStates.get(poolId);
     if (existing) {
@@ -412,12 +450,20 @@ export class TaskRunner {
 
   private acquirePoolSlot(task: TaskState): Promise<PoolAssignment | undefined> {
     const poolId = task.config.poolId?.trim();
-    if (!poolId) return Promise.resolve(undefined);
+    if (!poolId) {
+      if (task.config.executorType === 'ssh') {
+        throw new Error(
+          `Task ${task.id} has executorType=ssh but no poolId. ` +
+          'Assign SSH tasks to an execution pool.',
+        );
+      }
+      return Promise.resolve(undefined);
+    }
     const state = this.getOrBuildPoolState(poolId);
     const selected = this.pickAvailableMember(state);
     if (selected) {
       state.active.set(selected, (state.active.get(selected) ?? 0) + 1);
-      return Promise.resolve({ poolId, memberId: selected, type: state.type });
+      return Promise.resolve({ poolId, memberId: selected, type: state.memberTypes.get(selected) ?? 'worktree' });
     }
     return new Promise<PoolAssignment>((resolve) => {
       state.waiters.push(resolve);
@@ -431,7 +477,7 @@ export class TaskRunner {
       const waiter = state.waiters.shift();
       if (!waiter) return;
       state.active.set(selected, (state.active.get(selected) ?? 0) + 1);
-      waiter({ poolId: state.poolId, memberId: selected, type: state.type });
+      waiter({ poolId: state.poolId, memberId: selected, type: state.memberTypes.get(selected) ?? 'worktree' });
     }
   }
 
@@ -461,6 +507,8 @@ export class TaskRunner {
       ...task,
       config: {
         ...task.config,
+        executorType: 'worktree',
+        remoteTargetId: undefined,
         poolId: assignment.poolId,
       },
     } as TaskState;
@@ -1013,7 +1061,10 @@ export class TaskRunner {
       if (effectiveType === 'ssh') {
         const targetId = task.config.remoteTargetId;
         if (!targetId) {
-          throw new Error(`Task ${task.id} has executorType=ssh but no remoteTargetId`);
+          throw new Error(
+            `Task ${task.id} resolved to executorType=ssh but no pool member target was assigned. ` +
+            `poolId=${task.config.poolId ?? '(unset)'}`,
+          );
         }
 
         // Always re-read targets so dynamic provider updates are picked up.


### PR DESCRIPTION
TaskRunner now schedules through typed pool members with shared queue semantics and rejects member reuse across pools, with docs/tests updated for the new pool-only execution model.

Co-authored-by: Cursor <cursoragent@cursor.com>