### PR TITLE
Route CommandService through applyInvalidation (Phase 2)

### DIFF
--- a/packages/app/src/__tests__/parity-regression.test.ts
+++ b/packages/app/src/__tests__/parity-regression.test.ts
@@ -511,6 +511,9 @@ describe('Parity: CommandService routes to correct orchestrator primitives', () 
       selectExperiment: vi.fn(() => [makeTask()]),
       setTaskExternalGatePolicies: vi.fn(() => []),
       replaceTask: vi.fn(() => []),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
+      autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
+      forkWorkflow: vi.fn(() => ({ started: [] })),
     };
     commandService = new CommandService(orchestrator as any);
   });
@@ -723,6 +726,9 @@ describe('Parity: CommandService serializes concurrent mutations', () => {
         callOrder.push('edit-end');
         return [makeTask()];
       }),
+      cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
     };
     const cs = new CommandService(orchestrator as any);
 
@@ -750,6 +756,9 @@ describe('Parity: CommandService serializes concurrent mutations', () => {
         callOrder.push(`${wf}-retry-end`);
         return [makeTask({ id: taskId, config: { workflowId: wf } })];
       }),
+      cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
     };
     const cs = new CommandService(orchestrator as any);
 

--- a/packages/workflow-core/src/__tests__/command-service-routing.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service-routing.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CommandService } from '../command-service.js';
+import type {
+  InvalidationDeps,
+  InvalidationScope,
+  InvalidationAction,
+} from '../invalidation-policy.js';
+import type { Orchestrator } from '../orchestrator.js';
+import type { CommandEnvelope } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-graph';
+
+function makeEnvelope<P>(payload: P, id = 'cmd-1'): CommandEnvelope<P> {
+  return {
+    commandId: id,
+    source: 'headless',
+    scope: 'task',
+    idempotencyKey: `key-${id}`,
+    payload,
+  };
+}
+
+// Fixed `createdAt` so two separate `makeTask()` calls produce
+// deeply-equal results — needed for `toEqual` against the orchestrator
+// fallback's return value.
+const FIXED_CREATED_AT = new Date('2026-01-01T00:00:00.000Z');
+
+function makeTask(): TaskState {
+  return {
+    id: 'task-1',
+    description: 'task',
+    dependencies: [],
+    status: 'pending',
+    createdAt: FIXED_CREATED_AT,
+    config: { workflowId: 'wf-1', isMergeNode: false },
+    execution: {},
+  } as unknown as TaskState;
+}
+
+function makeOrchestrator(): Orchestrator {
+  return {
+    getTask: vi.fn(() => makeTask()),
+    cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+    cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+    retryTask: vi.fn(() => [makeTask()]),
+    recreateTask: vi.fn(() => [makeTask()]),
+    retryWorkflow: vi.fn(() => [makeTask()]),
+    recreateWorkflow: vi.fn(() => [makeTask()]),
+    recreateWorkflowFromFreshBase: vi.fn(async () => [makeTask()]),
+    forkWorkflow: vi.fn(() => ({ started: [] })),
+    cascadeInvalidationToDownstream: vi.fn(() => []),
+    autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
+    approve: vi.fn(async () => []),
+    reject: vi.fn(),
+  } as unknown as Orchestrator;
+}
+
+function makeSpiedDeps(): {
+  deps: InvalidationDeps;
+  events: Array<{ stage: string; scope?: InvalidationScope; id: string }>;
+} {
+  const events: Array<{ stage: string; scope?: InvalidationScope; id: string }> = [];
+  const result: TaskState[] = [];
+  const deps: InvalidationDeps = {
+    cancelInFlight: vi.fn(async (scope, id) => {
+      events.push({ stage: 'cancelInFlight', scope, id });
+    }),
+    retryTask: vi.fn((id) => {
+      events.push({ stage: 'retryTask', id });
+      return result;
+    }),
+    recreateTask: vi.fn((id) => {
+      events.push({ stage: 'recreateTask', id });
+      return result;
+    }),
+    retryWorkflow: vi.fn((id) => {
+      events.push({ stage: 'retryWorkflow', id });
+      return result;
+    }),
+    recreateWorkflow: vi.fn((id) => {
+      events.push({ stage: 'recreateWorkflow', id });
+      return result;
+    }),
+    recreateWorkflowFromFreshBase: vi.fn(async (id) => {
+      events.push({ stage: 'recreateWorkflowFromFreshBase', id });
+      return result;
+    }),
+    cascadeDownstream: vi.fn((scope, id) => {
+      events.push({ stage: 'cascadeDownstream', scope, id });
+      return [];
+    }),
+  };
+  return { deps, events };
+}
+
+describe('CommandService → applyInvalidation routing', () => {
+  let orchestrator: Orchestrator;
+
+  beforeEach(() => {
+    orchestrator = makeOrchestrator();
+  });
+
+  type RoutedCase = {
+    method: 'retryTask' | 'recreateTask' | 'retryWorkflow' | 'recreateWorkflow' | 'recreateWorkflowFromFreshBase';
+    scope: InvalidationScope;
+    action: InvalidationAction;
+    id: string;
+    invoke: (cs: CommandService) => Promise<unknown>;
+  };
+
+  const routedCases: RoutedCase[] = [
+    {
+      method: 'retryTask',
+      scope: 'task',
+      action: 'retryTask',
+      id: 'task-1',
+      invoke: (cs) => cs.retryTask(makeEnvelope({ taskId: 'task-1' }, 'r-task')),
+    },
+    {
+      method: 'recreateTask',
+      scope: 'task',
+      action: 'recreateTask',
+      id: 'task-1',
+      invoke: (cs) => cs.recreateTask(makeEnvelope({ taskId: 'task-1' }, 'rc-task')),
+    },
+    {
+      method: 'retryWorkflow',
+      scope: 'workflow',
+      action: 'retryWorkflow',
+      id: 'wf-1',
+      invoke: (cs) => cs.retryWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'r-wf')),
+    },
+    {
+      method: 'recreateWorkflow',
+      scope: 'workflow',
+      action: 'recreateWorkflow',
+      id: 'wf-1',
+      invoke: (cs) => cs.recreateWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'rc-wf')),
+    },
+    {
+      method: 'recreateWorkflowFromFreshBase',
+      scope: 'workflow',
+      action: 'recreateWorkflowFromFreshBase',
+      id: 'wf-1',
+      invoke: (cs) =>
+        cs.recreateWorkflowFromFreshBase(
+          makeEnvelope({ workflowId: 'wf-1' }, 'rcffb-wf'),
+        ),
+    },
+  ];
+
+  for (const c of routedCases) {
+    it(`${c.method}: routes through applyInvalidation('${c.scope}', '${c.action}', '${c.id}', injectedDeps)`, async () => {
+      const { deps, events } = makeSpiedDeps();
+      const cs = new CommandService(orchestrator, deps);
+
+      const result = await c.invoke(cs);
+
+      expect(result).toEqual({ ok: true, data: [] });
+
+      const stages = events.map((e) => e.stage);
+      expect(stages).toEqual(['cancelInFlight', c.action, 'cascadeDownstream']);
+
+      const cancel = events[0];
+      const dispatch = events[1];
+      const cascade = events[2];
+      expect(cancel.scope).toBe(c.scope);
+      expect(cancel.id).toBe(c.id);
+      expect(dispatch.id).toBe(c.id);
+      expect(cascade.scope).toBe(c.scope);
+      expect(cascade.id).toBe(c.id);
+
+      expect(orchestrator.cancelTask).not.toHaveBeenCalled();
+      expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+      expect(orchestrator.cascadeInvalidationToDownstream).not.toHaveBeenCalled();
+    });
+  }
+
+  it('falls back to orchestrator-only deps when none are injected', async () => {
+    const cs = new CommandService(orchestrator);
+
+    const result = await cs.retryTask(makeEnvelope({ taskId: 'task-1' }));
+
+    expect(result).toEqual({ ok: true, data: [makeTask()] });
+    expect(orchestrator.cancelTask).toHaveBeenCalledWith('task-1');
+    expect(orchestrator.retryTask).toHaveBeenCalledWith('task-1');
+    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-1');
+  });
+});

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -43,6 +43,9 @@ function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
     retryWorkflow: vi.fn().mockReturnValue([]),
     recreateWorkflow: vi.fn().mockReturnValue([]),
     recreateWorkflowFromFreshBase: vi.fn().mockResolvedValue([] as TaskState[]),
