### PR TITLE
Launch-handoff Phase B: activate task_launch_dispatch outbox behind flag

### DIFF
--- a/packages/app/src/__tests__/headless-create-executor.test.ts
+++ b/packages/app/src/__tests__/headless-create-executor.test.ts
@@ -1,0 +1,160 @@
+/**
+ * CB.7 acceptance: verifies createHeadlessExecutor's active-mode
+ * short-circuit. In `INVOKER_LAUNCH_OUTBOX=active` mode the owner's
+ * long-lived TaskRunner is the single launch path (it services the
+ * task_launch_dispatch outbox via LaunchDispatcher), so headless
+ * commands must reuse it instead of constructing a per-command
+ * TaskRunner — that was the root of Issue 6 (multi-TaskRunner
+ * blindness from per-instance `launchingAttemptIds` Sets).
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type { Logger } from '@invoker/contracts';
+import type { TaskRunner } from '@invoker/execution-engine';
+import { createHeadlessExecutor, type HeadlessDeps } from '../headless.js';
+
+function makeLogger(): Logger & {
+  records: { level: 'info' | 'warn' | 'error' | 'debug'; msg: string }[];
+} {
+  const records: { level: 'info' | 'warn' | 'error' | 'debug'; msg: string }[] = [];
+  const push =
+    (level: 'info' | 'warn' | 'error' | 'debug') =>
+    (msg: string) => {
+      records.push({ level, msg });
+    };
+  const logger: Logger = {
+    debug: push('debug'),
+    info: push('info'),
+    warn: push('warn'),
+    error: push('error'),
+    child: () => logger,
+  };
+  return Object.assign(logger, { records });
+}
+
+function fakeOwnerTaskRunner(): TaskRunner {
+  return { kind: 'owner-runner' } as unknown as TaskRunner;
+}
+
+function makeDeps(overrides: Partial<HeadlessDeps>): HeadlessDeps {
+  return {
+    logger: makeLogger(),
+    orchestrator: {} as any,
+    persistence: {
+      appendTaskOutput: vi.fn(),
+    } as any,
+    executorRegistry: {} as any,
+    messageBus: {} as any,
+    commandService: {} as any,
+    repoRoot: '/tmp/repo',
+    invokerConfig: {
+      launchOutboxMode: 'disabled',
+      defaultBranch: 'main',
+      docker: {},
+      executionPools: {},
+      remoteTargets: {},
+    } as any,
+    initServices: async () => {},
+    wireSlackBot: async () => ({}),
+    ...overrides,
+  };
+}
+
+describe('createHeadlessExecutor (CB.7 active-mode short-circuit)', () => {
+  it('returns the owner TaskRunner when launchOutboxMode=active and the provider yields one', () => {
+    const owner = fakeOwnerTaskRunner();
+    const deps = makeDeps({
+      invokerConfig: {
+        launchOutboxMode: 'active',
+        defaultBranch: 'main',
+        docker: {},
+        executionPools: {},
+        remoteTargets: {},
+      } as any,
+      ownerTaskRunnerProvider: () => owner,
+    });
+
+    const executor = createHeadlessExecutor(deps);
+    expect(executor).toBe(owner);
+  });
+
+  it('logs a debug note and still returns the owner when callbackOverrides are passed (overrides are ignored)', () => {
+    const owner = fakeOwnerTaskRunner();
+    const logger = makeLogger();
+    const deps = makeDeps({
+      logger,
+      invokerConfig: {
+        launchOutboxMode: 'active',
+        defaultBranch: 'main',
+        docker: {},
+        executionPools: {},
+        remoteTargets: {},
+      } as any,
+      ownerTaskRunnerProvider: () => owner,
+    });
+
+    const executor = createHeadlessExecutor(deps, { onOutput: () => {} });
+    expect(executor).toBe(owner);
+    const debugRecord = logger.records.find(
+      (r) => r.level === 'debug' && r.msg.includes('ignoring callbackOverrides'),
+    );
+    expect(debugRecord).toBeDefined();
+  });
+
+  it('warns and falls back to constructing a fresh TaskRunner when active but no owner is available', () => {
+    const logger = makeLogger();
+    const deps = makeDeps({
+      logger,
+      invokerConfig: {
+        launchOutboxMode: 'active',
+        defaultBranch: 'main',
+        docker: {},
+        executionPools: {},
+        remoteTargets: {},
+      } as any,
+      // No ownerTaskRunnerProvider — simulates a true standalone owner
+      // that hasn't initialised its TaskRunner yet.
+    });
+
+    // The constructor of TaskRunner requires real shared services to
+    // succeed; for this test we only care that the active branch took
+    // the fallback path (warning emitted) before any throw. We catch
+    // any constructor-time error so we can assert on the warning
+    // independently.
+    let threw = false;
+    try {
+      createHeadlessExecutor(deps);
+    } catch {
+      threw = true;
+    }
+    void threw; // either outcome is acceptable for this assertion
+    const warn = logger.records.find(
+      (r) => r.level === 'warn' && r.msg.includes('ownerTaskRunnerProvider is unavailable'),
+    );
+    expect(warn).toBeDefined();
+  });
+
+  it('does not short-circuit when launchOutboxMode is not active', () => {
+    const owner = fakeOwnerTaskRunner();
+    const providerCalls = vi.fn(() => owner);
+    const deps = makeDeps({
+      invokerConfig: {
+        launchOutboxMode: 'observe',
+        defaultBranch: 'main',
+        docker: {},
+        executionPools: {},
+        remoteTargets: {},
+      } as any,
+      ownerTaskRunnerProvider: providerCalls,
+    });
+
+    // We expect a real TaskRunner construction to fail in this minimal
+    // env; that's fine — what we're asserting is that the provider was
+    // *not* consulted (the legacy code path was taken).
+    try {
+      createHeadlessExecutor(deps);
+    } catch {
+      // swallow — verifying the provider call below
+    }
+    expect(providerCalls).not.toHaveBeenCalled();
+  });
+});

--- a/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
+++ b/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
@@ -26,8 +26,9 @@
 
 import { afterEach, describe, expect, it } from 'vitest';
 import { SQLiteAdapter } from '@invoker/data-store';
-import { Orchestrator, type PlanDefinition } from '@invoker/workflow-core';
+import { Orchestrator, type PlanDefinition, type TaskState } from '@invoker/workflow-core';
 import { InMemoryBus } from '@invoker/test-kit';
+import { LaunchDispatcher } from '../launch-dispatcher.js';
 import {
   LAUNCH_CLAIM_EVENT_TYPE,
   LaunchInvariantViolationError,
@@ -123,6 +124,121 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
         }
         throw err;
       }
+    },
+  );
+
+  it(
+    'with INVOKER_LAUNCH_OUTBOX=active, the LaunchDispatcher resolves every claim into a terminal event',
+    async () => {
+      // CB.5 acceptance: wire the same 38-claim storm through the durable
+      // outbox dispatcher (orchestrator -> task_launch_dispatch ->
+      // LaunchDispatcher -> fake TaskRunner). The invariant must hold:
+      // every `task.launch_claimed` reaches a terminal launch event.
+      const persistence = await SQLiteAdapter.create(':memory:');
+      adapters.push(persistence);
+
+      const orchestrator = new Orchestrator({
+        persistence: persistence as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: STORM_SIZE,
+        deferRunningUntilLaunch: true,
+        // Active mode causes drainScheduler to write the outbox row alongside
+        // the durable launch claim — that row is what the LaunchDispatcher
+        // polls below.
+        launchOutboxMode: 'active',
+      });
+
+      const startedTasks: TaskState[] = [];
+      const fakeTaskRunner = {
+        async executeTask(
+          task: TaskState,
+          opts?: { dispatchId: number; launchOutbox: LaunchDispatcher },
+        ): Promise<void> {
+          startedTasks.push(task);
+          if (!opts) return;
+          const accepted = opts.launchOutbox.ackDispatch(opts.dispatchId, 'fake-runner');
+          if (!accepted) return;
+          // Mark the task as running synchronously: this writes a terminal
+          // launch event (`task.running`) which satisfies the invariant.
+          const attemptId = task.execution.selectedAttemptId;
+          if (attemptId) {
+            orchestrator.markTaskRunningAfterLaunch(task.id, attemptId);
+          }
+          opts.launchOutbox.completeDispatch(opts.dispatchId);
+        },
+      };
+
+      const dispatcher = new LaunchDispatcher({
+        persistence,
+        orchestrator: {
+          prepareTaskForNewAttempt: (taskId, reason) =>
+            orchestrator.prepareTaskForNewAttempt(taskId, reason),
+          getTask: (taskId) => orchestrator.getTask(taskId),
+        },
+        taskRunnerProvider: () => fakeTaskRunner,
+        ownerId: 'cb5-test-owner',
+        mode: 'active',
+        maxConcurrency: STORM_SIZE,
+        maxLeasesPerPoll: STORM_SIZE,
+      });
+
+      for (let i = 0; i < STORM_SIZE; i++) {
+        const plan: PlanDefinition = {
+          name: `rebase-recreate-storm-active-${i}`,
+          baseBranch: 'master',
+          featureBranch: `experiment/storm-active-${i}`,
+          tasks: [
+            {
+              id: `t-${i}`,
+              description: `Storm task ${i}`,
+              command: `echo storm-${i}`,
+            },
+          ],
+        };
+        orchestrator.loadPlan(plan);
+      }
+
+      orchestrator.startExecution();
+      // Single poll handles every row because maxLeasesPerPoll is STORM_SIZE.
+      dispatcher.poll();
+      // Drain microtasks so the dispatcher's promise chain (and the
+      // synchronous markTaskRunningAfterLaunch inside the fake runner) all
+      // commit before the invariant check.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+
+      expect(startedTasks).toHaveLength(STORM_SIZE);
+
+      const claimCount = persistence
+        .getAllTaskIds()
+        .reduce(
+          (acc, taskId) =>
+            acc +
+            persistence
+              .getEvents(taskId)
+              .filter((event) => event.eventType === LAUNCH_CLAIM_EVENT_TYPE)
+              .length,
+          0,
+        );
+      expect(claimCount).toBe(STORM_SIZE);
+
+      const terminalCount = persistence
+        .getAllTaskIds()
+        .reduce(
+          (acc, taskId) =>
+            acc +
+            persistence
+              .getEvents(taskId)
+              .filter((event) => TERMINAL_LAUNCH_EVENT_TYPES.has(event.eventType))
+              .length,
+          0,
+        );
+      expect(terminalCount).toBeGreaterThanOrEqual(STORM_SIZE);
+
+      // The invariant must hold: no orphaned claims.
+      assertLaunchInvariant(persistence, {
+        maxGapMs: TIGHT_MAX_GAP_MS,
+        nowMs: Date.now() + PRETEND_LATER_MS,
+      });
     },
   );
 });

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -87,18 +87,25 @@ describe('LaunchDispatcher', () => {
     expect(afterPoll).toMatchObject({ state: 'enqueued' });
   });
 
-  it('active mode throws a CB.5 placeholder error after running the reapers', () => {
+  it('active mode without a taskRunnerProvider warns and does not dispatch', () => {
     const listSpy = vi.spyOn(adapter, 'listLaunchDispatchesByState');
+    const claimSpy = vi.spyOn(adapter, 'claimLaunchDispatchAtomic');
+    const logger = makeLogger();
     const dispatcher = new LaunchDispatcher({
       persistence: adapter,
       ownerId: 'owner-test',
+      logger,
       mode: 'active',
     });
-    expect(() => dispatcher.poll()).toThrow(/CB\.5 not implemented/);
+    expect(() => dispatcher.poll()).not.toThrow();
+    expect(claimSpy).not.toHaveBeenCalled();
+    const warn = logger.records.find((entry) => entry.level === 'warn');
+    expect(warn?.msg).toMatch(/active mode without taskRunner/);
     // Active mode never observes (no aggregate log) — observation is the
     // observer-mode tail and the reapers don't need it.
     expect(listSpy).not.toHaveBeenCalled();
     listSpy.mockRestore();
+    claimSpy.mockRestore();
   });
 
   it('observer mode reports zero counts when the outbox is empty', () => {
@@ -437,6 +444,184 @@ describe('LaunchDispatcher', () => {
       });
       observer.poll();
       expect(adapter.loadLaunchDispatchById(row.id)?.state).toBe('enqueued');
+    });
+  });
+
+  describe('active mode dispatch (CB.5)', () => {
+    function seedWorkflowAndTask(taskId: string, workflowId = 'wf-a') {
+      adapter.saveWorkflow({
+        id: workflowId,
+        name: workflowId,
+        status: 'running',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      const task = {
+        id: taskId,
+        description: taskId,
+        status: 'pending' as const,
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId },
+        execution: {},
+        taskStateVersion: 1,
+      };
+      adapter.saveTask(workflowId, task);
+      return task;
+    }
+
+    it('active mode leases an enqueued row and hands it to the TaskRunner', () => {
+      const task = seedWorkflowAndTask('wf-a/t1');
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-active-1',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const getTask = vi.fn().mockReturnValue(task as any);
+
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask,
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+        mode: 'active',
+        maxConcurrency: 4,
+      });
+      dispatcher.poll();
+
+      expect(getTask).toHaveBeenCalledWith(task.id);
+      expect(executeTask).toHaveBeenCalledTimes(1);
+      const [taskArg, optsArg] = executeTask.mock.calls[0]!;
+      expect(taskArg.id).toBe(task.id);
+      expect(optsArg.dispatchId).toBe(enq.id);
+      expect(optsArg.launchOutbox).toBe(dispatcher);
+
+      // Row is leased on this poll; the runner will transition it via
+      // ackDispatch/completeDispatch (those are unit-tested elsewhere).
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('leased');
+      expect(after?.dispatchOwner).toBe('owner-a');
+    });
+
+    it('active mode loops until maxLeasesPerPoll is reached', () => {
+      for (let i = 0; i < 3; i += 1) {
+        seedWorkflowAndTask(`wf-a/t${i}`);
+      }
+      for (let i = 0; i < 3; i += 1) {
+        adapter.enqueueLaunchDispatch({
+          taskId: `wf-a/t${i}`,
+          attemptId: `attempt-multi-${i}`,
+          workflowId: 'wf-a',
+          generation: 0,
+        });
+      }
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const getTask = vi.fn((id: string) => ({
+        id,
+        description: id,
+        status: 'pending',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: 'wf-a' },
+        execution: {},
+        taskStateVersion: 1,
+      } as any));
+
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask,
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+        mode: 'active',
+        maxConcurrency: 10,
+        maxLeasesPerPoll: 2,
+      });
+      dispatcher.poll();
+      expect(executeTask).toHaveBeenCalledTimes(2);
+    });
+
+    it('active mode fails the dispatch when the orchestrator has no matching task', () => {
+      seedWorkflowAndTask('wf-a/t-missing');
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-a/t-missing',
+        attemptId: 'attempt-missing',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      const executeTask = vi.fn();
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(undefined),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+        mode: 'active',
+        maxConcurrency: 4,
+      });
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      // failDispatch re-enqueues with last_error set (so the next poll
+      // can try again after the fence expires).
+      expect(after?.state).toBe('enqueued');
+      expect(after?.lastError).toMatch(/missing from orchestrator state/);
+    });
+
+    it('active mode is a no-op when the queue is empty', () => {
+      const executeTask = vi.fn();
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn(),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+        mode: 'active',
+        maxConcurrency: 4,
+      });
+      dispatcher.poll();
+      expect(executeTask).not.toHaveBeenCalled();
+    });
+
+    it('active mode catches runner promise rejections via failDispatch backstop', async () => {
+      const task = seedWorkflowAndTask('wf-a/t-throw');
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-throw',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      const executeTask = vi.fn().mockRejectedValue(new Error('runner exploded synchronously'));
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(task as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+        mode: 'active',
+        maxConcurrency: 4,
+      });
+      dispatcher.poll();
+      // Wait one microtask tick for the .catch backstop to run.
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('enqueued');
+      expect(after?.lastError).toMatch(/runner exploded synchronously/);
     });
   });
 });

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -87,17 +87,18 @@ describe('LaunchDispatcher', () => {
     expect(afterPoll).toMatchObject({ state: 'enqueued' });
   });
 
-  it('active mode throws a CB.5 placeholder error', () => {
-    const fakePersistence = {
-      listLaunchDispatchesByState: vi.fn(),
-    };
+  it('active mode throws a CB.5 placeholder error after running the reapers', () => {
+    const listSpy = vi.spyOn(adapter, 'listLaunchDispatchesByState');
     const dispatcher = new LaunchDispatcher({
-      persistence: fakePersistence as unknown as SQLiteAdapter,
+      persistence: adapter,
       ownerId: 'owner-test',
       mode: 'active',
     });
     expect(() => dispatcher.poll()).toThrow(/CB\.5 not implemented/);
-    expect(fakePersistence.listLaunchDispatchesByState).not.toHaveBeenCalled();
+    // Active mode never observes (no aggregate log) — observation is the
+    // observer-mode tail and the reapers don't need it.
+    expect(listSpy).not.toHaveBeenCalled();
+    listSpy.mockRestore();
   });
 
   it('observer mode reports zero counts when the outbox is empty', () => {
@@ -273,6 +274,169 @@ describe('LaunchDispatcher', () => {
 
       const { dispatcher } = makeDispatcher();
       expect(dispatcher.failDispatch(enqueued.id, 'too late')).toBe(false);
+    });
+  });
+
+  describe('reapers', () => {
+    function seed(): void {
+      adapter.saveWorkflow({
+        id: 'wf-r',
+        name: 'wf-r',
+        status: 'running',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      adapter.saveTask('wf-r', {
+        id: 'wf-r/t1',
+        description: 't1',
+        status: 'pending',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: 'wf-r' },
+        execution: {},
+        taskStateVersion: 1,
+      });
+    }
+
+    function dispatcherWithOrchestrator(orchestrator?: { prepareTaskForNewAttempt: ReturnType<typeof vi.fn> }) {
+      const logger = makeLogger();
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        orchestrator,
+        ownerId: 'owner-test',
+        logger,
+        mode: 'observe',
+        maxAttempts: 2,
+      });
+      return { dispatcher, logger };
+    }
+
+    it('reapExpiredLeases resets stale leased rows and emits an audit event per row', () => {
+      seed();
+      const row = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-r/t1',
+        attemptId: 'attempt-reap',
+        workflowId: 'wf-r',
+        generation: 0,
+      });
+      const pastIso = new Date(Date.now() - 60_000).toISOString();
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'leased', dispatch_owner = 'owner-x', fenced_until = ? WHERE id = ?`,
+        [pastIso, row.id],
+      );
+
+      const { dispatcher } = dispatcherWithOrchestrator();
+      const reaped = dispatcher.reapExpiredLeases();
+
+      expect(reaped).toBe(1);
+      expect(adapter.loadLaunchDispatchById(row.id)?.state).toBe('enqueued');
+      const events = adapter.getEvents('wf-r/t1');
+      const reapEvent = events.find((event) => event.eventType === 'task.launch_dispatch_reaped');
+      expect(reapEvent).toBeDefined();
+      expect(JSON.parse(reapEvent!.payload!)).toMatchObject({
+        dispatchId: row.id,
+        reason: 'lease_expired',
+      });
+    });
+
+    it('reapExpiredLeases is a no-op when nothing is stale', () => {
+      seed();
+      const { dispatcher } = dispatcherWithOrchestrator();
+      expect(dispatcher.reapExpiredLeases()).toBe(0);
+    });
+
+    it('abandonStuckLeases abandons acknowledged rows past max attempts and calls prepareTaskForNewAttempt', () => {
+      seed();
+      const row = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-r/t1',
+        attemptId: 'attempt-abandon',
+        workflowId: 'wf-r',
+        generation: 0,
+      });
+      const pastIso = new Date(Date.now() - 60_000).toISOString();
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch
+           SET state = 'acknowledged', dispatch_owner = 'owner-x',
+               fenced_until = ?, attempts_count = 2, last_error = 'startup error'
+         WHERE id = ?`,
+        [pastIso, row.id],
+      );
+
+      const prepare = vi.fn();
+      const { dispatcher } = dispatcherWithOrchestrator({ prepareTaskForNewAttempt: prepare });
+      const abandoned = dispatcher.abandonStuckLeases();
+
+      expect(abandoned).toBe(1);
+      const after = adapter.loadLaunchDispatchById(row.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/Launch dispatch abandoned after 2 attempt/);
+      expect(prepare).toHaveBeenCalledWith('wf-r/t1', 'launch-dispatch-abandoned');
+      const events = adapter.getEvents('wf-r/t1');
+      const failedEvent = events.find((event) => event.eventType === 'task.failed');
+      expect(failedEvent).toBeDefined();
+      expect(JSON.parse(failedEvent!.payload!)).toMatchObject({
+        source: 'launch-dispatcher',
+        dispatchId: row.id,
+      });
+    });
+
+    it('abandonStuckLeases ignores rows still within their fence or below max attempts', () => {
+      seed();
+      const futureRow = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-r/t1',
+        attemptId: 'attempt-future',
+        workflowId: 'wf-r',
+        generation: 0,
+      });
+      const futureIso = new Date(Date.now() + 60_000).toISOString();
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch
+           SET state = 'acknowledged', fenced_until = ?, attempts_count = 5
+         WHERE id = ?`,
+        [futureIso, futureRow.id],
+      );
+
+      const underAttemptRow = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-r/t1',
+        attemptId: 'attempt-under',
+        workflowId: 'wf-r',
+        generation: 0,
+      });
+      const pastIso = new Date(Date.now() - 60_000).toISOString();
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch
+           SET state = 'acknowledged', fenced_until = ?, attempts_count = 1
+         WHERE id = ?`,
+        [pastIso, underAttemptRow.id],
+      );
+
+      const prepare = vi.fn();
+      const { dispatcher } = dispatcherWithOrchestrator({ prepareTaskForNewAttempt: prepare });
+      expect(dispatcher.abandonStuckLeases()).toBe(0);
+      expect(prepare).not.toHaveBeenCalled();
+    });
+
+    it('poll() runs reapers in both observer and active modes', () => {
+      seed();
+      const row = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-r/t1',
+        attemptId: 'attempt-poll',
+        workflowId: 'wf-r',
+        generation: 0,
+      });
+      const pastIso = new Date(Date.now() - 60_000).toISOString();
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'leased', dispatch_owner = 'owner-x', fenced_until = ? WHERE id = ?`,
+        [pastIso, row.id],
+      );
+
+      const observer = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'observer',
+        mode: 'observe',
+      });
+      observer.poll();
+      expect(adapter.loadLaunchDispatchById(row.id)?.state).toBe('enqueued');
     });
   });
 });

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -114,4 +114,165 @@ describe('LaunchDispatcher', () => {
     const observed = logger.records.find((entry) => entry.msg.includes('observed'));
     expect(observed?.fields?.total).toBe(0);
   });
+
+  describe('ack / complete / fail transitions', () => {
+    function seedWorkflowAndTask(): void {
+      adapter.saveWorkflow({
+        id: 'wf-1',
+        name: 'wf-1',
+        status: 'running',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      adapter.saveTask('wf-1', {
+        id: 'wf-1/t1',
+        description: 'one',
+        status: 'pending',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: 'wf-1' },
+        execution: {},
+        taskStateVersion: 1,
+      });
+    }
+
+    function makeDispatcher(logger = makeLogger()) {
+      return {
+        logger,
+        dispatcher: new LaunchDispatcher({
+          persistence: adapter,
+          ownerId: 'owner-test',
+          logger,
+          mode: 'observe',
+        }),
+      };
+    }
+
+    it('ack moves a leased row to acknowledged and logs the transition', () => {
+      seedWorkflowAndTask();
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-1/t1',
+        attemptId: 'attempt-ack',
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+      const leased = adapter.claimLaunchDispatchAtomic({
+        ownerId: 'owner-test',
+        maxConcurrency: 4,
+      });
+      expect(leased?.id).toBe(enqueued.id);
+
+      const { dispatcher, logger } = makeDispatcher();
+      expect(dispatcher.ackDispatch(enqueued.id, 'runner-1')).toBe(true);
+
+      const after = adapter.loadLaunchDispatchById(enqueued.id);
+      expect(after?.state).toBe('acknowledged');
+      expect(after?.dispatchOwner).toBe('runner-1');
+
+      const ackLog = logger.records.find((entry) => entry.msg.includes('ack'));
+      expect(ackLog?.fields?.accepted).toBe(true);
+      expect(ackLog?.fields?.dispatchId).toBe(enqueued.id);
+    });
+
+    it('ack returns false when the row is no longer leased', () => {
+      seedWorkflowAndTask();
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-1/t1',
+        attemptId: 'attempt-ack-stale',
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+
+      const { dispatcher } = makeDispatcher();
+      expect(dispatcher.ackDispatch(enqueued.id, 'runner-1')).toBe(false);
+    });
+
+    it('complete moves an acknowledged row to completed', () => {
+      seedWorkflowAndTask();
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-1/t1',
+        attemptId: 'attempt-complete',
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+
+      const { dispatcher, logger } = makeDispatcher();
+      expect(dispatcher.completeDispatch(enqueued.id)).toBe(true);
+
+      const after = adapter.loadLaunchDispatchById(enqueued.id);
+      expect(after?.state).toBe('completed');
+
+      const log = logger.records.find((entry) => entry.msg.includes('complete'));
+      expect(log?.fields?.accepted).toBe(true);
+    });
+
+    it('complete returns false on an already-terminal row', () => {
+      seedWorkflowAndTask();
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-1/t1',
+        attemptId: 'attempt-complete-twice',
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+      const { dispatcher } = makeDispatcher();
+      expect(dispatcher.completeDispatch(enqueued.id)).toBe(true);
+      expect(dispatcher.completeDispatch(enqueued.id)).toBe(false);
+    });
+
+    it('fail re-enqueues a leased row with the error message and clears the owner', () => {
+      seedWorkflowAndTask();
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-1/t1',
+        attemptId: 'attempt-fail',
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+      adapter.claimLaunchDispatchAtomic({
+        ownerId: 'owner-test',
+        maxConcurrency: 4,
+      });
+
+      const { dispatcher } = makeDispatcher();
+      expect(dispatcher.failDispatch(enqueued.id, new Error('boom'))).toBe(true);
+
+      const after = adapter.loadLaunchDispatchById(enqueued.id);
+      expect(after?.state).toBe('enqueued');
+      expect(after?.lastError).toBe('boom');
+      expect(after?.dispatchOwner).toBeUndefined();
+      expect(after?.fencedUntil).toBeUndefined();
+    });
+
+    it('fail coerces a non-Error value to its string form', () => {
+      seedWorkflowAndTask();
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-1/t1',
+        attemptId: 'attempt-fail-string',
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+      adapter.claimLaunchDispatchAtomic({
+        ownerId: 'owner-test',
+        maxConcurrency: 4,
+      });
+
+      const { dispatcher } = makeDispatcher();
+      expect(dispatcher.failDispatch(enqueued.id, 'plain string')).toBe(true);
+      const after = adapter.loadLaunchDispatchById(enqueued.id);
+      expect(after?.lastError).toBe('plain string');
+    });
+
+    it('fail returns false on a row that is already terminal', () => {
+      seedWorkflowAndTask();
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-1/t1',
+        attemptId: 'attempt-fail-terminal',
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+      adapter.markLaunchDispatchCompleted(enqueued.id);
+
+      const { dispatcher } = makeDispatcher();
+      expect(dispatcher.failDispatch(enqueued.id, 'too late')).toBe(false);
+    });
+  });
 });

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -4,6 +4,20 @@ import type { TaskRunner } from '@invoker/execution-engine';
 import { createExecutionBench } from '@invoker/execution-engine';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
 
+export type LaunchOutboxMode = 'disabled' | 'observe' | 'active';
+
+/**
+ * Resolve the launch-outbox mode for a dispatch call. Explicit
+ * arguments take precedence over the process-wide env-var fallback so
+ * tests can run multiple modes in the same process; the env var is the
+ * production wiring (see `resolveLaunchOutboxMode` in config.ts).
+ */
+function resolveLaunchOutboxMode(explicit?: LaunchOutboxMode): LaunchOutboxMode {
+  if (explicit) return explicit;
+  const raw = (process.env.INVOKER_LAUNCH_OUTBOX ?? '').toLowerCase().trim();
+  return raw === 'active' || raw === 'observe' ? raw : 'disabled';
+}
+
 type GlobalTopupParams = {
   orchestrator: Orchestrator;
   taskExecutor: TaskRunner;
@@ -12,6 +26,16 @@ type GlobalTopupParams = {
   alreadyDispatched?: TaskState[];
   mutationTiming?: WorkflowMutationTiming;
   dispatchMode?: 'await' | 'fire-and-forget';
+  /**
+   * When the durable launch-outbox dispatcher is `'active'`, the
+   * in-process `taskExecutor.executeTasks` call becomes a no-op
+   * because the orchestrator's drainScheduler already enqueues into
+   * `task_launch_dispatch` and the LaunchDispatcher polls and
+   * services that queue. We still walk the rest of the top-up
+   * pipeline (logging, bench marks, return shape) so callers see
+   * the same metadata regardless of mode.
+   */
+  launchOutboxMode?: LaunchOutboxMode;
 };
 
 type MutationTopupParams = {
@@ -24,6 +48,7 @@ type MutationTopupParams = {
   scopedTaskIds?: string[];
   mutationTiming?: WorkflowMutationTiming;
   dispatchMode?: 'await' | 'fire-and-forget';
+  launchOutboxMode?: LaunchOutboxMode;
 };
 
 function runningExecutionKey(task: TaskState): string {
@@ -74,6 +99,7 @@ function dispatchTasks({
   beforeMark,
   afterMark,
   dispatchMode,
+  launchOutboxMode,
 }: {
   taskExecutor: TaskRunner;
   logger?: Logger;
@@ -85,8 +111,22 @@ function dispatchTasks({
   beforeMark: string;
   afterMark: string;
   dispatchMode: 'await' | 'fire-and-forget';
+  launchOutboxMode?: LaunchOutboxMode;
 }): Promise<void> {
   bench(beforeMark);
+  const effectiveMode = resolveLaunchOutboxMode(launchOutboxMode);
+  if (effectiveMode === 'active') {
+    // The durable launch outbox is the dispatcher in active mode. The
+    // orchestrator's drainScheduler already enqueued each runnable into
+    // task_launch_dispatch, and the LaunchDispatcher's poll loop calls
+    // taskExecutor.executeTask(task, dispatchOpts). Calling
+    // taskExecutor.executeTasks(runnable) here would race the outbox.
+    logger?.debug?.(
+      `[global-topup] ${context}: launchOutboxMode=active — outbox dispatcher owns launch (skipping in-process executeTasks)`,
+    );
+    bench(`${afterMark}.skippedForOutbox`, { runnableCount: runnable.length });
+    return Promise.resolve();
+  }
   const run = () => taskExecutor.executeTasks(runnable);
   if (dispatchMode === 'await') {
     return mutationTiming
@@ -95,7 +135,6 @@ function dispatchTasks({
       : Promise.resolve().then(run).then(() => bench(afterMark));
   }
 
-  // TODO: replace app-level workflow mutation leases with atomic DB state transitions plus an outbox for launch/cancel side effects.
   const dispatchPromise = mutationTiming
     ? mutationTiming.span(spanName, { context, runnableCount: runnable.length }, run)
     : Promise.resolve().then(run);
@@ -118,6 +157,7 @@ function executeRunnableTasks({
   mutationTiming,
   spanName,
   dispatchMode,
+  launchOutboxMode,
 }: {
   taskExecutor: TaskRunner;
   logger?: Logger;
@@ -127,6 +167,7 @@ function executeRunnableTasks({
   mutationTiming?: WorkflowMutationTiming;
   spanName: string;
   dispatchMode: 'await' | 'fire-and-forget';
+  launchOutboxMode?: LaunchOutboxMode;
 }): Promise<void> {
   const bench = createDispatchBench(logger, context, runnable, dispatchKind);
   const phasePrefix = dispatchKind === 'scoped'
@@ -143,6 +184,7 @@ function executeRunnableTasks({
     beforeMark: `${phasePrefix}.before`,
     afterMark: `${phasePrefix}.after`,
     dispatchMode,
+    launchOutboxMode,
   });
 }
 
@@ -168,6 +210,7 @@ export async function executeGlobalTopup({
   alreadyDispatched = [],
   mutationTiming,
   dispatchMode = mutationTiming ? 'fire-and-forget' : 'await',
+  launchOutboxMode,
 }: GlobalTopupParams): Promise<TaskState[]> {
   const dedupeKeys = new Set(
     alreadyDispatched
@@ -212,6 +255,7 @@ export async function executeGlobalTopup({
     beforeMark: 'executeGlobalTopup.taskExecutor.executeTasks.before',
     afterMark: 'executeGlobalTopup.taskExecutor.executeTasks.after',
     dispatchMode,
+    launchOutboxMode,
   });
   return runnable;
 }
@@ -230,6 +274,7 @@ export async function dispatchStartedTasksWithGlobalTopup({
   scopedTaskIds,
   mutationTiming,
   dispatchMode = mutationTiming ? 'fire-and-forget' : 'await',
+  launchOutboxMode,
 }: MutationTopupParams): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
   const dispatchable = started.filter(isDispatchableLaunch);
   const scopedTaskIdSet = new Set(scopedTaskIds ?? []);
@@ -255,6 +300,7 @@ export async function dispatchStartedTasksWithGlobalTopup({
       mutationTiming,
       spanName: 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks',
       dispatchMode,
+      launchOutboxMode,
     });
   } else {
     bench('dispatchStartedTasksWithGlobalTopup.noScopedRunnable');
@@ -272,6 +318,7 @@ export async function dispatchStartedTasksWithGlobalTopup({
       mutationTiming,
       spanName: 'dispatchStartedTasksWithGlobalTopup.prestartedTopupExecuteTasks',
       dispatchMode,
+      launchOutboxMode,
     });
   }
   bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.before');
@@ -283,6 +330,7 @@ export async function dispatchStartedTasksWithGlobalTopup({
     alreadyDispatched: [...runnable, ...prestartedTopup],
     mutationTiming,
     dispatchMode,
+    launchOutboxMode,
   });
   const topup = [...prestartedTopup, ...additionalTopup];
   bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.after', { topupCount: topup.length });
@@ -304,6 +352,7 @@ export async function finalizeMutationWithGlobalTopup({
   scopedTaskIds,
   mutationTiming,
   dispatchMode,
+  launchOutboxMode,
 }: MutationTopupParams): Promise<{ started: TaskState[]; topup: TaskState[] }> {
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator,
@@ -315,6 +364,7 @@ export async function finalizeMutationWithGlobalTopup({
     scopedTaskIds,
     mutationTiming,
     dispatchMode,
+    launchOutboxMode,
   });
   return { started, topup };
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -114,6 +114,18 @@ export interface HeadlessDeps {
   signal?: AbortSignal;
   mutationTiming?: WorkflowMutationTiming;
   runtimeServices?: RuntimeServices;
+  /**
+   * CB.7: provider for the owner's long-lived TaskRunner. When the
+   * launch-outbox is `'active'`, `createHeadlessExecutor` reuses this
+   * instance instead of constructing a fresh `TaskRunner` per command.
+   * Returning `null` (or omitting the provider entirely) falls back to
+   * the legacy behaviour (a new TaskRunner each call). This eliminates
+   * Issue 6 (multi-TaskRunner blindness — each runner has its own
+   * `launchingAttemptIds` Set) once the outbox dispatcher is the only
+   * launch path. The fallback also keeps the function safe to call in
+   * environments without an owner-mode TaskRunner (peer mode, tests).
+   */
+  ownerTaskRunnerProvider?: () => TaskRunner | null;
 }
 
 // ── ANSI Helpers ─────────────────────────────────────────────
@@ -196,6 +208,32 @@ export function createHeadlessExecutor(
   deps: HeadlessDeps,
   callbackOverrides?: Partial<ConstructorParameters<typeof TaskRunner>[0]['callbacks']>,
 ): TaskRunner {
+  // CB.7: in active launch-outbox mode the owner's long-lived
+  // TaskRunner is the single launch path (it services the
+  // task_launch_dispatch outbox via LaunchDispatcher). Reusing it
+  // eliminates the multi-TaskRunner blindness from Issue 6 — every
+  // headless command shares the same launchingAttemptIds Set so
+  // duplicate-suppression and dispatch-row ack/complete/fail accounting
+  // all stay coherent. callbackOverrides are intentionally ignored on
+  // this path because the owner's TaskRunner already has its own
+  // production callbacks (persistence writes, renderer deltas, etc.);
+  // per-command callbacks would either duplicate that work or fight it.
+  if (deps.invokerConfig.launchOutboxMode === 'active') {
+    const owner = deps.ownerTaskRunnerProvider?.() ?? null;
+    if (owner) {
+      if (callbackOverrides) {
+        deps.logger?.debug?.(
+          '[headless] createHeadlessExecutor: ignoring callbackOverrides — launchOutboxMode=active reuses owner TaskRunner',
+          { module: 'headless' },
+        );
+      }
+      return owner;
+    }
+    deps.logger?.warn?.(
+      '[headless] createHeadlessExecutor: launchOutboxMode=active but ownerTaskRunnerProvider is unavailable — falling back to per-command TaskRunner',
+      { module: 'headless' },
+    );
+  }
   let executor: TaskRunner;
   executor = new TaskRunner({
     orchestrator: deps.orchestrator,

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -14,7 +14,7 @@
  */
 
 import type { SQLiteAdapter, TaskLaunchDispatch, TaskLaunchDispatchState } from '@invoker/data-store';
-import type { Logger } from '@invoker/contracts';
+import { DISPATCH_MAX_ATTEMPTS, type Logger } from '@invoker/contracts';
 
 export type LaunchDispatcherMode = 'observe' | 'active';
 
@@ -24,13 +24,27 @@ export type LaunchDispatcherPersistence = Pick<
   | 'markLaunchDispatchAcknowledged'
   | 'markLaunchDispatchCompleted'
   | 'markLaunchDispatchFailed'
+  | 'markLaunchDispatchAbandoned'
+  | 'reapExpiredLaunchDispatchLeases'
+  | 'listAbandonableAcknowledgedLeases'
+  | 'logEvent'
 >;
+
+/**
+ * Narrow interface for the orchestrator surface the dispatcher needs.
+ * Avoids widening the dependency on the whole Orchestrator class.
+ */
+export interface LaunchDispatcherOrchestrator {
+  prepareTaskForNewAttempt(taskId: string, reason: string): unknown;
+}
 
 export interface LaunchDispatcherOptions {
   persistence: LaunchDispatcherPersistence;
+  orchestrator?: LaunchDispatcherOrchestrator;
   ownerId: string;
   logger?: Logger;
   mode: LaunchDispatcherMode;
+  maxAttempts?: number;
 }
 
 const OBSERVED_STATES: readonly TaskLaunchDispatchState[] = [
@@ -41,15 +55,19 @@ const OBSERVED_STATES: readonly TaskLaunchDispatchState[] = [
 
 export class LaunchDispatcher {
   private readonly persistence: LaunchDispatcherPersistence;
+  private readonly orchestrator?: LaunchDispatcherOrchestrator;
   private readonly ownerId: string;
   private readonly logger?: Logger;
   private readonly mode: LaunchDispatcherMode;
+  private readonly maxAttempts: number;
 
   constructor(options: LaunchDispatcherOptions) {
     this.persistence = options.persistence;
+    this.orchestrator = options.orchestrator;
     this.ownerId = options.ownerId;
     this.logger = options.logger;
     this.mode = options.mode;
+    this.maxAttempts = options.maxAttempts ?? DISPATCH_MAX_ATTEMPTS;
   }
 
   getMode(): LaunchDispatcherMode {
@@ -61,11 +79,26 @@ export class LaunchDispatcher {
   }
 
   /**
-   * In observe mode, list non-terminal rows and log aggregate counts.
-   * In active mode, dispatch real work — Phase B (CB.5) provides the
-   * implementation; today this throws so the placeholder is visible.
+   * Single dispatcher tick:
+   *
+   *   1. Reap any leased rows whose dispatch lease expired (TaskRunner
+   *      never acked — we want to try again).
+   *   2. Abandon any acknowledged rows whose dispatch lease expired AND
+   *      that have exhausted their retry budget (TaskRunner accepted
+   *      ownership but never completed; report the failure and let the
+   *      orchestrator prepare a fresh attempt).
+   *   3. In observe mode, log the aggregate state counts. In active mode,
+   *      (CB.5) lease and dispatch new work.
+   *
+   * Steps 1 and 2 run in BOTH observer and active modes. They only mutate
+   * already-stuck rows, so they are safe under observer mode — the goal
+   * is to surface the orphan condition with concrete events rather than
+   * letting it accumulate silently.
    */
   poll(): void {
+    this.reapExpiredLeases();
+    this.abandonStuckLeases();
+
     if (this.mode === 'observe') {
       const rows = this.persistence.listLaunchDispatchesByState(OBSERVED_STATES);
       const counts = countByState(rows);
@@ -79,6 +112,84 @@ export class LaunchDispatcher {
       return;
     }
     throw new Error('CB.5 not implemented');
+  }
+
+  /**
+   * Reset every `leased` row whose `fenced_until` has passed back to
+   * `enqueued` so the next `poll()` can re-lease it. Emits a
+   * `task.launch_dispatch_reaped` audit event per reaped row.
+   * Returns the number of rows reaped.
+   */
+  reapExpiredLeases(nowIso?: string): number {
+    const reaped = this.persistence.reapExpiredLaunchDispatchLeases(nowIso);
+    for (const row of reaped) {
+      this.persistence.logEvent?.(row.taskId, 'task.launch_dispatch_reaped', {
+        dispatchId: row.id,
+        attemptId: row.attemptId,
+        attemptsCount: row.attemptsCount,
+        reason: 'lease_expired',
+      });
+    }
+    if (reaped.length > 0) {
+      this.logger?.info?.('[launch-dispatcher] reaped', {
+        ownerId: this.ownerId,
+        count: reaped.length,
+        dispatchIds: reaped.map((row) => row.id),
+        module: 'launch-dispatcher',
+      });
+    }
+    return reaped.length;
+  }
+
+  /**
+   * For every `acknowledged` row whose fence has expired AND whose
+   * attempts_count has reached `maxAttempts`, transition it to
+   * `abandoned`, ask the orchestrator to prepare a fresh attempt, and
+   * emit a real `task.failed` event with a concrete error message.
+   * Returns the number of rows abandoned.
+   */
+  abandonStuckLeases(nowIso?: string): number {
+    const candidates = this.persistence.listAbandonableAcknowledgedLeases({
+      nowIso,
+      maxAttempts: this.maxAttempts,
+    });
+    if (candidates.length === 0) return 0;
+    let abandoned = 0;
+    for (const row of candidates) {
+      const message =
+        `Launch dispatch abandoned after ${row.attemptsCount} attempt(s); ` +
+        `last error: ${row.lastError ?? 'no concrete error recorded'}`;
+      const ok = this.persistence.markLaunchDispatchAbandoned(row.id, message, nowIso);
+      if (!ok) continue;
+      abandoned += 1;
+      this.persistence.logEvent?.(row.taskId, 'task.failed', {
+        source: 'launch-dispatcher',
+        dispatchId: row.id,
+        attemptId: row.attemptId,
+        attemptsCount: row.attemptsCount,
+        error: message,
+      });
+      try {
+        this.orchestrator?.prepareTaskForNewAttempt(row.taskId, 'launch-dispatch-abandoned');
+      } catch (err) {
+        this.logger?.warn?.('[launch-dispatcher] prepareTaskForNewAttempt failed', {
+          ownerId: this.ownerId,
+          taskId: row.taskId,
+          dispatchId: row.id,
+          error: err instanceof Error ? err.message : String(err),
+          module: 'launch-dispatcher',
+        });
+      }
+    }
+    if (abandoned > 0) {
+      this.logger?.warn?.('[launch-dispatcher] abandoned', {
+        ownerId: this.ownerId,
+        count: abandoned,
+        dispatchIds: candidates.map((row) => row.id),
+        module: 'launch-dispatcher',
+      });
+    }
+    return abandoned;
   }
 
   /**

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -14,6 +14,8 @@
  */
 
 import type { SQLiteAdapter, TaskLaunchDispatch, TaskLaunchDispatchState } from '@invoker/data-store';
+import type { LaunchOutboxAck } from '@invoker/execution-engine';
+import type { TaskState } from '@invoker/workflow-core';
 import { DISPATCH_MAX_ATTEMPTS, type Logger } from '@invoker/contracts';
 
 export type LaunchDispatcherMode = 'observe' | 'active';
@@ -27,24 +29,52 @@ export type LaunchDispatcherPersistence = Pick<
   | 'markLaunchDispatchAbandoned'
   | 'reapExpiredLaunchDispatchLeases'
   | 'listAbandonableAcknowledgedLeases'
+  | 'claimLaunchDispatchAtomic'
   | 'logEvent'
 >;
 
 /**
  * Narrow interface for the orchestrator surface the dispatcher needs.
  * Avoids widening the dependency on the whole Orchestrator class.
+ * `getTask` is optional because the reaper path (used in observer
+ * mode and by tests that only exercise abandon/reap) does not need
+ * it; only active-mode dispatch reads it.
  */
 export interface LaunchDispatcherOrchestrator {
   prepareTaskForNewAttempt(taskId: string, reason: string): unknown;
+  getTask?(taskId: string): TaskState | undefined;
+}
+
+/**
+ * Narrow interface for the TaskRunner surface the dispatcher hands
+ * leased rows to. Defined here (rather than `Pick<TaskRunner, ...>`)
+ * because @invoker/app already depends on @invoker/execution-engine
+ * but we want to keep the surface area minimal and testable.
+ */
+export interface LaunchDispatcherTaskRunner {
+  executeTask(
+    task: TaskState,
+    dispatchOpts?: { dispatchId: number; launchOutbox: LaunchOutboxAck },
+  ): Promise<void>;
 }
 
 export interface LaunchDispatcherOptions {
   persistence: LaunchDispatcherPersistence;
   orchestrator?: LaunchDispatcherOrchestrator;
+  /**
+   * Provider for the current TaskRunner. A function (rather than a
+   * direct reference) so that rebuildTaskRunner() in main.ts can
+   * swap the runner instance without re-creating the dispatcher.
+   * Returning `null` short-circuits the active-mode dispatch loop
+   * (logged as a warning).
+   */
+  taskRunnerProvider?: () => LaunchDispatcherTaskRunner | null;
   ownerId: string;
   logger?: Logger;
   mode: LaunchDispatcherMode;
   maxAttempts?: number;
+  maxConcurrency?: number;
+  maxLeasesPerPoll?: number;
 }
 
 const OBSERVED_STATES: readonly TaskLaunchDispatchState[] = [
@@ -56,18 +86,26 @@ const OBSERVED_STATES: readonly TaskLaunchDispatchState[] = [
 export class LaunchDispatcher {
   private readonly persistence: LaunchDispatcherPersistence;
   private readonly orchestrator?: LaunchDispatcherOrchestrator;
+  private readonly taskRunnerProvider?: () => LaunchDispatcherTaskRunner | null;
   private readonly ownerId: string;
   private readonly logger?: Logger;
   private readonly mode: LaunchDispatcherMode;
   private readonly maxAttempts: number;
+  private readonly maxConcurrency: number;
+  private readonly maxLeasesPerPoll: number;
 
   constructor(options: LaunchDispatcherOptions) {
     this.persistence = options.persistence;
     this.orchestrator = options.orchestrator;
+    this.taskRunnerProvider = options.taskRunnerProvider;
     this.ownerId = options.ownerId;
     this.logger = options.logger;
     this.mode = options.mode;
     this.maxAttempts = options.maxAttempts ?? DISPATCH_MAX_ATTEMPTS;
+    this.maxConcurrency = options.maxConcurrency ?? 16;
+    // Bound a single poll's work so the dispatcher cannot starve other
+    // owner-loop ticks; the leftover rows are picked up on the next tick.
+    this.maxLeasesPerPoll = options.maxLeasesPerPoll ?? 32;
   }
 
   getMode(): LaunchDispatcherMode {
@@ -111,7 +149,62 @@ export class LaunchDispatcher {
       });
       return;
     }
-    throw new Error('CB.5 not implemented');
+    this.dispatchActive();
+  }
+
+  /**
+   * Active-mode dispatch loop. Lease as many enqueued rows as capacity
+   * allows (bounded by `maxLeasesPerPoll`) and hand each one to the
+   * TaskRunner. The TaskRunner ack/complete/fail flow drives the rest
+   * of the lifecycle; if the JS promise drops mid-flight, the durable
+   * outbox row stays leased and the next poll's `reapExpiredLeases`
+   * reclaims it after `DISPATCH_LEASE_MS`.
+   */
+  private dispatchActive(): void {
+    const runner = this.taskRunnerProvider?.() ?? null;
+    if (!runner) {
+      this.logger?.warn?.('[launch-dispatcher] active mode without taskRunner — skipping dispatch', {
+        ownerId: this.ownerId,
+        module: 'launch-dispatcher',
+      });
+      return;
+    }
+    let dispatched = 0;
+    while (dispatched < this.maxLeasesPerPoll) {
+      const leased = this.persistence.claimLaunchDispatchAtomic({
+        ownerId: this.ownerId,
+        maxConcurrency: this.maxConcurrency,
+      });
+      if (!leased) break;
+      dispatched += 1;
+      const task = this.orchestrator?.getTask?.(leased.taskId);
+      if (!task) {
+        this.failDispatch(
+          leased.id,
+          new Error(`Task ${leased.taskId} missing from orchestrator state at dispatch time`),
+        );
+        continue;
+      }
+      // Fire-and-forget within the loop: the dispatch row is the durable
+      // anchor. If the promise drops, the next poll reaps the lease and
+      // tries again; if it completes, the runner calls completeDispatch.
+      void runner
+        .executeTask(task, { dispatchId: leased.id, launchOutbox: this })
+        .catch((err) => {
+          // The runner's outer catch should already have called failDispatch;
+          // this is a defensive backstop for the case the runner itself threw
+          // before reaching its own catch (e.g. synchronous setup error).
+          this.failDispatch(leased.id, err);
+        });
+    }
+    if (dispatched > 0) {
+      this.logger?.info?.('[launch-dispatcher] dispatched', {
+        ownerId: this.ownerId,
+        dispatched,
+        maxLeasesPerPoll: this.maxLeasesPerPoll,
+        module: 'launch-dispatcher',
+      });
+    }
   }
 
   /**

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -18,8 +18,16 @@ import type { Logger } from '@invoker/contracts';
 
 export type LaunchDispatcherMode = 'observe' | 'active';
 
+export type LaunchDispatcherPersistence = Pick<
+  SQLiteAdapter,
+  | 'listLaunchDispatchesByState'
+  | 'markLaunchDispatchAcknowledged'
+  | 'markLaunchDispatchCompleted'
+  | 'markLaunchDispatchFailed'
+>;
+
 export interface LaunchDispatcherOptions {
-  persistence: Pick<SQLiteAdapter, 'listLaunchDispatchesByState'>;
+  persistence: LaunchDispatcherPersistence;
   ownerId: string;
   logger?: Logger;
   mode: LaunchDispatcherMode;
@@ -32,7 +40,7 @@ const OBSERVED_STATES: readonly TaskLaunchDispatchState[] = [
 ];
 
 export class LaunchDispatcher {
-  private readonly persistence: LaunchDispatcherOptions['persistence'];
+  private readonly persistence: LaunchDispatcherPersistence;
   private readonly ownerId: string;
   private readonly logger?: Logger;
   private readonly mode: LaunchDispatcherMode;
@@ -46,6 +54,10 @@ export class LaunchDispatcher {
 
   getMode(): LaunchDispatcherMode {
     return this.mode;
+  }
+
+  getOwnerId(): string {
+    return this.ownerId;
   }
 
   /**
@@ -67,6 +79,62 @@ export class LaunchDispatcher {
       return;
     }
     throw new Error('CB.5 not implemented');
+  }
+
+  /**
+   * Transition a leased dispatch row to acknowledged. Called by the
+   * TaskRunner at the top of {@link executeTask} once it has accepted
+   * ownership of the launch. Returns false when the row is no longer
+   * in `leased` (e.g. it was reaped first), in which case the runner
+   * should bail out without starting the executor.
+   */
+  ackDispatch(dispatchId: number, runnerId: string): boolean {
+    const ok = this.persistence.markLaunchDispatchAcknowledged(dispatchId, runnerId);
+    this.logger?.info?.('[launch-dispatcher] ack', {
+      ownerId: this.ownerId,
+      dispatchId,
+      runnerId,
+      accepted: ok,
+      module: 'launch-dispatcher',
+    });
+    return ok;
+  }
+
+  /**
+   * Transition an acknowledged dispatch row to completed. Called by the
+   * TaskRunner once {@link markTaskRunningAfterLaunch} has succeeded
+   * (the executor handle is live and the task is in the executing
+   * phase). Returns false when the row is already terminal.
+   */
+  completeDispatch(dispatchId: number): boolean {
+    const ok = this.persistence.markLaunchDispatchCompleted(dispatchId);
+    this.logger?.info?.('[launch-dispatcher] complete', {
+      ownerId: this.ownerId,
+      dispatchId,
+      accepted: ok,
+      module: 'launch-dispatcher',
+    });
+    return ok;
+  }
+
+  /**
+   * Record a launch failure by re-enqueuing the dispatch row and storing
+   * the error message in `last_error`. The dispatcher's reaper /
+   * abandon-after-N-attempts logic decides whether to retry or abandon.
+   * Returns false when the row is already terminal.
+   */
+  failDispatch(dispatchId: number, error: unknown): boolean {
+    const message =
+      error instanceof Error ? error.message : String(error ?? 'unknown launch error');
+    const ok = this.persistence.markLaunchDispatchFailed(dispatchId, message);
+    this.logger?.info?.('[launch-dispatcher] fail', {
+      ownerId: this.ownerId,
+      dispatchId,
+      error: message,
+      accepted: ok,
+      module: 'launch-dispatcher',
+    });
+    return ok;
   }
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2581,6 +2581,20 @@ function createEmbeddedTerminalBackendFromConfig(
                   });
                   const { launchAgeMs, launchStalled } = launchStall;
                   if (launchStalled) {
+                    // CB.6: in active launch-outbox mode the LaunchDispatcher's
+                    // abandonStuckLeases is the authoritative recovery path —
+                    // it writes a concrete `task.failed` event (with the real
+                    // reason, not the misleading "60s without a spawned
+                    // execution handle") and re-prepares the task for a fresh
+                    // attempt. The legacy watchdog action below would double-
+                    // fire and emit a misleading error, so we skip it.
+                    if (invokerConfig.launchOutboxMode === 'active') {
+                      logger.debug?.(
+                        `[launch-stall] suppressed for task="${task.id}" launchAgeMs=${launchAgeMs} — launchOutboxMode=active`,
+                        { module: 'db-poll' },
+                      );
+                      continue;
+                    }
                     const launchError =
                       `Launch stalled: task remained in running/launching for ${Math.floor(launchingStallTimeoutMs / 1000)}s without a spawned execution handle`;
                     logger.info(

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2769,6 +2769,7 @@ function createEmbeddedTerminalBackendFromConfig(
       if (invokerConfig.launchOutboxMode && invokerConfig.launchOutboxMode !== 'disabled') {
         launchDispatcher = new LaunchDispatcher({
           persistence,
+          orchestrator,
           ownerId: workflowMutationOwnerId,
           logger,
           mode: invokerConfig.launchOutboxMode as LaunchDispatcherMode,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -803,6 +803,14 @@ if (isHeadless) {
         orchestrator, persistence, executorRegistry, messageBus,
         repoRoot, invokerConfig, initServices, wireSlackBot,
         commandService,
+        // CB.7: expose the owner's long-lived TaskRunner so
+        // createHeadlessExecutor can short-circuit in active mode
+        // instead of building a fresh runner per command. Reading via
+        // a function (not a captured reference) so rebuildTaskRunner()
+        // is picked up automatically. Returns null while the owner is
+        // still bootstrapping; createHeadlessExecutor falls back to a
+        // per-command runner in that case (logged as a warning).
+        ownerTaskRunnerProvider: () => taskExecutor,
         getUiPerfStats: () => ({
           ts: new Date().toISOString(),
           mainDeltaToUi: 0,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -803,14 +803,6 @@ if (isHeadless) {
         orchestrator, persistence, executorRegistry, messageBus,
         repoRoot, invokerConfig, initServices, wireSlackBot,
         commandService,
-        // CB.7: expose the owner's long-lived TaskRunner so
-        // createHeadlessExecutor can short-circuit in active mode
-        // instead of building a fresh runner per command. Reading via
-        // a function (not a captured reference) so rebuildTaskRunner()
-        // is picked up automatically. Returns null while the owner is
-        // still bootstrapping; createHeadlessExecutor falls back to a
-        // per-command runner in that case (logged as a warning).
-        ownerTaskRunnerProvider: () => taskExecutor,
         getUiPerfStats: () => ({
           ts: new Date().toISOString(),
           mainDeltaToUi: 0,

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2770,9 +2770,14 @@ function createEmbeddedTerminalBackendFromConfig(
         launchDispatcher = new LaunchDispatcher({
           persistence,
           orchestrator,
+          // taskExecutor is re-built by rebuildTaskRunner(); read via
+          // a provider so the dispatcher always picks up the current
+          // instance instead of capturing a stale reference.
+          taskRunnerProvider: () => taskExecutor,
           ownerId: workflowMutationOwnerId,
           logger,
           mode: invokerConfig.launchOutboxMode as LaunchDispatcherMode,
+          maxConcurrency: effectiveMaxConcurrency,
         });
       }
     } else {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -428,10 +428,157 @@ describe('SQLiteAdapter', () => {
       expect(liveAfter?.state).toBe('leased');
     });
 
-    it('claimLaunchDispatchAtomic is a CB.1 placeholder that throws', () => {
-      expect(() =>
-        adapter.claimLaunchDispatchAtomic({ ownerId: 'runner-x', maxConcurrency: 1 }),
-      ).toThrow('CB.1 not implemented');
+    describe('claimLaunchDispatchAtomic', () => {
+      it('leases the only enqueued row when capacity allows', () => {
+        setupWorkflowAndTask();
+        const enqueued = adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t1',
+          attemptId: 'attempt-claim-1',
+          workflowId: 'wf-launch',
+          generation: 0,
+        });
+
+        const claimed = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-1',
+          maxConcurrency: 4,
+        });
+
+        expect(claimed?.id).toBe(enqueued.id);
+        expect(claimed?.state).toBe('leased');
+        expect(claimed?.dispatchOwner).toBe('runner-1');
+        expect(claimed?.attemptsCount).toBe(1);
+        expect(claimed?.fencedUntil).toBeDefined();
+        expect(claimed?.leasedAt).toBeDefined();
+      });
+
+      it('returns undefined when no enqueued rows exist', () => {
+        setupWorkflowAndTask();
+        const claimed = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-1',
+          maxConcurrency: 4,
+        });
+        expect(claimed).toBeUndefined();
+      });
+
+      it('does not double-lease an already-leased row', () => {
+        setupWorkflowAndTask();
+        adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t1',
+          attemptId: 'attempt-conflict',
+          workflowId: 'wf-launch',
+          generation: 0,
+        });
+
+        const first = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-a',
+          maxConcurrency: 4,
+        });
+        const second = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-b',
+          maxConcurrency: 4,
+        });
+
+        expect(first?.dispatchOwner).toBe('runner-a');
+        expect(second).toBeUndefined();
+      });
+
+      it('orders by priority (high, normal, low) then by insertion order', () => {
+        setupWorkflowAndTask();
+        const normal1 = adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t1',
+          attemptId: 'attempt-normal-1',
+          workflowId: 'wf-launch',
+          generation: 0,
+        });
+        adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t1',
+          attemptId: 'attempt-low',
+          workflowId: 'wf-launch',
+          priority: 'low',
+          generation: 0,
+        });
+        const high = adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t1',
+          attemptId: 'attempt-high',
+          workflowId: 'wf-launch',
+          priority: 'high',
+          generation: 0,
+        });
+
+        const firstClaim = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-pri',
+          maxConcurrency: 4,
+        });
+        const secondClaim = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-pri',
+          maxConcurrency: 4,
+        });
+        const thirdClaim = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-pri',
+          maxConcurrency: 4,
+        });
+
+        expect(firstClaim?.id).toBe(high.id);
+        expect(secondClaim?.id).toBe(normal1.id);
+        expect(thirdClaim?.attemptId).toBe('attempt-low');
+      });
+
+      it('enforces maxConcurrency by counting leased + acknowledged rows', () => {
+        setupWorkflowAndTask();
+        adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t1',
+          attemptId: 'attempt-cap-1',
+          workflowId: 'wf-launch',
+          generation: 0,
+        });
+        adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t1',
+          attemptId: 'attempt-cap-2',
+          workflowId: 'wf-launch',
+          generation: 0,
+        });
+
+        const first = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-c',
+          maxConcurrency: 1,
+        });
+        expect(first?.attemptId).toBe('attempt-cap-1');
+
+        const blocked = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-c',
+          maxConcurrency: 1,
+        });
+        expect(blocked).toBeUndefined();
+
+        adapter.markLaunchDispatchAcknowledged(first!.id, 'runner-c');
+        const stillBlocked = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-c',
+          maxConcurrency: 1,
+        });
+        expect(stillBlocked).toBeUndefined();
+
+        adapter.markLaunchDispatchCompleted(first!.id);
+        const unblocked = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-c',
+          maxConcurrency: 1,
+        });
+        expect(unblocked?.attemptId).toBe('attempt-cap-2');
+      });
+
+      it('returns undefined when maxConcurrency is zero', () => {
+        setupWorkflowAndTask();
+        adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t1',
+          attemptId: 'attempt-zero',
+          workflowId: 'wf-launch',
+          generation: 0,
+        });
+        const claimed = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-z',
+          maxConcurrency: 0,
+        });
+        expect(claimed).toBeUndefined();
+      });
     });
   });
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -29,6 +29,7 @@ import type {
   WorkflowRollup,
   WorkflowRollupTaskSummary,
 } from '@invoker/workflow-core';
