### PR TITLE
Launch-handoff Phase A: install task_launch_dispatch outbox in observer mode

### DIFF
--- a/docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md
+++ b/docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md
@@ -1,0 +1,473 @@
+# Launch-Handoff Architecture Proposal
+
+Date: 2026-05-22
+Status: Design (not yet planned via `/plan-to-invoker`).
+Companion to: [`2026-05-22-launch-handoff-orphan-architecture.md`](./2026-05-22-launch-handoff-orphan-architecture.md) (the investigation).
+
+## Purpose
+
+Replace the fire-and-forget JavaScript-promise seam between `orchestrator.startExecution()` and `TaskRunner.executeTask()` with a durable, polled, single-source-of-truth dispatcher. Eliminate Issues 0–15 from the investigation as a class instead of patch-by-patch.
+
+The proposal is **not** a rewrite. It is a targeted re-architecture of the launch handoff. The orchestrator state machine, the executor lifecycle, the DAG semantics, the pool selection, and the persistence layer are kept as-is.
+
+## What already exists in the codebase that we can lean on
+
+The exact pattern we need is already deployed elsewhere in this codebase:
+
+- `workflow_mutation_intents` table — durable outbox for workflow mutations.
+- `workflow_mutation_leases` table — per-workflow active-mutation lease.
+- `PersistedWorkflowMutationCoordinator` (`packages/app/src/persisted-workflow-mutation-coordinator.ts`) — a mature outbox dispatcher with priority, supersession, heartbeat renewal, lease takeover, and crash recovery.
+- `execution_resource_leases` table — per-resource lease (used today for SSH pool members).
+
+We are **not inventing a new pattern**. We are applying the same outbox pattern to launch dispatch.
+
+## Invariants the new architecture must hold
+
+The two new invariants that fix the regression:
+
+1. **Durable-write/durable-recovery symmetry.** Every durable state change has a polled recovery owner. There is no durable state that depends on an in-memory promise to make progress.
+2. **No in-memory dispatch ownership across process boundaries or task batches.** All cross-task, cross-process coordination goes through SQLite, not through JS objects.
+
+Five derived invariants worth stating explicitly:
+
+3. **One TaskRunner per process.** Headless commands and mutations do not instantiate their own `TaskRunner`. They enqueue into the outbox; the owner's `TaskRunner` services it.
+4. **Capacity is enforced at dispatch time, not at claim time.** The orchestrator can enqueue freely. The dispatcher enforces `maxConcurrency` when it tries to lease an outbox row.
+5. **Every `task.launch_claimed` is followed within bounded time by exactly one terminal launch event**: `task.executor.selected | task.executor.deferred | task.executor.startup-retry | task.failed-with-startup-error | task.prepared_for_new_attempt`. This is the regression-test invariant.
+6. **Process restart is recovery.** All in-memory state is derivable from durable state. There is no "you must restart Invoker" recovery path; the dispatcher does the same thing on startup as on tick N.
+7. **Single source of truth for time-outs and leases.** One module owns `ATTEMPT_LEASE_MS`, one owns `DISPATCH_LEASE_MS`, one owns `EXECUTING_HEARTBEAT_TIMEOUT_MS`.
+
+## Layered Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Layer 1: STATE  (packages/workflow-core, unchanged shape)                    │
+│  Pure DAG state machine. Workflows, tasks, dependencies, attempts.           │
+│  All transitions are (state, event) → state via the repository.              │
+│  No knowledge of executors, pools, processes, or time-outs.                  │
+└─────────────────────────────────────────────────────────────────────────────┘
+                  │
+                  │ Orchestrator.startExecution() / handleWorkerResponse()
+                  ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Layer 2: SCHEDULING POLICY  (small new module in workflow-core)              │
+│  Pure function: (ready_tasks, ...) → tasks_to_enqueue.                       │
+│  Idempotent; re-runnable any time without side effects.                      │
+│  Replaces the half-used in-memory TaskScheduler with a stateless planner.    │
+└─────────────────────────────────────────────────────────────────────────────┘
+                  │
+                  │ launchOutbox.enqueue(taskId, attemptId, priority)
+                  ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Layer 3: LAUNCH OUTBOX  (NEW: task_launch_dispatch table + LaunchDispatcher) │
+│  Durable seam. Modeled on workflow_mutation_intents.                         │
+│  States: enqueued → leased → acknowledged → completed/abandoned.             │
+│  Short dispatch lease (30 s) — quick recovery; no 20-minute orphans.         │
+│  Enforces maxConcurrency at lease time.                                      │
+│  Polled by a single LaunchDispatcher in the owner process.                   │
+└─────────────────────────────────────────────────────────────────────────────┘
+                  │
+                  │ atomically lease + hand to the local TaskRunner
+                  ▼
+┌─────────────────────────────────────────────────────────────────────────────┐
+│ Layer 4: TASKRUNNER  (packages/execution-engine, mostly unchanged)           │
+│  Per-task executor lifecycle: select → start → output/heartbeat → complete.  │
+│  ACKs the outbox on entry; completes the outbox on exit.                     │
+│  Stateless across crashes — all state derivable from DB.                     │
+└─────────────────────────────────────────────────────────────────────────────┘
+                  │
+                  │ task.executor.selected, task.running, task.completed, …
+                  ▼
+              (back to Layer 1 via Orchestrator.handleWorkerResponse)
+```
+
+### Why these four layers
+
+Each layer has a single responsibility and a single concurrency model:
+
+- **Layer 1 (State)** is a pure state machine. It does not know about wall-clock time, executors, or processes. Today's `Orchestrator` already has this shape; the launch-claim writes inside `drainScheduler` are the only thing that violate it.
+- **Layer 2 (Policy)** is a pure function. Today's `TaskScheduler` half-implements this; we strip it down. Re-running the planner is always safe and produces the same result.
+- **Layer 3 (Outbox)** is the only durable, persisted, polled component. It is the single point where the "what should we launch" decision meets the "what is currently launching" reality. Today this layer does not exist; the fire-and-forget JS promise is its degenerate placeholder.
+- **Layer 4 (Runner)** is per-task in-memory state with crash-safe ack/complete semantics. Today's `TaskRunner` already has this shape; we add explicit outbox ACK/COMPLETE calls and strip the `launchingAttemptIds`/`activeExecutions` cross-task accounting (the DB owns it).
+
+## The `task_launch_dispatch` outbox
+
+### Schema (mirrors `workflow_mutation_intents`)
+
+```sql
+CREATE TABLE IF NOT EXISTS task_launch_dispatch (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  task_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  workflow_id TEXT NOT NULL,
+  state TEXT NOT NULL DEFAULT 'enqueued',
+      -- 'enqueued' | 'leased' | 'acknowledged' | 'completed' | 'abandoned'
+  priority TEXT NOT NULL DEFAULT 'normal',
+  dispatch_owner TEXT,          -- runner instance id + pid; null while enqueued
+  enqueued_at TEXT NOT NULL DEFAULT (datetime('now')),
+  leased_at TEXT,
+  acknowledged_at TEXT,
+  completed_at TEXT,
+  fenced_until TEXT,            -- dispatch lease expiry (short: 30 s)
+  attempts_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  generation INTEGER NOT NULL,  -- copied from the task at enqueue time
+  FOREIGN KEY (task_id) REFERENCES tasks(id),
+  FOREIGN KEY (workflow_id) REFERENCES workflows(id)
+);
+
+CREATE UNIQUE INDEX idx_task_launch_dispatch_active_attempt
+  ON task_launch_dispatch(attempt_id)
+  WHERE state IN ('enqueued', 'leased', 'acknowledged');
+
+CREATE INDEX idx_task_launch_dispatch_ready
+  ON task_launch_dispatch(state, priority, id)
+  WHERE state IN ('enqueued', 'leased');
+
+CREATE INDEX idx_task_launch_dispatch_workflow_state
+  ON task_launch_dispatch(workflow_id, state);
+```
+
+The unique index on `attempt_id` (filtered to non-terminal states) makes "one active dispatch per attempt" a database invariant, not a code rule.
+
+### State machine
+
+```
+              ┌─────────┐
+              │enqueued │ ◄── orchestrator.enqueueLaunch(taskId, attemptId)
+              └────┬────┘
+                   │ dispatcher.tryLease() — atomic, enforces maxConcurrency
+                   ▼
+              ┌─────────┐  fenced_until expires (TaskRunner crashed / never ran)
+              │ leased  │ ─────────────────────────────► dispatcher resets to enqueued
+              └────┬────┘                                  (incr attempts_count)
+                   │ TaskRunner.executeTask() called runner.ackDispatch()
+                   ▼
+            ┌──────────────┐  fenced_until expires (TaskRunner started but is stuck)
+            │ acknowledged │ ────────────────────────────► dispatcher abandons + relaunches
+            └──────┬───────┘                                 via prepareTaskForNewAttempt
+                   │ markTaskRunningAfterLaunch + executor finishes
+                   ▼
+              ┌──────────┐         ┌───────────┐
+              │completed │   OR    │ abandoned │  (after attempts_count >= max)
+              └──────────┘         └───────────┘
+```
+
+Three timer-driven transitions, all polled, all atomic SQL:
+
+1. `enqueued → leased`: `UPDATE … SET state='leased', dispatch_owner=?, leased_at=?, fenced_until=datetime('now','+30 seconds'), attempts_count=attempts_count+1 WHERE state='enqueued' AND id=(SELECT id FROM task_launch_dispatch WHERE state='enqueued' ORDER BY CASE priority WHEN 'high' THEN 0 WHEN 'normal' THEN 1 ELSE 2 END, id LIMIT 1) AND (SELECT COUNT(*) FROM task_launch_dispatch WHERE state IN ('leased','acknowledged')) < ?`. Enforces priority + capacity in one statement.
+2. `leased → enqueued` (timeout): `UPDATE task_launch_dispatch SET state='enqueued', dispatch_owner=NULL, fenced_until=NULL, last_error=? WHERE state='leased' AND fenced_until < datetime('now')`.
+3. `acknowledged → abandoned` (final orphan): after `attempts_count >= max_attempts` and `fenced_until < now`, mark `abandoned`, write `task.failed` with a real error message, and let `prepareTaskForNewAttempt` decide whether to make a fresh attempt.
+
+### Companion changes to the existing `tasks` / `attempts` tables
+
+Almost nothing changes. The `task.launch_claimed` event is **still** emitted by the orchestrator when an attempt is durably claimed, but only after the dispatcher leases the outbox row. The `attempt.leaseExpiresAt` 20-minute lease still exists for executing work but is no longer the recovery window for stuck launches — the 30 s dispatch lease is.
+
+The `task.execution.phase` field gets a new value:
+
+- `enqueued` (NEW): outbox row exists, dispatcher hasn't leased it yet.
+- `launching` (existing): dispatcher leased; TaskRunner is selecting executor / starting.
+- `executing` (existing): TaskRunner has called `markTaskRunningAfterLaunch`.
+- `completed` / `failed` / etc. (existing).
+
+This gives operators a clear way to see "is this task stuck because nothing is dispatching, or stuck because dispatch started and the executor hung?"
+
+## Component responsibilities and interfaces
+
+### `Orchestrator` (Layer 1, modified)
+
+Keeps its current API. Three changes inside:
+
+- `startExecution()` returns `TaskState[]` as today, but those tasks have `phase: 'enqueued'`, not `'launching'`. The durable claim event becomes `task.dispatch_enqueued` (carrying the new outbox row id).
+- `drainScheduler` no longer writes `attempts.status='claimed'`. It calls `launchOutbox.enqueue({taskId, attemptId, priority, generation})` inside the same transaction as the attempt creation, and emits `task.dispatch_enqueued`.
+- `markTaskRunningAfterLaunch(taskId, attemptId)` continues to exist but now also calls `launchOutbox.markAcknowledged(dispatchId)` and `launchOutbox.markCompleted(dispatchId)` at the appropriate moments. (The orchestrator does not own the outbox state machine — `LaunchDispatcher` does — but the orchestrator coordinates the per-attempt linkage.)
+
+### `LaunchScheduler` (Layer 2, simplified)
+
+Replaces the current `TaskScheduler` class. Pure function:
+
+```ts
+function planLaunches(input: {
+  readyTasks: TaskState[];          // from Orchestrator.getReadyTasks()
+  externalGateBlocker: (task: TaskState) => boolean;
+}): Array<{ taskId: string; attemptId: string; priority: 'low'|'normal'|'high' }> {
+  return input.readyTasks
+    .filter((task) => !input.externalGateBlocker(task))
+    .map((task) => ({
+      taskId: task.id,
+      attemptId: ensurePendingAttempt(task).id,
+      priority: priorityOf(task),
+    }));
+}
+```
+
+No state. No `running` map. No concurrency check (the dispatcher owns that). Idempotent enqueue via the unique index on `attempt_id`.
+
+### `LaunchDispatcher` (Layer 3, new)
+
+Modeled on `PersistedWorkflowMutationCoordinator`. Owner-only.
+
+```ts
+interface LaunchDispatcher {
+  // Called every poll tick (e.g. 250 ms) from the existing db-poll loop.
+  poll(): Promise<void>;
+
+  // Called by orchestrator after enqueue, to nudge the dispatcher if it's idle.
+  notifyEnqueued(): void;
+
+  // Called by TaskRunner.executeTask on entry, before any executor work.
+  ackDispatch(dispatchId: number, owner: string): boolean;
+
+  // Called by TaskRunner after markTaskRunningAfterLaunch succeeds.
+  completeDispatch(dispatchId: number): void;
+
+  // Called by TaskRunner if executor startup fails after a launch was leased.
+  failDispatch(dispatchId: number, error: string): void;
+
+  // Periodic / on-tick: reset 'leased' rows whose fenced_until expired.
+  reapExpiredLeases(): number;
+
+  // Periodic / on-tick: abandon 'acknowledged' rows whose attempts_count >= max.
+  abandonStuckLeases(): TaskState[];
+}
+```
+
+`poll()` does, in order:
+
+1. `reapExpiredLeases()` — leased rows whose dispatcher crashed go back to `enqueued`.
+2. `abandonStuckLeases()` — acknowledged rows that have re-tried `max_attempts` get a real failure event and a fresh attempt via the orchestrator.
+3. Loop while `currentCapacity() > 0` and an `enqueued` row exists:
+   a. Atomically transition `enqueued → leased` (the single SQL above).
+   b. Build a `TaskState` from the leased row.
+   c. Hand it to the local `TaskRunner.executeTask(task, dispatchId)`. Fire-and-forget within the dispatcher's own loop (the row is durable; if this call drops, the next poll re-leases after `fenced_until` expiry).
+
+`currentCapacity()` reads `SELECT (SELECT max_concurrency FROM invoker_config) - COUNT(*) FROM task_launch_dispatch WHERE state IN ('leased','acknowledged')` — capacity is DB-derived, single query.
+
+### `TaskRunner` (Layer 4, lightly modified)
+
+Three changes:
+
+- `executeTask(task, dispatchId)`: the entry point takes the dispatch row id. Immediately calls `launchOutbox.ackDispatch(dispatchId, runnerInstanceId)`. If `ackDispatch` returns false (lease was reaped by another runner), bail out.
+- The internal `launchingAttemptIds` Set is removed. Dedup is by the unique outbox-row index.
+- `markTaskRunningAfterLaunch` success path also calls `launchOutbox.completeDispatch(dispatchId)` (in the same transaction would be ideal; if not, on a best-effort basis with a follow-up reaper).
+- Errors thrown during executor selection/startup call `launchOutbox.failDispatch(dispatchId, error)`. The dispatcher decides whether to retry (`enqueued`) or abandon (`abandoned`) based on `attempts_count`.
+
+### Removed
+
+- `relaunchOrphansAndStartReady`: folded into `LaunchDispatcher.reapExpiredLeases` + `abandonStuckLeases`. On startup, the dispatcher's first `poll()` does the same recovery as on any other tick.
+- `evaluateLaunchStall` and the two stall watchdogs in `main.ts`: replaced by the dispatcher's lease-expiry loop. The watchdog stops being a sentinel-that-fails and becomes a participant in the recovery loop.
+- The in-memory `launchingTasks` Set in `main.ts`: replaced by an indexed DB query (`WHERE state IN ('leased','acknowledged')`).
+- The `running` / `dequeue` / `completeJob` / `getRunningJobs` surface of `TaskScheduler`: dead code paths deleted; `TaskScheduler` becomes the pure function in Layer 2.
+
+## Sequence diagrams
+
+### Happy path: one launch
+
+```
+Caller         Orchestrator      LaunchScheduler   LaunchOutbox    LaunchDispatcher    TaskRunner    Executor
+  │  startExecution()│                 │                  │                 │              │            │
+  │─────────────────►│                 │                  │                 │              │            │
+  │                  │  planLaunches() │                  │                 │              │            │
+  │                  │────────────────►│                  │                 │              │            │
+  │                  │◄────────────────│                  │                 │              │            │
+  │                  │       enqueue({task,attempt})       │                │              │            │
+  │                  │────────────────────────────────────►│                 │              │            │
+  │                  │     (event: task.dispatch_enqueued) │                 │              │            │
+  │                  │                 │                  │  notifyEnqueued()│              │            │
+  │                  │                 │                  │────────────────►│              │            │
+  │                  │                 │                  │   poll() loops  │              │            │
+  │                  │                 │                  │◄────────────────│              │            │
+  │                  │                 │  tryLease() atomic SQL              │              │            │
+  │                  │                 │                  │◄────────────────│              │            │
+  │                  │                 │                  │   row → leased  │              │            │
+  │                  │                 │                  │     executeTask(task, dispatchId)            │
+  │                  │                 │                  │                 │─────────────►│            │
+  │                  │                 │                  │       ackDispatch(dispatchId, owner)         │
+  │                  │                 │                  │◄─────────────────────────────│            │
+  │                  │                 │                  │   row → acknowledged          │            │
+  │                  │  task.launch_claimed (event)        │                                │            │
+  │                  │◄────────────────────────────────────────────────────────────────────│            │
+  │                  │                 │                  │                 │              │ executor.start()
+  │                  │                 │                  │                 │              │───────────►│
+  │                  │                 │                  │                 │              │◄───────────│
+  │                  │  markTaskRunningAfterLaunch()       │                 │              │            │
+  │                  │◄────────────────────────────────────────────────────────────────────│            │
+  │                  │                 │                  │   completeDispatch(dispatchId)│            │
+  │                  │                 │                  │◄─────────────────────────────│            │
+  │                  │                 │                  │   row → completed             │            │
+```
+
+### Failure path 1: dispatch promise dropped (the original bug)
+
+```
+Orchestrator   LaunchOutbox    LaunchDispatcher    TaskRunner
+   │  enqueue({task,attempt})   │                 │
+   │────────────────────────────►│                 │
+   │   row=42 state=enqueued     │                 │
+   │                             │ poll → tryLease │
+   │                             │◄────────────────│
+   │                             │ row=42 → leased │
+   │                             │ fenced_until=now+30s
+   │                             │ executeTask(task, 42)
+   │                             │────────────────────────────►X (call drops, JS engine hiccup)
+   │                             │                 │
+   │                             │ ... 30 s pass ...
+   │                             │ poll → reapExpiredLeases
+   │                             │◄────────────────│
+   │                             │ row=42 → enqueued (attempts_count=1)
+   │                             │ poll → tryLease
+   │                             │◄────────────────│
+   │                             │ row=42 → leased │
+   │                             │ executeTask(task, 42)
+   │                             │────────────────────────────►│ ack → run → complete
+```
+
+Recovery is automatic and bounded by `fenced_until` (30 s), not by `leaseExpiresAt` (20 min). No `task.failed` is emitted unless `attempts_count` reaches `max_attempts`.
+
+### Failure path 2: executor hangs during start()
+
+```
+LaunchDispatcher    TaskRunner    Executor
+       │ executeTask(task, 42)
+       │────────────────────►│ ackDispatch(42)
+       │◄────────────────────│
+       │ row=42 → acknowledged
+       │                     │ executor.start()
+       │                     │─────────────►█ (hung)
+       │                     │ preStartHeartbeat renews dispatch lease every 10s
+       │                     │  ackDispatch keeps fenced_until rolling
+       │                     │
+       │  attempts_count >= max_attempts after N retries
+       │                     │
+       │  abandonStuckLeases:
+       │    failDispatch(42, "executor.start() hung > startup_timeout × max_attempts")
+       │    write task.failed
+       │    prepareTaskForNewAttempt() — creates a fresh attempt
+       │    LaunchScheduler.planLaunches enqueues the new attempt
+```
+
+The pre-start heartbeat now renews **both** the attempt lease (for "is this attempt still owned") and the dispatch lease (for "is this dispatch still alive"). Either can serve as the orphan trigger.
+
+### Failure path 3: process restart mid-launch
+
+```
+T = 0     Orchestrator enqueues row 42 → enqueued
+T = 1     Dispatcher leases row 42 → leased, fenced_until = T+30
+T = 2     TaskRunner calls ackDispatch → acknowledged
+T = 3     executor.start() running, preStart heartbeat at T+10, T+20
+T = 25    OWNER PROCESS RESTARTS
+
+(Owner comes back up)
+T = 35    Dispatcher.poll(): fenced_until=30 < now=35 → row 42 reaped to enqueued, attempts_count=2
+T = 35    Dispatcher.tryLease → row 42 → leased
+T = 35    TaskRunner.executeTask(task, 42) → ackDispatch → executor.start() → ...
+```
+
+Process restart is just another `fenced_until` expiry. No special "orphan relaunch" code path on startup; the dispatcher does the same thing every poll. (We can still keep a startup hook that calls `dispatcher.poll()` once eagerly, but it is no longer special.)
+
+## Mapping: current code → target architecture
+
+| Current code | Target | Notes |
+|---|---|---|
+| `Orchestrator.drainScheduler` (writes claim, lease, `phase='launching'`, emits `task.launch_claimed`, returns `TaskState[]`) | `Orchestrator.drainScheduler` writes the attempt as `pending` (no `claimed`), emits `task.dispatch_enqueued`, calls `launchOutbox.enqueue()`, returns `TaskState[]` for callers that want to know what was enqueued. | The 20-minute lease moves to executing-phase only. |
+| `TaskScheduler` (in-memory priority queue, half-used `running` set) | `LaunchScheduler` (pure `planLaunches` function) | Delete `running`, `dequeue`, `completeJob`, `getRunningJobs`. |
+| `global-topup.ts:dispatchTasks` (fire-and-forget JS promise) | Deleted. All callers replace `executeTasks(started)` with `orchestrator.startExecution()` (which already enqueues) and stop. | The IDs are already in the outbox by the time `startExecution` returns. |
+| `global-topup.ts:executeGlobalTopup`, `dispatchStartedTasksWithGlobalTopup`, `finalizeMutationWithGlobalTopup` | Reduced to thin wrappers that just call `orchestrator.startExecution()` for the appropriate scope. | The "global top-up" effect is automatic — the dispatcher always picks the highest priority `enqueued` row first. |
+| `relaunchOrphansAndStartReady` | Deleted. | Replaced by `LaunchDispatcher.poll()` which runs the same logic every tick. |
+| `evaluateLaunchStall` + `[launch-stall] forcing failure` watchdog in `main.ts:2566–2611` | Deleted. | The dispatcher's `reapExpiredLeases` and `abandonStuckLeases` are the replacements. The `[executing-stall]` watchdog at 2615–… stays (different concern: executor stopped heartbeating after launch). |
+| `launchingTasks` Set in `main.ts:1266` + `onLaunchAccepted`/`onLaunchStart`/`onSpawned`/`onLaunchSettled` callbacks | Deleted. Capacity and "is this launching" answered by `SELECT … FROM task_launch_dispatch WHERE state IN ('leased','acknowledged')`. | Removes the multi-TaskRunner blindness. |
+| `createHeadlessExecutor` + every `new TaskRunner` in headless paths | Deleted. | Headless commands enqueue into the outbox; the owner's `TaskRunner` services it. |
+| `TaskRunner.executeTasks(tasks)` and `TaskRunner.executeTask(task)` | `TaskRunner.executeTask(task, dispatchId)`. The plural form is removed; the dispatcher loop is the only entry. | `Promise.all` race collapses. |
+| `TaskRunner.launchingAttemptIds` Set | Deleted. Dedup by the outbox unique index. | |
+| `markTaskRunningAfterLaunch` | Adds `launchOutbox.completeDispatch(dispatchId)`. | Same lifecycle event; one new line. |
+| `deferTask` (resource-limit defer) | Calls `launchOutbox.deferDispatch(dispatchId, reason)` which transitions the row back to `enqueued` with a delayed `available_after_at` field. | Defer becomes a first-class outbox state instead of a separate `deferredTaskIds` Set. |
+| `ATTEMPT_LEASE_MS = 20 * 60 * 1000` in two files | Consolidated into one constant in `@invoker/contracts`. | `DISPATCH_LEASE_MS = 30_000` added there too. |
+| Pre-start heartbeat (`task-runner.ts:776`) | Renews both the attempt lease and the dispatch lease. | One additional `UPDATE task_launch_dispatch SET fenced_until=…` in the existing tick. |
+
+## Issue elimination matrix
+
+| Issue | What the new architecture does |
+|---|---|
+| **0** Durable launch claim with non-durable dispatch | **Eliminated.** Outbox row is the durable companion. A dropped JS promise just means the row stays `leased` and is reaped 30 s later. |
+| **1** Watchdog error message lies about elapsed time | **Eliminated.** No more launch-stall watchdog; the dispatcher's retry log carries `attempts_count` and real wall-clock since `leased_at`. |
+| **2** Orphan-relaunch not wired to db-poll | **Eliminated.** `LaunchDispatcher.poll()` is the recovery, runs every tick, no special startup path. |
+| **3** Scheduler `running` set is dead code | **Eliminated.** `TaskScheduler` reduced to a pure function; the dead state is deleted, not patched. |
+| **4** `takeNext` is destructive without re-insert | **Eliminated.** The outbox row is the queue entry; nothing pops it without an atomic state transition. Re-enqueue is just an UPDATE. |
+| **5** Launching tasks count against `maxConcurrency` for 20 minutes | **Eliminated.** Capacity is gated by `state IN ('leased','acknowledged')` and the dispatch lease is 30 s, not 20 min. |
+| **6** Multi-TaskRunner: per-instance Sets/Maps | **Eliminated.** One TaskRunner per process. Headless paths enqueue into the outbox; the owner services them. |
+| **7** Fire-and-forget recursion inside `executor.onComplete` | **Eliminated by removal.** Completion calls `orchestrator.handleWorkerResponse` → newly ready tasks → `orchestrator.startExecution` → outbox enqueue. No fire-and-forget call. |
+| **8** `Promise.all` rejection bypasses per-task safety net | **Eliminated.** `executeTasks` plural form is removed. The dispatcher iterates one row at a time. |
+| **9** Watchdog cascades re-reproduce the bug | **Eliminated by removal.** Cascade dispatch is gone; everything goes through enqueue. |
+| **10** Pre-start heartbeat masks a hung `executor.start()` | **Mitigated.** Pre-start heartbeat still exists, but `attempts_count` is incremented on every dispatcher re-lease, so a wedged `executor.start()` eventually hits `abandonStuckLeases` and gets a real `task.failed`. |
+| **11** `ATTEMPT_LEASE_MS` duplicated | **Eliminated.** Single source of truth in `@invoker/contracts`. |
+| **12** `markTaskRunningAfterLaunch` rejection silently leaves DB in `launching` | **Eliminated.** The dispatch row goes to `abandoned` and a fresh attempt is created via `prepareTaskForNewAttempt`. |
+| **13** Pivot/spawn-experiments skips `markTaskRunningAfterLaunch` | **Targeted fix.** The pivot path also calls `launchOutbox.completeDispatch(dispatchId)`. Not eliminated by architecture alone — pivot is a special case — but the fix is local and unmistakable. |
+| **14** SSH pool-selection lease can leak | **Out of scope for the launch architecture**, but the dispatcher's `abandonStuckLeases` includes a "release related pool leases" hook so abandoned dispatches drop their SSH leases. |
+| **15** Regression repro tests inverse condition | **Replaced.** The new regression repro asserts the `task.dispatch_enqueued → terminal launch event` invariant. The inverted SQL is deleted. |
+
+Twelve of the fifteen issues are eliminated by the architecture itself. Two more (13, 14) become small, local, well-defined fixes. One (15) is a one-line test rewrite.
+
+## Migration plan
+
+The new architecture can be rolled in incrementally behind a feature flag. Four phases:
+
+**Phase A — Outbox installed in parallel (zero behavior change).**
+
+1. Add `task_launch_dispatch` table + migration.
+2. In `drainScheduler`, write the outbox row in the same transaction as the existing claim. The row is informational only.
+3. Add `LaunchDispatcher` as a passive observer that reads the outbox and logs but takes no action.
+4. Add the regression-repro test that asserts the launch-claimed → terminal-event invariant. It will fail; we accept that failure as the baseline.
+
+This phase ships with `INVOKER_LAUNCH_OUTBOX=observe`. No code path is replaced. We gather production data on `attempts_count`, lease expiry rates, and `fenced_until` distributions.
+
+**Phase B — Outbox owns dispatch behind a flag.**
+
+1. `LaunchDispatcher.poll()` becomes the active dispatcher when `INVOKER_LAUNCH_OUTBOX=active`.
+2. `global-topup.ts:dispatchTasks` is changed to a no-op when the flag is on (the outbox is the dispatcher).
+3. The `[launch-stall]` watchdog in `main.ts` becomes a no-op when the flag is on.
+4. `createHeadlessExecutor`'s `TaskRunner` is replaced by an outbox enqueue when the flag is on.
+
+We run with `INVOKER_LAUNCH_OUTBOX=active` in dogfood for one week. Backout is `INVOKER_LAUNCH_OUTBOX=observe`.
+
+**Phase C — Cleanup.**
+
+1. Delete `TaskScheduler.running`/`dequeue`/`completeJob`/`getRunningJobs`/`isRunning`.
+2. Delete `relaunchOrphansAndStartReady`.
+3. Delete `evaluateLaunchStall` and the launch-stall watchdog block in `main.ts`.
+4. Delete `launchingTasks` Set and the `onLaunchAccepted`/`onLaunchSettled` callbacks (keep `onSpawned`/`onComplete` for the UI).
+5. Delete `global-topup.ts:dispatchTasks` and the fire-and-forget path; `executeGlobalTopup` becomes a wrapper around `orchestrator.startExecution()`.
+6. Consolidate `ATTEMPT_LEASE_MS` and `DISPATCH_LEASE_MS` constants in `@invoker/contracts`.
+7. Delete the feature flag.
+
+**Phase D — Targeted fixes for the residual issues.**
+
+1. Pivot/spawn-experiments completion (Issue 13).
+2. SSH pool-lease release hook in `abandonStuckLeases` (Issue 14).
+3. Replace `repro-rebase-recreate-storm-launch-stall.sh` with the new invariant repro (Issue 15).
+
+## Testing strategy
+
+Three layers of test:
+
+1. **Pure unit tests** of `LaunchScheduler.planLaunches` (deterministic, no DB).
+2. **`@invoker/data-store` tests** that exercise the outbox SQL transitions directly: lease conflict, fenced_until expiry, max-attempts abandonment, unique-index enforcement. Mirror the existing `workflow-mutation-intents` tests.
+3. **Integration tests** for the launch-claimed → terminal-event invariant, run under four scenarios:
+   - Happy path (single task, single mutation).
+   - Storm (38 concurrent rebase-recreates) — the exact incident shape.
+   - Dropped dispatch (inject a synthetic JS promise rejection right after `ackDispatch`).
+   - Process restart between `acknowledged` and `markTaskRunningAfterLaunch`.
+
+All four scenarios must produce one of the five terminal launch events within `2 × DISPATCH_LEASE_MS × max_attempts`, regardless of how the dispatch was perturbed.
+
+## Open questions
+
+1. **Should `task.launch_claimed` keep its current event name or be renamed?** I propose `task.dispatch_enqueued` for the outbox enqueue and reusing `task.launch_claimed` for the moment the dispatcher leases the row (i.e. when work actually begins). This keeps log-grep compatibility for the existing operator tooling.
+2. **Where does the dispatcher run in follower mode?** The current code disables most dispatch in follower mode. I propose: outbox enqueue is always allowed (durable, harmless), but `LaunchDispatcher.poll()` is gated to owner mode. Followers see the outbox grow until the owner catches up.
+3. **Do we want a per-workflow concurrency limit?** Today only `maxConcurrency` is global. The outbox makes per-workflow limits trivial: `WHERE workflow_id = ? AND state IN ('leased','acknowledged')`. This is out of scope for this proposal but worth flagging as a future capability the outbox enables for free.
+4. **What is the right `max_attempts` value?** I propose 3 as a starting point: 30 s + 30 s + 30 s of dispatch retries before giving up and writing a real `task.failed`. Tunable via env var.
+5. **Should we keep the 20-minute attempt lease at all once the outbox is in place?** Probably yes for `executing` work (long-running real tasks), but the value can be revisited. The dispatch lease (30 s) is the new short-cycle recovery; the attempt lease becomes "this attempt is still owned by some runner instance" rather than "this launch claim is still valid."
+
+## Recommendation
+
+Adopt this proposal. The implementation cost is well-scoped (one new table, one new dispatcher modeled on a coordinator we already have, a handful of deletions, one feature flag) and the cumulative cost of point-fixes over the last nine PRs already exceeds it. The architecture pays for itself in two ways: it eliminates the regression class, and it removes ~500 lines of accumulated workaround code (`launchingTasks`, `relaunchOrphansAndStartReady`'s scattered call sites, the two stall watchdogs in `main.ts`, the half-used `TaskScheduler` internals, and the four fire-and-forget dispatch sites in `global-topup.ts`).
+
+If we proceed, my recommended next concrete step is **Phase 1 (Reproduce) of the existing bug-fix policy**: write the launch-claimed → terminal-event invariant test against the current head, get it failing on the storm scenario, and use that as the gate for Phase A of the migration above.

--- a/docs/incidents/2026-05-22-launch-handoff-orphan-architecture.md
+++ b/docs/incidents/2026-05-22-launch-handoff-orphan-architecture.md
@@ -1,0 +1,449 @@
+# Launch-Handoff Orphan Architecture Review
+
+Date: 2026-05-22
+Status: Investigation complete (Phase 2 of the bug-fix policy). No code changes yet.
+Owner: TBD
+
+## Summary
+
+During a workflow-mutation storm (38 concurrent `headless.exec rebase-recreate` mutations queued in ~50 ms at `2026-05-22T01:55:56`), four tasks remained in `pending/launching` for ≈20 minutes each before the db-poll watchdog force-failed them. The misleading `Launch stalled: …60s without a spawned execution handle` log lines hide the real timing: the watchdog cannot fire until the 20-minute attempt lease expires (added by `35c0ad97 "Guard launch stalls with live attempt leases"`).
+
+The proximate cause is a single design seam: **the launch claim is durably written (`task.launch_claimed`, attempt `claimed` with 20-minute lease, `phase: 'launching'`) before the actual handoff to a `TaskRunner` is durable**. The handoff itself is a fire-and-forget JavaScript promise (`global-topup.ts:dispatchTasks`, with the author's own `// TODO: replace app-level workflow mutation leases with atomic DB state transitions plus an outbox for launch/cancel side effects.` next to it). When that promise is dropped — by a microtask race, a synchronous throw, a transient TaskRunner instance going out of scope, or any other in-memory perturbation — the DB is left in `pending/launching` with no in-memory state holding a recovery reference. The only thing that eventually fires is the watchdog, which marks the task `failed` instead of relaunching it.
+
+The investigation also surfaced **14 additional issues** in the queue/dispatch/executor pipeline that are independent of the original orphan bug but share the same underlying architectural pattern. The cumulative picture indicates this subsystem has accreted point-fixes over at least nine PRs and is now overdue for a focused redesign of the launch handoff itself.
+
+## Evidence (incident log, `~/.invoker/invoker.log`)
+
+- `2026-05-22T01:55:56.217Z` and the ~50 ms following: 38 `executeHeadlessExec begin args="rebase-recreate ..."` intents (intentIds 3887–3924+).
+- `2026-05-22T02:20:09.590Z` first launch-stall force-fail:
+  ```
+  [launch-stall] detected task="wf-1778431097453-46/implement-inv-117" phase=launching launchAgeMs=1201165 handlePresent=false
+  [launch-stall] forcing failure for "wf-1778431097453-46/implement-inv-117":
+    Launch stalled: task remained in running/launching for 60s without a spawned execution handle
+  ```
+- Same shape at 02:21:47, 02:23:13, 02:25:54 with `launchAgeMs ≈ 1.2M ms` (≈20 min) in each.
+- No intervening `task.executor.selected`, `task.executor.deferred`, `task.executor.startup-retry`, `task.running`, or concrete startup-error events between `task.launch_claimed` and the watchdog for any of the four tasks.
+
+The watchdog message hardcodes "60s" from `launchingStallTimeoutMs / 1000` regardless of the observed `launchAgeMs` (`packages/app/src/main.ts:2582`). The actual delay is bounded below by the attempt lease (20 min) because of the `!launchLeaseActive` gate in `evaluateLaunchStall`.
+
+## Full Execution-Path Trace
+
+```
+DB (durable)                             | In-memory (TaskRunner instance)
+-----------------------------------------|------------------------------------
+attempt.status='claimed' + 20m lease     |
+task.status='pending', phase='launching' |
+event task.launch_claimed                |
+                                          \
+                                           → Promise from dispatchTasks (fire-and-forget)
+                                              ↓ (microtask)
+                                           TaskRunner.executeTasks → executeTask
+                                              ↓
+                                           launchingAttemptIds.add (per-instance Set)
+                                              ↓
+                                           selectExecutor → pool lease (durable row)
+                                              ↓
+preStartHeartbeatTimer renews lease  ←──── setInterval (per-instance timer)
+                                              ↓
+                                           executor.start() (per-instance promise)
+                                              ↓
+task.running event, phase='executing'    ←  markTaskRunningAfterLaunch
+attempt.status='running', lease renewed  ←
+                                              ↓
+                                           activeExecutions.set (per-instance Map)
+                                              ↓
+                                           executor.onComplete callback
+                                              ↓
+task.completed / task.failed             ←  handleWorkerResponse
+```
+
+### Hop 0 — Trigger: someone calls `orchestrator.startExecution()`
+
+Callers in `packages/app/src/main.ts` and `packages/app/src/headless.ts` include:
+- Owner startup (`init`)
+- `resume-workflow`, `executeHeadlessRun`, `executeHeadlessResume`
+- ~30 sites that follow the `const started = orchestrator.startExecution(); requireTaskExecutor().executeTasks(started).catch(...)` pattern
+- `executeGlobalTopup` / `dispatchStartedTasksWithGlobalTopup` after mutations
+- The two stall watchdogs themselves on cascade (`main.ts:2599`, `:2654`)
+
+### Hop 1 — `startExecution()` → enqueue ready tasks
+
+`packages/workflow-core/src/orchestrator.ts:1547–1567`. `refreshFromDb`, gather `getReadyTasks` filtered by external dependency blockers, enqueue each via `enqueueIfNotScheduled` into the in-memory `TaskScheduler.queue`, then call `drainScheduler`.
+
+### Hop 2 — `drainScheduler()`: pop, durably claim, mark `pending/launching`
+
+`packages/workflow-core/src/orchestrator.ts:4870–4988`. For each popped `TaskJob`:
+
+1. `claimAttemptForLaunch` writes `attempts[id].status='claimed', claimedAt, leaseExpiresAt = now + 20m`.
+2. `writeAndSync` writes `tasks.status='pending', execution.phase='launching', execution.launchStartedAt=now, execution.selectedAttemptId, execution.generation`.
+3. `logEvent('task.launch_claimed', changes)` is appended.
+4. The new `TaskState` is pushed onto the local `started` array.
+
+After Hop 2 the **DB believes the task is launching for the next 20 minutes**, but nothing other than the caller's local `started` variable references the work in memory.
+
+### Hop 3 — Caller hands `started` to a `TaskRunner`
+
+The hot mutation path (`packages/app/src/global-topup.ts:88–110`):
+
+```ts
+// TODO: replace app-level workflow mutation leases with atomic DB state transitions plus an outbox for launch/cancel side effects.
+const dispatchPromise = mutationTiming
+  ? mutationTiming.span(spanName, ..., run)
+  : Promise.resolve().then(run);
+void dispatchPromise
+  .then(() => bench(afterMark))
+  .catch((err) => { logger?.error(`[global-topup] ${context}: asynchronous task dispatch failed: ${message}`); });
+bench(`${afterMark}.accepted`);
+return Promise.resolve();
+```
+
+`dispatchMode` defaults to `'fire-and-forget'` whenever `mutationTiming` is present (`global-topup.ts:170`, `:232`). Every workflow mutation supplies `mutationTiming`. So **every workflow mutation dispatches launches fire-and-forget**, decoupled from the durable claim, with the only failure path being a logger.error.
+
+The non-mutation IPC paths use the simpler `requireTaskExecutor().executeTasks(started).catch(err => logger.error(...))` pattern — same fire-and-forget semantics, just without the `mutationTiming` wrapper.
+
+### Hop 4 — `TaskRunner.executeTasks → executeTask` per task
+
+`packages/execution-engine/src/task-runner.ts:416–423`:
+
+```ts
+async executeTasks(tasks: TaskState[]): Promise<void> {
+  ...
+  await Promise.all(tasks.map((task) => this.executeTask(task)));
+}
+```
+
+Inside `executeTask` (`task-runner.ts:458–485`) the per-instance `launchingAttemptIds` Set is mutated and `onLaunchAccepted` callback is fired. `launchingAttemptIds` is per-TaskRunner; `onLaunchAccepted` is only wired in the owner's TaskRunner (`main.ts:1709`), not in headless-spawned ones.
+
+### Hop 5 — `executeTaskInner → selectExecutor → pool lease → executor.start()`
+
+`task-runner.ts:558–795`. Notable behaviours:
+
+- `preStartHeartbeatTimer` (`task-runner.ts:776`) is a `setInterval` that renews `leaseExpiresAt = nextLeaseExpiry(now)` while `executor.start()` is awaited. This is what stops `launch-stall` from firing during slow SSH startups.
+- `Promise.race([executor.start(...), startTimeout])` provides an outer upper bound, but only kicks in once `executor.start()` is actually awaited.
+- Pool capacity errors throw a `ResourceLimitError` (wrapped as `cause`) which the outer catch (`task-runner.ts:492–495`) translates into `orchestrator.deferTask(taskId)`.
+
+### Hop 6 — `markTaskRunningAfterLaunch` → `phase: 'executing'`
+
+`task-runner.ts:893–910` → `orchestrator.ts:4996–5091`. Writes `task.running`, transitions `phase: 'executing'`, and resets the lease. If the orchestrator rejects (`attempt_mismatch`, `attempt_superseded`, `invalid_status`, `not_found`), the TaskRunner kills the spawned process and returns without emitting any `task.failed` event — leaving the old attempt's `pending/launching` row in place.
+
+### Hop 7 — Output/heartbeat/completion wiring
+
+`task-runner.ts:1005–1097`. Output, heartbeat (which renews the attempt lease again at `nextLeaseExpiry(now)`), and a serialized `onComplete` chain. Completion fans back through `handleWorkerResponse` → `drainScheduler` → recursive `this.executeTasks(newlyStarted)` (no `await`, no `.catch`).
+
+## Catalog of Issues
+
+The launch-claim orphan is **Issue 0**. The trace surfaced 14 additional issues; all are independent symptoms of the same architectural seam.
+
+### Issue 0 — Durable launch claim with non-durable dispatch (the original bug)
+
+- `drainScheduler` writes `task.launch_claimed`, a claimed attempt with a 20-minute lease, and `phase: 'launching'` (`orchestrator.ts:4917–4974`).
+- The corresponding executor invocation is a fire-and-forget JavaScript promise (`global-topup.ts:dispatchTasks`).
+- If the promise is dropped, no in-memory state recovers it; the only fallback is the watchdog.
+- The watchdog (`evaluateLaunchStall` in `packages/app/src/launch-stall.ts:41–48`) requires `!launchLeaseActive`, so it cannot fire until the 20-minute lease expires.
+- The watchdog action is `handleWorkerResponse({status: 'failed'})` — it never relaunches.
+
+### Issue 1 — Watchdog error message is misleading
+
+`packages/app/src/main.ts:2581–2582`:
+
+```ts
+const launchError =
+  `Launch stalled: task remained in running/launching for ${Math.floor(launchingStallTimeoutMs / 1000)}s without a spawned execution handle`;
+```
+
+`launchingStallTimeoutMs` is the configured timeout (default 60_000). `launchAgeMs` (the real wall-clock age) is computed but never substituted into the error. Every observed launch-stall failure in the incident reports "60s" while `launchAgeMs ≈ 1.2M`.
+
+### Issue 2 — Watchdog has no relaunch action; orphan-relaunch is wired to startup-only
+
+`packages/app/src/orphan-relaunch.ts` exposes `relaunchOrphansAndStartReady`, which is the correct recovery primitive (`prepareTaskForNewAttempt` + re-enqueue). It is invoked at:
+- `init` startup (`main.ts:2887`)
+- `resume-workflow` (`main.ts:3032`)
+- `headless` (`headless.ts:1386`)
+- A handful of IPC delegate paths (`main.ts:853, 1086, 1913`)
+
+It is **never** invoked from the db-poll loop. The watchdog has the trigger condition; orphan-relaunch has the recovery; they never meet. The only way to recover an orphaned `launching` claim in steady state today is to restart Invoker.
+
+### Issue 3 — Scheduler's in-memory `running` set is dead code on the hot path
+
+`packages/workflow-core/src/scheduler.ts`:
+
+- `drainScheduler` calls `takeNext()` (`scheduler.ts:103`), which removes from `queue` but never adds to `running`.
+- Only `dequeue()` (`scheduler.ts:114`) adds to `running`, and the orchestrator does not call it.
+- `completeJob`, `isRunning`, `getRunningAttemptIds`, `getRunningTaskIds`, `killAll`, `getRunningJobs`, `getStatus().runningCount` all reflect an empty `running` set on the production path.
+
+Capacity is correctly enforced via `countActivePersistedAttempts`, which goes back to the DB, but any code (including tests and instrumentation) that consults the scheduler's `running` view gets misleading answers.
+
+### Issue 4 — `takeNext()` is destructive without re-insert
+
+Three skip branches inside `drainScheduler` (`orchestrator.ts:4887, 4902, 4936`) all do `job = this.scheduler.takeNext(); continue;` — they pop and never re-insert. If a job is skipped because:
+
+- `task.status !== 'pending'` (a stale-write race),
+- the attempt is discarded,
+- claim fails because someone else has it,
+
+the job is gone from the scheduler. The only path back is the next `startExecution()`'s walk over `getReadyTasks`. A task in `pending/launching` is not "ready" — so a popped-and-skipped job can sit until orphan-relaunch is invoked (Issue 2).
+
+### Issue 5 — Launching tasks count against `maxConcurrency` for 20 minutes
+
+`packages/workflow-core/src/orchestrator.ts:1135–1153`:
+
+```ts
+private isAttemptLeaseActive(attempt, now) {
+  if (!attempt) return false;
+  if (isDiscardedAttempt(attempt)) return false;
+  if (attempt.status !== 'claimed' && attempt.status !== 'running') return false;
+  if (!attempt.leaseExpiresAt) return true;
+  return attempt.leaseExpiresAt.getTime() >= now;
+}
+
+private isTaskExecutionActive(task, attempt, now) {
+  if (attempt && this.isAttemptLeaseActive(attempt, now)) {
+    return task.status === 'pending' || task.status === 'running' || task.status === 'fixing_with_ai';
+  }
+  return task.status === 'running' || task.status === 'fixing_with_ai';
+}
+```
+
+A `pending/launching` task with an active 20-minute lease counts as active for capacity. Default `maxConcurrency = 3` (`orchestrator.ts:798`). **Three orphans starve the queue for 20 minutes at default settings.** Higher concurrencies merely raise the floor.
+
+### Issue 6 — Multi-TaskRunner: per-instance Sets/Maps, owner watchdog blind to headless launches
+
+`packages/app/src/headless.ts:195–243`: `createHeadlessExecutor` instantiates a fresh `TaskRunner` per headless command. The owner has its own long-lived `TaskRunner` (`main.ts:1671`). Each owns its own:
+
+- `launchingAttemptIds` Set
+- `activeExecutions` Map
+- `pendingPoolSelections`
+- `completionChain`
+
+The owner's `launchingTasks` Set (`main.ts:1266`) is populated only by callbacks (`onLaunchAccepted`, `onLaunchStart`, `onSpawned`, `onLaunchSettled`) that are wired on the owner's TaskRunner. Headless TaskRunners don't pass these callbacks (`headless.ts:230–241`).
+
+Consequences:
+- The owner's watchdog has no in-memory state for any headless-launched task. The watchdog relies entirely on the attempt lease (Hop 5's pre-start heartbeat) to distinguish "currently launching" from "orphaned."
+- Two TaskRunners can both call `executeTask` on the same task. The DB-level `claimAttemptForLaunch` deduplicates them, but only after both have walked through `selectExecutor`. Wasted work and noisier logs; a regression vector if either guard has a bug.
+
+### Issue 7 — Fire-and-forget recursion inside `executor.onComplete`
+
+`packages/execution-engine/src/task-runner.ts:1067–1069`:
+
+```ts
+if (newlyStarted.length > 0) {
+  this.executeTasks(newlyStarted);
+}
+```
+
+No `void`, no `await`, no `.catch`. A synchronous rejection in `executeTasks` (e.g. `resolveAttemptIdForStart` failing because `loadLatestAttemptId` raises) becomes an unhandled promise rejection. Same orphan mechanism as Issue 0, inside the executor instead of the caller.
+
+The pattern repeats at `task-runner.ts:549–551` (post-launch-failure fallback) and `task-runner.ts:594–596` (pivot/spawn-experiments).
+
+### Issue 8 — `Promise.all` rejection bypasses the per-task safety net
+
+`packages/execution-engine/src/task-runner.ts:422`: `await Promise.all(tasks.map((task) => this.executeTask(task)))`. Per-task work is wrapped in try/catch inside `executeTask`, which translates exceptions into a `'failed'` `WorkResponse`. But if anything throws **between** `resolveAttemptIdForStart` and the `try` block (lines 462–482), the throw escapes the per-task safety net. `Promise.all` rejects with that one error; the fire-and-forget caller's `.catch` logs it; the other tasks in the batch are still running but uninstrumented at this seam.
+
+### Issue 9 — Watchdog cascades reproduce the bug
+
+`packages/app/src/main.ts:2599–2609` (launch-stall) and `:2655–2664` (executing-stall) both use the fire-and-forget pattern to dispatch downstream tasks unblocked by the watchdog's force-failure. The recovery action can spawn new orphans by the same mechanism, exponentially.
+
+### Issue 10 — Pre-start heartbeat masks a hung `executor.start()`
+
+`packages/execution-engine/src/task-runner.ts:776–784` sets a `setInterval` that renews `leaseExpiresAt = nextLeaseExpiry(now)` for the duration of `executor.start()`. If `executor.start()` hangs indefinitely (e.g. SSH connect deadlock before `startTimeoutMs` can take effect, or a worktree-add that never returns), the heartbeat keeps renewing the lease. `launch-stall` cannot fire (lease always active). `executing-stall` doesn't apply (phase is still `launching`). The task is stuck in `launching` until `Promise.race` resolves to the timeout — which assumes the timeout fires reliably and that nothing in the start path can drop it.
+
+### Issue 11 — `ATTEMPT_LEASE_MS` is duplicated in two packages
+
+- `packages/workflow-core/src/orchestrator.ts:111`: `const ATTEMPT_LEASE_MS = 20 * 60 * 1000;`
+- `packages/execution-engine/src/task-runner.ts:66`: same constant, same value.
+
+Both expose a local `nextLeaseExpiry`. Any change to one without the other (or to `INVOKER_LAUNCHING_STALL_TIMEOUT_MS = 60_000` in `main.ts:1301`) produces silent skew across the launch-stall window.
+
+### Issue 12 — `markTaskRunningAfterLaunch` rejection silently leaves DB in `launching`
+
+`packages/execution-engine/src/task-runner.ts:893–909`. When the orchestrator rejects the transition (attempt superseded by a concurrent recreate/cancel during `executor.start()`), the spawn is killed and the function returns without emitting any task event. The DB still reflects `pending/launching` for the old attempt; the task may already have a fresh attempt from `prepareTaskForNewAttempt`. The launch-stall watchdog will eventually pick up the old attempt's orphan.
+
+### Issue 13 — Pivot/spawn-experiments path skips `markTaskRunningAfterLaunch`
+
+`packages/execution-engine/src/task-runner.ts:572–601`: for `task.config.pivot && experimentVariants.length > 0`, the inner method synthesizes a `spawn_experiments` `WorkResponse` and routes it through `handleWorkerResponse`. The parent task is left in `pending/launching` because the pivot path never calls `markTaskRunningAfterLaunch`. The parent's slot is held until the lease expires (Issue 5), then the watchdog fails it.
+
+### Issue 14 — SSH pool-selection lease can leak on early exception
+
+`packages/execution-engine/src/task-runner.ts:1213–1255`. The release sites at `:868, :904, :916, :985–986, :1047` cover the normal flow, but an exception thrown between `selectExecutor` releasing the early `pendingPoolSelections` entry and the proper acquisition can leave the SSH resource lease held with no in-memory owner. There is no watchdog for stale `execution_resource_lease` rows.
+
+### Issue 15 — Regression repro tests the inverse condition of the current bug
+
+`scripts/repro/repro-rebase-recreate-storm-launch-stall.sh:87–91`:
+
+```sql
+where lease_expires_at is not null
+  and julianday(lease_expires_at) > julianday(created_at);
+```
+
+This counts launch-stall failures **only** where the lease was still active at failure time. After `35c0ad97 "Guard launch stalls with live attempt leases"`, the watchdog refuses to fire while the lease is active — so this check is structurally green on every real orphan. The CI gate has been guarding the wrong condition since that PR landed.
+
+## How We Keep Missing This (Recurrence Analysis)
+
+`git log --grep="launch.stall|launching|orphan.*launch|launch claim|launch handoff|outbox" -i`:
+
+| Commit | Date | Intent | What it actually did |
+|---|---|---|---|
+| `0ece767c` Avoid false launch stalls during SSH startup | — | Slow-start tolerance | Tuned watchdog timing |
+| `905af5ec` Fix duplicate task launch claims | — | Double-claim safety | Idempotency in the claim path |
+| `b7cd9cc2` Fix launch prestart tracking | — | Memo a "launching" set | Added in-memory `launchingTasks` Set, used only as a gate in the watchdog |
+| `06ae8ed7` Fix reset paths to clear stale launch metadata | — | Cleanup after reset | Reset path only |
+| `a8a8001e` Guard stale launch poller after reset | — | More watchdog gating | Watchdog only |
+| `19c73337` Dispatch tasks after review gate auto-approval | — | Missing call site | One new `executeTasks` call site |
+| `32aaaa35` Dispatch tasks unblocked by launch-stall failures | — | Cascade after stall | Added the post-stall `executeTasks` chain (Issue 9 introduced here) |
+| `ebf9cf3d` Fix launch dispatch gaps and harden launch-stall recovery | 2026-04-16 | Centralize dispatch & add orphan-relaunch | Added `orphan-relaunch.ts` and `launching-stall-watchdog.spec.ts`; did not wire orphan-relaunch into the db-poll loop |
+| `35c0ad97 / 1be5852d` Guard launch stalls with live attempt leases | 2026-05-18 | Eliminate false positives | Added `!launchLeaseActive` to `evaluateLaunchStall`; converts false positives into 20-minute true positives that fail real work |
+
+Three structural reasons this keeps coming back:
+
+1. **Every PR patched one corner.** No PR introduced a durable companion record for the dispatch (an outbox), and no PR wired the existing recovery (`relaunchOrphansAndStartReady`) into the steady-state db-poll loop. The last PR (`35c0ad97`) made the symptom rarer at the cost of making each occurrence cost 20 minutes of capacity and an unrecoverable `task.failed`.
+2. **Regression tests assert the symptom-side action, not the desired outcome.** `packages/app/e2e/launching-stall-watchdog.spec.ts` asserts that the watchdog fires (i.e. that we mark the task `failed`). It locks in the wrong recovery. `packages/app/src/__tests__/launch-stall.test.ts` is a pure-unit test of `evaluateLaunchStall`'s boolean gate. Neither tests the durable-claim → executor-event invariant.
+3. **The most relevant repro tests the inverse condition** (Issue 15). The CI signal that should have caught a regression has been silently green-by-construction since 2026-05-18.
+
+## Architectural Diagnosis
+
+The subsystem has two correctly-designed halves and a brittle seam in the middle:
+
+- **Left half (durable, in DB):** state machine, attempts, leases, events, persistence. Well-instrumented; transactions cover atomicity.
+- **Right half (in-memory, in TaskRunner):** per-task state machine for spawn/heartbeat/complete, with `Promise.race` timeouts, retry loops, pool selection. Internally consistent inside one TaskRunner instance.
+- **Middle seam (fire-and-forget dispatch promise):** a single in-memory promise that connects them, with no durable record of "this claim is being dispatched." The author's own `// TODO: ... outbox for launch/cancel side effects` next to this code (Hop 3) is exact.
+
+Every issue in the catalog is a consequence of this seam:
+
+- Issues 0, 7, 8, 9 are direct expressions of "the promise can be dropped."
+- Issues 2, 4 are "we don't have a polled recovery on the durable side."
+- Issues 3, 6 are "we don't have a durable companion on the in-memory side."
+- Issues 1, 11, 13, 15 are "test/instrumentation drift around the seam."
+- Issues 5, 10, 12, 14 are "leases and slots become inconsistent across the seam."
+
+## Recommended Direction: Targeted Re-Architecture
+
+A focused redesign of the launch handoff, scoped tightly. **Not** a rewrite of the orchestrator or executor; both halves are sound. The proposal is to introduce a single new structure and route every launch through it:
+
+### Proposal 1 — Launch-dispatch outbox (preferred)
+
+Introduce a new persisted table `launch_dispatch`:
+
+```
+launch_dispatch (
+  id PK,
+  task_id NOT NULL,
+  attempt_id NOT NULL,                       -- the durable claim
+  state TEXT NOT NULL,                       -- 'pending' | 'dispatched' | 'completed' | 'abandoned'
+  dispatch_owner TEXT,                       -- runner instance id + pid; null when pending
+  enqueued_at NOT NULL,
+  dispatched_at,
+  acknowledged_at,                           -- when TaskRunner.executeTask first ran
+  fenced_until,                              -- short-lived dispatch lease (e.g. 30s)
+  attempts_count INTEGER NOT NULL DEFAULT 0,
+  last_error TEXT,
+  generation INTEGER NOT NULL
+);
+```
+
+Rule: **`drainScheduler` always writes a `launch_dispatch` row in the same transaction as the `task.launch_claimed` event.** No durable claim exists without a matching outbox row.
+
+A new `LaunchDispatcher` polls `launch_dispatch` where `state='pending'` (or `dispatched` with expired `fenced_until`):
+1. Atomically transitions `pending → dispatched`, sets `dispatch_owner` and a short `fenced_until` (e.g. 30 s).
+2. Hands the task to the local `TaskRunner`.
+3. `TaskRunner.executeTask` acknowledges receipt by transitioning to `acknowledged_at = now` (still `dispatched`).
+4. `markTaskRunningAfterLaunch` transitions `dispatched → completed`.
+5. If `fenced_until` expires without acknowledgement, the dispatcher re-issues from `pending`.
+
+Result:
+- Issue 0 disappears: the in-memory promise has a durable companion. A dropped promise becomes a `pending` (or stale `dispatched`) row that the dispatcher retries on its next tick.
+- Issue 2 disappears: the dispatcher is itself the polled recovery.
+- Issue 6 disappears: any TaskRunner (owner or headless) competes for the row atomically; the dispatch lease is the source of truth.
+- Issue 9 disappears: watchdog cascades enqueue into the outbox, not into a fire-and-forget promise.
+- Issue 5 mitigates: the attempt lease can stay 20 m for `executing` work, but `launching` work no longer needs to occupy a slot for the full lease — the outbox tells the orchestrator when a launch is genuinely in progress versus orphaned.
+
+### Proposal 2 — Wire `relaunchOrphansAndStartReady` into db-poll (cheaper fallback)
+
+If a full outbox is too much surface area, the minimum viable change is:
+
+1. Change the watchdog's recovery action from "mark `failed`" to "call `relaunchOrphansAndStartReady` for orphaned `pending/launching` tasks; mark `failed` only on the Nth consecutive orphan."
+2. Reduce the attempt lease for `launching` (e.g. 60 s) and the lease for `executing` separately (keep 20 m).
+3. Fix the watchdog error message to substitute `launchAgeMs / 1000`, not the configured timeout.
+4. Add a true-invariant regression test: every `task.launch_claimed` must be followed within `2 * launching_lease` seconds by exactly one of `task.executor.selected | task.executor.deferred | task.executor.startup-retry | task.failed (with concrete startup error) | task.prepared_for_new_attempt`.
+
+This is a smaller change but does not address Issues 3, 6, 7, 9, 10, 13, 14. It just stops the steady-state regression from being terminal.
+
+### Cleanups regardless of which proposal is taken
+
+- Single `ATTEMPT_LEASE_MS` source of truth (consolidate into `@invoker/contracts` or `@invoker/workflow-core`) — closes Issue 11.
+- Remove the dead `running`/`dequeue` path in `TaskScheduler` and document that capacity is DB-owned — closes Issue 3.
+- Fix `repro-rebase-recreate-storm-launch-stall.sh` to assert the inverse condition (closes Issue 15), and add the launch_claimed → executor-event invariant test (Phase 1 of any fix).
+- Make every `executeTasks` call either `await` or `void … .catch(...)` — closes the structural mistake at the JS level even if the outbox is the real solution.
+
+## Test Gaps (what we should be checking but aren't)
+
+1. **Invariant: `task.launch_claimed` → terminal launch event within bounded time.** No test asserts this. Add an integration test that drives a launch through `drainScheduler` and asserts the next event for the same attempt is one of `{task.executor.selected, task.executor.deferred, task.executor.startup-retry, task.failed-with-startup-error, task.prepared_for_new_attempt}` — and that it arrives within a bounded time.
+2. **Repro: storm with dropped dispatch promise.** Force the fire-and-forget promise to be cancelled mid-flight (e.g. by killing the headless TaskRunner reference before its microtask resolves) and assert the system recovers without operator intervention.
+3. **Concurrency starvation under orphan**: assert that N orphaned launches at `maxConcurrency=N` do not block downstream work for more than the launching-lease duration.
+4. **Watchdog cascade safety**: assert that a watchdog-induced cascade does not itself produce a second orphan.
+5. **Pivot completion**: assert pivot/spawn-experiments parents do not remain in `pending/launching` after `handleWorkerResponse`.
+6. **`markTaskRunningAfterLaunch` rejection cleanup**: assert that old-attempt `pending/launching` rows are cleared when the orchestrator rejects a transition.
+7. **SSH resource-lease leak**: assert that an exception during executor selection releases any held SSH pool lease.
+
+## Suggested Next Steps
+
+1. **Phase 1 (Reproduce).** Write the failing repro that asserts the `launch_claimed → executor-event` invariant against the current head. Confirm it fails for at least the storm scenario; ideally also for the pivot, double-TaskRunner, and watchdog-cascade vectors.
+2. **Decision point.** Choose Proposal 1 (outbox) or Proposal 2 (wire orphan-relaunch + fix lease split). Recommend Proposal 1 because the cumulative cost of point-fixes over the last nine PRs already exceeds the implementation cost of an outbox.
+3. **Phase 3 (Plan).** Write a YAML plan with explicit, testable steps:
+   - Outbox schema + migration.
+   - LaunchDispatcher with atomic claim/ack/expire transitions.
+   - Route every `drainScheduler`-issued claim through the outbox.
+   - Replace every `executeTasks(started).catch(...)` and fire-and-forget dispatch site with an outbox enqueue.
+   - Convert the watchdog from "mark `failed`" to "log a dispatcher exception and rely on retries; fail only after configurable max retries."
+   - Fix the existing repro script's inverted condition and add the new invariant test.
+   - Cleanups (single `ATTEMPT_LEASE_MS`, scheduler `running` set removal).
+4. **Backout safety.** Keep the existing watchdog behind a feature flag during rollout so the old recovery (mark `failed`) is still available if the dispatcher regresses.
+
+## Appendix: Source Citations
+
+Key source locations referenced in this document:
+
+```4870:4988:packages/workflow-core/src/orchestrator.ts
+  private drainScheduler(): TaskState[] {
+    ...
+    claimSucceeded = this.taskRepository.claimAttemptForLaunch?.(attemptId, claimPatch, now) ?? ...;
+    ...
+    this.persistence.logEvent?.(job.taskId, this.deferRunningUntilLaunch ? 'task.launch_claimed' : 'task.running', changes);
+    ...
+```
+
+```88:110:packages/app/src/global-topup.ts
+  // TODO: replace app-level workflow mutation leases with atomic DB state transitions plus an outbox for launch/cancel side effects.
+  const dispatchPromise = mutationTiming
+    ? mutationTiming.span(spanName, ..., run)
+    : Promise.resolve().then(run);
+  void dispatchPromise
+    .then(() => bench(afterMark))
+    .catch((err) => { logger?.error(...); });
+  bench(`${afterMark}.accepted`);
+  return Promise.resolve();
+```
+
+```41:48:packages/app/src/launch-stall.ts
+  const launchStalled =
+    phase === 'launching'
+    && launchStartedAt !== undefined
+    && launchAgeMs >= launchingStallTimeoutMs
+    && launchClaimedForCurrentAttempt
+    && !launchLeaseActive
+    && !hasExecutionHandle
+    && !isKnownLaunching;
+```
+
+```2581:2611:packages/app/src/main.ts
+                    const launchError =
+                      `Launch stalled: task remained in running/launching for ${Math.floor(launchingStallTimeoutMs / 1000)}s without a spawned execution handle`;
+                    ...
+                    void requireTaskExecutor().executeTasks(runnableAfterFailure).catch(...);
+```
+
+```87:91:scripts/repro/repro-rebase-recreate-storm-launch-stall.sh
+    select count(*)
+    from failed_stalls
+    where lease_expires_at is not null
+      and julianday(lease_expires_at) > julianday(created_at);
+```

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { loadConfig, resolveEmbeddedTerminalBackendConfig } from '../config.js';
+import {
+  loadConfig,
+  resolveEmbeddedTerminalBackendConfig,
+  resolveLaunchOutboxMode,
+} from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -24,9 +28,9 @@ vi.mock('node:os', async (importOriginal) => {
 });
 
 describe('loadConfig', () => {
-  it('returns empty config when no files exist', () => {
+  it('returns config with default launchOutboxMode when no files exist', () => {
     const config = loadConfig();
-    expect(config).toEqual({});
+    expect(config).toEqual({ launchOutboxMode: 'disabled' });
   });
 
   it('reads user-level ~/.invoker/config.json', () => {
@@ -248,5 +252,42 @@ describe('resolveEmbeddedTerminalBackendConfig', () => {
       {},
       { INVOKER_EMBEDDED_TERMINAL_BACKEND: 'external' },
     )).toThrow(/Invalid embedded terminal backend/);
+  });
+});
+
+describe('resolveLaunchOutboxMode', () => {
+  it('defaults to disabled when INVOKER_LAUNCH_OUTBOX is unset', () => {
+    expect(resolveLaunchOutboxMode({})).toBe('disabled');
+  });
+
+  it('returns observe when INVOKER_LAUNCH_OUTBOX=observe', () => {
+    expect(
+      resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'observe' }),
+    ).toBe('observe');
+  });
+
+  it('returns active when INVOKER_LAUNCH_OUTBOX=active', () => {
+    expect(
+      resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'active' }),
+    ).toBe('active');
+  });
+
+  it('falls back to disabled with a warning for unknown values', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      expect(
+        resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'on' }),
+      ).toBe('disabled');
+      expect(warnSpy).toHaveBeenCalledOnce();
+      expect(warnSpy.mock.calls[0]?.[0]).toMatch(/Unknown INVOKER_LAUNCH_OUTBOX/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(
+      resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: '  Observe  ' }),
+    ).toBe('observe');
   });
 });

