### PR TITLE
Add generic task and workflow metadata setters

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -74,6 +74,7 @@ let port: number;
 let mocks: {
   orchestrator: Record<string, ReturnType<typeof vi.fn>>;
   persistence: Record<string, ReturnType<typeof vi.fn>>;
+  commandService: Record<string, ReturnType<typeof vi.fn>>;
   executorRegistry: Record<string, ReturnType<typeof vi.fn>>;
   taskExecutor: Record<string, ReturnType<typeof vi.fn>>;
   killRunningTask: ReturnType<typeof vi.fn>;
@@ -86,6 +87,7 @@ function createMocks() {
     orchestrator: {
       getWorkflowStatus: vi.fn(() => ({ total: 1, completed: 0, failed: 0, running: 1, pending: 0 })),
       getAllTasks: vi.fn(() => [makeTask()]),
+      syncFromDb: vi.fn(),
       startExecution: vi.fn(() => []),
       getTask: vi.fn((id: string) => (id === 'task-1' ? makeTask() : undefined)),
       approve: vi.fn().mockResolvedValue([]),
@@ -122,12 +124,21 @@ function createMocks() {
     persistence: {
       listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'test', generation: 1 }]),
       loadWorkflow: vi.fn(() => ({ id: 'wf-1', generation: 1 })),
+      loadTask: vi.fn((id: string) => (id === 'task-1' ? makeTask() : undefined)),
       updateWorkflow: vi.fn(),
-      loadTasks: vi.fn(() => []),
+      updateTask: vi.fn(),
+      loadTasks: vi.fn(() => [makeTask()]),
+      logEvent: vi.fn(),
       getEvents: vi.fn(() => [{ taskId: 'task-1', eventType: 'started', timestamp: '2024-01-01' }]),
       getTaskOutput: vi.fn(() => 'hello world output'),
     },
     executorRegistry: {},
+    commandService: {
+      runSerializedForWorkflow: vi.fn(async (_workflowId: string, fn: () => unknown) => {
+        await fn();
+        return { ok: true, data: undefined };
+      }),
+    },
     taskExecutor: {
       executeTasks: vi.fn().mockResolvedValue(undefined),
       publishAfterFix: vi.fn().mockResolvedValue(undefined),
@@ -145,6 +156,7 @@ function buildFacade(m: typeof mocks) {
   return new WorkflowMutationFacade({
     orchestrator: m.orchestrator as any,
     persistence: m.persistence as any,
+    commandService: m.commandService as any,
     taskExecutor: m.taskExecutor as any,
     killRunningTask: m.killRunningTask,
   });
@@ -181,7 +193,7 @@ afterAll(async () => {
 
 beforeEach(() => {
   // Reset all mocks between tests
-  for (const group of [mocks.orchestrator, mocks.persistence, mocks.taskExecutor]) {
+  for (const group of [mocks.orchestrator, mocks.persistence, mocks.taskExecutor, mocks.commandService]) {
     for (const fn of Object.values(group)) {
       if (typeof fn === 'function' && 'mockClear' in fn) fn.mockClear();
     }
@@ -193,6 +205,7 @@ beforeEach(() => {
   // Re-apply default return values after clear
   mocks.orchestrator.getWorkflowStatus.mockReturnValue({ total: 1, completed: 0, failed: 0, running: 1, pending: 0 });
   mocks.orchestrator.getAllTasks.mockReturnValue([makeTask()]);
+  mocks.orchestrator.syncFromDb.mockReturnValue(undefined);
   mocks.orchestrator.startExecution.mockReturnValue([]);
   mocks.orchestrator.getTask.mockImplementation((id: string) => (id === 'task-1' ? makeTask() : undefined));
   mocks.orchestrator.approve.mockResolvedValue([]);
@@ -210,7 +223,12 @@ beforeEach(() => {
   });
   mocks.persistence.listWorkflows.mockReturnValue([{ id: 'wf-1', name: 'test', generation: 1 }]);
   mocks.persistence.loadWorkflow.mockReturnValue({ id: 'wf-1', generation: 1 });
-  mocks.persistence.loadTasks.mockReturnValue([]);
+  mocks.persistence.loadTask.mockImplementation((id: string) => (id === 'task-1' ? makeTask() : undefined));
+  mocks.persistence.loadTasks.mockReturnValue([makeTask()]);
+  mocks.commandService.runSerializedForWorkflow.mockImplementation(async (_workflowId: string, fn: () => unknown) => {
+    await fn();
+    return { ok: true, data: undefined };
+  });
   mocks.persistence.getEvents.mockReturnValue([{ taskId: 'task-1', eventType: 'started', timestamp: '2024-01-01' }]);
   mocks.persistence.getTaskOutput.mockReturnValue('hello world output');
   mocks.killRunningTask.mockResolvedValue(undefined);
@@ -964,6 +982,72 @@ describe('POST /api/workflows/:id/merge-mode', () => {
     const res = await request(port, 'POST', '/api/workflows/wf-1/merge-mode', { mode: 'invalid' });
     expect(res.status).toBe(400);
     expect(res.body.error).toContain('Invalid mergeMode');
+  });
+});
+
+describe('PATCH metadata endpoints', () => {
+  it('updates workflow metadata through the facade', async () => {
+    const res = await request(port, 'PATCH', '/api/workflows/wf-1/metadata', {
+      fieldPath: 'repoUrl',
+      value: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.scope).toBe('workflow');
+    expect(mocks.commandService.runSerializedForWorkflow).toHaveBeenCalledWith('wf-1', expect.any(Function));
+    expect(mocks.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', {
+      repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+    });
+  });
+
+  it('updates task metadata through the facade', async () => {
+    const res = await request(port, 'PATCH', '/api/tasks/task-1/metadata', {
+      fieldPath: 'config.poolId',
+      value: 'some-pool',
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.scope).toBe('task');
+    expect(mocks.persistence.updateTask).toHaveBeenCalledWith('task-1', {
+      config: { poolId: 'some-pool' },
+    });
+  });
+
+  it('rejects forbidden fields in normal mode', async () => {
+    const res = await request(port, 'PATCH', '/api/tasks/task-1/metadata', {
+      fieldPath: 'execution.error',
+      value: 'boom',
+    });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('not allowed');
+    expect(mocks.persistence.updateTask).not.toHaveBeenCalled();
+  });
+
+  it('gates raw metadata repair mode', async () => {
+    const original = process.env.INVOKER_ALLOW_RAW_METADATA_SET;
+    delete process.env.INVOKER_ALLOW_RAW_METADATA_SET;
+    const rejected = await request(port, 'PATCH', '/api/tasks/task-1/metadata', {
+      fieldPath: 'raw.execution.error',
+      value: 'boom',
+    });
+    expect(rejected.status).toBe(400);
+    expect(rejected.body.error).toContain('Raw metadata updates are disabled');
+
+    process.env.INVOKER_ALLOW_RAW_METADATA_SET = '1';
+    const accepted = await request(port, 'PATCH', '/api/tasks/task-1/metadata', {
+      fieldPath: 'raw.execution.error',
+      value: 'boom',
+    });
+    expect(accepted.status).toBe(200);
+    expect(mocks.persistence.updateTask).toHaveBeenCalledWith('task-1', {
+      execution: { error: 'boom' },
+    });
+
+    if (original === undefined) delete process.env.INVOKER_ALLOW_RAW_METADATA_SET;
+    else process.env.INVOKER_ALLOW_RAW_METADATA_SET = original;
   });
 });
 

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -107,11 +107,28 @@ describe('headless delegation enforcement', () => {
       ).resolves.toBeUndefined();
     });
 
-    it('allows deprecated list command in read-only mode', async () => {
-      await expect(
-        runHeadless(['list'], mockDeps)
-      ).resolves.toBeUndefined();
-    });
+      it('allows deprecated list command in read-only mode', async () => {
+        await expect(
+          runHeadless(['list'], mockDeps)
+        ).resolves.toBeUndefined();
+      });
+
+      it('allows query workflow for a single workflow', async () => {
+        mockDeps.persistence.loadWorkflow = vi.fn(() => ({
+          id: 'wf-1',
+          name: 'Workflow one',
+          status: 'pending',
+          generation: 0,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        } as any));
+
+        await expect(
+          runHeadless(['query', 'workflow', 'wf-1', '--output', 'json'], mockDeps),
+        ).resolves.toBeUndefined();
+
+        expect(mockDeps.persistence.loadWorkflow).toHaveBeenCalledWith('wf-1');
+      });
 
     it('allows deprecated status command in read-only mode', async () => {
       mockDeps.orchestrator.syncFromDb = vi.fn();
@@ -459,6 +476,77 @@ describe('headless delegation enforcement', () => {
 
         expect(mockDeps.commandService.editTaskAgent).toHaveBeenCalled();
         expect(elapsed).toBeLessThan(1000);
+      });
+
+      it('headless generic setters update workflow and task metadata without dispatching', async () => {
+        mockDeps.commandService.runSerializedForWorkflow = vi.fn(async (_workflowId: string, fn: () => unknown) => {
+          await fn();
+          return { ok: true as const, data: undefined };
+        });
+        mockDeps.orchestrator.syncFromDb = vi.fn();
+        mockDeps.persistence.loadWorkflow = vi.fn(() => ({ id: 'wf-1', name: 'Workflow one' } as any));
+        mockDeps.persistence.loadTask = vi.fn((id: string) => (id === 'task-1'
+          ? {
+              id: 'task-1',
+              status: 'pending',
+              description: 'Task one',
+              dependencies: [],
+              config: { workflowId: 'wf-1' },
+              execution: {},
+            } as any
+          : undefined));
+        mockDeps.persistence.listWorkflows = vi.fn(() => [{
+          id: 'wf-1',
+          name: 'test-workflow',
+          generation: 0,
+          status: 'running' as const,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }]);
+        mockDeps.persistence.loadTasks = vi.fn(() => [{
+          id: 'task-1',
+          status: 'pending',
+          description: 'Task one',
+          dependencies: [],
+          config: { workflowId: 'wf-1' },
+          execution: {},
+        } as any]);
+        mockDeps.persistence.updateWorkflow = vi.fn();
+        mockDeps.persistence.updateTask = vi.fn();
+        mockDeps.persistence.logEvent = vi.fn();
+        const executeTasksSpy = vi.spyOn(TaskRunner.prototype, 'executeTasks');
+
+        await runHeadless(
+          ['set', 'workflow', 'wf-1', 'repoUrl', 'git@github.com:Neko-Catpital-Labs/Invoker.git'],
+          mockDeps,
+        );
+        await runHeadless(['set', 'task', 'task-1', 'config.poolId', 'some-pool'], mockDeps);
+
+        expect(mockDeps.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', {
+          repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+        });
+        expect(mockDeps.persistence.updateTask).toHaveBeenCalledWith('task-1', {
+          config: { poolId: 'some-pool' },
+        });
+        expect(executeTasksSpy).not.toHaveBeenCalled();
+
+        executeTasksSpy.mockRestore();
+      });
+
+      it('headless generic setters reject forbidden fields', async () => {
+        mockDeps.commandService.runSerializedForWorkflow = vi.fn();
+        mockDeps.persistence.loadTask = vi.fn(() => ({
+          id: 'task-1',
+          config: { workflowId: 'wf-1' },
+          execution: {},
+        } as any));
+
+        await expect(runHeadless(['set', 'task', 'task-1', 'execution.error', 'boom'], mockDeps))
+          .rejects.toThrow(/not allowed/);
+        await expect(runHeadless(['set', 'task', 'task-1', 'status', 'failed'], mockDeps))
+          .rejects.toThrow(/not allowed/);
+        await expect(runHeadless(['set', 'task', 'task-1', 'config.workflowId', 'wf-2'], mockDeps))
+          .rejects.toThrow(/not allowed/);
       });
 
       it('headless set mutations dispatch runnable tasks before waiting for completion', async () => {

--- a/packages/app/src/__tests__/metadata-setter.test.ts
+++ b/packages/app/src/__tests__/metadata-setter.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  parseMetadataValue,
+  setTaskMetadata,
+  setWorkflowMetadata,
+} from '../metadata-setter.js';
+
+function makeDeps() {
+  const task = {
+    id: 'task-1',
+    description: 'Task one',
+    dependencies: [],
+    config: { workflowId: 'wf-1' },
+    execution: {},
+  };
+  return {
+    commandService: {
+      runSerializedForWorkflow: vi.fn(async (_workflowId: string, fn: () => unknown) => {
+        await fn();
+        return { ok: true, data: undefined };
+      }),
+    },
+    orchestrator: {
+      syncFromDb: vi.fn(),
+    },
+    persistence: {
+      loadWorkflow: vi.fn(() => ({ id: 'wf-1', name: 'Workflow one' })),
+      listWorkflows: vi.fn(() => [{ id: 'wf-1', name: 'Workflow one' }]),
+      loadTask: vi.fn((id: string) => (id === 'task-1' ? task : undefined)),
+      loadTasks: vi.fn(() => [task]),
+      updateWorkflow: vi.fn(),
+      updateTask: vi.fn(),
+      logEvent: vi.fn(),
+    },
+  } as any;
+}
+
+describe('metadata-setter', () => {
+  const originalRawFlag = process.env.INVOKER_ALLOW_RAW_METADATA_SET;
+
+  beforeEach(() => {
+    delete process.env.INVOKER_ALLOW_RAW_METADATA_SET;
+  });
+
+  afterEach(() => {
+    if (originalRawFlag === undefined) delete process.env.INVOKER_ALLOW_RAW_METADATA_SET;
+    else process.env.INVOKER_ALLOW_RAW_METADATA_SET = originalRawFlag;
+  });
+
+  it('parses JSON values and falls back to strings', () => {
+    expect(parseMetadataValue('null')).toBeNull();
+    expect(parseMetadataValue('["a","b"]')).toEqual(['a', 'b']);
+    expect(parseMetadataValue('git@github.com:Neko-Catpital-Labs/Invoker.git')).toBe('git@github.com:Neko-Catpital-Labs/Invoker.git');
+  });
+
+  it('sets allowed workflow metadata through serialized workflow mutation', async () => {
+    const deps = makeDeps();
+    await setWorkflowMetadata(deps, 'wf-1', 'repoUrl', 'git@github.com:Neko-Catpital-Labs/Invoker.git');
+
+    expect(deps.commandService.runSerializedForWorkflow).toHaveBeenCalledWith('wf-1', expect.any(Function));
+    expect(deps.persistence.updateWorkflow).toHaveBeenCalledWith('wf-1', {
+      repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+    });
+    expect(deps.persistence.logEvent).toHaveBeenCalledWith('task-1', 'workflow.metadata.updated', expect.objectContaining({
+      workflowId: 'wf-1',
+      fieldPath: 'repoUrl',
+    }));
+    expect(deps.orchestrator.syncFromDb).toHaveBeenCalledWith('wf-1');
+  });
+
+  it('sets allowed task config metadata through serialized workflow mutation', async () => {
+    const deps = makeDeps();
+    await setTaskMetadata(deps, 'task-1', 'config.poolId', 'some-pool');
+
+    expect(deps.commandService.runSerializedForWorkflow).toHaveBeenCalledWith('wf-1', expect.any(Function));
+    expect(deps.persistence.updateTask).toHaveBeenCalledWith('task-1', {
+      config: { poolId: 'some-pool' },
+    });
+    expect(deps.persistence.logEvent).toHaveBeenCalledWith('task-1', 'task.metadata.updated', expect.objectContaining({
+      taskId: 'task-1',
+      fieldPath: 'config.poolId',
+    }));
+  });
+
+  it('rejects forbidden task runtime and structural fields in normal mode', async () => {
+    const deps = makeDeps();
+    await expect(setTaskMetadata(deps, 'task-1', 'execution.error', 'boom')).rejects.toThrow(/not allowed/);
+    await expect(setTaskMetadata(deps, 'task-1', 'status', 'failed')).rejects.toThrow(/not allowed/);
+    await expect(setTaskMetadata(deps, 'task-1', 'config.workflowId', 'wf-2')).rejects.toThrow(/not allowed/);
+    expect(deps.persistence.updateTask).not.toHaveBeenCalled();
+  });
+
+  it('rejects invalid enum and type values', async () => {
+    const deps = makeDeps();
+    await expect(setWorkflowMetadata(deps, 'wf-1', 'mergeMode', 'sometimes')).rejects.toThrow(/manual, automatic, external_review/);
+    await expect(setTaskMetadata(deps, 'task-1', 'dependencies', 'task-a')).rejects.toThrow(/array of strings/);
+    await expect(setTaskMetadata(deps, 'task-1', 'config.requiresManualApproval', 'true')).rejects.toThrow(/boolean/);
+  });
+
+  it('gates raw repair mode behind INVOKER_ALLOW_RAW_METADATA_SET', async () => {
+    const deps = makeDeps();
+    await expect(setTaskMetadata(deps, 'task-1', 'raw.execution.error', 'boom')).rejects.toThrow(/Raw metadata updates are disabled/);
+
+    process.env.INVOKER_ALLOW_RAW_METADATA_SET = '1';
+    await setTaskMetadata(deps, 'task-1', 'raw.execution.error', 'boom');
+
+    expect(deps.persistence.updateTask).toHaveBeenCalledWith('task-1', {
+      execution: { error: 'boom' },
+    });
+  });
+});

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -52,6 +52,7 @@ import type { ExecutorRegistry } from '@invoker/execution-engine';
 import type { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
+import { parseMetadataPatchBody } from './metadata-setter.js';
 
 export interface ApiServerDeps {
   logger?: Logger;
@@ -589,6 +590,21 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         return;
       }
 
+      // PATCH /api/tasks/:id/metadata
+      const taskMetadataMatch = path.match(/^\/api\/tasks\/([^/]+)\/metadata$/);
+      if (method === 'PATCH' && taskMetadataMatch) {
+        const taskId = decodeURIComponent(taskMetadataMatch[1]);
+        try {
+          const body = await readBody(req);
+          const patch = parseMetadataPatchBody(body);
+          const result = await mutations.setTaskMetadata(taskId, patch.fieldPath, patch.value, { raw: patch.raw });
+          json(res, 200, { ok: true, ...result });
+        } catch (err) {
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
+        }
+        return;
+      }
+
       // DELETE /api/workflows/:id
       const wfDeleteMatch = path.match(/^\/api\/workflows\/([^/]+)$/);
       if (method === 'DELETE' && wfDeleteMatch) {
@@ -639,6 +655,21 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           }
           await mutations.setWorkflowMergeMode(workflowId, mode);
           json(res, 200, { ok: true, workflowId, action: 'merge_mode_set', mode });
+        } catch (err) {
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
+        }
+        return;
+      }
+
+      // PATCH /api/workflows/:id/metadata
+      const wfMetadataMatch = path.match(/^\/api\/workflows\/([^/]+)\/metadata$/);
+      if (method === 'PATCH' && wfMetadataMatch) {
+        const workflowId = decodeURIComponent(wfMetadataMatch[1]);
+        try {
+          const body = await readBody(req);
+          const patch = parseMetadataPatchBody(body);
+          const result = await mutations.setWorkflowMetadata(workflowId, patch.fieldPath, patch.value, { raw: patch.raw });
+          json(res, 200, { ok: true, ...result });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -15,6 +15,8 @@ export const HEADLESS_SET_SUBCOMMANDS = [
   'fix-prompt',
   'fix-context',
   'gate-policy',
+  'workflow',
+  'task',
 ] as const;
 
 export const HEADLESS_COMMANDS = [

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -32,6 +32,11 @@ import { backupPlan } from './plan-backup.js';
 import { startApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
 import {
+  parseMetadataValue,
+  setTaskMetadata,
+  setWorkflowMetadata,
+} from './metadata-setter.js';
+import {
   approveTask,
   autoFixOnReviewGateFailure,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
@@ -137,6 +142,7 @@ function buildHeadlessApiServerDeps(
       dispatchMode: deps.mutationTiming ? 'fire-and-forget' : 'await',
       autoApproveAIFixes: deps.invokerConfig?.autoApproveAIFixes,
       killRunningTask: (taskId: string) => taskExecutor.killActiveExecution(taskId),
+      commandService: deps.commandService,
     }),
     deleteWorkflow: async (workflowId: string) => {
       const allTasks = deps.orchestrator.getAllTasks();
@@ -413,6 +419,19 @@ async function headlessQuery(args: string[], deps: HeadlessDeps): Promise<void> 
         case 'json':  process.stdout.write(formatAsJson(workflows.map(serializeWorkflow)) + '\n'); break;
         case 'jsonl': process.stdout.write(formatAsJsonl(workflows.map(serializeWorkflow)) + '\n'); break;
         default:      process.stdout.write(formatWorkflowList(workflows) + '\n'); break;
+      }
+      break;
+    }
+    case 'workflow': {
+      const workflowId = flags.positional[0];
+      if (!workflowId) throw new Error('Missing workflowId. Usage: --headless query workflow <workflowId>');
+      const workflow = deps.persistence.loadWorkflow(workflowId);
+      if (!workflow) throw new Error(`Workflow "${workflowId}" not found.`);
+      switch (flags.output) {
+        case 'label': process.stdout.write(`${workflow.id}\n`); break;
+        case 'json':  process.stdout.write(formatAsJson(serializeWorkflow(workflow)) + '\n'); break;
+        case 'jsonl': process.stdout.write(formatAsJsonl([serializeWorkflow(workflow)]) + '\n'); break;
+        default:      process.stdout.write(formatWorkflowList([workflow]) + '\n'); break;
       }
       break;
     }
@@ -867,7 +886,7 @@ async function headlessCostEvents(
 async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
   const subCommand = args[0];
   if (!subCommand) {
-    throw new Error('Missing set sub-command. Usage: --headless set <command|executor|agent|merge-mode|gate-policy>');
+    throw new Error('Missing set sub-command. Usage: --headless set <command|executor|agent|merge-mode|gate-policy|workflow|task>');
   }
 
   switch (subCommand) {
@@ -895,8 +914,14 @@ async function headlessSet(args: string[], deps: HeadlessDeps): Promise<void> {
     case 'gate-policy':
       await headlessSetGatePolicy(args.slice(1), deps);
       break;
+    case 'workflow':
+      await headlessSetWorkflowMetadata(args[1], args[2], args.slice(3).join(' '), deps);
+      break;
+    case 'task':
+      await headlessSetTaskMetadata(args[1], args[2], args.slice(3).join(' '), deps);
+      break;
     default:
-      throw new Error(`Unknown set sub-command: "${subCommand}". Use: command, prompt, executor, agent, merge-mode, fix-prompt, fix-context, gate-policy`);
+      throw new Error(`Unknown set sub-command: "${subCommand}". Use: command, prompt, executor, agent, merge-mode, fix-prompt, fix-context, gate-policy, workflow, task`);
   }
 }
 
@@ -1128,6 +1153,7 @@ ${BOLD}Usage:${RESET}  electron dist/main.js --headless <command> [args...]
 
 ${BOLD}Query${RESET} (read-only, all support --output text|label|json|jsonl):
   query workflows [--status S] [--output F]          List all saved workflows
+  query workflow <workflowId> [--output F]           Show one workflow
   query tasks [--workflow <id>|<workflowId>] [--status S]
                                                       Show task states (latest workflow by default)
     [--no-merge] [--output F]
@@ -1170,6 +1196,8 @@ ${BOLD}Configure:${RESET}
   set fix-context <taskId> <text>                     Update fix-session context and retry
   set gate-policy <taskId> <wfId> [depTaskId] <policy>
                                                       policy: completed | review_ready
+  set workflow <workflowId> <fieldPath> <value>      Safely update workflow metadata/config
+  set task <taskId> <fieldPath> <value>              Safely update task metadata/config
   migrate-compat                                     Normalize persisted compatibility workflow/task state
 
 ${BOLD}Lifecycle:${RESET}
@@ -2674,6 +2702,50 @@ async function headlessSetGatePolicy(args: string[], deps: HeadlessDeps): Promis
       `Updated gate policy for ${taskId}: ${workflowId}/${depTaskId} -> ${gatePolicy} (${runnable.length} task(s) started)\n`,
     );
   });
+}
+
+async function headlessSetWorkflowMetadata(
+  workflowId: string,
+  fieldPath: string,
+  rawValue: string,
+  deps: HeadlessDeps,
+): Promise<void> {
+  if (!workflowId || !fieldPath || rawValue === '') {
+    throw new Error('Missing arguments. Usage: --headless set workflow <workflowId> <fieldPath> <value>');
+  }
+  const result = await setWorkflowMetadata(
+    {
+      commandService: deps.commandService,
+      orchestrator: deps.orchestrator,
+      persistence: deps.persistence,
+    },
+    workflowId,
+    fieldPath,
+    parseMetadataValue(rawValue),
+  );
+  process.stdout.write(`Updated workflow "${result.id}" ${result.fieldPath} → ${JSON.stringify(result.value)}\n`);
+}
+
+async function headlessSetTaskMetadata(
+  taskId: string,
+  fieldPath: string,
+  rawValue: string,
+  deps: HeadlessDeps,
+): Promise<void> {
+  if (!taskId || !fieldPath || rawValue === '') {
+    throw new Error('Missing arguments. Usage: --headless set task <taskId> <fieldPath> <value>');
+  }
+  const result = await setTaskMetadata(
+    {
+      commandService: deps.commandService,
+      orchestrator: deps.orchestrator,
+      persistence: deps.persistence,
+    },
+    taskId,
+    fieldPath,
+    parseMetadataValue(rawValue),
+  );
+  process.stdout.write(`Updated task "${result.id}" ${result.fieldPath} → ${JSON.stringify(result.value)}\n`);
 }
 
 async function headlessSlack(deps: HeadlessDeps): Promise<void> {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2440,6 +2440,7 @@ function createEmbeddedTerminalBackendFromConfig(
           logger,
           orchestrator,
           persistence,
+          commandService,
           taskExecutor: requireTaskExecutor(),
           autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
           killRunningTask,

--- a/packages/app/src/metadata-setter.ts
+++ b/packages/app/src/metadata-setter.ts
@@ -1,0 +1,289 @@
+import type { CommandService, TaskStateChanges } from '@invoker/workflow-core';
+import { normalizeRunnerKind } from '@invoker/workflow-core';
+import type { SQLiteAdapter, Workflow } from '@invoker/data-store';
+import type { Orchestrator } from '@invoker/workflow-core';
+
+export type MetadataScope = 'task' | 'workflow';
+
+export interface MetadataSetResult {
+  scope: MetadataScope;
+  id: string;
+  fieldPath: string;
+  value: unknown;
+  raw: boolean;
+}
+
+export interface MetadataSetDeps {
+  commandService: CommandService;
+  orchestrator: Pick<Orchestrator, 'syncFromDb'>;
+  persistence: Pick<
+    SQLiteAdapter,
+    'loadWorkflow' | 'loadTask' | 'loadTasks' | 'listWorkflows' | 'updateWorkflow' | 'updateTask' | 'logEvent'
+  >;
+}
+
+const WORKFLOW_FIELDS = new Set([
+  'name',
+  'description',
+  'visualProof',
+  'planFile',
+  'repoUrl',
+  'intermediateRepoUrl',
+  'branch',
+  'onFinish',
+  'baseBranch',
+  'featureBranch',
+  'mergeMode',
+  'reviewProvider',
+]);
+
+const TASK_FIELDS = new Set(['description', 'dependencies']);
+
+const TASK_CONFIG_FIELDS = new Set([
+  'command',
+  'prompt',
+  'experimentPrompt',
+  'parentTask',
+  'featureBranch',
+  'runnerKind',
+  'poolId',
+  'poolMemberId',
+  'dockerImage',
+  'executionAgent',
+  'pivot',
+  'experimentVariants',
+  'isReconciliation',
+  'requiresManualApproval',
+  'summary',
+  'problem',
+  'approach',
+  'testPlan',
+  'reproCommand',
+  'externalDependencies',
+  'fixPrompt',
+  'fixContext',
+]);
+
+const WORKFLOW_STRING_FIELDS = new Set([
+  'description',
+  'planFile',
+  'repoUrl',
+  'intermediateRepoUrl',
+  'branch',
+  'baseBranch',
+  'featureBranch',
+  'reviewProvider',
+]);
+
+const TASK_CONFIG_STRING_FIELDS = new Set([
+  'command',
+  'prompt',
+  'experimentPrompt',
+  'parentTask',
+  'featureBranch',
+  'poolId',
+  'poolMemberId',
+  'dockerImage',
+  'executionAgent',
+  'summary',
+  'problem',
+  'approach',
+  'testPlan',
+  'reproCommand',
+  'fixPrompt',
+  'fixContext',
+]);
+
+export function parseMetadataValue(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
+}
+
+function assertRawAllowed(raw: boolean): void {
+  if (raw && process.env.INVOKER_ALLOW_RAW_METADATA_SET !== '1') {
+    throw new Error('Raw metadata updates are disabled. Set INVOKER_ALLOW_RAW_METADATA_SET=1 to enable repair mode.');
+  }
+}
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function nullableString(fieldPath: string, value: unknown): string | null {
+  if (value === null) return null;
+  if (typeof value !== 'string') throw new Error(`Field "${fieldPath}" must be a string or null.`);
+  return value;
+}
+
+function requiredString(fieldPath: string, value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new Error(`Field "${fieldPath}" must be a non-empty string.`);
+  }
+  return value;
+}
+
+function booleanValue(fieldPath: string, value: unknown): boolean {
+  if (typeof value !== 'boolean') throw new Error(`Field "${fieldPath}" must be a boolean.`);
+  return value;
+}
+
+function stringArray(fieldPath: string, value: unknown): string[] {
+  if (!Array.isArray(value) || !value.every((item) => typeof item === 'string')) {
+    throw new Error(`Field "${fieldPath}" must be an array of strings.`);
+  }
+  return value;
+}
+
+function enumValue<T extends string>(fieldPath: string, value: unknown, allowed: readonly T[]): T | null {
+  if (value === null) return null;
+  if (typeof value !== 'string' || !allowed.includes(value as T)) {
+    throw new Error(`Field "${fieldPath}" must be one of: ${allowed.join(', ')}.`);
+  }
+  return value as T;
+}
+
+function validateWorkflowValue(fieldPath: string, value: unknown, raw: boolean): Partial<Workflow> {
+  const path = raw && fieldPath.startsWith('raw.') ? fieldPath.slice(4) : fieldPath;
+  if (!raw && !WORKFLOW_FIELDS.has(path)) {
+    throw new Error(`Field "${fieldPath}" is not allowed for workflow metadata updates.`);
+  }
+  if (path.includes('.')) {
+    throw new Error(`Nested workflow field "${fieldPath}" is not supported.`);
+  }
+
+  if (path === 'name') return { name: requiredString(path, value) };
+  if (path === 'visualProof') return { visualProof: booleanValue(path, value) };
+  if (path === 'onFinish') {
+    return { onFinish: enumValue<'none' | 'merge' | 'pull_request'>(path, value, ['none', 'merge', 'pull_request']) ?? undefined };
+  }
+  if (path === 'mergeMode') {
+    return { mergeMode: enumValue<'manual' | 'automatic' | 'external_review'>(path, value, ['manual', 'automatic', 'external_review']) ?? undefined };
+  }
+  if (WORKFLOW_STRING_FIELDS.has(path)) {
+    return { [path]: nullableString(path, value) ?? undefined } as Partial<Workflow>;
+  }
+
+  if (raw && (path === 'generation')) {
+    if (typeof value !== 'number' || !Number.isInteger(value) || value < 0) {
+      throw new Error(`Field "${fieldPath}" must be a non-negative integer.`);
+    }
+    return { generation: value };
+  }
+  throw new Error(`Field "${fieldPath}" is not persisted as workflow metadata.`);
+}
+
+function validateTaskValue(fieldPath: string, value: unknown, raw: boolean): TaskStateChanges {
+  const path = raw && fieldPath.startsWith('raw.') ? fieldPath.slice(4) : fieldPath;
+  const parts = path.split('.');
+  if (!raw) {
+    const allowed = parts.length === 1
+      ? TASK_FIELDS.has(path)
+      : parts.length === 2 && parts[0] === 'config' && TASK_CONFIG_FIELDS.has(parts[1]);
+    if (!allowed) throw new Error(`Field "${fieldPath}" is not allowed for task metadata updates.`);
+  }
+
+  if (path === 'description') return { description: requiredString(path, value) } as TaskStateChanges;
+  if (path === 'dependencies') return { dependencies: stringArray(path, value) };
+  if (parts[0] !== 'config' || parts.length !== 2) {
+    if (raw && path === 'status') return { status: requiredString(path, value) as TaskStateChanges['status'] };
+    if (raw && parts[0] === 'execution' && parts.length === 2) return { execution: { [parts[1]]: value } as TaskStateChanges['execution'] };
+    throw new Error(`Field "${fieldPath}" is not persisted as task metadata/config.`);
+  }
+
+  const key = parts[1];
+  if (key === 'runnerKind') {
+    const runnerKind = value === null ? undefined : normalizeRunnerKind(requiredString(path, value));
+    return { config: { runnerKind } as TaskStateChanges['config'] };
+  }
+  if (key === 'pivot' || key === 'isReconciliation' || key === 'requiresManualApproval') {
+    return { config: { [key]: booleanValue(path, value) } as TaskStateChanges['config'] };
+  }
+  if (key === 'experimentVariants' || key === 'externalDependencies') {
+    if (value !== null && !Array.isArray(value)) throw new Error(`Field "${fieldPath}" must be an array or null.`);
+    return { config: { [key]: value ?? undefined } as TaskStateChanges['config'] };
+  }
+  if (TASK_CONFIG_STRING_FIELDS.has(key)) {
+    return { config: { [key]: nullableString(path, value) ?? undefined } as TaskStateChanges['config'] };
+  }
+  if (raw) return { config: { [key]: value } as TaskStateChanges['config'] };
+  throw new Error(`Field "${fieldPath}" is not allowed for task metadata updates.`);
+}
+
+function taskWorkflowId(deps: MetadataSetDeps, taskId: string): { workflowId: string; resolvedTaskId: string } {
+  const direct = deps.persistence.loadTask(taskId);
+  if (direct?.config.workflowId) return { workflowId: direct.config.workflowId, resolvedTaskId: direct.id };
+  for (const workflow of deps.persistence.listWorkflows()) {
+    const task = deps.persistence.loadTasks(workflow.id).find((candidate) => candidate.id === taskId || candidate.id.endsWith(`/${taskId}`));
+    if (task) return { workflowId: workflow.id, resolvedTaskId: task.id };
+  }
+  throw new Error(`Task "${taskId}" not found.`);
+}
+
+export async function setWorkflowMetadata(
+  deps: MetadataSetDeps,
+  workflowId: string,
+  fieldPath: string,
+  value: unknown,
+  options: { raw?: boolean } = {},
+): Promise<MetadataSetResult> {
+  const raw = options.raw === true || fieldPath.startsWith('raw.');
+  assertRawAllowed(raw);
+  if (!workflowId || !fieldPath) throw new Error('Missing workflow metadata setter arguments.');
+  const patch = validateWorkflowValue(fieldPath, value, raw);
+  const result = await deps.commandService.runSerializedForWorkflow(workflowId, async () => {
+    if (!deps.persistence.loadWorkflow(workflowId)) throw new Error(`Workflow "${workflowId}" not found.`);
+    deps.persistence.updateWorkflow(workflowId, patch);
+    const auditTask = deps.persistence.loadTasks(workflowId)[0];
+    if (auditTask) {
+      deps.persistence.logEvent(auditTask.id, 'workflow.metadata.updated', {
+        workflowId,
+        fieldPath,
+        value,
+        raw,
+      });
+    }
+    deps.orchestrator.syncFromDb(workflowId);
+  });
+  if (!result.ok) throw new Error(result.error.message);
+  return { scope: 'workflow', id: workflowId, fieldPath, value, raw };
+}
+
+export async function setTaskMetadata(
+  deps: MetadataSetDeps,
+  taskId: string,
+  fieldPath: string,
+  value: unknown,
+  options: { raw?: boolean } = {},
+): Promise<MetadataSetResult> {
+  const raw = options.raw === true || fieldPath.startsWith('raw.');
+  assertRawAllowed(raw);
+  if (!taskId || !fieldPath) throw new Error('Missing task metadata setter arguments.');
+  const changes = validateTaskValue(fieldPath, value, raw);
+  const resolved = taskWorkflowId(deps, taskId);
+  const result = await deps.commandService.runSerializedForWorkflow(resolved.workflowId, async () => {
+    deps.persistence.updateTask(resolved.resolvedTaskId, changes);
+    deps.persistence.logEvent(resolved.resolvedTaskId, 'task.metadata.updated', {
+      taskId: resolved.resolvedTaskId,
+      fieldPath,
+      value,
+      raw,
+    });
+    deps.orchestrator.syncFromDb(resolved.workflowId);
+  });
+  if (!result.ok) throw new Error(result.error.message);
+  return { scope: 'task', id: resolved.resolvedTaskId, fieldPath, value, raw };
+}
+
+export function parseMetadataPatchBody(body: string): { fieldPath: string; value: unknown; raw: boolean } {
+  const parsed = body ? JSON.parse(body) : {};
+  if (!isObjectRecord(parsed)) throw new Error('Metadata patch body must be a JSON object.');
+  const fieldPath = parsed.fieldPath ?? parsed.path ?? parsed.field;
+  if (typeof fieldPath !== 'string' || fieldPath.length === 0) {
+    throw new Error('Missing "fieldPath" in request body.');
+  }
+  if (!('value' in parsed)) throw new Error('Missing "value" in request body.');
+  return { fieldPath, value: parsed.value, raw: parsed.raw === true };
+}

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -16,7 +16,7 @@
  */
 
 import type { Logger } from '@invoker/contracts';
-import type { Orchestrator, ExternalGatePolicyUpdate, TaskState } from '@invoker/workflow-core';
+import type { CommandService, Orchestrator, ExternalGatePolicyUpdate, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
 import {
@@ -53,6 +53,11 @@ import {
   executeGlobalTopup,
   isDispatchableLaunch,
 } from './global-topup.js';
+import {
+  setTaskMetadata as sharedSetTaskMetadata,
+  setWorkflowMetadata as sharedSetWorkflowMetadata,
+  type MetadataSetResult,
+} from './metadata-setter.js';
 
 // ── Result types ─────────────────────────────────────────────
 
@@ -101,6 +106,7 @@ export interface WorkflowMutationFacadeDeps {
   logger?: Logger;
   orchestrator: Orchestrator;
   persistence: SQLiteAdapter;
+  commandService?: CommandService;
   taskExecutor: TaskRunner;
   dispatchMode?: 'await' | 'fire-and-forget';
   autoApproveAIFixes?: boolean;
@@ -217,6 +223,20 @@ export class WorkflowMutationFacade {
     return this.finalizeWithTopup(started, 'facade.set-gate-policy', { scopedTaskIds: [taskId] });
   }
 
+  async setTaskMetadata(
+    taskId: string,
+    fieldPath: string,
+    value: unknown,
+    options: { raw?: boolean } = {},
+  ): Promise<MetadataSetResult> {
+    if (!this.deps.commandService) throw new Error('Metadata updates require CommandService serialization.');
+    return sharedSetTaskMetadata({
+      commandService: this.deps.commandService,
+      orchestrator: this.deps.orchestrator,
+      persistence: this.deps.persistence,
+    }, taskId, fieldPath, value, options);
+  }
+
   async cancelTask(taskId: string): Promise<CancelMutationResult> {
     const result = this.deps.orchestrator.cancelTask(taskId);
     if (this.deps.killRunningTask) {
@@ -328,6 +348,20 @@ export class WorkflowMutationFacade {
       persistence: this.deps.persistence,
       taskExecutor: this.deps.taskExecutor,
     });
+  }
+
+  async setWorkflowMetadata(
+    workflowId: string,
+    fieldPath: string,
+    value: unknown,
+    options: { raw?: boolean } = {},
+  ): Promise<MetadataSetResult> {
+    if (!this.deps.commandService) throw new Error('Metadata updates require CommandService serialization.');
+    return sharedSetWorkflowMetadata({
+      commandService: this.deps.commandService,
+      orchestrator: this.deps.orchestrator,
+      persistence: this.deps.persistence,
+    }, workflowId, fieldPath, value, options);
   }
 
   // ── AI-driven mutations ──────────────────────────────────

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -491,6 +491,59 @@ describe('SQLiteAdapter', () => {
       expect(loaded!.updatedAt).toBe(newTime);
     });
 
+    it('updates workflow metadata fields including repoUrl', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.updateWorkflow('wf-1', {
+        name: 'Renamed',
+        description: 'new description',
+        visualProof: true,
+        planFile: '/tmp/plan.yaml',
+        repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+        intermediateRepoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker-Intermediate.git',
+        branch: 'main',
+        onFinish: 'pull_request',
+        baseBranch: 'master',
+        featureBranch: 'feature/generic-setters',
+        mergeMode: 'external_review',
+        reviewProvider: 'github',
+      });
+
+      expect(adapter.loadWorkflow('wf-1')).toMatchObject({
+        name: 'Renamed',
+        description: 'new description',
+        visualProof: true,
+        planFile: '/tmp/plan.yaml',
+        repoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker.git',
+        intermediateRepoUrl: 'git@github.com:Neko-Catpital-Labs/Invoker-Intermediate.git',
+        branch: 'main',
+        onFinish: 'pull_request',
+        baseBranch: 'master',
+        featureBranch: 'feature/generic-setters',
+        mergeMode: 'external_review',
+        reviewProvider: 'github',
+      });
+    });
+
+    it('updates task description and representative config metadata', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('task-1'));
+      adapter.updateTask('task-1', {
+        description: 'Updated task',
+        config: {
+          poolId: 'some-pool',
+          fixPrompt: 'fix this',
+        },
+      });
+
+      expect(adapter.loadTask('task-1')).toMatchObject({
+        description: 'Updated task',
+        config: {
+          poolId: 'some-pool',
+          fixPrompt: 'fix this',
+        },
+      });
+    });
+
     it('auto-sets updatedAt when not provided', () => {
       adapter.saveWorkflow(testWorkflow);
       const before = new Date().toISOString();

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -76,7 +76,7 @@ export interface WorkflowTaskSnapshot {
 export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: Workflow): void;
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'updatedAt' | 'baseBranch' | 'generation' | 'mergeMode'>>): void;
+  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'generation' | 'updatedAt'>>): void;
   loadWorkflow(workflowId: string): Workflow | undefined;
   listWorkflows(): Workflow[];
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -575,6 +575,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
         approach TEXT,
         test_plan TEXT,
         repro_command TEXT,
+        fix_prompt TEXT,
+        fix_context TEXT,
 
         -- Git
         branch TEXT,
@@ -816,6 +818,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE tasks ADD COLUMN fixed_integration_sha TEXT',
       'ALTER TABLE tasks ADD COLUMN fixed_integration_recorded_at TEXT',
       'ALTER TABLE tasks ADD COLUMN fixed_integration_source TEXT',
+      'ALTER TABLE tasks ADD COLUMN fix_prompt TEXT',
+      'ALTER TABLE tasks ADD COLUMN fix_context TEXT',
       'ALTER TABLE attempts ADD COLUMN queue_priority INTEGER NOT NULL DEFAULT 0',
       'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
       'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
@@ -978,20 +982,41 @@ export class SQLiteAdapter implements PersistenceAdapter {
     ]);
   }
 
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'updatedAt' | 'baseBranch' | 'generation' | 'mergeMode'>>): void {
+  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'generation' | 'updatedAt'>>): void {
     const setClauses: string[] = [];
     const values: unknown[] = [];
+    const columnMap: Record<string, string> = {
+      name: 'name',
+      description: 'description',
+      planFile: 'plan_file',
+      repoUrl: 'repo_url',
+      intermediateRepoUrl: 'intermediate_repo_url',
+      branch: 'branch',
+      onFinish: 'on_finish',
+      baseBranch: 'base_branch',
+      featureBranch: 'feature_branch',
+      mergeMode: 'merge_mode',
+      reviewProvider: 'review_provider',
+    };
+    for (const [key, column] of Object.entries(columnMap)) {
+      if (key in changes) {
+        setClauses.push(`${column} = ?`);
+        values.push((changes as any)[key] ?? null);
+      }
+    }
+    if (changes.visualProof !== undefined) {
+      setClauses.push('visual_proof = ?');
+      values.push(changes.visualProof ? 1 : 0);
+    }
     if (changes.baseBranch !== undefined) {
-      setClauses.push('base_branch = ?');
-      values.push(changes.baseBranch);
+      // handled by columnMap; kept for backward-compatible patch shapes
     }
     if (changes.generation !== undefined) {
       setClauses.push('generation = ?');
       values.push(changes.generation);
     }
     if (changes.mergeMode !== undefined) {
-      setClauses.push('merge_mode = ?');
-      values.push(changes.mergeMode);
+      // handled by columnMap; kept for backward-compatible patch shapes
     }
     setClauses.push('updated_at = ?');
     values.push(changes.updatedAt ?? new Date().toISOString());
@@ -1073,7 +1098,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       INSERT OR REPLACE INTO tasks (
         id, workflow_id, description, status, blocked_by, dependencies,
         command, prompt, experiment_prompt, exit_code, error, protocol_error_code, protocol_error_message, input_prompt, external_dependencies,
-        summary, problem, approach, test_plan, repro_command,
+        summary, problem, approach, test_plan, repro_command, fix_prompt, fix_context,
         branch, commit_hash, fixed_integration_sha, fixed_integration_recorded_at, fixed_integration_source, parent_task,
         pivot, experiment_variants, is_reconciliation, selected_experiment,
         selected_experiments, experiment_results, requires_manual_approval,
@@ -1095,7 +1120,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       ) VALUES (
         ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?,
         ?, ?, ?,
@@ -1123,7 +1148,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       exec.exitCode ?? null, exec.error ?? null, exec.protocolErrorCode ?? null, exec.protocolErrorMessage ?? null, exec.inputPrompt ?? null,
       cfg.externalDependencies ? JSON.stringify(cfg.externalDependencies) : null,
       cfg.summary ?? null, cfg.problem ?? null, cfg.approach ?? null,
-      cfg.testPlan ?? null, cfg.reproCommand ?? null,
+      cfg.testPlan ?? null, cfg.reproCommand ?? null, cfg.fixPrompt ?? null, cfg.fixContext ?? null,
       exec.branch ?? null,
       exec.commit ?? null,
       exec.fixedIntegrationSha ?? null,
@@ -1176,6 +1201,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
     const setClauses: string[] = [];
     const values: any[] = [];
 
+    if (changes.description !== undefined) {
+      setClauses.push('description = ?');
+      values.push(changes.description);
+    }
     if (changes.status !== undefined) {
       setClauses.push('status = ?');
       values.push(changes.status);
@@ -1203,6 +1232,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
         poolMemberId: 'pool_member_id',
         dockerImage: 'docker_image',
         executionAgent: 'execution_agent',
+        fixPrompt: 'fix_prompt',
+        fixContext: 'fix_context',
       };
       const configBoolMap: Record<string, string> = {
         pivot: 'pivot',
@@ -2268,6 +2299,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
         approach: row.approach ?? undefined,
         testPlan: row.test_plan ?? undefined,
         reproCommand: row.repro_command ?? undefined,
+        fixPrompt: row.fix_prompt ?? undefined,
+        fixContext: row.fix_context ?? undefined,
         executionAgent: row.execution_agent ?? undefined,
       },
       execution: {

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -473,6 +473,28 @@ export class CommandService {
     );
   }
 
+  async runSerializedForWorkflow<T>(
+    workflowId: string | undefined,
+    fn: () => T | Promise<T>,
+  ): Promise<CommandResult<T>> {
+    return this.executeCommand<T>(
+      'SERIALIZED_WORKFLOW_MUTATION_FAILED',
+      fn,
+      workflowId,
+    );
+  }
+
+  async runSerializedForTask<T>(
+    taskId: string,
+    fn: () => T | Promise<T>,
+  ): Promise<CommandResult<T>> {
+    return this.executeCommand<T>(
+      'SERIALIZED_TASK_MUTATION_FAILED',
+      fn,
+      this.workflowIdForTask(taskId),
+    );
+  }
+
   // ── Private Helpers ────────────────────────────────────
 
   private async executeCommand<T>(

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -30,10 +30,20 @@ export interface WorkflowRecord {
 }
 
 export interface WorkflowChanges {
+  name?: string;
+  description?: string;
+  visualProof?: boolean;
+  planFile?: string;
+  repoUrl?: string;
+  intermediateRepoUrl?: string;
+  branch?: string;
+  onFinish?: string;
   updatedAt?: string;
   baseBranch?: string;
+  featureBranch?: string;
   generation?: number;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
+  reviewProvider?: string;
 }
 
 export type AttemptChanges = Partial<

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -178,6 +178,7 @@ export interface ExperimentResultEntry {
 // ── Task State Changes (for updates / deltas) ───────────────
 
 export interface TaskStateChanges {
+  readonly description?: string;
   readonly status?: TaskStatus;
   readonly dependencies?: readonly string[];
   readonly config?: Partial<TaskConfig>;


### PR DESCRIPTION
## Summary

- Add generic safe setters for workflow metadata and task metadata/config through headless commands and API endpoints.
- Add `query workflow <workflowId>` for single-workflow inspection.
- Route generic setter mutations through the command service serialization path, with field allowlists, JSON value parsing, audit events, and a raw repair mode gated by `INVOKER_ALLOW_RAW_METADATA_SET=1`.
- Extend SQLite persistence for allowlisted workflow fields plus task description and fix-context metadata.

## Architecture

### Before

```mermaid
flowchart TD
  Operator[Operator] --> Semantic[Semantic commands and APIs]
  Semantic --> Facade[Workflow mutation facade]
  Facade --> Store[SQLite adapter]
  Operator -. unsafe repair .-> DB[(Direct SQLite edits)]
```

### After

```mermaid
flowchart TD
  Operator[Operator] --> Headless[set/query headless commands]
  Operator --> API[PATCH metadata APIs]
  Headless --> Policy[metadata-setter policy and value parser]
  API --> Policy
  Policy --> Coordinator[Command service serialization]
  Coordinator --> Store[SQLite adapter]
  Store --> Events[Audit metadata update events]
  Policy -. gated by INVOKER_ALLOW_RAW_METADATA_SET=1 .-> Raw[Raw repair metadata patch]
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `pnpm --dir packages/app exec vitest run src/__tests__/metadata-setter.test.ts src/__tests__/api-server.test.ts src/__tests__/headless-delegation.test.ts`
- [x] `pnpm --dir packages/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/data-store build` (ESM build passed; DTS build still hits existing `TS6307` package file-list errors)
- [x] `pnpm --filter @invoker/workflow-core build` (ESM build passed; DTS build still hits existing `TS6307` package file-list errors)

## Revert Plan

Revert `b3de27a0` with `git revert b3de27a0`, then restart any running Invoker owner or desktop process so command and API registrations reload. The SQLite columns added for fix-context metadata are additive and can remain unused after revert; no destructive data migration is required.
