### PR TITLE
Add UI keyboard workflow plans

### DIFF
--- a/plans/context-menu-keyboard-navigation.yaml
+++ b/plans/context-menu-keyboard-navigation.yaml
@@ -1,0 +1,128 @@
+name: "Fix context menu keyboard navigation"
+description: |
+  Fixes context menus so a user can open a menu, press ArrowUp/ArrowDown to move through menu items, and press Enter or Space to execute the highlighted action.
+
+  Phase 1a static analysis found two root causes. The task context menu in packages/ui/src/components/ContextMenu.tsx defines ArrowUp/ArrowDown/Enter handling on the menu container, but the menu is rendered with tabIndex={-1} and never receives focus when opened, so normal document-level key presses do not reach that handler. The workflow context menu defined inline in packages/ui/src/App.tsx has no roving keyboard handler at all; it only closes on Escape through a document listener. App-level graph keyboard handling remains active while a menu is open, so Arrow keys and Enter can be consumed by graph navigation/open-menu behavior instead of menu selection.
+
+  Phase 1b repro added packages/ui/src/__tests__/context-menu-keyboard-repro.test.tsx locally and ran `cd packages/ui && pnpm test src/__tests__/context-menu-keyboard-repro.test.tsx`. The test opened a workflow context menu, pressed ArrowDown three times, pressed Enter, and expected Copy Workflow ID to call `navigator.clipboard.writeText('wf-1')`. It failed with zero clipboard calls, proving the open menu does not receive or execute keyboard navigation.
+
+  This plan adds durable regression coverage, implements accessible keyboard behavior for task and workflow menus, captures visual proof for the highlighted menu state, and ends with the full repository test suite. Because this is Invoker-on-Invoker work, publish the resulting GitHub PR stack with Mergify Stacks (`mergify stack push`) after the workflow is ready.
+visualProof: true
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: git@github.com:Neko-Catpital-Labs/Invoker.git
+baseBranch: stack/EdbertChan/prompt-terminal-configured-agent
+featureBranch: fix/context-menu-keyboard-navigation
+
+tasks:
+  - id: add-context-menu-keyboard-regression-tests
+    dependencies: []
+    prompt: "Assume no prior context. Goal: Add durable regression tests for open context menu keyboard navigation and activation in packages/ui/src/__tests__/context-menu-e2e.test.tsx, using packages/ui/src/__tests__/context-menu-keyboard-repro.test.tsx only as temporary source material if present. Motivation: A local repro proved that opening a workflow context menu, pressing ArrowDown three times, and pressing Enter does not call navigator.clipboard.writeText('wf-1'), so the tests must render the real App/menu components and dispatch keyboard events. Alternative considerations: Do not rely only on static checks and do not leave a permanent __tmp repro file; fold the repro into durable context menu coverage. Implementation details: Add tests that open workflow-node-wf-1, send ArrowDown three times and Enter from the active/document keyboard target, and expect navigator.clipboard.writeText to be called with wf-1; verify ArrowUp wraps deterministically; open a task context menu in the mini DAG, send ArrowDown then Enter, and expect the next enabled task action to call the mock API; verify Space activates the highlighted item as well as Enter. Acceptance criteria: Running cd packages/ui && pnpm test src/__tests__/context-menu-e2e.test.tsx must exit code 0 after the implementation task, and the new expectations must fail on the pre-fix behavior."
+    description: |
+      Layer: e2e_regression
+      Feature state: active
+      Goal:
+      Add failing-first regression coverage for keyboard navigation and activation in open context menus.
+      Motivation:
+      The verified repro shows that document-level ArrowDown and Enter do not execute the highlighted workflow menu item, and task menus have the same focus-delivery risk because their keyboard handler is only attached to an unfocused menu element.
+      Alternative considerations:
+      A static-only assertion would miss the event propagation and focus interaction between App-level graph shortcuts and menu shortcuts, so use rendered component tests that dispatch real keyboard events after opening the menus.
+      Implementation details:
+      Add component-level tests that open workflow and task context menus and assert ArrowUp/ArrowDown move the active item while Enter/Space execute the selected action.
+      Files:
+      packages/ui/src/__tests__/context-menu-e2e.test.tsx
+      packages/ui/src/__tests__/context-menu-keyboard-repro.test.tsx may be used as source material but should be folded into durable non-temporary coverage or removed after equivalent coverage exists.
+      Change types:
+      Test-only changes in the UI package.
+      Acceptance criteria:
+      Before the implementation fix, at least one new test must fail for the current defect. After the implementation fix, tests must prove workflow menu ArrowDown x3 + Enter executes Copy Workflow ID, task menu ArrowDown + Enter executes the next enabled task action, ArrowUp wraps to the last enabled item, and disabled task actions are skipped.
+
+  - id: implement-context-menu-keyboard-navigation
+    dependencies: []
+    prompt: "Assume no prior context. Goal: Implement keyboard navigation and activation for every Invoker context menu. Motivation: Static analysis found that packages/ui/src/components/ContextMenu.tsx has ArrowUp/ArrowDown/Enter handling but the menu uses tabIndex={-1} and never focuses itself when opened, while WorkflowContextMenu in packages/ui/src/App.tsx has no Arrow/Enter handler at all and App document keydown can consume graph shortcuts while a menu is open. Alternative considerations: Do not introduce a broad dependency or rewrite unrelated menu organization; keep the fix local to packages/ui/src/components/ContextMenu.tsx and packages/ui/src/App.tsx, using an optional helper such as packages/ui/src/lib/menu-keyboard.ts only if it clearly reduces duplication. Implementation details: Focus each menu on open with preventScroll; ensure ArrowDown and ArrowUp cycle through enabled menu items, skipping disabled task actions; ensure Enter and Space activate the highlighted enabled item; ensure handled keys call preventDefault and stopPropagation; make the More item reachable and keyboard-activatable; after More expands, move focus/highlight to a deterministic enabled item; keep Escape and outside-click dismissal; guard App-level graph shortcuts so open context menus own ArrowUp, ArrowDown, Enter, and Space. Acceptance criteria: cd packages/ui && pnpm test src/__tests__/context-menu-e2e.test.tsx must exit code 0, manual behavior must allow opening a menu, moving the visual highlight with ArrowUp/ArrowDown, activating with Enter or Space, closing after action, and preserving existing click behavior."
+    description: |
+      Layer: ui_activation
+      Feature state: active
+      Goal:
+      Make task and workflow context menus own ArrowUp/ArrowDown/Enter/Space while open.
+      Motivation:
+      Users should be able to operate context menus without switching to the mouse after the menu is visible. Current task menus do not focus their keyboard handler, workflow menus have no roving handler, and App-level graph shortcuts can consume the same keys while a menu is open.
+      Alternative considerations:
+      Replacing menus with a third-party menu library would be larger than needed. A small shared local helper or consistent duplicated pattern is enough if it keeps ARIA roles, focus, and menu item activation correct.
+      Implementation details:
+      Focus the menu on open, add or standardize roving active-index keyboard handling for both menus, stop handled menu key events from falling through to graph shortcuts, and keep Escape/outside-click dismissal intact.
+      Files:
+      packages/ui/src/components/ContextMenu.tsx
+      packages/ui/src/App.tsx
+      Optional shared helper under packages/ui/src/components/ or packages/ui/src/lib/ if it reduces duplication.
+      Change types:
+      UI behavior changes and small refactor if needed.
+      Acceptance criteria:
+      Opening either a task or workflow context menu must focus a keyboard event target. ArrowDown and ArrowUp must cycle through enabled role=menuitem controls, skipping disabled task actions. Enter and Space must execute the highlighted enabled action and close the menu. The More item must be reachable and activatable by keyboard, with focus moving to a sensible item after expansion. Escape and outside click dismissal must continue working. App graph keyboard shortcuts must not run for ArrowUp/ArrowDown/Enter/Space while a context menu is open.
+
+  - id: add-context-menu-visual-proof
+    dependencies: [implement-context-menu-keyboard-navigation]
+    prompt: "Assume no prior context. Goal: Add visual proof for context menu keyboard navigation in packages/app/e2e/visual-proof.spec.ts. Motivation: The implementation changes interactive menu focus and highlight behavior in packages/ui/, so reviewers need deterministic screenshot proof that the keyboard-selected menu item is visible. Alternative considerations: Do not add a standalone screenshot mechanism; use the existing captureScreenshot helper from packages/app/e2e/fixtures/electron-app.ts and the visual-proof.spec.ts conventions. Implementation details: Add a test under the existing Visual proof capture describe block that loads a stable plan, opens a workflow or task context menu, presses ArrowDown at least once, asserts the newly active menu item has the active/highlight styling or accessible marker added by the implementation, and calls captureScreenshot(page, 'context-menu-keyboard-navigation'). Acceptance criteria: pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after must produce the context-menu-keyboard-navigation capture with exit code 0; the test must be deterministic and avoid arbitrary sleeps."
+    description: |
+      Layer: e2e_regression
+      Feature state: active
+      Goal:
+      Add visual proof coverage for the keyboard-highlighted context menu state.
+      Motivation:
+      This plan modifies packages/ui/ interactive behavior. The review should include screenshot proof that keyboard focus/highlight is visible and that the menu remains visually coherent after keyboard navigation.
+      Alternative considerations:
+      Unit tests prove behavior but do not show the visual active state; visual-proof.spec.ts is the repo's existing screenshot surface for UI changes.
+      Implementation details:
+      Add a Playwright visual-proof test that opens a workflow or task context menu, presses ArrowDown to move the highlighted item, asserts the target menu item is keyboard-active, and captures a screenshot.
+      Files:
+      packages/app/e2e/visual-proof.spec.ts
+      Change types:
+      E2E visual proof test.
+      Acceptance criteria:
+      The test must use captureScreenshot from packages/app/e2e/fixtures/electron-app.ts with a stable label such as context-menu-keyboard-navigation. It must assert the menu is visible and that keyboard navigation changed the active/highlighted item before capturing.
+
+  - id: run-ui-context-menu-tests
+    command: "cd packages/ui && pnpm test src/__tests__/context-menu-e2e.test.tsx"
+    dependencies: [add-context-menu-keyboard-regression-tests, implement-context-menu-keyboard-navigation]
+    description: |
+      Layer: e2e_regression
+      Feature state: active
+      Goal:
+      Verify focused UI package coverage for context menu keyboard behavior.
+      Motivation:
+      The local repro failed in packages/ui, so the fastest deterministic confirmation is the targeted UI package test lane.
+      Alternative considerations:
+      Running only the full suite would make failures slower to diagnose; this task keeps the focused signal before broader gates.
+      Implementation details:
+      Run the UI package test file that contains the context menu regression coverage.
+
+  - id: capture-context-menu-visual-proof
+    command: "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after"
+    dependencies: [implement-context-menu-keyboard-navigation, add-context-menu-visual-proof]
+    description: |
+      Layer: e2e_regression
+      Feature state: active
+      Goal:
+      Build the UI/app packages and capture after-state visual proof for the keyboard-highlighted menu.
+      Motivation:
+      The change affects visible keyboard focus state, so screenshot proof is required for review confidence.
+      Alternative considerations:
+      A unit-only gate would prove behavior but not the reviewed visual state.
+      Implementation details:
+      Build the relevant packages and run the repo visual proof script in after mode.
+
+  - id: verify-full-regression-suite
+    command: "pnpm run test:all"
+    dependencies: [add-context-menu-keyboard-regression-tests, implement-context-menu-keyboard-navigation, add-context-menu-visual-proof, run-ui-context-menu-tests, capture-context-menu-visual-proof]
+    description: |
+      Layer: app_regression
+      Layer exception: allowed because the terminal repository-wide regression gate intentionally depends on focused UI and E2E verification tasks before running the broad suite.
+      Feature state: active
+      Goal:
+      Run the full repository test suite as the final regression gate.
+      Motivation:
+      Context menu keyboard handling touches App-level document shortcuts, so broad regression coverage is needed after focused UI and visual proof gates pass.
+      Alternative considerations:
+      Skipping the full suite could miss keyboard shortcut regressions outside the context menu path.
+      Implementation details:
+      Run the standard repository-wide test command from the repo root.

