### PR TITLE
Split rebase into retry and recreate operations

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -782,8 +782,8 @@ describe('POST /api/workflows/:id/restart', () => {
   });
 });
 
-describe('POST /api/workflows/:id/rebase-and-retry', () => {
-  it('normalizes merge-node targets to the owning workflow before fresh-base recreate', async () => {
+describe('POST /api/workflows/:id/rebase-retry', () => {
+  it('normalizes merge-node targets to the owning workflow before fresh-base retry', async () => {
     mocks.persistence.loadWorkflow = vi.fn((workflowId: string) => (
       workflowId === 'wf-1' ? { id: 'wf-1', generation: 1 } : undefined
     ));
@@ -792,19 +792,16 @@ describe('POST /api/workflows/:id/rebase-and-retry', () => {
         ? [makeTask({ id: '__merge__wf-1', config: { workflowId: 'wf-1', isMergeNode: true } })]
         : []
     ));
-    mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn(async () => [makeTask()]);
+    mocks.orchestrator.retryWorkflow = vi.fn(() => [makeTask()]);
 
-    const res = await request(port, 'POST', '/api/workflows/__merge__wf-1/rebase-and-retry');
+    const res = await request(port, 'POST', '/api/workflows/__merge__wf-1/rebase-retry');
 
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.workflowId).toBe('wf-1');
-    expect(res.body.action).toBe('rebase_and_retried');
-    expect(mocks.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', expect.any(Object));
-    expect(mocks.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
-      'wf-1',
-      expect.objectContaining({ refreshBase: expect.any(Function) }),
-    );
+    expect(res.body.action).toBe('rebase_retried');
+    expect(mocks.persistence.updateWorkflow).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
   });
 });
 
@@ -830,22 +827,19 @@ describe('POST /api/workflows/:id/fork', () => {
   });
 });
 
-describe('POST /api/workflows/:id/recreate-with-rebase', () => {
+describe('POST /api/workflows/:id/rebase-recreate', () => {
   it('recreates workflow from fresh base', async () => {
-    mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn().mockResolvedValue([makeTask()]);
-    const res = await request(port, 'POST', '/api/workflows/wf-1/recreate-with-rebase');
+    mocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask()]);
+    const res = await request(port, 'POST', '/api/workflows/wf-1/rebase-recreate');
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
-    expect(res.body.action).toBe('recreated_with_rebase');
+    expect(res.body.action).toBe('rebase_recreated');
     expect(res.body.tasksStarted).toBe(1);
     expect(res.body.deprecated).toBeUndefined();
-    expect(mocks.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
-      'wf-1',
-      expect.objectContaining({ refreshBase: expect.any(Function) }),
-    );
+    expect(mocks.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
   });
 
-  it('keeps cross-workflow started tasks out of the scoped recreate-with-rebase runnable result', async () => {
+  it('keeps cross-workflow started tasks out of the scoped rebase-recreate runnable result', async () => {
     const scoped = makeTask({
       id: 'wf-1/task-a',
       config: { workflowId: 'wf-1' },
@@ -856,10 +850,10 @@ describe('POST /api/workflows/:id/recreate-with-rebase', () => {
       config: { workflowId: 'wf-2' },
       execution: { selectedAttemptId: 'attempt-b' },
     });
-    mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn().mockResolvedValue([scoped, crossWorkflow]);
+    mocks.orchestrator.recreateWorkflow = vi.fn(() => [scoped, crossWorkflow]);
     mocks.orchestrator.startExecution.mockReturnValue([]);
 
-    const res = await request(port, 'POST', '/api/workflows/wf-1/recreate-with-rebase');
+    const res = await request(port, 'POST', '/api/workflows/wf-1/rebase-recreate');
 
     expect(res.status).toBe(200);
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
@@ -867,21 +861,16 @@ describe('POST /api/workflows/:id/recreate-with-rebase', () => {
     expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
   });
 
-  it('rebase-and-retry still works as deprecated alias', async () => {
-    mocks.orchestrator.recreateWorkflowFromFreshBase = vi.fn().mockResolvedValue([makeTask()]);
+  it('old rebase-and-retry route is gone', async () => {
     const res = await request(port, 'POST', '/api/workflows/wf-1/rebase-and-retry');
-    expect(res.status).toBe(200);
-    expect(res.body.ok).toBe(true);
-    expect(res.body.action).toBe('rebase_and_retried');
-    expect(res.body.deprecated).toBe(true);
-    expect(res.body.replacement).toBe('/api/workflows/:id/recreate-with-rebase');
+    expect(res.status).toBe(404);
   });
 
   it('returns 404 when workflow not found', async () => {
     mocks.persistence.loadWorkflow.mockReturnValue(undefined);
-    const res = await request(port, 'POST', '/api/workflows/wf-missing/recreate-with-rebase');
+    const res = await request(port, 'POST', '/api/workflows/wf-missing/rebase-recreate');
     expect(res.status).toBe(404);
-    expect(res.body.error).toContain('not found');
+    expect(res.body.error).toContain('Could not resolve workflow');
   });
 });
 

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -132,7 +132,7 @@ describe('headless-client', () => {
       .mockResolvedValueOnce(firstBus)
       .mockResolvedValueOnce(secondBus);
 
-    const exitCode = await runHeadlessClientCommand(['rebase', 'wf-2/root', '--no-track'], {
+    const exitCode = await runHeadlessClientCommand(['rebase-retry', 'wf-2/root', '--no-track'], {
       messageBus: firstBus,
       ensureStandaloneOwner,
       refreshMessageBus,
@@ -187,7 +187,7 @@ describe('headless-client', () => {
       });
     });
 
-    const exitCode = await runHeadlessClientCommand(['rebase', 'wf-9/root', '--no-track'], {
+    const exitCode = await runHeadlessClientCommand(['rebase-retry', 'wf-9/root', '--no-track'], {
       messageBus: bus,
       ensureStandaloneOwner,
       runElectronHeadless: vi.fn(async () => 0),

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -986,14 +986,14 @@ describe('headless delegation enforcement', () => {
           preemptWorkflowExecution,
         } as HeadlessDeps;
 
-        await expect(runHeadless(['rebase', 'task-1'], depsWithNoTrack)).rejects.toThrow();
+        await expect(runHeadless(['rebase-retry', 'task-1'], depsWithNoTrack)).rejects.toThrow();
         expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
       });
 
       // ── Step 12: routing assertions ────────────────────────────────────
       //
       // These pin the chart's three-way distinction at the headless layer:
-      // each verb routes to its own orchestrator method, and `rebase` reaches
+      // each verb routes to its own orchestrator method, and `rebase-retry` reaches
       // the new first-class `recreateWorkflowFromFreshBase` (which closes
       // Step 11's "not yet wired" hole on `applyInvalidation`).
       describe('workflow-scope routing', () => {
@@ -1038,15 +1038,9 @@ describe('headless delegation enforcement', () => {
             }
             return undefined;
           });
-          mockDeps.orchestrator.recreateWorkflowFromFreshBase = vi.fn(
-            async (_workflowId: string, options?: any) => {
-              // Drive the refresh callback the way the orchestrator does in
-              // production so we exercise the real `preparePoolForRebaseRetry`
-              // wiring inside `workflow-actions.recreateWorkflowFromFreshBase`.
-              await options?.refreshBase?.(_workflowId);
-              return [];
-            },
-          ) as any;
+          mockDeps.orchestrator.retryWorkflow = vi.fn(() => []);
+          mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
+          mockDeps.orchestrator.recreateWorkflowFromFreshBase = vi.fn(async () => []);
 
           // Spy on `preparePoolForRebaseRetry` to assert the app-layer
           // `recreateWorkflowFromFreshBase` actually invokes pool prep
@@ -1058,7 +1052,7 @@ describe('headless delegation enforcement', () => {
           return { preemptWorkflowExecution, preparePoolSpy };
         }
 
-        it('headless `rebase <taskId>` routes to orchestrator.recreateWorkflowFromFreshBase', async () => {
+        it('headless `rebase-retry <taskId>` routes to orchestrator.retryWorkflow after fresh-base prep', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
 
           const depsWithNoTrack: HeadlessDeps = {
@@ -1067,24 +1061,22 @@ describe('headless delegation enforcement', () => {
             preemptWorkflowExecution,
           } as HeadlessDeps;
 
-          await runHeadless(['rebase', 'task-1'], depsWithNoTrack);
+          await runHeadless(['rebase-retry', 'task-1'], depsWithNoTrack);
 
           expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
-          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledTimes(1);
-          expect(
-            (mockDeps.orchestrator.recreateWorkflowFromFreshBase as any).mock.calls[0][0],
-          ).toBe('wf-1');
+          expect(mockDeps.orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           // Cancel-first invariant: preempt before the recreate-from-fresh-base method.
           const preemptOrder = (preemptWorkflowExecution.mock.invocationCallOrder ?? [])[0];
-          const recreateOrder = (
-            (mockDeps.orchestrator.recreateWorkflowFromFreshBase as any).mock.invocationCallOrder ?? []
+          const retryOrder = (
+            (mockDeps.orchestrator.retryWorkflow as any).mock.invocationCallOrder ?? []
           )[0];
-          expect(preemptOrder).toBeLessThan(recreateOrder);
+          expect(preemptOrder).toBeLessThan(retryOrder);
 
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `rebase` exercises the fresh-base-distinct pool prep step (preparePoolForRebaseRetry)', async () => {
+        it('headless `rebase-retry` exercises the fresh-base-distinct pool prep step (preparePoolForRebaseRetry)', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
 
           const depsWithNoTrack: HeadlessDeps = {
@@ -1093,7 +1085,7 @@ describe('headless delegation enforcement', () => {
             preemptWorkflowExecution,
           } as HeadlessDeps;
 
-          await runHeadless(['rebase', 'task-1'], depsWithNoTrack);
+          await runHeadless(['rebase-retry', 'task-1'], depsWithNoTrack);
 
           // The whole reason `recreateWorkflowFromFreshBase` is distinct
           // from `recreateWorkflow`: it refreshes the upstream pool/base.
@@ -1106,7 +1098,7 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
-        it('deprecated alias `rebase-and-retry` routes to the same orchestrator.recreateWorkflowFromFreshBase method', async () => {
+        it('deprecated alias `rebase-and-retry` is removed', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
 
           const depsWithNoTrack: HeadlessDeps = {
@@ -1115,17 +1107,16 @@ describe('headless delegation enforcement', () => {
             preemptWorkflowExecution,
           } as HeadlessDeps;
 
-          await runHeadless(['rebase-and-retry', 'task-1'], depsWithNoTrack);
+          await expect(runHeadless(['rebase-and-retry', 'task-1'], depsWithNoTrack))
+            .rejects.toThrow('Unknown command: rebase-and-retry');
 
-          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
-            'wf-1',
-            expect.objectContaining({ refreshBase: expect.any(Function) }),
-          );
+          expect(mockDeps.orchestrator.retryWorkflow).not.toHaveBeenCalled();
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
 
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `recreate-with-rebase <wfId>` routes to orchestrator.recreateWorkflowFromFreshBase with workflowId directly', async () => {
+        it('headless `rebase-recreate <wfId>` routes to orchestrator.recreateWorkflow with workflowId directly', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
 
           const depsWithNoTrack: HeadlessDeps = {
@@ -1134,13 +1125,11 @@ describe('headless delegation enforcement', () => {
             preemptWorkflowExecution,
           } as HeadlessDeps;
 
-          await runHeadless(['recreate-with-rebase', 'wf-1'], depsWithNoTrack);
+          await runHeadless(['rebase-recreate', 'wf-1'], depsWithNoTrack);
 
           expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
-          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledTimes(1);
-          expect(
-            (mockDeps.orchestrator.recreateWorkflowFromFreshBase as any).mock.calls[0][0],
-          ).toBe('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           expect(preparePoolSpy).toHaveBeenCalledWith(
             'wf-1',
             'https://example/repo.git',
@@ -1150,7 +1139,7 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `recreate-with-rebase <mergeTaskId>` normalizes to the owning workflow', async () => {
+        it('headless `rebase-recreate <mergeTaskId>` normalizes to the owning workflow', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
 
           const depsWithNoTrack: HeadlessDeps = {
@@ -1159,18 +1148,15 @@ describe('headless delegation enforcement', () => {
             preemptWorkflowExecution,
           } as HeadlessDeps;
 
-          await runHeadless(['recreate-with-rebase', '__merge__wf-1'], depsWithNoTrack);
+          await runHeadless(['rebase-recreate', '__merge__wf-1'], depsWithNoTrack);
 
           expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
-          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
-            'wf-1',
-            expect.objectContaining({ refreshBase: expect.any(Function) }),
-          );
+          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
 
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `recreate-with-rebase <taskId>` normalizes to the owning workflow', async () => {
+        it('headless `rebase-recreate <taskId>` normalizes to the owning workflow', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
 
           const depsWithNoTrack: HeadlessDeps = {
@@ -1179,13 +1165,10 @@ describe('headless delegation enforcement', () => {
             preemptWorkflowExecution,
           } as HeadlessDeps;
 
-          await runHeadless(['recreate-with-rebase', 'task-1'], depsWithNoTrack);
+          await runHeadless(['rebase-recreate', 'task-1'], depsWithNoTrack);
 
           expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
-          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
-            'wf-1',
-            expect.objectContaining({ refreshBase: expect.any(Function) }),
-          );
+          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
 
           preparePoolSpy.mockRestore();
         });
@@ -1291,6 +1274,7 @@ describe('headless delegation enforcement', () => {
           mockDeps.orchestrator.startExecution = vi.fn(() => []);
           mockDeps.orchestrator.getPersistedActiveTaskIds = vi.fn(() => new Set<string>());
           mockDeps.orchestrator.recreateTask = vi.fn(() => []);
+          mockDeps.orchestrator.retryWorkflow = vi.fn(() => []);
           mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
           mockDeps.orchestrator.recreateWorkflowFromFreshBase = vi.fn(
             async (_id: string, options?: any) => {
@@ -1389,7 +1373,7 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `rebase <taskId>` routes to orchestrator.recreateWorkflowFromFreshBase (only) — NOT plain recreateWorkflow', async () => {
+        it('headless `rebase-retry <taskId>` routes to orchestrator.retryWorkflow after fresh-base prep', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedHappyPath();
           const depsWithNoTrack: HeadlessDeps = {
             ...mockDeps,
@@ -1397,14 +1381,9 @@ describe('headless delegation enforcement', () => {
             preemptWorkflowExecution,
           } as HeadlessDeps;
 
-          await runHeadless(['rebase', 'task-1'], depsWithNoTrack);
+          await runHeadless(['rebase-retry', 'task-1'], depsWithNoTrack);
 
-          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
-            'wf-1',
-            expect.objectContaining({ refreshBase: expect.any(Function) }),
-          );
-          // The whole reason rebase is a separate cell from
-          // recreate-workflow: it refreshes the upstream pool/base.
+          expect(mockDeps.orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
           expect(preparePoolSpy).toHaveBeenCalledWith(
             'wf-1',
             'https://example/repo.git',
@@ -1414,11 +1393,12 @@ describe('headless delegation enforcement', () => {
           expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
           expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `recreate-with-rebase <wfId>` routes to orchestrator.recreateWorkflowFromFreshBase (only) — takes workflowId directly', async () => {
+        it('headless `rebase-recreate <wfId>` routes to orchestrator.recreateWorkflow after fresh-base prep', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedHappyPath();
           const depsWithNoTrack: HeadlessDeps = {
             ...mockDeps,
@@ -1426,21 +1406,18 @@ describe('headless delegation enforcement', () => {
             preemptWorkflowExecution,
           } as HeadlessDeps;
 
-          await runHeadless(['recreate-with-rebase', 'wf-1'], depsWithNoTrack);
+          await runHeadless(['rebase-recreate', 'wf-1'], depsWithNoTrack);
 
-          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
-            'wf-1',
-            expect.objectContaining({ refreshBase: expect.any(Function) }),
-          );
+          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
           expect(preparePoolSpy).toHaveBeenCalledWith(
             'wf-1',
             'https://example/repo.git',
             'main',
           );
-          expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
           expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
+          expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
           preparePoolSpy.mockRestore();
         });

--- a/packages/app/src/__tests__/owner-delegation.test.ts
+++ b/packages/app/src/__tests__/owner-delegation.test.ts
@@ -62,24 +62,20 @@ describe('headless→owner delegation', () => {
   }
 
   describe('delegation timeout policy', () => {
-    it('uses 60s timeout for workflow-scoped rebase', () => {
-      expect(delegationTimeoutMs(['rebase', 'wf-1'], targetLookup)).toBe(60_000);
+    it('uses 60s timeout for workflow-scoped rebase-retry', () => {
+      expect(delegationTimeoutMs(['rebase-retry', 'wf-1'], targetLookup)).toBe(60_000);
     });
 
-    it('uses 60s timeout for workflow-scoped rebase-and-retry', () => {
-      expect(delegationTimeoutMs(['rebase-and-retry', 'wf-1'], targetLookup)).toBe(60_000);
-    });
-
-    it('uses 60s timeout for workflow-scoped recreate-with-rebase', () => {
-      expect(delegationTimeoutMs(['recreate-with-rebase', 'wf-1'], targetLookup)).toBe(60_000);
+    it('uses 60s timeout for workflow-scoped rebase-recreate', () => {
+      expect(delegationTimeoutMs(['rebase-recreate', 'wf-1'], targetLookup)).toBe(60_000);
     });
 
     it('uses 60s timeout for workflow-scoped restart', () => {
       expect(delegationTimeoutMs(['restart', 'wf-123'], targetLookup)).toBe(60_000);
     });
 
-    it('keeps task-scoped rebase at the default timeout', () => {
-      expect(delegationTimeoutMs(['rebase', 'wf-123/task-1'], targetLookup)).toBe(5_000);
+    it('keeps task-scoped rebase-retry at the default timeout', () => {
+      expect(delegationTimeoutMs(['rebase-retry', 'wf-123/task-1'], targetLookup)).toBe(5_000);
     });
 
     it('keeps non-matching workflow ids at the default timeout', () => {
@@ -209,12 +205,12 @@ describe('headless→owner delegation', () => {
       }));
     });
 
-    it('delegates rebase with noTrack so owner can return before workflow settlement', async () => {
+    it('delegates rebase-retry with noTrack so owner can return before workflow settlement', async () => {
       const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(
-        ['rebase', 'wf-1/task-1'],
+        ['rebase-retry', 'wf-1/task-1'],
         messageBus,
         undefined,
         true,
@@ -222,18 +218,18 @@ describe('headless→owner delegation', () => {
 
       expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
-        args: ['rebase', 'wf-1/task-1'],
+        args: ['rebase-retry', 'wf-1/task-1'],
         noTrack: true,
         waitForApproval: undefined,
       }));
     });
 
-    it('delegates recreate-with-rebase command to owner', async () => {
+    it('delegates rebase-recreate command to owner', async () => {
       const ownerHandler = vi.fn(async () => ({ ok: true }));
       messageBus.onRequest('headless.exec', ownerHandler);
 
       const outcome = await tryDelegateExec(
-        ['recreate-with-rebase', 'wf-1'],
+        ['rebase-recreate', 'wf-1'],
         messageBus,
         undefined,
         true,
@@ -241,7 +237,7 @@ describe('headless→owner delegation', () => {
 
       expect(outcome.kind).toBe('delegated');
       expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
-        args: ['recreate-with-rebase', 'wf-1'],
+        args: ['rebase-recreate', 'wf-1'],
         noTrack: true,
         waitForApproval: undefined,
       }));
@@ -280,9 +276,8 @@ describe('headless→owner delegation', () => {
     });
 
     it.each([
-      ['rebase', ['rebase', 'wf-1']],
-      ['rebase-and-retry', ['rebase-and-retry', 'wf-1']],
-      ['recreate-with-rebase', ['recreate-with-rebase', 'wf-1']],
+      ['rebase-retry', ['rebase-retry', 'wf-1']],
+      ['rebase-recreate', ['rebase-recreate', 'wf-1']],
       ['restart workflow', ['restart', 'wf-123']],
     ])('keeps %s pending at 5s and only times out at 60s', async (_label, args) => {
       const delegatedPromise = tryDelegateExec(

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -380,7 +380,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
-  it('evicts older queued workflow intents when recreate-with-rebase fence starts', async () => {
+  it('evicts older queued workflow intents when rebase-recreate fence starts', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({
@@ -408,22 +408,22 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     void running.catch(() => {});
     const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['old-queued']);
     void olderQueued.catch(() => {});
-    const recreateWithRebase = coordinator.enqueue<void>('wf-1', 'high', 'invoker:recreate-with-rebase', ['wf-1']);
+    const rebaseRecreate = coordinator.enqueue<void>('wf-1', 'high', 'invoker:rebase-recreate', ['wf-1']);
     const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['new-queued']);
 
-    await recreateWithRebase;
+    await rebaseRecreate;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by recreate intent/i);
     await expect(olderQueued).rejects.toThrow(/evicted/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
-      'invoker:recreate-with-rebase:wf-1',
+      'invoker:rebase-recreate:wf-1',
       'invoker:edit-task-agent:new-queued',
     ]);
   });
 
-  it('invalidates an older running workflow intent when recreate-with-rebase is enqueued', async () => {
+  it('invalidates an older running workflow intent when rebase-recreate is enqueued', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({
@@ -456,13 +456,13 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     void olderRunning.catch(() => {});
     await waitFor(() => adapter.listWorkflowMutationIntents('wf-1', ['running']).length === 1);
 
-    const recreateWithRebase = coordinator.enqueue<void>(
+    const rebaseRecreate = coordinator.enqueue<void>(
       'wf-1',
       'high',
-      'invoker:recreate-with-rebase',
+      'invoker:rebase-recreate',
       ['wf-1'],
     );
-    await recreateWithRebase;
+    await rebaseRecreate;
     await expect(olderRunning).rejects.toThrow(/superseded by recreate intent/i);
 
     const intentsAfterRecreate = adapter.listWorkflowMutationIntents('wf-1');
@@ -471,11 +471,11 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     expect(intentsAfterRecreate.find((intent) => intent.id === 2)?.status).toBe('completed');
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
-      'invoker:recreate-with-rebase:wf-1',
+      'invoker:rebase-recreate:wf-1',
     ]);
   });
 
-  it('treats headless recreate-with-rebase as a recreate fence', async () => {
+  it('treats headless rebase-recreate as a recreate fence', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({
@@ -504,22 +504,22 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     void running.catch(() => {});
     const olderQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['old-queued']);
     void olderQueued.catch(() => {});
-    const recreateWithRebase = coordinator.enqueue<void>(
+    const rebaseRecreate = coordinator.enqueue<void>(
       'wf-1',
       'high',
       'headless.exec',
-      [{ args: ['recreate-with-rebase', 'wf-1'], noTrack: true }],
+      [{ args: ['rebase-recreate', 'wf-1'], noTrack: true }],
     );
     const newerQueued = coordinator.enqueue<void>('wf-1', 'normal', 'invoker:edit-task-agent', ['new-queued']);
 
-    await recreateWithRebase;
+    await rebaseRecreate;
     await newerQueued;
     await expect(running).rejects.toThrow(/superseded by recreate intent/i);
     await expect(olderQueued).rejects.toThrow(/evicted/i);
 
     expect(order).toEqual([
       'invoker:fix-with-agent:wf-1/blocker-task',
-      'headless.exec:recreate-with-rebase wf-1',
+      'headless.exec:rebase-recreate wf-1',
       'invoker:edit-task-agent:new-queued',
     ]);
   });
@@ -1433,7 +1433,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     await expect(olderRunning).rejects.toThrow(/superseded by delete intent/i);
   });
 
-  it('aborts the dispatch AbortSignal when recreate-with-rebase preempts a running fix mutation', async () => {
+  it('aborts the dispatch AbortSignal when rebase-recreate preempts a running fix mutation', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);
     adapter.saveWorkflow({
@@ -1471,7 +1471,7 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     const recreateRebase = coordinator.enqueue<void>(
       'wf-1',
       'high',
-      'invoker:recreate-with-rebase',
+      'invoker:rebase-recreate',
       ['wf-1'],
     );
     await recreateRebase;

--- a/packages/app/src/__tests__/rebase-and-retry.test.ts
+++ b/packages/app/src/__tests__/rebase-and-retry.test.ts
@@ -1,7 +1,7 @@
 /**
  * Rebase-and-retry integration test with real git.
  *
- * Proves that rebaseAndRetry() with taskExecutor refreshes the pool mirror,
+ * Proves that rebaseRecreate() with taskExecutor refreshes the pool mirror,
  * removes managed experiment branches there, then bumps generation so
  * re-execution branches from the updated base (including new commits on master).
  *
@@ -19,7 +19,7 @@ import { execSync } from 'node:child_process';
 import type { WorkResponse } from '@invoker/contracts';
 import type { TaskState } from '@invoker/workflow-core';
 import { TaskRunner, ExecutorRegistry, WorktreeExecutor } from '@invoker/execution-engine';
-import { rebaseAndRetry, bumpGenerationAndRecreate } from '../workflow-actions.js';
+import { rebaseRecreate, bumpGenerationAndRecreate } from '../workflow-actions.js';
 
 function createTempRepo(): string {
   const dir = mkdtempSync(join(tmpdir(), 'rebase-retry-'));
@@ -82,7 +82,7 @@ function makeTaskState(overrides: {
   } as TaskState;
 }
 
-describe('rebase-and-retry: pool mirror cleanup before restart', { timeout: 120_000 }, () => {
+describe('rebase-recreate: pool mirror cleanup before restart', { timeout: 120_000 }, () => {
   let tmpDir: string;
   let prevCleanupEnv: string | undefined;
 
@@ -156,28 +156,21 @@ describe('rebase-and-retry: pool mirror cleanup before restart', { timeout: 120_
         }
         return tasks;
       },
-      // Step 12: rebaseAndRetry now delegates through
-      // recreateWorkflowFromFreshBase. Mirror the real orchestrator: drive
-      // the refreshBase callback (so pool prep runs) before reusing the
-      // recreateWorkflow reset path.
-      recreateWorkflowFromFreshBase: async (
-        workflowId: string,
-        options?: { refreshBase?: (workflowId: string) => Promise<unknown> },
-      ): Promise<TaskState[]> => {
-        await options?.refreshBase?.(workflowId);
-        return orchestrator.recreateWorkflow(workflowId);
-      },
     };
 
     const repoUrl = `file://${tmpDir}`;
 
     const persistence = {
-      loadWorkflow: () => ({
-        id: 'wf-test',
-        baseBranch: 'master',
-        repoUrl,
-        generation,
-      }),
+      loadWorkflow: (id: string) => (id === 'wf-test'
+        ? {
+          id: 'wf-test',
+          baseBranch: 'master',
+          repoUrl,
+          generation,
+        }
+        : undefined),
+      listWorkflows: () => [{ id: 'wf-test' }],
+      loadTasks: () => tasks,
       updateWorkflow: (_id: string, changes: any) => {
         if (changes.generation !== undefined) {
           generation = changes.generation;
@@ -244,14 +237,14 @@ describe('rebase-and-retry: pool mirror cleanup before restart', { timeout: 120_
     // Step 2: Add commit Y to master (source repo)
     const commitY = addCommitToMaster(tmpDir, 'new-feature.txt', 'commit Y: new feature');
 
-    // Step 3: rebaseAndRetry refreshes mirror, removes managed branches, bumps generation
+    // Step 3: rebaseRecreate refreshes mirror, removes managed branches, bumps generation
     const deps = {
       orchestrator: orchestrator as any,
       persistence: persistence as any,
       repoRoot: tmpDir,
       taskExecutor: executor,
     };
-    await rebaseAndRetry('task-a', deps);
+    await rebaseRecreate('task-a', deps);
 
     // Verify stale execution metadata is cleared (regression: scripts/repro/repro-stale-agent-session-after-rebase.sh)
     expect(task.execution.agentSessionId).toBeUndefined();

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -16,8 +16,8 @@ import {
   retryTask,
   retryWorkflow,
   recreateWorkflowFromFreshBase,
-  recreateWithRebase,
-  rebaseAndRetry,
+  rebaseRetry,
+  rebaseRecreate,
   approveTask,
   rejectTask,
   provideInput,
@@ -274,56 +274,52 @@ describe('recreateWorkflowFromFreshBase', () => {
   });
 });
 
-describe('rebaseAndRetry', () => {
-  it('translates taskId → workflowId and delegates to recreateWorkflowFromFreshBase', async () => {
+describe('rebaseRetry', () => {
+  it('translates target → workflowId, prepares fresh base, and delegates to retryWorkflow', async () => {
     const tasks = [makeRunningTask()];
     const orchestrator = {
       getTask: vi.fn(() => makeTask({ config: { workflowId: 'wf-1' } })),
-      recreateWorkflowFromFreshBase: vi.fn(async () => tasks),
+      retryWorkflow: vi.fn(() => tasks),
     };
     const persistence = {
       loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1, repoUrl: 'https://example/repo.git', baseBranch: 'master' })),
+      listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+      loadTasks: vi.fn(() => []),
       updateWorkflow: vi.fn(),
     };
 
-    const result = await rebaseAndRetry('wf-1/task-a', {
+    const result = await rebaseRetry('wf-1/task-a', {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
     });
 
-    expect(orchestrator.getTask).toHaveBeenCalledWith('wf-1/task-a');
-    expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 2 });
-    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
-      'wf-1',
-      expect.objectContaining({ refreshBase: expect.any(Function) }),
-    );
+    expect(orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
+    expect(persistence.updateWorkflow).not.toHaveBeenCalled();
     expect(result).toBe(tasks);
   });
 
-  it('throws when task not found', async () => {
+  it('throws when target cannot resolve to a workflow', async () => {
     const orchestrator = {
       getTask: vi.fn(() => undefined),
-      recreateWorkflowFromFreshBase: vi.fn(),
+      retryWorkflow: vi.fn(),
     };
-    const persistence = { loadWorkflow: vi.fn(), updateWorkflow: vi.fn() };
+    const persistence = { loadWorkflow: vi.fn(), listWorkflows: vi.fn(() => []), loadTasks: vi.fn(() => []), updateWorkflow: vi.fn() };
 
     await expect(
-      rebaseAndRetry('missing-task', {
+      rebaseRetry('missing-task', {
         orchestrator: orchestrator as unknown as Orchestrator,
         persistence: persistence as unknown as SQLiteAdapter,
       }),
-    ).rejects.toThrow('Task missing-task not found or has no workflow');
+    ).rejects.toThrow('Could not resolve workflow for rebase target "missing-task"');
   });
 });
 
-describe('recreateWithRebase', () => {
-  it('delegates directly to recreateWorkflowFromFreshBase with the provided workflowId', async () => {
+describe('rebaseRecreate', () => {
+  it('prepares fresh base, then delegates to recreateWorkflow', async () => {
     const tasks = [makeRunningTask()];
     const orchestrator = {
-      recreateWorkflowFromFreshBase: vi.fn(async (_id: string, opts?: { refreshBase?: () => Promise<unknown> }) => {
-        await opts?.refreshBase?.();
-        return tasks;
-      }),
+      getTask: vi.fn(() => undefined),
+      recreateWorkflow: vi.fn(() => tasks),
     };
     const persistence = {
       loadWorkflow: vi.fn(() => ({
@@ -333,22 +329,21 @@ describe('recreateWithRebase', () => {
         baseBranch: 'main',
       })),
       updateWorkflow: vi.fn(),
+      listWorkflows: vi.fn(() => [{ id: 'wf-1' }]),
+      loadTasks: vi.fn(() => []),
     };
     const taskExecutor = {
       preparePoolForRebaseRetry: vi.fn(async () => undefined),
     } as unknown as TaskRunner;
 
-    const result = await recreateWithRebase('wf-1', {
+    const result = await rebaseRecreate('wf-1', {
       orchestrator: orchestrator as unknown as Orchestrator,
       persistence: persistence as unknown as SQLiteAdapter,
       taskExecutor,
     });
 
     expect(persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', { generation: 3 });
-    expect(orchestrator.recreateWorkflowFromFreshBase).toHaveBeenCalledWith(
-      'wf-1',
-      expect.objectContaining({ refreshBase: expect.any(Function) }),
-    );
+    expect(orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
     expect(taskExecutor.preparePoolForRebaseRetry).toHaveBeenCalledWith(
       'wf-1',
       'https://example/repo.git',
@@ -358,15 +353,15 @@ describe('recreateWithRebase', () => {
   });
 
   it('throws when workflow not found', async () => {
-    const orchestrator = { recreateWorkflowFromFreshBase: vi.fn(async () => []) };
-    const persistence = { loadWorkflow: vi.fn(() => undefined), updateWorkflow: vi.fn() };
+    const orchestrator = { getTask: vi.fn(() => undefined), recreateWorkflow: vi.fn(() => []) };
+    const persistence = { loadWorkflow: vi.fn(() => undefined), listWorkflows: vi.fn(() => []), loadTasks: vi.fn(() => []), updateWorkflow: vi.fn() };
 
     await expect(
-      recreateWithRebase('missing', {
+      rebaseRecreate('missing', {
         orchestrator: orchestrator as unknown as Orchestrator,
         persistence: persistence as unknown as SQLiteAdapter,
       }),
-    ).rejects.toThrow('Workflow missing not found');
+    ).rejects.toThrow('Could not resolve workflow for rebase target "missing"');
   });
 });
 

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -31,7 +31,8 @@
  *   POST   /api/tasks/:id/gate-policy  body: { updates: [{ workflowId, taskId?, gatePolicy }] }
  *   POST   /api/workflows/:id/detach  body: { upstreamWorkflowId }
  *   POST   /api/workflows/:id/restart
- *   POST   /api/workflows/:id/recreate-with-rebase
+ *   POST   /api/workflows/:id/rebase-retry
+ *   POST   /api/workflows/:id/rebase-recreate
  *   POST   /api/workflows/:id/cancel
  *   POST   /api/workflows/:id/merge-mode  body: { mode }
  *   DELETE /api/workflows/:id
@@ -357,28 +358,39 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
-      // POST /api/workflows/:id/recreate-with-rebase  (legacy: /api/workflows/:id/rebase-and-retry)
-      const wfRecreateWithRebaseMatch = path.match(/^\/api\/workflows\/([^/]+)\/recreate-with-rebase$/);
-      const wfRebaseAndRetryMatch = path.match(/^\/api\/workflows\/([^/]+)\/rebase-and-retry$/);
-      if (method === 'POST' && (wfRecreateWithRebaseMatch || wfRebaseAndRetryMatch)) {
-        const isLegacy = !!wfRebaseAndRetryMatch;
-        const workflowTarget = decodeURIComponent((wfRecreateWithRebaseMatch ?? wfRebaseAndRetryMatch)![1]);
+      // POST /api/workflows/:id/rebase-retry
+      const wfRebaseRetryMatch = path.match(/^\/api\/workflows\/([^/]+)\/rebase-retry$/);
+      if (method === 'POST' && wfRebaseRetryMatch) {
+        const workflowTarget = decodeURIComponent(wfRebaseRetryMatch[1]);
         try {
           const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, persistence);
-          const result = await mutations.recreateWorkflowFromFreshBase(workflowId);
-          if (isLegacy) {
-            res.setHeader(
-              'Deprecation',
-              'true; reason="Use /api/workflows/:id/recreate-with-rebase"',
-            );
-          }
+          const result = await mutations.rebaseRetry(workflowId);
           const tasksStarted = result.started.filter(t => t.status === 'running').length;
           json(res, 200, {
             ok: true,
             workflowId,
-            action: isLegacy ? 'rebase_and_retried' : 'recreated_with_rebase',
+            action: 'rebase_retried',
             tasksStarted,
-            ...(isLegacy ? { deprecated: true, replacement: '/api/workflows/:id/recreate-with-rebase' } : {}),
+          });
+        } catch (err) {
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
+        }
+        return;
+      }
+
+      // POST /api/workflows/:id/rebase-recreate
+      const wfRebaseRecreateMatch = path.match(/^\/api\/workflows\/([^/]+)\/rebase-recreate$/);
+      if (method === 'POST' && wfRebaseRecreateMatch) {
+        const workflowTarget = decodeURIComponent(wfRebaseRecreateMatch[1]);
+        try {
+          const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, persistence);
+          const result = await mutations.rebaseRecreate(workflowId);
+          const tasksStarted = result.started.filter(t => t.status === 'running').length;
+          json(res, 200, {
+            ok: true,
+            workflowId,
+            action: 'rebase_recreated',
+            tasksStarted,
           });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });

--- a/packages/app/src/headless-command-classification.ts
+++ b/packages/app/src/headless-command-classification.ts
@@ -121,10 +121,9 @@ export function isHeadlessMutatingCommand(args: string[]): boolean {
   }
 
   return [
-    'run', 'resume', 'retry', 'retry-task', 'recreate', 'recreate-task', 'rebase', 'recreate-with-rebase', 'fix', 'resolve-conflict',
+    'run', 'resume', 'retry', 'retry-task', 'recreate', 'recreate-task', 'rebase-retry', 'rebase-recreate', 'fix', 'resolve-conflict',
     'detach-workflow',
     'migrate-compat',
-    'rebase-and-retry',
     'approve', 'reject', 'input', 'select',
     'cancel', 'cancel-workflow',
     'delete', 'delete-workflow', 'delete-all',

--- a/packages/app/src/headless-delegation.ts
+++ b/packages/app/src/headless-delegation.ts
@@ -82,12 +82,7 @@ export async function tryDelegateResume(
 }
 
 function usesExtendedDelegationTimeout(command: string): boolean {
-  return (
-    command === 'rebase' ||
-    command === 'rebase-and-retry' ||
-    command === 'recreate-with-rebase' ||
-    command === 'restart'
-  );
+  return command === 'rebase-retry' || command === 'rebase-recreate' || command === 'restart';
 }
 
 function looksLikeWorkflowId(target: unknown): boolean {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -35,8 +35,8 @@ import {
   approveTask,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   fixWithAgentAction,
-  rebaseAndRetry,
-  recreateWithRebase,
+  rebaseRetry,
+  rebaseRecreate,
   resolveConflictAction,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
@@ -970,17 +970,11 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'detach-workflow':
       await headlessDetachWorkflow(args[1], args[2], deps);
       break;
-    case 'rebase':
-      await headlessRebaseAndRetry(args[1], deps);
+    case 'rebase-retry':
+      await headlessRebaseRetry(args[1], deps);
       break;
-    case 'recreate-with-rebase':
-      await headlessRecreateWithRebase(args[1], deps);
-      break;
-
-    // Deprecated aliases
-    case 'rebase-and-retry':
-      warnDeprecated('rebase-and-retry', 'rebase');
-      await headlessRebaseAndRetry(args[1], deps);
+    case 'rebase-recreate':
+      await headlessRebaseRecreate(args[1], deps);
       break;
     case 'fix':
       await headlessFix(args[1], deps, args[2]);
@@ -1140,8 +1134,8 @@ ${BOLD}Execute:${RESET}
   recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
   fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
   detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
-  rebase <taskId>                                     Refresh pool base + nuclear restart
-  recreate-with-rebase <workflowId|mergeTaskId|taskId> Recreate workflow from fresh upstream base
+  rebase-retry <workflowId|mergeTaskId|taskId>        Refresh pool base, then retry incomplete work
+  rebase-recreate <workflowId|mergeTaskId|taskId>     Refresh pool base, then recreate workflow
   fix <taskId> [claude|codex]                         Fix a failed task (default: claude)
   resolve-conflict <taskId> [claude|codex]            Resolve merge conflict + restart
 
@@ -1178,7 +1172,6 @@ ${BOLD}Deprecated${RESET} (use new names above):
   edit → set command            edit-executor → set executor
   edit-agent → set agent        set-merge-mode → set merge-mode
   delete-workflow → delete
-  rebase-and-retry → rebase (task) or recreate-with-rebase (workflow)
 
 ${BOLD}Options:${RESET}
   --wait-for-approval    Keep running until PR approval (use with 'run' or 'resume')
@@ -1637,29 +1630,25 @@ async function headlessResolveConflict(taskId: string, deps: HeadlessDeps, agent
   }
 }
 
-async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promise<void> {
-  if (!taskId) throw new Error('Missing arguments. Usage: --headless rebase-and-retry <taskId>');
-  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'rebase');
-  if (!restored) return;
-  taskId = restored.resolvedTaskId;
-  const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
-  if (!workflowId) throw new Error(`Task "${taskId}" has no workflow`);
+async function headlessRebaseRetry(target: string, deps: HeadlessDeps): Promise<void> {
+  if (!target) throw new Error('Missing arguments. Usage: --headless rebase-retry <workflowId|mergeTaskId|taskId>');
+  const workflowId = resolveHeadlessTargetWorkflowId(target, deps.persistence);
   await preemptWorkflowBeforeMutation(workflowId, {
     preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
     logger: deps.logger,
-    context: 'headless.rebase-and-retry',
+    context: 'headless.rebase-retry',
     mutationTiming: deps.mutationTiming,
   });
 
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
-  const started = await rebaseAndRetry(taskId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
+  const started = await rebaseRetry(target, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
   const runnable = started.filter(isDispatchableLaunch);
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
     taskExecutor: te,
     logger: deps.logger,
-    context: 'headless.rebase-and-retry',
+    context: 'headless.rebase-retry',
     started,
     scopedWorkflowId: workflowId,
     mutationTiming: deps.mutationTiming,
@@ -1669,7 +1658,7 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
     return;
   }
   if (deps.noTrack) {
-    process.stdout.write('[headless] --no-track enabled: rebase accepted; exiting without tracking.\n');
+    process.stdout.write('[headless] --no-track enabled: rebase-retry accepted; exiting without tracking.\n');
     autoFix.unsubscribe();
     return;
   }
@@ -1682,28 +1671,28 @@ async function headlessRebaseAndRetry(taskId: string, deps: HeadlessDeps): Promi
   autoFix.unsubscribe();
 
   const tasksStarted = runnable.length;
-  process.stdout.write(`Rebase-and-retry: resetting workflow from current HEAD (${tasksStarted} task(s))\n`);
+  process.stdout.write(`Rebase-retry: retried workflow from fresh base (${tasksStarted} task(s))\n`);
 }
 
-async function headlessRecreateWithRebase(workflowTarget: string, deps: HeadlessDeps): Promise<void> {
-  if (!workflowTarget) throw new Error('Missing arguments. Usage: --headless recreate-with-rebase <workflowId|mergeTaskId|taskId>');
+async function headlessRebaseRecreate(workflowTarget: string, deps: HeadlessDeps): Promise<void> {
+  if (!workflowTarget) throw new Error('Missing arguments. Usage: --headless rebase-recreate <workflowId|mergeTaskId|taskId>');
   const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, deps.persistence);
   await preemptWorkflowBeforeMutation(workflowId, {
     preemptWorkflowExecution: (id) => preemptWorkflowExecution(id, deps),
     logger: deps.logger,
-    context: 'headless.recreate-with-rebase',
+    context: 'headless.rebase-recreate',
     mutationTiming: deps.mutationTiming,
   });
 
   const te = createHeadlessExecutor(deps);
   const autoFix = wireHeadlessAutoFix(deps, te);
-  const started = await recreateWithRebase(workflowId, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
+  const started = await rebaseRecreate(workflowTarget, { ...deps, taskExecutor: te, mutationTiming: deps.mutationTiming });
   const runnable = started.filter(isDispatchableLaunch);
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator: deps.orchestrator,
     taskExecutor: te,
     logger: deps.logger,
-    context: 'headless.recreate-with-rebase',
+    context: 'headless.rebase-recreate',
     started,
     scopedWorkflowId: workflowId,
     mutationTiming: deps.mutationTiming,
@@ -1713,7 +1702,7 @@ async function headlessRecreateWithRebase(workflowTarget: string, deps: Headless
     return;
   }
   if (deps.noTrack) {
-    process.stdout.write('[headless] --no-track enabled: recreate-with-rebase accepted; exiting without tracking.\n');
+    process.stdout.write('[headless] --no-track enabled: rebase-recreate accepted; exiting without tracking.\n');
     autoFix.unsubscribe();
     return;
   }
@@ -1726,7 +1715,7 @@ async function headlessRecreateWithRebase(workflowTarget: string, deps: Headless
   autoFix.unsubscribe();
 
   const tasksStarted = runnable.length;
-  process.stdout.write(`Recreate-with-rebase: resetting workflow from fresh base (${tasksStarted} task(s))\n`);
+  process.stdout.write(`Rebase-recreate: recreated workflow from fresh base (${tasksStarted} task(s))\n`);
 }
 
 async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps): Promise<void> {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -15,7 +15,8 @@
  *   electron dist/main.js --headless select <taskId> <expId>
  *   electron dist/main.js --headless retry-task <taskId>
  *   electron dist/main.js --headless retry <workflowId>
- *   electron dist/main.js --headless rebase-and-retry <taskId>
+ *   electron dist/main.js --headless rebase-retry <workflowId|mergeTaskId|taskId>
+ *   electron dist/main.js --headless rebase-recreate <workflowId|mergeTaskId|taskId>
  *   electron dist/main.js --headless fix <taskId>
  *   electron dist/main.js --headless resolve-conflict <taskId>
  *   electron dist/main.js --headless edit <taskId> <newCommand>
@@ -121,8 +122,8 @@ import {
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
   fixWithAgentAction,
-  rebaseAndRetry,
-  recreateWithRebase,
+  rebaseRetry,
+  rebaseRecreate,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
   resolveConflictAction,
@@ -915,9 +916,9 @@ if (isHeadless) {
             case 'recreate':
             case 'cancel-workflow':
               return { workflowId: arg0 === undefined ? undefined : String(arg0), priority: 'high' };
-            case 'recreate-with-rebase':
+            case 'rebase-retry':
+            case 'rebase-recreate':
               return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'high' };
-            case 'rebase':
             case 'cancel':
             case 'recreate-task':
               return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'high' };
@@ -1898,9 +1899,9 @@ if (isHeadless) {
       case 'delete':
       case 'delete-workflow':
         return { workflowId: arg0, priority: 'high' };
-      case 'recreate-with-rebase':
+      case 'rebase-retry':
+      case 'rebase-recreate':
         return { workflowId: workflowIdForTargetArg(arg0), priority: 'high' };
-      case 'rebase':
       case 'cancel':
       case 'recreate-task':
         return { workflowId: workflowIdForTaskArg(arg0), priority: 'high' };
@@ -1980,10 +1981,10 @@ if (isHeadless) {
         return { channel: 'headless.exec', request: { args: ['recreate-task', String(arg0)] } };
       case 'invoker:retry-workflow':
         return { channel: 'headless.exec', request: { args: ['retry', String(arg0)] } };
-      case 'invoker:rebase-and-retry':
-        return { channel: 'headless.exec', request: { args: ['rebase', String(arg0)] } };
-      case 'invoker:recreate-with-rebase':
-        return { channel: 'headless.exec', request: { args: ['recreate-with-rebase', String(arg0)] } };
+      case 'invoker:rebase-retry':
+        return { channel: 'headless.exec', request: { args: ['rebase-retry', String(arg0)] } };
+      case 'invoker:rebase-recreate':
+        return { channel: 'headless.exec', request: { args: ['rebase-recreate', String(arg0)] } };
       case 'invoker:set-merge-mode':
         return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
       case 'invoker:approve-merge': {
@@ -3414,23 +3415,24 @@ if (isHeadless) {
     );
 
     registerWorkflowScopedGuiMutationHandler(
-      'invoker:rebase-and-retry',
-      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'invoker:rebase-retry',
+      (targetArg: unknown) => workflowIdForTargetArg(targetArg),
       'high',
-      async (taskIdArg: unknown) => {
-      const taskId = String(taskIdArg);
-      logger.info(`rebase-and-retry: "${taskId}"`, { module: 'ipc' });
+      async (targetArg: unknown) => {
+      const target = String(targetArg);
+      const workflowId = workflowIdForTargetArg(targetArg);
+      if (!workflowId) {
+        throw new Error(`Could not resolve workflow for rebase-retry target "${target}"`);
+      }
+      logger.info(`rebase-retry: "${target}"`, { module: 'ipc' });
       try {
-        const workflowId = workflowIdForTaskArg(taskIdArg);
-        if (workflowId) {
-          await preemptWorkflowBeforeMutation(workflowId, {
-            preemptWorkflowExecution,
-            logger,
-            context: 'ipc.rebase-and-retry',
-            mutationTiming: activeMutationContext?.mutationTiming,
-          });
-        }
-        const started = await rebaseAndRetry(taskId, {
+        await preemptWorkflowBeforeMutation(workflowId, {
+          preemptWorkflowExecution,
+          logger,
+          context: 'ipc.rebase-retry',
+          mutationTiming: activeMutationContext?.mutationTiming,
+        });
+        const started = await rebaseRetry(target, {
           orchestrator,
           persistence,
           repoRoot,
@@ -3441,37 +3443,38 @@ if (isHeadless) {
           orchestrator,
           taskExecutor: requireTaskExecutor(),
           logger,
-          context: 'ipc.rebase-and-retry',
+          context: 'ipc.rebase-retry',
           started,
-          ...(workflowId ? { scopedWorkflowId: workflowId } : { scopedTaskIds: [taskId] }),
+          scopedWorkflowId: workflowId,
           mutationTiming: activeMutationContext?.mutationTiming,
         });
       } catch (err) {
-        logger.error(`rebase-and-retry failed: ${err}`, { module: 'ipc' });
+        logger.error(`rebase-retry failed: ${err}`, { module: 'ipc' });
         throw err;
       }
       },
     );
 
     registerWorkflowScopedGuiMutationHandler(
-      'invoker:recreate-with-rebase',
-      (workflowIdArg: unknown) => workflowIdForTargetArg(workflowIdArg),
+      'invoker:rebase-recreate',
+      (targetArg: unknown) => workflowIdForTargetArg(targetArg),
       'high',
-      async (workflowIdArg: unknown) => {
-      const workflowId = workflowIdForTargetArg(workflowIdArg);
+      async (targetArg: unknown) => {
+      const target = String(targetArg);
+      const workflowId = workflowIdForTargetArg(targetArg);
       if (!workflowId) {
-        throw new Error(`Could not resolve workflow for recreate-with-rebase target "${String(workflowIdArg)}"`);
+        throw new Error(`Could not resolve workflow for rebase-recreate target "${target}"`);
       }
-      cancelDeferredWorkflowLaunch(workflowId, 'ipc.recreate-with-rebase');
-      logger.info(`recreate-with-rebase: "${workflowId}"`, { module: 'ipc' });
+      cancelDeferredWorkflowLaunch(workflowId, 'ipc.rebase-recreate');
+      logger.info(`rebase-recreate: "${target}"`, { module: 'ipc' });
       try {
         await preemptWorkflowBeforeMutation(workflowId, {
           preemptWorkflowExecution,
           logger,
-          context: 'ipc.recreate-with-rebase',
+          context: 'ipc.rebase-recreate',
           mutationTiming: activeMutationContext?.mutationTiming,
         });
-        const started = await recreateWithRebase(workflowId, {
+        const started = await rebaseRecreate(target, {
           orchestrator,
           persistence,
           repoRoot,
@@ -3482,13 +3485,13 @@ if (isHeadless) {
           orchestrator,
           taskExecutor: requireTaskExecutor(),
           logger,
-          context: 'ipc.recreate-with-rebase',
+          context: 'ipc.rebase-recreate',
           started,
           scopedWorkflowId: workflowId,
           mutationTiming: activeMutationContext?.mutationTiming,
         });
       } catch (err) {
-        logger.error(`recreate-with-rebase failed: ${err}`, { module: 'ipc' });
+        logger.error(`rebase-recreate failed: ${err}`, { module: 'ipc' });
         throw err;
       }
       },

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -387,7 +387,7 @@ export class PersistedWorkflowMutationCoordinator {
     if (
       channel === 'invoker:recreate-workflow'
       || channel === 'invoker:recreate-task'
-      || channel === 'invoker:recreate-with-rebase'
+      || channel === 'invoker:rebase-recreate'
     ) {
       return 'recreate';
     }
@@ -399,7 +399,7 @@ export class PersistedWorkflowMutationCoordinator {
     }
     const payload = args[0] as { args?: unknown[] } | undefined;
     const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
-    if (rawArgs[0] === 'recreate' || rawArgs[0] === 'recreate-task' || rawArgs[0] === 'recreate-with-rebase') {
+    if (rawArgs[0] === 'recreate' || rawArgs[0] === 'recreate-task' || rawArgs[0] === 'rebase-recreate') {
       return 'recreate';
     }
     if (rawArgs[0] === 'delete' || rawArgs[0] === 'delete-workflow' || rawArgs[0] === 'delete-all') {
@@ -413,7 +413,8 @@ export class PersistedWorkflowMutationCoordinator {
       intent.channel === 'invoker:retry-workflow'
       || intent.channel === 'invoker:recreate-workflow'
       || intent.channel === 'invoker:recreate-task'
-      || intent.channel === 'invoker:recreate-with-rebase'
+      || intent.channel === 'invoker:rebase-retry'
+      || intent.channel === 'invoker:rebase-recreate'
       || intent.channel === 'invoker:delete-workflow'
       || intent.channel === 'invoker:delete-all-workflows'
       || intent.channel === 'invoker:delete-all-workflows-bulk'
@@ -437,7 +438,7 @@ export class PersistedWorkflowMutationCoordinator {
     if (!isWorkflowId) {
       return false;
     }
-    return command === 'recreate' || command === 'recreate-with-rebase' || command === 'retry';
+    return command === 'recreate' || command === 'rebase-retry' || command === 'rebase-recreate' || command === 'retry';
   }
 
   private createTiming(

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -96,7 +96,7 @@ export interface ActionDeps {
   persistence: SQLiteAdapter;
   /** @deprecated Pool cleanup uses the workflow mirror; repoRoot branch deletion is no longer used. */
   repoRoot?: string;
-  /** When set, rebase-and-refreshes the pool mirror and removes managed branches before bumping generation. */
+  /** When set, fresh-base actions refresh the pool mirror and remove managed branches before retry/recreate. */
   taskExecutor?: TaskRunner;
   mutationTiming?: WorkflowMutationTiming;
   /** When true, successful AI-applied fixes are approved immediately. */
@@ -211,6 +211,39 @@ export function recreateWorkflow(
   deps: Pick<ActionDeps, 'logger' | 'persistence' | 'orchestrator'>,
 ): TaskState[] {
   return bumpGenerationAndRecreate(workflowId, deps);
+}
+
+function workflowIdFromMergeTaskId(target: string): string | undefined {
+  if (!target.startsWith('__merge__')) return undefined;
+  return target.slice('__merge__'.length) || undefined;
+}
+
+export function resolveWorkflowIdForRebaseTarget(
+  target: string,
+  deps: Pick<ActionDeps, 'orchestrator' | 'persistence'>,
+): string {
+  const workflow = deps.persistence.loadWorkflow(target);
+  if (workflow) return workflow.id;
+
+  const mergeWorkflowId = workflowIdFromMergeTaskId(target);
+  if (mergeWorkflowId && deps.persistence.loadWorkflow(mergeWorkflowId)) {
+    return mergeWorkflowId;
+  }
+
+  const task = deps.orchestrator.getTask(target);
+  if (task?.config.workflowId) return task.config.workflowId;
+
+  for (const candidate of deps.persistence.listWorkflows()) {
+    const storedTask = deps.persistence.loadTasks(candidate.id).find((item) => (
+      item.id === target || item.id.endsWith(`/${target}`)
+    ));
+    if (storedTask) return candidate.id;
+  }
+
+  throw new OrchestratorError(
+    OrchestratorErrorCode.WORKFLOW_NOT_FOUND,
+    `Could not resolve workflow for rebase target "${target}"`,
+  );
 }
 
 export function recreateTask(
@@ -352,12 +385,45 @@ export async function deleteAllWorkflowsBulk(
  * their own `refreshBase` callback (via the orchestrator method
  * directly) to assert the fresh-base observable.
  */
+async function prepareWorkflowFreshBase(
+  workflowId: string,
+  deps: ActionDeps,
+) {
+  const workflow = deps.persistence.loadWorkflow(workflowId);
+  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
+
+  if (deps.taskExecutor && workflow.repoUrl) {
+    const prepare = () => deps.mutationTiming
+      ? deps.taskExecutor!.preparePoolForRebaseRetry(
+        workflowId,
+        workflow.repoUrl,
+        workflow.baseBranch,
+        deps.mutationTiming,
+      )
+      : deps.taskExecutor!.preparePoolForRebaseRetry(
+        workflowId,
+        workflow.repoUrl,
+        workflow.baseBranch,
+      );
+    if (deps.mutationTiming) {
+      await deps.mutationTiming.span(
+        'workflow-actions.prepareWorkflowFreshBase.preparePoolForRebaseRetry',
+        { repoUrl: workflow.repoUrl, baseBranch: workflow.baseBranch },
+        prepare,
+      );
+    } else {
+      await prepare();
+    }
+  }
+
+  return workflow;
+}
+
 export async function recreateWorkflowFromFreshBase(
   workflowId: string,
   deps: ActionDeps,
 ): Promise<TaskState[]> {
-  const workflow = deps.persistence.loadWorkflow(workflowId);
-  if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
+  const workflow = await prepareWorkflowFreshBase(workflowId, deps);
   const nextGen = (workflow.generation ?? 0) + 1;
   deps.mutationTiming?.mark('workflow-actions.recreateWorkflowFromFreshBase.bumpGeneration', 'started', {
     nextGeneration: nextGen,
@@ -371,39 +437,14 @@ export async function recreateWorkflowFromFreshBase(
     { module: 'workflow' },
   );
   deps.logger?.info(
-    `recreateWorkflowFromFreshBase: workflowId=${workflowId} → orchestrator.recreateWorkflowFromFreshBase (pool prep if taskExecutor+repoUrl)`,
+    `recreateWorkflowFromFreshBase: workflowId=${workflowId} → orchestrator.recreateWorkflowFromFreshBase`,
     { module: 'agent-session-trace' },
   );
 
   const recreate = () => deps.orchestrator.recreateWorkflowFromFreshBase(workflowId, {
     refreshBase: async () => {
-      if (deps.taskExecutor && workflow.repoUrl) {
-        const prepare = () => deps.mutationTiming
-          ? deps.taskExecutor!.preparePoolForRebaseRetry(
-            workflowId,
-            workflow.repoUrl,
-            workflow.baseBranch,
-            deps.mutationTiming,
-          )
-          : deps.taskExecutor!.preparePoolForRebaseRetry(
-            workflowId,
-            workflow.repoUrl,
-            workflow.baseBranch,
-          );
-        if (deps.mutationTiming) {
-          await deps.mutationTiming.span(
-            'workflow-actions.recreateWorkflowFromFreshBase.preparePoolForRebaseRetry',
-            { repoUrl: workflow.repoUrl, baseBranch: workflow.baseBranch },
-            prepare,
-          );
-        } else {
-          await prepare();
-        }
-      }
-      // `preparePoolForRebaseRetry` does not yet expose the resulting
-      // upstream HEAD SHA; surfacing it (so the orchestrator can
-      // record `knownFreshBaseCommits` in production too) is the
-      // follow-up the roadmap calls out in "Out of scope".
+      // Pool preparation already ran above. The callback is kept so the
+      // orchestrator still sees the fresh-base lifecycle entrypoint.
       return undefined;
     },
   });
@@ -412,58 +453,46 @@ export async function recreateWorkflowFromFreshBase(
     : recreate();
 }
 
-/**
- * Recreate a workflow from a fresh upstream base — workflow-scoped
- * entry point for the `invoker:recreate-with-rebase` IPC channel.
- *
- * This is the direct workflow-id counterpart of `rebaseAndRetry`
- * (which performs a `taskId → workflowId` translation first). Both
- * delegate to `recreateWorkflowFromFreshBase` for the actual
- * pool-refresh + generation-bump + DAG reset.
- */
-export async function recreateWithRebase(
-  workflowId: string,
+export async function rebaseRetry(
+  target: string,
   deps: ActionDeps,
 ): Promise<TaskState[]> {
-  deps.mutationTiming?.mark('workflow-actions.recreateWithRebase', 'started', { workflowId });
+  const workflowId = resolveWorkflowIdForRebaseTarget(target, deps);
+  deps.mutationTiming?.mark('workflow-actions.rebaseRetry', 'started', { target, workflowId });
   deps.logger?.info(
-    `recreateWithRebase: workflowId=${workflowId} → recreateWorkflowFromFreshBase`,
+    `rebaseRetry: target=${target} workflowId=${workflowId} → prepare fresh base + retryWorkflow`,
     { module: 'agent-session-trace' },
   );
-  const started = await recreateWorkflowFromFreshBase(workflowId, deps);
-  deps.mutationTiming?.mark('workflow-actions.recreateWithRebase', 'completed', {
+  await prepareWorkflowFreshBase(workflowId, deps);
+  const retry = async (): Promise<TaskState[]> => Promise.resolve(deps.orchestrator.retryWorkflow(workflowId));
+  const started = deps.mutationTiming
+    ? await deps.mutationTiming.span('workflow-actions.rebaseRetry.orchestrator', undefined, retry)
+    : await retry();
+  deps.mutationTiming?.mark('workflow-actions.rebaseRetry', 'completed', {
+    target,
     workflowId,
     startedCount: started.length,
   });
   return started;
 }
 
-/**
- * Rebase-and-retry: refresh the pool mirror / origin base, remove managed
- * experiment/invoker branches in that mirror, bump generation, and restart the DAG.
- *
- * Step 12: this wrapper is now a thin delegate to
- * `recreateWorkflowFromFreshBase` — the chart's first-class action
- * for this behavior. It is preserved as a separate export because
- * existing callers (notably `headlessRebaseAndRetry`) speak in task
- * ids while the workflow-scope action speaks in workflow ids; this
- * function continues to do the `taskId → workflowId` translation.
- */
-export async function rebaseAndRetry(
-  taskId: string,
+export async function rebaseRecreate(
+  target: string,
   deps: ActionDeps,
 ): Promise<TaskState[]> {
-  const task = deps.orchestrator.getTask(taskId);
-  if (!task?.config.workflowId) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found or has no workflow`);
-  const workflowId = task.config.workflowId;
-  deps.mutationTiming?.mark('workflow-actions.rebaseAndRetry', 'started', { taskId, workflowId });
+  const workflowId = resolveWorkflowIdForRebaseTarget(target, deps);
+  deps.mutationTiming?.mark('workflow-actions.rebaseRecreate', 'started', { target, workflowId });
   deps.logger?.info(
-    `rebaseAndRetry: taskId=${taskId} workflowId=${workflowId} → recreateWorkflowFromFreshBase (Step 12 delegate)`,
+    `rebaseRecreate: target=${target} workflowId=${workflowId} → prepare fresh base + recreateWorkflow`,
     { module: 'agent-session-trace' },
   );
-  const started = await recreateWorkflowFromFreshBase(workflowId, deps);
-  deps.mutationTiming?.mark('workflow-actions.rebaseAndRetry', 'completed', {
-    taskId,
+  await prepareWorkflowFreshBase(workflowId, deps);
+  const recreate = async (): Promise<TaskState[]> => Promise.resolve(bumpGenerationAndRecreate(workflowId, deps));
+  const started = deps.mutationTiming
+    ? await deps.mutationTiming.span('workflow-actions.rebaseRecreate.orchestrator', undefined, recreate)
+    : await recreate();
+  deps.mutationTiming?.mark('workflow-actions.rebaseRecreate', 'completed', {
+    target,
     workflowId,
     startedCount: started.length,
   });

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -28,8 +28,9 @@ import {
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
   recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
-  recreateWithRebase as sharedRecreateWithRebase,
-  rebaseAndRetry as sharedRebaseAndRetry,
+  rebaseRetry as sharedRebaseRetry,
+  rebaseRecreate as sharedRebaseRecreate,
+  resolveWorkflowIdForRebaseTarget,
   cancelWorkflow as sharedCancelWorkflow,
   forkWorkflow as sharedForkWorkflow,
   editTaskCommand as sharedEditTaskCommand,
@@ -250,19 +251,16 @@ export class WorkflowMutationFacade {
     return this.finalizeWithTopup(started, 'facade.recreate-from-fresh-base', { scopedWorkflowId: workflowId });
   }
 
-  async recreateWithRebase(workflowId: string): Promise<MutationResult> {
-    const started = await sharedRecreateWithRebase(workflowId, this.actionDeps());
-    return this.finalizeWithTopup(started, 'facade.recreate-with-rebase', { scopedWorkflowId: workflowId });
+  async rebaseRetry(target: string): Promise<MutationResult> {
+    const workflowId = resolveWorkflowIdForRebaseTarget(target, this.actionDeps());
+    const started = await sharedRebaseRetry(target, this.actionDeps());
+    return this.finalizeWithTopup(started, 'facade.rebase-retry', { scopedWorkflowId: workflowId });
   }
 
-  async rebaseAndRetry(taskId: string): Promise<MutationResult> {
-    const workflowId = this.deps.orchestrator.getTask(taskId)?.config.workflowId;
-    const started = await sharedRebaseAndRetry(taskId, this.actionDeps());
-    return this.finalizeWithTopup(
-      started,
-      'facade.rebase-and-retry',
-      workflowId ? { scopedWorkflowId: workflowId } : { scopedTaskIds: [taskId] },
-    );
+  async rebaseRecreate(target: string): Promise<MutationResult> {
+    const workflowId = resolveWorkflowIdForRebaseTarget(target, this.actionDeps());
+    const started = await sharedRebaseRecreate(target, this.actionDeps());
+    return this.finalizeWithTopup(started, 'facade.rebase-recreate', { scopedWorkflowId: workflowId });
   }
 
   async cancelWorkflow(workflowId: string): Promise<CancelMutationResult> {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -422,12 +422,12 @@ export const IpcChannels = {
     request: [workflowId: string];
     response: void;
   },
-  'invoker:rebase-and-retry': {} as {
-    request: [mergeTaskId: string];
+  'invoker:rebase-retry': {} as {
+    request: [target: string];
     response: RebaseAndRetryResult;
   },
-  'invoker:recreate-with-rebase': {} as {
-    request: [workflowId: string];
+  'invoker:rebase-recreate': {} as {
+    request: [target: string];
     response: RebaseAndRetryResult;
   },
   'invoker:set-merge-branch': {} as {

--- a/packages/execution-engine/src/__tests__/fetch-failure-visibility.test.ts
+++ b/packages/execution-engine/src/__tests__/fetch-failure-visibility.test.ts
@@ -207,7 +207,7 @@ describe('syncFromRemote - fetch failure handling', () => {
     it('warns when local branch is behind remote', async () => {
       // Create a second clone and push commits ahead
       const secondClone = mkdtempSync(join(tmpdir(), 'fetch-failure-clone-'));
-      execSync(`git clone ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
+      execSync(`git clone --no-local ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
       execSync('git checkout -B master origin/master', { cwd: secondClone });
       execSync('git config user.email "test@test.com"', { cwd: secondClone });
       execSync('git config user.name "Test"', { cwd: secondClone });
@@ -237,7 +237,7 @@ describe('syncFromRemote - fetch failure handling', () => {
       // rev-list count so this test exercises the warning threshold without
       // manufacturing 101 physical commits in CI's temporary git store.
       const secondClone = mkdtempSync(join(tmpdir(), 'fetch-failure-clone-'));
-      execSync(`git clone ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
+      execSync(`git clone --no-local ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
       execSync('git checkout -B master origin/master', { cwd: secondClone });
       execSync('git config user.email "test@test.com"', { cwd: secondClone });
       execSync('git config user.name "Test"', { cwd: secondClone });

--- a/packages/execution-engine/src/__tests__/fetch-status-output.test.ts
+++ b/packages/execution-engine/src/__tests__/fetch-status-output.test.ts
@@ -135,7 +135,7 @@ describe('fetch status visibility in task output', () => {
     it('shows staleness when commits behind', async () => {
       // Create a second clone and push commits ahead
       const secondClone = mkdtempSync(join(tmpdir(), 'fetch-status-clone-'));
-      execSync(`git clone ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
+      execSync(`git clone --no-local ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
       execSync('git checkout -B master origin/master', { cwd: secondClone });
       execSync('git config user.email "test@test.com"', { cwd: secondClone });
       execSync('git config user.name "Test"', { cwd: secondClone });
@@ -165,7 +165,7 @@ describe('fetch status visibility in task output', () => {
       // rev-list count so this test exercises the warning threshold without
       // manufacturing 101 physical commits in CI's temporary git store.
       const secondClone = mkdtempSync(join(tmpdir(), 'fetch-status-clone-'));
-      execSync(`git clone ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
+      execSync(`git clone --no-local ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
       execSync('git checkout -B master origin/master', { cwd: secondClone });
       execSync('git config user.email "test@test.com"', { cwd: secondClone });
       execSync('git config user.name "Test"', { cwd: secondClone });

--- a/scripts/bench-rebase-recreate-all.sh
+++ b/scripts/bench-rebase-recreate-all.sh
@@ -13,7 +13,7 @@ usage() {
   cat <<'EOF'
 Usage: scripts/bench-rebase-recreate-all.sh [--dry-run] [--workflow <id-or-name>] [--timeout <seconds>]
 
-Dispatches recreate-with-rebase across matching workflows, then reports
+Dispatches rebase-recreate across matching workflows, then reports
 workflow_mutation_intents timing:
   intent id, workflow id/name, created, started, completed, queue wait seconds,
   run seconds, and final status.
@@ -119,9 +119,9 @@ fi
 while IFS=$'\t' read -r workflow_id workflow_name; do
   [[ -z "$workflow_id" ]] && continue
   if [[ "$DRY_RUN" = true ]]; then
-    printf '[DRY RUN] would dispatch recreate-with-rebase\t%s\t%s\n' "$workflow_id" "$workflow_name"
+    printf '[DRY RUN] would dispatch rebase-recreate\t%s\t%s\n' "$workflow_id" "$workflow_name"
   else
-    printf '{"label":"%s","workflowId":"%s","args":["recreate-with-rebase","%s"]}\n' \
+    printf '{"label":"%s","workflowId":"%s","args":["rebase-recreate","%s"]}\n' \
       "$workflow_id" "$workflow_id" "$workflow_id" >> "$COMMANDS_FILE"
   fi
 done < "$WORKFLOWS_FILE"
@@ -149,7 +149,7 @@ while true; do
       from workflow_mutation_intents
       where id > $LAST_INTENT_ID
         and workflow_id in ($WORKFLOW_ID_LIST)
-        and args_json like '%recreate-with-rebase%'
+        and args_json like '%rebase-recreate%'
         and status in ('queued', 'running');
     "
   )"
@@ -159,14 +159,14 @@ while true; do
       from workflow_mutation_intents
       where id > $LAST_INTENT_ID
         and workflow_id in ($WORKFLOW_ID_LIST)
-        and args_json like '%recreate-with-rebase%';
+        and args_json like '%rebase-recreate%';
     "
   )"
   if [[ "$intent_count" -ge "$TOTAL_WORKFLOWS" && "$pending_count" -eq 0 ]]; then
     break
   fi
   if (( $(date +%s) - started_at_epoch >= TIMEOUT_SECONDS )); then
-    echo "Timed out waiting for recreate-with-rebase intents (seen=$intent_count pending=$pending_count)." >&2
+    echo "Timed out waiting for rebase-recreate intents (seen=$intent_count pending=$pending_count)." >&2
     break
   fi
   sleep "$POLL_INTERVAL_SECONDS"
@@ -195,7 +195,7 @@ sqlite3 -header -separator $'\t' "$DB_PATH" "
   from workflow_mutation_intents i
   join target_workflows on target_workflows.id = i.workflow_id
   where i.id > $LAST_INTENT_ID
-    and i.args_json like '%recreate-with-rebase%'
+    and i.args_json like '%rebase-recreate%'
   order by i.id asc;
 " | tee "$METRICS_FILE"
 

--- a/scripts/e2e-chaos/run-overload.sh
+++ b/scripts/e2e-chaos/run-overload.sh
@@ -902,7 +902,7 @@ run_owner_restart_loop_during_tracked_rebase() {
   done
 
   echo "==> overload: starting tracked rebase before owner restart loop"
-  ov_spawn_command_timed "tracked-rebase" 120 invoker_e2e_run_headless rebase "$target_task"
+  ov_spawn_command_timed "tracked-rebase" 120 invoker_e2e_run_headless rebase-retry "$target_task"
   sleep 2
 
   local restart_cycles=3
@@ -2312,7 +2312,7 @@ run_mixed_control_plane_storm() {
   echo "==> overload: firing mixed control-plane storm burst=$operation_burst"
   ov_spawn_command "recreate-fail-1" invoker_e2e_run_headless --no-track recreate "${fail_workflows[0]}"
   ov_spawn_command "recreate-fail-2" invoker_e2e_run_headless --no-track recreate "${fail_workflows[1]}"
-  ov_spawn_command "rebase-fail-3" invoker_e2e_run_headless --no-track rebase "${fail_workflows[2]}/root"
+  ov_spawn_command "rebase-fail-3" invoker_e2e_run_headless --no-track rebase-retry "${fail_workflows[2]}/root"
   ov_spawn_command "retry-fail-3" invoker_e2e_run_headless --no-track retry "${fail_workflows[2]}"
   ov_spawn_command "approve-1" invoker_e2e_run_headless --no-track approve "${approval_workflows[0]}/approve-me"
   ov_spawn_command "approve-2" invoker_e2e_run_headless --no-track approve "${approval_workflows[1]}/approve-me"
@@ -2421,7 +2421,7 @@ run_owner_restart_loop_during_mixed_storm() {
   echo "==> overload: firing mixed storm before restart loop burst=$operation_burst"
   ov_spawn_command "recreate-fail-1" invoker_e2e_run_headless --no-track recreate "${fail_workflows[0]}"
   ov_spawn_command "recreate-fail-2" invoker_e2e_run_headless --no-track recreate "${fail_workflows[1]}"
-  ov_spawn_command "rebase-fail-3" invoker_e2e_run_headless --no-track rebase "${fail_workflows[2]}/root"
+  ov_spawn_command "rebase-fail-3" invoker_e2e_run_headless --no-track rebase-retry "${fail_workflows[2]}/root"
   ov_spawn_command "retry-fail-3" invoker_e2e_run_headless --no-track retry "${fail_workflows[2]}"
   ov_spawn_command "approve-1" invoker_e2e_run_headless --no-track approve "${approval_workflows[0]}/approve-me"
   ov_spawn_command "approve-2" invoker_e2e_run_headless --no-track approve "${approval_workflows[1]}/approve-me"

--- a/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
+++ b/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
@@ -66,7 +66,7 @@ trap 'rm -rf "$TMP_DIR" "$CFG_FILE"; invoker_e2e_cleanup' EXIT
 echo "==> case 2.13: race reset intents (rebase + recreate x4)"
 (
   set +e
-  invoker_e2e_run_headless rebase "$TASK_ID" >"$TMP_DIR/rebase.out" 2>&1
+  invoker_e2e_run_headless rebase-recreate "$TASK_ID" >"$TMP_DIR/rebase.out" 2>&1
   echo $? >"$TMP_DIR/rebase.code"
 ) &
 for i in 1 2 3 4; do

--- a/scripts/rebase-retry-all.sh
+++ b/scripts/rebase-retry-all.sh
@@ -224,14 +224,14 @@ if [ "$FOLLOW" = true ]; then
     if [ "$COMMAND_TIMEOUT_SECONDS" -gt 0 ]; then
       set +e
       cmd_out="$(
-        run_with_optional_timeout "$COMMAND_TIMEOUT_SECONDS" headless_mutation --no-track recreate-with-rebase "$wf_id" 2>&1
+        run_with_optional_timeout "$COMMAND_TIMEOUT_SECONDS" headless_mutation --no-track rebase-retry "$wf_id" 2>&1
       )"
       cmd_status=$?
       set -e
     else
       set +e
       cmd_out="$(
-        headless_mutation --no-track recreate-with-rebase "$wf_id" 2>&1
+        headless_mutation --no-track rebase-retry "$wf_id" 2>&1
       )"
       cmd_status=$?
       set -e
@@ -299,13 +299,13 @@ else
     echo "[queue $IDX/$TOTAL_WORKFLOWS] $WF_ID" >&2
 
     if [ "$DRY_RUN" = true ]; then
-      echo "  [DRY RUN] Would dispatch recreate-with-rebase for workflow: $WF_ID" >&2
+      echo "  [DRY RUN] Would dispatch rebase-retry for workflow: $WF_ID" >&2
       DISPATCHED=$((DISPATCHED + 1))
       continue
     fi
 
     log_file="$LOG_DIR/${WF_ID}.log"
-    printf '{"label":"%s","workflowId":"%s","args":["recreate-with-rebase","%s"]}\n' "$WF_ID" "$WF_ID" "$WF_ID" >> "$COMMANDS_FILE"
+    printf '{"label":"%s","workflowId":"%s","args":["rebase-retry","%s"]}\n' "$WF_ID" "$WF_ID" "$WF_ID" >> "$COMMANDS_FILE"
     echo "  queued log=$log_file" >&2
   done <<< "$WORKFLOW_IDS"
 

--- a/scripts/repro/repro-prod-copy-rebase-retry-all.sh
+++ b/scripts/repro/repro-prod-copy-rebase-retry-all.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Repro/verification for production-shaped bulk recreate-with-rebase.
+# Repro/verification for production-shaped bulk rebase-recreate.
 #
 # Copies the local production DB into an isolated temp INVOKER_DB_DIR, marks
 # copied workflows/tasks failed, then runs the real scripts/rebase-retry-all.sh
@@ -269,7 +269,7 @@ while true; do
         sum(case when status = 'queued' then 1 else 0 end),
         sum(case when status = 'failed' then 1 else 0 end)
       from workflow_mutation_intents
-      where args_json like '%recreate-with-rebase%';
+      where args_json like '%rebase-recreate%';
     " | tr '|' ' '
   )
   NOW_MS="$(now_ms)"
@@ -292,7 +292,7 @@ FINAL_STATUS="$(sqlite3 "$DB_DIR/invoker.db" "
   select coalesce(status, '')
   from workflow_mutation_intents
   where workflow_id = '$FINAL_WORKFLOW_ID'
-    and args_json like '%recreate-with-rebase%'
+    and args_json like '%rebase-recreate%'
   order by id desc
   limit 1;
 ")"
@@ -300,13 +300,13 @@ FINAL_STATUS="$(sqlite3 "$DB_DIR/invoker.db" "
 MAX_INTENT_MS="$(sqlite3 "$DB_DIR/invoker.db" "
   select coalesce(cast(round(max((julianday(completed_at) - julianday(started_at)) * 86400000.0)) as integer), 0)
   from workflow_mutation_intents
-  where args_json like '%recreate-with-rebase%'
+  where args_json like '%rebase-recreate%'
     and started_at is not null
     and completed_at is not null;
 ")"
 
 if [[ "$INTENT_TOTAL" -ne "$WORKFLOW_COUNT" ]]; then
-  echo "FAIL: expected $WORKFLOW_COUNT recreate-with-rebase intents, found $INTENT_TOTAL" >&2
+  echo "FAIL: expected $WORKFLOW_COUNT rebase-recreate intents, found $INTENT_TOTAL" >&2
   exit 1
 fi
 if [[ "$INTENT_COMPLETED" -ne "$WORKFLOW_COUNT" || "$INTENT_RUNNING" -ne 0 || "$INTENT_QUEUED" -ne 0 || "$INTENT_FAILED" -ne 0 ]]; then

--- a/scripts/repro/repro-rebase-recreate-race.sh
+++ b/scripts/repro/repro-rebase-recreate-race.sh
@@ -50,7 +50,7 @@ GEN_BEFORE="$(generation_for_workflow "$WF_ID")"
 
 (
   set +e
-  invoker_e2e_run_headless rebase "$TASK_ID" >"$TMP_DIR/rebase.out" 2>&1
+  invoker_e2e_run_headless rebase-recreate "$TASK_ID" >"$TMP_DIR/rebase.out" 2>&1
   echo $? >"$TMP_DIR/rebase.code"
 ) &
 for i in 1 2 3 4; do
@@ -79,7 +79,7 @@ done
 echo ""
 
 echo "==> relevant log lines (workflow + reset operations)"
-rg -n "$WF_ID|rebaseAndRetry: taskId=$TASK_ID|headless.exec: \\\"rebase $TASK_ID\\\"|bumped generation to [0-9]+ for $WF_ID|bumpGenerationAndRecreate: calling recreateWorkflow\\($WF_ID\\)" \
+rg -n "$WF_ID|rebaseRecreate: target=$TASK_ID|headless.exec: \\\"rebase-recreate $TASK_ID\\\"|bumped generation to [0-9]+ for $WF_ID|bumpGenerationAndRecreate: calling recreateWorkflow\\($WF_ID\\)" \
   ~/.invoker/invoker.log | tail -n 120 || true
 
 echo ""

--- a/scripts/repro/repro-stale-agent-session-after-rebase.sh
+++ b/scripts/repro/repro-stale-agent-session-after-rebase.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
-# Regression guard: after rebase-and-retry, pending downstream tasks must NOT keep
+# Regression guard: after rebase-recreate, pending downstream tasks must NOT keep
 # the previous run's agent_session_id (orchestrator restart clears it to NULL before
 # the next executor.start()). A stale UUID is what the GUI can pass to
 # `claude --resume`, which then errors with:
 #   No conversation found with session ID: …
 #
 # This script polls SQLite while reprosess-a is running and reprosess-b is still
-# pending after a headless rebase-and-retry, and passes only if reprosess-b has
+# pending after a headless rebase-recreate, and passes only if reprosess-b has
 # no stale session id in that window.
 #
 # Requirements: python3, git, network (clone test-playground), built app (dist/main.js).
@@ -129,10 +129,10 @@ if [[ -z "$SESSION_BEFORE" ]]; then
 fi
 echo "==> reprosess-b agent_session_id after first run: $SESSION_BEFORE"
 
-echo "==> Starting rebase-and-retry in background (same DB; reprosess-a will sleep again)"
+echo "==> Starting rebase-recreate in background (same DB; reprosess-a will sleep again)"
 (cd "$REPO_ROOT" && INVOKER_HEADLESS_STANDALONE=1 INVOKER_DB_DIR="$INVOKER_DB_DIR" PATH="$STUB_DIR:$PATH" \
   INVOKER_E2E_MARKER_ROOT="$INVOKER_E2E_MARKER_ROOT" \
-  timeout 600 ./run.sh --headless rebase-and-retry reprosess-b) >"$REBASE_LOG" 2>&1 &
+  timeout 600 ./run.sh --headless rebase-recreate reprosess-b) >"$REBASE_LOG" 2>&1 &
 REBASE_PID=$!
 
 echo "==> Polling on-disk DB until reprosess-a is running, reprosess-b pending, and b has no stale session…"
@@ -166,13 +166,13 @@ done
 
 if [[ -n "$FOUND" ]]; then
   echo ""
-  echo "=== [agent-session-trace] from rebase-and-retry subprocess (orchestrator + workflow path) ==="
+  echo "=== [agent-session-trace] from rebase-recreate subprocess (orchestrator + workflow path) ==="
   grep -F '[agent-session-trace]' "$REBASE_LOG" 2>/dev/null || echo "(no matches — see full log at $REBASE_LOG)"
   echo ""
   echo "-------------------------------------------------------------------"
   echo "FIX VERIFIED"
   echo "  While reprosess-a was running and reprosess-b was still pending"
-  echo "  after rebase-and-retry, reprosess-b.agent_session_id was cleared"
+  echo "  after rebase-recreate, reprosess-b.agent_session_id was cleared"
   echo "  (not the pre-rebase value: $SESSION_BEFORE)."
   echo "-------------------------------------------------------------------"
 else
@@ -183,6 +183,6 @@ fi
 
 wait "$REBASE_PID" || true
 REBASE_PID=""
-echo "==> rebase-and-retry subprocess finished."
+echo "==> rebase-recreate subprocess finished."
 
 exit 0


### PR DESCRIPTION
Replace the ambiguous rebase mutation surface with explicit rebase-retry and rebase-recreate operations across backend workflow actions, CLI, IPC contracts, HTTP routes, mutation fencing, and helper scripts.

```mermaid
flowchart TD
  Target[workflow, merge task, or task id] --> Rebase[rebase / rebase-and-retry / recreate-with-rebase]
  Rebase --> FreshBase[refresh upstream base]
  FreshBase --> Mixed[retry or recreate semantics by entry point]
```

```mermaid
flowchart TD
  Target[workflow, merge task, or task id] --> Resolve[resolve owning workflow]
  Resolve --> FreshBase[prepare fresh upstream base]
  FreshBase --> Retry[rebase-retry calls retryWorkflow]
  FreshBase --> Recreate[rebase-recreate calls recreateWorkflow]
```

- [x] pnpm vitest run src/__tests__/api-server.test.ts src/__tests__/headless-delegation.test.ts src/__tests__/workflow-actions.test.ts src/__tests__/rebase-and-retry.test.ts
- [x] pnpm --filter @invoker/app test
- [x] pnpm --filter @invoker/app build

- Safe to revert? Yes
- Revert command: git revert <sha>
- Post-revert steps: Restore the previous rebase aliases only if external automation still depends on them.
- Data migration? No