### PR TITLE
Add Closed Status: Core Review Gate Semantics

### DIFF
--- a/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
+++ b/packages/execution-engine/src/__tests__/github-merge-gate-provider.test.ts
@@ -334,7 +334,7 @@ describe('GitHubMergeGateProvider', () => {
       const result = await provider.checkApproval({ identifier: '3', cwd: '/tmp/repo' });
 
       expect(result.approved).toBe(false);
-      expect(result.rejected).toBe(true);
+      expect(result.rejected).toBe(false);
       expect(result.closed).toBe(true);
       expect(result.statusText).toBe('Closed');
     });

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -4427,7 +4427,7 @@ console.log(JSON.stringify(out));
       const mergeGateProvider = {
         checkApproval: vi.fn().mockResolvedValue({
           approved: false,
-          rejected: true,
+          rejected: false,
           closed: true,
           statusText: 'Closed',
           url: 'https://github.com/owner/repo/pull/43',
@@ -4963,7 +4963,7 @@ console.log(JSON.stringify(out));
         const mergeGateProvider = {
           checkApproval: vi.fn().mockResolvedValue({
             approved: false,
-            rejected: true,
+            rejected: false,
             closed: true,
             statusText: 'Closed',
           }),

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -4991,6 +4991,100 @@ console.log(JSON.stringify(out));
         expect(orchestrator.approve).not.toHaveBeenCalled();
         expect(executeTasks).not.toHaveBeenCalled();
       });
+
+      it('closed PR transitions an awaiting_approval gate to closed on refresh', async () => {
+        const closingTask = makeTask({
+          id: 'merge-awaiting-closed',
+          status: 'awaiting_approval',
+          config: { isMergeNode: true },
+          execution: {
+            reviewId: 'owner/repo#206',
+            workspacePath: '/workspace/awaiting-closed-gate',
+          },
+        });
+        const orchestrator = {
+          getTask: (id: string) => (id === closingTask.id ? closingTask : undefined),
+          getAllTasks: () => [closingTask],
+          approve: vi.fn(),
+        };
+        const persistence = { updateTask: vi.fn() };
+        const mergeGateProvider = {
+          checkApproval: vi.fn().mockResolvedValue({
+            approved: false,
+            rejected: false,
+            closed: true,
+            statusText: 'Closed',
+          }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: persistence as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/runner-base-cwd',
+          mergeGateProvider: mergeGateProvider as any,
+        });
+        const executeTasks = vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
+
+        await executor.checkMergeGateStatuses();
+
+        expect(persistence.updateTask).toHaveBeenCalledWith('merge-awaiting-closed', {
+          status: 'closed',
+          execution: { reviewStatus: 'Closed' },
+        });
+        expect(orchestrator.approve).not.toHaveBeenCalled();
+        expect(executeTasks).not.toHaveBeenCalled();
+      });
+
+      it('stops polling a closed merge gate on subsequent refresh passes', async () => {
+        const task = makeTask({
+          id: 'merge-closed-stops-polling',
+          status: 'review_ready',
+          config: { isMergeNode: true },
+          execution: {
+            reviewId: 'owner/repo#207',
+            workspacePath: '/workspace/closed-stop-poll',
+          },
+        });
+        const orchestrator = {
+          getTask: (id: string) => (id === task.id ? task : undefined),
+          getAllTasks: () => [task],
+          approve: vi.fn(),
+        };
+        const persistence = {
+          updateTask: vi.fn((id: string, changes: any) => {
+            if (id === task.id && changes.status) {
+              (task as any).status = changes.status;
+            }
+          }),
+        };
+        const mergeGateProvider = {
+          checkApproval: vi.fn().mockResolvedValue({
+            approved: false,
+            rejected: false,
+            closed: true,
+            statusText: 'Closed',
+          }),
+        };
+
+        const executor = new TaskRunner({
+          orchestrator: orchestrator as any,
+          persistence: persistence as any,
+          executorRegistry: { getDefault: () => ({ type: 'worktree' }), get: () => null, getAll: () => [] } as any,
+          cwd: '/runner-base-cwd',
+          mergeGateProvider: mergeGateProvider as any,
+        });
+        vi.spyOn(executor, 'executeTasks').mockResolvedValue(undefined);
+
+        await executor.checkMergeGateStatuses();
+        expect(mergeGateProvider.checkApproval).toHaveBeenCalledTimes(1);
+        expect(task.status).toBe('closed');
+
+        await executor.checkMergeGateStatuses();
+        // Closed status falls outside the (review_ready || awaiting_approval) polling filter,
+        // so no additional provider call should happen on the second refresh pass.
+        expect(mergeGateProvider.checkApproval).toHaveBeenCalledTimes(1);
+      });
     });
   });
 

