### PR TITLE
External failure recovery supervisor

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -220,6 +220,21 @@ describe('loadConfig', () => {
     expect(config.defaultPoolId).toBe('mixed-local-ssh');
   });
 
+  it('reads externalFailureRecovery from user config', () => {
+    const externalFailureRecovery = {
+      enabled: true,
+      command: '/tmp/recover.sh --once',
+      cwd: '/work',
+      cooldownSeconds: 90,
+    };
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ externalFailureRecovery }),
+    );
+    const config = loadConfig();
+    expect(config.externalFailureRecovery).toEqual(externalFailureRecovery);
+  });
+
 });
 
 describe('resolveEmbeddedTerminalBackendConfig', () => {

--- a/packages/app/src/__tests__/external-failure-recovery.test.ts
+++ b/packages/app/src/__tests__/external-failure-recovery.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildRecoveryEnv,
+  createExternalRecoveryLauncher,
+  type RecoveryContext,
+  type RecoverySpawnFn,
+} from '../external-failure-recovery.js';
+import type { ExternalFailureRecoveryConfig } from '../config.js';
+
+const ctx: RecoveryContext = {
+  taskId: 'task-1',
+  workflowId: 'wf-1',
+  repoRoot: '/repo',
+  dbDir: '/db',
+};
+
+function makeSpawnSpy() {
+  const calls: Array<{
+    command: string;
+    args: ReadonlyArray<string>;
+    options: Parameters<RecoverySpawnFn>[2];
+  }> = [];
+  let nextPid = 1000;
+  const child = { pid: 0, unref: () => {} };
+  const spawn: RecoverySpawnFn = (command, args, options) => {
+    calls.push({ command, args, options });
+    nextPid += 1;
+    return { ...child, pid: nextPid };
+  };
+  return { spawn, calls };
+}
+
+describe('buildRecoveryEnv', () => {
+  it('produces the documented env-var bag verbatim', () => {
+    const env = buildRecoveryEnv(ctx, {});
+    expect(env).toEqual({
+      INVOKER_FAILED_TASK_ID: 'task-1',
+      INVOKER_FAILED_WORKFLOW_ID: 'wf-1',
+      INVOKER_REPO_ROOT: '/repo',
+      INVOKER_DB_DIR: '/db',
+      INVOKER_RECOVERY_REASON: 'task_failed',
+    });
+  });
+
+  it('merges over a provided base env without dropping unrelated keys', () => {
+    const env = buildRecoveryEnv(ctx, { PATH: '/usr/bin', UNRELATED: 'keep' });
+    expect(env.PATH).toBe('/usr/bin');
+    expect(env.UNRELATED).toBe('keep');
+    expect(env.INVOKER_RECOVERY_REASON).toBe('task_failed');
+  });
+
+  it('lets recovery vars override colliding keys in the base env', () => {
+    const env = buildRecoveryEnv(ctx, {
+      INVOKER_FAILED_TASK_ID: 'stale',
+      INVOKER_RECOVERY_REASON: 'stale',
+    });
+    expect(env.INVOKER_FAILED_TASK_ID).toBe('task-1');
+    expect(env.INVOKER_RECOVERY_REASON).toBe('task_failed');
+  });
+});
+
+describe('createExternalRecoveryLauncher', () => {
+  it('skips with reason="disabled" when config is undefined', () => {
+    const { spawn, calls } = makeSpawnSpy();
+    const launcher = createExternalRecoveryLauncher({ spawn, baseEnv: {} });
+    const result = launcher.launch(undefined, ctx);
+    expect(result).toEqual({ launched: false, reason: 'disabled' });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('skips with reason="disabled" when enabled is false', () => {
+    const { spawn, calls } = makeSpawnSpy();
+    const launcher = createExternalRecoveryLauncher({ spawn, baseEnv: {} });
+    const cfg: ExternalFailureRecoveryConfig = {
+      enabled: false,
+      command: '/tmp/recover.sh',
+    };
+    const result = launcher.launch(cfg, ctx);
+    expect(result).toEqual({ launched: false, reason: 'disabled' });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('skips with reason="missing-command" when command is empty or whitespace', () => {
+    const { spawn, calls } = makeSpawnSpy();
+    const launcher = createExternalRecoveryLauncher({ spawn, baseEnv: {} });
+    expect(launcher.launch({ enabled: true, command: '' }, ctx)).toEqual({
+      launched: false,
+      reason: 'missing-command',
+    });
+    expect(launcher.launch({ enabled: true, command: '   ' }, ctx)).toEqual({
+      launched: false,
+      reason: 'missing-command',
+    });
+    expect(calls).toHaveLength(0);
+  });
+
+  it('launches the command with cwd, shell, detached, and the recovery env bag', () => {
+    const { spawn, calls } = makeSpawnSpy();
+    const launcher = createExternalRecoveryLauncher({
+      spawn,
+      baseEnv: { PATH: '/usr/bin' },
+      now: () => 1000,
+    });
+    const cfg: ExternalFailureRecoveryConfig = {
+      enabled: true,
+      command: '/tmp/recover.sh --verbose',
+      cwd: '/work',
+    };
+    const result = launcher.launch(cfg, ctx);
+
+    expect(result).toEqual({ launched: true, pid: 1001 });
+    expect(calls).toHaveLength(1);
+    const call = calls[0]!;
+    expect(call.command).toBe('/tmp/recover.sh --verbose');
+    expect(call.args).toEqual([]);
+    expect(call.options.cwd).toBe('/work');
+    expect(call.options.shell).toBe(true);
+    expect(call.options.detached).toBe(true);
+    expect(call.options.stdio).toBe('ignore');
+    expect(call.options.env).toEqual({
+      PATH: '/usr/bin',
+      INVOKER_FAILED_TASK_ID: 'task-1',
+      INVOKER_FAILED_WORKFLOW_ID: 'wf-1',
+      INVOKER_REPO_ROOT: '/repo',
+      INVOKER_DB_DIR: '/db',
+      INVOKER_RECOVERY_REASON: 'task_failed',
+    });
+  });
+
+  it('returns reason="spawn-error" with the thrown message when spawn fails', () => {
+    const failing: RecoverySpawnFn = () => {
+      throw new Error('ENOENT recover.sh');
+    };
+    const launcher = createExternalRecoveryLauncher({ spawn: failing, baseEnv: {} });
+    const result = launcher.launch(
+      { enabled: true, command: '/missing.sh' },
+      ctx,
+    );
+    expect(result).toEqual({
+      launched: false,
+      reason: 'spawn-error',
+      detail: 'ENOENT recover.sh',
+    });
+  });
+
+  describe('cooldown', () => {
+    it('allows back-to-back launches when cooldownSeconds is unset', () => {
+      const { spawn, calls } = makeSpawnSpy();
+      const launcher = createExternalRecoveryLauncher({
+        spawn,
+        baseEnv: {},
+        now: () => 0,
+      });
+      const cfg: ExternalFailureRecoveryConfig = {
+        enabled: true,
+        command: '/tmp/recover.sh',
+      };
+      expect(launcher.launch(cfg, ctx).launched).toBe(true);
+      expect(launcher.launch(cfg, ctx).launched).toBe(true);
+      expect(calls).toHaveLength(2);
+    });
+
+    it('skips with reason="cooldown" inside the window and launches again after', () => {
+      const { spawn, calls } = makeSpawnSpy();
+      let nowMs = 1_000_000;
+      const launcher = createExternalRecoveryLauncher({
+        spawn,
+        baseEnv: {},
+        now: () => nowMs,
+      });
+      const cfg: ExternalFailureRecoveryConfig = {
+        enabled: true,
+        command: '/tmp/recover.sh',
+        cooldownSeconds: 30,
+      };
+
+      // First launch always proceeds.
+      expect(launcher.launch(cfg, ctx)).toEqual({ launched: true, pid: 1001 });
+
+      // 29s later — inside the 30s cooldown.
+      nowMs += 29_000;
+      expect(launcher.launch(cfg, ctx)).toEqual({
+        launched: false,
+        reason: 'cooldown',
+      });
+
+      // Exactly at 30s — boundary is considered out of cooldown.
+      nowMs += 1_000;
+      expect(launcher.launch(cfg, ctx)).toEqual({ launched: true, pid: 1002 });
+
+      expect(calls).toHaveLength(2);
+    });
+
+    it('does not start the cooldown clock from skipped launches', () => {
+      const { spawn, calls } = makeSpawnSpy();
+      let nowMs = 0;
+      const launcher = createExternalRecoveryLauncher({
+        spawn,
+        baseEnv: {},
+        now: () => nowMs,
+      });
+
+      // Disabled launch must not arm the cooldown.
+      launcher.launch({ enabled: false, command: '/tmp/recover.sh' }, ctx);
+      nowMs += 5_000;
+
+      const cfg: ExternalFailureRecoveryConfig = {
+        enabled: true,
+        command: '/tmp/recover.sh',
+        cooldownSeconds: 60,
+      };
+      expect(launcher.launch(cfg, ctx).launched).toBe(true);
+      expect(calls).toHaveLength(1);
+    });
+  });
+});

--- a/packages/app/src/__tests__/headless-autofix.test.ts
+++ b/packages/app/src/__tests__/headless-autofix.test.ts
@@ -1,25 +1,72 @@
 import { describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { LocalBus } from '@invoker/transport';
 import { Channels } from '@invoker/transport';
 import type { MessageBus } from '@invoker/transport';
 import { wireHeadlessAutoFix } from '../headless.js';
+import type {
+  ExternalRecoveryLauncher,
+  RecoveryContext,
+  RecoveryLaunchResult,
+} from '../external-failure-recovery.js';
+import type { ExternalFailureRecoveryConfig } from '../config.js';
+
+function makeOrchestrator(taskWorkflowMap: Record<string, string>) {
+  return {
+    getTask: (taskId: string) => {
+      const workflowId = taskWorkflowMap[taskId];
+      return workflowId ? { config: { workflowId } } : undefined;
+    },
+    shouldAutoFix: vi.fn(() => true),
+  };
+}
+
+function captureLauncher(launchResult: RecoveryLaunchResult = { launched: true, pid: 99 }): {
+  launcher: ExternalRecoveryLauncher;
+  calls: Array<{ config: ExternalFailureRecoveryConfig | undefined; context: RecoveryContext }>;
+} {
+  const calls: Array<{ config: ExternalFailureRecoveryConfig | undefined; context: RecoveryContext }> = [];
+  const launcher: ExternalRecoveryLauncher = {
+    launch(config, context) {
+      calls.push({ config, context });
+      return launchResult;
+    },
+  };
+  return { launcher, calls };
+}
+
+function writeConfig(cfg: object): string {
+  const dir = mkdtempSync(join(tmpdir(), 'wire-hl-af-'));
+  const cfgPath = join(dir, 'config.json');
+  writeFileSync(cfgPath, JSON.stringify(cfg));
+  process.env.INVOKER_REPO_CONFIG_PATH = cfgPath;
+  return cfgPath;
+}
+
+function clearConfigEnv(): void {
+  delete process.env.INVOKER_REPO_CONFIG_PATH;
+}
 
 describe('wireHeadlessAutoFix', () => {
-  it('subscribes auto-fix for failed deltas in generic headless execution paths', async () => {
+  it('does not launch external recovery when config is missing', () => {
+    clearConfigEnv();
+    writeConfig({}); // ensure no externalFailureRecovery key
     const messageBus = new LocalBus() as MessageBus;
-    const shouldAutoFix = vi.fn((taskId: string) => taskId === 'wf-1/task-1');
-    const invokeAutoFix = vi.fn(async () => {});
-    const onError = vi.fn();
+    const persistence = { logEvent: vi.fn() };
+    const orchestrator = makeOrchestrator({ 'wf-1/task-1': 'wf-1' });
+    const { launcher, calls } = captureLauncher();
 
     wireHeadlessAutoFix(
       {
         messageBus,
-        orchestrator: { shouldAutoFix } as any,
-        persistence: {} as any,
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        repoRoot: '/repo',
       },
       {} as any,
-      invokeAutoFix,
-      onError,
+      launcher,
     );
 
     messageBus.publish(Channels.TASK_DELTA, {
@@ -27,19 +74,140 @@ describe('wireHeadlessAutoFix', () => {
       taskId: 'wf-1/task-1',
       changes: { status: 'failed' },
     });
+
+    expect(calls).toHaveLength(0);
+    expect(persistence.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.external-recovery',
+      expect.objectContaining({ phase: 'skip', reason: 'disabled' }),
+    );
+  });
+
+  it('launches external recovery for failed deltas with workflow context', () => {
+    const enabledConfig: ExternalFailureRecoveryConfig = {
+      enabled: true,
+      command: '/tmp/recover.sh',
+    };
+    writeConfig({ externalFailureRecovery: enabledConfig });
+
+    const messageBus = new LocalBus() as MessageBus;
+    const persistence = { logEvent: vi.fn() };
+    const orchestrator = makeOrchestrator({ 'wf-1/task-1': 'wf-1' });
+    const { launcher, calls } = captureLauncher({ launched: true, pid: 4242 });
+
+    wireHeadlessAutoFix(
+      {
+        messageBus,
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        repoRoot: '/repo',
+      },
+      {} as any,
+      launcher,
+    );
+
     messageBus.publish(Channels.TASK_DELTA, {
       type: 'updated',
-      taskId: 'wf-1/task-2',
+      taskId: 'wf-1/task-1',
       changes: { status: 'failed' },
     });
 
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.config).toEqual(enabledConfig);
+    expect(calls[0]!.context.taskId).toBe('wf-1/task-1');
+    expect(calls[0]!.context.workflowId).toBe('wf-1');
+    expect(calls[0]!.context.repoRoot).toBe('/repo');
+    expect(typeof calls[0]!.context.dbDir).toBe('string');
+    expect(persistence.logEvent).toHaveBeenCalledWith(
+      'wf-1/task-1',
+      'debug.external-recovery',
+      expect.objectContaining({ phase: 'launched', workflowId: 'wf-1', pid: 4242 }),
+    );
+  });
+
+  it('does not invoke any in-process Fix-with-AI path on failed deltas', async () => {
+    writeConfig({ externalFailureRecovery: { enabled: true, command: '/tmp/recover.sh' } });
+    const workflowActions = await import('../workflow-actions.js');
+    const autoFixSpy = vi.spyOn(workflowActions, 'autoFixOnFailure');
+
+    const messageBus = new LocalBus() as MessageBus;
+    const persistence = { logEvent: vi.fn() };
+    const orchestrator = makeOrchestrator({ 'wf-1/task-1': 'wf-1' });
+    const { launcher } = captureLauncher();
+
+    wireHeadlessAutoFix(
+      {
+        messageBus,
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        repoRoot: '/repo',
+      },
+      {} as any,
+      launcher,
+    );
+
+    messageBus.publish(Channels.TASK_DELTA, {
+      type: 'updated',
+      taskId: 'wf-1/task-1',
+      changes: { status: 'failed' },
+    });
+
+    // Allow any microtasks queued by the delta handler to flush.
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(shouldAutoFix).toHaveBeenCalledWith('wf-1/task-1');
-    expect(shouldAutoFix).toHaveBeenCalledWith('wf-1/task-2');
-    expect(invokeAutoFix).toHaveBeenCalledTimes(1);
-    expect(invokeAutoFix).toHaveBeenCalledWith('wf-1/task-1');
-    expect(onError).not.toHaveBeenCalled();
+    expect(autoFixSpy).not.toHaveBeenCalled();
+    autoFixSpy.mockRestore();
+  });
+
+  it('skips when the task cannot be resolved to a workflow', () => {
+    writeConfig({ externalFailureRecovery: { enabled: true, command: '/tmp/recover.sh' } });
+    const messageBus = new LocalBus() as MessageBus;
+    const persistence = { logEvent: vi.fn() };
+    const orchestrator = makeOrchestrator({});
+    const { launcher, calls } = captureLauncher();
+
+    wireHeadlessAutoFix(
+      {
+        messageBus,
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        repoRoot: '/repo',
+      },
+      {} as any,
+      launcher,
+    );
+
+    messageBus.publish(Channels.TASK_DELTA, {
+      type: 'updated',
+      taskId: 'wf-1/orphan',
+      changes: { status: 'failed' },
+    });
+
+    expect(calls).toHaveLength(0);
+    expect(persistence.logEvent).toHaveBeenCalledWith(
+      'wf-1/orphan',
+      'debug.external-recovery',
+      expect.objectContaining({ phase: 'skip', reason: 'workflow-not-found' }),
+    );
+  });
+
+  it('isBusy is always false because recovery runs out of process', () => {
+    const messageBus = new LocalBus() as MessageBus;
+    const persistence = { logEvent: vi.fn() };
+    const orchestrator = makeOrchestrator({ 'wf-1/task-1': 'wf-1' });
+    const { launcher } = captureLauncher();
+    const controller = wireHeadlessAutoFix(
+      {
+        messageBus,
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        repoRoot: '/repo',
+      },
+      {} as any,
+      launcher,
+    );
+
+    expect(controller.isBusy()).toBe(false);
   });
 });

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -231,9 +231,35 @@ export interface InvokerConfig {
    * preserved while the dispatcher matures.
    */
   launchOutboxMode?: LaunchOutboxMode;
+  /**
+   * Optional external failure-recovery hook. When enabled and a command is
+   * configured, failed task deltas can route to an external process (e.g. a
+   * supervisor script) while still preserving the in-app manual "Fix with AI"
+   * flow. Dormant until a caller wires it in; see
+   * `external-failure-recovery.ts` for the launcher helper.
+   */
+  externalFailureRecovery?: ExternalFailureRecoveryConfig;
 }
 
 export type LaunchOutboxMode = 'disabled' | 'observe' | 'active';
+
+export interface ExternalFailureRecoveryConfig {
+  /** Master switch. When false, the launcher is a no-op. */
+  enabled: boolean;
+  /**
+   * Command line to run when a failed task is observed. Executed via the
+   * platform shell, so simple values like `/path/to/supervisor.sh` and
+   * `bash /path/to/supervisor.sh --flag` both work.
+   */
+  command: string;
+  /** Working directory for the spawned process. Defaults to process cwd. */
+  cwd?: string;
+  /**
+   * Minimum seconds between successive launches; further failures within the
+   * window are skipped. Default: 0 (no cooldown).
+   */
+  cooldownSeconds?: number;
+}
 
 function readJsonSafe(path: string): InvokerConfig {
   if (!existsSync(path)) {

--- a/packages/app/src/external-failure-recovery.ts
+++ b/packages/app/src/external-failure-recovery.ts
@@ -1,0 +1,131 @@
+/**
+ * External failure-recovery launcher.
+ *
+ * Dormant helper: callers (e.g. failed-task delta handling) can ask this
+ * module to launch a configured supervisor command when a task fails. The
+ * in-app manual "Fix with AI" flow is unaffected — this is an additional
+ * out-of-process hook for operators who want their own recovery script.
+ *
+ * Time and process-launch dependencies are injectable so tests can drive
+ * the cooldown clock and observe spawn calls without touching real
+ * processes.
+ */
+
+import {
+  spawn as nodeSpawn,
+  type ChildProcess,
+  type SpawnOptions,
+} from 'node:child_process';
+
+import type { ExternalFailureRecoveryConfig } from './config.js';
+
+/** Per-failure context forwarded to the recovery process via env vars. */
+export interface RecoveryContext {
+  taskId: string;
+  workflowId: string;
+  repoRoot: string;
+  dbDir: string;
+}
+
+export type RecoverySkipReason =
+  | 'disabled'
+  | 'missing-command'
+  | 'cooldown'
+  | 'spawn-error';
+
+export type RecoveryLaunchResult =
+  | { launched: true; pid: number | undefined }
+  | { launched: false; reason: RecoverySkipReason; detail?: string };
+
+/** Minimal child-process surface the launcher relies on. */
+export type RecoverySpawnedChild = Pick<ChildProcess, 'pid' | 'unref'>;
+
+export type RecoverySpawnFn = (
+  command: string,
+  args: ReadonlyArray<string>,
+  options: SpawnOptions,
+) => RecoverySpawnedChild;
+
+export interface RecoveryLauncherDeps {
+  /** Monotonic-ish clock in ms; defaults to `Date.now`. */
+  now?: () => number;
+  /** Process launcher; defaults to `child_process.spawn`. */
+  spawn?: RecoverySpawnFn;
+  /** Base environment merged into the spawn env; defaults to `process.env`. */
+  baseEnv?: NodeJS.ProcessEnv;
+}
+
+export interface ExternalRecoveryLauncher {
+  launch(
+    config: ExternalFailureRecoveryConfig | undefined,
+    context: RecoveryContext,
+  ): RecoveryLaunchResult;
+}
+
+/**
+ * Build the exact env-var bag passed to the recovery process. Exposed for
+ * tests and for callers that want to log what would be forwarded.
+ */
+export function buildRecoveryEnv(
+  context: RecoveryContext,
+  baseEnv: NodeJS.ProcessEnv = {},
+): NodeJS.ProcessEnv {
+  return {
+    ...baseEnv,
+    INVOKER_FAILED_TASK_ID: context.taskId,
+    INVOKER_FAILED_WORKFLOW_ID: context.workflowId,
+    INVOKER_REPO_ROOT: context.repoRoot,
+    INVOKER_DB_DIR: context.dbDir,
+    INVOKER_RECOVERY_REASON: 'task_failed',
+  };
+}
+
+/**
+ * Create a launcher with its own private cooldown clock. Each launcher
+ * instance tracks the last successful launch independently, so callers
+ * with different scopes can keep separate cooldown windows.
+ */
+export function createExternalRecoveryLauncher(
+  deps: RecoveryLauncherDeps = {},
+): ExternalRecoveryLauncher {
+  const now = deps.now ?? Date.now;
+  const spawn = deps.spawn ?? (nodeSpawn as unknown as RecoverySpawnFn);
+  const baseEnv = deps.baseEnv ?? process.env;
+  let lastLaunchMs: number | null = null;
+
+  return {
+    launch(config, context) {
+      if (!config || !config.enabled) {
+        return { launched: false, reason: 'disabled' };
+      }
+
+      const command = typeof config.command === 'string' ? config.command.trim() : '';
+      if (command === '') {
+        return { launched: false, reason: 'missing-command' };
+      }
+
+      const cooldownMs = Math.max(0, (config.cooldownSeconds ?? 0) * 1000);
+      const tick = now();
+      if (cooldownMs > 0 && lastLaunchMs !== null && tick - lastLaunchMs < cooldownMs) {
+        return { launched: false, reason: 'cooldown' };
+      }
+
+      const env = buildRecoveryEnv(context, baseEnv);
+      try {
+        const child = spawn(command, [], {
+          cwd: config.cwd,
+          env,
+          shell: true,
+          detached: true,
+          stdio: 'ignore',
+        });
+        child.unref?.();
+        lastLaunchMs = tick;
+        return { launched: true, pid: child.pid ?? undefined };
+      } catch (err) {
+        const detail = err instanceof Error ? err.message : String(err);
+        return { launched: false, reason: 'spawn-error', detail };
+      }
+    },
+  };
+}

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -28,6 +28,11 @@ import {
   type AgentRegistry,
 } from '@invoker/execution-engine';
 import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from './config.js';
+import {
+  createExternalRecoveryLauncher,
+  type ExternalRecoveryLauncher,
+} from './external-failure-recovery.js';
+import { resolveInvokerHomeRoot } from './delete-all-snapshot.js';
 import { backupPlan } from './plan-backup.js';
 import { startApiServer } from './api-server.js';
 import { WorkflowMutationFacade } from './workflow-mutation-facade.js';
@@ -281,72 +286,63 @@ export function createHeadlessExecutor(
 }
 
 export function wireHeadlessAutoFix(
-  deps: Pick<HeadlessDeps, 'messageBus' | 'orchestrator' | 'persistence'>,
+  deps: Pick<HeadlessDeps, 'messageBus' | 'orchestrator' | 'persistence' | 'repoRoot'>,
   taskExecutor: Pick<TaskRunner, 'executeTasks' | 'fixWithAgent' | 'resolveConflict'>,
-  invokeAutoFix: (taskId: string) => Promise<void> = async (taskId) => {
-    const { autoFixOnFailure } = await import('./workflow-actions.js');
-    await autoFixOnFailure(taskId, {
-      orchestrator: deps.orchestrator,
-      persistence: deps.persistence,
-      taskExecutor: taskExecutor as TaskRunner,
-      getAutoFixAgent: () => loadConfig().autoFixAgent,
-      getAutoApproveAIFixes: () => loadConfig().autoApproveAIFixes,
-    });
-  },
+  launcher: ExternalRecoveryLauncher = createExternalRecoveryLauncher(),
   onError: (taskId: string, err: unknown) => void = (taskId, err) => {
-    process.stderr.write(`[auto-fix] "${taskId}": ${err}\n`);
+    process.stderr.write(`[external-recovery] "${taskId}": ${err}\n`);
   },
 ): HeadlessAutoFixController {
-  const autoFixInProgress = new Set<string>();
-  const logHeadlessAutoFixDebug = (
+  const logExternalRecoveryDebug = (
     taskId: string,
     phase: string,
     details: Record<string, unknown> = {},
   ): void => {
-    const getTask = (deps.orchestrator as { getTask?: (id: string) => unknown }).getTask;
-    const task = getTask?.(taskId) as
-      | { status?: string; execution?: { autoFixAttempts?: number | null } }
-      | undefined;
-    const payload = {
-      phase,
-      status: task?.status ?? 'missing',
-      autoFixAttempts: task?.execution?.autoFixAttempts ?? null,
-      inProgressCount: autoFixInProgress.size,
-      inProgressForTask: autoFixInProgress.has(taskId),
-      ...details,
-    };
-    deps.persistence.logEvent?.(taskId, 'debug.auto-fix', payload);
-    process.stderr.write(`[auto-fix-debug][headless] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}\n`);
+    const payload = { phase, ...details };
+    deps.persistence.logEvent?.(taskId, 'debug.external-recovery', payload);
+    process.stderr.write(
+      `[external-recovery][headless] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}\n`,
+    );
   };
 
   const unsubscribe = deps.messageBus.subscribe<TaskDelta>(Channels.TASK_DELTA, (delta) => {
     if (delta.type !== 'updated' || delta.changes.status !== 'failed') return;
-    const inProgress = autoFixInProgress.has(delta.taskId);
-    const shouldAutoFix = deps.orchestrator.shouldAutoFix(delta.taskId);
-    logHeadlessAutoFixDebug(delta.taskId, 'delta-failed', { shouldAutoFix, inProgress });
-    if (inProgress || !shouldAutoFix) {
-      logHeadlessAutoFixDebug(delta.taskId, 'schedule-skip', {
-        reason: !shouldAutoFix ? 'shouldAutoFix-false' : 'already-in-progress',
-      });
+    const config = loadConfig().externalFailureRecovery;
+    if (!config?.enabled) {
+      logExternalRecoveryDebug(delta.taskId, 'skip', { reason: 'disabled' });
       return;
     }
-    autoFixInProgress.add(delta.taskId);
-    logHeadlessAutoFixDebug(delta.taskId, 'dispatch');
-    void invokeAutoFix(delta.taskId)
-      .catch((err) => {
-        logHeadlessAutoFixDebug(delta.taskId, 'dispatch-error', {
-          error: err instanceof Error ? err.stack ?? err.message : String(err),
-        });
-        onError(delta.taskId, err);
-      })
-      .finally(() => {
-        autoFixInProgress.delete(delta.taskId);
-        logHeadlessAutoFixDebug(delta.taskId, 'dispatch-finished');
+    try {
+      const task = (deps.orchestrator as {
+        getTask?: (id: string) => { config?: { workflowId?: string } } | undefined;
+      }).getTask?.(delta.taskId);
+      const workflowId = task?.config?.workflowId;
+      if (!workflowId) {
+        logExternalRecoveryDebug(delta.taskId, 'skip', { reason: 'workflow-not-found' });
+        return;
+      }
+      const result = launcher.launch(config, {
+        taskId: delta.taskId,
+        workflowId,
+        repoRoot: deps.repoRoot,
+        dbDir: resolveInvokerHomeRoot(),
       });
+      if (result.launched) {
+        logExternalRecoveryDebug(delta.taskId, 'launched', { workflowId, pid: result.pid });
+      } else {
+        logExternalRecoveryDebug(delta.taskId, 'skip', {
+          workflowId,
+          reason: result.reason,
+          ...(result.detail ? { detail: result.detail } : {}),
+        });
+      }
+    } catch (err) {
+      onError(delta.taskId, err);
+    }
   });
   return {
     unsubscribe,
-    isBusy: () => autoFixInProgress.size > 0,
+    isBusy: () => false,
   };
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -159,6 +159,11 @@ import {
   WorkflowMetadataInvalidator,
 } from './workflow-metadata-invalidation.js';
 import { shouldSkipAutoFixForError } from './auto-fix-gating.js';
+import {
+  createExternalRecoveryLauncher,
+  type ExternalRecoveryLauncher,
+  type RecoveryLaunchResult,
+} from './external-failure-recovery.js';
 import type { WorkflowMutationPriority } from './workflow-mutation-coordinator.js';
 import { PersistedWorkflowMutationCoordinator } from './persisted-workflow-mutation-coordinator.js';
 import { LaunchDispatcher, type LaunchDispatcherMode } from './launch-dispatcher.js';
@@ -1603,57 +1608,47 @@ function createEmbeddedTerminalBackendFromConfig(
     return result.started;
   };
 
-  const scheduleAutoFix = (taskId: string): void => {
-    logAutoFixDebug(taskId, 'schedule-enter');
-    if (!workflowMutationCoordinator) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'no-workflow-mutation-coordinator' });
-      return;
-    }
-    if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'fix-handler-not-ready' });
+  const externalRecoveryLauncher: ExternalRecoveryLauncher = createExternalRecoveryLauncher();
+
+  const logExternalRecoveryDebug = (
+    taskId: string,
+    phase: string,
+    details: Record<string, unknown> = {},
+  ): void => {
+    const payload = { phase, ...details };
+    persistence.logEvent?.(taskId, 'debug.external-recovery', payload);
+    logger.info(
+      `[external-recovery] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}`,
+      { module: 'external-recovery' },
+    );
+  };
+
+  const dispatchExternalRecovery = (taskId: string): void => {
+    const config = loadConfig().externalFailureRecovery;
+    if (!config?.enabled) {
+      logExternalRecoveryDebug(taskId, 'skip', { reason: 'disabled' });
       return;
     }
     const workflowId = workflowIdForTaskArg(taskId);
     if (!workflowId) {
-      logAutoFixDebug(taskId, 'schedule-skip', { reason: 'workflow-not-found' });
+      logExternalRecoveryDebug(taskId, 'skip', { reason: 'workflow-not-found' });
       return;
     }
-    const shouldAutoFixNow = orchestrator.shouldAutoFix(taskId);
-    if (!shouldAutoFixNow) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'shouldAutoFix-false',
-        shouldAutoFix: shouldAutoFixNow,
-      });
-      return;
-    }
-    const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
-    const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
-    if (openTaskFixIntents.length > 0) {
-      logAutoFixDebug(taskId, 'schedule-skip', {
-        reason: 'already-queued-intent',
-        existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
-      });
-      return;
-    }
-    const configuredAgent = loadConfig().autoFixAgent?.trim();
-    const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
-    logAutoFixDebug(taskId, 'schedule-enqueue');
-    logAutoFixDebug(taskId, 'schedule-enqueued');
-    void runWorkflowMutation(
+    const result: RecoveryLaunchResult = externalRecoveryLauncher.launch(config, {
+      taskId,
       workflowId,
-      'normal',
-      'invoker:fix-with-agent',
-      [taskId, selectedAgent],
-      async () => executeFixWithAgentMutation(taskId, selectedAgent, 'auto-fix'),
-    )
-      .then(() => {
-        logAutoFixDebug(taskId, 'schedule-dispatch-finished');
-      })
-      .catch((err) => {
-        logAutoFixDebug(taskId, 'schedule-dispatch-error', {
-          error: err instanceof Error ? err.stack ?? err.message : String(err),
-        });
+      repoRoot,
+      dbDir: resolveInvokerHomeRoot(),
+    });
+    if (result.launched) {
+      logExternalRecoveryDebug(taskId, 'launched', { workflowId, pid: result.pid });
+    } else {
+      logExternalRecoveryDebug(taskId, 'skip', {
+        workflowId,
+        reason: result.reason,
+        ...(result.detail ? { detail: result.detail } : {}),
       });
+    }
   };
 
   const parseExecutionDate = (value: unknown): Date | undefined => {
@@ -2900,14 +2895,11 @@ function createEmbeddedTerminalBackendFromConfig(
         : undefined;
       if (d.type === 'updated' && d.changes.status === 'failed') {
         const cancellationError = shouldSkipAutoFixForError(d.changes.execution?.error);
-        const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(d.taskId);
-        logAutoFixDebug(d.taskId, 'delta-failed', {
+        logExternalRecoveryDebug(d.taskId, 'delta-failed', {
           shouldSkipForCancellation: cancellationError,
-          shouldAutoFixFromOrchestrator,
         });
-        if (!cancellationError && shouldAutoFixFromOrchestrator && deltaTaskId) {
-          logAutoFixDebug(deltaTaskId, 'delta-trigger-schedule');
-          scheduleAutoFix(deltaTaskId);
+        if (!cancellationError && deltaTaskId) {
+          dispatchExternalRecovery(deltaTaskId);
         }
       }
 

--- a/scripts/prod-recreate-supervisor.sh
+++ b/scripts/prod-recreate-supervisor.sh
@@ -1,0 +1,200 @@
+#!/usr/bin/env bash
+# External failure recovery supervisor.
+#
+# A long-running loop intended to replace the ad-hoc tmp supervisor that was
+# previously copied onto production hosts. Each cycle:
+#
+#   1. Synchronises the local refs/heads/master from upstream by fetching
+#      refs/heads/master:refs/remotes/upstream/master, resolving the upstream
+#      SHA, and updating the local ref with `git update-ref`. The supervisor
+#      does NOT check out master, reset the current branch, or touch the
+#      repo-pool mirror copies — those mutations have caused production
+#      incidents in the past.
+#   2. Queries every workflow via the headless CLI.
+#   3. Queues `recreate <wf_id>` for each failed workflow (fire-and-forget).
+#   4. Tracks how many workflows are still incomplete. If that count is
+#      unchanged for STALL_CYCLES consecutive cycles (i.e. the system is wedged
+#      on something external), queues `recreate <wf_id>` for every incomplete
+#      workflow as a wider unblocking action.
+#
+# Environment knobs:
+#   INTERVAL_SECONDS   Sleep between cycles. Default: 300.
+#   MAX_CYCLES         Stop after this many cycles. 0 = run forever. Default: 0.
+#   STALL_CYCLES       Consecutive unchanged-incomplete cycles before the
+#                      "recreate everything" branch fires. Default: 3.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# shellcheck source=scripts/headless-lib.sh
+source "$REPO_ROOT/scripts/headless-lib.sh"
+
+INTERVAL_SECONDS="${INTERVAL_SECONDS:-300}"
+MAX_CYCLES="${MAX_CYCLES:-0}"
+STALL_CYCLES="${STALL_CYCLES:-3}"
+
+for var in INTERVAL_SECONDS MAX_CYCLES STALL_CYCLES; do
+  value="${!var}"
+  if ! [[ "$value" =~ ^(0|[1-9][0-9]*)$ ]]; then
+    echo "Invalid $var: '$value' (expected non-negative integer)" >&2
+    exit 1
+  fi
+done
+
+if [[ "$INTERVAL_SECONDS" -lt 1 ]]; then
+  echo "INTERVAL_SECONDS must be >= 1" >&2
+  exit 1
+fi
+
+ts() { date -Is; }
+
+# ---------------------------------------------------------------------------
+# Phase 1 — host master ref sync.
+#
+# The earlier supervisor implementations would `git checkout master`,
+# `git reset --hard upstream/master`, or reach into repo-pool mirrors. Each of
+# those mutated state owned by other processes and produced wedge cases on
+# prod. This phase deliberately uses fetch + update-ref so the active worktree
+# branch and the repo-pool mirrors are untouched.
+# ---------------------------------------------------------------------------
+
+sync_master_ref() {
+  echo "[$(ts)] phase=sync-master-ref"
+
+  if ! git -C "$REPO_ROOT" fetch upstream refs/heads/master:refs/remotes/upstream/master; then
+    echo "  ! fetch upstream master failed; continuing" >&2
+    return 1
+  fi
+
+  local sha=""
+  if ! sha="$(git -C "$REPO_ROOT" rev-parse refs/remotes/upstream/master 2>/dev/null)"; then
+    echo "  ! cannot resolve refs/remotes/upstream/master" >&2
+    return 1
+  fi
+  if [[ -z "$sha" ]]; then
+    echo "  ! refs/remotes/upstream/master resolved to empty SHA" >&2
+    return 1
+  fi
+
+  if ! git -C "$REPO_ROOT" update-ref refs/heads/master "$sha"; then
+    echo "  ! update-ref refs/heads/master $sha failed" >&2
+    return 1
+  fi
+
+  echo "  refs/heads/master -> $sha"
+}
+
+# ---------------------------------------------------------------------------
+# Workflow queries.
+# ---------------------------------------------------------------------------
+
+# Emit "<wf_id>\t<status>" lines for every workflow.
+list_workflow_status_pairs() {
+  local json=""
+  json="$(headless_query query workflows --output json || true)"
+  WORKFLOWS_JSON_INPUT="$json" python3 - <<'PY'
+import json
+import os
+import sys
+
+raw = os.environ.get("WORKFLOWS_JSON_INPUT", "").strip()
+if not raw:
+    sys.exit(0)
+try:
+    workflows = json.loads(raw)
+except json.JSONDecodeError:
+    sys.exit(0)
+if not isinstance(workflows, list):
+    sys.exit(0)
+for wf in workflows:
+    if not isinstance(wf, dict):
+        continue
+    wf_id = wf.get("id")
+    status = wf.get("status")
+    if wf_id and status:
+        print(f"{wf_id}\t{status}")
+PY
+}
+
+# Enqueue a recreate for a single workflow id.
+recreate_workflow() {
+  local wf_id="$1"
+  local label="$2"
+  echo "[$(ts)] enqueue=recreate workflow=$wf_id reason=$label"
+  if headless_mutation --no-track recreate "$wf_id"; then
+    echo "  OK $wf_id"
+    return 0
+  fi
+  echo "  FAILED $wf_id" >&2
+  return 1
+}
+
+# ---------------------------------------------------------------------------
+# Cycle.
+# ---------------------------------------------------------------------------
+
+PREV_INCOMPLETE_COUNT=-1
+STALL_STREAK=0
+
+run_cycle() {
+  local cycle_no="$1"
+  echo "=== cycle $cycle_no (max=$MAX_CYCLES interval=${INTERVAL_SECONDS}s stall=$STALL_CYCLES) ==="
+
+  sync_master_ref || true
+
+  local pairs=""
+  pairs="$(list_workflow_status_pairs || true)"
+
+  local failed_ids="" incomplete_ids="" incomplete_count=0
+  if [[ -n "$pairs" ]]; then
+    failed_ids="$(printf '%s\n' "$pairs" | awk -F'\t' '$2 == "failed" { print $1 }')"
+    incomplete_ids="$(printf '%s\n' "$pairs" | awk -F'\t' '$2 == "running" || $2 == "failed" || $2 == "pending" { print $1 }')"
+  fi
+  incomplete_count="$(printf '%s\n' "$incomplete_ids" | sed '/^$/d' | wc -l | tr -d ' ')"
+
+  echo "  workflows incomplete=$incomplete_count"
+
+  if [[ -n "$failed_ids" ]]; then
+    while IFS= read -r wf; do
+      [[ -z "$wf" ]] && continue
+      recreate_workflow "$wf" failed-recreate || true
+    done <<< "$failed_ids"
+  fi
+
+  # Stall detection: incomplete count unchanged across consecutive cycles.
+  if [[ "$PREV_INCOMPLETE_COUNT" -ge 0 ]] \
+     && [[ "$incomplete_count" -eq "$PREV_INCOMPLETE_COUNT" ]] \
+     && [[ "$incomplete_count" -gt 0 ]]; then
+    STALL_STREAK=$((STALL_STREAK + 1))
+  else
+    STALL_STREAK=0
+  fi
+  PREV_INCOMPLETE_COUNT="$incomplete_count"
+
+  echo "  stall streak=$STALL_STREAK threshold=$STALL_CYCLES"
+
+  if [[ "$STALL_STREAK" -ge "$STALL_CYCLES" ]] && [[ -n "$incomplete_ids" ]]; then
+    echo "  STALL detected — recreating all incomplete workflows"
+    while IFS= read -r wf; do
+      [[ -z "$wf" ]] && continue
+      recreate_workflow "$wf" stall-recreate-all || true
+    done <<< "$incomplete_ids"
+    STALL_STREAK=0
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Main loop.
+# ---------------------------------------------------------------------------
+
+cycle=0
+while :; do
+  cycle=$((cycle + 1))
+  run_cycle "$cycle"
+  if [[ "$MAX_CYCLES" -gt 0 ]] && [[ "$cycle" -ge "$MAX_CYCLES" ]]; then
+    echo "Reached MAX_CYCLES=$MAX_CYCLES; exiting."
+    break
+  fi
+  echo "Sleeping ${INTERVAL_SECONDS}s..."
+  sleep "$INTERVAL_SECONDS"
+done

--- a/scripts/test-suites/required/25-prod-recreate-supervisor.sh
+++ b/scripts/test-suites/required/25-prod-recreate-supervisor.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Focused coverage for scripts/prod-recreate-supervisor.sh.
+#
+# Proves three things:
+#   1. The script contains the expected `git fetch upstream` /
+#      `git update-ref refs/heads/master` lines and is missing the
+#      forbidden checkout/reset-hard/repo-pool mutations.
+#   2. A single cycle, when wired against mocked git + run.sh, actually
+#      invokes fetch + update-ref with the right argument shape.
+#   3. A single cycle queues a `recreate <wf_id>` mutation per failed
+#      workflow (and only for failed workflows when no stall is detected).
+#      A multi-cycle stall scenario triggers `recreate` for every incomplete
+#      workflow once STALL_CYCLES is reached.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+SCRIPT="$ROOT/scripts/prod-recreate-supervisor.sh"
+HEADLESS_LIB="$ROOT/scripts/headless-lib.sh"
+
+[[ -f "$SCRIPT" ]] || { echo "FAIL: missing $SCRIPT"; exit 1; }
+[[ -x "$SCRIPT" ]] || { echo "FAIL: $SCRIPT is not executable"; exit 1; }
+[[ -f "$HEADLESS_LIB" ]] || { echo "FAIL: missing $HEADLESS_LIB"; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Phase A — static content checks.
+# ---------------------------------------------------------------------------
+
+# Required commands (positive checks).
+grep -qE 'git[^#]*fetch[^#]*upstream[^#]*refs/heads/master:refs/remotes/upstream/master' "$SCRIPT" \
+  || { echo "FAIL: missing 'git fetch upstream refs/heads/master:refs/remotes/upstream/master'"; exit 1; }
+
+grep -qE 'git[^#]*rev-parse[^#]*refs/remotes/upstream/master' "$SCRIPT" \
+  || { echo "FAIL: missing 'git rev-parse refs/remotes/upstream/master'"; exit 1; }
+
+grep -qE 'git[^#]*update-ref[^#]*refs/heads/master' "$SCRIPT" \
+  || { echo "FAIL: missing 'git update-ref refs/heads/master'"; exit 1; }
+
+# Required env knobs.
+for var in INTERVAL_SECONDS MAX_CYCLES STALL_CYCLES; do
+  grep -qE "${var}:-" "$SCRIPT" \
+    || { echo "FAIL: missing env knob ${var}"; exit 1; }
+done
+
+# Forbidden mutations (negative checks). Strip comments so the *script behaviour*
+# is what we check, not the explanatory header.
+CODE_ONLY="$(sed -E 's/[[:space:]]*#.*$//' "$SCRIPT")"
+if grep -qE 'git[[:space:]]+(-C[[:space:]]+[^[:space:]]+[[:space:]]+)?checkout[[:space:]]+master' <<<"$CODE_ONLY"; then
+  echo "FAIL: forbidden 'git checkout master' present in script body"; exit 1
+fi
+if grep -qE 'reset[[:space:]]+--hard' <<<"$CODE_ONLY"; then
+  echo "FAIL: forbidden 'reset --hard' present in script body"; exit 1
+fi
+if grep -qE 'repo-pool' <<<"$CODE_ONLY"; then
+  echo "FAIL: forbidden 'repo-pool' mutation reference present in script body"; exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Test harness — copy script + headless-lib into a sandbox repo root with
+# mock electron / run.sh / git binaries so behaviour can be observed.
+# ---------------------------------------------------------------------------
+
+TMP="$(mktemp -d -t prod-recreate-supervisor-test.XXXXXX)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/scripts" "$TMP/packages/app/dist" "$TMP/state" "$TMP/bin"
+
+cp "$SCRIPT" "$TMP/scripts/prod-recreate-supervisor.sh"
+cp "$HEADLESS_LIB" "$TMP/scripts/headless-lib.sh"
+chmod +x "$TMP/scripts/prod-recreate-supervisor.sh"
+
+# Mock electron.cjs — only needs to satisfy `query workflows --output json`.
+cat > "$TMP/scripts/electron.cjs" <<'NODE'
+#!/usr/bin/env node
+const fs = require('node:fs');
+const args = process.argv.slice(2);
+const isHeadless = args.includes('--headless');
+const subIdx = args.indexOf('query');
+const sub = subIdx >= 0 ? args[subIdx + 1] : '';
+if (isHeadless && sub === 'workflows') {
+  const fixture = process.env.MOCK_WORKFLOWS_JSON_FILE || '';
+  if (fixture && fs.existsSync(fixture)) {
+    process.stdout.write(fs.readFileSync(fixture, 'utf8'));
+  } else {
+    process.stdout.write('[]');
+  }
+  process.exit(0);
+}
+process.exit(0);
+NODE
+chmod +x "$TMP/scripts/electron.cjs"
+
+# Stub main.js so the path exists; the mock electron.cjs ignores its contents.
+: > "$TMP/packages/app/dist/main.js"
+
+# Mock run.sh — captures every headless mutation as a single line in the log.
+cat > "$TMP/run.sh" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${MOCK_MUTATION_LOG:?MOCK_MUTATION_LOG required}"
+if [[ "${1:-}" != "--headless" ]]; then
+  echo "mock run.sh expected --headless, got: $*" >&2
+  exit 1
+fi
+shift
+printf '%s\n' "$*" >> "$log"
+BASH
+chmod +x "$TMP/run.sh"
+
+# Mock git — record every invocation (sans leading `-C <dir>`) and answer
+# `rev-parse refs/remotes/upstream/master` with a deterministic SHA.
+cat > "$TMP/bin/git" <<'BASH'
+#!/usr/bin/env bash
+set -euo pipefail
+log="${MOCK_GIT_LOG:?MOCK_GIT_LOG required}"
+args=("$@")
+if [[ "${args[0]:-}" == "-C" ]]; then
+  args=("${args[@]:2}")
+fi
+printf '%s\n' "${args[*]}" >> "$log"
+case "${args[*]}" in
+  "rev-parse refs/remotes/upstream/master")
+    printf '%s\n' "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    ;;
+esac
+exit 0
+BASH
+chmod +x "$TMP/bin/git"
+
+# Fixture: 2 failed, 1 running, 1 completed. Incomplete count = 3 (stable).
+FIX="$TMP/state/workflows.json"
+cat > "$FIX" <<'JSON'
+[
+  {"id":"wf-1000-1","status":"failed"},
+  {"id":"wf-1001-1","status":"failed"},
+  {"id":"wf-1002-1","status":"running"},
+  {"id":"wf-1003-1","status":"completed"}
+]
+JSON
+
+run_supervisor() {
+  local mutation_log="$1"
+  local git_log="$2"
+  local max_cycles="$3"
+  local stall_cycles="$4"
+  : > "$mutation_log"
+  : > "$git_log"
+  env PATH="$TMP/bin:$PATH" \
+    INVOKER_HEADLESS_STANDALONE=1 \
+    MOCK_WORKFLOWS_JSON_FILE="$FIX" \
+    MOCK_MUTATION_LOG="$mutation_log" \
+    MOCK_GIT_LOG="$git_log" \
+    INTERVAL_SECONDS=1 \
+    MAX_CYCLES="$max_cycles" \
+    STALL_CYCLES="$stall_cycles" \
+    bash "$TMP/scripts/prod-recreate-supervisor.sh" > "$TMP/state/run.out" 2>&1 \
+    || { echo "FAIL: supervisor exited non-zero"; cat "$TMP/state/run.out"; exit 1; }
+}
+
+# ---------------------------------------------------------------------------
+# Phase B — single cycle: git fetch + update-ref + recreate failed only.
+# ---------------------------------------------------------------------------
+
+MUT_LOG="$TMP/state/mutations-1.log"
+GIT_LOG="$TMP/state/git-1.log"
+run_supervisor "$MUT_LOG" "$GIT_LOG" 1 10
+
+grep -qxF 'fetch upstream refs/heads/master:refs/remotes/upstream/master' "$GIT_LOG" \
+  || { echo "FAIL: expected upstream fetch invocation"; echo "--- git log ---"; cat "$GIT_LOG"; exit 1; }
+
+grep -qxF 'rev-parse refs/remotes/upstream/master' "$GIT_LOG" \
+  || { echo "FAIL: expected rev-parse of refs/remotes/upstream/master"; cat "$GIT_LOG"; exit 1; }
+
+grep -qxF 'update-ref refs/heads/master deadbeefdeadbeefdeadbeefdeadbeefdeadbeef' "$GIT_LOG" \
+  || { echo "FAIL: expected update-ref with resolved SHA"; cat "$GIT_LOG"; exit 1; }
+
+if grep -qE '^(checkout|reset)' "$GIT_LOG"; then
+  echo "FAIL: supervisor invoked checkout/reset"; cat "$GIT_LOG"; exit 1
+fi
+
+# Failed workflows recreated.
+grep -qxF -- '--no-track recreate wf-1000-1' "$MUT_LOG" \
+  || { echo "FAIL: missing recreate enqueue for wf-1000-1"; cat "$MUT_LOG"; exit 1; }
+grep -qxF -- '--no-track recreate wf-1001-1' "$MUT_LOG" \
+  || { echo "FAIL: missing recreate enqueue for wf-1001-1"; cat "$MUT_LOG"; exit 1; }
+
+# Without a stall, running/completed workflows are not touched.
+if grep -qxF -- '--no-track recreate wf-1002-1' "$MUT_LOG"; then
+  echo "FAIL: unexpected recreate of running workflow before stall"; cat "$MUT_LOG"; exit 1
+fi
+if grep -qxF -- '--no-track recreate wf-1003-1' "$MUT_LOG"; then
+  echo "FAIL: unexpected recreate of completed workflow"; cat "$MUT_LOG"; exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Phase C — stall scenario: same incomplete count across STALL_CYCLES cycles
+# triggers recreate of every incomplete workflow (including running).
+# ---------------------------------------------------------------------------
+
+MUT_LOG="$TMP/state/mutations-stall.log"
+GIT_LOG="$TMP/state/git-stall.log"
+# Cycle 1: baseline (streak=0). Cycle 2: streak=1. Cycle 3: streak=2 >= 2 → fire.
+run_supervisor "$MUT_LOG" "$GIT_LOG" 3 2
+
+grep -qxF -- '--no-track recreate wf-1002-1' "$MUT_LOG" \
+  || { echo "FAIL: stall did not trigger recreate of running workflow"; cat "$MUT_LOG"; exit 1; }
+
+# Completed workflows must stay untouched even under stall.
+if grep -qxF -- '--no-track recreate wf-1003-1' "$MUT_LOG"; then
+  echo "FAIL: stall recreate touched a completed workflow"; cat "$MUT_LOG"; exit 1
+fi
+
+# Fetch must be re-issued every cycle (3 of them here).
+fetch_count="$(grep -cxF 'fetch upstream refs/heads/master:refs/remotes/upstream/master' "$GIT_LOG" || true)"
+if [[ "$fetch_count" -ne 3 ]]; then
+  echo "FAIL: expected 3 upstream fetches across 3 cycles, got $fetch_count"; cat "$GIT_LOG"; exit 1
+fi
+
+echo "PASS: prod-recreate-supervisor enforces upstream master ref sync, safe-mode git, and correct recreate enqueue shape"


### PR DESCRIPTION
Validation passed. Here is the final PR body:

## Summary

Replace the automatic `invoker:fix-with-agent` mutation queue path for failed tasks with an external recovery hook. When `externalFailureRecovery` is configured, failed task deltas spawn a detached supervisor process instead of enqueuing an in-process AI fix. Manual "Fix with AI" via IPC and headless commands is preserved.

Adds a production supervisor script (`scripts/prod-recreate-supervisor.sh`) that syncs the host `refs/heads/master` to `upstream/master` via `git update-ref` (no checkout/reset) and recreates failed workflows through the existing headless owner delegation path.

## Architecture

### Before

```mermaid
graph TD
    A["Task delta: status=failed"] --> B{"shouldAutoFix?"}
    B -- yes --> C["scheduleAutoFix / invokeAutoFix"]
    C --> D["workflowMutationCoordinator.enqueue"]
    D --> E["invoker:fix-with-agent handler"]
    E --> F["In-process AI fix attempt"]
    B -- no --> G["Skip"]
```

### After

```mermaid
graph TD
    A["Task delta: status=failed"] --> B{"externalFailureRecovery.enabled?"}
    B -- yes --> C["externalRecoveryLauncher.launch()"]
    C --> D{"Cooldown elapsed?"}
    D -- yes --> E["spawn detached supervisor process"]
    E --> F["Env: INVOKER_FAILED_WORKFLOW_ID, etc."]
    D -- no --> G["Skip (cooldown)"]
    B -- no --> H["Skip (disabled)"]
```

## Test Plan

- [x] `cd packages/app && pnpm test -- src/__tests__/external-failure-recovery.test.ts src/__tests__/headless-autofix.test.ts src/__tests__/workflow-actions.test.ts`
- [x] `bash scripts/test-suites/required/25-prod-recreate-supervisor.sh`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — reverts to the prior `invoker:fix-with-agent` auto-trigger behavior
- Data migration? No