### PR TITLE
Replace upstream-setting pushes with refspecs

### DIFF
--- a/packages/execution-engine/src/__tests__/git-config-mutation.test.ts
+++ b/packages/execution-engine/src/__tests__/git-config-mutation.test.ts
@@ -4,9 +4,11 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
 import {
+  assertNotGitConfigMutation,
   classifyGitConfigMutation,
   ensureRemoteUrl,
 } from '../git-config-mutation.js';
+import { TaskRunner, ExecutorRegistry } from '../index.js';
 
 function git(cwd: string, args: string): string {
   return execSync(`git ${args}`, { cwd, stdio: ['ignore', 'pipe', 'pipe'] }).toString().trim();
@@ -97,5 +99,21 @@ describe('git config mutation gateway', () => {
     expect(results).toContain('added');
     expect(results).toContain('unchanged');
     expect(git(root, 'remote get-url origin')).toBe('/tmp/origin.git');
+  });
+
+  it('rejects raw runtime git config mutations at TaskRunner boundaries', () => {
+    root = createRepo();
+    const runner = new TaskRunner({
+      orchestrator: { getAllTasks: () => [] } as any,
+      persistence: { updateTask: () => {} } as any,
+      executorRegistry: new ExecutorRegistry(),
+      cwd: root,
+      defaultBranch: 'master',
+    });
+
+    expect(() => runner.execGitIn(['remote', 'add', 'origin', '/tmp/origin.git'], root!))
+      .toThrow('TaskRunner.execGitIn rejected');
+    expect(() => assertNotGitConfigMutation(['push', '-u', 'origin', 'branch'], 'test'))
+      .toThrow('mutates .git/config');
   });
 });