+import { DISPATCH_LEASE_MS } from '@invoker/contracts';
 import {
   computeWorkflowRollupFromSummaries,
   isDiscardedAttempt,
@@ -2945,12 +2946,64 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return rows.map((row) => this.rowToTaskLaunchDispatch(row));
   }
 
-  claimLaunchDispatchAtomic(_options: {
+  /**
+   * Atomic capacity-gated lease of the next enqueued dispatch row.
+   *
+   * Selects the oldest enqueued row (priority high < normal < low, then id
+   * ascending) and transitions it to `leased` only if the current count of
+   * `leased | acknowledged` rows is below `maxConcurrency`. Wrapped in an
+   * IMMEDIATE transaction so concurrent dispatchers cannot double-lease.
+   * Returns the freshly leased row or `undefined` when nothing is enqueued,
+   * capacity is exhausted, or another dispatcher beat us to it.
+   */
+  claimLaunchDispatchAtomic(options: {
     ownerId: string;
     maxConcurrency: number;
     nowIso?: string;
   }): TaskLaunchDispatch | undefined {
-    throw new Error('CB.1 not implemented');
+    if (options.maxConcurrency <= 0) return undefined;
+    const now = options.nowIso ?? new Date().toISOString();
+    const fencedUntil = new Date(
+      new Date(now).getTime() + DISPATCH_LEASE_MS,
+    ).toISOString();
+    return this.runTransaction(() => {
+      const activeRow = this.queryOne(
+        `SELECT COUNT(*) AS active FROM task_launch_dispatch
+           WHERE state IN ('leased', 'acknowledged')`,
+      );
+      const active = Number(activeRow?.active ?? 0);
+      if (active >= options.maxConcurrency) return undefined;
+      const candidate = this.queryOne(
+        `SELECT id FROM task_launch_dispatch
+           WHERE state = 'enqueued'
+           ORDER BY CASE priority
+             WHEN 'high' THEN 0
+             WHEN 'normal' THEN 1
+             ELSE 2
+           END, id
+           LIMIT 1`,
+      );
+      if (!candidate || candidate.id == null) return undefined;
+      const candidateId = Number(candidate.id);
+      this.execRun(
+        `UPDATE task_launch_dispatch
+           SET state = 'leased',
+               dispatch_owner = ?,
+               leased_at = ?,
+               fenced_until = ?,
+               attempts_count = attempts_count + 1
+         WHERE id = ?
+           AND state = 'enqueued'`,
+        [options.ownerId, now, fencedUntil, candidateId],
+      );
+      const updated = (this.db.getRowsModified?.() ?? 0) > 0;
+      if (!updated) return undefined;
+      const row = this.queryOne(
+        'SELECT * FROM task_launch_dispatch WHERE id = ?',
+        [candidateId],
+      );
+      return row ? this.rowToTaskLaunchDispatch(row) : undefined;
+    });
   }
 
   markLaunchDispatchAcknowledged(
@@ -2960,7 +3013,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
   ): boolean {
     const now = nowIso ?? new Date().toISOString();
     const fencedUntil = new Date(
-      new Date(now).getTime() + 30_000,
+      new Date(now).getTime() + DISPATCH_LEASE_MS,
     ).toISOString();
     this.execRun(
       `UPDATE task_launch_dispatch

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3059,6 +3059,54 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return (this.db.getRowsModified?.() ?? 0) > 0;
   }
 
+  /**
+   * Return the dispatch rows in `acknowledged` whose fence has expired AND
+   * whose `attempts_count` has reached `maxAttempts`. These are the rows
+   * that the dispatcher should abandon and report to the orchestrator —
+   * they have already burned through their retry budget without the
+   * TaskRunner finishing the launch.
+   */
+  listAbandonableAcknowledgedLeases(options: {
+    nowIso?: string;
+    maxAttempts: number;
+  }): TaskLaunchDispatch[] {
+    const now = options.nowIso ?? new Date().toISOString();
+    const rows = this.queryAll(
+      `SELECT * FROM task_launch_dispatch
+         WHERE state = 'acknowledged'
+           AND fenced_until IS NOT NULL
+           AND fenced_until < ?
+           AND attempts_count >= ?
+         ORDER BY id ASC`,
+      [now, options.maxAttempts],
+    );
+    return rows.map((row) => this.rowToTaskLaunchDispatch(row));
+  }
+
+  /**
+   * Terminal abandon: row leaves the live set. Returns false when the row
+   * is already terminal so callers can treat a race as a no-op.
+   */
+  markLaunchDispatchAbandoned(
+    id: number,
+    errorMessage: string,
+    nowIso?: string,
+  ): boolean {
+    const now = nowIso ?? new Date().toISOString();
+    this.execRun(
+      `UPDATE task_launch_dispatch
+         SET state = 'abandoned',
+             completed_at = ?,
+             last_error = ?,
+             dispatch_owner = NULL,
+             fenced_until = NULL
+       WHERE id = ?
+         AND state NOT IN ('completed', 'abandoned')`,
+      [now, errorMessage, id],
+    );
+    return (this.db.getRowsModified?.() ?? 0) > 0;
+  }
+
   reapExpiredLaunchDispatchLeases(nowIso?: string): TaskLaunchDispatch[] {
     const now = nowIso ?? new Date().toISOString();
     return this.runTransaction(() => {

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { TaskState } from '@invoker/workflow-core';
+import type { WorkResponse, Logger } from '@invoker/contracts';
+import { TaskRunner, type LaunchOutboxAck } from '../task-runner.js';
+
+function makeLogger(): Logger {
+  const noop = () => {};
+  const logger: Logger = {
+    debug: vi.fn(noop),
+    info: vi.fn(noop),
+    warn: vi.fn(noop),
+    error: vi.fn(noop),
+    child: vi.fn(),
+  };
+  (logger.child as any).mockReturnValue(logger);
+  return logger;
+}
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id: 'wf-d/t1',
+    description: 'launch-dispatch test task',
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date(),
+    config: { workflowId: 'wf-d' },
+    execution: { selectedAttemptId: 'attempt-1', generation: 1, phase: 'launching' },
+    ...overrides,
+  } as TaskState;
+}
+
+interface RunnerEnv {
+  runner: TaskRunner;
+  orchestrator: {
+    getTask: ReturnType<typeof vi.fn>;
+    markTaskRunningAfterLaunch: ReturnType<typeof vi.fn>;
+    handleWorkerResponse: ReturnType<typeof vi.fn>;
+    deferTask: ReturnType<typeof vi.fn>;
+  };
+  executor: {
+    start: ReturnType<typeof vi.fn>;
+    onComplete: ReturnType<typeof vi.fn>;
+    onOutput: ReturnType<typeof vi.fn>;
+    onHeartbeat: ReturnType<typeof vi.fn>;
+    kill: ReturnType<typeof vi.fn>;
+    destroyAll: ReturnType<typeof vi.fn>;
+    type: string;
+  };
+  triggerComplete: () => void;
+}
+
+function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}): RunnerEnv {
+  let completeCallback: ((response: WorkResponse) => void) | undefined;
+  const executor = {
+    type: 'worktree',
+    start: vi.fn().mockImplementation(async (request: any) => {
+      if (options.startThrows) throw options.startThrows;
+      return {
+        executionId: `exec-${request.actionId}`,
+        taskId: request.actionId,
+        workspacePath: '/tmp/mock-ws',
+        branch: `experiment/${request.actionId}-mock`,
+      };
+    }),
+    onComplete: vi.fn().mockImplementation((_h: any, cb: any) => {
+      completeCallback = cb;
+      return () => {};
+    }),
+    onOutput: vi.fn().mockReturnValue(() => {}),
+    onHeartbeat: vi.fn().mockReturnValue(() => {}),
+    kill: vi.fn().mockResolvedValue(undefined),
+    destroyAll: vi.fn().mockResolvedValue(undefined),
+  };
+  const orchestrator = {
+    getTask: vi.fn().mockReturnValue(task),
+    getAllTasks: vi.fn().mockReturnValue([task]),
+    markTaskRunningAfterLaunch: vi.fn().mockReturnValue(true),
+    handleWorkerResponse: vi.fn().mockReturnValue([]),
+    deferTask: vi.fn(),
+  };
+  const runner = new TaskRunner({
+    orchestrator: orchestrator as any,
+    persistence: {
+      updateTask: vi.fn(),
+      loadAttempts: vi.fn().mockReturnValue([]),
+      logEvent: vi.fn(),
+    } as any,
+    executorRegistry: {
+      get: vi.fn().mockReturnValue(executor),
+      getAll: vi.fn().mockReturnValue([['worktree', executor]]),
+      getDefault: vi.fn().mockReturnValue(executor),
+    } as any,
+    cwd: '/tmp/test-runner-dispatch',
+    logger: makeLogger(),
+  });
+  return {
+    runner,
+    orchestrator,
+    executor,
+    triggerComplete: () => {
+      completeCallback?.({
+        requestId: 'req',
+        actionId: task.id,
+        attemptId: task.execution.selectedAttemptId,
+        executionGeneration: task.execution.generation ?? 0,
+        status: 'completed',
+        outputs: { exitCode: 0 },
+      });
+    },
+  };
+}
+
+function makeLaunchOutbox(): LaunchOutboxAck & {
+  ackCalls: Array<[number, string]>;
+  completeCalls: number[];
+  failCalls: Array<[number, unknown]>;
+} {
+  const ackCalls: Array<[number, string]> = [];
+  const completeCalls: number[] = [];
+  const failCalls: Array<[number, unknown]> = [];
+  return {
+    ackCalls,
+    completeCalls,
+    failCalls,
+    ackDispatch(id, runnerId) {
+      ackCalls.push([id, runnerId]);
+      return true;
+    },
+    completeDispatch(id) {
+      completeCalls.push(id);
+      return true;
+    },
+    failDispatch(id, err) {
+      failCalls.push([id, err]);
+      return true;
+    },
+  };
+}
+
+describe('TaskRunner launch-dispatch wiring', () => {
+  it('acks dispatch at the top of executeTask and proceeds to executor.start when accepted', async () => {
+    const task = makeTask();
+    const env = buildRunnerEnv(task, { startThrows: new Error('isolated start sentinel') });
+    const launchOutbox = makeLaunchOutbox();
+
+    await env.runner.executeTask(task, { dispatchId: 42, launchOutbox });
+
+    expect(launchOutbox.ackCalls).toHaveLength(1);
+    expect(launchOutbox.ackCalls[0][0]).toBe(42);
+    expect(launchOutbox.ackCalls[0][1]).toMatch(/^[0-9a-f-]+$/);
+    expect(env.executor.start).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call the executor when ackDispatch returns false', async () => {
+    const task = makeTask();
+    const env = buildRunnerEnv(task);
+    const launchOutbox = makeLaunchOutbox();
+    launchOutbox.ackDispatch = vi.fn().mockReturnValue(false);
+
+    await env.runner.executeTask(task, { dispatchId: 99, launchOutbox });
+
+    expect(env.executor.start).not.toHaveBeenCalled();
+    expect(env.orchestrator.markTaskRunningAfterLaunch).not.toHaveBeenCalled();
+    expect(launchOutbox.completeCalls).toHaveLength(0);
+    expect(launchOutbox.failCalls).toHaveLength(0);
+  });
+
+  it('calls failDispatch when the executor start throws', async () => {
+    const task = makeTask();
+    const env = buildRunnerEnv(task, { startThrows: new Error('startup explosion') });
+    const launchOutbox = makeLaunchOutbox();
+
+    await env.runner.executeTask(task, { dispatchId: 7, launchOutbox });
+
+    expect(launchOutbox.ackCalls).toHaveLength(1);
+    expect(launchOutbox.completeCalls).toHaveLength(0);
+    expect(launchOutbox.failCalls).toHaveLength(1);
+    expect(launchOutbox.failCalls[0][0]).toBe(7);
+    const failArg = launchOutbox.failCalls[0][1];
+    expect(failArg).toBeInstanceOf(Error);
+    expect((failArg as Error).message).toMatch(/startup explosion/);
+  });
+
+  it('is a no-op for the outbox when dispatchOpts is omitted', async () => {
+    const task = makeTask();
+    const env = buildRunnerEnv(task, { startThrows: new Error('start sentinel') });
+    const launchOutbox = makeLaunchOutbox();
+
+    await env.runner.executeTask(task);
+
+    expect(launchOutbox.ackCalls).toHaveLength(0);
+    expect(launchOutbox.completeCalls).toHaveLength(0);
+    expect(launchOutbox.failCalls).toHaveLength(0);
+    expect(env.executor.start).toHaveBeenCalled();
+  });
+
+  it('fails the dispatch and short-circuits when the attempt is already launching', async () => {
+    const task = makeTask();
+    const env = buildRunnerEnv(task, { startThrows: new Error('unused') });
+    (env.runner as any).launchingAttemptIds.add('attempt-1');
+    const launchOutbox = makeLaunchOutbox();
+
+    await env.runner.executeTask(task, { dispatchId: 123, launchOutbox });
+
+    expect(env.executor.start).not.toHaveBeenCalled();
+    expect(launchOutbox.ackCalls).toHaveLength(0);
+    expect(launchOutbox.failCalls).toHaveLength(1);
+    expect(launchOutbox.failCalls[0][0]).toBe(123);
+    expect((launchOutbox.failCalls[0][1] as Error).message).toMatch(/Duplicate launch suppressed/);
+  });
+});

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -169,6 +169,31 @@ const NOOP_LOGGER: Logger = {
   child: () => NOOP_LOGGER,
 };
 
+// ── Launch outbox ─────────────────────────────────────────
+
+/**
+ * Narrow interface for the launch-handoff outbox surface that
+ * `executeTask` calls into. Defined here (rather than imported from
+ * `@invoker/app`) to avoid a layering cycle: the execution engine
+ * never depends on the app shell, the app provides this implementation
+ * via the LaunchDispatcher.
+ *
+ * Each method MUST be safe to call even if the dispatch row was reaped
+ * between the dispatcher's lease and the runner's call — the
+ * persistence layer returns false in that case and the runner bails
+ * out without starting the executor.
+ */
+export interface LaunchOutboxAck {
+  ackDispatch(dispatchId: number, runnerId: string): boolean;
+  completeDispatch(dispatchId: number): boolean;
+  failDispatch(dispatchId: number, error: unknown): boolean;
+}
+
+export interface LaunchDispatchOptions {
+  dispatchId: number;
+  launchOutbox: LaunchOutboxAck;
+}
+
 // ── Config ────────────────────────────────────────────────
 
 export interface TaskRunnerConfig {
@@ -455,7 +480,7 @@ export class TaskRunner {
     return false;
   }
 
-  async executeTask(task: TaskState): Promise<void> {
+  async executeTask(task: TaskState, dispatchOpts?: LaunchDispatchOptions): Promise<void> {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} TaskRunner.executeTask BEGIN taskId=${task.id} isMergeNode=${Boolean(task.config.isMergeNode)} status=${task.status}`,
     );
@@ -472,16 +497,38 @@ export class TaskRunner {
         `[TaskRunner] executeTask skipping duplicate launch for task=${task.id} attempt=${attemptId}`,
       );
       bench('executeTask.duplicateSkipped');
+      if (dispatchOpts) {
+        // Another runner already owns this attempt — release the dispatch
+        // row so the dispatcher can re-queue if needed instead of orphaning.
+        dispatchOpts.launchOutbox.failDispatch(
+          dispatchOpts.dispatchId,
+          new Error('Duplicate launch suppressed in TaskRunner'),
+        );
+      }
       return;
+    }
+    if (dispatchOpts) {
+      const accepted = dispatchOpts.launchOutbox.ackDispatch(
+        dispatchOpts.dispatchId,
+        this.runnerInstanceId,
+      );
+      if (!accepted) {
+        this.logger.warn(
+          `[TaskRunner] launch dispatch ack rejected (lease reaped?) for task=${task.id} attempt=${attemptId} dispatchId=${dispatchOpts.dispatchId}`,
+        );
+        bench('executeTask.dispatchAckRejected');
+        return;
+      }
     }
     this.logger.info(
       `[TaskRunner] launch accepted task=${task.id} attempt=${attemptId} status=${task.status} ` +
-        `phase=${task.execution.phase ?? 'none'} generation=${startGeneration}`,
+        `phase=${task.execution.phase ?? 'none'} generation=${startGeneration} ` +
+        `dispatchId=${dispatchOpts?.dispatchId ?? 'none'}`,
     );
     this.launchingAttemptIds.add(attemptId);
     this.callbacks.onLaunchAccepted?.(task.id);
     try {
-      await this.executeTaskInner(task, attemptId, bench);
+      await this.executeTaskInner(task, attemptId, bench, dispatchOpts);
       bench('executeTask.innerReturned');
     } catch (err) {
       bench('executeTask.failed', {
@@ -508,6 +555,9 @@ export class TaskRunner {
       }
 
       this.logger.error(`[TaskRunner] executeTask failed for task=${task.id}`, { err });
+      if (dispatchOpts) {
+        dispatchOpts.launchOutbox.failDispatch(dispatchOpts.dispatchId, err);
+      }
       const launchFailedAt = new Date();
       try {
         const latest = this.orchestrator.getTask(task.id);
@@ -559,6 +609,7 @@ export class TaskRunner {
     task: TaskState,
     attemptId: string,
     bench: (phase: string, metadata?: Record<string, unknown>) => void = () => {},
+    dispatchOpts?: LaunchDispatchOptions,
   ): Promise<void> {
     bench('executeTaskInner.begin', {
       dependencyCount: task.dependencies.length,
@@ -908,6 +959,9 @@ export class TaskRunner {
       return;
     }
     bench('markTaskRunningAfterLaunch.accepted');
+    if (dispatchOpts) {
+      dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId);
+    }
 
     // Persist execution metadata immediately at task start — all fields explicit
     {


### PR DESCRIPTION
## Summary

Third PR in the launch-handoff re-architecture stack. Stacked on top of #871 (Phase A).

Makes the `task_launch_dispatch` outbox the **authoritative** dispatcher when `INVOKER_LAUNCH_OUTBOX=active`. The legacy fire-and-forget path remains intact when the flag is `disabled` or `observe`, so this PR is a one-line rollback away from previous behaviour.

With this PR landed and the flag flipped to `active`, the regression test added in Phase 1 (`launch-claim-orphan-regression.test.ts`) goes from `.fails` to passing — every `task.launch_claimed` reaches a terminal launch event within the `2 * DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS` bound, regardless of in-memory perturbations (process restarts, scheduler-loop interruption, callback drops, etc.).

Phase B commits (CB.1–CB.7):

- CB.1 `claimLaunchDispatchAtomic` — priority-ordered, capacity-checked atomic SQL `UPDATE`.
- CB.2 `LaunchDispatcher.ackDispatch` / `completeDispatch` / `failDispatch`.
- CB.3 Reapers: `reapExpiredLaunchDispatchLeases` (leased → enqueued after fence expiry) and `abandonStuckLeases` (acknowledged → abandoned after N attempts, with concrete error message replacing the misleading "60s without a spawned execution handle").
- CB.4 `TaskRunner.executeTask` accepts `dispatchOpts?: { dispatchId, launchOutbox }` and drives `ackDispatch` at the top, `completeDispatch` on `markTaskRunningAfterLaunch` success, `failDispatch` on startup error.
- CB.5 `LaunchDispatcher` active-mode loop: `claimLaunchDispatchAtomic` → `taskRunnerProvider().executeTask(task, { dispatchId, launchOutbox })`. `global-topup.dispatchTasks` short-circuits when active so we don't race with the outbox.
- CB.6 Legacy launch-stall watchdog in `main.ts` skips its "forcing failure" action when active (the dispatcher's `abandonStuckLeases` handles it with a concrete error message).
- CB.7 `createHeadlessExecutor` reuses the owner's `TaskRunner` (via `ownerTaskRunnerProvider`) when active, eliminating multi-TaskRunner blindness (Issue 6) for headless commands.

## Architecture

### Before (legacy fire-and-forget, observer mode)

```mermaid
flowchart TD
    Orch["Orchestrator drainScheduler"] -->|"task.launch_claimed"| Runner["TaskRunner (fire-and-forget)"]
    Runner -->|"executor.start"| Exec["Executor"]
    Orch -.->|"enqueueLaunchDispatch (no-op observer)"| Outbox[("task_launch_dispatch")]
```

### After (active mode — outbox is authoritative)

```mermaid
flowchart TD
    Orch["Orchestrator drainScheduler"] -->|"task.launch_claimed + enqueueLaunchDispatch"| Outbox[("task_launch_dispatch")]
    Outbox -->|"claimLaunchDispatchAtomic (priority + capacity)"| Dispatcher["LaunchDispatcher.poll"]
    Dispatcher -->|"executeTask(task, dispatchOpts)"| Runner["TaskRunner (one per process)"]
    Runner -->|"ack / complete / fail"| Outbox
    Runner -->|"executor.start, onComplete"| Orch
    Outbox -.->|"fenced_until expiry → reapExpiredLeases"| Dispatcher
    Outbox -.->|"attempts_count >= max → abandonStuckLeases → task.failed"| Orch
```

## Test Plan

- [ ] `cd packages/data-store && pnpm test sqlite-adapter`
- [ ] `cd packages/app && pnpm test launch-dispatcher`
- [ ] `cd packages/app && pnpm test launch-claim-orphan-regression`
- [ ] `cd packages/app && pnpm test launch-stall`
- [ ] `cd packages/app && pnpm test headless-delegation`
- [ ] `cd packages/app && pnpm test headless-create-executor`
- [ ] `cd packages/execution-engine && pnpm test task-runner-launch-dispatch`

## Revert Plan

- Safe to revert? Yes
- Revert command: Flip the flag back to `disabled` (one-line config change) for an immediate rollback. Full `git revert <merge-commit>` removes the active code paths but leaves Phase A's observer infrastructure intact.
- Post-revert steps: Phases C–D depend on this; reverting forces revert of the stacked PRs above.
- Data migration? No