--- a/packages/app/src/__tests__/execution-capacity.test.ts
+++ b/packages/app/src/__tests__/execution-capacity.test.ts
@@ -2,7 +2,10 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
+  assertExecutionCapacityInvariant,
+  computeConfiguredExecutionCapacity,
   resolveEffectiveMaxConcurrency,
+  shouldFatalOnExecutionCapacityOvercommit,
 } from '../execution-capacity.js';
 
 describe('execution-capacity', () => {
@@ -17,5 +20,72 @@ describe('execution-capacity', () => {
   it('falls back to safe defaults for invalid values', () => {
     expect(resolveEffectiveMaxConcurrency(undefined)).toBe(DEFAULT_WORKTREE_MAX_CONCURRENCY);
     expect(resolveEffectiveMaxConcurrency(0)).toBe(DEFAULT_WORKTREE_MAX_CONCURRENCY);
+  });
+
+  it('computes capacity from SSH pool members', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        ssh: {
+          members: [
+            { type: 'ssh', id: 'a' },
+            { type: 'ssh', id: 'b' },
+            { type: 'ssh', id: 'c' },
+            { type: 'ssh', id: 'd' },
+          ],
+        },
+      },
+    })).toBe(4);
+    expect(() => assertExecutionCapacityInvariant({
+      config: {
+        executionPools: {
+          ssh: {
+            members: [
+              { type: 'ssh', id: 'a' },
+              { type: 'ssh', id: 'b' },
+              { type: 'ssh', id: 'c' },
+              { type: 'ssh', id: 'd' },
+            ],
+          },
+        },
+      },
+      activeExecutions: 5,
+    })).toThrow(/configured capacity=4/);
+  });
+
+  it('does not double count the same member across overlapping pools', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        one: { members: [{ type: 'ssh', id: 'shared' }, { type: 'ssh', id: 'a' }] },
+        two: { members: [{ type: 'ssh', id: 'shared' }, { type: 'ssh', id: 'b' }] },
+      },
+    })).toBe(3);
+  });
+
+  it('uses the max capacity for a repeated member instead of summing', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        one: { maxConcurrentTasksPerMember: 2, members: [{ type: 'ssh', id: 'shared' }] },
+        two: { maxConcurrentTasksPerMember: 4, members: [{ type: 'ssh', id: 'shared' }] },
+      },
+    })).toBe(4);
+  });
+
+  it('counts worktree member maxConcurrentTasks', () => {
+    expect(computeConfiguredExecutionCapacity({
+      executionPools: {
+        worktree: { members: [{ type: 'worktree', id: 'local', maxConcurrentTasks: 12 }] },
+      },
+    })).toBe(12);
+  });
+
+  it('falls back to top-level maxConcurrency when no execution pools exist', () => {
+    expect(computeConfiguredExecutionCapacity({ maxConcurrency: 7 })).toBe(7);
+  });
+
+  it('keeps fatal capacity checks disabled unless opted in', () => {
+    expect(shouldFatalOnExecutionCapacityOvercommit({})).toBe(false);
+    expect(shouldFatalOnExecutionCapacityOvercommit({
+      INVOKER_FATAL_ON_EXECUTION_CAPACITY_OVERCOMMIT: '1',
+    })).toBe(true);
   });
 });

