### PR TITLE
Use direct URLs in generated remote scripts

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -372,9 +372,9 @@ describe('buildRecordAndPushScript', () => {
       pushRemoteUrl: 'https://github.com/fork/repo.git',
     });
 
-    expect(script).toContain('git remote set-url invoker-branches "$PUSH_URL"');
-    expect(script).toContain('git remote add invoker-branches "$PUSH_URL"');
-    expect(script).toContain('git push invoker-branches "$BR:refs/heads/$BR"');
+    expect(script).not.toContain('git remote set-url invoker-branches "$PUSH_URL"');
+    expect(script).not.toContain('git remote add invoker-branches "$PUSH_URL"');
+    expect(script).toContain('git push "$PUSH_URL" "$BR:refs/heads/$BR"');
   });
 
   it('commits and pushes successfully without preconfigured git identity', () => {

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -211,12 +211,7 @@ if git -C "$WT_DIR" remote get-url origin >/dev/null 2>&1; then
   git -C "$WT_DIR" fetch origin '+refs/heads/*:refs/remotes/origin/*' --prune
 fi
 ${branchRepo ? `BRANCH_REPO_URL=${q(branchRepo)}
-if git -C "$WT_DIR" remote get-url invoker-branches >/dev/null 2>&1; then
-  git -C "$WT_DIR" remote set-url invoker-branches "$BRANCH_REPO_URL"
-else
-  git -C "$WT_DIR" remote add invoker-branches "$BRANCH_REPO_URL"
-fi
-if ! git -C "$WT_DIR" fetch invoker-branches '+refs/heads/*:refs/remotes/invoker-branches/*' --prune; then
+if ! git -C "$WT_DIR" fetch "$BRANCH_REPO_URL" '+refs/heads/*:refs/remotes/invoker-branches/*' --prune; then
   echo "BRANCH_REPO_FETCH_FAILED=$BRANCH_REPO_URL" >&2
   exit 32
 fi` : ''}

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -343,12 +343,7 @@ HASH=$(git rev-parse HEAD)
 BR=$(echo ${brB} | base64 -d)
 PUSH_URL=$(echo ${pushRemoteUrlB} | base64 -d)
 if [ -n "$PUSH_URL" ]; then
-  if git remote get-url invoker-branches >/dev/null 2>&1; then
-    git remote set-url invoker-branches "$PUSH_URL"
-  else
-    git remote add invoker-branches "$PUSH_URL"
-  fi
-  git push invoker-branches "$BR:refs/heads/$BR"
+  git push "$PUSH_URL" "$BR:refs/heads/$BR"
 else
   git push origin "$BR:refs/heads/$BR"
 fi


### PR DESCRIPTION
## Summary

Avoid generated-script remote configuration writes by using direct URL transport.

Generated branch-fetch and SSH record/push scripts now use one-shot repository URLs for branch repo transport instead of adding or updating an `invoker-branches` remote. This keeps generated scripts from writing `.git/config` while preserving the same fetch and push targets.

## Test Plan

- [x] `INVOKER_DB_DIR=$(mktemp -d) pnpm --dir packages/execution-engine exec vitest run src/__tests__/ssh-git-exec.test.ts src/__tests__/branch-utils.test.ts`
- [x] `bash -n run.sh`

## Revert Plan

- Safe to revert? Yes, after reverting dependent stack PRs above this one.
- Revert command: `git revert a08134be`
- Post-revert steps: Generated scripts would again create or rewrite the `invoker-branches` remote for branch repo transport.
- Data migration? No.
