### PR TITLE
Repair SSH approved-fix workspace paths

### DIFF
--- a/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
+++ b/packages/execution-engine/src/__tests__/remote-fix-worktree-repair.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fixWithAgentImpl } from '../conflict-resolver.js';
 import type { ConflictResolverHost } from '../conflict-resolver.js';
+import { TaskRunner } from '../task-runner.js';
+import { SshExecutor } from '../ssh-executor.js';
 import type { Orchestrator } from '@invoker/workflow-core';
 import { registerBuiltinAgents } from '../agents/index.js';
 
@@ -114,5 +116,81 @@ branch refs/heads/${branch}
       task.id,
       expect.stringContaining('[Fix with codex (remote)] Output:'),
     );
+  });
+
+  it('repairs the remote workspace path before publishing an approved fix', async () => {
+    const { spawn } = await import('node:child_process');
+    const stalePath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-b68b146f';
+    const ownerPath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-bc7a0b71';
+    const branch = 'experiment/wf-1/test-execution-engine-b68b146f';
+    const task = {
+      id: 'wf-1/test-execution-engine',
+      description: 'Fix execution engine',
+      status: 'awaiting_approval' as const,
+      execution: {
+        workspacePath: stalePath,
+        branch,
+        selectedAttemptId: 'attempt-1',
+      },
+      config: {
+        command: 'pnpm test',
+        runnerKind: 'ssh' as const,
+        poolMemberId: 'remote-1',
+      },
+    };
+    const updateTask = vi.fn();
+    const updateAttempt = vi.fn();
+    const logEvent = vi.fn();
+    const runner = new TaskRunner({
+      orchestrator: { getTask: () => task } as any,
+      persistence: { updateTask, updateAttempt, logEvent } as any,
+      executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, register: () => {}, getAll: () => [] } as any,
+      cwd: '/tmp',
+      remoteTargetsProvider: () => ({
+        'remote-1': {
+          host: 'remote.example',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          remoteInvokerHome: '/home/invoker/.invoker',
+          managedWorkspaces: true,
+        },
+      }),
+    });
+    const publishSpy = vi.spyOn(SshExecutor.prototype, 'publishApprovedFix').mockResolvedValue({
+      commitHash: 'deadbeef',
+    });
+    const listChild = mockSshChild(
+      `worktree ${ownerPath}
+HEAD deadbeef
+branch refs/heads/${branch}
+`,
+      0,
+    );
+    vi.mocked(spawn).mockReturnValueOnce(listChild as any);
+
+    await runner.publishApprovedFix(task as any);
+
+    expect(updateTask).toHaveBeenCalledWith(task.id, {
+      execution: {
+        workspacePath: ownerPath,
+      },
+    });
+    expect(logEvent).toHaveBeenCalledWith(task.id, 'debug.approved-fix', {
+      phase: 'publish-approved-fix-remote-path-repaired',
+      previousWorkspacePath: stalePath,
+      repairedWorkspacePath: ownerPath,
+    });
+    expect(publishSpy).toHaveBeenCalledWith(
+      ownerPath,
+      expect.objectContaining({ actionId: task.id }),
+      branch,
+    );
+    expect(updateTask).toHaveBeenCalledWith(task.id, {
+      execution: { commit: 'deadbeef' },
+    });
+    expect(updateAttempt).toHaveBeenCalledWith('attempt-1', {
+      branch,
+      commit: 'deadbeef',
+    });
   });
 });

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -738,6 +738,87 @@ describe('TaskRunner', () => {
       });
     });
 
