### PR TITLE
Instrument workflow mutation timing

### DIFF
--- a/docs/workflow-mutation-timing.md
+++ b/docs/workflow-mutation-timing.md
@@ -1,0 +1,24 @@
+# Workflow Mutation Timing
+
+Invoker records timing spans for workflow recreate/rebase/retry mutations as
+`workflow.mutation.timing` task events. The event is attached to the workflow's
+merge gate when one exists, otherwise the first task in the workflow.
+
+The payload includes:
+
+- `workflowId`, `channel`, `intentId`, and `traceId` when available.
+- `function` and `phase`.
+- `at`, `offsetMs`, and `durationMs` for completed/failed spans.
+- Operation counts such as `queueWaitMs`, `startedCount`, `branchCount`, or
+  `runningCancelledCount` where the function has that data.
+
+To inspect the persisted timeline, first identify the merge gate task for the
+workflow, then use the existing audit query:
+
+```sh
+invoker --headless query tasks <workflowId> --output json
+invoker --headless query audit <mergeTaskId> --output json
+```
+
+Filter for `eventType === "workflow.mutation.timing"` and sort by event id.
+For live debugging, filter logs by the same `intentId` or `traceId`.

--- a/packages/app/e2e/task-death-logs.spec.ts
+++ b/packages/app/e2e/task-death-logs.spec.ts
@@ -22,6 +22,17 @@ import {
   getTasks,
   findTaskByIdSuffix,
 } from './fixtures/electron-app.js';
+import type { Page } from '@playwright/test';
+
+async function selectTaskNode(page: Page, taskId: string): Promise<void> {
+  const node = page.locator(`.react-flow__node[data-testid$="/${taskId}"]`).first();
+  await expect(node).toBeVisible({ timeout: 10000 });
+
+  await expect(async () => {
+    await node.click();
+    await expect(page.locator('[data-testid="command-display"]')).toBeVisible({ timeout: 500 });
+  }).toPass({ timeout: 5000 });
+}
 
 const DEATH_LOG_PLAN = {
   name: 'E2E Death Log Plan',
@@ -84,7 +95,7 @@ test.describe('Task death logs', () => {
     await startPlan(page);
     await waitForTaskStatus(page, 'silent-fail', 'failed');
 
-    await page.locator('.react-flow__node[data-testid$="/silent-fail"]').click();
+    await selectTaskNode(page, 'silent-fail');
 
     await expect(page.locator('text=Exit code: 1')).toBeVisible({ timeout: 3000 });
   });
@@ -122,7 +133,7 @@ test.describe('Task death logs', () => {
       },
     ]);
 
