### PR TITLE
Normalize stale launch metadata

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1612,6 +1612,7 @@ describe('SQLiteAdapter', () => {
         migratedFixingWithAiStatuses: 1,
         normalizedMergeModes: 1,
         staleAutoFixExperimentTasks: 2,
+        normalizedStaleLaunchMetadata: 0,
       });
       const taskById = new Map(adapter.loadTasks('wf-1').map((task) => [task.id, task]));
       expect(adapter.loadWorkflow('wf-1')?.mergeMode).toBe('external_review');
@@ -1626,7 +1627,46 @@ describe('SQLiteAdapter', () => {
         migratedFixingWithAiStatuses: 0,
         normalizedMergeModes: 0,
         staleAutoFixExperimentTasks: 0,
+        normalizedStaleLaunchMetadata: 0,
       });
+    });
+
+    it('normalizes stale terminal launch metadata without touching legitimate long executions', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('stale-launch', {
+        status: 'failed',
+        execution: {
+          phase: 'launching',
+          launchStartedAt: new Date('2026-05-13T18:11:40.000Z'),
+          launchCompletedAt: undefined,
+          startedAt: new Date('2026-05-15T07:29:37.000Z'),
+          completedAt: new Date('2026-05-15T07:29:37.000Z'),
+          error: 'fixWithAgent: task has no valid workspace (workspacePath=undefined)',
+        },
+      }));
+      adapter.saveTask('wf-1', makeTask('long-running', {
+        status: 'completed',
+        execution: {
+          phase: 'executing',
+          launchStartedAt: new Date('2026-05-15T07:25:54.000Z'),
+          launchCompletedAt: new Date('2026-05-15T07:26:18.000Z'),
+          startedAt: new Date('2026-05-15T07:26:18.000Z'),
+          completedAt: new Date('2026-05-15T09:46:52.000Z'),
+        },
+      }));
+
+      const report = adapter.runCompatibilityMigration();
+
+      expect(report.normalizedStaleLaunchMetadata).toBe(1);
+      const taskById = new Map(adapter.loadTasks('wf-1').map((task) => [task.id, task]));
+      expect(taskById.get('stale-launch')?.execution.phase).toBeUndefined();
+      expect(taskById.get('stale-launch')?.execution.launchStartedAt).toBeUndefined();
+      expect(taskById.get('stale-launch')?.execution.launchCompletedAt).toBeUndefined();
+      expect(taskById.get('long-running')?.execution.launchStartedAt?.toISOString()).toBe('2026-05-15T07:25:54.000Z');
+      expect(taskById.get('long-running')?.execution.launchCompletedAt?.toISOString()).toBe('2026-05-15T07:26:18.000Z');
+
+      const secondRun = adapter.runCompatibilityMigration();
+      expect(secondRun.normalizedStaleLaunchMetadata).toBe(0);
     });
   });
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -237,11 +237,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
     migratedFixingWithAiStatuses: number;
     normalizedMergeModes: number;
     staleAutoFixExperimentTasks: number;
+    normalizedStaleLaunchMetadata: number;
   } {
     const report = {
       migratedFixingWithAiStatuses: 0,
       normalizedMergeModes: 0,
       staleAutoFixExperimentTasks: 0,
+      normalizedStaleLaunchMetadata: 0,
     };
     this.runTransaction(() => {
       this.db.run(
@@ -283,6 +285,18 @@ export class SQLiteAdapter implements PersistenceAdapter {
            )`,
       );
       report.staleAutoFixExperimentTasks = this.db.getRowsModified();
+
+      this.db.run(
+        `UPDATE tasks
+         SET launch_phase = NULL,
+             launch_started_at = NULL,
+             launch_completed_at = NULL
+         WHERE status IN ('completed', 'failed', 'needs_input', 'awaiting_approval', 'review_ready', 'stale')
+           AND launch_started_at IS NOT NULL
+           AND started_at IS NOT NULL
+           AND (julianday(started_at) - julianday(launch_started_at)) * 86400.0 > 3600.0`,
+      );
+      report.normalizedStaleLaunchMetadata = this.db.getRowsModified();
     });
     return report;
   }

--- a/scripts/repro/repro-mece-10-stale-launch-metadata.sh
+++ b/scripts/repro/repro-mece-10-stale-launch-metadata.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-mece-10-stale-launch-metadata.sh --expect bug|fixed
+
+What it proves:
+  Persisted terminal tasks whose launchStartedAt predates their real start by
+  hours are compatibility-normalized so old retry-storm rows stop reporting
+  stale launch metadata, while legitimate long executions keep launch timing.
+
+Exit codes:
+  0  observed behavior matches --expect
+  1  observed behavior does not match --expect
+  2  repro setup or assertion was invalid / unexpected
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "bug" && "$EXPECTATION" != "fixed" ]]; then
+  echo "repro: --expect requires bug|fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+cd "$ROOT_DIR"
+
+set +e
+pnpm --filter @invoker/data-store exec vitest run \
+  --reporter verbose \
+  -t "normalizes stale terminal launch metadata without touching legitimate long executions" \
+  src/__tests__/sqlite-adapter.test.ts
+STATUS=$?
+set -e
+
+if [[ "$STATUS" -eq 0 ]]; then
+  OBSERVED="fixed"
+else
+  OBSERVED="bug"
+fi
+
+echo "stale_launch_metadata_exit     : $STATUS"
+echo "stale_launch_metadata_observed : $OBSERVED"
+echo "expected                       : $EXPECTATION"
+
+if [[ "$OBSERVED" != "$EXPECTATION" ]]; then
+  exit 1
+fi
+
+echo "==> repro matched expectation"


### PR DESCRIPTION
## Summary

Normalize stale launch metadata left behind by the May 15 workflow retry storm. Terminal tasks whose launch timestamp predates their actual start by more than an hour now have obsolete launch phase/timestamps cleared during the compatibility migration, while legitimate long-running executions retain their launch timing.

Adds the missing local repro wrapper for `scripts/repro/repro-mece-10-stale-launch-metadata.sh --expect fixed` so this case can be rerun directly.

## Test Plan

- [x] `bash scripts/repro/repro-mece-10-stale-launch-metadata.sh --expect fixed`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/data-store build` *(ESM build succeeded; existing DTS build fails with TS6307 project file-list errors for adapter/sqlite-adapter/conversation-repository/sqlite-task-repository imports)*

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert bcd23f1a`
- Post-revert steps: Restart Invoker so the previous compatibility migration behavior is restored.
- Data migration? Yes. Reverting stops future cleanup of stale launch metadata but does not recreate cleared launch timestamps.
