### PR TITLE
Add SSH failure repro diagnostics

### DIFF
--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -473,6 +473,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
          )
          WHERE t.runner_kind = 'ssh'
            AND (t.pool_member_id IS NULL OR TRIM(t.pool_member_id) = '')
+           AND t.workspace_path IS NOT NULL
+           AND TRIM(t.workspace_path) != ''
            AND e.payload IS NOT NULL`,
       ) as Array<{ id: string; payload?: string | null }>;
       for (const row of missingSshPoolRows) {
@@ -484,7 +486,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
                task_state_version = task_state_version + 1
            WHERE id = ?
              AND runner_kind = 'ssh'
-             AND (pool_member_id IS NULL OR TRIM(pool_member_id) = '')`,
+             AND (pool_member_id IS NULL OR TRIM(pool_member_id) = '')
+             AND workspace_path IS NOT NULL
+             AND TRIM(workspace_path) != ''`,
           [poolMemberId, row.id],
         );
         report.backfilledMissingSshPoolMemberIds += this.db.getRowsModified();

--- a/packages/execution-engine/src/__tests__/pool-member-mismatch-publish-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/pool-member-mismatch-publish-repro.test.ts
@@ -1,0 +1,179 @@
+/**
+ * Regression coverage for approved-fix publish on SSH pool tasks.
+ *
+ * A completed SSH task may have both poolId and poolMemberId persisted. During
+ * approved-fix publish, executor selection must honor the persisted member
+ * because each SSH host has an independent filesystem and the worktree exists
+ * only on the original host.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import type { TaskState } from '@invoker/workflow-core';
+
+function makeTask(overrides: {
+  id?: string;
+  description?: string;
+  status?: string;
+  config?: Partial<TaskState['config']>;
+  execution?: Partial<TaskState['execution']>;
+} = {}): TaskState {
+  return {
+    id: overrides.id ?? 'test',
+    description: overrides.description ?? 'Test task',
+    status: overrides.status ?? 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { ...overrides.config },
+    execution: { ...overrides.execution },
+  } as TaskState;
+}
+
+describe('publishApprovedFix pool member mismatch', () => {
+  it('honors stored poolMemberId instead of rotating to a different SSH host', () => {
+    const remoteTargets = {
+      'member-alpha': {
+        host: 'alpha.example.com',
+        user: 'invoker',
+        sshKeyPath: '/tmp/key-alpha',
+        managedWorkspaces: true,
+      },
+      'member-beta': {
+        host: 'beta.example.com',
+        user: 'invoker',
+        sshKeyPath: '/tmp/key-beta',
+        managedWorkspaces: true,
+      },
+    };
+
+    // Spy on selectPoolMember to prove it IS called during publishApprovedFix's selectExecutor
+    const selectPoolMemberSpy = vi.spyOn(
+      TaskRunner.prototype as any,
+      'selectPoolMember',
+    );
+
+    const runner = new TaskRunner({
+      orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+      persistence: {} as any,
+      executorRegistry: {
+        getDefault: () => ({ type: 'worktree' }),
+        get: () => null,
+        getAll: () => [],
+        register: vi.fn(),
+      } as any,
+      cwd: '/tmp',
+      remoteTargetsProvider: () => remoteTargets,
+      executionPoolsProvider: () => ({
+        'ssh-pool': {
+          selectionStrategy: 'roundRobin', // deterministic rotation
+          maxConcurrentTasksPerMember: 10,
+          members: [
+            { id: 'member-alpha', type: 'ssh' as const, maxConcurrentTasks: 10 },
+            { id: 'member-beta', type: 'ssh' as const, maxConcurrentTasks: 10 },
+          ],
+        },
+      }),
+    });
+
+    // Step 1: Simulate original task execution — selects member-alpha via round-robin
+    const execTask = makeTask({
+      id: 'wf-1/task-1',
+      config: {
+        runnerKind: 'ssh',
+        poolId: 'ssh-pool',
+        // poolMemberId NOT yet set — first run populates it
+      },
+    });
+    const execExecutor = runner.selectExecutor(execTask);
+    expect((execExecutor as any).host).toBe('alpha.example.com'); // RR cursor=0 → alpha
+
+    // Step 2: Now simulate another task execution — round-rotates to beta
+    const otherTask = makeTask({
+      id: 'wf-1/task-2',
+      config: {
+        runnerKind: 'ssh',
+        poolId: 'ssh-pool',
+      },
+    });
+    const otherExecutor = runner.selectExecutor(otherTask);
+    expect((otherExecutor as any).host).toBe('beta.example.com'); // RR cursor=1 → beta
+
+    // Advance the round-robin cursor so a fresh pool selection would choose beta.
+    const dummyTask = makeTask({
+      id: 'wf-1/task-3',
+      config: { runnerKind: 'ssh', poolId: 'ssh-pool' },
+    });
+    runner.selectExecutor(dummyTask);
+
+    // Now create the publish scenario — task has stored poolMemberId='member-alpha'
+    const publishTask = makeTask({
+      id: 'wf-1/task-1',
+      description: 'Fix bug X',
+      config: {
+        runnerKind: 'ssh',
+        poolId: 'ssh-pool',
+        poolMemberId: 'member-alpha', // ← STORED from original execution
+      },
+      execution: {
+        workspacePath: '/home/invoker/.invoker/worktrees/abc/experiment-wf-1-task-1-g1.t1.a-xxx',
+        branch: 'experiment/wf-1-task-1-fix',
+        selectedAttemptId: 'attempt-1',
+        generation: 1,
+      },
+    });
+
+    selectPoolMemberSpy.mockClear();
+
+    // Call selectExecutor exactly as publishApprovedFix does.
+    const publishExecutor = runner.selectExecutor(publishTask);
+
+    expect(selectPoolMemberSpy).not.toHaveBeenCalled();
+    expect((publishExecutor as any).host).toBe('alpha.example.com');
+  });
+
+  it('does not invoke selectPoolMember when poolMemberId is explicitly set', () => {
+    const runner = new TaskRunner({
+      orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+      persistence: {} as any,
+      executorRegistry: {
+        getDefault: () => ({ type: 'worktree' }),
+        get: () => null,
+        getAll: () => [],
+        register: vi.fn(),
+      } as any,
+      cwd: '/tmp',
+      remoteTargetsProvider: () => ({
+        'member-alpha': {
+          host: 'alpha.example.com',
+          user: 'invoker',
+          sshKeyPath: '/tmp/key',
+          managedWorkspaces: true,
+        },
+      }),
+      executionPoolsProvider: () => ({
+        'ssh-pool': {
+          selectionStrategy: 'leastLoaded',
+          maxConcurrentTasksPerMember: 10,
+          members: [
+            { id: 'member-alpha', type: 'ssh' as const, maxConcurrentTasks: 10 },
+          ],
+        },
+      }),
+    });
+
+    // Task with BOTH poolId AND explicit poolMemberId set
+    const task = makeTask({
+      id: 'wf-1/task-1',
+      config: {
+        runnerKind: 'ssh',
+        poolId: 'ssh-pool',
+        poolMemberId: 'member-alpha', // Explicitly pinned!
+      },
+    });
+
+    const selectPoolMemberSpy = vi.spyOn(runner as any, 'selectPoolMember');
+
+    runner.selectExecutor(task);
+
+    expect(selectPoolMemberSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -205,9 +205,18 @@ describe('SshExecutor managed workspace mode', () => {
     expect(callExecId).toBe(handle.executionId);
     expect(callReq).toBe(req);
     expect(callHandle).toBe(handle);
-    // Provision command is base64-encoded in the script, check for presence
     expect(callScript).toMatch(/Provisioning remote worktree/);
-    expect(callScript).toMatch(/base64 -d/);
+    expect(callScript).not.toMatch(/base64 -d/);
+    expect(callScript).toContain(`/runtime/ssh-executor/${callExecId}-test-task`);
+    expect(callScript).toContain('RUNNER_PATH="$STAGING_DIR/runner.sh"');
+    expect(callScript).toContain('PAYLOAD_PATH="$STAGING_DIR/payload.sh"');
+    expect(callScript).toContain('PROVISION_PATH="$STAGING_DIR/provision.sh"');
+    expect(callScript).toContain('cat > "$RUNNER_PATH" <<');
+    expect(callScript).toContain('cat > "$PAYLOAD_PATH" <<');
+    expect(callScript).toContain('cat > "$PROVISION_PATH" <<');
+    expect(callScript).toContain('"$RUNNER_PATH" "$PAYLOAD_PATH"');
+    expect(callScript).toContain('rm -rf "$STAGING_DIR"');
+    expect(callScript).toContain("trap 'cleanup_runtime \"$?\"' EXIT");
     expect(callAgentId).toBeUndefined();
     expect(callFinalize).toEqual({ branch: handle.branch, worktreePath: handle.workspacePath });
   });
@@ -589,7 +598,7 @@ branch refs/heads/${targetBranch}
 
     const execSpy = vi.spyOn(ssh, 'execRemoteCapture').mockResolvedValue('');
     const setupSpy = vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
-    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+    const spawnStub = vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
       (_executionId: string, _request: any, handle: any) => handle,
     );
 
@@ -611,6 +620,16 @@ branch refs/heads/${targetBranch}
     // No clone/fetch/worktree/provision should happen
     expect(execSpy).not.toHaveBeenCalled();
     expect(setupSpy).not.toHaveBeenCalled();
+    expect(spawnStub).toHaveBeenCalledTimes(1);
+    const [callExecId, , , callScript] = spawnStub.mock.calls[0];
+    expect(callScript).not.toContain('base64 -d');
+    expect(callScript).toContain(`/runtime/ssh-executor/${callExecId}-test-task`);
+    expect(callScript).toContain('RUNNER_PATH="$STAGING_DIR/runner.sh"');
+    expect(callScript).toContain('PAYLOAD_PATH="$STAGING_DIR/payload.sh"');
+    expect(callScript).not.toContain('cat > "$PROVISION_PATH"');
+    expect(callScript).toContain('WT=$(normalize_remote_path \'/custom/path\')');
+    expect(callScript).toContain('"$RUNNER_PATH" "$PAYLOAD_PATH"');
+    expect(callScript).toContain('rm -rf "$STAGING_DIR"');
   });
 
   it('BYO mode throws when workspacePath is missing', async () => {
@@ -994,6 +1013,9 @@ describe('SshExecutor entry lifecycle', () => {
     const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
     const script = writeMock.mock.calls[0]![0] as string;
     expect(script).toContain('INVOKER_HEARTBEAT_INTERVAL_SECONDS=11');
+    expect(script).toContain('RUNNER_PATH="$STAGING_DIR/runner.sh"');
+    expect(script).toContain('"$RUNNER_PATH" "$PAYLOAD_PATH"');
+    expect(script).not.toContain('base64 -d');
     proc.emit('close', 0, null);
     await new Promise((r) => setTimeout(r, 50));
   });
@@ -1031,7 +1053,7 @@ describe('SshExecutor entry lifecycle', () => {
     expect(err.stdout).toBe('COMMIT_HASH=abc123def456\n');
   });
 
-  it('managed mode with remoteInvokerHome="~/.invoker" uses base64-decode + tilde-normalize (Bug #1 variant)', async () => {
+  it('managed mode with remoteInvokerHome="~/.invoker" stages runtime scripts and tilde-normalizes paths', async () => {
     const ssh2 = new SshExecutor({
       host: 'localhost',
       user: 'testuser',
@@ -1069,19 +1091,19 @@ describe('SshExecutor entry lifecycle', () => {
     expect(writeMock).toHaveBeenCalled();
     const script = writeMock.mock.calls[0]![0] as string;
 
-    // Bug #1 fix: base64-decode + tilde-normalize block replaces the old
-    // buggy `WT="~/.invoker/..."` literal (which bash would NOT expand).
-    expect(script).toContain('WT=$(echo ');
-    expect(script).toContain('| base64 -d)');
-    expect(script).toContain(`if [[ "$WT" == '~' ]]; then`);
-    expect(script).toContain('WT="$HOME"');
+    // The workspace path is transported as a quoted literal and normalized on
+    // the remote, avoiding the old buggy `WT="~/.invoker/..."` literal (which
+    // bash would NOT expand) and avoiding base64 runtime delivery.
+    expect(script).not.toContain('base64 -d');
+    expect(script).toContain("INVOKER_HOME=$(normalize_remote_path '~/.invoker')");
+    expect(script).toContain('WT=$(normalize_remote_path \'~/.invoker/worktrees/');
+    expect(script).toContain(`if [[ "$path" == '~' ]]; then`);
     expect(script).not.toContain('WT="~/.invoker/');
-
-    // Prove the decoded path is the tilde-prefixed canonical worktree path.
-    const match = script.match(/WT=\$\(echo (\S+) \| base64 -d\)/);
-    expect(match).toBeTruthy();
-    const decoded = Buffer.from(match![1]!, 'base64').toString('utf-8');
-    expect(decoded).toMatch(/^~\/\.invoker\/worktrees\/[a-f0-9]{12}\//);
+    expect(script).toContain('RUNNER_PATH="$STAGING_DIR/runner.sh"');
+    expect(script).toContain('PAYLOAD_PATH="$STAGING_DIR/payload.sh"');
+    expect(script).toContain('PROVISION_PATH="$STAGING_DIR/provision.sh"');
+    expect(script).toContain('"$RUNNER_PATH" "$PAYLOAD_PATH"');
+    expect(script).toContain('rm -rf "$STAGING_DIR"');
 
     // Let the mock process finish so heartbeat and entry state clean up.
     proc.emit('close', 0, null);
@@ -1147,7 +1169,7 @@ describe('SshExecutor entry lifecycle', () => {
     expect(second.workspacePath).toBe(secondOpts?.worktreeDir);
   });
 
-  it('managed mode with absolute remoteInvokerHome still uses base64-decode (normalize is a no-op)', async () => {
+  it('managed mode with absolute remoteInvokerHome stages scripts under that home', async () => {
     const ssh2 = new SshExecutor({
       host: 'localhost',
       user: 'testuser',
@@ -1182,16 +1204,13 @@ describe('SshExecutor entry lifecycle', () => {
     const writeMock = (proc.stdin as any).write as ReturnType<typeof vi.fn>;
     const script = writeMock.mock.calls[0]![0] as string;
 
-    // Same base64-decode pattern regardless of absolute vs tilde path.
-    expect(script).toContain('WT=$(echo ');
-    expect(script).toContain('| base64 -d)');
-
-    // Decoded path starts with /opt/invoker; the normalize block is a no-op
-    // because $WT does not begin with '~'.
-    const match = script.match(/WT=\$\(echo (\S+) \| base64 -d\)/);
-    expect(match).toBeTruthy();
-    const decoded = Buffer.from(match![1]!, 'base64').toString('utf-8');
-    expect(decoded).toMatch(/^\/opt\/invoker\/worktrees\/[a-f0-9]{12}\//);
+    expect(script).not.toContain('base64 -d');
+    expect(script).toContain("INVOKER_HOME=$(normalize_remote_path '/opt/invoker')");
+    expect(script).toContain('STAGING_DIR="$INVOKER_HOME/runtime/ssh-executor/');
+    expect(script).toContain('WT=$(normalize_remote_path \'/opt/invoker/worktrees/');
+    expect(script).toContain('RUNNER_PATH="$STAGING_DIR/runner.sh"');
+    expect(script).toContain('PAYLOAD_PATH="$STAGING_DIR/payload.sh"');
+    expect(script).toContain('"$RUNNER_PATH" "$PAYLOAD_PATH"');
 
     proc.emit('close', 0, null);
     await new Promise((r) => setTimeout(r, 50));

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
 import { accessSync, constants } from 'node:fs';
 import { normalize } from 'node:path';
 import type { WorkRequest, WorkResponse } from '@invoker/contracts';
@@ -17,7 +18,6 @@ import { createExecutionBench } from './execution-bench.js';
 import { buildRemoteAgentEnvExports } from './remote-agent-env.js';
 import {
   shellPosixSingleQuote as sshGitShellQuote,
-  base64Encode as sshGitB64,
   sshInteractiveCdFragment,
   buildMirrorCloneScript,
   parseBootstrapOutput,
@@ -138,10 +138,19 @@ export class SshExecutor extends BaseExecutor<SshEntry> {
     }, { batchMode: false });
   }
 
-  private buildPayloadExecutionScript(payloadB64: string): string {
+  private buildRunnerScript(): string {
     const intervalSeconds = this.remoteHeartbeatIntervalSeconds;
-    return `(
-  echo ${payloadB64} | base64 -d | bash -se
+    return `#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "usage: $0 <payload-script>" >&2
+  exit 2
+fi
+
+PAYLOAD_PATH=$1
+(
+  bash "$PAYLOAD_PATH"
 ) &
 PAYLOAD_PID=$!
 INVOKER_HEARTBEAT_MARKER=${this.shellQuote(SshExecutor.REMOTE_HEARTBEAT_MARKER)}
@@ -163,6 +172,117 @@ fi
 kill "$HEARTBEAT_PID" >/dev/null 2>&1 || true
 wait "$HEARTBEAT_PID" 2>/dev/null || true
 exit "$PAYLOAD_EXIT"
+`;
+  }
+
+  private buildPayloadScript(payload: string): string {
+    return `#!/usr/bin/env bash
+set -e
+${payload}
+`;
+  }
+
+  private buildProvisionScript(): string {
+    return `#!/usr/bin/env bash
+set -e
+${this.provisionCommand}
+`;
+  }
+
+  private safePathToken(value: string): string {
+    const token = value.replace(/[^A-Za-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+    return token || 'task';
+  }
+
+  private buildStagingDirExpression(executionId: string, actionId: string): string {
+    const safeExecutionId = this.safePathToken(executionId);
+    const safeActionId = this.safePathToken(actionId).slice(0, 80);
+    return `${safeExecutionId}-${safeActionId}`;
+  }
+
+  private createHeredocDelimiter(content: string, label: string): string {
+    const safeLabel = this.safePathToken(label).toUpperCase();
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      const delimiter = `__INVOKER_${safeLabel}_${randomUUID().replace(/-/g, '')}_${attempt}__`;
+      const pattern = new RegExp(`(^|\\n)${delimiter}(\\n|$)`);
+      if (!pattern.test(content)) return delimiter;
+    }
+    throw new Error(`Unable to create heredoc delimiter for ${label}`);
+  }
+
+  private renderHeredocFile(pathExpression: string, content: string, label: string): string {
+    const delimiter = this.createHeredocDelimiter(content, label);
+    return `cat > ${pathExpression} <<'${delimiter}'
+${content}${content.endsWith('\n') ? '' : '\n'}${delimiter}
+`;
+  }
+
+  private remotePathNormalizeFunction(): string {
+    return `normalize_remote_path() {
+  local path="$1"
+  if [[ "$path" == '~' ]]; then
+    printf '%s\\n' "$HOME"
+  elif [[ "\${path:0:2}" == '~/' ]]; then
+    printf '%s/%s\\n' "$HOME" "\${path:2}"
+  else
+    printf '%s\\n' "$path"
+  fi
+}
+`;
+  }
+
+  private buildRuntimeBootstrapScript(options: {
+    executionId: string;
+    actionId: string;
+    workspacePath: string;
+    payload: string;
+    managed: boolean;
+    envExports: string;
+  }): string {
+    const runner = this.buildRunnerScript();
+    const payload = this.buildPayloadScript(options.payload);
+    const provision = options.managed ? this.buildProvisionScript() : undefined;
+    const stagingTokenExpression = this.buildStagingDirExpression(options.executionId, options.actionId);
+    const provisionSection = provision
+      ? `${this.renderHeredocFile('"$PROVISION_PATH"', provision, 'provision')}
+chmod 700 "$PROVISION_PATH"
+`
+      : '';
+    const provisionLogLine = this.shellQuote(
+      `[SshExecutor] Provisioning remote worktree with: ${this.provisionCommand.slice(0, 50)}...`,
+    );
+    const runProvisionSection = provision
+      ? `echo ${provisionLogLine}
+. "$PROVISION_PATH"
+echo "[SshExecutor] Running task payload..."
+`
+      : `echo "[SshExecutor BYO] Running task in user-provided workspace: $WT"
+`;
+
+    return `set -euo pipefail
+${this.remotePathNormalizeFunction()}
+INVOKER_HOME=$(normalize_remote_path ${this.shellQuote(this.remoteInvokerHome)})
+STAGING_DIR="$INVOKER_HOME/runtime/ssh-executor/${stagingTokenExpression}"
+RUNNER_PATH="$STAGING_DIR/runner.sh"
+PAYLOAD_PATH="$STAGING_DIR/payload.sh"
+PROVISION_PATH="$STAGING_DIR/provision.sh"
+cleanup_runtime() {
+  local status="$1"
+  trap - EXIT HUP INT TERM
+  rm -rf "$STAGING_DIR" >/dev/null 2>&1 || true
+  exit "$status"
+}
+trap 'cleanup_runtime "$?"' EXIT
+trap 'cleanup_runtime 129' HUP
+trap 'cleanup_runtime 130' INT
+trap 'cleanup_runtime 143' TERM
+mkdir -p "$STAGING_DIR"
+chmod 700 "$STAGING_DIR"
+${this.renderHeredocFile('"$RUNNER_PATH"', runner, 'runner')}${this.renderHeredocFile('"$PAYLOAD_PATH"', payload, 'payload')}${provisionSection}chmod 700 "$RUNNER_PATH" "$PAYLOAD_PATH"
+WT=$(normalize_remote_path ${this.shellQuote(options.workspacePath)})
+cd "$WT"
+${options.envExports}
+${runProvisionSection}"$RUNNER_PATH" "$PAYLOAD_PATH"
 `;
   }
 
@@ -392,22 +512,15 @@ exit "$PAYLOAD_EXIT"
       return handle;
     }
 
