### PR TITLE
Fix launch prestart tracking

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1515,6 +1515,10 @@ if (isHeadless) {
         onOutput: (taskId, data) => {
           enqueueTaskOutput(taskId, data);
         },
+        onLaunchAccepted: (taskId) => {
+          launchingTasks.add(taskId);
+          logger.info(`Task "${taskId}" launch accepted by TaskRunner`, { module: 'exec' });
+        },
         onLaunchStart: (taskId, executor) => {
           launchingTasks.add(taskId);
           logger.info(`Task "${taskId}" launch started (executor: ${executor.type})`, { module: 'exec' });
@@ -1563,6 +1567,9 @@ if (isHeadless) {
             `Heartbeat for "${taskId}" (status: ${task?.status ?? 'unknown'}, generation: ${task?.execution.generation ?? 'unknown'}, gapMs: ${heartbeatGapMs ?? 'first'})`,
             { module: 'heartbeat' },
           );
+        },
+        onLaunchSettled: (taskId) => {
+          launchingTasks.delete(taskId);
         },
       },
     });

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1709,6 +1709,87 @@ describe('TaskRunner', () => {
   });
 
   describe('launch timeout repro', () => {
+    it('marks launch accepted while building upstream context before executor start', async () => {
+      let releaseUpstreamContext!: () => void;
+      const upstreamContextBlocked = new Promise<void>((resolve) => {
+        releaseUpstreamContext = resolve;
+      });
+      let completeCallback: ((response: WorkResponse) => void) | undefined;
+      const onLaunchAccepted = vi.fn();
+      const onLaunchStart = vi.fn();
+      const onLaunchSettled = vi.fn();
+      const handleWorkerResponse = vi.fn(() => []);
+      const task = makeTask({
+        id: 'preparing-before-start',
+        status: 'running',
+        config: { command: 'echo hello' },
+        execution: { selectedAttemptId: 'preparing-before-start-a1' },
+      });
+      const executor = {
+        type: 'worktree',
+        start: vi.fn(async () => ({
+          executionId: 'exec-preparing-before-start',
+          taskId: task.id,
+          workspacePath: '/tmp/preparing-before-start',
+          branch: 'experiment/preparing-before-start',
+        })),
+        onOutput: vi.fn(),
+        onComplete: vi.fn((_handle: any, cb: (response: WorkResponse) => void) => {
+          completeCallback = cb;
+        }),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+        destroyAll: vi.fn(),
+      };
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: () => task,
+          markTaskRunningAfterLaunch: vi.fn(() => true),
+          handleWorkerResponse,
+        } as any,
+        persistence: {
+          loadWorkflow: vi.fn(),
+          updateTask: vi.fn(),
+          updateAttempt: vi.fn(),
+          logEvent: vi.fn(),
+        } as any,
+        executorRegistry: {
+          getDefault: () => executor,
+          get: () => executor,
+          getAll: () => [executor],
+        } as any,
+        cwd: '/tmp',
+        callbacks: { onLaunchAccepted, onLaunchStart, onLaunchSettled },
+      });
+      vi.spyOn(runner as any, 'buildUpstreamContext').mockImplementation(async () => {
+        await upstreamContextBlocked;
+        return [];
+      });
+
+      const done = runner.executeTask(task);
+      await vi.waitFor(() => expect(onLaunchAccepted).toHaveBeenCalledWith(task.id));
+
+      expect(executor.start).not.toHaveBeenCalled();
+      expect(onLaunchStart).not.toHaveBeenCalled();
+
+      releaseUpstreamContext();
+      await vi.waitFor(() => expect(executor.start).toHaveBeenCalledTimes(1));
+      expect(onLaunchStart).toHaveBeenCalledWith(task.id, executor);
+
+      completeCallback?.({
+        requestId: 'req-preparing-before-start',
+        actionId: task.id,
+        attemptId: task.execution.selectedAttemptId,
+        executionGeneration: task.execution.generation ?? 0,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+      await done;
+
+      expect(handleWorkerResponse).toHaveBeenCalled();
+      expect(onLaunchSettled).toHaveBeenCalledWith(task.id);
+    });
+
     it('reports launch-in-progress callbacks while executor.start is still pending', async () => {
       const launchStart = vi.fn();
       const launchFailed = vi.fn();

--- a/packages/execution-engine/src/task-runner-callbacks.ts
+++ b/packages/execution-engine/src/task-runner-callbacks.ts
@@ -3,9 +3,11 @@ import type { Executor, ExecutorHandle } from './executor.js';
 
 export interface TaskRunnerCallbacks {
   onOutput?: (taskId: string, data: string) => void;
+  onLaunchAccepted?: (taskId: string) => void;
   onLaunchStart?: (taskId: string, executor: Executor) => void;
   onLaunchFailed?: (taskId: string, error: Error, executor: Executor) => void;
   onSpawned?: (taskId: string, handle: ExecutorHandle, executor: Executor) => void;
   onComplete?: (taskId: string, response: WorkResponse) => void;
   onHeartbeat?: (taskId: string) => void;
+  onLaunchSettled?: (taskId: string) => void;
 }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -387,6 +387,7 @@ export class TaskRunner {
       return;
     }
     this.launchingAttemptIds.add(attemptId);
+    this.callbacks.onLaunchAccepted?.(task.id);
     try {
       await this.executeTaskInner(task, attemptId);
     } catch (err) {
@@ -454,6 +455,7 @@ export class TaskRunner {
       }
     } finally {
       this.launchingAttemptIds.delete(attemptId);
+      this.callbacks.onLaunchSettled?.(task.id);
     }
   }
 
@@ -492,7 +494,27 @@ export class TaskRunner {
     );
 
     // Gather upstream context from completed dependencies
-    const upstreamContext = await this.buildUpstreamContext(task);
+    const upstreamContextStartMs = Date.now();
+    let upstreamContext: Array<{taskId: string; description: string; summary?: string; commitHash?: string; commitMessage?: string}>;
+    try {
+      upstreamContext = await this.buildUpstreamContext(task);
+      const durationMs = Date.now() - upstreamContextStartMs;
+      this.logger.info('[TaskRunner] buildUpstreamContext completed', {
+        taskId: task.id,
+        durationMs,
+        contextCount: upstreamContext.length,
+      });
+      traceExecution(`[benchmark] TaskRunner.buildUpstreamContext task=${task.id} durationMs=${durationMs} contextCount=${upstreamContext.length}`);
+    } catch (err) {
+      const durationMs = Date.now() - upstreamContextStartMs;
+      this.logger.warn('[TaskRunner] buildUpstreamContext failed', {
+        taskId: task.id,
+        durationMs,
+        err,
+      });
+      traceExecution(`[benchmark] TaskRunner.buildUpstreamContext task=${task.id} failed durationMs=${durationMs}`);
+      throw err;
+    }
     const upstreamBranches = this.collectUpstreamBranches(task);
     const alternatives = this.buildAlternatives(task);
 

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5106,6 +5106,37 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('B')!.status).toBe('pending');
     });
 
