### PR TITLE
Remove workflow drain concurrency cap

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -687,7 +687,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['completed']).length === 1);
   });
 
-  it('bounds concurrent workflow drains across workflows during resume and burst submission', async () => {
+  it('starts all queued workflow drains across workflows during resume', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     for (let index = 1; index <= 4; index += 1) {
@@ -718,27 +718,64 @@ describe('PersistedWorkflowMutationCoordinator', () => {
         await gate.promise;
         active -= 1;
       },
-      { maxConcurrentWorkflowDrains: 2 },
     );
 
     const resumePromise = coordinator.resumePending();
-    await waitFor(() => started.length === 2);
-    expect(maxActive).toBe(2);
+    await waitFor(() => started.length === 4);
+    expect(maxActive).toBe(4);
 
     gates.get('job-1')?.resolve();
-    await waitFor(() => started.length === 3);
-    expect(maxActive).toBe(2);
-
     gates.get('job-2')?.resolve();
-    await waitFor(() => started.length === 4);
-    expect(maxActive).toBe(2);
-
     gates.get('job-3')?.resolve();
     gates.get('job-4')?.resolve();
     await resumePromise;
 
     expect(adapter.listWorkflowMutationIntents(undefined, ['completed'])).toHaveLength(4);
-    expect(maxActive).toBe(2);
+    expect(maxActive).toBe(4);
+  });
+
+  it('does not run two intents for the same workflow concurrently', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const firstGate = deferred();
+    const order: string[] = [];
+    let active = 0;
+    let maxActive = 0;
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (_channel, args) => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        order.push(String(args[0]));
+        if (args[0] === 'first') {
+          await firstGate.promise;
+        }
+        active -= 1;
+      },
+    );
+
+    const first = coordinator.enqueue<void>('wf-1', 'normal', 'mut', ['first']);
+    const second = coordinator.enqueue<void>('wf-1', 'normal', 'mut', ['second']);
+
+    await waitFor(() => order.length === 1);
+    expect(order).toEqual(['first']);
+    expect(maxActive).toBe(1);
+
+    firstGate.resolve();
+    await first;
+    await second;
+
+    expect(order).toEqual(['first', 'second']);
+    expect(maxActive).toBe(1);
   });
 
   it('invalidates an older running workflow intent when internal delete-workflow is enqueued', async () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -226,24 +226,6 @@ let hourlyBackupInterval: ReturnType<typeof setInterval> | null = null;
 let writerLock: DbWriterLockResult | null = null;
 const workflowMutationOwnerId = `owner-${process.pid}-${Date.now()}`;
 const appProcessStartedAt = Date.now();
-const DEFAULT_MAX_CONCURRENT_WORKFLOW_DRAINS = 8;
-
-function resolveMaxConcurrentWorkflowDrains(): number {
-  const raw = process.env.INVOKER_MAX_CONCURRENT_WORKFLOW_DRAINS;
-  if (!raw) {
-    return DEFAULT_MAX_CONCURRENT_WORKFLOW_DRAINS;
-  }
-  const parsed = Number(raw);
-  if (Number.isInteger(parsed) && parsed > 0) {
-    return parsed;
-  }
-  process.stderr.write(
-    `[workflow-mutation-coordinator] ignoring invalid INVOKER_MAX_CONCURRENT_WORKFLOW_DRAINS="${raw}", using default ${DEFAULT_MAX_CONCURRENT_WORKFLOW_DRAINS}\n`,
-  );
-  return DEFAULT_MAX_CONCURRENT_WORKFLOW_DRAINS;
-}
-
-const maxConcurrentWorkflowDrains = resolveMaxConcurrentWorkflowDrains();
 
 interface GuiMutationPayload {
   channel: string;
@@ -988,7 +970,7 @@ if (isHeadless) {
                 activeMutationContext = undefined;
               }
             },
-            { maxConcurrentWorkflowDrains, logger },
+            { logger },
           );
         }
 
@@ -2581,7 +2563,7 @@ if (isHeadless) {
             activeMutationContext = undefined;
           }
         },