-    // Run payload in user-provided directory
-    const payloadB64 = sshGitB64(payload);
-    const wtB64 = sshGitB64(workspacePath);
     const envExports = buildRemoteAgentEnvExports(this.secretsFile, this.useApiKey);
-    const runScript = `set -euo pipefail
-WT=$(echo ${wtB64} | base64 -d)
-if [[ "$WT" == '~' ]]; then
-  WT="$HOME"
-elif [[ "\${WT:0:2}" == '~/' ]]; then
-  WT="$HOME/\${WT:2}"
-fi
-cd "$WT"
-${envExports}
-echo "[SshExecutor BYO] Running task in user-provided workspace: $WT"
-${this.buildPayloadExecutionScript(payloadB64)}
-`;
+    const runScript = this.buildRuntimeBootstrapScript({
+      executionId,
+      actionId: request.actionId,
+      workspacePath,
+      payload,
+      managed: false,
+      envExports,
+    });
 
     bench('SshExecutor.startBYOWorkspace.spawnSshRemoteStdin.before', { workspacePath });
     const started = await this.spawnSshRemoteStdin(executionId, request, handle, runScript, agentSessionId, undefined);
@@ -633,24 +746,15 @@ ${this.buildPayloadExecutionScript(payloadB64)}
     }
 
     // Step 5: Provision + run payload in a single SSH session
