### PR TITLE
Improve PR summary readability guidance

### DIFF
--- a/scripts/create-pr.mjs
+++ b/scripts/create-pr.mjs
@@ -31,7 +31,7 @@ import { homedir } from 'node:os';
 import { randomBytes } from 'node:crypto';
 import { execSync } from 'node:child_process';
 import aws4 from 'aws4';
-import { validatePrBody } from './validate-pr-body.mjs';
+import { getPrBodyWarnings, validatePrBody } from './validate-pr-body.mjs';
 
 const DEFAULT_PARENT_REMOTE = process.env.INVOKER_PARENT_REMOTE || 'upstream';
 
@@ -163,6 +163,16 @@ function assertValidPrBody(body) {
       '  node scripts/validate-pr-body.mjs --body-file <file>',
     ].join('\n'),
   );
+}
+
+function printPrBodyWarnings(body) {
+  const warnings = getPrBodyWarnings(body);
+  if (warnings.length === 0) return;
+
+  console.error('PR body validation warnings:');
+  for (const warning of warnings) {
+    console.error(`- ${warning}`);
+  }
 }
 
 // ── Image injection ─────────────────────────────────────────────────────────
@@ -370,6 +380,7 @@ async function main() {
   }
 
   assertValidPrBody(body);
+  printPrBodyWarnings(body);
 
   // Inject images
   body = await injectImages(body, args.dryRun);

--- a/scripts/pr-body-template.md
+++ b/scripts/pr-body-template.md
@@ -1,6 +1,10 @@
 ## Summary
 
-Describe what changed and why. Keep this concrete and outcome-focused.
+Describe what changed and why in plain English.
+
+Write paragraphs, not bullets. Keep each paragraph under 30 words.
+
+Put one idea in each paragraph. If one idea leads to another, split them into separate short paragraphs.
 
 ## Architecture
 

--- a/scripts/test-pr-body-validator.mjs
+++ b/scripts/test-pr-body-validator.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { validatePrBody } from './validate-pr-body.mjs';
+import { getPrBodyWarnings, validatePrBody } from './validate-pr-body.mjs';
 
 function assert(condition, message) {
   if (!condition) {
@@ -71,6 +71,7 @@ None.
 
 assert(validatePrBody(validMinimal).length === 0, 'valid minimal body should pass');
 assert(validatePrBody(validArchitecture).length === 0, 'valid architecture body should pass');
+assert(getPrBodyWarnings(validMinimal).length === 0, 'short summary should produce no warnings');
 
 const lightweightErrors = validatePrBody(lightweight);
 assert(lightweightErrors.some((error) => error.includes('Unsupported section: ## Testing')), 'lightweight format should reject ## Testing');
@@ -114,5 +115,25 @@ graph TD
 - Data migration? No
 `);
 assert(malformedArchitectureErrors.some((error) => error.includes('Architecture section is missing required subsection: ### After')), 'missing architecture after section should fail');
+
+const longSummary = `## Summary
+
+This summary paragraph uses too many words because it tries to explain several related implementation details at the same time instead of giving a tired reviewer one clear idea they can understand immediately.
+
+## Test Plan
+
+- [ ] \`pnpm test\`
+
+## Revert Plan
+
+- Safe to revert? Yes
+- Revert command: \`git revert <sha>\`
+- Post-revert steps: None
+- Data migration? No
+`;
+
+const longSummaryWarnings = getPrBodyWarnings(longSummary);
+assert(validatePrBody(longSummary).length === 0, 'summary readability warnings should not fail validation');
+assert(longSummaryWarnings.some((warning) => warning.includes('Summary paragraph 1')), 'long summary paragraph should warn');
 
 console.log('OK: PR body validator checks passed');

--- a/scripts/validate-pr-body.mjs
+++ b/scripts/validate-pr-body.mjs
@@ -4,6 +4,46 @@ import { readFileSync } from 'node:fs';
 
 const REQUIRED_SECTIONS = ['## Summary', '## Test Plan', '## Revert Plan'];
 const DISCOURAGED_HEADINGS = ['## Testing', '## Notes'];
+const SUMMARY_WORD_LIMIT = 30;
+
+function getSectionBody(body, heading) {
+  const lines = body.split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === heading);
+  if (start === -1) return '';
+
+  const sectionLines = [];
+  for (const line of lines.slice(start + 1)) {
+    if (/^##\s+/.test(line.trim())) break;
+    sectionLines.push(line);
+  }
+
+  return sectionLines.join('\n').trim();
+}
+
+function countWords(text) {
+  return text
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean).length;
+}
+
+export function getPrBodyWarnings(body) {
+  const warnings = [];
+  const summary = getSectionBody(body, '## Summary');
+  if (!summary) return warnings;
+
+  const paragraphs = summary.split(/\n\s*\n/).map((paragraph) => paragraph.trim()).filter(Boolean);
+  paragraphs.forEach((paragraph, index) => {
+    const wordCount = countWords(paragraph);
+    if (wordCount > SUMMARY_WORD_LIMIT) {
+      warnings.push(
+        `Summary paragraph ${index + 1} is ${wordCount} words. Keep each Summary paragraph under ${SUMMARY_WORD_LIMIT} words.`,
+      );
+    }
+  });
+
+  return warnings;
+}
 
 export function validatePrBody(body) {
   const errors = [];
@@ -82,6 +122,7 @@ function main() {
   const args = parseArgs(process.argv.slice(2));
   const body = args.bodyFile ? readFileSync(args.bodyFile, 'utf-8') : args.body;
   const errors = validatePrBody(body);
+  const warnings = getPrBodyWarnings(body);
 
   if (errors.length > 0) {
     console.error('PR body validation failed:');
@@ -89,6 +130,13 @@ function main() {
       console.error(`- ${error}`);
     }
     process.exit(1);
+  }
+
+  if (warnings.length > 0) {
+    console.error('PR body validation warnings:');
+    for (const warning of warnings) {
+      console.error(`- ${warning}`);
+    }
   }
 
   console.log('PR body validation passed.');

--- a/skills/make-pr/SKILL.md
+++ b/skills/make-pr/SKILL.md
@@ -27,7 +27,15 @@ Default to this structure:
 ```md
 ## Summary
 
-Short explanation of what changed and why.
+Plain-English explanation of what changed and why.
+
+Write this for a burnt out developer who needs the point quickly.
+
+Use paragraphs, not bullets. Keep each paragraph under 30 words.
+
+Put one idea in each paragraph. If one idea leads to another, split them into separate short paragraphs.
+
+Avoid implementation jargon unless it is necessary for understanding the change.
 
 ## Architecture
 


### PR DESCRIPTION
## Summary

PR summaries now tell reviewers what changed in plain English.

The make-pr skill and PR template ask for short paragraphs with one idea each.

The validator now warns when a Summary paragraph runs over 30 words, without blocking the PR.

## Test Plan

- [x] `node scripts/test-pr-body-validator.mjs`
- [x] `node scripts/validate-pr-body.mjs --body-file scripts/pr-body-template.md`
- [x] `git diff --check`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 693d9f3f4`
- Post-revert steps: None
- Data migration? No
