### PR TITLE
Run full regression only at stack terminal workflow

### DIFF
--- a/packages/surfaces/src/__tests__/plan-conversation.test.ts
+++ b/packages/surfaces/src/__tests__/plan-conversation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { PlanConversation, extractYamlPlan, rewritePnpmTestCommand, globToRegex, isDangerousCommand, isConfirmation } from '../slack/plan-conversation.js';
+import { PlanConversation, extractYamlPlan, globToRegex, isDangerousCommand, isConfirmation } from '../slack/plan-conversation.js';
 import { parse as parseYaml } from 'yaml';
 import * as child_process from 'node:child_process';
 import { EventEmitter } from 'node:events';
@@ -161,34 +161,31 @@ tasks:
     expect(plan.tasks[0].requiresManualApproval).toBe(true);
   });
 
-  it('rewrites npx vitest run to pnpm test in task commands', () => {
+  it('preserves discovered repo commands without rewriting them', () => {
     const text = `\`\`\`yaml
-name: "Rewrite Test"
+name: "Preserve Commands"
 tasks:
-  - id: run-tests
-    description: "Run tests"
+  - id: run-vitest
+    description: "Run Vitest"
     command: "cd packages/surfaces && npx vitest run"
     dependencies: []
-\`\`\``;
-    const result = extractYamlPlan(text);
-    expect(result).not.toBeNull();
-    const plan = parsePlanText(result!);
-    expect(plan.tasks[0].command).toBe('cd packages/surfaces && pnpm test');
-  });
-
-  it('rewrites pnpm test packages/... to cd packages/... && pnpm test', () => {
-    const text = `\`\`\`yaml
-name: "Rewrite Root Test"
-tasks:
-  - id: run-tests
-    description: "Run tests"
+  - id: run-root-package-test
+    description: "Run package test"
     command: "pnpm test packages/protocol/src/__tests__/validation.test.ts"
-    dependencies: []
+    dependencies:
+      - run-vitest
+  - id: run-npm-test
+    description: "Run npm test"
+    command: "npm test -- src/foo.test.ts"
+    dependencies:
+      - run-root-package-test
 \`\`\``;
     const result = extractYamlPlan(text);
     expect(result).not.toBeNull();
     const plan = parsePlanText(result!);
-    expect(plan.tasks[0].command).toBe('cd packages/protocol && pnpm test -- src/__tests__/validation.test.ts');
+    expect(plan.tasks[0].command).toBe('cd packages/surfaces && npx vitest run');
+    expect(plan.tasks[1].command).toBe('pnpm test packages/protocol/src/__tests__/validation.test.ts');
+    expect(plan.tasks[2].command).toBe('npm test -- src/foo.test.ts');
   });
 
   it('extracts correctly when YAML contains nested triple backticks', () => {
@@ -336,33 +333,6 @@ Does this look better?`;
   });
 });
 
-describe('rewritePnpmTestCommand', () => {
-  it('rewrites pnpm test packages/<pkg>/<path> to cd + pnpm test -- <relpath>', () => {
-    expect(rewritePnpmTestCommand('pnpm test packages/protocol/src/__tests__/validation.test.ts'))
-      .toBe('cd packages/protocol && pnpm test -- src/__tests__/validation.test.ts');
-  });
-
-  it('rewrites pnpm test -- packages/<pkg>/<path>', () => {
-    expect(rewritePnpmTestCommand('pnpm test -- packages/surfaces/src/__tests__/slack.test.ts'))
-      .toBe('cd packages/surfaces && pnpm test -- src/__tests__/slack.test.ts');
-  });
-
-  it('rewrites pnpm test packages/<pkg> (no file)', () => {
-    expect(rewritePnpmTestCommand('pnpm test packages/protocol'))
-      .toBe('cd packages/protocol && pnpm test');
-  });
-
-  it('preserves trailing suffixes like 2>&1', () => {
-    expect(rewritePnpmTestCommand('pnpm test packages/ui/src/__tests__/foo.test.ts 2>&1'))
-      .toBe('cd packages/ui && pnpm test -- src/__tests__/foo.test.ts 2>&1');
-  });
-
-  it('returns already-correct commands unchanged', () => {
-    expect(rewritePnpmTestCommand('cd packages/protocol && pnpm test'))
-      .toBe('cd packages/protocol && pnpm test');
-  });
-});
-
 describe('globToRegex', () => {
   it('converts *.ts to match .ts files', () => {
     const re = globToRegex('*.ts');
@@ -456,7 +426,7 @@ describe('PlanConversation', () => {
     const prompt = mockSpawn.mock.calls[0][1][1] as string;
     expect(prompt).toContain('YAML task plan');
     expect(prompt).toContain('Hello');
-    expect(prompt).toContain('pnpm run test:all');
+    expect(prompt).toContain('Use the package manager and test runner the target repo already uses');
   });
 
   it('submittedPlanText is null before confirmation', async () => {

--- a/packages/surfaces/src/slack/plan-conversation.ts
+++ b/packages/surfaces/src/slack/plan-conversation.ts
@@ -109,15 +109,14 @@ Rules:
 3. Keep plans focused — 3-8 tasks maximum.
 4. File-count guidance is a soft heuristic, not a hard validator gate. Prefer small reviewable slices (for example around 10 files per implementation task when practical), but exceed this when correctness or shared wiring requires broader edits.
 5. Each task should have either a \`command\` or a \`prompt\`, not both.
-6. Every step MUST be testable. Every implementation task MUST have a corresponding test task that verifies it works using a concrete, executable \`command\` (e.g. \`cd packages/protocol && pnpm test\`, \`git diff --name-only\`). The test command must produce a clear pass/fail exit code. Do NOT skip tests for any step. Do NOT use prompts for test tasks — use commands only.
+6. Every step MUST be testable. Every implementation task MUST have a corresponding test task that verifies it works using a concrete, executable \`command\` discovered from the target repo (e.g. that repo's package scripts, build commands, or focused checks such as \`git diff --name-only\`). The test command must produce a clear pass/fail exit code. Do NOT skip tests for any step. Do NOT use prompts for test tasks — use commands only.
    Test command rules:
-   - For focused package tests, ALWAYS cd into the package directory first: \`cd packages/<pkg> && pnpm test\`
-   - To target a specific test file: \`cd packages/<pkg> && pnpm test -- src/__tests__/file.test.ts\`
-   - NEVER run \`pnpm test <path>\` from the repo root — it runs \`pnpm -r test\` across all packages and the path will be wrong
-   - NEVER use \`npx vitest run\` — always use \`pnpm test\` which runs the package.json test script
-   - For implementation plans (\`onFinish\` is not \`none\`), the FINAL task MUST be a \`command\` task that runs \`pnpm run test:all\` from the repo root
-   - That final \`pnpm run test:all\` task MUST depend on every earlier task so it is the terminal regression gate
-   - If Invoker config auto-routes heavyweight commands, keep \`pnpm ...\` as a normal command unless the task must name a specific remote target
+   - Inspect repo manifests and existing docs/scripts before choosing commands.
+   - Use the package manager and test runner the target repo already uses; do not impose Invoker-specific commands on external repos.
+   - For focused package tests in a monorepo, run from the relevant package/workspace directory or use the repo's documented workspace filter.
+   - To target a specific test file, use the syntax supported by the discovered test script.
+   - Prefer focused verification during iteration and reserve broad/full-suite commands for the final gate only when the target repo documents such a command.
+   - If Invoker config auto-routes heavyweight commands, keep discovered test/build commands as normal command tasks unless the task must name a specific remote target
    - NEVER invent test file names. Verify the test file exists before referencing it in a command.
 7. Use meaningful task IDs (kebab-case).
 8. When ready, output the plan inside a \`\`\`yaml code block.
@@ -434,31 +433,11 @@ export function globToRegex(pattern: string): RegExp {
   return new RegExp(`^${escaped}$`);
 }
 
-// ── Command Rewriting ────────────────────────────────────────
-
-/**
- * Rewrite `pnpm test packages/<pkg>/...` (run from repo root, incorrect)
- * into `cd packages/<pkg> && pnpm test -- <relative-path>` (correct).
- */
-export function rewritePnpmTestCommand(cmd: string): string {
-  const withFile = cmd.match(/^(pnpm test)\s+(?:--\s+)?packages\/([^/\s]+)\/(\S+)(.*)/);
-  if (withFile) {
-    const [, , pkg, rest, suffix] = withFile;
-    return `cd packages/${pkg} && pnpm test -- ${rest}${suffix}`;
-  }
-  const pkgOnly = cmd.match(/^(pnpm test)\s+(?:--\s+)?packages\/([^/\s]+)(.*)/);
-  if (pkgOnly) {
-    const [, , pkg, suffix] = pkgOnly;
-    return `cd packages/${pkg} && pnpm test${suffix}`;
-  }
-  return cmd;
-}
-
 // ── YAML Extraction ─────────────────────────────────────────
 
 /**
  * Extract and validate a YAML plan from a message containing ```yaml blocks.
- * Returns the raw YAML string (with command rewrites applied) or null if invalid.
+ * Returns the raw YAML string or null if invalid.
  * Defaulting (onFinish, baseBranch, mergeMode, etc.) is NOT applied here —
  * callers should pass the returned string through parsePlan() for that.
  */
@@ -503,20 +482,9 @@ export function extractYamlPlan(text: string): string | null {
         console.warn(`extractYamlPlan: task missing id or description: ${JSON.stringify(task).slice(0, 120)}`);
         return null;
       }
-      if (task.command && /\bnpx vitest run\b/.test(task.command)) {
-        console.warn(`extractYamlPlan: task "${task.id}" uses 'npx vitest run' — rewriting to 'pnpm test'`);
-        task.command = task.command.replace(/\bnpx vitest run\b/, 'pnpm test');
-      }
-      if (task.command && /\bpnpm test\b.*\bpackages\//.test(task.command)) {
-        const rewritten = rewritePnpmTestCommand(task.command);
-        if (rewritten !== task.command) {
-          console.warn(`extractYamlPlan: task "${task.id}" uses root-level 'pnpm test packages/...' — rewriting to '${rewritten}'`);
-          task.command = rewritten;
-        }
-      }
     }
 
-    // Return serialized YAML (with command rewrites applied) — no defaulting
+    // Return serialized YAML as provided — no defaulting or repo-specific command rewriting.
     return stringifyYaml(plan);
   } catch (err) {
     console.warn(`extractYamlPlan: YAML parse error: ${err instanceof Error ? err.message : String(err)}`);

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -58,7 +58,7 @@ must_contain "$SKILL_MD" "## Intended flow (do not skip steps)" "SKILL must docu
 must_contain "$SKILL_MD" "Runtime verification (Phase 1b)" "SKILL must require runtime behavioral verification"
 must_contain "$SKILL_MD" "Invoker headless" "SKILL must mention Invoker headless as a verification lane"
 must_contain "$SKILL_MD" "pnpm test" "SKILL must mention pnpm test for behavioral proof"
-must_contain "$SKILL_MD" "pnpm run test:all" "SKILL must require the final full-suite regression gate for implementation plans"
+must_contain "$SKILL_MD" "terminal stack workflows must end with" "SKILL must require the final full-suite regression gate for standalone plans and terminal stack workflows"
 must_contain "$SKILL_MD" "Grep-only checks" "SKILL must separate grep from behavioral verification"
 must_contain "$SKILL_MD" "see playbook" "SKILL Execution must reference the playbook"
 must_contain "$SKILL_MD" "Phase 1b" "SKILL must reference Phase 1b"

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -33,7 +33,7 @@ Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b 
 
 **Cross-layer dependency direction (required):** Dependency DAGs must flow from lower/foundational layers toward higher/integration layers. If a lower-layer task depends on a higher-layer task, mark an explicit exception in the task description with `Layer exception: allowed` and a rationale.
 
-**Experiment artifact persistence rule (required when prompt tasks design experiments):** Any `experiment-*` prompt task must write a deterministic artifact path (for example `docs/context/<issue>/experiment-brief.md`) and commit it during that task. Any `implement-*` task that depends on that experiment must reference and consume the exact artifact path in both `description` and `prompt` with explicit acceptance language. The workflow must include a dedicated cleanup task (typically `cleanup-experiment-artifacts-*`) that removes the artifact and commits cleanup before the final regression gate (`pnpm run test:all`).
+**Experiment artifact persistence rule (required when prompt tasks design experiments):** Any `experiment-*` prompt task must write a deterministic artifact path (for example `docs/context/<issue>/experiment-brief.md`) and commit it during that task. Any `implement-*` task that depends on that experiment must reference and consume the exact artifact path in both `description` and `prompt` with explicit acceptance language. The workflow must include a dedicated cleanup task (typically `cleanup-experiment-artifacts-*`) that removes the artifact and commits cleanup before that workflow's final verification gate.
 
 **Bugfix repro:** For bug/regression plans, a shared `bash scripts/repro-<slug>.sh` (or the same `command:` before and after) is **strongly recommended**; **`skill-doctor` does not require it.** If the fix invalidates the original repro, use another explicit verification task. See `references/task-patterns.md` § *Bugfix repro*.
 
@@ -80,7 +80,7 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
    `bash skills/plan-to-invoker/scripts/validate-plan.sh <plan-file>`
 4. `step-lint-atomicity`
    `bash skills/plan-to-invoker/scripts/lint-task-atomicity.sh <plan-file>`  
-  Optional: append `--warn-delegation` to print additional advisory hints. Atomicity lint always runs `--strict-delegation` inside `skill-doctor` and, for implementation plans (`onFinish != none`), hard-fails missing/invalid `Layer:` and `Feature state:` metadata, missing required rationale headings in `description` on any task (`Goal`, `Motivation`, `Alternative considerations`/`Alternatives`, `Implementation details`/`Implementation`), missing required rationale headings in `prompt` for prompt tasks, prompt tasks without `Files:`/`Change types:`/`Acceptance criteria:` description blocks, prompts missing zero-context execution framing, prompts missing deterministic pass/fail expectations, invalid cross-layer dependency direction without `Layer exception: allowed`, and missing experiment-artifact handoff/cleanup contract when experiment tasks are present.
+  Optional: append `--warn-delegation` to print additional advisory hints. For authored stacks, append `--stack-manifest <file>` so non-terminal workflows may end with focused verification while the highest-order workflow still requires `pnpm run test:all`. Atomicity lint always runs `--strict-delegation` inside `skill-doctor` and, for implementation plans (`onFinish != none`), hard-fails missing/invalid `Layer:` and `Feature state:` metadata, missing required rationale headings in `description` on any task (`Goal`, `Motivation`, `Alternative considerations`/`Alternatives`, `Implementation details`/`Implementation`), missing required rationale headings in `prompt` for prompt tasks, prompt tasks without `Files:`/`Change types:`/`Acceptance criteria:` description blocks, prompts missing zero-context execution framing, prompts missing deterministic pass/fail expectations, invalid cross-layer dependency direction without `Layer exception: allowed`, and missing experiment-artifact handoff/cleanup contract when experiment tasks are present.
 5. `step-parse-verify-results`
    `bash skills/plan-to-invoker/scripts/parse-results.sh < /tmp/invoker-verify.txt`
 
@@ -116,7 +116,7 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
 - Unit/package lane: `cd packages/<pkg> && pnpm test`
 - Invoker headless lane: run `./submit-plan.sh plans/verify-<slug>.yaml` when flow involves orchestrator/executor/persistence/headless behavior
 - Visual proof lane when UI changes apply
-- Implementation-plan final gate: the last task in any plan with `onFinish != none` must run `pnpm run test:all` from the repo root and depend on every earlier task
+- Implementation-plan full-suite gate: standalone implementation plans and terminal stack workflows must end with `pnpm run test:all` from the repo root and depend on every earlier task. Non-terminal stack workflows should end with focused verification; validate them with `skill-doctor --stack-manifest <file>` so the stack position is explicit.
 
 When Invoker config enables heavyweight command routing, keep `pnpm ...` commands in the plan as normal command tasks unless a specific remote target must be declared explicitly. Runtime config may auto-route those commands to SSH.
 

--- a/skills/plan-to-invoker/fixtures/README.md
+++ b/skills/plan-to-invoker/fixtures/README.md
@@ -37,7 +37,7 @@ Positive fixtures demonstrate valid plan patterns:
 - **05-ui-change-with-visual-proof.yaml** - UI workflow that pairs visual proof with a final full-suite regression gate
 - **06-invoker-dogfood-mergify-stack.yaml** - Invoker-on-Invoker PR publication example with a final full-suite regression gate
 - **07-prompt-edit-layered-split-with-dormant.yaml** - Dependency-first layer split for prompt-edit bridge work, including a dormant activation slice
-- Implementation fixtures with `onFinish != none` end with a final `pnpm run test:all` task
+- Standalone implementation fixtures with `onFinish != none` end with a final `pnpm run test:all` task. In authored stacks, only the terminal workflow requires that full-suite gate; non-terminal workflows must be validated with a stack manifest.
 
 All positive fixtures are extracted from `references/examples.md` sections 1-4.
 
@@ -55,7 +55,7 @@ Negative fixtures demonstrate anti-patterns and validation errors:
 - **anti-pattern-f-dangerous-commands.yaml** - Dangerous commands (rm -rf, force push, etc.)
 - **anti-pattern-g-monolithic-prompt-edit-bridge.yaml** - Monolithic `wf-1777929074509-8`-shaped workflow missing required layer/state decomposition metadata (**fails `skill-doctor` lint, not YAML schema**)
 - **anti-pattern-h-layer-order-violation.yaml** - Lower architectural layer depends on a higher layer without `Layer exception: allowed` (**fails `skill-doctor` lint, not YAML schema**)
-- **anti-pattern-i-final-regression-not-test-all.yaml** - Implementation workflow missing the terminal `pnpm run test:all` regression gate (**fails `skill-doctor` lint, not YAML schema**)
+- **anti-pattern-i-final-regression-not-test-all.yaml** - Standalone implementation workflow missing the terminal `pnpm run test:all` regression gate (**fails `skill-doctor` lint, not YAML schema**)
 
 ### Edge Cases (specific validation errors)
 

--- a/skills/plan-to-invoker/fixtures/negative/anti-pattern-i-final-regression-not-test-all.yaml
+++ b/skills/plan-to-invoker/fixtures/negative/anti-pattern-i-final-regression-not-test-all.yaml
@@ -1,11 +1,11 @@
-# Anti-Pattern I: Implementation plan without terminal full-suite regression
+# Anti-Pattern I: Standalone implementation plan without terminal full-suite regression
 # Expected outcome: validate-plan passes schema, but skill-doctor fails lint-task-atomicity
-# because implementation workflows must end with a `pnpm run test:all` task that
-# depends on every earlier task.
+# because standalone implementation workflows must end with a `pnpm run test:all`
+# task that depends on every earlier task.
 
 name: "Anti-pattern: final regression is not full suite"
 description: |
-  Demonstrates an implementation workflow that incorrectly ends with a
+  Demonstrates a standalone implementation workflow that incorrectly ends with a
   package-scoped test command instead of the required full-suite gate.
 onFinish: pull_request
 mergeMode: github

--- a/skills/plan-to-invoker/playbooks/verify-then-build.md
+++ b/skills/plan-to-invoker/playbooks/verify-then-build.md
@@ -165,13 +165,13 @@ The implementation plan **must** end with a final **`command`** task that runs:
 
 - `pnpm run test:all`
 
-Use earlier tasks to re-run the focused repro from Phase 1b (`cd packages/<pkg> && pnpm test -- <repro>`, `./submit-plan.sh plans/verify-<slug>.yaml`, or both). The terminal gate for submitted implementation plans is always the full repo suite.
+Use earlier tasks to re-run the focused repro from Phase 1b (`cd packages/<pkg> && pnpm test -- <repro>`, `./submit-plan.sh plans/verify-<slug>.yaml`, or both). The terminal gate for standalone implementation plans and terminal stack workflows is the full repo suite; non-terminal stack workflows use focused verification.
 
-**Dependencies:** The final `pnpm run test:all` task **must depend on every earlier task** so it runs last as the terminal regression gate.
+**Dependencies:** When present, the final `pnpm run test:all` task **must depend on every earlier task** so it runs last as the terminal regression gate.
 
 **Naming:** `final-regression`, `regression-test-all`, `final-test-suite`, etc.
 
-**Anti-pattern:** Implementation plan with **no** final `pnpm run test:all` task — you cannot show the submitted workflow passed the full suite end-to-end.
+**Anti-pattern:** Standalone implementation plan or terminal stack workflow with **no** final `pnpm run test:all` task — you cannot show the submitted workflow or stack passed the full suite end-to-end.
 
 ### Visual proof capture task (when `visualProof: true`)
 
@@ -199,4 +199,4 @@ Generate the implementation plan, validate with `scripts/validate-plan.sh`, pres
 - **Not cleaning up verification workflow** — Invoker may still have the verify plan running. Use `delete-all` before submitting implementation when needed.
 - **Trusting file paths from a plan without checking** — plans can reference moved, renamed, or deleted files. Verify first.
 - **Proceeding after verification failures without adjusting** — the whole point of Phase 1 is to inform Phase 2.
-- **Implementation plan without a final `pnpm run test:all` task** — cannot confirm the submitted workflow passed the full suite.
+- **Standalone plan or terminal stack workflow without a final `pnpm run test:all` task** — cannot confirm the submitted workflow or stack passed the full suite.

--- a/skills/plan-to-invoker/references/examples.md
+++ b/skills/plan-to-invoker/references/examples.md
@@ -20,7 +20,7 @@ Standard pattern: **implement → test → verify**. Uses `onFinish: merge` to a
 
 **See**: `fixtures/positive/02-feature-implementation.yaml`
 
-**Pattern**: Every prompt task MUST have a corresponding command task to verify, and implementation plans end with a final `pnpm run test:all` gate.
+**Pattern**: Every prompt task MUST have a corresponding command task to verify. Standalone implementation plans and terminal stack workflows end with a final `pnpm run test:all` gate; non-terminal stack workflows end with focused verification.
 
 ---
 
@@ -55,7 +55,7 @@ Complex plan with diamond dependencies. Uses `onFinish: pull_request` for manual
 - `fixtures/negative/anti-pattern-f-dangerous-commands.yaml` — Avoid destructive commands (`rm -rf`, force push)
 - `fixtures/negative/anti-pattern-g-monolithic-prompt-edit-bridge.yaml` — Monolithic `wf-1777929074509-8`-style workflow missing dependency-first layered decomposition metadata
 - `fixtures/negative/anti-pattern-h-layer-order-violation.yaml` — Lower layer depends on higher layer without `Layer exception: allowed`
-- `fixtures/negative/anti-pattern-i-final-regression-not-test-all.yaml` — Implementation plan ends without a terminal `pnpm run test:all` gate
+- `fixtures/negative/anti-pattern-i-final-regression-not-test-all.yaml` — Standalone implementation plan ends without a terminal `pnpm run test:all` gate
 - `fixtures/negative/anti-pattern-j-zero-context-missing-metadata.yaml` — Prompt task omits strict zero-context handoff metadata required for implementation plans
 
 All anti-patterns are validated by `scripts/test-fixtures.sh` with deterministic error detection.
@@ -143,7 +143,7 @@ Use this pattern when a change is too large for a single reviewable workflow. Fo
 
 **Validation enforces**:
 - Every prompt task must have verification command task
-- Implementation plans must end with `pnpm run test:all` as the final regression gate
+- Standalone implementation plans and terminal stack workflows must end with `pnpm run test:all` as the final regression gate
 - Use `pnpm test`, never `npx vitest run`
 - Dependencies field required (even if empty)
 - No dangerous commands without manual approval

--- a/skills/plan-to-invoker/references/schema.md
+++ b/skills/plan-to-invoker/references/schema.md
@@ -50,7 +50,7 @@ Source of truth: `packages/app/src/plan-parser.ts` (interfaces + validation, lin
 
 ## Implementation plans (convention)
 
-`plan-parser.ts` does not require a special field for this, but **implementation** YAML (not one-off verify-only plans) must reserve the **last** task for the terminal regression gate: a `command` task that runs `pnpm run test:all`. Keep focused package/headless repro commands earlier in the plan. The final `pnpm run test:all` task must depend on every earlier task so it runs last. See `references/task-patterns.md` and `playbooks/verify-then-build.md` Phase 2.
+`plan-parser.ts` does not require a special field for this, but **standalone implementation** YAML (not one-off verify-only plans) must reserve the **last** task for the terminal regression gate: a `command` task that runs `pnpm run test:all`. In authored stacks, reserve that full-suite task for the highest-order workflow in the stack manifest; non-terminal stack workflows should end with focused package/headless repro verification. When a final `pnpm run test:all` task is present, it must depend on every earlier task so it runs last. See `references/task-patterns.md` and `playbooks/verify-then-build.md` Phase 2.
 
 ## Banned Patterns
 

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -17,7 +17,7 @@ Source of truth: `packages/surfaces/src/slack/plan-conversation.ts:100-116`
 | "Lint / type-check" | `command` | `pnpm --filter @invoker/<pkg> lint` or `pnpm --filter @invoker/<pkg> typecheck` |
 | "Check file exists" | `command` | `test -f <path>` |
 | "Check pattern in file" | `command` | `grep -q '<pattern>' <path>` |
-| **Post-fix / regression** (final submitted-plan gate) | `command` | `pnpm run test:all` — keep focused repro commands earlier in the plan, but the final task for implementation plans must be the full-suite gate |
+| **Post-fix / regression** (standalone or terminal stack gate) | `command` | `pnpm run test:all` — keep focused repro commands earlier in the plan, and reserve the full-suite gate for standalone plans or the terminal stack workflow |
 | "Modify UI component" / "Fix layout" | `prompt` + `visualProof: true` | Set `visualProof: true` at plan level; include `description` |
 | **Add visual proof E2E test case** | `prompt` | Add a test to `packages/app/e2e/visual-proof.spec.ts` that sets up the exact UI state being changed and calls `captureScreenshot(page, '<plan-slug>-<state>')`. See `skills/visual-proof/SKILL.md`. |
 | **Capture visual proof (after)** | `command` | `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after` — depends on **all** implementation tasks |
@@ -32,7 +32,7 @@ These are constraints, not guidelines. Violating them produces broken plans.
 - **Test task** → depends on the implementation task it verifies.
 - **Build/compile check** → depends on all implementation tasks that change source.
 - **Integration test** → depends on all unit-level tasks it integrates.
-- **Final regression task** → depends on **every earlier task** and runs **last** as `pnpm run test:all`.
+- **Final full-suite regression task** → for standalone plans and terminal stack workflows, depends on **every earlier task** and runs **last** as `pnpm run test:all`; non-terminal stack workflows end with focused verification instead.
 - **Visual proof capture task** → depends on **all** implementation tasks and the E2E test case task (it must run after code changes AND the new Playwright test exist).
 
 ### Can be parallel (no dependency needed)
@@ -187,7 +187,7 @@ See `SKILL.md` (bugfix repro blurb) and this repo’s `scripts/repro-*.sh` examp
 
 When writing `command` fields:
 
-1. **Package tests must `cd` first**: `cd packages/<pkg> && pnpm test`; reserve root-level `pnpm run test:all` for the final implementation-plan regression gate
+1. **Package tests must `cd` first**: `cd packages/<pkg> && pnpm test`; reserve root-level `pnpm run test:all` for standalone plans or the final workflow in an authored stack.
 2. **Use `&&` for sequential steps**: ensures early failure stops execution
 3. **Exit codes matter**: the command succeeds (exit 0) or fails (non-zero). Design accordingly.
 4. **No interactive commands**: everything must run non-interactively
@@ -246,7 +246,7 @@ tasks:
 
 - **God task**: one `prompt` task that says "implement the whole feature" — split it up.
 - **Test-free plan**: every implementation task needs a corresponding verification. No exceptions.
-- **No final full-suite task**: implementation plans must end with a **command** task that runs `pnpm run test:all`.
+- **No final full-suite task**: standalone implementation plans and terminal stack workflows must end with a **command** task that runs `pnpm run test:all`. Non-terminal stack workflows must be validated with a stack manifest and focused verification.
 - **Circular dependencies**: task A depends on B, B depends on A — validator catches this but don't generate it.
 - **Phantom files**: referencing files that don't exist without a task to create them first.
 - **UI plan without visual proof tasks**: `visualProof: true` without the E2E test case task and capture task means no plan-specific screenshots are captured.

--- a/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
+++ b/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 # Enforce atomic + detailed task quality constraints for Invoker plans.
-# Usage: bash lint-task-atomicity.sh [--warn-delegation] [--strict-delegation] <plan.yaml>
+# Usage: bash lint-task-atomicity.sh [--warn-delegation] [--strict-delegation] [--stack-manifest FILE] <plan.yaml>
 #
 # --warn-delegation  Print advisory warnings if task descriptions omit best-effort
 #                    delegation headings (Files: / Change types: / Acceptance criteria:).
 #                    Does not change exit code (still 0 if no hard errors). Optional.
 # --strict-delegation  For implementation plans (onFinish != none), fail prompt tasks
 #                    that are not self-contained for zero-context remote execution.
+# --stack-manifest FILE
+#                    When validating an authored stack, require the full-suite
+#                    pnpm run test:all gate only on the highest-order workflow.
 set -euo pipefail
 
 warn_delegation=0
 strict_delegation=0
+stack_manifest_file=""
 while [[ $# -gt 0 ]]; do
   case "${1:-}" in
     --warn-delegation)
@@ -21,20 +25,98 @@ while [[ $# -gt 0 ]]; do
       strict_delegation=1
       shift
       ;;
+    --stack-manifest)
+      stack_manifest_file="${2:-}"
+      if [[ -z "$stack_manifest_file" ]]; then
+        echo "ERROR: --stack-manifest requires a file path" >&2
+        exit 2
+      fi
+      shift 2
+      ;;
     *)
       break
       ;;
   esac
 done
 
-file="${1:?Usage: lint-task-atomicity.sh [--warn-delegation] [--strict-delegation] <plan.yaml>}"
+file="${1:?Usage: lint-task-atomicity.sh [--warn-delegation] [--strict-delegation] [--stack-manifest FILE] <plan.yaml>}"
 
 if [[ ! -f "$file" ]]; then
   echo "ERROR: File not found: $file" >&2
   exit 1
 fi
 
-awk -v warnDelegation="$warn_delegation" -v strictDelegation="$strict_delegation" '
+require_final_test_all=1
+if [[ -n "$stack_manifest_file" ]]; then
+  if [[ ! -f "$stack_manifest_file" ]]; then
+    echo "ERROR: Stack manifest not found: $stack_manifest_file" >&2
+    exit 1
+  fi
+  require_final_test_all="$(
+    python3 - "$file" "$stack_manifest_file" <<'PY'
+import json
+import pathlib
+import subprocess
+import sys
+
+plan_file = pathlib.Path(sys.argv[1]).resolve()
+manifest_file = pathlib.Path(sys.argv[2]).resolve()
+
+try:
+    data = json.loads(manifest_file.read_text(encoding="utf-8"))
+except Exception as exc:
+    print(f"ERROR: failed to parse stack manifest: {exc}", file=sys.stderr)
+    sys.exit(1)
+
+manifest_dir = manifest_file.parent
+try:
+    repo_root_raw = subprocess.check_output(
+        ["git", "-C", str(manifest_dir), "rev-parse", "--show-toplevel"],
+        text=True,
+        stderr=subprocess.DEVNULL,
+    ).strip()
+    repo_root = pathlib.Path(repo_root_raw)
+except Exception:
+    repo_root = None
+
+def resolve(candidate: str) -> pathlib.Path:
+    path = pathlib.Path(candidate)
+    if path.is_absolute():
+        return path.resolve()
+    if repo_root is not None:
+        return (repo_root / path).resolve()
+    return (manifest_dir / path).resolve()
+
+workflows = data.get("workflows")
+if not isinstance(workflows, list) or not workflows:
+    print("ERROR: stack manifest must contain a non-empty workflows array", file=sys.stderr)
+    sys.exit(1)
+
+rows = []
+for item in workflows:
+    if not isinstance(item, dict):
+        continue
+    plan = item.get("planFile")
+    order = item.get("order")
+    if isinstance(plan, str) and plan.strip() and isinstance(order, int):
+        rows.append((order, resolve(plan)))
+
+if not rows:
+    print("ERROR: stack manifest has no valid planFile/order entries", file=sys.stderr)
+    sys.exit(1)
+
+matches = [order for order, path in rows if path == plan_file]
+if not matches:
+    print(f"ERROR: plan file is not listed in stack manifest: {plan_file}", file=sys.stderr)
+    sys.exit(1)
+
+max_order = max(order for order, _ in rows)
+print("1" if max(matches) == max_order else "0")
+PY
+  )"
+fi
+
+awk -v warnDelegation="$warn_delegation" -v strictDelegation="$strict_delegation" -v requireFinalTestAll="$require_final_test_all" '
 function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
 function strip_quotes(s) { gsub(/["'\''"]/, "", s); return s }
 function normalize_command(s) {
@@ -434,7 +516,7 @@ END {
       }
 
       if (cleanup_id == "") {
-        errors[++errn] = "Task \"" experiment_id "\" requires cleanup task \"cleanup-experiment-artifacts-" suffix "\" before final regression gate"
+        errors[++errn] = "Task \"" experiment_id "\" requires cleanup task \"cleanup-experiment-artifacts-" suffix "\" before that workflow final verification gate"
       } else {
         cleanup_idx = task_id_to_index[cleanup_id]
         if (cleanup_idx > 0) {
@@ -474,15 +556,15 @@ END {
     }
   }
 
-  if (enforce_layering == 1 && taskn > 0) {
+  if (enforce_layering == 1 && requireFinalTestAll == 1 && taskn > 0) {
     final_idx = taskn
     final_id = task_ids[final_idx]
     final_command = task_command_line[final_idx]
 
     if (task_has_command[final_idx] != 1) {
-      errors[++errn] = "Task \"" final_id "\" must be a command task because implementation plans require a final pnpm run test:all regression gate"
+      errors[++errn] = "Task \"" final_id "\" must be a command task because standalone implementation plans and terminal stack workflows require a final pnpm run test:all regression gate"
     } else if (final_command != "pnpm run test:all") {
-      errors[++errn] = "Task \"" final_id "\" must be the final regression gate and run exactly \"pnpm run test:all\""
+      errors[++errn] = "Task \"" final_id "\" must be the final full-suite regression gate and run exactly \"pnpm run test:all\""
     }
 
     split(task_dependencies[final_idx], final_dep_ids, /,/)

--- a/skills/plan-to-invoker/scripts/skill-doctor.sh
+++ b/skills/plan-to-invoker/scripts/skill-doctor.sh
@@ -303,6 +303,9 @@ fi
 # Check 4: Task atomicity linting (if not skipped)
 if [[ "$SKIP_ATOMICITY" == "false" ]]; then
   atomicity_args=(--strict-delegation)
+  if [[ -n "$STACK_MANIFEST_FILE" ]]; then
+    atomicity_args+=(--stack-manifest "$STACK_MANIFEST_FILE")
+  fi
   if [[ "$WARN_DELEGATION" == "true" ]]; then
     atomicity_args+=(--warn-delegation)
     run_check \

--- a/skills/plan-to-invoker/scripts/test-fixtures.sh
+++ b/skills/plan-to-invoker/scripts/test-fixtures.sh
@@ -424,10 +424,151 @@ EOF
     return 1
   fi
 
-  if ! grep -q 'must be the final regression gate and run exactly "pnpm run test:all"' <<<"$output"; then
+  if ! grep -q 'must be the final full-suite regression gate and run exactly "pnpm run test:all"' <<<"$output"; then
     echo "Expected final gate command error, got: $output" >&2
     return 1
   fi
+}
+
+test_lint_allows_nonterminal_stack_workflow_without_test_all() {
+  local temp_dir first_plan second_plan stack_manifest
+  temp_dir=$(mktemp -d)
+  trap "rm -rf $temp_dir" RETURN
+  first_plan="$temp_dir/stack-step-1.yaml"
+  second_plan="$temp_dir/stack-step-2.yaml"
+  stack_manifest="$temp_dir/stack-manifest.json"
+
+  cat > "$first_plan" <<'EOF'
+name: "Stack step 1 without full-suite gate"
+description: "First implementation workflow in a stack with focused verification only."
+onFinish: pull_request
+mergeMode: github
+repoUrl: git@github.com:example-org/acme-repo.git
+featureBranch: plan/stack-step-1
+tasks:
+  - id: implement-surface
+    description: |
+      Goal:
+      - Implement the first stacked workflow surface change.
+      Motivation:
+      - Keep non-terminal stack workflows fast while preserving focused verification.
+      Alternative considerations:
+      - Option A (chosen): focused package verification before the PR gate.
+      - Option B: repeat full-suite verification in every stack layer.
+      Implementation details:
+      - Update packages/foo/src/surface.ts with the stack step one behavior.
+      Layer: contact_surface
+      Feature state: active
+      Files:
+      - packages/foo/src/surface.ts
+      Change types:
+      - Implementation update.
+      Acceptance criteria:
+      - The focused package verification task passes.
+    prompt: |
+      Goal:
+      - Implement the first stacked workflow surface change in packages/foo/src/surface.ts.
+      Motivation:
+      - Keep non-terminal stack workflows fast while preserving focused verification.
+      Alternative considerations:
+      - Option A (chosen): focused package verification before the PR gate.
+      - Option B: repeat full-suite verification in every stack layer.
+      Implementation details:
+      - Assume no prior context. Update packages/foo/src/surface.ts with the stack step one behavior.
+      Acceptance criteria:
+      - Pass condition: focused package tests exit code 0 after this change.
+    dependencies: []
+  - id: verify-surface
+    description: |
+      Goal:
+      - Run focused verification for the first stacked workflow.
+      Motivation:
+      - Catch local regressions without paying for the stack-level full suite.
+      Alternative considerations:
+      - Option A (chosen): package-scoped test command.
+      - Option B: root full-suite test in every stack layer.
+      Implementation details:
+      - Execute the package test lane for packages/foo.
+      Layer: app_regression
+      Feature state: active
+    command: "cd packages/foo && pnpm test"
+    dependencies: [implement-surface]
+EOF
+
+  cat > "$second_plan" <<'EOF'
+name: "Stack step 2 terminal full-suite gate"
+description: "Terminal implementation workflow in a stack with the full regression gate."
+onFinish: pull_request
+mergeMode: github
+repoUrl: git@github.com:example-org/acme-repo.git
+baseBranch: plan/stack-step-1
+featureBranch: plan/stack-step-2
+externalDependencies:
+  - workflowId: wf-upstream
+    taskId: "__merge__"
+    requiredStatus: completed
+    gatePolicy: completed
+tasks:
+  - id: implement-terminal-surface
+    description: |
+      Goal:
+      - Implement the terminal stacked workflow surface change.
+      Motivation:
+      - Validate the integrated stack at the final workflow only.
+      Alternative considerations:
+      - Option A (chosen): one full-suite gate at stack end.
+      - Option B: repeat full-suite verification in every stack layer.
+      Implementation details:
+      - Update packages/foo/src/terminal-surface.ts with the stack terminal behavior.
+      Layer: contact_surface
+      Feature state: active
+      Files:
+      - packages/foo/src/terminal-surface.ts
+      Change types:
+      - Implementation update.
+      Acceptance criteria:
+      - The terminal full-suite gate passes.
+    prompt: |
+      Goal:
+      - Implement the terminal stacked workflow surface change in packages/foo/src/terminal-surface.ts.
+      Motivation:
+      - Validate the integrated stack at the final workflow only.
+      Alternative considerations:
+      - Option A (chosen): one full-suite gate at stack end.
+      - Option B: repeat full-suite verification in every stack layer.
+      Implementation details:
+      - Assume no prior context. Update packages/foo/src/terminal-surface.ts with the stack terminal behavior.
+      Acceptance criteria:
+      - Pass condition: the final full-suite gate exits 0.
+    dependencies: []
+  - id: final-regression
+    description: |
+      Goal:
+      - Run final full-suite regression gate for the stack.
+      Motivation:
+      - Validate all stack layers together before publication.
+      Alternative considerations:
+      - Option A (chosen): root full-suite test only at stack end.
+      - Option B: root full-suite test in every stack layer.
+      Implementation details:
+      - Execute root-level test gate after all earlier terminal-workflow tasks complete.
+      Layer: e2e_regression
+      Feature state: active
+    command: "pnpm run test:all"
+    dependencies: [implement-terminal-surface]
+EOF
+
+  cat > "$stack_manifest" <<EOF
+{
+  "workflows": [
+    { "label": "Stack step 1", "planFile": "$first_plan", "order": 1 },
+    { "label": "Stack step 2", "planFile": "$second_plan", "order": 2 }
+  ]
+}
+EOF
+
+  bash "$LINT_SCRIPT" --stack-manifest "$stack_manifest" "$first_plan" >/dev/null
+  bash "$LINT_SCRIPT" --stack-manifest "$stack_manifest" "$second_plan" >/dev/null
 }
 
 test_lint_rejects_final_gate_missing_dependencies() {
@@ -917,6 +1058,7 @@ run_test "Edge: unrendered_template_placeholder" test_unrendered_template_placeh
 run_test "Edge: stacked_basebranch_default" test_stacked_basebranch_master
 run_test "Lint: valid final pnpm run test:all gate" test_lint_valid_final_test_all
 run_test "Lint: reject non-test:all final gate" test_lint_rejects_non_test_all_final_gate
+run_test "Lint: allow non-terminal stack workflow without test:all" test_lint_allows_nonterminal_stack_workflow_without_test_all
 run_test "Lint: reject final gate missing dependencies" test_lint_rejects_final_gate_missing_dependencies
 run_test "Lint: reject missing design sections for prompt tasks" test_lint_requires_design_sections_for_prompt_tasks
 run_test "Lint: accept prompt tasks with design sections" test_lint_accepts_design_sections_for_prompt_tasks


### PR DESCRIPTION
## Summary

Update the plan-to-invoker skill so full regression verification is required at the end of a standalone plan or terminal stack workflow, while non-terminal stack workflows can keep focused verification before their PR gate.

Keep the Slack planner repo-agnostic: it now tells planners to discover the target repo's package manager and test commands, and `extractYamlPlan` preserves authored commands instead of rewriting them into Invoker-specific pnpm commands.

## Test Plan

- [x] `bash skills/plan-to-invoker/scripts/test-fixtures.sh`
- [x] `bash skills/plan-to-invoker/scripts/test-policy-coverage.sh`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`
- [x] `cd packages/surfaces && pnpm test -- src/__tests__/plan-conversation.test.ts`
- [x] `git diff --check`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 29b7286d`
- Post-revert steps: Re-run `bash scripts/test-plan-to-invoker-skill.sh` and `cd packages/surfaces && pnpm test -- src/__tests__/plan-conversation.test.ts` after reverting.
- Data migration? No
