### PR TITLE
feat(ui): detect task-delta stream-sequence gaps and re-sync from owner (3/5)

### DIFF
--- a/packages/app/src/__tests__/delta-merge.test.ts
+++ b/packages/app/src/__tests__/delta-merge.test.ts
@@ -14,7 +14,12 @@
  * - Multi-task quarantine isolation
  */
 import { describe, it, expect } from 'vitest';
-import { applyDelta, resolveQuarantine, TaskSnapshotCache } from '../delta-merge.js';
+import {
+  applyDelta,
+  recoverQuarantinedTask,
+  resolveQuarantine,
+  TaskSnapshotCache,
+} from '../delta-merge.js';
 import type { TaskState, TaskDelta } from '@invoker/workflow-core';
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -333,29 +338,38 @@ describe('resolveQuarantine', () => {
 
 // ── Gap recovery: main-process integration simulation ────────
 //
-// These tests simulate the recovery loop from main.ts (lines 2429-2437):
+// These tests simulate the production recovery loop in main.ts:
 //   1. applyDelta detects gap → returns quarantined IDs
-//   2. caller loads authoritative state from persistence (loadTask)
-//   3. resolveQuarantine re-seeds cache
-//   4. caller sends { type: 'created', task: authoritative } to renderer
+//   2. caller delegates to recoverQuarantinedTask, which restores the
+//      cache from persistence OR (for synthetic merge ids) the orchestrator
+//      in-memory state, and ALWAYS returns a renderer delta so no message
+//      to the renderer is silently dropped.
+//   3. caller forwards the returned renderer delta.
 //
-// The mock persistence loader is a plain function, not a real SQLite
-// adapter, which keeps tests deterministic and fast.
+// The mock loaders are plain functions, keeping the tests deterministic
+// and fast. `getMergeNode` defaults to returning undefined for the
+// non-synthetic tests in this file; the synthetic-merge-quarantine repro
+// covers the orchestrator-fallback path.
 
 /** Simulates the main-process recovery loop from main.ts. */
 function simulateMainProcessDeltaHandler(
   delta: TaskDelta,
   cache: TaskSnapshotCache,
   persistence: { loadTask: (id: string) => TaskState | undefined },
+  orchestrator: { getMergeNode: (workflowId: string) => TaskState | undefined } = {
+    getMergeNode: () => undefined,
+  },
 ): { rendererDeltas: TaskDelta[] } {
   const rendererDeltas: TaskDelta[] = [];
 
   const { quarantined } = applyDelta(delta, cache);
   for (const taskId of quarantined) {
-    const authoritative = persistence.loadTask(taskId);
-    resolveQuarantine(cache, taskId, authoritative);
-    if (authoritative) {
-      rendererDeltas.push({ type: 'created', task: authoritative });
+    const { rendererDelta } = recoverQuarantinedTask(cache, taskId, {
+      loadTask: persistence.loadTask,
+      getMergeNode: orchestrator.getMergeNode,
+    });
+    if (rendererDelta) {
+      rendererDeltas.push(rendererDelta);
     }
   }
   return { rendererDeltas };
@@ -390,7 +404,12 @@ describe('gap recovery: unknown task → quarantine + authoritative reload', () 
     expect((rendererDeltas[0] as { type: 'created'; task: TaskState }).task.taskStateVersion).toBe(3);
   });
 
-  it('unknown task with no persistence record removes cache entry silently', () => {
+  it('unknown task with no persistence record removes cache entry AND emits removed delta', () => {
+    // No-implicit-message-drops contract: any time the owner deletes a cache
+    // entry during recovery, it MUST tell the renderer so the renderer can
+    // drop its stale copy too. Silently dropping the recovery message is
+    // what causes the synthetic __merge__ graph-blank bug; the same
+    // discipline applies to non-synthetic ghost ids.
     const cache = new TaskSnapshotCache();
     const persistence = { loadTask: (_id: string) => undefined };
 
@@ -405,8 +424,10 @@ describe('gap recovery: unknown task → quarantine + authoritative reload', () 
     const { rendererDeltas } = simulateMainProcessDeltaHandler(delta, cache, persistence);
 
     expect(cache.has('ghost')).toBe(false);
-    // No renderer delta emitted for a task that doesn't exist in persistence
-    expect(rendererDeltas).toHaveLength(0);
+    expect(rendererDeltas).toHaveLength(1);
+    const [first] = rendererDeltas;
+    expect(first.type).toBe('removed');
+    expect((first as { type: 'removed'; taskId: string }).taskId).toBe('ghost');
   });
 });
 

--- a/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
+++ b/packages/app/src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Repro + regression guard for the synthetic `__merge__wf-…` quarantine-loop
+ * desync that blanks the graph UI.
+ *
+ * Real-world symptom: bursts of `[gap-detect] quarantined task="__merge__wf-X"`
+ * lines in ~/.invoker/invoker.log with no intervening recovery, after which
+ * the selected workflow's mini-DAG renders blank until the user reloads.
+ *
+ * Owner-side root cause (current production code at
+ * packages/app/src/main.ts:2896–2904):
+ *
+ *   const { quarantined } = applyDelta(d, lastKnownTaskStates);
+ *   for (const taskId of quarantined) {
+ *     const authoritative = loadTaskByIdFromPersistence(taskId);
+ *     resolveQuarantine(lastKnownTaskStates, taskId, authoritative);
+ *     if (authoritative) {
+ *       sendTaskDeltaToRenderer({ type: 'created', task: authoritative });
+ *     }
+ *   }
+ *
+ * For synthetic merge ids (`__merge__${workflowId}`) persistence has no
+ * record, so `authoritative === undefined`. `resolveQuarantine` silently
+ * deletes the owner cache entry and the renderer is told nothing. The next
+ * `updated` delta on the same id re-quarantines (unknown task branch in
+ * applyDelta) and the loop repeats indefinitely. The renderer keeps its
+ * stale snapshot for the merge node while the owner has erased it; when
+ * `workflows-changed` next reconciles, the selected workflow disappears.
+ *
+ * The fix introduces `recoverQuarantinedTask` in delta-merge.ts (with the
+ * "no implicit message drops" contract: every cache deletion is mirrored
+ * to the renderer via either `created` or `removed`). This file pins the
+ * four post-fix expectations as a permanent regression guard. Reverting
+ * the fix re-fails all four cases with the same diff shape as the
+ * original Phase 1 reproduction.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  applyDelta,
+  recoverQuarantinedTask,
+  TaskSnapshotCache,
+  type RecoveryLoaders,
+} from '../delta-merge.js';
+import type { TaskState, TaskDelta } from '@invoker/workflow-core';
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeTask(id: string, overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id,
+    description: `Task ${id}`,
+    status: 'running',
+    dependencies: [],
+    createdAt: new Date('2025-01-01'),
+    config: { workflowId: 'wf-1', command: `echo ${id}`, runnerKind: 'worktree' as const },
+    execution: {},
+    taskStateVersion: 1,
+    ...overrides,
+  } as TaskState;
+}
+
+function makeMergeNode(workflowId: string, taskStateVersion: number): TaskState {
+  return makeTask(`__merge__${workflowId}`, {
+    taskStateVersion,
+    config: {
+      workflowId,
+      command: 'noop',
+      runnerKind: 'worktree' as const,
+      isMergeNode: true,
+    },
+  });
+}
+
+/**
+ * Faithful mirror of the production main-process recovery loop
+ * (packages/app/src/main.ts:2896–2906): apply the delta, then for each
+ * quarantined id, run the shared `recoverQuarantinedTask` helper and
+ * collect every renderer delta it returns.
+ *
+ * Pre-fix, this file used a `simulateLegacyRecoveryLoop` that inlined the
+ * old buggy code (no orchestrator fallback, silent delete on persistence
+ * miss). Post-fix it calls the real helper so the assertions below act as
+ * a permanent regression guard.
+ */
+function runRecovery(
+  delta: TaskDelta,
+  cache: TaskSnapshotCache,
+  loaders: RecoveryLoaders,
+): { rendererDeltas: TaskDelta[] } {
+  const rendererDeltas: TaskDelta[] = [];
+  const { quarantined } = applyDelta(delta, cache);
+  for (const taskId of quarantined) {
+    const { rendererDelta } = recoverQuarantinedTask(cache, taskId, loaders);
+    if (rendererDelta) {
+      rendererDeltas.push(rendererDelta);
+    }
+  }
+  return { rendererDeltas };
+}
+
+// ── Fixtures ────────────────────────────────────────────────
+
+const SYNTHETIC_ID = '__merge__wf-X';
+const WORKFLOW_ID = 'wf-X';
+
+function seedCacheWithMergeNode(version: number): TaskSnapshotCache {
+  const cache = new TaskSnapshotCache();
+  cache.set(SYNTHETIC_ID, JSON.stringify(makeMergeNode(WORKFLOW_ID, version)));
+  return cache;
+}
+
+function loadTaskNeverReturnsSynthetic(_id: string): TaskState | undefined {
+  // Persistence never holds synthetic merge nodes.
+  return undefined;
+}
+
+function copyCache(source: TaskSnapshotCache): TaskSnapshotCache {
+  const clone = new TaskSnapshotCache();
+  for (const id of source.keys()) {
+    const snap = source.get(id);
+    if (snap) clone.set(id, snap);
+  }
+  return clone;
+}
+
+// ── Repro cases ─────────────────────────────────────────────
+
+describe('synthetic __merge__ quarantine-loop repro (graph-blank root cause)', () => {
+  it('(a) synthetic gap recovers from orchestrator memory and emits created delta', () => {
+    const cache = seedCacheWithMergeNode(2);
+    const authoritative = makeMergeNode(WORKFLOW_ID, 4);
+    const loaders: RecoveryLoaders = {
+      loadTask: loadTaskNeverReturnsSynthetic,
+      getMergeNode: (workflowId) => (workflowId === WORKFLOW_ID ? authoritative : undefined),
+    };
+
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: SYNTHETIC_ID,
+      changes: { status: 'completed' },
+      taskStateVersion: 4,
+      previousTaskStateVersion: 3,
+    };
+
+    const { rendererDeltas } = runRecovery(delta, cache, loaders);
+
+    expect(cache.has(SYNTHETIC_ID)).toBe(true);
+    expect(cache.getEntry(SYNTHETIC_ID)?.taskStateVersion).toBe(4);
+    expect(rendererDeltas).toHaveLength(1);
+    const first = rendererDeltas[0];
+    expect(first.type).toBe('created');
+    expect((first as { type: 'created'; task: TaskState }).task.id).toBe(SYNTHETIC_ID);
+    expect((first as { type: 'created'; task: TaskState }).task.taskStateVersion).toBe(4);
+  });
+
+  it('(b) synthetic gap with no orchestrator entry emits removed delta', () => {
+    const cache = seedCacheWithMergeNode(2);
+    const loaders: RecoveryLoaders = {
+      loadTask: loadTaskNeverReturnsSynthetic,
+      getMergeNode: (_workflowId) => undefined,
+    };
+
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: SYNTHETIC_ID,
+      changes: { status: 'completed' },
+      taskStateVersion: 4,
+      previousTaskStateVersion: 3,
+    };
+
+    const { rendererDeltas } = runRecovery(delta, cache, loaders);
+
+    expect(cache.has(SYNTHETIC_ID)).toBe(false);
+    expect(rendererDeltas).toHaveLength(1);
+    expect(rendererDeltas[0].type).toBe('removed');
+    expect((rendererDeltas[0] as { type: 'removed'; taskId: string }).taskId).toBe(SYNTHETIC_ID);
+  });
+
+  it('(c) burst of stale out-of-order synthetic deltas each get a recovery delta (no silent loop)', () => {
+    // Models the live-log signature: three `[gap-detect]` events for
+    // `__merge__wf-X` in <1s. Each iteration sends an `updated` delta whose
+    // `previousTaskStateVersion` does not match the (post-recovery) cache,
+    // mirroring the realistic case where the orchestrator races ahead and
+    // multiple stale deltas land in quick succession. Every quarantine MUST
+    // produce exactly one recovery delta — no silent loops.
+    const cache = seedCacheWithMergeNode(2);
+    // Orchestrator advances faster than the deltas arriving on the bus.
+    let authoritativeVersion = 10;
+    const loaders: RecoveryLoaders = {
+      loadTask: loadTaskNeverReturnsSynthetic,
+      getMergeNode: (workflowId) =>
+        workflowId === WORKFLOW_ID ? makeMergeNode(WORKFLOW_ID, authoritativeVersion) : undefined,
+    };
+
+    const allRendererDeltas: TaskDelta[] = [];
+    let totalQuarantined = 0;
+
+    for (const orchestratorVersion of [10, 11, 12]) {
+      authoritativeVersion = orchestratorVersion;
+      // Each delta is stale (prev=3) relative to whatever the cache holds
+      // after the previous recovery (v=10, then v=11, then v=12) — so all
+      // three deltas hit the gap branch in applyDelta.
+      const delta: TaskDelta = {
+        type: 'updated',
+        taskId: SYNTHETIC_ID,
+        changes: { status: 'running' },
+        taskStateVersion: 4,
+        previousTaskStateVersion: 3,
+      };
+
+      const beforeQuarantineState = applyDelta(delta, copyCache(cache));
+      totalQuarantined += beforeQuarantineState.quarantined.length;
+
+      const { rendererDeltas } = runRecovery(delta, cache, loaders);
+      allRendererDeltas.push(...rendererDeltas);
+    }
+
+    expect(totalQuarantined).toBe(3);
+    expect(allRendererDeltas).toHaveLength(3);
+    expect(allRendererDeltas.every((d) => d.type === 'created')).toBe(true);
+    expect(cache.getEntry(SYNTHETIC_ID)?.taskStateVersion).toBe(12);
+  });
+
+  it('(d) no implicit drops: non-synthetic ghost task emits removed delta', () => {
+    // Cache is empty: an updated delta for an unknown non-synthetic id should
+    // quarantine, persistence has no record, and recovery must still emit a
+    // removed delta so the renderer's stale entry is cleared.
+    const cache = new TaskSnapshotCache();
+    const loaders: RecoveryLoaders = {
+      loadTask: (_id) => undefined,
+      getMergeNode: (_workflowId) => undefined,
+    };
+
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: 't-ghost-real',
+      changes: { status: 'completed' },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    };
+
+    const { rendererDeltas } = runRecovery(delta, cache, loaders);
+
+    expect(cache.has('t-ghost-real')).toBe(false);
+    expect(rendererDeltas).toHaveLength(1);
+    expect(rendererDeltas[0].type).toBe('removed');
+    expect((rendererDeltas[0] as { type: 'removed'; taskId: string }).taskId).toBe('t-ghost-real');
+  });
+});

--- a/packages/app/src/__tests__/task-delta-stream-sequence.test.ts
+++ b/packages/app/src/__tests__/task-delta-stream-sequence.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from 'vitest';
+import { createTaskDeltaStreamSequence } from '../task-delta-stream-sequence.js';
+import type { TaskDelta, TaskState } from '@invoker/workflow-core';
+
+function makeTask(id: string): TaskState {
+  return {
+    id,
+    description: `task ${id}`,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2025-01-01'),
+    config: {},
+    execution: {},
+    taskStateVersion: 1,
+  } as TaskState;
+}
+
+describe('createTaskDeltaStreamSequence', () => {
+  it('starts at 0 and is non-incrementing on current()', () => {
+    const s = createTaskDeltaStreamSequence();
+    expect(s.current()).toBe(0);
+    expect(s.current()).toBe(0);
+    expect(s.current()).toBe(0);
+  });
+
+  it('stamps strictly monotonically increasing sequences starting at 1', () => {
+    const s = createTaskDeltaStreamSequence();
+    const stamped = [
+      s.stamp({ type: 'created', task: makeTask('a') }),
+      s.stamp({ type: 'created', task: makeTask('b') }),
+      s.stamp({ type: 'updated', taskId: 'b', changes: { status: 'running' }, taskStateVersion: 2, previousTaskStateVersion: 1 }),
+      s.stamp({ type: 'removed', taskId: 'a', previousTaskStateVersion: 1 }),
+    ];
+    expect(stamped.map((d) => d.streamSequence)).toEqual([1, 2, 3, 4]);
+  });
+
+  it('current() after stamp() returns the just-stamped sequence', () => {
+    const s = createTaskDeltaStreamSequence();
+    s.stamp({ type: 'created', task: makeTask('a') });
+    expect(s.current()).toBe(1);
+    s.stamp({ type: 'created', task: makeTask('b') });
+    expect(s.current()).toBe(2);
+  });
+
+  it('overwrites any incoming streamSequence on the input delta', () => {
+    const s = createTaskDeltaStreamSequence();
+    const stamped = s.stamp({
+      type: 'updated',
+      taskId: 'a',
+      changes: { status: 'running' },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+      streamSequence: 999,
+    } as TaskDelta);
+    expect(stamped.streamSequence).toBe(1);
+    expect(s.current()).toBe(1);
+  });
+
+  it('preserves the underlying delta payload (type, taskId, changes)', () => {
+    const s = createTaskDeltaStreamSequence();
+    const original: TaskDelta = {
+      type: 'updated',
+      taskId: 'wf-1/task-x',
+      changes: { status: 'completed', execution: { exitCode: 0 } },
+      taskStateVersion: 5,
+      previousTaskStateVersion: 4,
+    };
+    const stamped = s.stamp(original);
+    expect(stamped).toMatchObject({
+      type: 'updated',
+      taskId: 'wf-1/task-x',
+      changes: { status: 'completed', execution: { exitCode: 0 } },
+      taskStateVersion: 5,
+      previousTaskStateVersion: 4,
+    });
+    expect(stamped.streamSequence).toBe(1);
+  });
+
+  it('snapshot watermark contract: current() after stamping reflects every delta', () => {
+    const s = createTaskDeltaStreamSequence();
+    s.stamp({ type: 'created', task: makeTask('a') });
+    s.stamp({ type: 'created', task: makeTask('b') });
+    s.stamp({ type: 'created', task: makeTask('c') });
+    const snapshotWatermark = s.current();
+    expect(snapshotWatermark).toBe(3);
+    const nextStamp = s.stamp({ type: 'created', task: makeTask('d') });
+    expect(nextStamp.streamSequence).toBe(snapshotWatermark + 1);
+  });
+
+  it('independent instances do not share state', () => {
+    const a = createTaskDeltaStreamSequence();
+    const b = createTaskDeltaStreamSequence();
+    a.stamp({ type: 'created', task: makeTask('x') });
+    a.stamp({ type: 'created', task: makeTask('y') });
+    expect(a.current()).toBe(2);
+    expect(b.current()).toBe(0);
+  });
+});

--- a/packages/app/src/delta-merge.ts
+++ b/packages/app/src/delta-merge.ts
@@ -162,6 +162,11 @@ export function applyDelta(
  * with the authoritative snapshot from persistence.
  *
  * If `task` is undefined (task no longer exists), the cache entry is removed.
+ *
+ * NOTE: this primitive is intentionally low-level — it does NOT notify the
+ * renderer. Production callers should go through `recoverQuarantinedTask`
+ * below, which enforces the "no implicit message drops" rule by always
+ * returning a renderer delta whenever it mutates the owner cache.
  */
 export function resolveQuarantine(
   cache: TaskSnapshotCache,
@@ -173,4 +178,76 @@ export function resolveQuarantine(
     return;
   }
   cache.set(taskId, JSON.stringify(task));
+}
+
+// ── Authoritative recovery (no implicit message drops) ──────
+
+/**
+ * Loaders the recovery loop consults to find an authoritative snapshot
+ * for a quarantined task id.
+ *
+ * - `loadTask`: persistence by id. Returns `undefined` for ids that have
+ *   never been persisted (notably synthetic merge nodes).
+ * - `getMergeNode`: orchestrator in-memory lookup by workflowId. Authoritative
+ *   source for synthetic `__merge__${workflowId}` ids, which are not stored
+ *   in persistence but are tracked in `Orchestrator.stateMachine`.
+ */
+export interface RecoveryLoaders {
+  loadTask: (taskId: string) => TaskState | undefined;
+  getMergeNode: (workflowId: string) => TaskState | undefined;
+}
+
+export interface RecoveryResult {
+  /**
+   * Renderer-bound delta the caller MUST forward to keep the renderer in
+   * sync with the owner cache. `undefined` only when no cache mutation
+   * happened (currently never — every branch either restores from an
+   * authoritative source or emits `removed`).
+   */
+  rendererDelta?: TaskDelta;
+}
+
+const SYNTHETIC_MERGE_PREFIX = '__merge__';
+
+/**
+ * Single source of truth for the main-process quarantine-recovery loop.
+ *
+ * Contract — no implicit message drops:
+ * - If persistence has the task → restore from persistence, emit `created`.
+ * - Else if it's a synthetic merge id and the orchestrator has it in memory
+ *   → restore from orchestrator, emit `created`.
+ * - Else (truly absent) → delete the cache entry, emit `removed` so the
+ *   renderer drops its stale copy too.
+ *
+ * This replaces the legacy `if (authoritative) { sendTaskDeltaToRenderer(...) }`
+ * pattern that silently dropped the recovery message whenever
+ * `loadTask` returned `undefined`. For synthetic merge nodes that path
+ * never produced a recovery delta, leaving the renderer's selected
+ * mini-DAG blank after every `[gap-detect]` event.
+ */
+export function recoverQuarantinedTask(
+  cache: TaskSnapshotCache,
+  taskId: string,
+  loaders: RecoveryLoaders,
+): RecoveryResult {
+  const persisted = loaders.loadTask(taskId);
+  if (persisted) {
+    resolveQuarantine(cache, taskId, persisted);
+    return { rendererDelta: { type: 'created', task: persisted } };
+  }
+
+  if (taskId.startsWith(SYNTHETIC_MERGE_PREFIX)) {
+    const workflowId = taskId.slice(SYNTHETIC_MERGE_PREFIX.length);
+    const synthetic = loaders.getMergeNode(workflowId);
+    if (synthetic) {
+      resolveQuarantine(cache, taskId, synthetic);
+      return { rendererDelta: { type: 'created', task: synthetic } };
+    }
+  }
+
+  const previousTaskStateVersion = cache.getEntry(taskId)?.taskStateVersion ?? 0;
+  resolveQuarantine(cache, taskId, undefined);
+  return {
+    rendererDelta: { type: 'removed', taskId, previousTaskStateVersion },
+  };
 }

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -26,6 +26,7 @@ export interface RegisterReadOnlyIpcHandlersContext {
   ) => Promise<unknown>;
   timeStartupPhase: <T>(label: string, fn: () => T, fields?: () => Record<string, unknown>) => T;
   recordStartupDuration: (label: string, startedAtMs: number, fields?: Record<string, unknown>) => void;
+  getTaskDeltaStreamSequence: () => number;
 }
 
 export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlersContext): void {
@@ -44,6 +45,7 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     resolveAgentSession,
     timeStartupPhase,
     recordStartupDuration,
+    getTaskDeltaStreamSequence,
   } = context;
 
   ipcMain.handle('invoker:list-workflows', () => persistence.listWorkflows());
@@ -100,14 +102,16 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
       `get-tasks(forceRefresh=${forceRefresh ? 'true' : 'false'}) returning ${tasks.length} tasks, ${workflows.length} workflows`,
       { module: 'ipc' },
     );
+    const streamSequence = getTaskDeltaStreamSequence();
     if (forceRefresh) {
       recordStartupDuration('get-tasks.force-refresh.return', startedAtMs, {
         taskCount: tasks.length,
         workflowCount: workflows.length,
         jsonSizeBytes: Buffer.byteLength(JSON.stringify({ tasks, workflows }), 'utf8'),
+        streamSequence,
       });
     }
-    return { tasks, workflows };
+    return { tasks, workflows, streamSequence };
   });
 
   ipcMain.handle('invoker:get-events', (_event, taskId: string) => persistence.getEvents(taskId));

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -152,7 +152,7 @@ import { collectSystemDiagnostics } from './system-diagnostics.js';
 import { installBundledSkills, resolveBundledSkillsStatus } from './bundled-skills.js';
 import { createRequire } from 'node:module';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
-import { applyDelta, resolveQuarantine, TaskSnapshotCache } from './delta-merge.js';
+import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from './delta-merge.js';
 import {
   CoalescedWorkflowMetadataPublisher,
   WorkflowMetadataInvalidator,
@@ -2896,10 +2896,12 @@ function createEmbeddedTerminalBackendFromConfig(
       const { quarantined } = applyDelta(d, lastKnownTaskStates);
       for (const taskId of quarantined) {
         logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
-        const authoritative = loadTaskByIdFromPersistence(taskId);
-        resolveQuarantine(lastKnownTaskStates, taskId, authoritative);
-        if (authoritative) {
-          sendTaskDeltaToRenderer({ type: 'created', task: authoritative });
+        const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {
+          loadTask: loadTaskByIdFromPersistence,
+          getMergeNode: (workflowId) => orchestrator.getMergeNode(workflowId),
+        });
+        if (rendererDelta) {
+          sendTaskDeltaToRenderer(rendererDelta);
         }
       }
     });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -178,6 +178,7 @@ import {
   resolveActionDiagnosticsStallThresholdMs,
 } from './action-graph-diagnostics.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
+import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
 import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
 import {
   executeNoTrackHeadlessBatch,
@@ -1464,12 +1465,15 @@ function createEmbeddedTerminalBackendFromConfig(
     mainWindow.webContents.send('invoker:task-delta-batch', batch);
   };
 
+  const taskDeltaStream = createTaskDeltaStreamSequence();
+  const getTaskDeltaStreamSequence = (): number => taskDeltaStream.current();
+
   const sendTaskDeltaToRenderer = (delta: TaskDelta): void => {
     workflowMetadataInvalidator?.markFromTaskDelta(delta);
     if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) {
       return;
     }
-    pendingUiTaskDeltas.push(delta);
+    pendingUiTaskDeltas.push(taskDeltaStream.stamp(delta));
     if (uiTaskDeltaFlushTimer) {
       return;
     }
@@ -2930,11 +2934,13 @@ function createEmbeddedTerminalBackendFromConfig(
       const startedAtMs = Date.now();
       const tasks = orchestrator.getAllTasks();
       const workflows = listWorkflowsByStartupRecency();
+      const streamSequence = getTaskDeltaStreamSequence();
       const payload = {
         tasks,
         workflows,
         initialWorkflowId: startupWorkflowId,
         appStartedAtEpochMs: appProcessStartedAt,
+        streamSequence,
       };
       const jsonSizeBytes = Buffer.byteLength(JSON.stringify(payload), 'utf8');
       recordStartupDuration('bootstrap-ipc.serialize-return', startedAtMs, {
@@ -3096,6 +3102,7 @@ function createEmbeddedTerminalBackendFromConfig(
       resolveAgentSession,
       timeStartupPhase,
       recordStartupDuration,
+      getTaskDeltaStreamSequence,
     });
 
     registerGuiMutationHandler('invoker:delete-all-workflows', async () => {
@@ -3938,8 +3945,8 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     // ── DB Polling — detect external workflow changes ───
-    ipcMain.handle('invoker:get-activity-logs', () => {
-      return persistence.getActivityLogs(0, 2000);
+    ipcMain.handle('invoker:get-activity-logs', (_event, sinceId?: number, limit?: number) => {
+      return persistence.getActivityLogs(sinceId ?? 0, limit ?? 2000);
     });
 
     // ── Embedded terminal session manager (GUI) ─────────────────

--- a/packages/app/src/task-delta-stream-sequence.ts
+++ b/packages/app/src/task-delta-stream-sequence.ts
@@ -1,0 +1,17 @@
+import type { TaskDelta } from '@invoker/workflow-core';
+
+export interface TaskDeltaStreamSequence {
+  current: () => number;
+  stamp: (delta: TaskDelta) => TaskDelta;
+}
+
+export function createTaskDeltaStreamSequence(): TaskDeltaStreamSequence {
+  let counter = 0;
+  return {
+    current: () => counter,
+    stamp: (delta) => {
+      counter += 1;
+      return { ...delta, streamSequence: counter } as TaskDelta;
+    },
+  };
+}

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -348,7 +348,7 @@ export const IpcChannels = {
   // Task Queries
   'invoker:get-tasks': {} as {
     request: [forceRefresh?: boolean];
-    response: { tasks: TaskState[]; workflows: WorkflowMeta[] };
+    response: { tasks: TaskState[]; workflows: WorkflowMeta[]; streamSequence: number };
   },
   'invoker:get-events': {} as {
     request: [taskId: string];
@@ -538,7 +538,7 @@ export const IpcChannels = {
     response: Record<string, unknown>;
   },
   'invoker:get-activity-logs': {} as {
-    request: [];
+    request: [sinceId?: number, limit?: number];
     response: ActivityLogEntry[];
   },
 

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -135,9 +135,9 @@ export interface TaskStateChanges {
 // ── Task Delta (for UI updates) ─────────────────────────────
 
 export type TaskDelta =
-  | { readonly type: 'created'; readonly task: TaskState }
-  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number }
-  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number };
+  | { readonly type: 'created'; readonly task: TaskState; readonly streamSequence?: number }
+  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number; readonly streamSequence?: number }
+  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number; readonly streamSequence?: number };
 
 // ── Task Create Options (alias for TaskConfig) ──────────────
 

--- a/packages/ui/src/hooks/useTasks.ts
+++ b/packages/ui/src/hooks/useTasks.ts
@@ -72,6 +72,8 @@ export function useTasks(): UseTasksResult {
   const getTasksGenerationRef = useRef(0);
   const reportedStartupBootstrapRef = useRef(false);
   const reportedStartupSnapshotRef = useRef(false);
+  const lastSeenSequenceRef = useRef<number>(bootstrapState?.streamSequence ?? 0);
+  const isResyncInFlightRef = useRef<boolean>(false);
 
   const fetchAll = useCallback((forceRefresh = false) => {
     if (typeof window === 'undefined' || !window.invoker) return;
@@ -111,6 +113,10 @@ export function useTasks(): UseTasksResult {
         }
         return wfMap;
       });
+      if (typeof result.streamSequence === 'number') {
+        lastSeenSequenceRef.current = result.streamSequence;
+      }
+      isResyncInFlightRef.current = false;
       const replaceDurationMs = performance.now() - replaceStartedAt;
       void window.invoker.reportUiPerf?.('useTasks_snapshot_replace', {
         taskCount: taskList.length,
@@ -221,6 +227,26 @@ export function useTasks(): UseTasksResult {
               `execPatchKeys=${ex ? Object.keys(ex).join(',') : '—'}`,
           );
         }
+      }
+
+      const seq = delta.streamSequence;
+      if (typeof seq === 'number') {
+        const lastSeen = lastSeenSequenceRef.current;
+        if (seq <= lastSeen) return;
+        if (isResyncInFlightRef.current) return;
+        if (seq !== lastSeen + 1) {
+          const gapSize = seq - (lastSeen + 1);
+          window.invoker.reportUiPerf?.('ui_delta_stream_gap_detected', {
+            expected: lastSeen + 1,
+            actual: seq,
+            gapSize,
+          });
+          isResyncInFlightRef.current = true;
+          deltaPipelineRef.current?.clear();
+          fetchAll(true);
+          return;
+        }
+        lastSeenSequenceRef.current = seq;
       }
 
       deltaPipelineRef.current?.push(delta);

--- a/packages/ui/src/lib/task-delta-pipeline.ts
+++ b/packages/ui/src/lib/task-delta-pipeline.ts
@@ -3,6 +3,7 @@ import type { TaskDelta } from '../types.js';
 export interface TaskDeltaPipeline {
   push: (delta: TaskDelta) => void;
   flushNow: () => void;
+  clear: () => void;
   dispose: () => void;
 }
 
@@ -60,6 +61,13 @@ export function createTaskDeltaPipeline(
       schedule();
     },
     flushNow,
+    clear(): void {
+      if (timer) {
+        clearTimeout(timer);
+        timer = null;
+      }
+      queue = [];
+    },
     dispose(): void {
       if (timer) {
         clearTimeout(timer);

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -144,9 +144,9 @@ export interface TaskStateChanges {
 // ── Task Delta ──────────────────────────────────────────────
 
 export type TaskDelta =
-  | { readonly type: 'created'; readonly task: TaskState }
-  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number }
-  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number };
+  | { readonly type: 'created'; readonly task: TaskState; readonly streamSequence?: number }
+  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number; readonly streamSequence?: number }
+  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number; readonly streamSequence?: number };
 
 // ── Workflow Metadata ────────────────────────────────────────
 
@@ -283,6 +283,7 @@ declare global {
       workflows?: WorkflowMeta[];
       initialWorkflowId?: string | null;
       appStartedAtEpochMs?: number;
+      streamSequence?: number;
     };
     __INVOKER_TEST_OPEN_TERMINAL__?: (taskId: string) => ReturnType<InvokerAPI['openTerminal']>;
     __INVOKER_TEST_ON_TERMINAL_OUTPUT__?: (cb: (event: TerminalOutputEvent) => void) => () => void;

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -188,9 +188,9 @@ export interface TaskStateChanges {
 // ── Task Delta (for UI updates) ─────────────────────────────
 
 export type TaskDelta =
-  | { readonly type: 'created'; readonly task: TaskState }
-  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number }
-  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number };
+  | { readonly type: 'created'; readonly task: TaskState; readonly streamSequence?: number }
+  | { readonly type: 'updated'; readonly taskId: string; readonly changes: TaskStateChanges; readonly taskStateVersion: number; readonly previousTaskStateVersion: number; readonly streamSequence?: number }
+  | { readonly type: 'removed'; readonly taskId: string; readonly previousTaskStateVersion: number; readonly streamSequence?: number };
 
 // ── Task Create Options (alias for TaskConfig) ──────────────
 


### PR DESCRIPTION
## Summary

Stacks on #897. Wires up renderer-side gap detection: [`useTasks`](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260523-b18494/useTasks.ts) tracks `lastSeenSequenceRef` (seeded from the bootstrap watermark) and reacts to each incoming delta with `streamSequence === seq`:

- `seq <= lastSeen` -> drop (stale post-resync replay)
- resync already in flight -> drop (the snapshot will be authoritative)
- `seq === lastSeen + 1` -> apply, advance `lastSeen`
- otherwise (a gap) -> emit `ui_delta_stream_gap_detected{ expected, actual, gapSize }`, clear the pipeline, call `fetchAll(true)`

[`packages/ui/src/lib/task-delta-pipeline.ts`](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260523-b18494/task-delta-pipeline.ts) gains a `clear()` method used by the gap-recovery path. The post-resync snapshot already covers any queued deltas (the owner reads the watermark after the snapshot), so flushing them on top would regress state.

Backward-compat: deltas without `streamSequence` (in-process fixtures) bypass gap-check and apply as before.

Tests land in #899, e2e bench in #900.

## Architecture

### Before

```mermaid
graph TD
  Delta[TaskDelta from IPC] -->|"streamSequence ignored"| Apply[apply to task map]
  Apply --> State[useTasks state]
  Drop[wire drop / IPC backpressure] -.->|"silently consumes delta"| Delta
  State -.->|"silent desync"| Blank[stale UI]
```

### After

```mermaid
graph TD
  Delta[TaskDelta from IPC] --> Check{seq vs lastSeen}
  Check -->|"seq == lastSeen + 1"| Apply[apply, lastSeen = seq]
  Check -->|"seq <= lastSeen"| DropStale[drop stale replay]
  Check -->|"resync in flight"| DropInflight[drop, snapshot wins]
  Check -->|"gap"| Recover[emit gap-detected, clear pipeline, fetchAll true]
  Recover --> Snapshot[get-tasks -> tasks + watermark W]
  Snapshot --> Replace[replace state, lastSeen = W]
  Apply --> State[useTasks state]
  Replace --> State
```

## Test Plan

- [x] `pnpm run check:types`
- [x] `cd packages/ui && pnpm test`

Tests for this logic live in #899.

## Revert Plan

- Safe to revert? Yes — `streamSequence` stays optional and the owner keeps stamping. Renderer reverts to silent-drop behavior (post-#886 baseline).
- Revert command: `git revert <sha>`
- Post-revert steps: PRs #899 and #900 must be reverted (or rebased) — their tests/bench assert the gap-detect behavior.
- Data migration? No.
