### PR TITLE
Make recreate dispatch non-blocking

### DIFF
--- a/packages/app/src/__tests__/global-topup.test.ts
+++ b/packages/app/src/__tests__/global-topup.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
-import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from '../global-topup.js';
+import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup, scheduleStartedTasksWithGlobalTopup } from '../global-topup.js';
 
 function makeTask(id: string, status: TaskState['status'], attemptId?: string): TaskState {
   return {
@@ -83,5 +83,35 @@ describe('global-topup helpers', () => {
     expect(taskExecutor.executeTasks).toHaveBeenCalledWith([scoped]);
     expect(result.started).toEqual([scoped]);
     expect(result.topup).toEqual([]);
+  });
+
+  it('scheduleStartedTasksWithGlobalTopup returns before executor dispatch settles', async () => {
+    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
+    const topupTask = makeTask('topup-task', 'running', 'attempt-topup');
+    const orchestrator = {
+      startExecution: vi.fn().mockReturnValue([topupTask]),
+    };
+    let resolveDispatch!: () => void;
+    const dispatchSettled = new Promise<void>((resolve) => {
+      resolveDispatch = resolve;
+    });
+    const taskExecutor = {
+      executeTasks: vi.fn().mockReturnValue(dispatchSettled),
+    };
+
+    const result = scheduleStartedTasksWithGlobalTopup({
+      orchestrator: orchestrator as any,
+      taskExecutor: taskExecutor as any,
+      context: 'test.schedule',
+      started: [scoped],
+    });
+
+    expect(result.runnable).toEqual([scoped]);
+    expect(result.topup).toEqual([topupTask]);
+    expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
+
+    await Promise.resolve();
+    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
+    resolveDispatch();
   });
 });

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -21,9 +21,51 @@ type MutationTopupParams = {
   mutationTiming?: WorkflowMutationTiming;
 };
 
+type ScheduledDispatchParams = {
+  taskExecutor: TaskRunner;
+  logger?: Logger;
+  context: string;
+  tasks: TaskState[];
+  timingName: string;
+  mutationTiming?: WorkflowMutationTiming;
+};
+
 function runningExecutionKey(task: TaskState): string {
   const attemptId = task.execution.selectedAttemptId?.trim();
   return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
+}
+
+function scheduleTaskDispatch({
+  taskExecutor,
+  logger,
+  context,
+  tasks,
+  timingName,
+  mutationTiming,
+}: ScheduledDispatchParams): void {
+  if (tasks.length === 0) return;
+  mutationTiming?.mark(timingName, 'completed', {
+    context,
+    runnableCount: tasks.length,
+    scheduled: true,
+  });
+  void Promise.resolve()
+    .then(() => {
+      if (mutationTiming) {
+        return mutationTiming.span(
+          timingName,
+          { context, runnableCount: tasks.length, asyncDispatch: true },
+          () => taskExecutor.executeTasks(tasks),
+        );
+      }
+      return taskExecutor.executeTasks(tasks);
+    })
+    .catch((error) => {
+      logger?.error(
+        `[global-topup] ${context}: async task dispatch failed: ${error instanceof Error ? error.stack ?? error.message : String(error)}`,
+        { module: 'global-topup' },
+      );
+    });
 }
 
 /**
@@ -104,6 +146,59 @@ export async function dispatchStartedTasksWithGlobalTopup({
     alreadyDispatched: runnable,
     mutationTiming,
   });
+  return { runnable, topup };
+}
+
+/**
+ * Mark runnable work and scheduler top-up synchronously, but launch executor
+ * startup in the background. This keeps recreate/retry control-plane
+ * finalization outside executor startup latency while preserving the same
+ * runnable/top-up accounting returned to callers.
+ */
+export function scheduleStartedTasksWithGlobalTopup({
+  orchestrator,
+  taskExecutor,
+  logger,
+  context,
+  started = [],
+  mutationTiming,
+}: MutationTopupParams): { runnable: TaskState[]; topup: TaskState[] } {
+  const runnable = started.filter((task) => task.status === 'running');
+  if (runnable.length > 0) {
+    logger?.info(
+      `[global-topup] ${context}: scheduling ${runnable.length} scoped task(s): [${runnable.map((task) => task.id).join(', ')}]`,
+    );
+    scheduleTaskDispatch({
+      taskExecutor,
+      logger,
+      context,
+      tasks: runnable,
+      timingName: 'scheduleStartedTasksWithGlobalTopup.scopedExecuteTasks',
+      mutationTiming,
+    });
+  }
+
+  const dedupeKeys = new Set(runnable.map((task) => runningExecutionKey(task)));
+  const topup = orchestrator.startExecution()
+    .filter((task) => task.status === 'running')
+    .filter((task) => !dedupeKeys.has(runningExecutionKey(task)));
+
+  if (topup.length === 0) {
+    logger?.info(`[global-topup] ${context}: no additional globally ready tasks`);
+  } else {
+    logger?.info(
+      `[global-topup] ${context}: scheduling ${topup.length} additional task(s): [${topup.map((task) => task.id).join(', ')}]`,
+    );
+    scheduleTaskDispatch({
+      taskExecutor,
+      logger,
+      context,
+      tasks: topup,
+      timingName: 'scheduleStartedTasksWithGlobalTopup.topupExecuteTasks',
+      mutationTiming,
+    });
+  }
+
   return { runnable, topup };
 }
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -46,7 +46,7 @@ import {
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
-import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup, scheduleStartedTasksWithGlobalTopup } from './global-topup.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
@@ -1533,7 +1533,7 @@ async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<vo
 
     const taskExecutor = createHeadlessExecutor(deps);
     const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
-    const { topup } = await dispatchStartedTasksWithGlobalTopup({
+    const { topup } = scheduleStartedTasksWithGlobalTopup({
       orchestrator: deps.orchestrator,
       taskExecutor,
       logger: deps.logger,
@@ -1665,7 +1665,7 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
   const autoFix = wireHeadlessAutoFix(deps, te);
   const started = await rebaseAndRetry(taskId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
   const runnable = started.filter(t => t.status === 'running');
-  const { topup } = await dispatchStartedTasksWithGlobalTopup({
+  const { topup } = scheduleStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
     taskExecutor: te,
     logger: deps.logger,
@@ -1708,7 +1708,7 @@ async function headlessRecreateWithRebase(workflowTarget: string, deps: Headless
   const autoFix = wireHeadlessAutoFix(deps, te);
   const started = await recreateWithRebase(workflowId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
   const runnable = started.filter(t => t.status === 'running');
-  const { topup } = await dispatchStartedTasksWithGlobalTopup({
+  const { topup } = scheduleStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
     taskExecutor: te,
     logger: deps.logger,
@@ -1761,15 +1761,14 @@ async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps):
     remoteFetchForPool.enabled = false;
     let topup: TaskState[] = [];
     try {
-      await te.executeTasks(runnable);
-      topup = await executeGlobalTopup({
+      ({ topup } = scheduleStartedTasksWithGlobalTopup({
         orchestrator: deps.orchestrator,
         taskExecutor: te,
         logger: deps.logger,
         context: 'headless.recreate-workflow',
-        alreadyDispatched: runnable,
+        started,
         mutationTiming: deps.mutationTiming,
-      });
+      }));
     } finally {
       remoteFetchForPool.enabled = true;
     }
@@ -1826,7 +1825,7 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
   remoteFetchForPool.enabled = false;
   let topup: TaskState[] = [];
   try {
-    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
+    ({ topup } = scheduleStartedTasksWithGlobalTopup({
       orchestrator: deps.orchestrator,
       taskExecutor: te,
       logger: deps.logger,
@@ -1985,7 +1984,7 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
   remoteFetchForPool.enabled = false;
   let topup: TaskState[] = [];
   try {
-    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
+    ({ topup } = scheduleStartedTasksWithGlobalTopup({
       orchestrator: deps.orchestrator,
       taskExecutor: te,
       logger: deps.logger,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -142,7 +142,7 @@ import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
-import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup, scheduleStartedTasksWithGlobalTopup } from './global-topup.js';
 import { computeDeferredLaunchTiming } from './deferred-runnable.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
@@ -3212,7 +3212,7 @@ if (isHeadless) {
           : sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
         remoteFetchForPool.enabled = false;
         try {
-          await dispatchStartedTasksWithGlobalTopup({
+          scheduleStartedTasksWithGlobalTopup({
             orchestrator,
             taskExecutor: requireTaskExecutor(),
             logger,
@@ -3256,7 +3256,7 @@ if (isHeadless) {
           : sharedRecreateTask(taskId, { persistence, orchestrator });
         remoteFetchForPool.enabled = false;
         try {
-          await dispatchStartedTasksWithGlobalTopup({
+          scheduleStartedTasksWithGlobalTopup({
             orchestrator,
             taskExecutor: requireTaskExecutor(),
             logger,
@@ -3300,7 +3300,7 @@ if (isHeadless) {
         if (!result.ok) throw new Error(result.error.message);
         remoteFetchForPool.enabled = false;
         try {
-          await dispatchStartedTasksWithGlobalTopup({
+          scheduleStartedTasksWithGlobalTopup({
             orchestrator,
             taskExecutor: requireTaskExecutor(),
             logger,
@@ -3342,7 +3342,7 @@ if (isHeadless) {
           taskExecutor: requireTaskExecutor(),
           mutationTiming: activeMutationContext?.mutationTiming,
         });
-        await dispatchStartedTasksWithGlobalTopup({
+        scheduleStartedTasksWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
           logger,
@@ -3382,7 +3382,7 @@ if (isHeadless) {
           taskExecutor: requireTaskExecutor(),
           mutationTiming: activeMutationContext?.mutationTiming,
         });
-        await dispatchStartedTasksWithGlobalTopup({
+        scheduleStartedTasksWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
           logger,

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -50,6 +50,7 @@ import {
 import {
   dispatchStartedTasksWithGlobalTopup,
   executeGlobalTopup,
+  scheduleStartedTasksWithGlobalTopup,
 } from './global-topup.js';
 
 // ── Result types ─────────────────────────────────────────────
@@ -137,7 +138,7 @@ export class WorkflowMutationFacade {
 
   async retryTask(taskId: string): Promise<MutationResult> {
     const started = sharedRetryTask(taskId, { orchestrator: this.deps.orchestrator });
-    return this.finalizeWithTopup(started, 'facade.retry-task');
+    return this.scheduleWithTopup(started, 'facade.retry-task');
   }
 
   async recreateTask(taskId: string): Promise<MutationResult> {
@@ -145,7 +146,7 @@ export class WorkflowMutationFacade {
       orchestrator: this.deps.orchestrator,
       persistence: this.deps.persistence,
     });
-    return this.finalizeWithTopup(started, 'facade.recreate-task');
+    return this.scheduleWithTopup(started, 'facade.recreate-task');
   }
 
   async selectExperiment(taskId: string, experimentId: string): Promise<MutationResult> {
@@ -225,7 +226,7 @@ export class WorkflowMutationFacade {
     const started = sharedRetryWorkflow(workflowId, {
       orchestrator: this.deps.orchestrator,
     });
-    return this.finalizeWithTopup(started, 'facade.retry-workflow');
+    return this.scheduleWithTopup(started, 'facade.retry-workflow');
   }
 
   async recreateWorkflow(workflowId: string): Promise<MutationResult> {
@@ -234,22 +235,22 @@ export class WorkflowMutationFacade {
       persistence: this.deps.persistence,
       orchestrator: this.deps.orchestrator,
     });
-    return this.finalizeWithTopup(started, 'facade.recreate-workflow');
+    return this.scheduleWithTopup(started, 'facade.recreate-workflow');
   }
 
   async recreateWorkflowFromFreshBase(workflowId: string): Promise<MutationResult> {
     const started = await sharedRecreateWorkflowFromFreshBase(workflowId, this.actionDeps());
-    return this.finalizeWithTopup(started, 'facade.recreate-from-fresh-base');
+    return this.scheduleWithTopup(started, 'facade.recreate-from-fresh-base');
   }
 
   async recreateWithRebase(workflowId: string): Promise<MutationResult> {
     const started = await sharedRecreateWithRebase(workflowId, this.actionDeps());
-    return this.finalizeWithTopup(started, 'facade.recreate-with-rebase');
+    return this.scheduleWithTopup(started, 'facade.recreate-with-rebase');
   }
 
   async rebaseAndRetry(taskId: string): Promise<MutationResult> {
     const started = await sharedRebaseAndRetry(taskId, this.actionDeps());
-    return this.finalizeWithTopup(started, 'facade.rebase-and-retry');
+    return this.scheduleWithTopup(started, 'facade.rebase-and-retry');
   }
 
   async cancelWorkflow(workflowId: string): Promise<CancelMutationResult> {
@@ -406,6 +407,20 @@ export class WorkflowMutationFacade {
     context: string,
   ): Promise<MutationResult> {
     const { runnable, topup } = await this.dispatchWithTopup(started, context);
+    return { started, runnable, topup };
+  }
+
+  private scheduleWithTopup(
+    started: TaskState[],
+    context: string,
+  ): MutationResult {
+    const { runnable, topup } = scheduleStartedTasksWithGlobalTopup({
+      orchestrator: this.deps.orchestrator,
+      taskExecutor: this.deps.taskExecutor,
+      logger: this.deps.logger,
+      context,
+      started,
+    });
     return { started, runnable, topup };
   }
 


### PR DESCRIPTION
## Summary

- Adds a non-blocking recreate/retry dispatch helper so mutation finalization can return after runnable replacement tasks are recorded instead of waiting for executor launch work.
- Moves the recreate/retry headless, facade, and IPC paths that are part of mutation finalization onto the scheduled dispatch helper while preserving logged background failures and global top-up behavior.
- Keeps executor startup measured outside the mutation response path.

## Architecture

### Before

```mermaid
graph TD
    A[Recreate mutation] --> B[Mark replacement tasks running]
    B --> C[await taskExecutor.executeTasks]
    C --> D[Complete mutation intent]
```

### After

```mermaid
graph TD
    A[Recreate mutation] --> B[Mark replacement tasks running]
    B --> C[Schedule executor dispatch in background]
    C --> D[Complete mutation intent]
    C --> E[Log async dispatch failures]
```

## Test Plan

- [x] `pnpm --filter @invoker/app test -- global-topup workflow-actions persisted-workflow-mutation-coordinator`
- [x] `pnpm --filter @invoker/execution-engine test -- repo-pool`
- [x] `pnpm run check:types`
- [x] `TARGET_MS=200 bash scripts/repro/repro-current-db-recreate-latency.sh` could not run because `scripts/repro/repro-current-db-recreate-latency.sh` is not present on this branch.
- [x] `BURST=40 TARGET_MS=200 bash scripts/repro/repro-recreate-reexecute-latency.sh` could not run because `scripts/repro/repro-recreate-reexecute-latency.sh` is not present on this branch.
- [x] Equivalent local no-track control-plane benchmark: isolated temp DB/repo, standalone owner, `pnpm --filter @invoker/transport build`, `pnpm --filter @invoker/app build`, submit a 10-task plan with `scripts/electron.cjs packages/app/dist/main.js --headless --no-track run <plan>`, wait for original tasks, then measure `node scripts/headless-ipc.js exec --no-track --timeout-ms 60000 -- recreate <workflow>` response time and first replacement `launch_started_at` observed in SQLite.

| Ref | mutation_response_ms | reexecution_enqueue_observed_ms | executor_launch_observed_ms |
| --- | ---: | ---: | ---: |
| `origin/master` | 1450, 1294, 1308 | 1482, 1313, 1342 | 27, 19, 16 |
| `perf/fast-recreate-01-dispatch` | 120, 120, 158 | 213, 363, 406 | 36, 36, 26 |

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert aea90b6`
- Post-revert steps: Re-run the targeted tests and benchmark above.
- Data migration? No
