### PR TITLE
Fix recreate-all dispatch acknowledgement

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -828,6 +828,40 @@ describe('POST /api/workflows/:id/fork', () => {
 });
 
 describe('POST /api/workflows/:id/rebase-recreate', () => {
+  it('queues rebase-recreate through the workflow mutation coordinator when available', async () => {
+    const localMocks = createMocks();
+    localMocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask()]);
+    const queueWorkflowMutation = vi.fn(() => 123);
+    const queuedApi = startApiServer({
+      orchestrator: localMocks.orchestrator as any,
+      persistence: localMocks.persistence as any,
+      executorRegistry: localMocks.executorRegistry as any,
+      mutations: buildFacade(localMocks),
+      queueWorkflowMutation,
+      deleteWorkflow: localMocks.deleteWorkflow,
+      detachWorkflow: localMocks.detachWorkflow,
+    });
+    await new Promise<void>((resolve) => {
+      if (queuedApi.server.listening) resolve();
+      else queuedApi.server.on('listening', resolve);
+    });
+    const queuedAddr = queuedApi.server.address();
+    const queuedPort = typeof queuedAddr === 'object' && queuedAddr ? queuedAddr.port : queuedApi.port;
+
+    try {
+      const res = await request(queuedPort, 'POST', '/api/workflows/wf-1/rebase-recreate');
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.queued).toBe(true);
+      expect(res.body.intentId).toBe(123);
+      expect(queueWorkflowMutation).toHaveBeenCalledWith('wf-1', 'high', 'invoker:rebase-recreate', ['wf-1']);
+      expect(localMocks.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+    } finally {
+      await queuedApi.close();
+    }
+  });
+
   it('recreates workflow from fresh base', async () => {
     mocks.orchestrator.recreateWorkflow = vi.fn(() => [makeTask()]);
     const res = await request(port, 'POST', '/api/workflows/wf-1/rebase-recreate');

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -51,6 +51,7 @@ import type { SQLiteAdapter } from '@invoker/data-store';
 import type { ExecutorRegistry } from '@invoker/execution-engine';
 import type { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
+import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 
 export interface ApiServerDeps {
   logger?: Logger;
@@ -59,6 +60,13 @@ export interface ApiServerDeps {
   executorRegistry: ExecutorRegistry;
   /** All write endpoints delegate to the facade for mutation + dispatch + topup. */
   mutations: WorkflowMutationFacade;
+  queueWorkflowMutation?: (
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: string,
+    args: unknown[],
+    options?: { deferDrain?: boolean },
+  ) => number;
   deleteWorkflow: (workflowId: string) => Promise<void>;
   detachWorkflow: (workflowId: string, upstreamWorkflowId: string) => Promise<void>;
 }
@@ -384,6 +392,18 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         const workflowTarget = decodeURIComponent(wfRebaseRecreateMatch[1]);
         try {
           const workflowId = resolveHeadlessTargetWorkflowId(workflowTarget, persistence);
+          if (deps.queueWorkflowMutation) {
+            const intentId = deps.queueWorkflowMutation(workflowId, 'high', 'invoker:rebase-recreate', [workflowId]);
+            json(res, 202, {
+              ok: true,
+              workflowId,
+              action: 'rebase_recreated',
+              queued: true,
+              intentId,
+              tasksStarted: 0,
+            });
+            return;
+          }
           const result = await mutations.rebaseRecreate(workflowId);
           const tasksStarted = result.started.filter(t => t.status === 'running').length;
           json(res, 200, {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -266,6 +266,65 @@ interface HeadlessExecMutationPayload {
   traceId?: string;
 }
 
+type HeadlessOwnerMode = 'standalone' | 'gui';
+
+function headlessExecLogFields(
+  payload: HeadlessExecMutationPayload,
+  mode: HeadlessOwnerMode,
+  extra: Record<string, string | number | undefined> = {},
+): string {
+  const fields: Record<string, string | number | undefined> = {
+    trace: payload.traceId ?? '<none>',
+    args: `"${payload.args.join(' ')}"`,
+    noTrack: payload.noTrack ? 'true' : 'false',
+    ...extra,
+    coordinator: workflowMutationCoordinator ? 'true' : 'false',
+    mode,
+  };
+  return Object.entries(fields)
+    .map(([key, value]) => `${key}=${value ?? '<none>'}`)
+    .join(' ');
+}
+
+function logHeadlessExecReceived(payload: HeadlessExecMutationPayload, mode: HeadlessOwnerMode): void {
+  logger.info(
+    `headless.exec received ${headlessExecLogFields(payload, mode, { ownerId: workflowMutationOwnerId })}`,
+    { module: 'ipc-delegate' },
+  );
+}
+
+function acknowledgeNoTrackHeadlessExec(
+  payload: HeadlessExecMutationPayload,
+  workflowId: string | undefined,
+  priority: WorkflowMutationPriority,
+  mode: HeadlessOwnerMode,
+): { ok: true; intentId: number } | undefined {
+  logger.info(
+    `headless.exec decision ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId ?? '<none>'}"`, priority })}`,
+    { module: 'ipc-delegate' },
+  );
+
+  if (!payload.noTrack) return undefined;
+
+  if (workflowId && workflowMutationCoordinator) {
+    const intentId = workflowMutationCoordinator.submit(workflowId, priority, 'headless.exec', [payload], {
+      deferDrain: true,
+    });
+    logger.info(
+      `headless.exec accepted ${headlessExecLogFields(payload, mode, { workflow: `"${workflowId}"`, intent: intentId, priority })}`,
+      { module: 'ipc-delegate' },
+    );
+    return { ok: true, intentId };
+  }
+
+  const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
+  logger.error(
+    `headless.exec rejected ${headlessExecLogFields(payload, mode, { reason, workflow: `"${workflowId ?? '<none>'}"` })}`,
+    { module: 'ipc-delegate' },
+  );
+  throw new Error(`Fire-and-forget headless.exec could not be queued: ${reason}`);
+}
+
 // Root logger: created early in initServices() once persistence is available.
 // Before initServices(), use the pre-init logger (file-only, no DB).
 let logger: Logger = new FileAndDbLogger({ module: 'main' });
@@ -1091,39 +1150,16 @@ if (isHeadless) {
           if (!Array.isArray(args) || args.length === 0) {
             throw new Error('Missing delegated headless command arguments');
           }
-          logger.info(
-            `headless.exec received trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=${delegatedNoTrack ? 'true' : 'false'} ownerId=${workflowMutationOwnerId} coordinator=${workflowMutationCoordinator ? 'true' : 'false'} mode=standalone`,
-            { module: 'ipc-delegate' },
-          );
           const payload: HeadlessExecMutationPayload = {
             args,
             waitForApproval: delegatedWait,
             noTrack: delegatedNoTrack,
             traceId,
           };
+          logHeadlessExecReceived(payload, 'standalone');
           const { workflowId, priority } = classifyStandaloneHeadlessExecMutation(payload);
-          logger.info(
-            `headless.exec decision trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=${delegatedNoTrack ? 'true' : 'false'} workflow="${workflowId ?? '<none>'}" coordinator=${workflowMutationCoordinator ? 'true' : 'false'} priority=${priority} mode=standalone`,
-            { module: 'ipc-delegate' },
-          );
-          if (delegatedNoTrack && workflowId && workflowMutationCoordinator) {
-            const intentId = workflowMutationCoordinator.submit(workflowId, priority, 'headless.exec', [payload], {
-              deferDrain: true,
-            });
-            logger.info(
-              `headless.exec accepted trace=${traceId ?? '<none>'} workflow="${workflowId}" intent=${intentId} noTrack=true priority=${priority} mode=standalone`,
-              { module: 'ipc-delegate' },
-            );
-            return { ok: true, intentId };
-          }
-          if (delegatedNoTrack) {
-            const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
-            logger.error(
-              `headless.exec rejected trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=true reason=${reason} workflow="${workflowId ?? '<none>'}" coordinator=${workflowMutationCoordinator ? 'true' : 'false'} mode=standalone`,
-              { module: 'ipc-delegate' },
-            );
-            throw new Error(`Fire-and-forget headless.exec could not be queued: ${reason}`);
-          }
+          const acknowledgement = acknowledgeNoTrackHeadlessExec(payload, workflowId, priority, 'standalone');
+          if (acknowledgement) return acknowledgement;
           await runStandaloneWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => {
             await runHeadless(args, {
               ...headlessDeps,
@@ -2731,39 +2767,16 @@ function createEmbeddedTerminalBackendFromConfig(
         if (!Array.isArray(args) || args.length === 0) {
           throw new Error('Missing delegated headless command arguments');
         }
-        logger.info(
-          `headless.exec received trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=${delegatedNoTrack ? 'true' : 'false'} ownerId=${workflowMutationOwnerId} coordinator=${workflowMutationCoordinator ? 'true' : 'false'} mode=gui`,
-          { module: 'ipc-delegate' },
-        );
         const payload: HeadlessExecMutationPayload = {
           args,
           waitForApproval: delegatedWait,
           noTrack: delegatedNoTrack,
           traceId,
         };
+        logHeadlessExecReceived(payload, 'gui');
         const { workflowId, priority } = classifyHeadlessExecMutation(payload);
-        logger.info(
-          `headless.exec decision trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=${delegatedNoTrack ? 'true' : 'false'} workflow="${workflowId ?? '<none>'}" coordinator=${workflowMutationCoordinator ? 'true' : 'false'} priority=${priority} mode=gui`,
-          { module: 'ipc-delegate' },
-        );
-        if (delegatedNoTrack && workflowId && workflowMutationCoordinator) {
-          const intentId = workflowMutationCoordinator.submit(workflowId, priority, 'headless.exec', [payload], {
-            deferDrain: true,
-          });
-          logger.info(
-            `headless.exec accepted trace=${traceId ?? '<none>'} workflow="${workflowId}" intent=${intentId} noTrack=true priority=${priority} mode=gui`,
-            { module: 'ipc-delegate' },
-          );
-          return { ok: true, intentId };
-        }
-        if (delegatedNoTrack) {
-          const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
-          logger.error(
-            `headless.exec rejected trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=true reason=${reason} workflow="${workflowId ?? '<none>'}" coordinator=${workflowMutationCoordinator ? 'true' : 'false'} mode=gui`,
-            { module: 'ipc-delegate' },
-          );
-          throw new Error(`Fire-and-forget headless.exec could not be queued: ${reason}`);
-        }
+        const acknowledgement = acknowledgeNoTrackHeadlessExec(payload, workflowId, priority, 'gui');
+        if (acknowledgement) return acknowledgement;
         return runWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => executeHeadlessExec(payload));
       });
       logger.info(`owner-ipc-ready ownerId=${workflowMutationOwnerId}`, { module: 'ipc-delegate' });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1092,7 +1092,7 @@ if (isHeadless) {
             throw new Error('Missing delegated headless command arguments');
           }
           logger.info(
-            `headless.exec received trace=${traceId ?? '<none>'} args="${args.join(' ')}" ownerId=${workflowMutationOwnerId} mode=standalone`,
+            `headless.exec received trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=${delegatedNoTrack ? 'true' : 'false'} ownerId=${workflowMutationOwnerId} coordinator=${workflowMutationCoordinator ? 'true' : 'false'} mode=standalone`,
             { module: 'ipc-delegate' },
           );
           const payload: HeadlessExecMutationPayload = {
@@ -1102,6 +1102,10 @@ if (isHeadless) {
             traceId,
           };
           const { workflowId, priority } = classifyStandaloneHeadlessExecMutation(payload);
+          logger.info(
+            `headless.exec decision trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=${delegatedNoTrack ? 'true' : 'false'} workflow="${workflowId ?? '<none>'}" coordinator=${workflowMutationCoordinator ? 'true' : 'false'} priority=${priority} mode=standalone`,
+            { module: 'ipc-delegate' },
+          );
           if (delegatedNoTrack && workflowId && workflowMutationCoordinator) {
             const intentId = workflowMutationCoordinator.submit(workflowId, priority, 'headless.exec', [payload], {
               deferDrain: true,
@@ -1111,6 +1115,14 @@ if (isHeadless) {
               { module: 'ipc-delegate' },
             );
             return { ok: true, intentId };
+          }
+          if (delegatedNoTrack) {
+            const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
+            logger.error(
+              `headless.exec rejected trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=true reason=${reason} workflow="${workflowId ?? '<none>'}" coordinator=${workflowMutationCoordinator ? 'true' : 'false'} mode=standalone`,
+              { module: 'ipc-delegate' },
+            );
+            throw new Error(`Fire-and-forget headless.exec could not be queued: ${reason}`);
           }
           await runStandaloneWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => {
             await runHeadless(args, {
@@ -2396,6 +2408,12 @@ function createEmbeddedTerminalBackendFromConfig(
           autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
           killRunningTask,
         }),
+        queueWorkflowMutation: (workflowId, priority, channel, args, options) => {
+          if (!workflowMutationCoordinator) {
+            throw new Error('Workflow mutation coordinator is unavailable');
+          }
+          return workflowMutationCoordinator.submit(workflowId, priority, channel, args, options);
+        },
         deleteWorkflow: performDeleteWorkflow,
         detachWorkflow: performDetachWorkflow,
       });
@@ -2714,7 +2732,7 @@ function createEmbeddedTerminalBackendFromConfig(
           throw new Error('Missing delegated headless command arguments');
         }
         logger.info(
-          `headless.exec received trace=${traceId ?? '<none>'} args="${args.join(' ')}" ownerId=${workflowMutationOwnerId} mode=gui`,
+          `headless.exec received trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=${delegatedNoTrack ? 'true' : 'false'} ownerId=${workflowMutationOwnerId} coordinator=${workflowMutationCoordinator ? 'true' : 'false'} mode=gui`,
           { module: 'ipc-delegate' },
         );
         const payload: HeadlessExecMutationPayload = {
@@ -2724,6 +2742,10 @@ function createEmbeddedTerminalBackendFromConfig(
           traceId,
         };
         const { workflowId, priority } = classifyHeadlessExecMutation(payload);
+        logger.info(
+          `headless.exec decision trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=${delegatedNoTrack ? 'true' : 'false'} workflow="${workflowId ?? '<none>'}" coordinator=${workflowMutationCoordinator ? 'true' : 'false'} priority=${priority} mode=gui`,
+          { module: 'ipc-delegate' },
+        );
         if (delegatedNoTrack && workflowId && workflowMutationCoordinator) {
           const intentId = workflowMutationCoordinator.submit(workflowId, priority, 'headless.exec', [payload], {
             deferDrain: true,
@@ -2733,6 +2755,14 @@ function createEmbeddedTerminalBackendFromConfig(
             { module: 'ipc-delegate' },
           );
           return { ok: true, intentId };
+        }
+        if (delegatedNoTrack) {
+          const reason = !workflowId ? 'workflow-not-resolved' : 'coordinator-unavailable';
+          logger.error(
+            `headless.exec rejected trace=${traceId ?? '<none>'} args="${args.join(' ')}" noTrack=true reason=${reason} workflow="${workflowId ?? '<none>'}" coordinator=${workflowMutationCoordinator ? 'true' : 'false'} mode=gui`,
+            { module: 'ipc-delegate' },
+          );
+          throw new Error(`Fire-and-forget headless.exec could not be queued: ${reason}`);
         }
         return runWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => executeHeadlessExec(payload));
       });

--- a/scripts/headless-ipc.js
+++ b/scripts/headless-ipc.js
@@ -168,6 +168,19 @@ async function requestExec(bus, item, options) {
     waitForApproval: options.waitForApproval,
   };
   const response = await withTimeout(bus.request('headless.exec', payload), options.timeoutMs);
+  if (options.noTrack) {
+    const acknowledged =
+      response &&
+      typeof response === 'object' &&
+      response.ok === true &&
+      (typeof response.intentId === 'number' || typeof response.intentId === 'string');
+    if (!acknowledged) {
+      throw new Error(
+        `Fire-and-forget dispatch was not queued for args "${item.args.join(' ')}"; ` +
+        `expected owner response { ok: true, intentId }, got ${JSON.stringify(response)}`,
+      );
+    }
+  }
   return {
     ...item,
     ok: true,

--- a/scripts/headless-lib.sh
+++ b/scripts/headless-lib.sh
@@ -184,9 +184,16 @@ for raw in output_jsonl.read_text(encoding="utf-8").splitlines():
         continue
     item = json.loads(raw)
     workflow_id = item.get("workflowId") or item.get("label") or "unknown"
+    response = item.get("response")
+    queued = (
+        item.get("ok") is True
+        and isinstance(response, dict)
+        and response.get("ok") is True
+        and response.get("intentId") not in (None, "")
+    )
     (log_dir / f"{workflow_id}.log").write_text(raw + "\n", encoding="utf-8")
     with result_file.open("a", encoding="utf-8") as handle:
-        handle.write(f"{workflow_id}\t{'SUCCEEDED' if item.get('ok') else 'FAILED'}\n")
+        handle.write(f"{workflow_id}\t{'SUCCEEDED' if queued else 'FAILED'}\n")
 PY
 }
 

--- a/scripts/recreate-all.sh
+++ b/scripts/recreate-all.sh
@@ -171,9 +171,9 @@ elif $FOLLOW; then
     exit 1
   fi
 else
-  echo "Dispatched $DISPATCHED workflow(s) (fire-and-forget). Logs: $LOG_DIR"
+  echo "Queued $DISPATCHED workflow mutation intent(s) (fire-and-forget). Logs: $LOG_DIR"
   if [[ "$LAUNCH_FAILED" -ne 0 ]]; then
-    echo "$LAUNCH_FAILED workflow(s) failed to launch."
+    echo "$LAUNCH_FAILED workflow(s) were not acknowledged as queued."
     exit 1
   fi
 fi


### PR DESCRIPTION
## Summary

Fix `scripts/recreate-all.sh` fire-and-forget dispatch reliability by requiring owner acknowledgement that every requested recreate was persisted as a workflow mutation intent.

This change:

- Makes no-track IPC dispatch fail loudly when the owner does not return `{ ok: true, intentId }`.
- Counts only acknowledged queued intents as successful bulk recreate dispatches.
- Routes production HTTP `rebase-recreate` requests through the persisted workflow mutation queue instead of running the long mutation inline.
- Adds owner-side diagnostics for no-track dispatch decisions and rejections.
- Refactors duplicated GUI and standalone `headless.exec` acknowledgement logging into shared helpers for readability.

## Architecture

### Before

```mermaid
flowchart TD
    script["recreate-all.sh"] --> ipc["headless-ipc batch-exec --no-track"]
    ipc --> owner["GUI or standalone owner"]
    owner --> inline["Inline mutation or generic success"]
    ipc --> counted["Script counts IPC success as dispatched"]
```

### After

```mermaid
flowchart TD
    script["recreate-all.sh"] --> ipc["headless-ipc batch-exec --no-track"]
    ipc --> owner["GUI or standalone owner"]
    owner --> queue["Persist workflow mutation intent"]
    queue --> ack["Owner returns ok plus intentId"]
    ack --> success["Script counts queued intent as success"]
    owner --> reject["Reject unresolved workflow or missing coordinator"]
    reject --> failure["Script exits nonzero"]
```

## Test Plan

- [x] `pnpm exec vitest run src/__tests__/api-server.test.ts src/__tests__/owner-delegation.test.ts src/__tests__/headless-transport.test.ts` from `packages/app`
- [x] `pnpm run check:types`
- [x] `bash -n scripts/recreate-all.sh scripts/headless-lib.sh`
- [x] `bash scripts/recreate-all.sh --dry-run`
- [x] `bash scripts/recreate-all.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 80f7827a 37400b0d`
- Post-revert steps: Re-run `bash scripts/recreate-all.sh --dry-run` if script behavior is touched again
- Data migration? No