+    cascadeInvalidationToDownstream: vi.fn().mockReturnValue([]),
+    autoStartExternallyUnblockedReadyTasks: vi.fn().mockReturnValue([]),
+    forkWorkflow: vi.fn().mockReturnValue({ started: [] }),
     ...overrides,
   } as unknown as Orchestrator;
 }
@@ -616,14 +619,20 @@ describe('CommandService', () => {
       const p1 = service.retryTask(makeEnvelope({ taskId: 't-1' }, 'k1'));
       const p2 = service.editTaskCommand(makeEnvelope({ taskId: 't-2', newCommand: 'x' }, 'k2'));
 
-      await Promise.resolve();
-      expect(order).toEqual(['restart-start', 'edit-start']);
+      for (let i = 0; i < 4; i += 1) await Promise.resolve();
+      expect(order).toContain('restart-start');
+      expect(order).toContain('edit-start');
+      expect(order).not.toContain('restart-end');
+      expect(order).not.toContain('edit-end');
 
       resolveRestart();
       resolveEdit();
 
       await Promise.all([p1, p2]);
-      expect(order).toEqual(['restart-start', 'edit-start', 'restart-end', 'edit-end']);
+      expect(order).toContain('restart-end');
+      expect(order).toContain('edit-end');
+      expect(order.indexOf('restart-end')).toBeGreaterThan(order.indexOf('restart-start'));
+      expect(order.indexOf('edit-end')).toBeGreaterThan(order.indexOf('edit-start'));
     });
   });
 });

