### PR TITLE
[Embargo] Add review compression planning skill

### DIFF
--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -65,6 +65,9 @@ must_contain "$SKILL_MD" "Phase 1b" "SKILL must reference Phase 1b"
 must_contain "$SKILL_MD" "Policy-matrix documents" "SKILL must document policy-matrix coverage mode"
 must_contain "$SKILL_MD" "verify-noop" "SKILL must explain policy-matrix degradation checks"
 must_contain "$SKILL_MD" "zero-context executable" "SKILL must require zero-context executable prompt instructions"
+must_contain "$SKILL_MD" "Review compression" "SKILL must require review compression for implementation plans"
+must_contain "$SKILL_MD" "Review claim:" "SKILL must require review claim metadata"
+must_contain "$SKILL_MD" "Safety invariant:" "SKILL must require safety invariant metadata"
 
 # Playbook — Phase 1a / 1b (three lanes) and anti-patterns
 must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must define Phase 1a"
@@ -79,6 +82,7 @@ must_contain "$PLAYBOOK" "assume no prior context" "Playbook must require zero-c
 # Task patterns — strict prompt handoff requirements
 must_contain "$TASK_PATTERNS" "Assume zero context" "Task patterns must define zero-context prompt requirement"
 must_contain "$TASK_PATTERNS" "deterministic pass/fail expectations" "Task patterns must require deterministic prompt outcomes"
+must_contain "$TASK_PATTERNS" "Review compression contract" "Task patterns must define review compression metadata"
 
 echo "OK: plan-to-invoker skill contract checks passed"
 

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -21,6 +21,8 @@ Minimal controller skill. Keep policy short here; use deterministic scripts and 
 
 Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b evidence.
 
+**Review compression (required for implementation plans):** Before authoring any plan with `onFinish != none`, apply `skills/review-compression/SKILL.md`. Split by reviewer cognition, not file count: one local review claim, one safety invariant, one slice rationale, and one architectural effect per implementation task. This applies to Invoker and non-Invoker target repos.
+
 **Policy-matrix documents:** When the source is an architecture or policy document with a decision table, exception rules, or cross-cutting invariants, you must preserve row-level coverage before authoring workflows. Do not stop at files/functions/packages; every required policy row must map to a workflow step or an explicit waiver.
 
 **Delegated task hints (hard requirement for implementation plans):** For plans with `onFinish != none`, every prompt task must include `Files:`, `Change types:`, and `Acceptance criteria:` sections in `description`. Prompt text must be zero-context executable: assume no prior chat knowledge, include deterministic pass/fail expectations, and keep instructions self-contained. Verify-only plans (`onFinish: none`) keep delegation hints advisory.
@@ -29,7 +31,7 @@ Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b 
 
 **Dependency-first layered decomposition (required for implementation plans):** For plans whose `onFinish` is not `none`, every implementation task must include `Layer:` and `Feature state:` headings in `description`. Use normalized layer names (`persistence`, `domain`, `transport`, `api`, `contact_surface`, `app_bridge`, `owner_delegation`, `ui_activation`, `app_regression`, `e2e_regression`, `ui`, `docs`) and feature state values (`active` or `dormant`). `dormant` tasks must still include `Acceptance criteria:` in `description`. Verify-only plans (`onFinish: none`) are exempt from this hard requirement.
 
-**Implementation-rationale headings (required for all implementation tasks):** For plans whose `onFinish` is not `none`, every task (prompt or command) must include `Goal:`, `Motivation:`, `Alternative considerations:` (or `Alternatives:`), and `Implementation details:` (or `Implementation:`) in the task `description`. In addition, prompt tasks must include the same rationale headings directly in `prompt` so execution instructions contain explicit intent (not only metadata). This is a hard requirement enforced by `lint-task-atomicity.sh` so implementation intent is explicit and reviewable in authored workflow YAML.
+**Implementation-rationale headings (required for all implementation tasks):** For plans whose `onFinish` is not `none`, every task (prompt or command) must include `Review claim:`, `Safety invariant:`, `Slice rationale:`, `Architectural effect:`, `Goal:`, `Motivation:`, `Alternative considerations:` (or `Alternatives:`), and `Implementation details:` (or `Implementation:`) in the task `description`. In addition, prompt tasks must include the same rationale headings directly in `prompt` so execution instructions contain explicit intent (not only metadata). This is a hard requirement enforced by `lint-task-atomicity.sh` so implementation intent is explicit and reviewable in authored workflow YAML.
 
 **Cross-layer dependency direction (required):** Dependency DAGs must flow from lower/foundational layers toward higher/integration layers. If a lower-layer task depends on a higher-layer task, mark an explicit exception in the task description with `Layer exception: allowed` and a rationale.
 
