### PR TITLE
Add review gate status worker

### DIFF
--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -65,7 +65,7 @@ function buildPlan(index: number) {
 
 async function waitForWorkflowGraphVisible(page: Page, timeoutMs: number): Promise<number> {
   const startedAt = Date.now();
-  await page.locator('[data-testid^="workflow-node-"]').first().waitFor({
+  await page.locator('[data-testid^="workflow-node-"]:visible').first().waitFor({
     state: 'visible',
     timeout: timeoutMs,
   });

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -592,7 +592,6 @@ describe('merge gate open-terminal', () => {
       detectDefaultBranch: vi.fn(),
       gitLogMessage: vi.fn(),
       gitDiffStat: vi.fn(),
-      startPrPolling: vi.fn(),
       executeTasks: vi.fn(),
       buildMergeSummary: vi.fn(),
       consolidateAndMerge: vi.fn(),

--- a/packages/app/src/__tests__/review-gate-status-worker.test.ts
+++ b/packages/app/src/__tests__/review-gate-status-worker.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { startReviewGateStatusWorker } from '../review-gate-status-worker.js';
+
+const logger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+};
+
+describe('review-gate status worker', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('starts in owner mode', async () => {
+    vi.useFakeTimers();
+    const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
+
+    const worker = startReviewGateStatusWorker({
+      ownerMode: true,
+      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+      logger,
+      intervalMs: 1000,
+    });
+
+    expect(worker).not.toBeNull();
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(checkMergeGateStatuses).toHaveBeenCalledTimes(1);
+    worker?.stop();
+  });
+
+  it('starts in owner mode even when startup auto-run is disabled', async () => {
+    vi.useFakeTimers();
+    const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
+
+    const worker = startReviewGateStatusWorker({
+      ownerMode: true,
+      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+      logger,
+      intervalMs: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(checkMergeGateStatuses).toHaveBeenCalledTimes(1);
+    worker?.stop();
+  });
+
+  it('does not start in follower or read-only mode', async () => {
+    vi.useFakeTimers();
+    const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
+
+    const worker = startReviewGateStatusWorker({
+      ownerMode: false,
+      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+      logger,
+      intervalMs: 1000,
+    });
+
+    expect(worker).toBeNull();
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(checkMergeGateStatuses).not.toHaveBeenCalled();
+  });
+
+  it('does not overlap ticks', async () => {
+    vi.useFakeTimers();
+    let resolveFirst!: () => void;
+    const firstTick = new Promise<void>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const checkMergeGateStatuses = vi.fn()
+      .mockReturnValueOnce(firstTick)
+      .mockResolvedValue(undefined);
+
+    const worker = startReviewGateStatusWorker({
+      ownerMode: true,
+      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+      logger,
+      intervalMs: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(checkMergeGateStatuses).toHaveBeenCalledTimes(1);
+
+    resolveFirst();
+    await firstTick;
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(checkMergeGateStatuses).toHaveBeenCalledTimes(2);
+    worker?.stop();
+  });
+
+  it('continues after a tick error', async () => {
+    vi.useFakeTimers();
+    const checkMergeGateStatuses = vi.fn()
+      .mockRejectedValueOnce(new Error('temporary failure'))
+      .mockResolvedValue(undefined);
+
+    const worker = startReviewGateStatusWorker({
+      ownerMode: true,
+      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+      logger,
+      intervalMs: 1000,
+    });
+
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(checkMergeGateStatuses).toHaveBeenCalledTimes(2);
+    expect(logger.error).toHaveBeenCalledWith('review-gate status worker tick failed', expect.any(Object));
+    worker?.stop();
+  });
+
+  it('clears the interval on shutdown', async () => {
+    vi.useFakeTimers();
+    const checkMergeGateStatuses = vi.fn().mockResolvedValue(undefined);
+
+    const worker = startReviewGateStatusWorker({
+      ownerMode: true,
+      getTaskExecutor: () => ({ checkMergeGateStatuses }),
+      logger,
+      intervalMs: 1000,
+    });
+
+    worker?.stop();
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(checkMergeGateStatuses).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -173,6 +173,7 @@ import {
   resolveActionDiagnosticsStallThresholdMs,
 } from './action-graph-diagnostics.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
+import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -723,6 +724,7 @@ if (isHeadless) {
     }
 
     let exitCode = 0;
+    let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
     try {
       // Standalone mode: initialize services and run headless
       await initServices({
@@ -1024,7 +1026,6 @@ if (isHeadless) {
               logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
             });
           }
-          executor.resumeMergeGatePolling();
           const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
           return { workflowId, tasks };
         };
@@ -1121,6 +1122,12 @@ if (isHeadless) {
           });
           return { ok: true };
         });
+
+        reviewGateStatusWorker = startReviewGateStatusWorker({
+          ownerMode: true,
+          getTaskExecutor: createStandaloneTaskExecutor,
+          logger,
+        });
       }
 
       await runHeadless(cliArgs, headlessDeps);
@@ -1128,6 +1135,7 @@ if (isHeadless) {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
       exitCode = 1;
     } finally {
+      reviewGateStatusWorker?.stop();
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
       }
@@ -1186,6 +1194,7 @@ function createEmbeddedTerminalBackendFromConfig(
   const agentRegistry = registerBuiltinAgents();
   let mainWindow: BrowserWindow | null = null;
   let taskExecutor: TaskRunner | null = null;
+  let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
   let apiServer: ApiServer | null = null;
   let ownerMode = true;
   const taskHandles = new Map<string, { handle: ExecutorHandle; executor: Executor }>();
@@ -1805,7 +1814,6 @@ function createEmbeddedTerminalBackendFromConfig(
         logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
       });
     }
-    requireTaskExecutor().resumeMergeGatePolling();
     const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
     return { workflowId, tasks };
   }
@@ -2726,6 +2734,12 @@ function createEmbeddedTerminalBackendFromConfig(
 
     bootstrapInitialWorkflowState();
 
+    reviewGateStatusWorker = startReviewGateStatusWorker({
+      ownerMode,
+      getTaskExecutor: requireTaskExecutor,
+      logger,
+    });
+
     // Relaunch orphaned running tasks and start any pending-but-ready tasks.
     if (!ownerMode) {
       logger.info('follower mode startup: auto-run and orphan relaunch disabled', { module: 'init' });
@@ -2736,7 +2750,6 @@ function createEmbeddedTerminalBackendFromConfig(
       if (allStarted.length > 0) {
         requireTaskExecutor().executeTasks(allStarted);
       }
-      requireTaskExecutor().resumeMergeGatePolling();
     }
 
     const dbPath = path.join(resolveInvokerHomeRoot(), 'invoker.db');
@@ -2890,7 +2903,6 @@ function createEmbeddedTerminalBackendFromConfig(
       if (allStarted.length > 0) {
         void requireTaskExecutor().executeTasks(allStarted);
       }
-      requireTaskExecutor().resumeMergeGatePolling();
       return { workflow: workflows[0], taskCount: tasks.length, startedCount: allStarted.length };
     });
 
@@ -3897,6 +3909,8 @@ function createEmbeddedTerminalBackendFromConfig(
 
     try {
       if (apiServer) await apiServer.close().catch(() => {});
+      reviewGateStatusWorker?.stop();
+      reviewGateStatusWorker = null;
       if (dbPollInterval) clearInterval(dbPollInterval);
       if (activityPollInterval) clearInterval(activityPollInterval);
       if (uiPerfLogInterval) clearInterval(uiPerfLogInterval);

--- a/packages/app/src/review-gate-status-worker.ts
+++ b/packages/app/src/review-gate-status-worker.ts
@@ -1,0 +1,64 @@
+import type { Logger } from '@invoker/contracts';
+import type { TaskRunner } from '@invoker/execution-engine';
+
+export interface ReviewGateStatusWorker {
+  tick(): Promise<void>;
+  stop(): void;
+}
+
+export interface ReviewGateStatusWorkerOptions {
+  ownerMode: boolean;
+  getTaskExecutor: () => Pick<TaskRunner, 'checkMergeGateStatuses'>;
+  logger: Logger;
+  intervalMs?: number;
+}
+
+const DEFAULT_REVIEW_GATE_STATUS_WORKER_INTERVAL_MS = 60_000;
+
+export function startReviewGateStatusWorker(
+  options: ReviewGateStatusWorkerOptions,
+): ReviewGateStatusWorker | null {
+  if (!options.ownerMode) {
+    options.logger.info('review-gate status worker disabled outside owner mode', { module: 'merge-gate' });
+    return null;
+  }
+
+  const intervalMs = options.intervalMs ?? DEFAULT_REVIEW_GATE_STATUS_WORKER_INTERVAL_MS;
+  let stopped = false;
+  let inFlight = false;
+
+  const tick = async (): Promise<void> => {
+    if (stopped) return;
+    if (inFlight) {
+      options.logger.info('review-gate status worker tick skipped because previous tick is still running', {
+        module: 'merge-gate',
+      });
+      return;
+    }
+    inFlight = true;
+    try {
+      await options.getTaskExecutor().checkMergeGateStatuses();
+    } catch (err) {
+      options.logger.error('review-gate status worker tick failed', { module: 'merge-gate', err });
+    } finally {
+      inFlight = false;
+    }
+  };
+
+  const interval = setInterval(() => {
+    void tick();
+  }, intervalMs);
+  interval.unref?.();
+
+  options.logger.info(`review-gate status worker started intervalMs=${intervalMs}`, { module: 'merge-gate' });
+
+  return {
+    tick,
+    stop: () => {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(interval);
+      options.logger.info('review-gate status worker stopped', { module: 'merge-gate' });
+    },
+  };
+}

--- a/packages/execution-engine/src/__tests__/ensure-local-branch-for-merge.test.ts
+++ b/packages/execution-engine/src/__tests__/ensure-local-branch-for-merge.test.ts
@@ -83,7 +83,6 @@ describe('ensureLocalBranchForMerge pool mirror fallback', () => {
       async gitDiffStat() {
         return '';
       },
-      startPrPolling() {},
       async executeTasks() {},
       async consolidateAndMerge() {
         return undefined;

--- a/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
+++ b/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
@@ -106,7 +106,6 @@ function makeHost(hostDir: string, gateDir: string, allTasks: TaskState[]): Merg
     async detectDefaultBranch() { return 'master'; },
     async gitLogMessage() { return ''; },
     async gitDiffStat() { return ''; },
-    startPrPolling: vi.fn(),
     async executeTasks() {},
     async buildMergeSummary() { return '## Summary'; },
     async consolidateAndMerge() { return undefined; },

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -1566,7 +1566,6 @@ describe('TaskRunner', () => {
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).buildMergeSummary = vi.fn().mockResolvedValue('Raw summary text only');
 
       const authoredBody = '## Summary\n\nRich authored body with details\n\n## Test Plan\n\n- [x] `pnpm test`\n\n## Revert Plan\n\n- Safe to revert? Yes';
@@ -1959,7 +1958,6 @@ describe('TaskRunner', () => {
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).buildMergeSummary = vi.fn().mockResolvedValue('## Summary');
       (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
         body: '## Summary\n\nPublished body',
@@ -3832,7 +3830,6 @@ describe('TaskRunner', () => {
       (executor as any).execGitIn = async () => '';
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).buildMergeSummary = vi.fn().mockResolvedValue(rawSummary);
       (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
         body: authoredBody,
@@ -3906,7 +3903,6 @@ describe('TaskRunner', () => {
       (executor as any).execGitIn = async () => '';
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).buildMergeSummary = vi.fn().mockResolvedValue('## Summary\nWorkflow summary');
       (executor as any).authorPrBodyWithSkill = authorPrSpy;
 

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -2950,9 +2950,6 @@ describe('TaskRunner', () => {
         config: { isMergeNode: true, workflowId: 'wf-1' },
       });
 
-      // Prevent setInterval leak from startPrPolling
-      (executor as any).startPrPolling = vi.fn();
-
       await (executor as any).executeMergeNode(mergeTask);
 
       // Should consolidate task branches into featureBranch
@@ -3065,7 +3062,6 @@ describe('TaskRunner', () => {
         .mockResolvedValueOnce(gateWorkspace)
         .mockResolvedValueOnce(consolidateWorkspace);
       (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
         body: '## Summary\n\nAuthored body',
         sessionId: 'sess-pr-ext',
@@ -3209,7 +3205,6 @@ console.log(JSON.stringify(out));
       (executor as any).createMergeWorktree = vi.fn().mockResolvedValue(join(cwd, 'mock-wt'));
       (executor as any).removeMergeWorktree = vi.fn();
       (executor as any).gitDiffStat = vi.fn().mockResolvedValue(' packages/execution-engine/src/task-runner.ts | 20 +++++');
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).authorPrBodyWithSkill = vi.fn().mockImplementation(async (args: any) => ({
         body: `## Summary\n\n${args.workflowSummary}\n\n${args.structuredContext?.visualProofMarkdown ?? ''}`,
         sessionId: 'sess-wf-1778431030512-12',
@@ -3358,7 +3353,6 @@ console.log(JSON.stringify(out));
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
         body: '## Summary\n\nAuthored body',
         sessionId: 'sess-pr-ext2',
@@ -3397,9 +3391,6 @@ console.log(JSON.stringify(out));
         }),
       }));
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
-
-      // Should start polling
-      expect((executor as any).startPrPolling).toHaveBeenCalledWith('__merge__wf-1', 'owner/repo#55', 'wf-1');
     });
 
     it('executeMergeNode anchors external_review gate worktrees on the origin-backed base branch', async () => {
@@ -3445,7 +3436,6 @@ console.log(JSON.stringify(out));
       const createMergeWorktreeSpy = vi.fn().mockResolvedValue('/tmp/mock-wt');
       (executor as any).createMergeWorktree = createMergeWorktreeSpy;
       (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
         body: '## Summary\n\nAuthored body',
         sessionId: 'sess-pr-ext3',
@@ -3515,7 +3505,6 @@ console.log(JSON.stringify(out));
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
         body: '## Summary\n\nAuthored body',
         sessionId: 'sess-pr-ext4',
@@ -3690,7 +3679,6 @@ console.log(JSON.stringify(out));
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
         body: '## Summary\n\nAuthored body',
         sessionId: 'sess-pr-ext5',
@@ -3760,7 +3748,6 @@ console.log(JSON.stringify(out));
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
         body: '## Summary\n\nAuthored body',
         sessionId: 'sess-pr-ext6',
@@ -3977,7 +3964,6 @@ console.log(JSON.stringify(out));
       };
       (executor as any).createMergeWorktree = async () => '/tmp/mock-wt';
       (executor as any).removeMergeWorktree = async () => {};
-      (executor as any).startPrPolling = vi.fn();
       (executor as any).buildMergeSummary = vi.fn().mockResolvedValue('## Summary\nTest summary');
       (executor as any).authorPrBodyWithSkill = vi.fn().mockResolvedValue({
         body: '## Summary\n\nAuthored PR body from summary',
@@ -4159,9 +4145,6 @@ console.log(JSON.stringify(out));
         mergeGateProvider: mergeGateProvider as any,
       });
 
-      // Simulate active poller by adding to activePrPollers map
-      (executor as any).activePrPollers.set('task-1', setInterval(() => {}, 1000));
-
       await executor.checkPrApprovalNow('task-1');
 
       expect(orchestrator.getTask).toHaveBeenCalledWith('task-1');
@@ -4173,10 +4156,6 @@ console.log(JSON.stringify(out));
         execution: { reviewStatus: 'Awaiting review' },
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
-
-      // Clean up interval
-      clearInterval((executor as any).activePrPollers.get('task-1'));
-      (executor as any).activePrPollers.delete('task-1');
     });
 
     it('merged PR auto-completes a review_ready merge gate', async () => {
@@ -4211,10 +4190,6 @@ console.log(JSON.stringify(out));
         cwd: '/tmp',
         mergeGateProvider: mergeGateProvider as any,
       });
-
-      // Simulate active poller
-      const interval = setInterval(() => {}, 1000);
-      (executor as any).activePrPollers.set('task-1', interval);
       const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
       await executor.checkPrApprovalNow('task-1');
@@ -4224,9 +4199,6 @@ console.log(JSON.stringify(out));
       });
       expect(orchestrator.approve).toHaveBeenCalledWith('task-1');
       expect(executeTasks).toHaveBeenCalledWith([downstream]);
-
-      // Should stop polling after approval
-      expect((executor as any).activePrPollers.has('task-1')).toBe(false);
     });
 
     it('approved-but-open PR updates persistence without completing the gate', async () => {
@@ -4258,23 +4230,12 @@ console.log(JSON.stringify(out));
         mergeGateProvider: mergeGateProvider as any,
       });
 
-      // Simulate active poller
-      const interval = setInterval(() => {}, 1000);
-      (executor as any).activePrPollers.set('task-1', interval);
-
       await executor.checkPrApprovalNow('task-1');
 
       expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
         execution: { reviewStatus: 'Approved, awaiting merge' },
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
-
-      // Should continue polling since PR is still open
-      expect((executor as any).activePrPollers.has('task-1')).toBe(true);
-
-      // Clean up interval
-      clearInterval((executor as any).activePrPollers.get('task-1'));
-      (executor as any).activePrPollers.delete('task-1');
     });
 
     it('rejected PR stops polling without completing the gate', async () => {
@@ -4305,9 +4266,6 @@ console.log(JSON.stringify(out));
         cwd: '/tmp',
         mergeGateProvider: mergeGateProvider as any,
       });
-
-      const interval = setInterval(() => {}, 1000);
-      (executor as any).activePrPollers.set('task-1', interval);
       const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
       await executor.checkPrApprovalNow('task-1');
@@ -4317,9 +4275,6 @@ console.log(JSON.stringify(out));
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
       expect(executeTasks).not.toHaveBeenCalled();
-      // Polling should stop on rejection so the user can retry without an
-      // orphaned interval firing in the background.
-      expect((executor as any).activePrPollers.has('task-1')).toBe(false);
     });
 
     it('closed PR marks the gate closed without approving on manual check', async () => {
@@ -4351,9 +4306,6 @@ console.log(JSON.stringify(out));
         cwd: '/tmp',
         mergeGateProvider: mergeGateProvider as any,
       });
-
-      const interval = setInterval(() => {}, 1000);
-      (executor as any).activePrPollers.set('task-closed', interval);
       const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
       await executor.checkPrApprovalNow('task-closed');
@@ -4364,7 +4316,6 @@ console.log(JSON.stringify(out));
       });
       expect(orchestrator.approve).not.toHaveBeenCalled();
       expect(executeTasks).not.toHaveBeenCalled();
-      expect((executor as any).activePrPollers.has('task-closed')).toBe(false);
     });
 
     it('merged PR completes the gate even when no poller is active (e.g. after process restart)', async () => {
@@ -4460,17 +4411,10 @@ console.log(JSON.stringify(out));
         cwd: '/tmp',
       });
 
-      // Simulate active poller
-      (executor as any).activePrPollers.set('task-1', setInterval(() => {}, 1000));
-
       await executor.checkPrApprovalNow('task-1');
 
       expect(orchestrator.getTask).not.toHaveBeenCalled();
       expect(persistence.updateTask).not.toHaveBeenCalled();
-
-      // Clean up
-      clearInterval((executor as any).activePrPollers.get('task-1'));
-      (executor as any).activePrPollers.delete('task-1');
     });
   });
 
