### PR TITLE
Enforce superseded attempts as discarded

### DIFF
--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -63,9 +63,9 @@ function buildPlan(index: number) {
   };
 }
 
-async function waitForGraphVisible(page: Page, taskSuffix: string, timeoutMs: number): Promise<number> {
+async function waitForWorkflowGraphVisible(page: Page, timeoutMs: number): Promise<number> {
   const startedAt = Date.now();
-  await page.locator(`.react-flow__node[data-testid$="${taskSuffix}"]`).first().waitFor({
+  await page.locator('[data-testid^="workflow-node-"]').first().waitFor({
     state: 'visible',
     timeout: timeoutMs,
   });
@@ -99,10 +99,9 @@ async function dragGraphAndAssertViewportMoves(page: Page): Promise<void> {
 
 test('non-empty persisted startup stays responsive and avoids initial db-poll replay flood', async () => {
   const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-startup-nonempty-'));
-  const workflowCount = 14;
+  const workflowCount = 30;
   const tasksPerWorkflow = 8;
   const expectedTaskCount = workflowCount * tasksPerWorkflow;
-  const initialWorkflowIndex = workflowCount - 1;
   try {
     const seedApp = await launchElectronApp(testDir);
     try {
@@ -134,7 +133,7 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
       await page.waitForLoadState('domcontentloaded');
       await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 5000 });
 
-      await waitForGraphVisible(page, `task-${initialWorkflowIndex}-0`, 5000);
+      await waitForWorkflowGraphVisible(page, 5000);
       await dragGraphAndAssertViewportMoves(page);
 
       const result = await page.evaluate(async () => {
@@ -157,15 +156,44 @@ test('non-empty persisted startup stays responsive and avoids initial db-poll re
       const graphVisible = startupEntries.find(
         (entry) =>
           entry.source === 'ui-perf'
+          && entry.payload?.metric === 'startup_workflow_graph_visible'
+          && entry.payload?.nodeCount === workflowCount,
+      )?.payload;
+      const taskGraphVisible = startupEntries.find(
+        (entry) =>
+          entry.source === 'ui-perf'
           && entry.payload?.metric === 'startup_graph_visible'
           && entry.payload?.nodeCount === tasksPerWorkflow,
       )?.payload;
+      const backgroundHydration = startupEntries.find(
+        (entry) =>
+          entry.source === 'startup-phase'
+          && typeof entry.payload?.phase === 'string'
+          && entry.payload.phase.startsWith('background-hydration'),
+      );
+      const phaseNames = new Set(
+        ((result.perf.startupPhaseDetails as Array<{ phase?: string }> | undefined) ?? [])
+          .map((entry) => entry.phase)
+          .filter(Boolean),
+      );
 
       expect(windowShow).toBeTruthy();
       expect(graphVisible).toBeTruthy();
+      expect(taskGraphVisible).toBeTruthy();
+      expect(backgroundHydration).toBeUndefined();
       expect(Number(graphVisible?.processElapsedMs) - Number(windowShow?.elapsedMs)).toBeLessThan(2000);
-      expect(Number(graphVisible?.nodeCount)).toBe(tasksPerWorkflow);
+      expect(Number(graphVisible?.nodeCount)).toBe(workflowCount);
+      expect(Number(taskGraphVisible?.nodeCount)).toBe(tasksPerWorkflow);
       expect(elapsedMs).toBeLessThan(STARTUP_BUDGET_MS);
+      expect([...phaseNames]).toEqual(expect.arrayContaining([
+        'listWorkflowsByStartupRecency',
+        'orchestrator.restore.full-snapshot',
+        'sqlite.workflow-metadata.query',
+        'sqlite.tasks.query',
+        'sqlite.workflow-rollups.compute',
+        'sqlite.tasks.deserialize-reconcile',
+        'bootstrap-ipc.serialize-return',
+      ]));
 
       expect(result.taskCount).toBe(expectedTaskCount);
       expect(result.perf.dbPollCreated).toBe(0);

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -178,8 +178,9 @@ async function loadPlanAndSelectWorkflow(page: Page, plan: unknown): Promise<str
     return created?.id ?? workflows[workflows.length - 1]?.id ?? null;
   }, beforeIds);
   expect(workflowId).toBeTruthy();
-  await workflowNode(page, workflowId!).waitFor({ state: 'visible', timeout: 15000 });
-  await workflowNode(page, workflowId!).dispatchEvent('click', { bubbles: true });
+  const node = workflowNode(page, workflowId!);
+  await node.waitFor({ state: 'attached', timeout: 15000 });
+  await node.dispatchEvent('click', { bubbles: true });
   await expect(page.getByTestId('selected-workflow-mini-dag')).toBeVisible({ timeout: 10000 });
   return workflowId!;
 }

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -16,6 +16,7 @@ import { EventEmitter } from 'node:events';
 
 import {
   Orchestrator,
+  type Attempt,
   type PlanDefinition,
   type TaskState,
   type OrchestratorPersistence,
@@ -60,6 +61,7 @@ const worktreeCheckoutShell = process.platform === 'darwin' ? 'zsh' : 'bash';
 class InMemoryPersistence implements OrchestratorPersistence {
   workflows = new Map<string, { id: string; name: string; status: string; createdAt: string; updatedAt: string }>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
+  attempts = new Map<string, Attempt>();
 
   saveWorkflow(workflow: { id: string; name: string; status: string }): void {
     const now = new Date().toISOString();
@@ -85,6 +87,20 @@ class InMemoryPersistence implements OrchestratorPersistence {
       .map((e) => e.task);
   }
   logEvent(): void {}
+  saveAttempt(attempt: Attempt): void {
+    this.attempts.set(attempt.id, { ...attempt });
+  }
+  loadAttempts(nodeId: string): Attempt[] {
+    return Array.from(this.attempts.values()).filter((attempt) => attempt.nodeId === nodeId);
+  }
+  loadAttempt(attemptId: string): Attempt | undefined {
+    const attempt = this.attempts.get(attemptId);
+    return attempt ? { ...attempt } : undefined;
+  }
+  updateAttempt(attemptId: string, changes: Partial<Attempt>): void {
+    const attempt = this.attempts.get(attemptId);
+    if (attempt) this.attempts.set(attemptId, { ...attempt, ...changes });
+  }
 }
 
 class InMemoryBus implements OrchestratorMessageBus {

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -1,6 +1,7 @@
 import type { Logger } from '@invoker/contracts';
 import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { TaskRunner } from '@invoker/execution-engine';
+import { createExecutionBench } from '@invoker/execution-engine';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 
 type GlobalTopupParams = {
@@ -24,6 +25,25 @@ type MutationTopupParams = {
 function runningExecutionKey(task: TaskState): string {
   const attemptId = task.execution.selectedAttemptId?.trim();
   return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
+}
+
+function createDispatchBench(
+  logger: Logger | undefined,
+  context: string,
+  runnable: TaskState[],
+  dispatchKind: 'global-topup' | 'scoped',
+): (phase: string, metadata?: Record<string, unknown>) => void {
+  return createExecutionBench({
+    module: 'scheduler-dispatch-bench',
+    logger,
+    baseMetadata: {
+      context,
+      dispatchKind,
+      runnableCount: runnable.length,
+      taskIds: runnable.map((task) => task.id),
+      attemptIds: runnable.map((task) => task.execution.selectedAttemptId ?? null),
+    },
+  });
 }
 
 export function isDispatchableLaunch(task: TaskState): boolean {
@@ -53,13 +73,27 @@ export async function executeGlobalTopup({
       .filter(isDispatchableLaunch)
       .map((task) => runningExecutionKey(task)),
   );
+  const startBench = createExecutionBench({
+    module: 'scheduler-dispatch-bench',
+    logger,
+    baseMetadata: {
+      context,
+      dispatchKind: 'global-topup',
+      alreadyDispatchedCount: alreadyDispatched.length,
+    },
+  });
+  startBench('executeGlobalTopup.startExecution.before');
   const started = orchestrator.startExecution();
+  startBench('executeGlobalTopup.startExecution.after', { startedCount: started.length });
   const runnable = started
     .filter(isDispatchableLaunch)
     .filter((task) => !dedupeKeys.has(runningExecutionKey(task)));
+  const bench = createDispatchBench(logger, context, runnable, 'global-topup');
+  bench('executeGlobalTopup.runnableFiltered', { startedCount: started.length });
 
   if (runnable.length === 0) {
     logger?.info(`[global-topup] ${context}: no additional globally ready tasks`);
+    bench('executeGlobalTopup.noRunnable');
     return [];
   }
 
@@ -67,13 +101,17 @@ export async function executeGlobalTopup({
     `[global-topup] ${context}: dispatching ${runnable.length} additional task(s): [${runnable.map((task) => task.id).join(', ')}]`,
   );
   if (mutationTiming) {
+    bench('executeGlobalTopup.taskExecutor.executeTasks.before');
     await mutationTiming.span(
       'executeGlobalTopup.taskExecutor.executeTasks',
       { context, runnableCount: runnable.length },
       () => taskExecutor.executeTasks(runnable),
     );
+    bench('executeGlobalTopup.taskExecutor.executeTasks.after');
   } else {
+    bench('executeGlobalTopup.taskExecutor.executeTasks.before');
     await taskExecutor.executeTasks(runnable);
+    bench('executeGlobalTopup.taskExecutor.executeTasks.after');
   }
   return runnable;
 }
@@ -91,20 +129,29 @@ export async function dispatchStartedTasksWithGlobalTopup({
   mutationTiming,
 }: MutationTopupParams): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
   const runnable = started.filter(isDispatchableLaunch);
+  const bench = createDispatchBench(logger, context, runnable, 'scoped');
+  bench('dispatchStartedTasksWithGlobalTopup.runnableFiltered', { startedCount: started.length });
   if (runnable.length > 0) {
     logger?.info(
       `[global-topup] ${context}: dispatching ${runnable.length} scoped task(s): [${runnable.map((task) => task.id).join(', ')}]`,
     );
     if (mutationTiming) {
+      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.before');
       await mutationTiming.span(
         'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks',
         { context, runnableCount: runnable.length },
         () => taskExecutor.executeTasks(runnable),
       );
+      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.after');
     } else {
+      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.before');
       await taskExecutor.executeTasks(runnable);
+      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.after');
     }
+  } else {
+    bench('dispatchStartedTasksWithGlobalTopup.noScopedRunnable');
   }
+  bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.before');
   const topup = await executeGlobalTopup({
     orchestrator,
     taskExecutor,
@@ -113,6 +160,7 @@ export async function dispatchStartedTasksWithGlobalTopup({
     alreadyDispatched: runnable,
     mutationTiming,
   });
+  bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.after', { topupCount: topup.length });
   return { runnable, topup };
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -730,6 +730,9 @@ if (isHeadless) {
           dbPollUpdatedAsUpdated: 0,
           rendererReports: 0,
           maxRendererEventLoopLagMs: 0,
+          maxRendererHiddenEventLoopLagMs: 0,
+          maxRendererCumulativeLagMs: 0,
+          maxRendererTickDeltaMs: 0,
           maxRendererLongTaskMs: 0,
         }),
         resetUiPerfStats: () => {},
@@ -1214,6 +1217,9 @@ if (isHeadless) {
     dbPollUpdatedAsUpdated: 0,
     rendererReports: 0,
     maxRendererEventLoopLagMs: 0,
+    maxRendererHiddenEventLoopLagMs: 0,
+    maxRendererCumulativeLagMs: 0,
+    maxRendererTickDeltaMs: 0,
     maxRendererLongTaskMs: 0,
   };
   const startupMarks = new Map<string, number>();
@@ -1268,6 +1274,9 @@ if (isHeadless) {
     uiPerfStats.dbPollUpdatedAsUpdated = 0;
     uiPerfStats.rendererReports = 0;
     uiPerfStats.maxRendererEventLoopLagMs = 0;
+    uiPerfStats.maxRendererHiddenEventLoopLagMs = 0;
+    uiPerfStats.maxRendererCumulativeLagMs = 0;
+    uiPerfStats.maxRendererTickDeltaMs = 0;
     uiPerfStats.maxRendererLongTaskMs = 0;
   };
 
@@ -3235,7 +3244,18 @@ if (isHeadless) {
         ...(data ?? {}),
       };
       if (metric === 'renderer_event_loop_lag' && typeof data?.lagMs === 'number') {
-        uiPerfStats.maxRendererEventLoopLagMs = Math.max(uiPerfStats.maxRendererEventLoopLagMs, data.lagMs);
+        const hiddenOrUnfocused = data.visibilityState === 'hidden' || data.hasFocus === false;
+        if (hiddenOrUnfocused) {
+          uiPerfStats.maxRendererHiddenEventLoopLagMs = Math.max(uiPerfStats.maxRendererHiddenEventLoopLagMs, data.lagMs);
+        } else {
+          uiPerfStats.maxRendererEventLoopLagMs = Math.max(uiPerfStats.maxRendererEventLoopLagMs, data.lagMs);
+        }
+        if (typeof data.cumulativeLagMs === 'number') {
+          uiPerfStats.maxRendererCumulativeLagMs = Math.max(uiPerfStats.maxRendererCumulativeLagMs, data.cumulativeLagMs);
+        }
+        if (typeof data.tickDeltaMs === 'number') {
+          uiPerfStats.maxRendererTickDeltaMs = Math.max(uiPerfStats.maxRendererTickDeltaMs, data.tickDeltaMs);
+        }
       }
       if (metric === 'renderer_long_task' && typeof data?.durationMs === 'number') {
         uiPerfStats.maxRendererLongTaskMs = Math.max(uiPerfStats.maxRendererLongTaskMs, data.durationMs);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3819,7 +3819,7 @@ if (isHeadless) {
 
     // ── DB Polling — detect external workflow changes ───
     ipcMain.handle('invoker:get-activity-logs', () => {
-      return persistence.getActivityLogs(0);
+      return persistence.getActivityLogs(0, 2000);
     });
 
     // ── External terminal launcher ──────────────────────────────

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1197,6 +1197,7 @@ if (isHeadless) {
   let lastKnownWorkflowCount = 0;
   let lastActivityLogId = 0;
   let startupWorkflowId: string | null = null;
+  let allWorkflowsHydrated = false;
   let uiInteractive = false;
   let deferredStartupTriggered = false;
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
@@ -2242,6 +2243,7 @@ if (isHeadless) {
     const workflows = listWorkflowsByStartupRecency();
     lastKnownWorkflowCount = workflows.length;
     startupWorkflowId = workflows[0]?.id ?? null;
+    allWorkflowsHydrated = workflows.length === 0;
     if (!startupWorkflowId) {
       logger.info('[init] No workflows available for initial startup bootstrap', { module: 'init' });
       return;
@@ -2251,6 +2253,7 @@ if (isHeadless) {
         workflowCount: workflows.length,
         taskCount: orchestrator.getAllTasks().length,
       }));
+      allWorkflowsHydrated = true;
       const snapshotStats = (persistence as unknown as {
         getLastWorkflowTaskSnapshotStats?: () => Record<string, unknown> | null;
       }).getLastWorkflowTaskSnapshotStats?.();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1194,9 +1194,6 @@ if (isHeadless) {
   let lastKnownWorkflowCount = 0;
   let lastActivityLogId = 0;
   let startupWorkflowId: string | null = null;
-  let allWorkflowsHydrated = false;
-  let backgroundHydrationStarted = false;
-  let backgroundHydrationScheduled = false;
   let uiInteractive = false;
   let deferredStartupTriggered = false;
   const traceUiDeltaFlow = process.env.INVOKER_TRACE_UI_DELTA === '1';
@@ -1220,6 +1217,7 @@ if (isHeadless) {
     maxRendererLongTaskMs: 0,
   };
   const startupMarks = new Map<string, number>();
+  const startupPhaseDetails: Array<Record<string, unknown>> = [];
   const recordStartupMark = (phase: string, extra?: Record<string, unknown>): void => {
     const elapsedMs = Date.now() - appProcessStartedAt;
     startupMarks.set(phase, elapsedMs);
@@ -1237,6 +1235,31 @@ if (isHeadless) {
       // best effort; db can be locked during startup
     }
   };
+  const recordStartupDuration = (phase: string, startedAtMs: number, extra?: Record<string, unknown>): void => {
+    const durationMs = Date.now() - startedAtMs;
+    startupPhaseDetails.push({
+      phase,
+      durationMs,
+      ...(extra ?? {}),
+    });
+    recordStartupMark(phase, {
+      durationMs,
+      ...(extra ?? {}),
+    });
+  };
+  const recordStartupDetail = (phase: string, details: Record<string, unknown>): void => {
+    startupPhaseDetails.push({
+      phase,
+      ...details,
+    });
+    recordStartupMark(phase, details);
+  };
+  const timeStartupPhase = <T>(phase: string, work: () => T, extra?: (result: T) => Record<string, unknown>): T => {
+    const startedAtMs = Date.now();
+    const result = work();
+    recordStartupDuration(phase, startedAtMs, extra?.(result));
+    return result;
+  };
 
   const resetUiPerfStats = (): void => {
     uiPerfStats.mainDeltaToUi = 0;
@@ -1251,6 +1274,7 @@ if (isHeadless) {
   const getUiPerfStats = (): Record<string, unknown> => ({
     ...uiPerfStats,
     startupMarks: Object.fromEntries(startupMarks.entries()),
+    startupPhaseDetails: [...startupPhaseDetails],
     ts: new Date().toISOString(),
   });
 
@@ -2175,11 +2199,7 @@ if (isHeadless) {
   }
 
   function loadTaskByIdFromPersistence(taskId: string): TaskState | undefined {
-    for (const workflow of persistence.listWorkflows()) {
-      const task = persistence.loadTasks(workflow.id).find((candidate) => candidate.id === taskId);
-      if (task) return task;
-    }
-    return undefined;
+    return persistence.loadTask(taskId);
   }
 
   workflowMetadataInvalidator = new WorkflowMetadataInvalidator({
@@ -2196,7 +2216,10 @@ if (isHeadless) {
   });
 
   function listWorkflowsByStartupRecency() {
-    return [...persistence.listWorkflows()].sort((left, right) => {
+    const workflows = timeStartupPhase('listWorkflowsByStartupRecency', () => persistence.listWorkflows(), (result) => ({
+      workflowCount: result.length,
+    }));
+    return [...workflows].sort((left, right) => {
       const rightTs = Date.parse(right.updatedAt ?? '') || 0;
       const leftTs = Date.parse(left.updatedAt ?? '') || 0;
       if (rightTs !== leftTs) {
@@ -2210,27 +2233,50 @@ if (isHeadless) {
     const workflows = listWorkflowsByStartupRecency();
     lastKnownWorkflowCount = workflows.length;
     startupWorkflowId = workflows[0]?.id ?? null;
-    allWorkflowsHydrated = workflows.length <= 1;
     if (!startupWorkflowId) {
       logger.info('[init] No workflows available for initial startup bootstrap', { module: 'init' });
       return;
     }
     try {
-      orchestrator.syncFromDb(startupWorkflowId);
+      timeStartupPhase('orchestrator.restore.full-snapshot', () => orchestrator.syncAllFromDb(), () => ({
+        workflowCount: workflows.length,
+        taskCount: orchestrator.getAllTasks().length,
+      }));
+      const snapshotStats = (persistence as unknown as {
+        getLastWorkflowTaskSnapshotStats?: () => Record<string, unknown> | null;
+      }).getLastWorkflowTaskSnapshotStats?.();
+      if (snapshotStats) {
+        recordStartupDetail('sqlite.workflow-metadata.query', {
+          durationMs: snapshotStats.workflowMetadataQueryMs,
+          workflowCount: snapshotStats.workflowCount,
+        });
+        recordStartupDetail('sqlite.tasks.query', {
+          durationMs: snapshotStats.taskQueryMs,
+          taskCount: snapshotStats.taskCount,
+        });
+        recordStartupDetail('sqlite.workflow-rollups.compute', {
+          durationMs: snapshotStats.rollupComputationMs,
+          workflowCount: snapshotStats.workflowCount,
+          taskCount: snapshotStats.taskCount,
+        });
+        recordStartupDetail('sqlite.tasks.deserialize-reconcile', {
+          durationMs: snapshotStats.taskDeserializeReconcileMs,
+          taskCount: snapshotStats.taskCount,
+        });
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      logger.error(`workflow invariant violation during initial workflow bootstrap: ${message}`, {
+      logger.error(`workflow invariant violation during full startup bootstrap: ${message}`, {
         module: 'init',
         error: message,
-        workflowId: startupWorkflowId,
       });
       throw err;
     }
     logger.info(
-      `[init] Bootstrapped startup workflow "${startupWorkflowId}" with ${orchestrator.getAllTasks().length} tasks (${workflows.length} workflows total)`,
+      `[init] Bootstrapped full workflow graph with ${orchestrator.getAllTasks().length} tasks across ${workflows.length} workflows`,
       { module: 'init' },
     );
-    recordStartupMark('startup.initial-workflow.ready', {
+    recordStartupMark('startup.full-graph.ready', {
       workflowId: startupWorkflowId,
       taskCount: orchestrator.getAllTasks().length,
       workflowCount: workflows.length,
@@ -2257,88 +2303,6 @@ if (isHeadless) {
       }
       mainWindow.webContents.send('invoker:workflows-changed', workflows);
     }
-  }
-
-  function startBackgroundHydration(reason: string): void {
-    if (backgroundHydrationStarted || backgroundHydrationScheduled || allWorkflowsHydrated) {
-      return;
-    }
-    const hydrateDelayMs = Number.parseInt(process.env.INVOKER_BACKGROUND_HYDRATE_DELAY_MS ?? '10000', 10) || 10000;
-    backgroundHydrationScheduled = true;
-    setTimeout(() => {
-      backgroundHydrationScheduled = false;
-      backgroundHydrationStarted = true;
-      const workflows = listWorkflowsByStartupRecency();
-      const remainingWorkflowIds = workflows
-        .map((workflow) => workflow.id)
-        .filter((workflowId) => workflowId !== startupWorkflowId);
-      if (remainingWorkflowIds.length === 0) {
-        allWorkflowsHydrated = true;
-        backgroundHydrationStarted = false;
-        recordStartupMark('background-hydration.end', {
-          reason,
-          workflowCount: workflows.length,
-          taskCount: orchestrator.getAllTasks().length,
-        });
-        return;
-      }
-      try {
-        recordStartupMark('background-hydration.start', {
-          reason,
-          startupWorkflowId,
-          remainingWorkflowCount: remainingWorkflowIds.length,
-        });
-      } catch (err) {
-        backgroundHydrationStarted = false;
-        logger.error(
-          `background hydration failed before scheduling: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-          { module: 'init' },
-        );
-        return;
-      }
-
-      const hydrateNext = (index: number): void => {
-        if (index >= remainingWorkflowIds.length) {
-          allWorkflowsHydrated = true;
-          backgroundHydrationStarted = false;
-          if (ownerMode && !invokerConfig.disableAutoRunOnStartup) {
-            const newlyStarted = relaunchOrphansAndStartReady(orchestrator, logger, 'background-hydration');
-            if (newlyStarted.length > 0) {
-              requireTaskExecutor().executeTasks(newlyStarted);
-            }
-            requireTaskExecutor().resumeMergeGatePolling();
-          }
-          publishOrchestratorSnapshotToRenderer();
-          recordStartupMark('background-hydration.end', {
-            reason,
-            workflowCount: workflows.length,
-            taskCount: orchestrator.getAllTasks().length,
-          });
-          return;
-        }
-
-        const workflowId = remainingWorkflowIds[index];
-        try {
-          orchestrator.hydrateWorkflowFromDb(workflowId);
-          recordStartupMark('background-hydration.workflow', {
-            workflowId,
-            index: index + 1,
-            total: remainingWorkflowIds.length,
-          });
-        } catch (err) {
-          backgroundHydrationStarted = false;
-          logger.error(
-            `background hydration failed for workflow "${workflowId}": ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-            { module: 'init' },
-          );
-          return;
-        }
-
-        setTimeout(() => hydrateNext(index + 1), 0).unref?.();
-      };
-
-      hydrateNext(0);
-    }, hydrateDelayMs).unref?.();
   }
 
   function startDeferredStartupWork(): void {
@@ -2778,14 +2742,23 @@ if (isHeadless) {
 
     // Register IPC handlers
     ipcMain.on('invoker:get-bootstrap-state-sync', (event) => {
-      event.returnValue = {
-        tasks: orchestrator.getAllTasks(),
-        workflows: listWorkflowsByStartupRecency(),
+      const startedAtMs = Date.now();
+      const tasks = orchestrator.getAllTasks();
+      const workflows = listWorkflowsByStartupRecency();
+      const payload = {
+        tasks,
+        workflows,
         initialWorkflowId: startupWorkflowId,
         appStartedAtEpochMs: appProcessStartedAt,
       };
+      const jsonSizeBytes = Buffer.byteLength(JSON.stringify(payload), 'utf8');
+      recordStartupDuration('bootstrap-ipc.serialize-return', startedAtMs, {
+        taskCount: tasks.length,
+        workflowCount: workflows.length,
+        jsonSizeBytes,
+      });
+      event.returnValue = payload;
     });
-
     registerGuiMutationHandler('invoker:load-plan', async (planTextArg: unknown) => {
       const planText = String(planTextArg);
       const { parsePlan } = await import('./plan-parser.js');
@@ -3003,8 +2976,11 @@ if (isHeadless) {
     });
 
     ipcMain.handle('invoker:get-tasks', (_event, forceRefresh?: boolean) => {
+      const startedAtMs = Date.now();
       if (forceRefresh) {
-        orchestrator.syncAllFromDb();
+        timeStartupPhase('get-tasks.force-refresh.syncAllFromDb', () => orchestrator.syncAllFromDb(), () => ({
+          taskCount: orchestrator.getAllTasks().length,
+        }));
       }
       const tasks = orchestrator.getAllTasks();
       const workflows = persistence.listWorkflows();
@@ -3030,6 +3006,13 @@ if (isHeadless) {
         `get-tasks(forceRefresh=${forceRefresh ? 'true' : 'false'}) returning ${tasks.length} tasks, ${workflows.length} workflows`,
         { module: 'ipc' },
       );
+      if (forceRefresh) {
+        recordStartupDuration('get-tasks.force-refresh.return', startedAtMs, {
+          taskCount: tasks.length,
+          workflowCount: workflows.length,
+          jsonSizeBytes: Buffer.byteLength(JSON.stringify({ tasks, workflows }), 'utf8'),
+        });
+      }
       return { tasks, workflows };
     });
     ipcMain.handle('invoker:get-events', (_event, taskId: string) => persistence.getEvents(taskId));
@@ -3258,9 +3241,6 @@ if (isHeadless) {
         uiPerfStats.maxRendererLongTaskMs = Math.max(uiPerfStats.maxRendererLongTaskMs, data.durationMs);
       }
       uiPerfStats.rendererReports += 1;
-      if (metric === 'startup_graph_visible') {
-        startBackgroundHydration('startup_graph_visible');
-      }
       try {
         persistence.writeActivityLog('ui-perf', 'info', JSON.stringify(payload));
       } catch {

--- a/packages/app/src/preload.ts
+++ b/packages/app/src/preload.ts
@@ -29,9 +29,11 @@ function channelToEventMethod(channel: string): string {
 // ── Build the API object from the channel registries ────────
 
 const api: Record<string, unknown> = {};
+const bootstrapStartedAt = Date.now();
 const bootstrapState = ipcRenderer.sendSync('invoker:get-bootstrap-state-sync') as
   | { tasks?: unknown[]; workflows?: unknown[]; appStartedAtEpochMs?: number }
   | undefined;
+const bootstrapDurationMs = Date.now() - bootstrapStartedAt;
 
 // Invoke channels: each becomes (...args) => ipcRenderer.invoke(channel, ...args)
 for (const channel of Object.keys(IpcChannels)) {
@@ -78,3 +80,15 @@ for (const channel of Object.keys(IpcEventChannels)) {
 
 contextBridge.exposeInMainWorld('invoker', api as InvokerAPI);
 contextBridge.exposeInMainWorld('__INVOKER_BOOTSTRAP__', bootstrapState ?? { tasks: [], workflows: [] });
+
+setTimeout(() => {
+  ipcRenderer.invoke('invoker:report-ui-perf', 'preload_bootstrap_sync', {
+    durationMs: bootstrapDurationMs,
+    taskCount: bootstrapState?.tasks?.length ?? 0,
+    workflowCount: bootstrapState?.workflows?.length ?? 0,
+    jsonSizeBytes: Buffer.byteLength(JSON.stringify(bootstrapState ?? { tasks: [], workflows: [] }), 'utf8'),
+    processElapsedMs: bootstrapState?.appStartedAtEpochMs
+      ? Date.now() - bootstrapState.appStartedAtEpochMs
+      : undefined,
+  }).catch(() => undefined);
+}, 0);

--- a/packages/data-store/src/__tests__/attempt-persistence.test.ts
+++ b/packages/data-store/src/__tests__/attempt-persistence.test.ts
@@ -118,6 +118,23 @@ describe('Attempt persistence', () => {
     }, new Date('2026-05-12T00:06:00Z'))).toBe(true);
   });
 
+  it('does not hydrate a task with a superseded selected attempt as runnable', () => {
+    const attempt = createAttempt('taskA', { status: 'superseded' });
+    adapter.saveAttempt(attempt);
+    adapter.updateTask('taskA', {
+      status: 'running',
+      execution: {
+        selectedAttemptId: attempt.id,
+        startedAt: new Date('2026-05-12T00:00:00Z'),
+        lastHeartbeatAt: new Date('2026-05-12T00:01:00Z'),
+      },
+    });
+
+    const [task] = adapter.loadTasks('wf-1');
+    expect(task.status).toBe('stale');
+    expect(task.execution.selectedAttemptId).toBe(attempt.id);
+  });
+
   it('merge conflict JSON round-trip', () => {
     const attempt = createAttempt('taskA', {
       mergeConflict: {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -109,6 +109,45 @@ describe('SQLiteAdapter', () => {
       expect(loaded[0].dependencies).toEqual(['dep1']);
       expect(loaded[0].status).toBe('pending');
     });
+
+    it('loads all workflows and tasks in one startup snapshot', () => {
+      const wf2: Workflow = {
+        ...testWorkflow,
+        id: 'wf-2',
+        name: 'Second Workflow',
+      };
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveWorkflow(wf2);
+      adapter.saveTask('wf-1', makeTask('wf-1/task-1', { status: 'completed', config: { workflowId: 'wf-1' } }));
+      adapter.saveTask('wf-2', makeTask('wf-2/task-1', { status: 'failed', config: { workflowId: 'wf-2' } }));
+
+      const snapshot = adapter.loadWorkflowTaskSnapshot();
+
+      expect(snapshot.workflows.map((workflow) => workflow.id).sort()).toEqual(['wf-1', 'wf-2']);
+      expect(snapshot.tasks.map((task) => task.id).sort()).toEqual(['wf-1/task-1', 'wf-2/task-1']);
+      expect(snapshot.tasksByWorkflowId.get('wf-1')?.map((task) => task.id)).toEqual(['wf-1/task-1']);
+      expect(snapshot.tasksByWorkflowId.get('wf-2')?.map((task) => task.id)).toEqual(['wf-2/task-1']);
+    });
+
+    it('computes snapshot workflow rollups from the snapshot task rows', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('wf-1/task-1', { status: 'completed', config: { workflowId: 'wf-1' } }));
+      adapter.saveTask('wf-1', makeTask('wf-1/task-2', { status: 'failed', config: { workflowId: 'wf-1' } }));
+
+      const [snapshotWorkflow] = adapter.loadWorkflowTaskSnapshot().workflows;
+      const [listedWorkflow] = adapter.listWorkflows();
+
+      expect(snapshotWorkflow.rollup).toEqual(listedWorkflow.rollup);
+      expect(snapshotWorkflow.status).toBe(listedWorkflow.status);
+      expect(snapshotWorkflow.rollup?.countsByStatus.failed).toBe(1);
+      expect(snapshotWorkflow.rollup?.countsByStatus.completed).toBe(1);
+    });
+
+    it('creates an index for workflow task lookups', () => {
+      const result = (adapter as any).db.exec('PRAGMA index_list(tasks)') as Array<{ values: unknown[][] }>;
+      const indexNames = (result[0]?.values ?? []).map((row) => String(row[1]));
+      expect(indexNames).toContain('idx_tasks_workflow_id');
+    });
   });
 
   describe('updateTask', () => {

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -67,6 +67,12 @@ export interface ActivityLogEntry {
   message: string;
 }
 
+export interface WorkflowTaskSnapshot {
+  workflows: Workflow[];
+  tasks: TaskState[];
+  tasksByWorkflowId: Map<string, TaskState[]>;
+}
+
 export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: Workflow): void;
@@ -78,6 +84,7 @@ export interface PersistenceAdapter {
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   loadTasks(workflowId: string): TaskState[];
+  loadWorkflowTaskSnapshot?(): WorkflowTaskSnapshot;
   /** Authoritative single-task read by ID, suitable for recovery workflows. */
   loadTask(taskId: string): TaskState | undefined;
   getAllTaskIds(): string[];

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -20,7 +20,15 @@ import {
   computeWorkflowRollupFromSummaries,
   normalizeRunnerKind,
 } from '@invoker/workflow-core';
-import type { PersistenceAdapter, Workflow, TaskEvent, ActivityLogEntry, Conversation, ConversationMessage } from './adapter.js';
+import type {
+  PersistenceAdapter,
+  Workflow,
+  WorkflowTaskSnapshot,
+  TaskEvent,
+  ActivityLogEntry,
+  Conversation,
+  ConversationMessage,
+} from './adapter.js';
 
 /**
  * Rewrite `pnpm test packages/<pkg>/...` (incorrect root-level invocation)
@@ -90,6 +98,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private outputTailLimit: number;
   private outputTailCache = new Map<string, OutputChunk[]>();
   private writeTransactionDepth = 0;
+  private lastWorkflowTaskSnapshotStats: Record<string, unknown> | null = null;
 
   /** Use SQLiteAdapter.create() instead. */
   private constructor(db: SqlJsDatabase, dbPath: string | null, options?: { readOnly?: boolean; outputTailLimit?: number }) {
@@ -453,6 +462,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
       CREATE INDEX IF NOT EXISTS idx_task_output_task
         ON task_output(task_id);
 
+      CREATE INDEX IF NOT EXISTS idx_tasks_workflow_id
+        ON tasks(workflow_id);
+
       CREATE TABLE IF NOT EXISTS attempts (
         id TEXT PRIMARY KEY,
         node_id TEXT NOT NULL,
@@ -620,6 +632,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     // Replace old attempt_number index with created_at index
     this.db.run('DROP INDEX IF EXISTS idx_attempts_node');
     this.db.run('CREATE INDEX IF NOT EXISTS idx_attempts_node_created ON attempts(node_id, created_at)');
+    this.db.run('CREATE INDEX IF NOT EXISTS idx_tasks_workflow_id ON tasks(workflow_id)');
 
     if (!this.readOnly) {
       this.migrateTestCommands();
@@ -798,6 +811,54 @@ export class SQLiteAdapter implements PersistenceAdapter {
     const workflowIds = rows.map((row: any) => String(row.id));
     const rollups = this.loadWorkflowRollups(workflowIds);
     return rows.map((row: any) => this.rowToWorkflow(row, rollups.get(String(row.id))));
+  }
+
+  loadWorkflowTaskSnapshot(): WorkflowTaskSnapshot {
+    const totalStartedAt = Date.now();
+    const workflowQueryStartedAt = Date.now();
+    const workflowRows = this.queryAll('SELECT * FROM workflows ORDER BY created_at DESC');
+    const workflowMetadataQueryMs = Date.now() - workflowQueryStartedAt;
+    const taskQueryStartedAt = Date.now();
+    const taskRows = this.queryAll('SELECT * FROM tasks ORDER BY workflow_id ASC, id ASC');
+    const taskQueryMs = Date.now() - taskQueryStartedAt;
+    const tasksByWorkflowId = new Map<string, TaskState[]>();
+    const workflowIds = workflowRows.map((row: any) => String(row.id));
+    const rollupStartedAt = Date.now();
+    const rollups = this.computeWorkflowRollupsFromRows(workflowIds, taskRows);
+    const rollupComputationMs = Date.now() - rollupStartedAt;
+    const tasks: TaskState[] = [];
+
+    const deserializeStartedAt = Date.now();
+    for (const row of taskRows) {
+      const task = this.reconcileTaskFromSelectedAttempt(this.rowToTask(row));
+      tasks.push(task);
+      const workflowId = task.config.workflowId ?? '';
+      if (!workflowId) continue;
+      const workflowTasks = tasksByWorkflowId.get(workflowId) ?? [];
+      workflowTasks.push(task);
+      tasksByWorkflowId.set(workflowId, workflowTasks);
+    }
+    const taskDeserializeReconcileMs = Date.now() - deserializeStartedAt;
+
+    const snapshot = {
+      workflows: workflowRows.map((row: any) => this.rowToWorkflow(row, rollups.get(String(row.id)))),
+      tasks,
+      tasksByWorkflowId,
+    };
+    this.lastWorkflowTaskSnapshotStats = {
+      workflowMetadataQueryMs,
+      taskQueryMs,
+      rollupComputationMs,
+      taskDeserializeReconcileMs,
+      totalMs: Date.now() - totalStartedAt,
+      workflowCount: snapshot.workflows.length,
+      taskCount: tasks.length,
+    };
+    return snapshot;
+  }
+
+  getLastWorkflowTaskSnapshotStats(): Record<string, unknown> | null {
+    return this.lastWorkflowTaskSnapshotStats ? { ...this.lastWorkflowTaskSnapshotStats } : null;
   }
 
   // ── Tasks ─────────────────────────────────────────────
@@ -1741,6 +1802,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
       workflowIds,
     );
 
+    return this.computeWorkflowRollupsFromRows(workflowIds, taskRows);
+  }
+
+  private computeWorkflowRollupsFromRows(
+    workflowIds: string[],
+    taskRows: Record<string, unknown>[],
+  ): Map<string, WorkflowRollup> {
+    const rollups = new Map<string, WorkflowRollup>();
     const tasksByWorkflow = new Map<string, WorkflowRollupTaskSummary[]>();
     for (const row of taskRows as any[]) {
       const workflowId = String(row.workflow_id);

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -18,6 +18,7 @@ import type {
 } from '@invoker/workflow-core';
 import {
   computeWorkflowRollupFromSummaries,
+  isDiscardedAttempt,
   normalizeRunnerKind,
 } from '@invoker/workflow-core';
 import type {
@@ -1957,6 +1958,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
     const attempt = this.loadAttempt(attemptId);
     if (!attempt) return task;
+
+    if (isDiscardedAttempt(attempt)) {
+      return {
+        ...task,
+        status: 'stale',
+      };
+    }
 
     if (attempt.status === 'failed') {
       return {

--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -845,11 +845,12 @@ describe('diamond dependency merge', () => {
 
 import { TaskRunner, ExecutorRegistry } from '../index.js';
 import { WorktreeExecutor } from '../worktree-executor.js';
-import { Orchestrator, type TaskState, type TaskStateChanges, type PlanDefinition, type OrchestratorPersistence, type OrchestratorMessageBus } from '@invoker/workflow-core';
+import { Orchestrator, type Attempt, type TaskState, type TaskStateChanges, type PlanDefinition, type OrchestratorPersistence, type OrchestratorMessageBus } from '@invoker/workflow-core';
 
 class TestPersistence implements OrchestratorPersistence {
   workflows = new Map<string, any>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
+  attempts = new Map<string, Attempt>();
 
   saveWorkflow(wf: any): void {
     this.workflows.set(wf.id, { ...wf, createdAt: wf.createdAt ?? new Date().toISOString(), updatedAt: wf.updatedAt ?? new Date().toISOString() });
@@ -881,10 +882,20 @@ class TestPersistence implements OrchestratorPersistence {
     return entry?.task.execution.workspacePath ?? null;
   }
   logEvent(): void {}
-  saveAttempt(): void {}
-  loadAttempts(): any[] { return []; }
-  loadAttempt(): undefined { return undefined; }
-  updateAttempt(): void {}
+  saveAttempt(attempt: Attempt): void {
+    this.attempts.set(attempt.id, { ...attempt });
+  }
+  loadAttempts(nodeId: string): Attempt[] {
+    return Array.from(this.attempts.values()).filter((attempt) => attempt.nodeId === nodeId);
+  }
+  loadAttempt(attemptId: string): Attempt | undefined {
+    const attempt = this.attempts.get(attemptId);
+    return attempt ? { ...attempt } : undefined;
+  }
+  updateAttempt(attemptId: string, changes: Partial<Attempt>): void {
+    const attempt = this.attempts.get(attemptId);
+    if (attempt) this.attempts.set(attemptId, { ...attempt, ...changes });
+  }
 }
 
 class TestBus implements OrchestratorMessageBus {
@@ -1312,10 +1323,24 @@ describe('merge gate commit topology (real git)', () => {
     // Simulate task completion with branch info
     const taskA = orchestrator.getTask('task-a')!;
     const taskB = orchestrator.getTask('task-b')!;
-    persistence.updateTask('task-a', { execution: { branch: 'experiment/task-a' } });
-    persistence.updateTask('task-b', { execution: { branch: 'experiment/task-b' } });
-    orchestrator.handleWorkerResponse({ requestId: 'r1', actionId: 'task-a', status: 'completed', outputs: { exitCode: 0 } });
-    orchestrator.handleWorkerResponse({ requestId: 'r2', actionId: 'task-b', status: 'completed', outputs: { exitCode: 0 } });
+    persistence.updateTask(taskA.id, { execution: { branch: 'experiment/task-a' } });
+    persistence.updateTask(taskB.id, { execution: { branch: 'experiment/task-b' } });
+    orchestrator.handleWorkerResponse({
+      requestId: 'r1',
+      actionId: taskA.id,
+      attemptId: taskA.execution.selectedAttemptId,
+      executionGeneration: taskA.execution.generation ?? 0,
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    });
+    orchestrator.handleWorkerResponse({
+      requestId: 'r2',
+      actionId: taskB.id,
+      attemptId: taskB.execution.selectedAttemptId,
+      executionGeneration: taskB.execution.generation ?? 0,
+      status: 'completed',
+      outputs: { exitCode: 0 },
+    });
 
     // Find the merge node and execute it (consolidation phase)
     const mergeNode = orchestrator.getAllTasks().find(t => t.config.isMergeNode)!;
@@ -1329,15 +1354,6 @@ describe('merge gate commit topology (real git)', () => {
     const masterBeforeApprove = execSync('git rev-parse master', { cwd: tmpDir }).toString().trim();
     expect(masterBeforeApprove).toBe(masterHead);
 
-    // The test's persistence.updateTask uses short IDs ('task-a') which don't
-    // match the orchestrator's prefixed IDs ('wf-XXXX/task-a'), so consolidation
-    // merges 0 task branches. Recreate feat/hook-e2e with the real merges and
-    // push to origin so approveMerge's merge worktree picks it up correctly.
-    execSync('git checkout -b feat/hook-e2e master', { cwd: tmpDir });
-    execSync('git merge --no-ff experiment/task-a -m "Merge experiment/task-a"', { cwd: tmpDir });
-    execSync('git merge --no-ff experiment/task-b -m "Merge experiment/task-b"', { cwd: tmpDir });
-    execSync('git push --force origin feat/hook-e2e', { cwd: tmpDir });
-    execSync('git checkout master', { cwd: tmpDir });
 
     // Approve via orchestrator — hook should fire and do the squash merge
     await orchestrator.approve(mergeNode.id);

--- a/packages/execution-engine/src/execution-bench.ts
+++ b/packages/execution-engine/src/execution-bench.ts
@@ -1,0 +1,44 @@
+import type { Logger } from '@invoker/contracts';
+import { executionTraceEnabled, traceExecution } from './exec-trace.js';
+
+export const EXECUTE_TASK_BENCH_ENV = 'INVOKER_BENCH_EXECUTE_TASK';
+
+export function executionBenchEnabled(): boolean {
+  return process.env[EXECUTE_TASK_BENCH_ENV] === '1' || executionTraceEnabled();
+}
+
+export function createExecutionBench({
+  module,
+  logger,
+  baseMetadata = {},
+}: {
+  module: string;
+  logger?: Logger;
+  baseMetadata?: Record<string, unknown>;
+}): (phase: string, metadata?: Record<string, unknown>) => void {
+  if (!executionBenchEnabled()) return () => {};
+  const startedAt = Date.now();
+  let previousAt = startedAt;
+
+  return (phase, metadata = {}) => {
+    const now = Date.now();
+    const elapsedMs = now - startedAt;
+    const deltaMs = now - previousAt;
+    previousAt = now;
+    const payload = {
+      module,
+      phase,
+      elapsedMs,
+      deltaMs,
+      ...baseMetadata,
+      ...metadata,
+    };
+    const message = `[${module}] phase="${phase}" elapsedMs=${elapsedMs} deltaMs=${deltaMs}`;
+    if (logger) {
+      logger.info(message, payload);
+    } else {
+      console.info(message, payload);
+    }
+    traceExecution(message);
+  };
+}

--- a/packages/execution-engine/src/index.ts
+++ b/packages/execution-engine/src/index.ts
@@ -1,4 +1,5 @@
 export { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
+export * from './execution-bench.js';
 export { remoteFetchForPool } from './remote-fetch-policy.js';
 export {
   syncPlanBaseRemote,

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -3,6 +3,7 @@ import { mkdirSync, existsSync, rmSync } from 'node:fs';
 import { normalize } from 'node:path';
 import { bashPreserveOrReset, runBashLocal } from './branch-utils.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
+import { createExecutionBench } from './execution-bench.js';
 import { planManagedWorktree } from './managed-worktree-controller.js';
 import {
   abbrevRefMatchesBranch,
@@ -241,16 +242,29 @@ export class RepoPool {
   }
 
   async ensureClone(repoUrl: string): Promise<string> {
+    const bench = createExecutionBench({
+      module: 'repo-pool-bench',
+      baseMetadata: { repoUrl },
+    });
+    bench('RepoPool.ensureClone.begin');
     // Serialize clone operations per repo to prevent concurrent clone races
     const existing = this.cloneLocks.get(repoUrl);
-    if (existing) return existing;
+    if (existing) {
+      bench('RepoPool.ensureClone.waitForExistingLock.before');
+      const clonePath = await existing;
+      bench('RepoPool.ensureClone.waitForExistingLock.after', { clonePath });
+      return clonePath;
+    }
 
     const promise = this.doEnsureClone(repoUrl);
     this.cloneLocks.set(repoUrl, promise);
     try {
-      return await promise;
+      const clonePath = await promise;
+      bench('RepoPool.ensureClone.after', { clonePath });
+      return clonePath;
     } finally {
       this.cloneLocks.delete(repoUrl);
+      bench('RepoPool.ensureClone.lockDeleted');
     }
   }
 
@@ -314,6 +328,11 @@ export class RepoPool {
     branch: string,
     base: string,
   ): Promise<void> {
+    const bench = createExecutionBench({
+      module: 'repo-pool-bench',
+      baseMetadata: { branch, base, clonePath, worktreePath },
+    });
+    bench('RepoPool.runPreserveOrResetWithRecovery.begin');
     const script = bashPreserveOrReset({
       repoDir: clonePath,
       worktreeDir: worktreePath,
@@ -321,41 +340,76 @@ export class RepoPool {
       base,
     });
     try {
+      bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.before');
       await runBashLocal(script, clonePath);
+      bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.after');
       return;
     } catch (err) {
       if (!this.isAlreadyExistsWorktreeError(err, worktreePath)) {
+        bench('RepoPool.runPreserveOrResetWithRecovery.runBashLocal.failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
         throw err;
       }
       traceExecution(
         `[RepoPool] runPreserveOrResetWithRecovery: retrying after pre-existing path branch=${branch} path=${worktreePath}`,
       );
+      bench('RepoPool.runPreserveOrResetWithRecovery.reconcileStaleWorktreePath.before');
       await this.reconcileStaleWorktreePath(clonePath, worktreePath);
+      bench('RepoPool.runPreserveOrResetWithRecovery.reconcileStaleWorktreePath.after');
     }
+    bench('RepoPool.runPreserveOrResetWithRecovery.retryRunBashLocal.before');
     await runBashLocal(script, clonePath);
+    bench('RepoPool.runPreserveOrResetWithRecovery.retryRunBashLocal.after');
   }
 
   private async doEnsureClone(repoUrl: string): Promise<string> {
+    const bench = createExecutionBench({
+      module: 'repo-pool-bench',
+      baseMetadata: { repoUrl },
+    });
     const dir = this.cloneDir(repoUrl);
+    bench('RepoPool.doEnsureClone.begin', { dir, exists: existsSync(dir) });
     if (existsSync(dir)) {
       if (remoteFetchForPool.enabled) {
         try {
+          bench('RepoPool.doEnsureClone.gitFetchAllPrune.before', { dir });
           await this.execGit(['fetch', '--all', '--prune'], dir);
+          bench('RepoPool.doEnsureClone.gitFetchAllPrune.after', { dir });
         } catch (err) {
           console.warn(`[RepoPool] doEnsureClone fetch failed: ${err}`);
+          bench('RepoPool.doEnsureClone.gitFetchAllPrune.failed', {
+            dir,
+            error: err instanceof Error ? err.message : String(err),
+          });
         }
         // Advance local HEAD branch to match origin so rev-parse returns the fresh ref
         try {
+          bench('RepoPool.doEnsureClone.gitCurrentBranch.before', { dir });
           const branch = (await this.execGit(['rev-parse', '--abbrev-ref', 'HEAD'], dir)).trim();
+          bench('RepoPool.doEnsureClone.gitCurrentBranch.after', { dir, branch });
           if (branch !== 'HEAD') {
+            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.before', { dir, branch });
             await this.execGit(['merge', '--ff-only', `origin/${branch}`], dir);
+            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.after', { dir, branch });
+          } else {
+            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.skipped', { dir, branch });
           }
-        } catch { /* non-ff or detached; leave as-is */ }
+        } catch (err) {
+          bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.failed', {
+            dir,
+            error: err instanceof Error ? err.message : String(err),
+          });
+          /* non-ff or detached; leave as-is */
+        }
       }
+      bench('RepoPool.doEnsureClone.returnExisting', { dir });
       return dir;
     }
     mkdirSync(this.cacheDir, { recursive: true });
+    bench('RepoPool.doEnsureClone.gitClone.before', { dir });
     await this.execGit(['clone', repoUrl, dir], this.cacheDir);
+    bench('RepoPool.doEnsureClone.gitClone.after', { dir });
     return dir;
   }
 
@@ -366,11 +420,22 @@ export class RepoPool {
     actionId?: string,
     opts?: AcquireWorktreeOptions,
   ): Promise<AcquiredWorktree> {
+    const bench = createExecutionBench({
+      module: 'repo-pool-bench',
+      baseMetadata: { repoUrl, branch, base, actionId },
+    });
+    bench('RepoPool.acquireWorktree.begin');
     // Serialize per-repo to prevent concurrent git worktree operations
     const prev = this.repoChains.get(repoUrl) ?? Promise.resolve();
-    const next = prev.then(() => this.doAcquireWorktree(repoUrl, branch, base, actionId, opts));
+    const queuedAtMs = Date.now();
+    const next = prev.then(() => {
+      bench('RepoPool.acquireWorktree.repoChainWait.after', { durationMs: Date.now() - queuedAtMs });
+      return this.doAcquireWorktree(repoUrl, branch, base, actionId, opts);
+    });
     this.repoChains.set(repoUrl, next.catch(() => {}));
-    return next;
+    const acquired = await next;
+    bench('RepoPool.acquireWorktree.after', { worktreePath: acquired.worktreePath });
+    return acquired;
   }
 
   /**
@@ -408,11 +473,19 @@ export class RepoPool {
     actionId?: string,
     opts?: AcquireWorktreeOptions,
   ): Promise<AcquiredWorktree> {
+    const bench = createExecutionBench({
+      module: 'repo-pool-bench',
+      baseMetadata: { repoUrl, branch, base, actionId, forceFresh: opts?.forceFresh === true },
+    });
+    bench('RepoPool.doAcquireWorktree.begin');
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree branch=${branch} (bashPreserveOrReset here; BaseExecutor.setupTaskBranch is not used for this path)`,
     );
+    bench('RepoPool.doAcquireWorktree.ensureClone.before');
     const clonePath = await this.ensureClone(repoUrl);
+    bench('RepoPool.doAcquireWorktree.ensureClone.after', { clonePath });
     const active = this.activeWorktrees.get(repoUrl) ?? new Set();
+    bench('RepoPool.doAcquireWorktree.activeWorktreeCount', { activeCount: active.size, maxWorktrees: this.maxWorktrees });
     if (active.size >= this.maxWorktrees) {
       throw new ResourceLimitError(`Worktree limit reached for ${repoUrl}: ${active.size}/${this.maxWorktrees}`);
     }
@@ -432,12 +505,16 @@ export class RepoPool {
 
     let porcelain = '';
     try {
+      bench('RepoPool.doAcquireWorktree.gitWorktreeList.before', { clonePath });
       porcelain = await this.execGit(['worktree', 'list', '--porcelain'], clonePath);
+      bench('RepoPool.doAcquireWorktree.gitWorktreeList.after', { clonePath });
     } catch {
       porcelain = '';
+      bench('RepoPool.doAcquireWorktree.gitWorktreeList.failed', { clonePath });
     }
 
     const allowReuse = opts?.forceFresh !== true;
+    bench('RepoPool.doAcquireWorktree.findReuseCandidates.before', { allowReuse });
     const reuseCandidate = allowReuse ? findManagedWorktreeForBranch(porcelain, branch, managedPrefixes) : undefined;
     let exactBranchCandidate: { path: string; headMatchesTargetBranch: boolean } | undefined;
     if (reuseCandidate && existsSync(reuseCandidate)) {
@@ -507,7 +584,14 @@ export class RepoPool {
         );
       }
     }
+    bench('RepoPool.doAcquireWorktree.findReuseCandidates.after', {
+      hasReuseCandidate: !!reuseCandidate,
+      hasExactBranchCandidate: !!exactBranchCandidate,
+      hasActionIdCandidate: !!actionIdCandidate,
+      hasContentCandidate: !!contentCandidate,
+    });
 
+    bench('RepoPool.doAcquireWorktree.planManagedWorktree.before');
     let plan = planManagedWorktree({
       targetBranch: branch,
       targetWorktreePath: worktreePath,
@@ -516,9 +600,19 @@ export class RepoPool {
       actionIdCandidate,
       contentCandidate,
     });
+    bench('RepoPool.doAcquireWorktree.planManagedWorktree.after', { planKind: plan.kind });
 
     if (plan.kind === 'reuse_exact') {
+      bench('RepoPool.doAcquireWorktree.isReusableManagedWorktree.before', {
+        planKind: plan.kind,
+        worktreePath: plan.worktreePath,
+      });
       const reusable = await this.isReusableManagedWorktree(plan.worktreePath, branch);
+      bench('RepoPool.doAcquireWorktree.isReusableManagedWorktree.after', {
+        planKind: plan.kind,
+        worktreePath: plan.worktreePath,
+        reusable,
+      });
       if (!reusable) {
         plan = {
           kind: 'recreate',
@@ -527,7 +621,16 @@ export class RepoPool {
         };
       }
     } else if (plan.kind === 'rename_reuse' || plan.kind === 'rename_to_lifecycle') {
+      bench('RepoPool.doAcquireWorktree.isReusableManagedWorktree.before', {
+        planKind: plan.kind,
+        worktreePath: plan.worktreePath,
+      });
       const reusable = await this.isReusableManagedWorktree(plan.worktreePath, plan.fromBranch);
+      bench('RepoPool.doAcquireWorktree.isReusableManagedWorktree.after', {
+        planKind: plan.kind,
+        worktreePath: plan.worktreePath,
+        reusable,
+      });
       if (!reusable) {
         plan = {
           kind: 'recreate',
@@ -538,6 +641,7 @@ export class RepoPool {
     }
 
     let effectivePath = worktreePath;
+    bench('RepoPool.doAcquireWorktree.applyPlan.before', { planKind: plan.kind });
     switch (plan.kind) {
       case 'reuse_exact':
         effectivePath = plan.worktreePath;
@@ -568,23 +672,30 @@ export class RepoPool {
             branch,
             base ?? 'HEAD',
           );
+          bench('RepoPool.doAcquireWorktree.renameFallbackPreserveOrReset.after', { worktreePath });
           effectivePath = worktreePath;
         }
         break;
       case 'recreate':
+        bench('RepoPool.doAcquireWorktree.reconcileLeakedTargetPath.before', { worktreePath });
         await this.reconcileLeakedTargetPath(clonePath, worktreePath, porcelain, branch);
+        bench('RepoPool.doAcquireWorktree.reconcileLeakedTargetPath.after', { worktreePath });
         if (isWorkspaceCleanupEnabled()) {
           for (const cleanupPath of plan.cleanupPaths) {
+            bench('RepoPool.doAcquireWorktree.reconcileStaleWorktreePath.before', { cleanupPath });
             await this.reconcileStaleWorktreePath(clonePath, cleanupPath);
+            bench('RepoPool.doAcquireWorktree.reconcileStaleWorktreePath.after', { cleanupPath });
           }
         }
         mkdirSync(worktreeParent, { recursive: true });
+        bench('RepoPool.doAcquireWorktree.runPreserveOrResetWithRecovery.before', { worktreePath });
         await this.runPreserveOrResetWithRecovery(
           clonePath,
           worktreePath,
           branch,
           base ?? 'HEAD',
         );
+        bench('RepoPool.doAcquireWorktree.runPreserveOrResetWithRecovery.after', { worktreePath });
         effectivePath = worktreePath;
         break;
     }
@@ -592,6 +703,11 @@ export class RepoPool {
     effectivePath = canonicalPathForComparison(effectivePath);
     active.add(effectivePath);
     this.activeWorktrees.set(repoUrl, active);
+    bench('RepoPool.doAcquireWorktree.applyPlan.after', {
+      planKind: plan.kind,
+      effectivePath,
+      activeCount: active.size,
+    });
 
     const release = async () => {
       try {
@@ -604,6 +720,7 @@ export class RepoPool {
 
     const softRelease = () => { active.delete(effectivePath); };
 
+    bench('RepoPool.doAcquireWorktree.returning', { effectivePath });
     return { clonePath, worktreePath: effectivePath, branch, release, softRelease };
   }
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -13,6 +13,7 @@ import type { AgentRegistry } from './agent-registry.js';
 import { computeRepoUrlHash, sanitizeBranchForPath } from './git-utils.js';
 import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { buildSshConnectionArgs } from './ssh-transport-options.js';
+import { createExecutionBench } from './execution-bench.js';
 import {
   shellPosixSingleQuote as sshGitShellQuote,
   base64Encode as sshGitB64,
@@ -162,19 +163,37 @@ exit "$PAYLOAD_EXIT"
   }
 
   private async execRemoteCapture(script: string, phase?: string): Promise<string> {
+    const bench = createExecutionBench({
+      module: 'ssh-executor-start-bench',
+      baseMetadata: {
+        host: this.host,
+        user: this.user,
+        remotePhase: phase ?? 'remote_capture',
+      },
+    });
+    bench('SshExecutor.execRemoteCapture.begin');
     return new Promise((resolve, reject) => {
       const child = spawn('ssh', [...this.buildSshArgs(), ...this.buildRemoteCommand()], {
         stdio: ['pipe', 'pipe', 'pipe'],
         env: cleanElectronEnv(),
       });
+      bench('SshExecutor.execRemoteCapture.spawned');
       child.stdin.write(script);
       child.stdin.end();
       let out = '';
       let err = '';
       child.stdout?.on('data', (c: Buffer) => { out += c.toString(); });
       child.stderr?.on('data', (c: Buffer) => { err += c.toString(); });
-      child.on('error', reject);
+      child.on('error', (error) => {
+        bench('SshExecutor.execRemoteCapture.spawnError', { error: error.message });
+        reject(error);
+      });
       child.on('close', (code) => {
+        bench('SshExecutor.execRemoteCapture.closed', {
+          code,
+          stdoutBytes: out.length,
+          stderrBytes: err.length,
+        });
         if (code === 0) resolve(out);
         else {
           reject(createSshRemoteScriptError(code, out, err, phase));
@@ -190,6 +209,18 @@ exit "$PAYLOAD_EXIT"
   async start(request: WorkRequest): Promise<ExecutorHandle> {
     const handle = this.createHandle(request);
     const executionId = handle.executionId;
+    const bench = createExecutionBench({
+      module: 'ssh-executor-start-bench',
+      baseMetadata: {
+        requestId: request.requestId,
+        actionId: request.actionId,
+        actionType: request.actionType,
+        host: this.host,
+        user: this.user,
+        managedWorkspaces: this.managedWorkspaces,
+      },
+    });
+    bench('SshExecutor.start.begin');
 
     if (request.actionType === 'reconciliation') {
       const entry: SshEntry = {
@@ -205,12 +236,16 @@ exit "$PAYLOAD_EXIT"
       };
       this.registerEntry(handle, entry);
       this.scheduleReconciliationResponse(executionId);
+      bench('SshExecutor.start.reconciliation.returning');
       return handle;
     }
 
     try {
+      bench('SshExecutor.sshKey.access.before', { sshKeyPath: this.sshKeyPath });
       accessSync(this.sshKeyPath, constants.R_OK);
+      bench('SshExecutor.sshKey.access.after', { sshKeyPath: this.sshKeyPath });
     } catch {
+      bench('SshExecutor.sshKey.access.failed', { sshKeyPath: this.sshKeyPath });
       throw new Error(
         `SSH key file not accessible: ${this.sshKeyPath}\n` +
         `Update "sshKeyPath" in your Invoker config (.invoker.json or ~/.invoker/config.json).`,
@@ -224,6 +259,7 @@ exit "$PAYLOAD_EXIT"
       const command = request.inputs.command;
       if (!command) throw new Error('WorkRequest with actionType "command" must have inputs.command');
       payload = command;
+      bench('SshExecutor.payload.built', { command: true });
     } else if (request.actionType === 'ai_task') {
       if (this.agentRegistry) {
         const requestedAgent = request.inputs.executionAgent ?? 'claude';
@@ -232,13 +268,22 @@ exit "$PAYLOAD_EXIT"
         const spec = agent.buildCommand(fullPrompt);
         agentSessionId = spec.sessionId;
         payload = `${spec.cmd} ${spec.args.map(a => this.shellQuote(a)).join(' ')}`;
+        bench('SshExecutor.payload.built', {
+          executionAgent: requestedAgent,
+          hasAgentSessionId: !!agentSessionId,
+        });
       } else {
         const session = this.prepareClaudeSession(request);
         agentSessionId = session.sessionId;
         payload = `claude ${session.cliArgs.map(a => this.shellQuote(a)).join(' ')}`;
+        bench('SshExecutor.payload.built', {
+          executionAgent: 'claude',
+          hasAgentSessionId: !!agentSessionId,
+        });
       }
     } else {
       payload = 'echo "Unsupported action type"';
+      bench('SshExecutor.payload.built', { unsupportedActionType: request.actionType });
     }
 
     try {
@@ -250,11 +295,26 @@ exit "$PAYLOAD_EXIT"
             `Add a top-level "repoUrl" to your plan YAML (e.g. repoUrl: git@github.com:user/repo.git).`,
           );
         }
-        return await this.startManagedWorkspace(request, handle, repoUrl, payload, agentSessionId);
+        bench('SshExecutor.startManagedWorkspace.before', { repoUrl });
+        const started = await this.startManagedWorkspace(request, handle, repoUrl, payload, agentSessionId);
+        bench('SshExecutor.startManagedWorkspace.after', {
+          workspacePath: started.workspacePath,
+          branch: started.branch,
+        });
+        return started;
       } else {
-        return await this.startBYOWorkspace(request, handle, payload, agentSessionId);
+        bench('SshExecutor.startBYOWorkspace.before');
+        const started = await this.startBYOWorkspace(request, handle, payload, agentSessionId);
+        bench('SshExecutor.startBYOWorkspace.after', {
+          workspacePath: started.workspacePath,
+          branch: started.branch,
+        });
+        return started;
       }
     } catch (err) {
+      bench('SshExecutor.start.failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
       throw this.withStartupMetadata(err, handle);
     }
   }
@@ -269,6 +329,16 @@ exit "$PAYLOAD_EXIT"
     payload: string,
     agentSessionId?: string,
   ): Promise<ExecutorHandle> {
+    const bench = createExecutionBench({
+      module: 'ssh-executor-start-bench',
+      baseMetadata: {
+        requestId: request.requestId,
+        actionId: request.actionId,
+        host: this.host,
+        user: this.user,
+      },
+    });
+    bench('SshExecutor.startBYOWorkspace.begin');
     const executionId = handle.executionId;
     const workspacePath = request.inputs.workspacePath;
 
@@ -281,6 +351,10 @@ exit "$PAYLOAD_EXIT"
 
     handle.workspacePath = workspacePath;
     handle.agentSessionId = agentSessionId;
+    bench('SshExecutor.startBYOWorkspace.workspaceResolved', {
+      workspacePath,
+      hasAgentSessionId: !!agentSessionId,
+    });
 
     // No-command tasks complete immediately
     if (!request.inputs.command && !request.inputs.prompt) {
@@ -305,6 +379,7 @@ exit "$PAYLOAD_EXIT"
       };
       this.registerEntry(handle, entry);
       this.emitComplete(executionId, response);
+      bench('SshExecutor.startBYOWorkspace.noCommand.returning');
       return handle;
     }
 
@@ -323,7 +398,10 @@ echo "[SshExecutor BYO] Running task in user-provided workspace: $WT"
 ${this.buildPayloadExecutionScript(payloadB64)}
 `;
 
-    return this.spawnSshRemoteStdin(executionId, request, handle, runScript, agentSessionId, undefined);
+    bench('SshExecutor.startBYOWorkspace.spawnSshRemoteStdin.before', { workspacePath });
+    const started = await this.spawnSshRemoteStdin(executionId, request, handle, runScript, agentSessionId, undefined);
+    bench('SshExecutor.startBYOWorkspace.spawnSshRemoteStdin.after', { workspacePath });
+    return started;
   }
 
   /**
@@ -336,6 +414,17 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     payload: string,
     agentSessionId?: string,
   ): Promise<ExecutorHandle> {
+    const bench = createExecutionBench({
+      module: 'ssh-executor-start-bench',
+      baseMetadata: {
+        requestId: request.requestId,
+        actionId: request.actionId,
+        host: this.host,
+        user: this.user,
+        repoUrl,
+      },
+    });
+    bench('SshExecutor.startManagedWorkspace.begin');
     const executionId = handle.executionId;
     const h = computeRepoUrlHash(repoUrl);
     const baseRef = request.inputs.baseBranch ?? 'HEAD';
@@ -356,8 +445,15 @@ ${this.buildPayloadExecutionScript(payloadB64)}
       baseRef,
       invokerHome,
     });
+    bench('SshExecutor.startManagedWorkspace.bootstrapCloneFetch.before', { baseRef });
     const bootstrapOut = await this.execRemoteCapture(script1, 'bootstrap_clone_fetch');
     const { resolvedBaseRef, baseHead, warning, fetchSuccess } = parseBootstrapOutput(bootstrapOut);
+    bench('SshExecutor.startManagedWorkspace.bootstrapCloneFetch.after', {
+      resolvedBaseRef,
+      baseHead,
+      fetchSuccess,
+      hasWarning: !!warning,
+    });
     if (warning) {
       this.emitOutput(executionId, `[SshExecutor] ${warning}\n`);
     }
@@ -378,11 +474,17 @@ ${this.buildPayloadExecutionScript(payloadB64)}
       lifecycleTag,
       contentHash,
     );
+    bench('SshExecutor.startManagedWorkspace.branchComputed', {
+      experimentBranch,
+      contentHash,
+    });
     // Persist the branch on the attempt row before we run any remote git
     // command that could leak a worktree without a recorded branch.
     try {
       request.onBranchResolved?.(experimentBranch);
+      bench('SshExecutor.startManagedWorkspace.onBranchResolved.done', { experimentBranch });
     } catch {
+      bench('SshExecutor.startManagedWorkspace.onBranchResolved.failed', { experimentBranch });
       // Best-effort; the post-start path persists this again.
     }
     const san = sanitizeBranchForPath(experimentBranch);
@@ -393,9 +495,13 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     // path as real until Git has actually created or confirmed it.
     handle.branch = experimentBranch;
 
+    bench('SshExecutor.startManagedWorkspace.detectHome.before');
     const remoteHome = (await this.execRemoteCapture('printf %s "$HOME"', 'detect_home')).trim();
+    bench('SshExecutor.startManagedWorkspace.detectHome.after', { remoteHome });
     const porcelainScript = buildWorktreeListScript({ repoHash: h, invokerHome });
+    bench('SshExecutor.startManagedWorkspace.listWorktrees.before');
     const porcelain = await this.execRemoteCapture(porcelainScript, 'list_worktrees');
+    bench('SshExecutor.startManagedWorkspace.listWorktrees.after', { bytes: porcelain.length });
 
     // Expand ~ in invokerHome for path matching
     const expandedInvokerHome = invokerHome === '~'
@@ -411,22 +517,31 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     if (reuseAbs) {
       const headScript = buildWorktreeHeadScript(reuseAbs);
       try {
+        bench('SshExecutor.startManagedWorkspace.inspectReuseHead.before', { reuseAbs });
         const head = (await this.execRemoteCapture(headScript)).trim();
         exactBranchCandidate = {
           path: reuseAbs,
           headMatchesTargetBranch: abbrevRefMatchesBranch(head, experimentBranch),
         };
+        bench('SshExecutor.startManagedWorkspace.inspectReuseHead.after', {
+          reuseAbs,
+          head,
+          headMatchesTargetBranch: exactBranchCandidate.headMatchesTargetBranch,
+        });
       } catch {
         exactBranchCandidate = undefined;
+        bench('SshExecutor.startManagedWorkspace.inspectReuseHead.failed', { reuseAbs });
       }
     }
 
+    bench('SshExecutor.startManagedWorkspace.planManagedWorktree.before');
     const worktreePlan = planManagedWorktree({
       targetBranch: experimentBranch,
       targetWorktreePath: canonicalRemoteWt,
       forceFresh: request.inputs.freshWorkspace === true,
       exactBranchCandidate,
     });
+    bench('SshExecutor.startManagedWorkspace.planManagedWorktree.after', { planKind: worktreePlan.kind });
 
     let remoteWt = canonicalRemoteWt;
     let skippedRemotePreserve = false;
@@ -450,7 +565,13 @@ ${this.buildPayloadExecutionScript(payloadB64)}
             remoteClone,
             worktreePaths: worktreePlan.cleanupPaths,
           });
+          bench('SshExecutor.startManagedWorkspace.cleanupWorktree.before', {
+            cleanupCount: worktreePlan.cleanupPaths.length,
+          });
           await this.execRemoteCapture(cleanupScript, 'cleanup_worktree');
+          bench('SshExecutor.startManagedWorkspace.cleanupWorktree.after', {
+            cleanupCount: worktreePlan.cleanupPaths.length,
+          });
         }
         remoteWt = canonicalRemoteWt;
         break;
@@ -458,17 +579,32 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     }
 
     if (skippedRemotePreserve) {
+      bench('SshExecutor.startManagedWorkspace.mergeRequestUpstreamBranches.before', { remoteWt });
       await this.mergeRequestUpstreamBranches(request, remoteWt, resolvedBaseRef);
+      bench('SshExecutor.startManagedWorkspace.mergeRequestUpstreamBranches.after', { remoteWt });
     } else {
       try {
+        bench('SshExecutor.startManagedWorkspace.setupTaskBranch.before', {
+          branchName: experimentBranch,
+          base: resolvedBaseRef,
+          remoteWt,
+        });
         await this.setupTaskBranch(remoteClone, request, handle, {
           branchName: experimentBranch,
           base: resolvedBaseRef,
           worktreeDir: remoteWt,
         });
+        bench('SshExecutor.startManagedWorkspace.setupTaskBranch.after', {
+          branchName: experimentBranch,
+          remoteWt,
+        });
       } catch (err) {
         const wrapped = err instanceof Error ? err : new Error(String(err));
         if (!(wrapped as any).phase) (wrapped as any).phase = 'setup_branch';
+        bench('SshExecutor.startManagedWorkspace.setupTaskBranch.failed', {
+          error: wrapped.message,
+          remoteWt,
+        });
         throw wrapped;
       }
       handle.workspacePath =
@@ -480,6 +616,7 @@ ${this.buildPayloadExecutionScript(payloadB64)}
       await this.handleProcessExit(executionId, request, remoteWt, 0, {
         branch: experimentBranch,
       });
+      bench('SshExecutor.startManagedWorkspace.noCommand.returning', { remoteWt });
       return handle;
     }
 
@@ -501,10 +638,21 @@ echo "[SshExecutor] Running task payload..."
 ${this.buildPayloadExecutionScript(payloadB64)}
 `;
 
-    return this.spawnSshRemoteStdin(executionId, request, handle, runScript, agentSessionId, {
+    bench('SshExecutor.startManagedWorkspace.spawnSshRemoteStdin.before', {
+      remoteWt,
+      workspacePath: handle.workspacePath,
+      branch: experimentBranch,
+    });
+    const started = await this.spawnSshRemoteStdin(executionId, request, handle, runScript, agentSessionId, {
       worktreePath: handle.workspacePath!,
       branch: experimentBranch,
     });
+    bench('SshExecutor.startManagedWorkspace.spawnSshRemoteStdin.after', {
+      remoteWt,
+      workspacePath: started.workspacePath,
+      branch: started.branch,
+    });
+    return started;
   }
 
   private withStartupMetadata(err: unknown, handle: ExecutorHandle): Error {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -18,7 +18,8 @@ import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/con
 import type { Executor, ExecutorHandle } from './executor.js';
 import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 import { BaseExecutor } from './base-executor.js';
-import { RESTART_TO_BRANCH_TRACE, executionTraceEnabled, traceExecution } from './exec-trace.js';
+import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
+import { createExecutionBench } from './execution-bench.js';
 import { ResourceLimitError, type RepoPoolTiming } from './repo-pool.js';
 import type { ExecutorRegistry } from './registry.js';
 import type { AgentRegistry } from './agent-registry.js';
@@ -61,7 +62,6 @@ export type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
 const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
 const DEFAULT_EXECUTOR_START_TIMEOUT_MS = 10 * 60 * 1000;
-const EXECUTE_TASK_BENCH_ENV = 'INVOKER_BENCH_EXECUTE_TASK';
 
 type StartupFailureMetadata = {
   workspacePath?: string;
@@ -330,36 +330,15 @@ export class TaskRunner {
     return undefined;
   }
 
-  private executeTaskBenchEnabled(): boolean {
-    return process.env[EXECUTE_TASK_BENCH_ENV] === '1' || executionTraceEnabled();
-  }
-
   private createExecuteTaskBench(taskId: string, attemptId: string): (phase: string, metadata?: Record<string, unknown>) => void {
-    if (!this.executeTaskBenchEnabled()) return () => {};
-    const startedAt = Date.now();
-    let previousAt = startedAt;
-    return (phase, metadata = {}) => {
-      const now = Date.now();
-      const elapsedMs = now - startedAt;
-      const deltaMs = now - previousAt;
-      previousAt = now;
-      const payload = {
-        module: 'execute-task-bench',
+    return createExecutionBench({
+      module: 'execute-task-bench',
+      logger: this.logger,
+      baseMetadata: {
         taskId,
         attemptId,
-        phase,
-        elapsedMs,
-        deltaMs,
-        ...metadata,
-      };
-      this.logger.info(
-        `[execute-task-bench] task="${taskId}" attempt="${attemptId}" phase="${phase}" elapsedMs=${elapsedMs} deltaMs=${deltaMs}`,
-        payload,
-      );
-      traceExecution(
-        `[execute-task-bench] task=${taskId} attempt=${attemptId} phase=${phase} elapsedMs=${elapsedMs} deltaMs=${deltaMs}`,
-      );
-    };
+      },
+    });
   }
 
   /**

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -18,7 +18,7 @@ import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/con
 import type { Executor, ExecutorHandle } from './executor.js';
 import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 import { BaseExecutor } from './base-executor.js';
-import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
+import { RESTART_TO_BRANCH_TRACE, executionTraceEnabled, traceExecution } from './exec-trace.js';
 import { ResourceLimitError, type RepoPoolTiming } from './repo-pool.js';
 import type { ExecutorRegistry } from './registry.js';
 import type { AgentRegistry } from './agent-registry.js';
@@ -61,6 +61,7 @@ export type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
 const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
 const DEFAULT_EXECUTOR_START_TIMEOUT_MS = 10 * 60 * 1000;
+const EXECUTE_TASK_BENCH_ENV = 'INVOKER_BENCH_EXECUTE_TASK';
 
 type StartupFailureMetadata = {
   workspacePath?: string;
@@ -329,6 +330,38 @@ export class TaskRunner {
     return undefined;
   }
 
+  private executeTaskBenchEnabled(): boolean {
+    return process.env[EXECUTE_TASK_BENCH_ENV] === '1' || executionTraceEnabled();
+  }
+
+  private createExecuteTaskBench(taskId: string, attemptId: string): (phase: string, metadata?: Record<string, unknown>) => void {
+    if (!this.executeTaskBenchEnabled()) return () => {};
+    const startedAt = Date.now();
+    let previousAt = startedAt;
+    return (phase, metadata = {}) => {
+      const now = Date.now();
+      const elapsedMs = now - startedAt;
+      const deltaMs = now - previousAt;
+      previousAt = now;
+      const payload = {
+        module: 'execute-task-bench',
+        taskId,
+        attemptId,
+        phase,
+        elapsedMs,
+        deltaMs,
+        ...metadata,
+      };
+      this.logger.info(
+        `[execute-task-bench] task="${taskId}" attempt="${attemptId}" phase="${phase}" elapsedMs=${elapsedMs} deltaMs=${deltaMs}`,
+        payload,
+      );
+      traceExecution(
+        `[execute-task-bench] task=${taskId} attempt=${attemptId} phase=${phase} elapsedMs=${elapsedMs} deltaMs=${deltaMs}`,
+      );
+    };
+  }
+
   /**
    * Execute multiple tasks concurrently.
    */
@@ -380,16 +413,27 @@ export class TaskRunner {
     );
     const attemptId = this.resolveAttemptIdForStart(task);
     const startGeneration = task.execution.generation ?? 0;
+    const bench = this.createExecuteTaskBench(task.id, attemptId);
+    bench('executeTask.accepted', {
+      status: task.status,
+      phase: task.execution.phase,
+      generation: startGeneration,
+    });
     if (this.launchingAttemptIds.has(attemptId) || this.activeExecutions.has(attemptId)) {
       traceExecution(
         `[TaskRunner] executeTask skipping duplicate launch for task=${task.id} attempt=${attemptId}`,
       );
+      bench('executeTask.duplicateSkipped');
       return;
     }
     this.launchingAttemptIds.add(attemptId);
     try {
-      await this.executeTaskInner(task, attemptId);
+      await this.executeTaskInner(task, attemptId, bench);
+      bench('executeTask.innerReturned');
     } catch (err) {
+      bench('executeTask.failed', {
+        error: err instanceof Error ? err.message : String(err),
+      });
       // Resource limit: defer the task instead of failing it
       const cause = err instanceof Error ? err.cause : undefined;
       if (cause instanceof ResourceLimitError) {
@@ -454,13 +498,26 @@ export class TaskRunner {
       }
     } finally {
       this.launchingAttemptIds.delete(attemptId);
+      bench('executeTask.settled');
     }
   }
 
-  private async executeTaskInner(task: TaskState, attemptId: string): Promise<void> {
+  private async executeTaskInner(
+    task: TaskState,
+    attemptId: string,
+    bench: (phase: string, metadata?: Record<string, unknown>) => void = () => {},
+  ): Promise<void> {
+    bench('executeTaskInner.begin', {
+      dependencyCount: task.dependencies.length,
+      externalDependencyCount: task.config.externalDependencies?.length ?? 0,
+      runnerKind: task.config.runnerKind,
+      poolId: task.config.poolId,
+      isMergeNode: task.config.isMergeNode,
+    });
     // Pivot tasks with experimentVariants: synthesize a spawn_experiments
     // response instead of running through the executor.
     if (task.config.pivot && task.config.experimentVariants && task.config.experimentVariants.length > 0) {
+      bench('executeTaskInner.pivotResponse');
       const response: WorkResponse = {
         requestId: `req-${task.id}`,
         actionId: task.id,
@@ -484,6 +541,9 @@ export class TaskRunner {
       if (newlyStarted.length > 0) {
         this.executeTasks(newlyStarted);
       }
+      bench('executeTaskInner.pivotReturned', {
+        newlyStartedCount: newlyStarted.length,
+      });
       return;
     }
 
@@ -492,9 +552,21 @@ export class TaskRunner {
     );
 
     // Gather upstream context from completed dependencies
+    bench('buildUpstreamContext.start');
     const upstreamContext = await this.buildUpstreamContext(task);
+    bench('buildUpstreamContext.end', {
+      upstreamContextCount: upstreamContext.length,
+    });
+    bench('collectUpstreamBranches.start');
     const upstreamBranches = this.collectUpstreamBranches(task);
+    bench('collectUpstreamBranches.end', {
+      upstreamBranchCount: upstreamBranches.length,
+    });
+    bench('buildAlternatives.start');
     const alternatives = this.buildAlternatives(task);
+    bench('buildAlternatives.end', {
+      alternativeCount: alternatives.length,
+    });
 
     // Guard: every completed dependency (local or external) must have branch metadata.
     // Without it the downstream worktree would run against bare base branch,
@@ -520,6 +592,7 @@ export class TaskRunner {
         }
       }
     }
+    bench('dependencyBranchGuard.end');
 
     // Read workflow + task generations to build the visible lifecycle tag that
     // is appended to every experiment branch name. Lifecycle uniqueness lives
@@ -593,16 +666,31 @@ export class TaskRunner {
       },
       onBranchResolved,
     };
+    bench('workRequest.built', {
+      actionType: request.actionType,
+      hasRepoUrl: Boolean(request.inputs.repoUrl),
+      upstreamBranchCount: upstreamBranches.length,
+    });
 
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} executeTaskInner taskId=${task.id} WorkRequest built actionType=${request.actionType} repoUrl=${request.inputs.repoUrl ?? '(none)'} upstreamBranches=${JSON.stringify(request.inputs.upstreamBranches ?? [])}`,
     );
+    bench('selectExecutor.start');
     const executor = this.selectExecutor(task);
+    bench('selectExecutor.end', {
+      executorType: executor.type,
+    });
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} executeTaskInner taskId=${task.id} selectExecutor → type=${executor.type} calling executor.start()`,
     );
     traceExecution(`[trace] TaskRunner: task=${task.id} calling executor.start() type=${executor.type}`);
+    bench('onLaunchStart.before', {
+      executorType: executor.type,
+    });
     this.callbacks.onLaunchStart?.(task.id, executor);
+    bench('executor.start.before', {
+      executorType: executor.type,
+    });
     const startT0 = Date.now();
     const startTimeoutMs = getExecutorStartTimeoutMs();
     const preStartHeartbeatTimer = setInterval(() => {
@@ -666,6 +754,12 @@ export class TaskRunner {
       if (preStartTimeout) clearTimeout(preStartTimeout);
     }
     traceExecution(`[trace] TaskRunner: task=${task.id} executor.start() returned after ${Date.now() - startT0}ms executor=${executor.type} sessionId=${handle.agentSessionId ?? 'none'} workspace=${handle.workspacePath ?? 'default'}`);
+    bench('executor.start.after', {
+      executorType: executor.type,
+      executorStartMs: Date.now() - startT0,
+      hasWorkspacePath: Boolean(handle.workspacePath),
+      hasAgentSessionId: Boolean(handle.agentSessionId),
+    });
     const launchAccepted =
       this.orchestrator.markTaskRunningAfterLaunch?.(task.id, attemptId) ?? true;
     if (!launchAccepted) {
@@ -679,8 +773,10 @@ export class TaskRunner {
       }
       this.pendingPoolSelections.delete(task.id);
       await this.cleanupPerTaskDockerExecutor(task);
+      bench('markTaskRunningAfterLaunch.rejected');
       return;
     }
+    bench('markTaskRunningAfterLaunch.accepted');
 
     // Persist execution metadata immediately at task start — all fields explicit
     {
@@ -737,6 +833,10 @@ export class TaskRunner {
         );
       }
       traceExecution(`[trace] TaskRunner: persisted metadata for task=${task.id} workspacePath=${handle.workspacePath} branch=${handle.branch ?? 'null'}`);
+      bench('persistStartMetadata.end', {
+        workspacePath: handle.workspacePath,
+        branch: handle.branch ?? undefined,
+      });
     }
 
     // Notify consumer about the spawned handle
@@ -751,7 +851,9 @@ export class TaskRunner {
       poolId: poolSelection?.poolId,
       poolMemberKey: poolSelection?.memberKey,
     });
+    bench('onSpawned.before');
     this.callbacks.onSpawned?.(task.id, handle, executor);
+    bench('onSpawned.after');
 
     // Wire output
     executor.onOutput(handle, (data) => {

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -13,6 +13,7 @@ import {
   buildExperimentBranchName,
 } from './branch-utils.js';
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
+import { createExecutionBench } from './execution-bench.js';
 import {
   syncPlanBaseRemote,
   syncPlanBaseRemoteForRef,
@@ -135,23 +136,41 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} WorktreeExecutor.start() actionId=${request.actionId} repoUrl=${repoUrl}`,
     );
+    const bench = createExecutionBench({
+      module: 'worktree-executor-start-bench',
+      baseMetadata: {
+        requestId: request.requestId,
+        actionId: request.actionId,
+        actionType: request.actionType,
+        repoUrl,
+      },
+    });
+    bench('WorktreeExecutor.start.begin');
     await this.ensureGitAvailable();
+    bench('WorktreeExecutor.ensureGitAvailable.done');
     const handle = this.createHandle(request);
     const executionId = handle.executionId;
     const t0 = Date.now();
     const log = (step: string) => traceExecution(`[WorktreeExecutor] start task=${request.actionId} step=${step} elapsed=${Date.now() - t0}ms`);
 
+    bench('RepoPool.ensureClone.before');
     const clonePath = await this.pool.ensureClone(repoUrl);
+    bench('RepoPool.ensureClone.after', { clonePath });
     const baseRef = request.inputs.baseBranch ?? 'HEAD';
     log(`resolve base ${baseRef} begin`);
     const runGit = (args: string[]) => this.execGitSimple(args, clonePath);
+    bench('WorktreeExecutor.resolveBase.before', { baseRef });
     if (remoteFetchForPool.enabled && shouldResolveViaOriginTracking(baseRef)) {
       const preferredRemote = await resolvePreferredTrackingRemote(runGit, baseRef.trim());
+      bench('WorktreeExecutor.resolvePreferredTrackingRemote.done', { baseRef, preferredRemote });
       await syncPlanBaseRemote(runGit, baseRef.trim(), preferredRemote);
+      bench('WorktreeExecutor.syncPlanBaseRemote.done', { baseRef, preferredRemote });
     } else if (remoteFetchForPool.enabled) {
       await syncPlanBaseRemoteForRef(runGit, baseRef.trim());
+      bench('WorktreeExecutor.syncPlanBaseRemoteForRef.done', { baseRef });
     }
     const baseHead = await resolvePlanBaseRevision(runGit, baseRef);
+    bench('WorktreeExecutor.resolveBase.after', { baseRef, baseHead });
     log(`resolve base ${baseRef} done → ${baseHead}`);
     const upstreamCommits = (request.inputs.upstreamContext ?? [])
       .map(c => c.commitHash)
@@ -169,14 +188,20 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       contentHash,
     );
     traceExecution(`[WorktreeExecutor] branch=${branch} contentHash=${contentHash}`);
+    bench('WorktreeExecutor.branchComputed', { branch, contentHash });
     // Notify the orchestrator before any `git worktree add` so a leaked
     // worktree (process killed mid-acquire) can still be reconciled.
     try {
       request.onBranchResolved?.(branch);
+      bench('WorktreeExecutor.onBranchResolved.done', { branch });
     } catch (err) {
       traceExecution(
         `[WorktreeExecutor] onBranchResolved threw — continuing: ${err instanceof Error ? err.message : String(err)}`,
       );
+      bench('WorktreeExecutor.onBranchResolved.failed', {
+        branch,
+        error: err instanceof Error ? err.message : String(err),
+      });
     }
 
     // -- Reconciliation: real pool worktree at plan base (no upstream merges), then needs_input --
@@ -184,6 +209,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       traceExecution(
         `${RESTART_TO_BRANCH_TRACE} WorktreeExecutor.start() actionId=${request.actionId} reconciliation → acquireWorktree (skip upstream merge)`,
       );
+      bench('RepoPool.acquireWorktree.reconciliation.before', { branch, baseHead });
       const acquired = await this.pool.acquireWorktree(
         repoUrl,
         branch,
@@ -191,6 +217,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         request.actionId,
         { forceFresh: request.inputs.freshWorkspace === true },
       );
+      bench('RepoPool.acquireWorktree.reconciliation.after', {
+        branch: acquired.branch,
+        worktreePath: acquired.worktreePath,
+      });
       this.cleanStaleLocks(acquired.worktreePath);
 
       const entry: WorktreeEntry = {
@@ -212,6 +242,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       this.registerEntry(handle, entry);
       handle.workspacePath = acquired.worktreePath;
       handle.branch = acquired.branch;
+      bench('WorktreeExecutor.registerEntry.reconciliation.done', {
+        workspacePath: handle.workspacePath,
+        branch: handle.branch,
+      });
 
       setTimeout(() => {
         const e = this.entries.get(executionId);
@@ -227,6 +261,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         this.softReleasePoolSlot(e);
       }, 0);
 
+      bench('WorktreeExecutor.start.reconciliation.returning');
       return handle;
     }
 
@@ -234,7 +269,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} WorktreeExecutor.start() actionId=${request.actionId} → RepoPool path`,
     );
+    bench('WorktreeExecutor.reconcilePoolSlots.before');
     this.reconcilePoolSlots(repoUrl);
+    bench('WorktreeExecutor.reconcilePoolSlots.after');
+    bench('RepoPool.acquireWorktree.before', { branch, baseHead });
     const acquired = await this.pool.acquireWorktree(
       repoUrl,
       branch,
@@ -242,6 +280,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       request.actionId,
       { forceFresh: request.inputs.freshWorkspace === true },
     );
+    bench('RepoPool.acquireWorktree.after', {
+      branch: acquired.branch,
+      worktreePath: acquired.worktreePath,
+    });
 
     this.cleanStaleLocks(acquired.worktreePath);
 
@@ -249,7 +291,9 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     const poolUpstreams = request.inputs.upstreamBranches ?? [];
     if (poolUpstreams.length > 0) {
       try {
+        bench('WorktreeExecutor.mergeRequestUpstreamBranches.before', { upstreamCount: poolUpstreams.length });
         await this.mergeRequestUpstreamBranches(request, acquired.worktreePath, baseHead);
+        bench('WorktreeExecutor.mergeRequestUpstreamBranches.after', { upstreamCount: poolUpstreams.length });
       } catch (err: any) {
         if (err instanceof MergeConflictError) {
           const entry: WorktreeEntry = {
@@ -281,8 +325,12 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
           };
           this.emitComplete(handle.executionId, response);
           this.softReleasePoolSlot(entry);
+          bench('WorktreeExecutor.mergeConflict.returning', { failedBranch: err.failedBranch });
           return handle;
         }
+        bench('WorktreeExecutor.mergeRequestUpstreamBranches.failed', {
+          error: err instanceof Error ? err.message : String(err),
+        });
         throw err;
       }
     }
@@ -302,9 +350,14 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       this.registerEntry(handle, entry);
       handle.workspacePath = acquired.worktreePath;
       handle.branch = acquired.branch;
+      bench('WorktreeExecutor.registerEntry.noCommand.done', {
+        workspacePath: handle.workspacePath,
+        branch: handle.branch,
+      });
       await this.handleProcessExit(executionId, request, acquired.worktreePath, 0, { branch });
       entry.phase = 'completed';
       this.softReleasePoolSlot(entry);
+      bench('WorktreeExecutor.start.noCommand.returning');
       return handle;
     }
 
@@ -327,13 +380,19 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     this.registerEntry(handle, entry);
     handle.workspacePath = acquired.worktreePath;
     handle.branch = acquired.branch;
+    bench('WorktreeExecutor.registerEntry.provisioning.done', {
+      workspacePath: handle.workspacePath,
+      branch: handle.branch,
+    });
 
+    bench('WorktreeExecutor.provisionWorktree.before');
     const provisioning = this.provisionWorktree(acquired.worktreePath, executionId);
     entry.process = provisioning.child;
     try {
       await provisioning.completion;
       entry.process = null;
       entry.phase = 'running';
+      bench('WorktreeExecutor.provisionWorktree.after');
     } catch (err) {
       // Keep the failed workspace on disk for post-failure debugging/fix flows.
       // Only free the in-memory pool slot so retries are not blocked.
@@ -345,24 +404,37 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       const startupErr = err instanceof Error ? err : new Error(String(err));
       (startupErr as Error & { workspacePath?: string; branch?: string }).workspacePath = acquired.worktreePath;
       (startupErr as Error & { workspacePath?: string; branch?: string }).branch = acquired.branch;
+      bench('WorktreeExecutor.provisionWorktree.failed', {
+        error: startupErr.message,
+        workspacePath: acquired.worktreePath,
+        branch: acquired.branch,
+      });
       throw startupErr;
     }
 
+    bench('WorktreeExecutor.buildCommandAndArgs.before');
     const { cmd, args, agentSessionId } = this.buildCommandAndArgs(request, {
       claudeCommand: this.claudeCommand,
       agentRegistry: this.agentRegistry,
+    });
+    bench('WorktreeExecutor.buildCommandAndArgs.after', {
+      cmd,
+      argCount: args.length,
+      hasAgentSessionId: !!agentSessionId,
     });
 
     const executionAgent = request.inputs.executionAgent ?? 'claude';
     const stdinMode = this.agentRegistry && executionAgent
       ? this.agentRegistry.getOrThrow(executionAgent).stdinMode
       : (request.actionType === 'ai_task' ? 'ignore' : 'pipe');
+    bench('WorktreeExecutor.spawn.before', { cmd, argCount: args.length, cwd: acquired.worktreePath });
     const child = spawn(cmd, args, {
       stdio: [stdinMode, 'pipe', 'pipe'],
       cwd: acquired.worktreePath,
       detached: true,
       env: cleanElectronEnv(),
     });
+    bench('WorktreeExecutor.spawn.after');
 
     // Register error handler IMMEDIATELY to catch synchronous spawn failures
     child.on('error', (err) => {
@@ -452,6 +524,10 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
 
     this.startHeartbeat(executionId, child);
     log('startHeartbeat done — start() returning');
+    bench('WorktreeExecutor.start.returning', {
+      workspacePath: handle.workspacePath,
+      branch: handle.branch,
+    });
     return handle;
   }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -282,17 +282,33 @@ export function App() {
       return true;
     };
 
-    // Track renderer event loop lag.
-    let expected = performance.now() + 1000;
+    // Track per-tick renderer timer drift. Keep the old cumulative schedule
+    // value in the payload so startup perf data can prove whether a large
+    // number is an actual single stall or accumulated timer throttling.
+    const intervalMs = 1000;
+    let expected = performance.now() + intervalMs;
+    let previousTickAt = performance.now();
+    let tickCount = 0;
     const lagInterval = setInterval(() => {
       const now = performance.now();
-      const lagMs = Math.max(0, now - expected);
-      expected += 1000;
-      if (lagMs >= 250 && shouldEmit('event_loop_lag', 5000)) {
+      const tickDeltaMs = now - previousTickAt;
+      const lagMs = Math.max(0, tickDeltaMs - intervalMs);
+      const cumulativeLagMs = Math.max(0, now - expected);
+      previousTickAt = now;
+      expected = now + intervalMs;
+      tickCount += 1;
+      if ((lagMs >= 250 || cumulativeLagMs >= 250) && shouldEmit('event_loop_lag', 5000)) {
         // Defensive: window.invoker is undefined in vitest/jsdom environments.
-        void window.invoker?.reportUiPerf?.('renderer_event_loop_lag', { lagMs: Math.round(lagMs) });
+        void window.invoker?.reportUiPerf?.('renderer_event_loop_lag', {
+          lagMs: Math.round(lagMs),
+          cumulativeLagMs: Math.round(cumulativeLagMs),
+          tickDeltaMs: Math.round(tickDeltaMs),
+          tickCount,
+          visibilityState: document.visibilityState,
+          hasFocus: document.hasFocus(),
+        });
       }
-    }, 1000);
+    }, intervalMs);
 
     // Track long tasks if supported by Chromium.
     let perfObserver: PerformanceObserver | null = null;

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -143,6 +143,42 @@ describe('useTasks', () => {
     expect(result.current.tasks.get('t1')?.id).toBe('t1');
   });
 
+  it('does not replace a full bootstrap with a smaller initial snapshot', async () => {
+    const bootA = makeUITask({ id: 'boot-a', description: 'Bootstrap A' });
+    const bootB = makeUITask({ id: 'boot-b', description: 'Bootstrap B' });
+    const smaller = makeUITask({ id: 'boot-a', description: 'Smaller A' });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [bootA, bootB],
+      workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'running' }],
+    };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks: vi.fn().mockResolvedValue({
+        tasks: [smaller],
+        workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'running' }],
+      }),
+      reportUiPerf: vi.fn(),
+      onTaskDelta: vi.fn(() => () => {}),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(window.invoker.getTasks).toHaveBeenCalled();
+    });
+
+    expect(result.current.tasks.size).toBe(2);
+    expect(result.current.tasks.get('boot-a')?.description).toBe('Bootstrap A');
+    expect(result.current.tasks.get('boot-b')?.description).toBe('Bootstrap B');
+    expect(window.invoker.reportUiPerf).toHaveBeenCalledWith(
+      'startup_snapshot_skipped_smaller_than_bootstrap',
+      expect.objectContaining({
+        bootstrapTaskCount: 2,
+        snapshotTaskCount: 1,
+      }),
+    );
+  });
+
   it('passes forceRefresh flag to getTasks when requested', async () => {
     const getTasks = vi.fn().mockResolvedValue({ tasks: [], workflows: [] });
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { MouseEvent } from 'react';
 import type { TaskState, WorkflowMeta, WorkflowStatus } from '../types.js';
 import { deriveWorkflowGraph, layoutWorkflowGraph } from '../lib/workflow-graph.js';
@@ -72,26 +72,43 @@ function WorkflowGraphInner({
   onWorkflowContextMenu,
 }: WorkflowGraphProps): JSX.Element {
   const { fitView } = useReactFlow();
-  const graph = useMemo(() => deriveWorkflowGraph(workflows, tasks), [workflows, tasks]);
-  const positions = useMemo(() => layoutWorkflowGraph(graph), [graph]);
+  const reportedVisibleRef = useRef(false);
+  const graphMetricsRef = useRef({ deriveMs: 0, layoutMs: 0, objectsMs: 0 });
+  const graph = useMemo(() => {
+    const startedAt = performance.now();
+    const nextGraph = deriveWorkflowGraph(workflows, tasks);
+    graphMetricsRef.current.deriveMs = performance.now() - startedAt;
+    return nextGraph;
+  }, [workflows, tasks]);
+  const positions = useMemo(() => {
+    const startedAt = performance.now();
+    const nextPositions = layoutWorkflowGraph(graph);
+    graphMetricsRef.current.layoutMs = performance.now() - startedAt;
+    return nextPositions;
+  }, [graph]);
 
-  const nodes = useMemo<Node<WorkflowNodeData>[]>(() => graph.nodes.map((node) => {
-    const position = positions.get(node.id) ?? { x: 80, y: 80 };
-    const dimmed = statusFilters.size > 0 && !statusFilters.has(node.workflow.status);
-    return {
-      id: node.id,
-      type: 'workflowNode',
-      position,
-      sourcePosition: Position.Right,
-      targetPosition: Position.Left,
-      zIndex: 2,
-      data: {
-        workflow: node.workflow,
-        selected: selectedWorkflowId === node.id,
-        dimmed,
-      },
-    };
-  }), [graph.nodes, positions, selectedWorkflowId, statusFilters]);
+  const nodes = useMemo<Node<WorkflowNodeData>[]>(() => {
+    const startedAt = performance.now();
+    const nextNodes = graph.nodes.map((node) => {
+      const position = positions.get(node.id) ?? { x: 80, y: 80 };
+      const dimmed = statusFilters.size > 0 && !statusFilters.has(node.workflow.status);
+      return {
+        id: node.id,
+        type: 'workflowNode',
+        position,
+        sourcePosition: Position.Right,
+        targetPosition: Position.Left,
+        zIndex: 2,
+        data: {
+          workflow: node.workflow,
+          selected: selectedWorkflowId === node.id,
+          dimmed,
+        },
+      };
+    });
+    graphMetricsRef.current.objectsMs = performance.now() - startedAt;
+    return nextNodes;
+  }, [graph.nodes, positions, selectedWorkflowId, statusFilters]);
 
   const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => ({
     id: `workflow:${edge.source}->${edge.target}`,
@@ -124,6 +141,29 @@ function WorkflowGraphInner({
     event.preventDefault();
     onWorkflowContextMenu(event, node.id);
   }, [onWorkflowContextMenu]);
+
+  useEffect(() => {
+    if (reportedVisibleRef.current || graph.nodes.length === 0 || typeof window === 'undefined') {
+      return;
+    }
+    const frame = requestAnimationFrame(() => {
+      const visibleNode = document.querySelector('[data-testid^="workflow-node-"]');
+      if (!visibleNode) return;
+      reportedVisibleRef.current = true;
+      void window.invoker?.reportUiPerf?.('startup_workflow_graph_visible', {
+        nodeCount: graph.nodes.length,
+        edgeCount: graph.edges.length,
+        deriveMs: graphMetricsRef.current.deriveMs,
+        layoutMs: graphMetricsRef.current.layoutMs,
+        objectsMs: graphMetricsRef.current.objectsMs,
+        elapsedMs: Math.round(performance.now()),
+        processElapsedMs: window.__INVOKER_BOOTSTRAP__?.appStartedAtEpochMs
+          ? Date.now() - window.__INVOKER_BOOTSTRAP__.appStartedAtEpochMs
+          : undefined,
+      });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [graph.edges.length, graph.nodes.length]);
 
   if (graph.nodes.length === 0) {
     return (

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -29,18 +29,32 @@ export function useTasks(): UseTasksResult {
   const bootstrapState =
     typeof window !== 'undefined' ? window.__INVOKER_BOOTSTRAP__ : undefined;
   const [tasks, setTasks] = useState<Map<string, TaskState>>(() => {
+    const startedAt = performance.now();
     const next = new Map<string, TaskState>();
     for (const task of bootstrapState?.tasks ?? []) {
       next.set(task.id, task);
     }
+    if (typeof window !== 'undefined' && window.invoker) {
+      void window.invoker.reportUiPerf?.('useTasks_bootstrap_task_map', {
+        durationMs: performance.now() - startedAt,
+        taskCount: next.size,
+      });
+    }
     return next;
   });
   const [workflows, setWorkflows] = useState<Map<string, WorkflowMeta>>(() => {
+    const startedAt = performance.now();
     const next = new Map<string, WorkflowMeta>();
     for (const workflow of bootstrapState?.workflows ?? []) {
       next.set(workflow.id, {
         ...workflow,
         status: normalizeWorkflowStatus((workflow as { status?: string }).status),
+      });
+    }
+    if (typeof window !== 'undefined' && window.invoker) {
+      void window.invoker.reportUiPerf?.('useTasks_bootstrap_workflow_map', {
+        durationMs: performance.now() - startedAt,
+        workflowCount: next.size,
       });
     }
     return next;
@@ -62,12 +76,25 @@ export function useTasks(): UseTasksResult {
   const fetchAll = useCallback((forceRefresh = false) => {
     if (typeof window === 'undefined' || !window.invoker) return;
     const gen = ++getTasksGenerationRef.current;
+    const requestedAt = performance.now();
     window.invoker.getTasks(forceRefresh).then((result) => {
+      const requestDurationMs = performance.now() - requestedAt;
       if (gen !== getTasksGenerationRef.current) {
         return;
       }
       const taskList = result.tasks ?? [];
       const wfList = result.workflows ?? [];
+      const bootstrapTaskCount = bootstrapState?.tasks?.length ?? 0;
+      if (!forceRefresh && bootstrapTaskCount > taskList.length) {
+        void window.invoker?.reportUiPerf?.('startup_snapshot_skipped_smaller_than_bootstrap', {
+          bootstrapTaskCount,
+          snapshotTaskCount: taskList.length,
+          workflowCount: wfList.length,
+          requestDurationMs,
+        });
+        return;
+      }
+      const replaceStartedAt = performance.now();
       // Always replace from server snapshot — empty lists mean "no tasks/workflows" (e.g. after delete).
       setTasks(() => {
         const next = new Map<string, TaskState>();
@@ -83,6 +110,15 @@ export function useTasks(): UseTasksResult {
           });
         }
         return wfMap;
+      });
+      const replaceDurationMs = performance.now() - replaceStartedAt;
+      void window.invoker.reportUiPerf?.('useTasks_snapshot_replace', {
+        taskCount: taskList.length,
+        workflowCount: wfList.length,
+        forceRefresh,
+        requestDurationMs,
+        replaceDurationMs,
+        jsonSizeBytes: new Blob([JSON.stringify(result)]).size,
       });
       if (!reportedStartupSnapshotRef.current) {
         reportedStartupSnapshotRef.current = true;

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -104,13 +104,13 @@ function makeResponse(
 }
 
 function makeOrchestrator(
-  opts: { deferRunningUntilLaunch?: boolean } = {},
+  opts: { deferRunningUntilLaunch?: boolean; maxConcurrency?: number } = {},
 ): { orchestrator: Orchestrator; persistence: InMemoryPersistence } {
   const persistence = new InMemoryPersistence();
   const orchestrator = new Orchestrator({
     persistence,
     messageBus: new InMemoryBus(),
-    maxConcurrency: 4,
+    maxConcurrency: opts.maxConcurrency ?? 4,
     deferRunningUntilLaunch: opts.deferRunningUntilLaunch,
   });
   return { orchestrator, persistence };
@@ -267,6 +267,80 @@ describe('Orchestrator launch claims', () => {
     expect(staleResult).toEqual([]);
     expect(orchestrator.getTask(taskId)?.execution.selectedAttemptId).toBe(replacementAttemptId);
     expect(orchestrator.getTask(taskId)?.status).toBe('pending');
+  });
+
+  it('ignores responses for a selected attempt row that has been superseded', () => {
+    const { orchestrator, persistence } = makeOrchestrator();
+    orchestrator.loadPlan({
+      name: 'superseded-response',
+      onFinish: 'none',
+      tasks: [{ id: 't1', description: 'one', command: 'echo one' }],
+    });
+
+    const taskId = taskIdBySuffix(orchestrator, 't1');
+    const [started] = orchestrator.startExecution();
+    const attemptId = started!.execution.selectedAttemptId!;
+    persistence.updateAttempt(attemptId, { status: 'superseded' });
+
+    const result = orchestrator.handleWorkerResponse({
+      ...makeResponse(taskId, 'completed', started!.execution.generation ?? 0),
+      attemptId,
+    });
+
+    expect(result).toEqual([]);
+    expect(orchestrator.getTask(taskId)?.status).toBe('running');
+    expect(persistence.loadAttempt(attemptId)?.status).toBe('superseded');
+  });
+
+  it('rejects launch finalization for a superseded selected attempt', () => {
+    const { orchestrator, persistence } = makeOrchestrator({ deferRunningUntilLaunch: true });
+    orchestrator.loadPlan({
+      name: 'superseded-launch',
+      onFinish: 'none',
+      tasks: [{ id: 't1', description: 'one', command: 'echo one' }],
+    });
+
+    const taskId = taskIdBySuffix(orchestrator, 't1');
+    const [claim] = orchestrator.startExecution();
+    const attemptId = claim!.execution.selectedAttemptId!;
+    persistence.updateAttempt(attemptId, { status: 'superseded' });
+
+    expect(orchestrator.markTaskRunningAfterLaunch(taskId, attemptId)).toBe(false);
+    expect(orchestrator.getTask(taskId)?.status).toBe('pending');
+    expect(persistence.loadAttempt(attemptId)?.status).toBe('superseded');
+  });
+
+  it('creates a fresh attempt instead of claiming a superseded queued job', () => {
+    const { orchestrator, persistence } = makeOrchestrator({ maxConcurrency: 1 });
+    orchestrator.loadPlan({
+      name: 'superseded-queued',
+      onFinish: 'none',
+      tasks: [
+        { id: 't1', description: 'first', command: 'echo one' },
+        { id: 't2', description: 'second', command: 'echo two' },
+      ],
+    });
+
+    const [started] = orchestrator.startExecution();
+    const firstTaskId = taskIdBySuffix(orchestrator, 't1');
+    const secondTaskId = taskIdBySuffix(orchestrator, 't2');
+    expect(started!.id).toBe(firstTaskId);
+
+    const queuedAttemptId = orchestrator.getTask(secondTaskId)!.execution.selectedAttemptId!;
+    persistence.updateAttempt(queuedAttemptId, { status: 'superseded' });
+
+    orchestrator.handleWorkerResponse({
+      ...makeResponse(firstTaskId, 'completed', started!.execution.generation ?? 0),
+      attemptId: started!.execution.selectedAttemptId,
+    });
+
+    const secondTask = orchestrator.getTask(secondTaskId)!;
+    const freshAttemptId = secondTask.execution.selectedAttemptId!;
+    expect(secondTask.status).toBe('running');
+    expect(freshAttemptId).not.toBe(queuedAttemptId);
+    expect(persistence.loadAttempt(queuedAttemptId)?.status).toBe('superseded');
+    expect(persistence.loadAttempt(freshAttemptId)?.status).toBe('running');
+    expect(persistence.loadAttempt(freshAttemptId)?.supersedesAttemptId).toBe(queuedAttemptId);
   });
 
   it('resumeWorkflow returns persisted pending launch claims', () => {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -142,6 +142,30 @@ class InMemoryPersistence implements OrchestratorPersistence {
     return Array.from(this.workflows.values()).map((workflow) => this.withDerivedStatus(workflow));
   }
 
+  loadWorkflowTaskSnapshot(): {
+    workflows: Array<{ id: string; name: string; status: string; createdAt: string; updatedAt: string }>;
+    tasks: TaskState[];
+    tasksByWorkflowId: Map<string, TaskState[]>;
+  } {
+    const tasksByWorkflowId = new Map<string, TaskState[]>();
+    for (const { workflowId, task } of this.tasks.values()) {
+      const workflowTasks = tasksByWorkflowId.get(workflowId) ?? [];
+      workflowTasks.push(task);
+      tasksByWorkflowId.set(workflowId, workflowTasks);
+    }
+    const workflows = Array.from(this.workflows.values()).map((workflow) => {
+      const tasks = tasksByWorkflowId.get(workflow.id) ?? [];
+      if (tasks.length === 0) return workflow;
+      const rollup = computeWorkflowRollup(tasks);
+      return { ...workflow, status: rollup.status, rollup };
+    });
+    return {
+      workflows,
+      tasks: Array.from(this.tasks.values()).map((entry) => entry.task),
+      tasksByWorkflowId,
+    };
+  }
+
   private withDerivedStatus<T extends { id: string; status: string }>(workflow: T): T {
     const tasks = this.loadTasks(workflow.id);
     if (tasks.length === 0) return workflow;
@@ -4430,6 +4454,27 @@ describe('Orchestrator', () => {
       orchestrator.syncAllFromDb();
       expect(orchestrator.getTask('a1')!.status).toBe('completed');
       expect(orchestrator.getTask('b1')!.status).toBe('pending');
+      expect(orchestrator.getAllTasks()).toHaveLength(4);
+    });
+
+    it('syncAllFromDb uses a bulk snapshot when the adapter provides one', () => {
+      orchestrator.loadPlan({
+        name: 'Plan A',
+        tasks: [{ id: 'a1', description: 'A1', command: 'echo a1' }],
+      });
+      orchestrator.loadPlan({
+        name: 'Plan B',
+        tasks: [{ id: 'b1', description: 'B1', command: 'echo b1' }],
+      });
+      const snapshotSpy = vi.spyOn(persistence as any, 'loadWorkflowTaskSnapshot');
+      const loadTasksSpy = vi.spyOn(persistence, 'loadTasks');
+
+      orchestrator.syncAllFromDb();
+
+      expect(snapshotSpy).toHaveBeenCalledTimes(1);
+      expect(loadTasksSpy).not.toHaveBeenCalled();
+      expect(orchestrator.getTask('a1')).toBeDefined();
+      expect(orchestrator.getTask('b1')).toBeDefined();
       expect(orchestrator.getAllTasks()).toHaveLength(4);
     });
 

--- a/packages/workflow-core/src/attempt-policy.ts
+++ b/packages/workflow-core/src/attempt-policy.ts
@@ -1,0 +1,45 @@
+import type { Attempt, AttemptStatus } from '@invoker/workflow-graph';
+
+export const ACTIVE_ATTEMPT_STATUSES: readonly AttemptStatus[] = [
+  'pending',
+  'claimed',
+  'running',
+  'needs_input',
+];
+
+export const DISCARDED_ATTEMPT_STATUSES: readonly AttemptStatus[] = [
+  'superseded',
+];
+
+export const OUTCOME_TERMINAL_ATTEMPT_STATUSES: readonly AttemptStatus[] = [
+  'completed',
+  'failed',
+];
+
+export function isActiveAttemptStatus(status: AttemptStatus | undefined): boolean {
+  return status !== undefined && ACTIVE_ATTEMPT_STATUSES.includes(status);
+}
+
+export function isDiscardedAttemptStatus(status: AttemptStatus | undefined): boolean {
+  return status !== undefined && DISCARDED_ATTEMPT_STATUSES.includes(status);
+}
+
+export function isOutcomeTerminalAttemptStatus(status: AttemptStatus | undefined): boolean {
+  return status !== undefined && OUTCOME_TERMINAL_ATTEMPT_STATUSES.includes(status);
+}
+
+export function isTerminalAttemptStatus(status: AttemptStatus | undefined): boolean {
+  return isDiscardedAttemptStatus(status) || isOutcomeTerminalAttemptStatus(status);
+}
+
+export function isActiveAttempt(attempt: Attempt | undefined): boolean {
+  return isActiveAttemptStatus(attempt?.status);
+}
+
+export function isDiscardedAttempt(attempt: Attempt | undefined): boolean {
+  return isDiscardedAttemptStatus(attempt?.status);
+}
+
+export function isOutcomeTerminalAttempt(attempt: Attempt | undefined): boolean {
+  return isOutcomeTerminalAttemptStatus(attempt?.status);
+}

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -10,3 +10,4 @@ export * from './command-service.js';
 export * from './task-repository.js';
 export * from './invalidation-policy.js';
 export * from './invalidation-plan.js';
+export * from './attempt-policy.js';

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -184,6 +184,21 @@ export interface OrchestratorPersistence {
     generation?: number;
   }>;
   loadTasks(workflowId: string): TaskState[];
+  loadWorkflowTaskSnapshot?(): {
+    workflows: Array<{
+      id: string;
+      name: string;
+      status: string;
+      createdAt: string;
+      updatedAt: string;
+      baseBranch?: string;
+      onFinish?: string;
+      mergeMode?: 'manual' | 'automatic' | 'external_review';
+      generation?: number;
+    }>;
+    tasks: TaskState[];
+    tasksByWorkflowId: Map<string, TaskState[]>;
+  };
   // Attempt methods
   saveAttempt(attempt: Attempt): void;
   loadAttempts(nodeId: string): Attempt[];
@@ -3512,10 +3527,11 @@ export class Orchestrator {
   syncAllFromDb(): void {
     this.stateMachine.clear();
     this.activeWorkflowIds.clear();
-    const workflows = this.persistence.listWorkflows();
+    const snapshot = this.persistence.loadWorkflowTaskSnapshot?.();
+    const workflows = snapshot?.workflows ?? this.persistence.listWorkflows();
     for (const wf of workflows) {
       this.activeWorkflowIds.add(wf.id);
-      const tasks = this.persistence.loadTasks(wf.id);
+      const tasks = snapshot?.tasksByWorkflowId.get(wf.id) ?? this.persistence.loadTasks(wf.id);
       for (const task of tasks) {
         this.stateMachine.restoreTask(task);
       }

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -76,6 +76,11 @@ import {
   withSchedulerEnqueueCandidates,
   type InvalidationPlan,
 } from './invalidation-plan.js';
+import {
+  isActiveAttempt,
+  isDiscardedAttempt,
+  isOutcomeTerminalAttempt,
+} from './attempt-policy.js';
 
 // ── Channel Constants ───────────────────────────────────────
 
@@ -1115,6 +1120,7 @@ export class Orchestrator {
 
   private isAttemptLeaseActive(attempt: Attempt | undefined, now: number = Date.now()): boolean {
     if (!attempt) return false;
+    if (isDiscardedAttempt(attempt)) return false;
     if (attempt.status !== 'claimed' && attempt.status !== 'running') return false;
     if (!attempt.leaseExpiresAt) return true;
     return attempt.leaseExpiresAt.getTime() >= now;
@@ -1171,7 +1177,7 @@ export class Orchestrator {
 
   private ensureCurrentPendingAttempt(task: TaskState): string {
     const selected = this.getSelectedAttempt(task);
-    if (selected && (selected.status === 'pending' || selected.status === 'claimed' || selected.status === 'running' || selected.status === 'needs_input')) {
+    if (selected && isActiveAttempt(selected)) {
       return selected.id;
     }
 
@@ -1179,7 +1185,7 @@ export class Orchestrator {
     const attempts =
       typeof loadAttempts === 'function' ? loadAttempts.call(this.persistence, task.id) : [];
     const current = attempts[attempts.length - 1];
-    if (current && (current.status === 'pending' || current.status === 'claimed' || current.status === 'running' || current.status === 'needs_input')) {
+    if (current && isActiveAttempt(current)) {
       if (task.execution.selectedAttemptId !== current.id) {
         this.writeAndSync(task.id, { execution: { selectedAttemptId: current.id } });
       }
@@ -1194,7 +1200,7 @@ export class Orchestrator {
       upstreamAttemptIds,
       supersedesAttemptId: current?.id,
     });
-    if (current && current.status !== 'completed' && current.status !== 'failed' && current.status !== 'superseded') {
+    if (current && !isOutcomeTerminalAttempt(current) && !isDiscardedAttempt(current)) {
       this.taskRepository.updateAttempt(current.id, { status: 'superseded' });
     }
     this.taskRepository.saveAttempt(freshAttempt);
@@ -1213,7 +1219,7 @@ export class Orchestrator {
       typeof loadAttempts === 'function' ? loadAttempts.call(this.persistence, task.id) : [];
     const current = selected ?? attempts[attempts.length - 1];
 
-    if (current && current.status !== 'completed' && current.status !== 'failed' && current.status !== 'superseded') {
+    if (current && !isOutcomeTerminalAttempt(current) && !isDiscardedAttempt(current)) {
       this.taskRepository.updateAttempt(current.id, { status: 'superseded' });
     }
 
@@ -1499,6 +1505,17 @@ export class Orchestrator {
             });
             return [];
           }
+        }
+        const responseAttemptId = response.attemptId ?? activeAttemptId;
+        const responseAttempt = this.loadAttemptById(responseAttemptId);
+        if (isDiscardedAttempt(responseAttempt)) {
+          this.logger.warn('[worker-response] SUPERSEDED_ATTEMPT_REJECTED', {
+            taskId: earlyTask.id,
+            responseAttemptId: responseAttemptId ?? 'none',
+            activeAttemptId: activeAttemptId ?? 'none',
+            workerResponseStatus: response.status,
+          });
+          return [];
         }
         const activeGeneration = this.getExecutionGeneration(earlyTask);
         if (
@@ -4700,13 +4717,27 @@ export class Orchestrator {
       }
 
       const now = new Date();
-      const attemptId = job.attemptId ?? this.ensureCurrentPendingAttempt(task);
+      let attemptId = job.attemptId ?? this.ensureCurrentPendingAttempt(task);
+      let currentAttempt = this.loadAttemptById(attemptId);
+      if (!currentAttempt || isDiscardedAttempt(currentAttempt)) {
+        attemptId = this.ensureCurrentPendingAttempt(task);
+        currentAttempt = this.loadAttemptById(attemptId);
+      }
+      if (!currentAttempt || isDiscardedAttempt(currentAttempt)) {
+        this.logger.info('[orchestrator] drainScheduler: skipping non-runnable attempt', {
+          taskId: job.taskId,
+          attemptId,
+          attemptStatus: currentAttempt?.status ?? 'missing',
+        });
+        job = this.scheduler.takeNext();
+        continue;
+      }
       let launchAttemptId = attemptId;
-      if (task.execution.selectedAttemptId !== attemptId) {
+      const selectedTask = this.stateGetTask(job.taskId) ?? task;
+      if (selectedTask.execution.selectedAttemptId !== attemptId) {
         this.writeAndSync(job.taskId, { execution: { selectedAttemptId: attemptId } });
       }
       let claimSucceeded = false;
-      const currentAttempt = this.loadAttemptById(attemptId);
       const claimPatch = this.deferRunningUntilLaunch
         ? {
             status: 'claimed' as const,
@@ -4721,29 +4752,10 @@ export class Orchestrator {
             lastHeartbeatAt: now,
             leaseExpiresAt: nextLeaseExpiry(now),
           };
-      if (!currentAttempt) {
-        const upstreamAttemptIds = task.dependencies
-          .map(depId => this.stateGetTask(depId)?.execution.selectedAttemptId)
-          .filter((id): id is string => !!id);
-        const attempt = createAttempt(job.taskId, {
-          status: 'pending',
-          upstreamAttemptIds,
-        });
-        this.taskRepository.saveAttempt(attempt);
-        if (task.execution.selectedAttemptId !== attempt.id) {
-          this.writeAndSync(job.taskId, { execution: { selectedAttemptId: attempt.id } });
-        }
-        launchAttemptId = attempt.id;
-        claimSucceeded = this.taskRepository.claimAttemptForLaunch?.(attempt.id, claimPatch, now) ?? true;
-        if (claimSucceeded && !this.taskRepository.claimAttemptForLaunch) {
-          this.taskRepository.updateAttempt(attempt.id, claimPatch);
-        }
-      } else {
-        claimSucceeded = this.taskRepository.claimAttemptForLaunch?.(attemptId, claimPatch, now)
-          ?? !this.isAttemptLeaseActive(currentAttempt, now.getTime());
-        if (claimSucceeded && !this.taskRepository.claimAttemptForLaunch) {
-          this.taskRepository.updateAttempt(attemptId, claimPatch);
-        }
+      claimSucceeded = this.taskRepository.claimAttemptForLaunch?.(attemptId, claimPatch, now)
+        ?? !this.isAttemptLeaseActive(currentAttempt, now.getTime());
+      if (claimSucceeded && !this.taskRepository.claimAttemptForLaunch) {
+        this.taskRepository.updateAttempt(attemptId, claimPatch);
       }
       if (!claimSucceeded) {
         this.logger.info('[orchestrator] drainScheduler: skipping already-claimed attempt', {
@@ -4819,12 +4831,23 @@ export class Orchestrator {
     }
 
     const selectedAttemptId = task.execution.selectedAttemptId;
-    if (selectedAttemptId && selectedAttemptId !== attemptId) {
+    if (selectedAttemptId !== attemptId) {
       this.logger.info('[orchestrator] markTaskRunningAfterLaunch: reject', {
         taskId,
         attemptId,
         reason: 'attempt_mismatch',
         selectedAttemptId,
+      });
+      this.clearQueuedSchedulerEntries(taskId, attemptId);
+      return false;
+    }
+
+    const existingAttempt = this.loadAttemptById(attemptId);
+    if (!existingAttempt || isDiscardedAttempt(existingAttempt)) {
+      this.logger.info('[orchestrator] markTaskRunningAfterLaunch: reject', {
+        taskId,
+        attemptId,
+        reason: !existingAttempt ? 'attempt_missing' : 'attempt_superseded',
       });
       this.clearQueuedSchedulerEntries(taskId, attemptId);
       return false;
@@ -4871,33 +4894,13 @@ export class Orchestrator {
     }
 
     try {
-      const existingAttempt = this.persistence.loadAttempt(attemptId);
-      if (existingAttempt) {
-        this.taskRepository.updateAttempt(attemptId, {
-          status: 'running',
-          claimedAt: existingAttempt.claimedAt ?? launchedAt,
-          startedAt: launchedAt,
-          lastHeartbeatAt: launchedAt,
-          leaseExpiresAt: nextLeaseExpiry(launchedAt),
-        });
-      } else {
-        const upstreamAttemptIds = task.dependencies
-          .map(depId => this.stateGetTask(depId)?.execution.selectedAttemptId)
-          .filter((id): id is string => !!id);
-        const attempt: Attempt = {
-          ...createAttempt(taskId, {
-            status: 'running',
-            claimedAt: launchedAt,
-            startedAt: launchedAt,
-            lastHeartbeatAt: launchedAt,
-            leaseExpiresAt: nextLeaseExpiry(launchedAt),
-            upstreamAttemptIds,
-          }),
-          id: attemptId,
-        };
-        this.taskRepository.saveAttempt(attempt);
-        this.writeAndSync(taskId, { execution: { selectedAttemptId: attempt.id } });
-      }
+      this.taskRepository.updateAttempt(attemptId, {
+        status: 'running',
+        claimedAt: existingAttempt.claimedAt ?? launchedAt,
+        startedAt: launchedAt,
+        lastHeartbeatAt: launchedAt,
+        leaseExpiresAt: nextLeaseExpiry(launchedAt),
+      });
     } catch {
       // best effort — do not fail launch-state transition due to attempt sync
     }


### PR DESCRIPTION
## Summary

Treat `attempt.status = superseded` as a discarded terminal state throughout launch, response, queue-drain, and DB hydration paths.

- Adds shared workflow-core attempt policy helpers for active, discarded, and outcome-terminal statuses.
- Rejects worker responses and launch finalization when the selected attempt row is superseded or missing.
- Forces scheduler drain to create/select a fresh attempt instead of claiming a superseded queued attempt.
- Derives tasks with superseded selected attempts as stale during SQLite hydration while preserving the historical attempt row and supersession link.
- Updates test persistence doubles used by merge-gate and open-terminal integration tests so they store attempt rows instead of silently dropping launch state.

## Architecture

### Before

```mermaid
graph TD
    A[Task selectedAttemptId] --> B[Attempt row]
    B --> C{Task status guard}
    C --> D[Launch / response / queue mutation]
    B --> E[History, including superseded]
```

### After

```mermaid
graph TD
    A[Task selectedAttemptId] --> B[Attempt row]
    B --> C{Attempt policy}
    C -->|pending / claimed / running / needs_input| D[Runnable / mutable]
    C -->|superseded| E[Discarded audit history]
    C -->|completed / failed| F[Outcome terminal]
    E --> G[Reject launch, response, and claim]
```

## Test Plan

- [x] `pnpm --dir packages/workflow-core exec vitest run src/__tests__/orchestrator-dispatcher.test.ts`
- [x] `pnpm --dir packages/data-store exec vitest run src/__tests__/attempt-persistence.test.ts`
- [x] `pnpm --dir packages/workflow-core exec tsc -p tsconfig.json --noEmit`
- [x] `bash scripts/repro/repro-stale-late-completion-after-reset.sh --mode=both --expect-fixed`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/auto-commit.test.ts --testNamePattern "orchestrator.approve"`
- [x] `pnpm --filter @invoker/execution-engine test`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/open-terminal.test.ts`
- [ ] GitHub CI is rerunning after the latest test-double fix

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 61030d7b 80075a87 00f2e38a`
- Post-revert steps: Re-run the focused workflow-core, data-store, execution-engine, and app tests listed above.
- Data migration? No