@@ -80,7 +82,7 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
    `bash skills/plan-to-invoker/scripts/validate-plan.sh <plan-file>`
 4. `step-lint-atomicity`
    `bash skills/plan-to-invoker/scripts/lint-task-atomicity.sh <plan-file>`  
-  Optional: append `--warn-delegation` to print additional advisory hints. For authored stacks, append `--stack-manifest <file>` so non-terminal workflows may end with focused verification while the highest-order workflow still requires `pnpm run test:all`. Atomicity lint always runs `--strict-delegation` inside `skill-doctor` and, for implementation plans (`onFinish != none`), hard-fails missing/invalid `Layer:` and `Feature state:` metadata, missing required rationale headings in `description` on any task (`Goal`, `Motivation`, `Alternative considerations`/`Alternatives`, `Implementation details`/`Implementation`), missing required rationale headings in `prompt` for prompt tasks, prompt tasks without `Files:`/`Change types:`/`Acceptance criteria:` description blocks, prompts missing zero-context execution framing, prompts missing deterministic pass/fail expectations, invalid cross-layer dependency direction without `Layer exception: allowed`, and missing experiment-artifact handoff/cleanup contract when experiment tasks are present.
+  Optional: append `--warn-delegation` to print additional advisory hints. For authored stacks, append `--stack-manifest <file>` so non-terminal workflows may end with focused verification while the highest-order workflow still requires `pnpm run test:all`. Atomicity lint always runs `--strict-delegation` inside `skill-doctor` and, for implementation plans (`onFinish != none`), hard-fails missing/invalid `Layer:` and `Feature state:` metadata, missing required review-compression/rationale headings in `description` on any task (`Review claim`, `Safety invariant`, `Slice rationale`, `Architectural effect`, `Goal`, `Motivation`, `Alternative considerations`/`Alternatives`, `Implementation details`/`Implementation`), missing required rationale headings in `prompt` for prompt tasks, prompt tasks without `Files:`/`Change types:`/`Acceptance criteria:` description blocks, prompts missing zero-context execution framing, prompts missing deterministic pass/fail expectations, invalid cross-layer dependency direction without `Layer exception: allowed`, and missing experiment-artifact handoff/cleanup contract when experiment tasks are present.
 5. `step-parse-verify-results`
    `bash skills/plan-to-invoker/scripts/parse-results.sh < /tmp/invoker-verify.txt`
 
@@ -160,6 +162,7 @@ When those hardening workflows target Invoker itself, the branch/PR publication 
 - File/function-heavy plans: see playbook `playbooks/verify-then-build.md`
 - Schema and required fields: `references/schema.md`
 - Task decomposition and dependency patterns: `references/task-patterns.md`
+- Review compression: `../review-compression/SKILL.md`
 - End-to-end examples: `references/examples.md`
 - Efficacy / soft scoring: `references/efficacy-rubric.md`
 

--- a/skills/plan-to-invoker/fixtures/README.md
+++ b/skills/plan-to-invoker/fixtures/README.md
@@ -56,6 +56,8 @@ Negative fixtures demonstrate anti-patterns and validation errors:
 - **anti-pattern-g-monolithic-prompt-edit-bridge.yaml** - Monolithic `wf-1777929074509-8`-shaped workflow missing required layer/state decomposition metadata (**fails `skill-doctor` lint, not YAML schema**)
 - **anti-pattern-h-layer-order-violation.yaml** - Lower architectural layer depends on a higher layer without `Layer exception: allowed` (**fails `skill-doctor` lint, not YAML schema**)
 - **anti-pattern-i-final-regression-not-test-all.yaml** - Standalone implementation workflow missing the terminal `pnpm run test:all` regression gate (**fails `skill-doctor` lint, not YAML schema**)
