### PR TITLE
Trigger CI autofix from review-gate polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Minimal example:
   "maxConcurrency": 6,
   "autoFixRetries": 3,
   "autoFixAgent": "claude",
+  "autoFixCi": false,
   "remoteTargets": {
     "staging-a": {
       "host": "203.0.113.10",

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -79,6 +79,7 @@
 
   "autoFixRetries": 3,
   "autoApproveAIFixes": true,
+  "autoFixCi": false,
 
   "notes": {
     "fetch_behavior": "Git fetch failures always abort the task. Fix the underlying network/auth issue and rerun.",

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -111,6 +111,15 @@ describe('loadConfig', () => {
     expect(config.autoFixAgent).toBe('codex');
   });
 
+  it('reads autoFixCi from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ autoFixCi: true }),
+    );
+    const config = loadConfig();
+    expect(config.autoFixCi).toBe(true);
+  });
+
   it('loadConfig picks up browser field', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -44,6 +44,13 @@ export interface InvokerConfig {
    */
   autoFixAgent?: string;
   /**
+   * When true, failed CI checks on Invoker-created review-gate PRs can
+   * trigger the same auto-fix recovery flow used for task failures.
+   *
+   * Default: false.
+   */
+  autoFixCi?: boolean;
+  /**
    * Read-only diagnostics tuning for the Action Graph view.
    * Default stall threshold: 60000ms. Env fallback:
    * INVOKER_ACTION_STALL_THRESHOLD_MS.

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -338,5 +338,69 @@ describe('GitHubMergeGateProvider', () => {
       expect(result.closed).toBe(true);
       expect(result.statusText).toBe('Closed');
     });
+
+    it('returns PR head metadata and failed checks for review-gate auto-fix', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/4',
+            headRefOid: 'abc123',
+            headRefName: 'feature/red-ci',
+            mergeStateStatus: 'CLEAN',
+            statusCheckRollup: [
+              {
+                __typename: 'StatusContext',
+                context: 'invoker/fake-ci',
+                state: 'FAILURE',
+                targetUrl: 'https://github.com/owner/repo/pull/4',
+                description: 'Fixture failed',
+              },
+              {
+                name: 'test-all',
+                status: 'COMPLETED',
+                conclusion: 'FAILURE',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/1',
+                summary: 'Tests failed',
+              },
+              {
+                name: 'lint',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+              },
+            ],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '4', cwd: '/tmp/repo' });
+
+      expect(result.headSha).toBe('abc123');
+      expect(result.headRef).toBe('feature/red-ci');
+      expect(result.mergeState).toBe('clean');
+      expect(result.checks).toEqual({
+        state: 'failure',
+        failed: [
+          {
+            name: 'invoker/fake-ci',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/owner/repo/pull/4',
+            summary: 'Fixture failed',
+          },
+          {
+            name: 'test-all',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/owner/repo/actions/runs/1',
+            summary: 'Tests failed',
+          },
+        ],
+      });
+    });
   });
 });

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -465,6 +465,7 @@ export async function fixWithAgentImpl(
   taskOutput: string,
   agentName?: string,
   savedError?: string,
+  fixContext?: string,
 ): Promise<void> {
   host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
     phase: 'fix-with-agent-start',
@@ -481,7 +482,10 @@ export async function fixWithAgentImpl(
   const taskForPrompt = savedError
     ? { ...task, execution: { ...task.execution, error: savedError } }
     : task;
-  const prompt = buildFixPrompt(taskForPrompt, taskOutput);
+  const basePrompt = buildFixPrompt(taskForPrompt, taskOutput);
+  const prompt = fixContext?.trim()
+    ? `${basePrompt}\n\nAdditional fix context:\n${fixContext.trim()}`
+    : basePrompt;
   const workspacePath = task.execution.workspacePath;
 
   // SSH tasks: run agent on the remote host

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -1,6 +1,11 @@
 import { spawn } from 'node:child_process';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
-import type { MergeGateProvider, MergeGateProviderResult, MergeGateApprovalStatus } from './merge-gate-provider.js';
+import type {
+  MergeGateProvider,
+  MergeGateProviderResult,
+  MergeGateApprovalStatus,
+  MergeGateFailedCheck,
+} from './merge-gate-provider.js';
 import { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
 
 export class GitHubMergeGateProvider implements MergeGateProvider {
@@ -90,13 +95,17 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     const stdout = await this.exec('gh', [
       'pr', 'view', identifier,
       '--repo', targetRepo,
-      '--json', 'state,reviewDecision,url',
+      '--json', 'state,reviewDecision,url,headRefOid,headRefName,mergeStateStatus,statusCheckRollup',
     ], cwd);
 
     const data = JSON.parse(stdout) as {
       state: string;
       reviewDecision: string | null;
       url: string;
+      headRefOid?: string;
+      headRefName?: string;
+      mergeStateStatus?: string;
+      statusCheckRollup?: unknown[];
     };
 
     const approved = data.state === 'MERGED';
@@ -122,6 +131,10 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       closed,
       statusText,
       url: data.url,
+      headSha: data.headRefOid,
+      headRef: data.headRefName,
+      mergeState: normalizeMergeState(data.mergeStateStatus),
+      checks: summarizeStatusChecks(data.statusCheckRollup),
     };
   }
 
@@ -167,4 +180,73 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       });
     });
   }
+}
+
+function normalizeMergeState(value: string | undefined): 'clean' | 'dirty' | 'unknown' {
+  switch (value) {
+    case 'CLEAN':
+    case 'HAS_HOOKS':
+    case 'UNSTABLE':
+      return 'clean';
+    case 'DIRTY':
+    case 'BLOCKED':
+    case 'BEHIND':
+      return 'dirty';
+    default:
+      return 'unknown';
+  }
+}
+
+function stringProp(value: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return undefined;
+}
+
+function summarizeStatusChecks(items: unknown[] | undefined): MergeGateApprovalStatus['checks'] {
+  if (!Array.isArray(items) || items.length === 0) return undefined;
+
+  let hasPending = false;
+  const failed: MergeGateFailedCheck[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const check = item as Record<string, unknown>;
+    const name = stringProp(check, 'name', 'workflowName', 'context') ?? 'unknown check';
+    const status = stringProp(check, 'status')?.toUpperCase();
+    const conclusion = stringProp(check, 'conclusion')?.toUpperCase();
+    const state = stringProp(check, 'state')?.toUpperCase();
+    if (state) {
+      if (state === 'PENDING' || state === 'EXPECTED') {
+        hasPending = true;
+        continue;
+      }
+      if (state !== 'SUCCESS') {
+        failed.push({
+          name,
+          conclusion: state,
+          detailsUrl: stringProp(check, 'detailsUrl', 'targetUrl'),
+          summary: stringProp(check, 'summary', 'description'),
+        });
+      }
+      continue;
+    }
+    if (status && status !== 'COMPLETED') {
+      hasPending = true;
+      continue;
+    }
+    if (conclusion && conclusion !== 'SUCCESS' && conclusion !== 'SKIPPED' && conclusion !== 'NEUTRAL') {
+      failed.push({
+        name,
+        conclusion,
+        detailsUrl: stringProp(check, 'detailsUrl', 'targetUrl'),
+        summary: stringProp(check, 'summary', 'description'),
+      });
+    }
+  }
+
+  if (failed.length > 0) return { state: 'failure', failed };
+  if (hasPending) return { state: 'pending', failed: [] };
+  return { state: 'success', failed: [] };
 }

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -9,6 +9,20 @@ export interface MergeGateApprovalStatus {
   closed?: boolean;
   statusText: string;
   url: string;
+  headSha?: string;
+  headRef?: string;
+  mergeState?: 'clean' | 'dirty' | 'unknown';
+  checks?: {
+    state: 'pending' | 'success' | 'failure';
+    failed: MergeGateFailedCheck[];
+  };
+}
+
+export interface MergeGateFailedCheck {
+  name: string;
+  conclusion?: string;
+  detailsUrl?: string;
+  summary?: string;
 }
 
 export interface MergeGateProvider {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -23,7 +23,7 @@ import { createExecutionBench } from './execution-bench.js';
 import { ResourceLimitError, type RepoPoolTiming } from './repo-pool.js';
 import type { ExecutorRegistry } from './registry.js';
 import type { AgentRegistry } from './agent-registry.js';
-import type { MergeGateProvider } from './merge-gate-provider.js';
+import type { MergeGateProvider, MergeGateApprovalStatus } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
@@ -109,6 +109,20 @@ type RemoteTargetDisplay = {
   remoteHeartbeatIntervalSeconds?: number;
 };
 
+export interface ReviewGateCiFailureTrigger {
+  taskId: string;
+  workflowId: string;
+  reviewId: string;
+  reviewUrl: string;
+  headSha?: string;
+  headRef?: string;
+  branch?: string;
+  selectedAttemptId?: string;
+  generation: number;
+  failedChecks: NonNullable<MergeGateApprovalStatus['checks']>['failed'];
+  statusText: string;
+}
+
 function nextLeaseExpiry(from: Date): Date {
   return new Date(from.getTime() + ATTEMPT_LEASE_MS);
 }
@@ -144,6 +158,7 @@ export interface TaskRunnerConfig {
   callbacks?: TaskRunnerCallbacks;
   mergeGateProvider?: MergeGateProvider;
   reviewProviderRegistry?: ReviewProviderRegistry;
+  onReviewGateCiFailure?: (trigger: ReviewGateCiFailureTrigger) => Promise<void>;
   /**
    * Provider that returns remote SSH targets keyed by target ID.
    * Called at task-execution time so config file changes take effect on retry.
@@ -191,6 +206,8 @@ export class TaskRunner {
   /** @internal */ callbacks: TaskRunnerCallbacks;
   /** @internal */ mergeGateProvider?: MergeGateProvider;
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
+  private onReviewGateCiFailure?: (trigger: ReviewGateCiFailureTrigger) => Promise<void>;
+  private reviewGateCiFixInFlight = new Set<string>();
   private activePrPollers = new Map<string, ReturnType<typeof setInterval>>();
   private getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   private getExecutionPools: () => Record<string, ExecutionPoolConfig>;
@@ -276,6 +293,7 @@ export class TaskRunner {
     this.callbacks = config.callbacks ?? {};
     this.mergeGateProvider = config.mergeGateProvider;
     this.reviewProviderRegistry = config.reviewProviderRegistry;
+    this.onReviewGateCiFailure = config.onReviewGateCiFailure;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
     this.getExecutionPools = config.executionPoolsProvider ?? (() => ({}));
     this.dockerConfig = config.dockerConfig ?? {};
@@ -1805,8 +1823,17 @@ export class TaskRunner {
    * Fix a failed task by spawning an agent with the error output.
    * The agent's output is captured and appended to the task's output stream for auditing.
    */
-  async fixWithAgent(taskId: string, taskOutput: string, agentName?: string, savedError?: string): Promise<void> {
-    return this.withAttemptHeartbeat(taskId, () => fixWithAgentImpl(this, taskId, taskOutput, agentName, savedError));
+  async fixWithAgent(
+    taskId: string,
+    taskOutput: string,
+    agentName?: string,
+    savedError?: string,
+    fixContext?: string,
+  ): Promise<void> {
+    return this.withAttemptHeartbeat(
+      taskId,
+      () => fixWithAgentImpl(this, taskId, taskOutput, agentName, savedError, fixContext),
+    );
   }
 
   private async withAttemptHeartbeat<T>(taskId: string, work: () => Promise<T>): Promise<T> {
@@ -1925,6 +1952,7 @@ export class TaskRunner {
             this.persistence.updateTask(task.id, {
               execution: { reviewStatus: status.statusText },
             });
+            await this.maybeTriggerReviewGateCiFix(task, status);
           }
         } catch (err) {
           this.logger.error(`[merge-gate] PR status check error for ${task.id}`, { err });
@@ -1963,6 +1991,8 @@ export class TaskRunner {
           this.persistence.updateTask(taskId, {
             execution: { reviewStatus: status.statusText },
           });
+          const latestTask = this.orchestrator.getTask(taskId);
+          if (latestTask) await this.maybeTriggerReviewGateCiFix(latestTask, status);
         }
       } catch (err) {
         this.logger.error(`[merge-gate] PR poll error for ${taskId}`, { err });
@@ -2011,9 +2041,46 @@ export class TaskRunner {
         this.persistence.updateTask(taskId, {
           execution: { reviewStatus: status.statusText },
         });
+        await this.maybeTriggerReviewGateCiFix(task, status);
       }
     } catch (err) {
       this.logger.error(`[merge-gate] Manual PR check error for ${taskId}`, { err });
+    }
+  }
+
+  private async maybeTriggerReviewGateCiFix(
+    task: TaskState,
+    status: MergeGateApprovalStatus,
+  ): Promise<void> {
+    if (!this.onReviewGateCiFailure) return;
+    if (!task.config.workflowId || !task.execution.reviewId) return;
+    if (status.checks?.state !== 'failure' || status.checks.failed.length === 0) return;
+
+    const key = [
+      task.id,
+      task.execution.selectedAttemptId ?? 'no-attempt',
+      task.execution.generation ?? 0,
+      status.headSha ?? 'no-head-sha',
+    ].join(':');
+    if (this.reviewGateCiFixInFlight.has(key)) return;
+
+    this.reviewGateCiFixInFlight.add(key);
+    try {
+      await this.onReviewGateCiFailure({
+        taskId: task.id,
+        workflowId: task.config.workflowId,
+        reviewId: task.execution.reviewId,
+        reviewUrl: status.url,
+        headSha: status.headSha,
+        headRef: status.headRef,
+        branch: task.execution.branch,
+        selectedAttemptId: task.execution.selectedAttemptId,
+        generation: task.execution.generation ?? 0,
+        failedChecks: status.checks.failed,
+        statusText: status.statusText,
+      });
+    } finally {
+      this.reviewGateCiFixInFlight.delete(key);
     }
   }
 


### PR DESCRIPTION
## Summary

Stack part 2 of 4 for review-gate CI auto-fix.

This PR wires the execution-engine side of the feature:

- Adds a `ReviewGateCiFailureTrigger` payload for failed review-gate CI checks.
- Adds an optional `onReviewGateCiFailure` callback to `TaskRunner`.
- Calls that callback from refresh, polling, and manual PR status checks when failed checks are observed.
- Keeps the existing closed/approved/rejected review-gate behavior intact and only triggers CI auto-fix on non-terminal failed-check states.
- Allows `fixWithAgent` to receive extra fix context so the CI failure details can reach the agent prompt.

The callback remains inert unless the app layer provides it, which happens only behind `autoFixCi` in later stack entries.

## Test Plan

- [x] `pnpm exec tsc -p tsconfig.typecheck.json --noEmit`
- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/github-merge-gate-provider.test.ts`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/config.test.ts src/__tests__/workflow-actions.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 304eda8`
- Post-revert steps: None
- Data migration? No

Depends-On: #748
