### PR TITLE
Fix sql.js OOM from task output storage

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -45,6 +45,11 @@ describe('SQLiteAdapter', () => {
     return (result[0]?.values ?? []).map((row) => String(row[1]));
   }
 
+  function sqliteScalar(db: SQLiteAdapter, sql: string): number {
+    const result = (db as any).db.exec(sql) as Array<{ values: unknown[][] }>;
+    return Number(result[0]?.values?.[0]?.[0] ?? 0);
+  }
+
   describe('workflow schema', () => {
     it('does not persist a workflow status column on fresh databases', () => {
       expect(workflowColumns(adapter)).not.toContain('status');
@@ -1113,6 +1118,50 @@ describe('SQLiteAdapter', () => {
       expect(firstIdx).toBeLessThan(secondIdx);
       expect(secondIdx).toBeLessThan(thirdIdx);
     });
+
+    it('keeps new task output out of SQLite while preserving readback', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-output-file-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const db = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        db.saveWorkflow(testWorkflow);
+        db.saveTask('wf-1', makeTask('t-file-output'));
+
+        const payload = 'x'.repeat(1024 * 1024);
+        db.appendTaskOutput('t-file-output', payload);
+
+        expect(sqliteScalar(db, 'SELECT COUNT(*) FROM task_output')).toBe(0);
+        expect(db.getTaskOutput('t-file-output')).toBe(payload);
+
+        db.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('returns legacy SQLite task output before new file-backed output', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-output-legacy-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const db = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        db.saveWorkflow(testWorkflow);
+        db.saveTask('wf-1', makeTask('t-legacy-output'));
+        (db as any).db.run(
+          'INSERT INTO task_output (task_id, data) VALUES (?, ?)',
+          ['t-legacy-output', 'legacy\n'],
+        );
+
+        db.appendTaskOutput('t-legacy-output', 'file\n');
+
+        expect(db.getTaskOutput('t-legacy-output')).toBe('legacy\nfile\n');
+
+        db.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   // ── Conversations ──────────────────────────────────────
@@ -1996,6 +2045,36 @@ describe('SQLiteAdapter', () => {
       const resumeOffset = batch1[0].offset + batch1[0].data.length;
       expect(firstOffset2).toBeGreaterThanOrEqual(resumeOffset);
     });
+
+    it('continues offsets from legacy SQLite spool rows into file-backed chunks', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-spool-legacy-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const db = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+        db.saveWorkflow(testWorkflow);
+        db.saveTask('wf-1', makeTask('t-legacy-spool'));
+        (db as any).db.run(
+          'INSERT INTO output_spool (task_id, offset, data) VALUES (?, ?, ?)',
+          ['t-legacy-spool', 0, 'old'],
+        );
+
+        db.appendOutputChunk('t-legacy-spool', 'new');
+
+        expect(sqliteScalar(db, "SELECT COUNT(*) FROM output_spool WHERE task_id = 't-legacy-spool'")).toBe(1);
+        expect(db.replayOutputFrom('t-legacy-spool', 0)).toEqual([
+          { offset: 0, data: 'old' },
+          { offset: 3, data: 'new' },
+        ]);
+        expect(db.replayOutputFrom('t-legacy-spool', 3)).toEqual([
+          { offset: 3, data: 'new' },
+        ]);
+
+        db.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('output spool: in-memory cache with tail limit', () => {
@@ -2125,6 +2204,37 @@ describe('SQLiteAdapter', () => {
 
       db.close();
     });
+
+    it('reads only the configured tail from file-backed spool storage after restart', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-file-tail-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const db1 = await SQLiteAdapter.create(dbPath, { ownerCapability: true, outputTailLimit: 4 });
+        db1.saveWorkflow(testWorkflow);
+        db1.saveTask('wf-1', makeTask('t-file-tail'));
+        for (let i = 0; i < 12; i++) {
+          db1.appendOutputChunk('t-file-tail', `tail ${i}\n`);
+        }
+        expect(sqliteScalar(db1, 'SELECT COUNT(*) FROM output_spool')).toBe(0);
+        db1.close();
+
+        const db2 = await SQLiteAdapter.create(dbPath, { ownerCapability: true, outputTailLimit: 4 });
+        const tail = db2.getOutputTail('t-file-tail');
+
+        expect(tail.map((chunk) => chunk.data)).toEqual([
+          'tail 8\n',
+          'tail 9\n',
+          'tail 10\n',
+          'tail 11\n',
+        ]);
+        expect(db2.replayOutputFrom('t-file-tail', 0)).toHaveLength(12);
+
+        db2.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 
   describe('output spool: durability and persistence', () => {
@@ -2178,6 +2288,32 @@ describe('SQLiteAdapter', () => {
         expect(chunks2[1].data).toBe('BBB');
 
         db2.close();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps workflow metadata queries functional after large output writes', async () => {
+      const dir = mkdtempSync(join(tmpdir(), 'sqlite-adapter-output-oom-'));
+      const dbPath = join(dir, 'invoker.db');
+
+      try {
+        const db = await SQLiteAdapter.create(dbPath, { ownerCapability: true, outputTailLimit: 5 });
+        db.saveWorkflow(testWorkflow);
+        db.saveTask('wf-1', makeTask('t-large-output'));
+
+        const payload = 'z'.repeat(256 * 1024);
+        for (let i = 0; i < 24; i++) {
+          db.appendTaskOutput('t-large-output', payload);
+          db.appendOutputChunk('t-large-output', `${i}:${payload}`);
+        }
+
+        expect(sqliteScalar(db, 'SELECT COUNT(*) FROM task_output')).toBe(0);
+        expect(sqliteScalar(db, 'SELECT COUNT(*) FROM output_spool')).toBe(0);
+        expect(db.listWorkflows()).toHaveLength(1);
+        expect(db.getOutputTail('t-large-output')).toHaveLength(5);
+
+        db.close();
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -6,8 +6,22 @@
  */
 
 import initSqlJs, { type Database as SqlJsDatabase } from 'sql.js';
-import { readFileSync, writeFileSync, existsSync, mkdirSync, renameSync } from 'node:fs';
-import { dirname } from 'node:path';
+import {
+  appendFileSync,
+  closeSync,
+  existsSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { createHash } from 'node:crypto';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
 import type {
   TaskState,
   TaskStateChanges,
@@ -57,6 +71,13 @@ export interface OutputChunk {
   data: string;
 }
 
+interface SQLiteAdapterOptions {
+  readOnly?: boolean;
+  ownerCapability?: boolean;
+  outputTailLimit?: number;
+  outputDir?: string;
+}
+
 export type WorkflowMutationPriority = 'high' | 'normal';
 export type WorkflowMutationIntentStatus = 'queued' | 'running' | 'completed' | 'failed';
 export const WORKFLOW_MUTATION_LEASE_MS = 30_000;
@@ -98,11 +119,13 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private lastFlushWarnAtMs = 0;
   private outputTailLimit: number;
   private outputTailCache = new Map<string, OutputChunk[]>();
+  private outputDir: string;
+  private spoolNextOffsetCache = new Map<string, number>();
   private writeTransactionDepth = 0;
   private lastWorkflowTaskSnapshotStats: Record<string, unknown> | null = null;
 
   /** Use SQLiteAdapter.create() instead. */
-  private constructor(db: SqlJsDatabase, dbPath: string | null, options?: { readOnly?: boolean; outputTailLimit?: number }) {
+  private constructor(db: SqlJsDatabase, dbPath: string | null, options?: SQLiteAdapterOptions) {
     this.db = db;
     this.dbPath = dbPath;
     this.readOnly = options?.readOnly === true;
@@ -113,6 +136,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.flushWarnDbSizeBytes = Number(process.env.INVOKER_SQLITE_FLUSH_WARN_DB_MB ?? 256) * 1024 * 1024;
     this.flushWarnCooldownMs = Number(process.env.INVOKER_SQLITE_FLUSH_WARN_COOLDOWN_MS ?? 60_000);
     this.outputTailLimit = options?.outputTailLimit ?? 100;
+    this.outputDir = options?.outputDir ?? this.resolveOutputDir(dbPath);
     this.db.run('PRAGMA foreign_keys = ON');
     this.initSchema();
     this.migrate();
@@ -125,7 +149,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
    * @param options readOnly=true opens DB for read operations without schema mutation/flush.
    *                ownerCapability=true is required to open DB in writable mode for file-backed databases.
    */
-  static async create(dbPath: string = ':memory:', options?: { readOnly?: boolean; ownerCapability?: boolean; outputTailLimit?: number }): Promise<SQLiteAdapter> {
+  static async create(dbPath: string = ':memory:', options?: SQLiteAdapterOptions): Promise<SQLiteAdapter> {
     if (!sqlJsPromise) {
       sqlJsPromise = initSqlJs();
     }
@@ -160,6 +184,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
     const db = new SQL.Database();
     return new SQLiteAdapter(db, isFile ? dbPath : null, options);
+  }
+
+  private resolveOutputDir(dbPath: string | null): string {
+    const invokerHome = process.env.INVOKER_DB_DIR ?? (dbPath ? dirname(dbPath) : join(homedir(), '.invoker'));
+    if (!dbPath && !process.env.INVOKER_DB_DIR) {
+      return join(tmpdir(), `invoker-output-${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+    }
+    return join(invokerHome, 'task-output');
   }
 
   // ── sql.js Helpers ───────────────────────────────────────
@@ -1174,7 +1206,135 @@ export class SQLiteAdapter implements PersistenceAdapter {
   private invalidateOutputTailCache(taskIds: string[]): void {
     for (const taskId of taskIds) {
       this.outputTailCache.delete(taskId);
+      this.spoolNextOffsetCache.delete(taskId);
     }
+  }
+
+  private taskOutputKey(taskId: string): string {
+    return createHash('sha256').update(taskId).digest('hex');
+  }
+
+  private taskOutputFile(taskId: string): string {
+    return join(this.outputDir, 'full', `${this.taskOutputKey(taskId)}.log`);
+  }
+
+  private taskSpoolFile(taskId: string): string {
+    return join(this.outputDir, 'spool', `${this.taskOutputKey(taskId)}.jsonl`);
+  }
+
+  private ensureOutputSubdir(kind: 'full' | 'spool'): void {
+    mkdirSync(join(this.outputDir, kind), { recursive: true });
+  }
+
+  private removeOutputFiles(taskIds: string[]): void {
+    for (const taskId of taskIds) {
+      rmSync(this.taskOutputFile(taskId), { force: true });
+      rmSync(this.taskSpoolFile(taskId), { force: true });
+    }
+    this.invalidateOutputTailCache(taskIds);
+  }
+
+  private readTaskOutputFile(taskId: string): string {
+    const file = this.taskOutputFile(taskId);
+    if (!existsSync(file)) return '';
+    return readFileSync(file, 'utf8');
+  }
+
+  private encodeSpoolLine(chunk: OutputChunk): string {
+    const data = Buffer.from(chunk.data, 'utf8').toString('base64');
+    return `${chunk.offset}\t${data}\n`;
+  }
+
+  private decodeSpoolLine(line: string): OutputChunk | null {
+    if (!line) return null;
+    const separator = line.indexOf('\t');
+    if (separator <= 0) return null;
+    const offset = Number.parseInt(line.slice(0, separator), 10);
+    if (!Number.isFinite(offset)) return null;
+    return {
+      offset,
+      data: Buffer.from(line.slice(separator + 1), 'base64').toString('utf8'),
+    };
+  }
+
+  private readSpoolLines(taskId: string): OutputChunk[] {
+    const file = this.taskSpoolFile(taskId);
+    if (!existsSync(file)) return [];
+    return readFileSync(file, 'utf8')
+      .split('\n')
+      .map((line) => this.decodeSpoolLine(line))
+      .filter((chunk): chunk is OutputChunk => chunk !== null);
+  }
+
+  private readLastSpoolLines(taskId: string, limit: number): OutputChunk[] {
+    if (limit <= 0) return [];
+    const file = this.taskSpoolFile(taskId);
+    if (!existsSync(file)) return [];
+
+    const fd = openSync(file, 'r');
+    try {
+      const size = statSync(file).size;
+      const chunkSize = 64 * 1024;
+      let position = size;
+      let suffix = '';
+      let lines: string[] = [];
+
+      while (position > 0 && lines.length <= limit) {
+        const readSize = Math.min(chunkSize, position);
+        position -= readSize;
+        const buffer = Buffer.allocUnsafe(readSize);
+        readSync(fd, buffer, 0, readSize, position);
+        const text = buffer.toString('utf8') + suffix;
+        const parts = text.split('\n');
+        suffix = parts.shift() ?? '';
+        lines = parts.concat(lines);
+      }
+      if (position === 0 && suffix) {
+        lines.unshift(suffix);
+      }
+
+      return lines
+        .filter(Boolean)
+        .slice(-limit)
+        .map((line) => this.decodeSpoolLine(line))
+        .filter((chunk): chunk is OutputChunk => chunk !== null);
+    } finally {
+      closeSync(fd);
+    }
+  }
+
+  private readLastSpoolChunk(taskId: string): OutputChunk | null {
+    return this.readLastSpoolLines(taskId, 1)[0] ?? null;
+  }
+
+  private getLegacySpoolChunks(taskId: string): OutputChunk[] {
+    const rows = this.queryAll(
+      'SELECT offset, data FROM output_spool WHERE task_id = ? ORDER BY offset ASC',
+      [taskId],
+    ) as Array<{ offset: number; data: string }>;
+
+    return rows.map((row) => ({ offset: row.offset, data: row.data }));
+  }
+
+  private getLegacySpoolEndOffset(taskId: string): number {
+    const row = this.queryOne(
+      'SELECT offset, data FROM output_spool WHERE task_id = ? ORDER BY offset DESC LIMIT 1',
+      [taskId],
+    ) as { offset: number; data: string } | undefined;
+    if (!row) return 0;
+    return row.offset + Buffer.byteLength(row.data, 'utf8');
+  }
+
+  private getNextSpoolOffset(taskId: string): number {
+    const cached = this.spoolNextOffsetCache.get(taskId);
+    if (cached !== undefined) return cached;
+
+    const legacyEnd = this.getLegacySpoolEndOffset(taskId);
+    const fileLast = this.readLastSpoolChunk(taskId);
+    const fileEnd = fileLast ? fileLast.offset + Buffer.byteLength(fileLast.data, 'utf8') : 0;
+    const nextOffset = Math.max(legacyEnd, fileEnd);
+    this.spoolNextOffsetCache.set(taskId, nextOffset);
+    return nextOffset;
   }
 
   loadAllCompletedTasks(): Array<TaskState & { workflowName: string }> {
@@ -1216,10 +1376,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
       `, [workflowId]);
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
     });
-    this.invalidateOutputTailCache(taskIds);
+    this.removeOutputFiles(taskIds);
   }
 
   deleteAllWorkflows(): void {
+    const taskIds = this.getAllTaskIds();
     this.runTransaction(() => {
       this.db.run('DELETE FROM events');
       this.db.run('DELETE FROM task_output');
@@ -1228,7 +1389,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM tasks');
       this.db.run('DELETE FROM workflows');
     });
+    this.removeOutputFiles(taskIds);
     this.outputTailCache.clear();
+    this.spoolNextOffsetCache.clear();
   }
 
   deleteWorkflow(workflowId: string): void {
@@ -1267,7 +1430,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       // Finally delete the workflow
       this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
     });
-    this.invalidateOutputTailCache(taskIds);
+    this.removeOutputFiles(taskIds);
   }
 
   // ── Events ────────────────────────────────────────────
@@ -1505,10 +1668,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
   // ── Task Output ─────────────────────────────────────
 
   appendTaskOutput(taskId: string, data: string): void {
-    this.execRun(
-      'INSERT INTO task_output (task_id, data) VALUES (?, ?)',
-      [taskId, data],
-    );
+    this.ensureWritable();
+    this.ensureOutputSubdir('full');
+    appendFileSync(this.taskOutputFile(taskId), data, 'utf8');
   }
 
   getTaskOutput(taskId: string): string {
@@ -1516,28 +1678,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'SELECT data FROM task_output WHERE task_id = ? ORDER BY id ASC',
       [taskId],
     ) as Array<{ data: string }>;
-    return rows.map((r) => r.data).join('');
+    return rows.map((r) => r.data).join('') + this.readTaskOutputFile(taskId);
   }
 
   // ── Output Spool ────────────────────────────────────────
 
   appendOutputChunk(taskId: string, data: string): void {
     this.ensureWritable();
-
-    // Get current max offset for this task
-    const row = this.queryOne(
-      'SELECT COALESCE(MAX(offset), -1) AS max_offset FROM output_spool WHERE task_id = ?',
-      [taskId],
-    ) as { max_offset: number } | undefined;
-
-    const currentMaxOffset = row?.max_offset ?? -1;
-    const nextOffset = currentMaxOffset === -1 ? 0 : currentMaxOffset + this.getLastChunkLength(taskId, currentMaxOffset);
-
-    // Insert new chunk
-    this.execRun(
-      'INSERT INTO output_spool (task_id, offset, data) VALUES (?, ?, ?)',
-      [taskId, nextOffset, data],
-    );
+    const nextOffset = this.getNextSpoolOffset(taskId);
+    this.ensureOutputSubdir('spool');
+    appendFileSync(this.taskSpoolFile(taskId), this.encodeSpoolLine({ offset: nextOffset, data }), 'utf8');
+    this.spoolNextOffsetCache.set(taskId, nextOffset + Buffer.byteLength(data, 'utf8'));
 
     // Update in-memory tail cache
     const tail = this.outputTailCache.get(taskId) ?? [];
@@ -1550,32 +1701,20 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.outputTailCache.set(taskId, tail);
   }
 
-  private getLastChunkLength(taskId: string, offset: number): number {
-    const row = this.queryOne(
-      'SELECT data FROM output_spool WHERE task_id = ? AND offset = ?',
-      [taskId, offset],
-    ) as { data: string } | undefined;
-
-    if (!row) return 0;
-    return Buffer.byteLength(row.data, 'utf8');
-  }
-
   getOutputChunks(taskId: string): OutputChunk[] {
-    const rows = this.queryAll(
-      'SELECT offset, data FROM output_spool WHERE task_id = ? ORDER BY offset ASC',
-      [taskId],
-    ) as Array<{ offset: number; data: string }>;
-
-    return rows.map(r => ({ offset: r.offset, data: r.data }));
+    return [...this.getLegacySpoolChunks(taskId), ...this.readSpoolLines(taskId)]
+      .sort((a, b) => a.offset - b.offset);
   }
 
   replayOutputFrom(taskId: string, fromOffset: number): OutputChunk[] {
-    const rows = this.queryAll(
+    const legacyRows = this.queryAll(
       'SELECT offset, data FROM output_spool WHERE task_id = ? AND offset >= ? ORDER BY offset ASC',
       [taskId, fromOffset],
     ) as Array<{ offset: number; data: string }>;
 
-    return rows.map(r => ({ offset: r.offset, data: r.data }));
+    const legacyChunks = legacyRows.map((row) => ({ offset: row.offset, data: row.data }));
+    const fileChunks = this.readSpoolLines(taskId).filter((chunk) => chunk.offset >= fromOffset);
+    return [...legacyChunks, ...fileChunks].sort((a, b) => a.offset - b.offset);
   }
 
   getOutputTail(taskId: string): OutputChunk[] {
@@ -1585,8 +1724,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       return cached;
     }
 
-    // Otherwise fetch the tail from storage
-    const rows = this.queryAll(
+    const legacyRows = this.queryAll(
       `SELECT offset, data FROM output_spool
        WHERE task_id = ?
        ORDER BY offset DESC
@@ -1594,8 +1732,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
       [taskId, this.outputTailLimit],
     ) as Array<{ offset: number; data: string }>;
 
-    // Reverse to get ascending order
-    const chunks = rows.reverse().map(r => ({ offset: r.offset, data: r.data }));
+    const legacyChunks = legacyRows.map((row) => ({ offset: row.offset, data: row.data }));
+    const fileChunks = this.readLastSpoolLines(taskId, this.outputTailLimit);
+    const chunks = [...legacyChunks, ...fileChunks]
+      .sort((a, b) => a.offset - b.offset)
+      .slice(-this.outputTailLimit);
 
     // Populate cache
     if (chunks.length > 0) {

--- a/scripts/repro-workflow-mutation-oom.mjs
+++ b/scripts/repro-workflow-mutation-oom.mjs
@@ -6,6 +6,7 @@ import { createRequire } from 'node:module';
 
 const MB = 1024 * 1024;
 const VALID_MODES = new Set(['safe', 'sandbox']);
+const VALID_EXPECTATIONS = new Set(['bug', 'fixed']);
 
 function envInt(name, fallback) {
   const raw = process.env[name];
@@ -16,8 +17,10 @@ function envInt(name, fallback) {
 
 function parseArgs(argv) {
   let mode = process.env.REPRO_MODE ?? 'safe';
+  let expect = process.env.REPRO_EXPECT ?? null;
   let help = false;
-  for (const arg of argv) {
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
     if (arg === '--help' || arg === '-h') {
       help = true;
       continue;
@@ -32,19 +35,34 @@ function parseArgs(argv) {
     }
     if (arg === '--sandbox') {
       mode = 'sandbox';
+      continue;
+    }
+    if (arg === '--expect') {
+      expect = argv[i + 1] ?? '';
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--expect=')) {
+      expect = arg.slice('--expect='.length);
     }
   }
   if (!VALID_MODES.has(mode)) {
     throw new Error(`invalid mode "${mode}" (expected: safe|sandbox)`);
   }
-  return { mode, help };
+  if (expect !== null && !VALID_EXPECTATIONS.has(expect)) {
+    throw new Error(`invalid expectation "${expect}" (expected: bug|fixed)`);
+  }
+  return { mode, expect, help };
 }
 
 function printHelp() {
-  console.error('Usage: node scripts/repro-workflow-mutation-oom.mjs [--mode=safe|sandbox]');
+  console.error('Usage: node scripts/repro-workflow-mutation-oom.mjs [--mode=safe|sandbox] [--expect bug|fixed]');
   console.error('Modes:');
   console.error('  safe    Default. Enforces timeout/db-size guards for host safety.');
   console.error('  sandbox Intended for memory-limited containers; guards mostly disabled.');
+  console.error('Expectations:');
+  console.error('  bug     Original SQLite-backed output growth is expected to hit a guard or OOM.');
+  console.error('  fixed   Task output is externalized; SQLite output_spool must stay empty.');
   console.error('Env overrides (optional):');
   console.error('  REPRO_ROWS_PER_CYCLE, REPRO_PAYLOAD_BYTES, REPRO_RENEWS_PER_CYCLE, REPRO_MAX_CYCLES');
   console.error('  REPRO_EXPORT_EVERY, REPRO_MAX_DB_MB, REPRO_SQLITE_HARD_HEAP_LIMIT_MB, REPRO_TIMEOUT_SEC');
@@ -135,7 +153,22 @@ function renewWorkflowMutationLease(db, workflowId, ownerId, options = {}) {
   return 'updated';
 }
 
-function fillLargeTables(db, rows, payloadBytes) {
+function appendExternalOutput(tempDir, taskId, data) {
+  const outputDir = path.join(tempDir, 'task-output');
+  fs.mkdirSync(outputDir, { recursive: true });
+  const key = Buffer.from(taskId).toString('base64url');
+  fs.appendFileSync(path.join(outputDir, `${key}.log`), data);
+}
+
+function externalOutputBytes(tempDir) {
+  const outputDir = path.join(tempDir, 'task-output');
+  if (!fs.existsSync(outputDir)) return 0;
+  return fs.readdirSync(outputDir).reduce((total, name) => {
+    return total + fs.statSync(path.join(outputDir, name)).size;
+  }, 0);
+}
+
+function fillLargeTables(db, rows, payloadBytes, options = {}) {
   const insertIntent = db.prepare(
     `INSERT INTO workflow_mutation_intents (workflow_id, channel, args_json, priority, status)
      VALUES (?, ?, ?, 'normal', 'queued')`
@@ -145,10 +178,16 @@ function fillLargeTables(db, rows, payloadBytes) {
   );
   const payload = 'x'.repeat(payloadBytes);
   for (let i = 0; i < rows; i += 1) {
-    const argsJson = JSON.stringify([payload, i, { nested: payload }]);
+    const argsJson = options.externalizeOutput
+      ? JSON.stringify(['dispatch', i])
+      : JSON.stringify([payload, i, { nested: payload }]);
     insertIntent.run(['wf-oom', 'dispatch', argsJson]);
     if (i % 4 === 0) {
-      insertSpool.run(['wf-oom/task', i * payloadBytes, payload]);
+      if (options.externalizeOutput) {
+        appendExternalOutput(options.tempDir, 'wf-oom/task', payload);
+      } else {
+        insertSpool.run(['wf-oom/task', i * payloadBytes, payload]);
+      }
     }
   }
   insertIntent.free();
@@ -156,7 +195,7 @@ function fillLargeTables(db, rows, payloadBytes) {
 }
 
 async function main() {
-  const { mode, help } = parseArgs(process.argv.slice(2));
+  const { mode, expect, help } = parseArgs(process.argv.slice(2));
   if (help) {
     printHelp();
     return;
@@ -216,10 +255,11 @@ async function main() {
   let leaseRenewUpdateWrites = 0;
   let seededIntentRows = 0;
   let failureReason = null;
+  const externalizeOutput = expect === 'fixed';
 
   console.error(`[repro] temp db=${dbPath}`);
   console.error(
-    `[repro] mode=${mode} rowsPerCycle=${rowsPerCycle} payloadBytes=${payloadBytes} renewsPerCycle=${renewsPerCycle} maxCycles=${maxCycles} hardHeapLimitMb=${hardHeapLimitMb} maxDbMb=${maxDbMb} timeoutSec=${timeoutSec}`
+    `[repro] mode=${mode} expect=${expect ?? 'none'} externalizeOutput=${externalizeOutput} rowsPerCycle=${rowsPerCycle} payloadBytes=${payloadBytes} renewsPerCycle=${renewsPerCycle} maxCycles=${maxCycles} hardHeapLimitMb=${hardHeapLimitMb} maxDbMb=${maxDbMb} timeoutSec=${timeoutSec}`
   );
   console.error(
     `[repro] flushDebounceMs=${flushDebounceMs} exportEvery=${exportEvery} leaseRenewMinIntervalMs=${leaseRenewMinIntervalMs} leaseRenewMinExpiryLeadMs=${leaseRenewMinExpiryLeadMs}`
@@ -287,7 +327,7 @@ async function main() {
       }
     };
     for (let cycle = 1; cycle <= maxCycles; cycle += 1) {
-      fillLargeTables(db, rowsPerCycle, payloadBytes);
+      fillLargeTables(db, rowsPerCycle, payloadBytes, { externalizeOutput, tempDir });
       seededIntentRows += rowsPerCycle;
       console.error(`[repro] cycle=${cycle} seeded rows; starting renew loop`);
       for (let i = 1; i <= renewsPerCycle; i += 1) {
@@ -299,11 +339,15 @@ async function main() {
         });
         leaseRenewWrites += 1;
         if (renewResult === 'updated') leaseRenewUpdateWrites += 1;
-        db.run('INSERT INTO output_spool (task_id, offset, data) VALUES (?, ?, ?)', [
-          'wf-oom/task',
-          (cycle * renewsPerCycle) + i,
-          'y'.repeat(payloadBytes),
-        ]);
+        if (externalizeOutput) {
+          appendExternalOutput(tempDir, 'wf-oom/task', 'y'.repeat(payloadBytes));
+        } else {
+          db.run('INSERT INTO output_spool (task_id, offset, data) VALUES (?, ?, ?)', [
+            'wf-oom/task',
+            (cycle * renewsPerCycle) + i,
+            'y'.repeat(payloadBytes),
+          ]);
+        }
         dirty = true;
         if (flushDebounceMs <= 0) {
           if (i % exportEvery === 0) maybeFlush();
@@ -324,13 +368,24 @@ async function main() {
         throw new Error(`db size guard reached (${dbSizeMb.toFixed(1)}MB > ${maxDbMb}MB) before OOM`);
       }
     }
+    if (expect === 'fixed') {
+      const spoolRows = queryOne(db, 'SELECT COUNT(*) AS count FROM output_spool')?.count ?? 0;
+      const bytes = externalOutputBytes(tempDir);
+      if (Number(spoolRows) !== 0) {
+        throw new Error(`fixed expectation failed: output_spool has ${spoolRows} row(s)`);
+      }
+      if (bytes <= 0) {
+        throw new Error('fixed expectation failed: no externalized output bytes were written');
+      }
+      console.error(`[repro] fixed expectation satisfied: output_spool=0 externalOutputBytes=${bytes}`);
+    }
     console.error('[repro] no OOM observed within configured cycles');
-    process.exitCode = 0;
+    process.exitCode = expect === 'bug' ? 1 : 0;
   } catch (err) {
     failureReason = err instanceof Error ? err.message : String(err);
     console.error(`[workflow-mutation-coordinator] drain failed for wf-1778141641513-26: ${err}`);
     console.error(`[workflow-mutation-coordinator] drain failed for wf-1778141629042-19: ${err}`);
-    process.exitCode = 1;
+    process.exitCode = expect === 'bug' ? 0 : 1;
   } finally {
     const elapsedMs = nowMs() - startedAt;
     const meanFlushIntervalMs = flushCount > 1

--- a/scripts/run-oom-repro.sh
+++ b/scripts/run-oom-repro.sh
@@ -2,6 +2,10 @@
 set -euo pipefail
 
 MODE="${1:-safe}"
+if [[ $# -gt 0 ]]; then
+  shift
+fi
+EXTRA_ARGS=("$@")
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 SCRIPT_PATH="scripts/repro-workflow-mutation-oom.mjs"
 
@@ -14,7 +18,7 @@ if [[ "$MODE" == "safe" ]]; then
   NODE_HEAP_MB="${REPRO_NODE_HEAP_MB:-192}"
   echo "[runner] mode=safe node_heap_mb=${NODE_HEAP_MB}"
   cd "$ROOT_DIR"
-  exec node --max-old-space-size="${NODE_HEAP_MB}" "$SCRIPT_PATH" --mode=safe
+  exec node --max-old-space-size="${NODE_HEAP_MB}" "$SCRIPT_PATH" --mode=safe "${EXTRA_ARGS[@]}"
 fi
 
 if ! command -v docker >/dev/null 2>&1; then
@@ -39,4 +43,4 @@ exec docker run --rm \
   -e REPRO_SQLITE_HARD_HEAP_LIMIT_MB \
   -e REPRO_TIMEOUT_SEC \
   node:26 \
-  node --max-old-space-size="${NODE_HEAP_MB}" "$SCRIPT_PATH" --mode=sandbox
+  node --max-old-space-size="${NODE_HEAP_MB}" "$SCRIPT_PATH" --mode=sandbox "${EXTRA_ARGS[@]}"

--- a/scripts/test-docker-comprehensive.sh
+++ b/scripts/test-docker-comprehensive.sh
@@ -191,7 +191,24 @@ fi
 # ── Helper: query task output from DB ────────────────────────
 
 task_output() {
-  sqlite3 "$DB_PATH" "SELECT data FROM task_output WHERE task_id = '$1' OR task_id LIKE '%/' || '$1' ORDER BY id ASC;" 2>/dev/null || echo ""
+  local query_id="$1"
+  local task_id
+  task_id="$(sqlite3 "$DB_PATH" "SELECT id FROM tasks WHERE id = '$query_id' OR id LIKE '%/' || '$query_id' ORDER BY id DESC LIMIT 1;" 2>/dev/null || true)"
+  if [[ -z "$task_id" ]]; then
+    task_id="$query_id"
+  fi
+
+  sqlite3 "$DB_PATH" "SELECT data FROM task_output WHERE task_id = '$task_id' ORDER BY id ASC;" 2>/dev/null || true
+
+  local output_file=""
+  if command -v shasum >/dev/null 2>&1; then
+    output_file="$INVOKER_DB_DIR/task-output/full/$(printf '%s' "$task_id" | shasum -a 256 | awk '{print $1}').log"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    output_file="$INVOKER_DB_DIR/task-output/full/$(printf '%s' "$task_id" | sha256sum | awk '{print $1}').log"
+  fi
+  if [[ -n "$output_file" && -f "$output_file" ]]; then
+    cat "$output_file"
+  fi
 }
 
 task_status() {


### PR DESCRIPTION
## Summary

Move task stdout/stderr and output-spool persistence out of the sql.js database and into append-only files under the Invoker data directory. SQLite now keeps workflow/control metadata small while legacy `task_output` and `output_spool` rows remain readable for existing databases.

## Architecture

### Before

```mermaid
graph TD
    Executor[Executor output] --> Adapter[SQLiteAdapter]
    Adapter --> TaskOutput[(task_output TEXT rows)]
    Adapter --> OutputSpool[(output_spool TEXT rows)]
    Adapter --> SqlJs[sql.js export/flush]
```

### After

```mermaid
graph TD
    Executor[Executor output] --> Adapter[SQLiteAdapter]
    Adapter --> OutputFiles[Append-only files under Invoker home/task-output]
    Adapter --> TailCache[Bounded in-memory tail cache]
    Adapter --> LegacyRows[(Legacy SQLite output rows read-only compatibility)]
    Adapter --> Metadata[(SQLite workflow/control metadata)]
    Metadata --> SqlJs[sql.js export/flush]
```

## Test Plan

- [x] `pnpm --filter @invoker/data-store test`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app test -- shutdown-diagnostic`
- [x] `REPRO_ROWS_PER_CYCLE=20 REPRO_PAYLOAD_BYTES=4096 REPRO_RENEWS_PER_CYCLE=50 REPRO_MAX_CYCLES=2 REPRO_EXPORT_EVERY=25 REPRO_MAX_DB_MB=20 REPRO_SQLITE_HARD_HEAP_LIMIT_MB=64 REPRO_TIMEOUT_SEC=20 node scripts/repro-workflow-mutation-oom.mjs --mode=safe --expect fixed`
- [x] `REPRO_ROWS_PER_CYCLE=5 REPRO_PAYLOAD_BYTES=1024 REPRO_RENEWS_PER_CYCLE=5 REPRO_MAX_CYCLES=1 REPRO_EXPORT_EVERY=5 REPRO_MAX_DB_MB=20 REPRO_SQLITE_HARD_HEAP_LIMIT_MB=64 REPRO_TIMEOUT_SEC=20 bash scripts/run-oom-repro.sh safe --expect fixed`

## Revert Plan

- Safe to revert? Yes, with compatibility caveat: output written while this change is deployed lives in `task-output` files and would not be visible to the older SQLite-only reader after revert.
- Revert command: `git revert d9b3cc53`
- Post-revert steps: Preserve or manually inspect the external `task-output` directory if output written by this version must remain accessible.
- Data migration? No SQLite migration. This change adds external append-only output files and keeps legacy SQLite output rows readable.
