### PR TITLE
Require poolId-only SSH task parsing.

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -689,7 +689,7 @@ tasks:
       expect(() => parsePlan(yaml)).toThrow('executorType "docker" but is missing required field "dockerImage"');
     });
 
-    it('rejects executorType ssh without remoteTargetId or poolId', () => {
+    it('rejects executorType ssh without poolId', () => {
       const yaml = `
 name: SSH No Target
 repoUrl: git@github.com:test/repo.git
@@ -700,7 +700,7 @@ tasks:
     executorType: ssh
 `;
       expect(() => parsePlan(yaml)).toThrow(PlanParseError);
-      expect(() => parsePlan(yaml)).toThrow('executorType "ssh" but is missing required field "remoteTargetId" or "poolId"');
+      expect(() => parsePlan(yaml)).toThrow('executorType "ssh" but is missing required field "poolId"');
     });
 
     it('accepts executorType docker with dockerImage', () => {
@@ -719,7 +719,7 @@ tasks:
       expect(plan.tasks[0].dockerImage).toBe('node:20');
     });
 
-    it('accepts executorType ssh with remoteTargetId', () => {
+    it('rejects executorType ssh with legacy remoteTargetId', () => {
       const yaml = `
 name: SSH With Target
 repoUrl: git@github.com:test/repo.git
@@ -730,9 +730,7 @@ tasks:
     executorType: ssh
     remoteTargetId: prod-server-1
 `;
-      const plan = parsePlan(yaml);
-      expect(plan.tasks[0].executorType).toBe('ssh');
-      expect(plan.tasks[0].remoteTargetId).toBe('prod-server-1');
+      expect(() => parsePlan(yaml)).toThrow('uses unsupported field "remoteTargetId". Use "poolId" instead.');
     });
 
     it('accepts executorType ssh with poolId', () => {

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -332,9 +332,14 @@ export function parsePlan(yamlContent: string): PlanDefinition {
         `Task "${task.id}" has executorType "docker" but is missing required field "dockerImage"`,
       );
     }
-    if (resolvedExecutorType === 'ssh' && !task.remoteTargetId && !task.poolId) {
+    if (task.remoteTargetId !== undefined) {
       throw new PlanParseError(
-        `Task "${task.id}" has executorType "ssh" but is missing required field "remoteTargetId" or "poolId"`,
+        `Task "${task.id}" uses unsupported field "remoteTargetId". Use "poolId" instead.`,
+      );
+    }
+    if (resolvedExecutorType === 'ssh' && !task.poolId) {
+      throw new PlanParseError(
+        `Task "${task.id}" has executorType "ssh" but is missing required field "poolId"`,
       );
     }
 
@@ -351,7 +356,6 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       featureBranch: task.featureBranch,
       executorType: resolvedExecutorType,
       dockerImage: task.dockerImage,
-      remoteTargetId: task.remoteTargetId,
       poolId: task.poolId,
       executionAgent: task.executionAgent?.trim() || undefined,
     };


### PR DESCRIPTION
Reject legacy remoteTargetId fields in plan YAML and enforce poolId for ssh tasks so plan definitions match the new pool-only routing contract.

Co-authored-by: Cursor <cursoragent@cursor.com>