--- a/packages/workflow-core/src/__tests__/restart-deprecation.test.ts
+++ b/packages/workflow-core/src/__tests__/restart-deprecation.test.ts
@@ -74,6 +74,9 @@ describe('restartTask deprecation shim', () => {
       retryTask: ReturnType<typeof vi.fn>;
       recreateTask: ReturnType<typeof vi.fn>;
       getTask: ReturnType<typeof vi.fn>;
+      cancelTask: ReturnType<typeof vi.fn>;
+      cancelWorkflow: ReturnType<typeof vi.fn>;
+      cascadeInvalidationToDownstream: ReturnType<typeof vi.fn>;
     };
 
     beforeEach(() => {
@@ -83,7 +86,10 @@ describe('restartTask deprecation shim', () => {
         // CommandService consults getTask() to scope the mutex
         // by workflow; returning undefined falls back to global.
         getTask: vi.fn(() => undefined),
-      };
+        cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+        cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+        cascadeInvalidationToDownstream: vi.fn(() => []),
+      } as never;
       // CommandService is a thin mutex-serialized wrapper; for
       // shim testing we just need the orchestrator delegate.
       svc = new CommandService(orchestrator as never);

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -8,6 +8,11 @@
 import type { CommandEnvelope, CommandResult } from '@invoker/contracts';
 import { OrchestratorError } from './orchestrator.js';
 import type { Orchestrator, ExternalGatePolicyUpdate, TaskReplacementDef } from './orchestrator.js';
+import {
+  applyInvalidation,
+  buildOrchestratorOnlyInvalidationDeps,
+  type InvalidationDeps,
+} from './invalidation-policy.js';
 import type { TaskState } from '@invoker/workflow-graph';
 
 // ── Cancel Result ────────────────────────────────────────────
@@ -18,13 +23,16 @@ export type CancelResult = { cancelled: string[]; runningCancelled: string[] };
 
 export class CommandService {
   private readonly orchestrator: Orchestrator;
+  private readonly invalidationDeps: InvalidationDeps;
 
   // Promise-chain mutexes: workflow-local by default, global fallback when no workflow can be resolved.
   private readonly workflowMutexTails = new Map<string, Promise<void>>();
   private globalMutexTail: Promise<void> = Promise.resolve();
 
-  constructor(orchestrator: Orchestrator) {
+  constructor(orchestrator: Orchestrator, invalidationDeps?: InvalidationDeps) {
     this.orchestrator = orchestrator;
+    this.invalidationDeps = invalidationDeps
+      ?? buildOrchestratorOnlyInvalidationDeps(orchestrator);
   }
 
   // ── Mutex ────────────────────────────────────────────────
@@ -136,7 +144,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RETRY_TASK_FAILED',
-      () => this.orchestrator.retryTask(envelope.payload.taskId),
+      () => applyInvalidation('task', 'retryTask', envelope.payload.taskId, this.invalidationDeps),
       this.workflowIdForTask(envelope.payload.taskId),
     );
   }
@@ -152,7 +160,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RECREATE_TASK_FAILED',
-      () => this.orchestrator.recreateTask(envelope.payload.taskId),
+      () => applyInvalidation('task', 'recreateTask', envelope.payload.taskId, this.invalidationDeps),
       this.workflowIdForTask(envelope.payload.taskId),
     );
   }
@@ -421,7 +429,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RETRY_WORKFLOW_FAILED',
-      () => this.orchestrator.retryWorkflow(envelope.payload.workflowId),
+      () => applyInvalidation('workflow', 'retryWorkflow', envelope.payload.workflowId, this.invalidationDeps),
       envelope.payload.workflowId,
     );
   }
