### PR TITLE
Derive workflow metadata from task state

### DIFF
--- a/packages/app/e2e/action-graph-visual-proof.spec.ts
+++ b/packages/app/e2e/action-graph-visual-proof.spec.ts
@@ -16,7 +16,9 @@ test.describe('Action Graph visual proof', () => {
 
     await page.getByTestId('rail-action-graph').click();
     await expect(page.getByTestId('action-graph-view')).toBeVisible();
-    await expect(page.getByText('E2E Test Plan', { exact: true })).toBeVisible();
+    await expect(
+      page.getByTestId('action-graph-node-action:wf-test-1').getByText('E2E Test Plan', { exact: true }),
+    ).toBeVisible();
     await expect(page.getByTestId('action-graph-node-attempt:wf-test-1/task-alpha')).toBeVisible();
     await page.getByTestId('action-graph-node-attempt:wf-test-1/task-alpha').click();
     await expect(page.getByTestId('workflow-inspector-title')).toHaveText('First test task');

--- a/packages/app/src/__tests__/workflow-metadata-invalidation.test.ts
+++ b/packages/app/src/__tests__/workflow-metadata-invalidation.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { WorkflowMetadataInvalidator } from '../workflow-metadata-invalidation.js';
+import type { Workflow } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+function makeWorkflow(id: string, status: Workflow['status'] = 'pending'): Workflow {
+  return {
+    id,
+    name: id,
+    status,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeTask(id: string, workflowId: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    config: { workflowId },
+    execution: {},
+    taskStateVersion: 1,
+  };
+}
+
+describe('WorkflowMetadataInvalidator', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('publishes backend workflow metadata after a created task delta', () => {
+    vi.useFakeTimers();
+    const publish = vi.fn();
+    const invalidator = new WorkflowMetadataInvalidator({
+      getCachedTaskSnapshot: () => undefined,
+      loadTask: () => undefined,
+      listWorkflows: () => [makeWorkflow('wf-1', 'running')],
+      publish,
+      flushMs: 25,
+    });
+
+    invalidator.markFromTaskDelta({ type: 'created', task: makeTask('task-1', 'wf-1') });
+
+    expect(publish).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(25);
+    expect(publish).toHaveBeenCalledWith([expect.objectContaining({ id: 'wf-1', status: 'running' })]);
+  });
+
+  it('uses the cached pre-delete task snapshot for removed deltas', () => {
+    vi.useFakeTimers();
+    const publish = vi.fn();
+    const invalidator = new WorkflowMetadataInvalidator({
+      getCachedTaskSnapshot: (taskId) => JSON.stringify(makeTask(taskId, 'wf-removed')),
+      loadTask: () => undefined,
+      listWorkflows: () => [makeWorkflow('wf-removed', 'pending')],
+      publish,
+      flushMs: 25,
+    });
+
+    invalidator.markFromTaskDelta({ type: 'removed', taskId: 'task-1', previousTaskStateVersion: 1 });
+    vi.advanceTimersByTime(25);
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0][0]).toEqual([expect.objectContaining({ id: 'wf-removed' })]);
+  });
+
+  it('marks both old and new workflows when an updated task moves between workflows', () => {
+    vi.useFakeTimers();
+    const publish = vi.fn();
+    const invalidator = new WorkflowMetadataInvalidator({
+      getCachedTaskSnapshot: (taskId) => JSON.stringify(makeTask(taskId, 'wf-old')),
+      loadTask: () => undefined,
+      listWorkflows: () => [makeWorkflow('wf-old', 'pending'), makeWorkflow('wf-new', 'running')],
+      publish,
+      flushMs: 25,
+    });
+
+    invalidator.markFromTaskDelta({
+      type: 'updated',
+      taskId: 'task-1',
+      changes: { config: { workflowId: 'wf-new' } },
+      previousTaskStateVersion: 1,
+      taskStateVersion: 2,
+    });
+    vi.advanceTimersByTime(25);
+
+    expect(publish).toHaveBeenCalledTimes(1);
+    expect(publish.mock.calls[0][0]).toEqual([
+      expect.objectContaining({ id: 'wf-old' }),
+      expect.objectContaining({ id: 'wf-new' }),
+    ]);
+  });
+
+  it('coalesces rapid task deltas into one workflow metadata publish', () => {
+    vi.useFakeTimers();
+    const publish = vi.fn();
+    const invalidator = new WorkflowMetadataInvalidator({
+      getCachedTaskSnapshot: () => undefined,
+      loadTask: () => undefined,
+      listWorkflows: () => [makeWorkflow('wf-1')],
+      publish,
+      flushMs: 25,
+    });
+
+    invalidator.markFromTaskDelta({ type: 'created', task: makeTask('task-1', 'wf-1') });
+    invalidator.markFromTaskDelta({ type: 'created', task: makeTask('task-2', 'wf-1') });
+    vi.advanceTimersByTime(25);
+
+    expect(publish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -137,6 +137,7 @@ import { installBundledSkills, resolveBundledSkillsStatus } from './bundled-skil
 import { createRequire } from 'node:module';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
 import { applyDelta, resolveQuarantine, TaskSnapshotCache } from './delta-merge.js';
+import { WorkflowMetadataInvalidator } from './workflow-metadata-invalidation.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import { ensureSqliteFlushDebounceForOwner } from './sqlite-flush-policy.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
@@ -1189,6 +1190,7 @@ if (isHeadless) {
   const outputFlushTimers = new Map<string, ReturnType<typeof setTimeout>>();
   const pendingUiTaskDeltas: TaskDelta[] = [];
   let uiTaskDeltaFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  let workflowMetadataInvalidator: WorkflowMetadataInvalidator | null = null;
   let lastKnownWorkflowCount = 0;
   let lastActivityLogId = 0;
   let startupWorkflowId: string | null = null;
@@ -1307,6 +1309,7 @@ if (isHeadless) {
   };
 
   const sendTaskDeltaToRenderer = (delta: TaskDelta): void => {
+    workflowMetadataInvalidator?.markFromTaskDelta(delta);
     if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) {
       return;
     }
@@ -2178,6 +2181,19 @@ if (isHeadless) {
     }
     return undefined;
   }
+
+  workflowMetadataInvalidator = new WorkflowMetadataInvalidator({
+    getCachedTaskSnapshot: (taskId) => lastKnownTaskStates.get(taskId),
+    loadTask: loadTaskByIdFromPersistence,
+    listWorkflows: () => persistence.listWorkflows(),
+    publish: (workflows) => {
+      lastKnownWorkflowCount = workflows.length;
+      if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) {
+        return;
+      }
+      mainWindow.webContents.send('invoker:workflows-changed', workflows);
+    },
+  });
 
   function listWorkflowsByStartupRecency() {
     return [...persistence.listWorkflows()].sort((left, right) => {

--- a/packages/app/src/workflow-metadata-invalidation.ts
+++ b/packages/app/src/workflow-metadata-invalidation.ts
@@ -1,0 +1,88 @@
+import type { Workflow } from '@invoker/data-store';
+import type { TaskDelta, TaskState } from '@invoker/workflow-core';
+
+export interface WorkflowMetadataInvalidatorDeps {
+  getCachedTaskSnapshot(taskId: string): string | undefined;
+  loadTask(taskId: string): TaskState | undefined;
+  listWorkflows(): Workflow[];
+  publish(workflows: Workflow[]): void;
+  flushMs?: number;
+}
+
+function workflowIdFromSnapshot(snapshot: string | undefined): string | undefined {
+  if (!snapshot) return undefined;
+  try {
+    const task = JSON.parse(snapshot) as Pick<TaskState, 'config'>;
+    return task.config?.workflowId;
+  } catch {
+    return undefined;
+  }
+}
+
+function workflowIdFromLoadedTask(task: TaskState | undefined): string | undefined {
+  return task?.config.workflowId;
+}
+
+export class WorkflowMetadataInvalidator {
+  private readonly dirtyWorkflowIds = new Set<string>();
+  private flushTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly flushMs: number;
+
+  constructor(private readonly deps: WorkflowMetadataInvalidatorDeps) {
+    this.flushMs = deps.flushMs ?? 25;
+  }
+
+  markWorkflowDirty(workflowId: string | undefined | null): void {
+    if (!workflowId) return;
+    this.dirtyWorkflowIds.add(workflowId);
+    this.scheduleFlush();
+  }
+
+  markFromTaskDelta(delta: TaskDelta): void {
+    if (delta.type === 'created') {
+      this.markWorkflowDirty(delta.task.config.workflowId);
+      return;
+    }
+
+    if (delta.type === 'removed') {
+      const workflowId =
+        workflowIdFromSnapshot(this.deps.getCachedTaskSnapshot(delta.taskId)) ??
+        workflowIdFromLoadedTask(this.deps.loadTask(delta.taskId));
+      this.markWorkflowDirty(workflowId);
+      return;
+    }
+
+    const oldWorkflowId =
+      workflowIdFromSnapshot(this.deps.getCachedTaskSnapshot(delta.taskId)) ??
+      workflowIdFromLoadedTask(this.deps.loadTask(delta.taskId));
+    const newWorkflowId = delta.changes.config?.workflowId;
+    this.markWorkflowDirty(oldWorkflowId);
+    if (newWorkflowId !== oldWorkflowId) {
+      this.markWorkflowDirty(newWorkflowId);
+    }
+  }
+
+  flush(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    if (this.dirtyWorkflowIds.size === 0) return;
+    this.dirtyWorkflowIds.clear();
+    this.deps.publish(this.deps.listWorkflows());
+  }
+
+  dispose(): void {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer);
+      this.flushTimer = null;
+    }
+    this.dirtyWorkflowIds.clear();
+  }
+
+  private scheduleFlush(): void {
+    if (this.flushTimer) return;
+    this.flushTimer = setTimeout(() => this.flush(), this.flushMs);
+    this.flushTimer.unref?.();
+  }
+}

--- a/packages/data-store/src/__tests__/owner-boundary.test.ts
+++ b/packages/data-store/src/__tests__/owner-boundary.test.ts
@@ -59,7 +59,7 @@ describe('owner boundary enforcement', () => {
       // Verify mutations are blocked
       expect(() => reader.saveWorkflow({ ...testWorkflow, status: 'completed' }))
         .toThrow(/read-only/i);
-      expect(() => reader.updateWorkflow('wf-boundary-test', { status: 'completed' }))
+      expect(() => reader.updateWorkflow('wf-boundary-test', { generation: 1 }))
         .toThrow(/read-only/i);
       expect(() => reader.deleteWorkflow('wf-boundary-test'))
         .toThrow(/read-only/i);
@@ -164,23 +164,24 @@ describe('owner boundary enforcement', () => {
       // Reader opens read-only
       const reader = await SQLiteAdapter.create(dbPath, { readOnly: true });
       const before = reader.loadWorkflow('wf-boundary-test');
-      expect(before!.status).toBe('running');
+      expect(before!.status).toBe('pending');
+      expect(before!.generation).toBe(0);
 
       // Owner process reopens and mutates
       const owner2 = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
-      owner2.updateWorkflow('wf-boundary-test', { status: 'completed' });
+      owner2.updateWorkflow('wf-boundary-test', { generation: 1 });
       owner2.close();
 
       // Reader sees stale data (expected - SQLite isolation)
       const stillStale = reader.loadWorkflow('wf-boundary-test');
-      expect(stillStale!.status).toBe('running');
+      expect(stillStale!.generation).toBe(0);
 
       reader.close();
 
       // New reader sees updated data
       const reader2 = await SQLiteAdapter.create(dbPath, { readOnly: true });
       const updated = reader2.loadWorkflow('wf-boundary-test');
-      expect(updated!.status).toBe('completed');
+      expect(updated!.generation).toBe(1);
       reader2.close();
     });
 
@@ -228,12 +229,12 @@ describe('owner boundary enforcement', () => {
       owner.saveWorkflow(testWorkflow);
       let loaded = owner.loadWorkflow('wf-boundary-test');
       expect(loaded).toBeDefined();
-      expect(loaded!.status).toBe('running');
+      expect(loaded!.status).toBe('pending');
 
       // Update
-      owner.updateWorkflow('wf-boundary-test', { status: 'completed' });
+      owner.updateWorkflow('wf-boundary-test', { generation: 1 });
       loaded = owner.loadWorkflow('wf-boundary-test');
-      expect(loaded!.status).toBe('completed');
+      expect(loaded!.generation).toBe(1);
 
       // List
       const workflows = owner.listWorkflows();

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -40,6 +40,62 @@ describe('SQLiteAdapter', () => {
     };
   }
 
+  function workflowColumns(db: SQLiteAdapter): string[] {
+    const result = (db as any).db.exec('PRAGMA table_info(workflows)') as Array<{ values: unknown[][] }>;
+    return (result[0]?.values ?? []).map((row) => String(row[1]));
+  }
+
+  describe('workflow schema', () => {
+    it('does not persist a workflow status column on fresh databases', () => {
+      expect(workflowColumns(adapter)).not.toContain('status');
+    });
+
+    it('migrates existing workflow tables by removing status and preserving metadata', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-workflow-status-migration-'));
+      const dbPath = join(dir, 'invoker.db');
+      try {
+        const oldDb = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        (oldDb as any).db.run(`ALTER TABLE workflows ADD COLUMN status TEXT DEFAULT 'running'`);
+        (oldDb as any).db.run(
+          `INSERT INTO workflows (
+            id, name, description, visual_proof, status, plan_file, repo_url,
+            intermediate_repo_url, branch, on_finish, base_branch, parent_remote,
+            feature_branch, merge_mode, review_provider, generation, created_at, updated_at
+          ) VALUES (
+            'wf-old', 'Old Workflow', 'kept', 1, 'failed', 'plan.yml', 'repo',
+            'intermediate', 'branch-a', 'none', 'main', 'origin',
+            'feature/a', 'manual', 'github', 7, '2026-01-01T00:00:00.000Z', '2026-01-02T00:00:00.000Z'
+          )`,
+        );
+        (oldDb as any).dirty = true;
+        oldDb.close();
+
+        const migrated = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        expect(workflowColumns(migrated)).not.toContain('status');
+        const workflow = migrated.loadWorkflow('wf-old')!;
+        expect(workflow).toMatchObject({
+          id: 'wf-old',
+          name: 'Old Workflow',
+          description: 'kept',
+          visualProof: true,
+          status: 'pending',
+          planFile: 'plan.yml',
+          repoUrl: 'repo',
+          intermediateRepoUrl: 'intermediate',
+          branch: 'branch-a',
+          baseBranch: 'main',
+          featureBranch: 'feature/a',
+          mergeMode: 'manual',
+          reviewProvider: 'github',
+          generation: 7,
+        });
+        migrated.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('saveTask + loadTasks', () => {
     it('round-trips a task through save and load', () => {
       adapter.saveWorkflow(testWorkflow);
@@ -246,7 +302,8 @@ describe('SQLiteAdapter', () => {
       const loaded = adapter.loadWorkflow('wf-1');
       expect(loaded).toBeDefined();
       expect(loaded!.name).toBe('Test Workflow');
-      expect(loaded!.status).toBe('running');
+      expect(loaded!.status).toBe('pending');
+      expect(loaded!.rollup?.countsByStatus.pending).toBe(0);
     });
 
     it('derives workflow status and rollup details from task rows', () => {
@@ -354,28 +411,29 @@ describe('SQLiteAdapter', () => {
   });
 
   describe('updateWorkflow', () => {
-    it('updates workflow status', () => {
+    it('ignores workflow status mutations because status is derived from tasks', () => {
       adapter.saveWorkflow(testWorkflow);
+      // @ts-expect-error workflow status is derived output, not a persistence input.
       adapter.updateWorkflow('wf-1', { status: 'completed' });
 
       const loaded = adapter.loadWorkflow('wf-1');
-      expect(loaded!.status).toBe('completed');
+      expect(loaded!.status).toBe('pending');
     });
 
     it('updates workflow updatedAt', () => {
       adapter.saveWorkflow(testWorkflow);
       const newTime = '2099-01-01T00:00:00.000Z';
-      adapter.updateWorkflow('wf-1', { status: 'failed', updatedAt: newTime });
+      adapter.updateWorkflow('wf-1', { updatedAt: newTime });
 
       const loaded = adapter.loadWorkflow('wf-1');
-      expect(loaded!.status).toBe('failed');
+      expect(loaded!.status).toBe('pending');
       expect(loaded!.updatedAt).toBe(newTime);
     });
 
     it('auto-sets updatedAt when not provided', () => {
       adapter.saveWorkflow(testWorkflow);
       const before = new Date().toISOString();
-      adapter.updateWorkflow('wf-1', { status: 'completed' });
+      adapter.updateWorkflow('wf-1', { generation: 1 });
 
       const loaded = adapter.loadWorkflow('wf-1');
       expect(loaded!.updatedAt >= before).toBe(true);
@@ -1280,7 +1338,7 @@ describe('SQLiteAdapter', () => {
       const workflows = adapter.listWorkflows();
       expect(workflows[0].id).toBe('wf-1');
       expect(workflows[0].name).toBe('Test Workflow');
-      expect(workflows[0].status).toBe('running');
+      expect(workflows[0].status).toBe('pending');
       expect(workflows[0].planFile).toBe('plan.yaml');
       expect(workflows[0].repoUrl).toBe('https://github.com/test');
       expect(workflows[0].onFinish).toBe('merge');
@@ -1315,7 +1373,7 @@ describe('SQLiteAdapter', () => {
       adapter.updateWorkflow('wf-1', { baseBranch: 'release' });
 
       const loaded = adapter.loadWorkflow('wf-1');
-      expect(loaded!.status).toBe('running');
+      expect(loaded!.status).toBe('pending');
       expect(loaded!.baseBranch).toBe('release');
     });
   });
@@ -1350,7 +1408,7 @@ describe('SQLiteAdapter', () => {
       adapter.updateWorkflow('wf-1', { generation: 5 });
 
       const loaded = adapter.loadWorkflow('wf-1');
-      expect(loaded!.status).toBe('running');
+      expect(loaded!.status).toBe('pending');
       expect(loaded!.baseBranch).toBe('master');
       expect(loaded!.generation).toBe(5);
     });

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -70,7 +70,7 @@ export interface ActivityLogEntry {
 export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: Workflow): void;
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'status' | 'updatedAt' | 'baseBranch' | 'generation' | 'mergeMode'>>): void;
+  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'updatedAt' | 'baseBranch' | 'generation' | 'mergeMode'>>): void;
   loadWorkflow(workflowId: string): Workflow | undefined;
   listWorkflows(): Workflow[];
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -323,12 +323,19 @@ export class SQLiteAdapter implements PersistenceAdapter {
       CREATE TABLE IF NOT EXISTS workflows (
         id TEXT PRIMARY KEY,
         name TEXT NOT NULL,
-        status TEXT DEFAULT 'running',
+        description TEXT,
+        visual_proof INTEGER,
         plan_file TEXT,
         repo_url TEXT,
         intermediate_repo_url TEXT,
         branch TEXT,
+        on_finish TEXT,
+        base_branch TEXT,
         parent_remote TEXT,
+        feature_branch TEXT,
+        merge_mode TEXT,
+        review_provider TEXT,
+        generation INTEGER DEFAULT 0,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
       );
@@ -608,6 +615,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         }
       }
     }
+    this.migrateWorkflowStatusColumn();
 
     // Replace old attempt_number index with created_at index
     this.db.run('DROP INDEX IF EXISTS idx_attempts_node');
@@ -618,6 +626,58 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.migrateGatePolicyApprovedToCompleted();
       this.runCompatibilityMigration();
     }
+  }
+
+  private migrateWorkflowStatusColumn(): void {
+    if (this.readOnly) return;
+    const columns = this.queryAll('PRAGMA table_info(workflows)') as Array<{ name: string }>;
+    if (!columns.some((column) => column.name === 'status')) return;
+
+    const foreignKeys = this.queryOne('PRAGMA foreign_keys') as { foreign_keys?: number } | undefined;
+    const foreignKeysEnabled = foreignKeys?.foreign_keys === 1;
+    if (foreignKeysEnabled) {
+      this.db.run('PRAGMA foreign_keys = OFF');
+    }
+    this.db.run(`
+      CREATE TABLE workflows_new (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL,
+        description TEXT,
+        visual_proof INTEGER,
+        plan_file TEXT,
+        repo_url TEXT,
+        intermediate_repo_url TEXT,
+        branch TEXT,
+        on_finish TEXT,
+        base_branch TEXT,
+        parent_remote TEXT,
+        feature_branch TEXT,
+        merge_mode TEXT,
+        review_provider TEXT,
+        generation INTEGER DEFAULT 0,
+        created_at TEXT DEFAULT (datetime('now')),
+        updated_at TEXT DEFAULT (datetime('now'))
+      )
+    `);
+    this.db.run(`
+      INSERT INTO workflows_new (
+        id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
+        branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
+        review_provider, generation, created_at, updated_at
+      )
+      SELECT
+        id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
+        branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
+        review_provider, generation, created_at, updated_at
+      FROM workflows
+    `);
+    this.db.run('DROP TABLE workflows');
+    this.db.run('ALTER TABLE workflows_new RENAME TO workflows');
+    if (foreignKeysEnabled) {
+      this.db.run('PRAGMA foreign_keys = ON');
+    }
+    this.dirty = true;
+    this.scheduleFlush();
   }
 
   /**
@@ -687,13 +747,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   saveWorkflow(workflow: Workflow): void {
     this.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, status, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, generation, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
       workflow.visualProof ? 1 : 0,
-      workflow.status,
       workflow.planFile ?? null, workflow.repoUrl ?? null, workflow.intermediateRepoUrl ?? null, workflow.branch ?? null,
       workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
       workflow.mergeMode ?? null,
@@ -703,13 +762,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
     ]);
   }
 
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'status' | 'updatedAt' | 'baseBranch' | 'generation' | 'mergeMode'>>): void {
+  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'updatedAt' | 'baseBranch' | 'generation' | 'mergeMode'>>): void {
     const setClauses: string[] = [];
     const values: unknown[] = [];
-    if (changes.status !== undefined) {
-      setClauses.push('status = ?');
-      values.push(changes.status);
-    }
     if (changes.baseBranch !== undefined) {
       setClauses.push('base_branch = ?');
       values.push(changes.baseBranch);
@@ -1714,7 +1769,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
     for (const workflowId of workflowIds) {
       const tasks = tasksByWorkflow.get(workflowId) ?? [];
-      if (tasks.length === 0) continue;
       rollups.set(workflowId, computeWorkflowRollupFromSummaries(tasks));
     }
 
@@ -1727,7 +1781,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       name: row.name,
       description: row.description ?? undefined,
       visualProof: row.visual_proof === 1,
-      status: rollup?.status ?? row.status,
+      status: rollup?.status ?? 'pending',
       rollup,
       planFile: row.plan_file ?? undefined,
       repoUrl: row.repo_url ?? undefined,

--- a/packages/test-kit/src/in-memory-persistence.ts
+++ b/packages/test-kit/src/in-memory-persistence.ts
@@ -31,10 +31,9 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     });
   }
 
-  updateWorkflow(workflowId: string, changes: { status?: string; updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' }): void {
+  updateWorkflow(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' }): void {
     const wf = this.workflows.get(workflowId);
     if (wf) {
-      if (changes.status) wf.status = changes.status;
       if (changes.updatedAt) wf.updatedAt = changes.updatedAt;
       if (changes.baseBranch !== undefined) wf.baseBranch = changes.baseBranch;
       if (changes.generation !== undefined) wf.generation = changes.generation;
@@ -107,7 +106,6 @@ export class InMemoryPersistence implements OrchestratorPersistence {
 
   private withDerivedStatus<T extends { id: string; status: string }>(workflow: T): T {
     const tasks = this.loadTasks(workflow.id);
-    if (tasks.length === 0) return workflow;
     const rollup = computeWorkflowRollup(tasks);
     return { ...workflow, status: rollup.status, rollup };
   }

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -19,6 +19,7 @@ vi.mock('@xyflow/react', async () => {
 const { App } = await import('../App.js');
 
 const workflows: WorkflowMeta[] = [{ id: 'wf-a', name: 'Workflow A', status: 'running' }];
+const failedWorkflows: WorkflowMeta[] = [{ id: 'wf-a', name: 'Workflow A', status: 'failed' }];
 const alpha = makeUITask({ id: 'task-alpha', description: 'First test task', status: 'pending', workflowId: 'wf-a', command: 'echo hello-alpha' });
 const beta = makeUITask({ id: 'task-beta', description: 'Second test task depending on alpha', status: 'pending', workflowId: 'wf-a', dependencies: ['task-alpha'], command: 'echo hello-beta' });
 
@@ -80,7 +81,7 @@ describe('Task interaction (component)', () => {
     });
 
     render(<App />);
-    act(() => mock.setTasks([failedTask], workflows));
+    act(() => mock.setTasks([failedTask], failedWorkflows));
 
     await waitFor(() => {
       expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -163,7 +163,7 @@ describe('useTasks', () => {
     });
   });
 
-  it('recomputes workflow status from task deltas after failed metadata becomes pending or running', async () => {
+  it('keeps backend-sent workflow status until workflows-changed refreshes metadata', async () => {
     const taskA = makeUITask({ id: 'wf-1/task-a', workflowId: 'wf-1', status: 'failed' });
     const taskB = makeUITask({ id: 'wf-1/task-b', workflowId: 'wf-1', status: 'completed' });
     (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
@@ -207,27 +207,45 @@ describe('useTasks', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.workflows.get('wf-1')?.status).toBe('pending');
+      expect(result.current.tasks.get('wf-1/task-a')?.status).toBe('pending');
+      expect(result.current.tasks.get('wf-1/task-b')?.status).toBe('pending');
+    });
+    expect(result.current.workflows.get('wf-1')?.status).toBe('failed');
+
+    act(() => {
+      workflowsChangedHandler!([
+        {
+          id: 'wf-1',
+          name: 'Workflow 1',
+          status: 'pending',
+          rollup: {
+            status: 'pending',
+            countsByStatus: {
+              pending: 2,
+              running: 0,
+              fixing_with_ai: 0,
+              completed: 0,
+              failed: 0,
+              needs_input: 0,
+              blocked: 0,
+              review_ready: 0,
+              awaiting_approval: 0,
+              stale: 0,
+            },
+            failedTasks: [],
+            fixingTasks: [],
+            waitingTasks: [],
+          },
+        },
+      ]);
     });
 
-    await act(async () => {
-      taskDeltaHandler!({
-        type: 'updated',
-        taskId: 'wf-1/task-a',
-        changes: { status: 'running' },
-        taskStateVersion: 3,
-        previousTaskStateVersion: 2,
-      });
-      await new Promise((resolve) => setTimeout(resolve, 110));
-    });
-
-    await waitFor(() => {
-      expect(result.current.workflows.get('wf-1')?.status).toBe('running');
-    });
+    expect(result.current.workflows.get('wf-1')?.status).toBe('pending');
+    expect(result.current.workflows.get('wf-1')?.rollup?.countsByStatus.pending).toBe(2);
     expect(result.current.workflows.get('wf-1')?.name).toBe('Workflow 1');
   });
 
-  it('keeps workflow failed when pending tasks are blocked by a failed dependency path', async () => {
+  it('does not locally recompute failed dependency paths from task deltas', async () => {
     const failedTask = makeUITask({
       id: 'wf-1/add-regression-coverage',
       workflowId: 'wf-1',
@@ -280,7 +298,14 @@ describe('useTasks', () => {
     });
 
     await waitFor(() => {
-      expect(result.current.workflows.get('wf-1')?.status).toBe('failed');
+      expect(result.current.tasks.get('wf-1/add-regression-coverage')?.status).toBe('failed');
     });
+    expect(result.current.workflows.get('wf-1')?.status).toBe('running');
+
+    act(() => {
+      workflowsChangedHandler!([{ id: 'wf-1', name: 'Workflow 1', status: 'failed' }]);
+    });
+
+    expect(result.current.workflows.get('wf-1')?.status).toBe('failed');
   });
 });

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -7,7 +7,6 @@
  */
 
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { computeWorkflowRollupFromSummaries } from '@invoker/workflow-graph';
 import type { TaskState, WorkflowMeta } from '../types.js';
 import { applyDelta } from '../lib/delta.js';
 import { normalizeWorkflowStatus } from '../lib/workflow-status.js';
@@ -15,55 +14,6 @@ import {
   createTaskDeltaPipeline,
   type TaskDeltaPipeline,
 } from '../lib/task-delta-pipeline.js';
-
-function deriveWorkflowStatusFromTasks(tasks: TaskState[]): WorkflowMeta['status'] {
-  return computeWorkflowRollupFromSummaries(
-    tasks.map((task) => ({
-      id: task.id,
-      description: task.description,
-      status: task.status,
-      dependencies: task.dependencies,
-      execution: {
-        error: task.execution.error,
-        protocolErrorCode: task.execution.protocolErrorCode,
-        protocolErrorMessage: task.execution.protocolErrorMessage,
-        pendingFixError: task.execution.pendingFixError,
-        exitCode: task.execution.exitCode,
-        completedAt: task.execution.completedAt,
-        agentSessionId: task.execution.agentSessionId,
-        agentName: task.execution.agentName,
-        reviewUrl: task.execution.reviewUrl,
-        inputPrompt: task.execution.inputPrompt,
-        isFixingWithAI: task.execution.isFixingWithAI,
-      },
-    })),
-  ).status;
-}
-
-function deriveWorkflowStatuses(
-  workflowMap: Map<string, WorkflowMeta>,
-  taskMap: Map<string, TaskState>,
-): Map<string, WorkflowMeta> {
-  const tasksByWorkflow = new Map<string, TaskState[]>();
-  for (const task of taskMap.values()) {
-    const workflowId = task.config.workflowId;
-    if (!workflowId) continue;
-    const workflowTasks = tasksByWorkflow.get(workflowId) ?? [];
-    workflowTasks.push(task);
-    tasksByWorkflow.set(workflowId, workflowTasks);
-  }
-
-  let changed = false;
-  const next = new Map<string, WorkflowMeta>();
-  for (const [workflowId, workflow] of workflowMap) {
-    const status = deriveWorkflowStatusFromTasks(tasksByWorkflow.get(workflowId) ?? []);
-    if (workflow.status !== status) {
-      changed = true;
-    }
-    next.set(workflowId, { ...workflow, status });
-  }
-  return changed ? next : workflowMap;
-}
 
 export interface UseTasksResult {
   tasks: Map<string, TaskState>;
@@ -95,9 +45,6 @@ export function useTasks(): UseTasksResult {
     }
     return next;
   });
-  useEffect(() => {
-    setWorkflows((prev) => deriveWorkflowStatuses(prev, tasks));
-  }, [tasks]);
   const workflowsRef = useRef(workflows);
   workflowsRef.current = workflows;
   const deltaPipelineRef = useRef<TaskDeltaPipeline | null>(null);

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -168,7 +168,7 @@ export interface OrchestratorPersistence {
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
   }): void;
-  updateWorkflow?(workflowId: string, changes: { status?: WorkflowDerivedStatus | string; updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' }): void;
+  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' }): void;
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -30,7 +30,6 @@ export interface WorkflowRecord {
 }
 
 export interface WorkflowChanges {
-  status?: string;
   updatedAt?: string;
   baseBranch?: string;
   generation?: number;


### PR DESCRIPTION
## Summary

Make workflow status canonical backend-derived metadata instead of cached persisted state or renderer-local recomputation.

This removes `workflows.status` from the SQLite workflow table, migrates existing databases by rebuilding `workflows` without that column, and derives `Workflow.status`/`Workflow.rollup` from current task rows on every workflow read. It also adds a main-process workflow metadata invalidator so task deltas automatically coalesce into `workflows-changed` refreshes, and removes the `useTasks` status recomputation that could turn `failed + pending` into the wrong workflow status.

## Architecture

### Before

```mermaid
graph TD
    Tasks[Task rows] --> BackendRollup[Backend rollup when available]
    WorkflowRow[workflows.status cached column] --> BackendFallback[Backend fallback]
    BackendRollup --> IPC[IPC WorkflowMeta]
    BackendFallback --> IPC
    IPC --> UI[useTasks]
    UI --> UIDerive[Renderer recomputes from local task counts]
    UIDerive --> Render[Graph chips inspector]
```

### After

```mermaid
graph TD
    TaskMutation[Task state mutation] --> TaskDelta[Task delta]
    TaskDelta --> Invalidator[Main workflow metadata invalidator]
    Invalidator --> ListWorkflows[persistence.listWorkflows]
    Tasks[Task rows] --> Rollup[computeWorkflowRollupFromSummaries]
    Rollup --> WorkflowMeta[Derived Workflow.status and rollup]
    ListWorkflows --> WorkflowMeta
    WorkflowMeta --> IPC[bootstrap getTasks listWorkflows workflows-changed]
    IPC --> UI[useTasks stores backend metadata]
    UI --> Render[Graph chips inspector]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-metadata-invalidation.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/use-tasks.test.tsx`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts src/__tests__/owner-boundary.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/workflow-status-composition.spec.ts`

## Revert Plan

- Safe to revert? No, not as a plain code-only revert after users have opened a DB with this migration. The migration drops `workflows.status`, so reverting to code that writes/reads the cached column would require restoring that column or restoring a DB backup.
- Revert command: `git revert 34a22ab1`
- Post-revert steps: If any database has already run this migration, add a rollback migration such as `ALTER TABLE workflows ADD COLUMN status TEXT DEFAULT 'pending'` before running reverted code, or restore a pre-migration DB backup.
- Data migration? Yes. Startup rebuilds the `workflows` table without the persisted `status` column and preserves workflow metadata columns by name.
