### PR TITLE
Reland PTY backend and default GUI terminals to PTY

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "electron"
+      "electron",
+      "node-pty"
     ]
   },
   "devDependencies": {

--- a/packages/app/e2e/embedded-terminal-pty.spec.ts
+++ b/packages/app/e2e/embedded-terminal-pty.spec.ts
@@ -1,0 +1,165 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  E2E_REPO_URL,
+  expect,
+  injectTaskStates,
+  loadPlan,
+  test,
+} from './fixtures/electron-app.js';
+
+const CODEX_RESUME_PLAN = {
+  name: 'Embedded PTY Resume',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'codex-resume',
+      description: 'Completed Codex resume task',
+      command: 'echo unused',
+      executionAgent: 'codex',
+      dependencies: [],
+    },
+  ],
+};
+
+const CLAUDE_RESUME_PLAN = {
+  name: 'Embedded Claude PTY Resume',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'claude-resume',
+      description: 'Completed Claude resume task',
+      command: 'echo unused',
+      executionAgent: 'claude',
+      dependencies: [],
+    },
+  ],
+};
+
+test.describe('Embedded terminal PTY', () => {
+  test('completed Codex resume terminal gets a real TTY in the drawer', async ({ page, testDir }) => {
+    await loadPlan(page, CODEX_RESUME_PLAN);
+    const workspacePath = path.join(testDir, 'codex-resume-workspace');
+    mkdirSync(workspacePath, { recursive: true });
+    const agentSessionId = 'codex-session-e2e-tty';
+    const sessionDir = path.join(testDir, 'agent-sessions');
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      path.join(sessionDir, `${agentSessionId}.jsonl`),
+      '{"type":"thread.started","thread_id":"codex-session-e2e-tty"}\n{"type":"task_complete","last_agent_message":"done"}\n',
+      'utf8',
+    );
+
+    await injectTaskStates(page, [
+      {
+        taskId: 'codex-resume',
+        changes: {
+          status: 'completed',
+          config: {
+            runnerKind: 'worktree',
+            executionAgent: 'codex',
+          },
+          execution: {
+            workspacePath,
+            agentSessionId,
+            lastAgentSessionId: agentSessionId,
+            agentName: 'codex',
+            lastAgentName: 'codex',
+            completedAt: new Date('2025-01-01T00:00:00.000Z'),
+          },
+        },
+      },
+    ]);
+
+    const tasksResult = await page.evaluate(() => window.invoker.getTasks(true));
+    const tasks = Array.isArray(tasksResult) ? tasksResult : tasksResult.tasks;
+    const task = tasks.find((candidate) => candidate.id.endsWith('/codex-resume'));
+    const fullTaskId = task?.id;
+    expect(fullTaskId).toBeTruthy();
+    expect(task?.execution?.agentSessionId).toBe(agentSessionId);
+    expect(task?.execution?.agentName).toBe('codex');
+
+    const taskNode = page
+      .getByTestId('selected-workflow-mini-dag')
+      .locator('.react-flow__node[data-testid$="codex-resume"]')
+      .first();
+    const box = await taskNode.boundingBox();
+    if (!box) throw new Error('Codex resume task node has no bounding box');
+    await taskNode.locator('> div').dispatchEvent('dblclick', {
+      bubbles: true,
+      cancelable: true,
+      clientX: box.x + box.width / 2,
+      clientY: box.y + box.height / 2,
+    });
+
+    await expect(page.getByTestId('terminal-drawer-body')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('terminal-session-command')).toContainText('codex');
+    await expect(page.getByTestId('terminal-session-command')).toContainText(`resume ${agentSessionId}`);
+    const terminalPane = page.getByTestId(`terminal-pane-${fullTaskId}`);
+    await expect(terminalPane).toBeVisible();
+    await expect(terminalPane.getByText(`TTY OK: codex resume ${agentSessionId}`)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('stdin is not a terminal')).toHaveCount(0);
+    await expect(page.getByText('No deferred tool marker found')).toHaveCount(0);
+  });
+
+  test('completed Claude resume terminal gets a real TTY in the drawer', async ({ page, testDir }) => {
+    await loadPlan(page, CLAUDE_RESUME_PLAN);
+    const workspacePath = path.join(testDir, 'claude-resume-workspace');
+    mkdirSync(workspacePath, { recursive: true });
+    const agentSessionId = 'claude-session-e2e-tty';
+
+    await injectTaskStates(page, [
+      {
+        taskId: 'claude-resume',
+        changes: {
+          status: 'completed',
+          config: {
+            runnerKind: 'worktree',
+            executionAgent: 'claude',
+          },
+          execution: {
+            workspacePath,
+            agentSessionId,
+            lastAgentSessionId: agentSessionId,
+            agentName: 'claude',
+            lastAgentName: 'claude',
+            completedAt: new Date('2025-01-01T00:00:00.000Z'),
+          },
+        },
+      },
+    ]);
+
+    const tasksResult = await page.evaluate(() => window.invoker.getTasks(true));
+    const tasks = Array.isArray(tasksResult) ? tasksResult : tasksResult.tasks;
+    const task = tasks.find((candidate) => candidate.id.endsWith('/claude-resume'));
+    const fullTaskId = task?.id;
+    expect(fullTaskId).toBeTruthy();
+    expect(task?.execution?.agentSessionId).toBe(agentSessionId);
+    expect(task?.execution?.agentName).toBe('claude');
+
+    const taskNode = page
+      .getByTestId('selected-workflow-mini-dag')
+      .locator('.react-flow__node[data-testid$="claude-resume"]')
+      .first();
+    const box = await taskNode.boundingBox();
+    if (!box) throw new Error('Claude resume task node has no bounding box');
+    await taskNode.locator('> div').dispatchEvent('dblclick', {
+      bubbles: true,
+      cancelable: true,
+      clientX: box.x + box.width / 2,
+      clientY: box.y + box.height / 2,
+    });
+
+    await expect(page.getByTestId('terminal-drawer-body')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('terminal-session-command')).toContainText('--resume');
+    await expect(page.getByTestId('terminal-session-command')).toContainText(agentSessionId);
+    await expect(page.getByTestId('terminal-session-command')).toContainText('--dangerously-skip-permissions');
+    const terminalPane = page.getByTestId(`terminal-pane-${fullTaskId}`);
+    await expect(terminalPane).toBeVisible();
+    await expect(terminalPane.getByText(`TTY OK: claude resume ${agentSessionId}`)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('stdin is not a terminal')).toHaveCount(0);
+    await expect(page.getByText('No deferred tool marker found')).toHaveCount(0);
+  });
+});

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -11,7 +11,7 @@ import { resolveRepoRoot } from '@invoker/contracts';
 import { test as base, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import { stringify as yamlStringify } from 'yaml';
@@ -48,6 +48,28 @@ export const test = base.extend<ElectronFixtures>({
     } catch {
       // Windows / EPERM: fix path still uses INVOKER_CLAUDE_FIX_COMMAND; prompt tasks may hit real claude.
     }
+    const codexStub = path.join(stubDir, 'codex');
+    writeFileSync(codexStub, `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "resume" ]]; then
+  if [[ ! -t 0 || ! -t 1 ]]; then
+    echo "stdin is not a terminal" >&2
+    exit 12
+  fi
+  sleep 1
+  echo "TTY OK: codex resume \${2:-}"
+  exit 0
+fi
+if [[ "\${1:-}" == "exec" ]]; then
+  echo '{"type":"session_configured","session_id":"codex-e2e-exec"}'
+  echo '{"type":"turn_context","cwd":"'"$PWD"'"}'
+  echo '{"type":"task_complete","last_agent_message":"Codex E2E exec complete"}'
+  exit 0
+fi
+echo "unsupported codex args: $*" >&2
+exit 64
+`, 'utf8');
+    chmodSync(codexStub, 0o755);
     const pathEnv = `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`;
     const app = await electron.launch({
       args: [
@@ -65,6 +87,8 @@ export const test = base.extend<ElectronFixtures>({
         INVOKER_ALLOW_DELETE_ALL: '1',
         INVOKER_E2E_ENABLE_COMPOSITOR: '1',
         INVOKER_REPO_CONFIG_PATH: configPath,
+        INVOKER_EMBEDDED_TERMINAL_BACKEND:
+          process.env.INVOKER_E2E_EMBEDDED_TERMINAL_BACKEND ?? 'pty',
         INVOKER_E2E_MARKER_ROOT: markerRoot,
         INVOKER_TEST_FIXED_NOW: '2025-01-01T00:00:00.000Z',
         INVOKER_CLAUDE_COMMAND: claudeMarker,

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -77,6 +77,9 @@
     "dotenv": "^16.0.0",
     "yaml": "^2.7.0"
   },
+  "optionalDependencies": {
+    "node-pty": "^1.1.0"
+  },
   "devDependencies": {
     "@electron/rebuild": "^4.0.3",
     "@invoker/test-kit": "workspace:*",

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -219,8 +219,8 @@ describe('loadConfig', () => {
 });
 
 describe('resolveEmbeddedTerminalBackendConfig', () => {
-  it('defaults GUI embedded terminals to the bash backend', () => {
-    expect(resolveEmbeddedTerminalBackendConfig({}, {})).toBe('bash');
+  it('defaults GUI embedded terminals to the PTY backend', () => {
+    expect(resolveEmbeddedTerminalBackendConfig({}, {})).toBe('pty');
   });
 
   it('reads the configured GUI embedded terminal backend', () => {

--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -20,8 +20,11 @@ import { mkdirSync, rmSync } from 'node:fs';
 import {
   EmbeddedTerminalManager,
   createBashTerminalBackend,
+  createPtyTerminalBackend,
   type EmbeddedTerminalBackend,
   type BashSpawnFn,
+  type PtyLike,
+  type PtySpawnFn,
 } from '../embedded-terminal-manager.js';
 import { resolveTaskTerminalSpec } from '../open-terminal-for-task.js';
 import {
@@ -51,6 +54,35 @@ function createFakeChild() {
     },
   };
   ee.killed = false;
+  ee.kill = () => {
+    ee.killed = true;
+  };
+  return ee;
+}
+
+function createFakePty() {
+  const ee = new EventEmitter() as EventEmitter & PtyLike & {
+    __written: string[];
+    __resized: Array<{ cols: number; rows: number }>;
+    killed: boolean;
+  };
+  ee.__written = [];
+  ee.__resized = [];
+  ee.killed = false;
+  ee.onData = (listener) => {
+    ee.on('data', listener);
+    return { dispose: () => ee.off('data', listener) };
+  };
+  ee.onExit = (listener) => {
+    ee.on('exit', listener);
+    return { dispose: () => ee.off('exit', listener) };
+  };
+  ee.write = (data: string) => {
+    ee.__written.push(data);
+  };
+  ee.resize = (cols: number, rows: number) => {
+    ee.__resized.push({ cols, rows });
+  };
   ee.kill = () => {
     ee.killed = true;
   };
@@ -224,6 +256,29 @@ describe('EmbeddedTerminalManager', () => {
     const res = mgr.resize(session.sessionId, 120, 40);
 
     expect(res.ok).toBe(true);
+  });
+
+  it('opt-in PTY backend preserves command metadata and forwards resize', () => {
+    const pty = createFakePty();
+    const ptySpawnFn = vi.fn(() => pty) as unknown as PtySpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createPtyTerminalBackend({ spawnFn: ptySpawnFn }),
+    });
+    const session = mgr.openOrReuse({
+      taskId: 't',
+      spec: { command: 'claude', args: ['--resume', 'session-1'], cwd: '/tmp' },
+      cwd: '/tmp',
+    });
+
+    const res = mgr.resize(session.sessionId, 120, 40);
+
+    expect(ptySpawnFn).toHaveBeenCalledWith(
+      'claude',
+      ['--resume', 'session-1'],
+      expect.objectContaining({ cwd: '/tmp', cols: 80, rows: 24, name: 'xterm-256color' }),
+    );
+    expect(res.ok).toBe(true);
+    expect(pty.__resized).toEqual([{ cols: 120, rows: 40 }]);
   });
 
   it('emits exit and removes session when the bash child exits', () => {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -242,7 +242,7 @@ export function resolveEmbeddedTerminalBackendConfig(
   config: InvokerConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): EmbeddedTerminalBackendConfig {
-  const rawValue = env.INVOKER_EMBEDDED_TERMINAL_BACKEND ?? config.terminal?.embeddedBackend ?? 'bash';
+  const rawValue = env.INVOKER_EMBEDDED_TERMINAL_BACKEND ?? config.terminal?.embeddedBackend ?? 'pty';
   const raw = typeof rawValue === 'string' ? rawValue : String(rawValue);
   const value = raw.trim().toLowerCase();
   if (value === 'bash' || value === 'pty') return value;

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -8,6 +8,7 @@
 
 import { EventEmitter } from 'node:events';
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import {
   spawn as nodeSpawn,
   type ChildProcessWithoutNullStreams,
@@ -21,6 +22,29 @@ import type {
 import type { Executor, ExecutorHandle, TerminalSpec } from '@invoker/execution-engine';
 
 export type EmbeddedTerminalBackendName = 'bash' | 'pty';
+
+export interface PtyForkOptionsLike {
+  name: string;
+  cols: number;
+  rows: number;
+  cwd: string;
+  env: Record<string, string | undefined>;
+}
+
+export interface PtyLike {
+  onData(listener: (data: string) => void): { dispose: () => void };
+  onExit(listener: (event: { exitCode: number }) => void): { dispose: () => void };
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(): void;
+}
+
+/** Factory used by the optional PTY backend. Tests can supply a fake. */
+export type PtySpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: PtyForkOptionsLike,
+) => PtyLike;
 
 /** Factory used by the default bash/pipe backend. Tests can supply a fake. */
 export type BashSpawnFn = (
@@ -49,6 +73,11 @@ export interface EmbeddedTerminalBackend {
 export interface BashTerminalBackendOptions {
   /** Override the child_process.spawn function for this Bash backend instance. */
   spawnFn?: BashSpawnFn;
+}
+
+export interface PtyTerminalBackendOptions {
+  /** Override the node-pty spawn function for this PTY backend instance. */
+  spawnFn?: PtySpawnFn;
 }
 
 /** Optional attach handle pair routing a session through a live executor. */
@@ -91,7 +120,7 @@ interface AttachedSessionState extends BaseSessionState {
 type SessionState = SpawnSessionState | AttachedSessionState;
 
 export interface EmbeddedTerminalManagerOptions {
-  /** Single backend used for GUI spawned sessions. Defaults to the Bash/pipe backend. */
+  /** Single backend used for GUI spawned sessions. Defaults to the PTY backend. */
   backend?: EmbeddedTerminalBackend;
   /** Default shell for `spawn`-mode sessions when the spec has no command. */
   defaultShell?: string;
@@ -159,6 +188,57 @@ export function createBashTerminalBackend(
   options: BashTerminalBackendOptions = {},
 ): EmbeddedTerminalBackend {
   return new BashTerminalBackend(options.spawnFn);
+}
+
+class PtyTerminalBackend implements EmbeddedTerminalBackend {
+  readonly name = 'pty' as const;
+  private readonly spawnFn: PtySpawnFn;
+
+  constructor(spawnFn?: PtySpawnFn) {
+    this.spawnFn = spawnFn ?? loadNodePtySpawn();
+  }
+
+  spawn(opts: Parameters<EmbeddedTerminalBackend['spawn']>[0]): SpawnedTerminalProcess {
+    const command = opts.spec.command ?? opts.defaultShell;
+    const args = opts.spec.command ? opts.spec.args ?? [] : [];
+    const pty = this.spawnFn(command, args, {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+      cwd: opts.cwd,
+      env: { ...process.env, TERM: process.env.TERM ?? 'xterm-256color' },
+    });
+    const dataDisposable = pty.onData(opts.emitOutput);
+    const exitDisposable = pty.onExit(({ exitCode }) => opts.emitExit(exitCode));
+
+    return {
+      write(data: string) {
+        pty.write(data);
+      },
+      resize(cols: number, rows: number) {
+        pty.resize(cols, rows);
+      },
+      close() {
+        try {
+          dataDisposable.dispose();
+          exitDisposable.dispose();
+        } catch {
+          /* listener disposal is best-effort */
+        }
+        try {
+          pty.kill();
+        } catch {
+          /* already dead */
+        }
+      },
+    };
+  }
+}
+
+export function createPtyTerminalBackend(
+  options: PtyTerminalBackendOptions = {},
+): EmbeddedTerminalBackend {
+  return new PtyTerminalBackend(options.spawnFn);
 }
 
 export class EmbeddedTerminalManager extends EventEmitter {
@@ -330,7 +410,23 @@ export class EmbeddedTerminalManager extends EventEmitter {
 
 function resolveBackend(options: EmbeddedTerminalManagerOptions): EmbeddedTerminalBackend {
   if (options.backend) return options.backend;
-  return createBashTerminalBackend();
+  return createPtyTerminalBackend();
+}
+
+function loadNodePtySpawn(): PtySpawnFn {
+  try {
+    const nodeRequire = createRequire(__filename);
+    const mod = nodeRequire('node-pty') as { spawn?: PtySpawnFn };
+    if (typeof mod.spawn !== 'function') {
+      throw new Error('node-pty does not export spawn()');
+    }
+    return mod.spawn;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Embedded terminal PTY backend requested, but node-pty is unavailable or not built: ${detail}`,
+    );
+  }
 }
 
 function buildTargetKey(opts: OpenSessionOptions): string {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -142,6 +142,7 @@ import { spawn, execSync } from 'node:child_process';
 import { resolveTaskTerminalSpec } from './open-terminal-for-task.js';
 import {
   createBashTerminalBackend,
+  createPtyTerminalBackend,
   EmbeddedTerminalManager,
   type EmbeddedTerminalBackend,
 } from './embedded-terminal-manager.js';
@@ -1187,7 +1188,7 @@ function createEmbeddedTerminalBackendFromConfig(
   backend: EmbeddedTerminalBackendConfig,
 ): EmbeddedTerminalBackend {
   if (backend === 'bash') return createBashTerminalBackend();
-  throw new Error('Embedded terminal PTY backend requested, but the PTY backend is not installed.');
+  return createPtyTerminalBackend();
 }
 
   function setupGuiMode(): void {

--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   entry: ['src/main.ts', 'src/preload.ts', 'src/headless-client.ts'],
   format: ['cjs'],
   outDir: 'dist',
-  external: ['electron', 'node:sqlite', 'sql.js', 'dockerode', '@invoker/surfaces', '@slack/bolt', 'dotenv'],
+  external: ['electron', 'node:sqlite', 'sql.js', 'dockerode', 'node-pty', '@invoker/surfaces', '@slack/bolt', 'dotenv'],
   noExternal: [
     '@invoker/workflow-core',
     '@invoker/workflow-graph',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,10 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
+    optionalDependencies:
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
 
   packages/contracts:
     dependencies:
@@ -2842,6 +2846,9 @@ packages:
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
@@ -2849,6 +2856,9 @@ packages:
     resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -6396,6 +6406,9 @@ snapshots:
   node-addon-api@1.7.2:
     optional: true
 
+  node-addon-api@7.1.1:
+    optional: true
+
   node-api-version@0.2.1:
     dependencies:
       semver: 7.7.4
@@ -6414,6 +6427,11 @@ snapshots:
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+    optional: true
 
   node-releases@2.0.27: {}
 

--- a/scripts/e2e-dry-run/fixtures/claude-marker.sh
+++ b/scripts/e2e-dry-run/fixtures/claude-marker.sh
@@ -3,6 +3,7 @@
 # Invoked like: claude --session-id <uuid> ... (prompt) or via INVOKER_CLAUDE_FIX_COMMAND (fix).
 set -eu
 SESSION_ID=""
+RESUME_ID=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --session-id)
@@ -13,11 +14,29 @@ while [ "$#" -gt 0 ]; do
       SESSION_ID="$2"
       shift 2
       ;;
+    --resume)
+      if [ "$#" -lt 2 ]; then
+        echo "claude-marker: --resume requires a value" >&2
+        exit 2
+      fi
+      RESUME_ID="$2"
+      shift 2
+      ;;
     *)
       shift
       ;;
   esac
 done
+
+if [ -n "$RESUME_ID" ]; then
+  if [ ! -t 0 ] || [ ! -t 1 ]; then
+    echo "stdin is not a terminal" >&2
+    exit 12
+  fi
+  sleep 1
+  echo "TTY OK: claude resume $RESUME_ID"
+  exit 0
+fi
 
 ROOT="${INVOKER_E2E_MARKER_ROOT:-}"
 if [ -n "$ROOT" ] && [ -n "$SESSION_ID" ]; then


### PR DESCRIPTION
## Summary

Reland the embedded node-pty backend and default GUI embedded terminals to PTY. This makes completed Codex and Claude resume terminals open with a real TTY in the embedded drawer.

## Architecture

### Before

```mermaid
graph TD
    GUI[GUI terminal open] --> Manager[Embedded terminal manager]
    Manager --> Shell[Shell backend]
    Shell --> Resume[Agent resume command]
    Resume --> Error[No controlling TTY]
```

### After

```mermaid
graph TD
    GUI[GUI terminal open] --> Manager[Embedded terminal manager]
    Manager --> PTY[node-pty backend]
    PTY --> Resume[Agent resume command]
    Resume --> OK[Interactive TTY session]
```

## Visual Proof

Codex resume terminal:

![Codex PTY resume terminal](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260518-a179da/pty-codex-resume-terminal.png)

Claude resume terminal:

![Claude PTY resume terminal](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260518-a179da/pty-claude-resume-terminal.png)

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app exec playwright test e2e/embedded-terminal-pty.spec.ts`
- [x] `CAPTURE_MODE=terminal-stack pnpm --filter @invoker/app exec playwright test e2e/embedded-terminal-pty.spec.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 7e27b177`
- Post-revert steps: Re-run `pnpm install --frozen-lockfile` if the lockfile changes need to be removed locally.
- Data migration? No