-        { maxConcurrentWorkflowDrains, logger },
+        { logger },
       );
     } else {
       logger.info('Launched in follower mode; mutation execution is delegated to the current owner', {

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -55,18 +55,15 @@ export class PersistedWorkflowMutationCoordinator {
     this.leaseHeartbeatMs,
     envMs('INVOKER_MUTATION_LEASE_RENEW_MIN_EXPIRY_LEAD_MS', 12_000),
   );
-  private readonly maxConcurrentWorkflowDrains: number;
   private readonly enableTraceLogs: boolean;
-  private activeWorkflowDrains = 0;
   private deferredDrainTimer: NodeJS.Timeout | null = null;
 
   constructor(
     private readonly persistence: SQLiteAdapter,
     private readonly ownerId: string,
     private readonly dispatch: (channel: string, args: unknown[], context: WorkflowMutationContext) => Promise<unknown>,
-    private readonly options?: { maxConcurrentWorkflowDrains?: number; logger?: Logger },
+    private readonly options?: { logger?: Logger },
   ) {
-    this.maxConcurrentWorkflowDrains = Math.max(1, options?.maxConcurrentWorkflowDrains ?? 1);
     this.enableTraceLogs = process.env.INVOKER_TRACE_MUTATION_QUEUE === '1';
   }
 
@@ -82,7 +79,7 @@ export class PersistedWorkflowMutationCoordinator {
       .mark('PersistedWorkflowMutationCoordinator.enqueue', 'queued', { priority });
     this.invalidateSupersededRunningIntent(workflowId, intentId, channel, args);
     this.trace(
-      `enqueue intent=${intentId} workflow=${workflowId} priority=${priority} channel=${channel} activeDrains=${this.activeWorkflowDrains} pendingWorkflows=${this.pendingDrainWorkflows.size}`,
+      `enqueue intent=${intentId} workflow=${workflowId} priority=${priority} channel=${channel} pendingWorkflows=${this.pendingDrainWorkflows.size}`,
     );
     const result = new Promise<T>((resolve, reject) => {
       this.inFlightPromises.set(intentId, { resolve: resolve as (value: unknown) => void, reject });
@@ -107,7 +104,7 @@ export class PersistedWorkflowMutationCoordinator {
       });
     this.invalidateSupersededRunningIntent(workflowId, intentId, channel, args);
     this.trace(
-      `submit intent=${intentId} workflow=${workflowId} priority=${priority} channel=${channel} defer=${Boolean(options?.deferDrain)} activeDrains=${this.activeWorkflowDrains} pendingWorkflows=${this.pendingDrainWorkflows.size}`,
+      `submit intent=${intentId} workflow=${workflowId} priority=${priority} channel=${channel} defer=${Boolean(options?.deferDrain)} pendingWorkflows=${this.pendingDrainWorkflows.size}`,
     );
     if (options?.deferDrain) {
       this.scheduleWorkflowDrainDeferred(workflowId);
@@ -162,7 +159,7 @@ export class PersistedWorkflowMutationCoordinator {
   }
 
   private async processPendingDrains(): Promise<void> {
-    while (this.activeWorkflowDrains < this.maxConcurrentWorkflowDrains) {
+    while (true) {
       const nextWorkflowId = Array.from(this.pendingDrainWorkflows).find(
         (workflowId) => !this.drainingWorkflows.has(workflowId),
       );
@@ -170,14 +167,12 @@ export class PersistedWorkflowMutationCoordinator {
         return;
       }
       this.pendingDrainWorkflows.delete(nextWorkflowId);
-      this.activeWorkflowDrains += 1;
       void this.runWorkflowDrain(nextWorkflowId)
         .catch((error) => {
           const message = error instanceof Error ? error.stack ?? error.message : String(error);
           process.stderr.write(`[workflow-mutation-coordinator] drain failed for ${nextWorkflowId}: ${message}\n`);
         })
         .finally(() => {
-          this.activeWorkflowDrains = Math.max(0, this.activeWorkflowDrains - 1);
           void this.processPendingDrains();
         });
     }


### PR DESCRIPTION
## Summary

Remove the global workflow-drain concurrency cap and its environment-variable wiring. The coordinator now starts every pending workflow drain that is not already draining, while retaining one active drain per workflow and serial intent execution within each workflow.

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/persisted-workflow-mutation-coordinator.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-mutation-startup.test.ts`
- [x] `bash scripts/bench-rebase-recreate-all.sh --dry-run --workflow "Cost Query Attempt Attribution via Persisted Attempts"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 764dc3bb`
- Post-revert steps: Restore cap-related configuration if callers still depend on it
- Data migration? No
