### PR TITLE
Wire cascadeDownstream in buildInvalidationDeps

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -1994,6 +1994,75 @@ describe('buildInvalidationDeps', () => {
       taskExecutor.killActiveExecution.mock.invocationCallOrder[0],
     );
   });
+
+  // Cross-workflow cascade wiring (Phase 3.3 of "Cascade Upstream
+  // Invalidations to Downstream Workflows"). The dep MUST resolve a
+  // task-scoped id to its owning workflowId via
+  // `orchestrator.getTask(id)?.config.workflowId`, then delegate to
+  // `Orchestrator.cascadeInvalidationToDownstream`.
+  it('exposes cascadeDownstream that delegates to orchestrator.cascadeInvalidationToDownstream for workflow scope', async () => {
+    const cascaded = [makeRunningTask({ id: 'wf-2/leaf' })];
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      cascadeInvalidationToDownstream: vi.fn(() => cascaded),
+      getTask: vi.fn(() => undefined),
+    };
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
+    expect(deps.cascadeDownstream).toBeDefined();
+    const result = await deps.cascadeDownstream!('workflow', 'wf-1');
+
+    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-1');
+    expect(orchestrator.getTask).not.toHaveBeenCalled();
+    expect(result).toEqual(cascaded);
+  });
+
+  it('cascadeDownstream resolves task scope to workflowId via orchestrator.getTask', async () => {
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
+      getTask: vi.fn(() => ({
+        id: 'task-a',
+        config: { workflowId: 'wf-resolved' },
+      })),
+    };
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
+    await deps.cascadeDownstream!('task', 'task-a');
+
+    expect(orchestrator.getTask).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-resolved');
+  });
+
+  it('cascadeDownstream returns [] without calling orchestrator when task is not found', async () => {
+    const orchestrator = {
+      ...makeBaseOrchestrator(),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
+      getTask: vi.fn(() => undefined),
+    };
+    const persistence = makePersistence();
+
+    const deps = buildInvalidationDeps({
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+    });
+
+    const result = await deps.cascadeDownstream!('task', 'unknown-task');
+
+    expect(orchestrator.getTask).toHaveBeenCalledWith('unknown-task');
+    expect(orchestrator.cascadeInvalidationToDownstream).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+  });
 });
 
 describe('deleteAllWorkflows', () => {

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -578,6 +578,21 @@ export function buildInvalidationDeps(
       rejectTask(taskId, { orchestrator: deps.orchestrator });
       return [];
     },
+    // Cross-workflow cascade: every invalidating action in
+    // `applyInvalidation` (six in total: retryTask, recreateTask,
+    // retryWorkflow, recreateWorkflow, recreateWorkflowFromFreshBase,
+    // workflowFork) propagates to transitive downstream workflows
+    // via `Orchestrator.cascadeInvalidationToDownstream`. For task
+    // scope we resolve the task's owning workflow first; if the task
+    // is not found (already detached) the cascade is a no-op.
+    cascadeDownstream: (scope, id) => {
+      const workflowId =
+        scope === 'workflow'
+          ? id
+          : deps.orchestrator.getTask(id)?.config.workflowId;
+      if (!workflowId) return [];
+      return deps.orchestrator.cascadeInvalidationToDownstream(workflowId);
+    },
   };
 }
 


### PR DESCRIPTION
Production callers (CommandService, headless command path, IPC
handlers) construct InvalidationDeps via buildInvalidationDeps in
packages/app/src/workflow-actions.ts. To activate the cross-workflow
cascade introduced in the previous commit on real callers, wire
deps.cascadeDownstream to Orchestrator.cascadeInvalidationToDownstream.

For workflow scope the dep forwards the workflowId directly; for task
scope it resolves the owning workflowId via
orchestrator.getTask(id)?.config.workflowId. If the task is missing
(e.g. already detached) the dep returns [] without invoking the
orchestrator, mirroring the defensive style of the other deps.

Test plan:
- cd packages/app && pnpm test
  → 994 passed, including 3 new buildInvalidationDeps tests:
    workflow-scope delegation, task-scope workflowId resolution, and
    the missing-task no-op.


Co-authored-by: Cursor <cursoragent@cursor.com>

Depends-On: #887