### PR TITLE
Wire buildInvalidationDeps into production CommandService

### DIFF
--- a/packages/app/src/__tests__/parity-regression.test.ts
+++ b/packages/app/src/__tests__/parity-regression.test.ts
@@ -511,6 +511,9 @@ describe('Parity: CommandService routes to correct orchestrator primitives', () 
       selectExperiment: vi.fn(() => [makeTask()]),
       setTaskExternalGatePolicies: vi.fn(() => []),
       replaceTask: vi.fn(() => []),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
+      autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
+      forkWorkflow: vi.fn(() => ({ started: [] })),
     };
     commandService = new CommandService(orchestrator as any);
   });
@@ -723,6 +726,9 @@ describe('Parity: CommandService serializes concurrent mutations', () => {
         callOrder.push('edit-end');
         return [makeTask()];
       }),
+      cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
     };
     const cs = new CommandService(orchestrator as any);
 
@@ -750,6 +756,9 @@ describe('Parity: CommandService serializes concurrent mutations', () => {
         callOrder.push(`${wf}-retry-end`);
         return [makeTask({ id: taskId, config: { workflowId: wf } })];
       }),
+      cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+      cascadeInvalidationToDownstream: vi.fn(() => []),
     };
     const cs = new CommandService(orchestrator as any);
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -128,6 +128,7 @@ import {
 import {
   approveTask as sharedApproveTask,
   autoFixOnReviewGateFailure,
+  buildInvalidationDeps,
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
   fixWithAgentAction,
@@ -239,6 +240,10 @@ let persistence: SQLiteAdapter;
 let executorRegistry: ExecutorRegistry;
 let orchestrator: Orchestrator;
 let commandService: CommandService;
+// Latest TaskRunner reference for invalidation deps. CommandService is
+// constructed in initServices before TaskRunner exists, so the deps
+// resolve via this getter at cancel-in-flight time.
+let latestTaskExecutor: TaskRunner | null = null;
 let runtimeServices: RuntimeServices;
 let workflowMutationCoordinator: PersistedWorkflowMutationCoordinator | null = null;
 let launchDispatcher: LaunchDispatcher | null = null;
@@ -503,7 +508,15 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     deferRunningUntilLaunch: true,
     launchOutboxMode: invokerConfig.launchOutboxMode,
   });
-  commandService = new CommandService(orchestrator);
+  commandService = new CommandService(
+    orchestrator,
+    buildInvalidationDeps({
+      logger,
+      orchestrator,
+      persistence,
+      taskExecutor: () => latestTaskExecutor,
+    }),
+  );
 
   const startupSyncMode = options?.startupSyncMode ?? 'all';
   const initLog = isHeadless
@@ -1762,6 +1775,7 @@ function createEmbeddedTerminalBackendFromConfig(
         },
       },
     });
+    latestTaskExecutor = taskExecutor;
     wireApproveHook();
   }
 
@@ -3082,7 +3096,15 @@ function createEmbeddedTerminalBackendFromConfig(
         deferRunningUntilLaunch: true,
         launchOutboxMode: invokerConfig.launchOutboxMode,
       });
-      commandService = new CommandService(orchestrator);
+      commandService = new CommandService(
+        orchestrator,
+        buildInvalidationDeps({
+          logger,
+          orchestrator,
+          persistence,
+          taskExecutor: () => latestTaskExecutor,
+        }),
+      );
       rebuildTaskRunner();
       taskHandles.clear();
     });

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -500,9 +500,23 @@ export async function rebaseRecreate(
   return started;
 }
 
+/**
+ * Reference to a TaskRunner. Either a direct instance or a getter that
+ * returns the current instance — the latter is required when the dep
+ * builder runs before `taskExecutor` is constructed (the executor is
+ * built lazily by `rebuildTaskRunner` after `commandService`).
+ */
+export type TaskExecutorRef = TaskRunner | (() => TaskRunner | null | undefined);
+
+function resolveTaskExecutor(ref: TaskExecutorRef | undefined): TaskRunner | undefined {
+  if (!ref) return undefined;
+  if (typeof ref === 'function') return ref() ?? undefined;
+  return ref;
+}
+
 export interface BuildCancelInFlightDeps {
   orchestrator: Orchestrator;
-  taskExecutor?: TaskRunner;
+  taskExecutor?: TaskExecutorRef;
 }
 
 export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
@@ -512,7 +526,7 @@ export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlig
       scope === 'task'
         ? deps.orchestrator.cancelTask(id)
         : deps.orchestrator.cancelWorkflow(id);
-    const taskExecutor = deps.taskExecutor;
+    const taskExecutor = resolveTaskExecutor(deps.taskExecutor);
     if (!taskExecutor) return;
     for (const runningId of result.runningCancelled) {
       await taskExecutor.killActiveExecution(runningId);
@@ -520,9 +534,12 @@ export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlig
   };
 }
 
