### PR TITLE
Avoid runtime git config mutations

### DIFF
--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -2069,6 +2069,7 @@ describe('BaseExecutor.pushBranchToRemote', () => {
 
     const remoteBranches = execSync('git branch', { cwd: intermediateDir }).toString();
     expect(remoteBranches).toContain('invoker/task-intermediate');
+    expect(() => execSync('git remote get-url invoker-branches', { cwd: cloneDir, stdio: 'pipe' })).toThrow();
   });
 });
 

--- a/packages/execution-engine/src/__tests__/branch-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-utils.test.ts
@@ -736,6 +736,13 @@ describe('bashMergeUpstreams', () => {
         worktreeDir: wtDir,
         branchRepoUrl: intermediateDir,
       }));
+      const fetchScript = bashFetchNodeRemotes({
+        worktreeDir: wtDir,
+        branchRepoUrl: intermediateDir,
+      });
+      expect(fetchScript).not.toContain('remote set-url invoker-branches');
+      expect(fetchScript).not.toContain('remote add invoker-branches');
+      expect(fetchScript).toContain('fetch "$BRANCH_REPO_URL" \'+refs/heads/*:refs/remotes/invoker-branches/*\' --prune');
       await runBashLocal(bashMergeUpstreams({
         worktreeDir: wtDir,
         upstreamBranches: ['dep-from-intermediate'],
@@ -746,6 +753,17 @@ describe('bashMergeUpstreams', () => {
       rmSync(seedDir, { recursive: true, force: true });
       rmSync(intermediateDir, { recursive: true, force: true });
       rmSync(originDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not generate high-risk runtime config mutations for branch repo fetches', () => {
+    const script = bashFetchNodeRemotes({
+      worktreeDir: '/tmp/worktree',
+      branchRepoUrl: '/tmp/branch-repo.git',
+    });
+
+    for (const forbidden of ['git remote add', 'git remote set-url', 'git config user.', 'git config remote.']) {
+      expect(script).not.toContain(forbidden);
     }
   });
 });

--- a/packages/execution-engine/src/__tests__/create-merge-worktree.test.ts
+++ b/packages/execution-engine/src/__tests__/create-merge-worktree.test.ts
@@ -1,9 +1,9 @@
 /**
  * createMergeWorktree isolation tests (real git).
  *
- * Proves that createMergeWorktree produces a clone whose origin points to
- * the real GitHub remote (not the host working directory), and that branches
- * are mirrored correctly.  Covers gaps 2-5 from scripts/repro/repro-host-cwd-safety.sh.
+ * Proves that createMergeWorktree produces an isolated clone with mirrored
+ * branches and can refresh requested bases without mutating clone remotes.
+ * Covers gaps 2-5 from scripts/repro/repro-host-cwd-safety.sh.
  *
  * Pattern: bare remote + working clone + TaskRunner with real git.
  */
@@ -57,21 +57,16 @@ describe('createMergeWorktree isolation (real git)', { timeout: 30_000 }, () => 
     });
   }
 
