### PR TITLE
Fix SSH remote agent auth and workspace recovery

### DIFF
--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -109,6 +109,16 @@ export interface InvokerConfig {
      */
     provisionCommand?: string;
     /**
+     * When true, export agent API keys from the local secrets file into SSH task/fix
+     * shells. Default false so remote Claude/Codex CLI account auth is preserved.
+     */
+    use_api_key?: boolean;
+    /**
+     * Optional local KEY=value secrets file used when use_api_key is true.
+     * Defaults to docker.secretsFile/fallback when unset.
+     */
+    secretsFile?: string;
+    /**
      * Remote workload heartbeat interval (seconds) emitted by the SSH payload wrapper.
      * Used for SSH executing-stall liveness checks. Default: 30.
      */

--- a/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
@@ -658,9 +658,52 @@ describe('conflict-resolver fail-fast workspace invariant', () => {
 
       // Should not throw workspace check - SSH tasks can have remote paths
       // This path will still fail in unit tests because no SSH target exists.
-      await expect(
+    await expect(
         fixWithAgentImpl(host, 'task-ssh', 'error output'),
       ).rejects.not.toThrow(/has no valid workspace/);
+    });
+
+    it('uses launch audit poolMemberId for pool-routed SSH task fixes', async () => {
+      const task = {
+        id: 'task-ssh-pool',
+        status: 'failed' as const,
+        execution: {
+          error: 'Test failed',
+          workspacePath: '~/.invoker/worktrees/repo/task-ssh-pool',
+        },
+        config: {
+          command: 'npm test',
+          runnerKind: 'ssh' as const,
+          poolId: 'pnpm-ssh',
+        },
+      };
+      const getRemoteTargetConfig = vi.fn(() => ({
+        host: 'remote.example',
+        user: 'user',
+        sshKeyPath: '/key',
+      }));
+
+      const host: ConflictResolverHost = {
+        ...makeHost(task),
+        persistence: {
+          getEvents: () => [
+            {
+              id: 1,
+              taskId: task.id,
+              eventType: 'task.executor.selected',
+              payload: JSON.stringify({ poolMemberId: 'remote-from-audit' }),
+              createdAt: new Date().toISOString(),
+            },
+          ],
+        } as any,
+        getRemoteTargetConfig,
+        agentRegistry: registerBuiltinAgents(),
+      };
+
+      await expect(
+        fixWithAgentImpl(host, task.id, 'error output'),
+      ).rejects.not.toThrow(/has no valid workspace/);
+      expect(getRemoteTargetConfig).toHaveBeenCalledWith('remote-from-audit');
     });
   });
 });

--- a/packages/execution-engine/src/__tests__/remote-fix-process-output.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-fix-process-output.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { spawnRemoteAgentFixImpl } from '../conflict-resolver.js';
 import type { AgentRegistry } from '../agent-registry.js';
 
