### PR TITLE
Refactor routing rules to pool-only destinations.

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -916,24 +916,25 @@ describe('Orchestrator', () => {
     // ── executor routing rules ───────────────────────────────
 
     describe('executor routing rules', () => {
-      it('validates matching pattern rule: task must declare required executorType and remoteTargetId', () => {
+      it('validates matching pattern rule: task must declare required executorType and poolId', () => {
         const routedOrchestrator = new Orchestrator({
           persistence: new InMemoryPersistence(),
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { pattern: 'deploy', executorType: 'ssh', remoteTargetId: 'prod-server' },
+            { pattern: 'deploy', executorType: 'ssh', poolId: 'prod-pool' },
           ],
+          availablePoolIds: ['prod-pool'],
         });
 
         routedOrchestrator.loadPlan({
           name: 'routing-test',
-          tasks: [{ id: 't1', description: 'Deploy task', command: 'deploy --env prod', executorType: 'ssh', remoteTargetId: 'prod-server' }],
+          tasks: [{ id: 't1', description: 'Deploy task', command: 'deploy --env prod', executorType: 'ssh', poolId: 'prod-pool' }],
         });
 
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.executorType).toBe('ssh');
-        expect(task!.config.remoteTargetId).toBe('prod-server');
+        expect(task!.config.poolId).toBe('prod-pool');
       });
 
       it('throws when task executorType does not match routing rule', () => {
@@ -942,14 +943,15 @@ describe('Orchestrator', () => {
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { pattern: 'deploy', executorType: 'ssh', remoteTargetId: 'prod-server' },
+            { pattern: 'deploy', executorType: 'ssh', poolId: 'prod-pool' },
           ],
+          availablePoolIds: ['prod-pool'],
         });
 
         expect(() => {
           routedOrchestrator.loadPlan({
             name: 'mismatch-test',
-            tasks: [{ id: 't1', description: 'Deploy task', command: 'deploy --env prod', executorType: 'worktree', remoteTargetId: 'prod-server' }],
+            tasks: [{ id: 't1', description: 'Deploy task', command: 'deploy --env prod', executorType: 'worktree', poolId: 'prod-pool' }],
           });
         }).toThrow('requires executorType="ssh"');
       });
@@ -960,8 +962,9 @@ describe('Orchestrator', () => {
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { pattern: 'deploy', executorType: 'ssh', remoteTargetId: 'prod-server' },
+            { pattern: 'deploy', executorType: 'ssh', poolId: 'prod-pool' },
           ],
+          availablePoolIds: ['prod-pool'],
         });
 
         routedOrchestrator.loadPlan({
@@ -971,7 +974,7 @@ describe('Orchestrator', () => {
 
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.executorType).toBe('worktree');
-        expect(task!.config.remoteTargetId).toBeUndefined();
+        expect(task!.config.poolId).toBeUndefined();
       });
 
       it('validates regex rule matching pnpm test', () => {
@@ -980,18 +983,19 @@ describe('Orchestrator', () => {
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { regex: '^pnpm test', executorType: 'ssh', remoteTargetId: 'ci-box' },
+            { regex: '^pnpm test', executorType: 'ssh', poolId: 'ci-pool' },
           ],
+          availablePoolIds: ['ci-pool'],
         });
 
         routedOrchestrator.loadPlan({
           name: 'test-routing',
-          tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test', executorType: 'ssh', remoteTargetId: 'ci-box' }],
+          tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test', executorType: 'ssh', poolId: 'ci-pool' }],
         });
 
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.executorType).toBe('ssh');
-        expect(task!.config.remoteTargetId).toBe('ci-box');
+        expect(task!.config.poolId).toBe('ci-pool');
       });
 
       it('validates pattern rule matching test command', () => {
@@ -1000,18 +1004,19 @@ describe('Orchestrator', () => {
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { pattern: 'pnpm test', executorType: 'ssh', remoteTargetId: 'ci-box' },
+            { pattern: 'pnpm test', executorType: 'ssh', poolId: 'ci-pool' },
           ],
+          availablePoolIds: ['ci-pool'],
         });
 
         routedOrchestrator.loadPlan({
           name: 'test-routing-pattern',
-          tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test --coverage', executorType: 'ssh', remoteTargetId: 'ci-box' }],
+          tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test --coverage', executorType: 'ssh', poolId: 'ci-pool' }],
         });
 
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.executorType).toBe('ssh');
-        expect(task!.config.remoteTargetId).toBe('ci-box');
+        expect(task!.config.poolId).toBe('ci-pool');
       });
 
       it('throws when task executorType does not match regex rule', () => {
@@ -1020,34 +1025,36 @@ describe('Orchestrator', () => {
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { regex: '^pnpm test', executorType: 'ssh', remoteTargetId: 'ci-box' },
+            { regex: '^pnpm test', executorType: 'ssh', poolId: 'ci-pool' },
           ],
+          availablePoolIds: ['ci-pool'],
         });
 
         expect(() => {
           routedOrchestrator.loadPlan({
             name: 'test-mismatch',
-            tasks: [{ id: 't1', description: 'Run tests locally', command: 'pnpm test', executorType: 'worktree', remoteTargetId: 'ci-box' }],
+            tasks: [{ id: 't1', description: 'Run tests locally', command: 'pnpm test', executorType: 'worktree', poolId: 'ci-pool' }],
           });
         }).toThrow('requires executorType="ssh"');
       });
 
-      it('throws when task remoteTargetId does not match routing rule', () => {
+      it('throws when task poolId does not match routing rule', () => {
         const routedOrchestrator = new Orchestrator({
           persistence: new InMemoryPersistence(),
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { pattern: 'pnpm test', executorType: 'ssh', remoteTargetId: 'ci-box' },
+            { pattern: 'pnpm test', executorType: 'ssh', poolId: 'ci-pool' },
           ],
+          availablePoolIds: ['ci-pool'],
         });
 
         expect(() => {
           routedOrchestrator.loadPlan({
             name: 'remote-mismatch',
-            tasks: [{ id: 't1', description: 'Run tests on staging', command: 'pnpm test', executorType: 'ssh', remoteTargetId: 'staging-box' }],
+            tasks: [{ id: 't1', description: 'Run tests on staging', command: 'pnpm test', executorType: 'ssh', poolId: 'staging-pool' }],
           });
-        }).toThrow('requires remoteTargetId="ci-box"');
+        }).toThrow('requires poolId="ci-pool"');
       });
 
       it('throws when task executorType is missing for matching rule', () => {
@@ -1056,34 +1063,36 @@ describe('Orchestrator', () => {
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { pattern: 'deploy', executorType: 'ssh', remoteTargetId: 'prod-server' },
+            { pattern: 'deploy', executorType: 'ssh', poolId: 'prod-pool' },
           ],
+          availablePoolIds: ['prod-pool'],
         });
 
         expect(() => {
           routedOrchestrator.loadPlan({
             name: 'missing-executorType',
-            tasks: [{ id: 't1', description: 'Deploy task', command: 'deploy --env prod', remoteTargetId: 'prod-server' }],
+            tasks: [{ id: 't1', description: 'Deploy task', command: 'deploy --env prod', poolId: 'prod-pool' }],
           });
         }).toThrow('requires executorType="ssh"');
       });
 
-      it('throws when task remoteTargetId is missing for matching rule', () => {
+      it('throws when task poolId is missing for matching rule', () => {
         const routedOrchestrator = new Orchestrator({
           persistence: new InMemoryPersistence(),
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { pattern: 'deploy', executorType: 'ssh', remoteTargetId: 'prod-server' },
+            { pattern: 'deploy', executorType: 'ssh', poolId: 'prod-pool' },
           ],
+          availablePoolIds: ['prod-pool'],
         });
 
         expect(() => {
           routedOrchestrator.loadPlan({
-            name: 'missing-remoteTargetId',
+            name: 'missing-poolId',
             tasks: [{ id: 't1', description: 'Deploy task', command: 'deploy --env prod', executorType: 'ssh' }],
           });
-        }).toThrow('requires remoteTargetId="prod-server"');
+        }).toThrow('requires poolId="prod-pool"');
       });
 
       it('validates matching rule with poolId destination', () => {
@@ -1132,13 +1141,14 @@ describe('Orchestrator', () => {
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { pattern: 'deploy', executorType: 'ssh', remoteTargetId: 'prod-server' },
+            { pattern: 'deploy', executorType: 'ssh', poolId: 'prod-pool' },
           ],
+          availablePoolIds: ['prod-pool'],
         });
 
         routedOrchestrator.loadPlan({
           name: 'merge-routing-test',
-          tasks: [{ id: 't1', description: 'Deploy task', command: 'deploy --env prod', executorType: 'ssh', remoteTargetId: 'prod-server' }],
+          tasks: [{ id: 't1', description: 'Deploy task', command: 'deploy --env prod', executorType: 'ssh', poolId: 'prod-pool' }],
         });
 
         const mergeNode = routedOrchestrator.getAllTasks().find((t) => t.config.isMergeNode);
@@ -1146,15 +1156,15 @@ describe('Orchestrator', () => {
         expect(mergeNode!.config.executorType).toBe('merge');
       });
 
-      it('auto-routes pnpm test to SSH target with route strategy when executor is omitted', () => {
+      it('auto-routes pnpm test to pool with route strategy when executor is omitted', () => {
         const routedOrchestrator = new Orchestrator({
           persistence: new InMemoryPersistence(),
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { regex: '\\bpnpm(?:\\s|$)', executorType: 'ssh', remoteTargetId: 'ci-box', strategy: 'route' },
+            { regex: '\\bpnpm(?:\\s|$)', executorType: 'ssh', poolId: 'ci-pool', strategy: 'route' },
           ],
-          availableRemoteTargetIds: ['ci-box'],
+          availablePoolIds: ['ci-pool'],
         });
 
         routedOrchestrator.loadPlan({
@@ -1164,7 +1174,7 @@ describe('Orchestrator', () => {
 
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.executorType).toBe('ssh');
-        expect(task!.config.remoteTargetId).toBe('ci-box');
+        expect(task!.config.poolId).toBe('ci-pool');
       });
 
       it('auto-routes matching command to configured poolId with route strategy', () => {
@@ -1194,9 +1204,9 @@ describe('Orchestrator', () => {
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { regex: '\\bpnpm(?:\\s|$)', executorType: 'ssh', remoteTargetId: 'ci-box', strategy: 'route' },
+            { regex: '\\bpnpm(?:\\s|$)', executorType: 'ssh', poolId: 'ci-pool', strategy: 'route' },
           ],
-          availableRemoteTargetIds: ['ci-box'],
+          availablePoolIds: ['ci-pool'],
         });
 
         expect(() => {
@@ -1232,9 +1242,9 @@ describe('Orchestrator', () => {
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
-            { regex: '\\bpnpm(?:\\s|$)', executorType: 'ssh', remoteTargetId: 'ci-box', strategy: 'route' },
+            { regex: '\\bpnpm(?:\\s|$)', executorType: 'ssh', poolId: 'ci-pool', strategy: 'route' },
           ],
-          availableRemoteTargetIds: ['ci-box'],
+          availablePoolIds: ['ci-pool'],
         });
 
         routedOrchestrator.loadPlan({
@@ -1244,7 +1254,7 @@ describe('Orchestrator', () => {
 
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.executorType).toBe('worktree');
-        expect(task!.config.remoteTargetId).toBeUndefined();
+        expect(task!.config.poolId).toBeUndefined();
       });
 
       it('keeps heavyweightCommandRouting as compatibility alias to route strategy', () => {
@@ -3576,10 +3586,17 @@ describe('Orchestrator', () => {
     it('same-host ssh:A → ssh:A is RETRY-class — preserves branch/workspacePath (regression of Step 5)', () => {
       orchestrator.loadPlan({
         name: 'edit-type-step6-same-ssh',
-        tasks: [{ id: 't1', description: 'Task 1', command: 'echo hello', executorType: 'ssh', remoteTargetId: 'remote_a' }],
+        tasks: [{ id: 't1', description: 'Task 1', command: 'echo hello', executorType: 'ssh', poolId: 'ssh-light' }],
       });
       orchestrator.startExecution();
       const taskId = sid(orchestrator, 0, 't1');
+      // Seed the current host assignment through the API (plan YAML is pool-only).
+      orchestrator.editTaskType(taskId, 'ssh', 'remote_a');
+      // Persisted state must reflect the current ssh member before asserting
+      // same-host retry semantics on the next editTaskType call.
+      persistence.updateTask(taskId, {
+        config: { remoteTargetId: 'remote_a' } as any,
+      });
 
       persistence.updateTask(taskId, {
         execution: {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -254,7 +254,6 @@ export interface PlanDefinition {
     featureBranch?: string;
     executorType?: string;
     dockerImage?: string;
-    remoteTargetId?: string;
     poolId?: string;
     executionAgent?: string;
   }>;
@@ -379,7 +378,7 @@ export interface ExternalGatePolicyUpdate {
 /**
  * A single routing rule that validates task execution environment against command patterns.
  * When a rule matches a task command, the orchestrator validates that the task's
- * executorType and destination (remoteTargetId or poolId) conform to the rule's requirements.
+ * executorType and pool destination conform to the rule's requirements.
  */
 export interface ExecutorRoutingRule {
   /** Substring to match against the task command. */
@@ -388,10 +387,8 @@ export interface ExecutorRoutingRule {
   regex?: string;
   /** Required executor type for matching commands (e.g. "ssh", "docker", "worktree"). */
   executorType: string;
-  /** Required remote target ID for matching commands (legacy mode). */
-  remoteTargetId?: string;
   /** Required execution pool ID for matching commands. */
-  poolId?: string;
+  poolId: string;
   /**
    * Rule behavior:
    * - enforce (default): task must already declare matching executor/destination
@@ -408,8 +405,7 @@ export interface CommandRoutingMatcher {
 export interface HeavyweightCommandRoutingPolicy {
   enabled?: boolean;
   executorType?: string;
-  remoteTargetId?: string;
-  poolId?: string;
+  poolId: string;
   matchers?: CommandRoutingMatcher[];
 }
 
@@ -417,58 +413,24 @@ const DEFAULT_HEAVYWEIGHT_COMMAND_MATCHERS: CommandRoutingMatcher[] = [
   { regex: '\\bpnpm(?:\\s|$)' },
 ];
 
-function validateRoutingDestinationShape(
-  taskId: string,
-  command: string,
-  sourceLabel: string,
-  remoteTargetId: string | undefined,
-  poolId: string | undefined,
-): void {
-  if (remoteTargetId && poolId) {
-    throw new Error(
-      `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
-      'but config must set exactly one destination: remoteTargetId or poolId.',
-    );
-  }
-}
-
 function validateRoutingDestinationAvailability(
   taskId: string,
   command: string,
   sourceLabel: string,
-  remoteTargetId: string | undefined,
   poolId: string | undefined,
-  availableRemoteTargetIds: Set<string>,
   availablePoolIds: Set<string>,
 ): void {
-  if (remoteTargetId) {
-    if (availableRemoteTargetIds.size > 0 && !availableRemoteTargetIds.has(remoteTargetId)) {
-      throw new Error(
-        `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
-        `but config remoteTargetId="${remoteTargetId}" is not defined in remoteTargets.`,
-      );
-    }
-    if (availableRemoteTargetIds.size === 0) {
-      throw new Error(
-        `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
-        'but no remoteTargets are configured.',
-      );
-    }
+  if (availablePoolIds.size > 0 && !availablePoolIds.has(poolId)) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
+      `but config poolId="${poolId}" is not defined in executionPools.`,
+    );
   }
-
-  if (poolId) {
-    if (availablePoolIds.size > 0 && !availablePoolIds.has(poolId)) {
-      throw new Error(
-        `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
-        `but config poolId="${poolId}" is not defined in executionPools.`,
-      );
-    }
-    if (availablePoolIds.size === 0) {
-      throw new Error(
-        `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
-        'but no executionPools are configured.',
-      );
-    }
+  if (availablePoolIds.size === 0) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
+      'but no executionPools are configured.',
+    );
   }
 }
 
@@ -481,16 +443,10 @@ function buildHeavyweightRoutingRules(
   }
 
   const matchers = policy.matchers?.length ? policy.matchers : DEFAULT_HEAVYWEIGHT_COMMAND_MATCHERS;
-  if (policy.remoteTargetId && policy.poolId) {
+  if (!policy.poolId) {
     throw new Error(
       `Task "${taskId}" matched heavyweight command routing, ` +
-      'but config must set exactly one destination: remoteTargetId or poolId.',
-    );
-  }
-  if (!policy.remoteTargetId && !policy.poolId) {
-    throw new Error(
-      `Task "${taskId}" matched heavyweight command routing, ` +
-      'but config is missing destination: set remoteTargetId or poolId.',
+      'but config is missing destination: set poolId.',
     );
   }
 
@@ -506,7 +462,6 @@ function buildHeavyweightRoutingRules(
     pattern: matcher.pattern,
     regex: matcher.regex,
     executorType,
-    remoteTargetId: policy.remoteTargetId,
     poolId: policy.poolId,
     strategy: 'route',
   }));
@@ -516,22 +471,17 @@ function applyRoutingRule(
   taskId: string,
   command: string,
   planExecutorType: string | undefined,
-  planRemoteTargetId: string | undefined,
   planPoolId: string | undefined,
   rule: ExecutorRoutingRule,
   sourceLabel: string,
-  availableRemoteTargetIds: Set<string>,
   availablePoolIds: Set<string>,
-): { executorType?: string; remoteTargetId?: string; poolId?: string } | undefined {
+): { executorType?: string; poolId?: string } | undefined {
   const normalizedRuleType = normalizeExecutorType(rule.executorType) ?? rule.executorType;
-  validateRoutingDestinationShape(taskId, command, sourceLabel, rule.remoteTargetId, rule.poolId);
   validateRoutingDestinationAvailability(
     taskId,
     command,
     sourceLabel,
-    rule.remoteTargetId,
     rule.poolId,
-    availableRemoteTargetIds,
     availablePoolIds,
   );
   const normalizedPlanType = normalizeExecutorType(planExecutorType) ?? 'worktree';
@@ -541,13 +491,7 @@ function applyRoutingRule(
       `executorType="${normalizedRuleType}", but plan declares executorType="${normalizedPlanType}"`,
     );
   }
-  if (rule.remoteTargetId && planRemoteTargetId !== undefined && planRemoteTargetId !== rule.remoteTargetId) {
-    throw new Error(
-      `Task "${taskId}" with command "${command}" matched ${sourceLabel} and must use ` +
-      `remoteTargetId="${rule.remoteTargetId}", but plan declares remoteTargetId="${planRemoteTargetId}"`,
-    );
-  }
-  if (rule.poolId && planPoolId !== undefined && planPoolId !== rule.poolId) {
+  if (planPoolId !== undefined && planPoolId !== rule.poolId) {
     throw new Error(
       `Task "${taskId}" with command "${command}" matched ${sourceLabel} and must use ` +
       `poolId="${rule.poolId}", but plan declares poolId="${planPoolId}"`,
@@ -555,7 +499,6 @@ function applyRoutingRule(
   }
   return {
     executorType: normalizedRuleType,
-    remoteTargetId: rule.remoteTargetId ?? planRemoteTargetId,
     poolId: rule.poolId ?? planPoolId,
   };
 }
@@ -583,14 +526,13 @@ export function findMatchingExecutorRoutingRule(
 /**
  * Validates that a task's routing conforms to executor routing rules.
  * Returns immediately if the task has no command or no rules are configured.
- * When a rule matches the task command, throws if the task's executorType or remoteTargetId
+ * When a rule matches the task command, throws if the task's executorType or poolId
  * do not match the rule's requirements.
  */
 export function assertExecutorRoutingConforms(
   taskId: string,
   command: string | undefined,
   planExecutorType: string | undefined,
-  planRemoteTargetId: string | undefined,
   planPoolId: string | undefined,
   rules: ExecutorRoutingRule[],
 ): void {
@@ -601,13 +543,6 @@ export function assertExecutorRoutingConforms(
   const matchingRule = findMatchingExecutorRoutingRule(command, rules);
   if (!matchingRule) {
     return;
-  }
-
-  if (matchingRule.remoteTargetId && matchingRule.poolId) {
-    throw new Error(
-      `Task "${taskId}" with command "${command}" matched an invalid routing rule: ` +
-      'rule must set exactly one destination (remoteTargetId or poolId).',
-    );
   }
 
   // Normalize both plan and rule executorType the same way createTaskState does
@@ -621,13 +556,7 @@ export function assertExecutorRoutingConforms(
     );
   }
 
-  if (matchingRule.remoteTargetId && planRemoteTargetId !== matchingRule.remoteTargetId) {
-    throw new Error(
-      `Task "${taskId}" with command "${command}" requires remoteTargetId="${matchingRule.remoteTargetId}" ` +
-      `but plan declares remoteTargetId="${planRemoteTargetId ?? '(undefined)'}"`
-    );
-  }
-  if (matchingRule.poolId && planPoolId !== matchingRule.poolId) {
+  if (planPoolId !== matchingRule.poolId) {
     throw new Error(
       `Task "${taskId}" with command "${command}" requires poolId="${matchingRule.poolId}" ` +
       `but plan declares poolId="${planPoolId ?? '(undefined)'}"`
@@ -639,22 +568,18 @@ function resolveExecutorRouting(
   taskId: string,
   command: string | undefined,
   planExecutorType: string | undefined,
-  planRemoteTargetId: string | undefined,
   planPoolId: string | undefined,
   rules: ExecutorRoutingRule[],
-  availableRemoteTargetIds: Set<string>,
   availablePoolIds: Set<string>,
-): { executorType?: string; remoteTargetId?: string; poolId?: string } {
+): { executorType?: string; poolId?: string } {
   if (!command || rules.length === 0) {
     return {
       executorType: planExecutorType,
-      remoteTargetId: planRemoteTargetId,
       poolId: planPoolId,
     };
   }
 
   let effectiveExecutorType = planExecutorType;
-  let effectiveRemoteTargetId = planRemoteTargetId;
   let effectivePoolId = planPoolId;
 
   const routingRules = rules.filter((rule) => (rule.strategy ?? 'enforce') === 'route');
@@ -664,15 +589,12 @@ function resolveExecutorRouting(
       taskId,
       command,
       effectiveExecutorType,
-      effectiveRemoteTargetId,
       effectivePoolId,
       matchingRoutingRule,
       'routing rule',
-      availableRemoteTargetIds,
       availablePoolIds,
     );
     effectiveExecutorType = routed?.executorType ?? effectiveExecutorType;
-    effectiveRemoteTargetId = routed?.remoteTargetId ?? effectiveRemoteTargetId;
     effectivePoolId = routed?.poolId ?? effectivePoolId;
   }
 
@@ -681,14 +603,12 @@ function resolveExecutorRouting(
     taskId,
     command,
     effectiveExecutorType,
-    effectiveRemoteTargetId,
     effectivePoolId,
     enforcementRules,
   );
 
   return {
     executorType: effectiveExecutorType,
-    remoteTargetId: effectiveRemoteTargetId,
     poolId: effectivePoolId,
   };
 }
@@ -743,8 +663,7 @@ export interface OrchestratorConfig {
   /**
    * Rules that validate task execution environment against command patterns.
    * When loading a plan, the orchestrator validates that tasks with commands matching
-   * a rule have the required executorType and destination (remoteTargetId or poolId)
-   * specified in the plan.
+   * a rule have the required executorType and poolId specified in the plan.
    */
   executorRoutingRules?: ExecutorRoutingRule[];
   /**
@@ -752,8 +671,6 @@ export interface OrchestratorConfig {
    * Internally translated into executorRoutingRules with strategy="route".
    */
   heavyweightCommandRouting?: HeavyweightCommandRoutingPolicy;
-  /** Valid SSH remote target IDs available at plan submission time. */
-  availableRemoteTargetIds?: string[];
   /** Valid execution pool IDs available at plan submission time. */
   availablePoolIds?: string[];
   /**
@@ -780,7 +697,6 @@ export class Orchestrator {
   private readonly taskRepository: TaskRepository;
   private readonly maxConcurrency: number;
   private readonly executorRoutingRules: ExecutorRoutingRule[];
-  private readonly availableRemoteTargetIds: Set<string>;
   private readonly availablePoolIds: Set<string>;
   private readonly defaultAutoFixRetries: number;
   private readonly deferRunningUntilLaunch: boolean;
@@ -845,7 +761,6 @@ export class Orchestrator {
       ...(config.executorRoutingRules ?? []),
       ...buildHeavyweightRoutingRules('config', config.heavyweightCommandRouting),
     ];
-    this.availableRemoteTargetIds = new Set(config.availableRemoteTargetIds ?? []);
     this.availablePoolIds = new Set(config.availablePoolIds ?? []);
     this.defaultAutoFixRetries = Math.min(Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0)), 10);
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
@@ -1393,14 +1308,11 @@ export class Orchestrator {
         taskDef.id,
         taskDef.command,
         taskDef.executorType,
-        taskDef.remoteTargetId,
         taskDef.poolId,
         this.executorRoutingRules,
-        this.availableRemoteTargetIds,
         this.availablePoolIds,
       );
       const effectiveExecutorType = resolvedRouting.executorType;
-      const effectiveRemoteTargetId = resolvedRouting.remoteTargetId;
       const effectivePoolId = resolvedRouting.poolId;
 
       const scopedId = localToScoped.get(taskDef.id)!;
@@ -1434,13 +1346,13 @@ export class Orchestrator {
       let taskConfig: TaskConfig;
       switch (executorType) {
         case 'docker':
-          taskConfig = { ...baseConfig, executorType, dockerImage: taskDef.dockerImage, remoteTargetId: effectiveRemoteTargetId };
+          taskConfig = { ...baseConfig, executorType, dockerImage: taskDef.dockerImage };
           break;
         case 'ssh':
-          taskConfig = { ...baseConfig, executorType, remoteTargetId: effectiveRemoteTargetId };
+          taskConfig = { ...baseConfig, executorType };
           break;
         default:
-          taskConfig = { ...baseConfig, executorType: 'worktree' as const, remoteTargetId: effectiveRemoteTargetId };
+          taskConfig = { ...baseConfig, executorType: 'worktree' as const };
           break;
       }
       const task = createTaskState(


### PR DESCRIPTION
Unify routing enforcement around poolId so command routing no longer accepts direct remote target destinations, aligning the orchestration path with pool-based execution semantics.

Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #520