### PR TITLE
Skip disabled cleanup repo chain work

### DIFF
--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -418,6 +418,8 @@ describe('RepoPool', () => {
   });
 
   describe('repoChains serialization', () => {
+    let prevWorkspaceCleanup: string | undefined;
+
     function createDeferred<T>() {
       let resolve!: (value: T) => void;
       let reject!: (reason?: any) => void;
@@ -432,7 +434,19 @@ describe('RepoPool', () => {
       for (let i = 0; i < 10; i++) await Promise.resolve();
     }
 
-    afterEach(() => { vi.restoreAllMocks(); });
+    beforeEach(() => {
+      prevWorkspaceCleanup = process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+      process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = '1';
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+      if (prevWorkspaceCleanup === undefined) {
+        delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+      } else {
+        process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = prevWorkspaceCleanup;
+      }
+    });
 
     it('serializes concurrent refreshMirrorForRebase calls on same repo', async () => {
       const log: string[] = [];
@@ -490,6 +504,25 @@ describe('RepoPool', () => {
       deferred2.resolve();
       await Promise.all([p1, p2]);
       expect(log).toEqual(['enter-1', 'exit-1', 'enter-2', 'exit-2']);
+    });
+
+    it('skips removeManagedBranchesInMirror chain enqueue when cleanup is disabled', async () => {
+      delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+      const removeSpy = vi.spyOn(pool as any, 'doRemoveManagedBranchesInMirror');
+      const timing = { mark: vi.fn(), span: vi.fn() };
+
+      await pool.removeManagedBranchesInMirror('repo-a', ['b1'], timing as any);
+
+      expect(removeSpy).not.toHaveBeenCalled();
+      expect(timing.mark).toHaveBeenCalledWith(
+        'RepoPool.removeManagedBranchesInMirror',
+        'completed',
+        expect.objectContaining({
+          enabled: false,
+          skipped: true,
+          reason: 'workspace-cleanup-disabled',
+        }),
+      );
     });
 
     it('serializes cross-method calls (refreshMirror + acquireWorktree) on same repo', async () => {

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -141,6 +141,15 @@ export class RepoPool {
    * Remove Invoker-managed branches (experiment/*, invoker/*) from the mirror and linked worktrees.
    */
   async removeManagedBranchesInMirror(repoUrl: string, branches: string[], timing?: RepoPoolTiming): Promise<void> {
+    if (!isWorkspaceCleanupEnabled()) {
+      timing?.mark('RepoPool.removeManagedBranchesInMirror', 'completed', {
+        enabled: false,
+        branchCount: branches.length,
+        skipped: true,
+        reason: 'workspace-cleanup-disabled',
+      });
+      return;
+    }
     const prev = this.repoChains.get(repoUrl) ?? Promise.resolve();
     const queuedAtMs = Date.now();
     const next = prev.then(() => {
@@ -156,17 +165,6 @@ export class RepoPool {
   }
 
   private async doRemoveManagedBranchesInMirror(repoUrl: string, branches: string[], timing?: RepoPoolTiming): Promise<void> {
-    // Gated: with attemptId in branch hash, leftover refs cannot collide with
-    // future attempts, so deletion is unnecessary. Set
-    // INVOKER_ENABLE_WORKSPACE_CLEANUP=1 to restore the rebase-and-retry
-    // branch sweep.
-    if (!isWorkspaceCleanupEnabled()) {
-      timing?.mark('RepoPool.doRemoveManagedBranchesInMirror', 'completed', {
-        enabled: false,
-        branchCount: branches.length,
-      });
-      return;
-    }
     const dir = this.cloneDir(repoUrl);
     if (!existsSync(dir) || !this.worktreeBaseDir) {
       timing?.mark('RepoPool.doRemoveManagedBranchesInMirror', 'completed', {


### PR DESCRIPTION
## Summary

- Skips the managed-branch cleanup repo-chain operation entirely when workspace cleanup is disabled.
- Preserves the existing serialized cleanup behavior when `INVOKER_ENABLE_WORKSPACE_CLEANUP=1`.
- Reduces same-repo recreate queueing work for the default cleanup-disabled path.

## Test Plan

- [x] `pnpm --filter @invoker/app test -- global-topup workflow-actions persisted-workflow-mutation-coordinator`
- [x] `pnpm --filter @invoker/execution-engine test -- repo-pool`
- [x] `pnpm run check:types`
- [x] `TARGET_MS=200 bash scripts/repro/repro-current-db-recreate-latency.sh` could not run because `scripts/repro/repro-current-db-recreate-latency.sh` is not present on this branch.
- [x] `BURST=40 TARGET_MS=200 bash scripts/repro/repro-recreate-reexecute-latency.sh` could not run because `scripts/repro/repro-recreate-reexecute-latency.sh` is not present on this branch.
- [x] Equivalent local no-track control-plane benchmark: isolated temp DB/repo, standalone owner, `pnpm --filter @invoker/transport build`, `pnpm --filter @invoker/app build`, submit a 10-task plan with `scripts/electron.cjs packages/app/dist/main.js --headless --no-track run <plan>`, wait for original tasks, then measure `node scripts/headless-ipc.js exec --no-track --timeout-ms 60000 -- recreate <workflow>` response time and first replacement `launch_started_at` observed in SQLite.

| Ref | mutation_response_ms | reexecution_enqueue_observed_ms | executor_launch_observed_ms |
| --- | ---: | ---: | ---: |
| `perf/fast-recreate-01-dispatch` | 120, 120, 158 | 213, 363, 406 | 36, 36, 26 |
| `perf/fast-recreate-02-skip-cleanup-chain` | 109, 155, 115 | 361, 177, 371 | 38, 19, 29 |

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 57e4822`
- Post-revert steps: Re-run the targeted tests and benchmark above.
- Data migration? No
