### PR TITLE
Add keyboard-first UI navigation

### DIFF
--- a/packages/app/e2e/keyboard-navigation.spec.ts
+++ b/packages/app/e2e/keyboard-navigation.spec.ts
@@ -1,0 +1,49 @@
+import { test, expect, TEST_PLAN, loadPlan } from './fixtures/electron-app.js';
+
+test.describe('keyboard-first navigation', () => {
+  test('opens workflow and task context menus without the mouse', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('menu')).toContainText('Open Workflow');
+    await page.keyboard.press('Escape');
+
+    await page.keyboard.press('Shift');
+    await page.keyboard.press('Shift');
+    await page.getByTestId('keyboard-search-input').fill('Second test task');
+    await page.keyboard.press('Enter');
+    await expect(page.getByTestId('workflow-inspector-title')).toContainText('Second test task');
+
+    await page.keyboard.press('Enter');
+    await expect(page.getByRole('menu')).toContainText('Open Terminal');
+  });
+
+  test('search jumps to workflows and tasks from the keyboard', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+
+    await page.keyboard.press('Shift');
+    await page.keyboard.press('Shift');
+    await page.getByTestId('keyboard-search-input').fill('E2E Test Plan');
+    await page.keyboard.press('Enter');
+    await expect(page.getByTestId('selected-workflow-mini-dag')).toContainText('E2E Test Plan task DAG');
+
+    await page.keyboard.press('Shift');
+    await page.keyboard.press('Shift');
+    await page.getByTestId('keyboard-search-input').fill('Second test task');
+    await page.keyboard.press('Enter');
+    await expect(page.getByTestId('workflow-inspector-title')).toContainText('Second test task');
+  });
+
+  test('expands and collapses the bottom drawer from the keyboard', async ({ page }) => {
+    await loadPlan(page, TEST_PLAN);
+
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('Tab');
+    await page.keyboard.press('ArrowUp');
+    await expect(page.getByTestId('terminal-drawer-body')).toBeVisible();
+
+    await page.keyboard.press('ArrowDown');
+    await expect(page.getByTestId('terminal-drawer-body')).toBeHidden();
+  });
+});

