### PR TITLE
Add editable executor pool controls

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1980,6 +1980,8 @@ if (isHeadless) {
         return { channel: 'headless.exec', request: { args: ['set', 'prompt', String(arg0), String(arg1)] } };
       case 'invoker:edit-task-type':
         return { channel: 'headless.exec', request: { args: ['set', 'executor', String(arg0), String(arg1)] } };
+      case 'invoker:edit-task-pool':
+        return null;
       case 'invoker:edit-task-agent':
         return { channel: 'headless.exec', request: { args: ['set', 'agent', String(arg0), String(arg1)] } };
       case 'invoker:set-task-external-gate-policies': {
@@ -2903,6 +2905,7 @@ if (isHeadless) {
     });
 
     ipcMain.handle('invoker:list-workflows', () => persistence.listWorkflows());
+    ipcMain.handle('invoker:get-execution-pools', () => Object.keys(loadConfig().executionPools ?? {}));
 
     registerGuiMutationHandler('invoker:delete-all-workflows', async () => {
       logger.info('delete-all-workflows', { module: 'ipc' });
@@ -3683,6 +3686,27 @@ if (isHeadless) {
         });
       } catch (err) {
         logger.error(`edit-task-type failed: ${err}`, { module: 'ipc' });
+        throw err;
+      }
+    });
+
+    registerGuiMutationHandler('invoker:edit-task-pool', async (taskIdArg: unknown, poolIdArg: unknown) => {
+      const taskId = String(taskIdArg);
+      const poolId = String(poolIdArg);
+      logger.info(`edit-task-pool: "${taskId}" → "${poolId}"`, { module: 'ipc' });
+      try {
+        const envelope = makeEnvelope('edit-task-pool', 'ui', 'task', { taskId, poolId });
+        const result = await commandService.editTaskPool(envelope);
+        if (!result.ok) throw new Error(result.error.message);
+        await dispatchStartedTasksWithGlobalTopup({
+          orchestrator,
+          taskExecutor: requireTaskExecutor(),
+          logger,
+          context: 'ipc.edit-task-pool',
+          started: result.data,
+        });
+      } catch (err) {
+        logger.error(`edit-task-pool failed: ${err}`, { module: 'ipc' });
         throw err;
       }
     });

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -376,6 +376,10 @@ export const IpcChannels = {
     request: [taskId: string, runnerKind: string, poolMemberId?: string];
     response: void;
   },
+  'invoker:edit-task-pool': {} as {
+    request: [taskId: string, poolId: string];
+    response: void;
+  },
   'invoker:edit-task-agent': {} as {
     request: [taskId: string, agentName: string];
     response: void;
@@ -465,6 +469,10 @@ export const IpcChannels = {
     response: ActionGraphResponse;
   },
   'invoker:get-remote-targets': {} as {
+    request: [];
+    response: string[];
+  },
+  'invoker:get-execution-pools': {} as {
     request: [];
     response: string[];
   },

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -74,6 +74,24 @@ type ActiveExecutionEntry = {
   handle: ActiveExecutionHandle;
   executor: Executor;
   taskId: string;
+  poolId?: string;
+  poolMemberKey?: string;
+};
+
+type ExecutionPoolMember =
+  | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
+  | { type: 'worktree'; id: string; maxConcurrentTasks?: number };
+
+type ExecutionPoolConfig = {
+  members: ExecutionPoolMember[];
+  selectionStrategy?: 'roundRobin' | 'leastLoaded';
+  maxConcurrentTasksPerMember?: number;
+};
+
+type PoolSelection = {
+  poolId: string;
+  member: ExecutionPoolMember;
+  memberKey: string;
 };
 
 function nextLeaseExpiry(from: Date): Date {
@@ -158,19 +176,14 @@ export class TaskRunner {
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
   private activePrPollers = new Map<string, ReturnType<typeof setInterval>>();
   private getRemoteTargets: () => Record<string, { host: string; user: string; sshKeyPath: string; port?: number; managedWorkspaces?: boolean; remoteInvokerHome?: string; provisionCommand?: string; remoteHeartbeatIntervalSeconds?: number }>;
-  private getExecutionPools: () => Record<string, {
-    members: Array<
-      | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
-      | { type: 'worktree'; id: string; maxConcurrentTasks?: number }
-    >;
-    selectionStrategy?: 'roundRobin' | 'leastLoaded';
-    maxConcurrentTasksPerMember?: number;
-  }>;
+  private getExecutionPools: () => Record<string, ExecutionPoolConfig>;
   private dockerConfig: { imageName?: string; secretsFile?: string };
   private executionAgentRegistry?: AgentRegistry;
   private logger: Logger;
   /** Cache for SSH executors, keyed by poolMemberId. One instance per target for correct git locking. */
   private sshExecutorCache = new Map<string, SshExecutor>();
+  private poolRoundRobinCursor = new Map<string, number>();
+  private pendingPoolSelections = new Map<string, PoolSelection>();
 
   /** In-flight executions keyed by attemptId (with taskId retained for external kill resolution). */
   private activeExecutions = new Map<string, ActiveExecutionEntry>();
@@ -600,6 +613,7 @@ export class TaskRunner {
         }),
       ]);
     } catch (err) {
+      this.pendingPoolSelections.delete(task.id);
       const meta = err as StartupFailureMetadata;
       const startupErrorMessage = `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}\n`;
       this.callbacks.onOutput?.(task.id, startupErrorMessage);
@@ -651,6 +665,7 @@ export class TaskRunner {
       } catch (killErr) {
         this.logger.warn(`[TaskRunner] failed to kill rejected launch for task=${task.id}`, { killErr });
       }
+      this.pendingPoolSelections.delete(task.id);
       await this.cleanupPerTaskDockerExecutor(task);
       return;
     }