-export function buildInvalidationDeps(
-  deps: Pick<ActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'taskExecutor' | 'mutationTiming'>,
-): InvalidationDeps {
+export type BuildInvalidationDepsArgs = Omit<
+  Pick<ActionDeps, 'logger' | 'orchestrator' | 'persistence' | 'mutationTiming'>,
+  'taskExecutor'
+> & { taskExecutor?: TaskExecutorRef };
+
+export function buildInvalidationDeps(deps: BuildInvalidationDepsArgs): InvalidationDeps {
   const cancelInFlight = buildCancelInFlight({
     orchestrator: deps.orchestrator,
     taskExecutor: deps.taskExecutor,
@@ -543,7 +560,7 @@ export function buildInvalidationDeps(
         logger: deps.logger,
         orchestrator: deps.orchestrator,
         persistence: deps.persistence,
-        taskExecutor: deps.taskExecutor,
+        taskExecutor: resolveTaskExecutor(deps.taskExecutor),
         mutationTiming: deps.mutationTiming,
       }),
     workflowFork: (workflowId: string) => {
@@ -554,23 +571,15 @@ export function buildInvalidationDeps(
       );
       return result.started;
     },
-    // Step 15 wiring (`docs/architecture/task-invalidation-roadmap.md`,
-    // chart row "Change external gate policy"). The dep is invoked
-    // by `applyInvalidation` for action `'scheduleOnly'` WITHOUT a
-    // preceding `cancelInFlight` call — gate-policy edits are
-    // non-invalidating per the chart. The orchestrator's existing
-    // `autoStartExternallyUnblockedReadyTasks` primitive is the
-    // right scheduler entrypoint: it re-evaluates every task with
-    // external dependencies whose blocker has cleared. Today's
-    // primitive is workflow-agnostic; the `taskId` argument is
-    // accepted for future scoping but ignored by the underlying
-    // method.
+    // `scheduleOnly` is invoked by applyInvalidation WITHOUT a
+    // preceding cancelInFlight; the underlying primitive is
+    // workflow-agnostic and ignores the taskId argument.
     scheduleOnly: (_taskId: string) =>
       deps.orchestrator.autoStartExternallyUnblockedReadyTasks(),
     fixApprove: async (taskId: string) => {
       const result = await approveTask(taskId, {
         orchestrator: deps.orchestrator,
-        taskExecutor: deps.taskExecutor,
+        taskExecutor: resolveTaskExecutor(deps.taskExecutor),
       });
       return result.started;
     },

--- a/packages/workflow-core/src/__tests__/command-service-routing.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service-routing.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CommandService } from '../command-service.js';
+import type {
+  InvalidationDeps,
+  InvalidationScope,
+  InvalidationAction,
+} from '../invalidation-policy.js';
+import type { Orchestrator } from '../orchestrator.js';
+import type { CommandEnvelope } from '@invoker/contracts';
+import type { TaskState } from '@invoker/workflow-graph';
+
+function makeEnvelope<P>(payload: P, id = 'cmd-1'): CommandEnvelope<P> {
+  return {
+    commandId: id,
+    source: 'headless',
+    scope: 'task',
+    idempotencyKey: `key-${id}`,
+    payload,
+  };
+}
+
+// Fixed `createdAt` so two separate `makeTask()` calls produce
+// deeply-equal results — needed for `toEqual` against the orchestrator
+// fallback's return value.
+const FIXED_CREATED_AT = new Date('2026-01-01T00:00:00.000Z');
+
+function makeTask(): TaskState {
+  return {
+    id: 'task-1',
+    description: 'task',
+    dependencies: [],
+    status: 'pending',
+    createdAt: FIXED_CREATED_AT,
+    config: { workflowId: 'wf-1', isMergeNode: false },
+    execution: {},
+  } as unknown as TaskState;
+}
+
+function makeOrchestrator(): Orchestrator {
+  return {
+    getTask: vi.fn(() => makeTask()),
+    cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+    cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+    retryTask: vi.fn(() => [makeTask()]),
+    recreateTask: vi.fn(() => [makeTask()]),
+    retryWorkflow: vi.fn(() => [makeTask()]),
+    recreateWorkflow: vi.fn(() => [makeTask()]),
+    recreateWorkflowFromFreshBase: vi.fn(async () => [makeTask()]),
+    forkWorkflow: vi.fn(() => ({ started: [] })),
+    cascadeInvalidationToDownstream: vi.fn(() => []),
+    autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
+    approve: vi.fn(async () => []),
+    reject: vi.fn(),
+  } as unknown as Orchestrator;
+}
+
+function makeSpiedDeps(): {
+  deps: InvalidationDeps;
+  events: Array<{ stage: string; scope?: InvalidationScope; id: string }>;
+} {
+  const events: Array<{ stage: string; scope?: InvalidationScope; id: string }> = [];
+  const result: TaskState[] = [];
+  const deps: InvalidationDeps = {
+    cancelInFlight: vi.fn(async (scope, id) => {
+      events.push({ stage: 'cancelInFlight', scope, id });
+    }),
+    retryTask: vi.fn((id) => {
+      events.push({ stage: 'retryTask', id });
+      return result;
+    }),
+    recreateTask: vi.fn((id) => {
+      events.push({ stage: 'recreateTask', id });
+      return result;
+    }),
+    retryWorkflow: vi.fn((id) => {
+      events.push({ stage: 'retryWorkflow', id });
+      return result;
+    }),
+    recreateWorkflow: vi.fn((id) => {
+      events.push({ stage: 'recreateWorkflow', id });
+      return result;
+    }),
+    recreateWorkflowFromFreshBase: vi.fn(async (id) => {
+      events.push({ stage: 'recreateWorkflowFromFreshBase', id });
+      return result;
+    }),
+    cascadeDownstream: vi.fn((scope, id) => {
+      events.push({ stage: 'cascadeDownstream', scope, id });
+      return [];
+    }),
+  };
+  return { deps, events };
+}
+
+describe('CommandService → applyInvalidation routing', () => {
+  let orchestrator: Orchestrator;
+
+  beforeEach(() => {
+    orchestrator = makeOrchestrator();
+  });
+
+  type RoutedCase = {
+    method: 'retryTask' | 'recreateTask' | 'retryWorkflow' | 'recreateWorkflow' | 'recreateWorkflowFromFreshBase';
+    scope: InvalidationScope;
+    action: InvalidationAction;
+    id: string;
+    invoke: (cs: CommandService) => Promise<unknown>;
+  };
+
+  const routedCases: RoutedCase[] = [
+    {
+      method: 'retryTask',
+      scope: 'task',
+      action: 'retryTask',
+      id: 'task-1',
+      invoke: (cs) => cs.retryTask(makeEnvelope({ taskId: 'task-1' }, 'r-task')),
+    },
+    {
+      method: 'recreateTask',
+      scope: 'task',
+      action: 'recreateTask',
+      id: 'task-1',
+      invoke: (cs) => cs.recreateTask(makeEnvelope({ taskId: 'task-1' }, 'rc-task')),
+    },
+    {
+      method: 'retryWorkflow',
+      scope: 'workflow',
+      action: 'retryWorkflow',
+      id: 'wf-1',
+      invoke: (cs) => cs.retryWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'r-wf')),
+    },
+    {
+      method: 'recreateWorkflow',
+      scope: 'workflow',
+      action: 'recreateWorkflow',
+      id: 'wf-1',
+      invoke: (cs) => cs.recreateWorkflow(makeEnvelope({ workflowId: 'wf-1' }, 'rc-wf')),
+    },
+    {
+      method: 'recreateWorkflowFromFreshBase',
+      scope: 'workflow',
+      action: 'recreateWorkflowFromFreshBase',
+      id: 'wf-1',
+      invoke: (cs) =>
+        cs.recreateWorkflowFromFreshBase(
+          makeEnvelope({ workflowId: 'wf-1' }, 'rcffb-wf'),
+        ),
+    },
+  ];
+
+  for (const c of routedCases) {
+    it(`${c.method}: routes through applyInvalidation('${c.scope}', '${c.action}', '${c.id}', injectedDeps)`, async () => {
+      const { deps, events } = makeSpiedDeps();
+      const cs = new CommandService(orchestrator, deps);
+
+      const result = await c.invoke(cs);
+
+      expect(result).toEqual({ ok: true, data: [] });
+
+      const stages = events.map((e) => e.stage);
+      expect(stages).toEqual(['cancelInFlight', c.action, 'cascadeDownstream']);
+
+      const cancel = events[0];
+      const dispatch = events[1];
+      const cascade = events[2];
+      expect(cancel.scope).toBe(c.scope);
+      expect(cancel.id).toBe(c.id);
+      expect(dispatch.id).toBe(c.id);
+      expect(cascade.scope).toBe(c.scope);
+      expect(cascade.id).toBe(c.id);
+
+      expect(orchestrator.cancelTask).not.toHaveBeenCalled();
+      expect(orchestrator.cancelWorkflow).not.toHaveBeenCalled();
+      expect(orchestrator.cascadeInvalidationToDownstream).not.toHaveBeenCalled();
+    });
+  }
+
+  it('falls back to orchestrator-only deps when none are injected', async () => {
+    const cs = new CommandService(orchestrator);
+
+    const result = await cs.retryTask(makeEnvelope({ taskId: 'task-1' }));
+
+    expect(result).toEqual({ ok: true, data: [makeTask()] });
+    expect(orchestrator.cancelTask).toHaveBeenCalledWith('task-1');
+    expect(orchestrator.retryTask).toHaveBeenCalledWith('task-1');
+    expect(orchestrator.cascadeInvalidationToDownstream).toHaveBeenCalledWith('wf-1');
+  });
+});

