### PR TITLE
Share buildCancelInFlight between fallback and production deps

### DIFF
--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -14,7 +14,11 @@ import type {
   InvalidationScope,
   TaskState,
 } from '@invoker/workflow-core';
-import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
+import {
+  OrchestratorError,
+  OrchestratorErrorCode,
+  buildCancelInFlight as buildCoreCancelInFlight,
+} from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner, ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
@@ -520,18 +524,14 @@ export interface BuildCancelInFlightDeps {
 }
 
 export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
-  return async (scope: InvalidationScope, id: string): Promise<void> => {
-    if (scope === 'none') return;
-    const result =
-      scope === 'task'
-        ? deps.orchestrator.cancelTask(id)
-        : deps.orchestrator.cancelWorkflow(id);
-    const taskExecutor = resolveTaskExecutor(deps.taskExecutor);
-    if (!taskExecutor) return;
-    for (const runningId of result.runningCancelled) {
-      await taskExecutor.killActiveExecution(runningId);
-    }
-  };
+  return buildCoreCancelInFlight({
+    orchestrator: deps.orchestrator,
+    killActiveExecution: async (id) => {
+      const taskExecutor = resolveTaskExecutor(deps.taskExecutor);
+      if (!taskExecutor) return;
+      await taskExecutor.killActiveExecution(id);
+    },
+  });
 }
 
 export type BuildInvalidationDepsArgs = Omit<

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -281,8 +281,8 @@ export async function applyInvalidation(
 // Structural type to avoid a circular import on the full
 // `Orchestrator` class (which imports `applyInvalidation` from here).
 export interface InvalidationDepsOrchestrator {
-  cancelTask(taskId: string): unknown;
-  cancelWorkflow(workflowId: string): unknown;
+  cancelTask(taskId: string): { runningCancelled: string[] };
+  cancelWorkflow(workflowId: string): { runningCancelled: string[] };
   retryTask(taskId: string): TaskState[];
   recreateTask(taskId: string): TaskState[];
   retryWorkflow(workflowId: string): TaskState[];
@@ -301,23 +301,50 @@ const TERMINAL_CANCEL_ERROR_CODES = new Set([
   'WORKFLOW_ALREADY_TERMINAL',
 ]);
 
+export interface BuildCancelInFlightDeps {
+  orchestrator: Pick<InvalidationDepsOrchestrator, 'cancelTask' | 'cancelWorkflow'>;
+  /**
+   * Optional hook to kill the active executor handle for each running
+   * task that was cancelled. Production callers wire this to
+   * `TaskRunner.killActiveExecution`; the orchestrator-only fallback
+   * omits it (the orchestrator state machine still transitions the
+   * tasks, but the in-flight process keeps running until it self-exits).
+   */
+  killActiveExecution?: (taskId: string) => void | Promise<void>;
+}
+
+/**
+ * Single cancel-in-flight implementation shared by the orchestrator-only
+ * fallback and the production `buildInvalidationDeps`. Tolerates
+ * already-terminal targets (the rest of the pipeline still runs) and
+ * fans out the optional executor-kill hook for every running task that
+ * was cancelled.
+ */
+export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
+  return async (scope, id) => {
+    if (scope === 'none') return;
+    let result: { runningCancelled: string[] };
+    try {
+      result = scope === 'task'
+        ? deps.orchestrator.cancelTask(id)
+        : deps.orchestrator.cancelWorkflow(id);
+    } catch (e) {
+      const code = (e as { code?: string })?.code;
+      if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
+      throw e;
+    }
+    if (!deps.killActiveExecution) return;
+    for (const runningId of result.runningCancelled) {
+      await deps.killActiveExecution(runningId);
+    }
+  };
+}
+
 export function buildOrchestratorOnlyInvalidationDeps(
   orchestrator: InvalidationDepsOrchestrator,
 ): InvalidationDeps {
   return {
-    cancelInFlight: async (scope, id) => {
-      if (scope === 'none') return;
-      try {
-        if (scope === 'task') orchestrator.cancelTask(id);
-        else orchestrator.cancelWorkflow(id);
-      } catch (e) {
-        // Already-terminal targets have nothing to cancel; the rest
-        // of the pipeline still runs.
-        const code = (e as { code?: string })?.code;
-        if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
-        throw e;
-      }
-    },
+    cancelInFlight: buildCancelInFlight({ orchestrator }),
     retryTask: (taskId) => orchestrator.retryTask(taskId),
     recreateTask: (taskId) => orchestrator.recreateTask(taskId),
     retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),


### PR DESCRIPTION
## Summary

Move `buildCancelInFlight` to `workflow-core` so the orchestrator-only fallback (`buildOrchestratorOnlyInvalidationDeps`) and the app-side production deps (`buildInvalidationDeps`) share one cancel-first implementation.

Before this PR there were two cancel paths with subtly different behavior:

- **Fallback** (`workflow-core/invalidation-policy.ts`): tolerates already-terminal targets (`TASK_ALREADY_TERMINAL` / `WORKFLOW_ALREADY_TERMINAL`) so the rest of the pipeline still runs. No executor kill.
- **App** (`app/workflow-actions.ts`): kills the executor for each running task that was cancelled. Did NOT tolerate already-terminal errors — would throw and abort the whole pipeline.

The unified helper does both:

- Catches `TERMINAL_CANCEL_ERROR_CODES`.
- Optionally fans out a `killActiveExecution(taskId)` hook for every running task in `runningCancelled`.

The app's `buildCancelInFlight` is now a thin wrapper that resolves the `TaskExecutorRef` (introduced in #908) and forwards `killActiveExecution` to the core helper.

`InvalidationDepsOrchestrator.cancelTask`/`cancelWorkflow` are tightened from `unknown` to `{ runningCancelled: string[] }` so the helper can iterate without an unsafe cast.

## Test Plan

- [x] `pnpm run check:types`
- [x] `cd packages/workflow-core && pnpm test` — 49 files, 1040 tests pass.
- [x] `cd packages/app && pnpm test` — 63 files, 994 tests pass.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 06bc98246`
- Post-revert steps: None
- Data migration? No
