### PR TITLE
Coalesce duplicate rebase mirror refreshes

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -319,12 +319,12 @@ describe('SQLiteAdapter', () => {
       ]);
     });
 
-    it('keeps running when failed tasks do not block all pending work', () => {
+    it('derives failed when failed tasks do not block all pending work', () => {
       adapter.saveWorkflow({ ...testWorkflow, status: 'running' });
       adapter.saveTask('wf-1', makeTask('alpha', { status: 'failed' }));
       adapter.saveTask('wf-1', makeTask('independent', { status: 'pending' }));
 
-      expect(adapter.loadWorkflow('wf-1')!.status).toBe('running');
+      expect(adapter.loadWorkflow('wf-1')!.status).toBe('failed');
     });
 
     it('derives listWorkflows with one aggregate rollup per workflow', () => {

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -26,8 +26,11 @@ describe('RepoPool', () => {
   let tmpDir: string;
   let localRepoUrl: string;
   let pool: RepoPool;
+  let previousWorkspaceCleanup: string | undefined;
 
   beforeEach(() => {
+    previousWorkspaceCleanup = process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+    delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
     tmpDir = mkdtempSync(join(tmpdir(), 'repo-pool-cache-'));
     localRepoUrl = createTempRepo();
     pool = new RepoPool({ cacheDir: tmpDir });
@@ -35,6 +38,11 @@ describe('RepoPool', () => {
 
   afterEach(async () => {
     remoteFetchForPool.enabled = true;
+    if (previousWorkspaceCleanup === undefined) {
+      delete process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP;
+    } else {
+      process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = previousWorkspaceCleanup;
+    }
     await pool.destroyAll();
     rmSync(tmpDir, { recursive: true, force: true });
     rmSync(localRepoUrl, { recursive: true, force: true });
@@ -464,6 +472,7 @@ describe('RepoPool', () => {
     });
 
     it('serializes concurrent removeManagedBranchesInMirror calls on same repo', async () => {
+      process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = '1';
       const log: string[] = [];
       const deferred1 = createDeferred<void>();
       const deferred2 = createDeferred<void>();
@@ -490,6 +499,71 @@ describe('RepoPool', () => {
       deferred2.resolve();
       await Promise.all([p1, p2]);
       expect(log).toEqual(['enter-1', 'exit-1', 'enter-2', 'exit-2']);
+    });
+
+    it('skips disabled removeManagedBranchesInMirror without waiting for repo chain', async () => {
+      const log: string[] = [];
+      const deferredRefresh = createDeferred<string>();
+      const doRemove = vi.spyOn(pool as any, 'doRemoveManagedBranchesInMirror');
+      const timing = { mark: vi.fn(), span: vi.fn() };
+
+      vi.spyOn(pool as any, 'doRefreshMirrorForRebase').mockImplementation(async () => {
+        log.push('enter-refresh');
+        const result = await deferredRefresh.promise;
+        log.push('exit-refresh');
+        return result;
+      });
+
+      const refresh = pool.refreshMirrorForRebase('repo-a', 'master');
+      await flush();
+      expect(log).toEqual(['enter-refresh']);
+
+      await pool.removeManagedBranchesInMirror('repo-a', ['experiment/old'], timing);
+      expect(log).toEqual(['enter-refresh']);
+      expect(doRemove).not.toHaveBeenCalled();
+      expect(timing.mark).toHaveBeenCalledWith('RepoPool.removeManagedBranchesInMirror', 'completed', {
+        repoUrl: 'repo-a',
+        enabled: false,
+        skipped: true,
+        reason: 'disabled',
+        branchCount: 1,
+      });
+
+      deferredRefresh.resolve('/fake/path');
+      await refresh;
+    });
+
+    it('skips empty removeManagedBranchesInMirror without waiting for repo chain', async () => {
+      process.env.INVOKER_ENABLE_WORKSPACE_CLEANUP = '1';
+      const log: string[] = [];
+      const deferredRefresh = createDeferred<string>();
+      const doRemove = vi.spyOn(pool as any, 'doRemoveManagedBranchesInMirror');
+      const timing = { mark: vi.fn(), span: vi.fn() };
+
+      vi.spyOn(pool as any, 'doRefreshMirrorForRebase').mockImplementation(async () => {
+        log.push('enter-refresh');
+        const result = await deferredRefresh.promise;
+        log.push('exit-refresh');
+        return result;
+      });
+
+      const refresh = pool.refreshMirrorForRebase('repo-a', 'master');
+      await flush();
+      expect(log).toEqual(['enter-refresh']);
+
+      await pool.removeManagedBranchesInMirror('repo-a', [], timing);
+      expect(log).toEqual(['enter-refresh']);
+      expect(doRemove).not.toHaveBeenCalled();
+      expect(timing.mark).toHaveBeenCalledWith('RepoPool.removeManagedBranchesInMirror', 'completed', {
+        repoUrl: 'repo-a',
+        enabled: true,
+        skipped: true,
+        reason: 'no-branches',
+        branchCount: 0,
+      });
+
+      deferredRefresh.resolve('/fake/path');
+      await refresh;
     });
 
     it('serializes cross-method calls (refreshMirror + acquireWorktree) on same repo', async () => {

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -442,7 +442,38 @@ describe('RepoPool', () => {
 
     afterEach(() => { vi.restoreAllMocks(); });
 
-    it('serializes concurrent refreshMirrorForRebase calls on same repo', async () => {
+    it('coalesces concurrent refreshMirrorForRebase calls on same repo and base branch', async () => {
+      const log: string[] = [];
+      const deferred1 = createDeferred<string>();
+      let callCount = 0;
+      const timing = { mark: vi.fn(), span: vi.fn() };
+
+      vi.spyOn(pool as any, 'doRefreshMirrorForRebase').mockImplementation(async () => {
+        const n = ++callCount;
+        log.push(`enter-${n}`);
+        const result = await deferred1.promise;
+        log.push(`exit-${n}`);
+        return result;
+      });
+
+      const p1 = pool.refreshMirrorForRebase('repo-a', 'master');
+      const p2 = pool.refreshMirrorForRebase('repo-a', 'master', timing);
+
+      await flush();
+      expect(log).toEqual(['enter-1']);
+      expect(callCount).toBe(1);
+      expect(timing.mark).toHaveBeenCalledWith('RepoPool.refreshMirrorForRebase.coalesced', 'completed', {
+        repoUrl: 'repo-a',
+        baseBranch: 'master',
+      });
+
+      deferred1.resolve('/fake/path');
+      await expect(Promise.all([p1, p2])).resolves.toEqual(['/fake/path', '/fake/path']);
+      expect(log).toEqual(['enter-1', 'exit-1']);
+      expect(callCount).toBe(1);
+    });
+
+    it('serializes concurrent refreshMirrorForRebase calls on same repo with different base branches', async () => {
       const log: string[] = [];
       const deferred1 = createDeferred<string>();
       const deferred2 = createDeferred<string>();
@@ -457,17 +488,17 @@ describe('RepoPool', () => {
       });
 
       const p1 = pool.refreshMirrorForRebase('repo-a', 'master');
-      const p2 = pool.refreshMirrorForRebase('repo-a', 'master');
+      const p2 = pool.refreshMirrorForRebase('repo-a', 'release');
 
       await flush();
       expect(log).toEqual(['enter-1']);
 
-      deferred1.resolve('/fake/path');
+      deferred1.resolve('/fake/path-master');
       await flush();
       expect(log).toEqual(['enter-1', 'exit-1', 'enter-2']);
 
-      deferred2.resolve('/fake/path');
-      await Promise.all([p1, p2]);
+      deferred2.resolve('/fake/path-release');
+      await expect(Promise.all([p1, p2])).resolves.toEqual(['/fake/path-master', '/fake/path-release']);
       expect(log).toEqual(['enter-1', 'exit-1', 'enter-2', 'exit-2']);
     });
 

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -7918,6 +7918,195 @@ console.log(JSON.stringify(out));
   });
 
   describe('metadata persistence hardening', () => {
+    function createCompletingExecutor(type: string, handle: Record<string, unknown>) {
+      return {
+        type,
+        start: vi.fn(async (request: any) => ({
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          ...handle,
+        })),
+        onComplete: vi.fn((_handle, cb) => {
+          setTimeout(() => cb({
+            requestId: 'req-1',
+            actionId: (_handle as any).taskId,
+            status: 'completed',
+            outputs: { exitCode: 0 },
+          }), 0);
+        }),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+        destroyAll: vi.fn(),
+      };
+    }
+
+    it('logs pool-routed SSH executor selection with remote target display fields', async () => {
+      const sshExecutor = createCompletingExecutor('ssh', {
+        workspacePath: '/remote/worktrees/task-1',
+        branch: 'experiment/task-1',
+      });
+      const logEvent = vi.fn();
+      const task = makeTask({
+        id: 'task-1',
+        status: 'pending',
+        config: { command: 'pnpm test', runnerKind: 'ssh', poolId: 'ci-pool' },
+        execution: { selectedAttemptId: 'attempt-1' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse: vi.fn() } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent } as any,
+        executorRegistry: {
+          getDefault: () => sshExecutor,
+          get: (type: string) => type === 'ssh' ? sshExecutor : null,
+          getAll: () => [sshExecutor],
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          'ci-pool': {
+            selectionStrategy: 'leastLoaded',
+            members: [{ type: 'ssh', id: 'remote-a' }],
+          },
+        }),
+        remoteTargetsProvider: () => ({
+          'remote-a': {
+            host: 'ci.example.com',
+            user: 'runner',
+            sshKeyPath: '/secret/key',
+            port: 2222,
+          },
+        }),
+      });
+
+      await runner.executeTask(task);
+
+      expect(logEvent).toHaveBeenCalledWith('task-1', 'task.executor.selected', {
+        runnerKind: 'ssh',
+        reason: {
+          type: 'poolId',
+          poolId: 'ci-pool',
+          selectionStrategy: 'leastLoaded',
+          poolMemberId: 'remote-a',
+        },
+        attemptId: 'attempt-1',
+        workspacePath: '/remote/worktrees/task-1',
+        branch: 'experiment/task-1',
+        poolMemberId: 'remote-a',
+        remoteHost: 'ci.example.com',
+        remoteUser: 'runner',
+        port: 2222,
+      });
+      const selectedPayload = logEvent.mock.calls.find((call) => call[1] === 'task.executor.selected')?.[2];
+      expect(JSON.stringify(selectedPayload)).not.toContain('sshKeyPath');
+      expect(JSON.stringify(selectedPayload)).not.toContain('/secret/key');
+    });
+
+    it('logs explicit SSH executor selection as explicitPoolMemberId', async () => {
+      const sshExecutor = createCompletingExecutor('ssh', {
+        workspacePath: '/remote/worktrees/task-explicit',
+        branch: 'experiment/task-explicit',
+      });
+      const logEvent = vi.fn();
+      const task = makeTask({
+        id: 'task-explicit',
+        status: 'pending',
+        config: { command: 'echo hi', runnerKind: 'ssh', poolMemberId: 'remote-b' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse: vi.fn() } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent } as any,
+        executorRegistry: {
+          getDefault: () => sshExecutor,
+          get: (type: string) => type === 'ssh' ? sshExecutor : null,
+          getAll: () => [sshExecutor],
+        } as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'remote-b': { host: 'dev.example.com', user: 'dev', sshKeyPath: '/secret/dev-key' },
+        }),
+      });
+
+      await runner.executeTask(task);
+
+      expect(logEvent).toHaveBeenCalledWith('task-explicit', 'task.executor.selected', expect.objectContaining({
+        runnerKind: 'ssh',
+        reason: { type: 'explicitPoolMemberId' },
+        poolMemberId: 'remote-b',
+        remoteHost: 'dev.example.com',
+        remoteUser: 'dev',
+      }));
+    });
+
+    it('logs configured worktree executor selection reason', async () => {
+      const worktreeExecutor = createCompletingExecutor('worktree', {
+        workspacePath: '/tmp/worktree/task-local',
+        branch: 'experiment/task-local',
+      });
+      const logEvent = vi.fn();
+      const task = makeTask({
+        id: 'task-local',
+        status: 'pending',
+        config: { command: 'echo local', runnerKind: 'worktree' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse: vi.fn() } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent } as any,
+        executorRegistry: {
+          getDefault: () => worktreeExecutor,
+          get: (type: string) => type === 'worktree' ? worktreeExecutor : null,
+          getAll: () => [worktreeExecutor],
+        } as any,
+        cwd: '/tmp',
+      });
+
+      await runner.executeTask(task);
+
+      expect(logEvent).toHaveBeenCalledWith('task-local', 'task.executor.selected', expect.objectContaining({
+        runnerKind: 'worktree',
+        reason: { type: 'configuredWorktree' },
+        workspacePath: '/tmp/worktree/task-local',
+        branch: 'experiment/task-local',
+      }));
+    });
+
+    it('logs SSH pool fallback to worktree when no pool member or remote target exists', async () => {
+      const worktreeExecutor = createCompletingExecutor('worktree', {
+        workspacePath: '/tmp/worktree/task-fallback',
+        branch: 'experiment/task-fallback',
+      });
+      const logEvent = vi.fn();
+      const task = makeTask({
+        id: 'task-fallback',
+        status: 'pending',
+        config: { command: 'echo fallback', runnerKind: 'ssh', poolId: 'missing-pool' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse: vi.fn() } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent } as any,
+        executorRegistry: {
+          getDefault: () => worktreeExecutor,
+          get: (type: string) => type === 'worktree' ? worktreeExecutor : null,
+          getAll: () => [worktreeExecutor],
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({}),
+        remoteTargetsProvider: () => ({}),
+      });
+
+      await runner.executeTask(task);
+
+      expect(logEvent).toHaveBeenCalledWith('task-fallback', 'task.executor.selected', expect.objectContaining({
+        runnerKind: 'worktree',
+        reason: { type: 'sshPoolFallbackToWorktree', poolId: 'missing-pool' },
+        workspacePath: '/tmp/worktree/task-fallback',
+        branch: 'experiment/task-fallback',
+      }));
+    });
+
     it('fails fast when executor returns handle without workspacePath', async () => {
       const badExecutor = {
         type: 'bad-executor',

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -141,6 +141,26 @@ export class RepoPool {
    * Remove Invoker-managed branches (experiment/*, invoker/*) from the mirror and linked worktrees.
    */
   async removeManagedBranchesInMirror(repoUrl: string, branches: string[], timing?: RepoPoolTiming): Promise<void> {
+    if (branches.length === 0) {
+      timing?.mark('RepoPool.removeManagedBranchesInMirror', 'completed', {
+        repoUrl,
+        enabled: isWorkspaceCleanupEnabled(),
+        skipped: true,
+        reason: 'no-branches',
+        branchCount: 0,
+      });
+      return;
+    }
+    if (!isWorkspaceCleanupEnabled()) {
+      timing?.mark('RepoPool.removeManagedBranchesInMirror', 'completed', {
+        repoUrl,
+        enabled: false,
+        skipped: true,
+        reason: 'disabled',
+        branchCount: branches.length,
+      });
+      return;
+    }
     const prev = this.repoChains.get(repoUrl) ?? Promise.resolve();
     const queuedAtMs = Date.now();
     const next = prev.then(() => {
@@ -156,17 +176,6 @@ export class RepoPool {
   }
 
   private async doRemoveManagedBranchesInMirror(repoUrl: string, branches: string[], timing?: RepoPoolTiming): Promise<void> {
-    // Gated: with attemptId in branch hash, leftover refs cannot collide with
-    // future attempts, so deletion is unnecessary. Set
-    // INVOKER_ENABLE_WORKSPACE_CLEANUP=1 to restore the rebase-and-retry
-    // branch sweep.
-    if (!isWorkspaceCleanupEnabled()) {
-      timing?.mark('RepoPool.doRemoveManagedBranchesInMirror', 'completed', {
-        enabled: false,
-        branchCount: branches.length,
-      });
-      return;
-    }
     const dir = this.cloneDir(repoUrl);
     if (!existsSync(dir) || !this.worktreeBaseDir) {
       timing?.mark('RepoPool.doRemoveManagedBranchesInMirror', 'completed', {

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -59,6 +59,7 @@ export class RepoPool {
   private cloneLocks = new Map<string, Promise<string>>();
   /** Chain of operations per repo to serialize git operations. */
   private repoChains = new Map<string, Promise<unknown>>();
+  private inFlightRebaseRefreshes = new Map<string, Promise<string>>();
 
   constructor(config: RepoPoolConfig) {
     this.cacheDir = config.cacheDir;
@@ -83,6 +84,16 @@ export class RepoPool {
    * Force-fetch mirror and sync origin/<baseBranch> (rebase-and-retry). Ignores remoteFetchForPool.
    */
   async refreshMirrorForRebase(repoUrl: string, baseBranch: string, timing?: RepoPoolTiming): Promise<string> {
+    const refreshKey = `${repoUrl}\0${baseBranch}`;
+    const inFlight = this.inFlightRebaseRefreshes.get(refreshKey);
+    if (inFlight) {
+      timing?.mark('RepoPool.refreshMirrorForRebase.coalesced', 'completed', {
+        repoUrl,
+        baseBranch,
+      });
+      return inFlight;
+    }
+
     const prev = this.repoChains.get(repoUrl) ?? Promise.resolve();
     const queuedAtMs = Date.now();
     const next = prev.then(() => {
@@ -94,7 +105,14 @@ export class RepoPool {
       return this.doRefreshMirrorForRebase(repoUrl, baseBranch, timing);
     });
     this.repoChains.set(repoUrl, next.catch(() => {}));
-    return next;
+    let shared!: Promise<string>;
+    shared = next.finally(() => {
+      if (this.inFlightRebaseRefreshes.get(refreshKey) === shared) {
+        this.inFlightRebaseRefreshes.delete(refreshKey);
+      }
+    });
+    this.inFlightRebaseRefreshes.set(refreshKey, shared);
+    return shared;
   }
 
   private async doRefreshMirrorForRebase(repoUrl: string, baseBranch: string, timing?: RepoPoolTiming): Promise<string> {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -92,6 +92,18 @@ type PoolSelection = {
   poolId: string;
   member: ExecutionPoolMember;
   memberKey: string;
+  selectionStrategy: 'roundRobin' | 'leastLoaded';
+};
+
+type RemoteTargetDisplay = {
+  host: string;
+  user: string;
+  sshKeyPath: string;
+  port?: number;
+  managedWorkspaces?: boolean;
+  remoteInvokerHome?: string;
+  provisionCommand?: string;
+  remoteHeartbeatIntervalSeconds?: number;
 };
 
 function nextLeaseExpiry(from: Date): Date {
@@ -175,7 +187,7 @@ export class TaskRunner {
   /** @internal */ mergeGateProvider?: MergeGateProvider;
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
   private activePrPollers = new Map<string, ReturnType<typeof setInterval>>();
-  private getRemoteTargets: () => Record<string, { host: string; user: string; sshKeyPath: string; port?: number; managedWorkspaces?: boolean; remoteInvokerHome?: string; provisionCommand?: string; remoteHeartbeatIntervalSeconds?: number }>;
+  private getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   private getExecutionPools: () => Record<string, ExecutionPoolConfig>;
   private dockerConfig: { imageName?: string; secretsFile?: string };
   private executionAgentRegistry?: AgentRegistry;
@@ -680,6 +692,14 @@ export class TaskRunner {
         );
       }
 
+      this.logExecutorSelected(
+        task,
+        executor,
+        handle,
+        attemptId,
+        this.pendingPoolSelections.get(task.id),
+      );
+
       const changes = {
         config: { runnerKind: executor.type as RunnerKind },
         execution: {
@@ -863,6 +883,80 @@ export class TaskRunner {
     return candidates[0]?.member;
   }
 
+  private logExecutorSelected(
+    task: TaskState,
+    executor: Executor,
+    handle: ExecutorHandle,
+    attemptId: string,
+    poolSelection: PoolSelection | undefined,
+  ): void {
+    const payload: Record<string, unknown> = {
+      runnerKind: executor.type,
+      reason: this.executorSelectionReason(task, executor, poolSelection),
+      attemptId,
+      workspacePath: handle.workspacePath,
+      branch: handle.branch ?? undefined,
+    };
+
+    if (executor.type === 'ssh') {
+      const targetId = this.selectedRemoteTargetId(task, poolSelection);
+      const target = targetId ? this.getRemoteTargets()[targetId] : undefined;
+      if (targetId) payload.poolMemberId = targetId;
+      if (target) {
+        payload.remoteHost = target.host;
+        payload.remoteUser = target.user;
+        payload.port = target.port;
+      }
+    }
+
+    this.persistence.logEvent?.(task.id, 'task.executor.selected', payload);
+  }
+
+  private executorSelectionReason(
+    task: TaskState,
+    executor: Executor,
+    poolSelection: PoolSelection | undefined,
+  ): Record<string, unknown> {
+    if (executor.type === 'ssh') {
+      if (poolSelection) {
+        return {
+          type: 'poolId',
+          poolId: poolSelection.poolId,
+          selectionStrategy: poolSelection.selectionStrategy,
+          poolMemberId: poolSelection.member.id,
+        };
+      }
+      if ((task.config as { poolMemberId?: string }).poolMemberId) {
+        return { type: 'explicitPoolMemberId' };
+      }
+      if (task.config.poolId) {
+        return { type: 'poolId', poolId: task.config.poolId };
+      }
+    }
+
+    if (executor.type === 'worktree') {
+      if (task.config.runnerKind === 'ssh' && task.config.poolId) {
+        return { type: 'sshPoolFallbackToWorktree', poolId: task.config.poolId };
+      }
+      if (task.config.runnerKind === 'worktree') {
+        return { type: 'configuredWorktree' };
+      }
+      return { type: 'defaultWorktree' };
+    }
+
+    if (executor.type === 'docker') {
+      return { type: 'dockerImage' };
+    }
+
+    return { type: 'configuredRunnerKind', runnerKind: executor.type };
+  }
+
+  private selectedRemoteTargetId(task: TaskState, poolSelection: PoolSelection | undefined): string | undefined {
+    if (poolSelection?.member.type === 'ssh') return poolSelection.member.id;
+    return (task.config as { poolMemberId?: string }).poolMemberId
+      ?? (task.config.poolId && this.getRemoteTargets()[task.config.poolId] ? task.config.poolId : undefined);
+  }
+
   selectExecutor(task: TaskState): Executor {
     let effectiveType = task.config.runnerKind ?? (task.config.isMergeNode ? 'merge' : undefined);
     let selectedPoolMemberId: string | undefined;
@@ -878,6 +972,7 @@ export class TaskRunner {
           poolId: task.config.poolId,
           member,
           memberKey: this.poolMemberKey(member),
+          selectionStrategy: pool.selectionStrategy ?? 'roundRobin',
         });
       }
     }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1265,8 +1265,9 @@ describe('Orchestrator', () => {
       });
 
       it('auto-routes matching command to configured poolId with route strategy', () => {
+        const persistence = new InMemoryPersistence();
         const routedOrchestrator = new Orchestrator({
-          persistence: new InMemoryPersistence(),
+          persistence,
           messageBus: new InMemoryBus(),
           maxConcurrency: 3,
           executorRoutingRules: [
@@ -1283,6 +1284,60 @@ describe('Orchestrator', () => {
         const task = routedOrchestrator.getTask('t1');
         expect(task!.config.runnerKind).toBe('ssh');
         expect(task!.config.poolId).toBe('ssh-light');
+        const routedEvent = persistence.events.find((event) =>
+          event.taskId.endsWith('/t1') && event.eventType === 'task.executor.routed'
+        );
+        expect(routedEvent?.payload).toEqual({
+          runnerKind: 'ssh',
+          poolId: 'ssh-light',
+          reason: { type: 'routingRule', regex: '\\bpnpm(?:\\s|$)', poolId: 'ssh-light' },
+        });
+      });
+
+      it('logs default worktree routing when no pool or docker rule applies', () => {
+        const persistence = new InMemoryPersistence();
+        const routedOrchestrator = new Orchestrator({
+          persistence,
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'default-worktree-routing-test',
+          tasks: [{ id: 't1', description: 'Local task', command: 'echo local' }],
+        });
+
+        const routedEvent = persistence.events.find((event) =>
+          event.taskId.endsWith('/t1') && event.eventType === 'task.executor.routed'
+        );
+        expect(routedEvent?.payload).toEqual({
+          runnerKind: 'worktree',
+          reason: { type: 'defaultWorktree' },
+        });
+      });
+
+      it('logs explicit pool routing when a task declares poolId', () => {
+        const persistence = new InMemoryPersistence();
+        const routedOrchestrator = new Orchestrator({
+          persistence,
+          messageBus: new InMemoryBus(),
+          maxConcurrency: 3,
+          availablePoolIds: ['ssh-light'],
+        });
+
+        routedOrchestrator.loadPlan({
+          name: 'explicit-pool-routing-test',
+          tasks: [{ id: 't1', description: 'Remote task', command: 'echo remote', poolId: 'ssh-light' }],
+        });
+
+        const routedEvent = persistence.events.find((event) =>
+          event.taskId.endsWith('/t1') && event.eventType === 'task.executor.routed'
+        );
+        expect(routedEvent?.payload).toEqual({
+          runnerKind: 'ssh',
+          poolId: 'ssh-light',
+          reason: { type: 'poolId', poolId: 'ssh-light' },
+        });
       });
 
       it('routes matching command without an explicit runner kind', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -543,7 +543,7 @@ function resolveExecutorRouting(
   defaultPoolId: string | undefined,
   rules: ExecutorRoutingRule[],
   availablePoolIds: Set<string>,
-): { poolId?: string } {
+): { poolId?: string; reason: ExecutorRoutingReason } {
   if (!command || rules.length === 0) {
     if (planPoolId === undefined && defaultPoolId !== undefined) {
       validateRoutingDestinationAvailability(
@@ -555,14 +555,19 @@ function resolveExecutorRouting(
       );
       return {
         poolId: defaultPoolId,
+        reason: { type: 'defaultPoolId', poolId: defaultPoolId },
       };
     }
     return {
       poolId: planPoolId,
+      reason: planPoolId ? { type: 'poolId', poolId: planPoolId } : { type: 'defaultWorktree' },
     };
   }
 
   let effectivePoolId = planPoolId;
+  let reason: ExecutorRoutingReason = planPoolId
+    ? { type: 'poolId', poolId: planPoolId }
+    : { type: 'defaultWorktree' };
 
   const routingRules = rules.filter((rule) => (rule.strategy ?? 'enforce') === 'route');
   const matchingRoutingRule = findMatchingExecutorRoutingRule(command, routingRules);
@@ -576,6 +581,14 @@ function resolveExecutorRouting(
       availablePoolIds,
     );
     effectivePoolId = routed?.poolId ?? effectivePoolId;
+    if (routed?.poolId) {
+      reason = {
+        type: 'routingRule',
+        poolId: routed.poolId,
+        ...(matchingRoutingRule.pattern !== undefined ? { pattern: matchingRoutingRule.pattern } : {}),
+        ...(matchingRoutingRule.regex !== undefined ? { regex: matchingRoutingRule.regex } : {}),
+      };
+    }
   }
 
   if (effectivePoolId === undefined && defaultPoolId !== undefined) {
@@ -599,6 +612,26 @@ function resolveExecutorRouting(
 
   return {
     poolId: effectivePoolId,
+    reason,
+  };
+}
+
+type ExecutorRoutingReason =
+  | { type: 'dockerImage' }
+  | { type: 'poolId'; poolId: string }
+  | { type: 'defaultPoolId'; poolId: string }
+  | { type: 'routingRule'; poolId: string; pattern?: string; regex?: string }
+  | { type: 'defaultWorktree' };
+
+function buildExecutorRoutedPayload(
+  runnerKind: RunnerKind,
+  poolId: string | undefined,
+  reason: ExecutorRoutingReason,
+): Record<string, unknown> {
+  return {
+    runnerKind,
+    ...(poolId ? { poolId } : {}),
+    reason,
   };
 }
 
@@ -1282,6 +1315,7 @@ export class Orchestrator {
     }
 
     const validatedTasks: TaskState[] = [];
+    const resolvedRoutingByTaskId = new Map<string, ExecutorRoutingReason>();
     for (const taskDef of plan.tasks) {
       const resolvedRouting = resolveExecutorRouting(
         taskDef.id,
@@ -1294,6 +1328,10 @@ export class Orchestrator {
       const effectivePoolId = resolvedRouting.poolId;
 
       const scopedId = localToScoped.get(taskDef.id)!;
+      resolvedRoutingByTaskId.set(
+        scopedId,
+        taskDef.dockerImage ? { type: 'dockerImage' } : resolvedRouting.reason,
+      );
       const scopedDeps = (taskDef.dependencies ?? []).map((dep) => {
         const s = localToScoped.get(dep);
         if (!s) {
@@ -1391,10 +1429,17 @@ export class Orchestrator {
     const deltas: TaskDelta[] = [];
     for (const task of validatedTasks) {
       this.createAndSync(task);
+      this.persistence.logEvent?.(task.id, 'task.created');
+      this.persistence.logEvent?.(task.id, 'task.executor.routed', buildExecutorRoutedPayload(
+        task.config.runnerKind ?? 'worktree',
+        task.config.poolId,
+        task.config.dockerImage ? { type: 'dockerImage' } : resolvedRoutingByTaskId.get(task.id) ?? { type: 'defaultWorktree' },
+      ));
       deltas.push({ type: 'created', task });
     }
 
     this.createAndSync(mergeTask);
+    this.persistence.logEvent?.(mergeTask.id, 'task.created');
     deltas.push({ type: 'created', task: mergeTask });
 
     for (const delta of deltas) {
@@ -2764,7 +2809,7 @@ export class Orchestrator {
         poolId,
         runnerKind: undefined,
         poolMemberId: undefined,
-      },
+      } as TaskStateChanges['config'],
     };
     const poolBefore = this.stateGetTask(taskId)!;
     const poolUpdated = this.writeAndSync(taskId, poolChanges);

--- a/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
+++ b/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
@@ -21,7 +21,7 @@ describe('workflow rollup', () => {
     { name: 'review ready', statuses: ['completed', 'review_ready'], expected: 'review_ready' },
     { name: 'blocked task', statuses: ['completed', 'blocked'], expected: 'blocked' },
     { name: 'needs input task', statuses: ['completed', 'needs_input'], expected: 'blocked' },
-    { name: 'failed with unrelated pending work by counts only', statuses: ['failed', 'pending'], expected: 'running' },
+    { name: 'failed with unrelated pending work by counts only', statuses: ['failed', 'pending'], expected: 'failed' },
     { name: 'terminal failed', statuses: ['failed', 'completed'], expected: 'failed' },
     { name: 'completed workflow', statuses: ['completed', 'completed'], expected: 'completed' },
     { name: 'completed with stale prior task', statuses: ['completed', 'stale'], expected: 'completed' },
@@ -44,12 +44,23 @@ describe('workflow rollup', () => {
     expect(rollup.status).toBe('failed');
   });
 
-  it('keeps running when a failed task does not block all remaining pending work', () => {
+  it('fails when a failed task does not block all remaining pending work', () => {
     const rollup = computeWorkflowRollupFromSummaries([
       task('alpha', 'failed'),
       task('independent', 'pending'),
     ]);
 
-    expect(rollup.status).toBe('running');
+    expect(rollup.status).toBe('failed');
+  });
+
+  it('fails a diamond workflow when one ready branch failed and another is still pending', () => {
+    const rollup = computeWorkflowRollupFromSummaries([
+      task('alpha', 'completed'),
+      task('left', 'failed', ['alpha']),
+      task('right', 'pending', ['alpha']),
+      task('merge', 'pending', ['left', 'right']),
+    ]);
+
+    expect(rollup.status).toBe('failed');
   });
 });

--- a/packages/workflow-graph/src/workflow-rollup.ts
+++ b/packages/workflow-graph/src/workflow-rollup.ts
@@ -81,13 +81,13 @@ export function computeWorkflowStatusFromCounts(
   if (total === 0) return 'pending';
 
   if (counts.fixing_with_ai > 0) return 'fixing_with_ai';
+  if (counts.failed > 0) return 'failed';
   if (counts.running > 0) return 'running';
   if (counts.awaiting_approval > 0) return 'awaiting_approval';
   if (counts.review_ready > 0) return 'review_ready';
   if (counts.blocked > 0 || counts.needs_input > 0) return 'blocked';
   if (counts.pending === total) return 'pending';
   if (counts.pending > 0) return 'running';
-  if (counts.failed > 0) return 'failed';
   if (counts.completed > 0 && counts.completed + counts.stale === total) return 'completed';
   if (counts.stale === total) return 'stale';
 

--- a/scripts/bench-workflow-drain-queue.sh
+++ b/scripts/bench-workflow-drain-queue.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOWS="${PROD_SCALE_WORKFLOWS:-24}"
+DRAIN_MS="${PROD_SCALE_DRAIN_MS:-30000}"
+TIMEOUT_SECONDS="${PROD_SCALE_TIMEOUT_SECONDS:-120}"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/bench-workflow-drain-queue.sh [--workflows N] [--drain-ms MS] [--timeout SECONDS]
+
+Runs a synthetic, in-memory workflow mutation drain benchmark. This measures
+workflow_mutation_intents queue wait: started_at - created_at.
+
+The benchmark does not create real workflows, launch task processes, or touch
+the production Invoker DB. It generates a temporary Vitest file, runs it, and
+removes it before exiting.
+
+Examples:
+  scripts/bench-workflow-drain-queue.sh --workflows 24 --drain-ms 30000
+  scripts/bench-workflow-drain-queue.sh --workflows 3 --drain-ms 10
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workflows)
+      WORKFLOWS="${2:-}"
+      shift 2
+      ;;
+    --drain-ms)
+      DRAIN_MS="${2:-}"
+      shift 2
+      ;;
+    --timeout)
+      TIMEOUT_SECONDS="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if ! [[ "$WORKFLOWS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid --workflows value: $WORKFLOWS" >&2
+  exit 1
+fi
+if ! [[ "$DRAIN_MS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid --drain-ms value: $DRAIN_MS" >&2
+  exit 1
+fi
+if ! [[ "$TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  echo "Invalid --timeout value: $TIMEOUT_SECONDS" >&2
+  exit 1
+fi
+
+BENCH_FILE="$ROOT_DIR/packages/app/src/__tests__/workflow-drain-queue-bench.tmp.test.ts"
+
+cleanup() {
+  rm -f "$BENCH_FILE" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+cat > "$BENCH_FILE" <<'TS'
+import { describe, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { PersistedWorkflowMutationCoordinator } from '../persisted-workflow-mutation-coordinator.js';
+
+const workflowCount = Number(process.env.PROD_SCALE_WORKFLOWS ?? 24);
+const drainMs = Number(process.env.PROD_SCALE_DRAIN_MS ?? 30_000);
+const timeoutMs = Number(process.env.PROD_SCALE_TIMEOUT_SECONDS ?? 120) * 1000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function percentile(values: number[], p: number): number {
+  if (values.length === 0) return 0;
+  return values[Math.min(values.length - 1, Math.floor(values.length * p))] ?? 0;
+}
+
+describe('temporary workflow drain queue benchmark', () => {
+  it('prints workflow mutation queue wait metrics', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-workflow-drain-queue-bench',
+      async () => {
+        await sleep(drainMs);
+      },
+    );
+
+    const startedAt = Date.now();
+    const promises: Promise<void>[] = [];
+    for (let index = 1; index <= workflowCount; index += 1) {
+      const workflowId = `wf-bench-${index}`;
+      adapter.saveWorkflow({
+        id: workflowId,
+        name: workflowId,
+        status: 'running',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      promises.push(coordinator.enqueue<void>(workflowId, 'normal', 'bench', [workflowId]));
+    }
+
+    await Promise.all(promises);
+    const elapsedSeconds = (Date.now() - startedAt) / 1000;
+    const rows = (adapter as unknown as {
+      queryAll: (sql: string) => Array<{ queue_wait_seconds: number }>;
+    }).queryAll(`
+      select (julianday(started_at) - julianday(created_at)) * 86400.0 as queue_wait_seconds
+      from workflow_mutation_intents
+      where status = 'completed'
+      order by id asc
+    `);
+    const waits = rows.map((row) => row.queue_wait_seconds).sort((left, right) => left - right);
+    process.stdout.write(
+      [
+        'WORKFLOW_DRAIN_QUEUE_BENCH',
+        `workflows=${workflowCount}`,
+        'cap=none',
+        `drainMs=${drainMs}`,
+        `elapsedSeconds=${elapsedSeconds.toFixed(3)}`,
+        `p50QueueWaitSeconds=${percentile(waits, 0.5).toFixed(3)}`,
+        `p90QueueWaitSeconds=${percentile(waits, 0.9).toFixed(3)}`,
+        `p99QueueWaitSeconds=${percentile(waits, 0.99).toFixed(3)}`,
+        `maxQueueWaitSeconds=${(waits.at(-1) ?? 0).toFixed(3)}`,
+      ].join(' ') + '\n',
+    );
+    adapter.close();
+  }, timeoutMs);
+});
+TS
+
+(
+  cd "$ROOT_DIR"
+  PROD_SCALE_WORKFLOWS="$WORKFLOWS" \
+  PROD_SCALE_DRAIN_MS="$DRAIN_MS" \
+  PROD_SCALE_TIMEOUT_SECONDS="$TIMEOUT_SECONDS" \
+    pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-drain-queue-bench.tmp.test.ts --reporter=verbose
+)

--- a/scripts/e2e-dry-run/cases/case-2.9-diamond-fail.sh
+++ b/scripts/e2e-dry-run/cases/case-2.9-diamond-fail.sh
@@ -19,12 +19,10 @@ invoker_e2e_submit_plan "$INVOKER_E2E_REPO_ROOT/plans/e2e-dry-run/group2-multi-t
 
 invoker_e2e_wait_task_status e2e-g229-taskB failed 180
 
-STA=$(invoker_e2e_task_status e2e-g229-taskA)
-STB=$(invoker_e2e_task_status e2e-g229-taskB)
-STC=$(invoker_e2e_task_status e2e-g229-taskC)
-STD=$(invoker_e2e_task_status e2e-g229-taskD)
-WF_STATUS=$(
-  invoker_e2e_run_headless query workflows --output jsonl 2>/dev/null | python3 -c '
+WF_STATUS=""
+for _ in {1..30}; do
+  WF_STATUS=$(
+    invoker_e2e_run_headless query workflows --output jsonl 2>/dev/null | python3 -c '
 import json, sys
 rows = []
 for line in sys.stdin:
@@ -33,7 +31,17 @@ for line in sys.stdin:
         rows.append(json.loads(line))
 print(rows[-1].get("status", "") if rows else "")
 '
-)
+  )
+  if [ "$WF_STATUS" = "failed" ]; then
+    break
+  fi
+  sleep 1
+done
+
+STA=$(invoker_e2e_task_status e2e-g229-taskA)
+STB=$(invoker_e2e_task_status e2e-g229-taskB)
+STC=$(invoker_e2e_task_status e2e-g229-taskC)
+STD=$(invoker_e2e_task_status e2e-g229-taskD)
 if [ "$STA" != "completed" ] || [ "$STB" != "failed" ] || { [ "$STC" != "pending" ] && [ "$STC" != "completed" ]; } || [ "$STD" != "pending" ] || [ "$WF_STATUS" != "failed" ]; then
   echo "FAIL case 2.9: expected workflow=failed A=completed B=failed C=pending|completed D=pending, got workflow='$WF_STATUS' A='$STA' B='$STB' C='$STC' D='$STD'"
   invoker_e2e_run_headless status 2>&1 || true


### PR DESCRIPTION
Depends-On: #591

## Summary

Adding `throwIfMutationAborted()` before workflow mutations.

## Test Plan

- [x] `node scripts/validate-pr-body.mjs --body-file /tmp/pr-592-body.md`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 337f11bf0c5e461c5c3527321c80e895e4629bae`
- Post-revert steps: None
- Data migration? No
