### PR TITLE
Add pool-aware plan parsing plumbing.

### DIFF
--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -689,7 +689,7 @@ tasks:
       expect(() => parsePlan(yaml)).toThrow('executorType "docker" but is missing required field "dockerImage"');
     });
 
-    it('rejects executorType ssh without remoteTargetId', () => {
+    it('rejects executorType ssh without remoteTargetId or poolId', () => {
       const yaml = `
 name: SSH No Target
 repoUrl: git@github.com:test/repo.git
@@ -700,7 +700,7 @@ tasks:
     executorType: ssh
 `;
       expect(() => parsePlan(yaml)).toThrow(PlanParseError);
-      expect(() => parsePlan(yaml)).toThrow('executorType "ssh" but is missing required field "remoteTargetId"');
+      expect(() => parsePlan(yaml)).toThrow('executorType "ssh" but is missing required field "remoteTargetId" or "poolId"');
     });
 
     it('accepts executorType docker with dockerImage', () => {
@@ -733,6 +733,22 @@ tasks:
       const plan = parsePlan(yaml);
       expect(plan.tasks[0].executorType).toBe('ssh');
       expect(plan.tasks[0].remoteTargetId).toBe('prod-server-1');
+    });
+
+    it('accepts executorType ssh with poolId', () => {
+      const yaml = `
+name: SSH With Pool
+repoUrl: git@github.com:test/repo.git
+tasks:
+  - id: deploy
+    description: Deploy via SSH pool
+    command: echo deploy
+    executorType: ssh
+    poolId: ssh-light
+`;
+      const plan = parsePlan(yaml);
+      expect(plan.tasks[0].executorType).toBe('ssh');
+      expect(plan.tasks[0].poolId).toBe('ssh-light');
     });
 
     it('accepts worktree executorType without docker or ssh fields', () => {

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -61,6 +61,7 @@ export interface RawPlanTask {
   executorType?: string;
   dockerImage?: string;
   remoteTargetId?: string;
+  poolId?: string;
   executionAgent?: string;
 }
 
@@ -331,9 +332,9 @@ export function parsePlan(yamlContent: string): PlanDefinition {
         `Task "${task.id}" has executorType "docker" but is missing required field "dockerImage"`,
       );
     }
-    if (resolvedExecutorType === 'ssh' && !task.remoteTargetId) {
+    if (resolvedExecutorType === 'ssh' && !task.remoteTargetId && !task.poolId) {
       throw new PlanParseError(
-        `Task "${task.id}" has executorType "ssh" but is missing required field "remoteTargetId"`,
+        `Task "${task.id}" has executorType "ssh" but is missing required field "remoteTargetId" or "poolId"`,
       );
     }
 
@@ -351,6 +352,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       executorType: resolvedExecutorType,
       dockerImage: task.dockerImage,
       remoteTargetId: task.remoteTargetId,
+      poolId: task.poolId,
       executionAgent: task.executionAgent?.trim() || undefined,
     };
   });


### PR DESCRIPTION
This introduces poolId-aware SSH plan validation while keeping routing behavior unchanged.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #516