### PR TITLE
Fix node branch dependency setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,8 @@ jobs:
             command: bash scripts/test-suites/required/10-vitest-workspace.sh
           - name: Submit Workflow Chain
             command: bash scripts/test-suites/required/15-submit-workflow-chain.sh
+          - name: Branch Carry Forward
+            command: bash scripts/test-suites/required/16-branch-carry-forward.sh
 
     name: required-fast / ${{ matrix.name }}
 

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -22,8 +22,8 @@ export interface WorkRequestInputs {
   experimentResults?: ExperimentResult[];
   /** URL of the git repository to clone and work in via RepoPool. */
   repoUrl?: string;
-  /** Optional URL where non-merge intermediate branches are published. */
-  intermediateRepoUrl?: string;
+  /** Optional repo used by executors to publish and fetch node branches. */
+  branchRepoUrl?: string;
   /** Feature branch name to create/checkout in the pooled worktree. */
   featureBranch?: string;
   /** Summaries from completed upstream dependencies, providing context for this task. */

--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -2041,12 +2041,12 @@ describe('BaseExecutor.pushBranchToRemote', () => {
     expect(typeof err).toBe('string');
   });
 
-  it('pushes to intermediate remote when configured on request inputs', async () => {
+  it('pushes to branch repo remote when configured on request inputs', async () => {
     execSync('git checkout -b invoker/task-intermediate', { cwd: cloneDir });
     writeFileSync(join(cloneDir, 'intermediate.txt'), 'task result');
     execSync('git add -A && git commit -m "task commit intermediate"', { cwd: cloneDir });
 
-    const req = makeRequest('task-intermediate', { intermediateRepoUrl: intermediateDir });
+    const req = makeRequest('task-intermediate', { branchRepoUrl: intermediateDir });
     executor.registerTestEntry('exec-intermediate', req);
     const pushErr = await executor.testPushBranchToRemote(cloneDir, 'invoker/task-intermediate', 'exec-intermediate');
     expect(pushErr).toBeUndefined();

--- a/packages/execution-engine/src/__tests__/branch-chain.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-chain.test.ts
@@ -53,6 +53,82 @@ function branchExists(cwd: string, branch: string): boolean {
   }
 }
 
+function showFile(cwd: string, branch: string, file: string): string {
+  return execSync(`git show ${JSON.stringify(`${branch}:${file}`)}`, { cwd }).toString();
+}
+
+function fileOrAbsent(cwd: string, branch: string, file: string): string {
+  try {
+    execSync(`git cat-file -e ${JSON.stringify(`${branch}:${file}`)}`, { cwd, stdio: 'ignore' });
+    return showFile(cwd, branch, file);
+  } catch {
+    return '<absent>';
+  }
+}
+
+function branchFileSnapshot(cwd: string, branch: string): {
+  branch: string;
+  files: Record<'a.txt' | 'b.txt' | 'c.txt', string>;
+} {
+  return {
+    branch,
+    files: {
+      'a.txt': fileOrAbsent(cwd, branch, 'a.txt'),
+      'b.txt': fileOrAbsent(cwd, branch, 'b.txt'),
+      'c.txt': fileOrAbsent(cwd, branch, 'c.txt'),
+    },
+  };
+}
+
+function showBareFile(gitDir: string, branch: string, file: string): string {
+  return execSync(`git --git-dir=${JSON.stringify(gitDir)} show ${JSON.stringify(`${branch}:${file}`)}`).toString();
+}
+
+function bareFileOrAbsent(gitDir: string, branch: string, file: string): string {
+  try {
+    execSync(`git --git-dir=${JSON.stringify(gitDir)} cat-file -e ${JSON.stringify(`${branch}:${file}`)}`, {
+      stdio: 'ignore',
+    });
+    return showBareFile(gitDir, branch, file);
+  } catch {
+    return '<absent>';
+  }
+}
+
+function bareBranchFileSnapshot(gitDir: string, branch: string): {
+  branch: string;
+  files: Record<'a.txt' | 'b.txt' | 'c.txt', string>;
+} {
+  return {
+    branch,
+    files: {
+      'a.txt': bareFileOrAbsent(gitDir, branch, 'a.txt'),
+      'b.txt': bareFileOrAbsent(gitDir, branch, 'b.txt'),
+      'c.txt': bareFileOrAbsent(gitDir, branch, 'c.txt'),
+    },
+  };
+}
+
+function bareBranchExists(gitDir: string, branch: string): boolean {
+  try {
+    execSync(`git --git-dir=${JSON.stringify(gitDir)} rev-parse --verify ${JSON.stringify(`refs/heads/${branch}`)}`, {
+      stdio: 'ignore',
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isBareAncestor(gitDir: string, ancestor: string, descendant: string): boolean {
+  try {
+    execSync(`git --git-dir=${JSON.stringify(gitDir)} merge-base --is-ancestor ${JSON.stringify(ancestor)} ${JSON.stringify(descendant)}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 type TaskType = { executor: 'worktree'; action: 'command' | 'claude' };
 
 interface ChainConfig {
@@ -579,6 +655,286 @@ describe('A→B→C branch chain', { timeout: 120_000 }, () => {
       expect(upstreams).toContain(taskA.execution.branch);
       expect(upstreams).toContain(taskB.execution.branch);
       expect(upstreams).toHaveLength(3);
+    });
+  });
+
+  describe('review gate direct dependency branch', () => {
+    it('merges only C while C carries A and B changes', async () => {
+      const intermediateDir = join(tmpDir, 'intermediate.git');
+      execSync(`git init --bare ${JSON.stringify(intermediateDir)}`, { cwd: tmpDir });
+
+      const taskA = makeTaskState({
+        id: 'task-a',
+        description: 'Step A',
+        config: { command: 'printf A_CHANGE > a.txt', executorType: 'worktree', workflowId: 'wf-test' },
+      });
+      const taskB = makeTaskState({
+        id: 'task-b',
+        description: 'Step B',
+        config: { command: 'printf B_CHANGE > b.txt', executorType: 'worktree', workflowId: 'wf-test' },
+      });
+      const taskC = makeTaskState({
+        id: 'task-c',
+        description: 'Step C',
+        dependencies: ['task-a', 'task-b'],
+        config: { command: 'printf C_CHANGE > c.txt', executorType: 'worktree', workflowId: 'wf-test' },
+      });
+      const mergeTask = makeTaskState({
+        id: '__merge__wf-test',
+        description: 'Review gate',
+        dependencies: ['task-c'],
+        status: 'running',
+        config: { executorType: 'merge', isMergeNode: true, workflowId: 'wf-test' },
+      });
+
+      const tasks = [taskA, taskB, taskC, mergeTask];
+      const registry = new ExecutorRegistry();
+      registry.register(
+        'worktree',
+        new WorktreeExecutor({
+          cacheDir: join(tmpDir, 'branch-chain-cache'),
+          worktreeBaseDir: join(tmpDir, 'branch-chain-wt'),
+          claudeCommand: '/bin/echo',
+        }),
+      );
+
+      const orchestrator = {
+        getTask: (id: string) => tasks.find(t => t.id === id),
+        getAllTasks: () => tasks,
+        handleWorkerResponse: (response: WorkResponse) => {
+          const task = tasks.find(t => t.id === response.actionId);
+          if (task) task.status = response.status;
+          return [];
+        },
+        setTaskAwaitingApproval: () => {},
+      };
+      const persistence = {
+        loadWorkflow: () => ({
+          id: 'wf-test',
+          name: 'Branch carry forward',
+          onFinish: 'none',
+          mergeMode: 'manual',
+          baseBranch: 'master',
+          featureBranch: 'feature/review-branch',
+          repoUrl: `file://${tmpDir}`,
+          intermediateRepoUrl: intermediateDir,
+        }),
+        updateTask: (id: string, changes: any) => {
+          const task = tasks.find(t => t.id === id);
+          if (task && changes.execution) Object.assign(task.execution, changes.execution);
+          if (task && changes.config) Object.assign(task.config, changes.config);
+        },
+      };
+
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: registry,
+        cwd: tmpDir,
+        defaultBranch: 'master',
+      });
+
+      taskA.status = 'running';
+      await (executor as any).executeTaskInner(taskA);
+      taskB.status = 'running';
+      await (executor as any).executeTaskInner(taskB);
+      const branchA = taskA.execution.branch!;
+      const branchB = taskB.execution.branch!;
+
+      expect(bareBranchExists(intermediateDir, branchA)).toBe(true);
+      expect(bareBranchExists(intermediateDir, branchB)).toBe(true);
+      expect(showBareFile(intermediateDir, branchA, 'a.txt')).toBe('A_CHANGE');
+      expect(showBareFile(intermediateDir, branchB, 'b.txt')).toBe('B_CHANGE');
+
+      taskC.status = 'running';
+      await (executor as any).executeTaskInner(taskC);
+      const branchC = taskC.execution.branch!;
+
+      expect(bareBranchExists(intermediateDir, branchC)).toBe(true);
+      expect(showBareFile(intermediateDir, branchC, 'a.txt')).toBe('A_CHANGE');
+      expect(showBareFile(intermediateDir, branchC, 'b.txt')).toBe('B_CHANGE');
+      expect(showBareFile(intermediateDir, branchC, 'c.txt')).toBe('C_CHANGE');
+
+      expect(isBareAncestor(intermediateDir, branchA, branchC)).toBe(true);
+      expect(isBareAncestor(intermediateDir, branchB, branchC)).toBe(true);
+      expect(executor.collectUpstreamBranches(mergeTask)).toEqual([branchC]);
+
+      await (executor as any).consolidateAndMerge(
+        'none',
+        'master',
+        'feature/review-branch',
+        'wf-test',
+        'Branch carry forward',
+        undefined,
+        undefined,
+        false,
+        'master',
+        '__merge__wf-test',
+      );
+
+      const branchProof = {
+        taskToBranch: {
+          'task-a': branchA,
+          'task-b': branchB,
+          'task-c': branchC,
+          '__merge__wf-test': 'feature/review-branch',
+        },
+        branchFiles: {
+          'task-a': bareBranchFileSnapshot(intermediateDir, branchA),
+          'task-b': bareBranchFileSnapshot(intermediateDir, branchB),
+          'task-c': bareBranchFileSnapshot(intermediateDir, branchC),
+          '__merge__wf-test': branchFileSnapshot(tmpDir, 'feature/review-branch'),
+        },
+      };
+
+      expect(branchProof.branchFiles).toEqual({
+        'task-a': {
+          branch: branchA,
+          files: {
+            'a.txt': 'A_CHANGE',
+            'b.txt': '<absent>',
+            'c.txt': '<absent>',
+          },
+        },
+        'task-b': {
+          branch: branchB,
+          files: {
+            'a.txt': '<absent>',
+            'b.txt': 'B_CHANGE',
+            'c.txt': '<absent>',
+          },
+        },
+        'task-c': {
+          branch: branchC,
+          files: {
+            'a.txt': 'A_CHANGE',
+            'b.txt': 'B_CHANGE',
+            'c.txt': 'C_CHANGE',
+          },
+        },
+        '__merge__wf-test': {
+          branch: 'feature/review-branch',
+          files: {
+            'a.txt': 'A_CHANGE',
+            'b.txt': 'B_CHANGE',
+            'c.txt': 'C_CHANGE',
+          },
+        },
+      });
+    });
+
+    it('keeps implementation changes through validation and post-fix leaf branches', async () => {
+      const implementation = makeTaskState({
+        id: 'implementation',
+        description: 'Implementation',
+        config: {
+          command: 'printf implementation > implementation.txt',
+          executorType: 'worktree',
+          workflowId: 'wf-test',
+        },
+      });
+      const verify = makeTaskState({
+        id: 'verify',
+        description: 'Verify',
+        dependencies: ['implementation'],
+        config: { command: 'true', executorType: 'worktree', workflowId: 'wf-test' },
+      });
+      const postFix = makeTaskState({
+        id: 'post-fix',
+        description: 'Post-fix regression',
+        dependencies: ['verify'],
+        config: { command: 'true', executorType: 'worktree', workflowId: 'wf-test' },
+      });
+      const mergeTask = makeTaskState({
+        id: '__merge__wf-test',
+        description: 'Review gate',
+        dependencies: ['post-fix'],
+        status: 'running',
+        config: { executorType: 'merge', isMergeNode: true, workflowId: 'wf-test' },
+      });
+
+      const tasks = [implementation, verify, postFix, mergeTask];
+      const registry = new ExecutorRegistry();
+      registry.register(
+        'worktree',
+        new WorktreeExecutor({
+          cacheDir: join(tmpDir, 'branch-chain-cache'),
+          worktreeBaseDir: join(tmpDir, 'branch-chain-wt'),
+          claudeCommand: '/bin/echo',
+        }),
+      );
+
+      const orchestrator = {
+        getTask: (id: string) => tasks.find(t => t.id === id),
+        getAllTasks: () => tasks,
+        handleWorkerResponse: (response: WorkResponse) => {
+          const task = tasks.find(t => t.id === response.actionId);
+          if (task) task.status = response.status;
+          return [];
+        },
+        setTaskAwaitingApproval: () => {},
+      };
+      const persistence = {
+        loadWorkflow: () => ({
+          id: 'wf-test',
+          name: 'Validation carry forward',
+          onFinish: 'none',
+          mergeMode: 'manual',
+          baseBranch: 'master',
+          featureBranch: 'feature/validation-review',
+          repoUrl: `file://${tmpDir}`,
+        }),
+        updateTask: (id: string, changes: any) => {
+          const task = tasks.find(t => t.id === id);
+          if (task && changes.execution) Object.assign(task.execution, changes.execution);
+          if (task && changes.config) Object.assign(task.config, changes.config);
+        },
+      };
+
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: registry,
+        cwd: tmpDir,
+        defaultBranch: 'master',
+      });
+
+      implementation.status = 'running';
+      await (executor as any).executeTaskInner(implementation);
+      verify.status = 'running';
+      await (executor as any).executeTaskInner(verify);
+      postFix.status = 'running';
+      await (executor as any).executeTaskInner(postFix);
+
+      const implementationBranch = implementation.execution.branch!;
+      const verifyBranch = verify.execution.branch!;
+      const postFixBranch = postFix.execution.branch!;
+
+      expect(isAncestor(tmpDir, implementationBranch, verifyBranch)).toBe(true);
+      expect(isAncestor(tmpDir, verifyBranch, postFixBranch)).toBe(true);
+      expect(execSync(`git show ${JSON.stringify(verifyBranch)}:implementation.txt`, { cwd: tmpDir }).toString()).toBe('implementation');
+      expect(execSync(`git show ${JSON.stringify(postFixBranch)}:implementation.txt`, { cwd: tmpDir }).toString()).toBe('implementation');
+
+      const mergeUpstreams = executor.collectUpstreamBranches(mergeTask);
+      expect(mergeUpstreams).toEqual([postFixBranch]);
+      expect(mergeUpstreams).not.toContain(implementationBranch);
+      expect(mergeUpstreams).not.toContain(verifyBranch);
+
+      await (executor as any).consolidateAndMerge(
+        'none',
+        'master',
+        'feature/validation-review',
+        'wf-test',
+        'Validation carry forward',
+        undefined,
+        undefined,
+        false,
+        'master',
+        '__merge__wf-test',
+      );
+
+      expect(isAncestor(tmpDir, postFixBranch, 'feature/validation-review')).toBe(true);
+      expect(execSync('git show feature/validation-review:implementation.txt', { cwd: tmpDir }).toString()).toBe('implementation');
     });
   });
 });

--- a/packages/execution-engine/src/__tests__/branch-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-utils.test.ts
@@ -9,6 +9,7 @@ import {
   buildExperimentBranchName,
   extractAttemptSuffix,
   bashPreserveOrReset,
+  bashFetchNodeRemotes,
   bashMergeUpstreams,
   bashEnsureRef,
   parsePreserveResult,
@@ -535,12 +536,22 @@ describe('bashMergeUpstreams', () => {
     expect(stdout).toContain('SKIPPED=master');
   });
 
-  it('skips missing refs gracefully (exit 0)', async () => {
+  it('fails missing refs by default', async () => {
     const script = bashMergeUpstreams({
       worktreeDir: wtDir,
       upstreamBranches: ['nonexistent-branch'],
     });
-    // Should succeed (exit 0) and skip the missing branch
+    await expect(runBashLocal(script)).rejects.toMatchObject({
+      exitCode: 30,
+    });
+  });
+
+  it('can skip missing refs only when explicitly requested', async () => {
+    const script = bashMergeUpstreams({
+      worktreeDir: wtDir,
+      upstreamBranches: ['nonexistent-branch'],
+      missingRefMode: 'skip',
+    });
     const stdout = await runBashLocal(script);
     expect(stdout).toContain('SKIPPED_MISSING_REF=nonexistent-branch');
   });
@@ -697,6 +708,43 @@ describe('bashMergeUpstreams', () => {
       expect(readFileSync(join(wtDir, 'shared.txt'), 'utf-8')).toBe('dep-v2\n');
     } finally {
       rmSync(seedDir, { recursive: true, force: true });
+      rmSync(originDir, { recursive: true, force: true });
+    }
+  });
+
+  it('fetches and merges dependency branches from intermediate', async () => {
+    const originDir = join(repoDir, '..', `origin-intermediate-${Date.now()}.git`);
+    const intermediateDir = join(repoDir, '..', `intermediate-${Date.now()}.git`);
+    const seedDir = join(repoDir, '..', `seed-intermediate-${Date.now()}`);
+
+    try {
+      execSync(`git init --bare "${originDir}"`);
+      gitExec(`git remote add origin "${originDir}"`, repoDir);
+      gitExec('git push origin master', repoDir);
+      execSync(`git init --bare "${intermediateDir}"`);
+      execSync(`git clone "${repoDir}" "${seedDir}"`, { stdio: 'ignore' });
+      gitExec('git config user.email "test@example.com"', seedDir);
+      gitExec('git config user.name "Test User"', seedDir);
+      gitExec(`git remote add intermediate "${intermediateDir}"`, seedDir);
+      gitExec('git push intermediate master', seedDir);
+      gitExec('git checkout -b dep-from-intermediate', seedDir);
+      writeFileSync(join(seedDir, 'intermediate-dep.txt'), 'from intermediate');
+      gitExec('git add -A && git commit -m "intermediate dep"', seedDir);
+      gitExec('git push intermediate dep-from-intermediate', seedDir);
+
+      await runBashLocal(bashFetchNodeRemotes({
+        worktreeDir: wtDir,
+        branchRepoUrl: intermediateDir,
+      }));
+      await runBashLocal(bashMergeUpstreams({
+        worktreeDir: wtDir,
+        upstreamBranches: ['dep-from-intermediate'],
+      }));
+
+      expect(readFileSync(join(wtDir, 'intermediate-dep.txt'), 'utf-8')).toBe('from intermediate');
+    } finally {
+      rmSync(seedDir, { recursive: true, force: true });
+      rmSync(intermediateDir, { recursive: true, force: true });
       rmSync(originDir, { recursive: true, force: true });
     }
   });

--- a/packages/execution-engine/src/__tests__/merge-missing-branch-graceful.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-missing-branch-graceful.test.ts
@@ -1,9 +1,6 @@
 /**
- * Regression test for: merge gate attempts to merge already-incorporated
- * experiment branches that no longer exist.
- *
- * Scenario: An experiment branch was merged via another path and deleted.
- * The merge gate still references it. Should skip gracefully, not fail.
+ * Legacy opt-in coverage for callers that explicitly allow missing branches.
+ * Node branch setup and merge gates use the default fatal mode.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -54,6 +51,7 @@ describe('Merge gate missing experiment branch handling', () => {
           worktreeDir: wtDir,
           upstreamBranches: ['experiment/add-feature-abc123'],
           skipAncestors: true,
+          missingRefMode: 'skip',
         });
 
         // Should succeed and skip the missing branch
@@ -80,6 +78,7 @@ describe('Merge gate missing experiment branch handling', () => {
         worktreeDir: wtDir,
         upstreamBranches: ['feature/missing-important-branch'],
         skipAncestors: true,
+        missingRefMode: 'skip',
       });
 
       // Should succeed but skip (bash script doesn't differentiate branch types,
@@ -115,6 +114,7 @@ describe('Merge gate missing experiment branch handling', () => {
           'experiment/missing-branch-2',
         ],
         skipAncestors: true,
+        missingRefMode: 'skip',
       });
 
       const stdout = await runBashLocal(script);

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -142,6 +142,22 @@ describe('buildMirrorCloneScript', () => {
     expect(script).toContain('REPO=$(echo');
     expect(script).toContain('base64 -d)');
   });
+
+  it('configures and fetches branch repo when provided', () => {
+    const script = buildMirrorCloneScript({
+      repoUrl: 'git@github.com:owner/repo.git',
+      branchRepoUrl: 'git@github.com:fork/repo.git',
+      repoHash: 'abc123',
+      baseRef: 'main',
+    });
+
+    expect(script).toContain('BRANCH_REPO=$(echo');
+    expect(script).toContain('git -C "$CLONE" remote set-url invoker-branches "$BRANCH_REPO"');
+    expect(script).toContain('git -C "$CLONE" remote add invoker-branches "$BRANCH_REPO"');
+    expect(script).toContain("git -C \"$CLONE\" fetch invoker-branches '+refs/heads/*:refs/remotes/invoker-branches/*' --prune");
+    expect(script).toContain('BRANCH_REPO_FETCH_FAILED=$BRANCH_REPO');
+    expect(script).toContain('exit 32');
+  });
 });
 
 describe('parseBootstrapOutput', () => {
@@ -345,7 +361,7 @@ describe('buildRecordAndPushScript', () => {
     expect(script).toContain(bashNormalizeTildePath());
   });
 
-  it('targets intermediate remote when pushRemoteUrl is provided', () => {
+  it('targets branch repo remote when pushRemoteUrl is provided', () => {
     const script = buildRecordAndPushScript({
       worktreePath: '~/worktree',
       branch: 'branch',
@@ -356,9 +372,9 @@ describe('buildRecordAndPushScript', () => {
       pushRemoteUrl: 'https://github.com/fork/repo.git',
     });
 
-    expect(script).toContain('git remote set-url intermediate "$PUSH_URL"');
-    expect(script).toContain('git remote add intermediate "$PUSH_URL"');
-    expect(script).toContain('git push -u intermediate "$BR"');
+    expect(script).toContain('git remote set-url invoker-branches "$PUSH_URL"');
+    expect(script).toContain('git remote add invoker-branches "$PUSH_URL"');
+    expect(script).toContain('git push -u invoker-branches "$BR"');
   });
 
   it('commits and pushes successfully without preconfigured git identity', () => {

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1858,6 +1858,53 @@ describe('TaskRunner', () => {
   });
 
   describe('baseBranch in WorkRequest', () => {
+    it('translates workflow intermediateRepoUrl into executor branchRepoUrl', async () => {
+      let capturedRequest: any;
+      const capturingExecutor = {
+        type: 'worktree',
+        start: async (req: any) => {
+          capturedRequest = req;
+          return { executionId: 'exec-branch-repo', taskId: 'task-branch-repo' };
+        },
+        onOutput: () => () => {},
+        onComplete: (_handle: any, cb: any) => {
+          cb({ requestId: 'r', actionId: 'task-branch-repo', status: 'completed', outputs: { exitCode: 0 } });
+          return () => {};
+        },
+        onHeartbeat: () => () => {},
+      };
+      const registry = {
+        getDefault: () => capturingExecutor,
+        get: () => capturingExecutor,
+        getAll: () => [capturingExecutor],
+      };
+      const persistence = {
+        updateTask: vi.fn(),
+        loadWorkflow: () => ({ generation: 0, intermediateRepoUrl: '  git@example.com:owner/branches.git  ' }),
+      };
+      const orchestrator = {
+        getTask: () => undefined,
+        handleWorkerResponse: vi.fn(),
+      };
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: registry as any,
+        cwd: '/tmp',
+      });
+
+      const task = makeTask({
+        id: 'task-branch-repo',
+        status: 'running',
+        config: { command: 'echo hi', workflowId: 'wf-branch-repo' },
+      });
+      await executor.executeTask(task);
+
+      expect(capturedRequest).toBeDefined();
+      expect(capturedRequest.inputs.branchRepoUrl).toBe('git@example.com:owner/branches.git');
+      expect(capturedRequest.inputs.intermediateRepoUrl).toBeUndefined();
+    });
+
     it('encodes workflow generation, task generation, and attemptId in request lifecycleTag', async () => {
       let capturedRequest: any;
       const capturingExecutor = {

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { spawn, type ChildProcess } from 'node:child_process';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { Executor, ExecutorHandle, PersistedTaskMeta, TerminalSpec, Unsubscribe } from './executor.js';
-import { bashPreserveOrReset, bashMergeUpstreams, parsePreserveResult, parseMergeError } from './branch-utils.js';
+import { bashPreserveOrReset, bashMergeUpstreams, bashFetchNodeRemotes, parsePreserveResult, parseMergeError } from './branch-utils.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { checkStaleness } from './git-staleness-detector.js';
@@ -79,7 +79,7 @@ export class MergeConflictError extends Error {
 }
 
 export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor {
-  protected static readonly INTERMEDIATE_REMOTE_NAME = 'intermediate';
+  protected static readonly BRANCH_REMOTE_NAME = 'invoker-branches';
   abstract readonly type: string;
   protected entries = new Map<string, TEntry>();
   protected heartbeatIntervalMs: number;
@@ -539,10 +539,18 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
       traceExecution(`${RESTART_TO_BRANCH_TRACE} [mergeRequestUpstreamBranches] no upstream merges`);
       return;
     }
+    await this.runBash(
+      bashFetchNodeRemotes({
+        worktreeDir: mergeCwd,
+        branchRepoUrl: request.inputs.branchRepoUrl,
+      }),
+      mergeCwd,
+    );
     const mergeScript = bashMergeUpstreams({
       worktreeDir: mergeCwd,
       upstreamBranches: upstreamsToMerge,
       skipAncestors: true,
+      missingRefMode: 'fail',
     });
     try {
       await this.runBash(mergeScript, mergeCwd);
@@ -598,6 +606,16 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         traceExecution(`${RESTART_TO_BRANCH_TRACE} [setupTaskBranch] originalBranch (repo checkout mode)=${originalBranch}`);
       } else {
         traceExecution(`${RESTART_TO_BRANCH_TRACE} [setupTaskBranch] originalBranch=(skipped, worktree mode)`);
+      }
+
+      if (!opts?.worktreeDir && upstreams.length > 0) {
+        await this.runBash(
+          bashFetchNodeRemotes({
+            worktreeDir: mergeCwd,
+            branchRepoUrl: request.inputs.branchRepoUrl,
+          }),
+          mergeCwd,
+        );
       }
 
       const preserveScript = bashPreserveOrReset({
@@ -671,7 +689,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     if (!commitHash) {
       return { error: 'commit approved fix failed' };
     }
-    const pushError = await this.pushBranchToRemote(cwd, branch, undefined, request.inputs.intermediateRepoUrl);
+    const pushError = await this.pushBranchToRemote(cwd, branch, undefined, request.inputs.branchRepoUrl);
     if (pushError) {
       return { error: pushError };
     }
@@ -786,27 +804,27 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     cwd: string,
     branch: string,
     executionId?: string,
-    intermediateRepoUrlOverride?: string,
+    branchRepoUrlOverride?: string,
   ): Promise<string | undefined> {
     try {
-      const requestIntermediateRepoUrl = intermediateRepoUrlOverride ?? (executionId
-        ? this.entries.get(executionId)?.request.inputs.intermediateRepoUrl
+      const requestBranchRepoUrl = branchRepoUrlOverride ?? (executionId
+        ? this.entries.get(executionId)?.request.inputs.branchRepoUrl
         : undefined);
-      const intermediateRepoUrl = requestIntermediateRepoUrl?.trim();
-      if (intermediateRepoUrl) {
+      const branchRepoUrl = requestBranchRepoUrl?.trim();
+      if (branchRepoUrl) {
         try {
           await this.execGitSimple(
-            ['remote', 'set-url', BaseExecutor.INTERMEDIATE_REMOTE_NAME, intermediateRepoUrl],
+            ['remote', 'set-url', BaseExecutor.BRANCH_REMOTE_NAME, branchRepoUrl],
             cwd,
           );
         } catch {
           await this.execGitSimple(
-            ['remote', 'add', BaseExecutor.INTERMEDIATE_REMOTE_NAME, intermediateRepoUrl],
+            ['remote', 'add', BaseExecutor.BRANCH_REMOTE_NAME, branchRepoUrl],
             cwd,
           );
         }
         await this.execGitSimpleWithNetworkTimeout(
-          ['push', '--force-with-lease', '-u', BaseExecutor.INTERMEDIATE_REMOTE_NAME, branch],
+          ['push', '--force-with-lease', '-u', BaseExecutor.BRANCH_REMOTE_NAME, branch],
           cwd,
         );
       } else {

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -187,19 +187,55 @@ export interface MergeUpstreamsOpts {
   worktreeDir: string;
   upstreamBranches: string[];
   skipAncestors?: boolean;
+  missingRefMode?: 'fail' | 'skip';
+}
+
+export interface FetchNodeRemotesOpts {
+  worktreeDir: string;
+  branchRepoUrl?: string;
+}
+
+/**
+ * Fetch refs needed for node branch setup. If a branch repo is configured
+ * it is part of the workflow's branch transport contract, so fetch failures are
+ * fatal instead of silently falling back to stale or incomplete refs.
+ */
+export function bashFetchNodeRemotes(opts: FetchNodeRemotesOpts): string {
+  const { worktreeDir, branchRepoUrl } = opts;
+  const q = shellQuote;
+  const branchRepo = branchRepoUrl?.trim();
+
+  return `set -euo pipefail
+WT_DIR=${q(worktreeDir)}
+if git -C "$WT_DIR" remote get-url origin >/dev/null 2>&1; then
+  git -C "$WT_DIR" fetch origin '+refs/heads/*:refs/remotes/origin/*' --prune
+fi
+${branchRepo ? `BRANCH_REPO_URL=${q(branchRepo)}
+if git -C "$WT_DIR" remote get-url invoker-branches >/dev/null 2>&1; then
+  git -C "$WT_DIR" remote set-url invoker-branches "$BRANCH_REPO_URL"
+else
+  git -C "$WT_DIR" remote add invoker-branches "$BRANCH_REPO_URL"
+fi
+if ! git -C "$WT_DIR" fetch invoker-branches '+refs/heads/*:refs/remotes/invoker-branches/*' --prune; then
+  echo "BRANCH_REPO_FETCH_FAILED=$BRANCH_REPO_URL" >&2
+  exit 32
+fi` : ''}
+`;
 }
 
 /**
  * Generate a bash script that merges upstream dependency branches into the
  * working directory. Skips branches already in HEAD's ancestry by default.
- * Skips missing branches gracefully (exit 0) when they don't exist locally or on origin.
+ * Fails missing branches by default because dependency branches are required
+ * graph inputs. Callers may opt into legacy skip behavior only where missing
+ * refs are explicitly non-authoritative.
  *
- * Exit codes: 0=success (includes skipped branches), 31=merge conflict.
+ * Exit codes: 0=success, 30=missing required upstream ref, 31=merge conflict.
  * On conflict, stderr contains MERGE_CONFLICT_BRANCH=<branch> and MERGE_CONFLICT_FILES.
- * On skipped missing refs, stdout contains SKIPPED_MISSING_REF=<branch>.
+ * On missing refs, stderr contains MISSING_REF=<branch> unless skip mode is used.
  */
 export function bashMergeUpstreams(opts: MergeUpstreamsOpts): string {
-  const { worktreeDir, upstreamBranches, skipAncestors = true } = opts;
+  const { worktreeDir, upstreamBranches, skipAncestors = true, missingRefMode = 'fail' } = opts;
   if (!upstreamBranches.length) return 'true';
 
   const q = shellQuote;
@@ -213,17 +249,20 @@ WT_DIR=${q(worktreeDir)}
 git -C "$WT_DIR" reset --hard HEAD >/dev/null 2>&1 || true
 git -C "$WT_DIR" clean -fd >/dev/null 2>&1 || true
 for upBranch in ${branches}; do
-  # Resolve: prefer fetched origin/<branch> over same-named local branches.
+  # Resolve: prefer fetched origin/<branch> or invoker-branches/<branch> over same-named local branches.
   # Managed mirrors accumulate local experiment refs from prior runs; after a
   # fetch, a stale local branch must not shadow a newer remote-tracking ref.
   if git -C "$WT_DIR" rev-parse --verify "origin/$upBranch" >/dev/null 2>&1; then
     upRef="origin/$upBranch"
+  elif git -C "$WT_DIR" rev-parse --verify "invoker-branches/$upBranch" >/dev/null 2>&1; then
+    upRef="invoker-branches/$upBranch"
   elif git -C "$WT_DIR" rev-parse --verify "$upBranch" >/dev/null 2>&1; then
     upRef="$upBranch"
   else
-    # Branch doesn't exist locally or on origin - skip gracefully
+${missingRefMode === 'skip' ? `    # Branch doesn't exist locally or on configured remotes - skip by caller request.
     echo "SKIPPED_MISSING_REF=$upBranch"
-    continue
+    continue` : `    echo "MISSING_REF=$upBranch" >&2
+    exit 30`}
   fi
 ${skipAncestors ? `  if git -C "$WT_DIR" merge-base --is-ancestor "$upRef" HEAD 2>/dev/null; then
     echo "SKIPPED=$upBranch"

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -227,7 +227,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
     cwd: string,
     branch: string,
     executionId?: string,
-    intermediateRepoUrlOverride?: string,
+    branchRepoUrlOverride?: string,
   ): Promise<string | undefined> {
     try {
       await this.execGitSimple(['remote', 'get-url', 'origin'], cwd);
@@ -239,9 +239,9 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
         if (executionId) this.emitOutput(executionId, msg);
         return undefined;
       }
-      return await super.pushBranchToRemote(cwd, branch, executionId, intermediateRepoUrlOverride);
+      return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride);
     }
-    return await super.pushBranchToRemote(cwd, branch, executionId, intermediateRepoUrlOverride);
+    return await super.pushBranchToRemote(cwd, branch, executionId, branchRepoUrlOverride);
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -268,15 +268,16 @@ export async function buildPrAuthoringContext(
  * already have the ref; SSH (or other) tasks often push to origin from another host,
  * so fetch into refs/heads/{branch} when missing.
  *
- * Returns true if the branch was found/fetched, false if it's missing everywhere
- * (graceful skip - caller should check ancestry before treating as an error).
+ * Returns true if the branch was found/fetched, false if it's missing everywhere.
+ * Callers that are preparing node output branches must treat false as fatal:
+ * dependency branches are required graph inputs.
  */
 export async function ensureLocalBranchForMerge(
   host: MergeRunnerHost,
   worktreeDir: string,
   branch: string,
   repoUrl?: string,
-  intermediateRepoUrl?: string,
+  branchRepoUrl?: string,
 ): Promise<boolean> {
   let hadLocal = false;
   try {
@@ -300,12 +301,12 @@ export async function ensureLocalBranchForMerge(
     originErr = err;
   }
 
-  const trimmedIntermediateRepoUrl = intermediateRepoUrl?.trim();
-  if (trimmedIntermediateRepoUrl) {
+  const trimmedBranchRepoUrl = branchRepoUrl?.trim();
+  if (trimmedBranchRepoUrl) {
     try {
       await execGitInMergeSafe(
         host,
-        ['fetch', trimmedIntermediateRepoUrl, `+refs/heads/${branch}:refs/heads/${branch}`],
+        ['fetch', trimmedBranchRepoUrl, `+refs/heads/${branch}:refs/heads/${branch}`],
         worktreeDir,
       );
       return true;
@@ -336,7 +337,7 @@ export async function ensureLocalBranchForMerge(
     }
   }
 
-  // Branch not found anywhere - return false to allow graceful skip
+  // Branch not found anywhere.
   const originMsg = originErr instanceof Error ? originErr.message : String(originErr);
   console.log(
     `[merge-gate-workspace] ensureLocalBranchForMerge: branch ${branch} not found locally, on origin, or in mirror. ` +
@@ -708,6 +709,7 @@ export async function approveMergeImpl(
   // Clean up the persistent gate worktree created by executeMergeNodeImpl
   const mergeTaskId = `__merge__${workflowId}`;
   const gateWorktreePath = safeGetWorkspacePath(host.persistence, mergeTaskId);
+  const branchRepoUrl = workflow.intermediateRepoUrl?.trim() || undefined;
 
   if (onFinish === 'merge') {
     const worktreeDir = await host.createMergeWorktree(baseBranch, 'approve-' + workflowId, workflow.repoUrl);
@@ -718,7 +720,7 @@ export async function approveMergeImpl(
         worktreeDir,
         featureBranch,
         workflow.repoUrl,
-        workflow.intermediateRepoUrl,
+        branchRepoUrl,
       );
       await execGitInMergeSafe(host, ['merge', '--squash', featureBranch], worktreeDir);
       mergeTrace('GIT_COMMIT', { mergeMessage });
@@ -962,23 +964,18 @@ export async function publishAfterFixImpl(
         } catch { /* not an ancestor — needs merging */ }
 
         console.log(`[merge] Post-fix: merging task branch ${branch} → ${featureBranch}`);
+        const branchRepoUrl = workflow?.intermediateRepoUrl?.trim() || undefined;
         const branchAvailable = await ensureLocalBranchForMerge(
           host,
           consolidateDir,
           branch,
           workflow?.repoUrl,
-          workflow?.intermediateRepoUrl,
+          branchRepoUrl,
         );
         if (!branchAvailable) {
-          // Branch missing - skip gracefully if experiment branch
-          if (branch.startsWith('experiment/')) {
-            console.log(`[merge] Post-fix: skipping missing experiment branch ${branch} (likely already incorporated)`);
-            skippedCount++;
-            continue;
-          }
           throw new Error(
             `Cannot merge ${branch}: not found locally, on origin, or in mirror. ` +
-            `The branch must exist for non-experiment branches.`,
+            `Dependency branches are required graph inputs and must be available.`,
           );
         }
         const mergeMsg = description ? `Merge ${branch} — ${description}` : `Merge ${branch}`;
@@ -1324,31 +1321,18 @@ export async function consolidateAndMergeImpl(
     let skippedCount = 0;
     for (const branch of taskBranches) {
       console.log(`[merge] Merging task branch: ${branch} → ${featureBranch}`);
+      const branchRepoUrl = workflowForMerge?.intermediateRepoUrl?.trim() || undefined;
       const branchAvailable = await ensureLocalBranchForMerge(
         host,
         worktreeDir,
         branch,
         repoUrlForMerge,
-        workflowForMerge?.intermediateRepoUrl,
+        branchRepoUrl,
       );
       if (!branchAvailable) {
-        // Branch missing everywhere - check if already incorporated via ancestry
-        console.log(`[merge] Branch ${branch} not found, checking if already incorporated...`);
-        try {
-          // If we can't find the branch, we can't verify ancestry. Assume it's already incorporated
-          // if this is an experiment/* branch (common pattern for short-lived branches).
-          if (branch.startsWith('experiment/')) {
-            console.log(`[merge] Skipping missing experiment branch ${branch} (likely already incorporated and deleted)`);
-            skippedCount++;
-            continue;
-          }
-        } catch {
-          /* ancestry check failed, branch truly missing */
-        }
-        // Non-experiment branches must be available for merge
         throw new Error(
           `Cannot merge ${branch}: not found locally, on origin, or in mirror. ` +
-          `The branch must exist for non-experiment branches.`,
+          `Dependency branches are required graph inputs and must be available.`,
         );
       }
       const task = allTasks.find(t => t.execution.branch === branch);

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -351,6 +351,7 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     // Step 1: Clone/fetch on remote + resolve baseHead
     const script1 = buildMirrorCloneScript({
       repoUrl,
+      branchRepoUrl: request.inputs.branchRepoUrl,
       repoHash: h,
       baseRef,
       invokerHome,
@@ -592,7 +593,7 @@ ${this.buildPayloadExecutionScript(payloadB64)}
       commitMessageEmpty: msgEmpty,
       gitUserName,
       gitUserEmail,
-      pushRemoteUrl: request.inputs.intermediateRepoUrl?.trim() || undefined,
+      pushRemoteUrl: request.inputs.branchRepoUrl?.trim() || undefined,
     });
 
     try {

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -93,6 +93,8 @@ export function sshInteractiveCdFragment(workspacePath: string): string {
 export interface GitMirrorCloneOpts {
   /** Repository URL to clone */
   repoUrl: string;
+  /** Optional repository URL used to publish/read node branches. */
+  branchRepoUrl?: string;
   /** Repo URL hash (12 chars from computeRepoUrlHash) */
   repoHash: string;
   /** Base ref to resolve (e.g., "main", "origin/master", or "HEAD") */
@@ -122,12 +124,14 @@ export interface GitMirrorCloneOpts {
  */
 export function buildMirrorCloneScript(opts: GitMirrorCloneOpts): string {
   const repoB64 = base64Encode(opts.repoUrl);
+  const branchRepoB64 = base64Encode(opts.branchRepoUrl?.trim() ?? '');
   const baseB64 = base64Encode(opts.baseRef);
   const { repoHash, invokerHome = '$HOME/.invoker' } = opts;
   const homeB64 = base64Encode(invokerHome);
 
   return `set -euo pipefail
 REPO=$(echo ${repoB64} | base64 -d)
+BRANCH_REPO=$(echo ${branchRepoB64} | base64 -d)
 BASE=$(echo ${baseB64} | base64 -d)
 H="${repoHash}"
 INVOKER_HOME=$(echo ${homeB64} | base64 -d)
@@ -139,12 +143,25 @@ fi
 CLONE="$INVOKER_HOME/repos/$H"
 mkdir -p "$(dirname "$CLONE")"
 if [ ! -d "$CLONE/.git" ]; then git clone "$REPO" "$CLONE"; fi
+if [ -n "$BRANCH_REPO" ]; then
+  if git -C "$CLONE" remote get-url invoker-branches >/dev/null 2>&1; then
+    git -C "$CLONE" remote set-url invoker-branches "$BRANCH_REPO"
+  else
+    git -C "$CLONE" remote add invoker-branches "$BRANCH_REPO"
+  fi
+fi
 if ! git -C "$CLONE" fetch --all --prune; then
   echo "[WARNING] Git fetch failed for $CLONE" >&2
   echo "[WARNING] Continuing with existing refs. Tasks may use stale commits." >&2
   echo "__INVOKER_FETCH_FAILED__=1"
 else
   echo "__INVOKER_FETCH_SUCCESS__=1"
+fi
+if [ -n "$BRANCH_REPO" ]; then
+  if ! git -C "$CLONE" fetch invoker-branches '+refs/heads/*:refs/remotes/invoker-branches/*' --prune; then
+    echo "BRANCH_REPO_FETCH_FAILED=$BRANCH_REPO" >&2
+    exit 32
+  fi
 fi
 RESOLVED_BASE="$BASE"
 ORIGIN_HEAD=$(git -C "$CLONE" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
@@ -333,12 +350,12 @@ HASH=$(git rev-parse HEAD)
 BR=$(echo ${brB} | base64 -d)
 PUSH_URL=$(echo ${pushRemoteUrlB} | base64 -d)
 if [ -n "$PUSH_URL" ]; then
-  if git remote get-url intermediate >/dev/null 2>&1; then
-    git remote set-url intermediate "$PUSH_URL"
+  if git remote get-url invoker-branches >/dev/null 2>&1; then
+    git remote set-url invoker-branches "$PUSH_URL"
   else
-    git remote add intermediate "$PUSH_URL"
+    git remote add invoker-branches "$PUSH_URL"
   fi
-  git push -u intermediate "$BR"
+  git push -u invoker-branches "$BR"
 else
   git push -u origin "$BR"
 fi

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -145,7 +145,7 @@ export interface TaskRunnerConfig {
 // ── TaskRunner ──────────────────────────────────────────
 
 export class TaskRunner {
-  private static readonly INTERMEDIATE_REMOTE_NAME = 'intermediate';
+  private static readonly BRANCH_REMOTE_NAME = 'invoker-branches';
   /** @internal */ orchestrator: Orchestrator;
   /** @internal */ persistence: SQLiteAdapter;
   private executorRegistry: ExecutorRegistry;
@@ -484,7 +484,7 @@ export class TaskRunner {
     });
     const baseBranch = workflow?.baseBranch ?? this.defaultBranch;
     const repoUrl = workflow?.repoUrl;
-    const intermediateRepoUrl = workflow?.intermediateRepoUrl;
+    const branchRepoUrl = workflow?.intermediateRepoUrl?.trim() || undefined;
 
     // Persist the experiment branch as soon as the executor knows it — well
     // before `git worktree add` could leak a worktree without a recorded branch
@@ -526,7 +526,7 @@ export class TaskRunner {
         prompt: task.config.prompt,
         executionAgent: task.config.executionAgent?.trim() || DEFAULT_EXECUTION_AGENT,
         repoUrl,
-        intermediateRepoUrl,
+        branchRepoUrl,
         featureBranch: task.config.featureBranch,
         upstreamContext: upstreamContext.length > 0 ? upstreamContext : undefined,
         alternatives: alternatives.length > 0 ? alternatives : undefined,
@@ -951,7 +951,7 @@ export class TaskRunner {
         description: task.description,
         command: task.config.command,
         prompt: task.config.prompt,
-        intermediateRepoUrl: workflow?.intermediateRepoUrl,
+        branchRepoUrl: workflow?.intermediateRepoUrl?.trim() || undefined,
       },
       callbackUrl: '',
       timestamps: {
@@ -1444,7 +1444,7 @@ export class TaskRunner {
         ? this.persistence.loadWorkflow(reconWorkflowId)
         : undefined;
     const reconRepoUrl = reconWorkflow?.repoUrl;
-    const reconIntermediateRepoUrl = reconWorkflow?.intermediateRepoUrl;
+    const reconBranchRepoUrl = reconWorkflow?.intermediateRepoUrl?.trim() || undefined;
 
     const worktreeDir = await this.createMergeWorktree(baseBranch, 'recon-' + reconTaskId, reconRepoUrl);
 
@@ -1462,12 +1462,12 @@ export class TaskRunner {
           throw new Error(`Experiment ${expId} has no branch`);
         }
         const b = expTask.execution.branch;
-        await ensureLocalBranchForMerge(this, worktreeDir, b, reconRepoUrl, reconIntermediateRepoUrl);
+        await ensureLocalBranchForMerge(this, worktreeDir, b, reconRepoUrl, reconBranchRepoUrl);
         const expMergeMsg = `Merge ${b} — ${expTask.description}`;
         await this.execGitIn(['merge', '--no-ff', '-m', expMergeMsg, b], worktreeDir);
       }
 
-      await this.pushBranchFromMergeWorktree(worktreeDir, branchName, reconIntermediateRepoUrl);
+      await this.pushBranchFromMergeWorktree(worktreeDir, branchName, reconBranchRepoUrl);
 
       const commit = await this.execGitIn(['rev-parse', 'HEAD'], worktreeDir);
       return { branch: branchName, commit };
@@ -2008,7 +2008,7 @@ export class TaskRunner {
 
     const rebaseWorkflow = this.persistence.loadWorkflow?.(workflowId);
     const rebaseRepoUrl = rebaseWorkflow?.repoUrl;
-    const rebaseIntermediateRepoUrl = rebaseWorkflow?.intermediateRepoUrl;
+    const rebaseBranchRepoUrl = rebaseWorkflow?.intermediateRepoUrl?.trim() || undefined;
     const worktreeDir = await this.createMergeWorktree(baseBranch, 'rebase-' + workflowId, rebaseRepoUrl);
 
     const rebasedBranches: string[] = [];
@@ -2019,7 +2019,7 @@ export class TaskRunner {
         try {
           await this.execGitIn(['checkout', branch], worktreeDir);
           await this.execGitIn(['rebase', baseBranch], worktreeDir);
-          await this.pushBranchFromMergeWorktree(worktreeDir, branch, rebaseIntermediateRepoUrl);
+          await this.pushBranchFromMergeWorktree(worktreeDir, branch, rebaseBranchRepoUrl);
           rebasedBranches.push(branch);
           this.logger.info(`[rebase] Successfully rebased ${branch} onto ${baseBranch}`);
         } catch (err) {
@@ -2043,23 +2043,23 @@ export class TaskRunner {
   private async pushBranchFromMergeWorktree(
     worktreeDir: string,
     branch: string,
-    intermediateRepoUrl?: string,
+    branchRepoUrl?: string,
   ): Promise<void> {
-    const trimmedIntermediateUrl = intermediateRepoUrl?.trim();
-    if (trimmedIntermediateUrl) {
+    const trimmedBranchRepoUrl = branchRepoUrl?.trim();
+    if (trimmedBranchRepoUrl) {
       try {
         await this.execGitIn(
-          ['remote', 'set-url', TaskRunner.INTERMEDIATE_REMOTE_NAME, trimmedIntermediateUrl],
+          ['remote', 'set-url', TaskRunner.BRANCH_REMOTE_NAME, trimmedBranchRepoUrl],
           worktreeDir,
         );
       } catch {
         await this.execGitIn(
-          ['remote', 'add', TaskRunner.INTERMEDIATE_REMOTE_NAME, trimmedIntermediateUrl],
+          ['remote', 'add', TaskRunner.BRANCH_REMOTE_NAME, trimmedBranchRepoUrl],
           worktreeDir,
         );
       }
       await this.execGitIn(
-        ['push', '--force', TaskRunner.INTERMEDIATE_REMOTE_NAME, `${branch}:refs/heads/${branch}`],
+        ['push', '--force', TaskRunner.BRANCH_REMOTE_NAME, `${branch}:refs/heads/${branch}`],
         worktreeDir,
       );
       return;

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -4,15 +4,13 @@ import { resolve, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
-import { BaseExecutor, type BaseEntry } from './base-executor.js';
+import { BaseExecutor, MergeConflictError, type BaseEntry } from './base-executor.js';
 import { RepoPool } from './repo-pool.js';
 import { killProcessGroup, cleanElectronEnv, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 import { DEFAULT_WORKTREE_PROVISION_COMMAND } from './default-worktree-provision-command.js';
 import {
   computeContentHash,
   buildExperimentBranchName,
-  bashMergeUpstreams,
-  parseMergeError,
 } from './branch-utils.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import {
@@ -251,17 +249,9 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     const poolUpstreams = request.inputs.upstreamBranches ?? [];
     if (poolUpstreams.length > 0) {
       try {
-        const mergeScript = bashMergeUpstreams({
-          worktreeDir: acquired.worktreePath,
-          upstreamBranches: poolUpstreams,
-          skipAncestors: true,
-        });
-        await this.runBash(mergeScript, acquired.worktreePath);
+        await this.mergeRequestUpstreamBranches(request, acquired.worktreePath, baseHead);
       } catch (err: any) {
-        const exitCode = err.exitCode ?? 1;
-        const stderr = err.stderr ?? err.message ?? '';
-        if (exitCode === 31) {
-          const parsed = parseMergeError(exitCode, stderr);
+        if (err instanceof MergeConflictError) {
           const entry: WorktreeEntry = {
             process: null, request, worktreeDir: acquired.worktreePath, branch,
             phase: 'completed',
@@ -284,8 +274,8 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
               exitCode: 1,
               error: JSON.stringify({
                 type: 'merge_conflict',
-                failedBranch: parsed.failedBranch,
-                conflictFiles: parsed.conflictFiles,
+                failedBranch: err.failedBranch,
+                conflictFiles: err.conflictFiles,
               }),
             },
           };

--- a/scripts/test-suites/required/16-branch-carry-forward.sh
+++ b/scripts/test-suites/required/16-branch-carry-forward.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Required regression: every node branch carries direct dependency changes, and
+# merge/review gates merge only their direct dependency branch.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/branch-chain.test.ts -t 'review gate direct dependency branch'


### PR DESCRIPTION
## Summary

Fixes node branch setup so dependency branches are required graph inputs instead of optional refs that can be silently skipped.

The execution engine now fetches configured node remotes, including `intermediateRepoUrl`, before dependency merges; fails when configured intermediate fetches fail; and fails when required dependency branches are missing. Worktree, SSH, local setup, and merge/review gate paths now share the same fetch/merge behavior. The review gate still merges only its direct dependency branch, relying on that branch to carry its own dependency history.

Adds real-git regressions for A+B -> C -> review gate and implementation -> verify -> post-fix -> review gate, and wires the focused branch carry-forward regression into required CI.

## Architecture

### Before

```mermaid
flowchart TD
  Worktree[Worktree task setup] --> LocalMerge[local merge path]
  SSH[SSH managed setup] --> SSHFetch[separate SSH fetch path]
  Gate[Merge/review gate] --> GateMerge[gate consolidation path]
  SSHFetch -. missed intermediate refs .-> Missing[missing dependency branch]
  GateMerge -. skipped experiment refs .-> EmptyPR[0-file review branch]
```

### After

```mermaid
flowchart TD
  Node[Workflow node] --> Fetch[fetch origin and configured intermediate]
  Fetch --> Missing{required dependency ref exists?}
  Missing -- no --> Fail[fail node setup]
  Missing -- yes --> Merge[merge direct dependency branches]
  Merge --> Output[push node output branch]
  Gate[Review gate node] --> Fetch
  Gate --> LeafOnly[merge direct leaf branch only]
```

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/auto-commit.test.ts src/__tests__/branch-utils.test.ts src/__tests__/branch-chain.test.ts src/__tests__/ssh-git-exec.test.ts`
- [x] `bash scripts/test-suites/required/16-branch-carry-forward.sh`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert c181acea`
- Post-revert steps: None
- Data migration? No
