### PR TITLE
Refine embedded terminal drawer behavior

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -123,6 +123,40 @@ describe('EmbeddedTerminalManager', () => {
     expect(mgr.list()).toHaveLength(1);
   });
 
+  it('opens a distinct tab when the same task targets a different terminal identity', () => {
+    const pty1 = createFakePty();
+    const pty2 = createFakePty();
+    const ptySpawnFn = vi
+      .fn()
+      .mockReturnValueOnce(pty1)
+      .mockReturnValueOnce(pty2) as unknown as PtySpawnFn;
+    const mgr = new EmbeddedTerminalManager({ ptySpawnFn });
+
+    const first = mgr.openOrReuse({
+      taskId: 'task-1',
+      spec: { cwd: '/tmp/wt-1', command: 'codex', args: ['resume', 'sess-1'] },
+      cwd: '/tmp/wt-1',
+      terminalKey: 'branch-a/session-1',
+    });
+    const sameTarget = mgr.openOrReuse({
+      taskId: 'task-1',
+      spec: { cwd: '/tmp/wt-1', command: 'codex', args: ['resume', 'sess-1'] },
+      cwd: '/tmp/wt-1',
+      terminalKey: 'branch-a/session-1',
+    });
+    const nextAttempt = mgr.openOrReuse({
+      taskId: 'task-1',
+      spec: { cwd: '/tmp/wt-2', command: 'codex', args: ['resume', 'sess-2'] },
+      cwd: '/tmp/wt-2',
+      terminalKey: 'branch-b/session-2',
+    });
+
+    expect(sameTarget.sessionId).toBe(first.sessionId);
+    expect(nextAttempt.sessionId).not.toBe(first.sessionId);
+    expect(ptySpawnFn).toHaveBeenCalledTimes(2);
+    expect(mgr.list()).toHaveLength(2);
+  });
+
   it('fans PTY data through the output event', () => {
     const pty = createFakePty();
     const ptySpawnFn = vi.fn(() => pty as never) as unknown as PtySpawnFn;

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -49,6 +49,8 @@ export interface OpenSessionOptions {
   spec: TerminalSpec;
   cwd: string;
   agentName?: string;
+  /** Stable identity for the concrete terminal target: workspace, branch, session, command. */
+  terminalKey?: string;
   /** When provided, the session attaches to the running executor rather than spawning a child. */
   attach?: AttachContext;
 }
@@ -59,6 +61,7 @@ interface BaseSessionState {
   spec: TerminalSpec;
   cwd: string;
   agentName?: string;
+  terminalKey: string;
   createdAt: string;
   status: 'running' | 'exited';
   exitCode?: number;
@@ -105,7 +108,7 @@ function describeSession(state: SessionState): TerminalSessionDescriptor {
 
 export class EmbeddedTerminalManager extends EventEmitter {
   private readonly sessions = new Map<string, SessionState>();
-  private readonly taskIndex = new Map<string, string>();
+  private readonly targetIndex = new Map<string, string>();
   private readonly ptySpawnFn: PtySpawnFn;
   private readonly defaultShell: string;
 
@@ -124,14 +127,16 @@ export class EmbeddedTerminalManager extends EventEmitter {
    * intentionally `open-terminal` for both paths.
    */
   openOrReuse(opts: OpenSessionOptions): TerminalSessionDescriptor {
-    const existingId = this.taskIndex.get(opts.taskId);
+    const terminalKey = opts.terminalKey ?? this.defaultTerminalKey(opts);
+    const targetKey = this.targetIndexKey(opts.taskId, terminalKey);
+    const existingId = this.targetIndex.get(targetKey);
     if (existingId) {
       const existing = this.sessions.get(existingId);
       if (existing && existing.status === 'running') {
         return describeSession(existing);
       }
       // Stale entry — clean up before re-opening.
-      this.taskIndex.delete(opts.taskId);
+      this.targetIndex.delete(targetKey);
       if (existing) this.sessions.delete(existingId);
     }
 
@@ -143,6 +148,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
       spec: opts.spec,
       cwd: opts.cwd,
       agentName: opts.agentName,
+      terminalKey,
       createdAt,
       status: 'running' as const,
     };
@@ -174,7 +180,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
     }
 
     this.sessions.set(sessionId, state);
-    this.taskIndex.set(opts.taskId, sessionId);
+    this.targetIndex.set(targetKey, sessionId);
     return describeSession(state);
   }
 
@@ -242,6 +248,20 @@ export class EmbeddedTerminalManager extends EventEmitter {
     }
   }
 
+  private targetIndexKey(taskId: string, terminalKey: string): string {
+    return `${taskId}\0${terminalKey}`;
+  }
+
+  private defaultTerminalKey(opts: OpenSessionOptions): string {
+    return JSON.stringify({
+      mode: opts.attach ? 'attached' : 'pty',
+      cwd: opts.cwd,
+      command: opts.spec.command ?? null,
+      args: opts.spec.args ?? [],
+      attachExecutionId: opts.attach?.handle.executionId ?? null,
+    });
+  }
+
   private spawnPty(spec: TerminalSpec, cwd: string): nodePty.IPty {
     const command = spec.command ?? this.defaultShell;
     const args = spec.command ? spec.args ?? [] : [];
@@ -282,8 +302,9 @@ export class EmbeddedTerminalManager extends EventEmitter {
       }
     }
 
-    if (this.taskIndex.get(state.taskId) === state.sessionId) {
-      this.taskIndex.delete(state.taskId);
+    const targetKey = this.targetIndexKey(state.taskId, state.terminalKey);
+    if (this.targetIndex.get(targetKey) === state.sessionId) {
+      this.targetIndex.delete(targetKey);
     }
     if (remove) {
       this.sessions.delete(state.sessionId);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3824,6 +3824,17 @@ if (isHeadless) {
           spec: resolved.spec,
           cwd: resolved.cwd,
           agentName: resolved.meta.agentSessionId ? resolved.meta.executionAgent : undefined,
+          terminalKey: JSON.stringify({
+            runnerKind: resolved.meta.runnerKind,
+            workspacePath: resolved.meta.workspacePath ?? resolved.cwd,
+            branch: resolved.meta.branch ?? null,
+            agentSessionId: resolved.meta.agentSessionId ?? null,
+            executionAgent: resolved.meta.executionAgent ?? null,
+            containerId: resolved.meta.containerId ?? null,
+            command: resolved.spec.command ?? null,
+            args: resolved.spec.args ?? [],
+            attachExecutionId: liveHandle?.handle.executionId ?? null,
+          }),
           attach: liveHandle ? { handle: liveHandle.handle, executor: liveHandle.executor } : undefined,
         });
         return { opened: true, session };

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -63,7 +63,9 @@ describe('Terminal drawer (component)', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: 'Expand terminal drawer' })).toBeInTheDocument();
     });