--- a/plans/fix-gui-open-terminal-pty-replay.yaml
+++ b/plans/fix-gui-open-terminal-pty-replay.yaml
@@ -1,0 +1,280 @@
+name: "Fix GUI open-terminal PTY replay"
+description: |
+  Fixes the GUI Open Terminal path for embedded PTY sessions that emit output immediately after spawn. Phase 1 static analysis found that `packages/app/src/main.ts` opens an embedded terminal through `EmbeddedTerminalManager.openOrReuse()`, while `packages/ui/src/components/TerminalDrawer.tsx` only subscribes to `invoker:terminal-output` after React mounts the terminal pane. The repro script `scripts/repro-gui-open-terminal-pty-race.sh` proves the root cause: PTY output emitted before the renderer pane subscribes is not replayed, so the GUI can show a blank terminal even though the PTY session started.
+
+  The implementation should add bounded output replay at the embedded terminal session boundary and seed the renderer terminal from that replay snapshot. This keeps live streaming intact while making early PTY output deterministic for newly opened panes and reloaded GUI sessions. Because this targets Invoker itself, keep `onFinish: pull_request` with the external review PR gate; after the resulting branch stack is ready, publish/update it with `mergify stack push`.
+onFinish: pull_request
+mergeMode: external_review
+repoUrl: git@github.com:Neko-Catpital-Labs/Invoker.git
+baseBranch: master
+featureBranch: plan/fix-gui-open-terminal-pty-replay
+
+tasks:
+  - id: implement-embedded-terminal-replay-buffer
+    description: |
+      Goal:
+      Preserve early embedded PTY output so GUI terminal panes can replay it after React subscribes.
+      Motivation:
+      `EmbeddedTerminalManager` emits terminal output immediately, but the renderer terminal pane subscribes only after `openTerminal` returns a session descriptor and React mounts the pane. Output emitted during that gap is currently lost.
+      Alternative considerations:
+      A renderer-only global listener would reduce the common race, but it would not help `terminalList()` reloads or any renderer listener that attaches late. A bounded app-bridge replay snapshot makes the session descriptor itself authoritative.
+      Implementation details:
+      Add a bounded per-session output replay buffer in `packages/app/src/embedded-terminal-manager.ts`, include that snapshot on `TerminalSessionDescriptor` in `packages/contracts/src/ipc-channels.ts`, and make synchronous backend output/exit during spawn safe. Keep the buffer small and bounded, for example the most recent 64 KiB per session.
+      Layer: app_bridge
+      Feature state: active
+      Files:
+      - packages/app/src/embedded-terminal-manager.ts
+      - packages/contracts/src/ipc-channels.ts
+      Change types:
+      - packages/app/src/embedded-terminal-manager.ts -- modify
+      - packages/contracts/src/ipc-channels.ts -- modify
+      Acceptance criteria:
+      - Output emitted before `openOrReuse()` returns is included in the returned session descriptor.
+      - `terminalList()` descriptors include the same bounded replay snapshot for live sessions.
+      - Synchronous backend output and synchronous backend exit do not throw because of uninitialized session state.
+      - The replay buffer is bounded and does not grow without limit.
+    prompt: |
+      Goal:
+      Preserve early embedded PTY output so GUI terminal panes can replay it after React subscribes.
+      Motivation:
+      `EmbeddedTerminalManager.openOrReuse()` can emit terminal output before the renderer has mounted `TerminalDrawer`/`TerminalSessionPane` and subscribed to `invoker:terminal-output`, causing a blank GUI terminal for fast PTY startup output.
+      Alternative considerations:
+      Do not solve this only with a renderer-side global listener. The app bridge should expose a bounded replay snapshot so `openTerminal()` and `terminalList()` are deterministic even for late subscribers.
+      Implementation details:
+      Zero-context execution: assume no prior context. Modify `packages/app/src/embedded-terminal-manager.ts` and `packages/contracts/src/ipc-channels.ts`.
+      Add an optional replay field to `TerminalSessionDescriptor`, such as `outputSnapshot?: string`, documented as a bounded recent terminal output snapshot used by the renderer to seed newly mounted panes.
+      In `EmbeddedTerminalManager`, maintain a bounded per-session output buffer initialized before backend spawn starts. Append in `emitOutput()` before emitting the live `output` event. Trim to a fixed maximum, for example 64 KiB, so memory is bounded.
+      Ensure output emitted synchronously during backend spawn is captured before `openOrReuse()` returns. Also make synchronous backend exit safe; avoid closures that call `finalizeSession(state, ...)` before `state` has been assigned. If needed, create placeholder bookkeeping before spawn and finalize after state assignment.
+      Include the replay snapshot in `describeSession()` for both `openOrReuse()` responses and `list()` responses.
+      Acceptance criteria:
+      - Output emitted before `openOrReuse()` returns is included in the returned session descriptor.
+      - `terminalList()` descriptors include the same bounded replay snapshot for live sessions.
+      - Synchronous backend output and synchronous backend exit do not throw because of uninitialized session state.
+      - The replay buffer is bounded and does not grow without limit.
+      - Deterministic pass/fail expectation: `cd packages/app && pnpm test -- src/__tests__/embedded-terminal-manager.test.ts` must exit code 0 after tests are updated.
+    dependencies: []
+
+  - id: implement-terminal-drawer-replay-seeding
+    description: |
+      Goal:
+      Seed xterm.js panes with the embedded terminal replay snapshot before live streaming continues.
+      Motivation:
+      The app bridge can preserve early output, but the GUI must write that snapshot into the xterm instance when the terminal pane mounts or when sessions are restored from `terminalList()`.
+      Alternative considerations:
+      Replaying only the latest preview line would not restore the actual terminal buffer. The terminal pane should write the bounded snapshot to xterm and continue writing live events.
+      Implementation details:
+      Update `packages/ui/src/components/TerminalDrawer.tsx`, `packages/ui/src/App.tsx` if needed, and related UI types/tests so an `outputSnapshot` from the session descriptor is rendered exactly once per pane before live output is appended.
+      Layer: ui_activation
+      Feature state: active
+      Files:
+      - packages/ui/src/components/TerminalDrawer.tsx
+      - packages/ui/src/App.tsx
+      - packages/ui/src/types.ts
+      - packages/ui/src/__tests__/terminal-drawer.test.tsx
+      - packages/ui/src/__tests__/helpers/mock-invoker.ts
+      Change types:
+      - packages/ui/src/components/TerminalDrawer.tsx -- modify
+      - packages/ui/src/App.tsx -- modify
+      - packages/ui/src/types.ts -- modify
+      - packages/ui/src/__tests__/terminal-drawer.test.tsx -- modify
+      - packages/ui/src/__tests__/helpers/mock-invoker.ts -- modify
+      Acceptance criteria:
+      - A newly mounted terminal pane writes the session replay snapshot into xterm before live output.
+      - The snapshot is not repeatedly duplicated on re-render.
+      - Existing live `invoker:terminal-output` streaming, terminal input, resize, close, tab selection, and output preview behavior continue to work.
+      - UI tests cover replay seeding without requiring a real PTY.
+    prompt: |
+      Goal:
+      Seed xterm.js panes with the embedded terminal replay snapshot before live streaming continues.
+      Motivation:
+      The app bridge will expose early PTY output on the session descriptor, but the renderer must write that snapshot into xterm so users see output that arrived before the pane subscribed to live output events.
+      Alternative considerations:
+      Do not replace live IPC streaming with polling. Keep the current event stream for new output and use the snapshot only as initial replay data.
+      Implementation details:
+      Zero-context execution: assume no prior context. Modify `packages/ui/src/components/TerminalDrawer.tsx`, `packages/ui/src/App.tsx` if the parent session state needs adjustment, `packages/ui/src/types.ts` if global typing needs the new descriptor field surfaced, and tests under `packages/ui/src/__tests__`.
+      In `TerminalSessionPane`, after xterm is opened and before or alongside live event subscription, write `session.outputSnapshot` when present. Guard against duplicate writes when React re-renders the same session by tracking which session/snapshot has already been seeded.
+      Preserve input routing through `window.invoker.terminalWrite`, resize routing through `terminalResize`, and close behavior through `terminalClose`.
+      Update `terminal-drawer.test.tsx` and `helpers/mock-invoker.ts` so replay seeding is covered in jsdom using the existing xterm mock pattern.
+      Acceptance criteria:
+      - A newly mounted terminal pane writes the session replay snapshot into xterm before live output.
+      - The snapshot is not repeatedly duplicated on re-render.
+      - Existing live output, input, resize, close, tab selection, and output preview behavior remain covered.
+      - Deterministic pass/fail expectation: `cd packages/ui && pnpm test -- src/__tests__/terminal-drawer.test.tsx` must exit code 0.
+    dependencies: [implement-embedded-terminal-replay-buffer]
+
+  - id: add-pty-race-repro-and-regression
+    description: |
+      Goal:
+      Convert the proven PTY output race into deterministic regression coverage.
+      Motivation:
+      Existing E2E coverage sleeps before printing, which masks the broken timing. The fix needs a fast-output regression that fails on the old behavior and passes after replay buffering lands.
+      Alternative considerations:
+      Full Electron E2E can remain focused on real PTY behavior; the precise race is cheaper and more deterministic as an app package manager test with a fake backend.
+      Implementation details:
+      Add or update `scripts/repro-gui-open-terminal-pty-race.sh` and permanent tests in `packages/app/src/__tests__/embedded-terminal-manager.test.ts` so early output replay is asserted directly.
+      Layer: app_regression
+      Feature state: active
+      Files:
+      - scripts/repro-gui-open-terminal-pty-race.sh
+      - packages/app/src/__tests__/embedded-terminal-manager.test.ts
+      Change types:
+      - scripts/repro-gui-open-terminal-pty-race.sh -- create
+      - packages/app/src/__tests__/embedded-terminal-manager.test.ts -- modify
+      Acceptance criteria:
+      - The repro script is non-interactive and exits non-zero on the broken baseline behavior.
+      - After the fix, the same repro script exits 0.
+      - Permanent app tests assert replay of output emitted before `openOrReuse()` returns.
+      - Permanent app tests assert synchronous backend exit does not throw.
+    prompt: |
+      Goal:
+      Convert the proven PTY output race into deterministic regression coverage.
+      Motivation:
+      The current tests in `packages/app/e2e/embedded-terminal-pty.spec.ts` use stub CLIs that sleep before output, which avoids the race. The regression needs immediate output before the renderer-style subscriber attaches.
+      Alternative considerations:
+      Do not rely only on Playwright timing sleeps for this race. Use a fake embedded terminal backend in unit tests to deterministically emit output during spawn.
+      Implementation details:
+      Zero-context execution: assume no prior context. Add or update `scripts/repro-gui-open-terminal-pty-race.sh` and `packages/app/src/__tests__/embedded-terminal-manager.test.ts`.
+      The script should generate or run a focused test that expects replayed first-frame PTY output and exits non-zero on the old behavior. After the implementation, `bash scripts/repro-gui-open-terminal-pty-race.sh` must exit 0.
+      In `embedded-terminal-manager.test.ts`, add permanent tests with a fake backend that emits `FIRST_FRAME_FROM_PTY\n` synchronously during spawn. Assert the returned descriptor includes the bounded replay snapshot and a late consumer can seed from it. Add a separate test for synchronous backend exit safety if the implementation changes exit handling.
+      Acceptance criteria:
+      - The repro script is non-interactive and exits non-zero on the broken baseline behavior.
+      - After the fix, the same repro script exits 0.
+      - Permanent app tests assert replay of output emitted before `openOrReuse()` returns.
+      - Permanent app tests assert synchronous backend exit does not throw.
+      - Deterministic pass/fail expectation: `bash scripts/repro-gui-open-terminal-pty-race.sh` must exit code 0 after the fix.
+    dependencies: [implement-embedded-terminal-replay-buffer]
+
+  - id: verify-repro-terminal-replay
+    description: |
+      Goal:
+      Run the focused repro script for the terminal replay fix.
+      Motivation:
+      The repro script is the deterministic proof for the originally reported GUI Open Terminal race.
+      Alternative considerations:
+      App and UI package tests run in separate tasks so each command stays atomic and failures localize cleanly.
+      Implementation details:
+      Run the repro script from the repo root.
+      Layer: app_regression
+      Feature state: active
+      Files:
+      - scripts/repro-gui-open-terminal-pty-race.sh
+      Change types:
+      - none
+      Acceptance criteria:
+      - `bash scripts/repro-gui-open-terminal-pty-race.sh` exits 0.
+    command: "bash scripts/repro-gui-open-terminal-pty-race.sh"
+    dependencies: [implement-terminal-drawer-replay-seeding, add-pty-race-repro-and-regression]
+
+  - id: verify-app-terminal-manager-tests
+    description: |
+      Goal:
+      Run focused app package tests for embedded terminal replay.
+      Motivation:
+      The manager owns app-bridge session descriptors, buffering, synchronous spawn output, and synchronous exit handling.
+      Alternative considerations:
+      The repro script proves the old failure mode; this package test task proves the permanent app regression tests.
+      Implementation details:
+      Run the embedded terminal manager Vitest file from inside `packages/app`.
+      Layer: app_regression
+      Feature state: active
+      Files:
+      - packages/app/src/__tests__/embedded-terminal-manager.test.ts
+      Change types:
+      - none
+      Acceptance criteria:
+      - `cd packages/app && pnpm test -- src/__tests__/embedded-terminal-manager.test.ts` exits 0.
+    command: "cd packages/app && pnpm test -- src/__tests__/embedded-terminal-manager.test.ts"
+    dependencies: [implement-embedded-terminal-replay-buffer, add-pty-race-repro-and-regression]
+
+  - id: verify-ui-terminal-drawer-tests
+    description: |
+      Goal:
+      Run focused UI package tests for terminal drawer replay seeding.
+      Motivation:
+      The renderer must write the descriptor replay snapshot into xterm exactly once and keep live terminal behavior intact.
+      Alternative considerations:
+      Full UI tests are covered by the final regression gate; this task targets the terminal drawer behavior changed by the fix.
+      Implementation details:
+      Run the terminal drawer Vitest file from inside `packages/ui`.
+      Layer: ui
+      Feature state: active
+      Files:
+      - packages/ui/src/__tests__/terminal-drawer.test.tsx
+      Change types:
+      - none
+      Acceptance criteria:
+      - `cd packages/ui && pnpm test -- src/__tests__/terminal-drawer.test.tsx` exits 0.
+    command: "cd packages/ui && pnpm test -- src/__tests__/terminal-drawer.test.tsx"
+    dependencies: [implement-terminal-drawer-replay-seeding]
+
+  - id: build-embedded-terminal-e2e
+    description: |
+      Goal:
+      Build the UI and app packages before Electron embedded PTY E2E verification.
+      Motivation:
+      The Playwright Electron fixture launches built app artifacts from `packages/app/dist`, so focused E2E should run against fresh build outputs.
+      Alternative considerations:
+      Build and E2E run are split into separate tasks to keep command tasks atomic.
+      Implementation details:
+      Build the renderer and Electron app packages from the repo root.
+      Layer: e2e_regression
+      Layer exception: allowed
+      This e2e preparation task depends on app bridge and UI activation work so it builds the integrated GUI behavior after those changes exist.
+      Feature state: active
+      Files:
+      - packages/ui/src/components/TerminalDrawer.tsx
+      - packages/app/src/embedded-terminal-manager.ts
+      Change types:
+      - none
+      Acceptance criteria:
+      - The command exits 0.
+    command: "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build"
+    dependencies: [implement-terminal-drawer-replay-seeding, add-pty-race-repro-and-regression]
+
+  - id: verify-embedded-terminal-e2e
+    description: |
+      Goal:
+      Run the existing Electron embedded PTY E2E coverage after the replay fix.
+      Motivation:
+      The unit tests prove the race, while the Electron E2E test proves the PTY backend still creates a real TTY in the GUI drawer.
+      Alternative considerations:
+      This does not replace final `test:all`; it is a focused integration gate for the user-facing Open Terminal workflow.
+      Implementation details:
+      Run the existing embedded terminal PTY Playwright spec after the build task has produced fresh artifacts.
+      Layer: e2e_regression
+      Layer exception: allowed
+      This e2e regression task depends on app bridge and UI activation work so it validates the integrated GUI behavior after those higher-level changes exist.
+      Feature state: active
+      Files:
+      - packages/app/e2e/embedded-terminal-pty.spec.ts
+      - packages/app/e2e/fixtures/electron-app.ts
+      Change types:
+      - none
+      Acceptance criteria:
+      - The command exits 0.
+      - The existing Codex and Claude embedded PTY resume tests still show TTY output in the drawer.
+    command: "cd packages/app && pnpm exec playwright test e2e/embedded-terminal-pty.spec.ts"
+    dependencies: [build-embedded-terminal-e2e]
+
+  - id: final-regression
+    description: |
+      Goal:
+      Run the full repository regression suite as the terminal gate.
+      Motivation:
+      The fix changes a shared IPC contract, Electron app bridge behavior, and renderer terminal mounting, so the final workflow gate should catch cross-package regressions before PR review.
+      Alternative considerations:
+      Focused app, UI, and E2E checks run earlier for faster failure localization; this full suite remains the required terminal implementation gate.
+      Implementation details:
+      Run the repository's canonical full test command from the repo root after every implementation and focused verification task completes.
+      Layer: e2e_regression
+      Layer exception: allowed
+      This terminal regression gate intentionally depends on all implementation and verification tasks so the full repository suite validates the completed feature.
+      Feature state: active
+      Files:
+      - none
+      Change types:
+      - none
+      Acceptance criteria:
+      - `pnpm run test:all` exits 0.
+    command: "pnpm run test:all"
+    dependencies: [implement-embedded-terminal-replay-buffer, implement-terminal-drawer-replay-seeding, add-pty-race-repro-and-regression, verify-repro-terminal-replay, verify-app-terminal-manager-tests, verify-ui-terminal-drawer-tests, build-embedded-terminal-e2e, verify-embedded-terminal-e2e]