@@ -4508,17 +4452,12 @@ console.log(JSON.stringify(out));
           mergeGateProvider: mergeGateProvider as any,
         });
 
-        (executor as any).activePrPollers.set('task-ws', setInterval(() => {}, 1000));
-
         await executor.checkPrApprovalNow('task-ws');
 
         expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
           identifier: 'owner/repo#99',
           cwd: '/workspace/merge-worktree',
         });
-
-        clearInterval((executor as any).activePrPollers.get('task-ws'));
-        (executor as any).activePrPollers.delete('task-ws');
       });
 
       it('falls back to runner cwd when workspacePath is undefined', async () => {
@@ -4548,17 +4487,12 @@ console.log(JSON.stringify(out));
           mergeGateProvider: mergeGateProvider as any,
         });
 
-        (executor as any).activePrPollers.set('task-no-ws', setInterval(() => {}, 1000));
-
         await executor.checkPrApprovalNow('task-no-ws');
 
         expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
           identifier: 'owner/repo#100',
           cwd: '/runner-base-cwd',
         });
-
-        clearInterval((executor as any).activePrPollers.get('task-no-ws'));
-        (executor as any).activePrPollers.delete('task-no-ws');
       });
 
       it('merged PR with workspacePath triggers orchestrator.approve', async () => {
@@ -4594,9 +4528,6 @@ console.log(JSON.stringify(out));
           cwd: '/runner-base-cwd',
           mergeGateProvider: mergeGateProvider as any,
         });