--- a/packages/workflow-core/src/__tests__/command-service.test.ts
+++ b/packages/workflow-core/src/__tests__/command-service.test.ts
@@ -43,6 +43,9 @@ function stubOrchestrator(overrides: Partial<Orchestrator> = {}): Orchestrator {
     retryWorkflow: vi.fn().mockReturnValue([]),
     recreateWorkflow: vi.fn().mockReturnValue([]),
     recreateWorkflowFromFreshBase: vi.fn().mockResolvedValue([] as TaskState[]),
+    cascadeInvalidationToDownstream: vi.fn().mockReturnValue([]),
+    autoStartExternallyUnblockedReadyTasks: vi.fn().mockReturnValue([]),
+    forkWorkflow: vi.fn().mockReturnValue({ started: [] }),
     ...overrides,
   } as unknown as Orchestrator;
 }
@@ -616,14 +619,20 @@ describe('CommandService', () => {
       const p1 = service.retryTask(makeEnvelope({ taskId: 't-1' }, 'k1'));
       const p2 = service.editTaskCommand(makeEnvelope({ taskId: 't-2', newCommand: 'x' }, 'k2'));
 
-      await Promise.resolve();
-      expect(order).toEqual(['restart-start', 'edit-start']);
+      for (let i = 0; i < 4; i += 1) await Promise.resolve();
+      expect(order).toContain('restart-start');
+      expect(order).toContain('edit-start');
+      expect(order).not.toContain('restart-end');
+      expect(order).not.toContain('edit-end');
 
       resolveRestart();
       resolveEdit();
 
       await Promise.all([p1, p2]);
-      expect(order).toEqual(['restart-start', 'edit-start', 'restart-end', 'edit-end']);
+      expect(order).toContain('restart-end');
+      expect(order).toContain('edit-end');
+      expect(order.indexOf('restart-end')).toBeGreaterThan(order.indexOf('restart-start'));
+      expect(order.indexOf('edit-end')).toBeGreaterThan(order.indexOf('edit-start'));
     });
   });
 });

