### PR TITLE
Fix disappearing task DAG recovery

### DIFF
--- a/packages/execution-engine/src/__tests__/fetch-failure-visibility.test.ts
+++ b/packages/execution-engine/src/__tests__/fetch-failure-visibility.test.ts
@@ -201,6 +201,7 @@ describe('syncFromRemote - fetch failure handling', () => {
     afterEach(() => {
       rmSync(tmpDir, { recursive: true, force: true });
       rmSync(remoteRepo, { recursive: true, force: true });
+      vi.restoreAllMocks();
     });
 
     it('warns when local branch is behind remote', async () => {
@@ -232,22 +233,30 @@ describe('syncFromRemote - fetch failure handling', () => {
     });
 
     it('emits loud warning when >100 commits behind', async () => {
-      // Create a second clone and push many commits ahead
+      // Create a second clone and push one commit ahead. Mock only the
+      // rev-list count so this test exercises the warning threshold without
+      // manufacturing 101 physical commits in CI's temporary git store.
       const secondClone = mkdtempSync(join(tmpdir(), 'fetch-failure-clone-'));
       execSync(`git clone ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
       execSync('git checkout -B master origin/master', { cwd: secondClone });
       execSync('git config user.email "test@test.com"', { cwd: secondClone });
       execSync('git config user.name "Test"', { cwd: secondClone });
 
-      // Push 101 commits to trigger loud warning
-      for (let i = 1; i <= 101; i++) {
-        writeFileSync(join(secondClone, `file${i}.txt`), `content${i}`);
-        execSync(`git add -A && git commit -m "commit ${i}"`, { cwd: secondClone });
-      }
+      writeFileSync(join(secondClone, 'file101.txt'), 'content101');
+      execSync('git add -A && git commit -m "commit 101"', { cwd: secondClone });
       execSync('git push', { cwd: secondClone });
 
       const executionId = 'test-exec-staleness-loud';
       executor.registerTestEntry(executionId, makeRequest('test-action'));
+      const originalExecGitSimple = (executor as any).execGitSimple.bind(executor);
+      vi.spyOn(executor as any, 'execGitSimple').mockImplementation(
+        async (args: string[], cwd: string, opts?: { signal?: AbortSignal }) => {
+          if (args[0] === 'rev-list' && args[1] === '--count') {
+            return '101';
+          }
+          return originalExecGitSimple(args, cwd, opts);
+        },
+      );
 
       await executor.testSyncFromRemote(tmpDir, executionId);
 

--- a/packages/execution-engine/src/__tests__/fetch-status-output.test.ts
+++ b/packages/execution-engine/src/__tests__/fetch-status-output.test.ts
@@ -161,22 +161,30 @@ describe('fetch status visibility in task output', () => {
     });
 
     it('emits loud warning when >100 commits behind', async () => {
-      // Create a second clone and push many commits ahead
+      // Create a second clone and push one commit ahead. Mock only the
+      // rev-list count so this test exercises the warning threshold without
+      // manufacturing 101 physical commits in CI's temporary git store.
       const secondClone = mkdtempSync(join(tmpdir(), 'fetch-status-clone-'));
       execSync(`git clone ${remoteRepo} ${secondClone}`, { cwd: tmpdir() });
       execSync('git checkout -B master origin/master', { cwd: secondClone });
       execSync('git config user.email "test@test.com"', { cwd: secondClone });
       execSync('git config user.name "Test"', { cwd: secondClone });
 
-      // Push 101 commits to trigger loud warning
-      for (let i = 1; i <= 101; i++) {
-        writeFileSync(join(secondClone, `file${i}.txt`), `content${i}`);
-        execSync(`git add -A && git commit -m "commit ${i}"`, { cwd: secondClone });
-      }
+      writeFileSync(join(secondClone, 'file101.txt'), 'content101');
+      execSync('git add -A && git commit -m "commit 101"', { cwd: secondClone });
       execSync('git push', { cwd: secondClone });
 
       const executionId = 'test-exec-very-behind';
       executor.registerTestEntry(executionId, makeRequest('test-action'));
+      const originalExecGitSimple = (executor as any).execGitSimple.bind(executor);
+      vi.spyOn(executor as any, 'execGitSimple').mockImplementation(
+        async (args: string[], cwd: string, opts?: { signal?: AbortSignal }) => {
+          if (args[0] === 'rev-list' && args[1] === '--count') {
+            return '101';
+          }
+          return originalExecGitSimple(args, cwd, opts);
+        },
+      );
 
       await executor.testSyncFromRemote(tmpDir, executionId);
 

--- a/packages/ui/src/__tests__/task-dag-stability.test.ts
+++ b/packages/ui/src/__tests__/task-dag-stability.test.ts
@@ -3,10 +3,10 @@
  * - onNodesChange filters to only dimension/select changes
  * - Watchdog detects both missing and visibility:hidden nodes
  * - fitView prop removed (no visibility:hidden mechanism)
- * - rfNodes state syncs from task-derived nodes
+ * - rfNodes state preserves measured dimensions from task-derived node updates
  */
 
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { applyNodeChanges, type Node, type NodeChange } from '@xyflow/react';
@@ -155,7 +155,23 @@ describe('TaskDAG stability', () => {
       expect(updated[0].measured).toEqual({ width: 260, height: 80 });
     });
 
-    it('dimension changes survive a simulated task-delta re-render', () => {
+    function mergeMeasuredNodeState(prevNodes: Node[], nextNodes: Node[]): Node[] {
+      const previousById = new Map(prevNodes.map((node) => [node.id, node]));
+
+      return nextNodes.map((node) => {
+        const previous = previousById.get(node.id);
+        if (!previous) return node;
+
+        return {
+          ...node,
+          ...(previous.measured ? { measured: previous.measured } : {}),
+          ...(previous.width !== undefined ? { width: previous.width } : {}),
+          ...(previous.height !== undefined ? { height: previous.height } : {}),
+        };
+      });
+    }
+
+    it('preserves dimensions across a simulated task-delta re-render', () => {
       // 1. Start with task-derived nodes (no dimensions)
       let rfNodes: Node[] = [{ ...baseNode }];
 
@@ -181,11 +197,16 @@ describe('TaskDAG stability', () => {
           data: { task: { status: 'running' }, label: 'Test' },
         },
       ];
-      rfNodes = newTaskNodes;
+      rfNodes = mergeMeasuredNodeState(rfNodes, newTaskNodes);
 
-      // 4. Dimensions are lost on the new objects — this is expected.
-      //    React Flow will re-measure but without fitView prop it won't hide them.
-      expect(rfNodes[0].measured).toBeUndefined();
+      // 4. Dimensions are retained so React Flow does not need to re-measure
+      //    existing nodes after each status/task data update.
+      expect(rfNodes[0].measured).toEqual({ width: 260, height: 80 });
+      expect(rfNodes[0].data).toEqual({ task: { status: 'running' }, label: 'Test' });
+    });
+
+    it('wires task-derived node sync through measured-state merge', () => {
+      expect(source).toContain('mergeMeasuredNodeState(prev, nodes)');
     });
   });
 
@@ -220,6 +241,36 @@ describe('TaskDAG stability', () => {
 
     it('does not trigger when no props nodes exist', () => {
       expect(shouldTrigger(0, 0, 0)).toBe(false);
+    });
+
+    function shouldRecover(missCount: number, recoveryAttempted: boolean): boolean {
+      return missCount >= 3 && !recoveryAttempted;
+    }
+
+    it('does not recover before repeated watchdog misses', () => {
+      expect(shouldRecover(1, false)).toBe(false);
+      expect(shouldRecover(2, false)).toBe(false);
+    });
+
+    it('recovers once after repeated watchdog misses', () => {
+      expect(shouldRecover(3, false)).toBe(true);
+      expect(shouldRecover(4, true)).toBe(false);
+    });
+
+    it('logs watchdog miss and recovery state', () => {
+      expect(source).toContain('missCount: watchdogMissCountRef.current');
+      expect(source).toContain('recoveryAttempted: watchdogRecoveryAttemptedRef.current');
+      expect(source).toContain('recoveryTriggered: shouldRecover');
+    });
+
+    it('remounts React Flow for bounded watchdog recovery', () => {
+      const reactFlowBlock = source.slice(
+        source.indexOf('<ReactFlow'),
+        source.indexOf('</ReactFlow>'),
+      );
+      expect(source).toContain('const WATCHDOG_RECOVERY_MISS_COUNT = 3;');
+      expect(source).toContain('setFlowInstanceKey((key) => key + 1)');
+      expect(reactFlowBlock).toContain('key={flowInstanceKey}');
     });
   });
 

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -49,6 +49,7 @@ interface TaskDAGProps {
 const nodeTypes = { taskNode: TaskNode, mergeGateNode: MergeGateNode };
 const edgeTypes = { bundled: BundledEdge };
 const WORKFLOW_GAP = 100;
+const WATCHDOG_RECOVERY_MISS_COUNT = 3;
 
 type RawTaskEdge = LayoutEdge & {
   kind: 'local' | 'external';
@@ -125,11 +126,30 @@ function layoutKeyFor(tasks: TaskState[], edges: RawTaskEdge[]): string {
   });
 }
 
+function mergeMeasuredNodeState(prevNodes: Node[], nextNodes: Node[]): Node[] {
+  const previousById = new Map(prevNodes.map((node) => [node.id, node]));
+
+  return nextNodes.map((node) => {
+    const previous = previousById.get(node.id);
+    if (!previous) return node;
+
+    return {
+      ...node,
+      ...(previous.measured ? { measured: previous.measured } : {}),
+      ...(previous.width !== undefined ? { width: previous.width } : {}),
+      ...(previous.height !== undefined ? { height: previous.height } : {}),
+    };
+  });
+}
+
 function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDoubleClick, onTaskContextMenu, statusFilters }: TaskDAGProps) {
   const { fitView } = useReactFlow();
   const prevNodeCount = useRef(0);
   const reportedGraphVisibleRef = useRef(false);
+  const watchdogMissCountRef = useRef(0);
+  const watchdogRecoveryAttemptedRef = useRef(false);
   const [layoutState, setLayoutState] = useState<LayoutState | null>(null);
+  const [flowInstanceKey, setFlowInstanceKey] = useState(0);
 
   const onInitHandler = useCallback(() => {
     requestAnimationFrame(() => fitView({ padding: 0.2 }));
@@ -370,13 +390,13 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
     return { nodes: allNodes, edges: newEdges };
   }, [activeLayout.positions, rawGraph, routedEdgePoints, selectedTaskId, statusFilters, tasks, workflows]);
 
-  // Merge task-derived nodes with React Flow's internal dimension/selection state.
+  // Merge task-derived nodes with React Flow's internal dimension state.
   // Without this, each task-delta re-render creates new node objects that discard
   // previously measured dimensions, forcing React Flow to re-measure.
   const [rfNodes, setRfNodes] = useState<Node[]>([]);
 
   useEffect(() => {
-    setRfNodes(nodes);
+    setRfNodes((prev) => mergeMeasuredNodeState(prev, nodes));
   }, [nodes]);
 
   const onNodesChange = useCallback((changes: NodeChange[]) => {
@@ -390,6 +410,8 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
   useEffect(() => {
     if (nodes.length !== prevNodeCount.current && nodes.length > 0) {
       prevNodeCount.current = nodes.length;
+      watchdogMissCountRef.current = 0;
+      watchdogRecoveryAttemptedRef.current = false;
       requestAnimationFrame(() => fitView({ padding: 0.2 }));
     }
   }, [nodes.length, fitView]);
@@ -426,15 +448,31 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
         (domNodes.length === 0 && nodes.length > 0) ||
         (hiddenNodes.length > 0 && hiddenNodes.length === domNodes.length)
       ) {
+        watchdogMissCountRef.current += 1;
+        const shouldRecover =
+          watchdogMissCountRef.current >= WATCHDOG_RECOVERY_MISS_COUNT &&
+          !watchdogRecoveryAttemptedRef.current;
+
         console.warn(
-          '[DAG-watchdog] Nodes hidden or missing, forcing fitView',
+          shouldRecover
+            ? '[DAG-watchdog] Nodes hidden or missing, remounting React Flow'
+            : '[DAG-watchdog] Nodes hidden or missing, forcing fitView',
           {
             propsNodeCount: nodes.length,
             domNodeCount: domNodes.length,
             hiddenCount: hiddenNodes.length,
+            missCount: watchdogMissCountRef.current,
+            recoveryAttempted: watchdogRecoveryAttemptedRef.current,
+            recoveryTriggered: shouldRecover,
           },
         );
         fitView({ padding: 0.2 });
+        if (shouldRecover) {
+          watchdogRecoveryAttemptedRef.current = true;
+          setFlowInstanceKey((key) => key + 1);
+        }
+      } else {
+        watchdogMissCountRef.current = 0;
       }
     }, 2000);
     return () => clearInterval(interval);
@@ -485,6 +523,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
   return (
     <div className="h-full w-full" style={{ minHeight: '300px' }}>
       <ReactFlow
+        key={flowInstanceKey}
         nodes={rfNodes}
         edges={edges}
         nodeTypes={nodeTypes}


### PR DESCRIPTION
## Summary

Fix the task DAG disappearing after task/status delta updates by preserving React Flow's measured node dimensions when task-derived nodes are synced into local `rfNodes`.

Add a bounded watchdog recovery path so repeated hidden or missing node detections remount React Flow once instead of only warning and calling `fitView` forever.

Stabilize the CI fetch-staleness warning tests by mocking only the `git rev-list --count` result for the `>100 commits behind` threshold instead of creating 101 physical commits in temporary git repos.

## Architecture

### Before

```mermaid
graph TD
    A[Task/status delta] --> B[Build fresh task-derived nodes]
    B --> C[Replace rfNodes with fresh node objects]
    C --> D[Measured dimensions are discarded]
    E[Watchdog detects hidden or missing nodes] --> F[Log warning]
    F --> G[Call fitView]
```

### After

```mermaid
graph TD
    A[Task/status delta] --> B[Build fresh task-derived nodes]
    B --> C[Merge prior measured dimensions by node id]
    C --> D[Update rfNodes with current data and preserved dimensions]
    E[Watchdog detects hidden or missing nodes] --> F[Increment miss count and log recovery fields]
    F --> G[Call fitView]
    F --> H{Repeated misses and no prior recovery?}
    H -->|Yes| I[Remount React Flow once]
    H -->|No| J[Keep monitoring]
```

## Test Plan

- [x] `cd packages/ui && pnpm vitest run src/__tests__/task-dag-stability.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/fetch-status-output.test.ts src/__tests__/fetch-failure-visibility.test.ts`
- [x] `pnpm run check:types`
- [x] `cd packages/ui && pnpm test`
- [x] `CI=1 pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert fa59efe1 631051c5`
- Post-revert steps: None
- Data migration? No
