### PR TITLE
fix(ssh-executor): Bazel-style sandbox hygiene — staging eviction + worktree reset on reuse

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -321,7 +321,7 @@ branch refs/heads/experiment/test-task-oldhash
       return '';
     });
 
-    vi.spyOn(ssh, 'mergeRequestUpstreamBranches').mockResolvedValue(undefined);
+    const mergeUpstreamSpy = vi.spyOn(ssh, 'mergeRequestUpstreamBranches').mockResolvedValue(undefined);
     vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
       (_executionId: string, _request: any, handle: any) => handle,
     );
@@ -332,15 +332,27 @@ branch refs/heads/experiment/test-task-oldhash
       inputs: { command, description: 'sandbox reset test', repoUrl: 'git@github.com:owner/repo.git' },
     }));
 
-    // sandbox_reset must have been called
+    // sandbox_reset must have been called with the right script content
     const sandboxResetCall = capturedCalls.find(c => c.phase === 'sandbox_reset');
     expect(sandboxResetCall).toBeDefined();
     expect(sandboxResetCall?.script).toContain('git -C "$WT" reset --hard "$REF"');
-    expect(sandboxResetCall?.script).toContain('git -C "$WT" clean -fdx');
+    expect(sandboxResetCall?.script).toContain('git -C "$WT" clean -fd');
 
-    // sandbox_reset must appear before mergeRequestUpstreamBranches
-    const resetIndex = capturedCalls.findIndex(c => c.phase === 'sandbox_reset');
-    expect(resetIndex).toBeGreaterThanOrEqual(0);
+    // mergeRequestUpstreamBranches must have been called exactly once
+    expect(mergeUpstreamSpy).toHaveBeenCalledTimes(1);
+
+    // sandbox_reset (execRemoteCapture call) must be ordered before mergeRequestUpstreamBranches.
+    // We verify this via invocationCallOrder so a future refactor cannot silently move
+    // the reset after the merge without breaking this test.
+    const sandboxResetCallIndex = capturedCalls.findIndex(c => c.phase === 'sandbox_reset');
+    // execRemoteCapture is called once per capturedCalls entry; find which mock invocation
+    // index corresponds to the sandbox_reset call.
+    const execMock = vi.mocked(ssh.execRemoteCapture as unknown as (...args: any[]) => any);
+    const sandboxResetInvocationOrder = execMock.mock.invocationCallOrder[sandboxResetCallIndex];
+    const mergeInvocationOrder = mergeUpstreamSpy.mock.invocationCallOrder[0];
+    expect(sandboxResetInvocationOrder).toBeDefined();
+    expect(mergeInvocationOrder).toBeDefined();
+    expect(sandboxResetInvocationOrder!).toBeLessThan(mergeInvocationOrder!);
   });
 
   it('staging dir is always evicted (rm -rf before mkdir) in buildRuntimeBootstrapScript', async () => {

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -275,6 +275,114 @@ branch refs/heads/experiment/test-task-oldhash
     expect(execRemoteCapture).not.toHaveBeenCalledWith(expect.stringContaining('branch -m'), 'rename_reuse_branch');
   });
 