+- **anti-pattern-j-zero-context-missing-metadata.yaml** - Prompt task omits strict zero-context handoff metadata (**fails `skill-doctor` lint, not YAML schema**)
+- **anti-pattern-k-missing-review-compression.yaml** - Implementation task omits review-compression metadata (**fails `skill-doctor` lint, not YAML schema**)
 
 ### Edge Cases (specific validation errors)
 

--- a/skills/plan-to-invoker/fixtures/negative/anti-pattern-k-missing-review-compression.yaml
+++ b/skills/plan-to-invoker/fixtures/negative/anti-pattern-k-missing-review-compression.yaml
@@ -1,19 +1,13 @@
-name: "Anti-pattern J: prompt lacks zero-context metadata contract"
-description: "Implementation plan where prompt task omits strict zero-context handoff fields."
+# Expected outcome: skill-doctor fails lint-task-atomicity because implementation
+# tasks omit Review claim / Safety invariant / Slice rationale / Architectural effect.
+name: "Anti-pattern K: missing review compression metadata"
+description: "Implementation plan missing review-compression headings."
 onFinish: pull_request
 mergeMode: external_review
 repoUrl: git@github.com:example-org/acme-repo.git
 tasks:
   - id: implement-runtime-flow
     description: |
-      Review claim:
-      - This task makes one locally reviewable implementation claim.
-      Safety invariant:
-      - The slice is safe because its verification remains local and explicit.
-      Slice rationale:
-      - This work is isolated from neighboring behavior or cleanup changes.
-      Architectural effect:
-      - The affected boundary and data or control flow remain explicit.
       Goal:
       - Implement deterministic runtime flow updates.
       Motivation:
@@ -25,6 +19,12 @@ tasks:
       - Apply runtime-flow edits and preserve existing behavior contracts.
       Layer: transport
       Feature state: active
+      Files:
+      - packages/execution-engine/src/task-runner.ts
+      Change types:
+      - modify
+      Acceptance criteria:
+      - `cd packages/execution-engine && pnpm test` exits 0.
     prompt: |
       Goal:
       - Implement deterministic runtime flow updates in task-runner.
@@ -34,20 +34,12 @@ tasks:
       - Option A (chosen): targeted update.
       - Option B: broad refactor.
       Implementation details:
-      - Update packages/execution-engine/src/task-runner.ts.
+      - Assume no prior context. Update packages/execution-engine/src/task-runner.ts.
       Acceptance criteria:
-      - Tests should pass.
+      - Pass condition: `cd packages/execution-engine && pnpm test` exits 0.
     dependencies: []
   - id: final-regression
     description: |
-      Review claim:
-      - This task makes one locally reviewable implementation claim.
-      Safety invariant:
-      - The slice is safe because its verification remains local and explicit.
-      Slice rationale:
-      - This work is isolated from neighboring behavior or cleanup changes.
-      Architectural effect:
-      - The affected boundary and data or control flow remain explicit.
       Goal:
       - Run final full-suite regression gate.
       Motivation:

--- a/skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml
@@ -15,7 +15,24 @@ featureBranch: plan/prompt-edit-layered-split-with-dormant
 tasks:
   - id: prompt-edit-contact-surface
     description: |
+      Review claim:
+      - Add the prompt-edit renderer contract without activating behavior.
+      Safety invariant:
+      - Existing command-edit contracts remain intact and no UI path calls the new prompt-edit surface yet.
+      Slice rationale:
+      - The contact surface lands before app bridge and UI activation work.
+      Architectural effect:
+      - Renderer-to-app typing gains a prompt-edit entry point while runtime behavior stays unchanged.
       Define the renderer contact surface for prompt editing without activating UI behavior.
+      Goal:
+      - Define the renderer contact surface for prompt editing without activating UI behavior.
+      Motivation:
+      - Keep the contract reviewable before any app bridge or UI behavior changes.
+      Alternative considerations:
+      - Option A (chosen): add the contact surface first.
+      - Option B: bundle contract, app bridge, and UI activation together.
+      Implementation details:
+      - Mirror existing command-edit contract shapes for prompt editing.
       Layer: contact_surface
       Feature state: active
       Files:
@@ -26,6 +43,15 @@ tasks:
       Acceptance criteria:
       - Ensure renderer types compile and expose a typed editTaskPrompt callback.
     prompt: |
