### PR TITLE
Keep selected workflow mini-DAG during metadata gaps

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -11,7 +11,7 @@
 
 import { useState, useCallback, useMemo, useEffect, useRef, useLayoutEffect } from 'react';
 import yaml from 'js-yaml';
-import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowStatus } from './types.js';
+import type { TaskState, TaskReplacementDef, ExternalGatePolicyUpdate, WorkflowMeta, WorkflowStatus } from './types.js';
 import type { ActionGraphNode, TerminalSessionDescriptor } from '@invoker/contracts';
 import { useTasks } from './hooks/useTasks.js';
 import { useInvoker } from './hooks/useInvoker.js';
@@ -267,6 +267,7 @@ export function App() {
   const graphSurfaceRef = useRef<HTMLDivElement>(null);
   const [selectedTaskId, setSelectedTaskId] = useState<string | null>(null);
   const [selectedWorkflowId, setSelectedWorkflowId] = useState<string | null>(null);
+  const [stickySelectedWorkflow, setStickySelectedWorkflow] = useState<WorkflowMeta | null>(null);
   const [workflowSelectionDismissed, setWorkflowSelectionDismissed] = useState(false);
   const [modal, setModal] = useState<ModalState>({ type: 'none' });
   const [hasLoadedPlan, setHasLoadedPlan] = useState(false);
@@ -414,15 +415,29 @@ export function App() {
 
   const selectedTask = selectedTaskId ? tasks.get(selectedTaskId) ?? null : null;
   const contextMenuTask = contextMenu ? tasks.get(contextMenu.taskId) ?? null : null;
+  const selectedWorkflowTaskCount = useMemo(() => {
+    if (!selectedWorkflowId) return 0;
+    let count = 0;
+    for (const task of tasks.values()) {
+      if (task.config.workflowId === selectedWorkflowId) count += 1;
+    }
+    return count;
+  }, [selectedWorkflowId, tasks]);
   const selectedWorkflow = useMemo(() => {
     if (selectedWorkflowId) {
-      return workflows.get(selectedWorkflowId) ?? null;
+      return workflows.get(selectedWorkflowId)
+        ?? (stickySelectedWorkflow?.id === selectedWorkflowId && selectedWorkflowTaskCount > 0
+          ? stickySelectedWorkflow
+          : null);
     }
     if (selectedTask?.config.workflowId) {
-      return workflows.get(selectedTask.config.workflowId) ?? null;
+      return workflows.get(selectedTask.config.workflowId)
+        ?? (stickySelectedWorkflow?.id === selectedTask.config.workflowId
+          ? stickySelectedWorkflow
+          : null);
     }
     return null;
-  }, [selectedWorkflowId, selectedTask, workflows]);
+  }, [selectedWorkflowId, selectedTask, workflows, stickySelectedWorkflow, selectedWorkflowTaskCount]);
   const miniDagTasks = useMemo(() => {
     const activeWorkflowId = selectedWorkflow?.id ?? selectedWorkflowId;
     if (!activeWorkflowId) return new Map<string, TaskState>();
@@ -434,6 +449,29 @@ export function App() {
     }
     return next;
   }, [selectedWorkflow, selectedWorkflowId, tasks]);
