### PR TITLE
UI Perf Issue 1: Remove redundant startup snapshot refresh

### DIFF
--- a/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks-stream-gap-detect.test.tsx
@@ -15,6 +15,7 @@ function installInvoker(opts: {
 }): {
   getTasksMock: ReturnType<typeof vi.fn>;
   reportUiPerfMock: ReturnType<typeof vi.fn>;
+  onTaskDeltaMock: ReturnType<typeof vi.fn>;
   fireDelta: (delta: unknown) => void;
 } {
   let handler: ((delta: unknown) => void) | undefined;
@@ -27,14 +28,15 @@ function installInvoker(opts: {
   const lastResponse = opts.responses[opts.responses.length - 1];
   const getTasksMock = vi.fn(async () => queue.shift() ?? lastResponse);
   const reportUiPerfMock = vi.fn();
+  const onTaskDeltaMock = vi.fn((cb: (delta: unknown) => void) => {
+    handler = cb;
+    return () => { handler = undefined; };
+  });
 
   (window as unknown as { invoker: Record<string, unknown> }).invoker = {
     getTasks: getTasksMock,
     reportUiPerf: reportUiPerfMock,
-    onTaskDelta: vi.fn((cb: (delta: unknown) => void) => {
-      handler = cb;
-      return () => { handler = undefined; };
-    }),
+    onTaskDelta: onTaskDeltaMock,
     onWorkflowsChanged: vi.fn(() => () => {}),
     checkPrStatuses: vi.fn(async () => {}),
   };
@@ -42,6 +44,7 @@ function installInvoker(opts: {
   return {
     getTasksMock,
     reportUiPerfMock,
+    onTaskDeltaMock,
     fireDelta: (delta) => handler?.(delta),
   };
 }
@@ -61,7 +64,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     const t2 = makeUITask({ id: 't2', status: 'pending' });
     const t3 = makeUITask({ id: 't3', status: 'pending' });
 
-    const { getTasksMock, reportUiPerfMock, fireDelta } = installInvoker({
+    const { getTasksMock, reportUiPerfMock, onTaskDeltaMock, fireDelta } = installInvoker({
       bootstrap: { tasks: [t1, t2, t3], streamSequence: 0 },
       responses: [{ tasks: [t1, t2, t3], workflows: [], streamSequence: 0 }],
     });
@@ -69,8 +72,9 @@ describe('useTasks stream-sequence gap-detect', () => {
     const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(getTasksMock).toHaveBeenCalledTimes(1);
+      expect(onTaskDeltaMock).toHaveBeenCalledTimes(1);
     });
+    expect(getTasksMock).not.toHaveBeenCalled();
 
     await act(async () => {
       fireDelta({ type: 'updated', taskId: 't1', changes: { status: 'running' }, taskStateVersion: 2, previousTaskStateVersion: 1, streamSequence: 1 });
@@ -82,7 +86,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     expect(result.current.tasks.get('t1')?.status).toBe('running');
     expect(result.current.tasks.get('t2')?.status).toBe('running');
     expect(result.current.tasks.get('t3')?.status).toBe('running');
-    expect(getTasksMock).toHaveBeenCalledTimes(1);
+    expect(getTasksMock).not.toHaveBeenCalled();
     expect(reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected')).toHaveLength(0);
   });
 
@@ -98,10 +102,9 @@ describe('useTasks stream-sequence gap-detect', () => {
       makeUITask({ id: 't3', status: 'running' }),
     ];
 
-    const { getTasksMock, reportUiPerfMock, fireDelta } = installInvoker({
+    const { getTasksMock, reportUiPerfMock, onTaskDeltaMock, fireDelta } = installInvoker({
       bootstrap: { tasks: initial, streamSequence: 0 },
       responses: [
-        { tasks: initial, workflows: [], streamSequence: 0 },
         { tasks: post, workflows: [], streamSequence: 4 },
       ],
     });
@@ -109,8 +112,9 @@ describe('useTasks stream-sequence gap-detect', () => {
     const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(getTasksMock).toHaveBeenCalledTimes(1);
+      expect(onTaskDeltaMock).toHaveBeenCalledTimes(1);
     });
+    expect(getTasksMock).not.toHaveBeenCalled();
 
     await act(async () => {
       fireDelta({ type: 'updated', taskId: 't1', changes: { status: 'running' }, taskStateVersion: 2, previousTaskStateVersion: 1, streamSequence: 1 });
@@ -120,7 +124,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     });
 
     await waitFor(() => {
-      expect(getTasksMock).toHaveBeenCalledTimes(2);
+      expect(getTasksMock).toHaveBeenCalledTimes(1);
       expect(getTasksMock).toHaveBeenLastCalledWith(true);
     });
 
@@ -139,10 +143,9 @@ describe('useTasks stream-sequence gap-detect', () => {
     const initial = [makeUITask({ id: 't1', status: 'pending' })];
     const post = [makeUITask({ id: 't1', status: 'completed' })];
 
-    const { getTasksMock, fireDelta } = installInvoker({
+    const { getTasksMock, onTaskDeltaMock, fireDelta } = installInvoker({
       bootstrap: { tasks: initial, streamSequence: 0 },
       responses: [
-        { tasks: initial, workflows: [], streamSequence: 0 },
         { tasks: post, workflows: [], streamSequence: 10 },
       ],
     });
@@ -150,8 +153,9 @@ describe('useTasks stream-sequence gap-detect', () => {
     const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(getTasksMock).toHaveBeenCalledTimes(1);
+      expect(onTaskDeltaMock).toHaveBeenCalledTimes(1);
     });
+    expect(getTasksMock).not.toHaveBeenCalled();
 
     await act(async () => {
       fireDelta({ type: 'updated', taskId: 't1', changes: { status: 'running' }, taskStateVersion: 2, previousTaskStateVersion: 1, streamSequence: 1 });
@@ -160,7 +164,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     });
 
     await waitFor(() => {
-      expect(getTasksMock).toHaveBeenCalledTimes(2);
+      expect(getTasksMock).toHaveBeenCalledTimes(1);
       expect(result.current.tasks.get('t1')?.status).toBe('completed');
     });
 
@@ -170,17 +174,16 @@ describe('useTasks stream-sequence gap-detect', () => {
     });
 
     expect(result.current.tasks.get('t1')?.status).toBe('completed');
-    expect(getTasksMock).toHaveBeenCalledTimes(2);
+    expect(getTasksMock).toHaveBeenCalledTimes(1);
   });
 
   it('triggers only ONE re-sync when multiple gaps arrive in quick succession', async () => {
     const initial = [makeUITask({ id: 't1', status: 'pending' })];
     const post = [makeUITask({ id: 't1', status: 'completed' })];
 
-    const { getTasksMock, reportUiPerfMock, fireDelta } = installInvoker({
+    const { getTasksMock, reportUiPerfMock, onTaskDeltaMock, fireDelta } = installInvoker({
       bootstrap: { tasks: initial, streamSequence: 0 },
       responses: [
-        { tasks: initial, workflows: [], streamSequence: 0 },
         { tasks: post, workflows: [], streamSequence: 100 },
       ],
     });
@@ -188,8 +191,9 @@ describe('useTasks stream-sequence gap-detect', () => {
     renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(getTasksMock).toHaveBeenCalledTimes(1);
+      expect(onTaskDeltaMock).toHaveBeenCalledTimes(1);
     });
+    expect(getTasksMock).not.toHaveBeenCalled();
 
     await act(async () => {
       fireDelta({ type: 'updated', taskId: 't1', changes: { status: 'running' }, taskStateVersion: 2, previousTaskStateVersion: 1, streamSequence: 5 });
@@ -198,7 +202,7 @@ describe('useTasks stream-sequence gap-detect', () => {
       await new Promise((resolve) => setTimeout(resolve, 150));
     });
 
-    expect(getTasksMock).toHaveBeenCalledTimes(2);
+    expect(getTasksMock).toHaveBeenCalledTimes(1);
     const gapReports = reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected');
     expect(gapReports).toHaveLength(1);
   });
@@ -206,7 +210,7 @@ describe('useTasks stream-sequence gap-detect', () => {
   it('skips gap-check for deltas without a streamSequence (backward compatibility)', async () => {
     const t1 = makeUITask({ id: 't1', status: 'pending' });
 
-    const { getTasksMock, reportUiPerfMock, fireDelta } = installInvoker({
+    const { getTasksMock, reportUiPerfMock, onTaskDeltaMock, fireDelta } = installInvoker({
       bootstrap: { tasks: [t1], streamSequence: 0 },
       responses: [{ tasks: [t1], workflows: [], streamSequence: 0 }],
     });
@@ -214,8 +218,9 @@ describe('useTasks stream-sequence gap-detect', () => {
     const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(getTasksMock).toHaveBeenCalledTimes(1);
+      expect(onTaskDeltaMock).toHaveBeenCalledTimes(1);
     });
+    expect(getTasksMock).not.toHaveBeenCalled();
 
     await act(async () => {
       fireDelta({ type: 'updated', taskId: 't1', changes: { status: 'running' }, taskStateVersion: 2, previousTaskStateVersion: 1 });
@@ -223,7 +228,7 @@ describe('useTasks stream-sequence gap-detect', () => {
     });
 
     expect(result.current.tasks.get('t1')?.status).toBe('running');
-    expect(getTasksMock).toHaveBeenCalledTimes(1);
+    expect(getTasksMock).not.toHaveBeenCalled();
     expect(reportUiPerfMock.mock.calls.filter((c) => c[0] === 'ui_delta_stream_gap_detected')).toHaveLength(0);
   });
 });

--- a/packages/ui/src/__tests__/use-tasks.test.tsx
+++ b/packages/ui/src/__tests__/use-tasks.test.tsx
@@ -143,20 +143,18 @@ describe('useTasks', () => {
     expect(result.current.tasks.get('t1')?.id).toBe('t1');
   });
 
-  it('does not replace a full bootstrap with a smaller initial snapshot', async () => {
+  it('skips the immediate non-forced snapshot when bootstrap already hydrated state', async () => {
     const bootA = makeUITask({ id: 'boot-a', description: 'Bootstrap A' });
     const bootB = makeUITask({ id: 'boot-b', description: 'Bootstrap B' });
-    const smaller = makeUITask({ id: 'boot-a', description: 'Smaller A' });
+    const getTasks = vi.fn().mockResolvedValue({ tasks: [bootA, bootB], workflows: [] });
+    const reportUiPerf = vi.fn();
     (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
       tasks: [bootA, bootB],
       workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'running' }],
     };
     (window as unknown as { invoker: Record<string, unknown> }).invoker = {
-      getTasks: vi.fn().mockResolvedValue({
-        tasks: [smaller],
-        workflows: [{ id: 'wf-1', name: 'Workflow 1', status: 'running' }],
-      }),
-      reportUiPerf: vi.fn(),
+      getTasks,
+      reportUiPerf,
       onTaskDelta: vi.fn(() => () => {}),
       onWorkflowsChanged: vi.fn(() => () => {}),
     };
@@ -164,19 +162,117 @@ describe('useTasks', () => {
     const { result } = renderHook(() => useTasks());
 
     await waitFor(() => {
-      expect(window.invoker.getTasks).toHaveBeenCalled();
+      expect(reportUiPerf).toHaveBeenCalledWith(
+        'startup_snapshot_skipped_bootstrap_complete',
+        expect.objectContaining({
+          bootstrapTaskCount: 2,
+          bootstrapWorkflowCount: 1,
+        }),
+      );
     });
 
-    expect(result.current.tasks.size).toBe(2);
-    expect(result.current.tasks.get('boot-a')?.description).toBe('Bootstrap A');
-    expect(result.current.tasks.get('boot-b')?.description).toBe('Bootstrap B');
-    expect(window.invoker.reportUiPerf).toHaveBeenCalledWith(
-      'startup_snapshot_skipped_smaller_than_bootstrap',
-      expect.objectContaining({
-        bootstrapTaskCount: 2,
-        snapshotTaskCount: 1,
-      }),
+    expect(getTasks).not.toHaveBeenCalled();
+    expect(reportUiPerf).not.toHaveBeenCalledWith(
+      'useTasks_snapshot_replace',
+      expect.anything(),
     );
+    expect(result.current.tasks.size).toBe(2);
+    expect(result.current.workflows.size).toBe(1);
+  });
+
+  it('falls back to fetchAll on mount when bootstrap is empty', async () => {
+    const fetched = makeUITask({ id: 'fetched-1', description: 'Fetched' });
+    const getTasks = vi.fn().mockResolvedValue({
+      tasks: [fetched],
+      workflows: [{ id: 'wf-x', name: 'WF X', status: 'running' }],
+    });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [],
+      workflows: [],
+    };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks,
+      onTaskDelta: vi.fn(() => () => {}),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    await waitFor(() => {
+      expect(getTasks).toHaveBeenCalledTimes(1);
+      expect(getTasks).toHaveBeenLastCalledWith(false);
+    });
+
+    await waitFor(() => {
+      expect(result.current.tasks.get('fetched-1')?.description).toBe('Fetched');
+      expect(result.current.workflows.get('wf-x')?.name).toBe('WF X');
+    });
+  });
+
+  it('forced refresh after a hydrated bootstrap still calls getTasks(true) and replaces state', async () => {
+    const bootTask = makeUITask({ id: 'boot-1', description: 'Boot' });
+    const refreshedTask = makeUITask({ id: 'refreshed-1', description: 'Refreshed' });
+    const getTasks = vi.fn().mockResolvedValue({ tasks: [refreshedTask], workflows: [] });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [bootTask],
+      workflows: [{ id: 'wf-1', name: 'WF 1', status: 'running' }],
+    };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks,
+      onTaskDelta: vi.fn(() => () => {}),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    expect(getTasks).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.refreshTasks(true);
+    });
+
+    await waitFor(() => {
+      expect(getTasks).toHaveBeenCalledTimes(1);
+      expect(getTasks).toHaveBeenLastCalledWith(true);
+    });
+
+    await waitFor(() => {
+      expect(result.current.tasks.has('refreshed-1')).toBe(true);
+      expect(result.current.tasks.has('boot-1')).toBe(false);
+    });
+  });
+
+  it('non-forced refresh after a hydrated bootstrap still calls getTasks and replaces state', async () => {
+    const bootTask = makeUITask({ id: 'boot-1', description: 'Boot' });
+    const updated = makeUITask({ id: 'boot-1', description: 'Updated' });
+    const getTasks = vi.fn().mockResolvedValue({ tasks: [updated], workflows: [] });
+    (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__ = {
+      tasks: [bootTask],
+      workflows: [{ id: 'wf-1', name: 'WF 1', status: 'running' }],
+    };
+    (window as unknown as { invoker: Record<string, unknown> }).invoker = {
+      getTasks,
+      onTaskDelta: vi.fn(() => () => {}),
+      onWorkflowsChanged: vi.fn(() => () => {}),
+    };
+
+    const { result } = renderHook(() => useTasks());
+
+    expect(getTasks).not.toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.refreshTasks();
+    });
+
+    await waitFor(() => {
+      expect(getTasks).toHaveBeenCalledTimes(1);
+      expect(getTasks).toHaveBeenLastCalledWith(false);
+    });
+
+    await waitFor(() => {
+      expect(result.current.tasks.get('boot-1')?.description).toBe('Updated');
+      expect(result.current.workflows.size).toBe(0);
+    });
   });
 
   it('passes forceRefresh flag to getTasks when requested', async () => {

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -86,16 +86,6 @@ export function useTasks(): UseTasksResult {
       }
       const taskList = result.tasks ?? [];
       const wfList = result.workflows ?? [];
-      const bootstrapTaskCount = bootstrapState?.tasks?.length ?? 0;
-      if (!forceRefresh && bootstrapTaskCount > taskList.length) {
-        void window.invoker?.reportUiPerf?.('startup_snapshot_skipped_smaller_than_bootstrap', {
-          bootstrapTaskCount,
-          snapshotTaskCount: taskList.length,
-          workflowCount: wfList.length,
-          requestDurationMs,
-        });
-        return;
-      }
       const replaceStartedAt = performance.now();
       // Always replace from server snapshot — empty lists mean "no tasks/workflows" (e.g. after delete).
       setTasks(() => {
@@ -145,15 +135,15 @@ export function useTasks(): UseTasksResult {
   useEffect(() => {
     if (typeof window === 'undefined' || !window.invoker) return;
 
-    if (
-      !reportedStartupBootstrapRef.current &&
-      bootstrapState &&
-      ((bootstrapState.tasks?.length ?? 0) > 0 || (bootstrapState.workflows?.length ?? 0) > 0)
-    ) {
+    const bootstrapTaskCount = bootstrapState?.tasks?.length ?? 0;
+    const bootstrapWorkflowCount = bootstrapState?.workflows?.length ?? 0;
+    const bootstrapHasState = bootstrapTaskCount > 0 || bootstrapWorkflowCount > 0;
+
+    if (!reportedStartupBootstrapRef.current && bootstrapState && bootstrapHasState) {
       reportedStartupBootstrapRef.current = true;
       void window.invoker.reportUiPerf?.('startup_bootstrap_state', {
-        taskCount: bootstrapState.tasks?.length ?? 0,
-        workflowCount: bootstrapState.workflows?.length ?? 0,
+        taskCount: bootstrapTaskCount,
+        workflowCount: bootstrapWorkflowCount,
         elapsedMs: Math.round(performance.now()),
         processElapsedMs: bootstrapState.appStartedAtEpochMs
           ? Date.now() - bootstrapState.appStartedAtEpochMs
@@ -161,7 +151,23 @@ export function useTasks(): UseTasksResult {
       });
     }
 
-    fetchAll();
+    // Preload bootstrap already hydrated tasks/workflows synchronously, so
+    // the immediate non-forced snapshot would be a redundant full payload.
+    // Skip it when bootstrap is populated; deltas keep state live, and
+    // explicit refreshTasks() / refreshTasks(true) callers still run fetchAll.
+    if (bootstrapHasState) {
+      reportedStartupSnapshotRef.current = true;
+      void window.invoker.reportUiPerf?.('startup_snapshot_skipped_bootstrap_complete', {
+        bootstrapTaskCount,
+        bootstrapWorkflowCount,
+        elapsedMs: Math.round(performance.now()),
+        processElapsedMs: bootstrapState?.appStartedAtEpochMs
+          ? Date.now() - bootstrapState.appStartedAtEpochMs
+          : undefined,
+      });
+    } else {
+      fetchAll();
+    }
 
     deltaPipelineRef.current = createTaskDeltaPipeline({
       flushMs: 100,

--- a/scripts/repro/repro-startup-snapshot-refresh-overhead.sh
+++ b/scripts/repro/repro-startup-snapshot-refresh-overhead.sh
@@ -75,10 +75,13 @@ BARE_REPO="$TMP_DIR/seed-remote.git"
 SEED_CLONE="$TMP_DIR/seed-clone"
 CONFIG_PATH="$TMP_DIR/config.json"
 REPORT_PATH="$TMP_DIR/report.json"
-HELPER_PATH="$TMP_DIR/probe.mjs"
+# Helper.mjs must live inside packages/app so Node ESM resolution can find
+# @playwright/test via the app's node_modules. NODE_PATH does not work for ESM.
+HELPER_PATH="$REPO_ROOT/packages/app/.repro-startup-snapshot-probe.mjs"
 HELPER_LOG="$TMP_DIR/probe.log"
 
 cleanup() {
+  rm -f "$HELPER_PATH"
   if [[ "$KEEP_TMP" = "1" ]]; then
     echo "repro: KEEP_TMP=1 -- leaving $TMP_DIR in place"
     return
@@ -251,8 +254,11 @@ const uiPerf = observed.activityLogs
   })
   .filter((entry) => entry.payload && typeof entry.payload === 'object');
 
-const bootstrap = uiPerf.find((e) => e.payload.metric === 'preload_bootstrap_sync');
-const graphVisible = uiPerf.find((e) => e.payload.metric === 'startup_workflow_graph_visible');
+// Use findLast so we capture phase 2's bootstrap (the measurement
+// relaunch), not phase 1's seed-phase bootstrap which precedes it in
+// the shared activity_log.
+const bootstrap = uiPerf.findLast((e) => e.payload.metric === 'preload_bootstrap_sync');
+const graphVisible = uiPerf.findLast((e) => e.payload.metric === 'startup_workflow_graph_visible');
 
 const snapshotReplacesAfterBootstrap = uiPerf
   .filter((e) => e.payload.metric === 'useTasks_snapshot_replace')

--- a/scripts/repro/repro-startup-snapshot-refresh-overhead.sh
+++ b/scripts/repro/repro-startup-snapshot-refresh-overhead.sh
@@ -1,0 +1,390 @@
+#!/usr/bin/env bash
+#
+# Deterministic repro for the redundant post-bootstrap startup snapshot.
+#
+# After preload pushes a full `preload_bootstrap_sync` into the renderer
+# (carrying every persisted task + workflow), the useTasks hook still issues
+# a non-forced getTasks() call on mount. The resulting
+# `useTasks_snapshot_replace` rebuilds the renderer's task/workflow maps
+# from a payload identical to what bootstrap already supplied, costing
+# ~65-164ms of main-thread work and ~377KB of IPC moved after the graph
+# is already visible.
+#
+# This script boots an isolated Electron app twice against a seeded DB
+# with multiple workflows/tasks, captures `ui-perf` activity_log entries,
+# and decides PASS/FAIL based on whether a non-forced
+# `useTasks_snapshot_replace` appears AFTER `preload_bootstrap_sync`.
+#
+# Modes:
+#   --expect-issue   PASS when the redundant non-forced snapshot IS seen
+#                    (confirms the bug exists today).
+#   (default)        PASS only when no redundant non-forced snapshot is
+#                    seen (validates the optimization).
+
+set -euo pipefail
+
+EXPECT_ISSUE=0
+WORKFLOW_COUNT="${WORKFLOW_COUNT:-5}"
+TASKS_PER_WORKFLOW="${TASKS_PER_WORKFLOW:-7}"
+SETTLE_MS="${SETTLE_MS:-4000}"
+LAUNCH_TIMEOUT_MS="${LAUNCH_TIMEOUT_MS:-60000}"
+KEEP_TMP="${KEEP_TMP:-0}"
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") [options]
+
+Options:
+  --expect-issue                 PASS only if the redundant non-forced
+                                 useTasks_snapshot_replace IS observed after
+                                 preload_bootstrap_sync (baseline mode).
+  --workflows N                  Number of seeded workflows (default: ${WORKFLOW_COUNT}).
+  --tasks-per-workflow N         Tasks per seeded workflow (default: ${TASKS_PER_WORKFLOW}).
+  --settle-ms MS                 Renderer settle window after graph visible
+                                 (default: ${SETTLE_MS}).
+  --launch-timeout-ms MS         Electron launch / page-readiness timeout
+                                 (default: ${LAUNCH_TIMEOUT_MS}).
+  --keep-tmp                     Leave the temp dir in place after exit.
+  -h, --help                     Show this help.
+EOF
+}
+
+while (( $# )); do
+  case "$1" in
+    --expect-issue)            EXPECT_ISSUE=1 ;;
+    --workflows)               shift; WORKFLOW_COUNT="$1" ;;
+    --workflows=*)             WORKFLOW_COUNT="${1#*=}" ;;
+    --tasks-per-workflow)      shift; TASKS_PER_WORKFLOW="$1" ;;
+    --tasks-per-workflow=*)    TASKS_PER_WORKFLOW="${1#*=}" ;;
+    --settle-ms)               shift; SETTLE_MS="$1" ;;
+    --settle-ms=*)             SETTLE_MS="${1#*=}" ;;
+    --launch-timeout-ms)       shift; LAUNCH_TIMEOUT_MS="$1" ;;
+    --launch-timeout-ms=*)     LAUNCH_TIMEOUT_MS="${1#*=}" ;;
+    --keep-tmp)                KEEP_TMP=1 ;;
+    -h|--help)                 usage; exit 0 ;;
+    *) echo "Unknown argument: $1" >&2; usage >&2; exit 64 ;;
+  esac
+  shift
+done
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d -t invoker-startup-snapshot.XXXXXX)"
+HOME_DIR="$TMP_DIR/home"
+DB_DIR="$HOME_DIR/.invoker"
+BARE_REPO="$TMP_DIR/seed-remote.git"
+SEED_CLONE="$TMP_DIR/seed-clone"
+CONFIG_PATH="$TMP_DIR/config.json"
+REPORT_PATH="$TMP_DIR/report.json"
+HELPER_PATH="$TMP_DIR/probe.mjs"
+HELPER_LOG="$TMP_DIR/probe.log"
+
+cleanup() {
+  if [[ "$KEEP_TMP" = "1" ]]; then
+    echo "repro: KEEP_TMP=1 -- leaving $TMP_DIR in place"
+    return
+  fi
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$DB_DIR"
+
+if [[ ! -f "$REPO_ROOT/packages/ui/dist/index.html" ]]; then
+  echo "repro: building @invoker/ui dist..."
+  (cd "$REPO_ROOT" && pnpm --filter @invoker/ui build >/dev/null)
+fi
+if [[ ! -f "$REPO_ROOT/packages/surfaces/dist/index.js" ]]; then
+  echo "repro: building @invoker/surfaces dist..."
+  (cd "$REPO_ROOT" && pnpm --filter @invoker/surfaces build >/dev/null)
+fi
+if [[ ! -f "$REPO_ROOT/packages/app/dist/main.js" ]]; then
+  echo "repro: building @invoker/app dist..."
+  (cd "$REPO_ROOT" && pnpm --filter @invoker/app build >/dev/null)
+fi
+
+# Bare repo with master + main so any incidental WorktreeExecutor clone
+# attempts during seeding don't error out on missing branches.
+git init --bare "$BARE_REPO" >/dev/null 2>&1
+git clone --quiet "$BARE_REPO" "$SEED_CLONE" >/dev/null 2>&1
+(
+  cd "$SEED_CLONE"
+  git -c user.name='Invoker Repro' -c user.email='repro@invoker.dev' \
+      commit --allow-empty --quiet -m 'init'
+  git push --quiet origin HEAD:refs/heads/master
+  git push --quiet origin HEAD:refs/heads/main
+)
+rm -rf "$SEED_CLONE"
+
+cat > "$CONFIG_PATH" <<'JSON'
+{"autoFixRetries":0,"maxConcurrency":1}
+JSON
+
+# ── Playwright-driven Electron probe ──────────────────────────
+# Phase 1 seeds N workflows via window.invoker.loadPlan (which only
+# persists into the orchestrator; no execution kicks off without a
+# subsequent invoker:start). Phase 2 relaunches against the same DB,
+# waits for the workflow graph to become visible, and reads activity_log
+# entries so we can pin down which ui-perf events fired AFTER
+# preload_bootstrap_sync.
+cat > "$HELPER_PATH" <<'NODE'
+import { _electron as electron } from '@playwright/test';
+import { writeFileSync } from 'node:fs';
+import * as path from 'node:path';
+
+const repoRoot = process.env.REPO_ROOT;
+const dbDir = process.env.REPRO_DB_DIR;
+const configPath = process.env.REPRO_CONFIG_PATH;
+const bareRepo = process.env.REPRO_BARE_REPO;
+const reportPath = process.env.REPRO_REPORT_PATH;
+const workflowCount = Number(process.env.REPRO_WORKFLOW_COUNT ?? '5');
+const tasksPerWorkflow = Number(process.env.REPRO_TASKS_PER_WORKFLOW ?? '7');
+const settleMs = Number(process.env.REPRO_SETTLE_MS ?? '4000');
+const launchTimeoutMs = Number(process.env.REPRO_LAUNCH_TIMEOUT_MS ?? '60000');
+const mainEntry = path.join(repoRoot, 'packages', 'app', 'dist', 'main.js');
+const repoUrl = `file://${bareRepo}`;
+
+function buildPlanYaml(index) {
+  const lines = [
+    `name: startup-snapshot-repro-${index}`,
+    'onFinish: none',
+    `repoUrl: ${repoUrl}`,
+    'tasks:',
+  ];
+  for (let i = 0; i < tasksPerWorkflow; i += 1) {
+    const id = `task-${index}-${i}`;
+    lines.push(`  - id: ${id}`);
+    lines.push(`    description: "Seed ${id}"`);
+    lines.push('    command: "true"');
+    if (i > 0) {
+      lines.push(`    dependencies: ["task-${index}-${i - 1}"]`);
+    }
+  }
+  return lines.join('\n') + '\n';
+}
+
+const linuxArgs = process.platform === 'linux'
+  ? [
+      '--no-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-gpu',
+      '--disable-gpu-compositing',
+      '--disable-gpu-sandbox',
+      '--disable-software-rasterizer',
+    ]
+  : [];
+
+const launchEnv = {
+  ...process.env,
+  HOME: process.env.HOME,
+  INVOKER_DB_DIR: dbDir,
+  INVOKER_REPO_CONFIG_PATH: configPath,
+  INVOKER_ALLOW_DELETE_ALL: '1',
+};
+
+// chdir so @playwright/test (and the bundled electron) resolves from the
+// workspace it was installed into.
+process.chdir(path.join(repoRoot, 'packages', 'app'));
+
+async function withElectron(label, fn) {
+  const app = await electron.launch({
+    args: [...linuxArgs, mainEntry],
+    env: launchEnv,
+    timeout: launchTimeoutMs,
+  });
+  try {
+    return await fn(app);
+  } finally {
+    try {
+      await app.close();
+    } catch (err) {
+      console.error(`[${label}] electron close failed:`, err);
+    }
+  }
+}
+
+await withElectron('seed', async (app) => {
+  const page = await app.firstWindow({ timeout: launchTimeoutMs });
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(
+    () => typeof window.invoker !== 'undefined',
+    null,
+    { timeout: launchTimeoutMs },
+  );
+  for (let i = 0; i < workflowCount; i += 1) {
+    const yaml = buildPlanYaml(i);
+    await page.evaluate(async (planText) => {
+      await window.invoker.loadPlan(planText);
+    }, yaml);
+  }
+});
+
+const observed = await withElectron('measure', async (app) => {
+  const page = await app.firstWindow({ timeout: launchTimeoutMs });
+  await page.waitForLoadState('domcontentloaded');
+  await page.waitForFunction(
+    () => typeof window.invoker !== 'undefined',
+    null,
+    { timeout: launchTimeoutMs },
+  );
+  await page
+    .locator('[data-testid^="workflow-node-"]')
+    .first()
+    .waitFor({ state: 'visible', timeout: launchTimeoutMs });
+  // Let late-firing ui-perf reports (snapshot replace, graph visible)
+  // flush before we read the activity_log.
+  await page.waitForTimeout(settleMs);
+  return await page.evaluate(async () => ({
+    activityLogs: await window.invoker.getActivityLogs(),
+  }));
+});
+
+const uiPerf = observed.activityLogs
+  .filter((entry) => entry.source === 'ui-perf')
+  .map((entry) => {
+    let payload = null;
+    try {
+      payload = JSON.parse(entry.message);
+    } catch {
+      payload = null;
+    }
+    return { id: entry.id, timestamp: entry.timestamp, payload };
+  })
+  .filter((entry) => entry.payload && typeof entry.payload === 'object');
+
+const bootstrap = uiPerf.find((e) => e.payload.metric === 'preload_bootstrap_sync');
+const graphVisible = uiPerf.find((e) => e.payload.metric === 'startup_workflow_graph_visible');
+
+const snapshotReplacesAfterBootstrap = uiPerf
+  .filter((e) => e.payload.metric === 'useTasks_snapshot_replace')
+  .filter((e) => !bootstrap || e.id > bootstrap.id)
+  .map((e) => ({ id: e.id, timestamp: e.timestamp, ...e.payload }));
+
+const report = {
+  expectedWorkflowCount: workflowCount,
+  expectedTasksPerWorkflow: tasksPerWorkflow,
+  preloadBootstrapSync: bootstrap
+    ? { id: bootstrap.id, timestamp: bootstrap.timestamp, ...bootstrap.payload }
+    : null,
+  startupWorkflowGraphVisible: graphVisible
+    ? { id: graphVisible.id, timestamp: graphVisible.timestamp, ...graphVisible.payload }
+    : null,
+  snapshotReplacesAfterBootstrap,
+  uiPerfTimeline: uiPerf.map((e) => ({
+    id: e.id,
+    timestamp: e.timestamp,
+    metric: e.payload.metric,
+  })),
+};
+
+writeFileSync(reportPath, JSON.stringify(report, null, 2));
+NODE
+
+run_helper() {
+  local -a helper_env=(
+    REPO_ROOT="$REPO_ROOT"
+    HOME="$HOME_DIR"
+    REPRO_DB_DIR="$DB_DIR"
+    REPRO_CONFIG_PATH="$CONFIG_PATH"
+    REPRO_BARE_REPO="$BARE_REPO"
+    REPRO_REPORT_PATH="$REPORT_PATH"
+    REPRO_WORKFLOW_COUNT="$WORKFLOW_COUNT"
+    REPRO_TASKS_PER_WORKFLOW="$TASKS_PER_WORKFLOW"
+    REPRO_SETTLE_MS="$SETTLE_MS"
+    REPRO_LAUNCH_TIMEOUT_MS="$LAUNCH_TIMEOUT_MS"
+  )
+
+  if [[ "$(uname -s)" == "Linux" ]] && command -v xvfb-run >/dev/null 2>&1; then
+    env "${helper_env[@]}" xvfb-run --auto-servernum node "$HELPER_PATH"
+  else
+    env "${helper_env[@]}" node "$HELPER_PATH"
+  fi
+}
+
+echo "repro: launching Electron probe (workflows=$WORKFLOW_COUNT, tasks=$TASKS_PER_WORKFLOW)..."
+if ! run_helper >"$HELPER_LOG" 2>&1; then
+  echo "repro: helper failed -- last 100 lines of $HELPER_LOG:" >&2
+  tail -n 100 "$HELPER_LOG" >&2 || true
+  exit 1
+fi
+
+if [[ ! -s "$REPORT_PATH" ]]; then
+  echo "repro: helper produced no report at $REPORT_PATH" >&2
+  tail -n 100 "$HELPER_LOG" >&2 || true
+  exit 1
+fi
+
+EXPECT_ISSUE="$EXPECT_ISSUE" python3 - "$REPORT_PATH" <<'PY'
+import json
+import os
+import sys
+
+expect_issue = os.environ.get("EXPECT_ISSUE", "0") == "1"
+with open(sys.argv[1], "r", encoding="utf-8") as fh:
+    report = json.load(fh)
+
+
+def show(value):
+    return "<missing>" if value is None else value
+
+
+bootstrap = report.get("preloadBootstrapSync") or {}
+graph = report.get("startupWorkflowGraphVisible") or {}
+replaces = report.get("snapshotReplacesAfterBootstrap") or []
+
+print("repro-summary:")
+print(f"  preload_bootstrap_sync.taskCount: {show(bootstrap.get('taskCount'))}")
+print(f"  preload_bootstrap_sync.workflowCount: {show(bootstrap.get('workflowCount'))}")
+print(f"  preload_bootstrap_sync.jsonSizeBytes: {show(bootstrap.get('jsonSizeBytes'))}")
+print(f"  preload_bootstrap_sync.durationMs: {show(bootstrap.get('durationMs'))}")
+print(f"  preload_bootstrap_sync.processElapsedMs: {show(bootstrap.get('processElapsedMs'))}")
+print(f"  startup_workflow_graph_visible.nodeCount: {show(graph.get('nodeCount'))}")
+print(f"  startup_workflow_graph_visible.edgeCount: {show(graph.get('edgeCount'))}")
+print(f"  startup_workflow_graph_visible.elapsedMs: {show(graph.get('elapsedMs'))}")
+print(f"  startup_workflow_graph_visible.processElapsedMs: {show(graph.get('processElapsedMs'))}")
+print(f"  useTasks_snapshot_replace events after bootstrap: {len(replaces)}")
+
+non_forced = []
+for entry in replaces:
+    forced = bool(entry.get("forceRefresh"))
+    label = "forced" if forced else "non-forced"
+    print(
+        "  - "
+        f"{label} "
+        f"requestDurationMs={show(entry.get('requestDurationMs'))} "
+        f"replaceDurationMs={show(entry.get('replaceDurationMs'))} "
+        f"taskCount={show(entry.get('taskCount'))} "
+        f"workflowCount={show(entry.get('workflowCount'))} "
+        f"jsonSizeBytes={show(entry.get('jsonSizeBytes'))}"
+    )
+    if not forced:
+        non_forced.append(entry)
+
+if not bootstrap:
+    print("repro: FAIL -- preload_bootstrap_sync was not observed", file=sys.stderr)
+    sys.exit(2)
+
+if expect_issue:
+    if non_forced:
+        print(
+            f"repro: PASS (--expect-issue) -- observed {len(non_forced)} "
+            "redundant non-forced startup snapshot(s) after preload_bootstrap_sync"
+        )
+        sys.exit(0)
+    print(
+        "repro: FAIL (--expect-issue) -- no redundant non-forced startup "
+        "snapshot observed; the bug appears to be already fixed",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+if non_forced:
+    print(
+        f"repro: FAIL -- {len(non_forced)} redundant non-forced startup "
+        "snapshot(s) detected after preload_bootstrap_sync",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print("repro: PASS -- no redundant non-forced startup snapshot after preload_bootstrap_sync")
+sys.exit(0)
+PY


### PR DESCRIPTION
## Summary

Skip an unnecessary startup data fetch because preload already loaded the same task and workflow data. Manual refreshes and live updates still work; startup just avoids extra IPC work.

The PR also adds a repro script for this redundant fetch so the behavior is measurable before and after the fix.

## Architecture

### Before

```mermaid
flowchart TD
    Preload["preload bootstrap_sync<br/>full tasks and workflows"] --> Hook["useTasks mount"]
    Hook --> Fetch["fetchAll calls invoker.getTasks"]
    Fetch --> Guard{"Snapshot smaller than bootstrap?"}
    Guard -->|yes| Skip["Report skipped_smaller"]
    Guard -->|no| Replace["snapshot_replace<br/>65-164ms, about 377KB"]
    Hook --> Deltas["onTaskDelta and onWorkflowsChanged"]
```

### After

```mermaid
flowchart TD
    Preload["preload bootstrap_sync<br/>full tasks and workflows"] --> Hook["useTasks mount"]
    Hook --> BootCheck{"Bootstrap has tasks or workflows?"}
    BootCheck -->|yes| SkipFetch["Report startup_snapshot_skipped_bootstrap_complete<br/>no IPC and no replace"]
    BootCheck -->|no| Fetch["fetchAll calls invoker.getTasks"]
    Fetch --> Replace["snapshot_replace"]
    Hook --> Deltas["onTaskDelta and onWorkflowsChanged"]
    Explicit["Explicit refreshTasks calls"] --> Fetch
```

## Test Plan

- [ ] `bash scripts/repro/repro-startup-snapshot-refresh-overhead.sh`
- [ ] `cd packages/ui && pnpm test -- src/__tests__/use-tasks.test.tsx`
- [ ] `cd packages/app && pnpm run test:e2e -- e2e/startup-nonempty-responsiveness.spec.ts`
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a1b14a0a7f9e15cf2a95d52b4bada53f9de90d16`
- Post-revert steps: None. Reverting restores the prior `fetchAll()` on mount and the `startup_snapshot_skipped_smaller_than_bootstrap` guard; delta wiring and forced-refresh paths are unchanged either way.
- Data migration? No. The change is renderer-only behavior in `packages/ui/src/hooks/useTasks.ts`; no schema, IPC contract, or persisted state is modified.

