### PR TITLE
Remove Phase-0 in-primitive cross-workflow cascade calls

### DIFF
--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -14,7 +14,11 @@ import type {
   InvalidationScope,
   TaskState,
 } from '@invoker/workflow-core';
-import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
+import {
+  OrchestratorError,
+  OrchestratorErrorCode,
+  buildCancelInFlight as buildCoreCancelInFlight,
+} from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner, ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
@@ -520,18 +524,14 @@ export interface BuildCancelInFlightDeps {
 }
 
 export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
-  return async (scope: InvalidationScope, id: string): Promise<void> => {
-    if (scope === 'none') return;
-    const result =
-      scope === 'task'
-        ? deps.orchestrator.cancelTask(id)
-        : deps.orchestrator.cancelWorkflow(id);
-    const taskExecutor = resolveTaskExecutor(deps.taskExecutor);
-    if (!taskExecutor) return;
-    for (const runningId of result.runningCancelled) {
-      await taskExecutor.killActiveExecution(runningId);
-    }
-  };
+  return buildCoreCancelInFlight({
+    orchestrator: deps.orchestrator,
+    killActiveExecution: async (id) => {
+      const taskExecutor = resolveTaskExecutor(deps.taskExecutor);
+      if (!taskExecutor) return;
+      await taskExecutor.killActiveExecution(id);
+    },
+  });
 }
 
 export type BuildInvalidationDepsArgs = Omit<