-
-        const interval = setInterval(() => {}, 1000);
-        (executor as any).activePrPollers.set('task-approved', interval);
         const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
         await executor.checkPrApprovalNow('task-approved');
@@ -4610,7 +4541,6 @@ console.log(JSON.stringify(out));
         });
         expect(orchestrator.approve).toHaveBeenCalledWith('task-approved');
         expect(executeTasks).toHaveBeenCalledWith([downstream]);
-        expect((executor as any).activePrPollers.has('task-approved')).toBe(false);
       });
     });
 
@@ -4641,8 +4571,6 @@ console.log(JSON.stringify(out));
           cwd: '/runner-base-cwd',
           mergeGateProvider: mergeGateProvider as any,
         });
-        const interval = setInterval(() => {}, 1000);
-        (executor as any).activePrPollers.set('merge-close', interval);
 
         await executor.closeWorkflowReview('wf-close');
 
@@ -4650,7 +4578,6 @@ console.log(JSON.stringify(out));
           identifier: '205',
           cwd: '/workspace/close-gate',
         });
-        expect((executor as any).activePrPollers.has('merge-close')).toBe(false);
       });
 
       it('uses task workspacePath as cwd when present', async () => {
@@ -4865,9 +4792,6 @@ console.log(JSON.stringify(out));
           cwd: '/runner-base-cwd',
           mergeGateProvider: mergeGateProvider as any,
         });