+  const selectedTaskDagWorkflows = useMemo(() => {
+    if (!selectedWorkflow || workflows.has(selectedWorkflow.id)) {
+      return workflows;
+    }
+    const next = new Map(workflows);
+    next.set(selectedWorkflow.id, selectedWorkflow);
+    return next;
+  }, [selectedWorkflow, workflows]);
+
+  useEffect(() => {
+    if (!selectedWorkflowId) {
+      setStickySelectedWorkflow(null);
+      return;
+    }
+    const liveWorkflow = workflows.get(selectedWorkflowId);
+    if (liveWorkflow) {
+      setStickySelectedWorkflow(liveWorkflow);
+      return;
+    }
+    if (selectedWorkflowTaskCount === 0) {
+      setStickySelectedWorkflow((prev) => (prev?.id === selectedWorkflowId ? null : prev));
+    }
+  }, [selectedWorkflowId, selectedWorkflowTaskCount, workflows]);
 
   useEffect(() => {
     if (selectedTask?.config.workflowId) {
@@ -441,7 +479,7 @@ export function App() {
       setSelectedWorkflowId(selectedTask.config.workflowId);
       return;
     }
-    if (selectedWorkflowId && workflows.has(selectedWorkflowId)) {
+    if (selectedWorkflowId && (workflows.has(selectedWorkflowId) || selectedWorkflowTaskCount > 0)) {
       return;
     }
     if (workflowSelectionDismissed) {
@@ -449,7 +487,7 @@ export function App() {
     }
     const firstWorkflowId = workflows.keys().next().value as string | undefined;
     setSelectedWorkflowId(firstWorkflowId ?? null);
-  }, [selectedTask, selectedWorkflowId, workflowSelectionDismissed, workflows]);
+  }, [selectedTask, selectedWorkflowId, selectedWorkflowTaskCount, workflowSelectionDismissed, workflows]);
 
   const handleStatusClick = useCallback((filterKey: WorkflowStatus, event: React.MouseEvent) => {
     setStatusFilters(prev => {
@@ -1583,7 +1621,7 @@ export function App() {
                       >
                         <TaskDAG
                           tasks={miniDagTasks}
-                          workflows={workflows}
+                          workflows={selectedTaskDagWorkflows}
                           selectedTaskId={selectedTaskId}
                           centerTaskId={centerTaskId}
                           onTaskClick={handleTaskClick}

--- a/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
+++ b/packages/ui/src/__tests__/selected-workflow-graph-disappears-repro.test.tsx
@@ -1,0 +1,79 @@
+/**
+ * Regression: the selected workflow mini-DAG remains visible when workflows-changed
+ * transiently omits the selected workflow metadata while its tasks remain.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
+import { vi } from 'vitest';
+import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import type { WorkflowMeta } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const { App } = await import('../App.js');
+
+const workflowA: WorkflowMeta = { id: 'wf-a', name: 'Workflow A', status: 'running' };
+const workflowB: WorkflowMeta = { id: 'wf-b', name: 'Workflow B', status: 'pending' };
+
+const taskAlpha = makeUITask({
+  id: 'task-alpha',
+  description: 'Workflow A first task',
+  status: 'pending',
+  workflowId: 'wf-a',
+});
+const taskBeta = makeUITask({
+  id: 'task-beta',
+  description: 'Workflow A second task',
+  status: 'pending',
+  workflowId: 'wf-a',
+  dependencies: ['task-alpha'],
+});
+
+describe('selected workflow graph metadata-gap regression', () => {
+  let mock: MockInvoker;
+
+  beforeEach(() => {
+    mock = createMockInvoker();
+    mock.install();
+  });
+
+  afterEach(() => {
+    mock.cleanup();
+  });
+
+  it('keeps the selected mini-DAG visible when workflow metadata briefly omits the selected workflow', async () => {
+    render(<App />);
+    act(() => mock.setTasks([taskAlpha, taskBeta], [workflowA, workflowB]));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('rf__node-wf-a'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A task DAG');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
+      expect(screen.getByTestId('rf__node-task-beta')).toBeInTheDocument();
+    });
+
+    act(() => mock.fireWorkflowsChanged([workflowB]));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Workflow A task DAG');
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('Workflow A');
+    });
+
+    expect(screen.getByText('Total:')).toHaveTextContent('Total: 2');
+    expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
+    expect(screen.queryByTestId('workflow-node-wf-a')).not.toBeInTheDocument();
+    expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
+    expect(screen.getByTestId('rf__node-task-beta')).toBeInTheDocument();
+  });
+});

--- a/scripts/repro/repro-selected-workflow-graph-disappears-on-workflow-metadata-gap.sh
+++ b/scripts/repro/repro-selected-workflow-graph-disappears-on-workflow-metadata-gap.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-selected-workflow-graph-repro.XXXXXX.log")"
+trap 'rm -f "$log_file"' EXIT
+
+echo "[repro] Running selected workflow mini-DAG metadata-gap regression."
+echo "[repro] Scenario: select wf-a, keep wf-a tasks, then publish workflows-changed with only wf-b."
+
+if pnpm -C "$repo_root" --filter @invoker/ui exec vitest run \
+  src/__tests__/selected-workflow-graph-disappears-repro.test.tsx \
+  >"$log_file" 2>&1; then
+  echo "[repro] PASS: selected mini-DAG stayed visible while task state remained present."
+  echo "[repro] Regression confirms the UI is resilient to transient workflow metadata gaps."
+else
+  status=$?
+  echo "[repro] FAIL: focused regression did not complete as expected."
+  cat "$log_file"
+  exit "$status"
+fi


### PR DESCRIPTION
## Summary

Keep the selected workflow mini-DAG visible when the renderer receives a transient `workflows-changed` metadata snapshot that omits the selected workflow while its tasks still exist.

The UI now keeps last-known metadata only for the selected workflow, preserving the mini-DAG and inspector without changing global workflow snapshot replacement semantics.

## Architecture

### Before

```mermaid
graph TD
    A[workflows-changed omits selected workflow] --> B[workflows map no longer has selectedWorkflowId]
    B --> C[selectedWorkflow becomes null]
    C --> D[selected mini-DAG unmounts even though tasks remain]
```

### After

```mermaid
graph TD
    A[workflows-changed omits selected workflow] --> B[workflows map no longer has selectedWorkflowId]
    B --> C{selected workflow tasks still exist?}
    C -->|yes| D[use last-known selected workflow metadata]
    D --> E[selected mini-DAG and inspector remain visible]
    C -->|no| F[clear sticky metadata and follow normal selection behavior]
```

## Test Plan

- [x] `bash scripts/repro/repro-selected-workflow-graph-disappears-on-workflow-metadata-gap.sh`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/selected-workflow-graph-disappears-repro.test.tsx src/__tests__/task-interaction.test.tsx src/__tests__/keyboard-controls.test.tsx`
- [x] `pnpm --filter @invoker/ui build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f6897998`
- Post-revert steps: None
- Data migration? No
