### PR TITLE
Route review-gate CI failures through autofix

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Minimal example:
   "maxConcurrency": 6,
   "autoFixRetries": 3,
   "autoFixAgent": "claude",
+  "autoFixCi": false,
   "remoteTargets": {
     "staging-a": {
       "host": "203.0.113.10",

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -79,6 +79,7 @@
 
   "autoFixRetries": 3,
   "autoApproveAIFixes": true,
+  "autoFixCi": false,
 
   "notes": {
     "fetch_behavior": "Git fetch failures always abort the task. Fix the underlying network/auth issue and rerun.",

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -111,6 +111,15 @@ describe('loadConfig', () => {
     expect(config.autoFixAgent).toBe('codex');
   });
 
+  it('reads autoFixCi from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ autoFixCi: true }),
+    );
+    const config = loadConfig();
+    expect(config.autoFixCi).toBe(true);
+  });
+
   it('loadConfig picks up browser field', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -29,6 +29,7 @@ import {
   fixWithAgentAction,
   finalizeAppliedFix,
   autoFixOnFailure,
+  autoFixOnReviewGateFailure,
   buildCancelInFlight,
   buildInvalidationDeps,
   selectFailureRecoveryRoute,
@@ -2527,6 +2528,107 @@ describe('autoFixOnFailure lineage guard', () => {
 
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).not.toHaveBeenCalled();
+  });
+});
+
+describe('autoFixOnReviewGateFailure', () => {
+  const trigger = {
+    taskId: 'merge-a',
+    workflowId: 'wf-1',
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    headSha: 'abc123',
+    headRef: 'feature/ci-red',
+    branch: 'feature/ci-red',
+    selectedAttemptId: 'att-1',
+    generation: 7,
+    statusText: 'CI failed',
+    failedChecks: [
+      { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
+    ],
+  };
+
+  it('starts a review-gate fix session and passes CI context to the fix agent', async () => {
+    const task = makeTask({
+      id: 'merge-a',
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        autoFixAttempts: 0,
+        workspacePath: '/tmp/merge-a',
+        branch: 'feature/ci-red',
+        reviewId: '123',
+        selectedAttemptId: 'att-1',
+        generation: 7,
+      },
+    });
+    const orchestrator = {
+      getTask: vi.fn(() => task),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginAutoFixSession: vi.fn(() => ({ savedError: 'Review-gate CI failed' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'prior task output'),
+      appendTaskOutput: vi.fn(),
+      logEvent: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      execGitIn: vi.fn().mockResolvedValue('fixed-sha\n'),
+    };
+
+    await autoFixOnReviewGateFailure(trigger, {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+      getAutoFixAgent: () => 'codex',
+      getAutoApproveAIFixes: () => false,
+    });
+
+    expect(orchestrator.beginAutoFixSession).toHaveBeenCalledWith(
+      'merge-a',
+      expect.objectContaining({ savedError: expect.stringContaining('Review-gate CI failed') }),
+    );
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith(
+      'merge-a',
+      'prior task output',
+      'codex',
+      'Review-gate CI failed',
+      expect.stringContaining('This auto-fix was triggered by failed CI'),
+    );
+    expect(taskExecutor.fixWithAgent.mock.calls[0]?.[4]).toContain('test-all');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('merge-a', 'Review-gate CI failed');
+  });
+
+  it('does not start when review-gate lineage is stale', async () => {
+    const staleTask = makeTask({
+      id: 'merge-a',
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        branch: 'feature/ci-red',
+        reviewId: '123',
+        selectedAttemptId: 'att-2',
+        generation: 8,
+      },
+    });
+    const orchestrator = {
+      getTask: vi.fn(() => staleTask),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginAutoFixSession: vi.fn(),
+      setFixAwaitingApproval: vi.fn(),
+    };
+
+    await expect(autoFixOnReviewGateFailure(trigger, {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: { updateTask: vi.fn() } as unknown as SQLiteAdapter,
+      taskExecutor: { fixWithAgent: vi.fn() } as unknown as TaskRunner,
+    })).rejects.toThrow(StaleLineageError);
+
+    expect(orchestrator.beginAutoFixSession).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -44,6 +44,13 @@ export interface InvokerConfig {
    */
   autoFixAgent?: string;
   /**
+   * When true, failed CI checks on Invoker-created review-gate PRs can
+   * trigger the same auto-fix recovery flow used for task failures.
+   *
+   * Default: false.
+   */
+  autoFixCi?: boolean;
+  /**
    * Read-only diagnostics tuning for the Action Graph view.
    * Default stall threshold: 60000ms. Env fallback:
    * INVOKER_ACTION_STALL_THRESHOLD_MS.

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -33,6 +33,7 @@ import { startApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
   approveTask,
+  autoFixOnReviewGateFailure,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   fixWithAgentAction,
   rebaseRetry,
@@ -189,7 +190,8 @@ export function createHeadlessExecutor(
   deps: HeadlessDeps,
   callbackOverrides?: Partial<ConstructorParameters<typeof TaskRunner>[0]['callbacks']>,
 ): TaskRunner {
-  const executor = new TaskRunner({
+  let executor: TaskRunner;
+  executor = new TaskRunner({
     orchestrator: deps.orchestrator,
     persistence: deps.persistence,
     executorRegistry: deps.executorRegistry,
@@ -201,6 +203,17 @@ export function createHeadlessExecutor(
     },
     remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
     executionPoolsProvider: () => deps.invokerConfig.executionPools ?? {},
+    onReviewGateCiFailure: deps.invokerConfig.autoFixCi
+      ? async (trigger) => {
+          await autoFixOnReviewGateFailure(trigger, {
+            orchestrator: deps.orchestrator,
+            persistence: deps.persistence,
+            taskExecutor: executor,
+            getAutoFixAgent: () => loadConfig().autoFixAgent,
+            getAutoApproveAIFixes: () => loadConfig().autoApproveAIFixes,
+          });
+        }
+      : undefined,
     mergeGateProvider: new GitHubMergeGateProvider(),
     reviewProviderRegistry: (() => {
       const registry = new ReviewProviderRegistry();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -119,6 +119,7 @@ import {
 } from './headless.js';
 import {
   approveTask as sharedApproveTask,
+  autoFixOnReviewGateFailure,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
   fixWithAgentAction,
@@ -1556,6 +1557,21 @@ if (isHeadless) {
       },
       remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
       executionPoolsProvider: () => loadConfig().executionPools ?? {},
+      onReviewGateCiFailure: invokerConfig.autoFixCi
+        ? async (trigger) => {
+            const currentTaskExecutor = taskExecutor;
+            if (!currentTaskExecutor) {
+              throw new Error('Task executor is not initialized for review-gate CI auto-fix');
+            }
+            await autoFixOnReviewGateFailure(trigger, {
+              orchestrator,
+              persistence,
+              taskExecutor: currentTaskExecutor,
+              getAutoFixAgent: () => loadConfig().autoFixAgent,
+              getAutoApproveAIFixes: () => loadConfig().autoApproveAIFixes,
+            });
+          }
+        : undefined,
       mergeGateProvider: new GitHubMergeGateProvider(),
       reviewProviderRegistry: (() => {
         const registry = new ReviewProviderRegistry();

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -16,7 +16,7 @@ import type {
 } from '@invoker/workflow-core';
 import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { TaskRunner } from '@invoker/execution-engine';
+import type { TaskRunner, ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
@@ -1231,6 +1231,139 @@ export async function autoFixOnFailure(
         }
       }
       orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg);
+    }
+  }
+}
+
+function formatReviewGateCiSavedError(trigger: ReviewGateCiFailureTrigger): string {
+  const lines = [
+    `Review-gate CI failed for PR ${trigger.reviewId}.`,
+    `PR: ${trigger.reviewUrl}`,
+    trigger.headRef ? `Branch: ${trigger.headRef}` : undefined,
+    trigger.headSha ? `Head SHA: ${trigger.headSha}` : undefined,
+    `Status: ${trigger.statusText}`,
+    '',
+    'Failed checks:',
+    ...trigger.failedChecks.map((check) => (
+      `- ${check.name}${check.conclusion ? ` (${check.conclusion})` : ''}`
+    )),
+  ].filter((line): line is string => line !== undefined);
+  return lines.join('\n');
+}
+
+function formatReviewGateCiFixContext(trigger: ReviewGateCiFailureTrigger): string {
+  const checkLines = trigger.failedChecks.map((check) => {
+    const details = [
+      check.conclusion ? `conclusion=${check.conclusion}` : undefined,
+      check.detailsUrl ? `details=${check.detailsUrl}` : undefined,
+      check.summary ? `summary=${check.summary}` : undefined,
+    ].filter(Boolean).join(' ');
+    return `- ${check.name}${details ? `: ${details}` : ''}`;
+  });
+  return [
+    'This auto-fix was triggered by failed CI on an external review gate PR.',
+    `PR: ${trigger.reviewUrl}`,
+    `Review ID: ${trigger.reviewId}`,
+    trigger.headRef ? `PR head ref: ${trigger.headRef}` : undefined,
+    trigger.headSha ? `PR head SHA: ${trigger.headSha}` : undefined,
+    trigger.branch ? `Invoker branch: ${trigger.branch}` : undefined,
+    '',
+    'Fix the code on this task branch so the failed PR checks pass.',
+    'Preserve the original task intent and do not recreate the PR manually.',
+    '',
+    'Failed checks:',
+    ...checkLines,
+  ].filter((line): line is string => line !== undefined).join('\n');
+}
+
+function assertReviewGateTriggerCurrent(
+  trigger: ReviewGateCiFailureTrigger,
+  orchestrator: Pick<Orchestrator, 'getTask'>,
+): void {
+  const task = orchestrator.getTask(trigger.taskId);
+  if (!task) {
+    throw new StaleLineageError(`Review-gate CI auto-fix task ${trigger.taskId} no longer exists`);
+  }
+  if (
+    task.execution.selectedAttemptId !== trigger.selectedAttemptId ||
+    (task.execution.generation ?? 0) !== trigger.generation ||
+    task.execution.reviewId !== trigger.reviewId ||
+    task.execution.branch !== trigger.branch
+  ) {
+    throw new StaleLineageError(`Review-gate CI auto-fix for ${trigger.taskId} is stale`);
+  }
+}
+
+export async function autoFixOnReviewGateFailure(
+  trigger: ReviewGateCiFailureTrigger,
+  deps: {
+    orchestrator: Orchestrator;
+    persistence: SQLiteAdapter;
+    taskExecutor: TaskRunner;
+    getAutoFixAgent?: () => string | undefined;
+    getAutoApproveAIFixes?: () => boolean | undefined;
+    signal?: AbortSignal;
+  },
+): Promise<void> {
+  const { orchestrator, persistence, taskExecutor } = deps;
+  const task = orchestrator.getTask(trigger.taskId);
+  if (!task) return;
+  if (task.status !== 'review_ready' && task.status !== 'awaiting_approval' && task.status !== 'failed') return;
+  const max = orchestrator.getAutoFixRetryBudget(trigger.taskId);
+  if (max <= 0) return;
+  const attempts = (task.execution.autoFixAttempts ?? 0) + 1;
+  if (attempts > max) return;
+
+  assertReviewGateTriggerCurrent(trigger, orchestrator);
+  persistence.updateTask(trigger.taskId, { execution: { autoFixAttempts: attempts } });
+  const savedError = formatReviewGateCiSavedError(trigger);
+  const fixContext = formatReviewGateCiFixContext(trigger);
+  const agentSelection = resolveAutoFixAgent(deps.getAutoFixAgent?.());
+
+  let persistedSavedError: string | undefined;
+  let lineage: TaskLineageSnapshot | undefined;
+  try {
+    ({ savedError: persistedSavedError } = orchestrator.beginAutoFixSession(trigger.taskId, { savedError }));
+    lineage = captureTaskLineage(trigger.taskId, orchestrator);
+    persistence.logEvent?.(trigger.taskId, 'debug.auto-fix', {
+      phase: 'review-gate-ci-auto-fix-start',
+      reviewId: trigger.reviewId,
+      headSha: trigger.headSha ?? null,
+      failedCheckCount: trigger.failedChecks.length,
+      selectedAgent: agentSelection.selectedAgent,
+    });
+    const output = persistence.getTaskOutput(trigger.taskId);
+    await taskExecutor.fixWithAgent(
+      trigger.taskId,
+      output,
+      agentSelection.selectedAgent,
+      persistedSavedError,
+      fixContext,
+    );
+    assertLineageCurrent(lineage, orchestrator, deps.signal);
+    const latest = orchestrator.getTask(trigger.taskId);
+    if (!latest) throw new StaleLineageError(`Review-gate CI auto-fix task ${trigger.taskId} disappeared`);
+    await recordFixedIntegrationAnchor(trigger.taskId, latest, { persistence, taskExecutor });
+    const finalizeResult = await finalizeAppliedFix(trigger.taskId, persistedSavedError, {
+      orchestrator,
+      taskExecutor,
+      autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
+    }, deps.signal);
+    persistence.logEvent?.(trigger.taskId, 'debug.auto-fix', {
+      phase: 'review-gate-ci-auto-fix-finalize',
+      autoApproved: finalizeResult.autoApproved,
+      startedCount: finalizeResult.started.length,
+    });
+  } catch (err) {
+    if (err instanceof StaleLineageError) throw err;
+    const msg = err instanceof Error ? err.message : String(err);
+    persistence.appendTaskOutput(
+      trigger.taskId,
+      `\n[Review Gate Auto-fix] Agent failed (attempt ${attempts}/${max}): ${msg}`,
+    );
+    if (persistedSavedError !== undefined) {
+      if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
+      orchestrator.revertConflictResolution(trigger.taskId, persistedSavedError, msg);
     }
   }
 }

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -338,5 +338,69 @@ describe('GitHubMergeGateProvider', () => {
       expect(result.closed).toBe(true);
       expect(result.statusText).toBe('Closed');
     });
+
+    it('returns PR head metadata and failed checks for review-gate auto-fix', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/4',
+            headRefOid: 'abc123',
+            headRefName: 'feature/red-ci',
+            mergeStateStatus: 'CLEAN',
+            statusCheckRollup: [
+              {
+                __typename: 'StatusContext',
+                context: 'invoker/fake-ci',
+                state: 'FAILURE',
+                targetUrl: 'https://github.com/owner/repo/pull/4',
+                description: 'Fixture failed',
+              },
+              {
+                name: 'test-all',
+                status: 'COMPLETED',
+                conclusion: 'FAILURE',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/1',
+                summary: 'Tests failed',
+              },
+              {
+                name: 'lint',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+              },
+            ],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '4', cwd: '/tmp/repo' });
+
+      expect(result.headSha).toBe('abc123');
+      expect(result.headRef).toBe('feature/red-ci');
+      expect(result.mergeState).toBe('clean');
+      expect(result.checks).toEqual({
+        state: 'failure',
+        failed: [
+          {
+            name: 'invoker/fake-ci',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/owner/repo/pull/4',
+            summary: 'Fixture failed',
+          },
+          {
+            name: 'test-all',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/owner/repo/actions/runs/1',
+            summary: 'Tests failed',
+          },
+        ],
+      });
+    });
   });
 });

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -465,6 +465,7 @@ export async function fixWithAgentImpl(
   taskOutput: string,
   agentName?: string,
   savedError?: string,
+  fixContext?: string,
 ): Promise<void> {
   host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
     phase: 'fix-with-agent-start',
@@ -481,7 +482,10 @@ export async function fixWithAgentImpl(
   const taskForPrompt = savedError
     ? { ...task, execution: { ...task.execution, error: savedError } }
     : task;
-  const prompt = buildFixPrompt(taskForPrompt, taskOutput);
+  const basePrompt = buildFixPrompt(taskForPrompt, taskOutput);
+  const prompt = fixContext?.trim()
+    ? `${basePrompt}\n\nAdditional fix context:\n${fixContext.trim()}`
+    : basePrompt;
   const workspacePath = task.execution.workspacePath;
 
   // SSH tasks: run agent on the remote host

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -1,6 +1,11 @@
 import { spawn } from 'node:child_process';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
-import type { MergeGateProvider, MergeGateProviderResult, MergeGateApprovalStatus } from './merge-gate-provider.js';
+import type {
+  MergeGateProvider,
+  MergeGateProviderResult,
+  MergeGateApprovalStatus,
+  MergeGateFailedCheck,
+} from './merge-gate-provider.js';
 import { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
 
 export class GitHubMergeGateProvider implements MergeGateProvider {
@@ -90,13 +95,17 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     const stdout = await this.exec('gh', [
       'pr', 'view', identifier,
       '--repo', targetRepo,
-      '--json', 'state,reviewDecision,url',
+      '--json', 'state,reviewDecision,url,headRefOid,headRefName,mergeStateStatus,statusCheckRollup',
     ], cwd);
 
     const data = JSON.parse(stdout) as {
       state: string;
       reviewDecision: string | null;
       url: string;
+      headRefOid?: string;
+      headRefName?: string;
+      mergeStateStatus?: string;
+      statusCheckRollup?: unknown[];
     };
 
     const approved = data.state === 'MERGED';
@@ -122,6 +131,10 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       closed,
       statusText,
       url: data.url,
+      headSha: data.headRefOid,
+      headRef: data.headRefName,
+      mergeState: normalizeMergeState(data.mergeStateStatus),
+      checks: summarizeStatusChecks(data.statusCheckRollup),
     };
   }
 
@@ -167,4 +180,73 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       });
     });
   }
+}
+
+function normalizeMergeState(value: string | undefined): 'clean' | 'dirty' | 'unknown' {
+  switch (value) {
+    case 'CLEAN':
+    case 'HAS_HOOKS':
+    case 'UNSTABLE':
+      return 'clean';
+    case 'DIRTY':
+    case 'BLOCKED':
+    case 'BEHIND':
+      return 'dirty';
+    default:
+      return 'unknown';
+  }
+}
+
+function stringProp(value: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return undefined;
+}
+
+function summarizeStatusChecks(items: unknown[] | undefined): MergeGateApprovalStatus['checks'] {
+  if (!Array.isArray(items) || items.length === 0) return undefined;
+
+  let hasPending = false;
+  const failed: MergeGateFailedCheck[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const check = item as Record<string, unknown>;
+    const name = stringProp(check, 'name', 'workflowName', 'context') ?? 'unknown check';
+    const status = stringProp(check, 'status')?.toUpperCase();
+    const conclusion = stringProp(check, 'conclusion')?.toUpperCase();
+    const state = stringProp(check, 'state')?.toUpperCase();
+    if (state) {
+      if (state === 'PENDING' || state === 'EXPECTED') {
+        hasPending = true;
+        continue;
+      }
+      if (state !== 'SUCCESS') {
+        failed.push({
+          name,
+          conclusion: state,
+          detailsUrl: stringProp(check, 'detailsUrl', 'targetUrl'),
+          summary: stringProp(check, 'summary', 'description'),
+        });
+      }
+      continue;
+    }
+    if (status && status !== 'COMPLETED') {
+      hasPending = true;
+      continue;
+    }
+    if (conclusion && conclusion !== 'SUCCESS' && conclusion !== 'SKIPPED' && conclusion !== 'NEUTRAL') {
+      failed.push({
+        name,
+        conclusion,
+        detailsUrl: stringProp(check, 'detailsUrl', 'targetUrl'),
+        summary: stringProp(check, 'summary', 'description'),
+      });
+    }
+  }
+
+  if (failed.length > 0) return { state: 'failure', failed };
+  if (hasPending) return { state: 'pending', failed: [] };
+  return { state: 'success', failed: [] };
 }

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -9,6 +9,20 @@ export interface MergeGateApprovalStatus {
   closed?: boolean;
   statusText: string;
   url: string;
+  headSha?: string;
+  headRef?: string;
+  mergeState?: 'clean' | 'dirty' | 'unknown';
+  checks?: {
+    state: 'pending' | 'success' | 'failure';
+    failed: MergeGateFailedCheck[];
+  };
+}
+
+export interface MergeGateFailedCheck {
+  name: string;
+  conclusion?: string;
+  detailsUrl?: string;
+  summary?: string;
 }
 
 export interface MergeGateProvider {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -23,7 +23,7 @@ import { createExecutionBench } from './execution-bench.js';
 import { ResourceLimitError, type RepoPoolTiming } from './repo-pool.js';
 import type { ExecutorRegistry } from './registry.js';
 import type { AgentRegistry } from './agent-registry.js';
-import type { MergeGateProvider } from './merge-gate-provider.js';
+import type { MergeGateProvider, MergeGateApprovalStatus } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
@@ -109,6 +109,20 @@ type RemoteTargetDisplay = {
   remoteHeartbeatIntervalSeconds?: number;
 };
 
+export interface ReviewGateCiFailureTrigger {
+  taskId: string;
+  workflowId: string;
+  reviewId: string;
+  reviewUrl: string;
+  headSha?: string;
+  headRef?: string;
+  branch?: string;
+  selectedAttemptId?: string;
+  generation: number;
+  failedChecks: NonNullable<MergeGateApprovalStatus['checks']>['failed'];
+  statusText: string;
+}
+
 function nextLeaseExpiry(from: Date): Date {
   return new Date(from.getTime() + ATTEMPT_LEASE_MS);
 }
@@ -144,6 +158,7 @@ export interface TaskRunnerConfig {
   callbacks?: TaskRunnerCallbacks;
   mergeGateProvider?: MergeGateProvider;
   reviewProviderRegistry?: ReviewProviderRegistry;
+  onReviewGateCiFailure?: (trigger: ReviewGateCiFailureTrigger) => Promise<void>;
   /**
    * Provider that returns remote SSH targets keyed by target ID.
    * Called at task-execution time so config file changes take effect on retry.
@@ -191,6 +206,8 @@ export class TaskRunner {
   /** @internal */ callbacks: TaskRunnerCallbacks;
   /** @internal */ mergeGateProvider?: MergeGateProvider;
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
+  private onReviewGateCiFailure?: (trigger: ReviewGateCiFailureTrigger) => Promise<void>;
+  private reviewGateCiFixInFlight = new Set<string>();
   private activePrPollers = new Map<string, ReturnType<typeof setInterval>>();
   private getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   private getExecutionPools: () => Record<string, ExecutionPoolConfig>;
@@ -276,6 +293,7 @@ export class TaskRunner {
     this.callbacks = config.callbacks ?? {};
     this.mergeGateProvider = config.mergeGateProvider;
     this.reviewProviderRegistry = config.reviewProviderRegistry;
+    this.onReviewGateCiFailure = config.onReviewGateCiFailure;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
     this.getExecutionPools = config.executionPoolsProvider ?? (() => ({}));
     this.dockerConfig = config.dockerConfig ?? {};
@@ -1805,8 +1823,17 @@ export class TaskRunner {
    * Fix a failed task by spawning an agent with the error output.
    * The agent's output is captured and appended to the task's output stream for auditing.
    */
-  async fixWithAgent(taskId: string, taskOutput: string, agentName?: string, savedError?: string): Promise<void> {
-    return this.withAttemptHeartbeat(taskId, () => fixWithAgentImpl(this, taskId, taskOutput, agentName, savedError));
+  async fixWithAgent(
+    taskId: string,
+    taskOutput: string,
+    agentName?: string,
+    savedError?: string,
+    fixContext?: string,
+  ): Promise<void> {
+    return this.withAttemptHeartbeat(
+      taskId,
+      () => fixWithAgentImpl(this, taskId, taskOutput, agentName, savedError, fixContext),
+    );
   }
 
   private async withAttemptHeartbeat<T>(taskId: string, work: () => Promise<T>): Promise<T> {
@@ -1925,6 +1952,7 @@ export class TaskRunner {
             this.persistence.updateTask(task.id, {
               execution: { reviewStatus: status.statusText },
             });
+            await this.maybeTriggerReviewGateCiFix(task, status);
           }
         } catch (err) {
           this.logger.error(`[merge-gate] PR status check error for ${task.id}`, { err });
@@ -1963,6 +1991,8 @@ export class TaskRunner {
           this.persistence.updateTask(taskId, {
             execution: { reviewStatus: status.statusText },
           });
+          const latestTask = this.orchestrator.getTask(taskId);
+          if (latestTask) await this.maybeTriggerReviewGateCiFix(latestTask, status);
         }
       } catch (err) {
         this.logger.error(`[merge-gate] PR poll error for ${taskId}`, { err });
@@ -2011,9 +2041,46 @@ export class TaskRunner {
         this.persistence.updateTask(taskId, {
           execution: { reviewStatus: status.statusText },
         });
+        await this.maybeTriggerReviewGateCiFix(task, status);
       }
     } catch (err) {
       this.logger.error(`[merge-gate] Manual PR check error for ${taskId}`, { err });
+    }
+  }
+
+  private async maybeTriggerReviewGateCiFix(
+    task: TaskState,
+    status: MergeGateApprovalStatus,
+  ): Promise<void> {
+    if (!this.onReviewGateCiFailure) return;
+    if (!task.config.workflowId || !task.execution.reviewId) return;
+    if (status.checks?.state !== 'failure' || status.checks.failed.length === 0) return;
+
+    const key = [
+      task.id,
+      task.execution.selectedAttemptId ?? 'no-attempt',
+      task.execution.generation ?? 0,
+      status.headSha ?? 'no-head-sha',
+    ].join(':');
+    if (this.reviewGateCiFixInFlight.has(key)) return;
+
+    this.reviewGateCiFixInFlight.add(key);
+    try {
+      await this.onReviewGateCiFailure({
+        taskId: task.id,
+        workflowId: task.config.workflowId,
+        reviewId: task.execution.reviewId,
+        reviewUrl: status.url,
+        headSha: status.headSha,
+        headRef: status.headRef,
+        branch: task.execution.branch,
+        selectedAttemptId: task.execution.selectedAttemptId,
+        generation: task.execution.generation ?? 0,
+        failedChecks: status.checks.failed,
+        statusText: status.statusText,
+      });
+    } finally {
+      this.reviewGateCiFixInFlight.delete(key);
     }
   }
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2774,6 +2774,60 @@ export class Orchestrator {
   }
 
   /**
+   * Begin an AI fix session from either a failed task or an external review
+   * gate state. Review-gate CI failures use this path because the merge task
+   * may still be review_ready/awaiting_approval while the PR checks are red.
+   */
+  beginAutoFixSession(taskId: string, opts: { savedError?: string } = {}): { savedError: string } {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    if (
+      task.status !== 'failed' &&
+      task.status !== 'review_ready' &&
+      task.status !== 'awaiting_approval'
+    ) {
+      throw new Error(`Task ${taskId} is not in an auto-fixable state (status: ${task.status})`);
+    }
+
+    const savedError = opts.savedError ?? task.execution.error ?? '';
+    const startedAt = new Date();
+    const id = task.id;
+    const changes: TaskStateChanges = {
+      status: 'fixing_with_ai',
+      execution: {
+        error: undefined,
+        exitCode: undefined,
+        completedAt: undefined,
+        mergeConflict: undefined,
+        isFixingWithAI: false,
+        startedAt,
+        lastHeartbeatAt: startedAt,
+      },
+    };
+    const changesWithGeneration = this.withBumpedExecutionGeneration(task, changes);
+    const updated = this.writeAndSync(id, changesWithGeneration);
+    const attemptId = this.replaceSelectedAttempt(task);
+    this.taskRepository.updateAttempt(attemptId, {
+      status: 'running',
+      startedAt,
+      lastHeartbeatAt: startedAt,
+      branch: task.execution.branch,
+      commit: task.execution.commit,
+      workspacePath: task.execution.workspacePath,
+      agentSessionId: task.execution.agentSessionId,
+      containerId: task.execution.containerId,
+      mergeConflict: undefined,
+      error: undefined,
+      exitCode: undefined,
+    });
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changesWithGeneration);
+    this.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+    return { savedError };
+  }
+
+  /**
    * Revert a conflict resolution attempt: restore the task to failed
    * with its original error and re-parsed mergeConflict field.
    */


### PR DESCRIPTION
## Summary

Stack part 3 of 4 for review-gate CI auto-fix.

This PR connects failed review-gate CI checks to the existing auto-fix architecture in the app/workflow layer:

- Adds a review-gate auto-fix session transition for merge tasks that are `review_ready`, `awaiting_approval`, or `failed`.
- Formats CI-specific saved error and agent context, including PR URL, head SHA/ref, and failed checks.
- Guards against stale work by checking selected attempt, generation, review ID, and branch before and during the fix flow.
- Reuses the existing `fixWithAgent`, fixed integration anchor, and finalize/publish path rather than introducing a parallel recovery mechanism.
- Wires the callback in headless and Electron only when `autoFixCi` is enabled.

## Architecture

### Before

```mermaid
graph TD
    A[Review-gate PR check fails CI] --> B[Task remains review_ready]
    B --> C[User/manual intervention]
```

### After

```mermaid
graph TD
    A[Review-gate PR check fails CI] --> B{autoFixCi enabled?}
    B -->|no| C[Task remains review_ready]
    B -->|yes| D[Begin auto-fix session]
    D --> E[Run fixWithAgent with CI context]
    E --> F[Record fixed integration anchor]
    F --> G[Finalize and republish review-gate branch]
```

## Test Plan

- [x] `pnpm exec tsc -p tsconfig.typecheck.json --noEmit`
- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/github-merge-gate-provider.test.ts`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/config.test.ts src/__tests__/workflow-actions.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a19a53e`
- Post-revert steps: Ensure `autoFixCi` is unset/false in any local config used for testing
- Data migration? No

Depends-On: #749