--- a/packages/app/src/__tests__/headless-batch-exec.test.ts
+++ b/packages/app/src/__tests__/headless-batch-exec.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+import { executeNoTrackHeadlessBatch, type HeadlessExecMutationPayload } from '../headless-batch-exec.js';
+
+describe('executeNoTrackHeadlessBatch', () => {
+  it('queues multiple no-track workflow mutations and returns per-item acknowledgements', () => {
+    const classify = vi.fn((payload: HeadlessExecMutationPayload) => ({
+      workflowId: payload.args[1],
+      priority: 'high' as const,
+    }));
+    let nextIntentId = 100;
+    const submit = vi.fn(() => nextIntentId++);
+
+    const results = executeNoTrackHeadlessBatch(
+      {
+        noTrack: true,
+        items: [
+          { label: 'first', workflowId: 'wf-1', args: ['rebase-recreate', 'wf-1'] },
+          { label: 'second', workflowId: 'wf-2', args: ['rebase-recreate', 'wf-2'] },
+        ],
+      },
+      { classify, submit },
+    );
+
+    expect(results).toEqual([
+      {
+        label: 'first',
+        workflowId: 'wf-1',
+        args: ['rebase-recreate', 'wf-1'],
+        ok: true,
+        response: { ok: true, intentId: 100 },
+      },
+      {
+        label: 'second',
+        workflowId: 'wf-2',
+        args: ['rebase-recreate', 'wf-2'],
+        ok: true,
+        response: { ok: true, intentId: 101 },
+      },
+    ]);
+    expect(submit).toHaveBeenNthCalledWith(
+      1,
+      'wf-1',
+      'high',
+      'headless.exec',
+      [{ args: ['rebase-recreate', 'wf-1'], waitForApproval: undefined, noTrack: true, traceId: undefined }],
+      { deferDrain: true },
+    );
+    expect(submit).toHaveBeenNthCalledWith(
+      2,
+      'wf-2',
+      'high',
+      'headless.exec',
+      [{ args: ['rebase-recreate', 'wf-2'], waitForApproval: undefined, noTrack: true, traceId: undefined }],
+      { deferDrain: true },
+    );
+  });
+
+  it('reports per-item failures without aborting the rest of the batch', () => {
+    const classify = vi.fn((payload: HeadlessExecMutationPayload) => ({
+      workflowId: payload.args[1]?.startsWith('wf-') ? payload.args[1] : undefined,
+      priority: 'high' as const,
+    }));
+    const submit = vi.fn(() => 42);
+
+    const results = executeNoTrackHeadlessBatch(
+      {
+        noTrack: true,
+        items: [
+          { label: 'bad-args', args: 'rebase-recreate wf-1' },
+          { label: 'bad-target', args: ['rebase-recreate', 'missing'] },
+          { label: 'good', args: ['rebase-recreate', 'wf-1'] },
+        ],
+      },
+      { classify, submit },
+    );
+
+    expect(results).toEqual([
+      {
+        label: 'bad-args',
+        workflowId: undefined,
+        args: [],
+        ok: false,
+        error: 'Invalid batch item: args must be a string array',
+      },
+      {
+        label: 'bad-target',
+        workflowId: undefined,
+        args: ['rebase-recreate', 'missing'],
+        ok: false,
+        error: 'Fire-and-forget headless.exec could not be queued: workflow-not-resolved',
+      },
+      {
+        label: 'good',
+        workflowId: 'wf-1',
+        args: ['rebase-recreate', 'wf-1'],
+        ok: true,
+        response: { ok: true, intentId: 42 },
+      },
+    ]);
+    expect(submit).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws retryable queue errors so the caller can retry the batch', () => {
+    const classify = vi.fn(() => ({
+      workflowId: 'wf-1',
+      priority: 'high' as const,
+    }));
+    const submit = vi.fn(() => {
+      throw new Error('database is locked');
+    });
+
+    expect(() => executeNoTrackHeadlessBatch(
+      {
+        noTrack: true,
+        items: [{ label: 'locked', args: ['rebase-recreate', 'wf-1'] }],
+      },
+      { classify, submit },
+    )).toThrow('database is locked');
+  });
+});

