### PR TITLE
Dispatch tasks after review gate auto-approval

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -3922,13 +3922,17 @@ console.log(JSON.stringify(out));
     });
 
     it('merged PR auto-completes a review_ready merge gate', async () => {
+      const downstream = makeTask({
+        id: 'downstream-after-manual-check',
+        status: 'running',
+      });
       const orchestrator = {
         getTask: vi.fn((id: string) => ({
           id,
           status: 'review_ready',
           execution: { reviewId: 'owner/repo#42' },
         })),
-        approve: vi.fn(),
+        approve: vi.fn().mockResolvedValue([downstream]),
       };
       const persistence = {
         updateTask: vi.fn(),
@@ -3953,6 +3957,7 @@ console.log(JSON.stringify(out));
       // Simulate active poller
       const interval = setInterval(() => {}, 1000);
       (executor as any).activePrPollers.set('task-1', interval);
+      const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
       await executor.checkPrApprovalNow('task-1');
 
@@ -3960,6 +3965,7 @@ console.log(JSON.stringify(out));
         execution: { reviewStatus: 'Merged' },
       });
       expect(orchestrator.approve).toHaveBeenCalledWith('task-1');
+      expect(executeTasks).toHaveBeenCalledWith([downstream]);
 
       // Should stop polling after approval
       expect((executor as any).activePrPollers.has('task-1')).toBe(false);
@@ -4157,6 +4163,10 @@ console.log(JSON.stringify(out));
       });
 
       it('merged PR with workspacePath triggers orchestrator.approve', async () => {
+        const downstream = makeTask({
+          id: 'downstream-after-check-now',
+          status: 'running',
+        });
         const orchestrator = {
           getTask: vi.fn((id: string) => ({
             id,
@@ -4166,7 +4176,7 @@ console.log(JSON.stringify(out));
               workspacePath: '/workspace/approved-worktree',
             },
           })),
-          approve: vi.fn(),
+          approve: vi.fn().mockResolvedValue([downstream]),
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
@@ -4188,6 +4198,7 @@ console.log(JSON.stringify(out));
 
         const interval = setInterval(() => {}, 1000);
         (executor as any).activePrPollers.set('task-approved', interval);
+        const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
         await executor.checkPrApprovalNow('task-approved');
 
@@ -4199,6 +4210,7 @@ console.log(JSON.stringify(out));
           execution: { reviewStatus: 'Merged' },
         });
         expect(orchestrator.approve).toHaveBeenCalledWith('task-approved');
+        expect(executeTasks).toHaveBeenCalledWith([downstream]);
         expect((executor as any).activePrPollers.has('task-approved')).toBe(false);
       });
     });
@@ -4286,6 +4298,10 @@ console.log(JSON.stringify(out));
       });
 
       it('merged status with workspacePath triggers orchestrator.approve', async () => {
+        const downstream = makeTask({
+          id: 'downstream-after-refresh',
+          status: 'running',
+        });
         const allTasks = [
           makeTask({
             id: 'merge-approved',
@@ -4300,7 +4316,7 @@ console.log(JSON.stringify(out));
         const orchestrator = {
           getTask: (id: string) => allTasks.find(t => t.id === id),
           getAllTasks: () => allTasks,
-          approve: vi.fn(),
+          approve: vi.fn().mockResolvedValue([downstream]),
         };
         const persistence = { updateTask: vi.fn() };
         const mergeGateProvider = {
@@ -4318,6 +4334,7 @@ console.log(JSON.stringify(out));
           cwd: '/runner-base-cwd',
           mergeGateProvider: mergeGateProvider as any,
         });
+        const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
         await executor.checkMergeGateStatuses();
 
@@ -4329,6 +4346,7 @@ console.log(JSON.stringify(out));
           execution: { reviewStatus: 'Merged' },
         });
         expect(orchestrator.approve).toHaveBeenCalledWith('merge-approved');
+        expect(executeTasks).toHaveBeenCalledWith([downstream]);
       });
 
       it('approved-but-open PR updates persistence without completing the gate', async () => {
@@ -4473,6 +4491,10 @@ console.log(JSON.stringify(out));
       it('poll with workspacePath triggers orchestrator.approve on merged PR', async () => {
         vi.useFakeTimers();
         try {
+          const downstream = makeTask({
+            id: 'downstream-after-poll',
+            status: 'running',
+          });
           const orchestrator = {
             getTask: vi.fn((id: string) => ({
               id,
@@ -4482,7 +4504,7 @@ console.log(JSON.stringify(out));
                 workspacePath: '/workspace/poll-approved',
               },
             })),
-            approve: vi.fn(),
+            approve: vi.fn().mockResolvedValue([downstream]),
           };
           const persistence = { updateTask: vi.fn() };
           const mergeGateProvider = {
@@ -4500,6 +4522,7 @@ console.log(JSON.stringify(out));
             cwd: '/runner-base-cwd',
             mergeGateProvider: mergeGateProvider as any,
           });
+          const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
           (executor as any).startPrPolling('poll-approved', 'owner/repo#302', 'wf-1');
 
@@ -4513,6 +4536,7 @@ console.log(JSON.stringify(out));
             execution: { reviewStatus: 'Merged' },
           });
           expect(orchestrator.approve).toHaveBeenCalledWith('poll-approved');
+          expect(executeTasks).toHaveBeenCalledWith([downstream]);
           expect((executor as any).activePrPollers.has('poll-approved')).toBe(false);
         } finally {
           vi.useRealTimers();

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1737,6 +1737,13 @@ export class TaskRunner {
     }
   }
 
