### PR TITLE
Add headless conflict heatmap query

### DIFF
--- a/packages/app/src/__tests__/conflict-heatmap.test.ts
+++ b/packages/app/src/__tests__/conflict-heatmap.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+import { buildConflictHeatmap } from '../conflict-heatmap.js';
+import { formatConflictHeatmap, serializeConflictHeatmapRow } from '../formatter.js';
+
+function task(id: string, workflowId: string, conflictFiles: string[], createdAt: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'failed',
+    dependencies: [],
+    createdAt: new Date(createdAt),
+    config: { workflowId },
+    execution: {
+      mergeConflict: {
+        failedBranch: `branch/${id}`,
+        conflictFiles,
+      },
+    },
+  } as TaskState;
+}
+
+describe('conflict heatmap', () => {
+  it('ranks conflict files across workflows', () => {
+    const rows = buildConflictHeatmap({
+      listWorkflows: () => [{ id: 'wf-1' }, { id: 'wf-2' }],
+      loadTasks: (workflowId) => workflowId === 'wf-1'
+        ? [
+            task('wf-1/a', 'wf-1', ['packages/app/src/main.ts', 'README.md'], '2026-01-01T00:00:00Z'),
+            task('wf-1/b', 'wf-1', ['packages/app/src/main.ts'], '2026-01-02T00:00:00Z'),
+          ]
+        : [
+            task('wf-2/c', 'wf-2', ['packages/app/src/headless.ts'], '2026-01-03T00:00:00Z'),
+          ],
+    });
+
+    expect(rows[0]).toEqual({
+      file: 'packages/app/src/main.ts',
+      count: 2,
+      workflowIds: ['wf-1'],
+      taskIds: ['wf-1/a', 'wf-1/b'],
+      latestTaskId: 'wf-1/b',
+    });
+    expect(rows.map(row => row.file)).toEqual([
+      'packages/app/src/main.ts',
+      'packages/app/src/headless.ts',
+      'README.md',
+    ]);
+  });
+
+  it('formats text and JSON-safe rows', () => {
+    const row = {
+      file: 'packages/app/src/main.ts',
+      count: 2,
+      workflowIds: ['wf-1'],
+      taskIds: ['wf-1/a', 'wf-1/b'],
+      latestTaskId: 'wf-1/b',
+    };
+
+    expect(formatConflictHeatmap([row])).toContain('packages/app/src/main.ts');
+    expect(serializeConflictHeatmapRow(row)).toEqual(row);
+  });
+});

--- a/packages/app/src/conflict-heatmap.ts
+++ b/packages/app/src/conflict-heatmap.ts
@@ -1,0 +1,78 @@
+import type { TaskState } from '@invoker/workflow-core';
+
+export interface ConflictHeatmapRow {
+  file: string;
+  count: number;
+  workflowIds: string[];
+  taskIds: string[];
+  latestTaskId: string;
+}
+
+export interface ConflictHeatmapWorkflow {
+  id: string;
+}
+
+export interface ConflictHeatmapPersistence {
+  listWorkflows(): ConflictHeatmapWorkflow[];
+  loadTasks(workflowId: string): TaskState[];
+}
+
+export function buildConflictHeatmap(persistence: ConflictHeatmapPersistence): ConflictHeatmapRow[] {
+  const rows = new Map<string, {
+    count: number;
+    workflowIds: Set<string>;
+    taskIds: Set<string>;
+    latestTaskId: string;
+    latestTime: number;
+  }>();
+
+  for (const workflow of persistence.listWorkflows()) {
+    for (const task of persistence.loadTasks(workflow.id)) {
+      const mergeConflict = task.execution.mergeConflict;
+      if (!mergeConflict) continue;
+
+      const completedAt = task.execution.completedAt;
+      const startedAt = task.execution.startedAt;
+      const timestamp = completedAt instanceof Date
+        ? completedAt.getTime()
+        : typeof completedAt === 'string'
+          ? Date.parse(completedAt)
+          : startedAt instanceof Date
+            ? startedAt.getTime()
+            : typeof startedAt === 'string'
+              ? Date.parse(startedAt)
+              : task.createdAt instanceof Date
+                ? task.createdAt.getTime()
+                : Date.parse(String(task.createdAt));
+      const effectiveTime = Number.isFinite(timestamp) ? timestamp : 0;
+
+      for (const file of mergeConflict.conflictFiles) {
+        const existing = rows.get(file) ?? {
+          count: 0,
+          workflowIds: new Set<string>(),
+          taskIds: new Set<string>(),
+          latestTaskId: task.id,
+          latestTime: effectiveTime,
+        };
+        existing.count += 1;
+        existing.workflowIds.add(workflow.id);
+        existing.taskIds.add(task.id);
+        if (effectiveTime >= existing.latestTime) {
+          existing.latestTime = effectiveTime;
+          existing.latestTaskId = task.id;
+        }
+        rows.set(file, existing);
+      }
+    }
+  }
+
+  return [...rows.entries()]
+    .map(([file, row]) => ({
+      file,
+      count: row.count,
+      workflowIds: [...row.workflowIds].sort(),
+      taskIds: [...row.taskIds].sort(),
+      latestTaskId: row.latestTaskId,
+    }))
+    .sort((a, b) => b.count - a.count || a.file.localeCompare(b.file));
+}

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -8,6 +8,7 @@ import type { TaskState, TaskStatus } from '@invoker/workflow-core';
 import type { TaskEvent, Workflow } from '@invoker/data-store';
 import type { NormalizedCostEvent, CostRollup } from '@invoker/contracts';
 import type { GroupedCostRollup } from './cost-rollup.js';
+import type { ConflictHeatmapRow } from './conflict-heatmap.js';
 
 // ── ANSI Color Codes ─────────────────────────────────────────
 
@@ -237,6 +238,31 @@ export function formatWorkflowStats(stats: {
   }
 
   return lines.join('\n');
+}
+
+export function formatConflictHeatmap(rows: ConflictHeatmapRow[]): string {
+  if (rows.length === 0) {
+    return `${DIM}No merge conflicts recorded.${RESET}`;
+  }
+
+  const lines = [`${BOLD}Conflict heatmap${RESET}`];
+  for (const row of rows) {
+    lines.push(
+      `  ${RED}${row.count}x${RESET} ${BOLD}${row.file}${RESET} ${DIM}` +
+      `[workflows: ${row.workflowIds.length}, latest: ${row.latestTaskId}]${RESET}`,
+    );
+  }
+  return lines.join('\n');
+}
+
+export function serializeConflictHeatmapRow(row: ConflictHeatmapRow): Record<string, unknown> {
+  return {
+    file: row.file,
+    count: row.count,
+    workflowIds: row.workflowIds,
+    taskIds: row.taskIds,
+    latestTaskId: row.latestTaskId,
+  };
 }
 
 // ── Output Format Type ──────────────────────────────────────

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -378,14 +378,14 @@ export function parseQueryFlags(args: string[]): QueryFlags {
 async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|audit|session|cost|cost-events|costs|ui-perf|stats>');
+    throw new Error('Missing query sub-command. Usage: --headless query <workflows|tasks|task|queue|audit|session|conflicts|cost|cost-events|costs|ui-perf|stats>');
   }
   const flags = parseQueryFlags(args.slice(1));
 
   const {
     formatWorkflowList, formatTaskStatus, formatWorkflowStatus,
-    formatEventLog, formatQueueStatus, formatWorkflowStats,
-    serializeWorkflow, serializeTask, serializeEvent,
+    formatEventLog, formatQueueStatus, formatWorkflowStats, formatConflictHeatmap,
+    serializeWorkflow, serializeTask, serializeEvent, serializeConflictHeatmapRow,
     formatAsLabel, formatAsJson, formatAsJsonl,
   } = await import('./formatter.js');
 
@@ -505,6 +505,17 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
       }
       break;
     }
+    case 'conflicts': {
+      const { buildConflictHeatmap } = await import('./conflict-heatmap.js');
+      const rows = buildConflictHeatmap(deps.persistence);
+      switch (flags.output) {
+        case 'label': process.stdout.write(rows.map(row => row.file).join('\n') + '\n'); break;
+        case 'json':  process.stdout.write(formatAsJson(rows.map(serializeConflictHeatmapRow)) + '\n'); break;
+        case 'jsonl': process.stdout.write(formatAsJsonl(rows.map(serializeConflictHeatmapRow)) + '\n'); break;
+        default:      process.stdout.write(formatConflictHeatmap(rows) + '\n'); break;
+      }
+      break;
+    }
     case 'session': {
       const taskId = flags.positional[0];
       if (!taskId) throw new Error('Usage: --headless query session <taskId>');
@@ -610,7 +621,7 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
       break;
     }
     default:
-      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, cost, cost-events, costs, ui-perf, stats`);
+      throw new Error(`Unknown query sub-command: "${subCommand}". Use: workflows, tasks, task, queue, audit, session, conflicts, cost, cost-events, costs, ui-perf, stats`);
   }
 }
 
@@ -1122,6 +1133,7 @@ ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
   query queue [--output F]                            Show queue status
   query audit <taskId> [--output F]                   Print event history
   query session <taskId>                              Print agent session messages
+  query conflicts [--output F]                        Rank files seen in merge conflicts
   query ui-perf [--output F] [--reset]               Print live UI perf stats
   query stats [--output F]                           Aggregate stats across all workflows
 


### PR DESCRIPTION
## Summary

Add `invoker query conflicts` to rank files observed in persisted merge-conflict task state, giving a cheap conflict heatmap without a schema migration.

Depends-On: #735

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/conflict-heatmap.test.ts src/__tests__/headless-command-classification.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-command-classification.test.ts src/__tests__/headless-watch.test.ts src/__tests__/conflict-heatmap.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 57d16599`
- Post-revert steps: None
- Data migration? No
