### PR TITLE
Wire cascadeDownstream in buildInvalidationDeps

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -1994,6 +1994,73 @@ describe('buildInvalidationDeps', () => {
       taskExecutor.killActiveExecution.mock.invocationCallOrder[0],
     );
   });
+
+  // Cross-workflow cascade wiring: a task-scoped id resolves to its
+  // owning workflowId via `orchestrator.getTask(id)?.config.workflowId`,
+  // then delegates to `Orchestrator.cascadeInvalidationToDownstream`.
+  it('exposes cascadeDownstream that delegates to orchestrator.cascadeInvalidationToDownstream for workflow scope', async () => {
+    const cascaded = [makeRunningTask({ id: 'wf-2/leaf' })];
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      cascadeInvalidationToDownstream: vi.fn(() => cascaded),
+      getTask: vi.fn(() => undefined),
+    };
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
+    expect(deps.cascadeDownstream).toBeDefined();
+    const result = await deps.cascadeDownstream!('workflow', 'wf-1');
+
+    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-1');
+    expect(orchestrator.getTask).not.toHaveBeenCalled();
+    expect(result).toEqual(cascaded);
+  });
+
+  it('cascadeDownstream resolves task scope to workflowId via orchestrator.getTask', async () => {
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
+      getTask: vi.fn(() => ({
+        id: 'task-a',
+        config: { workflowId: 'wf-resolved' },
+      })),
+    };
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
+    await deps.cascadeDownstream!('task', 'task-a');
+
+    expect(orchestrator.getTask).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-resolved');
+  });
+
+  it('cascadeDownstream returns [] without calling orchestrator when task is not found', async () => {
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
+      getTask: vi.fn(() => undefined),
+    };
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
+    const result = await deps.cascadeDownstream!('task', 'unknown-task');
+
+    expect(orchestrator.getTask).toHaveBeenCalledWith('unknown-task');
+    expect(orchestrator.cascadeInvalidationToDownstream).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
 });
 
 describe('deleteAllWorkflows', () => {

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -578,6 +578,16 @@ export function buildInvalidationDeps(
       rejectTask(taskId, { orchestrator: deps.orchestrator });
       return [];
     },
+    // For task scope, resolve the owning workflow first; if the task
+    // is gone (detached), the cascade is a no-op.
+    cascadeDownstream: (scope, id) => {
+      const workflowId =
+        scope === 'workflow'
+          ? id
+          : deps.orchestrator.getTask(id)?.config.workflowId;
+      if (!workflowId) return [];
+      return deps.orchestrator.cascadeInvalidationToDownstream(workflowId);
+    },
   };
 }
 

