### PR TITLE
Persist SSH pool member selection

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -7947,6 +7947,7 @@ console.log(JSON.stringify(out));
         branch: 'experiment/task-1',
       });
       const logEvent = vi.fn();
+      const updateTask = vi.fn();
       const task = makeTask({
         id: 'task-1',
         status: 'pending',
@@ -7956,7 +7957,7 @@ console.log(JSON.stringify(out));
 
       const runner = new TaskRunner({
         orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse: vi.fn() } as any,
-        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent } as any,
+        persistence: { updateTask, updateAttempt: vi.fn(), logEvent } as any,
         executorRegistry: {
           getDefault: () => sshExecutor,
           get: (type: string) => type === 'ssh' ? sshExecutor : null,
@@ -8000,6 +8001,16 @@ console.log(JSON.stringify(out));
       const selectedPayload = logEvent.mock.calls.find((call) => call[1] === 'task.executor.selected')?.[2];
       expect(JSON.stringify(selectedPayload)).not.toContain('sshKeyPath');
       expect(JSON.stringify(selectedPayload)).not.toContain('/secret/key');
+      expect(updateTask).toHaveBeenCalledWith('task-1', expect.objectContaining({
+        config: expect.objectContaining({
+          runnerKind: 'ssh',
+          poolMemberId: 'remote-a',
+        }),
+        execution: expect.objectContaining({
+          workspacePath: '/remote/worktrees/task-1',
+          branch: 'experiment/task-1',
+        }),
+      }));
     });
 
     it('logs explicit SSH executor selection as explicitPoolMemberId', async () => {
@@ -8036,6 +8047,77 @@ console.log(JSON.stringify(out));
         poolMemberId: 'remote-b',
         remoteHost: 'dev.example.com',
         remoteUser: 'dev',
+      }));
+    });
+
+    it('persists pool member metadata for current pool-routed SSH startup failures', async () => {
+      const startupError = Object.assign(new Error('provision failed'), {
+        workspacePath: '/remote/worktrees/task-start-fail',
+        branch: 'experiment/task-start-fail',
+      });
+      const sshExecutor = {
+        type: 'ssh',
+        start: vi.fn(async () => {
+          throw startupError;
+        }),
+        onComplete: vi.fn(),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+        destroyAll: vi.fn(),
+      };
+      const updateTask = vi.fn();
+      const task = makeTask({
+        id: 'task-start-fail',
+        status: 'pending',
+        config: { command: 'pnpm test', runnerKind: 'ssh', poolId: 'ci-pool' },
+        execution: { selectedAttemptId: 'attempt-start-fail', phase: 'launching' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: () => task,
+          getAllTasks: () => [task],
+          handleWorkerResponse: vi.fn(),
+        } as any,
+        persistence: {
+          updateTask,
+          updateAttempt: vi.fn(),
+          appendTaskOutput: vi.fn(),
+          logEvent: vi.fn(),
+        } as any,
+        executorRegistry: {
+          getDefault: () => sshExecutor,
+          get: (type: string) => type === 'ssh' ? sshExecutor : null,
+          getAll: () => [sshExecutor],
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          'ci-pool': {
+            selectionStrategy: 'leastLoaded',
+            members: [{ type: 'ssh', id: 'remote-a' }],
+          },
+        }),
+        remoteTargetsProvider: () => ({
+          'remote-a': {
+            host: 'ci.example.com',
+            user: 'runner',
+            sshKeyPath: '/secret/key',
+          },
+        }),
+      });
+
+      await runner.executeTask(task);
+
+      expect(updateTask).toHaveBeenCalledWith('task-start-fail', expect.objectContaining({
+        config: expect.objectContaining({
+          runnerKind: 'ssh',
+          poolMemberId: 'remote-a',
+        }),
+        execution: expect.objectContaining({
+          workspacePath: '/remote/worktrees/task-start-fail',
+          branch: 'experiment/task-start-fail',
+        }),
       }));
     });
 
