### PR TITLE
Speed up bulk recreate-with-rebase dispatch

### DIFF
--- a/packages/app/e2e/workflow-lifecycle.spec.ts
+++ b/packages/app/e2e/workflow-lifecycle.spec.ts
@@ -42,7 +42,7 @@ test.describe('Workflow lifecycle', () => {
     const workflowNode = tasks.find((t: any) => t.config?.isMergeNode);
     expect(alpha?.status).toBe('completed');
     expect(beta?.status).toBe('completed');
-    expect(['running', 'completed']).toContain(gamma?.status);
+    expect(['pending', 'running', 'completed']).toContain(gamma?.status);
     expect(workflowNode?.status).toBe('pending');
   });
 
@@ -55,7 +55,7 @@ test.describe('Workflow lifecycle', () => {
 
     const status = await page.evaluate(() => window.invoker.getStatus());
     expect(status.completed).toBe(2);
-    expect(status.running).toBe(1);
+    expect(status.pending + status.running).toBeGreaterThanOrEqual(1);
   });
 
   test('clear resets task state via IPC', async ({ page }) => {

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -422,6 +422,55 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
+  it('treats headless recreate-with-rebase as a recreate fence', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const gate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel, args) => {
+        const payload = args[0] as { args?: unknown[] } | undefined;
+        order.push(`${channel}:${Array.isArray(payload?.args) ? payload.args.join(' ') : String(args[0])}`);
+        if (channel === 'invoker:fix-with-agent') {
+          await gate.promise;
+        }
+      },
+    );
+
+    const running = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:fix-with-agent', ['wf-1/blocker-task', null]);
+    void running.catch(() => {});
+    const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['old-queued']);
+    void olderQueued.catch(() => {});
+    const recreateWithRebase = coordinator.enqueue<void>(
+      'wf-1',
+      'high',
+      'headless.exec',
+      [{ args: ['recreate-with-rebase', 'wf-1'], noTrack: true }],
+    );
+    const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['new-queued']);
+
+    await recreateWithRebase;
+    await newerQueued;
+    await expect(running).rejects.toThrow(/superseded by recreate intent/i);
+    await expect(olderQueued).rejects.toThrow(/evicted/i);
+
+    expect(order).toEqual([
+      'invoker:fix-with-agent:wf-1/blocker-task',
+      'headless.exec:recreate-with-rebase wf-1',
+      'invoker:edit-task-agent:new-queued',
+    ]);
+  });
+
   it('evicts older queued workflow intents when retry-workflow fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -26,6 +26,15 @@ function runningExecutionKey(task: TaskState): string {
   return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
 }
 
