### PR TITLE
Add SSH stall lifecycle diagnostics

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2504,12 +2504,19 @@ function createEmbeddedTerminalBackendFromConfig(
                   });
 
                   if (executingStalled) {
+                    const selectedAttemptHeartbeat = parseExecutionDate(selectedAttempt?.lastHeartbeatAt);
                     const executingError =
                       `Execution stalled: task remained in running/executing for ${Math.floor(executingAgeMs / 1000)}s ` +
                       `without a live execution handle and no completion signal from executor (${staleReason}).`;
                     logger.info(
                       `[executing-stall] detected task="${task.id}" phase=${task.execution.phase} executingAgeMs=${executingAgeMs} ` +
-                        `handlePresent=${taskHandles.has(task.id)} leaseExpired=${leaseExpired} heartbeatStale=${heartbeatStale}`,
+                        `handlePresent=${taskHandles.has(task.id)} leaseExpired=${leaseExpired} heartbeatStale=${heartbeatStale} ` +
+                        `runnerKind=${task.config.runnerKind ?? 'none'} selectedAttemptId=${task.execution.selectedAttemptId ?? 'none'} ` +
+                        `attemptStatus=${selectedAttempt?.status ?? 'none'} executorHeartbeatAt=${previousHeartbeat?.toISOString() ?? 'none'} ` +
+                        `remoteHeartbeatAt=${remoteHeartbeat?.toISOString() ?? 'none'} attemptHeartbeatAt=${selectedAttemptHeartbeat?.toISOString() ?? 'none'} ` +
+                        `leaseExpiresAt=${leaseExpiresAt?.toISOString() ?? 'none'} launchStartedAt=${task.execution.launchStartedAt instanceof Date ? task.execution.launchStartedAt.toISOString() : task.execution.launchStartedAt ?? 'none'} ` +
+                        `launchCompletedAt=${task.execution.launchCompletedAt instanceof Date ? task.execution.launchCompletedAt.toISOString() : task.execution.launchCompletedAt ?? 'none'} ` +
+                        `startedAt=${executingStartedAt?.toISOString() ?? 'none'} completedAt=${task.execution.completedAt instanceof Date ? task.execution.completedAt.toISOString() : task.execution.completedAt ?? 'none'}`,
                       { module: 'db-poll' },
                     );
                     const failedResponse: WorkResponse = {

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -693,6 +693,11 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     streamState.remainder = lines.pop() ?? '';
     for (const line of lines) {
       if (line.startsWith(SshExecutor.REMOTE_HEARTBEAT_MARKER)) {
+        const entry = this.entries.get(executionId);
+        console.info(
+          `[ssh-lifecycle] remote heartbeat marker executionId=${executionId} ` +
+            `task=${entry?.request.actionId ?? 'unknown'} marker="${line}"`,
+        );
         this.emitHeartbeat(executionId);
         continue;
       }
@@ -703,6 +708,11 @@ ${this.buildPayloadExecutionScript(payloadB64)}
   private flushOutputRemainder(executionId: string, streamState: { remainder: string }): void {
     if (!streamState.remainder) return;
     if (streamState.remainder.startsWith(SshExecutor.REMOTE_HEARTBEAT_MARKER)) {
+      const entry = this.entries.get(executionId);
+      console.info(
+        `[ssh-lifecycle] remote heartbeat marker executionId=${executionId} ` +
+          `task=${entry?.request.actionId ?? 'unknown'} marker="${streamState.remainder}" source=remainder`,
+      );
       this.emitHeartbeat(executionId);
     } else {
       this.emitOutput(executionId, streamState.remainder);
@@ -791,6 +801,11 @@ ${this.buildPayloadExecutionScript(payloadB64)}
       detached: true,
       env: cleanElectronEnv(),
     });
+    console.info(
+      `[ssh-lifecycle] spawned ssh session task=${request.actionId} executionId=${executionId} ` +
+        `pid=${child.pid ?? 'unknown'} finalizeRemote=${finalizeRemote ? 'yes' : 'no'} ` +
+        `workspace=${handle.workspacePath ?? 'none'} branch=${handle.branch ?? 'none'}`,
+    );
     child.stdin?.write(bashScript);
     child.stdin?.end();
 
@@ -808,8 +823,16 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     };
 
     this.registerEntry(handle, entry);
+    console.info(
+      `[ssh-lifecycle] registered entry task=${request.actionId} executionId=${executionId} ` +
+        `pid=${child.pid ?? 'unknown'} entries=${this.entries.size}`,
+    );
 
     child.on('error', (err) => {
+      console.info(
+        `[ssh-lifecycle] child error task=${request.actionId} executionId=${executionId} ` +
+          `pid=${child.pid ?? 'unknown'} error=${err.message}`,
+      );
       const e = this.entries.get(executionId);
       if (e) e.completed = true;
       const response: WorkResponse = {
@@ -843,6 +866,11 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     });
 
     child.on('close', (code, signal) => {
+      console.info(
+        `[ssh-lifecycle] child close task=${request.actionId} executionId=${executionId} ` +
+          `pid=${child.pid ?? 'unknown'} code=${code ?? 'null'} signal=${signal ?? 'none'} ` +
+          `stderrBytes=${stderrOutput.length}`,
+      );
       void (async () => {
         this.flushOutputRemainder(executionId, stdoutState);
         this.flushOutputRemainder(executionId, stderrState);
@@ -868,6 +896,10 @@ ${this.buildPayloadExecutionScript(payloadB64)}
           let commitHash: string | undefined;
 
           if (finalizeRemote) {
+            console.info(
+              `[ssh-lifecycle] remote finalize begin task=${request.actionId} executionId=${executionId} ` +
+                `worktree=${finalizeRemote.worktreePath} branch=${finalizeRemote.branch} exitCode=${exitCode}`,
+            );
             this.emitOutput(executionId, '[SshExecutor] Recording task result and pushing branch on remote...\n');
             const fin = await this.remoteGitRecordAndPush(
               executionId,
@@ -882,6 +914,10 @@ ${this.buildPayloadExecutionScript(payloadB64)}
               if (exitCode === 0) status = 'failed';
               mappedError = fin.error;
             }
+            console.info(
+              `[ssh-lifecycle] remote finalize end task=${request.actionId} executionId=${executionId} ` +
+                `commitHash=${commitHash ?? 'none'} error=${fin.error ?? 'none'}`,
+            );
           }
 
           // When the command fails but no specific error was mapped (exit 30/31),
@@ -928,9 +964,18 @@ ${this.buildPayloadExecutionScript(payloadB64)}
             },
           };
           if (e) e.finalizingAfterClose = false;
+          console.info(
+            `[ssh-lifecycle] emit complete task=${request.actionId} executionId=${executionId} ` +
+              `status=${status} exitCode=${finalExitCode} commitHash=${commitHash ?? 'none'} ` +
+              `agentSessionId=${entry.agentSessionId ?? 'none'}`,
+          );
           this.emitComplete(executionId, response);
         } catch (err) {
           if (e) e.finalizingAfterClose = false;
+          console.info(
+            `[ssh-lifecycle] completion failure task=${request.actionId} executionId=${executionId} ` +
+              `error=${err instanceof Error ? err.message : String(err)}`,
+          );
           const response: WorkResponse = {
             requestId: request.requestId,
             actionId: request.actionId,

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -436,6 +436,10 @@ export class TaskRunner {
       bench('executeTask.duplicateSkipped');
       return;
     }
+    this.logger.info(
+      `[TaskRunner] launch accepted task=${task.id} attempt=${attemptId} status=${task.status} ` +
+        `phase=${task.execution.phase ?? 'none'} generation=${startGeneration}`,
+    );
     this.launchingAttemptIds.add(attemptId);
     try {
       await this.executeTaskInner(task, attemptId, bench);
@@ -705,6 +709,10 @@ export class TaskRunner {
       `${RESTART_TO_BRANCH_TRACE} executeTaskInner taskId=${task.id} selectExecutor → type=${executor.type} calling executor.start()`,
     );
     traceExecution(`[trace] TaskRunner: task=${task.id} calling executor.start() type=${executor.type}`);
+    this.logger.info(
+      `[TaskRunner] executor.start begin task=${task.id} attempt=${attemptId} executor=${executor.type} ` +
+        `generation=${task.execution.generation ?? 0}`,
+    );
     bench('onLaunchStart.before', {
       executorType: executor.type,
     });
@@ -782,6 +790,12 @@ export class TaskRunner {
       if (preStartTimeout) clearTimeout(preStartTimeout);
     }
     traceExecution(`[trace] TaskRunner: task=${task.id} executor.start() returned after ${Date.now() - startT0}ms executor=${executor.type} sessionId=${handle.agentSessionId ?? 'none'} workspace=${handle.workspacePath ?? 'default'}`);
+    this.logger.info(
+      `[TaskRunner] executor.start returned task=${task.id} attempt=${attemptId} executor=${executor.type} ` +
+        `elapsedMs=${Date.now() - startT0} executionId=${handle.executionId} ` +
+        `workspace=${handle.workspacePath ?? 'none'} branch=${handle.branch ?? 'none'} ` +
+        `agentSessionId=${handle.agentSessionId ?? 'none'}`,
+    );
     bench('executor.start.after', {
       executorType: executor.type,
       executorStartMs: Date.now() - startT0,
@@ -887,6 +901,10 @@ export class TaskRunner {
       poolId: poolSelection?.poolId,
       poolMemberKey: poolSelection?.memberKey,
     });
+    this.logger.info(
+      `[TaskRunner] active execution registered task=${task.id} attempt=${attemptId} ` +
+        `executor=${executor.type} executionId=${handle.executionId} activeExecutions=${this.activeExecutions.size}`,
+    );
     bench('onSpawned.before');
     this.callbacks.onSpawned?.(task.id, handle, executor);
     bench('onSpawned.after');
@@ -900,6 +918,12 @@ export class TaskRunner {
     executor.onHeartbeat(handle, () => {
       const now = new Date();
       const isRemoteWorkloadHeartbeat = executor.type === 'ssh';
+      if (isRemoteWorkloadHeartbeat) {
+        this.logger.info(
+          `[TaskRunner] ssh heartbeat received task=${task.id} attempt=${attemptId} executionId=${handle.executionId} ` +
+            `at=${now.toISOString()}`,
+        );
+      }
       this.persistence.updateAttempt?.(attemptId, {
         lastHeartbeatAt: now,
         leaseExpiresAt: nextLeaseExpiry(now),
@@ -923,6 +947,11 @@ export class TaskRunner {
         const work = async () => {
           const normalizedResponse = response.attemptId ? response : { ...response, attemptId };
           this.activeExecutions.delete(normalizedResponse.attemptId ?? attemptId);
+          this.logger.info(
+            `[TaskRunner] completion callback task=${task.id} attempt=${normalizedResponse.attemptId ?? attemptId} ` +
+              `status=${normalizedResponse.status} exitCode=${normalizedResponse.outputs.exitCode ?? 'none'} ` +
+              `executionId=${handle.executionId} activeExecutions=${this.activeExecutions.size}`,
+          );
           try {
             traceExecution(
               `[task-runner] onComplete taskId=${task.id} responseStatus=${response.status} ` +


### PR DESCRIPTION
## Summary

- Add TaskRunner lifecycle logs around SSH task launch acceptance, executor.start begin/return, active execution registration, SSH heartbeat receipt, and completion callbacks.
- Add SSH executor lifecycle logs for heartbeat marker parsing, child spawn/register/error/close, remote finalize begin/end, and completion emission/failure.
- Expand executing-stall watchdog diagnostics with runner kind, selected attempt, heartbeat timestamps, lease/launch timestamps, and completion state.

## Test Plan

- [x] pnpm install
- [x] pnpm run check:types
- [x] pnpm --filter @invoker/execution-engine test -- src/__tests__/ssh-executor.test.ts src/__tests__/task-runner-fix-publish-and-ssh.test.ts

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert b9f2414b`
- Post-revert steps: None.
- Data migration required? No.