@@ -8220,7 +8302,7 @@ console.log(JSON.stringify(out));
 
       // Check that metadata was persisted immediately after start
       expect(updateSpy).toHaveBeenCalledWith('ssh-task-1', {
-        config: { runnerKind: 'ssh' },
+        config: { runnerKind: 'ssh', poolMemberId: 'remote-1' },
         execution: {
           workspacePath: '~/.invoker/worktrees/abc123/experiment-ssh-task-1-def456',
           branch: 'experiment/ssh-task-1-def456',

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -598,6 +598,10 @@ export class TaskRunner {
       `${RESTART_TO_BRANCH_TRACE} executeTaskInner taskId=${task.id} WorkRequest built actionType=${request.actionType} repoUrl=${request.inputs.repoUrl ?? '(none)'} upstreamBranches=${JSON.stringify(request.inputs.upstreamBranches ?? [])}`,
     );
     const executor = this.selectExecutor(task);
+    const poolSelectionForStart = this.pendingPoolSelections.get(task.id);
+    const selectedSshPoolMemberId = executor.type === 'ssh'
+      ? this.selectedRemoteTargetId(task, poolSelectionForStart)
+      : undefined;
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} executeTaskInner taskId=${task.id} selectExecutor → type=${executor.type} calling executor.start()`,
     );
@@ -651,7 +655,10 @@ export class TaskRunner {
         }
         if (meta.containerId) execution.containerId = meta.containerId;
         this.persistence.updateTask(task.id, {
-          config: { runnerKind: executor.type as RunnerKind },
+          config: {
+            runnerKind: executor.type as RunnerKind,
+            ...(selectedSshPoolMemberId ? { poolMemberId: selectedSshPoolMemberId } : {}),
+          },
           execution: execution as any,
         });
       }
@@ -697,11 +704,14 @@ export class TaskRunner {
         executor,
         handle,
         attemptId,
-        this.pendingPoolSelections.get(task.id),
+        poolSelectionForStart,
       );
 
       const changes = {
-        config: { runnerKind: executor.type as RunnerKind },
+        config: {
+          runnerKind: executor.type as RunnerKind,
+          ...(selectedSshPoolMemberId ? { poolMemberId: selectedSshPoolMemberId } : {}),
+        },
         execution: {
           workspacePath: handle.workspacePath,
           branch: handle.branch ?? undefined,  // Explicit undefined when branch is not applicable (e.g., BYO mode)
@@ -742,7 +752,7 @@ export class TaskRunner {
     // Notify consumer about the spawned handle
     const activeHandle = handle as ActiveExecutionHandle;
     activeHandle.attemptId = attemptId;
-    const poolSelection = this.pendingPoolSelections.get(task.id);
+    const poolSelection = poolSelectionForStart;
     this.pendingPoolSelections.delete(task.id);
     this.activeExecutions.set(attemptId, {
       handle: activeHandle,

--- a/scripts/repro/repro-ssh-pool-member-persistence.sh
+++ b/scripts/repro/repro-ssh-pool-member-persistence.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TEST_FILE="$ROOT/packages/execution-engine/src/__tests__/ssh-pool-member-persistence.repro.test.ts"
+
+cleanup() {
+  rm -f "$TEST_FILE"
+}
+trap cleanup EXIT
+
+cat > "$TEST_FILE" <<'TS'
+import { describe, expect, it, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import type { TaskState } from '@invoker/workflow-core';
+import type { WorkResponse } from '@invoker/contracts';
+
+function makeTask(): TaskState {
+  return {
+    id: 'pool-task',
+    description: 'Pool-routed SSH task',
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'echo hi', runnerKind: 'ssh', poolId: 'ci-pool' },
+    execution: { selectedAttemptId: 'attempt-pool-task' },
+  } as TaskState;
+}
+
+describe('ssh pool member persistence repro', () => {
+  it('persists the concrete pool member selected for a pool-routed SSH start', async () => {
+    const task = makeTask();
+    let complete: ((response: WorkResponse) => void) | undefined;
+    const sshExecutor = {
+      type: 'ssh',
+      start: vi.fn(async (request: any) => ({
+        executionId: `exec-${request.actionId}`,
+        taskId: request.actionId,
+        workspacePath: '/remote/worktrees/pool-task',
+        branch: 'experiment/pool-task',
+      })),
+      onComplete: vi.fn((_handle: any, cb: (response: WorkResponse) => void) => {
+        complete = cb;
+      }),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+    const updateTask = vi.fn();
+    const logEvent = vi.fn();
+    const runner = new TaskRunner({
+      orchestrator: {
+        getTask: () => task,
+        getAllTasks: () => [task],
+        markTaskRunningAfterLaunch: () => true,
+        handleWorkerResponse: vi.fn(),
+      } as any,
+      persistence: {
+        updateTask,
+        updateAttempt: vi.fn(),
+        logEvent,
+      } as any,
+      executorRegistry: {
+        getDefault: () => sshExecutor,
+        get: (type: string) => type === 'ssh' ? sshExecutor : null,
+        getAll: () => [sshExecutor],
+      } as any,
+      cwd: '/tmp',
+      executionPoolsProvider: () => ({
+        'ci-pool': {
+          selectionStrategy: 'leastLoaded',
+          members: [{ type: 'ssh', id: 'remote-a' }],
+        },
+      }),
+      remoteTargetsProvider: () => ({
+        'remote-a': {
+          host: 'ci.example.com',
+          user: 'runner',
+          sshKeyPath: '/tmp/fake-key',
+        },
+      }),
+    });
+
+    const run = runner.executeTask(task);
+    await vi.waitFor(() => expect(complete).toBeDefined());
+    complete?.({
+      requestId: 'req-1',
+      actionId: task.id,
+      attemptId: 'attempt-pool-task',
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    });
+    await run;
+
+    const selected = logEvent.mock.calls.find((call) => call[1] === 'task.executor.selected')?.[2];
+    expect(selected).toEqual(expect.objectContaining({ poolMemberId: 'remote-a' }));
+
+    const metadataWrite = updateTask.mock.calls.find((call) => (
+      call[0] === 'pool-task'
+      && call[1]?.execution?.workspacePath === '/remote/worktrees/pool-task'
+    ))?.[1];
+    if (metadataWrite?.config?.poolMemberId !== 'remote-a') {
+      throw new Error(
+        `pool member not persisted: selected=${selected?.poolMemberId ?? 'missing'} ` +
+        `persisted=${metadataWrite?.config?.poolMemberId ?? 'missing'}`,
+      );
+    }
+  });
+});
+TS
+
+cd "$ROOT"
+pnpm --filter @invoker/execution-engine exec vitest run "$TEST_FILE"


### PR DESCRIPTION
## Summary

Persist the concrete SSH pool member selected for pool-routed task launches so later recovery and `fixWithAgent` flows can reconnect to the machine that owns the remote workspace.

This keeps `poolId` as the scheduling route while recording `poolMemberId` as launch-time ownership metadata. It also adds a focused repro script that fails on the old behavior and passes after the fix.

## Architecture

### Before

```mermaid
graph TD
    A[Pool-routed SSH task] --> B[selectExecutor chooses remote-a]
    B --> C[executor.start creates remote workspace]
    C --> D[Task metadata persists runnerKind/workspace/branch]
    B --> E[Selection event logs poolMemberId]
    D --> F[Later fix flow lacks concrete remote target]
```

### After

```mermaid
graph TD
    A[Pool-routed SSH task] --> B[selectExecutor chooses remote-a]
    B --> C[TaskRunner captures selected remote target]
    C --> D[executor.start creates remote workspace]
    D --> E[Task metadata persists runnerKind/poolMemberId/workspace/branch]
    E --> F[Later fix flow can reconnect to owning remote target]
```

## Test Plan

- [x] `scripts/repro/repro-ssh-pool-member-persistence.sh` (confirmed pre-fix failure: `pool member not persisted: selected=remote-a persisted=missing`)
- [x] `scripts/repro/repro-ssh-pool-member-persistence.sh`
- [x] `pnpm --filter @invoker/execution-engine test`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0858bf67`
- Post-revert steps: None
- Data migration? No