-  it('clone origin points to real remote, not host cwd', async () => {
+  it('clone origin remains local clone source to avoid runtime remote rewrites', async () => {
     const sandbox = createSandbox();
     root = sandbox.root;
 
     const executor = buildExecutor(sandbox.host);
     const clonePath = await executor.createMergeWorktree('master', 'test-origin');
 
-    // The clone's origin should point to the bare remote (real GitHub),
-    // NOT to the host working directory.
     const cloneOrigin = git(clonePath, 'remote get-url origin');
-    const hostOrigin = git(sandbox.host, 'remote get-url origin');
 
-    expect(cloneOrigin).toBe(hostOrigin);
-    expect(cloneOrigin).toContain('bare.git');
-    expect(cloneOrigin).not.toBe(sandbox.host);
+    expect(cloneOrigin).toBe(sandbox.host);
 
     await executor.removeMergeWorktree(clonePath);
   });
@@ -190,10 +185,9 @@ describe('createMergeWorktree isolation (real git)', { timeout: 30_000 }, () => 
     // Host should be behind remote
     expect(hostMasterSha).not.toBe(remoteMasterSha);
 
-    // When repoUrl is provided, createMergeWorktree falls back to host.cwd
-    // (no pool mirror in test), but origin still points to bare remote.
-    // The clone should have branches mirrored from the host and origin
-    // should be set to the bare remote URL.
+    // When repoUrl is provided, createMergeWorktree falls back to cloning
+    // from the repo URL directly (no pool mirror in test) so origin is correct
+    // without a follow-up remote rewrite.
     const executor = buildExecutor(sandbox.host);
     const clonePath = await executor.createMergeWorktree('master', 'test-stale', sandbox.bare);
 

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -337,14 +337,17 @@ describe('buildRecordAndPushScript', () => {
     expect(script).toContain('set -euo pipefail');
     expect(script).toContain('WT=$(echo');
     expect(script).toContain('base64 -d)');
-    expect(script).toContain('git config user.name');
-    expect(script).toContain('git config user.email');
+    expect(script).not.toContain('git config user.');
+    expect(script).toContain('export GIT_AUTHOR_NAME=');
+    expect(script).toContain('export GIT_AUTHOR_EMAIL=');
+    expect(script).toContain('export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"');
+    expect(script).toContain('export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"');
     expect(script).toContain('git add -A');
     expect(script).toContain('if git diff --cached --quiet');
     expect(script).toContain('git commit --allow-empty -F');
     expect(script).toContain('git commit -F');
     expect(script).toContain('HASH=$(git rev-parse HEAD)');
-    expect(script).toContain('git push -u origin "$BR"');
+    expect(script).toContain('git push origin "HEAD:refs/heads/$BR"');
     expect(script).toContain('printf "%s" "$HASH"');
   });
 
@@ -372,9 +375,9 @@ describe('buildRecordAndPushScript', () => {
       pushRemoteUrl: 'https://github.com/fork/repo.git',
     });
 
-    expect(script).toContain('git remote set-url invoker-branches "$PUSH_URL"');
-    expect(script).toContain('git remote add invoker-branches "$PUSH_URL"');
-    expect(script).toContain('git push -u invoker-branches "$BR"');
+    expect(script).not.toContain('git remote set-url');
+    expect(script).not.toContain('git remote add');
+    expect(script).toContain('git push "$PUSH_URL" "HEAD:refs/heads/$BR"');
   });
 
   it('commits and pushes successfully without preconfigured git identity', () => {
@@ -423,6 +426,67 @@ describe('buildRecordAndPushScript', () => {
     expect(authorName).toBe('Remote CI Bot');
     expect(authorEmail).toBe('remote-ci@example.com');
     expect(pushedHead).toBe(localHead);
+  });
+
+  it('commits and pushes while .git/config.lock exists', () => {
+    const root = mkdtempSync(join(tmpdir(), 'ssh-record-push-lock-'));
+    const source = join(root, 'source');
+    const bare = join(root, 'remote.git');
+    const clone = join(root, 'clone');
+
+    mkdirSync(source, { recursive: true });
+    execSync('git init -b master', { cwd: source, stdio: 'ignore' });
+    writeFileSync(join(source, 'README.md'), 'seed\n');
+    execSync('git add README.md', { cwd: source, stdio: 'ignore' });
+    execSync('git -c user.name="Seed User" -c user.email="seed@example.com" commit -m "seed"', {
+      cwd: source,
+      stdio: 'ignore',
+    });
+    execSync(`git clone --bare ${JSON.stringify(source)} ${JSON.stringify(bare)}`, { stdio: 'ignore' });
+    execSync(`git clone ${JSON.stringify(bare)} ${JSON.stringify(clone)}`, { stdio: 'ignore' });
+    execSync('git checkout -b experiment/config-lock', { cwd: clone, stdio: 'ignore' });
+    writeFileSync(join(clone, 'result.txt'), 'ok\n');
+    writeFileSync(join(clone, '.git', 'config.lock'), '');
+
+    const script = buildRecordAndPushScript({
+      worktreePath: clone,
+      branch: 'experiment/config-lock',
+      commitMessageChanges: 'invoker: record remote result',
+      commitMessageEmpty: 'invoker: record remote empty result',
+      gitUserName: 'Remote CI Bot',
+      gitUserEmail: 'remote-ci@example.com',
+    });
+
+    execFileSync('bash', ['-lc', script], {
+      env: {
+        ...process.env,
+        GIT_CONFIG_GLOBAL: '/dev/null',
+        GIT_CONFIG_NOSYSTEM: '1',
+      },
+      stdio: 'pipe',
+    });
+
+    const pushed = execSync('git show experiment/config-lock:result.txt', {
+      cwd: bare,
+      encoding: 'utf8',
+    }).trim();
+    expect(pushed).toBe('ok');
+  });
+
+  it('does not generate high-risk runtime config mutations', () => {
+    const script = buildRecordAndPushScript({
+      worktreePath: '~/worktree',
+      branch: 'branch',
+      commitMessageChanges: 'msg',
+      commitMessageEmpty: 'empty',
+      gitUserName: 'Invoker Bot',
+      gitUserEmail: 'invoker@local',
+      pushRemoteUrl: 'https://github.com/fork/repo.git',
+    });
+
+    for (const forbidden of ['git remote add', 'git remote set-url', 'git config user.', 'git config remote.']) {
+      expect(script).not.toContain(forbidden);
+    }
   });
 });
 

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -781,6 +781,34 @@ describe('TaskRunner', () => {
     });
   });
 
