### PR TITLE
Refine workflow graph UI

### DIFF
--- a/packages/ui/src/__tests__/layout.test.ts
+++ b/packages/ui/src/__tests__/layout.test.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it } from 'vitest';
-import { layoutTaskGraph } from '../lib/layout.js';
+/**
+ * Tests for layoutNodes — the Sugiyama-inspired DAG layout algorithm.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { layoutNodes, layoutTaskGraph, countCrossings } from '../lib/layout.js';
 import type { TaskState } from '../types.js';
 
-function makeTask(id: string, deps: string[] = []): TaskState {
+function makeTask(
+  id: string,
+  deps: string[] = [],
+): TaskState {
   return {
     id,
     description: `Task ${id}`,
@@ -13,6 +20,257 @@ function makeTask(id: string, deps: string[] = []): TaskState {
     execution: {},
   };
 }
+
+describe('layoutNodes', () => {
+  it('positions nodes at correct x/y for each level', () => {
+    // A -> B -> C (linear chain, 3 levels)
+    const tasks = [
+      makeTask('a'),
+      makeTask('b', ['a']),
+      makeTask('c', ['b']),
+    ];
+
+    const positions = layoutNodes(tasks);
+
+    expect(positions.size).toBe(3);
+
+    const posA = positions.get('a')!;
+    const posB = positions.get('b')!;
+    const posC = positions.get('c')!;
+
+    // Level 0, 1, 2 — x should increase
+    expect(posA.x).toBeLessThan(posB.x);
+    expect(posB.x).toBeLessThan(posC.x);
+
+    // Single node at each level, so y should be the same (centered)
+    expect(posA.y).toBe(posB.y);
+    expect(posB.y).toBe(posC.y);
+  });
+
+  it('handles single node', () => {
+    const tasks = [makeTask('solo')];
+
+    const positions = layoutNodes(tasks);
+
+    expect(positions.size).toBe(1);
+    expect(positions.has('solo')).toBe(true);
+
+    const pos = positions.get('solo')!;
+    expect(pos.x).toBe(0); // Level 0
+    expect(typeof pos.y).toBe('number');
+  });
+
+  it('handles disconnected components', () => {
+    // Two independent tasks (no dependencies between them)
+    const tasks = [
+      makeTask('alpha'),
+      makeTask('beta'),
+    ];
+
+    const positions = layoutNodes(tasks);
+
+    expect(positions.size).toBe(2);
+
+    const posAlpha = positions.get('alpha')!;
+    const posBeta = positions.get('beta')!;
+
+    // Both at level 0, same x
+    expect(posAlpha.x).toBe(posBeta.x);
+
+    // Different y (stacked vertically)
+    expect(posAlpha.y).not.toBe(posBeta.y);
+  });
+
+  it('handles empty task list', () => {
+    const positions = layoutNodes([]);
+    expect(positions.size).toBe(0);
+  });
+
+  it('stacks multiple nodes at same level vertically', () => {
+    // A -> B, A -> C (B and C at same level)
+    const tasks = [
+      makeTask('a'),
+      makeTask('b', ['a']),
+      makeTask('c', ['a']),
+    ];
+
+    const positions = layoutNodes(tasks);
+
+    const posB = positions.get('b')!;
+    const posC = positions.get('c')!;
+
+    // Same level, same x
+    expect(posB.x).toBe(posC.x);
+
+    // Different y
+    expect(posB.y).not.toBe(posC.y);
+  });
+
+  it('gives more vertical space to highly connected nodes', () => {
+    // Hub: A -> B, A -> C, A -> D, A -> E (A has 4 connections)
+    // Lone: X (0 connections)
+    // Both A and X at level 0
+    const tasks = [
+      makeTask('a'),
+      makeTask('x'),
+      makeTask('b', ['a']),
+      makeTask('c', ['a']),
+      makeTask('d', ['a']),
+      makeTask('e', ['a']),
+    ];
+
+    const positions = layoutNodes(tasks);
+
+    const posA = positions.get('a')!;
+    const posX = positions.get('x')!;
+
+    // A and X are both at level 0, stacked vertically
+    expect(posA.x).toBe(posX.x);
+    expect(posA.y).not.toBe(posX.y);
+
+    // The gap between A and X should be > base gap (40)
+    // because A has 4 children (4 connections)
+    const gap = Math.abs(posA.y - posX.y) - 80; // subtract NODE_HEIGHT
+    expect(gap).toBeGreaterThan(40);
+  });
+
+  it('reduces edge crossings in a diamond+crossing pattern', () => {
+    // Classic crossing scenario:
+    //   a1 -> b2   (cross)
+    //   a2 -> b1   (cross)
+    // Without reordering: edges cross. With barycenter: b1, b2 reorder to match.
+    const tasks = [
+      makeTask('a1'),
+      makeTask('a2'),
+      makeTask('b1', ['a2']),
+      makeTask('b2', ['a1']),
+    ];
+
+    const positions = layoutNodes(tasks);
+
+    const posA1 = positions.get('a1')!;
+    const posA2 = positions.get('a2')!;
+    const posB1 = positions.get('b1')!;
+    const posB2 = positions.get('b2')!;
+
+    // After barycenter ordering:
+    // If a1 is above a2, then b2 (child of a1) should be above b1 (child of a2)
+    // This means edges don't cross.
+    if (posA1.y < posA2.y) {
+      expect(posB2.y).toBeLessThan(posB1.y);
+    } else {
+      expect(posB1.y).toBeLessThan(posB2.y);
+    }
+  });
+
+  it('handles complex DAG with multiple levels and fan-out', () => {
+    // root -> mid1, mid2; mid1 -> leaf; mid2 -> leaf
+    const tasks = [
+      makeTask('root'),
+      makeTask('mid1', ['root']),
+      makeTask('mid2', ['root']),
+      makeTask('leaf', ['mid1', 'mid2']),
+    ];
+
+    const positions = layoutNodes(tasks);
+
+    expect(positions.size).toBe(4);
+
+    const posRoot = positions.get('root')!;
+    const posMid1 = positions.get('mid1')!;
+    const posMid2 = positions.get('mid2')!;
+    const posLeaf = positions.get('leaf')!;
+
+    // root at level 0, mid at level 1, leaf at level 2
+    expect(posRoot.x).toBeLessThan(posMid1.x);
+    expect(posMid1.x).toBe(posMid2.x);
+    expect(posMid1.x).toBeLessThan(posLeaf.x);
+
+    // Leaf should be roughly centered between mid1 and mid2
+    // (median alignment nudges it toward neighbors)
+    const midCenter = (posMid1.y + posMid2.y) / 2;
+    expect(Math.abs(posLeaf.y - midCenter)).toBeLessThan(100);
+  });
+
+  it('gives deterministic positions regardless of input order', () => {
+    const tasks = [
+      makeTask('z', ['m']),
+      makeTask('a'),
+      makeTask('m', ['a']),
+    ];
+    // Shuffle the input order
+    const shuffled = [tasks[1], tasks[2], tasks[0]];
+
+    const pos1 = layoutNodes(tasks);
+    const pos2 = layoutNodes(shuffled);
+
+    expect(pos1.get('a')).toEqual(pos2.get('a'));
+    expect(pos1.get('m')).toEqual(pos2.get('m'));
+    expect(pos1.get('z')).toEqual(pos2.get('z'));
+  });
+
+  it('preserves correct levels for wide fan-in', () => {
+    // a, b, c all feed into d
+    const tasks = [
+      makeTask('a'),
+      makeTask('b'),
+      makeTask('c'),
+      makeTask('d', ['a', 'b', 'c']),
+    ];
+
+    const positions = layoutNodes(tasks);
+
+    const posA = positions.get('a')!;
+    const posB = positions.get('b')!;
+    const posC = positions.get('c')!;
+    const posD = positions.get('d')!;
+
+    // a, b, c at level 0 (same x), d at level 1
+    expect(posA.x).toBe(posB.x);
+    expect(posB.x).toBe(posC.x);
+    expect(posD.x).toBeGreaterThan(posA.x);
+  });
+});
+
+describe('countCrossings', () => {
+  it('returns 0 for parallel non-crossing edges', () => {
+    const children = new Map<string, string[]>([
+      ['a', ['c']],
+      ['b', ['d']],
+    ]);
+
+    // a->c and b->d don't cross when order matches
+    expect(countCrossings(['a', 'b'], ['c', 'd'], children)).toBe(0);
+  });
+
+  it('detects a single crossing', () => {
+    const children = new Map<string, string[]>([
+      ['a', ['d']],
+      ['b', ['c']],
+    ]);
+
+    // a->d and b->c cross because a is above b but d is below c
+    expect(countCrossings(['a', 'b'], ['c', 'd'], children)).toBe(1);
+  });
+
+  it('returns 0 for empty levels', () => {
+    const children = new Map<string, string[]>();
+    expect(countCrossings([], [], children)).toBe(0);
+  });
+
+  it('counts multiple crossings', () => {
+    // 3 nodes on each side, fully reversed
+    const children = new Map<string, string[]>([
+      ['a', ['z']],
+      ['b', ['y']],
+      ['c', ['x']],
+    ]);
+
+    // a->z, b->y, c->x with left=[a,b,c] right=[x,y,z]
+    // All 3 pairs cross: (a->z,b->y), (a->z,c->x), (b->y,c->x)
+    expect(countCrossings(['a', 'b', 'c'], ['x', 'y', 'z'], children)).toBe(3);
+  });
+});
 
 describe('layoutTaskGraph', () => {
   it('returns a position for every task', async () => {
@@ -27,6 +285,7 @@ describe('layoutTaskGraph', () => {
       { id: 'local:b->c', source: 'b', target: 'c' },
     ]);
 
+    expect(result.usedFallback).toBe(false);
     expect(result.positions.size).toBe(tasks.length);
     for (const task of tasks) {
       expect(result.positions.has(task.id)).toBe(true);
@@ -64,10 +323,7 @@ describe('layoutTaskGraph', () => {
     ];
 
     const reference = await layoutTaskGraph(tasks, edges);
-    const shuffled = await layoutTaskGraph(
-      [tasks[3], tasks[1], tasks[0], tasks[2]],
-      [edges[2], edges[0], edges[3], edges[1]],
-    );
+    const shuffled = await layoutTaskGraph([tasks[3], tasks[1], tasks[0], tasks[2]], [edges[2], edges[0], edges[3], edges[1]]);
 
     for (const task of tasks) {
       expect(shuffled.positions.get(task.id)).toEqual(reference.positions.get(task.id));
@@ -88,17 +344,22 @@ describe('layoutTaskGraph', () => {
     expect(result.positions.get('source')!.x).toBeLessThan(result.positions.get('target')!.x);
   });
 
-  it('rejects when ELK fails', async () => {
+  it('falls back to legacy positions when ELK fails', async () => {
     const tasks = [
       makeTask('a'),
       makeTask('b', ['a']),
     ];
 
-    await expect(layoutTaskGraph(
+    const result = await layoutTaskGraph(
       tasks,
       [{ id: 'local:a->b', source: 'a', target: 'b' }],
       { elk: { layout: async () => { throw new Error('forced failure'); } } },
-    )).rejects.toThrow('forced failure');
+    );
+
+    expect(result.usedFallback).toBe(true);
+    expect(result.edgePoints.size).toBe(0);
+    expect(result.error).toContain('forced failure');
+    expect(result.positions).toEqual(layoutNodes(tasks));
   });
 
   it('passes through routed edge points when ELK returns them', async () => {
@@ -134,6 +395,7 @@ describe('layoutTaskGraph', () => {
       },
     );
 
+    expect(result.usedFallback).toBe(false);
     expect(result.edgePoints.get('local:a->b')).toEqual([
       { x: 290, y: 60 },
       { x: 320, y: 60 },

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -20,7 +20,7 @@ function task(id: string, workflowId: string): TaskState {
 }
 
 describe('WorkflowGraph', () => {
-  it('calls selection and context menu handlers', async () => {
+  it('calls selection and context menu handlers', () => {
     const onSelectWorkflow = vi.fn();
     const onWorkflowContextMenu = vi.fn();
     const workflows = new Map([
@@ -41,7 +41,7 @@ describe('WorkflowGraph', () => {
       />,
     );
 
-    const node = await screen.findByRole('button');
+    const node = screen.getByRole('button');
     fireEvent.click(node);
     expect(onSelectWorkflow).toHaveBeenCalledWith('wf-a');
 
@@ -50,7 +50,7 @@ describe('WorkflowGraph', () => {
     expect(onWorkflowContextMenu.mock.calls[0][1]).toBe('wf-a');
   });
 
-  it('renders workflow even when status filter does not match', async () => {
+  it('renders workflow even when status filter does not match', () => {
     const workflows = new Map([
       ['wf-a', wf('wf-a', 'running')],
     ]);
@@ -69,149 +69,6 @@ describe('WorkflowGraph', () => {
       />,
     );
 
-    expect((await screen.findAllByText('wf-a')).length).toBeGreaterThan(0);
-  });
-
-  it('renders workflow dependency edges as dashed cross-workflow edges', async () => {
-    const workflows = new Map([
-      ['wf-a', wf('wf-a', 'completed')],
-      ['wf-b', wf('wf-b', 'running')],
-    ]);
-    const tasks = new Map([
-      ['t1', task('t1', 'wf-a')],
-      [
-        't2',
-        {
-          ...task('t2', 'wf-b'),
-          config: {
-            workflowId: 'wf-b',
-            externalDependencies: [
-              { workflowId: 'wf-a', requiredStatus: 'completed' as const },
-            ],
-          },
-        },
-      ],
-    ]);
-
-    const { container } = render(
-      <WorkflowGraph
-        tasks={tasks}
-        workflows={workflows}
-        selectedWorkflowId={null}
-        statusFilters={new Set()}
-        onSelectWorkflow={() => {}}
-        onWorkflowContextMenu={() => {}}
-      />,
-    );
-
-    await screen.findByTestId('workflow-node-wf-a');
-    const edgePath = container.querySelector('svg path');
-    expect(edgePath).toHaveAttribute('stroke-dasharray', '6 4');
-  });
-
-  it('does not render the workflow id as secondary chip text', async () => {
-    const workflows = new Map([
-      ['branch-like-id', { id: 'branch-like-id', name: 'Workflow A', status: 'running' } satisfies WorkflowMeta],
-    ]);
-    const tasks = new Map([
-      ['t1', task('t1', 'branch-like-id')],
-    ]);
-
-    render(
-      <WorkflowGraph
-        tasks={tasks}
-        workflows={workflows}
-        selectedWorkflowId={null}
-        statusFilters={new Set()}
-        onSelectWorkflow={() => {}}
-        onWorkflowContextMenu={() => {}}
-      />,
-    );
-
-    expect(await screen.findByText('Workflow A')).toBeInTheDocument();
-    expect(screen.queryByText('branch-like-id')).not.toBeInTheDocument();
-  });
-
-  it('uses the selected workflow status color for the selection ring', async () => {
-    const workflows = new Map([
-      ['wf-failed', wf('wf-failed', 'failed')],
-      ['wf-completed', wf('wf-completed', 'completed')],
-    ]);
-    const tasks = new Map([
-      ['t1', task('t1', 'wf-failed')],
-      ['t2', task('t2', 'wf-completed')],
-    ]);
-
-    const { rerender } = render(
-      <WorkflowGraph
-        tasks={tasks}
-        workflows={workflows}
-        selectedWorkflowId="wf-failed"
-        statusFilters={new Set()}
-        onSelectWorkflow={() => {}}
-        onWorkflowContextMenu={() => {}}
-      />,
-    );
-
-    expect(await screen.findByTestId('workflow-node-wf-failed')).toHaveClass('ring-red-500/80');
-    expect(screen.getByTestId('workflow-node-wf-failed')).not.toHaveClass('ring-blue-400/80');
-
-    rerender(
-      <WorkflowGraph
-        tasks={tasks}
-        workflows={workflows}
-        selectedWorkflowId="wf-completed"
-        statusFilters={new Set()}
-        onSelectWorkflow={() => {}}
-        onWorkflowContextMenu={() => {}}
-      />,
-    );
-
-    expect(await screen.findByTestId('workflow-node-wf-completed')).toHaveClass('ring-green-500/80');
-  });
-
-  it('renders failed workflow status from query-provided workflow metadata', async () => {
-    const workflows = new Map([
-      [
-        'wf-1778431088547-35',
-        {
-          id: 'wf-1778431088547-35',
-          name: 'Reduce Large Files Step 2: main.ts decomposition',
-          status: 'failed',
-        } satisfies WorkflowMeta,
-      ],
-    ]);
-    const tasks = new Map([
-      ['wf-1778431088547-35/extract-main-bootstrap-and-ipc', task('wf-1778431088547-35/extract-main-bootstrap-and-ipc', 'wf-1778431088547-35')],
-      [
-        'wf-1778431088547-35/extract-main-window-and-runner-wiring',
-        {
-          ...task('wf-1778431088547-35/extract-main-window-and-runner-wiring', 'wf-1778431088547-35'),
-          status: 'failed' as const,
-          dependencies: ['wf-1778431088547-35/extract-main-bootstrap-and-ipc'],
-        },
-      ],
-      [
-        'wf-1778431088547-35/verify-main-decomposition-lane',
-        {
-          ...task('wf-1778431088547-35/verify-main-decomposition-lane', 'wf-1778431088547-35'),
-          dependencies: ['wf-1778431088547-35/extract-main-window-and-runner-wiring'],
-        },
-      ],
-    ]);
-
-    render(
-      <WorkflowGraph
-        tasks={tasks}
-        workflows={workflows}
-        selectedWorkflowId={null}
-        statusFilters={new Set()}
-        onSelectWorkflow={() => {}}
-        onWorkflowContextMenu={() => {}}
-      />,
-    );
-
-    expect(await screen.findByText('Reduce Large Files Step 2: main.ts decomposition')).toBeInTheDocument();
-    expect(screen.getByText('failed')).toBeInTheDocument();
+    expect(screen.getAllByText('wf-a').length).toBeGreaterThan(0);
   });
 });

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -1,5 +1,5 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
 import { WorkflowInspector } from '../components/WorkflowInspector.js';
 import type { TaskState, WorkflowMeta } from '../types.js';
 
@@ -23,48 +23,12 @@ const workflow: WorkflowMeta = {
   baseBranch: 'main',
 };
 
-function workflowTaskMap(...workflowTasks: TaskState[]): Map<string, TaskState> {
-  return new Map(workflowTasks.map((workflowTask) => [workflowTask.id, workflowTask]));
-}
-
 describe('WorkflowInspector', () => {
-  it('uses the selected node name as the sidebar title', () => {
-    const { rerender } = render(
-      <WorkflowInspector
-        workflow={workflow}
-        task={null}
-        executionAgents={['codex', 'claude']}
-        collapsed={false}
-        advancedExpanded={false}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow 1 task DAG');
-    expect(screen.queryByText('Inspector')).not.toBeInTheDocument();
-
-    rerender(
-      <WorkflowInspector
-        workflow={workflow}
-        task={makeTask({ description: 'Full task node title' })}
-        executionAgents={['codex', 'claude']}
-        collapsed={false}
-        advancedExpanded={false}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Full task node title');
-  });
-
   it('keeps advanced metadata collapsed by default', () => {
     render(
       <WorkflowInspector
         workflow={workflow}
         task={makeTask()}
-        executionAgents={['codex', 'claude']}
         collapsed={false}
         advancedExpanded={false}
         onToggleCollapsed={() => {}}
@@ -81,7 +45,6 @@ describe('WorkflowInspector', () => {
       <WorkflowInspector
         workflow={workflow}
         task={makeTask()}
-        executionAgents={['codex', 'claude']}
         collapsed={false}
         advancedExpanded={false}
         onToggleCollapsed={() => {}}
@@ -93,271 +56,29 @@ describe('WorkflowInspector', () => {
     expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/12');
   });
 
-  it('keeps the status section before task controls when a task is selected', () => {
-    render(
-      <WorkflowInspector
-        workflow={workflow}
-        task={makeTask()}
-        executionAgents={['codex', 'claude']}
-        collapsed={false}
-        advancedExpanded={false}
-        onEditAgent={vi.fn()}
-        onEditPrompt={vi.fn()}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    const statusLabel = screen.getByText('Task Status');
-    const agentLabel = screen.getByText('AI Agent');
-    const promptInput = screen.getByTestId('workflow-inspector-prompt-input');
-
-    expect(statusLabel.compareDocumentPosition(agentLabel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-    expect(statusLabel.compareDocumentPosition(promptInput) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-  });
-
-  it('shows workflow status at the top when only a workflow is selected', () => {
-    render(
-      <WorkflowInspector
-        workflow={{ ...workflow, status: 'running' }}
-        task={null}
-        executionAgents={['codex', 'claude']}
-        collapsed={false}
-        advancedExpanded={false}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    const statusLabel = screen.getByText('Workflow Status');
-    const pullRequestLabel = screen.getByText('Pull Request');
-
-    expect(screen.getByTestId('workflow-inspector-status-label')).toHaveTextContent('running');
-    expect(statusLabel.compareDocumentPosition(pullRequestLabel) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
-  });
-
-  it('uses the selected workflow merge gate PR URL when only a workflow is selected', () => {
-    render(
-      <WorkflowInspector
-        workflow={workflow}
-        task={null}
-        workflowTasks={workflowTaskMap(
-          makeTask({
-            id: 'task-with-pr',
-            execution: { reviewUrl: 'https://github.com/org/repo/pull/leaf' },
-          }),
-          makeTask({
-            id: '__merge__wf-1',
-            config: { workflowId: 'wf-1', prompt: 'Merge', isMergeNode: true },
-            execution: { reviewUrl: 'https://github.com/org/repo/pull/merge' },
-          }),
-        )}
-        executionAgents={['codex', 'claude']}
-        collapsed={false}
-        advancedExpanded={false}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    const link = screen.getByRole('link', { name: /pull\/merge/i });
-    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/merge');
-  });
-
-  it('shows no PR linked for workflow selection when no workflow task has a PR URL', () => {
-    render(
-      <WorkflowInspector
-        workflow={workflow}
-        task={null}
-        workflowTasks={workflowTaskMap(
-          makeTask({
-            id: '__merge__wf-1',
-            config: { workflowId: 'wf-1', prompt: 'Merge', isMergeNode: true },
-            execution: {},
-          }),
-        )}
-        executionAgents={['codex', 'claude']}
-        collapsed={false}
-        advancedExpanded={false}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    expect(screen.getByText('No PR linked')).toBeInTheDocument();
-  });
-
-  it('uses the selected task PR URL before the workflow merge gate PR URL', () => {
-    render(
-      <WorkflowInspector
-        workflow={workflow}
-        task={makeTask({ execution: { reviewUrl: 'https://github.com/org/repo/pull/task' } })}
-        workflowTasks={workflowTaskMap(
-          makeTask({
-            id: '__merge__wf-1',
-            config: { workflowId: 'wf-1', prompt: 'Merge', isMergeNode: true },
-            execution: { reviewUrl: 'https://github.com/org/repo/pull/merge' },
-          }),
-        )}
-        executionAgents={['codex', 'claude']}
-        collapsed={false}
-        advancedExpanded={false}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    const link = screen.getByRole('link', { name: /pull\/task/i });
-    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/task');
-  });
-
   it('can be collapsed and restored', () => {
     const { rerender } = render(
       <WorkflowInspector
         workflow={workflow}
         task={makeTask()}
-        executionAgents={['codex', 'claude']}
         collapsed={true}
         advancedExpanded={false}
         onToggleCollapsed={() => {}}
         onToggleAdvanced={() => {}}
       />,
     );
-    expect(screen.getByRole('button', { name: 'Maximize inspector' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Show' })).toBeInTheDocument();
 
     rerender(
       <WorkflowInspector
         workflow={workflow}
         task={makeTask()}
-        executionAgents={['codex', 'claude']}
         collapsed={false}
         advancedExpanded={false}
         onToggleCollapsed={() => {}}
         onToggleAdvanced={() => {}}
       />,
     );
-    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Task');
-  });
-
-  it('edits the selected task agent and prompt from inspector controls', () => {
-    const onEditAgent = vi.fn();
-    const onEditPrompt = vi.fn();
-
-    render(
-      <WorkflowInspector
-        workflow={workflow}
-        task={makeTask({ status: 'pending' })}
-        executionAgents={['claude', 'codex']}
-        collapsed={false}
-        advancedExpanded={false}
-        onEditAgent={onEditAgent}
-        onEditPrompt={onEditPrompt}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    fireEvent.change(screen.getByTestId('workflow-inspector-agent-select'), {
-      target: { value: 'claude' },
-    });
-    expect(onEditAgent).toHaveBeenCalledWith('task-1', 'claude');
-
-    fireEvent.change(screen.getByTestId('workflow-inspector-prompt-input'), {
-      target: { value: 'Fix failing tests and update docs' },
-    });
-    fireEvent.blur(screen.getByTestId('workflow-inspector-prompt-input'));
-    expect(onEditPrompt).toHaveBeenCalledWith('task-1', 'Fix failing tests and update docs');
-  });
-
-  it('edits the selected task executor from a primary inspector control', () => {
-    const onEditType = vi.fn();
-
-    render(
-      <WorkflowInspector
-        workflow={workflow}
-        task={makeTask({ status: 'pending' })}
-        remoteTargets={['remote-a']}
-        executionAgents={['claude', 'codex']}
-        collapsed={false}
-        advancedExpanded={false}
-        onEditType={onEditType}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    const select = screen.getByTestId('workflow-inspector-executor-select');
-    expect(select).toBeInTheDocument();
-
-    fireEvent.change(select, { target: { value: 'ssh:remote-a' } });
-    expect(onEditType).toHaveBeenCalledWith('task-1', 'ssh', 'remote-a');
-  });
-
-  it('shows task status instead of workflow status when a task is selected', () => {
-    render(
-      <WorkflowInspector
-        workflow={{ ...workflow, status: 'running' }}
-        task={makeTask({ status: 'failed', execution: { error: 'boom' } })}
-        executionAgents={['claude', 'codex']}
-        collapsed={false}
-        advancedExpanded={false}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    expect(screen.getByTestId('workflow-inspector-status-label')).toHaveTextContent('failed');
-  });
-
-  it('hides task-only controls when only a workflow is selected', () => {
-    render(
-      <WorkflowInspector
-        workflow={{ ...workflow, status: 'running' }}
-        task={null}
-        executionAgents={['claude', 'codex']}
-        collapsed={false}
-        advancedExpanded={false}
-        onEditAgent={vi.fn()}
-        onEditPrompt={vi.fn()}
-        onEditType={vi.fn()}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    expect(screen.getByTestId('workflow-inspector-status-label')).toHaveTextContent('running');
-    expect(screen.queryByTestId('workflow-inspector-agent-select')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('workflow-inspector-prompt-input')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('workflow-inspector-executor-select')).not.toBeInTheDocument();
-  });
-
-  it('hides AI agent and prompt controls for review gate tasks', () => {
-    render(
-      <WorkflowInspector
-        workflow={{ ...workflow, status: 'review_ready' }}
-        task={makeTask({
-          id: '__merge__wf-1',
-          description: 'Review gate for Workflow 1',
-          status: 'review_ready',
-          config: { workflowId: 'wf-1', prompt: 'Review this workflow', isMergeNode: true },
-          execution: { reviewUrl: 'https://github.com/org/repo/pull/merge' },
-        })}
-        executionAgents={['claude', 'codex']}
-        collapsed={false}
-        advancedExpanded={false}
-        onEditAgent={vi.fn()}
-        onEditPrompt={vi.fn()}
-        onEditType={vi.fn()}
-        onToggleCollapsed={() => {}}
-        onToggleAdvanced={() => {}}
-      />,
-    );
-
-    expect(screen.getByTestId('workflow-inspector-status-label')).toHaveTextContent('review ready');
-    expect(screen.queryByText('AI Agent')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('workflow-inspector-agent-select')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('workflow-inspector-prompt-input')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('workflow-inspector-executor-select')).not.toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /pull\/merge/i })).toBeInTheDocument();
+    expect(screen.getByText('Workflow 1')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -22,7 +22,7 @@ import {
 import '@xyflow/react/dist/style.css';
 
 import type { TaskState, WorkflowMeta } from '../types.js';
-import { layoutTaskGraph, type LayoutEdge, type TaskGraphLayout } from '../lib/layout.js';
+import { layoutNodes, layoutTaskGraph, type LayoutEdge, type TaskGraphLayout } from '../lib/layout.js';
 import { getEdgeStyle, getEffectiveVisualStatus, matchesStatusFilter } from '../lib/colors.js';
 import { TaskNode } from './TaskNode.js';
 import { BundledEdge, type BundledEdgeData } from './BundledEdge.js';
@@ -48,7 +48,7 @@ interface TaskDAGProps {
 
 const nodeTypes = { taskNode: TaskNode, mergeGateNode: MergeGateNode };
 const edgeTypes = { bundled: BundledEdge };
-const EMPTY_EDGE_POINTS = new Map<string, { x: number; y: number }[]>();
+const WORKFLOW_GAP = 100;
 
 type RawTaskEdge = LayoutEdge & {
   kind: 'local' | 'external';
@@ -57,11 +57,6 @@ type RawTaskEdge = LayoutEdge & {
 type LayoutState = {
   key: string;
   result: TaskGraphLayout;
-};
-
-type LayoutErrorState = {
-  key: string;
-  error: string;
 };
 
 /** Short label for edge hover tooltip showing the dependency relationship. */