+    it('restartTask clears stale launch metadata when resetting to pending', () => {
+      orchestrator.loadPlan({
+        name: 'pending-restart-launch-metadata-test',
+        tasks: [
+          { id: 'A', description: 'Root', command: 'echo A' },
+          { id: 'B', description: 'Depends on A', command: 'echo B', dependencies: ['A'] },
+        ],
+      });
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: 'A', status: 'failed', outputs: { exitCode: 1, error: 'fail' } }),
+      );
+      persistence.updateTask('B', {
+        execution: {
+          phase: 'launching',
+          launchStartedAt: new Date('2026-04-16T05:25:16.531Z'),
+          launchCompletedAt: new Date('2026-04-16T05:26:16.531Z'),
+        },
+      });
+      orchestrator.syncAllFromDb();
+
+      const result = orchestrator.retryTask('B');
+      const task = orchestrator.getTask('B')!;
+
+      expect(result[0].status).toBe('pending');
+      expect(task.status).toBe('pending');
+      expect(task.execution.phase).toBeUndefined();
+      expect(task.execution.launchStartedAt).toBeUndefined();
+      expect(task.execution.launchCompletedAt).toBeUndefined();
+    });
+
     it('restartTask from needs_input status resets to pending', () => {
       orchestrator.loadPlan({
         name: 'needs-input-restart-test',

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -777,6 +777,20 @@ export class Orchestrator {
     },
   };
 
+  private clearStaleLaunchMetadataForPending(changes: TaskStateChanges): TaskStateChanges {
+    if (changes.status !== 'pending') return changes;
+    if (changes.execution?.phase === 'launching') return changes;
+    return {
+      ...changes,
+      execution: {
+        ...changes.execution,
+        phase: undefined,
+        launchStartedAt: undefined,
+        launchCompletedAt: undefined,
+      },
+    };
+  }
+
   constructor(config: OrchestratorConfig) {
     this.maxConcurrency = config.maxConcurrency ?? 3;
     this.persistence = config.persistence;
@@ -832,6 +846,7 @@ export class Orchestrator {
     changes: TaskStateChanges,
     opts?: { skipWorkflowStatusSync?: boolean },
   ): TaskState {
+    changes = this.clearStaleLaunchMetadataForPending(changes);
     const existing = this.stateGetTask(taskId);
     if (!existing) {
       throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `writeAndSync: task ${taskId} not found in graph`);


### PR DESCRIPTION
## Summary

- Add TaskRunner accepted/preparing launch callbacks so the app watchdog treats work as actively launching before upstream context building and before executor.start().
- Clear stale launch lifecycle metadata on pending transitions unless the scheduler is claiming a fresh launch with phase=launching.
- Log buildUpstreamContext duration and context count, and add regressions for pre-start tracking plus stale pending launch metadata cleanup.

## Architecture

### Before

```mermaid
flowchart TD
  Scheduler[Scheduler claims launch] --> Runner[TaskRunner.executeTask]
  Runner --> Context[buildUpstreamContext]
  Context --> LaunchStart[onLaunchStart]
  LaunchStart --> Executor[executor.start]
  Watchdog[App watchdog] -->|sees no handle and no launchingTasks entry during Context| Fail[launch-stall failure]
```

### After

```mermaid
flowchart TD
  Scheduler[Scheduler claims launch] --> Runner[TaskRunner.executeTask]
  Runner --> Accepted[onLaunchAccepted adds launchingTasks entry]
  Accepted --> Context[buildUpstreamContext with duration logging]
  Context --> LaunchStart[onLaunchStart]
  LaunchStart --> Executor[executor.start]
  Executor --> Spawned[onSpawned clears launchingTasks entry]
  Runner --> Settled[onLaunchSettled clears pre-spawn exits]
  Watchdog[App watchdog] -->|sees launchingTasks entry during Context| Observe[does not force launch-stall failure]
```

## Test Plan

- [x] `pnpm install`
- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/task-runner.test.ts -t "marks launch accepted"`
- [x] `pnpm --dir packages/workflow-core exec vitest run src/__tests__/orchestrator.test.ts -t "restartTask clears stale launch metadata"`
- [x] `pnpm --filter @invoker/workflow-core test -- packages/workflow-core/src/__tests__/orchestrator.test.ts -t "restartTask clears stale launch metadata"` (package suite ran and passed: 44 files, 977 tests)
- [x] `pnpm --filter @invoker/execution-engine test -- packages/execution-engine/src/__tests__/task-runner.test.ts -t "launch timeout repro"` (package suite ran and passed: 46 files, 947 tests)
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert ca6949ee`
- Post-revert steps: Re-run the focused workflow-core and execution-engine tests above.
- Data migration? No
