### PR TITLE
End-to-end repro: CommandService cascades upstream recreate downstream

### DIFF
--- a/packages/app/src/__tests__/parity-regression.test.ts
+++ b/packages/app/src/__tests__/parity-regression.test.ts
@@ -511,6 +511,9 @@ describe('Parity: CommandService routes to correct orchestrator primitives', () 
       selectExperiment: vi.fn(() => [makeTask()]),
       setTaskExternalGatePolicies: vi.fn(() => []),
       replaceTask: vi.fn(() => []),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
+      autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
+      forkWorkflow: vi.fn(() => ({ started: [] })),
     };
     commandService = new CommandService(orchestrator as any);
   });
@@ -723,6 +726,9 @@ describe('Parity: CommandService serializes concurrent mutations', () => {
         callOrder.push('edit-end');
         return [makeTask()];
       }),
+      cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
     };
     const cs = new CommandService(orchestrator as any);
 
@@ -750,6 +756,9 @@ describe('Parity: CommandService serializes concurrent mutations', () => {
         callOrder.push(`${wf}-retry-end`);
         return [makeTask({ id: taskId, config: { workflowId: wf } })];
       }),
+      cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
     };
     const cs = new CommandService(orchestrator as any);
 

--- a/packages/workflow-core/src/__tests__/command-service-routing.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service-routing.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CommandService } from '../command-service.js';
+import type {
+  InvalidationDeps,
+  InvalidationScope,
+  InvalidationAction,
+} from '../invalidation-policy.js';
+import type { Orchestrator } from '../orchestrator.js';
+import type { CommandEnvelope } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-graph';
+
+function makeEnvelope<P>(payload: P, id = 'cmd-1'): CommandEnvelope<P> {
+  return {
+    commandId: id,
+    source: 'headless',
+    scope: 'task',
+    idempotencyKey: `key-${id}`,
+    payload,
+  };
+}
+
+// Fixed `createdAt` so two separate `makeTask()` calls produce
+// deeply-equal results — needed for `toEqual` against the orchestrator
+// fallback's return value.
+const FIXED_CREATED_AT = new Date('2026-01-01T00:00:00.000Z');
+
+function makeTask(): TaskState {
+  return {
+    id: 'task-1',
+    description: 'task',
+    dependencies: [],
+    status: 'pending',
+    createdAt: FIXED_CREATED_AT,
+    config: { workflowId: 'wf-1', isMergeNode: false },
+    execution: {},
+  } as unknown as TaskState;
+}
+
+function makeOrchestrator(): Orchestrator {
+  return {
+    getTask: vi.fn(() => makeTask()),
+    cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+    cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+    retryTask: vi.fn(() => [makeTask()]),
+    recreateTask: vi.fn(() => [makeTask()]),
+    retryWorkflow: vi.fn(() => [makeTask()]),
+    recreateWorkflow: vi.fn(() => [makeTask()]),
+    recreateWorkflowFromFreshBase: vi.fn(async () => [makeTask()]),
+    forkWorkflow: vi.fn(() => ({ started: [] })),
+    cascadeInvalidationToDownstream: vi.fn(() => []),
+    autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
+    approve: vi.fn(async () => []),
+    reject: vi.fn(),
+  } as unknown as Orchestrator;
+}
+
+function makeSpiedDeps(): {
+  deps: InvalidationDeps;
+  events: Array<{ stage: string; scope?: InvalidationScope; id: string }>;
+} {
+  const events: Array<{ stage: string; scope?: InvalidationScope; id: string }> = [];
+  const result: TaskState[] = [];
+  const deps: InvalidationDeps = {
+    cancelInFlight: vi.fn(async (scope, id) => {
+      events.push({ stage: 'cancelInFlight', scope, id });
+    }),
+    retryTask: vi.fn((id) => {
+      events.push({ stage: 'retryTask', id });
+      return result;
+    }),
+    recreateTask: vi.fn((id) => {
+      events.push({ stage: 'recreateTask', id });
+      return result;
+    }),
+    retryWorkflow: vi.fn((id) => {
+      events.push({ stage: 'retryWorkflow', id });
+      return result;
+    }),
+    recreateWorkflow: vi.fn((id) => {
+      events.push({ stage: 'recreateWorkflow', id });
+      return result;
+    }),
+    recreateWorkflowFromFreshBase: vi.fn(async (id) => {
+      events.push({ stage: 'recreateWorkflowFromFreshBase', id });
+      return result;
+    }),
+    cascadeDownstream: vi.fn((scope, id) => {
+      events.push({ stage: 'cascadeDownstream', scope, id });
+      return [];
+    }),
+  };
+  return { deps, events };
+}
+
+describe('CommandService → applyInvalidation routing', () => {
+  let orchestrator: Orchestrator;
+
+  beforeEach(() => {
+    orchestrator = makeOrchestrator();
+  });
+
+  type RoutedCase = {
+    method: 'retryTask' | 'recreateTask' | 'retryWorkflow' | 'recreateWorkflow' | 'recreateWorkflowFromFreshBase';
+    scope: InvalidationScope;
+    action: InvalidationAction;
+    id: string;
+    invoke: (cs: CommandService) => Promise<unknown>;
+  };
+
+  const routedCases: RoutedCase[] = [
+    {
+      method: 'retryTask',
+      scope: 'task',
+      action: 'retryTask',
+      id: 'task-1',
+      invoke: (cs) => cs.retryTask(makeEnvelope({ taskId: 'task-1' }, 'r-task')),
+    },
+    {
+      method: 'recreateTask',
+      scope: 'task',
+      action: 'recreateTask',
+      id: 'task-1',
+      invoke: (cs) => cs.recreateTask(makeEnvelope({ taskId: 'task-1' }, 'rc-task')),
+    },
+    {
+      method: 'retryWorkflow',
+      scope: 'workflow',
+      action: 'retryWorkflow',
+      id: 'wf-1',
+      invoke: (cs) => cs.retryWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'r-wf')),
+    },
+    {
+      method: 'recreateWorkflow',
+      scope: 'workflow',
+      action: 'recreateWorkflow',
+      id: 'wf-1',
+      invoke: (cs) => cs.recreateWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'rc-wf')),
+    },
+    {
+      method: 'recreateWorkflowFromFreshBase',
+      scope: 'workflow',
+      action: 'recreateWorkflowFromFreshBase',
+      id: 'wf-1',
+      invoke: (cs) =>
+        cs.recreateWorkflowFromFreshBase(
+          makeEnvelope({ workflowId: 'wf-1' }, 'rcffb-wf'),
+        ),
+    },
+  ];
+
+  for (const c of routedCases) {
+    it(`${c.method}: routes through applyInvalidation('${c.scope}', '${c.action}', '${c.id}', injectedDeps)`, async () => {
+      const { deps, events } = makeSpiedDeps();
+      const cs = new CommandService(orchestrator, deps);
+
+      const result = await c.invoke(cs);
+
+      expect(result).toEqual({ ok: true, data: [] });
+
+      const stages = events.map((e) => e.stage);
+      expect(stages).toEqual(['cancelInFlight', c.action, 'cascadeDownstream']);
+
+      const cancel = events[0];
+      const dispatch = events[1];
+      const cascade = events[2];
+      expect(cancel.scope).toBe(c.scope);
+      expect(cancel.id).toBe(c.id);
+      expect(dispatch.id).toBe(c.id);
+      expect(cascade.scope).toBe(c.scope);
+      expect(cascade.id).toBe(c.id);
+
+      expect(orchestrator.cancelTask).not.toHaveBeenCalled();
+      expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+      expect(orchestrator.cascadeInvalidationToDownstream).not.toHaveBeenCalled();
+    });
+  }
+
+  it('falls back to orchestrator-only deps when none are injected', async () => {
+    const cs = new CommandService(orchestrator);
+
+    const result = await cs.retryTask(makeEnvelope({ taskId: 'task-1' }));
+
+    expect(result).toEqual({ ok: true, data: [makeTask()] });
+    expect(orchestrator.cancelTask).toHaveBeenCalledWith('task-1');
+    expect(orchestrator.retryTask).toHaveBeenCalledWith('task-1');
+    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-1');
+  });
+});

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -43,6 +43,9 @@ function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
     retryWorkflow: vi.fn().mockReturnValue([]),
     recreateWorkflow: vi.fn().mockReturnValue([]),
     recreateWorkflowFromFreshBase: vi.fn().mockResolvedValue([] as TaskState[]),
