### PR TITLE
Instrument launch handoff timings

### DIFF
--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@invoker/contracts';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { TaskRunner } from '@invoker/execution-engine';
+import { createExecutionBench } from '@invoker/execution-engine';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 
 type GlobalTopupParams = {
@@ -24,6 +25,25 @@ type MutationTopupParams = {
 function runningExecutionKey(task: TaskState): string {
   const attemptId = task.execution.selectedAttemptId?.trim();
   return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
+}
+
+function createDispatchBench(
+  logger: Logger | undefined,
+  context: string,
+  runnable: TaskState[],
+  dispatchKind: 'global-topup' | 'scoped',
+): (phase: string, metadata?: Record<string, unknown>) => void {
+  return createExecutionBench({
+    module: 'scheduler-dispatch-bench',
+    logger,
+    baseMetadata: {
+      context,
+      dispatchKind,
+      runnableCount: runnable.length,
+      taskIds: runnable.map((task) => task.id),
+      attemptIds: runnable.map((task) => task.execution.selectedAttemptId ?? null),
+    },
+  });
 }
 
 export function isDispatchableLaunch(task: TaskState): boolean {
@@ -53,13 +73,27 @@ export async function executeGlobalTopup({
       .filter(isDispatchableLaunch)
       .map((task) => runningExecutionKey(task)),
   );
+  const startBench = createExecutionBench({
+    module: 'scheduler-dispatch-bench',
+    logger,
+    baseMetadata: {
+      context,
+      dispatchKind: 'global-topup',
+      alreadyDispatchedCount: alreadyDispatched.length,
+    },
+  });
+  startBench('executeGlobalTopup.startExecution.before');
   const started = orchestrator.startExecution();
+  startBench('executeGlobalTopup.startExecution.after', { startedCount: started.length });
   const runnable = started
     .filter(isDispatchableLaunch)
     .filter((task) => !dedupeKeys.has(runningExecutionKey(task)));
+  const bench = createDispatchBench(logger, context, runnable, 'global-topup');
+  bench('executeGlobalTopup.runnableFiltered', { startedCount: started.length });
 
   if (runnable.length === 0) {
     logger?.info(`[global-topup] ${context}: no additional globally ready tasks`);
+    bench('executeGlobalTopup.noRunnable');
     return [];
   }
 
@@ -67,13 +101,17 @@ export async function executeGlobalTopup({
     `[global-topup] ${context}: dispatching ${runnable.length} additional task(s): [${runnable.map((task) => task.id).join(', ')}]`,
   );
   if (mutationTiming) {
+    bench('executeGlobalTopup.taskExecutor.executeTasks.before');
     await mutationTiming.span(
       'executeGlobalTopup.taskExecutor.executeTasks',
       { context, runnableCount: runnable.length },
       () => taskExecutor.executeTasks(runnable),
     );
+    bench('executeGlobalTopup.taskExecutor.executeTasks.after');
   } else {
+    bench('executeGlobalTopup.taskExecutor.executeTasks.before');
     await taskExecutor.executeTasks(runnable);
+    bench('executeGlobalTopup.taskExecutor.executeTasks.after');
   }
   return runnable;
 }
@@ -91,20 +129,29 @@ export async function dispatchStartedTasksWithGlobalTopup({
   mutationTiming,
 }: MutationTopupParams): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
   const runnable = started.filter(isDispatchableLaunch);
+  const bench = createDispatchBench(logger, context, runnable, 'scoped');
+  bench('dispatchStartedTasksWithGlobalTopup.runnableFiltered', { startedCount: started.length });
   if (runnable.length > 0) {
     logger?.info(
       `[global-topup] ${context}: dispatching ${runnable.length} scoped task(s): [${runnable.map((task) => task.id).join(', ')}]`,
     );
     if (mutationTiming) {
+      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.before');
       await mutationTiming.span(
         'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks',
         { context, runnableCount: runnable.length },
         () => taskExecutor.executeTasks(runnable),
       );
+      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.after');
     } else {
+      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.before');
       await taskExecutor.executeTasks(runnable);
+      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.after');
     }
+  } else {
+    bench('dispatchStartedTasksWithGlobalTopup.noScopedRunnable');
   }
+  bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.before');
   const topup = await executeGlobalTopup({
     orchestrator,
     taskExecutor,
@@ -113,6 +160,7 @@ export async function dispatchStartedTasksWithGlobalTopup({
     alreadyDispatched: runnable,
     mutationTiming,
   });
+  bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.after', { topupCount: topup.length });
   return { runnable, topup };
 }
 

--- a/packages/execution-engine/src/execution-bench.ts
+++ b/packages/execution-engine/src/execution-bench.ts
@@ -1,0 +1,44 @@
+import type { Logger } from '@invoker/contracts';
+import { executionTraceEnabled, traceExecution } from './exec-trace.js';
+
+export const EXECUTE_TASK_BENCH_ENV = 'INVOKER_BENCH_EXECUTE_TASK';
+
+export function executionBenchEnabled(): boolean {
+  return process.env[EXECUTE_TASK_BENCH_ENV] === '1' || executionTraceEnabled();
+}
+
+export function createExecutionBench({
+  module,
+  logger,
+  baseMetadata = {},
+}: {
+  module: string;
+  logger?: Logger;
+  baseMetadata?: Record<string, unknown>;
+}): (phase: string, metadata?: Record<string, unknown>) => void {
+  if (!executionBenchEnabled()) return () => {};
+  const startedAt = Date.now();
+  let previousAt = startedAt;
+
+  return (phase, metadata = {}) => {
+    const now = Date.now();
+    const elapsedMs = now - startedAt;
+    const deltaMs = now - previousAt;
+    previousAt = now;
+    const payload = {
+      module,
+      phase,
+      elapsedMs,
+      deltaMs,
+      ...baseMetadata,
+      ...metadata,
+    };
+    const message = `[${module}] phase="${phase}" elapsedMs=${elapsedMs} deltaMs=${deltaMs}`;
+    if (logger) {
+      logger.info(message, payload);
+    } else {
+      console.info(message, payload);
+    }
+    traceExecution(message);
+  };
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -1,4 +1,5 @@
 export { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
+export * from './execution-bench.js';
 export { remoteFetchForPool } from './remote-fetch-policy.js';
 export {
   syncPlanBaseRemote,

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -3,6 +3,7 @@ import { mkdirSync, existsSync, rmSync } from 'node:fs';
 import { normalize } from 'node:path';
 import { bashPreserveOrReset, runBashLocal } from './branch-utils.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
+import { createExecutionBench } from './execution-bench.js';
 import { planManagedWorktree } from './managed-worktree-controller.js';
 import {
   abbrevRefMatchesBranch,
@@ -241,16 +242,29 @@ export class RepoPool {
   }
 
   async ensureClone(repoUrl: string): Promise<string> {
+    const bench = createExecutionBench({
+      module: 'repo-pool-bench',
+      baseMetadata: { repoUrl },
+    });
+    bench('RepoPool.ensureClone.begin');
     // Serialize clone operations per repo to prevent concurrent clone races
     const existing = this.cloneLocks.get(repoUrl);
-    if (existing) return existing;
+    if (existing) {
+      bench('RepoPool.ensureClone.waitForExistingLock.before');
+      const clonePath = await existing;
+      bench('RepoPool.ensureClone.waitForExistingLock.after', { clonePath });
+      return clonePath;
+    }
 
     const promise = this.doEnsureClone(repoUrl);
     this.cloneLocks.set(repoUrl, promise);
     try {
-      return await promise;
+      const clonePath = await promise;
+      bench('RepoPool.ensureClone.after', { clonePath });
+      return clonePath;
     } finally {
       this.cloneLocks.delete(repoUrl);
+      bench('RepoPool.ensureClone.lockDeleted');
     }
   }
 
@@ -314,6 +328,11 @@ export class RepoPool {
     branch: string,
     base: string,
   ): Promise<void> {
+    const bench = createExecutionBench({
+      module: 'repo-pool-bench',
+      baseMetadata: { branch, base, clonePath, worktreePath },
+    });
+    bench('RepoPool.runPreserveOrResetWithRecovery.begin');
     const script = bashPreserveOrReset({
       repoDir: clonePath,
       worktreeDir: worktreePath,
@@ -321,41 +340,76 @@ export class RepoPool {
       base,
     });
     try {
+      bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.before');
       await runBashLocal(script, clonePath);
+      bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.after');
       return;
     } catch (err) {
       if (!this.isAlreadyExistsWorktreeError(err, worktreePath)) {
+        bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
         throw err;
       }
       traceExecution(
         `[RepoPool] runPreserveOrResetWithRecovery: retrying after pre-existing path branch=${branch} path=${worktreePath}`,
       );
+      bench('RepoPool.runPreserveOrResetWithRecovery.reconcileStaleWorktreePath.before');
       await this.reconcileStaleWorktreePath(clonePath, worktreePath);
+      bench('RepoPool.runPreserveOrResetWithRecovery.reconcileStaleWorktreePath.after');
     }
+    bench('RepoPool.runPreserveOrResetWithRecovery.retryRunBashLocal.before');
     await runBashLocal(script, clonePath);
+    bench('RepoPool.runPreserveOrResetWithRecovery.retryRunBashLocal.after');
   }
 
   private async doEnsureClone(repoUrl: string): Promise<string> {
+    const bench = createExecutionBench({
+      module: 'repo-pool-bench',
+      baseMetadata: { repoUrl },
+    });
     const dir = this.cloneDir(repoUrl);
+    bench('RepoPool.doEnsureClone.begin', { dir, exists: existsSync(dir) });
     if (existsSync(dir)) {
       if (remoteFetchForPool.enabled) {
         try {
+          bench('RepoPool.doEnsureClone.gitFetchAllPrune.before', { dir });
           await this.execGit(['fetch', '--all', '--prune'], dir);
+          bench('RepoPool.doEnsureClone.gitFetchAllPrune.after', { dir });
         } catch (err) {
           console.warn(`[RepoPool] doEnsureClone fetch failed: ${err}`);
+          bench('RepoPool.doEnsureClone.gitFetchAllPrune.failed', {
+            dir,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
         // Advance local HEAD branch to match origin so rev-parse returns the fresh ref
         try {
+          bench('RepoPool.doEnsureClone.gitCurrentBranch.before', { dir });
           const branch = (await this.execGit(['rev-parse', '--abbrev-ref', 'HEAD'], dir)).trim();
+          bench('RepoPool.doEnsureClone.gitCurrentBranch.after', { dir, branch });
           if (branch !== 'HEAD') {
+            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.before', { dir, branch });
             await this.execGit(['merge', '--ff-only', `origin/${branch}`], dir);
+            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.after', { dir, branch });
+          } else {
+            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.skipped', { dir, branch });
           }
-        } catch { /* non-ff or detached; leave as-is */ }
+        } catch (err) {
+          bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.failed', {
+            dir,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          /* non-ff or detached; leave as-is */
+        }
       }
+      bench('RepoPool.doEnsureClone.returnExisting', { dir });
       return dir;
     }
     mkdirSync(this.cacheDir, { recursive: true });
+    bench('RepoPool.doEnsureClone.gitClone.before', { dir });
     await this.execGit(['clone', repoUrl, dir], this.cacheDir);
+    bench('RepoPool.doEnsureClone.gitClone.after', { dir });
     return dir;
   }
 
@@ -366,11 +420,22 @@ export class RepoPool {
     actionId?: string,
     opts?: AcquireWorktreeOptions,
   ): Promise<AcquiredWorktree> {
+    const bench = createExecutionBench({
+      module: 'repo-pool-bench',
+      baseMetadata: { repoUrl, branch, base, actionId },
+    });
+    bench('RepoPool.acquireWorktree.begin');
     // Serialize per-repo to prevent concurrent git worktree operations
     const prev = this.repoChains.get(repoUrl) ?? Promise.resolve();
-    const next = prev.then(() => this.doAcquireWorktree(repoUrl, branch, base, actionId, opts));
+    const queuedAtMs = Date.now();
+    const next = prev.then(() => {
+      bench('RepoPool.acquireWorktree.repoChainWait.after', { durationMs: Date.now() - queuedAtMs });
+      return this.doAcquireWorktree(repoUrl, branch, base, actionId, opts);
+    });
     this.repoChains.set(repoUrl, next.catch(() => {}));
-    return next;
+    const acquired = await next;
+    bench('RepoPool.acquireWorktree.after', { worktreePath: acquired.worktreePath });
+    return acquired;
   }
 
   /**
@@ -408,11 +473,19 @@ export class RepoPool {
     actionId?: string,
     opts?: AcquireWorktreeOptions,
   ): Promise<AcquiredWorktree> {
+    const bench = createExecutionBench({
+      module: 'repo-pool-bench',
+      baseMetadata: { repoUrl, branch, base, actionId, forceFresh: opts?.forceFresh === true },
+    });
+    bench('RepoPool.doAcquireWorktree.begin');
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree branch=${branch} (bashPreserveOrReset here; BaseExecutor.setupTaskBranch is not used for this path)`,
     );
+    bench('RepoPool.doAcquireWorktree.ensureClone.before');
     const clonePath = await this.ensureClone(repoUrl);
+    bench('RepoPool.doAcquireWorktree.ensureClone.after', { clonePath });
     const active = this.activeWorktrees.get(repoUrl) ?? new Set();
+    bench('RepoPool.doAcquireWorktree.activeWorktreeCount', { activeCount: active.size, maxWorktrees: this.maxWorktrees });
     if (active.size >= this.maxWorktrees) {
       throw new ResourceLimitError(`Worktree limit reached for ${repoUrl}: ${active.size}/${this.maxWorktrees}`);
     }
@@ -432,12 +505,16 @@ export class RepoPool {
 
     let porcelain = '';
     try {
+      bench('RepoPool.doAcquireWorktree.gitWorktreeList.before', { clonePath });
       porcelain = await this.execGit(['worktree', 'list', '--porcelain'], clonePath);
+      bench('RepoPool.doAcquireWorktree.gitWorktreeList.after', { clonePath });
     } catch {
       porcelain = '';
+      bench('RepoPool.doAcquireWorktree.gitWorktreeList.failed', { clonePath });
     }
 
     const allowReuse = opts?.forceFresh !== true;
+    bench('RepoPool.doAcquireWorktree.findReuseCandidates.before', { allowReuse });
     const reuseCandidate = allowReuse ? findManagedWorktreeForBranch(porcelain, branch, managedPrefixes) : undefined;
     let exactBranchCandidate: { path: string; headMatchesTargetBranch: boolean } | undefined;
     if (reuseCandidate && existsSync(reuseCandidate)) {
@@ -507,7 +584,14 @@ export class RepoPool {
         );
       }
     }
+    bench('RepoPool.doAcquireWorktree.findReuseCandidates.after', {
+      hasReuseCandidate: !!reuseCandidate,
+      hasExactBranchCandidate: !!exactBranchCandidate,
+      hasActionIdCandidate: !!actionIdCandidate,
+      hasContentCandidate: !!contentCandidate,
+    });
 
+    bench('RepoPool.doAcquireWorktree.planManagedWorktree.before');
     let plan = planManagedWorktree({
       targetBranch: branch,
       targetWorktreePath: worktreePath,
@@ -516,9 +600,19 @@ export class RepoPool {
       actionIdCandidate,
       contentCandidate,
     });
+    bench('RepoPool.doAcquireWorktree.planManagedWorktree.after', { planKind: plan.kind });
 
     if (plan.kind === 'reuse_exact') {
+      bench('RepoPool.doAcquireWorktree.isReusableManagedWorktree.before', {
+        planKind: plan.kind,
+        worktreePath: plan.worktreePath,
+      });
       const reusable = await this.isReusableManagedWorktree(plan.worktreePath, branch);
+      bench('RepoPool.doAcquireWorktree.isReusableManagedWorktree.after', {
+        planKind: plan.kind,
+        worktreePath: plan.worktreePath,
+        reusable,
+      });
       if (!reusable) {
         plan = {
           kind: 'recreate',
@@ -527,7 +621,16 @@ export class RepoPool {
         };
       }
     } else if (plan.kind === 'rename_reuse' || plan.kind === 'rename_to_lifecycle') {
+      bench('RepoPool.doAcquireWorktree.isReusableManagedWorktree.before', {
+        planKind: plan.kind,
+        worktreePath: plan.worktreePath,
+      });
       const reusable = await this.isReusableManagedWorktree(plan.worktreePath, plan.fromBranch);
+      bench('RepoPool.doAcquireWorktree.isReusableManagedWorktree.after', {
+        planKind: plan.kind,
+        worktreePath: plan.worktreePath,
+        reusable,
+      });
       if (!reusable) {
         plan = {
           kind: 'recreate',
@@ -538,6 +641,7 @@ export class RepoPool {
     }
 
     let effectivePath = worktreePath;
+    bench('RepoPool.doAcquireWorktree.applyPlan.before', { planKind: plan.kind });
     switch (plan.kind) {
       case 'reuse_exact':
         effectivePath = plan.worktreePath;
@@ -568,23 +672,30 @@ export class RepoPool {
             branch,
             base ?? 'HEAD',
           );
+          bench('RepoPool.doAcquireWorktree.renameFallbackPreserveOrReset.after', { worktreePath });
           effectivePath = worktreePath;
         }
         break;
       case 'recreate':
+        bench('RepoPool.doAcquireWorktree.reconcileLeakedTargetPath.before', { worktreePath });
         await this.reconcileLeakedTargetPath(clonePath, worktreePath, porcelain, branch);
+        bench('RepoPool.doAcquireWorktree.reconcileLeakedTargetPath.after', { worktreePath });
         if (isWorkspaceCleanupEnabled()) {
           for (const cleanupPath of plan.cleanupPaths) {
+            bench('RepoPool.doAcquireWorktree.reconcileStaleWorktreePath.before', { cleanupPath });
             await this.reconcileStaleWorktreePath(clonePath, cleanupPath);
+            bench('RepoPool.doAcquireWorktree.reconcileStaleWorktreePath.after', { cleanupPath });
           }
         }
         mkdirSync(worktreeParent, { recursive: true });
+        bench('RepoPool.doAcquireWorktree.runPreserveOrResetWithRecovery.before', { worktreePath });
         await this.runPreserveOrResetWithRecovery(
           clonePath,
           worktreePath,
           branch,
           base ?? 'HEAD',
         );
+        bench('RepoPool.doAcquireWorktree.runPreserveOrResetWithRecovery.after', { worktreePath });
         effectivePath = worktreePath;
         break;
     }
@@ -592,6 +703,11 @@ export class RepoPool {
     effectivePath = canonicalPathForComparison(effectivePath);
     active.add(effectivePath);
     this.activeWorktrees.set(repoUrl, active);
+    bench('RepoPool.doAcquireWorktree.applyPlan.after', {
+      planKind: plan.kind,
+      effectivePath,
+      activeCount: active.size,
+    });
 
     const release = async () => {
       try {
@@ -604,6 +720,7 @@ export class RepoPool {
 
     const softRelease = () => { active.delete(effectivePath); };
 
+    bench('RepoPool.doAcquireWorktree.returning', { effectivePath });
     return { clonePath, worktreePath: effectivePath, branch, release, softRelease };
   }
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -13,6 +13,7 @@ import type { AgentRegistry } from './agent-registry.js';
 import { computeRepoUrlHash, sanitizeBranchForPath } from './git-utils.js';
 import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { buildSshConnectionArgs } from './ssh-transport-options.js';
+import { createExecutionBench } from './execution-bench.js';
 import {
   shellPosixSingleQuote as sshGitShellQuote,
   base64Encode as sshGitB64,
@@ -162,19 +163,37 @@ exit "$PAYLOAD_EXIT"
   }
 
   private async execRemoteCapture(script: string, phase?: string): Promise<string> {
+    const bench = createExecutionBench({
+      module: 'ssh-executor-start-bench',
+      baseMetadata: {
+        host: this.host,
+        user: this.user,
+        remotePhase: phase ?? 'remote_capture',
+      },
+    });
+    bench('SshExecutor.execRemoteCapture.begin');
     return new Promise((resolve, reject) => {
       const child = spawn('ssh', [...this.buildSshArgs(), ...this.buildRemoteCommand()], {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: cleanElectronEnv(),
       });
+      bench('SshExecutor.execRemoteCapture.spawned');
       child.stdin.write(script);
       child.stdin.end();
       let out = '';
       let err = '';
       child.stdout?.on('data', (c: Buffer) => { out += c.toString(); });
       child.stderr?.on('data', (c: Buffer) => { err += c.toString(); });
-      child.on('error', reject);
+      child.on('error', (error) => {
+        bench('SshExecutor.execRemoteCapture.spawnError', { error: error.message });
+        reject(error);
+      });
       child.on('close', (code) => {
+        bench('SshExecutor.execRemoteCapture.closed', {
+          code,
+          stdoutBytes: out.length,
+          stderrBytes: err.length,
+        });
         if (code === 0) resolve(out);
         else {
           reject(createSshRemoteScriptError(code, out, err, phase));
@@ -190,6 +209,18 @@ exit "$PAYLOAD_EXIT"
   async start(request: WorkRequest): Promise<ExecutorHandle> {
     const handle = this.createHandle(request);
     const executionId = handle.executionId;
+    const bench = createExecutionBench({
+      module: 'ssh-executor-start-bench',
+      baseMetadata: {
+        requestId: request.requestId,
+        actionId: request.actionId,
+        actionType: request.actionType,
+        host: this.host,
+        user: this.user,
+        managedWorkspaces: this.managedWorkspaces,
+      },
+    });
+    bench('SshExecutor.start.begin');
 
     if (request.actionType === 'reconciliation') {
       const entry: SshEntry = {
@@ -205,12 +236,16 @@ exit "$PAYLOAD_EXIT"
       };
       this.registerEntry(handle, entry);
       this.scheduleReconciliationResponse(executionId);
+      bench('SshExecutor.start.reconciliation.returning');
       return handle;
     }
 
     try {
+      bench('SshExecutor.sshKey.access.before', { sshKeyPath: this.sshKeyPath });
       accessSync(this.sshKeyPath, constants.R_OK);
+      bench('SshExecutor.sshKey.access.after', { sshKeyPath: this.sshKeyPath });
     } catch {
+      bench('SshExecutor.sshKey.access.failed', { sshKeyPath: this.sshKeyPath });
       throw new Error(
         `SSH key file not accessible: ${this.sshKeyPath}\n` +
         `Update "sshKeyPath" in your Invoker config (.invoker.json or ~/.invoker/config.json).`,
@@ -224,6 +259,7 @@ exit "$PAYLOAD_EXIT"
       const command = request.inputs.command;
       if (!command) throw new Error('WorkRequest with actionType "command" must have inputs.command');
       payload = command;
+      bench('SshExecutor.payload.built', { command: true });
     } else if (request.actionType === 'ai_task') {
       if (this.agentRegistry) {
         const requestedAgent = request.inputs.executionAgent ?? 'claude';
@@ -232,13 +268,22 @@ exit "$PAYLOAD_EXIT"
         const spec = agent.buildCommand(fullPrompt);
         agentSessionId = spec.sessionId;
         payload = `${spec.cmd} ${spec.args.map(a => this.shellQuote(a)).join(' ')}`;
+        bench('SshExecutor.payload.built', {
+          executionAgent: requestedAgent,
+          hasAgentSessionId: !!agentSessionId,
+        });
       } else {
         const session = this.prepareClaudeSession(request);
         agentSessionId = session.sessionId;
         payload = `claude ${session.cliArgs.map(a => this.shellQuote(a)).join(' ')}`;
+        bench('SshExecutor.payload.built', {
+          executionAgent: 'claude',
+          hasAgentSessionId: !!agentSessionId,
+        });
       }
     } else {
       payload = 'echo "Unsupported action type"';
+      bench('SshExecutor.payload.built', { unsupportedActionType: request.actionType });
     }
 
     try {
@@ -250,11 +295,26 @@ exit "$PAYLOAD_EXIT"
             `Add a top-level "repoUrl" to your plan YAML (e.g. repoUrl: git@github.com:user/repo.git).`,
           );
         }
-        return await this.startManagedWorkspace(request, handle, repoUrl, payload, agentSessionId);
+        bench('SshExecutor.startManagedWorkspace.before', { repoUrl });
+        const started = await this.startManagedWorkspace(request, handle, repoUrl, payload, agentSessionId);
+        bench('SshExecutor.startManagedWorkspace.after', {
+          workspacePath: started.workspacePath,
+          branch: started.branch,
+        });
+        return started;
       } else {
-        return await this.startBYOWorkspace(request, handle, payload, agentSessionId);
+        bench('SshExecutor.startBYOWorkspace.before');
+        const started = await this.startBYOWorkspace(request, handle, payload, agentSessionId);
+        bench('SshExecutor.startBYOWorkspace.after', {
+          workspacePath: started.workspacePath,
+          branch: started.branch,
+        });
+        return started;
       }
     } catch (err) {
+      bench('SshExecutor.start.failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
       throw this.withStartupMetadata(err, handle);
     }
   }
@@ -269,6 +329,16 @@ exit "$PAYLOAD_EXIT"
     payload: string,
     agentSessionId?: string,
   ): Promise<ExecutorHandle> {
+    const bench = createExecutionBench({
+      module: 'ssh-executor-start-bench',
+      baseMetadata: {
+        requestId: request.requestId,
+        actionId: request.actionId,
+        host: this.host,
+        user: this.user,
+      },
+    });
+    bench('SshExecutor.startBYOWorkspace.begin');
     const executionId = handle.executionId;
     const workspacePath = request.inputs.workspacePath;
 
@@ -281,6 +351,10 @@ exit "$PAYLOAD_EXIT"
 
     handle.workspacePath = workspacePath;
     handle.agentSessionId = agentSessionId;
+    bench('SshExecutor.startBYOWorkspace.workspaceResolved', {
+      workspacePath,
+      hasAgentSessionId: !!agentSessionId,
+    });
 
     // No-command tasks complete immediately
     if (!request.inputs.command && !request.inputs.prompt) {
@@ -305,6 +379,7 @@ exit "$PAYLOAD_EXIT"
       };
       this.registerEntry(handle, entry);
       this.emitComplete(executionId, response);
+      bench('SshExecutor.startBYOWorkspace.noCommand.returning');
       return handle;
     }
 
@@ -323,7 +398,10 @@ echo "[SshExecutor BYO] Running task in user-provided workspace: $WT"
 ${this.buildPayloadExecutionScript(payloadB64)}
 `;
 
-    return this.spawnSshRemoteStdin(executionId, request, handle, runScript, agentSessionId, undefined);
+    bench('SshExecutor.startBYOWorkspace.spawnSshRemoteStdin.before', { workspacePath });
+    const started = await this.spawnSshRemoteStdin(executionId, request, handle, runScript, agentSessionId, undefined);
+    bench('SshExecutor.startBYOWorkspace.spawnSshRemoteStdin.after', { workspacePath });
+    return started;
   }
 
   /**
@@ -336,6 +414,17 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     payload: string,
     agentSessionId?: string,
   ): Promise<ExecutorHandle> {
+    const bench = createExecutionBench({
+      module: 'ssh-executor-start-bench',
+      baseMetadata: {
+        requestId: request.requestId,
+        actionId: request.actionId,
+        host: this.host,
+        user: this.user,
+        repoUrl,
+      },
+    });
+    bench('SshExecutor.startManagedWorkspace.begin');
     const executionId = handle.executionId;
     const h = computeRepoUrlHash(repoUrl);
     const baseRef = request.inputs.baseBranch ?? 'HEAD';
@@ -356,8 +445,15 @@ ${this.buildPayloadExecutionScript(payloadB64)}
       baseRef,
       invokerHome,
     });
+    bench('SshExecutor.startManagedWorkspace.bootstrapCloneFetch.before', { baseRef });
     const bootstrapOut = await this.execRemoteCapture(script1, 'bootstrap_clone_fetch');
     const { resolvedBaseRef, baseHead, warning, fetchSuccess } = parseBootstrapOutput(bootstrapOut);
+    bench('SshExecutor.startManagedWorkspace.bootstrapCloneFetch.after', {
+      resolvedBaseRef,
+      baseHead,
+      fetchSuccess,
+      hasWarning: !!warning,
+    });
     if (warning) {
       this.emitOutput(executionId, `[SshExecutor] ${warning}\n`);
     }
@@ -378,11 +474,17 @@ ${this.buildPayloadExecutionScript(payloadB64)}
       lifecycleTag,
       contentHash,
     );
+    bench('SshExecutor.startManagedWorkspace.branchComputed', {
+      experimentBranch,
+      contentHash,
+    });
     // Persist the branch on the attempt row before we run any remote git
     // command that could leak a worktree without a recorded branch.
     try {
       request.onBranchResolved?.(experimentBranch);
+      bench('SshExecutor.startManagedWorkspace.onBranchResolved.done', { experimentBranch });
     } catch {
+      bench('SshExecutor.startManagedWorkspace.onBranchResolved.failed', { experimentBranch });
       // Best-effort; the post-start path persists this again.
     }
     const san = sanitizeBranchForPath(experimentBranch);
@@ -393,9 +495,13 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     // path as real until Git has actually created or confirmed it.
     handle.branch = experimentBranch;
 
+    bench('SshExecutor.startManagedWorkspace.detectHome.before');
     const remoteHome = (await this.execRemoteCapture('printf %s "$HOME"', 'detect_home')).trim();
+    bench('SshExecutor.startManagedWorkspace.detectHome.after', { remoteHome });
     const porcelainScript = buildWorktreeListScript({ repoHash: h, invokerHome });
+    bench('SshExecutor.startManagedWorkspace.listWorktrees.before');
     const porcelain = await this.execRemoteCapture(porcelainScript, 'list_worktrees');
+    bench('SshExecutor.startManagedWorkspace.listWorktrees.after', { bytes: porcelain.length });
 
     // Expand ~ in invokerHome for path matching
     const expandedInvokerHome = invokerHome === '~'
@@ -411,22 +517,31 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     if (reuseAbs) {
       const headScript = buildWorktreeHeadScript(reuseAbs);
       try {
+        bench('SshExecutor.startManagedWorkspace.inspectReuseHead.before', { reuseAbs });
         const head = (await this.execRemoteCapture(headScript)).trim();
         exactBranchCandidate = {
           path: reuseAbs,
           headMatchesTargetBranch: abbrevRefMatchesBranch(head, experimentBranch),
         };
+        bench('SshExecutor.startManagedWorkspace.inspectReuseHead.after', {
+          reuseAbs,
+          head,
+          headMatchesTargetBranch: exactBranchCandidate.headMatchesTargetBranch,
+        });
       } catch {
         exactBranchCandidate = undefined;
+        bench('SshExecutor.startManagedWorkspace.inspectReuseHead.failed', { reuseAbs });
       }
     }
 
+    bench('SshExecutor.startManagedWorkspace.planManagedWorktree.before');
     const worktreePlan = planManagedWorktree({
       targetBranch: experimentBranch,
       targetWorktreePath: canonicalRemoteWt,
       forceFresh: request.inputs.freshWorkspace === true,
       exactBranchCandidate,
     });
+    bench('SshExecutor.startManagedWorkspace.planManagedWorktree.after', { planKind: worktreePlan.kind });
 
     let remoteWt = canonicalRemoteWt;
     let skippedRemotePreserve = false;
@@ -450,7 +565,13 @@ ${this.buildPayloadExecutionScript(payloadB64)}
             remoteClone,
             worktreePaths: worktreePlan.cleanupPaths,
           });
+          bench('SshExecutor.startManagedWorkspace.cleanupWorktree.before', {
+            cleanupCount: worktreePlan.cleanupPaths.length,
+          });
           await this.execRemoteCapture(cleanupScript, 'cleanup_worktree');
+          bench('SshExecutor.startManagedWorkspace.cleanupWorktree.after', {
+            cleanupCount: worktreePlan.cleanupPaths.length,
+          });
         }
         remoteWt = canonicalRemoteWt;
         break;
@@ -458,17 +579,32 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     }
 
     if (skippedRemotePreserve) {
+      bench('SshExecutor.startManagedWorkspace.mergeRequestUpstreamBranches.before', { remoteWt });
       await this.mergeRequestUpstreamBranches(request, remoteWt, resolvedBaseRef);
+      bench('SshExecutor.startManagedWorkspace.mergeRequestUpstreamBranches.after', { remoteWt });
     } else {
       try {
+        bench('SshExecutor.startManagedWorkspace.setupTaskBranch.before', {
+          branchName: experimentBranch,
+          base: resolvedBaseRef,
+          remoteWt,
+        });
         await this.setupTaskBranch(remoteClone, request, handle, {
           branchName: experimentBranch,
           base: resolvedBaseRef,
           worktreeDir: remoteWt,
         });
+        bench('SshExecutor.startManagedWorkspace.setupTaskBranch.after', {
+          branchName: experimentBranch,
+          remoteWt,
+        });
       } catch (err) {
         const wrapped = err instanceof Error ? err : new Error(String(err));
         if (!(wrapped as any).phase) (wrapped as any).phase = 'setup_branch';
+        bench('SshExecutor.startManagedWorkspace.setupTaskBranch.failed', {
+          error: wrapped.message,
+          remoteWt,
+        });
         throw wrapped;
       }
       handle.workspacePath =
@@ -480,6 +616,7 @@ ${this.buildPayloadExecutionScript(payloadB64)}
       await this.handleProcessExit(executionId, request, remoteWt, 0, {
         branch: experimentBranch,
       });
+      bench('SshExecutor.startManagedWorkspace.noCommand.returning', { remoteWt });
       return handle;
     }
 
@@ -501,10 +638,21 @@ echo "[SshExecutor] Running task payload..."
 ${this.buildPayloadExecutionScript(payloadB64)}
 `;
 
-    return this.spawnSshRemoteStdin(executionId, request, handle, runScript, agentSessionId, {
+    bench('SshExecutor.startManagedWorkspace.spawnSshRemoteStdin.before', {
+      remoteWt,
+      workspacePath: handle.workspacePath,
+      branch: experimentBranch,
+    });
+    const started = await this.spawnSshRemoteStdin(executionId, request, handle, runScript, agentSessionId, {
       worktreePath: handle.workspacePath!,
       branch: experimentBranch,
     });
+    bench('SshExecutor.startManagedWorkspace.spawnSshRemoteStdin.after', {
+      remoteWt,
+      workspacePath: started.workspacePath,
+      branch: started.branch,
+    });
+    return started;
   }
 
   private withStartupMetadata(err: unknown, handle: ExecutorHandle): Error {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -18,7 +18,8 @@ import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/con
 import type { Executor, ExecutorHandle } from './executor.js';
 import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 import { BaseExecutor } from './base-executor.js';
-import { RESTART_TO_BRANCH_TRACE, executionTraceEnabled, traceExecution } from './exec-trace.js';
+import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
+import { createExecutionBench } from './execution-bench.js';
 import { ResourceLimitError, type RepoPoolTiming } from './repo-pool.js';
 import type { ExecutorRegistry } from './registry.js';
 import type { AgentRegistry } from './agent-registry.js';
@@ -61,7 +62,6 @@ export type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
 const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
 const DEFAULT_EXECUTOR_START_TIMEOUT_MS = 10 * 60 * 1000;
-const EXECUTE_TASK_BENCH_ENV = 'INVOKER_BENCH_EXECUTE_TASK';
 
 type StartupFailureMetadata = {
   workspacePath?: string;
@@ -330,36 +330,15 @@ export class TaskRunner {
     return undefined;
   }
 
-  private executeTaskBenchEnabled(): boolean {
-    return process.env[EXECUTE_TASK_BENCH_ENV] === '1' || executionTraceEnabled();
-  }
-
   private createExecuteTaskBench(taskId: string, attemptId: string): (phase: string, metadata?: Record<string, unknown>) => void {
-    if (!this.executeTaskBenchEnabled()) return () => {};
-    const startedAt = Date.now();
-    let previousAt = startedAt;
-    return (phase, metadata = {}) => {
-      const now = Date.now();
-      const elapsedMs = now - startedAt;
-      const deltaMs = now - previousAt;
-      previousAt = now;
-      const payload = {
-        module: 'execute-task-bench',
+    return createExecutionBench({
+      module: 'execute-task-bench',
+      logger: this.logger,
+      baseMetadata: {
         taskId,
         attemptId,
-        phase,
-        elapsedMs,
-        deltaMs,
-        ...metadata,
-      };
-      this.logger.info(
-        `[execute-task-bench] task="${taskId}" attempt="${attemptId}" phase="${phase}" elapsedMs=${elapsedMs} deltaMs=${deltaMs}`,
-        payload,
-      );
-      traceExecution(
-        `[execute-task-bench] task=${taskId} attempt=${attemptId} phase=${phase} elapsedMs=${elapsedMs} deltaMs=${deltaMs}`,
-      );
-    };
+      },
+    });
   }
 
   /**

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -13,6 +13,7 @@ import {
   buildExperimentBranchName,
 } from './branch-utils.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
+import { createExecutionBench } from './execution-bench.js';
 import {
   syncPlanBaseRemote,
   syncPlanBaseRemoteForRef,
@@ -135,23 +136,41 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} WorktreeExecutor.start() actionId=${request.actionId} repoUrl=${repoUrl}`,
     );
+    const bench = createExecutionBench({
+      module: 'worktree-executor-start-bench',
+      baseMetadata: {
+        requestId: request.requestId,
+        actionId: request.actionId,
+        actionType: request.actionType,
+        repoUrl,
+      },
+    });
+    bench('WorktreeExecutor.start.begin');
     await this.ensureGitAvailable();
+    bench('WorktreeExecutor.ensureGitAvailable.done');
     const handle = this.createHandle(request);
     const executionId = handle.executionId;
     const t0 = Date.now();
     const log = (step: string) => traceExecution(`[WorktreeExecutor] start task=${request.actionId} step=${step} elapsed=${Date.now() - t0}ms`);
 
+    bench('RepoPool.ensureClone.before');
     const clonePath = await this.pool.ensureClone(repoUrl);
+    bench('RepoPool.ensureClone.after', { clonePath });
     const baseRef = request.inputs.baseBranch ?? 'HEAD';
     log(`resolve base ${baseRef} begin`);
     const runGit = (args: string[]) => this.execGitSimple(args, clonePath);
+    bench('WorktreeExecutor.resolveBase.before', { baseRef });
     if (remoteFetchForPool.enabled && shouldResolveViaOriginTracking(baseRef)) {
       const preferredRemote = await resolvePreferredTrackingRemote(runGit, baseRef.trim());
+      bench('WorktreeExecutor.resolvePreferredTrackingRemote.done', { baseRef, preferredRemote });
       await syncPlanBaseRemote(runGit, baseRef.trim(), preferredRemote);
+      bench('WorktreeExecutor.syncPlanBaseRemote.done', { baseRef, preferredRemote });
     } else if (remoteFetchForPool.enabled) {
       await syncPlanBaseRemoteForRef(runGit, baseRef.trim());
+      bench('WorktreeExecutor.syncPlanBaseRemoteForRef.done', { baseRef });
     }
     const baseHead = await resolvePlanBaseRevision(runGit, baseRef);
+    bench('WorktreeExecutor.resolveBase.after', { baseRef, baseHead });
     log(`resolve base ${baseRef} done → ${baseHead}`);
     const upstreamCommits = (request.inputs.upstreamContext ?? [])
       .map(c => c.commitHash)
@@ -169,14 +188,20 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       contentHash,
     );
     traceExecution(`[WorktreeExecutor] branch=${branch} contentHash=${contentHash}`);
+    bench('WorktreeExecutor.branchComputed', { branch, contentHash });
     // Notify the orchestrator before any `git worktree add` so a leaked
     // worktree (process killed mid-acquire) can still be reconciled.
     try {
       request.onBranchResolved?.(branch);
+      bench('WorktreeExecutor.onBranchResolved.done', { branch });
     } catch (err) {
       traceExecution(
         `[WorktreeExecutor] onBranchResolved threw — continuing: ${err instanceof Error ? err.message : String(err)}`,
       );
+      bench('WorktreeExecutor.onBranchResolved.failed', {
+        branch,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
 
     // -- Reconciliation: real pool worktree at plan base (no upstream merges), then needs_input --
@@ -184,6 +209,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       traceExecution(
         `${RESTART_TO_BRANCH_TRACE} WorktreeExecutor.start() actionId=${request.actionId} reconciliation → acquireWorktree (skip upstream merge)`,
       );
+      bench('RepoPool.acquireWorktree.reconciliation.before', { branch, baseHead });
       const acquired = await this.pool.acquireWorktree(
         repoUrl,
         branch,
@@ -191,6 +217,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         request.actionId,
         { forceFresh: request.inputs.freshWorkspace === true },
       );
+      bench('RepoPool.acquireWorktree.reconciliation.after', {
+        branch: acquired.branch,
+        worktreePath: acquired.worktreePath,
+      });
       this.cleanStaleLocks(acquired.worktreePath);
 
       const entry: WorktreeEntry = {
@@ -212,6 +242,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       this.registerEntry(handle, entry);
       handle.workspacePath = acquired.worktreePath;
       handle.branch = acquired.branch;
+      bench('WorktreeExecutor.registerEntry.reconciliation.done', {
+        workspacePath: handle.workspacePath,
+        branch: handle.branch,
+      });
 
       setTimeout(() => {
         const e = this.entries.get(executionId);
@@ -227,6 +261,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         this.softReleasePoolSlot(e);
       }, 0);
 
+      bench('WorktreeExecutor.start.reconciliation.returning');
       return handle;
     }
 
@@ -234,7 +269,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} WorktreeExecutor.start() actionId=${request.actionId} → RepoPool path`,
     );
+    bench('WorktreeExecutor.reconcilePoolSlots.before');
     this.reconcilePoolSlots(repoUrl);
+    bench('WorktreeExecutor.reconcilePoolSlots.after');
+    bench('RepoPool.acquireWorktree.before', { branch, baseHead });
     const acquired = await this.pool.acquireWorktree(
       repoUrl,
       branch,
@@ -242,6 +280,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       request.actionId,
       { forceFresh: request.inputs.freshWorkspace === true },
     );
+    bench('RepoPool.acquireWorktree.after', {
+      branch: acquired.branch,
+      worktreePath: acquired.worktreePath,
+    });
 
     this.cleanStaleLocks(acquired.worktreePath);
 
@@ -249,7 +291,9 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     const poolUpstreams = request.inputs.upstreamBranches ?? [];
     if (poolUpstreams.length > 0) {
       try {
+        bench('WorktreeExecutor.mergeRequestUpstreamBranches.before', { upstreamCount: poolUpstreams.length });
         await this.mergeRequestUpstreamBranches(request, acquired.worktreePath, baseHead);
+        bench('WorktreeExecutor.mergeRequestUpstreamBranches.after', { upstreamCount: poolUpstreams.length });
       } catch (err: any) {
         if (err instanceof MergeConflictError) {
           const entry: WorktreeEntry = {
@@ -281,8 +325,12 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
           };
           this.emitComplete(handle.executionId, response);
           this.softReleasePoolSlot(entry);
+          bench('WorktreeExecutor.mergeConflict.returning', { failedBranch: err.failedBranch });
           return handle;
         }
+        bench('WorktreeExecutor.mergeRequestUpstreamBranches.failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
         throw err;
       }
     }
@@ -302,9 +350,14 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       this.registerEntry(handle, entry);
       handle.workspacePath = acquired.worktreePath;
       handle.branch = acquired.branch;
+      bench('WorktreeExecutor.registerEntry.noCommand.done', {
+        workspacePath: handle.workspacePath,
+        branch: handle.branch,
+      });
       await this.handleProcessExit(executionId, request, acquired.worktreePath, 0, { branch });
       entry.phase = 'completed';
       this.softReleasePoolSlot(entry);
+      bench('WorktreeExecutor.start.noCommand.returning');
       return handle;
     }
 
@@ -327,13 +380,19 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     this.registerEntry(handle, entry);
     handle.workspacePath = acquired.worktreePath;
     handle.branch = acquired.branch;
+    bench('WorktreeExecutor.registerEntry.provisioning.done', {
+      workspacePath: handle.workspacePath,
+      branch: handle.branch,
+    });
 
+    bench('WorktreeExecutor.provisionWorktree.before');
     const provisioning = this.provisionWorktree(acquired.worktreePath, executionId);
     entry.process = provisioning.child;
     try {
       await provisioning.completion;
       entry.process = null;
       entry.phase = 'running';
+      bench('WorktreeExecutor.provisionWorktree.after');
     } catch (err) {
       // Keep the failed workspace on disk for post-failure debugging/fix flows.
       // Only free the in-memory pool slot so retries are not blocked.
@@ -345,24 +404,37 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       const startupErr = err instanceof Error ? err : new Error(String(err));
       (startupErr as Error & { workspacePath?: string; branch?: string }).workspacePath = acquired.worktreePath;
       (startupErr as Error & { workspacePath?: string; branch?: string }).branch = acquired.branch;
+      bench('WorktreeExecutor.provisionWorktree.failed', {
+        error: startupErr.message,
+        workspacePath: acquired.worktreePath,
+        branch: acquired.branch,
+      });
       throw startupErr;
     }
 
+    bench('WorktreeExecutor.buildCommandAndArgs.before');
     const { cmd, args, agentSessionId } = this.buildCommandAndArgs(request, {
       claudeCommand: this.claudeCommand,
       agentRegistry: this.agentRegistry,
+    });
+    bench('WorktreeExecutor.buildCommandAndArgs.after', {
+      cmd,
+      argCount: args.length,
+      hasAgentSessionId: !!agentSessionId,
     });
 
     const executionAgent = request.inputs.executionAgent ?? 'claude';
     const stdinMode = this.agentRegistry && executionAgent
       ? this.agentRegistry.getOrThrow(executionAgent).stdinMode
       : (request.actionType === 'ai_task' ? 'ignore' : 'pipe');
+    bench('WorktreeExecutor.spawn.before', { cmd, argCount: args.length, cwd: acquired.worktreePath });
     const child = spawn(cmd, args, {
       stdio: [stdinMode, 'pipe', 'pipe'],
       cwd: acquired.worktreePath,
       detached: true,
       env: cleanElectronEnv(),
     });
+    bench('WorktreeExecutor.spawn.after');
 
     // Register error handler IMMEDIATELY to catch synchronous spawn failures
     child.on('error', (err) => {
@@ -452,6 +524,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
 
     this.startHeartbeat(executionId, child);
     log('startHeartbeat done — start() returning');
+    bench('WorktreeExecutor.start.returning', {
+      workspacePath: handle.workspacePath,
+      branch: handle.branch,
+    });
     return handle;
   }
 


### PR DESCRIPTION
## Summary

Extend launch timing instrumentation across the scheduler-to-executor handoff, so a launch stall can be localized to dispatch, repo preparation, SSH startup, worktree startup, or pool operations.

- Adds shared `createExecutionBench` timing helpers gated by `INVOKER_BENCH_EXECUTE_TASK` or execution tracing.
- Instruments global top-up dispatch, scoped dispatch, repo pool clone/worktree phases, SSH executor setup, and worktree executor setup.
- Keeps instrumentation passive: no scheduling or execution behavior changes are intended.

## Architecture

### Before

```mermaid
flowchart TD
  A[Orchestrator starts tasks] --> B[TaskRunner]
  B --> C[Executor]
  C --> D[Repo/SSH/worktree setup]
```

### After

```mermaid
flowchart TD
  A[Orchestrator starts tasks] --> B[Dispatch bench]
  B --> C[TaskRunner bench]
  C --> D[Executor bench]
  D --> E[Repo pool / SSH / worktree phase timings]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] GitHub CI for #646: required-fast, Playwright shards, SSH shards, Docker, package builds, and type checks passed

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert ae8d8af3`
- Post-revert steps: Re-run typecheck and smoke a task launch with bench tracing disabled and enabled.
- Data migration? No

Depends-On: #645