+      Goal:
+      - Define the renderer contact surface for prompt editing without activating UI behavior.
+      Motivation:
+      - Keep the contract reviewable before any app bridge or UI behavior changes.
+      Alternative considerations:
+      - Option A (chosen): add the contact surface first.
+      - Option B: bundle contract, app bridge, and UI activation together.
+      Implementation details:
+      - Assume no prior context.
       Modify packages/app/src/preload.ts and packages/ui/src/types/window-invoker.d.ts.
       Update the renderer contract so prompt tasks can call editTaskPrompt through
       the existing window.invoker surface. Modify the preload and type declaration
@@ -33,11 +59,30 @@ tasks:
       signature carries workflowId, taskId, and prompt text safely. The result
       must keep existing command-edit contracts intact and avoid enabling UI
       activation behavior yet; this task is contract-only.
+      Acceptance criteria:
+      - Pass condition: renderer types expose a typed editTaskPrompt callback and existing command-edit contracts remain intact.
     dependencies: []
 
   - id: app-bridge-and-owner-delegation
     description: |
+      Review claim:
+      - Route prompt-edit requests through the app bridge and owner delegation.
+      Safety invariant:
+      - The renderer contract already exists and TaskPanel behavior remains inactive.
+      Slice rationale:
+      - App plumbing is reviewed separately from both the contact surface and UI activation.
+      Architectural effect:
+      - Prompt edits gain an app-layer path to commandService with owner-aware routing.
       Add app-layer IPC bridge and owner delegation routing for prompt edits.
+      Goal:
+      - Add app-layer IPC bridge and owner delegation routing for prompt edits.
+      Motivation:
+      - Keep app plumbing separate from UI activation.
+      Alternative considerations:
+      - Option A (chosen): bridge after the contact surface exists.
+      - Option B: activate UI editing while adding app bridge plumbing.
+      Implementation details:
+      - Route prompt edits through existing command-service and owner-delegation paths.
       Layer: app_bridge
       Feature state: active
       Files:
@@ -48,6 +93,15 @@ tasks:
       Acceptance criteria:
       - Ensure GUI-origin prompt edits route through owner-aware app handlers.
     prompt: |
+      Goal:
+      - Add app-layer IPC bridge and owner delegation routing for prompt edits.
+      Motivation:
+      - Keep app plumbing separate from UI activation.
+      Alternative considerations:
+      - Option A (chosen): bridge after the contact surface exists.
+      - Option B: activate UI editing while adding app bridge plumbing.
+      Implementation details:
+      - Assume no prior context.
       Modify packages/app/src/main.ts and packages/app/src/headless-delegation.ts.
       In the app layer, register IPC handlers for invoker:edit-task-prompt and
       connect them to the existing commandService.editTaskPrompt pathway so
@@ -55,11 +109,30 @@ tasks:
       existing mutation routes and ensure the bridge can execute when GUI owner
       mode is active. Keep this task scoped to bridge and delegation plumbing;
       do not activate TaskPanel inline editing behavior yet.
+      Acceptance criteria:
+      - Pass condition: GUI-origin prompt edits route through owner-aware app handlers without activating TaskPanel editing.
     dependencies: [prompt-edit-contact-surface]
 
   - id: ui-prompt-editing-activation
     description: |
+      Review claim:
+      - Prepare dormant TaskPanel prompt editing behind the existing UI pattern.
+      Safety invariant:
+      - The path is wired but not default-enabled, so existing command editing remains unchanged.
+      Slice rationale:
+      - UI activation is separated from app bridge plumbing and regression proof.
+      Architectural effect:
+      - TaskPanel can call the prompt-edit bridge only through a dormant activation path.
       Prepare TaskPanel prompt editing activation behind a dormant rollout marker.
+      Goal:
+      - Prepare TaskPanel prompt editing activation behind a dormant rollout marker.
+      Motivation:
+      - Keep UI activation reviewable and dormant after the app bridge exists.
+      Alternative considerations:
+      - Option A (chosen): wire dormant UI activation separately.
+      - Option B: enable UI behavior by default in the same slice.
+      Implementation details:
+      - Reuse command-edit primitives while keeping prompt editing gated.
       Layer: ui_activation
       Feature state: dormant
       Files:
@@ -69,17 +142,45 @@ tasks:
       Acceptance criteria:
       - Ensure dormant prompt-edit activation path is wired but not default-enabled.
     prompt: |
