### PR TITLE
Reset task runtime state before new attempts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           - name: Start Running MECE Repros
             command: bash scripts/test-suites/required/18-start-running-mece-repros.sh
           - name: Task New Attempt Reset Repro
-            command: bash scripts/test-suites/required/18-task-new-attempt-reset-repro.sh
+            command: bash scripts/test-suites/required/19-task-new-attempt-reset-repro.sh
 
     name: required-fast / ${{ matrix.name }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,8 @@ jobs:
             command: bash scripts/test-suites/required/17-merge-gate-concurrency-repro.sh
           - name: Start Running MECE Repros
             command: bash scripts/test-suites/required/18-start-running-mece-repros.sh
+          - name: Task New Attempt Reset Repro
+            command: bash scripts/test-suites/required/18-task-new-attempt-reset-repro.sh
 
     name: required-fast / ${{ matrix.name }}
 

--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -1,0 +1,200 @@
+import { test as base, _electron as electron, expect, type ElectronApplication, type Page } from '@playwright/test';
+import { tmpdir } from 'node:os';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { stringify as yamlStringify } from 'yaml';
+import { E2E_REPO_URL } from './fixtures/electron-app.js';
+
+const MAIN_JS = path.resolve(__dirname, '..', 'dist', 'main.js');
+
+const RESET_PLAN = {
+  name: 'Task New Attempt Reset Repro',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'fast-task',
+      description: 'Completes quickly',
+      command: 'echo fast',
+    },
+    {
+      id: 'slow-task',
+      description: 'Long task interrupted before resume',
+      command: 'sleep 60',
+      dependencies: ['fast-task'],
+    },
+  ],
+};
+
+function launchArgs(): string[] {
+  return [
+    ...(process.platform === 'linux'
+      ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
+      : []),
+    MAIN_JS,
+  ];
+}
+
+async function waitForInvoker(page: Page): Promise<void> {
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
+}
+
+function findTask(tasks: Array<{ id: string; status: string }>, taskId: string) {
+  return tasks.find((task) => task.id === taskId || task.id.endsWith(`/${taskId}`));
+}
+
+async function getTasks(page: Page): Promise<any[]> {
+  const result = await page.evaluate(() => window.invoker.getTasks(true));
+  return Array.isArray(result) ? result : result.tasks;
+}
+
+async function waitForTask(page: Page, taskId: string, predicate: (task: any) => boolean): Promise<any> {
+  const deadline = Date.now() + 45_000;
+  let task: any;
+  while (Date.now() < deadline) {
+    task = findTask(await getTasks(page), taskId);
+    if (task && predicate(task)) return task;
+    await page.waitForTimeout(250);
+  }
+  throw new Error(`Timed out waiting for ${taskId}; last=${JSON.stringify(task)}`);
+}
+
+async function launchApp(testDir: string, configPath: string): Promise<{ app: ElectronApplication; page: Page }> {
+  const app = await electron.launch({
+    args: launchArgs(),
+    env: {
+      ...process.env,
+      NODE_ENV: 'test',
+      TZ: 'UTC',
+      INVOKER_DB_DIR: testDir,
+      INVOKER_ALLOW_DELETE_ALL: '1',
+      INVOKER_E2E_ENABLE_COMPOSITOR: '1',
+      INVOKER_REPO_CONFIG_PATH: configPath,
+    },
+  });
+  const page = await app.firstWindow();
+  await waitForInvoker(page);
+  return { app, page };
+}
+
+async function seedStaleLaunchAttempt(dbPath: string, taskId: string, attemptId: string, staleAt: Date): Promise<void> {
+  const adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+  try {
+    adapter.saveAttempt({
+      id: attemptId,
+      nodeId: taskId,
+      queuePriority: 0,
+      upstreamAttemptIds: [],
+      status: 'claimed',
+      claimedAt: staleAt,
+      startedAt: staleAt,
+      lastHeartbeatAt: staleAt,
+      branch: 'stale-branch',
+      commit: 'stale-commit',
+      workspacePath: '/tmp/stale-workspace',
+      agentSessionId: 'stale-session',
+      createdAt: staleAt,
+    });
+    adapter.updateTask(taskId, {
+      status: 'pending',
+      execution: {
+        phase: 'launching',
+        startedAt: staleAt,
+        lastHeartbeatAt: staleAt,
+        launchStartedAt: staleAt,
+        launchCompletedAt: staleAt,
+        selectedAttemptId: attemptId,
+        branch: 'stale-branch',
+        commit: 'stale-commit',
+        workspacePath: '/tmp/stale-workspace',
+        agentSessionId: 'stale-session',
+        error: 'stale launch error',
+        exitCode: 123,
+        inputPrompt: 'stale prompt',
+        pendingFixError: 'stale fix error',
+      },
+    });
+  } finally {
+    adapter.close();
+  }
+}
+
+base.describe('Task new-attempt reset repro', () => {
+  base('explicit resume supersedes stale selected attempt and clears launch runtime state', async () => {
+    const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-new-attempt-reset-'));
+    const configPath = path.join(testDir, 'e2e-config.json');
+    const dbPath = path.join(testDir, 'invoker.db');
+    writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
+
+    let app: ElectronApplication | undefined;
+    try {
+      const launched = await launchApp(testDir, configPath);
+      app = launched.app;
+      let page = launched.page;
+
+      await page.evaluate(async () => {
+        await window.invoker.clear();
+        await window.invoker.deleteAllWorkflows();
+      });
+      await page.evaluate((planYaml) => window.invoker.loadPlan(planYaml), yamlStringify(RESET_PLAN));
+
+      const loaded = await waitForTask(page, 'slow-task', (task) => task.status === 'pending');
+      const oldAttemptId = `${loaded.id}-old-attempt`;
+      const staleTs = '2025-01-01T00:00:00.000Z';
+      await app.close();
+      app = undefined;
+      await seedStaleLaunchAttempt(dbPath, loaded.id, oldAttemptId, new Date(staleTs));
+
+      const relaunchedApp = await launchApp(testDir, configPath);
+      app = relaunchedApp.app;
+      page = relaunchedApp.page;
+
+      const staleBeforeResume = await waitForTask(
+        page,
+        'slow-task',
+        (task) =>
+          task.status === 'pending'
+          && task.execution?.phase === 'launching'
+          && task.execution?.selectedAttemptId === oldAttemptId,
+      );
+      expect(staleBeforeResume.execution.selectedAttemptId).toBe(oldAttemptId);
+
+      await page.evaluate(() => window.invoker.resumeWorkflow());
+
+      const relaunched = await waitForTask(
+        page,
+        'slow-task',
+        (task) =>
+          task.status === 'running'
+          && task.execution?.selectedAttemptId
+          && task.execution.selectedAttemptId !== oldAttemptId
+          && task.execution.phase !== 'launching',
+      );
+      const newAttemptId = relaunched.execution.selectedAttemptId;
+      expect(newAttemptId).toBeTruthy();
+      expect(newAttemptId).not.toBe(oldAttemptId);
+      expect(relaunched.execution.startedAt).not.toBe(staleTs);
+      expect(relaunched.execution.launchStartedAt).not.toBe(staleTs);
+      expect(relaunched.execution.launchCompletedAt).not.toBe(staleTs);
+      expect(relaunched.execution.workspacePath).not.toBe('/tmp/stale-workspace');
+      expect(relaunched.execution.agentSessionId).toBeUndefined();
+      expect(relaunched.execution.error).toBeUndefined();
+      expect(relaunched.execution.exitCode).toBeUndefined();
+      expect(relaunched.execution.inputPrompt).toBeUndefined();
+      expect(relaunched.execution.pendingFixError).toBeUndefined();
+
+      const graph = await page.evaluate(() => window.invoker.getActionGraph());
+      const oldAttempt = graph.nodes.find((node: any) => node.attemptId === oldAttemptId);
+      const newAttempt = graph.nodes.find((node: any) => node.attemptId === newAttemptId);
+      expect(oldAttempt?.status).toBe('cancelled');
+      expect(newAttempt?.status).toBe('running');
+    } finally {
+      await app?.close().catch(() => undefined);
+      if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
+        rmSync(testDir, { recursive: true, force: true });
+      }
+    }
+  });
+});

