### PR TITLE
Route orchestrator edit primitives through MUTATION_POLICIES

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -97,6 +97,9 @@ function createMocks() {
       beginConflictResolution: vi.fn(() => ({ savedError: 'saved-error' })),
       setFixAwaitingApproval: vi.fn(),
       retryTask: vi.fn(() => [makeTask()]),
+      recreateTask: vi.fn(() => [makeTask()]),
+      retryWorkflow: vi.fn(() => [makeTask()]),
+      recreateWorkflow: vi.fn(() => [makeTask()]),
       editTaskCommand: vi.fn(() => [makeTask()]),
       editTaskPrompt: vi.fn(() => [makeTask()]),
       editTaskType: vi.fn(() => [makeTask()]),
@@ -137,6 +140,49 @@ function createMocks() {
       runSerializedForWorkflow: vi.fn(async (_workflowId: string, fn: () => unknown) => {
         await fn();
         return { ok: true, data: undefined };
+      }),
+      // Production CommandService routes through applyInvalidation which
+      // ultimately invokes orchestrator.{retry,recreate}{Task,Workflow}
+      // and (for recreateWorkflow) bumpGenerationAndRecreate which calls
+      // persistence.loadWorkflow first. Mocks below preserve the same
+      // observable behavior (orchestrator is still called, generation
+      // bump persisted, WORKFLOW_NOT_FOUND surfaced) so existing
+      // assertions keep working after the facade routes through
+      // CommandService.
+      retryTask: vi.fn(async (envelope: { payload: { taskId: string } }) => {
+        try {
+          return { ok: true, data: mocks.orchestrator.retryTask(envelope.payload.taskId) };
+        } catch (err) {
+          return { ok: false, error: { code: 'RETRY_TASK_FAILED', message: (err as Error).message } };
+        }
+      }),
+      recreateTask: vi.fn(async (envelope: { payload: { taskId: string } }) => {
+        try {
+          return { ok: true, data: mocks.orchestrator.recreateTask(envelope.payload.taskId) };
+        } catch (err) {
+          return { ok: false, error: { code: 'RECREATE_TASK_FAILED', message: (err as Error).message } };
+        }
+      }),
+      retryWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => {
+        try {
+          return { ok: true, data: mocks.orchestrator.retryWorkflow(envelope.payload.workflowId) };
+        } catch (err) {
+          return { ok: false, error: { code: 'RETRY_WORKFLOW_FAILED', message: (err as Error).message } };
+        }
+      }),
+      recreateWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => {
+        const workflowId = envelope.payload.workflowId;
+        const wf = mocks.persistence.loadWorkflow(workflowId);
+        if (!wf) {
+          return { ok: false, error: { code: 'WORKFLOW_NOT_FOUND', message: `Workflow ${workflowId} not found` } };
+        }
+        const nextGen = (wf.generation ?? 0) + 1;
+        mocks.persistence.updateWorkflow(workflowId, { generation: nextGen });
+        try {
+          return { ok: true, data: mocks.orchestrator.recreateWorkflow(workflowId) };
+        } catch (err) {
+          return { ok: false, error: { code: 'RECREATE_WORKFLOW_FAILED', message: (err as Error).message } };
+        }
       }),
     },
     taskExecutor: {

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -929,7 +929,7 @@ describe('headless delegation enforcement', () => {
 
       it('headless recreate preempts workflow before recreate mutation', async () => {
         const preemptWorkflowExecution = vi.fn(async () => ({ cancelled: [], runningCancelled: [] }));
-        mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
+        (mockDeps.commandService as any).recreateWorkflow = vi.fn(async () => ({ ok: true as const, data: [] }));
         mockDeps.persistence.updateWorkflow = vi.fn();
 
         const depsWithNoTrack: HeadlessDeps = {
@@ -941,19 +941,22 @@ describe('headless delegation enforcement', () => {
         await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
 
         expect(preemptWorkflowExecution).toHaveBeenCalledWith('wf-1');
-        expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+        expect(mockDeps.commandService.recreateWorkflow).toHaveBeenCalled();
       });
 
       it('headless recreate dispatches runnable tasks before waiting for completion', async () => {
         let taskStatus: 'running' | 'completed' = 'running';
-        mockDeps.orchestrator.recreateWorkflow = vi.fn(() => [
-          {
-            id: 'wf-1/task-1',
-            status: 'running',
-            config: { workflowId: 'wf-1' },
-            execution: {},
-          } as any,
-        ]);
+        (mockDeps.commandService as any).recreateWorkflow = vi.fn(async () => ({
+          ok: true as const,
+          data: [
+            {
+              id: 'wf-1/task-1',
+              status: 'running',
+              config: { workflowId: 'wf-1' },
+              execution: {},
+            } as any,
+          ],
+        }));
         mockDeps.orchestrator.startExecution = vi.fn(() => []);
         mockDeps.persistence.updateWorkflow = vi.fn();
         mockDeps.persistence.listWorkflows = vi.fn(() => [{
@@ -987,7 +990,7 @@ describe('headless delegation enforcement', () => {
         await runHeadless(['recreate', 'wf-1'], mockDeps);
 
         expect(executeTasksSpy).toHaveBeenCalledTimes(1);
-        expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+        expect((mockDeps.commandService as any).recreateWorkflow).toHaveBeenCalled();
 
         executeTasksSpy.mockRestore();
       });
@@ -1221,9 +1224,9 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `recreate <wfId>` routes to orchestrator.recreateWorkflow — NOT recreateWorkflowFromFreshBase (no upstream pool refresh)', async () => {
+        it('headless `recreate <wfId>` routes to commandService.recreateWorkflow — NOT recreateWorkflowFromFreshBase (no upstream pool refresh)', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedRebaseHappyPath();
-          mockDeps.orchestrator.recreateWorkflow = vi.fn(() => []);
+          (mockDeps.commandService as any).recreateWorkflow = vi.fn(async () => ({ ok: true as const, data: [] }));
 
           const depsWithNoTrack: HeadlessDeps = {
             ...mockDeps,
@@ -1233,8 +1236,7 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
 
-          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
-          // Distinction guard — recreate must NOT refresh the upstream pool.
+          expect((mockDeps.commandService as any).recreateWorkflow).toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           expect(preparePoolSpy).not.toHaveBeenCalled();
 
@@ -1364,7 +1366,7 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `recreate-task <id>` routes to orchestrator.recreateTask (only)', async () => {
+        it('headless `recreate-task <id>` routes to commandService.recreateTask (only)', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedHappyPath();
           const depsWithNoTrack: HeadlessDeps = {
             ...mockDeps,
@@ -1374,9 +1376,10 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['recreate-task', 'wf-1/task-1'], depsWithNoTrack);
 
-          expect(mockDeps.orchestrator.recreateTask).toHaveBeenCalledWith('wf-1/task-1');
+          expect((mockDeps.commandService as any).recreateTask).toHaveBeenCalled();
           expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
           expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
+          expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
@@ -1402,7 +1405,7 @@ describe('headless delegation enforcement', () => {
           preparePoolSpy.mockRestore();
         });
 
-        it('headless `recreate <wfId>` routes to orchestrator.recreateWorkflow (only)', async () => {
+        it('headless `recreate <wfId>` routes to commandService.recreateWorkflow (only)', async () => {
           const { preemptWorkflowExecution, preparePoolSpy } = seedHappyPath();
           const depsWithNoTrack: HeadlessDeps = {
             ...mockDeps,
@@ -1412,10 +1415,11 @@ describe('headless delegation enforcement', () => {
 
           await runHeadless(['recreate', 'wf-1'], depsWithNoTrack);
 
-          expect(mockDeps.orchestrator.recreateWorkflow).toHaveBeenCalledWith('wf-1');
+          expect((mockDeps.commandService as any).recreateWorkflow).toHaveBeenCalled();
           expect(mockDeps.commandService.retryTask).not.toHaveBeenCalled();
           expect(mockDeps.commandService.retryWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateTask).not.toHaveBeenCalled();
+          expect(mockDeps.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
           expect(mockDeps.orchestrator.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
           expect((mockDeps.orchestrator as any).restartTask).not.toHaveBeenCalled();
           preparePoolSpy.mockRestore();

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1807,13 +1807,16 @@ async function headlessRecreateWorkflow(workflowId: string, deps: HeadlessDeps):
     context: 'headless.recreate-workflow',
     mutationTiming: deps.mutationTiming,
   });
-  const started = deps.mutationTiming
+  const recreateWfEnvelope = makeEnvelope('recreate-workflow', 'headless', 'workflow', { workflowId });
+  const recreateWfResult = deps.mutationTiming
     ? await deps.mutationTiming.span(
-      'headless.recreate-workflow.sharedRecreateWorkflow',
+      'headless.recreate-workflow.commandService.recreateWorkflow',
       undefined,
-      async () => sharedRecreateWorkflow(workflowId, { persistence: deps.persistence, orchestrator: deps.orchestrator }),
+      () => deps.commandService.recreateWorkflow(recreateWfEnvelope),
     )
-    : sharedRecreateWorkflow(workflowId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
+    : await deps.commandService.recreateWorkflow(recreateWfEnvelope);
+  if (!recreateWfResult.ok) throw new Error(recreateWfResult.error.message);
+  const started = recreateWfResult.data;
   const runnable = started.filter(isDispatchableLaunch);
   if (runnable.length > 0) {
     const te = createHeadlessExecutor(deps);
@@ -1871,13 +1874,16 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
     await preemptTaskSubgraph(taskId, deps);
   }
 
-  const started = deps.mutationTiming
+  const recreateTaskEnvelope = makeEnvelope('recreate-task', 'headless', 'task', { taskId });
+  const recreateTaskResult = deps.mutationTiming
     ? await deps.mutationTiming.span(
-      'headless.recreate-task.sharedRecreateTask',
+      'headless.recreate-task.commandService.recreateTask',
       { taskId },
-      async () => sharedRecreateTask(taskId, { persistence: deps.persistence, orchestrator: deps.orchestrator }),
+      () => deps.commandService.recreateTask(recreateTaskEnvelope),
     )
-    : sharedRecreateTask(taskId, { persistence: deps.persistence, orchestrator: deps.orchestrator });
+    : await deps.commandService.recreateTask(recreateTaskEnvelope);
+  if (!recreateTaskResult.ok) throw new Error(recreateTaskResult.error.message);
+  const started = recreateTaskResult.data;
   const runnable = started.filter(isDispatchableLaunch);
   const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
   process.stdout.write(`Recreate task "${taskId}" (+ downstream) — ${runnable.length} task(s) to execute (pool fetch skipped)\n`);

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3417,13 +3417,16 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.recreate-workflow',
           mutationTiming: activeMutationContext?.mutationTiming,
         });
-        const started = activeMutationContext?.mutationTiming
+        const recreateWfEnvelope = makeEnvelope('recreate-workflow', 'ui', 'workflow', { workflowId });
+        const recreateWfResult = activeMutationContext?.mutationTiming
           ? await activeMutationContext.mutationTiming.span(
-            'main.ipc.recreate-workflow.sharedRecreateWorkflow',
+            'main.ipc.recreate-workflow.commandService.recreateWorkflow',
             undefined,
-            async () => sharedRecreateWorkflow(workflowId, { persistence, orchestrator }),
+            () => commandService.recreateWorkflow(recreateWfEnvelope),
           )
-          : sharedRecreateWorkflow(workflowId, { persistence, orchestrator });
+          : await commandService.recreateWorkflow(recreateWfEnvelope);
+        if (!recreateWfResult.ok) throw new Error(recreateWfResult.error.message);
+        const started = recreateWfResult.data;
         remoteFetchForPool.enabled = false;
         try {
           await dispatchStartedTasksWithGlobalTopup({
@@ -3462,13 +3465,16 @@ function createEmbeddedTerminalBackendFromConfig(
         } else {
           await preemptTaskSubgraph(taskId);
         }
-        const started = activeMutationContext?.mutationTiming
+        const recreateTaskEnvelope = makeEnvelope('recreate-task', 'ui', 'task', { taskId });
+        const recreateTaskResult = activeMutationContext?.mutationTiming
           ? await activeMutationContext.mutationTiming.span(
-            'main.ipc.recreate-task.sharedRecreateTask',
+            'main.ipc.recreate-task.commandService.recreateTask',
             { taskId },
-            async () => sharedRecreateTask(taskId, { persistence, orchestrator }),
+            () => commandService.recreateTask(recreateTaskEnvelope),
           )
-          : sharedRecreateTask(taskId, { persistence, orchestrator });
+          : await commandService.recreateTask(recreateTaskEnvelope);
+        if (!recreateTaskResult.ok) throw new Error(recreateTaskResult.error.message);
+        const started = recreateTaskResult.data;
         remoteFetchForPool.enabled = false;
         try {
           await dispatchStartedTasksWithGlobalTopup({

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -14,7 +14,11 @@ import type {
   InvalidationScope,
   TaskState,
 } from '@invoker/workflow-core';
-import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
+import {
+  OrchestratorError,
+  OrchestratorErrorCode,
+  buildCancelInFlight as buildCoreCancelInFlight,
+} from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner, ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
 import { normalizeMergeModeForPersistence } from './merge-mode.js';
@@ -520,18 +524,14 @@ export interface BuildCancelInFlightDeps {
 }
 
 export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
-  return async (scope: InvalidationScope, id: string): Promise<void> => {
-    if (scope === 'none') return;
-    const result =
-      scope === 'task'
-        ? deps.orchestrator.cancelTask(id)
-        : deps.orchestrator.cancelWorkflow(id);
-    const taskExecutor = resolveTaskExecutor(deps.taskExecutor);
-    if (!taskExecutor) return;
-    for (const runningId of result.runningCancelled) {
-      await taskExecutor.killActiveExecution(runningId);
-    }
-  };
+  return buildCoreCancelInFlight({
+    orchestrator: deps.orchestrator,
+    killActiveExecution: async (id) => {
+      const taskExecutor = resolveTaskExecutor(deps.taskExecutor);
+      if (!taskExecutor) return;
+      await taskExecutor.killActiveExecution(id);
+    },
+  });
 }
 
 export type BuildInvalidationDepsArgs = Omit<

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -16,6 +16,8 @@
  */
 
 import type { Logger } from '@invoker/contracts';
+import { makeEnvelope } from '@invoker/contracts';
+import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type { CommandService, Orchestrator, ExternalGatePolicyUpdate, TaskState } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner } from '@invoker/execution-engine';
@@ -151,15 +153,25 @@ export class WorkflowMutationFacade {
   }
 
   async retryTask(taskId: string): Promise<MutationResult> {
-    const started = sharedRetryTask(taskId, { orchestrator: this.deps.orchestrator });
+    const started = await this.runViaCommandService(
+      'task',
+      taskId,
+      (cs) => cs.retryTask(makeEnvelope('facade.retry-task', 'surface', 'task', { taskId })),
+      () => sharedRetryTask(taskId, { orchestrator: this.deps.orchestrator }),
+    );
     return this.finalizeWithTopup(started, 'facade.retry-task', { scopedTaskIds: [taskId] });
   }
 
   async recreateTask(taskId: string): Promise<MutationResult> {
-    const started = sharedRecreateTask(taskId, {
-      orchestrator: this.deps.orchestrator,
-      persistence: this.deps.persistence,
-    });
+    const started = await this.runViaCommandService(
+      'task',
+      taskId,
+      (cs) => cs.recreateTask(makeEnvelope('facade.recreate-task', 'surface', 'task', { taskId })),
+      () => sharedRecreateTask(taskId, {
+        orchestrator: this.deps.orchestrator,
+        persistence: this.deps.persistence,
+      }),
+    );
     return this.finalizeWithTopup(started, 'facade.recreate-task', { scopedTaskIds: [taskId] });
   }
 
@@ -251,18 +263,26 @@ export class WorkflowMutationFacade {
   // ── Workflow-scoped mutations ────────────────────────────
 
   async retryWorkflow(workflowId: string): Promise<MutationResult> {
-    const started = sharedRetryWorkflow(workflowId, {
-      orchestrator: this.deps.orchestrator,
-    });
+    const started = await this.runViaCommandService(
+      'workflow',
+      workflowId,
+      (cs) => cs.retryWorkflow(makeEnvelope('facade.retry-workflow', 'surface', 'workflow', { workflowId })),
+      () => sharedRetryWorkflow(workflowId, { orchestrator: this.deps.orchestrator }),
+    );
     return this.finalizeWithTopup(started, 'facade.retry-workflow', { scopedWorkflowId: workflowId });
   }
 
   async recreateWorkflow(workflowId: string): Promise<MutationResult> {
-    const started = sharedRecreateWorkflow(workflowId, {
-      logger: this.deps.logger,
-      persistence: this.deps.persistence,
-      orchestrator: this.deps.orchestrator,
-    });
+    const started = await this.runViaCommandService(
+      'workflow',
+      workflowId,
+      (cs) => cs.recreateWorkflow(makeEnvelope('facade.recreate-workflow', 'surface', 'workflow', { workflowId })),
+      () => sharedRecreateWorkflow(workflowId, {
+        logger: this.deps.logger,
+        persistence: this.deps.persistence,
+        orchestrator: this.deps.orchestrator,
+      }),
+    );
     return this.finalizeWithTopup(started, 'facade.recreate-workflow', { scopedWorkflowId: workflowId });
   }
 
@@ -461,6 +481,35 @@ export class WorkflowMutationFacade {
   ): Promise<MutationResult> {
     const { runnable, topup } = await this.dispatchWithTopup(started, context, scope);
     return { started, runnable, topup };
+  }
+
+  /**
+   * Route through the production CommandService when available so the
+   * mutation gets mutex serialization, executor kill on cancel-in-flight,
+   * and the cross-workflow cascade. Falls back to the shared action when
+   * no CommandService is wired (legacy entrypoints / tests).
+   */
+  private async runViaCommandService(
+    _scope: 'task' | 'workflow',
+    _id: string,
+    routed: (cs: CommandService) => Promise<{ ok: true; data: TaskState[] } | { ok: false; error: { code: string; message: string } }>,
+    fallback: () => TaskState[] | Promise<TaskState[]>,
+  ): Promise<TaskState[]> {
+    if (this.deps.commandService) {
+      const result = await routed(this.deps.commandService);
+      if (!result.ok) {
+        // Surface OrchestratorError when CommandService bubbles a known
+        // domain code (e.g. WORKFLOW_NOT_FOUND -> HTTP 404). Plain Error
+        // is the fallback for unmapped codes.
+        const known = (Object.values(OrchestratorErrorCode) as string[]).includes(result.error.code);
+        if (known) {
+          throw new OrchestratorError(result.error.code as OrchestratorErrorCode, result.error.message);
+        }
+        throw new Error(result.error.message);
+      }
+      return result.data;
+    }
+    return Promise.resolve(fallback());
   }
 
   private async topupOnly(context: string): Promise<TaskState[]> {

--- a/packages/workflow-core/src/__tests__/cross-workflow-cascade-primitives.test.ts
+++ b/packages/workflow-core/src/__tests__/cross-workflow-cascade-primitives.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Orchestrator } from '../orchestrator.js';
 import {
+  applyInvalidation,
+  buildOrchestratorOnlyInvalidationDeps,
+} from '../invalidation-policy.js';
+import {
   InMemoryPersistence,
   makeOrchestrator,
   makeResponse,
@@ -8,7 +12,7 @@ import {
   type ChainContext,
 } from './helpers/cross-workflow-cascade-helpers.js';
 
-describe('cross-workflow cascade — primitives invoked directly (no applyInvalidation)', () => {
+describe('cross-workflow cascade — applyInvalidation pipeline', () => {
   let persistence: InMemoryPersistence;
   let orchestrator: Orchestrator;
 
@@ -16,6 +20,10 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
     persistence = new InMemoryPersistence();
     orchestrator = makeOrchestrator(persistence);
   });
+
+  function deps() {
+    return buildOrchestratorOnlyInvalidationDeps(orchestrator);
+  }
 
   function expectDownstreamPending(ctx: ChainContext, label: string): void {
     for (const id of [
@@ -31,10 +39,10 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
     }
   }
 
-  it('orchestrator.recreateWorkflow(upstream) cascades to downstream', () => {
+  it('applyInvalidation(recreateWorkflow, upstream) cascades to downstream', async () => {
     const ctx = setupChain(orchestrator);
 
-    orchestrator.recreateWorkflow(ctx.upstreamWfId);
+    await applyInvalidation('workflow', 'recreateWorkflow', ctx.upstreamWfId, deps());
 
     expectDownstreamPending(ctx, 'recreateWorkflow');
 
@@ -51,7 +59,7 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
     expect(upstreamMarkers.length).toBeGreaterThan(0);
   });
 
-  it('orchestrator.retryWorkflow(upstream) cascades to downstream', () => {
+  it('applyInvalidation(retryWorkflow, upstream) cascades to downstream', async () => {
     const ctx = setupChain(orchestrator);
 
     orchestrator.handleWorkerResponse(makeResponse({
@@ -60,20 +68,20 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
       outputs: { exitCode: 1, error: 'boom' },
     }));
 
-    orchestrator.retryWorkflow(ctx.upstreamWfId);
+    await applyInvalidation('workflow', 'retryWorkflow', ctx.upstreamWfId, deps());
 
     expectDownstreamPending(ctx, 'retryWorkflow');
   });
 
-  it('orchestrator.recreateTask(upstream task) cascades to downstream', () => {
+  it('applyInvalidation(recreateTask, upstream task) cascades to downstream', async () => {
     const ctx = setupChain(orchestrator);
 
-    orchestrator.recreateTask(ctx.upstreamTaskId);
+    await applyInvalidation('task', 'recreateTask', ctx.upstreamTaskId, deps());
 
     expectDownstreamPending(ctx, 'recreateTask');
   });
 
-  it('orchestrator.retryTask(upstream merge gate) cascades to downstream', () => {
+  it('applyInvalidation(retryTask, upstream merge gate) cascades to downstream', async () => {
     const ctx = setupChain(orchestrator);
 
     orchestrator.handleWorkerResponse(makeResponse({
@@ -82,22 +90,31 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
       outputs: { exitCode: 1, error: 'boom' },
     }));
 
-    orchestrator.retryTask(ctx.upstreamMergeId);
+    await applyInvalidation('task', 'retryTask', ctx.upstreamMergeId, deps());
 
     expectDownstreamPending(ctx, 'retryTask');
   });
 
-  it('orchestrator.recreateWorkflowFromFreshBase(upstream) cascades to downstream', async () => {
+  it('applyInvalidation(recreateWorkflowFromFreshBase, upstream) cascades to downstream', async () => {
     const ctx = setupChain(orchestrator);
 
-    await orchestrator.recreateWorkflowFromFreshBase(ctx.upstreamWfId, {
-      refreshBase: async () => ({ commit: 'fresh-sha' }),
-    });
+    await applyInvalidation(
+      'workflow',
+      'recreateWorkflowFromFreshBase',
+      ctx.upstreamWfId,
+      {
+        ...deps(),
+        recreateWorkflowFromFreshBase: (id) =>
+          orchestrator.recreateWorkflowFromFreshBase(id, {
+            refreshBase: async () => ({ commit: 'fresh-sha' }),
+          }),
+      },
+    );
 
     expectDownstreamPending(ctx, 'recreateWorkflowFromFreshBase');
   });
 
-  it('orchestrator.forkWorkflow(upstream) cascades to downstream', () => {
+  it('forkWorkflow(upstream) cascades to downstream (still primitive — fork keeps Phase-0 cascade)', () => {
     const ctx = setupChain(orchestrator);
 
     orchestrator.forkWorkflow(ctx.upstreamWfId, { autoStart: false });
@@ -105,8 +122,7 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
     expectDownstreamPending(ctx, 'forkWorkflow');
   });
 
-  it('cascade is transitive when invoked directly: A → B → C, primitives only', () => {
-    // Workflow A
+  it('cascade is transitive: A → B → C via applyInvalidation', async () => {
     orchestrator.loadPlan({
       name: 'wf-a',
       baseBranch: 'master',
@@ -157,12 +173,12 @@ describe('cross-workflow cascade — primitives invoked directly (no applyInvali
 
     expect(orchestrator.getTask(cTaskId)!.status).toBe('running');
 
-    orchestrator.recreateWorkflow(aWfId);
+    await applyInvalidation('workflow', 'recreateWorkflow', aWfId, deps());
 
     for (const id of [bTaskId, bMergeId, cTaskId, cMergeId]) {
       expect(
         orchestrator.getTask(id)!.status,
-        `${id} should be pending after transitive primitive-only cascade`,
+        `${id} should be pending after transitive applyInvalidation cascade`,
       ).toBe('pending');
     }
   });

--- a/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { createTaskState, type TaskState } from '@invoker/workflow-graph';
 import {
-  INVALIDATION_POLICIES,
   planInvalidation,
   withSchedulerEnqueueCandidates,
 } from '../invalidation-plan.js';
+import { ACTION_SPECS } from '../invalidation-policy.js';
 
 function task(
   id: string,
@@ -23,28 +23,23 @@ function task(
 
 describe('InvalidationPlan policy registry', () => {
   it('registers invalidating recreate/retry and schedule-only policies', () => {
-    expect(INVALIDATION_POLICIES.recreateWorkflow).toMatchObject({
-      action: 'recreateWorkflow',
+    expect(ACTION_SPECS.recreateWorkflow).toMatchObject({
       scope: 'workflow',
       mode: 'recreate',
     });
-    expect(INVALIDATION_POLICIES.recreateTask).toMatchObject({
-      action: 'recreateTask',
+    expect(ACTION_SPECS.recreateTask).toMatchObject({
       scope: 'task',
       mode: 'recreate',
     });
-    expect(INVALIDATION_POLICIES.retryWorkflow).toMatchObject({
-      action: 'retryWorkflow',
+    expect(ACTION_SPECS.retryWorkflow).toMatchObject({
       scope: 'workflow',
       mode: 'retry',
     });
-    expect(INVALIDATION_POLICIES.retryTask).toMatchObject({
-      action: 'retryTask',
+    expect(ACTION_SPECS.retryTask).toMatchObject({
       scope: 'task',
       mode: 'retry',
     });
-    expect(INVALIDATION_POLICIES.scheduleOnly).toMatchObject({
-      action: 'scheduleOnly',
+    expect(ACTION_SPECS.scheduleOnly).toMatchObject({
       scope: 'task',
       mode: 'scheduleOnly',
     });

--- a/packages/workflow-core/src/invalidation-plan.ts
+++ b/packages/workflow-core/src/invalidation-plan.ts
@@ -1,7 +1,13 @@
-import { getTransitiveDependents, type TaskState } from '@invoker/workflow-graph';
-import type { InvalidationAction, InvalidationScope } from './invalidation-policy.js';
+import type { TaskState } from '@invoker/workflow-graph';
+import {
+  ACTION_SPECS,
+  type InvalidationAction,
+  type InvalidationMode,
+  type InvalidationPlanningContext,
+  type InvalidationScope,
+} from './invalidation-policy.js';
 
-export type InvalidationMode = 'retry' | 'recreate' | 'scheduleOnly';
+export type { InvalidationMode, InvalidationPlanningContext } from './invalidation-policy.js';
 
 export interface SchedulerEnqueueCandidate {
   taskId: string;
@@ -23,36 +29,13 @@ export interface InvalidationPlan {
   lockPlan: InvalidationLockPlan;
 }
 
-export interface InvalidationPlanningContext {
-  targetId: string;
-  tasks: readonly TaskState[];
-  retryStatuses?: ReadonlySet<TaskState['status']>;
-}
-
 export interface InvalidationPlanningRequest extends InvalidationPlanningContext {
   action: InvalidationAction;
   reason?: string;
 }
 
-interface InvalidationPolicy {
-  action: InvalidationAction;
-  scope: InvalidationScope;
-  mode: InvalidationMode;
-  reason: string;
-  selectAffectedTasks: (context: InvalidationPlanningContext) => TaskState[];
-  selectInitialEnqueueCandidates?: (context: InvalidationPlanningContext, affectedTasks: readonly TaskState[]) => string[];
-}
-
-function definePolicy(policy: InvalidationPolicy): InvalidationPolicy {
-  return Object.freeze(policy);
-}
-
 function sorted(values: Iterable<string>): string[] {
   return Array.from(new Set(values)).sort();
-}
-
-function taskMap(tasks: readonly TaskState[]): Map<string, TaskState> {
-  return new Map(tasks.map((task) => [task.id, task]));
 }
 
 function workflowIdsForTasks(tasks: Iterable<TaskState>): string[] {
@@ -63,128 +46,24 @@ function workflowIdsForTasks(tasks: Iterable<TaskState>): string[] {
   );
 }
 
-function descendantsOf(
-  taskId: string,
-  tasksById: ReadonlyMap<string, TaskState>,
-  stop?: (task: TaskState) => boolean,
-): TaskState[] {
-  return getTransitiveDependents(taskId, tasksById, stop ?? (() => false))
-    .map((id) => tasksById.get(id))
-    .filter((task): task is TaskState => !!task);
-}
-
-function taskAndDescendants(
-  taskId: string,
-  tasks: readonly TaskState[],
-  stop?: (task: TaskState) => boolean,
-): TaskState[] {
-  const byId = taskMap(tasks);
-  const root = byId.get(taskId);
-  if (!root) return [];
-  return [root, ...descendantsOf(taskId, byId, stop)];
-}
-
-function retryStop(task: TaskState): boolean {
-  return task.status === 'completed' || task.status === 'stale';
-}
-
-function defaultRetryStatuses(): ReadonlySet<TaskState['status']> {
-  return new Set<TaskState['status']>([
-    'failed',
-    'needs_input',
-    'blocked',
-    'stale',
-    'fixing_with_ai',
-    'awaiting_approval',
-    'review_ready',
-  ]);
-}
-
-function makePlan(policy: InvalidationPolicy, context: InvalidationPlanningContext, reason?: string): InvalidationPlan {
-  const affectedTasks = policy.selectAffectedTasks(context);
+export function planInvalidation(request: InvalidationPlanningRequest): InvalidationPlan {
+  const spec = ACTION_SPECS[request.action];
+  if (!spec.selectAffectedTasks || !spec.mode) {
+    throw new Error(`No invalidation policy registered for action "${request.action}"`);
+  }
+  const affectedTasks = spec.selectAffectedTasks(request);
   const affectedWorkflowIds = workflowIdsForTasks(affectedTasks);
-  const enqueueTaskIds = policy.selectInitialEnqueueCandidates?.(context, affectedTasks) ?? [];
+  const enqueueTaskIds = spec.selectInitialEnqueueCandidates?.(request, affectedTasks) ?? [];
   return {
-    reason: reason ?? policy.reason,
-    action: policy.action,
-    scope: policy.scope,
-    mode: policy.mode,
+    reason: request.reason ?? spec.reason ?? request.action,
+    action: request.action,
+    scope: spec.scope,
+    mode: spec.mode,
     affectedWorkflowIds,
     affectedTaskIds: sorted(affectedTasks.map((task) => task.id)),
     schedulerEnqueueCandidates: sorted(enqueueTaskIds).map((taskId) => ({ taskId })),
     lockPlan: { workflowIds: affectedWorkflowIds },
   };
-}
-
-export const INVALIDATION_POLICIES: Readonly<Partial<Record<InvalidationAction, InvalidationPolicy>>> = Object.freeze({
-  recreateWorkflow: definePolicy({
-    action: 'recreateWorkflow',
-    scope: 'workflow',
-    mode: 'recreate',
-    reason: 'workflow.recreate',
-    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
-  }),
-  recreateWorkflowFromFreshBase: definePolicy({
-    action: 'recreateWorkflowFromFreshBase',
-    scope: 'workflow',
-    mode: 'recreate',
-    reason: 'workflow.recreateFromFreshBase',
-    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
-  }),
-  recreateTask: definePolicy({
-    action: 'recreateTask',
-    scope: 'task',
-    mode: 'recreate',
-    reason: 'task.recreate',
-    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
-  }),
-  retryTask: definePolicy({
-    action: 'retryTask',
-    scope: 'task',
-    mode: 'retry',
-    reason: 'task.retry',
-    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks, retryStop),
-  }),
-  retryWorkflow: definePolicy({
-    action: 'retryWorkflow',
-    scope: 'workflow',
-    mode: 'retry',
-    reason: 'workflow.retry',
-    selectAffectedTasks: ({ targetId, tasks, retryStatuses }) => {
-      const statuses = retryStatuses ?? defaultRetryStatuses();
-      const byId = taskMap(tasks);
-      const affectedIds = new Set<string>();
-      for (const task of tasks) {
-        if (task.config.workflowId !== targetId || !statuses.has(task.status)) continue;
-        affectedIds.add(task.id);
-        for (const descendant of descendantsOf(task.id, byId, retryStop)) {
-          affectedIds.add(descendant.id);
-        }
-      }
-      return Array.from(affectedIds)
-        .map((id) => byId.get(id))
-        .filter((task): task is TaskState => !!task);
-    },
-  }),
-  scheduleOnly: definePolicy({
-    action: 'scheduleOnly',
-    scope: 'task',
-    mode: 'scheduleOnly',
-    reason: 'externalGatePolicy',
-    selectAffectedTasks: ({ targetId, tasks }) => {
-      const task = tasks.find((item) => item.id === targetId);
-      return task ? [task] : [];
-    },
-    selectInitialEnqueueCandidates: (_context, affectedTasks) => affectedTasks.map((task) => task.id),
-  }),
-});
-
-export function planInvalidation(request: InvalidationPlanningRequest): InvalidationPlan {
-  const policy = INVALIDATION_POLICIES[request.action];
-  if (!policy) {
-    throw new Error(`No invalidation policy registered for action "${request.action}"`);
-  }
-  return makePlan(policy, request, request.reason);
 }
 
 export function withSchedulerEnqueueCandidates(

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -1,5 +1,5 @@
 
-import type { TaskState } from '@invoker/workflow-graph';
+import { getTransitiveDependents, type TaskState } from '@invoker/workflow-graph';
 export type InvalidationAction =
   | 'none'
   | 'scheduleOnly'
@@ -113,6 +113,14 @@ export type InvalidationStage =
   | 'applyPrimitive'
   | 'cascadeAcrossWorkflows';
 
+export type InvalidationMode = 'retry' | 'recreate' | 'scheduleOnly';
+
+export interface InvalidationPlanningContext {
+  targetId: string;
+  tasks: readonly TaskState[];
+  retryStatuses?: ReadonlySet<TaskState['status']>;
+}
+
 export interface ActionSpec {
   /** Required `scope` for this action. */
   readonly scope: InvalidationScope;
@@ -125,6 +133,19 @@ export interface ActionSpec {
    * in `invalidation-policy.test.ts`.
    */
   readonly cascadesAcrossWorkflows: boolean;
+  /**
+   * Planning fields used by `planInvalidation` (in `invalidation-plan.ts`).
+   * Set on actions with planning support; absent for `'none'`,
+   * `'fixApprove'`, `'fixReject'`, `'workflowFork'`. `planInvalidation`
+   * throws when called with an action that lacks `selectAffectedTasks`.
+   */
+  readonly mode?: InvalidationMode;
+  readonly reason?: string;
+  readonly selectAffectedTasks?: (context: InvalidationPlanningContext) => TaskState[];
+  readonly selectInitialEnqueueCandidates?: (
+    context: InvalidationPlanningContext,
+    affectedTasks: readonly TaskState[],
+  ) => string[];
 }
 
 const NON_INVALIDATING_TASK_STAGES: readonly InvalidationStage[] = [
@@ -139,17 +160,136 @@ const INVALIDATING_STAGES: readonly InvalidationStage[] = [
   'cascadeAcrossWorkflows',
 ];
 
+// ── Planning helpers (used by `selectAffectedTasks` callbacks below) ──
+
+function taskMap(tasks: readonly TaskState[]): Map<string, TaskState> {
+  return new Map(tasks.map((task) => [task.id, task]));
+}
+
+function descendantsOf(
+  taskId: string,
+  tasksById: ReadonlyMap<string, TaskState>,
+  stop?: (task: TaskState) => boolean,
+): TaskState[] {
+  return getTransitiveDependents(taskId, tasksById, stop ?? (() => false))
+    .map((id) => tasksById.get(id))
+    .filter((task): task is TaskState => !!task);
+}
+
+function taskAndDescendants(
+  taskId: string,
+  tasks: readonly TaskState[],
+  stop?: (task: TaskState) => boolean,
+): TaskState[] {
+  const byId = taskMap(tasks);
+  const root = byId.get(taskId);
+  if (!root) return [];
+  return [root, ...descendantsOf(taskId, byId, stop)];
+}
+
+function retryStop(task: TaskState): boolean {
+  return task.status === 'completed' || task.status === 'stale';
+}
+
+function defaultRetryStatuses(): ReadonlySet<TaskState['status']> {
+  return new Set<TaskState['status']>([
+    'failed',
+    'needs_input',
+    'blocked',
+    'stale',
+    'fixing_with_ai',
+    'awaiting_approval',
+    'review_ready',
+  ]);
+}
+
 export const ACTION_SPECS: Readonly<Record<InvalidationAction, ActionSpec>> = Object.freeze({
-  none:                          { scope: 'none',     stages: ['validateScope'] as const, cascadesAcrossWorkflows: false },
-  scheduleOnly:                  { scope: 'task',     stages: NON_INVALIDATING_TASK_STAGES, cascadesAcrossWorkflows: false },
-  fixApprove:                    { scope: 'task',     stages: NON_INVALIDATING_TASK_STAGES, cascadesAcrossWorkflows: false },
-  fixReject:                     { scope: 'task',     stages: NON_INVALIDATING_TASK_STAGES, cascadesAcrossWorkflows: false },
-  retryTask:                     { scope: 'task',     stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
-  recreateTask:                  { scope: 'task',     stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
-  retryWorkflow:                 { scope: 'workflow', stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
-  recreateWorkflow:              { scope: 'workflow', stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
-  recreateWorkflowFromFreshBase: { scope: 'workflow', stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
-  workflowFork:                  { scope: 'workflow', stages: INVALIDATING_STAGES,         cascadesAcrossWorkflows: true  },
+  none: {
+    scope: 'none',
+    stages: ['validateScope'] as const,
+    cascadesAcrossWorkflows: false,
+  },
+  scheduleOnly: {
+    scope: 'task',
+    stages: NON_INVALIDATING_TASK_STAGES,
+    cascadesAcrossWorkflows: false,
+    mode: 'scheduleOnly',
+    reason: 'externalGatePolicy',
+    selectAffectedTasks: ({ targetId, tasks }) => {
+      const task = tasks.find((item) => item.id === targetId);
+      return task ? [task] : [];
+    },
+    selectInitialEnqueueCandidates: (_context, affectedTasks) => affectedTasks.map((task) => task.id),
+  },
+  fixApprove: {
+    scope: 'task',
+    stages: NON_INVALIDATING_TASK_STAGES,
+    cascadesAcrossWorkflows: false,
+  },
+  fixReject: {
+    scope: 'task',
+    stages: NON_INVALIDATING_TASK_STAGES,
+    cascadesAcrossWorkflows: false,
+  },
+  retryTask: {
+    scope: 'task',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'retry',
+    reason: 'task.retry',
+    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks, retryStop),
+  },
+  recreateTask: {
+    scope: 'task',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'task.recreate',
+    selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
+  },
+  retryWorkflow: {
+    scope: 'workflow',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'retry',
+    reason: 'workflow.retry',
+    selectAffectedTasks: ({ targetId, tasks, retryStatuses }) => {
+      const statuses = retryStatuses ?? defaultRetryStatuses();
+      const byId = taskMap(tasks);
+      const affectedIds = new Set<string>();
+      for (const task of tasks) {
+        if (task.config.workflowId !== targetId || !statuses.has(task.status)) continue;
+        affectedIds.add(task.id);
+        for (const descendant of descendantsOf(task.id, byId, retryStop)) {
+          affectedIds.add(descendant.id);
+        }
+      }
+      return Array.from(affectedIds)
+        .map((id) => byId.get(id))
+        .filter((task): task is TaskState => !!task);
+    },
+  },
+  recreateWorkflow: {
+    scope: 'workflow',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'workflow.recreate',
+    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
+  },
+  recreateWorkflowFromFreshBase: {
+    scope: 'workflow',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'workflow.recreateFromFreshBase',
+    selectAffectedTasks: ({ targetId, tasks }) => tasks.filter((task) => task.config.workflowId === targetId),
+  },
+  workflowFork: {
+    scope: 'workflow',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+  },
 });
 
 interface PipelineCtx {

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -281,8 +281,8 @@ export async function applyInvalidation(
 // Structural type to avoid a circular import on the full
 // `Orchestrator` class (which imports `applyInvalidation` from here).
 export interface InvalidationDepsOrchestrator {
-  cancelTask(taskId: string): unknown;
-  cancelWorkflow(workflowId: string): unknown;
+  cancelTask(taskId: string): { runningCancelled: string[] };
+  cancelWorkflow(workflowId: string): { runningCancelled: string[] };
   retryTask(taskId: string): TaskState[];
   recreateTask(taskId: string): TaskState[];
   retryWorkflow(workflowId: string): TaskState[];
@@ -301,23 +301,50 @@ const TERMINAL_CANCEL_ERROR_CODES = new Set([
   'WORKFLOW_ALREADY_TERMINAL',
 ]);
 
+export interface BuildCancelInFlightDeps {
+  orchestrator: Pick<InvalidationDepsOrchestrator, 'cancelTask' | 'cancelWorkflow'>;
+  /**
+   * Optional hook to kill the active executor handle for each running
+   * task that was cancelled. Production callers wire this to
+   * `TaskRunner.killActiveExecution`; the orchestrator-only fallback
+   * omits it (the orchestrator state machine still transitions the
+   * tasks, but the in-flight process keeps running until it self-exits).
+   */
+  killActiveExecution?: (taskId: string) => void | Promise<void>;
+}
+
+/**
+ * Single cancel-in-flight implementation shared by the orchestrator-only
+ * fallback and the production `buildInvalidationDeps`. Tolerates
+ * already-terminal targets (the rest of the pipeline still runs) and
+ * fans out the optional executor-kill hook for every running task that
+ * was cancelled.
+ */
+export function buildCancelInFlight(deps: BuildCancelInFlightDeps): CancelInFlightFn {
+  return async (scope, id) => {
+    if (scope === 'none') return;
+    let result: { runningCancelled: string[] };
+    try {
+      result = scope === 'task'
+        ? deps.orchestrator.cancelTask(id)
+        : deps.orchestrator.cancelWorkflow(id);
+    } catch (e) {
+      const code = (e as { code?: string })?.code;
+      if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
+      throw e;
+    }
+    if (!deps.killActiveExecution) return;
+    for (const runningId of result.runningCancelled) {
+      await deps.killActiveExecution(runningId);
+    }
+  };
+}
+
 export function buildOrchestratorOnlyInvalidationDeps(
   orchestrator: InvalidationDepsOrchestrator,
 ): InvalidationDeps {
   return {
-    cancelInFlight: async (scope, id) => {
-      if (scope === 'none') return;
-      try {
-        if (scope === 'task') orchestrator.cancelTask(id);
-        else orchestrator.cancelWorkflow(id);
-      } catch (e) {
-        // Already-terminal targets have nothing to cancel; the rest
-        // of the pipeline still runs.
-        const code = (e as { code?: string })?.code;
-        if (code && TERMINAL_CANCEL_ERROR_CODES.has(code)) return;
-        throw e;
-      }
-    },
+    cancelInFlight: buildCancelInFlight({ orchestrator }),
     retryTask: (taskId) => orchestrator.retryTask(taskId),
     recreateTask: (taskId) => orchestrator.recreateTask(taskId),
     retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -79,6 +79,10 @@ import {
   type InvalidationPlan,
 } from './invalidation-plan.js';
 import {
+  MUTATION_POLICIES,
+  type InvalidationAction,
+} from './invalidation-policy.js';
+import {
   isActiveAttempt,
   isDiscardedAttempt,
   isOutcomeTerminalAttempt,
@@ -2894,6 +2898,40 @@ export class Orchestrator {
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
   }
 
+  /**
+   * Sync dispatch for an edit primitive's post-cancel reset stage.
+   *
+   * Each `editTask*` method shares the same shape: validate, optional
+   * cancel-first when the task is active, persist the new spec, then
+   * apply the post-edit invalidation primitive (`recreateTask` or
+   * `retryTask`) selected by `MUTATION_POLICIES`. Routing the final
+   * dispatch through this helper keeps the action source-of-truth in
+   * the policy table rather than hard-coded literals at each site, so
+   * a chart change (e.g. flipping `command` from `recreateTask` to
+   * `retryTask`) propagates without touching `editTask*` bodies.
+   *
+   * Sync by design: the public `editTask*` API is sync and most
+   * callers (api-server, headless, tests) consume the returned
+   * `TaskState[]` synchronously. The async `applyInvalidation`
+   * pipeline is reserved for the higher-level CommandService /
+   * facade routing where cross-workflow cascade fires.
+   */
+  private dispatchPostMutation(
+    action: InvalidationAction,
+    taskId: string,
+  ): TaskState[] {
+    switch (action) {
+      case 'recreateTask':
+        return this.recreateTask(taskId);
+      case 'retryTask':
+        return this.retryTask(taskId);
+      default:
+        throw new Error(
+          `dispatchPostMutation: unsupported action '${action}' for orchestrator edit primitives`,
+        );
+    }
+  }
+
   editTaskCommand(taskId: string, newCommand: string): TaskState[] {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
@@ -2911,7 +2949,7 @@ export class Orchestrator {
     this.persistence.logEvent?.(taskId, 'task.updated', cmdChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, cmdDelta);
 
-    return this.recreateTask(taskId);
+    return this.dispatchPostMutation(MUTATION_POLICIES.command.action, taskId);
   }
 
     editTaskPrompt(taskId: string, newPrompt: string): TaskState[] {
@@ -2931,7 +2969,7 @@ export class Orchestrator {
     this.persistence.logEvent?.(taskId, 'task.updated', promptChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, promptDelta);
 
-    return this.recreateTask(taskId);
+    return this.dispatchPostMutation(MUTATION_POLICIES.prompt.action, taskId);
   }
 
     editTaskType(taskId: string, runnerKind: string, poolMemberId?: string): TaskState[] {
@@ -2980,7 +3018,10 @@ export class Orchestrator {
     this.persistence.logEvent?.(taskId, 'task.updated', typeChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, typeDelta);
 
-    return hostChanged ? this.recreateTask(taskId) : this.retryTask(taskId);
+    const typeAction = hostChanged
+      ? MUTATION_POLICIES.poolMemberId.action
+      : MUTATION_POLICIES.runnerKind.action;
+    return this.dispatchPostMutation(typeAction, taskId);
   }
 
     editTaskPool(taskId: string, poolId: string): TaskState[] {
@@ -3012,7 +3053,7 @@ export class Orchestrator {
     this.persistence.logEvent?.(taskId, 'task.updated', poolChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, poolDelta);
 
-    return this.recreateTask(taskId);
+    return this.dispatchPostMutation(MUTATION_POLICIES.poolMemberId.action, taskId);
   }
 
     editTaskAgent(taskId: string, agentName: string): TaskState[] {
@@ -3032,7 +3073,7 @@ export class Orchestrator {
     this.persistence.logEvent?.(taskId, 'task.updated', agentChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, agentDelta);
 
-    return this.recreateTask(taskId);
+    return this.dispatchPostMutation(MUTATION_POLICIES.executionAgent.action, taskId);
   }
 
   /**
@@ -3164,14 +3205,12 @@ export class Orchestrator {
     // attempt picks up the new policy when restartTask reschedules it.
     this.persistence.updateWorkflow?.(workflowId, { mergeMode });
 
-    // Step 9 retry-class reset: restartTask is today's `retryTask`
-    // compatibility wire (`buildInvalidationDeps` →
-    // `orchestrator.restartTask`). It resets the merge node to
-    // `pending`, clears volatile attempt state, and bumps execution
-    // generation exactly once via `withBumpedExecutionGeneration`
-    // while preserving branch/workspacePath lineage — the chart's
-    // retry-class semantics for merge-mode mutations.
-    return this.retryTask(taskId);
+    // Retry-class reset via the policy table — `restartTask` is the
+    // current `retryTask` compatibility wire. Routing through
+    // `MUTATION_POLICIES.mergeMode` keeps merge-mode dispatch
+    // table-driven so a chart change propagates without touching this
+    // method body.
+    return this.dispatchPostMutation(MUTATION_POLICIES.mergeMode.action, taskId);
   }
 
   /**
@@ -3308,16 +3347,12 @@ export class Orchestrator {
     this.persistence.logEvent?.(taskId, 'task.updated', fixContextChanges);
     this.messageBus.publish(TASK_DELTA_CHANNEL, fixContextDelta);
 
-    // Step 10 retry-class reset: restartTask is today's `retryTask`
-    // compatibility wire (`buildInvalidationDeps` →
-    // `orchestrator.restartTask`). It resets the task to `pending`,
-    // clears volatile attempt state (`agentSessionId`, `containerId`,
-    // transient `error`/`exitCode`/timing fields), and bumps
-    // execution generation exactly once via
-    // `withBumpedExecutionGeneration` while preserving branch /
-    // workspacePath lineage — the chart's "retry from reverted
-    // failed state" baseline for fix-context mutations.
-    return this.retryTask(taskId);
+    // Retry-class reset via the policy table — `restartTask` is the
+    // current `retryTask` compatibility wire. Routing through
+    // `MUTATION_POLICIES.fixContext` keeps fix-context dispatch
+    // table-driven so a chart change propagates without touching this
+    // method body.
+    return this.dispatchPostMutation(MUTATION_POLICIES.fixContext.action, taskId);
   }
 
   /**

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2914,7 +2914,7 @@ export class Orchestrator {
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot edit merge node ${taskId}`);
 
-    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+    if (isActiveForInvalidation(task.status)) {
       this.cancelTask(taskId);
     }
 
@@ -2934,7 +2934,7 @@ export class Orchestrator {
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot edit merge node ${taskId}`);
 
-    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+    if (isActiveForInvalidation(task.status)) {
       this.cancelTask(taskId);
     }
 
@@ -2977,7 +2977,7 @@ export class Orchestrator {
       hostKey(oldRunnerKind, oldPoolMemberId) !==
       hostKey(effectiveType, newPoolMemberId);
 
-    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+    if (isActiveForInvalidation(task.status)) {
       this.cancelTask(taskId);
     }
 
@@ -3009,7 +3009,7 @@ export class Orchestrator {
       );
     }
 
-    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+    if (isActiveForInvalidation(task.status)) {
       this.cancelTask(taskId);
     }
 
@@ -3035,7 +3035,7 @@ export class Orchestrator {
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     if (task.config.isMergeNode) throw new Error(`Cannot change execution agent of merge node ${taskId}`);
 
-    if (task.status === 'running' || task.status === 'fixing_with_ai') {
+    if (isActiveForInvalidation(task.status)) {
       this.cancelTask(taskId);
     }
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2326,11 +2326,6 @@ export class Orchestrator {
       });
     }
 
-    const retryTaskWorkflowId = this.stateGetTask(id)?.config.workflowId;
-    if (retryTaskWorkflowId) {
-      this.cascadeInvalidationToDownstream(retryTaskWorkflowId);
-    }
-
     const readyTasks = this.stateMachine.getReadyTasks();
     const isReady = readyTasks.some((t) => t.id === id);
     this.logger.info('[orchestrator] retryTask ready check', { taskId: id, ready: isReady });
@@ -2442,8 +2437,6 @@ export class Orchestrator {
       note: 'preserved completed outside invalidated subgraphs',
     });
 
-    this.cascadeInvalidationToDownstream(workflowId);
-
     const readyIds = this.stateMachine
       .getReadyTasks()
       .map((t) => t.id)
@@ -2533,11 +2526,6 @@ export class Orchestrator {
 
       this.deferredTaskIds.delete(id);
       this.clearQueuedSchedulerEntries(id, priorAttemptId);
-    }
-
-    const recreateTaskWorkflowId = task.config.workflowId;
-    if (recreateTaskWorkflowId) {
-      this.cascadeInvalidationToDownstream(recreateTaskWorkflowId);
     }
 
     const readyIds = this.stateMachine
@@ -2645,8 +2633,6 @@ export class Orchestrator {
       this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
       this.clearQueuedSchedulerEntries(task.id, priorAttemptId);
     }
-
-    this.cascadeInvalidationToDownstream(workflowId);
 
     const readyIds = this.stateMachine
       .getReadyTasks()


### PR DESCRIPTION
## Summary

PR-H of the invalidation cleanup follow-on stack. Removes the
hard-coded `recreateTask` / `retryTask` literals at the tail of each
synchronous orchestrator edit primitive and replaces them with a
small table-driven dispatch helper:

- `editTaskCommand`, `editTaskPrompt`, `editTaskAgent` —
  dispatch via `MUTATION_POLICIES.{command,prompt,executionAgent}.action`
- `editTaskType` — dispatch via `MUTATION_POLICIES.poolMemberId.action`
  when the host changed, `MUTATION_POLICIES.runnerKind.action` otherwise
- `editTaskPool` — dispatch via `MUTATION_POLICIES.poolMemberId.action`
- `editTaskMergeMode` — dispatch via `MUTATION_POLICIES.mergeMode.action`
- `editTaskFixContext` — dispatch via `MUTATION_POLICIES.fixContext.action`

A new private `Orchestrator.dispatchPostMutation(action, taskId)`
helper switches on the action and calls the matching primitive,
keeping the orchestrator's sync edit API intact (callers in
api-server, headless, and tests consume `TaskState[]` synchronously).

`selectExperiment(s)` and `replaceTask` are intentionally left alone:
they perform multi-target downstream cancel/recreate that does not
fit the single-id action dispatch shape; consolidating those is
follow-on work.

The async `applyInvalidation` pipeline continues to be the higher-
level seam used by `CommandService` and the facade for the
cross-workflow cascade — see PR-B (#908) and PR-G (#913).

Behavior is unchanged: every edit primitive still cancels first,
persists, and dispatches the same primitive it dispatched before;
the action is now read from the canonical `MUTATION_POLICIES` table
instead of being hard-coded at each site.

## Test Plan

- [x] `pnpm run check:types`
- [x] `cd packages/workflow-core && pnpm test`
- [x] `cd packages/app && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert fef54d76a`
- Post-revert steps: None — restores the inline `this.recreateTask` /
  `this.retryTask` literals at each edit primitive's tail
- Data migration? No