--- a/packages/app/e2e/keyboard-navigation.spec.ts
+++ b/packages/app/e2e/keyboard-navigation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, TEST_PLAN, loadPlan } from './fixtures/electron-app.js';
+import { test, expect, TEST_PLAN, loadPlan, captureScreenshot } from './fixtures/electron-app.js';
 
 test.describe('keyboard-first navigation', () => {
   test('opens workflow and task context menus without the mouse', async ({ page }) => {
@@ -6,6 +6,7 @@ test.describe('keyboard-first navigation', () => {
 
     await page.keyboard.press('Enter');
     await expect(page.getByRole('menu')).toContainText('Open Workflow');
+    await captureScreenshot(page, 'keyboard-workflow-context-menu');
     await page.keyboard.press('Escape');
 
     await page.keyboard.press('Shift');
@@ -16,6 +17,7 @@ test.describe('keyboard-first navigation', () => {
 
     await page.keyboard.press('Enter');
     await expect(page.getByRole('menu')).toContainText('Open Terminal');
+    await captureScreenshot(page, 'keyboard-task-context-menu');
   });
 
   test('search jumps to workflows and tasks from the keyboard', async ({ page }) => {
@@ -24,6 +26,8 @@ test.describe('keyboard-first navigation', () => {
     await page.keyboard.press('Shift');
     await page.keyboard.press('Shift');
     await page.getByTestId('keyboard-search-input').fill('E2E Test Plan');
+    await expect(page.getByTestId('keyboard-search-results')).toContainText('E2E Test Plan');
+    await captureScreenshot(page, 'keyboard-search-overlay');
     await page.keyboard.press('Enter');
     await expect(page.getByTestId('selected-workflow-mini-dag')).toContainText('E2E Test Plan task DAG');
 
@@ -42,6 +46,7 @@ test.describe('keyboard-first navigation', () => {
     await page.keyboard.press('Tab');
     await page.keyboard.press('ArrowUp');
     await expect(page.getByTestId('terminal-drawer-body')).toBeVisible();
+    await captureScreenshot(page, 'keyboard-bottom-drawer-expanded');
 
     await page.keyboard.press('ArrowDown');
     await expect(page.getByTestId('terminal-drawer-body')).toBeHidden();

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -45,6 +45,43 @@ type ModalState =
   | { type: 'experiment'; task: TaskState }
   | { type: 'replace'; task: TaskState };
 
+type KeyboardRegion = 'workflowGraph' | 'taskGraph' | 'inspector' | 'bottomBar';
+type SearchResult =
+  | { kind: 'workflow'; id: string; title: string; subtitle: string }
+  | { kind: 'task'; id: string; workflowId: string | null; title: string; subtitle: string };
+
+const KEYBOARD_REGION_ORDER: readonly KeyboardRegion[] = ['workflowGraph', 'taskGraph', 'inspector', 'bottomBar'];
+const STATUS_KEY_ORDER: readonly string[] = [
+  'completed',
+  'running',
+  'failed',
+  'closed',
+  'pending',
+  'needs_input',
+  'review_ready',
+  'awaiting_approval',
+  'blocked',
+  'fixing_with_ai',
+];
+const EDITABLE_SELECTOR = [
+  'input',
+  'textarea',
+  'select',
+  '[contenteditable="true"]',
+  '.xterm',
+  '[role="dialog"] input',
+  '[role="dialog"] textarea',
+].join(',');
+
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return Boolean(target.closest(EDITABLE_SELECTOR));
+}
+
+function normalizedSearchText(value: string | undefined): string {
+  return (value ?? '').toLowerCase();
+}
+
 interface WorkflowContextMenuProps {
   x: number;
   y: number;
@@ -254,7 +291,17 @@ export function App() {
   const [terminalSessions, setTerminalSessions] = useState<TerminalSessionDescriptor[]>([]);
   const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null);
   const [workflowContextMenu, setWorkflowContextMenu] = useState<{ x: number; y: number; workflowId: string } | null>(null);
+  const [keyboardRegion, setKeyboardRegion] = useState<KeyboardRegion>('workflowGraph');
+  const [previousGraphRegion, setPreviousGraphRegion] = useState<KeyboardRegion>('workflowGraph');
+  const [centerWorkflowId, setCenterWorkflowId] = useState<string | null>(null);
+  const [centerTaskId, setCenterTaskId] = useState<string | null>(null);
+  const [bottomStatusIndex, setBottomStatusIndex] = useState(0);
+  const [searchOpen, setSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchActiveIndex, setSearchActiveIndex] = useState(0);
   const uiPerfThrottleRef = useRef<Record<string, number>>({});
+  const lastShiftAtRef = useRef(0);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const refreshSystemDiagnostics = useCallback(() => {
     window.invoker?.getSystemDiagnostics?.().then((diagnostics) => {
@@ -424,6 +471,334 @@ export function App() {
       }
     });
   }, []);
+
+  const visibleStatusKeys = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const task of tasks.values()) {
+      const key = task.status === 'awaiting_approval' && task.execution.pendingFixError ? 'fix_approval' : task.status;
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+    return STATUS_KEY_ORDER.filter((key) => key === 'completed' || key === 'running' || key === 'failed' || key === 'pending' || (counts.get(key) ?? 0) > 0);
+  }, [tasks]);
+
+  const searchResults = useMemo<SearchResult[]>(() => {
+    const query = normalizedSearchText(searchQuery.trim());
+    if (!query) return [];
+    const results: SearchResult[] = [];
+    for (const workflow of workflows.values()) {
+      const workflowTasks = [...tasks.values()].filter((task) => task.config.workflowId === workflow.id);
+      const reviewUrl = workflowTasks.find((task) => task.execution.reviewUrl)?.execution.reviewUrl;
+      const haystack = [
+        workflow.id,
+        workflow.name,
+        workflow.status,
+        workflow.repoUrl,
+        workflow.intermediateRepoUrl,
+        reviewUrl,
+      ].map(normalizedSearchText).join(' ');
+      if (haystack.includes(query)) {
+        results.push({
+          kind: 'workflow',
+          id: workflow.id,
+          title: workflow.name || workflow.id,
+          subtitle: `Workflow · ${workflow.status}`,
+        });
+      }
+    }
+    for (const task of tasks.values()) {
+      const workflow = task.config.workflowId ? workflows.get(task.config.workflowId) : null;
+      const haystack = [
+        task.id,
+        task.description,
+        task.status,
+        task.config.summary,
+        task.config.prompt,
+        task.config.command,
+        task.execution.reviewUrl,
+        workflow?.name,
+      ].map(normalizedSearchText).join(' ');
+      if (haystack.includes(query)) {
+        results.push({
+          kind: 'task',
+          id: task.id,
+          workflowId: task.config.workflowId ?? null,
+          title: task.description || task.id,
+          subtitle: `Task · ${workflow?.name ?? task.config.workflowId ?? 'unknown workflow'}`,
+        });
+      }
+    }
+    return results.slice(0, 12);
+  }, [searchQuery, tasks, workflows]);
+
+  useEffect(() => {
+    setSearchActiveIndex(0);
+  }, [searchQuery]);
+
+  useEffect(() => {
+    if (searchOpen) {
+      const frame = requestAnimationFrame(() => searchInputRef.current?.focus());
+      return () => cancelAnimationFrame(frame);
+    }
+    return undefined;
+  }, [searchOpen]);
+
+  const focusKeyboardRegion = useCallback((region: KeyboardRegion) => {
+    setKeyboardRegion(region);
+    if (region === 'workflowGraph' || region === 'taskGraph') {
+      setPreviousGraphRegion(region);
+    }
+    requestAnimationFrame(() => {
+      document.querySelector<HTMLElement>(`[data-keyboard-region="${region}"]`)?.focus();
+    });
+  }, []);
+
+  const nodeCenter = useCallback((element: Element | null) => {
+    const rect = element?.getBoundingClientRect();
+    if (rect && (rect.width > 0 || rect.height > 0)) {
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+    }
+    return { x: Math.max(24, window.innerWidth / 2), y: Math.max(24, window.innerHeight / 2) };
+  }, []);
+
+  const selectWorkflowById = useCallback((workflowId: string) => {
+    setWorkflowSelectionDismissed(false);
+    setSelectedWorkflowId(workflowId);
+    setSelectedTaskId(null);
+    setContextMenu(null);
+    setWorkflowContextMenu(null);
+    setCenterWorkflowId(workflowId);
+    focusKeyboardRegion('workflowGraph');
+  }, [focusKeyboardRegion]);
+
+  const selectTaskById = useCallback((taskId: string) => {
+    const task = tasks.get(taskId);
+    if (!task) return;
+    setSelectedTaskId(task.id);
+    setWorkflowSelectionDismissed(false);
+    if (task.config.workflowId) {
+      setSelectedWorkflowId(task.config.workflowId);
+      setCenterWorkflowId(task.config.workflowId);
+    }
+    setContextMenu(null);
+    setWorkflowContextMenu(null);
+    setCenterTaskId(task.id);
+    focusKeyboardRegion('taskGraph');
+  }, [focusKeyboardRegion, tasks]);
+
+  const selectRelativeNode = useCallback((direction: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') => {
+    const inTaskGraph = keyboardRegion === 'taskGraph';
+    const nodeRecords = inTaskGraph
+      ? [...document.querySelectorAll<HTMLElement>('[data-testid="selected-workflow-mini-dag"] .react-flow__node')]
+          .map((element) => {
+            const testId = element.getAttribute('data-testid') ?? '';
+            const id = testId.startsWith('rf__node-') ? testId.slice('rf__node-'.length) : null;
+            return id && tasks.has(id) ? { id, element } : null;
+          })
+          .filter((record): record is { id: string; element: HTMLElement } => Boolean(record))
+      : [...document.querySelectorAll<HTMLElement>('[data-testid^="workflow-node-"]')]
+          .map((element) => {
+            const testId = element.getAttribute('data-testid') ?? '';
+            const id = testId.slice('workflow-node-'.length);
+            return workflows.has(id) ? { id, element } : null;
+          })
+          .filter((record): record is { id: string; element: HTMLElement } => Boolean(record));
+
+    if (nodeRecords.length === 0) return;
+    const currentId = inTaskGraph ? selectedTaskId : selectedWorkflow?.id ?? selectedWorkflowId;
+    const sorted = [...nodeRecords].sort((a, b) => a.id.localeCompare(b.id));
+    const current = nodeRecords.find((record) => record.id === currentId) ?? sorted[0];
+    const currentRect = current.element.getBoundingClientRect();
+    const currentCenter = {
+      x: currentRect.left + currentRect.width / 2,
+      y: currentRect.top + currentRect.height / 2,
+    };
+    const isHorizontal = direction === 'ArrowLeft' || direction === 'ArrowRight';
+    const sign = direction === 'ArrowLeft' || direction === 'ArrowUp' ? -1 : 1;
+    const candidates = nodeRecords
+      .filter((record) => record.id !== current.id)
+      .map((record) => {
+        const rect = record.element.getBoundingClientRect();
+        const center = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+        const primaryDelta = isHorizontal ? center.x - currentCenter.x : center.y - currentCenter.y;
+        const secondaryDelta = isHorizontal ? center.y - currentCenter.y : center.x - currentCenter.x;
+        return { ...record, primaryDelta, secondaryDelta };
+      })
+      .filter((record) => Math.sign(record.primaryDelta) === sign && Math.abs(record.primaryDelta) > 0)
+      .sort((a, b) => Math.abs(a.primaryDelta) - Math.abs(b.primaryDelta) || Math.abs(a.secondaryDelta) - Math.abs(b.secondaryDelta));
+
+    const fallbackIndex = Math.max(0, sorted.findIndex((record) => record.id === current.id));
+    const fallback = sorted[Math.min(sorted.length - 1, Math.max(0, fallbackIndex + sign))];
+    const next = candidates[0] ?? fallback;
+    if (!next || next.id === current.id) return;
+    if (inTaskGraph) {
+      selectTaskById(next.id);
+    } else {
+      selectWorkflowById(next.id);
+    }
+  }, [keyboardRegion, selectTaskById, selectWorkflowById, selectedTaskId, selectedWorkflow?.id, selectedWorkflowId, tasks, workflows]);
+
+  const openSelectedContextMenu = useCallback(() => {
+    if (keyboardRegion === 'taskGraph' && selectedTaskId && tasks.has(selectedTaskId)) {
+      const element = [...document.querySelectorAll<HTMLElement>('[data-testid="selected-workflow-mini-dag"] .react-flow__node')]
+        .find((candidate) => (candidate.getAttribute('data-testid') ?? '') === `rf__node-${selectedTaskId}`);
+      const point = nodeCenter(element ?? null);
+      setWorkflowContextMenu(null);
+      setContextMenu({ x: point.x, y: point.y, taskId: selectedTaskId });
+      return;
+    }
+    const workflowId = selectedWorkflow?.id ?? selectedWorkflowId;
+    if (keyboardRegion === 'workflowGraph' && workflowId && workflows.has(workflowId)) {
+      const element = document.querySelector<HTMLElement>(`[data-testid="workflow-node-${workflowId}"]`);
+      const point = nodeCenter(element);
+      setContextMenu(null);
+      setWorkflowContextMenu({ x: point.x, y: point.y, workflowId });
+    }
+  }, [keyboardRegion, nodeCenter, selectedTaskId, selectedWorkflow?.id, selectedWorkflowId, tasks, workflows]);
+
+  const activateSearchResult = useCallback((result: SearchResult | undefined) => {
+    if (!result) return;
+    setSearchOpen(false);
+    setSearchQuery('');
+    if (result.kind === 'workflow') {
+      selectWorkflowById(result.id);
+      return;
+    }
+    selectTaskById(result.id);
+  }, [selectTaskById, selectWorkflowById]);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Shift' && !isEditableKeyboardTarget(event.target)) {
+        const now = Date.now();
+        if (now - lastShiftAtRef.current <= 450) {
+          event.preventDefault();
+          setSearchOpen(true);
+          setSearchQuery('');
+          setSearchActiveIndex(0);
+          lastShiftAtRef.current = 0;
+          return;
+        }
+        lastShiftAtRef.current = now;
+      }
+
+      if (searchOpen) {
+        if (event.key === 'Escape') {
+          event.preventDefault();
+          setSearchOpen(false);
+        } else if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          setSearchActiveIndex((index) => Math.min(searchResults.length - 1, index + 1));
+        } else if (event.key === 'ArrowUp') {
+          event.preventDefault();
+          setSearchActiveIndex((index) => Math.max(0, index - 1));
+        } else if (event.key === 'Enter') {
+          event.preventDefault();
+          activateSearchResult(searchResults[searchActiveIndex]);
+        }
+        return;
+      }
+
+      if (isEditableKeyboardTarget(event.target) || modal.type !== 'none') return;
+
+      if (event.key === 'Tab') {
+        event.preventDefault();
+        const currentIndex = KEYBOARD_REGION_ORDER.indexOf(keyboardRegion);
+        const nextIndex = event.shiftKey
+          ? (currentIndex - 1 + KEYBOARD_REGION_ORDER.length) % KEYBOARD_REGION_ORDER.length
+          : (currentIndex + 1) % KEYBOARD_REGION_ORDER.length;
+        focusKeyboardRegion(KEYBOARD_REGION_ORDER[nextIndex]);
+        return;
+      }
+
+      if (event.key === 'Escape') {
+        if (keyboardRegion === 'inspector') {
+          event.preventDefault();
+          focusKeyboardRegion(previousGraphRegion);
+        }
+        return;
+      }
+
+      if (keyboardRegion === 'workflowGraph' || keyboardRegion === 'taskGraph') {
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          openSelectedContextMenu();
+          return;
+        }
+        if (event.key === 'Home' && keyboardRegion === 'taskGraph') {
+          event.preventDefault();
+          const firstTask = [...miniDagTasks.values()].sort((a, b) => a.dependencies.length - b.dependencies.length || a.id.localeCompare(b.id))[0];
+          if (firstTask) selectTaskById(firstTask.id);
+          return;
+        }
+        if (event.key === 'End' && keyboardRegion === 'taskGraph') {
+          event.preventDefault();
+          const terminalTask = [...miniDagTasks.values()].sort((a, b) => Number(Boolean(b.config.isMergeNode)) - Number(Boolean(a.config.isMergeNode)) || b.id.localeCompare(a.id))[0];
+          if (terminalTask) selectTaskById(terminalTask.id);
+          return;
+        }
+        if (event.key === 'ArrowUp' || event.key === 'ArrowDown' || event.key === 'ArrowLeft' || event.key === 'ArrowRight') {
+          event.preventDefault();
+          selectRelativeNode(event.key);
+        }
+        return;
+      }
+
+      if (keyboardRegion === 'inspector') {
+        if (event.key === 'ArrowLeft') {
+          event.preventDefault();
+          setInspectorCollapsed(false);
+        } else if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          setInspectorCollapsed(true);
+        } else if (event.key === 'Enter') {
+          event.preventDefault();
+          document.querySelector<HTMLElement>('[data-keyboard-region="inspector"] button, [data-keyboard-region="inspector"] select, [data-keyboard-region="inspector"] input')?.focus();
+        }
+        return;
+      }
+
+      if (keyboardRegion === 'bottomBar') {
+        if (event.key === 'ArrowUp') {
+          event.preventDefault();
+          setTerminalCollapsed(false);
+        } else if (event.key === 'ArrowDown') {
+          event.preventDefault();
+          setTerminalCollapsed(true);
+        } else if (event.key === 'ArrowRight') {
+          event.preventDefault();
+          setBottomStatusIndex((index) => Math.min(visibleStatusKeys.length - 1, index + 1));
+        } else if (event.key === 'ArrowLeft') {
+          event.preventDefault();
+          setBottomStatusIndex((index) => Math.max(0, index - 1));
+        } else if (event.key === 'Enter') {
+          event.preventDefault();
+          const key = visibleStatusKeys[bottomStatusIndex] ?? visibleStatusKeys[0];
+          if (key) {
+            handleStatusClick(key as WorkflowStatus, { ctrlKey: false, metaKey: false } as React.MouseEvent);
+          }
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [
+    activateSearchResult,
+    bottomStatusIndex,
+    focusKeyboardRegion,
+    handleStatusClick,
+    keyboardRegion,
+    miniDagTasks,
+    modal.type,
+    openSelectedContextMenu,
+    previousGraphRegion,
+    searchActiveIndex,
+    searchOpen,
+    searchResults,
+    selectRelativeNode,
+    selectTaskById,
+    visibleStatusKeys,
+  ]);
   const missingRequiredTool = systemDiagnostics?.tools.find((tool) => tool.required && !tool.installed) ?? null;
   const installedAgentCount = systemDiagnostics?.tools.filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed).length ?? 0;
   const needsBundledSkillsPrompt = Boolean(systemDiagnostics?.isPackaged && systemDiagnostics?.bundledSkills?.promptRecommended);
@@ -1154,7 +1529,10 @@ export function App() {
             <div
               ref={graphSurfaceRef}
               data-testid="workflow-graph-surface"
-              className="flex-1 relative overflow-hidden border-r border-gray-800 bg-gray-900"
+              data-keyboard-region="workflowGraph"
+              tabIndex={0}
+              data-keyboard-active={keyboardRegion === 'workflowGraph' ? 'true' : 'false'}
+              className={`flex-1 relative overflow-hidden border-r border-gray-800 bg-gray-900 outline-none ${keyboardRegion === 'workflowGraph' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
               onClick={viewMode === 'dag' ? handleDagSurfaceClick : undefined}
             >
               {viewMode === 'queue' ? (
@@ -1183,6 +1561,7 @@ export function App() {
                     tasks={tasks}
                     workflows={workflows}
                     selectedWorkflowId={selectedWorkflow?.id ?? null}
+                    centerWorkflowId={centerWorkflowId}
                     statusFilters={statusFilters}
                     onSelectWorkflow={handleWorkflowClick}
                     onWorkflowContextMenu={handleWorkflowContextMenu}
@@ -1196,15 +1575,23 @@ export function App() {
                       boundsRef={graphSurfaceRef}
                       contentClassName="h-[250px]"
                     >
-                      <TaskDAG
-                        tasks={miniDagTasks}
-                        workflows={workflows}
-                        selectedTaskId={selectedTaskId}
-                        onTaskClick={handleTaskClick}
-                        onTaskDoubleClick={handleTaskDoubleClick}
-                        onTaskContextMenu={handleTaskContextMenu}
-                        statusFilters={new Set()}
-                      />
+                      <div
+                        data-keyboard-region="taskGraph"
+                        tabIndex={0}
+                        data-keyboard-active={keyboardRegion === 'taskGraph' ? 'true' : 'false'}
+                        className={`h-full outline-none ${keyboardRegion === 'taskGraph' ? 'ring-2 ring-inset ring-blue-300/60' : ''}`}
+                      >
+                        <TaskDAG
+                          tasks={miniDagTasks}
+                          workflows={workflows}
+                          selectedTaskId={selectedTaskId}
+                          centerTaskId={centerTaskId}
+                          onTaskClick={handleTaskClick}
+                          onTaskDoubleClick={handleTaskDoubleClick}
+                          onTaskContextMenu={handleTaskContextMenu}
+                          statusFilters={new Set()}
+                        />
+                      </div>
                     </FloatingGraphPanel>
                   )}
                 </>
@@ -1212,10 +1599,16 @@ export function App() {
             </div>
 
             {viewMode === 'dag' && (
-              <>
+              <div
+                data-keyboard-region="bottomBar"
+                tabIndex={0}
+                data-keyboard-active={keyboardRegion === 'bottomBar' ? 'true' : 'false'}
+                className={`outline-none ${keyboardRegion === 'bottomBar' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+              >
                 <StatusBar
                   tasks={tasks}
                   activeFilters={statusFilters}
+                  keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
                   onStatusClick={(filterKey, event) => handleStatusClick(filterKey as WorkflowStatus, event)}
                 />
                 <TerminalDrawer
@@ -1227,11 +1620,16 @@ export function App() {
                   onCloseSession={(sessionId) => void handleCloseTerminalSession(sessionId)}
                   taskLabels={terminalTaskLabels}
                 />
-              </>
+              </div>
             )}
           </div>
 
-          <div className={`${inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150`}>
+          <div
+            data-keyboard-region="inspector"
+            tabIndex={0}
+            data-keyboard-active={keyboardRegion === 'inspector' ? 'true' : 'false'}
+            className={`${inspectorCollapsed ? 'w-16' : 'w-96'} transition-all duration-150 outline-none ${keyboardRegion === 'inspector' ? 'ring-2 ring-inset ring-blue-400/50' : ''}`}
+          >
             <WorkflowInspector
               workflow={selectedWorkflow}
               task={selectedTask}
@@ -1254,6 +1652,58 @@ export function App() {
           </div>
         </div>
       </div>
+
+      {searchOpen && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Search workflows and tasks"
+          data-testid="keyboard-search-overlay"
+          className="fixed inset-0 z-40 flex items-start justify-center bg-black/45 px-4 pt-[12vh]"
+          onClick={() => setSearchOpen(false)}
+        >
+          <div
+            className="w-full max-w-2xl overflow-hidden rounded-lg border border-gray-700 bg-gray-900 shadow-2xl"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <input
+              ref={searchInputRef}
+              data-testid="keyboard-search-input"
+              value={searchQuery}
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder="Search workflows, tasks, summaries, commands, or PRs"
+              className="w-full border-b border-gray-800 bg-gray-950 px-4 py-3 text-sm text-gray-100 outline-none placeholder:text-gray-500"
+            />
+            <div
+              role="listbox"
+              data-testid="keyboard-search-results"
+              className="max-h-[360px] overflow-auto py-1"
+            >
+              {searchQuery.trim() && searchResults.length === 0 && (
+                <div className="px-4 py-6 text-center text-sm text-gray-500">No matches</div>
+              )}
+              {!searchQuery.trim() && (
+                <div className="px-4 py-6 text-center text-sm text-gray-500">Start typing to search workflows and tasks</div>
+              )}
+              {searchResults.map((result, index) => (
+                <button
+                  key={`${result.kind}:${result.id}`}
+                  type="button"
+                  role="option"
+                  aria-selected={index === searchActiveIndex}
+                  data-testid={`keyboard-search-result-${result.kind}-${result.id}`}
+                  className={`flex w-full flex-col px-4 py-2 text-left text-sm ${index === searchActiveIndex ? 'bg-blue-600/25 text-white' : 'text-gray-200 hover:bg-gray-800'}`}
+                  onMouseEnter={() => setSearchActiveIndex(index)}
+                  onClick={() => activateSearchResult(result)}
+                >
+                  <span className="truncate font-medium">{result.title}</span>
+                  <span className="truncate text-xs text-gray-400">{result.subtitle}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
 
       {/* Modals */}
       {modal.type === 'input' && (

--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -18,6 +18,7 @@ import { vi } from 'vitest';
 
 export function createReactFlowMock() {
   const fitView = vi.fn();
+  const setCenter = vi.fn();
   const MockReactFlow = React.forwardRef(function MockReactFlow(
     props: {
       nodes?: Array<{
@@ -86,7 +87,8 @@ export function createReactFlowMock() {
   return {
     ReactFlow: MockReactFlow,
     ReactFlowProvider: MockReactFlowProvider,
-    useReactFlow: () => ({ fitView }),
+    useReactFlow: () => ({ fitView, setCenter }),
+    __setCenterMock: setCenter,
     __fitViewMock: fitView,
     applyNodeChanges: vi.fn((changes: unknown[], nodes: unknown[]) => nodes),
     Background: () => null,

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -8,7 +8,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
-import { createMockInvoker, type MockInvoker } from './helpers/mock-invoker.js';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
 
 vi.mock('@xyflow/react', async () => {
   const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
@@ -16,6 +17,44 @@ vi.mock('@xyflow/react', async () => {
 });
 
 const { App } = await import('../App.js');
+
+const workflows: WorkflowMeta[] = [
+  { id: 'wf-a', name: 'Alpha Workflow', status: 'running' },
+  { id: 'wf-b', name: 'Beta Workflow', status: 'pending' },
+];
+
+const tasks = [
+  makeUITask({
+    id: 'wf-a/task-a',
+    description: 'Alpha Task',
+    workflowId: 'wf-a',
+    command: 'echo alpha',
+  }),
+  makeUITask({
+    id: 'wf-a/task-b',
+    description: 'Second Task',
+    workflowId: 'wf-a',
+    command: 'echo second',
+    dependencies: ['wf-a/task-a'],
+  }),
+  makeUITask({
+    id: 'wf-b/task-c',
+    description: 'Beta Task',
+    workflowId: 'wf-b',
+    command: 'echo beta',
+  }),
+];
+
+async function renderKeyboardFixture(mock: MockInvoker) {
+  mock.setTasks(tasks, workflows);
+  render(<App />);
+  await screen.findByTestId('workflow-node-wf-a');
+  await screen.findByTestId('selected-workflow-mini-dag');
+}
+
+function key(keyName: string, init: Partial<KeyboardEvent> = {}) {
+  fireEvent.keyDown(document, { key: keyName, ...init });
+}
 
 describe('Side rail controls (component)', () => {
   let mock: MockInvoker;
@@ -46,5 +85,104 @@ describe('Side rail controls (component)', () => {
     await waitFor(() => {
       expect(mock.api.clear).toHaveBeenCalled();
     });
+  });
+
+  it('cycles major keyboard regions with Tab', async () => {
+    await renderKeyboardFixture(mock);
+
+    expect(screen.getByTestId('workflow-graph-surface')).toHaveAttribute('data-keyboard-active', 'true');
+    key('Tab');
+    expect(screen.getByTestId('selected-workflow-mini-dag').querySelector('[data-keyboard-region="taskGraph"]')).toHaveAttribute('data-keyboard-active', 'true');
+    key('Tab');
+    expect(document.querySelector('[data-keyboard-region="inspector"]')).toHaveAttribute('data-keyboard-active', 'true');
+    key('Tab');
+    expect(document.querySelector('[data-keyboard-region="bottomBar"]')).toHaveAttribute('data-keyboard-active', 'true');
+  });
+
+  it('navigates workflow nodes with arrows and opens workflow menu with Enter', async () => {
+    await renderKeyboardFixture(mock);
+
+    key('ArrowRight');
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Beta Workflow task DAG');
+    });
+
+    key('Enter');
+    expect(await screen.findByRole('menu')).toHaveTextContent('Open Workflow');
+  });
+
+  it('navigates task nodes with arrows and opens task menu with Enter', async () => {
+    await renderKeyboardFixture(mock);
+
+    key('Tab');
+    key('ArrowRight');
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Second Task');
+    });
+
+    key('Enter');
+    expect(await screen.findByRole('menu')).toHaveTextContent('Open Terminal');
+  });
+
+  it('expands and collapses the inspector with region arrow keys', async () => {
+    await renderKeyboardFixture(mock);
+
+    key('Tab');
+    key('Tab');
+    key('ArrowRight');
+    expect(await screen.findByLabelText('Maximize inspector')).toBeInTheDocument();
+
+    key('ArrowLeft');
+    expect(await screen.findByLabelText('Minimize inspector')).toBeInTheDocument();
+  });
+
+  it('expands and collapses the terminal drawer from the bottom region', async () => {
+    await renderKeyboardFixture(mock);
+
+    key('Tab');
+    key('Tab');
+    key('Tab');
+    key('ArrowUp');
+    expect(await screen.findByTestId('terminal-drawer-body')).toBeInTheDocument();
+
+    key('ArrowDown');
+    await waitFor(() => {
+      expect(screen.queryByTestId('terminal-drawer-body')).not.toBeInTheDocument();
+    });
+  });
+
+  it('opens search with double Shift and activates workflow and task results', async () => {
+    await renderKeyboardFixture(mock);
+
+    key('Shift');
+    key('Shift');
+    const input = await screen.findByTestId('keyboard-search-input');
+    fireEvent.change(input, { target: { value: 'beta workflow' } });
+    key('Enter');
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Beta Workflow task DAG');
+    });
+
+    key('Shift');
+    key('Shift');
+    const taskInput = await screen.findByTestId('keyboard-search-input');
+    fireEvent.change(taskInput, { target: { value: 'second task' } });
+    key('Enter');
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Second Task');
+    });
+  });
+
+  it('does not let region shortcuts steal focus while typing in search', async () => {
+    await renderKeyboardFixture(mock);
+
+    key('Shift');
+    key('Shift');
+    const input = await screen.findByTestId('keyboard-search-input');
+    fireEvent.change(input, { target: { value: 'alpha' } });
+    fireEvent.keyDown(input, { key: 'Tab' });
+
+    expect(screen.getByTestId('keyboard-search-overlay')).toBeInTheDocument();
+    expect(screen.getByTestId('workflow-graph-surface')).toHaveAttribute('data-keyboard-active', 'true');
   });
 });

--- a/packages/ui/src/components/StatusBar.tsx
+++ b/packages/ui/src/components/StatusBar.tsx
@@ -12,10 +12,11 @@ import { getStatusVisual } from '../lib/status-colors.js';
 interface StatusBarProps {
   tasks: Map<string, TaskState>;
   activeFilters?: Set<string>;
+  keyboardActiveKey?: string | null;
   onStatusClick?: (filterKey: string, event: React.MouseEvent) => void;
 }
 
-export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProps) {
+export function StatusBar({ tasks, activeFilters, keyboardActiveKey, onStatusClick }: StatusBarProps) {
   let completed = 0;
   let running = 0;
   let failed = 0;
@@ -76,11 +77,12 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
   const hasFilters = activeFilters && activeFilters.size > 0;
   const filterClass = (key: string) => {
     const baseClasses = 'px-2 py-0.5 text-xs rounded-full cursor-pointer select-none transition-opacity duration-75';
-    if (!hasFilters) return `${baseClasses} hover:brightness-125`;
+    const keyboardClass = keyboardActiveKey === key ? ' ring-2 ring-blue-300/90 ring-offset-1 ring-offset-gray-800' : '';
+    if (!hasFilters) return `${baseClasses}${keyboardClass} hover:brightness-125`;
     const isActive = activeFilters!.has(key);
     return `${baseClasses} ${
       isActive ? 'ring-1 ring-current' : 'opacity-60'
-    }`;
+    }${keyboardClass}`;
   };
   const statusTextClass = (key: string) => getStatusVisual(key).text;
 
@@ -91,6 +93,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       </span>
       <span
         data-testid="status-bar-pill-completed"
+        data-status-key="completed"
         className={`${statusTextClass('completed')} ${filterClass('completed')}`}
         onClick={(e) => onStatusClick?.('completed', e)}
       >
@@ -99,6 +102,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       </span>
       <span
         data-testid="status-bar-pill-running"
+        data-status-key="running"
         className={`${statusTextClass('running')} ${filterClass('running')}`}
         onClick={(e) => onStatusClick?.('running', e)}
       >
@@ -107,6 +111,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       </span>
       <span
         data-testid="status-bar-pill-failed"
+        data-status-key="failed"
         className={`${statusTextClass('failed')} ${filterClass('failed')}`}
         onClick={(e) => onStatusClick?.('failed', e)}
       >
@@ -116,6 +121,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       {closed > 0 && (
         <span
           data-testid="status-bar-pill-closed"
+          data-status-key="closed"
           className={`${statusTextClass('closed')} ${filterClass('closed')}`}
           onClick={(e) => onStatusClick?.('closed', e)}
         >
@@ -124,6 +130,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       )}
       <span
         data-testid="status-bar-pill-pending"
+        data-status-key="pending"
         className={`${statusTextClass('pending')} ${filterClass('pending')}`}
         onClick={(e) => onStatusClick?.('pending', e)}
       >
@@ -133,6 +140,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       {needsInput > 0 && (
         <span
           data-testid="status-bar-pill-needs_input"
+          data-status-key="needs_input"
           className={`${statusTextClass('needs_input')} ${filterClass('needs_input')}`}
           onClick={(e) => onStatusClick?.('needs_input', e)}
         >
@@ -142,6 +150,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       {reviewReady > 0 && (
         <span
           data-testid="status-bar-pill-review_ready"
+          data-status-key="review_ready"
           className={`${statusTextClass('review_ready')} ${filterClass('review_ready')}`}
           onClick={(e) => onStatusClick?.('review_ready', e)}
         >
@@ -151,6 +160,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       {awaitingApproval > 0 && (
         <span
           data-testid="status-bar-pill-awaiting_approval"
+          data-status-key="awaiting_approval"
           className={`${statusTextClass('awaiting_approval')} ${filterClass('awaiting_approval')}`}
           onClick={(e) => onStatusClick?.('awaiting_approval', e)}
         >
@@ -160,6 +170,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       {blocked > 0 && (
         <span
           data-testid="status-bar-pill-blocked"
+          data-status-key="blocked"
           className={`${statusTextClass('blocked')} ${filterClass('blocked')}`}
           onClick={(e) => onStatusClick?.('blocked', e)}
         >
@@ -169,6 +180,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       {fixing > 0 && (
         <span
           data-testid="status-bar-pill-fixing_with_ai"
+          data-status-key="fixing_with_ai"
           className={`${statusTextClass('fixing_with_ai')} ${filterClass('fixing_with_ai')}`}
           onClick={(e) => onStatusClick?.('fixing_with_ai', e)}
         >
@@ -178,6 +190,7 @@ export function StatusBar({ tasks, activeFilters, onStatusClick }: StatusBarProp
       {fixApproval > 0 && (
         <span
           data-testid="status-bar-pill-fix_approval"
+          data-status-key="fix_approval"
           className={`${statusTextClass('fix_approval')} ${filterClass('fix_approval')}`}
           onClick={(e) => onStatusClick?.('fix_approval', e)}
         >

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -40,6 +40,7 @@ interface TaskDAGProps {
   tasks: Map<string, TaskState>;
   workflows?: Map<string, WorkflowMeta>;
   selectedTaskId?: string | null;
+  centerTaskId?: string | null;
   onTaskClick?: (task: TaskState) => void;
   onTaskDoubleClick?: (task: TaskState) => void;
   onTaskContextMenu?: (task: TaskState, event: React.MouseEvent) => void;
@@ -142,8 +143,8 @@ function mergeMeasuredNodeState(prevNodes: Node[], nextNodes: Node[]): Node[] {
   });
 }
 
-function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDoubleClick, onTaskContextMenu, statusFilters }: TaskDAGProps) {
-  const { fitView } = useReactFlow();
+function TaskDAGInner({ tasks, workflows, selectedTaskId, centerTaskId, onTaskClick, onTaskDoubleClick, onTaskContextMenu, statusFilters }: TaskDAGProps) {
+  const { fitView, setCenter } = useReactFlow();
   const prevNodeCount = useRef(0);
   const lastNodeClickRef = useRef<{ id: string; at: number } | null>(null);
   const reportedGraphVisibleRef = useRef(false);
@@ -417,6 +418,20 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, onTaskClick, onTaskDou
       requestAnimationFrame(() => fitView({ padding: 0.2 }));
     }
   }, [nodes.length, fitView]);
+
+  useEffect(() => {
+    if (!centerTaskId || nodes.length === 0) return;
+    const node = nodes.find((candidate) => candidate.id === centerTaskId);
+    if (!node) return;
+    const frame = requestAnimationFrame(() => {
+      if (typeof setCenter === 'function') {
+        setCenter(node.position.x + 132, node.position.y + 55, { zoom: 1, duration: 180 });
+      } else {
+        fitView({ padding: 0.2 });
+      }
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [centerTaskId, fitView, nodes, setCenter]);
 
   useEffect(() => {
     if (reportedGraphVisibleRef.current || nodes.length === 0 || typeof window === 'undefined') {

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -22,6 +22,7 @@ interface WorkflowGraphProps {
   tasks: Map<string, TaskState>;
   workflows: Map<string, WorkflowMeta>;
   selectedWorkflowId: string | null;
+  centerWorkflowId?: string | null;
   statusFilters: Set<WorkflowStatus>;
   onSelectWorkflow: (workflowId: string) => void;
   onWorkflowContextMenu: (event: MouseEvent, workflowId: string) => void;
@@ -67,11 +68,12 @@ function WorkflowGraphInner({
   tasks,
   workflows,
   selectedWorkflowId,
+  centerWorkflowId,
   statusFilters,
   onSelectWorkflow,
   onWorkflowContextMenu,
 }: WorkflowGraphProps): JSX.Element {
-  const { fitView } = useReactFlow();
+  const { fitView, setCenter } = useReactFlow();
   const prevNodeCount = useRef(0);
   const reportedVisibleRef = useRef(false);
   const graphMetricsRef = useRef({ deriveMs: 0, layoutMs: 0, objectsMs: 0 });
@@ -188,6 +190,20 @@ function WorkflowGraphInner({
     });
     return () => cancelAnimationFrame(frame);
   }, [fitView, graph.nodes.length, graphSignature]);
+
+  useEffect(() => {
+    if (!centerWorkflowId || nodes.length === 0) return;
+    const node = nodes.find((candidate) => candidate.id === centerWorkflowId);
+    if (!node) return;
+    const frame = requestAnimationFrame(() => {
+      if (typeof setCenter === 'function') {
+        setCenter(node.position.x + 110, node.position.y + 45, { zoom: 1, duration: 180 });
+      } else {
+        fitView({ padding: 0.2 });
+      }
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [centerWorkflowId, fitView, nodes, setCenter]);
 
   useEffect(() => {
     if (nodes.length === 0) return;


### PR DESCRIPTION
## Summary

Add keyboard-first navigation to the Invoker UI so users can move through the workflow graph, selected workflow task graph, inspector, bottom controls, and global search without using the mouse.

- Adds region-mode keyboard focus for workflow graph, task graph, inspector, and bottom bar.
- Adds arrow-key graph traversal, Enter-to-context-menu, inspector collapse/expand keys, bottom drawer keys, and double-Shift search.
- Adds UI component coverage and Electron interactor coverage for the new keyboard flows.

Visual proof:

![Keyboard workflow context menu](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260518-416ed6/keyboard-workflow-context-menu.png)

![Keyboard task context menu](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260518-416ed6/keyboard-task-context-menu.png)

![Keyboard search overlay](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260518-416ed6/keyboard-search-overlay.png)

![Keyboard bottom drawer expanded](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260518-416ed6/keyboard-bottom-drawer-expanded.png)

## Architecture

### Before

```mermaid
flowchart LR
  User[User input] --> Mouse[Mouse clicks and right-clicks]
  Mouse --> App[App selection state]
  App --> Graphs[WorkflowGraph and TaskDAG]
  App --> Inspector[WorkflowInspector]
  App --> Bottom[StatusBar and TerminalDrawer]
```

### After

```mermaid
flowchart LR
  Keyboard[Keyboard events] --> Controller[App keyboard navigation controller]
  Controller --> Region[Active region state]
  Controller --> Search[Double-Shift search overlay]
  Region --> Graphs[WorkflowGraph and TaskDAG selection and centering]
  Region --> Inspector[WorkflowInspector expand/collapse/focus]
  Region --> Bottom[StatusBar highlight and TerminalDrawer expand/collapse]
  Search --> App[Workflow/task selection state]
```

## Test Plan

- [x] `pnpm --filter @invoker/ui test -- keyboard-controls.test.tsx`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/keyboard-navigation.spec.ts`
- [x] `CAPTURE_MODE=after pnpm --filter @invoker/app exec playwright test e2e/keyboard-navigation.spec.ts`
- [x] `node scripts/upload-pr-images.mjs packages/app/e2e/visual-proof/after/keyboard-workflow-context-menu.png packages/app/e2e/visual-proof/after/keyboard-task-context-menu.png packages/app/e2e/visual-proof/after/keyboard-search-overlay.png packages/app/e2e/visual-proof/after/keyboard-bottom-drawer-expanded.png`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 473558a6`
- Post-revert steps: Re-run `pnpm --filter @invoker/ui test -- keyboard-controls.test.tsx`
- Data migration? No