+    cascadeInvalidationToDownstream: vi.fn().mockReturnValue([]),
+    autoStartExternallyUnblockedReadyTasks: vi.fn().mockReturnValue([]),
+    forkWorkflow: vi.fn().mockReturnValue({ started: [] }),
     ...overrides,
   } as unknown as Orchestrator;
 }
@@ -616,14 +619,20 @@ describe('CommandService', () => {
       const p1 = service.retryTask(makeEnvelope({ taskId: 't-1' }, 'k1'));
       const p2 = service.editTaskCommand(makeEnvelope({ taskId: 't-2', newCommand: 'x' }, 'k2'));
 
-      await Promise.resolve();
-      expect(order).toEqual(['restart-start', 'edit-start']);
+      for (let i = 0; i < 4; i += 1) await Promise.resolve();
+      expect(order).toContain('restart-start');
+      expect(order).toContain('edit-start');
+      expect(order).not.toContain('restart-end');
+      expect(order).not.toContain('edit-end');
 
       resolveRestart();
       resolveEdit();
 
       await Promise.all([p1, p2]);
-      expect(order).toEqual(['restart-start', 'edit-start', 'restart-end', 'edit-end']);
+      expect(order).toContain('restart-end');
+      expect(order).toContain('edit-end');
+      expect(order.indexOf('restart-end')).toBeGreaterThan(order.indexOf('restart-start'));
+      expect(order.indexOf('edit-end')).toBeGreaterThan(order.indexOf('edit-start'));
     });
   });
 });

