### PR TITLE
Fix workflow mutation lock held during task dispatch

### DIFF
--- a/packages/app/src/__tests__/global-topup.test.ts
+++ b/packages/app/src/__tests__/global-topup.test.ts
@@ -16,6 +16,13 @@ function makeTask(id: string, status: TaskState['status'], attemptId?: string): 
   } as TaskState;
 }
 
+async function waitForCondition(condition: () => boolean): Promise<void> {
+  for (let i = 0; i < 20; i += 1) {
+    if (condition()) return;
+    await Promise.resolve();
+  }
+}
+
 describe('global-topup helpers', () => {
   it('dispatches scoped started tasks before running global top-up', async () => {
     const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
@@ -40,6 +47,77 @@ describe('global-topup helpers', () => {
     expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
     expect(result.runnable).toEqual([scoped]);
     expect(result.topup).toEqual([topupTask]);
+  });
+
+  it('awaited dispatch waits for executeTasks to finish', async () => {
+    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
+    const release = vi.fn();
+    let resolveDispatch!: () => void;
+    const taskExecutor = {
+      executeTasks: vi.fn(() => new Promise<void>((resolve) => {
+        resolveDispatch = () => {
+          release();
+          resolve();
+        };
+      })),
+    };
+    const dispatch = dispatchStartedTasksWithGlobalTopup({
+      orchestrator: { startExecution: vi.fn().mockReturnValue([]) } as any,
+      taskExecutor: taskExecutor as any,
+      context: 'test.awaited-dispatch',
+      started: [scoped],
+    });
+
+    await Promise.resolve();
+    let completed = false;
+    void dispatch.then(() => { completed = true; });
+    await Promise.resolve();
+
+    expect(completed).toBe(false);
+    resolveDispatch();
+    await dispatch;
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it('fire-and-forget dispatch returns before executeTasks finishes', async () => {
+    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
+    const taskExecutor = {
+      executeTasks: vi.fn(() => new Promise<void>(() => {})),
+    };
+
+    const result = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: { startExecution: vi.fn().mockReturnValue([]) } as any,
+      taskExecutor: taskExecutor as any,
+      context: 'test.fire-and-forget-dispatch',
+      started: [scoped],
+      dispatchMode: 'fire-and-forget',
+    });
+
+    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([scoped]);
+    expect(result.runnable).toEqual([scoped]);
+    expect(result.topup).toEqual([]);
+  });
+
+  it('fire-and-forget dispatch logs asynchronous executeTasks rejection', async () => {
+    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
+    const logger = { error: vi.fn(), info: vi.fn() };
+    const taskExecutor = {
+      executeTasks: vi.fn().mockRejectedValue(new Error('dispatch failed')),
+    };
+
+    await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: { startExecution: vi.fn().mockReturnValue([]) } as any,
+      taskExecutor: taskExecutor as any,
+      logger: logger as any,
+      context: 'test.fire-and-forget-rejection',
+      started: [scoped],
+      dispatchMode: 'fire-and-forget',
+    });
+
+    await waitForCondition(() => logger.error.mock.calls.length > 0);
+    expect(logger.error).toHaveBeenCalledWith(
+      expect.stringContaining('asynchronous task dispatch failed'),
+    );
   });
 
   it('executeGlobalTopup skips tasks already marked as dispatched', async () => {

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { SQLiteAdapter } from '@invoker/data-store';
 import { PersistedWorkflowMutationCoordinator, type WorkflowMutationContext } from '../persisted-workflow-mutation-coordinator.js';
+import { dispatchStartedTasksWithGlobalTopup } from '../global-topup.js';
 
 function deferred(): { promise: Promise<void>; resolve: () => void } {
   let resolve = () => {};
@@ -60,6 +61,58 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await queuedNormal;
 
     expect(order).toEqual(['mut:running-normal', 'mut:queued-high', 'mut:queued-normal']);
+  });
+
+  it('releases a workflow lease after fire-and-forget task launch acceptance', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const startedTask = {
+      id: 'task-a',
+      description: 'task-a',
+      status: 'running',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { workflowId: 'wf-1' },
+      execution: { selectedAttemptId: 'attempt-a' },
+    };
+    const order: string[] = [];
+    const taskExecutor = {
+      executeTasks: async () => new Promise<void>(() => {}),
+    };
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (channel) => {
+        order.push(channel);
+        if (channel === 'first') {
+          await dispatchStartedTasksWithGlobalTopup({
+            orchestrator: { startExecution: () => [] } as any,
+            taskExecutor: taskExecutor as any,
+            context: 'test.workflow-mutation-lease',
+            started: [startedTask as any],
+            dispatchMode: 'fire-and-forget',
+          });
+        }
+      },
+    );
+
+    const first = coordinator.enqueue<void>('wf-1', 'normal', 'first', []);
+    await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['completed']).length === 1);
+    const second = coordinator.enqueue<void>('wf-1', 'normal', 'second', []);
+
+    await first;
+    await second;
+
+    expect(order).toEqual(['first', 'second']);
+    expect(adapter.listWorkflowMutationLeases()).toHaveLength(0);
   });
 
   it('evicts older queued workflow intents when a delegated recreate fence starts', async () => {

--- a/packages/app/src/__tests__/workflow-mutation-facade.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-facade.test.ts
@@ -298,5 +298,22 @@ describe('WorkflowMutationFacade', () => {
       expect(deps.orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
       expect(result.started).toHaveLength(1);
     });
+
+    it('can return after launch acceptance without waiting for task runtime', async () => {
+      deps = makeDeps({
+        dispatchMode: 'fire-and-forget',
+        taskExecutor: {
+          executeTasks: vi.fn(() => new Promise<void>(() => {})),
+          killActiveExecution: vi.fn(),
+        } as unknown as TaskRunner,
+      });
+      facade = new WorkflowMutationFacade(deps);
+
+      const result = await facade.retryWorkflow('wf-1');
+
+      expect(result.started).toHaveLength(1);
+      expect(result.runnable).toHaveLength(1);
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -11,6 +11,7 @@ type GlobalTopupParams = {
   context: string;
   alreadyDispatched?: TaskState[];
   mutationTiming?: WorkflowMutationTiming;
+  dispatchMode?: 'await' | 'fire-and-forget';
 };
 
 type MutationTopupParams = {
@@ -20,6 +21,7 @@ type MutationTopupParams = {
   context: string;
   started?: TaskState[];
   mutationTiming?: WorkflowMutationTiming;
+  dispatchMode?: 'await' | 'fire-and-forget';
 };
 
 function runningExecutionKey(task: TaskState): string {
@@ -46,6 +48,52 @@ function createDispatchBench(
   });
 }
 
+function dispatchTasks({
+  taskExecutor,
+  logger,
+  context,
+  runnable,
+  mutationTiming,
+  bench,
+  spanName,
+  beforeMark,
+  afterMark,
+  dispatchMode,
+}: {
+  taskExecutor: TaskRunner;
+  logger?: Logger;
+  context: string;
+  runnable: TaskState[];
+  mutationTiming?: WorkflowMutationTiming;
+  bench: (phase: string, metadata?: Record<string, unknown>) => void;
+  spanName: string;
+  beforeMark: string;
+  afterMark: string;
+  dispatchMode: 'await' | 'fire-and-forget';
+}): Promise<void> {
+  bench(beforeMark);
+  const run = () => taskExecutor.executeTasks(runnable);
+  if (dispatchMode === 'await') {
+    return mutationTiming
+      ? mutationTiming.span(spanName, { context, runnableCount: runnable.length }, run)
+        .then(() => bench(afterMark))
+      : Promise.resolve().then(run).then(() => bench(afterMark));
+  }
+
+  // TODO: replace app-level workflow mutation leases with atomic DB state transitions plus an outbox for launch/cancel side effects.
+  const dispatchPromise = mutationTiming
+    ? mutationTiming.span(spanName, { context, runnableCount: runnable.length }, run)
+    : Promise.resolve().then(run);
+  void dispatchPromise
+    .then(() => bench(afterMark))
+    .catch((err) => {
+      const message = err instanceof Error ? err.stack ?? err.message : String(err);
+      logger?.error(`[global-topup] ${context}: asynchronous task dispatch failed: ${message}`);
+    });
+  bench(`${afterMark}.accepted`);
+  return Promise.resolve();
+}
+
 export function isDispatchableLaunch(task: TaskState): boolean {
   return task.status === 'running'
     || (
@@ -67,6 +115,7 @@ export async function executeGlobalTopup({
   context,
   alreadyDispatched = [],
   mutationTiming,
+  dispatchMode = mutationTiming ? 'fire-and-forget' : 'await',
 }: GlobalTopupParams): Promise<TaskState[]> {
   const dedupeKeys = new Set(
     alreadyDispatched
@@ -100,19 +149,18 @@ export async function executeGlobalTopup({
   logger?.info(
     `[global-topup] ${context}: dispatching ${runnable.length} additional task(s): [${runnable.map((task) => task.id).join(', ')}]`,
   );
-  if (mutationTiming) {
-    bench('executeGlobalTopup.taskExecutor.executeTasks.before');
-    await mutationTiming.span(
-      'executeGlobalTopup.taskExecutor.executeTasks',
-      { context, runnableCount: runnable.length },
-      () => taskExecutor.executeTasks(runnable),
-    );
-    bench('executeGlobalTopup.taskExecutor.executeTasks.after');
-  } else {
-    bench('executeGlobalTopup.taskExecutor.executeTasks.before');
-    await taskExecutor.executeTasks(runnable);
-    bench('executeGlobalTopup.taskExecutor.executeTasks.after');
-  }
+  await dispatchTasks({
+    taskExecutor,
+    logger,
+    context,
+    runnable,
+    mutationTiming,
+    bench,
+    spanName: 'executeGlobalTopup.taskExecutor.executeTasks',
+    beforeMark: 'executeGlobalTopup.taskExecutor.executeTasks.before',
+    afterMark: 'executeGlobalTopup.taskExecutor.executeTasks.after',
+    dispatchMode,
+  });
   return runnable;
 }
 
@@ -127,6 +175,7 @@ export async function dispatchStartedTasksWithGlobalTopup({
   context,
   started = [],
   mutationTiming,
+  dispatchMode = mutationTiming ? 'fire-and-forget' : 'await',
 }: MutationTopupParams): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
   const runnable = started.filter(isDispatchableLaunch);
   const bench = createDispatchBench(logger, context, runnable, 'scoped');
@@ -135,19 +184,18 @@ export async function dispatchStartedTasksWithGlobalTopup({
     logger?.info(
       `[global-topup] ${context}: dispatching ${runnable.length} scoped task(s): [${runnable.map((task) => task.id).join(', ')}]`,
     );
-    if (mutationTiming) {
-      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.before');
-      await mutationTiming.span(
-        'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks',
-        { context, runnableCount: runnable.length },
-        () => taskExecutor.executeTasks(runnable),
-      );
-      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.after');
-    } else {
-      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.before');
-      await taskExecutor.executeTasks(runnable);
-      bench('dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.after');
-    }
+    await dispatchTasks({
+      taskExecutor,
+      logger,
+      context,
+      runnable,
+      mutationTiming,
+      bench,
+      spanName: 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks',
+      beforeMark: 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.before',
+      afterMark: 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks.after',
+      dispatchMode,
+    });
   } else {
     bench('dispatchStartedTasksWithGlobalTopup.noScopedRunnable');
   }
@@ -159,6 +207,7 @@ export async function dispatchStartedTasksWithGlobalTopup({
     context,
     alreadyDispatched: runnable,
     mutationTiming,
+    dispatchMode,
   });
   bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.after', { topupCount: topup.length });
   return { runnable, topup };
@@ -176,6 +225,7 @@ export async function finalizeMutationWithGlobalTopup({
   context,
   started = [],
   mutationTiming,
+  dispatchMode,
 }: MutationTopupParams): Promise<{ started: TaskState[]; topup: TaskState[] }> {
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator,
@@ -184,6 +234,7 @@ export async function finalizeMutationWithGlobalTopup({
     context,
     started,
     mutationTiming,
+    dispatchMode,
   });
   return { started, topup };
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -131,6 +131,7 @@ function buildHeadlessApiServerDeps(
       orchestrator: deps.orchestrator,
       persistence: deps.persistence,
       taskExecutor,
+      dispatchMode: deps.mutationTiming ? 'fire-and-forget' : 'await',
       autoApproveAIFixes: deps.invokerConfig?.autoApproveAIFixes,
       killRunningTask: (taskId: string) => taskExecutor.killActiveExecution(taskId),
     }),
@@ -1401,6 +1402,7 @@ async function headlessApprove(taskId: string, deps: HeadlessDeps): Promise<void
       logger: deps.logger,
       context: 'headless.approve',
       started,
+      mutationTiming: deps.mutationTiming,
     });
     process.stdout.write(`Approved task: ${taskId}\n`);
     if (deps.noTrack) {
@@ -1558,6 +1560,7 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
       logger: deps.logger,
       context: 'headless.fix-with-agent',
       started: result.started,
+      mutationTiming: deps.mutationTiming,
     });
     if (result.kind === 'recreateWorkflowFromFreshBase') {
       process.stdout.write(
@@ -1576,6 +1579,7 @@ async function headlessFix(taskId: string, deps: HeadlessDeps, agentArg?: string
       taskExecutor: te,
       logger: deps.logger,
       context: 'headless.fix-with-agent.failure',
+      mutationTiming: deps.mutationTiming,
     });
     throw err;
   } finally {
@@ -1604,6 +1608,7 @@ async function headlessResolveConflict(taskId: string, deps: HeadlessDeps, agent
       logger: deps.logger,
       context: 'headless.resolve-conflict',
       started: result.started,
+      mutationTiming: deps.mutationTiming,
     });
     process.stdout.write(
       deps.invokerConfig.autoApproveAIFixes
@@ -1616,6 +1621,7 @@ async function headlessResolveConflict(taskId: string, deps: HeadlessDeps, agent
       taskExecutor: te,
       logger: deps.logger,
       context: 'headless.resolve-conflict.failure',
+      mutationTiming: deps.mutationTiming,
     });
     throw err;
   } finally {
@@ -2359,6 +2365,7 @@ async function headlessCancel(taskId: string, deps: HeadlessDeps): Promise<void>
       taskExecutor: te,
       logger: deps.logger,
       context: 'headless.cancel-task',
+      mutationTiming: deps.mutationTiming,
     });
     process.stdout.write(`Cancelled ${cmdResult.data.cancelled.length} task(s): [${cmdResult.data.cancelled.join(', ')}]\n`);
     if (cmdResult.data.runningCancelled.length > 0) {
@@ -2413,6 +2420,7 @@ async function headlessCancelWorkflow(workflowId: string, deps: HeadlessDeps): P
     taskExecutor: te,
     logger: deps.logger,
     context: 'headless.cancel-workflow',
+    mutationTiming: deps.mutationTiming,
   });
   process.stdout.write(`Cancelled ${result.cancelled.length} task(s) in workflow "${workflowId}": [${result.cancelled.join(', ')}]\n`);
   if (result.runningCancelled.length > 0) {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3089,6 +3089,7 @@ if (isHeadless) {
         logger,
         context: 'ipc.approve',
         started,
+        mutationTiming: activeMutationContext?.mutationTiming,
       });
       },
     );
@@ -3183,6 +3184,7 @@ if (isHeadless) {
           taskExecutor: requireTaskExecutor(),
           logger,
           context: 'ipc.cancel-task',
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
         return result;
       } catch (err) {
@@ -3204,12 +3206,14 @@ if (isHeadless) {
           preemptWorkflowExecution,
           logger,
           context: 'ipc.cancel-workflow',
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
         await finalizeMutationWithGlobalTopup({
           orchestrator,
           taskExecutor: requireTaskExecutor(),
           logger,
           context: 'ipc.cancel-workflow',
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
         return result;
       } catch (err) {
@@ -3546,6 +3550,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.approve-merge',
           started,
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
       } catch (err) {
         logger.error(`approve-merge failed: ${err}`, { module: 'ipc' });
@@ -3593,6 +3598,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.resolve-conflict',
           started: result.started,
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
       } catch (err) {
         await finalizeMutationWithGlobalTopup({
@@ -3600,6 +3606,7 @@ if (isHeadless) {
           taskExecutor: requireTaskExecutor(),
           logger,
           context: 'ipc.resolve-conflict.failure',
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
         logger.error(`resolve-conflict failed: ${err}`, { module: 'ipc' });
         throw err;
@@ -3622,6 +3629,7 @@ if (isHeadless) {
           logger,
           context: 'ipc.fix-with-agent',
           started,
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
       } catch (err) {
         await finalizeMutationWithGlobalTopup({
@@ -3629,6 +3637,7 @@ if (isHeadless) {
           taskExecutor: requireTaskExecutor(),
           logger,
           context: 'ipc.fix-with-agent.failure',
+          mutationTiming: activeMutationContext?.mutationTiming,
         });
         logger.error(`fix-with-agent failed: ${err}`, { module: 'ipc' });
         throw err;

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -96,6 +96,7 @@ export interface WorkflowMutationFacadeDeps {
   orchestrator: Orchestrator;
   persistence: SQLiteAdapter;
   taskExecutor: TaskRunner;
+  dispatchMode?: 'await' | 'fire-and-forget';
   autoApproveAIFixes?: boolean;
   /** Optional pre-kill hook for active task executions. */
   killRunningTask?: (taskId: string) => Promise<void>;
@@ -399,6 +400,7 @@ export class WorkflowMutationFacade {
       logger: this.deps.logger,
       context,
       started,
+      dispatchMode: this.deps.dispatchMode,
     });
   }
 
@@ -416,6 +418,7 @@ export class WorkflowMutationFacade {
       taskExecutor: this.deps.taskExecutor,
       logger: this.deps.logger,
       context,
+      dispatchMode: this.deps.dispatchMode,
     });
   }
 }


### PR DESCRIPTION
## Summary

Keep workflow mutation leases as the serialization mechanism, but stop holding them while launched tasks run. Scoped and global top-up dispatch can now run in fire-and-forget mode for coordinated workflow mutations, so the mutation intent completes once state mutation and launch acceptance finish.

Add regression coverage for awaited dispatch, fire-and-forget dispatch, async dispatch rejection logging, and same-workflow mutation progress after a long-running launch.

## Architecture

### Before

```mermaid
graph TD
    A[Workflow mutation intent claimed] --> B[Apply state mutation]
    B --> C[Call executeTasks]
    C --> D[Task runtime completes]
    D --> E[Complete intent and release workflow lease]
    E --> F[Next same-workflow mutation can run]
```

### After

```mermaid
graph TD
    A[Workflow mutation intent claimed] --> B[Apply state mutation]
    B --> C[Accept scoped and top-up launches]
    C --> D[Complete intent and release workflow lease]
    D --> E[Next same-workflow mutation can run]
    C --> F[Task runtime continues through executor result paths]
```

## Test Plan

- [x] `pnpm --dir packages/app exec vitest run src/__tests__/global-topup.test.ts src/__tests__/persisted-workflow-mutation-coordinator.test.ts src/__tests__/workflow-mutation-facade.test.ts`
- [x] `bash scripts/repro/repro-recreate-blocked-by-running-workflow-mutation.sh`
- [x] `pnpm --dir packages/app run build`
- [x] `pnpm run check:types`
- [x] `git diff --check`
- [ ] `scripts/repro/repro-mece-07-scoped-dispatch-blocking.sh` (not present on this branch)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e31121c1`
- Post-revert steps: None
- Data migration? No