--- a/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
+++ b/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Regression test for the 2026-05-22T01:55:56 launch-claim orphan storm.
+ *
+ * Background (see docs/incidents/2026-05-22-launch-handoff-orphan-architecture.md):
+ *  - 38 concurrent `rebase-recreate` mutations were dispatched.
+ *  - The orchestrator wrote `task.launch_claimed` for every claimed
+ *    attempt (durable state).
+ *  - The fire-and-forget hand-off to the TaskRunner was lost for four
+ *    of the claims, so no terminal launch event was ever written.
+ *  - Those four claims sat in `pending/launching` for ~20 minutes
+ *    before the watchdog failed them with the misleading
+ *    "60 seconds" error message.
+ *
+ * This test reproduces the steady-state shape in-process: 38 single-task
+ * plans are loaded, `startExecution()` is called to claim every
+ * attempt, and **no TaskRunner is wired in** — exactly the fragile
+ * seam the re-architecture is meant to eliminate.
+ *
+ * The test is marked `it.fails` so CI stays green while the bug is
+ * documented. The Phase B definition of done (see
+ * .cursor/plans/launch_handoff_rearchitecture_c13d3ffc.plan.md) calls
+ * for removing the `.fails` marker once the durable
+ * `task_launch_dispatch` outbox dispatcher is active and resolves
+ * every claim.
+ */
+
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { Orchestrator, type PlanDefinition } from '@invoker/workflow-core';
+import { InMemoryBus } from '@invoker/test-kit';
+import {
+  LAUNCH_CLAIM_EVENT_TYPE,
+  LaunchInvariantViolationError,
+  TERMINAL_LAUNCH_EVENT_TYPES,
+  assertLaunchInvariant,
+} from './launch-invariant.js';
+
+const STORM_SIZE = 38;
+const TIGHT_MAX_GAP_MS = 60_000;
+const PRETEND_LATER_MS = 10 * 60 * 1000; // 10 minutes after `now`
+
+describe('launch-claim orphan regression (2026-05-22 storm)', () => {
+  const adapters: SQLiteAdapter[] = [];
+
+  afterEach(() => {
+    for (const adapter of adapters.splice(0)) {
+      adapter.close();
+    }
+  });
+
+  it.fails(
+    'a 38-claim rebase-recreate storm without a dispatcher orphans every claim',
+    async () => {
+      const persistence = await SQLiteAdapter.create(':memory:');
+      adapters.push(persistence);
+
+      const orchestrator = new Orchestrator({
+        persistence: persistence as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: STORM_SIZE,
+        // Mirror production wiring (packages/app/src/main.ts:502) — without
+        // this flag the orchestrator writes `task.running` directly and skips
+        // the two-phase claim/launch hand-off that the bug lives in.
+        deferRunningUntilLaunch: true,
+      });
+
+      for (let i = 0; i < STORM_SIZE; i++) {
+        const plan: PlanDefinition = {
+          name: `rebase-recreate-storm-${i}`,
+          baseBranch: 'master',
+          featureBranch: `experiment/storm-${i}`,
+          tasks: [
+            {
+              id: `t-${i}`,
+              description: `Storm task ${i}`,
+              command: `echo storm-${i}`,
+            },
+          ],
+        };
+        orchestrator.loadPlan(plan);
+      }
+
+      orchestrator.startExecution();
+
+      const claimCount = persistence
+        .getAllTaskIds()
+        .reduce(
+          (acc, taskId) =>
+            acc +
+            persistence
+              .getEvents(taskId)
+              .filter((event) => event.eventType === LAUNCH_CLAIM_EVENT_TYPE)
+              .length,
+          0,
+        );
+      expect(claimCount).toBe(STORM_SIZE);
+
+      const terminalCount = persistence
+        .getAllTaskIds()
+        .reduce(
+          (acc, taskId) =>
+            acc +
+            persistence
+              .getEvents(taskId)
+              .filter((event) => TERMINAL_LAUNCH_EVENT_TYPES.has(event.eventType))
+              .length,
+          0,
+        );
+      expect(terminalCount).toBe(0);
+
+      try {
+        assertLaunchInvariant(persistence, {
+          maxGapMs: TIGHT_MAX_GAP_MS,
+          nowMs: Date.now() + PRETEND_LATER_MS,
+        });
+      } catch (err) {
+        expect(err).toBeInstanceOf(LaunchInvariantViolationError);
+        const violation = err as LaunchInvariantViolationError;
+        expect(violation.summary.claimCount).toBe(STORM_SIZE);
+        expect(violation.violations).toHaveLength(STORM_SIZE);
+        for (const v of violation.violations) {
+          expect(v.reason).toBe('no_terminal_event');
+        }
+        throw err;
+      }
+    },
+  );
+});

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { Logger } from '@invoker/contracts';
+import { LaunchDispatcher } from '../launch-dispatcher.js';
+
+function makeLogger(): Logger & {
+  records: { level: 'info' | 'warn' | 'error' | 'debug'; msg: string; fields?: Record<string, unknown> }[];
+} {
+  const records: { level: 'info' | 'warn' | 'error' | 'debug'; msg: string; fields?: Record<string, unknown> }[] = [];
+  const push = (level: 'info' | 'warn' | 'error' | 'debug') =>
+    (msg: string, fields?: Record<string, unknown>) => {
+      records.push({ level, msg, fields });
+    };
+  const logger: Logger = {
+    debug: push('debug'),
+    info: push('info'),
+    warn: push('warn'),
+    error: push('error'),
+    child: () => logger,
+  };
+  return Object.assign(logger, { records });
+}
+
+describe('LaunchDispatcher', () => {
+  let adapter: SQLiteAdapter;
+
+  beforeEach(async () => {
+    adapter = await SQLiteAdapter.create(':memory:');
+  });
+
+  afterEach(() => {
+    adapter.close();
+  });
+
+  it('constructs with a real SQLiteAdapter without throwing', () => {
+    expect(() => new LaunchDispatcher({
+      persistence: adapter,
+      ownerId: 'owner-test',
+      mode: 'observe',
+    })).not.toThrow();
+  });
+
+  it('observer mode logs state counts and does not mutate rows', () => {
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    adapter.saveTask('wf-1', {
+      id: 'wf-1/t1',
+      description: 'one',
+      status: 'pending',
+      dependencies: [],
+      createdAt: new Date(),
+      config: { workflowId: 'wf-1' },
+      execution: {},
+      taskStateVersion: 1,
+    });
+    const enqueued = adapter.enqueueLaunchDispatch({
+      taskId: 'wf-1/t1',
+      attemptId: 'attempt-1',
+      workflowId: 'wf-1',
+      generation: 0,
+    });
+
+    const logger = makeLogger();
+    const dispatcher = new LaunchDispatcher({
+      persistence: adapter,
+      ownerId: 'owner-test',
+      logger,
+      mode: 'observe',
+    });
+
+    dispatcher.poll();
+
+    const observed = logger.records.find((entry) => entry.msg.includes('observed'));
+    expect(observed).toBeDefined();
+    expect(observed?.fields?.total).toBe(1);
+    const counts = observed?.fields?.counts as Record<string, number> | undefined;
+    expect(counts?.enqueued).toBe(1);
+    expect(counts?.leased).toBe(0);
+    expect(counts?.acknowledged).toBe(0);
+
+    const afterPoll = adapter.loadLaunchDispatchById(enqueued.id);
+    expect(afterPoll).toMatchObject({ state: 'enqueued' });
+  });
+
+  it('active mode throws a CB.5 placeholder error', () => {
+    const fakePersistence = {
+      listLaunchDispatchesByState: vi.fn(),
+    };
+    const dispatcher = new LaunchDispatcher({
+      persistence: fakePersistence as unknown as SQLiteAdapter,
+      ownerId: 'owner-test',
+      mode: 'active',
+    });
+    expect(() => dispatcher.poll()).toThrow(/CB\.5 not implemented/);
+    expect(fakePersistence.listLaunchDispatchesByState).not.toHaveBeenCalled();
+  });
+
+  it('observer mode reports zero counts when the outbox is empty', () => {
+    const logger = makeLogger();
+    const dispatcher = new LaunchDispatcher({
+      persistence: adapter,
+      ownerId: 'owner-test',
+      logger,
+      mode: 'observe',
+    });
+
+    dispatcher.poll();
+
+    const observed = logger.records.find((entry) => entry.msg.includes('observed'));
+    expect(observed?.fields?.total).toBe(0);
+  });
+});