-
-        const interval = setInterval(() => {}, 1000);
-        (executor as any).activePrPollers.set('merge-rejected', interval);
         const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
         await executor.checkMergeGateStatuses();
@@ -4881,7 +4805,6 @@ console.log(JSON.stringify(out));
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(executeTasks).not.toHaveBeenCalled();
-        expect((executor as any).activePrPollers.has('merge-rejected')).toBe(false);
       });
 
       it('closed PR marks the gate closed on refresh without completing it', async () => {
@@ -4918,9 +4841,6 @@ console.log(JSON.stringify(out));
           cwd: '/runner-base-cwd',
           mergeGateProvider: mergeGateProvider as any,
         });
-
-        const interval = setInterval(() => {}, 1000);
-        (executor as any).activePrPollers.set('merge-closed', interval);
         const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
 
         await executor.checkMergeGateStatuses();
@@ -4935,313 +4855,6 @@ console.log(JSON.stringify(out));
         });
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(executeTasks).not.toHaveBeenCalled();
-        expect((executor as any).activePrPollers.has('merge-closed')).toBe(false);
-      });
-    });
-
-    describe('startPrPolling', () => {
-      it('poll uses task workspacePath as cwd when present', async () => {
-        vi.useFakeTimers();
-        try {
-          const orchestrator = {
-            getTask: vi.fn((id: string) => ({
-              id,
-              status: 'review_ready',
-              execution: {
-                reviewId: 'owner/repo#300',
-                workspacePath: '/workspace/poll-worktree',
-              },
-            })),
-            approve: vi.fn(),
-          };
-          const persistence = { updateTask: vi.fn() };
-          const mergeGateProvider = {
-            checkApproval: vi.fn().mockResolvedValue({
-              approved: false,
-              rejected: false,
-              statusText: 'Pending',
-            }),
-          };
-
-          const executor = new TaskRunner({
-            orchestrator: orchestrator as any,
-            persistence: persistence as any,
-            executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
-            cwd: '/runner-base-cwd',
-            mergeGateProvider: mergeGateProvider as any,
-          });
-
-          (executor as any).startPrPolling('poll-task', 'owner/repo#300', 'wf-1');
-
-          await vi.advanceTimersByTimeAsync(30_000);
-
-          expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
-            identifier: 'owner/repo#300',
-            cwd: '/workspace/poll-worktree',
-          });
-
-          // Cleanup
-          (executor as any).stopPrPolling('poll-task');
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it('poll falls back to runner cwd when workspacePath is undefined', async () => {
-        vi.useFakeTimers();
-        try {
-          const orchestrator = {
-            getTask: vi.fn((id: string) => ({
-              id,
-              status: 'review_ready',
-              execution: { reviewId: 'owner/repo#301' },
-            })),
-            approve: vi.fn(),
-          };
-          const persistence = { updateTask: vi.fn() };
-          const mergeGateProvider = {
-            checkApproval: vi.fn().mockResolvedValue({
-              approved: false,
-              rejected: false,
-              statusText: 'Pending',
-            }),
-          };
-
-          const executor = new TaskRunner({
-            orchestrator: orchestrator as any,
-            persistence: persistence as any,
-            executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
-            cwd: '/runner-base-cwd',
-            mergeGateProvider: mergeGateProvider as any,
-          });
-
-          (executor as any).startPrPolling('poll-task-no-ws', 'owner/repo#301', 'wf-1');
-
-          await vi.advanceTimersByTimeAsync(30_000);
-
-          expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
-            identifier: 'owner/repo#301',
-            cwd: '/runner-base-cwd',
-          });
-
-          // Cleanup
-          (executor as any).stopPrPolling('poll-task-no-ws');
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it('poll with workspacePath triggers orchestrator.approve on merged PR', async () => {
-        vi.useFakeTimers();
-        try {
-          const downstream = makeTask({
-            id: 'downstream-after-poll',
-            status: 'running',
-          });
-          const orchestrator = {
-            getTask: vi.fn((id: string) => ({
-              id,
-              status: 'review_ready',
-              execution: {
-                reviewId: 'owner/repo#302',
-                workspacePath: '/workspace/poll-approved',
-              },
-            })),
-            approve: vi.fn().mockResolvedValue([downstream]),
-          };
-          const persistence = { updateTask: vi.fn() };
-          const mergeGateProvider = {
-            checkApproval: vi.fn().mockResolvedValue({
-              approved: true,
-              rejected: false,
-              statusText: 'Merged',
-            }),
-          };
-
-          const executor = new TaskRunner({
-            orchestrator: orchestrator as any,
-            persistence: persistence as any,
-            executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
-            cwd: '/runner-base-cwd',
-            mergeGateProvider: mergeGateProvider as any,
-          });
-          const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
-
-          (executor as any).startPrPolling('poll-approved', 'owner/repo#302', 'wf-1');
-
-          await vi.advanceTimersByTimeAsync(30_000);
-
-          expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
-            identifier: 'owner/repo#302',
-            cwd: '/workspace/poll-approved',
-          });
-          expect(persistence.updateTask).toHaveBeenCalledWith('poll-approved', {
-            execution: { reviewStatus: 'Merged' },
-          });
-          expect(orchestrator.approve).toHaveBeenCalledWith('poll-approved');
-          expect(executeTasks).toHaveBeenCalledWith([downstream]);
-          expect((executor as any).activePrPollers.has('poll-approved')).toBe(false);
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it('poll with approved-but-open PR updates persistence without completing gate', async () => {
-        vi.useFakeTimers();
-        try {
-          const orchestrator = {
-            getTask: vi.fn((id: string) => ({
-              id,
-              status: 'review_ready',
-              execution: {
-                reviewId: 'owner/repo#303',
-                workspacePath: '/workspace/poll-open-approved',
-              },
-            })),
-            approve: vi.fn(),
-          };
-          const persistence = { updateTask: vi.fn() };
-          const mergeGateProvider = {
-            checkApproval: vi.fn().mockResolvedValue({
-              approved: false,
-              rejected: false,
-              statusText: 'Approved, awaiting merge',
-            }),
-          };
-
-          const executor = new TaskRunner({
-            orchestrator: orchestrator as any,
-            persistence: persistence as any,
-            executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
-            cwd: '/runner-base-cwd',
-            mergeGateProvider: mergeGateProvider as any,
-          });
-
-          (executor as any).startPrPolling('poll-open-approved', 'owner/repo#303', 'wf-1');
-
-          await vi.advanceTimersByTimeAsync(30_000);
-
-          expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
-            identifier: 'owner/repo#303',
-            cwd: '/workspace/poll-open-approved',
-          });
-          expect(persistence.updateTask).toHaveBeenCalledWith('poll-open-approved', {
-            execution: { reviewStatus: 'Approved, awaiting merge' },
-          });
-          expect(orchestrator.approve).not.toHaveBeenCalled();
-          // Should continue polling
-          expect((executor as any).activePrPollers.has('poll-open-approved')).toBe(true);
-
-          // Cleanup
-          (executor as any).stopPrPolling('poll-open-approved');
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it('poll with rejected PR stops polling without completing the gate', async () => {
-        vi.useFakeTimers();
-        try {
-          const orchestrator = {
-            getTask: vi.fn((id: string) => ({
-              id,
-              status: 'review_ready',
-              execution: {
-                reviewId: 'owner/repo#304',
-                workspacePath: '/workspace/poll-rejected',
-              },
-            })),
-            approve: vi.fn(),
-          };
-          const persistence = { updateTask: vi.fn() };
-          const mergeGateProvider = {
-            checkApproval: vi.fn().mockResolvedValue({
-              approved: false,
-              rejected: true,
-              statusText: 'Changes requested',
-            }),
-          };
-
-          const executor = new TaskRunner({
-            orchestrator: orchestrator as any,
-            persistence: persistence as any,
-            executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
-            cwd: '/runner-base-cwd',
-            mergeGateProvider: mergeGateProvider as any,
-          });
-          const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
-
-          (executor as any).startPrPolling('poll-rejected', 'owner/repo#304', 'wf-1');
-
-          await vi.advanceTimersByTimeAsync(30_000);
-
-          expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
-            identifier: 'owner/repo#304',
-            cwd: '/workspace/poll-rejected',
-          });
-          expect(persistence.updateTask).toHaveBeenCalledWith('poll-rejected', {
-            execution: { reviewStatus: 'Changes requested' },
-          });
-          expect(orchestrator.approve).not.toHaveBeenCalled();
-          expect(executeTasks).not.toHaveBeenCalled();
-          // Rejection should stop the poller (no further intervals scheduled).
-          expect((executor as any).activePrPollers.has('poll-rejected')).toBe(false);
-        } finally {
-          vi.useRealTimers();
-        }
-      });
-
-      it('poll with closed PR marks the gate closed and stops polling', async () => {
-        vi.useFakeTimers();
-        try {
-          const orchestrator = {
-            getTask: vi.fn((id: string) => ({
-              id,
-              status: 'review_ready',
-              execution: {
-                reviewId: 'owner/repo#305',
-                workspacePath: '/workspace/poll-closed',
-              },
-            })),
-            approve: vi.fn(),
-          };
-          const persistence = { updateTask: vi.fn() };
-          const mergeGateProvider = {
-            checkApproval: vi.fn().mockResolvedValue({
-              approved: false,
-              rejected: true,
-              closed: true,
-              statusText: 'Closed',
-            }),
-          };
-
-          const executor = new TaskRunner({
-            orchestrator: orchestrator as any,
-            persistence: persistence as any,
-            executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
-            cwd: '/runner-base-cwd',
-            mergeGateProvider: mergeGateProvider as any,
-          });
-          const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
-
-          (executor as any).startPrPolling('poll-closed', 'owner/repo#305', 'wf-1');
-
-          await vi.advanceTimersByTimeAsync(30_000);
-
-          expect(mergeGateProvider.checkApproval).toHaveBeenCalledWith({
-            identifier: 'owner/repo#305',
-            cwd: '/workspace/poll-closed',
-          });
-          expect(persistence.updateTask).toHaveBeenCalledWith('poll-closed', {
-            status: 'closed',
-            execution: { reviewStatus: 'Closed' },
-          });
-          expect(orchestrator.approve).not.toHaveBeenCalled();
-          expect(executeTasks).not.toHaveBeenCalled();
-          expect((executor as any).activePrPollers.has('poll-closed')).toBe(false);
-        } finally {
-          vi.useRealTimers();
-        }
       });
     });
   });

