### PR TITLE
Add embedded terminal backend facade

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -2,7 +2,7 @@
  * Embedded terminal manager unit + integration tests.
  *
  * Covers:
- *   - openOrReuse returns the same sessionId for the same taskId
+ *   - openOrReuse returns the same sessionId for the same resolved terminal target
  *   - spawn mode wires stdout/stderr → output events and exit
  *   - attached mode forwards executor.onOutput → output events and
  *     executor.sendInput → write()
@@ -19,7 +19,7 @@ import { mkdirSync, rmSync } from 'node:fs';
 
 import {
   EmbeddedTerminalManager,
-  type SpawnFn,
+  type BashSpawnFn,
 } from '../embedded-terminal-manager.js';
 import { resolveTaskTerminalSpec } from '../open-terminal-for-task.js';
 import {
@@ -37,13 +37,14 @@ function createFakeChild() {
     stdin: { write: (data: string) => boolean };
     kill: () => void;
     killed: boolean;
+    __written: string[];
   };
   ee.stdout = new EventEmitter();
   ee.stderr = new EventEmitter();
-  const written: string[] = [];
+  ee.__written = [];
   ee.stdin = {
     write: (data: string) => {
-      written.push(data);
+      ee.__written.push(data);
       return true;
     },
   };
@@ -51,15 +52,14 @@ function createFakeChild() {
   ee.kill = () => {
     ee.killed = true;
   };
-  (ee as unknown as { __written: string[] }).__written = written;
   return ee;
 }
 
 describe('EmbeddedTerminalManager', () => {
-  it('opens a spawn-mode session and returns a descriptor', () => {
+  it('opens a spawn-mode session through the default bash backend and returns a descriptor', () => {
     const child = createFakeChild();
-    const spawnFn = vi.fn(() => child as unknown as ReturnType<SpawnFn>) as unknown as SpawnFn;
-    const mgr = new EmbeddedTerminalManager({ spawnFn });
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({ bashSpawnFn });
 
     const spec: TerminalSpec = { cwd: '/tmp/wt-1' };
     const session = mgr.openOrReuse({ taskId: 'task-1', spec, cwd: '/tmp/wt-1' });
@@ -70,26 +70,80 @@ describe('EmbeddedTerminalManager', () => {
     expect(session.attached).toBe(false);
     expect(session.cwd).toBe('/tmp/wt-1');
     expect(typeof session.sessionId).toBe('string');
-    expect(spawnFn).toHaveBeenCalledTimes(1);
+    expect(bashSpawnFn).toHaveBeenCalledTimes(1);
   });
 
-  it('reopening the same task returns the same session id', () => {
+  it('reopening the same task and terminal target returns the same session id', () => {
     const child = createFakeChild();
-    const spawnFn = vi.fn(() => child as unknown as ReturnType<SpawnFn>) as unknown as SpawnFn;
-    const mgr = new EmbeddedTerminalManager({ spawnFn });
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({ bashSpawnFn });
 
     const first = mgr.openOrReuse({ taskId: 'task-1', spec: {}, cwd: '/tmp' });
     const second = mgr.openOrReuse({ taskId: 'task-1', spec: {}, cwd: '/tmp' });
 
     expect(second.sessionId).toBe(first.sessionId);
-    expect(spawnFn).toHaveBeenCalledTimes(1);
+    expect(bashSpawnFn).toHaveBeenCalledTimes(1);
     expect(mgr.list()).toHaveLength(1);
   });
 
-  it('fans stdout and stderr through the output event', () => {
+  it('opens a distinct session when the same task resolves to a different terminal target', () => {
+    const child1 = createFakeChild();
+    const child2 = createFakeChild();
+    const child3 = createFakeChild();
+    const bashSpawnFn = vi
+      .fn()
+      .mockReturnValueOnce(child1)
+      .mockReturnValueOnce(child2)
+      .mockReturnValueOnce(child3) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({ bashSpawnFn });
+
+    const first = mgr.openOrReuse({
+      taskId: 'task-1',
+      spec: { command: 'claude', args: ['--resume', 'session-a'], cwd: '/tmp/wt-a' },
+      cwd: '/tmp/wt-a',
+    });
+    const changedSession = mgr.openOrReuse({
+      taskId: 'task-1',
+      spec: { command: 'claude', args: ['--resume', 'session-b'], cwd: '/tmp/wt-a' },
+      cwd: '/tmp/wt-a',
+    });
+    const changedWorkspace = mgr.openOrReuse({
+      taskId: 'task-1',
+      spec: { command: 'claude', args: ['--resume', 'session-b'], cwd: '/tmp/wt-b' },
+      cwd: '/tmp/wt-b',
+    });
+
+    expect(changedSession.sessionId).not.toBe(first.sessionId);
+    expect(changedWorkspace.sessionId).not.toBe(changedSession.sessionId);
+    expect(bashSpawnFn).toHaveBeenCalledTimes(3);
+    expect(mgr.list()).toHaveLength(3);
+  });
+
+  it('preserves the resolved command, args, and cwd when spawning the bash backend', () => {
     const child = createFakeChild();
-    const spawnFn = vi.fn(() => child as unknown as ReturnType<SpawnFn>) as unknown as SpawnFn;
-    const mgr = new EmbeddedTerminalManager({ spawnFn });
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({ bashSpawnFn });
+
+    const session = mgr.openOrReuse({
+      taskId: 'task-1',
+      spec: { command: 'codex', args: ['resume', 'codex-session-1'], cwd: '/tmp/wt' },
+      cwd: '/tmp/wt',
+    });
+
+    expect(session.command).toBe('codex');
+    expect(session.args).toEqual(['resume', 'codex-session-1']);
+    expect(session.cwd).toBe('/tmp/wt');
+    expect(bashSpawnFn).toHaveBeenCalledWith(
+      'codex',
+      ['resume', 'codex-session-1'],
+      expect.objectContaining({ cwd: '/tmp/wt', stdio: ['pipe', 'pipe', 'pipe'] }),
+    );
+  });
+
+  it('fans bash stdout and stderr through the output event', () => {
+    const child = createFakeChild();
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({ bashSpawnFn });
     const events: Array<{ sessionId: string; data: string }> = [];
     mgr.on('output', (e) => events.push({ sessionId: e.sessionId, data: e.data }));
 
@@ -101,22 +155,33 @@ describe('EmbeddedTerminalManager', () => {
     expect(events.every((e) => e.sessionId === session.sessionId)).toBe(true);
   });
 
-  it('write() forwards data to child stdin in spawn mode', () => {
+  it('write() forwards data to bash stdin in spawn mode', () => {
     const child = createFakeChild();
-    const spawnFn = vi.fn(() => child as unknown as ReturnType<SpawnFn>) as unknown as SpawnFn;
-    const mgr = new EmbeddedTerminalManager({ spawnFn });
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({ bashSpawnFn });
     const session = mgr.openOrReuse({ taskId: 't', spec: {}, cwd: '/tmp' });
 
     const res = mgr.write(session.sessionId, 'ls\n');
 
     expect(res.ok).toBe(true);
-    expect((child as unknown as { __written: string[] }).__written).toEqual(['ls\n']);
+    expect(child.__written).toEqual(['ls\n']);
   });
 
-  it('emits exit and removes session when child exits', () => {
+  it('resize() is accepted by the bash backend as a no-op', () => {
     const child = createFakeChild();
-    const spawnFn = vi.fn(() => child as unknown as ReturnType<SpawnFn>) as unknown as SpawnFn;
-    const mgr = new EmbeddedTerminalManager({ spawnFn });
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({ bashSpawnFn });
+    const session = mgr.openOrReuse({ taskId: 't', spec: {}, cwd: '/tmp' });
+
+    const res = mgr.resize(session.sessionId, 120, 40);
+
+    expect(res.ok).toBe(true);
+  });
+
+  it('emits exit and removes session when the bash child exits', () => {
+    const child = createFakeChild();
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({ bashSpawnFn });
     const exits: Array<{ sessionId: string; exitCode?: number }> = [];
     mgr.on('exit', (e) => exits.push({ sessionId: e.sessionId, exitCode: e.exitCode }));
 
@@ -130,11 +195,11 @@ describe('EmbeddedTerminalManager', () => {
   it('after exit, openOrReuse spawns a fresh session', () => {
     const child1 = createFakeChild();
     const child2 = createFakeChild();
-    const spawnFn = vi
+    const bashSpawnFn = vi
       .fn()
       .mockReturnValueOnce(child1)
-      .mockReturnValueOnce(child2) as unknown as SpawnFn;
-    const mgr = new EmbeddedTerminalManager({ spawnFn });
+      .mockReturnValueOnce(child2) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({ bashSpawnFn });
 
     const a = mgr.openOrReuse({ taskId: 't', spec: {}, cwd: '/tmp' });
     child1.emit('exit', 0);
@@ -143,10 +208,10 @@ describe('EmbeddedTerminalManager', () => {
     expect(b.sessionId).not.toBe(a.sessionId);
   });
 
-  it('close() kills the child and clears the session', () => {
+  it('close() kills the bash child and clears the session', () => {
     const child = createFakeChild();
-    const spawnFn = vi.fn(() => child as unknown as ReturnType<SpawnFn>) as unknown as SpawnFn;
-    const mgr = new EmbeddedTerminalManager({ spawnFn });
+    const bashSpawnFn = vi.fn(() => child) as unknown as BashSpawnFn;
+    const mgr = new EmbeddedTerminalManager({ bashSpawnFn });
     const exits: Array<{ sessionId: string }> = [];
     mgr.on('exit', (e) => exits.push({ sessionId: e.sessionId }));
 
@@ -176,9 +241,9 @@ describe('EmbeddedTerminalManager', () => {
     };
     const handle: ExecutorHandle = { executionId: 'exec-1', taskId: 'task-live' };
     const mgr = new EmbeddedTerminalManager({
-      // spawnFn is irrelevant for attached mode; supply a guard.
-      spawnFn: () => {
-        throw new Error('spawn should not be called in attached mode');
+      // backend spawn is irrelevant for attached mode; supply a guard.
+      bashSpawnFn: () => {
+        throw new Error('bash should not be spawned in attached mode');
       },
     });
     const events: string[] = [];
@@ -209,7 +274,7 @@ describe('EmbeddedTerminalManager', () => {
   });
 
   it('write() rejects unknown sessions', () => {
-    const mgr = new EmbeddedTerminalManager({ spawnFn: () => createFakeChild() as never });
+    const mgr = new EmbeddedTerminalManager({ bashSpawnFn: () => createFakeChild() });
     const res = mgr.write('not-a-session', 'x');
     expect(res).toEqual({ ok: false, reason: expect.stringContaining('Unknown session') });
   });
@@ -250,7 +315,7 @@ describe('GUI open-terminal embedded route', () => {
 
       const child = createFakeChild();
       const mgr = new EmbeddedTerminalManager({
-        spawnFn: () => child as unknown as ReturnType<SpawnFn>,
+        bashSpawnFn: () => child,
       });
 
       const session = mgr.openOrReuse({

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -1,24 +1,9 @@
 /**
  * Embedded terminal manager (main process).
  *
- * Owns terminal sessions for the GUI: one logical session per task. When the
- * caller asks to open a terminal for a task we either reuse an existing live
- * session or spawn a new one. Two backing modes:
- *
- *  - `spawn`    — main process spawned a fresh child shell using the
- *                 {@link TerminalSpec} resolved from persisted task metadata.
- *                 This is the typical path for completed/failed tasks where
- *                 we restore the workspace and let the user inspect it.
- *  - `attached` — the session is wired to a live executor handle. Output is
- *                 fanned in from `executor.onOutput` and input is forwarded
- *                 through `executor.sendInput`. Used for tasks that are
- *                 still running (status `running` / `fixing_with_ai`) where
- *                 we cannot safely launch a competing shell against the
- *                 same workspace.
- *
- * The manager emits two events that the IPC layer forwards to the renderer:
- *  - `output { sessionId, taskId, data }`
- *  - `exit   { sessionId, taskId, exitCode? }`
+ * Owns GUI terminal sessions and delegates spawned sessions to a backend.
+ * Headless open-terminal is intentionally not routed through this manager; it
+ * continues to use the external OS terminal launcher.
  */
 
 import { EventEmitter } from 'node:events';
@@ -35,12 +20,31 @@ import type {
 } from '@invoker/contracts';
 import type { Executor, ExecutorHandle, TerminalSpec } from '@invoker/execution-engine';
 
-/** Factory used to spawn a child shell for `spawn`-mode sessions. */
-export type SpawnFn = (
+export type EmbeddedTerminalBackendName = 'bash';
+
+/** Factory used by the default bash/pipe backend. Tests can supply a fake. */
+export type BashSpawnFn = (
   command: string,
   args: readonly string[],
   options: SpawnOptions,
 ) => ChildProcessWithoutNullStreams;
+
+interface SpawnedTerminalProcess {
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  close(): void;
+}
+
+interface EmbeddedTerminalBackend {
+  readonly name: EmbeddedTerminalBackendName;
+  spawn(opts: {
+    spec: TerminalSpec;
+    cwd: string;
+    defaultShell: string;
+    emitOutput: (data: string) => void;
+    emitExit: (exitCode?: number) => void;
+  }): SpawnedTerminalProcess;
+}
 
 /** Optional attach handle pair routing a session through a live executor. */
 export interface AttachContext {
@@ -59,6 +63,7 @@ export interface OpenSessionOptions {
 interface BaseSessionState {
   sessionId: string;
   taskId: string;
+  targetKey: string;
   spec: TerminalSpec;
   cwd: string;
   createdAt: string;
@@ -68,7 +73,8 @@ interface BaseSessionState {
 
 interface SpawnSessionState extends BaseSessionState {
   mode: 'spawn';
-  child: ChildProcessWithoutNullStreams;
+  backend: EmbeddedTerminalBackendName;
+  process: SpawnedTerminalProcess;
 }
 
 interface AttachedSessionState extends BaseSessionState {
@@ -80,8 +86,10 @@ interface AttachedSessionState extends BaseSessionState {
 type SessionState = SpawnSessionState | AttachedSessionState;
 
 export interface EmbeddedTerminalManagerOptions {
-  /** Override the child_process.spawn function (used by tests). */
-  spawnFn?: SpawnFn;
+  /** Backend for GUI spawned sessions. Defaults to the dependency-free bash/pipe backend. */
+  backend?: EmbeddedTerminalBackend;
+  /** Override the child_process.spawn function for the bash backend. */
+  bashSpawnFn?: BashSpawnFn;
   /** Default shell for `spawn`-mode sessions when the spec has no command. */
   defaultShell?: string;
 }
@@ -101,33 +109,76 @@ function describeSession(state: SessionState): TerminalSessionDescriptor {
   };
 }
 
+class BashTerminalBackend implements EmbeddedTerminalBackend {
+  readonly name = 'bash' as const;
+  private readonly spawnFn: BashSpawnFn;
+
+  constructor(spawnFn: BashSpawnFn = nodeSpawn as unknown as BashSpawnFn) {
+    this.spawnFn = spawnFn;
+  }
+
+  spawn(opts: Parameters<EmbeddedTerminalBackend['spawn']>[0]): SpawnedTerminalProcess {
+    const command = opts.spec.command ?? opts.defaultShell;
+    const args = opts.spec.command ? opts.spec.args ?? [] : [];
+    const child = this.spawnFn(command, args, {
+      cwd: opts.cwd,
+      env: { ...process.env, TERM: process.env.TERM ?? 'xterm-256color' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    child.stdout?.on('data', (chunk: Buffer | string) => opts.emitOutput(chunk.toString()));
+    child.stderr?.on('data', (chunk: Buffer | string) => opts.emitOutput(chunk.toString()));
+    child.once('exit', (code: number | null) => opts.emitExit(code ?? undefined));
+    child.once('error', (err) => {
+      opts.emitOutput(`\n[embedded-terminal error] ${err.message}\n`);
+      opts.emitExit(undefined);
+    });
+
+    return {
+      write(data: string) {
+        child.stdin.write(data);
+      },
+      resize() {
+        // Pipe-backed child processes are not TTYs; resize is a no-op.
+      },
+      close() {
+        try {
+          if (!child.killed) child.kill();
+        } catch {
+          /* already dead */
+        }
+      },
+    };
+  }
+}
+
 export class EmbeddedTerminalManager extends EventEmitter {
   private readonly sessions = new Map<string, SessionState>();
-  private readonly taskIndex = new Map<string, string>();
-  private readonly spawnFn: SpawnFn;
+  private readonly targetIndex = new Map<string, string>();
+  private readonly backend: EmbeddedTerminalBackend;
   private readonly defaultShell: string;
 
   constructor(options: EmbeddedTerminalManagerOptions = {}) {
     super();
-    this.spawnFn = options.spawnFn ?? (nodeSpawn as unknown as SpawnFn);
+    this.backend = resolveBackend(options);
     this.defaultShell =
       options.defaultShell ?? (process.platform === 'darwin' ? 'zsh' : 'bash');
   }
 
   /**
-   * Open a new embedded session for the task, or return the existing live one.
-   * Reusing by taskId is what the spec calls "select" — the channel name is
-   * intentionally `open-terminal` for both paths.
+   * Open a new embedded session for the resolved terminal target, or return
+   * the existing live one. A changed attempt/session/workspace/branch resolves
+   * to a different target and therefore gets a distinct tab.
    */
   openOrReuse(opts: OpenSessionOptions): TerminalSessionDescriptor {
-    const existingId = this.taskIndex.get(opts.taskId);
+    const targetKey = buildTargetKey(opts);
+    const existingId = this.targetIndex.get(targetKey);
     if (existingId) {
       const existing = this.sessions.get(existingId);
       if (existing && existing.status === 'running') {
         return describeSession(existing);
       }
-      // Stale entry — clean up before re-opening.
-      this.taskIndex.delete(opts.taskId);
+      this.targetIndex.delete(targetKey);
       if (existing) this.sessions.delete(existingId);
     }
 
@@ -136,6 +187,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
     const base = {
       sessionId,
       taskId: opts.taskId,
+      targetKey,
       spec: opts.spec,
       cwd: opts.cwd,
       createdAt,
@@ -154,16 +206,23 @@ export class EmbeddedTerminalManager extends EventEmitter {
         unsubscribeOutput: unsubscribe,
       };
     } else {
+      const process = this.backend.spawn({
+        spec: opts.spec,
+        cwd: opts.cwd,
+        defaultShell: this.defaultShell,
+        emitOutput: (data) => this.emitOutput(sessionId, opts.taskId, data),
+        emitExit: (exitCode) => this.finalizeSession(state, exitCode),
+      });
       state = {
         ...base,
         mode: 'spawn',
-        child: this.spawnChild(opts.spec, opts.cwd),
+        backend: this.backend.name,
+        process,
       };
-      this.wireSpawnedChild(state);
     }
 
     this.sessions.set(sessionId, state);
-    this.taskIndex.set(opts.taskId, sessionId);
+    this.targetIndex.set(targetKey, sessionId);
     return describeSession(state);
   }
 
@@ -176,10 +235,6 @@ export class EmbeddedTerminalManager extends EventEmitter {
     return state ? describeSession(state) : undefined;
   }
 
-  /**
-   * Write user input to a session.
-   * Returns `{ ok: false, reason }` if the session is gone or the backing process refuses input.
-   */
   write(sessionId: string, data: string): { ok: boolean; reason?: string } {
     const state = this.sessions.get(sessionId);
     if (!state) return { ok: false, reason: `Unknown session "${sessionId}".` };
@@ -195,20 +250,26 @@ export class EmbeddedTerminalManager extends EventEmitter {
       }
     }
     try {
-      state.child.stdin.write(data);
+      state.process.write(data);
       return { ok: true };
     } catch (err) {
       return { ok: false, reason: err instanceof Error ? err.message : String(err) };
     }
   }
 
-  resize(sessionId: string, _cols: number, _rows: number): { ok: boolean; reason?: string } {
+  resize(sessionId: string, cols: number, rows: number): { ok: boolean; reason?: string } {
     const state = this.sessions.get(sessionId);
     if (!state) return { ok: false, reason: `Unknown session "${sessionId}".` };
-    // node:child_process spawn does not expose a TTY resize hook. We accept
-    // the call so the renderer can stay in sync, but it is a no-op until a
-    // true PTY backend (e.g. node-pty) is wired in.
-    return { ok: true };
+    if (state.status !== 'running') {
+      return { ok: false, reason: `Session "${sessionId}" has already exited.` };
+    }
+    if (state.mode === 'attached') return { ok: true };
+    try {
+      state.process.resize(cols, rows);
+      return { ok: true };
+    } catch (err) {
+      return { ok: false, reason: err instanceof Error ? err.message : String(err) };
+    }
   }
 
   close(sessionId: string): { ok: boolean; reason?: string } {
@@ -218,40 +279,10 @@ export class EmbeddedTerminalManager extends EventEmitter {
     return { ok: true };
   }
 
-  /** Tear down all live sessions; called from `before-quit`. */
   closeAll(): void {
     for (const state of Array.from(this.sessions.values())) {
       this.finalizeSession(state, undefined);
     }
-  }
-
-  private spawnChild(spec: TerminalSpec, cwd: string): ChildProcessWithoutNullStreams {
-    const command = spec.command ?? this.defaultShell;
-    const args = spec.command ? spec.args ?? [] : [];
-    const options: SpawnOptions = {
-      cwd,
-      env: { ...process.env, TERM: process.env.TERM ?? 'xterm-256color' },
-      stdio: ['pipe', 'pipe', 'pipe'],
-    };
-    return this.spawnFn(command, args, options);
-  }
-
-  private wireSpawnedChild(state: SpawnSessionState): void {
-    const { child, sessionId, taskId } = state;
-    child.stdout?.on('data', (chunk: Buffer | string) => {
-      this.emitOutput(sessionId, taskId, chunk.toString());
-    });
-    child.stderr?.on('data', (chunk: Buffer | string) => {
-      this.emitOutput(sessionId, taskId, chunk.toString());
-    });
-    const onExit = (code: number | null) => {
-      this.finalizeSession(state, code ?? undefined);
-    };
-    child.once('exit', onExit);
-    child.once('error', (err) => {
-      this.emitOutput(sessionId, taskId, `\n[embedded-terminal error] ${err.message}\n`);
-      this.finalizeSession(state, undefined);
-    });
   }
 
   private finalizeSession(state: SessionState, exitCode: number | undefined): void {
@@ -260,11 +291,7 @@ export class EmbeddedTerminalManager extends EventEmitter {
     state.exitCode = exitCode;
 
     if (state.mode === 'spawn') {
-      try {
-        if (!state.child.killed) state.child.kill();
-      } catch {
-        /* already dead */
-      }
+      state.process.close();
     } else {
       try {
         state.unsubscribeOutput();
@@ -273,8 +300,8 @@ export class EmbeddedTerminalManager extends EventEmitter {
       }
     }
 
-    if (this.taskIndex.get(state.taskId) === state.sessionId) {
-      this.taskIndex.delete(state.taskId);
+    if (this.targetIndex.get(state.targetKey) === state.sessionId) {
+      this.targetIndex.delete(state.targetKey);
     }
     this.sessions.delete(state.sessionId);
 
@@ -290,4 +317,28 @@ export class EmbeddedTerminalManager extends EventEmitter {
     const payload: TerminalOutputEvent = { sessionId, taskId, data };
     this.emit('output', payload);
   }
+}
+
+function resolveBackend(options: EmbeddedTerminalManagerOptions): EmbeddedTerminalBackend {
+  if (options.backend) return options.backend;
+  return new BashTerminalBackend(options.bashSpawnFn);
+}
+
+function buildTargetKey(opts: OpenSessionOptions): string {
+  return JSON.stringify({
+    taskId: opts.taskId,
+    cwd: opts.cwd,
+    command: opts.spec.command ?? null,
+    args: opts.spec.args ?? [],
+    linuxTerminalTail: opts.spec.linuxTerminalTail ?? null,
+    attach: opts.attach
+      ? {
+          executionId: opts.attach.handle.executionId,
+          agentSessionId: opts.attach.handle.agentSessionId ?? null,
+          containerId: opts.attach.handle.containerId ?? null,
+          workspacePath: opts.attach.handle.workspacePath ?? null,
+          branch: opts.attach.handle.branch ?? null,
+        }
+      : null,
+  });
 }


### PR DESCRIPTION
## Summary

- Introduce an embedded terminal backend facade inside `EmbeddedTerminalManager` while keeping the default implementation as the existing Bash/pipe child-process path.
- Reuse embedded terminal tabs by resolved terminal target instead of only by task ID, so changed session/workspace/branch metadata opens a distinct tab.
- Keep GUI terminal routing inside Invoker and leave headless `open-terminal` on the existing external OS terminal launcher.

## Architecture

### Before

```mermaid
flowchart TD
  UI[GUI Open Terminal] --> IPC[invoker:open-terminal]
  IPC --> Resolve[resolveTaskTerminalSpec]
  Resolve --> Manager[EmbeddedTerminalManager]
  Manager --> Child[child_process.spawn]
  Child --> Drawer[TerminalDrawer]

  CLI[Headless open-terminal] --> External[openExternalTerminalForTask]
  External --> OS[External OS terminal]
```

### After

```mermaid
flowchart TD
  UI[GUI Open Terminal] --> IPC[invoker:open-terminal]
  IPC --> Resolve[resolveTaskTerminalSpec]
  Resolve --> Manager[EmbeddedTerminalManager]
  Manager --> Facade[Backend facade]
  Facade --> Bash[Bash pipe backend]
  Bash --> Drawer[TerminalDrawer]

  CLI[Headless open-terminal] --> External[openExternalTerminalForTask]
  External --> OS[External OS terminal]
```

## Test Plan

- [x] `pnpm --filter @invoker/app test -- embedded-terminal-manager.test.ts open-terminal.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 966acdc0`
- Post-revert steps: None
- Data migration? No
