### PR TITLE
Add default execution pool config

### DIFF
--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -46,7 +46,7 @@
   },
 
   "executionPools": {
-    "ssh-light": {
+    "mixed-local-ssh": {
       "comment": "Pool routes tasks across mixed SSH/local members with shared queue/drain semantics",
       "members": [
         { "type": "ssh", "id": "staging-server" },
@@ -55,14 +55,24 @@
       ],
       "selectionStrategy": "roundRobin",
       "maxConcurrentTasksPerMember": 1
+    },
+    "pnpm-ssh": {
+      "comment": "Pool for pnpm commands that should run only on SSH machines",
+      "members": [
+        { "type": "ssh", "id": "staging-server" },
+        { "type": "ssh", "id": "build-server-b" }
+      ],
+      "selectionStrategy": "roundRobin",
+      "maxConcurrentTasksPerMember": 1
     }
   },
+  "defaultPoolId": "mixed-local-ssh",
 
   "executorRoutingRules": [
     {
-      "comment": "Route pnpm commands to ssh-light pool",
+      "comment": "Route pnpm commands to the SSH-only pool before defaultPoolId applies",
       "regex": "\\bpnpm(?:\\s|$)",
-      "poolId": "ssh-light",
+      "poolId": "pnpm-ssh",
       "strategy": "route"
     }
   ],

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -198,4 +198,13 @@ describe('loadConfig', () => {
     });
   });
 
+  it('reads defaultPoolId from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ defaultPoolId: 'mixed-local-ssh' }),
+    );
+    const config = loadConfig();
+    expect(config.defaultPoolId).toBe('mixed-local-ssh');
+  });
+
 });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -135,6 +135,11 @@ export interface InvokerConfig {
     maxConcurrentTasksPerMember?: number;
   }>;
   /**
+   * Default execution pool for tasks that do not declare poolId and are not
+   * routed by executorRoutingRules. Applies to command and prompt-only tasks.
+   */
+  defaultPoolId?: string;
+  /**
    * Config-owned routing policy for heavyweight shell commands.
    * Matching tasks are auto-routed to the configured pool at plan submission time.
    * Default matcher set for v1 is any command invoking `pnpm`.

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -437,6 +437,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     maxConcurrency: effectiveMaxConcurrency,
     defaultAutoFixRetries: invokerConfig.autoFixRetries,
     executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
+    defaultPoolId: invokerConfig.defaultPoolId,
     availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
     deferRunningUntilLaunch: true,
   });
@@ -2894,6 +2895,7 @@ if (isHeadless) {
         maxConcurrency: effectiveMaxConcurrency,
         defaultAutoFixRetries: invokerConfig.autoFixRetries,
         executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
+        defaultPoolId: invokerConfig.defaultPoolId,
         availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
         deferRunningUntilLaunch: true,
       });

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1365,6 +1365,86 @@ describe('Orchestrator', () => {
         expect(task!.config.runnerKind).toBe('ssh');
         expect(task!.config.poolId).toBe('ssh-light');
       });
+
+      it('applies defaultPoolId to command tasks when no route rule matches', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          defaultPoolId: 'mixed-local-ssh',
+          executorRoutingRules: [
+            { regex: '\\bpnpm(?:\\s|$)', poolId: 'pnpm-ssh', strategy: 'route' },
+          ],
+          availablePoolIds: ['mixed-local-ssh', 'pnpm-ssh'],
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'default-pool-command',
+          tasks: [{ id: 't1', description: 'Echo hello', command: 'echo hello' }],
+        });
+
+        const task = routedOrchestrator.getTask('t1');
+        expect(task!.config.runnerKind).toBe('ssh');
+        expect(task!.config.poolId).toBe('mixed-local-ssh');
+      });
+
+      it('applies defaultPoolId to prompt-only tasks', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          defaultPoolId: 'mixed-local-ssh',
+          availablePoolIds: ['mixed-local-ssh'],
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'default-pool-prompt',
+          tasks: [{ id: 't1', description: 'Prompt task', prompt: 'inspect the code' }],
+        });
+
+        const task = routedOrchestrator.getTask('t1');
+        expect(task!.config.runnerKind).toBe('ssh');
+        expect(task!.config.poolId).toBe('mixed-local-ssh');
+      });
+
+      it('lets route strategy override defaultPoolId', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          defaultPoolId: 'mixed-local-ssh',
+          executorRoutingRules: [
+            { regex: '\\bpnpm(?:\\s|$)', poolId: 'pnpm-ssh', strategy: 'route' },
+          ],
+          availablePoolIds: ['mixed-local-ssh', 'pnpm-ssh'],
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'default-pool-route-override',
+          tasks: [{ id: 't1', description: 'Run tests', command: 'pnpm test' }],
+        });
+
+        const task = routedOrchestrator.getTask('t1');
+        expect(task!.config.runnerKind).toBe('ssh');
+        expect(task!.config.poolId).toBe('pnpm-ssh');
+      });
+
+      it('throws when defaultPoolId is not configured as an execution pool', () => {
+        const routedOrchestrator = new Orchestrator({
+          persistence: new InMemoryPersistence(),
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          defaultPoolId: 'missing-pool',
+          availablePoolIds: ['other-pool'],
+        });
+
+        expect(() => {
+          routedOrchestrator.loadPlan({
+            name: 'default-pool-missing',
+            tasks: [{ id: 't1', description: 'Prompt task', prompt: 'inspect the code' }],
+          });
+        }).toThrow('defaultPoolId');
+      });
     });
 
     // ── atomicity ───────────────────────────────────────────

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -417,20 +417,21 @@ const DEFAULT_HEAVYWEIGHT_COMMAND_MATCHERS: CommandRoutingMatcher[] = [
 
 function validateRoutingDestinationAvailability(
   taskId: string,
-  command: string,
+  command: string | undefined,
   sourceLabel: string,
   poolId: string | undefined,
   availablePoolIds: Set<string>,
 ): void {
+  const commandLabel = command ? ` with command "${command}"` : '';
   if (availablePoolIds.size > 0 && (!poolId || !availablePoolIds.has(poolId))) {
     throw new Error(
-      `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
+      `Task "${taskId}"${commandLabel} matched ${sourceLabel}, ` +
       `but config poolId="${poolId}" is not defined in executionPools.`,
     );
   }
   if (availablePoolIds.size === 0) {
     throw new Error(
-      `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
+      `Task "${taskId}"${commandLabel} matched ${sourceLabel}, ` +
       'but no executionPools are configured.',
     );
   }
@@ -539,10 +540,23 @@ function resolveExecutorRouting(
   taskId: string,
   command: string | undefined,
   planPoolId: string | undefined,
+  defaultPoolId: string | undefined,
   rules: ExecutorRoutingRule[],
   availablePoolIds: Set<string>,
 ): { poolId?: string } {
   if (!command || rules.length === 0) {
+    if (planPoolId === undefined && defaultPoolId !== undefined) {
+      validateRoutingDestinationAvailability(
+        taskId,
+        command,
+        'defaultPoolId',
+        defaultPoolId,
+        availablePoolIds,
+      );
+      return {
+        poolId: defaultPoolId,
+      };
+    }
     return {
       poolId: planPoolId,
     };
@@ -562,6 +576,17 @@ function resolveExecutorRouting(
       availablePoolIds,
     );
     effectivePoolId = routed?.poolId ?? effectivePoolId;
+  }
+
+  if (effectivePoolId === undefined && defaultPoolId !== undefined) {
+    validateRoutingDestinationAvailability(
+      taskId,
+      command,
+      'defaultPoolId',
+      defaultPoolId,
+      availablePoolIds,
+    );
+    effectivePoolId = defaultPoolId;
   }
 
   const enforcementRules = rules.filter((rule) => (rule.strategy ?? 'enforce') === 'enforce');
@@ -635,6 +660,8 @@ export interface OrchestratorConfig {
    * Internally translated into executorRoutingRules with strategy="route".
    */
   heavyweightCommandRouting?: HeavyweightCommandRoutingPolicy;
