### PR TITLE
Pass fresh base commits into rebase worktrees

### DIFF
--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -22,6 +22,8 @@ import { createDeleteAllSnapshot } from './delete-all-snapshot.js';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 import { isDispatchableLaunch } from './global-topup.js';
 
+type LoadedWorkflow = NonNullable<ReturnType<SQLiteAdapter['loadWorkflow']>>;
+
 // ── Lineage guard ─────────────────────────────────────────────
 
 /**
@@ -379,19 +381,18 @@ export async function deleteAllWorkflowsBulk(
  *      `taskExecutor.killActiveExecution`) when invoked through that
  *      route — this wrapper does not add a parallel cancel call.
  *
- * The `refreshBase` callback returns `undefined` today because
- * `preparePoolForRebaseRetry` does not yet expose the resulting
- * upstream HEAD SHA; recording the SHA is a follow-up. Tests inject
- * their own `refreshBase` callback (via the orchestrator method
- * directly) to assert the fresh-base observable.
+ * `preparePoolForRebaseRetry` resolves the fresh upstream HEAD once.
+ * The explicit fresh-base lifecycle entrypoint can pass that commit
+ * through to the orchestrator callback when available.
  */
 async function prepareWorkflowFreshBase(
   workflowId: string,
   deps: ActionDeps,
-) {
+): Promise<{ workflow: LoadedWorkflow; freshBase?: { branch: string; commit: string } }> {
   const workflow = deps.persistence.loadWorkflow(workflowId);
   if (!workflow) throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
 
+  let freshBase: { branch: string; commit: string } | undefined;
   if (deps.taskExecutor && workflow.repoUrl) {
     const prepare = () => deps.mutationTiming
       ? deps.taskExecutor!.preparePoolForRebaseRetry(
@@ -406,24 +407,24 @@ async function prepareWorkflowFreshBase(
         workflow.baseBranch,
       );
     if (deps.mutationTiming) {
-      await deps.mutationTiming.span(
+      freshBase = await deps.mutationTiming.span(
         'workflow-actions.prepareWorkflowFreshBase.preparePoolForRebaseRetry',
         { repoUrl: workflow.repoUrl, baseBranch: workflow.baseBranch },
         prepare,
       );
     } else {
-      await prepare();
+      freshBase = await prepare();
     }
   }
 
-  return workflow;
+  return { workflow, freshBase };
 }
 
 export async function recreateWorkflowFromFreshBase(
   workflowId: string,
   deps: ActionDeps,
 ): Promise<TaskState[]> {
-  const workflow = await prepareWorkflowFreshBase(workflowId, deps);
+  const { workflow, freshBase } = await prepareWorkflowFreshBase(workflowId, deps);
   const nextGen = (workflow.generation ?? 0) + 1;
   deps.mutationTiming?.mark('workflow-actions.recreateWorkflowFromFreshBase.bumpGeneration', 'started', {
     nextGeneration: nextGen,
@@ -445,7 +446,7 @@ export async function recreateWorkflowFromFreshBase(
     refreshBase: async () => {
       // Pool preparation already ran above. The callback is kept so the
       // orchestrator still sees the fresh-base lifecycle entrypoint.
-      return undefined;
+      return freshBase;
     },
   });
   return deps.mutationTiming

--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -50,6 +50,8 @@ export interface WorkRequestInputs {
   lifecycleTag?: string;
   /** Workflow base branch — worktrees are created from this ref instead of HEAD. */
   baseBranch?: string;
+  /** Already-resolved base commit for baseBranch, used to skip redundant base ref resolution. */
+  baseCommit?: string;
   /** Name of the execution agent to use (e.g. 'claude', 'codex'). Defaults to 'claude'. */
   executionAgent?: string;
   /** When true, executors must not reuse existing task worktrees for this run. */

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -267,6 +267,35 @@ describe('WorktreeExecutor', () => {
     taskProcess.emit('close', 0, null);
   });
 
+  it('uses provided base commit without resolving the base ref again', async () => {
+    const { taskProcess } = setupSpawnMock();
+    const baseCommit = '1234567890abcdef1234567890abcdef12345678';
+
+    await executor.start(makeRequest({
+      inputs: {
+        command: 'echo hello',
+        baseBranch: 'master',
+        baseCommit,
+      },
+    }));
+
+    const pool = (executor as any).pool;
+    expect(pool.acquireWorktree).toHaveBeenCalledTimes(1);
+    expect(pool.acquireWorktree.mock.calls[0][2]).toBe(baseCommit);
+
+    const gitCalls = mockedSpawn.mock.calls
+      .filter(([cmd]) => cmd === 'git')
+      .map(([, args]) => args as string[]);
+    expect(gitCalls.some((args) => args[0] === 'fetch')).toBe(false);
+    expect(gitCalls.some((args) =>
+      args[0] === 'rev-parse'
+      && args.includes('--verify')
+      && args.some((arg) => arg.includes('master')),
+    )).toBe(false);
+
+    taskProcess.emit('close', 0, null);
+  });
+
   it('task runs in worktree directory, not main repo', async () => {
     const { taskProcess } = setupSpawnMock();
 

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -15,7 +15,7 @@ import {
   parseGitWorktreePorcelain,
   parseExperimentBranch,
 } from './worktree-discovery.js';
-import { syncPlanBaseRemoteForRef, isInvokerManagedPoolBranch } from './plan-base-remote.js';
+import { syncPlanBaseRemoteForRef, isInvokerManagedPoolBranch, resolvePlanBaseRevision } from './plan-base-remote.js';
 import { remoteFetchForPool } from './remote-fetch-policy.js';
 import { isWorkspaceCleanupEnabled } from './workspace-cleanup-policy.js';
 import { computeRepoCacheHash, computeRepoCacheKey, sanitizeBranchForPath } from './git-utils.js';
@@ -240,6 +240,14 @@ export class RepoPool {
       }
     }
     return dir;
+  }
+
+  async resolveBaseCommit(repoUrl: string, baseBranch: string, timing?: RepoPoolTiming): Promise<string> {
+    const dir = this.cloneDir(repoUrl);
+    const runGit = (args: string[]) => this.execGit(args, dir);
+    return this.time(timing, 'RepoPool.resolveBaseCommit.resolvePlanBaseRevision', { dir, baseBranch }, () =>
+      resolvePlanBaseRevision(runGit, baseBranch),
+    );
   }
 
   private async refreshMirrorCloneForRebase(repoUrl: string, timing?: RepoPoolTiming): Promise<RebaseMirrorRefreshResult> {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -96,6 +96,11 @@ type PoolSelection = {
   selectionStrategy: 'roundRobin' | 'leastLoaded';
 };
 
+type FreshBaseCommit = {
+  branch: string;
+  commit: string;
+};
+
 type RemoteTargetDisplay = {
   host: string;
   user: string;
@@ -218,6 +223,7 @@ export class TaskRunner {
   private sshExecutorCache = new Map<string, SshExecutor>();
   private poolRoundRobinCursor = new Map<string, number>();
   private pendingPoolSelections = new Map<string, PoolSelection>();
+  private freshBaseCommits = new Map<string, FreshBaseCommit>();
 
   /** In-flight executions keyed by attemptId (with taskId retained for external kill resolution). */
   private activeExecutions = new Map<string, ActiveExecutionEntry>();
@@ -239,13 +245,15 @@ export class TaskRunner {
     repoUrl: string | undefined,
     baseBranchHint: string | undefined,
     timing?: RepoPoolTiming,
-  ): Promise<void> {
-    if (!repoUrl) return;
+  ): Promise<{ branch: string; commit: string } | undefined> {
+    if (!repoUrl) return undefined;
     const executor = this.executorRegistry.get('worktree');
-    if (!(executor instanceof WorktreeExecutor)) return;
+    if (!(executor instanceof WorktreeExecutor)) return undefined;
     const pool = executor.getRepoPool();
     const baseBranch = baseBranchHint?.trim() || this.defaultBranch || 'master';
     await pool.refreshMirrorForRebase(repoUrl, baseBranch, timing);
+    const commit = await pool.resolveBaseCommit(repoUrl, baseBranch, timing);
+    this.freshBaseCommits.set(workflowId, { branch: baseBranch, commit });
     const collectStartedAtMs = Date.now();
     timing?.mark('TaskRunner.preparePoolForRebaseRetry.collectManagedWorkflowBranches', 'started', {
       workflowId,
@@ -257,6 +265,7 @@ export class TaskRunner {
       durationMs: Date.now() - collectStartedAtMs,
     });
     await pool.removeManagedBranchesInMirror(repoUrl, branches, timing);
+    return { branch: baseBranch, commit };
   }
 
   /**
@@ -612,6 +621,8 @@ export class TaskRunner {
     const baseBranch = workflow?.baseBranch ?? this.defaultBranch;
     const repoUrl = workflow?.repoUrl;
     const branchRepoUrl = workflow?.intermediateRepoUrl?.trim() || undefined;
+    const freshBase = task.config.workflowId ? this.freshBaseCommits.get(task.config.workflowId) : undefined;
+    const baseCommit = freshBase && freshBase.branch === baseBranch ? freshBase.commit : undefined;
 
     // Persist the experiment branch as soon as the executor knows it — well
     // before `git worktree add` could leak a worktree without a recorded branch
@@ -660,6 +671,7 @@ export class TaskRunner {
         upstreamBranches: upstreamBranches.length > 0 ? upstreamBranches : undefined,
         lifecycleTag,
         baseBranch,
+        baseCommit,
         freshWorkspace: this.shouldUseFreshWorkspace(task),
         reusableWorktree: task.execution.branch && task.execution.workspacePath
           ? {

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -157,21 +157,31 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     const clonePath = await this.pool.ensureClone(repoUrl);
     bench('RepoPool.ensureClone.after', { clonePath });
     const baseRef = request.inputs.baseBranch ?? 'HEAD';
-    log(`resolve base ${baseRef} begin`);
     const runGit = (args: string[]) => this.execGitSimple(args, clonePath);
-    bench('WorktreeExecutor.resolveBase.before', { baseRef });
-    if (remoteFetchForPool.enabled && shouldResolveViaOriginTracking(baseRef)) {
-      const preferredRemote = await resolvePreferredTrackingRemote(runGit, baseRef.trim());
-      bench('WorktreeExecutor.resolvePreferredTrackingRemote.done', { baseRef, preferredRemote });
-      await syncPlanBaseRemote(runGit, baseRef.trim(), preferredRemote);
-      bench('WorktreeExecutor.syncPlanBaseRemote.done', { baseRef, preferredRemote });
-    } else if (remoteFetchForPool.enabled) {
-      await syncPlanBaseRemoteForRef(runGit, baseRef.trim());
-      bench('WorktreeExecutor.syncPlanBaseRemoteForRef.done', { baseRef });
+    let baseHead = request.inputs.baseCommit?.trim();
+    if (baseHead) {
+      bench('WorktreeExecutor.resolveBase.skipped', {
+        baseRef,
+        baseHead,
+        reason: 'base-commit-provided',
+      });
+      log(`resolve base ${baseRef} skipped → ${baseHead}`);
+    } else {
+      log(`resolve base ${baseRef} begin`);
+      bench('WorktreeExecutor.resolveBase.before', { baseRef });
+      if (remoteFetchForPool.enabled && shouldResolveViaOriginTracking(baseRef)) {
+        const preferredRemote = await resolvePreferredTrackingRemote(runGit, baseRef.trim());
+        bench('WorktreeExecutor.resolvePreferredTrackingRemote.done', { baseRef, preferredRemote });
+        await syncPlanBaseRemote(runGit, baseRef.trim(), preferredRemote);
+        bench('WorktreeExecutor.syncPlanBaseRemote.done', { baseRef, preferredRemote });
+      } else if (remoteFetchForPool.enabled) {
+        await syncPlanBaseRemoteForRef(runGit, baseRef.trim());
+        bench('WorktreeExecutor.syncPlanBaseRemoteForRef.done', { baseRef });
+      }
+      baseHead = await resolvePlanBaseRevision(runGit, baseRef);
+      bench('WorktreeExecutor.resolveBase.after', { baseRef, baseHead });
+      log(`resolve base ${baseRef} done → ${baseHead}`);
     }
-    const baseHead = await resolvePlanBaseRevision(runGit, baseRef);
-    bench('WorktreeExecutor.resolveBase.after', { baseRef, baseHead });
-    log(`resolve base ${baseRef} done → ${baseHead}`);
     const upstreamCommits = (request.inputs.upstreamContext ?? [])
       .map(c => c.commitHash)
       .filter((h): h is string => !!h);


### PR DESCRIPTION
## Summary

Pass the fresh base commit resolved during rebase preparation through to replacement worktree launches.

This avoids each replacement task re-fetching/resolving the same base ref after `preparePoolForRebaseRetry` has already refreshed the mirror and resolved the base commit once.

Benchmark on an isolated temp DB/repo, 12 independent root tasks, `rebase-recreate` after initial completion:

- Baseline: wallMs=5504, executorLaunchMs=3370
- Patch: wallMs=4361, executorLaunchMs=2644
- Improvement: about 21% on both measured paths

## Architecture

### Before

```mermaid
flowchart TD
  A[rebase-recreate] --> B[preparePoolForRebaseRetry]
  B --> C[refresh mirror]
  D[each replacement task] --> E[WorktreeExecutor.start]
  E --> F[sync/resolve base ref]
  F --> G[acquire worktree]
```

### After

```mermaid
flowchart TD
  A[rebase-recreate] --> B[preparePoolForRebaseRetry]
  B --> C[refresh mirror]
  C --> D[resolve fresh base commit once]
  D --> E[TaskRunner stores workflow fresh base]
  F[each replacement task] --> G[WorktreeExecutor.start]
  E --> G
  G --> H[use provided base commit]
  H --> I[acquire worktree]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm vitest run src/__tests__/worktree-executor.test.ts src/__tests__/repo-pool.test.ts` from `packages/execution-engine`
- [x] `pnpm vitest run src/__tests__/workflow-actions.test.ts src/__tests__/rebase-and-retry.test.ts src/__tests__/api-server.test.ts src/__tests__/headless-delegation.test.ts` from `packages/app`
- [x] Isolated benchmark: 12-task temp repo/temp DB `rebase-recreate` baseline vs patch

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 93639013`
- Post-revert steps: Rebuild app dist before rerunning local benchmark
- Data migration? No
