### PR TITLE
External recovery Step 1: config and launcher

### DIFF
--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -220,6 +220,26 @@ describe('loadConfig', () => {
     expect(config.defaultPoolId).toBe('mixed-local-ssh');
   });
 
+  it('reads externalFailureRecovery from user config', () => {
+    const externalFailureRecovery = {
+      enabled: true,
+      command: 'node ./scripts/recover.js',
+      cwd: '/srv/invoker',
+      cooldownSeconds: 30,
+    };
+    writeFileSync(
+      join(fakeHome, '.invoker', 'config.json'),
+      JSON.stringify({ externalFailureRecovery }),
+    );
+    const config = loadConfig();
+    expect(config.externalFailureRecovery).toEqual(externalFailureRecovery);
+  });
+
+  it('omits externalFailureRecovery when not configured', () => {
+    const config = loadConfig();
+    expect(config.externalFailureRecovery).toBeUndefined();
+  });
+
 });
 
 describe('resolveEmbeddedTerminalBackendConfig', () => {

--- a/packages/app/src/__tests__/external-failure-recovery.test.ts
+++ b/packages/app/src/__tests__/external-failure-recovery.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  buildRecoveryEnv,
+  createExternalRecoveryLauncher,
+  type RecoveryContext,
+  type ExternalFailureRecoveryConfig,
+} from '../external-failure-recovery.js';
+
+const CONTEXT: RecoveryContext = {
+  failedTaskId: 'task-123',
+  failedWorkflowId: 'wf-456',
+  repoRoot: '/srv/repo',
+  dbDir: '/srv/repo/.invoker/db',
+  reason: 'executing-stall',
+};
+
+/** Build a fake spawn that records its args and returns a stub child with unref. */
+function makeSpawn(overrides: { pid?: number; throws?: Error } = {}) {
+  const unref = vi.fn();
+  const calls: Array<{ command: unknown; options: unknown }> = [];
+  const spawn = vi.fn((command: unknown, options: unknown) => {
+    calls.push({ command, options });
+    if (overrides.throws) throw overrides.throws;
+    return { pid: overrides.pid ?? 4242, unref } as never;
+  });
+  return { spawn: spawn as never, unref, calls };
+}
+
+describe('buildRecoveryEnv', () => {
+  it('layers the INVOKER_* failure vars on top of the base env', () => {
+    const env = buildRecoveryEnv(CONTEXT, { PATH: '/usr/bin', EXISTING: 'keep' });
+    expect(env.PATH).toBe('/usr/bin');
+    expect(env.EXISTING).toBe('keep');
+    expect(env.INVOKER_FAILED_TASK_ID).toBe('task-123');
+    expect(env.INVOKER_FAILED_WORKFLOW_ID).toBe('wf-456');
+    expect(env.INVOKER_REPO_ROOT).toBe('/srv/repo');
+    expect(env.INVOKER_DB_DIR).toBe('/srv/repo/.invoker/db');
+    expect(env.INVOKER_RECOVERY_REASON).toBe('executing-stall');
+  });
+
+  it('lets recovery vars override colliding base env keys', () => {
+    const env = buildRecoveryEnv(CONTEXT, { INVOKER_FAILED_TASK_ID: 'stale' });
+    expect(env.INVOKER_FAILED_TASK_ID).toBe('task-123');
+  });
+
+  it('does not mutate the provided base env', () => {
+    const base = { PATH: '/usr/bin' } as NodeJS.ProcessEnv;
+    buildRecoveryEnv(CONTEXT, base);
+    expect(base.INVOKER_FAILED_TASK_ID).toBeUndefined();
+  });
+});
+
+describe('createExternalRecoveryLauncher', () => {
+  const enabledConfig: ExternalFailureRecoveryConfig = {
+    enabled: true,
+    command: 'node ./recover.js',
+    cwd: '/srv/repo',
+    cooldownSeconds: 0,
+  };
+
+  it('returns disabled when config is absent', () => {
+    const { spawn } = makeSpawn();
+    const launcher = createExternalRecoveryLauncher({ config: undefined, spawn });
+    expect(launcher.launch(CONTEXT)).toEqual({ status: 'disabled' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('returns disabled when enabled is not true', () => {
+    const { spawn } = makeSpawn();
+    const launcher = createExternalRecoveryLauncher({
+      config: { ...enabledConfig, enabled: false },
+      spawn,
+    });
+    expect(launcher.launch(CONTEXT)).toEqual({ status: 'disabled' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('returns missing-command when command is empty or whitespace', () => {
+    const { spawn } = makeSpawn();
+    const launcher = createExternalRecoveryLauncher({
+      config: { enabled: true, command: '   ' },
+      spawn,
+    });
+    expect(launcher.launch(CONTEXT)).toEqual({ status: 'missing-command' });
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  it('returns missing-command when command is absent', () => {
+    const { spawn } = makeSpawn();
+    const launcher = createExternalRecoveryLauncher({
+      config: { enabled: true },
+      spawn,
+    });
+    expect(launcher.launch(CONTEXT)).toEqual({ status: 'missing-command' });
+  });
+
+  it('launches with shell, detached, ignored stdio, cwd, and recovery env', () => {
+    const { spawn, unref, calls } = makeSpawn({ pid: 777 });
+    const launcher = createExternalRecoveryLauncher({
+      config: enabledConfig,
+      spawn,
+      baseEnv: { PATH: '/usr/bin' },
+    });
+    const result = launcher.launch(CONTEXT);
+    expect(result).toEqual({ status: 'launched', pid: 777 });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.command).toBe('node ./recover.js');
+    const options = calls[0]?.options as Record<string, unknown>;
+    expect(options.shell).toBe(true);
+    expect(options.detached).toBe(true);
+    expect(options.stdio).toBe('ignore');
+    expect(options.cwd).toBe('/srv/repo');
+    const env = options.env as NodeJS.ProcessEnv;
+    expect(env.PATH).toBe('/usr/bin');
+    expect(env.INVOKER_FAILED_TASK_ID).toBe('task-123');
+    expect(env.INVOKER_FAILED_WORKFLOW_ID).toBe('wf-456');
+    expect(env.INVOKER_REPO_ROOT).toBe('/srv/repo');
+    expect(env.INVOKER_DB_DIR).toBe('/srv/repo/.invoker/db');
+    expect(env.INVOKER_RECOVERY_REASON).toBe('executing-stall');
+    expect(unref).toHaveBeenCalledOnce();
+  });
+
+  it('returns spawn-error when spawning throws', () => {
+    const { spawn } = makeSpawn({ throws: new Error('boom') });
+    const launcher = createExternalRecoveryLauncher({ config: enabledConfig, spawn });
+    const result = launcher.launch(CONTEXT);
+    expect(result.status).toBe('spawn-error');
+    if (result.status === 'spawn-error') {
+      expect(result.error.message).toBe('boom');
+    }
+  });
+
+  it('does not arm cooldown after a spawn error', () => {
+    let attempt = 0;
+    const unref = vi.fn();
+    const spawn = vi.fn(() => {
+      attempt += 1;
+      if (attempt === 1) throw new Error('transient');
+      return { pid: 9, unref } as never;
+    }) as never;
+    const launcher = createExternalRecoveryLauncher({
+      config: { ...enabledConfig, cooldownSeconds: 60 },
+      spawn,
+      now: () => 1000,
+    });
+    expect(launcher.launch(CONTEXT).status).toBe('spawn-error');
+    // Retry is allowed because the failed attempt did not arm the cooldown.
+    expect(launcher.launch(CONTEXT).status).toBe('launched');
+  });
+
+  it('enforces cooldown keyed by launcher instance', () => {
+    const { spawn } = makeSpawn();
+    let nowMs = 0;
+    const launcher = createExternalRecoveryLauncher({
+      config: { ...enabledConfig, cooldownSeconds: 30 },
+      spawn,
+      now: () => nowMs,
+    });
+
+    expect(launcher.launch(CONTEXT).status).toBe('launched');
+
+    nowMs = 10_000; // 10s later, still inside the 30s window
+    const cooled = launcher.launch(CONTEXT);
+    expect(cooled.status).toBe('cooldown');
+    if (cooled.status === 'cooldown') {
+      expect(cooled.remainingSeconds).toBeCloseTo(20, 5);
+    }
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    nowMs = 30_000; // exactly cooldown elapsed
+    expect(launcher.launch(CONTEXT).status).toBe('launched');
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps cooldown state independent between launcher instances', () => {
+    const { spawn } = makeSpawn();
+    const config = { ...enabledConfig, cooldownSeconds: 30 };
+    const a = createExternalRecoveryLauncher({ config, spawn, now: () => 0 });
+    const b = createExternalRecoveryLauncher({ config, spawn, now: () => 0 });
+    expect(a.launch(CONTEXT).status).toBe('launched');
+    // b has its own cooldown state, so it is not blocked by a's launch.
+    expect(b.launch(CONTEXT).status).toBe('launched');
+  });
+
+  it('launches without cooldown when cooldownSeconds is 0', () => {
+    const { spawn } = makeSpawn();
+    let nowMs = 0;
+    const launcher = createExternalRecoveryLauncher({
+      config: enabledConfig,
+      spawn,
+      now: () => nowMs,
+    });
+    expect(launcher.launch(CONTEXT).status).toBe('launched');
+    nowMs = 1;
+    expect(launcher.launch(CONTEXT).status).toBe('launched');
+    expect(spawn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -51,6 +51,28 @@ export interface InvokerConfig {
    */
   autoFixCi?: boolean;
   /**
+   * Dormant external failure-recovery hook.
+   *
+   * When present and `enabled`, an external supervisor process can be launched
+   * via the standalone launcher helper in `external-failure-recovery.ts` to react
+   * to failed tasks. This config is intentionally inert: no failed-task delta path
+   * activates it yet. It exists so the external process contract can be reviewed
+   * before failed-task routing is wired up.
+   */
+  externalFailureRecovery?: {
+    /** Set true to permit the launcher to spawn the recovery command. Default: false. */
+    enabled?: boolean;
+    /** Shell command line executed (with `shell: true`) when recovery is launched. */
+    command?: string;
+    /** Working directory for the spawned recovery process. Defaults to the launcher's process cwd. */
+    cwd?: string;
+    /**
+     * Minimum number of seconds between launches for a single launcher instance.
+     * Launches requested within the cooldown window are skipped. Default: 0 (no cooldown).
+     */
+    cooldownSeconds?: number;
+  };
+  /**
    * Read-only diagnostics tuning for the Action Graph view.
    * Default stall threshold: 60000ms. Env fallback:
    * INVOKER_ACTION_STALL_THRESHOLD_MS.

--- a/packages/app/src/external-failure-recovery.ts
+++ b/packages/app/src/external-failure-recovery.ts
@@ -1,0 +1,159 @@
+/**
+ * Dormant external failure-recovery launcher.
+ *
+ * This module provides the typed contract and a standalone launcher helper for
+ * handing a failed task off to an external supervisor process. It is intentionally
+ * inert: nothing in the failed-task delta path calls into it yet. It exists so the
+ * external process hook can be reviewed before failed-task routing is changed.
+ *
+ * See `InvokerConfig.externalFailureRecovery` in `config.ts` for the config shape.
+ */
+
+import { spawn as defaultSpawn } from 'node:child_process';
+import type { InvokerConfig } from './config.js';
+
+/** Resolved (non-optional wrapper) shape of the external recovery config block. */
+export type ExternalFailureRecoveryConfig = NonNullable<
+  InvokerConfig['externalFailureRecovery']
+>;
+
+/**
+ * Identifying information about the failure that triggered a recovery launch.
+ * Each field is exported to the spawned process as an `INVOKER_*` environment
+ * variable (see {@link buildRecoveryEnv}).
+ */
+export interface RecoveryContext {
+  /** ID of the failed task. Exported as INVOKER_FAILED_TASK_ID. */
+  failedTaskId: string;
+  /** ID of the workflow the failed task belongs to. Exported as INVOKER_FAILED_WORKFLOW_ID. */
+  failedWorkflowId: string;
+  /** Absolute path to the repository root. Exported as INVOKER_REPO_ROOT. */
+  repoRoot: string;
+  /** Directory containing the Invoker database. Exported as INVOKER_DB_DIR. */
+  dbDir: string;
+  /** Human-readable reason describing why recovery was requested. Exported as INVOKER_RECOVERY_REASON. */
+  reason: string;
+}
+
+/**
+ * Outcome of a single {@link ExternalRecoveryLauncher.launch} call.
+ *
+ * - `disabled`: config absent or `enabled !== true`.
+ * - `missing-command`: enabled but no non-empty command configured.
+ * - `cooldown`: a previous launch on this launcher instance is still within the cooldown window.
+ * - `launched`: the recovery command was spawned.
+ * - `spawn-error`: spawning threw synchronously.
+ */
+export type RecoveryLaunchResult =
+  | { status: 'disabled' }
+  | { status: 'missing-command' }
+  | { status: 'cooldown'; remainingSeconds: number }
+  | { status: 'launched'; pid?: number }
+  | { status: 'spawn-error'; error: Error };
+
+export interface ExternalRecoveryLauncher {
+  /** Attempt to launch the configured recovery command for the given failure context. */
+  launch(context: RecoveryContext): RecoveryLaunchResult;
+}
+
+export interface ExternalRecoveryLauncherOptions {
+  /** The `externalFailureRecovery` block from `InvokerConfig`, if any. */
+  config: ExternalFailureRecoveryConfig | undefined;
+  /** Injectable spawn (defaults to `node:child_process` spawn). */
+  spawn?: typeof defaultSpawn;
+  /** Injectable monotonic-ish clock in milliseconds (defaults to `Date.now`). */
+  now?: () => number;
+  /** Base environment inherited by the spawned process (defaults to `process.env`). */
+  baseEnv?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Build the environment for a recovery process: the inherited base env with the
+ * failure-context `INVOKER_*` variables layered on top (recovery vars override).
+ */
+export function buildRecoveryEnv(
+  context: RecoveryContext,
+  baseEnv: NodeJS.ProcessEnv = process.env,
+): NodeJS.ProcessEnv {
+  return {
+    ...baseEnv,
+    INVOKER_FAILED_TASK_ID: context.failedTaskId,
+    INVOKER_FAILED_WORKFLOW_ID: context.failedWorkflowId,
+    INVOKER_REPO_ROOT: context.repoRoot,
+    INVOKER_DB_DIR: context.dbDir,
+    INVOKER_RECOVERY_REASON: context.reason,
+  };
+}
+
+/**
+ * Create a standalone external-recovery launcher.
+ *
+ * Cooldown is keyed by launcher instance: each launcher tracks the timestamp of
+ * its own last successful launch and rejects further launches until
+ * `cooldownSeconds` has elapsed. Separate launcher instances have independent
+ * cooldown state.
+ *
+ * The returned launcher does not activate any failed-task path on its own; callers
+ * must invoke `launch` explicitly.
+ */
+export function createExternalRecoveryLauncher(
+  options: ExternalRecoveryLauncherOptions,
+): ExternalRecoveryLauncher {
+  const {
+    config,
+    spawn = defaultSpawn,
+    now = () => Date.now(),
+    baseEnv = process.env,
+  } = options;
+
+  // Cooldown state is private to this launcher instance.
+  let lastLaunchAt: number | null = null;
+
+  return {
+    launch(context: RecoveryContext): RecoveryLaunchResult {
+      if (!config || config.enabled !== true) {
+        return { status: 'disabled' };
+      }
+
+      const command =
+        typeof config.command === 'string' ? config.command.trim() : '';
+      if (command === '') {
+        return { status: 'missing-command' };
+      }
+
+      const cooldownSeconds = Math.max(0, config.cooldownSeconds ?? 0);
+      const currentTime = now();
+      if (cooldownSeconds > 0 && lastLaunchAt !== null) {
+        const elapsedSeconds = (currentTime - lastLaunchAt) / 1000;
+        if (elapsedSeconds < cooldownSeconds) {
+          return {
+            status: 'cooldown',
+            remainingSeconds: Math.max(0, cooldownSeconds - elapsedSeconds),
+          };
+        }
+      }
+
+      const env = buildRecoveryEnv(context, baseEnv);
+      try {
+        const child = spawn(command, {
+          shell: true,
+          detached: true,
+          stdio: 'ignore',
+          cwd: config.cwd,
+          env,
+        });
+        // Only successful spawns arm the cooldown so transient failures can retry.
+        lastLaunchAt = currentTime;
+        if (child && typeof child.unref === 'function') {
+          child.unref();
+        }
+        return { status: 'launched', pid: child?.pid };
+      } catch (error) {
+        return {
+          status: 'spawn-error',
+          error: error instanceof Error ? error : new Error(String(error)),
+        };
+      }
+    },
+  };
+}


### PR DESCRIPTION
Validation passes with no warnings.

## Summary

Add a dormant external failure-recovery configuration block and a standalone launcher helper. Failed-task behavior is unchanged: nothing in the failed-task delta path calls the helper yet.

This is the first PR in the replacement stack for the previous monolithic External failure recovery supervisor workflow. It keeps the new process boundary reviewable on its own.

The config gains an optional `externalFailureRecovery` block exposing `enabled`, `command`, `cwd`, and `cooldownSeconds`. Config parsing now surfaces these fields from user config.

The launcher spawns a detached shell command and exports the failure context as `INVOKER_FAILED_TASK_ID`, `INVOKER_FAILED_WORKFLOW_ID`, `INVOKER_REPO_ROOT`, `INVOKER_DB_DIR`, and `INVOKER_RECOVERY_REASON`.

It enforces per-instance cooldown and reports `disabled`, `missing-command`, `cooldown`, `launched`, and `spawn-error` outcomes. Only successful spawns arm the cooldown so transient failures can retry.

## Test Plan

- [ ] `cd packages/app && pnpm test -- src/__tests__/config.test.ts src/__tests__/external-failure-recovery.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None. The code is dormant and has no callers, so reverting removes only unused config and an unused helper.
- Data migration? No