### PR TITLE
Fix workflow status freshness from task deltas

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@invoker/contracts": "workspace:*",
+    "@invoker/workflow-graph": "workspace:*",
     "@xyflow/react": "^12.0.0",
     "elkjs": "^0.10.2",
     "js-yaml": "^4.1.1",

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -10,16 +10,22 @@ import { makeUITask } from './helpers/mock-invoker.js';
 
 describe('useTasks', () => {
   let workflowsChangedHandler: ((wfList: unknown[]) => void) | undefined;
+  let taskDeltaHandler: ((delta: unknown) => void) | undefined;
 
   beforeEach(() => {
+    vi.useRealTimers();
     workflowsChangedHandler = undefined;
+    taskDeltaHandler = undefined;
     (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
       tasks: [],
       workflows: [],
     };
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
       getTasks: vi.fn().mockResolvedValue({ tasks: [], workflows: [] }),
-      onTaskDelta: vi.fn(() => () => {}),
+      onTaskDelta: vi.fn((cb: (delta: unknown) => void) => {
+        taskDeltaHandler = cb;
+        return () => {};
+      }),
       onWorkflowsChanged: vi.fn((cb: (wfList: unknown[]) => void) => {
         workflowsChangedHandler = cb;
         return () => {};
@@ -28,6 +34,7 @@ describe('useTasks', () => {
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     delete (window as unknown as { invoker?: unknown }).invoker;
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
   });
@@ -153,6 +160,127 @@ describe('useTasks', () => {
     await waitFor(() => {
       expect(getTasks).toHaveBeenCalled();
       expect(getTasks).toHaveBeenLastCalledWith(true);
+    });
+  });
+
+  it('recomputes workflow status from task deltas after failed metadata becomes pending or running', async () => {
+    const taskA = makeUITask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'failed' });
+    const taskB = makeUITask({ id: 'wf-1/task-b', workflowId: 'wf-1', status: 'completed' });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [taskA, taskB],
+      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed' }],
+    };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks: vi.fn().mockResolvedValue({
+        tasks: [taskA, taskB],
+        workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'failed' }],
+      }),
+      onTaskDelta: vi.fn((cb: (delta: unknown) => void) => {
+        taskDeltaHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn((cb: (wfList: unknown[]) => void) => {
+        workflowsChangedHandler = cb;
+        return () => {};
+      }),
+    };
+
+    const { result } = renderHook(() => useTasks());
+    expect(result.current.workflows.get('wf-1')?.status).toBe('failed');
+
+    await act(async () => {
+      taskDeltaHandler!({
+        type: 'updated',
+        taskId: 'wf-1/task-a',
+        changes: { status: 'pending' },
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
+      });
+      taskDeltaHandler!({
+        type: 'updated',
+        taskId: 'wf-1/task-b',
+        changes: { status: 'pending' },
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 110));
+    });
+
+    await waitFor(() => {
+      expect(result.current.workflows.get('wf-1')?.status).toBe('pending');
+    });
+
+    await act(async () => {
+      taskDeltaHandler!({
+        type: 'updated',
+        taskId: 'wf-1/task-a',
+        changes: { status: 'running' },
+        taskStateVersion: 3,
+        previousTaskStateVersion: 2,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 110));
+    });
+
+    await waitFor(() => {
+      expect(result.current.workflows.get('wf-1')?.status).toBe('running');
+    });
+    expect(result.current.workflows.get('wf-1')?.name).toBe('Workflow 1');
+  });
+
+  it('keeps workflow failed when pending tasks are blocked by a failed dependency path', async () => {
+    const failedTask = makeUITask({
+      id: 'wf-1/add-regression-coverage',
+      workflowId: 'wf-1',
+      status: 'running',
+    });
+    const downstreamTask = makeUITask({
+      id: 'wf-1/run-focused-tests',
+      workflowId: 'wf-1',
+      status: 'pending',
+      dependencies: ['wf-1/add-regression-coverage'],
+    });
+    const mergeTask = makeUITask({
+      id: '__merge__wf-1',
+      workflowId: 'wf-1',
+      status: 'pending',
+      isMergeNode: true,
+      dependencies: ['wf-1/run-focused-tests'],
+    });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [failedTask, downstreamTask, mergeTask],
+      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'running' }],
+    };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks: vi.fn().mockResolvedValue({
+        tasks: [failedTask, downstreamTask, mergeTask],
+        workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'running' }],
+      }),
+      onTaskDelta: vi.fn((cb: (delta: unknown) => void) => {
+        taskDeltaHandler = cb;
+        return () => {};
+      }),
+      onWorkflowsChanged: vi.fn((cb: (wfList: unknown[]) => void) => {
+        workflowsChangedHandler = cb;
+        return () => {};
+      }),
+    };
+
+    const { result } = renderHook(() => useTasks());
+    expect(result.current.workflows.get('wf-1')?.status).toBe('running');
+
+    await act(async () => {
+      taskDeltaHandler!({
+        type: 'updated',
+        taskId: 'wf-1/add-regression-coverage',
+        changes: { status: 'failed' },
+        taskStateVersion: 2,
+        previousTaskStateVersion: 1,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 110));
+    });
+
+    await waitFor(() => {
+      expect(result.current.workflows.get('wf-1')?.status).toBe('failed');
     });
   });
 });

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -7,6 +7,7 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
+import { computeWorkflowRollupFromSummaries } from '@invoker/workflow-graph';
 import type { TaskState, WorkflowMeta } from '../types.js';
 import { applyDelta } from '../lib/delta.js';
 import { normalizeWorkflowStatus } from '../lib/workflow-status.js';