--- a/plans/task-graph-keyboard-controls.yaml
+++ b/plans/task-graph-keyboard-controls.yaml
@@ -1,0 +1,164 @@
+name: "Task graph keyboard controls"
+description: |
+  Adds keyboard affordances for the selected workflow task graph in the Invoker UI. Escape should dismiss the selected task graph when keyboard focus is inside that graph, and Space should expand/open the selected workflow's task graph while Enter remains reserved for the workflow context menu.
+
+  The change is contained in renderer keyboard state and tests, with visual proof enabled because it changes UI behavior in `packages/ui`. Because this targets Invoker itself, the implementation workflow uses the external review PR gate and the resulting stack should be published with `mergify stack push` after the branch commits are ready.
+onFinish: pull_request
+mergeMode: external_review
+visualProof: true
+repoUrl: git@github.com:Neko-Catpital-Labs/Invoker.git
+baseBranch: master
+featureBranch: plan/task-graph-keyboard-controls
+
+tasks:
+  - id: implement-task-graph-keyboard-controls
+    description: |
+      Goal:
+      Implement keyboard behavior for opening and dismissing the selected workflow task graph.
+      Motivation:
+      Users need a reversible keyboard path for task graph inspection: Space opens the graph from workflow selection, and Escape dismisses it from task-graph focus without interfering with search, modals, or inspector Escape behavior.
+      Alternative considerations:
+      Enter was rejected for expansion because it already opens context menus; Space matches activation semantics while keeping Enter stable.
+      Implementation details:
+      Update the central keyboard handler and selection helpers in App so task graph dismissal mirrors the existing graph-background click behavior, while Space expands the current workflow selection.
+      Layer: ui
+      Feature state: active
+      Files:
+      - packages/ui/src/App.tsx
+      - packages/ui/src/__tests__/keyboard-controls.test.tsx
+      Change types:
+      - packages/ui/src/App.tsx -- modify
+      - packages/ui/src/__tests__/keyboard-controls.test.tsx -- modify
+      Acceptance criteria:
+      - Pressing Escape while the task graph keyboard region is active removes `selected-workflow-mini-dag`, clears selected task/workflow state, and returns keyboard focus to `workflowGraph`.
+      - Pressing Space while the workflow graph keyboard region is active opens/expands the selected workflow task graph.
+      - Pressing Enter on a workflow node still opens the workflow context menu.
+      - `cd packages/ui && pnpm test -- src/__tests__/keyboard-controls.test.tsx` exits 0.
+    prompt: |
+      Goal:
+      Implement keyboard behavior for opening and dismissing the selected workflow task graph.
+      Motivation:
+      Users need a reversible keyboard path for task graph inspection: Space opens the graph from workflow selection, and Escape dismisses it from task-graph focus without interfering with search, modals, or inspector Escape behavior.
+      Alternative considerations:
+      Keep Enter reserved for the existing context-menu behavior. Do not remap Enter to expansion.
+      Implementation details:
+      Zero-context execution: assume no prior context. Modify `packages/ui/src/App.tsx` and `packages/ui/src/__tests__/keyboard-controls.test.tsx` to add task graph keyboard controls.
+      In the App keyboard handler, when `keyboardRegion === 'taskGraph'`, `event.key === 'Escape'`, and a selected workflow task graph is visible, prevent default, close any task/workflow context menus, clear selected task and selected workflow, set the dismissed flag so the mini DAG disappears, and move keyboard focus back to `workflowGraph`. Preserve the existing search Escape, modal guard, and inspector Escape behavior.
+      Add Space handling for `keyboardRegion === 'workflowGraph'`: when a workflow node is selected, prevent default and expand/open that workflow's task graph without opening the workflow context menu. Preserve Enter as the context menu shortcut.
+      Update `packages/ui/src/__tests__/keyboard-controls.test.tsx` with deterministic tests covering:
+      1. Escape dismisses `selected-workflow-mini-dag` from task graph keyboard focus and marks the workflow graph surface as keyboard-active.
+      2. Space opens/expands the selected workflow task graph from workflow graph keyboard focus.
+      3. Enter still opens the workflow context menu.
+      Acceptance criteria:
+      - Ensure Escape dismisses `selected-workflow-mini-dag` from task graph keyboard focus and returns keyboard activity to `workflowGraph`.
+      - Ensure Space opens the selected workflow task graph from workflow graph keyboard focus.
+      - Ensure Enter still opens the workflow context menu.
+      - Deterministic pass/fail expectation: `cd packages/ui && pnpm test -- src/__tests__/keyboard-controls.test.tsx` must exit code 0 after the changes.
+    dependencies: []
+
+  - id: add-task-graph-visual-proof
+    description: |
+      Goal:
+      Add visual proof coverage for the selected task graph keyboard state.
+      Motivation:
+      The plan modifies visible UI state, so the review should include a reproducible screenshot state that shows the selected workflow task graph before and after keyboard-driven changes.
+      Alternative considerations:
+      Unit tests prove behavior, but visual proof gives reviewers confidence that the selected graph panel remains framed and visible in the actual app shell.
+      Implementation details:
+      Add a plan-specific Playwright visual proof case that captures the selected task graph state using the existing visual proof harness patterns.
+      Layer: e2e_regression
+      Layer exception: allowed
+      This e2e regression task intentionally depends on the UI implementation so the screenshot state captures the activated behavior after the renderer change exists.
+      Feature state: active
+      Files:
+      - packages/app/e2e/visual-proof.spec.ts
+      Change types:
+      - packages/app/e2e/visual-proof.spec.ts -- modify
+      Acceptance criteria:
+      - A plan-specific visual proof case captures a stable selected task graph state.
+      - The test uses existing helpers and screenshot naming conventions.
+      - `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after` exits 0.
+    prompt: |
+      Goal:
+      Add visual proof coverage for the selected task graph keyboard state.
+      Motivation:
+      The plan modifies visible UI state, so reviewers need a reproducible screenshot state showing the selected workflow task graph in the real app shell.
+      Alternative considerations:
+      Do not create a new visual proof harness. Reuse the existing `visual-proof.spec.ts` helpers, setup style, and screenshot capture naming conventions.
+      Implementation details:
+      Zero-context execution: assume no prior context. Modify `packages/app/e2e/visual-proof.spec.ts` to add visual proof coverage for the selected workflow task graph state.
+      Add one plan-specific test case that loads or creates a workflow state with a selected workflow task graph visible and captures it with a stable screenshot name such as `task-graph-keyboard-controls-selected`. Keep the test scoped to the selected mini DAG visibility/framing; behavioral keyboard assertions belong in `packages/ui/src/__tests__/keyboard-controls.test.tsx`.
+      Acceptance criteria:
+      - Ensure a plan-specific visual proof case captures the selected task graph state.
+      - Ensure the new case uses existing helpers and screenshot naming conventions.
+      - Deterministic pass/fail expectation: `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after` must exit code 0 after the implementation and visual proof test land.
+    dependencies: [implement-task-graph-keyboard-controls]
+
+  - id: verify-ui-keyboard-controls
+    description: |
+      Goal:
+      Run focused renderer tests for the keyboard controls.
+      Motivation:
+      The central keyboard handler is easy to regress, so the component tests should prove Escape, Space, and Enter behavior before broader checks run.
+      Alternative considerations:
+      A full UI test pass is acceptable if the package script expands the file filter, but this task intentionally targets the keyboard-controls suite.
+      Implementation details:
+      Run the UI package Vitest command from inside `packages/ui`.
+      Layer: ui
+      Feature state: active
+      Files:
+      - packages/ui/src/App.tsx
+      - packages/ui/src/__tests__/keyboard-controls.test.tsx
+      Change types:
+      - none
+      Acceptance criteria:
+      - The command exits 0.
+    command: "cd packages/ui && pnpm test -- src/__tests__/keyboard-controls.test.tsx"
+    dependencies: [implement-task-graph-keyboard-controls]
+
+  - id: capture-task-graph-visual-proof
+    description: |
+      Goal:
+      Build the UI and app packages and capture after-change visual proof.
+      Motivation:
+      Visual proof documents that the selected task graph remains correctly rendered after keyboard behavior changes.
+      Alternative considerations:
+      Screenshot capture should happen after both implementation and the plan-specific visual proof test are present.
+      Implementation details:
+      Build the renderer and Electron app packages, then run the existing visual proof script with the `after` label.
+      Layer: e2e_regression
+      Layer exception: allowed
+      This e2e regression task intentionally depends on the UI implementation so visual proof runs only after the renderer behavior is present.
+      Feature state: active
+      Files:
+      - packages/ui/src/App.tsx
+      - packages/app/e2e/visual-proof.spec.ts
+      Change types:
+      - none
+      Acceptance criteria:
+      - The command exits 0 and produces after-change visual proof artifacts.
+    command: "pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after"
+    dependencies: [implement-task-graph-keyboard-controls, add-task-graph-visual-proof]
+
+  - id: final-regression
+    description: |
+      Goal:
+      Run the full repository regression suite as the terminal gate.
+      Motivation:
+      The UI keyboard handler sits in the main app shell, so the final workflow gate should catch cross-package regressions before PR review.
+      Alternative considerations:
+      Focused UI tests run earlier for fast feedback; this full suite remains the final standalone implementation-plan gate.
+      Implementation details:
+      Run the repository's canonical full test command from the repo root after every implementation and verification task completes.
+      Layer: e2e_regression
+      Layer exception: allowed
+      This terminal regression gate intentionally depends on UI implementation and UI verification tasks so the full repository suite validates the completed feature.
+      Feature state: active
+      Files:
+      - none
+      Change types:
+      - none
+      Acceptance criteria:
+      - `pnpm run test:all` exits 0.
+    command: "pnpm run test:all"
+    dependencies: [implement-task-graph-keyboard-controls, add-task-graph-visual-proof, verify-ui-keyboard-controls, capture-task-graph-visual-proof]