--- a/packages/workflow-core/src/__tests__/cross-workflow-cascade-primitives.test.ts
+++ b/packages/workflow-core/src/__tests__/cross-workflow-cascade-primitives.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Orchestrator } from '../orchestrator.js';
 import {
+  applyInvalidation,
+  buildOrchestratorOnlyInvalidationDeps,
+} from '../invalidation-policy.js';
+import {
   InMemoryPersistence,
   makeOrchestrator,
   makeResponse,
@@ -8,7 +12,7 @@ import {
   type ChainContext,
 } from './helpers/cross-workflow-cascade-helpers.js';
 
-describe('cross-workflow cascade — primitives invoked directly (no applyInvalidation)', () => {
+describe('cross-workflow cascade — applyInvalidation pipeline', () => {
   let persistence: InMemoryPersistence;
   let orchestrator: Orchestrator;
 
@@ -16,6 +20,10 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
     persistence = new InMemoryPersistence();
     orchestrator = makeOrchestrator(persistence);
   });
+
+  function deps() {
+    return buildOrchestratorOnlyInvalidationDeps(orchestrator);
+  }
 
   function expectDownstreamPending(ctx: ChainContext, label: string): void {
     for (const id of [
@@ -31,10 +39,10 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
     }
   }
 
-  it('orchestrator.recreateWorkflow(upstream) cascades to downstream', () => {
+  it('applyInvalidation(recreateWorkflow, upstream) cascades to downstream', async () => {
     const ctx = setupChain(orchestrator);
 
-    orchestrator.recreateWorkflow(ctx.upstreamWfId);
+    await applyInvalidation('workflow', 'recreateWorkflow', ctx.upstreamWfId, deps());
 
     expectDownstreamPending(ctx, 'recreateWorkflow');
 
@@ -51,7 +59,7 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
     expect(upstreamMarkers.length).toBeGreaterThan(0);
   });
 
-  it('orchestrator.retryWorkflow(upstream) cascades to downstream', () => {
+  it('applyInvalidation(retryWorkflow, upstream) cascades to downstream', async () => {
     const ctx = setupChain(orchestrator);
 
     orchestrator.handleWorkerResponse(makeResponse({
@@ -60,20 +68,20 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
       outputs: { exitCode: 1, error: 'boom' },
     }));
 
-    orchestrator.retryWorkflow(ctx.upstreamWfId);
+    await applyInvalidation('workflow', 'retryWorkflow', ctx.upstreamWfId, deps());
 
     expectDownstreamPending(ctx, 'retryWorkflow');
   });
 
-  it('orchestrator.recreateTask(upstream task) cascades to downstream', () => {
+  it('applyInvalidation(recreateTask, upstream task) cascades to downstream', async () => {
     const ctx = setupChain(orchestrator);
 
-    orchestrator.recreateTask(ctx.upstreamTaskId);
+    await applyInvalidation('task', 'recreateTask', ctx.upstreamTaskId, deps());
 
     expectDownstreamPending(ctx, 'recreateTask');
   });
 
-  it('orchestrator.retryTask(upstream merge gate) cascades to downstream', () => {
+  it('applyInvalidation(retryTask, upstream merge gate) cascades to downstream', async () => {
     const ctx = setupChain(orchestrator);
 
     orchestrator.handleWorkerResponse(makeResponse({
@@ -82,22 +90,31 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
       outputs: { exitCode: 1, error: 'boom' },
     }));
 
-    orchestrator.retryTask(ctx.upstreamMergeId);
+    await applyInvalidation('task', 'retryTask', ctx.upstreamMergeId, deps());
 
     expectDownstreamPending(ctx, 'retryTask');
   });
 
-  it('orchestrator.recreateWorkflowFromFreshBase(upstream) cascades to downstream', async () => {
+  it('applyInvalidation(recreateWorkflowFromFreshBase, upstream) cascades to downstream', async () => {
     const ctx = setupChain(orchestrator);
 
-    await orchestrator.recreateWorkflowFromFreshBase(ctx.upstreamWfId, {
-      refreshBase: async () => ({ commit: 'fresh-sha' }),
-    });
+    await applyInvalidation(
+      'workflow',
+      'recreateWorkflowFromFreshBase',
+      ctx.upstreamWfId,
+      {
+        ...deps(),
+        recreateWorkflowFromFreshBase: (id) =>
+          orchestrator.recreateWorkflowFromFreshBase(id, {
+            refreshBase: async () => ({ commit: 'fresh-sha' }),
+          }),
+      },
+    );
 
     expectDownstreamPending(ctx, 'recreateWorkflowFromFreshBase');
   });
 
-  it('orchestrator.forkWorkflow(upstream) cascades to downstream', () => {
+  it('forkWorkflow(upstream) cascades to downstream (still primitive — fork keeps Phase-0 cascade)', () => {
     const ctx = setupChain(orchestrator);
 
     orchestrator.forkWorkflow(ctx.upstreamWfId, { autoStart: false });
@@ -105,8 +122,7 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
     expectDownstreamPending(ctx, 'forkWorkflow');
   });
 
-  it('cascade is transitive when invoked directly: A → B → C, primitives only', () => {
-    // Workflow A
+  it('cascade is transitive: A → B → C via applyInvalidation', async () => {
     orchestrator.loadPlan({
       name: 'wf-a',
       baseBranch: 'master',
@@ -157,12 +173,12 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
 
     expect(orchestrator.getTask(cTaskId)!.status).toBe('running');
 
-    orchestrator.recreateWorkflow(aWfId);
+    await applyInvalidation('workflow', 'recreateWorkflow', aWfId, deps());
 
     for (const id of [bTaskId, bMergeId, cTaskId, cMergeId]) {
       expect(
         orchestrator.getTask(id)!.status,
-        `${id} should be pending after transitive primitive-only cascade`,
+        `${id} should be pending after transitive applyInvalidation cascade`,
       ).toBe('pending');
     }
   });

--- a/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { createTaskState, type TaskState } from '@invoker/workflow-graph';
 import {
-  INVALIDATION_POLICIES,
   planInvalidation,
   withSchedulerEnqueueCandidates,
 } from '../invalidation-plan.js';
+import { ACTION_SPECS } from '../invalidation-policy.js';
 
 function task(
   id: string,
@@ -23,28 +23,23 @@ function task(
 
 describe('InvalidationPlan policy registry', () => {
   it('registers invalidating recreate/retry and schedule-only policies', () => {
-    expect(INVALIDATION_POLICIES.recreateWorkflow).toMatchObject({
-      action: 'recreateWorkflow',
+    expect(ACTION_SPECS.recreateWorkflow).toMatchObject({
       scope: 'workflow',
       mode: 'recreate',
     });
-    expect(INVALIDATION_POLICIES.recreateTask).toMatchObject({
-      action: 'recreateTask',
+    expect(ACTION_SPECS.recreateTask).toMatchObject({
       scope: 'task',
       mode: 'recreate',
     });
-    expect(INVALIDATION_POLICIES.retryWorkflow).toMatchObject({
-      action: 'retryWorkflow',
+    expect(ACTION_SPECS.retryWorkflow).toMatchObject({
       scope: 'workflow',
       mode: 'retry',
     });
-    expect(INVALIDATION_POLICIES.retryTask).toMatchObject({
-      action: 'retryTask',
+    expect(ACTION_SPECS.retryTask).toMatchObject({
       scope: 'task',
       mode: 'retry',
     });
-    expect(INVALIDATION_POLICIES.scheduleOnly).toMatchObject({
-      action: 'scheduleOnly',
+    expect(ACTION_SPECS.scheduleOnly).toMatchObject({
       scope: 'task',
       mode: 'scheduleOnly',
     });

--- a/packages/workflow-core/src/invalidation-plan.ts
+++ b/packages/workflow-core/src/invalidation-plan.ts
@@ -1,7 +1,13 @@
-import { getTransitiveDependents, type TaskState } from '@invoker/workflow-graph';
-import type { InvalidationAction, InvalidationScope } from './invalidation-policy.js';
+import type { TaskState } from '@invoker/workflow-graph';
+import {
+  ACTION_SPECS,
+  type InvalidationAction,
+  type InvalidationMode,
+  type InvalidationPlanningContext,
+  type InvalidationScope,
+} from './invalidation-policy.js';
 
-export type InvalidationMode = 'retry' | 'recreate' | 'scheduleOnly';
+export type { InvalidationMode, InvalidationPlanningContext } from './invalidation-policy.js';
 
 export interface SchedulerEnqueueCandidate {
   taskId: string;
@@ -23,36 +29,13 @@ export interface InvalidationPlan {
   lockPlan: InvalidationLockPlan;
 }
 
-export interface InvalidationPlanningContext {
-  targetId: string;
-  tasks: readonly TaskState[];
-  retryStatuses?: ReadonlySet<TaskState['status']>;
-}
-
 export interface InvalidationPlanningRequest extends InvalidationPlanningContext {
   action: InvalidationAction;
   reason?: string;
 }
 
-interface InvalidationPolicy {
-  action: InvalidationAction;
-  scope: InvalidationScope;
-  mode: InvalidationMode;
-  reason: string;
-  selectAffectedTasks: (context: InvalidationPlanningContext) => TaskState[];
-  selectInitialEnqueueCandidates?: (context: InvalidationPlanningContext, affectedTasks: readonly TaskState[]) => string[];
-}
-
-function definePolicy(policy: InvalidationPolicy): InvalidationPolicy {
-  return Object.freeze(policy);
-}
-
 function sorted(values: Iterable<string>): string[] {
   return Array.from(new Set(values)).sort();
-}
-
-function taskMap(tasks: readonly TaskState[]): Map<string, TaskState> {
-  return new Map(tasks.map((task) => [task.id, task]));
 }
 
 function workflowIdsForTasks(tasks: Iterable<TaskState>): string[] {
@@ -63,128 +46,24 @@ function workflowIdsForTasks(tasks: Iterable<TaskState>): string[] {
   );
 }
 
-function descendantsOf(
-  taskId: string,
-  tasksById: ReadonlyMap<string, TaskState>,
-  stop?: (task: TaskState) => boolean,
-): TaskState[] {
-  return getTransitiveDependents(taskId, tasksById, stop ?? (() => false))
-    .map((id) => tasksById.get(id))
-    .filter((task): task is TaskState => !!task);
-}
-
-function taskAndDescendants(
-  taskId: string,
-  tasks: readonly TaskState[],
-  stop?: (task: TaskState) => boolean,
-): TaskState[] {
-  const byId = taskMap(tasks);
-  const root = byId.get(taskId);
-  if (!root) return [];
-  return [root, ...descendantsOf(taskId, byId, stop)];
-}
-
-function retryStop(task: TaskState): boolean {
-  return task.status === 'completed' || task.status === 'stale';
-}
-
-function defaultRetryStatuses(): ReadonlySet<TaskState['status']> {
-  return new Set<TaskState['status']>([
-    'failed',
-    'needs_input',
-    'blocked',
-    'stale',
-    'fixing_with_ai',
-    'awaiting_approval',
-    'review_ready',
-  ]);
-}
-
-function makePlan(policy: InvalidationPolicy, context: InvalidationPlanningContext, reason?: string): InvalidationPlan {
-  const affectedTasks = policy.selectAffectedTasks(context);
+export function planInvalidation(request: InvalidationPlanningRequest): InvalidationPlan {
+  const spec = ACTION_SPECS[request.action];
+  if (!spec.selectAffectedTasks || !spec.mode) {
+    throw new Error(`No invalidation policy registered for action "${request.action}"`);
+  }
+  const affectedTasks = spec.selectAffectedTasks(request);
   const affectedWorkflowIds = workflowIdsForTasks(affectedTasks);
-  const enqueueTaskIds = policy.selectInitialEnqueueCandidates?.(context, affectedTasks) ?? [];
+  const enqueueTaskIds = spec.selectInitialEnqueueCandidates?.(request, affectedTasks) ?? [];
   return {
-    reason: reason ?? policy.reason,
-    action: policy.action,
-    scope: policy.scope,
-    mode: policy.mode,
+    reason: request.reason ?? spec.reason ?? request.action,
+    action: request.action,
+    scope: spec.scope,
+    mode: spec.mode,
     affectedWorkflowIds,
     affectedTaskIds: sorted(affectedTasks.map((task) => task.id)),
     schedulerEnqueueCandidates: sorted(enqueueTaskIds).map((taskId) => ({ taskId })),
     lockPlan: { workflowIds: affectedWorkflowIds },
   };
-}
-
-export const INVALIDATION_POLICIES: Readonly<Partial<Record<InvalidationAction, InvalidationPolicy>>> = Object.freeze({
-  recreateWorkflow: definePolicy({
-    action: 'recreateWorkflow',
-    scope: 'workflow',
-    mode: 'recreate',
-    reason: 'workflow.recreate',
-    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
-  }),
-  recreateWorkflowFromFreshBase: definePolicy({
-    action: 'recreateWorkflowFromFreshBase',
-    scope: 'workflow',
-    mode: 'recreate',
-    reason: 'workflow.recreateFromFreshBase',
-    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
-  }),
-  recreateTask: definePolicy({
-    action: 'recreateTask',
-    scope: 'task',
-    mode: 'recreate',
-    reason: 'task.recreate',
-    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
-  }),
-  retryTask: definePolicy({
-    action: 'retryTask',
-    scope: 'task',
-    mode: 'retry',
-    reason: 'task.retry',
-    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks, retryStop),
-  }),
-  retryWorkflow: definePolicy({
-    action: 'retryWorkflow',
-    scope: 'workflow',
-    mode: 'retry',
-    reason: 'workflow.retry',
-    selectAffectedTasks: ({ targetId, tasks, retryStatuses }) => {
-      const statuses = retryStatuses ?? defaultRetryStatuses();
-      const byId = taskMap(tasks);
-      const affectedIds = new Set<string>();
-      for (const task of tasks) {
-        if (task.config.workflowId !== targetId || !statuses.has(task.status)) continue;
-        affectedIds.add(task.id);
-        for (const descendant of descendantsOf(task.id, byId, retryStop)) {
-          affectedIds.add(descendant.id);
-        }
-      }
-      return Array.from(affectedIds)
-        .map((id) => byId.get(id))
-        .filter((task): task is TaskState => !!task);
-    },
-  }),
-  scheduleOnly: definePolicy({
-    action: 'scheduleOnly',
-    scope: 'task',
-    mode: 'scheduleOnly',
-    reason: 'externalGatePolicy',
-    selectAffectedTasks: ({ targetId, tasks }) => {
-      const task = tasks.find((item) => item.id === targetId);
-      return task ? [task] : [];
-    },
-    selectInitialEnqueueCandidates: (_context, affectedTasks) => affectedTasks.map((task) => task.id),
-  }),
-});
-
-export function planInvalidation(request: InvalidationPlanningRequest): InvalidationPlan {
-  const policy = INVALIDATION_POLICIES[request.action];
-  if (!policy) {
-    throw new Error(`No invalidation policy registered for action "${request.action}"`);
-  }
-  return makePlan(policy, request, request.reason);
 }
 
 export function withSchedulerEnqueueCandidates(

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -1,5 +1,5 @@
 
-import type { TaskState } from '@invoker/workflow-graph';
+import { getTransitiveDependents, type TaskState } from '@invoker/workflow-graph';
 export type InvalidationAction =
   | 'none'
   | 'scheduleOnly'
@@ -113,6 +113,14 @@ export type InvalidationStage =
   | 'applyPrimitive'
   | 'cascadeAcrossWorkflows';
 
+export type InvalidationMode = 'retry' | 'recreate' | 'scheduleOnly';
+
+export interface InvalidationPlanningContext {
+  targetId: string;
+  tasks: readonly TaskState[];
+  retryStatuses?: ReadonlySet<TaskState['status']>;
+}
+
 export interface ActionSpec {
   /** Required `scope` for this action. */
   readonly scope: InvalidationScope;
@@ -125,6 +133,19 @@ export interface ActionSpec {
    * in `invalidation-policy.test.ts`.
    */
   readonly cascadesAcrossWorkflows: boolean;
+  /**
+   * Planning fields used by `planInvalidation` (in `invalidation-plan.ts`).
+   * Set on actions with planning support; absent for `'none'`,
+   * `'fixApprove'`, `'fixReject'`, `'workflowFork'`. `planInvalidation`
+   * throws when called with an action that lacks `selectAffectedTasks`.
+   */
+  readonly mode?: InvalidationMode;
+  readonly reason?: string;
+  readonly selectAffectedTasks?: (context: InvalidationPlanningContext) => TaskState[];
+  readonly selectInitialEnqueueCandidates?: (
+    context: InvalidationPlanningContext,
+    affectedTasks: readonly TaskState[],
+  ) => string[];
 }
 
 const NON_INVALIDATING_TASK_STAGES: readonly InvalidationStage[] = [
@@ -139,17 +160,136 @@ const INVALIDATING_STAGES: readonly InvalidationStage[] = [
   'cascadeAcrossWorkflows',
 ];
 
+// ── Planning helpers (used by `selectAffectedTasks` callbacks below) ──
+
+function taskMap(tasks: readonly TaskState[]): Map<string, TaskState> {
+  return new Map(tasks.map((task) => [task.id, task]));
+}
+
+function descendantsOf(
+  taskId: string,
+  tasksById: ReadonlyMap<string, TaskState>,
+  stop?: (task: TaskState) => boolean,
+): TaskState[] {
+  return getTransitiveDependents(taskId, tasksById, stop ?? (() => false))
+    .map((id) => tasksById.get(id))
+    .filter((task): task is TaskState => !!task);
+}
+
+function taskAndDescendants(
+  taskId: string,
+  tasks: readonly TaskState[],
+  stop?: (task: TaskState) => boolean,
+): TaskState[] {
+  const byId = taskMap(tasks);
+  const root = byId.get(taskId);
+  if (!root) return [];
+  return [root, ...descendantsOf(taskId, byId, stop)];
+}
+
+function retryStop(task: TaskState): boolean {
+  return task.status === 'completed' || task.status === 'stale';
+}
+
+function defaultRetryStatuses(): ReadonlySet<TaskState['status']> {
+  return new Set<TaskState['status']>([
+    'failed',
+    'needs_input',
+    'blocked',
+    'stale',
+    'fixing_with_ai',
+    'awaiting_approval',
+    'review_ready',
+  ]);
+}
+
 export const ACTION_SPECS: Readonly<Record<InvalidationAction, ActionSpec>> = Object.freeze({
-  none:                          { scope: 'none',     stages: ['validateScope'] as const, cascadesAcrossWorkflows: false },
-  scheduleOnly:                  { scope: 'task',     stages: NON_INVALIDATING_TASK_STAGES, cascadesAcrossWorkflows: false },
-  fixApprove:                    { scope: 'task',     stages: NON_INVALIDATING_TASK_STAGES, cascadesAcrossWorkflows: false },
-  fixReject:                     { scope: 'task',     stages: NON_INVALIDATING_TASK_STAGES, cascadesAcrossWorkflows: false },
-  retryTask:                     { scope: 'task',     stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
-  recreateTask:                  { scope: 'task',     stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
-  retryWorkflow:                 { scope: 'workflow', stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
-  recreateWorkflow:              { scope: 'workflow', stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
-  recreateWorkflowFromFreshBase: { scope: 'workflow', stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
-  workflowFork:                  { scope: 'workflow', stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
+  none: {
+    scope: 'none',
+    stages: ['validateScope'] as const,
+    cascadesAcrossWorkflows: false,
+  },
+  scheduleOnly: {
+    scope: 'task',
+    stages: NON_INVALIDATING_TASK_STAGES,
+    cascadesAcrossWorkflows: false,
+    mode: 'scheduleOnly',
+    reason: 'externalGatePolicy',
+    selectAffectedTasks: ({ targetId, tasks }) => {
+      const task = tasks.find((item) => item.id === targetId);
+      return task ? [task] : [];
+    },
+    selectInitialEnqueueCandidates: (_context, affectedTasks) => affectedTasks.map((task) => task.id),
+  },
+  fixApprove: {
+    scope: 'task',
+    stages: NON_INVALIDATING_TASK_STAGES,
+    cascadesAcrossWorkflows: false,
+  },
+  fixReject: {
+    scope: 'task',
+    stages: NON_INVALIDATING_TASK_STAGES,
+    cascadesAcrossWorkflows: false,
+  },
+  retryTask: {
+    scope: 'task',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'retry',
+    reason: 'task.retry',
+    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks, retryStop),
+  },
+  recreateTask: {
+    scope: 'task',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'task.recreate',
+    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
+  },
+  retryWorkflow: {
+    scope: 'workflow',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'retry',
+    reason: 'workflow.retry',
+    selectAffectedTasks: ({ targetId, tasks, retryStatuses }) => {
+      const statuses = retryStatuses ?? defaultRetryStatuses();
+      const byId = taskMap(tasks);
+      const affectedIds = new Set<string>();
+      for (const task of tasks) {
+        if (task.config.workflowId !== targetId || !statuses.has(task.status)) continue;
+        affectedIds.add(task.id);
+        for (const descendant of descendantsOf(task.id, byId, retryStop)) {
+          affectedIds.add(descendant.id);
+        }
+      }
+      return Array.from(affectedIds)
+        .map((id) => byId.get(id))
+        .filter((task): task is TaskState => !!task);
+    },
+  },
+  recreateWorkflow: {
+    scope: 'workflow',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'workflow.recreate',
+    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
+  },
+  recreateWorkflowFromFreshBase: {
+    scope: 'workflow',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'workflow.recreateFromFreshBase',
+    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
+  },
+  workflowFork: {
+    scope: 'workflow',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+  },
 });
 
 interface PipelineCtx {

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -281,8 +281,8 @@ export async function applyInvalidation(
 // Structural type to avoid a circular import on the full
 // `Orchestrator` class (which imports `applyInvalidation` from here).
 export interface InvalidationDepsOrchestrator {
-  cancelTask(taskId: string): unknown;
-  cancelWorkflow(workflowId: string): unknown;
+  cancelTask(taskId: string): { runningCancelled: string[] };
+  cancelWorkflow(workflowId: string): { runningCancelled: string[] };
   retryTask(taskId: string): TaskState[];
   recreateTask(taskId: string): TaskState[];
   retryWorkflow(workflowId: string): TaskState[];
@@ -301,23 +301,50 @@ const TERMINAL_CANCEL_ERROR_CODES = new Set([
   'WORKFLOW_ALREADY_TERMINAL',
 ]);
 
+export interface BuildCancelInFlightDeps {
+  orchestrator: Pick<InvalidationDepsOrchestrator, 'cancelTask' | 'cancelWorkflow'>;
+  /**
+   * Optional hook to kill the active executor handle for each running
+   * task that was cancelled. Production callers wire this to
+   * `TaskRunner.killActiveExecution`; the orchestrator-only fallback
+   * omits it (the orchestrator state machine still transitions the
+   * tasks, but the in-flight process keeps running until it self-exits).
+   */
+  killActiveExecution?: (taskId: string) => void | Promise<void>;
+}
+
+/**
+ * Single cancel-in-flight implementation shared by the orchestrator-only
+ * fallback and the production `buildInvalidationDeps`. Tolerates
+ * already-terminal targets (the rest of the pipeline still runs) and
+ * fans out the optional executor-kill hook for every running task that
+ * was cancelled.
+ */
+export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
+  return async (scope, id) => {
+    if (scope === 'none') return;
+    let result: { runningCancelled: string[] };
+    try {
+      result = scope === 'task'
+        ? deps.orchestrator.cancelTask(id)
+        : deps.orchestrator.cancelWorkflow(id);
+    } catch (e) {
+      const code = (e as { code?: string })?.code;
+      if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
+      throw e;
+    }
+    if (!deps.killActiveExecution) return;
+    for (const runningId of result.runningCancelled) {
+      await deps.killActiveExecution(runningId);
+    }
+  };
+}
+
 export function buildOrchestratorOnlyInvalidationDeps(
   orchestrator: InvalidationDepsOrchestrator,
 ): InvalidationDeps {
   return {
-    cancelInFlight: async (scope, id) => {
-      if (scope === 'none') return;
-      try {
-        if (scope === 'task') orchestrator.cancelTask(id);
-        else orchestrator.cancelWorkflow(id);
-      } catch (e) {
-        // Already-terminal targets have nothing to cancel; the rest
-        // of the pipeline still runs.
-        const code = (e as { code?: string })?.code;
-        if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
-        throw e;
-      }
-    },
+    cancelInFlight: buildCancelInFlight({ orchestrator }),
     retryTask: (taskId) => orchestrator.retryTask(taskId),
     recreateTask: (taskId) => orchestrator.recreateTask(taskId),
     retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2914,7 +2914,7 @@ export class Orchestrator {
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot edit merge node ${taskId}`);
 
-    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+    if (isActiveForInvalidation(task.status)) {
       this.cancelTask(taskId);
     }
 
@@ -2934,7 +2934,7 @@ export class Orchestrator {
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot edit merge node ${taskId}`);
 
-    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+    if (isActiveForInvalidation(task.status)) {
       this.cancelTask(taskId);
     }
 
@@ -2977,7 +2977,7 @@ export class Orchestrator {
       hostKey(oldRunnerKind, oldPoolMemberId) !==
       hostKey(effectiveType, newPoolMemberId);
 
-    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+    if (isActiveForInvalidation(task.status)) {
       this.cancelTask(taskId);
     }
 
@@ -3009,7 +3009,7 @@ export class Orchestrator {
       );
     }
 
-    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+    if (isActiveForInvalidation(task.status)) {
       this.cancelTask(taskId);
     }
 
@@ -3035,7 +3035,7 @@ export class Orchestrator {
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot change execution agent of merge node ${taskId}`);
 
-    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+    if (isActiveForInvalidation(task.status)) {
       this.cancelTask(taskId);
     }
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2326,11 +2326,6 @@ export class Orchestrator {
       });
     }
 
-    const retryTaskWorkflowId = this.stateGetTask(id)?.config.workflowId;
-    if (retryTaskWorkflowId) {
-      this.cascadeInvalidationToDownstream(retryTaskWorkflowId);
-    }
-
     const readyTasks = this.stateMachine.getReadyTasks();
     const isReady = readyTasks.some((t) => t.id === id);
     this.logger.info('[orchestrator] retryTask ready check', { taskId: id, ready: isReady });
@@ -2442,8 +2437,6 @@ export class Orchestrator {
       note: 'preserved completed outside invalidated subgraphs',
     });
 
-    this.cascadeInvalidationToDownstream(workflowId);
-
     const readyIds = this.stateMachine
       .getReadyTasks()
       .map((t) => t.id)
@@ -2533,11 +2526,6 @@ export class Orchestrator {
 
       this.deferredTaskIds.delete(id);
       this.clearQueuedSchedulerEntries(id, priorAttemptId);
-    }
-
-    const recreateTaskWorkflowId = task.config.workflowId;
-    if (recreateTaskWorkflowId) {
-      this.cascadeInvalidationToDownstream(recreateTaskWorkflowId);
     }
 
     const readyIds = this.stateMachine
@@ -2645,8 +2633,6 @@ export class Orchestrator {
       this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
       this.clearQueuedSchedulerEntries(task.id, priorAttemptId);
     }
-
-    this.cascadeInvalidationToDownstream(workflowId);
 
     const readyIds = this.stateMachine
       .getReadyTasks()


### PR DESCRIPTION
## Summary

Drop the Phase-0 in-primitive cross-workflow cascade calls added by #890. With #908 now routing the production CommandService through `buildInvalidationDeps`, the cascade flows through `applyInvalidation`'s `cascadeAcrossWorkflows` stage. The in-primitive calls are redundant — and worse, would fire the cascade twice for any caller that goes through CommandService.

## Architecture

### Before (Phase-0 belt-and-suspenders)

```mermaid
flowchart TD
  CS[CommandService.recreateTask] --> apply[applyInvalidation]
  apply --> stages["validateScope, cancelInFlight, applyPrimitive, cascadeAcrossWorkflows"]
  stages --> prim[orchestrator.recreateTask]
  prim --> phase0["cascadeInvalidationToDownstream<br/>(in-primitive)"]
  stages --> dep[deps.cascadeDownstream] --> ds[cascadeInvalidationToDownstream]
  phase0 -. duplicate .- ds
```

### After

```mermaid
flowchart TD
  CS[CommandService.recreateTask] --> apply[applyInvalidation]
  apply --> stages["validateScope, cancelInFlight, applyPrimitive, cascadeAcrossWorkflows"]
  stages --> prim[orchestrator.recreateTask]
  stages --> dep[deps.cascadeDownstream] --> ds[cascadeInvalidationToDownstream]
```

### Removed call sites

- `retryTask` (was line 2330-2331)
- `retryWorkflow` (was line 2445)
- `recreateTask` (was line 2539-2540)
- `recreateWorkflow` (was line 2649)

### Retained

- `forkWorkflow` (prior line 3541) keeps its in-primitive cascade. `forkWorkflow` isn't yet routed through `applyInvalidation`'s `'workflowFork'` action in production callers (separate Phase-3 refactor).

## Test Plan

- [x] `pnpm run check:types`
- [x] `cd packages/workflow-core && pnpm test` — 49 files, 1040 tests pass.
- [x] `cd packages/app && pnpm test` — 63 files, 994 tests pass.

`cross-workflow-cascade-primitives.test.ts` is rewritten to invoke `applyInvalidation(...)` with `buildOrchestratorOnlyInvalidationDeps(orchestrator)` instead of calling the primitives directly. The fork test still exercises the primitive directly to document the intentional difference. The end-to-end CommandService cascade test (`cross-workflow-cascade-command-service-e2e.test.ts` from #894) continues to assert the production-deps cascade path.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 6c8570880`
- Post-revert steps: None — restoring the Phase-0 belt-and-suspenders is safe (it just becomes redundant again).
- Data migration? No
