### PR TITLE
Add cache-hit and planning/execution analysis tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,11 @@ packages/app/test-results/
 .claude.json.backup*
 tmp/plans/
 release/
+
+# Generated local analysis outputs (regenerate, do not commit)
+/reports/
+cache-hit-audit-codex-*.csv
+cache-hit-audit-report.json
+planning-session-*-user-prompts.txt
+planning-session-*-quick-summary.txt
+planning-session-cost-breakdown.json

--- a/docs/reports/planning-vs-execution-tooling.md
+++ b/docs/reports/planning-vs-execution-tooling.md
@@ -1,0 +1,51 @@
+# Planning vs Execution Tooling
+
+This repo includes local analysis tooling for AI token/cost investigation and
+planning-vs-execution attribution.
+
+## Scripts
+
+- `scripts/cache_hit_audit.py`
+  - Runs `ccusage` audits across local + configured remote targets.
+  - Computes deduplicated usage views.
+  - Extracts repeated input blocks that drive cache hit rates.
+- `scripts/planning_vs_execution_report.py`
+  - Splits session activity into `planning` vs `execution` using phrase matching.
+  - Generates Codex, Claude, and Combined sections.
+  - Produces per-session/per-prompt distributions, Pareto cuts, and tool-call
+    breakdowns with projected cost attribution.
+
+## Regenerate
+
+Run from repo root:
+
+```bash
+python3 scripts/cache_hit_audit.py --output cache-hit-audit-report.json --top 50
+python3 scripts/planning_vs_execution_report.py --out-dir reports
+```
+
+Primary outputs:
+
+- `reports/planning-vs-execution-report.json`
+- `reports/planning-vs-execution-sessions.csv`
+- `reports/planning-vs-execution-prompts.csv`
+- `reports/planning-vs-execution-tool-breakdown.csv`
+- `reports/planning-vs-execution-summary.md`
+
+## Methodology notes
+
+- Planning classifier phrases:
+  - `plan-to-invoker`
+  - `/plan-to-invoker`
+  - `submit to invoker`
+  - `create invoker plan`
+  - `convert to invoker`
+- Cost allocation:
+  - Per model, costs are proportionally attributed from local `ccusage` totals.
+  - Effective input uses `input_tokens + 0.1 * cached_input_tokens`.
+- Tool projected cost:
+  - Uniform-rate attribution per session:
+    - `session_cost / session_tool_calls`
+    - multiplied by tool call counts in that session.
+  - This is useful for ranking tool families but does not capture per-call
+    token variance.