+  it('reuse_exact: sandbox-resets the worktree before mergeRequestUpstreamBranches', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+    }) as any;
+
+    const repoHash = computeRepoUrlHash('git@github.com:owner/repo.git');
+    const baseHead = 'aabbccddeeff00112233445566778899aabbccdd';
+    const actionId = 'reuse-sandbox-test';
+    const command = 'pnpm test';
+    const lifecycleTag = '';
+    const upstreamCommits: string[] = [];
+
+    // Compute the exact branch the executor will derive from these inputs.
+    // The executor uses request.inputs.prompt (not description) as the third arg.
+    const contentHash = computeContentHash(actionId, command, undefined, upstreamCommits, baseHead);
+    const experimentBranch = buildExperimentBranchName(actionId, lifecycleTag, contentHash);
+    const san = experimentBranch.replace(/\//g, '-');
+    const invokerHome = '/home/testuser/.invoker';
+    const exactPath = `${invokerHome}/worktrees/${repoHash}/${san}`;
+
+    const capturedCalls: Array<{ script: string; phase?: string }> = [];
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string, phase?: string) => {
+      capturedCalls.push({ script, phase });
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return `__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=${baseHead}`;
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) {
+        // Return a porcelain listing that includes the exact canonical path with the right branch
+        return [
+          `worktree ${exactPath}`,
+          `HEAD ${baseHead}`,
+          `branch refs/heads/${experimentBranch}`,
+          '',
+        ].join('\n');
+      }
+      // Respond to the abbrev-ref HEAD inspection for reuse candidate
+      if (script.includes('rev-parse --abbrev-ref HEAD')) {
+        return experimentBranch;
+      }
+      return '';
+    });
+
+    vi.spyOn(ssh, 'mergeRequestUpstreamBranches').mockResolvedValue(undefined);
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any) => handle,
+    );
+
+    await ssh.start(makeRequest({
+      actionType: 'command',
+      actionId,
+      inputs: { command, description: 'sandbox reset test', repoUrl: 'git@github.com:owner/repo.git' },
+    }));
+
+    // sandbox_reset must have been called
+    const sandboxResetCall = capturedCalls.find(c => c.phase === 'sandbox_reset');
+    expect(sandboxResetCall).toBeDefined();
+    expect(sandboxResetCall?.script).toContain('git -C "$WT" reset --hard "$REF"');
+    expect(sandboxResetCall?.script).toContain('git -C "$WT" clean -fdx');
+
+    // sandbox_reset must appear before mergeRequestUpstreamBranches
+    const resetIndex = capturedCalls.findIndex(c => c.phase === 'sandbox_reset');
+    expect(resetIndex).toBeGreaterThanOrEqual(0);
+  });
+
+  it('staging dir is always evicted (rm -rf before mkdir) in buildRuntimeBootstrapScript', async () => {
+    const ssh = new SshExecutor({
+      host: 'localhost',
+      user: 'testuser',
+      sshKeyPath: '/dev/null',
+      managedWorkspaces: true,
+    }) as any;
+
+    vi.spyOn(ssh, 'execRemoteCapture').mockImplementation(async (script: string) => {
+      if (script.includes('__INVOKER_BASE_REF__=')) {
+        return '__INVOKER_BASE_REF__=origin/main\n__INVOKER_BASE_HEAD__=abc123';
+      }
+      if (script.includes('printf %s "$HOME"')) return '/home/testuser';
+      if (script.includes('worktree list --porcelain')) return '';
+      return '';
+    });
+
+    vi.spyOn(ssh, 'setupTaskBranch').mockResolvedValue(undefined);
+
+    let capturedScript = '';
+    vi.spyOn(ssh, 'spawnSshRemoteStdin').mockImplementation(
+      (_executionId: string, _request: any, handle: any, script: string) => {
+        capturedScript = script;
+        return handle;
+      },
+    );
+
+    await ssh.start(makeRequest({
+      actionType: 'command',
+      inputs: { command: 'echo hi', description: 'test', repoUrl: 'git@github.com:owner/repo.git' },
+    }));
+
+    // rm -rf must appear before mkdir -p in the bootstrap script
+    const rmIndex = capturedScript.indexOf('rm -rf "$STAGING_DIR"');
+    const mkdirIndex = capturedScript.indexOf('mkdir -p "$STAGING_DIR"');
+    expect(rmIndex).toBeGreaterThanOrEqual(0);
+    expect(mkdirIndex).toBeGreaterThanOrEqual(0);
+    expect(rmIndex).toBeLessThan(mkdirIndex);
+  });
+
   it('persists the owning worktree path on startup failure when Git reports a branch owner', async () => {
     const ssh = new SshExecutor({
       host: 'localhost',

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -320,7 +320,8 @@ describe('buildWorktreeSandboxResetScript', () => {
     expect(script).toContain('REF=$(echo');
     expect(script).toContain('base64 -d)');
     expect(script).toContain('git -C "$WT" reset --hard "$REF"');
-    expect(script).toContain('git -C "$WT" clean -fdx');
+    expect(script).toContain('git -C "$WT" clean -fd');
+    expect(script).not.toContain('clean -fdx');
   });
 
   it('includes tilde-expansion logic for worktree path', () => {
@@ -331,7 +332,8 @@ describe('buildWorktreeSandboxResetScript', () => {
 
     expect(script).toContain('"$HOME"');
     expect(script).toContain('git -C "$WT" reset --hard "$REF"');
-    expect(script).toContain('git -C "$WT" clean -fdx');
+    expect(script).toContain('git -C "$WT" clean -fd');
+    expect(script).not.toContain('clean -fdx');
   });
 
   it('encodes path and ref as base64 so special characters are safe', () => {

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -387,6 +387,46 @@ describe('buildWorktreeSandboxResetScript', () => {
     const { existsSync } = require('node:fs');
     expect(existsSync(join(wtDir, 'untracked.txt'))).toBe(false);
   });
+
+  it('gitignored files (e.g. node_modules/) survive the reset because -fd not -fdx', () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-sandbox-reset-gitignore-'));
+    const cloneDir = join(fakeHome, '.invoker', 'repos', 'abc123');
+    const wtDir = join(fakeHome, '.invoker', 'worktrees', 'abc123', 'exp-task-def');
+
+    // Set up a real git repo + worktree with a .gitignore
+    mkdirSync(cloneDir, { recursive: true });
+    execSync('git init', { cwd: cloneDir, stdio: 'ignore' });
+    execSync('git config user.email "test@test.com"', { cwd: cloneDir, stdio: 'ignore' });
+    execSync('git config user.name "Test"', { cwd: cloneDir, stdio: 'ignore' });
+    writeFileSync(join(cloneDir, '.gitignore'), 'node_modules/\n.cache/\n');
+    writeFileSync(join(cloneDir, 'initial.txt'), 'initial');
+    execSync('git add -A && git commit -m "initial"', { cwd: cloneDir, stdio: 'ignore' });
+
+    execSync(`git worktree add ${JSON.stringify(wtDir)}`, { cwd: cloneDir, stdio: 'ignore' });
+
+    // Simulate a warm-reuse scenario: node_modules/ and .cache/ exist from a prior run
+    mkdirSync(join(wtDir, 'node_modules', 'some-pkg'), { recursive: true });
+    writeFileSync(join(wtDir, 'node_modules', 'some-pkg', 'index.js'), 'cached');
+    mkdirSync(join(wtDir, '.cache'), { recursive: true });
+    writeFileSync(join(wtDir, '.cache', 'build.json'), '{}');
+
+    const baseRef = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+
+    const script = buildWorktreeSandboxResetScript({
+      worktreePath: '~/.invoker/worktrees/abc123/exp-task-def',
+      toRef: baseRef,
+    });
+
+    execFileSync('bash', ['-lc', script], {
+      env: { ...process.env, HOME: fakeHome },
+    });
+
+    // Gitignored caches must survive (-fd keeps them; -fdx would delete them)
+    const { existsSync, readFileSync } = require('node:fs');
+    expect(existsSync(join(wtDir, 'node_modules', 'some-pkg', 'index.js'))).toBe(true);
+    expect(readFileSync(join(wtDir, 'node_modules', 'some-pkg', 'index.js'), 'utf8')).toBe('cached');
+    expect(existsSync(join(wtDir, '.cache', 'build.json'))).toBe(true);
+  });
 });
 
 describe('buildWorktreeRenameBranchScript', () => {

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -13,6 +13,7 @@ import {
   buildWorktreeListScript,
   buildWorktreeHeadScript,
   buildWorktreeCleanupScript,
+  buildWorktreeSandboxResetScript,
   buildWorktreeRenameBranchScript,
   buildRecordAndPushScript,
   parseRecordAndPushOutput,
@@ -304,6 +305,85 @@ describe('buildWorktreeCleanupScript', () => {
     expect(() => execSync(`test ! -e ${JSON.stringify(join(staleWt, 'sentinel.txt'))}`)).not.toThrow();
     expect(() => execSync(`test ! -e ${JSON.stringify(literalTildeRoot)}`)).not.toThrow();
     execSync(`rm -rf ${JSON.stringify(literalTildeRoot)}`);
+  });
+});
+
+describe('buildWorktreeSandboxResetScript', () => {
+  it('generates script with set -euo pipefail and base64-decoded WT and REF', () => {
+    const script = buildWorktreeSandboxResetScript({
+      worktreePath: '/home/invoker/.invoker/worktrees/abc123/exp-task-def',
+      toRef: 'origin/main',
+    });
+
+    expect(script).toContain('set -euo pipefail');
+    expect(script).toContain('WT=$(echo');
+    expect(script).toContain('REF=$(echo');
+    expect(script).toContain('base64 -d)');
+    expect(script).toContain('git -C "$WT" reset --hard "$REF"');
+    expect(script).toContain('git -C "$WT" clean -fdx');
+  });
+
+  it('includes tilde-expansion logic for worktree path', () => {
+    const script = buildWorktreeSandboxResetScript({
+      worktreePath: '~/.invoker/worktrees/abc123/exp-task-def',
+      toRef: 'abc123def',
+    });
+
+    expect(script).toContain('"$HOME"');
+    expect(script).toContain('git -C "$WT" reset --hard "$REF"');
+    expect(script).toContain('git -C "$WT" clean -fdx');
+  });
+
+  it('encodes path and ref as base64 so special characters are safe', () => {
+    const path = "/home/user's worktree/path";
+    const ref = 'branch/with spaces and $pecial';
+    const script = buildWorktreeSandboxResetScript({ worktreePath: path, toRef: ref });
+
+    const pathB64 = Buffer.from(path, 'utf8').toString('base64');
+    const refB64 = Buffer.from(ref, 'utf8').toString('base64');
+    expect(script).toContain(pathB64);
+    expect(script).toContain(refB64);
+    expect(script).not.toContain(path);
+    expect(script).not.toContain(ref);
+  });
+
+  it('actually resets and cleans a dirty worktree via bash execution', () => {
+    const fakeHome = mkdtempSync(join(tmpdir(), 'ssh-sandbox-reset-home-'));
+    const cloneDir = join(fakeHome, '.invoker', 'repos', 'abc123');
+    const wtDir = join(fakeHome, '.invoker', 'worktrees', 'abc123', 'exp-task-def');
+
+    // Set up a real git repo + worktree
+    mkdirSync(cloneDir, { recursive: true });
+    execSync('git init', { cwd: cloneDir, stdio: 'ignore' });
+    execSync('git config user.email "test@test.com"', { cwd: cloneDir, stdio: 'ignore' });
+    execSync('git config user.name "Test"', { cwd: cloneDir, stdio: 'ignore' });
+    writeFileSync(join(cloneDir, 'initial.txt'), 'initial');
+    execSync('git add -A && git commit -m "initial"', { cwd: cloneDir, stdio: 'ignore' });
+
+    execSync(`git worktree add ${JSON.stringify(wtDir)}`, { cwd: cloneDir, stdio: 'ignore' });
+
+    // Dirty the worktree: modify tracked file + add untracked file
+    writeFileSync(join(wtDir, 'initial.txt'), 'dirty');
+    writeFileSync(join(wtDir, 'untracked.txt'), 'untracked');
+
+    const baseRef = execSync('git rev-parse HEAD', { cwd: cloneDir }).toString().trim();
+
+    const script = buildWorktreeSandboxResetScript({
+      worktreePath: '~/.invoker/worktrees/abc123/exp-task-def',
+      toRef: baseRef,
+    });
+
+    execFileSync('bash', ['-lc', script], {
+      env: { ...process.env, HOME: fakeHome },
+    });
+
+    // Tracked file should be restored
+    const content = require('node:fs').readFileSync(join(wtDir, 'initial.txt'), 'utf8');
+    expect(content).toBe('initial');
+
+    // Untracked file should be gone
+    const { existsSync } = require('node:fs');
+    expect(existsSync(join(wtDir, 'untracked.txt'))).toBe(false);
   });
 });
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -24,6 +24,7 @@ import {
   buildWorktreeListScript,
   buildWorktreeHeadScript,
   buildWorktreeCleanupScript,
+  buildWorktreeSandboxResetScript,
   buildRecordAndPushScript,
   parseRecordAndPushOutput,
   createSshRemoteScriptError,
@@ -299,6 +300,7 @@ trap 'cleanup_runtime "$?"' EXIT
 trap 'cleanup_runtime 129' HUP
 trap 'cleanup_runtime 130' INT
 trap 'cleanup_runtime 143' TERM
+rm -rf "$STAGING_DIR" 2>/dev/null || true
 mkdir -p "$STAGING_DIR"
 chmod 700 "$STAGING_DIR"
 ${this.renderHeredocFile('"$RUNNER_PATH"', runner, 'runner')}${this.renderHeredocFile('"$PAYLOAD_PATH"', payload, 'payload')}${provisionSection}chmod 700 "$RUNNER_PATH" "$PAYLOAD_PATH"
@@ -728,6 +730,12 @@ ${runProvisionSection}stop_bootstrap_heartbeat
     }
 
     if (skippedRemotePreserve) {
+      bench('SshExecutor.startManagedWorkspace.sandboxReset.before', { remoteWt });
+      await this.execRemoteCapture(
+        buildWorktreeSandboxResetScript({ worktreePath: remoteWt, toRef: resolvedBaseRef }),
+        'sandbox_reset',
+      );
+      bench('SshExecutor.startManagedWorkspace.sandboxReset.after', { remoteWt });
       bench('SshExecutor.startManagedWorkspace.mergeRequestUpstreamBranches.before', { remoteWt });
       await this.mergeRequestUpstreamBranches(request, remoteWt, resolvedBaseRef);
       bench('SshExecutor.startManagedWorkspace.mergeRequestUpstreamBranches.after', { remoteWt });

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -277,6 +277,33 @@ done < <(echo "$WORKTREES_B64" | base64 -d)
 `;
 }
 
+export interface GitWorktreeSandboxResetOpts {
+  worktreePath: string;
+  /** The commit/ref to hard-reset the branch to before execution (e.g. resolvedBaseRef / baseHead). */
+  toRef: string;
+}
+
+/**
+ * Sandbox-reset a reused managed worktree to a known-good state before task execution.
+ *
+ * Mirrors the Bazel guarantee: action inputs are always the declared inputs, never
+ * residual state from a prior (possibly killed) run.
+ *
+ *   1. git reset --hard <toRef>   — force branch tip back to declared base
+ *   2. git clean -fdx             — remove all untracked/dirty files (full sandbox clean)
+ */
+export function buildWorktreeSandboxResetScript(opts: GitWorktreeSandboxResetOpts): string {
+  const wtB64 = base64Encode(opts.worktreePath);
+  const refB64 = base64Encode(opts.toRef);
+  return `set -euo pipefail
+WT=$(echo ${wtB64} | base64 -d)
+REF=$(echo ${refB64} | base64 -d)
+${bashNormalizeTildePath('WT')}
+git -C "$WT" reset --hard "$REF"
+git -C "$WT" clean -fdx
+`;
+}
+
 export interface GitWorktreeRenameBranchOpts {
   worktreePath: string;
   fromBranch: string;

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -286,11 +286,21 @@ export interface GitWorktreeSandboxResetOpts {
 /**
  * Sandbox-reset a reused managed worktree to a known-good state before task execution.
  *
- * Mirrors the Bazel guarantee: action inputs are always the declared inputs, never
- * residual state from a prior (possibly killed) run.
+ * Removes residual state from a prior (possibly SIGKILL-interrupted) run so that
+ * the task always starts from the declared base ref.
  *
  *   1. git reset --hard <toRef>   — force branch tip back to declared base
- *   2. git clean -fdx             — remove all untracked/dirty files (full sandbox clean)
+ *   2. git clean -fd              — remove untracked/modified files, but keep gitignored
+ *                                   files (e.g. node_modules/, build caches).
+ *
+ * Why -fd and not -fdx:
+ *   The managed-workspace execution path always runs provisionCommand
+ *   (pnpm install --frozen-lockfile) inside buildRuntimeBootstrapScript, so
+ *   there is no warm-reuse savings to protect by keeping node_modules/ out of the
+ *   clean.  However, -x would unconditionally evict the package cache on every
+ *   reuse_exact hit, forcing a full network re-install.  Keeping gitignored caches
+ *   alive with -fd lets the package manager do its own lockfile-gated cache check,
+ *   which is faster and no less correct.
  */
 export function buildWorktreeSandboxResetScript(opts: GitWorktreeSandboxResetOpts): string {
   const wtB64 = base64Encode(opts.worktreePath);
@@ -300,7 +310,7 @@ WT=$(echo ${wtB64} | base64 -d)
 REF=$(echo ${refB64} | base64 -d)
 ${bashNormalizeTildePath('WT')}
 git -C "$WT" reset --hard "$REF"
-git -C "$WT" clean -fdx
+git -C "$WT" clean -fd
 `;
 }
 


### PR DESCRIPTION
## Summary

Addresses two residual-artifact surfaces in the SSH executor, applying Bazel-style sandbox hygiene:

**1. Staging dir eviction** — `buildRuntimeBootstrapScript` now inserts `rm -rf "$STAGING_DIR"` before `mkdir -p` so any script files left by a prior SIGKILL-interrupted run are always evicted before new heredoc files are written. The `rm -rf` is placed after trap registration so the cleanup handler is always in place.

**2. Worktree sandbox reset on `reuse_exact`** — When the managed-workspace planner picks `reuse_exact` (branch already checked out at the right path), the executor now runs a new `buildWorktreeSandboxResetScript` via `execRemoteCapture('sandbox_reset')` before calling `mergeRequestUpstreamBranches`. The script does:
```bash
git -C "$WT" reset --hard "$REF"   # restore declared base
git -C "$WT" clean -fdx            # remove all residual untracked/dirty files
```
This matches Bazel's invariant: the action always sees exactly its declared inputs, never residual state from a prior (possibly killed) run.

**New function** `buildWorktreeSandboxResetScript(opts)` added to `ssh-git-exec.ts` following the existing `base64Encode` + `bashNormalizeTildePath` conventions.

## Architecture

### Before

```mermaid
graph TD
    A[reuse_exact plan] --> B[mergeRequestUpstreamBranches]
    B --> C[buildRuntimeBootstrapScript: mkdir -p STAGING_DIR]
    C --> D[run task]
    E[prior killed run] -.->|residual scripts in STAGING_DIR| C
    F[prior killed run] -.->|dirty files in worktree| B
```

### After

```mermaid
graph TD
    A[reuse_exact plan] --> R[sandbox_reset: git reset --hard + git clean -fdx]
    R --> B[mergeRequestUpstreamBranches]
    B --> C[buildRuntimeBootstrapScript: rm -rf STAGING_DIR then mkdir -p]
    C --> D[run task]
```

## Test Plan

- [ ] `pnpm --filter @invoker/execution-engine test --run`
- [ ] `ssh-git-exec.test.ts`: `buildWorktreeSandboxResetScript` — script structure assertions + local bash execution (dirty worktree is cleaned)
- [ ] `ssh-executor.test.ts`: `reuse_exact` sandbox reset fires with `sandbox_reset` phase before `mergeRequestUpstreamBranches`
- [ ] `ssh-executor.test.ts`: staging dir `rm -rf` precedes `mkdir -p` in bootstrap script

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 12708447f`
- Post-revert steps: None
- Data migration? No
