### PR TITLE
Defer SSH pool tasks at member capacity

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -172,6 +172,63 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  describe('execution resource leases', () => {
+    it('allows only one live holder per resource key', () => {
+      const acquired = adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:invoker@example.com:22',
+        resourceType: 'ssh',
+        holderId: 'holder-1',
+        taskId: 'task-1',
+        poolId: 'ssh-pool',
+        poolMemberId: 'remote-a',
+      });
+      const blocked = adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:invoker@example.com:22',
+        resourceType: 'ssh',
+        holderId: 'holder-2',
+        taskId: 'task-2',
+        poolId: 'ssh-pool',
+        poolMemberId: 'remote-a',
+      });
+
+      expect(acquired).toBe(true);
+      expect(blocked).toBe(false);
+      expect(adapter.listExecutionResourceLeases()).toHaveLength(1);
+    });
+
+    it('reclaims expired resource leases', () => {
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:invoker@example.com:22',
+        resourceType: 'ssh',
+        holderId: 'holder-1',
+        leaseMs: -1,
+      })).toBe(true);
+
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:invoker@example.com:22',
+        resourceType: 'ssh',
+        holderId: 'holder-2',
+      })).toBe(true);
+
+      const leases = adapter.listExecutionResourceLeases();
+      expect(leases).toHaveLength(1);
+      expect(leases[0].holderId).toBe('holder-2');
+    });
+
+    it('renews and releases resource leases by holder', () => {
+      adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:invoker@example.com:22',
+        resourceType: 'ssh',
+        holderId: 'holder-1',
+      });
+
+      expect(adapter.renewExecutionResourceLease('ssh:invoker@example.com:22', 'holder-1')).toBe(true);
+      adapter.releaseExecutionResourceLease('ssh:invoker@example.com:22', 'holder-1');
+
+      expect(adapter.listExecutionResourceLeases()).toHaveLength(0);
+    });
+  });
+
   describe('updateTask', () => {
     it('persists partial changes', () => {
       adapter.saveWorkflow(testWorkflow);

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -87,6 +87,20 @@ interface SQLiteAdapterOptions {
 export type WorkflowMutationPriority = 'high' | 'normal';
 export type WorkflowMutationIntentStatus = 'queued' | 'running' | 'completed' | 'failed';
 export const WORKFLOW_MUTATION_LEASE_MS = 30_000;
+export const EXECUTION_RESOURCE_LEASE_MS = 20 * 60 * 1000;
+
+export interface ExecutionResourceLease {
+  resourceKey: string;
+  resourceType: string;
+  holderId: string;
+  taskId?: string;
+  poolId?: string;
+  poolMemberId?: string;
+  acquiredAt: string;
+  lastHeartbeatAt: string;
+  leaseExpiresAt: string;
+  metadata?: unknown;
+}
 
 type SQLiteParams = unknown[] | Record<string, unknown>;
 
@@ -747,6 +761,26 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
       CREATE INDEX IF NOT EXISTS idx_workflow_mutation_leases_expiry
         ON workflow_mutation_leases(lease_expires_at);
+
+      CREATE TABLE IF NOT EXISTS execution_resource_leases (
+        resource_key TEXT NOT NULL,
+        resource_type TEXT NOT NULL,
+        holder_id TEXT NOT NULL,
+        task_id TEXT,
+        pool_id TEXT,
+        pool_member_id TEXT,
+        acquired_at TEXT NOT NULL,
+        last_heartbeat_at TEXT NOT NULL,
+        lease_expires_at TEXT NOT NULL,
+        metadata_json TEXT,
+        PRIMARY KEY(resource_key, holder_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_execution_resource_leases_resource
+        ON execution_resource_leases(resource_key, lease_expires_at);
+
+      CREATE INDEX IF NOT EXISTS idx_execution_resource_leases_expiry
+        ON execution_resource_leases(lease_expires_at);
 
       CREATE TABLE IF NOT EXISTS output_spool (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -2657,6 +2691,103 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'DELETE FROM workflow_mutation_leases WHERE workflow_id = ? AND owner_id = ?',
       [workflowId, ownerId],
     );
+  }
+
+  claimExecutionResourceLease(options: {
+    resourceKey: string;
+    resourceType: string;
+    holderId: string;
+    taskId?: string;
+    poolId?: string;
+    poolMemberId?: string;
+    metadata?: unknown;
+    leaseMs?: number;
+  }): boolean {
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const leaseExpiresAt = new Date(now.getTime() + (options.leaseMs ?? EXECUTION_RESOURCE_LEASE_MS)).toISOString();
+    return this.runTransaction(() => {
+      this.execRun(
+        'DELETE FROM execution_resource_leases WHERE resource_key = ? AND lease_expires_at <= ?',
+        [options.resourceKey, nowIso],
+      );
+      const active = this.queryOne(
+        `SELECT holder_id FROM execution_resource_leases
+         WHERE resource_key = ?
+           AND holder_id != ?
+           AND lease_expires_at > ?
+         LIMIT 1`,
+        [options.resourceKey, options.holderId, nowIso],
+      );
+      if (active) return false;
+
+      this.execRun(
+        `INSERT OR REPLACE INTO execution_resource_leases (
+          resource_key, resource_type, holder_id, task_id, pool_id, pool_member_id,
+          acquired_at, last_heartbeat_at, lease_expires_at, metadata_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        [
+          options.resourceKey,
+          options.resourceType,
+          options.holderId,
+          options.taskId ?? null,
+          options.poolId ?? null,
+          options.poolMemberId ?? null,
+          nowIso,
+          nowIso,
+          leaseExpiresAt,
+          options.metadata === undefined ? null : JSON.stringify(options.metadata),
+        ],
+      );
+      return true;
+    });
+  }
+
+  renewExecutionResourceLease(
+    resourceKey: string,
+    holderId: string,
+    leaseMs = EXECUTION_RESOURCE_LEASE_MS,
+  ): boolean {
+    const now = new Date();
+    this.execRun(
+      `UPDATE execution_resource_leases
+         SET last_heartbeat_at = ?,
+             lease_expires_at = ?
+       WHERE resource_key = ?
+         AND holder_id = ?`,
+      [
+        now.toISOString(),
+        new Date(now.getTime() + leaseMs).toISOString(),
+        resourceKey,
+        holderId,
+      ],
+    );
+    const changed = (this.db.getRowsModified?.() ?? 0) as number;
+    return changed > 0;
+  }
+
+  releaseExecutionResourceLease(resourceKey: string, holderId: string): void {
+    this.execRun(
+      'DELETE FROM execution_resource_leases WHERE resource_key = ? AND holder_id = ?',
+      [resourceKey, holderId],
+    );
+  }
+
+  listExecutionResourceLeases(): ExecutionResourceLease[] {
+    return this.queryAll(
+      'SELECT * FROM execution_resource_leases ORDER BY resource_key ASC, acquired_at ASC',
+    ).map((row) => ({
+      resourceKey: String(row.resource_key),
+      resourceType: String(row.resource_type),
+      holderId: String(row.holder_id),
+      taskId: row.task_id ? String(row.task_id) : undefined,
+      poolId: row.pool_id ? String(row.pool_id) : undefined,
+      poolMemberId: row.pool_member_id ? String(row.pool_member_id) : undefined,
+      acquiredAt: String(row.acquired_at),
+      lastHeartbeatAt: String(row.last_heartbeat_at),
+      leaseExpiresAt: String(row.lease_expires_at),
+      metadata: row.metadata_json ? JSON.parse(String(row.metadata_json)) : undefined,
+    }));
   }
 
   listWorkflowMutationLeases(): WorkflowMutationLease[] {

--- a/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-pool-member-capacity.test.ts
@@ -1,0 +1,215 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import { ResourceLimitError } from '../repo-pool.js';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+function makeTask(id: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { command: 'echo hi', runnerKind: 'ssh', poolId: 'ssh-pool' },
+    execution: { selectedAttemptId: `${id}-attempt`, generation: 0 },
+  } as TaskState;
+}
+
+function makeRunner(overrides: {
+  members?: Array<{ id: string; type: 'ssh'; maxConcurrentTasks?: number }>;
+  strategy?: 'roundRobin' | 'leastLoaded';
+  orchestrator?: any;
+  persistence?: any;
+  sshExecutor?: any;
+} = {}): TaskRunner {
+  const sshExecutor = overrides.sshExecutor ?? {
+    type: 'ssh',
+    start: vi.fn(),
+    onComplete: vi.fn(),
+    onOutput: vi.fn(),
+    onHeartbeat: vi.fn(),
+    kill: vi.fn(),
+    destroyAll: vi.fn(),
+  };
+  const members = overrides.members ?? [{ id: 'remote-a', type: 'ssh' as const, maxConcurrentTasks: 1 }];
+  return new TaskRunner({
+    orchestrator: overrides.orchestrator ?? { getTask: () => null, getAllTasks: () => [], deferTask: vi.fn() },
+    persistence: overrides.persistence ?? { logEvent: vi.fn() },
+    executorRegistry: {
+      getDefault: () => sshExecutor,
+      get: (type: string) => type === 'ssh' ? sshExecutor : null,
+      getAll: () => [sshExecutor],
+      register: vi.fn(),
+    } as any,
+    cwd: '/tmp',
+    remoteTargetsProvider: () => ({
+      'remote-a': { host: 'remote-a.example.com', user: 'invoker', sshKeyPath: '/tmp/fake-a' },
+      'remote-b': { host: 'remote-b.example.com', user: 'invoker', sshKeyPath: '/tmp/fake-b' },
+    }),
+    executionPoolsProvider: () => ({
+      'ssh-pool': {
+        selectionStrategy: overrides.strategy ?? 'leastLoaded',
+        maxConcurrentTasksPerMember: 1,
+        members,
+      },
+    }),
+  });
+}
+
+describe('SSH pool member capacity', () => {
+  it('treats leastLoaded maxConcurrentTasksPerMember as a hard cap', () => {
+    const runner = makeRunner();
+    runner.selectExecutor(makeTask('wf-1/task-a'));
+
+    expect(() => runner.selectExecutor(makeTask('wf-2/task-b'))).toThrow(/no member capacity/);
+    try {
+      runner.selectExecutor(makeTask('wf-2/task-b'));
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).cause).toBeInstanceOf(ResourceLimitError);
+    }
+  });
+
+  it('round-robin skips full members and uses the next available member', () => {
+    const runner = makeRunner({
+      strategy: 'roundRobin',
+      members: [
+        { id: 'remote-a', type: 'ssh', maxConcurrentTasks: 1 },
+        { id: 'remote-b', type: 'ssh', maxConcurrentTasks: 1 },
+      ],
+    });
+
+    runner.selectExecutor(makeTask('wf-1/task-a'));
+    runner.selectExecutor(makeTask('wf-2/task-b'));
+
+    const selections = [...(runner as any).pendingPoolSelections.values()];
+    expect(selections.map((selection: any) => selection.member.id)).toEqual(['remote-a', 'remote-b']);
+  });
+
+  it('defers instead of starting when all pool members are full', async () => {
+    const firstTask = makeTask('wf-1/task-a');
+    const secondTask = makeTask('wf-2/task-b');
+    const sshExecutor = {
+      type: 'ssh',
+      start: vi.fn(),
+      onComplete: vi.fn(),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+    const deferTask = vi.fn();
+    const runner = makeRunner({
+      sshExecutor,
+      orchestrator: {
+        getTask: (id: string) => id === secondTask.id ? secondTask : firstTask,
+        getAllTasks: () => [firstTask, secondTask],
+        deferTask,
+      },
+      persistence: {
+        logEvent: vi.fn(),
+        updateAttempt: vi.fn(),
+      },
+    });
+
+    runner.selectExecutor(firstTask);
+    await runner.executeTask(secondTask);
+
+    expect(deferTask).toHaveBeenCalledWith(secondTask.id);
+    expect(sshExecutor.start).not.toHaveBeenCalled();
+  });
+
+  it('uses execution resource leases to defer across TaskRunner instances', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const firstTask = makeTask('wf-1/task-a');
+      const secondTask = makeTask('wf-2/task-b');
+      let firstComplete: ((response: any) => void) | undefined;
+      const firstExecutor = {
+        type: 'ssh',
+        start: vi.fn(async (request: any) => ({
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/remote/task-a',
+        })),
+        onComplete: vi.fn((_handle: any, cb: any) => { firstComplete = cb; }),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+        destroyAll: vi.fn(),
+      };
+      const secondExecutor = {
+        type: 'ssh',
+        start: vi.fn(async (request: any) => ({
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/remote/task-b',
+        })),
+        onComplete: vi.fn(),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+        destroyAll: vi.fn(),
+      };
+      const firstRunner = makeRunner({
+        sshExecutor: firstExecutor,
+        orchestrator: {
+          getTask: () => firstTask,
+          getAllTasks: () => [firstTask],
+          markTaskRunningAfterLaunch: () => true,
+          handleWorkerResponse: () => [],
+          deferTask: vi.fn(),
+        },
+        persistence: {
+          updateTask: vi.fn(),
+          updateAttempt: vi.fn(),
+          appendTaskOutput: vi.fn(),
+          logEvent: vi.fn(),
+          claimExecutionResourceLease: adapter.claimExecutionResourceLease.bind(adapter),
+          renewExecutionResourceLease: adapter.renewExecutionResourceLease.bind(adapter),
+          releaseExecutionResourceLease: adapter.releaseExecutionResourceLease.bind(adapter),
+        },
+      });
+      const deferTask = vi.fn();
+      const secondRunner = makeRunner({
+        sshExecutor: secondExecutor,
+        orchestrator: {
+          getTask: () => secondTask,
+          getAllTasks: () => [secondTask],
+          markTaskRunningAfterLaunch: () => true,
+          handleWorkerResponse: () => [],
+          deferTask,
+        },
+        persistence: {
+          ...adapter,
+          updateTask: vi.fn(),
+          updateAttempt: vi.fn(),
+          appendTaskOutput: vi.fn(),
+          logEvent: vi.fn(),
+          claimExecutionResourceLease: adapter.claimExecutionResourceLease.bind(adapter),
+          renewExecutionResourceLease: adapter.renewExecutionResourceLease.bind(adapter),
+          releaseExecutionResourceLease: adapter.releaseExecutionResourceLease.bind(adapter),
+        },
+      });
+
+      const firstRun = firstRunner.executeTask(firstTask);
+      await vi.waitFor(() => expect(firstExecutor.start).toHaveBeenCalledTimes(1));
+      await secondRunner.executeTask(secondTask);
+
+      expect(secondExecutor.start).not.toHaveBeenCalled();
+      expect(deferTask).toHaveBeenCalledWith(secondTask.id);
+
+      firstComplete?.({
+        requestId: 'req',
+        actionId: firstTask.id,
+        attemptId: firstTask.execution.selectedAttemptId,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+      await firstRun;
+    } finally {
+      adapter.close();
+    }
+  });
+});

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -80,6 +80,8 @@ type ActiveExecutionEntry = {
   taskId: string;
   poolId?: string;
   poolMemberKey?: string;
+  leaseResourceKey?: string;
+  leaseHolderId?: string;
 };
 
 type ExecutionPoolMember =
@@ -97,6 +99,8 @@ type PoolSelection = {
   member: ExecutionPoolMember;
   memberKey: string;
   selectionStrategy: 'roundRobin' | 'leastLoaded';
+  leaseResourceKey?: string;
+  leaseHolderId?: string;
 };
 
 function isRetryableSshStartupTransportError(err: unknown): boolean {
@@ -235,6 +239,7 @@ export class TaskRunner {
   private dockerConfig: { imageName?: string; secretsFile?: string };
   private executionAgentRegistry?: AgentRegistry;
   private logger: Logger;
+  private readonly runnerInstanceId = randomUUID();
   /** Cache for SSH executors, keyed by poolMemberId. One instance per target for correct git locking. */
   private sshExecutorCache = new Map<string, SshExecutor>();
   private poolRoundRobinCursor = new Map<string, number>();
@@ -346,6 +351,9 @@ export class TaskRunner {
     const resolved = this.resolveActiveExecution(taskId);
     if (!resolved) return;
     this.activeExecutions.delete(resolved.attemptId);
+    if (resolved.entry.leaseResourceKey && resolved.entry.leaseHolderId) {
+      this.persistence.releaseExecutionResourceLease?.(resolved.entry.leaseResourceKey, resolved.entry.leaseHolderId);
+    }
     try {
       await resolved.entry.executor.kill(resolved.entry.handle);
     } catch {
@@ -738,6 +746,13 @@ export class TaskRunner {
       bench('selectExecutor.start');
       executor = this.selectExecutor(task, attemptedPoolMemberKeys);
       const poolSelectionForStart = this.pendingPoolSelections.get(task.id);
+      if (!this.acquirePoolSelectionLease(task, attemptId, poolSelectionForStart)) {
+        if (poolSelectionForStart) {
+          attemptedPoolMemberKeys.add(poolSelectionForStart.memberKey);
+          this.pendingPoolSelections.delete(task.id);
+        }
+        continue;
+      }
       bench('selectExecutor.end', {
         executorType: executor.type,
       });
@@ -759,6 +774,7 @@ export class TaskRunner {
       const startTimeoutMs = getExecutorStartTimeoutMs();
       const preStartHeartbeatTimer = setInterval(() => {
         const now = new Date();
+        this.renewPoolSelectionLease(poolSelectionForStart);
         this.persistence.updateAttempt?.(attemptId, {
           lastHeartbeatAt: now,
           leaseExpiresAt: nextLeaseExpiry(now),
@@ -808,6 +824,7 @@ export class TaskRunner {
               error: err instanceof Error ? err.message : String(err),
             });
             this.pendingPoolSelections.delete(task.id);
+            this.releasePoolSelectionLease(poolSelectionForStart);
             continue;
           }
         }
@@ -847,6 +864,7 @@ export class TaskRunner {
           });
         }
         this.pendingPoolSelections.delete(task.id);
+        this.releasePoolSelectionLease(poolSelectionForStart);
         const wrapped = new Error(
           `Executor startup failed (${executor.type}): ${err instanceof Error ? err.message : String(err)}`,
           { cause: err },
@@ -882,6 +900,7 @@ export class TaskRunner {
       } catch (killErr) {
         this.logger.warn(`[TaskRunner] failed to kill rejected launch for task=${task.id}`, { killErr });
       }
+      this.releasePoolSelectionLease(this.pendingPoolSelections.get(task.id));
       this.pendingPoolSelections.delete(task.id);
       await this.cleanupPerTaskDockerExecutor(task);
       bench('markTaskRunningAfterLaunch.rejected');
@@ -893,6 +912,7 @@ export class TaskRunner {
     {
       // Fail-fast: workspacePath must be provided by all executors
       if (!handle.workspacePath) {
+        this.releasePoolSelectionLease(this.pendingPoolSelections.get(task.id));
         throw new Error(
           `Executor "${executor.type}" did not provide workspacePath for task "${task.id}". ` +
           `All executors must set workspacePath; refusing to fall back to host repo.`,
@@ -969,6 +989,8 @@ export class TaskRunner {
       taskId: task.id,
       poolId: poolSelection?.poolId,
       poolMemberKey: poolSelection?.memberKey,
+      leaseResourceKey: poolSelection?.leaseResourceKey,
+      leaseHolderId: poolSelection?.leaseHolderId,
     });
     this.logger.info(
       `[TaskRunner] active execution registered task=${task.id} attempt=${attemptId} ` +
@@ -993,6 +1015,10 @@ export class TaskRunner {
             `at=${now.toISOString()}`,
         );
       }
+      const activeLease = this.activeExecutions.get(attemptId);
+      if (activeLease?.leaseResourceKey && activeLease.leaseHolderId) {
+        this.persistence.renewExecutionResourceLease?.(activeLease.leaseResourceKey, activeLease.leaseHolderId);
+      }
       this.persistence.updateAttempt?.(attemptId, {
         lastHeartbeatAt: now,
         leaseExpiresAt: nextLeaseExpiry(now),
@@ -1015,6 +1041,10 @@ export class TaskRunner {
       executor.onComplete(handle, async (response: WorkResponse) => {
         const work = async () => {
           const normalizedResponse = response.attemptId ? response : { ...response, attemptId };
+          const activeExecution = this.activeExecutions.get(normalizedResponse.attemptId ?? attemptId);
+          if (activeExecution?.leaseResourceKey && activeExecution.leaseHolderId) {
+            this.persistence.releaseExecutionResourceLease?.(activeExecution.leaseResourceKey, activeExecution.leaseHolderId);
+          }
           this.activeExecutions.delete(normalizedResponse.attemptId ?? attemptId);
           this.logger.info(
             `[TaskRunner] completion callback task=${task.id} attempt=${normalizedResponse.attemptId ?? attemptId} ` +
@@ -1096,6 +1126,15 @@ export class TaskRunner {
     return load;
   }
 
+  private poolMemberLimit(pool: ExecutionPoolConfig, member: ExecutionPoolMember): number | undefined {
+    return member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
+  }
+
+  private poolMemberHasCapacity(poolId: string, pool: ExecutionPoolConfig, member: ExecutionPoolMember): boolean {
+    const limit = this.poolMemberLimit(pool, member);
+    return limit === undefined || this.poolMemberLoad(poolId, this.poolMemberKey(member)) < limit;
+  }
+
   private selectPoolMember(
     poolId: string,
     pool: ExecutionPoolConfig,
@@ -1109,6 +1148,7 @@ export class TaskRunner {
         const index = (cursor + offset) % pool.members.length;
         const member = pool.members[index];
         if (excludedMemberKeys.has(this.poolMemberKey(member))) continue;
+        if (!this.poolMemberHasCapacity(poolId, pool, member)) continue;
         this.poolRoundRobinCursor.set(poolId, (index + 1) % pool.members.length);
         return member;
       }
@@ -1118,14 +1158,99 @@ export class TaskRunner {
     const scored = pool.members.filter((member) => !excludedMemberKeys.has(this.poolMemberKey(member))).map((member, index) => {
       const memberKey = this.poolMemberKey(member);
       const load = this.poolMemberLoad(poolId, memberKey);
-      const limit = member.maxConcurrentTasks ?? pool.maxConcurrentTasksPerMember;
+      const limit = this.poolMemberLimit(pool, member);
       return { member, index, load, hasCapacity: limit === undefined || load < limit };
     });
-    const candidates = scored.some((entry) => entry.hasCapacity)
-      ? scored.filter((entry) => entry.hasCapacity)
-      : scored;
+    const candidates = scored.filter((entry) => entry.hasCapacity);
     candidates.sort((a, b) => a.load - b.load || a.index - b.index);
     return candidates[0]?.member;
+  }
+
+  private poolCapacitySnapshot(poolId: string, pool: ExecutionPoolConfig): Array<{
+    memberId: string;
+    memberType: string;
+    load: number;
+    limit: number | undefined;
+  }> {
+    return pool.members.map((member) => {
+      const memberKey = this.poolMemberKey(member);
+      return {
+        memberId: member.id,
+        memberType: member.type,
+        load: this.poolMemberLoad(poolId, memberKey),
+        limit: this.poolMemberLimit(pool, member),
+      };
+    });
+  }
+
+  private poolCapacityError(taskId: string, poolId: string, pool: ExecutionPoolConfig, excludedMemberKeys: Set<string>): Error {
+    const snapshot = this.poolCapacitySnapshot(poolId, pool);
+    const message = `Execution pool "${poolId}" has no member capacity available`;
+    const resourceLimit = new ResourceLimitError(message);
+    this.persistence.logEvent?.(taskId, 'task.executor.deferred', {
+      reason: 'execution-pool-capacity',
+      poolId,
+      excludedMemberKeys: [...excludedMemberKeys],
+      members: snapshot,
+    });
+    this.logger.info(`[TaskRunner] deferring task: ${message}`, {
+      poolId,
+      excludedMemberKeys: [...excludedMemberKeys],
+      members: snapshot,
+    });
+    return new Error(message, { cause: resourceLimit });
+  }
+
+  private sshResourceKey(target: RemoteTargetDisplay): string {
+    return `ssh:${target.user}@${target.host}:${target.port ?? 22}`;
+  }
+
+  private leaseHolderId(taskId: string, attemptId: string): string {
+    return `${this.runnerInstanceId}:${process.pid}:${taskId}:${attemptId}`;
+  }
+
+  private acquirePoolSelectionLease(task: TaskState, attemptId: string, selection: PoolSelection | undefined): boolean {
+    if (!selection || selection.member.type !== 'ssh') return true;
+    const target = this.getRemoteTargets()[selection.member.id];
+    if (!target) return true;
+    const resourceKey = this.sshResourceKey(target);
+    const holderId = this.leaseHolderId(task.id, attemptId);
+    const acquired = this.persistence.claimExecutionResourceLease?.({
+      resourceKey,
+      resourceType: 'ssh',
+      holderId,
+      taskId: task.id,
+      poolId: selection.poolId,
+      poolMemberId: selection.member.id,
+      metadata: {
+        runnerInstanceId: this.runnerInstanceId,
+        pid: process.pid,
+      },
+    }) ?? true;
+    if (!acquired) {
+      this.persistence.logEvent?.(task.id, 'task.executor.deferred', {
+        reason: 'ssh-resource-lease-held',
+        poolId: selection.poolId,
+        poolMemberId: selection.member.id,
+        resourceKey,
+      });
+      return false;
+    }
+    selection.leaseResourceKey = resourceKey;
+    selection.leaseHolderId = holderId;
+    return true;
+  }
+
+  private renewPoolSelectionLease(selection: PoolSelection | undefined): void {
+    if (!selection?.leaseResourceKey || !selection.leaseHolderId) return;
+    this.persistence.renewExecutionResourceLease?.(selection.leaseResourceKey, selection.leaseHolderId);
+  }
+
+  private releasePoolSelectionLease(selection: PoolSelection | undefined): void {
+    if (!selection?.leaseResourceKey || !selection.leaseHolderId) return;
+    this.persistence.releaseExecutionResourceLease?.(selection.leaseResourceKey, selection.leaseHolderId);
+    selection.leaseResourceKey = undefined;
+    selection.leaseHolderId = undefined;
   }
 
   private logExecutorSelected(
@@ -1220,6 +1345,8 @@ export class TaskRunner {
           memberKey: this.poolMemberKey(member),
           selectionStrategy: pool.selectionStrategy ?? 'roundRobin',
         });
+      } else if (pool) {
+        throw this.poolCapacityError(task.id, task.config.poolId, pool, excludedPoolMemberKeys);
       }
     }
     if (

--- a/scripts/repro/repro-ssh-pool-member-overcommit.sh
+++ b/scripts/repro/repro-ssh-pool-member-overcommit.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECT="fixed"
+
+case "${1:-}" in
+  --expect)
+    EXPECT="${2:-}"
+    ;;
+  --expect=*)
+    EXPECT="${1#--expect=}"
+    ;;
+  "")
+    ;;
+  *)
+    echo "usage: $0 [--expect broken|fixed]" >&2
+    exit 2
+    ;;
+esac
+
+if [[ "$EXPECT" != "broken" && "$EXPECT" != "fixed" ]]; then
+  echo "usage: $0 [--expect broken|fixed]" >&2
+  exit 2
+fi
+
+TEST_FILE="$ROOT/packages/execution-engine/src/__tests__/ssh-pool-member-overcommit.$$.repro.test.ts"
+
+cleanup() {
+  rm -f "$TEST_FILE"
+}
+trap cleanup EXIT
+
+cat > "$TEST_FILE" <<'TS'
+import { describe, expect, it, vi } from 'vitest';
+import { TaskRunner } from '../task-runner.js';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { TaskState } from '@invoker/workflow-core';
+
+const expectFixed = process.env.INVOKER_REPRO_EXPECT === 'fixed';
+
+function makeTask(id: string): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { runnerKind: 'ssh', poolId: 'ssh-pool' },
+    execution: {},
+  } as TaskState;
+}
+
+function makeRunner(): TaskRunner {
+  const sshExecutor = {
+    type: 'ssh',
+    start: vi.fn(),
+    onComplete: vi.fn(),
+    onOutput: vi.fn(),
+    onHeartbeat: vi.fn(),
+    kill: vi.fn(),
+    destroyAll: vi.fn(),
+  };
+
+  return new TaskRunner({
+    orchestrator: { getTask: () => null, getAllTasks: () => [] } as any,
+    persistence: {} as any,
+    executorRegistry: {
+      getDefault: () => sshExecutor,
+      get: (type: string) => type === 'ssh' ? sshExecutor : null,
+      getAll: () => [sshExecutor],
+      register: vi.fn(),
+    } as any,
+    cwd: '/tmp',
+    remoteTargetsProvider: () => ({
+      'remote-a': {
+        host: 'remote-a.example.com',
+        user: 'invoker',
+        sshKeyPath: '/tmp/fake-key',
+        managedWorkspaces: true,
+      },
+    }),
+    executionPoolsProvider: () => ({
+      'ssh-pool': {
+        selectionStrategy: 'leastLoaded',
+        maxConcurrentTasksPerMember: 1,
+        members: [{ id: 'remote-a', type: 'ssh' as const, maxConcurrentTasks: 1 }],
+      },
+    }),
+  });
+}
+
+describe('ssh pool member overcommit repro', () => {
+  it('does not admit a second task onto a maxConcurrentTasks=1 SSH member', () => {
+    const runner = makeRunner();
+    const first = makeTask('wf-1/task-a');
+    const second = makeTask('wf-2/task-b');
+
+    runner.selectExecutor(first);
+    const firstSelection = (runner as any).pendingPoolSelections.get(first.id);
+    expect(firstSelection?.member.id).toBe('remote-a');
+
+    if (expectFixed) {
+      expect(() => runner.selectExecutor(second)).toThrow(/no member capacity/);
+    } else {
+      runner.selectExecutor(second);
+      const secondSelection = (runner as any).pendingPoolSelections.get(second.id);
+      expect(secondSelection?.member.id).toBe('remote-a');
+    }
+  });
+
+  it('uses a durable lease to make separate owners defer instead of starting on the same SSH member', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    try {
+      const firstTask = makeTask('wf-1/task-a');
+      const secondTask = makeTask('wf-2/task-b');
+      let firstComplete: ((response: any) => void) | undefined;
+      const firstExecutor = {
+        type: 'ssh',
+        start: vi.fn(async (request: any) => ({
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/remote/task-a',
+        })),
+        onComplete: vi.fn((_handle: any, cb: any) => { firstComplete = cb; }),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+        destroyAll: vi.fn(),
+      };
+      const secondExecutor = {
+        type: 'ssh',
+        start: vi.fn(async (request: any) => ({
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/remote/task-b',
+        })),
+        onComplete: vi.fn(),
+        onOutput: vi.fn(),
+        onHeartbeat: vi.fn(),
+        kill: vi.fn(),
+        destroyAll: vi.fn(),
+      };
+      const runnerA = makeRunnerWith({ adapter, task: firstTask, executor: firstExecutor, deferTask: vi.fn() });
+      const deferTask = vi.fn();
+      const runnerB = makeRunnerWith({ adapter, task: secondTask, executor: secondExecutor, deferTask });
+
+      const firstRun = runnerA.executeTask(firstTask);
+      await vi.waitFor(() => expect(firstExecutor.start).toHaveBeenCalledTimes(1));
+      await runnerB.executeTask(secondTask);
+
+      if (expectFixed) {
+        expect(secondExecutor.start).not.toHaveBeenCalled();
+        expect(deferTask).toHaveBeenCalledWith(secondTask.id);
+      } else {
+        expect(secondExecutor.start).toHaveBeenCalledTimes(1);
+      }
+
+      firstComplete?.({
+        requestId: 'req',
+        actionId: firstTask.id,
+        attemptId: firstTask.execution.selectedAttemptId,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+      await firstRun;
+    } finally {
+      adapter.close();
+    }
+  });
+});
+
+function makeRunnerWith(input: { adapter: SQLiteAdapter; task: TaskState; executor: any; deferTask: any }): TaskRunner {
+  return new TaskRunner({
+    orchestrator: {
+      getTask: () => input.task,
+      getAllTasks: () => [input.task],
+      markTaskRunningAfterLaunch: () => true,
+      handleWorkerResponse: () => [],
+      deferTask: input.deferTask,
+    } as any,
+    persistence: {
+      ...input.adapter,
+      updateTask: vi.fn(),
+      updateAttempt: vi.fn(),
+      appendTaskOutput: vi.fn(),
+      logEvent: vi.fn(),
+      claimExecutionResourceLease: input.adapter.claimExecutionResourceLease.bind(input.adapter),
+      renewExecutionResourceLease: input.adapter.renewExecutionResourceLease.bind(input.adapter),
+      releaseExecutionResourceLease: input.adapter.releaseExecutionResourceLease.bind(input.adapter),
+    } as any,
+    executorRegistry: {
+      getDefault: () => input.executor,
+      get: (type: string) => type === 'ssh' ? input.executor : null,
+      getAll: () => [input.executor],
+      register: vi.fn(),
+    } as any,
+    cwd: '/tmp',
+    remoteTargetsProvider: () => ({
+      'remote-a': {
+        host: 'remote-a.example.com',
+        user: 'invoker',
+        sshKeyPath: '/tmp/fake-key',
+        managedWorkspaces: true,
+      },
+    }),
+    executionPoolsProvider: () => ({
+      'ssh-pool': {
+        selectionStrategy: 'leastLoaded',
+        maxConcurrentTasksPerMember: 1,
+        members: [{ id: 'remote-a', type: 'ssh' as const, maxConcurrentTasks: 1 }],
+      },
+    }),
+  });
+}
+TS
+
+cd "$ROOT"
+echo "repro: running SSH pool overcommit repro with --expect $EXPECT"
+INVOKER_REPRO_EXPECT="$EXPECT" pnpm --filter @invoker/execution-engine exec vitest run "$TEST_FILE"


### PR DESCRIPTION
## Summary

SSH pool member limits are now hard admission caps instead of selection hints. When every eligible member is full, the task is deferred through the existing resource-limit path instead of starting another executor on the same remote host.

This also adds a SQLite-backed execution resource lease for SSH targets so separate TaskRunner instances cannot both start work on the same machine, plus a repro that proves the overcommit case stays fixed.

## Architecture

### Before

```mermaid
graph TD
    A[TaskRunner selects pool member] --> B{Any member scored?}
    B --> C[Pick least loaded member]
    C --> D[Start SSH executor]
    D --> E[Multiple owners can start on same host]
```

### After

```mermaid
graph TD
    A[TaskRunner selects pool member] --> B{Member below capacity?}
    B -- no --> C[ResourceLimitError]
    C --> D[orchestrator.deferTask]
    B -- yes --> E{Acquire SSH resource lease?}
    E -- no --> C
    E -- yes --> F[Start SSH executor]
    F --> G[Heartbeat and release lease]
```

## Test Plan

- [x] `bash scripts/repro/repro-ssh-pool-member-overcommit.sh`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-pool-member-capacity.test.ts`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts -t "execution resource leases"`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "pool member|startup transport|fallback|SSH"`
- [ ] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/pool-member-mismatch-publish-repro.test.ts` not run on this base because the test file is not present on `upstream/master`.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 530e7e9f`
- Post-revert steps: Re-run SSH pool tests to confirm prior behavior is restored.
- Data migration? No destructive migration. The new `execution_resource_leases` table is additive and can be left unused after revert.
