### PR TITLE
Make the launch outbox the single dispatch path

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -438,9 +438,7 @@ describe('POST /api/tasks/:id/restart', () => {
 
     const res = await request(port, 'POST', '/api/tasks/task-1/restart');
     expect(res.status).toBe(200);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [topup]);
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('does not relaunch duplicate attempt from global top-up', async () => {
@@ -459,8 +457,7 @@ describe('POST /api/tasks/:id/restart', () => {
 
     const res = await request(port, 'POST', '/api/tasks/task-1/restart');
     expect(res.status).toBe(200);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledWith([scoped]);
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 
@@ -474,7 +471,7 @@ describe('POST /api/tasks/:id/approve', () => {
     expect(mocks.orchestrator.startExecution).toHaveBeenCalled();
   });
 
-  it('routes downstream merge nodes to executeTasks (not publishAfterFix)', async () => {
+  it('routes downstream merge nodes through the outbox (not publishAfterFix)', async () => {
     mocks.orchestrator.approve.mockResolvedValue([
       makeTask({ id: 'merge-1', status: 'running', config: { isMergeNode: true } }),
       makeTask({ id: 'task-2', status: 'running', config: {} }),
@@ -483,12 +480,7 @@ describe('POST /api/tasks/:id/approve', () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/approve');
     expect(res.status).toBe(200);
     expect(mocks.taskExecutor.publishAfterFix).not.toHaveBeenCalled();
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ id: 'merge-1' }),
-        expect.objectContaining({ id: 'task-2' }),
-      ]),
-    );
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('routes post-fix merge nodes to publishAfterFix', async () => {
@@ -647,7 +639,7 @@ describe('POST /api/tasks/:id/edit-prompt', () => {
     expect(mocks.orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-1', 'do the thing');
     expect(mocks.orchestrator.editTaskCommand).not.toHaveBeenCalled();
     // Facade dispatches any newly-runnable tasks via the executor.
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('returns 400 when prompt is missing', async () => {
@@ -656,7 +648,7 @@ describe('POST /api/tasks/:id/edit-prompt', () => {
     expect(res.body.error).toContain('Missing "prompt"');
   });
 
-  it('only dispatches running tasks returned by editTaskPrompt', async () => {
+  it('only counts running tasks as started in the editTaskPrompt response', async () => {
     const running = makeTask({
       id: 'task-1',
       status: 'running',
@@ -672,8 +664,7 @@ describe('POST /api/tasks/:id/edit-prompt', () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/edit-prompt', { prompt: 'new prompt' });
     expect(res.status).toBe(200);
     expect(res.body.tasksStarted).toBe(1);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledWith([running]);
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('does not call editTaskCommand when editing prompt', async () => {
@@ -716,7 +707,7 @@ describe('POST /api/tasks/:id/edit-type', () => {
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('type_edited');
     expect(mocks.orchestrator.editTaskType).toHaveBeenCalledWith('task-1', 'ssh', 'remote-b');
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 
@@ -730,7 +721,7 @@ describe('POST /api/tasks/:id/edit-agent', () => {
     expect(mocks.orchestrator.editTaskCommand).not.toHaveBeenCalled();
     expect(mocks.orchestrator.editTaskPrompt).not.toHaveBeenCalled();
     // Facade dispatches any newly-runnable tasks via the executor.
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('returns 400 when agent is missing', async () => {
@@ -741,7 +732,7 @@ describe('POST /api/tasks/:id/edit-agent', () => {
 });
 
 describe('POST /api/tasks/:id/gate-policy', () => {
-  it('updates gate policy and executes started tasks', async () => {
+  it('updates gate policy and enqueues newly-runnable tasks to the outbox', async () => {
     const res = await request(port, 'POST', '/api/tasks/task-1/gate-policy', {
       updates: [
         { workflowId: 'wf-upstream', taskId: '__merge__', gatePolicy: 'review_ready' },
@@ -754,7 +745,7 @@ describe('POST /api/tasks/:id/gate-policy', () => {
       'task-1',
       [{ workflowId: 'wf-upstream', taskId: '__merge__', gatePolicy: 'review_ready' }],
     );
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('returns 400 when updates are missing', async () => {
@@ -814,7 +805,7 @@ describe('POST /api/workflows/:id/restart', () => {
     expect(r2.body.coalesced).toBeUndefined();
     expect(mocks.persistence.updateWorkflow).toHaveBeenCalledTimes(2);
     expect(mocks.orchestrator.recreateWorkflow).toHaveBeenCalledTimes(2);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('returns 404 when workflow not found', async () => {
@@ -840,9 +831,7 @@ describe('POST /api/workflows/:id/restart', () => {
 
     const res = await request(port, 'POST', '/api/workflows/wf-1/restart');
     expect(res.status).toBe(200);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [topup]);
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 
@@ -878,7 +867,7 @@ describe('POST /api/workflows/:id/fork', () => {
     expect(res.body.sourceWorkflowId).toBe('wf-1');
     expect(res.body.forkedWorkflowId).toBe('wf-1-fork');
     expect(mocks.orchestrator.forkWorkflow).toHaveBeenCalledWith('wf-1');
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalled();
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
   });
 
   it('returns an error status when forkWorkflow throws', async () => {
@@ -954,9 +943,7 @@ describe('POST /api/workflows/:id/rebase-recreate', () => {
     const res = await request(port, 'POST', '/api/workflows/wf-1/rebase-recreate');
 
     expect(res.status).toBe(200);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
+    expect(mocks.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
   it('old rebase-and-retry route is gone', async () => {

--- a/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
+++ b/packages/app/src/__tests__/app-layer-handoff-repro.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { createTestHarness, type TestHarness } from '@invoker/test-kit';
-import type { PlanDefinition } from '@invoker/workflow-core';
-import { dispatchStartedTasksWithGlobalTopup } from '../global-topup.js';
+import type { PlanDefinition, TaskState } from '@invoker/workflow-core';
 
 const LINEAR_PLAN: PlanDefinition = {
   name: 'Linear Handoff Repro',
@@ -28,13 +27,20 @@ const PARALLEL_PLAN: PlanDefinition = {
   ],
 };
 
-async function dispatchStarted(h: TestHarness, started: Array<any>, context: string) {
-  return dispatchStartedTasksWithGlobalTopup({
-    orchestrator: h.orchestrator,
-    taskExecutor: h.executor,
-    context,
-    started,
-  });
+/**
+ * Drive the post-mutation launch in the test harness. The harness does
+ * not run a LaunchDispatcher, so we call the executor directly on the
+ * runnable subset to mirror what the dispatcher would do for each
+ * leased outbox row.
+ */
+async function dispatchStarted(h: TestHarness, started: Array<TaskState>, _context: string) {
+  const runnable = started.filter(
+    (task) =>
+      task.status === 'running'
+      || (task.status === 'pending' && task.execution.phase === 'launching'),
+  );
+  if (runnable.length === 0) return;
+  await h.executor.executeTasks(runnable);
 }
 
 describe('app-layer handoff repros', () => {

--- a/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
+++ b/packages/app/src/__tests__/bridge-orchestrator-executor.test.ts
@@ -67,7 +67,7 @@ const INDEPENDENT_TWO_TASK_PLAN: PlanDefinition = {
 };
 
 describe('global top-up dispatch', () => {
-  it('dispatches only newly started tasks and skips duplicates', async () => {
+  it('returns only newly started tasks in the top-up and skips duplicates', async () => {
     const duplicate = {
       id: 'wf-1/task-a',
       status: 'running',
@@ -101,8 +101,7 @@ describe('global top-up dispatch', () => {
     });
 
     expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
-    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([newTask]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(topup.map((task) => task.id)).toEqual(['wf-2/task-b']);
   });
 
@@ -153,9 +152,7 @@ describe('global top-up dispatch', () => {
     });
 
     expect(topup.map((task) => task.id)).toEqual([taskB.id]);
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([
-      expect.objectContaining({ id: taskB.id, status: 'running' }),
-    ]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   loadConfig,
   resolveEmbeddedTerminalBackendConfig,
-  resolveLaunchOutboxMode,
 } from '../config.js';
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join } from 'node:path';
@@ -28,9 +27,9 @@ vi.mock('node:os', async (importOriginal) => {
 });
 
 describe('loadConfig', () => {
-  it('returns config with default launchOutboxMode when no files exist', () => {
+  it('returns an empty config when no files exist', () => {
     const config = loadConfig();
-    expect(config).toEqual({ launchOutboxMode: 'disabled' });
+    expect(config).toEqual({});
   });
 
   it('reads user-level ~/.invoker/config.json', () => {
@@ -252,42 +251,5 @@ describe('resolveEmbeddedTerminalBackendConfig', () => {
       {},
       { INVOKER_EMBEDDED_TERMINAL_BACKEND: 'external' },
     )).toThrow(/Invalid embedded terminal backend/);
-  });
-});
-
-describe('resolveLaunchOutboxMode', () => {
-  it('defaults to disabled when INVOKER_LAUNCH_OUTBOX is unset', () => {
-    expect(resolveLaunchOutboxMode({})).toBe('disabled');
-  });
-
-  it('returns observe when INVOKER_LAUNCH_OUTBOX=observe', () => {
-    expect(
-      resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'observe' }),
-    ).toBe('observe');
-  });
-
-  it('returns active when INVOKER_LAUNCH_OUTBOX=active', () => {
-    expect(
-      resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'active' }),
-    ).toBe('active');
-  });
-
-  it('falls back to disabled with a warning for unknown values', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      expect(
-        resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'on' }),
-      ).toBe('disabled');
-      expect(warnSpy).toHaveBeenCalledOnce();
-      expect(warnSpy.mock.calls[0]?.[0]).toMatch(/Unknown INVOKER_LAUNCH_OUTBOX/);
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('is case- and whitespace-insensitive', () => {
-    expect(
-      resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: '  Observe  ' }),
-    ).toBe('observe');
   });
 });

--- a/packages/app/src/__tests__/global-topup.test.ts
+++ b/packages/app/src/__tests__/global-topup.test.ts
@@ -21,14 +21,14 @@ function makeTask(
   } as TaskState;
 }
 
-async function waitForCondition(condition: () => boolean): Promise<void> {
-  for (let i = 0; i < 20; i += 1) {
-    if (condition()) return;
-    await Promise.resolve();
-  }
-}
-
-describe('global-topup helpers', () => {
+/**
+ * The global-topup helpers drive `orchestrator.startExecution()` at
+ * the scheduler boundaries and partition the result into
+ * scoped/runnable/topup buckets. Launch is owned by the outbox
+ * (`task_launch_dispatch`) + `LaunchDispatcher`, so these helpers do
+ * not invoke `taskExecutor.executeTasks` in-process.
+ */
+describe('global-topup helpers (outbox-only)', () => {
   it('keeps cross-workflow prestarted tasks in top-up when a workflow scope is explicit', async () => {
     const scoped = makeTask('wf-1/task-a', 'running', 'attempt-a', 'wf-1');
     const crossWorkflow = makeTask('wf-2/task-b', 'running', 'attempt-b', 'wf-2');
@@ -47,9 +47,7 @@ describe('global-topup helpers', () => {
       scopedWorkflowId: 'wf-1',
     });
 
-    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
     expect(result.runnable).toEqual([scoped]);
     expect(result.topup).toEqual([crossWorkflow]);
@@ -74,15 +72,12 @@ describe('global-topup helpers', () => {
       scopedWorkflowId: 'wf-1',
     });
 
-    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(3);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [crossWorkflow]);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(3, [extraTopup]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(result.runnable).toEqual([scoped]);
     expect(result.topup).toEqual([crossWorkflow, extraTopup]);
   });
 
-  it('dispatches scoped started tasks before running global top-up', async () => {
+  it('partitions scoped started tasks ahead of additional global top-up', async () => {
     const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
     const topupTask = makeTask('topup-task', 'running', 'attempt-topup');
     const orchestrator = {
@@ -99,83 +94,10 @@ describe('global-topup helpers', () => {
       started: [scoped],
     });
 
-    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
-    expect(taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [topupTask]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(orchestrator.startExecution).toHaveBeenCalledTimes(1);
     expect(result.runnable).toEqual([scoped]);
     expect(result.topup).toEqual([topupTask]);
-  });
-
-  it('awaited dispatch waits for executeTasks to finish', async () => {
-    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
-    const release = vi.fn();
-    let resolveDispatch!: () => void;
-    const taskExecutor = {
-      executeTasks: vi.fn(() => new Promise<void>((resolve) => {
-        resolveDispatch = () => {
-          release();
-          resolve();
-        };
-      })),
-    };
-    const dispatch = dispatchStartedTasksWithGlobalTopup({
-      orchestrator: { startExecution: vi.fn().mockReturnValue([]) } as any,
-      taskExecutor: taskExecutor as any,
-      context: 'test.awaited-dispatch',
-      started: [scoped],
-    });
-
-    await Promise.resolve();
-    let completed = false;
-    void dispatch.then(() => { completed = true; });
-    await Promise.resolve();
-
-    expect(completed).toBe(false);
-    resolveDispatch();
-    await dispatch;
-    expect(release).toHaveBeenCalledTimes(1);
-  });
-
-  it('fire-and-forget dispatch returns before executeTasks finishes', async () => {
-    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
-    const taskExecutor = {
-      executeTasks: vi.fn(() => new Promise<void>(() => {})),
-    };
-
-    const result = await dispatchStartedTasksWithGlobalTopup({
-      orchestrator: { startExecution: vi.fn().mockReturnValue([]) } as any,
-      taskExecutor: taskExecutor as any,
-      context: 'test.fire-and-forget-dispatch',
-      started: [scoped],
-      dispatchMode: 'fire-and-forget',
-    });
-
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([scoped]);
-    expect(result.runnable).toEqual([scoped]);
-    expect(result.topup).toEqual([]);
-  });
-
-  it('fire-and-forget dispatch logs asynchronous executeTasks rejection', async () => {
-    const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
-    const logger = { error: vi.fn(), info: vi.fn() };
-    const taskExecutor = {
-      executeTasks: vi.fn().mockRejectedValue(new Error('dispatch failed')),
-    };
-
-    await dispatchStartedTasksWithGlobalTopup({
-      orchestrator: { startExecution: vi.fn().mockReturnValue([]) } as any,
-      taskExecutor: taskExecutor as any,
-      logger: logger as any,
-      context: 'test.fire-and-forget-rejection',
-      started: [scoped],
-      dispatchMode: 'fire-and-forget',
-    });
-
-    await waitForCondition(() => logger.error.mock.calls.length > 0);
-    expect(logger.error).toHaveBeenCalledWith(
-      expect.stringContaining('asynchronous task dispatch failed'),
-    );
   });
 
   it('executeGlobalTopup skips tasks already marked as dispatched', async () => {
@@ -195,12 +117,11 @@ describe('global-topup helpers', () => {
       alreadyDispatched: [scoped],
     });
 
-    expect(taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([topupTask]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(topup).toEqual([topupTask]);
   });
 
-  it('finalizeMutationWithGlobalTopup dispatches started runnable work', async () => {
+  it('finalizeMutationWithGlobalTopup returns the started set without dispatching in-process', async () => {
     const scoped = makeTask('scoped-task', 'running', 'attempt-scoped');
     const orchestrator = {
       startExecution: vi.fn().mockReturnValue([]),
@@ -216,7 +137,7 @@ describe('global-topup helpers', () => {
       started: [scoped],
     });
 
-    expect(taskExecutor.executeTasks).toHaveBeenCalledWith([scoped]);
+    expect(taskExecutor.executeTasks).not.toHaveBeenCalled();
     expect(result.started).toEqual([scoped]);
     expect(result.topup).toEqual([]);
   });

--- a/packages/app/src/__tests__/headless-create-executor.test.ts
+++ b/packages/app/src/__tests__/headless-create-executor.test.ts
@@ -1,11 +1,10 @@
 /**
- * CB.7 acceptance: verifies createHeadlessExecutor's active-mode
- * short-circuit. In `INVOKER_LAUNCH_OUTBOX=active` mode the owner's
- * long-lived TaskRunner is the single launch path (it services the
- * task_launch_dispatch outbox via LaunchDispatcher), so headless
+ * Verifies createHeadlessExecutor's owner-runner short-circuit. The
+ * owner's long-lived TaskRunner is the single launch path (it services
+ * the task_launch_dispatch outbox via LaunchDispatcher), so headless
  * commands must reuse it instead of constructing a per-command
- * TaskRunner — that was the root of Issue 6 (multi-TaskRunner
- * blindness from per-instance `launchingAttemptIds` Sets).
+ * TaskRunner — a per-instance `launchingAttemptIds` Set would break
+ * duplicate-launch suppression across processes.
  */
 import { describe, expect, it, vi } from 'vitest';
 import type { Logger } from '@invoker/contracts';
@@ -47,7 +46,6 @@ function makeDeps(overrides: Partial<HeadlessDeps>): HeadlessDeps {
     commandService: {} as any,
     repoRoot: '/tmp/repo',
     invokerConfig: {
-      launchOutboxMode: 'disabled',
       defaultBranch: 'main',
       docker: {},
       executionPools: {},
@@ -59,17 +57,10 @@ function makeDeps(overrides: Partial<HeadlessDeps>): HeadlessDeps {
   };
 }
 
-describe('createHeadlessExecutor (CB.7 active-mode short-circuit)', () => {
-  it('returns the owner TaskRunner when launchOutboxMode=active and the provider yields one', () => {
+describe('createHeadlessExecutor (owner-runner short-circuit)', () => {
+  it('returns the owner TaskRunner when the provider yields one', () => {
     const owner = fakeOwnerTaskRunner();
     const deps = makeDeps({
-      invokerConfig: {
-        launchOutboxMode: 'active',
-        defaultBranch: 'main',
-        docker: {},
-        executionPools: {},
-        remoteTargets: {},
-      } as any,
       ownerTaskRunnerProvider: () => owner,
     });
 
@@ -82,13 +73,6 @@ describe('createHeadlessExecutor (CB.7 active-mode short-circuit)', () => {
     const logger = makeLogger();
     const deps = makeDeps({
       logger,
-      invokerConfig: {
-        launchOutboxMode: 'active',
-        defaultBranch: 'main',
-        docker: {},
-        executionPools: {},
-        remoteTargets: {},
-      } as any,
       ownerTaskRunnerProvider: () => owner,
     });
 
@@ -100,61 +84,23 @@ describe('createHeadlessExecutor (CB.7 active-mode short-circuit)', () => {
     expect(debugRecord).toBeDefined();
   });
 
-  it('warns and falls back to constructing a fresh TaskRunner when active but no owner is available', () => {
+  it('falls through to constructing a fresh TaskRunner when no owner provider is available', () => {
     const logger = makeLogger();
     const deps = makeDeps({
       logger,
-      invokerConfig: {
-        launchOutboxMode: 'active',
-        defaultBranch: 'main',
-        docker: {},
-        executionPools: {},
-        remoteTargets: {},
-      } as any,
-      // No ownerTaskRunnerProvider — simulates a true standalone owner
-      // that hasn't initialised its TaskRunner yet.
+      // No ownerTaskRunnerProvider — TaskRunner construction may fail
+      // with minimal deps; either outcome is fine, we only care that
+      // the owner short-circuit did not fire.
     });
 
-    // The constructor of TaskRunner requires real shared services to
-    // succeed; for this test we only care that the active branch took
-    // the fallback path (warning emitted) before any throw. We catch
-    // any constructor-time error so we can assert on the warning
-    // independently.
     let threw = false;
     try {
       createHeadlessExecutor(deps);
     } catch {
       threw = true;
     }
-    void threw; // either outcome is acceptable for this assertion
-    const warn = logger.records.find(
-      (r) => r.level === 'warn' && r.msg.includes('ownerTaskRunnerProvider is unavailable'),
-    );
-    expect(warn).toBeDefined();
-  });
-
-  it('does not short-circuit when launchOutboxMode is not active', () => {
-    const owner = fakeOwnerTaskRunner();
-    const providerCalls = vi.fn(() => owner);
-    const deps = makeDeps({
-      invokerConfig: {
-        launchOutboxMode: 'observe',
-        defaultBranch: 'main',
-        docker: {},
-        executionPools: {},
-        remoteTargets: {},
-      } as any,
-      ownerTaskRunnerProvider: providerCalls,
-    });
-
-    // We expect a real TaskRunner construction to fail in this minimal
-    // env; that's fine — what we're asserting is that the provider was
-    // *not* consulted (the legacy code path was taken).
-    try {
-      createHeadlessExecutor(deps);
-    } catch {
-      // swallow — verifying the provider call below
-    }
-    expect(providerCalls).not.toHaveBeenCalled();
+    void threw;
+    const warn = logger.records.find((r) => r.level === 'warn');
+    expect(warn).toBeUndefined();
   });
 });

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -625,21 +625,18 @@ describe('headless delegation enforcement', () => {
           config: { workflowId: 'wf-1' },
           execution: {},
         } as any;
-        mockDeps.commandService.approve = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
-
-        const executeTasksSpy = vi
-          .spyOn(TaskRunner.prototype, 'executeTasks')
-          .mockImplementation(async () => {
+        mockDeps.commandService.approve = vi.fn(async () => {
+          // Stand in for the LaunchDispatcher settling the row.
+          setTimeout(() => {
             taskBStatus = 'completed';
-          });
+          }, 5);
+          return { ok: true as const, data: [runnableTask] };
+        });
 
         await runHeadless(['approve', 'wf-1/task-a'], mockDeps);
 
-        expect(executeTasksSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-        expect(executeTasksSpy).toHaveBeenCalledWith([runnableTask]);
         expect(mockDeps.commandService.approve).toHaveBeenCalled();
-
-        executeTasksSpy.mockRestore();
+        expect(taskBStatus).toBe('completed');
       });
 
       // Step 16: pin headless approve/reject routing.
@@ -752,20 +749,17 @@ describe('headless delegation enforcement', () => {
           config: { workflowId: 'wf-1' },
           execution: {},
         } as any;
-        mockDeps.commandService.approve = vi.fn(async () => ({ ok: true as const, data: [runnableTask] }));
-
-        const executeTasksSpy = vi
-          .spyOn(TaskRunner.prototype, 'executeTasks')
-          .mockImplementation(async () => {
-            taskBStatus = 'pending';
-          });
+        mockDeps.commandService.approve = vi.fn(async () => {
+          // Stand in for the LaunchDispatcher draining the row.
+          taskBStatus = 'pending';
+          return { ok: true as const, data: [runnableTask] };
+        });
 
         await expect(runHeadless(['approve', 'wf-1/task-a'], mockDeps)).resolves.toBeUndefined();
 
-        expect(executeTasksSpy).toHaveBeenCalledTimes(1);
+        expect(mockDeps.commandService.approve).toHaveBeenCalled();
         expect(mockDeps.orchestrator.getReadyTasks).toHaveBeenCalled();
-
-        executeTasksSpy.mockRestore();
+        expect(taskBStatus).toBe('pending');
       });
 
       it('headless retry with deps.noTrack=true can defer runnable execution to the caller', async () => {

--- a/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
+++ b/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
@@ -11,17 +11,16 @@
  *    before the watchdog failed them with the misleading
  *    "60 seconds" error message.
  *
- * This test reproduces the steady-state shape in-process: 38 single-task
+ * The first case reproduces the original orphan shape: 38 single-task
  * plans are loaded, `startExecution()` is called to claim every
- * attempt, and **no TaskRunner is wired in** — exactly the fragile
- * seam the re-architecture is meant to eliminate.
+ * attempt, and **no LaunchDispatcher polls the outbox** — so the
+ * outbox rows accumulate but are never serviced. The invariant must
+ * detect this (`no_terminal_event` violations). This stands in for
+ * the worst-case "owner crashed before dispatching" scenario.
  *
- * The test is marked `it.fails` so CI stays green while the bug is
- * documented. The Phase B definition of done (see
- * .cursor/plans/launch_handoff_rearchitecture_c13d3ffc.plan.md) calls
- * for removing the `.fails` marker once the durable
- * `task_launch_dispatch` outbox dispatcher is active and resolves
- * every claim.
+ * The second case wires the LaunchDispatcher (which is always-on in
+ * production) and verifies the invariant holds end-to-end: every
+ * claim reaches a terminal launch event.
  */
 
 import { afterEach, describe, expect, it } from 'vitest';
@@ -49,8 +48,8 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
     }
   });
 
-  it.fails(
-    'a 38-claim rebase-recreate storm without a dispatcher orphans every claim',
+  it(
+    'a 38-claim rebase-recreate storm with no dispatcher polling still orphans every claim (invariant detects it)',
     async () => {
       const persistence = await SQLiteAdapter.create(':memory:');
       adapters.push(persistence);
@@ -109,26 +108,27 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
         );
       expect(terminalCount).toBe(0);
 
+      let caught: unknown = null;
       try {
         assertLaunchInvariant(persistence, {
           maxGapMs: TIGHT_MAX_GAP_MS,
           nowMs: Date.now() + PRETEND_LATER_MS,
         });
       } catch (err) {
-        expect(err).toBeInstanceOf(LaunchInvariantViolationError);
-        const violation = err as LaunchInvariantViolationError;
-        expect(violation.summary.claimCount).toBe(STORM_SIZE);
-        expect(violation.violations).toHaveLength(STORM_SIZE);
-        for (const v of violation.violations) {
-          expect(v.reason).toBe('no_terminal_event');
-        }
-        throw err;
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(LaunchInvariantViolationError);
+      const violation = caught as LaunchInvariantViolationError;
+      expect(violation.summary.claimCount).toBe(STORM_SIZE);
+      expect(violation.violations).toHaveLength(STORM_SIZE);
+      for (const v of violation.violations) {
+        expect(v.reason).toBe('no_terminal_event');
       }
     },
   );
 
   it(
-    'with INVOKER_LAUNCH_OUTBOX=active, the LaunchDispatcher resolves every claim into a terminal event',
+    'with the LaunchDispatcher polling, every claim resolves to a terminal event',
     async () => {
       // CB.5 acceptance: wire the same 38-claim storm through the durable
       // outbox dispatcher (orchestrator -> task_launch_dispatch ->
@@ -142,10 +142,6 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
         messageBus: new InMemoryBus(),
         maxConcurrency: STORM_SIZE,
         deferRunningUntilLaunch: true,
-        // Active mode causes drainScheduler to write the outbox row alongside
-        // the durable launch claim — that row is what the LaunchDispatcher
-        // polls below.
-        launchOutboxMode: 'active',
       });
 
       const startedTasks: TaskState[] = [];
@@ -177,7 +173,6 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
         },
         taskRunnerProvider: () => fakeTaskRunner,
         ownerId: 'cb5-test-owner',
-        mode: 'active',
         maxConcurrency: STORM_SIZE,
         maxLeasesPerPoll: STORM_SIZE,
       });

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -36,91 +36,22 @@ describe('LaunchDispatcher', () => {
     expect(() => new LaunchDispatcher({
       persistence: adapter,
       ownerId: 'owner-test',
-      mode: 'observe',
     })).not.toThrow();
   });
 
-  it('observer mode logs state counts and does not mutate rows', () => {
-    adapter.saveWorkflow({
-      id: 'wf-1',
-      name: 'wf-1',
-      status: 'running',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    });
-    adapter.saveTask('wf-1', {
-      id: 'wf-1/t1',
-      description: 'one',
-      status: 'pending',
-      dependencies: [],
-      createdAt: new Date(),
-      config: { workflowId: 'wf-1' },
-      execution: {},
-      taskStateVersion: 1,
-    });
-    const enqueued = adapter.enqueueLaunchDispatch({
-      taskId: 'wf-1/t1',
-      attemptId: 'attempt-1',
-      workflowId: 'wf-1',
-      generation: 0,
-    });
-
-    const logger = makeLogger();
-    const dispatcher = new LaunchDispatcher({
-      persistence: adapter,
-      ownerId: 'owner-test',
-      logger,
-      mode: 'observe',
-    });
-
-    dispatcher.poll();
-
-    const observed = logger.records.find((entry) => entry.msg.includes('observed'));
-    expect(observed).toBeDefined();
-    expect(observed?.fields?.total).toBe(1);
-    const counts = observed?.fields?.counts as Record<string, number> | undefined;
-    expect(counts?.enqueued).toBe(1);
-    expect(counts?.leased).toBe(0);
-    expect(counts?.acknowledged).toBe(0);
-
-    const afterPoll = adapter.loadLaunchDispatchById(enqueued.id);
-    expect(afterPoll).toMatchObject({ state: 'enqueued' });
-  });
-
-  it('active mode without a taskRunnerProvider warns and does not dispatch', () => {
-    const listSpy = vi.spyOn(adapter, 'listLaunchDispatchesByState');
+  it('without a taskRunnerProvider, poll warns and does not lease anything', () => {
     const claimSpy = vi.spyOn(adapter, 'claimLaunchDispatchAtomic');
     const logger = makeLogger();
     const dispatcher = new LaunchDispatcher({
       persistence: adapter,
       ownerId: 'owner-test',
       logger,
-      mode: 'active',
     });
     expect(() => dispatcher.poll()).not.toThrow();
     expect(claimSpy).not.toHaveBeenCalled();
     const warn = logger.records.find((entry) => entry.level === 'warn');
-    expect(warn?.msg).toMatch(/active mode without taskRunner/);
-    // Active mode never observes (no aggregate log) — observation is the
-    // observer-mode tail and the reapers don't need it.
-    expect(listSpy).not.toHaveBeenCalled();
-    listSpy.mockRestore();
+    expect(warn?.msg).toMatch(/no taskRunner available/);
     claimSpy.mockRestore();
-  });
-
-  it('observer mode reports zero counts when the outbox is empty', () => {
-    const logger = makeLogger();
-    const dispatcher = new LaunchDispatcher({
-      persistence: adapter,
-      ownerId: 'owner-test',
-      logger,
-      mode: 'observe',
-    });
-
-    dispatcher.poll();
-
-    const observed = logger.records.find((entry) => entry.msg.includes('observed'));
-    expect(observed?.fields?.total).toBe(0);
   });
 
   describe('ack / complete / fail transitions', () => {
@@ -151,7 +82,6 @@ describe('LaunchDispatcher', () => {
           persistence: adapter,
           ownerId: 'owner-test',
           logger,
-          mode: 'observe',
         }),
       };
     }
@@ -312,7 +242,6 @@ describe('LaunchDispatcher', () => {
         orchestrator,
         ownerId: 'owner-test',
         logger,
-        mode: 'observe',
         maxAttempts: 2,
       });
       return { dispatcher, logger };
@@ -531,7 +460,7 @@ describe('LaunchDispatcher', () => {
       expect(prepare).not.toHaveBeenCalled();
     });
 
-    it('poll() runs reapers in both observer and active modes', () => {
+    it('poll() reaps expired leases before attempting dispatch', () => {
       seed();
       const row = adapter.enqueueLaunchDispatch({
         taskId: 'wf-r/t1',
@@ -545,17 +474,16 @@ describe('LaunchDispatcher', () => {
         [pastIso, row.id],
       );
 
-      const observer = new LaunchDispatcher({
+      const dispatcher = new LaunchDispatcher({
         persistence: adapter,
-        ownerId: 'observer',
-        mode: 'observe',
+        ownerId: 'owner-r',
       });
-      observer.poll();
+      dispatcher.poll();
       expect(adapter.loadLaunchDispatchById(row.id)?.state).toBe('enqueued');
     });
   });
 
-  describe('active mode dispatch (CB.5)', () => {
+  describe('dispatch loop', () => {
     function seedWorkflowAndTask(taskId: string, workflowId = 'wf-a') {
       adapter.saveWorkflow({
         id: workflowId,
@@ -578,7 +506,7 @@ describe('LaunchDispatcher', () => {
       return task;
     }
 
-    it('active mode leases an enqueued row and hands it to the TaskRunner', () => {
+    it('leases an enqueued row and hands it to the TaskRunner', () => {
       const task = seedWorkflowAndTask('wf-a/t1');
       const enq = adapter.enqueueLaunchDispatch({
         taskId: task.id,
@@ -598,7 +526,6 @@ describe('LaunchDispatcher', () => {
           getTask,
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
         maxConcurrency: 4,
       });
       dispatcher.poll();
@@ -617,7 +544,7 @@ describe('LaunchDispatcher', () => {
       expect(after?.dispatchOwner).toBe('owner-a');
     });
 
-    it('active mode loops until maxLeasesPerPoll is reached', () => {
+    it('loops until maxLeasesPerPoll is reached', () => {
       for (let i = 0; i < 3; i += 1) {
         seedWorkflowAndTask(`wf-a/t${i}`);
       }
@@ -649,7 +576,6 @@ describe('LaunchDispatcher', () => {
           getTask,
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
         maxConcurrency: 10,
         maxLeasesPerPoll: 2,
       });
@@ -657,7 +583,7 @@ describe('LaunchDispatcher', () => {
       expect(executeTask).toHaveBeenCalledTimes(2);
     });
 
-    it('active mode fails the dispatch when the orchestrator has no matching task', () => {
+    it('fails the dispatch when the orchestrator has no matching task', () => {
       seedWorkflowAndTask('wf-a/t-missing');
       const enq = adapter.enqueueLaunchDispatch({
         taskId: 'wf-a/t-missing',
@@ -674,7 +600,6 @@ describe('LaunchDispatcher', () => {
           getTask: vi.fn().mockReturnValue(undefined),
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
         maxConcurrency: 4,
       });
       dispatcher.poll();
@@ -687,7 +612,7 @@ describe('LaunchDispatcher', () => {
       expect(after?.lastError).toMatch(/missing from orchestrator state/);
     });
 
-    it('active mode is a no-op when the queue is empty', () => {
+    it('is a no-op when the queue is empty', () => {
       const executeTask = vi.fn();
       const dispatcher = new LaunchDispatcher({
         persistence: adapter,
@@ -697,14 +622,13 @@ describe('LaunchDispatcher', () => {
           getTask: vi.fn(),
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
         maxConcurrency: 4,
       });
       dispatcher.poll();
       expect(executeTask).not.toHaveBeenCalled();
     });
 
-    it('active mode catches runner promise rejections via failDispatch backstop', async () => {
+    it('catches runner promise rejections via failDispatch backstop', async () => {
       const task = seedWorkflowAndTask('wf-a/t-throw');
       const enq = adapter.enqueueLaunchDispatch({
         taskId: task.id,
@@ -721,7 +645,6 @@ describe('LaunchDispatcher', () => {
           getTask: vi.fn().mockReturnValue(task as any),
         },
         taskRunnerProvider: () => ({ executeTask }),
-        mode: 'active',
         maxConcurrency: 4,
       });
       dispatcher.poll();

--- a/packages/app/src/__tests__/parity-regression.test.ts
+++ b/packages/app/src/__tests__/parity-regression.test.ts
@@ -9,8 +9,9 @@
  *
  * Test groups:
  *   1. Facade dispatch+topup lifecycle — every mutation method
- *      filters runnable tasks, dispatches via taskExecutor, then
- *      calls startExecution for global topup with deduplication.
+ *      filters runnable tasks and calls startExecution for global
+ *      topup with deduplication. Launch is owned by the outbox so
+ *      the facade does not call taskExecutor.executeTasks directly.
  *   2. API server → facade wiring — HTTP endpoints call the correct
  *      facade method and return the structured result.
  *   3. Headless → commandService routing — headless CLI verbs
@@ -170,16 +171,10 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
     it(`${name}: follows dispatch+topup lifecycle and returns MutationResult shape`, async () => {
       const result = await invoke(facade);
 
-      // Correct orchestrator method was called
       expect((deps.orchestrator as any)[orchestratorMethod]).toHaveBeenCalled();
-
-      // Runnable tasks dispatched via executor
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
-
-      // Global topup invoked (startExecution)
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
       expect(deps.orchestrator.startExecution).toHaveBeenCalled();
 
-      // Result has the canonical MutationResult shape
       expect(result).toHaveProperty('started');
       expect(result).toHaveProperty('runnable');
       expect(result).toHaveProperty('topup');
@@ -189,7 +184,7 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
     });
   }
 
-  it('all mutations filter non-running tasks from dispatch', async () => {
+  it('all mutations filter non-running tasks out of the runnable launch set', async () => {
     // Orchestrator returns a mix of running and pending tasks
     const mixed = [makeTask({ id: 'task-1', status: 'running' }), makePendingTask({ id: 't2' })];
     (deps.orchestrator as any).retryTask.mockReturnValue(mixed);
@@ -197,15 +192,12 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
 
     const result = await facade.retryTask('task-1');
 
-    // Only the running task should be dispatched
     expect(result.runnable).toHaveLength(1);
     expect(result.runnable[0].id).toBe('task-1');
-    expect(deps.taskExecutor.executeTasks).toHaveBeenCalledWith([
-      expect.objectContaining({ id: 'task-1', status: 'running' }),
-    ]);
+    expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
-  it('topup deduplicates tasks already dispatched in scoped phase', async () => {
+  it('topup deduplicates attempts already in the scoped runnable set', async () => {
     const scoped = makeTask({
       id: 'task-1',
       execution: { selectedAttemptId: 'attempt-1' },
@@ -219,12 +211,12 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
 
     const result = await facade.retryTask('task-1');
 
-    // Scoped dispatch happens, but topup should NOT re-dispatch
-    expect(deps.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
+    expect(result.runnable).toHaveLength(1);
     expect(result.topup).toHaveLength(0);
+    expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 
-  it('topup dispatches genuinely new tasks from global pool', async () => {
+  it('topup includes genuinely new tasks from the global pool', async () => {
     const scoped = makeTask({
       id: 'task-1',
       execution: { selectedAttemptId: 'attempt-1' },
@@ -240,10 +232,10 @@ describe('Parity: facade dispatch+topup lifecycle', () => {
 
     const result = await facade.retryTask('task-1');
 
-    // Two dispatch calls: scoped + topup
-    expect(deps.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
+    expect(result.runnable).toHaveLength(1);
     expect(result.topup).toHaveLength(1);
     expect(result.topup[0].id).toBe('wf-2/task-9');
+    expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/app/src/__tests__/workflow-mutation-facade.test.ts
+++ b/packages/app/src/__tests__/workflow-mutation-facade.test.ts
@@ -84,43 +84,43 @@ describe('WorkflowMutationFacade', () => {
   });
 
   describe('retryTask', () => {
-    it('calls orchestrator.retryTask and dispatches runnable tasks', async () => {
+    it('calls orchestrator.retryTask and returns started tasks for outbox dispatch', async () => {
       const result = await facade.retryTask('task-a');
 
       expect(deps.orchestrator.retryTask).toHaveBeenCalledWith('task-a');
       expect(result.started).toHaveLength(1);
       expect(result.started[0].status).toBe('running');
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 
   describe('recreateTask', () => {
-    it('calls orchestrator.recreateTask and dispatches runnable tasks', async () => {
+    it('calls orchestrator.recreateTask and returns started tasks for outbox dispatch', async () => {
       const result = await facade.recreateTask('task-a');
 
       expect(deps.orchestrator.recreateTask).toHaveBeenCalledWith('task-a');
       expect(result.started).toHaveLength(1);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 
   describe('editTaskCommand', () => {
-    it('calls orchestrator.editTaskCommand and dispatches runnable tasks', async () => {
+    it('calls orchestrator.editTaskCommand and returns started tasks for outbox dispatch', async () => {
       const result = await facade.editTaskCommand('task-a', 'new-cmd');
 
       expect(deps.orchestrator.editTaskCommand).toHaveBeenCalledWith('task-a', 'new-cmd');
       expect(result.started).toHaveLength(1);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 
   describe('editTaskPrompt', () => {
-    it('calls orchestrator.editTaskPrompt and dispatches runnable tasks', async () => {
+    it('calls orchestrator.editTaskPrompt and returns started tasks for outbox dispatch', async () => {
       const result = await facade.editTaskPrompt('task-a', 'new prompt');
 
       expect(deps.orchestrator.editTaskPrompt).toHaveBeenCalledWith('task-a', 'new prompt');
       expect(result.started).toHaveLength(1);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 
@@ -134,7 +134,7 @@ describe('WorkflowMutationFacade', () => {
   });
 
   describe('editTaskAgent', () => {
-    it('calls orchestrator.editTaskAgent and dispatches', async () => {
+    it('calls orchestrator.editTaskAgent and returns started tasks for outbox dispatch', async () => {
       const result = await facade.editTaskAgent('task-a', 'claude');
 
       expect(deps.orchestrator.editTaskAgent).toHaveBeenCalledWith('task-a', 'claude');
@@ -231,14 +231,15 @@ describe('WorkflowMutationFacade', () => {
   });
 
   describe('forkWorkflow', () => {
-    it('forks and dispatches runnable tasks', async () => {
+    it('forks and dispatches runnable tasks in-process', async () => {
       const result = await facade.forkWorkflow('wf-1');
 
       expect(deps.orchestrator.forkWorkflow).toHaveBeenCalledWith('wf-1');
       expect(result.forkedWorkflowId).toBe('wf-fork');
       expect(result.sourceWorkflowId).toBe('wf-1');
       expect(result.runnable).toHaveLength(1);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
+      expect(deps.taskExecutor.executeTasks).toHaveBeenCalledWith(result.runnable);
     });
   });
 
@@ -294,7 +295,7 @@ describe('WorkflowMutationFacade', () => {
   });
 
   describe('retryWorkflow', () => {
-    it('calls orchestrator.retryWorkflow and dispatches', async () => {
+    it('calls orchestrator.retryWorkflow and returns started tasks for outbox dispatch', async () => {
       const result = await facade.retryWorkflow('wf-1');
 
       expect(deps.orchestrator.retryWorkflow).toHaveBeenCalledWith('wf-1');
@@ -315,7 +316,7 @@ describe('WorkflowMutationFacade', () => {
 
       expect(result.started).toHaveLength(1);
       expect(result.runnable).toHaveLength(1);
-      expect(deps.taskExecutor.executeTasks).toHaveBeenCalled();
+      expect(deps.taskExecutor.executeTasks).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -206,34 +206,7 @@ export interface InvokerConfig {
     /** Routing strategy. Defaults to "enforce". */
     strategy?: 'enforce' | 'route';
   }>;
-  /**
-   * Launch-handoff outbox mode (Phase A of the launch-handoff
-   * re-architecture). Resolved from the INVOKER_LAUNCH_OUTBOX env var:
-   * - "disabled" (default): legacy in-memory dispatch only.
-   * - "observe": orchestrator writes task_launch_dispatch rows alongside
-   *   the existing claim path; LaunchDispatcher polls and logs counts but
-   *   does not own dispatch.
-   * - "active": LaunchDispatcher is the source of truth for dispatch
-   *   (Phase B, default in production).
-   *
-   * Unknown values fall back to "disabled" with a console warning.
-   *
-   * CC.6 deferral: the plan's Phase C calls for removing this flag
-   * entirely once the outbox has dogfooded clean. That deletion is
-   * left as a follow-up because the test surface still flips between
-   * 'observe' / 'active' / 'disabled' to exercise both code paths
-   * (see launch-dispatcher.test.ts active-mode suite,
-   * launch-claim-orphan-regression.test.ts active-mode passing test,
-   * and several headless-delegation parity cases). Each Phase C
-   * cleanup is independently revertable per the plan; CC.6 stays
-   * documented-but-deferred so the production env-var rollout (and
-   * the ability to flip back to observe mode in a hot incident) is
-   * preserved while the dispatcher matures.
-   */
-  launchOutboxMode?: LaunchOutboxMode;
 }
-
-export type LaunchOutboxMode = 'disabled' | 'observe' | 'active';
 
 function readJsonSafe(path: string): InvokerConfig {
   if (!existsSync(path)) {
@@ -260,31 +233,7 @@ export function loadConfig(): InvokerConfig {
   const base = process.env.INVOKER_REPO_CONFIG_PATH
     ? readJsonSafe(process.env.INVOKER_REPO_CONFIG_PATH)
     : readJsonSafe(join(homedir(), '.invoker', 'config.json'));
-  base.launchOutboxMode = resolveLaunchOutboxMode();
   return base;
-}
-
-/**
- * Resolve the launch-outbox feature-flag mode from the
- * `INVOKER_LAUNCH_OUTBOX` env var.
- *
- * Returns `'disabled'` when the var is unset, empty, or holds an
- * unrecognised value (with a console warning for unknown values so
- * operators notice typos like `INVOKER_LAUNCH_OUTBOX=on`).
- */
-export function resolveLaunchOutboxMode(
-  env: NodeJS.ProcessEnv = process.env,
-): LaunchOutboxMode {
-  const raw = env.INVOKER_LAUNCH_OUTBOX;
-  if (typeof raw !== 'string' || raw.trim() === '') return 'disabled';
-  const normalized = raw.trim().toLowerCase();
-  if (normalized === 'disabled' || normalized === 'observe' || normalized === 'active') {
-    return normalized;
-  }
-  console.warn(
-    `[config] Unknown INVOKER_LAUNCH_OUTBOX value "${raw}"; falling back to "disabled".`,
-  );
-  return 'disabled';
 }
 
 export type EmbeddedTerminalBackendConfig = 'bash' | 'pty';

--- a/packages/app/src/global-topup.ts
+++ b/packages/app/src/global-topup.ts
@@ -1,35 +1,13 @@
 /**
  * Post-mutation scheduler refill helpers.
  *
- * Phase B (CB.5) short-circuited the in-process dispatch path:
- * when the launch outbox is `'active'` the helpers stop at
- * `orchestrator.startExecution()` (which writes
- * task_launch_dispatch rows via drainScheduler). The
- * LaunchDispatcher's poll loop is the single launch path from
- * there, so `taskExecutor.executeTasks(runnable)` is no longer
- * invoked in that mode.
- *
- * Phase C (CC.4) was meant to delete the legacy fire-and-forget
- * fallback wholesale. That deletion has been left as a follow-up
- * because the existing test surface (~40 cases in
- * api-server.test.ts, parity-regression.test.ts,
- * app-layer-handoff-repro.test.ts, workflow-mutation-facade.test.ts,
- * bridge-orchestrator-executor.test.ts, headless-delegation.test.ts)
- * still asserts on `taskExecutor.executeTasks` being called via
- * these helpers, and CB.4's duplicate-launch suppression already
- * makes the in-process call functionally idempotent. Each Phase C
- * cleanup commit is independently revertable per the plan's
- * Risks-and-Mitigations note; CC.4's full deletion remains
- * available behind a follow-up PR once those callers have been
- * updated.
- *
- * What still happens here, mode-by-mode:
- *   - `'active'`: helpers call `orchestrator.startExecution()` and
- *     return; the in-process executeTasks call is skipped (see
- *     CB.5).
- *   - `'observe'` / `'disabled'`: helpers preserve the legacy
- *     fire-and-forget behaviour so a flag rollback has zero other
- *     code changes.
+ * The durable `task_launch_dispatch` outbox is the single launch path:
+ * `orchestrator.startExecution()` writes outbox rows for every claimed
+ * attempt via `drainScheduler`, and the `LaunchDispatcher` poll loop
+ * leases and dispatches them. These helpers exist to drive
+ * `startExecution()` at the right scheduler boundaries (post-mutation
+ * top-up, scoped vs. global drain) and to surface the resulting
+ * runnable set to the caller for logging/telemetry.
  */
 
 import type { Logger } from '@invoker/contracts';
@@ -37,20 +15,6 @@ import type { Orchestrator, TaskState } from '@invoker/workflow-core';
 import type { TaskRunner } from '@invoker/execution-engine';
 import { createExecutionBench } from '@invoker/execution-engine';
 import type { WorkflowMutationTiming } from './workflow-mutation-timing.js';
-
-export type LaunchOutboxMode = 'disabled' | 'observe' | 'active';
-
-/**
- * Resolve the launch-outbox mode for a dispatch call. Explicit
- * arguments take precedence over the process-wide env-var fallback so
- * tests can run multiple modes in the same process; the env var is the
- * production wiring (see `resolveLaunchOutboxMode` in config.ts).
- */
-function resolveLaunchOutboxMode(explicit?: LaunchOutboxMode): LaunchOutboxMode {
-  if (explicit) return explicit;
-  const raw = (process.env.INVOKER_LAUNCH_OUTBOX ?? '').toLowerCase().trim();
-  return raw === 'active' || raw === 'observe' ? raw : 'disabled';
-}
 
 type GlobalTopupParams = {
   orchestrator: Orchestrator;
@@ -60,16 +24,6 @@ type GlobalTopupParams = {
   alreadyDispatched?: TaskState[];
   mutationTiming?: WorkflowMutationTiming;
   dispatchMode?: 'await' | 'fire-and-forget';
-  /**
-   * When the durable launch-outbox dispatcher is `'active'`, the
-   * in-process `taskExecutor.executeTasks` call becomes a no-op
-   * because the orchestrator's drainScheduler already enqueues into
-   * `task_launch_dispatch` and the LaunchDispatcher polls and
-   * services that queue. We still walk the rest of the top-up
-   * pipeline (logging, bench marks, return shape) so callers see
-   * the same metadata regardless of mode.
-   */
-  launchOutboxMode?: LaunchOutboxMode;
 };
 
 type MutationTopupParams = {
@@ -82,7 +36,6 @@ type MutationTopupParams = {
   scopedTaskIds?: string[];
   mutationTiming?: WorkflowMutationTiming;
   dispatchMode?: 'await' | 'fire-and-forget';
-  launchOutboxMode?: LaunchOutboxMode;
 };
 
 function runningExecutionKey(task: TaskState): string {
@@ -122,63 +75,33 @@ function matchesScope(
     || scopedTaskIds.has(task.id);
 }
 
+/**
+ * Record bench/log telemetry for a set of runnables already enqueued
+ * to the launch outbox by `orchestrator.startExecution()`.
+ */
 function dispatchTasks({
-  taskExecutor,
   logger,
   context,
   runnable,
-  mutationTiming,
   bench,
   spanName,
   beforeMark,
   afterMark,
-  dispatchMode,
-  launchOutboxMode,
 }: {
-  taskExecutor: TaskRunner;
   logger?: Logger;
   context: string;
   runnable: TaskState[];
-  mutationTiming?: WorkflowMutationTiming;
   bench: (phase: string, metadata?: Record<string, unknown>) => void;
   spanName: string;
   beforeMark: string;
   afterMark: string;
-  dispatchMode: 'await' | 'fire-and-forget';
-  launchOutboxMode?: LaunchOutboxMode;
 }): Promise<void> {
   bench(beforeMark);
-  const effectiveMode = resolveLaunchOutboxMode(launchOutboxMode);
-  if (effectiveMode === 'active') {
-    // The durable launch outbox is the dispatcher in active mode. The
-    // orchestrator's drainScheduler already enqueued each runnable into
-    // task_launch_dispatch, and the LaunchDispatcher's poll loop calls
-    // taskExecutor.executeTask(task, dispatchOpts). Calling
-    // taskExecutor.executeTasks(runnable) here would race the outbox.
-    logger?.debug?.(
-      `[global-topup] ${context}: launchOutboxMode=active — outbox dispatcher owns launch (skipping in-process executeTasks)`,
-    );
-    bench(`${afterMark}.skippedForOutbox`, { runnableCount: runnable.length });
-    return Promise.resolve();
-  }
-  const run = () => taskExecutor.executeTasks(runnable);
-  if (dispatchMode === 'await') {
-    return mutationTiming
-      ? mutationTiming.span(spanName, { context, runnableCount: runnable.length }, run)
-        .then(() => bench(afterMark))
-      : Promise.resolve().then(run).then(() => bench(afterMark));
-  }
-
-  const dispatchPromise = mutationTiming
-    ? mutationTiming.span(spanName, { context, runnableCount: runnable.length }, run)
-    : Promise.resolve().then(run);
-  void dispatchPromise
-    .then(() => bench(afterMark))
-    .catch((err) => {
-      const message = err instanceof Error ? err.stack ?? err.message : String(err);
-      logger?.error(`[global-topup] ${context}: asynchronous task dispatch failed: ${message}`);
-  });
-  bench(`${afterMark}.accepted`);
+  void spanName;
+  logger?.debug?.(
+    `[global-topup] ${context}: ${runnable.length} task(s) enqueued to launch outbox (LaunchDispatcher owns dispatch)`,
+  );
+  bench(`${afterMark}.enqueuedToOutbox`, { runnableCount: runnable.length });
   return Promise.resolve();
 }
 
@@ -191,7 +114,6 @@ function executeRunnableTasks({
   mutationTiming,
   spanName,
   dispatchMode,
-  launchOutboxMode,
 }: {
   taskExecutor: TaskRunner;
   logger?: Logger;
@@ -201,24 +123,22 @@ function executeRunnableTasks({
   mutationTiming?: WorkflowMutationTiming;
   spanName: string;
   dispatchMode: 'await' | 'fire-and-forget';
-  launchOutboxMode?: LaunchOutboxMode;
 }): Promise<void> {
+  void taskExecutor;
+  void mutationTiming;
+  void dispatchMode;
   const bench = createDispatchBench(logger, context, runnable, dispatchKind);
   const phasePrefix = dispatchKind === 'scoped'
     ? 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks'
     : 'dispatchStartedTasksWithGlobalTopup.prestartedTopupExecuteTasks';
   return dispatchTasks({
-    taskExecutor,
     logger,
     context,
     runnable,
-    mutationTiming,
     bench,
     spanName,
     beforeMark: `${phasePrefix}.before`,
     afterMark: `${phasePrefix}.after`,
-    dispatchMode,
-    launchOutboxMode,
   });
 }
 
@@ -244,8 +164,9 @@ export async function executeGlobalTopup({
   alreadyDispatched = [],
   mutationTiming,
   dispatchMode = mutationTiming ? 'fire-and-forget' : 'await',
-  launchOutboxMode,
 }: GlobalTopupParams): Promise<TaskState[]> {
+  void taskExecutor;
+  void dispatchMode;
   const dedupeKeys = new Set(
     alreadyDispatched
       .filter(isDispatchableLaunch)
@@ -279,17 +200,13 @@ export async function executeGlobalTopup({
     `[global-topup] ${context}: dispatching ${runnable.length} additional task(s): [${runnable.map((task) => task.id).join(', ')}]`,
   );
   await dispatchTasks({
-    taskExecutor,
     logger,
     context,
     runnable,
-    mutationTiming,
     bench,
     spanName: 'executeGlobalTopup.taskExecutor.executeTasks',
     beforeMark: 'executeGlobalTopup.taskExecutor.executeTasks.before',
     afterMark: 'executeGlobalTopup.taskExecutor.executeTasks.after',
-    dispatchMode,
-    launchOutboxMode,
   });
   return runnable;
 }
@@ -308,7 +225,6 @@ export async function dispatchStartedTasksWithGlobalTopup({
   scopedTaskIds,
   mutationTiming,
   dispatchMode = mutationTiming ? 'fire-and-forget' : 'await',
-  launchOutboxMode,
 }: MutationTopupParams): Promise<{ runnable: TaskState[]; topup: TaskState[] }> {
   const dispatchable = started.filter(isDispatchableLaunch);
   const scopedTaskIdSet = new Set(scopedTaskIds ?? []);
@@ -334,7 +250,6 @@ export async function dispatchStartedTasksWithGlobalTopup({
       mutationTiming,
       spanName: 'dispatchStartedTasksWithGlobalTopup.scopedExecuteTasks',
       dispatchMode,
-      launchOutboxMode,
     });
   } else {
     bench('dispatchStartedTasksWithGlobalTopup.noScopedRunnable');
@@ -352,7 +267,6 @@ export async function dispatchStartedTasksWithGlobalTopup({
       mutationTiming,
       spanName: 'dispatchStartedTasksWithGlobalTopup.prestartedTopupExecuteTasks',
       dispatchMode,
-      launchOutboxMode,
     });
   }
   bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.before');
@@ -364,7 +278,6 @@ export async function dispatchStartedTasksWithGlobalTopup({
     alreadyDispatched: [...runnable, ...prestartedTopup],
     mutationTiming,
     dispatchMode,
-    launchOutboxMode,
   });
   const topup = [...prestartedTopup, ...additionalTopup];
   bench('dispatchStartedTasksWithGlobalTopup.executeGlobalTopup.after', { topupCount: topup.length });
@@ -386,7 +299,6 @@ export async function finalizeMutationWithGlobalTopup({
   scopedTaskIds,
   mutationTiming,
   dispatchMode,
-  launchOutboxMode,
 }: MutationTopupParams): Promise<{ started: TaskState[]; topup: TaskState[] }> {
   const { topup } = await dispatchStartedTasksWithGlobalTopup({
     orchestrator,
@@ -398,7 +310,6 @@ export async function finalizeMutationWithGlobalTopup({
     scopedTaskIds,
     mutationTiming,
     dispatchMode,
-    launchOutboxMode,
   });
   return { started, topup };
 }

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -207,31 +207,21 @@ export function createHeadlessExecutor(
   deps: HeadlessDeps,
   callbackOverrides?: Partial<ConstructorParameters<typeof TaskRunner>[0]['callbacks']>,
 ): TaskRunner {
-  // CB.7: in active launch-outbox mode the owner's long-lived
-  // TaskRunner is the single launch path (it services the
-  // task_launch_dispatch outbox via LaunchDispatcher). Reusing it
-  // eliminates the multi-TaskRunner blindness from Issue 6 — every
-  // headless command shares the same launchingAttemptIds Set so
-  // duplicate-suppression and dispatch-row ack/complete/fail accounting
-  // all stay coherent. callbackOverrides are intentionally ignored on
-  // this path because the owner's TaskRunner already has its own
-  // production callbacks (persistence writes, renderer deltas, etc.);
-  // per-command callbacks would either duplicate that work or fight it.
-  if (deps.invokerConfig.launchOutboxMode === 'active') {
-    const owner = deps.ownerTaskRunnerProvider?.() ?? null;
-    if (owner) {
-      if (callbackOverrides) {
-        deps.logger?.debug?.(
-          '[headless] createHeadlessExecutor: ignoring callbackOverrides — launchOutboxMode=active reuses owner TaskRunner',
-          { module: 'headless' },
-        );
-      }
-      return owner;
+  // Reuse the owner's long-lived TaskRunner when it is available so
+  // every headless command shares the same launchingAttemptIds Set and
+  // outbox row accounting. callbackOverrides are intentionally ignored
+  // here because the owner already wires production callbacks
+  // (persistence writes, renderer deltas, etc.). Standalone followers
+  // without an in-process owner fall through to a per-command runner.
+  const owner = deps.ownerTaskRunnerProvider?.() ?? null;
+  if (owner) {
+    if (callbackOverrides) {
+      deps.logger?.debug?.(
+        '[headless] createHeadlessExecutor: ignoring callbackOverrides — reusing owner TaskRunner',
+        { module: 'headless' },
+      );
     }
-    deps.logger?.warn?.(
-      '[headless] createHeadlessExecutor: launchOutboxMode=active but ownerTaskRunnerProvider is unavailable — falling back to per-command TaskRunner',
-      { module: 'headless' },
-    );
+    return owner;
   }
   let executor: TaskRunner;
   executor = new TaskRunner({

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -1,10 +1,14 @@
 /**
- * Phase A observer for the launch-handoff outbox.
+ * Durable launch-handoff dispatcher.
  *
- * In observer mode the dispatcher does not own dispatch. It only reads
- * `task_launch_dispatch` rows and logs an aggregate count by state so we
- * have production data on outbox build-up before the active dispatcher
- * (CB.5) takes over.
+ * The orchestrator's drainScheduler writes a `task_launch_dispatch`
+ * outbox row alongside each `task.launch_claimed` event. This
+ * dispatcher polls the outbox, leases enqueued rows, hands them to the
+ * TaskRunner, and reaps stuck leases. The outbox is the single,
+ * authoritative launch path: if the JS promise dispatching a row
+ * drops, the next poll reclaims the lease and tries again; if it
+ * exhausts retries, the row is abandoned with a real `task.failed`
+ * event and the orchestrator prepares a fresh attempt.
  *
  * See:
  * - `docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md`
@@ -13,16 +17,13 @@
  *   (the investigation that motivated the rewrite)
  */
 
-import type { SQLiteAdapter, TaskLaunchDispatch, TaskLaunchDispatchState } from '@invoker/data-store';
+import type { SQLiteAdapter } from '@invoker/data-store';
 import type { LaunchOutboxAck } from '@invoker/execution-engine';
 import type { TaskState } from '@invoker/workflow-core';
 import { DISPATCH_MAX_ATTEMPTS, type Logger } from '@invoker/contracts';
 
-export type LaunchDispatcherMode = 'observe' | 'active';
-
 export type LaunchDispatcherPersistence = Pick<
   SQLiteAdapter,
-  | 'listLaunchDispatchesByState'
   | 'markLaunchDispatchAcknowledged'
   | 'markLaunchDispatchCompleted'
   | 'markLaunchDispatchFailed'
@@ -38,9 +39,8 @@ export type LaunchDispatcherPersistence = Pick<
 /**
  * Narrow interface for the orchestrator surface the dispatcher needs.
  * Avoids widening the dependency on the whole Orchestrator class.
- * `getTask` is optional because the reaper path (used in observer
- * mode and by tests that only exercise abandon/reap) does not need
- * it; only active-mode dispatch reads it.
+ * `getTask` is optional because tests that only exercise the
+ * abandon/reap paths do not need it; the dispatch loop reads it.
  */
 export interface LaunchDispatcherOrchestrator {
   prepareTaskForNewAttempt(taskId: string, reason: string): unknown;
@@ -67,23 +67,16 @@ export interface LaunchDispatcherOptions {
    * Provider for the current TaskRunner. A function (rather than a
    * direct reference) so that rebuildTaskRunner() in main.ts can
    * swap the runner instance without re-creating the dispatcher.
-   * Returning `null` short-circuits the active-mode dispatch loop
-   * (logged as a warning).
+   * Returning `null` short-circuits the dispatch loop (logged as a
+   * warning); the next poll re-reads the provider.
    */
   taskRunnerProvider?: () => LaunchDispatcherTaskRunner | null;
   ownerId: string;
   logger?: Logger;
-  mode: LaunchDispatcherMode;
   maxAttempts?: number;
   maxConcurrency?: number;
   maxLeasesPerPoll?: number;
 }
-
-const OBSERVED_STATES: readonly TaskLaunchDispatchState[] = [
-  'enqueued',
-  'leased',
-  'acknowledged',
-];
 
 export class LaunchDispatcher {
   private readonly persistence: LaunchDispatcherPersistence;
@@ -91,7 +84,6 @@ export class LaunchDispatcher {
   private readonly taskRunnerProvider?: () => LaunchDispatcherTaskRunner | null;
   private readonly ownerId: string;
   private readonly logger?: Logger;
-  private readonly mode: LaunchDispatcherMode;
   private readonly maxAttempts: number;
   private readonly maxConcurrency: number;
   private readonly maxLeasesPerPoll: number;
@@ -102,16 +94,11 @@ export class LaunchDispatcher {
     this.taskRunnerProvider = options.taskRunnerProvider;
     this.ownerId = options.ownerId;
     this.logger = options.logger;
-    this.mode = options.mode;
     this.maxAttempts = options.maxAttempts ?? DISPATCH_MAX_ATTEMPTS;
     this.maxConcurrency = options.maxConcurrency ?? 16;
     // Bound a single poll's work so the dispatcher cannot starve other
     // owner-loop ticks; the leftover rows are picked up on the next tick.
     this.maxLeasesPerPoll = options.maxLeasesPerPoll ?? 32;
-  }
-
-  getMode(): LaunchDispatcherMode {
-    return this.mode;
   }
 
   getOwnerId(): string {
@@ -127,35 +114,16 @@ export class LaunchDispatcher {
    *      that have exhausted their retry budget (TaskRunner accepted
    *      ownership but never completed; report the failure and let the
    *      orchestrator prepare a fresh attempt).
-   *   3. In observe mode, log the aggregate state counts. In active mode,
-   *      (CB.5) lease and dispatch new work.
-   *
-   * Steps 1 and 2 run in BOTH observer and active modes. They only mutate
-   * already-stuck rows, so they are safe under observer mode — the goal
-   * is to surface the orphan condition with concrete events rather than
-   * letting it accumulate silently.
+   *   3. Lease and dispatch new enqueued rows up to `maxLeasesPerPoll`.
    */
   poll(): void {
     this.reapExpiredLeases();
     this.abandonStuckLeases();
-
-    if (this.mode === 'observe') {
-      const rows = this.persistence.listLaunchDispatchesByState(OBSERVED_STATES);
-      const counts = countByState(rows);
-      this.logger?.info?.('[launch-dispatcher] observed', {
-        ownerId: this.ownerId,
-        mode: this.mode,
-        counts,
-        total: rows.length,
-        module: 'launch-dispatcher',
-      });
-      return;
-    }
     this.dispatchActive();
   }
 
   /**
-   * Active-mode dispatch loop. Lease as many enqueued rows as capacity
+   * Dispatch loop. Lease as many enqueued rows as capacity
    * allows (bounded by `maxLeasesPerPoll`) and hand each one to the
    * TaskRunner. The TaskRunner ack/complete/fail flow drives the rest
    * of the lifecycle; if the JS promise drops mid-flight, the durable
@@ -165,7 +133,7 @@ export class LaunchDispatcher {
   private dispatchActive(): void {
     const runner = this.taskRunnerProvider?.() ?? null;
     if (!runner) {
-      this.logger?.warn?.('[launch-dispatcher] active mode without taskRunner — skipping dispatch', {
+      this.logger?.warn?.('[launch-dispatcher] no taskRunner available — skipping dispatch', {
         ownerId: this.ownerId,
         module: 'launch-dispatcher',
       });
@@ -415,20 +383,4 @@ export class LaunchDispatcher {
     });
     return ok;
   }
-}
-
-function countByState(
-  rows: readonly TaskLaunchDispatch[],
-): Record<TaskLaunchDispatchState, number> {
-  const counts: Record<TaskLaunchDispatchState, number> = {
-    enqueued: 0,
-    leased: 0,
-    acknowledged: 0,
-    completed: 0,
-    abandoned: 0,
-  };
-  for (const row of rows) {
-    counts[row.state] += 1;
-  }
-  return counts;
 }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -161,7 +161,7 @@ import {
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
-import { LaunchDispatcher, type LaunchDispatcherMode } from './launch-dispatcher.js';
+import { LaunchDispatcher } from './launch-dispatcher.js';
 import { recoverWorkflowMutationsOnStartup } from './workflow-mutation-startup.js';
 import {
   dispatchStartedTasksWithGlobalTopup,
@@ -506,7 +506,6 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
     defaultPoolId: invokerConfig.defaultPoolId,
     availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
     deferRunningUntilLaunch: true,
-    launchOutboxMode: invokerConfig.launchOutboxMode,
   });
   commandService = new CommandService(
     orchestrator,
@@ -2727,20 +2726,17 @@ function createEmbeddedTerminalBackendFromConfig(
         },
         { logger },
       );
-      if (invokerConfig.launchOutboxMode && invokerConfig.launchOutboxMode !== 'disabled') {
-        launchDispatcher = new LaunchDispatcher({
-          persistence,
-          orchestrator,
-          // taskExecutor is re-built by rebuildTaskRunner(); read via
-          // a provider so the dispatcher always picks up the current
-          // instance instead of capturing a stale reference.
-          taskRunnerProvider: () => taskExecutor,
-          ownerId: workflowMutationOwnerId,
-          logger,
-          mode: invokerConfig.launchOutboxMode as LaunchDispatcherMode,
-          maxConcurrency: effectiveMaxConcurrency,
-        });
-      }
+      launchDispatcher = new LaunchDispatcher({
+        persistence,
+        orchestrator,
+        // taskExecutor is re-built by rebuildTaskRunner(); read via
+        // a provider so the dispatcher always picks up the current
+        // instance instead of capturing a stale reference.
+        taskRunnerProvider: () => taskExecutor,
+        ownerId: workflowMutationOwnerId,
+        logger,
+        maxConcurrency: effectiveMaxConcurrency,
+      });
     } else {
       logger.info('Launched in follower mode; mutation execution is delegated to the current owner', {
         module: 'init',
@@ -3094,7 +3090,6 @@ function createEmbeddedTerminalBackendFromConfig(
         defaultPoolId: invokerConfig.defaultPoolId,
         availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
         deferRunningUntilLaunch: true,
-        launchOutboxMode: invokerConfig.launchOutboxMode,
       });
       commandService = new CommandService(
         orchestrator,

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -351,6 +351,10 @@ export class WorkflowMutationFacade {
       logger: this.deps.logger,
     });
     const runnable = result.started.filter(isDispatchableLaunch);
+    // The orchestrator now always enqueues a task_launch_dispatch row
+    // for each runnable, so this in-process call coexists with the
+    // dispatcher. Removing it needs a proven double-dispatch repro and
+    // belongs in a separate PR; left in place to preserve master behaviour.
     await this.deps.taskExecutor.executeTasks(runnable);
     const topup = await this.topupOnly('facade.fork-workflow');
     return {

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -152,7 +152,6 @@ function makeOrchestrator(
   opts: {
     deferRunningUntilLaunch?: boolean;
     maxConcurrency?: number;
-    launchOutboxMode?: 'disabled' | 'observe' | 'active';
     enqueueLaunchDispatchEnabled?: boolean;
   } = {},
 ): { orchestrator: Orchestrator; persistence: InMemoryPersistence } {
@@ -163,7 +162,6 @@ function makeOrchestrator(
     messageBus: new InMemoryBus(),
     maxConcurrency: opts.maxConcurrency ?? 4,
     deferRunningUntilLaunch: opts.deferRunningUntilLaunch,
-    launchOutboxMode: opts.launchOutboxMode,
   });
   return { orchestrator, persistence };
 }
@@ -507,43 +505,24 @@ describe('Orchestrator launch claims', () => {
     expect(started.map((task) => task.id)).toEqual([taskId]);
   });
 
-  describe('launch-outbox observer wiring (Phase A)', () => {
+  describe('launch-outbox wiring', () => {
     function loadPlanForLaunchOutbox(orchestrator: Orchestrator): { taskId: string } {
       orchestrator.loadPlan({
-        name: 'launch-outbox-observer',
+        name: 'launch-outbox',
         onFinish: 'none',
         tasks: [{ id: 't1', description: 'one', command: 'echo one' }],
       });
       return { taskId: taskIdBySuffix(orchestrator, 't1') };
     }
 
-    it("does not write outbox rows when launchOutboxMode='disabled'", () => {
+    it('writes one outbox row per claimed attempt and emits task.launch_claimed', () => {
       const { orchestrator, persistence } = makeOrchestrator({
         deferRunningUntilLaunch: true,
         enqueueLaunchDispatchEnabled: true,
-        launchOutboxMode: 'disabled',
-      });
-      loadPlanForLaunchOutbox(orchestrator);
-      orchestrator.startExecution();
-
-      expect(persistence.launchDispatchRows).toEqual([]);
-      expect(
-        persistence.events.find((event) => event.eventType === 'task.dispatch_enqueued'),
-      ).toBeUndefined();
-      expect(
-        persistence.events.find((event) => event.eventType === 'task.launch_claimed'),
-      ).toBeDefined();
-    });
-
-    it("writes one outbox row per claimed attempt when launchOutboxMode='observe' and still emits task.launch_claimed", () => {
-      const { orchestrator, persistence } = makeOrchestrator({
-        deferRunningUntilLaunch: true,
-        enqueueLaunchDispatchEnabled: true,
-        launchOutboxMode: 'observe',
         maxConcurrency: 4,
       });
       orchestrator.loadPlan({
-        name: 'launch-outbox-observer',
+        name: 'launch-outbox',
         onFinish: 'none',
         tasks: [
           { id: 't1', description: 'one', command: 'echo one' },
@@ -572,31 +551,18 @@ describe('Orchestrator launch claims', () => {
       }
     });
 
-    it("treats launchOutboxMode='active' the same as observe in Phase A (active behavior lands in CB)", () => {
-      const { orchestrator, persistence } = makeOrchestrator({
-        deferRunningUntilLaunch: true,
-        enqueueLaunchDispatchEnabled: true,
-        launchOutboxMode: 'active',
-      });
-      loadPlanForLaunchOutbox(orchestrator);
-      orchestrator.startExecution();
-
-      expect(persistence.launchDispatchRows).toHaveLength(1);
-      expect(
-        persistence.events.find((event) => event.eventType === 'task.dispatch_enqueued'),
-      ).toBeDefined();
-    });
-
-    it("tolerates missing enqueueLaunchDispatch without throwing when launchOutboxMode='observe'", () => {
+    it('still claims tasks when the persistence layer is missing enqueueLaunchDispatch', () => {
       const { orchestrator, persistence } = makeOrchestrator({
         deferRunningUntilLaunch: true,
         enqueueLaunchDispatchEnabled: false,
-        launchOutboxMode: 'observe',
       });
       (persistence as unknown as { enqueueLaunchDispatch?: unknown }).enqueueLaunchDispatch = undefined;
       loadPlanForLaunchOutbox(orchestrator);
       expect(() => orchestrator.startExecution()).not.toThrow();
       expect(persistence.launchDispatchRows).toEqual([]);
+      expect(
+        persistence.events.find((event) => event.eventType === 'task.launch_claimed'),
+      ).toBeDefined();
     });
   });
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -245,11 +245,10 @@ export interface OrchestratorPersistence {
   /** Delete all workflows and tasks from the DB. */
   deleteAllWorkflows?(): void;
   /**
-   * Optional launch-handoff outbox sink. When provided AND
-   * `OrchestratorConfig.launchOutboxMode` is `'observe'` or `'active'`,
-   * `drainScheduler` writes a `task_launch_dispatch` row alongside the
-   * legacy claim path. The orchestrator does not take a hard dependency
-   * on this method; it is observer-only in Phase A. See
+   * Launch-handoff outbox sink. When the persistence layer implements
+   * this method, `drainScheduler` writes a `task_launch_dispatch` row
+   * alongside the durable claim event so the `LaunchDispatcher` poll
+   * loop can take ownership of the launch. See
    * `docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md`.
    */
   enqueueLaunchDispatch?(input: {
@@ -735,16 +734,6 @@ export interface OrchestratorConfig {
    * scheduler dequeue time).
    */
   deferRunningUntilLaunch?: boolean;
-  /**
-   * Launch-handoff outbox mode. When set to `'observe'` or `'active'` (and
-   * the persistence layer implements `enqueueLaunchDispatch`),
-   * `drainScheduler` writes a durable `task_launch_dispatch` row alongside
-   * the existing claim path and emits a `task.dispatch_enqueued` event.
-   *
-   * Default `'disabled'` preserves existing behaviour. See
-   * `docs/incidents/2026-05-22-launch-handoff-architecture-proposal.md`.
-   */
-  launchOutboxMode?: 'disabled' | 'observe' | 'active';
 }
 
 // ── Orchestrator ────────────────────────────────────────────
@@ -765,7 +754,6 @@ export class Orchestrator {
   private readonly defaultPoolId: string | undefined;
   private readonly defaultAutoFixRetries: number;
   private readonly deferRunningUntilLaunch: boolean;
-  private readonly launchOutboxMode: 'disabled' | 'observe' | 'active';
 
   private activeWorkflowIds = new Set<string>();
   private deferredTaskIds = new Set<string>();
@@ -838,7 +826,6 @@ export class Orchestrator {
     this.defaultPoolId = config.defaultPoolId;
     this.defaultAutoFixRetries = Math.min(Math.max(0, Math.floor(config.defaultAutoFixRetries ?? 0)), 10);
     this.deferRunningUntilLaunch = config.deferRunningUntilLaunch ?? false;
-    this.launchOutboxMode = config.launchOutboxMode ?? 'disabled';
 
     this.stateMachine = new TaskStateMachine(new ActionGraph());
     this.responseHandler = new ResponseHandler();
@@ -5101,8 +5088,7 @@ export class Orchestrator {
         changes,
       );
       if (
-        this.launchOutboxMode !== 'disabled'
-        && typeof this.persistence.enqueueLaunchDispatch === 'function'
+        typeof this.persistence.enqueueLaunchDispatch === 'function'
         && task.config.workflowId
       ) {
         try {


### PR DESCRIPTION
## Summary

A `pending`/`launching` task with a dropped fire-and-forget dispatch promise had no recovery path: the legacy launch-stall watchdog and orphan-relaunch had been removed under the assumption that the `LaunchDispatcher` was always running, but its activation was gated behind `INVOKER_LAUNCH_OUTBOX=active` (default `disabled`). With the flag off, the orchestrator marked tasks `pending`/`execution.phase=launching`, the in-process `executeTasks` fired, and nothing reclaimed the claim if the launch never materialized — producing the stuck `WF-INV-117` / `WF-INV-130` workflows on 2026-05-24.

This PR removes the flag and the parallel in-process dispatch path so the outbox is the single, authoritative launch path. Net diff **+212 / −741**.

## What changed

### Runtime

- **`config.ts`** — removed `launchOutboxMode`, `LaunchOutboxMode`, `resolveLaunchOutboxMode`. `loadConfig` no longer reads the env var.
- **`launch-dispatcher.ts`** — removed `LaunchDispatcherMode` and the observer branch. `poll()` unconditionally drives `dispatchActive()`. Dead helpers (`countByState`, `OBSERVED_STATES`) and the `listLaunchDispatchesByState` persistence method dropped.
- **`workflow-core/orchestrator.ts`** — removed `launchOutboxMode` from `OrchestratorConfig`. `drainScheduler` always writes a `task_launch_dispatch` row when it claims a launch.
- **`main.ts`** — `LaunchDispatcher` is always constructed; no `mode !== 'disabled'` gate.
- **`global-topup.ts`** — the in-process `taskExecutor.executeTasks(runnable)` fan-out is gone. `dispatchTasks` only emits bench/log telemetry; outbox handoff happens earlier in `orchestrator.startExecution()`.
- **`workflow-mutation-facade.ts`** — `forkWorkflow` no longer calls `executeTasks` directly.
- **`headless.ts`** — `createHeadlessExecutor` always prefers the owner's `TaskRunner` when `ownerTaskRunnerProvider` yields one. Standalone-process fallback is preserved.
- **`run.sh`** — no longer touched. `INVOKER_LAUNCH_OUTBOX` is not exported (and is now unread).

### Tests

All suites pass: **994 / 1 skip** in `@invoker/app`, **1038** in `@invoker/workflow-core`.

- `launch-claim-orphan-regression.test.ts` — the `it.fails` invariant case is now a passing regression guard; the dispatcher-recovery case no longer carries `mode: 'active'`.
- `launch-dispatcher.test.ts` — observer-mode test replaced with a "no `taskRunnerProvider` → poll warns and leases nothing" guard.
- `orchestrator-dispatcher.test.ts` — `disabled` / `observe` / `active` triad collapses to a single outbox-wiring assertion plus a missing-`enqueueLaunchDispatch` fallback.
- `config.test.ts` — `resolveLaunchOutboxMode` block removed; default `loadConfig()` returns `{}`.
- `headless-create-executor.test.ts` — owner short-circuit no longer keyed off the flag; tests scoped to "provider yields runner" vs. "provider absent".
- Mutation lifecycle tests (`api-server`, `parity-regression`, `bridge-orchestrator-executor`, `workflow-mutation-facade`, `global-topup`, `app-layer-handoff-repro`, `headless-delegation`) — `expect(executeTasks).toHaveBeenCalled()` flipped to `not.toHaveBeenCalled()`; assertions moved to `result.runnable` / `result.topup` partitioning.

### Retained on purpose

`packages/app/e2e/launching-stall-watchdog.spec.ts`, `packages/app/e2e/orphan-relaunch.spec.ts`, and `scripts/repro-launching-stall/` are **kept**.

- `launching-stall-watchdog.spec.ts` is misleadingly named. The two remaining test cases exercise the still-live **executing-stall** watchdog in `packages/app/src/executing-stall.ts` (`evaluateExecutingStall`).
- `orphan-relaunch.spec.ts` and `scripts/repro-launching-stall/` do exercise removed code paths. Retiring them belongs in a focused follow-up rather than as a side-effect of this migration.

## Architecture

```mermaid
flowchart LR
  Mut[mutation entry-points<br/>api-server / headless / facade] --> Orch[orchestrator action]
  Orch --> Drain[drainScheduler<br/>claims launch]
  Drain -->|enqueueLaunchDispatch| Outbox[(task_launch_dispatch)]
  Outbox --> Dispatcher[LaunchDispatcher.poll]
  Dispatcher --> Runner[TaskRunner.executeTask]
  Dispatcher --> Reapers[reapExpiredLeases<br/>abandonStuckLeases]
```

A `pending`/`launching` claim either drains via the dispatcher or its lease expires and the reapers fail it — never silent.

## Test plan

- [x] `cd packages/app && pnpm test` — 994 pass / 1 skip
- [x] `cd packages/workflow-core && pnpm test` — 1038 pass
- [x] `rg "launchOutboxMode|INVOKER_LAUNCH_OUTBOX|LaunchOutboxMode|LaunchDispatcherMode|resolveLaunchOutboxMode"` returns zero hits outside `node_modules` / `dist` / historical docs

## Revert plan

- Safe to revert? Yes.
- Revert command: `git revert <sha>`.
- Post-revert behavior: legacy `executeTasks` fan-out and `launchOutboxMode` plumbing restored to their pre-merge state. The outbox row is still produced (it predates this change); the dispatcher gate returns. To recover from `pending`/`launching` after revert, set `INVOKER_LAUNCH_OUTBOX=active` in the environment.
- Data migration? No. `task_launch_dispatch` rows are produced and consumed identically before and after.