### PR TITLE
Add Invoker command concurrency watchdog

### DIFF
--- a/packages/app/src/__tests__/execution-capacity.test.ts
+++ b/packages/app/src/__tests__/execution-capacity.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
+  assertExecutionCapacityInvariant,
+  computeConfiguredExecutionCapacity,
   resolveEffectiveMaxConcurrency,
+  shouldFatalOnExecutionCapacityOvercommit,
 } from '../execution-capacity.js';
 
 describe('execution-capacity', () => {
@@ -17,5 +20,72 @@ describe('execution-capacity', () => {
   it('falls back to safe defaults for invalid values', () => {
     expect(resolveEffectiveMaxConcurrency(undefined)).toBe(DEFAULT_WORKTREE_MAX_CONCURRENCY);
     expect(resolveEffectiveMaxConcurrency(0)).toBe(DEFAULT_WORKTREE_MAX_CONCURRENCY);
+  });
+
+  it('computes capacity from SSH pool members', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        ssh: {
+          members: [
+            { type: 'ssh', id: 'a' },
+            { type: 'ssh', id: 'b' },
+            { type: 'ssh', id: 'c' },
+            { type: 'ssh', id: 'd' },
+          ],
+        },
+      },
+    })).toBe(4);
+    expect(() => assertExecutionCapacityInvariant({
+      config: {
+        executionPools: {
+          ssh: {
+            members: [
+              { type: 'ssh', id: 'a' },
+              { type: 'ssh', id: 'b' },
+              { type: 'ssh', id: 'c' },
+              { type: 'ssh', id: 'd' },
+            ],
+          },
+        },
+      },
+      activeExecutions: 5,
+    })).toThrow(/configured capacity=4/);
+  });
+
+  it('does not double count the same member across overlapping pools', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        one: { members: [{ type: 'ssh', id: 'shared' }, { type: 'ssh', id: 'a' }] },
+        two: { members: [{ type: 'ssh', id: 'shared' }, { type: 'ssh', id: 'b' }] },
+      },
+    })).toBe(3);
+  });
+
+  it('uses the max capacity for a repeated member instead of summing', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        one: { maxConcurrentTasksPerMember: 2, members: [{ type: 'ssh', id: 'shared' }] },
+        two: { maxConcurrentTasksPerMember: 4, members: [{ type: 'ssh', id: 'shared' }] },
+      },
+    })).toBe(4);
+  });
+
+  it('counts worktree member maxConcurrentTasks', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        worktree: { members: [{ type: 'worktree', id: 'local', maxConcurrentTasks: 12 }] },
+      },
+    })).toBe(12);
+  });
+
+  it('falls back to top-level maxConcurrency when no execution pools exist', () => {
+    expect(computeConfiguredExecutionCapacity({ maxConcurrency: 7 })).toBe(7);
+  });
+
+  it('keeps fatal capacity checks disabled unless opted in', () => {
+    expect(shouldFatalOnExecutionCapacityOvercommit({})).toBe(false);
+    expect(shouldFatalOnExecutionCapacityOvercommit({
+      INVOKER_FATAL_ON_EXECUTION_CAPACITY_OVERCOMMIT: '1',
+    })).toBe(true);
   });
 });

--- a/packages/app/src/execution-capacity.ts
+++ b/packages/app/src/execution-capacity.ts
@@ -1,10 +1,69 @@
 const DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY = 6;
 export const DEFAULT_WORKTREE_MAX_CONCURRENCY = DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY;
 
