### PR TITLE
Drop remote-target availability wiring from app bootstrap.

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -423,7 +423,6 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     defaultAutoFixRetries: invokerConfig.autoFixRetries,
     executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
     heavyweightCommandRouting: invokerConfig.heavyweightCommandRouting,
-    availableRemoteTargetIds: Object.keys(invokerConfig.remoteTargets ?? {}),
     availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
     deferRunningUntilLaunch: true,
   });
@@ -2834,7 +2833,6 @@ if (isHeadless) {
         defaultAutoFixRetries: invokerConfig.autoFixRetries,
         executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
         heavyweightCommandRouting: invokerConfig.heavyweightCommandRouting,
-        availableRemoteTargetIds: Object.keys(invokerConfig.remoteTargets ?? {}),
         availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
         deferRunningUntilLaunch: true,
       });


### PR DESCRIPTION
Remove now-obsolete remote target routing metadata from orchestrator initialization so startup wiring matches pool-only routing validation.

Co-authored-by: Cursor <cursoragent@cursor.com>