### PR TITLE
Hide sidebar prompt for non-executable selections

### DIFF
--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -98,6 +98,38 @@ describe('WorkflowInspector', () => {
     expect(screen.getByText('failed')).toBeInTheDocument();
   });
 
+  it('does not render prompt content for workflow-only selection', () => {
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={null}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId('prompt-command-display')).not.toBeInTheDocument();
+    expect(screen.queryByText('No prompt or command available.')).not.toBeInTheDocument();
+  });
+
+  it('does not render prompt content for non-AI and non-command tasks', () => {
+    render(
+      <WorkflowInspector
+        workflow={workflow}
+        task={makeTask({ config: { workflowId: 'wf-1', runnerKind: 'merge', isMergeNode: true } })}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId('prompt-command-display')).not.toBeInTheDocument();
+    expect(screen.queryByText('No prompt or command available.')).not.toBeInTheDocument();
+  });
+
   it('edits AI agent from a dropdown', () => {
     const onEditAgent = vi.fn();
     render(

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -85,6 +85,9 @@ export function WorkflowInspector({
     return [...ids].filter(Boolean);
   }, [executionPools, task?.config.poolId]);
   const isTaskBusy = task?.status === 'running' || task?.status === 'fixing_with_ai';
+  const hasPrompt = task?.config.prompt !== undefined;
+  const hasCommand = task?.config.command !== undefined;
+  const hasExecutableContent = Boolean(hasPrompt || hasCommand);
   const canEditPrompt = Boolean(task?.config.prompt !== undefined && onEditPrompt && !isTaskBusy);
   const canEditCommand = Boolean(task?.config.command !== undefined && onEditCommand && !isTaskBusy);
   const statusBorder = taskColors?.border ?? workflowVisual?.borderClass ?? 'border-gray-700';
@@ -251,70 +254,70 @@ export function WorkflowInspector({
           </section>
         )}
 
-        <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
-          <div className="text-[11px] uppercase tracking-wide text-gray-400">
-            {task?.config.prompt ? 'Prompt' : task?.config.command ? 'Command' : 'Prompt'}
-          </div>
-          {isEditingPrompt && task?.config.prompt !== undefined ? (
-            <div className="mt-2 space-y-2">
-              <textarea
-                value={editPromptValue}
-                onChange={(event) => setEditPromptValue(event.target.value)}
-                rows={5}
-                className="w-full resize-y rounded border border-blue-500 bg-gray-950 p-2 text-xs text-gray-100 focus:outline-none"
-                data-testid="edit-prompt-input"
-              />
-              <div className="flex gap-2">
-                <button data-testid="save-prompt-btn" onClick={savePrompt} className="flex-1 rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500">
-                  Save & Re-run
-                </button>
-                <button onClick={() => setIsEditingPrompt(false)} className="flex-1 rounded bg-gray-700 px-2 py-1 text-xs text-gray-100 hover:bg-gray-600">
-                  Cancel
-                </button>
-              </div>
+        {hasExecutableContent && (
+          <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+            <div className="text-[11px] uppercase tracking-wide text-gray-400">
+              {hasPrompt ? 'Prompt' : 'Command'}
             </div>
-          ) : isEditingCommand && task?.config.command !== undefined ? (
-            <div className="mt-2 space-y-2">
-              <textarea
-                value={editCommandValue}
-                onChange={(event) => setEditCommandValue(event.target.value)}
-                rows={4}
-                className="w-full resize-y rounded border border-blue-500 bg-gray-950 p-2 font-mono text-xs text-green-300 focus:outline-none"
-                data-testid="edit-command-input"
-              />
-              <div className="flex gap-2">
-                <button data-testid="save-command-btn" onClick={saveCommand} className="flex-1 rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500">
-                  Save & Re-run
-                </button>
-                <button onClick={() => setIsEditingCommand(false)} className="flex-1 rounded bg-gray-700 px-2 py-1 text-xs text-gray-100 hover:bg-gray-600">
-                  Cancel
-                </button>
+            {isEditingPrompt && task?.config.prompt !== undefined ? (
+              <div className="mt-2 space-y-2">
+                <textarea
+                  value={editPromptValue}
+                  onChange={(event) => setEditPromptValue(event.target.value)}
+                  rows={5}
+                  className="w-full resize-y rounded border border-blue-500 bg-gray-950 p-2 text-xs text-gray-100 focus:outline-none"
+                  data-testid="edit-prompt-input"
+                />
+                <div className="flex gap-2">
+                  <button data-testid="save-prompt-btn" onClick={savePrompt} className="flex-1 rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500">
+                    Save & Re-run
+                  </button>
+                  <button onClick={() => setIsEditingPrompt(false)} className="flex-1 rounded bg-gray-700 px-2 py-1 text-xs text-gray-100 hover:bg-gray-600">
+                    Cancel
+                  </button>
+                </div>
               </div>
-            </div>
-          ) : (
-            <div
-              className={`mt-2 rounded border p-2 text-xs leading-relaxed ${
-                canEditPrompt || canEditCommand
-                  ? 'cursor-pointer border-gray-600 bg-gray-950 hover:border-blue-500'
-                  : 'cursor-text border-gray-700 bg-gray-950'
-              }`}
-              onClick={startEditingPromptOrCommand}
-              onDoubleClick={startEditingPromptOrCommand}
-              onDoubleClickCapture={startEditingPromptOrCommand}
-              data-testid="command-display"
-            >
-              <div data-testid="prompt-command-display" onClick={startEditingPromptOrCommand} onDoubleClick={startEditingPromptOrCommand}>
-                {task?.config.prompt ? (
-                  <p className="whitespace-pre-wrap break-words text-gray-200">{task.config.prompt}</p>
-                ) : task?.config.command ? (
-                  <code className="whitespace-pre-wrap break-words font-mono text-green-300">{task.config.command}</code>
-                ) : (
-                  <p className="text-gray-400">No prompt or command available.</p>
-                )}
+            ) : isEditingCommand && task?.config.command !== undefined ? (
+              <div className="mt-2 space-y-2">
+                <textarea
+                  value={editCommandValue}
+                  onChange={(event) => setEditCommandValue(event.target.value)}
+                  rows={4}
+                  className="w-full resize-y rounded border border-blue-500 bg-gray-950 p-2 font-mono text-xs text-green-300 focus:outline-none"
+                  data-testid="edit-command-input"
+                />
+                <div className="flex gap-2">
+                  <button data-testid="save-command-btn" onClick={saveCommand} className="flex-1 rounded bg-blue-600 px-2 py-1 text-xs text-white hover:bg-blue-500">
+                    Save & Re-run
+                  </button>
+                  <button onClick={() => setIsEditingCommand(false)} className="flex-1 rounded bg-gray-700 px-2 py-1 text-xs text-gray-100 hover:bg-gray-600">
+                    Cancel
+                  </button>
+                </div>
               </div>
-            </div>
-          )}
-        </section>
+            ) : (
+              <div
+                className={`mt-2 rounded border p-2 text-xs leading-relaxed ${
+                  canEditPrompt || canEditCommand
+                    ? 'cursor-pointer border-gray-600 bg-gray-950 hover:border-blue-500'
+                    : 'cursor-text border-gray-700 bg-gray-950'
+                }`}
+                onClick={startEditingPromptOrCommand}
+                onDoubleClick={startEditingPromptOrCommand}
+                onDoubleClickCapture={startEditingPromptOrCommand}
+                data-testid="command-display"
+              >
+                <div data-testid="prompt-command-display" onClick={startEditingPromptOrCommand} onDoubleClick={startEditingPromptOrCommand}>
+                  {hasPrompt ? (
+                    <p className="whitespace-pre-wrap break-words text-gray-200">{task?.config.prompt}</p>
+                  ) : (
+                    <code className="whitespace-pre-wrap break-words font-mono text-green-300">{task?.config.command}</code>
+                  )}
+                </div>
+              </div>
+            )}
+          </section>
+        )}
 
         <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
           <div className="text-[11px] uppercase tracking-wide text-gray-400">Pull Request</div>


### PR DESCRIPTION
## Summary

Hide the sidebar Prompt/Command panel unless the selected task actually has an AI prompt or command to show.

This removes the misleading "Prompt / No prompt or command available" block for workflow-only selections and non-executable task nodes such as merge gates, while preserving prompt and command editing for executable tasks.

Visual proof:

Before:

![Before sidebar prompt fallback](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260515-7e47a0/before-sidebar-non-exec-prompt.png)

After:

![After sidebar prompt fallback removed](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260515-7e47a0/after-sidebar-non-exec-prompt.png)

## Test Plan

- [x] `pnpm install`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/workflow-inspector.test.tsx`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app exec playwright install chromium`
- [x] `pnpm --filter @invoker/app exec playwright screenshot --viewport-size=920,660 http://127.0.0.1:5191/visual-proof-workflow-inspector.html packages/app/e2e/visual-proof/before/sidebar-non-exec-prompt.png`
- [x] `pnpm --filter @invoker/app exec playwright screenshot --viewport-size=920,660 http://127.0.0.1:5192/visual-proof-workflow-inspector.html packages/app/e2e/visual-proof/after/sidebar-non-exec-prompt.png`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert b101c2c1`
- Post-revert steps: None
- Data migration? No
