### PR TITLE
Fail fast when Electron is not provisioned

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
-    "postinstall": "node scripts/electron.cjs --ensure-only",
+    "postinstall": "node scripts/electron.cjs --install-only",
     "test": "bash scripts/test-plan-to-invoker-skill.sh && bash scripts/workspace-test.sh",
     "test:high-resource": "bash scripts/test-plan-to-invoker-skill.sh && INVOKER_VITEST_HIGH_RESOURCE=1 bash scripts/workspace-test.sh",
     "test:low-resource": "pnpm run test",

--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -2,26 +2,33 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawn, spawnSync } = require('node:child_process');
+const { spawn } = require('node:child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
-const ELECTRON_INSTALL_ATTEMPTS = 3;
-
-function sleepSync(ms) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
+const MISSING_ELECTRON_MESSAGE =
+  'Electron is not installed. Provision this machine before running Invoker: ' +
+  'run pnpm install with network access and approved Electron build scripts.';
 
 function resolveElectronPackageDir() {
-  const electronPackageJson = require.resolve('electron/package.json', {
-    paths: [
-      path.join(repoRoot, 'packages', 'app'),
-      repoRoot,
-    ],
-  });
+  let electronPackageJson;
+  try {
+    electronPackageJson = require.resolve('electron/package.json', {
+      paths: [
+        path.join(repoRoot, 'packages', 'app'),
+        repoRoot,
+      ],
+    });
+  } catch {
+    return null;
+  }
   return path.dirname(electronPackageJson);
 }
 
 function resolveInstalledElectronBinary(electronPackageDir) {
+  if (!electronPackageDir) {
+    return null;
+  }
+
   const pathFile = path.join(electronPackageDir, 'path.txt');
   if (!fs.existsSync(pathFile)) {
     return null;
@@ -38,124 +45,15 @@ function resolveInstalledElectronBinary(electronPackageDir) {
   return fs.existsSync(binaryPath) ? binaryPath : null;
 }
 
-function getElectronPlatformPath() {
-  const platform = process.env.npm_config_platform || process.platform;
-
-  switch (platform) {
-    case 'mas':
-    case 'darwin':
-      return 'Electron.app/Contents/MacOS/Electron';
-    case 'freebsd':
-    case 'openbsd':
-    case 'linux':
-      return 'electron';
-    case 'win32':
-      return 'electron.exe';
-    default:
-      throw new Error(`Electron builds are not available on platform: ${platform}`);
-  }
-}
-
-async function repairElectronWithSystemUnzip(electronPackageDir) {
-  if (process.env.ELECTRON_OVERRIDE_DIST_PATH) {
-    return null;
-  }
-
-  const electronPackage = require(path.join(electronPackageDir, 'package.json'));
-  const electronGetPath = require.resolve('@electron/get', {
-    paths: [electronPackageDir],
-  });
-  const { downloadArtifact } = require(electronGetPath);
-  const platformPath = getElectronPlatformPath();
-  const platform = process.env.npm_config_platform || process.platform;
-  const arch = process.env.npm_config_arch || process.arch;
-  const zipPath = await downloadArtifact({
-    version: electronPackage.version,
-    artifactName: 'electron',
-    force: process.env.force_no_cache === 'true',
-    cacheRoot: process.env.electron_config_cache,
-    checksums: process.env.electron_use_remote_checksums ?? process.env.npm_config_electron_use_remote_checksums
-      ? undefined
-      : require(path.join(electronPackageDir, 'checksums.json')),
-    platform,
-    arch,
-  });
-
-  const distPath = path.join(electronPackageDir, 'dist');
-  fs.rmSync(distPath, { recursive: true, force: true });
-  fs.mkdirSync(distPath, { recursive: true });
-
-  const unzip = spawnSync('unzip', ['-q', '-o', zipPath, '-d', distPath], {
-    cwd: electronPackageDir,
-    env: process.env,
-    stdio: 'inherit',
-  });
-  if (unzip.status !== 0) {
-    return null;
-  }
-  if (unzip.signal) {
-    process.kill(process.pid, unzip.signal);
-    return null;
-  }
-
-  const sourceTypeDefinitions = path.join(distPath, 'electron.d.ts');
-  if (fs.existsSync(sourceTypeDefinitions)) {
-    fs.renameSync(sourceTypeDefinitions, path.join(electronPackageDir, 'electron.d.ts'));
-  }
-  fs.writeFileSync(path.join(electronPackageDir, 'path.txt'), platformPath);
-  return resolveInstalledElectronBinary(electronPackageDir);
-}
-
-function ensureElectronInstalled() {
+function getElectronBinaryOrExit() {
   const electronPackageDir = resolveElectronPackageDir();
   const existingBinary = resolveInstalledElectronBinary(electronPackageDir);
   if (existingBinary) {
     return existingBinary;
   }
 
-  const installScript = path.join(electronPackageDir, 'install.js');
-  for (let attempt = 1; attempt <= ELECTRON_INSTALL_ATTEMPTS; attempt += 1) {
-    const install = spawnSync(process.execPath, [installScript], {
-      cwd: repoRoot,
-      env: process.env,
-      stdio: 'inherit',
-    });
-
-    if (install.signal) {
-      process.kill(process.pid, install.signal);
-      return null;
-    }
-    if (install.status === 0) {
-      break;
-    }
-    if (attempt === ELECTRON_INSTALL_ATTEMPTS) {
-      process.exit(install.status ?? 1);
-    }
-
-    const delayMs = attempt * 1_000;
-    console.warn(
-      `Electron installer failed with exit code ${install.status ?? 1}; retrying in ${delayMs}ms ` +
-      `(${attempt + 1}/${ELECTRON_INSTALL_ATTEMPTS})`,
-    );
-    sleepSync(delayMs);
-  }
-
-  const repairedBinary = resolveInstalledElectronBinary(electronPackageDir);
-  if (!repairedBinary) {
-    return repairElectronWithSystemUnzip(electronPackageDir).then((fallbackBinary) => {
-      if (!fallbackBinary) {
-        console.error(
-          'Electron is still unavailable after running its installer. ' +
-          'If your environment blocks dependency build scripts, run `pnpm approve-builds` or reinstall with network access.',
-        );
-        process.exit(1);
-      }
-
-      return fallbackBinary;
-    });
-  }
-
-  return repairedBinary;
+  console.error(MISSING_ELECTRON_MESSAGE);
+  process.exit(1);
 }
 
 function withLinuxSandboxFallback(binaryPath, args) {
@@ -178,36 +76,29 @@ function withLinuxSandboxFallback(binaryPath, args) {
 
 function main() {
   const args = process.argv.slice(2);
-  Promise.resolve(ensureElectronInstalled()).then((binaryPath) => {
-    if (!binaryPath) {
-      process.exit(1);
-    }
+  const binaryPath = getElectronBinaryOrExit();
 
-    if (args.length === 1 && args[0] === '--ensure-only') {
-      return;
-    }
+  if (args.length === 1 && args[0] === '--ensure-only') {
+    return;
+  }
 
-    const launchArgs = withLinuxSandboxFallback(binaryPath, args);
-    const child = spawn(binaryPath, launchArgs, {
-      cwd: process.cwd(),
-      env: process.env,
-      stdio: 'inherit',
-    });
+  const launchArgs = withLinuxSandboxFallback(binaryPath, args);
+  const child = spawn(binaryPath, launchArgs, {
+    cwd: process.cwd(),
+    env: process.env,
+    stdio: 'inherit',
+  });
 
-    child.once('error', (error) => {
-      console.error(error instanceof Error ? error.message : String(error));
-      process.exit(1);
-    });
-    child.once('exit', (code, signal) => {
-      if (signal) {
-        process.kill(process.pid, signal);
-        return;
-      }
-      process.exit(code ?? 0);
-    });
-  }).catch((error) => {
+  child.once('error', (error) => {
     console.error(error instanceof Error ? error.message : String(error));
     process.exit(1);
+  });
+  child.once('exit', (code, signal) => {
+    if (signal) {
+      process.kill(process.pid, signal);
+      return;
+    }
+    process.exit(code ?? 0);
   });
 }
 

--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -2,12 +2,17 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
-const { spawn } = require('node:child_process');
+const { spawn, spawnSync } = require('node:child_process');
 
 const repoRoot = path.resolve(__dirname, '..');
+const ELECTRON_INSTALL_ATTEMPTS = 3;
 const MISSING_ELECTRON_MESSAGE =
   'Electron is not installed. Provision this machine before running Invoker: ' +
   'run pnpm install with network access and approved Electron build scripts.';
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
 
 function resolveElectronPackageDir() {
   let electronPackageJson;
@@ -45,6 +50,129 @@ function resolveInstalledElectronBinary(electronPackageDir) {
   return fs.existsSync(binaryPath) ? binaryPath : null;
 }
 
+function getElectronPlatformPath() {
+  const platform = process.env.npm_config_platform || process.platform;
+
+  switch (platform) {
+    case 'mas':
+    case 'darwin':
+      return 'Electron.app/Contents/MacOS/Electron';
+    case 'freebsd':
+    case 'openbsd':
+    case 'linux':
+      return 'electron';
+    case 'win32':
+      return 'electron.exe';
+    default:
+      throw new Error(`Electron builds are not available on platform: ${platform}`);
+  }
+}
+
+async function repairElectronWithSystemUnzip(electronPackageDir) {
+  if (process.env.ELECTRON_OVERRIDE_DIST_PATH) {
+    return null;
+  }
+
+  const electronPackage = require(path.join(electronPackageDir, 'package.json'));
+  const electronGetPath = require.resolve('@electron/get', {
+    paths: [electronPackageDir],
+  });
+  const { downloadArtifact } = require(electronGetPath);
+  const platformPath = getElectronPlatformPath();
+  const platform = process.env.npm_config_platform || process.platform;
+  const arch = process.env.npm_config_arch || process.arch;
+  const zipPath = await downloadArtifact({
+    version: electronPackage.version,
+    artifactName: 'electron',
+    force: process.env.force_no_cache === 'true',
+    cacheRoot: process.env.electron_config_cache,
+    checksums: process.env.electron_use_remote_checksums ?? process.env.npm_config_electron_use_remote_checksums
+      ? undefined
+      : require(path.join(electronPackageDir, 'checksums.json')),
+    platform,
+    arch,
+  });
+
+  const distPath = path.join(electronPackageDir, 'dist');
+  fs.rmSync(distPath, { recursive: true, force: true });
+  fs.mkdirSync(distPath, { recursive: true });
+
+  const unzip = spawnSync('unzip', ['-q', '-o', zipPath, '-d', distPath], {
+    cwd: electronPackageDir,
+    env: process.env,
+    stdio: 'inherit',
+  });
+  if (unzip.status !== 0) {
+    return null;
+  }
+  if (unzip.signal) {
+    process.kill(process.pid, unzip.signal);
+    return null;
+  }
+
+  const sourceTypeDefinitions = path.join(distPath, 'electron.d.ts');
+  if (fs.existsSync(sourceTypeDefinitions)) {
+    fs.renameSync(sourceTypeDefinitions, path.join(electronPackageDir, 'electron.d.ts'));
+  }
+  fs.writeFileSync(path.join(electronPackageDir, 'path.txt'), platformPath);
+  return resolveInstalledElectronBinary(electronPackageDir);
+}
+
+async function installElectronOrExit() {
+  const electronPackageDir = resolveElectronPackageDir();
+  if (!electronPackageDir) {
+    console.error('Electron package is not installed. Run pnpm install with network access.');
+    process.exit(1);
+  }
+
+  const existingBinary = resolveInstalledElectronBinary(electronPackageDir);
+  if (existingBinary) {
+    return existingBinary;
+  }
+
+  const installScript = path.join(electronPackageDir, 'install.js');
+  for (let attempt = 1; attempt <= ELECTRON_INSTALL_ATTEMPTS; attempt += 1) {
+    const install = spawnSync(process.execPath, [installScript], {
+      cwd: repoRoot,
+      env: process.env,
+      stdio: 'inherit',
+    });
+
+    if (install.signal) {
+      process.kill(process.pid, install.signal);
+      return null;
+    }
+    if (install.status === 0) {
+      break;
+    }
+    if (attempt === ELECTRON_INSTALL_ATTEMPTS) {
+      process.exit(install.status ?? 1);
+    }
+
+    const delayMs = attempt * 1_000;
+    console.warn(
+      `Electron installer failed with exit code ${install.status ?? 1}; retrying in ${delayMs}ms ` +
+      `(${attempt + 1}/${ELECTRON_INSTALL_ATTEMPTS})`,
+    );
+    sleepSync(delayMs);
+  }
+
+  const installedBinary = resolveInstalledElectronBinary(electronPackageDir);
+  if (installedBinary) {
+    return installedBinary;
+  }
+
+  const repairedBinary = await repairElectronWithSystemUnzip(electronPackageDir);
+  if (!repairedBinary) {
+    console.error(
+      'Electron is still unavailable after running its installer. ' +
+      'If your environment blocks dependency build scripts, run `pnpm approve-builds` or reinstall with network access.',
+    );
+    process.exit(1);
+  }
+  return repairedBinary;
+}
+
 function getElectronBinaryOrExit() {
   const electronPackageDir = resolveElectronPackageDir();
   const existingBinary = resolveInstalledElectronBinary(electronPackageDir);
@@ -74,8 +202,14 @@ function withLinuxSandboxFallback(binaryPath, args) {
   return ['--no-sandbox', ...args];
 }
 
-function main() {
+async function main() {
   const args = process.argv.slice(2);
+
+  if (args.length === 1 && args[0] === '--install-only') {
+    await installElectronOrExit();
+    return;
+  }
+
   const binaryPath = getElectronBinaryOrExit();
 
   if (args.length === 1 && args[0] === '--ensure-only') {
@@ -102,4 +236,7 @@ function main() {
   });
 }
 
-main();
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/repro/repro-mece-04-remote-electron-provisioning.sh
+++ b/scripts/repro/repro-mece-04-remote-electron-provisioning.sh
@@ -36,6 +36,13 @@ cat >"$TMP_DIR/repo/node_modules/electron/install.js" <<'JS'
 const fs = require('node:fs');
 const path = require('node:path');
 fs.writeFileSync(path.join(__dirname, '..', '..', 'installer-ran'), 'yes\n');
+if (process.env.FAKE_ELECTRON_INSTALL_SUCCESS === '1') {
+  const distDir = path.join(__dirname, 'dist');
+  fs.mkdirSync(distDir, { recursive: true });
+  fs.writeFileSync(path.join(distDir, 'electron'), '#!/usr/bin/env sh\nexit 0\n', { mode: 0o755 });
+  fs.writeFileSync(path.join(__dirname, 'path.txt'), 'electron\n');
+  process.exit(0);
+}
 console.error('fake Electron installer ran');
 process.exit(42);
 JS
@@ -79,6 +86,17 @@ if ! grep -q "Electron is not installed. Provision this machine before running I
   echo "repro: missing pre-provisioning error message" >&2
   echo "--- stderr ---" >&2
   cat "$TMP_DIR/stderr" >&2
+  exit 1
+fi
+
+(
+  cd "$TMP_DIR/repo"
+  FAKE_ELECTRON_INSTALL_SUCCESS=1 node scripts/electron.cjs --install-only
+) >"$TMP_DIR/install-stdout" 2>"$TMP_DIR/install-stderr"
+if [[ ! -f "$INSTALLER_MARKER" ]]; then
+  echo "repro: install-only did not invoke Electron provisioning" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMP_DIR/install-stderr" >&2
   exit 1
 fi
 

--- a/scripts/repro/repro-mece-04-remote-electron-provisioning.sh
+++ b/scripts/repro/repro-mece-04-remote-electron-provisioning.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECT_ISSUE=0
+if [[ "${1:-}" == "--expect-issue" ]]; then
+  EXPECT_ISSUE=1
+  shift
+fi
+if [[ $# -ne 0 ]]; then
+  echo "usage: $0 [--expect-issue]" >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-electron-provision.XXXXXX")"
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p \
+  "$TMP_DIR/repo/scripts" \
+  "$TMP_DIR/repo/packages/app" \
+  "$TMP_DIR/repo/node_modules/electron"
+cp "$ROOT_DIR/scripts/electron.cjs" "$TMP_DIR/repo/scripts/electron.cjs"
+
+cat >"$TMP_DIR/repo/node_modules/electron/package.json" <<'JSON'
+{
+  "name": "electron",
+  "version": "0.0.0-test",
+  "main": "index.js"
+}
+JSON
+
+cat >"$TMP_DIR/repo/node_modules/electron/install.js" <<'JS'
+const fs = require('node:fs');
+const path = require('node:path');
+fs.writeFileSync(path.join(__dirname, '..', '..', 'installer-ran'), 'yes\n');
+console.error('fake Electron installer ran');
+process.exit(42);
+JS
+
+set +e
+(
+  cd "$TMP_DIR/repo"
+  node scripts/electron.cjs --ensure-only
+) >"$TMP_DIR/stdout" 2>"$TMP_DIR/stderr"
+STATUS=$?
+set -e
+
+INSTALLER_MARKER="$TMP_DIR/repo/installer-ran"
+
+if [[ "$EXPECT_ISSUE" -eq 1 ]]; then
+  if [[ "$STATUS" -eq 0 ]]; then
+    echo "repro: expected current issue command to fail after installer attempt" >&2
+    exit 1
+  fi
+  if [[ ! -f "$INSTALLER_MARKER" ]]; then
+    echo "repro: expected Electron installer to run, but marker is missing" >&2
+    echo "--- stderr ---" >&2
+    cat "$TMP_DIR/stderr" >&2
+    exit 1
+  fi
+  echo "remote-electron-provisioning issue reproduced: installer was invoked"
+  exit 0
+fi
+
+if [[ "$STATUS" -eq 0 ]]; then
+  echo "repro: expected missing Electron to fail fast" >&2
+  exit 1
+fi
+if [[ -f "$INSTALLER_MARKER" ]]; then
+  echo "repro: Electron installer was invoked; remote task startup must only verify provisioning" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMP_DIR/stderr" >&2
+  exit 1
+fi
+if ! grep -q "Electron is not installed. Provision this machine before running Invoker" "$TMP_DIR/stderr"; then
+  echo "repro: missing pre-provisioning error message" >&2
+  echo "--- stderr ---" >&2
+  cat "$TMP_DIR/stderr" >&2
+  exit 1
+fi
+
+echo "remote-electron-provisioning fixed: missing Electron fails without installer"

--- a/scripts/test-suites/required/08-electron-preprovision-repro.sh
+++ b/scripts/test-suites/required/08-electron-preprovision-repro.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Regression: Electron launcher must verify pre-provisioning without running installers.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+exec bash "$ROOT/scripts/repro/repro-mece-04-remote-electron-provisioning.sh"


### PR DESCRIPTION
## Summary

Fail fast when Invoker starts without a provisioned Electron binary, without making clean dependency installs fail in CI.

The launcher/preflight path now treats `--ensure-only` as strict verification only: missing Electron reports the provisioning error and does not invoke Electron's installer. The root `postinstall` script uses a separate `--install-only` mode so fresh checkouts can still provision Electron during `pnpm install --frozen-lockfile`.

## Architecture

### Before

```mermaid
graph TD
    A[pnpm install] --> B[postinstall: electron.cjs --ensure-only]
    C[Invoker launcher] --> D[electron.cjs runtime path]
    B --> E{Electron binary exists?}
    D --> E
    E -- yes --> F[Continue]
    E -- no --> G[Fail with provisioning error]
```

### After

```mermaid
graph TD
    A[pnpm install] --> B[postinstall: electron.cjs --install-only]
    B --> C[Run Electron installer or unzip fallback]
    C --> D[Electron provisioned for this checkout]
    E[Invoker launcher or preflight] --> F[electron.cjs --ensure-only/runtime]
    F --> G{Electron binary exists?}
    G -- yes --> H[Continue]
    G -- no --> I[Fail with provisioning error without installer]
```

## Test Plan

- [x] `bash scripts/repro/repro-mece-04-remote-electron-provisioning.sh`
- [x] `bash scripts/test-suites/required/08-electron-preprovision-repro.sh`
- [x] `pnpm install --frozen-lockfile`
- [x] `node scripts/electron.cjs --ensure-only`
- [x] `pnpm run check:types`
- [x] `pnpm run check:required-builds`
- [x] `pnpm run check:deps`
- [x] `git diff --check`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 13e23799 0f56c939`
- Post-revert steps: None
- Data migration? No
