### PR TITLE
Skip no-op rebase cleanup queueing

### DIFF
--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -26,8 +26,11 @@ describe('RepoPool', () => {
   let tmpDir: string;
   let localRepoUrl: string;
   let pool: RepoPool;
+  let previousWorkspaceCleanup: string | undefined;
 
   beforeEach(() => {
+    previousWorkspaceCleanup = process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+    delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
     tmpDir = mkdtempSync(join(tmpdir(), 'repo-pool-cache-'));
     localRepoUrl = createTempRepo();
     pool = new RepoPool({ cacheDir: tmpDir });
@@ -35,6 +38,11 @@ describe('RepoPool', () => {
 
   afterEach(async () => {
     remoteFetchForPool.enabled = true;
+    if (previousWorkspaceCleanup === undefined) {
+      delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+    } else {
+      process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = previousWorkspaceCleanup;
+    }
     await pool.destroyAll();
     rmSync(tmpDir, { recursive: true, force: true });
     rmSync(localRepoUrl, { recursive: true, force: true });
@@ -464,6 +472,7 @@ describe('RepoPool', () => {
     });
 
     it('serializes concurrent removeManagedBranchesInMirror calls on same repo', async () => {
+      process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = '1';
       const log: string[] = [];
       const deferred1 = createDeferred<void>();
       const deferred2 = createDeferred<void>();
@@ -490,6 +499,71 @@ describe('RepoPool', () => {
       deferred2.resolve();
       await Promise.all([p1, p2]);
       expect(log).toEqual(['enter-1', 'exit-1', 'enter-2', 'exit-2']);
+    });
+
+    it('skips disabled removeManagedBranchesInMirror without waiting for repo chain', async () => {
+      const log: string[] = [];
+      const deferredRefresh = createDeferred<string>();
+      const doRemove = vi.spyOn(pool as any, 'doRemoveManagedBranchesInMirror');
+      const timing = { mark: vi.fn(), span: vi.fn() };
+
+      vi.spyOn(pool as any, 'doRefreshMirrorForRebase').mockImplementation(async () => {
+        log.push('enter-refresh');
+        const result = await deferredRefresh.promise;
+        log.push('exit-refresh');
+        return result;
+      });
+
+      const refresh = pool.refreshMirrorForRebase('repo-a', 'master');
+      await flush();
+      expect(log).toEqual(['enter-refresh']);
+
+      await pool.removeManagedBranchesInMirror('repo-a', ['experiment/old'], timing);
+      expect(log).toEqual(['enter-refresh']);
+      expect(doRemove).not.toHaveBeenCalled();
+      expect(timing.mark).toHaveBeenCalledWith('RepoPool.removeManagedBranchesInMirror', 'completed', {
+        repoUrl: 'repo-a',
+        enabled: false,
+        skipped: true,
+        reason: 'disabled',
+        branchCount: 1,
+      });
+
+      deferredRefresh.resolve('/fake/path');
+      await refresh;
+    });
+
+    it('skips empty removeManagedBranchesInMirror without waiting for repo chain', async () => {
+      process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = '1';
+      const log: string[] = [];
+      const deferredRefresh = createDeferred<string>();
+      const doRemove = vi.spyOn(pool as any, 'doRemoveManagedBranchesInMirror');
+      const timing = { mark: vi.fn(), span: vi.fn() };
+
+      vi.spyOn(pool as any, 'doRefreshMirrorForRebase').mockImplementation(async () => {
+        log.push('enter-refresh');
+        const result = await deferredRefresh.promise;
+        log.push('exit-refresh');
+        return result;
+      });
+
+      const refresh = pool.refreshMirrorForRebase('repo-a', 'master');
+      await flush();
+      expect(log).toEqual(['enter-refresh']);
+
+      await pool.removeManagedBranchesInMirror('repo-a', [], timing);
+      expect(log).toEqual(['enter-refresh']);
+      expect(doRemove).not.toHaveBeenCalled();
+      expect(timing.mark).toHaveBeenCalledWith('RepoPool.removeManagedBranchesInMirror', 'completed', {
+        repoUrl: 'repo-a',
+        enabled: true,
+        skipped: true,
+        reason: 'no-branches',
+        branchCount: 0,
+      });
+
+      deferredRefresh.resolve('/fake/path');
+      await refresh;
     });
 
     it('serializes cross-method calls (refreshMirror + acquireWorktree) on same repo', async () => {

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -141,6 +141,26 @@ export class RepoPool {
    * Remove Invoker-managed branches (experiment/*, invoker/*) from the mirror and linked worktrees.
    */
   async removeManagedBranchesInMirror(repoUrl: string, branches: string[], timing?: RepoPoolTiming): Promise<void> {
+    if (branches.length === 0) {
+      timing?.mark('RepoPool.removeManagedBranchesInMirror', 'completed', {
+        repoUrl,
+        enabled: isWorkspaceCleanupEnabled(),
+        skipped: true,
+        reason: 'no-branches',
+        branchCount: 0,
+      });
+      return;
+    }
+    if (!isWorkspaceCleanupEnabled()) {
+      timing?.mark('RepoPool.removeManagedBranchesInMirror', 'completed', {
+        repoUrl,
+        enabled: false,
+        skipped: true,
+        reason: 'disabled',
+        branchCount: branches.length,
+      });
+      return;
+    }
     const prev = this.repoChains.get(repoUrl) ?? Promise.resolve();
     const queuedAtMs = Date.now();
     const next = prev.then(() => {
@@ -156,17 +176,6 @@ export class RepoPool {
   }
 
   private async doRemoveManagedBranchesInMirror(repoUrl: string, branches: string[], timing?: RepoPoolTiming): Promise<void> {
-    // Gated: with attemptId in branch hash, leftover refs cannot collide with
-    // future attempts, so deletion is unnecessary. Set
-    // INVOKER_ENABLE_WORKSPACE_CLEANUP=1 to restore the rebase-and-retry
-    // branch sweep.
-    if (!isWorkspaceCleanupEnabled()) {
-      timing?.mark('RepoPool.doRemoveManagedBranchesInMirror', 'completed', {
-        enabled: false,
-        branchCount: branches.length,
-      });
-      return;
-    }
     const dir = this.cloneDir(repoUrl);
     if (!existsSync(dir) || !this.worktreeBaseDir) {
       timing?.mark('RepoPool.doRemoveManagedBranchesInMirror', 'completed', {


### PR DESCRIPTION
## Summary

Skips `RepoPool.removeManagedBranchesInMirror` before it enters the per-repo git operation chain when there is nothing useful to clean up:

- `branches.length === 0`
- workspace cleanup is disabled (`INVOKER_ENABLE_WORKSPACE_CLEANUP !== '1'`)

The skipped path still emits a timing marker (`RepoPool.removeManagedBranchesInMirror`) with `skipped: true`, but it no longer waits behind unrelated queued repo work just to discover cleanup is disabled.

Benchmark, focused workflow `Fix intent cancellation Step 1: workflow mutation cancellation hardening (regression gated v2)`:

- Before, intent `805`: submit to first `task.pending` was `20.797s`; `RepoPool.removeManagedBranchesInMirror.repoChainWait` was `0ms` in this run; top contributors were `gitFetchAllPrune=17.684s`, `syncPlanBaseRemoteForRef=3.031s`, `preparePoolForRebaseRetry=20.777s`.
- After, intent `809`: submit to first `task.pending` was `19.249s`; cleanup emitted the new skipped marker at `offsetMs=19249` with no repo-chain wait; top contributors were `gitFetchAllPrune=16.502s`, `syncPlanBaseRemoteForRef=2.641s`, `preparePoolForRebaseRetry=19.219s`.

The reproduced focused run did not hit the earlier observed multi-minute cleanup queue wait; this change removes that wait source when cleanup is a no-op.

## Architecture

### Before

```mermaid
flowchart TD
  A[preparePoolForRebaseRetry] --> B[refreshMirrorForRebase]
  B --> C[collect managed branches]
  C --> D[removeManagedBranchesInMirror]
  D --> E[wait behind repoChains]
  E --> F[doRemoveManagedBranchesInMirror]
  F --> G{cleanup enabled?}
  G -- no --> H[return]
```

### After

```mermaid
flowchart TD
  A[preparePoolForRebaseRetry] --> B[refreshMirrorForRebase]
  B --> C[collect managed branches]
  C --> D[removeManagedBranchesInMirror]
  D --> E{branches empty or cleanup disabled?}
  E -- yes --> F[record skipped timing and return]
  E -- no --> G[wait behind repoChains]
  G --> H[doRemoveManagedBranchesInMirror]
```

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/repo-pool.test.ts`
- [x] `pnpm --filter @invoker/transport build`
- [x] `scripts/bench-rebase-recreate-all.sh --workflow "Fix intent cancellation Step 1: workflow mutation cancellation hardening (regression gated v2)" --timeout 1800`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 49ac3e18`
- Post-revert steps: Restart the Invoker owner so `RepoPool` uses the reverted code.
- Data migration? No