--- a/scripts/repro-gui-open-terminal-pty-race.sh
+++ b/scripts/repro-gui-open-terminal-pty-race.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_FILE="$ROOT_DIR/packages/app/src/__tests__/__tmp_repro_gui_open_terminal_pty_race.test.ts"
+
+cleanup() {
+  rm -f "$TEST_FILE"
+}
+trap cleanup EXIT
+
+cat >"$TEST_FILE" <<'TS'
+import { describe, expect, it } from 'vitest';
+import {
+  EmbeddedTerminalManager,
+  type EmbeddedTerminalBackend,
+} from '../embedded-terminal-manager.js';
+
+describe('repro: GUI open-terminal PTY output race', () => {
+  it('drops output emitted before the renderer terminal pane subscribes', () => {
+    const backend: EmbeddedTerminalBackend = {
+      name: 'pty',
+      spawn(opts) {
+        opts.emitOutput('FIRST_FRAME_FROM_PTY\n');
+        return {
+          write() {},
+          resize() {},
+          close() {},
+        };
+      },
+    };
+
+    const manager = new EmbeddedTerminalManager({ backend });
+
+    const session = manager.openOrReuse({
+      taskId: 'wf/repro-terminal',
+      spec: { command: 'repro-command', args: [] },
+      cwd: process.cwd(),
+    });
+
+    const rendererObserved: string[] = [];
+    manager.on('output', (event) => {
+      if (event.sessionId === session.sessionId) rendererObserved.push(event.data);
+    });
+
+    expect(session.mode).toBe('spawn');
+    expect(rendererObserved).toContain('FIRST_FRAME_FROM_PTY\n');
+  });
+});
+TS
+
+set +e
+OUTPUT="$(cd "$ROOT_DIR" && pnpm --filter @invoker/app exec vitest run "$TEST_FILE" 2>&1)"
+STATUS=$?
+set -e
+
+printf '%s\n' "$OUTPUT"
+
+if [[ $STATUS -eq 0 ]]; then
+  echo "UNEXPECTED: repro did not reproduce the race; the temporary test passed." >&2
+  exit 1
+fi
+
+if grep -q "FIRST_FRAME_FROM_PTY" <<<"$OUTPUT" && grep -q "toContain" <<<"$OUTPUT"; then
+  echo "REPRODUCED: PTY output emitted before the renderer subscribes is not replayed to the GUI."
+  exit 0
+fi
+
+echo "UNEXPECTED: temporary test failed for a different reason." >&2
+exit "$STATUS"

