### PR TITLE
Log executor routing audit events

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -7918,6 +7918,195 @@ console.log(JSON.stringify(out));
   });
 
   describe('metadata persistence hardening', () => {
+    function createCompletingExecutor(type: string, handle: Record<string, unknown>) {
+      return {
+        type,
+        start: vi.fn(async (request: any) => ({
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          ...handle,
+        })),
+        onComplete: vi.fn((_handle, cb) => {
+          setTimeout(() => cb({
+            requestId: 'req-1',
+            actionId: (_handle as any).taskId,
+            status: 'completed',
+            outputs: { exitCode: 0 },
+          }), 0);
+        }),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+        destroyAll: vi.fn(),
+      };
+    }
+
+    it('logs pool-routed SSH executor selection with remote target display fields', async () => {
+      const sshExecutor = createCompletingExecutor('ssh', {
+        workspacePath: '/remote/worktrees/task-1',
+        branch: 'experiment/task-1',
+      });
+      const logEvent = vi.fn();
+      const task = makeTask({
+        id: 'task-1',
+        status: 'pending',
+        config: { command: 'pnpm test', runnerKind: 'ssh', poolId: 'ci-pool' },
+        execution: { selectedAttemptId: 'attempt-1' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse: vi.fn() } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent } as any,
+        executorRegistry: {
+          getDefault: () => sshExecutor,
+          get: (type: string) => type === 'ssh' ? sshExecutor : null,
+          getAll: () => [sshExecutor],
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          'ci-pool': {
+            selectionStrategy: 'leastLoaded',
+            members: [{ type: 'ssh', id: 'remote-a' }],
+          },
+        }),
+        remoteTargetsProvider: () => ({
+          'remote-a': {
+            host: 'ci.example.com',
+            user: 'runner',
+            sshKeyPath: '/secret/key',
+            port: 2222,
+          },
+        }),
+      });
+
+      await runner.executeTask(task);
+
+      expect(logEvent).toHaveBeenCalledWith('task-1', 'task.executor.selected', {
+        runnerKind: 'ssh',
+        reason: {
+          type: 'poolId',
+          poolId: 'ci-pool',
+          selectionStrategy: 'leastLoaded',
+          poolMemberId: 'remote-a',
+        },
+        attemptId: 'attempt-1',
+        workspacePath: '/remote/worktrees/task-1',
+        branch: 'experiment/task-1',
+        poolMemberId: 'remote-a',
+        remoteHost: 'ci.example.com',
+        remoteUser: 'runner',
+        port: 2222,
+      });
+      const selectedPayload = logEvent.mock.calls.find((call) => call[1] === 'task.executor.selected')?.[2];
+      expect(JSON.stringify(selectedPayload)).not.toContain('sshKeyPath');
+      expect(JSON.stringify(selectedPayload)).not.toContain('/secret/key');
+    });
+
+    it('logs explicit SSH executor selection as explicitPoolMemberId', async () => {
+      const sshExecutor = createCompletingExecutor('ssh', {
+        workspacePath: '/remote/worktrees/task-explicit',
+        branch: 'experiment/task-explicit',
+      });
+      const logEvent = vi.fn();
+      const task = makeTask({
+        id: 'task-explicit',
+        status: 'pending',
+        config: { command: 'echo hi', runnerKind: 'ssh', poolMemberId: 'remote-b' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse: vi.fn() } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent } as any,
+        executorRegistry: {
+          getDefault: () => sshExecutor,
+          get: (type: string) => type === 'ssh' ? sshExecutor : null,
+          getAll: () => [sshExecutor],
+        } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'remote-b': { host: 'dev.example.com', user: 'dev', sshKeyPath: '/secret/dev-key' },
+        }),
+      });
+
+      await runner.executeTask(task);
+
+      expect(logEvent).toHaveBeenCalledWith('task-explicit', 'task.executor.selected', expect.objectContaining({
+        runnerKind: 'ssh',
+        reason: { type: 'explicitPoolMemberId' },
+        poolMemberId: 'remote-b',
+        remoteHost: 'dev.example.com',
+        remoteUser: 'dev',
+      }));
+    });
+
+    it('logs configured worktree executor selection reason', async () => {
+      const worktreeExecutor = createCompletingExecutor('worktree', {
+        workspacePath: '/tmp/worktree/task-local',
+        branch: 'experiment/task-local',
+      });
+      const logEvent = vi.fn();
+      const task = makeTask({
+        id: 'task-local',
+        status: 'pending',
+        config: { command: 'echo local', runnerKind: 'worktree' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse: vi.fn() } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent } as any,
+        executorRegistry: {
+          getDefault: () => worktreeExecutor,
+          get: (type: string) => type === 'worktree' ? worktreeExecutor : null,
+          getAll: () => [worktreeExecutor],
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await runner.executeTask(task);
+
+      expect(logEvent).toHaveBeenCalledWith('task-local', 'task.executor.selected', expect.objectContaining({
+        runnerKind: 'worktree',
+        reason: { type: 'configuredWorktree' },
+        workspacePath: '/tmp/worktree/task-local',
+        branch: 'experiment/task-local',
+      }));
+    });
+
+    it('logs SSH pool fallback to worktree when no pool member or remote target exists', async () => {
+      const worktreeExecutor = createCompletingExecutor('worktree', {
+        workspacePath: '/tmp/worktree/task-fallback',
+        branch: 'experiment/task-fallback',
+      });
+      const logEvent = vi.fn();
+      const task = makeTask({
+        id: 'task-fallback',
+        status: 'pending',
+        config: { command: 'echo fallback', runnerKind: 'ssh', poolId: 'missing-pool' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse: vi.fn() } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent } as any,
+        executorRegistry: {
+          getDefault: () => worktreeExecutor,
+          get: (type: string) => type === 'worktree' ? worktreeExecutor : null,
+          getAll: () => [worktreeExecutor],
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({}),
+        remoteTargetsProvider: () => ({}),
+      });
+
+      await runner.executeTask(task);
+
+      expect(logEvent).toHaveBeenCalledWith('task-fallback', 'task.executor.selected', expect.objectContaining({
+        runnerKind: 'worktree',
+        reason: { type: 'sshPoolFallbackToWorktree', poolId: 'missing-pool' },
+        workspacePath: '/tmp/worktree/task-fallback',
+        branch: 'experiment/task-fallback',
+      }));
+    });
+
     it('fails fast when executor returns handle without workspacePath', async () => {
       const badExecutor = {
         type: 'bad-executor',

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -92,6 +92,18 @@ type PoolSelection = {
   poolId: string;
   member: ExecutionPoolMember;
   memberKey: string;
+  selectionStrategy: 'roundRobin' | 'leastLoaded';
+};
+
+type RemoteTargetDisplay = {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+  managedWorkspaces?: boolean;
+  remoteInvokerHome?: string;
+  provisionCommand?: string;
+  remoteHeartbeatIntervalSeconds?: number;
 };
 
 function nextLeaseExpiry(from: Date): Date {
@@ -175,7 +187,7 @@ export class TaskRunner {
   /** @internal */ mergeGateProvider?: MergeGateProvider;
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
   private activePrPollers = new Map<string, ReturnType<typeof setInterval>>();
-  private getRemoteTargets: () => Record<string, { host: string; user: string; sshKeyPath: string; port?: number; managedWorkspaces?: boolean; remoteInvokerHome?: string; provisionCommand?: string; remoteHeartbeatIntervalSeconds?: number }>;
+  private getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   private getExecutionPools: () => Record<string, ExecutionPoolConfig>;
   private dockerConfig: { imageName?: string; secretsFile?: string };
   private executionAgentRegistry?: AgentRegistry;
@@ -680,6 +692,14 @@ export class TaskRunner {
         );
       }
 
+      this.logExecutorSelected(
+        task,
+        executor,
+        handle,
+        attemptId,
+        this.pendingPoolSelections.get(task.id),
+      );
+
       const changes = {
         config: { runnerKind: executor.type as RunnerKind },
         execution: {
@@ -863,6 +883,80 @@ export class TaskRunner {
     return candidates[0]?.member;
   }
 
+  private logExecutorSelected(
+    task: TaskState,
+    executor: Executor,
+    handle: ExecutorHandle,
+    attemptId: string,
+    poolSelection: PoolSelection | undefined,
+  ): void {
+    const payload: Record<string, unknown> = {
+      runnerKind: executor.type,
+      reason: this.executorSelectionReason(task, executor, poolSelection),
+      attemptId,
+      workspacePath: handle.workspacePath,
+      branch: handle.branch ?? undefined,
+    };
+
+    if (executor.type === 'ssh') {
+      const targetId = this.selectedRemoteTargetId(task, poolSelection);
+      const target = targetId ? this.getRemoteTargets()[targetId] : undefined;
+      if (targetId) payload.poolMemberId = targetId;
+      if (target) {
+        payload.remoteHost = target.host;
+        payload.remoteUser = target.user;
+        payload.port = target.port;
+      }
+    }
+
+    this.persistence.logEvent?.(task.id, 'task.executor.selected', payload);
+  }
+
+  private executorSelectionReason(
+    task: TaskState,
+    executor: Executor,
+    poolSelection: PoolSelection | undefined,
+  ): Record<string, unknown> {
+    if (executor.type === 'ssh') {
+      if (poolSelection) {
+        return {
+          type: 'poolId',
+          poolId: poolSelection.poolId,
+          selectionStrategy: poolSelection.selectionStrategy,
+          poolMemberId: poolSelection.member.id,
+        };
+      }
+      if ((task.config as { poolMemberId?: string }).poolMemberId) {
+        return { type: 'explicitPoolMemberId' };
+      }
+      if (task.config.poolId) {
+        return { type: 'poolId', poolId: task.config.poolId };
+      }
+    }
+
+    if (executor.type === 'worktree') {
+      if (task.config.runnerKind === 'ssh' && task.config.poolId) {
+        return { type: 'sshPoolFallbackToWorktree', poolId: task.config.poolId };
+      }
+      if (task.config.runnerKind === 'worktree') {
+        return { type: 'configuredWorktree' };
+      }
+      return { type: 'defaultWorktree' };
+    }
+
+    if (executor.type === 'docker') {
+      return { type: 'dockerImage' };
+    }
+
+    return { type: 'configuredRunnerKind', runnerKind: executor.type };
+  }
+
+  private selectedRemoteTargetId(task: TaskState, poolSelection: PoolSelection | undefined): string | undefined {
+    if (poolSelection?.member.type === 'ssh') return poolSelection.member.id;
+    return (task.config as { poolMemberId?: string }).poolMemberId
+      ?? (task.config.poolId && this.getRemoteTargets()[task.config.poolId] ? task.config.poolId : undefined);
+  }
+
   selectExecutor(task: TaskState): Executor {
     let effectiveType = task.config.runnerKind ?? (task.config.isMergeNode ? 'merge' : undefined);
     let selectedPoolMemberId: string | undefined;
@@ -878,6 +972,7 @@ export class TaskRunner {
           poolId: task.config.poolId,
           member,
           memberKey: this.poolMemberKey(member),
+          selectionStrategy: pool.selectionStrategy ?? 'roundRobin',
         });
       }
     }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1265,8 +1265,9 @@ describe('Orchestrator', () => {
       });
 
       it('auto-routes matching command to configured poolId with route strategy', () => {
+        const persistence = new InMemoryPersistence();
         const routedOrchestrator = new Orchestrator({
-          persistence: new InMemoryPersistence(),
+          persistence,
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
@@ -1283,6 +1284,60 @@ describe('Orchestrator', () => {
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.runnerKind).toBe('ssh');
         expect(task!.config.poolId).toBe('ssh-light');
+        const routedEvent = persistence.events.find((event) =>
+          event.taskId.endsWith('/t1') && event.eventType === 'task.executor.routed'
+        );
+        expect(routedEvent?.payload).toEqual({
+          runnerKind: 'ssh',
+          poolId: 'ssh-light',
+          reason: { type: 'routingRule', regex: '\\bpnpm(?:\\s|$)', poolId: 'ssh-light' },
+        });
+      });
+
+      it('logs default worktree routing when no pool or docker rule applies', () => {
+        const persistence = new InMemoryPersistence();
+        const routedOrchestrator = new Orchestrator({
+          persistence,
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'default-worktree-routing-test',
+          tasks: [{ id: 't1', description: 'Local task', command: 'echo local' }],
+        });
+
+        const routedEvent = persistence.events.find((event) =>
+          event.taskId.endsWith('/t1') && event.eventType === 'task.executor.routed'
+        );
+        expect(routedEvent?.payload).toEqual({
+          runnerKind: 'worktree',
+          reason: { type: 'defaultWorktree' },
+        });
+      });
+
+      it('logs explicit pool routing when a task declares poolId', () => {
+        const persistence = new InMemoryPersistence();
+        const routedOrchestrator = new Orchestrator({
+          persistence,
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          availablePoolIds: ['ssh-light'],
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'explicit-pool-routing-test',
+          tasks: [{ id: 't1', description: 'Remote task', command: 'echo remote', poolId: 'ssh-light' }],
+        });
+
+        const routedEvent = persistence.events.find((event) =>
+          event.taskId.endsWith('/t1') && event.eventType === 'task.executor.routed'
+        );
+        expect(routedEvent?.payload).toEqual({
+          runnerKind: 'ssh',
+          poolId: 'ssh-light',
+          reason: { type: 'poolId', poolId: 'ssh-light' },
+        });
       });
 
       it('routes matching command without an explicit runner kind', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -541,14 +541,18 @@ function resolveExecutorRouting(
   planPoolId: string | undefined,
   rules: ExecutorRoutingRule[],
   availablePoolIds: Set<string>,
-): { poolId?: string } {
+): { poolId?: string; reason: ExecutorRoutingReason } {
   if (!command || rules.length === 0) {
     return {
       poolId: planPoolId,
+      reason: planPoolId ? { type: 'poolId', poolId: planPoolId } : { type: 'defaultWorktree' },
     };
   }
 
   let effectivePoolId = planPoolId;
+  let reason: ExecutorRoutingReason = planPoolId
+    ? { type: 'poolId', poolId: planPoolId }
+    : { type: 'defaultWorktree' };
 
   const routingRules = rules.filter((rule) => (rule.strategy ?? 'enforce') === 'route');
   const matchingRoutingRule = findMatchingExecutorRoutingRule(command, routingRules);
@@ -562,6 +566,14 @@ function resolveExecutorRouting(
       availablePoolIds,
     );
     effectivePoolId = routed?.poolId ?? effectivePoolId;
+    if (routed?.poolId) {
+      reason = {
+        type: 'routingRule',
+        poolId: routed.poolId,
+        ...(matchingRoutingRule.pattern !== undefined ? { pattern: matchingRoutingRule.pattern } : {}),
+        ...(matchingRoutingRule.regex !== undefined ? { regex: matchingRoutingRule.regex } : {}),
+      };
+    }
   }
 
   const enforcementRules = rules.filter((rule) => (rule.strategy ?? 'enforce') === 'enforce');
@@ -574,6 +586,25 @@ function resolveExecutorRouting(
 
   return {
     poolId: effectivePoolId,
+    reason,
+  };
+}
+
+type ExecutorRoutingReason =
+  | { type: 'dockerImage' }
+  | { type: 'poolId'; poolId: string }
+  | { type: 'routingRule'; poolId: string; pattern?: string; regex?: string }
+  | { type: 'defaultWorktree' };
+
+function buildExecutorRoutedPayload(
+  runnerKind: RunnerKind,
+  poolId: string | undefined,
+  reason: ExecutorRoutingReason,
+): Record<string, unknown> {
+  return {
+    runnerKind,
+    ...(poolId ? { poolId } : {}),
+    reason,
   };
 }
 
@@ -1253,6 +1284,7 @@ export class Orchestrator {
     }
 
     const validatedTasks: TaskState[] = [];
+    const resolvedRoutingByTaskId = new Map<string, ExecutorRoutingReason>();
     for (const taskDef of plan.tasks) {
       const resolvedRouting = resolveExecutorRouting(
         taskDef.id,
@@ -1264,6 +1296,10 @@ export class Orchestrator {
       const effectivePoolId = resolvedRouting.poolId;
 
       const scopedId = localToScoped.get(taskDef.id)!;
+      resolvedRoutingByTaskId.set(
+        scopedId,
+        taskDef.dockerImage ? { type: 'dockerImage' } : resolvedRouting.reason,
+      );
       const scopedDeps = (taskDef.dependencies ?? []).map((dep) => {
         const s = localToScoped.get(dep);
         if (!s) {
@@ -1361,10 +1397,17 @@ export class Orchestrator {
     const deltas: TaskDelta[] = [];
     for (const task of validatedTasks) {
       this.createAndSync(task);
+      this.persistence.logEvent?.(task.id, 'task.created');
+      this.persistence.logEvent?.(task.id, 'task.executor.routed', buildExecutorRoutedPayload(
+        task.config.runnerKind ?? 'worktree',
+        task.config.poolId,
+        task.config.dockerImage ? { type: 'dockerImage' } : resolvedRoutingByTaskId.get(task.id) ?? { type: 'defaultWorktree' },
+      ));
       deltas.push({ type: 'created', task });
     }
 
     this.createAndSync(mergeTask);
+    this.persistence.logEvent?.(mergeTask.id, 'task.created');
     deltas.push({ type: 'created', task: mergeTask });
 
     for (const delta of deltas) {
@@ -2734,7 +2777,7 @@ export class Orchestrator {
         poolId,
         runnerKind: undefined,
         poolMemberId: undefined,
-      },
+      } as TaskStateChanges['config'],
     };
     const poolBefore = this.stateGetTask(taskId)!;
     const poolUpdated = this.writeAndSync(taskId, poolChanges);


### PR DESCRIPTION
## Summary

Adds durable executor audit events so `query audit <taskId>` shows both the static routing decision and the runtime executor/machine selection for each task.

- Logs `task.executor.routed` when plan tasks are created, including Docker, explicit pool, routing-rule, and default-worktree reasons.
- Logs `task.executor.selected` after executor startup succeeds, including attempt/workspace/branch and non-secret SSH target display fields.
- Avoids secrets in audit payloads, including SSH key paths, env vars, provision commands, tokens, and repo credentials.

## Architecture

### Before

```mermaid
flowchart TD
  Plan[Plan task] --> Route[Resolve runnerKind/poolId]
  Route --> Created[task.created audit event]
  Runner[TaskRunner executor.start] --> Metadata[Persist workspace metadata]
```

### After

```mermaid
flowchart TD
  Plan[Plan task] --> Route[Resolve runnerKind/poolId plus reason]
  Route --> Created[task.created audit event]
  Created --> Routed[task.executor.routed audit event]
  Runner[TaskRunner executor.start succeeds] --> Selected[task.executor.selected audit event]
  Selected --> Metadata[Persist workspace metadata]
```

## Test Plan

- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/orchestrator.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/task-runner.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts -t "logs"`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts -t "logs|auto-routes matching command to configured poolId"`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 7f67b082`
- Post-revert steps: None
- Data migration? No

Depends-On: #579