-    await page.locator('.react-flow__node[data-testid$="/silent-fail"]').click();
+    await selectTaskNode(page, 'silent-fail');
 
     await expect(
       page.locator('text=Executor startup failed (worktree): git not found'),

--- a/packages/app/src/__tests__/workflow-mutation-timing.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-timing.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { createWorkflowMutationTiming } from '../workflow-mutation-timing.js';
+
+describe('createWorkflowMutationTiming', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) {
+      adapter.close();
+    }
+  });
+
+  it('persists timing events on the workflow merge gate', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    const now = new Date();
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
+    });
+    adapter.saveTask('wf-1', {
+      id: '__merge__wf-1',
+      description: 'merge',
+      status: 'pending',
+      dependencies: [],
+      createdAt: now,
+      config: { workflowId: 'wf-1', isMergeNode: true, executorType: 'merge' },
+      execution: {},
+      taskStateVersion: 1,
+    });
+
+    const timing = createWorkflowMutationTiming({
+      persistence: adapter,
+      workflowId: 'wf-1',
+      channel: 'headless.exec',
+      intentId: 12,
+      args: [{ traceId: 'trace-1' }],
+    });
+
+    timing.mark('test.mark', 'queued', { priority: 'high' });
+    await timing.span('test.span', { count: 1 }, async () => undefined);
+
+    const events = adapter.getEvents('__merge__wf-1')
+      .filter((event) => event.eventType === 'workflow.mutation.timing');
+    expect(events).toHaveLength(3);
+    const payloads = events.map((event) => JSON.parse(event.payload ?? '{}'));
+    expect(payloads[0]).toMatchObject({
+      workflowId: 'wf-1',
+      channel: 'headless.exec',
+      intentId: 12,
+      traceId: 'trace-1',
+      function: 'test.mark',
+      phase: 'queued',
+      priority: 'high',
+    });
+    expect(payloads[1]).toMatchObject({
+      function: 'test.span',
+      phase: 'started',
+      count: 1,
+    });
+    expect(payloads[2]).toMatchObject({
+      function: 'test.span',
+      phase: 'completed',
+      count: 1,
+    });
+    expect(typeof payloads[2].durationMs).toBe('number');
+  });
+});

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@invoker/contracts';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { TaskRunner } from '@invoker/execution-engine';
+import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 
 type GlobalTopupParams = {
   orchestrator: Orchestrator;
@@ -8,6 +9,7 @@ type GlobalTopupParams = {
   logger?: Logger;
   context: string;
   alreadyDispatched?: TaskState[];
+  mutationTiming?: WorkflowMutationTiming;
 };
 
 type MutationTopupParams = {
@@ -16,6 +18,7 @@ type MutationTopupParams = {
   logger?: Logger;
   context: string;
   started?: TaskState[];
+  mutationTiming?: WorkflowMutationTiming;
 };
 
 function runningExecutionKey(task: TaskState): string {
@@ -34,6 +37,7 @@ export async function executeGlobalTopup({
   logger,
   context,
   alreadyDispatched = [],
+  mutationTiming,
 }: GlobalTopupParams): Promise<TaskState[]> {
   const dedupeKeys = new Set(
     alreadyDispatched
@@ -53,7 +57,15 @@ export async function executeGlobalTopup({
   logger?.info(
     `[global-topup] ${context}: dispatching ${runnable.length} additional task(s): [${runnable.map((task) => task.id).join(', ')}]`,
   );
-  await taskExecutor.executeTasks(runnable);
+  if (mutationTiming) {
+    await mutationTiming.span(
+      'executeGlobalTopup.taskExecutor.executeTasks',
+      { context, runnableCount: runnable.length },
+      () => taskExecutor.executeTasks(runnable),
+    );
+  } else {
+    await taskExecutor.executeTasks(runnable);
+  }
   return runnable;
 }
 
@@ -67,13 +79,22 @@ export async function dispatchStartedTasksWithGlobalTopup({
   logger,
   context,
   started = [],
+  mutationTiming,
 }: MutationTopupParams): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
   const runnable = started.filter((task) => task.status === 'running');
   if (runnable.length > 0) {
     logger?.info(
       `[global-topup] ${context}: dispatching ${runnable.length} scoped task(s): [${runnable.map((task) => task.id).join(', ')}]`,
     );
-    await taskExecutor.executeTasks(runnable);
+    if (mutationTiming) {
+      await mutationTiming.span(
+        'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks',
+        { context, runnableCount: runnable.length },
+        () => taskExecutor.executeTasks(runnable),
+      );
+    } else {
+      await taskExecutor.executeTasks(runnable);
+    }
   }
   const topup = await executeGlobalTopup({
     orchestrator,
@@ -81,6 +102,7 @@ export async function dispatchStartedTasksWithGlobalTopup({
     logger,
     context,
     alreadyDispatched: runnable,
+    mutationTiming,
   });
   return { runnable, topup };
 }
@@ -96,6 +118,7 @@ export async function finalizeMutationWithGlobalTopup({
   logger,
   context,
   started = [],
+  mutationTiming,
 }: MutationTopupParams): Promise<{ started: TaskState[]; topup: TaskState[] }> {
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator,
@@ -103,6 +126,7 @@ export async function finalizeMutationWithGlobalTopup({
     logger,
     context,
     started,
+    mutationTiming,
   });
   return { started, topup };
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -51,6 +51,7 @@ import { resolveHeadlessTargetWorkflowId } from './headless-command-classificati
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
+import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import type { RuntimeServices } from '@invoker/runtime-service';
 
 export { bumpGenerationAndRecreate } from './workflow-actions.js';
@@ -98,6 +99,7 @@ export interface HeadlessDeps {
   installBundledSkills?: (mode?: BundledSkillsInstallMode) => BundledSkillsStatus;
   /** Abort signal from the workflow mutation coordinator, if running inside a coordinated mutation. */
   signal?: AbortSignal;
+  mutationTiming?: WorkflowMutationTiming;
   runtimeServices?: RuntimeServices;
 }
 
@@ -1506,10 +1508,24 @@ async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<vo
   if (!taskId) throw new Error('Missing arguments. Usage: --headless retry-task <taskId>');
   await withRestoredTaskUnlessDeleteAllWon(taskId, deps, 'retry-task', async (restored) => {
     taskId = restored.resolvedTaskId;
-    await preemptTaskSubgraph(taskId, deps);
+    if (deps.mutationTiming) {
+      await deps.mutationTiming.span(
+        'headless.retry-task.preemptTaskSubgraph',
+        { taskId },
+        () => preemptTaskSubgraph(taskId, deps),
+      );
+    } else {
+      await preemptTaskSubgraph(taskId, deps);
+    }
 
     const envelope = makeEnvelope('restart-task', 'headless', 'task', { taskId });
-    const result = await deps.commandService.retryTask(envelope);
+    const result = deps.mutationTiming
+      ? await deps.mutationTiming.span(
+        'headless.retry-task.commandService.retryTask',
+        { taskId },
+        () => deps.commandService.retryTask(envelope),
+      )
+      : await deps.commandService.retryTask(envelope);
     if (!result.ok) throw new Error(result.error.message);
     const runnable = result.data.filter(t => t.status === 'running');
     process.stdout.write(`Restarted task "${taskId}" — ${runnable.length} task(s) to execute\n`);
@@ -1522,6 +1538,7 @@ async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<vo
       logger: deps.logger,
       context: 'headless.restart-task',
       started: result.data,
+      mutationTiming: deps.mutationTiming,
     });
     if (runnable.length + topup.length === 0) {
       autoFix.unsubscribe();
@@ -1640,11 +1657,12 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
     preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
     logger: deps.logger,
     context: 'headless.rebase-and-retry',
+    mutationTiming: deps.mutationTiming,
   });
 
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
-  const started = await rebaseAndRetry(taskId, { ...deps, taskExecutor: te });
+  const started = await rebaseAndRetry(taskId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
   const runnable = started.filter(t => t.status === 'running');
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
@@ -1652,6 +1670,7 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
     logger: deps.logger,
     context: 'headless.rebase-and-retry',
     started,
+    mutationTiming: deps.mutationTiming,
   });
   if (runnable.length + topup.length === 0) {
     autoFix.unsubscribe();
@@ -1681,11 +1700,12 @@ async function headlessRecreateWithRebase(workflowTarget: string, deps: Headless
     preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
     logger: deps.logger,
     context: 'headless.recreate-with-rebase',
+    mutationTiming: deps.mutationTiming,
   });
 
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
-  const started = await recreateWithRebase(workflowId, { ...deps, taskExecutor: te });
+  const started = await recreateWithRebase(workflowId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
   const runnable = started.filter(t => t.status === 'running');
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
@@ -1693,6 +1713,7 @@ async function headlessRecreateWithRebase(workflowTarget: string, deps: Headless
     logger: deps.logger,
     context: 'headless.recreate-with-rebase',
     started,
+    mutationTiming: deps.mutationTiming,
   });
   if (runnable.length + topup.length === 0) {
     autoFix.unsubscribe();
@@ -1723,8 +1744,15 @@ async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps):
     preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
     logger: deps.logger,
     context: 'headless.recreate-workflow',
+    mutationTiming: deps.mutationTiming,
   });
-  const started = sharedRecreateWorkflow(workflowId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
+  const started = deps.mutationTiming
+    ? await deps.mutationTiming.span(
+      'headless.recreate-workflow.sharedRecreateWorkflow',
+      undefined,
+      async () => sharedRecreateWorkflow(workflowId, { persistence: deps.persistence, orchestrator: deps.orchestrator }),
+    )
+    : sharedRecreateWorkflow(workflowId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
   const runnable = started.filter(t => t.status === 'running');
   if (runnable.length > 0) {
     const te = createHeadlessExecutor(deps);
@@ -1739,6 +1767,7 @@ async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps):
         logger: deps.logger,
         context: 'headless.recreate-workflow',
         alreadyDispatched: runnable,
+        mutationTiming: deps.mutationTiming,
       });
     } finally {
       remoteFetchForPool.enabled = true;
@@ -1771,9 +1800,23 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
   const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'recreate-task');
   if (!restored) return;
   taskId = restored.resolvedTaskId;
-  await preemptTaskSubgraph(taskId, deps);
+  if (deps.mutationTiming) {
+    await deps.mutationTiming.span(
+      'headless.recreate-task.preemptTaskSubgraph',
+      { taskId },
+      () => preemptTaskSubgraph(taskId, deps),
+    );
+  } else {
+    await preemptTaskSubgraph(taskId, deps);
+  }
 
-  const started = sharedRecreateTask(taskId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
+  const started = deps.mutationTiming
+    ? await deps.mutationTiming.span(
+      'headless.recreate-task.sharedRecreateTask',
+      { taskId },
+      async () => sharedRecreateTask(taskId, { persistence: deps.persistence, orchestrator: deps.orchestrator }),
+    )
+    : sharedRecreateTask(taskId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
   const runnable = started.filter(t => t.status === 'running');
   const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
   process.stdout.write(`Recreate task "${taskId}" (+ downstream) — ${runnable.length} task(s) to execute (pool fetch skipped)\n`);
@@ -1788,6 +1831,7 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
       logger: deps.logger,
       context: 'headless.recreate-task',
       started,
+      mutationTiming: deps.mutationTiming,
     }));
   } finally {
     remoteFetchForPool.enabled = true;
@@ -1848,9 +1892,16 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
     preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
     logger: deps.logger,
     context: 'headless.retry-workflow',
+    mutationTiming: deps.mutationTiming,
   });
   const envelope = makeEnvelope('retry-workflow', 'headless', 'workflow', { workflowId });
