### PR TITLE
Add Action Graph diagnostics view

### DIFF
--- a/packages/app/e2e/action-graph-visual-proof.spec.ts
+++ b/packages/app/e2e/action-graph-visual-proof.spec.ts
@@ -1,0 +1,26 @@
+import {
+  test,
+  expect,
+  TEST_PLAN,
+  captureScreenshot,
+} from './fixtures/electron-app.js';
+import { stringify as yamlStringify } from 'yaml';
+
+test.describe('Action Graph visual proof', () => {
+  test('action graph diagnostics view', async ({ page }) => {
+    await page.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(TEST_PLAN));
+    await page.waitForFunction(async () => {
+      const graph = await window.invoker.getActionGraph();
+      return graph.nodes.length > 0;
+    });
+
+    await page.getByTestId('rail-action-graph').click();
+    await expect(page.getByTestId('action-graph-view')).toBeVisible();
+    await expect(page.getByText('E2E Test Plan', { exact: true })).toBeVisible();
+    await expect(page.getByTestId('action-graph-node-attempt:wf-test-1/task-alpha')).toBeVisible();
+    await page.getByTestId('action-graph-node-attempt:wf-test-1/task-alpha').click();
+    await expect(page.getByTestId('workflow-inspector-title')).toHaveText('First test task');
+
+    await captureScreenshot(page, 'action-graph-diagnostics-view');
+  });
+});

--- a/packages/app/src/__tests__/action-graph-diagnostics.test.ts
+++ b/packages/app/src/__tests__/action-graph-diagnostics.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it } from 'vitest';
+import type { Attempt, TaskState } from '@invoker/workflow-core';
+import type { Workflow } from '@invoker/data-store';
+import {
+  buildActionGraphDiagnostics,
+  resolveActionDiagnosticsStallThresholdMs,
+} from '../action-graph-diagnostics.js';
+
+const now = new Date('2026-05-14T12:00:00.000Z');
+
+function task(overrides: Partial<TaskState> & { id: string }): TaskState {
+  return {
+    id: overrides.id,
+    description: overrides.description ?? overrides.id,
+    status: overrides.status ?? 'pending',
+    dependencies: overrides.dependencies ?? [],
+    createdAt: overrides.createdAt ?? new Date('2026-05-14T11:45:00.000Z'),
+    config: { workflowId: 'wf-1', ...(overrides.config ?? {}) },
+    execution: { generation: 0, ...(overrides.execution ?? {}) },
+    taskStateVersion: 1,
+  };
+}
+
+function attempt(overrides: Partial<Attempt> & { id: string; nodeId: string }): Attempt {
+  return {
+    id: overrides.id,
+    nodeId: overrides.nodeId,
+    queuePriority: overrides.queuePriority ?? 0,
+    status: overrides.status ?? 'pending',
+    upstreamAttemptIds: overrides.upstreamAttemptIds ?? [],
+    createdAt: overrides.createdAt ?? new Date('2026-05-14T11:40:00.000Z'),
+    ...overrides,
+  };
+}
+
+const workflow: Workflow = {
+  id: 'wf-1',
+  name: 'Workflow One',
+  status: 'running',
+  createdAt: '2026-05-14T11:30:00.000Z',
+  updatedAt: '2026-05-14T11:50:00.000Z',
+};
+
+describe('buildActionGraphDiagnostics', () => {
+  it('creates queued mutation action nodes with queue duration', () => {
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [],
+      attemptsByTaskId: new Map(),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [{
+        id: 7,
+        workflowId: 'wf-1',
+        channel: 'invoker:retry-workflow',
+        args: ['wf-1'],
+        priority: 'high',
+        status: 'queued',
+        createdAt: '2026-05-14T11:55:00.000Z',
+      }],
+      mutationLeases: [],
+      eventsByTaskId: new Map(),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    const intent = graph.nodes.find((node) => node.id === 'intent:7');
+    expect(intent?.type).toBe('mutation-intent');
+    expect(intent?.status).toBe('queued');
+    expect(intent?.durations?.queuedMs).toBe(5 * 60_000);
+    expect(graph.edges).toContainEqual(expect.objectContaining({ source: 'action:wf-1', target: 'intent:7' }));
+  });
+
+  it('marks expired mutation leases as stalled with heartbeat age', () => {
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [],
+      attemptsByTaskId: new Map(),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [],
+      mutationLeases: [{
+        workflowId: 'wf-1',
+        ownerId: 'owner',
+        activeIntentId: 2,
+        activeMutationKind: 'invoker:recreate-workflow',
+        leasedAt: '2026-05-14T11:57:00.000Z',
+        lastHeartbeatAt: '2026-05-14T11:58:00.000Z',
+        leaseExpiresAt: '2026-05-14T11:59:00.000Z',
+      }],
+      eventsByTaskId: new Map(),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    const lease = graph.nodes.find((node) => node.id === 'lease:wf-1');
+    expect(lease?.status).toBe('stalled');
+    expect(lease?.durations?.heartbeatAgeMs).toBe(2 * 60_000);
+  });
+
+  it('links pending downstream task attempts to upstream blocker nodes', () => {
+    const upstream = task({ id: 'upstream', status: 'failed' });
+    const downstream = task({ id: 'downstream', status: 'pending', dependencies: ['upstream'] });
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [upstream, downstream],
+      attemptsByTaskId: new Map([
+        ['downstream', [attempt({ id: 'downstream-a1', nodeId: 'downstream' })]],
+      ]),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [],
+      mutationLeases: [],
+      eventsByTaskId: new Map(),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    expect(graph.nodes.find((node) => node.id === 'blocker:downstream:dependency:upstream')).toEqual(
+      expect.objectContaining({ type: 'blocker', status: 'waiting' }),
+    );
+    expect(graph.edges).toContainEqual(expect.objectContaining({
+      source: 'blocker:downstream:dependency:upstream',
+      target: 'attempt:downstream-a1',
+    }));
+  });
+
+  it('creates blocker nodes for launch errors and missing workspaces', () => {
+    const failed = task({
+      id: 'launch-failed',
+      status: 'failed',
+      execution: { phase: 'launching', error: 'spawn failed: missing workspace' },
+    });
+    const graph = buildActionGraphDiagnostics({
+      workflows: [workflow],
+      tasks: [failed],
+      attemptsByTaskId: new Map(),
+      queueStatus: { maxConcurrency: 1, runningCount: 0, running: [], queued: [] },
+      mutationIntents: [],
+      mutationLeases: [],
+      eventsByTaskId: new Map(),
+      activityLogs: [],
+      stallThresholdMs: 60_000,
+      now,
+    });
+
+    expect(graph.nodes.find((node) => node.id === 'blocker:launch-failed:error')?.label).toBe('Launch failed');
+    expect(graph.nodes.find((node) => node.id === 'blocker:launch-failed:workspace')?.label).toBe('Missing workspace');
+  });
+});
+
+describe('resolveActionDiagnosticsStallThresholdMs', () => {
+  it('uses config before env and falls back to default', () => {
+    expect(resolveActionDiagnosticsStallThresholdMs({ actionDiagnostics: { stallThresholdMs: 12_000 } }, {
+      INVOKER_ACTION_STALL_THRESHOLD_MS: '5000',
+    })).toBe(12_000);
+    expect(resolveActionDiagnosticsStallThresholdMs({}, { INVOKER_ACTION_STALL_THRESHOLD_MS: '5000' })).toBe(5_000);
+    expect(resolveActionDiagnosticsStallThresholdMs({}, { INVOKER_ACTION_STALL_THRESHOLD_MS: 'bad' })).toBe(60_000);
+  });
+});
+