+export function isDispatchableLaunch(task: TaskState): boolean {
+  return task.status === 'running'
+    || (
+      task.status === 'pending'
+      && task.execution.phase === 'launching'
+      && !!task.execution.selectedAttemptId
+    );
+}
+
 /**
  * Top up idle scheduler capacity after a scoped mutation.
  * This starts globally-ready work while avoiding duplicate execution
@@ -41,12 +50,12 @@ export async function executeGlobalTopup({
 }: GlobalTopupParams): Promise<TaskState[]> {
   const dedupeKeys = new Set(
     alreadyDispatched
-      .filter((task) => task.status === 'running')
+      .filter(isDispatchableLaunch)
       .map((task) => runningExecutionKey(task)),
   );
   const started = orchestrator.startExecution();
   const runnable = started
-    .filter((task) => task.status === 'running')
+    .filter(isDispatchableLaunch)
     .filter((task) => !dedupeKeys.has(runningExecutionKey(task)));
 
   if (runnable.length === 0) {
@@ -81,7 +90,7 @@ export async function dispatchStartedTasksWithGlobalTopup({
   started = [],
   mutationTiming,
 }: MutationTopupParams): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
-  const runnable = started.filter((task) => task.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     logger?.info(
       `[global-topup] ${context}: dispatching ${runnable.length} scoped task(s): [${runnable.map((task) => task.id).join(', ')}]`,

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -46,7 +46,12 @@ import {
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import type { CostGroupDimension } from './cost-rollup.js';
 import { openExternalTerminalForTask } from './open-terminal-for-task.js';
-import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import {
+  dispatchStartedTasksWithGlobalTopup,
+  executeGlobalTopup,
+  finalizeMutationWithGlobalTopup,
+  isDispatchableLaunch,
+} from './global-topup.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
@@ -1528,7 +1533,7 @@ async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<vo
       )
       : await deps.commandService.retryTask(envelope);
     if (!result.ok) throw new Error(result.error.message);
-    const runnable = result.data.filter(t => t.status === 'running');
+    const runnable = result.data.filter(isDispatchableLaunch);
     process.stdout.write(`Restarted task "${taskId}" — ${runnable.length} task(s) to execute\n`);
 
     const taskExecutor = createHeadlessExecutor(deps);
@@ -1664,7 +1669,7 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
   const started = await rebaseAndRetry(taskId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
-  const runnable = started.filter(t => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
     taskExecutor: te,
@@ -1707,7 +1712,7 @@ async function headlessRecreateWithRebase(workflowTarget: string, deps: Headless
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
   const started = await recreateWithRebase(workflowId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
-  const runnable = started.filter(t => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
     taskExecutor: te,
@@ -1754,7 +1759,7 @@ async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps):
       async () => sharedRecreateWorkflow(workflowId, { persistence: deps.persistence, orchestrator: deps.orchestrator }),
     )
     : sharedRecreateWorkflow(workflowId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
-  const runnable = started.filter(t => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     const te = createHeadlessExecutor(deps);
     const autoFix = wireHeadlessAutoFix(deps, te);
@@ -1818,7 +1823,7 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
       async () => sharedRecreateTask(taskId, { persistence: deps.persistence, orchestrator: deps.orchestrator }),
     )
     : sharedRecreateTask(taskId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
-  const runnable = started.filter(t => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
   process.stdout.write(`Recreate task "${taskId}" (+ downstream) — ${runnable.length} task(s) to execute (pool fetch skipped)\n`);
   const te = createHeadlessExecutor(deps);
@@ -1913,7 +1918,7 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
     { module: 'headless' },
   );
   const retryRunningSummary = result.data
-    .filter((task) => task.status === 'running')
+    .filter(isDispatchableLaunch)
     .map((task) => `${task.id}(${task.config.workflowId ?? 'unknown'})`);
   if (retryRunningSummary.length > 0) {
     deps.logger.info(
@@ -1921,7 +1926,7 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
       { module: 'headless' },
     );
   }
-  const runnable = result.data.filter((t) => t.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   const crossWorkflow = runnable.filter((t) => t.config.workflowId !== workflowId);
   if (crossWorkflow.length > 0) {
     deps.logger.info(
@@ -1940,7 +1945,7 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
   const scopedKeys = new Set(runnable.map((task) => runningKey(task)));
   const globalTopup = deps.orchestrator
     .startExecution()
-    .filter((task) => task.status === 'running')
+    .filter(isDispatchableLaunch)
     .filter((task) => !scopedKeys.has(runningKey(task)));
   deps.logger.info(
     `headlessRetryWorkflow trace workflow="${workflowId}" postStartExecution globalTopup=${globalTopup.length}`,
@@ -2057,7 +2062,7 @@ async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDe
   const envelope = makeEnvelope('edit-task-command', 'headless', 'task', { taskId, newCommand });
   const result = await deps.commandService.editTaskCommand(envelope);
   if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((task) => task.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2091,7 +2096,7 @@ async function headlessEditPrompt(taskId: string, newPrompt: string, deps: Headl
   const envelope = makeEnvelope('edit-task-prompt', 'headless', 'task', { taskId, newPrompt });
   const result = await deps.commandService.editTaskPrompt(envelope);
   if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((task) => task.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2135,7 +2140,7 @@ async function headlessEditExecutor(
   const envelope = makeEnvelope('edit-task-type', 'headless', 'task', { taskId, runnerKind, poolMemberId });
   const result = await deps.commandService.editTaskType(envelope);
   if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((task) => task.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2173,7 +2178,7 @@ async function headlessEditAgent(taskId: string, agentName: string, deps: Headle
   const envelope = makeEnvelope('edit-task-agent', 'headless', 'task', { taskId, agentName });
   const result = await deps.commandService.editTaskAgent(envelope);
   if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((task) => task.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2561,7 +2566,7 @@ async function headlessSetMergeMode(
   });
   const result = await deps.commandService.editTaskMergeMode(envelope);
   if (!result.ok) throw new Error(result.error.message);
-  const runnable = result.data.filter((t) => t.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2617,7 +2622,7 @@ async function headlessSetFixContext(
     autoFix.unsubscribe();
     throw new Error(result.error.message);
   }
-  const runnable = result.data.filter((t) => t.status === 'running');
+  const runnable = result.data.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await taskExecutor.executeTasks(runnable);
   }
@@ -2664,7 +2669,7 @@ async function headlessSetGatePolicy(args: string[], deps: HeadlessDeps): Promis
     });
     const result = await deps.commandService.setTaskExternalGatePolicies(envelope);
     if (!result.ok) throw new Error(result.error.message);
-    const runnable = result.data.filter((t) => t.status === 'running');
+    const runnable = result.data.filter(isDispatchableLaunch);
     if (runnable.length > 0) {
       const taskExecutor = createHeadlessExecutor(deps);
       await taskExecutor.executeTasks(runnable);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -142,7 +142,12 @@ import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
-import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from './global-topup.js';
+import {
+  dispatchStartedTasksWithGlobalTopup,
+  executeGlobalTopup,
+  finalizeMutationWithGlobalTopup,
+  isDispatchableLaunch,
+} from './global-topup.js';
 import { computeDeferredLaunchTiming } from './deferred-runnable.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
 import { relaunchOrphansAndStartReady } from './orphan-relaunch.js';
@@ -153,6 +158,12 @@ import {
   buildActionGraphDiagnostics,
   resolveActionDiagnosticsStallThresholdMs,
 } from './action-graph-diagnostics.js';
+
+function isTaskInFlightForForcedStop(task: TaskState): boolean {
+  return task.status === 'running'
+    || task.status === 'fixing_with_ai'
+    || (task.status === 'pending' && task.execution.phase === 'launching');
+}
 
 declare const __BUILD_SHA__: string | undefined;
 declare const __BUILD_VERSION__: string | undefined;
@@ -821,7 +832,7 @@ if (isHeadless) {
             const envelope = makeEnvelope('replace-task', 'ui', 'task', { taskId, replacementTasks });
             const result = await commandService.replaceTask(envelope);
             if (!result.ok) throw new Error(result.error.message);
-            const runnable = result.data.filter((task) => task.status === 'running');
+            const runnable = result.data.filter(isDispatchableLaunch);
             if (runnable.length > 0) {
               const executor = createStandaloneTaskExecutor();
               await executor.executeTasks(runnable);
@@ -851,7 +862,7 @@ if (isHeadless) {
               const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId, experimentId: ids[0] });
               const result = await commandService.selectExperiment(envelope);
               if (!result.ok) throw new Error(result.error.message);
-              const runnable = result.data.filter((task) => task.status === 'running');
+              const runnable = result.data.filter(isDispatchableLaunch);
               if (runnable.length > 0) await executor.executeTasks(runnable);
               return undefined;
             }
@@ -865,7 +876,7 @@ if (isHeadless) {
             const envelope = makeEnvelope('set-gate-policies', 'ui', 'task', { taskId, updates });
             const result = await commandService.setTaskExternalGatePolicies(envelope);
             if (!result.ok) throw new Error(result.error.message);
-            const runnable = result.data.filter((task) => task.status === 'running');
+            const runnable = result.data.filter(isDispatchableLaunch);
             if (runnable.length > 0) {
               const executor = createStandaloneTaskExecutor();
               await executor.executeTasks(runnable);
@@ -1088,11 +1099,12 @@ if (isHeadless) {
       }
       if (ownsHeadlessShutdown && orchestrator) {
         for (const task of orchestrator.getAllTasks()) {
-          if (task.status === 'running' || task.status === 'fixing_with_ai') {
+          if (isTaskInFlightForForcedStop(task)) {
             if (persistence) persistShutdownDiagnostic(task, persistence);
             orchestrator.handleWorkerResponse({
               requestId: `quit-${task.id}`,
               actionId: task.id,
+              attemptId: task.execution.selectedAttemptId,
               executionGeneration: task.execution.generation ?? 0,
               status: 'failed',
               outputs: { exitCode: 1, error: 'Application quit' },
@@ -2359,7 +2371,7 @@ if (isHeadless) {
                 const leaseExpiresAt = parseExecutionDate(selectedAttempt?.leaseExpiresAt);
                 const remoteHeartbeat = parseExecutionDate(task.execution.remoteHeartbeatAt);
 
-                if (task.status === 'running') {
+                if (task.status === 'running' || (task.status === 'pending' && task.execution.phase === 'launching')) {
                   const launchStartedAt = parseExecutionDate(task.execution.launchStartedAt)
                     ?? parseExecutionDate(task.execution.startedAt);
                   const launchAgeMs = launchStartedAt ? now.getTime() - launchStartedAt.getTime() : 0;
@@ -2389,7 +2401,7 @@ if (isHeadless) {
                     };
                     logger.error(`[launch-stall] forcing failure for "${task.id}": ${launchError}`, { module: 'db-poll' });
                     const startedAfterFailure = orchestrator.handleWorkerResponse(failedResponse);
-                    const runnableAfterFailure = startedAfterFailure.filter((candidate) => candidate.status === 'running');
+                    const runnableAfterFailure = startedAfterFailure.filter(isDispatchableLaunch);
                     if (runnableAfterFailure.length > 0) {
                       logger.info(
                         `[launch-stall] dispatching ${runnableAfterFailure.length} task(s) started after failing "${task.id}"`,
@@ -2437,7 +2449,7 @@ if (isHeadless) {
                     };
                     logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
                     const startedAfterFailure = orchestrator.handleWorkerResponse(failedResponse);
-                    const runnableAfterFailure = startedAfterFailure.filter((candidate) => candidate.status === 'running');
+                    const runnableAfterFailure = startedAfterFailure.filter(isDispatchableLaunch);
                     if (runnableAfterFailure.length > 0) {
                       logger.info(
                         `[executing-stall] dispatching ${runnableAfterFailure.length} task(s) started after failing "${task.id}"`,
@@ -2808,20 +2820,25 @@ if (isHeadless) {
 
     registerGuiMutationHandler('invoker:stop', async () => {
       logger.info('stop — destroying all executors', { module: 'ipc' });
-      await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
-      const allTasks = orchestrator.getAllTasks();
-      for (const task of allTasks) {
-        if (task.status === 'running' || task.status === 'fixing_with_ai') {
-          logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc' });
-          orchestrator.handleWorkerResponse({
-            requestId: `stop-${task.id}`,
-            actionId: task.id,
-            executionGeneration: task.execution.generation ?? 0,
-            status: 'failed',
-            outputs: { exitCode: 1, error: 'Stopped by user' },
-          });
+      const failInFlightTasks = (): void => {
+        const allTasks = orchestrator.getAllTasks();
+        for (const task of allTasks) {
+          if (isTaskInFlightForForcedStop(task)) {
+            logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc' });
+            orchestrator.handleWorkerResponse({
+              requestId: `stop-${task.id}`,
+              actionId: task.id,
+              attemptId: task.execution.selectedAttemptId,
+              executionGeneration: task.execution.generation ?? 0,
+              status: 'failed',
+              outputs: { exitCode: 1, error: 'Stopped by user' },
+            });
+          }
         }
-      }
+      };
+      failInFlightTasks();
+      await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
+      failInFlightTasks();
     });
 
     registerGuiMutationHandler('invoker:clear', async () => {
@@ -3057,7 +3074,7 @@ if (isHeadless) {
           const envelope = makeEnvelope('select-experiment', 'ui', 'task', { taskId, experimentId: ids[0] });
           const result = await commandService.selectExperiment(envelope);
           if (!result.ok) throw new Error(result.error.message);
-          const runnable = result.data.filter(t => t.status === 'running');
+          const runnable = result.data.filter(isDispatchableLaunch);
           await requireTaskExecutor().executeTasks(runnable);
         } else {
           // Multi-select: needs taskExecutor for branch merge, stays in workflow-actions
@@ -3095,7 +3112,7 @@ if (isHeadless) {
           `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task after commandService.retryTask: count=${started.length} [${started.map((t) => `${t.id}(${t.status})`).join(', ')}]`,
           { module: 'ipc' },
         );
-        const runnable = started.filter(t => t.status === 'running');
+        const runnable = started.filter(isDispatchableLaunch);
         logger.info(
           `${RESTART_TO_BRANCH_TRACE} ipc invoker:restart-task runnable=${runnable.length} [${runnable.map((t) => t.id).join(', ') || '(none)'}] → taskExecutor.executeTasks`,
           { module: 'ipc' },

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -614,7 +614,7 @@ if (isHeadless) {
     const command = cliArgs[0];
     const readOnlyMode = isHeadlessReadOnlyCommand(cliArgs);
     const mutatingMode = isHeadlessMutatingCommand(cliArgs);
-    const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1';
+    const standaloneMode = process.env.INVOKER_HEADLESS_STANDALONE === '1' || command === 'owner-serve';
     const ownsHeadlessShutdown = standaloneMode && !readOnlyMode && command === 'owner-serve';
     const queueQueryMode = command === 'queue' || (command === 'query' && cliArgs[1] === 'queue');
 
@@ -958,6 +958,39 @@ if (isHeadless) {
           }
           return workflowMutationCoordinator.enqueue<T>(workflowId, priority, channel, args);
         };
+
+        if (!workflowMutationDispatcher.has('headless.exec')) {
+          workflowMutationDispatcher.set('headless.exec', async (payloadArg: unknown) => {
+            const payload = payloadArg as HeadlessExecMutationPayload;
+            await runHeadless(payload.args, {
+              ...headlessDeps,
+              waitForApproval: payload.waitForApproval,
+              noTrack: payload.noTrack,
+              signal: activeMutationContext?.signal,
+              mutationTiming: activeMutationContext?.mutationTiming,
+            });
+            return { ok: true };
+          });
+        }
+        if (!workflowMutationCoordinator) {
+          workflowMutationCoordinator = new PersistedWorkflowMutationCoordinator(
+            persistence,
+            workflowMutationOwnerId,
+            async (channel: string, args: unknown[], context) => {
+              const handler = workflowMutationDispatcher.get(channel);
+              if (!handler) {
+                throw new Error(`No workflow mutation dispatcher registered for ${channel}`);
+              }
+              activeMutationContext = context;
+              try {
+                return await handler(...args);
+              } finally {
+                activeMutationContext = undefined;
+              }
+            },
+            { maxConcurrentWorkflowDrains, logger },
+          );
+        }
 
         const executeStandaloneHeadlessRun = async (
           payload: HeadlessRunMutationPayload,

--- a/packages/app/src/orphan-relaunch.ts
+++ b/packages/app/src/orphan-relaunch.ts
@@ -1,5 +1,6 @@
 import type { Logger } from '@invoker/contracts';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
+import { isDispatchableLaunch } from './global-topup.js';
 
 export function relaunchOrphansAndStartReady(
   orchestrator: Orchestrator,
@@ -31,7 +32,7 @@ export function relaunchOrphansAndStartReady(
       { module: logPrefix },
     );
     const started = orchestrator.retryTask(task.id);
-    const runnable = started.filter((candidate) => candidate.status === 'running');
+    const runnable = started.filter(isDispatchableLaunch);
     if (runnable.length > 0) {
       orphanRestarted.push(...runnable);
       continue;

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -404,7 +404,7 @@ export class PersistedWorkflowMutationCoordinator {
     }
     const payload = args[0] as { args?: unknown[] } | undefined;
     const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
-    if (rawArgs[0] === 'recreate' || rawArgs[0] === 'recreate-task') {
+    if (rawArgs[0] === 'recreate' || rawArgs[0] === 'recreate-task' || rawArgs[0] === 'recreate-with-rebase') {
       return 'recreate';
     }
     if (rawArgs[0] === 'delete' || rawArgs[0] === 'delete-workflow' || rawArgs[0] === 'delete-all') {
@@ -442,7 +442,7 @@ export class PersistedWorkflowMutationCoordinator {
     if (!isWorkflowId) {
       return false;
     }
-    return command === 'recreate' || command === 'retry';
+    return command === 'recreate' || command === 'recreate-with-rebase' || command === 'retry';
   }
 
   private createTiming(

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -20,6 +20,7 @@ import type { TaskRunner } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
+import { isDispatchableLaunch } from './global-topup.js';
 
 // ── Lineage guard ─────────────────────────────────────────────
 
@@ -689,7 +690,7 @@ export async function setWorkflowMergeMode(
     return;
   }
   const started = deps.orchestrator.editTaskMergeMode(mergeTask.id, normalized);
-  const runnable = started.filter((t) => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await deps.taskExecutor.executeTasks(runnable);
   }
@@ -734,7 +735,7 @@ export async function setTaskFixContext(
   deps: Pick<ActionDeps, 'orchestrator'> & { taskExecutor: TaskRunner },
 ): Promise<TaskState[]> {
   const started = deps.orchestrator.editTaskFixContext(taskId, patch);
-  const runnable = started.filter((t) => t.status === 'running');
+  const runnable = started.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     await deps.taskExecutor.executeTasks(runnable);
   }
@@ -1090,7 +1091,7 @@ export async function autoFixOnFailure(
         persistence,
         taskExecutor,
       });
-      const runnable = started.filter((candidate) => candidate.status === 'running');
+      const runnable = started.filter(isDispatchableLaunch);
       persistence.logEvent?.(taskId, 'debug.auto-fix', {
         phase: 'auto-fix-post-route-recreate-workflow',
         workflowId: recoveryRoute.workflowId,
@@ -1165,7 +1166,7 @@ export async function autoFixOnFailure(
     }
     assertLineageCurrent(lineage, orchestrator, deps.signal);
     const started = orchestrator.retryTask(taskId);
-    const runnable = started.filter(t => t.status === 'running');
+    const runnable = started.filter(isDispatchableLaunch);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-post-route-restart',
       startedCount: started.length,

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -50,6 +50,7 @@ import {
 import {
   dispatchStartedTasksWithGlobalTopup,
   executeGlobalTopup,
+  isDispatchableLaunch,
 } from './global-topup.js';
 
 // ── Result types ─────────────────────────────────────────────
@@ -298,7 +299,7 @@ export class WorkflowMutationFacade {
       orchestrator: this.deps.orchestrator,
       logger: this.deps.logger,
     });
-    const runnable = result.started.filter((t) => t.status === 'running');
+    const runnable = result.started.filter(isDispatchableLaunch);
     await this.deps.taskExecutor.executeTasks(runnable);
     const topup = await this.topupOnly('facade.fork-workflow');
     return {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -389,7 +389,14 @@ export class TaskRunner {
       const launchFailedAt = new Date();
       try {
         const latest = this.orchestrator.getTask(task.id);
-        if (latest && (latest.status === 'running' || latest.status === 'fixing_with_ai')) {
+        if (
+          latest
+          && (
+            latest.status === 'running'
+            || latest.status === 'fixing_with_ai'
+            || (latest.status === 'pending' && latest.execution.phase === 'launching')
+          )
+        ) {
           this.persistence.updateTask(task.id, {
             execution: {
               phase: latest.execution.phase ?? 'launching',

--- a/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import { createTaskState, type TaskState } from '@invoker/workflow-graph';
+import {
+  INVALIDATION_POLICIES,
+  planInvalidation,
+  withSchedulerEnqueueCandidates,
+} from '../invalidation-plan.js';
+
+function task(
+  id: string,
+  workflowId: string,
+  dependencies: string[] = [],
+  status: TaskState['status'] = 'completed',
+): TaskState {
+  return {
+    ...createTaskState(id, id, dependencies, {
+      workflowId,
+      command: `echo ${id}`,
+    }),
+    status,
+  };
+}
+
+describe('InvalidationPlan policy registry', () => {
+  it('registers invalidating recreate/retry and schedule-only policies', () => {
+    expect(INVALIDATION_POLICIES.recreateWorkflow).toMatchObject({
+      action: 'recreateWorkflow',
+      scope: 'workflow',
+      mode: 'recreate',
+    });
+    expect(INVALIDATION_POLICIES.recreateTask).toMatchObject({
+      action: 'recreateTask',
+      scope: 'task',
+      mode: 'recreate',
+    });
+    expect(INVALIDATION_POLICIES.retryWorkflow).toMatchObject({
+      action: 'retryWorkflow',
+      scope: 'workflow',
+      mode: 'retry',
+    });
+    expect(INVALIDATION_POLICIES.retryTask).toMatchObject({
+      action: 'retryTask',
+      scope: 'task',
+      mode: 'retry',
+    });
+    expect(INVALIDATION_POLICIES.scheduleOnly).toMatchObject({
+      action: 'scheduleOnly',
+      scope: 'task',
+      mode: 'scheduleOnly',
+    });
+  });
+
+  it('plans workflow recreate as every task in the workflow', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/b', 'wf-1', ['wf-1/a']),
+      task('wf-2/a', 'wf-2'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateWorkflow',
+      targetId: 'wf-1',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'recreateWorkflow',
+      scope: 'workflow',
+      mode: 'recreate',
+      affectedWorkflowIds: ['wf-1'],
+      affectedTaskIds: ['wf-1/a', 'wf-1/b'],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+  });
+
+  it('plans task recreate as the task plus all descendants', () => {
+    const tasks = [
+      task('wf-1/root', 'wf-1'),
+      task('wf-1/child', 'wf-1', ['wf-1/root']),
+      task('wf-1/grandchild', 'wf-1', ['wf-1/child']),
+      task('wf-1/sibling', 'wf-1'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateTask',
+      targetId: 'wf-1/root',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'recreateTask',
+      scope: 'task',
+      mode: 'recreate',
+      affectedWorkflowIds: ['wf-1'],
+      affectedTaskIds: ['wf-1/child', 'wf-1/grandchild', 'wf-1/root'],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+  });
+
+  it('plans task retry as the task plus non-completed descendants', () => {
+    const tasks = [
+      task('wf-1/root', 'wf-1', [], 'failed'),
+      task('wf-1/failed-child', 'wf-1', ['wf-1/root'], 'failed'),
+      task('wf-1/completed-child', 'wf-1', ['wf-1/root'], 'completed'),
+      task('wf-1/after-completed', 'wf-1', ['wf-1/completed-child'], 'failed'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'retryTask',
+      targetId: 'wf-1/root',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'retryTask',
+      scope: 'task',
+      mode: 'retry',
+      affectedTaskIds: ['wf-1/failed-child', 'wf-1/root'],
+    });
+  });
+
+  it('plans workflow retry from retryable roots and downstream retry footprint', () => {
+    const retryStatuses = new Set<TaskState['status']>(['failed', 'blocked']);
+    const tasks = [
+      task('wf-1/root', 'wf-1', [], 'completed'),
+      task('wf-1/failed', 'wf-1', ['wf-1/root'], 'failed'),
+      task('wf-1/downstream', 'wf-1', ['wf-1/failed'], 'pending'),
+      task('wf-1/completed-downstream', 'wf-1', ['wf-1/failed'], 'completed'),
+      task('wf-2/failed', 'wf-2', [], 'failed'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'retryWorkflow',
+      targetId: 'wf-1',
+      tasks,
+      retryStatuses,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'retryWorkflow',
+      scope: 'workflow',
+      mode: 'retry',
+      affectedWorkflowIds: ['wf-1'],
+      affectedTaskIds: ['wf-1/downstream', 'wf-1/failed'],
+    });
+  });
+
+  it('plans schedule-only without invalidating active attempts', () => {
+    const tasks = [
+      task('wf-1/gated', 'wf-1', [], 'running'),
+      task('wf-1/other', 'wf-1'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'scheduleOnly',
+      targetId: 'wf-1/gated',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'scheduleOnly',
+      scope: 'task',
+      mode: 'scheduleOnly',
+      affectedWorkflowIds: ['wf-1'],
+      affectedTaskIds: ['wf-1/gated'],
+      schedulerEnqueueCandidates: [{ taskId: 'wf-1/gated' }],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+  });
+
+  it('sorts lock workflow ids deterministically', () => {
+    const tasks = [
+      task('z/root', 'z'),
+      task('a/child', 'a', ['z/root']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateTask',
+      targetId: 'z/root',
+      tasks,
+    });
+
+    expect(plan.affectedWorkflowIds).toEqual(['a', 'z']);
+    expect(plan.lockPlan.workflowIds).toEqual(['a', 'z']);
+  });
+
+  it('updates scheduler enqueue candidates immutably', () => {
+    const plan = planInvalidation({
+      action: 'recreateWorkflow',
+      targetId: 'wf-1',
+      tasks: [task('wf-1/a', 'wf-1')],
+    });
+
+    const updated = withSchedulerEnqueueCandidates(plan, ['wf-1/b', 'wf-1/a', 'wf-1/a']);
+
+    expect(plan.schedulerEnqueueCandidates).toEqual([]);
+    expect(updated.schedulerEnqueueCandidates).toEqual([
+      { taskId: 'wf-1/a' },
+      { taskId: 'wf-1/b' },
+    ]);
+  });
+});

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -103,12 +103,15 @@ function makeResponse(
   };
 }
 
-function makeOrchestrator(): { orchestrator: Orchestrator; persistence: InMemoryPersistence } {
+function makeOrchestrator(
+  opts: { deferRunningUntilLaunch?: boolean } = {},
+): { orchestrator: Orchestrator; persistence: InMemoryPersistence } {
   const persistence = new InMemoryPersistence();
   const orchestrator = new Orchestrator({
     persistence,
     messageBus: new InMemoryBus(),
     maxConcurrency: 4,
+    deferRunningUntilLaunch: opts.deferRunningUntilLaunch,
   });
   return { orchestrator, persistence };
 }
@@ -203,6 +206,67 @@ describe('Orchestrator launch claims', () => {
     respondForTask(orchestrator, taskId, 'failed', 1);
     started = orchestrator.recreateWorkflow(workflowId);
     expect(started.map((task) => task.id)).toEqual([taskId]);
+  });
+
+  it('keeps recreated tasks pending until executor launch is confirmed', () => {
+    const { orchestrator, persistence } = makeOrchestrator({ deferRunningUntilLaunch: true });
+    orchestrator.loadPlan({
+      name: 'truthful-recreate',
+      onFinish: 'none',
+      tasks: [{ id: 't1', description: 'one', command: 'echo one' }],
+    });
+
+    const taskId = taskIdBySuffix(orchestrator, 't1');
+    const workflowId = orchestrator.getWorkflowIds()[0]!;
+
+    let [claim] = orchestrator.startExecution();
+    expect(claim!.status).toBe('pending');
+    expect(persistence.loadAttempt(claim!.execution.selectedAttemptId!)?.status).toBe('claimed');
+    expect(orchestrator.markTaskRunningAfterLaunch(taskId, claim!.execution.selectedAttemptId!)).toBe(true);
+    respondForTask(orchestrator, taskId, 'completed');
+
+    [claim] = orchestrator.recreateWorkflow(workflowId);
+    const replacementAttemptId = claim!.execution.selectedAttemptId!;
+
+    expect(claim!.status).toBe('pending');
+    expect(orchestrator.getTask(taskId)?.status).toBe('pending');
+    expect(persistence.loadAttempt(replacementAttemptId)?.status).toBe('claimed');
+    expect(orchestrator.getLastInvalidationPlan()).toMatchObject({
+      action: 'recreateWorkflow',
+      mode: 'recreate',
+      affectedTaskIds: [`__merge__${workflowId}`, taskId],
+    });
+
+    expect(orchestrator.markTaskRunningAfterLaunch(taskId, replacementAttemptId)).toBe(true);
+    expect(orchestrator.getTask(taskId)?.status).toBe('running');
+    expect(persistence.loadAttempt(replacementAttemptId)?.status).toBe('running');
+  });
+
+  it('rejects stale attempt completions after recreate advances lineage', () => {
+    const { orchestrator } = makeOrchestrator({ deferRunningUntilLaunch: true });
+    orchestrator.loadPlan({
+      name: 'stale-recreate',
+      onFinish: 'none',
+      tasks: [{ id: 't1', description: 'one', command: 'echo one' }],
+    });
+
+    const taskId = taskIdBySuffix(orchestrator, 't1');
+    const [firstClaim] = orchestrator.startExecution();
+    const staleAttemptId = firstClaim!.execution.selectedAttemptId!;
+    expect(orchestrator.markTaskRunningAfterLaunch(taskId, staleAttemptId)).toBe(true);
+
+    const [replacementClaim] = orchestrator.recreateTask(taskId);
+    const replacementAttemptId = replacementClaim!.execution.selectedAttemptId!;
+    const generation = firstClaim!.execution.generation ?? 0;
+
+    const staleResult = orchestrator.handleWorkerResponse({
+      ...makeResponse(taskId, 'completed', generation),
+      attemptId: staleAttemptId,
+    });
+
+    expect(staleResult).toEqual([]);
+    expect(orchestrator.getTask(taskId)?.execution.selectedAttemptId).toBe(replacementAttemptId);
+    expect(orchestrator.getTask(taskId)?.status).toBe('pending');
   });
 
   it('resumeWorkflow returns persisted pending launch claims', () => {

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -9,3 +9,4 @@ export * from './graph-mutation.js';
 export * from './command-service.js';
 export * from './task-repository.js';
 export * from './invalidation-policy.js';
+export * from './invalidation-plan.js';

--- a/packages/workflow-core/src/invalidation-plan.ts
+++ b/packages/workflow-core/src/invalidation-plan.ts
@@ -1,0 +1,198 @@
+import { getTransitiveDependents, type TaskState } from '@invoker/workflow-graph';
+import type { InvalidationAction, InvalidationScope } from './invalidation-policy.js';
+
+export type InvalidationMode = 'retry' | 'recreate' | 'scheduleOnly';
+
+export interface SchedulerEnqueueCandidate {
+  taskId: string;
+  priority?: number;
+}
+
+export interface InvalidationLockPlan {
+  workflowIds: string[];
+}
+
+export interface InvalidationPlan {
+  reason: string;
+  action: InvalidationAction;
+  scope: InvalidationScope;
+  mode: InvalidationMode;
+  affectedWorkflowIds: string[];
+  affectedTaskIds: string[];
+  schedulerEnqueueCandidates: SchedulerEnqueueCandidate[];
+  lockPlan: InvalidationLockPlan;
+}
+
+export interface InvalidationPlanningContext {
+  targetId: string;
+  tasks: readonly TaskState[];
+  retryStatuses?: ReadonlySet<TaskState['status']>;
+}
+
+export interface InvalidationPlanningRequest extends InvalidationPlanningContext {
+  action: InvalidationAction;
+  reason?: string;
+}
+
+interface InvalidationPolicy {
+  action: InvalidationAction;
+  scope: InvalidationScope;
+  mode: InvalidationMode;
+  reason: string;
+  selectAffectedTasks: (context: InvalidationPlanningContext) => TaskState[];
+  selectInitialEnqueueCandidates?: (context: InvalidationPlanningContext, affectedTasks: readonly TaskState[]) => string[];
+}
+
+function definePolicy(policy: InvalidationPolicy): InvalidationPolicy {
+  return Object.freeze(policy);
+}
+
+function sorted(values: Iterable<string>): string[] {
+  return Array.from(new Set(values)).sort();
+}
+
+function taskMap(tasks: readonly TaskState[]): Map<string, TaskState> {
+  return new Map(tasks.map((task) => [task.id, task]));
+}
+
+function workflowIdsForTasks(tasks: Iterable<TaskState>): string[] {
+  return sorted(
+    Array.from(tasks)
+      .map((task) => task.config.workflowId)
+      .filter((id): id is string => !!id),
+  );
+}
+
+function descendantsOf(
+  taskId: string,
+  tasksById: ReadonlyMap<string, TaskState>,
+  stop?: (task: TaskState) => boolean,
+): TaskState[] {
+  return getTransitiveDependents(taskId, tasksById, stop ?? (() => false))
+    .map((id) => tasksById.get(id))
+    .filter((task): task is TaskState => !!task);
+}
+
+function taskAndDescendants(
+  taskId: string,
+  tasks: readonly TaskState[],
+  stop?: (task: TaskState) => boolean,
+): TaskState[] {
+  const byId = taskMap(tasks);
+  const root = byId.get(taskId);
+  if (!root) return [];
+  return [root, ...descendantsOf(taskId, byId, stop)];
+}
+
+function retryStop(task: TaskState): boolean {
+  return task.status === 'completed' || task.status === 'stale';
+}
+
+function defaultRetryStatuses(): ReadonlySet<TaskState['status']> {
+  return new Set<TaskState['status']>([
+    'failed',
+    'needs_input',
+    'blocked',
+    'stale',
+    'fixing_with_ai',
+    'awaiting_approval',
+    'review_ready',
+  ]);
+}
+
+function makePlan(policy: InvalidationPolicy, context: InvalidationPlanningContext, reason?: string): InvalidationPlan {
+  const affectedTasks = policy.selectAffectedTasks(context);
+  const affectedWorkflowIds = workflowIdsForTasks(affectedTasks);
+  const enqueueTaskIds = policy.selectInitialEnqueueCandidates?.(context, affectedTasks) ?? [];
+  return {
+    reason: reason ?? policy.reason,
+    action: policy.action,
+    scope: policy.scope,
+    mode: policy.mode,
+    affectedWorkflowIds,
+    affectedTaskIds: sorted(affectedTasks.map((task) => task.id)),
+    schedulerEnqueueCandidates: sorted(enqueueTaskIds).map((taskId) => ({ taskId })),
+    lockPlan: { workflowIds: affectedWorkflowIds },
+  };
+}
+
+export const INVALIDATION_POLICIES: Readonly<Partial<Record<InvalidationAction, InvalidationPolicy>>> = Object.freeze({
+  recreateWorkflow: definePolicy({
+    action: 'recreateWorkflow',
+    scope: 'workflow',
+    mode: 'recreate',
+    reason: 'workflow.recreate',
+    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
+  }),
+  recreateWorkflowFromFreshBase: definePolicy({
+    action: 'recreateWorkflowFromFreshBase',
+    scope: 'workflow',
+    mode: 'recreate',
+    reason: 'workflow.recreateFromFreshBase',
+    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
+  }),
+  recreateTask: definePolicy({
+    action: 'recreateTask',
+    scope: 'task',
+    mode: 'recreate',
+    reason: 'task.recreate',
+    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
+  }),
+  retryTask: definePolicy({
+    action: 'retryTask',
+    scope: 'task',
+    mode: 'retry',
+    reason: 'task.retry',
+    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks, retryStop),
+  }),
+  retryWorkflow: definePolicy({
+    action: 'retryWorkflow',
+    scope: 'workflow',
+    mode: 'retry',
+    reason: 'workflow.retry',
+    selectAffectedTasks: ({ targetId, tasks, retryStatuses }) => {
+      const statuses = retryStatuses ?? defaultRetryStatuses();
+      const byId = taskMap(tasks);
+      const affectedIds = new Set<string>();
+      for (const task of tasks) {
+        if (task.config.workflowId !== targetId || !statuses.has(task.status)) continue;
+        affectedIds.add(task.id);
+        for (const descendant of descendantsOf(task.id, byId, retryStop)) {
+          affectedIds.add(descendant.id);
+        }
+      }
+      return Array.from(affectedIds)
+        .map((id) => byId.get(id))
+        .filter((task): task is TaskState => !!task);
+    },
+  }),
+  scheduleOnly: definePolicy({
+    action: 'scheduleOnly',
+    scope: 'task',
+    mode: 'scheduleOnly',
+    reason: 'externalGatePolicy',
+    selectAffectedTasks: ({ targetId, tasks }) => {
+      const task = tasks.find((item) => item.id === targetId);
+      return task ? [task] : [];
+    },
+    selectInitialEnqueueCandidates: (_context, affectedTasks) => affectedTasks.map((task) => task.id),
+  }),
+});
+
+export function planInvalidation(request: InvalidationPlanningRequest): InvalidationPlan {
+  const policy = INVALIDATION_POLICIES[request.action];
+  if (!policy) {
+    throw new Error(`No invalidation policy registered for action "${request.action}"`);
+  }
+  return makePlan(policy, request, request.reason);
+}
+
+export function withSchedulerEnqueueCandidates(
+  plan: InvalidationPlan,
+  taskIds: Iterable<string>,
+): InvalidationPlan {
+  return {
+    ...plan,
+    schedulerEnqueueCandidates: sorted(taskIds).map((taskId) => ({ taskId })),
+  };
+}

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -71,6 +71,11 @@ import {
 import type { GraphMutationHost } from './graph-mutation.js';
 import { buildPlanLocalToScopedIdMap, scopePlanTaskId } from './task-id-scope.js';
 import type { TaskRepository } from './task-repository.js';
+import {
+  planInvalidation,
+  withSchedulerEnqueueCandidates,
+  type InvalidationPlan,
+} from './invalidation-plan.js';
 
 // ── Channel Constants ───────────────────────────────────────
 
@@ -663,6 +668,7 @@ export class Orchestrator {
   private activeWorkflowIds = new Set<string>();
   private deferredTaskIds = new Set<string>();
   private beforeApproveHook?: (task: TaskState) => Promise<void>;
+  private lastInvalidationPlan?: InvalidationPlan;
 
   /**
    * Per-workflow record of the most recently observed upstream base
@@ -1066,6 +1072,16 @@ export class Orchestrator {
     return task.status === 'running' || task.status === 'fixing_with_ai';
   }
 
+  private isExecutableResponseTask(task: TaskState): boolean {
+    return task.status === 'running'
+      || task.status === 'fixing_with_ai'
+      || (
+        task.status === 'pending'
+        && task.execution.phase === 'launching'
+        && !!task.execution.selectedAttemptId
+      );
+  }
+
   private countActivePersistedAttempts(now: number = Date.now()): number {
     let count = 0;
     for (const task of this.stateMachine.getAllTasks()) {
@@ -1427,12 +1443,12 @@ export class Orchestrator {
         }
       }
       if (earlyTask) {
-        const executableStatuses = new Set(['running', 'fixing_with_ai']);
-        if (!executableStatuses.has(earlyTask.status)) {
+        if (!this.isExecutableResponseTask(earlyTask)) {
           this.logger.warn('[orchestrator] handleWorkerResponse: ignoring response for non-executable task', {
             workerResponseStatus: response.status,
             taskId: response.actionId,
             status: earlyTask.status,
+            phase: earlyTask.execution.phase,
           });
           return [];
         }
@@ -2033,6 +2049,12 @@ export class Orchestrator {
     // wired in Step 17) that bypass `applyInvalidation`'s upstream
     // cancel; a no-op when invoked through `applyInvalidation`.
     this.cancelActiveBeforeInvalidation('task', id);
+    let plan = planInvalidation({
+      action: 'retryTask',
+      targetId: id,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
 
     const prevStatus = task.status;
     this.logger.info('[orchestrator] retryTask', { taskId: id, previousStatus: prevStatus });
@@ -2073,6 +2095,8 @@ export class Orchestrator {
     const { affectedIds } = this.resetSubgraphToPending([id], resetChanges, {
       forceResetIds: new Set([id]),
     });
+    plan = withSchedulerEnqueueCandidates(plan, affectedIds);
+    this.lastInvalidationPlan = plan;
     const afterRt = this.stateGetTask(id)!;
     this.logger.info('[agent-session-trace] retryTask: after writeAndSync', {
       taskId: id,
@@ -2149,7 +2173,7 @@ export class Orchestrator {
       (t) => t.config.workflowId === workflowId,
     );
 
-    const retryStatuses = new Set([
+    const retryStatuses: ReadonlySet<TaskStatus> = new Set<TaskStatus>([
       'failed',
       'needs_input',
       'blocked',
@@ -2158,6 +2182,13 @@ export class Orchestrator {
       'awaiting_approval',
       'review_ready',
     ]);
+    let plan = planInvalidation({
+      action: 'retryWorkflow',
+      targetId: workflowId,
+      tasks: this.stateMachine.getAllTasks(),
+      retryStatuses,
+    });
+    this.lastInvalidationPlan = plan;
 
     const resetChanges: TaskStateChanges = {
       status: 'pending',
@@ -2179,6 +2210,8 @@ export class Orchestrator {
       .filter((task) => retryStatuses.has(task.status))
       .map((task) => task.id);
     const { affectedIds } = this.resetSubgraphToPending(retryRootIds, resetChanges);
+    plan = withSchedulerEnqueueCandidates(plan, affectedIds);
+    this.lastInvalidationPlan = plan;
     const afterResetMs = Date.now();
 
     this.logger.info('[orchestrator] retryWorkflow invalidation', {
@@ -2232,10 +2265,13 @@ export class Orchestrator {
     // Defense-in-depth for direct callers (CommandService.recreateTask
     // wired in Step 17); a no-op when invoked through `applyInvalidation`.
     this.cancelActiveBeforeInvalidation('task', rootId);
-    const allTasks = this.stateMachine.getAllTasks();
-    const taskMap = new Map(allTasks.map((t) => [t.id, t]));
-    const descendantIds = getTransitiveDependents(rootId, taskMap, () => false);
-    const toResetIds = [rootId, ...descendantIds];
+    let plan = planInvalidation({
+      action: 'recreateTask',
+      targetId: rootId,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
+    const toResetIds = plan.affectedTaskIds;
     const toResetSet = new Set(toResetIds);
 
     const resetChanges: TaskStateChanges = {
@@ -2283,6 +2319,8 @@ export class Orchestrator {
       .getReadyTasks()
       .map((t) => t.id)
       .filter((id) => toResetSet.has(id));
+    plan = withSchedulerEnqueueCandidates(plan, readyIds);
+    this.lastInvalidationPlan = plan;
     return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
   }
 
@@ -2304,6 +2342,12 @@ export class Orchestrator {
     // recreateWorkflowFromFreshBase wired in Step 17); a no-op when
     // invoked through `applyInvalidation`.
     this.cancelActiveBeforeInvalidation('workflow', workflowId);
+    let plan = planInvalidation({
+      action: 'recreateWorkflow',
+      targetId: workflowId,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
 
     const resetChanges: TaskStateChanges = {
       status: 'pending',
@@ -2378,6 +2422,8 @@ export class Orchestrator {
       .getReadyTasks()
       .map((t) => t.id)
       .filter((id) => this.stateGetTask(id)?.config.workflowId === workflowId);
+    plan = withSchedulerEnqueueCandidates(plan, readyIds);
+    this.lastInvalidationPlan = plan;
     return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
   }
 
@@ -3016,6 +3062,11 @@ export class Orchestrator {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    this.lastInvalidationPlan = planInvalidation({
+      action: 'scheduleOnly',
+      targetId: task.id,
+      tasks: this.stateMachine.getAllTasks(),
+    });
     if (task.status === 'running' || task.status === 'fixing_with_ai') {
       throw new Error(`Cannot edit running task ${taskId}`);
     }
@@ -3571,6 +3622,10 @@ export class Orchestrator {
 
   getAllTasks(): TaskState[] {
     return this.stateMachine.getAllTasks();
+  }
+
+  getLastInvalidationPlan(): InvalidationPlan | undefined {
+    return this.lastInvalidationPlan;
   }
 
   getReadyTasks(): TaskState[] {
@@ -4590,20 +4645,36 @@ export class Orchestrator {
         continue;
       }
 
-      const changes: TaskStateChanges = {
-        status: 'running',
-        execution: {
-          selectedAttemptId: launchAttemptId,
-          generation: this.getExecutionGeneration(task),
-          startedAt: now,
-          lastHeartbeatAt: now,
-          phase: 'launching',
-          launchStartedAt: now,
-          launchCompletedAt: undefined,
-        },
-      };
+      const changes: TaskStateChanges = this.deferRunningUntilLaunch
+        ? {
+            status: 'pending',
+            execution: {
+              selectedAttemptId: launchAttemptId,
+              generation: this.getExecutionGeneration(task),
+              lastHeartbeatAt: now,
+              phase: 'launching',
+              launchStartedAt: now,
+              launchCompletedAt: undefined,
+            },
+          }
+        : {
+            status: 'running',
+            execution: {
+              selectedAttemptId: launchAttemptId,
+              generation: this.getExecutionGeneration(task),
+              startedAt: now,
+              lastHeartbeatAt: now,
+              phase: 'launching',
+              launchStartedAt: now,
+              launchCompletedAt: undefined,
+            },
+          };
       const updated = this.writeAndSync(job.taskId, changes);
-      this.persistence.logEvent?.(job.taskId, 'task.running', changes);
+      this.persistence.logEvent?.(
+        job.taskId,
+        this.deferRunningUntilLaunch ? 'task.launch_claimed' : 'task.running',
+        changes,
+      );
       this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
       started.push(updated);
       this.logger.info('[orchestrator] drainScheduler: started', {

--- a/scripts/bench-recreate-planner-queue.sh
+++ b/scripts/bench-recreate-planner-queue.sh
@@ -1,0 +1,239 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TASK_COUNT="${TASK_COUNT:-20}"
+TIMEOUT_SECONDS="${BENCH_TIMEOUT_SECONDS:-120}"
+KEEP_TEMP="${KEEP_TEMP:-false}"
+SKIP_BUILD="${SKIP_BUILD:-false}"
+
+case "${1:-}" in
+  -h|--help)
+    cat <<'EOF'
+Usage: TASK_COUNT=20 scripts/bench-recreate-planner-queue.sh
+
+Reports:
+  mutationCompletionMs: recreate request start until workflow mutation intent completes
+  replacementEnqueueMs: recreate request start until first replacement selected attempt is pending/claimed/running/completed
+  executorLaunchMs:     first replacement attempt claimed_at until last replacement task launch_completed_at
+
+The benchmark uses an isolated temp HOME/DB/socket/repo and a standalone owner
+plus headless client path. Run it on a baseline checkout and this branch with
+the same TASK_COUNT/environment for before/after comparison.
+EOF
+    exit 0
+    ;;
+esac
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "sqlite3 is required" >&2
+  exit 1
+fi
+
+now_ms() {
+  node -e 'process.stdout.write(String(Date.now()))'
+}
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-recreate-bench.XXXXXX")"
+HOME_DIR="$TMP_DIR/home"
+DB_DIR="$HOME_DIR/.invoker"
+PLAN_PATH="$TMP_DIR/bench-plan.yaml"
+REPO_DIR="$TMP_DIR/repo"
+IPC_SOCKET_PATH="$DB_DIR/bench-ipc.sock"
+OWNER_STDOUT="$TMP_DIR/owner.stdout.log"
+OWNER_STDERR="$TMP_DIR/owner.stderr.log"
+RUN_STDOUT="$TMP_DIR/run.stdout.log"
+RUN_STDERR="$TMP_DIR/run.stderr.log"
+RECREATE_STDOUT="$TMP_DIR/recreate.stdout.log"
+RECREATE_STDERR="$TMP_DIR/recreate.stderr.log"
+
+cleanup() {
+  if [[ -n "${RECREATE_PID:-}" ]]; then
+    kill "$RECREATE_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${OWNER_WRAPPER_PID:-}" ]]; then
+    kill "$OWNER_WRAPPER_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ "$KEEP_TEMP" != "true" ]]; then
+    rm -rf "$TMP_DIR" >/dev/null 2>&1 || true
+  else
+    echo "kept temp: $TMP_DIR" >&2
+  fi
+}
+trap cleanup EXIT
+
+query_sqlite_value() {
+  sqlite3 -noheader "$DB_DIR/invoker.db" "$1"
+}
+
+wait_for_sql() {
+  local sql="$1"
+  local expected="$2"
+  local label="$3"
+  local started_at
+  started_at="$(now_ms)"
+  while true; do
+    local value
+    value="$(query_sqlite_value "$sql" 2>/dev/null || true)"
+    if [[ "$value" == "$expected" ]]; then
+      return 0
+    fi
+    if (( $(now_ms) - started_at > TIMEOUT_SECONDS * 1000 )); then
+      echo "timed out waiting for $label (last=$value)" >&2
+      return 1
+    fi
+    sleep 0.05
+  done
+}
+
+mkdir -p "$DB_DIR" "$REPO_DIR"
+
+pushd "$ROOT_DIR" >/dev/null
+
+if [[ "$SKIP_BUILD" != "true" ]]; then
+  pnpm --filter @invoker/app build >/dev/null
+elif [[ ! -f packages/app/dist/main.js ]]; then
+  echo "packages/app/dist/main.js is missing; unset SKIP_BUILD or build the app first" >&2
+  exit 1
+fi
+
+git -C "$REPO_DIR" init -b main >/dev/null 2>&1
+git -C "$REPO_DIR" config user.name "Invoker Bench"
+git -C "$REPO_DIR" config user.email "bench@example.com"
+printf 'recreate benchmark fixture\n' > "$REPO_DIR/README.md"
+git -C "$REPO_DIR" add README.md
+git -C "$REPO_DIR" commit -m "Initial fixture" >/dev/null 2>&1
+
+cat > "$DB_DIR/config.json" <<EOF
+{
+  "maxConcurrency": $TASK_COUNT
+}
+EOF
+
+{
+  echo "name: Recreate Planner Queue Benchmark"
+  echo "repoUrl: $REPO_DIR"
+  echo "onFinish: none"
+  echo "tasks:"
+  for i in $(seq 1 "$TASK_COUNT"); do
+    echo "  - id: root-$i"
+    echo "    description: Independent root $i"
+    echo "    command: >-"
+    echo "      bash -lc 'printf root-$i > bench-$i.txt'"
+  done
+} > "$PLAN_PATH"
+
+ELECTRON_BIN="$ROOT_DIR/scripts/electron.cjs"
+MAIN_JS="$ROOT_DIR/packages/app/dist/main.js"
+
+HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" NODE_ENV=test "$ELECTRON_BIN" "$MAIN_JS" \
+  >"$OWNER_STDOUT" 2>"$OWNER_STDERR" &
+OWNER_WRAPPER_PID=$!
+
+for _ in {1..300}; do
+  if [[ -f "$DB_DIR/invoker.db.lock/pid" ]]; then
+    OWNER_PID="$(cat "$DB_DIR/invoker.db.lock/pid" 2>/dev/null || true)"
+    if [[ -n "${OWNER_PID:-}" ]] && kill -0 "$OWNER_PID" >/dev/null 2>&1; then
+      break
+    fi
+  fi
+  sleep 0.05
+done
+
+if [[ -z "${OWNER_PID:-}" ]] || ! kill -0 "$OWNER_PID" >/dev/null 2>&1; then
+  echo "owner failed to start" >&2
+  cat "$OWNER_STDERR" >&2 || true
+  exit 1
+fi
+
+HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" NODE_ENV=test "$ELECTRON_BIN" "$MAIN_JS" \
+  --headless run "$PLAN_PATH" >"$RUN_STDOUT" 2>"$RUN_STDERR"
+
+WORKFLOW_ID="$(
+  {
+    sed -n 's/^Workflow ID: //p' "$RUN_STDOUT"
+    sed -n 's/^Delegated to owner .*workflow: //p' "$RUN_STDOUT"
+    sed -n 's/^Delegated to GUI .*workflow: //p' "$RUN_STDOUT"
+  } | head -n1
+)"
+
+if [[ -z "${WORKFLOW_ID:-}" ]]; then
+  echo "failed to capture workflow id" >&2
+  cat "$RUN_STDOUT" >&2 || true
+  cat "$RUN_STDERR" >&2 || true
+  exit 1
+fi
+
+wait_for_sql "select count(*) from tasks where workflow_id = '$WORKFLOW_ID' and is_merge_node = 0 and status = 'completed';" "$TASK_COUNT" "initial completion"
+BASE_GENERATION="$(query_sqlite_value "select min(execution_generation) from tasks where workflow_id = '$WORKFLOW_ID' and is_merge_node = 0;")"
+NEXT_GENERATION="$((BASE_GENERATION + 1))"
+
+START_MS="$(now_ms)"
+HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET_PATH" NODE_ENV=test "$ELECTRON_BIN" "$MAIN_JS" \
+  --headless --no-track recreate "$WORKFLOW_ID" >"$RECREATE_STDOUT" 2>"$RECREATE_STDERR" &
+RECREATE_PID=$!
+
+INTENT_ID=""
+for _ in {1..300}; do
+  INTENT_ID="$(query_sqlite_value "select coalesce(max(id),'') from workflow_mutation_intents where workflow_id = '$WORKFLOW_ID' and args_json like '%\"recreate\",\"$WORKFLOW_ID\"%';" 2>/dev/null || true)"
+  [[ -n "$INTENT_ID" && "$INTENT_ID" != "0" ]] && break
+  sleep 0.05
+done
+
+if [[ -z "$INTENT_ID" || "$INTENT_ID" == "0" ]]; then
+  echo "failed to capture recreate intent" >&2
+  cat "$RECREATE_STDOUT" >&2 || true
+  cat "$RECREATE_STDERR" >&2 || true
+  exit 1
+fi
+
+REPLACEMENT_ENQUEUE_MS=""
+MUTATION_COMPLETION_MS=""
+POLL_START_MS="$(now_ms)"
+while true; do
+  now="$(now_ms)"
+  if [[ -z "$REPLACEMENT_ENQUEUE_MS" ]]; then
+    count="$(query_sqlite_value "select count(*) from tasks t join attempts a on a.id = t.selected_attempt_id where t.workflow_id = '$WORKFLOW_ID' and t.is_merge_node = 0 and t.execution_generation >= $NEXT_GENERATION and a.status in ('pending','claimed','running','completed');" 2>/dev/null || true)"
+    if [[ "${count:-0}" != "0" ]]; then
+      REPLACEMENT_ENQUEUE_MS="$((now - START_MS))"
+    fi
+  fi
+
+  intent_status="$(query_sqlite_value "select coalesce(status,'') from workflow_mutation_intents where id = $INTENT_ID;" 2>/dev/null || true)"
+  if [[ "$intent_status" == "completed" && -z "$MUTATION_COMPLETION_MS" ]]; then
+    MUTATION_COMPLETION_MS="$((now - START_MS))"
+  fi
+
+  if [[ -n "$REPLACEMENT_ENQUEUE_MS" && -n "$MUTATION_COMPLETION_MS" ]]; then
+    break
+  fi
+  if (( now - POLL_START_MS > TIMEOUT_SECONDS * 1000 )); then
+    echo "timed out waiting for recreate metrics (intent=$intent_status enqueueMs=${REPLACEMENT_ENQUEUE_MS:-})" >&2
+    exit 1
+  fi
+  sleep 0.02
+done
+
+wait_for_sql "select count(*) from tasks where workflow_id = '$WORKFLOW_ID' and is_merge_node = 0 and execution_generation >= $NEXT_GENERATION and launch_completed_at is not null;" "$TASK_COUNT" "replacement launch completion"
+
+if ! wait "$RECREATE_PID"; then
+  echo "recreate command failed" >&2
+  cat "$RECREATE_STDOUT" >&2 || true
+  cat "$RECREATE_STDERR" >&2 || true
+  exit 1
+fi
+unset RECREATE_PID
+
+EXECUTOR_LAUNCH_MS="$(query_sqlite_value "select cast(round((julianday(max(t.launch_completed_at)) - julianday(min(a.claimed_at))) * 86400000.0) as integer) from tasks t join attempts a on a.id = t.selected_attempt_id where t.workflow_id = '$WORKFLOW_ID' and t.is_merge_node = 0 and t.execution_generation >= $NEXT_GENERATION and a.claimed_at is not null and t.launch_completed_at is not null;")"
+
+cat <<EOF
+benchmark=recreate-planner-queue
+taskCount=$TASK_COUNT
+workflowId=$WORKFLOW_ID
+intentId=$INTENT_ID
+mutationCompletionMs=$MUTATION_COMPLETION_MS
+replacementEnqueueMs=$REPLACEMENT_ENQUEUE_MS
+executorLaunchMs=$EXECUTOR_LAUNCH_MS
+EOF
+
+popd >/dev/null

--- a/scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh
+++ b/scripts/e2e-dry-run/cases/case-2.15-recreate-preempt-attempt-refresh.sh
@@ -28,22 +28,6 @@ echo "==> case 2.15: submit plan (background — sleep 8 blocks)"
 SUBMIT_LOG="$(mktemp "${TMPDIR:-/tmp}/invoker-e2e-2.15-submit.XXXXXX.log")"
 invoker_e2e_submit_plan_no_track_capture "$PLAN_PATH" "$SUBMIT_LOG"
 
-echo "==> case 2.15: waiting for task to reach running"
-for i in $(seq 1 30); do
-  ST="$(invoker_e2e_task_status e2e-g2215-task 2>/dev/null || true)"
-  if [ "$ST" = "running" ]; then
-    echo "==> case 2.15: task is running (poll $i)"
-    break
-  fi
-  sleep 1
-done
-
-if [ "$(invoker_e2e_task_status e2e-g2215-task 2>/dev/null || true)" != "running" ]; then
-  echo "FAIL case 2.15: task did not reach running before recreate"
-  invoker_e2e_run_headless status 2>&1 || true
-  exit 1
-fi
-
 WF_ID="$(invoker_e2e_extract_workflow_id_from_log "$SUBMIT_LOG")"
 if [ -z "$WF_ID" ]; then
   echo "FAIL case 2.15: could not resolve workflow id"
@@ -52,6 +36,33 @@ if [ -z "$WF_ID" ]; then
 fi
 
 TASK_ID="$WF_ID/e2e-g2215-task"
+
+echo "==> case 2.15: waiting for task to become in-flight"
+IN_FLIGHT=""
+for i in $(seq 1 30); do
+  TASK_JSON="$(invoker_e2e_run_headless query task "$TASK_ID" --output json 2>/dev/null || true)"
+  IN_FLIGHT="$(printf '%s' "$TASK_JSON" | python3 -c 'import json,sys
+try:
+    d=json.load(sys.stdin)
+except Exception:
+    print("")
+    raise SystemExit(0)
+status=d.get("status","")
+phase=(d.get("execution") or {}).get("phase","")
+print("yes" if status=="running" or (status=="pending" and phase=="launching") else "")
+')"
+  if [ "$IN_FLIGHT" = "yes" ]; then
+    echo "==> case 2.15: task is in-flight (poll $i)"
+    break
+  fi
+  sleep 1
+done
+
+if [ "$IN_FLIGHT" != "yes" ]; then
+  echo "FAIL case 2.15: task did not become in-flight before recreate"
+  invoker_e2e_run_headless status 2>&1 || true
+  exit 1
+fi
 
 echo "==> case 2.15: recreate (no-track) while workflow is in-flight"
 invoker_e2e_run_headless --no-track recreate "$WF_ID"

--- a/scripts/rebase-retry-all.sh
+++ b/scripts/rebase-retry-all.sh
@@ -206,42 +206,32 @@ if [ "$FOLLOW" = true ]; then
   process_one_workflow() {
     local wf_id="$1"
     local result_file="$2"
-    local task_id=""
-
     echo "Processing workflow: $wf_id" >&2
 
-    # Use first non-merge task as rebase anchor.
-    task_id=$(headless_task_ids query tasks --workflow "$wf_id" --no-merge --output label | head -1)
-    if [ -z "$task_id" ]; then
-      echo "  No non-merge tasks found, skipping" >&2
-      printf "%s\tSKIPPED\n" "$wf_id" >> "$result_file"
-      return 0
-    fi
-
     if [ "$DRY_RUN" = true ]; then
-      echo "  [DRY RUN] Would rebase task: $task_id" >&2
+      echo "  [DRY RUN] Would recreate workflow from fresh base: $wf_id" >&2
       printf "%s\tSUCCEEDED\n" "$wf_id" >> "$result_file"
       return 0
     fi
 
     if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ]; then
-      echo "  Rebasing task: $task_id (timeout=${COMMAND_TIMEOUT_SECONDS}s)" >&2
+      echo "  Recreating workflow from fresh base: $wf_id (timeout=${COMMAND_TIMEOUT_SECONDS}s)" >&2
     else
-      echo "  Rebasing task: $task_id (no timeout)" >&2
+      echo "  Recreating workflow from fresh base: $wf_id (no timeout)" >&2
     fi
     local cmd_out
     local cmd_status
     if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ]; then
       set +e
       cmd_out="$(
-        run_with_optional_timeout "$COMMAND_TIMEOUT_SECONDS" headless_mutation --no-track rebase "$task_id" 2>&1
+        run_with_optional_timeout "$COMMAND_TIMEOUT_SECONDS" headless_mutation --no-track recreate-with-rebase "$wf_id" 2>&1
       )"
       cmd_status=$?
       set -e
     else
       set +e
       cmd_out="$(
-        headless_mutation --no-track rebase "$task_id" 2>&1
+        headless_mutation --no-track recreate-with-rebase "$wf_id" 2>&1
       )"
       cmd_status=$?
       set -e
@@ -308,21 +298,14 @@ else
     IDX=$((IDX + 1))
     echo "[queue $IDX/$TOTAL_WORKFLOWS] $WF_ID" >&2
 
-    task_id="$(headless_task_ids query tasks --workflow "$WF_ID" --no-merge --output label | head -1)"
-    if [ -z "$task_id" ]; then
-      echo "  No non-merge tasks found, skipping" >&2
-      SKIPPED=$((SKIPPED + 1))
-      continue
-    fi
-
     if [ "$DRY_RUN" = true ]; then
-      echo "  [DRY RUN] Would dispatch rebase for task: $task_id" >&2
+      echo "  [DRY RUN] Would dispatch recreate-with-rebase for workflow: $WF_ID" >&2
       DISPATCHED=$((DISPATCHED + 1))
       continue
     fi
 
     log_file="$LOG_DIR/${WF_ID}.log"
-    printf '{"label":"%s","workflowId":"%s","taskId":"%s","args":["rebase","%s"]}\n' "$WF_ID" "$WF_ID" "$task_id" "$task_id" >> "$COMMANDS_FILE"
+    printf '{"label":"%s","workflowId":"%s","args":["recreate-with-rebase","%s"]}\n' "$WF_ID" "$WF_ID" "$WF_ID" >> "$COMMANDS_FILE"
     echo "  queued log=$log_file" >&2
   done <<< "$WORKFLOW_IDS"
 

--- a/scripts/repro/repro-prod-copy-rebase-retry-all.sh
+++ b/scripts/repro/repro-prod-copy-rebase-retry-all.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# Repro/verification for production-shaped bulk recreate-with-rebase.
+#
+# Copies the local production DB into an isolated temp INVOKER_DB_DIR, marks
+# copied workflows/tasks failed, then runs the real scripts/rebase-retry-all.sh
+# path against a standalone owner. The production DB is never mutated.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+SOURCE_DB="${INVOKER_PROD_DB_SOURCE:-$HOME/.invoker/invoker.db}"
+TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-600}"
+PARALLELISM="${REPRO_PARALLELISM:-12}"
+COMMAND_TIMEOUT_SECONDS="${REPRO_COMMAND_TIMEOUT_SECONDS:-120}"
+KEEP_TMP="${REPRO_KEEP_TMP:-0}"
+PRESERVE_TASK_COMMANDS="${REPRO_PRESERVE_TASK_COMMANDS:-0}"
+SKIP_BUILD="${REPRO_SKIP_BUILD:-0}"
+
+if [[ ! -f "$SOURCE_DB" ]]; then
+  echo "FAIL: production DB not found: $SOURCE_DB" >&2
+  exit 1
+fi
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "FAIL: sqlite3 is required" >&2
+  exit 1
+fi
+
+TMP_DIR="$(mktemp -d -t invoker-prod-rebase-repro.XXXXXX)"
+HOME_DIR="$TMP_DIR/home"
+DB_DIR="$TMP_DIR/db"
+LOG_DIR="$TMP_DIR/logs"
+IPC_SOCKET="/tmp/invoker-prod-rebase-repro-$$.sock"
+OWNER_LOG="$LOG_DIR/owner.log"
+BULK_LOG="$LOG_DIR/rebase-retry-all.log"
+mkdir -p "$HOME_DIR/.invoker" "$DB_DIR" "$LOG_DIR"
+
+OWNER_PID=""
+cleanup() {
+  if [[ -n "${OWNER_PID:-}" ]] && kill -0 "$OWNER_PID" >/dev/null 2>&1; then
+    kill "$OWNER_PID" >/dev/null 2>&1 || true
+    wait "$OWNER_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ "$KEEP_TMP" != "1" ]]; then
+    rm -rf "$TMP_DIR"
+  else
+    echo "Kept temp repro dir: $TMP_DIR" >&2
+  fi
+  rm -f "$IPC_SOCKET"
+}
+trap cleanup EXIT
+
+run_with_timeout() {
+  local seconds="$1"
+  shift
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "$seconds" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "$seconds" "$@"
+  else
+    python3 - "$seconds" "$@" <<'PY'
+import subprocess
+import sys
+
+timeout = int(sys.argv[1])
+cmd = sys.argv[2:]
+try:
+    raise SystemExit(subprocess.run(cmd, timeout=timeout).returncode)
+except subprocess.TimeoutExpired:
+    print(f"Timed out after {timeout}s: {' '.join(cmd)}", file=sys.stderr)
+    raise SystemExit(124)
+PY
+  fi
+}
+
+probe_exec_endpoint() {
+  node - <<'JS'
+const path = require('node:path');
+
+(async () => {
+  const repoRoot = process.cwd();
+  const mod = await import(path.join(repoRoot, 'packages', 'transport', 'dist', 'index.js'));
+  const bus = new mod.IpcBus(undefined, { allowServe: false });
+  await bus.ready();
+  try {
+    await Promise.race([
+      bus.request('headless.exec', { args: ['__endpoint_probe__'], noTrack: true }),
+      new Promise((_, reject) => setTimeout(() => reject(new Error('probe timeout')), 1000)),
+    ]);
+    process.exitCode = 0;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (/Unknown command: __endpoint_probe__/.test(message)) {
+      process.exitCode = 0;
+    } else {
+      process.stderr.write(message + '\n');
+      process.exitCode = 1;
+    }
+  } finally {
+    bus.disconnect();
+  }
+})().catch((error) => {
+  process.stderr.write((error instanceof Error ? error.message : String(error)) + '\n');
+  process.exitCode = 1;
+});
+JS
+}
+
+now_ms() {
+  python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+}
+
+echo "==> copying production DB into isolated repro DB"
+sqlite3 "$SOURCE_DB" ".backup '$DB_DIR/invoker.db'"
+
+cat > "$HOME_DIR/.invoker/config.json" <<'JSON'
+{
+  "allowGraphMutation": true,
+  "disableAutoRunOnStartup": true,
+  "maxConcurrency": 12,
+  "autoFixRetries": 0
+}
+JSON
+
+echo "==> normalizing copied DB to failed-workload state"
+sqlite3 "$DB_DIR/invoker.db" <<SQL
+delete from workflow_mutation_intents;
+delete from workflow_mutation_leases;
+update workflows
+set status = 'failed',
+    updated_at = datetime('now');
+update tasks
+set status = 'failed',
+    exit_code = 1,
+    error = 'prod-copy bulk recreate repro synthetic failure',
+    launch_phase = null,
+    launch_started_at = null,
+    launch_completed_at = null,
+    started_at = null,
+    completed_at = datetime('now'),
+    last_heartbeat_at = null,
+    selected_attempt_id = null,
+    is_fixing_with_ai = 0,
+    pending_fix_error = null;
+update attempts
+set status = 'failed',
+    claimed_at = null,
+    started_at = null,
+    completed_at = datetime('now'),
+    exit_code = 1,
+    error = 'prod-copy bulk recreate repro synthetic failure',
+    last_heartbeat_at = null,
+    lease_expires_at = null;
+SQL
+
+if [[ "$PRESERVE_TASK_COMMANDS" != "1" ]]; then
+  sqlite3 "$DB_DIR/invoker.db" <<'SQL'
+update tasks
+set command = 'true',
+    prompt = coalesce(prompt, 'prod-copy bulk recreate repro noop prompt')
+where is_merge_node = 0;
+SQL
+fi
+
+WORKFLOW_COUNT="$(sqlite3 "$DB_DIR/invoker.db" "select count(*) from workflows;")"
+TASK_COUNT="$(sqlite3 "$DB_DIR/invoker.db" "select count(*) from tasks;")"
+FINAL_WORKFLOW_ID="$(sqlite3 "$DB_DIR/invoker.db" "select id from workflows order by id desc limit 1;")"
+echo "==> copied workload: workflows=$WORKFLOW_COUNT tasks=$TASK_COUNT finalWorkflow=$FINAL_WORKFLOW_ID"
+
+ELECTRON="$REPO_ROOT/scripts/electron.cjs"
+MAIN="$REPO_ROOT/packages/app/dist/main.js"
+if [[ "$SKIP_BUILD" != "1" ]]; then
+  echo "==> building current transport/app dist"
+  pnpm --filter @invoker/transport build >/dev/null
+  pnpm --filter @invoker/app build >/dev/null
+elif [[ ! -f "$MAIN" ]]; then
+  echo "==> building app dist"
+  pnpm --filter @invoker/app build >/dev/null
+fi
+
+echo "==> starting standalone owner"
+HOME="$HOME_DIR" \
+INVOKER_DB_DIR="$DB_DIR" \
+INVOKER_IPC_SOCKET="$IPC_SOCKET" \
+INVOKER_HEADLESS_STANDALONE=1 \
+INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS=900000 \
+INVOKER_CLAUDE_COMMAND="${INVOKER_CLAUDE_COMMAND:-/usr/bin/true}" \
+INVOKER_CLAUDE_FIX_COMMAND="${INVOKER_CLAUDE_FIX_COMMAND:-/usr/bin/true}" \
+INVOKER_GIT_NETWORK_TIMEOUT_MS="${INVOKER_GIT_NETWORK_TIMEOUT_MS:-120000}" \
+NODE_ENV=test \
+"$ELECTRON" "$MAIN" --headless owner-serve >"$OWNER_LOG" 2>&1 &
+OWNER_PID="$!"
+
+for _ in $(seq 1 120); do
+  if ! kill -0 "$OWNER_PID" >/dev/null 2>&1; then
+    echo "FAIL: owner exited before ready" >&2
+    cat "$OWNER_LOG" >&2 || true
+    exit 1
+  fi
+  if grep -q 'standalone owner ready' "$OWNER_LOG" 2>/dev/null && [[ -e "$IPC_SOCKET" ]]; then
+    break
+  fi
+  sleep 0.25
+done
+if ! grep -q 'standalone owner ready' "$OWNER_LOG" 2>/dev/null; then
+  echo "FAIL: owner never became ready" >&2
+  cat "$OWNER_LOG" >&2 || true
+  exit 1
+fi
+
+for _ in $(seq 1 80); do
+  if HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET" probe_exec_endpoint >/dev/null 2>&1; then
+    break
+  fi
+  sleep 0.25
+done
+if ! HOME="$HOME_DIR" INVOKER_DB_DIR="$DB_DIR" INVOKER_IPC_SOCKET="$IPC_SOCKET" probe_exec_endpoint >/tmp/invoker-prod-rebase-probe.out 2>&1; then
+  echo "FAIL: owner headless.exec endpoint never became ready" >&2
+  cat /tmp/invoker-prod-rebase-probe.out >&2 || true
+  cat "$OWNER_LOG" >&2 || true
+  exit 1
+fi
+
+echo "==> running scripts/rebase-retry-all.sh against prod-copy DB"
+START_MS="$(now_ms)"
+set +e
+HOME="$HOME_DIR" \
+INVOKER_DB_DIR="$DB_DIR" \
+INVOKER_IPC_SOCKET="$IPC_SOCKET" \
+INVOKER_CLAUDE_COMMAND="${INVOKER_CLAUDE_COMMAND:-/usr/bin/true}" \
+INVOKER_CLAUDE_FIX_COMMAND="${INVOKER_CLAUDE_FIX_COMMAND:-/usr/bin/true}" \
+INVOKER_GIT_NETWORK_TIMEOUT_MS="${INVOKER_GIT_NETWORK_TIMEOUT_MS:-120000}" \
+NODE_ENV=test \
+run_with_timeout "$TIMEOUT_SECONDS" \
+  bash "$REPO_ROOT/scripts/rebase-retry-all.sh" \
+    --status failed \
+    --parallel "$PARALLELISM" \
+    --timeout "$COMMAND_TIMEOUT_SECONDS" \
+  >"$BULK_LOG" 2>&1
+STATUS=$?
+set -e
+DISPATCH_END_MS="$(now_ms)"
+DISPATCH_ELAPSED_MS=$((DISPATCH_END_MS - START_MS))
+
+if [[ "$STATUS" -ne 0 ]]; then
+  echo "FAIL: rebase-retry-all exited $STATUS after ${DISPATCH_ELAPSED_MS}ms" >&2
+  tail -n 120 "$BULK_LOG" >&2 || true
+  echo "owner log:" >&2
+  tail -n 120 "$OWNER_LOG" >&2 || true
+  exit "$STATUS"
+fi
+
+INTENT_TOTAL=0
+INTENT_COMPLETED=0
+INTENT_RUNNING=0
+INTENT_QUEUED=0
+INTENT_FAILED=0
+
+while true; do
+  read -r INTENT_TOTAL INTENT_COMPLETED INTENT_RUNNING INTENT_QUEUED INTENT_FAILED < <(
+    sqlite3 "$DB_DIR/invoker.db" "
+      select
+        count(*),
+        sum(case when status = 'completed' then 1 else 0 end),
+        sum(case when status = 'running' then 1 else 0 end),
+        sum(case when status = 'queued' then 1 else 0 end),
+        sum(case when status = 'failed' then 1 else 0 end)
+      from workflow_mutation_intents
+      where args_json like '%recreate-with-rebase%';
+    " | tr '|' ' '
+  )
+  NOW_MS="$(now_ms)"
+  if [[ "$INTENT_TOTAL" -eq "$WORKFLOW_COUNT" && "$INTENT_COMPLETED" -eq "$WORKFLOW_COUNT" && "$INTENT_RUNNING" -eq 0 && "$INTENT_QUEUED" -eq 0 && "$INTENT_FAILED" -eq 0 ]]; then
+    break
+  fi
+  if [[ $(((NOW_MS - START_MS) / 1000)) -ge "$TIMEOUT_SECONDS" ]]; then
+    echo "FAIL: mutation queue did not drain before ${TIMEOUT_SECONDS}s: total=$INTENT_TOTAL completed=$INTENT_COMPLETED running=$INTENT_RUNNING queued=$INTENT_QUEUED failed=$INTENT_FAILED" >&2
+    tail -n 120 "$BULK_LOG" >&2 || true
+    echo "owner log:" >&2
+    tail -n 160 "$OWNER_LOG" >&2 || true
+    exit 1
+  fi
+  sleep 1
+done
+DRAIN_END_MS="$(now_ms)"
+DRAIN_ELAPSED_MS=$((DRAIN_END_MS - START_MS))
+
+FINAL_STATUS="$(sqlite3 "$DB_DIR/invoker.db" "
+  select coalesce(status, '')
+  from workflow_mutation_intents
+  where workflow_id = '$FINAL_WORKFLOW_ID'
+    and args_json like '%recreate-with-rebase%'
+  order by id desc
+  limit 1;
+")"
+
+MAX_INTENT_MS="$(sqlite3 "$DB_DIR/invoker.db" "
+  select coalesce(cast(round(max((julianday(completed_at) - julianday(started_at)) * 86400000.0)) as integer), 0)
+  from workflow_mutation_intents
+  where args_json like '%recreate-with-rebase%'
+    and started_at is not null
+    and completed_at is not null;
+")"
+
+if [[ "$INTENT_TOTAL" -ne "$WORKFLOW_COUNT" ]]; then
+  echo "FAIL: expected $WORKFLOW_COUNT recreate-with-rebase intents, found $INTENT_TOTAL" >&2
+  exit 1
+fi
+if [[ "$INTENT_COMPLETED" -ne "$WORKFLOW_COUNT" || "$INTENT_RUNNING" -ne 0 || "$INTENT_QUEUED" -ne 0 || "$INTENT_FAILED" -ne 0 ]]; then
+  echo "FAIL: mutation queue did not drain: completed=$INTENT_COMPLETED running=$INTENT_RUNNING queued=$INTENT_QUEUED failed=$INTENT_FAILED" >&2
+  exit 1
+fi
+if [[ "$FINAL_STATUS" != "completed" ]]; then
+  echo "FAIL: final workflow $FINAL_WORKFLOW_ID intent status is '$FINAL_STATUS'" >&2
+  exit 1
+fi
+
+echo "PASS prod-copy rebase-retry-all"
+echo "  workflows: $WORKFLOW_COUNT"
+echo "  tasks: $TASK_COUNT"
+echo "  dispatchWallMs: $DISPATCH_ELAPSED_MS"
+echo "  queueDrainWallMs: $DRAIN_ELAPSED_MS"
+echo "  maxIntentMs: $MAX_INTENT_MS"
+echo "  finalWorkflow: $FINAL_WORKFLOW_ID"
+echo "  finalWorkflowIntentStatus: $FINAL_STATUS"
+echo "  logs: $LOG_DIR"


### PR DESCRIPTION
## Summary

Mass `rebase-retry-all` was timing out before it could reliably submit every workflow. The script queried a task for each workflow, dispatched through that task id, and standalone owner mode processed no-track delegated mutations inline instead of durably enqueueing them.

This PR sends the workflow command directly, `recreate-with-rebase <workflowId>`, treats it as a recreate queue fence, and gives standalone owner mode the same persisted mutation queue used by the GUI owner. Bulk submit now returns after the recreate intent is accepted, while the owner drains the actual rebase/recreate work in the background.

## Architecture

### Before

```mermaid
flowchart TD
  Bulk[rebase-retry-all] --> W[query workflows]
  W --> T[query first non-merge task per workflow]
  T --> R[dispatch rebase taskId]
  R --> Inline[standalone owner may run mutation inline]
  Inline --> Timeout[bulk IPC request can time out]
```

### After

```mermaid
flowchart TD
  Bulk[rebase-retry-all] --> W[query workflows]
  W --> R[dispatch recreate-with-rebase workflowId]
  R --> Q[persist workflow mutation intent]
  Q --> Drain[owner drains recreate/rebase queue]
```

## Test Plan

- [x] `bash -n scripts/repro/repro-prod-copy-rebase-retry-all.sh`
- [x] Prod-copy repro: `REPRO_SKIP_BUILD=1 REPRO_TIMEOUT_SECONDS=600 REPRO_PARALLELISM=12 REPRO_COMMAND_TIMEOUT_SECONDS=120 REPRO_KEEP_TMP=1 bash scripts/repro/repro-prod-copy-rebase-retry-all.sh`
  - copied `33` workflows / `164` tasks from `~/.invoker/invoker.db`
  - forced only the copy into failed state
  - result: `dispatchWallMs=18381`, `queueDrainWallMs=189522`, `maxIntentMs=101690`, final workflow `completed`
- [x] Repro before the standalone queue fix hit the real failure: `33` request timeouts after `108019ms`
- [x] `pnpm --filter @invoker/app test -- headless-client owner-delegation persisted-workflow-mutation-coordinator` (`56` files, `883` passed, `1` skipped)
- [x] `pnpm run check:types`
- [x] `git diff --check`

## Revert Plan

- Safe to revert? Yes.
- Revert command: `git revert 115347e 91c41a3`
- Post-revert steps: None.
- Data migration? No.