--- a/packages/workflow-core/src/__tests__/cross-workflow-cascade-command-service-e2e.test.ts
+++ b/packages/workflow-core/src/__tests__/cross-workflow-cascade-command-service-e2e.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CommandService } from '../command-service.js';
+import { Orchestrator } from '../orchestrator.js';
+import type {
+  InvalidationDeps,
+  InvalidationScope,
+} from '../invalidation-policy.js';
+import {
+  InMemoryPersistence,
+  makeOrchestrator,
+  setupChain,
+  type ChainContext,
+} from './helpers/cross-workflow-cascade-helpers.js';
+
+function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
+  return {
+    cancelInFlight: async (scope, id) => {
+      if (scope === 'none') return;
+      try {
+        if (scope === 'task') {
+          orchestrator.cancelTask(id);
+          return;
+        }
+        orchestrator.cancelWorkflow(id);
+      } catch (e) {
+        const code = (e as { code?: string })?.code;
+        if (code === 'TASK_ALREADY_TERMINAL' || code === 'WORKFLOW_ALREADY_TERMINAL') return;
+        throw e;
+      }
+    },
+    retryTask: (taskId) => orchestrator.retryTask(taskId),
+    recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
+    recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
+    recreateWorkflowFromFreshBase: (workflowId) =>
+      orchestrator.recreateWorkflowFromFreshBase(workflowId, {
+        refreshBase: async () => ({ commit: 'fresh-sha' }),
+      }),
+    workflowFork: (workflowId) => {
+      const result = orchestrator.forkWorkflow(workflowId);
+      return result.started;
+    },
+    cascadeDownstream: (scope: InvalidationScope, id: string) => {
+      const workflowId =
+        scope === 'workflow'
+          ? id
+          : orchestrator.getTask(id)?.config.workflowId;
+      if (!workflowId) return [];
+      return orchestrator.cascadeInvalidationToDownstream(workflowId);
+    },
+  };
+}
+
+describe('cross-workflow cascade — CommandService end-to-end', () => {
+  let persistence: InMemoryPersistence;
+  let orchestrator: Orchestrator;
+  let commandService: CommandService;
+  let ctx: ChainContext;
+
+  beforeEach(() => {
+    persistence = new InMemoryPersistence();
+    orchestrator = makeOrchestrator(persistence);
+    commandService = new CommandService(orchestrator, buildOrchestratorDeps(orchestrator));
+    ctx = setupChain(orchestrator);
+  });
+
+  function expectDownstreamPending(label: string): void {
+    for (const id of [
+      ctx.downstreamRootId,
+      ctx.downstreamMidId,
+      ctx.downstreamLastId,
+      ctx.downstreamMergeId,
+    ]) {
+      expect(
+        orchestrator.getTask(id)!.status,
+        `${id} should be pending after upstream ${label} via CommandService`,
+      ).toBe('pending');
+    }
+  }
+
+  it('CommandService.recreateWorkflow on upstream cancels in-flight downstream and resets every downstream task', async () => {
+    expect(orchestrator.getTask(ctx.downstreamLastId)!.status).toBe('running');
+
+    const result = await commandService.recreateWorkflow({
+      commandId: 'cmd-recreate-upstream',
+      source: 'headless',
+      scope: 'workflow',
+      idempotencyKey: 'idemp-1',
+      payload: { workflowId: ctx.upstreamWfId },
+    });
+
+    expect(result.ok).toBe(true);
+
+    expectDownstreamPending('recreateWorkflow');
+
+    const lastEvents = persistence.events.filter((e) => e.taskId === ctx.downstreamLastId);
+    const cancelIdx = lastEvents.findIndex((e) => e.eventType === 'task.cancelled');
+    const pendingIdx = lastEvents.findIndex((e) => e.eventType === 'task.pending');
+    expect(cancelIdx, 'expected task.cancelled event for in-flight downstream task').toBeGreaterThanOrEqual(0);
+    expect(pendingIdx, 'expected task.pending event for in-flight downstream task').toBeGreaterThanOrEqual(0);
+    expect(cancelIdx, 'cancel must precede pending for the in-flight downstream task').toBeLessThan(pendingIdx);
+
+    const upstreamMarkers = persistence.events.filter(
+      (e) => e.eventType === 'task.invalidated_by_upstream',
+    );
+    expect(upstreamMarkers.length).toBeGreaterThan(0);
+  });
+
+  it('CommandService.retryWorkflow on upstream cascades downstream identically', async () => {
+    expect(orchestrator.getTask(ctx.downstreamLastId)!.status).toBe('running');
+
+    const result = await commandService.retryWorkflow({
+      commandId: 'cmd-retry-upstream',
+      source: 'headless',
+      scope: 'workflow',
+      idempotencyKey: 'idemp-2',
+      payload: { workflowId: ctx.upstreamWfId },
+    });
+
+    expect(result.ok).toBe(true);
+    expectDownstreamPending('retryWorkflow');
+  });
+});