--- a/scripts/repro/repro-node-pty-spawn-helper-permission.sh
+++ b/scripts/repro/repro-node-pty-spawn-helper-permission.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Proves node-pty's macOS spawn-helper execute bit is required for PTY spawn.
+# The script copies the installed node-pty package to a temp directory so it
+# never mutates the repo's node_modules.
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+APP_DIR="$ROOT/packages/app"
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-node-pty-repro.XXXXXX")"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+NODE_PTY_DIR="$(
+  cd "$APP_DIR"
+  node - <<'NODE'
+const path = require('node:path');
+const entry = require.resolve('node-pty');
+console.log(path.dirname(path.dirname(entry)));
+NODE
+)"
+
+COPY_DIR="$TMP_DIR/node-pty"
+cp -R "$NODE_PTY_DIR" "$COPY_DIR"
+
+HELPER="$COPY_DIR/prebuilds/$(node -p '`${process.platform}-${process.arch}`')/spawn-helper"
+if [[ ! -f "$HELPER" ]]; then
+  echo "SKIP: no spawn-helper for $(node -p '`${process.platform}-${process.arch}`')" >&2
+  exit 0
+fi
+
+run_spawn() {
+  local mode_label="$1"
+  NODE_PTY_COPY="$COPY_DIR" node - <<'NODE'
+const pty = require(process.env.NODE_PTY_COPY);
+try {
+  const term = pty.spawn('/bin/sh', ['-lc', 'printf ok'], {
+    name: 'xterm-256color',
+    cols: 80,
+    rows: 24,
+    cwd: process.cwd(),
+    env: process.env,
+  });
+  let output = '';
+  term.onData((data) => { output += data; });
+  term.onExit((event) => {
+    console.log(JSON.stringify({ ok: true, output, exitCode: event.exitCode }));
+  });
+} catch (err) {
+  console.log(JSON.stringify({ ok: false, error: err instanceof Error ? err.message : String(err) }));
+  process.exitCode = 42;
+}
+NODE
+  local status=$?
+  echo "spawn status with $mode_label helper: $status"
+  return "$status"
+}
+
+chmod 0644 "$HELPER"
+echo "helper mode after chmod 0644: $(stat -f '%Lp %N' "$HELPER" 2>/dev/null || stat -c '%a %n' "$HELPER")"
+if run_spawn "0644"; then
+  echo "FAIL: spawn unexpectedly succeeded with non-executable spawn-helper" >&2
+  exit 1
+fi
+
+chmod 0755 "$HELPER"
+echo "helper mode after chmod 0755: $(stat -f '%Lp %N' "$HELPER" 2>/dev/null || stat -c '%a %n' "$HELPER")"
+run_spawn "0755"
+
+echo "PASS: node-pty spawn fails when spawn-helper is non-executable and succeeds when executable"