--- a/packages/app/src/orphan-relaunch.ts
+++ b/packages/app/src/orphan-relaunch.ts
@@ -8,6 +8,7 @@ export function relaunchOrphansAndStartReady(
   logPrefix: string,
   workflowId?: string,
 ): TaskState[] {
+  let preparedOrphanCount = 0;
   const orphanRestarted: TaskState[] = [];
   const activeTaskIds = orchestrator.getPersistedActiveTaskIds?.() ?? new Set<string>();
   for (const task of orchestrator.getAllTasks()) {
@@ -31,30 +32,32 @@ export function relaunchOrphansAndStartReady(
         `startedAt=${startedAt} lastHeartbeatAt=${lastHeartbeat} generation=${task.execution.generation ?? 0}`,
       { module: logPrefix },
     );
-    const started = orchestrator.retryTask(task.id);
-    const runnable = started.filter(isDispatchableLaunch);
-    if (runnable.length > 0) {
-      orphanRestarted.push(...runnable);
-      continue;
+    const prepareTaskForNewAttempt = (
+      orchestrator as Partial<Pick<Orchestrator, 'prepareTaskForNewAttempt'>>
+    ).prepareTaskForNewAttempt;
+    if (typeof prepareTaskForNewAttempt === 'function') {
+      prepareTaskForNewAttempt.call(orchestrator, task.id, `${logPrefix}_orphan_relaunch`);
+    } else {
+      const started = orchestrator.retryTask(task.id);
+      const runnable = started.filter(isDispatchableLaunch);
+      if (runnable.length > 0) {
+        orphanRestarted.push(...runnable);
+      } else {
+        const refreshed = orchestrator.getTask?.(task.id);
+        orphanRestarted.push(refreshed?.status === 'running' ? refreshed : { ...task, status: 'running' });
+      }
     }
-
-    const refreshed = orchestrator.getTask?.(task.id);
-    if (refreshed?.status === 'running') {
-      orphanRestarted.push(refreshed);
-      continue;
-    }
-
-    orphanRestarted.push({
-      ...task,
-      status: 'running',
-    });
+    preparedOrphanCount += 1;
   }
 
   const readyStarted = orchestrator.startExecution();
-  const allStarted = [...orphanRestarted, ...readyStarted];
+  const allStarted = [
+    ...orphanRestarted,
+    ...readyStarted.filter(isDispatchableLaunch),
+  ];
   if (allStarted.length > 0) {
     logger.info(
-      `started ${allStarted.length} tasks (${orphanRestarted.length} orphans relaunched, ${readyStarted.length} ready): [${allStarted.map((task) => task.id).join(', ')}]`,
+      `started ${allStarted.length} tasks (${preparedOrphanCount} orphans prepared, ${readyStarted.length} ready): [${allStarted.map((task) => task.id).join(', ')}]`,
       { module: logPrefix },
     );
   }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2728,8 +2728,16 @@ describe('Orchestrator', () => {
       expect(resumeOrchestrator.getTask('t3')!.status).toBe('running');
     });
 
-    it('preserves running tasks and only starts pending ones', () => {
+    it('recovers stale running tasks and starts a fresh attempt', () => {
       const resumePersistence = new InMemoryPersistence();
+      const oldAttempt: Attempt = {
+        id: 't1-aold',
+        nodeId: 't1',
+        queuePriority: 0,
+        status: 'running',
+        upstreamAttemptIds: [],
+        createdAt: new Date(),
+      };
       resumePersistence.saveTask('wf-resume', {
         id: 't1',
         description: 'Was running when process died',
@@ -2737,8 +2745,9 @@ describe('Orchestrator', () => {
         dependencies: [],
         createdAt: new Date(),
         config: {},
-        execution: { startedAt: new Date() },
+        execution: { startedAt: new Date(), selectedAttemptId: oldAttempt.id },
       });
+      resumePersistence.saveAttempt(oldAttempt);
 
       const resumeOrchestrator = new Orchestrator({
         persistence: resumePersistence,
@@ -2748,8 +2757,194 @@ describe('Orchestrator', () => {
 
       const started = resumeOrchestrator.resumeWorkflow('wf-resume');
 
-      expect(started).toHaveLength(0);
+      expect(started).toHaveLength(1);
       expect(resumeOrchestrator.getTask('t1')!.status).toBe('running');
+      const newAttemptId = resumeOrchestrator.getTask('t1')!.execution.selectedAttemptId;
+      expect(newAttemptId).toBeTruthy();
+      expect(newAttemptId).not.toBe(oldAttempt.id);
+      expect(resumePersistence.loadAttempt(oldAttempt.id)?.status).toBe('superseded');
+      expect(resumePersistence.loadAttempt(newAttemptId!)?.status).toBe('running');
+    });
+  });
+
+  describe('prepareTaskForNewAttempt', () => {
+    it('resets a running launching task to pending with a fresh selected attempt and preserves durable fields', () => {
+      orchestrator.loadPlan({
+        name: 'prepare-running-launching',
+        tasks: [
+          {
+            id: 't0',
+            description: 'Dependency',
+            command: 'echo dep',
+          },
+          {
+            id: 't1',
+            description: 'Task 1',
+            command: 'pnpm test',
+            prompt: 'Keep this prompt',
+            dependencies: ['t0'],
+          },
+        ],
+      });
+
+      const [depStarted] = orchestrator.startExecution();
+      const depAttemptId = depStarted!.execution.selectedAttemptId!;
+      orchestrator.handleWorkerResponse(
+        makeResponse({ actionId: depStarted!.id, status: 'completed', outputs: { exitCode: 0 } }),
+      );
+      const taskId = sid(orchestrator, 0, 't1');
+      const oldAttemptId = orchestrator.getTask(taskId)!.execution.selectedAttemptId!;
+      const startedAt = new Date('2026-04-16T05:25:16.531Z');
+      const completedAt = new Date('2026-04-16T05:35:16.531Z');
+      const heartbeatAt = new Date('2026-04-16T05:30:16.531Z');
+      const launchCompletedAt = new Date('2026-04-16T05:25:20.531Z');
+      persistence.updateTask(taskId, {
+        status: 'running',
+        config: {
+          summary: 'durable summary',
+          problem: 'durable problem',
+          approach: 'durable approach',
+          testPlan: 'durable test plan',
+        },
+        execution: {
+          phase: 'launching',
+          startedAt,
+          completedAt,
+          launchStartedAt: startedAt,
+          launchCompletedAt,
+          lastHeartbeatAt: heartbeatAt,
+          error: 'volatile error',
+          exitCode: 1,
+          inputPrompt: 'volatile prompt',
+          pendingFixError: 'volatile fix error',
+          agentSessionId: 'sess-1',
+          workspacePath: '/tmp/workspace',
+          containerId: 'container-1',
+          isFixingWithAI: true,
+          branch: 'feature/task',
+          commit: 'abc123',
+          reviewUrl: 'https://example.test/review',
+          reviewId: 'review-1',
+          reviewStatus: 'open',
+          reviewProviderId: 'provider-1',
+        },
+      });
+
+      const prepared = orchestrator.prepareTaskForNewAttempt(taskId, 'unit-test');
+      const newAttemptId = prepared.execution.selectedAttemptId!;
+
+      expect(prepared.status).toBe('pending');
+      expect(newAttemptId).toBeTruthy();
+      expect(newAttemptId).not.toBe(oldAttemptId);
+      expect(persistence.loadAttempt(oldAttemptId)?.status).toBe('superseded');
+      expect(persistence.loadAttempt(newAttemptId)?.status).toBe('pending');
+      expect(persistence.loadAttempt(newAttemptId)?.supersedesAttemptId).toBe(oldAttemptId);
+      expect(prepared.execution.phase).toBeUndefined();
+      expect(prepared.execution.startedAt).toBeUndefined();
+      expect(prepared.execution.completedAt).toBeUndefined();
+      expect(prepared.execution.launchStartedAt).toBeUndefined();
+      expect(prepared.execution.launchCompletedAt).toBeUndefined();
+      expect(prepared.execution.lastHeartbeatAt).toBeUndefined();
+      expect(prepared.execution.error).toBeUndefined();
+      expect(prepared.execution.exitCode).toBeUndefined();
+      expect(prepared.execution.inputPrompt).toBeUndefined();
+      expect(prepared.execution.pendingFixError).toBeUndefined();
+      expect(prepared.execution.agentSessionId).toBeUndefined();
+      expect(prepared.execution.workspacePath).toBeUndefined();
+      expect(prepared.execution.containerId).toBeUndefined();
+      expect(prepared.execution.isFixingWithAI).toBe(false);
+      expect(prepared.config.command).toBe('pnpm test');
+      expect(prepared.config.prompt).toBe('Keep this prompt');
+      expect(prepared.config.summary).toBe('durable summary');
+      expect(prepared.config.problem).toBe('durable problem');
+      expect(prepared.config.approach).toBe('durable approach');
+      expect(prepared.config.testPlan).toBe('durable test plan');
+      expect(prepared.dependencies).toEqual([sid(orchestrator, 0, 't0')]);
+      expect(prepared.execution.branch).toBe('feature/task');
+      expect(prepared.execution.commit).toBe('abc123');
+      expect(prepared.execution.reviewUrl).toBe('https://example.test/review');
+      expect(prepared.execution.reviewId).toBe('review-1');
+      expect(prepared.execution.reviewStatus).toBe('open');
+      expect(prepared.execution.reviewProviderId).toBe('provider-1');
+      expect(persistence.loadAttempt(newAttemptId)?.upstreamAttemptIds).toEqual([depAttemptId]);
+      expect(persistence.events.at(-1)).toEqual({
+        taskId,
+        eventType: 'task.prepared_for_new_attempt',
+        payload: {
+          reason: 'unit-test',
+          oldAttemptId,
+          newAttemptId,
+        },
+      });
+    });
+
+    it('resets a pending launching task with a claimed selected attempt', () => {
+      const claimedOrchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        maxConcurrency: 3,
+        deferRunningUntilLaunch: true,
+      });
+      claimedOrchestrator.loadPlan({
+        name: 'prepare-claimed-launching',
+        tasks: [{ id: 't1', description: 'Task 1' }],
+      });
+
+      const [started] = claimedOrchestrator.startExecution();
+      const taskId = started!.id;
+      const oldAttemptId = started!.execution.selectedAttemptId!;
+      expect(started!.status).toBe('pending');
+      expect(started!.execution.phase).toBe('launching');
+      expect(persistence.loadAttempt(oldAttemptId)?.status).toBe('claimed');
+
+      const prepared = claimedOrchestrator.prepareTaskForNewAttempt(taskId, 'claimed-launch-reset');
+      const newAttemptId = prepared.execution.selectedAttemptId!;
+
+      expect(prepared.status).toBe('pending');
+      expect(prepared.execution.phase).toBeUndefined();
+      expect(prepared.execution.launchStartedAt).toBeUndefined();
+      expect(prepared.execution.lastHeartbeatAt).toBeUndefined();
+      expect(newAttemptId).not.toBe(oldAttemptId);
+      expect(persistence.loadAttempt(oldAttemptId)?.status).toBe('superseded');
+      expect(persistence.loadAttempt(newAttemptId)?.status).toBe('pending');
+    });
+
+    it('rejects terminal tasks without changing attempts', () => {
+      for (const status of ['completed', 'failed'] as const) {
+        const taskId = `t-${status}`;
+        const attempt: Attempt = {
+          id: `${taskId}-aold`,
+          nodeId: taskId,
+          queuePriority: 0,
+          status,
+          upstreamAttemptIds: [],
+          createdAt: new Date(),
+        };
+        persistence.saveTask('wf-terminal', {
+          id: taskId,
+          description: `${status} task`,
+          status,
+          dependencies: [],
+          createdAt: new Date(),
+          config: {},
+          execution: {
+            completedAt: new Date('2026-04-16T05:35:16.531Z'),
+            error: status === 'failed' ? 'boom' : undefined,
+            selectedAttemptId: attempt.id,
+          },
+        });
+        persistence.saveAttempt(attempt);
+      }
+      orchestrator.syncFromDb('wf-terminal');
+
+      for (const status of ['completed', 'failed'] as const) {
+        const taskId = `t-${status}`;
+        const attemptId = `${taskId}-aold`;
+        expect(() => orchestrator.prepareTaskForNewAttempt(taskId, 'terminal-test')).toThrow('terminal');
+        expect(orchestrator.getTask(taskId)!.status).toBe(status);
+        expect(orchestrator.getTask(taskId)!.execution.selectedAttemptId).toBe(attemptId);
+        expect(persistence.loadAttempt(attemptId)?.status).toBe(status);
+      }
     });
   });
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -60,6 +60,7 @@ function isActiveForInvalidation(status: TaskStatus): boolean {
     status === 'review_ready'
   );
 }
+
 import { getTransitiveDependents } from '@invoker/workflow-graph';
 import { ActionGraph } from '@invoker/workflow-graph';
 import {
@@ -81,6 +82,13 @@ import {
 
 const TASK_DELTA_CHANNEL = 'task.delta';
 let workflowCounter = 0;
+
+function isReplaceableAttemptStatus(status: Attempt['status']): boolean {
+  return status === 'pending'
+    || status === 'claimed'
+    || status === 'running'
+    || status === 'needs_input';
+}
 
 function nextWorkflowId(): string {
   workflowCounter += 1;
@@ -1216,6 +1224,79 @@ export class Orchestrator {
     this.taskRepository.saveAttempt(freshAttempt);
     this.writeAndSync(task.id, { execution: { selectedAttemptId: freshAttempt.id } }, writeOpts);
     return freshAttempt.id;
+  }
+
+  prepareTaskForNewAttempt(taskId: string, reason: string): TaskState {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) {
+      throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    }
+    if (task.status === 'completed' || task.status === 'failed') {
+      throw new OrchestratorError(
+        OrchestratorErrorCode.TASK_ALREADY_TERMINAL,
+        `Task ${task.id} is terminal and cannot be prepared for a new attempt`,
+      );
+    }
+
+    const selected = this.getSelectedAttempt(task);
+    const loadAttempts = (this.persistence as Partial<OrchestratorPersistence>).loadAttempts;
+    const attempts =
+      typeof loadAttempts === 'function' ? loadAttempts.call(this.persistence, task.id) : [];
+    const latest = attempts[attempts.length - 1];
+    const activeAttempt = selected && isReplaceableAttemptStatus(selected.status)
+      ? selected
+      : latest && isReplaceableAttemptStatus(latest.status)
+        ? latest
+        : undefined;
+
+    const upstreamAttemptIds = task.dependencies
+      .map(depId => this.stateGetTask(depId)?.execution.selectedAttemptId)
+      .filter((id): id is string => !!id);
+    const freshAttempt = createAttempt(task.id, {
+      status: 'pending',
+      snapshotCommit: activeAttempt?.commit,
+      upstreamAttemptIds,
+      supersedesAttemptId: activeAttempt?.id,
+    });
+
+    const changes = this.withBumpedExecutionGeneration(task, {
+      status: 'pending',
+      execution: {
+        selectedAttemptId: freshAttempt.id,
+        phase: undefined,
+        startedAt: undefined,
+        completedAt: undefined,
+        launchStartedAt: undefined,
+        launchCompletedAt: undefined,
+        lastHeartbeatAt: undefined,
+        error: undefined,
+        exitCode: undefined,
+        inputPrompt: undefined,
+        pendingFixError: undefined,
+        agentSessionId: undefined,
+        workspacePath: undefined,
+        containerId: undefined,
+        isFixingWithAI: false,
+      },
+    });
+
+    let updated!: TaskState;
+    this.taskRepository.runInTransaction(() => {
+      if (activeAttempt) {
+        this.taskRepository.updateAttempt(activeAttempt.id, { status: 'superseded' });
+      }
+      this.taskRepository.saveAttempt(freshAttempt);
+      updated = this.writeAndSync(task.id, changes);
+    });
+    this.clearQueuedSchedulerEntries(task.id, task.execution.selectedAttemptId);
+    this.persistence.logEvent?.(task.id, 'task.prepared_for_new_attempt', {
+      reason,
+      oldAttemptId: activeAttempt?.id,
+      newAttemptId: freshAttempt.id,
+    });
+    this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
+    return updated;
   }
 
   private updateSelectedAttempt(
@@ -3557,6 +3638,21 @@ export class Orchestrator {
    */
   resumeWorkflow(workflowId: string): TaskState[] {
     this.syncFromDb(workflowId);
+    const workflowTaskIds = new Set(this.persistence.loadTasks(workflowId).map((task) => task.id));
+    const tasksToRecover = this.stateMachine
+      .getAllTasks()
+      .filter((task) => task.config.workflowId === workflowId || workflowTaskIds.has(task.id))
+      .filter((task) =>
+        task.status === 'running'
+        || (
+          task.status === 'pending'
+          && task.execution.phase === 'launching'
+          && !!task.execution.selectedAttemptId
+        )
+      );
+    for (const task of tasksToRecover) {
+      this.prepareTaskForNewAttempt(task.id, 'resume_workflow_recovery');
+    }
     return this.startExecution();
   }
 

--- a/scripts/check-owner-boundary.sh
+++ b/scripts/check-owner-boundary.sh
@@ -15,6 +15,7 @@ if command -v rg >/dev/null 2>&1; then
     --glob '!**/*.test.ts' \
     --glob '!**/*.d.ts' \
     --glob '!**/dist/**' \
+    --glob '!**/e2e/**' \
     --glob '!**/node_modules/**' \
     --glob '!packages/app/src/main.ts' \
     --glob '!packages/persistence/src/sqlite-adapter.ts' \
@@ -27,6 +28,7 @@ if command -v rg >/dev/null 2>&1; then
     --glob '!**/*.test.ts' \
     --glob '!**/*.d.ts' \
     --glob '!**/dist/**' \
+    --glob '!**/e2e/**' \
     --glob '!**/node_modules/**' \
     --glob '!packages/app/src/main.ts' || true)"
 
@@ -40,6 +42,7 @@ else
   create_violations="$(grep -RInE "SQLiteAdapter\\.create\\(" packages \
     --exclude-dir="__tests__" \
     --exclude-dir="dist" \
+    --exclude-dir="e2e" \
     --exclude-dir="node_modules" \
     --exclude="*.d.ts" \
     --exclude="*.test.ts" \
@@ -50,6 +53,7 @@ else
   value_import_violations="$(grep -RInE "import[[:space:]]+\\{[^}]*SQLiteAdapter[^}]*\\}[[:space:]]+from[[:space:]]+'@invoker/(persistence|data-store)'" packages \
     --exclude-dir="__tests__" \
     --exclude-dir="dist" \
+    --exclude-dir="e2e" \
     --exclude-dir="node_modules" \
     --exclude="*.d.ts" \
     --exclude="*.test.ts" \

--- a/scripts/test-suites/required/18-task-new-attempt-reset-repro.sh
+++ b/scripts/test-suites/required/18-task-new-attempt-reset-repro.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Electron repro for explicit resume replacing stale task launch attempts.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/ui build
+pnpm --filter @invoker/app build
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec pnpm --filter @invoker/app exec xvfb-run --auto-servernum playwright test \
+    e2e/task-new-attempt-reset.spec.ts
+fi
+
+exec pnpm --filter @invoker/app exec playwright test \
+  e2e/task-new-attempt-reset.spec.ts

--- a/scripts/test-suites/required/19-task-new-attempt-reset-repro.sh
+++ b/scripts/test-suites/required/19-task-new-attempt-reset-repro.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Electron repro for explicit resume replacing stale task launch attempts.
+# Required regression coverage for explicit resume replacing stale task launch attempts.
 set -euo pipefail
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "$ROOT"


### PR DESCRIPTION
## Summary

Add a task-level `prepareTaskForNewAttempt(taskId, reason)` primitive and route explicit resume/requeue recovery through it so stale `pending`/`running` launch state is replaced before a new attempt starts. The reset supersedes the old selected attempt, creates a fresh pending attempt, clears volatile runtime fields, and preserves task definition, dependency, output, review, branch, and commit provenance.

This update also adds required e2e regression coverage for the stale selected-attempt case and registers it in CI.

## Architecture

### Before

```mermaid
graph TD
    A[Explicit resume/requeue] --> B[Retry/relaunch task]
    B --> C[Task keeps stale launch/runtime fields]
    C --> D[Existing selected attempt remains active]
    D --> E[New launch can inherit stale state]
```

### After

```mermaid
graph TD
    A[Explicit resume/requeue] --> B[prepareTaskForNewAttempt]
    B --> C[Supersede active selected/latest attempt]
    C --> D[Create fresh pending attempt]
    D --> E[Clear volatile runtime fields]
    E --> F[startExecution launches clean attempt]
```

## Test Plan

- [x] `cd packages/workflow-core && pnpm test -- orchestrator.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/orphan-relaunch.test.ts src/__tests__/orphan-reconciliation.test.ts src/__tests__/headless-delegation.test.ts`
- [x] `bash scripts/test-suites/required/19-task-new-attempt-reset-repro.sh`
- [x] `pnpm run check:types`
- [x] `git diff --check`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 247a9934 99cc6673`
- Post-revert steps: Remove the CI matrix entry if reverting manually rather than with git revert.
- Data migration? No