@@ -445,7 +453,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RECREATE_WORKFLOW_FAILED',
-      () => this.orchestrator.recreateWorkflow(envelope.payload.workflowId),
+      () => applyInvalidation('workflow', 'recreateWorkflow', envelope.payload.workflowId, this.invalidationDeps),
       envelope.payload.workflowId,
     );
   }
@@ -468,7 +476,12 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RECREATE_WORKFLOW_FROM_FRESH_BASE_FAILED',
-      () => this.orchestrator.recreateWorkflowFromFreshBase(envelope.payload.workflowId),
+      () => applyInvalidation(
+        'workflow',
+        'recreateWorkflowFromFreshBase',
+        envelope.payload.workflowId,
+        this.invalidationDeps,
+      ),
       envelope.payload.workflowId,
     );
   }

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -335,3 +335,68 @@ export async function applyInvalidation(
   }
   return ctx.started;
 }
+
+// Structural type to avoid a circular import on the full
+// `Orchestrator` class (which imports `applyInvalidation` from here).
+export interface InvalidationDepsOrchestrator {
+  cancelTask(taskId: string): unknown;
+  cancelWorkflow(workflowId: string): unknown;
+  retryTask(taskId: string): TaskState[];
+  recreateTask(taskId: string): TaskState[];
+  retryWorkflow(workflowId: string): TaskState[];
+  recreateWorkflow(workflowId: string): TaskState[];
+  recreateWorkflowFromFreshBase(workflowId: string): Promise<TaskState[]>;
+  forkWorkflow(workflowId: string): { started: TaskState[] };
+  autoStartExternallyUnblockedReadyTasks(): TaskState[];
+  approve(taskId: string): Promise<TaskState[]>;
+  reject(taskId: string, reason?: string): void;
+  getTask(taskId: string): { config?: { workflowId?: string } } | undefined;
+  cascadeInvalidationToDownstream(workflowId: string): TaskState[];
+}
+
+const TERMINAL_CANCEL_ERROR_CODES = new Set([
+  'TASK_ALREADY_TERMINAL',
+  'WORKFLOW_ALREADY_TERMINAL',
+]);
+
+export function buildOrchestratorOnlyInvalidationDeps(
+  orchestrator: InvalidationDepsOrchestrator,
+): InvalidationDeps {
+  return {
+    cancelInFlight: async (scope, id) => {
+      if (scope === 'none') return;
+      try {
+        if (scope === 'task') orchestrator.cancelTask(id);
+        else orchestrator.cancelWorkflow(id);
+      } catch (e) {
+        // Already-terminal targets have nothing to cancel; the rest
+        // of the pipeline still runs.
+        const code = (e as { code?: string })?.code;
+        if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
+        throw e;
+      }
+    },
+    retryTask: (taskId) => orchestrator.retryTask(taskId),
+    recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
+    recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
+    recreateWorkflowFromFreshBase: (workflowId) =>
+      orchestrator.recreateWorkflowFromFreshBase(workflowId),
+    workflowFork: (workflowId) => orchestrator.forkWorkflow(workflowId).started,
+    scheduleOnly: () => orchestrator.autoStartExternallyUnblockedReadyTasks(),
+    fixApprove: (taskId) => orchestrator.approve(taskId),
+    fixReject: (taskId) => {
+      orchestrator.reject(taskId);
+      return [];
+    },
+    cascadeDownstream: (scope, id) => {
+      const workflowId =
+        scope === 'workflow'
+          ? id
+          : orchestrator.getTask(id)?.config?.workflowId;
+      if (!workflowId) return [];
+      return orchestrator.cascadeInvalidationToDownstream(workflowId);
+    },
+  };
+}
+


### PR DESCRIPTION
Route CommandService.{retryTask, recreateTask, retryWorkflow,
recreateWorkflow, recreateWorkflowFromFreshBase} through
applyInvalidation instead of calling orchestrator primitives directly
(the long-deferred Step 17 wiring). The constructor now takes an
optional InvalidationDeps; when none is injected,
buildOrchestratorOnlyInvalidationDeps synthesizes a minimal deps
object directly from the orchestrator. Phase-0 in-primitive cascade
and cancelActiveBeforeInvalidation calls remain as idempotent
defense-in-depth. Routing of workflow-actions.ts is intentionally
deferred (richer dep surface).

Depends-On: #904