+  /** Default execution pool ID for tasks that do not otherwise select a pool. */
+  defaultPoolId?: string;
   /** Valid execution pool IDs available at plan submission time. */
   availablePoolIds?: string[];
   /**
@@ -661,6 +688,7 @@ export class Orchestrator {
   private readonly taskRepository: TaskRepository;
   private readonly maxConcurrency: number;
   private readonly executorRoutingRules: ExecutorRoutingRule[];
+  private readonly defaultPoolId?: string;
   private readonly availablePoolIds: Set<string>;
   private readonly defaultAutoFixRetries: number;
   private readonly deferRunningUntilLaunch: boolean;
@@ -726,6 +754,7 @@ export class Orchestrator {
       ...(config.executorRoutingRules ?? []),
       ...buildHeavyweightRoutingRules('config', config.heavyweightCommandRouting),
     ];
+    this.defaultPoolId = config.defaultPoolId;
     this.availablePoolIds = new Set(config.availablePoolIds ?? []);
     this.defaultAutoFixRetries = Math.min(Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0)), 10);
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
@@ -1258,6 +1287,7 @@ export class Orchestrator {
         taskDef.id,
         taskDef.command,
         taskDef.poolId,
+        this.defaultPoolId,
         this.executorRoutingRules,
         this.availablePoolIds,
       );


### PR DESCRIPTION
## Summary

Adds `defaultPoolId` to user config so tasks without an explicit `poolId` can use a named execution pool by default.

This lets a config define a mixed default pool, while keeping more specific route rules such as `pnpm` to an SSH-only pool. The default applies to both command tasks and prompt-only tasks after explicit plan routing and route-strategy rules have had a chance to select a pool.

## Architecture

### Before

```mermaid
graph TD
    A[Plan task] --> B{Task has command?}
    B -->|yes| C[Apply matching route/enforce rules]
    B -->|no| D[No pool routing]
    C --> E[Persist selected poolId or none]
    D --> E
```

### After

```mermaid
graph TD
    A[Plan task] --> B{Explicit poolId?}
    B -->|yes| E[Use explicit poolId]
    B -->|no| C{Route rule matches?}
    C -->|yes| F[Use routed poolId]
    C -->|no| D{defaultPoolId set?}
    D -->|yes| G[Use defaultPoolId]
    D -->|no| H[No poolId]
    E --> I[Persist task]
    F --> I
    G --> I
    H --> I
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/config.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert bf7fe3a`
- Post-revert steps: Remove `defaultPoolId` from any local `~/.invoker/config.json` files that started using it.
- Data migration? No