-    expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
+    const body = screen.getByTestId('terminal-drawer-body');
+    expect(body).toHaveAttribute('aria-hidden', 'true');
+    expect(body).toHaveStyle({ height: '0px' });
   });
 
   it('expands the drawer and adds a tab when opening a terminal via double-click', async () => {
@@ -78,6 +80,8 @@ describe('Terminal drawer (component)', () => {
       expect(screen.getByTestId('terminal-drawer-body')).toBeInTheDocument();
       expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument();
     });
+    expect(screen.getByTestId('terminal-drawer')).toHaveAttribute('data-state', 'expanded');
+    expect(screen.getByTestId('terminal-drawer-body')).toHaveStyle({ height: 'calc(100vh - 88px)' });
     expect(mock.api.openTerminal).toHaveBeenCalledWith('task-alpha');
   });
 
@@ -100,6 +104,71 @@ describe('Terminal drawer (component)', () => {
     });
     const tabs = screen.getAllByTestId('terminal-tab-task-alpha');
     expect(tabs).toHaveLength(1);
+  });
+
+  it('keeps mounted panes across minimize and expand', async () => {
+    render(<App />);
+    act(() => mock.setTasks([taskAlpha], workflows));
+    await selectWorkflow();
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    await waitFor(() => expect(screen.getByTestId('terminal-pane-task-alpha')).toBeInTheDocument());
+    const pane = screen.getByTestId('terminal-pane-task-alpha');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Collapse terminal drawer' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-drawer-body')).toHaveAttribute('aria-hidden', 'true');
+    });
+    expect(screen.getByTestId('terminal-pane-task-alpha')).toBe(pane);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Expand terminal drawer' }));
+    await waitFor(() => {
+      expect(screen.getByTestId('terminal-drawer-body')).toHaveAttribute('aria-hidden', 'false');
+    });
+    expect(screen.getByTestId('terminal-pane-task-alpha')).toBe(pane);
+  });
+
+  it('adds another tab when the same task opens a different attempt session', async () => {
+    (mock.api.openTerminal as ReturnType<typeof vi.fn>)
+      .mockResolvedValueOnce({
+        opened: true,
+        session: {
+          sessionId: 'mock-session-task-alpha-attempt-1',
+          taskId: 'task-alpha',
+          status: 'running',
+          mode: 'pty',
+          backend: 'pty',
+          attached: false,
+          cwd: '/tmp/wt-attempt-1',
+          createdAt: new Date('2025-01-01T00:00:00Z').toISOString(),
+        },
+      })
+      .mockResolvedValueOnce({
+        opened: true,
+        session: {
+          sessionId: 'mock-session-task-alpha-attempt-2',
+          taskId: 'task-alpha',
+          status: 'running',
+          mode: 'pty',
+          backend: 'pty',
+          attached: false,
+          cwd: '/tmp/wt-attempt-2',
+          createdAt: new Date('2025-01-01T00:00:01Z').toISOString(),
+        },
+      });
+
+    render(<App />);
+    act(() => mock.setTasks([taskAlpha], workflows));
+    await selectWorkflow();
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    await waitFor(() => expect(screen.getAllByTestId('terminal-tab-task-alpha')).toHaveLength(1));
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    await waitFor(() => expect(screen.getAllByTestId('terminal-tab-task-alpha')).toHaveLength(2));
+    const panes = screen.getAllByTestId('terminal-pane-task-alpha');
+    expect(panes[0].dataset.sessionId).toBe('mock-session-task-alpha-attempt-1');
+    expect(panes[1].dataset.sessionId).toBe('mock-session-task-alpha-attempt-2');
   });
 
   it('renders distinct tabs for different tasks side by side', async () => {

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -14,6 +14,7 @@ import { FitAddon } from 'xterm-addon-fit';
 import type { TerminalSessionDescriptor } from '@invoker/contracts';
 
 const DRAWER_BODY_HEIGHT_PX = 280;
+const EXPANDED_BODY_HEIGHT = 'calc(100vh - 88px)';
 const ANSI_PATTERN = /\x1b\[[0-9;?]*[ -/]*[@-~]/g;
 
 interface TerminalDrawerProps {
@@ -30,6 +31,7 @@ interface TerminalDrawerProps {
 interface TerminalSessionPaneProps {
   session: TerminalSessionDescriptor;
   isActive: boolean;
+  drawerCollapsed: boolean;
   hasHeader: boolean;
   onOutput: (sessionId: string, data: string) => void;
 }
@@ -46,7 +48,7 @@ function commandLabel(session: TerminalSessionDescriptor): string {
   return session.command ? 'command' : 'shell';
 }
 
-function TerminalSessionPane({ session, isActive, hasHeader, onOutput }: TerminalSessionPaneProps): JSX.Element {
+function TerminalSessionPane({ session, isActive, drawerCollapsed, hasHeader, onOutput }: TerminalSessionPaneProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTermTerminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
@@ -133,7 +135,7 @@ function TerminalSessionPane({ session, isActive, hasHeader, onOutput }: Termina
   }, [onOutput, session.sessionId]);
 
   useEffect(() => {
-    if (!isActive) return;
+    if (!isActive || drawerCollapsed) return;
     const term = termRef.current;
     const fit = fitRef.current;
     if (!term || !fit) return;
@@ -144,7 +146,7 @@ function TerminalSessionPane({ session, isActive, hasHeader, onOutput }: Termina
     } catch {
       /* fit failed (e.g., hidden) */
     }
-  }, [isActive, session.sessionId]);
+  }, [drawerCollapsed, isActive, session.sessionId]);
 
   return (
     <div
@@ -186,7 +188,8 @@ export function TerminalDrawer({
   return (
     <div
       data-testid="terminal-drawer"
-      className="border-t border-gray-800 bg-gray-950"
+      data-state={collapsed ? 'collapsed' : 'expanded'}
+      className="shrink-0 border-t border-gray-800 bg-gray-950"
     >
       <div className="flex items-center gap-2 border-b border-gray-800 px-3 py-2">
         <div
@@ -248,12 +251,12 @@ export function TerminalDrawer({
           {collapsed ? 'Expand' : 'Minimize'}
         </button>
       </div>
-      {!collapsed && (
-        <div
-          data-testid="terminal-drawer-body"
-          className="relative bg-black"
-          style={{ height: DRAWER_BODY_HEIGHT_PX }}
-        >
+      <div
+        data-testid="terminal-drawer-body"
+        aria-hidden={collapsed}
+        className="relative overflow-hidden bg-black transition-[height] duration-150"
+        style={{ height: collapsed ? 0 : EXPANDED_BODY_HEIGHT, minHeight: collapsed ? 0 : DRAWER_BODY_HEIGHT_PX }}
+      >
           {sessions.length === 0 && (
             <div className="absolute inset-0 flex items-center justify-center px-3 text-xs text-gray-500">
               Open a terminal from a task to attach.
@@ -285,12 +288,12 @@ export function TerminalDrawer({
               key={session.sessionId}
               session={session}
               isActive={session.sessionId === activeSessionId}
+              drawerCollapsed={collapsed}
               hasHeader={Boolean(session.sessionId === activeSessionId && activeCommand)}
               onOutput={handleOutput}
             />
           ))}
-        </div>
-      )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Depends-On: #760

Refines the embedded terminal drawer on top of the `node-pty` terminal work. Minimize/expand now keeps terminal panes mounted so the xterm instance is not recreated into a blank body, and expanded mode uses the full window height available to the drawer instead of staying at the compact half-height size.

Terminal reuse is now keyed by the concrete target for a task: runner kind, workspace path, branch, agent session, container, command, args, and attached execution. Double-clicking the same task restores the existing tab when that folder/session is still the target, while a changed task attempt with a new folder, branch, or session opens a separate tab.

## Architecture

### Before

```mermaid
graph TD
    Task[Task double click] --> TaskId[Lookup by task id]
    TaskId --> SameTab[Always restore same running terminal]
    Drawer[Terminal drawer] --> Collapse[Collapse unmounts body]
    Collapse --> Expand[Expand remounts xterm pane]
```

### After

```mermaid
graph TD
    Task[Task double click] --> Target[Lookup by task plus terminal target]
    Target -->|same workspace branch session| Restore[Restore existing tab]
    Target -->|new attempt target| NewTab[Open another tab]
    Drawer[Terminal drawer] --> Collapse[Collapse hides mounted body]
    Collapse --> Expand[Expand refits existing xterm pane]
```

## Test Plan

- [x] `pnpm --filter @invoker/app test -- embedded-terminal-manager.test.ts`
- [x] `pnpm --filter @invoker/ui test -- terminal-drawer.test.tsx`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert cc4da3d2`
- Post-revert steps: None
- Data migration? No
