### PR TITLE
Model execution pools as mixed typed members.

### DIFF
--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -47,9 +47,12 @@
 
   "executionPools": {
     "ssh-light": {
-      "comment": "Pool routes tasks across both SSH machines with shared queue/drain semantics",
-      "type": "ssh",
-      "members": ["staging-server", "build-server-b"],
+      "comment": "Pool routes tasks across mixed SSH/local members with shared queue/drain semantics",
+      "members": [
+        { "type": "ssh", "id": "staging-server" },
+        { "type": "ssh", "id": "build-server-b" },
+        { "type": "worktree", "id": "local-fallback", "maxConcurrentTasks": 2 }
+      ],
       "selectionStrategy": "roundRobin",
       "maxConcurrentTasksPerMember": 1
     }

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -176,8 +176,11 @@ describe('loadConfig', () => {
       JSON.stringify({
         executionPools: {
           'ssh-light': {
-            type: 'ssh',
-            members: ['remote-1', 'remote-2'],
+            members: [
+              { type: 'ssh', id: 'remote-1' },
+              { type: 'ssh', id: 'remote-2' },
+              { type: 'worktree', id: 'local-fallback', maxConcurrentTasks: 2 },
+            ],
             selectionStrategy: 'roundRobin',
             maxConcurrentTasksPerMember: 1,
           },
@@ -186,8 +189,11 @@ describe('loadConfig', () => {
     );
     const config = loadConfig();
     expect(config.executionPools?.['ssh-light']).toEqual({
-      type: 'ssh',
-      members: ['remote-1', 'remote-2'],
+      members: [
+        { type: 'ssh', id: 'remote-1' },
+        { type: 'ssh', id: 'remote-2' },
+        { type: 'worktree', id: 'local-fallback', maxConcurrentTasks: 2 },
+      ],
       selectionStrategy: 'roundRobin',
       maxConcurrentTasksPerMember: 1,
     });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -116,14 +116,11 @@ export interface InvokerConfig {
    * Pools provide shared queue + drain semantics with per-member capacity limits.
    */
   executionPools?: Record<string, {
-    /** Pool executor substrate. */
-    type: 'worktree' | 'ssh';
-    /**
-     * Member IDs:
-     * - ssh pools: remote target IDs from `remoteTargets`
-     * - worktree pools: logical member IDs (for example ["local"])
-     */
-    members: string[];
+    /** Pool members can mix substrates under one shared queue. */
+    members: Array<
+      | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
+      | { type: 'worktree'; id: string; maxConcurrentTasks?: number }
+    >;
     /** Member selection strategy for available capacity. Default: roundRobin */
     selectionStrategy?: 'roundRobin' | 'leastLoaded';
     /** Fallback per-member cap when member-specific capacity is not set. */
@@ -138,10 +135,8 @@ export interface InvokerConfig {
     enabled?: boolean;
     /** Destination executor type. Default: "ssh". */
     executorType?: string;
-    /** Destination remote target ID (legacy mode). */
-    remoteTargetId?: string;
     /** Destination execution pool ID. */
-    poolId?: string;
+    poolId: string;
     /** Optional command matchers; defaults to matching any `pnpm` invocation. */
     matchers?: Array<{
       pattern?: string;
@@ -169,10 +164,8 @@ export interface InvokerConfig {
     regex?: string;
     /** Required executor type for matching commands (e.g. "ssh", "docker", "worktree"). */
     executorType: string;
-    /** Required remote target ID for matching commands (legacy mode). */
-    remoteTargetId?: string;
     /** Required execution pool ID for matching commands. */
-    poolId?: string;
+    poolId: string;
     /** Routing strategy. Defaults to "enforce". */
     strategy?: 'enforce' | 'route';
   }>;


### PR DESCRIPTION
Update config schema and examples so pools declare typed member entries with per-member caps, preparing for shared queue scheduling across SSH and worktree members.

Co-authored-by: Cursor <cursoragent@cursor.com>