--- a/packages/execution-engine/src/github-merge-gate-provider.ts
+++ b/packages/execution-engine/src/github-merge-gate-provider.ts
@@ -110,7 +110,7 @@ export class GitHubMergeGateProvider implements MergeGateProvider {
 
     const approved = data.state === 'MERGED';
     const closed = data.state === 'CLOSED';
-    const rejected = closed || data.reviewDecision === 'CHANGES_REQUESTED';
+    const rejected = data.reviewDecision === 'CHANGES_REQUESTED';
 
     let statusText: string;
     if (data.state === 'MERGED') {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -1894,6 +1894,26 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(reviewLeafId)!.status).toBe('pending');
     });
 
+    it('closed task does not satisfy a regular non-reconciliation downstream dependency', () => {
+      orchestrator.loadPlan({
+        name: 'closed-dep-workflow',
+        tasks: [
+          { id: 'upstream', description: 'Upstream task' },
+          { id: 'downstream', description: 'Downstream task', dependencies: ['upstream'] },
+        ],
+      });
+      const upstreamId = sid(orchestrator, 0, 'upstream');
+      const downstreamId = sid(orchestrator, 0, 'downstream');
+
+      orchestrator.startExecution();
+      persistence.updateTask(upstreamId, { status: 'closed' });
+      orchestrator.syncAllFromDb();
+
+      const startedAfterClose = orchestrator.startExecution();
+      expect(startedAfterClose.map((t) => t.id)).not.toContain(downstreamId);
+      expect(orchestrator.getTask(downstreamId)!.status).toBe('pending');
+    });
+
     it('setTaskExternalGatePolicies can unblock pending task immediately', () => {
       orchestrator.loadPlan({
         name: 'prereq-workflow',

--- a/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
+++ b/packages/workflow-graph/src/__tests__/workflow-rollup.test.ts
@@ -97,4 +97,17 @@ describe('workflow rollup', () => {
     expect(rollup.countsByStatus.failed).toBe(0);
     expect(rollup.failedTasks).toEqual([]);
   });
+
+  it('does not roll up to completed when a closed task is mixed with completed tasks', () => {
+    const rollup = computeWorkflowRollupFromSummaries([
+      task('alpha', 'completed'),
+      task('beta', 'completed'),
+      task('gamma', 'closed'),
+    ]);
+
+    expect(rollup.status).toBe('closed');
+    expect(rollup.status).not.toBe('completed');
+    expect(rollup.countsByStatus.completed).toBe(2);
+    expect(rollup.countsByStatus.closed).toBe(1);
+  });
 });


### PR DESCRIPTION
## Summary

This PR is part 1 of the `closed` status migration. It stops treating closed-unmerged GitHub PRs as generic rejections and introduces the first core plumbing for a distinct terminal-neutral `closed` state.

The main behavior change is in merge-gate polling: GitHub `CLOSED` now maps to `closed: true` instead of `rejected: true`, allowing TaskRunner and workflow rollups to handle closed review gates separately from changes-requested failures. It also begins replacing scattered `"closed"` handling with shared status semantics so later migration work can remove remaining ad hoc strings cleanly.

Closed-unmerged is now distinct from changes-requested:
- A `CLOSED` PR returns `{ approved: false, rejected: false, closed: true }` from the provider.
- `TaskRunner.checkMergeGateStatuses` transitions both `review_ready` and `awaiting_approval` merge nodes to `status: 'closed'` with `reviewStatus: 'Closed'`, does **not** call `orchestrator.approve`, and does **not** dispatch downstream tasks.
- Subsequent polling passes skip the now-`closed` task because the polling filter only covers `review_ready || awaiting_approval`.
- Workflow rollup with a closed task plus completed tasks rolls up to `closed`, not `completed`, so downstream non-reconciliation dependencies do not unblock.

Only `CHANGES_REQUESTED` continues to set `rejected = true`.

## Architecture

State flow for a merge-gate task whose upstream GitHub PR is closed without merging.

### Before

```mermaid
flowchart TD
    GH["GitHub PR: CLOSED"]
    Provider["Provider: rejected=true"]
    Runner["TaskRunner: no closed transition"]
    UI["Gate remains review_ready"]
    Polling["Polling continues"]

    GH --> Provider --> Runner --> UI --> Polling
```

### After

```mermaid
flowchart TD
    GH["GitHub PR: CLOSED"]
    Provider["Provider: closed=true<br/>rejected=false"]
    Runner["TaskRunner: status=closed"]
    Rollup["Workflow rollup: closed"]
    Deps["Downstream deps stay blocked"]

    GH --> Provider --> Runner --> Rollup --> Deps
```

## Test Plan

- [ ] `cd packages/workflow-graph && pnpm test`
- [ ] `cd packages/workflow-core && pnpm test`
- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None. Reverting restores the prior behavior where closed-unmerged PRs are reported as `rejected = true` by the GitHub merge-gate provider and the new closed-transition tests are removed. No persisted task rows need migration; any task that was set to `status: 'closed'` while this change was live remains a valid value in the existing `TaskStatus` union on `master`.
- Data migration? No