-  const result = await deps.commandService.retryWorkflow(envelope);
+  const result = deps.mutationTiming
+    ? await deps.mutationTiming.span(
+      'headless.retry-workflow.commandService.retryWorkflow',
+      undefined,
+      () => deps.commandService.retryWorkflow(envelope),
+    )
+    : await deps.commandService.retryWorkflow(envelope);
   if (!result.ok) throw new Error(result.error.message);
   const statusCounts = result.data.reduce<Record<string, number>>((acc, task) => {
     acc[task.status] = (acc[task.status] ?? 0) + 1;
@@ -1939,6 +1990,7 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
       logger: deps.logger,
       context: 'headless.retry-workflow',
       started: dispatchable,
+      mutationTiming: deps.mutationTiming,
     }));
   } finally {
     remoteFetchForPool.enabled = true;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1064,6 +1064,7 @@ if (isHeadless) {
               waitForApproval: delegatedWait,
               noTrack: delegatedNoTrack,
               signal: activeMutationContext?.signal,
+              mutationTiming: activeMutationContext?.mutationTiming,
             });
           });
           return { ok: true };
@@ -1696,6 +1697,7 @@ if (isHeadless) {
       commandService,
       repoRoot, invokerConfig, initServices, wireSlackBot,
       signal: activeMutationContext?.signal,
+      mutationTiming: activeMutationContext?.mutationTiming,
       cancelTask: (taskId: string) => performCancelTask(taskId),
       cancelWorkflow: (workflowId: string) => performCancelWorkflow(workflowId),
       waitForApproval: payload.waitForApproval,
@@ -2524,7 +2526,7 @@ if (isHeadless) {
             activeMutationContext = undefined;
           }
         },
