### PR TITLE
Add review-gate CI autofix E2E harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Minimal example:
   "maxConcurrency": 6,
   "autoFixRetries": 3,
   "autoFixAgent": "claude",
+  "autoFixCi": false,
   "remoteTargets": {
     "staging-a": {
       "host": "203.0.113.10",

--- a/docs/invoker-config-example.json
+++ b/docs/invoker-config-example.json
@@ -79,6 +79,7 @@
 
   "autoFixRetries": 3,
   "autoApproveAIFixes": true,
+  "autoFixCi": false,
 
   "notes": {
     "fetch_behavior": "Git fetch failures always abort the task. Fix the underlying network/auth issue and rerun.",

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -111,6 +111,15 @@ describe('loadConfig', () => {
     expect(config.autoFixAgent).toBe('codex');
   });
 
+  it('reads autoFixCi from user config', () => {
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ autoFixCi: true }),
+    );
+    const config = loadConfig();
+    expect(config.autoFixCi).toBe(true);
+  });
+
   it('loadConfig picks up browser field', () => {
     writeFileSync(
       join(fakeHome, '.invoker', 'config.json'),

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -29,6 +29,7 @@ import {
   fixWithAgentAction,
   finalizeAppliedFix,
   autoFixOnFailure,
+  autoFixOnReviewGateFailure,
   buildCancelInFlight,
   buildInvalidationDeps,
   selectFailureRecoveryRoute,
@@ -2527,6 +2528,107 @@ describe('autoFixOnFailure lineage guard', () => {
 
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).not.toHaveBeenCalled();
+  });
+});
+
+describe('autoFixOnReviewGateFailure', () => {
+  const trigger = {
+    taskId: 'merge-a',
+    workflowId: 'wf-1',
+    reviewId: '123',
+    reviewUrl: 'https://github.com/owner/repo/pull/123',
+    headSha: 'abc123',
+    headRef: 'feature/ci-red',
+    branch: 'feature/ci-red',
+    selectedAttemptId: 'att-1',
+    generation: 7,
+    statusText: 'CI failed',
+    failedChecks: [
+      { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
+    ],
+  };
+
+  it('starts a review-gate fix session and passes CI context to the fix agent', async () => {
+    const task = makeTask({
+      id: 'merge-a',
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        autoFixAttempts: 0,
+        workspacePath: '/tmp/merge-a',
+        branch: 'feature/ci-red',
+        reviewId: '123',
+        selectedAttemptId: 'att-1',
+        generation: 7,
+      },
+    });
+    const orchestrator = {
+      getTask: vi.fn(() => task),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginAutoFixSession: vi.fn(() => ({ savedError: 'Review-gate CI failed' })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      updateTask: vi.fn(),
+      getTaskOutput: vi.fn(() => 'prior task output'),
+      appendTaskOutput: vi.fn(),
+      logEvent: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn().mockResolvedValue(undefined),
+      execGitIn: vi.fn().mockResolvedValue('fixed-sha\n'),
+    };
+
+    await autoFixOnReviewGateFailure(trigger, {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+      getAutoFixAgent: () => 'codex',
+      getAutoApproveAIFixes: () => false,
+    });
+
+    expect(orchestrator.beginAutoFixSession).toHaveBeenCalledWith(
+      'merge-a',
+      expect.objectContaining({ savedError: expect.stringContaining('Review-gate CI failed') }),
+    );
+    expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith(
+      'merge-a',
+      'prior task output',
+      'codex',
+      'Review-gate CI failed',
+      expect.stringContaining('This auto-fix was triggered by failed CI'),
+    );
+    expect(taskExecutor.fixWithAgent.mock.calls[0]?.[4]).toContain('test-all');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('merge-a', 'Review-gate CI failed');
+  });
+
+  it('does not start when review-gate lineage is stale', async () => {
+    const staleTask = makeTask({
+      id: 'merge-a',
+      status: 'review_ready',
+      config: { workflowId: 'wf-1', isMergeNode: true },
+      execution: {
+        branch: 'feature/ci-red',
+        reviewId: '123',
+        selectedAttemptId: 'att-2',
+        generation: 8,
+      },
+    });
+    const orchestrator = {
+      getTask: vi.fn(() => staleTask),
+      getAutoFixRetryBudget: vi.fn(() => 3),
+      beginAutoFixSession: vi.fn(),
+      setFixAwaitingApproval: vi.fn(),
+    };
+
+    await expect(autoFixOnReviewGateFailure(trigger, {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: { updateTask: vi.fn() } as unknown as SQLiteAdapter,
+      taskExecutor: { fixWithAgent: vi.fn() } as unknown as TaskRunner,
+    })).rejects.toThrow(StaleLineageError);
+
+    expect(orchestrator.beginAutoFixSession).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -44,6 +44,13 @@ export interface InvokerConfig {
    */
   autoFixAgent?: string;
   /**
+   * When true, failed CI checks on Invoker-created review-gate PRs can
+   * trigger the same auto-fix recovery flow used for task failures.
+   *
+   * Default: false.
+   */
+  autoFixCi?: boolean;
+  /**
    * Read-only diagnostics tuning for the Action Graph view.
    * Default stall threshold: 60000ms. Env fallback:
    * INVOKER_ACTION_STALL_THRESHOLD_MS.

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -290,6 +290,9 @@ export function serializeTask(task: TaskState): Record<string, unknown> {
   if (task.execution.error != null) execution.error = task.execution.error;
   if (task.execution.exitCode != null) execution.exitCode = task.execution.exitCode;
   if (task.execution.reviewUrl != null) execution.reviewUrl = task.execution.reviewUrl;
+  if (task.execution.reviewId != null) execution.reviewId = task.execution.reviewId;
+  if (task.execution.reviewStatus != null) execution.reviewStatus = task.execution.reviewStatus;
+  if (task.execution.autoFixAttempts != null) execution.autoFixAttempts = task.execution.autoFixAttempts;
   if (task.execution.agentSessionId != null) execution.agentSessionId = task.execution.agentSessionId;
   if (task.execution.lastAgentSessionId != null) execution.lastAgentSessionId = task.execution.lastAgentSessionId;
   if (task.execution.agentName != null) execution.agentName = task.execution.agentName;

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -33,6 +33,7 @@ import { startApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
   approveTask,
+  autoFixOnReviewGateFailure,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   fixWithAgentAction,
   rebaseRetry,
@@ -189,7 +190,8 @@ export function createHeadlessExecutor(
   deps: HeadlessDeps,
   callbackOverrides?: Partial<ConstructorParameters<typeof TaskRunner>[0]['callbacks']>,
 ): TaskRunner {
-  const executor = new TaskRunner({
+  let executor: TaskRunner;
+  executor = new TaskRunner({
     orchestrator: deps.orchestrator,
     persistence: deps.persistence,
     executorRegistry: deps.executorRegistry,
@@ -201,6 +203,17 @@ export function createHeadlessExecutor(
     },
     remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
     executionPoolsProvider: () => deps.invokerConfig.executionPools ?? {},
+    onReviewGateCiFailure: deps.invokerConfig.autoFixCi
+      ? async (trigger) => {
+          await autoFixOnReviewGateFailure(trigger, {
+            orchestrator: deps.orchestrator,
+            persistence: deps.persistence,
+            taskExecutor: executor,
+            getAutoFixAgent: () => loadConfig().autoFixAgent,
+            getAutoApproveAIFixes: () => loadConfig().autoApproveAIFixes,
+          });
+        }
+      : undefined,
     mergeGateProvider: new GitHubMergeGateProvider(),
     reviewProviderRegistry: (() => {
       const registry = new ReviewProviderRegistry();

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -119,6 +119,7 @@ import {
 } from './headless.js';
 import {
   approveTask as sharedApproveTask,
+  autoFixOnReviewGateFailure,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
   fixWithAgentAction,
@@ -1556,6 +1557,21 @@ if (isHeadless) {
       },
       remoteTargetsProvider: () => loadConfig().remoteTargets ?? {},
       executionPoolsProvider: () => loadConfig().executionPools ?? {},
+      onReviewGateCiFailure: invokerConfig.autoFixCi
+        ? async (trigger) => {
+            const currentTaskExecutor = taskExecutor;
+            if (!currentTaskExecutor) {
+              throw new Error('Task executor is not initialized for review-gate CI auto-fix');
+            }
+            await autoFixOnReviewGateFailure(trigger, {
+              orchestrator,
+              persistence,
+              taskExecutor: currentTaskExecutor,
+              getAutoFixAgent: () => loadConfig().autoFixAgent,
+              getAutoApproveAIFixes: () => loadConfig().autoApproveAIFixes,
+            });
+          }
+        : undefined,
       mergeGateProvider: new GitHubMergeGateProvider(),
       reviewProviderRegistry: (() => {
         const registry = new ReviewProviderRegistry();

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -16,7 +16,7 @@ import type {
 } from '@invoker/workflow-core';
 import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
-import type { TaskRunner } from '@invoker/execution-engine';
+import type { TaskRunner, ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
 import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
@@ -1231,6 +1231,139 @@ export async function autoFixOnFailure(
         }
       }
       orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg);
+    }
+  }
+}
+
+function formatReviewGateCiSavedError(trigger: ReviewGateCiFailureTrigger): string {
+  const lines = [
+    `Review-gate CI failed for PR ${trigger.reviewId}.`,
+    `PR: ${trigger.reviewUrl}`,
+    trigger.headRef ? `Branch: ${trigger.headRef}` : undefined,
+    trigger.headSha ? `Head SHA: ${trigger.headSha}` : undefined,
+    `Status: ${trigger.statusText}`,
+    '',
+    'Failed checks:',
+    ...trigger.failedChecks.map((check) => (
+      `- ${check.name}${check.conclusion ? ` (${check.conclusion})` : ''}`
+    )),
+  ].filter((line): line is string => line !== undefined);
+  return lines.join('\n');
+}
+
+function formatReviewGateCiFixContext(trigger: ReviewGateCiFailureTrigger): string {
+  const checkLines = trigger.failedChecks.map((check) => {
+    const details = [
+      check.conclusion ? `conclusion=${check.conclusion}` : undefined,
+      check.detailsUrl ? `details=${check.detailsUrl}` : undefined,
+      check.summary ? `summary=${check.summary}` : undefined,
+    ].filter(Boolean).join(' ');
+    return `- ${check.name}${details ? `: ${details}` : ''}`;
+  });
+  return [
+    'This auto-fix was triggered by failed CI on an external review gate PR.',
+    `PR: ${trigger.reviewUrl}`,
+    `Review ID: ${trigger.reviewId}`,
+    trigger.headRef ? `PR head ref: ${trigger.headRef}` : undefined,
+    trigger.headSha ? `PR head SHA: ${trigger.headSha}` : undefined,
+    trigger.branch ? `Invoker branch: ${trigger.branch}` : undefined,
+    '',
+    'Fix the code on this task branch so the failed PR checks pass.',
+    'Preserve the original task intent and do not recreate the PR manually.',
+    '',
+    'Failed checks:',
+    ...checkLines,
+  ].filter((line): line is string => line !== undefined).join('\n');
+}
+
+function assertReviewGateTriggerCurrent(
+  trigger: ReviewGateCiFailureTrigger,
+  orchestrator: Pick<Orchestrator, 'getTask'>,
+): void {
+  const task = orchestrator.getTask(trigger.taskId);
+  if (!task) {
+    throw new StaleLineageError(`Review-gate CI auto-fix task ${trigger.taskId} no longer exists`);
+  }
+  if (
+    task.execution.selectedAttemptId !== trigger.selectedAttemptId ||
+    (task.execution.generation ?? 0) !== trigger.generation ||
+    task.execution.reviewId !== trigger.reviewId ||
+    task.execution.branch !== trigger.branch
+  ) {
+    throw new StaleLineageError(`Review-gate CI auto-fix for ${trigger.taskId} is stale`);
+  }
+}
+
+export async function autoFixOnReviewGateFailure(
+  trigger: ReviewGateCiFailureTrigger,
+  deps: {
+    orchestrator: Orchestrator;
+    persistence: SQLiteAdapter;
+    taskExecutor: TaskRunner;
+    getAutoFixAgent?: () => string | undefined;
+    getAutoApproveAIFixes?: () => boolean | undefined;
+    signal?: AbortSignal;
+  },
+): Promise<void> {
+  const { orchestrator, persistence, taskExecutor } = deps;
+  const task = orchestrator.getTask(trigger.taskId);
+  if (!task) return;
+  if (task.status !== 'review_ready' && task.status !== 'awaiting_approval' && task.status !== 'failed') return;
+  const max = orchestrator.getAutoFixRetryBudget(trigger.taskId);
+  if (max <= 0) return;
+  const attempts = (task.execution.autoFixAttempts ?? 0) + 1;
+  if (attempts > max) return;
+
+  assertReviewGateTriggerCurrent(trigger, orchestrator);
+  persistence.updateTask(trigger.taskId, { execution: { autoFixAttempts: attempts } });
+  const savedError = formatReviewGateCiSavedError(trigger);
+  const fixContext = formatReviewGateCiFixContext(trigger);
+  const agentSelection = resolveAutoFixAgent(deps.getAutoFixAgent?.());
+
+  let persistedSavedError: string | undefined;
+  let lineage: TaskLineageSnapshot | undefined;
+  try {
+    ({ savedError: persistedSavedError } = orchestrator.beginAutoFixSession(trigger.taskId, { savedError }));
+    lineage = captureTaskLineage(trigger.taskId, orchestrator);
+    persistence.logEvent?.(trigger.taskId, 'debug.auto-fix', {
+      phase: 'review-gate-ci-auto-fix-start',
+      reviewId: trigger.reviewId,
+      headSha: trigger.headSha ?? null,
+      failedCheckCount: trigger.failedChecks.length,
+      selectedAgent: agentSelection.selectedAgent,
+    });
+    const output = persistence.getTaskOutput(trigger.taskId);
+    await taskExecutor.fixWithAgent(
+      trigger.taskId,
+      output,
+      agentSelection.selectedAgent,
+      persistedSavedError,
+      fixContext,
+    );
+    assertLineageCurrent(lineage, orchestrator, deps.signal);
+    const latest = orchestrator.getTask(trigger.taskId);
+    if (!latest) throw new StaleLineageError(`Review-gate CI auto-fix task ${trigger.taskId} disappeared`);
+    await recordFixedIntegrationAnchor(trigger.taskId, latest, { persistence, taskExecutor });
+    const finalizeResult = await finalizeAppliedFix(trigger.taskId, persistedSavedError, {
+      orchestrator,
+      taskExecutor,
+      autoApproveAIFixes: deps.getAutoApproveAIFixes?.() ?? true,
+    }, deps.signal);
+    persistence.logEvent?.(trigger.taskId, 'debug.auto-fix', {
+      phase: 'review-gate-ci-auto-fix-finalize',
+      autoApproved: finalizeResult.autoApproved,
+      startedCount: finalizeResult.started.length,
+    });
+  } catch (err) {
+    if (err instanceof StaleLineageError) throw err;
+    const msg = err instanceof Error ? err.message : String(err);
+    persistence.appendTaskOutput(
+      trigger.taskId,
+      `\n[Review Gate Auto-fix] Agent failed (attempt ${attempts}/${max}): ${msg}`,
+    );
+    if (persistedSavedError !== undefined) {
+      if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
+      orchestrator.revertConflictResolution(trigger.taskId, persistedSavedError, msg);
     }
   }
 }

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -338,5 +338,69 @@ describe('GitHubMergeGateProvider', () => {
       expect(result.closed).toBe(true);
       expect(result.statusText).toBe('Closed');
     });
+
+    it('returns PR head metadata and failed checks for review-gate auto-fix', async () => {
+      process.env.INVOKER_GITHUB_TARGET_REPO = 'owner/repo';
+      const { spawn } = await import('node:child_process');
+      const spawnMock = vi.mocked(spawn);
+
+      spawnMock.mockImplementation(((cmd: string) => {
+        if (cmd === 'gh') {
+          return mockSpawnResult(JSON.stringify({
+            state: 'OPEN',
+            reviewDecision: null,
+            url: 'https://github.com/owner/repo/pull/4',
+            headRefOid: 'abc123',
+            headRefName: 'feature/red-ci',
+            mergeStateStatus: 'CLEAN',
+            statusCheckRollup: [
+              {
+                __typename: 'StatusContext',
+                context: 'invoker/fake-ci',
+                state: 'FAILURE',
+                targetUrl: 'https://github.com/owner/repo/pull/4',
+                description: 'Fixture failed',
+              },
+              {
+                name: 'test-all',
+                status: 'COMPLETED',
+                conclusion: 'FAILURE',
+                detailsUrl: 'https://github.com/owner/repo/actions/runs/1',
+                summary: 'Tests failed',
+              },
+              {
+                name: 'lint',
+                status: 'COMPLETED',
+                conclusion: 'SUCCESS',
+              },
+            ],
+          }), 0);
+        }
+        return mockSpawnResult('', 0);
+      }) as any);
+
+      const result = await provider.checkApproval({ identifier: '4', cwd: '/tmp/repo' });
+
+      expect(result.headSha).toBe('abc123');
+      expect(result.headRef).toBe('feature/red-ci');
+      expect(result.mergeState).toBe('clean');
+      expect(result.checks).toEqual({
+        state: 'failure',
+        failed: [
+          {
+            name: 'invoker/fake-ci',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/owner/repo/pull/4',
+            summary: 'Fixture failed',
+          },
+          {
+            name: 'test-all',
+            conclusion: 'FAILURE',
+            detailsUrl: 'https://github.com/owner/repo/actions/runs/1',
+            summary: 'Tests failed',
+          },
+        ],
+      });
+    });
   });
 });

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -465,6 +465,7 @@ export async function fixWithAgentImpl(
   taskOutput: string,
   agentName?: string,
   savedError?: string,
+  fixContext?: string,
 ): Promise<void> {
   host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
     phase: 'fix-with-agent-start',
@@ -481,7 +482,10 @@ export async function fixWithAgentImpl(
   const taskForPrompt = savedError
     ? { ...task, execution: { ...task.execution, error: savedError } }
     : task;
-  const prompt = buildFixPrompt(taskForPrompt, taskOutput);
+  const basePrompt = buildFixPrompt(taskForPrompt, taskOutput);
+  const prompt = fixContext?.trim()
+    ? `${basePrompt}\n\nAdditional fix context:\n${fixContext.trim()}`
+    : basePrompt;
   const workspacePath = task.execution.workspacePath;
 
   // SSH tasks: run agent on the remote host

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -1,6 +1,11 @@
 import { spawn } from 'node:child_process';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
-import type { MergeGateProvider, MergeGateProviderResult, MergeGateApprovalStatus } from './merge-gate-provider.js';
+import type {
+  MergeGateProvider,
+  MergeGateProviderResult,
+  MergeGateApprovalStatus,
+  MergeGateFailedCheck,
+} from './merge-gate-provider.js';
 import { RESTART_TO_BRANCH_TRACE } from './exec-trace.js';
 
 export class GitHubMergeGateProvider implements MergeGateProvider {
@@ -90,13 +95,17 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     const stdout = await this.exec('gh', [
       'pr', 'view', identifier,
       '--repo', targetRepo,
-      '--json', 'state,reviewDecision,url',
+      '--json', 'state,reviewDecision,url,headRefOid,headRefName,mergeStateStatus,statusCheckRollup',
     ], cwd);
 
     const data = JSON.parse(stdout) as {
       state: string;
       reviewDecision: string | null;
       url: string;
+      headRefOid?: string;
+      headRefName?: string;
+      mergeStateStatus?: string;
+      statusCheckRollup?: unknown[];
     };
 
     const approved = data.state === 'MERGED';
@@ -122,6 +131,10 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       closed,
       statusText,
       url: data.url,
+      headSha: data.headRefOid,
+      headRef: data.headRefName,
+      mergeState: normalizeMergeState(data.mergeStateStatus),
+      checks: summarizeStatusChecks(data.statusCheckRollup),
     };
   }
 
@@ -167,4 +180,73 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
       });
     });
   }
+}
+
+function normalizeMergeState(value: string | undefined): 'clean' | 'dirty' | 'unknown' {
+  switch (value) {
+    case 'CLEAN':
+    case 'HAS_HOOKS':
+    case 'UNSTABLE':
+      return 'clean';
+    case 'DIRTY':
+    case 'BLOCKED':
+    case 'BEHIND':
+      return 'dirty';
+    default:
+      return 'unknown';
+  }
+}
+
+function stringProp(value: Record<string, unknown>, ...keys: string[]): string | undefined {
+  for (const key of keys) {
+    const candidate = value[key];
+    if (typeof candidate === 'string' && candidate.trim()) return candidate;
+  }
+  return undefined;
+}
+
+function summarizeStatusChecks(items: unknown[] | undefined): MergeGateApprovalStatus['checks'] {
+  if (!Array.isArray(items) || items.length === 0) return undefined;
+
+  let hasPending = false;
+  const failed: MergeGateFailedCheck[] = [];
+  for (const item of items) {
+    if (!item || typeof item !== 'object') continue;
+    const check = item as Record<string, unknown>;
+    const name = stringProp(check, 'name', 'workflowName', 'context') ?? 'unknown check';
+    const status = stringProp(check, 'status')?.toUpperCase();
+    const conclusion = stringProp(check, 'conclusion')?.toUpperCase();
+    const state = stringProp(check, 'state')?.toUpperCase();
+    if (state) {
+      if (state === 'PENDING' || state === 'EXPECTED') {
+        hasPending = true;
+        continue;
+      }
+      if (state !== 'SUCCESS') {
+        failed.push({
+          name,
+          conclusion: state,
+          detailsUrl: stringProp(check, 'detailsUrl', 'targetUrl'),
+          summary: stringProp(check, 'summary', 'description'),
+        });
+      }
+      continue;
+    }
+    if (status && status !== 'COMPLETED') {
+      hasPending = true;
+      continue;
+    }
+    if (conclusion && conclusion !== 'SUCCESS' && conclusion !== 'SKIPPED' && conclusion !== 'NEUTRAL') {
+      failed.push({
+        name,
+        conclusion,
+        detailsUrl: stringProp(check, 'detailsUrl', 'targetUrl'),
+        summary: stringProp(check, 'summary', 'description'),
+      });
+    }
+  }
+
+  if (failed.length > 0) return { state: 'failure', failed };
+  if (hasPending) return { state: 'pending', failed: [] };
+  return { state: 'success', failed: [] };
 }

--- a/packages/execution-engine/src/merge-gate-provider.ts
+++ b/packages/execution-engine/src/merge-gate-provider.ts
@@ -9,6 +9,20 @@ export interface MergeGateApprovalStatus {
   closed?: boolean;
   statusText: string;
   url: string;
+  headSha?: string;
+  headRef?: string;
+  mergeState?: 'clean' | 'dirty' | 'unknown';
+  checks?: {
+    state: 'pending' | 'success' | 'failure';
+    failed: MergeGateFailedCheck[];
+  };
+}
+
+export interface MergeGateFailedCheck {
+  name: string;
+  conclusion?: string;
+  detailsUrl?: string;
+  summary?: string;
 }
 
 export interface MergeGateProvider {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -23,7 +23,7 @@ import { createExecutionBench } from './execution-bench.js';
 import { ResourceLimitError, type RepoPoolTiming } from './repo-pool.js';
 import type { ExecutorRegistry } from './registry.js';
 import type { AgentRegistry } from './agent-registry.js';
-import type { MergeGateProvider } from './merge-gate-provider.js';
+import type { MergeGateProvider, MergeGateApprovalStatus } from './merge-gate-provider.js';
 import type { ReviewProviderRegistry } from './review-provider-registry.js';
 import { DockerExecutor } from './docker-executor.js';
 import { WorktreeExecutor } from './worktree-executor.js';
@@ -109,6 +109,20 @@ type RemoteTargetDisplay = {
   remoteHeartbeatIntervalSeconds?: number;
 };
 
+export interface ReviewGateCiFailureTrigger {
+  taskId: string;
+  workflowId: string;
+  reviewId: string;
+  reviewUrl: string;
+  headSha?: string;
+  headRef?: string;
+  branch?: string;
+  selectedAttemptId?: string;
+  generation: number;
+  failedChecks: NonNullable<MergeGateApprovalStatus['checks']>['failed'];
+  statusText: string;
+}
+
 function nextLeaseExpiry(from: Date): Date {
   return new Date(from.getTime() + ATTEMPT_LEASE_MS);
 }
@@ -144,6 +158,7 @@ export interface TaskRunnerConfig {
   callbacks?: TaskRunnerCallbacks;
   mergeGateProvider?: MergeGateProvider;
   reviewProviderRegistry?: ReviewProviderRegistry;
+  onReviewGateCiFailure?: (trigger: ReviewGateCiFailureTrigger) => Promise<void>;
   /**
    * Provider that returns remote SSH targets keyed by target ID.
    * Called at task-execution time so config file changes take effect on retry.
@@ -191,6 +206,8 @@ export class TaskRunner {
   /** @internal */ callbacks: TaskRunnerCallbacks;
   /** @internal */ mergeGateProvider?: MergeGateProvider;
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
+  private onReviewGateCiFailure?: (trigger: ReviewGateCiFailureTrigger) => Promise<void>;
+  private reviewGateCiFixInFlight = new Set<string>();
   private activePrPollers = new Map<string, ReturnType<typeof setInterval>>();
   private getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   private getExecutionPools: () => Record<string, ExecutionPoolConfig>;
@@ -276,6 +293,7 @@ export class TaskRunner {
     this.callbacks = config.callbacks ?? {};
     this.mergeGateProvider = config.mergeGateProvider;
     this.reviewProviderRegistry = config.reviewProviderRegistry;
+    this.onReviewGateCiFailure = config.onReviewGateCiFailure;
     this.getRemoteTargets = config.remoteTargetsProvider ?? (() => ({}));
     this.getExecutionPools = config.executionPoolsProvider ?? (() => ({}));
     this.dockerConfig = config.dockerConfig ?? {};
@@ -1805,8 +1823,17 @@ export class TaskRunner {
    * Fix a failed task by spawning an agent with the error output.
    * The agent's output is captured and appended to the task's output stream for auditing.
    */
-  async fixWithAgent(taskId: string, taskOutput: string, agentName?: string, savedError?: string): Promise<void> {
-    return this.withAttemptHeartbeat(taskId, () => fixWithAgentImpl(this, taskId, taskOutput, agentName, savedError));
+  async fixWithAgent(
+    taskId: string,
+    taskOutput: string,
+    agentName?: string,
+    savedError?: string,
+    fixContext?: string,
+  ): Promise<void> {
+    return this.withAttemptHeartbeat(
+      taskId,
+      () => fixWithAgentImpl(this, taskId, taskOutput, agentName, savedError, fixContext),
+    );
   }
 
   private async withAttemptHeartbeat<T>(taskId: string, work: () => Promise<T>): Promise<T> {
@@ -1925,6 +1952,7 @@ export class TaskRunner {
             this.persistence.updateTask(task.id, {
               execution: { reviewStatus: status.statusText },
             });
+            await this.maybeTriggerReviewGateCiFix(task, status);
           }
         } catch (err) {
           this.logger.error(`[merge-gate] PR status check error for ${task.id}`, { err });
@@ -1963,6 +1991,8 @@ export class TaskRunner {
           this.persistence.updateTask(taskId, {
             execution: { reviewStatus: status.statusText },
           });
+          const latestTask = this.orchestrator.getTask(taskId);
+          if (latestTask) await this.maybeTriggerReviewGateCiFix(latestTask, status);
         }
       } catch (err) {
         this.logger.error(`[merge-gate] PR poll error for ${taskId}`, { err });
@@ -2011,9 +2041,46 @@ export class TaskRunner {
         this.persistence.updateTask(taskId, {
           execution: { reviewStatus: status.statusText },
         });
+        await this.maybeTriggerReviewGateCiFix(task, status);
       }
     } catch (err) {
       this.logger.error(`[merge-gate] Manual PR check error for ${taskId}`, { err });
+    }
+  }
+
+  private async maybeTriggerReviewGateCiFix(
+    task: TaskState,
+    status: MergeGateApprovalStatus,
+  ): Promise<void> {
+    if (!this.onReviewGateCiFailure) return;
+    if (!task.config.workflowId || !task.execution.reviewId) return;
+    if (status.checks?.state !== 'failure' || status.checks.failed.length === 0) return;
+
+    const key = [
+      task.id,
+      task.execution.selectedAttemptId ?? 'no-attempt',
+      task.execution.generation ?? 0,
+      status.headSha ?? 'no-head-sha',
+    ].join(':');
+    if (this.reviewGateCiFixInFlight.has(key)) return;
+
+    this.reviewGateCiFixInFlight.add(key);
+    try {
+      await this.onReviewGateCiFailure({
+        taskId: task.id,
+        workflowId: task.config.workflowId,
+        reviewId: task.execution.reviewId,
+        reviewUrl: status.url,
+        headSha: status.headSha,
+        headRef: status.headRef,
+        branch: task.execution.branch,
+        selectedAttemptId: task.execution.selectedAttemptId,
+        generation: task.execution.generation ?? 0,
+        failedChecks: status.checks.failed,
+        statusText: status.statusText,
+      });
+    } finally {
+      this.reviewGateCiFixInFlight.delete(key);
     }
   }
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2774,6 +2774,60 @@ export class Orchestrator {
   }
 
   /**
+   * Begin an AI fix session from either a failed task or an external review
+   * gate state. Review-gate CI failures use this path because the merge task
+   * may still be review_ready/awaiting_approval while the PR checks are red.
+   */
+  beginAutoFixSession(taskId: string, opts: { savedError?: string } = {}): { savedError: string } {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    if (
+      task.status !== 'failed' &&
+      task.status !== 'review_ready' &&
+      task.status !== 'awaiting_approval'
+    ) {
+      throw new Error(`Task ${taskId} is not in an auto-fixable state (status: ${task.status})`);
+    }
+
+    const savedError = opts.savedError ?? task.execution.error ?? '';
+    const startedAt = new Date();
+    const id = task.id;
+    const changes: TaskStateChanges = {
+      status: 'fixing_with_ai',
+      execution: {
+        error: undefined,
+        exitCode: undefined,
+        completedAt: undefined,
+        mergeConflict: undefined,
+        isFixingWithAI: false,
+        startedAt,
+        lastHeartbeatAt: startedAt,
+      },
+    };
+    const changesWithGeneration = this.withBumpedExecutionGeneration(task, changes);
+    const updated = this.writeAndSync(id, changesWithGeneration);
+    const attemptId = this.replaceSelectedAttempt(task);
+    this.taskRepository.updateAttempt(attemptId, {
+      status: 'running',
+      startedAt,
+      lastHeartbeatAt: startedAt,
+      branch: task.execution.branch,
+      commit: task.execution.commit,
+      workspacePath: task.execution.workspacePath,
+      agentSessionId: task.execution.agentSessionId,
+      containerId: task.execution.containerId,
+      mergeConflict: undefined,
+      error: undefined,
+      exitCode: undefined,
+    });
+    const delta: TaskDelta = this.buildUpdateDelta(task, updated, changesWithGeneration);
+    this.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
+    return { savedError };
+  }
+
+  /**
    * Revert a conflict resolution attempt: restore the task to failed
    * with its original error and re-parsed mergeConflict field.
    */

--- a/scripts/verify-review-gate-ci-autofix-e2e.sh
+++ b/scripts/verify-review-gate-ci-autofix-e2e.sh
@@ -1,0 +1,227 @@
+#!/usr/bin/env bash
+# Real GitHub E2E for review-gate CI auto-fix.
+#
+# This intentionally talks to https://github.com/EdbertChan/test-playground.
+# It uses an isolated Invoker DB/config and creates a temporary external-review
+# workflow whose PR is expected to have a failing CI check that the configured
+# auto-fix agent can repair.
+#
+# Required:
+#   - gh authenticated with permission to create/update PRs in EdbertChan/test-playground
+#   - git push permission to EdbertChan/test-playground
+#   - an auto-fix-capable agent available on PATH (default: codex)
+#
+# Optional:
+#   INVOKER_REVIEW_GATE_E2E_REPO_URL      default: https://github.com/EdbertChan/test-playground.git
+#   INVOKER_REVIEW_GATE_E2E_REPO_NWO      default: EdbertChan/test-playground
+#   INVOKER_REVIEW_GATE_E2E_BASE_BRANCH  default: main
+#   INVOKER_REVIEW_GATE_E2E_AGENT        default: codex
+#   INVOKER_REVIEW_GATE_E2E_TIMEOUT      default: 900
+#   INVOKER_REVIEW_GATE_E2E_KEEP_TMP     set 1 to keep temp DB/config/plan
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_URL="${INVOKER_REVIEW_GATE_E2E_REPO_URL:-https://github.com/EdbertChan/test-playground.git}"
+REPO_NWO="${INVOKER_REVIEW_GATE_E2E_REPO_NWO:-EdbertChan/test-playground}"
+BASE_BRANCH="${INVOKER_REVIEW_GATE_E2E_BASE_BRANCH:-main}"
+AGENT="${INVOKER_REVIEW_GATE_E2E_AGENT:-codex}"
+TIMEOUT_SECONDS="${INVOKER_REVIEW_GATE_E2E_TIMEOUT:-900}"
+BRANCH_SUFFIX="$(date +%Y%m%d%H%M%S)-$$"
+FEATURE_BRANCH="invoker/review-gate-ci-autofix-e2e-$BRANCH_SUFFIX"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/invoker-rg-ci-e2e.XXXXXX")"
+CONFIG="$TMP_ROOT/config.json"
+PLAN="$TMP_ROOT/review-gate-ci-autofix.yaml"
+DB_DIR="$TMP_ROOT/db"
+RUN_LOG="$TMP_ROOT/headless-run.log"
+FAKE_STATUS_CONTEXT="invoker/fake-ci"
+FAKE_STATUS_DESCRIPTION="Change invoker-autofix-ci.txt to contain exactly pass."
+run_pid=""
+
+cleanup() {
+  if [ -n "$run_pid" ] && kill -0 "$run_pid" >/dev/null 2>&1; then
+    kill "$run_pid" >/dev/null 2>&1 || true
+    wait "$run_pid" >/dev/null 2>&1 || true
+  fi
+  if [ "${INVOKER_REVIEW_GATE_E2E_KEEP_TMP:-0}" = "1" ]; then
+    echo "Keeping temp root: $TMP_ROOT"
+    return
+  fi
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "ERROR: gh is required" >&2
+  exit 127
+fi
+if ! gh auth status >/dev/null 2>&1; then
+  echo "ERROR: gh is not authenticated" >&2
+  exit 1
+fi
+
+mkdir -p "$DB_DIR"
+cat >"$CONFIG" <<JSON
+{
+  "defaultBranch": "$BASE_BRANCH",
+  "autoFixRetries": 1,
+  "autoApproveAIFixes": true,
+  "autoFixAgent": "$AGENT",
+  "autoFixCi": true
+}
+JSON
+
+cat >"$PLAN" <<YAML
+name: "Review gate CI auto-fix E2E"
+repoUrl: "$REPO_URL"
+onFinish: none
+mergeMode: external_review
+featureBranch: "$FEATURE_BRANCH"
+baseBranch: "$BASE_BRANCH"
+
+tasks:
+  - id: rg-ci-autofix-seed
+    description: "Create a PR state that the test-playground CI should reject until auto-fix repairs it"
+    command: |
+      printf 'fail\n' > invoker-autofix-ci.txt
+      git add invoker-autofix-ci.txt
+    dependencies: []
+YAML
+
+export INVOKER_DB_DIR="$DB_DIR"
+export INVOKER_REPO_CONFIG_PATH="$CONFIG"
+export INVOKER_HEADLESS_STANDALONE=1
+export INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS="${INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:-30000}"
+
+echo "==> Temp root: $TMP_ROOT"
+echo "==> Repo: $REPO_URL"
+echo "==> Feature branch: $FEATURE_BRANCH"
+echo "==> Config: $CONFIG"
+echo "==> Plan: $PLAN"
+echo "==> Headless run log: $RUN_LOG"
+
+"$ROOT/run.sh" --headless run "$PLAN" --wait-for-approval >"$RUN_LOG" 2>&1 &
+run_pid="$!"
+
+deadline=$((SECONDS + TIMEOUT_SECONDS))
+review_url=""
+while [ "$SECONDS" -lt "$deadline" ]; do
+  if ! kill -0 "$run_pid" >/dev/null 2>&1; then
+    echo "ERROR: headless run exited before creating a review PR" >&2
+    cat "$RUN_LOG" >&2
+    exit 1
+  fi
+  tasks_json="$("$ROOT/run.sh" --headless query tasks --output json 2>/dev/null || true)"
+  review_url="$(node -e '
+function parseQuery(raw) {
+  const text = raw || "[]";
+  const arrayAt = text.lastIndexOf("\n[");
+  if (arrayAt >= 0) return JSON.parse(text.slice(arrayAt + 1));
+  const trimmed = text.trim();
+  if (trimmed.startsWith("[")) return JSON.parse(trimmed);
+  return [];
+}
+let data;
+try {
+  data = parseQuery(process.argv[1]);
+} catch {
+  process.exit(0);
+}
+const tasks = Array.isArray(data) ? data : data.tasks || [];
+const merge = tasks.find((t) => t.config && t.config.isMergeNode);
+process.stdout.write(merge?.execution?.reviewUrl || "");
+' "$tasks_json")"
+  if [ -n "$review_url" ]; then
+    break
+  fi
+  sleep 5
+done
+
+if [ -z "$review_url" ]; then
+  echo "ERROR: review gate PR was not created before timeout" >&2
+  exit 1
+fi
+
+echo "==> Review PR: $review_url"
+pr_number="${review_url##*/}"
+initial_head_sha="$(gh pr view "$pr_number" --repo "$REPO_NWO" --json headRefOid --jq '.headRefOid')"
+if [ -z "$initial_head_sha" ]; then
+  echo "ERROR: failed to read initial PR head SHA" >&2
+  exit 1
+fi
+
+echo "==> Posting fake failing CI status on $initial_head_sha"
+gh api "repos/$REPO_NWO/statuses/$initial_head_sha" \
+  -f state=failure \
+  -f context="$FAKE_STATUS_CONTEXT" \
+  -f description="$FAKE_STATUS_DESCRIPTION" \
+  -f target_url="$review_url" >/dev/null
+
+echo "==> Waiting for review-gate CI auto-fix to run"
+
+success_posted=0
+while [ "$SECONDS" -lt "$deadline" ]; do
+  if ! kill -0 "$run_pid" >/dev/null 2>&1; then
+    echo "ERROR: headless run exited before fake CI passed" >&2
+    cat "$RUN_LOG" >&2
+    exit 1
+  fi
+  current_head_sha="$(gh pr view "$pr_number" --repo "$REPO_NWO" --json headRefOid --jq '.headRefOid' 2>/dev/null || true)"
+  if [ "$success_posted" = "0" ] && [ -n "$current_head_sha" ] && [ "$current_head_sha" != "$initial_head_sha" ]; then
+    fixed_content="$(
+      gh api "repos/$REPO_NWO/contents/invoker-autofix-ci.txt?ref=$current_head_sha" --jq '.content' 2>/dev/null \
+        | { base64 --decode 2>/dev/null || base64 -D 2>/dev/null; } \
+        || true
+    )"
+    if [ "$fixed_content" = "pass" ]; then
+      echo "==> Posting fake successful CI status on $current_head_sha"
+      gh api "repos/$REPO_NWO/statuses/$current_head_sha" \
+        -f state=success \
+        -f context="$FAKE_STATUS_CONTEXT" \
+        -f description="invoker-autofix-ci.txt contains pass" \
+        -f target_url="$review_url" >/dev/null
+      success_posted=1
+    else
+      echo "==> New head $current_head_sha does not satisfy fake CI yet"
+      gh api "repos/$REPO_NWO/statuses/$current_head_sha" \
+        -f state=failure \
+        -f context="$FAKE_STATUS_CONTEXT" \
+        -f description="$FAKE_STATUS_DESCRIPTION" \
+        -f target_url="$review_url" >/dev/null
+      initial_head_sha="$current_head_sha"
+    fi
+  fi
+
+  tasks_json="$("$ROOT/run.sh" --headless query tasks --output json 2>/dev/null || true)"
+  node -e '
+function parseQuery(raw) {
+  const text = raw || "[]";
+  const arrayAt = text.lastIndexOf("\n[");
+  if (arrayAt >= 0) return JSON.parse(text.slice(arrayAt + 1));
+  const trimmed = text.trim();
+  if (trimmed.startsWith("[")) return JSON.parse(trimmed);
+  return [];
+}
+let data;
+try {
+  data = parseQuery(process.argv[1]);
+} catch {
+  process.exit(2);
+}
+const tasks = Array.isArray(data) ? data : data.tasks || [];
+const merge = tasks.find((t) => t.config && t.config.isMergeNode);
+if (!merge) process.exit(1);
+const status = merge.status;
+const reviewStatus = merge.execution?.reviewStatus || "";
+const attempts = merge.execution?.autoFixAttempts || 0;
+console.log(`merge=${status} reviewStatus=${reviewStatus} autoFixAttempts=${attempts}`);
+if (attempts > 0 && process.argv[2] === "1" && (status === "awaiting_approval" || status === "review_ready" || status === "completed")) {
+  process.exit(0);
+}
+process.exit(2);
+' "$tasks_json" "$success_posted" && exit 0
+  sleep 10
+done
+
+echo "ERROR: review-gate CI auto-fix did not complete before timeout" >&2
+echo "PR: $review_url" >&2
+exit 1


### PR DESCRIPTION
## Summary

Stack part 4 of 4 for review-gate CI auto-fix.

This PR adds the end-to-end harness used to prove the feature against a real GitHub PR without depending on `test-playground` having native GitHub Actions workflows:

- Adds `scripts/verify-review-gate-ci-autofix-e2e.sh`.
- Creates an isolated temp Invoker DB/config with `autoFixCi: true`.
- Submits a fake external-review workflow against `EdbertChan/test-playground`.
- Posts a synthetic failing GitHub commit status on the review PR head.
- Waits for Invoker to auto-fix the PR branch, validates the sentinel file changed to `pass`, then posts a synthetic success status.
- Exposes `reviewId`, `reviewStatus`, and `autoFixAttempts` in JSON task output so the harness can observe completion cleanly.

## Test Plan

- [x] `bash -n scripts/verify-review-gate-ci-autofix-e2e.sh`
- [x] `INVOKER_REVIEW_GATE_E2E_TIMEOUT=900 scripts/verify-review-gate-ci-autofix-e2e.sh` — created temporary `EdbertChan/test-playground` PR #100, triggered fake failing CI, observed auto-fix push a new head, posted fake success after validating `invoker-autofix-ci.txt`, then closed/deleted the temporary PR branch
- [x] `pnpm exec tsc -p tsconfig.typecheck.json --noEmit`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/config.test.ts src/__tests__/workflow-actions.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 507a3bf`
- Post-revert steps: None
- Data migration? No

Depends-On: #750