--- a/packages/workflow-core/src/__tests__/cross-workflow-cascade-command-service-e2e.test.ts
+++ b/packages/workflow-core/src/__tests__/cross-workflow-cascade-command-service-e2e.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { CommandService } from '../command-service.js';
+import { Orchestrator } from '../orchestrator.js';
+import type {
+  InvalidationDeps,
+  InvalidationScope,
+} from '../invalidation-policy.js';
+import {
+  InMemoryPersistence,
+  makeOrchestrator,
+  setupChain,
+  type ChainContext,
+} from './helpers/cross-workflow-cascade-helpers.js';
+
+function buildOrchestratorDeps(orchestrator: Orchestrator): InvalidationDeps {
+  return {
+    cancelInFlight: async (scope, id) => {
+      if (scope === 'none') return;
+      try {
+        if (scope === 'task') {
+          orchestrator.cancelTask(id);
+          return;
+        }
+        orchestrator.cancelWorkflow(id);
+      } catch (e) {
+        const code = (e as { code?: string })?.code;
+        if (code === 'TASK_ALREADY_TERMINAL' || code === 'WORKFLOW_ALREADY_TERMINAL') return;
+        throw e;
+      }
+    },
+    retryTask: (taskId) => orchestrator.retryTask(taskId),
+    recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
+    recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
+    recreateWorkflowFromFreshBase: (workflowId) =>
+      orchestrator.recreateWorkflowFromFreshBase(workflowId, {
+        refreshBase: async () => ({ commit: 'fresh-sha' }),
+      }),
+    workflowFork: (workflowId) => {
+      const result = orchestrator.forkWorkflow(workflowId);
+      return result.started;
+    },
+    cascadeDownstream: (scope: InvalidationScope, id: string) => {
+      const workflowId =
+        scope === 'workflow'
+          ? id
+          : orchestrator.getTask(id)?.config.workflowId;
+      if (!workflowId) return [];
+      return orchestrator.cascadeInvalidationToDownstream(workflowId);
+    },
+  };
+}
+
+describe('cross-workflow cascade — CommandService end-to-end', () => {
+  let persistence: InMemoryPersistence;
+  let orchestrator: Orchestrator;
+  let commandService: CommandService;
+  let ctx: ChainContext;
+
+  beforeEach(() => {
+    persistence = new InMemoryPersistence();
+    orchestrator = makeOrchestrator(persistence);
+    commandService = new CommandService(orchestrator, buildOrchestratorDeps(orchestrator));
+    ctx = setupChain(orchestrator);
+  });
+
+  function expectDownstreamPending(label: string): void {
+    for (const id of [
+      ctx.downstreamRootId,
+      ctx.downstreamMidId,
+      ctx.downstreamLastId,
+      ctx.downstreamMergeId,
+    ]) {
+      expect(
+        orchestrator.getTask(id)!.status,
+        `${id} should be pending after upstream ${label} via CommandService`,
+      ).toBe('pending');
+    }
+  }
+
+  it('CommandService.recreateWorkflow on upstream cancels in-flight downstream and resets every downstream task', async () => {
+    expect(orchestrator.getTask(ctx.downstreamLastId)!.status).toBe('running');
+
+    const result = await commandService.recreateWorkflow({
+      commandId: 'cmd-recreate-upstream',
+      source: 'headless',
+      scope: 'workflow',
+      idempotencyKey: 'idemp-1',
+      payload: { workflowId: ctx.upstreamWfId },
+    });
+
+    expect(result.ok).toBe(true);
+
+    expectDownstreamPending('recreateWorkflow');
+
+    const lastEvents = persistence.events.filter((e) => e.taskId === ctx.downstreamLastId);
+    const cancelIdx = lastEvents.findIndex((e) => e.eventType === 'task.cancelled');
+    const pendingIdx = lastEvents.findIndex((e) => e.eventType === 'task.pending');
+    expect(cancelIdx, 'expected task.cancelled event for in-flight downstream task').toBeGreaterThanOrEqual(0);
+    expect(pendingIdx, 'expected task.pending event for in-flight downstream task').toBeGreaterThanOrEqual(0);
+    expect(cancelIdx, 'cancel must precede pending for the in-flight downstream task').toBeLessThan(pendingIdx);
+
+    const upstreamMarkers = persistence.events.filter(
+      (e) => e.eventType === 'task.invalidated_by_upstream',
+    );
+    expect(upstreamMarkers.length).toBeGreaterThan(0);
+  });
+
+  it('CommandService.retryWorkflow on upstream cascades downstream identically', async () => {
+    expect(orchestrator.getTask(ctx.downstreamLastId)!.status).toBe('running');
+
+    const result = await commandService.retryWorkflow({
+      commandId: 'cmd-retry-upstream',
+      source: 'headless',
+      scope: 'workflow',
+      idempotencyKey: 'idemp-2',
+      payload: { workflowId: ctx.upstreamWfId },
+    });
+
+    expect(result.ok).toBe(true);
+    expectDownstreamPending('retryWorkflow');
+  });
+});