+  private async approveMergeGateAndDispatch(taskId: string): Promise<void> {
+    const newlyStarted = await this.orchestrator.approve(taskId);
+    if (newlyStarted.length > 0) {
+      await this.executeTasks(newlyStarted);
+    }
+  }
+
   async checkMergeGateStatuses(): Promise<void> {
     if (!this.mergeGateProvider) return;
     for (const task of this.orchestrator.getAllTasks()) {
@@ -1757,7 +1764,7 @@ export class TaskRunner {
           if (status.approved) {
             this.logger.info(`[merge-gate] PR ${task.execution.reviewId} approved (refresh), completing merge gate`);
             this.stopPrPolling(task.id);
-            await this.orchestrator.approve(task.id);
+            await this.approveMergeGateAndDispatch(task.id);
           } else if (status.rejected) {
             this.logger.info(`[merge-gate] PR ${task.execution.reviewId} rejected (refresh): ${status.statusText}`);
             this.stopPrPolling(task.id);
@@ -1789,7 +1796,7 @@ export class TaskRunner {
         if (status.approved) {
           this.logger.info(`[merge-gate] PR ${reviewId} approved, completing merge gate`);
           this.stopPrPolling(taskId);
-          await this.orchestrator.approve(taskId);
+          await this.approveMergeGateAndDispatch(taskId);
         } else if (status.rejected) {
           this.logger.info(`[merge-gate] PR ${reviewId} rejected: ${status.statusText}`);
           this.stopPrPolling(taskId);
@@ -1834,7 +1841,7 @@ export class TaskRunner {
       if (status.approved) {
         this.logger.info(`[merge-gate] PR ${reviewId} approved (manual check), completing merge gate`);
         this.stopPrPolling(taskId);
-        await this.orchestrator.approve(taskId);
+        await this.approveMergeGateAndDispatch(taskId);
       } else if (status.rejected) {
         this.logger.info(`[merge-gate] PR ${reviewId} rejected (manual check): ${status.statusText}`);
         this.stopPrPolling(taskId);

--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -5,6 +5,11 @@ const path = require('node:path');
 const { spawn, spawnSync } = require('node:child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
+const ELECTRON_INSTALL_ATTEMPTS = 3;
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
 
 function resolveElectronPackageDir() {
   const electronPackageJson = require.resolve('electron/package.json', {
@@ -109,18 +114,30 @@ function ensureElectronInstalled() {
   }
 
   const installScript = path.join(electronPackageDir, 'install.js');
-  const install = spawnSync(process.execPath, [installScript], {
-    cwd: repoRoot,
-    env: process.env,
-    stdio: 'inherit',
-  });
+  for (let attempt = 1; attempt <= ELECTRON_INSTALL_ATTEMPTS; attempt += 1) {
+    const install = spawnSync(process.execPath, [installScript], {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: 'inherit',
+    });
 
-  if (install.status !== 0) {
-    process.exit(install.status ?? 1);
-  }
-  if (install.signal) {
-    process.kill(process.pid, install.signal);
-    return null;
+    if (install.signal) {
+      process.kill(process.pid, install.signal);
+      return null;
+    }
+    if (install.status === 0) {
+      break;
+    }
+    if (attempt === ELECTRON_INSTALL_ATTEMPTS) {
+      process.exit(install.status ?? 1);
+    }
+
+    const delayMs = attempt * 1_000;
+    console.warn(
+      `Electron installer failed with exit code ${install.status ?? 1}; retrying in ${delayMs}ms ` +
+      `(${attempt + 1}/${ELECTRON_INSTALL_ATTEMPTS})`,
+    );
+    sleepSync(delayMs);
   }
 
   const repairedBinary = resolveInstalledElectronBinary(electronPackageDir);

--- a/scripts/repro/repro-review-gate-auto-continuation.sh
+++ b/scripts/repro/repro-review-gate-auto-continuation.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+base_ref="${1:-upstream/master}"
+tmp_root="$(mktemp -d "${TMPDIR:-/tmp}/invoker-review-gate-auto-continuation.XXXXXX")"
+before_worktree="$tmp_root/before"
+
+cleanup() {
+  git -C "$repo_root" worktree remove --force "$before_worktree" >/dev/null 2>&1 || true
+  rm -rf "$tmp_root"
+}
+trap cleanup EXIT
+
+echo "[repro] Creating before-fix worktree at $base_ref"
+git -C "$repo_root" worktree add --detach "$before_worktree" "$base_ref" >/dev/null
+
+cat > "$tmp_root/repro.patch" <<'PATCH'
+diff --git a/packages/execution-engine/src/__tests__/task-runner.test.ts b/packages/execution-engine/src/__tests__/task-runner.test.ts
+index 16b32712..961a29a7 100644
+--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
++++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
+@@ -4286,6 +4286,10 @@ console.log(JSON.stringify(out));
+       });
+ 
+       it('merged status with workspacePath triggers orchestrator.approve', async () => {
++        const downstream = makeTask({
++          id: 'downstream-after-refresh',
++          status: 'running',
++        });
+         const allTasks = [
+           makeTask({
+             id: 'merge-approved',
+@@ -4300,7 +4304,7 @@ console.log(JSON.stringify(out));
+         const orchestrator = {
+           getTask: (id: string) => allTasks.find(t => t.id === id),
+           getAllTasks: () => allTasks,
+-          approve: vi.fn(),
++          approve: vi.fn().mockResolvedValue([downstream]),
+         };
+         const persistence = { updateTask: vi.fn() };
+         const mergeGateProvider = {
+@@ -4318,6 +4322,7 @@ console.log(JSON.stringify(out));
+           cwd: '/runner-base-cwd',
+           mergeGateProvider: mergeGateProvider as any,
+         });
++        const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
+ 
+         await executor.checkMergeGateStatuses();
+ 
+@@ -4329,6 +4334,7 @@ console.log(JSON.stringify(out));
+           execution: { reviewStatus: 'Merged' },
+         });
+         expect(orchestrator.approve).toHaveBeenCalledWith('merge-approved');
++        expect(executeTasks).toHaveBeenCalledWith([downstream]);
+       });
+ 
+       it('approved-but-open PR updates persistence without completing the gate', async () => {
+PATCH
+
+echo "[repro] Installing dependencies in before-fix worktree"
+pnpm -C "$before_worktree" install --frozen-lockfile >/dev/null
+
+echo "[repro] Injecting failing assertion into before-fix worktree"
+git -C "$before_worktree" apply "$tmp_root/repro.patch"
+
+before_log="$tmp_root/before.log"
+echo "[repro] Running before-fix repro. This is expected to fail."
+set +e
+pnpm -C "$before_worktree" --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner.test.ts \
+  -t 'merged status with workspacePath triggers orchestrator.approve' \
+  >"$before_log" 2>&1
+before_status=$?
+set -e
+
+if [[ "$before_status" -eq 0 ]]; then
+  echo "[repro] ERROR: before-fix repro unexpectedly passed"
+  cat "$before_log"
+  exit 1
+fi
+
+if ! grep -q 'Number of calls: 0' "$before_log"; then
+  echo "[repro] ERROR: before-fix failure did not prove missing downstream dispatch"
+  cat "$before_log"
+  exit 1
+fi
+
+echo "[repro] Before-fix failure confirmed: approve returned downstream work, executeTasks was not called."
+
+echo "[repro] Installing dependencies in fixed worktree"
+pnpm -C "$repo_root" install --frozen-lockfile >/dev/null
+
+after_log="$tmp_root/after.log"
+echo "[repro] Running fixed-branch regression. This must pass."
+pnpm -C "$repo_root" --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner.test.ts \
+  -t 'merged status with workspacePath triggers orchestrator.approve' \
+  >"$after_log" 2>&1
+
+echo "[repro] Fixed-branch pass confirmed."


### PR DESCRIPTION
## Summary

Fix review-gate auto-continuation after an external review PR is merged.

Previously the automatic review-gate paths called `orchestrator.approve(...)` and completed the gate, but ignored the runnable tasks returned by approval. That left downstream DAG work in the graph without launching it.

This change routes all review-gate auto-approval paths through a shared helper that approves the gate and dispatches any newly started tasks via `TaskRunner.executeTasks(...)`. It also adds a repro script that demonstrates the before-fix failure on `upstream/master` and the after-fix pass on this branch.

CI initially failed before TypeScript/build commands ran because Electron postinstall hit a transient upstream `503 Service Unavailable`. This PR now retries the Electron installer a few times so transient CDN failures do not fail unrelated CI jobs.

## Architecture

### Before

```mermaid
flowchart TD
  A[GitHub PR merged] --> B[TaskRunner detects approved gate]
  B --> C[orchestrator.approve gate]
  C --> D[Gate marked completed]
  C --> E[Runnable downstream tasks returned]
  E --> F[Dropped]
```

### After

```mermaid
flowchart TD
  A[GitHub PR merged] --> B[TaskRunner detects approved gate]
  B --> C[approveMergeGateAndDispatch]
  C --> D[orchestrator.approve gate]
  D --> E[Gate marked completed]
  D --> F[Runnable downstream tasks returned]
  F --> G[TaskRunner.executeTasks]
```

## Test Plan

- [x] `scripts/repro/repro-review-gate-auto-continuation.sh upstream/master`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts -t 'merged PR auto-completes|merged PR with workspacePath|merged status with workspacePath|poll with workspacePath triggers'`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm run check:required-builds`
- [x] `node scripts/electron.cjs --ensure-only`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 14548163^..718f5f0c`
- Post-revert steps: None
- Data migration? No