--- a/packages/app/src/action-graph-diagnostics.ts
+++ b/packages/app/src/action-graph-diagnostics.ts
@@ -1,0 +1,377 @@
+import type {
+  ActionGraphEdge,
+  ActionGraphHistoryEntry,
+  ActionGraphNode,
+  ActionGraphNodeStatus,
+  ActionGraphResponse,
+  ActivityLogEntry,
+  QueueStatus,
+} from '@invoker/contracts';
+import type { TaskEvent, WorkflowMutationIntent, WorkflowMutationLease } from '@invoker/data-store';
+import type { Attempt, TaskState } from '@invoker/workflow-core';
+import type { Workflow } from '@invoker/data-store';
+import type { InvokerConfig } from './config.js';
+
+const DEFAULT_STALL_THRESHOLD_MS = 60_000;
+
+export function resolveActionDiagnosticsStallThresholdMs(config: InvokerConfig, env = process.env): number {
+  const configured = config.actionDiagnostics?.stallThresholdMs;
+  if (typeof configured === 'number' && Number.isFinite(configured) && configured > 0) {
+    return Math.floor(configured);
+  }
+  const raw = env.INVOKER_ACTION_STALL_THRESHOLD_MS;
+  const parsed = raw ? Number(raw) : NaN;
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : DEFAULT_STALL_THRESHOLD_MS;
+}
+
+export interface ActionGraphDiagnosticsInput {
+  workflows: Workflow[];
+  tasks: TaskState[];
+  attemptsByTaskId: Map<string, Attempt[]>;
+  queueStatus: QueueStatus;
+  mutationIntents: WorkflowMutationIntent[];
+  mutationLeases: WorkflowMutationLease[];
+  eventsByTaskId: Map<string, TaskEvent[]>;
+  activityLogs: ActivityLogEntry[];
+  stallThresholdMs: number;
+  now?: Date;
+}
+
+function iso(value: Date | string | undefined): string | undefined {
+  if (!value) return undefined;
+  return value instanceof Date ? value.toISOString() : value;
+}
+
+function ageMs(nowMs: number, value: Date | string | undefined): number | undefined {
+  const timestamp = value instanceof Date ? value.getTime() : value ? Date.parse(value) : NaN;
+  if (!Number.isFinite(timestamp)) return undefined;
+  return Math.max(0, nowMs - timestamp);
+}
+
+function taskStatusToActionStatus(status: TaskState['status']): ActionGraphNodeStatus {
+  switch (status) {
+    case 'completed':
+    case 'failed':
+    case 'running':
+    case 'pending':
+      return status;
+    case 'blocked':
+    case 'needs_input':
+    case 'awaiting_approval':
+    case 'review_ready':
+      return 'waiting';
+    case 'stale':
+      return 'cancelled';
+    case 'fixing_with_ai':
+      return 'running';
+  }
+}
+
+function attemptStatusToActionStatus(status: Attempt['status']): ActionGraphNodeStatus {
+  switch (status) {
+    case 'completed':
+    case 'failed':
+    case 'running':
+    case 'pending':
+      return status;
+    case 'claimed':
+      return 'queued';
+    case 'needs_input':
+      return 'waiting';
+    case 'superseded':
+      return 'cancelled';
+  }
+}
+
+function edgeId(source: string, target: string, label?: string): string {
+  return `${source}->${target}${label ? `:${label}` : ''}`;
+}
+
+function compactHistory(events: TaskEvent[], activityLogs: ActivityLogEntry[]): ActionGraphHistoryEntry[] {
+  const taskEvents = events.slice(-20).map((event) => ({
+    id: `event:${event.id}`,
+    timestamp: event.createdAt,
+    source: event.eventType,
+    message: event.payload ?? event.eventType,
+  }));
+  const logs = activityLogs.slice(-10).map((entry) => ({
+    id: `activity:${entry.id}`,
+    timestamp: entry.timestamp,
+    source: entry.source,
+    level: entry.level,
+    message: entry.message,
+  }));
+  return [...taskEvents, ...logs].sort((a, b) => a.timestamp.localeCompare(b.timestamp)).slice(-25);
+}
+
+function addBlocker(
+  nodes: ActionGraphNode[],
+  edges: ActionGraphEdge[],
+  blocker: ActionGraphNode,
+  targetId: string,
+  label = 'blocks',
+): void {
+  if (!nodes.some((node) => node.id === blocker.id)) {
+    nodes.push(blocker);
+  }
+  edges.push({ id: edgeId(blocker.id, targetId, label), source: blocker.id, target: targetId, label });
+}
+
+export function buildActionGraphDiagnostics(input: ActionGraphDiagnosticsInput): ActionGraphResponse {
+  const now = input.now ?? new Date();
+  const nowMs = now.getTime();
+  const nodes: ActionGraphNode[] = [];
+  const edges: ActionGraphEdge[] = [];
+  const tasksById = new Map(input.tasks.map((task) => [task.id, task]));
+  const workflowsById = new Map(input.workflows.map((workflow) => [workflow.id, workflow]));
+  const runningQueueIds = new Set(input.queueStatus.running.map((item) => item.taskId));
+  const queuedQueueIds = new Set(input.queueStatus.queued.map((item) => item.taskId));
+
+  for (const workflow of input.workflows) {
+    const actionId = `action:${workflow.id}`;
+    nodes.push({
+      id: actionId,
+      type: 'user-action',
+      label: workflow.name || workflow.id,
+      status: taskStatusToActionStatus(workflow.status as TaskState['status']),
+      workflowId: workflow.id,
+      createdAt: workflow.createdAt,
+      completedAt: workflow.status === 'completed' || workflow.status === 'failed' ? workflow.updatedAt : undefined,
+      durations: workflow.status === 'pending'
+        ? { pendingMs: ageMs(nowMs, workflow.createdAt) }
+        : workflow.status === 'running'
+          ? { runningMs: ageMs(nowMs, workflow.updatedAt) }
+          : undefined,
+      details: {
+        baseBranch: workflow.baseBranch,
+        featureBranch: workflow.featureBranch,
+        mergeMode: workflow.mergeMode,
+      },
+      suggestedNextAction: workflow.status === 'failed' ? 'Inspect failed task blockers before retrying the workflow.' : undefined,
+    });
+  }
+
+  for (const intent of input.mutationIntents) {
+    const id = `intent:${intent.id}`;
+    const status = intent.status === 'running' || intent.status === 'queued' || intent.status === 'completed'
+      ? intent.status
+      : 'failed';
+    nodes.push({
+      id,
+      type: 'mutation-intent',
+      label: intent.channel,
+      status,
+      workflowId: intent.workflowId,
+      intentId: intent.id,
+      priority: intent.priority === 'high' ? 1 : 0,
+      ownerId: intent.ownerId,
+      createdAt: intent.createdAt,
+      startedAt: intent.startedAt,
+      completedAt: intent.completedAt,
+      latestError: intent.error,
+      durations: {
+        queuedMs: intent.status === 'queued' ? ageMs(nowMs, intent.createdAt) : undefined,
+        runningMs: intent.status === 'running' ? ageMs(nowMs, intent.startedAt) : undefined,
+      },
+      details: { args: intent.args, priority: intent.priority },
+      suggestedNextAction: intent.status === 'failed' ? 'Open the history expander and inspect the failed mutation error.' : undefined,
+    });
+    const workflowNodeId = `action:${intent.workflowId}`;
+    if (workflowsById.has(intent.workflowId)) {
+      edges.push({ id: edgeId(workflowNodeId, id, 'mutation'), source: workflowNodeId, target: id, label: 'mutation' });
+    }
+  }
+
+  for (const lease of input.mutationLeases) {
+    const heartbeatAge = ageMs(nowMs, lease.lastHeartbeatAt);
+    const expiresAtMs = Date.parse(lease.leaseExpiresAt);
+    const expired = Number.isFinite(expiresAtMs) && expiresAtMs <= nowMs;
+    const heartbeatStalled = heartbeatAge !== undefined && heartbeatAge > input.stallThresholdMs;
+    const status: ActionGraphNodeStatus = expired || heartbeatStalled ? 'stalled' : 'running';
+    const id = `lease:${lease.workflowId}`;
+    nodes.push({
+      id,
+      type: 'mutation-lease',
+      label: lease.activeMutationKind ?? `Lease ${lease.workflowId}`,
+      status,
+      workflowId: lease.workflowId,
+      intentId: lease.activeIntentId,
+      ownerId: lease.ownerId,
+      createdAt: lease.leasedAt,
+      heartbeatAt: lease.lastHeartbeatAt,
+      leaseExpiresAt: lease.leaseExpiresAt,
+      durations: {
+        heartbeatAgeMs: heartbeatAge,
+        leaseExpiresInMs: Number.isFinite(expiresAtMs) ? expiresAtMs - nowMs : undefined,
+        stalledMs: status === 'stalled' ? Math.max(0, heartbeatAge ?? nowMs - expiresAtMs) : undefined,
+      },
+      suggestedNextAction: status === 'stalled' ? 'Refresh or restart the owner process so expired mutation work can be requeued.' : undefined,
+    });
+    const source = lease.activeIntentId ? `intent:${lease.activeIntentId}` : `action:${lease.workflowId}`;
+    edges.push({ id: edgeId(source, id, 'lease'), source, target: id, label: 'lease' });
+  }
+
+  for (const task of input.tasks) {
+    const workflowId = task.config.workflowId;
+    const actionId = workflowId ? `action:${workflowId}` : undefined;
+    const attempts = input.attemptsByTaskId.get(task.id) ?? [];
+    const selectedAttemptId = task.execution.selectedAttemptId ?? attempts.at(-1)?.id ?? task.id;
+    const selectedNodeId = `attempt:${selectedAttemptId}`;
+    const taskEvents = input.eventsByTaskId.get(task.id) ?? [];
+
+    for (const attempt of attempts.length > 0 ? attempts : [{
+      id: selectedAttemptId,
+      nodeId: task.id,
+      queuePriority: 0,
+      status: task.status === 'running' ? 'running' : task.status === 'completed' ? 'completed' : task.status === 'failed' ? 'failed' : 'pending',
+      upstreamAttemptIds: [],
+      createdAt: task.createdAt,
+      startedAt: task.execution.startedAt,
+      completedAt: task.execution.completedAt,
+      error: task.execution.error,
+      lastHeartbeatAt: task.execution.lastHeartbeatAt,
+      leaseExpiresAt: undefined,
+      workspacePath: task.execution.workspacePath,
+      agentSessionId: task.execution.agentSessionId,
+    } satisfies Attempt]) {
+      const heartbeatAge = ageMs(nowMs, attempt.lastHeartbeatAt);
+      const leaseExpiresAtMs = attempt.leaseExpiresAt?.getTime() ?? NaN;
+      const stalled = (attempt.status === 'running' || attempt.status === 'claimed') && (
+        (Number.isFinite(leaseExpiresAtMs) && leaseExpiresAtMs <= nowMs) ||
+        (heartbeatAge !== undefined && heartbeatAge > input.stallThresholdMs)
+      );
+      const nodeId = `attempt:${attempt.id}`;
+      nodes.push({
+        id: nodeId,
+        type: 'task-attempt',
+        label: task.description,
+        status: stalled ? 'stalled' : attemptStatusToActionStatus(attempt.status),
+        workflowId,
+        taskId: task.id,
+        attemptId: attempt.id,
+        priority: attempt.queuePriority,
+        createdAt: iso(attempt.createdAt),
+        startedAt: iso(attempt.startedAt),
+        completedAt: iso(attempt.completedAt),
+        heartbeatAt: iso(attempt.lastHeartbeatAt),
+        leaseExpiresAt: iso(attempt.leaseExpiresAt),
+        latestError: attempt.error ?? task.execution.error,
+        history: attempt.id === selectedAttemptId ? compactHistory(taskEvents, input.activityLogs) : undefined,
+        durations: {
+          queuedMs: queuedQueueIds.has(task.id) ? ageMs(nowMs, attempt.createdAt) : undefined,
+          pendingMs: task.status === 'pending' ? ageMs(nowMs, task.createdAt) : undefined,
+          runningMs: attempt.status === 'running' ? ageMs(nowMs, attempt.startedAt) : undefined,
+          heartbeatAgeMs: heartbeatAge,
+          stalledMs: stalled ? heartbeatAge ?? ageMs(nowMs, attempt.startedAt) : undefined,
+        },
+        details: {
+          taskStatus: task.status,
+          phase: task.execution.phase,
+          workspacePath: attempt.workspacePath ?? task.execution.workspacePath,
+          agentSessionId: attempt.agentSessionId ?? task.execution.agentSessionId,
+          upstreamAttemptIds: attempt.upstreamAttemptIds,
+        },
+        suggestedNextAction: stalled
+          ? 'Check the terminal session or retry the task if the process is no longer alive.'
+          : task.status === 'failed'
+            ? 'Open the task logs, then retry or fix with an agent.'
+            : undefined,
+      });
+
+      for (const upstreamAttemptId of attempt.upstreamAttemptIds) {
+        edges.push({
+          id: edgeId(`attempt:${upstreamAttemptId}`, nodeId, 'upstream'),
+          source: `attempt:${upstreamAttemptId}`,
+          target: nodeId,
+          label: 'upstream',
+        });
+      }
+    }
+
+    if (actionId && workflowsById.has(workflowId ?? '')) {
+      edges.push({ id: edgeId(actionId, selectedNodeId, 'task'), source: actionId, target: selectedNodeId, label: 'task' });
+    }
+
+    if (runningQueueIds.has(task.id) || queuedQueueIds.has(task.id)) {
+      const queueItem = input.queueStatus.queued.find((item) => item.taskId === task.id);
+      const schedulerId = `scheduler:${task.id}`;
+      nodes.push({
+        id: schedulerId,
+        type: 'scheduler-job',
+        label: task.description,
+        status: runningQueueIds.has(task.id) ? 'running' : 'queued',
+        workflowId,
+        taskId: task.id,
+        priority: queueItem?.priority ?? 0,
+        createdAt: iso(task.createdAt),
+        durations: {
+          queuedMs: queuedQueueIds.has(task.id) ? ageMs(nowMs, task.createdAt) : undefined,
+          runningMs: runningQueueIds.has(task.id) ? ageMs(nowMs, task.execution.startedAt) : undefined,
+        },
+        details: { maxConcurrency: input.queueStatus.maxConcurrency },
+      });
+      edges.push({ id: edgeId(schedulerId, selectedNodeId, 'dispatch'), source: schedulerId, target: selectedNodeId, label: 'dispatch' });
+    }
+
+    if (task.execution.error) {
+      addBlocker(nodes, edges, {
+        id: `blocker:${task.id}:error`,
+        type: 'blocker',
+        label: task.execution.phase === 'launching' ? 'Launch failed' : 'Task error',
+        status: 'failed',
+        workflowId,
+        taskId: task.id,
+        latestError: task.execution.error,
+        createdAt: iso(task.execution.completedAt ?? task.createdAt),
+        suggestedNextAction: 'Inspect the error details and retry once the root cause is fixed.',
+      }, selectedNodeId);
+    }
+
+    if ((task.status === 'running' || task.status === 'failed') && !task.execution.workspacePath && task.config.runnerKind !== 'merge') {
+      addBlocker(nodes, edges, {
+        id: `blocker:${task.id}:workspace`,
+        type: 'blocker',
+        label: 'Missing workspace',
+        status: 'waiting',
+        workflowId,
+        taskId: task.id,
+        latestError: 'No workspace path is recorded for this task.',
+        suggestedNextAction: 'Retry the task to reprovision its workspace.',
+      }, selectedNodeId);
+    }
+
+    if (task.status === 'pending') {
+      const blockerIds: string[] = [];
+      for (const dependencyId of task.dependencies) {
+        const dependency = tasksById.get(dependencyId);
+        if (dependency?.status === 'completed') continue;
+        const blockerId = `blocker:${task.id}:dependency:${dependencyId}`;
+        blockerIds.push(blockerId);
+        addBlocker(nodes, edges, {
+          id: blockerId,
+          type: 'blocker',
+          label: dependency ? `Waiting for ${dependency.description}` : `Missing dependency ${dependencyId}`,
+          status: 'waiting',
+          workflowId,
+          taskId: task.id,
+          details: { dependencyId, dependencyStatus: dependency?.status ?? 'missing' },
+          suggestedNextAction: dependency ? 'Resolve the upstream task first.' : 'Check whether the plan references a deleted task.',
+        }, selectedNodeId);
+      }
+      const selectedNode = nodes.find((node) => node.id === selectedNodeId);
+      if (selectedNode && blockerIds.length > 0) {
+        selectedNode.blockerIds = [...(selectedNode.blockerIds ?? []), ...blockerIds];
+        selectedNode.status = 'waiting';
+        selectedNode.durations = { ...selectedNode.durations, waitingMs: ageMs(nowMs, task.createdAt) };
+      }
+    }
+  }
+
+  const uniqueEdges = new Map(edges.map((edge) => [edge.id, edge]));
+  return {
+    generatedAt: now.toISOString(),
+    stallThresholdMs: input.stallThresholdMs,
+    nodes,
+    edges: [...uniqueEdges.values()],
+  };
+}

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -43,6 +43,14 @@ export interface InvokerConfig {
    * then to the built-in default agent.
    */
   autoFixAgent?: string;
+  /**
+   * Read-only diagnostics tuning for the Action Graph view.
+   * Default stall threshold: 60000ms. Env fallback:
+   * INVOKER_ACTION_STALL_THRESHOLD_MS.
+   */
+  actionDiagnostics?: {
+    stallThresholdMs?: number;
+  };
   /** Cursor CLI subprocess timeout for plan conversations in seconds. Default: 7200 (2 hours). */
   planningTimeoutSeconds?: number;
   /** Interval for heartbeat messages posted to Slack during planning in seconds. Default: 120 (2 minutes). Set to 0 to disable. */

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -149,6 +149,10 @@ import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
 import { evaluateExecutingStall } from './executing-stall.js';
 import { listOpenFixIntentsForTask } from './auto-fix-intents.js';
 import { persistShutdownDiagnostic } from './shutdown-diagnostic.js';
+import {
+  buildActionGraphDiagnostics,
+  resolveActionDiagnosticsStallThresholdMs,
+} from './action-graph-diagnostics.js';
 
 declare const __BUILD_SHA__: string | undefined;
 declare const __BUILD_VERSION__: string | undefined;
@@ -3162,6 +3166,23 @@ if (isHeadless) {
 
     ipcMain.handle('invoker:get-queue-status', () => {
       return orchestrator.getQueueStatus();
+    });
+
+    ipcMain.handle('invoker:get-action-graph', () => {
+      orchestrator.syncAllFromDb();
+      const tasks = orchestrator.getAllTasks();
+      const workflows = persistence.listWorkflows();
+      return buildActionGraphDiagnostics({
+        workflows,
+        tasks,
+        attemptsByTaskId: new Map(tasks.map((task) => [task.id, persistence.loadAttempts(task.id)])),
+        queueStatus: orchestrator.getQueueStatus(),
+        mutationIntents: persistence.listWorkflowMutationIntents(),
+        mutationLeases: persistence.listWorkflowMutationLeases(),
+        eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
+        activityLogs: persistence.getActivityLogs(0, 200),
+        stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
+      });
     });
 
     ipcMain.handle('invoker:report-ui-perf', (_event, metric: string, data?: Record<string, unknown>) => {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -105,6 +105,80 @@ export interface QueueStatus {
   queued: Array<{ taskId: string; priority: number; description: string }>;
 }
 
+export type ActionGraphNodeType =
+  | 'user-action'
+  | 'mutation-intent'
+  | 'mutation-lease'
+  | 'scheduler-job'
+  | 'task-attempt'
+  | 'blocker';
+
+export type ActionGraphNodeStatus =
+  | 'queued'
+  | 'pending'
+  | 'running'
+  | 'waiting'
+  | 'stalled'
+  | 'failed'
+  | 'cancelled'
+  | 'completed';
+
+export interface ActionGraphHistoryEntry {
+  id: string;
+  timestamp: string;
+  source: string;
+  message: string;
+  level?: string;
+}
+
+export interface ActionGraphNodeDurations {
+  queuedMs?: number;
+  pendingMs?: number;
+  runningMs?: number;
+  waitingMs?: number;
+  stalledMs?: number;
+  heartbeatAgeMs?: number;
+  leaseExpiresInMs?: number;
+}
+
+export interface ActionGraphNode {
+  id: string;
+  type: ActionGraphNodeType;
+  label: string;
+  status: ActionGraphNodeStatus;
+  workflowId?: string;
+  taskId?: string;
+  attemptId?: string;
+  intentId?: number;
+  priority?: number;
+  ownerId?: string;
+  createdAt?: string;
+  startedAt?: string;
+  completedAt?: string;
+  heartbeatAt?: string;
+  leaseExpiresAt?: string;
+  latestError?: string;
+  details?: Record<string, unknown>;
+  durations?: ActionGraphNodeDurations;
+  blockerIds?: string[];
+  suggestedNextAction?: string;
+  history?: ActionGraphHistoryEntry[];
+}
+
+export interface ActionGraphEdge {
+  id: string;
+  source: string;
+  target: string;
+  label?: string;
+}
+
+export interface ActionGraphResponse {
+  generatedAt: string;
+  stallThresholdMs: number;
+  nodes: ActionGraphNode[];
+  edges: ActionGraphEdge[];
+}
+
 export interface ResumeWorkflowResult {
   workflow: { id: string; name: string; status: string };
   taskCount: number;
@@ -385,6 +459,10 @@ export const IpcChannels = {
   'invoker:get-queue-status': {} as {
     request: [];
     response: QueueStatus;
+  },
+  'invoker:get-action-graph': {} as {
+    request: [];
+    response: ActionGraphResponse;
   },
   'invoker:get-remote-targets': {} as {
     request: [];

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -12,6 +12,7 @@
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
 import yaml from 'js-yaml';
 import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowStatus } from './types.js';
+import type { ActionGraphNode } from '@invoker/contracts';
 import { useTasks } from './hooks/useTasks.js';
 import { useInvoker } from './hooks/useInvoker.js';
 import { TaskDAG } from './components/TaskDAG.js';
@@ -26,6 +27,7 @@ import { ReplaceTaskModal } from './components/ReplaceTaskModal.js';
 import { SystemSetupModal } from './components/SystemSetupModal.js';
 import { WorkflowGraph } from './components/WorkflowGraph.js';
 import { WorkflowInspector } from './components/WorkflowInspector.js';
+import { ActionGraphView } from './components/ActionGraphView.js';
 import { WorkflowStatusChips } from './components/WorkflowStatusChips.js';
 import { TerminalDrawer } from './components/TerminalDrawer.js';
 import {
@@ -227,7 +229,8 @@ export function App() {
   const [hasStarted, setHasStarted] = useState(false);
   const [planName, setPlanName] = useState<string | null>(null);
   const [onFinish, setOnFinish] = useState<'none' | 'merge' | 'pull_request'>('merge');
-  const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue'>('dag');
+  const [viewMode, setViewMode] = useState<'dag' | 'history' | 'timeline' | 'queue' | 'actionGraph'>('dag');
+  const [selectedActionNode, setSelectedActionNode] = useState<ActionGraphNode | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; taskId: string } | null>(null);
   const [remoteTargets, setRemoteTargets] = useState<string[]>([]);
   const [executionAgents, setExecutionAgents] = useState<string[]>([]);
@@ -977,6 +980,17 @@ export function App() {
               History
             </button>
             <button
+              data-testid="rail-action-graph"
+              onClick={() => {
+                setViewMode('actionGraph');
+                setWorkflowSelectionDismissed(true);
+                setSelectedTaskId(null);
+              }}
+              className={`w-full rounded px-2 py-1.5 text-left text-xs ${viewMode === 'actionGraph' ? 'bg-gray-800 text-white' : 'text-gray-300 hover:bg-gray-800/70'}`}
+            >
+              Action Graph
+            </button>
+            <button
               data-testid="rail-queue"
               onClick={() => {
                 setViewMode('queue');
@@ -1041,6 +1055,15 @@ export function App() {
                 <HistoryView onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
               ) : viewMode === 'timeline' ? (
                 <TimelineView tasks={tasks} onTaskClick={handleTaskClick} selectedTaskId={selectedTaskId} />
+              ) : viewMode === 'actionGraph' ? (
+                <ActionGraphView
+                  selectedNodeId={selectedActionNode?.id ?? null}
+                  onSelectNode={(node) => {
+                    setSelectedActionNode(node);
+                    if (node?.taskId) setSelectedTaskId(node.taskId);
+                    if (node?.workflowId) setSelectedWorkflowId(node.workflowId);
+                  }}
+                />
               ) : (
                 <>
                   <WorkflowGraph
@@ -1100,6 +1123,7 @@ export function App() {
               executionAgents={executionAgents}
               collapsed={inspectorCollapsed}
               advancedExpanded={advancedMetadataExpanded}
+              actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
               onEditType={handleEditType}
               onEditAgent={handleEditAgent}
               onEditPrompt={handleEditPrompt}

--- a/packages/ui/src/__tests__/action-graph-view.test.tsx
+++ b/packages/ui/src/__tests__/action-graph-view.test.tsx
@@ -1,0 +1,65 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ActionGraphResponse } from '@invoker/contracts';
+import { ActionGraphView } from '../components/ActionGraphView.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const graph: ActionGraphResponse = {
+  generatedAt: '2026-05-14T12:00:00.000Z',
+  stallThresholdMs: 60_000,
+  nodes: [
+    {
+      id: 'intent:1',
+      type: 'mutation-intent',
+      label: 'invoker:retry-workflow',
+      status: 'queued',
+      workflowId: 'wf-1',
+      durations: { queuedMs: 14 * 60_000 },
+      history: [{ id: 'h1', timestamp: '2026-05-14T11:46:00.000Z', source: 'test', message: 'queued' }],
+    },
+    {
+      id: 'attempt:task-a-a1',
+      type: 'task-attempt',
+      label: 'Task A',
+      status: 'running',
+      taskId: 'task-a',
+      workflowId: 'wf-1',
+      durations: { heartbeatAgeMs: 8_000 },
+    },
+  ],
+  edges: [{ id: 'intent:1->attempt:task-a-a1', source: 'intent:1', target: 'attempt:task-a-a1' }],
+};
+
+describe('ActionGraphView', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    window.invoker = {
+      getActionGraph: vi.fn().mockResolvedValue(graph),
+    } as any;
+  });
+
+  it('renders action graph nodes with duration badges', async () => {
+    render(<ActionGraphView selectedNodeId={null} onSelectNode={() => {}} />);
+
+    expect(await screen.findByTestId('action-graph-view')).toBeInTheDocument();
+    expect(screen.getByText('invoker:retry-workflow')).toBeInTheDocument();
+    expect(screen.getByText('queued 14m')).toBeInTheDocument();
+    expect(screen.getByText('heartbeat 8s ago')).toBeInTheDocument();
+    expect(screen.getByTestId('rf__edge-intent:1->attempt:task-a-a1')).toHaveAttribute('data-source', 'intent:1');
+    expect(screen.getByTestId('rf__edge-intent:1->attempt:task-a-a1')).toHaveAttribute('data-target', 'attempt:task-a-a1');
+  });
+
+  it('selecting a node notifies the inspector owner', async () => {
+    const onSelectNode = vi.fn();
+    render(<ActionGraphView selectedNodeId={null} onSelectNode={onSelectNode} />);
+
+    await waitFor(() => expect(screen.getByTestId('rf__node-intent:1')).toBeInTheDocument());
+    fireEvent.click(screen.getByTestId('rf__node-intent:1'));
+
+    expect(onSelectNode).toHaveBeenCalledWith(expect.objectContaining({ id: 'intent:1' }));
+  });
+});

--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -43,6 +43,14 @@ export function createReactFlowMock() {
 
     return (
       <div data-testid="mock-react-flow" className="react-flow">
+        {props.edges?.map((edge: any) => (
+          <div
+            key={edge.id}
+            data-testid={`rf__edge-${edge.id}`}
+            data-source={edge.source}
+            data-target={edge.target}
+          />
+        ))}
         {nodes.map((node) => {
           const NodeComponent = nodeTypes[node.type ?? ''];
           return (

--- a/packages/ui/src/components/ActionGraphView.tsx
+++ b/packages/ui/src/components/ActionGraphView.tsx
@@ -1,0 +1,245 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  Background,
+  Controls,
+  Handle,
+  MarkerType,
+  Position,
+  ReactFlow,
+  ReactFlowProvider,
+  type Edge,
+  type Node,
+} from '@xyflow/react';
+import '@xyflow/react/dist/style.css';
+import type { ActionGraphNode, ActionGraphResponse } from '@invoker/contracts';
+import { BundledEdge } from './BundledEdge.js';
+
+interface ActionGraphViewProps {
+  selectedNodeId: string | null;
+  onSelectNode: (node: ActionGraphNode | null) => void;
+}
+
+const NODE_WIDTH = 230;
+const X_GAP = 320;
+const Y_GAP = 140;
+const EDGE_SPACING = 18;
+
+const statusClasses: Record<ActionGraphNode['status'], string> = {
+  queued: 'border-amber-500/70 bg-amber-950/35 text-amber-100',
+  pending: 'border-gray-600 bg-gray-800 text-gray-200',
+  running: 'border-blue-500/70 bg-blue-950/35 text-blue-100',
+  waiting: 'border-violet-500/70 bg-violet-950/35 text-violet-100',
+  stalled: 'border-orange-500/80 bg-orange-950/45 text-orange-100',
+  failed: 'border-red-500/80 bg-red-950/45 text-red-100',
+  cancelled: 'border-gray-600 bg-gray-800/60 text-gray-400',
+  completed: 'border-green-500/70 bg-green-950/35 text-green-100',
+};
+
+const typeOrder: Record<ActionGraphNode['type'], number> = {
+  'user-action': 0,
+  'mutation-intent': 1,
+  'mutation-lease': 2,
+  'scheduler-job': 2,
+  'task-attempt': 3,
+  blocker: 4,
+};
+
+function formatDuration(ms: number | undefined): string | null {
+  if (ms === undefined || !Number.isFinite(ms)) return null;
+  const abs = Math.max(0, Math.abs(ms));
+  if (abs < 1_000) return `${Math.round(abs)}ms`;
+  if (abs < 60_000) return `${Math.round(abs / 1_000)}s`;
+  if (abs < 3_600_000) return `${Math.round(abs / 60_000)}m`;
+  return `${Math.round(abs / 3_600_000)}h`;
+}
+
+function primaryDurationLabel(node: ActionGraphNode): string {
+  const durations = node.durations ?? {};
+  if (node.status === 'queued') return `queued ${formatDuration(durations.queuedMs) ?? ''}`.trim();
+  if (node.status === 'pending') return `pending ${formatDuration(durations.pendingMs) ?? ''}`.trim();
+  if (node.status === 'waiting') return `waiting ${formatDuration(durations.waitingMs) ?? ''}`.trim();
+  if (node.status === 'stalled') return `stalled ${formatDuration(durations.stalledMs) ?? ''}`.trim();
+  if (node.status === 'running' && durations.heartbeatAgeMs !== undefined) {
+    return `heartbeat ${formatDuration(durations.heartbeatAgeMs)} ago`;
+  }
+  if (node.status === 'running') return `running ${formatDuration(durations.runningMs) ?? ''}`.trim();
+  return node.status;
+}
+
+function ActionNode({ data }: { data: { node: ActionGraphNode; selected: boolean } }): JSX.Element {
+  const node = data.node;
+  const className = statusClasses[node.status];
+  return (
+    <div
+      className={`relative w-[230px] rounded border px-3 py-2 shadow-sm ${className} ${data.selected ? 'ring-2 ring-white/70' : ''}`}
+      data-testid={`action-graph-node-${node.id}`}
+    >
+      <Handle
+        type="target"
+        position={Position.Left}
+        className="!h-2.5 !w-2.5 !border !border-gray-950 !bg-slate-300"
+      />
+      <div className="flex items-center justify-between gap-2">
+        <div className="truncate text-xs font-semibold">{node.label}</div>
+        <span className="shrink-0 rounded border border-current/30 px-1.5 py-0.5 text-[10px] uppercase">
+          {node.status}
+        </span>
+      </div>
+      <div className="mt-1 flex items-center justify-between gap-2 text-[11px] opacity-80">
+        <span className="truncate">{node.type.replace('-', ' ')}</span>
+        <span className="shrink-0">{primaryDurationLabel(node)}</span>
+      </div>
+      {node.latestError && (
+        <div className="mt-1 truncate text-[11px] text-red-100/90">{node.latestError}</div>
+      )}
+      <Handle
+        type="source"
+        position={Position.Right}
+        className="!h-2.5 !w-2.5 !border !border-gray-950 !bg-slate-300"
+      />
+    </div>
+  );
+}
+
+const nodeTypes = { actionNode: ActionNode };
+const edgeTypes = { bundled: BundledEdge };
+
+function layoutGraph(graph: ActionGraphResponse | null, selectedNodeId: string | null): { nodes: Node[]; edges: Edge[] } {
+  if (!graph) return { nodes: [], edges: [] };
+  const buckets = new Map<number, ActionGraphNode[]>();
+  const nodesById = new Map(graph.nodes.map((node) => [node.id, node]));
+  for (const node of graph.nodes) {
+    const level = typeOrder[node.type] ?? 0;
+    const items = buckets.get(level) ?? [];
+    items.push(node);
+    buckets.set(level, items);
+  }
+
+  const nodes: Node[] = [];
+  for (const [level, bucket] of [...buckets.entries()].sort(([a], [b]) => a - b)) {
+    bucket
+      .sort((a, b) => (a.workflowId ?? '').localeCompare(b.workflowId ?? '') || a.label.localeCompare(b.label))
+      .forEach((node, index) => {
+        nodes.push({
+          id: node.id,
+          type: 'actionNode',
+          position: { x: level * X_GAP + 40, y: index * Y_GAP + 40 },
+          data: { node, selected: node.id === selectedNodeId },
+          style: { width: NODE_WIDTH },
+        });
+      });
+  }
+
+  const sourceOutCount = new Map<string, number>();
+  const targetInCount = new Map<string, number>();
+  for (const edge of graph.edges) {
+    sourceOutCount.set(edge.source, (sourceOutCount.get(edge.source) ?? 0) + 1);
+    targetInCount.set(edge.target, (targetInCount.get(edge.target) ?? 0) + 1);
+  }
+
+  const sourceOutIndex = new Map<string, number>();
+  const targetInIndex = new Map<string, number>();
+  const edges: Edge[] = graph.edges.map((edge) => {
+    const srcTotal = sourceOutCount.get(edge.source) ?? 1;
+    const srcIdx = sourceOutIndex.get(edge.source) ?? 0;
+    sourceOutIndex.set(edge.source, srcIdx + 1);
+
+    const tgtTotal = targetInCount.get(edge.target) ?? 1;
+    const tgtIdx = targetInIndex.get(edge.target) ?? 0;
+    targetInIndex.set(edge.target, tgtIdx + 1);
+
+    const sourceOffset = srcTotal > 1 ? (srcIdx - (srcTotal - 1) / 2) * EDGE_SPACING : 0;
+    const targetOffset = tgtTotal > 1 ? (tgtIdx - (tgtTotal - 1) / 2) * EDGE_SPACING : 0;
+    const sourceStatus = nodesById.get(edge.source)?.status ?? 'pending';
+    const targetStatus = nodesById.get(edge.target)?.status ?? 'pending';
+
+    return {
+      id: edge.id,
+      source: edge.source,
+      target: edge.target,
+      type: 'bundled',
+      markerEnd: { type: MarkerType.ArrowClosed, color: 'rgba(203, 213, 225, 0.9)' },
+      style: { stroke: 'rgba(203, 213, 225, 0.9)', strokeWidth: 2 },
+      data: {
+        sourceOffset,
+        targetOffset,
+        sourceStatus,
+        targetStatus,
+        label: edge.label,
+        hoverStroke: '#f8fafc',
+        hoverWidth: 3,
+      },
+    };
+  });
+
+  return { nodes, edges };
+}
+
+function ActionGraphInner({ selectedNodeId, onSelectNode }: ActionGraphViewProps): JSX.Element {
+  const [graph, setGraph] = useState<ActionGraphResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    const load = () => {
+      window.invoker?.getActionGraph?.()
+        .then((response) => {
+          if (!alive) return;
+          setGraph(response);
+          setError(null);
+        })
+        .catch((err) => {
+          if (!alive) return;
+          setError(err instanceof Error ? err.message : String(err));
+        });
+    };
+    load();
+    const interval = setInterval(load, 5_000);
+    return () => {
+      alive = false;
+      clearInterval(interval);
+    };
+  }, []);
+
+  const rendered = useMemo(() => layoutGraph(graph, selectedNodeId), [graph, selectedNodeId]);
+
+  if (error) {
+    return <div className="h-full p-4 text-sm text-red-300">Action Graph failed to load: {error}</div>;
+  }
+  if (!graph) {
+    return <div className="h-full flex items-center justify-center text-sm text-gray-500">Loading Action Graph</div>;
+  }
+  if (graph.nodes.length === 0) {
+    return <div className="h-full flex items-center justify-center text-sm text-gray-500">No actions recorded</div>;
+  }
+
+  return (
+    <div className="h-full" data-testid="action-graph-view">
+      <ReactFlow
+        nodes={rendered.nodes}
+        edges={rendered.edges}
+        nodeTypes={nodeTypes}
+        edgeTypes={edgeTypes}
+        fitView
+        minZoom={0.2}
+        maxZoom={1.4}
+        onNodeClick={(_event, node) => {
+          const actionNode = graph.nodes.find((item) => item.id === node.id) ?? null;
+          onSelectNode(actionNode);
+        }}
+        onPaneClick={() => onSelectNode(null)}
+      >
+        <Background />
+        <Controls />
+      </ReactFlow>
+    </div>
+  );
+}
+
+export function ActionGraphView(props: ActionGraphViewProps): JSX.Element {
+  return (
+    <ReactFlowProvider>
+      <ActionGraphInner {...props} />
+    </ReactFlowProvider>
+  );
+}

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
+import type { ActionGraphNode } from '@invoker/contracts';
 import type { TaskState, WorkflowMeta, WorkflowRollupTaskIssue } from '../types.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
@@ -11,6 +12,7 @@ interface WorkflowInspectorProps {
   executionAgents: string[];
   collapsed: boolean;
   advancedExpanded: boolean;
+  actionNode?: ActionGraphNode | null;
   onEditType?: (taskId: string, executorType: string, remoteTargetId?: string) => void;
   onEditAgent?: (taskId: string, agentName: string) => void;
   onEditPrompt?: (taskId: string, newPrompt: string) => void;
@@ -82,6 +84,7 @@ export function WorkflowInspector({
   executionAgents,
   collapsed,
   advancedExpanded,
+  actionNode,
   onEditType,
   onEditAgent,
   onEditPrompt,
@@ -174,6 +177,96 @@ export function WorkflowInspector({
     : workflow?.status?.replaceAll('_', ' ') ?? 'unknown';
   const workflowTitle = workflow?.name ?? workflow?.id;
   const inspectorTitle = task?.description ?? (workflowTitle ? `${workflowTitle} task DAG` : 'No workflow selected');
+
+  if (actionNode) {
+    const durations = actionNode.durations ?? {};
+    const formatMs = (value: number | undefined) => {
+      if (value === undefined || !Number.isFinite(value)) return 'n/a';
+      const absolute = Math.max(0, Math.abs(value));
+      if (absolute < 1_000) return `${Math.round(absolute)}ms`;
+      if (absolute < 60_000) return `${Math.round(absolute / 1_000)}s`;
+      if (absolute < 3_600_000) return `${Math.round(absolute / 60_000)}m`;
+      return `${Math.round(absolute / 3_600_000)}h`;
+    };
+    return (
+      <aside className="h-full w-full border-l border-gray-800 bg-gray-900 flex flex-col">
+        <div className="flex items-center justify-between border-b border-gray-800 px-3 py-2">
+          <div className="min-w-0 pr-2">
+            <div className="text-sm font-semibold leading-snug text-gray-100" data-testid="workflow-inspector-title">
+              {actionNode.label}
+            </div>
+            <div className="mt-0.5 text-[11px] uppercase text-gray-500">{actionNode.type.replace('-', ' ')}</div>
+          </div>
+          <button
+            onClick={onToggleCollapsed}
+            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white"
+            aria-label="Minimize inspector"
+            title="Minimize inspector"
+          >
+            <InspectorToggleIcon collapsed={collapsed} />
+          </button>
+        </div>
+        <div className="flex-1 overflow-auto p-3 space-y-3 text-sm">
+          <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+            <div className="text-[11px] uppercase tracking-wide text-gray-400">Action Status</div>
+            <div className="mt-1 text-xs text-gray-100">{actionNode.status}</div>
+            {actionNode.latestError && <p className="mt-2 break-words text-xs text-red-300">{actionNode.latestError}</p>}
+          </section>
+          <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+            <div className="text-[11px] uppercase tracking-wide text-gray-400">Timing</div>
+            <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-gray-300">
+              <div>queued: {formatMs(durations.queuedMs)}</div>
+              <div>pending: {formatMs(durations.pendingMs)}</div>
+              <div>running: {formatMs(durations.runningMs)}</div>
+              <div>waiting: {formatMs(durations.waitingMs)}</div>
+              <div>stalled: {formatMs(durations.stalledMs)}</div>
+              <div>heartbeat: {formatMs(durations.heartbeatAgeMs)}</div>
+            </div>
+            <div className="mt-2 space-y-1 text-xs text-gray-400">
+              <div>lease expires: {actionNode.leaseExpiresAt ?? 'n/a'}</div>
+              <div>heartbeat at: {actionNode.heartbeatAt ?? 'n/a'}</div>
+            </div>
+          </section>
+          {actionNode.blockerIds?.length ? (
+            <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+              <div className="text-[11px] uppercase tracking-wide text-gray-400">Blocker Chain</div>
+              <div className="mt-2 space-y-1 text-xs text-gray-300">
+                {actionNode.blockerIds.map((blockerId) => <div key={blockerId}>{blockerId}</div>)}
+              </div>
+            </section>
+          ) : null}
+          {actionNode.suggestedNextAction && (
+            <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+              <div className="text-[11px] uppercase tracking-wide text-gray-400">Suggested Next Action</div>
+              <div className="mt-1 text-xs text-gray-200">{actionNode.suggestedNextAction}</div>
+            </section>
+          )}
+          <section className="rounded border border-gray-700 bg-gray-800/70">
+            <button
+              onClick={onToggleAdvanced}
+              className="w-full px-3 py-2 text-left text-[11px] uppercase tracking-wide text-gray-300 hover:bg-gray-800"
+            >
+              Full history {advancedExpanded ? '▲' : '▼'}
+            </button>
+            {advancedExpanded && (
+              <div className="border-t border-gray-700 px-3 py-2 space-y-2 text-xs text-gray-300">
+                <div>workflow id: {actionNode.workflowId ?? 'n/a'}</div>
+                <div>task id: {actionNode.taskId ?? 'n/a'}</div>
+                <div>attempt id: {actionNode.attemptId ?? 'n/a'}</div>
+                <div>intent id: {actionNode.intentId ?? 'n/a'}</div>
+                {actionNode.history?.map((entry) => (
+                  <div key={entry.id} className="border-t border-gray-700 pt-2">
+                    <div className="text-gray-500">{entry.timestamp} · {entry.source}</div>
+                    <div className="break-words">{entry.message}</div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </section>
+        </div>
+      </aside>
+    );
+  }
 
   return (
     <aside className="h-full w-full border-l border-gray-800 bg-gray-900 flex flex-col">


### PR DESCRIPTION
## Summary

Adds a read-only Action Graph diagnostics view stacked on `feature/coding-ui-reskin`.

- Adds `invoker:get-action-graph` with action, mutation intent, mutation lease, scheduler job, task attempt, and blocker nodes.
- Adds configurable stall detection via `actionDiagnostics.stallThresholdMs`, `INVOKER_ACTION_STALL_THRESHOLD_MS`, and a 60000ms default.
- Adds an Action Graph rail view and reuses the existing workflow inspector for selected action details, timings, blocker chains, history, and suggested next action.

Visual proof:

![Action Graph diagnostics view](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260514-7864db/action-graph-diagnostics-view.png)

## Architecture

### Before

```mermaid
graph TD
    UI[Renderer views] --> Tasks[invoker:get-tasks]
    UI --> Queue[invoker:get-queue-status]
    Queue --> Orchestrator[Orchestrator queue]
    Tasks --> Orchestrator
```

### After

```mermaid
graph TD
    UI[Action Graph view] --> IPC[invoker:get-action-graph]
    IPC --> Builder[Action graph diagnostics builder]
    Builder --> Orchestrator[Scheduler queue and tasks]
    Builder --> Store[Workflows, attempts, mutation intents, leases, audit events]
    UI --> Inspector[Existing workflow inspector]
```

## Test Plan

- [x] `pnpm install`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/ui test -- src/__tests__/action-graph-view.test.tsx`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/action-graph-diagnostics.test.ts`
- [x] `bash scripts/ui-visual-proof.sh capture-after --spec action-graph-visual-proof.spec.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 4f834d2`
- Post-revert steps: None
- Data migration? No