+  describe('pushBranchFromMergeWorktree', () => {
+    it('pushes branch repo updates by direct URL without mutating remotes', async () => {
+      const calls: string[][] = [];
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => undefined } as any,
+        persistence: {} as any,
+        executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+        cwd: '/tmp',
+      });
+      (runner as any).execGitIn = async (args: string[]) => {
+        calls.push(args);
+        return '';
+      };
+
+      await (runner as any).pushBranchFromMergeWorktree(
+        '/tmp/mock-wt',
+        'experiment/direct-url',
+        'https://github.com/fork/repo.git',
+      );
+
+      expect(calls).toEqual([
+        ['push', '--force', 'https://github.com/fork/repo.git', 'experiment/direct-url:refs/heads/experiment/direct-url'],
+      ]);
+      expect(calls.flat().join(' ')).not.toContain('remote set-url');
+      expect(calls.flat().join(' ')).not.toContain('remote add');
+    });
+  });
+
   describe('merge commit messages include task descriptions', () => {
     it('consolidateAndMerge includes task description in merge -m', async () => {
       const tasks = new Map<string, TaskState>();
@@ -1555,6 +1583,7 @@ describe('TaskRunner', () => {
 
       (executor as any).execGitReadonly = async (args: string[]) => {
         if (args[0] === 'branch' && args[1] === '--show-current') return 'master';
+        if (args[0] === 'remote' && args[1] === 'get-url' && args[2] === 'origin') return '/tmp/origin.git';
         return '';
       };
       (executor as any).execGitIn = async (args: string[], dir: string) => {
@@ -2003,9 +2032,11 @@ describe('TaskRunner', () => {
       const mergeCall = gateGitCalls.find((c) => c.args[0] === 'merge' && c.args.includes('invoker/t1'));
       expect(mergeCall).toBeDefined();
 
-      // Feature branch pushed directly from gate clone to origin
-      const gatePush = gateGitCalls.find((c) => c.args[0] === 'push' && c.args.includes('origin') && c.args.includes('plan/feature'));
+      // Feature branch pushed directly by URL without mutating clone remotes.
+      const gatePush = gateGitCalls.find((c) => c.args[0] === 'push' && c.args.includes('plan/feature:refs/heads/plan/feature'));
       expect(gatePush).toBeDefined();
+      expect(gatePush!.args).not.toContain('origin');
+      expect(gatePush!.args).not.toContain('-u');
 
       // No git operations in host.cwd
       const hostCalls = gitCalls.filter((c) => c.dir === '/tmp/host');

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -79,7 +79,6 @@ export class MergeConflictError extends Error {
 }
 
 export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor {
-  protected static readonly BRANCH_REMOTE_NAME = 'invoker-branches';
   abstract readonly type: string;
   protected entries = new Map<string, TEntry>();
   protected heartbeatIntervalMs: number;
@@ -812,23 +811,12 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         : undefined);
       const branchRepoUrl = requestBranchRepoUrl?.trim();
       if (branchRepoUrl) {
-        try {
-          await this.execGitSimple(
-            ['remote', 'set-url', BaseExecutor.BRANCH_REMOTE_NAME, branchRepoUrl],
-            cwd,
-          );
-        } catch {
-          await this.execGitSimple(
-            ['remote', 'add', BaseExecutor.BRANCH_REMOTE_NAME, branchRepoUrl],
-            cwd,
-          );
-        }
         await this.execGitSimpleWithNetworkTimeout(
-          ['push', '--force-with-lease', '-u', BaseExecutor.BRANCH_REMOTE_NAME, branch],
+          ['push', '--force-with-lease', branchRepoUrl, `${branch}:refs/heads/${branch}`],
           cwd,
         );
       } else {
-        await this.execGitSimpleWithNetworkTimeout(['push', '--force-with-lease', '-u', 'origin', branch], cwd);
+        await this.execGitSimpleWithNetworkTimeout(['push', '--force-with-lease', 'origin', `${branch}:refs/heads/${branch}`], cwd);
       }
       return undefined;
     } catch (err) {

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -211,12 +211,7 @@ if git -C "$WT_DIR" remote get-url origin >/dev/null 2>&1; then
   git -C "$WT_DIR" fetch origin '+refs/heads/*:refs/remotes/origin/*' --prune
 fi
 ${branchRepo ? `BRANCH_REPO_URL=${q(branchRepo)}
-if git -C "$WT_DIR" remote get-url invoker-branches >/dev/null 2>&1; then
-  git -C "$WT_DIR" remote set-url invoker-branches "$BRANCH_REPO_URL"
-else
-  git -C "$WT_DIR" remote add invoker-branches "$BRANCH_REPO_URL"
-fi
-if ! git -C "$WT_DIR" fetch invoker-branches '+refs/heads/*:refs/remotes/invoker-branches/*' --prune; then
+if ! git -C "$WT_DIR" fetch "$BRANCH_REPO_URL" '+refs/heads/*:refs/remotes/invoker-branches/*' --prune; then
   echo "BRANCH_REPO_FETCH_FAILED=$BRANCH_REPO_URL" >&2
   exit 32
 fi` : ''}

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -130,6 +130,12 @@ async function execGitInMergeSafe(
   return host.execGitIn(args, dir);
 }
 
+async function resolveOriginPushUrl(host: MergeRunnerHost, repoUrl?: string): Promise<string> {
+  const trimmedRepoUrl = repoUrl?.trim();
+  if (trimmedRepoUrl) return trimmedRepoUrl;
+  return (await host.execGitReadonly(['remote', 'get-url', 'origin'])).trim();
+}
+
 async function syncGateWorkspaceToFeatureBranch(
   host: MergeRunnerHost,
   gateWorkspacePath: string | undefined,
@@ -329,6 +335,19 @@ export async function ensureLocalBranchForMerge(
   }
 
   const trimmedUrl = repoUrl?.trim();
+  if (trimmedUrl) {
+    try {
+      await execGitInMergeSafe(
+        host,
+        ['fetch', trimmedUrl, `+refs/heads/${branch}:refs/heads/${branch}`],
+        worktreeDir,
+      );
+      return true;
+    } catch {
+      // Fall through to mirror fetch and final diagnostics.
+    }
+  }
+
   let mirrorErr: string | undefined;
   if (trimmedUrl && host.ensureRepoMirrorPath) {
     const mirror = await host.ensureRepoMirrorPath(trimmedUrl);
@@ -765,8 +784,9 @@ export async function approveMergeImpl(
       mergeTrace('GIT_COMMIT', { mergeMessage });
       const commitBody = fullSummary ? `${mergeMessage}\n\n${fullSummary}` : mergeMessage;
       await execGitInMergeSafe(host, ['commit', '-m', commitBody], worktreeDir);
-      // Push squash commit directly to origin (GitHub) from the clone
-      await execGitInMergeSafe(host, ['push', '--force', 'origin', `HEAD:refs/heads/${baseBranch}`], worktreeDir);
+      // Push squash commit directly to the origin URL without mutating clone remotes.
+      const originPushUrl = await resolveOriginPushUrl(host, workflow.repoUrl);
+      await execGitInMergeSafe(host, ['push', '--force', originPushUrl, `HEAD:refs/heads/${baseBranch}`], worktreeDir);
       // Advance the baseBranch ref in the clone so subsequent operations see the updated base
       const newHead = (await execGitInMergeSafe(host, ['rev-parse', 'HEAD'], worktreeDir)).trim();
       await execGitInMergeSafe(host, ['update-ref', `refs/heads/${baseBranch}`, newHead], worktreeDir);
@@ -786,8 +806,9 @@ export async function approveMergeImpl(
     const worktreeDir = await host.createMergeWorktree(featureBranch, 'approve-pr-' + workflowId, workflow.repoUrl);
     try {
       mergeTrace('GIT_PUSH', { featureBranch, worktreeDir });
-      // Push feature branch directly to origin (GitHub) from the clone
-      await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
+      // Push feature branch directly without mutating clone remotes/upstream config.
+      const featurePushUrl = branchRepoUrl ?? await resolveOriginPushUrl(host, workflow.repoUrl);
+      await execGitInMergeSafe(host, ['push', '--force', featurePushUrl, `${featureBranch}:refs/heads/${featureBranch}`], worktreeDir);
       const prBody = await authorPrBodyForMerge(host, {
         workflowId,
         mergeNodeTaskId: mergeTaskId,
@@ -967,6 +988,7 @@ export async function publishAfterFixImpl(
       })
       .map((t) => ({ branch: t.execution.branch!, description: t.description }))
       .sort((a, b) => a.branch.localeCompare(b.branch));
+    const branchRepoUrl = workflow?.intermediateRepoUrl?.trim() || undefined;
 
     let mergedViaPriorConsolidation = false;
     if (priorConsolidatedSha) {
@@ -1003,7 +1025,6 @@ export async function publishAfterFixImpl(
         } catch { /* not an ancestor — needs merging */ }
 
         console.log(`[merge] Post-fix: merging task branch ${branch} → ${featureBranch}`);
-        const branchRepoUrl = workflow?.intermediateRepoUrl?.trim() || undefined;
         const branchAvailable = await ensureLocalBranchForMerge(
           host,
           consolidateDir,
@@ -1034,8 +1055,9 @@ export async function publishAfterFixImpl(
         (skippedCount > 0 ? ` (skipped ${skippedCount} missing branches)` : ''));
     }
 
-    // Push feature branch directly to origin (GitHub) from the gate clone
-    await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], consolidateDir);
+    // Push feature branch directly without mutating clone remotes/upstream config.
+    const featurePushUrl = branchRepoUrl ?? await resolveOriginPushUrl(host, workflow?.repoUrl);
+    await execGitInMergeSafe(host, ['push', '--force', featurePushUrl, `${featureBranch}:refs/heads/${featureBranch}`], consolidateDir);
 
     let fullSummary = summary;
     let vpMarkdownCapture2: string | undefined;
@@ -1394,7 +1416,9 @@ export async function consolidateAndMergeImpl(
     // Push feature branch to origin so other clones (e.g., the gate clone used
     // by external review providers can access it. The consolidation clone is removed
     // in the finally block, so without this push the branch would be lost.
-    await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
+    const featurePushUrl = workflowForMerge?.intermediateRepoUrl?.trim()
+      || await resolveOriginPushUrl(host, repoUrlForMerge);
+    await execGitInMergeSafe(host, ['push', '--force', featurePushUrl, `${featureBranch}:refs/heads/${featureBranch}`], worktreeDir);
 
     if (visualProof && onFinish === 'pull_request' && host.runVisualProofCapture) {
       const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
@@ -1416,7 +1440,8 @@ export async function consolidateAndMergeImpl(
       if (hasChanges) {
         const commitBody = body ? `${mergeMessage}\n\n${body}` : mergeMessage;
         await execGitInMergeSafe(host, ['commit', '-m', commitBody], worktreeDir);
-        await execGitInMergeSafe(host, ['push', '--force', 'origin', `HEAD:refs/heads/${baseBranch}`], worktreeDir);
+        const originPushUrl = await resolveOriginPushUrl(host, repoUrlForMerge);
+        await execGitInMergeSafe(host, ['push', '--force', originPushUrl, `HEAD:refs/heads/${baseBranch}`], worktreeDir);
         // Advance the baseBranch ref in the clone so subsequent operations see the updated base
         const newHead = (await execGitInMergeSafe(host, ['rev-parse', 'HEAD'], worktreeDir)).trim();
         await execGitInMergeSafe(host, ['update-ref', `refs/heads/${baseBranch}`, newHead], worktreeDir);
@@ -1425,8 +1450,10 @@ export async function consolidateAndMergeImpl(
         console.log(`[merge] No changes to commit — ${baseBranch} already up-to-date with ${featureBranch}`);
       }
     } else if (onFinish === 'pull_request') {
-      // Push feature branch directly to origin (GitHub) from the clone
-      await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
+      // Push feature branch directly without mutating clone remotes/upstream config.
+      const featurePushUrl = workflowForMerge?.intermediateRepoUrl?.trim()
+        || await resolveOriginPushUrl(host, repoUrlForMerge);
+      await execGitInMergeSafe(host, ['push', '--force', featurePushUrl, `${featureBranch}:refs/heads/${featureBranch}`], worktreeDir);
       const structuredCtx3 = workflowId
         ? await buildPrAuthoringContext(host, workflowId)
         : undefined;

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -327,8 +327,10 @@ export function buildRecordAndPushScript(opts: GitRecordAndPushOpts): string {
 WT=$(echo ${wtB} | base64 -d)
 ${bashNormalizeTildePath()}
 cd "$WT"
-git config user.name "$(echo ${userNameB} | base64 -d)"
-git config user.email "$(echo ${userEmailB} | base64 -d)"
+export GIT_AUTHOR_NAME="$(echo ${userNameB} | base64 -d)"
+export GIT_AUTHOR_EMAIL="$(echo ${userEmailB} | base64 -d)"
+export GIT_COMMITTER_NAME="$GIT_AUTHOR_NAME"
+export GIT_COMMITTER_EMAIL="$GIT_AUTHOR_EMAIL"
 git add -A
 M=$(mktemp)
 trap 'rm -f "$M"' EXIT
@@ -343,14 +345,9 @@ HASH=$(git rev-parse HEAD)
 BR=$(echo ${brB} | base64 -d)
 PUSH_URL=$(echo ${pushRemoteUrlB} | base64 -d)
 if [ -n "$PUSH_URL" ]; then
-  if git remote get-url invoker-branches >/dev/null 2>&1; then
-    git remote set-url invoker-branches "$PUSH_URL"
-  else
-    git remote add invoker-branches "$PUSH_URL"
-  fi
-  git push -u invoker-branches "$BR"
+  git push "$PUSH_URL" "HEAD:refs/heads/$BR"
 else
-  git push -u origin "$BR"
+  git push origin "HEAD:refs/heads/$BR"
 fi
 printf "%s" "$HASH"
 `;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -201,7 +201,6 @@ export interface TaskRunnerConfig {
 // ── TaskRunner ──────────────────────────────────────────
 
 export class TaskRunner {
-  private static readonly BRANCH_REMOTE_NAME = 'invoker-branches';
   /** @internal */ orchestrator: Orchestrator;
   /** @internal */ persistence: SQLiteAdapter;
   private executorRegistry: ExecutorRegistry;
@@ -1570,25 +1569,27 @@ export class TaskRunner {
         cloneSource = mirrorPath;
         originUrl = repoUrl;
       } else {
-        this.logger.warn(`[createMergeWorktree] Pool mirror unavailable for ${repoUrl}, falling back to host repo`);
+        cloneSource = repoUrl;
+        originUrl = repoUrl;
+        this.logger.warn(`[createMergeWorktree] Pool mirror unavailable for ${repoUrl}, cloning from repo URL`);
       }
     }
 
-    // Clone with hard-linked objects — near-instant, fully isolated refs
-    await this.execGitReadonly(['clone', '--local', '--no-checkout', cloneSource, clonePath]);
+    // Prefer hard-linked local clones; when no mirror exists, clone from repoUrl
+    // directly so origin is correct without mutating .git/config afterward.
+    const cloneArgs = cloneSource === originUrl
+      ? ['clone', '--no-checkout', cloneSource, clonePath]
+      : ['clone', '--local', '--no-checkout', cloneSource, clonePath];
+    await this.execGitReadonly(cloneArgs);
     // Detach HEAD so the fetch can overwrite all branch refs (including the default branch)
     const headSha = (await this.execGitIn(['rev-parse', 'HEAD'], clonePath)).trim();
     await this.execGitIn(['update-ref', '--no-deref', 'HEAD', headSha], clonePath);
     // Mirror all branches as local refs so bare branch names resolve.
     await this.execGitIn(['fetch', 'origin', '+refs/heads/*:refs/heads/*'], clonePath);
 
-    // Reconfigure origin to the real remote URL (GitHub) so subsequent push/fetch
-    // operations go directly to GitHub, bypassing any intermediate clone.
     if (!originUrl) {
-      // Fallback: read origin from the host repo (old behavior)
       originUrl = (await this.execGitReadonly(['remote', 'get-url', 'origin'])).trim();
     }
-    await this.execGitIn(['remote', 'set-url', 'origin', originUrl], clonePath);
 
     // Refresh the requested base branch from the real remote. The pool mirror's
     // local refs/heads/* can go stale after force-pushes or history rewrites,
@@ -1602,7 +1603,7 @@ export class TaskRunner {
       : strippedRemoteRef;
     try {
       await this.execGitIn(
-        ['fetch', remoteName, `+refs/heads/${baseRef}:refs/remotes/${remoteName}/${baseRef}`],
+        ['fetch', originUrl, `+refs/heads/${baseRef}:refs/remotes/${remoteName}/${baseRef}`],
         clonePath,
       );
     } catch {
@@ -2443,25 +2444,15 @@ export class TaskRunner {
   ): Promise<void> {
     const trimmedBranchRepoUrl = branchRepoUrl?.trim();
     if (trimmedBranchRepoUrl) {
-      try {
-        await this.execGitIn(
-          ['remote', 'set-url', TaskRunner.BRANCH_REMOTE_NAME, trimmedBranchRepoUrl],
-          worktreeDir,
-        );
-      } catch {
-        await this.execGitIn(
-          ['remote', 'add', TaskRunner.BRANCH_REMOTE_NAME, trimmedBranchRepoUrl],
-          worktreeDir,
-        );
-      }
       await this.execGitIn(
-        ['push', '--force', TaskRunner.BRANCH_REMOTE_NAME, `${branch}:refs/heads/${branch}`],
+        ['push', '--force', trimmedBranchRepoUrl, `${branch}:refs/heads/${branch}`],
         worktreeDir,
       );
       return;
     }
 
-    await this.execGitIn(['push', '--force', 'origin', `${branch}:refs/heads/${branch}`], worktreeDir);
+    const originUrl = (await this.execGitReadonly(['remote', 'get-url', 'origin'])).trim();
+    await this.execGitIn(['push', '--force', originUrl, `${branch}:refs/heads/${branch}`], worktreeDir);
   }
 
   /** @internal */ gitLogMessage(commitHash: string, cwd?: string): Promise<string> {


### PR DESCRIPTION
## Summary

Remove runtime `.git/config` mutation from task/fix/merge/rebase branch transport paths.

- Use direct URL fetch/push for branch-repo and merge-runner transport instead of creating or rewriting remotes.
- Use per-command commit identity environment variables for SSH approved-fix publish instead of `git config user.*`.
- Keep merge clone `origin` stable while fetching/pushing requested refs through explicit URLs.
- Add regression coverage for `.git/config.lock` and static guards against high-risk generated script mutations.

## Architecture

### Before

```mermaid
graph TD
    Runtime[Runtime task/fix/merge path] --> Config[Mutate .git/config]
    Config --> Remote[remote add or set-url]
    Config --> Identity[git config user identity]
    Remote --> PushFetch[fetch or push via named remote]
```

### After

```mermaid
graph TD
    Runtime[Runtime task/fix/merge path] --> Explicit[Use explicit URL refs]
    Runtime --> EnvIdentity[Use GIT_AUTHOR and GIT_COMMITTER env]
    Explicit --> PushFetch[fetch or push direct URL refspec]
    EnvIdentity --> Commit[commit without .git/config writes]
```

## Test Plan

- [x] `INVOKER_DB_DIR=$(mktemp -d) pnpm --dir packages/execution-engine exec vitest run src/__tests__/ssh-git-exec.test.ts src/__tests__/branch-utils.test.ts src/__tests__/auto-commit.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `bash -n run.sh`
- [x] `rg -n "remote set-url|remote add|git config user\\.|git config remote\\.|git push -u|'-u'|\\\"-u\\\"" packages/execution-engine/src/ssh-git-exec.ts packages/execution-engine/src/base-executor.ts packages/execution-engine/src/branch-utils.ts packages/execution-engine/src/task-runner.ts packages/execution-engine/src/merge-runner.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 698d8462`
- Post-revert steps: Re-run the targeted execution-engine Vitest command from the Test Plan.
- Data migration? No
