### PR TITLE
Fix mutation scoped attribution for global top-up tasks

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -845,6 +845,28 @@ describe('POST /api/workflows/:id/recreate-with-rebase', () => {
     );
   });
 
+  it('keeps cross-workflow started tasks out of the scoped recreate-with-rebase runnable result', async () => {
+    const scoped = makeTask({
+      id: 'wf-1/task-a',
+      config: { workflowId: 'wf-1' },
+      execution: { selectedAttemptId: 'attempt-a' },
+    });
+    const crossWorkflow = makeTask({
+      id: 'wf-2/task-b',
+      config: { workflowId: 'wf-2' },
+      execution: { selectedAttemptId: 'attempt-b' },
+    });
+    mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn().mockResolvedValue([scoped, crossWorkflow]);
+    mocks.orchestrator.startExecution.mockReturnValue([]);
+
+    const res = await request(port, 'POST', '/api/workflows/wf-1/recreate-with-rebase');
+
+    expect(res.status).toBe(200);
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
+  });
+
   it('rebase-and-retry still works as deprecated alias', async () => {
     mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn().mockResolvedValue([makeTask()]);
     const res = await request(port, 'POST', '/api/workflows/wf-1/rebase-and-retry');

--- a/packages/app/src/__tests__/global-topup.test.ts
+++ b/packages/app/src/__tests__/global-topup.test.ts
@@ -2,14 +2,19 @@ import { describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
 import { dispatchStartedTasksWithGlobalTopup, executeGlobalTopup, finalizeMutationWithGlobalTopup } from '../global-topup.js';
 
-function makeTask(id: string, status: TaskState['status'], attemptId?: string): TaskState {
+function makeTask(
+  id: string,
+  status: TaskState['status'],
+  attemptId?: string,
+  workflowId = 'wf-1',
+): TaskState {
   return {
     id,
     description: id,
     status,
     dependencies: [],
     createdAt: new Date(),
-    config: {},
+    config: { workflowId },
     execution: {
       ...(attemptId ? { selectedAttemptId: attemptId } : {}),
     },
@@ -24,6 +29,59 @@ async function waitForCondition(condition: () => boolean): Promise<void> {
 }
 
 describe('global-topup helpers', () => {
+  it('keeps cross-workflow prestarted tasks in top-up when a workflow scope is explicit', async () => {
+    const scoped = makeTask('wf-1/task-a', 'running', 'attempt-a', 'wf-1');
+    const crossWorkflow = makeTask('wf-2/task-b', 'running', 'attempt-b', 'wf-2');
+    const orchestrator = {
+      startExecution: vi.fn().mockReturnValue([]),
+    };
+    const taskExecutor = {
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: orchestrator as any,
+      taskExecutor: taskExecutor as any,
+      context: 'test.dispatch-scoped-workflow',
+      started: [scoped, crossWorkflow],
+      scopedWorkflowId: 'wf-1',
+    });
+
+    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
+    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
+    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
+    expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
+    expect(result.runnable).toEqual([scoped]);
+    expect(result.topup).toEqual([crossWorkflow]);
+  });
+
+  it('dedupes scoped and prestarted top-up tasks before additional global top-up', async () => {
+    const scoped = makeTask('wf-1/task-a', 'running', 'attempt-a', 'wf-1');
+    const crossWorkflow = makeTask('wf-2/task-b', 'running', 'attempt-b', 'wf-2');
+    const extraTopup = makeTask('wf-3/task-c', 'running', 'attempt-c', 'wf-3');
+    const orchestrator = {
+      startExecution: vi.fn().mockReturnValue([scoped, crossWorkflow, extraTopup]),
+    };
+    const taskExecutor = {
+      executeTasks: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: orchestrator as any,
+      taskExecutor: taskExecutor as any,
+      context: 'test.dispatch-dedupes-prestarted',
+      started: [scoped, crossWorkflow],
+      scopedWorkflowId: 'wf-1',
+    });
+
+    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(3);
+    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
+    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
+    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(3, [extraTopup]);
+    expect(result.runnable).toEqual([scoped]);
+    expect(result.topup).toEqual([crossWorkflow, extraTopup]);
+  });
+
   it('dispatches scoped started tasks before running global top-up', async () => {
     const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
     const topupTask = makeTask('topup-task', 'running', 'attempt-topup');

--- a/packages/app/src/__tests__/parity-regression.test.ts
+++ b/packages/app/src/__tests__/parity-regression.test.ts
@@ -191,7 +191,7 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
 
   it('all mutations filter non-running tasks from dispatch', async () => {
     // Orchestrator returns a mix of running and pending tasks
-    const mixed = [makeTask({ id: 't1', status: 'running' }), makePendingTask({ id: 't2' })];
+    const mixed = [makeTask({ id: 'task-1', status: 'running' }), makePendingTask({ id: 't2' })];
     (deps.orchestrator as any).retryTask.mockReturnValue(mixed);
     facade = new WorkflowMutationFacade(deps);
 
@@ -199,9 +199,9 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
 
     // Only the running task should be dispatched
     expect(result.runnable).toHaveLength(1);
-    expect(result.runnable[0].id).toBe('t1');
+    expect(result.runnable[0].id).toBe('task-1');
     expect(deps.taskExecutor.executeTasks).toHaveBeenCalledWith([
-      expect.objectContaining({ id: 't1', status: 'running' }),
+      expect.objectContaining({ id: 'task-1', status: 'running' }),
     ]);
   });
 

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -20,6 +20,8 @@ type MutationTopupParams = {
   logger?: Logger;
   context: string;
   started?: TaskState[];
+  scopedWorkflowId?: string;
+  scopedTaskIds?: string[];
   mutationTiming?: WorkflowMutationTiming;
   dispatchMode?: 'await' | 'fire-and-forget';
 };
@@ -46,6 +48,19 @@ function createDispatchBench(
       attemptIds: runnable.map((task) => task.execution.selectedAttemptId ?? null),
     },
   });
+}
+
+function hasExplicitScope(scopedWorkflowId?: string, scopedTaskIds?: string[]): boolean {
+  return !!scopedWorkflowId || !!scopedTaskIds?.length;
+}
+
+function matchesScope(
+  task: TaskState,
+  scopedWorkflowId: string | undefined,
+  scopedTaskIds: Set<string>,
+): boolean {
+  return (!!scopedWorkflowId && task.config.workflowId === scopedWorkflowId)
+    || scopedTaskIds.has(task.id);
 }
 
 function dispatchTasks({
@@ -89,9 +104,46 @@ function dispatchTasks({
     .catch((err) => {
       const message = err instanceof Error ? err.stack ?? err.message : String(err);
       logger?.error(`[global-topup] ${context}: asynchronous task dispatch failed: ${message}`);
-    });
+  });
   bench(`${afterMark}.accepted`);
   return Promise.resolve();
+}
+
+function executeRunnableTasks({
+  taskExecutor,
+  logger,
+  context,
+  runnable,
+  dispatchKind,
+  mutationTiming,
+  spanName,
+  dispatchMode,
+}: {
+  taskExecutor: TaskRunner;
+  logger?: Logger;
+  context: string;
+  runnable: TaskState[];
+  dispatchKind: 'global-topup' | 'scoped';
+  mutationTiming?: WorkflowMutationTiming;
+  spanName: string;
+  dispatchMode: 'await' | 'fire-and-forget';
+}): Promise<void> {
+  const bench = createDispatchBench(logger, context, runnable, dispatchKind);
+  const phasePrefix = dispatchKind === 'scoped'
+    ? 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks'
+    : 'dispatchStartedTasksWithGlobalTopup.prestartedTopupExecuteTasks';
+  return dispatchTasks({
+    taskExecutor,
+    logger,
+    context,
+    runnable,
+    mutationTiming,
+    bench,
+    spanName,
+    beforeMark: `${phasePrefix}.before`,
+    afterMark: `${phasePrefix}.after`,
+    dispatchMode,
+  });
 }
 
 export function isDispatchableLaunch(task: TaskState): boolean {
@@ -174,41 +226,65 @@ export async function dispatchStartedTasksWithGlobalTopup({
   logger,
   context,
   started = [],
+  scopedWorkflowId,
+  scopedTaskIds,
   mutationTiming,
   dispatchMode = mutationTiming ? 'fire-and-forget' : 'await',
 }: MutationTopupParams): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
-  const runnable = started.filter(isDispatchableLaunch);
+  const dispatchable = started.filter(isDispatchableLaunch);
+  const scopedTaskIdSet = new Set(scopedTaskIds ?? []);
+  const useScope = hasExplicitScope(scopedWorkflowId, scopedTaskIds);
+  const runnable = useScope
+    ? dispatchable.filter((task) => matchesScope(task, scopedWorkflowId, scopedTaskIdSet))
+    : dispatchable;
+  const prestartedTopup = useScope
+    ? dispatchable.filter((task) => !matchesScope(task, scopedWorkflowId, scopedTaskIdSet))
+    : [];
   const bench = createDispatchBench(logger, context, runnable, 'scoped');
   bench('dispatchStartedTasksWithGlobalTopup.runnableFiltered', { startedCount: started.length });
   if (runnable.length > 0) {
     logger?.info(
       `[global-topup] ${context}: dispatching ${runnable.length} scoped task(s): [${runnable.map((task) => task.id).join(', ')}]`,
     );
-    await dispatchTasks({
+    await executeRunnableTasks({
       taskExecutor,
       logger,
       context,
       runnable,
+      dispatchKind: 'scoped',
       mutationTiming,
-      bench,
       spanName: 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks',
-      beforeMark: 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.before',
-      afterMark: 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.after',
       dispatchMode,
     });
   } else {
     bench('dispatchStartedTasksWithGlobalTopup.noScopedRunnable');
   }
+  if (prestartedTopup.length > 0) {
+    logger?.info(
+      `[global-topup] ${context}: dispatching ${prestartedTopup.length} prestarted top-up task(s): [${prestartedTopup.map((task) => task.id).join(', ')}]`,
+    );
+    await executeRunnableTasks({
+      taskExecutor,
+      logger,
+      context,
+      runnable: prestartedTopup,
+      dispatchKind: 'global-topup',
+      mutationTiming,
+      spanName: 'dispatchStartedTasksWithGlobalTopup.prestartedTopupExecuteTasks',
+      dispatchMode,
+    });
+  }
   bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.before');
-  const topup = await executeGlobalTopup({
+  const additionalTopup = await executeGlobalTopup({
     orchestrator,
     taskExecutor,
     logger,
     context,
-    alreadyDispatched: runnable,
+    alreadyDispatched: [...runnable, ...prestartedTopup],
     mutationTiming,
     dispatchMode,
   });
+  const topup = [...prestartedTopup, ...additionalTopup];
   bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.after', { topupCount: topup.length });
   return { runnable, topup };
 }
@@ -224,6 +300,8 @@ export async function finalizeMutationWithGlobalTopup({
   logger,
   context,
   started = [],
+  scopedWorkflowId,
+  scopedTaskIds,
   mutationTiming,
   dispatchMode,
 }: MutationTopupParams): Promise<{ started: TaskState[]; topup: TaskState[] }> {
@@ -233,6 +311,8 @@ export async function finalizeMutationWithGlobalTopup({
     logger,
     context,
     started,
+    scopedWorkflowId,
+    scopedTaskIds,
     mutationTiming,
     dispatchMode,
   });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1403,6 +1403,7 @@ async function headlessApprove(taskId: string, deps: HeadlessDeps): Promise<void
       context: 'headless.approve',
       started,
       mutationTiming: deps.mutationTiming,
+      scopedTaskIds: [taskId],
     });
     process.stdout.write(`Approved task: ${taskId}\n`);
     if (deps.noTrack) {
@@ -1517,6 +1518,7 @@ async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<vo
       logger: deps.logger,
       context: 'headless.restart-task',
       started: result.data,
+      scopedTaskIds: [taskId],
       mutationTiming: deps.mutationTiming,
     });
     if (runnable.length + topup.length === 0) {
@@ -1561,6 +1563,9 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
       context: 'headless.fix-with-agent',
       started: result.started,
       mutationTiming: deps.mutationTiming,
+      ...(result.kind === 'recreateWorkflowFromFreshBase'
+        ? { scopedWorkflowId: result.workflowId }
+        : { scopedTaskIds: [taskId] }),
     });
     if (result.kind === 'recreateWorkflowFromFreshBase') {
       process.stdout.write(
@@ -1609,6 +1614,7 @@ async function headlessResolveConflict(taskId: string, deps: HeadlessDeps, agent
       context: 'headless.resolve-conflict',
       started: result.started,
       mutationTiming: deps.mutationTiming,
+      scopedTaskIds: [taskId],
     });
     process.stdout.write(
       deps.invokerConfig.autoApproveAIFixes
@@ -1653,6 +1659,7 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
     logger: deps.logger,
     context: 'headless.rebase-and-retry',
     started,
+    scopedWorkflowId: workflowId,
     mutationTiming: deps.mutationTiming,
   });
   if (runnable.length + topup.length === 0) {
@@ -1696,6 +1703,7 @@ async function headlessRecreateWithRebase(workflowTarget: string, deps: Headless
     logger: deps.logger,
     context: 'headless.recreate-with-rebase',
     started,
+    scopedWorkflowId: workflowId,
     mutationTiming: deps.mutationTiming,
   });
   if (runnable.length + topup.length === 0) {
@@ -1857,6 +1865,7 @@ async function headlessForkWorkflow(
     logger: deps.logger,
     context: 'headless.fork-workflow',
     started: result.started,
+    scopedWorkflowId: result.forkedWorkflowId,
   });
   process.stdout.write(
     `Forked workflow ${result.sourceWorkflowId} → ${result.forkedWorkflowId}; ` +
@@ -1973,6 +1982,7 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
       logger: deps.logger,
       context: 'headless.retry-workflow',
       started: dispatchable,
+      scopedWorkflowId: workflowId,
       mutationTiming: deps.mutationTiming,
     }));
   } finally {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -810,6 +810,7 @@ if (isHeadless) {
               logger,
               context: 'standalone.set-merge-branch',
               started,
+              scopedTaskIds: [mergeTask.id],
             });
             return undefined;
           }
@@ -3085,6 +3086,7 @@ if (isHeadless) {
         context: 'ipc.approve',
         started,
         mutationTiming: activeMutationContext?.mutationTiming,
+        scopedTaskIds: [taskId],
       });
       },
     );