@@ -89,6 +84,34 @@ function resolveExternalDependencyTaskId(
   return undefined;
 }
 
+function makeFallbackLayout(tasks: TaskState[]): TaskGraphLayout {
+  const workflowGroups = groupTasksByWorkflow(tasks);
+  const positions = new Map<string, { x: number; y: number }>();
+  let yOffset = 0;
+
+  for (const [, wfTasksRaw] of sortedWorkflowGroups(workflowGroups)) {
+    const wfTasks = [...wfTasksRaw].sort((a, b) => a.id.localeCompare(b.id));
+    const groupPositions = layoutNodes(wfTasks);
+
+    let minY = Infinity;
+    let maxY = -Infinity;
+    for (const pos of groupPositions.values()) {
+      minY = Math.min(minY, pos.y);
+      maxY = Math.max(maxY, pos.y);
+    }
+
+    for (const task of wfTasks) {
+      const pos = groupPositions.get(task.id) ?? { x: 0, y: 0 };
+      positions.set(task.id, { x: pos.x, y: pos.y + yOffset });
+    }
+
+    const groupHeight = maxY === -Infinity ? 0 : maxY - minY + 80;
+    yOffset += groupHeight + WORKFLOW_GAP;
+  }
+
+  return { positions, edgePoints: new Map(), usedFallback: true };
+}
+
 function layoutHasAllTasks(layout: TaskGraphLayout, tasks: TaskState[]): boolean {
   return tasks.every((task) => layout.positions.has(task.id));
 }
