### PR TITLE
Add Closed Status: Core Review Gate Semantics

### DIFF
--- a/packages/app/src/__tests__/formatter.test.ts
+++ b/packages/app/src/__tests__/formatter.test.ts
@@ -100,15 +100,17 @@ describe('formatWorkflowStatus', () => {
       total: 5,
       completed: 2,
       failed: 1,
+      closed: 1,
       running: 1,
-      pending: 1,
+      pending: 0,
     };
     const output = formatWorkflowStatus(status);
     expect(output).toContain('5 total');
     expect(output).toContain('2 completed');
     expect(output).toContain('1 failed');
+    expect(output).toContain('1 closed');
     expect(output).toContain('1 running');
-    expect(output).toContain('1 pending');
+    expect(output).toContain('0 pending');
   });
 
   it('uses colored output', () => {

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -84,6 +84,7 @@ export function formatWorkflowStatus(status: {
   total: number;
   completed: number;
   failed: number;
+  closed?: number;
   running: number;
   pending: number;
 }): string {
@@ -91,6 +92,7 @@ export function formatWorkflowStatus(status: {
     `${BOLD}Workflow:${RESET} ${status.total} total`,
     `${GREEN}${status.completed} completed${RESET}`,
     `${RED}${status.failed} failed${RESET}`,
+    `${DIM}${status.closed ?? 0} closed${RESET}`,
     `${YELLOW}${status.running} running${RESET}`,
     `${DIM}${status.pending} pending${RESET}`,
   ];

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1855,6 +1855,45 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(sid(orchestrator, 1, 'leaf-a'))!.status).toBe('pending');
     });
 
+    it('closed merge-gate dependency keeps downstream pending for completed and review_ready policies', () => {
+      orchestrator.loadPlan({
+        name: 'prereq-workflow',
+        tasks: [{ id: 'verify-control-plane-regression', description: 'Prereq task' }],
+      });
+      const prereqTaskId = sid(orchestrator, 0, 'verify-control-plane-regression');
+      const prereqWfId = prereqTaskId.split('/')[0]!;
+      const prereqMergeId = `__merge__${prereqWfId}`;
+
+      orchestrator.loadPlan({
+        name: 'workflow-gated-closed',
+        tasks: [
+          {
+            id: 'strict-leaf',
+            description: 'strict leaf waits for upstream merge completion',
+            externalDependencies: [{ workflowId: prereqWfId, gatePolicy: 'completed' }],
+          },
+          {
+            id: 'review-leaf',
+            description: 'review leaf waits for upstream merge review readiness',
+            externalDependencies: [{ workflowId: prereqWfId, gatePolicy: 'review_ready' }],
+          },
+        ],
+      });
+      const strictLeafId = sid(orchestrator, 1, 'strict-leaf');
+      const reviewLeafId = sid(orchestrator, 1, 'review-leaf');
+
+      orchestrator.startExecution();
+      orchestrator.handleWorkerResponse(makeResponse({ actionId: prereqTaskId, status: 'completed' }));
+      persistence.updateTask(prereqMergeId, { status: 'closed' });
+      orchestrator.syncAllFromDb();
+
+      const startedAfterClosedGate = orchestrator.startExecution();
+      expect(startedAfterClosedGate.map((t) => t.id)).not.toContain(strictLeafId);
+      expect(startedAfterClosedGate.map((t) => t.id)).not.toContain(reviewLeafId);
+      expect(orchestrator.getTask(strictLeafId)!.status).toBe('pending');
+      expect(orchestrator.getTask(reviewLeafId)!.status).toBe('pending');
+    });
+
     it('setTaskExternalGatePolicies can unblock pending task immediately', () => {
       orchestrator.loadPlan({
         name: 'prereq-workflow',
@@ -4612,10 +4651,12 @@ describe('Orchestrator', () => {
       const statusA = orchestrator.getWorkflowStatus(wfIds[0]);
       expect(statusA.total).toBe(3);
       expect(statusA.pending).toBe(3);
+      expect(statusA.closed).toBe(0);
 
       const statusB = orchestrator.getWorkflowStatus(wfIds[1]);
       expect(statusB.total).toBe(2);
       expect(statusB.pending).toBe(2);
+      expect(statusB.closed).toBe(0);
     });
 
     it('getWorkflowStatus() without wfId returns aggregate across all workflows', () => {
@@ -4630,6 +4671,22 @@ describe('Orchestrator', () => {
 
       const status = orchestrator.getWorkflowStatus();
       expect(status.total).toBe(4);
+    });
+
+    it('getWorkflowStatus() counts closed separately from completed and failed', () => {
+      orchestrator.loadPlan({
+        name: 'Closed Status',
+        tasks: [{ id: 'a1', description: 'A1', command: 'echo a1' }],
+      });
+      const taskId = sid(orchestrator, 0, 'a1');
+
+      persistence.updateTask(taskId, { status: 'closed' });
+      orchestrator.syncAllFromDb();
+
+      const status = orchestrator.getWorkflowStatus();
+      expect(status.closed).toBe(1);
+      expect(status.completed).toBe(0);
+      expect(status.failed).toBe(0);
     });
 
     it('syncAllFromDb reloads tasks from all workflows', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -3936,6 +3936,7 @@ export class Orchestrator {
     total: number;
     completed: number;
     failed: number;
+    closed: number;
     running: number;
     pending: number;
   } {
@@ -3948,6 +3949,7 @@ export class Orchestrator {
       total: tasks.length,
       completed: tasks.filter((t) => t.status === 'completed').length,
       failed: tasks.filter((t) => t.status === 'failed').length,
+      closed: tasks.filter((t) => t.status === 'closed').length,
       running: tasks.filter((t) => t.status === 'running' || t.status === 'fixing_with_ai').length,
       pending: tasks.filter((t) => t.status === 'pending').length,
     };

--- a/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
+++ b/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
@@ -24,6 +24,10 @@ describe('workflow rollup', () => {
     { name: 'failed with unrelated pending work by counts only', statuses: ['failed', 'pending'], expected: 'failed' },
     { name: 'terminal failed', statuses: ['failed', 'completed'], expected: 'failed' },
     { name: 'closed gate', statuses: ['completed', 'closed'], expected: 'closed' },
+    { name: 'running outranks closed', statuses: ['closed', 'running'], expected: 'running' },
+    { name: 'awaiting approval outranks closed', statuses: ['closed', 'awaiting_approval'], expected: 'awaiting_approval' },
+    { name: 'review ready outranks closed', statuses: ['closed', 'review_ready'], expected: 'review_ready' },
+    { name: 'closed outranks blocked', statuses: ['closed', 'blocked'], expected: 'closed' },
     { name: 'completed workflow', statuses: ['completed', 'completed'], expected: 'completed' },
     { name: 'completed with stale prior task', statuses: ['completed', 'stale'], expected: 'completed' },
     { name: 'all stale', statuses: ['stale', 'stale'], expected: 'stale' },
@@ -73,5 +77,14 @@ describe('workflow rollup', () => {
     ]);
 
     expect(rollup.status).toBe('closed');
+  });
+
+  it('does not report closed tasks as failed issues', () => {
+    const rollup = computeWorkflowRollupFromSummaries([
+      task('alpha', 'closed'),
+      task('beta', 'failed'),
+    ]);
+
+    expect(rollup.failedTasks.map((issue) => issue.taskId)).toEqual(['beta']);
   });
 });

--- a/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
+++ b/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
@@ -87,4 +87,14 @@ describe('workflow rollup', () => {
 
     expect(rollup.failedTasks.map((issue) => issue.taskId)).toEqual(['beta']);
   });
+
+  it('counts closed tasks as terminal-neutral (not completed, not failed)', () => {
+    const rollup = computeWorkflowRollupFromSummaries([task('alpha', 'closed')]);
+
+    expect(rollup.status).toBe('closed');
+    expect(rollup.countsByStatus.closed).toBe(1);
+    expect(rollup.countsByStatus.completed).toBe(0);
+    expect(rollup.countsByStatus.failed).toBe(0);
+    expect(rollup.failedTasks).toEqual([]);
+  });
 });

--- a/packages/workflow-graph/src/workflow-rollup.ts
+++ b/packages/workflow-graph/src/workflow-rollup.ts
@@ -84,10 +84,10 @@ export function computeWorkflowStatusFromCounts(
 
   if (counts.fixing_with_ai > 0) return 'fixing_with_ai';
   if (counts.failed > 0) return 'failed';
-  if (counts.closed > 0) return 'closed';
   if (counts.running > 0) return 'running';
   if (counts.awaiting_approval > 0) return 'awaiting_approval';
   if (counts.review_ready > 0) return 'review_ready';
+  if (counts.closed > 0) return 'closed';
   if (counts.blocked > 0 || counts.needs_input > 0) return 'blocked';
   if (counts.pending === total) return 'pending';
   if (counts.pending > 0) return 'running';
@@ -145,7 +145,7 @@ export function computeWorkflowRollupFromSummaries(
     counts[task.status] += 1;
     const issue = toRollupIssue(task);
 
-    if (task.status === 'failed' || task.status === 'closed') {
+    if (task.status === 'failed') {
       failedTasks.push(issue);
     }
     if (task.status === 'fixing_with_ai' || task.execution?.isFixingWithAI) {
@@ -180,7 +180,7 @@ export function computeWorkflowRollupFromCountsAndIssues(
 
   for (const task of issues) {
     const issue = toRollupIssue(task);
-    if (task.status === 'failed' || task.status === 'closed') failedTasks.push(issue);
+    if (task.status === 'failed') failedTasks.push(issue);
     if (task.status === 'fixing_with_ai' || task.execution?.isFixingWithAI) fixingTasks.push(issue);
     if (
       task.status === 'needs_input' ||


### PR DESCRIPTION
## Summary

Add first-class `closed` status accounting for closed-unmerged external review gates so workflows can stop waiting without treating the gate as completed or failed.

The rollup layer now prioritizes `closed` after active review/running states, excludes closed tasks from failed issue lists, and keeps closed counts separate from completed and failed totals. The orchestrator exposes closed workflow status counts and keeps downstream external dependencies pending when their upstream merge gate is closed without merge. CLI workflow status formatting now reports closed counts explicitly.

## Architecture

### Before

Closed-unmerged review gates were either left in review-facing states or counted alongside failure-oriented workflow issues, so downstream gate checks could not distinguish neutral closure from completion or failure.

Flow: external review gate -> workflow rollup/status counts -> orchestrator dependency checks -> downstream task scheduling.

### After

`closed` is a terminal-neutral task and workflow state. Rollups surface it only after higher-priority active states, status counts include it separately, failed issue lists ignore it, and external dependency policies for `completed` and `review_ready` do not unblock downstream work from a closed gate.

Flow: external review gate closes unmerged -> task status `closed` -> rollup/status count `closed` -> dependency checks remain unsatisfied -> downstream tasks stay pending.

## Test Plan

- [x] `cd packages/workflow-graph && pnpm test`
- [x] `cd packages/workflow-core && pnpm test`
- [x] `cd packages/execution-engine && pnpm test`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert d2d473a4`
- Post-revert steps: Re-run `pnpm run test:all`
- Data migration? No