### PR TITLE
Persist SSH pool member on tasks

### DIFF
--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -44,6 +44,7 @@ import {
   spawnDetachedTerminal,
 } from '../terminal-external-launch.js';
 import { openExternalTerminalForTask } from '../open-terminal-for-task.js';
+import * as configModule from '../config.js';
 
 vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
@@ -731,8 +732,13 @@ describe('SshExecutor getRestoredTerminalSpec', () => {
       getContainerId: vi.fn(() => null),
       getWorkspacePath: vi.fn(() => null),  // Missing workspace path - invariant violation!
       getBranch: vi.fn(() => 'experiment/test-branch'),
-      getPoolMemberId: vi.fn(() => null),
+      getPoolMemberId: vi.fn(() => 'remote-missing-workspace'),
     };
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: {
+        'remote-missing-workspace': { host: 'h', user: 'u', sshKeyPath: '/k' },
+      },
+    } as any);
 
     const ssh = new SshExecutor({ host: 'h', user: 'u', sshKeyPath: '/k' });
     const registry = new ExecutorRegistry();
@@ -752,6 +758,7 @@ describe('SshExecutor getRestoredTerminalSpec', () => {
     expect(result.reason).toContain('workspacePath is not set');
     expect(result.reason).toContain('Recreate the task');
     expect(result.reason).toContain('Refusing to fall back to host repo');
+    loadConfigSpy.mockRestore();
 
     // Verify no real SSH call attempted
     expect(mockPersistence.getWorkspacePath).toHaveBeenCalledWith('task-ssh-no-workspace');
@@ -767,9 +774,19 @@ describe('SshExecutor getRestoredTerminalSpec', () => {
       getContainerId: vi.fn(() => null),
       getWorkspacePath: vi.fn(() => '~/.invoker/worktrees/abc/experiment-ssh-task'),  // Has workspace!
       getBranch: vi.fn(() => 'experiment/ssh-task'),
-      getPoolMemberId: vi.fn(() => null),
+      getPoolMemberId: vi.fn(() => 'droplet-1'),
       getExecutionAgent: vi.fn(() => 'claude'),
     };
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: {
+        'droplet-1': {
+          host: 'droplet.example',
+          user: 'ubuntu',
+          sshKeyPath: '/home/user/.ssh/id_rsa',
+          port: 2222,
+        },
+      },
+    } as any);
 
     const ssh = new SshExecutor({
       host: 'droplet.example',
@@ -794,6 +811,7 @@ describe('SshExecutor getRestoredTerminalSpec', () => {
       expect(result.reason).not.toContain('requires a managed workspace');
       expect(result.reason).not.toContain('workspacePath is not set');
     }
+    loadConfigSpy.mockRestore();
 
     // Verify persistence was queried correctly
     expect(mockPersistence.getWorkspacePath).toHaveBeenCalledWith('task-ssh-with-workspace');
@@ -821,9 +839,19 @@ describe('SshExecutor getRestoredTerminalSpec', () => {
       getContainerId: vi.fn(() => null),
       getWorkspacePath: vi.fn(() => '~/.invoker/worktrees/xyz/experiment-ssh-managed-deadbeef'),
       getBranch: vi.fn(() => 'experiment/ssh-managed-deadbeef'),
-      getPoolMemberId: vi.fn(() => null),
+      getPoolMemberId: vi.fn(() => 'remote-1'),
       getExecutionAgent: vi.fn(() => 'claude'),
     };
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: {
+        'remote-1': {
+          host: 'remote.dev',
+          user: 'deployer',
+          sshKeyPath: '/home/me/.ssh/deploy_key',
+          port: 2222,
+        },
+      },
+    } as any);
 
     const ssh = new SshExecutor({
       host: 'remote.dev',
@@ -877,11 +905,70 @@ describe('SshExecutor getRestoredTerminalSpec', () => {
     // Verify no workspace invariant error
     expect(mockPersistence.getWorkspacePath).toHaveBeenCalledWith('ssh-managed-task');
     expect(mockPersistence.getBranch).toHaveBeenCalledWith('ssh-managed-task');
+    expect(mockPersistence.getPoolMemberId).toHaveBeenCalledWith('ssh-managed-task');
+    loadConfigSpy.mockRestore();
 
     // Reset only the per-test spy. Do not call vi.restoreAllMocks() — it would
     // wipe the module-level vi.mock for spawnDetachedTerminal that subsequent
     // tests rely on, causing "vi.mocked(spawnDetachedTerminal).mockClear is
     // not a function" failures in the fail-fast invariant describe block.
+    vi.mocked(terminalLaunch.spawnDetachedTerminal).mockReset();
+    vi.mocked(terminalLaunch.spawnDetachedTerminal).mockImplementation(
+      async () => ({ opened: true } as const),
+    );
+  });
+
+  it('opens completed SSH task from persisted pool member instead of host worktree lookup', async () => {
+    const mockSpawnDetached = vi.fn(
+      async (_cmd: string, _args: string[], _opts: any, _onClose: () => void) =>
+        ({ opened: true } as const),
+    );
+    const terminalLaunch = await import('../terminal-external-launch.js');
+    vi.spyOn(terminalLaunch, 'spawnDetachedTerminal').mockImplementation(mockSpawnDetached as any);
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: {
+        'remote-db': {
+          host: 'db.remote.example',
+          user: 'runner',
+          sshKeyPath: '/tmp/key',
+          port: 2222,
+        },
+      },
+    } as any);
+
+    const mockPersistence = {
+      getTaskStatus: vi.fn(() => 'completed'),
+      getRunnerKind: vi.fn(() => 'ssh'),
+      getAgentSessionId: vi.fn(() => null),
+      getContainerId: vi.fn(() => null),
+      getWorkspacePath: vi.fn(() => '~/.invoker/worktrees/xyz/experiment-db-backed'),
+      getBranch: vi.fn(() => 'experiment/db-backed'),
+      getPoolMemberId: vi.fn(() => 'remote-db'),
+      getExecutionAgent: vi.fn(() => 'claude'),
+    };
+    const registry = new ExecutorRegistry();
+    registry.register('ssh', new WorktreeExecutor({
+      worktreeBaseDir: '/tmp/wt',
+      cacheDir: '/tmp/cache',
+    }) as any);
+    vi.mocked(existsSync).mockReturnValue(false);
+
+    const result = await openExternalTerminalForTask({
+      taskId: 'ssh-db-backed-task',
+      persistence: mockPersistence as any,
+      executorRegistry: registry,
+      repoRoot: '/local/repo',
+    });
+
+    expect(result.opened).toBe(true);
+    expect(mockSpawnDetached).toHaveBeenCalledTimes(1);
+    const spawned = mockSpawnDetached.mock.calls[0];
+    expect(spawned?.[0]).toBe(process.platform === 'darwin' ? 'osascript' : 'x-terminal-emulator');
+    expect(JSON.stringify(spawned?.[1])).toContain('db.remote.example');
+    expect(JSON.stringify(spawned?.[1])).toContain('experiment/db-backed');
+    expect(existsSync).not.toHaveBeenCalledWith('~/.invoker/worktrees/xyz/experiment-db-backed');
+
+    loadConfigSpy.mockRestore();
     vi.mocked(terminalLaunch.spawnDetachedTerminal).mockReset();
     vi.mocked(terminalLaunch.spawnDetachedTerminal).mockImplementation(
       async () => ({ opened: true } as const),
@@ -1315,8 +1402,13 @@ describe('openExternalTerminalForTask fail-fast workspace invariant', () => {
       getContainerId: vi.fn(() => null),
       getWorkspacePath: vi.fn(() => null),  // Missing workspace path!
       getBranch: vi.fn(() => null),
-      getPoolMemberId: vi.fn(() => null),
+      getPoolMemberId: vi.fn(() => 'remote-missing-workspace-2'),
     };
+    const loadConfigSpy = vi.spyOn(configModule, 'loadConfig').mockReturnValue({
+      remoteTargets: {
+        'remote-missing-workspace-2': { host: 'h', user: 'u', sshKeyPath: '/k' },
+      },
+    } as any);
 
     const ssh = new SshExecutor({ host: 'h', user: 'u', sshKeyPath: '/k' });
     const registry = new ExecutorRegistry();
@@ -1332,6 +1424,7 @@ describe('openExternalTerminalForTask fail-fast workspace invariant', () => {
     expect(result.opened).toBe(false);
     expect(result.reason).toContain('workspace metadata is missing');
     expect(result.reason).toContain('Executor type "ssh" requires a managed workspace');
+    loadConfigSpy.mockRestore();
   });
 
   it('refuses host-repo fallback when docker task has no workspace path', async () => {

--- a/packages/app/src/open-terminal-for-task.ts
+++ b/packages/app/src/open-terminal-for-task.ts
@@ -193,10 +193,26 @@ export function resolveTaskTerminalSpec(
     `meta from DB: runnerKind=${repairedMeta.runnerKind} workspacePath=${repairedMeta.workspacePath ?? 'undefined'} branch=${repairedMeta.branch ?? 'undefined'} agentSessionId=${repairedMeta.agentSessionId ?? 'undefined'} executionAgent=${repairedMeta.executionAgent ?? 'undefined'} containerId=${repairedMeta.containerId ?? 'undefined'}`,
   );
 
-  let executor = executorRegistry.get(repairedMeta.runnerKind);
+  let executor = repairedMeta.runnerKind === 'ssh' ? undefined : executorRegistry.get(repairedMeta.runnerKind);
   termLogger?.info(`executorRegistry.get("${repairedMeta.runnerKind}") → ${executor ? executor.type : 'null (will lazy-create)'}`);
 
-  if (!executor) {
+  if (repairedMeta.runnerKind === 'ssh') {
+    const targetId = persistence.getPoolMemberId?.(taskId)?.trim();
+    const target = targetId ? loadConfig().remoteTargets?.[targetId] : undefined;
+    if (!targetId) {
+      return {
+        ok: false,
+        reason: `Cannot open terminal for SSH task "${taskId}": pool member metadata is missing.`,
+      };
+    }
+    if (!target) {
+      return {
+        ok: false,
+        reason: `Cannot open terminal for SSH task "${taskId}": remote target "${targetId}" is not configured.`,
+      };
+    }
+    executor = new SshExecutor({ ...target, agentRegistry: opts.executionAgentRegistry });
+  } else if (!executor) {
     if (repairedMeta.runnerKind === 'docker') {
       const docker = new DockerExecutor({
         agentRegistry: opts.executionAgentRegistry,
@@ -214,12 +230,6 @@ export function resolveTaskTerminalSpec(
       });
       executorRegistry.register('worktree', worktree);
       executor = worktree;
-    } else if (repairedMeta.runnerKind === 'ssh') {
-      const targetId = persistence.getPoolMemberId?.(taskId);
-      const target = targetId ? loadConfig().remoteTargets?.[targetId] : undefined;
-      executor = target
-        ? new SshExecutor({ ...target, agentRegistry: opts.executionAgentRegistry })
-        : executorRegistry.getDefault();
     } else {
       executor = executorRegistry.getDefault();
     }

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -115,6 +115,23 @@ describe('SQLiteAdapter', () => {
       expect(loaded[0].status).toBe('pending');
     });
 
+    it('persists poolMemberId through updateTask and getPoolMemberId', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('ssh-task', {
+        config: { runnerKind: 'ssh' },
+      }));
+
+      adapter.updateTask('ssh-task', {
+        config: { poolMemberId: 'remote-1' },
+      });
+
+      expect(adapter.getPoolMemberId('ssh-task')).toBe('remote-1');
+      expect(adapter.loadTask('ssh-task')?.config).toMatchObject({
+        runnerKind: 'ssh',
+        poolMemberId: 'remote-1',
+      });
+    });
+
     it('loads all workflows and tasks in one startup snapshot', () => {
       const wf2: Workflow = {
         ...testWorkflow,
@@ -1793,6 +1810,7 @@ describe('SQLiteAdapter', () => {
         normalizedMergeModes: 1,
         staleAutoFixExperimentTasks: 2,
         normalizedStaleLaunchMetadata: 0,
+        backfilledMissingSshPoolMemberIds: 0,
       });
       const taskById = new Map(adapter.loadTasks('wf-1').map((task) => [task.id, task]));
       expect(adapter.loadWorkflow('wf-1')?.mergeMode).toBe('external_review');
@@ -1808,7 +1826,42 @@ describe('SQLiteAdapter', () => {
         normalizedMergeModes: 0,
         staleAutoFixExperimentTasks: 0,
         normalizedStaleLaunchMetadata: 0,
+        backfilledMissingSshPoolMemberIds: 0,
       });
+    });
+
+    it('repairs missing SSH pool member ids from the latest executor-selected event', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('ssh-old', {
+        status: 'completed',
+        config: { runnerKind: 'ssh' },
+        execution: { workspacePath: '~/.invoker/worktrees/ssh-old', branch: 'experiment/ssh-old' },
+      }));
+      adapter.logEvent('ssh-old', 'task.executor.selected', { runnerKind: 'ssh', poolMemberId: 'remote-old' });
+      adapter.logEvent('ssh-old', 'task.executor.selected', { runnerKind: 'ssh', poolMemberId: 'remote-new' });
+
+      const report = adapter.runCompatibilityMigration();
+
+      expect(report.backfilledMissingSshPoolMemberIds).toBe(1);
+      expect(adapter.getPoolMemberId('ssh-old')).toBe('remote-new');
+      expect(adapter.loadTask('ssh-old')?.config).toMatchObject({ runnerKind: 'ssh', poolMemberId: 'remote-new' });
+      expect(adapter.runCompatibilityMigration().backfilledMissingSshPoolMemberIds).toBe(0);
+    });
+
+    it('does not repair missing SSH pool member ids from malformed or empty event payloads', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('ssh-empty', { config: { runnerKind: 'ssh' } }));
+      adapter.logEvent('ssh-empty', 'task.executor.selected', { runnerKind: 'ssh', poolMemberId: '  ' });
+      adapter.saveTask('wf-1', makeTask('ssh-bad', { config: { runnerKind: 'ssh' } }));
+      (adapter as any).db.run(
+        `INSERT INTO events (task_id, event_type, payload) VALUES ('ssh-bad', 'task.executor.selected', '{')`,
+      );
+
+      const report = adapter.runCompatibilityMigration();
+
+      expect(report.backfilledMissingSshPoolMemberIds).toBe(0);
+      expect(adapter.getPoolMemberId('ssh-empty')).toBeNull();
+      expect(adapter.getPoolMemberId('ssh-bad')).toBeNull();
     });
 
     it('normalizes stale terminal launch metadata without touching legitimate long executions', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -382,12 +382,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
     normalizedMergeModes: number;
     staleAutoFixExperimentTasks: number;
     normalizedStaleLaunchMetadata: number;
+    backfilledMissingSshPoolMemberIds: number;
   } {
     const report = {
       migratedFixingWithAiStatuses: 0,
       normalizedMergeModes: 0,
       staleAutoFixExperimentTasks: 0,
       normalizedStaleLaunchMetadata: 0,
+      backfilledMissingSshPoolMemberIds: 0,
     };
     this.runTransaction(() => {
       this.db.run(
@@ -455,8 +457,52 @@ export class SQLiteAdapter implements PersistenceAdapter {
            AND (julianday(started_at) - julianday(launch_started_at)) * 86400.0 > 3600.0`,
       );
       report.normalizedStaleLaunchMetadata = this.db.getRowsModified();
+
+      // One-time compatibility backfill for SSH tasks created before
+      // pool_member_id was durably written to tasks. Runtime routing must use
+      // tasks.pool_member_id; this audit-event fallback is migration-only and
+      // can be deleted after old databases no longer need the backfill.
+      const missingSshPoolRows = this.queryAll(
+        `SELECT t.id, e.payload
+         FROM tasks t
+         JOIN events e ON e.id = (
+           SELECT MAX(id)
+           FROM events
+           WHERE task_id = t.id
+             AND event_type = 'task.executor.selected'
+         )
+         WHERE t.runner_kind = 'ssh'
+           AND (t.pool_member_id IS NULL OR TRIM(t.pool_member_id) = '')
+           AND e.payload IS NOT NULL`,
+      ) as Array<{ id: string; payload?: string | null }>;
+      for (const row of missingSshPoolRows) {
+        const poolMemberId = this.parseExecutorSelectedPoolMemberId(row.payload);
+        if (!poolMemberId) continue;
+        this.db.run(
+          `UPDATE tasks
+           SET pool_member_id = ?,
+               task_state_version = task_state_version + 1
+           WHERE id = ?
+             AND runner_kind = 'ssh'
+             AND (pool_member_id IS NULL OR TRIM(pool_member_id) = '')`,
+          [poolMemberId, row.id],
+        );
+        report.backfilledMissingSshPoolMemberIds += this.db.getRowsModified();
+      }
     });
     return report;
+  }
+
+  private parseExecutorSelectedPoolMemberId(payload: string | null | undefined): string | undefined {
+    if (!payload) return undefined;
+    try {
+      const parsed = JSON.parse(payload) as { poolMemberId?: unknown };
+      return typeof parsed.poolMemberId === 'string' && parsed.poolMemberId.trim()
+        ? parsed.poolMemberId.trim()
+        : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   checkpointWal(mode: 'PASSIVE' | 'FULL' | 'RESTART' | 'TRUNCATE' = 'PASSIVE'): void {

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -8171,6 +8171,7 @@ console.log(JSON.stringify(out));
         branch: 'experiment/task-1',
       });
       const logEvent = vi.fn();
+      const updateTask = vi.fn();
       const task = makeTask({
         id: 'task-1',
         status: 'pending',
@@ -8180,7 +8181,7 @@ console.log(JSON.stringify(out));
 
       const runner = new TaskRunner({
         orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse: vi.fn() } as any,
-        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent } as any,
+        persistence: { updateTask, updateAttempt: vi.fn(), logEvent } as any,
         executorRegistry: {
           getDefault: () => sshExecutor,
           get: (type: string) => type === 'ssh' ? sshExecutor : null,
@@ -8224,6 +8225,13 @@ console.log(JSON.stringify(out));
       const selectedPayload = logEvent.mock.calls.find((call) => call[1] === 'task.executor.selected')?.[2];
       expect(JSON.stringify(selectedPayload)).not.toContain('sshKeyPath');
       expect(JSON.stringify(selectedPayload)).not.toContain('/secret/key');
+      expect(updateTask).toHaveBeenCalledWith('task-1', {
+        config: { runnerKind: 'ssh', poolMemberId: 'remote-a' },
+        execution: expect.objectContaining({
+          workspacePath: '/remote/worktrees/task-1',
+          branch: 'experiment/task-1',
+        }),
+      });
     });
 
     it('logs explicit SSH executor selection as explicitPoolMemberId', async () => {
@@ -8522,6 +8530,61 @@ console.log(JSON.stringify(out));
           }),
         }),
       );
+    });
+
+    it('persists pool-routed SSH target on error path when executor.start throws', async () => {
+      const failingExecutor = {
+        type: 'ssh',
+        start: vi.fn().mockRejectedValue(Object.assign(new Error('SSH startup failed'), {
+          workspacePath: '~/.invoker/worktrees/ci/task-failed',
+          branch: 'experiment/task-failed',
+        })),
+        onComplete: vi.fn(),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+        destroyAll: vi.fn(),
+      };
+      const task = makeTask({
+        id: 'task-failed-pool',
+        status: 'pending',
+        config: { command: 'echo test', runnerKind: 'ssh', poolId: 'ci-pool' },
+      });
+      const updateTask = vi.fn();
+
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: () => task,
+          getAllTasks: () => [task],
+          handleWorkerResponse: vi.fn(),
+        } as any,
+        persistence: { updateTask } as any,
+        executorRegistry: {
+          getDefault: () => failingExecutor,
+          get: () => failingExecutor,
+          getAll: () => [failingExecutor],
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          'ci-pool': {
+            selectionStrategy: 'leastLoaded',
+            members: [{ type: 'ssh', id: 'remote-a' }],
+          },
+        }),
+        remoteTargetsProvider: () => ({
+          'remote-a': { host: 'ci.example.com', user: 'runner', sshKeyPath: '/secret/key' },
+        }),
+      });
+
+      await runner.executeTask(task);
+
+      expect(updateTask).toHaveBeenCalledWith('task-failed-pool', {
+        config: { runnerKind: 'ssh', poolMemberId: 'remote-a' },
+        execution: {
+          workspacePath: '~/.invoker/worktrees/ci/task-failed',
+          branch: 'experiment/task-failed',
+        },
+      });
     });
 
     it('persists attempt.branch via onBranchResolved when executor crashes mid-acquire', async () => {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -702,7 +702,6 @@ export class TaskRunner {
         }),
       ]);
     } catch (err) {
-      this.pendingPoolSelections.delete(task.id);
       const meta = err as StartupFailureMetadata;
       const startupErrorMessage = `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}\n`;
       this.callbacks.onOutput?.(task.id, startupErrorMessage);
@@ -727,11 +726,19 @@ export class TaskRunner {
           execution.lastAgentSessionId = meta.agentSessionId;
         }
         if (meta.containerId) execution.containerId = meta.containerId;
+        const poolSelection = this.pendingPoolSelections.get(task.id);
+        const selectedSshTargetId = executor.type === 'ssh'
+          ? this.selectedRemoteTargetId(task, poolSelection)
+          : undefined;
         this.persistence.updateTask(task.id, {
-          config: { runnerKind: executor.type as RunnerKind },
+          config: {
+            runnerKind: executor.type as RunnerKind,
+            ...(selectedSshTargetId ? { poolMemberId: selectedSshTargetId } : {}),
+          },
           execution: execution as any,
         });
       }
+      this.pendingPoolSelections.delete(task.id);
       const wrapped = new Error(
         `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}`,
         { cause: err },


### PR DESCRIPTION
## Summary

Persist the selected SSH pool member on the task row so completed SSH tasks can reopen terminals from durable task metadata instead of audit events.

- Write `config.poolMemberId` alongside `runnerKind`, `workspacePath`, and branch metadata for successful and startup-failed SSH launches.
- Backfill missing `tasks.pool_member_id` for old SSH rows from the latest valid `task.executor.selected` audit event during compatibility migration.
- Make open-terminal rebuild completed SSH terminal specs from `getPoolMemberId(taskId)` and configured remote targets, avoiding host worktree path checks for remote workspaces.

## Architecture

### Before

```mermaid
graph TD
    Launch[TaskRunner SSH launch] --> Event[Audit event with poolMemberId]
    Launch --> TaskRow[Task row runner/workspace/branch]
    Open[Open terminal for completed task] --> Registry[Executor registry/default]
    Registry --> Local[May use WorktreeExecutor host path checks]
    Event -. used by repair/manual inference .-> Open
```

### After

```mermaid
graph TD
    Launch[TaskRunner SSH launch] --> TaskRow[Task row runner/workspace/branch/pool_member_id]
    Launch --> Event[Audit event]
    Repair[Compatibility migration] --> TaskRow
    Event -. old rows only .-> Repair
    Open[Open terminal for completed task] --> PoolId[getPoolMemberId taskId]
    PoolId --> SSH[SshExecutor for configured remote target]
```

## Test Plan

- [x] `pnpm --dir packages/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/task-runner.test.ts`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/open-terminal.test.ts`
- [x] `pnpm run check:types`
- [x] `bash scripts/test-suites/required/19-task-new-attempt-reset-repro.sh`
- [ ] `pnpm run test:all` attempted; required `19-task-new-attempt-reset-repro.sh` timed out once at 120s during the full run, then passed when rerun directly.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: Recreate or repair affected SSH tasks if completed remote terminals need to be reopened.
- Data migration? No schema change; the compatibility backfill is idempotent task-row data repair.