@@ -707,7 +722,15 @@ export class TaskRunner {
     // Notify consumer about the spawned handle
     const activeHandle = handle as ActiveExecutionHandle;
     activeHandle.attemptId = attemptId;
-    this.activeExecutions.set(attemptId, { handle: activeHandle, executor, taskId: task.id });
+    const poolSelection = this.pendingPoolSelections.get(task.id);
+    this.pendingPoolSelections.delete(task.id);
+    this.activeExecutions.set(attemptId, {
+      handle: activeHandle,
+      executor,
+      taskId: task.id,
+      poolId: poolSelection?.poolId,
+      poolMemberKey: poolSelection?.memberKey,
+    });
     this.callbacks.onSpawned?.(task.id, handle, executor);
 
     // Wire output
@@ -802,16 +825,60 @@ export class TaskRunner {
    * Uses task.runnerKind to look up in the registry; falls back to default.
    * Merge gate tasks use the dedicated merge executor.
    */
+  private poolMemberKey(member: ExecutionPoolMember): string {
+    return `${member.type}:${member.id}`;
+  }
+
+  private poolMemberLoad(poolId: string, memberKey: string): number {
+    let load = 0;
+    for (const selection of this.pendingPoolSelections.values()) {
+      if (selection.poolId === poolId && selection.memberKey === memberKey) load += 1;
+    }
+    for (const entry of this.activeExecutions.values()) {
+      if (entry.poolId === poolId && entry.poolMemberKey === memberKey) load += 1;
+    }
+    return load;
+  }
+
+  private selectPoolMember(poolId: string, pool: ExecutionPoolConfig): ExecutionPoolMember | undefined {
+    if (pool.members.length === 0) return undefined;
+
+    if (pool.selectionStrategy === 'roundRobin') {
+      const cursor = this.poolRoundRobinCursor.get(poolId) ?? 0;
+      const member = pool.members[cursor % pool.members.length];
+      this.poolRoundRobinCursor.set(poolId, (cursor + 1) % pool.members.length);
+      return member;
+    }
+
+    const scored = pool.members.map((member, index) => {
+      const memberKey = this.poolMemberKey(member);
+      const load = this.poolMemberLoad(poolId, memberKey);
+      const limit = member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
+      return { member, index, load, hasCapacity: limit === undefined || load < limit };
+    });
+    const candidates = scored.some((entry) => entry.hasCapacity)
+      ? scored.filter((entry) => entry.hasCapacity)
+      : scored;
+    candidates.sort((a, b) => a.load - b.load || a.index - b.index);
+    return candidates[0]?.member;
+  }
+
   selectExecutor(task: TaskState): Executor {
     let effectiveType = task.config.runnerKind ?? (task.config.isMergeNode ? 'merge' : undefined);
     let selectedPoolMemberId: string | undefined;
+    this.pendingPoolSelections.delete(task.id);
 
     if (task.config.poolId) {
       const pool = this.getExecutionPools()[task.config.poolId];
-      const member = pool?.members[0];
+      const member = pool ? this.selectPoolMember(task.config.poolId, pool) : undefined;
       if (member) {
         effectiveType = member.type;
         selectedPoolMemberId = member.type === 'ssh' ? member.id : undefined;
+        this.pendingPoolSelections.set(task.id, {
+          poolId: task.config.poolId,
+          member,
+          memberKey: this.poolMemberKey(member),
+        });
       }
     }
     if (

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -233,6 +233,7 @@ export function App() {
   const [selectedActionNode, setSelectedActionNode] = useState<ActionGraphNode | null>(null);
   const [contextMenu, setContextMenu] = useState<{ x: number; y: number; taskId: string } | null>(null);
   const [remoteTargets, setRemoteTargets] = useState<string[]>([]);
+  const [executionPools, setExecutionPools] = useState<string[]>([]);
   const [executionAgents, setExecutionAgents] = useState<string[]>([]);
   const [statusFilters, setStatusFilters] = useState<Set<WorkflowStatus>>(new Set());
   const [systemDiagnostics, setSystemDiagnostics] = useState<SystemDiagnostics | null>(null);
@@ -263,6 +264,7 @@ export function App() {
 
   useEffect(() => {
     window.invoker?.getRemoteTargets?.().then(setRemoteTargets).catch(() => {});
+    window.invoker?.getExecutionPools?.().then(setExecutionPools).catch(() => {});
     window.invoker?.getExecutionAgents?.().then(setExecutionAgents).catch(() => {});
     refreshSystemDiagnostics();
   }, [refreshSystemDiagnostics]);
@@ -805,6 +807,19 @@ export function App() {
     [invoker],
   );
 
+  // ── Edit task execution pool ─────────────────────────────
+  const handleEditPool = useCallback(
+    async (taskId: string, poolId: string) => {
+      if (!invoker) return;
+      try {
+        await invoker.editTaskPool(taskId, poolId);
+      } catch (err) {
+        console.error('Failed to edit task pool:', err);
+      }
+    },
+    [invoker],
+  );
+
   // ── Edit task execution agent ────────────────────────────
   const handleEditAgent = useCallback(
     async (taskId: string, agentName: string) => {
@@ -1120,11 +1135,13 @@ export function App() {
               task={selectedTask}
               workflowTasks={miniDagTasks}
               remoteTargets={remoteTargets}
+              executionPools={executionPools}
               executionAgents={executionAgents}
               collapsed={inspectorCollapsed}
               advancedExpanded={advancedMetadataExpanded}
               actionNode={viewMode === 'actionGraph' ? selectedActionNode : null}
               onEditType={handleEditType}
+              onEditPool={handleEditPool}
               onEditAgent={handleEditAgent}
               onEditPrompt={handleEditPrompt}
               onEditCommand={handleEditCommand}

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -76,9 +76,11 @@ export function createMockInvoker(
     restartTask: vi.fn(async () => {}),
     editTaskCommand: vi.fn(async () => {}),
     editTaskType: vi.fn(async () => {}),
+    editTaskPool: vi.fn(async () => {}),
     editTaskAgent: vi.fn(async () => {}),
     setTaskExternalGatePolicies: vi.fn(async () => {}),
     getRemoteTargets: vi.fn(async () => []),
+    getExecutionPools: vi.fn(async () => ['mixed-local-ssh', 'pnpm-ssh']),
     getExecutionAgents: vi.fn(async () => ['claude', 'codex']),
     getSystemDiagnostics: vi.fn(async () => ({
       platform: 'linux',

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
 import { WorkflowInspector } from '../components/WorkflowInspector.js';
 import type { TaskState, WorkflowMeta } from '../types.js';
 
@@ -28,7 +28,7 @@ describe('WorkflowInspector', () => {
     render(
       <WorkflowInspector
         workflow={workflow}
-        task={makeTask()}
+        task={makeTask({ status: 'failed' })}
         collapsed={false}
         advancedExpanded={false}
         onToggleCollapsed={() => {}}
@@ -44,7 +44,7 @@ describe('WorkflowInspector', () => {
     render(
       <WorkflowInspector
         workflow={workflow}
-        task={makeTask()}
+        task={makeTask({ status: 'failed' })}
         collapsed={false}
         advancedExpanded={false}
         onToggleCollapsed={() => {}}
@@ -80,5 +80,102 @@ describe('WorkflowInspector', () => {
       />,
     );
     expect(screen.getByText('Workflow 1')).toBeInTheDocument();
+  });
+
+  it('renders selected task title and selected task status first', () => {
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ description: 'Fix cancellation race', status: 'failed' })}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Fix cancellation race')).toBeInTheDocument();
+    expect(screen.getByText('failed')).toBeInTheDocument();
+  });
+
+  it('edits AI agent from a dropdown', () => {
+    const onEditAgent = vi.fn();
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask()}
+        executionAgents={['claude', 'codex']}
+        collapsed={false}
+        advancedExpanded={false}
+        onEditAgent={onEditAgent}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('execution-agent-select'), { target: { value: 'claude' } });
+    expect(onEditAgent).toHaveBeenCalledWith('task-1', 'claude');
+  });
+
+  it('double-click edits prompt and saves through callback', () => {
+    const onEditPrompt = vi.fn();
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ status: 'failed' })}
+        collapsed={false}
+        advancedExpanded={false}
+        onEditPrompt={onEditPrompt}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    fireEvent.doubleClick(screen.getByTestId('prompt-command-display'));
+    fireEvent.change(screen.getByTestId('edit-prompt-input'), { target: { value: 'New prompt' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save & Re-run' }));
+
+    expect(onEditPrompt).toHaveBeenCalledWith('task-1', 'New prompt');
+  });
+
+  it('double-click edits command and saves through callback', () => {
+    const onEditCommand = vi.fn();
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ status: 'failed', config: { workflowId: 'wf-1', command: 'pnpm test' } })}
+        collapsed={false}
+        advancedExpanded={false}
+        onEditCommand={onEditCommand}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    fireEvent.doubleClick(screen.getByTestId('prompt-command-display'));
+    fireEvent.change(screen.getByTestId('edit-command-input'), { target: { value: 'pnpm test --runInBand' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save & Re-run' }));
+
+    expect(onEditCommand).toHaveBeenCalledWith('task-1', 'pnpm test --runInBand');
+  });
+
+  it('edits executor pool outside advanced metadata', () => {
+    const onEditPool = vi.fn();
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ config: { workflowId: 'wf-1', prompt: 'Fix failing tests', poolId: 'mixed-local-ssh' } })}
+        executionPools={['mixed-local-ssh', 'pnpm-ssh']}
+        collapsed={false}
+        advancedExpanded={true}
+        onEditPool={onEditPool}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('executor-pool-select'), { target: { value: 'pnpm-ssh' } });
+    expect(onEditPool).toHaveBeenCalledWith('task-1', 'pnpm-ssh');
+    expect(screen.queryByText(/executor:/i)).not.toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -1,28 +1,99 @@
+import { useEffect, useMemo, useState } from 'react';
 import type { TaskState, WorkflowMeta } from '../types.js';
+import { getEffectiveVisualStatus, getStatusColor } from '../lib/colors.js';
 import { workflowStatusVisual } from '../lib/workflow-status.js';
 
 interface WorkflowInspectorProps {
   workflow: WorkflowMeta | null;
   task: TaskState | null;
+  workflowTasks?: Map<string, TaskState>;
+  remoteTargets?: string[];
+  executionPools?: string[];
+  executionAgents?: string[];
+  actionNode?: unknown;
   collapsed: boolean;
   advancedExpanded: boolean;
+  onEditType?: (taskId: string, runnerKind: string, poolMemberId?: string) => void;
+  onEditPool?: (taskId: string, poolId: string) => void;
+  onEditAgent?: (taskId: string, agentName: string) => void;
+  onEditPrompt?: (taskId: string, newPrompt: string) => void;
+  onEditCommand?: (taskId: string, newCommand: string) => void;
+  onSetMergeBranch?: (workflowId: string, baseBranch: string) => Promise<void>;
   onToggleCollapsed: () => void;
   onToggleAdvanced: () => void;
 }
 
-function summarizePrompt(task: TaskState | null): string {
-  if (!task) return 'No task selected.';
-  return task.config.prompt ?? task.config.command ?? 'No prompt or command available.';
+function formatStatus(value: string | undefined): string {
+  return value?.replaceAll('_', ' ') ?? 'unknown';
+}
+
+function capitalize(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
 export function WorkflowInspector({
   workflow,
   task,
+  executionPools,
+  executionAgents,
   collapsed,
   advancedExpanded,
+  onEditPool,
+  onEditAgent,
+  onEditPrompt,
+  onEditCommand,
   onToggleCollapsed,
   onToggleAdvanced,
 }: WorkflowInspectorProps): JSX.Element {
+  const [isEditingPrompt, setIsEditingPrompt] = useState(false);
+  const [editPromptValue, setEditPromptValue] = useState('');
+  const [isEditingCommand, setIsEditingCommand] = useState(false);
+  const [editCommandValue, setEditCommandValue] = useState('');
+
+  useEffect(() => {
+    setIsEditingPrompt(false);
+    setEditPromptValue(task?.config.prompt ?? '');
+    setIsEditingCommand(false);
+    setEditCommandValue(task?.config.command ?? '');
+  }, [task?.id, task?.config.prompt, task?.config.command]);
+
+  const taskVisualStatus = task ? getEffectiveVisualStatus(task.status, task.execution) : null;
+  const taskColors = taskVisualStatus ? getStatusColor(taskVisualStatus) : null;
+  const workflowVisual = workflow ? workflowStatusVisual(workflow.status) : null;
+  const reviewUrl = task?.execution.reviewUrl;
+  const nodeTitle = task?.description ?? workflow?.name ?? workflow?.id ?? 'No node selected';
+  const currentAgent = task?.config.executionAgent ?? task?.execution.agentName ?? 'claude';
+  const agentOptions = useMemo(() => {
+    const names = new Set(executionAgents ?? []);
+    names.add(currentAgent);
+    return [...names].filter(Boolean);
+  }, [currentAgent, executionAgents]);
+  const poolOptions = useMemo(() => {
+    const ids = new Set(executionPools ?? []);
+    if (task?.config.poolId) ids.add(task.config.poolId);
+    return [...ids].filter(Boolean);
+  }, [executionPools, task?.config.poolId]);
+  const isTaskBusy = task?.status === 'running' || task?.status === 'fixing_with_ai';
+  const canEditPrompt = Boolean(task?.config.prompt !== undefined && onEditPrompt && !isTaskBusy);
+  const canEditCommand = Boolean(task?.config.command !== undefined && onEditCommand && !isTaskBusy);
+  const statusBorder = taskColors?.border ?? workflowVisual?.borderClass ?? 'border-gray-700';
+  const statusText = taskColors?.text ?? workflowVisual?.textClass ?? 'text-gray-300';
+  const statusDot = taskColors?.dot ?? '';
+
+  const savePrompt = () => {
+    if (task && onEditPrompt && editPromptValue !== (task.config.prompt ?? '')) {
+      onEditPrompt(task.id, editPromptValue);
+    }
+    setIsEditingPrompt(false);
+  };
+
+  const saveCommand = () => {
+    if (task && onEditCommand && editCommandValue !== (task.config.command ?? '')) {
+      onEditCommand(task.id, editCommandValue);
+    }
+    setIsEditingCommand(false);
+  };
+
   if (collapsed) {
     return (
       <aside className="h-full w-full border-l border-gray-800 bg-gray-900 flex items-start justify-center pt-3">
@@ -36,16 +107,15 @@ export function WorkflowInspector({
     );
   }
 
-  const visual = workflow ? workflowStatusVisual(workflow.status) : null;
-  const reviewUrl = task?.execution.reviewUrl;
-  const agent = task?.config.executionAgent ?? task?.execution.agentName ?? 'n/a';
-
   return (
     <aside className="h-full w-full border-l border-gray-800 bg-gray-900 flex flex-col">
       <div className="flex items-center justify-between border-b border-gray-800 px-3 py-2">
-        <div>
+        <div className="min-w-0">
           <div className="text-xs font-semibold uppercase tracking-wide text-gray-300">Inspector</div>
-          <div className="text-[11px] text-gray-400 truncate max-w-[240px]">{workflow?.name ?? workflow?.id ?? 'No workflow selected'}</div>
+          <div className="mt-1 text-sm font-medium text-gray-100 truncate max-w-[270px]">{nodeTitle}</div>
+          {workflow && task && (
+            <div className="text-[11px] text-gray-400 truncate max-w-[270px]">{workflow.name}</div>
+          )}
         </div>
         <button
           onClick={onToggleCollapsed}
@@ -56,22 +126,126 @@ export function WorkflowInspector({
       </div>
 
       <div className="flex-1 overflow-auto p-3 space-y-3 text-sm">
-        <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
-          <div className="text-[11px] uppercase tracking-wide text-gray-400">AI Agent</div>
-          <div className="mt-1 text-gray-100">{agent}</div>
-          <div className="mt-2 text-[11px] uppercase tracking-wide text-gray-400">Prompt</div>
-          <p className="mt-1 text-gray-200 text-xs leading-relaxed whitespace-pre-wrap break-words">
-            {summarizePrompt(task)}
-          </p>
-        </section>
-
-        <section className={`rounded border p-3 ${visual?.borderClass ?? 'border-gray-700'} bg-gray-800/70`}>
+        <section className={`rounded border p-3 ${statusBorder} bg-gray-800/70`}>
           <div className="text-[11px] uppercase tracking-wide text-gray-400">Status</div>
-          <div className={`mt-1 text-xs ${visual?.textClass ?? 'text-gray-300'}`}>
-            {workflow?.status?.replaceAll('_', ' ') ?? 'unknown'}
+          <div className={`mt-1 inline-flex items-center gap-2 text-xs ${statusText}`}>
+            {taskColors && (
+              <span className={`h-2 w-2 rounded-full ${statusDot} ${task?.status === 'running' ? 'animate-pulse' : ''}`} />
+            )}
+            {formatStatus(task?.status ?? workflow?.status)}
           </div>
           {task?.execution.error && (
             <p className="mt-2 text-xs text-red-300 break-words">{task.execution.error}</p>
+          )}
+        </section>
+
+        {task && !task.config.isMergeNode && onEditPool && (
+          <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+            <label className="flex items-center justify-between gap-3">
+              <span className="text-xs uppercase tracking-wide text-gray-400">Executor Pool</span>
+              <select
+                value={task.config.poolId ?? ''}
+                onChange={(event) => {
+                  if (event.target.value) onEditPool(task.id, event.target.value);
+                }}
+                disabled={isTaskBusy || poolOptions.length === 0}
+                className="min-w-0 max-w-[190px] rounded border border-gray-600 bg-gray-700 px-2 py-1 text-xs text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                data-testid="executor-pool-select"
+              >
+                {!task.config.poolId && <option value="">No pool</option>}
+                {poolOptions.map((poolId) => (
+                  <option key={poolId} value={poolId}>{poolId}</option>
+                ))}
+              </select>
+            </label>
+          </section>
+        )}
+
+        {task?.config.prompt && onEditAgent && (
+          <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+            <label className="flex items-center justify-between gap-3">
+              <span className="text-xs uppercase tracking-wide text-gray-400">AI Agent</span>
+              <select
+                value={currentAgent}
+                onChange={(event) => onEditAgent(task.id, event.target.value)}
+                disabled={isTaskBusy || agentOptions.length === 0}
+                className="min-w-0 max-w-[190px] rounded border border-gray-600 bg-gray-700 px-2 py-1 text-xs text-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+                data-testid="execution-agent-select"
+              >
+                {agentOptions.map((agentName) => (
+                  <option key={agentName} value={agentName}>{capitalize(agentName)}</option>
+                ))}
+              </select>
+            </label>
+          </section>
+        )}
+
+        <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+          <div className="text-[11px] uppercase tracking-wide text-gray-400">
+            {task?.config.prompt ? 'Prompt' : task?.config.command ? 'Command' : 'Prompt'}
+          </div>
+          {isEditingPrompt && task?.config.prompt !== undefined ? (
+            <div className="mt-2 space-y-2">
+              <textarea
+                value={editPromptValue}
+                onChange={(event) => setEditPromptValue(event.target.value)}
+                rows={5}
+                className="w-full resize-y rounded border border-blue-500 bg-gray-950 p-2 text-xs text-gray-100 focus:outline-none"
+                data-testid="edit-prompt-input"
+              />
+              <div className="flex gap-2">
+                <button onClick={savePrompt} className="flex-1 rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500">
+                  Save & Re-run
+                </button>
+                <button onClick={() => setIsEditingPrompt(false)} className="flex-1 rounded bg-gray-700 px-2 py-1 text-xs text-gray-100 hover:bg-gray-600">
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : isEditingCommand && task?.config.command !== undefined ? (
+            <div className="mt-2 space-y-2">
+              <textarea
+                value={editCommandValue}
+                onChange={(event) => setEditCommandValue(event.target.value)}
+                rows={4}
+                className="w-full resize-y rounded border border-blue-500 bg-gray-950 p-2 font-mono text-xs text-green-300 focus:outline-none"
+                data-testid="edit-command-input"
+              />
+              <div className="flex gap-2">
+                <button onClick={saveCommand} className="flex-1 rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500">
+                  Save & Re-run
+                </button>
+                <button onClick={() => setIsEditingCommand(false)} className="flex-1 rounded bg-gray-700 px-2 py-1 text-xs text-gray-100 hover:bg-gray-600">
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div
+              className={`mt-2 rounded border p-2 text-xs leading-relaxed ${
+                canEditPrompt || canEditCommand
+                  ? 'cursor-pointer border-gray-600 bg-gray-950 hover:border-blue-500'
+                  : 'cursor-text border-gray-700 bg-gray-950'
+              }`}
+              onDoubleClick={() => {
+                if (task?.config.prompt !== undefined && canEditPrompt) {
+                  setEditPromptValue(task.config.prompt);
+                  setIsEditingPrompt(true);
+                } else if (task?.config.command !== undefined && canEditCommand) {
+                  setEditCommandValue(task.config.command);
+                  setIsEditingCommand(true);
+                }
+              }}
+              data-testid="prompt-command-display"
+            >
+              {task?.config.prompt ? (
+                <p className="whitespace-pre-wrap break-words text-gray-200">{task.config.prompt}</p>
+              ) : task?.config.command ? (
+                <code className="whitespace-pre-wrap break-words font-mono text-green-300">{task.config.command}</code>
+              ) : (
+                <p className="text-gray-400">No prompt or command available.</p>
+              )}
+            </div>
           )}
         </section>
 
@@ -105,7 +279,7 @@ export function WorkflowInspector({
               <div>target branch: {workflow?.featureBranch ?? task?.config.featureBranch ?? 'n/a'}</div>
               <div>base branch: {workflow?.baseBranch ?? 'n/a'}</div>
               <div>heartbeat: {String(task?.execution.lastHeartbeatAt ?? 'n/a')}</div>
-              <div>executor: {task?.config.executorType ?? 'n/a'}</div>
+              <div>pool id: {task?.config.poolId ?? 'n/a'}</div>
             </div>
           )}
         </section>

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -62,6 +62,7 @@ export interface TaskConfig {
   readonly requiresManualApproval?: boolean;
   readonly repoUrl?: string;
   readonly featureBranch?: string;
+  readonly poolId?: string;
   readonly runnerKind?: string;
   readonly autoFix?: boolean;
   readonly poolMemberId?: string;

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -3572,6 +3572,89 @@ describe('Orchestrator', () => {
       expect(task?.config.poolMemberId).toBeUndefined();
     });
 
+    it('edits poolId and clears legacy runner placement fields', () => {
+      orchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        maxConcurrency: 3,
+        logger: consoleLogger,
+        availablePoolIds: ['mixed-local-ssh', 'pnpm-ssh'],
+      });
+      orchestrator.loadPlan({
+        name: 'edit-pool',
+        tasks: [{ id: 't1', description: 'Task 1', command: 'echo hello' }],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 't1', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
+      );
+      persistence.updateTask('t1', { config: { runnerKind: 'ssh', poolMemberId: 'remote-a' } });
+
+      orchestrator.editTaskPool('t1', 'mixed-local-ssh');
+
+      const task = orchestrator.getTask('t1');
+      expect(task?.config.poolId).toBe('mixed-local-ssh');
+      expect(task?.config.runnerKind).toBeUndefined();
+      expect(task?.config.poolMemberId).toBeUndefined();
+      expect(persistence.getTaskEntry('t1')?.task.config.poolId).toBe('mixed-local-ssh');
+    });
+
+    it('rejects unknown poolId edits', () => {
+      orchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        maxConcurrency: 3,
+        logger: consoleLogger,
+        availablePoolIds: ['mixed-local-ssh'],
+      });
+      orchestrator.loadPlan({
+        name: 'edit-pool-unknown',
+        tasks: [{ id: 't1', description: 'Task 1', command: 'echo hello' }],
+      });
+
+      expect(() => orchestrator.editTaskPool('t1', 'missing-pool')).toThrow('pool is not defined');
+    });
+
+    it('rejects pool edits for merge nodes', () => {
+      orchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        maxConcurrency: 3,
+        logger: consoleLogger,
+        availablePoolIds: ['mixed-local-ssh'],
+      });
+      orchestrator.loadPlan({
+        name: 'edit-pool-merge',
+        tasks: [{ id: 't1', description: 'Task 1', command: 'echo hello' }],
+      });
+      const mergeTask = orchestrator.getAllTasks().find((candidate) => candidate.config.isMergeNode)!;
+
+      expect(() => orchestrator.editTaskPool(mergeTask.id, 'mixed-local-ssh')).toThrow('Cannot change executor pool');
+    });
+
+    it('cancels active work before recreating for a pool edit', () => {
+      orchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        maxConcurrency: 3,
+        logger: consoleLogger,
+        availablePoolIds: ['mixed-local-ssh'],
+      });
+      orchestrator.loadPlan({
+        name: 'edit-pool-active',
+        tasks: [{ id: 't1', description: 'Task 1', command: 'echo hello' }],
+      });
+      orchestrator.startExecution();
+      const before = orchestrator.getTask('t1')!.execution.generation ?? 0;
+
+      orchestrator.editTaskPool('t1', 'mixed-local-ssh');
+
+      const task = orchestrator.getTask('t1')!;
+      expect(task.status).toBe('running');
+      expect(task.config.poolId).toBe('mixed-local-ssh');
+      expect(task.execution.generation).toBeGreaterThan(before);
+    });
+
     it('switching worktree → ssh (host change) is RECREATE-class — clears branch/commit/workspacePath', () => {
       orchestrator.loadPlan({
         name: 'edit-type-step6-worktree-to-ssh',

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -221,6 +221,16 @@ export class CommandService {
     );
   }
 
+    async editTaskPool(
+    envelope: CommandEnvelope<{ taskId: string; poolId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'EDIT_TASK_POOL_FAILED',
+      () => this.orchestrator.editTaskPool(envelope.payload.taskId, envelope.payload.poolId),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
     async editTaskAgent(
     envelope: CommandEnvelope<{ taskId: string; agentName: string }>,
   ): Promise<CommandResult<TaskState[]>> {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2713,6 +2713,38 @@ export class Orchestrator {
     return hostChanged ? this.recreateTask(taskId) : this.retryTask(taskId);
   }
 
+    editTaskPool(taskId: string, poolId: string): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    if (task.config.isMergeNode) throw new Error(`Cannot change executor pool of merge node ${taskId}`);
+    if (!poolId || !this.availablePoolIds.has(poolId)) {
+      throw new Error(
+        `Cannot switch task "${taskId}" to poolId="${poolId}": pool is not defined in executionPools. ` +
+        `Available: [${[...this.availablePoolIds].join(', ')}]`,
+      );
+    }
+
+    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+      this.cancelTask(taskId);
+    }
+
+    const poolChanges: TaskStateChanges = {
+      config: {
+        poolId,
+        runnerKind: undefined,
+        poolMemberId: undefined,
+      },
+    };
+    const poolBefore = this.stateGetTask(taskId)!;
+    const poolUpdated = this.writeAndSync(taskId, poolChanges);
+    const poolDelta: TaskDelta = this.buildUpdateDelta(poolBefore, poolUpdated, poolChanges);
+    this.persistence.logEvent?.(taskId, 'task.updated', poolChanges);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, poolDelta);
+
+    return this.recreateTask(taskId);
+  }
+
     editTaskAgent(taskId: string, agentName: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);


### PR DESCRIPTION
## Summary

Add real executor-pool controls to the workflow inspector and wire them through IPC, command service, and orchestrator mutation handling.

- Show the selected task title and status at the top of the inspector.
- Add editable agent, prompt/command, and executor pool controls.
- Persist pool changes by clearing legacy runner placement fields, validating the pool id, and recreating the task.
- Honor pool member selection strategy when assigning pooled execution.

## Architecture

### Before

```mermaid
flowchart LR
  UI["WorkflowInspector"] --> Main["Electron main"]
  Main --> CommandService
  CommandService --> Orchestrator
  UI -. displayed .-> LegacyExecutor["executor metadata"]
```

### After

```mermaid
flowchart LR
  UI["WorkflowInspector"] --> App["App handlers"]
  App --> IPC["invoker:edit-task-pool"]
  IPC --> CommandService
  CommandService --> Orchestrator
  Orchestrator --> Config["task config poolId"]
  Orchestrator --> Recreate["recreateTask"]
  Runner["TaskRunner"] --> PoolStrategy["pool selectionStrategy"]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-inspector.test.tsx`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts -t "edit.*pool|pool edits|poolId"`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/ui build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0e52c45f`
- Post-revert steps: Restart the Electron app if it is running.
- Data migration? No