@@ -42,6 +45,60 @@ function mockSpawnChildWithStderr(stdoutData: string, stderrData: string, exitCo
 describe('spawnRemoteAgentFixImpl processOutput', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it('does not export API keys into the remote fix shell by default', async () => {
+    const { spawn } = await import('node:child_process');
+    const previous = process.env.ANTHROPIC_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'ambient-key-that-should-not-forward';
+    const child = mockSpawnChild('ok', 0) as any;
+    vi.mocked(spawn).mockReturnValueOnce(child);
+
+    try {
+      await spawnRemoteAgentFixImpl(
+        'fix the bug',
+        '/home/user/worktree',
+        { host: '1.2.3.4', user: 'invoker', sshKeyPath: '/tmp/key' },
+        'claude',
+      );
+
+      const script = child.stdin.write.mock.calls[0][0] as string;
+      expect(script).not.toContain('ANTHROPIC_API_KEY');
+      expect(script).not.toContain('ambient-key-that-should-not-forward');
+    } finally {
+      if (previous === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = previous;
+    }
+  });
+
+  it('exports agent API keys from secrets only when use_api_key is true', async () => {
+    const { spawn } = await import('node:child_process');
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-remote-agent-env-'));
+    const secretsFile = join(dir, 'secrets.env');
+    writeFileSync(secretsFile, "ANTHROPIC_API_KEY=test-key-with-'quote\nIGNORED_TOKEN=nope\n", { mode: 0o600 });
+    const child = mockSpawnChild('ok', 0) as any;
+    vi.mocked(spawn).mockReturnValueOnce(child);
+
+    try {
+      await spawnRemoteAgentFixImpl(
+        'fix the bug',
+        '/home/user/worktree',
+        {
+          host: '1.2.3.4',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          use_api_key: true,
+          secretsFile,
+        },
+        'claude',
+      );
+
+      const script = child.stdin.write.mock.calls[0][0] as string;
+      expect(script).toContain("export ANTHROPIC_API_KEY='test-key-with-'\\''quote'");
+      expect(script).not.toContain('IGNORED_TOKEN');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('calls driver.processOutput with effectiveSessionId and stdout on success', async () => {

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -8444,7 +8444,7 @@ console.log(JSON.stringify(out));
 
       // Check that metadata was persisted immediately after start
       expect(updateSpy).toHaveBeenCalledWith('ssh-task-1', {
-        config: { runnerKind: 'ssh' },
+        config: { runnerKind: 'ssh', poolMemberId: 'remote-1' },
         execution: {
           workspacePath: '~/.invoker/worktrees/abc123/experiment-ssh-task-1-def456',
           branch: 'experiment/ssh-task-1-def456',

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -21,6 +21,7 @@ import type { AgentRegistry } from './agent-registry.js';
 import { buildWorktreeListScript, createSshRemoteScriptError } from './ssh-git-exec.js';
 import { buildSshConnectionArgs } from './ssh-transport-options.js';
 import { findManagedWorktreeForBranch } from './worktree-discovery.js';
+import { buildRemoteAgentEnvExports } from './remote-agent-env.js';
 
 // ── Host interface ───────────────────────────────────────
 
@@ -31,6 +32,8 @@ export interface RemoteTargetConfig {
   port?: number;
   managedWorkspaces?: boolean;
   remoteInvokerHome?: string;
+  use_api_key?: boolean;
+  secretsFile?: string;
 }
 
 /**
@@ -206,7 +209,7 @@ export async function resolveConflictImpl(
   }
 
   // SSH tasks: run conflict resolution on the remote host
-  const poolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
+  const poolMemberId = resolveSelectedRemoteTargetId(host, taskId, task);
   if (task.config.runnerKind === 'ssh' && poolMemberId && !existsSync(rawCwd)) {
     host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'resolve-conflict-remote-path',
@@ -330,6 +333,27 @@ function buildRemoteAgentCommand(
   };
 }
 
+function resolveSelectedRemoteTargetId(host: ConflictResolverHost, taskId: string, task: ReturnType<Orchestrator['getTask']> & {}): string | undefined {
+  const direct = (task.config as { poolMemberId?: string }).poolMemberId;
+  if (direct) return direct;
+
+  const events = host.persistence.getEvents?.(taskId) ?? [];
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i];
+    if (event?.eventType !== 'task.executor.selected' || !event.payload) continue;
+    try {
+      const payload = JSON.parse(event.payload) as { poolMemberId?: unknown };
+      if (typeof payload.poolMemberId === 'string' && payload.poolMemberId.trim()) {
+        return payload.poolMemberId;
+      }
+    } catch {
+      // Ignore malformed historical diagnostics.
+    }
+  }
+
+  return undefined;
+}
+
 async function resolveConflictRemote(
   host: ConflictResolverHost,
   task: ReturnType<Orchestrator['getTask']> & {},
@@ -360,11 +384,13 @@ async function resolveConflictRemote(
   const { shellCommand: agentCmd } = buildRemoteAgentCommand(prompt, host.agentRegistry, agentName);
   const agentCmdB64 = Buffer.from(agentCmd).toString('base64');
   const mergeMsgB64 = Buffer.from(conflictMergeMsg).toString('base64');
+  const envExports = buildRemoteAgentEnvExports(target.secretsFile, target.use_api_key === true);
 
   const script = `set -euo pipefail
 WT="${remoteCwd}"
 if [[ "$WT" == '~' ]]; then WT="$HOME"; elif [[ "\${WT:0:2}" == '~/' ]]; then WT="$HOME/\${WT:2}"; fi
 cd "$WT"
+${envExports}
 git checkout "${taskBranch}"
 MERGE_MSG=$(echo "${mergeMsgB64}" | base64 -d)
 if git merge --no-edit -m "$MERGE_MSG" "${conflictInfo.failedBranch}" 2>/dev/null; then
@@ -459,7 +485,7 @@ export async function fixWithAgentImpl(
   const workspacePath = task.execution.workspacePath;
 
   // SSH tasks: run agent on the remote host
-  const poolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
+  const poolMemberId = resolveSelectedRemoteTargetId(host, taskId, task);
   if (task.config.runnerKind === 'ssh' && poolMemberId && workspacePath && !existsSync(workspacePath)) {
     host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'fix-with-agent-remote-path',
@@ -612,11 +638,13 @@ export function spawnRemoteAgentFixImpl(
         `trap 'rm -f "$PROMPT_FILE"' EXIT`,
       ].join('\n') + '\n'
     : '';
+  const envExports = buildRemoteAgentEnvExports(target.secretsFile, target.use_api_key === true);
 
 const script = `set -euo pipefail
 WT="${remoteCwd}"
 if [[ "$WT" == '~' ]]; then WT="$HOME"; elif [[ "\${WT:0:2}" == '~/' ]]; then WT="$HOME/\${WT:2}"; fi
 cd "$WT"
+${envExports}
 ${promptWrite}
 eval "$(echo "${agentCmdB64}" | base64 -d)"
 `;

--- a/packages/execution-engine/src/remote-agent-env.ts
+++ b/packages/execution-engine/src/remote-agent-env.ts
@@ -1,0 +1,35 @@
+import { loadSecretsFile } from './secrets-loader.js';
+
+const AGENT_ENV_KEYS = new Set([
+  'ANTHROPIC_API_KEY',
+  'CLAUDE_API_KEY',
+  'OPENAI_API_KEY',
+  'CODEX_API_KEY',
+]);
+
+function shellQuote(value: string): string {
+  return "'" + value.replace(/'/g, "'\\''") + "'";
+}
+
+export function loadRemoteAgentEnv(secretsFile: string | undefined, useApiKey: boolean): Record<string, string> {
+  if (!useApiKey) return {};
+
+  const env: Record<string, string> = {};
+  for (const entry of loadSecretsFile(secretsFile)) {
+    const eq = entry.indexOf('=');
+    if (eq <= 0) continue;
+    const key = entry.slice(0, eq);
+    if (!AGENT_ENV_KEYS.has(key)) continue;
+    env[key] = entry.slice(eq + 1);
+  }
+
+  return env;
+}
+
+export function buildRemoteAgentEnvExports(secretsFile: string | undefined, useApiKey: boolean): string {
+  const entries = Object.entries(loadRemoteAgentEnv(secretsFile, useApiKey));
+  if (entries.length === 0) return '';
+  return entries
+    .map(([key, value]) => `export ${key}=${shellQuote(value)}`)
+    .join('\n') + '\n';
+}

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -14,6 +14,7 @@ import { computeRepoUrlHash, sanitizeBranchForPath } from './git-utils.js';
 import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { buildSshConnectionArgs } from './ssh-transport-options.js';
 import { createExecutionBench } from './execution-bench.js';
+import { buildRemoteAgentEnvExports } from './remote-agent-env.js';
 import {
   shellPosixSingleQuote as sshGitShellQuote,
   base64Encode as sshGitB64,
@@ -54,6 +55,10 @@ export interface SshExecutorConfig {
    * Only used in managed mode. Default: pnpm install --frozen-lockfile
    */
   provisionCommand?: string;
+  /** Opt-in: export agent API keys from secretsFile into remote task shells. */
+  useApiKey?: boolean;
+  /** Optional local secrets file used when useApiKey is true. */
+  secretsFile?: string;
   /**
    * Remote workload heartbeat interval (seconds) emitted by the SSH payload wrapper.
    * Default: 30.
@@ -87,6 +92,8 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
   private readonly managedWorkspaces: boolean;
   private readonly remoteInvokerHome: string;
   private readonly provisionCommand: string;
+  private readonly useApiKey: boolean;
+  private readonly secretsFile: string | undefined;
   private readonly remoteHeartbeatIntervalSeconds: number;
   private readonly remotePath: string;
 
@@ -100,6 +107,8 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     this.managedWorkspaces = config.managedWorkspaces ?? false;
     this.remoteInvokerHome = config.remoteInvokerHome ?? '~/.invoker';
     this.provisionCommand = config.provisionCommand ?? DEFAULT_WORKTREE_PROVISION_COMMAND;
+    this.useApiKey = config.useApiKey === true;
+    this.secretsFile = config.secretsFile;
     const configuredRemoteHeartbeatInterval = config.remoteHeartbeatIntervalSeconds;
     this.remoteHeartbeatIntervalSeconds =
       typeof configuredRemoteHeartbeatInterval === 'number'
@@ -386,6 +395,7 @@ exit "$PAYLOAD_EXIT"
     // Run payload in user-provided directory
     const payloadB64 = sshGitB64(payload);
     const wtB64 = sshGitB64(workspacePath);
+    const envExports = buildRemoteAgentEnvExports(this.secretsFile, this.useApiKey);
     const runScript = `set -euo pipefail
 WT=$(echo ${wtB64} | base64 -d)
 if [[ "$WT" == '~' ]]; then
@@ -394,6 +404,7 @@ elif [[ "\${WT:0:2}" == '~/' ]]; then
   WT="$HOME/\${WT:2}"
 fi
 cd "$WT"
+${envExports}
 echo "[SshExecutor BYO] Running task in user-provided workspace: $WT"
 ${this.buildPayloadExecutionScript(payloadB64)}
 `;
@@ -624,6 +635,7 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     const provB64 = sshGitB64(this.provisionCommand);
     const payloadB64 = sshGitB64(payload);
     const wtB64 = sshGitB64(remoteWt);
+    const envExports = buildRemoteAgentEnvExports(this.secretsFile, this.useApiKey);
     const runScript = `set -euo pipefail
 WT=$(echo ${wtB64} | base64 -d)
 if [[ "$WT" == '~' ]]; then
@@ -632,6 +644,7 @@ elif [[ "\${WT:0:2}" == '~/' ]]; then
   WT="$HOME/\${WT:2}"
 fi
 cd "$WT"
+${envExports}
 echo "[SshExecutor] Provisioning remote worktree with: ${this.provisionCommand.slice(0, 50)}..."
 eval "$(echo ${provB64} | base64 -d)"
 echo "[SshExecutor] Running task payload..."

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -104,6 +104,8 @@ type RemoteTargetDisplay = {
   managedWorkspaces?: boolean;
   remoteInvokerHome?: string;
   provisionCommand?: string;
+  use_api_key?: boolean;
+  secretsFile?: string;
   remoteHeartbeatIntervalSeconds?: number;
 };
 
@@ -154,6 +156,8 @@ export interface TaskRunnerConfig {
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
     provisionCommand?: string;
+    use_api_key?: boolean;
+    secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;
   }>;
   executionPoolsProvider?: () => Record<string, {
@@ -775,8 +779,15 @@ export class TaskRunner {
         this.pendingPoolSelections.get(task.id),
       );
 
+      const poolSelection = this.pendingPoolSelections.get(task.id);
+      const selectedSshTargetId = executor.type === 'ssh'
+        ? this.selectedRemoteTargetId(task, poolSelection)
+        : undefined;
       const changes = {
-        config: { runnerKind: executor.type as RunnerKind },
+        config: {
+          runnerKind: executor.type as RunnerKind,
+          ...(selectedSshTargetId ? { poolMemberId: selectedSshTargetId } : {}),
+        },
         execution: {
           workspacePath: handle.workspacePath,
           branch: handle.branch ?? undefined,  // Explicit undefined when branch is not applicable (e.g., BYO mode)
@@ -1139,6 +1150,8 @@ export class TaskRunner {
           managedWorkspaces: target.managedWorkspaces,
           remoteInvokerHome: target.remoteInvokerHome,
           provisionCommand: target.provisionCommand,
+          use_api_key: target.use_api_key === true,
+          secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
           remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
         });
         const cacheKey = `${targetId}|${configFingerprint}`;
@@ -1166,6 +1179,8 @@ export class TaskRunner {
           managedWorkspaces: target.managedWorkspaces,
           remoteInvokerHome: target.remoteInvokerHome,
           provisionCommand: target.provisionCommand,
+          useApiKey: target.use_api_key === true,
+          secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
           remoteHeartbeatIntervalSeconds: target.remoteHeartbeatIntervalSeconds,
         });
 
@@ -2097,9 +2112,16 @@ export class TaskRunner {
     managedWorkspaces?: boolean;
     remoteInvokerHome?: string;
     provisionCommand?: string;
+    use_api_key?: boolean;
+    secretsFile?: string;
     remoteHeartbeatIntervalSeconds?: number;
   } | undefined {
-    return this.getRemoteTargets()[targetId];
+    const target = this.getRemoteTargets()[targetId];
+    if (!target) return undefined;
+    return {
+      ...target,
+      secretsFile: target.secretsFile ?? this.dockerConfig.secretsFile,
+    };
   }
 
   /**


### PR DESCRIPTION
## Summary

- Persist the selected SSH pool member on task start so later fix/conflict recovery can identify the remote host that owns the workspace.
- Recover the selected SSH target for already-started historical tasks from the `task.executor.selected` audit event when `poolMemberId` was not persisted.
- Add opt-in remote target config `use_api_key: true` for teams that want SSH task/fix shells to export agent API keys from the local secrets file. The default is false, so remote Claude/Codex CLI account auth is preserved unless explicitly enabled.

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/conflict-resolver.test.ts src/__tests__/remote-fix-process-output.test.ts src/__tests__/task-runner.test.ts -t "pool-routed SSH|metadata persistence hardening|API keys"` *(Vitest ran the execution-engine suite: 46 files, 955 tests)*
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a5094ed6`
- Post-revert steps: pool-routed historical SSH fixes may report no valid workspace, and remote API-key forwarding will no longer be available as an opt-in.
- Data migration? No
