### PR TITLE
[Codex] Enforce SSH pool member capacity

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -6,6 +6,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { TaskRunner } from '../task-runner.js';
 import { collectDirectNonMergeTaskIds } from '../merge-runner.js';
 import { SshExecutor } from '../ssh-executor.js';
+import { ResourceLimitError } from '../repo-pool.js';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
 import { EventEmitter } from 'events';
@@ -2633,6 +2634,168 @@ describe('TaskRunner', () => {
         remoteHost: 'dev.example.com',
         remoteUser: 'dev',
       }));
+    });
+
+    it('defers explicit SSH pool member selection when the member is already at capacity', async () => {
+      const sshExecutor = createCompletingExecutor('ssh', {
+        workspacePath: '/remote/worktrees/task-explicit-capacity',
+        branch: 'experiment/task-explicit-capacity',
+      });
+      const deferTask = vi.fn();
+      const handleWorkerResponse = vi.fn();
+      const task = makeTask({
+        id: 'task-explicit-capacity',
+        status: 'pending',
+        config: {
+          command: 'pnpm test',
+          runnerKind: 'ssh',
+          poolId: 'ci-pool',
+          poolMemberId: 'remote-a',
+        },
+        execution: { selectedAttemptId: 'attempt-explicit-capacity' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: () => task,
+          getAllTasks: () => [task],
+          handleWorkerResponse,
+          deferTask,
+        } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent: vi.fn() } as any,
+        executorRegistry: {
+          getDefault: () => sshExecutor,
+          get: (type: string) => type === 'ssh' ? sshExecutor : null,
+          getAll: () => [sshExecutor],
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          'ci-pool': {
+            selectionStrategy: 'roundRobin',
+            maxConcurrentTasksPerMember: 1,
+            members: [{ type: 'ssh', id: 'remote-a' }],
+          },
+        }),
+        remoteTargetsProvider: () => ({
+          'remote-a': { host: 'a.example.com', user: 'runner', sshKeyPath: '/secret/a' },
+        }),
+      });
+      (runner as any).activeExecutions.set('attempt-active', {
+        taskId: 'task-active',
+        executor: sshExecutor,
+        handle: { executionId: 'exec-active', taskId: 'task-active' },
+        poolId: 'ci-pool',
+        poolMemberKey: 'ssh:remote-a',
+      });
+
+      await runner.executeTask(task);
+
+      expect(sshExecutor.start).not.toHaveBeenCalled();
+      expect(deferTask).toHaveBeenCalledWith('task-explicit-capacity');
+      expect(handleWorkerResponse).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
+    });
+
+    it('defers pool-routed SSH selection when every member is already at capacity', async () => {
+      const sshExecutor = createCompletingExecutor('ssh', {
+        workspacePath: '/remote/worktrees/task-pool-capacity',
+        branch: 'experiment/task-pool-capacity',
+      });
+      const deferTask = vi.fn();
+      const handleWorkerResponse = vi.fn();
+      const task = makeTask({
+        id: 'task-pool-capacity',
+        status: 'pending',
+        config: { command: 'pnpm test', runnerKind: 'ssh', poolId: 'ci-pool' },
+        execution: { selectedAttemptId: 'attempt-pool-capacity' },
+      });
+
+      const runner = new TaskRunner({
+        orchestrator: {
+          getTask: () => task,
+          getAllTasks: () => [task],
+          handleWorkerResponse,
+          deferTask,
+        } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent: vi.fn() } as any,
+        executorRegistry: {
+          getDefault: () => sshExecutor,
+          get: (type: string) => type === 'ssh' ? sshExecutor : null,
+          getAll: () => [sshExecutor],
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          'ci-pool': {
+            selectionStrategy: 'leastLoaded',
+            maxConcurrentTasksPerMember: 1,
+            members: [{ type: 'ssh', id: 'remote-a' }],
+          },
+        }),
+        remoteTargetsProvider: () => ({
+          'remote-a': { host: 'a.example.com', user: 'runner', sshKeyPath: '/secret/a' },
+        }),
+      });
+      (runner as any).activeExecutions.set('attempt-active', {
+        taskId: 'task-active',
+        executor: sshExecutor,
+        handle: { executionId: 'exec-active', taskId: 'task-active' },
+        poolId: 'ci-pool',
+        poolMemberKey: 'ssh:remote-a',
+      });
+
+      await runner.executeTask(task);
+
+      expect(sshExecutor.start).not.toHaveBeenCalled();
+      expect(deferTask).toHaveBeenCalledWith('task-pool-capacity');
+      expect(handleWorkerResponse).not.toHaveBeenCalledWith(expect.objectContaining({ status: 'failed' }));
+    });
+
+    it('throws a resource-limit cause for capacity-blocked explicit SSH selection', () => {
+      const sshExecutor = createCompletingExecutor('ssh', {
+        workspacePath: '/remote/worktrees/task-select-capacity',
+        branch: 'experiment/task-select-capacity',
+      });
+      const task = makeTask({
+        id: 'task-select-capacity',
+        status: 'pending',
+        config: {
+          command: 'pnpm test',
+          runnerKind: 'ssh',
+          poolId: 'ci-pool',
+          poolMemberId: 'remote-a',
+        },
+      });
+      const runner = new TaskRunner({
+        orchestrator: { getTask: () => task, getAllTasks: () => [task], handleWorkerResponse: vi.fn() } as any,
+        persistence: { updateTask: vi.fn(), updateAttempt: vi.fn(), logEvent: vi.fn() } as any,
+        executorRegistry: {
+          getDefault: () => sshExecutor,
+          get: (type: string) => type === 'ssh' ? sshExecutor : null,
+          getAll: () => [sshExecutor],
+        } as any,
+        cwd: '/tmp',
+        executionPoolsProvider: () => ({
+          'ci-pool': {
+            maxConcurrentTasksPerMember: 1,
+            members: [{ type: 'ssh', id: 'remote-a' }],
+          },
+        }),
+        remoteTargetsProvider: () => ({
+          'remote-a': { host: 'a.example.com', user: 'runner', sshKeyPath: '/secret/a' },
+        }),
+      });
+      (runner as any).activeExecutions.set('attempt-active', {
+        taskId: 'task-active',
+        executor: sshExecutor,
+        handle: { executionId: 'exec-active', taskId: 'task-active' },
+        poolId: 'ci-pool',
+        poolMemberKey: 'ssh:remote-a',
+      });
+
+      expect(() => runner.selectExecutor(task)).toThrow(
+        expect.objectContaining({
+          cause: expect.any(ResourceLimitError),
+        }),
+      );
     });
 
     it('logs configured worktree executor selection reason', async () => {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -123,6 +123,7 @@ type RemoteTargetDisplay = {
   user: string;
   sshKeyPath: string;
   port?: number;
+  maxConcurrentTasks?: number;
   managedWorkspaces?: boolean;
   remoteInvokerHome?: string;
   provisionCommand?: string;
@@ -1083,6 +1084,28 @@ export class TaskRunner {
     return load;
   }
 
+  private resourceLimitError(message: string): Error {
+    const err = new Error(message);
+    (err as Error & { cause?: unknown }).cause = new ResourceLimitError(message);
+    return err;
+  }
+
+  private assertPoolMemberCapacity(
+    poolId: string,
+    member: ExecutionPoolMember,
+    pool: Pick<ExecutionPoolConfig, 'maxConcurrentTasksPerMember'>,
+  ): string {
+    const memberKey = this.poolMemberKey(member);
+    const load = this.poolMemberLoad(poolId, memberKey);
+    const limit = member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
+    if (limit !== undefined && load >= limit) {
+      throw this.resourceLimitError(
+        `Execution pool member ${poolId}/${member.id} is at capacity (${load}/${limit})`,
+      );
+    }
+    return memberKey;
+  }
+
   private selectPoolMember(
     poolId: string,
     pool: ExecutionPoolConfig,
@@ -1095,7 +1118,11 @@ export class TaskRunner {
       for (let offset = 0; offset < pool.members.length; offset += 1) {
         const index = (cursor + offset) % pool.members.length;
         const member = pool.members[index];
-        if (excludedMemberKeys.has(this.poolMemberKey(member))) continue;
+        const memberKey = this.poolMemberKey(member);
+        if (excludedMemberKeys.has(memberKey)) continue;
+        const load = this.poolMemberLoad(poolId, memberKey);
+        const limit = member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
+        if (limit !== undefined && load >= limit) continue;
         this.poolRoundRobinCursor.set(poolId, (index + 1) % pool.members.length);
         return member;
       }
@@ -1108,9 +1135,8 @@ export class TaskRunner {
       const limit = member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
       return { member, index, load, hasCapacity: limit === undefined || load < limit };
     });
-    const candidates = scored.some((entry) => entry.hasCapacity)
-      ? scored.filter((entry) => entry.hasCapacity)
-      : scored;
+    const candidates = scored.filter((entry) => entry.hasCapacity);
+    if (candidates.length === 0) return undefined;
     candidates.sort((a, b) => a.load - b.load || a.index - b.index);
     return candidates[0]?.member;
   }
@@ -1193,9 +1219,26 @@ export class TaskRunner {
     let effectiveType = task.config.runnerKind ?? (task.config.isMergeNode ? 'merge' : undefined);
     let selectedPoolMemberId: string | undefined;
     const explicitPoolMemberId = (task.config as { poolMemberId?: string }).poolMemberId;
+    let remoteTargetsForSelection: Record<string, RemoteTargetDisplay> | undefined;
     this.pendingPoolSelections.delete(task.id);
 
-    if (task.config.poolId && !explicitPoolMemberId) {
+    if (task.config.poolId && explicitPoolMemberId) {
+      const pool = this.getExecutionPools()[task.config.poolId];
+      const member = pool?.members.find(
+        (candidate) => candidate.type === 'ssh' && candidate.id === explicitPoolMemberId,
+      );
+      if (pool && member) {
+        const memberKey = this.assertPoolMemberCapacity(task.config.poolId, member, pool);
+        selectedPoolMemberId = explicitPoolMemberId;
+        effectiveType = member.type;
+        this.pendingPoolSelections.set(task.id, {
+          poolId: task.config.poolId,
+          member,
+          memberKey,
+          selectionStrategy: pool.selectionStrategy ?? 'roundRobin',
+        });
+      }
+    } else if (task.config.poolId && !explicitPoolMemberId) {
       const pool = this.getExecutionPools()[task.config.poolId];
       const member = pool ? this.selectPoolMember(task.config.poolId, pool, excludedPoolMemberKeys) : undefined;
       if (member) {
@@ -1207,8 +1250,32 @@ export class TaskRunner {
           memberKey: this.poolMemberKey(member),
           selectionStrategy: pool.selectionStrategy ?? 'roundRobin',
         });
+      } else if (pool?.members.length) {
+        throw this.resourceLimitError(`Execution pool ${task.config.poolId} has no available members`);
       }
     }
+
+    if (effectiveType === 'ssh' && explicitPoolMemberId && !this.pendingPoolSelections.has(task.id)) {
+      remoteTargetsForSelection = this.getRemoteTargets();
+      const target = remoteTargetsForSelection[explicitPoolMemberId];
+      if (target?.maxConcurrentTasks !== undefined) {
+        const member: ExecutionPoolMember = {
+          type: 'ssh',
+          id: explicitPoolMemberId,
+          maxConcurrentTasks: target.maxConcurrentTasks,
+        };
+        const poolId = `remote-target:${explicitPoolMemberId}`;
+        const memberKey = this.assertPoolMemberCapacity(poolId, member, {});
+        selectedPoolMemberId = explicitPoolMemberId;
+        this.pendingPoolSelections.set(task.id, {
+          poolId,
+          member,
+          memberKey,
+          selectionStrategy: 'leastLoaded',
+        });
+      }
+    }
+
     if (
       effectiveType === 'ssh'
       && task.config.poolId
@@ -1264,7 +1331,7 @@ export class TaskRunner {
       // remoteTargetsProvider returning new values), we replace the cached executor so the
       // new config takes effect immediately.
       if (effectiveType === 'ssh') {
-        const remoteTargets = this.getRemoteTargets();
+        const remoteTargets = remoteTargetsForSelection ?? this.getRemoteTargets();
         const targetId =
           selectedPoolMemberId
           ?? (task.config as { poolMemberId?: string }).poolMemberId


### PR DESCRIPTION
## Summary

- Enforce SSH execution-pool member capacity even when a task already has an explicit `poolMemberId`.
- Stop least-loaded and round-robin pool selection from falling back to full members; capacity exhaustion now raises `ResourceLimitError` so the task is deferred instead of over-dispatched.
- Add regression coverage for explicit SSH member reuse and fully occupied pool routing.

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine test src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "capacity"`
- [x] `pnpm --filter @invoker/execution-engine test src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [ ] `pnpm --filter @invoker/execution-engine build` (existing declaration-generation failure: TS6307 files not listed in project)
- [ ] `pnpm exec tsc -p packages/execution-engine/tsconfig.json --noEmit` (existing project-reference failure: referenced packages are not `composite`)

## Revert Plan

Revert this commit to restore the previous soft pool-selection behavior. Tasks may again over-dispatch to a saturated SSH target if reverted.