--- a/scripts/cache_hit_audit.py
+++ b/scripts/cache_hit_audit.py
@@ -1,0 +1,521 @@
+#!/usr/bin/env python3
+"""
+Audit cache-hit behavior across local + Invoker SSH machines.
+
+Features:
+- Runs ccusage (generic/codex/claude) across all hosts.
+- Stages codex/claude logs from all hosts.
+- Computes cross-host log-overlap stats.
+- Deduplicates logs by content hash, reruns ccusage on deduped data.
+- Extracts repeated input blocks and exact repeated values.
+- Writes a full JSON report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import itertools
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from collections import Counter
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INV_CONFIG = Path.home() / ".invoker" / "config.json"
+SSH_KEY = Path.home() / ".ssh" / "id_ed25519"
+LOCAL_CODEX_SESSIONS = Path.home() / ".codex" / "sessions"
+LOCAL_CLAUDE_ROOT = Path.home() / ".claude"
+
+
+@dataclass(frozen=True)
+class Host:
+    name: str
+    host: str | None
+    user: str = "invoker"
+    port: int = 22
+    ssh_key: str = str(SSH_KEY)
+
+
+def run_cmd(
+    cmd: list[str],
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+    allow_failure: bool = False,
+) -> subprocess.CompletedProcess[str]:
+    cp = subprocess.run(
+        cmd,
+        cwd=str(cwd) if cwd else None,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    if not allow_failure and cp.returncode != 0:
+        raise RuntimeError(f"Command failed: {' '.join(cmd)}\n{cp.stdout[:2000]}")
+    return cp
+
+
+def parse_first_json(text: str) -> Any:
+    dec = json.JSONDecoder()
+    for i, ch in enumerate(text):
+        if ch not in "{[":
+            continue
+        try:
+            obj, _ = dec.raw_decode(text[i:])
+            return obj
+        except Exception:
+            continue
+    raise ValueError("No JSON found in command output")
+
+
+def to_int(v: Any) -> int:
+    try:
+        return int(v or 0)
+    except Exception:
+        return 0
+
+
+def to_float(v: Any) -> float:
+    try:
+        return float(v or 0.0)
+    except Exception:
+        return 0.0
+
+
+def token_estimate(chars: int) -> int:
+    return max(1, round(chars / 4))
+
+
+def load_hosts() -> list[Host]:
+    hosts = [Host("local_this_machine", None)]
+    if not INV_CONFIG.exists():
+        return hosts
+    cfg = json.loads(INV_CONFIG.read_text())
+    remotes = cfg.get("remoteTargets") or {}
+    for name, target in remotes.items():
+        if not isinstance(target, dict):
+            continue
+        host = target.get("host")
+        if not isinstance(host, str) or not host.strip():
+            continue
+        user = target.get("user") if isinstance(target.get("user"), str) else "invoker"
+        port = int(target.get("port") or 22)
+        ssh_key = target.get("sshKeyPath") if isinstance(target.get("sshKeyPath"), str) else str(SSH_KEY)
+        hosts.append(Host(name, host.strip(), user=user, port=port, ssh_key=ssh_key))
+    return hosts
+
+
+def ssh_cmd(h: Host, inner: str) -> list[str]:
+    return [
+        "ssh",
+        "-i",
+        h.ssh_key,
+        "-p",
+        str(h.port),
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        "ConnectTimeout=20",
+        f"{h.user}@{h.host}",
+        inner,
+    ]
+
+
+def run_ccusage_generic(host: Host) -> dict[str, Any]:
+    cmd = ["npx", "ccusage@latest", "daily", "--json"]
+    cp = run_cmd(cmd, cwd=REPO_ROOT) if host.host is None else run_cmd(ssh_cmd(host, " ".join(cmd)))
+    obj = parse_first_json(cp.stdout)
+    totals = obj.get("totals", {}) if isinstance(obj, dict) else {}
+    row = {
+        "inputTokens": to_int(totals.get("inputTokens")),
+        "outputTokens": to_int(totals.get("outputTokens")),
+        "cacheCreationTokens": to_int(totals.get("cacheCreationTokens")),
+        "cacheReadTokens": to_int(totals.get("cacheReadTokens")),
+        "totalTokens": to_int(totals.get("totalTokens")),
+        "totalCost": to_float(totals.get("totalCost")),
+    }
+    denom = row["inputTokens"] + row["cacheReadTokens"]
+    row["cacheHitPct"] = round((row["cacheReadTokens"] / denom * 100) if denom else 0.0, 6)
+    return row
+
+
+def run_ccusage_codex(host: Host, codex_home: Path | None = None) -> dict[str, Any]:
+    cmd = ["npx", "ccusage@latest", "codex", "daily", "--json"]
+    if host.host is None:
+        env = dict(os.environ)
+        if codex_home:
+            env["CODEX_HOME"] = str(codex_home)
+        cp = run_cmd(cmd, cwd=REPO_ROOT, env=env)
+    else:
+        cp = run_cmd(ssh_cmd(host, " ".join(cmd)))
+    obj = parse_first_json(cp.stdout)
+    totals = obj.get("totals", {}) if isinstance(obj, dict) else {}
+    row = {
+        "inputTokens": to_int(totals.get("inputTokens")),
+        "cachedInputTokens": to_int(totals.get("cachedInputTokens")),
+        "outputTokens": to_int(totals.get("outputTokens")),
+        "reasoningOutputTokens": to_int(totals.get("reasoningOutputTokens")),
+        "totalTokens": to_int(totals.get("totalTokens")),
+        "costUSD": to_float(totals.get("costUSD")),
+    }
+    denom = row["inputTokens"] + row["cachedInputTokens"]
+    row["cacheHitPct"] = round((row["cachedInputTokens"] / denom * 100) if denom else 0.0, 6)
+    return row
+
+
+def run_ccusage_claude(host: Host, home_override: Path | None = None) -> dict[str, Any]:
+    cmd = ["npx", "ccusage@latest", "claude", "daily", "--json"]
+    if host.host is None:
+        env = dict(os.environ)
+        if home_override:
+            env["HOME"] = str(home_override)
+        cp = run_cmd(cmd, cwd=REPO_ROOT, env=env)
+    else:
+        cp = run_cmd(ssh_cmd(host, " ".join(cmd)))
+    obj = parse_first_json(cp.stdout)
+    totals = obj.get("totals", {}) if isinstance(obj, dict) else {}
+    row = {
+        "inputTokens": to_int(totals.get("inputTokens")),
+        "outputTokens": to_int(totals.get("outputTokens")),
+        "cacheCreationTokens": to_int(totals.get("cacheCreationTokens")),
+        "cacheReadTokens": to_int(totals.get("cacheReadTokens")),
+        "totalTokens": to_int(totals.get("totalTokens")),
+        "totalCost": to_float(totals.get("totalCost")),
+    }
+    denom = row["inputTokens"] + row["cacheReadTokens"]
+    row["cacheHitPct"] = round((row["cacheReadTokens"] / denom * 100) if denom else 0.0, 6)
+    return row
+
+
+def sum_rows(rows: list[dict[str, Any]], keys: list[str]) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for k in keys:
+        if "Cost" in k or "cost" in k:
+            out[k] = float(sum(to_float(r.get(k)) for r in rows))
+        else:
+            out[k] = int(sum(to_int(r.get(k)) for r in rows))
+    return out
+
+
+def rsync_pull(src: str, dst: Path, jsonl_only: bool = False) -> None:
+    cmd = ["rsync", "-a"]
+    if jsonl_only:
+        cmd.extend(["--prune-empty-dirs", "--include=*/", "--include=*.jsonl", "--exclude=*"])
+    cmd.extend([src, str(dst) + "/"])
+    run_cmd(cmd)
+
+
+def stage_logs(hosts: list[Host], stage_root: Path) -> tuple[dict[str, Path], dict[str, Path]]:
+    codex_roots: dict[str, Path] = {}
+    claude_roots: dict[str, Path] = {}
+    for h in hosts:
+        codex_dst = stage_root / h.name / "codex_sessions"
+        claude_dst = stage_root / h.name / "claude_root"
+        codex_dst.mkdir(parents=True, exist_ok=True)
+        claude_dst.mkdir(parents=True, exist_ok=True)
+        if h.host is None:
+            if LOCAL_CODEX_SESSIONS.exists():
+                rsync_pull(str(LOCAL_CODEX_SESSIONS) + "/", codex_dst)
+            if LOCAL_CLAUDE_ROOT.exists():
+                rsync_pull(str(LOCAL_CLAUDE_ROOT) + "/", claude_dst, jsonl_only=True)
+        else:
+            ssh_transport = (
+                "ssh -i "
+                + h.ssh_key
+                + " -p "
+                + str(h.port)
+                + " -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20"
+            )
+            run_cmd(
+                [
+                    "rsync",
+                    "-a",
+                    "-e",
+                    ssh_transport,
+                    f"{h.user}@{h.host}:/home/invoker/.codex/sessions/",
+                    str(codex_dst) + "/",
+                ]
+            )
+            run_cmd(
+                [
+                    "rsync",
+                    "-a",
+                    "--prune-empty-dirs",
+                    "--include=*/",
+                    "--include=*.jsonl",
+                    "--exclude=*",
+                    "-e",
+                    ssh_transport,
+                    f"{h.user}@{h.host}:/home/invoker/.claude/",
+                    str(claude_dst) + "/",
+                ]
+            )
+        codex_roots[h.name] = codex_dst
+        claude_roots[h.name] = claude_dst
+    return codex_roots, claude_roots
+
+
+def overlap_stats(roots: dict[str, Path], pattern: str = "*.jsonl") -> dict[str, Any]:
+    per_host_sets: dict[str, set[str]] = {}
+    for name, root in roots.items():
+        per_host_sets[name] = {str(p.relative_to(root)) for p in root.rglob(pattern) if p.is_file()}
+    pairwise = []
+    for a, b in itertools.combinations(per_host_sets.keys(), 2):
+        inter = len(per_host_sets[a] & per_host_sets[b])
+        if inter:
+            union = len(per_host_sets[a] | per_host_sets[b]) or 1
+            pairwise.append({"a": a, "b": b, "overlapCount": inter, "jaccard": round(inter / union, 6)})
+    pairwise.sort(key=lambda x: x["overlapCount"], reverse=True)
+    return {"countsByHost": {k: len(v) for k, v in per_host_sets.items()}, "pairOverlap": pairwise}
+
+
+def dedupe_by_hash(host_order: list[str], roots: dict[str, Path], merged_root: Path) -> dict[str, Any]:
+    merged_root.mkdir(parents=True, exist_ok=True)
+    seen: set[str] = set()
+    kept = dropped = collisions = 0
+    kept_by_host: dict[str, int] = {}
+    dropped_by_host: dict[str, int] = {}
+    for host in host_order:
+        root = roots[host]
+        kept_by_host[host] = 0
+        dropped_by_host[host] = 0
+        for fp in root.rglob("*.jsonl"):
+            rel = fp.relative_to(root)
+            blob = fp.read_bytes()
+            h = hashlib.sha256(blob).hexdigest()
+            if h in seen:
+                dropped += 1
+                dropped_by_host[host] += 1
+                continue
+            seen.add(h)
+            dst = merged_root / rel
+            if dst.exists():
+                collisions += 1
+                dst = merged_root / rel.parent / f"{rel.stem}__{host}.jsonl"
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            dst.write_bytes(blob)
+            kept += 1
+            kept_by_host[host] += 1
+    return {
+        "uniqueJsonlKept": kept,
+        "duplicateJsonlDropped": dropped,
+        "pathCollisions": collisions,
+        "keptByHost": kept_by_host,
+        "droppedByHost": dropped_by_host,
+    }
+
+
+def top_repeated_entries(counter: Counter[str], source: str, top_n: int) -> list[dict[str, Any]]:
+    rows = []
+    for value, count in counter.items():
+        chars = len(value)
+        tok = token_estimate(chars)
+        total_tok = tok * count
+        shrinkability = round((chars / 20000) * 100, 2)
+        rows.append(
+            {
+                "source": source,
+                "count": count,
+                "chars": chars,
+                "tokenEstimatePerValue": tok,
+                "tokenEstimateTotal": total_tok,
+                "shrinkabilityScore": shrinkability,
+                "value": value,
+            }
+        )
+    rows.sort(key=lambda x: (x["tokenEstimateTotal"], x["count"]), reverse=True)
+    return rows[:top_n]
+
+
+def analyze_codex_repeats(codex_sessions_root: Path, top_n: int) -> list[dict[str, Any]]:
+    base = Counter()
+    developer = Counter()
+    env_ctx = Counter()
+    user_prefix = Counter()
+    for fp in codex_sessions_root.rglob("*.jsonl"):
+        for line in fp.read_text(errors="ignore").splitlines():
+            if not line.strip():
+                continue
+            try:
+                obj = json.loads(line)
+            except Exception:
+                continue
+            t = obj.get("type")
+            if t == "session_meta":
+                txt = ((obj.get("payload") or {}).get("base_instructions") or {}).get("text")
+                if isinstance(txt, str) and txt.strip():
+                    base[txt] += 1
+            elif t == "response_item":
+                payload = obj.get("payload") or {}
+                if payload.get("type") == "message" and payload.get("role") == "developer":
+                    parts = []
+                    for c in payload.get("content") or []:
+                        if isinstance(c, dict) and c.get("type") == "input_text" and isinstance(c.get("text"), str):
+                            parts.append(c["text"])
+                    if parts:
+                        developer["\n".join(parts)] += 1
+                if payload.get("type") == "message" and payload.get("role") == "user":
+                    for c in payload.get("content") or []:
+                        txt = c.get("text") if isinstance(c, dict) else None
+                        if isinstance(txt, str) and "<environment_context>" in txt:
+                            env_ctx[txt] += 1
+            elif t == "event_msg":
+                payload = obj.get("payload") or {}
+                if payload.get("type") == "user_message" and isinstance(payload.get("message"), str):
+                    msg = " ".join(payload["message"].split())
+                    user_prefix[msg[:180]] += 1
+    rows = []
+    rows += top_repeated_entries(base, "codex.base_instructions", top_n)
+    rows += top_repeated_entries(developer, "codex.developer_blob", top_n)
+    rows += top_repeated_entries(env_ctx, "codex.environment_context", top_n)
+    rows += top_repeated_entries(user_prefix, "codex.user_message_prefix180", top_n)
+    rows.sort(key=lambda x: (x["tokenEstimateTotal"], x["count"]), reverse=True)
+    return rows[:top_n]
+
+
+def analyze_claude_repeats(claude_root: Path, top_n: int) -> list[dict[str, Any]]:
+    enqueue = Counter()
+    skills = Counter()
+    tools_delta = Counter()
+    for fp in claude_root.rglob("*.jsonl"):
+        for line in fp.read_text(errors="ignore").splitlines():
+            if not line.strip():
+                continue
+            try:
+                obj = json.loads(line)
+            except Exception:
+                continue
+            if obj.get("type") == "queue-operation" and obj.get("operation") == "enqueue" and isinstance(obj.get("content"), str):
+                enqueue[" ".join(obj["content"].split())] += 1
+            attachment = obj.get("attachment")
+            if isinstance(attachment, dict):
+                if attachment.get("type") == "skill_listing" and isinstance(attachment.get("content"), str):
+                    skills[attachment["content"]] += 1
+                if attachment.get("type") == "deferred_tools_delta":
+                    names = attachment.get("addedNames") or []
+                    if isinstance(names, list) and names:
+                        tools_delta["\n".join(str(x) for x in names)] += 1
+    rows = []
+    rows += top_repeated_entries(enqueue, "claude.enqueue_content", top_n)
+    rows += top_repeated_entries(skills, "claude.attachment.skill_listing", top_n)
+    rows += top_repeated_entries(tools_delta, "claude.attachment.deferred_tools_delta", top_n)
+    rows.sort(key=lambda x: (x["tokenEstimateTotal"], x["count"]), reverse=True)
+    return rows[:top_n]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Cache-hit + repeated-input audit across Invoker machines.")
+    parser.add_argument("--output", default=None, help="Output JSON report path (default: ./cache-hit-audit-report.json)")
+    parser.add_argument("--top", type=int, default=20, help="How many repeated entries to keep in each ranked output.")
+    parser.add_argument("--keep-temp", action="store_true", help="Keep staging/dedupe temp directory.")
+    args = parser.parse_args()
+
+    out_path = Path(args.output) if args.output else (REPO_ROOT / "cache-hit-audit-report.json")
+    top_n = max(1, args.top)
+    hosts = load_hosts()
+    host_order = [h.name for h in hosts]
+
+    tmpdir = Path(tempfile.mkdtemp(prefix="cache-hit-audit-"))
+    stage_root = tmpdir / "stage"
+    merged = tmpdir / "merged"
+    merged_codex_home = merged / "codex_home"
+    merged_claude_home = merged / "claude_home"
+    merged_claude_dot = merged_claude_home / ".claude"
+
+    try:
+        generic_rows = {}
+        codex_rows = {}
+        claude_rows = {}
+        for h in hosts:
+            generic_rows[h.name] = run_ccusage_generic(h)
+            codex_rows[h.name] = run_ccusage_codex(h)
+            claude_rows[h.name] = run_ccusage_claude(h)
+
+        generic_total = sum_rows(list(generic_rows.values()), ["inputTokens", "outputTokens", "cacheCreationTokens", "cacheReadTokens", "totalTokens", "totalCost"])
+        codex_total = sum_rows(list(codex_rows.values()), ["inputTokens", "cachedInputTokens", "outputTokens", "reasoningOutputTokens", "totalTokens", "costUSD"])
+        claude_total = sum_rows(list(claude_rows.values()), ["inputTokens", "outputTokens", "cacheCreationTokens", "cacheReadTokens", "totalTokens", "totalCost"])
+
+        generic_denom = generic_total["inputTokens"] + generic_total["cacheReadTokens"]
+        codex_denom = codex_total["inputTokens"] + codex_total["cachedInputTokens"]
+        claude_denom = claude_total["inputTokens"] + claude_total["cacheReadTokens"]
+        generic_total["cacheHitPct"] = round((generic_total["cacheReadTokens"] / generic_denom * 100) if generic_denom else 0.0, 6)
+        codex_total["cacheHitPct"] = round((codex_total["cachedInputTokens"] / codex_denom * 100) if codex_denom else 0.0, 6)
+        claude_total["cacheHitPct"] = round((claude_total["cacheReadTokens"] / claude_denom * 100) if claude_denom else 0.0, 6)
+
+        codex_roots, claude_roots = stage_logs(hosts, stage_root)
+        codex_overlap = overlap_stats(codex_roots)
+        claude_overlap = overlap_stats(claude_roots)
+
+        dedup_codex_stats = dedupe_by_hash(host_order, codex_roots, merged_codex_home / "sessions")
+        dedup_claude_stats = dedupe_by_hash(host_order, claude_roots, merged_claude_dot)
+
+        dedup_codex_ccusage = run_ccusage_codex(Host("local", None), codex_home=merged_codex_home)
+        dedup_claude_ccusage = run_ccusage_claude(Host("local", None), home_override=merged_claude_home)
+
+        codex_repeats = analyze_codex_repeats(merged_codex_home / "sessions", top_n)
+        claude_repeats = analyze_claude_repeats(merged_claude_dot, top_n)
+
+        report = {
+            "hosts": [h.__dict__ for h in hosts],
+            "baselineCcusage": {
+                "genericDailyByHost": generic_rows,
+                "genericDailyTotal": generic_total,
+                "codexDailyByHost": codex_rows,
+                "codexDailyTotal": codex_total,
+                "claudeDailyByHost": claude_rows,
+                "claudeDailyTotal": claude_total,
+            },
+            "logOverlap": {
+                "codexSessions": codex_overlap,
+                "claudeJsonl": claude_overlap,
+            },
+            "dedup": {
+                "tempWorkspace": str(tmpdir),
+                "codex": {
+                    "stats": dedup_codex_stats,
+                    "ccusageDaily": dedup_codex_ccusage,
+                },
+                "claude": {
+                    "stats": dedup_claude_stats,
+                    "ccusageDaily": dedup_claude_ccusage,
+                },
+            },
+            "repeatBreakdown": {
+                "topCodexRepeatedValues": codex_repeats,
+                "topClaudeRepeatedValues": claude_repeats,
+            },
+        }
+
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(report, indent=2))
+
+        print(f"Report written: {out_path}")
+        print(f"Hosts checked: {', '.join(host_order)}")
+        print(f"Baseline cache hit % | generic={generic_total['cacheHitPct']:.2f}, codex={codex_total['cacheHitPct']:.2f}, claude={claude_total['cacheHitPct']:.2f}")
+        print(f"Dedup cache hit %    | codex={dedup_codex_ccusage['cacheHitPct']:.2f}, claude={dedup_claude_ccusage['cacheHitPct']:.2f}")
+        print(f"Top repeated rows    | codex={len(codex_repeats)}, claude={len(claude_repeats)}")
+
+        if args.keep_temp:
+            print(f"Temp workspace kept at: {tmpdir}")
+        else:
+            shutil.rmtree(tmpdir, ignore_errors=True)
+
+    except Exception:
+        if args.keep_temp:
+            print(f"Error occurred. Temp workspace retained: {tmpdir}")
+        raise
+
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/planning_vs_execution_report.py
+++ b/scripts/planning_vs_execution_report.py
@@ -1,0 +1,841 @@
+#!/usr/bin/env python3
+"""Planning vs execution report across Codex + Claude + combined.
+
+Outputs:
+- reports/planning-vs-execution-report.json
+- reports/planning-vs-execution-sessions.csv
+- reports/planning-vs-execution-prompts.csv
+- reports/planning-vs-execution-tool-breakdown.csv
+- reports/planning-vs-execution-summary.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import statistics
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_AUDIT_REPORT = REPO_ROOT / "cache-hit-audit-report.json"
+DEFAULT_CODEX_DIR = Path.home() / ".codex" / "sessions"
+DEFAULT_CLAUDE_DIR = Path.home() / ".claude" / "projects"
+
+PLANNING_PHRASES = [
+    "plan-to-invoker",
+    "/plan-to-invoker",
+    "submit to invoker",
+    "create invoker plan",
+    "convert to invoker",
+]
+PLANNING_RE = re.compile("|".join(re.escape(p) for p in PLANNING_PHRASES), re.IGNORECASE)
+SHELL_FUNCTION_NAMES = {"exec_command", "shell", "bash"}
+
+
+@dataclass
+class PromptWindow:
+    prompt_index: int
+    prompt_text: str
+    input_delta: int = 0
+    cached_delta: int = 0
+    output_delta: int = 0
+    reasoning_delta: int = 0
+    total_delta: int = 0
+    tool_calls: int = 0
+    agent_messages: int = 0
+    response_messages: int = 0
+    function_outputs: int = 0
+
+
+@dataclass
+class SessionStats:
+    model: str  # codex | claude
+    file: str
+    bucket: str  # planning | execution
+    user_prompts: int = 0
+    agent_messages: int = 0
+    tool_calls: int = 0
+    function_outputs: int = 0
+    final_input: int = 0
+    final_cached: int = 0
+    final_output: int = 0
+    final_reasoning: int = 0
+    final_total: int = 0
+    first_prompt: str = ""
+    prompt_windows: list[PromptWindow] = field(default_factory=list)
+    function_name_counts: Counter[str] = field(default_factory=Counter)
+    shell_verb_counts: Counter[str] = field(default_factory=Counter)
+
+
+def safe_div(num: float, denom: float) -> float:
+    return float(num / denom) if denom else 0.0
+
+
+def shorten(text: str, n: int = 220) -> str:
+    return " ".join(text.split())[:n]
+
+
+def percentile(values: list[float], p: float) -> float:
+    if not values:
+        return 0.0
+    s = sorted(values)
+    if len(s) == 1:
+        return s[0]
+    idx = (len(s) - 1) * p
+    lo = int(idx)
+    hi = min(lo + 1, len(s) - 1)
+    frac = idx - lo
+    return s[lo] * (1 - frac) + s[hi] * frac
+
+
+def session_distribution(values: list[float]) -> dict[str, float]:
+    if not values:
+        return {"count": 0, "sum": 0.0, "mean": 0.0, "median": 0.0, "p75": 0.0, "p90": 0.0, "p95": 0.0, "max": 0.0, "min": 0.0}
+    return {
+        "count": len(values),
+        "sum": float(sum(values)),
+        "mean": float(statistics.mean(values)),
+        "median": float(statistics.median(values)),
+        "p75": float(percentile(values, 0.75)),
+        "p90": float(percentile(values, 0.90)),
+        "p95": float(percentile(values, 0.95)),
+        "max": float(max(values)),
+        "min": float(min(values)),
+    }
+
+
+def pareto_cut(rows: list[dict[str, Any]], key: str, threshold: float = 0.80) -> dict[str, Any]:
+    sorted_rows = sorted(rows, key=lambda r: r.get(key, 0), reverse=True)
+    total = sum(r.get(key, 0) for r in sorted_rows) or 0.0
+    selected: list[dict[str, Any]] = []
+    cumulative = 0.0
+    for row in sorted_rows:
+        cumulative += row.get(key, 0)
+        selected.append(row)
+        if total and cumulative / total >= threshold:
+            break
+    return {
+        "key": key,
+        "threshold": threshold,
+        "total": float(total),
+        "selected_count": len(selected),
+        "selected_share": safe_div(cumulative, total),
+        "selected": selected,
+    }
+
+
+def extract_shell_verb(arguments_raw: Any) -> str | None:
+    if not arguments_raw:
+        return None
+    if isinstance(arguments_raw, str):
+        try:
+            args_obj = json.loads(arguments_raw)
+        except json.JSONDecodeError:
+            return None
+    elif isinstance(arguments_raw, dict):
+        args_obj = arguments_raw
+    else:
+        return None
+    cmd = args_obj.get("cmd") or args_obj.get("command") or args_obj.get("input", {}).get("command") or ""
+    if not isinstance(cmd, str):
+        return None
+    cmd = cmd.strip()
+    if not cmd:
+        return None
+    tokens = [t for t in cmd.split() if t]
+    if not tokens:
+        return None
+    verb = tokens[0]
+    if verb == "cd" and len(tokens) >= 4 and tokens[2] in {"&&", "||", ";"}:
+        verb = tokens[3]
+    if verb.startswith("/"):
+        return verb.split("/")[-1]
+    return verb
+
+
+def load_model_totals(audit_path: Path) -> dict[str, dict[str, float]]:
+    obj = json.loads(audit_path.read_text())
+    by_host_c = obj.get("baselineCcusage", {}).get("codexDailyByHost", {})
+    by_host_a = obj.get("baselineCcusage", {}).get("claudeDailyByHost", {})
+    codex = by_host_c.get("local_this_machine", {})
+    claude = by_host_a.get("local_this_machine", {})
+    return {
+        "codex": {
+            "inputTokens": float(codex.get("inputTokens") or 0),
+            "cachedInputTokens": float(codex.get("cachedInputTokens") or 0),
+            "outputTokens": float(codex.get("outputTokens") or 0),
+            "reasoningOutputTokens": float(codex.get("reasoningOutputTokens") or 0),
+            "costUSD": float(codex.get("costUSD") or 0),
+        },
+        "claude": {
+            "inputTokens": float(claude.get("inputTokens") or 0),
+            "cachedInputTokens": float(claude.get("cacheReadTokens") or 0),
+            "outputTokens": float(claude.get("outputTokens") or 0),
+            "reasoningOutputTokens": 0.0,
+            "costUSD": float(claude.get("totalCost") or 0),
+        },
+    }
+
+
+def load_repeat_breakdown(audit_path: Path) -> dict[str, Any]:
+    obj = json.loads(audit_path.read_text())
+    return obj.get("repeatBreakdown", {}) or {}
+
+
+def parse_codex_session(path: Path) -> SessionStats | None:
+    user_prompts: list[str] = []
+    windows: list[PromptWindow] = []
+    current: PromptWindow | None = None
+    cum_input = cum_cached = cum_output = cum_reasoning = cum_total = 0
+    last_total: dict[str, int] | None = None
+    agent_message_count = tool_calls_total = func_outputs_total = 0
+    fn_counts: Counter[str] = Counter()
+    verb_counts: Counter[str] = Counter()
+
+    try:
+        text = path.read_text(errors="ignore")
+    except OSError:
+        return None
+
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        t = obj.get("type")
+        if t == "event_msg":
+            payload = obj.get("payload") or {}
+            ptype = payload.get("type")
+            if ptype == "user_message" and isinstance(payload.get("message"), str):
+                if current is not None:
+                    windows.append(current)
+                user_prompts.append(payload["message"])
+                current = PromptWindow(prompt_index=len(user_prompts), prompt_text=payload["message"])
+            elif ptype == "agent_message":
+                agent_message_count += 1
+                if current is not None:
+                    current.agent_messages += 1
+            elif ptype == "token_count":
+                tt = ((payload.get("info") or {}).get("total_token_usage") or {})
+                if tt:
+                    ni = int(tt.get("input_tokens") or 0)
+                    nc = int(tt.get("cached_input_tokens") or 0)
+                    no = int(tt.get("output_tokens") or 0)
+                    nr = int(tt.get("reasoning_output_tokens") or 0)
+                    nt = int(tt.get("total_tokens") or 0)
+                    di, dc, do, dr, dt = max(0, ni - cum_input), max(0, nc - cum_cached), max(0, no - cum_output), max(0, nr - cum_reasoning), max(0, nt - cum_total)
+                    if current is not None:
+                        current.input_delta += di
+                        current.cached_delta += dc
+                        current.output_delta += do
+                        current.reasoning_delta += dr
+                        current.total_delta += dt
+                    cum_input, cum_cached, cum_output, cum_reasoning, cum_total = ni, nc, no, nr, nt
+                    last_total = {"input": ni, "cached": nc, "output": no, "reasoning": nr, "total": nt}
+        elif t == "response_item":
+            payload = obj.get("payload") or {}
+            ptype = payload.get("type")
+            if ptype == "function_call":
+                tool_calls_total += 1
+                if current is not None:
+                    current.tool_calls += 1
+                fname = (payload.get("name") or "unknown").lower()
+                fn_counts[fname] += 1
+                if fname in SHELL_FUNCTION_NAMES:
+                    verb = extract_shell_verb(payload.get("arguments"))
+                    if verb:
+                        verb_counts[verb] += 1
+            elif ptype == "function_call_output":
+                func_outputs_total += 1
+                if current is not None:
+                    current.function_outputs += 1
+            elif ptype == "message" and payload.get("role") in {"assistant", "agent"}:
+                if current is not None:
+                    current.response_messages += 1
+
+    if current is not None:
+        windows.append(current)
+    if not user_prompts and last_total is None:
+        return None
+
+    final = last_total or {"input": 0, "cached": 0, "output": 0, "reasoning": 0, "total": 0}
+    bucket = "planning" if PLANNING_RE.search("\n".join(user_prompts)) else "execution"
+    return SessionStats(
+        model="codex",
+        file=str(path),
+        bucket=bucket,
+        user_prompts=len(user_prompts),
+        agent_messages=agent_message_count,
+        tool_calls=tool_calls_total,
+        function_outputs=func_outputs_total,
+        final_input=final["input"],
+        final_cached=final["cached"],
+        final_output=final["output"],
+        final_reasoning=final["reasoning"],
+        final_total=final["total"],
+        first_prompt=user_prompts[0] if user_prompts else "",
+        prompt_windows=windows,
+        function_name_counts=fn_counts,
+        shell_verb_counts=verb_counts,
+    )
+
+
+def _extract_user_text(msg: dict[str, Any]) -> str | None:
+    content = msg.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                t = item.get("type")
+                if t == "text" and isinstance(item.get("text"), str):
+                    parts.append(item["text"])
+        out = "\n".join(p for p in parts if p.strip())
+        return out if out.strip() else None
+    return None
+
+
+def parse_claude_session(path: Path) -> SessionStats | None:
+    user_prompts: list[str] = []
+    windows: list[PromptWindow] = []
+    current: PromptWindow | None = None
+    agent_message_count = tool_calls_total = 0
+    fn_counts: Counter[str] = Counter()
+    verb_counts: Counter[str] = Counter()
+    seen_usage_ids: set[str] = set()
+    seen_tool_ids: set[str] = set()
+    fi = fc = fo = fr = ft = 0
+
+    try:
+        text = path.read_text(errors="ignore")
+    except OSError:
+        return None
+
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+
+        typ = obj.get("type")
+        if typ == "user":
+            msg = obj.get("message") or {}
+            if msg.get("role") == "user":
+                prompt = _extract_user_text(msg)
+                if prompt:
+                    if current is not None:
+                        windows.append(current)
+                    user_prompts.append(prompt)
+                    current = PromptWindow(prompt_index=len(user_prompts), prompt_text=prompt)
+        elif typ == "assistant":
+            msg = obj.get("message") or {}
+            if msg.get("role") != "assistant":
+                continue
+            agent_message_count += 1
+            if current is not None:
+                current.agent_messages += 1
+                current.response_messages += 1
+
+            uid = str(msg.get("id") or obj.get("uuid") or "")
+            if uid and uid not in seen_usage_ids:
+                seen_usage_ids.add(uid)
+                usage = msg.get("usage") or {}
+                di = int(usage.get("input_tokens") or 0)
+                dc = int(usage.get("cache_read_input_tokens") or 0)
+                do = int(usage.get("output_tokens") or 0)
+                dr = 0
+                dt = di + do
+                fi += di
+                fc += dc
+                fo += do
+                fr += dr
+                ft += dt
+                if current is not None:
+                    current.input_delta += di
+                    current.cached_delta += dc
+                    current.output_delta += do
+                    current.reasoning_delta += dr
+                    current.total_delta += dt
+
+            content = msg.get("content") or []
+            if isinstance(content, list):
+                for item in content:
+                    if not isinstance(item, dict) or item.get("type") != "tool_use":
+                        continue
+                    tuid = str(item.get("id") or "")
+                    if tuid and tuid in seen_tool_ids:
+                        continue
+                    if tuid:
+                        seen_tool_ids.add(tuid)
+                    name = str(item.get("name") or "unknown").lower()
+                    tool_calls_total += 1
+                    fn_counts[name] += 1
+                    if current is not None:
+                        current.tool_calls += 1
+                    if name in SHELL_FUNCTION_NAMES:
+                        verb = extract_shell_verb(item.get("input"))
+                        if verb:
+                            verb_counts[verb] += 1
+
+    if current is not None:
+        windows.append(current)
+    if not user_prompts and ft == 0:
+        return None
+
+    bucket = "planning" if PLANNING_RE.search("\n".join(user_prompts)) else "execution"
+    return SessionStats(
+        model="claude",
+        file=str(path),
+        bucket=bucket,
+        user_prompts=len(user_prompts),
+        agent_messages=agent_message_count,
+        tool_calls=tool_calls_total,
+        function_outputs=0,
+        final_input=fi,
+        final_cached=fc,
+        final_output=fo,
+        final_reasoning=fr,
+        final_total=ft,
+        first_prompt=user_prompts[0] if user_prompts else "",
+        prompt_windows=windows,
+        function_name_counts=fn_counts,
+        shell_verb_counts=verb_counts,
+    )
+
+
+def build_rows_for_model(sessions: list[SessionStats], model_totals: dict[str, float]) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    eff_corpus = sum(s.final_input + 0.1 * s.final_cached for s in sessions) or 0.0
+    cost_total = float(model_totals.get("costUSD", 0.0))
+    cost_per_eff = safe_div(cost_total, eff_corpus)
+
+    session_rows: list[dict[str, Any]] = []
+    prompt_rows: list[dict[str, Any]] = []
+
+    for s in sessions:
+        eff = s.final_input + 0.1 * s.final_cached
+        cost = eff * cost_per_eff
+        chp = safe_div(s.final_cached, s.final_input + s.final_cached) * 100.0
+        session_rows.append(
+            {
+                "model": s.model,
+                "file": s.file,
+                "bucket": s.bucket,
+                "user_prompts": s.user_prompts,
+                "agent_messages": s.agent_messages,
+                "tool_calls": s.tool_calls,
+                "function_outputs": s.function_outputs,
+                "input_tokens": s.final_input,
+                "cached_input_tokens": s.final_cached,
+                "output_tokens": s.final_output,
+                "reasoning_output_tokens": s.final_reasoning,
+                "total_tokens": s.final_total,
+                "effective_input_10pct": eff,
+                "cache_hit_pct": chp,
+                "estimated_cost_usd": cost,
+                "first_prompt_preview": shorten(s.first_prompt, 280),
+            }
+        )
+        for w in s.prompt_windows:
+            weff = w.input_delta + 0.1 * w.cached_delta
+            wcost = weff * cost_per_eff
+            wchp = safe_div(w.cached_delta, w.input_delta + w.cached_delta) * 100.0
+            prompt_rows.append(
+                {
+                    "model": s.model,
+                    "file": s.file,
+                    "bucket": s.bucket,
+                    "prompt_index": w.prompt_index,
+                    "prompt_preview": shorten(w.prompt_text, 280),
+                    "tool_calls": w.tool_calls,
+                    "agent_messages": w.agent_messages,
+                    "response_messages": w.response_messages,
+                    "function_outputs": w.function_outputs,
+                    "input_tokens_delta": w.input_delta,
+                    "cached_tokens_delta": w.cached_delta,
+                    "output_tokens_delta": w.output_delta,
+                    "reasoning_tokens_delta": w.reasoning_delta,
+                    "total_tokens_delta": w.total_delta,
+                    "effective_input_10pct": weff,
+                    "cache_hit_pct": wchp,
+                    "estimated_cost_usd": wcost,
+                }
+            )
+    return session_rows, prompt_rows
+
+
+def bucket_view(session_rows: list[dict[str, Any]], prompt_rows: list[dict[str, Any]], bucket_name: str) -> dict[str, Any]:
+    b_sessions = [r for r in session_rows if r["bucket"] == bucket_name]
+    b_prompts = [r for r in prompt_rows if r["bucket"] == bucket_name]
+    cost_p = pareto_cut(b_sessions, "estimated_cost_usd", 0.80)
+    tok_p = pareto_cut(b_sessions, "effective_input_10pct", 0.80)
+    tool_p = pareto_cut(b_sessions, "tool_calls", 0.80)
+    top_files = {r["file"] for r in cost_p["selected"]}
+    prompts_in_top = [p for p in b_prompts if p["file"] in top_files]
+
+    def total(k: str) -> float:
+        return float(sum(r.get(k, 0) for r in b_sessions))
+
+    inp = total("input_tokens")
+    cache = total("cached_input_tokens")
+    return {
+        "session_count": len(b_sessions),
+        "totals": {
+            "input_tokens": int(inp),
+            "cached_input_tokens": int(cache),
+            "output_tokens": int(total("output_tokens")),
+            "reasoning_output_tokens": int(total("reasoning_output_tokens")),
+            "total_tokens": int(total("total_tokens")),
+            "effective_input_10pct": float(total("effective_input_10pct")),
+            "estimated_cost_usd": float(total("estimated_cost_usd")),
+            "cache_hit_pct": safe_div(cache, inp + cache) * 100.0,
+        },
+        "distributions": {
+            "estimated_cost_usd": session_distribution([r["estimated_cost_usd"] for r in b_sessions]),
+            "effective_input_10pct": session_distribution([r["effective_input_10pct"] for r in b_sessions]),
+            "tool_calls": session_distribution([float(r["tool_calls"]) for r in b_sessions]),
+            "input_tokens": session_distribution([float(r["input_tokens"]) for r in b_sessions]),
+            "cached_input_tokens": session_distribution([float(r["cached_input_tokens"]) for r in b_sessions]),
+        },
+        "pareto80_by_cost": cost_p,
+        "pareto80_by_tokens": tok_p,
+        "pareto80_by_tool_calls": tool_p,
+        "top_driver_prompts_by_cost_in_pareto": sorted(prompts_in_top, key=lambda r: r["estimated_cost_usd"], reverse=True)[:25],
+        "top_driver_prompts_by_tool_calls_in_pareto": sorted(prompts_in_top, key=lambda r: r["tool_calls"], reverse=True)[:25],
+    }
+
+
+def aggregate_tools(sessions: list[SessionStats], session_rows: list[dict[str, Any]], bucket_name: str) -> dict[str, Any]:
+    index = {(r["model"], r["file"]): r for r in session_rows}
+    fn_calls: Counter[str] = Counter()
+    fn_cost: dict[str, float] = {}
+    fn_sess: dict[str, set[str]] = {}
+    v_calls: Counter[str] = Counter()
+    v_cost: dict[str, float] = {}
+    v_sess: dict[str, set[str]] = {}
+    bucket_cost = 0.0
+    for s in sessions:
+        if s.bucket != bucket_name:
+            continue
+        row = index.get((s.model, s.file))
+        if not row:
+            continue
+        sc = float(row["estimated_cost_usd"])
+        bucket_cost += sc
+        per_call = sc / max(1, int(row["tool_calls"]))
+        for n, c in s.function_name_counts.items():
+            fn_calls[n] += c
+            fn_cost[n] = fn_cost.get(n, 0.0) + per_call * c
+            fn_sess.setdefault(n, set()).add(s.file)
+        for n, c in s.shell_verb_counts.items():
+            v_calls[n] += c
+            v_cost[n] = v_cost.get(n, 0.0) + per_call * c
+            v_sess.setdefault(n, set()).add(s.file)
+
+    def rows(calls: Counter[str], costs: dict[str, float], smap: dict[str, set[str]]) -> list[dict[str, Any]]:
+        tot_calls = sum(calls.values()) or 1
+        out: list[dict[str, Any]] = []
+        for n, c in calls.items():
+            co = costs.get(n, 0.0)
+            out.append(
+                {
+                    "name": n,
+                    "calls": c,
+                    "calls_share_pct": c / tot_calls * 100.0,
+                    "sessions_with_tool": len(smap.get(n, set())),
+                    "avg_calls_per_using_session": c / max(1, len(smap.get(n, set()))),
+                    "projected_cost_usd": co,
+                    "projected_cost_share_pct": (co / bucket_cost * 100.0) if bucket_cost else 0.0,
+                }
+            )
+        out.sort(key=lambda r: r["calls"], reverse=True)
+        return out
+
+    return {
+        "bucket": bucket_name,
+        "bucket_total_cost_usd": bucket_cost,
+        "by_function_name": rows(fn_calls, fn_cost, fn_sess),
+        "by_shell_verb": rows(v_calls, v_cost, v_sess),
+    }
+
+
+def section_from_rows(name: str, sessions: list[SessionStats], session_rows: list[dict[str, Any]], prompt_rows: list[dict[str, Any]]) -> dict[str, Any]:
+    planning = bucket_view(session_rows, prompt_rows, "planning")
+    execution = bucket_view(session_rows, prompt_rows, "execution")
+    return {
+        "name": name,
+        "totals": {
+            "session_count": len(session_rows),
+            "planning_session_count": planning["session_count"],
+            "execution_session_count": execution["session_count"],
+            "estimated_cost_usd": planning["totals"]["estimated_cost_usd"] + execution["totals"]["estimated_cost_usd"],
+            "effective_input_10pct": planning["totals"]["effective_input_10pct"] + execution["totals"]["effective_input_10pct"],
+        },
+        "planning": planning,
+        "execution": execution,
+        "tool_breakdown": {
+            "planning": aggregate_tools(sessions, session_rows, "planning"),
+            "execution": aggregate_tools(sessions, session_rows, "execution"),
+            "methodology": (
+                "Projected tool cost uses uniform per-call attribution within each session: "
+                "session_cost/session_tool_calls multiplied by tool call counts."
+            ),
+        },
+    }
+
+
+def source_shares(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    c: Counter[str] = Counter()
+    for r in entries:
+        c[str(r.get("source", "unknown"))] += int(r.get("tokenEstimateTotal", 0) or 0)
+    total = sum(c.values()) or 1
+    return [{"source": k, "estimated_repeated_tokens": v, "share_pct": v / total * 100.0} for k, v in sorted(c.items(), key=lambda kv: kv[1], reverse=True)]
+
+
+def build_report(out_dir: Path, audit_path: Path, codex_dir: Path, claude_dir: Path) -> dict[str, Any]:
+    model_totals = load_model_totals(audit_path)
+    repeat_breakdown = load_repeat_breakdown(audit_path)
+
+    codex_sessions = [s for fp in sorted(codex_dir.rglob("*.jsonl")) if (s := parse_codex_session(fp))]
+    claude_sessions = [s for fp in sorted(claude_dir.rglob("*.jsonl")) if (s := parse_claude_session(fp))]
+
+    codex_session_rows, codex_prompt_rows = build_rows_for_model(codex_sessions, model_totals["codex"])
+    claude_session_rows, claude_prompt_rows = build_rows_for_model(claude_sessions, model_totals["claude"])
+
+    all_sessions = codex_sessions + claude_sessions
+    all_session_rows = codex_session_rows + claude_session_rows
+    all_prompt_rows = codex_prompt_rows + claude_prompt_rows
+
+    codex_section = section_from_rows("codex", codex_sessions, codex_session_rows, codex_prompt_rows)
+    claude_section = section_from_rows("claude", claude_sessions, claude_session_rows, claude_prompt_rows)
+    combined_section = section_from_rows("combined", all_sessions, all_session_rows, all_prompt_rows)
+
+    codex_repeats = sorted((repeat_breakdown.get("topCodexRepeatedValues") or []), key=lambda r: r.get("tokenEstimateTotal", 0), reverse=True)
+    claude_repeats = sorted((repeat_breakdown.get("topClaudeRepeatedValues") or []), key=lambda r: r.get("tokenEstimateTotal", 0), reverse=True)
+    combined_repeats = sorted(codex_repeats + claude_repeats, key=lambda r: r.get("tokenEstimateTotal", 0), reverse=True)
+
+    report = {
+        "scope": {
+            "codex_sessions_dir": str(codex_dir),
+            "claude_sessions_dir": str(claude_dir),
+            "audit_report": str(audit_path),
+            "planning_phrases": PLANNING_PHRASES,
+            "cost_model": {
+                "method": "proportional-to-ccusage",
+                "effective_formula": "input_tokens + 0.1 * cached_input_tokens",
+                "model_totals": model_totals,
+            },
+        },
+        "combined": combined_section,
+        "codex": codex_section,
+        "claude": claude_section,
+        "cache_hit_drivers": {
+            "combined": {
+                "source_shares": source_shares(combined_repeats),
+                "top_repeated_values": combined_repeats[:15],
+            },
+            "codex": {
+                "source_shares": source_shares(codex_repeats),
+                "top_repeated_values": codex_repeats[:15],
+            },
+            "claude": {
+                "source_shares": source_shares(claude_repeats),
+                "top_repeated_values": claude_repeats[:15],
+            },
+        },
+    }
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    (out_dir / "planning-vs-execution-report.json").write_text(json.dumps(report, indent=2))
+
+    def write_csv(path: Path, rows: list[dict[str, Any]]) -> None:
+        with path.open("w", newline="", encoding="utf-8") as f:
+            if rows:
+                w = csv.DictWriter(f, fieldnames=list(rows[0].keys()))
+                w.writeheader()
+                w.writerows(rows)
+            else:
+                f.write("empty\n")
+
+    write_csv(out_dir / "planning-vs-execution-sessions.csv", all_session_rows)
+    write_csv(out_dir / "planning-vs-execution-prompts.csv", all_prompt_rows)
+
+    tool_rows: list[dict[str, Any]] = []
+    for sec_name, sec in [("combined", combined_section), ("codex", codex_section), ("claude", claude_section)]:
+        for bucket in ("planning", "execution"):
+            v = sec["tool_breakdown"][bucket]
+            for row in v["by_function_name"]:
+                tool_rows.append({**row, "section": sec_name, "bucket": bucket, "dimension": "function_name"})
+            for row in v["by_shell_verb"]:
+                tool_rows.append({**row, "section": sec_name, "bucket": bucket, "dimension": "shell_verb"})
+    write_csv(out_dir / "planning-vs-execution-tool-breakdown.csv", tool_rows)
+
+    (out_dir / "planning-vs-execution-summary.md").write_text(render_markdown(report))
+    return report
+
+
+def fmt_int(n: float) -> str:
+    return f"{int(n):,}"
+
+
+def fmt_money(n: float) -> str:
+    return f"${n:,.2f}"
+
+
+def fmt_pct(n: float) -> str:
+    return f"{n:.2f}%"
+
+
+def _write_bucket(lines: list[str], name: str, view: dict[str, Any]) -> None:
+    t = view["totals"]
+    d = view["distributions"]
+    lines.append(f"### {name.capitalize()} bucket")
+    lines.append("")
+    lines.append(f"- Sessions: **{view['session_count']}**, cost: **{fmt_money(t['estimated_cost_usd'])}**, cache-hit: **{fmt_pct(t['cache_hit_pct'])}**")
+    lines.append(
+        f"- Tokens: input={fmt_int(t['input_tokens'])}, cached={fmt_int(t['cached_input_tokens'])}, output={fmt_int(t['output_tokens'])}"
+    )
+    lines.append("")
+    lines.append("| Metric | Mean | Median | P90 | Max |")
+    lines.append("|---|---:|---:|---:|---:|")
+    for label, key in [
+        ("Estimated cost (USD)", "estimated_cost_usd"),
+        ("Effective input (tokens)", "effective_input_10pct"),
+        ("Tool calls", "tool_calls"),
+    ]:
+        stats = d[key]
+        fmt = fmt_money if "cost" in key else fmt_int
+        lines.append(f"| {label} | {fmt(stats['mean'])} | {fmt(stats['median'])} | {fmt(stats['p90'])} | {fmt(stats['max'])} |")
+    lines.append("")
+    p = view["pareto80_by_cost"]
+    lines.append(f"- 80% cost reached by top **{p['selected_count']}** sessions ({fmt_pct(p['selected_share']*100)} of bucket cost).")
+    lines.append("")
+
+
+def _write_tool(lines: list[str], sec_name: str, tb: dict[str, Any]) -> None:
+    lines.append(f"### Tool-call breakdown ({sec_name})")
+    lines.append("")
+    for bucket in ("planning", "execution"):
+        v = tb[bucket]
+        lines.append(f"#### {bucket.capitalize()} tools")
+        lines.append("")
+        lines.append("| Function | Calls | Call share | Projected cost |")
+        lines.append("|---|---:|---:|---:|")
+        for r in v["by_function_name"][:10]:
+            lines.append(f"| `{r['name']}` | {fmt_int(r['calls'])} | {fmt_pct(r['calls_share_pct'])} | {fmt_money(r['projected_cost_usd'])} |")
+        lines.append("")
+        lines.append("| Shell verb | Calls | Call share | Projected cost |")
+        lines.append("|---|---:|---:|---:|")
+        for r in v["by_shell_verb"][:12]:
+            lines.append(f"| `{r['name']}` | {fmt_int(r['calls'])} | {fmt_pct(r['calls_share_pct'])} | {fmt_money(r['projected_cost_usd'])} |")
+        lines.append("")
+    lines.append(f"_Methodology: {tb['methodology']}_")
+    lines.append("")
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    scope = report["scope"]
+    lines.append("# Planning vs Execution Token & Cost Report")
+    lines.append("")
+    lines.append("## Scope")
+    lines.append(f"- Codex sessions: `{scope['codex_sessions_dir']}`")
+    lines.append(f"- Claude sessions: `{scope['claude_sessions_dir']}`")
+    lines.append(f"- Audit report: `{scope['audit_report']}`")
+    lines.append(f"- Planning phrases: {', '.join(f'`{p}`' for p in scope['planning_phrases'])}")
+    lines.append("")
+
+    for sec_name in ("combined", "codex", "claude"):
+        sec = report[sec_name]
+        lines.append(f"## {sec_name.capitalize()} section")
+        lines.append("")
+        lines.append(
+            f"- Session count: **{sec['totals']['session_count']}** "
+            f"(planning {sec['totals']['planning_session_count']}, execution {sec['totals']['execution_session_count']})"
+        )
+        lines.append(
+            f"- Estimated cost: **{fmt_money(sec['totals']['estimated_cost_usd'])}**, "
+            f"effective input: **{fmt_int(sec['totals']['effective_input_10pct'])}**"
+        )
+        lines.append("")
+        _write_bucket(lines, "planning", sec["planning"])
+        _write_bucket(lines, "execution", sec["execution"])
+        _write_tool(lines, sec_name, sec["tool_breakdown"])
+
+    lines.append("## Cache-hit drivers")
+    lines.append("")
+    for sec_name in ("combined", "codex", "claude"):
+        c = report["cache_hit_drivers"][sec_name]
+        lines.append(f"### {sec_name.capitalize()} source shares")
+        lines.append("")
+        lines.append("| Source | Estimated repeated tokens | Share |")
+        lines.append("|---|---:|---:|")
+        for s in c["source_shares"][:10]:
+            lines.append(f"| `{s['source']}` | {fmt_int(s['estimated_repeated_tokens'])} | {fmt_pct(s['share_pct'])} |")
+        lines.append("")
+
+    lines.append("---")
+    lines.append("")
+    lines.append("Generated by `scripts/planning_vs_execution_report.py`.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Planning vs Execution token/cost report (Codex+Claude+combined)")
+    parser.add_argument("--out-dir", default=str(REPO_ROOT / "reports"), help="Output directory for report artifacts")
+    parser.add_argument("--audit-report", default=str(DEFAULT_AUDIT_REPORT), help="Path to cache-hit-audit-report.json")
+    parser.add_argument("--codex-sessions-dir", default=str(DEFAULT_CODEX_DIR), help="Codex sessions directory")
+    parser.add_argument("--claude-sessions-dir", default=str(DEFAULT_CLAUDE_DIR), help="Claude sessions directory")
+    args = parser.parse_args(argv)
+
+    out_dir = Path(args.out_dir)
+    audit_path = Path(args.audit_report)
+    codex_dir = Path(args.codex_sessions_dir)
+    claude_dir = Path(args.claude_sessions_dir)
+    if not audit_path.exists():
+        # Common worktree setup: audit file may live in sibling main checkout.
+        fallback = REPO_ROOT.parent.parent / "Invoker" / "cache-hit-audit-report.json"
+        if fallback.exists():
+            audit_path = fallback
+        else:
+            print(
+                "Audit report not found. Run `python3 scripts/cache_hit_audit.py "
+                "--output cache-hit-audit-report.json` first or pass --audit-report.",
+                file=sys.stderr,
+            )
+            return 1
+    if not codex_dir.exists():
+        print(f"Codex sessions directory does not exist: {codex_dir}", file=sys.stderr)
+        return 1
+    if not claude_dir.exists():
+        print(f"Claude sessions directory does not exist: {claude_dir}", file=sys.stderr)
+        return 1
+
+    report = build_report(out_dir, audit_path, codex_dir, claude_dir)
+    print(f"Report written to: {out_dir}")
+    for sec_name in ("combined", "codex", "claude"):
+        sec = report[sec_name]
+        print(
+            f"{sec_name}: sessions={sec['totals']['session_count']} "
+            f"planning={sec['totals']['planning_session_count']} "
+            f"execution={sec['totals']['execution_session_count']} "
+            f"cost={fmt_money(sec['totals']['estimated_cost_usd'])}"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `scripts/cache_hit_audit.py` and `scripts/planning_vs_execution_report.py` to reproduce cache-hit, token, cost, and tool-call analyses.
- Add `docs/reports/planning-vs-execution-tooling.md` with regeneration commands, output artifacts, and attribution methodology.
- Ignore generated local analysis outputs at repo root (`/reports/`, cache-hit and planning-session artifacts) so report regeneration stays reproducible without noisy commits.

## Test plan
- [x] `python3 -m py_compile scripts/cache_hit_audit.py scripts/planning_vs_execution_report.py`
- [x] `python3 scripts/planning_vs_execution_report.py --out-dir /tmp/pve-smoke`
- [x] `test -f /tmp/pve-smoke/planning-vs-execution-summary.md`

Made with [Cursor](https://cursor.com)