### PR TITLE
Use canonical rebase action in UI

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -488,7 +488,7 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByRole('menuitem', { name: 'Retry Workflow' })).toBeVisible();
     await expect(page.getByRole('menuitem', { name: 'Copy Workflow ID' })).toBeVisible();
     await page.getByRole('menuitem', { name: 'More' }).click();
-    await expect(page.getByRole('menuitem', { name: 'Recreate with Rebase' })).toBeVisible();
+    await expect(page.getByRole('menuitem', { name: 'Rebase Workflow' })).toBeVisible();
     await expect(page.getByRole('menuitem', { name: 'Recreate Workflow' })).toBeVisible();
     await expect(page.getByRole('menuitem', { name: 'Cancel Workflow' })).toBeVisible();
     await expect(page.getByRole('menuitem', { name: 'Delete Workflow' })).toBeVisible();

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -52,7 +52,7 @@ interface WorkflowContextMenuProps {
   onOpenWorkflow: (workflowId: string) => void;
   onOpenPr: (workflowId: string) => void;
   onRetryWorkflow: (workflowId: string) => void;
-  onRecreateWithRebase: (workflowId: string) => void;
+  onRebaseWorkflow: (workflowId: string) => void;
   onRecreateWorkflow: (workflowId: string) => void;
   onCancelWorkflow: (workflowId: string) => void;
   onDeleteWorkflow: (workflowId: string) => void;
@@ -67,7 +67,7 @@ function WorkflowContextMenu({
   onOpenWorkflow,
   onOpenPr,
   onRetryWorkflow,
-  onRecreateWithRebase,
+  onRebaseWorkflow,
   onRecreateWorkflow,
   onCancelWorkflow,
   onDeleteWorkflow,
@@ -169,8 +169,8 @@ function WorkflowContextMenu({
       ) : (
         <div>
           <div className="my-1 border-t border-gray-600" />
-          <button role="menuitem" onClick={() => runAction(onRecreateWithRebase)} className={dangerButtonClass}>
-            Recreate with Rebase
+          <button role="menuitem" onClick={() => runAction(onRebaseWorkflow)} className={dangerButtonClass}>
+            Rebase Workflow
           </button>
           <button role="menuitem" onClick={() => runAction(onRecreateWorkflow)} className={dangerButtonClass}>
             Recreate Workflow
@@ -508,15 +508,15 @@ export function App() {
     }
   }, []);
 
-  const handleRecreateWithRebase = useCallback(async (workflowId: string) => {
+  const handleRebaseWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     try {
-      const result = await window.invoker?.recreateWithRebase(workflowId);
+      const result = await window.invoker?.rebase(workflowId);
       if (result && !result.success) {
-        console.error('Recreate with Rebase failed for some branches:', result.errors);
+        console.error('Rebase failed for some branches:', result.errors);
       }
     } catch (err) {
-      console.error('Recreate with Rebase failed:', err);
+      console.error('Rebase failed:', err);
     }
   }, []);
 
@@ -1226,7 +1226,7 @@ export function App() {
           onOpenWorkflow={handleWorkflowClick}
           onOpenPr={handleOpenWorkflowPr}
           onRetryWorkflow={(workflowId) => void handleRetryWorkflow(workflowId)}
-          onRecreateWithRebase={(workflowId) => void handleRecreateWithRebase(workflowId)}
+          onRebaseWorkflow={(workflowId) => void handleRebaseWorkflow(workflowId)}
           onRecreateWorkflow={(workflowId) => void handleRecreateWorkflow(workflowId)}
           onCancelWorkflow={(workflowId) => void handleCancelWorkflow(workflowId)}
           onDeleteWorkflow={(workflowId) => void handleDeleteWorkflow(workflowId)}

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -117,12 +117,12 @@ describe('Context menu (component)', () => {
     await waitFor(() => expect(mock.api.recreateWorkflow).toHaveBeenCalledWith('wf-1'));
   });
 
-  it('workflow context menu recreates workflow with rebase', async () => {
+  it('workflow context menu rebases workflow', async () => {
     await setup();
     fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));
     fireEvent.click(await screen.findByText('More'));
-    fireEvent.click(await screen.findByText('Recreate with Rebase'));
-    await waitFor(() => expect(mock.api.recreateWithRebase).toHaveBeenCalledWith('wf-1'));
+    fireEvent.click(await screen.findByText('Rebase Workflow'));
+    await waitFor(() => expect(mock.api.rebase).toHaveBeenCalledWith('wf-1'));
   });
 
   it('workflow context menu cancels workflow', async () => {

--- a/packages/ui/src/__tests__/context-menu.test.ts
+++ b/packages/ui/src/__tests__/context-menu.test.ts
@@ -98,7 +98,7 @@ describe('ContextMenu getMenuItems', () => {
       const taskWithWorkflow = makeTask({ status: 'failed', workflowId: 'wf-1' });
       const itemsWithWorkflow = getMenuItems(taskWithWorkflow);
 
-      const workflowItemIds = ['rebase-retry', 'recreate-rebase', 'retry-workflow', 'recreate-workflow', 'cancel-workflow', 'delete-workflow'];
+      const workflowItemIds = ['rebase-workflow', 'retry-workflow', 'recreate-workflow', 'cancel-workflow', 'delete-workflow'];
       workflowItemIds.forEach((id) => {
         expect(itemsWithWorkflow.find((i) => i.id === id)).toBeUndefined();
       });

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -136,6 +136,8 @@ export function createMockInvoker(
     recreateWorkflow: vi.fn(async () => {}),
     recreateTask: vi.fn(async () => {}),
     retryWorkflow: vi.fn(async () => {}),
+    rebase: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
+    rebaseTask: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
     rebaseAndRetry: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
     recreateWithRebase: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
     setMergeBranch: vi.fn(async () => {}),


### PR DESCRIPTION
## Summary

Update the UI fresh-base reset action to use the canonical Rebase wording and API. The workflow context menu now shows `Rebase Workflow` and calls `window.invoker.rebase(workflowId)` instead of the legacy `recreateWithRebase` renderer method.

Compatibility methods remain in the mock API and contract, including the new derived `rebaseTask` method from the backend stack entry, but the primary UI no longer displays the old wording.

## Visual Proof

Captured the workflow context-menu state against PR 704's stack base (`94661426`) and the PR 704 head (`263ab17c`). The visual-proof state `workflow context menu organization` passed in both captures and shows the intended label change.

Before (`Recreate with Rebase`):

![Before workflow context menu](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260517-22b51c/pr704-before-workflow-context-menu.png)

After (`Rebase Workflow`):

![After workflow context menu](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260517-22b51c/pr704-after-workflow-context-menu.png)

## Test Plan

- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu-e2e.test.tsx src/__tests__/context-menu.test.ts`
- [x] `pnpm --filter @invoker/ui test`
- [x] `pnpm --filter @invoker/app test`
- [x] `bash scripts/ui-visual-proof.sh capture-before --output-dir /Users/edbertchan/Documents/GitHub/invoker-rebase-target-unification/packages/app/e2e/visual-proof` on PR 704 base `94661426` captured `workflow-context-menu-organization.png`; command exited nonzero due unrelated existing screenshot-baseline mismatches in other visual-proof states.
- [x] `bash scripts/ui-visual-proof.sh capture-after` on PR 704 head `263ab17c` captured `workflow-context-menu-organization.png`; command exited nonzero due unrelated existing screenshot-baseline mismatches in other visual-proof states.
- [ ] `bash scripts/ui-visual-proof.sh compare` not run successfully: local environment is missing `ffmpeg`.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 263ab17c`
- Post-revert steps: Re-run `pnpm --filter @invoker/ui test`
- Data migration? No