@@ -107,7 +130,6 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
   const prevNodeCount = useRef(0);
   const reportedGraphVisibleRef = useRef(false);
   const [layoutState, setLayoutState] = useState<LayoutState | null>(null);
-  const [layoutError, setLayoutError] = useState<LayoutErrorState | null>(null);
 
   const onInitHandler = useCallback(() => {
     requestAnimationFrame(() => fitView({ padding: 0.2 }));
@@ -121,6 +143,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
         rawEdges: [] as RawTaskEdge[],
         gateStatuses: new Map<string, ReturnType<typeof computeMergeGateStatus>>(),
         dimmedNodeIds: new Set<string>(),
+        fallbackLayout: makeFallbackLayout([]),
         layoutKey: 'empty',
       };
     }
@@ -178,6 +201,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
       rawEdges,
       gateStatuses,
       dimmedNodeIds,
+      fallbackLayout: makeFallbackLayout(taskArray),
       layoutKey: layoutKeyFor(layoutTasks, rawEdges),
     };
   }, [tasks, statusFilters]);
@@ -191,15 +215,6 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
     void layoutTaskGraph(layoutTasks, layoutEdges).then((result) => {
       if (!stale) {
         setLayoutState({ key: rawGraph.layoutKey, result });
-        setLayoutError(null);
-      }
-    }).catch((error: unknown) => {
-      if (!stale) {
-        setLayoutState(null);
-        setLayoutError({
-          key: rawGraph.layoutKey,
-          error: error instanceof Error ? error.message : String(error),
-        });
       }
     });
 
@@ -208,20 +223,20 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
     };
   }, [rawGraph.layoutKey]);
 
-  const activeLayout = useMemo(() => (
-    layoutState?.key === rawGraph.layoutKey
-      && layoutHasAllTasks(layoutState.result, rawGraph.taskArray)
-      ? layoutState.result
-      : null
-  ), [layoutState, rawGraph.layoutKey, rawGraph.taskArray]);
+  const activeLayout = useMemo(() => {
+    if (layoutState && layoutHasAllTasks(layoutState.result, rawGraph.taskArray)) {
+      return layoutState.result;
+    }
+    return rawGraph.fallbackLayout;
+  }, [layoutState, rawGraph.fallbackLayout, rawGraph.taskArray]);
 
-  const routedEdgePoints = layoutState?.key === rawGraph.layoutKey
-    ? layoutState.result.edgePoints
-    : EMPTY_EDGE_POINTS;
+  const emptyEdgePoints = useMemo(() => new Map<string, { x: number; y: number }[]>(), []);
+  const routedEdgePoints = useMemo(
+    () => layoutState?.key === rawGraph.layoutKey ? layoutState.result.edgePoints : emptyEdgePoints,
+    [emptyEdgePoints, layoutState, rawGraph.layoutKey],
+  );
 
   const { nodes, edges } = useMemo(() => {
-    if (!activeLayout) return { nodes: [] as Node[], edges: [] as Edge<BundledEdgeData>[] };
-
     const allNodes: Node[] = [];
     for (const task of rawGraph.taskArray) {
       const wfGroupId = task.config.workflowId ?? 'unknown';
@@ -353,7 +368,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
     });
 
     return { nodes: allNodes, edges: newEdges };
-  }, [activeLayout, rawGraph, routedEdgePoints, selectedTaskId, statusFilters, tasks, workflows]);
+  }, [activeLayout.positions, rawGraph, routedEdgePoints, selectedTaskId, statusFilters, tasks, workflows]);
 
   // Merge task-derived nodes with React Flow's internal dimension/selection state.
   // Without this, each task-delta re-render creates new node objects that discard
@@ -462,18 +477,6 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
         <div className="text-center">
           <p>No tasks yet</p>
           <p className="text-sm mt-1">Load a plan to create a task graph</p>