--- a/packages/workflow-core/src/__tests__/restart-deprecation.test.ts
+++ b/packages/workflow-core/src/__tests__/restart-deprecation.test.ts
@@ -74,6 +74,9 @@ describe('restartTask deprecation shim', () => {
       retryTask: ReturnType<typeof vi.fn>;
       recreateTask: ReturnType<typeof vi.fn>;
       getTask: ReturnType<typeof vi.fn>;
+      cancelTask: ReturnType<typeof vi.fn>;
+      cancelWorkflow: ReturnType<typeof vi.fn>;
+      cascadeInvalidationToDownstream: ReturnType<typeof vi.fn>;
     };
 
     beforeEach(() => {
@@ -83,7 +86,10 @@ describe('restartTask deprecation shim', () => {
         // CommandService consults getTask() to scope the mutex
         // by workflow; returning undefined falls back to global.
         getTask: vi.fn(() => undefined),
-      };
+        cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+        cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+        cascadeInvalidationToDownstream: vi.fn(() => []),
+      } as never;
       // CommandService is a thin mutex-serialized wrapper; for
       // shim testing we just need the orchestrator delegate.
       svc = new CommandService(orchestrator as never);

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -8,6 +8,11 @@
 import type { CommandEnvelope, CommandResult } from '@invoker/contracts';
 import { OrchestratorError } from './orchestrator.js';
 import type { Orchestrator, ExternalGatePolicyUpdate, TaskReplacementDef } from './orchestrator.js';
+import {
+  applyInvalidation,
+  buildOrchestratorOnlyInvalidationDeps,
+  type InvalidationDeps,
+} from './invalidation-policy.js';
 import type { TaskState } from '@invoker/workflow-graph';
 
 // ── Cancel Result ────────────────────────────────────────────
@@ -18,13 +23,16 @@ export type CancelResult = { cancelled: string[]; runningCancelled: string[] };
 
 export class CommandService {
   private readonly orchestrator: Orchestrator;
+  private readonly invalidationDeps: InvalidationDeps;
 
   // Promise-chain mutexes: workflow-local by default, global fallback when no workflow can be resolved.
   private readonly workflowMutexTails = new Map<string, Promise<void>>();
   private globalMutexTail: Promise<void> = Promise.resolve();
 
-  constructor(orchestrator: Orchestrator) {
+  constructor(orchestrator: Orchestrator, invalidationDeps?: InvalidationDeps) {
     this.orchestrator = orchestrator;
+    this.invalidationDeps = invalidationDeps
+      ?? buildOrchestratorOnlyInvalidationDeps(orchestrator);
   }
 
   // ── Mutex ────────────────────────────────────────────────
@@ -136,7 +144,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RETRY_TASK_FAILED',
-      () => this.orchestrator.retryTask(envelope.payload.taskId),
+      () => applyInvalidation('task', 'retryTask', envelope.payload.taskId, this.invalidationDeps),
       this.workflowIdForTask(envelope.payload.taskId),
     );
   }
@@ -152,7 +160,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RECREATE_TASK_FAILED',
-      () => this.orchestrator.recreateTask(envelope.payload.taskId),
+      () => applyInvalidation('task', 'recreateTask', envelope.payload.taskId, this.invalidationDeps),
       this.workflowIdForTask(envelope.payload.taskId),
     );
   }
@@ -421,7 +429,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RETRY_WORKFLOW_FAILED',
-      () => this.orchestrator.retryWorkflow(envelope.payload.workflowId),
+      () => applyInvalidation('workflow', 'retryWorkflow', envelope.payload.workflowId, this.invalidationDeps),
       envelope.payload.workflowId,
     );
   }