--- a/packages/workflow-core/src/__tests__/restart-deprecation.test.ts
+++ b/packages/workflow-core/src/__tests__/restart-deprecation.test.ts
@@ -74,6 +74,9 @@ describe('restartTask deprecation shim', () => {
       retryTask: ReturnType<typeof vi.fn>;
       recreateTask: ReturnType<typeof vi.fn>;
       getTask: ReturnType<typeof vi.fn>;
+      cancelTask: ReturnType<typeof vi.fn>;
+      cancelWorkflow: ReturnType<typeof vi.fn>;
+      cascadeInvalidationToDownstream: ReturnType<typeof vi.fn>;
     };
 
     beforeEach(() => {
@@ -83,7 +86,10 @@ describe('restartTask deprecation shim', () => {
         // CommandService consults getTask() to scope the mutex
         // by workflow; returning undefined falls back to global.
         getTask: vi.fn(() => undefined),
-      };
+        cancelTask: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+        cancelWorkflow: vi.fn(() => ({ cancelled: [], runningCancelled: [] })),
+        cascadeInvalidationToDownstream: vi.fn(() => []),
+      } as never;
       // CommandService is a thin mutex-serialized wrapper; for
       // shim testing we just need the orchestrator delegate.
       svc = new CommandService(orchestrator as never);

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -8,6 +8,11 @@
 import type { CommandEnvelope, CommandResult } from '@invoker/contracts';
 import { OrchestratorError } from './orchestrator.js';
 import type { Orchestrator, ExternalGatePolicyUpdate, TaskReplacementDef } from './orchestrator.js';
+import {
+  applyInvalidation,
+  buildOrchestratorOnlyInvalidationDeps,
+  type InvalidationDeps,
+} from './invalidation-policy.js';
 import type { TaskState } from '@invoker/workflow-graph';
 
 // ── Cancel Result ────────────────────────────────────────────
@@ -18,13 +23,16 @@ export type CancelResult = { cancelled: string[]; runningCancelled: string[] };
 
 export class CommandService {
   private readonly orchestrator: Orchestrator;
+  private readonly invalidationDeps: InvalidationDeps;
 
   // Promise-chain mutexes: workflow-local by default, global fallback when no workflow can be resolved.
   private readonly workflowMutexTails = new Map<string, Promise<void>>();
   private globalMutexTail: Promise<void> = Promise.resolve();
 
-  constructor(orchestrator: Orchestrator) {
+  constructor(orchestrator: Orchestrator, invalidationDeps?: InvalidationDeps) {
     this.orchestrator = orchestrator;
+    this.invalidationDeps = invalidationDeps
+      ?? buildOrchestratorOnlyInvalidationDeps(orchestrator);
   }
 
   // ── Mutex ────────────────────────────────────────────────
@@ -136,7 +144,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RETRY_TASK_FAILED',
-      () => this.orchestrator.retryTask(envelope.payload.taskId),
+      () => applyInvalidation('task', 'retryTask', envelope.payload.taskId, this.invalidationDeps),
       this.workflowIdForTask(envelope.payload.taskId),
     );
   }
@@ -152,7 +160,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RECREATE_TASK_FAILED',
-      () => this.orchestrator.recreateTask(envelope.payload.taskId),
+      () => applyInvalidation('task', 'recreateTask', envelope.payload.taskId, this.invalidationDeps),
       this.workflowIdForTask(envelope.payload.taskId),
     );
   }
@@ -421,7 +429,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RETRY_WORKFLOW_FAILED',
-      () => this.orchestrator.retryWorkflow(envelope.payload.workflowId),
+      () => applyInvalidation('workflow', 'retryWorkflow', envelope.payload.workflowId, this.invalidationDeps),
       envelope.payload.workflowId,
     );
   }