@@ -3157,6 +3159,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.restart-task',
           started,
+          scopedTaskIds: [taskId],
         });
       } catch (err) {
         logger.error(`restart-task failed: ${err}`, { module: 'ipc' });
@@ -3304,6 +3307,7 @@ if (isHeadless) {
             logger,
             context: 'ipc.recreate-workflow',
             started,
+            scopedWorkflowId: workflowId,
             mutationTiming: activeMutationContext?.mutationTiming,
           });
         } finally {
@@ -3348,6 +3352,7 @@ if (isHeadless) {
             logger,
             context: 'ipc.recreate-task',
             started,
+            scopedTaskIds: [taskId],
             mutationTiming: activeMutationContext?.mutationTiming,
           });
         } finally {
@@ -3392,6 +3397,7 @@ if (isHeadless) {
             logger,
             context: 'ipc.retry-workflow',
             started: result.data,
+            scopedWorkflowId: workflowId,
             mutationTiming: activeMutationContext?.mutationTiming,
           });
         } finally {
@@ -3434,6 +3440,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.rebase-and-retry',
           started,
+          ...(workflowId ? { scopedWorkflowId: workflowId } : { scopedTaskIds: [taskId] }),
           mutationTiming: activeMutationContext?.mutationTiming,
         });
       } catch (err) {
@@ -3474,6 +3481,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.recreate-with-rebase',
           started,
+          scopedWorkflowId: workflowId,
           mutationTiming: activeMutationContext?.mutationTiming,
         });
       } catch (err) {
@@ -3500,6 +3508,7 @@ if (isHeadless) {
             logger,
             context: 'ipc.set-merge-branch',
             started,
+            scopedTaskIds: [mergeTask.id],
           });
         }
       } catch (err) {
@@ -3546,6 +3555,7 @@ if (isHeadless) {
           context: 'ipc.approve-merge',
           started,
           mutationTiming: activeMutationContext?.mutationTiming,
+          scopedWorkflowId: workflowId,
         });
       } catch (err) {
         logger.error(`approve-merge failed: ${err}`, { module: 'ipc' });
@@ -3594,6 +3604,7 @@ if (isHeadless) {
           context: 'ipc.resolve-conflict',
           started: result.started,
           mutationTiming: activeMutationContext?.mutationTiming,
+          scopedTaskIds: [taskId],
         });
       } catch (err) {
         await finalizeMutationWithGlobalTopup({
@@ -3625,6 +3636,7 @@ if (isHeadless) {
           context: 'ipc.fix-with-agent',
           started,
           mutationTiming: activeMutationContext?.mutationTiming,
+          scopedTaskIds: [taskId],
         });
       } catch (err) {
         await finalizeMutationWithGlobalTopup({
@@ -3654,6 +3666,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.edit-task-command',
           started: result.data,
+          scopedTaskIds: [taskId],
         });
       } catch (err) {
         logger.error(`edit-task-command failed: ${err}`, { module: 'ipc' });
@@ -3675,6 +3688,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.edit-task-prompt',
           started: result.data,
+          scopedTaskIds: [taskId],
         });
       } catch (err) {
         logger.error(`edit-task-prompt failed: ${err}`, { module: 'ipc' });
@@ -3697,6 +3711,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.edit-task-type',
           started: result.data,
+          scopedTaskIds: [taskId],
         });
       } catch (err) {
         logger.error(`edit-task-type failed: ${err}`, { module: 'ipc' });
@@ -3718,6 +3733,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.edit-task-pool',
           started: result.data,
+          scopedTaskIds: [taskId],
         });
       } catch (err) {
         logger.error(`edit-task-pool failed: ${err}`, { module: 'ipc' });
@@ -3739,6 +3755,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.edit-task-agent',
           started: result.data,
+          scopedTaskIds: [taskId],
         });
       } catch (err) {
         logger.error(`edit-task-agent failed: ${err}`, { module: 'ipc' });
@@ -3762,6 +3779,7 @@ if (isHeadless) {
             logger,
             context: 'ipc.set-task-external-gate-policies',
             started: result.data,
+            scopedTaskIds: [taskId],
           });
         } catch (err) {
           logger.error(`set-task-external-gate-policies failed: ${err}`, { module: 'ipc' });
@@ -3813,6 +3831,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.replace-task',
           started: result.data,
+          scopedTaskIds: [taskId, ...result.data.map((task) => task.id)],
         });
         return result.data;
       } catch (err) {

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -89,6 +89,11 @@ export interface ResolveConflictMutationResult extends MutationResult {
   autoApproved: boolean;
 }
 
+type DispatchScope = {
+  scopedWorkflowId?: string;
+  scopedTaskIds?: string[];
+};
+
 // ── Facade deps ──────────────────────────────────────────────
 
 export interface WorkflowMutationFacadeDeps {
@@ -119,6 +124,7 @@ export class WorkflowMutationFacade {
     const { runnable, topup } = await this.dispatchWithTopup(
       result.started,
       'facade.approve-task',
+      { scopedTaskIds: [taskId] },
     );
     return {
       approvedTask: result.approvedTask,
@@ -139,7 +145,7 @@ export class WorkflowMutationFacade {
 
   async retryTask(taskId: string): Promise<MutationResult> {
     const started = sharedRetryTask(taskId, { orchestrator: this.deps.orchestrator });
-    return this.finalizeWithTopup(started, 'facade.retry-task');
+    return this.finalizeWithTopup(started, 'facade.retry-task', { scopedTaskIds: [taskId] });
   }
 
   async recreateTask(taskId: string): Promise<MutationResult> {
@@ -147,14 +153,14 @@ export class WorkflowMutationFacade {
       orchestrator: this.deps.orchestrator,
       persistence: this.deps.persistence,
     });
-    return this.finalizeWithTopup(started, 'facade.recreate-task');
+    return this.finalizeWithTopup(started, 'facade.recreate-task', { scopedTaskIds: [taskId] });
   }
 
   async selectExperiment(taskId: string, experimentId: string): Promise<MutationResult> {
     const started = sharedSelectExperiment(taskId, experimentId, {
       orchestrator: this.deps.orchestrator,
     });
-    return this.finalizeWithTopup(started, 'facade.select-experiment');
+    return this.finalizeWithTopup(started, 'facade.select-experiment', { scopedTaskIds: [taskId] });
   }
 
   async selectExperiments(taskId: string, experimentIds: string[]): Promise<MutationResult> {
@@ -162,21 +168,21 @@ export class WorkflowMutationFacade {
       orchestrator: this.deps.orchestrator,
       taskExecutor: this.deps.taskExecutor,
     });
-    return this.finalizeWithTopup(started, 'facade.select-experiments');
+    return this.finalizeWithTopup(started, 'facade.select-experiments', { scopedTaskIds: [taskId] });
   }
 
   async editTaskCommand(taskId: string, newCommand: string): Promise<MutationResult> {
     const started = sharedEditTaskCommand(taskId, newCommand, {
       orchestrator: this.deps.orchestrator,
     });
-    return this.finalizeWithTopup(started, 'facade.edit-task-command');
+    return this.finalizeWithTopup(started, 'facade.edit-task-command', { scopedTaskIds: [taskId] });
   }
 
   async editTaskPrompt(taskId: string, newPrompt: string): Promise<MutationResult> {
     const started = sharedEditTaskPrompt(taskId, newPrompt, {
       orchestrator: this.deps.orchestrator,
     });
-    return this.finalizeWithTopup(started, 'facade.edit-task-prompt');
+    return this.finalizeWithTopup(started, 'facade.edit-task-prompt', { scopedTaskIds: [taskId] });
   }
 
   async editTaskType(
@@ -190,14 +196,14 @@ export class WorkflowMutationFacade {
       { orchestrator: this.deps.orchestrator },
       poolMemberId,
     );
-    return this.finalizeWithTopup(started, 'facade.edit-task-type');
+    return this.finalizeWithTopup(started, 'facade.edit-task-type', { scopedTaskIds: [taskId] });
   }
 
   async editTaskAgent(taskId: string, agentName: string): Promise<MutationResult> {
     const started = sharedEditTaskAgent(taskId, agentName, {
       orchestrator: this.deps.orchestrator,
     });
-    return this.finalizeWithTopup(started, 'facade.edit-task-agent');
+    return this.finalizeWithTopup(started, 'facade.edit-task-agent', { scopedTaskIds: [taskId] });
   }
 
   async setTaskExternalGatePolicies(
@@ -207,7 +213,7 @@ export class WorkflowMutationFacade {
     const started = sharedSetTaskExternalGatePolicies(taskId, updates, {
       orchestrator: this.deps.orchestrator,
     });
-    return this.finalizeWithTopup(started, 'facade.set-gate-policy');
+    return this.finalizeWithTopup(started, 'facade.set-gate-policy', { scopedTaskIds: [taskId] });
   }
 
   async cancelTask(taskId: string): Promise<CancelMutationResult> {
@@ -227,7 +233,7 @@ export class WorkflowMutationFacade {
     const started = sharedRetryWorkflow(workflowId, {
       orchestrator: this.deps.orchestrator,
     });
-    return this.finalizeWithTopup(started, 'facade.retry-workflow');
+    return this.finalizeWithTopup(started, 'facade.retry-workflow', { scopedWorkflowId: workflowId });
   }
 
   async recreateWorkflow(workflowId: string): Promise<MutationResult> {
@@ -236,22 +242,27 @@ export class WorkflowMutationFacade {
       persistence: this.deps.persistence,
       orchestrator: this.deps.orchestrator,
     });
-    return this.finalizeWithTopup(started, 'facade.recreate-workflow');
+    return this.finalizeWithTopup(started, 'facade.recreate-workflow', { scopedWorkflowId: workflowId });
   }
 
   async recreateWorkflowFromFreshBase(workflowId: string): Promise<MutationResult> {
     const started = await sharedRecreateWorkflowFromFreshBase(workflowId, this.actionDeps());
-    return this.finalizeWithTopup(started, 'facade.recreate-from-fresh-base');
+    return this.finalizeWithTopup(started, 'facade.recreate-from-fresh-base', { scopedWorkflowId: workflowId });
   }
 
   async recreateWithRebase(workflowId: string): Promise<MutationResult> {
     const started = await sharedRecreateWithRebase(workflowId, this.actionDeps());
-    return this.finalizeWithTopup(started, 'facade.recreate-with-rebase');
+    return this.finalizeWithTopup(started, 'facade.recreate-with-rebase', { scopedWorkflowId: workflowId });
   }
 
   async rebaseAndRetry(taskId: string): Promise<MutationResult> {
+    const workflowId = this.deps.orchestrator.getTask(taskId)?.config.workflowId;
     const started = await sharedRebaseAndRetry(taskId, this.actionDeps());
-    return this.finalizeWithTopup(started, 'facade.rebase-and-retry');
+    return this.finalizeWithTopup(
+      started,
+      'facade.rebase-and-retry',
+      workflowId ? { scopedWorkflowId: workflowId } : { scopedTaskIds: [taskId] },
+    );
   }
 
   async cancelWorkflow(workflowId: string): Promise<CancelMutationResult> {
@@ -339,6 +350,7 @@ export class WorkflowMutationFacade {
     const { runnable, topup } = await this.dispatchWithTopup(
       result.started,
       'facade.resolve-conflict',
+      { scopedTaskIds: [taskId] },
     );
     return {
       autoApproved: result.autoApproved,
@@ -374,6 +386,9 @@ export class WorkflowMutationFacade {
     const { runnable, topup } = await this.dispatchWithTopup(
       started,
       'facade.fix-with-agent',
+      detail.kind === 'recreateWorkflowFromFreshBase'
+        ? { scopedWorkflowId: detail.workflowId }
+        : { scopedTaskIds: [taskId] },
     );
     return { detail, started, runnable, topup };
   }
@@ -393,6 +408,7 @@ export class WorkflowMutationFacade {
   private async dispatchWithTopup(
     started: TaskState[],
     context: string,
+    scope: DispatchScope = {},
   ): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
     return dispatchStartedTasksWithGlobalTopup({
       orchestrator: this.deps.orchestrator,
@@ -401,14 +417,16 @@ export class WorkflowMutationFacade {
       context,
       started,
       dispatchMode: this.deps.dispatchMode,
+      ...scope,
     });
   }
 
   private async finalizeWithTopup(
     started: TaskState[],
     context: string,
+    scope: DispatchScope = {},
   ): Promise<MutationResult> {
-    const { runnable, topup } = await this.dispatchWithTopup(started, context);
+    const { runnable, topup } = await this.dispatchWithTopup(started, context, scope);
     return { started, runnable, topup };
   }
 


### PR DESCRIPTION
## Summary

Mutation dispatch now separates explicitly scoped mutation work from cross-workflow work that was prestarted by scheduler top-up. Cross-workflow tasks may still start during mutation drain, but they are returned and logged as global top-up instead of being attributed to the active workflow's scoped runnable set.

## Architecture

### Before

```mermaid
flowchart TD
  A[Mutation returns started tasks] --> B[Filter dispatchable]
  B --> C[All started tasks become scoped runnable]
  C --> D[Execute scoped runnable]
  D --> E[startExecution global top-up]
```

### After

```mermaid
flowchart TD
  A[Mutation returns started tasks] --> B[Filter dispatchable]
  B --> C{Explicit scope?}
  C -->|No| D[Legacy: all started tasks scoped]
  C -->|Yes| E[Matching tasks scoped runnable]
  C -->|Yes| F[Out-of-scope started tasks top-up]
  E --> G[Execute scoped attribution]
  F --> H[Execute global top-up attribution]
  G --> I[startExecution with scoped and prestarted top-up dedupe]
  H --> I
```

## Test Plan

- [x] `pnpm install --offline`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/global-topup.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/api-server.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/parity-regression.test.ts`
- [x] `pnpm --filter @invoker/app build`
- [x] `scripts/test-suites/required/24-start-running-mece-repros.sh`
- [x] `pnpm --filter @invoker/app test -- global-topup`

`scripts/repro/repro-mece-08-mutation-wrapper-over-attribution.sh` is not present on this branch, so `scripts/test-suites/required/24-start-running-mece-repros.sh` was used as the closest committed start-running MECE repro suite.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0dd90cb7`
- Post-revert steps: None
- Data migration? No