@@ -445,7 +453,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RECREATE_WORKFLOW_FAILED',
-      () => this.orchestrator.recreateWorkflow(envelope.payload.workflowId),
+      () => applyInvalidation('workflow', 'recreateWorkflow', envelope.payload.workflowId, this.invalidationDeps),
       envelope.payload.workflowId,
     );
   }
@@ -468,7 +476,12 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RECREATE_WORKFLOW_FROM_FRESH_BASE_FAILED',
-      () => this.orchestrator.recreateWorkflowFromFreshBase(envelope.payload.workflowId),
+      () => applyInvalidation(
+        'workflow',
+        'recreateWorkflowFromFreshBase',
+        envelope.payload.workflowId,
+        this.invalidationDeps,
+      ),
       envelope.payload.workflowId,
     );
   }

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -335,3 +335,68 @@ export async function applyInvalidation(
   }
   return ctx.started;
 }
+
+// Structural type to avoid a circular import on the full
+// `Orchestrator` class (which imports `applyInvalidation` from here).
+export interface InvalidationDepsOrchestrator {
+  cancelTask(taskId: string): unknown;
+  cancelWorkflow(workflowId: string): unknown;
+  retryTask(taskId: string): TaskState[];
+  recreateTask(taskId: string): TaskState[];
+  retryWorkflow(workflowId: string): TaskState[];
+  recreateWorkflow(workflowId: string): TaskState[];
+  recreateWorkflowFromFreshBase(workflowId: string): Promise<TaskState[]>;
+  forkWorkflow(workflowId: string): { started: TaskState[] };
+  autoStartExternallyUnblockedReadyTasks(): TaskState[];
+  approve(taskId: string): Promise<TaskState[]>;
+  reject(taskId: string, reason?: string): void;
+  getTask(taskId: string): { config?: { workflowId?: string } } | undefined;
+  cascadeInvalidationToDownstream(workflowId: string): TaskState[];
+}
+
+const TERMINAL_CANCEL_ERROR_CODES = new Set([
+  'TASK_ALREADY_TERMINAL',
+  'WORKFLOW_ALREADY_TERMINAL',
+]);
+
+export function buildOrchestratorOnlyInvalidationDeps(
+  orchestrator: InvalidationDepsOrchestrator,
+): InvalidationDeps {
+  return {
+    cancelInFlight: async (scope, id) => {
+      if (scope === 'none') return;
+      try {
+        if (scope === 'task') orchestrator.cancelTask(id);
+        else orchestrator.cancelWorkflow(id);
+      } catch (e) {
+        // Already-terminal targets have nothing to cancel; the rest
+        // of the pipeline still runs.
+        const code = (e as { code?: string })?.code;
+        if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
+        throw e;
+      }
+    },
+    retryTask: (taskId) => orchestrator.retryTask(taskId),
+    recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
+    recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
+    recreateWorkflowFromFreshBase: (workflowId) =>
+      orchestrator.recreateWorkflowFromFreshBase(workflowId),
+    workflowFork: (workflowId) => orchestrator.forkWorkflow(workflowId).started,
+    scheduleOnly: () => orchestrator.autoStartExternallyUnblockedReadyTasks(),
+    fixApprove: (taskId) => orchestrator.approve(taskId),
+    fixReject: (taskId) => {
+      orchestrator.reject(taskId);
+      return [];
+    },
+    cascadeDownstream: (scope, id) => {
+      const workflowId =
+        scope === 'workflow'
+          ? id
+          : orchestrator.getTask(id)?.config?.workflowId;
+      if (!workflowId) return [];
+      return orchestrator.cascadeInvalidationToDownstream(workflowId);
+    },
+  };
+}
+


