### PR TITLE
Fix full graph startup snapshot

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1197,7 +1197,6 @@ if (isHeadless) {
   let lastKnownWorkflowCount = 0;
   let lastActivityLogId = 0;
   let startupWorkflowId: string | null = null;
-  let allWorkflowsHydrated = false;
   let uiInteractive = false;
   let deferredStartupTriggered = false;
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
@@ -2243,7 +2242,6 @@ if (isHeadless) {
     const workflows = listWorkflowsByStartupRecency();
     lastKnownWorkflowCount = workflows.length;
     startupWorkflowId = workflows[0]?.id ?? null;
-    allWorkflowsHydrated = workflows.length === 0;
     if (!startupWorkflowId) {
       logger.info('[init] No workflows available for initial startup bootstrap', { module: 'init' });
       return;
@@ -2253,7 +2251,6 @@ if (isHeadless) {
         workflowCount: workflows.length,
         taskCount: orchestrator.getAllTasks().length,
       }));
-      allWorkflowsHydrated = true;
       const snapshotStats = (persistence as unknown as {
         getLastWorkflowTaskSnapshotStats?: () => Record<string, unknown> | null;
       }).getLastWorkflowTaskSnapshotStats?.();
@@ -2369,10 +2366,8 @@ if (isHeadless) {
               lastKnownWorkflowCount = workflows.length;
               mainWindow.webContents.send('invoker:workflows-changed', workflows);
 
-              if (allWorkflowsHydrated) {
-                orchestrator.syncAllFromDb();
-                logger.info(`Synced orchestrator for all ${workflows.length} workflows`, { module: 'db-poll' });
-              }
+              orchestrator.syncAllFromDb();
+              logger.info(`Synced orchestrator for all ${workflows.length} workflows`, { module: 'db-poll' });
             }
 
             for (const wf of workflows) {


### PR DESCRIPTION
## Summary

Remove the stale `allWorkflowsHydrated` startup gate left after the full-graph startup snapshot work was absorbed upstream. Workflow-count changes now resync the orchestrator unconditionally, matching the current full-snapshot bootstrap behavior and fixing the TypeScript break from the removed hydration state.

## Architecture

### Before

```mermaid
graph TD
    Poll[DB poll sees workflow-count change] --> Gate{allWorkflowsHydrated}
    Gate -->|true| Sync[syncAllFromDb]
    Gate -->|false| Skip[Skip orchestrator resync]
```

### After

```mermaid
graph TD
    Poll[DB poll sees workflow-count change] --> Sync[syncAllFromDb]
    Sync --> Renderer[workflow update remains complete]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] GitHub Actions CI after latest push

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 2eec5094`
- Post-revert steps: None
- Data migration? No