-        { maxConcurrentWorkflowDrains },
+        { maxConcurrentWorkflowDrains, logger },
       );
     } else {
       logger.info('Launched in follower mode; mutation execution is delegated to the current owner', {
@@ -3192,8 +3194,15 @@ if (isHeadless) {
           preemptWorkflowExecution,
           logger,
           context: 'ipc.recreate-workflow',
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
-        const started = sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
+        const started = activeMutationContext?.mutationTiming
+          ? await activeMutationContext.mutationTiming.span(
+            'main.ipc.recreate-workflow.sharedRecreateWorkflow',
+            undefined,
+            async () => sharedRecreateWorkflow(workflowId, { persistence, orchestrator }),
+          )
+          : sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
         remoteFetchForPool.enabled = false;
         try {
           await dispatchStartedTasksWithGlobalTopup({
@@ -3202,6 +3211,7 @@ if (isHeadless) {
             logger,
             context: 'ipc.recreate-workflow',
             started,
+            mutationTiming: activeMutationContext?.mutationTiming,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -3221,8 +3231,22 @@ if (isHeadless) {
       const taskId = String(taskIdArg);
       logger.info(`recreate-task: "${taskId}"`, { module: 'ipc' });
       try {
-        await preemptTaskSubgraph(taskId);
-        const started = sharedRecreateTask(taskId, { persistence, orchestrator });
+        if (activeMutationContext?.mutationTiming) {
+          await activeMutationContext.mutationTiming.span(
+            'main.ipc.recreate-task.preemptTaskSubgraph',
+            { taskId },
+            () => preemptTaskSubgraph(taskId),
+          );
+        } else {
+          await preemptTaskSubgraph(taskId);
+        }
+        const started = activeMutationContext?.mutationTiming
+          ? await activeMutationContext.mutationTiming.span(
+            'main.ipc.recreate-task.sharedRecreateTask',
+            { taskId },
+            async () => sharedRecreateTask(taskId, { persistence, orchestrator }),
+          )
+          : sharedRecreateTask(taskId, { persistence, orchestrator });
         remoteFetchForPool.enabled = false;
         try {
           await dispatchStartedTasksWithGlobalTopup({
@@ -3231,6 +3255,7 @@ if (isHeadless) {
             logger,
             context: 'ipc.recreate-task',
             started,
+            mutationTiming: activeMutationContext?.mutationTiming,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -3255,9 +3280,16 @@ if (isHeadless) {
           preemptWorkflowExecution,
           logger,
           context: 'ipc.retry-workflow',
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
         const envelope = makeEnvelope('retry-workflow', 'ui', 'workflow', { workflowId });
-        const result = await commandService.retryWorkflow(envelope);
+        const result = activeMutationContext?.mutationTiming
+          ? await activeMutationContext.mutationTiming.span(
+            'main.ipc.retry-workflow.commandService.retryWorkflow',
+            undefined,
+            () => commandService.retryWorkflow(envelope),
+          )
+          : await commandService.retryWorkflow(envelope);
         if (!result.ok) throw new Error(result.error.message);
         remoteFetchForPool.enabled = false;
         try {
@@ -3267,6 +3299,7 @@ if (isHeadless) {
             logger,
             context: 'ipc.retry-workflow',
             started: result.data,
+            mutationTiming: activeMutationContext?.mutationTiming,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -3292,6 +3325,7 @@ if (isHeadless) {
             preemptWorkflowExecution,
             logger,
             context: 'ipc.rebase-and-retry',
+            mutationTiming: activeMutationContext?.mutationTiming,
           });
         }
         const started = await rebaseAndRetry(taskId, {
@@ -3299,6 +3333,7 @@ if (isHeadless) {
           persistence,
           repoRoot,
           taskExecutor: requireTaskExecutor(),
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
         await dispatchStartedTasksWithGlobalTopup({
           orchestrator,
@@ -3306,6 +3341,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.rebase-and-retry',
           started,
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
       } catch (err) {
         logger.error(`rebase-and-retry failed: ${err}`, { module: 'ipc' });
@@ -3330,12 +3366,14 @@ if (isHeadless) {
           preemptWorkflowExecution,
           logger,
           context: 'ipc.recreate-with-rebase',
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
         const started = await recreateWithRebase(workflowId, {
           orchestrator,
           persistence,
           repoRoot,
           taskExecutor: requireTaskExecutor(),
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
         await dispatchStartedTasksWithGlobalTopup({
           orchestrator,
@@ -3343,6 +3381,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.recreate-with-rebase',
           started,
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
       } catch (err) {
         logger.error(`recreate-with-rebase failed: ${err}`, { module: 'ipc' });

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -4,6 +4,8 @@ import {
   type WorkflowMutationIntent,
   type WorkflowMutationPriority,
 } from '@invoker/data-store';
+import type { Logger } from '@invoker/contracts';
+import { createWorkflowMutationTiming, type WorkflowMutationTiming } from './workflow-mutation-timing.js';
 
 type Deferred<T> = {
   resolve: (value: T) => void;
@@ -20,6 +22,7 @@ export type WorkflowMutationContext = {
   signal: AbortSignal;
   intentId: number;
   workflowId: string;
+  mutationTiming?: WorkflowMutationTiming;
 };
 
 function envMs(name: string, fallback: number): number {
@@ -61,7 +64,7 @@ export class PersistedWorkflowMutationCoordinator {
     private readonly persistence: SQLiteAdapter,
     private readonly ownerId: string,
     private readonly dispatch: (channel: string, args: unknown[], context: WorkflowMutationContext) => Promise<unknown>,
-    options?: { maxConcurrentWorkflowDrains?: number },
+    private readonly options?: { maxConcurrentWorkflowDrains?: number; logger?: Logger },
   ) {
     this.maxConcurrentWorkflowDrains = Math.max(1, options?.maxConcurrentWorkflowDrains ?? 1);
     this.enableTraceLogs = process.env.INVOKER_TRACE_MUTATION_QUEUE === '1';
@@ -75,6 +78,8 @@ export class PersistedWorkflowMutationCoordinator {
   ): Promise<T> {
     const intentId = this.persistence.enqueueWorkflowMutationIntent(workflowId, channel, args, priority);
     this.enqueueStartedAtMs.set(intentId, Date.now());
+    this.createTiming(workflowId, channel, intentId, args)
+      .mark('PersistedWorkflowMutationCoordinator.enqueue', 'queued', { priority });
     this.invalidateSupersededRunningIntent(workflowId, intentId, channel, args);
     this.trace(
       `enqueue intent=${intentId} workflow=${workflowId} priority=${priority} channel=${channel} activeDrains=${this.activeWorkflowDrains} pendingWorkflows=${this.pendingDrainWorkflows.size}`,
@@ -95,6 +100,11 @@ export class PersistedWorkflowMutationCoordinator {
   ): number {
     const intentId = this.persistence.enqueueWorkflowMutationIntent(workflowId, channel, args, priority);
     this.enqueueStartedAtMs.set(intentId, Date.now());
+    this.createTiming(workflowId, channel, intentId, args)
+      .mark('PersistedWorkflowMutationCoordinator.submit', 'queued', {
+        priority,
+        deferDrain: Boolean(options?.deferDrain),
+      });
     this.invalidateSupersededRunningIntent(workflowId, intentId, channel, args);
     this.trace(
       `submit intent=${intentId} workflow=${workflowId} priority=${priority} channel=${channel} defer=${Boolean(options?.deferDrain)} activeDrains=${this.activeWorkflowDrains} pendingWorkflows=${this.pendingDrainWorkflows.size}`,
@@ -182,9 +192,17 @@ export class PersistedWorkflowMutationCoordinator {
       if (!this.persistence.claimWorkflowMutationLease(workflowId, this.ownerId)) {
         return;
       }
+      this.createTiming(workflowId, 'workflow-mutation-drain')
+        .mark('PersistedWorkflowMutationCoordinator.runWorkflowDrain.claimLease', 'completed', {
+          ownerId: this.ownerId,
+        });
       let intent = this.persistence.claimNextWorkflowMutationIntent(workflowId, this.ownerId);
       while (intent) {
         const waitMs = this.intentQueueWaitMs(intent.id);
+        this.createTiming(workflowId, intent.channel, intent.id, intent.args)
+          .mark('PersistedWorkflowMutationCoordinator.runWorkflowDrain.claimNextIntent', 'started', {
+            queueWaitMs: waitMs,
+          });
         this.trace(`drain-start workflow=${workflowId} intent=${intent.id} channel=${intent.channel} queueWaitMs=${waitMs}`);
         this.persistence.renewWorkflowMutationLease(workflowId, this.ownerId, {
           activeIntentId: intent.id,
@@ -205,6 +223,8 @@ export class PersistedWorkflowMutationCoordinator {
   private async executeIntent(workflowId: string, intent: WorkflowMutationIntent): Promise<void> {
     const deferred = this.inFlightPromises.get(intent.id);
     const invalidation = this.createRunningIntentInvalidation(intent.id);
+    const timing = this.createTiming(workflowId, intent.channel, intent.id, intent.args);
+    const intentStartedAtMs = Date.now();
     const leaseHeartbeat = setInterval(() => {
       this.persistence.renewWorkflowMutationLease(workflowId, this.ownerId, {
         activeIntentId: intent.id,
@@ -215,12 +235,20 @@ export class PersistedWorkflowMutationCoordinator {
     }, this.leaseHeartbeatMs);
     try {
       this.evictQueuedWorkflowIntentsForFence(workflowId, intent);
+      timing.mark('PersistedWorkflowMutationCoordinator.executeIntent', 'started', {
+        queueWaitMs: this.intentQueueWaitMs(intent.id),
+      });
       const mutationContext: WorkflowMutationContext = {
         signal: invalidation.abortController.signal,
         intentId: intent.id,
         workflowId,
+        mutationTiming: timing,
       };
-      const dispatchPromise = Promise.resolve(this.dispatch(intent.channel, intent.args, mutationContext));
+      const dispatchPromise = timing.span(
+        'PersistedWorkflowMutationCoordinator.dispatch',
+        undefined,
+        () => this.dispatch(intent.channel, intent.args, mutationContext),
+      );
       void dispatchPromise.catch(() => {});
       const result = await Promise.race([
         dispatchPromise,
@@ -230,6 +258,9 @@ export class PersistedWorkflowMutationCoordinator {
       if (latestIntent?.status === 'running') {
         this.persistence.completeWorkflowMutationIntent(intent.id);
       }
+      timing.mark('PersistedWorkflowMutationCoordinator.executeIntent', 'completed', {
+        durationMs: Date.now() - intentStartedAtMs,
+      });
       deferred?.resolve(result);
     } catch (error) {
       const message = error instanceof Error ? (error.stack ?? error.message) : String(error);
@@ -237,6 +268,10 @@ export class PersistedWorkflowMutationCoordinator {
       if (latestIntent?.status === 'running') {
         this.persistence.failWorkflowMutationIntent(intent.id, message);
       }
+      timing.mark('PersistedWorkflowMutationCoordinator.executeIntent', 'failed', {
+        durationMs: Date.now() - intentStartedAtMs,
+        error: error instanceof Error ? error.message : String(error),
+      });
       deferred?.reject(error);
     } finally {
       clearInterval(leaseHeartbeat);
@@ -277,6 +312,16 @@ export class PersistedWorkflowMutationCoordinator {
     );
     if (evictedIds.length > 0) {
       for (const evictedId of evictedIds) {
+        const evictedIntent = this.persistence.loadWorkflowMutationIntent(evictedId);
+        this.createTiming(
+          workflowId,
+          evictedIntent?.channel ?? 'unknown',
+          evictedId,
+          evictedIntent?.args,
+        ).mark('PersistedWorkflowMutationCoordinator.evictQueuedWorkflowIntentsForFence', 'evicted', {
+          fenceIntentId: intent.id,
+          fenceChannel: intent.channel,
+        });
         const deferred = this.inFlightPromises.get(evictedId);
         if (!deferred) continue;
         deferred.reject(new Error(`Workflow mutation intent ${evictedId} was evicted by ${intent.channel}#${intent.id}`));
@@ -329,6 +374,12 @@ export class PersistedWorkflowMutationCoordinator {
     }
     const reason = `Superseded by ${fenceKind} intent #${newIntentId}`;
     this.persistence.failWorkflowMutationIntent(activeIntentId, reason);
+    this.createTiming(workflowId, activeIntent.channel, activeIntent.id, activeIntent.args)
+      .mark('PersistedWorkflowMutationCoordinator.invalidateSupersededRunningIntent', 'invalidated', {
+        newIntentId,
+        channel,
+        reason,
+      });
     const invalidation = this.runningIntentInvalidations.get(activeIntentId);
     invalidation?.abortController.abort(new WorkflowMutationInvalidatedError(reason));
     invalidation?.reject(new WorkflowMutationInvalidatedError(reason));
@@ -392,5 +443,21 @@ export class PersistedWorkflowMutationCoordinator {
       return false;
     }
     return command === 'recreate' || command === 'retry';
+  }
+
+  private createTiming(
+    workflowId: string,
+    channel: string,
+    intentId?: number,
+    args?: unknown[],
+  ): WorkflowMutationTiming {
+    return createWorkflowMutationTiming({
+      persistence: this.persistence,
+      logger: this.options?.logger,
+      workflowId,
+      channel,
+      intentId,
+      args,
+    });
   }
 }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -19,6 +19,7 @@ import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
+import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 
 // ── Lineage guard ─────────────────────────────────────────────
 
@@ -96,6 +97,7 @@ export interface ActionDeps {
   repoRoot?: string;
   /** When set, rebase-and-refreshes the pool mirror and removes managed branches before bumping generation. */
   taskExecutor?: TaskRunner;
+  mutationTiming?: WorkflowMutationTiming;
   /** When true, successful AI-applied fixes are approved immediately. */
   autoApproveAIFixes?: boolean;
 }
@@ -356,7 +358,13 @@ export async function recreateWorkflowFromFreshBase(
   const workflow = deps.persistence.loadWorkflow(workflowId);
   if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
   const nextGen = (workflow.generation ?? 0) + 1;
+  deps.mutationTiming?.mark('workflow-actions.recreateWorkflowFromFreshBase.bumpGeneration', 'started', {
+    nextGeneration: nextGen,
+  });
   deps.persistence.updateWorkflow(workflowId, { generation: nextGen });
+  deps.mutationTiming?.mark('workflow-actions.recreateWorkflowFromFreshBase.bumpGeneration', 'completed', {
+    nextGeneration: nextGen,
+  });
   deps.logger?.info(
     `recreateWorkflowFromFreshBase: workflowId=${workflowId} bumped generation to ${nextGen}`,
     { module: 'workflow' },
@@ -366,14 +374,30 @@ export async function recreateWorkflowFromFreshBase(
     { module: 'agent-session-trace' },
   );
 
-  return deps.orchestrator.recreateWorkflowFromFreshBase(workflowId, {
+  const recreate = () => deps.orchestrator.recreateWorkflowFromFreshBase(workflowId, {
     refreshBase: async () => {
       if (deps.taskExecutor && workflow.repoUrl) {
-        await deps.taskExecutor.preparePoolForRebaseRetry(
-          workflowId,
-          workflow.repoUrl,
-          workflow.baseBranch,
-        );
+        const prepare = () => deps.mutationTiming
+          ? deps.taskExecutor!.preparePoolForRebaseRetry(
+            workflowId,
+            workflow.repoUrl,
+            workflow.baseBranch,
+            deps.mutationTiming,
+          )
+          : deps.taskExecutor!.preparePoolForRebaseRetry(
+            workflowId,
+            workflow.repoUrl,
+            workflow.baseBranch,
+          );
+        if (deps.mutationTiming) {
+          await deps.mutationTiming.span(
+            'workflow-actions.recreateWorkflowFromFreshBase.preparePoolForRebaseRetry',
+            { repoUrl: workflow.repoUrl, baseBranch: workflow.baseBranch },
+            prepare,
+          );
+        } else {
+          await prepare();
+        }
       }
       // `preparePoolForRebaseRetry` does not yet expose the resulting
       // upstream HEAD SHA; surfacing it (so the orchestrator can
@@ -382,6 +406,9 @@ export async function recreateWorkflowFromFreshBase(
       return undefined;
     },
   });
+  return deps.mutationTiming
+    ? deps.mutationTiming.span('workflow-actions.recreateWorkflowFromFreshBase.orchestrator', undefined, recreate)
+    : recreate();
 }
 
 /**
@@ -397,11 +424,17 @@ export async function recreateWithRebase(
   workflowId: string,
   deps: ActionDeps,
 ): Promise<TaskState[]> {
+  deps.mutationTiming?.mark('workflow-actions.recreateWithRebase', 'started', { workflowId });
   deps.logger?.info(
     `recreateWithRebase: workflowId=${workflowId} → recreateWorkflowFromFreshBase`,
     { module: 'agent-session-trace' },
   );
-  return recreateWorkflowFromFreshBase(workflowId, deps);
+  const started = await recreateWorkflowFromFreshBase(workflowId, deps);
+  deps.mutationTiming?.mark('workflow-actions.recreateWithRebase', 'completed', {
+    workflowId,
+    startedCount: started.length,
+  });
+  return started;
 }
 
 /**
@@ -422,11 +455,18 @@ export async function rebaseAndRetry(
   const task = deps.orchestrator.getTask(taskId);
   if (!task?.config.workflowId) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found or has no workflow`);
   const workflowId = task.config.workflowId;
+  deps.mutationTiming?.mark('workflow-actions.rebaseAndRetry', 'started', { taskId, workflowId });
   deps.logger?.info(
     `rebaseAndRetry: taskId=${taskId} workflowId=${workflowId} → recreateWorkflowFromFreshBase (Step 12 delegate)`,
     { module: 'agent-session-trace' },
   );
-  return recreateWorkflowFromFreshBase(workflowId, deps);
+  const started = await recreateWorkflowFromFreshBase(workflowId, deps);
+  deps.mutationTiming?.mark('workflow-actions.rebaseAndRetry', 'completed', {
+    taskId,
+    workflowId,
+    startedCount: started.length,
+  });
+  return started;
 }
 
 export interface BuildCancelInFlightDeps {
@@ -450,7 +490,7 @@ export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlig
 }
 
 export function buildInvalidationDeps(
-  deps: Pick<ActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'taskExecutor'>,
+  deps: Pick<ActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'taskExecutor' | 'mutationTiming'>,
 ): InvalidationDeps {
   const cancelInFlight = buildCancelInFlight({
     orchestrator: deps.orchestrator,
@@ -473,6 +513,7 @@ export function buildInvalidationDeps(
         orchestrator: deps.orchestrator,
         persistence: deps.persistence,
         taskExecutor: deps.taskExecutor,
+        mutationTiming: deps.mutationTiming,
       }),
     workflowFork: (workflowId: string) => {
       const result = deps.orchestrator.forkWorkflow(workflowId);

--- a/packages/app/src/workflow-mutation-timing.ts
+++ b/packages/app/src/workflow-mutation-timing.ts
@@ -1,0 +1,114 @@
+import type { Logger } from '@invoker/contracts';
+import type { SQLiteAdapter } from '@invoker/data-store';
+
+type TimingPhase = 'queued' | 'started' | 'completed' | 'failed' | 'evicted' | 'invalidated';
+
+export interface WorkflowMutationTiming {
+  readonly workflowId: string;
+  readonly channel: string;
+  readonly intentId?: number;
+  mark(functionName: string, phase: TimingPhase, metadata?: Record<string, unknown>): void;
+  span<T>(functionName: string, metadata: Record<string, unknown> | undefined, fn: () => Promise<T>): Promise<T>;
+}
+
+export function createWorkflowMutationTiming(args: {
+  persistence: SQLiteAdapter;
+  logger?: Logger;
+  workflowId: string;
+  channel: string;
+  intentId?: number;
+  args?: unknown[];
+}): WorkflowMutationTiming {
+  const startedAtMs = Date.now();
+  const eventTaskId = findWorkflowEventTaskId(args.persistence, args.workflowId);
+  const base = {
+    workflowId: args.workflowId,
+    channel: args.channel,
+    intentId: args.intentId,
+    traceId: extractTraceId(args.args),
+  };
+
+  const record = (
+    functionName: string,
+    phase: TimingPhase,
+    metadata?: Record<string, unknown>,
+  ): void => {
+    const nowMs = Date.now();
+    const payload = compact({
+      ...base,
+      function: functionName,
+      phase,
+      at: new Date(nowMs).toISOString(),
+      offsetMs: nowMs - startedAtMs,
+      ...metadata,
+    });
+    args.logger?.info(
+      `[workflow-mutation-timing] ${functionName} ${phase}`,
+      { module: 'workflow-mutation-timing', ...payload },
+    );
+    if (!eventTaskId) return;
+    try {
+      args.persistence.logEvent(eventTaskId, 'workflow.mutation.timing', payload);
+    } catch (error) {
+      args.logger?.warn('[workflow-mutation-timing] failed to persist event', {
+        module: 'workflow-mutation-timing',
+        error: error instanceof Error ? error.message : String(error),
+        workflowId: args.workflowId,
+        function: functionName,
+        phase,
+      });
+    }
+  };
+
+  return {
+    workflowId: args.workflowId,
+    channel: args.channel,
+    intentId: args.intentId,
+    mark: record,
+    async span<T>(
+      functionName: string,
+      metadata: Record<string, unknown> | undefined,
+      fn: () => Promise<T>,
+    ): Promise<T> {
+      const spanStartedAtMs = Date.now();
+      record(functionName, 'started', metadata);
+      try {
+        const result = await fn();
+        record(functionName, 'completed', {
+          ...metadata,
+          durationMs: Date.now() - spanStartedAtMs,
+        });
+        return result;
+      } catch (error) {
+        record(functionName, 'failed', {
+          ...metadata,
+          durationMs: Date.now() - spanStartedAtMs,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        throw error;
+      }
+    },
+  };
+}
+
+function findWorkflowEventTaskId(persistence: SQLiteAdapter, workflowId: string): string | undefined {
+  try {
+    const tasks = persistence.loadTasks(workflowId);
+    return tasks.find((task) => task.config.isMergeNode)?.id ?? tasks[0]?.id;
+  } catch {
+    return undefined;
+  }
+}
+
+function extractTraceId(args: unknown[] | undefined): string | undefined {
+  const first = args?.[0];
+  if (!first || typeof first !== 'object') return undefined;
+  const traceId = (first as { traceId?: unknown }).traceId;
+  return typeof traceId === 'string' && traceId.trim() ? traceId : undefined;
+}
+
+function compact(values: Record<string, unknown>): Record<string, unknown> {
+  return Object.fromEntries(
+    Object.entries(values).filter(([, value]) => value !== undefined),
+  );
+}

--- a/packages/app/src/workflow-preemption.ts
+++ b/packages/app/src/workflow-preemption.ts
@@ -1,4 +1,5 @@
 import type { Logger } from '@invoker/contracts';
+import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 
 export type WorkflowCancelResult = {
   cancelled: string[];
@@ -13,11 +14,23 @@ export async function preemptWorkflowBeforeMutation(
     preemptWorkflowExecution: PreemptWorkflowExecution;
     logger?: Logger;
     context: string;
+    mutationTiming?: WorkflowMutationTiming;
   },
 ): Promise<WorkflowCancelResult> {
   deps.logger?.info(`preempt begin context="${deps.context}" workflow="${workflowId}"`, { module: 'preempt' });
-  const raw = await deps.preemptWorkflowExecution(workflowId);
+  const raw = deps.mutationTiming
+    ? await deps.mutationTiming.span(
+      'preemptWorkflowBeforeMutation',
+      { context: deps.context },
+      () => deps.preemptWorkflowExecution(workflowId),
+    )
+    : await deps.preemptWorkflowExecution(workflowId);
   const result: WorkflowCancelResult = raw ?? { cancelled: [], runningCancelled: [] };
+  deps.mutationTiming?.mark('preemptWorkflowBeforeMutation.result', 'completed', {
+    context: deps.context,
+    cancelledCount: result.cancelled.length,
+    runningCancelledCount: result.runningCancelled.length,
+  });
   deps.logger?.info(
     `preempt end context="${deps.context}" workflow="${workflowId}" cancelled=${result.cancelled.length} runningCancelled=${result.runningCancelled.length}`,
     { module: 'preempt' },

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -26,6 +26,11 @@ export interface RepoPoolConfig {
   worktreeBaseDir?: string;
 }
 
+export interface RepoPoolTiming {
+  mark(functionName: string, phase: 'started' | 'completed' | 'failed', metadata?: Record<string, unknown>): void;
+  span<T>(functionName: string, metadata: Record<string, unknown> | undefined, fn: () => Promise<T>): Promise<T>;
+}
+
 export interface AcquiredWorktree {
   clonePath: string;
   worktreePath: string;
@@ -77,60 +82,109 @@ export class RepoPool {
   /**
    * Force-fetch mirror and sync origin/<baseBranch> (rebase-and-retry). Ignores remoteFetchForPool.
    */
-  async refreshMirrorForRebase(repoUrl: string, baseBranch: string): Promise<string> {
+  async refreshMirrorForRebase(repoUrl: string, baseBranch: string, timing?: RepoPoolTiming): Promise<string> {
     const prev = this.repoChains.get(repoUrl) ?? Promise.resolve();
-    const next = prev.then(() => this.doRefreshMirrorForRebase(repoUrl, baseBranch));
+    const queuedAtMs = Date.now();
+    const next = prev.then(() => {
+      timing?.mark('RepoPool.refreshMirrorForRebase.repoChainWait', 'completed', {
+        repoUrl,
+        baseBranch,
+        durationMs: Date.now() - queuedAtMs,
+      });
+      return this.doRefreshMirrorForRebase(repoUrl, baseBranch, timing);
+    });
     this.repoChains.set(repoUrl, next.catch(() => {}));
     return next;
   }
 
-  private async doRefreshMirrorForRebase(repoUrl: string, baseBranch: string): Promise<string> {
+  private async doRefreshMirrorForRebase(repoUrl: string, baseBranch: string, timing?: RepoPoolTiming): Promise<string> {
     const dir = this.cloneDir(repoUrl);
     if (existsSync(dir)) {
       try {
-        await this.execGit(['fetch', '--all', '--prune'], dir);
+        await this.time(timing, 'RepoPool.doRefreshMirrorForRebase.gitFetchAllPrune', { dir }, () =>
+          this.execGit(['fetch', '--all', '--prune'], dir),
+        );
       } catch (err) {
         console.warn(`[RepoPool] refreshMirrorForRebase fetch failed: ${err}`);
       }
       try {
-        const branch = (await this.execGit(['rev-parse', '--abbrev-ref', 'HEAD'], dir)).trim();
+        const branch = (await this.time(timing, 'RepoPool.doRefreshMirrorForRebase.gitCurrentBranch', { dir }, () =>
+          this.execGit(['rev-parse', '--abbrev-ref', 'HEAD'], dir),
+        )).trim();
         if (branch !== 'HEAD') {
-          await this.execGit(['merge', '--ff-only', `origin/${branch}`], dir);
+          await this.time(timing, 'RepoPool.doRefreshMirrorForRebase.gitFastForwardCurrentBranch', { dir, branch }, () =>
+            this.execGit(['merge', '--ff-only', `origin/${branch}`], dir),
+          );
+        } else {
+          timing?.mark('RepoPool.doRefreshMirrorForRebase.gitFastForwardCurrentBranch', 'completed', {
+            dir,
+            branch,
+            skipped: true,
+            reason: 'detached-head',
+          });
         }
       } catch { /* non-ff or detached */ }
     } else {
       mkdirSync(this.cacheDir, { recursive: true });
-      await this.execGit(['clone', repoUrl, dir], this.cacheDir);
+      await this.time(timing, 'RepoPool.doRefreshMirrorForRebase.gitCloneMirror', { dir, repoUrl }, () =>
+        this.execGit(['clone', repoUrl, dir], this.cacheDir),
+      );
     }
     const runGit = (args: string[]) => this.execGit(args, dir);
-    await syncPlanBaseRemoteForRef(runGit, baseBranch);
+    await this.time(timing, 'RepoPool.doRefreshMirrorForRebase.syncPlanBaseRemoteForRef', { dir, baseBranch }, () =>
+      syncPlanBaseRemoteForRef(runGit, baseBranch),
+    );
     return dir;
   }
 
   /**
    * Remove Invoker-managed branches (experiment/*, invoker/*) from the mirror and linked worktrees.
    */
-  async removeManagedBranchesInMirror(repoUrl: string, branches: string[]): Promise<void> {
+  async removeManagedBranchesInMirror(repoUrl: string, branches: string[], timing?: RepoPoolTiming): Promise<void> {
     const prev = this.repoChains.get(repoUrl) ?? Promise.resolve();
-    const next = prev.then(() => this.doRemoveManagedBranchesInMirror(repoUrl, branches));
+    const queuedAtMs = Date.now();
+    const next = prev.then(() => {
+      timing?.mark('RepoPool.removeManagedBranchesInMirror.repoChainWait', 'completed', {
+        repoUrl,
+        branchCount: branches.length,
+        durationMs: Date.now() - queuedAtMs,
+      });
+      return this.doRemoveManagedBranchesInMirror(repoUrl, branches, timing);
+    });
     this.repoChains.set(repoUrl, next.catch(() => {}));
     return next;
   }
 
-  private async doRemoveManagedBranchesInMirror(repoUrl: string, branches: string[]): Promise<void> {
+  private async doRemoveManagedBranchesInMirror(repoUrl: string, branches: string[], timing?: RepoPoolTiming): Promise<void> {
     // Gated: with attemptId in branch hash, leftover refs cannot collide with
     // future attempts, so deletion is unnecessary. Set
     // INVOKER_ENABLE_WORKSPACE_CLEANUP=1 to restore the rebase-and-retry
     // branch sweep.
-    if (!isWorkspaceCleanupEnabled()) return;
+    if (!isWorkspaceCleanupEnabled()) {
+      timing?.mark('RepoPool.doRemoveManagedBranchesInMirror', 'completed', {
+        enabled: false,
+        branchCount: branches.length,
+      });
+      return;
+    }
     const dir = this.cloneDir(repoUrl);
-    if (!existsSync(dir) || !this.worktreeBaseDir) return;
+    if (!existsSync(dir) || !this.worktreeBaseDir) {
+      timing?.mark('RepoPool.doRemoveManagedBranchesInMirror', 'completed', {
+        enabled: true,
+        skipped: true,
+        reason: 'missing-dir-or-worktree-base',
+        branchCount: branches.length,
+      });
+      return;
+    }
     for (const branch of branches) {
       if (!isInvokerManagedPoolBranch(branch)) continue;
       const sanitized = sanitizeBranchForPath(branch);
       const wtPath = `${this.worktreeBaseDir}/${computeRepoUrlHash(repoUrl)}/${sanitized}`;
       try {
-        await this.execGit(['worktree', 'remove', '--force', wtPath], dir);
+        await this.time(timing, 'RepoPool.doRemoveManagedBranchesInMirror.gitWorktreeRemove', { dir, branch, wtPath }, () =>
+          this.execGit(['worktree', 'remove', '--force', wtPath], dir),
+        );
       } catch {
         /* not registered */
       }
@@ -140,11 +194,23 @@ export class RepoPool {
         } catch { /* */ }
       }
       try {
-        await this.execGit(['branch', '-D', branch], dir);
+        await this.time(timing, 'RepoPool.doRemoveManagedBranchesInMirror.gitBranchDelete', { dir, branch }, () =>
+          this.execGit(['branch', '-D', branch], dir),
+        );
       } catch {
         /* missing or checked out elsewhere */
       }
     }
+  }
+
+  private async time<T>(
+    timing: RepoPoolTiming | undefined,
+    functionName: string,
+    metadata: Record<string, unknown>,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    if (!timing) return fn();
+    return timing.span(functionName, metadata, fn);
   }
 
   async ensureClone(repoUrl: string): Promise<string> {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -18,7 +18,7 @@ import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/con
 import type { Executor, ExecutorHandle } from './executor.js';
 import { BaseExecutor } from './base-executor.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
-import { ResourceLimitError } from './repo-pool.js';
+import { ResourceLimitError, type RepoPoolTiming } from './repo-pool.js';
 import type { ExecutorRegistry } from './registry.js';
 import type { AgentRegistry } from './agent-registry.js';
 import type { MergeGateProvider } from './merge-gate-provider.js';
@@ -182,15 +182,25 @@ export class TaskRunner {
     workflowId: string,
     repoUrl: string | undefined,
     baseBranchHint: string | undefined,
+    timing?: RepoPoolTiming,
   ): Promise<void> {
     if (!repoUrl) return;
     const executor = this.executorRegistry.get('worktree');
     if (!(executor instanceof WorktreeExecutor)) return;
     const pool = executor.getRepoPool();
     const baseBranch = baseBranchHint?.trim() || this.defaultBranch || 'master';
-    await pool.refreshMirrorForRebase(repoUrl, baseBranch);
+    await pool.refreshMirrorForRebase(repoUrl, baseBranch, timing);
+    const collectStartedAtMs = Date.now();
+    timing?.mark('TaskRunner.preparePoolForRebaseRetry.collectManagedWorkflowBranches', 'started', {
+      workflowId,
+    });
     const branches = this.collectManagedWorkflowBranches(workflowId);
-    await pool.removeManagedBranchesInMirror(repoUrl, branches);
+    timing?.mark('TaskRunner.preparePoolForRebaseRetry.collectManagedWorkflowBranches', 'completed', {
+      workflowId,
+      branchCount: branches.length,
+      durationMs: Date.now() - collectStartedAtMs,
+    });
+    await pool.removeManagedBranchesInMirror(repoUrl, branches, timing);
   }
 
   /**


### PR DESCRIPTION
## Summary

Add persisted timing instrumentation for workflow recreate/rebase/retry mutations so slow resets can be explained from the existing task audit trail and logs. The timing spans cover mutation queue/drain/dispatch, preemption, action wrappers, scheduler top-up, and repo-pool git operations used by fresh-base recreate/rebase flows.

## Architecture

### Before

```mermaid
graph TD
    A[Workflow mutation intent] --> B[Coordinator dispatch]
    B --> C[Mutation handler]
    C --> D[Preempt / recreate / rebase / retry]
    D --> E[Dispatch runnable tasks]
    D --> F[Repo pool git prep]
    G[Task lifecycle events] -.-> H[Status-only audit trail]
```

### After

```mermaid
graph TD
    A[Workflow mutation intent] --> B[Coordinator timing context]
    B --> C[Mutation handler]
    C --> D[Preempt / recreate / rebase / retry spans]
    D --> E[Dispatch runnable task spans]
    D --> F[Repo pool git prep spans]
    B --> G[workflow.mutation.timing task events]
    B --> I[Structured logger fields]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-mutation-timing.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/persisted-workflow-mutation-coordinator.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts -t "recreateWorkflowFromFreshBase|recreateWithRebase|rebaseAndRetry"`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/repo-pool.test.ts -t "repoChains serialization"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 7ea3d8d`
- Post-revert steps: None
- Data migration? No