### PR DESCRIPTION
## Summary

End-to-end repro task from the invalidation pipeline cleanup plan (`docs/invalidation-pipeline-cleanup-plan.md`). Reproduces the original `WF-INV-113` / `WF-INV-55` bug shape — downstream workflow tasks running after upstream invalidation, even when an external dependency edge should have re-blocked them — through the post-Phase-2 production routing path landed in #893.

This PR adds two assertions exercising the full production code path:

1. `CommandService.recreateWorkflow(upstream)` cancels the in-flight downstream task and resets every downstream task (root, mid, last, merge) to `pending`. Cancel-before-reset ordering is verified on the formerly-running downstream task — `task.cancelled` precedes `task.pending` in the event log.
2. `CommandService.retryWorkflow(upstream)` produces the same downstream cascade.

The injected `InvalidationDeps` matches the shape of `packages/app/src/workflow-actions.ts::buildInvalidationDeps`, including the `cascadeDownstream` hook that resolves to `Orchestrator.cascadeInvalidationToDownstream`.

Pre-Phase-2 the `CommandService` lifecycle methods bypassed `applyInvalidation` and called orchestrator primitives directly; the cascade only fired because of the Phase-0 in-primitive defense-in-depth (covered by `cross-workflow-cascade-primitives.test.ts` from #890). Post-Phase-2 the routing path **is** the production path, and this suite pins it against the user-reported bug shape.

## Architecture

### Before

The cross-workflow cascade was only proven through `applyInvalidation` directly (#883) and through orchestrator primitives directly (#890 via Phase-0 in-primitive cascade). No test exercised the full production path: `CommandService → applyInvalidation → buildInvalidationDeps-shaped deps → orchestrator + cascade` end-to-end. A regression in any seam between those layers (e.g. dep injection, fallback wiring, action routing) would not have been caught before this PR.

```mermaid
flowchart LR
  CS1[CommandService] -. direct primitive call .-> Orch1[Orchestrator]
  Orch1 --> Cascade1[Phase-0 cascade<br/>only proof of cross-workflow propagation pre-Phase-2]

  Apply1[applyInvalidation tests] -. test-only path .-> DepsTest[mocked deps]
  DepsTest -. test-only path .-> Orch1
```

### After

This PR drives `CommandService.recreateWorkflow` and `CommandService.retryWorkflow` end-to-end through the post-Phase-2 routing: the policy router invokes `cancelInFlight` → `recreateWorkflow` → `cascadeDownstream` on a `buildInvalidationDeps`-shaped deps object backed by a real `Orchestrator`. The cascade is observed via real persistence events.

```mermaid
flowchart LR
  Caller[recreateWorkflow upstream]
  CS[CommandService.recreateWorkflow]
  Apply[applyInvalidation<br/>workflow recreateWorkflow upstream deps]

  subgraph Pipeline[Phase-1 stage pipeline]
    direction TB
    SC[cancelInFlight workflow upstream]
    SP[applyPrimitive recreateWorkflow]
    SX[cascadeAcrossWorkflows]
  end

  Deps[buildInvalidationDeps shape<br/>cancelInFlight cascadeDownstream]
  Orch[Orchestrator]
  Cancel[cancelWorkflow upstream]
  Recreate[recreateWorkflow upstream]
  Cascade[cascadeInvalidationToDownstream upstream<br/>cancel running downstream<br/>reset downstream tasks pending<br/>emit task.invalidated_by_upstream]

  Caller --> CS
  CS --> Apply
  Apply --> Pipeline
  Pipeline --> Deps
  Deps --> Orch
  Orch --> Cancel
  Cancel --> Recreate
  Recreate --> Cascade
```

## Test Plan

- [x] `cd packages/workflow-core && pnpm test` → Test Files 49 passed (49), Tests 1040 passed (1040) — was 1038 before, +2 e2e tests in this PR.
- [x] `cross-workflow-cascade-command-service-e2e.test.ts > recreateWorkflow`: downstream root/mid/last/merge all `pending`; `task.cancelled` precedes `task.pending` for the in-flight downstream task; `task.invalidated_by_upstream` events emitted.
- [x] `cross-workflow-cascade-command-service-e2e.test.ts > retryWorkflow`: identical downstream cascade for the second invalidating workflow action exposed via `CommandService`.
- [x] All prior Phase-0/1/2 suites stay green (cross-workflow-cascade, cross-workflow-cascade-primitives, command-service-routing, lifecycle-matrix, cancel-first-invariant, edit-task-*-invalidation, invalidation-policy).

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 6d70af794`
- Post-revert steps: None — this PR is test-only. Production behavior unaffected; existing routing tests in #893 continue to assert the same wiring at unit-level granularity.
- Data migration? No

Depends-On: #893