--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -129,9 +129,6 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
           execution: result.taskChanges.execution,
         });
       }
-      if (result.reviewIdForPolling && result.workflowIdForPolling) {
-        this.host.startPrPolling(task.id, result.reviewIdForPolling, result.workflowIdForPolling);
-      }
       this.emitOutput(handle.executionId, `[merge] Merge gate action finished: ${task.id} status=${result.response.status}\n`);
       this.emitComplete(handle.executionId, this.withAttempt(entry.request, result.response));
     } catch (err) {

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -178,7 +178,6 @@ export interface MergeRunnerHost {
   detectDefaultBranch(): Promise<string>;
   gitLogMessage(commitHash: string, cwd?: string): Promise<string>;
   gitDiffStat(branch: string, cwd?: string): Promise<string>;
-  startPrPolling(taskId: string, reviewId: string, workflowId: string): void;
   executeTasks(tasks: TaskState[]): Promise<void>;
   buildMergeSummary(workflowId: string): Promise<string>;
   runVisualProofCapture?(baseBranch: string, featureBranch: string, slug: string, repoUrl?: string): Promise<string | undefined>;
@@ -404,8 +403,6 @@ export function collectDirectNonMergeTaskIds(
 export interface MergeGateActionResult {
   response: WorkResponse;
   taskChanges: TaskStateChanges;
-  reviewIdForPolling?: string;
-  workflowIdForPolling?: string;
 }
 
 export async function runMergeGateActionImpl(
@@ -601,8 +598,6 @@ export async function runMergeGateActionImpl(
               reviewStatus,
             },
           },
-          reviewIdForPolling: reviewId,
-          workflowIdForPolling: workflowId,
         };
       }
       response = {
@@ -709,9 +704,6 @@ export async function executeMergeNodeImpl(
   if (response.status === 'review_ready') {
     setMergeGateReviewReady(host, task.id, legacyChanges);
     await startReviewReadyDependents(host);
-    if (result.reviewIdForPolling && result.workflowIdForPolling) {
-      host.startPrPolling(task.id, result.reviewIdForPolling, result.workflowIdForPolling);
-    }
   } else {
     const newlyStarted = host.orchestrator.handleWorkerResponse(response) ?? [];
     if (newlyStarted.length > 0) {
@@ -1101,7 +1093,6 @@ export async function publishAfterFixImpl(
         },
       });
       await startReviewReadyDependents(host);
-      host.startPrPolling(task.id, result.identifier, workflowId!);
       return;
     }
 

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -213,7 +213,6 @@ export class TaskRunner {
   /** @internal */ reviewProviderRegistry?: ReviewProviderRegistry;
   private onReviewGateCiFailure?: (trigger: ReviewGateCiFailureTrigger) => Promise<void>;
   private reviewGateCiFixInFlight = new Set<string>();
-  private activePrPollers = new Map<string, ReturnType<typeof setInterval>>();
   private getRemoteTargets: () => Record<string, RemoteTargetDisplay>;
   private getExecutionPools: () => Record<string, ExecutionPoolConfig>;
   private dockerConfig: { imageName?: string; secretsFile?: string };
@@ -1871,21 +1870,6 @@ export class TaskRunner {
     }
   }
 
-  resumeMergeGatePolling(): void {
-    if (!this.mergeGateProvider) return;
-    for (const task of this.orchestrator.getAllTasks()) {
-      if (
-        task.config.isMergeNode &&
-        (task.status === 'review_ready' || task.status === 'awaiting_approval') &&
-        task.execution.reviewId &&
-        !this.activePrPollers.has(task.id)
-      ) {
-        this.logger.info(`[merge-gate] Resuming PR polling for ${task.id} (PR ${task.execution.reviewId})`);
-        this.startPrPolling(task.id, task.execution.reviewId, task.config.workflowId!);
-      }
-    }
-  }
-
   async closeWorkflowReview(workflowId: string): Promise<void> {
     if (!this.mergeGateProvider?.closeReview) return;
     const getAllTasks = this.orchestrator.getAllTasks?.bind(this.orchestrator);
@@ -1897,7 +1881,6 @@ export class TaskRunner {
     );
     if (!mergeTask?.execution.reviewId) return;
 
-    this.stopPrPolling(mergeTask.id);
     await this.mergeGateProvider.closeReview({
       identifier: mergeTask.execution.reviewId,
       cwd: mergeTask.execution.workspacePath ?? this.cwd,
@@ -1911,7 +1894,6 @@ export class TaskRunner {
   ): Promise<void> {
     const sourceSuffix = source ? ` (${source})` : '';
     this.logger.info(`[merge-gate] PR ${reviewId} approved${sourceSuffix}, completing merge gate`);
-    this.stopPrPolling(taskId);
     const newlyStarted = await this.orchestrator.approve(taskId);
     if (newlyStarted.length > 0) {
       await this.executeTasks(newlyStarted);
@@ -1930,7 +1912,6 @@ export class TaskRunner {
       status: 'closed',
       execution: { reviewStatus: statusText },
     });
-    this.stopPrPolling(taskId);
   }
 
   async checkMergeGateStatuses(): Promise<void> {
@@ -1959,7 +1940,6 @@ export class TaskRunner {
               execution: { reviewStatus: status.statusText },
             });
             this.logger.info(`[merge-gate] PR ${task.execution.reviewId} rejected (refresh): ${status.statusText}`);
-            this.stopPrPolling(task.id);
           } else {
             this.persistence.updateTask(task.id, {
               execution: { reviewStatus: status.statusText },
@@ -1970,55 +1950,6 @@ export class TaskRunner {
           this.logger.error(`[merge-gate] PR status check error for ${task.id}`, { err });
         }
       }
-    }
-  }
-
-  /** @internal */ startPrPolling(taskId: string, reviewId: string, workflowId: string): void {
-    const pollIntervalMs = 30_000;
-    const interval = setInterval(async () => {
-      try {
-        if (!this.mergeGateProvider) return;
-        const pollTask = this.orchestrator.getTask(taskId);
-        const pollCwd = pollTask?.execution.workspacePath ?? this.cwd;
-        const status = await this.mergeGateProvider.checkApproval({
-          identifier: reviewId,
-          cwd: pollCwd,
-        });
-
-        if (status.closed) {
-          this.handleClosedMergeGate(taskId, reviewId, status.statusText);
-        } else if (status.approved) {
-          this.persistence.updateTask(taskId, {
-            execution: { reviewStatus: status.statusText },
-          });
-          await this.handleApprovedMergeGate(taskId, reviewId);
-        } else if (status.rejected) {
-          this.persistence.updateTask(taskId, {
-            execution: { reviewStatus: status.statusText },
-          });
-          this.logger.info(`[merge-gate] PR ${reviewId} rejected: ${status.statusText}`);
-          this.stopPrPolling(taskId);
-          // Leave in review_ready/awaiting_approval — user can retry
-        } else {
-          this.persistence.updateTask(taskId, {
-            execution: { reviewStatus: status.statusText },
-          });
-          const latestTask = this.orchestrator.getTask(taskId);
-          if (latestTask) await this.maybeTriggerReviewGateCiFix(latestTask, status);
-        }
-      } catch (err) {
-        this.logger.error(`[merge-gate] PR poll error for ${taskId}`, { err });
-        // Continue polling on transient errors
-      }
-    }, pollIntervalMs);
-    this.activePrPollers.set(taskId, interval);
-  }
-
-  private stopPrPolling(taskId: string): void {
-    const interval = this.activePrPollers.get(taskId);
-    if (interval) {
-      clearInterval(interval);
-      this.activePrPollers.delete(taskId);
     }
   }
 
@@ -2048,7 +1979,6 @@ export class TaskRunner {
           execution: { reviewStatus: status.statusText },
         });
         this.logger.info(`[merge-gate] PR ${reviewId} rejected (manual check): ${status.statusText}`);
-        this.stopPrPolling(taskId);
       } else {
         this.persistence.updateTask(taskId, {
           execution: { reviewStatus: status.statusText },


### PR DESCRIPTION
## Summary

- Replace per-PR merge-gate polling with a single owner-process review-gate status worker.
- Keep review-gate status handling in `TaskRunner.checkMergeGateStatuses()` so merged, closed, rejected, open, pending-check, and failed-check behavior remains centralized.
- Start and stop the worker from app lifecycle only in owner contexts, including GUI owner startup, headless standalone owner mode, and startup with auto-run disabled.

## Architecture

### Before

```mermaid
flowchart TD
  MergeRunner[Merge runner publishes PR] --> TaskRunnerPoller[TaskRunner.startPrPolling per PR]
  TaskRunnerPoller --> Provider[MergeGateProvider.checkApproval]
  Startup[Owner startup or resume] --> Resume[TaskRunner.resumeMergeGatePolling]
  Resume --> TaskRunnerPoller
```

### After

```mermaid
flowchart TD
  MergeRunner[Merge runner publishes PR] --> ReviewReady[Merge gate stores review metadata]
  OwnerApp[Owner app or headless owner process] --> Worker[Review-gate status worker 60s interval]
  Worker --> CheckStatuses[TaskRunner.checkMergeGateStatuses]
  CheckStatuses --> Provider[MergeGateProvider.checkApproval]
  CheckStatuses --> Downstream[Approve, close, update review status, or trigger CI auto-fix]
  Follower[Follower or read-only process] -. no worker .-> Worker
```

## Test Plan

- [x] `pnpm --filter @invoker/app test -- review-gate-status-worker`
- [x] `pnpm --filter @invoker/execution-engine test -- task-runner`
- [x] `pnpm run test:all`
- [x] `pnpm --filter /surfaces build && pnpm --filter /app build && pnpm --filter /app exec playwright test e2e/startup-nonempty-responsiveness.spec.ts --reporter=line`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 71cd22a`
- Post-revert steps: Restart owner processes so app lifecycle intervals are recreated from reverted code.
- Data migration? No
