### PR TITLE
Fix intent cancellation Step 4: durable failure diagnostics (regression gated v2)

### DIFF
--- a/packages/app/src/__tests__/shutdown-diagnostic.test.ts
+++ b/packages/app/src/__tests__/shutdown-diagnostic.test.ts
@@ -57,6 +57,16 @@ describe('persistShutdownDiagnostic', () => {
     expect(output).toContain('error=npm test failed with exit code 1');
   });
 
+  it('includes synthetic terminal error when provided', () => {
+    const task = makeTask({ status: 'running' });
+    const db = makeDb();
+
+    persistShutdownDiagnostic(task, db, { terminalError: 'Application quit' });
+
+    const output = db.appended[0];
+    expect(output).toContain('terminalError=Application quit');
+  });
+
   it('includes exitCode when present', () => {
     const task = makeTask({
       status: 'running',

--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -85,6 +85,7 @@ describe('task-runner-wiring', () => {
     const persistence = {
       updateTask: vi.fn(),
       loadWorkflow: vi.fn(),
+      appendTaskOutput: vi.fn(),
     };
 
     const runner = rebuildTaskRunner({
@@ -123,6 +124,23 @@ describe('task-runner-wiring', () => {
 
     config.callbacks.onOutput('task-1', 'chunk');
     expect(taskRunnerConstructor.mock.calls[0]?.[0].callbacks.onOutput).toBe(config.callbacks.onOutput);
+
+    const startupCause = Object.assign(new Error('ssh boot failed'), {
+      stderr: 'remote stderr line\nconcrete setup failure',
+    });
+    config.callbacks.onLaunchFailed(
+      'task-1',
+      new Error('Executor startup failed (ssh): ssh boot failed', { cause: startupCause }),
+      { type: 'ssh' },
+    );
+    expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
+      'task-1',
+      expect.stringContaining('[Startup Diagnostic]'),
+    );
+    expect(persistence.appendTaskOutput).toHaveBeenCalledWith(
+      'task-1',
+      expect.stringContaining('concrete setup failure'),
+    );
 
     const handle = { executionId: 'exec-1', workspacePath: '/repo/wt', branch: 'feature' };
     const executor = { type: 'worktree' };

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -53,6 +53,42 @@ export function wireTaskRunnerApproveHook(deps: Pick<
   });
 }
 
+const STARTUP_DIAGNOSTIC_TAIL_CHARS = 4_000;
+
+function compactDiagnosticValue(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+  if (trimmed.length <= STARTUP_DIAGNOSTIC_TAIL_CHARS) return trimmed;
+  return `...${trimmed.slice(trimmed.length - STARTUP_DIAGNOSTIC_TAIL_CHARS)}`;
+}
+
+function startupFailureDetail(error: Error, key: 'stderr' | 'stdout'): string | undefined {
+  const direct = compactDiagnosticValue((error as unknown as Record<string, unknown>)[key]);
+  if (direct) return direct;
+  const cause = error.cause as Record<string, unknown> | undefined;
+  return compactDiagnosticValue(cause?.[key]);
+}
+
+function appendStartupFailureDiagnostic(
+  taskId: string,
+  error: Error,
+  executor: Executor,
+  persistence: SQLiteAdapter,
+): void {
+  const parts = [
+    '\n[Startup Diagnostic]',
+    `executor=${executor.type}`,
+    `message=${error.message}`,
+  ];
+  const stderr = startupFailureDetail(error, 'stderr');
+  const stdout = startupFailureDetail(error, 'stdout');
+  if (stderr) parts.push(`--- startup stderr ---\n${stderr}`);
+  if (stdout) parts.push(`--- startup stdout ---\n${stdout}`);
+  parts.push('--- end startup diagnostic ---\n');
+  persistence.appendTaskOutput(taskId, parts.join('\n'));
+}
+
 export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
   const taskRunner = new TaskRunner({
     orchestrator: deps.orchestrator,
@@ -94,6 +130,11 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
       },
       onLaunchFailed: (taskId, error, executor) => {
         deps.assertFatalExecutionCapacity(`launch failed ${taskId}`);
+        try {
+          appendStartupFailureDiagnostic(taskId, error, executor, deps.persistence);
+        } catch {
+          // Best-effort: preserve the original startup failure flow.
+        }
         deps.logger.error(
           `Task "${taskId}" launch failed before spawn (executor: ${executor.type}): ${error.message}`,
           { module: 'exec' },

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1217,7 +1217,7 @@ if (isHeadless) {
       if (ownsHeadlessShutdown && orchestrator) {
         for (const task of orchestrator.getAllTasks()) {
           if (isTaskInFlightForForcedStop(task)) {
-            if (persistence) persistShutdownDiagnostic(task, persistence);
+            if (persistence) persistShutdownDiagnostic(task, persistence, { terminalError: 'Application quit' });
             orchestrator.handleWorkerResponse({
               requestId: `quit-${task.id}`,
               actionId: task.id,
@@ -3970,6 +3970,7 @@ function createEmbeddedTerminalBackendFromConfig(
               if (persistence) {
                 persistShutdownDiagnostic(task, persistence, {
                   flushPendingOutput: flushTaskOutput,
+                  terminalError: 'Application quit',
                 });
               }
               orchestrator.handleWorkerResponse({

--- a/packages/app/src/shutdown-diagnostic.ts
+++ b/packages/app/src/shutdown-diagnostic.ts
@@ -19,7 +19,7 @@ export const SHUTDOWN_DIAGNOSTIC_TAIL_CHARS = 4_000;
 export function persistShutdownDiagnostic(
   task: TaskState,
   db: ShutdownDiagnosticDb,
-  opts?: { flushPendingOutput?: (taskId: string) => void },
+  opts?: { flushPendingOutput?: (taskId: string) => void; terminalError?: string },
 ): void {
   try {
     // Flush any buffered output so the spool is up-to-date.
@@ -34,6 +34,9 @@ export function persistShutdownDiagnostic(
 
     const parts: string[] = ['\n[Shutdown Diagnostic]'];
     parts.push(`status=${task.status}`);
+    if (opts?.terminalError) {
+      parts.push(`terminalError=${opts.terminalError}`);
+    }
     if (task.execution.error) {
       parts.push(`error=${task.execution.error}`);
     }

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1978,7 +1978,7 @@ describe('SQLiteAdapter', () => {
       }
     });
 
-    it('prefers output_spool chunks over task_output rows when both exist', async () => {
+    it('returns output_spool chunks plus file-backed diagnostics while ignoring legacy duplicate rows', async () => {
       const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-output-prefer-spool-'));
       const dbPath = join(dir, 'invoker.db');
 
@@ -1997,8 +1997,11 @@ describe('SQLiteAdapter', () => {
         // Canonical spool data is what should be returned.
         db.appendOutputChunk('t-both', 'spool line 1\n');
         db.appendOutputChunk('t-both', 'spool line 2\n');
+        db.appendTaskOutput('t-both', '\n[Shutdown Diagnostic]\nterminalError=Application quit\n');
 
-        expect(db.getTaskOutput('t-both')).toBe('spool line 1\nspool line 2\n');
+        expect(db.getTaskOutput('t-both')).toBe(
+          'spool line 1\nspool line 2\n\n[Shutdown Diagnostic]\nterminalError=Application quit\n',
+        );
 
         db.close();
       } finally {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -2184,12 +2184,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   getTaskOutput(taskId: string): string {
     // Prefer the output spool (DB + file) when it has any chunks for this task —
-    // it is the canonical streaming-output store. Otherwise fall back to
-    // task_output (legacy DB rows + diagnostic file), which avoids returning a
-    // duplicated stream when both stores contain the same data.
+    // it is the canonical streaming-output store. File-backed task output is
+    // appended because new diagnostic writes (startup/shutdown/autofix) live
+    // there and should remain visible after persisted retrieval. Legacy
+    // task_output rows are still only used as a fallback to avoid returning
+    // duplicated historical streams.
     const spoolChunks = this.getOutputChunks(taskId);
     if (spoolChunks.length > 0) {
-      return spoolChunks.map((chunk) => chunk.data).join('');
+      return spoolChunks.map((chunk) => chunk.data).join('') + this.readTaskOutputFile(taskId);
     }
     const rows = this.queryAll(
       'SELECT data FROM task_output WHERE task_id = ? ORDER BY id ASC',


### PR DESCRIPTION
## Summary

Preserves concrete startup failure tails and forced-shutdown diagnostics in durable task output.

Startup failures now append executor, message, stdout, and stderr details through the durable output path read by the UI and API.

Forced shutdown diagnostics include the synthetic terminal error, and persisted retrieval combines spool output with file-backed diagnostics.

## Architecture

### Before

```mermaid
graph TD
    A[Executor startup failure] --> B[Launch failed callback]
    B --> C[Log failure]
    B --> D[Failed task response]
    D --> E[Later durable inspection]
    E --> F[Generic terminal error only]
    G[Forced shutdown] --> H[Shutdown diagnostic]
    H --> I[Task output file]
    J[getTaskOutput with spool chunks] --> K[Return spool chunks only]
```

### After

```mermaid
graph TD
    A[Executor startup failure] --> B[Launch failed callback]
    B --> C[appendTaskOutput startup diagnostic]
    C --> D[Task output file]
    B --> E[Existing failed task response]
    F[Forced shutdown] --> G[persistShutdownDiagnostic with terminal error]
    G --> D
    H[getTaskOutput] --> I[Spool chunks plus task output file]
    I --> J[UI and API durable output]
```

## Test Plan

- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert -m 1 6c19dae98623a3278865090a37f2598212c753ae`
- Post-revert steps: Re-run `pnpm run test:all`
- Data migration? No