--- a/packages/app/src/__tests__/launch-invariant.test.ts
+++ b/packages/app/src/__tests__/launch-invariant.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest';
+import type { TaskEvent } from '@invoker/data-store';
+import {
+  DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS,
+  LaunchInvariantViolationError,
+  assertLaunchInvariant,
+} from './launch-invariant.js';
+
+interface FixturePersistence {
+  getAllTaskIds(): string[];
+  getEvents(taskId: string): TaskEvent[];
+}
+
+function buildPersistence(
+  perTaskEvents: Record<string, Array<Omit<TaskEvent, 'taskId'>>>,
+): FixturePersistence {
+  return {
+    getAllTaskIds: () => Object.keys(perTaskEvents),
+    getEvents: (taskId) =>
+      (perTaskEvents[taskId] ?? []).map((event) => ({ ...event, taskId })),
+  };
+}
+
+const T0 = '2026-05-22T01:55:56.000Z';
+const T1 = '2026-05-22T01:55:57.000Z';
+const T1_PLUS_20MIN = '2026-05-22T02:15:57.000Z';
+
+describe('assertLaunchInvariant', () => {
+  it('passes when every claim is followed by a terminal launch event', () => {
+    const persistence = buildPersistence({
+      'task-a': [
+        { id: 1, eventType: 'task.launch_claimed', payload: undefined, createdAt: T0 },
+        { id: 2, eventType: 'task.executor.selected', payload: undefined, createdAt: T1 },
+        { id: 3, eventType: 'task.running', payload: undefined, createdAt: T1 },
+      ],
+    });
+
+    const result = assertLaunchInvariant(persistence, { maxGapMs: 5_000 });
+
+    expect(result.taskCount).toBe(1);
+    expect(result.claimCount).toBe(1);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('throws when a claim has no resolving terminal event and is older than maxGapMs', () => {
+    const persistence = buildPersistence({
+      'task-orphan': [
+        { id: 1, eventType: 'task.launch_claimed', payload: undefined, createdAt: T0 },
+      ],
+    });
+
+    try {
+      assertLaunchInvariant(persistence, {
+        maxGapMs: 60_000,
+        nowMs: Date.parse(T1_PLUS_20MIN),
+      });
+      throw new Error('expected violation');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LaunchInvariantViolationError);
+      const violations = (err as LaunchInvariantViolationError).violations;
+      expect(violations).toHaveLength(1);
+      expect(violations[0].reason).toBe('no_terminal_event');
+      expect(violations[0].taskId).toBe('task-orphan');
+    }
+  });
+
+  it('throws when a claim is followed only by a fresh claim (orphan-then-reclaim)', () => {
+    const persistence = buildPersistence({
+      'task-reclaim': [
+        { id: 1, eventType: 'task.launch_claimed', payload: undefined, createdAt: T0 },
+        { id: 2, eventType: 'task.launch_claimed', payload: undefined, createdAt: T1_PLUS_20MIN },
+        { id: 3, eventType: 'task.executor.selected', payload: undefined, createdAt: T1_PLUS_20MIN },
+      ],
+    });
+
+    try {
+      assertLaunchInvariant(persistence, {
+        maxGapMs: 60_000,
+        nowMs: Date.parse('2026-05-22T03:00:00.000Z'),
+      });
+      throw new Error('expected violation');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LaunchInvariantViolationError);
+      const violations = (err as LaunchInvariantViolationError).violations;
+      expect(violations).toHaveLength(1);
+      expect(violations[0].claimEventId).toBe(1);
+      expect(violations[0].reason).toBe('no_terminal_event');
+    }
+  });
+
+  it('throws when the gap between claim and terminal event exceeds maxGapMs', () => {
+    const persistence = buildPersistence({
+      'task-slow': [
+        { id: 1, eventType: 'task.launch_claimed', payload: undefined, createdAt: T0 },
+        { id: 2, eventType: 'task.executor.selected', payload: undefined, createdAt: T1_PLUS_20MIN },
+      ],
+    });
+
+    try {
+      assertLaunchInvariant(persistence, { maxGapMs: 60_000 });
+      throw new Error('expected violation');
+    } catch (err) {
+      expect(err).toBeInstanceOf(LaunchInvariantViolationError);
+      const violations = (err as LaunchInvariantViolationError).violations;
+      expect(violations).toHaveLength(1);
+      expect(violations[0].reason).toBe('gap_exceeded');
+      expect(violations[0].nextEventType).toBe('task.executor.selected');
+      expect(violations[0].gapMs).toBeGreaterThan(60_000);
+    }
+  });
+
+  it('honours options.taskIds to restrict the scan', () => {
+    const persistence = buildPersistence({
+      'task-orphan': [
+        { id: 1, eventType: 'task.launch_claimed', payload: undefined, createdAt: T0 },
+      ],
+      'task-ok': [
+        { id: 1, eventType: 'task.launch_claimed', payload: undefined, createdAt: T0 },
+        { id: 2, eventType: 'task.running', payload: undefined, createdAt: T1 },
+      ],
+    });
+
+    const result = assertLaunchInvariant(persistence, {
+      maxGapMs: 5_000,
+      taskIds: ['task-ok'],
+    });
+
+    expect(result.taskCount).toBe(1);
+    expect(result.violations).toHaveLength(0);
+  });
+
+  it('exposes a default maxGapMs anchored to the dispatch lease budget', () => {
+    expect(DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS).toBe(270_000);
+  });
+});

--- a/packages/app/src/__tests__/launch-invariant.ts
+++ b/packages/app/src/__tests__/launch-invariant.ts
@@ -1,0 +1,215 @@
+/**
+ * Launch-handoff invariant assertion.
+ *
+ * Companion to the launch-handoff re-architecture (see
+ * `docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md`).
+ *
+ * The invariant: every `task.launch_claimed` event recorded by the
+ * orchestrator must be followed within a bounded window by a terminal
+ * launch event for the same task. Terminal launch events are the
+ * concrete outcomes that resolve the durable launch claim:
+ *
+ *   - `task.executor.selected`            — executor picked and started
+ *   - `task.executor.deferred`            — executor selection deferred (capacity/lease)
+ *   - `task.executor.startup-retry`       — transient startup error, retry pending
+ *   - `task.running`                       — launch fully transitioned to executing
+ *   - `task.failed`                        — launch resulted in a concrete failure
+ *   - `task.prepared_for_new_attempt`      — orchestrator reset the claim to retry
+ *
+ * Any `task.launch_claimed` that does not reach one of these within
+ * `maxGapMs` is treated as an orphaned launch claim — exactly the
+ * symptom catalogued in the 2026-05-22 incident.
+ */
+
+import type { PersistenceAdapter, TaskEvent } from '@invoker/data-store';
+
+export const LAUNCH_CLAIM_EVENT_TYPE = 'task.launch_claimed';
+
+export const TERMINAL_LAUNCH_EVENT_TYPES: ReadonlySet<string> = new Set([
+  'task.executor.selected',
+  'task.executor.deferred',
+  'task.executor.startup-retry',
+  'task.running',
+  'task.failed',
+  'task.prepared_for_new_attempt',
+]);
+
+/**
+ * Default upper bound on the gap between `task.launch_claimed` and the
+ * next terminal launch event. Matches `3 * DISPATCH_LEASE_MS *
+ * DISPATCH_MAX_ATTEMPTS` (= 270 s with the proposed dispatch defaults of
+ * 30 s lease and 3 attempts). Tests that drive a deterministic in-memory
+ * scenario should pass a tighter bound.
+ */
+export const DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS = 270_000;
+
+export type LaunchInvariantPersistence = Pick<
+  PersistenceAdapter,
+  'getAllTaskIds' | 'getEvents'
+>;
+
+export interface LaunchInvariantOptions {
+  /** Maximum allowed gap (ms) between claim and terminal launch event. */
+  maxGapMs?: number;
+  /** Restrict the scan to these task ids; default scans every task. */
+  taskIds?: readonly string[];
+  /**
+   * Optional `now` override for deterministic tests where the latest
+   * event has not yet been followed by anything but enough wall-clock
+   * time has passed that we want to treat it as a violation regardless.
+   * Defaults to `Date.now()`.
+   */
+  nowMs?: number;
+}
+
+export type LaunchInvariantViolationReason =
+  | 'no_terminal_event'
+  | 'gap_exceeded';
+
+export interface LaunchInvariantViolation {
+  taskId: string;
+  claimEventId: number;
+  claimAt: string;
+  /** Undefined when no later terminal event exists at all. */
+  nextEventType?: string;
+  nextEventAt?: string;
+  /** Null when there is no later terminal event to compare against. */
+  gapMs: number | null;
+  reason: LaunchInvariantViolationReason;
+}
+
+export interface LaunchInvariantResult {
+  taskCount: number;
+  claimCount: number;
+  violations: readonly LaunchInvariantViolation[];
+}
+
+export class LaunchInvariantViolationError extends Error {
+  readonly violations: readonly LaunchInvariantViolation[];
+  readonly summary: { taskCount: number; claimCount: number };
+
+  constructor(
+    violations: readonly LaunchInvariantViolation[],
+    summary: { taskCount: number; claimCount: number },
+  ) {
+    super(formatViolationMessage(violations, summary));
+    this.name = 'LaunchInvariantViolationError';
+    this.violations = violations;
+    this.summary = summary;
+  }
+}
+
+/**
+ * Walk the events table for the given (or all) tasks and assert the
+ * launch-claim invariant. Throws `LaunchInvariantViolationError` when
+ * any violation is found.
+ */
+export function assertLaunchInvariant(
+  persistence: LaunchInvariantPersistence,
+  options: LaunchInvariantOptions = {},
+): LaunchInvariantResult {
+  const maxGapMs = options.maxGapMs ?? DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS;
+  const taskIds = options.taskIds ?? persistence.getAllTaskIds();
+  const nowMs = options.nowMs ?? Date.now();
+
+  const violations: LaunchInvariantViolation[] = [];
+  let claimCount = 0;
+
+  for (const taskId of taskIds) {
+    const events = persistence.getEvents(taskId);
+    for (let i = 0; i < events.length; i++) {
+      const claim = events[i];
+      if (claim.eventType !== LAUNCH_CLAIM_EVENT_TYPE) continue;
+      claimCount += 1;
+
+      const next = findResolvingEvent(events, i + 1);
+      if (!next) {
+        const claimMs = Date.parse(claim.createdAt);
+        const ageMs = Number.isFinite(claimMs)
+          ? Math.max(0, nowMs - claimMs)
+          : Number.POSITIVE_INFINITY;
+        if (ageMs > maxGapMs) {
+          violations.push({
+            taskId,
+            claimEventId: claim.id,
+            claimAt: claim.createdAt,
+            gapMs: null,
+            reason: 'no_terminal_event',
+          });
+        }
+        continue;
+      }
+
+      const gapMs = parseGapMs(claim.createdAt, next.createdAt);
+      if (gapMs > maxGapMs) {
+        violations.push({
+          taskId,
+          claimEventId: claim.id,
+          claimAt: claim.createdAt,
+          nextEventType: next.eventType,
+          nextEventAt: next.createdAt,
+          gapMs,
+          reason: 'gap_exceeded',
+        });
+      }
+    }
+  }
+
+  const summary = { taskCount: taskIds.length, claimCount };
+  if (violations.length > 0) {
+    throw new LaunchInvariantViolationError(violations, summary);
+  }
+  return { ...summary, violations };
+}
+
+/**
+ * Walk `events` starting at `startIndex` and return the first terminal
+ * launch event, OR `undefined` when another `task.launch_claimed`
+ * appears first (which itself is an orphan: a fresh claim recorded
+ * without the previous one being resolved).
+ */
+function findResolvingEvent(
+  events: readonly TaskEvent[],
+  startIndex: number,
+): TaskEvent | undefined {
+  for (let i = startIndex; i < events.length; i++) {
+    const event = events[i];
+    if (event.eventType === LAUNCH_CLAIM_EVENT_TYPE) {
+      return undefined;
+    }
+    if (TERMINAL_LAUNCH_EVENT_TYPES.has(event.eventType)) {
+      return event;
+    }
+  }
+  return undefined;
+}
+
+function parseGapMs(claimAt: string, nextAt: string): number {
+  const claimMs = Date.parse(claimAt);
+  const nextMs = Date.parse(nextAt);
+  if (!Number.isFinite(claimMs) || !Number.isFinite(nextMs)) {
+    return Number.POSITIVE_INFINITY;
+  }
+  return Math.max(0, nextMs - claimMs);
+}
+
+function formatViolationMessage(
+  violations: readonly LaunchInvariantViolation[],
+  summary: { taskCount: number; claimCount: number },
+): string {
+  const lines = violations.slice(0, 5).map((v) => {
+    const base = `  taskId=${v.taskId} claimEventId=${v.claimEventId} reason=${v.reason}`;
+    const nextPart = v.nextEventType ? ` next=${v.nextEventType}` : '';
+    const gapPart = v.gapMs != null ? ` gapMs=${v.gapMs}` : '';
+    return `${base}${nextPart}${gapPart}`;
+  });
+  const more =
+    violations.length > 5 ? `\n  ... and ${violations.length - 5} more` : '';
+  return (
+    `Launch invariant violated: ${violations.length} of ${summary.claimCount} ` +
+    `task.launch_claimed events across ${summary.taskCount} tasks did not reach ` +
+    `a terminal launch event within the allowed window.\n` +
+    lines.join('\n') +
+    more
+  );
+}

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -206,7 +206,22 @@ export interface InvokerConfig {
     /** Routing strategy. Defaults to "enforce". */
     strategy?: 'enforce' | 'route';
   }>;
+  /**
+   * Launch-handoff outbox mode (Phase A of the launch-handoff
+   * re-architecture). Resolved from the INVOKER_LAUNCH_OUTBOX env var:
+   * - "disabled" (default): legacy in-memory dispatch only.
+   * - "observe": orchestrator writes task_launch_dispatch rows alongside
+   *   the existing claim path; LaunchDispatcher polls and logs counts but
+   *   does not own dispatch.
+   * - "active": LaunchDispatcher is the source of truth for dispatch
+   *   (Phase B; placeholder today).
+   *
+   * Unknown values fall back to "disabled" with a console warning.
+   */
+  launchOutboxMode?: LaunchOutboxMode;
 }