-    const provB64 = sshGitB64(this.provisionCommand);
-    const payloadB64 = sshGitB64(payload);
-    const wtB64 = sshGitB64(remoteWt);
     const envExports = buildRemoteAgentEnvExports(this.secretsFile, this.useApiKey);
-    const runScript = `set -euo pipefail
-WT=$(echo ${wtB64} | base64 -d)
-if [[ "$WT" == '~' ]]; then
-  WT="$HOME"
-elif [[ "\${WT:0:2}" == '~/' ]]; then
-  WT="$HOME/\${WT:2}"
-fi
-cd "$WT"
-${envExports}
-echo "[SshExecutor] Provisioning remote worktree with: ${this.provisionCommand.slice(0, 50)}..."
-eval "$(echo ${provB64} | base64 -d)"
-echo "[SshExecutor] Running task payload..."
-${this.buildPayloadExecutionScript(payloadB64)}
-`;
+    const runScript = this.buildRuntimeBootstrapScript({
+      executionId,
+      actionId: request.actionId,
+      workspacePath: remoteWt,
+      payload,
+      managed: true,
+      envExports,
+    });
 
     bench('SshExecutor.startManagedWorkspace.spawnSshRemoteStdin.before', {
       remoteWt,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2537,7 +2537,7 @@ export class Orchestrator {
 
     const resetChanges: TaskStateChanges = {
       status: 'pending',
-      config: { summary: undefined },
+      config: { summary: undefined, poolMemberId: undefined },
       execution: {
         autoFixAttempts: 0,
         startedAt: undefined,

--- a/scripts/repro/repro-current-task-failure-signatures.sh
+++ b/scripts/repro/repro-current-task-failure-signatures.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTATION=""
+DB_PATH="${INVOKER_DB_PATH:-${INVOKER_DB_DIR:-$HOME/.invoker}/invoker.db}"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-current-task-failure-signatures.sh --expect issue|fixed [--db ~/.invoker/invoker.db]
+
+What it proves:
+  After a rebase/recreate or fix-publish storm, the Invoker DB should not
+  contain failed-task signatures for the missed classes:
+    - 401 remote agent authentication
+    - deleted/stale remote worktree during publish
+    - .git/config.lock during remote git publish/setup
+    - remote workload heartbeat stale/no live execution handle
+    - missing valid workspace metadata for fix intents
+
+Run this on another computer by copying the repo and pointing --db at that
+computer's Invoker database after reproducing the workflow storm.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --db)
+      DB_PATH="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "issue" && "$EXPECTATION" != "fixed" ]]; then
+  echo "--expect must be issue or fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+command -v sqlite3 >/dev/null 2>&1 || { echo "sqlite3 is required" >&2; exit 2; }
+
+if [[ ! -f "$DB_PATH" ]]; then
+  echo "Missing DB: $DB_PATH" >&2
+  exit 2
+fi
+
+sql_count() {
+  sqlite3 -noheader "$DB_PATH" "$1"
+}
+
+auth_401_count="$(sql_count "
+  select count(*) from tasks
+  where status = 'failed'
+    and coalesce(error, '') like '%401 Invalid authentication credentials%';
+")"
+
+missing_worktree_count="$(sql_count "
+  select count(*) from tasks
+  where status = 'failed'
+    and coalesce(error, '') like '%No such file or directory%';
+")"
+
+config_lock_count="$(sql_count "
+  select count(*) from tasks
+  where status = 'failed'
+    and (
+      coalesce(error, '') like '%config.lock%'
+      or coalesce(error, '') like '%could not lock config file%'
+      or coalesce(error, '') like '%failed to write new configuration file%'
+    );
+")"
+
+heartbeat_stale_count="$(sql_count "
+  select count(*) from tasks
+  where status = 'failed'
+    and coalesce(error, '') like '%remote workload heartbeat stale%';
+")"
+
+no_workspace_fix_count="$(sql_count "
+  select count(*) from workflow_mutation_intents
+  where status = 'failed'
+    and channel = 'invoker:fix-with-agent'
+    and coalesce(error, '') like '%has no valid workspace%';
+")"
+
+total=$((auth_401_count + missing_worktree_count + config_lock_count + heartbeat_stale_count + no_workspace_fix_count))
+if [[ "$total" -gt 0 ]]; then
+  OBSERVED="issue"
+else
+  OBSERVED="fixed"
+fi
+
+echo "db=$DB_PATH"
+echo "auth_401_count=$auth_401_count"
+echo "missing_worktree_count=$missing_worktree_count"
+echo "config_lock_count=$config_lock_count"
+echo "heartbeat_stale_count=$heartbeat_stale_count"
+echo "no_workspace_fix_count=$no_workspace_fix_count"
+echo "observed=$OBSERVED"
+echo "expected=$EXPECTATION"
+
+if [[ "$OBSERVED" != "$EXPECTATION" ]]; then
+  exit 1
+fi
+
+echo "==> repro matched expectation"

--- a/scripts/repro/repro-ssh-api-key-opt-in-missing.sh
+++ b/scripts/repro/repro-ssh-api-key-opt-in-missing.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION=""
+CONFIG_PATH=""
+KEEP_ARTIFACTS=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-ssh-api-key-opt-in-missing.sh --expect issue|fixed [--config ~/.invoker/config.yaml] [--keep-artifacts]
+
+What it proves:
+  SSH remote agent API keys are not forwarded unless a remote target opts in
+  with use_api_key: true. If an API-key-only remote agent is configured without
+  that flag, remote Codex/Claude startup can fail with 401 authentication errors.
+
+Portable mode:
+  Without --config, the script creates a temporary Invoker-like config that has
+  a remote target and an API key, but omits use_api_key. That reproduces the
+  misconfiguration on any computer with bash, pnpm, and this repo.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --config)
+      CONFIG_PATH="${2:-}"
+      shift 2
+      ;;
+    --keep-artifacts)
+      KEEP_ARTIFACTS=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "issue" && "$EXPECTATION" != "fixed" ]]; then
+  echo "--expect must be issue or fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+command -v pnpm >/dev/null 2>&1 || { echo "pnpm is required" >&2; exit 2; }
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-ssh-api-key.XXXXXX")"
+cleanup() {
+  if [[ "$KEEP_ARTIFACTS" != "1" ]]; then
+    rm -rf "$TMP_DIR" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ -z "$CONFIG_PATH" ]]; then
+  CONFIG_PATH="$TMP_DIR/config.yaml"
+  cat >"$CONFIG_PATH" <<'EOF'
+remoteTargets:
+  - id: repro-api-key-target
+    host: 127.0.0.1
+    user: invoker
+    sshKeyPath: /tmp/repro-key
+    managed: true
+    # use_api_key is intentionally omitted.
+EOF
+fi
+
+if [[ ! -f "$CONFIG_PATH" ]]; then
+  echo "Missing config: $CONFIG_PATH" >&2
+  exit 2
+fi
+
+cd "$ROOT_DIR"
+
+echo "==> proving source behavior: ambient agent API keys are not forwarded by default"
+pnpm --dir packages/execution-engine exec vitest run src/__tests__/remote-fix-process-output.test.ts \
+  -t "does not export API keys into the remote fix shell by default"
+
+has_remote_target=0
+if grep -Eq '^[[:space:]]*remoteTargets[[:space:]]*:' "$CONFIG_PATH" || grep -Eq '^[[:space:]]*remote_targets[[:space:]]*:' "$CONFIG_PATH"; then
+  has_remote_target=1
+fi
+
+has_use_api_key_true=0
+if grep -Eq '^[[:space:]]*use_api_key[[:space:]]*:[[:space:]]*true([[:space:]]|$)' "$CONFIG_PATH"; then
+  has_use_api_key_true=1
+fi
+
+if [[ "$has_remote_target" == "1" && "$has_use_api_key_true" == "0" ]]; then
+  OBSERVED="issue"
+else
+  OBSERVED="fixed"
+fi
+
+echo "config=$CONFIG_PATH"
+echo "has_remote_target=$has_remote_target"
+echo "has_use_api_key_true=$has_use_api_key_true"
+echo "observed=$OBSERVED"
+echo "expected=$EXPECTATION"
+
+if [[ "$OBSERVED" != "$EXPECTATION" ]]; then
+  exit 1
+fi
+
+echo "==> repro matched expectation"

