### PR TITLE
Add review-gate CI metadata plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Minimal example:
   "maxConcurrency": 6,
   "autoFixRetries": 3,
   "autoFixAgent": "claude",
+  "autoFixCi": false,
   "remoteTargets": {
     "staging-a": {
       "host": "203.0.113.10",

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -79,6 +79,7 @@
 
   "autoFixRetries": 3,
   "autoApproveAIFixes": true,
+  "autoFixCi": false,
 
   "notes": {
     "fetch_behavior": "Git fetch failures always abort the task. Fix the underlying network/auth issue and rerun.",

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -111,6 +111,15 @@ describe('loadConfig', () => {
     expect(config.autoFixAgent).toBe('codex');
   });
 
+  it('reads autoFixCi from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ autoFixCi: true }),
+    );
+    const config = loadConfig();
+    expect(config.autoFixCi).toBe(true);
+  });
+
   it('loadConfig picks up browser field', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -44,6 +44,13 @@ export interface InvokerConfig {
    */
   autoFixAgent?: string;
   /**
+   * When true, failed CI checks on Invoker-created review-gate PRs can
+   * trigger the same auto-fix recovery flow used for task failures.
+   *
+   * Default: false.
+   */
+  autoFixCi?: boolean;
+  /**
    * Read-only diagnostics tuning for the Action Graph view.
    * Default stall threshold: 60000ms. Env fallback:
    * INVOKER_ACTION_STALL_THRESHOLD_MS.

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -338,5 +338,69 @@ describe('GitHubMergeGateProvider', () => {
       expect(result.closed).toBe(true);
       expect(result.statusText).toBe('Closed');
     });
+
+    it('returns PR head metadata and failed checks for review-gate auto-fix', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/4',
+            headRefOid: 'abc123',
+            headRefName: 'feature/red-ci',
+            mergeStateStatus: 'CLEAN',
+            statusCheckRollup: [
+              {
+                __typename: 'StatusContext',
+                context: 'invoker/fake-ci',
+                state: 'FAILURE',
+                targetUrl: 'https://github.com/owner/repo/pull/4',
+                description: 'Fixture failed',
+              },
+              {
+                name: 'test-all',
+                status: 'COMPLETED',
+                conclusion: 'FAILURE',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/1',
+                summary: 'Tests failed',
+              },
+              {
+                name: 'lint',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+              },
+            ],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '4', cwd: '/tmp/repo' });
+
+      expect(result.headSha).toBe('abc123');
+      expect(result.headRef).toBe('feature/red-ci');
+      expect(result.mergeState).toBe('clean');
+      expect(result.checks).toEqual({
+        state: 'failure',
+        failed: [
+          {
+            name: 'invoker/fake-ci',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/owner/repo/pull/4',
+            summary: 'Fixture failed',
+          },
+          {
+            name: 'test-all',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/owner/repo/actions/runs/1',
+            summary: 'Tests failed',
+          },
+        ],
+      });
+    });
   });
 });

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -1,6 +1,11 @@
 import { spawn } from 'node:child_process';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
-import type { MergeGateProvider, MergeGateProviderResult, MergeGateApprovalStatus } from './merge-gate-provider.js';
+import type {
+  MergeGateProvider,
+  MergeGateProviderResult,
+  MergeGateApprovalStatus,
+  MergeGateFailedCheck,
+} from './merge-gate-provider.js';
 import { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
 
 export class GitHubMergeGateProvider implements MergeGateProvider {
@@ -90,13 +95,17 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     const stdout = await this.exec('gh', [
       'pr', 'view', identifier,
       '--repo', targetRepo,
-      '--json', 'state,reviewDecision,url',
+      '--json', 'state,reviewDecision,url,headRefOid,headRefName,mergeStateStatus,statusCheckRollup',
     ], cwd);
 
     const data = JSON.parse(stdout) as {
       state: string;
       reviewDecision: string | null;
       url: string;
+      headRefOid?: string;
+      headRefName?: string;
+      mergeStateStatus?: string;
+      statusCheckRollup?: unknown[];
     };
 
     const approved = data.state === 'MERGED';
@@ -122,6 +131,10 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       closed,
       statusText,
       url: data.url,
+      headSha: data.headRefOid,
+      headRef: data.headRefName,
+      mergeState: normalizeMergeState(data.mergeStateStatus),
+      checks: summarizeStatusChecks(data.statusCheckRollup),
     };
   }
 
@@ -167,4 +180,73 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       });
     });
   }
+}
+
+function normalizeMergeState(value: string | undefined): 'clean' | 'dirty' | 'unknown' {
+  switch (value) {
+    case 'CLEAN':
+    case 'HAS_HOOKS':
+    case 'UNSTABLE':
+      return 'clean';
+    case 'DIRTY':
+    case 'BLOCKED':
+    case 'BEHIND':
+      return 'dirty';
+    default:
+      return 'unknown';
+  }
+}
+
+function stringProp(value: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return undefined;
+}
+
+function summarizeStatusChecks(items: unknown[] | undefined): MergeGateApprovalStatus['checks'] {
+  if (!Array.isArray(items) || items.length === 0) return undefined;
+
+  let hasPending = false;
+  const failed: MergeGateFailedCheck[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const check = item as Record<string, unknown>;
+    const name = stringProp(check, 'name', 'workflowName', 'context') ?? 'unknown check';
+    const status = stringProp(check, 'status')?.toUpperCase();
+    const conclusion = stringProp(check, 'conclusion')?.toUpperCase();
+    const state = stringProp(check, 'state')?.toUpperCase();
+    if (state) {
+      if (state === 'PENDING' || state === 'EXPECTED') {
+        hasPending = true;
+        continue;
+      }
+      if (state !== 'SUCCESS') {
+        failed.push({
+          name,
+          conclusion: state,
+          detailsUrl: stringProp(check, 'detailsUrl', 'targetUrl'),
+          summary: stringProp(check, 'summary', 'description'),
+        });
+      }
+      continue;
+    }
+    if (status && status !== 'COMPLETED') {
+      hasPending = true;
+      continue;
+    }
+    if (conclusion && conclusion !== 'SUCCESS' && conclusion !== 'SKIPPED' && conclusion !== 'NEUTRAL') {
+      failed.push({
+        name,
+        conclusion,
+        detailsUrl: stringProp(check, 'detailsUrl', 'targetUrl'),
+        summary: stringProp(check, 'summary', 'description'),
+      });
+    }
+  }
+
+  if (failed.length > 0) return { state: 'failure', failed };
+  if (hasPending) return { state: 'pending', failed: [] };
+  return { state: 'success', failed: [] };
 }

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -9,6 +9,20 @@ export interface MergeGateApprovalStatus {
   closed?: boolean;
   statusText: string;
   url: string;
+  headSha?: string;
+  headRef?: string;
+  mergeState?: 'clean' | 'dirty' | 'unknown';
+  checks?: {
+    state: 'pending' | 'success' | 'failure';
+    failed: MergeGateFailedCheck[];
+  };
+}
+
+export interface MergeGateFailedCheck {
+  name: string;
+  conclusion?: string;
+  detailsUrl?: string;
+  summary?: string;
 }
 
 export interface MergeGateProvider {


### PR DESCRIPTION
## Summary

Stack part 1 of 4 for review-gate CI auto-fix.

This PR adds the data and config plumbing needed before any auto-fix behavior is enabled:

- Adds `autoFixCi` to Invoker config, defaulting off unless explicitly set.
- Documents the flag in the config example and README snippet.
- Extends merge-gate approval status with PR head metadata, merge state, and normalized failed-check details.
- Teaches the GitHub merge-gate provider to summarize both CheckRun-style rollups and commit `StatusContext` failures.

This is intentionally passive plumbing. It does not start fixes by itself.

## Test Plan

- [x] `pnpm exec tsc -p tsconfig.typecheck.json --noEmit`
- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/github-merge-gate-provider.test.ts`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/config.test.ts src/__tests__/workflow-actions.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert abc651fa`
- Post-revert steps: None
- Data migration? No
