### PR TITLE
Stack disconnected workflow graph components

### DIFF
--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -44,6 +44,8 @@ export interface WorkflowMeta {
   mergeMode?: string;
   repoUrl?: string;
   intermediateRepoUrl?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export interface WorkflowStatus {

--- a/packages/ui/src/lib/workflow-graph.test.ts
+++ b/packages/ui/src/lib/workflow-graph.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import type { TaskState, WorkflowMeta } from '../types.js';
-import { deriveWorkflowGraph } from './workflow-graph.js';
+import { deriveWorkflowGraph, layoutWorkflowGraph, type WorkflowGraph } from './workflow-graph.js';
 
-function makeWorkflow(id: string, status: WorkflowMeta['status'] = 'running'): WorkflowMeta {
-  return { id, name: id, status };
+function makeWorkflow(
+  id: string,
+  status: WorkflowMeta['status'] = 'running',
+  createdAt?: string,
+): WorkflowMeta {
+  return { id, name: id, status, createdAt };
 }
 
 function makeTask(
@@ -94,3 +98,136 @@ describe('deriveWorkflowGraph', () => {
     expect(graph.edges).toEqual([]);
   });
 });
+
+describe('layoutWorkflowGraph', () => {
+  it('places a standalone workflow component in its own row band', () => {
+    const graph = makeGraph(
+      [
+        makeWorkflow('chain-a', 'running', '2026-01-01T00:00:00.000Z'),
+        makeWorkflow('chain-b', 'running', '2026-01-01T00:00:00.000Z'),
+        makeWorkflow('solo', 'running', '2026-02-01T00:00:00.000Z'),
+      ],
+      [{ source: 'chain-a', target: 'chain-b' }],
+    );
+
+    const positions = layoutWorkflowGraph(graph, 100, 50, 25);
+
+    expect(positions.get('solo')).toEqual({ x: 80, y: 80 });
+    expect(positions.get('chain-a')?.y).toBe(155);
+    expect(positions.get('chain-b')?.y).toBe(155);
+  });
+
+  it('stacks disconnected chain components without overlapping rows', () => {
+    const graph = makeGraph(
+      [
+        makeWorkflow('older-a', 'running', '2026-01-01T00:00:00.000Z'),
+        makeWorkflow('older-b', 'running', '2026-01-01T00:00:00.000Z'),
+        makeWorkflow('newer-a', 'running', '2026-03-01T00:00:00.000Z'),
+        makeWorkflow('newer-b', 'running', '2026-03-01T00:00:00.000Z'),
+      ],
+      [
+        { source: 'older-a', target: 'older-b' },
+        { source: 'newer-a', target: 'newer-b' },
+      ],
+    );
+
+    const positions = layoutWorkflowGraph(graph, 100, 50, 25);
+
+    expect(positions.get('newer-a')).toEqual({ x: 80, y: 80 });
+    expect(positions.get('newer-b')).toEqual({ x: 180, y: 80 });
+    expect(positions.get('older-a')).toEqual({ x: 80, y: 155 });
+    expect(positions.get('older-b')).toEqual({ x: 180, y: 155 });
+  });
+
+  it('orders components newest-created first', () => {
+    const graph = makeGraph(
+      [
+        makeWorkflow('old', 'running', '2026-01-01T00:00:00.000Z'),
+        makeWorkflow('new', 'running', '2026-04-01T00:00:00.000Z'),
+        makeWorkflow('middle', 'running', '2026-02-01T00:00:00.000Z'),
+      ],
+      [],
+    );
+
+    const positions = layoutWorkflowGraph(graph, 100, 50, 25);
+
+    expect(positions.get('new')?.y).toBe(80);
+    expect(positions.get('middle')?.y).toBe(155);
+    expect(positions.get('old')?.y).toBe(230);
+  });
+
+  it('reserves component height from the widest dependency level', () => {
+    const graph = makeGraph(
+      [
+        makeWorkflow('root', 'running', '2026-03-01T00:00:00.000Z'),
+        makeWorkflow('left', 'running', '2026-03-01T00:00:00.000Z'),
+        makeWorkflow('middle', 'running', '2026-03-01T00:00:00.000Z'),
+        makeWorkflow('right', 'running', '2026-03-01T00:00:00.000Z'),
+        makeWorkflow('older', 'running', '2026-01-01T00:00:00.000Z'),
+      ],
+      [
+        { source: 'root', target: 'left' },
+        { source: 'root', target: 'middle' },
+        { source: 'root', target: 'right' },
+      ],
+    );
+
+    const positions = layoutWorkflowGraph(graph, 100, 50, 25);
+
+    expect(positions.get('left')?.y).toBe(80);
+    expect(positions.get('middle')?.y).toBe(130);
+    expect(positions.get('right')?.y).toBe(180);
+    expect(positions.get('older')?.y).toBe(255);
+  });
+
+  it('keeps crossing-prone disconnected workflows in separate row groups', () => {
+    const graph = makeGraph(
+      [
+        makeWorkflow('fix-step-1', 'running', '2026-01-01T00:00:00.000Z'),
+        makeWorkflow('fix-step-2', 'running', '2026-01-01T00:00:00.000Z'),
+        { ...makeWorkflow('cost-query', 'running', '2026-02-01T00:00:00.000Z'), name: 'Cost Query' },
+      ],
+      [{ source: 'fix-step-1', target: 'fix-step-2' }],
+    );
+
+    const positions = layoutWorkflowGraph(graph, 100, 50, 25);
+
+    expect(positions.get('cost-query')?.y).toBe(80);
+    expect(positions.get('fix-step-1')?.y).toBe(155);
+    expect(positions.get('fix-step-2')?.y).toBe(155);
+  });
+
+  it('orders nodes inside a component by adjacent-level barycenter', () => {
+    const graph = makeGraph(
+      [
+        makeWorkflow('a-root'),
+        makeWorkflow('b-root'),
+        makeWorkflow('x-target'),
+        makeWorkflow('y-target'),
+        makeWorkflow('z-join'),
+      ],
+      [
+        { source: 'a-root', target: 'y-target' },
+        { source: 'b-root', target: 'x-target' },
+        { source: 'x-target', target: 'z-join' },
+        { source: 'y-target', target: 'z-join' },
+      ],
+    );
+
+    const positions = layoutWorkflowGraph(graph, 100, 50, 25);
+
+    expect(positions.get('y-target')).toEqual({ x: 180, y: 80 });
+    expect(positions.get('x-target')).toEqual({ x: 180, y: 130 });
+  });
+});
+
+function makeGraph(
+  workflows: WorkflowMeta[],
+  edges: WorkflowGraph['edges'],
+): WorkflowGraph {
+  return {
+    nodes: workflows.map((workflow) => ({ id: workflow.id, name: workflow.name, workflow })),
+    edges,
+    missingDependencies: [],
+  };
+}

--- a/packages/ui/src/lib/workflow-graph.ts
+++ b/packages/ui/src/lib/workflow-graph.ts
@@ -65,31 +65,139 @@ export function layoutWorkflowGraph(
   graph: WorkflowGraph,
   horizontalSpacing = 280,
   verticalSpacing = 150,
+  componentGap = 120,
 ): Map<string, WorkflowPosition> {
   const positions = new Map<string, WorkflowPosition>();
   if (graph.nodes.length === 0) return positions;
 
-  const indegree = new Map<string, number>();
-  const outgoing = new Map<string, string[]>();
-  const level = new Map<string, number>();
-
-  for (const node of graph.nodes) {
-    indegree.set(node.id, 0);
-    outgoing.set(node.id, []);
-  }
+  const nodesById = new Map(graph.nodes.map((node) => [node.id, node]));
+  const outgoing = createNodeMap<string[]>(graph.nodes, []);
+  const incoming = createNodeMap<string[]>(graph.nodes, []);
+  const weakAdjacency = createNodeMap<string[]>(graph.nodes, []);
 
   for (const edge of graph.edges) {
-    indegree.set(edge.target, (indegree.get(edge.target) ?? 0) + 1);
+    if (!nodesById.has(edge.source) || !nodesById.has(edge.target)) continue;
     outgoing.get(edge.source)?.push(edge.target);
+    incoming.get(edge.target)?.push(edge.source);
+    weakAdjacency.get(edge.source)?.push(edge.target);
+    weakAdjacency.get(edge.target)?.push(edge.source);
   }
 
-  const queue: string[] = graph.nodes
+  const components = findWorkflowComponents(graph.nodes, weakAdjacency)
+    .sort((a, b) => compareComponentsNewestFirst(a, b));
+
+  let componentYOffset = 80;
+  for (const component of components) {
+    const componentIds = new Set(component.map((node) => node.id));
+    const levels = assignDependencyLevels(component, outgoing, componentIds);
+    const orderedLevels = orderComponentLevels(component, levels, incoming, outgoing);
+    const maxRows = Math.max(1, ...[...orderedLevels.values()].map((nodes) => nodes.length));
+
+    for (const [nodeLevel, nodes] of orderedLevels.entries()) {
+      nodes.forEach((node, index) => {
+        positions.set(node.id, {
+          x: 80 + nodeLevel * horizontalSpacing,
+          y: componentYOffset + index * verticalSpacing,
+        });
+      });
+    }
+
+    componentYOffset += maxRows * verticalSpacing + componentGap;
+  }
+
+  return positions;
+}
+
+function createNodeMap<T>(nodes: WorkflowGraphNode[], initialValue: T): Map<string, T> {
+  const map = new Map<string, T>();
+  for (const node of nodes) {
+    map.set(node.id, Array.isArray(initialValue) ? ([...initialValue] as T) : initialValue);
+  }
+  return map;
+}
+
+function findWorkflowComponents(
+  nodes: WorkflowGraphNode[],
+  weakAdjacency: Map<string, string[]>,
+): WorkflowGraphNode[][] {
+  const nodesById = new Map(nodes.map((node) => [node.id, node]));
+  const visited = new Set<string>();
+  const components: WorkflowGraphNode[][] = [];
+
+  for (const node of nodes) {
+    if (visited.has(node.id)) continue;
+    const component: WorkflowGraphNode[] = [];
+    const queue = [node.id];
+    visited.add(node.id);
+
+    while (queue.length > 0) {
+      const current = queue.shift()!;
+      const currentNode = nodesById.get(current);
+      if (currentNode) component.push(currentNode);
+      for (const next of weakAdjacency.get(current) ?? []) {
+        if (visited.has(next)) continue;
+        visited.add(next);
+        queue.push(next);
+      }
+      queue.sort(compareIds);
+    }
+
+    components.push(component.sort(compareNodesByNameId));
+  }
+
+  return components;
+}
+
+function compareComponentsNewestFirst(a: WorkflowGraphNode[], b: WorkflowGraphNode[]): number {
+  const aTimestamp = componentTimestamp(a);
+  const bTimestamp = componentTimestamp(b);
+  if (aTimestamp !== bTimestamp) return bTimestamp - aTimestamp;
+  return componentSortKey(a).localeCompare(componentSortKey(b));
+}
+
+function componentTimestamp(nodes: WorkflowGraphNode[]): number {
+  const timestamps = nodes
+    .map((node) => parseWorkflowTimestamp(node.workflow.createdAt))
+    .filter((timestamp) => timestamp !== null);
+  return timestamps.length > 0 ? Math.max(...timestamps) : Number.NEGATIVE_INFINITY;
+}
+
+function parseWorkflowTimestamp(value: string | undefined): number | null {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function componentSortKey(nodes: WorkflowGraphNode[]): string {
+  return [...nodes]
+    .sort(compareNodesByNameId)
+    .map((node) => `${node.name}\u0000${node.id}`)
+    .join('\u0001');
+}
+
+function assignDependencyLevels(
+  nodes: WorkflowGraphNode[],
+  outgoing: Map<string, string[]>,
+  componentIds: Set<string>,
+): Map<string, number> {
+  const indegree = new Map<string, number>();
+  const level = new Map<string, number>();
+
+  for (const node of nodes) indegree.set(node.id, 0);
+  for (const node of nodes) {
+    for (const target of outgoing.get(node.id) ?? []) {
+      if (!componentIds.has(target)) continue;
+      indegree.set(target, (indegree.get(target) ?? 0) + 1);
+    }
+  }
+
+  const queue = nodes
     .map((node) => node.id)
     .filter((id) => (indegree.get(id) ?? 0) === 0)
-    .sort();
+    .sort(compareIds);
 
   if (queue.length === 0) {
-    for (const node of graph.nodes) queue.push(node.id);
+    for (const node of nodes) queue.push(node.id);
   }
 
   const visited = new Set<string>();
@@ -99,35 +207,91 @@ export function layoutWorkflowGraph(
     visited.add(current);
     const currentLevel = level.get(current) ?? 0;
     for (const target of outgoing.get(current) ?? []) {
+      if (!componentIds.has(target)) continue;
       const nextLevel = Math.max(level.get(target) ?? 0, currentLevel + 1);
       level.set(target, nextLevel);
       indegree.set(target, (indegree.get(target) ?? 0) - 1);
       if ((indegree.get(target) ?? 0) <= 0) queue.push(target);
     }
-    queue.sort();
+    queue.sort(compareIds);
   }
 
-  for (const node of graph.nodes) {
+  for (const node of nodes) {
     if (!level.has(node.id)) level.set(node.id, 0);
   }
 
+  return level;
+}
+
+function orderComponentLevels(
+  nodes: WorkflowGraphNode[],
+  level: Map<string, number>,
+  incoming: Map<string, string[]>,
+  outgoing: Map<string, string[]>,
+): Map<number, WorkflowGraphNode[]> {
   const byLevel = new Map<number, WorkflowGraphNode[]>();
-  for (const node of graph.nodes) {
+  for (const node of nodes) {
     const nodeLevel = level.get(node.id) ?? 0;
     const bucket = byLevel.get(nodeLevel) ?? [];
     bucket.push(node);
     byLevel.set(nodeLevel, bucket);
   }
 
-  for (const [nodeLevel, nodes] of byLevel.entries()) {
-    nodes.sort((a, b) => a.name.localeCompare(b.name));
-    nodes.forEach((node, index) => {
-      positions.set(node.id, {
-        x: 80 + nodeLevel * horizontalSpacing,
-        y: 80 + index * verticalSpacing,
-      });
-    });
+  const levelNumbers = [...byLevel.keys()].sort((a, b) => a - b);
+  for (const nodeLevel of levelNumbers) {
+    byLevel.get(nodeLevel)?.sort(compareNodesByNameId);
   }
 
-  return positions;
+  for (let iteration = 0; iteration < 4; iteration += 1) {
+    for (const nodeLevel of levelNumbers) {
+      sortLevelByBarycenter(byLevel, nodeLevel, incoming.get.bind(incoming));
+    }
+    for (const nodeLevel of [...levelNumbers].reverse()) {
+      sortLevelByBarycenter(byLevel, nodeLevel, outgoing.get.bind(outgoing));
+    }
+  }
+
+  return new Map(levelNumbers.map((nodeLevel) => [nodeLevel, byLevel.get(nodeLevel) ?? []]));
+}
+
+function sortLevelByBarycenter(
+  byLevel: Map<number, WorkflowGraphNode[]>,
+  nodeLevel: number,
+  getNeighborIds: (id: string) => string[] | undefined,
+): void {
+  const nodes = byLevel.get(nodeLevel);
+  if (!nodes || nodes.length <= 1) return;
+
+  const originalIndex = new Map(nodes.map((node, index) => [node.id, index]));
+  const indexById = new Map<string, number>();
+  for (const levelNodes of byLevel.values()) {
+    levelNodes.forEach((node, index) => indexById.set(node.id, index));
+  }
+
+  nodes.sort((a, b) => {
+    const aBarycenter = barycenter(a.id, getNeighborIds, indexById);
+    const bBarycenter = barycenter(b.id, getNeighborIds, indexById);
+    if (aBarycenter !== bBarycenter) return aBarycenter - bBarycenter;
+    return (originalIndex.get(a.id) ?? 0) - (originalIndex.get(b.id) ?? 0) || compareNodesByNameId(a, b);
+  });
+}
+
+function barycenter(
+  nodeId: string,
+  getNeighborIds: (id: string) => string[] | undefined,
+  indexById: Map<string, number>,
+): number {
+  const neighborIndexes = (getNeighborIds(nodeId) ?? [])
+    .map((neighborId) => indexById.get(neighborId))
+    .filter((index): index is number => index !== undefined);
+  if (neighborIndexes.length === 0) return Number.POSITIVE_INFINITY;
+  return neighborIndexes.reduce((sum, index) => sum + index, 0) / neighborIndexes.length;
+}
+
+function compareNodesByNameId(a: WorkflowGraphNode, b: WorkflowGraphNode): number {
+  return a.name.localeCompare(b.name) || compareIds(a.id, b.id);
+}
+
+function compareIds(a: string, b: string): number {
+  return a.localeCompare(b);
 }

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -161,6 +161,8 @@ export interface WorkflowMeta {
   repoUrl?: string;
   intermediateRepoUrl?: string;
   reviewProvider?: string;
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 export type WorkflowStatus =


### PR DESCRIPTION
## Summary

Lay out disconnected workflow DAGs as separate vertical component bands so unrelated workflows no longer share rows or edge lanes.

Order components newest-first by workflow `createdAt`, preserve dependency-depth columns within each component, and use barycenter sorting within levels to reduce crossings while keeping deterministic fallbacks.

Add optional workflow timestamp fields to the UI and IPC `WorkflowMeta` types so renderer layout can use snapshot creation times when present.

## Architecture

### Before

```mermaid
graph TD
    Graph[Workflow graph]
    Global[Global dependency-depth levels]
    Rows[Alphabetical rows shared by all workflows]
    Graph --> Global --> Rows
```

### After

```mermaid
graph TD
    Graph[Workflow graph]
    Components[Weakly connected workflow components]
    Ordered[Newest-first component stack]
    Levels[Per-component dependency-depth levels]
    Rows[Barycenter-ordered rows inside each component]
    Graph --> Components --> Ordered --> Levels --> Rows
```

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/lib/workflow-graph.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-graph.test.tsx`
- [x] `pnpm --filter @invoker/ui build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 662761b3bfbfc0bcfe3d38a041d2ba7ddda639a0`
- Post-revert steps: None
- Data migration? No
