### PR TITLE
Show workflow PR in inspector

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -412,7 +412,8 @@ test.describe('Visual proof capture', () => {
     ]);
 
     await workflowNode(page, workflowId).dispatchEvent('click', { bubbles: true });
-    await expect(page.getByTestId('workflow-inspector-title')).toContainText('Review ready workflow PR proof');
+    await expect(page.getByTestId('workflow-inspector-title')).toHaveText('Review ready workflow PR proof');
+    await expect(page.getByText('Inspector', { exact: true })).toHaveCount(0);
     await expect(page.getByTestId('workflow-inspector-status-label')).toContainText('review ready');
     await expect(page.getByRole('link', { name: reviewUrl })).toHaveAttribute('href', reviewUrl);
 

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -98,6 +98,22 @@ const MERGE_GATE_NO_INLINE_APPROVE_PLAN = {
   ],
 };
 
+/** Pull-request workflow for proving workflow selection exposes the merge gate PR in the inspector. */
+const REVIEW_READY_WORKFLOW_PR_PLAN = {
+  name: 'Review ready workflow PR proof',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'pull_request' as const,
+  mergeMode: 'external_review',
+  tasks: [
+    {
+      id: 'rr-work',
+      description: 'Work that produced a pull request',
+      command: 'echo review-ready',
+      dependencies: [] as string[],
+    },
+  ],
+};
+
 /** Plan for queue-action-surface hardening: combines canonical states, dependency relationships, and destructive actions. */
 const QUEUE_HARDENING_PLAN = {
   name: 'Queue Hardening Visual Proof',
@@ -371,6 +387,36 @@ test.describe('Visual proof capture', () => {
 
     await captureScreenshot(page, 'merge-gate-no-inline-approve');
     await assertPageScreenshot(page, 'merge-gate-no-inline-approve');
+  });
+
+  test('review-ready workflow exposes pull request in inspector', async ({ page }) => {
+    const workflowId = await loadPlanAndSelectWorkflow(page, REVIEW_READY_WORKFLOW_PR_PLAN);
+    await page.locator('.react-flow__node[data-testid$="rr-work"]').first().waitFor({ state: 'visible', timeout: 15000 });
+
+    const reviewUrl = 'https://github.com/Neko-Catpital-Labs/Invoker/pull/626';
+    await injectTaskStates(page, [
+      {
+        taskId: 'rr-work',
+        changes: {
+          status: 'completed',
+          execution: { startedAt: new Date(Date.now() - 5000), completedAt: new Date() },
+        },
+      },
+      {
+        taskId: `__merge__${workflowId}`,
+        changes: {
+          status: 'review_ready',
+          execution: { startedAt: new Date(Date.now() - 3000), reviewUrl },
+        },
+      },
+    ]);
+
+    await workflowNode(page, workflowId).dispatchEvent('click', { bubbles: true });
+    await expect(page.getByTestId('workflow-inspector-title')).toContainText('Review ready workflow PR proof');
+    await expect(page.getByTestId('workflow-inspector-status-label')).toContainText('review ready');
+    await expect(page.getByRole('link', { name: reviewUrl })).toHaveAttribute('href', reviewUrl);
+
+    await captureScreenshot(page, 'review-ready-workflow-pr-sidebar');
   });
 
   test('interactive-status-hues — fixing-with-ai, needs-input, awaiting-approval', async ({ page }) => {

--- a/packages/ui/src/__tests__/task-interaction.test.tsx
+++ b/packages/ui/src/__tests__/task-interaction.test.tsx
@@ -46,8 +46,8 @@ describe('Task interaction (component)', () => {
     fireEvent.click(screen.getByTestId('rf__node-wf-a'));
 
     await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A task DAG');
-      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A task DAG');
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
     });
   });
 
@@ -104,7 +104,7 @@ describe('Task interaction (component)', () => {
 
     fireEvent.click(screen.getByTestId('workflow-node-wf-a'));
     await waitFor(() => {
-      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A task DAG');
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A');
     });
 
     fireEvent.click(screen.getByTestId('workflow-graph-react-flow'));
@@ -127,7 +127,7 @@ describe('Task interaction (component)', () => {
     fireEvent.click(panel);
 
     expect(screen.getByTestId('selected-workflow-mini-dag')).toBeInTheDocument();
-    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A task DAG');
+    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
   });
 
   it('drags the selected workflow mini DAG by its header', async () => {

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -114,6 +114,40 @@ describe('WorkflowInspector', () => {
     expect(screen.getByText('Workflow 1')).toBeInTheDocument();
   });
 
+  it('uses the selected workflow title as the side panel title without a generic inspector label', () => {
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={null}
+        workflowTasks={new Map([['task-1', makeTask()]])}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow 1');
+    expect(screen.queryByText('Workflow 1 task DAG')).not.toBeInTheDocument();
+    expect(screen.queryByText('Inspector')).not.toBeInTheDocument();
+  });
+
+  it('uses the selected task title as the side panel title without a generic inspector label', () => {
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ description: 'Fix cancellation race', status: 'failed' })}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Fix cancellation race');
+    expect(screen.queryByText('Inspector')).not.toBeInTheDocument();
+  });
+
   it('renders selected task title and selected task status first', () => {
     render(
       <WorkflowInspector

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -56,6 +56,38 @@ describe('WorkflowInspector', () => {
     expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/12');
   });
 
+  it('renders workflow PR URL from its review-ready merge node', () => {
+    const mergeTask = makeTask({
+      id: '__merge__wf-1',
+      description: 'Merge gate',
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: { reviewUrl: 'https://github.com/org/repo/pull/34' },
+    });
+    const otherTask = makeTask({
+      id: 'task-2',
+      execution: { reviewUrl: 'https://github.com/org/repo/pull/12' },
+    });
+
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready' }}
+        task={null}
+        workflowTasks={new Map([
+          [otherTask.id, otherTask],
+          [mergeTask.id, mergeTask],
+        ])}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: /github\.com/i });
+    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/34');
+  });
+
   it('can be collapsed and restored', () => {
     const { rerender } = render(
       <WorkflowInspector

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -79,8 +79,7 @@ export function WorkflowInspector({
   const taskColors = taskVisualStatus ? getStatusColor(taskVisualStatus) : null;
   const workflowVisual = workflow ? workflowStatusVisual(workflow.status) : null;
   const reviewUrl = task?.execution.reviewUrl ?? getWorkflowReviewUrl(workflowTasks);
-  const workflowTaskCount = workflowTasks?.size ?? 0;
-  const workflowTitle = workflow ? `${workflow.name || workflow.id}${workflowTaskCount > 0 ? ' task DAG' : ''}` : null;
+  const workflowTitle = workflow ? workflow.name || workflow.id : null;
   const nodeTitle = task?.description ?? workflowTitle ?? 'No node selected';
   const showsWorkflowMergeDetails = Boolean(!task && workflow?.id && workflow.onFinish === 'pull_request');
   const isMergeNode = Boolean((task?.config.isMergeNode || showsWorkflowMergeDetails) && workflow?.id);
@@ -155,8 +154,7 @@ export function WorkflowInspector({
     <aside className="h-full w-full border-l border-gray-800 bg-gray-900 flex flex-col">
       <div className="flex items-center justify-between border-b border-gray-800 px-3 py-2">
         <div className="min-w-0">
-          <div className="text-xs font-semibold uppercase tracking-wide text-gray-300">Inspector</div>
-          <h2 data-testid="workflow-inspector-title" className="mt-1 text-sm font-medium text-gray-100 truncate max-w-[270px]">{nodeTitle}</h2>
+          <h2 data-testid="workflow-inspector-title" className="text-sm font-medium text-gray-100 truncate max-w-[270px]">{nodeTitle}</h2>
           {workflow && task && (
             <div className="text-[11px] text-gray-400 truncate max-w-[270px]">{workflow.name}</div>
           )}

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -31,6 +31,17 @@ function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
+function getWorkflowReviewUrl(tasks: Map<string, TaskState> | undefined): string | undefined {
+  if (!tasks) return undefined;
+  let fallbackUrl: string | undefined;
+  for (const candidate of tasks.values()) {
+    if (!candidate.execution.reviewUrl) continue;
+    if (candidate.config.isMergeNode) return candidate.execution.reviewUrl;
+    fallbackUrl ??= candidate.execution.reviewUrl;
+  }
+  return fallbackUrl;
+}
+
 export function WorkflowInspector({
   workflow,
   task,
@@ -67,7 +78,7 @@ export function WorkflowInspector({
   const taskVisualStatus = task ? getEffectiveVisualStatus(task.status, task.execution) : null;
   const taskColors = taskVisualStatus ? getStatusColor(taskVisualStatus) : null;
   const workflowVisual = workflow ? workflowStatusVisual(workflow.status) : null;
-  const reviewUrl = task?.execution.reviewUrl;
+  const reviewUrl = task?.execution.reviewUrl ?? getWorkflowReviewUrl(workflowTasks);
   const workflowTaskCount = workflowTasks?.size ?? 0;
   const workflowTitle = workflow ? `${workflow.name || workflow.id}${workflowTaskCount > 0 ? ' task DAG' : ''}` : null;
   const nodeTitle = task?.description ?? workflowTitle ?? 'No node selected';


### PR DESCRIPTION
## Summary

Show the selected workflow's pull request in the inspector sidebar when a review-ready workflow has a merge-node PR, even when no individual task is selected.

Make the side panel header use only the selected Workflow or Task title. The generic visible `Inspector` label is removed, and workflow titles no longer append `task DAG` in the side panel.

Prefer the merge node's review URL when multiple tasks have review URLs, with a fallback to any task-level review URL.

## Visual Proof

Captured on SSH target `remote_digital_ocean_1` from the PR branch after the selected-title update.

![Review-ready workflow PR sidebar with selected workflow title](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260515-4f8f3d/review-ready-workflow-pr-sidebar-selected-title.png)

## Test Plan

- [x] SSH `remote_digital_ocean_1`: `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-inspector.test.tsx src/__tests__/task-interaction.test.tsx`
- [x] SSH `remote_digital_ocean_1`: `pnpm run check:types`
- [x] SSH `remote_digital_ocean_1`: `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 xvfb-run --auto-servernum npx playwright test visual-proof.spec.ts -g "review-ready workflow exposes pull request in inspector"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 9f7b4d30 73daa24c`
- Post-revert steps: None
- Data migration? No
