### PR TITLE
Batch headless workflow mutation dispatch through owner

### DIFF
--- a/packages/app/src/__tests__/execution-capacity.test.ts
+++ b/packages/app/src/__tests__/execution-capacity.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
+  assertExecutionCapacityInvariant,
+  computeConfiguredExecutionCapacity,
   resolveEffectiveMaxConcurrency,
+  shouldFatalOnExecutionCapacityOvercommit,
 } from '../execution-capacity.js';
 
 describe('execution-capacity', () => {
@@ -17,5 +20,72 @@ describe('execution-capacity', () => {
   it('falls back to safe defaults for invalid values', () => {
     expect(resolveEffectiveMaxConcurrency(undefined)).toBe(DEFAULT_WORKTREE_MAX_CONCURRENCY);
     expect(resolveEffectiveMaxConcurrency(0)).toBe(DEFAULT_WORKTREE_MAX_CONCURRENCY);
+  });
+
+  it('computes capacity from SSH pool members', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        ssh: {
+          members: [
+            { type: 'ssh', id: 'a' },
+            { type: 'ssh', id: 'b' },
+            { type: 'ssh', id: 'c' },
+            { type: 'ssh', id: 'd' },
+          ],
+        },
+      },
+    })).toBe(4);
+    expect(() => assertExecutionCapacityInvariant({
+      config: {
+        executionPools: {
+          ssh: {
+            members: [
+              { type: 'ssh', id: 'a' },
+              { type: 'ssh', id: 'b' },
+              { type: 'ssh', id: 'c' },
+              { type: 'ssh', id: 'd' },
+            ],
+          },
+        },
+      },
+      activeExecutions: 5,
+    })).toThrow(/configured capacity=4/);
+  });
+
+  it('does not double count the same member across overlapping pools', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        one: { members: [{ type: 'ssh', id: 'shared' }, { type: 'ssh', id: 'a' }] },
+        two: { members: [{ type: 'ssh', id: 'shared' }, { type: 'ssh', id: 'b' }] },
+      },
+    })).toBe(3);
+  });
+
+  it('uses the max capacity for a repeated member instead of summing', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        one: { maxConcurrentTasksPerMember: 2, members: [{ type: 'ssh', id: 'shared' }] },
+        two: { maxConcurrentTasksPerMember: 4, members: [{ type: 'ssh', id: 'shared' }] },
+      },
+    })).toBe(4);
+  });
+
+  it('counts worktree member maxConcurrentTasks', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        worktree: { members: [{ type: 'worktree', id: 'local', maxConcurrentTasks: 12 }] },
+      },
+    })).toBe(12);
+  });
+
+  it('falls back to top-level maxConcurrency when no execution pools exist', () => {
+    expect(computeConfiguredExecutionCapacity({ maxConcurrency: 7 })).toBe(7);
+  });
+
+  it('keeps fatal capacity checks disabled unless opted in', () => {
+    expect(shouldFatalOnExecutionCapacityOvercommit({})).toBe(false);
+    expect(shouldFatalOnExecutionCapacityOvercommit({
+      INVOKER_FATAL_ON_EXECUTION_CAPACITY_OVERCOMMIT: '1',
+    })).toBe(true);
   });
 });