--- a/scripts/verify-node-pty-install.cjs
+++ b/scripts/verify-node-pty-install.cjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+'use strict';
+
+const { createRequire } = require('node:module');
+const { existsSync, readFileSync, statSync } = require('node:fs');
+const path = require('node:path');
+
+const repoRoot = path.resolve(__dirname, '..');
+const appDir = path.join(repoRoot, 'packages', 'app');
+const appPackageJson = path.join(appDir, 'package.json');
+const platformArch = `${process.platform}-${process.arch}`;
+
+function modeString(mode) {
+  return `0o${(mode & 0o777).toString(8).padStart(3, '0')}`;
+}
+
+function shellQuote(value) {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+function readPackageName(packageDir) {
+  const packageJsonPath = path.join(packageDir, 'package.json');
+  const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+  return parsed.name;
+}
+
+function findNodePtyPackageRoot(entryPath) {
+  let current = path.dirname(entryPath);
+  while (current !== path.dirname(current)) {
+    const packageJsonPath = path.join(current, 'package.json');
+    if (existsSync(packageJsonPath)) {
+      try {
+        const parsed = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+        if (parsed.name === 'node-pty') return current;
+      } catch {
+        // Keep walking; a malformed unrelated package.json should not mask the
+        // actual resolution failure below.
+      }
+    }
+    current = path.dirname(current);
+  }
+  throw new Error(`resolved entry is not inside a node-pty package: ${entryPath}`);
+}
+
+function resolveNodePtyPackageRoot() {
+  const overrideDir = process.env.INVOKER_VERIFY_NODE_PTY_PACKAGE_DIR;
+  if (overrideDir) {
+    const packageDir = path.resolve(overrideDir);
+    const packageName = readPackageName(packageDir);
+    if (packageName !== 'node-pty') {
+      throw new Error(
+        `INVOKER_VERIFY_NODE_PTY_PACKAGE_DIR must point at node-pty, got ${packageName}`,
+      );
+    }
+    return packageDir;
+  }
+
+  const appRequire = createRequire(appPackageJson);
+  const entryPath = appRequire.resolve('node-pty');
+  return findNodePtyPackageRoot(entryPath);
+}
+
+function main() {
+  let nodePtyDir;
+  try {
+    nodePtyDir = resolveNodePtyPackageRoot();
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error('ERROR: node-pty is not resolvable from @invoker/app.');
+    console.error(`@invoker/app directory: ${appDir}`);
+    console.error(`Reason: ${reason}`);
+    console.error('Run pnpm install from the repository root.');
+    process.exit(1);
+  }
+
+  const helperPath = path.join(nodePtyDir, 'prebuilds', platformArch, 'spawn-helper');
+  if (!existsSync(helperPath)) {
+    console.log(
+      `node-pty install check: no prebuilt spawn-helper for ${platformArch}; skipping permission check.`,
+    );
+    return;
+  }
+
+  const stat = statSync(helperPath);
+  const executable = (stat.mode & 0o111) !== 0;
+  if (executable) {
+    console.log(`node-pty install check: spawn-helper is executable (${helperPath}).`);
+    return;
+  }
+
+  console.error('ERROR: node-pty spawn-helper is not executable.');
+  console.error(`Helper path: ${helperPath}`);
+  console.error(`Current mode: ${modeString(stat.mode)}`);
+  console.error('Expected mode: 0o755 (or any mode with an execute bit set)');
+  console.error('Manual remediation:');
+  console.error(`  chmod 755 ${shellQuote(helperPath)}`);
+  console.error('  pnpm install');
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Add Invoker workflow plans for two UI keyboard workstreams: context-menu keyboard navigation and selected task-graph keyboard controls. The plans include focused tests, visual proof steps, and final regression gates.

## Test Plan

- [ ] `bash skills/plan-to-invoker/scripts/skill-doctor.sh plans/context-menu-keyboard-navigation.yaml`
- [ ] `bash skills/plan-to-invoker/scripts/skill-doctor.sh plans/task-graph-keyboard-controls.yaml`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert e50f60af`
- Post-revert steps: None
- Data migration? No

Depends-On: #844