+    it('pins SSH approved-fix publish to the recorded pool member in mixed pools', async () => {
+      const publishSpy = vi.spyOn(SshExecutor.prototype, 'publishApprovedFix').mockResolvedValue({
+        commitHash: 'def5678',
+      });
+      const worktreePublish = vi.fn().mockResolvedValue({
+        error: 'local worktree publish should not be used for an SSH workspace',
+      });
+      const worktreeExecutor = {
+        type: 'worktree',
+        publishApprovedFix: worktreePublish,
+      };
+
+      const task = makeTask({
+        id: 'mixed-pool-ssh-fix-task',
+        description: 'Apply approved fix over the recorded SSH pool member',
+        config: {
+          runnerKind: 'ssh',
+          poolId: 'mixed-local-ssh',
+          poolMemberId: 'remote-1',
+          command: 'bash -lc false',
+        },
+        execution: {
+          workspacePath: '~/.invoker/worktrees/task-a',
+          branch: 'experiment/mixed-pool-ssh-fix-gap',
+          selectedAttemptId: 'attempt-mixed-ssh-1',
+        },
+      });
+      const tasks = new Map<string, TaskState>([['mixed-pool-ssh-fix-task', task]]);
+      const updateTask = vi.fn();
+      const updateAttempt = vi.fn();
+      const registryMap = new Map<string, any>([['worktree', worktreeExecutor]]);
+      const executorRegistry = {
+        getDefault: () => worktreeExecutor,
+        get: (name: string) => registryMap.get(name) ?? null,
+        register: (name: string, executor: any) => {
+          registryMap.set(name, executor);
+        },
+        getAll: () => [...registryMap.values()],
+      };
+      const runner = new TaskRunner({
+        orchestrator: { getTask: (id: string) => tasks.get(id) } as any,
+        persistence: { updateTask, updateAttempt } as any,
+        executorRegistry: executorRegistry as any,
+        cwd: '/tmp',
+        remoteTargetsProvider: () => ({
+          'remote-1': {
+            host: 'example.com',
+            user: 'invoker',
+            sshKeyPath: '/tmp/test-key',
+          },
+        }),
+        executionPoolsProvider: () => ({
+          'mixed-local-ssh': {
+            selectionStrategy: 'roundRobin',
+            members: [
+              { type: 'worktree', id: 'local' },
+              { type: 'ssh', id: 'remote-1' },
+            ],
+          },
+        }),
+      });
+
+      await runner.publishApprovedFix(task);
+
+      expect(worktreePublish).not.toHaveBeenCalled();
+      expect(publishSpy).toHaveBeenCalledWith(
+        '~/.invoker/worktrees/task-a',
+        expect.objectContaining({
+          actionId: 'mixed-pool-ssh-fix-task',
+        }),
+        'experiment/mixed-pool-ssh-fix-gap',
+      );
+      expect(updateTask).toHaveBeenCalledWith('mixed-pool-ssh-fix-task', {
+        execution: { commit: 'def5678' },
+      });
+      expect(updateAttempt).toHaveBeenCalledWith('attempt-mixed-ssh-1', {
+        branch: 'experiment/mixed-pool-ssh-fix-gap',
+        commit: 'def5678',
+      });
+    });
+
     it('commits approved merge-gate fixes locally and records a fixed integration anchor', async () => {
       const repoDir = createTempWorkspace();
       execSync('git init', { cwd: repoDir });

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -140,7 +140,7 @@ function deriveRemoteManagedWorkspaceInfo(
   };
 }
 
-async function resolveRemoteBranchOwnerPath(
+export async function resolveRemoteBranchOwnerPath(
   branch: string | undefined,
   workspacePath: string,
   target: RemoteTargetConfig,
@@ -333,7 +333,7 @@ function buildRemoteAgentCommand(
   };
 }
 
-function resolveSelectedRemoteTargetId(host: ConflictResolverHost, taskId: string, task: ReturnType<Orchestrator['getTask']> & {}): string | undefined {
+export function resolveSelectedRemoteTargetId(host: ConflictResolverHost, taskId: string, task: ReturnType<Orchestrator['getTask']> & {}): string | undefined {
   const direct = (task.config as { poolMemberId?: string }).poolMemberId;
   if (direct) return direct;
 

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -45,6 +45,8 @@ import {
   resolveConflictImpl,
   fixWithAgentImpl,
   spawnAgentFixViaRegistry,
+  resolveRemoteBranchOwnerPath,
+  resolveSelectedRemoteTargetId,
 } from './conflict-resolver.js';
 import { DEFAULT_EXECUTION_AGENT } from './agent.js';
 import {
@@ -1128,9 +1130,10 @@ export class TaskRunner {
   selectExecutor(task: TaskState): Executor {
     let effectiveType = task.config.runnerKind ?? (task.config.isMergeNode ? 'merge' : undefined);
     let selectedPoolMemberId: string | undefined;
+    const explicitPoolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
     this.pendingPoolSelections.delete(task.id);
 
-    if (task.config.poolId) {
+    if (task.config.poolId && !explicitPoolMemberId) {
       const pool = this.getExecutionPools()[task.config.poolId];
       const member = pool ? this.selectPoolMember(task.config.poolId, pool) : undefined;
       if (member) {
@@ -1148,7 +1151,7 @@ export class TaskRunner {
       effectiveType === 'ssh'
       && task.config.poolId
       && !selectedPoolMemberId
-      && !(task.config as { poolMemberId?: string }).poolMemberId
+      && !explicitPoolMemberId
       && !this.getRemoteTargets()[task.config.poolId]
     ) {
       effectiveType = 'worktree';
@@ -1335,12 +1338,34 @@ export class TaskRunner {
       },
     };
 
+    let publishWorkspacePath = workspacePath;
+    if (task.config.runnerKind === 'ssh') {
+      const poolMemberId = resolveSelectedRemoteTargetId(this, task.id, task);
+      const target = poolMemberId ? this.getRemoteTargetConfig(poolMemberId) : undefined;
+      if (target) {
+        const repairedWorkspacePath = await resolveRemoteBranchOwnerPath(branch, workspacePath, target);
+        if (repairedWorkspacePath && repairedWorkspacePath !== workspacePath) {
+          publishWorkspacePath = repairedWorkspacePath;
+          this.persistence.updateTask(task.id, {
+            execution: {
+              workspacePath: repairedWorkspacePath,
+            },
+          });
+          this.persistence.logEvent?.(task.id, 'debug.approved-fix', {
+            phase: 'publish-approved-fix-remote-path-repaired',
+            previousWorkspacePath: workspacePath,
+            repairedWorkspacePath,
+          });
+        }
+      }
+    }
+
     const executor = this.selectExecutor(task);
     let result: { commitHash?: string; error?: string };
     if (executor instanceof SshExecutor) {
-      result = await executor.publishApprovedFix(workspacePath, request, branch);
+      result = await executor.publishApprovedFix(publishWorkspacePath, request, branch);
     } else if (executor instanceof BaseExecutor) {
-      result = await executor.publishApprovedFix(workspacePath, request, branch);
+      result = await executor.publishApprovedFix(publishWorkspacePath, request, branch);
     } else {
       throw new Error(
         `Executor ${executor.type} does not support approved-fix publish for task ${task.id}`,

--- a/scripts/repro/repro-ssh-approved-fix-mixed-pool-reselection.sh
+++ b/scripts/repro/repro-ssh-approved-fix-mixed-pool-reselection.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd -P)"
+
+cd "$repo_root"
+pnpm --dir packages/execution-engine exec vitest run \
+  src/__tests__/task-runner-fix-publish-and-ssh.test.ts \
+  -t "pins SSH approved-fix publish to the recorded pool member in mixed pools"
+
+echo "PASS: approved-fix publish honors the recorded SSH pool member instead of reselecting a mixed-pool executor"

--- a/scripts/repro/repro-ssh-approved-fix-stale-worktree-path.sh
+++ b/scripts/repro/repro-ssh-approved-fix-stale-worktree-path.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-approved-fix-stale-wt.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+git_init() {
+  git -c init.defaultBranch=master "$@"
+}
+
+origin="$tmpdir/origin.git"
+seed="$tmpdir/seed"
+mirror="$tmpdir/mirror"
+stale_wt="$tmpdir/worktrees/stale-task"
+owner_wt="$tmpdir/worktrees/current-task"
+branch="experiment/wf-1/test-task"
+
+git_init init --bare "$origin" >/dev/null
+git_init clone "$origin" "$seed" >/dev/null
+git -C "$seed" config user.name "Invoker Repro"
+git -C "$seed" config user.email "invoker-repro@example.com"
+printf 'base\n' >"$seed/result.txt"
+git -C "$seed" add result.txt
+git -C "$seed" commit -m "seed" >/dev/null
+git -C "$seed" push origin master >/dev/null
+
+git clone "$origin" "$mirror" >/dev/null
+git -C "$mirror" config user.name "Invoker Repro"
+git -C "$mirror" config user.email "invoker-repro@example.com"
+git -C "$mirror" worktree add -B "$branch" "$owner_wt" origin/master >/dev/null
+printf 'approved fix\n' >"$owner_wt/result.txt"
+
+mkdir -p "$(dirname "$stale_wt")"
+git -C "$mirror" worktree add -B stale/old "$stale_wt" origin/master >/dev/null
+git -C "$mirror" worktree remove --force "$stale_wt" >/dev/null
+
+if git -C "$stale_wt" status >/tmp/invoker-stale-wt.out 2>&1; then
+  echo "repro: expected stale recorded workspace to fail" >&2
+  exit 1
+fi
+
+if ! grep -E "No such file|not a git repository|cannot change to" /tmp/invoker-stale-wt.out >/dev/null; then
+  echo "repro: stale path failed for an unexpected reason:" >&2
+  cat /tmp/invoker-stale-wt.out >&2
+  exit 1
+fi
+
+resolved_wt="$(
+  git -C "$mirror" worktree list --porcelain |
+    awk -v branch="refs/heads/$branch" '
+      /^worktree / { path=substr($0, 10) }
+      /^branch / && substr($0, 8) == branch { print path; found=1 }
+      END { if (!found) exit 1 }
+    '
+)"
+
+resolved_wt_real="$(cd "$resolved_wt" && pwd -P)"
+owner_wt_real="$(cd "$owner_wt" && pwd -P)"
+if [[ "$resolved_wt_real" != "$owner_wt_real" ]]; then
+  echo "repro: expected branch owner $owner_wt_real, got $resolved_wt_real" >&2
+  exit 1
+fi
+
+git -C "$resolved_wt" add -A
+git -C "$resolved_wt" commit -m "approved fix" >/dev/null
+git -C "$resolved_wt" push origin "HEAD:refs/heads/$branch" >/dev/null
+
+remote_value="$(git -C "$mirror" show "origin/$branch:result.txt" 2>/dev/null || true)"
+if [[ "$remote_value" != "approved fix" ]]; then
+  echo "repro: expected approved fix to be pushed, got: $remote_value" >&2
+  exit 1
+fi
+
+echo "PASS: approved-fix publish must repair stale workspacePath from git worktree branch ownership"


### PR DESCRIPTION
## Summary

Repair SSH approved-fix publishing when the task's recorded remote `workspacePath` is stale. The publish path now resolves the branch owner from `git worktree list --porcelain`, persists the repaired path, and publishes from the live worktree instead of failing on `cd: ... No such file or directory`.

Also pin approved-fix executor selection to the recorded SSH `poolMemberId` when a task came from a mixed local/SSH pool. Without that, approval can reselect the local worktree executor for a remote workspace and fail with the generic `commit approved fix failed` error.

Add shell repros for both root causes: stale recorded worktree paths and mixed-pool executor reselection.

## Test Plan

- [x] `bash scripts/repro/repro-ssh-approved-fix-stale-worktree-path.sh`
- [x] `bash scripts/repro/repro-ssh-approved-fix-mixed-pool-reselection.sh`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/remote-fix-worktree-repair.test.ts`
- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `git diff --check`
- [x] `pnpm --filter @invoker/execution-engine build` (JS bundle succeeded; DTS failed with existing TS6307 project file-list errors)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 681e681c`
- Post-revert steps: Re-run affected SSH approved-fix tasks or recreate the workflow if stale workspace paths or mixed-pool approval failures were already recorded.
- Data migration? No