### PR TITLE
Avoid upstream config writes when creating worktree branches

### DIFF
--- a/packages/execution-engine/src/__tests__/branch-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/branch-utils.test.ts
@@ -447,6 +447,33 @@ describe('bashPreserveOrReset', () => {
       execSync(`git worktree remove --force "${wtDir}"`, { cwd: repoDir });
     });
 
+    it('does not write upstream tracking config when base is a remote-tracking ref', async () => {
+      const wtDir = join(repoDir, '..', 'wt-no-track-' + Date.now());
+      const head = gitExec('git rev-parse master', repoDir);
+      gitExec(`git update-ref refs/remotes/origin/master ${head}`, repoDir);
+      writeFileSync(join(repoDir, '.git', 'config.lock'), '');
+
+      try {
+        const script = bashPreserveOrReset({
+          repoDir,
+          worktreeDir: wtDir,
+          branch: 'invoker/wt-no-track',
+          base: 'origin/master',
+        });
+        const stdout = await runBashLocal(script);
+        const result = parsePreserveResult(stdout);
+
+        expect(result.preserved).toBe(false);
+        const currentBranch = gitExec('git branch --show-current', wtDir);
+        expect(currentBranch).toBe('invoker/wt-no-track');
+        const upstreamRemote = gitExec('git config --get branch.invoker/wt-no-track.remote || true', repoDir);
+        expect(upstreamRemote).toBe('');
+      } finally {
+        rmSync(join(repoDir, '.git', 'config.lock'), { force: true });
+        try { execSync(`git worktree remove --force "${wtDir}"`, { cwd: repoDir }); } catch { /* ignore */ }
+      }
+    });
+
     it('preserves worktree branch with commits ahead', async () => {
       // Create a branch with commits ahead
       gitExec('git checkout -b invoker/wt-preserve', repoDir);

--- a/packages/execution-engine/src/branch-utils.ts
+++ b/packages/execution-engine/src/branch-utils.ts
@@ -165,7 +165,7 @@ if git -C "$REPO_DIR" rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
   fi
 fi
 if [ "$preserved" -eq 0 ]; then
-  git -C "$REPO_DIR" worktree add -B "$BRANCH" "$WT_DIR" "$BASE"
+  git -C "$REPO_DIR" worktree add --no-track -B "$BRANCH" "$WT_DIR" "$BASE"
 fi`;
 }
 
@@ -179,7 +179,7 @@ function generateCheckoutPreserve(): string {
   fi
 fi
 if [ "$preserved" -eq 0 ]; then
-  git -C "$REPO_DIR" checkout -B "$BRANCH" "$BASE"
+  git -C "$REPO_DIR" checkout --no-track -B "$BRANCH" "$BASE"
 fi`;
 }
 

--- a/scripts/repro/repro-worktree-add-implicit-upstream-config-lock.sh
+++ b/scripts/repro/repro-worktree-add-implicit-upstream-config-lock.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-worktree-upstream-config-lock.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+origin_repo="$TMP_DIR/origin.git"
+seed_repo="$TMP_DIR/seed"
+mirror_repo="$TMP_DIR/mirror"
+bad_worktree="$TMP_DIR/bad-worktree"
+good_worktree="$TMP_DIR/good-worktree"
+
+git init --bare "$origin_repo" >/dev/null
+git clone "$origin_repo" "$seed_repo" >/dev/null 2>&1
+git -C "$seed_repo" config user.email "repro@example.com"
+git -C "$seed_repo" config user.name "Repro"
+printf 'seed\n' > "$seed_repo/README.md"
+git -C "$seed_repo" add README.md
+git -C "$seed_repo" commit -m "seed" >/dev/null
+git -C "$seed_repo" push origin HEAD:master >/dev/null
+
+git clone "$origin_repo" "$mirror_repo" >/dev/null 2>&1
+git -C "$mirror_repo" fetch origin '+refs/heads/*:refs/remotes/origin/*' >/dev/null
+
+config_lock="$(git -C "$mirror_repo" rev-parse --absolute-git-dir)/config.lock"
+touch "$config_lock"
+
+set +e
+bad_output="$(
+  git -C "$mirror_repo" worktree add -B repro/bad "$bad_worktree" origin/master 2>&1
+)"
+bad_status=$?
+set -e
+
+if [[ "$bad_status" -eq 0 ]]; then
+  echo "FAIL: expected git worktree add -B from origin/master to fail while config.lock exists" >&2
+  exit 1
+fi
+
+if ! grep -Eqi 'could not lock config file|unable to write upstream branch configuration|config\.lock' <<<"$bad_output"; then
+  echo "FAIL: expected upstream config lock failure, got:" >&2
+  printf '%s\n' "$bad_output" >&2
+  exit 1
+fi
+
+git -C "$mirror_repo" worktree add --no-track -B repro/good "$good_worktree" origin/master >/dev/null
+
+upstream="$(git -C "$good_worktree" config --get branch.repro/good.remote || true)"
+if [[ -n "$upstream" ]]; then
+  echo "FAIL: --no-track worktree branch unexpectedly recorded upstream remote: $upstream" >&2
+  exit 1
+fi
+
+echo "PASS: --no-track avoids implicit upstream config writes during worktree branch creation"


### PR DESCRIPTION
## Summary

Avoid implicit git upstream tracking writes during task branch/worktree creation.

`git worktree add -B <branch> <path> origin/master` can write `branch.<name>.*` into the shared repo config. Under concurrent SSH managed workspace startup, that can collide on `.git/config.lock` before a task workspace is recorded. The branch setup script now uses `--no-track` for fresh branch creation in both worktree and checkout modes.

Added a repro script that demonstrates the root cause directly: the plain command fails while `config.lock` exists, while the `--no-track` form succeeds and records no upstream remote.

## Test Plan

- [x] `bash scripts/repro/repro-worktree-add-implicit-upstream-config-lock.sh`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/branch-utils.test.ts` *(this command ran the full execution-engine suite in this worktree: 48 files, 968 tests passed)*
- [x] `git diff --check`
- [ ] `pnpm --filter @invoker/execution-engine build` *(JS bundle succeeded, DTS failed with existing TS6307 project include errors unrelated to this patch)*

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert bce0d660`
- Post-revert steps: Re-run `bash scripts/repro/repro-worktree-add-implicit-upstream-config-lock.sh` to confirm the regression returns if needed.
- Data migration? No