-        </div>
-      </div>
-    );
-  }
-
-  if (!activeLayout) {
-    const error = layoutError?.key === rawGraph.layoutKey ? layoutError.error : undefined;
-    return (
-      <div className="h-full w-full flex items-center justify-center text-gray-500">
-        <div className="text-center">
-          <p>{error ? 'Task graph layout failed' : 'Preparing task graph layout'}</p>
-          {error && <p className="text-sm mt-1 text-red-300">{error}</p>}
         </div>
       </div>
     );

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -3,24 +3,6 @@ interface TerminalDrawerProps {
   onToggle: () => void;
 }
 
-function TerminalToggleIcon({ collapsed }: { collapsed: boolean }): JSX.Element {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 16 16"
-      className="h-4 w-4"
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.7"
-    >
-      <path d="M3 3.5h10v9H3z" />
-      {collapsed ? <path d="M5.5 9 8 6.5 10.5 9" /> : <path d="M5.5 7 8 9.5 10.5 7" />}
-    </svg>
-  );
-}
-
 export function TerminalDrawer({ collapsed, onToggle }: TerminalDrawerProps): JSX.Element {
   return (
     <div className="border-t border-gray-800 bg-gray-950">
@@ -32,11 +14,9 @@ export function TerminalDrawer({ collapsed, onToggle }: TerminalDrawerProps): JS
         </div>
         <button
           onClick={onToggle}
-          className="inline-flex h-7 w-7 items-center justify-center rounded border border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white"
-          aria-label={collapsed ? 'Expand terminal drawer' : 'Minimize terminal drawer'}
-          title={collapsed ? 'Expand terminal drawer' : 'Minimize terminal drawer'}
+          className="rounded border border-gray-700 px-2 py-1 text-[11px] text-gray-300 hover:bg-gray-800"
         >
-          <TerminalToggleIcon collapsed={collapsed} />
+          {collapsed ? 'Expand' : 'Minimize'}
         </button>
       </div>
       {!collapsed && (

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -1,12 +1,7 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
-import type { MouseEvent, PointerEvent } from 'react';
+import { useMemo } from 'react';
+import type { MouseEvent } from 'react';
 import type { TaskState, WorkflowMeta, WorkflowStatus } from '../types.js';
-import {
-  deriveWorkflowGraph,
-  layoutWorkflowGraphWithElk,
-  type WorkflowGraphLayout,
-  type WorkflowRoutePoint,
-} from '../lib/workflow-graph.js';
+import { deriveWorkflowGraph, layoutWorkflowGraph } from '../lib/workflow-graph.js';
 import { WorkflowNode } from './WorkflowNode.js';
 
 interface WorkflowGraphProps {
@@ -26,51 +21,10 @@ export function WorkflowGraph({
   onSelectWorkflow,
   onWorkflowContextMenu,
 }: WorkflowGraphProps): JSX.Element {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const dragRef = useRef<{
-    pointerId: number;
-    x: number;
-    y: number;
-    scrollLeft: number;
-    scrollTop: number;
-  } | null>(null);
-  const pannedRef = useRef(false);
-  const [dragging, setDragging] = useState(false);
-  const [elkLayout, setElkLayout] = useState<{ key: string; result: WorkflowGraphLayout } | null>(null);
-  const [layoutError, setLayoutError] = useState<{ key: string; error: string } | null>(null);
   const graph = useMemo(() => deriveWorkflowGraph(workflows, tasks), [workflows, tasks]);
-  const graphKey = useMemo(() => JSON.stringify({
-    nodes: graph.nodes.map((node) => node.id).sort(),
-    edges: graph.edges.map((edge) => `${edge.source}->${edge.target}`).sort(),
-  }), [graph]);
-  const activeLayout = elkLayout?.key === graphKey ? elkLayout.result : null;
-  const positions = activeLayout?.positions ?? new Map<string, { x: number; y: number }>();
+  const positions = useMemo(() => layoutWorkflowGraph(graph), [graph]);
   const width = Math.max(1400, ...[...positions.values()].map((position) => position.x + 320));
   const height = Math.max(900, ...[...positions.values()].map((position) => position.y + 220));
-
-  useEffect(() => {
-    if (graph.nodes.length === 0) return;
-    let stale = false;
-
-    void layoutWorkflowGraphWithElk(graph).then((result) => {
-      if (!stale) {
-        setElkLayout({ key: graphKey, result });
-        setLayoutError(null);
-      }
-    }).catch((error: unknown) => {
-      if (!stale) {
-        setElkLayout(null);
-        setLayoutError({
-          key: graphKey,
-          error: error instanceof Error ? error.message : String(error),
-        });
-      }
-    });
-
-    return () => {
-      stale = true;
-    };
-  }, [graph, graphKey]);
 
   if (graph.nodes.length === 0) {
     return (
@@ -80,80 +34,14 @@ export function WorkflowGraph({
     );
   }
 
-  if (!activeLayout) {
-    const error = layoutError?.key === graphKey ? layoutError.error : undefined;
-    return (
-      <div className="h-full flex items-center justify-center text-gray-500 text-sm">
-        {error ? `Workflow graph layout failed: ${error}` : 'Preparing workflow graph layout'}
-      </div>
-    );
-  }
-
-  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
-    if (event.button !== 0) return;
-    const target = event.target as HTMLElement;
-    if (target.closest('[data-testid^="workflow-node-"], [role="menu"], button, a, input, textarea, select')) {
-      return;
-    }
-    const scroller = scrollRef.current;
-    if (!scroller) return;
-    dragRef.current = {
-      pointerId: event.pointerId,
-      x: event.clientX,
-      y: event.clientY,
-      scrollLeft: scroller.scrollLeft,
-      scrollTop: scroller.scrollTop,
-    };
-    pannedRef.current = false;
-    setDragging(true);
-    scroller.setPointerCapture(event.pointerId);
-    event.preventDefault();
-  };
-
-  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
-    const drag = dragRef.current;
-    const scroller = scrollRef.current;
-    if (!drag || !scroller || drag.pointerId !== event.pointerId) return;
-    if (Math.abs(event.clientX - drag.x) > 3 || Math.abs(event.clientY - drag.y) > 3) {
-      pannedRef.current = true;
-    }
-    scroller.scrollLeft = drag.scrollLeft - (event.clientX - drag.x);
-    scroller.scrollTop = drag.scrollTop - (event.clientY - drag.y);
-  };
-
-  const endDrag = (event: PointerEvent<HTMLDivElement>) => {
-    const drag = dragRef.current;
-    const scroller = scrollRef.current;
-    if (!drag || drag.pointerId !== event.pointerId) return;
-    if (scroller?.hasPointerCapture(event.pointerId)) {
-      scroller.releasePointerCapture(event.pointerId);
-    }
-    dragRef.current = null;
-    setDragging(false);
-  };
-
   return (
-    <div
-      ref={scrollRef}
-      className={`h-full w-full overflow-auto ${dragging ? 'cursor-grabbing select-none' : 'cursor-grab'}`}
-      data-testid="workflow-graph-scroll"
-      onPointerDown={handlePointerDown}
-      onPointerMove={handlePointerMove}
-      onPointerUp={endDrag}
-      onPointerCancel={endDrag}
-      onClick={(event) => {
-        if (!pannedRef.current) return;
-        pannedRef.current = false;
-        event.stopPropagation();
-      }}
-    >
+    <div className="h-full w-full overflow-auto">
       <div className="relative" style={{ width, height }}>
         <svg className="absolute inset-0 pointer-events-none" width={width} height={height}>
           {graph.edges.map((edge) => {
             const source = positions.get(edge.source);
             const target = positions.get(edge.target);
             if (!source || !target) return null;
-            const routePoints = activeLayout?.edgePoints.get(`${edge.source}->${edge.target}`);
             const x1 = source.x + 220;
             const y1 = source.y + 58;
             const x2 = target.x;
@@ -163,19 +51,17 @@ export function WorkflowGraph({
             return (
               <path
                 key={`${edge.source}-${edge.target}`}
-                d={routePoints ? routedPath(routePoints) : `M ${x1} ${y1} C ${cx1} ${y1}, ${cx2} ${y2}, ${x2} ${y2}`}
+                d={`M ${x1} ${y1} C ${cx1} ${y1}, ${cx2} ${y2}, ${x2} ${y2}`}
                 fill="none"
                 stroke="rgba(148,163,184,0.55)"
                 strokeWidth={2}
-                strokeDasharray="6 4"
               />
             );
           })}
         </svg>
 
         {graph.nodes.map((node) => {
-          const position = positions.get(node.id);
-          if (!position) return null;
+          const position = positions.get(node.id) ?? { x: 80, y: 80 };
           const dimmed = statusFilters.size > 0 && !statusFilters.has(node.workflow.status);
           return (
             <div
@@ -196,9 +82,4 @@ export function WorkflowGraph({
       </div>
     </div>
   );
-}
-
-function routedPath(points: readonly WorkflowRoutePoint[]): string {
-  const [first, ...rest] = points;
-  return `M ${first.x} ${first.y} ${rest.map((point) => `L ${point.x} ${point.y}`).join(' ')}`;
 }

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -1,23 +1,11 @@
-import { useEffect, useMemo, useState } from 'react';
-import type { ActionGraphNode } from '@invoker/contracts';
-import type { TaskState, WorkflowMeta, WorkflowRollupTaskIssue } from '../types.js';
+import type { TaskState, WorkflowMeta } from '../types.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
-import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 
 interface WorkflowInspectorProps {
   workflow: WorkflowMeta | null;
   task: TaskState | null;
-  workflowTasks?: ReadonlyMap<string, TaskState>;
-  remoteTargets?: string[];
-  executionAgents: string[];
   collapsed: boolean;
   advancedExpanded: boolean;
-  actionNode?: ActionGraphNode | null;
-  onEditType?: (taskId: string, executorType: string, remoteTargetId?: string) => void;
-  onEditAgent?: (taskId: string, agentName: string) => void;
-  onEditPrompt?: (taskId: string, newPrompt: string) => void;
-  onEditCommand?: (taskId: string, newCommand: string) => void;
-  onSetMergeBranch?: (workflowId: string, baseBranch: string) => Promise<void>;
   onToggleCollapsed: () => void;
   onToggleAdvanced: () => void;
 }
@@ -27,536 +15,65 @@ function summarizePrompt(task: TaskState | null): string {
   return task.config.prompt ?? task.config.command ?? 'No prompt or command available.';
 }
 
-function effectiveExecutorSelectValue(task: TaskState | null): string {
-  if (!task) return 'worktree';
-  if (task.config.executorType === 'ssh' && task.config.remoteTargetId) {
-    return `ssh:${task.config.remoteTargetId}`;
-  }
-  return task.config.executorType ?? 'worktree';
-}
-
-function InspectorToggleIcon({ collapsed }: { collapsed: boolean }): JSX.Element {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 16 16"
-      className="h-4 w-4"
-      fill="none"
-      stroke="currentColor"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      strokeWidth="1.7"
-    >
-      <path d="M3 3.5h10v9H3z" />
-      <path d="M10 3.5v9" />
-      {collapsed ? <path d="M5.5 6 7.5 8l-2 2" /> : <path d="M7.5 6 5.5 8l2 2" />}
-    </svg>
-  );
-}
-
-function primaryIssueText(issue: WorkflowRollupTaskIssue): string {
-  return issue.error
-    ?? issue.protocolErrorMessage
-    ?? issue.pendingFixError
-    ?? issue.inputPrompt
-    ?? issue.reviewUrl
-    ?? 'No detail recorded';
-}
-
-function formatRepoUrl(url: string): string {
-  const sshMatch = url.match(/^git@([^:]+):(.+?)(?:\.git)?$/);
-  if (sshMatch) return `${sshMatch[1]}/${sshMatch[2]}`;
-
-  try {
-    const parsed = new URL(url);
-    const path = parsed.pathname.replace(/^\//, '').replace(/\.git$/, '');
-    return `${parsed.host}/${path}`;
-  } catch {
-    return url;
-  }
-}
-
 export function WorkflowInspector({
   workflow,
   task,
-  workflowTasks,
-  remoteTargets,
-  executionAgents,
   collapsed,
   advancedExpanded,
-  actionNode,
-  onEditType,
-  onEditAgent,
-  onEditPrompt,
-  onEditCommand,
-  onSetMergeBranch,
   onToggleCollapsed,
   onToggleAdvanced,
 }: WorkflowInspectorProps): JSX.Element {
-  const [promptValue, setPromptValue] = useState('');
-  const [promptDirty, setPromptDirty] = useState(false);
-  const [editingTaskContent, setEditingTaskContent] = useState(false);
-  const [branchValue, setBranchValue] = useState('');
-
-  const promptText = summarizePrompt(task);
-  const agent = task?.config.executionAgent ?? task?.execution.agentName ?? '';
-  const agentOptions = useMemo(() => {
-    const options = new Set(executionAgents);
-    if (agent) options.add(agent);
-    return [...options].filter(Boolean).sort();
-  }, [agent, executionAgents]);
-
-  useEffect(() => {
-    setPromptValue(promptText);
-    setPromptDirty(false);
-    setEditingTaskContent(false);
-  }, [task?.id, promptText]);
-
-  useEffect(() => {
-    setBranchValue(workflow?.baseBranch ?? '');
-  }, [workflow?.baseBranch, workflow?.id]);
-
-  const savePrompt = () => {
-    if (!task || !promptDirty) return;
-    if (task.config.prompt !== undefined) {
-      onEditPrompt?.(task.id, promptValue);
-    } else if (task.config.command !== undefined) {
-      onEditCommand?.(task.id, promptValue);
-    }
-    setPromptDirty(false);
-  };
-
-  const saveTaskContentEdit = () => {
-    if (!task || !showTaskControls) return;
-    if (task.config.prompt !== undefined) {
-      onEditPrompt?.(task.id, promptValue);
-    } else if (task.config.command !== undefined) {
-      onEditCommand?.(task.id, promptValue);
-    }
-    setPromptDirty(false);
-    setEditingTaskContent(false);
-  };
-
   if (collapsed) {
     return (
       <aside className="h-full w-full border-l border-gray-800 bg-gray-900 flex items-start justify-center pt-3">
         <button
           onClick={onToggleCollapsed}
-          className="inline-flex h-7 w-7 items-center justify-center rounded border border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white"
-          aria-label="Maximize inspector"
-          title="Maximize inspector"
+          className="rounded border border-gray-700 px-2 py-1 text-xs text-gray-300 hover:bg-gray-800"
         >
-          <InspectorToggleIcon collapsed={collapsed} />
+          Show
         </button>
       </aside>
     );
   }
 
   const visual = workflow ? workflowStatusVisual(workflow.status) : null;
-  const rollup = workflow?.rollup;
-  const nonZeroCounts = rollup
-    ? Object.entries(rollup.countsByStatus).filter(([, count]) => count > 0)
-    : [];
-  const workflowTaskList = workflowTasks ? [...workflowTasks.values()] : [];
-  const mergeGateReviewUrl = workflowTaskList.find((workflowTask) => workflowTask.config.isMergeNode)?.execution.reviewUrl;
-  const fallbackWorkflowReviewUrl = workflowTaskList.find((workflowTask) => workflowTask.execution.reviewUrl)?.execution.reviewUrl;
-  const reviewUrl = task ? task.execution.reviewUrl : mergeGateReviewUrl ?? fallbackWorkflowReviewUrl;
-  const executorSelectValue = effectiveExecutorSelectValue(task);
-  const canEditExecutor = Boolean(task && onEditType && !task.config.isMergeNode);
-  const showTaskControls = Boolean(task && !task.config.isMergeNode);
-  const canEditPrompt = Boolean(showTaskControls && task && ((task.config.prompt !== undefined && onEditPrompt) || (task.config.command !== undefined && onEditCommand)));
-  const showMergeGateMetadata = Boolean(task?.config.isMergeNode);
-  const taskVisualStatus = task ? getEffectiveVisualStatus(task.status, task.execution) : null;
-  const taskStatusColors = taskVisualStatus ? getStatusColor(taskVisualStatus) : null;
-  const failedStatusColors = getStatusColor('failed');
-  const fixingStatusColors = getStatusColor('fixing_with_ai');
-  const statusBorderClass = taskStatusColors?.border ?? visual?.borderClass ?? 'border-gray-700';
-  const statusTextClass = taskStatusColors?.text ?? visual?.textClass ?? 'text-gray-300';
-  const statusLabel = task
-    ? taskVisualStatus?.replaceAll('_', ' ') ?? task.status.replaceAll('_', ' ')
-    : workflow?.status?.replaceAll('_', ' ') ?? 'unknown';
-  const workflowTitle = workflow?.name ?? workflow?.id;
-  const inspectorTitle = task?.description ?? (workflowTitle ? `${workflowTitle} task DAG` : 'No workflow selected');
-
-  if (actionNode) {
-    const durations = actionNode.durations ?? {};
-    const formatMs = (value: number | undefined) => {
-      if (value === undefined || !Number.isFinite(value)) return 'n/a';
-      const absolute = Math.max(0, Math.abs(value));
-      if (absolute < 1_000) return `${Math.round(absolute)}ms`;
-      if (absolute < 60_000) return `${Math.round(absolute / 1_000)}s`;
-      if (absolute < 3_600_000) return `${Math.round(absolute / 60_000)}m`;
-      return `${Math.round(absolute / 3_600_000)}h`;
-    };
-    return (
-      <aside className="h-full w-full border-l border-gray-800 bg-gray-900 flex flex-col">
-        <div className="flex items-center justify-between border-b border-gray-800 px-3 py-2">
-          <div className="min-w-0 pr-2">
-            <div className="text-sm font-semibold leading-snug text-gray-100" data-testid="workflow-inspector-title">
-              {actionNode.label}
-            </div>
-            <div className="mt-0.5 text-[11px] uppercase text-gray-500">{actionNode.type.replace('-', ' ')}</div>
-          </div>
-          <button
-            onClick={onToggleCollapsed}
-            className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white"
-            aria-label="Minimize inspector"
-            title="Minimize inspector"
-          >
-            <InspectorToggleIcon collapsed={collapsed} />
-          </button>
-        </div>
-        <div className="flex-1 overflow-auto p-3 space-y-3 text-sm">
-          <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
-            <div className="text-[11px] uppercase tracking-wide text-gray-400">Action Status</div>
-            <div className="mt-1 text-xs text-gray-100">{actionNode.status}</div>
-            {actionNode.latestError && <p className="mt-2 break-words text-xs text-red-300">{actionNode.latestError}</p>}
-          </section>
-          <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
-            <div className="text-[11px] uppercase tracking-wide text-gray-400">Timing</div>
-            <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-gray-300">
-              <div>queued: {formatMs(durations.queuedMs)}</div>
-              <div>pending: {formatMs(durations.pendingMs)}</div>
-              <div>running: {formatMs(durations.runningMs)}</div>
-              <div>waiting: {formatMs(durations.waitingMs)}</div>
-              <div>stalled: {formatMs(durations.stalledMs)}</div>
-              <div>heartbeat: {formatMs(durations.heartbeatAgeMs)}</div>
-            </div>
-            <div className="mt-2 space-y-1 text-xs text-gray-400">
-              <div>lease expires: {actionNode.leaseExpiresAt ?? 'n/a'}</div>
-              <div>heartbeat at: {actionNode.heartbeatAt ?? 'n/a'}</div>
-            </div>
-          </section>
-          {actionNode.blockerIds?.length ? (
-            <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
-              <div className="text-[11px] uppercase tracking-wide text-gray-400">Blocker Chain</div>
-              <div className="mt-2 space-y-1 text-xs text-gray-300">
-                {actionNode.blockerIds.map((blockerId) => <div key={blockerId}>{blockerId}</div>)}
-              </div>
-            </section>
-          ) : null}
-          {actionNode.suggestedNextAction && (
-            <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
-              <div className="text-[11px] uppercase tracking-wide text-gray-400">Suggested Next Action</div>
-              <div className="mt-1 text-xs text-gray-200">{actionNode.suggestedNextAction}</div>
-            </section>
-          )}
-          <section className="rounded border border-gray-700 bg-gray-800/70">
-            <button
-              onClick={onToggleAdvanced}
-              className="w-full px-3 py-2 text-left text-[11px] uppercase tracking-wide text-gray-300 hover:bg-gray-800"
-            >
-              Full history {advancedExpanded ? '▲' : '▼'}
-            </button>
-            {advancedExpanded && (
-              <div className="border-t border-gray-700 px-3 py-2 space-y-2 text-xs text-gray-300">
-                <div>workflow id: {actionNode.workflowId ?? 'n/a'}</div>
-                <div>task id: {actionNode.taskId ?? 'n/a'}</div>
-                <div>attempt id: {actionNode.attemptId ?? 'n/a'}</div>
-                <div>intent id: {actionNode.intentId ?? 'n/a'}</div>
-                {actionNode.history?.map((entry) => (
-                  <div key={entry.id} className="border-t border-gray-700 pt-2">
-                    <div className="text-gray-500">{entry.timestamp} · {entry.source}</div>
-                    <div className="break-words">{entry.message}</div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </section>
-        </div>
-      </aside>
-    );
-  }
+  const reviewUrl = task?.execution.reviewUrl;
+  const agent = task?.config.executionAgent ?? task?.execution.agentName ?? 'n/a';
 
   return (
     <aside className="h-full w-full border-l border-gray-800 bg-gray-900 flex flex-col">
       <div className="flex items-center justify-between border-b border-gray-800 px-3 py-2">
-        <div className="min-w-0 pr-2">
-          <h2 className="text-sm font-semibold leading-snug text-gray-100" data-testid="workflow-inspector-title">
-            {inspectorTitle}
-          </h2>
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-wide text-gray-300">Inspector</div>
+          <div className="text-[11px] text-gray-400 truncate max-w-[240px]">{workflow?.name ?? workflow?.id ?? 'No workflow selected'}</div>
         </div>
         <button
           onClick={onToggleCollapsed}
-          className="inline-flex h-7 w-7 shrink-0 items-center justify-center rounded border border-gray-700 text-gray-300 hover:bg-gray-800 hover:text-white"
-          aria-label="Minimize inspector"
-          title="Minimize inspector"
+          className="rounded border border-gray-700 px-2 py-1 text-[11px] text-gray-300 hover:bg-gray-800"
         >
-          <InspectorToggleIcon collapsed={collapsed} />
+          Minimize
         </button>
       </div>
 
       <div className="flex-1 overflow-auto p-3 space-y-3 text-sm">
-        <section className={`rounded border p-3 ${statusBorderClass} bg-gray-800/70`}>
-          <div className="text-[11px] uppercase tracking-wide text-gray-400">
-            {task ? 'Task Status' : 'Workflow Status'}
-          </div>
-          <div
-            className={`mt-1 text-xs ${statusTextClass}`}
-            data-testid="workflow-inspector-status-label"
-          >
-            {statusLabel}
-          </div>
-          {rollup && !task && (
-            <div className="mt-2 flex flex-wrap gap-1.5">
-              {nonZeroCounts.map(([status, count]) => (
-                <span
-                  key={status}
-                  className={`rounded border px-1.5 py-0.5 text-[10px] uppercase ${getStatusColor(status).border} ${getStatusColor(status).bg} ${getStatusColor(status).text}`}
-                >
-                  {status.replaceAll('_', ' ')} {count}
-                </span>
-              ))}
-            </div>
-          )}
-          {(task?.execution.error || task?.execution.exitCode !== undefined) && (
-            <div className="mt-3 rounded border border-red-500/60 bg-red-950/30 p-2">
-              <h3 className="text-[11px] uppercase tracking-wide text-red-300">Error</h3>
-              {task.execution.error && (
-                <p className="mt-1 whitespace-pre-wrap break-words text-xs text-red-200">{task.execution.error}</p>
-              )}
-              {task.execution.exitCode !== undefined && (
-                <p className="mt-1 text-xs text-red-200">Exit code: {task.execution.exitCode}</p>
-              )}
-            </div>
-          )}
-          {!task && rollup?.failedTasks.length ? (
-            <div className="mt-3 space-y-2">
-              <div className={`text-[11px] uppercase tracking-wide ${failedStatusColors.text}`}>Failed Tasks</div>
-              {rollup.failedTasks.map((failedTask) => (
-                <div key={failedTask.taskId} className={`rounded border p-2 ${failedStatusColors.border} ${failedStatusColors.bg}`}>
-                  <div className={`truncate text-xs font-medium ${failedStatusColors.text}`}>{failedTask.description}</div>
-                  <div className={`mt-1 break-words text-[11px] ${failedStatusColors.text}`}>{primaryIssueText(failedTask)}</div>
-                </div>
-              ))}
-            </div>
-          ) : null}
-          {!task && rollup?.fixingTasks.length ? (
-            <div className="mt-3 space-y-2">
-              <div className={`text-[11px] uppercase tracking-wide ${fixingStatusColors.text}`}>Fixing with AI</div>
-              {rollup.fixingTasks.map((fixingTask) => (
-                <div key={fixingTask.taskId} className={`rounded border p-2 ${fixingStatusColors.border} ${fixingStatusColors.bg}`}>
-                  <div className={`truncate text-xs font-medium ${fixingStatusColors.text}`}>{fixingTask.description}</div>
-                  <div className={`mt-1 text-[11px] ${fixingStatusColors.text}`}>
-                    {fixingTask.agentName ?? fixingTask.agentSessionId ?? 'Agent session pending'}
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : null}
-          {!task && rollup?.waitingTasks.length ? (
-            <div className="mt-3 space-y-2">
-              <div className="text-[11px] uppercase tracking-wide text-gray-300">Waiting Tasks</div>
-              {rollup.waitingTasks.map((waitingTask) => (
-                <div key={waitingTask.taskId} className={`rounded border p-2 ${getStatusColor(waitingTask.status).border} ${getStatusColor(waitingTask.status).bg}`}>
-                  <div className={`truncate text-xs font-medium ${getStatusColor(waitingTask.status).text}`}>{waitingTask.description}</div>
-                  <div className={`mt-1 break-words text-[11px] ${getStatusColor(waitingTask.status).text}`}>
-                    {waitingTask.status.replaceAll('_', ' ')} · {primaryIssueText(waitingTask)}
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : null}
+        <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+          <div className="text-[11px] uppercase tracking-wide text-gray-400">AI Agent</div>
+          <div className="mt-1 text-gray-100">{agent}</div>
+          <div className="mt-2 text-[11px] uppercase tracking-wide text-gray-400">Prompt</div>
+          <p className="mt-1 text-gray-200 text-xs leading-relaxed whitespace-pre-wrap break-words">
+            {summarizePrompt(task)}
+          </p>
         </section>
 
-        {showTaskControls && task && (
-          <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
-            <div className="text-[11px] uppercase tracking-wide text-gray-400">AI Agent</div>
-            {onEditAgent && agentOptions.length > 0 ? (
-              <select
-                data-testid="workflow-inspector-agent-select"
-                value={agent}
-                onChange={(event) => onEditAgent(task.id, event.target.value)}
-                className="mt-1 w-full rounded border border-gray-700 bg-gray-900 px-2 py-1.5 text-xs text-gray-100 outline-none focus:border-blue-500"
-              >
-                {!agent && <option value="">Select agent</option>}
-                {agentOptions.map((option) => (
-                  <option key={option} value={option}>
-                    {option}
-                  </option>
-                ))}
-              </select>
-            ) : (
-              <div className="mt-1 text-gray-100">{agent || 'n/a'}</div>
-            )}
-            {canEditExecutor && (
-              <>
-                <div className="mt-2 text-[11px] uppercase tracking-wide text-gray-400">Run on</div>
-                <select
-                  data-testid="workflow-inspector-executor-select"
-                  value={executorSelectValue}
-                  onChange={(event) => {
-                    const value = event.target.value;
-                    if (value.startsWith('ssh:')) {
-                      onEditType?.(task.id, 'ssh', value.slice(4));
-                    } else {
-                      onEditType?.(task.id, value);
-                    }
-                  }}
-                  disabled={task.status === 'running' || task.status === 'fixing_with_ai'}
-                  className="mt-1 w-full rounded border border-gray-700 bg-gray-900 px-2 py-1.5 text-xs text-gray-100 outline-none focus:border-blue-500 disabled:cursor-not-allowed disabled:opacity-50"
-                >
-                  <option value="worktree">Worktree</option>
-                  <option value="docker">Docker</option>
-                  {remoteTargets?.map((targetId) => (
-                    <option key={targetId} value={`ssh:${targetId}`}>
-                      SSH: {targetId}
-                    </option>
-                  ))}
-                </select>
-              </>
-            )}
-            <div className="mt-2 text-[11px] uppercase tracking-wide text-gray-400">Prompt</div>
-            {editingTaskContent ? (
-              <div className="mt-1 space-y-2">
-                <textarea
-                  data-testid={task.config.prompt !== undefined ? 'edit-prompt-input' : 'edit-command-input'}
-                  value={promptValue}
-                  onChange={(event) => {
-                    setPromptValue(event.target.value);
-                    setPromptDirty(event.target.value !== promptText);
-                  }}
-                  onKeyDown={(event) => {
-                    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
-                      event.preventDefault();
-                      saveTaskContentEdit();
-                    }
-                    if (event.key === 'Escape') {
-                      setPromptValue(promptText);
-                      setPromptDirty(false);
-                      setEditingTaskContent(false);
-                    }
-                  }}
-                  className="min-h-28 w-full resize-y rounded border border-blue-500 bg-gray-900 px-2 py-2 text-xs leading-relaxed text-gray-100 outline-none focus:border-blue-400"
-                />
-                <div className="flex justify-end gap-2">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setPromptValue(promptText);
-                      setPromptDirty(false);
-                      setEditingTaskContent(false);
-                    }}
-                    className="rounded border border-gray-700 px-2 py-1 text-xs text-gray-300 hover:bg-gray-800"
-                    data-testid="cancel-edit-btn"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    onClick={saveTaskContentEdit}
-                    className="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-500"
-                    data-testid={task.config.prompt !== undefined ? 'save-prompt-btn' : 'save-command-btn'}
-                  >
-                    Save & Re-run
-                  </button>
-                </div>
-              </div>
-            ) : (
-              <div
-                data-testid="command-display"
-                onDoubleClick={() => {
-                  if (canEditPrompt) setEditingTaskContent(true);
-                }}
-                className="mt-1"
-              >
-                <textarea
-                  data-testid="workflow-inspector-prompt-input"
-                  value={promptValue}
-                  onChange={(event) => {
-                    setPromptValue(event.target.value);
-                    setPromptDirty(event.target.value !== promptText);
-                  }}
-                  onBlur={savePrompt}
-                  onKeyDown={(event) => {
-                    if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
-                      event.preventDefault();
-                      savePrompt();
-                    }
-                    if (event.key === 'Escape') {
-                      setPromptValue(promptText);
-                      setPromptDirty(false);
-                      event.currentTarget.blur();
-                    }
-                  }}
-                  readOnly={!canEditPrompt}
-                  className={`min-h-28 w-full resize-y rounded border px-2 py-2 text-xs leading-relaxed outline-none ${
-                    canEditPrompt
-                      ? 'border-gray-700 bg-gray-900 text-gray-100 focus:border-blue-500'
-                      : 'border-gray-700 bg-gray-900/50 text-gray-400'
-                  }`}
-                />
-              </div>
-            )}
-            {!editingTaskContent && promptDirty && canEditPrompt && (
-              <div className="mt-2 flex justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => {
-                    setPromptValue(promptText);
-                    setPromptDirty(false);
-                  }}
-                  className="rounded border border-gray-700 px-2 py-1 text-xs text-gray-300 hover:bg-gray-800"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  onClick={savePrompt}
-                  className="rounded bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-500"
-                >
-                  Save
-                </button>
-              </div>
-            )}
-          </section>
-        )}
-
-        {showMergeGateMetadata && task && (
-          <section className="rounded border border-gray-700 bg-gray-800/70 p-3 space-y-3">
-            {onSetMergeBranch && task.config.workflowId && (
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-[11px] uppercase tracking-wide text-gray-400">Target Branch</span>
-                <input
-                  data-testid="target-branch-input"
-                  value={branchValue}
-                  onChange={(event) => setBranchValue(event.target.value)}
-                  onBlur={() => {
-                    const trimmed = branchValue.trim();
-                    if (trimmed && trimmed !== workflow?.baseBranch) {
-                      onSetMergeBranch(task.config.workflowId!, trimmed);
-                    }
-                  }}
-                  onKeyDown={(event) => {
-                    if (event.key === 'Enter') {
-                      event.currentTarget.blur();
-                    }
-                    if (event.key === 'Escape') {
-                      setBranchValue(workflow?.baseBranch ?? '');
-                    }
-                  }}
-                  className="w-32 rounded border border-gray-700 bg-gray-900 px-2 py-1 text-right font-mono text-xs text-gray-100 outline-none focus:border-blue-500"
-                />
-              </div>
-            )}
-            {task.execution.reviewStatus && (
-              <div className="flex items-center justify-between gap-3">
-                <span className="text-[11px] uppercase tracking-wide text-gray-400">Review Status</span>
-                <span className="text-xs text-gray-200" data-testid="pr-status-text">
-                  {task.execution.reviewStatus}
-                </span>
-              </div>
-            )}
-            {!task.execution.reviewUrl && workflow?.repoUrl && (
-              <div className="flex items-center justify-between gap-3" data-testid="pr-target-repo">
-                <span className="text-[11px] uppercase tracking-wide text-gray-400">PR target repo</span>
-                <span className="max-w-[220px] break-all text-right font-mono text-xs text-gray-200" title={workflow.repoUrl}>
-                  {formatRepoUrl(workflow.repoUrl)}
-                </span>
-              </div>
-            )}
-          </section>
-        )}
+        <section className={`rounded border p-3 ${visual?.borderClass ?? 'border-gray-700'} bg-gray-800/70`}>
+          <div className="text-[11px] uppercase tracking-wide text-gray-400">Status</div>
+          <div className={`mt-1 text-xs ${visual?.textClass ?? 'text-gray-300'}`}>
+            {workflow?.status?.replaceAll('_', ' ') ?? 'unknown'}
+          </div>
+          {task?.execution.error && (
+            <p className="mt-2 text-xs text-red-300 break-words">{task.execution.error}</p>
+          )}
+        </section>
 
         <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
           <div className="text-[11px] uppercase tracking-wide text-gray-400">Pull Request</div>
@@ -588,6 +105,7 @@ export function WorkflowInspector({
               <div>target branch: {workflow?.featureBranch ?? task?.config.featureBranch ?? 'n/a'}</div>
               <div>base branch: {workflow?.baseBranch ?? 'n/a'}</div>
               <div>heartbeat: {String(task?.execution.lastHeartbeatAt ?? 'n/a')}</div>
+              <div>executor: {task?.config.executorType ?? 'n/a'}</div>
             </div>
           )}
         </section>

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -14,30 +14,6 @@ function statusLabel(status: WorkflowStatus): string {
   return status.replaceAll('_', ' ');
 }
 
-function selectedRingClass(status: WorkflowStatus): string {
-  switch (status) {
-    case 'running':
-      return 'ring-2 ring-blue-400/80';
-    case 'fixing_with_ai':
-      return 'ring-2 ring-orange-400/80';
-    case 'completed':
-      return 'ring-2 ring-green-500/80';
-    case 'failed':
-      return 'ring-2 ring-red-500/80';
-    case 'review_ready':
-      return 'ring-2 ring-sky-400/80';
-    case 'awaiting_approval':
-      return 'ring-2 ring-purple-400/80';
-    case 'blocked':
-      return 'ring-2 ring-slate-500/80';
-    case 'stale':
-      return 'ring-2 ring-slate-600/80';
-    case 'pending':
-    default:
-      return 'ring-2 ring-slate-400/80';
-  }
-}
-
 export function WorkflowNode({
   workflow,
   selected,
@@ -63,7 +39,7 @@ export function WorkflowNode({
       className={[
         'relative w-[220px] rounded-lg border bg-gray-900/95 pl-4 pr-3 py-3 text-left transition-all',
         visual.borderClass,
-        selected ? selectedRingClass(workflow.status) : '',
+        selected ? 'ring-2 ring-blue-400/80' : '',
         dimmed ? 'opacity-35' : 'opacity-100',
         'hover:bg-gray-800/95',
       ].join(' ')}
@@ -74,6 +50,7 @@ export function WorkflowNode({
       )}
 
       <div className="text-[13px] font-semibold text-gray-100 truncate">{workflow.name || workflow.id}</div>
+      <div className="mt-1 text-[11px] text-gray-400 truncate">{workflow.id}</div>
       <div className={`mt-2 text-[10px] uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
     </div>
   );

--- a/packages/ui/src/components/WorkflowStatusChips.tsx
+++ b/packages/ui/src/components/WorkflowStatusChips.tsx
@@ -1,6 +1,6 @@
 import type { MouseEvent } from 'react';
 import type { WorkflowMeta, WorkflowStatus } from '../types.js';
-import { getStatusVisual } from '../lib/status-colors.js';
+import { workflowStatusVisual } from '../lib/workflow-status.js';
 
 interface WorkflowStatusChipsProps {
   workflows: Map<string, WorkflowMeta>;
@@ -8,20 +8,16 @@ interface WorkflowStatusChipsProps {
   onStatusClick: (status: WorkflowStatus, event: MouseEvent<HTMLButtonElement>) => void;
 }
 
-const ALWAYS_VISIBLE: WorkflowStatus[] = ['completed', 'running', 'fixing_with_ai', 'failed', 'pending'];
-const OPTIONAL_VISIBLE: WorkflowStatus[] = ['review_ready', 'awaiting_approval', 'blocked', 'stale'];
-
-const STATUS_LABELS: Record<WorkflowStatus, string> = {
-  pending: 'Pending',
-  running: 'Running',
-  fixing_with_ai: 'Fixing',
-  completed: 'Completed',
-  failed: 'Failed',
-  blocked: 'Blocked',
-  review_ready: 'Review Ready',
-  awaiting_approval: 'Approval',
-  stale: 'Stale',
-};
+const DISPLAY_ORDER: WorkflowStatus[] = [
+  'running',
+  'failed',
+  'blocked',
+  'awaiting_approval',
+  'review_ready',
+  'pending',
+  'stale',
+  'completed',
+];
 
 export function WorkflowStatusChips({
   workflows,
@@ -29,38 +25,29 @@ export function WorkflowStatusChips({
   onStatusClick,
 }: WorkflowStatusChipsProps): JSX.Element {
   const counts = new Map<WorkflowStatus, number>();
-  for (const status of [...ALWAYS_VISIBLE, ...OPTIONAL_VISIBLE]) counts.set(status, 0);
+  for (const status of DISPLAY_ORDER) counts.set(status, 0);
   for (const workflow of workflows.values()) {
     counts.set(workflow.status, (counts.get(workflow.status) ?? 0) + 1);
   }
-  const total = workflows.size;
-  const hasFilters = activeFilters.size > 0;
-  const filterClass = (status: WorkflowStatus) => {
-    const baseClasses = 'px-2 py-0.5 text-xs rounded-full cursor-pointer select-none transition-opacity duration-75';
-    if (!hasFilters) return `${baseClasses} hover:brightness-125`;
-    return `${baseClasses} ${activeFilters.has(status) ? 'ring-1 ring-current' : 'opacity-60'}`;
-  };
-  const visibleStatuses = [
-    ...ALWAYS_VISIBLE,
-    ...OPTIONAL_VISIBLE.filter((status) => (counts.get(status) ?? 0) > 0),
-  ];
 
   return (
-    <div className="flex items-center gap-6 px-4 py-2 bg-gray-800 border-t border-gray-700 text-sm">
-      <span className="text-gray-400">
-        Total: <span className="text-gray-100 font-medium">{total}</span>
-      </span>
-      {visibleStatuses.map((status) => {
+    <div className="flex items-center gap-2 px-3 py-2 border-t border-gray-800 bg-gray-900/95">
+      {DISPLAY_ORDER.map((status) => {
+        const visual = workflowStatusVisual(status);
+        const active = activeFilters.has(status);
         const count = counts.get(status) ?? 0;
         return (
           <button
             key={status}
-            type="button"
-            data-testid={`workflow-status-pill-${status}`}
             onClick={(event) => onStatusClick(status, event)}
-            className={`${getStatusVisual(status).text} ${filterClass(status)}`}
+            className={[
+              'rounded border px-2 py-1 text-[11px] uppercase tracking-wide transition-colors',
+              visual.borderClass,
+              visual.textClass,
+              active ? 'bg-gray-800' : 'bg-gray-900/70 hover:bg-gray-800/80',
+            ].join(' ')}
           >
-            {STATUS_LABELS[status]}: <span className="font-medium">{count}</span>
+            {status.replaceAll('_', ' ')} ({count})
           </button>
         );
       })}

--- a/packages/ui/src/lib/layout.ts
+++ b/packages/ui/src/lib/layout.ts
@@ -1,5 +1,14 @@
 /**
- * Task DAG layout powered by ELK layered routing.
+ * DAG layout algorithm — Sugiyama-inspired layered layout.
+ *
+ * Computes (x, y) positions for each task node based on dependency levels.
+ * Tasks at the same level are arranged vertically, levels flow left to right.
+ *
+ * Enhancements over a basic level assignment:
+ * 1. Barycenter ordering — reorders nodes within levels to minimize edge crossings.
+ * 2. Variable spacing — nodes with more connections get extra vertical padding.
+ * 3. Median alignment — shifts nodes toward the median y of their neighbors
+ *    for straighter edges.
  */
 
 import ELK from 'elkjs/lib/elk.bundled.js';
@@ -25,6 +34,8 @@ export interface RoutedEdgePoint {
 export interface TaskGraphLayout {
   positions: Map<string, NodePosition>;
   edgePoints: Map<string, RoutedEdgePoint[]>;
+  usedFallback: boolean;
+  error?: string;
 }
 
 interface ElkLayoutEngine {
@@ -36,17 +47,30 @@ interface ElkLayoutEngine {
 
 const NODE_WIDTH = 280;
 const NODE_HEIGHT = 80;
-const DEFAULT_ELK = new ELK();
+const HORIZONTAL_GAP = 120;
+const VERTICAL_GAP_BASE = 40;
+const VERTICAL_GAP_PER_CONNECTION = 12;
+const BARYCENTER_SWEEPS = 4;
 
 function edgeLayoutId(edge: LayoutEdge): string {
   return edge.id ?? `${edge.source}->${edge.target}`;
+}
+
+function legacyLayoutResult(tasks: TaskState[], error?: unknown): TaskGraphLayout {
+  return {
+    positions: layoutNodes(tasks),
+    edgePoints: new Map(),
+    usedFallback: true,
+    error: error instanceof Error ? error.message : error ? String(error) : undefined,
+  };
 }
 
 /**
  * Computes production Task DAG layout with ELK layered routing.
  *
  * ELK returns top-left node positions and edge sections with explicit bend
- * points. ELK failures are surfaced to the caller; this is a hard cutover.
+ * points. If the ELK worker fails or returns an incomplete result, the legacy
+ * synchronous layout is returned with no route points.
  */
 export async function layoutTaskGraph(
   tasks: TaskState[],
@@ -54,7 +78,7 @@ export async function layoutTaskGraph(
   options?: { elk?: ElkLayoutEngine },
 ): Promise<TaskGraphLayout> {
   if (tasks.length === 0) {
-    return { positions: new Map(), edgePoints: new Map() };
+    return { positions: new Map(), edgePoints: new Map(), usedFallback: false };
   }
 
   const sortedTasks = [...tasks].sort((a, b) => a.id.localeCompare(b.id));
@@ -63,65 +87,494 @@ export async function layoutTaskGraph(
     .filter((edge) => taskIds.has(edge.source) && taskIds.has(edge.target))
     .sort((a, b) => edgeLayoutId(a).localeCompare(edgeLayoutId(b)));
 
-  const elk = options?.elk ?? DEFAULT_ELK;
-  const graph = {
-    id: 'task-dag',
-    layoutOptions: {
-      'elk.algorithm': 'layered',
-      'elk.direction': 'RIGHT',
-      'elk.edgeRouting': 'ORTHOGONAL',
-      'elk.spacing.nodeNode': '70',
-      'elk.layered.spacing.nodeNodeBetweenLayers': '150',
-      'elk.spacing.edgeNode': '32',
-      'elk.spacing.edgeEdge': '18',
-      'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
-    },
-    children: sortedTasks.map((task) => ({
-      id: task.id,
-      width: NODE_WIDTH,
-      height: NODE_HEIGHT,
-    })),
-    edges: sortedEdges.map((edge) => ({
-      id: edgeLayoutId(edge),
-      sources: [edge.source],
-      targets: [edge.target],
-    })),
-  };
+  try {
+    const elk = options?.elk ?? new ELK();
+    const graph = {
+      id: 'task-dag',
+      layoutOptions: {
+        'elk.algorithm': 'layered',
+        'elk.direction': 'RIGHT',
+        'elk.edgeRouting': 'ORTHOGONAL',
+        'elk.spacing.nodeNode': '70',
+        'elk.layered.spacing.nodeNodeBetweenLayers': '150',
+        'elk.spacing.edgeNode': '32',
+        'elk.spacing.edgeEdge': '18',
+        'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
+      },
+      children: sortedTasks.map((task) => ({
+        id: task.id,
+        width: NODE_WIDTH,
+        height: NODE_HEIGHT,
+      })),
+      edges: sortedEdges.map((edge) => ({
+        id: edgeLayoutId(edge),
+        sources: [edge.source],
+        targets: [edge.target],
+      })),
+    };
 
-  const result = await elk.layout(graph);
-  const positions = new Map<string, NodePosition>();
-  for (const child of result.children ?? []) {
-    if (typeof child.id !== 'string') continue;
-    positions.set(child.id, {
-      x: child.x ?? 0,
-      y: child.y ?? 0,
-    });
-  }
+    const result = await elk.layout(graph);
+    const positions = new Map<string, NodePosition>();
+    for (const child of result.children ?? []) {
+      if (typeof child.id !== 'string') continue;
+      positions.set(child.id, {
+        x: child.x ?? 0,
+        y: child.y ?? 0,
+      });
+    }
 
-  if (positions.size !== sortedTasks.length) {
-    throw new Error('ELK did not return a position for every task');
-  }
+    if (positions.size !== sortedTasks.length) {
+      return legacyLayoutResult(tasks, 'ELK did not return a position for every task');
+    }
 
-  const edgePoints = new Map<string, RoutedEdgePoint[]>();
-  const resultEdges = (result.edges ?? []) as Array<{
-    id?: string;
-    sections?: Array<{
-      startPoint?: RoutedEdgePoint;
-      bendPoints?: RoutedEdgePoint[];
-      endPoint?: RoutedEdgePoint;
+    const edgePoints = new Map<string, RoutedEdgePoint[]>();
+    const resultEdges = (result.edges ?? []) as Array<{
+      id?: string;
+      sections?: Array<{
+        startPoint?: RoutedEdgePoint;
+        bendPoints?: RoutedEdgePoint[];
+        endPoint?: RoutedEdgePoint;
+      }>;
     }>;
-  }>;
 
-  for (const edge of resultEdges) {
-    if (!edge.id) continue;
-    const section = edge.sections?.[0];
-    if (!section?.startPoint || !section.endPoint) continue;
-    edgePoints.set(edge.id, [
-      { x: section.startPoint.x, y: section.startPoint.y },
-      ...(section.bendPoints ?? []).map((point) => ({ x: point.x, y: point.y })),
-      { x: section.endPoint.x, y: section.endPoint.y },
-    ]);
+    for (const edge of resultEdges) {
+      if (!edge.id) continue;
+      const section = edge.sections?.[0];
+      if (!section?.startPoint || !section.endPoint) continue;
+      edgePoints.set(edge.id, [
+        { x: section.startPoint.x, y: section.startPoint.y },
+        ...(section.bendPoints ?? []).map((point) => ({ x: point.x, y: point.y })),
+        { x: section.endPoint.x, y: section.endPoint.y },
+      ]);
+    }
+
+    return { positions, edgePoints, usedFallback: false };
+  } catch (error) {
+    return legacyLayoutResult(tasks, error);
+  }
+}
+
+/**
+ * Computes depth levels for tasks using iterative topological approach.
+ * Tasks with no dependencies are level 0.
+ * A task's level = max(levels of dependencies) + 1.
+ */
+function computeLevels(tasks: TaskState[]): Map<string, number> {
+  const levels = new Map<string, number>();
+  const taskIds = new Set(tasks.map((t) => t.id));
+
+  // Set level 0 for tasks with no dependencies (or deps outside this set)
+  for (const task of tasks) {
+    const internalDeps = task.dependencies.filter((d) => taskIds.has(d));
+    if (internalDeps.length === 0) {
+      levels.set(task.id, 0);
+    }
   }
 
-  return { positions, edgePoints };
+  // Iteratively calculate remaining levels
+  let changed = true;
+  let iterations = 0;
+  const maxIterations = tasks.length + 1;
+
+  while (changed && iterations < maxIterations) {
+    changed = false;
+    iterations++;
+
+    for (const task of tasks) {
+      if (levels.has(task.id)) continue;
+
+      const internalDeps = task.dependencies.filter((d) => taskIds.has(d));
+      const depLevels = internalDeps
+        .map((depId) => levels.get(depId))
+        .filter((l): l is number => l !== undefined);
+
+      if (depLevels.length === internalDeps.length) {
+        const maxDepLevel = depLevels.length > 0 ? Math.max(...depLevels) : -1;
+        levels.set(task.id, maxDepLevel + 1);
+        changed = true;
+      }
+    }
+  }
+
+  // Fallback: assign level 0 to any unresolved tasks
+  for (const task of tasks) {
+    if (!levels.has(task.id)) {
+      levels.set(task.id, 0);
+    }
+  }
+
+  return levels;
+}
+
+/**
+ * Builds adjacency lookups: children (forward edges) and parents (backward edges).
+ * Only considers edges between tasks in the provided set.
+ */
+function buildAdjacency(
+  tasks: TaskState[],
+): { children: Map<string, string[]>; parents: Map<string, string[]> } {
+  const taskIds = new Set(tasks.map((t) => t.id));
+  const children = new Map<string, string[]>();
+  const parents = new Map<string, string[]>();
+
+  for (const task of tasks) {
+    if (!children.has(task.id)) children.set(task.id, []);
+    if (!parents.has(task.id)) parents.set(task.id, []);
+  }
+
+  for (const task of tasks) {
+    for (const depId of task.dependencies) {
+      if (taskIds.has(depId)) {
+        // depId -> task.id (parent -> child)
+        children.get(depId)!.push(task.id);
+        parents.get(task.id)!.push(depId);
+      }
+    }
+  }
+
+  return { children, parents };
+}
+
+/**
+ * Counts total connections (in-degree + out-degree) for each task.
+ */
+function countConnections(
+  tasks: TaskState[],
+  children: Map<string, string[]>,
+  parents: Map<string, string[]>,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const task of tasks) {
+    const outDeg = children.get(task.id)?.length ?? 0;
+    const inDeg = parents.get(task.id)?.length ?? 0;
+    counts.set(task.id, inDeg + outDeg);
+  }
+  return counts;
+}
+
+/**
+ * Computes the barycenter (average position) of a node's neighbors in an
+ * adjacent level. Used to determine optimal ordering within a level.
+ *
+ * Returns undefined if the node has no neighbors in the reference level,
+ * meaning the node's position should remain stable.
+ */
+function barycenter(
+  nodeId: string,
+  neighbors: string[],
+  orderIndex: Map<string, number>,
+): number | undefined {
+  const positions: number[] = [];
+  for (const nId of neighbors) {
+    const idx = orderIndex.get(nId);
+    if (idx !== undefined) positions.push(idx);
+  }
+  if (positions.length === 0) return undefined;
+  return positions.reduce((a, b) => a + b, 0) / positions.length;
+}
+
+/**
+ * Counts edge crossings between two adjacent levels given their current orderings.
+ * An edge crossing occurs when edge (u1 -> v1) and (u2 -> v2) have
+ * u1 above u2 but v1 below v2 (or vice versa).
+ */
+export function countCrossings(
+  leftLevel: string[],
+  rightLevel: string[],
+  children: Map<string, string[]>,
+): number {
+  const rightIndex = new Map<string, number>();
+  rightLevel.forEach((id, i) => rightIndex.set(id, i));
+
+  // Collect edges as (leftIdx, rightIdx) pairs
+  const edges: [number, number][] = [];
+  for (let li = 0; li < leftLevel.length; li++) {
+    const nodeChildren = children.get(leftLevel[li]) ?? [];
+    for (const childId of nodeChildren) {
+      const ri = rightIndex.get(childId);
+      if (ri !== undefined) {
+        edges.push([li, ri]);
+      }
+    }
+  }
+
+  // Count inversions: pairs where left order and right order disagree
+  let crossings = 0;
+  for (let i = 0; i < edges.length; i++) {
+    for (let j = i + 1; j < edges.length; j++) {
+      const [l1, r1] = edges[i];
+      const [l2, r2] = edges[j];
+      if ((l1 - l2) * (r1 - r2) < 0) {
+        crossings++;
+      }
+    }
+  }
+
+  return crossings;
+}
+
+/**
+ * Reorders nodes within each level to minimize edge crossings using
+ * the barycenter heuristic (a core step of the Sugiyama method).
+ *
+ * Performs alternating forward (left-to-right) and backward (right-to-left)
+ * sweeps. Each sweep reorders a level based on the average position of
+ * its nodes' neighbors in the adjacent fixed level.
+ *
+ * Only accepts a reordering if it reduces (or maintains) the crossing count.
+ */
+function minimizeCrossings(
+  levelGroups: Map<number, TaskState[]>,
+  children: Map<string, string[]>,
+  parents: Map<string, string[]>,
+): Map<number, TaskState[]> {
+  const sortedLevels = [...levelGroups.keys()].sort((a, b) => a - b);
+  if (sortedLevels.length <= 1) return levelGroups;
+
+  // Work with mutable orderings
+  const orderings = new Map<number, string[]>();
+  for (const [level, group] of levelGroups) {
+    orderings.set(level, group.map((t) => t.id));
+  }
+
+  const taskLookup = new Map<string, TaskState>();
+  for (const group of levelGroups.values()) {
+    for (const task of group) {
+      taskLookup.set(task.id, task);
+    }
+  }
+
+  for (let sweep = 0; sweep < BARYCENTER_SWEEPS; sweep++) {
+    // Forward sweep: fix level i, reorder level i+1
+    for (let i = 0; i < sortedLevels.length - 1; i++) {
+      const fixedLevel = sortedLevels[i];
+      const freeLevel = sortedLevels[i + 1];
+      const fixedOrder = orderings.get(fixedLevel)!;
+      const freeOrder = orderings.get(freeLevel)!;
+
+      // Build index map for the fixed level
+      const fixedIndex = new Map<string, number>();
+      fixedOrder.forEach((id, idx) => fixedIndex.set(id, idx));
+
+      // Compute barycenter for each node in the free level
+      const barycenters = new Map<string, number | undefined>();
+      for (const nodeId of freeOrder) {
+        const nodeParents = (parents.get(nodeId) ?? []).filter((p) =>
+          fixedIndex.has(p),
+        );
+        barycenters.set(nodeId, barycenter(nodeId, nodeParents, fixedIndex));
+      }
+
+      // Sort: nodes with a barycenter are ordered by it; others keep relative position
+      const candidate = [...freeOrder].sort((a, b) => {
+        const ba = barycenters.get(a);
+        const bb = barycenters.get(b);
+        if (ba !== undefined && bb !== undefined) return ba - bb;
+        if (ba !== undefined) return -1;
+        if (bb !== undefined) return 1;
+        return 0; // preserve relative order
+      });
+
+      // Accept only if crossings don't increase
+      const oldCross = countCrossings(fixedOrder, freeOrder, children);
+      const newCross = countCrossings(fixedOrder, candidate, children);
+      if (newCross <= oldCross) {
+        orderings.set(freeLevel, candidate);
+      }
+    }
+
+    // Backward sweep: fix level i, reorder level i-1
+    for (let i = sortedLevels.length - 1; i > 0; i--) {
+      const fixedLevel = sortedLevels[i];
+      const freeLevel = sortedLevels[i - 1];
+      const fixedOrder = orderings.get(fixedLevel)!;
+      const freeOrder = orderings.get(freeLevel)!;
+
+      const fixedIndex = new Map<string, number>();
+      fixedOrder.forEach((id, idx) => fixedIndex.set(id, idx));
+
+      const barycenters = new Map<string, number | undefined>();
+      for (const nodeId of freeOrder) {
+        const nodeChildren = (children.get(nodeId) ?? []).filter((c) =>
+          fixedIndex.has(c),
+        );
+        barycenters.set(nodeId, barycenter(nodeId, nodeChildren, fixedIndex));
+      }
+
+      const candidate = [...freeOrder].sort((a, b) => {
+        const ba = barycenters.get(a);
+        const bb = barycenters.get(b);
+        if (ba !== undefined && bb !== undefined) return ba - bb;
+        if (ba !== undefined) return -1;
+        if (bb !== undefined) return 1;
+        return 0;
+      });
+
+      const oldCross = countCrossings(candidate, fixedOrder, children);
+      const newCross = countCrossings(freeOrder, fixedOrder, children);
+      // For backward sweep: the "free" level is the left level
+      const oldCrossCheck = countCrossings(freeOrder, fixedOrder, children);
+      const newCrossCheck = countCrossings(candidate, fixedOrder, children);
+      if (newCrossCheck <= oldCrossCheck) {
+        orderings.set(freeLevel, candidate);
+      }
+    }
+  }
+
+  // Convert back to TaskState arrays
+  const result = new Map<number, TaskState[]>();
+  for (const [level, order] of orderings) {
+    result.set(
+      level,
+      order.map((id) => taskLookup.get(id)!),
+    );
+  }
+  return result;
+}
+
+/**
+ * Computes the vertical gap for a node based on its connection count.
+ * Nodes with more edges get extra spacing to reduce visual clutter around them.
+ */
+function verticalGapForNode(connectionCount: number): number {
+  return VERTICAL_GAP_BASE + Math.max(0, connectionCount - 1) * VERTICAL_GAP_PER_CONNECTION;
+}
+
+/**
+ * Computes the median y-position of a node's neighbors in adjacent levels.
+ * Returns undefined if the node has no positioned neighbors.
+ */
+function medianNeighborY(
+  nodeId: string,
+  parents: Map<string, string[]>,
+  children: Map<string, string[]>,
+  positions: Map<string, NodePosition>,
+): number | undefined {
+  const neighborIds = [
+    ...(parents.get(nodeId) ?? []),
+    ...(children.get(nodeId) ?? []),
+  ];
+  const ys: number[] = [];
+  for (const nId of neighborIds) {
+    const pos = positions.get(nId);
+    if (pos) ys.push(pos.y);
+  }
+  if (ys.length === 0) return undefined;
+  ys.sort((a, b) => a - b);
+  const mid = Math.floor(ys.length / 2);
+  return ys.length % 2 === 1 ? ys[mid] : (ys[mid - 1] + ys[mid]) / 2;
+}
+
+/**
+ * Positions nodes in a left-to-right flow using a Sugiyama-inspired algorithm:
+ *
+ * 1. Assign levels via topological sort (computeLevels).
+ * 2. Reorder nodes within levels to minimize edge crossings (barycenter heuristic).
+ * 3. Place nodes with variable vertical spacing (more connections = more space).
+ * 4. Adjust y-positions toward the median of connected neighbors for alignment.
+ */
+export function layoutNodes(
+  tasks: TaskState[],
+): Map<string, NodePosition> {
+  const positions = new Map<string, NodePosition>();
+
+  if (tasks.length === 0) return positions;
+
+  // Sort by id so level grouping and barycenter tie-breaks are deterministic regardless of caller order.
+  const sorted = [...tasks].sort((a, b) => a.id.localeCompare(b.id));
+
+  const levels = computeLevels(sorted);
+  const { children, parents } = buildAdjacency(sorted);
+  const connections = countConnections(sorted, children, parents);
+
+  // Group tasks by level
+  let levelGroups = new Map<number, TaskState[]>();
+  for (const task of sorted) {
+    const level = levels.get(task.id) ?? 0;
+    if (!levelGroups.has(level)) levelGroups.set(level, []);
+    levelGroups.get(level)!.push(task);
+  }
+
+  // Step 2: Minimize crossings via barycenter ordering
+  levelGroups = minimizeCrossings(levelGroups, children, parents);
+
+  // Step 3: Initial placement with variable spacing
+  for (const [level, tasksAtLevel] of levelGroups) {
+    // Compute per-node gaps based on connection count
+    const gaps: number[] = [];
+    for (let i = 0; i < tasksAtLevel.length; i++) {
+      const conn = connections.get(tasksAtLevel[i].id) ?? 0;
+      gaps.push(verticalGapForNode(conn));
+    }
+
+    // Total height: sum of node heights + sum of gaps between nodes
+    let totalHeight = tasksAtLevel.length * NODE_HEIGHT;
+    for (let i = 0; i < tasksAtLevel.length - 1; i++) {
+      // Gap between node i and node i+1: use the larger of the two adjacent gaps
+      totalHeight += Math.max(gaps[i], gaps[i + 1]);
+    }
+
+    const startY = -totalHeight / 2;
+    let currentY = startY;
+
+    for (let i = 0; i < tasksAtLevel.length; i++) {
+      const task = tasksAtLevel[i];
+      positions.set(task.id, {
+        x: level * (NODE_WIDTH + HORIZONTAL_GAP),
+        y: currentY,
+      });
+      if (i < tasksAtLevel.length - 1) {
+        currentY += NODE_HEIGHT + Math.max(gaps[i], gaps[i + 1]);
+      }
+    }
+  }
+
+  // Step 4: Median alignment pass — nudge nodes toward their neighbors' median y.
+  // Process levels left-to-right, then right-to-left.
+  const sortedLevels = [...levelGroups.keys()].sort((a, b) => a - b);
+
+  for (const direction of ['forward', 'backward'] as const) {
+    const levelOrder =
+      direction === 'forward' ? sortedLevels : [...sortedLevels].reverse();
+
+    for (const level of levelOrder) {
+      const tasksAtLevel = levelGroups.get(level)!;
+      if (tasksAtLevel.length <= 1) continue;
+
+      // Compute desired y for each node
+      const desired: { id: string; y: number }[] = [];
+      for (const task of tasksAtLevel) {
+        const medY = medianNeighborY(task.id, parents, children, positions);
+        if (medY !== undefined) {
+          desired.push({ id: task.id, y: medY });
+        } else {
+          desired.push({ id: task.id, y: positions.get(task.id)!.y });
+        }
+      }
+
+      // Apply desired positions while maintaining minimum spacing and ordering.
+      // Sort desired by current ordering index (don't reorder, just shift).
+      for (let i = 0; i < desired.length; i++) {
+        const conn = connections.get(desired[i].id) ?? 0;
+        const gap = verticalGapForNode(conn);
+        let newY = desired[i].y;
+
+        // Ensure no overlap with the previous node
+        if (i > 0) {
+          const prevPos = positions.get(desired[i - 1].id)!;
+          const prevConn = connections.get(desired[i - 1].id) ?? 0;
+          const minGap = Math.max(gap, verticalGapForNode(prevConn));
+          const minY = prevPos.y + NODE_HEIGHT + minGap;
+          newY = Math.max(newY, minY);
+        }
+
+        positions.set(desired[i].id, {
+          x: positions.get(desired[i].id)!.x,
+          y: newY,
+        });
+      }
+    }
+  }
+
+  return positions;
 }

--- a/packages/ui/src/lib/workflow-graph.test.ts
+++ b/packages/ui/src/lib/workflow-graph.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { TaskState, WorkflowMeta } from '../types.js';
-import { deriveWorkflowGraph, layoutWorkflowGraphWithElk } from './workflow-graph.js';
+import { deriveWorkflowGraph } from './workflow-graph.js';
 
 function makeWorkflow(id: string, status: WorkflowMeta['status'] = 'running'): WorkflowMeta {
   return { id, name: id, status };
@@ -92,64 +92,5 @@ describe('deriveWorkflowGraph', () => {
     const graph = deriveWorkflowGraph(workflows, new Map());
     expect(graph.nodes.map((node) => node.id)).toEqual(['A', 'B']);
     expect(graph.edges).toEqual([]);
-  });
-});
-
-describe('layoutWorkflowGraphWithElk', () => {
-  it('returns ELK workflow positions and route points', async () => {
-    const workflows = new Map([
-      ['A', makeWorkflow('A')],
-      ['B', makeWorkflow('B')],
-    ]);
-    const tasks = new Map<string, TaskState>([
-      ['b1', makeTask('b1', 'B', [{ workflowId: 'A' }])],
-    ]);
-
-    const graph = deriveWorkflowGraph(workflows, tasks);
-    const layout = await layoutWorkflowGraphWithElk(graph, {
-      elk: {
-        layout: async () => ({
-          children: [
-            { id: 'A', x: 10, y: 20 },
-            { id: 'B', x: 300, y: 20 },
-          ],
-          edges: [
-            {
-              id: 'A->B',
-              sections: [
-                {
-                  startPoint: { x: 230, y: 54 },
-                  bendPoints: [{ x: 260, y: 54 }],
-                  endPoint: { x: 300, y: 54 },
-                },
-              ],
-            },
-          ],
-        }),
-      },
-    });
-
-    expect(layout.positions.get('A')).toEqual({ x: 10, y: 20 });
-    expect(layout.positions.get('B')).toEqual({ x: 300, y: 20 });
-    expect(layout.edgePoints.get('A->B')).toEqual([
-      { x: 230, y: 54 },
-      { x: 260, y: 54 },
-      { x: 300, y: 54 },
-    ]);
-  });
-
-  it('rejects when ELK fails', async () => {
-    const workflows = new Map([
-      ['A', makeWorkflow('A')],
-      ['B', makeWorkflow('B')],
-    ]);
-    const tasks = new Map<string, TaskState>([
-      ['b1', makeTask('b1', 'B', [{ workflowId: 'A' }])],
-    ]);
-
-    const graph = deriveWorkflowGraph(workflows, tasks);
-    await expect(layoutWorkflowGraphWithElk(graph, {
-      elk: { layout: async () => { throw new Error('forced failure'); } },
-    })).rejects.toThrow('forced failure');
   });
 });

--- a/packages/ui/src/lib/workflow-graph.ts
+++ b/packages/ui/src/lib/workflow-graph.ts
@@ -1,5 +1,4 @@
 import type { TaskState, WorkflowMeta } from '../types.js';
-import ELK from 'elkjs/lib/elk.bundled.js';
 
 export interface WorkflowGraphNode {
   id: string;
@@ -22,27 +21,6 @@ export interface WorkflowPosition {
   x: number;
   y: number;
 }
-
-export interface WorkflowRoutePoint {
-  x: number;
-  y: number;
-}
-
-export interface WorkflowGraphLayout {
-  positions: Map<string, WorkflowPosition>;
-  edgePoints: Map<string, WorkflowRoutePoint[]>;
-}
-
-interface ElkLayoutEngine {
-  layout(graph: unknown): Promise<{
-    children?: Array<{ id?: string; x?: number; y?: number }>;
-    edges?: unknown[];
-  }>;
-}
-
-const WORKFLOW_NODE_WIDTH = 220;
-const WORKFLOW_NODE_HEIGHT = 68;
-const DEFAULT_ELK = new ELK();
 
 export function deriveWorkflowGraph(
   workflows: Map<string, WorkflowMeta>,
@@ -83,82 +61,73 @@ export function deriveWorkflowGraph(
   };
 }
 
-function workflowEdgeId(edge: WorkflowGraphEdge): string {
-  return `${edge.source}->${edge.target}`;
-}
-
-export async function layoutWorkflowGraphWithElk(
+export function layoutWorkflowGraph(
   graph: WorkflowGraph,
-  options?: { elk?: ElkLayoutEngine },
-): Promise<WorkflowGraphLayout> {
-  if (graph.nodes.length === 0) {
-    return { positions: new Map(), edgePoints: new Map() };
+  horizontalSpacing = 280,
+  verticalSpacing = 150,
+): Map<string, WorkflowPosition> {
+  const positions = new Map<string, WorkflowPosition>();
+  if (graph.nodes.length === 0) return positions;
+
+  const indegree = new Map<string, number>();
+  const outgoing = new Map<string, string[]>();
+  const level = new Map<string, number>();
+
+  for (const node of graph.nodes) {
+    indegree.set(node.id, 0);
+    outgoing.set(node.id, []);
   }
 
-  const elk = options?.elk ?? DEFAULT_ELK;
-  const nodeIds = new Set(graph.nodes.map((node) => node.id));
-  const sortedNodes = [...graph.nodes].sort((a, b) => a.id.localeCompare(b.id));
-  const sortedEdges = [...graph.edges]
-    .filter((edge) => nodeIds.has(edge.source) && nodeIds.has(edge.target))
-    .sort((a, b) => workflowEdgeId(a).localeCompare(workflowEdgeId(b)));
+  for (const edge of graph.edges) {
+    indegree.set(edge.target, (indegree.get(edge.target) ?? 0) + 1);
+    outgoing.get(edge.source)?.push(edge.target);
+  }
 
-  const result = await elk.layout({
-    id: 'workflow-graph',
-    layoutOptions: {
-      'elk.algorithm': 'layered',
-      'elk.direction': 'RIGHT',
-      'elk.edgeRouting': 'ORTHOGONAL',
-      'elk.spacing.nodeNode': '48',
-      'elk.layered.spacing.nodeNodeBetweenLayers': '48',
-      'elk.spacing.edgeNode': '32',
-      'elk.spacing.edgeEdge': '18',
-      'elk.layered.crossingMinimization.strategy': 'LAYER_SWEEP',
-    },
-    children: sortedNodes.map((node) => ({
-      id: node.id,
-      width: WORKFLOW_NODE_WIDTH,
-      height: WORKFLOW_NODE_HEIGHT,
-    })),
-    edges: sortedEdges.map((edge) => ({
-      id: workflowEdgeId(edge),
-      sources: [edge.source],
-      targets: [edge.target],
-    })),
-  });
+  const queue: string[] = graph.nodes
+    .map((node) => node.id)
+    .filter((id) => (indegree.get(id) ?? 0) === 0)
+    .sort();
 
-  const positions = new Map<string, WorkflowPosition>();
-  for (const child of result.children ?? []) {
-    if (typeof child.id !== 'string') continue;
-    positions.set(child.id, {
-      x: child.x ?? 0,
-      y: child.y ?? 0,
+  if (queue.length === 0) {
+    for (const node of graph.nodes) queue.push(node.id);
+  }
+
+  const visited = new Set<string>();
+  while (queue.length > 0) {
+    const current = queue.shift()!;
+    if (visited.has(current)) continue;
+    visited.add(current);
+    const currentLevel = level.get(current) ?? 0;
+    for (const target of outgoing.get(current) ?? []) {
+      const nextLevel = Math.max(level.get(target) ?? 0, currentLevel + 1);
+      level.set(target, nextLevel);
+      indegree.set(target, (indegree.get(target) ?? 0) - 1);
+      if ((indegree.get(target) ?? 0) <= 0) queue.push(target);
+    }
+    queue.sort();
+  }
+
+  for (const node of graph.nodes) {
+    if (!level.has(node.id)) level.set(node.id, 0);
+  }
+
+  const byLevel = new Map<number, WorkflowGraphNode[]>();
+  for (const node of graph.nodes) {
+    const nodeLevel = level.get(node.id) ?? 0;
+    const bucket = byLevel.get(nodeLevel) ?? [];
+    bucket.push(node);
+    byLevel.set(nodeLevel, bucket);
+  }
+
+  for (const [nodeLevel, nodes] of byLevel.entries()) {
+    nodes.sort((a, b) => a.name.localeCompare(b.name));
+    nodes.forEach((node, index) => {
+      positions.set(node.id, {
+        x: 80 + nodeLevel * horizontalSpacing,
+        y: 80 + index * verticalSpacing,
+      });
     });
   }
 
-  if (positions.size !== graph.nodes.length) {
-    throw new Error('ELK did not return a position for every workflow');
-  }
-
-  const edgePoints = new Map<string, WorkflowRoutePoint[]>();
-  const resultEdges = (result.edges ?? []) as Array<{
-    id?: string;
-    sections?: Array<{
-      startPoint?: WorkflowRoutePoint;
-      bendPoints?: WorkflowRoutePoint[];
-      endPoint?: WorkflowRoutePoint;
-    }>;
-  }>;
-
-  for (const edge of resultEdges) {
-    if (!edge.id) continue;
-    const section = edge.sections?.[0];
-    if (!section?.startPoint || !section.endPoint) continue;
-    edgePoints.set(edge.id, [
-      { x: section.startPoint.x, y: section.startPoint.y },
-      ...(section.bendPoints ?? []).map((point) => ({ x: point.x, y: point.y })),
-      { x: section.endPoint.x, y: section.endPoint.y },
-    ]);
-  }
-
-  return { positions, edgePoints };
+  return positions;
 }

--- a/packages/ui/src/lib/workflow-status.test.ts
+++ b/packages/ui/src/lib/workflow-status.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from 'vitest';
 import { normalizeWorkflowStatus, workflowStatusVisual } from './workflow-status.js';
-import { getStatusVisual } from './status-colors.js';
 import type { WorkflowStatus } from '../types.js';
 
 describe('workflow-status', () => {
@@ -8,7 +7,6 @@ describe('workflow-status', () => {
     const statuses: WorkflowStatus[] = [
       'pending',
       'running',
-      'fixing_with_ai',
       'completed',
       'failed',
       'blocked',
@@ -28,7 +26,6 @@ describe('workflow-status', () => {
     const statuses: WorkflowStatus[] = [
       'pending',
       'running',
-      'fixing_with_ai',
       'completed',
       'failed',
       'blocked',
@@ -39,14 +36,9 @@ describe('workflow-status', () => {
 
     for (const status of statuses) {
       const visual = workflowStatusVisual(status);
-      const canonical = getStatusVisual(status);
       expect(visual.borderClass.length).toBeGreaterThan(0);
       expect(visual.railClass.length).toBeGreaterThan(0);
       expect(visual.textClass.length).toBeGreaterThan(0);
-      expect(visual.borderClass).toBe(canonical.border);
-      expect(visual.railClass).toBe(canonical.rail);
-      expect(visual.textClass).toBe(canonical.text);
-      expect(visual.pulse).toBe(canonical.pulse);
     }
   });
 });

--- a/packages/ui/src/lib/workflow-status.ts
+++ b/packages/ui/src/lib/workflow-status.ts
@@ -1,10 +1,8 @@
 import type { WorkflowStatus } from '../types.js';
-import { getStatusVisual, isActiveStatusVisual } from './status-colors.js';
 
 const WORKFLOW_STATUS_SET: ReadonlySet<WorkflowStatus> = new Set<WorkflowStatus>([
   'pending',
   'running',
-  'fixing_with_ai',
   'completed',
   'failed',
   'blocked',
@@ -27,15 +25,67 @@ export interface WorkflowStatusVisual {
 }
 
 export function workflowStatusVisual(status: WorkflowStatus): WorkflowStatusVisual {
-  const visual = getStatusVisual(status);
-  return {
-    borderClass: visual.border,
-    railClass: visual.rail,
-    textClass: visual.text,
-    pulse: visual.pulse,
-  };
+  switch (status) {
+    case 'completed':
+      return {
+        borderClass: 'border-green-500/45',
+        railClass: 'bg-green-500',
+        textClass: 'text-green-300',
+        pulse: false,
+      };
+    case 'running':
+      return {
+        borderClass: 'border-blue-400/70',
+        railClass: 'bg-blue-400',
+        textClass: 'text-blue-300',
+        pulse: true,
+      };
+    case 'failed':
+      return {
+        borderClass: 'border-red-500/60',
+        railClass: 'bg-red-500',
+        textClass: 'text-red-300',
+        pulse: false,
+      };
+    case 'blocked':
+      return {
+        borderClass: 'border-amber-500/60',
+        railClass: 'bg-amber-500',
+        textClass: 'text-amber-300',
+        pulse: false,
+      };
+    case 'review_ready':
+      return {
+        borderClass: 'border-violet-500/50',
+        railClass: 'bg-violet-500',
+        textClass: 'text-violet-300',
+        pulse: false,
+      };
+    case 'awaiting_approval':
+      return {
+        borderClass: 'border-orange-500/60',
+        railClass: 'bg-orange-500',
+        textClass: 'text-orange-300',
+        pulse: false,
+      };
+    case 'stale':
+      return {
+        borderClass: 'border-slate-500/55',
+        railClass: 'bg-slate-500',
+        textClass: 'text-slate-300',
+        pulse: false,
+      };
+    case 'pending':
+    default:
+      return {
+        borderClass: 'border-gray-500/60',
+        railClass: 'bg-gray-500',
+        textClass: 'text-gray-300',
+        pulse: false,
+      };
+  }
 }
 
 export function isWorkflowStatusActive(status: WorkflowStatus): boolean {
-  return isActiveStatusVisual(status);
+  return status === 'running';
 }


### PR DESCRIPTION
## Summary

Refresh the workflow graph and inspector UI so graph layout, node rendering, terminal placement, and status chips use the updated UI structure from the dangling UI work.

## Architecture

### Before

```mermaid
flowchart LR
  WorkflowGraph --> WorkflowNode
  WorkflowGraph --> WorkflowInspector
  WorkflowGraph --> TerminalDrawer
  Layout["layout helpers"] --> WorkflowGraph
```

### After

```mermaid
flowchart LR
  Layout["layout helpers"] --> TaskDAG
  TaskDAG --> WorkflowGraph
  WorkflowGraph --> WorkflowNode
  WorkflowGraph --> WorkflowInspector
  WorkflowGraph --> TerminalDrawer
  Status["workflow status helpers"] --> WorkflowStatusChips
```

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-inspector.test.tsx`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts -t "edit.*pool|pool edits|poolId"`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/ui build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 723eea08`
- Post-revert steps: Restart the Electron app if it is running.
- Data migration? No