@@ -445,7 +453,7 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RECREATE_WORKFLOW_FAILED',
-      () => this.orchestrator.recreateWorkflow(envelope.payload.workflowId),
+      () => applyInvalidation('workflow', 'recreateWorkflow', envelope.payload.workflowId, this.invalidationDeps),
       envelope.payload.workflowId,
     );
   }
@@ -468,7 +476,12 @@ export class CommandService {
   ): Promise<CommandResult<TaskState[]>> {
     return this.executeCommand<TaskState[]>(
       'RECREATE_WORKFLOW_FROM_FRESH_BASE_FAILED',
-      () => this.orchestrator.recreateWorkflowFromFreshBase(envelope.payload.workflowId),
+      () => applyInvalidation(
+        'workflow',
+        'recreateWorkflowFromFreshBase',
+        envelope.payload.workflowId,
+        this.invalidationDeps,
+      ),
       envelope.payload.workflowId,
     );
   }

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -53,26 +53,11 @@ export const MUTATION_POLICIES: Readonly<Record<MutationKey, TaskMutationPolicy>
   mergeMode:             { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
   fixContext:            { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'retryTask' as const },
   rebaseAndRetry:        { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'recreateWorkflowFromFreshBase' as const },
-  // Step 15 (`docs/architecture/task-invalidation-roadmap.md`): the
-  // chart's Decision Table row "Change external gate policy" is the
-  // intentional non-invalidating outlier — it's a scheduling policy
-  // edit, not an execution-spec edit. Action is now the explicit
-  // `'scheduleOnly'` (was `'none'` in Step 1) so the lock-in is
-  // encoded in the policy table itself: `applyInvalidation` skips
-  // `cancelInFlight` for this action and routes to a `scheduleOnly`
-  // dep that triggers an unblock-pass (e.g.
-  // `Orchestrator.autoStartExternallyUnblockedReadyTasks`). Per chart:
-  //   - `invalidatesExecutionSpec: false` (no ABI change)
-  //   - `invalidateIfActive: false`       (in-flight work survives)
+  // Non-invalidating: scheduling-policy edit, not execution-spec edit.
   externalGatePolicy:    { invalidatesExecutionSpec: false, invalidateIfActive: false, action: 'scheduleOnly' as const },
   fixApprove:            { invalidatesExecutionSpec: false, invalidateIfActive: false, action: 'fixApprove' as const },
   fixReject:             { invalidatesExecutionSpec: false, invalidateIfActive: false, action: 'fixReject' as const },
-  // Step 11 (`docs/architecture/task-invalidation-roadmap.md`): graph
-  // topology mutations (e.g. `replaceTask`, `addTask` that changes
-  // parent edges) are fork-class / workflow scope. They must NOT
-  // mutate a live workflow in place; they fork a new workflow rooted
-  // from the relevant node/result. Step 12 wires the matching
-  // `forkWorkflow*` lifecycle dep on `applyInvalidation`.
+  // Topology mutations fork rather than mutate live workflows.
   topology:              { invalidatesExecutionSpec: true,  invalidateIfActive: true,  action: 'workflowFork' as const },
 });
 
