### PR TITLE
Route remote config writes through gateway

### DIFF
--- a/packages/execution-engine/src/__tests__/git-config-mutation.test.ts
+++ b/packages/execution-engine/src/__tests__/git-config-mutation.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, unlinkSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { execSync } from 'node:child_process';
+import {
+  classifyGitConfigMutation,
+  ensureRemoteUrl,
+} from '../git-config-mutation.js';
+
+function git(cwd: string, args: string): string {
+  return execSync(`git ${args}`, { cwd, stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim();
+}
+
+function createRepo(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'git-config-mutation-'));
+  execSync('git init -b master', { cwd: dir, stdio: 'ignore' });
+  return dir;
+}
+
+describe('git config mutation classification', () => {
+  it('classifies runtime .git/config writers', () => {
+    expect(classifyGitConfigMutation(['config', 'user.name', 'Test'])).toMatchObject({
+      mutates: true,
+      kind: 'config-write',
+    });
+    expect(classifyGitConfigMutation(['remote', 'add', 'origin', 'git@example.com:repo.git'])).toMatchObject({
+      mutates: true,
+      kind: 'remote-add',
+    });
+    expect(classifyGitConfigMutation(['remote', 'set-url', 'origin', 'git@example.com:repo.git'])).toMatchObject({
+      mutates: true,
+      kind: 'remote-set-url',
+    });
+    expect(classifyGitConfigMutation(['push', '-u', 'origin', 'branch'])).toMatchObject({
+      mutates: true,
+      kind: 'push-upstream',
+    });
+    expect(classifyGitConfigMutation(['branch', '--set-upstream-to', 'origin/main'])).toMatchObject({
+      mutates: true,
+      kind: 'branch-upstream',
+    });
+  });
+
+  it('allows read-only config and non-upstream pushes', () => {
+    expect(classifyGitConfigMutation(['config', '--get', 'user.name']).mutates).toBe(false);
+    expect(classifyGitConfigMutation(['remote', 'get-url', 'origin']).mutates).toBe(false);
+    expect(classifyGitConfigMutation(['config', '--list']).mutates).toBe(false);
+    expect(classifyGitConfigMutation(['push', 'origin', 'branch:refs/heads/branch']).mutates).toBe(false);
+  });
+});
+
+describe('git config mutation gateway', () => {
+  let root: string | undefined;
+
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = undefined;
+  });
+
+  it('skips ensureRemoteUrl when the URL already matches', async () => {
+    root = createRepo();
+    git(root, 'remote add origin /tmp/origin.git');
+
+    const result = await ensureRemoteUrl({
+      cwd: root,
+      remote: 'origin',
+      url: '/tmp/origin.git',
+      context: { caller: 'test', detail: 'noop' },
+    });
+
+    expect(result).toBe('unchanged');
+    expect(git(root, 'remote get-url origin')).toBe('/tmp/origin.git');
+  });
+
+  it('serializes concurrent remote setup and waits for transient config.lock', async () => {
+    root = createRepo();
+    const configLock = join(root, '.git', 'config.lock');
+    writeFileSync(configLock, '');
+    setTimeout(() => unlinkSync(configLock), 100);
+
+    const results = await Promise.all([
+      ensureRemoteUrl({
+        cwd: root,
+        remote: 'origin',
+        url: '/tmp/origin.git',
+        context: { caller: 'test', detail: 'a' },
+      }),
+      ensureRemoteUrl({
+        cwd: root,
+        remote: 'origin',
+        url: '/tmp/origin.git',
+        context: { caller: 'test', detail: 'b' },
+      }),
+    ]);
+
+    expect(results).toContain('added');
+    expect(results).toContain('unchanged');
+    expect(git(root, 'remote get-url origin')).toBe('/tmp/origin.git');
+  });
+});

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -6,6 +6,7 @@ import { bashPreserveOrReset, bashMergeUpstreams, bashFetchNodeRemotes, parsePre
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { checkStaleness } from './git-staleness-detector.js';
+import { ensureRemoteUrl } from './git-config-mutation.js';
 
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -812,17 +813,12 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
         : undefined);
       const branchRepoUrl = requestBranchRepoUrl?.trim();
       if (branchRepoUrl) {
-        try {
-          await this.execGitSimple(
-            ['remote', 'set-url', BaseExecutor.BRANCH_REMOTE_NAME, branchRepoUrl],
-            cwd,
-          );
-        } catch {
-          await this.execGitSimple(
-            ['remote', 'add', BaseExecutor.BRANCH_REMOTE_NAME, branchRepoUrl],
-            cwd,
-          );
-        }
+        await ensureRemoteUrl({
+          cwd,
+          remote: BaseExecutor.BRANCH_REMOTE_NAME,
+          url: branchRepoUrl,
+          context: { caller: `${this.type}.pushBranchToRemote`, detail: branch },
+        });
         await this.execGitSimpleWithNetworkTimeout(
           ['push', '--force-with-lease', '-u', BaseExecutor.BRANCH_REMOTE_NAME, branch],
           cwd,

--- a/packages/execution-engine/src/git-config-mutation.ts
+++ b/packages/execution-engine/src/git-config-mutation.ts
@@ -1,0 +1,322 @@
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { isAbsolute, resolve } from 'node:path';
+import { performance } from 'node:perf_hooks';
+
+export type GitConfigMutationKind =
+  | 'config-write'
+  | 'remote-add'
+  | 'remote-set-url'
+  | 'remote-remove'
+  | 'remote-rename'
+  | 'push-upstream'
+  | 'branch-upstream';
+
+export interface GitConfigMutationClassification {
+  mutates: boolean;
+  kind?: GitConfigMutationKind;
+}
+
+export interface GitConfigMutationContext {
+  caller: string;
+  detail?: string;
+}
+
+const repoLocks = new Map<string, Promise<void>>();
+
+export function classifyGitConfigMutation(args: string[]): GitConfigMutationClassification {
+  const command = firstNonOption(args);
+  if (!command) return { mutates: false };
+
+  if (command === 'config') {
+    return classifyConfig(args.slice(args.indexOf(command) + 1));
+  }
+
+  if (command === 'remote') {
+    const subcommand = firstNonOption(args.slice(args.indexOf(command) + 1));
+    switch (subcommand) {
+      case 'add':
+        return { mutates: true, kind: 'remote-add' };
+      case 'set-url':
+        return { mutates: true, kind: 'remote-set-url' };
+      case 'remove':
+      case 'rm':
+        return { mutates: true, kind: 'remote-remove' };
+      case 'rename':
+        return { mutates: true, kind: 'remote-rename' };
+      default:
+        return { mutates: false };
+    }
+  }
+
+  if (command === 'push' && hasAnyArg(args, ['-u', '--set-upstream'])) {
+    return { mutates: true, kind: 'push-upstream' };
+  }
+
+  if (command === 'branch' && hasBranchUpstreamMutation(args.slice(args.indexOf(command) + 1))) {
+    return { mutates: true, kind: 'branch-upstream' };
+  }
+
+  return { mutates: false };
+}
+
+export function assertNotGitConfigMutation(args: string[], boundary: string): void {
+  const classification = classifyGitConfigMutation(args);
+  if (!classification.mutates) return;
+  throw new Error(
+    `${boundary} rejected git ${args.join(' ')} because it mutates .git/config ` +
+      `(${classification.kind}). Use git-config-mutation gateway helpers instead.`,
+  );
+}
+
+export async function ensureRemoteUrl(opts: {
+  cwd: string;
+  remote: string;
+  url: string;
+  context: GitConfigMutationContext;
+}): Promise<'added' | 'updated' | 'unchanged'> {
+  const expected = opts.url.trim();
+  if (!expected) throw new Error('ensureRemoteUrl requires a non-empty URL');
+
+  return withGitConfigMutationLock(opts.cwd, opts.context, async (lockInfo) => {
+    const current = await runGit(['remote', 'get-url', opts.remote], opts.cwd)
+      .then((value) => value.trim())
+      .catch((err) => {
+        if (isMissingRemoteError(err)) return undefined;
+        throw err;
+      });
+
+    if (current === expected) {
+      logGitConfigMutation({
+        kind: 'remote-set-url',
+        repo: lockInfo.repo,
+        context: opts.context,
+        retries: lockInfo.retries,
+        durationMs: 0,
+        result: 'noop',
+      });
+      return 'unchanged';
+    }
+
+    const start = performance.now();
+    const kind: GitConfigMutationKind = current === undefined ? 'remote-add' : 'remote-set-url';
+    try {
+      if (current === undefined) {
+        await runGit(['remote', 'add', opts.remote, expected], opts.cwd);
+      } else {
+        await runGit(['remote', 'set-url', opts.remote, expected], opts.cwd);
+      }
+      logGitConfigMutation({
+        kind,
+        repo: lockInfo.repo,
+        context: opts.context,
+        retries: lockInfo.retries,
+        durationMs: performance.now() - start,
+        result: 'success',
+      });
+      return current === undefined ? 'added' : 'updated';
+    } catch (err) {
+      logGitConfigMutation({
+        kind,
+        repo: lockInfo.repo,
+        context: opts.context,
+        retries: lockInfo.retries,
+        durationMs: performance.now() - start,
+        result: 'failed',
+      });
+      throw err;
+    }
+  });
+}
+
+export async function runGitConfigMutation(
+  args: string[],
+  cwd: string,
+  context: GitConfigMutationContext,
+): Promise<string> {
+  const classification = classifyGitConfigMutation(args);
+  if (!classification.mutates) {
+    throw new Error(`runGitConfigMutation requires a config-mutating git command, got: git ${args.join(' ')}`);
+  }
+
+  return withGitConfigMutationLock(cwd, context, async (lockInfo) => {
+    const start = performance.now();
+    try {
+      const result = await runGit(args, cwd);
+      logGitConfigMutation({
+        kind: classification.kind ?? 'config-write',
+        repo: lockInfo.repo,
+        context,
+        retries: lockInfo.retries,
+        durationMs: performance.now() - start,
+        result: 'success',
+      });
+      return result;
+    } catch (err) {
+      logGitConfigMutation({
+        kind: classification.kind ?? 'config-write',
+        repo: lockInfo.repo,
+        context,
+        retries: lockInfo.retries,
+        durationMs: performance.now() - start,
+        result: 'failed',
+      });
+      throw err;
+    }
+  });
+}
+
+export async function withGitConfigMutationLock<T>(
+  cwd: string,
+  context: GitConfigMutationContext,
+  fn: (lockInfo: { repo: string; retries: number }) => Promise<T>,
+): Promise<T> {
+  const repo = await resolveGitConfigRepoKey(cwd);
+  const previous = repoLocks.get(repo) ?? Promise.resolve();
+  let release!: () => void;
+  const current = previous.then(() => new Promise<void>((resolveRelease) => {
+    release = resolveRelease;
+  }));
+  repoLocks.set(repo, current);
+
+  await previous;
+  let retries = 0;
+  try {
+    retries = await waitForExistingConfigLock(repo);
+    return await fn({ repo, retries });
+  } finally {
+    release();
+    if (repoLocks.get(repo) === current) repoLocks.delete(repo);
+    if (retries > 0) {
+      logGitConfigMutation({
+        kind: 'config-write',
+        repo,
+        context,
+        retries,
+        durationMs: 0,
+        result: 'lock-released',
+      });
+    }
+  }
+}
+
+async function resolveGitConfigRepoKey(cwd: string): Promise<string> {
+  try {
+    const commonDir = (await runGit(['rev-parse', '--git-common-dir'], cwd)).trim();
+    return isAbsolute(commonDir) ? commonDir : resolve(cwd, commonDir);
+  } catch {
+    try {
+      const gitDir = (await runGit(['rev-parse', '--git-dir'], cwd)).trim();
+      return isAbsolute(gitDir) ? gitDir : resolve(cwd, gitDir);
+    } catch {
+      return resolve(cwd, '.git');
+    }
+  }
+}
+
+async function waitForExistingConfigLock(repo: string): Promise<number> {
+  const configLock = resolve(repo, 'config.lock');
+  let retries = 0;
+  const deadline = Date.now() + 10_000;
+  while (existsSync(configLock)) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for existing git config lock: ${configLock}`);
+    }
+    retries++;
+    await sleep(Math.min(50 * retries, 500));
+  }
+  return retries;
+}
+
+function runGit(args: string[], cwd: string): Promise<string> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn('git', args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('error', (err) => {
+      reject(new Error(`Failed to spawn git: ${err.message}`));
+    });
+    child.on('close', (code) => {
+      if (code === 0) resolvePromise(stdout.trim());
+      else reject(new Error(
+        `git ${args.join(' ')} failed (code ${code}): ${stderr.trim()}${stdout.trim() ? '\n' + stdout.trim() : ''}`,
+      ));
+    });
+  });
+}
+
+function classifyConfig(args: string[]): GitConfigMutationClassification {
+  const readOnly = new Set([
+    '--get',
+    '--get-all',
+    '--get-regexp',
+    '--get-urlmatch',
+    '--list',
+    '-l',
+    '--name-only',
+    '--get-color',
+    '--get-colorbool',
+  ]);
+  const writes = new Set([
+    '--add',
+    '--replace-all',
+    '--unset',
+    '--unset-all',
+    '--rename-section',
+    '--remove-section',
+  ]);
+
+  if (args.some((arg) => writes.has(arg))) return { mutates: true, kind: 'config-write' };
+  if (args.some((arg) => readOnly.has(arg))) return { mutates: false };
+
+  const positional = args.filter((arg) => !arg.startsWith('-'));
+  if (positional.length >= 2) return { mutates: true, kind: 'config-write' };
+  return { mutates: false };
+}
+
+function hasBranchUpstreamMutation(args: string[]): boolean {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--unset-upstream' || arg === '--set-upstream-to') return true;
+    if (arg.startsWith('--set-upstream-to=')) return true;
+    if (arg === '-u') return true;
+  }
+  return false;
+}
+
+function firstNonOption(args: string[]): string | undefined {
+  return args.find((arg) => !arg.startsWith('-'));
+}
+
+function hasAnyArg(args: string[], needles: string[]): boolean {
+  return args.some((arg) => needles.includes(arg));
+}
+
+function isMissingRemoteError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return /No such remote|No such remote '|No such remote:/i.test(msg);
+}
+
+function logGitConfigMutation(event: {
+  kind: GitConfigMutationKind;
+  repo: string;
+  context: GitConfigMutationContext;
+  retries: number;
+  durationMs: number;
+  result: string;
+}): void {
+  console.log(
+    `[git-config-mutation] kind=${event.kind} repo=${event.repo} ` +
+      `caller=${event.context.caller} detail=${event.context.detail ?? ''} ` +
+      `retries=${event.retries} durationMs=${Math.round(event.durationMs)} result=${event.result}`,
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolveSleep) => setTimeout(resolveSleep, ms));
+}

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -55,6 +55,7 @@ import {
   validateCanonicalPrBody,
   type PrAuthoringContext,
 } from './pr-authoring.js';
+import { ensureRemoteUrl } from './git-config-mutation.js';
 
 export type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 
@@ -1588,7 +1589,12 @@ export class TaskRunner {
       // Fallback: read origin from the host repo (old behavior)
       originUrl = (await this.execGitReadonly(['remote', 'get-url', 'origin'])).trim();
     }
-    await this.execGitIn(['remote', 'set-url', 'origin', originUrl], clonePath);
+    await ensureRemoteUrl({
+      cwd: clonePath,
+      remote: 'origin',
+      url: originUrl,
+      context: { caller: 'TaskRunner.createMergeWorktree', detail: `${label}:${ref}` },
+    });
 
     // Refresh the requested base branch from the real remote. The pool mirror's
     // local refs/heads/* can go stale after force-pushes or history rewrites,
@@ -2443,17 +2449,12 @@ export class TaskRunner {
   ): Promise<void> {
     const trimmedBranchRepoUrl = branchRepoUrl?.trim();
     if (trimmedBranchRepoUrl) {
-      try {
-        await this.execGitIn(
-          ['remote', 'set-url', TaskRunner.BRANCH_REMOTE_NAME, trimmedBranchRepoUrl],
-          worktreeDir,
-        );
-      } catch {
-        await this.execGitIn(
-          ['remote', 'add', TaskRunner.BRANCH_REMOTE_NAME, trimmedBranchRepoUrl],
-          worktreeDir,
-        );
-      }
+      await ensureRemoteUrl({
+        cwd: worktreeDir,
+        remote: TaskRunner.BRANCH_REMOTE_NAME,
+        url: trimmedBranchRepoUrl,
+        context: { caller: 'TaskRunner.pushBranchFromMergeWorktree', detail: branch },
+      });
       await this.execGitIn(
         ['push', '--force', TaskRunner.BRANCH_REMOTE_NAME, `${branch}:refs/heads/${branch}`],
         worktreeDir,


### PR DESCRIPTION
## Summary

Route existing runtime remote URL setup through the new `.git/config` mutation gateway.

`BaseExecutor.pushBranchToRemote`, `TaskRunner.createMergeWorktree`, and merge-worktree branch publishing now call `ensureRemoteUrl(...)` instead of directly running `git remote add` or `git remote set-url`. This keeps necessary remote configuration writes serialized, idempotent, retried around `config.lock`, and logged with caller context.

## Test Plan

- [x] `INVOKER_DB_DIR=$(mktemp -d) pnpm --dir packages/execution-engine exec vitest run src/__tests__/ssh-git-exec.test.ts src/__tests__/branch-utils.test.ts src/__tests__/auto-commit.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts src/__tests__/git-config-mutation.test.ts src/__tests__/github-merge-gate-provider.test.ts src/__tests__/create-merge-worktree.test.ts`
- [x] `bash scripts/test-suites/required/16-branch-carry-forward.sh`
- [x] `bash -n run.sh`

## Revert Plan

- Safe to revert? Yes, after reverting dependent stack PRs above this one.
- Revert command: `git revert 5b1d0e3f`
- Post-revert steps: Runtime remote setup would return to direct `git remote` mutation calls.
- Data migration? No.

Depends-On: #814
