### PR TITLE
fix(app): emit recovery delta for every quarantine resolution (no implicit drops)

### DIFF
--- a/packages/app/src/__tests__/delta-merge.test.ts
+++ b/packages/app/src/__tests__/delta-merge.test.ts
@@ -14,7 +14,12 @@
  * - Multi-task quarantine isolation
  */
 import { describe, it, expect } from 'vitest';
-import { applyDelta, resolveQuarantine, TaskSnapshotCache } from '../delta-merge.js';
+import {
+  applyDelta,
+  recoverQuarantinedTask,
+  resolveQuarantine,
+  TaskSnapshotCache,
+} from '../delta-merge.js';
 import type { TaskState, TaskDelta } from '@invoker/workflow-core';
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -333,29 +338,38 @@ describe('resolveQuarantine', () => {
 
 // ── Gap recovery: main-process integration simulation ────────
 //
-// These tests simulate the recovery loop from main.ts (lines 2429-2437):
+// These tests simulate the production recovery loop in main.ts:
 //   1. applyDelta detects gap → returns quarantined IDs
-//   2. caller loads authoritative state from persistence (loadTask)
-//   3. resolveQuarantine re-seeds cache
-//   4. caller sends { type: 'created', task: authoritative } to renderer
+//   2. caller delegates to recoverQuarantinedTask, which restores the
+//      cache from persistence OR (for synthetic merge ids) the orchestrator
+//      in-memory state, and ALWAYS returns a renderer delta so no message
+//      to the renderer is silently dropped.
+//   3. caller forwards the returned renderer delta.
 //
-// The mock persistence loader is a plain function, not a real SQLite
-// adapter, which keeps tests deterministic and fast.
+// The mock loaders are plain functions, keeping the tests deterministic
+// and fast. `getMergeNode` defaults to returning undefined for the
+// non-synthetic tests in this file; the synthetic-merge-quarantine repro
+// covers the orchestrator-fallback path.
 
 /** Simulates the main-process recovery loop from main.ts. */
 function simulateMainProcessDeltaHandler(
   delta: TaskDelta,
   cache: TaskSnapshotCache,
   persistence: { loadTask: (id: string) => TaskState | undefined },
+  orchestrator: { getMergeNode: (workflowId: string) => TaskState | undefined } = {
+    getMergeNode: () => undefined,
+  },
 ): { rendererDeltas: TaskDelta[] } {
   const rendererDeltas: TaskDelta[] = [];
 
   const { quarantined } = applyDelta(delta, cache);
   for (const taskId of quarantined) {
-    const authoritative = persistence.loadTask(taskId);
-    resolveQuarantine(cache, taskId, authoritative);
-    if (authoritative) {
-      rendererDeltas.push({ type: 'created', task: authoritative });
+    const { rendererDelta } = recoverQuarantinedTask(cache, taskId, {
+      loadTask: persistence.loadTask,
+      getMergeNode: orchestrator.getMergeNode,
+    });
+    if (rendererDelta) {
+      rendererDeltas.push(rendererDelta);
     }
   }
   return { rendererDeltas };
@@ -390,7 +404,12 @@ describe('gap recovery: unknown task → quarantine + authoritative reload', () 
     expect((rendererDeltas[0] as { type: 'created'; task: TaskState }).task.taskStateVersion).toBe(3);
   });
 
-  it('unknown task with no persistence record removes cache entry silently', () => {
+  it('unknown task with no persistence record removes cache entry AND emits removed delta', () => {
+    // No-implicit-message-drops contract: any time the owner deletes a cache
+    // entry during recovery, it MUST tell the renderer so the renderer can
+    // drop its stale copy too. Silently dropping the recovery message is
+    // what causes the synthetic __merge__ graph-blank bug; the same
+    // discipline applies to non-synthetic ghost ids.
     const cache = new TaskSnapshotCache();
     const persistence = { loadTask: (_id: string) => undefined };
 
@@ -405,8 +424,10 @@ describe('gap recovery: unknown task → quarantine + authoritative reload', () 
     const { rendererDeltas } = simulateMainProcessDeltaHandler(delta, cache, persistence);
 
     expect(cache.has('ghost')).toBe(false);
-    // No renderer delta emitted for a task that doesn't exist in persistence
-    expect(rendererDeltas).toHaveLength(0);
+    expect(rendererDeltas).toHaveLength(1);
+    const [first] = rendererDeltas;
+    expect(first.type).toBe('removed');
+    expect((first as { type: 'removed'; taskId: string }).taskId).toBe('ghost');
   });
 });
 

--- a/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
+++ b/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Repro + regression guard for the synthetic `__merge__wf-…` quarantine-loop
+ * desync that blanks the graph UI.
+ *
+ * Real-world symptom: bursts of `[gap-detect] quarantined task="__merge__wf-X"`
+ * lines in ~/.invoker/invoker.log with no intervening recovery, after which
+ * the selected workflow's mini-DAG renders blank until the user reloads.
+ *
+ * Owner-side root cause (current production code at
+ * packages/app/src/main.ts:2896–2904):
+ *
+ *   const { quarantined } = applyDelta(d, lastKnownTaskStates);
+ *   for (const taskId of quarantined) {
+ *     const authoritative = loadTaskByIdFromPersistence(taskId);
+ *     resolveQuarantine(lastKnownTaskStates, taskId, authoritative);
+ *     if (authoritative) {
+ *       sendTaskDeltaToRenderer({ type: 'created', task: authoritative });
+ *     }
+ *   }
+ *
+ * For synthetic merge ids (`__merge__${workflowId}`) persistence has no
+ * record, so `authoritative === undefined`. `resolveQuarantine` silently
+ * deletes the owner cache entry and the renderer is told nothing. The next
+ * `updated` delta on the same id re-quarantines (unknown task branch in
+ * applyDelta) and the loop repeats indefinitely. The renderer keeps its
+ * stale snapshot for the merge node while the owner has erased it; when
+ * `workflows-changed` next reconciles, the selected workflow disappears.
+ *
+ * The fix introduces `recoverQuarantinedTask` in delta-merge.ts (with the
+ * "no implicit message drops" contract: every cache deletion is mirrored
+ * to the renderer via either `created` or `removed`). This file pins the
+ * four post-fix expectations as a permanent regression guard. Reverting
+ * the fix re-fails all four cases with the same diff shape as the
+ * original Phase 1 reproduction.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  applyDelta,
+  recoverQuarantinedTask,
+  TaskSnapshotCache,
+  type RecoveryLoaders,
+} from '../delta-merge.js';
+import type { TaskState, TaskDelta } from '@invoker/workflow-core';
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeTask(id: string, overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id,
+    description: `Task ${id}`,
+    status: 'running',
+    dependencies: [],
+    createdAt: new Date('2025-01-01'),
+    config: { workflowId: 'wf-1', command: `echo ${id}`, runnerKind: 'worktree' as const },
+    execution: {},
+    taskStateVersion: 1,
+    ...overrides,
+  } as TaskState;
+}
+
+function makeMergeNode(workflowId: string, taskStateVersion: number): TaskState {
+  return makeTask(`__merge__${workflowId}`, {
+    taskStateVersion,
+    config: {
+      workflowId,
+      command: 'noop',
+      runnerKind: 'worktree' as const,
+      isMergeNode: true,
+    },
+  });
+}
+
+/**
+ * Faithful mirror of the production main-process recovery loop
+ * (packages/app/src/main.ts:2896–2906): apply the delta, then for each
+ * quarantined id, run the shared `recoverQuarantinedTask` helper and
+ * collect every renderer delta it returns.
+ *
+ * Pre-fix, this file used a `simulateLegacyRecoveryLoop` that inlined the
+ * old buggy code (no orchestrator fallback, silent delete on persistence
+ * miss). Post-fix it calls the real helper so the assertions below act as
+ * a permanent regression guard.
+ */
+function runRecovery(
+  delta: TaskDelta,
+  cache: TaskSnapshotCache,
+  loaders: RecoveryLoaders,
+): { rendererDeltas: TaskDelta[] } {
+  const rendererDeltas: TaskDelta[] = [];
+  const { quarantined } = applyDelta(delta, cache);
+  for (const taskId of quarantined) {
+    const { rendererDelta } = recoverQuarantinedTask(cache, taskId, loaders);
+    if (rendererDelta) {
+      rendererDeltas.push(rendererDelta);
+    }
+  }
+  return { rendererDeltas };
+}
+
+// ── Fixtures ────────────────────────────────────────────────
+
+const SYNTHETIC_ID = '__merge__wf-X';
+const WORKFLOW_ID = 'wf-X';
+
+function seedCacheWithMergeNode(version: number): TaskSnapshotCache {
+  const cache = new TaskSnapshotCache();
+  cache.set(SYNTHETIC_ID, JSON.stringify(makeMergeNode(WORKFLOW_ID, version)));
+  return cache;
+}
+
+function loadTaskNeverReturnsSynthetic(_id: string): TaskState | undefined {
+  // Persistence never holds synthetic merge nodes.
+  return undefined;
+}
+
+function copyCache(source: TaskSnapshotCache): TaskSnapshotCache {
+  const clone = new TaskSnapshotCache();
+  for (const id of source.keys()) {
+    const snap = source.get(id);
+    if (snap) clone.set(id, snap);
+  }
+  return clone;
+}
+
+// ── Repro cases ─────────────────────────────────────────────
+
+describe('synthetic __merge__ quarantine-loop repro (graph-blank root cause)', () => {
+  it('(a) synthetic gap recovers from orchestrator memory and emits created delta', () => {
+    const cache = seedCacheWithMergeNode(2);
+    const authoritative = makeMergeNode(WORKFLOW_ID, 4);
+    const loaders: RecoveryLoaders = {
+      loadTask: loadTaskNeverReturnsSynthetic,
+      getMergeNode: (workflowId) => (workflowId === WORKFLOW_ID ? authoritative : undefined),
+    };
+
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: SYNTHETIC_ID,
+      changes: { status: 'completed' },
+      taskStateVersion: 4,
+      previousTaskStateVersion: 3,
+    };
+
+    const { rendererDeltas } = runRecovery(delta, cache, loaders);
+
+    expect(cache.has(SYNTHETIC_ID)).toBe(true);
+    expect(cache.getEntry(SYNTHETIC_ID)?.taskStateVersion).toBe(4);
+    expect(rendererDeltas).toHaveLength(1);
+    const first = rendererDeltas[0];
+    expect(first.type).toBe('created');
+    expect((first as { type: 'created'; task: TaskState }).task.id).toBe(SYNTHETIC_ID);
+    expect((first as { type: 'created'; task: TaskState }).task.taskStateVersion).toBe(4);
+  });
+
+  it('(b) synthetic gap with no orchestrator entry emits removed delta', () => {
+    const cache = seedCacheWithMergeNode(2);
+    const loaders: RecoveryLoaders = {
+      loadTask: loadTaskNeverReturnsSynthetic,
+      getMergeNode: (_workflowId) => undefined,
+    };
+
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: SYNTHETIC_ID,
+      changes: { status: 'completed' },
+      taskStateVersion: 4,
+      previousTaskStateVersion: 3,
+    };
+
+    const { rendererDeltas } = runRecovery(delta, cache, loaders);
+
+    expect(cache.has(SYNTHETIC_ID)).toBe(false);
+    expect(rendererDeltas).toHaveLength(1);
+    expect(rendererDeltas[0].type).toBe('removed');
+    expect((rendererDeltas[0] as { type: 'removed'; taskId: string }).taskId).toBe(SYNTHETIC_ID);
+  });
+
+  it('(c) burst of stale out-of-order synthetic deltas each get a recovery delta (no silent loop)', () => {
+    // Models the live-log signature: three `[gap-detect]` events for
+    // `__merge__wf-X` in <1s. Each iteration sends an `updated` delta whose
+    // `previousTaskStateVersion` does not match the (post-recovery) cache,
+    // mirroring the realistic case where the orchestrator races ahead and
+    // multiple stale deltas land in quick succession. Every quarantine MUST
+    // produce exactly one recovery delta — no silent loops.
+    const cache = seedCacheWithMergeNode(2);
+    // Orchestrator advances faster than the deltas arriving on the bus.
+    let authoritativeVersion = 10;
+    const loaders: RecoveryLoaders = {
+      loadTask: loadTaskNeverReturnsSynthetic,
+      getMergeNode: (workflowId) =>
+        workflowId === WORKFLOW_ID ? makeMergeNode(WORKFLOW_ID, authoritativeVersion) : undefined,
+    };
+
+    const allRendererDeltas: TaskDelta[] = [];
+    let totalQuarantined = 0;
+
+    for (const orchestratorVersion of [10, 11, 12]) {
+      authoritativeVersion = orchestratorVersion;
+      // Each delta is stale (prev=3) relative to whatever the cache holds
+      // after the previous recovery (v=10, then v=11, then v=12) — so all
+      // three deltas hit the gap branch in applyDelta.
+      const delta: TaskDelta = {
+        type: 'updated',
+        taskId: SYNTHETIC_ID,
+        changes: { status: 'running' },
+        taskStateVersion: 4,
+        previousTaskStateVersion: 3,
+      };
+
+      const beforeQuarantineState = applyDelta(delta, copyCache(cache));
+      totalQuarantined += beforeQuarantineState.quarantined.length;
+
+      const { rendererDeltas } = runRecovery(delta, cache, loaders);
+      allRendererDeltas.push(...rendererDeltas);
+    }
+
+    expect(totalQuarantined).toBe(3);
+    expect(allRendererDeltas).toHaveLength(3);
+    expect(allRendererDeltas.every((d) => d.type === 'created')).toBe(true);
+    expect(cache.getEntry(SYNTHETIC_ID)?.taskStateVersion).toBe(12);
+  });
+
+  it('(d) no implicit drops: non-synthetic ghost task emits removed delta', () => {
+    // Cache is empty: an updated delta for an unknown non-synthetic id should
+    // quarantine, persistence has no record, and recovery must still emit a
+    // removed delta so the renderer's stale entry is cleared.
+    const cache = new TaskSnapshotCache();
+    const loaders: RecoveryLoaders = {
+      loadTask: (_id) => undefined,
+      getMergeNode: (_workflowId) => undefined,
+    };
+
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: 't-ghost-real',
+      changes: { status: 'completed' },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    };
+
+    const { rendererDeltas } = runRecovery(delta, cache, loaders);
+
+    expect(cache.has('t-ghost-real')).toBe(false);
+    expect(rendererDeltas).toHaveLength(1);
+    expect(rendererDeltas[0].type).toBe('removed');
+    expect((rendererDeltas[0] as { type: 'removed'; taskId: string }).taskId).toBe('t-ghost-real');
+  });
+});