+      Goal:
+      - Prepare TaskPanel prompt editing activation behind a dormant rollout marker.
+      Motivation:
+      - Keep UI activation reviewable and dormant after the app bridge exists.
+      Alternative considerations:
+      - Option A (chosen): wire dormant UI activation separately.
+      - Option B: enable UI behavior by default in the same slice.
+      Implementation details:
+      - Assume no prior context.
       Modify packages/ui/src/components/TaskPanel.tsx.
       Update TaskPanel prompt text to use the shared inline editing control path
       in a dormant activation state. Reuse command-edit UX primitives so behavior
       remains consistent, but keep activation gated so this workflow only lands
       dormant scaffolding. Ensure save handlers call the prompt-edit bridge path
       when activated later and preserve existing command task editing interactions.
+      Acceptance criteria:
+      - Pass condition: dormant prompt-edit activation path is wired but not default-enabled.
     dependencies: [app-bridge-and-owner-delegation]
 
   - id: app-and-e2e-regressions
     description: |
+      Review claim:
+      - Add focused app and E2E regressions for the prompt-edit path.
+      Safety invariant:
+      - The task is test-only and depends on the implementation layers it proves.
+      Slice rationale:
+      - Regression proof is separate from implementation so failures localize to behavior.
+      Architectural effect:
+      - No production architecture changes; tests document the bridge and TaskPanel flow.
       Add app-level and Playwright regressions proving prompt edit flow is stable.
+      Goal:
+      - Add app-level and Playwright regressions proving prompt edit flow is stable.
+      Motivation:
+      - Verify the layered prompt-edit flow after contract, bridge, and dormant UI slices exist.
+      Alternative considerations:
+      - Option A (chosen): add focused app and E2E regressions.
+      - Option B: rely only on the terminal full-suite gate.
+      Implementation details:
+      - Cover IPC routing and TaskPanel prompt-edit flow deterministically.
       Layer: e2e_regression
       Feature state: active
       Files:
@@ -91,6 +192,15 @@ tasks:
       Acceptance criteria:
       - Ensure app-level and end-to-end prompt-edit regressions pass in CI-style runs.
     prompt: |
+      Goal:
+      - Add app-level and Playwright regressions proving prompt edit flow is stable.
+      Motivation:
+      - Verify the layered prompt-edit flow after contract, bridge, and dormant UI slices exist.
+      Alternative considerations:
+      - Option A (chosen): add focused app and E2E regressions.
+      - Option B: rely only on the terminal full-suite gate.
+      Implementation details:
+      - Assume no prior context.
       Modify packages/app/src/__tests__/main.prompt-edit.test.ts and packages/app/e2e/prompt-edit.spec.ts.
       Add regression coverage that exercises the GUI prompt-edit bridge end to end.
       Include at least one app-layer test validating IPC-to-commandService routing,
@@ -98,11 +208,30 @@ tasks:
       TaskPanel flow. The regression suite must validate recreate semantics and
       confirm no command-edit regressions. Ensure test naming and setup are
       deterministic so this workflow can be reviewed as the final proof layer.
+      Acceptance criteria:
+      - Pass condition: app-level and end-to-end prompt-edit regressions pass in CI-style runs.
     dependencies: [ui-prompt-editing-activation]
 
   - id: final-regression
     description: |
+      Review claim:
+      - Run the terminal full-suite regression gate for the layered prompt-edit stack.
+      Safety invariant:
+      - The command changes no production code and depends on every earlier task.
+      Slice rationale:
+      - Full-suite validation belongs at the terminal workflow layer.
+      Architectural effect:
+      - No architecture changes; validates the integrated prompt-edit stack.
       Run the full repository test suite as the terminal regression gate.
+      Goal:
+      - Run the full repository test suite as the terminal regression gate.
+      Motivation:
+      - Validate all prompt-edit slices together after focused regressions exist.
+      Alternative considerations:
+      - Option A (chosen): one terminal full-suite gate.
+      - Option B: repeat full-suite verification in every slice.
+      Implementation details:
+      - Execute `pnpm run test:all` after every earlier task completes.
       Layer: e2e_regression
       Feature state: active
       Files:

