### PR TITLE
Fix review gate workspace checkout

### DIFF
--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -25,6 +25,7 @@ import {
 import type { TaskStateChanges } from '@invoker/workflow-graph';
 import {
   DockerExecutor, WorktreeExecutor, ExecutorRegistry, SshExecutor,
+  MergeGateExecutor,
   BaseExecutor,
   getEffectivePath,
   type ExecutorHandle, type TerminalSpec, type PersistedTaskMeta,
@@ -574,6 +575,29 @@ describe('merge gate open-terminal', () => {
     vi.mocked(existsSync).mockReset();
   });
 
+  function createMergeGateExecutor() {
+    return new MergeGateExecutor({
+      persistence: {} as any,
+      orchestrator: {} as any,
+      defaultBranch: 'master',
+      callbacks: {},
+      cwd: '/home/user/repo',
+      execGitReadonly: vi.fn(),
+      execGitIn: vi.fn(),
+      createMergeWorktree: vi.fn(),
+      removeMergeWorktree: vi.fn(),
+      execGh: vi.fn(),
+      execPr: vi.fn(),
+      detectDefaultBranch: vi.fn(),
+      gitLogMessage: vi.fn(),
+      gitDiffStat: vi.fn(),
+      startPrPolling: vi.fn(),
+      executeTasks: vi.fn(),
+      buildMergeSummary: vi.fn(),
+      consolidateAndMerge: vi.fn(),
+    } as any);
+  }
+
   it('resolves merge gate fallback to default worktree executor', () => {
     const registry = new ExecutorRegistry();
     const worktree = new WorktreeExecutor({ cacheDir: join(tmpdir(), 'cache'), worktreeBaseDir: join(tmpdir(), 'merge-gate-wt') });
@@ -598,6 +622,37 @@ describe('merge gate open-terminal', () => {
 
     expect(executor).toBe(worktree);
     expect(executor!.type).toBe('worktree');
+  });
+
+  it('merge executor restore checks out branch before opening shell', () => {
+    const merge = createMergeGateExecutor();
+    const meta: PersistedTaskMeta = {
+      taskId: '__merge__wf-123',
+      runnerKind: 'merge',
+      workspacePath: '/home/user/.invoker/merge-clones/gate-wf',
+      branch: 'plan/example',
+    };
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    const spec = merge.getRestoredTerminalSpec(meta);
+    expect(spec.cwd).toBe(meta.workspacePath);
+    expect(spec.command).toBe(worktreeCheckoutShell);
+    expect(spec.args).toContain('-c');
+    expect(spec.args![1]).toContain("git checkout 'plan/example'");
+    expect(spec.args![1]).toContain(`exec ${worktreeCheckoutShell}`);
+  });
+
+  it('merge executor restore keeps cwd-only behavior when branch is absent', () => {
+    const merge = createMergeGateExecutor();
+    const meta: PersistedTaskMeta = {
+      taskId: '__merge__wf-123',
+      runnerKind: 'merge',
+      workspacePath: '/home/user/.invoker/merge-clones/gate-wf',
+    };
+
+    vi.mocked(existsSync).mockReturnValue(true);
+    const spec = merge.getRestoredTerminalSpec(meta);
+    expect(spec).toEqual({ cwd: meta.workspacePath });
   });
 
   it('opens terminal with git checkout for merge gate with branch when workspacePath is a worktree', () => {

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -2850,6 +2850,113 @@ describe('TaskRunner', () => {
       );
     });
 
+    it('external_review checks out the fetched feature branch in the gate workspace', async () => {
+      const allTasks = [
+        makeTask({ id: 't1', config: { workflowId: 'wf-1' }, status: 'completed', execution: { branch: 'experiment/t1' } }),
+      ];
+      const orchestrator = {
+        getTask: (id: string) => allTasks.find(t => t.id === id),
+        getAllTasks: () => allTasks,
+        handleWorkerResponse: vi.fn(() => []),
+        setTaskAwaitingApproval: vi.fn(),
+      };
+      const persistence = {
+        loadWorkflow: () => ({
+          id: 'wf-1',
+          onFinish: 'merge',
+          mergeMode: 'external_review',
+          baseBranch: 'master',
+          featureBranch: 'plan/example',
+          name: 'Review Gate Checkout',
+        }),
+        updateTask: vi.fn(),
+      };
+      const mergeGateProvider = {
+        createReview: vi.fn().mockResolvedValue({
+          url: 'https://github.com/owner/repo/pull/42',
+          identifier: 'owner/repo#42',
+        }),
+      };
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp/host',
+        callbacks: { onComplete: vi.fn() },
+        mergeGateProvider: mergeGateProvider as any,
+      });
+
+      const gateWorkspace = '/tmp/gate-wt';
+      const consolidateWorkspace = '/tmp/consolidate-wt';
+      const currentBranchByDir = new Map<string, string | undefined>([
+        [gateWorkspace, undefined],
+        [consolidateWorkspace, 'plan/example'],
+      ]);
+      const gitCalls: Array<{ args: string[]; dir: string }> = [];
+      (executor as any).execGitReadonly = async () => '';
+      (executor as any).execGitIn = async (args: string[], dir: string) => {
+        gitCalls.push({ args: [...args], dir });
+        if (args[0] === 'checkout' && args[1] === 'plan/example') {
+          currentBranchByDir.set(dir, 'plan/example');
+        }
+        if (args[0] === 'checkout' && args[1] === '--detach') {
+          currentBranchByDir.set(dir, undefined);
+        }
+        if (args[0] === 'checkout' && args[1] === '-b' && args[2]) {
+          currentBranchByDir.set(dir, args[2]);
+        }
+        if (args[0] === 'branch' && args[1] === '--show-current') {
+          return currentBranchByDir.get(dir) ?? '';
+        }
+        return '';
+      };
+      (executor as any).createMergeWorktree = vi.fn()
+        .mockResolvedValueOnce(gateWorkspace)
+        .mockResolvedValueOnce(consolidateWorkspace);
+      (executor as any).removeMergeWorktree = async () => {};
+      (executor as any).startPrPolling = vi.fn();
+      (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
+        body: '## Summary\n\nAuthored body',
+        sessionId: 'sess-pr-ext',
+        agentName: 'codex',
+      });
+
+      const mergeTask = makeTask({
+        id: '__merge__wf-1',
+        status: 'running',
+        dependencies: ['t1'],
+        config: { isMergeNode: true, workflowId: 'wf-1' },
+      });
+
+      await (executor as any).executeMergeNode(mergeTask);
+
+      const gateGitCalls = gitCalls.filter(c => c.dir === gateWorkspace).map(c => c.args);
+      const fetchIndex = gateGitCalls.findIndex(args =>
+        args[0] === 'fetch' &&
+        args[1] === 'origin' &&
+        args[2] === '+refs/heads/plan/example:refs/heads/plan/example',
+      );
+      const checkoutIndex = gateGitCalls.findIndex(args =>
+        args[0] === 'checkout' &&
+        args[1] === 'plan/example',
+      );
+      expect(fetchIndex).toBeGreaterThanOrEqual(0);
+      expect(checkoutIndex).toBeGreaterThan(fetchIndex);
+      expect(currentBranchByDir.get(gateWorkspace)).toBe('plan/example');
+      expect(persistence.updateTask).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
+        execution: expect.objectContaining({
+          workspacePath: gateWorkspace,
+          branch: 'plan/example',
+        }),
+      }));
+      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
+        execution: expect.objectContaining({
+          workspacePath: gateWorkspace,
+          branch: 'plan/example',
+        }),
+      }));
+    });
+
     it('reproduces wf-1778431030512-12 visual-proof markdown in the merge-gate PR body', async () => {
       const cwd = createTempWorkspace();
       mkdirSync(join(cwd, 'scripts'), { recursive: true });

--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -91,6 +91,14 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
     if (!meta.workspacePath || !existsSync(meta.workspacePath)) {
       throw new Error(`Workspace path no longer exists for task ${meta.taskId}: ${meta.workspacePath ?? 'none'}`);
     }
+    if (meta.branch) {
+      const sh = process.platform === 'darwin' ? 'zsh' : 'bash';
+      return {
+        command: sh,
+        args: ['-c', `git checkout '${meta.branch}' 2>/dev/null; exec ${sh}`],
+        cwd: meta.workspacePath,
+      };
+    }
     return { cwd: meta.workspacePath };
   }
 

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -130,6 +130,20 @@ async function execGitInMergeSafe(
   return host.execGitIn(args, dir);
 }
 
+async function syncGateWorkspaceToFeatureBranch(
+  host: MergeRunnerHost,
+  gateWorkspacePath: string | undefined,
+  featureBranch: string,
+): Promise<void> {
+  if (!gateWorkspacePath) return;
+  await execGitInMergeSafe(
+    host,
+    ['fetch', 'origin', `+refs/heads/${featureBranch}:refs/heads/${featureBranch}`],
+    gateWorkspacePath,
+  );
+  await execGitInMergeSafe(host, ['checkout', featureBranch], gateWorkspacePath);
+}
+
 // ── Host interface ───────────────────────────────────────
 
 /**
@@ -507,6 +521,11 @@ export async function runMergeGateActionImpl(
           throw new Error('mergeMode is "external_review" but no review provider configured');
         }
 
+        // The PR branch is pushed from the separate consolidation clone above.
+        // Fetch it into the persistent gate workspace and check it out before
+        // persisting the workspace handoff used by review terminals.
+        await syncGateWorkspaceToFeatureBranch(host, gateWorkspacePath, featureBranch);
+
         let fullSummary = summary;
         let vpMarkdownCapture: string | undefined;
         if (visualProof && host.runVisualProofCapture) {
@@ -517,13 +536,6 @@ export async function runMergeGateActionImpl(
             fullSummary = (summary ?? '') + '\n\n' + vpMarkdown;
           }
         }
-
-        // Fetch the feature branch from origin into the gate clone.
-        // consolidateAndMerge() pushed it from a separate (now removed) clone.
-        await host.execGitIn(
-          ['fetch', 'origin', `+refs/heads/${featureBranch}:refs/heads/${featureBranch}`],
-          gateWorkspacePath!,
-        );
 
         // Route through shared PR-authoring helper for consistent PR bodies.
         const structuredCtx = workflowId


### PR DESCRIPTION
## Summary

Fix review-gate workspace handoff for external-review PR gates.

Root cause: the gate workspace was created from the workflow base and stayed detached there after the PR branch was fetched. The PR branch itself was created and pushed from a separate consolidation worktree, but the persistent gate workspace used for review terminals never checked that branch out.

Fix:
- Fetch and checkout the workflow feature branch in the persistent gate workspace for `external_review` merge gates before persisting/returning the workspace handoff.
- Preserve consolidation behavior: the PR branch is still created from the consolidation worktree, pushed to origin, and used for PR creation.
- Make merge-gate terminal restore defensive by checking out persisted `execution.branch` before opening the shell, while preserving cwd-only restore when no branch is stored.
- Add regression coverage for the external-review gate checkout and merge-gate terminal restore behavior.

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test -- merge` - passed
- [x] `pnpm --filter @invoker/app test -- open-terminal.test.ts` - passed
- [x] `pnpm run test:all` - passed with runner summary `Failed: 0`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 374e71b7`
- Post-revert steps: None
- Data migration? No
