### PR TITLE
Make timeline text selectable

### DIFF
--- a/packages/ui/src/__tests__/timeline-view-e2e.test.tsx
+++ b/packages/ui/src/__tests__/timeline-view-e2e.test.tsx
@@ -96,6 +96,54 @@ describe('Timeline view (component)', () => {
     });
   });
 
+  it('clicking a timeline row updates the inspector to the selected task', async () => {
+    const now = Date.now();
+    const startedAlpha = makeUITask({
+      id: 'task-alpha',
+      description: 'First test task',
+      status: 'completed',
+      workflowId: 'wf-timeline',
+      command: 'echo hello-alpha',
+      execution: {
+        startedAt: new Date(now - 5000),
+        completedAt: new Date(now),
+      },
+    } as any);
+
+    render(<App />);
+    act(() => mock.setTasks([startedAlpha, beta], workflows));
+
+    fireEvent.click(screen.getByTestId('rail-timeline'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-bar-task-alpha')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('timeline-bar-task-alpha'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-inspector-title')).toHaveTextContent('First test task');
+    });
+  });
+
+  it('timeline row text has selectable text styling', async () => {
+    render(<App />);
+    act(() => mock.setTasks([alpha, beta], workflows));
+
+    fireEvent.click(screen.getByTestId('rail-timeline'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('timeline-bar-task-alpha')).toBeInTheDocument();
+    });
+
+    const row = screen.getByTestId('timeline-bar-task-alpha');
+    expect(row.getAttribute('role')).toBe('button');
+
+    const taskLabel = row.querySelector('.select-text');
+    expect(taskLabel).not.toBeNull();
+    expect(taskLabel!.classList.contains('cursor-text')).toBe(true);
+  });
+
   it('switching back to Home workflow graph works', async () => {
     render(<App />);
     act(() => mock.setTasks([alpha, beta], workflows));

--- a/packages/ui/src/components/TimelineView.tsx
+++ b/packages/ui/src/components/TimelineView.tsx
@@ -150,10 +150,18 @@ export function TimelineView({ tasks, onTaskClick, selectedTaskId }: TimelineVie
             : null;
 
           return (
-            <button
+            <div
               key={task.id}
+              role="button"
+              tabIndex={0}
               data-testid={`timeline-bar-${task.id}`}
               onClick={() => onTaskClick(task)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  if (e.key === ' ') e.preventDefault();
+                  onTaskClick(task);
+                }
+              }}
               className={`w-full text-left rounded transition-all ${
                 isSelected ? 'ring-2 ring-indigo-400 ring-offset-1 ring-offset-gray-900' : ''
               }`}
@@ -161,11 +169,11 @@ export function TimelineView({ tasks, onTaskClick, selectedTaskId }: TimelineVie
             >
               <div className="flex items-center gap-3 px-2 py-1.5">
                 {/* Task label */}
-                <div className="w-40 shrink-0 truncate text-xs text-gray-300" title={task.description}>
+                <div className="w-40 shrink-0 truncate text-xs text-gray-300 select-text cursor-text" title={task.description}>
                   {task.id}
                 </div>
                 {phaseLabel && (
-                  <div className="w-20 shrink-0 text-xs text-amber-300 uppercase">
+                  <div className="w-20 shrink-0 text-xs text-amber-300 uppercase select-text cursor-text">
                     {phaseLabel}
                   </div>
                 )}
@@ -188,11 +196,11 @@ export function TimelineView({ tasks, onTaskClick, selectedTaskId }: TimelineVie
                 </div>
 
                 {/* Duration label */}
-                <div className="w-16 shrink-0 text-right text-xs tabular-nums" style={{ color: colors.bg }}>
+                <div className="w-16 shrink-0 text-right text-xs tabular-nums select-text cursor-text" style={{ color: colors.bg }}>
                   {elapsed ?? '—'}
                 </div>
               </div>
-            </button>
+            </div>
           );
         })}
       </div>


### PR DESCRIPTION
Validation passed. Here is the final PR body:

## Summary

Make timeline row text (task id, phase label, duration) selectable and copyable via native browser text selection. Previously, rows were `<button>` elements which suppress text selection. This replaces them with `<div role="button" tabIndex={0}>` with explicit keyboard handling (Enter/Space) and adds `select-text cursor-text` classes to the text labels, preserving click-to-select-task behavior while enabling drag-to-highlight.

## Test Plan

- [x] `cd packages/ui && pnpm test`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No