### PR TITLE
Restore root pnpm lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "check:required-builds": "bash scripts/required-builds.sh",
     "check:deps": "depcruise packages --config .dependency-cruiser.js",
     "check:types": "tsc -p tsconfig.typecheck.json",
-    "check:all": "pnpm run check:deps && pnpm run check:types && pnpm run check:required-builds && bash scripts/check-owner-boundary.sh"
+    "check:all": "pnpm run check:deps && pnpm run check:types && pnpm run check:required-builds && bash scripts/check-owner-boundary.sh",
+    "lint": "pnpm run check:all"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
## Summary

Restore the root `pnpm lint` command as an alias for the existing `pnpm run check:all` pipeline.

This keeps historical and generated verification lanes that call `pnpm lint` working while preserving the current repository check surface.

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm lint`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 5e75062c`
- Post-revert steps: Update any workflow or task lanes that still call `pnpm lint` to use `pnpm run check:all`
- Data migration? No