--- a/packages/workflow-core/src/__tests__/cross-workflow-cascade.test.ts
+++ b/packages/workflow-core/src/__tests__/cross-workflow-cascade.test.ts
@@ -1,0 +1,449 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  Orchestrator,
+  type OrchestratorPersistence,
+  type OrchestratorMessageBus,
+} from '../orchestrator.js';
+import {
+  applyInvalidation,
+  type InvalidationDeps,
+  type InvalidationScope,
+} from '../invalidation-policy.js';
+import type { TaskState, TaskStateChanges, Attempt } from '../task-types.js';
+import type { WorkResponse } from '@invoker/contracts';
+
+// ── In-memory fixtures (mirrors cancel-first-invariant.test.ts) ──
+
+class InMemoryPersistence implements OrchestratorPersistence {
+  workflows = new Map<string, {
+    id: string;
+    name: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+    repoUrl?: string;
+    baseBranch?: string;
+    featureBranch?: string;
+    mergeMode?: 'manual' | 'automatic' | 'external_review';
+  }>();
+  tasks = new Map<string, { workflowId: string; task: TaskState }>();
+  private attempts = new Map<string, Attempt[]>();
+  events: Array<{ taskId: string; eventType: string; payload?: unknown }> = [];
+
+  saveWorkflow(workflow: {
+    id: string;
+    name: string;
+    status: string;
+    repoUrl?: string;
+    baseBranch?: string;
+    featureBranch?: string;
+    mergeMode?: 'manual' | 'automatic' | 'external_review';
+  }): void {
+    const now = new Date().toISOString();
+    this.workflows.set(workflow.id, {
+      ...workflow,
+      repoUrl: workflow.repoUrl ?? 'memory://test-repo',
+      createdAt: (workflow as { createdAt?: string }).createdAt ?? now,
+      updatedAt: (workflow as { updatedAt?: string }).updatedAt ?? now,
+    });
+  }
+  updateWorkflow(): void {}
+  loadWorkflow(workflowId: string): { repoUrl?: string; baseBranch?: string; featureBranch?: string } | undefined {
+    const wf = this.workflows.get(workflowId);
+    return wf
+      ? { repoUrl: wf.repoUrl, baseBranch: wf.baseBranch, featureBranch: wf.featureBranch }
+      : undefined;
+  }
+  saveTask(workflowId: string, task: TaskState): void {
+    this.tasks.set(task.id, { workflowId, task });
+  }
+  getTaskEntry(taskId: string): { workflowId: string; task: TaskState } | undefined {
+    return this.tasks.get(taskId);
+  }
+  updateTask(taskId: string, changes: TaskStateChanges): void {
+    const entry = this.tasks.get(taskId);
+    if (!entry) return;
+    entry.task = {
+      ...entry.task,
+      ...(changes.status !== undefined ? { status: changes.status } : {}),
+      ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
+      config: { ...entry.task.config, ...changes.config },
+      execution: { ...entry.task.execution, ...changes.execution },
+    } as TaskState;
+  }
+  listWorkflows() { return Array.from(this.workflows.values()); }
+  loadTasks(workflowId: string): TaskState[] {
+    return Array.from(this.tasks.values())
+      .filter((e) => e.workflowId === workflowId)
+      .map((e) => e.task);
+  }
+  logEvent(taskId: string, eventType: string, payload?: unknown): void {
+    this.events.push({ taskId, eventType, payload });
+  }
+  saveAttempt(attempt: Attempt): void {
+    const list = this.attempts.get(attempt.nodeId) ?? [];
+    list.push(attempt);
+    this.attempts.set(attempt.nodeId, list);
+  }
+  loadAttempts(nodeId: string): Attempt[] { return this.attempts.get(nodeId) ?? []; }
+  loadAttempt(attemptId: string): Attempt | undefined {
+    for (const list of this.attempts.values()) {
+      const found = list.find((a) => a.id === attemptId);
+      if (found) return found;
+    }
+    return undefined;
+  }
+  updateAttempt(
+    attemptId: string,
+    changes: Partial<Pick<Attempt,
+      | 'status' | 'startedAt' | 'completedAt' | 'exitCode' | 'error'
+      | 'lastHeartbeatAt' | 'branch' | 'commit' | 'summary'
+      | 'workspacePath' | 'agentSessionId' | 'containerId' | 'mergeConflict'>>,
+  ): void {
+    for (const list of this.attempts.values()) {
+      const idx = list.findIndex((a) => a.id === attemptId);
+      if (idx !== -1) {
+        list[idx] = { ...list[idx], ...changes } as Attempt;
+        return;
+      }
+    }
+  }
+  deleteWorkflow(workflowId: string): void {
+    this.workflows.delete(workflowId);
+    for (const [id, entry] of this.tasks) {
+      if (entry.workflowId === workflowId) this.tasks.delete(id);
+    }
+  }
+  deleteAllWorkflows(): void { this.workflows.clear(); this.tasks.clear(); }
+}
+
+class InMemoryBus implements OrchestratorMessageBus {
+  publish<T>(_channel: string, _message: T): void {}
+  subscribe(_channel: string, _handler: (msg: unknown) => void): () => void {
+    return () => undefined;
+  }
+}
+
+function makeOrchestrator(persistence: OrchestratorPersistence): Orchestrator {
+  return new Orchestrator({
+    persistence,
+    messageBus: new InMemoryBus(),
+    maxConcurrency: 8,
+  });
+}
+
+function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
+  return {
+    cancelInFlight: async (scope, id) => {
+      if (scope === 'none') return;
+      try {
+        if (scope === 'task') {
+          orchestrator.cancelTask(id);
+          return;
+        }
+        orchestrator.cancelWorkflow(id);
+      } catch (e) {
+        // Already-terminal targets have nothing to cancel; the rest
+        // of the pipeline still runs.
+        const code = (e as { code?: string })?.code;
+        if (code === 'TASK_ALREADY_TERMINAL' || code === 'WORKFLOW_ALREADY_TERMINAL') return;
+        throw e;
+      }
+    },
+    retryTask: (taskId) => orchestrator.retryTask(taskId),
+    recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
+    recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
+    recreateWorkflowFromFreshBase: (workflowId) =>
+      orchestrator.recreateWorkflowFromFreshBase(workflowId, {
+        refreshBase: async () => ({ commit: 'fresh-sha' }),
+      }),
+    workflowFork: (workflowId) => {
+      const result = orchestrator.forkWorkflow(workflowId);
+      return result.started;
+    },
+    cascadeDownstream: (scope: InvalidationScope, id: string) => {
+      const workflowId =
+        scope === 'workflow'
+          ? id
+          : orchestrator.getTask(id)?.config.workflowId;
+      if (!workflowId) return [];
+      return orchestrator.cascadeInvalidationToDownstream(workflowId);
+    },
+  };
+}
+
+function makeResponse(overrides: Partial<WorkResponse>): WorkResponse {
+  return {
+    requestId: 'req-1',
+    actionId: 't1',
+    executionGeneration: 0,
+    status: 'completed',
+    outputs: { exitCode: 0 },
+    ...overrides,
+  };
+}
+
+/**
+ * Drive a chain of two workflows so the downstream first task has cleared the
+ * external merge-gate dependency, runs to completion locally, and a downstream
+ * later task is currently `running`. This mirrors the production scenario in
+ * `~/.invoker/invoker.db` for WF-INV-113 → WF-INV-55 (see plan reproduction
+ * notes) where the upstream merge gate cleared once, the downstream cascaded
+ * forward on local deps, and an upstream recreate fails to invalidate
+ * downstream work.
+ */
+function setupChain(orchestrator: Orchestrator): {
+  upstreamWfId: string;
+  upstreamTaskId: string;
+  upstreamMergeId: string;
+  downstreamWfId: string;
+  downstreamRootId: string;
+  downstreamMidId: string;
+  downstreamLastId: string;
+  downstreamMergeId: string;
+} {
+  orchestrator.loadPlan({
+    name: 'upstream-workflow',
+    baseBranch: 'master',
+    featureBranch: 'feature/upstream',
+    tasks: [{ id: 'verify-upstream', description: 'upstream prerequisite' }],
+  });
+  const upstreamTaskId = orchestrator.getAllTasks().find(
+    (t) => !t.config.isMergeNode && t.id.endsWith('/verify-upstream'),
+  )!.id;
+  const upstreamWfId = upstreamTaskId.split('/')[0]!;
+  const upstreamMergeId = `__merge__${upstreamWfId}`;
+
+  orchestrator.loadPlan({
+    name: 'downstream-workflow',
+    baseBranch: 'feature/upstream',
+    featureBranch: 'feature/downstream',
+    tasks: [
+      {
+        id: 'root',
+        description: 'downstream root waits for upstream merge gate',
+        externalDependencies: [{ workflowId: upstreamWfId, gatePolicy: 'completed' }],
+      },
+      {
+        id: 'mid',
+        description: 'downstream mid depends on root',
+        dependencies: ['root'],
+      },
+      {
+        id: 'last',
+        description: 'downstream last depends on mid',
+        dependencies: ['mid'],
+      },
+    ],
+  });
+
+  const downstreamRootId = orchestrator.getAllTasks().find(
+    (t) => t.id.endsWith('/root'),
+  )!.id;
+  const downstreamWfId = downstreamRootId.split('/')[0]!;
+  const downstreamMidId = `${downstreamWfId}/mid`;
+  const downstreamLastId = `${downstreamWfId}/last`;
+  const downstreamMergeId = `__merge__${downstreamWfId}`;
+
+  // Drive the upstream task and merge gate to `completed` so the
+  // downstream root clears the external dependency and runs.
+  orchestrator.startExecution();
+  orchestrator.handleWorkerResponse(makeResponse({ actionId: upstreamTaskId, status: 'completed' }));
+  orchestrator.handleWorkerResponse(makeResponse({ actionId: upstreamMergeId, status: 'completed' }));
+
+  // Downstream root should now be running.
+  expect(orchestrator.getTask(downstreamRootId)!.status).toBe('running');
+
+  // Cascade downstream root → mid → last on local deps.
+  orchestrator.handleWorkerResponse(makeResponse({ actionId: downstreamRootId, status: 'completed' }));
+  orchestrator.handleWorkerResponse(makeResponse({ actionId: downstreamMidId, status: 'completed' }));
+
+  // Downstream `last` is now running locally; merge gate still pending.
+  expect(orchestrator.getTask(downstreamLastId)!.status).toBe('running');
+  expect(orchestrator.getTask(downstreamMergeId)!.status).toBe('pending');
+
+  return {
+    upstreamWfId,
+    upstreamTaskId,
+    upstreamMergeId,
+    downstreamWfId,
+    downstreamRootId,
+    downstreamMidId,
+    downstreamLastId,
+    downstreamMergeId,
+  };
+}
+
+describe('cross-workflow cascade — upstream invalidation propagates downstream', () => {
+  let persistence: InMemoryPersistence;
+  let orchestrator: Orchestrator;
+  let deps: InvalidationDeps;
+
+  beforeEach(() => {
+    persistence = new InMemoryPersistence();
+    orchestrator = makeOrchestrator(persistence);
+    deps = buildOrchestratorDeps(orchestrator);
+  });
+
+  it('recreateWorkflow on upstream cancels in-flight downstream and resets every downstream task to pending', async () => {
+    const ctx = setupChain(orchestrator);
+
+    await applyInvalidation('workflow', 'recreateWorkflow', ctx.upstreamWfId, deps);
+
+    expect(orchestrator.getTask(ctx.upstreamMergeId)!.status).toBe('pending');
+
+    for (const id of [
+      ctx.downstreamRootId,
+      ctx.downstreamMidId,
+      ctx.downstreamLastId,
+      ctx.downstreamMergeId,
+    ]) {
+      expect(orchestrator.getTask(id)!.status, `${id} should be pending after upstream recreateWorkflow`).toBe('pending');
+    }
+
+    const lastEvents = persistence.events.filter((e) => e.taskId === ctx.downstreamLastId);
+    const cancelIdx = lastEvents.findIndex((e) => e.eventType === 'task.cancelled');
+    const pendingIdx = lastEvents.findIndex((e) => e.eventType === 'task.pending');
+    expect(cancelIdx, `expected task.cancelled for ${ctx.downstreamLastId}; got ${lastEvents.map((e) => e.eventType).join(',')}`).toBeGreaterThanOrEqual(0);
+    expect(pendingIdx).toBeGreaterThanOrEqual(0);
+    expect(cancelIdx).toBeLessThan(pendingIdx);
+  });
+
+  it('recreateTask on an upstream task also cascades downstream', async () => {
+    const ctx = setupChain(orchestrator);
+
+    await applyInvalidation('task', 'recreateTask', ctx.upstreamTaskId, deps);
+
+    for (const id of [
+      ctx.downstreamRootId,
+      ctx.downstreamMidId,
+      ctx.downstreamLastId,
+      ctx.downstreamMergeId,
+    ]) {
+      expect(orchestrator.getTask(id)!.status, `${id} should be pending after upstream recreateTask`).toBe('pending');
+    }
+  });
+
+  it('retryWorkflow on upstream cascades downstream', async () => {
+    const ctx = setupChain(orchestrator);
+
+    orchestrator.handleWorkerResponse(makeResponse({
+      actionId: ctx.upstreamMergeId,
+      status: 'failed',
+      outputs: { exitCode: 1, error: 'boom' },
+    }));
+    await applyInvalidation('workflow', 'retryWorkflow', ctx.upstreamWfId, deps);
+
+    for (const id of [
+      ctx.downstreamRootId,
+      ctx.downstreamMidId,
+      ctx.downstreamLastId,
+      ctx.downstreamMergeId,
+    ]) {
+      expect(orchestrator.getTask(id)!.status, `${id} should be pending after upstream retryWorkflow`).toBe('pending');
+    }
+  });
+
+  it('retryTask on an upstream task cascades downstream', async () => {
+    const ctx = setupChain(orchestrator);
+
+    orchestrator.handleWorkerResponse(makeResponse({
+      actionId: ctx.upstreamMergeId,
+      status: 'failed',
+      outputs: { exitCode: 1, error: 'boom' },
+    }));
+    await applyInvalidation('task', 'retryTask', ctx.upstreamMergeId, deps);
+
+    for (const id of [
+      ctx.downstreamRootId,
+      ctx.downstreamMidId,
+      ctx.downstreamLastId,
+      ctx.downstreamMergeId,
+    ]) {
+      expect(orchestrator.getTask(id)!.status, `${id} should be pending after upstream retryTask`).toBe('pending');
+    }
+  });
+
+  it('recreateWorkflowFromFreshBase on upstream cascades downstream', async () => {
+    const ctx = setupChain(orchestrator);
+
+    await applyInvalidation(
+      'workflow',
+      'recreateWorkflowFromFreshBase',
+      ctx.upstreamWfId,
+      deps,
+    );
+
+    for (const id of [
+      ctx.downstreamRootId,
+      ctx.downstreamMidId,
+      ctx.downstreamLastId,
+      ctx.downstreamMergeId,
+    ]) {
+      expect(orchestrator.getTask(id)!.status, `${id} should be pending after upstream recreateWorkflowFromFreshBase`).toBe('pending');
+    }
+  });
+
+  it('cascade is transitive: A → B → C, recreating A pends every task in B and C', async () => {
+    // Workflow A
+    orchestrator.loadPlan({
+      name: 'wf-a',
+      baseBranch: 'master',
+      featureBranch: 'feature/a',
+      tasks: [{ id: 'a-task', description: 'A' }],
+    });
+    const aTaskId = orchestrator.getAllTasks().find((t) => t.id.endsWith('/a-task'))!.id;
+    const aWfId = aTaskId.split('/')[0]!;
+    const aMergeId = `__merge__${aWfId}`;
+
+    // Workflow B depends on A
+    orchestrator.loadPlan({
+      name: 'wf-b',
+      baseBranch: 'feature/a',
+      featureBranch: 'feature/b',
+      tasks: [
+        {
+          id: 'b-task',
+          description: 'B depends on A merge gate',
+          externalDependencies: [{ workflowId: aWfId, gatePolicy: 'completed' }],
+        },
+      ],
+    });
+    const bTaskId = orchestrator.getAllTasks().find((t) => t.id.endsWith('/b-task'))!.id;
+    const bWfId = bTaskId.split('/')[0]!;
+    const bMergeId = `__merge__${bWfId}`;
+
+    // Workflow C depends on B
+    orchestrator.loadPlan({
+      name: 'wf-c',
+      baseBranch: 'feature/b',
+      featureBranch: 'feature/c',
+      tasks: [
+        {
+          id: 'c-task',
+          description: 'C depends on B merge gate',
+          externalDependencies: [{ workflowId: bWfId, gatePolicy: 'completed' }],
+        },
+      ],
+    });
+    const cTaskId = orchestrator.getAllTasks().find((t) => t.id.endsWith('/c-task'))!.id;
+    const cWfId = cTaskId.split('/')[0]!;
+    const cMergeId = `__merge__${cWfId}`;
+
+    // Drive A → B → C all to running by chaining merge-gate completions.
+    orchestrator.startExecution();
+    orchestrator.handleWorkerResponse(makeResponse({ actionId: aTaskId, status: 'completed' }));
+    orchestrator.handleWorkerResponse(makeResponse({ actionId: aMergeId, status: 'completed' }));
+    orchestrator.handleWorkerResponse(makeResponse({ actionId: bTaskId, status: 'completed' }));
+    orchestrator.handleWorkerResponse(makeResponse({ actionId: bMergeId, status: 'completed' }));
+
+    expect(orchestrator.getTask(cTaskId)!.status).toBe('running');
+
+    await applyInvalidation('workflow', 'recreateWorkflow', aWfId, deps);
+
+    for (const id of [bTaskId, bMergeId, cTaskId, cMergeId]) {
+      expect(orchestrator.getTask(id)!.status, `${id} should be pending after transitive cascade`).toBe('pending');
+    }
+  });
+});

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -15,6 +15,7 @@ type MockedDeps = InvalidationDeps & {
   recreateWorkflowFromFreshBase?: ReturnType<typeof vi.fn>;
   workflowFork?: ReturnType<typeof vi.fn>;
   scheduleOnly?: ReturnType<typeof vi.fn>;
+  cascadeDownstream?: ReturnType<typeof vi.fn>;
 };
 
 function makeDeps(overrides: Partial<MockedDeps> = {}): MockedDeps {
@@ -372,5 +373,141 @@ describe("applyInvalidation: action='scheduleOnly' (Step 15)", () => {
     expect(deps.recreateWorkflow).not.toHaveBeenCalled();
     expect(recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
     expect(workflowFork).not.toHaveBeenCalled();
+  });
+});
+
+// Cross-workflow cascade matrix. Every invalidating action MUST
+// invoke `deps.cascadeDownstream(scope, id)` AFTER the lifecycle dep
+// returns and AFTER `cancelInFlight`. Non-invalidating actions
+// (`'none'`, `'scheduleOnly'`, `'fixApprove'`, `'fixReject'`) MUST
+// NOT invoke the cascade.
+describe('applyInvalidation: cascadeDownstream (cross-workflow cascade)', () => {
+  it('calls cascadeDownstream after retryTask', async () => {
+    const cascadeDownstream = vi.fn(async () => []);
+    const deps = makeDeps({ cascadeDownstream });
+    await applyInvalidation('task', 'retryTask', 'task-a', deps);
+    expect(cascadeDownstream).toHaveBeenCalledWith('task', 'task-a');
+    expect(deps.retryTask.mock.invocationCallOrder[0]).toBeLessThan(
+      cascadeDownstream.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('calls cascadeDownstream after recreateTask', async () => {
+    const cascadeDownstream = vi.fn(async () => []);
+    const deps = makeDeps({ cascadeDownstream });
+    await applyInvalidation('task', 'recreateTask', 'task-a', deps);
+    expect(cascadeDownstream).toHaveBeenCalledWith('task', 'task-a');
+    expect(deps.recreateTask.mock.invocationCallOrder[0]).toBeLessThan(
+      cascadeDownstream.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('calls cascadeDownstream after retryWorkflow', async () => {
+    const cascadeDownstream = vi.fn(async () => []);
+    const deps = makeDeps({ cascadeDownstream });
+    await applyInvalidation('workflow', 'retryWorkflow', 'wf-1', deps);
+    expect(cascadeDownstream).toHaveBeenCalledWith('workflow', 'wf-1');
+    expect(deps.retryWorkflow.mock.invocationCallOrder[0]).toBeLessThan(
+      cascadeDownstream.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('calls cascadeDownstream after recreateWorkflow', async () => {
+    const cascadeDownstream = vi.fn(async () => []);
+    const deps = makeDeps({ cascadeDownstream });
+    await applyInvalidation('workflow', 'recreateWorkflow', 'wf-1', deps);
+    expect(cascadeDownstream).toHaveBeenCalledWith('workflow', 'wf-1');
+    expect(deps.recreateWorkflow.mock.invocationCallOrder[0]).toBeLessThan(
+      cascadeDownstream.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('calls cascadeDownstream after recreateWorkflowFromFreshBase', async () => {
+    const cascadeDownstream = vi.fn(async () => []);
+    const recreateWorkflowFromFreshBase = vi.fn(async () => []);
+    const deps = makeDeps({ cascadeDownstream, recreateWorkflowFromFreshBase });
+    await applyInvalidation('workflow', 'recreateWorkflowFromFreshBase', 'wf-1', deps);
+    expect(cascadeDownstream).toHaveBeenCalledWith('workflow', 'wf-1');
+    expect(recreateWorkflowFromFreshBase.mock.invocationCallOrder[0]).toBeLessThan(
+      cascadeDownstream.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('calls cascadeDownstream after workflowFork', async () => {
+    const cascadeDownstream = vi.fn(async () => []);
+    const workflowFork = vi.fn(async () => []);
+    const deps = makeDeps({ cascadeDownstream, workflowFork });
+    await applyInvalidation('workflow', 'workflowFork', 'wf-1', deps);
+    expect(cascadeDownstream).toHaveBeenCalledWith('workflow', 'wf-1');
+    expect(workflowFork.mock.invocationCallOrder[0]).toBeLessThan(
+      cascadeDownstream.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does NOT call cascadeDownstream for action 'none'", async () => {
+    const cascadeDownstream = vi.fn(async () => []);
+    const deps = makeDeps({ cascadeDownstream });
+    await applyInvalidation('none', 'none', 'task-a', deps);
+    expect(cascadeDownstream).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call cascadeDownstream for action 'scheduleOnly'", async () => {
+    const cascadeDownstream = vi.fn(async () => []);
+    const scheduleOnly = vi.fn(async () => []);
+    const deps = makeDeps({ cascadeDownstream, scheduleOnly });
+    await applyInvalidation('task', 'scheduleOnly', 'task-a', deps);
+    expect(cascadeDownstream).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call cascadeDownstream for action 'fixApprove'", async () => {
+    const cascadeDownstream = vi.fn(async () => []);
+    const fixApprove = vi.fn(async () => []);
+    const deps = makeDeps({ cascadeDownstream, fixApprove });
+    await applyInvalidation('task', 'fixApprove', 'task-a', deps);
+    expect(cascadeDownstream).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call cascadeDownstream for action 'fixReject'", async () => {
+    const cascadeDownstream = vi.fn(async () => []);
+    const fixReject = vi.fn(async () => []);
+    const deps = makeDeps({ cascadeDownstream, fixReject });
+    await applyInvalidation('task', 'fixReject', 'task-a', deps);
+    expect(cascadeDownstream).not.toHaveBeenCalled();
+  });
+
+  it('cascadeDownstream is optional — missing dep does not break invalidating actions', async () => {
+    const deps = makeDeps();
+    expect(deps.cascadeDownstream).toBeUndefined();
+    await expect(
+      applyInvalidation('workflow', 'recreateWorkflow', 'wf-1', deps),
+    ).resolves.toBeDefined();
+    expect(deps.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+  });
+
+  it('cascadeDownstream is awaited (sequencing lock-in)', async () => {
+    const events: string[] = [];
+    const cascadeDownstream = vi.fn(async () => {
+      events.push('cascade-start');
+      await new Promise((r) => setTimeout(r, 1));
+      events.push('cascade-end');
+      return [];
+    });
+    const recreateWorkflow = vi.fn(async () => {
+      events.push('recreate');
+      return [];
+    });
+    const deps = makeDeps({ cascadeDownstream, recreateWorkflow });
+    await applyInvalidation('workflow', 'recreateWorkflow', 'wf-1', deps);
+    expect(events).toEqual(['recreate', 'cascade-start', 'cascade-end']);
+  });
+
+  it('returns the lifecycle dep result, not the cascade result', async () => {
+    const lifecycleResult = [{ id: 'task-a' } as never];
+    const cascadeResult = [{ id: 'cascade-a' } as never];
+    const cascadeDownstream = vi.fn(async () => cascadeResult);
+    const recreateWorkflow = vi.fn(async () => lifecycleResult);
+    const deps = makeDeps({ cascadeDownstream, recreateWorkflow });
+    const out = await applyInvalidation('workflow', 'recreateWorkflow', 'wf-1', deps);
+    expect(out).toBe(lifecycleResult);
   });
 });

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -115,6 +115,33 @@ export interface InvalidationDeps {
   scheduleOnly?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   fixApprove?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   fixReject?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  /**
+   * Cross-workflow cascade hook. Invoked by `applyInvalidation` after
+   * an invalidating action's dep returns, so any transitive downstream
+   * workflow that depends on the invalidated upstream is itself
+   * cancel-and-reset-to-pending. The downstream's existing external
+   * dependency gate then re-blocks the freshly-pending tasks until
+   * the upstream re-completes.
+   *
+   * Only invoked for actions that change execution state:
+   *   - task scope:     `retryTask`, `recreateTask`
+   *   - workflow scope: `retryWorkflow`, `recreateWorkflow`,
+   *                     `recreateWorkflowFromFreshBase`, `workflowFork`
+   *
+   * Skipped for `'none'`, `'scheduleOnly'`, `'fixApprove'`, and
+   * `'fixReject'` — these are non-invalidating per `MUTATION_POLICIES`
+   * and must not reset downstream lineage.
+   *
+   * Production callers wire this via `buildInvalidationDeps`
+   * (`packages/app/src/workflow-actions.ts`) to
+   * `Orchestrator.cascadeInvalidationToDownstream`. The dep is
+   * optional so unit tests that build a partial `InvalidationDeps`
+   * keep working without supplying the cascade.
+   */
+  cascadeDownstream?: (
+    scope: InvalidationScope,
+    id: string,
+  ) => TaskState[] | Promise<TaskState[]>;
 }
 
 const TASK_ACTIONS = new Set<InvalidationAction>(['retryTask', 'recreateTask']);
@@ -195,15 +222,20 @@ export async function applyInvalidation(
 
   await deps.cancelInFlight(scope, id);
 
+  let started: TaskState[];
   switch (action) {
     case 'retryTask':
-      return await deps.retryTask(id);
+      started = await deps.retryTask(id);
+      break;
     case 'recreateTask':
-      return await deps.recreateTask(id);
+      started = await deps.recreateTask(id);
+      break;
     case 'retryWorkflow':
-      return await deps.retryWorkflow(id);
+      started = await deps.retryWorkflow(id);
+      break;
     case 'recreateWorkflow':
-      return await deps.recreateWorkflow(id);
+      started = await deps.recreateWorkflow(id);
+      break;
     case 'recreateWorkflowFromFreshBase': {
       if (!deps.recreateWorkflowFromFreshBase) {
         throw new Error(
@@ -211,7 +243,8 @@ export async function applyInvalidation(
             'Provide deps.recreateWorkflowFromFreshBase to use this action.',
         );
       }
-      return await deps.recreateWorkflowFromFreshBase(id);
+      started = await deps.recreateWorkflowFromFreshBase(id);
+      break;
     }
     case 'workflowFork': {
       if (!deps.workflowFork) {
@@ -226,7 +259,20 @@ export async function applyInvalidation(
             'deps.workflowFork to use this action.',
         );
       }
-      return await deps.workflowFork(id);
+      started = await deps.workflowFork(id);
+      break;
     }
   }
+
+  // Cross-workflow cascade: every invalidating action above (six in
+  // total) must propagate to transitive downstream workflows so their
+  // tasks are cancel-cancel-then-reset-to-pending and re-blocked by
+  // the existing external-dependency gate. Non-invalidating actions
+  // (`'none'`, `'scheduleOnly'`, `'fixApprove'`, `'fixReject'`)
+  // already returned above and never reach this point. The dep is
+  // optional so partial test wiring keeps working.
+  if (deps.cascadeDownstream) {
+    await deps.cascadeDownstream(scope, id);
+  }
+  return started;
 }

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -4809,6 +4809,68 @@ export class Orchestrator {
     return descendants;
   }
 
+  /**
+   * Cascade an upstream invalidation to every transitive downstream
+   * workflow. For each downstream workflow:
+   *   1. Cancel any in-flight task (`cancelActiveBeforeInvalidation`).
+   *   2. Reset every task in the workflow to `pending` (with bumped
+   *      execution generation to supersede prior attempts) using the
+   *      same shape as `detachWorkflowInternal`'s reset payload.
+   *
+   * The downstream's existing external-dependency gate
+   * (`getExternalDependencyBlocker`) re-evaluates at scheduling time
+   * and holds the now-pending tasks until the upstream re-completes,
+   * so this method does not start anything itself.
+   *
+   * Wired by `applyInvalidation` (via the `cascadeDownstream` dep on
+   * `InvalidationDeps`) so every invalidating action — `recreateTask`,
+   * `retryTask`, `recreateWorkflow`, `retryWorkflow`,
+   * `recreateWorkflowFromFreshBase`, `workflowFork` — propagates.
+   * Non-invalidating actions (`scheduleOnly`, `fixApprove`,
+   * `fixReject`, `none`) skip the cascade per `MUTATION_POLICIES`.
+   */
+  cascadeInvalidationToDownstream(workflowId: string): TaskState[] {
+    this.refreshFromDb();
+    const downstreamWorkflowIds = this.collectDownstreamWorkflowIds(workflowId);
+    if (downstreamWorkflowIds.length === 0) return [];
+
+    this.logger.info('[orchestrator] cascadeInvalidationToDownstream', {
+      upstreamWorkflowId: workflowId,
+      downstreamCount: downstreamWorkflowIds.length,
+      downstreamWorkflowIds,
+    });
+
+    for (const dwfId of downstreamWorkflowIds) {
+      this.cancelActiveBeforeInvalidation('workflow', dwfId);
+    }
+
+    const affectedTaskIds = downstreamWorkflowIds.flatMap((dwfId) =>
+      this.stateMachine
+        .getAllTasks()
+        .filter((task) => task.config.workflowId === dwfId)
+        .map((task) => task.id),
+    );
+    if (affectedTaskIds.length === 0) return [];
+
+    const forceResetIds = new Set(affectedTaskIds);
+    const { affectedIds } = this.resetSubgraphToPending(
+      affectedTaskIds,
+      Orchestrator.DETACH_RESET_CHANGES,
+      { forceResetIds },
+    );
+
+    for (const taskId of affectedIds) {
+      this.persistence.logEvent?.(taskId, 'task.invalidated_by_upstream', {
+        upstreamWorkflowId: workflowId,
+        downstreamWorkflowIds,
+      });
+    }
+
+    return affectedIds
+      .map((id) => this.stateGetTask(id))
+      .filter((t): t is TaskState => !!t);
+  }
+
   private detachWorkflowInternal(
     workflowId: string,
     upstreamWorkflowId: string,


### PR DESCRIPTION
## Summary

Production callers (`CommandService`, headless command path, IPC handlers) construct `InvalidationDeps` via `buildInvalidationDeps` in `packages/app/src/workflow-actions.ts`. The previous PR in the stack added the `cascadeDownstream` hook on `InvalidationDeps` and the underlying `Orchestrator.cascadeInvalidationToDownstream` primitive, but no production deps wire it.

This PR wires the production path:

- `buildInvalidationDeps.cascadeDownstream` now delegates to `Orchestrator.cascadeInvalidationToDownstream`.
- For workflow scope the dep forwards the workflowId directly; for task scope it resolves the owning workflowId via `orchestrator.getTask(id)?.config.workflowId`.
- If the task is missing (e.g. already detached) the dep returns `[]` without invoking the orchestrator, mirroring the defensive style of the other deps in `buildInvalidationDeps`.

After this PR lands, every invalidating action that flows through `applyInvalidation` (recreate-task, recreate-workflow, retry-task, retry-workflow, fresh-base recreate, fork) cancels in-flight downstream attempts and resets every transitive downstream workflow to `pending`. The downstream's existing external-dependency gate then re-blocks the freshly-pending tasks until the upstream re-completes — fixing the "downstream keeps running after upstream recreate" bug for all GUI / headless / IPC entry points.

## Test Plan

- [x] `cd packages/app && pnpm test`
  - 994 passed, 1 skipped
  - 3 new `buildInvalidationDeps` tests in `workflow-actions.test.ts`:
    - workflow-scope delegation calls `cascadeInvalidationToDownstream` with the workflowId
    - task-scope resolves to the owning workflowId via `orchestrator.getTask`
    - missing task returns `[]` without invoking the orchestrator
- [x] `pnpm run test:all`
  - 16 / 16 suites pass

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — reverting only this PR keeps the cascade primitive in core but disables the production wiring; the system reverts to the prior one-shot gate semantics with no schema or DB migration.
- Data migration? No

Depends-On: #883