--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -106,7 +106,7 @@ describe('GitHubMergeGateProvider', () => {
       expect(result.identifier).toBe('42');
       expect(spawnMock).toHaveBeenCalledWith(
         'git',
-        ['push', '--force', '-u', 'origin', 'feature/test'],
+        ['push', '--force', 'origin', 'feature/test:refs/heads/feature/test'],
         expect.objectContaining({ cwd: '/tmp/repo' }),
       );
       expect(spawnMock).toHaveBeenCalledWith(

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -344,7 +344,7 @@ describe('buildRecordAndPushScript', () => {
     expect(script).toContain('git commit --allow-empty -F');
     expect(script).toContain('git commit -F');
     expect(script).toContain('HASH=$(git rev-parse HEAD)');
-    expect(script).toContain('git push -u origin "$BR"');
+    expect(script).toContain('git push origin "$BR:refs/heads/$BR"');
     expect(script).toContain('printf "%s" "$HASH"');
   });
 
@@ -374,7 +374,7 @@ describe('buildRecordAndPushScript', () => {
 
     expect(script).toContain('git remote set-url invoker-branches "$PUSH_URL"');
     expect(script).toContain('git remote add invoker-branches "$PUSH_URL"');
-    expect(script).toContain('git push -u invoker-branches "$BR"');
+    expect(script).toContain('git push invoker-branches "$BR:refs/heads/$BR"');
   });
 
   it('commits and pushes successfully without preconfigured git identity', () => {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2004,7 +2004,10 @@ describe('TaskRunner', () => {
       expect(mergeCall).toBeDefined();
 
       // Feature branch pushed directly from gate clone to origin
-      const gatePush = gateGitCalls.find((c) => c.args[0] === 'push' && c.args.includes('origin') && c.args.includes('plan/feature'));
+      const gatePush = gateGitCalls.find((c) =>
+        c.args[0] === 'push' &&
+        c.args.includes('origin') &&
+        c.args.includes('plan/feature:refs/heads/plan/feature'));
       expect(gatePush).toBeDefined();
 
       // No git operations in host.cwd

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -6,7 +6,7 @@ import { bashPreserveOrReset, bashMergeUpstreams, bashFetchNodeRemotes, parsePre
 import { RESTART_TO_BRANCH_TRACE, traceExecution } from './exec-trace.js';
 import type { AgentRegistry } from './agent-registry.js';
 import { checkStaleness } from './git-staleness-detector.js';
-import { ensureRemoteUrl } from './git-config-mutation.js';
+import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
 
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -431,6 +431,7 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     cwd: string,
     opts?: { signal?: AbortSignal },
   ): Promise<string> {
+    assertNotGitConfigMutation(args, `${this.type}.execGitSimple`);
     const stack = new Error().stack;
     const callerFrames = stack?.split('\n').slice(1, 5).map(l => l.trim()).join('\n    ') ?? '(no stack)';
     traceExecution(`[git-trace] git ${args.join(' ')}  cwd=${cwd}\n    ${callerFrames}`);
@@ -820,11 +821,11 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
           context: { caller: `${this.type}.pushBranchToRemote`, detail: branch },
         });
         await this.execGitSimpleWithNetworkTimeout(
-          ['push', '--force-with-lease', '-u', BaseExecutor.BRANCH_REMOTE_NAME, branch],
+          ['push', '--force-with-lease', BaseExecutor.BRANCH_REMOTE_NAME, `${branch}:refs/heads/${branch}`],
           cwd,
         );
       } else {
-        await this.execGitSimpleWithNetworkTimeout(['push', '--force-with-lease', '-u', 'origin', branch], cwd);
+        await this.execGitSimpleWithNetworkTimeout(['push', '--force-with-lease', 'origin', `${branch}:refs/heads/${branch}`], cwd);
       }
       return undefined;
     } catch (err) {

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -30,7 +30,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
     const targetRepo = await this.resolveTargetRepo(cwd);
     console.log(`[merge-gate] createReview: ghBase=${ghBase} apiHead=${ghHead} cwd=${cwd}`);
 
-    await this.exec('git', ['push', '--force', '-u', 'origin', featureBranch], cwd);
+    await this.exec('git', ['push', '--force', 'origin', `${featureBranch}:refs/heads/${featureBranch}`], cwd);
 
     const listOutput = await this.exec('gh', [
       'pr', 'list',

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -787,7 +787,7 @@ export async function approveMergeImpl(
     try {
       mergeTrace('GIT_PUSH', { featureBranch, worktreeDir });
       // Push feature branch directly to origin (GitHub) from the clone
-      await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
+      await execGitInMergeSafe(host, ['push', '--force', 'origin', `${featureBranch}:refs/heads/${featureBranch}`], worktreeDir);
       const prBody = await authorPrBodyForMerge(host, {
         workflowId,
         mergeNodeTaskId: mergeTaskId,
@@ -1035,7 +1035,7 @@ export async function publishAfterFixImpl(
     }
 
     // Push feature branch directly to origin (GitHub) from the gate clone
-    await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], consolidateDir);
+    await execGitInMergeSafe(host, ['push', '--force', 'origin', `${featureBranch}:refs/heads/${featureBranch}`], consolidateDir);
 
     let fullSummary = summary;
     let vpMarkdownCapture2: string | undefined;
@@ -1394,7 +1394,7 @@ export async function consolidateAndMergeImpl(
     // Push feature branch to origin so other clones (e.g., the gate clone used
     // by external review providers can access it. The consolidation clone is removed
     // in the finally block, so without this push the branch would be lost.
-    await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
+    await execGitInMergeSafe(host, ['push', '--force', 'origin', `${featureBranch}:refs/heads/${featureBranch}`], worktreeDir);
 
     if (visualProof && onFinish === 'pull_request' && host.runVisualProofCapture) {
       const slug = (featureBranch ?? 'workflow').replace(/\//g, '-');
@@ -1426,7 +1426,7 @@ export async function consolidateAndMergeImpl(
       }
     } else if (onFinish === 'pull_request') {
       // Push feature branch directly to origin (GitHub) from the clone
-      await execGitInMergeSafe(host, ['push', '--force', '-u', 'origin', featureBranch], worktreeDir);
+      await execGitInMergeSafe(host, ['push', '--force', 'origin', `${featureBranch}:refs/heads/${featureBranch}`], worktreeDir);
       const structuredCtx3 = workflowId
         ? await buildPrAuthoringContext(host, workflowId)
         : undefined;

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -348,9 +348,9 @@ if [ -n "$PUSH_URL" ]; then
   else
     git remote add invoker-branches "$PUSH_URL"
   fi
-  git push -u invoker-branches "$BR"
+  git push invoker-branches "$BR:refs/heads/$BR"
 else
-  git push -u origin "$BR"
+  git push origin "$BR:refs/heads/$BR"
 fi
 printf "%s" "$HASH"
 `;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -55,7 +55,7 @@ import {
   validateCanonicalPrBody,
   type PrAuthoringContext,
 } from './pr-authoring.js';
-import { ensureRemoteUrl } from './git-config-mutation.js';
+import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
 
 export type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 
@@ -1537,9 +1537,10 @@ export class TaskRunner {
   }
 
   /**
-   * @internal Read-only git queries only. For mutations, use execGitIn.
+   * @internal Read-only git queries only. Config mutations must use git-config-mutation helpers.
    */
   execGitReadonly(args: string[], cwd?: string): Promise<string> {
+    assertNotGitConfigMutation(args, 'TaskRunner.execGitReadonly');
     return new Promise((resolvePromise, reject) => {
       const child = spawn('git', args, {
         cwd: cwd ?? this.cwd,
@@ -1562,6 +1563,7 @@ export class TaskRunner {
   }
 
   /** @internal */ execGitIn(args: string[], dir: string): Promise<string> {
+    assertNotGitConfigMutation(args, 'TaskRunner.execGitIn');
     return new Promise((resolvePromise, reject) => {
       const child = spawn('git', args, {
         cwd: dir,


### PR DESCRIPTION
## Summary

Replace runtime `git push -u` calls with explicit refspec pushes, then turn on runtime wrapper enforcement.

The updated pushes still publish the same branch refs, but they no longer set upstream tracking in `.git/config`. This covers normal task branch pushes, merge-runner feature branch pushes, GitHub merge-gate pushes, and the generated SSH record/push script.

After those callers stop mutating upstream config, `BaseExecutor.execGitSimple`, `TaskRunner.execGitIn`, and `execGitReadonly` reject direct config-mutating Git commands unless they use the gateway.

## Test Plan

- [x] `INVOKER_DB_DIR=$(mktemp -d) pnpm --dir packages/execution-engine exec vitest run src/__tests__/git-config-mutation.test.ts src/__tests__/ssh-git-exec.test.ts src/__tests__/github-merge-gate-provider.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `INVOKER_DB_DIR=$(mktemp -d) pnpm --dir packages/execution-engine exec vitest run src/__tests__/git-config-mutation.test.ts src/__tests__/branch-chain.test.ts -t "review gate direct dependency branch" src/__tests__/ssh-git-exec.test.ts src/__tests__/github-merge-gate-provider.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `bash scripts/test-suites/required/16-branch-carry-forward.sh`
- [x] `bash -n run.sh`

## Revert Plan

- Safe to revert? Yes, after reverting dependent stack PRs above this one.
- Revert command: `git revert ed42111f`
- Post-revert steps: Pushes would again set upstream tracking and mutate `.git/config`.
- Data migration? No.