@@ -14,6 +15,55 @@ import {
   createTaskDeltaPipeline,
   type TaskDeltaPipeline,
 } from '../lib/task-delta-pipeline.js';
+
+function deriveWorkflowStatusFromTasks(tasks: TaskState[]): WorkflowMeta['status'] {
+  return computeWorkflowRollupFromSummaries(
+    tasks.map((task) => ({
+      id: task.id,
+      description: task.description,
+      status: task.status,
+      dependencies: task.dependencies,
+      execution: {
+        error: task.execution.error,
+        protocolErrorCode: task.execution.protocolErrorCode,
+        protocolErrorMessage: task.execution.protocolErrorMessage,
+        pendingFixError: task.execution.pendingFixError,
+        exitCode: task.execution.exitCode,
+        completedAt: task.execution.completedAt,
+        agentSessionId: task.execution.agentSessionId,
+        agentName: task.execution.agentName,
+        reviewUrl: task.execution.reviewUrl,
+        inputPrompt: task.execution.inputPrompt,
+        isFixingWithAI: task.execution.isFixingWithAI,
+      },
+    })),
+  ).status;
+}
+
+function deriveWorkflowStatuses(
+  workflowMap: Map<string, WorkflowMeta>,
+  taskMap: Map<string, TaskState>,
+): Map<string, WorkflowMeta> {
+  const tasksByWorkflow = new Map<string, TaskState[]>();
+  for (const task of taskMap.values()) {
+    const workflowId = task.config.workflowId;
+    if (!workflowId) continue;
+    const workflowTasks = tasksByWorkflow.get(workflowId) ?? [];
+    workflowTasks.push(task);
+    tasksByWorkflow.set(workflowId, workflowTasks);
+  }
+
+  let changed = false;
+  const next = new Map<string, WorkflowMeta>();
+  for (const [workflowId, workflow] of workflowMap) {
+    const status = deriveWorkflowStatusFromTasks(tasksByWorkflow.get(workflowId) ?? []);
+    if (workflow.status !== status) {
+      changed = true;
+    }
+    next.set(workflowId, { ...workflow, status });
+  }
+  return changed ? next : workflowMap;
+}
 
 export interface UseTasksResult {
   tasks: Map<string, TaskState>;
@@ -45,6 +95,9 @@ export function useTasks(): UseTasksResult {
     }
     return next;
   });
+  useEffect(() => {
+    setWorkflows((prev) => deriveWorkflowStatuses(prev, tasks));
+  }, [tasks]);
   const workflowsRef = useRef(workflows);
   workflowsRef.current = workflows;
   const deltaPipelineRef = useRef<TaskDeltaPipeline | null>(null);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -407,6 +407,9 @@ importers:
       '@invoker/contracts':
         specifier: workspace:*
         version: link:../contracts
+      '@invoker/workflow-graph':
+        specifier: workspace:*
+        version: link:../workflow-graph
       '@xyflow/react':
         specifier: ^12.0.0
         version: 12.10.1(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)


### PR DESCRIPTION
## Summary

Derive renderer workflow status from the current task map so batched task deltas cannot leave workflow metadata visually stale. This preserves workflow metadata fields while replacing the status with the task rollup after resets or new running work.

This now uses the shared graph-aware `computeWorkflowRollupFromSummaries` logic instead of a renderer-only count rollup, so a failed task with only dependency-blocked pending descendants remains `failed` instead of being shown as `running`.

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/use-tasks.test.tsx`
- [x] `pnpm --filter @invoker/workflow-graph exec vitest run src/__tests__/workflow-rollup.test.ts`
- [x] `pnpm --filter @invoker/ui build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 3c4a9e0b`
- Post-revert steps: None
- Data migration? No
