### PR TITLE
Coalesce duplicate rebase mirror refreshes

### DIFF
--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -442,7 +442,38 @@ describe('RepoPool', () => {
 
     afterEach(() => { vi.restoreAllMocks(); });
 
-    it('serializes concurrent refreshMirrorForRebase calls on same repo', async () => {
+    it('coalesces concurrent refreshMirrorForRebase calls on same repo and base branch', async () => {
+      const log: string[] = [];
+      const deferred1 = createDeferred<string>();
+      let callCount = 0;
+      const timing = { mark: vi.fn(), span: vi.fn() };
+
+      vi.spyOn(pool as any, 'doRefreshMirrorForRebase').mockImplementation(async () => {
+        const n = ++callCount;
+        log.push(`enter-${n}`);
+        const result = await deferred1.promise;
+        log.push(`exit-${n}`);
+        return result;
+      });
+
+      const p1 = pool.refreshMirrorForRebase('repo-a', 'master');
+      const p2 = pool.refreshMirrorForRebase('repo-a', 'master', timing);
+
+      await flush();
+      expect(log).toEqual(['enter-1']);
+      expect(callCount).toBe(1);
+      expect(timing.mark).toHaveBeenCalledWith('RepoPool.refreshMirrorForRebase.coalesced', 'completed', {
+        repoUrl: 'repo-a',
+        baseBranch: 'master',
+      });
+
+      deferred1.resolve('/fake/path');
+      await expect(Promise.all([p1, p2])).resolves.toEqual(['/fake/path', '/fake/path']);
+      expect(log).toEqual(['enter-1', 'exit-1']);
+      expect(callCount).toBe(1);
+    });
+
+    it('serializes concurrent refreshMirrorForRebase calls on same repo with different base branches', async () => {
       const log: string[] = [];
       const deferred1 = createDeferred<string>();
       const deferred2 = createDeferred<string>();
@@ -457,17 +488,17 @@ describe('RepoPool', () => {
       });
 
       const p1 = pool.refreshMirrorForRebase('repo-a', 'master');
-      const p2 = pool.refreshMirrorForRebase('repo-a', 'master');
+      const p2 = pool.refreshMirrorForRebase('repo-a', 'release');
 
       await flush();
       expect(log).toEqual(['enter-1']);
 
-      deferred1.resolve('/fake/path');
+      deferred1.resolve('/fake/path-master');
       await flush();
       expect(log).toEqual(['enter-1', 'exit-1', 'enter-2']);
 
-      deferred2.resolve('/fake/path');
-      await Promise.all([p1, p2]);
+      deferred2.resolve('/fake/path-release');
+      await expect(Promise.all([p1, p2])).resolves.toEqual(['/fake/path-master', '/fake/path-release']);
       expect(log).toEqual(['enter-1', 'exit-1', 'enter-2', 'exit-2']);
     });
 

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -59,6 +59,7 @@ export class RepoPool {
   private cloneLocks = new Map<string, Promise<string>>();
   /** Chain of operations per repo to serialize git operations. */
   private repoChains = new Map<string, Promise<unknown>>();
+  private inFlightRebaseRefreshes = new Map<string, Promise<string>>();
 
   constructor(config: RepoPoolConfig) {
     this.cacheDir = config.cacheDir;
@@ -83,6 +84,16 @@ export class RepoPool {
    * Force-fetch mirror and sync origin/<baseBranch> (rebase-and-retry). Ignores remoteFetchForPool.
    */
   async refreshMirrorForRebase(repoUrl: string, baseBranch: string, timing?: RepoPoolTiming): Promise<string> {
+    const refreshKey = `${repoUrl}\0${baseBranch}`;
+    const inFlight = this.inFlightRebaseRefreshes.get(refreshKey);
+    if (inFlight) {
+      timing?.mark('RepoPool.refreshMirrorForRebase.coalesced', 'completed', {
+        repoUrl,
+        baseBranch,
+      });
+      return inFlight;
+    }
+
     const prev = this.repoChains.get(repoUrl) ?? Promise.resolve();
     const queuedAtMs = Date.now();
     const next = prev.then(() => {
@@ -94,7 +105,14 @@ export class RepoPool {
       return this.doRefreshMirrorForRebase(repoUrl, baseBranch, timing);
     });
     this.repoChains.set(repoUrl, next.catch(() => {}));
-    return next;
+    let shared!: Promise<string>;
+    shared = next.finally(() => {
+      if (this.inFlightRebaseRefreshes.get(refreshKey) === shared) {
+        this.inFlightRebaseRefreshes.delete(refreshKey);
+      }
+    });
+    this.inFlightRebaseRefreshes.set(refreshKey, shared);
+    return shared;
   }
 
   private async doRefreshMirrorForRebase(repoUrl: string, baseBranch: string, timing?: RepoPoolTiming): Promise<string> {


### PR DESCRIPTION
## Summary

Coalesces concurrent `RepoPool.refreshMirrorForRebase(repoUrl, baseBranch)` calls for the same repo/base pair through an in-flight promise map. The first caller still owns the serialized git refresh in `repoChains`; duplicate callers share that promise and emit a `RepoPool.refreshMirrorForRebase.coalesced` timing marker instead of enqueueing another identical fetch/sync.

Different base branches still serialize through the repo chain, different repos can still run independently, and cross-method operations such as `refreshMirrorForRebase` plus `acquireWorktree` remain serialized for the same repo.

Benchmark, focused workflow `Fix intent cancellation Step 1: workflow mutation cancellation hardening (regression gated v2)`:

- Before this PR, after PR 1, intent `809`: submit to first `task.pending` was `19.249s`; `RepoPool.refreshMirrorForRebase.repoChainWait=0ms`; top contributors were `gitFetchAllPrune=16.502s`, `syncPlanBaseRemoteForRef=2.641s`, `preparePoolForRebaseRetry=19.219s`.
- After this PR, intent `807`: submit to first `task.pending` was `19.673s`; `RepoPool.refreshMirrorForRebase.repoChainWait=0ms`; top contributors were `gitFetchAllPrune=16.281s`, `syncPlanBaseRemoteForRef=3.223s`, `preparePoolForRebaseRetry=19.645s`.

The focused single-workflow benchmark has one fresh-base refresh, so it does not exercise duplicate refresh coalescing; the unit test covers the coalesced same-repo/base case.

## Architecture

### Before

```mermaid
flowchart TD
  A[refreshMirrorForRebase repo/main call 1] --> C[repoChains]
  B[refreshMirrorForRebase repo/main call 2] --> C
  C --> D[fetch and sync]
  D --> E[fetch and sync again]
```

### After

```mermaid
flowchart TD
  A[refreshMirrorForRebase repo/main call 1] --> B{in-flight refresh?}
  B -- no --> C[register shared promise]
  C --> D[repoChains]
  D --> E[fetch and sync once]
  F[refreshMirrorForRebase repo/main call 2] --> G{in-flight refresh?}
  G -- yes --> C
  E --> H[clear shared promise]
```

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/repo-pool.test.ts`
- [x] `pnpm --filter @invoker/transport build`
- [x] `scripts/bench-rebase-recreate-all.sh --workflow "Fix intent cancellation Step 1: workflow mutation cancellation hardening (regression gated v2)" --timeout 1800`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert d99c5798`
- Post-revert steps: Restart the Invoker owner so `RepoPool` uses the reverted code.
- Data migration? No