--- a/packages/app/src/__tests__/headless-batch-exec.test.ts
+++ b/packages/app/src/__tests__/headless-batch-exec.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { executeNoTrackHeadlessBatch, type HeadlessExecMutationPayload } from '../headless-batch-exec.js';
+
+describe('executeNoTrackHeadlessBatch', () => {
+  it('queues multiple no-track workflow mutations and returns per-item acknowledgements', () => {
+    const classify = vi.fn((payload: HeadlessExecMutationPayload) => ({
+      workflowId: payload.args[1],
+      priority: 'high' as const,
+    }));
+    let nextIntentId = 100;
+    const submit = vi.fn(() => nextIntentId++);
+
+    const results = executeNoTrackHeadlessBatch(
+      {
+        noTrack: true,
+        items: [
+          { label: 'first', workflowId: 'wf-1', args: ['rebase-recreate', 'wf-1'] },
+          { label: 'second', workflowId: 'wf-2', args: ['rebase-recreate', 'wf-2'] },
+        ],
+      },
+      { classify, submit },
+    );
+
+    expect(results).toEqual([
+      {
+        label: 'first',
+        workflowId: 'wf-1',
+        args: ['rebase-recreate', 'wf-1'],
+        ok: true,
+        response: { ok: true, intentId: 100 },
+      },
+      {
+        label: 'second',
+        workflowId: 'wf-2',
+        args: ['rebase-recreate', 'wf-2'],
+        ok: true,
+        response: { ok: true, intentId: 101 },
+      },
+    ]);
+    expect(submit).toHaveBeenNthCalledWith(
+      1,
+      'wf-1',
+      'high',
+      'headless.exec',
+      [{ args: ['rebase-recreate', 'wf-1'], waitForApproval: undefined, noTrack: true, traceId: undefined }],
+      { deferDrain: true },
+    );
+    expect(submit).toHaveBeenNthCalledWith(
+      2,
+      'wf-2',
+      'high',
+      'headless.exec',
+      [{ args: ['rebase-recreate', 'wf-2'], waitForApproval: undefined, noTrack: true, traceId: undefined }],
+      { deferDrain: true },
+    );
+  });
+
+  it('reports per-item failures without aborting the rest of the batch', () => {
+    const classify = vi.fn((payload: HeadlessExecMutationPayload) => ({
+      workflowId: payload.args[1]?.startsWith('wf-') ? payload.args[1] : undefined,
+      priority: 'high' as const,
+    }));
+    const submit = vi.fn(() => 42);
+
+    const results = executeNoTrackHeadlessBatch(
+      {
+        noTrack: true,
+        items: [
+          { label: 'bad-args', args: 'rebase-recreate wf-1' },
+          { label: 'bad-target', args: ['rebase-recreate', 'missing'] },
+          { label: 'good', args: ['rebase-recreate', 'wf-1'] },
+        ],
+      },
+      { classify, submit },
+    );
+
+    expect(results).toEqual([
+      {
+        label: 'bad-args',
+        workflowId: undefined,
+        args: [],
+        ok: false,
+        error: 'Invalid batch item: args must be a string array',
+      },
+      {
+        label: 'bad-target',
+        workflowId: undefined,
+        args: ['rebase-recreate', 'missing'],
+        ok: false,
+        error: 'Fire-and-forget headless.exec could not be queued: workflow-not-resolved',
+      },
+      {
+        label: 'good',
+        workflowId: 'wf-1',
+        args: ['rebase-recreate', 'wf-1'],
+        ok: true,
+        response: { ok: true, intentId: 42 },
+      },
+    ]);
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws retryable queue errors so the caller can retry the batch', () => {
+    const classify = vi.fn(() => ({
+      workflowId: 'wf-1',
+      priority: 'high' as const,
+    }));
+    const submit = vi.fn(() => {
+      throw new Error('database is locked');
+    });
+
+    expect(() => executeNoTrackHeadlessBatch(
+      {
+        noTrack: true,
+        items: [{ label: 'locked', args: ['rebase-recreate', 'wf-1'] }],
+      },
+      { classify, submit },
+    )).toThrow('database is locked');
+  });
+});

--- a/packages/app/src/execution-capacity.ts
+++ b/packages/app/src/execution-capacity.ts
@@ -1,10 +1,69 @@
 const DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY = 6;
 export const DEFAULT_WORKTREE_MAX_CONCURRENCY = DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY;
 
+type ExecutionPoolMember =
+  | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
+  | { type: 'worktree'; id: string; maxConcurrentTasks?: number };
+
+type ExecutionPoolConfig = {
+  members?: ExecutionPoolMember[];
+  maxConcurrentTasksPerMember?: number;
+};
+
+export type ExecutionCapacityConfig = {
+  maxConcurrency?: number;
+  executionPools?: Record<string, ExecutionPoolConfig>;
+};
+
 export function resolveEffectiveMaxConcurrency(
   configuredMaxConcurrency: number | undefined,
 ): number {
   return Number.isInteger(configuredMaxConcurrency) && Number(configuredMaxConcurrency) > 0
     ? Number(configuredMaxConcurrency)
     : DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY;
+}
+
+function positiveIntegerOrUndefined(value: unknown): number | undefined {
+  return Number.isInteger(value) && Number(value) > 0 ? Number(value) : undefined;
+}
+
+export function computeConfiguredExecutionCapacity(config: ExecutionCapacityConfig): number {
+  const pools = config.executionPools ?? {};
+  const poolEntries = Object.values(pools);
+  if (poolEntries.length === 0) {
+    return resolveEffectiveMaxConcurrency(config.maxConcurrency);
+  }
+
+  const capacityByResource = new Map<string, number>();
+  for (const pool of poolEntries) {
+    for (const member of pool.members ?? []) {
+      const resourceKey = `${member.type}:${member.id}`;
+      const capacity = member.type === 'ssh'
+        ? positiveIntegerOrUndefined(member.maxConcurrentTasks)
+          ?? positiveIntegerOrUndefined(pool.maxConcurrentTasksPerMember)
+          ?? 1
+        : positiveIntegerOrUndefined(member.maxConcurrentTasks) ?? 1;
+      capacityByResource.set(resourceKey, Math.max(capacityByResource.get(resourceKey) ?? 0, capacity));
+    }
+  }
+
+  return [...capacityByResource.values()].reduce((sum, capacity) => sum + capacity, 0);
+}
+
+export function shouldFatalOnExecutionCapacityOvercommit(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.INVOKER_FATAL_ON_EXECUTION_CAPACITY_OVERCOMMIT === '1';
+}
+
+export function assertExecutionCapacityInvariant(input: {
+  config: ExecutionCapacityConfig;
+  activeExecutions: number;
+  label?: string;
+}): void {
+  const capacity = computeConfiguredExecutionCapacity(input.config);
+  if (input.activeExecutions <= capacity) return;
+  throw new Error(
+    `FATAL: Invoker execution capacity invariant violated` +
+    `${input.label ? ` (${input.label})` : ''}: ` +
+    `active/launching executions=${input.activeExecutions}, configured capacity=${capacity}`,
+  );
 }

