### PR TITLE
Normalize merge gate execution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,8 @@ jobs:
             command: bash scripts/test-suites/required/15-submit-workflow-chain.sh
           - name: Branch Carry Forward
             command: bash scripts/test-suites/required/16-branch-carry-forward.sh
+          - name: Merge Gate Concurrency Repro
+            command: bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh
 
     name: required-fast / ${{ matrix.name }}
 

--- a/packages/contracts/src/__tests__/validation.test.ts
+++ b/packages/contracts/src/__tests__/validation.test.ts
@@ -17,6 +17,12 @@ describe('validateWorkRequest', () => {
     expect(result.valid).toBe(true);
   });
 
+  it('accepts merge_gate action requests', () => {
+    const req = createWorkRequest('req-merge', '__merge__wf-1', 0, 'merge_gate', {}, 'http://localhost:4000/callback');
+    const result = validateWorkRequest(req);
+    expect(result.valid).toBe(true);
+  });
+
   it('rejects non-object input', () => {
     expect(validateWorkRequest(null).valid).toBe(false);
     expect(validateWorkRequest('string').valid).toBe(false);
@@ -52,6 +58,21 @@ describe('validateWorkResponse', () => {
 
   it('accepts an optional attemptId on WorkResponse', () => {
     const result = validateWorkResponse({ ...baseResponse, attemptId: 'task-1-a1' });
+    expect(result.valid).toBe(true);
+  });
+
+  it('accepts a valid review_ready response', () => {
+    const result = validateWorkResponse({
+      ...baseResponse,
+      status: 'review_ready',
+      outputs: {
+        exitCode: 0,
+        branch: 'feature/wf-1',
+        reviewUrl: 'https://github.com/owner/repo/pull/1',
+        reviewId: 'owner/repo#1',
+        reviewStatus: 'Awaiting review',
+      },
+    });
     expect(result.valid).toBe(true);
   });
 

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -8,7 +8,7 @@
 
 // ── Action Types ────────────────────────────────────────────
 
-export type ActionType = 'command' | 'ai_task' | 'reconciliation';
+export type ActionType = 'command' | 'ai_task' | 'reconciliation' | 'merge_gate';
 
 // ── Work Request ────────────────────────────────────────────
 
@@ -85,6 +85,7 @@ export interface WorkRequest {
 
 export type ResponseStatus =
   | 'completed'
+  | 'review_ready'
   | 'failed'
   | 'needs_input'
   | 'spawn_experiments'
@@ -100,6 +101,12 @@ export interface WorkResponseOutputs {
   agentName?: string;
   /** Branch the executor used — persisted at completion to close the write-once gap. */
   branch?: string;
+  /** Review URL produced by merge-gate style actions. */
+  reviewUrl?: string;
+  /** Provider-specific review identifier produced by merge-gate style actions. */
+  reviewId?: string;
+  /** Human-readable review state produced by merge-gate style actions. */
+  reviewStatus?: string;
 }
 
 export interface SpawnExperimentsRequest {

--- a/packages/contracts/src/validation.ts
+++ b/packages/contracts/src/validation.ts
@@ -33,7 +33,7 @@ export function validateWorkRequest(req: unknown): ValidationResult {
     return { valid: false, error: 'executionGeneration is required and must be a non-negative integer' };
   }
 
-  const validTypes = ['command', 'ai_task', 'reconciliation'];
+  const validTypes = ['command', 'ai_task', 'reconciliation', 'merge_gate'];
   if (!validTypes.includes(r.actionType as string)) {
     return { valid: false, error: `actionType must be one of: ${validTypes.join(', ')}` };
   }
@@ -72,7 +72,7 @@ export function validateWorkResponse(res: unknown): ValidationResult {
     return { valid: false, error: 'executionGeneration is required and must be a non-negative integer' };
   }
 
-  const validStatuses = ['completed', 'failed', 'needs_input', 'spawn_experiments', 'select_experiment'];
+  const validStatuses = ['completed', 'review_ready', 'failed', 'needs_input', 'spawn_experiments', 'select_experiment'];
   if (!validStatuses.includes(r.status as string)) {
     return { valid: false, error: `status must be one of: ${validStatuses.join(', ')}` };
   }

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -2655,7 +2655,7 @@ describe('TaskRunner', () => {
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
       expect(onComplete).toHaveBeenCalledWith(
         '__merge__wf-1',
-        expect.objectContaining({ status: 'completed' }),
+        expect.objectContaining({ status: 'review_ready' }),
       );
     });
 
@@ -2846,7 +2846,7 @@ describe('TaskRunner', () => {
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
       expect(onComplete).toHaveBeenCalledWith(
         '__merge__wf-1',
-        expect.objectContaining({ status: 'completed' }),
+        expect.objectContaining({ status: 'review_ready' }),
       );
     });
 
@@ -8486,7 +8486,7 @@ console.log(JSON.stringify(out));
       for (let i = 0; i < 10; i++) await Promise.resolve();
     }
 
-    it('serializes concurrent onComplete handlers for merge-node tasks', async () => {
+    it('does not run merge-node work from the completion handler', async () => {
       const log: string[] = [];
       const deferred1 = createDeferred();
       const deferred2 = createDeferred();
@@ -8532,8 +8532,8 @@ console.log(JSON.stringify(out));
         log.push(`exit-${n}`);
       });
 
-      const task1 = makeTask({ id: 'merge-1', status: 'running', config: { isMergeNode: true } });
-      const task2 = makeTask({ id: 'merge-2', status: 'running', config: { isMergeNode: true } });
+      const task1 = makeTask({ id: 'merge-1', status: 'running', config: { isMergeNode: true, runnerKind: 'worktree' } });
+      const task2 = makeTask({ id: 'merge-2', status: 'running', config: { isMergeNode: true, runnerKind: 'worktree' } });
 
       const done1 = runner.executeTask(task1);
       const done2 = runner.executeTask(task2);
@@ -8549,18 +8549,12 @@ console.log(JSON.stringify(out));
       });
 
       await flush();
-      expect(log).toEqual(['enter-1']);
-
-      deferred1.resolve(undefined as any);
-      await flush();
-      expect(log).toEqual(['enter-1', 'exit-1', 'enter-2']);
-
-      deferred2.resolve(undefined as any);
       await Promise.all([done1, done2]);
-      expect(log).toEqual(['enter-1', 'exit-1', 'enter-2', 'exit-2']);
+      expect(log).toEqual([]);
+      expect(mergeCallCount).toBe(0);
     });
 
-    it('a blocked first merge completion prevents a second merge completion from entering merge execution', async () => {
+    it('a completed no-command merge worktree does not enter merge execution from onComplete', async () => {
       vi.useFakeTimers();
       try {
         const log: string[] = [];
@@ -8593,7 +8587,7 @@ console.log(JSON.stringify(out));
                 return makeTask({
                   id,
                   status: 'running',
-                  config: { isMergeNode: true },
+                  config: { isMergeNode: true, runnerKind: 'worktree' },
                   execution: { selectedAttemptId: 'attempt-1', generation: 1 },
                 });
               }
@@ -8601,7 +8595,7 @@ console.log(JSON.stringify(out));
                 return makeTask({
                   id,
                   status: 'running',
-                  config: { isMergeNode: true },
+                  config: { isMergeNode: true, runnerKind: 'worktree' },
                   execution: { selectedAttemptId: 'attempt-2', generation: 1 },
                 });
               }
@@ -8634,13 +8628,13 @@ console.log(JSON.stringify(out));
         const task1 = makeTask({
           id: 'merge-1',
           status: 'running',
-          config: { isMergeNode: true },
+          config: { isMergeNode: true, runnerKind: 'worktree' },
           execution: { selectedAttemptId: 'attempt-1', generation: 1 },
         });
         const task2 = makeTask({
           id: 'merge-2',
           status: 'running',
-          config: { isMergeNode: true },
+          config: { isMergeNode: true, runnerKind: 'worktree' },
           execution: { selectedAttemptId: 'attempt-2', generation: 1 },
         });
 
@@ -8665,26 +8659,113 @@ console.log(JSON.stringify(out));
         await flush();
         await vi.advanceTimersByTimeAsync(6 * 60 * 1000);
 
-        expect(log).toEqual(['enter-merge-1']);
-        expect(updateAttempt).not.toHaveBeenCalledWith(
-          'attempt-2',
-          expect.objectContaining({
-            lastHeartbeatAt: expect.any(Date),
-            leaseExpiresAt: expect.any(Date),
-          }),
-        );
+        expect(log).toEqual([]);
         expect(receivedHeartbeats).not.toContain('merge-2');
-        expect(onCompleteCb).not.toHaveBeenCalledWith(
+        expect(onCompleteCb).toHaveBeenCalledWith(
           'merge-2',
-          expect.anything(),
+          expect.objectContaining({ status: 'completed' }),
         );
 
         deferred1.resolve(undefined as any);
         await Promise.all([done1, done2]);
-        expect(log).toEqual(['enter-merge-1', 'exit-merge-1', 'enter-merge-2', 'exit-merge-2']);
+        expect(log).toEqual([]);
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it('starts an independent merge gate while another merge gate is still preparing review', async () => {
+      const log: string[] = [];
+      const deferred1 = createDeferred();
+      const completeCallbacks = new Map<string, (response: WorkResponse) => void>();
+
+      const mergeExecutor = {
+        type: 'merge',
+        start: vi.fn(async (request: any) => {
+          const handle = {
+            executionId: `exec-${request.actionId}`,
+            taskId: request.actionId,
+            workspacePath: `/tmp/mock-worktree-${request.actionId}`,
+            branch: `invoker/${request.actionId}`,
+          };
+          setImmediate(async () => {
+            log.push(`enter-${request.actionId}`);
+            if (request.actionId === '__merge__wf-a') {
+              await deferred1.promise;
+            }
+            log.push(`exit-${request.actionId}`);
+            completeCallbacks.get(request.actionId)?.({
+              requestId: request.requestId,
+              actionId: request.actionId,
+              attemptId: request.attemptId,
+              executionGeneration: request.executionGeneration,
+              status: 'completed',
+              outputs: { exitCode: 0 },
+            });
+          });
+          return handle;
+        }),
+        onComplete: vi.fn((handle: any, cb: any) => {
+          completeCallbacks.set(handle.taskId, cb);
+        }),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+      };
+
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: (id: string) => makeTask({
+            id,
+            status: 'running',
+            config: { isMergeNode: true },
+            execution: {
+              selectedAttemptId: `attempt-${id}`,
+              generation: 1,
+            },
+          }),
+          handleWorkerResponse: vi.fn(() => []),
+          getAllTasks: () => [],
+        } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn() } as any,
+        executorRegistry: {
+          getDefault: () => mergeExecutor,
+          get: () => mergeExecutor,
+          getAll: () => [mergeExecutor],
+        } as any,
+        cwd: '/tmp',
+      });
+
+      const task1 = makeTask({
+        id: '__merge__wf-a',
+        status: 'running',
+        config: { isMergeNode: true, runnerKind: 'merge' },
+        execution: { selectedAttemptId: 'attempt-__merge__wf-a', generation: 1 },
+      });
+      const task2 = makeTask({
+        id: '__merge__wf-b',
+        status: 'running',
+        config: { isMergeNode: true, runnerKind: 'merge' },
+        execution: { selectedAttemptId: 'attempt-__merge__wf-b', generation: 1 },
+      });
+
+      const done1 = runner.executeTask(task1);
+      const done2 = runner.executeTask(task2);
+      await flush();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      expect(completeCallbacks.size).toBe(2);
+
+      await flush();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(log).toEqual([
+        'enter-__merge__wf-a',
+        'enter-__merge__wf-b',
+        'exit-__merge__wf-b',
+      ]);
+
+      deferred1.resolve(undefined as any);
+      await Promise.all([done1, done2]);
     });
 
     it('error in first onComplete handler does not block the second', async () => {

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -12,6 +12,7 @@ export * from './base-executor.js';
 export * from './process-utils.js';
 export * from './docker-executor.js';
 export * from './worktree-executor.js';
+export * from './merge-gate-executor.js';
 export * from './ssh-executor.js';
 export * from './repo-pool.js';
 export * from './registry.js';

--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -1,0 +1,153 @@
+import { existsSync } from 'node:fs';
+import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-core';
+import { BaseExecutor, type BaseEntry } from './base-executor.js';
+import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
+import type { MergeRunnerHost } from './merge-runner.js';
+import { runMergeGateActionImpl } from './merge-runner.js';
+import { normalizeBranchForGithubCli } from './github-branch-ref.js';
+
+interface MergeGateEntry extends BaseEntry {
+  killed?: boolean;
+}
+
+export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
+  readonly type = 'merge';
+
+  constructor(private readonly host: MergeRunnerHost) {
+    super();
+  }
+
+  async start(request: WorkRequest): Promise<ExecutorHandle> {
+    const task = this.resolveTask(request);
+    const workflow = task.config.workflowId
+      ? this.host.persistence.loadWorkflow(task.config.workflowId)
+      : undefined;
+    const baseBranch = workflow?.baseBranch ?? this.host.defaultBranch ?? await this.host.detectDefaultBranch();
+    const baseCheckoutRef = normalizeBranchForGithubCli(baseBranch);
+    const workspacePath = await this.host.createMergeWorktree(
+      baseCheckoutRef,
+      'gate-' + task.id.replace(/[^a-zA-Z0-9_-]/g, '-'),
+      workflow?.repoUrl,
+    );
+
+    const handle = this.createHandle(request);
+    handle.workspacePath = workspacePath;
+    handle.branch = workflow?.featureBranch ?? undefined;
+
+    const entry: MergeGateEntry = {
+      request,
+      outputListeners: new Set(),
+      completeListeners: new Set(),
+      heartbeatListeners: new Set(),
+      completed: false,
+      outputBuffer: [],
+      outputBufferBytes: 0,
+      evictedChunkCount: 0,
+    };
+    this.registerEntry(handle, entry);
+    entry.heartbeatTimer = setInterval(() => {
+      if (entry.completed) {
+        if (entry.heartbeatTimer) clearInterval(entry.heartbeatTimer);
+        entry.heartbeatTimer = undefined;
+        return;
+      }
+      this.emitHeartbeat(handle.executionId);
+    }, this.heartbeatIntervalMs);
+
+    setImmediate(() => {
+      void this.run(handle, task, workspacePath);
+    });
+
+    return handle;
+  }
+
+  async kill(handle: ExecutorHandle): Promise<void> {
+    const entry = this.getEntry(handle);
+    if (!entry || entry.completed) return;
+    entry.killed = true;
+    this.emitComplete(handle.executionId, {
+      requestId: entry.request.requestId,
+      actionId: entry.request.actionId,
+      attemptId: entry.request.attemptId,
+      executionGeneration: entry.request.executionGeneration,
+      status: 'failed',
+      outputs: {
+        exitCode: 1,
+        error: 'Merge gate execution was cancelled',
+      },
+    });
+  }
+
+  sendInput(_handle: ExecutorHandle, _input: string): void {
+    // Merge gates do not consume interactive input through the executor.
+  }
+
+  getTerminalSpec(handle: ExecutorHandle): TerminalSpec | null {
+    return handle.workspacePath ? { cwd: handle.workspacePath } : null;
+  }
+
+  getRestoredTerminalSpec(meta: PersistedTaskMeta): TerminalSpec {
+    if (!meta.workspacePath || !existsSync(meta.workspacePath)) {
+      throw new Error(`Workspace path no longer exists for task ${meta.taskId}: ${meta.workspacePath ?? 'none'}`);
+    }
+    return { cwd: meta.workspacePath };
+  }
+
+  async destroyAll(): Promise<void> {
+    for (const [executionId, entry] of this.entries) {
+      if (entry.heartbeatTimer) clearInterval(entry.heartbeatTimer);
+      this.entries.delete(executionId);
+    }
+  }
+
+  private resolveTask(request: WorkRequest): TaskState {
+    const task = this.host.orchestrator.getTask(request.actionId);
+    if (!task) {
+      throw new Error(`Merge gate task ${request.actionId} not found`);
+    }
+    return task;
+  }
+
+  private async run(handle: ExecutorHandle, task: TaskState, gateWorkspacePath: string): Promise<void> {
+    const entry = this.getEntry(handle);
+    if (!entry || entry.completed || entry.killed) return;
+
+    try {
+      this.emitOutput(handle.executionId, `[merge] Starting merge gate action: ${task.id}\n`);
+      const result = await runMergeGateActionImpl(this.host, task, { gateWorkspacePath });
+      if (result.taskChanges.execution) {
+        this.host.persistence.updateTask(task.id, {
+          execution: result.taskChanges.execution,
+        });
+      }
+      if (result.reviewIdForPolling && result.workflowIdForPolling) {
+        this.host.startPrPolling(task.id, result.reviewIdForPolling, result.workflowIdForPolling);
+      }
+      this.emitOutput(handle.executionId, `[merge] Merge gate action finished: ${task.id} status=${result.response.status}\n`);
+      this.emitComplete(handle.executionId, this.withAttempt(entry.request, result.response));
+    } catch (err) {
+      const response: WorkResponse = {
+        requestId: entry.request.requestId,
+        actionId: task.id,
+        attemptId: entry.request.attemptId,
+        executionGeneration: entry.request.executionGeneration,
+        status: 'failed',
+        outputs: {
+          exitCode: 1,
+          error: err instanceof Error ? (err.stack ?? err.message) : String(err),
+        },
+      };
+      this.emitComplete(handle.executionId, response);
+    }
+  }
+
+  private withAttempt(request: WorkRequest, response: WorkResponse): WorkResponse {
+    return {
+      ...response,
+      requestId: request.requestId,
+      attemptId: response.attemptId ?? request.attemptId,
+      executionGeneration: request.executionGeneration,
+    };
+  }
+}

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -14,7 +14,7 @@ import type { Orchestrator, TaskState, TaskStateChanges } from '@invoker/workflo
 import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkResponse } from '@invoker/contracts';
-import type { TaskRunnerCallbacks } from './task-runner.js';
+import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 import type { MergeGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
@@ -387,10 +387,18 @@ export function collectDirectNonMergeTaskIds(
 
 // ── Extracted functions ──────────────────────────────────
 
-export async function executeMergeNodeImpl(
+export interface MergeGateActionResult {
+  response: WorkResponse;
+  taskChanges: TaskStateChanges;
+  reviewIdForPolling?: string;
+  workflowIdForPolling?: string;
+}
+
+export async function runMergeGateActionImpl(
   host: MergeRunnerHost,
   task: TaskState,
-): Promise<void> {
+  opts: { gateWorkspacePath?: string } = {},
+): Promise<MergeGateActionResult> {
   const workflowId = task.config.workflowId;
   const workflow = workflowId
     ? host.persistence.loadWorkflow(workflowId)
@@ -403,6 +411,8 @@ export async function executeMergeNodeImpl(
 
   let response: WorkResponse;
   let reviewUrl: string | undefined;
+  let reviewId: string | undefined;
+  let reviewStatus: string | undefined;
 
   const summary = workflowId ? await host.buildMergeSummary(workflowId) : undefined;
 
@@ -432,8 +442,8 @@ export async function executeMergeNodeImpl(
   // Use baseBranch as the ref because featureBranch may not exist yet
   // (it gets created inside consolidateAndMerge). Terminal restore does
   // `git checkout <branch>` to switch to featureBranch anyway.
-  let gateWorkspacePath: string | undefined;
-  if (featureBranch) {
+  let gateWorkspacePath: string | undefined = opts.gateWorkspacePath;
+  if (!gateWorkspacePath && featureBranch) {
     const baseCheckoutRef = await resolveBaseCheckoutRef(
       host,
       baseBranch,
@@ -477,20 +487,20 @@ export async function executeMergeNodeImpl(
           `[merge-gate-workspace] setTaskReviewReady path=manual branch consolidate ` +
             `task=${task.id} gateWorkspacePath=${gateWorkspacePath ?? 'NULL'}`,
         );
-        const manualResponse: WorkResponse = {
+        response = {
           requestId: `merge-${task.id}`,
           actionId: task.id,
           executionGeneration: task.execution.generation ?? 0,
-          status: 'completed',
-          outputs: { exitCode: 0 },
+          status: 'review_ready',
+          outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
         };
-        host.callbacks.onComplete?.(task.id, manualResponse);
-        setMergeGateReviewReady(host, task.id, {
-          config: { runnerKind: 'worktree', summary },
-          execution: { branch: featureBranch ?? undefined, workspacePath: gateWorkspacePath },
-        });
-        await startReviewReadyDependents(host);
-        return;
+        return {
+          response,
+          taskChanges: {
+            config: { summary },
+            execution: { branch: featureBranch ?? undefined, workspacePath: gateWorkspacePath },
+          },
+        };
       }
       if (mergeMode === 'external_review') {
         if (!host.mergeGateProvider) {
@@ -541,14 +551,9 @@ export async function executeMergeNodeImpl(
         });
         console.log(`[merge] Created GitHub PR: ${result.url}`);
 
-        const prResponse: WorkResponse = {
-          requestId: `merge-${task.id}`,
-          actionId: task.id,
-          executionGeneration: task.execution.generation ?? 0,
-          status: 'completed',
-          outputs: { exitCode: 0 },
-        };
-        host.callbacks.onComplete?.(task.id, prResponse);
+        reviewUrl = result.url;
+        reviewId = result.identifier;
+        reviewStatus = 'Awaiting review';
         mergeTrace('GATE_WS_PATH_EXTERNAL_REVIEW_AWAIT', {
           taskId: task.id,
           gateWorkspacePath: gateWorkspacePath ?? null,
@@ -558,26 +563,42 @@ export async function executeMergeNodeImpl(
           `[merge-gate-workspace] setTaskReviewReady path=external_review ` +
             `task=${task.id} gateWorkspacePath=${gateWorkspacePath ?? 'NULL'}`,
         );
-        setMergeGateReviewReady(host, task.id, {
-          config: { runnerKind: 'worktree', summary },
-          execution: {
+        response = {
+          requestId: `merge-${task.id}`,
+          actionId: task.id,
+          executionGeneration: task.execution.generation ?? 0,
+          status: 'review_ready',
+          outputs: {
+            exitCode: 0,
+            summary,
             branch: featureBranch,
-            workspacePath: gateWorkspacePath,
-            reviewUrl: result.url,
-            reviewId: result.identifier,
-            reviewStatus: 'Awaiting review',
+            reviewUrl,
+            reviewId,
+            reviewStatus,
           },
-        });
-        await startReviewReadyDependents(host);
-        host.startPrPolling(task.id, result.identifier, workflowId!);
-        return;
+        };
+        return {
+          response,
+          taskChanges: {
+            config: { summary },
+            execution: {
+              branch: featureBranch,
+              workspacePath: gateWorkspacePath,
+              reviewUrl,
+              reviewId,
+              reviewStatus,
+            },
+          },
+          reviewIdForPolling: reviewId,
+          workflowIdForPolling: workflowId,
+        };
       }
       response = {
         requestId: `merge-${task.id}`,
         actionId: task.id,
         executionGeneration: task.execution.generation ?? 0,
         status: 'completed',
-        outputs: { exitCode: 0 },
+        outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
       };
     } catch (err) {
       response = {
@@ -602,27 +623,27 @@ export async function executeMergeNodeImpl(
         `[merge-gate-workspace] setTaskReviewReady path=no_consolidate_branch ` +
           `task=${task.id} gateWorkspacePath=${gateWorkspacePath ?? 'NULL'} mergeMode=${mergeMode}`,
       );
-      const gateResponse: WorkResponse = {
+      response = {
         requestId: `merge-${task.id}`,
         actionId: task.id,
         executionGeneration: task.execution.generation ?? 0,
-        status: 'completed',
-        outputs: { exitCode: 0 },
+        status: 'review_ready',
+        outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
       };
-      host.callbacks.onComplete?.(task.id, gateResponse);
-      setMergeGateReviewReady(host, task.id, {
-        config: { runnerKind: 'worktree', summary },
-        execution: { branch: featureBranch ?? undefined, workspacePath: gateWorkspacePath },
-      });
-      await startReviewReadyDependents(host);
-      return;
+        return {
+          response,
+          taskChanges: {
+            config: { summary },
+            execution: { branch: featureBranch ?? undefined, workspacePath: gateWorkspacePath },
+          },
+        };
     }
     response = {
       requestId: `merge-${task.id}`,
       actionId: task.id,
       executionGeneration: task.execution.generation ?? 0,
       status: 'completed',
-      outputs: { exitCode: 0 },
+      outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
     };
   }
 
@@ -635,36 +656,50 @@ export async function executeMergeNodeImpl(
     `[merge-gate-workspace] updateTask(merge metadata) task=${task.id} ` +
       `gateWorkspacePath=${gateWorkspacePath ?? 'NULL'} response=${response.status}`,
   );
-  host.persistence.updateTask(task.id, {
-    config: { runnerKind: 'worktree', summary },
-    execution: {
+  return {
+    response,
+    taskChanges: {
+      config: { summary },
+      execution: {
       branch: featureBranch ?? undefined,
       workspacePath: gateWorkspacePath,
       ...(reviewUrl ? { reviewUrl } : {}),
+      ...(reviewId ? { reviewId } : {}),
+      ...(reviewStatus ? { reviewStatus } : {}),
       ...(response.status === 'failed' && response.outputs.error
         ? { error: response.outputs.error }
         : {}),
-    },
-  });
-  host.callbacks.onComplete?.(task.id, response);
-  if (mergeMode === 'manual' && response.status === 'completed') {
-    mergeTrace('GATE_WS_PATH_MANUAL_AFTER_SUCCESS', {
-      taskId: task.id,
-      gateWorkspacePath: gateWorkspacePath ?? null,
-    });
-    console.log(
-      `[merge-gate-workspace] setTaskReviewReady path=manual_post_success ` +
-        `task=${task.id} gateWorkspacePath=${gateWorkspacePath ?? 'NULL'}`,
-    );
-    setMergeGateReviewReady(host, task.id, {
-      config: { runnerKind: 'worktree', summary },
-      execution: {
-        branch: featureBranch ?? undefined,
-        workspacePath: gateWorkspacePath,
-        ...(reviewUrl ? { reviewUrl } : {}),
       },
-    });
+    },
+  };
+}
+
+export async function executeMergeNodeImpl(
+  host: MergeRunnerHost,
+  task: TaskState,
+): Promise<void> {
+  const result = await runMergeGateActionImpl(host, task);
+  const { response } = result;
+  const legacyConfig = {
+    ...(result.taskChanges.config ?? {}),
+    runnerKind: 'worktree',
+  } as TaskStateChanges['config'];
+  const legacyChanges: TaskStateChanges = {
+    status: result.taskChanges.status,
+    dependencies: result.taskChanges.dependencies,
+    execution: result.taskChanges.execution,
+    config: legacyConfig,
+  };
+
+  host.persistence.updateTask(task.id, legacyChanges);
+  host.callbacks.onComplete?.(task.id, response);
+
+  if (response.status === 'review_ready') {
+    setMergeGateReviewReady(host, task.id, legacyChanges);
     await startReviewReadyDependents(host);
+    if (result.reviewIdForPolling && result.workflowIdForPolling) {
+      host.startPrPolling(task.id, result.reviewIdForPolling, result.workflowIdForPolling);
+    }
   } else {
     const newlyStarted = host.orchestrator.handleWorkerResponse(response) ?? [];
     if (newlyStarted.length > 0) {

--- a/packages/execution-engine/src/task-runner-callbacks.ts
+++ b/packages/execution-engine/src/task-runner-callbacks.ts
@@ -1,0 +1,11 @@
+import type { WorkResponse } from '@invoker/contracts';
+import type { Executor, ExecutorHandle } from './executor.js';
+
+export interface TaskRunnerCallbacks {
+  onOutput?: (taskId: string, data: string) => void;
+  onLaunchStart?: (taskId: string, executor: Executor) => void;
+  onLaunchFailed?: (taskId: string, error: Error, executor: Executor) => void;
+  onSpawned?: (taskId: string, handle: ExecutorHandle, executor: Executor) => void;
+  onComplete?: (taskId: string, response: WorkResponse) => void;
+  onHeartbeat?: (taskId: string) => void;
+}

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -16,6 +16,7 @@ import type { Orchestrator, TaskState, ExperimentVariant, RunnerKind } from '@in
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
 import type { Executor, ExecutorHandle } from './executor.js';
+import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 import { BaseExecutor } from './base-executor.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import { ResourceLimitError, type RepoPoolTiming } from './repo-pool.js';
@@ -25,6 +26,7 @@ import type { MergeGateProvider } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
+import { MergeGateExecutor } from './merge-gate-executor.js';
 import { isInvokerManagedPoolBranch } from './plan-base-remote.js';
 import { formatLifecycleTag, extractAttemptSuffix } from './branch-utils.js';
 import { SshExecutor } from './ssh-executor.js';
@@ -52,6 +54,8 @@ import {
   validateCanonicalPrBody,
   type PrAuthoringContext,
 } from './pr-authoring.js';
+
+export type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 
 /** Keeps `lastHeartbeatAt` fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). Matches BaseExecutor default heartbeat cadence. */
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -91,17 +95,6 @@ const NOOP_LOGGER: Logger = {
   error: () => {},
   child: () => NOOP_LOGGER,
 };
-
-// ── Callbacks ─────────────────────────────────────────────
-
-export interface TaskRunnerCallbacks {
-  onOutput?: (taskId: string, data: string) => void;
-  onLaunchStart?: (taskId: string, executor: Executor) => void;
-  onLaunchFailed?: (taskId: string, error: Error, executor: Executor) => void;
-  onSpawned?: (taskId: string, handle: ExecutorHandle, executor: Executor) => void;
-  onComplete?: (taskId: string, response: WorkResponse) => void;
-  onHeartbeat?: (taskId: string) => void;
-}
 
 // ── Config ────────────────────────────────────────────────
 
@@ -750,15 +743,6 @@ export class TaskRunner {
             traceExecution(
               `${RESTART_TO_BRANCH_TRACE} resolvePromise | task.config.isMergeNode = ${task.config.isMergeNode}`,
             );
-            // Merge nodes: run consolidation/finish logic after executor completes
-            if (task.config.isMergeNode) {
-              traceExecution(
-                `${RESTART_TO_BRANCH_TRACE} executor.onComplete taskId=${task.id} isMergeNode → executeMergeNode (consolidate / gate)`,
-              );
-              await this.executeMergeNode(task);
-              return;
-            }
-
             this.callbacks.onComplete?.(task.id, normalizedResponse);
 
             const newlyStarted = this.orchestrator.handleWorkerResponse(normalizedResponse) ?? [];
@@ -809,10 +793,10 @@ export class TaskRunner {
   /**
    * Select the executor to use for a given task.
    * Uses task.runnerKind to look up in the registry; falls back to default.
-   * Merge gate tasks use the default (worktree) executor when selected explicitly.
+   * Merge gate tasks use the dedicated merge executor.
    */
   selectExecutor(task: TaskState): Executor {
-    let effectiveType = task.config.runnerKind;
+    let effectiveType = task.config.runnerKind ?? (task.config.isMergeNode ? 'merge' : undefined);
     let selectedPoolMemberId: string | undefined;
 
     if (task.config.poolId) {
@@ -835,7 +819,7 @@ export class TaskRunner {
 
     if (effectiveType) {
       const registered = this.executorRegistry.get(effectiveType);
-      if (registered) {
+      if (registered && (effectiveType !== 'merge' || registered.type === 'merge')) {
         traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=${effectiveType} → ${registered.type}`);
         return registered;
       }
@@ -864,6 +848,13 @@ export class TaskRunner {
         this.executorRegistry.register('worktree', worktree);
         traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=worktree → worktree (lazy registered)`);
         return worktree;
+      }
+
+      if (effectiveType === 'merge') {
+        const merge = new MergeGateExecutor(this);
+        this.executorRegistry.register?.('merge', merge);
+        traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=merge → merge (lazy registered)`);
+        return merge;
       }
 
       // Lazy registration for SSH — resolve poolMemberId from config and cache by targetId.
@@ -934,12 +925,6 @@ export class TaskRunner {
       }
     }
 
-    if (task.config.isMergeNode) {
-      const mergeGateExecutor = this.executorRegistry.getDefault();
-      traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} isMergeNode=true → ${mergeGateExecutor.type} (merge gate)`);
-      return mergeGateExecutor;
-    }
-
     const defaultExecutor = this.executorRegistry.getDefault();
     traceExecution(`[trace] TaskRunner.selectExecutor: task=${task.id} effectiveType=${effectiveType ?? 'none'} → ${defaultExecutor.type} (default)`);
     return defaultExecutor;
@@ -947,9 +932,10 @@ export class TaskRunner {
 
   /**
    * Determine the correct ActionType for a task based on its fields.
-   * Priority: isReconciliation > command > prompt > default 'command'.
+   * Priority: merge gate > isReconciliation > command > prompt > default 'command'.
    */
   determineActionType(task: TaskState): ActionType {
+    if (task.config.runnerKind === 'merge' || task.config.isMergeNode) return 'merge_gate';
     if (task.config.isReconciliation) return 'reconciliation';
     if (task.config.command) return 'command';
     if (task.config.prompt) return 'ai_task';

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -312,6 +312,43 @@ describe('Orchestrator', () => {
     });
   });
 
+  describe('review_ready worker responses', () => {
+    it('transition a running merge gate through handleWorkerResponse', () => {
+      orchestrator.loadPlan({
+        name: 'Review ready workflow',
+        tasks: [{ id: 'task-a', description: 'task A' }],
+      });
+
+      const workflowId = orchestrator.getWorkflowIds()[0]!;
+      const mergeId = `__merge__${workflowId}`;
+      persistence.updateTask(mergeId, {
+        status: 'running',
+        execution: { generation: 0 },
+      });
+
+      orchestrator.handleWorkerResponse(makeResponse({
+        actionId: mergeId,
+        status: 'review_ready',
+        outputs: {
+          exitCode: 0,
+          summary: 'ready',
+          branch: 'feature/review-ready',
+          reviewUrl: 'https://github.com/owner/repo/pull/1',
+          reviewId: 'owner/repo#1',
+          reviewStatus: 'Awaiting review',
+        },
+      }));
+
+      const task = orchestrator.getTask(mergeId)!;
+      expect(task.status).toBe('review_ready');
+      expect(task.config.summary).toBe('ready');
+      expect(task.execution.branch).toBe('feature/review-ready');
+      expect(task.execution.reviewUrl).toBe('https://github.com/owner/repo/pull/1');
+      expect(task.execution.reviewId).toBe('owner/repo#1');
+      expect(task.execution.reviewStatus).toBe('Awaiting review');
+    });
+  });
+
   describe('workflow status transitions during retry paths', () => {
     it('stores a newly loaded workflow as pending while all tasks are pending', () => {
       orchestrator.loadPlan({

--- a/packages/workflow-core/src/__tests__/response-handler.test.ts
+++ b/packages/workflow-core/src/__tests__/response-handler.test.ts
@@ -52,6 +52,38 @@ describe('ResponseHandler (pure parser)', () => {
     });
   });
 
+  // ── review_ready ───────────────────────────────────────
+
+  describe('review_ready', () => {
+    it('parses merge gate review metadata', () => {
+      const result = handler.parseResponse(
+        makeResponse({
+          status: 'review_ready',
+          outputs: {
+            exitCode: 0,
+            summary: 'ready for review',
+            branch: 'feature/wf-1',
+            reviewUrl: 'https://github.com/owner/repo/pull/1',
+            reviewId: 'owner/repo#1',
+            reviewStatus: 'Awaiting review',
+          },
+        }),
+      );
+      expect('type' in result).toBe(true);
+      if (!('type' in result)) return;
+      expect(result).toEqual({
+        type: 'review_ready',
+        taskId: 't1',
+        exitCode: 0,
+        summary: 'ready for review',
+        branch: 'feature/wf-1',
+        reviewUrl: 'https://github.com/owner/repo/pull/1',
+        reviewId: 'owner/repo#1',
+        reviewStatus: 'Awaiting review',
+      });
+    });
+  });
+
   // ── failed ─────────────────────────────────────────────
 
   describe('failed', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1490,6 +1490,8 @@ export class Orchestrator {
     switch (parsed.type) {
       case 'completed':
         return this.handleCompleted(canonicalTaskId, parsed);
+      case 'review_ready':
+        return this.handleReviewReady(canonicalTaskId, parsed);
       case 'failed':
         return this.handleFailed(canonicalTaskId, parsed);
       case 'needs_input':
@@ -3845,6 +3847,9 @@ export class Orchestrator {
       lastAgentSessionId?: string;
       lastAgentName?: string;
       branch?: string;
+      reviewUrl?: string;
+      reviewId?: string;
+      reviewStatus?: string;
     } = {
       exitCode: parsed.exitCode,
       completedAt: new Date(),
@@ -3859,6 +3864,15 @@ export class Orchestrator {
     }
     if (parsed.branch !== undefined) {
       execution.branch = parsed.branch;
+    }
+    if (parsed.reviewUrl !== undefined) {
+      execution.reviewUrl = parsed.reviewUrl;
+    }
+    if (parsed.reviewId !== undefined) {
+      execution.reviewId = parsed.reviewId;
+    }
+    if (parsed.reviewStatus !== undefined) {
+      execution.reviewStatus = parsed.reviewStatus;
     }
 
     const changes: TaskStateChanges = {
@@ -3994,6 +4008,28 @@ export class Orchestrator {
       started.push(...this.drainScheduler());
     }
 
+    this.checkWorkflowCompletion();
+    return started;
+  }
+
+  private handleReviewReady(
+    taskId: string,
+    parsed: Extract<ParsedResponse, { type: 'review_ready' }>,
+  ): TaskState[] {
+    const changes: TaskStateChanges = {
+      config: { summary: parsed.summary },
+      execution: {
+        exitCode: parsed.exitCode,
+        branch: parsed.branch,
+        reviewUrl: parsed.reviewUrl,
+        reviewId: parsed.reviewId,
+        reviewStatus: parsed.reviewStatus,
+      },
+    };
+    this.setTaskApprovalStatus(taskId, 'review_ready', 'task.review_ready', changes);
+
+    const started = this.autoStartUnblockedTasks();
+    started.push(...this.autoStartExternallyUnblockedReadyTasks());
     this.checkWorkflowCompletion();
     return started;
   }
@@ -4668,14 +4704,17 @@ export class Orchestrator {
         const upstreamAttemptIds = task.dependencies
           .map(depId => this.stateGetTask(depId)?.execution.selectedAttemptId)
           .filter((id): id is string => !!id);
-        const attempt = createAttempt(taskId, {
-          status: 'running',
-          claimedAt: launchedAt,
-          startedAt: launchedAt,
-          lastHeartbeatAt: launchedAt,
-          leaseExpiresAt: nextLeaseExpiry(launchedAt),
-          upstreamAttemptIds,
-        });
+        const attempt: Attempt = {
+          ...createAttempt(taskId, {
+            status: 'running',
+            claimedAt: launchedAt,
+            startedAt: launchedAt,
+            lastHeartbeatAt: launchedAt,
+            leaseExpiresAt: nextLeaseExpiry(launchedAt),
+            upstreamAttemptIds,
+          }),
+          id: attemptId,
+        };
         this.taskRepository.saveAttempt(attempt);
         this.writeAndSync(taskId, { execution: { selectedAttemptId: attempt.id } });
       }

--- a/packages/workflow-core/src/response-handler.ts
+++ b/packages/workflow-core/src/response-handler.ts
@@ -36,6 +36,19 @@ export type ParsedResponse =
       commitHash?: string;
       agentSessionId?: string;
       branch?: string;
+      reviewUrl?: string;
+      reviewId?: string;
+      reviewStatus?: string;
+    }
+  | {
+      type: 'review_ready';
+      taskId: string;
+      exitCode: number;
+      summary?: string;
+      branch?: string;
+      reviewUrl?: string;
+      reviewId?: string;
+      reviewStatus?: string;
     }
   | {
       type: 'failed';
@@ -84,6 +97,21 @@ export class ResponseHandler {
           commitHash: outputs.commitHash,
           agentSessionId: outputs.agentSessionId,
           branch: outputs.branch,
+          reviewUrl: outputs.reviewUrl,
+          reviewId: outputs.reviewId,
+          reviewStatus: outputs.reviewStatus,
+        };
+
+      case 'review_ready':
+        return {
+          type: 'review_ready',
+          taskId: actionId,
+          exitCode: outputs.exitCode ?? 0,
+          summary: outputs.summary,
+          branch: outputs.branch,
+          reviewUrl: outputs.reviewUrl,
+          reviewId: outputs.reviewId,
+          reviewStatus: outputs.reviewStatus,
         };
 
       case 'failed':

--- a/scripts/test-suites/required/17-merge-gate-concurrency-repro.sh
+++ b/scripts/test-suites/required/17-merge-gate-concurrency-repro.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Regression proof for merge gates running as normal executor actions.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT/packages/execution-engine"
+exec pnpm exec vitest run src/__tests__/task-runner.test.ts \
+  -t "starts an independent merge gate while another merge gate is still preparing review"


### PR DESCRIPTION
## Summary

Normalize merge gates onto the same executor lifecycle as ordinary tasks. Merge nodes now select a dedicated `merge` executor, launch with a real gate workspace handle, run PR/review creation inside executor-owned action execution, and report terminal `completed`, `failed`, or `review_ready` worker responses through normal response handling.

This removes merge-gate work from `TaskRunner` completion handling and adds a required CI repro proving an independent merge gate can run while another merge gate is still preparing review.

## Architecture

### Before

```mermaid
flowchart TD
  A[Worktree executor completes task] --> B[TaskRunner onComplete]
  B --> C{is merge node?}
  C -->|yes| D[executeMergeNode inside completion handler]
  D --> E[direct callbacks / orchestrator updates / dependent startup]
  C -->|no| F[normal handleWorkerResponse]
```

### After

```mermaid
flowchart TD
  A[Scheduler starts merge task] --> B[MergeGateExecutor.start creates gate workspace]
  B --> C[merge_gate action creates PR or performs merge]
  C --> D[executor emits one terminal response]
  D --> E[TaskRunner onComplete]
  E --> F[normal handleWorkerResponse]
  F --> G{status}
  G -->|review_ready| H[generic review_ready transition and gated dependents]
  G -->|completed or failed| I[normal terminal handling]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh`
- [x] `pnpm exec vitest run src/__tests__/task-runner.test.ts --typecheck.enabled false`
- [x] `pnpm --filter @invoker/contracts test -- src/__tests__/validation.test.ts`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/response-handler.test.ts src/__tests__/orchestrator.test.ts -t "review_ready|review ready"`
- [x] `pnpm run check:required-builds`
- [x] `pnpm run check:deps`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0567af1`
- Post-revert steps: Remove the `Merge Gate Concurrency Repro` CI matrix entry if reverting manually instead of with git.
- Data migration? No
