### PR TITLE
Default INVOKER_LAUNCH_OUTBOX to active in run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,19 @@ cd "$REPO_ROOT"
 # from this launcher even if the caller's environment opts into it.
 export INVOKER_ENABLE_WORKSPACE_CLEANUP=0
 
+# Launch-handoff outbox: default to `active` so the LaunchDispatcher
+# (Phase B) is the source of truth for dispatch. Phase C (PR #873)
+# deleted the legacy `launch-stall` watchdog and
+# `relaunchOrphansAndStartReady` on the assumption this flag is
+# `active` in production. With the flag unset, `resolveLaunchOutboxMode`
+# falls back to `disabled`, which leaves no recovery path for orphaned
+# `pending/launching` claims and silently wedges tasks forever (see
+# docs/incidents/2026-05-22-launch-handoff-orphan-architecture.md).
+# Respect a caller-provided override so operators can flip back to
+# `observe` or `disabled` in a hot incident without editing this file
+# (matches the CC.6 rollback intent in packages/app/src/config.ts).
+export INVOKER_LAUNCH_OUTBOX="${INVOKER_LAUNCH_OUTBOX:-active}"
+
 has_bootstrap_artifacts() {
   [ -f "$REPO_ROOT/node_modules/.modules.yaml" ] \
     && [ -x "$REPO_ROOT/packages/app/node_modules/.bin/electron" ]


### PR DESCRIPTION
## Stack

- **#940 (this PR)** — minimal-risk hotfix: default `INVOKER_LAUNCH_OUTBOX` to `active` in `run.sh` so the `LaunchDispatcher` is the source of truth for dispatch.
- **#941 (follow-up)** — forces the full migration: removes the `launchOutboxMode` flag, deletes the legacy in-process `executeTasks` fan-out (CC.4), retires the now-dead launch-stall watchdog assets, and updates the test surface to assert the outbox-only contract. Lands on top of this one.

Both PRs land together as a single corrective unit. This PR is the conservative half (env-var default flip) and #941 finishes the migration so the flag no longer exists.

## Summary

Default `INVOKER_LAUNCH_OUTBOX` to `active` in `run.sh` so the `LaunchDispatcher` (Phase B) is the source of truth for dispatch.

Phase C (#873) deleted the legacy `launch-stall` watchdog (CC.1) and `relaunchOrphansAndStartReady` (CC.2) on the documented pre-condition that production was already running with `INVOKER_LAUNCH_OUTBOX=active`. That pre-condition was not enforced by the launcher:

- `resolveLaunchOutboxMode` in `packages/app/src/config.ts` falls back to `'disabled'` when the env var is unset.
- `loadConfig` in the same file overwrites any `launchOutboxMode` value loaded from `~/.invoker/config.json` with the env-resolved value, so editing the JSON file does nothing.
- `run.sh` never exported the variable.

The net effect is that the running owner has neither the legacy safety net (deleted by Phase C) nor the new `LaunchDispatcher` reapers (skipped because `launchDispatcher` is `null` when the mode is `disabled` at `packages/app/src/main.ts:2730`). A `pending/launching` claim whose fire-and-forget dispatch promise drops sits silently forever instead of failing at the 20-minute lease expiry.

Observed in the field on 2026-05-24: `wf-1778431097453-46/implement-inv-117` and `wf-1778431089965-37/verify-inv-130` stuck for 4+ hours with zero `[launch-stall]` or `[launch-dispatcher]` log lines, blocking their entire workflows. See `docs/incidents/2026-05-22-launch-handoff-orphan-architecture.md` for the Issue 0 analysis this default repairs.

The override-aware form `${INVOKER_LAUNCH_OUTBOX:-active}` lets operators flip back to `observe` or `disabled` in a hot incident without editing the launcher, matching the CC.6 rollback intent documented in `packages/app/src/config.ts`.

> Note: #941 deletes the `INVOKER_LAUNCH_OUTBOX` export entirely once it lands, so the override mechanism in this PR is only valid until that PR merges. After #941 the variable is a no-op and the dispatcher is unconditionally active.

## Architecture

### Before

```mermaid
flowchart LR
  Orch[drainScheduler] -->|task.launch_claimed only| Claim[(durable claim)]
  Orch -.->|fire-and-forget promise| Runner[TaskRunner]
  NoReaper["no reaper, no watchdog (post-Phase C)"]
```

### After

```mermaid
flowchart LR
  Orch[drainScheduler] -->|claim + enqueueLaunchDispatch| Outbox[(task_launch_dispatch)]
  Outbox --> Dispatcher[LaunchDispatcher.dispatchActive]
  Dispatcher --> Runner[TaskRunner]
  Dispatcher --> Reapers["reapExpiredLeases + abandonStuckLeases"]
```

## Test Plan

- [x] `cd packages/app && pnpm test launch-claim-orphan-regression` (2 tests pass; the `active`-mode case proves the launch invariant holds end-to-end through the dispatcher under a 38-claim storm)
- [x] `cd packages/app && pnpm test config` (28 tests pass; covers `resolveLaunchOutboxMode` defaults, `active`/`observe`/`disabled`, whitespace/case normalization, and unknown-value fallback with warning)
- [x] `bash -c 'unset INVOKER_LAUNCH_OUTBOX; source <(grep -E "^export INVOKER_LAUNCH_OUTBOX" run.sh); echo $INVOKER_LAUNCH_OUTBOX'` prints `active`; running the same with `INVOKER_LAUNCH_OUTBOX=observe` in the caller env preserves the override

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: operators currently relying on the launcher to set the flag must export `INVOKER_LAUNCH_OUTBOX=active` themselves before `./run.sh`, or accept the regressed `disabled`-mode behavior (orphan launches silently wedge until manual `invoker-ctl restart`). If #941 has also landed, this revert has no effect since the variable is unread.
- Data migration? No. The flag only changes future dispatch behavior; existing `task_launch_dispatch` rows remain valid under any mode.
