### PR TITLE
Add invalidation policy registry for recreate and retry

### DIFF
--- a/packages/app/e2e/workflow-lifecycle.spec.ts
+++ b/packages/app/e2e/workflow-lifecycle.spec.ts
@@ -42,7 +42,7 @@ test.describe('Workflow lifecycle', () => {
     const workflowNode = tasks.find((t: any) => t.config?.isMergeNode);
     expect(alpha?.status).toBe('completed');
     expect(beta?.status).toBe('completed');
-    expect(['running', 'completed']).toContain(gamma?.status);
+    expect(['pending', 'running', 'completed']).toContain(gamma?.status);
     expect(workflowNode?.status).toBe('pending');
   });
 
@@ -55,7 +55,7 @@ test.describe('Workflow lifecycle', () => {
 
     const status = await page.evaluate(() => window.invoker.getStatus());
     expect(status.completed).toBe(2);
-    expect(status.running).toBe(1);
+    expect(status.pending + status.running).toBeGreaterThanOrEqual(1);
   });
 
   test('clear resets task state via IPC', async ({ page }) => {

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -26,6 +26,15 @@ function runningExecutionKey(task: TaskState): string {
   return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
 }
 
+export function isDispatchableLaunch(task: TaskState): boolean {
+  return task.status === 'running'
+    || (
+      task.status === 'pending'
+      && task.execution.phase === 'launching'
+      && !!task.execution.selectedAttemptId
+    );
+}
+
 /**
  * Top up idle scheduler capacity after a scoped mutation.
  * This starts globally-ready work while avoiding duplicate execution
@@ -41,12 +50,12 @@ export async function executeGlobalTopup({
 }: GlobalTopupParams): Promise<TaskState[]> {
   const dedupeKeys = new Set(
     alreadyDispatched
-      .filter((task) => task.status === 'running')
+      .filter(isDispatchableLaunch)
       .map((task) => runningExecutionKey(task)),
   );
   const started = orchestrator.startExecution();
   const runnable = started
-    .filter((task) => task.status === 'running')
+    .filter(isDispatchableLaunch)
     .filter((task) => !dedupeKeys.has(runningExecutionKey(task)));
 
   if (runnable.length === 0) {
@@ -81,7 +90,7 @@ export async function dispatchStartedTasksWithGlobalTopup({
   started = [],
   mutationTiming,
 }: MutationTopupParams): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
-  const runnable = started.filter((task) => task.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     logger?.info(
       `[global-topup] ${context}: dispatching ${runnable.length} scoped task(s): [${runnable.map((task) => task.id).join(', ')}]`,

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -46,7 +46,12 @@ import {
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
-import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import {
+  dispatchStartedTasksWithGlobalTopup,
+  executeGlobalTopup,
+  finalizeMutationWithGlobalTopup,
+  isDispatchableLaunch,
+} from './global-topup.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
@@ -1528,7 +1533,7 @@ async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<vo
       )
       : await deps.commandService.retryTask(envelope);
     if (!result.ok) throw new Error(result.error.message);
-    const runnable = result.data.filter(t => t.status === 'running');
+    const runnable = result.data.filter(isDispatchableLaunch);
     process.stdout.write(`Restarted task "${taskId}" — ${runnable.length} task(s) to execute\n`);
 
     const taskExecutor = createHeadlessExecutor(deps);
@@ -1664,7 +1669,7 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
   const started = await rebaseAndRetry(taskId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
-  const runnable = started.filter(t => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
     taskExecutor: te,
@@ -1707,7 +1712,7 @@ async function headlessRecreateWithRebase(workflowTarget: string, deps: Headless
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
   const started = await recreateWithRebase(workflowId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
-  const runnable = started.filter(t => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
     taskExecutor: te,
@@ -1754,7 +1759,7 @@ async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps):
       async () => sharedRecreateWorkflow(workflowId, { persistence: deps.persistence, orchestrator: deps.orchestrator }),
     )
     : sharedRecreateWorkflow(workflowId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
-  const runnable = started.filter(t => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     const te = createHeadlessExecutor(deps);
     const autoFix = wireHeadlessAutoFix(deps, te);
@@ -1818,7 +1823,7 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
       async () => sharedRecreateTask(taskId, { persistence: deps.persistence, orchestrator: deps.orchestrator }),
     )
     : sharedRecreateTask(taskId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
-  const runnable = started.filter(t => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
   process.stdout.write(`Recreate task "${taskId}" (+ downstream) — ${runnable.length} task(s) to execute (pool fetch skipped)\n`);
   const te = createHeadlessExecutor(deps);
@@ -1913,7 +1918,7 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
     { module: 'headless' },
   );
   const retryRunningSummary = result.data
-    .filter((task) => task.status === 'running')
+    .filter(isDispatchableLaunch)
     .map((task) => `${task.id}(${task.config.workflowId ?? 'unknown'})`);
   if (retryRunningSummary.length > 0) {
     deps.logger.info(
@@ -1921,7 +1926,7 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
       { module: 'headless' },
     );
   }
-  const runnable = result.data.filter((t) => t.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   const crossWorkflow = runnable.filter((t) => t.config.workflowId !== workflowId);
   if (crossWorkflow.length > 0) {
     deps.logger.info(
@@ -1940,7 +1945,7 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
   const scopedKeys = new Set(runnable.map((task) => runningKey(task)));
   const globalTopup = deps.orchestrator
     .startExecution()
-    .filter((task) => task.status === 'running')
+    .filter(isDispatchableLaunch)
     .filter((task) => !scopedKeys.has(runningKey(task)));
   deps.logger.info(
     `headlessRetryWorkflow trace workflow="${workflowId}" postStartExecution globalTopup=${globalTopup.length}`,
@@ -2057,7 +2062,7 @@ async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDe
   const envelope = makeEnvelope('edit-task-command', 'headless', 'task', { taskId, newCommand });
   const result = await deps.commandService.editTaskCommand(envelope);
   if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((task) => task.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2091,7 +2096,7 @@ async function headlessEditPrompt(taskId: string, newPrompt: string, deps: Headl
   const envelope = makeEnvelope('edit-task-prompt', 'headless', 'task', { taskId, newPrompt });
   const result = await deps.commandService.editTaskPrompt(envelope);
   if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((task) => task.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2135,7 +2140,7 @@ async function headlessEditExecutor(
   const envelope = makeEnvelope('edit-task-type', 'headless', 'task', { taskId, runnerKind, poolMemberId });
   const result = await deps.commandService.editTaskType(envelope);
   if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((task) => task.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2173,7 +2178,7 @@ async function headlessEditAgent(taskId: string, agentName: string, deps: Headle
   const envelope = makeEnvelope('edit-task-agent', 'headless', 'task', { taskId, agentName });
   const result = await deps.commandService.editTaskAgent(envelope);
   if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((task) => task.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2561,7 +2566,7 @@ async function headlessSetMergeMode(
   });
   const result = await deps.commandService.editTaskMergeMode(envelope);
   if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((t) => t.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2617,7 +2622,7 @@ async function headlessSetFixContext(
     autoFix.unsubscribe();
     throw new Error(result.error.message);
   }
-  const runnable = result.data.filter((t) => t.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2664,7 +2669,7 @@ async function headlessSetGatePolicy(args: string[], deps: HeadlessDeps): Promis
     });
     const result = await deps.commandService.setTaskExternalGatePolicies(envelope);
     if (!result.ok) throw new Error(result.error.message);
-    const runnable = result.data.filter((t) => t.status === 'running');
+    const runnable = result.data.filter(isDispatchableLaunch);
     if (runnable.length > 0) {
       const taskExecutor = createHeadlessExecutor(deps);
       await taskExecutor.executeTasks(runnable);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -142,7 +142,12 @@ import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
-import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import {
+  dispatchStartedTasksWithGlobalTopup,
+  executeGlobalTopup,
+  finalizeMutationWithGlobalTopup,
+  isDispatchableLaunch,
+} from './global-topup.js';
 import { computeDeferredLaunchTiming } from './deferred-runnable.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
@@ -153,6 +158,12 @@ import {
   buildActionGraphDiagnostics,
   resolveActionDiagnosticsStallThresholdMs,
 } from './action-graph-diagnostics.js';
+
+function isTaskInFlightForForcedStop(task: TaskState): boolean {
+  return task.status === 'running'
+    || task.status === 'fixing_with_ai'
+    || (task.status === 'pending' && task.execution.phase === 'launching');
+}
 
 declare const __BUILD_SHA__: string | undefined;
 declare const __BUILD_VERSION__: string | undefined;
@@ -821,7 +832,7 @@ if (isHeadless) {
             const envelope = makeEnvelope('replace-task', 'ui', 'task', { taskId, replacementTasks });
             const result = await commandService.replaceTask(envelope);
             if (!result.ok) throw new Error(result.error.message);
-            const runnable = result.data.filter((task) => task.status === 'running');
+            const runnable = result.data.filter(isDispatchableLaunch);
             if (runnable.length > 0) {
               const executor = createStandaloneTaskExecutor();
               await executor.executeTasks(runnable);
@@ -851,7 +862,7 @@ if (isHeadless) {
               const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId, experimentId: ids[0] });
               const result = await commandService.selectExperiment(envelope);
               if (!result.ok) throw new Error(result.error.message);
-              const runnable = result.data.filter((task) => task.status === 'running');
+              const runnable = result.data.filter(isDispatchableLaunch);
               if (runnable.length > 0) await executor.executeTasks(runnable);
               return undefined;
             }
@@ -865,7 +876,7 @@ if (isHeadless) {
             const envelope = makeEnvelope('set-gate-policies', 'ui', 'task', { taskId, updates });
             const result = await commandService.setTaskExternalGatePolicies(envelope);
             if (!result.ok) throw new Error(result.error.message);
-            const runnable = result.data.filter((task) => task.status === 'running');
+            const runnable = result.data.filter(isDispatchableLaunch);
             if (runnable.length > 0) {
               const executor = createStandaloneTaskExecutor();
               await executor.executeTasks(runnable);
@@ -1088,11 +1099,12 @@ if (isHeadless) {
       }
       if (ownsHeadlessShutdown && orchestrator) {
         for (const task of orchestrator.getAllTasks()) {
-          if (task.status === 'running' || task.status === 'fixing_with_ai') {
+          if (isTaskInFlightForForcedStop(task)) {
             if (persistence) persistShutdownDiagnostic(task, persistence);
             orchestrator.handleWorkerResponse({
               requestId: `quit-${task.id}`,
               actionId: task.id,
+              attemptId: task.execution.selectedAttemptId,
               executionGeneration: task.execution.generation ?? 0,
               status: 'failed',
               outputs: { exitCode: 1, error: 'Application quit' },
@@ -2359,7 +2371,7 @@ if (isHeadless) {
                 const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
                 const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
 
-                if (task.status === 'running') {
+                if (task.status === 'running' || (task.status === 'pending' && task.execution.phase === 'launching')) {
                   const launchStartedAt = parseExecutionDate(task.execution.launchStartedAt)
                     ?? parseExecutionDate(task.execution.startedAt);
                   const launchAgeMs = launchStartedAt ? now.getTime() - launchStartedAt.getTime() : 0;
@@ -2389,7 +2401,7 @@ if (isHeadless) {
                     };
                     logger.error(`[launch-stall] forcing failure for "${task.id}": ${launchError}`, { module: 'db-poll' });
                     const startedAfterFailure = orchestrator.handleWorkerResponse(failedResponse);
-                    const runnableAfterFailure = startedAfterFailure.filter((candidate) => candidate.status === 'running');
+                    const runnableAfterFailure = startedAfterFailure.filter(isDispatchableLaunch);
                     if (runnableAfterFailure.length > 0) {
                       logger.info(
                         `[launch-stall] dispatching ${runnableAfterFailure.length} task(s) started after failing "${task.id}"`,
@@ -2437,7 +2449,7 @@ if (isHeadless) {
                     };
                     logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
                     const startedAfterFailure = orchestrator.handleWorkerResponse(failedResponse);
-                    const runnableAfterFailure = startedAfterFailure.filter((candidate) => candidate.status === 'running');
+                    const runnableAfterFailure = startedAfterFailure.filter(isDispatchableLaunch);
                     if (runnableAfterFailure.length > 0) {
                       logger.info(
                         `[executing-stall] dispatching ${runnableAfterFailure.length} task(s) started after failing "${task.id}"`,
@@ -2808,20 +2820,25 @@ if (isHeadless) {
 
     registerGuiMutationHandler('invoker:stop', async () => {
       logger.info('stop — destroying all executors', { module: 'ipc' });
-      await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
-      const allTasks = orchestrator.getAllTasks();
-      for (const task of allTasks) {
-        if (task.status === 'running' || task.status === 'fixing_with_ai') {
-          logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc' });
-          orchestrator.handleWorkerResponse({
-            requestId: `stop-${task.id}`,
-            actionId: task.id,
-            executionGeneration: task.execution.generation ?? 0,
-            status: 'failed',
-            outputs: { exitCode: 1, error: 'Stopped by user' },
-          });
+      const failInFlightTasks = (): void => {
+        const allTasks = orchestrator.getAllTasks();
+        for (const task of allTasks) {
+          if (isTaskInFlightForForcedStop(task)) {
+            logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc' });
+            orchestrator.handleWorkerResponse({
+              requestId: `stop-${task.id}`,
+              actionId: task.id,
+              attemptId: task.execution.selectedAttemptId,
+              executionGeneration: task.execution.generation ?? 0,
+              status: 'failed',
+              outputs: { exitCode: 1, error: 'Stopped by user' },
+            });
+          }
         }
-      }
+      };
+      failInFlightTasks();
+      await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
+      failInFlightTasks();
     });
 
     registerGuiMutationHandler('invoker:clear', async () => {
@@ -3057,7 +3074,7 @@ if (isHeadless) {
           const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId, experimentId: ids[0] });
           const result = await commandService.selectExperiment(envelope);
           if (!result.ok) throw new Error(result.error.message);
-          const runnable = result.data.filter(t => t.status === 'running');
+          const runnable = result.data.filter(isDispatchableLaunch);
           await requireTaskExecutor().executeTasks(runnable);
         } else {
           // Multi-select: needs taskExecutor for branch merge, stays in workflow-actions
@@ -3095,7 +3112,7 @@ if (isHeadless) {
           `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task after commandService.retryTask: count=${started.length} [${started.map((t) => `${t.id}(${t.status})`).join(', ')}]`,
           { module: 'ipc' },
         );
-        const runnable = started.filter(t => t.status === 'running');
+        const runnable = started.filter(isDispatchableLaunch);
         logger.info(
           `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task runnable=${runnable.length} [${runnable.map((t) => t.id).join(', ') || '(none)'}] → taskExecutor.executeTasks`,
           { module: 'ipc' },

--- a/packages/app/src/orphan-relaunch.ts
+++ b/packages/app/src/orphan-relaunch.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@invoker/contracts';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+import { isDispatchableLaunch } from './global-topup.js';
 
 export function relaunchOrphansAndStartReady(
   orchestrator: Orchestrator,
@@ -31,7 +32,7 @@ export function relaunchOrphansAndStartReady(
       { module: logPrefix },
     );
     const started = orchestrator.retryTask(task.id);
-    const runnable = started.filter((candidate) => candidate.status === 'running');
+    const runnable = started.filter(isDispatchableLaunch);
     if (runnable.length > 0) {
       orphanRestarted.push(...runnable);
       continue;

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -20,6 +20,7 @@ import type { TaskRunner } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
+import { isDispatchableLaunch } from './global-topup.js';
 
 // ── Lineage guard ─────────────────────────────────────────────
 
@@ -689,7 +690,7 @@ export async function setWorkflowMergeMode(
     return;
   }
   const started = deps.orchestrator.editTaskMergeMode(mergeTask.id, normalized);
-  const runnable = started.filter((t) => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await deps.taskExecutor.executeTasks(runnable);
   }
@@ -734,7 +735,7 @@ export async function setTaskFixContext(
   deps: Pick<ActionDeps, 'orchestrator'> & { taskExecutor: TaskRunner },
 ): Promise<TaskState[]> {
   const started = deps.orchestrator.editTaskFixContext(taskId, patch);
-  const runnable = started.filter((t) => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await deps.taskExecutor.executeTasks(runnable);
   }
@@ -1090,7 +1091,7 @@ export async function autoFixOnFailure(
         persistence,
         taskExecutor,
       });
-      const runnable = started.filter((candidate) => candidate.status === 'running');
+      const runnable = started.filter(isDispatchableLaunch);
       persistence.logEvent?.(taskId, 'debug.auto-fix', {
         phase: 'auto-fix-post-route-recreate-workflow',
         workflowId: recoveryRoute.workflowId,
@@ -1165,7 +1166,7 @@ export async function autoFixOnFailure(
     }
     assertLineageCurrent(lineage, orchestrator, deps.signal);
     const started = orchestrator.retryTask(taskId);
-    const runnable = started.filter(t => t.status === 'running');
+    const runnable = started.filter(isDispatchableLaunch);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-post-route-restart',
       startedCount: started.length,

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -50,6 +50,7 @@ import {
 import {
   dispatchStartedTasksWithGlobalTopup,
   executeGlobalTopup,
+  isDispatchableLaunch,
 } from './global-topup.js';
 
 // ── Result types ─────────────────────────────────────────────
@@ -298,7 +299,7 @@ export class WorkflowMutationFacade {
       orchestrator: this.deps.orchestrator,
       logger: this.deps.logger,
     });
-    const runnable = result.started.filter((t) => t.status === 'running');
+    const runnable = result.started.filter(isDispatchableLaunch);
     await this.deps.taskExecutor.executeTasks(runnable);
     const topup = await this.topupOnly('facade.fork-workflow');
     return {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -389,7 +389,14 @@ export class TaskRunner {
       const launchFailedAt = new Date();
       try {
         const latest = this.orchestrator.getTask(task.id);
-        if (latest && (latest.status === 'running' || latest.status === 'fixing_with_ai')) {
+        if (
+          latest
+          && (
+            latest.status === 'running'
+            || latest.status === 'fixing_with_ai'
+            || (latest.status === 'pending' && latest.execution.phase === 'launching')
+          )
+        ) {
           this.persistence.updateTask(task.id, {
             execution: {
               phase: latest.execution.phase ?? 'launching',

--- a/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import { createTaskState, type TaskState } from '@invoker/workflow-graph';
+import {
+  INVALIDATION_POLICIES,
+  planInvalidation,
+  withSchedulerEnqueueCandidates,
+} from '../invalidation-plan.js';
+
+function task(
+  id: string,
+  workflowId: string,
+  dependencies: string[] = [],
+  status: TaskState['status'] = 'completed',
+): TaskState {
+  return {
+    ...createTaskState(id, id, dependencies, {
+      workflowId,
+      command: `echo ${id}`,
+    }),
+    status,
+  };
+}
+
+describe('InvalidationPlan policy registry', () => {
+  it('registers invalidating recreate/retry and schedule-only policies', () => {
+    expect(INVALIDATION_POLICIES.recreateWorkflow).toMatchObject({
+      action: 'recreateWorkflow',
+      scope: 'workflow',
+      mode: 'recreate',
+    });
+    expect(INVALIDATION_POLICIES.recreateTask).toMatchObject({
+      action: 'recreateTask',
+      scope: 'task',
+      mode: 'recreate',
+    });
+    expect(INVALIDATION_POLICIES.retryWorkflow).toMatchObject({
+      action: 'retryWorkflow',
+      scope: 'workflow',
+      mode: 'retry',
+    });
+    expect(INVALIDATION_POLICIES.retryTask).toMatchObject({
+      action: 'retryTask',
+      scope: 'task',
+      mode: 'retry',
+    });
+    expect(INVALIDATION_POLICIES.scheduleOnly).toMatchObject({
+      action: 'scheduleOnly',
+      scope: 'task',
+      mode: 'scheduleOnly',
+    });
+  });
+
+  it('plans workflow recreate as every task in the workflow', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/b', 'wf-1', ['wf-1/a']),
+      task('wf-2/a', 'wf-2'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateWorkflow',
+      targetId: 'wf-1',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'recreateWorkflow',
+      scope: 'workflow',
+      mode: 'recreate',
+      affectedWorkflowIds: ['wf-1'],
+      affectedTaskIds: ['wf-1/a', 'wf-1/b'],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+  });
+
+  it('plans task recreate as the task plus all descendants', () => {
+    const tasks = [
+      task('wf-1/root', 'wf-1'),
+      task('wf-1/child', 'wf-1', ['wf-1/root']),
+      task('wf-1/grandchild', 'wf-1', ['wf-1/child']),
+      task('wf-1/sibling', 'wf-1'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateTask',
+      targetId: 'wf-1/root',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'recreateTask',
+      scope: 'task',
+      mode: 'recreate',
+      affectedWorkflowIds: ['wf-1'],
+      affectedTaskIds: ['wf-1/child', 'wf-1/grandchild', 'wf-1/root'],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+  });
+
+  it('plans task retry as the task plus non-completed descendants', () => {
+    const tasks = [
+      task('wf-1/root', 'wf-1', [], 'failed'),
+      task('wf-1/failed-child', 'wf-1', ['wf-1/root'], 'failed'),
+      task('wf-1/completed-child', 'wf-1', ['wf-1/root'], 'completed'),
+      task('wf-1/after-completed', 'wf-1', ['wf-1/completed-child'], 'failed'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'retryTask',
+      targetId: 'wf-1/root',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'retryTask',
+      scope: 'task',
+      mode: 'retry',
+      affectedTaskIds: ['wf-1/failed-child', 'wf-1/root'],
+    });
+  });
+
+  it('plans workflow retry from retryable roots and downstream retry footprint', () => {
+    const retryStatuses = new Set<TaskState['status']>(['failed', 'blocked']);
+    const tasks = [
+      task('wf-1/root', 'wf-1', [], 'completed'),
+      task('wf-1/failed', 'wf-1', ['wf-1/root'], 'failed'),
+      task('wf-1/downstream', 'wf-1', ['wf-1/failed'], 'pending'),
+      task('wf-1/completed-downstream', 'wf-1', ['wf-1/failed'], 'completed'),
+      task('wf-2/failed', 'wf-2', [], 'failed'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'retryWorkflow',
+      targetId: 'wf-1',
+      tasks,
+      retryStatuses,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'retryWorkflow',
+      scope: 'workflow',
+      mode: 'retry',
+      affectedWorkflowIds: ['wf-1'],
+      affectedTaskIds: ['wf-1/downstream', 'wf-1/failed'],
+    });
+  });
+
+  it('plans schedule-only without invalidating active attempts', () => {
+    const tasks = [
+      task('wf-1/gated', 'wf-1', [], 'running'),
+      task('wf-1/other', 'wf-1'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'scheduleOnly',
+      targetId: 'wf-1/gated',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'scheduleOnly',
+      scope: 'task',
+      mode: 'scheduleOnly',
+      affectedWorkflowIds: ['wf-1'],
+      affectedTaskIds: ['wf-1/gated'],
+      schedulerEnqueueCandidates: [{ taskId: 'wf-1/gated' }],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+  });
+
+  it('sorts lock workflow ids deterministically', () => {
+    const tasks = [
+      task('z/root', 'z'),
+      task('a/child', 'a', ['z/root']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateTask',
+      targetId: 'z/root',
+      tasks,
+    });
+
+    expect(plan.affectedWorkflowIds).toEqual(['a', 'z']);
+    expect(plan.lockPlan.workflowIds).toEqual(['a', 'z']);
+  });
+
+  it('updates scheduler enqueue candidates immutably', () => {
+    const plan = planInvalidation({
+      action: 'recreateWorkflow',
+      targetId: 'wf-1',
+      tasks: [task('wf-1/a', 'wf-1')],
+    });
+
+    const updated = withSchedulerEnqueueCandidates(plan, ['wf-1/b', 'wf-1/a', 'wf-1/a']);
+
+    expect(plan.schedulerEnqueueCandidates).toEqual([]);
+    expect(updated.schedulerEnqueueCandidates).toEqual([
+      { taskId: 'wf-1/a' },
+      { taskId: 'wf-1/b' },
+    ]);
+  });
+});

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -103,12 +103,15 @@ function makeResponse(
   };
 }
 
-function makeOrchestrator(): { orchestrator: Orchestrator; persistence: InMemoryPersistence } {
+function makeOrchestrator(
+  opts: { deferRunningUntilLaunch?: boolean } = {},
+): { orchestrator: Orchestrator; persistence: InMemoryPersistence } {
   const persistence = new InMemoryPersistence();
   const orchestrator = new Orchestrator({
     persistence,
     messageBus: new InMemoryBus(),
     maxConcurrency: 4,
+    deferRunningUntilLaunch: opts.deferRunningUntilLaunch,
   });
   return { orchestrator, persistence };
 }
@@ -203,6 +206,67 @@ describe('Orchestrator launch claims', () => {
     respondForTask(orchestrator, taskId, 'failed', 1);
     started = orchestrator.recreateWorkflow(workflowId);
     expect(started.map((task) => task.id)).toEqual([taskId]);
+  });
+
+  it('keeps recreated tasks pending until executor launch is confirmed', () => {
+    const { orchestrator, persistence } = makeOrchestrator({ deferRunningUntilLaunch: true });
+    orchestrator.loadPlan({
+      name: 'truthful-recreate',
+      onFinish: 'none',
+      tasks: [{ id: 't1', description: 'one', command: 'echo one' }],
+    });
+
+    const taskId = taskIdBySuffix(orchestrator, 't1');
+    const workflowId = orchestrator.getWorkflowIds()[0]!;
+
+    let [claim] = orchestrator.startExecution();
+    expect(claim!.status).toBe('pending');
+    expect(persistence.loadAttempt(claim!.execution.selectedAttemptId!)?.status).toBe('claimed');
+    expect(orchestrator.markTaskRunningAfterLaunch(taskId, claim!.execution.selectedAttemptId!)).toBe(true);
+    respondForTask(orchestrator, taskId, 'completed');
+
+    [claim] = orchestrator.recreateWorkflow(workflowId);
+    const replacementAttemptId = claim!.execution.selectedAttemptId!;
+
+    expect(claim!.status).toBe('pending');
+    expect(orchestrator.getTask(taskId)?.status).toBe('pending');
+    expect(persistence.loadAttempt(replacementAttemptId)?.status).toBe('claimed');
+    expect(orchestrator.getLastInvalidationPlan()).toMatchObject({
+      action: 'recreateWorkflow',
+      mode: 'recreate',
+      affectedTaskIds: [`__merge__${workflowId}`, taskId],
+    });
+
+    expect(orchestrator.markTaskRunningAfterLaunch(taskId, replacementAttemptId)).toBe(true);
+    expect(orchestrator.getTask(taskId)?.status).toBe('running');
+    expect(persistence.loadAttempt(replacementAttemptId)?.status).toBe('running');
+  });
+
+  it('rejects stale attempt completions after recreate advances lineage', () => {
+    const { orchestrator } = makeOrchestrator({ deferRunningUntilLaunch: true });
+    orchestrator.loadPlan({
+      name: 'stale-recreate',
+      onFinish: 'none',
+      tasks: [{ id: 't1', description: 'one', command: 'echo one' }],
+    });
+
+    const taskId = taskIdBySuffix(orchestrator, 't1');
+    const [firstClaim] = orchestrator.startExecution();
+    const staleAttemptId = firstClaim!.execution.selectedAttemptId!;
+    expect(orchestrator.markTaskRunningAfterLaunch(taskId, staleAttemptId)).toBe(true);
+
+    const [replacementClaim] = orchestrator.recreateTask(taskId);
+    const replacementAttemptId = replacementClaim!.execution.selectedAttemptId!;
+    const generation = firstClaim!.execution.generation ?? 0;
+
+    const staleResult = orchestrator.handleWorkerResponse({
+      ...makeResponse(taskId, 'completed', generation),
+      attemptId: staleAttemptId,
+    });
+
+    expect(staleResult).toEqual([]);
+    expect(orchestrator.getTask(taskId)?.execution.selectedAttemptId).toBe(replacementAttemptId);
+    expect(orchestrator.getTask(taskId)?.status).toBe('pending');
   });
 
   it('resumeWorkflow returns persisted pending launch claims', () => {

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -9,3 +9,4 @@ export * from './graph-mutation.js';
 export * from './command-service.js';
 export * from './task-repository.js';
 export * from './invalidation-policy.js';
+export * from './invalidation-plan.js';

--- a/packages/workflow-core/src/invalidation-plan.ts
+++ b/packages/workflow-core/src/invalidation-plan.ts
@@ -1,0 +1,198 @@
+import { getTransitiveDependents, type TaskState } from '@invoker/workflow-graph';
+import type { InvalidationAction, InvalidationScope } from './invalidation-policy.js';
+
+export type InvalidationMode = 'retry' | 'recreate' | 'scheduleOnly';
+
+export interface SchedulerEnqueueCandidate {
+  taskId: string;
+  priority?: number;
+}
+
+export interface InvalidationLockPlan {
+  workflowIds: string[];
+}
+
+export interface InvalidationPlan {
+  reason: string;
+  action: InvalidationAction;
+  scope: InvalidationScope;
+  mode: InvalidationMode;
+  affectedWorkflowIds: string[];
+  affectedTaskIds: string[];
+  schedulerEnqueueCandidates: SchedulerEnqueueCandidate[];
+  lockPlan: InvalidationLockPlan;
+}
+
+export interface InvalidationPlanningContext {
+  targetId: string;
+  tasks: readonly TaskState[];
+  retryStatuses?: ReadonlySet<TaskState['status']>;
+}
+
+export interface InvalidationPlanningRequest extends InvalidationPlanningContext {
+  action: InvalidationAction;
+  reason?: string;
+}
+
+interface InvalidationPolicy {
+  action: InvalidationAction;
+  scope: InvalidationScope;
+  mode: InvalidationMode;
+  reason: string;
+  selectAffectedTasks: (context: InvalidationPlanningContext) => TaskState[];
+  selectInitialEnqueueCandidates?: (context: InvalidationPlanningContext, affectedTasks: readonly TaskState[]) => string[];
+}
+
+function definePolicy(policy: InvalidationPolicy): InvalidationPolicy {
+  return Object.freeze(policy);
+}
+
+function sorted(values: Iterable<string>): string[] {
+  return Array.from(new Set(values)).sort();
+}
+
+function taskMap(tasks: readonly TaskState[]): Map<string, TaskState> {
+  return new Map(tasks.map((task) => [task.id, task]));
+}
+
+function workflowIdsForTasks(tasks: Iterable<TaskState>): string[] {
+  return sorted(
+    Array.from(tasks)
+      .map((task) => task.config.workflowId)
+      .filter((id): id is string => !!id),
+  );
+}
+
+function descendantsOf(
+  taskId: string,
+  tasksById: ReadonlyMap<string, TaskState>,
+  stop?: (task: TaskState) => boolean,
+): TaskState[] {
+  return getTransitiveDependents(taskId, tasksById, stop ?? (() => false))
+    .map((id) => tasksById.get(id))
+    .filter((task): task is TaskState => !!task);
+}
+
+function taskAndDescendants(
+  taskId: string,
+  tasks: readonly TaskState[],
+  stop?: (task: TaskState) => boolean,
+): TaskState[] {
+  const byId = taskMap(tasks);
+  const root = byId.get(taskId);
+  if (!root) return [];
+  return [root, ...descendantsOf(taskId, byId, stop)];
+}
+
+function retryStop(task: TaskState): boolean {
+  return task.status === 'completed' || task.status === 'stale';
+}
+
+function defaultRetryStatuses(): ReadonlySet<TaskState['status']> {
+  return new Set<TaskState['status']>([
+    'failed',
+    'needs_input',
+    'blocked',
+    'stale',
+    'fixing_with_ai',
+    'awaiting_approval',
+    'review_ready',
+  ]);
+}
+
+function makePlan(policy: InvalidationPolicy, context: InvalidationPlanningContext, reason?: string): InvalidationPlan {
+  const affectedTasks = policy.selectAffectedTasks(context);
+  const affectedWorkflowIds = workflowIdsForTasks(affectedTasks);
+  const enqueueTaskIds = policy.selectInitialEnqueueCandidates?.(context, affectedTasks) ?? [];
+  return {
+    reason: reason ?? policy.reason,
+    action: policy.action,
+    scope: policy.scope,
+    mode: policy.mode,
+    affectedWorkflowIds,
+    affectedTaskIds: sorted(affectedTasks.map((task) => task.id)),
+    schedulerEnqueueCandidates: sorted(enqueueTaskIds).map((taskId) => ({ taskId })),
+    lockPlan: { workflowIds: affectedWorkflowIds },
+  };
+}
+
+export const INVALIDATION_POLICIES: Readonly<Partial<Record<InvalidationAction, InvalidationPolicy>>> = Object.freeze({
+  recreateWorkflow: definePolicy({
+    action: 'recreateWorkflow',
+    scope: 'workflow',
+    mode: 'recreate',
+    reason: 'workflow.recreate',
+    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
+  }),
+  recreateWorkflowFromFreshBase: definePolicy({
+    action: 'recreateWorkflowFromFreshBase',
+    scope: 'workflow',
+    mode: 'recreate',
+    reason: 'workflow.recreateFromFreshBase',
+    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
+  }),
+  recreateTask: definePolicy({
+    action: 'recreateTask',
+    scope: 'task',
+    mode: 'recreate',
+    reason: 'task.recreate',
+    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
+  }),
+  retryTask: definePolicy({
+    action: 'retryTask',
+    scope: 'task',
+    mode: 'retry',
+    reason: 'task.retry',
+    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks, retryStop),
+  }),
+  retryWorkflow: definePolicy({
+    action: 'retryWorkflow',
+    scope: 'workflow',
+    mode: 'retry',
+    reason: 'workflow.retry',
+    selectAffectedTasks: ({ targetId, tasks, retryStatuses }) => {
+      const statuses = retryStatuses ?? defaultRetryStatuses();
+      const byId = taskMap(tasks);
+      const affectedIds = new Set<string>();
+      for (const task of tasks) {
+        if (task.config.workflowId !== targetId || !statuses.has(task.status)) continue;
+        affectedIds.add(task.id);
+        for (const descendant of descendantsOf(task.id, byId, retryStop)) {
+          affectedIds.add(descendant.id);
+        }
+      }
+      return Array.from(affectedIds)
+        .map((id) => byId.get(id))
+        .filter((task): task is TaskState => !!task);
+    },
+  }),
+  scheduleOnly: definePolicy({
+    action: 'scheduleOnly',
+    scope: 'task',
+    mode: 'scheduleOnly',
+    reason: 'externalGatePolicy',
+    selectAffectedTasks: ({ targetId, tasks }) => {
+      const task = tasks.find((item) => item.id === targetId);
+      return task ? [task] : [];
+    },
+    selectInitialEnqueueCandidates: (_context, affectedTasks) => affectedTasks.map((task) => task.id),
+  }),
+});
+
+export function planInvalidation(request: InvalidationPlanningRequest): InvalidationPlan {
+  const policy = INVALIDATION_POLICIES[request.action];
+  if (!policy) {
+    throw new Error(`No invalidation policy registered for action "${request.action}"`);
+  }
+  return makePlan(policy, request, request.reason);
+}
+
+export function withSchedulerEnqueueCandidates(
+  plan: InvalidationPlan,
+  taskIds: Iterable<string>,
+): InvalidationPlan {
+  return {
+    ...plan,
+    schedulerEnqueueCandidates: sorted(taskIds).map((taskId) => ({ taskId })),
+  };
+}

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -71,6 +71,11 @@ import {
 import type { GraphMutationHost } from './graph-mutation.js';
 import { buildPlanLocalToScopedIdMap, scopePlanTaskId } from './task-id-scope.js';
 import type { TaskRepository } from './task-repository.js';
+import {
+  planInvalidation,
+  withSchedulerEnqueueCandidates,
+  type InvalidationPlan,
+} from './invalidation-plan.js';
 
 // ── Channel Constants ───────────────────────────────────────
 
@@ -663,6 +668,7 @@ export class Orchestrator {
   private activeWorkflowIds = new Set<string>();
   private deferredTaskIds = new Set<string>();
   private beforeApproveHook?: (task: TaskState) => Promise<void>;
+  private lastInvalidationPlan?: InvalidationPlan;
 
   /**
    * Per-workflow record of the most recently observed upstream base
@@ -1066,6 +1072,16 @@ export class Orchestrator {
     return task.status === 'running' || task.status === 'fixing_with_ai';
   }
 
+  private isExecutableResponseTask(task: TaskState): boolean {
+    return task.status === 'running'
+      || task.status === 'fixing_with_ai'
+      || (
+        task.status === 'pending'
+        && task.execution.phase === 'launching'
+        && !!task.execution.selectedAttemptId
+      );
+  }
+
   private countActivePersistedAttempts(now: number = Date.now()): number {
     let count = 0;
     for (const task of this.stateMachine.getAllTasks()) {
@@ -1427,12 +1443,12 @@ export class Orchestrator {
         }
       }
       if (earlyTask) {
-        const executableStatuses = new Set(['running', 'fixing_with_ai']);
-        if (!executableStatuses.has(earlyTask.status)) {
+        if (!this.isExecutableResponseTask(earlyTask)) {
           this.logger.warn('[orchestrator] handleWorkerResponse: ignoring response for non-executable task', {
             workerResponseStatus: response.status,
             taskId: response.actionId,
             status: earlyTask.status,
+            phase: earlyTask.execution.phase,
           });
           return [];
         }
@@ -2033,6 +2049,12 @@ export class Orchestrator {
     // wired in Step 17) that bypass `applyInvalidation`'s upstream
     // cancel; a no-op when invoked through `applyInvalidation`.
     this.cancelActiveBeforeInvalidation('task', id);
+    let plan = planInvalidation({
+      action: 'retryTask',
+      targetId: id,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
 
     const prevStatus = task.status;
     this.logger.info('[orchestrator] retryTask', { taskId: id, previousStatus: prevStatus });
@@ -2073,6 +2095,8 @@ export class Orchestrator {
     const { affectedIds } = this.resetSubgraphToPending([id], resetChanges, {
       forceResetIds: new Set([id]),
     });
+    plan = withSchedulerEnqueueCandidates(plan, affectedIds);
+    this.lastInvalidationPlan = plan;
     const afterRt = this.stateGetTask(id)!;
     this.logger.info('[agent-session-trace] retryTask: after writeAndSync', {
       taskId: id,
@@ -2149,7 +2173,7 @@ export class Orchestrator {
       (t) => t.config.workflowId === workflowId,
     );
 
-    const retryStatuses = new Set([
+    const retryStatuses: ReadonlySet<TaskStatus> = new Set<TaskStatus>([
       'failed',
       'needs_input',
       'blocked',
@@ -2158,6 +2182,13 @@ export class Orchestrator {
       'awaiting_approval',
       'review_ready',
     ]);
+    let plan = planInvalidation({
+      action: 'retryWorkflow',
+      targetId: workflowId,
+      tasks: this.stateMachine.getAllTasks(),
+      retryStatuses,
+    });
+    this.lastInvalidationPlan = plan;
 
     const resetChanges: TaskStateChanges = {
       status: 'pending',
@@ -2179,6 +2210,8 @@ export class Orchestrator {
       .filter((task) => retryStatuses.has(task.status))
       .map((task) => task.id);
     const { affectedIds } = this.resetSubgraphToPending(retryRootIds, resetChanges);
+    plan = withSchedulerEnqueueCandidates(plan, affectedIds);
+    this.lastInvalidationPlan = plan;
     const afterResetMs = Date.now();
 
     this.logger.info('[orchestrator] retryWorkflow invalidation', {
@@ -2232,10 +2265,13 @@ export class Orchestrator {
     // Defense-in-depth for direct callers (CommandService.recreateTask
     // wired in Step 17); a no-op when invoked through `applyInvalidation`.
     this.cancelActiveBeforeInvalidation('task', rootId);
-    const allTasks = this.stateMachine.getAllTasks();
-    const taskMap = new Map(allTasks.map((t) => [t.id, t]));
-    const descendantIds = getTransitiveDependents(rootId, taskMap, () => false);
-    const toResetIds = [rootId, ...descendantIds];
+    let plan = planInvalidation({
+      action: 'recreateTask',
+      targetId: rootId,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
+    const toResetIds = plan.affectedTaskIds;
     const toResetSet = new Set(toResetIds);
 
     const resetChanges: TaskStateChanges = {
@@ -2283,6 +2319,8 @@ export class Orchestrator {
       .getReadyTasks()
       .map((t) => t.id)
       .filter((id) => toResetSet.has(id));
+    plan = withSchedulerEnqueueCandidates(plan, readyIds);
+    this.lastInvalidationPlan = plan;
     return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
   }
 
@@ -2304,6 +2342,12 @@ export class Orchestrator {
     // recreateWorkflowFromFreshBase wired in Step 17); a no-op when
     // invoked through `applyInvalidation`.
     this.cancelActiveBeforeInvalidation('workflow', workflowId);
+    let plan = planInvalidation({
+      action: 'recreateWorkflow',
+      targetId: workflowId,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
 
     const resetChanges: TaskStateChanges = {
       status: 'pending',
@@ -2378,6 +2422,8 @@ export class Orchestrator {
       .getReadyTasks()
       .map((t) => t.id)
       .filter((id) => this.stateGetTask(id)?.config.workflowId === workflowId);
+    plan = withSchedulerEnqueueCandidates(plan, readyIds);
+    this.lastInvalidationPlan = plan;
     return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
   }
 
@@ -3016,6 +3062,11 @@ export class Orchestrator {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    this.lastInvalidationPlan = planInvalidation({
+      action: 'scheduleOnly',
+      targetId: task.id,
+      tasks: this.stateMachine.getAllTasks(),
+    });
     if (task.status === 'running' || task.status === 'fixing_with_ai') {
       throw new Error(`Cannot edit running task ${taskId}`);
     }
@@ -3571,6 +3622,10 @@ export class Orchestrator {
 
   getAllTasks(): TaskState[] {
     return this.stateMachine.getAllTasks();
+  }
+
+  getLastInvalidationPlan(): InvalidationPlan | undefined {
+    return this.lastInvalidationPlan;
   }
 
   getReadyTasks(): TaskState[] {
@@ -4590,20 +4645,36 @@ export class Orchestrator {
         continue;
       }
 
-      const changes: TaskStateChanges = {
-        status: 'running',
-        execution: {
-          selectedAttemptId: launchAttemptId,
-          generation: this.getExecutionGeneration(task),
-          startedAt: now,
-          lastHeartbeatAt: now,
-          phase: 'launching',
-          launchStartedAt: now,
-          launchCompletedAt: undefined,
-        },
-      };
+      const changes: TaskStateChanges = this.deferRunningUntilLaunch
+        ? {
+            status: 'pending',
+            execution: {
+              selectedAttemptId: launchAttemptId,
+              generation: this.getExecutionGeneration(task),
+              lastHeartbeatAt: now,
+              phase: 'launching',
+              launchStartedAt: now,
+              launchCompletedAt: undefined,
+            },
+          }
+        : {
+            status: 'running',
+            execution: {
+              selectedAttemptId: launchAttemptId,
+              generation: this.getExecutionGeneration(task),
+              startedAt: now,
+              lastHeartbeatAt: now,
+              phase: 'launching',
+              launchStartedAt: now,
+              launchCompletedAt: undefined,
+            },
+          };
       const updated = this.writeAndSync(job.taskId, changes);
-      this.persistence.logEvent?.(job.taskId, 'task.running', changes);
+      this.persistence.logEvent?.(
+        job.taskId,
+        this.deferRunningUntilLaunch ? 'task.launch_claimed' : 'task.running',
+        changes,
+      );
       this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
       started.push(updated);
       this.logger.info('[orchestrator] drainScheduler: started', {

--- a/scripts/bench-recreate-planner-queue.sh
+++ b/scripts/bench-recreate-planner-queue.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TASK_COUNT="${TASK_COUNT:-20}"
+TIMEOUT_SECONDS="${BENCH_TIMEOUT_SECONDS:-120}"
+KEEP_TEMP="${KEEP_TEMP:-false}"
+SKIP_BUILD="${SKIP_BUILD:-false}"
+
+case "${1:-}" in
+  -h|--help)
+    cat <<'EOF'
+Usage: TASK_COUNT=20 scripts/bench-recreate-planner-queue.sh
+
+Reports:
+  mutationCompletionMs: recreate request start until workflow mutation intent completes
+  replacementEnqueueMs: recreate request start until first replacement selected attempt is pending/claimed/running/completed
+  executorLaunchMs:     first replacement attempt claimed_at until last replacement task launch_completed_at
+
+The benchmark uses an isolated temp HOME/DB/socket/repo and a standalone owner
+plus headless client path. Run it on a baseline checkout and this branch with
+the same TASK_COUNT/environment for before/after comparison.
+EOF
+    exit 0
+    ;;
+esac
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "sqlite3 is required" >&2
+  exit 1
+fi
+
+now_ms() {
+  node -e 'process.stdout.write(String(Date.now()))'
+}
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-recreate-bench.XXXXXX")"
+HOME_DIR="$TMP_DIR/home"
+DB_DIR="$HOME_DIR/.invoker"
+PLAN_PATH="$TMP_DIR/bench-plan.yaml"
+REPO_DIR="$TMP_DIR/repo"
+IPC_SOCKET_PATH="$DB_DIR/bench-ipc.sock"
+OWNER_STDOUT="$TMP_DIR/owner.stdout.log"
+OWNER_STDERR="$TMP_DIR/owner.stderr.log"
+RUN_STDOUT="$TMP_DIR/run.stdout.log"
+RUN_STDERR="$TMP_DIR/run.stderr.log"
+RECREATE_STDOUT="$TMP_DIR/recreate.stdout.log"
+RECREATE_STDERR="$TMP_DIR/recreate.stderr.log"
+
+cleanup() {
+  if [[ -n "${RECREATE_PID:-}" ]]; then
+    kill "$RECREATE_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${OWNER_WRAPPER_PID:-}" ]]; then
+    kill "$OWNER_WRAPPER_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ "$KEEP_TEMP" != "true" ]]; then
+    rm -rf "$TMP_DIR" >/dev/null 2>&1 || true
+  else
+    echo "kept temp: $TMP_DIR" >&2
+  fi
+}
+trap cleanup EXIT
+
+query_sqlite_value() {
+  sqlite3 -noheader "$DB_DIR/invoker.db" "$1"
+}
+
+wait_for_sql() {
+  local sql="$1"
+  local expected="$2"
+  local label="$3"
+  local started_at
+  started_at="$(now_ms)"
+  while true; do
+    local value
+    value="$(query_sqlite_value "$sql" 2>/dev/null || true)"
+    if [[ "$value" == "$expected" ]]; then
+      return 0
+    fi
+    if (( $(now_ms) - started_at > TIMEOUT_SECONDS * 1000 )); then
+      echo "timed out waiting for $label (last=$value)" >&2
+      return 1
+    fi
+    sleep 0.05
+  done
+}
+
+mkdir -p "$DB_DIR" "$REPO_DIR"
+
+pushd "$ROOT_DIR" >/dev/null
+
+if [[ "$SKIP_BUILD" != "true" ]]; then
+  pnpm --filter @invoker/app build >/dev/null
+elif [[ ! -f packages/app/dist/main.js ]]; then
+  echo "packages/app/dist/main.js is missing; unset SKIP_BUILD or build the app first" >&2
+  exit 1
+fi
+
+git -C "$REPO_DIR" init -b main >/dev/null 2>&1
+git -C "$REPO_DIR" config user.name "Invoker Bench"
+git -C "$REPO_DIR" config user.email "bench@example.com"
+printf 'recreate benchmark fixture\n' > "$REPO_DIR/README.md"
+git -C "$REPO_DIR" add README.md
+git -C "$REPO_DIR" commit -m "Initial fixture" >/dev/null 2>&1
+
+cat > "$DB_DIR/config.json" <<EOF
+{
+  "maxConcurrency": $TASK_COUNT
+}
+EOF
+
+{
+  echo "name: Recreate Planner Queue Benchmark"
+  echo "repoUrl: $REPO_DIR"
+  echo "onFinish: none"
+  echo "tasks:"
+  for i in $(seq 1 "$TASK_COUNT"); do
+    echo "  - id: root-$i"
+    echo "    description: Independent root $i"
+    echo "    command: >-"
+    echo "      bash -lc 'printf root-$i > bench-$i.txt'"
+  done
+} > "$PLAN_PATH"
+
+ELECTRON_BIN="$ROOT_DIR/scripts/electron.cjs"
+MAIN_JS="$ROOT_DIR/packages/app/dist/main.js"
+
+HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" NODE_ENV=test "$ELECTRON_BIN" "$MAIN_JS" \
+  >"$OWNER_STDOUT" 2>"$OWNER_STDERR" &
+OWNER_WRAPPER_PID=$!
+
+for _ in {1..300}; do
+  if [[ -f "$DB_DIR/invoker.db.lock/pid" ]]; then
+    OWNER_PID="$(cat "$DB_DIR/invoker.db.lock/pid" 2>/dev/null || true)"
+    if [[ -n "${OWNER_PID:-}" ]] && kill -0 "$OWNER_PID" >/dev/null 2>&1; then
+      break
+    fi
+  fi
+  sleep 0.05
+done
+
+if [[ -z "${OWNER_PID:-}" ]] || ! kill -0 "$OWNER_PID" >/dev/null 2>&1; then
+  echo "owner failed to start" >&2
+  cat "$OWNER_STDERR" >&2 || true
+  exit 1
+fi
+
+HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" NODE_ENV=test "$ELECTRON_BIN" "$MAIN_JS" \
+  --headless run "$PLAN_PATH" >"$RUN_STDOUT" 2>"$RUN_STDERR"
+
+WORKFLOW_ID="$(
+  {
+    sed -n 's/^Workflow ID: //p' "$RUN_STDOUT"
+    sed -n 's/^Delegated to owner .*workflow: //p' "$RUN_STDOUT"
+    sed -n 's/^Delegated to GUI .*workflow: //p' "$RUN_STDOUT"
+  } | head -n1
+)"
+
+if [[ -z "${WORKFLOW_ID:-}" ]]; then
+  echo "failed to capture workflow id" >&2
+  cat "$RUN_STDOUT" >&2 || true
+  cat "$RUN_STDERR" >&2 || true
+  exit 1
+fi
+
+wait_for_sql "select count(*) from tasks where workflow_id = '$WORKFLOW_ID' and is_merge_node = 0 and status = 'completed';" "$TASK_COUNT" "initial completion"
+BASE_GENERATION="$(query_sqlite_value "select min(execution_generation) from tasks where workflow_id = '$WORKFLOW_ID' and is_merge_node = 0;")"
+NEXT_GENERATION="$((BASE_GENERATION + 1))"
+
+START_MS="$(now_ms)"
+HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" NODE_ENV=test "$ELECTRON_BIN" "$MAIN_JS" \
+  --headless --no-track recreate "$WORKFLOW_ID" >"$RECREATE_STDOUT" 2>"$RECREATE_STDERR" &
+RECREATE_PID=$!
+
+INTENT_ID=""
+for _ in {1..300}; do
+  INTENT_ID="$(query_sqlite_value "select coalesce(max(id),'') from workflow_mutation_intents where workflow_id = '$WORKFLOW_ID' and args_json like '%\"recreate\",\"$WORKFLOW_ID\"%';" 2>/dev/null || true)"
+  [[ -n "$INTENT_ID" && "$INTENT_ID" != "0" ]] && break
+  sleep 0.05
+done
+
+if [[ -z "$INTENT_ID" || "$INTENT_ID" == "0" ]]; then
+  echo "failed to capture recreate intent" >&2
+  cat "$RECREATE_STDOUT" >&2 || true
+  cat "$RECREATE_STDERR" >&2 || true
+  exit 1
+fi
+
+REPLACEMENT_ENQUEUE_MS=""
+MUTATION_COMPLETION_MS=""
+POLL_START_MS="$(now_ms)"
+while true; do
+  now="$(now_ms)"
+  if [[ -z "$REPLACEMENT_ENQUEUE_MS" ]]; then
+    count="$(query_sqlite_value "select count(*) from tasks t join attempts a on a.id = t.selected_attempt_id where t.workflow_id = '$WORKFLOW_ID' and t.is_merge_node = 0 and t.execution_generation >= $NEXT_GENERATION and a.status in ('pending','claimed','running','completed');" 2>/dev/null || true)"
+    if [[ "${count:-0}" != "0" ]]; then
+      REPLACEMENT_ENQUEUE_MS="$((now - START_MS))"
+    fi
+  fi
+
+  intent_status="$(query_sqlite_value "select coalesce(status,'') from workflow_mutation_intents where id = $INTENT_ID;" 2>/dev/null || true)"
+  if [[ "$intent_status" == "completed" && -z "$MUTATION_COMPLETION_MS" ]]; then
+    MUTATION_COMPLETION_MS="$((now - START_MS))"
+  fi
+
+  if [[ -n "$REPLACEMENT_ENQUEUE_MS" && -n "$MUTATION_COMPLETION_MS" ]]; then
+    break
+  fi
+  if (( now - POLL_START_MS > TIMEOUT_SECONDS * 1000 )); then
+    echo "timed out waiting for recreate metrics (intent=$intent_status enqueueMs=${REPLACEMENT_ENQUEUE_MS:-})" >&2
+    exit 1
+  fi
+  sleep 0.02
+done
+
+wait_for_sql "select count(*) from tasks where workflow_id = '$WORKFLOW_ID' and is_merge_node = 0 and execution_generation >= $NEXT_GENERATION and launch_completed_at is not null;" "$TASK_COUNT" "replacement launch completion"
+
+if ! wait "$RECREATE_PID"; then
+  echo "recreate command failed" >&2
+  cat "$RECREATE_STDOUT" >&2 || true
+  cat "$RECREATE_STDERR" >&2 || true
+  exit 1
+fi
+unset RECREATE_PID
+
+EXECUTOR_LAUNCH_MS="$(query_sqlite_value "select cast(round((julianday(max(t.launch_completed_at)) - julianday(min(a.claimed_at))) * 86400000.0) as integer) from tasks t join attempts a on a.id = t.selected_attempt_id where t.workflow_id = '$WORKFLOW_ID' and t.is_merge_node = 0 and t.execution_generation >= $NEXT_GENERATION and a.claimed_at is not null and t.launch_completed_at is not null;")"
+
+cat <<EOF
+benchmark=recreate-planner-queue
+taskCount=$TASK_COUNT
+workflowId=$WORKFLOW_ID
+intentId=$INTENT_ID
+mutationCompletionMs=$MUTATION_COMPLETION_MS
+replacementEnqueueMs=$REPLACEMENT_ENQUEUE_MS
+executorLaunchMs=$EXECUTOR_LAUNCH_MS
+EOF
+
+popd >/dev/null

--- a/scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh
+++ b/scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh
@@ -28,22 +28,6 @@ echo "==> case 2.15: submit plan (background — sleep 8 blocks)"
 SUBMIT_LOG="$(mktemp "${TMPDIR:-/tmp}/invoker-e2e-2.15-submit.XXXXXX.log")"
 invoker_e2e_submit_plan_no_track_capture "$PLAN_PATH" "$SUBMIT_LOG"
 
-echo "==> case 2.15: waiting for task to reach running"
-for i in $(seq 1 30); do
-  ST="$(invoker_e2e_task_status e2e-g2215-task 2>/dev/null || true)"
-  if [ "$ST" = "running" ]; then
-    echo "==> case 2.15: task is running (poll $i)"
-    break
-  fi
-  sleep 1
-done
-
-if [ "$(invoker_e2e_task_status e2e-g2215-task 2>/dev/null || true)" != "running" ]; then
-  echo "FAIL case 2.15: task did not reach running before recreate"
-  invoker_e2e_run_headless status 2>&1 || true
-  exit 1
-fi
-
 WF_ID="$(invoker_e2e_extract_workflow_id_from_log "$SUBMIT_LOG")"
 if [ -z "$WF_ID" ]; then
   echo "FAIL case 2.15: could not resolve workflow id"
@@ -52,6 +36,33 @@ if [ -z "$WF_ID" ]; then
 fi
 
 TASK_ID="$WF_ID/e2e-g2215-task"
+
+echo "==> case 2.15: waiting for task to become in-flight"
+IN_FLIGHT=""
+for i in $(seq 1 30); do
+  TASK_JSON="$(invoker_e2e_run_headless query task "$TASK_ID" --output json 2>/dev/null || true)"
+  IN_FLIGHT="$(printf '%s' "$TASK_JSON" | python3 -c 'import json,sys
+try:
+    d=json.load(sys.stdin)
+except Exception:
+    print("")
+    raise SystemExit(0)
+status=d.get("status","")
+phase=(d.get("execution") or {}).get("phase","")
+print("yes" if status=="running" or (status=="pending" and phase=="launching") else "")
+')"
+  if [ "$IN_FLIGHT" = "yes" ]; then
+    echo "==> case 2.15: task is in-flight (poll $i)"
+    break
+  fi
+  sleep 1
+done
+
+if [ "$IN_FLIGHT" != "yes" ]; then
+  echo "FAIL case 2.15: task did not become in-flight before recreate"
+  invoker_e2e_run_headless status 2>&1 || true
+  exit 1
+fi
 
 echo "==> case 2.15: recreate (no-track) while workflow is in-flight"
 invoker_e2e_run_headless --no-track recreate "$WF_ID"


### PR DESCRIPTION
## Summary

Mass recreate-with-rebase is slow because one mutation currently does too many jobs at once: it decides what to reset, changes graph state, queues replacement work, and can blur task launch state. That makes the hot path hard to optimize safely and hard to measure.

This PR separates the decision step from the execution step. Recreate/retry now first builds an explicit invalidation plan: which workflows/tasks are affected, what reset mode applies, and which tasks should be queued afterward. The existing scheduler, persistence, executor, and workflow-level locking still remain in place.

It also fixes state truthfulness: recreated tasks stay pending/launching until executor startup succeeds, and startup failures/stop/shutdown paths now settle pending launch attempts correctly. This PR is the cleanup and measurement boundary for the next stacked performance PR, not the full mass-recreate speedup.

## Architecture

### Before

```mermaid
flowchart TD
  Mutation[recreate/retry mutation] --> Inline[inline footprint logic]
  Inline --> Reset[reset graph state]
  Reset --> Scheduler[enqueue ready tasks]
  Scheduler --> Running[task status could advance before executor truth]
  Running --> Executor[executor launch attempt]
```

### After

```mermaid
flowchart TD
  Mutation[recreate/retry mutation] --> Registry[Invalidation policy registry]
  Registry --> Plan[InvalidationPlan]
  Plan --> Apply[apply graph invalidation]
  Apply --> Queue[queue replacement attempts]
  Queue --> Pending[pending task + launching phase]
  Pending --> Executor[executor launch attempt]
  Executor --> Confirm[markTaskRunningAfterLaunch]
  Confirm --> Running[task status running]
```

This is an invalidation-boundary cleanup, not a scheduler rewrite. The next PR can use this boundary to batch and shorten mass recreate-with-rebase.

## Test Plan

- [x] `pnpm --filter @invoker/workflow-core test -- invalidation orchestrator` (`44` files, `960` tests passed)
- [x] `pnpm --filter @invoker/app test -- global-topup workflow-actions persisted-workflow-mutation-coordinator` (`56` files passed, `882` passed, `1` skipped)
- [x] `pnpm --filter @invoker/execution-engine test -- task-runner repo-pool` (`46` files, `937` tests passed)
- [x] `pnpm --filter @invoker/app exec playwright test e2e/workflow-lifecycle.spec.ts --reporter=line` (`5` passed)
- [x] `pnpm run check:types`
- [x] `git diff --check`
- [x] `bash -n scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh`
- [x] Benchmark smoke, baseline `6c19de2`: `TASK_COUNT=10 BENCH_TIMEOUT_SECONDS=180 scripts/bench-recreate-planner-queue.sh`: `mutationCompletionMs=2731`, `replacementEnqueueMs=839`, `executorLaunchMs=1884`
- [x] Benchmark smoke, final branch `ba89e3e`: `TASK_COUNT=10 BENCH_TIMEOUT_SECONDS=180 scripts/bench-recreate-planner-queue.sh`: `mutationCompletionMs=3219`, `replacementEnqueueMs=927`, `executorLaunchMs=2143`
- [x] Benchmark interpretation: mixed/neutral smoke numbers; this PR is correctness + measurement groundwork, not the mass recreate performance fix.
- [x] UI proof on copied production DB: 33/33 copied workflows submitted with `--no-track recreate-with-rebase`; copied DB only, `maxConcurrency=0`.
- [Playwright UI trace recording](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260514-cdd833/ui-recreate-with-rebase-production-copy-trace.zip)
- ![Before: copied production DB with failed tasks](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260514-cdd833/before-failed-workflows.png)
- ![After: copied workflows submitted for recreate-with-rebase](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260514-cdd833/after-recreate-with-rebase.png)
- [Submission results JSON](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260514-cdd833/recreate-with-rebase-results.json)

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert ba89e3e`
- Post-revert steps: None.
- Data migration? No. This PR adds no schema migration and the benchmark/proof artifacts are external to runtime state.