+
+export type LaunchOutboxMode = 'disabled' | 'observe' | 'active';
 
 function readJsonSafe(path: string): InvokerConfig {
   if (!existsSync(path)) {
@@ -230,10 +245,34 @@ function readJsonSafe(path: string): InvokerConfig {
 }
 
 export function loadConfig(): InvokerConfig {
-  if (process.env.INVOKER_REPO_CONFIG_PATH) {
-    return readJsonSafe(process.env.INVOKER_REPO_CONFIG_PATH);
+  const base = process.env.INVOKER_REPO_CONFIG_PATH
+    ? readJsonSafe(process.env.INVOKER_REPO_CONFIG_PATH)
+    : readJsonSafe(join(homedir(), '.invoker', 'config.json'));
+  base.launchOutboxMode = resolveLaunchOutboxMode();
+  return base;
+}
+
+/**
+ * Resolve the launch-outbox feature-flag mode from the
+ * `INVOKER_LAUNCH_OUTBOX` env var.
+ *
+ * Returns `'disabled'` when the var is unset, empty, or holds an
+ * unrecognised value (with a console warning for unknown values so
+ * operators notice typos like `INVOKER_LAUNCH_OUTBOX=on`).
+ */
+export function resolveLaunchOutboxMode(
+  env: NodeJS.ProcessEnv = process.env,
+): LaunchOutboxMode {
+  const raw = env.INVOKER_LAUNCH_OUTBOX;
+  if (typeof raw !== 'string' || raw.trim() === '') return 'disabled';
+  const normalized = raw.trim().toLowerCase();
+  if (normalized === 'disabled' || normalized === 'observe' || normalized === 'active') {
+    return normalized;
   }
-  return readJsonSafe(join(homedir(), '.invoker', 'config.json'));
+  console.warn(
+    `[config] Unknown INVOKER_LAUNCH_OUTBOX value "${raw}"; falling back to "disabled".`,
+  );
+  return 'disabled';
 }
 
 export type EmbeddedTerminalBackendConfig = 'bash' | 'pty';

--- a/packages/app/src/execution-capacity.ts
+++ b/packages/app/src/execution-capacity.ts
@@ -1,10 +1,69 @@
 const DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY = 6;
 export const DEFAULT_WORKTREE_MAX_CONCURRENCY = DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY;
 
+type ExecutionPoolMember =
+  | { type: 'ssh'; id: string; maxConcurrentTasks?: number }
+  | { type: 'worktree'; id: string; maxConcurrentTasks?: number };
+
+type ExecutionPoolConfig = {
+  members?: ExecutionPoolMember[];
+  maxConcurrentTasksPerMember?: number;
+};
+
+export type ExecutionCapacityConfig = {
+  maxConcurrency?: number;
+  executionPools?: Record<string, ExecutionPoolConfig>;
+};
+
 export function resolveEffectiveMaxConcurrency(
   configuredMaxConcurrency: number | undefined,
 ): number {
   return Number.isInteger(configuredMaxConcurrency) && Number(configuredMaxConcurrency) > 0
     ? Number(configuredMaxConcurrency)
     : DEFAULT_ORCHESTRATOR_MAX_CONCURRENCY;
+}
+
+function positiveIntegerOrUndefined(value: unknown): number | undefined {
+  return Number.isInteger(value) && Number(value) > 0 ? Number(value) : undefined;
+}
+
+export function computeConfiguredExecutionCapacity(config: ExecutionCapacityConfig): number {
+  const pools = config.executionPools ?? {};
+  const poolEntries = Object.values(pools);
+  if (poolEntries.length === 0) {
+    return resolveEffectiveMaxConcurrency(config.maxConcurrency);
+  }
+
+  const capacityByResource = new Map<string, number>();
+  for (const pool of poolEntries) {
+    for (const member of pool.members ?? []) {
+      const resourceKey = `${member.type}:${member.id}`;
+      const capacity = member.type === 'ssh'
+        ? positiveIntegerOrUndefined(member.maxConcurrentTasks)
+          ?? positiveIntegerOrUndefined(pool.maxConcurrentTasksPerMember)
+          ?? 1
+        : positiveIntegerOrUndefined(member.maxConcurrentTasks) ?? 1;
+      capacityByResource.set(resourceKey, Math.max(capacityByResource.get(resourceKey) ?? 0, capacity));
+    }
+  }
+
+  return [...capacityByResource.values()].reduce((sum, capacity) => sum + capacity, 0);
+}
+
+export function shouldFatalOnExecutionCapacityOvercommit(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.INVOKER_FATAL_ON_EXECUTION_CAPACITY_OVERCOMMIT === '1';
+}
+
+export function assertExecutionCapacityInvariant(input: {
+  config: ExecutionCapacityConfig;
+  activeExecutions: number;
+  label?: string;
+}): void {
+  const capacity = computeConfiguredExecutionCapacity(input.config);
+  if (input.activeExecutions <= capacity) return;
+  throw new Error(
+    `FATAL: Invoker execution capacity invariant violated` +
+    `${input.label ? ` (${input.label})` : ''}: ` +
+    `active/launching executions=${input.activeExecutions}, configured capacity=${capacity}`,
+  );
 }

--- a/packages/app/src/headless-batch-exec.ts
+++ b/packages/app/src/headless-batch-exec.ts
@@ -1,0 +1,111 @@
+import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
+
+export interface HeadlessExecMutationPayload {
+  args: string[];
+  waitForApproval?: boolean;
+  noTrack?: boolean;
+  traceId?: string;
+}
+
+export interface HeadlessBatchExecItem {
+  label?: string;
+  workflowId?: string;
+  args?: unknown;
+}
+
+export interface HeadlessBatchExecRequest {
+  items?: unknown;
+  waitForApproval?: boolean;
+  noTrack?: boolean;
+  traceId?: string;
+}
+
+export interface HeadlessBatchExecResult {
+  label?: string;
+  workflowId?: string;
+  args: string[];
+  ok: boolean;
+  response?: { ok: true; intentId: number };
+  error?: string;
+}
+
+export type HeadlessExecClassification = {
+  workflowId?: string;
+  priority: WorkflowMutationPriority;
+};
+
+export type HeadlessBatchExecDeps = {
+  classify: (payload: HeadlessExecMutationPayload) => HeadlessExecClassification;
+  submit: (
+    workflowId: string,
+    priority: WorkflowMutationPriority,
+    channel: 'headless.exec',
+    args: [HeadlessExecMutationPayload],
+    options: { deferDrain: true },
+  ) => number;
+};
+
+function resultBase(item: HeadlessBatchExecItem): Pick<HeadlessBatchExecResult, 'label' | 'workflowId' | 'args'> {
+  return {
+    label: typeof item.label === 'string' ? item.label : undefined,
+    workflowId: typeof item.workflowId === 'string' ? item.workflowId : undefined,
+    args: Array.isArray(item.args) && item.args.every((arg) => typeof arg === 'string') ? item.args : [],
+  };
+}
+
+function isRetryableQueueError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /database is locked|SQLITE_BUSY/i.test(message);
+}
+
+export function executeNoTrackHeadlessBatch(
+  request: HeadlessBatchExecRequest,
+  deps: HeadlessBatchExecDeps,
+): HeadlessBatchExecResult[] {
+  if (!request.noTrack) {
+    throw new Error('headless.batch-exec only supports noTrack=true');
+  }
+  if (!Array.isArray(request.items)) {
+    throw new Error('headless.batch-exec requires an items array');
+  }
+
+  return request.items.map((rawItem): HeadlessBatchExecResult => {
+    const item = rawItem && typeof rawItem === 'object' ? rawItem as HeadlessBatchExecItem : {};
+    const base = resultBase(item);
+    try {
+      if (!Array.isArray(item.args) || !item.args.every((arg) => typeof arg === 'string')) {
+        throw new Error('Invalid batch item: args must be a string array');
+      }
+      if (item.args.length === 0) {
+        throw new Error('Invalid batch item: args must not be empty');
+      }
+
+      const payload: HeadlessExecMutationPayload = {
+        args: item.args,
+        waitForApproval: request.waitForApproval,
+        noTrack: true,
+        traceId: request.traceId,
+      };
+      const { workflowId, priority } = deps.classify(payload);
+      if (!workflowId) {
+        throw new Error('Fire-and-forget headless.exec could not be queued: workflow-not-resolved');
+      }
+      const intentId = deps.submit(workflowId, priority, 'headless.exec', [payload], { deferDrain: true });
+      return {
+        ...base,
+        workflowId,
+        ok: true,
+        response: { ok: true, intentId },
+      };
+    } catch (error) {
+      if (isRetryableQueueError(error)) {
+        throw error;
+      }
+      return {
+        ...base,
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  });
+}

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -1,0 +1,87 @@
+/**
+ * Phase A observer for the launch-handoff outbox.
+ *
+ * In observer mode the dispatcher does not own dispatch. It only reads
+ * `task_launch_dispatch` rows and logs an aggregate count by state so we
+ * have production data on outbox build-up before the active dispatcher
+ * (CB.5) takes over.
+ *
+ * See:
+ * - `docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md`
+ *   (the architecture target)
+ * - `docs/incidents/2026-05-22-launch-handoff-orphan-architecture.md`
+ *   (the investigation that motivated the rewrite)
+ */
+
+import type { SQLiteAdapter, TaskLaunchDispatch, TaskLaunchDispatchState } from '@invoker/data-store';
+import type { Logger } from '@invoker/contracts';
+
+export type LaunchDispatcherMode = 'observe' | 'active';
+
+export interface LaunchDispatcherOptions {
+  persistence: Pick<SQLiteAdapter, 'listLaunchDispatchesByState'>;
+  ownerId: string;
+  logger?: Logger;
+  mode: LaunchDispatcherMode;
+}
+
+const OBSERVED_STATES: readonly TaskLaunchDispatchState[] = [
+  'enqueued',
+  'leased',
+  'acknowledged',
+];
+
+export class LaunchDispatcher {
+  private readonly persistence: LaunchDispatcherOptions['persistence'];
+  private readonly ownerId: string;
+  private readonly logger?: Logger;
+  private readonly mode: LaunchDispatcherMode;
+
+  constructor(options: LaunchDispatcherOptions) {
+    this.persistence = options.persistence;
+    this.ownerId = options.ownerId;
+    this.logger = options.logger;
+    this.mode = options.mode;
+  }
+
+  getMode(): LaunchDispatcherMode {
+    return this.mode;
+  }
+
+  /**
+   * In observe mode, list non-terminal rows and log aggregate counts.
+   * In active mode, dispatch real work — Phase B (CB.5) provides the
+   * implementation; today this throws so the placeholder is visible.
+   */
+  poll(): void {
+    if (this.mode === 'observe') {
+      const rows = this.persistence.listLaunchDispatchesByState(OBSERVED_STATES);
+      const counts = countByState(rows);
+      this.logger?.info?.('[launch-dispatcher] observed', {
+        ownerId: this.ownerId,
+        mode: this.mode,
+        counts,
+        total: rows.length,
+        module: 'launch-dispatcher',
+      });
+      return;
+    }
+    throw new Error('CB.5 not implemented');
+  }
+}
+
+function countByState(
+  rows: readonly TaskLaunchDispatch[],
+): Record<TaskLaunchDispatchState, number> {
+  const counts: Record<TaskLaunchDispatchState, number> = {
+    enqueued: 0,
+    leased: 0,
+    acknowledged: 0,
+    completed: 0,
+    abandoned: 0,
+  };
+  for (const row of rows) {
+    counts[row.state] += 1;
+  }
+  return counts;
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -160,6 +160,7 @@ import {
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
+import { LaunchDispatcher, type LaunchDispatcherMode } from './launch-dispatcher.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
 import {
   dispatchStartedTasksWithGlobalTopup,
@@ -241,6 +242,7 @@ let orchestrator: Orchestrator;
 let commandService: CommandService;
 let runtimeServices: RuntimeServices;
 let workflowMutationCoordinator: PersistedWorkflowMutationCoordinator | null = null;
+let launchDispatcher: LaunchDispatcher | null = null;
 const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
 /**
  * The mutation context for the currently executing workflow mutation.
@@ -2694,6 +2696,16 @@ function createEmbeddedTerminalBackendFromConfig(
                 }
               }
             }
+            if (launchDispatcher) {
+              try {
+                launchDispatcher.poll();
+              } catch (err) {
+                logger.warn(
+                  `[launch-dispatcher] poll() failed: ${err instanceof Error ? err.message : String(err)}`,
+                  { module: 'db-poll' },
+                );
+              }
+            }
           } catch {
             // DB might be locked — skip this tick
           }
@@ -2754,6 +2766,14 @@ function createEmbeddedTerminalBackendFromConfig(
         },
         { logger },
       );
+      if (invokerConfig.launchOutboxMode && invokerConfig.launchOutboxMode !== 'disabled') {
+        launchDispatcher = new LaunchDispatcher({
+          persistence,
+          ownerId: workflowMutationOwnerId,
+          logger,
+          mode: invokerConfig.launchOutboxMode as LaunchDispatcherMode,
+        });
+      }
     } else {
       logger.info('Launched in follower mode; mutation execution is delegated to the current owner', {
         module: 'init',

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -178,6 +178,11 @@ import {
 } from './action-graph-diagnostics.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
+import {
+  executeNoTrackHeadlessBatch,
+  type HeadlessBatchExecRequest,
+  type HeadlessExecMutationPayload,
+} from './headless-batch-exec.js';
 
 function isTaskInFlightForForcedStop(task: TaskState): boolean {
   return task.status === 'running'
@@ -259,13 +264,6 @@ interface HeadlessRunMutationPayload {
 
 interface HeadlessResumeMutationPayload {
   workflowId: string;
-  traceId?: string;
-}
-
-interface HeadlessExecMutationPayload {
-  args: string[];
-  waitForApproval?: boolean;
-  noTrack?: boolean;
   traceId?: string;
 }
 
@@ -2821,6 +2819,26 @@ function createEmbeddedTerminalBackendFromConfig(
         const acknowledgement = acknowledgeNoTrackHeadlessExec(payload, workflowId, priority, 'gui');
         if (acknowledgement) return acknowledgement;
         return runWorkflowMutation(workflowId, priority, 'headless.exec', [payload], async () => executeHeadlessExec(payload));
+      });
+      messageBus.onRequest('headless.batch-exec', async (req: unknown) => {
+        const request = req as HeadlessBatchExecRequest;
+        const itemCount = Array.isArray(request.items) ? request.items.length : 0;
+        logger.info(`headless.batch-exec received items=${itemCount} noTrack=${request.noTrack ? 'true' : 'false'} mode=gui`, {
+          module: 'ipc-delegate',
+        });
+        if (!workflowMutationCoordinator) {
+          throw new Error('Workflow mutation coordinator is unavailable');
+        }
+        const results = executeNoTrackHeadlessBatch(request, {
+          classify: classifyHeadlessExecMutation,
+          submit: (workflowId, priority, channel, args, options) =>
+            workflowMutationCoordinator.submit(workflowId, priority, channel, args, options),
+        });
+        const accepted = results.filter((result) => result.ok).length;
+        logger.info(`headless.batch-exec accepted=${accepted} failed=${results.length - accepted} mode=gui`, {
+          module: 'ipc-delegate',
+        });
+        return results;
       });
       logger.info(`owner-ipc-ready ownerId=${workflowMutationOwnerId}`, { module: 'ipc-delegate' });
       recordStartupMark('owner-ipc-ready');

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -94,7 +94,9 @@ import {
 } from './config.js';
 import {
   DEFAULT_WORKTREE_MAX_CONCURRENCY,
+  assertExecutionCapacityInvariant,
   resolveEffectiveMaxConcurrency,
+  shouldFatalOnExecutionCapacityOvercommit,
 } from './execution-capacity.js';
 import {
   createHourlySnapshot,
@@ -1640,6 +1642,23 @@ function createEmbeddedTerminalBackendFromConfig(
     return Number.isNaN(parsed.getTime()) ? undefined : parsed;
   };
 
+  function assertFatalExecutionCapacity(label: string): void {
+    if (!shouldFatalOnExecutionCapacityOvercommit()) return;
+    try {
+      assertExecutionCapacityInvariant({
+        config: loadConfig(),
+        activeExecutions: launchingTasks.size + taskHandles.size,
+        label,
+      });
+    } catch (err) {
+      logger.error(err instanceof Error ? err.stack ?? err.message : String(err), { module: 'exec' });
+      setImmediate(() => {
+        throw err;
+      });
+      throw err;
+    }
+  }
+
   // Focus existing window when a second instance is launched
   app.on('second-instance', () => {
     if (mainWindow) {
@@ -1689,14 +1708,17 @@ function createEmbeddedTerminalBackendFromConfig(
         },
         onLaunchAccepted: (taskId) => {
           launchingTasks.add(taskId);
+          assertFatalExecutionCapacity(`launch accepted ${taskId}`);
           logger.info(`Task "${taskId}" launch accepted by TaskRunner`, { module: 'exec' });
         },
         onLaunchStart: (taskId, executor) => {
           launchingTasks.add(taskId);
+          assertFatalExecutionCapacity(`launch start ${taskId}`);
           logger.info(`Task "${taskId}" launch started (executor: ${executor.type})`, { module: 'exec' });
         },
         onLaunchFailed: (taskId, error, executor) => {
           launchingTasks.delete(taskId);
+          assertFatalExecutionCapacity(`launch failed ${taskId}`);
           logger.error(
             `Task "${taskId}" launch failed before spawn (executor: ${executor.type}): ${error.message}`,
             { module: 'exec' },
@@ -1710,11 +1732,13 @@ function createEmbeddedTerminalBackendFromConfig(
             { module: 'exec' },
           );
           taskHandles.set(taskId, { handle, executor });
+          assertFatalExecutionCapacity(`spawned ${taskId}`);
         },
         onComplete: (taskId, response) => {
           flushTaskOutput(taskId);
           launchingTasks.delete(taskId);
           taskHandles.delete(taskId);
+          assertFatalExecutionCapacity(`complete ${taskId}`);
           logger.info(
             `Task "${taskId}" completion callback received (status: ${response.status}, generation: ${response.executionGeneration}, exitCode: ${response.outputs.exitCode ?? 'none'})`,
             { module: 'exec' },
@@ -1742,6 +1766,7 @@ function createEmbeddedTerminalBackendFromConfig(
         },
         onLaunchSettled: (taskId) => {
           launchingTasks.delete(taskId);
+          assertFatalExecutionCapacity(`launch settled ${taskId}`);
         },
       },
     });
@@ -2829,10 +2854,11 @@ function createEmbeddedTerminalBackendFromConfig(
         if (!workflowMutationCoordinator) {
           throw new Error('Workflow mutation coordinator is unavailable');
         }
+        const coordinator = workflowMutationCoordinator;
         const results = executeNoTrackHeadlessBatch(request, {
           classify: classifyHeadlessExecMutation,
           submit: (workflowId, priority, channel, args, options) =>
-            workflowMutationCoordinator.submit(workflowId, priority, channel, args, options),
+            coordinator.submit(workflowId, priority, channel, args, options),
         });
         const accepted = results.filter((result) => result.ok).length;
         logger.info(`headless.batch-exec accepted=${accepted} failed=${results.length - accepted} mode=gui`, {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -500,6 +500,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     defaultPoolId: invokerConfig.defaultPoolId,
     availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
     deferRunningUntilLaunch: true,
+    launchOutboxMode: invokerConfig.launchOutboxMode,
   });
   commandService = new CommandService(orchestrator);
 
@@ -3090,6 +3091,7 @@ function createEmbeddedTerminalBackendFromConfig(
         defaultPoolId: invokerConfig.defaultPoolId,
         availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
         deferRunningUntilLaunch: true,
+        launchOutboxMode: invokerConfig.launchOutboxMode,
       });
       commandService = new CommandService(orchestrator);
       rebuildTaskRunner();

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -7,3 +7,4 @@ export * from './command-envelope.js';
 export * from './ipc-channels.js';
 export * from './repo-root.js';
 export * from './cost-types.js';
+export * from './launch-timeouts.js';

--- a/packages/contracts/src/launch-timeouts.ts
+++ b/packages/contracts/src/launch-timeouts.ts
@@ -1,0 +1,17 @@
+/**
+ * Single source of truth for launch-handoff timeout constants.
+ *
+ * `ATTEMPT_LEASE_MS` was previously duplicated in `@invoker/workflow-core`
+ * and `@invoker/execution-engine`; both packages import it from here.
+ *
+ * `DISPATCH_LEASE_MS` and `DISPATCH_MAX_ATTEMPTS` describe the durable
+ * launch-outbox lease lifecycle introduced in the Phase A
+ * launch-handoff re-architecture (see
+ * `docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md`).
+ */
+
+export const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
+
+export const DISPATCH_LEASE_MS = 30_000;
+
+export const DISPATCH_MAX_ATTEMPTS = 3;

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -229,6 +229,212 @@ describe('SQLiteAdapter', () => {
     });
   });
 
+  describe('task_launch_dispatch outbox', () => {
+    function setupWorkflowAndTask(workflowId = 'wf-launch', taskId = 'wf-launch/t1'): void {
+      adapter.saveWorkflow({ ...testWorkflow, id: workflowId });
+      adapter.saveTask(workflowId, makeTask(taskId, { config: { workflowId } }));
+    }
+
+    it('round-trips enqueueLaunchDispatch + load by id and attempt', () => {
+      setupWorkflowAndTask();
+      const inserted = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-1',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+
+      expect(inserted.id).toBeGreaterThan(0);
+      expect(inserted.state).toBe('enqueued');
+      expect(inserted.priority).toBe('normal');
+      expect(inserted.attemptsCount).toBe(0);
+
+      const byId = adapter.loadLaunchDispatchById(inserted.id);
+      expect(byId).toMatchObject({
+        id: inserted.id,
+        attemptId: 'attempt-1',
+        taskId: 'wf-launch/t1',
+        workflowId: 'wf-launch',
+        state: 'enqueued',
+      });
+
+      const byAttempt = adapter.loadLaunchDispatchByAttempt('attempt-1');
+      expect(byAttempt?.id).toBe(inserted.id);
+    });
+
+    it('returns existing row instead of creating a duplicate active dispatch for the same attempt', () => {
+      setupWorkflowAndTask();
+      const first = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-dup',
+        workflowId: 'wf-launch',
+        priority: 'high',
+        generation: 0,
+      });
+      const second = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-dup',
+        workflowId: 'wf-launch',
+        priority: 'low',
+        generation: 0,
+      });
+
+      expect(second.id).toBe(first.id);
+      expect(second.priority).toBe('high');
+      expect(
+        adapter.listLaunchDispatchesByState(['enqueued', 'leased', 'acknowledged']),
+      ).toHaveLength(1);
+    });
+
+    it('filters listLaunchDispatchesByState by the requested states', () => {
+      setupWorkflowAndTask();
+      const a = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-a',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      const b = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-b',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-c',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      adapter.markLaunchDispatchCompleted(a.id);
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'leased', fenced_until = datetime('now', '+30 seconds') WHERE id = ?`,
+        [b.id],
+      );
+
+      const enqueuedOnly = adapter
+        .listLaunchDispatchesByState(['enqueued'])
+        .map((row) => row.attemptId);
+      expect(enqueuedOnly).toEqual(['attempt-c']);
+      const leasedOnly = adapter
+        .listLaunchDispatchesByState(['leased'])
+        .map((row) => row.attemptId);
+      expect(leasedOnly).toEqual(['attempt-b']);
+      const completedOnly = adapter
+        .listLaunchDispatchesByState(['completed'])
+        .map((row) => row.attemptId);
+      expect(completedOnly).toEqual(['attempt-a']);
+    });
+
+    it('markLaunchDispatchAcknowledged only succeeds for leased rows', () => {
+      setupWorkflowAndTask();
+      const row = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-ack',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+
+      expect(adapter.markLaunchDispatchAcknowledged(row.id, 'runner-1')).toBe(false);
+
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'leased', fenced_until = datetime('now', '+30 seconds') WHERE id = ?`,
+        [row.id],
+      );
+
+      expect(adapter.markLaunchDispatchAcknowledged(row.id, 'runner-1')).toBe(true);
+      const after = adapter.loadLaunchDispatchById(row.id);
+      expect(after?.state).toBe('acknowledged');
+      expect(after?.dispatchOwner).toBe('runner-1');
+      expect(after?.acknowledgedAt).toBeDefined();
+      expect(after?.fencedUntil).toBeDefined();
+
+      expect(adapter.markLaunchDispatchAcknowledged(row.id, 'runner-1')).toBe(false);
+    });
+
+    it('markLaunchDispatchCompleted transitions to completed and rejects already-terminal rows', () => {
+      setupWorkflowAndTask();
+      const row = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-complete',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+
+      expect(adapter.markLaunchDispatchCompleted(row.id)).toBe(true);
+      const after = adapter.loadLaunchDispatchById(row.id);
+      expect(after?.state).toBe('completed');
+      expect(after?.completedAt).toBeDefined();
+
+      expect(adapter.markLaunchDispatchCompleted(row.id)).toBe(false);
+    });
+
+    it('markLaunchDispatchFailed re-enqueues the row and clears the owner / fence', () => {
+      setupWorkflowAndTask();
+      const row = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-failed',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'leased', dispatch_owner = 'runner-x', fenced_until = datetime('now', '+30 seconds') WHERE id = ?`,
+        [row.id],
+      );
+
+      expect(adapter.markLaunchDispatchFailed(row.id, 'boom')).toBe(true);
+      const after = adapter.loadLaunchDispatchById(row.id);
+      expect(after?.state).toBe('enqueued');
+      expect(after?.lastError).toBe('boom');
+      expect(after?.dispatchOwner).toBeUndefined();
+      expect(after?.fencedUntil).toBeUndefined();
+
+      adapter.markLaunchDispatchCompleted(row.id);
+      expect(adapter.markLaunchDispatchFailed(row.id, 'too late')).toBe(false);
+    });
+
+    it('reapExpiredLaunchDispatchLeases resets leased rows whose fence has passed', () => {
+      setupWorkflowAndTask();
+      const expired = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-expired',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      const live = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-live',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      const now = new Date();
+      const pastIso = new Date(now.getTime() - 60_000).toISOString();
+      const futureIso = new Date(now.getTime() + 60_000).toISOString();
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'leased', dispatch_owner = 'runner-x', fenced_until = ? WHERE id = ?`,
+        [pastIso, expired.id],
+      );
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'leased', dispatch_owner = 'runner-y', fenced_until = ? WHERE id = ?`,
+        [futureIso, live.id],
+      );
+
+      const reaped = adapter.reapExpiredLaunchDispatchLeases(now.toISOString());
+      expect(reaped.map((row) => row.attemptId)).toEqual(['attempt-expired']);
+      const expiredAfter = adapter.loadLaunchDispatchById(expired.id);
+      expect(expiredAfter?.state).toBe('enqueued');
+      expect(expiredAfter?.dispatchOwner).toBeUndefined();
+      const liveAfter = adapter.loadLaunchDispatchById(live.id);
+      expect(liveAfter?.state).toBe('leased');
+    });
+
+    it('claimLaunchDispatchAtomic is a CB.1 placeholder that throws', () => {
+      expect(() =>
+        adapter.claimLaunchDispatchAtomic({ ownerId: 'runner-x', maxConcurrency: 1 }),
+      ).toThrow('CB.1 not implemented');
+    });
+  });
+
   describe('updateTask', () => {
     it('persists partial changes', () => {
       adapter.saveWorkflow(testWorkflow);

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -226,6 +226,33 @@ export interface WorkflowMutationLease {
   leaseExpiresAt: string;
 }
 
+export type TaskLaunchDispatchState =
+  | 'enqueued'
+  | 'leased'
+  | 'acknowledged'
+  | 'completed'
+  | 'abandoned';
+
+export type TaskLaunchDispatchPriority = 'high' | 'normal' | 'low';
+
+export interface TaskLaunchDispatch {
+  id: number;
+  taskId: string;
+  attemptId: string;
+  workflowId: string;
+  state: TaskLaunchDispatchState;
+  priority: TaskLaunchDispatchPriority;
+  dispatchOwner?: string;
+  enqueuedAt: string;
+  leasedAt?: string;
+  acknowledgedAt?: string;
+  completedAt?: string;
+  fencedUntil?: string;
+  attemptsCount: number;
+  lastError?: string;
+  generation: number;
+}
+
 export class SQLiteAdapter implements PersistenceAdapter {
   private db: NativeDatabaseCompat;
   private nativeDb: DatabaseSync;
@@ -2843,6 +2870,191 @@ export class SQLiteAdapter implements PersistenceAdapter {
       leaseExpiresAt: String(row.lease_expires_at),
       metadata: row.metadata_json ? JSON.parse(String(row.metadata_json)) : undefined,
     }));
+  }
+
+  enqueueLaunchDispatch(input: {
+    taskId: string;
+    attemptId: string;
+    workflowId: string;
+    priority?: TaskLaunchDispatchPriority;
+    generation: number;
+  }): TaskLaunchDispatch {
+    const priority: TaskLaunchDispatchPriority = input.priority ?? 'normal';
+    return this.runTransaction(() => {
+      const existing = this.queryOne(
+        `SELECT * FROM task_launch_dispatch
+           WHERE attempt_id = ?
+             AND state IN ('enqueued', 'leased', 'acknowledged')
+           LIMIT 1`,
+        [input.attemptId],
+      );
+      if (existing) {
+        return this.rowToTaskLaunchDispatch(existing);
+      }
+      this.execRun(
+        `INSERT INTO task_launch_dispatch (
+          task_id, attempt_id, workflow_id, state, priority, generation
+        ) VALUES (?, ?, ?, 'enqueued', ?, ?)`,
+        [input.taskId, input.attemptId, input.workflowId, priority, input.generation],
+      );
+      const inserted = this.queryOne(
+        `SELECT * FROM task_launch_dispatch
+           WHERE attempt_id = ?
+             AND state IN ('enqueued', 'leased', 'acknowledged')
+           LIMIT 1`,
+        [input.attemptId],
+      );
+      if (!inserted) {
+        throw new Error('Failed to read back inserted task_launch_dispatch row');
+      }
+      return this.rowToTaskLaunchDispatch(inserted);
+    });
+  }
+
+  loadLaunchDispatchById(id: number): TaskLaunchDispatch | undefined {
+    const row = this.queryOne(
+      'SELECT * FROM task_launch_dispatch WHERE id = ?',
+      [id],
+    );
+    return row ? this.rowToTaskLaunchDispatch(row) : undefined;
+  }
+
+  loadLaunchDispatchByAttempt(attemptId: string): TaskLaunchDispatch | undefined {
+    const row = this.queryOne(
+      `SELECT * FROM task_launch_dispatch
+         WHERE attempt_id = ?
+           AND state IN ('enqueued', 'leased', 'acknowledged')
+         ORDER BY id DESC
+         LIMIT 1`,
+      [attemptId],
+    );
+    return row ? this.rowToTaskLaunchDispatch(row) : undefined;
+  }
+
+  listLaunchDispatchesByState(
+    states: readonly TaskLaunchDispatchState[],
+  ): TaskLaunchDispatch[] {
+    if (states.length === 0) return [];
+    const placeholders = states.map(() => '?').join(', ');
+    const rows = this.queryAll(
+      `SELECT * FROM task_launch_dispatch
+         WHERE state IN (${placeholders})
+         ORDER BY id ASC`,
+      states as unknown as unknown[],
+    );
+    return rows.map((row) => this.rowToTaskLaunchDispatch(row));
+  }
+
+  claimLaunchDispatchAtomic(_options: {
+    ownerId: string;
+    maxConcurrency: number;
+    nowIso?: string;
+  }): TaskLaunchDispatch | undefined {
+    throw new Error('CB.1 not implemented');
+  }
+
+  markLaunchDispatchAcknowledged(
+    id: number,
+    runnerId: string,
+    nowIso?: string,
+  ): boolean {
+    const now = nowIso ?? new Date().toISOString();
+    const fencedUntil = new Date(
+      new Date(now).getTime() + 30_000,
+    ).toISOString();
+    this.execRun(
+      `UPDATE task_launch_dispatch
+         SET state = 'acknowledged',
+             acknowledged_at = ?,
+             dispatch_owner = ?,
+             fenced_until = ?
+       WHERE id = ?
+         AND state = 'leased'`,
+      [now, runnerId, fencedUntil, id],
+    );
+    return (this.db.getRowsModified?.() ?? 0) > 0;
+  }
+
+  markLaunchDispatchCompleted(id: number, nowIso?: string): boolean {
+    const now = nowIso ?? new Date().toISOString();
+    this.execRun(
+      `UPDATE task_launch_dispatch
+         SET state = 'completed',
+             completed_at = ?
+       WHERE id = ?
+         AND state NOT IN ('completed', 'abandoned')`,
+      [now, id],
+    );
+    return (this.db.getRowsModified?.() ?? 0) > 0;
+  }
+
+  markLaunchDispatchFailed(
+    id: number,
+    errorMessage: string,
+    _nowIso?: string,
+  ): boolean {
+    this.execRun(
+      `UPDATE task_launch_dispatch
+         SET state = 'enqueued',
+             last_error = ?,
+             dispatch_owner = NULL,
+             fenced_until = NULL
+       WHERE id = ?
+         AND state NOT IN ('completed', 'abandoned')`,
+      [errorMessage, id],
+    );
+    return (this.db.getRowsModified?.() ?? 0) > 0;
+  }
+
+  reapExpiredLaunchDispatchLeases(nowIso?: string): TaskLaunchDispatch[] {
+    const now = nowIso ?? new Date().toISOString();
+    return this.runTransaction(() => {
+      const expired = this.queryAll(
+        `SELECT * FROM task_launch_dispatch
+           WHERE state = 'leased'
+             AND fenced_until IS NOT NULL
+             AND fenced_until < ?`,
+        [now],
+      );
+      if (expired.length === 0) return [];
+      this.execRun(
+        `UPDATE task_launch_dispatch
+           SET state = 'enqueued',
+               dispatch_owner = NULL,
+               fenced_until = NULL
+         WHERE state = 'leased'
+           AND fenced_until IS NOT NULL
+           AND fenced_until < ?`,
+        [now],
+      );
+      return expired.map((row) => {
+        const reset = { ...row, state: 'enqueued', dispatch_owner: null, fenced_until: null };
+        return this.rowToTaskLaunchDispatch(reset);
+      });
+    });
+  }
+
+  private rowToTaskLaunchDispatch(row: Record<string, unknown>): TaskLaunchDispatch {
+    const priorityRaw = String(row.priority ?? 'normal');
+    const priority: TaskLaunchDispatchPriority =
+      priorityRaw === 'high' || priorityRaw === 'low' ? priorityRaw : 'normal';
+    return {
+      id: Number(row.id),
+      taskId: String(row.task_id),
+      attemptId: String(row.attempt_id),
+      workflowId: String(row.workflow_id),
+      state: String(row.state ?? 'enqueued') as TaskLaunchDispatchState,
+      priority,
+      dispatchOwner: row.dispatch_owner ? String(row.dispatch_owner) : undefined,
+      enqueuedAt: String(row.enqueued_at),
+      leasedAt: row.leased_at ? String(row.leased_at) : undefined,
+      acknowledgedAt: row.acknowledged_at ? String(row.acknowledged_at) : undefined,
+      completedAt: row.completed_at ? String(row.completed_at) : undefined,
+      fencedUntil: row.fenced_until ? String(row.fenced_until) : undefined,
+      attemptsCount: Number(row.attempts_count ?? 0),
+      lastError: row.last_error ? String(row.last_error) : undefined,
+      generation: Number(row.generation ?? 0),
+    };
   }
 
   listWorkflowMutationLeases(): WorkflowMutationLease[] {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -755,6 +755,37 @@ export class SQLiteAdapter implements PersistenceAdapter {
       CREATE INDEX IF NOT EXISTS idx_workflow_mutation_leases_expiry
         ON workflow_mutation_leases(lease_expires_at);
 
+      CREATE TABLE IF NOT EXISTS task_launch_dispatch (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        task_id TEXT NOT NULL,
+        attempt_id TEXT NOT NULL,
+        workflow_id TEXT NOT NULL,
+        state TEXT NOT NULL DEFAULT 'enqueued',
+        priority TEXT NOT NULL DEFAULT 'normal',
+        dispatch_owner TEXT,
+        enqueued_at TEXT NOT NULL DEFAULT (datetime('now')),
+        leased_at TEXT,
+        acknowledged_at TEXT,
+        completed_at TEXT,
+        fenced_until TEXT,
+        attempts_count INTEGER NOT NULL DEFAULT 0,
+        last_error TEXT,
+        generation INTEGER NOT NULL,
+        FOREIGN KEY (task_id) REFERENCES tasks(id),
+        FOREIGN KEY (workflow_id) REFERENCES workflows(id)
+      );
+
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_task_launch_dispatch_active_attempt
+        ON task_launch_dispatch(attempt_id)
+        WHERE state IN ('enqueued', 'leased', 'acknowledged');
+
+      CREATE INDEX IF NOT EXISTS idx_task_launch_dispatch_ready
+        ON task_launch_dispatch(state, priority, id)
+        WHERE state IN ('enqueued', 'leased');
+
+      CREATE INDEX IF NOT EXISTS idx_task_launch_dispatch_workflow_state
+        ON task_launch_dispatch(workflow_id, state);
+
       CREATE TABLE IF NOT EXISTS execution_resource_leases (
         resource_key TEXT NOT NULL,
         resource_type TEXT NOT NULL,

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -479,6 +479,7 @@ export class TaskRunner {
         `phase=${task.execution.phase ?? 'none'} generation=${startGeneration}`,
     );
     this.launchingAttemptIds.add(attemptId);
+    this.callbacks.onLaunchAccepted?.(task.id);
     try {
       await this.executeTaskInner(task, attemptId, bench);
       bench('executeTask.innerReturned');

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -15,6 +15,7 @@ import { scopePlanTaskId } from '@invoker/workflow-core';
 import type { Orchestrator, TaskState, ExperimentVariant, RunnerKind } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { WorkRequest, WorkResponse, ActionType, Logger } from '@invoker/contracts';
+import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import type { Executor, ExecutorHandle } from './executor.js';
 import type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 import { BaseExecutor } from './base-executor.js';
@@ -63,7 +64,6 @@ export type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
 
 /** Keeps `lastHeartbeatAt` fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). Matches BaseExecutor default heartbeat cadence. */
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
-const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
 const DEFAULT_EXECUTOR_START_TIMEOUT_MS = 10 * 60 * 1000;
 
 type StartupFailureMetadata = {

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -9,10 +9,29 @@ import type {
 import type { TaskState, TaskStateChanges } from '../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
 
+interface LoggedEvent {
+  taskId: string;
+  eventType: string;
+  payload?: unknown;
+}
+
+interface LaunchDispatchRow {
+  id: number;
+  taskId: string;
+  attemptId: string;
+  workflowId: string;
+  priority: 'high' | 'normal' | 'low';
+  generation: number;
+}
+
 class InMemoryPersistence implements OrchestratorPersistence {
   workflows = new Map<string, { id: string; name: string; status: string; createdAt: string; updatedAt: string }>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
+  events: LoggedEvent[] = [];
+  launchDispatchRows: LaunchDispatchRow[] = [];
+  enqueueLaunchDispatchEnabled = false;
   private attempts = new Map<string, Attempt[]>();
+  private nextDispatchId = 1;
 
   saveWorkflow(workflow: { id: string; name: string; status: string }): void {
     const now = new Date().toISOString();
@@ -78,7 +97,33 @@ class InMemoryPersistence implements OrchestratorPersistence {
     }
   }
 
-  logEvent(): void {}
+  logEvent(taskId: string, eventType: string, payload?: unknown): void {
+    this.events.push({ taskId, eventType, payload });
+  }
+
+  enqueueLaunchDispatch(input: {
+    taskId: string;
+    attemptId: string;
+    workflowId: string;
+    priority?: 'high' | 'normal' | 'low';
+    generation: number;
+  }): { id: number } {
+    if (!this.enqueueLaunchDispatchEnabled) {
+      throw new Error('enqueueLaunchDispatch called when not enabled');
+    }
+    const existing = this.launchDispatchRows.find((row) => row.attemptId === input.attemptId);
+    if (existing) return { id: existing.id };
+    const row: LaunchDispatchRow = {
+      id: this.nextDispatchId++,
+      taskId: input.taskId,
+      attemptId: input.attemptId,
+      workflowId: input.workflowId,
+      priority: input.priority ?? 'normal',
+      generation: input.generation,
+    };
+    this.launchDispatchRows.push(row);
+    return { id: row.id };
+  }
 }
 
 class InMemoryBus implements OrchestratorMessageBus {
@@ -104,14 +149,21 @@ function makeResponse(
 }
 
 function makeOrchestrator(
-  opts: { deferRunningUntilLaunch?: boolean; maxConcurrency?: number } = {},
+  opts: {
+    deferRunningUntilLaunch?: boolean;
+    maxConcurrency?: number;
+    launchOutboxMode?: 'disabled' | 'observe' | 'active';
+    enqueueLaunchDispatchEnabled?: boolean;
+  } = {},
 ): { orchestrator: Orchestrator; persistence: InMemoryPersistence } {
   const persistence = new InMemoryPersistence();
+  persistence.enqueueLaunchDispatchEnabled = opts.enqueueLaunchDispatchEnabled ?? false;
   const orchestrator = new Orchestrator({
     persistence,
     messageBus: new InMemoryBus(),
     maxConcurrency: opts.maxConcurrency ?? 4,
     deferRunningUntilLaunch: opts.deferRunningUntilLaunch,
+    launchOutboxMode: opts.launchOutboxMode,
   });
   return { orchestrator, persistence };
 }
@@ -453,6 +505,99 @@ describe('Orchestrator launch claims', () => {
 
     const started = orchestrator.resumeWorkflow(workflowId);
     expect(started.map((task) => task.id)).toEqual([taskId]);
+  });
+
+  describe('launch-outbox observer wiring (Phase A)', () => {
+    function loadPlanForLaunchOutbox(orchestrator: Orchestrator): { taskId: string } {
+      orchestrator.loadPlan({
+        name: 'launch-outbox-observer',
+        onFinish: 'none',
+        tasks: [{ id: 't1', description: 'one', command: 'echo one' }],
+      });
+      return { taskId: taskIdBySuffix(orchestrator, 't1') };
+    }
+
+    it("does not write outbox rows when launchOutboxMode='disabled'", () => {
+      const { orchestrator, persistence } = makeOrchestrator({
+        deferRunningUntilLaunch: true,
+        enqueueLaunchDispatchEnabled: true,
+        launchOutboxMode: 'disabled',
+      });
+      loadPlanForLaunchOutbox(orchestrator);
+      orchestrator.startExecution();
+
+      expect(persistence.launchDispatchRows).toEqual([]);
+      expect(
+        persistence.events.find((event) => event.eventType === 'task.dispatch_enqueued'),
+      ).toBeUndefined();
+      expect(
+        persistence.events.find((event) => event.eventType === 'task.launch_claimed'),
+      ).toBeDefined();
+    });
+
+    it("writes one outbox row per claimed attempt when launchOutboxMode='observe' and still emits task.launch_claimed", () => {
+      const { orchestrator, persistence } = makeOrchestrator({
+        deferRunningUntilLaunch: true,
+        enqueueLaunchDispatchEnabled: true,
+        launchOutboxMode: 'observe',
+        maxConcurrency: 4,
+      });
+      orchestrator.loadPlan({
+        name: 'launch-outbox-observer',
+        onFinish: 'none',
+        tasks: [
+          { id: 't1', description: 'one', command: 'echo one' },
+          { id: 't2', description: 'two', command: 'echo two' },
+        ],
+      });
+      const started = orchestrator.startExecution();
+
+      expect(started).toHaveLength(2);
+      expect(persistence.launchDispatchRows).toHaveLength(2);
+      const claimedAttemptIds = new Set(started.map((task) => task.execution.selectedAttemptId));
+      const dispatchedAttemptIds = new Set(
+        persistence.launchDispatchRows.map((row) => row.attemptId),
+      );
+      expect(dispatchedAttemptIds).toEqual(claimedAttemptIds);
+      expect(
+        persistence.events.filter((event) => event.eventType === 'task.launch_claimed'),
+      ).toHaveLength(2);
+      const enqueueEvents = persistence.events.filter(
+        (event) => event.eventType === 'task.dispatch_enqueued',
+      );
+      expect(enqueueEvents).toHaveLength(2);
+      for (const event of enqueueEvents) {
+        const payload = event.payload as { dispatchId?: number };
+        expect(typeof payload?.dispatchId).toBe('number');
+      }
+    });
+
+    it("treats launchOutboxMode='active' the same as observe in Phase A (active behavior lands in CB)", () => {
+      const { orchestrator, persistence } = makeOrchestrator({
+        deferRunningUntilLaunch: true,
+        enqueueLaunchDispatchEnabled: true,
+        launchOutboxMode: 'active',
+      });
+      loadPlanForLaunchOutbox(orchestrator);
+      orchestrator.startExecution();
+
+      expect(persistence.launchDispatchRows).toHaveLength(1);
+      expect(
+        persistence.events.find((event) => event.eventType === 'task.dispatch_enqueued'),
+      ).toBeDefined();
+    });
+
+    it("tolerates missing enqueueLaunchDispatch without throwing when launchOutboxMode='observe'", () => {
+      const { orchestrator, persistence } = makeOrchestrator({
+        deferRunningUntilLaunch: true,
+        enqueueLaunchDispatchEnabled: false,
+        launchOutboxMode: 'observe',
+      });
+      (persistence as unknown as { enqueueLaunchDispatch?: unknown }).enqueueLaunchDispatch = undefined;
+      loadPlanForLaunchOutbox(orchestrator);
+      expect(() => orchestrator.startExecution()).not.toThrow();
+      expect(persistence.launchDispatchRows).toEqual([]);
+    });
   });
 
   it('returns downstream launch claims from worker completion and approval cascades', async () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -24,6 +24,7 @@ import type { RunnerKind } from '@invoker/workflow-graph';
 import { createTaskState, createAttempt } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
 import type { Logger, WorkResponse } from '@invoker/contracts';
+import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import { normalizeRunnerKind } from '@invoker/workflow-graph';
 
 const MERGE_TRACE_LOG = resolve(homedir(), '.invoker', 'merge-trace.log');
@@ -108,7 +109,6 @@ function workflowTimestamp(): Date {
   return new Date();
 }
 const FIX_FAILURE_PREFIX_RE = /^\[Fix with (?:Claude|Agent) failed\] [^\n]*\n\n/;
-const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
 const TRACE_PERSIST_SYNC = process.env.INVOKER_TRACE_PERSIST_SYNC === '1';
 const TRACE_WORKER_RESPONSE = process.env.INVOKER_TRACE_WORKER_RESPONSE === '1';
 const noopLogger: Logger = {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -240,6 +240,21 @@ export interface OrchestratorPersistence {
   deleteWorkflow?(workflowId: string): void;
   /** Delete all workflows and tasks from the DB. */
   deleteAllWorkflows?(): void;
+  /**
+   * Optional launch-handoff outbox sink. When provided AND
+   * `OrchestratorConfig.launchOutboxMode` is `'observe'` or `'active'`,
+   * `drainScheduler` writes a `task_launch_dispatch` row alongside the
+   * legacy claim path. The orchestrator does not take a hard dependency
+   * on this method; it is observer-only in Phase A. See
+   * `docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md`.
+   */
+  enqueueLaunchDispatch?(input: {
+    taskId: string;
+    attemptId: string;
+    workflowId: string;
+    priority?: 'high' | 'normal' | 'low';
+    generation: number;
+  }): { id: number };
 }
 
 export interface OrchestratorMessageBus {
@@ -716,6 +731,16 @@ export interface OrchestratorConfig {
    * scheduler dequeue time).
    */
   deferRunningUntilLaunch?: boolean;
+  /**
+   * Launch-handoff outbox mode. When set to `'observe'` or `'active'` (and
+   * the persistence layer implements `enqueueLaunchDispatch`),
+   * `drainScheduler` writes a durable `task_launch_dispatch` row alongside
+   * the existing claim path and emits a `task.dispatch_enqueued` event.
+   *
+   * Default `'disabled'` preserves existing behaviour. See
+   * `docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md`.
+   */
+  launchOutboxMode?: 'disabled' | 'observe' | 'active';
 }
 
 // ── Orchestrator ────────────────────────────────────────────
@@ -736,6 +761,7 @@ export class Orchestrator {
   private readonly defaultPoolId: string | undefined;
   private readonly defaultAutoFixRetries: number;
   private readonly deferRunningUntilLaunch: boolean;
+  private readonly launchOutboxMode: 'disabled' | 'observe' | 'active';
 
   private activeWorkflowIds = new Set<string>();
   private deferredTaskIds = new Set<string>();
@@ -808,6 +834,7 @@ export class Orchestrator {
     this.defaultPoolId = config.defaultPoolId;
     this.defaultAutoFixRetries = Math.min(Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0)), 10);
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
+    this.launchOutboxMode = config.launchOutboxMode ?? 'disabled';
 
     this.stateMachine = new TaskStateMachine(new ActionGraph());
     this.responseHandler = new ResponseHandler();
@@ -4972,6 +4999,30 @@ export class Orchestrator {
         this.deferRunningUntilLaunch ? 'task.launch_claimed' : 'task.running',
         changes,
       );
+      if (
+        this.launchOutboxMode !== 'disabled'
+        && typeof this.persistence.enqueueLaunchDispatch === 'function'
+        && task.config.workflowId
+      ) {
+        try {
+          const dispatch = this.persistence.enqueueLaunchDispatch({
+            taskId: job.taskId,
+            attemptId: launchAttemptId,
+            workflowId: task.config.workflowId,
+            generation: this.getExecutionGeneration(task),
+          });
+          this.persistence.logEvent?.(job.taskId, 'task.dispatch_enqueued', {
+            ...changes,
+            dispatchId: dispatch.id,
+          });
+        } catch (err) {
+          this.logger.warn('[orchestrator] drainScheduler: enqueueLaunchDispatch failed', {
+            taskId: job.taskId,
+            attemptId: launchAttemptId,
+            error: err instanceof Error ? err.message : String(err),
+          });
+        }
+      }
       this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
       started.push(updated);
       this.logger.info('[orchestrator] drainScheduler: started', {

--- a/scripts/cleanup-ssh-sync-creds-rebase-recreate-all.sh
+++ b/scripts/cleanup-ssh-sync-creds-rebase-recreate-all.sh
@@ -394,7 +394,7 @@ sync_credentials_to_target() {
 
     local -a SSH_ARGS
     ssh_base_args "$port" "$key_path"
-    ssh "${SSH_ARGS[@]}" "$user_host" "mkdir -p ~/'$remote_parent' && chmod 700 ~"
+    ssh "${SSH_ARGS[@]}" "$user_host" "mkdir -p ~/'$remote_parent' && chmod 700 ~" </dev/null
 
     if [[ -d "$path_entry" ]]; then
       rsync -az --delete \

--- a/scripts/headless-ipc.js
+++ b/scripts/headless-ipc.js
@@ -115,6 +115,14 @@ function isRetryableDispatchError(error) {
   return /database is locked|SQLITE_BUSY|Timed out after/i.test(message);
 }
 
+function isNoHandlerError(error) {
+  if (error && typeof error === 'object' && error.code === 'NO_HANDLER') {
+    return true;
+  }
+  const message = error instanceof Error ? error.message : String(error);
+  return /NO_HANDLER|No request handler registered|No handler registered/i.test(message);
+}
+
 // ---------------------------------------------------------------------------
 // Stdin reader (for batch-exec)
 // ---------------------------------------------------------------------------
@@ -225,6 +233,38 @@ async function requestExecWithRetry(bus, item, options) {
   throw lastError;
 }
 
+async function requestBatchExec(bus, items, options) {
+  const payload = {
+    items,
+    noTrack: options.noTrack,
+    waitForApproval: options.waitForApproval,
+  };
+  const response = await withTimeout(bus.request('headless.batch-exec', payload), options.timeoutMs);
+  if (!Array.isArray(response)) {
+    throw new Error(`headless.batch-exec returned non-array response: ${JSON.stringify(response)}`);
+  }
+  return response;
+}
+
+async function requestBatchExecWithRetry(bus, items, options) {
+  const maxAttempts = Number.parseInt(process.env.INVOKER_HEADLESS_IPC_DISPATCH_ATTEMPTS ?? '8', 10);
+  const attempts = Number.isFinite(maxAttempts) && maxAttempts > 0 ? maxAttempts : 8;
+  let lastError;
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      return await requestBatchExec(bus, items, options);
+    } catch (error) {
+      lastError = error;
+      if (attempt >= attempts || isNoHandlerError(error) || !isRetryableDispatchError(error)) {
+        throw error;
+      }
+      const delayMs = Math.min(5_000, 250 * attempt * attempt);
+      await sleep(delayMs);
+    }
+  }
+  throw lastError;
+}
+
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
@@ -275,6 +315,21 @@ async function main() {
       }
       return parsed;
     });
+
+    if (options.noTrack) {
+      try {
+        const results = await requestBatchExecWithRetry(bus, items, options);
+        for (const result of results) {
+          process.stdout.write(`${JSON.stringify(result)}\n`);
+        }
+        return;
+      } catch (error) {
+        if (!isNoHandlerError(error)) {
+          throw error;
+        }
+        process.stderr.write('headless.batch-exec handler unavailable; falling back to per-item headless.exec dispatch\n');
+      }
+    }
 
     let nextIndex = 0;
     const parallel = Math.max(1, Number.isFinite(options.parallel) ? options.parallel : 1);

--- a/scripts/invoker-command-concurrency-watchdog.mjs
+++ b/scripts/invoker-command-concurrency-watchdog.mjs
@@ -1,0 +1,207 @@
+#!/usr/bin/env node
+import { execFileSync } from 'node:child_process';
+import { basename, resolve } from 'node:path';
+import { existsSync, readFileSync } from 'node:fs';
+
+const DEFAULT_COMMANDS = ['claude', 'codex', 'pnpm'];
+const FATAL_HEADER = 'FATAL: Invoker command concurrency invariant violated';
+
+function parseArgs(argv) {
+  const opts = {
+    max: 1,
+    commands: DEFAULT_COMMANDS,
+    action: 'kill-owner',
+    repoRoot: resolve(new URL('..', import.meta.url).pathname),
+  };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--max') opts.max = Number.parseInt(argv[++i] ?? '', 10);
+    else if (arg === '--commands') opts.commands = String(argv[++i] ?? '').split(',').map((v) => v.trim()).filter(Boolean);
+    else if (arg === '--action') opts.action = argv[++i];
+    else if (arg === '--owner-pid') opts.ownerPid = Number.parseInt(argv[++i] ?? '', 10);
+    else if (arg === '--snapshot-file') opts.snapshotFile = argv[++i];
+    else if (arg === '--repo-root') opts.repoRoot = resolve(argv[++i] ?? '.');
+    else if (arg === '--help' || arg === '-h') opts.help = true;
+    else throw new Error(`unknown argument: ${arg}`);
+  }
+  if (!Number.isInteger(opts.max) || opts.max < 1) throw new Error('--max must be a positive integer');
+  if (opts.action !== 'kill-owner' && opts.action !== 'report') throw new Error('--action must be kill-owner or report');
+  return opts;
+}
+
+function usage() {
+  return [
+    'usage: invoker-command-concurrency-watchdog.mjs [--max N] [--commands a,b] [--action kill-owner|report]',
+    '       [--owner-pid PID] [--snapshot-file PATH] [--repo-root PATH]',
+  ].join('\n');
+}
+
+function shellSplit(line) {
+  const out = [];
+  const re = /"([^"\\]*(?:\\.[^"\\]*)*)"|'([^'\\]*(?:\\.[^'\\]*)*)'|(\S+)/g;
+  let match;
+  while ((match = re.exec(line)) != null) out.push(match[1] ?? match[2] ?? match[3]);
+  return out;
+}
+
+function normalizeProcess(row) {
+  const args = Array.isArray(row.args) ? row.args.join(' ') : String(row.args ?? row.command ?? '');
+  return {
+    pid: Number(row.pid),
+    ppid: Number(row.ppid ?? 0),
+    command: String(row.command ?? row.comm ?? shellSplit(args)[0] ?? ''),
+    args,
+    cwd: row.cwd ? String(row.cwd) : undefined,
+  };
+}
+
+export function parseProcessSnapshot(raw) {
+  const trimmed = String(raw).trim();
+  if (!trimmed) return [];
+  if (trimmed.startsWith('[')) {
+    const parsed = JSON.parse(trimmed);
+    if (!Array.isArray(parsed)) throw new Error('JSON snapshot must be an array');
+    return parsed.map(normalizeProcess).filter((p) => Number.isInteger(p.pid));
+  }
+  const lines = trimmed.split(/\r?\n/).filter(Boolean);
+  return lines.map((line) => {
+    const match = line.match(/^\s*(\d+)\s+(\d+)\s+(\S+)\s*(.*)$/);
+    if (!match) throw new Error(`invalid ps snapshot line: ${line}`);
+    return normalizeProcess({
+      pid: Number(match[1]),
+      ppid: Number(match[2]),
+      command: match[3],
+      args: match[4] || match[3],
+    });
+  });
+}
+
+function readLiveProcesses() {
+  const output = execFileSync('ps', ['-axo', 'pid=,ppid=,comm=,args='], { encoding: 'utf8' });
+  const rows = parseProcessSnapshot(output);
+  if (process.platform !== 'linux') return rows;
+  return rows.map((row) => {
+    const cwdLink = `/proc/${row.pid}/cwd`;
+    if (!existsSync(cwdLink)) return row;
+    try {
+      return { ...row, cwd: execFileSync('readlink', ['-f', cwdLink], { encoding: 'utf8' }).trim() };
+    } catch {
+      return row;
+    }
+  });
+}
+
+function commandName(proc) {
+  const fromCommand = basename(proc.command || '');
+  const firstArg = basename(shellSplit(proc.args)[0] ?? '');
+  return fromCommand || firstArg;
+}
+
+function isGuarded(proc, commands) {
+  const names = new Set([commandName(proc), basename(shellSplit(proc.args)[0] ?? '')].filter(Boolean));
+  return commands.some((cmd) => names.has(cmd));
+}
+
+function isOwner(proc, ownerPid) {
+  if (ownerPid && proc.pid === ownerPid) return true;
+  const args = proc.args;
+  if (!args.includes('packages/app/dist/main.js') && !args.includes('/dist/main.js')) return false;
+  return /(^|\s)(electron|Electron|node)(\s|$|\/)/.test(args) || args.includes('--headless');
+}
+
+function hasAncestor(proc, ownerPids, byPid) {
+  const seen = new Set();
+  let ppid = proc.ppid;
+  while (ppid && !seen.has(ppid)) {
+    if (ownerPids.has(ppid)) return ppid;
+    seen.add(ppid);
+    ppid = byPid.get(ppid)?.ppid;
+  }
+  return undefined;
+}
+
+function isInvokerManagedCwd(cwd) {
+  if (!cwd) return false;
+  const normalized = resolve(cwd);
+  return normalized.includes('/.invoker/worktrees/')
+    || normalized.includes('/.invoker/test/worktrees/')
+    || normalized.includes('/.invoker/repos/')
+    || normalized.includes('/.invoker/test/repos/')
+    || normalized.includes('/invoker-worktrees/')
+    || normalized.includes('/invoker-runtime/');
+}
+
+export function evaluateSnapshot(processes, options = {}) {
+  const commands = options.commands ?? DEFAULT_COMMANDS;
+  const max = options.max ?? 1;
+  const byPid = new Map(processes.map((proc) => [proc.pid, proc]));
+  const ownerPids = new Set(processes.filter((proc) => isOwner(proc, options.ownerPid)).map((proc) => proc.pid));
+  if (options.ownerPid) ownerPids.add(options.ownerPid);
+
+  const offenders = [];
+  for (const proc of processes) {
+    if (!isGuarded(proc, commands)) continue;
+    const ownerPid = hasAncestor(proc, ownerPids, byPid);
+    if (ownerPid) {
+      offenders.push({ ...proc, ownerPid, ownership: 'ancestor' });
+      continue;
+    }
+    const platform = options.platform ?? process.platform;
+    if (ownerPids.size === 0 && platform === 'linux' && isInvokerManagedCwd(proc.cwd)) {
+      offenders.push({ ...proc, ownerPid: undefined, ownership: 'cwd' });
+    }
+  }
+  return {
+    ok: offenders.length <= max,
+    max,
+    count: offenders.length,
+    ownerPids: [...ownerPids],
+    offenders,
+  };
+}
+
+export function formatViolation(result) {
+  const lines = [
+    FATAL_HEADER,
+    `observed guarded processes: ${result.count}; max allowed: ${result.max}`,
+  ];
+  if (result.ownerPids.length > 0) lines.push(`owner PID(s): ${result.ownerPids.join(', ')}`);
+  for (const proc of result.offenders) {
+    lines.push(`- pid=${proc.pid} ppid=${proc.ppid} ownerPid=${proc.ownerPid ?? 'unknown'} command=${commandName(proc)} args=${proc.args}`);
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  if (opts.help) {
+    process.stdout.write(`${usage()}\n`);
+    return 0;
+  }
+  const processes = opts.snapshotFile
+    ? parseProcessSnapshot(readFileSync(opts.snapshotFile, 'utf8'))
+    : readLiveProcesses();
+  const result = evaluateSnapshot(processes, opts);
+  if (result.ok) return 0;
+  process.stderr.write(formatViolation(result));
+  if (opts.action === 'kill-owner') {
+    for (const ownerPid of result.ownerPids) {
+      try {
+        process.kill(ownerPid, 'SIGTERM');
+        process.stderr.write(`sent SIGTERM to owner PID ${ownerPid}\n`);
+      } catch (err) {
+        process.stderr.write(`failed to SIGTERM owner PID ${ownerPid}: ${err instanceof Error ? err.message : String(err)}\n`);
+      }
+    }
+  }
+  return 1;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    process.exitCode = main();
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n${usage()}\n`);
+    process.exitCode = 2;
+  }
+}

--- a/scripts/invoker-command-concurrency-watchdog.test.mjs
+++ b/scripts/invoker-command-concurrency-watchdog.test.mjs
@@ -1,0 +1,87 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateSnapshot, formatViolation } from './invoker-command-concurrency-watchdog.mjs';
+
+const owner = { pid: 100, ppid: 1, command: 'Electron', args: 'Electron packages/app/dist/main.js --headless run plan.yaml' };
+
+describe('invoker command concurrency watchdog', () => {
+  it('allows no guarded processes', () => {
+    assert.equal(evaluateSnapshot([owner]).ok, true);
+  });
+
+  it('allows one codex descendant of owner', () => {
+    const result = evaluateSnapshot([owner, { pid: 101, ppid: 100, command: 'codex', args: 'codex exec' }]);
+    assert.equal(result.ok, true);
+  });
+
+  it('fails on claude plus codex descendants of owner', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'claude', args: 'claude' },
+      { pid: 102, ppid: 100, command: 'codex', args: 'codex exec' },
+    ]);
+    assert.equal(result.ok, false);
+    assert.equal(result.count, 2);
+  });
+
+  it('fails on two codex descendants of owner', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'codex', args: 'codex exec' },
+      { pid: 102, ppid: 100, command: 'codex', args: 'codex exec' },
+    ]);
+    assert.equal(result.ok, false);
+  });
+
+  it('ignores unrelated pnpm outside owner ancestry', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 1, command: 'pnpm', args: 'pnpm test' },
+    ]);
+    assert.equal(result.ok, true);
+    assert.equal(result.count, 0);
+  });
+
+  it('--max 2 allows two guarded processes', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'claude', args: 'claude' },
+      { pid: 102, ppid: 100, command: 'codex', args: 'codex exec' },
+    ], { max: 2 });
+    assert.equal(result.ok, true);
+  });
+
+  it('violation output includes PID, command, and owner PID', () => {
+    const result = evaluateSnapshot([
+      owner,
+      { pid: 101, ppid: 100, command: 'codex', args: 'codex exec' },
+      { pid: 102, ppid: 100, command: 'pnpm', args: 'pnpm install' },
+    ]);
+    const output = formatViolation(result);
+    assert.match(output, /FATAL: Invoker command concurrency invariant violated/);
+    assert.match(output, /pid=101/);
+    assert.match(output, /command=codex/);
+    assert.match(output, /ownerPid=100/);
+  });
+
+  it('counts Linux guarded processes under Invoker-managed cwd when ancestry is unavailable', () => {
+    const result = evaluateSnapshot([
+      {
+        pid: 201,
+        ppid: 1,
+        command: 'pnpm',
+        args: 'pnpm test',
+        cwd: '/home/user/.invoker/worktrees/hash/experiment-task',
+      },
+      {
+        pid: 202,
+        ppid: 1,
+        command: 'pnpm',
+        args: 'pnpm test',
+        cwd: '/home/user/project',
+      },
+    ], { platform: 'linux' });
+    assert.equal(result.count, 1);
+    assert.equal(result.offenders[0].pid, 201);
+  });
+});

--- a/scripts/watch-invoker-command-concurrency.sh
+++ b/scripts/watch-invoker-command-concurrency.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HELPER="$REPO_ROOT/scripts/invoker-command-concurrency-watchdog.mjs"
+INTERVAL=10
+MAX=1
+COMMANDS="claude,codex,pnpm"
+ACTION="kill-owner"
+OWNER_PID=""
+SNAPSHOT_FILE=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --interval) INTERVAL="$2"; shift 2 ;;
+    --max) MAX="$2"; shift 2 ;;
+    --commands) COMMANDS="$2"; shift 2 ;;
+    --action) ACTION="$2"; shift 2 ;;
+    --owner-pid) OWNER_PID="$2"; shift 2 ;;
+    --snapshot-file) SNAPSHOT_FILE="$2"; shift 2 ;;
+    --help|-h)
+      echo "usage: $0 [--interval seconds] [--max N] [--commands a,b] [--action kill-owner|report] [--owner-pid PID] [--snapshot-file PATH]" >&2
+      exit 0
+      ;;
+    *) echo "watch-invoker-command-concurrency: unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+args=(--max "$MAX" --commands "$COMMANDS" --action "$ACTION" --repo-root "$REPO_ROOT")
+if [[ -n "$OWNER_PID" ]]; then args+=(--owner-pid "$OWNER_PID"); fi
+if [[ -n "$SNAPSHOT_FILE" ]]; then args+=(--snapshot-file "$SNAPSHOT_FILE"); fi
+
+while true; do
+  node "$HELPER" "${args[@]}"
+  if [[ -n "$SNAPSHOT_FILE" ]]; then exit 0; fi
+  sleep "$INTERVAL"
+done

--- a/scripts/with-invoker-command-watchdog.sh
+++ b/scripts/with-invoker-command-watchdog.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+WATCHDOG_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --)
+      shift
+      break
+      ;;
+    --interval|--max|--commands|--action|--owner-pid|--snapshot-file)
+      WATCHDOG_ARGS+=("$1" "$2")
+      shift 2
+      ;;
+    --help|-h)
+      echo "usage: $0 [watchdog options] -- <command> [args...]" >&2
+      exit 0
+      ;;
+    *) break ;;
+  esac
+done
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 [watchdog options] -- <command> [args...]" >&2
+  exit 2
+fi
+
+"$REPO_ROOT/scripts/watch-invoker-command-concurrency.sh" "${WATCHDOG_ARGS[@]}" &
+watchdog_pid=$!
+
+cleanup() {
+  if kill -0 "$watchdog_pid" 2>/dev/null; then
+    kill "$watchdog_pid" 2>/dev/null || true
+    wait "$watchdog_pid" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT INT TERM
+
+"$@" &
+command_pid=$!
+
+command_status=0
+watchdog_status=0
+
+while true; do
+  if ! kill -0 "$command_pid" 2>/dev/null; then
+    wait "$command_pid" || command_status=$?
+    cleanup
+    exit "$command_status"
+  fi
+  if ! kill -0 "$watchdog_pid" 2>/dev/null; then
+    wait "$watchdog_pid" || watchdog_status=$?
+    kill "$command_pid" 2>/dev/null || true
+    wait "$command_pid" 2>/dev/null || true
+    exit "$watchdog_status"
+  fi
+  sleep 1
+done


### PR DESCRIPTION
## Summary

Second PR in the launch-handoff re-architecture stack. Stacked on top of #870 (Phase 1).

Installs the new `task_launch_dispatch` outbox infrastructure but leaves dispatch behaviour unchanged. Every `drainScheduler` claim still flows through the existing fire-and-forget path; the new outbox row is written alongside but never read for dispatch. Behind `INVOKER_LAUNCH_OUTBOX=observe`, the `LaunchDispatcher` polls the outbox and logs aggregate counts only — no action taken.

Default for the new `INVOKER_LAUNCH_OUTBOX` flag is `disabled`, so production behaviour is bit-for-bit identical to before until the flag is flipped.

Phase A commits (CA.1–CA.6):

- CA.1 `task_launch_dispatch` table + unique attempt-id index (additive `CREATE TABLE IF NOT EXISTS`).
- CA.2 Repository methods (`enqueueLaunchDispatch`, `loadLaunchDispatchById`, `claimLaunchDispatchAtomic`, `markLaunch{Acknowledged,Completed,Failed,Abandoned}`, `reapExpiredLaunchDispatchLeases`).
- CA.3 Consolidate `ATTEMPT_LEASE_MS` into `@invoker/contracts` and add `DISPATCH_LEASE_MS = 30_000`, `DISPATCH_MAX_ATTEMPTS = 3`.
- CA.4 `INVOKER_LAUNCH_OUTBOX` feature flag plumbed through `InvokerConfig`.
- CA.5 `drainScheduler` writes the outbox row + `task.dispatch_enqueued` event in the same transaction as the existing `task.launch_claimed` event (observe/active modes only).
- CA.6 `LaunchDispatcher` class with observer-mode `poll()` wired into the owner db-poll loop.

## Architecture

### Before

```mermaid
flowchart TD
    Orch["Orchestrator drainScheduler"] -->|"task.launch_claimed event"| Runner["TaskRunner (fire-and-forget JS promise)"]
    Runner -->|"executor.start"| Exec["Executor"]
```

### After (observer mode, no behaviour change)

```mermaid
flowchart TD
    Orch["Orchestrator drainScheduler"] -->|"task.launch_claimed event"| Runner["TaskRunner (fire-and-forget JS promise)"]
    Orch -->|"enqueueLaunchDispatch (additive)"| Outbox[("task_launch_dispatch")]
    Runner -->|"executor.start"| Exec["Executor"]
    Outbox -.->|"poll, log counts only"| Dispatcher["LaunchDispatcher (observer)"]
```

## Test Plan

- [ ] `cd packages/data-store && pnpm test sqlite-adapter`
- [ ] `cd packages/workflow-core && pnpm test orchestrator-dispatcher`
- [ ] `cd packages/app && pnpm test launch-dispatcher`
- [ ] `cd packages/app && pnpm test config`
- [ ] `pnpm -F @invoker/contracts test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit>`
- Post-revert steps: Phases B–D depend on this. The `CREATE TABLE IF NOT EXISTS` is unconditionally additive, so existing DBs stay functional after revert (the table simply becomes orphaned and unused).
- Data migration? No (additive schema only; no data backfill required)