--- a/packages/app/src/headless-batch-exec.ts
+++ b/packages/app/src/headless-batch-exec.ts
@@ -1,0 +1,111 @@
+import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
+
+export interface HeadlessExecMutationPayload {
+  args: string[];
+  waitForApproval?: boolean;
+  noTrack?: boolean;
+  traceId?: string;
+}
+
+export interface HeadlessBatchExecItem {
+  label?: string;
+  workflowId?: string;
+  args?: unknown;
+}
+
+export interface HeadlessBatchExecRequest {
+  items?: unknown;
+  waitForApproval?: boolean;
+  noTrack?: boolean;
+  traceId?: string;
+}
+
+export interface HeadlessBatchExecResult {
+  label?: string;
+  workflowId?: string;
+  args: string[];
+  ok: boolean;
+  response?: { ok: true; intentId: number };
+  error?: string;
+}
+
+export type HeadlessExecClassification = {
+  workflowId?: string;
+  priority: WorkflowMutationPriority;
+};
+
+export type HeadlessBatchExecDeps = {
+  classify: (payload: HeadlessExecMutationPayload) => HeadlessExecClassification;
+  submit: (
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: 'headless.exec',
+    args: [HeadlessExecMutationPayload],
+    options: { deferDrain: true },
+  ) => number;
+};
+
+function resultBase(item: HeadlessBatchExecItem): Pick<HeadlessBatchExecResult, 'label' | 'workflowId' | 'args'> {
+  return {
+    label: typeof item.label === 'string' ? item.label : undefined,
+    workflowId: typeof item.workflowId === 'string' ? item.workflowId : undefined,
+    args: Array.isArray(item.args) && item.args.every((arg) => typeof arg === 'string') ? item.args : [],
+  };
+}
+
+function isRetryableQueueError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /database is locked|SQLITE_BUSY/i.test(message);
+}
+
+export function executeNoTrackHeadlessBatch(
+  request: HeadlessBatchExecRequest,
+  deps: HeadlessBatchExecDeps,
+): HeadlessBatchExecResult[] {
+  if (!request.noTrack) {
+    throw new Error('headless.batch-exec only supports noTrack=true');
+  }
+  if (!Array.isArray(request.items)) {
+    throw new Error('headless.batch-exec requires an items array');
+  }
+
+  return request.items.map((rawItem): HeadlessBatchExecResult => {
+    const item = rawItem && typeof rawItem === 'object' ? rawItem as HeadlessBatchExecItem : {};
+    const base = resultBase(item);
+    try {
+      if (!Array.isArray(item.args) || !item.args.every((arg) => typeof arg === 'string')) {
+        throw new Error('Invalid batch item: args must be a string array');
+      }
+      if (item.args.length === 0) {
+        throw new Error('Invalid batch item: args must not be empty');
+      }
+
+      const payload: HeadlessExecMutationPayload = {
+        args: item.args,
+        waitForApproval: request.waitForApproval,
+        noTrack: true,
+        traceId: request.traceId,
+      };
+      const { workflowId, priority } = deps.classify(payload);
+      if (!workflowId) {
+        throw new Error('Fire-and-forget headless.exec could not be queued: workflow-not-resolved');
+      }
+      const intentId = deps.submit(workflowId, priority, 'headless.exec', [payload], { deferDrain: true });
+      return {
+        ...base,
+        workflowId,
+        ok: true,
+        response: { ok: true, intentId },
+      };
+    } catch (error) {
+      if (isRetryableQueueError(error)) {
+        throw error;
+      }
+      return {
+        ...base,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  });
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -178,6 +178,11 @@ import {
 } from './action-graph-diagnostics.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
+import {
+  executeNoTrackHeadlessBatch,
+  type HeadlessBatchExecRequest,
+  type HeadlessExecMutationPayload,
+} from './headless-batch-exec.js';
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -259,13 +264,6 @@ interface HeadlessRunMutationPayload {
 
 interface HeadlessResumeMutationPayload {
   workflowId: string;
-  traceId?: string;
-}
-
-interface HeadlessExecMutationPayload {
-  args: string[];
-  waitForApproval?: boolean;
-  noTrack?: boolean;
   traceId?: string;
 }
 
@@ -2821,6 +2819,26 @@ function createEmbeddedTerminalBackendFromConfig(
         const acknowledgement = acknowledgeNoTrackHeadlessExec(payload, workflowId, priority, 'gui');
         if (acknowledgement) return acknowledgement;
         return runWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => executeHeadlessExec(payload));
+      });
+      messageBus.onRequest('headless.batch-exec', async (req: unknown) => {
+        const request = req as HeadlessBatchExecRequest;
+        const itemCount = Array.isArray(request.items) ? request.items.length : 0;
+        logger.info(`headless.batch-exec received items=${itemCount} noTrack=${request.noTrack ? 'true' : 'false'} mode=gui`, {
+          module: 'ipc-delegate',
+        });
+        if (!workflowMutationCoordinator) {
+          throw new Error('Workflow mutation coordinator is unavailable');
+        }
+        const results = executeNoTrackHeadlessBatch(request, {
+          classify: classifyHeadlessExecMutation,
+          submit: (workflowId, priority, channel, args, options) =>
+            workflowMutationCoordinator.submit(workflowId, priority, channel, args, options),
+        });
+        const accepted = results.filter((result) => result.ok).length;
+        logger.info(`headless.batch-exec accepted=${accepted} failed=${results.length - accepted} mode=gui`, {
+          module: 'ipc-delegate',
+        });
+        return results;
       });
       logger.info(`owner-ipc-ready ownerId=${workflowMutationOwnerId}`, { module: 'ipc-delegate' });
       recordStartupMark('owner-ipc-ready');

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -94,7 +94,9 @@ import {
 } from './config.js';
 import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
+  assertExecutionCapacityInvariant,
   resolveEffectiveMaxConcurrency,
+  shouldFatalOnExecutionCapacityOvercommit,
 } from './execution-capacity.js';
 import {
   createHourlySnapshot,
@@ -1640,6 +1642,23 @@ function createEmbeddedTerminalBackendFromConfig(
     return Number.isNaN(parsed.getTime()) ? undefined : parsed;
   };
 
+  function assertFatalExecutionCapacity(label: string): void {
+    if (!shouldFatalOnExecutionCapacityOvercommit()) return;
+    try {
+      assertExecutionCapacityInvariant({
+        config: loadConfig(),
+        activeExecutions: launchingTasks.size + taskHandles.size,
+        label,
+      });
+    } catch (err) {
+      logger.error(err instanceof Error ? err.stack ?? err.message : String(err), { module: 'exec' });
+      setImmediate(() => {
+        throw err;
+      });
+      throw err;
+    }
+  }
+
   // Focus existing window when a second instance is launched
   app.on('second-instance', () => {
     if (mainWindow) {
@@ -1689,14 +1708,17 @@ function createEmbeddedTerminalBackendFromConfig(
         },
         onLaunchAccepted: (taskId) => {
           launchingTasks.add(taskId);
+          assertFatalExecutionCapacity(`launch accepted ${taskId}`);
           logger.info(`Task "${taskId}" launch accepted by TaskRunner`, { module: 'exec' });
         },
         onLaunchStart: (taskId, executor) => {
           launchingTasks.add(taskId);
+          assertFatalExecutionCapacity(`launch start ${taskId}`);
           logger.info(`Task "${taskId}" launch started (executor: ${executor.type})`, { module: 'exec' });
         },
         onLaunchFailed: (taskId, error, executor) => {
           launchingTasks.delete(taskId);
+          assertFatalExecutionCapacity(`launch failed ${taskId}`);
           logger.error(
             `Task "${taskId}" launch failed before spawn (executor: ${executor.type}): ${error.message}`,
             { module: 'exec' },
@@ -1710,11 +1732,13 @@ function createEmbeddedTerminalBackendFromConfig(
             { module: 'exec' },
           );
           taskHandles.set(taskId, { handle, executor });
+          assertFatalExecutionCapacity(`spawned ${taskId}`);
         },
         onComplete: (taskId, response) => {
           flushTaskOutput(taskId);
           launchingTasks.delete(taskId);
           taskHandles.delete(taskId);
+          assertFatalExecutionCapacity(`complete ${taskId}`);
           logger.info(
             `Task "${taskId}" completion callback received (status: ${response.status}, generation: ${response.executionGeneration}, exitCode: ${response.outputs.exitCode ?? 'none'})`,
             { module: 'exec' },
@@ -1742,6 +1766,7 @@ function createEmbeddedTerminalBackendFromConfig(
         },
         onLaunchSettled: (taskId) => {
           launchingTasks.delete(taskId);
+          assertFatalExecutionCapacity(`launch settled ${taskId}`);
         },
       },
     });
@@ -2829,10 +2854,11 @@ function createEmbeddedTerminalBackendFromConfig(
         if (!workflowMutationCoordinator) {
           throw new Error('Workflow mutation coordinator is unavailable');
         }
+        const coordinator = workflowMutationCoordinator;
         const results = executeNoTrackHeadlessBatch(request, {
           classify: classifyHeadlessExecMutation,
           submit: (workflowId, priority, channel, args, options) =>
-            workflowMutationCoordinator.submit(workflowId, priority, channel, args, options),
+            coordinator.submit(workflowId, priority, channel, args, options),
         });
         const accepted = results.filter((result) => result.ok).length;
         logger.info(`headless.batch-exec accepted=${accepted} failed=${results.length - accepted} mode=gui`, {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -479,6 +479,7 @@ export class TaskRunner {
         `phase=${task.execution.phase ?? 'none'} generation=${startGeneration}`,
     );
     this.launchingAttemptIds.add(attemptId);
+    this.callbacks.onLaunchAccepted?.(task.id);
     try {
       await this.executeTaskInner(task, attemptId, bench);
       bench('executeTask.innerReturned');

--- a/scripts/cleanup-ssh-sync-creds-rebase-recreate-all.sh
+++ b/scripts/cleanup-ssh-sync-creds-rebase-recreate-all.sh
@@ -394,7 +394,7 @@ sync_credentials_to_target() {
 
     local -a SSH_ARGS
     ssh_base_args "$port" "$key_path"
-    ssh "${SSH_ARGS[@]}" "$user_host" "mkdir -p ~/'$remote_parent' && chmod 700 ~"
+    ssh "${SSH_ARGS[@]}" "$user_host" "mkdir -p ~/'$remote_parent' && chmod 700 ~" </dev/null
 
     if [[ -d "$path_entry" ]]; then
       rsync -az --delete \

--- a/scripts/headless-ipc.js
+++ b/scripts/headless-ipc.js
@@ -115,6 +115,14 @@ function isRetryableDispatchError(error) {
   return /database is locked|SQLITE_BUSY|Timed out after/i.test(message);
 }
 
+function isNoHandlerError(error) {
+  if (error && typeof error === 'object' && error.code === 'NO_HANDLER') {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return /NO_HANDLER|No request handler registered|No handler registered/i.test(message);
+}
+
 // ---------------------------------------------------------------------------
 // Stdin reader (for batch-exec)
 // ---------------------------------------------------------------------------
@@ -225,6 +233,38 @@ async function requestExecWithRetry(bus, item, options) {
   throw lastError;
 }
 
+async function requestBatchExec(bus, items, options) {
+  const payload = {
+    items,
+    noTrack: options.noTrack,
+    waitForApproval: options.waitForApproval,
+  };
+  const response = await withTimeout(bus.request('headless.batch-exec', payload), options.timeoutMs);
+  if (!Array.isArray(response)) {
+    throw new Error(`headless.batch-exec returned non-array response: ${JSON.stringify(response)}`);
+  }
+  return response;
+}
+
+async function requestBatchExecWithRetry(bus, items, options) {
+  const maxAttempts = Number.parseInt(process.env.INVOKER_HEADLESS_IPC_DISPATCH_ATTEMPTS ?? '8', 10);
+  const attempts = Number.isFinite(maxAttempts) && maxAttempts > 0 ? maxAttempts : 8;
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await requestBatchExec(bus, items, options);
+    } catch (error) {
+      lastError = error;
+      if (attempt >= attempts || isNoHandlerError(error) || !isRetryableDispatchError(error)) {
+        throw error;
+      }
+      const delayMs = Math.min(5_000, 250 * attempt * attempt);
+      await sleep(delayMs);
+    }
+  }
+  throw lastError;
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -275,6 +315,21 @@ async function main() {
       }
       return parsed;
     });
+
+    if (options.noTrack) {
+      try {
+        const results = await requestBatchExecWithRetry(bus, items, options);
+        for (const result of results) {
+          process.stdout.write(`${JSON.stringify(result)}\n`);
+        }
+        return;
+      } catch (error) {
+        if (!isNoHandlerError(error)) {
+          throw error;
+        }
+        process.stderr.write('headless.batch-exec handler unavailable; falling back to per-item headless.exec dispatch\n');
+      }
+    }
 
     let nextIndex = 0;
     const parallel = Math.max(1, Number.isFinite(options.parallel) ? options.parallel : 1);

--- a/scripts/invoker-command-concurrency-watchdog.mjs
+++ b/scripts/invoker-command-concurrency-watchdog.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { basename, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+
+const DEFAULT_COMMANDS = ['claude', 'codex', 'pnpm'];
+const FATAL_HEADER = 'FATAL: Invoker command concurrency invariant violated';
+
+function parseArgs(argv) {
+  const opts = {
+    max: 1,
+    commands: DEFAULT_COMMANDS,
+    action: 'kill-owner',
+    repoRoot: resolve(new URL('..', import.meta.url).pathname),
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--max') opts.max = Number.parseInt(argv[++i] ?? '', 10);
+    else if (arg === '--commands') opts.commands = String(argv[++i] ?? '').split(',').map((v) => v.trim()).filter(Boolean);
+    else if (arg === '--action') opts.action = argv[++i];
+    else if (arg === '--owner-pid') opts.ownerPid = Number.parseInt(argv[++i] ?? '', 10);
+    else if (arg === '--snapshot-file') opts.snapshotFile = argv[++i];
+    else if (arg === '--repo-root') opts.repoRoot = resolve(argv[++i] ?? '.');
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!Number.isInteger(opts.max) || opts.max < 1) throw new Error('--max must be a positive integer');
+  if (opts.action !== 'kill-owner' && opts.action !== 'report') throw new Error('--action must be kill-owner or report');
+  return opts;
+}
+
+function usage() {
+  return [
+    'usage: invoker-command-concurrency-watchdog.mjs [--max N] [--commands a,b] [--action kill-owner|report]',
+    '       [--owner-pid PID] [--snapshot-file PATH] [--repo-root PATH]',
+  ].join('\n');
+}
+
+function shellSplit(line) {
+  const out = [];
+  const re = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|(\S+)/g;
+  let match;
+  while ((match = re.exec(line)) != null) out.push(match[1] ?? match[2] ?? match[3]);
+  return out;
+}
+
+function normalizeProcess(row) {
+  const args = Array.isArray(row.args) ? row.args.join(' ') : String(row.args ?? row.command ?? '');
+  return {
+    pid: Number(row.pid),
+    ppid: Number(row.ppid ?? 0),
+    command: String(row.command ?? row.comm ?? shellSplit(args)[0] ?? ''),
+    args,
+    cwd: row.cwd ? String(row.cwd) : undefined,
+  };
+}
+
+export function parseProcessSnapshot(raw) {
+  const trimmed = String(raw).trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) throw new Error('JSON snapshot must be an array');
+    return parsed.map(normalizeProcess).filter((p) => Number.isInteger(p.pid));
+  }
+  const lines = trimmed.split(/\r?\n/).filter(Boolean);
+  return lines.map((line) => {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\S+)\s*(.*)$/);
+    if (!match) throw new Error(`invalid ps snapshot line: ${line}`);
+    return normalizeProcess({
+      pid: Number(match[1]),
+      ppid: Number(match[2]),
+      command: match[3],
+      args: match[4] || match[3],
+    });
+  });
+}
+
+function readLiveProcesses() {
+  const output = execFileSync('ps', ['-axo', 'pid=,ppid=,comm=,args='], { encoding: 'utf8' });
+  const rows = parseProcessSnapshot(output);
+  if (process.platform !== 'linux') return rows;
+  return rows.map((row) => {
+    const cwdLink = `/proc/${row.pid}/cwd`;
+    if (!existsSync(cwdLink)) return row;
+    try {
+      return { ...row, cwd: execFileSync('readlink', ['-f', cwdLink], { encoding: 'utf8' }).trim() };
+    } catch {
+      return row;
+    }
+  });
+}
+
+function commandName(proc) {
+  const fromCommand = basename(proc.command || '');
+  const firstArg = basename(shellSplit(proc.args)[0] ?? '');
+  return fromCommand || firstArg;
+}
+
+function isGuarded(proc, commands) {
+  const names = new Set([commandName(proc), basename(shellSplit(proc.args)[0] ?? '')].filter(Boolean));
+  return commands.some((cmd) => names.has(cmd));
+}
+
+function isOwner(proc, ownerPid) {
+  if (ownerPid && proc.pid === ownerPid) return true;
+  const args = proc.args;
+  if (!args.includes('packages/app/dist/main.js') && !args.includes('/dist/main.js')) return false;
+  return /(^|\s)(electron|Electron|node)(\s|$|\/)/.test(args) || args.includes('--headless');
+}
+
+function hasAncestor(proc, ownerPids, byPid) {
+  const seen = new Set();
+  let ppid = proc.ppid;
+  while (ppid && !seen.has(ppid)) {
+    if (ownerPids.has(ppid)) return ppid;
+    seen.add(ppid);
+    ppid = byPid.get(ppid)?.ppid;
+  }
+  return undefined;
+}
+
+function isInvokerManagedCwd(cwd) {
+  if (!cwd) return false;
+  const normalized = resolve(cwd);
+  return normalized.includes('/.invoker/worktrees/')
+    || normalized.includes('/.invoker/test/worktrees/')
+    || normalized.includes('/.invoker/repos/')
+    || normalized.includes('/.invoker/test/repos/')
+    || normalized.includes('/invoker-worktrees/')
+    || normalized.includes('/invoker-runtime/');
+}
+
+export function evaluateSnapshot(processes, options = {}) {
+  const commands = options.commands ?? DEFAULT_COMMANDS;
+  const max = options.max ?? 1;
+  const byPid = new Map(processes.map((proc) => [proc.pid, proc]));
+  const ownerPids = new Set(processes.filter((proc) => isOwner(proc, options.ownerPid)).map((proc) => proc.pid));
+  if (options.ownerPid) ownerPids.add(options.ownerPid);
+
+  const offenders = [];
+  for (const proc of processes) {
+    if (!isGuarded(proc, commands)) continue;
+    const ownerPid = hasAncestor(proc, ownerPids, byPid);
+    if (ownerPid) {
+      offenders.push({ ...proc, ownerPid, ownership: 'ancestor' });
+      continue;
+    }
+    const platform = options.platform ?? process.platform;
+    if (ownerPids.size === 0 && platform === 'linux' && isInvokerManagedCwd(proc.cwd)) {
+      offenders.push({ ...proc, ownerPid: undefined, ownership: 'cwd' });
+    }
+  }
+  return {
+    ok: offenders.length <= max,
+    max,
+    count: offenders.length,
+    ownerPids: [...ownerPids],
+    offenders,
+  };
+}
+
+export function formatViolation(result) {
+  const lines = [
+    FATAL_HEADER,
+    `observed guarded processes: ${result.count}; max allowed: ${result.max}`,
+  ];
+  if (result.ownerPids.length > 0) lines.push(`owner PID(s): ${result.ownerPids.join(', ')}`);
+  for (const proc of result.offenders) {
+    lines.push(`- pid=${proc.pid} ppid=${proc.ppid} ownerPid=${proc.ownerPid ?? 'unknown'} command=${commandName(proc)} args=${proc.args}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    process.stdout.write(`${usage()}\n`);
+    return 0;
+  }
+  const processes = opts.snapshotFile
+    ? parseProcessSnapshot(readFileSync(opts.snapshotFile, 'utf8'))
+    : readLiveProcesses();
+  const result = evaluateSnapshot(processes, opts);
+  if (result.ok) return 0;
+  process.stderr.write(formatViolation(result));
+  if (opts.action === 'kill-owner') {
+    for (const ownerPid of result.ownerPids) {
+      try {
+        process.kill(ownerPid, 'SIGTERM');
+        process.stderr.write(`sent SIGTERM to owner PID ${ownerPid}\n`);
+      } catch (err) {
+        process.stderr.write(`failed to SIGTERM owner PID ${ownerPid}: ${err instanceof Error ? err.message : String(err)}\n`);
+      }
+    }
+  }
+  return 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    process.exitCode = main();
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n${usage()}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/scripts/invoker-command-concurrency-watchdog.test.mjs
+++ b/scripts/invoker-command-concurrency-watchdog.test.mjs
@@ -1,0 +1,87 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateSnapshot, formatViolation } from './invoker-command-concurrency-watchdog.mjs';
+
+const owner = { pid: 100, ppid: 1, command: 'Electron', args: 'Electron packages/app/dist/main.js --headless run plan.yaml' };
+
+describe('invoker command concurrency watchdog', () => {
+  it('allows no guarded processes', () => {
+    assert.equal(evaluateSnapshot([owner]).ok, true);
+  });
+
+  it('allows one codex descendant of owner', () => {
+    const result = evaluateSnapshot([owner, { pid: 101, ppid: 100, command: 'codex', args: 'codex exec' }]);
+    assert.equal(result.ok, true);
+  });
+
+  it('fails on claude plus codex descendants of owner', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'claude', args: 'claude' },
+      { pid: 102, ppid: 100, command: 'codex', args: 'codex exec' },
+    ]);
+    assert.equal(result.ok, false);
+    assert.equal(result.count, 2);
+  });
+
+  it('fails on two codex descendants of owner', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'codex', args: 'codex exec' },
+      { pid: 102, ppid: 100, command: 'codex', args: 'codex exec' },
+    ]);
+    assert.equal(result.ok, false);
+  });
+
+  it('ignores unrelated pnpm outside owner ancestry', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 1, command: 'pnpm', args: 'pnpm test' },
+    ]);
+    assert.equal(result.ok, true);
+    assert.equal(result.count, 0);
+  });
+
+  it('--max 2 allows two guarded processes', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'claude', args: 'claude' },
+      { pid: 102, ppid: 100, command: 'codex', args: 'codex exec' },
+    ], { max: 2 });
+    assert.equal(result.ok, true);
+  });
+
+  it('violation output includes PID, command, and owner PID', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'codex', args: 'codex exec' },
+      { pid: 102, ppid: 100, command: 'pnpm', args: 'pnpm install' },
+    ]);
+    const output = formatViolation(result);
+    assert.match(output, /FATAL: Invoker command concurrency invariant violated/);
+    assert.match(output, /pid=101/);
+    assert.match(output, /command=codex/);
+    assert.match(output, /ownerPid=100/);
+  });
+
+  it('counts Linux guarded processes under Invoker-managed cwd when ancestry is unavailable', () => {
+    const result = evaluateSnapshot([
+      {
+        pid: 201,
+        ppid: 1,
+        command: 'pnpm',
+        args: 'pnpm test',
+        cwd: '/home/user/.invoker/worktrees/hash/experiment-task',
+      },
+      {
+        pid: 202,
+        ppid: 1,
+        command: 'pnpm',
+        args: 'pnpm test',
+        cwd: '/home/user/project',
+      },
+    ], { platform: 'linux' });
+    assert.equal(result.count, 1);
+    assert.equal(result.offenders[0].pid, 201);
+  });
+});

--- a/scripts/watch-invoker-command-concurrency.sh
+++ b/scripts/watch-invoker-command-concurrency.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$REPO_ROOT/scripts/invoker-command-concurrency-watchdog.mjs"
+INTERVAL=10
+MAX=1
+COMMANDS="claude,codex,pnpm"
+ACTION="kill-owner"
+OWNER_PID=""
+SNAPSHOT_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --interval) INTERVAL="$2"; shift 2 ;;
+    --max) MAX="$2"; shift 2 ;;
+    --commands) COMMANDS="$2"; shift 2 ;;
+    --action) ACTION="$2"; shift 2 ;;
+    --owner-pid) OWNER_PID="$2"; shift 2 ;;
+    --snapshot-file) SNAPSHOT_FILE="$2"; shift 2 ;;
+    --help|-h)
+      echo "usage: $0 [--interval seconds] [--max N] [--commands a,b] [--action kill-owner|report] [--owner-pid PID] [--snapshot-file PATH]" >&2
+      exit 0
+      ;;
+    *) echo "watch-invoker-command-concurrency: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+args=(--max "$MAX" --commands "$COMMANDS" --action "$ACTION" --repo-root "$REPO_ROOT")
+if [[ -n "$OWNER_PID" ]]; then args+=(--owner-pid "$OWNER_PID"); fi
+if [[ -n "$SNAPSHOT_FILE" ]]; then args+=(--snapshot-file "$SNAPSHOT_FILE"); fi
+
+while true; do
+  node "$HELPER" "${args[@]}"
+  if [[ -n "$SNAPSHOT_FILE" ]]; then exit 0; fi
+  sleep "$INTERVAL"
+done

--- a/scripts/with-invoker-command-watchdog.sh
+++ b/scripts/with-invoker-command-watchdog.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WATCHDOG_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --)
+      shift
+      break
+      ;;
+    --interval|--max|--commands|--action|--owner-pid|--snapshot-file)
+      WATCHDOG_ARGS+=("$1" "$2")
+      shift 2
+      ;;
+    --help|-h)
+      echo "usage: $0 [watchdog options] -- <command> [args...]" >&2
+      exit 0
+      ;;
+    *) break ;;
+  esac
+done
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 [watchdog options] -- <command> [args...]" >&2
+  exit 2
+fi
+
+"$REPO_ROOT/scripts/watch-invoker-command-concurrency.sh" "${WATCHDOG_ARGS[@]}" &
+watchdog_pid=$!
+
+cleanup() {
+  if kill -0 "$watchdog_pid" 2>/dev/null; then
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+"$@" &
+command_pid=$!
+
+command_status=0
+watchdog_status=0
+
+while true; do
+  if ! kill -0 "$command_pid" 2>/dev/null; then
+    wait "$command_pid" || command_status=$?
+    cleanup
+    exit "$command_status"
+  fi
+  if ! kill -0 "$watchdog_pid" 2>/dev/null; then
+    wait "$watchdog_pid" || watchdog_status=$?
+    kill "$command_pid" 2>/dev/null || true
+    wait "$command_pid" 2>/dev/null || true
+    exit "$watchdog_status"
+  fi
+  sleep 1
+done


### PR DESCRIPTION
## Summary

Batch fire-and-forget headless workflow mutation dispatch through the owner process. `scripts/headless-ipc.js batch-exec --no-track` now sends one `headless.batch-exec` IPC request when the owner supports it, preserving JSONL output while avoiding a per-command IPC/database write storm during mass rebase/recreate runs.

The owner handles each batch item inside the existing workflow mutation path, validates acknowledgement shape, and lets transient SQLite lock failures bubble so the CLI retries the whole batch with its existing backoff. Older owners still work because the CLI falls back to per-item `headless.exec` only when the batch handler is unavailable.

Also keep the SSH cleanup/credential-sync target loop isolated from helper `ssh` stdin so syncing credentials for one remote does not consume the remaining target rows. The retry-tolerant remote deletion behavior is already in the stacked base PR (#863); this PR adds the missing stdin isolation on top.

## Architecture

### Before

```mermaid
graph TD
    A[batch-exec JSONL input] --> B[scripts/headless-ipc.js]
    B --> C[parallel headless.exec IPC requests]
    C --> D[Owner workflow mutation handler]
    D --> E[SQLite writes]
```

### After

```mermaid
graph TD
    A[batch-exec JSONL input] --> B[scripts/headless-ipc.js]
    B --> C[one headless.batch-exec IPC request]
    C --> D[Owner batch handler]
    D --> E[Existing workflow mutation dispatch per item]
    E --> F[SQLite writes]
    C --> G[NO_HANDLER fallback]
    G --> H[legacy per-item headless.exec dispatch]
```

## Test Plan

- [x] `node --check scripts/headless-ipc.js`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-batch-exec.test.ts`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/transport build`
- [x] Isolated IPC stress harness: 2,000 `batch-exec --no-track --parallel 128` commands collapsed into exactly one `headless.batch-exec` request with 2,000 successful JSONL rows and zero per-item fallback requests.
- [x] Isolated retry stress harness: synthetic `database is locked` failures on the first two batch requests retried the whole batch and completed 500 successful rows with zero per-item fallback requests.
- [x] Running-UI live verification: launched the Electron UI from this branch, then ran `INVOKER_HEADLESS_BATCH_TIMEOUT_SECONDS=120 INVOKER_HEADLESS_IPC_DISPATCH_ATTEMPTS=5 bash scripts/bench-rebase-recreate-all.sh --timeout 180 --parallel 128`; dispatch accepted 38 workflows with 0 launch failures, and all 38 new rebase-recreate intents completed.
- [x] `bash -n scripts/cleanup-ssh-sync-creds-rebase-recreate-all.sh`
- [x] `bash scripts/cleanup-ssh-sync-creds-rebase-recreate-all.sh --dry-run --skip-rebase-recreate | rg "^\\[remote_|^Targets:|  -"` confirmed all five SSH targets are visited.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 8df6be72 6c209113`
- Post-revert steps: None
- Data migration? No
