### PR TITLE
Restrict side panel PR visibility

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -390,11 +390,19 @@ test.describe('Visual proof capture', () => {
     await assertPageScreenshot(page, 'merge-gate-no-inline-approve');
   });
 
-  test('review-ready workflow exposes pull request in inspector', async ({ page }) => {
+  test('workflow inspector captures review-ready and not-review-ready pull request states', async ({ page }) => {
     const workflowId = await loadPlanAndSelectWorkflow(page, REVIEW_READY_WORKFLOW_PR_PLAN);
     await page.locator('.react-flow__node[data-testid$="rr-work"]').first().waitFor({ state: 'visible', timeout: 15000 });
 
     const reviewUrl = 'https://github.com/Neko-Catpital-Labs/Invoker/pull/626';
+
+    await workflowNode(page, workflowId).dispatchEvent('click', { bubbles: true });
+    await expect(page.getByTestId('workflow-inspector-title')).toHaveText('Review ready workflow PR proof');
+    await expect(page.getByText('Inspector', { exact: true })).toHaveCount(0);
+    await expect(page.getByTestId('workflow-inspector-status-label')).not.toContainText('review ready');
+    await expect(page.getByRole('link', { name: reviewUrl })).toHaveCount(0);
+    await captureScreenshot(page, 'not-review-ready-workflow-pr-sidebar');
+
     await injectTaskStates(page, [
       {
         taskId: 'rr-work',

--- a/packages/ui/src/__tests__/workflow-inspector.test.tsx
+++ b/packages/ui/src/__tests__/workflow-inspector.test.tsx
@@ -40,11 +40,15 @@ describe('WorkflowInspector', () => {
     expect(screen.queryByText(/workflow id:/i)).not.toBeInTheDocument();
   });
 
-  it('renders PR URL as hyperlink when present', () => {
+  it('hides the Pull Request section for a non-review-gate task even when reviewUrl is set', () => {
     render(
       <WorkflowInspector
-        workflow={workflow}
-        task={makeTask({ status: 'failed' })}
+        workflow={{ ...workflow, status: 'review_ready' }}
+        task={makeTask({
+          status: 'completed',
+          config: { workflowId: 'wf-1', prompt: 'Fix failing tests' },
+          execution: { reviewUrl: 'https://github.com/org/repo/pull/12' },
+        })}
         collapsed={false}
         advancedExpanded={false}
         onToggleCollapsed={() => {}}
@@ -52,11 +56,56 @@ describe('WorkflowInspector', () => {
       />,
     );
 
-    const link = screen.getByRole('link', { name: /github\.com/i });
-    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/12');
+    expect(screen.queryByText('Pull Request')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /github\.com/i })).not.toBeInTheDocument();
   });
 
-  it('renders workflow PR URL from its review-ready merge node', () => {
+  it('hides the Pull Request section for a review gate when its workflow is not review_ready', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'running' }}
+        task={makeTask({
+          id: '__merge__wf-1',
+          description: 'Merge gate',
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+          execution: { reviewUrl: 'https://github.com/org/repo/pull/34' },
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText('Pull Request')).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /github\.com/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the PR link for a review-ready review gate in a review-ready workflow', () => {
+    render(
+      <WorkflowInspector
+        workflow={{ ...workflow, status: 'review_ready' }}
+        task={makeTask({
+          id: '__merge__wf-1',
+          description: 'Merge gate',
+          status: 'review_ready',
+          config: { workflowId: 'wf-1', isMergeNode: true },
+          execution: { reviewUrl: 'https://github.com/org/repo/pull/34' },
+        })}
+        collapsed={false}
+        advancedExpanded={false}
+        onToggleCollapsed={() => {}}
+        onToggleAdvanced={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Pull Request')).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /github\.com/i });
+    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/34');
+  });
+
+  it('resolves the review-ready merge node PR URL for workflow-only selection when the workflow is review_ready', () => {
     const mergeTask = makeTask({
       id: '__merge__wf-1',
       description: 'Merge gate',
@@ -84,6 +133,7 @@ describe('WorkflowInspector', () => {
       />,
     );
 
+    expect(screen.getByText('Pull Request')).toBeInTheDocument();
     const link = screen.getByRole('link', { name: /github\.com/i });
     expect(link).toHaveAttribute('href', 'https://github.com/org/repo/pull/34');
   });

--- a/packages/ui/src/components/WorkflowInspector.tsx
+++ b/packages/ui/src/components/WorkflowInspector.tsx
@@ -31,15 +31,20 @@ function capitalize(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
-function getWorkflowReviewUrl(tasks: Map<string, TaskState> | undefined): string | undefined {
+function getReviewReadyMergeNodeReviewUrl(
+  tasks: Map<string, TaskState> | undefined,
+): string | undefined {
   if (!tasks) return undefined;
-  let fallbackUrl: string | undefined;
   for (const candidate of tasks.values()) {
-    if (!candidate.execution.reviewUrl) continue;
-    if (candidate.config.isMergeNode) return candidate.execution.reviewUrl;
-    fallbackUrl ??= candidate.execution.reviewUrl;
+    if (
+      candidate.config.isMergeNode &&
+      candidate.status === 'review_ready' &&
+      candidate.execution.reviewUrl
+    ) {
+      return candidate.execution.reviewUrl;
+    }
   }
-  return fallbackUrl;
+  return undefined;
 }
 
 export function WorkflowInspector({
@@ -78,7 +83,14 @@ export function WorkflowInspector({
   const taskVisualStatus = task ? getEffectiveVisualStatus(task.status, task.execution) : null;
   const taskColors = taskVisualStatus ? getStatusColor(taskVisualStatus) : null;
   const workflowVisual = workflow ? workflowStatusVisual(workflow.status) : null;
-  const reviewUrl = task?.execution.reviewUrl ?? getWorkflowReviewUrl(workflowTasks);
+  const reviewUrl =
+    workflow?.status === 'review_ready'
+      ? task
+        ? task.config.isMergeNode && task.status === 'review_ready'
+          ? task.execution.reviewUrl
+          : undefined
+        : getReviewReadyMergeNodeReviewUrl(workflowTasks)
+      : undefined;
   const workflowTitle = workflow ? workflow.name || workflow.id : null;
   const nodeTitle = task?.description ?? workflowTitle ?? 'No node selected';
   const showsWorkflowMergeDetails = Boolean(!task && workflow?.id && workflow.onFinish === 'pull_request');
@@ -328,9 +340,9 @@ export function WorkflowInspector({
           </section>
         )}
 
-        <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
-          <div className="text-[11px] uppercase tracking-wide text-gray-400">Pull Request</div>
-          {reviewUrl ? (
+        {reviewUrl && (
+          <section className="rounded border border-gray-700 bg-gray-800/70 p-3">
+            <div className="text-[11px] uppercase tracking-wide text-gray-400">Pull Request</div>
             <a
               href={reviewUrl}
               target="_blank"
@@ -339,10 +351,8 @@ export function WorkflowInspector({
             >
               {reviewUrl}
             </a>
-          ) : (
-            <div className="mt-1 text-xs text-gray-400">No PR linked</div>
-          )}
-        </section>
+          </section>
+        )}
 
         <section className="rounded border border-gray-700 bg-gray-800/70">
           <button


### PR DESCRIPTION
## Summary

Restrict the right-side `WorkflowInspector` panel so Pull Request details only appear when the selected node is a workflow review gate and the workflow status is `review_ready`. The inspector no longer falls back to arbitrary task `execution.reviewUrl` values and no longer renders an empty Pull Request card for ordinary tasks or for review gates that have not yet reached review readiness.

Scope is limited to the side inspector behavior and focused tests. Graph and approval-modal PR behavior are unchanged, and no PR copy is renamed.

## UI Screenshots

Not review ready: no Pull Request link is shown in the workflow inspector.

![Not review ready workflow PR sidebar](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260517-c9722a/not-review-ready-workflow-pr-sidebar.png)

Review ready: the Pull Request link is shown once the workflow reaches `review_ready`.

![Review ready workflow PR sidebar](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260517-c9722a/review-ready-workflow-pr-sidebar.png)

## Test Plan

- [x] `pnpm install`
- [x] `cd packages/ui && pnpm test -- workflow-inspector.test.tsx`
- [x] `bash scripts/ui-visual-proof.sh validate`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 npx playwright test visual-proof.spec.ts -g "workflow inspector captures review-ready and not-review-ready pull request states"`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None. Reverting restores the prior inspector behavior of showing `reviewUrl` for any task with one set and removes the added visual-proof capture.
- Data migration? No
