### PR TITLE
Track pool destination in workflow invalidation metadata.

### DIFF
--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -32,6 +32,7 @@ export type MutationKey =
   | 'executionAgent'
   | 'executorType'
   | 'remoteTargetId'
+  | 'poolId'
   | 'selectedExperiment'
   | 'selectedExperimentSet'
   | 'mergeMode'
@@ -48,6 +49,7 @@ export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>
   executionAgent:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   executorType:          { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
   remoteTargetId:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
+  poolId:                { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   selectedExperiment:    { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   selectedExperimentSet: { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateTask' as const },
   mergeMode:             { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },


### PR DESCRIPTION
This includes poolId in mutation keys so reruns and invalidation decisions preserve SSH pool routing context.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #517