### PR TITLE
Guard launch stalls with live attempt leases

### DIFF
--- a/packages/app/src/__tests__/launch-stall.test.ts
+++ b/packages/app/src/__tests__/launch-stall.test.ts
@@ -37,6 +37,28 @@ describe('evaluateLaunchStall', () => {
     expect(result.launchStalled).toBe(true);
   });
 
+  it('does not fail claimed pending launches while the selected attempt lease is still alive', () => {
+    const result = evaluateLaunchStall({
+      now,
+      status: 'pending',
+      phase: 'launching',
+      launchStartedAt: staleLaunchStartedAt,
+      selectedAttempt: {
+        status: 'claimed',
+        claimedAt: staleLaunchStartedAt,
+        lastHeartbeatAt: new Date('2026-05-16T00:59:45.000Z'),
+        leaseExpiresAt: new Date('2026-05-16T01:20:00.000Z'),
+      },
+      hasExecutionHandle: false,
+      isKnownLaunching: false,
+      launchingStallTimeoutMs: 3_000,
+    });
+
+    expect(result.launchClaimedForCurrentAttempt).toBe(true);
+    expect(result.launchLeaseActive).toBe(true);
+    expect(result.launchStalled).toBe(false);
+  });
+
   it('preserves launch-stall detection for running tasks', () => {
     const result = evaluateLaunchStall({
       now,

--- a/packages/app/src/launch-stall.ts
+++ b/packages/app/src/launch-stall.ts
@@ -5,7 +5,7 @@ export interface LaunchStallEvaluationInput {
   status: TaskStatus;
   phase?: 'launching' | 'executing';
   launchStartedAt?: Date;
-  selectedAttempt?: Pick<Attempt, 'status' | 'claimedAt'>;
+  selectedAttempt?: Pick<Attempt, 'status' | 'claimedAt' | 'lastHeartbeatAt' | 'leaseExpiresAt'>;
   hasExecutionHandle: boolean;
   isKnownLaunching: boolean;
   launchingStallTimeoutMs: number;
@@ -14,6 +14,7 @@ export interface LaunchStallEvaluationInput {
 export interface LaunchStallEvaluation {
   launchAgeMs: number;
   launchClaimedForCurrentAttempt: boolean;
+  launchLeaseActive: boolean;
   launchStalled: boolean;
 }
 
@@ -29,6 +30,8 @@ export function evaluateLaunchStall(input: LaunchStallEvaluationInput): LaunchSt
     launchingStallTimeoutMs,
   } = input;
   const launchAgeMs = launchStartedAt ? now.getTime() - launchStartedAt.getTime() : 0;
+  const launchLeaseActive = selectedAttempt?.leaseExpiresAt !== undefined
+    && selectedAttempt.leaseExpiresAt.getTime() > now.getTime();
   const launchClaimedForCurrentAttempt = status === 'running'
     || (
       status === 'pending'
@@ -40,12 +43,14 @@ export function evaluateLaunchStall(input: LaunchStallEvaluationInput): LaunchSt
     && launchStartedAt !== undefined
     && launchAgeMs >= launchingStallTimeoutMs
     && launchClaimedForCurrentAttempt
+    && !launchLeaseActive
     && !hasExecutionHandle
     && !isKnownLaunching;
 
   return {
     launchAgeMs,
     launchClaimedForCurrentAttempt,
+    launchLeaseActive,
     launchStalled,
   };
 }

--- a/scripts/repro/repro-rebase-recreate-storm-launch-stall.sh
+++ b/scripts/repro/repro-rebase-recreate-storm-launch-stall.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION=""
+TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-900}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-rebase-recreate-storm-launch-stall.sh --expect issue
+  bash scripts/repro/repro-rebase-recreate-storm-launch-stall.sh --expect fixed
+
+What it proves:
+  A storm of workflow-scope rebase-recreate mutations must not let the
+  launch-stall poller fail tasks whose selected attempt is still alive and
+  heartbeating during slow executor startup.
+
+The script dispatches rebase-recreate for all saved workflows, then checks
+new event rows for "Launch stalled" failures where the selected attempt lease
+was still unexpired at the failure timestamp. Those rows prove the poller
+preempted a live startup.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --timeout)
+      TIMEOUT_SECONDS="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "issue" && "$EXPECTATION" != "fixed" ]]; then
+  echo "--expect must be issue or fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+cd "$ROOT_DIR"
+
+DB_PATH="${INVOKER_DB_PATH:-${INVOKER_DB_DIR:-$HOME/.invoker}/invoker.db}"
+if [[ ! -f "$DB_PATH" ]]; then
+  echo "Missing DB: $DB_PATH" >&2
+  exit 2
+fi
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "sqlite3 is required" >&2
+  exit 2
+fi
+
+BEFORE_EVENT_ID="$(sqlite3 -noheader "$DB_PATH" "select coalesce(max(id), 0) from events;")"
+BEFORE_INTENT_ID="$(sqlite3 -noheader "$DB_PATH" "select coalesce(max(id), 0) from workflow_mutation_intents;")"
+
+bash scripts/bench-rebase-recreate-all.sh --timeout "$TIMEOUT_SECONDS"
+
+LIVE_STALL_COUNT="$(
+  sqlite3 -noheader "$DB_PATH" "
+    with failed_stalls as (
+      select
+        e.id as event_id,
+        e.task_id,
+        e.created_at,
+        t.selected_attempt_id,
+        a.lease_expires_at,
+        e.payload
+      from events e
+      join tasks t on t.id = e.task_id
+      left join attempts a on a.id = t.selected_attempt_id
+      where e.id > $BEFORE_EVENT_ID
+        and e.event_type = 'task.failed'
+        and e.payload like '%Launch stalled:%'
+    )
+    select count(*)
+    from failed_stalls
+    where lease_expires_at is not null
+      and julianday(lease_expires_at) > julianday(created_at);
+  "
+)"
+
+NO_WORKSPACE_FIX_COUNT="$(
+  sqlite3 -noheader "$DB_PATH" "
+    select count(*)
+    from workflow_mutation_intents
+    where id > $BEFORE_INTENT_ID
+      and channel = 'invoker:fix-with-agent'
+      and status = 'failed'
+      and coalesce(error, '') like '%has no valid workspace%';
+  "
+)"
+
+echo "rebase_recreate_storm_live_launch_stalls=$LIVE_STALL_COUNT"
+echo "rebase_recreate_storm_no_workspace_fix_failures=$NO_WORKSPACE_FIX_COUNT"
+
+if [[ "$LIVE_STALL_COUNT" -gt 0 || "$NO_WORKSPACE_FIX_COUNT" -gt 0 ]]; then
+  OBSERVED="issue"
+else
+  OBSERVED="fixed"
+fi
+
+echo "observed=$OBSERVED"
+echo "expected=$EXPECTATION"
+
+if [[ "$OBSERVED" != "$EXPECTATION" ]]; then
+  exit 1
+fi
+
+echo "==> repro matched expectation"


### PR DESCRIPTION
## Summary

Guard launch-stall detection against false positives during rebase/recreate storms by treating the selected attempt's active lease as evidence that executor startup is still alive. The watchdog's job is to find dead launches, not slow but live launches: any selected attempt with a valid heartbeat/lease is excluded from launch-stall failure so we do not mark a still-running task failed, trigger bogus autofix, reset valid work, or create stale late-worker responses.

This also adds `scripts/repro/repro-rebase-recreate-storm-launch-stall.sh`, which runs the full saved-workflow rebase/recreate storm and checks for the two failure signatures seen in the repro: live launch-stall failures and follow-on autofix failures caused by missing workspaces.

## Architecture

### Before

```mermaid
graph TD
    A[Launch-stall poller] --> B{Task is launching past timeout?}
    B --> C{No in-memory handle and not in launchingTasks?}
    C --> D[Fail task as Launch stalled]
    D --> E[Autofix may run without workspace]
```

### After

```mermaid
graph TD
    A[Launch-stall poller] --> B{Task is launching past timeout?}
    B --> C{Selected attempt lease still active?}
    C -->|Yes| F[Keep startup alive]
    C -->|No| G{No in-memory handle and not in launchingTasks?}
    G --> H[Fail true stalled launch]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-stall.test.ts`
- [x] `git diff --check`
- [x] Cold isolated benchmark in `/tmp/invoker-storm-launch-stall-pr` using a SQLite backup copied into `/tmp/invoker-storm-bench.cWX2q0/invoker-home/invoker.db`, isolated `INVOKER_DB_DIR`, isolated `INVOKER_IPC_SOCKET`, isolated repo/worktree paths, and a standalone owner: `HOME=/tmp/invoker-storm-bench.cWX2q0/home INVOKER_DB_DIR=/tmp/invoker-storm-bench.cWX2q0/invoker-home INVOKER_IPC_SOCKET=/tmp/invoker-storm-bench.cWX2q0/ipc-transport.sock INVOKER_REPO_CONFIG_PATH=/tmp/invoker-storm-bench.cWX2q0/config.json INVOKER_LAUNCHING_STALL_TIMEOUT_MS=5000 bash scripts/repro/repro-rebase-recreate-storm-launch-stall.sh --expect fixed --timeout 900`
- [x] Warm isolated benchmark using a fresh SQLite backup and isolated DB/socket/worktrees under `/tmp/invoker-storm-bench-warm.7IHBbf`, reusing the already-populated isolated mirror cache from `/tmp/invoker-storm-bench.cWX2q0/repos`.

Cold isolated benchmark result:

```text
intents: 34
statuses: completed=34
queue_wait_seconds median=0.905 max=0.959
run_seconds median=39.233 max=56.170
rebase_recreate_storm_live_launch_stalls=0
rebase_recreate_storm_no_workspace_fix_failures=0
observed=fixed
expected=fixed
```

Warm isolated benchmark result:

```text
intents: 34
statuses: completed=34
queue_wait_seconds median=0.469 max=0.539
run_seconds median=38.968 max=44.772
rebase_recreate_storm_live_launch_stalls=0
rebase_recreate_storm_no_workspace_fix_failures=0
observed=fixed
expected=fixed
```

Timing note: the cold run's slowest phase was mirror/base preparation (`RepoPool.refreshMirrorForRebase.batched` / `syncPlanBaseRemoteForRef`), not mutation queueing. Reusing the isolated mirror cache cut the max run time by about 11.4s and the max queue wait by about 0.42s.

Build note: while preparing the isolated worktree, `pnpm --filter @invoker/execution-engine build` hit the existing `TS6307` declaration-build issue on `upstream/master`; `pnpm --filter @invoker/app build` and `pnpm --filter @invoker/transport build` succeeded and produced the benchmark runtime.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 1be5852d`
- Post-revert steps: rerun the launch-stall test and the isolated storm repro before recreating workflows in bulk
- Data migration? No