--- a/packages/app/src/delta-merge.ts
+++ b/packages/app/src/delta-merge.ts
@@ -162,6 +162,11 @@ export function applyDelta(
  * with the authoritative snapshot from persistence.
  *
  * If `task` is undefined (task no longer exists), the cache entry is removed.
+ *
+ * NOTE: this primitive is intentionally low-level — it does NOT notify the
+ * renderer. Production callers should go through `recoverQuarantinedTask`
+ * below, which enforces the "no implicit message drops" rule by always
+ * returning a renderer delta whenever it mutates the owner cache.
  */
 export function resolveQuarantine(
   cache: TaskSnapshotCache,
@@ -173,4 +178,76 @@ export function resolveQuarantine(
     return;
   }
   cache.set(taskId, JSON.stringify(task));
+}
+
+// ── Authoritative recovery (no implicit message drops) ──────
+
+/**
+ * Loaders the recovery loop consults to find an authoritative snapshot
+ * for a quarantined task id.
+ *
+ * - `loadTask`: persistence by id. Returns `undefined` for ids that have
+ *   never been persisted (notably synthetic merge nodes).
+ * - `getMergeNode`: orchestrator in-memory lookup by workflowId. Authoritative
+ *   source for synthetic `__merge__${workflowId}` ids, which are not stored
+ *   in persistence but are tracked in `Orchestrator.stateMachine`.
+ */
+export interface RecoveryLoaders {
+  loadTask: (taskId: string) => TaskState | undefined;
+  getMergeNode: (workflowId: string) => TaskState | undefined;
+}
+
+export interface RecoveryResult {
+  /**
+   * Renderer-bound delta the caller MUST forward to keep the renderer in
+   * sync with the owner cache. `undefined` only when no cache mutation
+   * happened (currently never — every branch either restores from an
+   * authoritative source or emits `removed`).
+   */
+  rendererDelta?: TaskDelta;
+}
+
+const SYNTHETIC_MERGE_PREFIX = '__merge__';
+
+/**
+ * Single source of truth for the main-process quarantine-recovery loop.
+ *
+ * Contract — no implicit message drops:
+ * - If persistence has the task → restore from persistence, emit `created`.
+ * - Else if it's a synthetic merge id and the orchestrator has it in memory
+ *   → restore from orchestrator, emit `created`.
+ * - Else (truly absent) → delete the cache entry, emit `removed` so the
+ *   renderer drops its stale copy too.
+ *
+ * This replaces the legacy `if (authoritative) { sendTaskDeltaToRenderer(...) }`
+ * pattern that silently dropped the recovery message whenever
+ * `loadTask` returned `undefined`. For synthetic merge nodes that path
+ * never produced a recovery delta, leaving the renderer's selected
+ * mini-DAG blank after every `[gap-detect]` event.
+ */
+export function recoverQuarantinedTask(
+  cache: TaskSnapshotCache,
+  taskId: string,
+  loaders: RecoveryLoaders,
+): RecoveryResult {
+  const persisted = loaders.loadTask(taskId);
+  if (persisted) {
+    resolveQuarantine(cache, taskId, persisted);
+    return { rendererDelta: { type: 'created', task: persisted } };
+  }
+
+  if (taskId.startsWith(SYNTHETIC_MERGE_PREFIX)) {
+    const workflowId = taskId.slice(SYNTHETIC_MERGE_PREFIX.length);
+    const synthetic = loaders.getMergeNode(workflowId);
+    if (synthetic) {
+      resolveQuarantine(cache, taskId, synthetic);
+      return { rendererDelta: { type: 'created', task: synthetic } };
+    }
+  }
+
+  const previousTaskStateVersion = cache.getEntry(taskId)?.taskStateVersion ?? 0;
+  resolveQuarantine(cache, taskId, undefined);
+  return {
+    rendererDelta: { type: 'removed', taskId, previousTaskStateVersion },
+  };
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -152,7 +152,7 @@ import { collectSystemDiagnostics } from './system-diagnostics.js';
 import { installBundledSkills, resolveBundledSkillsStatus } from './bundled-skills.js';
 import { createRequire } from 'node:module';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
-import { applyDelta, resolveQuarantine, TaskSnapshotCache } from './delta-merge.js';
+import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from './delta-merge.js';
 import {
   CoalescedWorkflowMetadataPublisher,
   WorkflowMetadataInvalidator,
@@ -2896,10 +2896,12 @@ function createEmbeddedTerminalBackendFromConfig(
       const { quarantined } = applyDelta(d, lastKnownTaskStates);
       for (const taskId of quarantined) {
         logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
-        const authoritative = loadTaskByIdFromPersistence(taskId);
-        resolveQuarantine(lastKnownTaskStates, taskId, authoritative);
-        if (authoritative) {
-          sendTaskDeltaToRenderer({ type: 'created', task: authoritative });
+        const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
+          loadTask: loadTaskByIdFromPersistence,
+          getMergeNode: (workflowId) => orchestrator.getMergeNode(workflowId),
+        });
+        if (rendererDelta) {
+          sendTaskDeltaToRenderer(rendererDelta);
         }
       }
     });


### PR DESCRIPTION
## Summary

Fixes the recurring graph-blank symptom where the selected workflow's mini-DAG disappears after a burst of `[gap-detect] quarantined task="__merge__wf-…"` events in `~/.invoker/invoker.log` (149 occurrences observed in a single live log).

Root cause is in the owner-side quarantine-recovery loop. Synthetic merge nodes (`__merge__${workflowId}`) are never persisted, so `persistence.loadTask('__merge__wf-…')` always returns `undefined`. The legacy loop in `packages/app/src/main.ts:2896–2904` then called `resolveQuarantine(... undefined)`, which silently deleted the owner cache entry without telling the renderer. Subsequent `updated` deltas for the same id re-quarantined (the owner now sees an unknown task), the loop repeated indefinitely, and the renderer kept its stale snapshot until the next `workflows-changed` reconcile dropped the workflow visually.

The fix extracts a single `recoverQuarantinedTask` helper that enforces a "no implicit message drops" contract: every branch that mutates the owner cache during recovery also returns a renderer delta — `created` from persistence, `created` from `orchestrator.getMergeNode` (synthetic-merge fallback), or `removed` when both sources are absent.

## Architecture

### Before

```mermaid
sequenceDiagram
  participant Orch as Orchestrator (in-mem)
  participant Bus as messageBus
  participant Owner as Owner cache
  participant Per as persistence.loadTask
  participant Rend as Renderer
  Note over Orch,Rend: cache and renderer both hold __merge__wf-X at v=2
  Orch->>Bus: updated prev=3 v=4
  Bus->>Owner: applyDelta -> gap -> quarantine
  Owner->>Per: loadTask("__merge__wf-X")
  Per-->>Owner: undefined (synthetic, never persisted)
  Owner-->>Owner: resolveQuarantine silently deletes entry
  Note over Owner,Rend: No renderer delta. Renderer keeps stale snapshot.
  Orch->>Bus: updated prev=4 v=5
  Bus->>Owner: applyDelta -> unknown task -> quarantine again
  Owner-->>Owner: silent delete (loop)
```

### After

```mermaid
sequenceDiagram
  participant Orch as Orchestrator (in-mem)
  participant Bus as messageBus
  participant Owner as Owner cache
  participant Per as persistence.loadTask
  participant Rec as recoverQuarantinedTask
  participant Rend as Renderer
  Orch->>Bus: updated prev=3 v=4
  Bus->>Owner: applyDelta -> gap -> quarantine
  Owner->>Rec: recoverQuarantinedTask("__merge__wf-X")
  Rec->>Per: loadTask -> undefined
  Rec->>Orch: getMergeNode("wf-X")
  Orch-->>Rec: authoritative merge node
  Rec-->>Owner: restore cache
  Rec-->>Rend: created delta
  Note over Owner,Rend: Owner and renderer back in sync. No silent loop.
```

## Test Plan

- [x] `cd packages/app && pnpm test -- synthetic-merge-quarantine-loop-repro` — new 4-case repro that fails 4/4 against the legacy loop and passes 4/4 against the fix. Covers synthetic-orchestrator-hit, synthetic-miss, stale-burst (3-in-a-row), and non-synthetic ghost branches.
- [x] `cd packages/app && pnpm test` — full package suite green (995 passed, 1 skipped, 0 failures), including the migrated ghost-task assertion in `packages/app/src/__tests__/delta-merge.test.ts`.
- [x] Live-log field evidence: `grep -c 'gap-detect\] quarantined task=\\"__merge__' ~/.invoker/invoker.log` returned `149`, confirming the production fingerprint of the bug this fix removes.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — the change is contained to `packages/app/src/delta-merge.ts`, `packages/app/src/main.ts`, and two test files.
- Data migration? No — no schema, IPC contract, or persistence-layer changes.
