### PR TITLE
Make rebase canonical fresh-base reset

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -782,7 +782,21 @@ describe('POST /api/workflows/:id/restart', () => {
   });
 });
 
-describe('POST /api/workflows/:id/rebase-and-retry', () => {
+describe('POST /api/workflows/:id/rebase', () => {
+  it('rebases workflow from fresh base', async () => {
+    mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn().mockResolvedValue([makeTask()]);
+    const res = await request(port, 'POST', '/api/workflows/wf-1/rebase');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.action).toBe('rebased');
+    expect(res.body.tasksStarted).toBe(1);
+    expect(res.body.deprecated).toBeUndefined();
+    expect(mocks.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+      'wf-1',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
+    );
+  });
+
   it('normalizes merge-node targets to the owning workflow before fresh-base recreate', async () => {
     mocks.persistence.loadWorkflow = vi.fn((workflowId: string) => (
       workflowId === 'wf-1' ? { id: 'wf-1', generation: 1 } : undefined
@@ -794,12 +808,12 @@ describe('POST /api/workflows/:id/rebase-and-retry', () => {
     ));
     mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn(async () => [makeTask()]);
 
-    const res = await request(port, 'POST', '/api/workflows/__merge__wf-1/rebase-and-retry');
+    const res = await request(port, 'POST', '/api/workflows/__merge__wf-1/rebase');
 
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.workflowId).toBe('wf-1');
-    expect(res.body.action).toBe('rebase_and_retried');
+    expect(res.body.action).toBe('rebased');
     expect(mocks.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', expect.any(Object));
     expect(mocks.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
       'wf-1',
@@ -831,14 +845,15 @@ describe('POST /api/workflows/:id/fork', () => {
 });
 
 describe('POST /api/workflows/:id/recreate-with-rebase', () => {
-  it('recreates workflow from fresh base', async () => {
+  it('still works as deprecated alias', async () => {
     mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn().mockResolvedValue([makeTask()]);
     const res = await request(port, 'POST', '/api/workflows/wf-1/recreate-with-rebase');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(res.body.action).toBe('recreated_with_rebase');
+    expect(res.body.action).toBe('rebased');
     expect(res.body.tasksStarted).toBe(1);
-    expect(res.body.deprecated).toBeUndefined();
+    expect(res.body.deprecated).toBe(true);
+    expect(res.body.replacement).toBe('/api/workflows/:id/rebase');
     expect(mocks.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
       'wf-1',
       expect.objectContaining({ refreshBase: expect.any(Function) }),
@@ -872,9 +887,9 @@ describe('POST /api/workflows/:id/recreate-with-rebase', () => {
     const res = await request(port, 'POST', '/api/workflows/wf-1/rebase-and-retry');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(res.body.action).toBe('rebase_and_retried');
+    expect(res.body.action).toBe('rebased');
     expect(res.body.deprecated).toBe(true);
-    expect(res.body.replacement).toBe('/api/workflows/:id/recreate-with-rebase');
+    expect(res.body.replacement).toBe('/api/workflows/:id/rebase');
   });
 
   it('returns 404 when workflow not found', async () => {

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1084,6 +1084,66 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
+        it('headless `rebase-task <taskId>` routes to orchestrator.recreateWorkflowFromFreshBase', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['rebase-task', 'task-1'], depsWithNoTrack);
+
+          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+            'wf-1',
+            expect.objectContaining({ refreshBase: expect.any(Function) }),
+          );
+
+          preparePoolSpy.mockRestore();
+        });
+
+        it('headless `rebase <workflowId>` routes to orchestrator.recreateWorkflowFromFreshBase', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['rebase', 'wf-1'], depsWithNoTrack);
+
+          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+            'wf-1',
+            expect.objectContaining({ refreshBase: expect.any(Function) }),
+          );
+
+          preparePoolSpy.mockRestore();
+        });
+
+        it('headless `rebase <mergeTaskId>` routes to orchestrator.recreateWorkflowFromFreshBase', async () => {
+          const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
+
+          const depsWithNoTrack: HeadlessDeps = {
+            ...mockDeps,
+            noTrack: true,
+            preemptWorkflowExecution,
+          } as HeadlessDeps;
+
+          await runHeadless(['rebase', '__merge__wf-1'], depsWithNoTrack);
+
+          expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+            'wf-1',
+            expect.objectContaining({ refreshBase: expect.any(Function) }),
+          );
+
+          preparePoolSpy.mockRestore();
+        });
+
         it('headless `rebase` exercises the fresh-base-distinct pool prep step (preparePoolForRebaseRetry)', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
 

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -26,7 +26,7 @@ describe('headless→owner delegation', () => {
       listWorkflows: () => [{ id: 'wf-1' } as any, { id: 'wf-123' } as any],
       loadTasks: (workflowId) => {
         if (workflowId === 'wf-1') {
-          return [{ id: '__merge__wf-1' }] as any;
+          return [{ id: '__merge__wf-1' }, { id: 'task-1' }] as any;
         }
         if (workflowId === 'wf-123') {
           return [{ id: 'wf-123/task-1' }] as any;
@@ -80,6 +80,10 @@ describe('headless→owner delegation', () => {
 
     it('keeps task-scoped rebase at the default timeout', () => {
       expect(delegationTimeoutMs(['rebase', 'wf-123/task-1'], targetLookup)).toBe(5_000);
+    });
+
+    it('keeps rebase-task at the default task timeout', () => {
+      expect(delegationTimeoutMs(['rebase-task', 'task-1'], targetLookup)).toBe(5_000);
     });
 
     it('keeps non-matching workflow ids at the default timeout', () => {
@@ -306,6 +310,7 @@ describe('headless→owner delegation', () => {
     });
 
     it.each([
+      ['rebase-task', ['rebase-task', 'task-1']],
       ['restart task', ['restart', 'wf-123/task-1']],
       ['approve', ['approve', 'wf-123/task-1']],
     ])('times out at the default 5s for %s', async (_label, args) => {

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -16,6 +16,7 @@ import {
   retryTask,
   retryWorkflow,
   recreateWorkflowFromFreshBase,
+  rebase,
   recreateWithRebase,
   rebaseAndRetry,
   approveTask,
@@ -263,7 +264,12 @@ describe('recreateWorkflowFromFreshBase', () => {
 
   it('throws when workflow not found', async () => {
     const orchestrator = { recreateWorkflowFromFreshBase: vi.fn(async () => []) };
-    const persistence = { loadWorkflow: vi.fn(() => undefined), updateWorkflow: vi.fn() };
+    const persistence = {
+      listWorkflows: vi.fn(() => []),
+      loadTasks: vi.fn(() => []),
+      loadWorkflow: vi.fn(() => undefined),
+      updateWorkflow: vi.fn(),
+    };
 
     await expect(
       recreateWorkflowFromFreshBase('missing', {
@@ -274,25 +280,72 @@ describe('recreateWorkflowFromFreshBase', () => {
   });
 });
 
-describe('rebaseAndRetry', () => {
-  it('translates taskId → workflowId and delegates to recreateWorkflowFromFreshBase', async () => {
+describe('rebase', () => {
+  function makeRebaseDeps() {
     const tasks = [makeRunningTask()];
     const orchestrator = {
-      getTask: vi.fn(() => makeTask({ config: { workflowId: 'wf-1' } })),
+      syncFromDb: vi.fn(),
       recreateWorkflowFromFreshBase: vi.fn(async () => tasks),
     };
     const persistence = {
-      loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1, repoUrl: 'https://example/repo.git', baseBranch: 'master' })),
+      listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+      loadTasks: vi.fn(() => [
+        makeTask({ id: 'wf-1/task-a', config: { workflowId: 'wf-1' } }),
+        makeTask({ id: '__merge__wf-1', config: { workflowId: 'wf-1', isMergeNode: true } }),
+      ]),
+      loadWorkflow: vi.fn((id: string) => (
+        id === 'wf-1'
+          ? { id: 'wf-1', generation: 1, repoUrl: 'https://example/repo.git', baseBranch: 'master' }
+          : undefined
+      )),
       updateWorkflow: vi.fn(),
     };
+    return { tasks, orchestrator, persistence };
+  }
 
-    const result = await rebaseAndRetry('wf-1/task-a', {
+  it.each([
+    ['workflow id', 'wf-1'],
+    ['merge task id', '__merge__wf-1'],
+    ['task id', 'task-a'],
+  ])('resolves %s and delegates to recreateWorkflowFromFreshBase', async (_label, target) => {
+    const { tasks, orchestrator, persistence } = makeRebaseDeps();
+
+    const result = await rebase(target, {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
     });
 
-    expect(orchestrator.getTask).toHaveBeenCalledWith('wf-1/task-a');
+    expect(orchestrator.syncFromDb).toHaveBeenCalledWith('wf-1');
     expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 2 });
+    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
+      'wf-1',
+      expect.objectContaining({ refreshBase: expect.any(Function) }),
+    );
+    expect(result).toBe(tasks);
+  });
+});
+
+describe('rebaseAndRetry', () => {
+  it('deprecated alias delegates to canonical rebase', async () => {
+    const tasks = [makeRunningTask()];
+    const orchestrator = {
+      syncFromDb: vi.fn(),
+      recreateWorkflowFromFreshBase: vi.fn(async () => tasks),
+    };
+    const persistence = {
+      listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+      loadTasks: vi.fn(() => [makeTask({ id: 'wf-1/task-a', config: { workflowId: 'wf-1' } })]),
+      loadWorkflow: vi.fn((id: string) => (
+        id === 'wf-1' ? { id: 'wf-1', generation: 1, repoUrl: 'https://example/repo.git', baseBranch: 'master' } : undefined
+      )),
+      updateWorkflow: vi.fn(),
+    };
+
+    const result = await rebaseAndRetry('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
     expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
       'wf-1',
       expect.objectContaining({ refreshBase: expect.any(Function) }),
@@ -302,17 +355,21 @@ describe('rebaseAndRetry', () => {
 
   it('throws when task not found', async () => {
     const orchestrator = {
-      getTask: vi.fn(() => undefined),
       recreateWorkflowFromFreshBase: vi.fn(),
     };
-    const persistence = { loadWorkflow: vi.fn(), updateWorkflow: vi.fn() };
+    const persistence = {
+      listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+      loadTasks: vi.fn(() => []),
+      loadWorkflow: vi.fn(() => undefined),
+      updateWorkflow: vi.fn(),
+    };
 
     await expect(
       rebaseAndRetry('missing-task', {
         orchestrator: orchestrator as unknown as Orchestrator,
         persistence: persistence as unknown as SQLiteAdapter,
       }),
-    ).rejects.toThrow('Task missing-task not found or has no workflow');
+    ).rejects.toThrow('Could not resolve headless target workflow');
   });
 });
 
@@ -359,14 +416,19 @@ describe('recreateWithRebase', () => {
 
   it('throws when workflow not found', async () => {
     const orchestrator = { recreateWorkflowFromFreshBase: vi.fn(async () => []) };
-    const persistence = { loadWorkflow: vi.fn(() => undefined), updateWorkflow: vi.fn() };
+    const persistence = {
+      listWorkflows: vi.fn(() => []),
+      loadTasks: vi.fn(() => []),
+      loadWorkflow: vi.fn(() => undefined),
+      updateWorkflow: vi.fn(),
+    };
 
     await expect(
       recreateWithRebase('missing', {
         orchestrator: orchestrator as unknown as Orchestrator,
         persistence: persistence as unknown as SQLiteAdapter,
       }),
-    ).rejects.toThrow('Workflow missing not found');
+    ).rejects.toThrow('Could not resolve headless target workflow');
   });
 });
 
@@ -378,12 +440,13 @@ describe('recreateWithRebase', () => {
 // canonical lifecycle wrappers (or routing a new one through a
 // legacy compat layer like `restartTask`).
 describe('Step 17: app-layer wrappers expose the 5-cell lifecycle matrix', () => {
-  it('exports retryTask, recreateTask, retryWorkflow, recreateWorkflow, recreateWorkflowFromFreshBase', () => {
+  it('exports retryTask, recreateTask, retryWorkflow, recreateWorkflow, recreateWorkflowFromFreshBase, rebase', () => {
     expect(typeof retryTask).toBe('function');
     expect(typeof recreateTask).toBe('function');
     expect(typeof retryWorkflow).toBe('function');
     expect(typeof recreateWorkflow).toBe('function');
     expect(typeof recreateWorkflowFromFreshBase).toBe('function');
+    expect(typeof rebase).toBe('function');
   });
 
   it('each wrapper routes to the matching orchestrator primitive (no restartTask path)', async () => {

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -31,7 +31,8 @@
  *   POST   /api/tasks/:id/gate-policy  body: { updates: [{ workflowId, taskId?, gatePolicy }] }
  *   POST   /api/workflows/:id/detach  body: { upstreamWorkflowId }
  *   POST   /api/workflows/:id/restart
- *   POST   /api/workflows/:id/recreate-with-rebase
+ *   POST   /api/workflows/:id/rebase
+ *   POST   /api/workflows/:id/recreate-with-rebase  Deprecated alias
  *   POST   /api/workflows/:id/cancel
  *   POST   /api/workflows/:id/merge-mode  body: { mode }
  *   DELETE /api/workflows/:id
@@ -357,28 +358,29 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
-      // POST /api/workflows/:id/recreate-with-rebase  (legacy: /api/workflows/:id/rebase-and-retry)
+      const wfRebaseMatch = path.match(/^\/api\/workflows\/([^/]+)\/rebase$/);
       const wfRecreateWithRebaseMatch = path.match(/^\/api\/workflows\/([^/]+)\/recreate-with-rebase$/);
       const wfRebaseAndRetryMatch = path.match(/^\/api\/workflows\/([^/]+)\/rebase-and-retry$/);
-      if (method === 'POST' && (wfRecreateWithRebaseMatch || wfRebaseAndRetryMatch)) {
-        const isLegacy = !!wfRebaseAndRetryMatch;
-        const workflowTarget = decodeURIComponent((wfRecreateWithRebaseMatch ?? wfRebaseAndRetryMatch)![1]);
+      if (method === 'POST' && (wfRebaseMatch || wfRecreateWithRebaseMatch || wfRebaseAndRetryMatch)) {
+        const legacyMatch = wfRecreateWithRebaseMatch ?? wfRebaseAndRetryMatch;
+        const isLegacy = !!legacyMatch;
+        const workflowTarget = decodeURIComponent((wfRebaseMatch ?? legacyMatch)![1]);
         try {
           const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, persistence);
-          const result = await mutations.recreateWorkflowFromFreshBase(workflowId);
+          const result = await mutations.rebase(workflowTarget);
           if (isLegacy) {
             res.setHeader(
               'Deprecation',
-              'true; reason="Use /api/workflows/:id/recreate-with-rebase"',
+              'true; reason="Use /api/workflows/:id/rebase"',
             );
           }
           const tasksStarted = result.started.filter(t => t.status === 'running').length;
           json(res, 200, {
             ok: true,
             workflowId,
-            action: isLegacy ? 'rebase_and_retried' : 'recreated_with_rebase',
+            action: 'rebased',
             tasksStarted,
-            ...(isLegacy ? { deprecated: true, replacement: '/api/workflows/:id/recreate-with-rebase' } : {}),
+            ...(isLegacy ? { deprecated: true, replacement: '/api/workflows/:id/rebase' } : {}),
           });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -121,7 +121,7 @@ export function isHeadlessMutatingCommand(args: string[]): boolean {
   }
 
   return [
-    'run', 'resume', 'retry', 'retry-task', 'recreate', 'recreate-task', 'rebase', 'recreate-with-rebase', 'fix', 'resolve-conflict',
+    'run', 'resume', 'retry', 'retry-task', 'recreate', 'recreate-task', 'rebase', 'rebase-task', 'recreate-with-rebase', 'fix', 'resolve-conflict',
     'detach-workflow',
     'migrate-compat',
     'rebase-and-retry',

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -71,7 +71,11 @@ export async function tryDelegateResume(
 }
 
 function usesExtendedDelegationTimeout(command: string): boolean {
-  return command === 'rebase' || command === 'rebase-and-retry' || command === 'recreate-with-rebase' || command === 'restart';
+  return command === 'rebase'
+    || command === 'rebase-task'
+    || command === 'rebase-and-retry'
+    || command === 'recreate-with-rebase'
+    || command === 'restart';
 }
 
 function looksLikeWorkflowId(target: unknown): boolean {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -35,8 +35,7 @@ import {
   approveTask,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   fixWithAgentAction,
-  rebaseAndRetry,
-  recreateWithRebase,
+  rebase,
   resolveConflictAction,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
@@ -969,16 +968,18 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
       await headlessDetachWorkflow(args[1], args[2], deps);
       break;
     case 'rebase':
-      await headlessRebaseAndRetry(args[1], deps);
+      await headlessRebase(args[1], deps, 'rebase');
+      break;
+    case 'rebase-task':
+      await headlessRebaseTask(args[1], deps);
       break;
     case 'recreate-with-rebase':
-      await headlessRecreateWithRebase(args[1], deps);
+      warnDeprecated('recreate-with-rebase', 'rebase');
+      await headlessRebase(args[1], deps, 'recreate-with-rebase');
       break;
-
-    // Deprecated aliases
     case 'rebase-and-retry':
-      warnDeprecated('rebase-and-retry', 'rebase');
-      await headlessRebaseAndRetry(args[1], deps);
+      warnDeprecated('rebase-and-retry', 'rebase-task');
+      await headlessRebaseTask(args[1], deps, 'rebase-and-retry');
       break;
     case 'fix':
       await headlessFix(args[1], deps, args[2]);
@@ -1138,8 +1139,9 @@ ${BOLD}Execute:${RESET}
   recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
   fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
   detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
-  rebase <taskId>                                     Refresh pool base + nuclear restart
-  recreate-with-rebase <workflowId|mergeTaskId|taskId> Recreate workflow from fresh upstream base
+  rebase <workflowId|mergeTaskId|taskId>              Rebase workflow from a fresh upstream base
+  rebase-task <taskId>                                Rebase workflow from a task on a fresh upstream base
+  recreate-with-rebase <workflowId|mergeTaskId|taskId> Deprecated alias for rebase
   fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
   resolve-conflict <taskId> [claude|codex]            Resolve merge conflict + restart
 
@@ -1176,7 +1178,7 @@ ${BOLD}Deprecated${RESET} (use new names above):
   edit → set command            edit-executor → set executor
   edit-agent → set agent        set-merge-mode → set merge-mode
   delete-workflow → delete
-  rebase-and-retry → rebase (task) or recreate-with-rebase (workflow)
+  rebase-and-retry → rebase-task
 
 ${BOLD}Options:${RESET}
   --wait-for-approval    Keep running until PR approval (use with 'run' or 'resume')
@@ -1635,29 +1637,32 @@ async function headlessResolveConflict(taskId: string, deps: HeadlessDeps, agent
   }
 }
 
-async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promise<void> {
-  if (!taskId) throw new Error('Missing arguments. Usage: --headless rebase-and-retry <taskId>');
-  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'rebase');
-  if (!restored) return;
-  taskId = restored.resolvedTaskId;
-  const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
-  if (!workflowId) throw new Error(`Task "${taskId}" has no workflow`);
+async function headlessRebase(
+  target: string,
+  deps: HeadlessDeps,
+  commandName: 'rebase' | 'rebase-task' | 'rebase-and-retry' | 'recreate-with-rebase' = 'rebase',
+): Promise<void> {
+  if (!target) {
+    throw new Error(`Missing arguments. Usage: --headless ${commandName} <workflowId|mergeTaskId|taskId>`);
+  }
+  const workflowId = resolveHeadlessTargetWorkflowId(target, deps.persistence);
+  deps.orchestrator.syncFromDb(workflowId);
   await preemptWorkflowBeforeMutation(workflowId, {
     preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
     logger: deps.logger,
-    context: 'headless.rebase-and-retry',
+    context: `headless.${commandName}`,
     mutationTiming: deps.mutationTiming,
   });
 
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
-  const started = await rebaseAndRetry(taskId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
+  const started = await rebase(target, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
   const runnable = started.filter(isDispatchableLaunch);
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
     taskExecutor: te,
     logger: deps.logger,
-    context: 'headless.rebase-and-retry',
+    context: `headless.${commandName}`,
     started,
     scopedWorkflowId: workflowId,
     mutationTiming: deps.mutationTiming,
@@ -1680,51 +1685,18 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
   autoFix.unsubscribe();
 
   const tasksStarted = runnable.length;
-  process.stdout.write(`Rebase-and-retry: resetting workflow from current HEAD (${tasksStarted} task(s))\n`);
+  process.stdout.write(`Rebase: resetting workflow from fresh base (${tasksStarted} task(s))\n`);
 }
 
-async function headlessRecreateWithRebase(workflowTarget: string, deps: HeadlessDeps): Promise<void> {
-  if (!workflowTarget) throw new Error('Missing arguments. Usage: --headless recreate-with-rebase <workflowId|mergeTaskId|taskId>');
-  const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, deps.persistence);
-  await preemptWorkflowBeforeMutation(workflowId, {
-    preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
-    logger: deps.logger,
-    context: 'headless.recreate-with-rebase',
-    mutationTiming: deps.mutationTiming,
-  });
-
-  const te = createHeadlessExecutor(deps);
-  const autoFix = wireHeadlessAutoFix(deps, te);
-  const started = await recreateWithRebase(workflowId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
-  const runnable = started.filter(isDispatchableLaunch);
-  const { topup } = await dispatchStartedTasksWithGlobalTopup({
-    orchestrator: deps.orchestrator,
-    taskExecutor: te,
-    logger: deps.logger,
-    context: 'headless.recreate-with-rebase',
-    started,
-    scopedWorkflowId: workflowId,
-    mutationTiming: deps.mutationTiming,
-  });
-  if (runnable.length + topup.length === 0) {
-    autoFix.unsubscribe();
-    return;
+async function headlessRebaseTask(
+  taskId: string,
+  deps: HeadlessDeps,
+  commandName: 'rebase-task' | 'rebase-and-retry' = 'rebase-task',
+): Promise<void> {
+  if (!taskId) {
+    throw new Error(`Missing arguments. Usage: --headless ${commandName} <taskId>`);
   }
-  if (deps.noTrack) {
-    process.stdout.write('[headless] --no-track enabled: recreate-with-rebase accepted; exiting without tracking.\n');
-    autoFix.unsubscribe();
-    return;
-  }
-  await trackHeadlessWorkflow(workflowId, deps, {
-    hasBackgroundWork: autoFix.isBusy,
-    printSummary: false,
-    printTaskOutput: true,
-    setExitCodeOnFailure: false,
-  });
-  autoFix.unsubscribe();
-
-  const tasksStarted = runnable.length;
-  process.stdout.write(`Recreate-with-rebase: resetting workflow from fresh base (${tasksStarted} task(s))\n`);
+  await headlessRebase(taskId, deps, commandName);
 }
 
 async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -121,8 +121,7 @@ import {
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
   fixWithAgentAction,
-  rebaseAndRetry,
-  recreateWithRebase,
+  rebase,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
   resolveConflictAction,
@@ -1901,6 +1900,7 @@ if (isHeadless) {
       case 'recreate-with-rebase':
         return { workflowId: workflowIdForTargetArg(arg0), priority: 'high' };
       case 'rebase':
+      case 'rebase-task':
       case 'cancel':
       case 'recreate-task':
         return { workflowId: workflowIdForTaskArg(arg0), priority: 'high' };
@@ -1980,10 +1980,13 @@ if (isHeadless) {
         return { channel: 'headless.exec', request: { args: ['recreate-task', String(arg0)] } };
       case 'invoker:retry-workflow':
         return { channel: 'headless.exec', request: { args: ['retry', String(arg0)] } };
-      case 'invoker:rebase-and-retry':
+      case 'invoker:rebase':
         return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
+      case 'invoker:rebase-task':
+      case 'invoker:rebase-and-retry':
+        return { channel: 'headless.exec', request: { args: ['rebase-task', String(arg0)] } };
       case 'invoker:recreate-with-rebase':
-        return { channel: 'headless.exec', request: { args: ['recreate-with-rebase', String(arg0)] } };
+        return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
       case 'invoker:set-merge-mode':
         return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
       case 'invoker:approve-merge': {
@@ -3413,24 +3416,25 @@ if (isHeadless) {
       },
     );
 
-    registerWorkflowScopedGuiMutationHandler(
-      'invoker:rebase-and-retry',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
-      'high',
-      async (taskIdArg: unknown) => {
-      const taskId = String(taskIdArg);
-      logger.info(`rebase-and-retry: "${taskId}"`, { module: 'ipc' });
+    async function performRebaseTarget(
+      targetArg: unknown,
+      context: 'ipc.rebase' | 'ipc.rebase-task' | 'ipc.rebase-and-retry' | 'ipc.recreate-with-rebase',
+    ): Promise<{ success: boolean; rebasedBranches: string[]; errors: string[] }> {
+      const target = String(targetArg);
+      const workflowId = workflowIdForTargetArg(targetArg);
+      if (!workflowId) {
+        throw new Error(`Could not resolve workflow for rebase target "${target}"`);
+      }
+      cancelDeferredWorkflowLaunch(workflowId, context);
+      logger.info(`rebase: target="${target}" workflow="${workflowId}"`, { module: 'ipc' });
       try {
-        const workflowId = workflowIdForTaskArg(taskIdArg);
-        if (workflowId) {
-          await preemptWorkflowBeforeMutation(workflowId, {
-            preemptWorkflowExecution,
-            logger,
-            context: 'ipc.rebase-and-retry',
-            mutationTiming: activeMutationContext?.mutationTiming,
-          });
-        }
-        const started = await rebaseAndRetry(taskId, {
+        await preemptWorkflowBeforeMutation(workflowId, {
+          preemptWorkflowExecution,
+          logger,
+          context,
+          mutationTiming: activeMutationContext?.mutationTiming,
+        });
+        const started = await rebase(target, {
           orchestrator,
           persistence,
           repoRoot,
@@ -3441,15 +3445,42 @@ if (isHeadless) {
           orchestrator,
           taskExecutor: requireTaskExecutor(),
           logger,
-          context: 'ipc.rebase-and-retry',
+          context,
           started,
-          ...(workflowId ? { scopedWorkflowId: workflowId } : { scopedTaskIds: [taskId] }),
+          scopedWorkflowId: workflowId,
           mutationTiming: activeMutationContext?.mutationTiming,
         });
+        return { success: true, rebasedBranches: [], errors: [] };
       } catch (err) {
-        logger.error(`rebase-and-retry failed: ${err}`, { module: 'ipc' });
+        logger.error(`rebase failed: ${err}`, { module: 'ipc' });
         throw err;
       }
+    }
+
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:rebase',
+      (targetArg: unknown) => workflowIdForTargetArg(targetArg),
+      'high',
+      async (targetArg: unknown) => {
+        return performRebaseTarget(targetArg, 'ipc.rebase');
+      },
+    );
+
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:rebase-and-retry',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'high',
+      async (taskIdArg: unknown) => {
+        return performRebaseTarget(taskIdArg, 'ipc.rebase-and-retry');
+      },
+    );
+
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:rebase-task',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'high',
+      async (taskIdArg: unknown) => {
+        return performRebaseTarget(taskIdArg, 'ipc.rebase-task');
       },
     );
 
@@ -3458,39 +3489,7 @@ if (isHeadless) {
       (workflowIdArg: unknown) => workflowIdForTargetArg(workflowIdArg),
       'high',
       async (workflowIdArg: unknown) => {
-      const workflowId = workflowIdForTargetArg(workflowIdArg);
-      if (!workflowId) {
-        throw new Error(`Could not resolve workflow for recreate-with-rebase target "${String(workflowIdArg)}"`);
-      }
-      cancelDeferredWorkflowLaunch(workflowId, 'ipc.recreate-with-rebase');
-      logger.info(`recreate-with-rebase: "${workflowId}"`, { module: 'ipc' });
-      try {
-        await preemptWorkflowBeforeMutation(workflowId, {
-          preemptWorkflowExecution,
-          logger,
-          context: 'ipc.recreate-with-rebase',
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        const started = await recreateWithRebase(workflowId, {
-          orchestrator,
-          persistence,
-          repoRoot,
-          taskExecutor: requireTaskExecutor(),
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-        await dispatchStartedTasksWithGlobalTopup({
-          orchestrator,
-          taskExecutor: requireTaskExecutor(),
-          logger,
-          context: 'ipc.recreate-with-rebase',
-          started,
-          scopedWorkflowId: workflowId,
-          mutationTiming: activeMutationContext?.mutationTiming,
-        });
-      } catch (err) {
-        logger.error(`recreate-with-rebase failed: ${err}`, { module: 'ipc' });
-        throw err;
-      }
+        return performRebaseTarget(workflowIdArg, 'ipc.recreate-with-rebase');
       },
     );
 

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -387,6 +387,8 @@ export class PersistedWorkflowMutationCoordinator {
     if (
       channel === 'invoker:recreate-workflow'
       || channel === 'invoker:recreate-task'
+      || channel === 'invoker:rebase'
+      || channel === 'invoker:rebase-task'
       || channel === 'invoker:recreate-with-rebase'
     ) {
       return 'recreate';
@@ -399,7 +401,7 @@ export class PersistedWorkflowMutationCoordinator {
     }
     const payload = args[0] as { args?: unknown[] } | undefined;
     const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
-    if (rawArgs[0] === 'recreate' || rawArgs[0] === 'recreate-task' || rawArgs[0] === 'recreate-with-rebase') {
+    if (rawArgs[0] === 'recreate' || rawArgs[0] === 'recreate-task' || rawArgs[0] === 'rebase' || rawArgs[0] === 'rebase-task' || rawArgs[0] === 'recreate-with-rebase') {
       return 'recreate';
     }
     if (rawArgs[0] === 'delete' || rawArgs[0] === 'delete-workflow' || rawArgs[0] === 'delete-all') {
@@ -413,6 +415,8 @@ export class PersistedWorkflowMutationCoordinator {
       intent.channel === 'invoker:retry-workflow'
       || intent.channel === 'invoker:recreate-workflow'
       || intent.channel === 'invoker:recreate-task'
+      || intent.channel === 'invoker:rebase'
+      || intent.channel === 'invoker:rebase-task'
       || intent.channel === 'invoker:recreate-with-rebase'
       || intent.channel === 'invoker:delete-workflow'
       || intent.channel === 'invoker:delete-all-workflows'
@@ -437,7 +441,7 @@ export class PersistedWorkflowMutationCoordinator {
     if (!isWorkflowId) {
       return false;
     }
-    return command === 'recreate' || command === 'recreate-with-rebase' || command === 'retry';
+    return command === 'recreate' || command === 'rebase' || command === 'rebase-task' || command === 'recreate-with-rebase' || command === 'retry';
   }
 
   private createTiming(

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -21,6 +21,7 @@ import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import { isDispatchableLaunch } from './global-topup.js';
+import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 
 // ── Lineage guard ─────────────────────────────────────────────
 
@@ -413,13 +414,37 @@ export async function recreateWorkflowFromFreshBase(
 }
 
 /**
- * Recreate a workflow from a fresh upstream base — workflow-scoped
- * entry point for the `invoker:recreate-with-rebase` IPC channel.
+ * Canonical fresh-base reset entry point.
  *
- * This is the direct workflow-id counterpart of `rebaseAndRetry`
- * (which performs a `taskId → workflowId` translation first). Both
- * delegate to `recreateWorkflowFromFreshBase` for the actual
- * pool-refresh + generation-bump + DAG reset.
+ * The target may be a workflow id, merge task id, or normal task id.
+ * It resolves to the owning workflow and delegates to
+ * `recreateWorkflowFromFreshBase` for the pool-refresh + generation-bump
+ * + DAG reset behavior.
+ */
+export async function rebase(
+  target: string,
+  deps: ActionDeps,
+): Promise<TaskState[]> {
+  const workflowId = resolveHeadlessTargetWorkflowId(target, deps.persistence);
+  (deps.orchestrator as { syncFromDb?: (workflowId: string) => void }).syncFromDb?.(workflowId);
+  deps.mutationTiming?.mark('workflow-actions.rebase', 'started', { target, workflowId });
+  deps.logger?.info(
+    `rebase: target=${target} workflowId=${workflowId} → recreateWorkflowFromFreshBase`,
+    { module: 'agent-session-trace' },
+  );
+  const started = await recreateWorkflowFromFreshBase(workflowId, deps);
+  deps.mutationTiming?.mark('workflow-actions.rebase', 'completed', {
+    target,
+    workflowId,
+    startedCount: started.length,
+  });
+  return started;
+}
+
+/**
+ * Deprecated compatibility alias for workflow-scoped fresh-base reset.
+ *
+ * @deprecated Prefer `rebase(target, deps)`.
  */
 export async function recreateWithRebase(
   workflowId: string,
@@ -427,10 +452,10 @@ export async function recreateWithRebase(
 ): Promise<TaskState[]> {
   deps.mutationTiming?.mark('workflow-actions.recreateWithRebase', 'started', { workflowId });
   deps.logger?.info(
-    `recreateWithRebase: workflowId=${workflowId} → recreateWorkflowFromFreshBase`,
+    `recreateWithRebase: workflowId=${workflowId} → rebase`,
     { module: 'agent-session-trace' },
   );
-  const started = await recreateWorkflowFromFreshBase(workflowId, deps);
+  const started = await rebase(workflowId, deps);
   deps.mutationTiming?.mark('workflow-actions.recreateWithRebase', 'completed', {
     workflowId,
     startedCount: started.length,
@@ -439,29 +464,21 @@ export async function recreateWithRebase(
 }
 
 /**
- * Rebase-and-retry: refresh the pool mirror / origin base, remove managed
- * experiment/invoker branches in that mirror, bump generation, and restart the DAG.
+ * Deprecated compatibility alias for task-scoped fresh-base reset.
  *
- * Step 12: this wrapper is now a thin delegate to
- * `recreateWorkflowFromFreshBase` — the chart's first-class action
- * for this behavior. It is preserved as a separate export because
- * existing callers (notably `headlessRebaseAndRetry`) speak in task
- * ids while the workflow-scope action speaks in workflow ids; this
- * function continues to do the `taskId → workflowId` translation.
+ * @deprecated Prefer `rebase(target, deps)`.
  */
 export async function rebaseAndRetry(
   taskId: string,
   deps: ActionDeps,
 ): Promise<TaskState[]> {
-  const task = deps.orchestrator.getTask(taskId);
-  if (!task?.config.workflowId) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found or has no workflow`);
-  const workflowId = task.config.workflowId;
+  const workflowId = resolveHeadlessTargetWorkflowId(taskId, deps.persistence);
   deps.mutationTiming?.mark('workflow-actions.rebaseAndRetry', 'started', { taskId, workflowId });
   deps.logger?.info(
-    `rebaseAndRetry: taskId=${taskId} workflowId=${workflowId} → recreateWorkflowFromFreshBase (Step 12 delegate)`,
+    `rebaseAndRetry: taskId=${taskId} workflowId=${workflowId} → rebase`,
     { module: 'agent-session-trace' },
   );
-  const started = await recreateWorkflowFromFreshBase(workflowId, deps);
+  const started = await rebase(taskId, deps);
   deps.mutationTiming?.mark('workflow-actions.rebaseAndRetry', 'completed', {
     taskId,
     workflowId,

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -28,8 +28,7 @@ import {
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
   recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
-  recreateWithRebase as sharedRecreateWithRebase,
-  rebaseAndRetry as sharedRebaseAndRetry,
+  rebase as sharedRebase,
   cancelWorkflow as sharedCancelWorkflow,
   forkWorkflow as sharedForkWorkflow,
   editTaskCommand as sharedEditTaskCommand,
@@ -47,6 +46,7 @@ import {
   type FixWithAgentActionResult,
   type ActionDeps,
 } from './workflow-actions.js';
+import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import {
   dispatchStartedTasksWithGlobalTopup,
   executeGlobalTopup,
@@ -115,6 +115,10 @@ export interface WorkflowMutationFacadeDeps {
  */
 export class WorkflowMutationFacade {
   constructor(private readonly deps: WorkflowMutationFacadeDeps) {}
+
+  private resolveTargetWorkflowId(target: string): string {
+    return resolveHeadlessTargetWorkflowId(target, this.deps.persistence);
+  }
 
   // ── Task-scoped mutations ────────────────────────────────
 
@@ -250,19 +254,22 @@ export class WorkflowMutationFacade {
     return this.finalizeWithTopup(started, 'facade.recreate-from-fresh-base', { scopedWorkflowId: workflowId });
   }
 
+  async rebase(target: string): Promise<MutationResult> {
+    const workflowId = this.resolveTargetWorkflowId(target);
+    const started = await sharedRebase(target, this.actionDeps());
+    return this.finalizeWithTopup(started, 'facade.rebase', { scopedWorkflowId: workflowId });
+  }
+
+  async rebaseTask(taskId: string): Promise<MutationResult> {
+    return this.rebase(taskId);
+  }
+
   async recreateWithRebase(workflowId: string): Promise<MutationResult> {
-    const started = await sharedRecreateWithRebase(workflowId, this.actionDeps());
-    return this.finalizeWithTopup(started, 'facade.recreate-with-rebase', { scopedWorkflowId: workflowId });
+    return this.rebase(workflowId);
   }
 
   async rebaseAndRetry(taskId: string): Promise<MutationResult> {
-    const workflowId = this.deps.orchestrator.getTask(taskId)?.config.workflowId;
-    const started = await sharedRebaseAndRetry(taskId, this.actionDeps());
-    return this.finalizeWithTopup(
-      started,
-      'facade.rebase-and-retry',
-      workflowId ? { scopedWorkflowId: workflowId } : { scopedTaskIds: [taskId] },
-    );
+    return this.rebase(taskId);
   }
 
   async cancelWorkflow(workflowId: string): Promise<CancelMutationResult> {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -422,6 +422,14 @@ export const IpcChannels = {
     request: [workflowId: string];
     response: void;
   },
+  'invoker:rebase': {} as {
+    request: [target: string];
+    response: RebaseAndRetryResult;
+  },
+  'invoker:rebase-task': {} as {
+    request: [taskId: string];
+    response: RebaseAndRetryResult;
+  },
   'invoker:rebase-and-retry': {} as {
     request: [mergeTaskId: string];
     response: RebaseAndRetryResult;


### PR DESCRIPTION
## Summary

Make `rebase <target>` the canonical fresh-base reset command for workflows. The target resolver accepts workflow ids, merge task ids, and normal task ids, then routes all forms through `recreateWorkflowFromFreshBase`.

Add canonical task-target naming with `rebase-task <taskId>` and `invoker:rebase-task`, matching the existing task command/API convention. Compatibility is preserved for existing CLI, IPC, and HTTP callers: `rebase-and-retry` and `recreate-with-rebase` continue to work as deprecated aliases, and old API routes still return the same mutation result.

## Architecture

### Before

```mermaid
graph TD
    A[rebase taskId] --> B[rebaseAndRetry]
    C[recreate-with-rebase target] --> D[recreateWithRebase]
    B --> E[recreateWorkflowFromFreshBase]
    D --> E
```

### After

```mermaid
graph TD
    A[rebase target] --> B[resolve workflow target]
    C[rebase-task taskId] --> A
    D[rebase-and-retry alias] --> C
    E[recreate-with-rebase alias] --> A
    F[invoker:rebase IPC/API] --> A
    G[invoker:rebase-task IPC] --> C
    B --> H[recreateWorkflowFromFreshBase]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-delegation.test.ts src/__tests__/owner-delegation.test.ts src/__tests__/persisted-workflow-mutation-coordinator.test.ts src/__tests__/api-server.test.ts src/__tests__/workflow-actions.test.ts`
- [x] `pnpm --filter @invoker/app test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 94661426`
- Post-revert steps: Re-run `pnpm --filter @invoker/app test`
- Data migration? No
