### PR TITLE
Fix workflow delete and build DTS noise

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "echo 'compat package: tests moved to @invoker/workflow-core'",
     "test:watch": "echo 'compat package: tests moved to @invoker/workflow-core'",
     "clean": "rm -rf dist"

--- a/packages/core/tsconfig.build.json
+++ b/packages/core/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/data-store/package.json
+++ b/packages/data-store/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1512,6 +1512,36 @@ describe('SQLiteAdapter', () => {
       expect(adapter.listWorkflows()).toHaveLength(1);
     });
 
+    it('deletes workflow with mutation intents, leases, and launch dispatch rows', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      const attempt = createAttempt('t1', { status: 'running' });
+      adapter.saveAttempt(attempt);
+
+      const intentId = adapter.enqueueWorkflowMutationIntent(
+        'wf-1', 'test-channel', [{ action: 'delete' }], 'normal',
+      );
+      adapter.claimWorkflowMutationLease('wf-1', 'owner-1', {
+        activeIntentId: intentId,
+        activeMutationKind: 'delete',
+      });
+      adapter.enqueueLaunchDispatch({
+        taskId: 't1',
+        attemptId: attempt.id,
+        workflowId: 'wf-1',
+        generation: 1,
+      });
+
+      expect(() => adapter.deleteWorkflow('wf-1')).not.toThrow();
+
+      expect(adapter.loadWorkflow('wf-1')).toBeUndefined();
+      expect(adapter.loadTasks('wf-1')).toEqual([]);
+      expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM workflow_mutation_intents WHERE workflow_id = 'wf-1'")).toBe(0);
+      expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM workflow_mutation_leases WHERE workflow_id = 'wf-1'")).toBe(0);
+      expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM task_launch_dispatch WHERE workflow_id = 'wf-1'")).toBe(0);
+    });
+
     it('removes output spool rows and tail cache only for deleted workflow tasks', () => {
       adapter.saveWorkflow({
         id: 'wf-delete-target',

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1667,6 +1667,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
   deleteAllWorkflows(): void {
     const taskIds = this.getAllTaskIds();
     this.runTransaction(() => {
+      this.db.run('DELETE FROM workflow_mutation_leases');
+      this.db.run('DELETE FROM workflow_mutation_intents');
+      this.db.run('DELETE FROM task_launch_dispatch');
       this.db.run('DELETE FROM events');
       this.db.run('DELETE FROM task_output');
       this.db.run('DELETE FROM attempts');
@@ -1682,21 +1685,22 @@ export class SQLiteAdapter implements PersistenceAdapter {
   deleteWorkflow(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
     this.runTransaction(() => {
-      // Delete events first (FK constraint: events -> tasks)
+      this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
+      this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
+      this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
+
       this.db.run(`
         DELETE FROM events WHERE task_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
 
-      // Delete task output (FK constraint: task_output -> tasks)
       this.db.run(`
         DELETE FROM task_output WHERE task_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
         )
       `, [workflowId]);
 
-      // Delete attempts (FK constraint: attempts -> tasks)
       this.db.run(`
         DELETE FROM attempts WHERE node_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
@@ -1709,10 +1713,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
         )
       `, [workflowId]);
 
-      // Delete tasks (FK constraint: tasks -> workflows)
       this.db.run('DELETE FROM tasks WHERE workflow_id = ?', [workflowId]);
 
-      // Finally delete the workflow
       this.db.run('DELETE FROM workflows WHERE id = ?', [workflowId]);
     });
     this.removeOutputFiles(taskIds);

--- a/packages/data-store/tsconfig.build.json
+++ b/packages/data-store/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/execution-engine/package.json
+++ b/packages/execution-engine/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "docker:build": "bash ../../scripts/build-agent-base-image.sh",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/packages/execution-engine/tsconfig.build.json
+++ b/packages/execution-engine/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -13,7 +13,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/protocol/tsconfig.build.json
+++ b/packages/protocol/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/runtime-adapters/package.json
+++ b/packages/runtime-adapters/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/runtime-adapters/tsconfig.build.json
+++ b/packages/runtime-adapters/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/runtime-domain/package.json
+++ b/packages/runtime-domain/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/runtime-domain/tsconfig.build.json
+++ b/packages/runtime-domain/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/runtime-service/package.json
+++ b/packages/runtime-service/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/runtime-service/tsconfig.build.json
+++ b/packages/runtime-service/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/shell/tsconfig.build.json
+++ b/packages/shell/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/svc-api/package.json
+++ b/packages/svc-api/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/svc-api/tsconfig.build.json
+++ b/packages/svc-api/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}

--- a/packages/workflow-core/package.json
+++ b/packages/workflow-core/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
+    "build": "tsup src/index.ts --format esm --dts --tsconfig tsconfig.build.json",
     "test": "vitest run",
     "test:watch": "vitest",
     "clean": "rm -rf dist"

--- a/packages/workflow-core/tsconfig.build.json
+++ b/packages/workflow-core/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": false
+  }
+}


### PR DESCRIPTION
## Summary

Workflow deletion now clears workflow-owned mutation and launch-dispatch rows before removing workflows; DTS builds use non-composite configs.

## Architecture

### Before

```mermaid
flowchart TD
    GUI[GUI delete action] --> DeleteWorkflow[deleteWorkflow]
    DeleteWorkflow --> WorkflowRow[DELETE workflows row]
    Intents[(workflow_mutation_intents)] -->|FK to workflow| WorkflowRow
    Leases[(workflow_mutation_leases)] -->|FK to workflow| WorkflowRow
    Dispatch[(task_launch_dispatch)] -->|FK to workflow| WorkflowRow
    WorkflowRow --> Rejected[SQLite foreign-key rejection]
```

### After

```mermaid
flowchart TD
    GUI[GUI delete action] --> DeleteWorkflow[deleteWorkflow]
    DeleteWorkflow --> Cleanup[Delete workflow-owned queue rows]
    Cleanup --> Intents[(workflow_mutation_intents)]
    Cleanup --> Leases[(workflow_mutation_leases)]
    Cleanup --> Dispatch[(task_launch_dispatch)]
    Cleanup --> Tasks[Delete workflow tasks]
    Tasks --> WorkflowRow[DELETE workflows row]
    WorkflowRow --> Removed[Workflow removed]
```

## Test Plan

- [ ] `cd packages/data-store && pnpm test` -- regression test creates a workflow with active mutation intent, lease, and launch dispatch, then asserts `deleteWorkflow` succeeds and all workflow-owned rows are removed
- [ ] `pnpm run build` -- exits 0 without TS6307 declaration-build warnings
- [ ] `pnpm run test:all` -- full suite passes (verified in workflow gate)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None -- the GUI delete bug will resurface but no data is at risk
- Data migration? No