### PR TITLE
Reuse batched base commits for rebase storms

### DIFF
--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -439,6 +439,34 @@ describe('RepoPool', () => {
       });
     });
 
+    it('reuses the base commit resolved by the rebase refresh batch', async () => {
+      await pool.ensureClone(localRepoUrl);
+      const orig = (pool as any).execGit.bind(pool);
+      const execGit = vi.spyOn(pool as any, 'execGit').mockImplementation(
+        (...params: unknown[]) => {
+          const args = params[0] as string[];
+          const cwd = params[1] as string;
+          return orig(args, cwd);
+        },
+      );
+      const timing = {
+        mark: vi.fn(),
+        span: vi.fn(async (_functionName, _metadata, fn) => fn()),
+      };
+
+      await pool.refreshMirrorForRebase(localRepoUrl, 'master', timing);
+      execGit.mockClear();
+
+      const commit = await pool.resolveBaseCommit(localRepoUrl, 'master', timing);
+
+      expect(commit).toMatch(/^[0-9a-f]{40}$/);
+      expect(execGit).not.toHaveBeenCalled();
+      expect(timing.mark).toHaveBeenCalledWith('RepoPool.resolveBaseCommit.batched', 'completed', {
+        repoUrl: localRepoUrl,
+        baseBranch: 'master',
+      });
+    });
+
     it('concurrent fetches from separate pools sharing cacheDir both succeed', async () => {
       // Setup: bare repo so multiple clones can fetch concurrently
       const bareDir = mkdtempSync(join(tmpdir(), 'repo-pool-bare-'));

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -52,6 +52,7 @@ export interface AcquireWorktreeOptions {
 interface RebaseRefreshBatch {
   baseBranches: Set<string>;
   syncedBaseBranches: Set<string>;
+  resolvedBaseCommits: Map<string, string>;
   callerCount: number;
   timings: RepoPoolTiming[];
   promise: Promise<string>;
@@ -141,6 +142,7 @@ export class RepoPool {
     const batch: RebaseRefreshBatch = {
       baseBranches: new Set([baseBranch]),
       syncedBaseBranches: new Set(),
+      resolvedBaseCommits: new Map(),
       callerCount: 1,
       timings: timing ? [timing] : [],
       promise: Promise.resolve(''),
@@ -237,12 +239,71 @@ export class RepoPool {
           );
         }
         batch.syncedBaseBranches.add(branch);
+        const commit = await this.time(timing, 'RepoPool.doRefreshMirrorForRebase.resolveBaseCommitNoFetch', { dir, baseBranch: branch }, () =>
+          this.tryResolveBaseCommitNoFetch(runGit, branch),
+        );
+        if (commit) {
+          batch.resolvedBaseCommits.set(branch, commit);
+        }
       }
     }
     return dir;
   }
 
+  private async tryResolveBaseCommitNoFetch(runGit: (args: string[]) => Promise<string>, baseRef: string): Promise<string | undefined> {
+    const ref = baseRef.trim() || 'HEAD';
+    const tryRevParse = async (expr: string): Promise<string | undefined> => {
+      try {
+        const resolved = (await runGit(['rev-parse', '--verify', expr])).trim();
+        return resolved || undefined;
+      } catch {
+        return undefined;
+      }
+    };
+    if (ref === 'HEAD') {
+      try {
+        const resolved = (await runGit(['rev-parse', 'HEAD'])).trim();
+        return resolved || undefined;
+      } catch {
+        return undefined;
+      }
+    }
+    if (/^[0-9a-f]{40}$/i.test(ref)) {
+      return tryRevParse(`${ref}^{commit}`);
+    }
+    if (ref.startsWith('refs/heads/') || ref.startsWith('refs/remotes/origin/') || ref.startsWith('origin/')) {
+      return tryRevParse(`${ref}^{commit}`);
+    }
+    if (ref.startsWith('refs/')) {
+      return undefined;
+    }
+    if (ref.includes('~') || ref.includes('^')) {
+      return tryRevParse(ref);
+    }
+
+    const originResolved = await tryRevParse(`origin/${ref}^{commit}`);
+    if (originResolved) return originResolved;
+    const localResolved = await tryRevParse(`refs/heads/${ref}^{commit}`);
+    if (localResolved) return localResolved;
+    try {
+      const originHeadRef = (await runGit(['symbolic-ref', '--quiet', '--short', 'refs/remotes/origin/HEAD'])).trim();
+      if (originHeadRef) return tryRevParse(`${originHeadRef}^{commit}`);
+    } catch {
+      return undefined;
+    }
+    return undefined;
+  }
+
   async resolveBaseCommit(repoUrl: string, baseBranch: string, timing?: RepoPoolTiming): Promise<string> {
+    const batch = this.pendingRebaseRefreshBatches.get(this.repoKey(repoUrl));
+    const batchedCommit = batch?.resolvedBaseCommits.get(baseBranch);
+    if (batchedCommit) {
+      timing?.mark('RepoPool.resolveBaseCommit.batched', 'completed', {
+        repoUrl,
+        baseBranch,
+      });
+      return batchedCommit;
+    }
     const dir = this.cloneDir(repoUrl);
     const runGit = (args: string[]) => this.execGit(args, dir);
     return this.time(timing, 'RepoPool.resolveBaseCommit.resolvePlanBaseRevision', { dir, baseBranch }, () =>


### PR DESCRIPTION
## Summary

Reuse the base commit already resolved by a rebase refresh batch when multiple workflow rebase/recreate intents share the same repo/base storm.

The existing refresh batch already coalesces same-repo refresh work. This change records a no-fetch base commit resolution in that batch and lets `resolveBaseCommit` return it instead of running another git resolution for each caller.

Owner/batch benchmark on an isolated temp DB/repo, 6 workflows sharing one repo/base, concurrent `rebase-recreate` dispatch:

- Baseline: median run_seconds=0.231, max=0.264, wallMs=2066
- Patch: median run_seconds=0.185, max=0.189, wallMs=1243
- Improvement: about 20% median intent runtime and 28% max intent runtime in this focused storm path

## Architecture

### Before

```mermaid
flowchart TD
  A[workflow rebase storm] --> B[RepoPool refresh batch]
  B --> C[refresh/sync base refs]
  D[each workflow caller] --> E[resolveBaseCommit]
  E --> F[git resolve base]
```

### After

```mermaid
flowchart TD
  A[workflow rebase storm] --> B[RepoPool refresh batch]
  B --> C[refresh/sync base refs]
  C --> D[resolve base commit once without fetch]
  D --> E[store commit on refresh batch]
  F[each workflow caller] --> G[resolveBaseCommit]
  E --> G
  G --> H[return batched commit]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm vitest run src/__tests__/repo-pool.test.ts` from `packages/execution-engine`
- [x] Owner/batch isolated benchmark: 6 workflows sharing one temp repo/base, concurrent `scripts/bench-rebase-recreate-all.sh` baseline vs patch

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert bc4898ac`
- Post-revert steps: Rebuild app dist before rerunning local benchmark
- Data migration? No
