### PR TITLE
CodeBuddy: enforce SSH pool concurrency limit

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -5988,4 +5988,114 @@ console.log(JSON.stringify(out));
     });
   });
 
+  // -------------------------------------------------------------------------
+  // SSH pool concurrency-limit regression tests
+  // Bug 1: selectPoolMember() over-limit fallback returned over-limit members
+  //        instead of undefined, making maxConcurrentTasksPerMember advisory.
+  // Bug 2: Promise.all dispatch raced before pendingPoolSelections was updated,
+  //        so all concurrent tasks observed load=0 for the same pool member.
+  // -------------------------------------------------------------------------
+
+  describe('selectPoolMember – maxConcurrentTasksPerMember hard cap (Bug 1)', () => {
+    it('returns undefined when all members are at the concurrency limit', () => {
+      const tasks = new Map<string, TaskState>();
+      const runner = createExecutorWithTasks(tasks);
+
+      const pool = {
+        members: [{ type: 'ssh' as const, id: 'host-1', host: '1.2.3.4', user: 'root' }],
+        selectionStrategy: 'leastLoaded' as const,
+        maxConcurrentTasksPerMember: 1,
+      };
+
+      // Simulate one task already occupying the member by injecting a
+      // pending pool selection directly into the internal map.
+      // poolMemberKey() returns "type:id", e.g. "ssh:host-1".
+      const member = pool.members[0];
+      const memberKey = `${member.type}:${member.id}`;
+      (runner as any).pendingPoolSelections.set('existing-task', {
+        poolId: 'pool-a',
+        member,
+        memberKey,
+        selectionStrategy: 'leastLoaded',
+      });
+
+      const result = (runner as any).selectPoolMember('pool-a', pool, new Set());
+      expect(result).toBeUndefined();
+    });
+
+    it('returns a member when a member has remaining capacity', () => {
+      const tasks = new Map<string, TaskState>();
+      const runner = createExecutorWithTasks(tasks);
+
+      const pool = {
+        members: [
+          { type: 'ssh' as const, id: 'host-1', host: '1.2.3.4', user: 'root' },
+          { type: 'ssh' as const, id: 'host-2', host: '5.6.7.8', user: 'root' },
+        ],
+        selectionStrategy: 'leastLoaded' as const,
+        maxConcurrentTasksPerMember: 1,
+      };
+
+      // Fill host-1 but leave host-2 free.
+      (runner as any).pendingPoolSelections.set('existing-task', {
+        poolId: 'pool-a',
+        member: pool.members[0],
+        memberKey: 'ssh:host-1',
+        selectionStrategy: 'leastLoaded',
+      });
+
+      const result = (runner as any).selectPoolMember('pool-a', pool, new Set());
+      expect(result).toBeDefined();
+      expect((result as any).id).toBe('host-2');
+    });
+  });
+
+  describe('withPoolSelectionLock – serializes concurrent selections (Bug 2)', () => {
+    it('serializes concurrent selections so load is visible to subsequent waiters', async () => {
+      const tasks = new Map<string, TaskState>();
+      const runner = createExecutorWithTasks(tasks);
+
+      const poolId = 'pool-b';
+      const pool = {
+        members: [{ type: 'ssh' as const, id: 'only-host', host: '9.9.9.9', user: 'root' }],
+        selectionStrategy: 'leastLoaded' as const,
+        maxConcurrentTasksPerMember: 1,
+      };
+      // poolMemberKey() format is "type:id"
+      const memberKey = 'ssh:only-host';
+
+      // Track how many times selectPoolMember returned a member vs undefined.
+      let gotMember = 0;
+      let gotUndefined = 0;
+      let taskCounter = 0;
+
+      // Each call selects a member and immediately registers pendingPoolSelection
+      // if one is returned — exactly as selectExecutor does.
+      const runSelection = () =>
+        (runner as any).withPoolSelectionLock(poolId, () => {
+          const member = (runner as any).selectPoolMember(poolId, pool, new Set());
+          if (member) {
+            gotMember += 1;
+            taskCounter += 1;
+            // Register the selection so the next waiter in the queue sees load=1.
+            (runner as any).pendingPoolSelections.set(`task-${taskCounter}`, {
+              poolId,
+              member,
+              memberKey,
+              selectionStrategy: 'leastLoaded',
+            });
+          } else {
+            gotUndefined += 1;
+          }
+          return member;
+        });
+
+      await Promise.all([runSelection(), runSelection()]);
+
+      // With the mutex in place only one task should have acquired the slot;
+      // the second should have observed load=1 and received undefined.
+      expect(gotMember).toBe(1);
+      expect(gotUndefined).toBe(1);
+    });
+  });
 });

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -239,6 +239,13 @@ export class TaskRunner {
   private sshExecutorCache = new Map<string, SshExecutor>();
   private poolRoundRobinCursor = new Map<string, number>();
   private pendingPoolSelections = new Map<string, PoolSelection>();
+  /**
+   * Per-pool promise-chain mutex for pool member selection.
+   * Ensures that selectPoolMember() + pendingPoolSelections.set() is atomic
+   * across concurrent executeTask() calls so the load count is accurate
+   * before the next task queries it.
+   */
+  private poolSelectionLocks = new Map<string, Promise<void>>();
   private freshBaseCommits = new Map<string, FreshBaseCommit>();
 
   /** In-flight executions keyed by attemptId (with taskId retained for external kill resolution). */
@@ -723,7 +730,14 @@ export class TaskRunner {
     let handle!: ExecutorHandle;
     while (true) {
       bench('selectExecutor.start');
-      executor = this.selectExecutor(task, attemptedPoolMemberKeys);
+      // Serialize pool member selection per pool so that selectPoolMember() and
+      // pendingPoolSelections.set() are atomic across concurrent executeTask() calls.
+      // Without this, Promise.all-launched tasks all observe load=0 before any
+      // pendingPoolSelections entries are written, defeating maxConcurrentTasksPerMember.
+      executor = await this.withPoolSelectionLock(
+        task.config.poolId ?? `_nopool_${task.id}`,
+        () => this.selectExecutor(task, attemptedPoolMemberKeys),
+      );
       const poolSelectionForStart = this.pendingPoolSelections.get(task.id);
       bench('selectExecutor.end', {
         executorType: executor.type,
@@ -1072,6 +1086,28 @@ export class TaskRunner {
     return `${member.type}:${member.id}`;
   }
 
+  /**
+   * Serialize pool member selection for a given pool so that the
+   * selectPoolMember() query and the pendingPoolSelections.set() update
+   * are never interleaved across concurrent executeTask() calls.
+   */
+  private async withPoolSelectionLock<T>(poolId: string, fn: () => T): Promise<T> {
+    const prev = this.poolSelectionLocks.get(poolId) ?? Promise.resolve();
+    let resolve!: () => void;
+    const next = new Promise<void>((r) => { resolve = r; });
+    this.poolSelectionLocks.set(poolId, next);
+    await prev;
+    try {
+      return fn();
+    } finally {
+      resolve();
+      // Clean up the lock entry when it is no longer needed to avoid unbounded growth.
+      if (this.poolSelectionLocks.get(poolId) === next) {
+        this.poolSelectionLocks.delete(poolId);
+      }
+    }
+  }
+
   private poolMemberLoad(poolId: string, memberKey: string): number {
     let load = 0;
     for (const selection of this.pendingPoolSelections.values()) {
@@ -1108,9 +1144,10 @@ export class TaskRunner {
       const limit = member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
       return { member, index, load, hasCapacity: limit === undefined || load < limit };
     });
-    const candidates = scored.some((entry) => entry.hasCapacity)
-      ? scored.filter((entry) => entry.hasCapacity)
-      : scored;
+    const candidates = scored.filter((entry) => entry.hasCapacity);
+    // Hard cap: when all members are at capacity return undefined so the caller
+    // defers the task rather than dispatching it to an over-limit member.
+    if (candidates.length === 0) return undefined;
     candidates.sort((a, b) => a.load - b.load || a.index - b.index);
     return candidates[0]?.member;
   }


### PR DESCRIPTION
## Problem

Two compounding bugs allowed unlimited concurrent tasks to land on a single SSH pool member even when `maxConcurrentTasksPerMember` was configured, causing the SSH host overload seen after `rebase-recreate-all`.

**Root cause in production:** After dispatching 37 workflows simultaneously on a single-member SSH pool, in-memory load maps were empty (fresh process state), so every task saw `load=0` on the same host. 9 concurrent SSH sessions landed on `remote_digital_ocean_1` (157.230.133.215), causing .git/config lock contention, heartbeat stalls, and cascading autofix triggers.

---

## Bug 1 — over-limit fallback in `selectPoolMember()`

**File:** `packages/execution-engine/src/task-runner.ts`

When `leastLoaded` strategy was active and all members were at capacity, the fallback returned the full `scored` array instead of `undefined`, making the limit advisory rather than enforced.

```typescript
// BEFORE (broken): returns over-limit members when all are full
const candidates = scored.some((e) => e.hasCapacity)
  ? scored.filter((e) => e.hasCapacity)
  : scored;

// AFTER: hard block
const candidates = scored.filter((e) => e.hasCapacity);
if (candidates.length === 0) return undefined;
```

---

## Bug 2 — `Promise.all` race in `executeTaskInner()`

`executeTasks()` dispatches all ready tasks concurrently via `Promise.all`. SSH `executor.start()` takes 30+ seconds to complete. Tasks 2–N all enter `selectPoolMember()` before task 1 has finished registering its `pendingPoolSelections` entry, so they all observe `load=0` for the same member.

**Fix:** Introduce a per-pool promise-chain mutex (`poolSelectionLocks: Map<string, Promise<void>>`) via a new `withPoolSelectionLock(poolId, fn)` method. The `selectExecutor()` call — which atomically queries `selectPoolMember()` and writes `pendingPoolSelections` — is now serialised per `poolId` before `executor.start()` is awaited.

```typescript
executor = await this.withPoolSelectionLock(
  task.config.poolId ?? `_nopool_${task.id}`,
  () => this.selectExecutor(task, attemptedPoolMemberKeys),
);
```

---

## Tests

Two new `describe` blocks in `task-runner.test.ts`:

- **`selectPoolMember – maxConcurrentTasksPerMember hard cap (Bug 1)`** — verifies `undefined` is returned when a single-member pool is saturated; verifies the least-loaded member is selected when one has capacity.
- **`withPoolSelectionLock – serializes concurrent selections (Bug 2)`** — verifies that two concurrent `Promise.all` selections on a single-member pool result in exactly one successful selection and one `undefined`, not two successes.

**Result:** 974/974 tests pass, `tsc` clean.