--- a/skills/plan-to-invoker/references/examples.md
+++ b/skills/plan-to-invoker/references/examples.md
@@ -57,6 +57,7 @@ Complex plan with diamond dependencies. Uses `onFinish: pull_request` for manual
 - `fixtures/negative/anti-pattern-h-layer-order-violation.yaml` — Lower layer depends on higher layer without `Layer exception: allowed`
 - `fixtures/negative/anti-pattern-i-final-regression-not-test-all.yaml` — Standalone implementation plan ends without a terminal `pnpm run test:all` gate
 - `fixtures/negative/anti-pattern-j-zero-context-missing-metadata.yaml` — Prompt task omits strict zero-context handoff metadata required for implementation plans
+- `fixtures/negative/anti-pattern-k-missing-review-compression.yaml` — Implementation task omits review claim, safety invariant, slice rationale, and architectural effect metadata
 
 All anti-patterns are validated by `scripts/test-fixtures.sh` with deterministic error detection.
 

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -63,6 +63,21 @@ For plans with `onFinish` set to `pull_request` or `merge`, each task `descripti
 
 `onFinish: none` verify-only plans are exempt.
 
+### Review compression contract
+
+Apply `skills/review-compression/SKILL.md` before authoring implementation tasks.
+Each implementation task must include these description headings:
+
+- `Review claim:` the one sentence a reviewer is being asked to approve.
+- `Safety invariant:` why this slice is safe to review locally.
+- `Slice rationale:` why this slice is separate from neighboring work.
+- `Architectural effect:` what changes in control flow, data flow, ownership,
+  dependency direction, or public surface.
+
+Keep directly affected tests and compatibility adapters with the change that
+requires them. Split optional cleanup, special cases, behavior-plus-rename,
+default-flip-plus-deletion, and unrelated stale visual refreshes.
+
 ### Cross-layer direction
 
 - Dependencies should flow from lower/foundational layers to higher/integration layers.
@@ -265,5 +280,6 @@ The validator now enforces atomic/detailed tasks:
 - IDs must avoid generic placeholders (`task-1`, `step-2`); kebab-case is recommended
 - Each task must have exactly one of `command` or `prompt`
 - Descriptions must be specific (minimum detail threshold)
+- Implementation task descriptions must include review-compression headings
 - Command tasks cannot be overloaded with long shell chains
 - Prompt tasks must include concrete file paths and explicit acceptance language

--- a/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
+++ b/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
@@ -155,6 +155,10 @@ function parse_metadata(desc_lower,    tmp, parts) {
   has_motivation_heading = (desc_lower ~ /(^|\n)[ \t]*motivation:/)
   has_alternatives_heading = (desc_lower ~ /(^|\n)[ \t]*(alternative considerations|alternatives):/)
   has_implementation_heading = (desc_lower ~ /(^|\n)[ \t]*(implementation details|implementation):/)
+  has_review_claim_heading = (desc_lower ~ /(^|\n)[ \t]*review claim:/)
+  has_safety_invariant_heading = (desc_lower ~ /(^|\n)[ \t]*safety invariant:/)
+  has_slice_rationale_heading = (desc_lower ~ /(^|\n)[ \t]*slice rationale:/)
+  has_architectural_effect_heading = (desc_lower ~ /(^|\n)[ \t]*architectural effect:/)
 
   tmp = desc_lower
   sub(/^.*layer:[ \t]*/, "", tmp)
@@ -259,6 +263,18 @@ function flush_task(    wc, and_count, valid_id, d, desc_lower, idx) {
       errors[++errn] = "Task \"" id "\" uses Feature state dormant but omits \"Acceptance criteria:\" in description"
     }
 
+    if (strictDelegation == 1 && has_review_claim_heading == 0) {
+      errors[++errn] = "Task \"" id "\" missing required \"Review claim:\" section in description for implementation plans"
+    }
+    if (strictDelegation == 1 && has_safety_invariant_heading == 0) {
+      errors[++errn] = "Task \"" id "\" missing required \"Safety invariant:\" section in description for implementation plans"
+    }
+    if (strictDelegation == 1 && has_slice_rationale_heading == 0) {
+      errors[++errn] = "Task \"" id "\" missing required \"Slice rationale:\" section in description for implementation plans"
+    }
+    if (strictDelegation == 1 && has_architectural_effect_heading == 0) {
+      errors[++errn] = "Task \"" id "\" missing required \"Architectural effect:\" section in description for implementation plans"
+    }
     if (has_goal_heading == 0) {
       errors[++errn] = "Task \"" id "\" missing required \"Goal:\" section in description for implementation plans"
     }

--- a/skills/plan-to-invoker/scripts/test-fixtures.sh
+++ b/skills/plan-to-invoker/scripts/test-fixtures.sh
@@ -22,6 +22,7 @@ DOCTOR_NEGATIVE_FIXTURES=(
   "anti-pattern-h-layer-order-violation.yaml"
   "anti-pattern-i-final-regression-not-test-all.yaml"
   "anti-pattern-j-zero-context-missing-metadata.yaml"
+  "anti-pattern-k-missing-review-compression.yaml"
 )
 
 is_doctor_negative_fixture() {
@@ -738,6 +739,29 @@ EOF
   fi
 }
 
+test_lint_requires_review_compression_sections() {
+  local fixture="$NEGATIVE_DIR/anti-pattern-k-missing-review-compression.yaml"
+  local output
+  set +e
+  output=$(bash "$LINT_SCRIPT" --strict-delegation "$fixture" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Expected lint to reject missing review-compression sections" >&2
+    return 1
+  fi
+
+  if ! grep -q 'missing required "Review claim:" section' <<<"$output"; then
+    echo "Expected Review claim lint error, got: $output" >&2
+    return 1
+  fi
+  if ! grep -q 'missing required "Safety invariant:" section' <<<"$output"; then
+    echo "Expected Safety invariant lint error, got: $output" >&2
+    return 1
+  fi
+}
+
 test_lint_accepts_design_sections_for_prompt_tasks() {
   local temp_plan
   temp_plan=$(mktemp)
@@ -870,6 +894,14 @@ repoUrl: git@github.com:example-org/acme-repo.git
 tasks:
   - id: implement-runtime-flow
     description: |
+      Review claim:
+      - Implement deterministic runtime flow updates in task-runner.
+      Safety invariant:
+      - The change is scoped to one execution-engine file and verified by package tests.
+      Slice rationale:
+      - Runtime implementation is separate from terminal full-suite validation.
+      Architectural effect:
+      - Updates the execution-engine runtime path without changing external surfaces.
       Goal:
       - Implement deterministic runtime flow updates.
       Motivation:
@@ -904,6 +936,14 @@ tasks:
     dependencies: []
   - id: final-regression
     description: |
+      Review claim:
+      - Run the terminal full-suite regression gate for runtime changes.
+      Safety invariant:
+      - This command changes no production code and depends on runtime implementation.
+      Slice rationale:
+      - Terminal validation is separate from implementation work.
+      Architectural effect:
+      - No architecture changes; validates integrated behavior.
       Goal:
       - Run final full-suite regression gate.
       Motivation:
@@ -1061,6 +1101,7 @@ run_test "Lint: reject non-test:all final gate" test_lint_rejects_non_test_all_f
 run_test "Lint: allow non-terminal stack workflow without test:all" test_lint_allows_nonterminal_stack_workflow_without_test_all
 run_test "Lint: reject final gate missing dependencies" test_lint_rejects_final_gate_missing_dependencies
 run_test "Lint: reject missing design sections for prompt tasks" test_lint_requires_design_sections_for_prompt_tasks
+run_test "Lint: reject missing review-compression sections" test_lint_requires_review_compression_sections
 run_test "Lint: accept prompt tasks with design sections" test_lint_accepts_design_sections_for_prompt_tasks
 run_test "Lint: reject missing design sections for command tasks" test_lint_requires_design_sections_for_command_tasks
 run_test "Lint strict: accept zero-context prompt contract" test_lint_strict_accepts_zero_context_prompt_contract

--- a/skills/review-compression/SKILL.md
+++ b/skills/review-compression/SKILL.md
@@ -1,0 +1,99 @@
+---
+name: review-compression
+description: >
+  Shape code changes, workflow plans, and PR stacks so each diff is easy to
+  review: one local claim, one safety invariant, clear architectural effect,
+  and an explicit reason for the slice.
+---
+
+# review-compression
+
+Use this skill before authoring implementation workflows, PR stacks, or any
+multi-diff plan. Optimize for reviewer cognition, not smallest total patch.
+
+## Core Rule
+
+Each diff or workflow should make one locally reviewable claim. A tired senior
+engineer should be able to answer:
+
+- What architectural thing changed?
+- Why does this slice exist?
+- Why is it safe?
+- What alternatives were rejected?
+
+## Required Metadata
+
+Every implementation slice should carry these fields in task descriptions and
+PR bodies:
+
+- `Review claim:` one sentence the reviewer is being asked to approve.
+- `Safety invariant:` why this slice is safe to review locally.
+- `Slice rationale:` why this work is split here instead of bundled elsewhere.
+- `Architectural effect:` what changed in control flow, data flow, ownership,
+  dependency direction, or public surface.
+- `Alternative considerations:` rejected designs or split shapes.
+
+For mechanical slices, these can be terse. For cross-boundary changes, explain
+the before/after architecture and why the split is acceptable.
+
+## Ordering Rules
+
+- Evidence before change: add repros, benchmarks, or instrumentation before the
+  fix when they prove the problem.
+- Foundation before behavior: add schemas, types, helpers, migrations, flags,
+  and dormant code before behavior changes.
+- Compatibility before exposure: include adapters with a lower-level change
+  when needed to preserve existing behavior.
+- Behavior before cleanup: fix correctness or security first; rename and cleanup
+  later.
+- Activate one surface or path per diff.
+- Delete after migration, in a separate deletion slice as soon as safely unused.
+
+## Boundary Rules
+
+Split across architectural boundaries unless the downstream edit is required to
+preserve existing behavior.
+
+Common boundaries:
+
+- DB migration, write path, read/API exposure, UI use, old column deletion.
+- Core behavior, API exposure, UI behavior.
+- Contract, handler, UI.
+- CLI, API, UI.
+- Mechanical rename, module reorganization.
+- Helper extraction, usage migrations.
+
+Exception: directly affected tests and compatibility adapters stay with the
+change that requires them. Unrelated test stabilization and optional cleanup are
+separate slices.
+
+## Grouping Rules
+
+Group changes only when they share the same review claim:
+
+- generated output with the source schema change
+- docs explaining the changed behavior, API, or default
+- visual proof with the UI behavior change
+- dependency bump with required adaptation
+- exact same mechanical migration across many files
+- pure repo-wide import-path rename
+
+Split changes when they introduce a different claim:
+
+- optional cleanup
+- special cases inside a mechanical migration
+- stale unrelated screenshots
+- behavior fix plus rename
+- default flip plus dead-path removal
+- broad mechanical moves too large to inspect comfortably
+
+## PR Body Guidance
+
+Do not summarize the patch file-by-file. Compress the human judgment:
+
+- state the review claim
+- state the safety invariant
+- describe architectural effect in plain English
+- call out why this slice exists
+- include alternatives for non-obvious or cross-boundary choices
+


### PR DESCRIPTION
## Summary

Adds a repo-versioned `review-compression` skill that captures the review-slicing policy we developed for making workflow diffs easy to approve: one local review claim, one safety invariant, a clear slice rationale, and an architectural effect per implementation slice.

This also wires the policy into `plan-to-invoker` for implementation plans. `skill-doctor` now hard-fails strict implementation-plan lint when task descriptions omit `Review claim:`, `Safety invariant:`, `Slice rationale:`, or `Architectural effect:` metadata, while verification-only plans remain exempt.

The fixture coverage adds a negative review-compression anti-pattern and updates the layered prompt-edit positive fixture so it models the new metadata contract with concrete planning context.

## Architecture

### Before

```mermaid
graph TD
    A[plan-to-invoker] --> B[Layer and rationale headings]
    B --> C[Goal, Motivation, Alternatives, Implementation]
    A --> D[skill-doctor]
    D --> E[Atomicity and zero-context lint]
```

### After

```mermaid
graph TD
    R[review-compression skill] --> A[plan-to-invoker]
    A --> B[Layer and rationale headings]
    B --> C[Review claim, Safety invariant, Slice rationale, Architectural effect]
    B --> D[Goal, Motivation, Alternatives, Implementation]
    A --> E[skill-doctor]
    E --> F[Strict review-compression lint for implementation plans]
```

## Test Plan

- [x] `bash skills/plan-to-invoker/scripts/test-fixtures.sh`
- [x] `bash skills/plan-to-invoker/scripts/skill-doctor.sh skills/plan-to-invoker/fixtures/positive/07-prompt-edit-layered-split-with-dormant.yaml`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
