### PR TITLE
Retry SSH startup on alternate pool member

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -2440,6 +2440,83 @@ describe('TaskRunner', () => {
       });
     });
 
+    it('retries SSH startup transport failures on another pool member before failing the task', async () => {
+      const sshExecutor = createCompletingExecutor('ssh', {
+        workspacePath: '/remote/worktrees/task-retry',
+        branch: 'experiment/task-retry',
+      });
+      sshExecutor.start = vi.fn()
+        .mockRejectedValueOnce(new Error(
+          'SSH remote script failed (exit=255)\nSTDERR:\nConnection timed out during banner exchange',
+        ))
+        .mockResolvedValueOnce({
+          executionId: 'exec-task-retry',
+          taskId: 'task-retry',
+          workspacePath: '/remote/worktrees/task-retry',
+          branch: 'experiment/task-retry',
+        });
+      const logEvent = vi.fn();
+      const updateTask = vi.fn();
+      const appendTaskOutput = vi.fn();
+      const handleWorkerResponse = vi.fn();
+      const task = makeTask({
+        id: 'task-retry',
+        status: 'pending',
+        config: { command: 'pnpm test', runnerKind: 'ssh', poolId: 'ci-pool' },
+        execution: { selectedAttemptId: 'attempt-retry' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse } as any,
+        persistence: { updateTask, updateAttempt: vi.fn(), appendTaskOutput, logEvent } as any,
+        executorRegistry: {
+          getDefault: () => sshExecutor,
+          get: (type: string) => type === 'ssh' ? sshExecutor : null,
+          getAll: () => [sshExecutor],
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          'ci-pool': {
+            selectionStrategy: 'leastLoaded',
+            members: [
+              { type: 'ssh', id: 'remote-a' },
+              { type: 'ssh', id: 'remote-b' },
+            ],
+          },
+        }),
+        remoteTargetsProvider: () => ({
+          'remote-a': { host: 'a.example.com', user: 'runner', sshKeyPath: '/secret/a' },
+          'remote-b': { host: 'b.example.com', user: 'runner', sshKeyPath: '/secret/b' },
+        }),
+      });
+
+      await runner.executeTask(task);
+
+      expect(sshExecutor.start).toHaveBeenCalledTimes(2);
+      expect(appendTaskOutput).toHaveBeenCalledWith(
+        'task-retry',
+        expect.stringContaining('retrying another SSH pool member'),
+      );
+      expect(logEvent).toHaveBeenCalledWith('task-retry', 'task.executor.startup-retry', expect.objectContaining({
+        poolId: 'ci-pool',
+        poolMemberId: 'remote-a',
+        reason: 'ssh-startup-transport-failure',
+      }));
+      expect(logEvent).toHaveBeenCalledWith('task-retry', 'task.executor.selected', expect.objectContaining({
+        runnerKind: 'ssh',
+        poolMemberId: 'remote-b',
+        remoteHost: 'b.example.com',
+      }));
+      expect(updateTask).toHaveBeenCalledWith('task-retry', {
+        config: { runnerKind: 'ssh', poolMemberId: 'remote-b' },
+        execution: expect.objectContaining({
+          workspacePath: '/remote/worktrees/task-retry',
+          branch: 'experiment/task-retry',
+        }),
+      });
+      expect(handleWorkerResponse).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
+    });
+
     it('logs explicit SSH executor selection as explicitPoolMemberId', async () => {
       const sshExecutor = createCompletingExecutor('ssh', {
         workspacePath: '/remote/worktrees/task-explicit',

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -97,6 +97,20 @@ type PoolSelection = {
   selectionStrategy: 'roundRobin' | 'leastLoaded';
 };
 
+function isRetryableSshStartupTransportError(err: unknown): boolean {
+  const message = err instanceof Error ? `${err.message}\n${err.stack ?? ''}` : String(err);
+  const lower = message.toLowerCase();
+  return lower.includes('exit=255')
+    || lower.includes('ssh transport failed')
+    || lower.includes('connection timed out')
+    || lower.includes('operation timed out')
+    || lower.includes('connection reset')
+    || lower.includes('broken pipe')
+    || lower.includes('banner exchange')
+    || lower.includes('kex_exchange_identification')
+    || lower.includes('remote session terminated unexpectedly');
+}
+
 type FreshBaseCommit = {
   branch: string;
   commit: string;
@@ -701,94 +715,133 @@ export class TaskRunner {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} executeTaskInner taskId=${task.id} WorkRequest built actionType=${request.actionType} repoUrl=${request.inputs.repoUrl ?? '(none)'} upstreamBranches=${JSON.stringify(request.inputs.upstreamBranches ?? [])}`,
     );
-    bench('selectExecutor.start');
-    const executor = this.selectExecutor(task);
-    bench('selectExecutor.end', {
-      executorType: executor.type,
-    });
-    traceExecution(
-      `${RESTART_TO_BRANCH_TRACE} executeTaskInner taskId=${task.id} selectExecutor → type=${executor.type} calling executor.start()`,
-    );
-    traceExecution(`[trace] TaskRunner: task=${task.id} calling executor.start() type=${executor.type}`);
-    this.logger.info(
-      `[TaskRunner] executor.start begin task=${task.id} attempt=${attemptId} executor=${executor.type} ` +
-        `generation=${task.execution.generation ?? 0}`,
-    );
-    bench('onLaunchStart.before', {
-      executorType: executor.type,
-    });
-    this.callbacks.onLaunchStart?.(task.id, executor);
-    bench('executor.start.before', {
-      executorType: executor.type,
-    });
     const startT0 = Date.now();
-    const startTimeoutMs = getExecutorStartTimeoutMs();
-    const preStartHeartbeatTimer = setInterval(() => {
-      const now = new Date();
-      this.persistence.updateAttempt?.(attemptId, {
-        lastHeartbeatAt: now,
-        leaseExpiresAt: nextLeaseExpiry(now),
-      } as any);
-      this.callbacks.onHeartbeat?.(task.id);
-    }, PRE_START_HEARTBEAT_INTERVAL_MS);
-    let preStartTimeout: ReturnType<typeof setTimeout> | undefined;
-    let handle: ExecutorHandle;
-    try {
-      handle = await Promise.race<ExecutorHandle>([
-        executor.start(request),
-        new Promise<ExecutorHandle>((_resolve, reject) => {
-          preStartTimeout = setTimeout(() => {
-            reject(new Error(`Executor startup timed out after ${startTimeoutMs}ms (${executor.type})`));
-          }, startTimeoutMs);
-        }),
-      ]);
-    } catch (err) {
-      const meta = err as StartupFailureMetadata;
-      const startupErrorMessage = `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}\n`;
-      this.callbacks.onOutput?.(task.id, startupErrorMessage);
-      try {
-        this.persistence.appendTaskOutput(task.id, startupErrorMessage);
-      } catch {
-        // Preserve the original startup failure if output persistence also fails.
-      }
-      // Only persist startup-failure metadata when the launch is still
-      // current.  If the task has moved to a newer attempt or generation
-      // (e.g. via recreate-task), writing old workspace/branch metadata
-      // would corrupt the live attempt's state.
-      if (
-        (meta.workspacePath || meta.branch || meta.agentSessionId || meta.containerId)
-        && !this.isLaunchStale(task.id, attemptId, task.execution.generation ?? 0)
-      ) {
-        const execution: Record<string, string> = {};
-        if (meta.workspacePath) execution.workspacePath = meta.workspacePath;
-        if (meta.branch) execution.branch = meta.branch;
-        if (meta.agentSessionId) {
-          execution.agentSessionId = meta.agentSessionId;
-          execution.lastAgentSessionId = meta.agentSessionId;
-        }
-        if (meta.containerId) execution.containerId = meta.containerId;
-        const poolSelection = this.pendingPoolSelections.get(task.id);
-        const selectedSshTargetId = executor.type === 'ssh'
-          ? this.selectedRemoteTargetId(task, poolSelection)
-          : undefined;
-        this.persistence.updateTask(task.id, {
-          config: {
-            runnerKind: executor.type as RunnerKind,
-            ...(selectedSshTargetId ? { poolMemberId: selectedSshTargetId } : {}),
-          },
-          execution: execution as any,
-        });
-      }
-      this.pendingPoolSelections.delete(task.id);
-      const wrapped = new Error(
-        `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}`,
-        { cause: err },
+    const attemptedPoolMemberKeys = new Set<string>();
+    let executor!: Executor;
+    let handle!: ExecutorHandle;
+    while (true) {
+      bench('selectExecutor.start');
+      executor = this.selectExecutor(task, attemptedPoolMemberKeys);
+      const poolSelectionForStart = this.pendingPoolSelections.get(task.id);
+      bench('selectExecutor.end', {
+        executorType: executor.type,
+      });
+      traceExecution(
+        `${RESTART_TO_BRANCH_TRACE} executeTaskInner taskId=${task.id} selectExecutor → type=${executor.type} calling executor.start()`,
       );
-      this.callbacks.onLaunchFailed?.(task.id, wrapped, executor);
-      throw wrapped;
-    } finally {
-      clearInterval(preStartHeartbeatTimer);
-      if (preStartTimeout) clearTimeout(preStartTimeout);
+      traceExecution(`[trace] TaskRunner: task=${task.id} calling executor.start() type=${executor.type}`);
+      this.logger.info(
+        `[TaskRunner] executor.start begin task=${task.id} attempt=${attemptId} executor=${executor.type} ` +
+          `generation=${task.execution.generation ?? 0}`,
+      );
+      bench('onLaunchStart.before', {
+        executorType: executor.type,
+      });
+      this.callbacks.onLaunchStart?.(task.id, executor);
+      bench('executor.start.before', {
+        executorType: executor.type,
+      });
+      const startTimeoutMs = getExecutorStartTimeoutMs();
+      const preStartHeartbeatTimer = setInterval(() => {
+        const now = new Date();
+        this.persistence.updateAttempt?.(attemptId, {
+          lastHeartbeatAt: now,
+          leaseExpiresAt: nextLeaseExpiry(now),
+        } as any);
+        this.callbacks.onHeartbeat?.(task.id);
+      }, PRE_START_HEARTBEAT_INTERVAL_MS);
+      let preStartTimeout: ReturnType<typeof setTimeout> | undefined;
+      try {
+        handle = await Promise.race<ExecutorHandle>([
+          executor.start(request),
+          new Promise<ExecutorHandle>((_resolve, reject) => {
+            preStartTimeout = setTimeout(() => {
+              reject(new Error(`Executor startup timed out after ${startTimeoutMs}ms (${executor.type})`));
+            }, startTimeoutMs);
+          }),
+        ]);
+        break;
+      } catch (err) {
+        const meta = err as StartupFailureMetadata;
+        if (
+          executor.type === 'ssh'
+          && poolSelectionForStart?.member.type === 'ssh'
+          && !meta.workspacePath
+          && !meta.branch
+          && isRetryableSshStartupTransportError(err)
+        ) {
+          attemptedPoolMemberKeys.add(poolSelectionForStart.memberKey);
+          const pool = this.getExecutionPools()[poolSelectionForStart.poolId];
+          const hasAnotherSshMember = pool?.members.some((member) =>
+            member.type === 'ssh' && !attemptedPoolMemberKeys.has(this.poolMemberKey(member)),
+          ) ?? false;
+          if (hasAnotherSshMember) {
+            const retryMessage =
+              `Executor startup failed (${executor.type}) on pool member ${poolSelectionForStart.member.id}; ` +
+              `retrying another SSH pool member: ${err instanceof Error ? err.message : String(err)}\n`;
+            this.callbacks.onOutput?.(task.id, retryMessage);
+            try {
+              this.persistence.appendTaskOutput(task.id, retryMessage);
+            } catch {
+              // Preserve the original startup failure if output persistence also fails.
+            }
+            this.persistence.logEvent?.(task.id, 'task.executor.startup-retry', {
+              runnerKind: executor.type,
+              poolId: poolSelectionForStart.poolId,
+              poolMemberId: poolSelectionForStart.member.id,
+              reason: 'ssh-startup-transport-failure',
+              error: err instanceof Error ? err.message : String(err),
+            });
+            this.pendingPoolSelections.delete(task.id);
+            continue;
+          }
+        }
+        const startupErrorMessage = `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}\n`;
+        this.callbacks.onOutput?.(task.id, startupErrorMessage);
+        try {
+          this.persistence.appendTaskOutput(task.id, startupErrorMessage);
+        } catch {
+          // Preserve the original startup failure if output persistence also fails.
+        }
+        // Only persist startup-failure metadata when the launch is still
+        // current.  If the task has moved to a newer attempt or generation
+        // (e.g. via recreate-task), writing old workspace/branch metadata
+        // would corrupt the live attempt's state.
+        if (
+          (meta.workspacePath || meta.branch || meta.agentSessionId || meta.containerId)
+          && !this.isLaunchStale(task.id, attemptId, task.execution.generation ?? 0)
+        ) {
+          const execution: Record<string, string> = {};
+          if (meta.workspacePath) execution.workspacePath = meta.workspacePath;
+          if (meta.branch) execution.branch = meta.branch;
+          if (meta.agentSessionId) {
+            execution.agentSessionId = meta.agentSessionId;
+            execution.lastAgentSessionId = meta.agentSessionId;
+          }
+          if (meta.containerId) execution.containerId = meta.containerId;
+          const poolSelection = this.pendingPoolSelections.get(task.id);
+          const selectedSshTargetId = executor.type === 'ssh'
+            ? this.selectedRemoteTargetId(task, poolSelection)
+            : undefined;
+          this.persistence.updateTask(task.id, {
+            config: {
+              runnerKind: executor.type as RunnerKind,
+              ...(selectedSshTargetId ? { poolMemberId: selectedSshTargetId } : {}),
+            },
+            execution: execution as any,
+          });
+        }
+        this.pendingPoolSelections.delete(task.id);
+        const wrapped = new Error(
+          `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}`,
+          { cause: err },
+        );
+        this.callbacks.onLaunchFailed?.(task.id, wrapped, executor);
+        throw wrapped;
+      } finally {
+        clearInterval(preStartHeartbeatTimer);
+        if (preStartTimeout) clearTimeout(preStartTimeout);
+      }
     }
     traceExecution(`[trace] TaskRunner: task=${task.id} executor.start() returned after ${Date.now() - startT0}ms executor=${executor.type} sessionId=${handle.agentSessionId ?? 'none'} workspace=${handle.workspacePath ?? 'default'}`);
     this.logger.info(
@@ -1028,17 +1081,26 @@ export class TaskRunner {
     return load;
   }
 
-  private selectPoolMember(poolId: string, pool: ExecutionPoolConfig): ExecutionPoolMember | undefined {
+  private selectPoolMember(
+    poolId: string,
+    pool: ExecutionPoolConfig,
+    excludedMemberKeys: Set<string> = new Set(),
+  ): ExecutionPoolMember | undefined {
     if (pool.members.length === 0) return undefined;
 
     if (pool.selectionStrategy === 'roundRobin') {
       const cursor = this.poolRoundRobinCursor.get(poolId) ?? 0;
-      const member = pool.members[cursor % pool.members.length];
-      this.poolRoundRobinCursor.set(poolId, (cursor + 1) % pool.members.length);
-      return member;
+      for (let offset = 0; offset < pool.members.length; offset += 1) {
+        const index = (cursor + offset) % pool.members.length;
+        const member = pool.members[index];
+        if (excludedMemberKeys.has(this.poolMemberKey(member))) continue;
+        this.poolRoundRobinCursor.set(poolId, (index + 1) % pool.members.length);
+        return member;
+      }
+      return undefined;
     }
 
-    const scored = pool.members.map((member, index) => {
+    const scored = pool.members.filter((member) => !excludedMemberKeys.has(this.poolMemberKey(member))).map((member, index) => {
       const memberKey = this.poolMemberKey(member);
       const load = this.poolMemberLoad(poolId, memberKey);
       const limit = member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
@@ -1125,14 +1187,14 @@ export class TaskRunner {
       ?? (task.config.poolId && this.getRemoteTargets()[task.config.poolId] ? task.config.poolId : undefined);
   }
 
-  selectExecutor(task: TaskState): Executor {
+  selectExecutor(task: TaskState, excludedPoolMemberKeys: Set<string> = new Set()): Executor {
     let effectiveType = task.config.runnerKind ?? (task.config.isMergeNode ? 'merge' : undefined);
     let selectedPoolMemberId: string | undefined;
     this.pendingPoolSelections.delete(task.id);
 
     if (task.config.poolId) {
       const pool = this.getExecutionPools()[task.config.poolId];
-      const member = pool ? this.selectPoolMember(task.config.poolId, pool) : undefined;
+      const member = pool ? this.selectPoolMember(task.config.poolId, pool, excludedPoolMemberKeys) : undefined;
       if (member) {
         effectiveType = member.type;
         selectedPoolMemberId = member.type === 'ssh' ? member.id : undefined;

--- a/scripts/repro/repro-ssh-pool-dead-member-startup-retry.sh
+++ b/scripts/repro/repro-ssh-pool-dead-member-startup-retry.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+members=(remote-a remote-b)
+
+start_member() {
+  case "$1" in
+    remote-a)
+      echo "Connection timed out during banner exchange" >&2
+      return 255
+      ;;
+    remote-b)
+      echo "workspace=/home/invoker/.invoker/worktrees/recovered-task"
+      return 0
+      ;;
+    *)
+      echo "unknown member $1" >&2
+      return 1
+      ;;
+  esac
+}
+
+old_scheduler() {
+  start_member "${members[0]}"
+}
+
+retry_scheduler() {
+  local member
+  local output
+  for member in "${members[@]}"; do
+    if output="$(start_member "$member" 2>&1)"; then
+      printf '%s\n' "$output"
+      return 0
+    fi
+    case "$output" in
+      *"Connection timed out during banner exchange"*|*"connection reset"*|*"exit=255"*)
+        continue
+        ;;
+      *)
+        printf '%s\n' "$output" >&2
+        return 1
+        ;;
+    esac
+  done
+  return 1
+}
+
+if old_scheduler >/tmp/invoker-ssh-pool-old.out 2>&1; then
+  echo "repro: expected old scheduler to fail on the first dead SSH member" >&2
+  exit 1
+fi
+
+if ! grep -q "Connection timed out during banner exchange" /tmp/invoker-ssh-pool-old.out; then
+  echo "repro: old scheduler failed for an unexpected reason" >&2
+  cat /tmp/invoker-ssh-pool-old.out >&2
+  exit 1
+fi
+
+if ! retry_scheduler >/tmp/invoker-ssh-pool-retry.out 2>&1; then
+  echo "repro: retry scheduler should recover on the second member" >&2
+  cat /tmp/invoker-ssh-pool-retry.out >&2
+  exit 1
+fi
+
+if ! grep -q "workspace=/home/invoker/.invoker/worktrees/recovered-task" /tmp/invoker-ssh-pool-retry.out; then
+  echo "repro: retry scheduler did not reach the healthy member" >&2
+  cat /tmp/invoker-ssh-pool-retry.out >&2
+  exit 1
+fi
+
+echo "PASS: SSH pool startup retries recover from a dead member before failing the task"


### PR DESCRIPTION
## Summary

Retry SSH task startup on another pool member when the selected member fails with a pre-workspace transport error such as banner timeout, connection reset, or SSH exit 255.

This prevents a dead SSH target from failing the task before any workspace exists. The retry is intentionally narrow: it only applies before branch/workspace metadata exists, so it will not abandon a partially created remote worktree.

Add a repro script that models the old fail-fast scheduler against a dead first member and the fixed retry behavior that reaches the healthy second member.

## Test Plan

- [x] `bash scripts/repro/repro-ssh-pool-dead-member-startup-retry.sh`
- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "retries SSH startup transport failures"`
- [x] `pnpm --dir packages/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `git diff --check`
- [x] `pnpm --filter @invoker/execution-engine build` (JS bundle succeeded; DTS failed with existing TS6307 project file-list errors)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a0007a04`
- Post-revert steps: Avoid routing SSH pool work to unhealthy targets until the retry behavior is restored.
- Data migration? No