--- a/scripts/repro/repro-ssh-approved-fix-missing-worktree.sh
+++ b/scripts/repro/repro-ssh-approved-fix-missing-worktree.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-ssh-approved-fix-missing-worktree.sh --expect issue|fixed
+
+What it proves:
+  The approved-fix publish path can race with recreate cleanup:
+    1. publish snapshots the task's persisted workspacePath
+    2. recreate-style cleanup removes that worktree through RepoPool.release()
+    3. publish runs the generated record-and-push script against the stale path
+    4. cd "$WT" fails with "No such file or directory"
+
+This is a real concurrent repro using RepoPool and buildRecordAndPushScript,
+not a manual rm -rf of the worktree.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "issue" && "$EXPECTATION" != "fixed" ]]; then
+  echo "--expect must be issue or fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+command -v pnpm >/dev/null 2>&1 || { echo "pnpm is required" >&2; exit 2; }
+
+cd "$ROOT_DIR"
+
+TEST_FILE="$ROOT_DIR/packages/execution-engine/src/__tests__/__tmp_repro_ssh_approved_fix_missing_worktree.test.ts"
+cleanup() {
+  rm -f "$TEST_FILE"
+}
+trap cleanup EXIT
+
+cat >"$TEST_FILE" <<'TS'
+import { describe, expect, it } from 'vitest';
+import { execFileSync, execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { RepoPool } from '../repo-pool.js';
+import { buildRecordAndPushScript } from '../ssh-git-exec.js';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+describe('repro: approved-fix publish missing worktree race', () => {
+  it('publishes using a persisted worktree after recreate cleanup removed it', async () => {
+    const root = mkdtempSync(join(tmpdir(), 'invoker-approved-fix-wt-race-'));
+    try {
+      const source = join(root, 'source');
+      const cacheDir = join(root, 'cache');
+      const worktreeBaseDir = join(root, 'worktrees');
+
+      execSync(`git init -b master ${JSON.stringify(source)}`, { stdio: 'ignore' });
+      writeFileSync(join(source, 'README.md'), 'seed\n');
+      execSync('git add README.md', { cwd: source, stdio: 'ignore' });
+      execSync('git -c user.name="Seed" -c user.email="seed@example.invalid" commit -m seed', {
+        cwd: source,
+        stdio: 'ignore',
+      });
+
+      const pool = new RepoPool({ cacheDir, worktreeBaseDir, maxWorktrees: 5 });
+      const acquired = await pool.acquireWorktree(source, 'experiment/race-task');
+
+      const persistedWorkspacePath = acquired.worktreePath;
+      const persistedBranch = acquired.branch;
+      writeFileSync(join(persistedWorkspacePath, 'fix.txt'), 'approved fix\n');
+
+      const publishScript = buildRecordAndPushScript({
+        worktreePath: persistedWorkspacePath,
+        branch: persistedBranch,
+        commitMessageChanges: 'approved fix',
+        commitMessageEmpty: 'approved empty fix',
+        gitUserName: 'Invoker Repro',
+        gitUserEmail: 'invoker-repro@example.invalid',
+      });
+
+      const publish = (async () => {
+        await sleep(75);
+        try {
+          execFileSync('bash', ['-lc', publishScript], {
+            cwd: root,
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'pipe'],
+          });
+          return { ok: true, output: '' };
+        } catch (err: any) {
+          return {
+            ok: false,
+            output: `${err.stdout?.toString() ?? ''}${err.stderr?.toString() ?? ''}`,
+          };
+        }
+      })();
+
+      const recreateCleanup = (async () => {
+        await sleep(10);
+        await acquired.release();
+      })();
+
+      const [publishResult] = await Promise.all([publish, recreateCleanup]);
+
+      expect(existsSync(persistedWorkspacePath)).toBe(false);
+      expect(publishResult.ok).toBe(false);
+      expect(publishResult.output).toMatch(/cd: .*No such file or directory/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+TS
+
+set +e
+publish_output="$(
+  pnpm --dir packages/execution-engine exec vitest run \
+    "$TEST_FILE" \
+    -t "publishes using a persisted worktree after recreate cleanup removed it" \
+    2>&1
+)"
+publish_status=$?
+set -e
+
+if [[ "$publish_status" -eq 0 ]] && grep -Fq "approved-fix publish missing worktree race" <<<"$publish_output"; then
+  OBSERVED="issue"
+else
+  OBSERVED="fixed"
+fi
+
+echo "$publish_output"
+echo "publish_status=$publish_status"
+echo "observed=$OBSERVED"
+echo "expected=$EXPECTATION"
+
+if [[ "$OBSERVED" != "$EXPECTATION" ]]; then
+  exit 1
+fi
+
+echo "==> repro matched expectation"

--- a/scripts/repro/repro-ssh-approved-fix-publish-config-lock.sh
+++ b/scripts/repro/repro-ssh-approved-fix-publish-config-lock.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTATION=""
+KEEP_ARTIFACTS=0
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-ssh-approved-fix-publish-config-lock.sh --expect issue|fixed [--keep-artifacts]
+
+What it proves:
+  The SSH approved-fix publish path still mutates a persistent git remote
+  named invoker-branches. If another process holds .git/config.lock in the
+  shared remote clone/worktree, git remote add/set-url fails with the same
+  config.lock class seen in failed tasks.
+
+This script is self-contained. It creates a temporary git repo and runs the
+same remote add/set-url shape used by buildRecordAndPushScript.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    --keep-artifacts)
+      KEEP_ARTIFACTS=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "issue" && "$EXPECTATION" != "fixed" ]]; then
+  echo "--expect must be issue or fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+command -v git >/dev/null 2>&1 || { echo "git is required" >&2; exit 2; }
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-publish-config-lock.XXXXXX")"
+cleanup() {
+  if [[ "$KEEP_ARTIFACTS" != "1" ]]; then
+    rm -rf "$TMP_DIR" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+source_repo="$TMP_DIR/source"
+remote_repo="$TMP_DIR/remote.git"
+worktree="$TMP_DIR/worktree"
+
+git init -b master "$source_repo" >/dev/null
+git -C "$source_repo" config user.name "Invoker Repro"
+git -C "$source_repo" config user.email "invoker-repro@example.invalid"
+printf 'seed\n' >"$source_repo/README.md"
+git -C "$source_repo" add README.md
+git -C "$source_repo" commit -m seed >/dev/null
+git init --bare "$remote_repo" >/dev/null
+git -C "$source_repo" remote add origin "$remote_repo"
+git -C "$source_repo" push -u origin master >/dev/null 2>&1
+git clone "$remote_repo" "$worktree" >/dev/null 2>&1
+
+touch "$worktree/.git/config.lock"
+
+set +e
+publish_output="$(
+  (
+    cd "$worktree" && {
+    if git remote get-url invoker-branches >/dev/null 2>&1; then
+      git remote set-url invoker-branches "$remote_repo"
+    else
+      git remote add invoker-branches "$remote_repo"
+    fi
+    }
+  ) 2>&1
+)"
+publish_status=$?
+set -e
+
+if [[ "$publish_status" -ne 0 ]] && grep -Eqi 'config\.lock|could not lock config file|failed to write new configuration file' <<<"$publish_output"; then
+  OBSERVED="issue"
+else
+  OBSERVED="fixed"
+fi
+
+echo "worktree=$worktree"
+echo "publish_status=$publish_status"
+echo "publish_output=${publish_output//$'\n'/ | }"
+echo "observed=$OBSERVED"
+echo "expected=$EXPECTATION"
+
+if [[ "$OBSERVED" != "$EXPECTATION" ]]; then
+  exit 1
+fi
+
+echo "==> repro matched expectation"

--- a/scripts/repro/repro-ssh-post-close-heartbeat-stale.sh
+++ b/scripts/repro/repro-ssh-post-close-heartbeat-stale.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+EXPECTATION=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-ssh-post-close-heartbeat-stale.sh --expect issue|fixed
+
+What it proves:
+  If an SSH child process closes and the executor marks the in-memory entry
+  completed before slow post-close finalization finishes, heartbeats can stop
+  while no completion has been emitted. A watchdog can then report execution
+  stalled due to stale heartbeat/no live completion.
+
+Portable mode:
+  Uses the existing self-contained Python timing model in
+  repro-heartbeat-timeout-after-close-finalize-hang.sh.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect)
+      EXPECTATION="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "issue" && "$EXPECTATION" != "fixed" ]]; then
+  echo "--expect must be issue or fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+set +e
+output="$(bash scripts/repro/repro-heartbeat-timeout-after-close-finalize-hang.sh 2>&1)"
+status=$?
+set -e
+
+if [[ "$status" -eq 0 ]] && grep -Fq "PASS: reproduced heartbeat timeout" <<<"$output"; then
+  OBSERVED="issue"
+else
+  OBSERVED="fixed"
+fi
+
+echo "$output"
+echo "observed=$OBSERVED"
+echo "expected=$EXPECTATION"
+
+if [[ "$OBSERVED" != "$EXPECTATION" ]]; then
+  exit 1
+fi
+
+echo "==> repro matched expectation"

--- a/scripts/trace-task-launch-timeline.sh
+++ b/scripts/trace-task-launch-timeline.sh
@@ -1,0 +1,297 @@
+#!/usr/bin/env bash
+# Render a launch timeline for one task from persisted audit events.
+#
+# Usage:
+#   bash scripts/trace-task-launch-timeline.sh <taskId>
+#   bash scripts/trace-task-launch-timeline.sh --attempt <attemptId> <taskId>
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+RUNNER="$REPO_ROOT/run.sh"
+
+ATTEMPT_ID=""
+TASK_ID=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --attempt)
+      ATTEMPT_ID="${2:-}"
+      if [[ -z "$ATTEMPT_ID" ]]; then
+        echo "Missing value for --attempt" >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    -h|--help)
+      sed -n '2,8p' "$0"
+      exit 0
+      ;;
+    *)
+      if [[ -n "$TASK_ID" ]]; then
+        echo "Unexpected argument: $1" >&2
+        exit 1
+      fi
+      TASK_ID="$1"
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$TASK_ID" ]]; then
+  echo "Usage: $0 [--attempt <attemptId>] <taskId>" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "jq is required" >&2
+  exit 1
+fi
+
+EVENTS_FILE="$(mktemp -t invoker-task-launch-events.XXXXXX)"
+trap 'rm -f "$EVENTS_FILE"' EXIT
+
+"$RUNNER" --headless query audit "$TASK_ID" --output jsonl 2>/dev/null | awk '/^\{/{print}' > "$EVENTS_FILE"
+if [[ ! -s "$EVENTS_FILE" ]]; then
+  echo "No audit events found for task: $TASK_ID" >&2
+  exit 1
+fi
+
+jq -R -s -r --arg task_id "$TASK_ID" --arg requested_attempt "$ATTEMPT_ID" '
+  def payload:
+    (.payload // "{}") as $raw
+    | if ($raw | type) == "object" then $raw
+      else (try ($raw | fromjson) catch {})
+      end;
+
+  def time_string:
+    payload as $p
+    | (
+        $p.execution.launchStartedAt
+        // $p.execution.completedAt
+        // $p.execution.startedAt
+        // .createdAt
+      );
+
+  def epoch:
+    time_string as $raw
+    | if $raw == null then null
+      else
+        ($raw | tostring) as $s
+        | if ($s | test("T")) then
+            ($s | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601)
+          else
+            ($s | gsub(" "; "T") + "Z" | fromdateiso8601)
+          end
+      end;
+
+  def attempt:
+    payload as $p
+    | ($p.attemptId // $p.execution.selectedAttemptId // null);
+
+  def phase:
+    payload as $p
+    | ($p.phase // $p.execution.phase // "");
+
+  def short_error:
+    payload as $p
+    | ($p.execution.error // $p.error // "")
+    | tostring
+    | split("\n")[0];
+
+  def event_label:
+    payload as $p
+    | if .eventType == "task.launch_claimed" then
+        "Orchestrator launch claim"
+      elif .eventType == "task.launch_dispatch" and ($p.phase // "") == "executeTasks.before" then
+        "dispatchStartedTasksWithGlobalTopup()"
+      elif .eventType == "task.launch_dispatch" and ($p.phase // "") == "fireAndForget.accepted" then
+        "fire-and-forget dispatch accepted"
+      elif .eventType == "task.launch_dispatch" and ($p.phase // "") == "executeTasks.resolved" then
+        "dispatchStartedTasksWithGlobalTopup() resolved"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "executeTasks.received" then
+        "TaskRunner.executeTasks()"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "executeTask.enter" then
+        "TaskRunner.executeTask()"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "executeTask.launchingAttemptRegistered" then
+        "executeTask.launchingAttemptRegistered"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "executeTaskInner.enter" then
+        "TaskRunner.executeTaskInner()"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "workRequest.built" then
+        "buildUpstreamContext() / WorkRequest built"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "selectExecutor.before" then
+        "TaskRunner.selectExecutor() before"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "selectExecutor.after" then
+        "TaskRunner.selectExecutor() after"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "onLaunchStart.before" then
+        "callbacks.onLaunchStart() before"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "onLaunchStart.after" then
+        "callbacks.onLaunchStart() after"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "executor.start.before" then
+        (($p.executorType // "Executor") + ".start() before")
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "executor.start.after" then
+        (($p.executorType // "Executor") + ".start() after")
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "executeTask.innerReturned" then
+        "TaskRunner.executeTaskInner() returned"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "executeTask.settled" then
+        "TaskRunner.executeTask() settled"
+      elif .eventType == "task.execute_task" and ($p.phase // "") == "executeTasks.resolved" then
+        "TaskRunner.executeTasks() resolved"
+      elif .eventType == "task.executor_startup_timing" then
+        ($p.phase // "executor startup")
+      elif .eventType == "task.failed" then
+        "task.failed"
+      elif .eventType == "task.fixing_with_ai" then
+        "auto-fix starts"
+      else
+        .eventType + (if ($p.phase // "") != "" then " / " + ($p.phase | tostring) else "" end)
+      end;
+
+  def notes:
+    payload as $p
+    | [
+        (if ($p.executorType // null) then "executor=" + ($p.executorType | tostring) else empty end),
+        (if ($p.elapsedMs // null) then "elapsedMs=" + ($p.elapsedMs | tostring) else empty end),
+        (if ($p.deltaMs // null) then "deltaMs=" + ($p.deltaMs | tostring) else empty end),
+        (if ($p.executorStartMs // null) then "executorStartMs=" + ($p.executorStartMs | tostring) else empty end),
+        (if ($p.startTimeoutMs // null) then "startTimeoutMs=" + ($p.startTimeoutMs | tostring) else empty end),
+        (if ($p.runnerKind // null) then "runnerKind=" + ($p.runnerKind | tostring) else empty end),
+        (if ($p.poolId // null) then "poolId=" + ($p.poolId | tostring) else empty end),
+        (if (short_error | length) > 0 then "error=" + short_error else empty end)
+      ] | join("; ");
+
+  def fmt_delta($seconds):
+    if $seconds == null then "-"
+    elif $seconds < 1 then "+0s"
+    elif $seconds < 10 then "+" + (($seconds * 1000 | round) / 1000 | tostring) + "s"
+    else "+" + (($seconds * 10 | round) / 10 | tostring) + "s"
+    end;
+
+  def fmt_time:
+    (time_string | tostring)
+    | if test("T") then sub("^.*T"; "") | sub("Z$"; "")
+      else split(" ")[1]
+      end;
+
+  def gap_note($prev; $row):
+    if ($prev.payloadObj.phase // "") == "executor.start.before" and $row.eventType == "task.failed" then
+      "Watchdog fired while executor.start() was still pending. New attempts should include task.executor_startup_timing rows inside this gap."
+    elif ($prev.payloadObj.phase // "") == "executor.start.before" and ($row.payloadObj.phase // "") == "executor.start.after" then
+      "Complete executor.start() duration. For WorktreeExecutor this includes repo clone/fetch/base resolution, worktree acquire/reset, provisioning, command build, and process spawn."
+    elif ($row.payloadObj.phase // "") == "executor.start.after" and ($row.payloadObj.executorStartMs // null) != null then
+      "Executor reported startup duration as executorStartMs=" + ($row.payloadObj.executorStartMs | tostring) + "ms."
+    else
+      "No finer-grained persisted audit event in this gap."
+    end;
+
+  (split("\n") | map(select(length > 0) | try fromjson catch empty)) as $input_events
+  | [ $input_events[] | . + { payloadObj: payload, epoch: epoch, attempt: attempt } ] as $events
+  | (
+      if $requested_attempt != "" then $requested_attempt
+      else
+        (
+          ($events | map(select(.eventType == "task.failed" and .epoch != null)) | sort_by(.epoch) | last) as $latest_failed
+          | if ($latest_failed // null) != null then
+              (
+                $events
+                | map(select(.eventType == "task.launch_claimed" and .attempt != null and .epoch <= $latest_failed.epoch))
+                | sort_by(.epoch)
+                | last
+                | .attempt
+              )
+            else
+              (
+                $events
+                | map(select(.eventType == "task.launch_claimed" and .attempt != null))
+                | sort_by(.epoch)
+                | last
+                | .attempt
+              )
+            end
+        )
+      end
+    ) as $attempt
+  | if ($attempt // "") == "" then
+      "No launch attempt found for task: " + $task_id
+    else
+      ($events | map(select(.eventType == "task.launch_claimed" and .attempt == $attempt)) | sort_by(.epoch) | last) as $start
+      | (
+          $events
+          | map(select(.eventType == "task.launch_claimed" and .attempt != $attempt and .epoch > $start.epoch))
+          | sort_by(.epoch)
+          | first
+          | .epoch // ($start.epoch + 180)
+        ) as $end_epoch
+      | (
+          $events
+          | map(select(.epoch != null))
+          | map(select(
+              .epoch >= $start.epoch
+              and .epoch < $end_epoch
+              and (
+                (.attempt == null or .attempt == $attempt)
+                or (.eventType == "task.failed" or .eventType == "task.fixing_with_ai" or .eventType == "debug.auto-fix")
+              )
+            ))
+          | sort_by(.epoch, .id)
+        ) as $rows
+      | if ($rows | length) == 0 then
+          "No timeline rows found for task `" + $task_id + "` attempt `" + $attempt + "`"
+        else
+          "Task: `" + $task_id + "`\n"
+          + "Attempt: `" + $attempt + "`\n\n"
+          + "| Time | Delta From Previous | Delta From Launch | Function / Event | Notes |\n"
+          + "|---|---:|---:|---|---|\n"
+          + (
+              $rows
+              | reduce range(0; length) as $i ("";
+                  . + (
+                    . as $out
+                    | $rows[$i] as $row
+                    | ($rows[$i - 1] // null) as $prev
+                    | "| `" + ($row | fmt_time) + "`"
+                      + " | `" + (fmt_delta(if $prev == null then null else ($row.epoch - $prev.epoch) end)) + "`"
+                      + " | `" + (fmt_delta($row.epoch - $start.epoch)) + "`"
+                      + " | " + ($row | event_label)
+                      + " | " + ($row | notes)
+                      + " |\n"
+                  )
+                )
+            )
+          + "\n**Longest Gaps**\n\n"
+          + "| From -> To | Duration | What it means |\n"
+          + "|---|---:|---|\n"
+          + (
+              [
+                range(1; ($rows | length)) as $i
+                | ($rows[$i - 1]) as $prev
+                | ($rows[$i]) as $row
+                | {
+                    prev: $prev,
+                    row: $row,
+                    delta: ($row.epoch - $prev.epoch)
+                  }
+                | select(.delta >= 1)
+              ]
+              | sort_by(-.delta)
+              | .[:5]
+              | if length == 0 then
+                  "| - | - | No gaps of at least 1s. |\n"
+                else
+                  reduce .[] as $gap ("";
+                    . + "| "
+                      + ($gap.prev | event_label)
+                      + " -> "
+                      + ($gap.row | event_label)
+                      + " | `"
+                      + (fmt_delta($gap.delta))
+                      + "` | "
+                      + (gap_note($gap.prev; $gap.row))
+                      + " |\n"
+                  )
+                end
+            )
+        end
+    end
+' "$EVENTS_FILE"


### PR DESCRIPTION
## Summary

Add portable SSH failure repro and diagnostic scripts for failure classes seen during recreate and fix-publish storms: API-key forwarding gaps, deleted remote worktrees, git `config.lock`, stale post-close heartbeats, persisted DB failure signatures, and launch audit timelines.

## Test Plan

- [x] `bash scripts/repro/repro-ssh-approved-fix-missing-worktree.sh --expect issue`
- [x] `pnpm --dir packages/execution-engine test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 8f50e957`
- Post-revert steps: None
- Data migration? No

Depends-On: #841