@@ -88,42 +73,14 @@ export interface InvalidationDeps {
   retryWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflowFromFreshBase?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
-  /**
-   * Step 11 surfaced `'workflowFork'` as the topology-class action;
-   * Step 14 (`docs/architecture/task-invalidation-roadmap.md`) wires
-   * the implementation. Production callers (`buildInvalidationDeps`
-   * in `packages/app/src/workflow-actions.ts`) supply
-   * `Orchestrator.forkWorkflow` here, so the "not yet wired" error
-   * path below is now dead code in production — it only fires for
-   * focused unit tests that build a partial `InvalidationDeps`.
-   */
   workflowFork?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
-  /**
-   * Step 15 (`docs/architecture/task-invalidation-roadmap.md`):
-   * scheduling-only unblock pass for the chart's "Change external
-   * gate policy" row. Production callers wire this to a scheduler
-   * entrypoint (e.g.
-   * `Orchestrator.autoStartExternallyUnblockedReadyTasks`) via
-   * `buildInvalidationDeps` (`packages/app/src/workflow-actions.ts`).
-   * Unlike retry/recreate deps, this is invoked WITHOUT a
-   * preceding `cancelInFlight` call — gate-policy edits MUST NOT
-   * cancel active work. The dep takes the affected task id so it
-   * can scope the scheduling pass if desired; today's
-   * implementation re-evaluates all externally-unblocked ready
-   * tasks across the orchestrator.
-   */
+  /** Scheduling-only unblock pass; invoked WITHOUT a preceding `cancelInFlight`. */
   scheduleOnly?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   fixApprove?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   fixReject?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   /**
-   * Cross-workflow cascade hook. Invoked by `applyInvalidation` after
-   * an invalidating action's dep returns, so any transitive downstream
-   * workflow that depends on the invalidated upstream is itself
-   * cancel-and-reset-to-pending. The downstream's existing external
-   * dependency gate then re-blocks the freshly-pending tasks until
-   * the upstream re-completes.
-   *
-   * Only invoked for actions that change execution state:
+   * Cross-workflow cascade hook. Invoked only for actions that change
+   * execution state:
    *   - task scope:     `retryTask`, `recreateTask`
    *   - workflow scope: `retryWorkflow`, `recreateWorkflow`,
    *                     `recreateWorkflowFromFreshBase`, `workflowFork`
@@ -131,12 +88,6 @@ export interface InvalidationDeps {
    * Skipped for `'none'`, `'scheduleOnly'`, `'fixApprove'`, and
    * `'fixReject'` — these are non-invalidating per `MUTATION_POLICIES`
    * and must not reset downstream lineage.
-   *
-   * Production callers wire this via `buildInvalidationDeps`
-   * (`packages/app/src/workflow-actions.ts`) to
-   * `Orchestrator.cascadeInvalidationToDownstream`. The dep is
-   * optional so unit tests that build a partial `InvalidationDeps`
-   * keep working without supplying the cascade.
    */
   cascadeDownstream?: (
     scope: InvalidationScope,
@@ -261,11 +212,6 @@ async function invokePrimitive(
       return [];
     case 'scheduleOnly': {
       if (!deps.scheduleOnly) {
-        // Step 15: production callers wire this dep via
-        // `buildInvalidationDeps` (`packages/app/src/workflow-actions.ts`)
-        // to `Orchestrator.autoStartExternallyUnblockedReadyTasks`. This
-        // branch is reachable only from focused unit tests that build a
-        // partial `InvalidationDeps` without the scheduler dep.
         throw new Error(
           "applyInvalidation: 'scheduleOnly' dep is missing. " +
             'Production callers wire this via buildInvalidationDeps in ' +
@@ -306,10 +252,6 @@ async function invokePrimitive(
     }
     case 'workflowFork': {
       if (!deps.workflowFork) {
-        // Step 14 wires this dep in production via
-        // `buildInvalidationDeps` (`packages/app/src/workflow-actions.ts`).
-        // This branch is reachable only from focused unit tests that
-        // build a partial `InvalidationDeps` without the topology dep.
         throw new Error(
           "applyInvalidation: 'workflowFork' dep is missing. " +
             'Production callers wire this via buildInvalidationDeps in ' +

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -335,3 +335,68 @@ export async function applyInvalidation(
   }
   return ctx.started;
 }
+
+// Structural type to avoid a circular import on the full
+// `Orchestrator` class (which imports `applyInvalidation` from here).
+export interface InvalidationDepsOrchestrator {
+  cancelTask(taskId: string): unknown;
+  cancelWorkflow(workflowId: string): unknown;
+  retryTask(taskId: string): TaskState[];
+  recreateTask(taskId: string): TaskState[];
+  retryWorkflow(workflowId: string): TaskState[];
+  recreateWorkflow(workflowId: string): TaskState[];
+  recreateWorkflowFromFreshBase(workflowId: string): Promise<TaskState[]>;
+  forkWorkflow(workflowId: string): { started: TaskState[] };
+  autoStartExternallyUnblockedReadyTasks(): TaskState[];
+  approve(taskId: string): Promise<TaskState[]>;
+  reject(taskId: string, reason?: string): void;
+  getTask(taskId: string): { config?: { workflowId?: string } } | undefined;
+  cascadeInvalidationToDownstream(workflowId: string): TaskState[];
+}
+
+const TERMINAL_CANCEL_ERROR_CODES = new Set([
+  'TASK_ALREADY_TERMINAL',
+  'WORKFLOW_ALREADY_TERMINAL',
+]);
+
+export function buildOrchestratorOnlyInvalidationDeps(
+  orchestrator: InvalidationDepsOrchestrator,
+): InvalidationDeps {
+  return {
+    cancelInFlight: async (scope, id) => {
+      if (scope === 'none') return;
+      try {
+        if (scope === 'task') orchestrator.cancelTask(id);
+        else orchestrator.cancelWorkflow(id);
+      } catch (e) {
+        // Already-terminal targets have nothing to cancel; the rest
+        // of the pipeline still runs.
+        const code = (e as { code?: string })?.code;
+        if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
+        throw e;
+      }
+    },
+    retryTask: (taskId) => orchestrator.retryTask(taskId),
+    recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
+    recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
+    recreateWorkflowFromFreshBase: (workflowId) =>
+      orchestrator.recreateWorkflowFromFreshBase(workflowId),
+    workflowFork: (workflowId) => orchestrator.forkWorkflow(workflowId).started,
+    scheduleOnly: () => orchestrator.autoStartExternallyUnblockedReadyTasks(),
+    fixApprove: (taskId) => orchestrator.approve(taskId),
+    fixReject: (taskId) => {
+      orchestrator.reject(taskId);
+      return [];
+    },
+    cascadeDownstream: (scope, id) => {
+      const workflowId =
+        scope === 'workflow'
+          ? id
+          : orchestrator.getTask(id)?.config?.workflowId;
+      if (!workflowId) return [];
+      return orchestrator.cascadeInvalidationToDownstream(workflowId);
+    },
+  };
+}
+


### PR DESCRIPTION
## Summary

Wire `buildInvalidationDeps({...})` into both `commandService = new CommandService(orchestrator)` call sites in `packages/app/src/main.ts` (initServices and the GUI-mode reset). Until now, both fell back to `buildOrchestratorOnlyInvalidationDeps`, losing:

- **executor kill on cancel-in-flight** — the orchestrator marks tasks as cancelled but the running TaskRunner attempts continue.
- **generation bump on `recreateWorkflow`** — workflows would be recreated without bumping the execution generation, undermining stale-result rejection.
- **`recreateWorkflowFromFreshBase` composite** — the fresh-base path (mirror refresh + branch cleanup + recreate) was unreachable through the production CommandService.

Cross-workflow cascade was already wired in #890–#894, but only flows through the production deps now that this PR lands.

## Architecture

### Before

```mermaid
flowchart LR
  IPC[IPC handlers] --> CS[CommandService]
  CS --> apply[applyInvalidation]
  apply --> fallback[buildOrchestratorOnlyInvalidationDeps]
  fallback -. no kill .-> Orch[Orchestrator]
  TaskRunner[TaskRunner kill] -. unreachable .-> Orch
```

### After

```mermaid
flowchart LR
  IPC[IPC handlers] --> CS[CommandService]
  CS --> apply[applyInvalidation]
  apply --> deps[buildInvalidationDeps]
  deps --> Orch[Orchestrator]
  deps --> TaskRunner[TaskRunner kill]
  deps --> FreshBase[recreateWorkflowFromFreshBase]
  deps --> Cascade[cascadeInvalidationToDownstream]
```

### Lazy TaskExecutor reference

The TaskRunner is constructed by `rebuildTaskRunner()` *after* `commandService`. To break the chicken-and-egg, this PR introduces `TaskExecutorRef = TaskRunner | (() => TaskRunner | null | undefined)` and changes `BuildCancelInFlightDeps.taskExecutor` and `BuildInvalidationDepsArgs.taskExecutor` to accept it. The deps resolve the ref at action time (cancel-in-flight, fresh-base, approve) instead of at construction.

A module-level `latestTaskExecutor: TaskRunner | null` is updated by `rebuildTaskRunner()`; the production deps read it via `() => latestTaskExecutor`.

## Test Plan

- [x] `pnpm run check:types`
- [x] `cd packages/workflow-core && pnpm test` — 49 files, 1040 tests pass.
- [x] `cd packages/app && pnpm test` — 63 files, 994 tests pass (1 pre-existing skip).

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert fca3e3463`
- Post-revert steps: None — the `TaskExecutorRef` widening is backward-compatible (a direct `TaskRunner` still type-checks).
- Data migration? No