+type ExecutionPoolMember =
+  | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
+  | { type: 'worktree'; id: string; maxConcurrentTasks?: number };
+
+type ExecutionPoolConfig = {
+  members?: ExecutionPoolMember[];
+  maxConcurrentTasksPerMember?: number;
+};
+
+export type ExecutionCapacityConfig = {
+  maxConcurrency?: number;
+  executionPools?: Record<string, ExecutionPoolConfig>;
+};
+
 export function resolveEffectiveMaxConcurrency(
   configuredMaxConcurrency: number | undefined,
 ): number {
   return Number.isInteger(configuredMaxConcurrency) && Number(configuredMaxConcurrency) > 0
     ? Number(configuredMaxConcurrency)
     : DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY;
+}
+
+function positiveIntegerOrUndefined(value: unknown): number | undefined {
+  return Number.isInteger(value) && Number(value) > 0 ? Number(value) : undefined;
+}
+
+export function computeConfiguredExecutionCapacity(config: ExecutionCapacityConfig): number {
+  const pools = config.executionPools ?? {};
+  const poolEntries = Object.values(pools);
+  if (poolEntries.length === 0) {
+    return resolveEffectiveMaxConcurrency(config.maxConcurrency);
+  }
+
+  const capacityByResource = new Map<string, number>();
+  for (const pool of poolEntries) {
+    for (const member of pool.members ?? []) {
+      const resourceKey = `${member.type}:${member.id}`;
+      const capacity = member.type === 'ssh'
+        ? positiveIntegerOrUndefined(member.maxConcurrentTasks)
+          ?? positiveIntegerOrUndefined(pool.maxConcurrentTasksPerMember)
+          ?? 1
+        : positiveIntegerOrUndefined(member.maxConcurrentTasks) ?? 1;
+      capacityByResource.set(resourceKey, Math.max(capacityByResource.get(resourceKey) ?? 0, capacity));
+    }
+  }
+
+  return [...capacityByResource.values()].reduce((sum, capacity) => sum + capacity, 0);
+}
+
+export function shouldFatalOnExecutionCapacityOvercommit(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.INVOKER_FATAL_ON_EXECUTION_CAPACITY_OVERCOMMIT === '1';
+}
+
+export function assertExecutionCapacityInvariant(input: {
+  config: ExecutionCapacityConfig;
+  activeExecutions: number;
+  label?: string;
+}): void {
+  const capacity = computeConfiguredExecutionCapacity(input.config);
+  if (input.activeExecutions <= capacity) return;
+  throw new Error(
+    `FATAL: Invoker execution capacity invariant violated` +
+    `${input.label ? ` (${input.label})` : ''}: ` +
+    `active/launching executions=${input.activeExecutions}, configured capacity=${capacity}`,
+  );
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -94,7 +94,9 @@ import {
 } from './config.js';
 import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
+  assertExecutionCapacityInvariant,
   resolveEffectiveMaxConcurrency,
+  shouldFatalOnExecutionCapacityOvercommit,
 } from './execution-capacity.js';
 import {
   createHourlySnapshot,
@@ -1640,6 +1642,23 @@ function createEmbeddedTerminalBackendFromConfig(
     return Number.isNaN(parsed.getTime()) ? undefined : parsed;
   };
 
+  function assertFatalExecutionCapacity(label: string): void {
+    if (!shouldFatalOnExecutionCapacityOvercommit()) return;
+    try {
+      assertExecutionCapacityInvariant({
+        config: loadConfig(),
+        activeExecutions: launchingTasks.size + taskHandles.size,
+        label,
+      });
+    } catch (err) {
+      logger.error(err instanceof Error ? err.stack ?? err.message : String(err), { module: 'exec' });
+      setImmediate(() => {
+        throw err;
+      });
+      throw err;
+    }
+  }
+
   // Focus existing window when a second instance is launched
   app.on('second-instance', () => {
     if (mainWindow) {
@@ -1689,14 +1708,17 @@ function createEmbeddedTerminalBackendFromConfig(
         },
         onLaunchAccepted: (taskId) => {
           launchingTasks.add(taskId);
+          assertFatalExecutionCapacity(`launch accepted ${taskId}`);
           logger.info(`Task "${taskId}" launch accepted by TaskRunner`, { module: 'exec' });
         },
         onLaunchStart: (taskId, executor) => {
           launchingTasks.add(taskId);
+          assertFatalExecutionCapacity(`launch start ${taskId}`);
           logger.info(`Task "${taskId}" launch started (executor: ${executor.type})`, { module: 'exec' });
         },
         onLaunchFailed: (taskId, error, executor) => {
           launchingTasks.delete(taskId);
+          assertFatalExecutionCapacity(`launch failed ${taskId}`);
           logger.error(
             `Task "${taskId}" launch failed before spawn (executor: ${executor.type}): ${error.message}`,
             { module: 'exec' },
@@ -1710,11 +1732,13 @@ function createEmbeddedTerminalBackendFromConfig(
             { module: 'exec' },
           );
           taskHandles.set(taskId, { handle, executor });
+          assertFatalExecutionCapacity(`spawned ${taskId}`);
         },
         onComplete: (taskId, response) => {
           flushTaskOutput(taskId);
           launchingTasks.delete(taskId);
           taskHandles.delete(taskId);
+          assertFatalExecutionCapacity(`complete ${taskId}`);
           logger.info(
             `Task "${taskId}" completion callback received (status: ${response.status}, generation: ${response.executionGeneration}, exitCode: ${response.outputs.exitCode ?? 'none'})`,
             { module: 'exec' },
@@ -1742,6 +1766,7 @@ function createEmbeddedTerminalBackendFromConfig(
         },
         onLaunchSettled: (taskId) => {
           launchingTasks.delete(taskId);
+          assertFatalExecutionCapacity(`launch settled ${taskId}`);
         },
       },
     });
@@ -2829,10 +2854,11 @@ function createEmbeddedTerminalBackendFromConfig(
         if (!workflowMutationCoordinator) {
           throw new Error('Workflow mutation coordinator is unavailable');
         }
+        const coordinator = workflowMutationCoordinator;
         const results = executeNoTrackHeadlessBatch(request, {
           classify: classifyHeadlessExecMutation,
           submit: (workflowId, priority, channel, args, options) =>
-            workflowMutationCoordinator.submit(workflowId, priority, channel, args, options),
+            coordinator.submit(workflowId, priority, channel, args, options),
         });
         const accepted = results.filter((result) => result.ok).length;
         logger.info(`headless.batch-exec accepted=${accepted} failed=${results.length - accepted} mode=gui`, {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -479,6 +479,7 @@ export class TaskRunner {
         `phase=${task.execution.phase ?? 'none'} generation=${startGeneration}`,
     );
     this.launchingAttemptIds.add(attemptId);
+    this.callbacks.onLaunchAccepted?.(task.id);
     try {
       await this.executeTaskInner(task, attemptId, bench);
       bench('executeTask.innerReturned');

--- a/scripts/invoker-command-concurrency-watchdog.mjs
+++ b/scripts/invoker-command-concurrency-watchdog.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { basename, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+
+const DEFAULT_COMMANDS = ['claude', 'codex', 'pnpm'];
+const FATAL_HEADER = 'FATAL: Invoker command concurrency invariant violated';
+
+function parseArgs(argv) {
+  const opts = {
+    max: 1,
+    commands: DEFAULT_COMMANDS,
+    action: 'kill-owner',
+    repoRoot: resolve(new URL('..', import.meta.url).pathname),
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--max') opts.max = Number.parseInt(argv[++i] ?? '', 10);
+    else if (arg === '--commands') opts.commands = String(argv[++i] ?? '').split(',').map((v) => v.trim()).filter(Boolean);
+    else if (arg === '--action') opts.action = argv[++i];
+    else if (arg === '--owner-pid') opts.ownerPid = Number.parseInt(argv[++i] ?? '', 10);
+    else if (arg === '--snapshot-file') opts.snapshotFile = argv[++i];
+    else if (arg === '--repo-root') opts.repoRoot = resolve(argv[++i] ?? '.');
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!Number.isInteger(opts.max) || opts.max < 1) throw new Error('--max must be a positive integer');
+  if (opts.action !== 'kill-owner' && opts.action !== 'report') throw new Error('--action must be kill-owner or report');
+  return opts;
+}
+
+function usage() {
+  return [
+    'usage: invoker-command-concurrency-watchdog.mjs [--max N] [--commands a,b] [--action kill-owner|report]',
+    '       [--owner-pid PID] [--snapshot-file PATH] [--repo-root PATH]',
+  ].join('\n');
+}
+
+function shellSplit(line) {
+  const out = [];
+  const re = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|(\S+)/g;
+  let match;
+  while ((match = re.exec(line)) != null) out.push(match[1] ?? match[2] ?? match[3]);
+  return out;
+}
+
+function normalizeProcess(row) {
+  const args = Array.isArray(row.args) ? row.args.join(' ') : String(row.args ?? row.command ?? '');
+  return {
+    pid: Number(row.pid),
+    ppid: Number(row.ppid ?? 0),
+    command: String(row.command ?? row.comm ?? shellSplit(args)[0] ?? ''),
+    args,
+    cwd: row.cwd ? String(row.cwd) : undefined,
+  };
+}
+
+export function parseProcessSnapshot(raw) {
+  const trimmed = String(raw).trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) throw new Error('JSON snapshot must be an array');
+    return parsed.map(normalizeProcess).filter((p) => Number.isInteger(p.pid));
+  }
+  const lines = trimmed.split(/\r?\n/).filter(Boolean);
+  return lines.map((line) => {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\S+)\s*(.*)$/);
+    if (!match) throw new Error(`invalid ps snapshot line: ${line}`);
+    return normalizeProcess({
+      pid: Number(match[1]),
+      ppid: Number(match[2]),
+      command: match[3],
+      args: match[4] || match[3],
+    });
+  });
+}
+
+function readLiveProcesses() {
+  const output = execFileSync('ps', ['-axo', 'pid=,ppid=,comm=,args='], { encoding: 'utf8' });
+  const rows = parseProcessSnapshot(output);
+  if (process.platform !== 'linux') return rows;
+  return rows.map((row) => {
+    const cwdLink = `/proc/${row.pid}/cwd`;
+    if (!existsSync(cwdLink)) return row;
+    try {
+      return { ...row, cwd: execFileSync('readlink', ['-f', cwdLink], { encoding: 'utf8' }).trim() };
+    } catch {
+      return row;
+    }
+  });
+}
+
+function commandName(proc) {
+  const fromCommand = basename(proc.command || '');
+  const firstArg = basename(shellSplit(proc.args)[0] ?? '');
+  return fromCommand || firstArg;
+}
+
+function isGuarded(proc, commands) {
+  const names = new Set([commandName(proc), basename(shellSplit(proc.args)[0] ?? '')].filter(Boolean));
+  return commands.some((cmd) => names.has(cmd));
+}
+
+function isOwner(proc, ownerPid) {
+  if (ownerPid && proc.pid === ownerPid) return true;
+  const args = proc.args;
+  if (!args.includes('packages/app/dist/main.js') && !args.includes('/dist/main.js')) return false;
+  return /(^|\s)(electron|Electron|node)(\s|$|\/)/.test(args) || args.includes('--headless');
+}
+
+function hasAncestor(proc, ownerPids, byPid) {
+  const seen = new Set();
+  let ppid = proc.ppid;
+  while (ppid && !seen.has(ppid)) {
+    if (ownerPids.has(ppid)) return ppid;
+    seen.add(ppid);
+    ppid = byPid.get(ppid)?.ppid;
+  }
+  return undefined;
+}
+
+function isInvokerManagedCwd(cwd) {
+  if (!cwd) return false;
+  const normalized = resolve(cwd);
+  return normalized.includes('/.invoker/worktrees/')
+    || normalized.includes('/.invoker/test/worktrees/')
+    || normalized.includes('/.invoker/repos/')
+    || normalized.includes('/.invoker/test/repos/')
+    || normalized.includes('/invoker-worktrees/')
+    || normalized.includes('/invoker-runtime/');
+}
+
+export function evaluateSnapshot(processes, options = {}) {
+  const commands = options.commands ?? DEFAULT_COMMANDS;
+  const max = options.max ?? 1;
+  const byPid = new Map(processes.map((proc) => [proc.pid, proc]));
+  const ownerPids = new Set(processes.filter((proc) => isOwner(proc, options.ownerPid)).map((proc) => proc.pid));
+  if (options.ownerPid) ownerPids.add(options.ownerPid);
+
+  const offenders = [];
+  for (const proc of processes) {
+    if (!isGuarded(proc, commands)) continue;
+    const ownerPid = hasAncestor(proc, ownerPids, byPid);
+    if (ownerPid) {
+      offenders.push({ ...proc, ownerPid, ownership: 'ancestor' });
+      continue;
+    }
+    const platform = options.platform ?? process.platform;
+    if (ownerPids.size === 0 && platform === 'linux' && isInvokerManagedCwd(proc.cwd)) {
+      offenders.push({ ...proc, ownerPid: undefined, ownership: 'cwd' });
+    }
+  }
+  return {
+    ok: offenders.length <= max,
+    max,
+    count: offenders.length,
+    ownerPids: [...ownerPids],
+    offenders,
+  };
+}
+
+export function formatViolation(result) {
+  const lines = [
+    FATAL_HEADER,
+    `observed guarded processes: ${result.count}; max allowed: ${result.max}`,
+  ];
+  if (result.ownerPids.length > 0) lines.push(`owner PID(s): ${result.ownerPids.join(', ')}`);
+  for (const proc of result.offenders) {
+    lines.push(`- pid=${proc.pid} ppid=${proc.ppid} ownerPid=${proc.ownerPid ?? 'unknown'} command=${commandName(proc)} args=${proc.args}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    process.stdout.write(`${usage()}\n`);
+    return 0;
+  }
+  const processes = opts.snapshotFile
+    ? parseProcessSnapshot(readFileSync(opts.snapshotFile, 'utf8'))
+    : readLiveProcesses();
+  const result = evaluateSnapshot(processes, opts);
+  if (result.ok) return 0;
+  process.stderr.write(formatViolation(result));
+  if (opts.action === 'kill-owner') {
+    for (const ownerPid of result.ownerPids) {
+      try {
+        process.kill(ownerPid, 'SIGTERM');
+        process.stderr.write(`sent SIGTERM to owner PID ${ownerPid}\n`);
+      } catch (err) {
+        process.stderr.write(`failed to SIGTERM owner PID ${ownerPid}: ${err instanceof Error ? err.message : String(err)}\n`);
+      }
+    }
+  }
+  return 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    process.exitCode = main();
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n${usage()}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/scripts/invoker-command-concurrency-watchdog.test.mjs
+++ b/scripts/invoker-command-concurrency-watchdog.test.mjs
@@ -1,0 +1,87 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateSnapshot, formatViolation } from './invoker-command-concurrency-watchdog.mjs';
+
+const owner = { pid: 100, ppid: 1, command: 'Electron', args: 'Electron packages/app/dist/main.js --headless run plan.yaml' };
+
+describe('invoker command concurrency watchdog', () => {
+  it('allows no guarded processes', () => {
+    assert.equal(evaluateSnapshot([owner]).ok, true);
+  });
+
+  it('allows one codex descendant of owner', () => {
+    const result = evaluateSnapshot([owner, { pid: 101, ppid: 100, command: 'codex', args: 'codex exec' }]);
+    assert.equal(result.ok, true);
+  });
+
+  it('fails on claude plus codex descendants of owner', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'claude', args: 'claude' },
+      { pid: 102, ppid: 100, command: 'codex', args: 'codex exec' },
+    ]);
+    assert.equal(result.ok, false);
+    assert.equal(result.count, 2);
+  });
+
+  it('fails on two codex descendants of owner', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'codex', args: 'codex exec' },
+      { pid: 102, ppid: 100, command: 'codex', args: 'codex exec' },
+    ]);
+    assert.equal(result.ok, false);
+  });
+
+  it('ignores unrelated pnpm outside owner ancestry', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 1, command: 'pnpm', args: 'pnpm test' },
+    ]);
+    assert.equal(result.ok, true);
+    assert.equal(result.count, 0);
+  });
+
+  it('--max 2 allows two guarded processes', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'claude', args: 'claude' },
+      { pid: 102, ppid: 100, command: 'codex', args: 'codex exec' },
+    ], { max: 2 });
+    assert.equal(result.ok, true);
+  });
+
+  it('violation output includes PID, command, and owner PID', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'codex', args: 'codex exec' },
+      { pid: 102, ppid: 100, command: 'pnpm', args: 'pnpm install' },
+    ]);
+    const output = formatViolation(result);
+    assert.match(output, /FATAL: Invoker command concurrency invariant violated/);
+    assert.match(output, /pid=101/);
+    assert.match(output, /command=codex/);
+    assert.match(output, /ownerPid=100/);
+  });
+
+  it('counts Linux guarded processes under Invoker-managed cwd when ancestry is unavailable', () => {
+    const result = evaluateSnapshot([
+      {
+        pid: 201,
+        ppid: 1,
+        command: 'pnpm',
+        args: 'pnpm test',
+        cwd: '/home/user/.invoker/worktrees/hash/experiment-task',
+      },
+      {
+        pid: 202,
+        ppid: 1,
+        command: 'pnpm',
+        args: 'pnpm test',
+        cwd: '/home/user/project',
+      },
+    ], { platform: 'linux' });
+    assert.equal(result.count, 1);
+    assert.equal(result.offenders[0].pid, 201);
+  });
+});

--- a/scripts/watch-invoker-command-concurrency.sh
+++ b/scripts/watch-invoker-command-concurrency.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$REPO_ROOT/scripts/invoker-command-concurrency-watchdog.mjs"
+INTERVAL=10
+MAX=1
+COMMANDS="claude,codex,pnpm"
+ACTION="kill-owner"
+OWNER_PID=""
+SNAPSHOT_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --interval) INTERVAL="$2"; shift 2 ;;
+    --max) MAX="$2"; shift 2 ;;
+    --commands) COMMANDS="$2"; shift 2 ;;
+    --action) ACTION="$2"; shift 2 ;;
+    --owner-pid) OWNER_PID="$2"; shift 2 ;;
+    --snapshot-file) SNAPSHOT_FILE="$2"; shift 2 ;;
+    --help|-h)
+      echo "usage: $0 [--interval seconds] [--max N] [--commands a,b] [--action kill-owner|report] [--owner-pid PID] [--snapshot-file PATH]" >&2
+      exit 0
+      ;;
+    *) echo "watch-invoker-command-concurrency: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+args=(--max "$MAX" --commands "$COMMANDS" --action "$ACTION" --repo-root "$REPO_ROOT")
+if [[ -n "$OWNER_PID" ]]; then args+=(--owner-pid "$OWNER_PID"); fi
+if [[ -n "$SNAPSHOT_FILE" ]]; then args+=(--snapshot-file "$SNAPSHOT_FILE"); fi
+
+while true; do
+  node "$HELPER" "${args[@]}"
+  if [[ -n "$SNAPSHOT_FILE" ]]; then exit 0; fi
+  sleep "$INTERVAL"
+done

--- a/scripts/with-invoker-command-watchdog.sh
+++ b/scripts/with-invoker-command-watchdog.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WATCHDOG_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --)
+      shift
+      break
+      ;;
+    --interval|--max|--commands|--action|--owner-pid|--snapshot-file)
+      WATCHDOG_ARGS+=("$1" "$2")
+      shift 2
+      ;;
+    --help|-h)
+      echo "usage: $0 [watchdog options] -- <command> [args...]" >&2
+      exit 0
+      ;;
+    *) break ;;
+  esac
+done
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 [watchdog options] -- <command> [args...]" >&2
+  exit 2
+fi
+
+"$REPO_ROOT/scripts/watch-invoker-command-concurrency.sh" "${WATCHDOG_ARGS[@]}" &
+watchdog_pid=$!
+
+cleanup() {
+  if kill -0 "$watchdog_pid" 2>/dev/null; then
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+"$@" &
+command_pid=$!
+
+command_status=0
+watchdog_status=0
+
+while true; do
+  if ! kill -0 "$command_pid" 2>/dev/null; then
+    wait "$command_pid" || command_status=$?
+    cleanup
+    exit "$command_status"
+  fi
+  if ! kill -0 "$watchdog_pid" 2>/dev/null; then
+    wait "$watchdog_pid" || watchdog_status=$?
+    kill "$command_pid" 2>/dev/null || true
+    wait "$command_pid" 2>/dev/null || true
+    exit "$watchdog_status"
+  fi
+  sleep 1
+done


### PR DESCRIPTION
## Summary

Adds an external Invoker command concurrency watchdog that samples guarded Invoker-owned commands and fails when more than one guarded command is observed. The default guarded set is `claude`, `codex`, and `pnpm`, with report and owner-kill modes plus a wrapper for running stress commands under the watchdog.

Adds an opt-in internal execution-capacity invariant behind `INVOKER_FATAL_ON_EXECUTION_CAPACITY_OVERCOMMIT=1`, deriving capacity from configured execution pools without double-counting repeated members.

## Architecture

### Before

```mermaid
graph TD
    Owner[Invoker owner]
    Owner --> Runner[TaskRunner]
    Runner --> Cmd[claude/codex/pnpm]
    Observer[External stress scripts]
    Observer -. no owner-scoped command guard .-> Cmd
```

### After

```mermaid
graph TD
    Owner[Invoker owner]
    Owner --> Runner[TaskRunner]
    Runner --> Cmd[claude/codex/pnpm]
    Watchdog[External concurrency watchdog]
    Watchdog --> Snapshot[Process snapshot]
    Snapshot --> Cmd
    Watchdog -->|violation| Owner
    Runner -->|opt-in invariant| Capacity[Configured execution capacity]
```

## Test Plan

- [x] `bash -n scripts/watch-invoker-command-concurrency.sh scripts/with-invoker-command-watchdog.sh`
- [x] `node --test scripts/invoker-command-concurrency-watchdog.test.mjs`
- [x] fake snapshot report-mode violation check
- [x] fake owner PID `kill-owner` SIGTERM check
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/execution-capacity.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No

Depends-On: #867