### PR TITLE
Fix workflow graph recovery after refresh

### DIFF
--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -17,6 +17,7 @@ import React from 'react';
 import { vi } from 'vitest';
 
 export function createReactFlowMock() {
+  const fitView = vi.fn();
   const MockReactFlow = React.forwardRef(function MockReactFlow(
     props: {
       nodes?: Array<{
@@ -85,7 +86,8 @@ export function createReactFlowMock() {
   return {
     ReactFlow: MockReactFlow,
     ReactFlowProvider: MockReactFlowProvider,
-    useReactFlow: () => ({ fitView: vi.fn() }),
+    useReactFlow: () => ({ fitView }),
+    __fitViewMock: fitView,
     applyNodeChanges: vi.fn((changes: unknown[], nodes: unknown[]) => nodes),
     Background: () => null,
     Controls: () => null,

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -1,12 +1,15 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { WorkflowGraph } from '../components/WorkflowGraph.js';
 import type { TaskState, WorkflowMeta, WorkflowStatus } from '../types.js';
+import * as ReactFlowModule from '@xyflow/react';
 
 vi.mock('@xyflow/react', async () => {
   const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
   return createReactFlowMock();
 });
+
+const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
 
 function wf(id: string, status: WorkflowStatus): WorkflowMeta {
   return { id, name: id, status };
@@ -25,6 +28,10 @@ function task(id: string, workflowId: string): TaskState {
 }
 
 describe('WorkflowGraph', () => {
+  beforeEach(() => {
+    fitViewMock.mockClear();
+  });
+
   it('calls selection and context menu handlers', () => {
     const onSelectWorkflow = vi.fn();
     const onWorkflowContextMenu = vi.fn();
@@ -100,5 +107,52 @@ describe('WorkflowGraph', () => {
 
     expect(screen.getByTestId('workflow-graph-react-flow')).toBeInTheDocument();
     expect(screen.getByTestId('mock-react-flow')).toBeInTheDocument();
+  });
+
+  it('re-fits after a non-empty workflow snapshot replacement', async () => {
+    const workflows = new Map([
+      ['wf-a', wf('wf-a', 'running')],
+    ]);
+    const tasks = new Map([
+      ['t1', task('t1', 'wf-a')],
+    ]);
+
+    const { rerender } = render(
+      <WorkflowGraph
+        tasks={tasks}
+        workflows={workflows}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    fitViewMock.mockClear();
+
+    const refreshedWorkflows = new Map([
+      ['wf-a', wf('wf-a', 'running')],
+      ['wf-b', wf('wf-b', 'pending')],
+    ]);
+    const refreshedTasks = new Map([
+      ['t1', task('t1', 'wf-a')],
+      ['t2', task('t2', 'wf-b')],
+    ]);
+
+    rerender(
+      <WorkflowGraph
+        tasks={refreshedTasks}
+        workflows={refreshedWorkflows}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    await vi.waitFor(() => {
+      expect(fitViewMock).toHaveBeenCalledWith({ padding: 0.2 });
+    });
+    expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -129,6 +129,12 @@ function WorkflowGraphInner({
     },
   })), [graph.edges]);
 
+  const graphSignature = useMemo(() => {
+    const nodeIds = graph.nodes.map((node) => node.id).join('|');
+    const edgeIds = graph.edges.map((edge) => `${edge.source}->${edge.target}`).join('|');
+    return `${nodeIds}::${edgeIds}`;
+  }, [graph.edges, graph.nodes]);
+
   const onInitHandler = useCallback(() => {
     requestAnimationFrame(() => fitView({ padding: 0.2 }));
   }, [fitView]);
@@ -165,6 +171,14 @@ function WorkflowGraphInner({
     return () => cancelAnimationFrame(frame);
   }, [graph.edges.length, graph.nodes.length]);
 
+  useEffect(() => {
+    if (graph.nodes.length === 0 || typeof window === 'undefined') return;
+    const frame = requestAnimationFrame(() => {
+      requestAnimationFrame(() => fitView({ padding: 0.2 }));
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [fitView, graph.nodes.length, graphSignature]);
+
   if (graph.nodes.length === 0) {
     return (
       <div className="h-full flex items-center justify-center text-gray-500 text-sm">
@@ -181,6 +195,7 @@ function WorkflowGraphInner({
     >
       <div data-testid="workflow-graph-react-flow" className="h-full w-full">
         <ReactFlow
+          key={graphSignature}
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}


### PR DESCRIPTION
## Summary

Fix workflow graph recovery after a forced refresh or high-volume delta burst replaces the already-rendered workflow snapshot.

The workflow graph now derives a stable node/edge signature, remounts ReactFlow when that structure changes, and schedules a post-paint `fitView`. This gives the UI the same recovery path that closing/reopening the window provided, without requiring a BrowserWindow restart.

## Test Plan

- [x] `pnpm --filter @invoker/ui test -- workflow-graph.test.tsx`
- [x] `pnpm --filter @invoker/ui build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 157bf6a4`
- Post-revert steps: None
- Data migration? No
