### PR TITLE
Fix headless agent metadata routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
   },
   "pnpm": {
     "onlyBuiltDependencies": [
-      "electron"
+      "electron",
+      "node-pty"
     ]
   },
   "devDependencies": {

--- a/packages/app/e2e/embedded-terminal-pty.spec.ts
+++ b/packages/app/e2e/embedded-terminal-pty.spec.ts
@@ -1,0 +1,165 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+import {
+  E2E_REPO_URL,
+  expect,
+  injectTaskStates,
+  loadPlan,
+  test,
+} from './fixtures/electron-app.js';
+
+const CODEX_RESUME_PLAN = {
+  name: 'Embedded PTY Resume',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'codex-resume',
+      description: 'Completed Codex resume task',
+      command: 'echo unused',
+      executionAgent: 'codex',
+      dependencies: [],
+    },
+  ],
+};
+
+const CLAUDE_RESUME_PLAN = {
+  name: 'Embedded Claude PTY Resume',
+  repoUrl: E2E_REPO_URL,
+  onFinish: 'none' as const,
+  tasks: [
+    {
+      id: 'claude-resume',
+      description: 'Completed Claude resume task',
+      command: 'echo unused',
+      executionAgent: 'claude',
+      dependencies: [],
+    },
+  ],
+};
+
+test.describe('Embedded terminal PTY', () => {
+  test('completed Codex resume terminal gets a real TTY in the drawer', async ({ page, testDir }) => {
+    await loadPlan(page, CODEX_RESUME_PLAN);
+    const workspacePath = path.join(testDir, 'codex-resume-workspace');
+    mkdirSync(workspacePath, { recursive: true });
+    const agentSessionId = 'codex-session-e2e-tty';
+    const sessionDir = path.join(testDir, 'agent-sessions');
+    mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(
+      path.join(sessionDir, `${agentSessionId}.jsonl`),
+      '{"type":"thread.started","thread_id":"codex-session-e2e-tty"}\n{"type":"task_complete","last_agent_message":"done"}\n',
+      'utf8',
+    );
+
+    await injectTaskStates(page, [
+      {
+        taskId: 'codex-resume',
+        changes: {
+          status: 'completed',
+          config: {
+            runnerKind: 'worktree',
+            executionAgent: 'codex',
+          },
+          execution: {
+            workspacePath,
+            agentSessionId,
+            lastAgentSessionId: agentSessionId,
+            agentName: 'codex',
+            lastAgentName: 'codex',
+            completedAt: new Date('2025-01-01T00:00:00.000Z'),
+          },
+        },
+      },
+    ]);
+
+    const tasksResult = await page.evaluate(() => window.invoker.getTasks(true));
+    const tasks = Array.isArray(tasksResult) ? tasksResult : tasksResult.tasks;
+    const task = tasks.find((candidate) => candidate.id.endsWith('/codex-resume'));
+    const fullTaskId = task?.id;
+    expect(fullTaskId).toBeTruthy();
+    expect(task?.execution?.agentSessionId).toBe(agentSessionId);
+    expect(task?.execution?.agentName).toBe('codex');
+
+    const taskNode = page
+      .getByTestId('selected-workflow-mini-dag')
+      .locator('.react-flow__node[data-testid$="codex-resume"]')
+      .first();
+    const box = await taskNode.boundingBox();
+    if (!box) throw new Error('Codex resume task node has no bounding box');
+    await taskNode.locator('> div').dispatchEvent('dblclick', {
+      bubbles: true,
+      cancelable: true,
+      clientX: box.x + box.width / 2,
+      clientY: box.y + box.height / 2,
+    });
+
+    await expect(page.getByTestId('terminal-drawer-body')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('terminal-session-command')).toContainText('codex');
+    await expect(page.getByTestId('terminal-session-command')).toContainText(`resume ${agentSessionId}`);
+    const terminalPane = page.getByTestId(`terminal-pane-${fullTaskId}`);
+    await expect(terminalPane).toBeVisible();
+    await expect(terminalPane.getByText(`TTY OK: codex resume ${agentSessionId}`)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('stdin is not a terminal')).toHaveCount(0);
+    await expect(page.getByText('No deferred tool marker found')).toHaveCount(0);
+  });
+
+  test('completed Claude resume terminal gets a real TTY in the drawer', async ({ page, testDir }) => {
+    await loadPlan(page, CLAUDE_RESUME_PLAN);
+    const workspacePath = path.join(testDir, 'claude-resume-workspace');
+    mkdirSync(workspacePath, { recursive: true });
+    const agentSessionId = 'claude-session-e2e-tty';
+
+    await injectTaskStates(page, [
+      {
+        taskId: 'claude-resume',
+        changes: {
+          status: 'completed',
+          config: {
+            runnerKind: 'worktree',
+            executionAgent: 'claude',
+          },
+          execution: {
+            workspacePath,
+            agentSessionId,
+            lastAgentSessionId: agentSessionId,
+            agentName: 'claude',
+            lastAgentName: 'claude',
+            completedAt: new Date('2025-01-01T00:00:00.000Z'),
+          },
+        },
+      },
+    ]);
+
+    const tasksResult = await page.evaluate(() => window.invoker.getTasks(true));
+    const tasks = Array.isArray(tasksResult) ? tasksResult : tasksResult.tasks;
+    const task = tasks.find((candidate) => candidate.id.endsWith('/claude-resume'));
+    const fullTaskId = task?.id;
+    expect(fullTaskId).toBeTruthy();
+    expect(task?.execution?.agentSessionId).toBe(agentSessionId);
+    expect(task?.execution?.agentName).toBe('claude');
+
+    const taskNode = page
+      .getByTestId('selected-workflow-mini-dag')
+      .locator('.react-flow__node[data-testid$="claude-resume"]')
+      .first();
+    const box = await taskNode.boundingBox();
+    if (!box) throw new Error('Claude resume task node has no bounding box');
+    await taskNode.locator('> div').dispatchEvent('dblclick', {
+      bubbles: true,
+      cancelable: true,
+      clientX: box.x + box.width / 2,
+      clientY: box.y + box.height / 2,
+    });
+
+    await expect(page.getByTestId('terminal-drawer-body')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('terminal-session-command')).toContainText('--resume');
+    await expect(page.getByTestId('terminal-session-command')).toContainText(agentSessionId);
+    await expect(page.getByTestId('terminal-session-command')).toContainText('--dangerously-skip-permissions');
+    const terminalPane = page.getByTestId(`terminal-pane-${fullTaskId}`);
+    await expect(terminalPane).toBeVisible();
+    await expect(terminalPane.getByText(`TTY OK: claude resume ${agentSessionId}`)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('stdin is not a terminal')).toHaveCount(0);
+    await expect(page.getByText('No deferred tool marker found')).toHaveCount(0);
+  });
+});

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -11,7 +11,7 @@ import { resolveRepoRoot } from '@invoker/contracts';
 import { test as base, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import { stringify as yamlStringify } from 'yaml';
@@ -48,6 +48,28 @@ export const test = base.extend<ElectronFixtures>({
     } catch {
       // Windows / EPERM: fix path still uses INVOKER_CLAUDE_FIX_COMMAND; prompt tasks may hit real claude.
     }
+    const codexStub = path.join(stubDir, 'codex');
+    writeFileSync(codexStub, `#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\${1:-}" == "resume" ]]; then
+  if [[ ! -t 0 || ! -t 1 ]]; then
+    echo "stdin is not a terminal" >&2
+    exit 12
+  fi
+  sleep 1
+  echo "TTY OK: codex resume \${2:-}"
+  exit 0
+fi
+if [[ "\${1:-}" == "exec" ]]; then
+  echo '{"type":"session_configured","session_id":"codex-e2e-exec"}'
+  echo '{"type":"turn_context","cwd":"'"$PWD"'"}'
+  echo '{"type":"task_complete","last_agent_message":"Codex E2E exec complete"}'
+  exit 0
+fi
+echo "unsupported codex args: $*" >&2
+exit 64
+`, 'utf8');
+    chmodSync(codexStub, 0o755);
     const pathEnv = `${stubDir}${path.delimiter}${process.env.PATH ?? ''}`;
     const app = await electron.launch({
       args: [
@@ -65,6 +87,8 @@ export const test = base.extend<ElectronFixtures>({
         INVOKER_ALLOW_DELETE_ALL: '1',
         INVOKER_E2E_ENABLE_COMPOSITOR: '1',
         INVOKER_REPO_CONFIG_PATH: configPath,
+        INVOKER_EMBEDDED_TERMINAL_BACKEND:
+          process.env.INVOKER_E2E_EMBEDDED_TERMINAL_BACKEND ?? 'pty',
         INVOKER_E2E_MARKER_ROOT: markerRoot,
         INVOKER_TEST_FIXED_NOW: '2025-01-01T00:00:00.000Z',
         INVOKER_CLAUDE_COMMAND: claudeMarker,

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -77,6 +77,9 @@
     "dotenv": "^16.0.0",
     "yaml": "^2.7.0"
   },
+  "optionalDependencies": {
+    "node-pty": "^1.1.0"
+  },
   "devDependencies": {
     "@electron/rebuild": "^4.0.3",
     "@invoker/test-kit": "workspace:*",

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -219,8 +219,8 @@ describe('loadConfig', () => {
 });
 
 describe('resolveEmbeddedTerminalBackendConfig', () => {
-  it('defaults GUI embedded terminals to the bash backend', () => {
-    expect(resolveEmbeddedTerminalBackendConfig({}, {})).toBe('bash');
+  it('defaults GUI embedded terminals to the PTY backend', () => {
+    expect(resolveEmbeddedTerminalBackendConfig({}, {})).toBe('pty');
   });
 
   it('reads the configured GUI embedded terminal backend', () => {

--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -20,8 +20,11 @@ import { mkdirSync, rmSync } from 'node:fs';
 import {
   EmbeddedTerminalManager,
   createBashTerminalBackend,
+  createPtyTerminalBackend,
   type EmbeddedTerminalBackend,
   type BashSpawnFn,
+  type PtyLike,
+  type PtySpawnFn,
 } from '../embedded-terminal-manager.js';
 import { resolveTaskTerminalSpec } from '../open-terminal-for-task.js';
 import {
@@ -51,6 +54,35 @@ function createFakeChild() {
     },
   };
   ee.killed = false;
+  ee.kill = () => {
+    ee.killed = true;
+  };
+  return ee;
+}
+
+function createFakePty() {
+  const ee = new EventEmitter() as EventEmitter & PtyLike & {
+    __written: string[];
+    __resized: Array<{ cols: number; rows: number }>;
+    killed: boolean;
+  };
+  ee.__written = [];
+  ee.__resized = [];
+  ee.killed = false;
+  ee.onData = (listener) => {
+    ee.on('data', listener);
+    return { dispose: () => ee.off('data', listener) };
+  };
+  ee.onExit = (listener) => {
+    ee.on('exit', listener);
+    return { dispose: () => ee.off('exit', listener) };
+  };
+  ee.write = (data: string) => {
+    ee.__written.push(data);
+  };
+  ee.resize = (cols: number, rows: number) => {
+    ee.__resized.push({ cols, rows });
+  };
   ee.kill = () => {
     ee.killed = true;
   };
@@ -224,6 +256,29 @@ describe('EmbeddedTerminalManager', () => {
     const res = mgr.resize(session.sessionId, 120, 40);
 
     expect(res.ok).toBe(true);
+  });
+
+  it('opt-in PTY backend preserves command metadata and forwards resize', () => {
+    const pty = createFakePty();
+    const ptySpawnFn = vi.fn(() => pty) as unknown as PtySpawnFn;
+    const mgr = new EmbeddedTerminalManager({
+      backend: createPtyTerminalBackend({ spawnFn: ptySpawnFn }),
+    });
+    const session = mgr.openOrReuse({
+      taskId: 't',
+      spec: { command: 'claude', args: ['--resume', 'session-1'], cwd: '/tmp' },
+      cwd: '/tmp',
+    });
+
+    const res = mgr.resize(session.sessionId, 120, 40);
+
+    expect(ptySpawnFn).toHaveBeenCalledWith(
+      'claude',
+      ['--resume', 'session-1'],
+      expect.objectContaining({ cwd: '/tmp', cols: 80, rows: 24, name: 'xterm-256color' }),
+    );
+    expect(res.ok).toBe(true);
+    expect(pty.__resized).toEqual([{ cols: 120, rows: 40 }]);
   });
 
   it('emits exit and removes session when the bash child exits', () => {

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -242,7 +242,7 @@ export function resolveEmbeddedTerminalBackendConfig(
   config: InvokerConfig,
   env: NodeJS.ProcessEnv = process.env,
 ): EmbeddedTerminalBackendConfig {
-  const rawValue = env.INVOKER_EMBEDDED_TERMINAL_BACKEND ?? config.terminal?.embeddedBackend ?? 'bash';
+  const rawValue = env.INVOKER_EMBEDDED_TERMINAL_BACKEND ?? config.terminal?.embeddedBackend ?? 'pty';
   const raw = typeof rawValue === 'string' ? rawValue : String(rawValue);
   const value = raw.trim().toLowerCase();
   if (value === 'bash' || value === 'pty') return value;

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -8,6 +8,7 @@
 
 import { EventEmitter } from 'node:events';
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import {
   spawn as nodeSpawn,
   type ChildProcessWithoutNullStreams,
@@ -21,6 +22,29 @@ import type {
 import type { Executor, ExecutorHandle, TerminalSpec } from '@invoker/execution-engine';
 
 export type EmbeddedTerminalBackendName = 'bash' | 'pty';
+
+export interface PtyForkOptionsLike {
+  name: string;
+  cols: number;
+  rows: number;
+  cwd: string;
+  env: Record<string, string | undefined>;
+}
+
+export interface PtyLike {
+  onData(listener: (data: string) => void): { dispose: () => void };
+  onExit(listener: (event: { exitCode: number }) => void): { dispose: () => void };
+  write(data: string): void;
+  resize(cols: number, rows: number): void;
+  kill(): void;
+}
+
+/** Factory used by the optional PTY backend. Tests can supply a fake. */
+export type PtySpawnFn = (
+  command: string,
+  args: readonly string[],
+  options: PtyForkOptionsLike,
+) => PtyLike;
 
 /** Factory used by the default bash/pipe backend. Tests can supply a fake. */
 export type BashSpawnFn = (
@@ -49,6 +73,11 @@ export interface EmbeddedTerminalBackend {
 export interface BashTerminalBackendOptions {
   /** Override the child_process.spawn function for this Bash backend instance. */
   spawnFn?: BashSpawnFn;
+}
+
+export interface PtyTerminalBackendOptions {
+  /** Override the node-pty spawn function for this PTY backend instance. */
+  spawnFn?: PtySpawnFn;
 }
 
 /** Optional attach handle pair routing a session through a live executor. */
@@ -91,7 +120,7 @@ interface AttachedSessionState extends BaseSessionState {
 type SessionState = SpawnSessionState | AttachedSessionState;
 
 export interface EmbeddedTerminalManagerOptions {
-  /** Single backend used for GUI spawned sessions. Defaults to the Bash/pipe backend. */
+  /** Single backend used for GUI spawned sessions. Defaults to the PTY backend. */
   backend?: EmbeddedTerminalBackend;
   /** Default shell for `spawn`-mode sessions when the spec has no command. */
   defaultShell?: string;
@@ -159,6 +188,57 @@ export function createBashTerminalBackend(
   options: BashTerminalBackendOptions = {},
 ): EmbeddedTerminalBackend {
   return new BashTerminalBackend(options.spawnFn);
+}
+
+class PtyTerminalBackend implements EmbeddedTerminalBackend {
+  readonly name = 'pty' as const;
+  private readonly spawnFn: PtySpawnFn;
+
+  constructor(spawnFn?: PtySpawnFn) {
+    this.spawnFn = spawnFn ?? loadNodePtySpawn();
+  }
+
+  spawn(opts: Parameters<EmbeddedTerminalBackend['spawn']>[0]): SpawnedTerminalProcess {
+    const command = opts.spec.command ?? opts.defaultShell;
+    const args = opts.spec.command ? opts.spec.args ?? [] : [];
+    const pty = this.spawnFn(command, args, {
+      name: 'xterm-256color',
+      cols: 80,
+      rows: 24,
+      cwd: opts.cwd,
+      env: { ...process.env, TERM: process.env.TERM ?? 'xterm-256color' },
+    });
+    const dataDisposable = pty.onData(opts.emitOutput);
+    const exitDisposable = pty.onExit(({ exitCode }) => opts.emitExit(exitCode));
+
+    return {
+      write(data: string) {
+        pty.write(data);
+      },
+      resize(cols: number, rows: number) {
+        pty.resize(cols, rows);
+      },
+      close() {
+        try {
+          dataDisposable.dispose();
+          exitDisposable.dispose();
+        } catch {
+          /* listener disposal is best-effort */
+        }
+        try {
+          pty.kill();
+        } catch {
+          /* already dead */
+        }
+      },
+    };
+  }
+}
+
+export function createPtyTerminalBackend(
+  options: PtyTerminalBackendOptions = {},
+): EmbeddedTerminalBackend {
+  return new PtyTerminalBackend(options.spawnFn);
 }
 
 export class EmbeddedTerminalManager extends EventEmitter {
@@ -330,7 +410,23 @@ export class EmbeddedTerminalManager extends EventEmitter {
 
 function resolveBackend(options: EmbeddedTerminalManagerOptions): EmbeddedTerminalBackend {
   if (options.backend) return options.backend;
-  return createBashTerminalBackend();
+  return createPtyTerminalBackend();
+}
+
+function loadNodePtySpawn(): PtySpawnFn {
+  try {
+    const nodeRequire = createRequire(__filename);
+    const mod = nodeRequire('node-pty') as { spawn?: PtySpawnFn };
+    if (typeof mod.spawn !== 'function') {
+      throw new Error('node-pty does not export spawn()');
+    }
+    return mod.spawn;
+  } catch (err) {
+    const detail = err instanceof Error ? err.message : String(err);
+    throw new Error(
+      `Embedded terminal PTY backend requested, but node-pty is unavailable or not built: ${detail}`,
+    );
+  }
 }
 
 function buildTargetKey(opts: OpenSessionOptions): string {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -142,6 +142,7 @@ import { spawn, execSync } from 'node:child_process';
 import { resolveTaskTerminalSpec } from './open-terminal-for-task.js';
 import {
   createBashTerminalBackend,
+  createPtyTerminalBackend,
   EmbeddedTerminalManager,
   type EmbeddedTerminalBackend,
 } from './embedded-terminal-manager.js';
@@ -1187,7 +1188,7 @@ function createEmbeddedTerminalBackendFromConfig(
   backend: EmbeddedTerminalBackendConfig,
 ): EmbeddedTerminalBackend {
   if (backend === 'bash') return createBashTerminalBackend();
-  throw new Error('Embedded terminal PTY backend requested, but the PTY backend is not installed.');
+  return createPtyTerminalBackend();
 }
 
   function setupGuiMode(): void {

--- a/packages/app/tsup.config.ts
+++ b/packages/app/tsup.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
   entry: ['src/main.ts', 'src/preload.ts', 'src/headless-client.ts'],
   format: ['cjs'],
   outDir: 'dist',
-  external: ['electron', 'node:sqlite', 'sql.js', 'dockerode', '@invoker/surfaces', '@slack/bolt', 'dotenv'],
+  external: ['electron', 'node:sqlite', 'sql.js', 'dockerode', 'node-pty', '@invoker/surfaces', '@slack/bolt', 'dotenv'],
   noExternal: [
     '@invoker/workflow-core',
     '@invoker/workflow-graph',

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -317,6 +317,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
     log(`${TAG} Container created: ${container.id.slice(0, 12)} image=${this.imageName}`);
 
     // Determine task command and Claude session before entry registration
+    const executionAgent = request.inputs.executionAgent ?? 'claude';
     const { cmd, args: cmdArgs, agentSessionId } = this.buildCommandAndArgs(request, {
       agentRegistry: this.agentRegistry,
     });
@@ -408,6 +409,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
       if (!request.inputs.command && !request.inputs.prompt) {
         await this.handleProcessExit(executionId, request, CONTAINER_CWD, 0, {
           branch: handle.branch,
+          agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
         });
         return handle;
       }
@@ -434,6 +436,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
           outputs: {
             exitCode: 1,
             error: `Failed to spawn docker exec: ${err.message}`,
+            agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
           },
         };
         this.emitComplete(executionId, response);
@@ -455,6 +458,7 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
             signal,
             branch: handle.branch,
             agentSessionId: entry.agentSessionId,
+            agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
           });
 
           // Stop the idle container after git finalize completes

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -263,6 +263,7 @@ exit "$PAYLOAD_EXIT"
 
     let payload: string;
     let agentSessionId: string | undefined;
+    const executionAgent = request.inputs.executionAgent ?? 'claude';
 
     if (request.actionType === 'command') {
       const command = request.inputs.command;
@@ -271,14 +272,13 @@ exit "$PAYLOAD_EXIT"
       bench('SshExecutor.payload.built', { command: true });
     } else if (request.actionType === 'ai_task') {
       if (this.agentRegistry) {
-        const requestedAgent = request.inputs.executionAgent ?? 'claude';
-        const agent = this.agentRegistry.getOrThrow(requestedAgent);
+        const agent = this.agentRegistry.getOrThrow(executionAgent);
         const fullPrompt = this.buildFullPrompt(request);
         const spec = agent.buildCommand(fullPrompt);
         agentSessionId = spec.sessionId;
         payload = `${spec.cmd} ${spec.args.map(a => this.shellQuote(a)).join(' ')}`;
         bench('SshExecutor.payload.built', {
-          executionAgent: requestedAgent,
+          executionAgent,
           hasAgentSessionId: !!agentSessionId,
         });
       } else {
@@ -626,6 +626,7 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     if (!request.inputs.command && !request.inputs.prompt) {
       await this.handleProcessExit(executionId, request, remoteWt, 0, {
         branch: experimentBranch,
+        agentName: request.actionType === 'ai_task' ? request.inputs.executionAgent ?? 'claude' : undefined,
       });
       bench('SshExecutor.startManagedWorkspace.noCommand.returning', { remoteWt });
       return handle;
@@ -919,6 +920,7 @@ ${this.buildPayloadExecutionScript(payloadB64)}
               exitCode: finalExitCode,
               commitHash,
               agentSessionId: entry.agentSessionId,
+              agentName: request.actionType === 'ai_task' ? request.inputs.executionAgent ?? 'claude' : undefined,
               ...(mappedError ? { error: mappedError } : {}),
               ...(finalizeRemote && commitHash
                 ? { summary: `branch=${finalizeRemote.branch} commit=${commitHash}` }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -651,17 +651,19 @@ export class TaskRunner {
       }
     };
 
+    const actionType = this.determineActionType(task);
+    const executionAgent = task.config.executionAgent?.trim() || DEFAULT_EXECUTION_AGENT;
     const request: WorkRequest = {
       requestId: randomUUID(),
       actionId: task.id,
       attemptId,
       executionGeneration: task.execution.generation ?? 0,
-      actionType: this.determineActionType(task),
+      actionType,
       inputs: {
         description: task.description,
         command: task.config.command,
         prompt: task.config.prompt,
-        executionAgent: task.config.executionAgent?.trim() || DEFAULT_EXECUTION_AGENT,
+        executionAgent,
         repoUrl,
         branchRepoUrl,
         featureBranch: task.config.featureBranch,
@@ -836,7 +838,8 @@ export class TaskRunner {
           branch: handle.branch ?? undefined,  // Explicit undefined when branch is not applicable (e.g., BYO mode)
           agentSessionId: handle.agentSessionId ?? undefined,
           lastAgentSessionId: handle.agentSessionId ?? undefined,
-          lastAgentName: task.execution.agentName ?? undefined,
+          agentName: actionType === 'ai_task' ? executionAgent : undefined,
+          lastAgentName: actionType === 'ai_task' ? executionAgent : undefined,
           containerId: handle.containerId ?? undefined,
         },
       };

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -468,6 +468,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
         outputs: {
           exitCode: 1,
           error: `Failed to spawn command: ${err.message}`,
+          agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
         },
       };
       this.emitComplete(executionId, response);
@@ -511,6 +512,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
           signal,
           branch,
           agentSessionId: entry.agentSessionId,
+          agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
         });
       } catch (err) {
         const ent = this.entries.get(executionId);
@@ -529,6 +531,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
               exitCode: exitCode === 0 ? 1 : exitCode,
               error: `Invoker finalization failed after agent exited: ${reason}`,
               agentSessionId: entry.agentSessionId,
+              agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
               branch,
             },
           });

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -4190,6 +4190,7 @@ export class Orchestrator {
       completedAt: Date;
       commit?: string;
       agentSessionId?: string;
+      agentName?: string;
       lastAgentSessionId?: string;
       lastAgentName?: string;
       branch?: string;
@@ -4206,7 +4207,11 @@ export class Orchestrator {
     if (parsed.agentSessionId !== undefined) {
       execution.agentSessionId = parsed.agentSessionId;
       execution.lastAgentSessionId = parsed.agentSessionId;
-      execution.lastAgentName = task?.execution.agentName ?? task?.execution.lastAgentName;
+      execution.lastAgentName = parsed.agentName ?? task?.execution.agentName ?? task?.execution.lastAgentName;
+    }
+    if (parsed.agentName !== undefined) {
+      execution.agentName = parsed.agentName;
+      execution.lastAgentName = parsed.agentName;
     }
     if (parsed.branch !== undefined) {
       execution.branch = parsed.branch;
@@ -4288,6 +4293,8 @@ export class Orchestrator {
     executionFields: {
       exitCode?: number;
       error?: string;
+      agentName?: string;
+      lastAgentName?: string;
       protocolErrorCode?: string;
       protocolErrorMessage?: string;
       mergeConflict?: { failedBranch: string; conflictFiles: string[] };
@@ -4390,6 +4397,8 @@ export class Orchestrator {
       {
         exitCode: parsed.exitCode,
         error: parsed.error,
+        agentName: parsed.agentName,
+        lastAgentName: parsed.agentName,
         mergeConflict,
       },
       'task.failed',

--- a/packages/workflow-core/src/response-handler.ts
+++ b/packages/workflow-core/src/response-handler.ts
@@ -35,6 +35,7 @@ export type ParsedResponse =
       summary?: string;
       commitHash?: string;
       agentSessionId?: string;
+      agentName?: string;
       branch?: string;
       reviewUrl?: string;
       reviewId?: string;
@@ -55,6 +56,7 @@ export type ParsedResponse =
       taskId: string;
       exitCode: number;
       error?: string;
+      agentName?: string;
     }
   | {
       type: 'needs_input';
@@ -96,6 +98,7 @@ export class ResponseHandler {
           summary: outputs.summary,
           commitHash: outputs.commitHash,
           agentSessionId: outputs.agentSessionId,
+          agentName: outputs.agentName,
           branch: outputs.branch,
           reviewUrl: outputs.reviewUrl,
           reviewId: outputs.reviewId,
@@ -120,6 +123,7 @@ export class ResponseHandler {
           taskId: actionId,
           exitCode: outputs.exitCode ?? 1,
           error: outputs.error,
+          agentName: outputs.agentName,
         };
 
       case 'needs_input':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,10 @@ importers:
       vitest:
         specifier: ^3.0.0
         version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
+    optionalDependencies:
+      node-pty:
+        specifier: ^1.1.0
+        version: 1.1.0
 
   packages/contracts:
     dependencies:
@@ -2842,6 +2846,9 @@ packages:
   node-addon-api@1.7.2:
     resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
 
+  node-addon-api@7.1.1:
+    resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
+
   node-api-version@0.2.1:
     resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
@@ -2849,6 +2856,9 @@ packages:
     resolution: {integrity: sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ==}
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
+
+  node-pty@1.1.0:
+    resolution: {integrity: sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg==}
 
   node-releases@2.0.27:
     resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
@@ -6396,6 +6406,9 @@ snapshots:
   node-addon-api@1.7.2:
     optional: true
 
+  node-addon-api@7.1.1:
+    optional: true
+
   node-api-version@0.2.1:
     dependencies:
       semver: 7.7.4
@@ -6414,6 +6427,11 @@ snapshots:
       which: 5.0.0
     transitivePeerDependencies:
       - supports-color
+
+  node-pty@1.1.0:
+    dependencies:
+      node-addon-api: 7.1.1
+    optional: true
 
   node-releases@2.0.27: {}
 

--- a/scripts/e2e-dry-run/fixtures/claude-marker.sh
+++ b/scripts/e2e-dry-run/fixtures/claude-marker.sh
@@ -3,6 +3,7 @@
 # Invoked like: claude --session-id <uuid> ... (prompt) or via INVOKER_CLAUDE_FIX_COMMAND (fix).
 set -eu
 SESSION_ID=""
+RESUME_ID=""
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --session-id)
@@ -13,11 +14,29 @@ while [ "$#" -gt 0 ]; do
       SESSION_ID="$2"
       shift 2
       ;;
+    --resume)
+      if [ "$#" -lt 2 ]; then
+        echo "claude-marker: --resume requires a value" >&2
+        exit 2
+      fi
+      RESUME_ID="$2"
+      shift 2
+      ;;
     *)
       shift
       ;;
   esac
 done
+
+if [ -n "$RESUME_ID" ]; then
+  if [ ! -t 0 ] || [ ! -t 1 ]; then
+    echo "stdin is not a terminal" >&2
+    exit 12
+  fi
+  sleep 1
+  echo "TTY OK: claude resume $RESUME_ID"
+  exit 0
+fi
 
 ROOT="${INVOKER_E2E_MARKER_ROOT:-}"
 if [ -n "$ROOT" ] && [ -n "$SESSION_ID" ]; then

--- a/scripts/repro/repro-headless-agent-launch-metadata.sh
+++ b/scripts/repro/repro-headless-agent-launch-metadata.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+# Proves headless executionAgent routing and persisted agent metadata for Codex and Claude.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+# shellcheck disable=SC1091
+source "$ROOT/scripts/e2e-dry-run/lib/common.sh"
+
+export INVOKER_E2E_FORCE_BUILD="${INVOKER_E2E_FORCE_BUILD:-1}"
+invoker_e2e_ensure_app_built
+invoker_e2e_init
+trap invoker_e2e_cleanup EXIT
+
+unset ELECTRON_RUN_AS_NODE
+
+CODEX_LOG="$INVOKER_E2E_MARKER_ROOT/codex.invocations"
+CLAUDE_LOG="$INVOKER_E2E_MARKER_ROOT/claude.invocations"
+PLAN_PATH="$(mktemp "${TMPDIR:-/tmp}/invoker-agent-launch-plan.XXXXXX.yaml")"
+trap 'rm -f "$PLAN_PATH"; invoker_e2e_cleanup' EXIT
+
+rm -f "$INVOKER_E2E_STUB_DIR/codex" "$INVOKER_E2E_STUB_DIR/claude"
+cat >"$INVOKER_E2E_STUB_DIR/codex" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="${INVOKER_E2E_MARKER_ROOT:?missing marker root}"
+mkdir -p "$ROOT"
+SESSION_ID="e2e-codex-headless-session"
+printf 'cwd=%s argv=%s\n' "$(pwd)" "$*" >>"$ROOT/codex.invocations"
+printf '%s\n' "{\"type\":\"thread.started\",\"thread_id\":\"${SESSION_ID}\"}"
+printf '%s\n' "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_started\"}}"
+printf '%s\n' "{\"type\":\"response_item\",\"payload\":{\"type\":\"message\",\"role\":\"assistant\",\"content\":[{\"type\":\"output_text\",\"text\":\"codex task complete\"}]}}"
+printf '%s\n' "{\"type\":\"event_msg\",\"payload\":{\"type\":\"task_complete\"}}"
+exit 0
+SH
+
+cat >"$INVOKER_E2E_STUB_DIR/claude" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="${INVOKER_E2E_MARKER_ROOT:?missing marker root}"
+mkdir -p "$ROOT"
+SESSION_ID=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --session-id)
+      SESSION_ID="${2:-}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+if [ -z "$SESSION_ID" ]; then
+  echo "claude stub expected --session-id" >&2
+  exit 2
+fi
+printf 'session=%s cwd=%s\n' "$SESSION_ID" "$(pwd)" >>"$ROOT/claude.invocations"
+exit 0
+SH
+chmod +x "$INVOKER_E2E_STUB_DIR/codex" "$INVOKER_E2E_STUB_DIR/claude"
+
+cat >"$PLAN_PATH" <<'YAML'
+name: "headless agent launch metadata repro"
+repoUrl: git@github.com:example-org/acme-repo.git
+onFinish: none
+baseBranch: HEAD
+
+tasks:
+  - id: e2e-headless-agent-codex
+    description: "E2E headless Codex launch"
+    executionAgent: codex
+    prompt: "Complete the Codex launch metadata proof."
+    dependencies: []
+
+  - id: e2e-headless-agent-claude
+    description: "E2E headless Claude launch"
+    executionAgent: claude
+    prompt: "Complete the Claude launch metadata proof."
+    dependencies: []
+YAML
+
+echo "==> delete-all in isolated DB"
+invoker_e2e_run_headless delete-all
+
+echo "==> submit headless Codex/Claude plan"
+invoker_e2e_submit_plan "$PLAN_PATH"
+
+for task_id in e2e-headless-agent-codex e2e-headless-agent-claude; do
+  invoker_e2e_wait_settled "$task_id"
+  status="$(invoker_e2e_task_status "$task_id")"
+  if [ "$status" != "completed" ]; then
+    echo "FAIL: expected $task_id status=completed, got '$status'" >&2
+    invoker_e2e_run_headless status 2>&1 || true
+    exit 1
+  fi
+done
+
+codex_count="$(wc -l <"$CODEX_LOG" 2>/dev/null || printf '0')"
+claude_count="$(wc -l <"$CLAUDE_LOG" 2>/dev/null || printf '0')"
+if [ "$codex_count" -ne 1 ]; then
+  echo "FAIL: expected exactly one Codex invocation, got $codex_count" >&2
+  ls -la "$INVOKER_E2E_MARKER_ROOT" >&2 || true
+  exit 1
+fi
+if [ "$claude_count" -ne 1 ]; then
+  echo "FAIL: expected exactly one Claude invocation, got $claude_count" >&2
+  ls -la "$INVOKER_E2E_MARKER_ROOT" >&2 || true
+  exit 1
+fi
+
+python3 - <<'PY' "$INVOKER_DB_DIR/invoker.db"
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+expected = {
+    "e2e-headless-agent-codex": {
+        "execution_agent": "codex",
+        "agent_name": "codex",
+        "last_agent_name": "codex",
+        "agent_session_id": "e2e-codex-headless-session",
+        "last_agent_session_id": "e2e-codex-headless-session",
+    },
+    "e2e-headless-agent-claude": {
+        "execution_agent": "claude",
+        "agent_name": "claude",
+        "last_agent_name": "claude",
+    },
+}
+
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+for task_id, fields in expected.items():
+    row = conn.execute(
+        """
+        SELECT id, status, execution_agent, agent_name, last_agent_name,
+               agent_session_id, last_agent_session_id
+        FROM tasks
+        WHERE id = ? OR id LIKE ?
+        ORDER BY length(id) DESC
+        LIMIT 1
+        """,
+        (task_id, f"%/{task_id}"),
+    ).fetchone()
+    if row is None:
+        raise SystemExit(f"FAIL: task row missing: {task_id}")
+    if row["status"] != "completed":
+        raise SystemExit(f"FAIL: {task_id} status={row['status']!r}, expected 'completed'")
+    for field, value in fields.items():
+        if row[field] != value:
+            raise SystemExit(
+                f"FAIL: {task_id} {field}={row[field]!r}, expected {value!r}"
+            )
+    if task_id.endswith("claude") and not row["agent_session_id"]:
+        raise SystemExit("FAIL: Claude task did not persist an agent_session_id")
+    if task_id.endswith("claude") and row["last_agent_session_id"] != row["agent_session_id"]:
+        raise SystemExit("FAIL: Claude last_agent_session_id does not match agent_session_id")
+
+print("PASS: headless Codex and Claude launch routing plus DB metadata verified")
+PY


### PR DESCRIPTION
## Summary

Fix headless task launch routing so task agent metadata is preserved through workflow creation and executor launch. The deterministic repro verifies a Codex task launches Codex and a Claude task launches Claude.

## Architecture

### Before

```mermaid
graph TD
    Plan[Plan task agent] --> Workflow[Workflow task]
    Workflow --> Executor[Executor launch]
    Executor --> Fallback[Stale or inferred agent]
    Fallback --> WrongCLI[Wrong CLI may launch]
```

### After

```mermaid
graph TD
    Plan[Plan task agent] --> Workflow[Workflow task metadata]
    Workflow --> Executor[Executor launch]
    Executor --> Command[Agent-specific command]
    Command --> RightCLI[Codex launches Codex, Claude launches Claude]
```

## Visual Proof

No new UI surface is introduced in this PR. The deterministic proof is `bash scripts/repro/repro-headless-agent-launch-metadata.sh`, and the stack-level terminal UI screenshots are captured in #797/#799.

## Test Plan

- [x] `pnpm run check:types`
- [x] `bash scripts/repro/repro-headless-agent-launch-metadata.sh`
- [x] `pnpm --filter @invoker/app test -- embedded-terminal-manager.test.ts config.test.ts open-terminal.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 71d5ac28`
- Post-revert steps: None
- Data migration? No
