### PR TITLE
Defer planning-phase pnpm test guidance in plan-to-invoker

### DIFF
--- a/.cursor/rules/skill-command-precedence.mdc
+++ b/.cursor/rules/skill-command-precedence.mdc
@@ -18,7 +18,7 @@ When **any** of these apply for the current user message, treat the linked **ski
 Until the user confirms the workflow is complete:
 
 1. Do **not** edit application or library code under `packages/` (or other product paths) for the substantive request.
-2. Follow the skill: scope → Phase 1a → Phase 1b (`pnpm test` / headless as applicable) → implementation YAML from facts → `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` → present plan → **wait for user confirmation** before `./submit-plan.sh` or before coding.
+2. Follow the skill: scope → Phase 1a → Phase 1b (headless runtime verification as applicable; defer package-test commands unless repro/debug requires them) → implementation YAML from facts → `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>` → present plan → **wait for user confirmation** before `./submit-plan.sh` or before coding.
 
 Treat free text after `/plan-to-invoker` as **input to the skill workflow**, not a directive to implement immediately.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@
 - **Bootstrap after clone:** Run `bash scripts/setup-agent-skills.sh` so `.cursor/skills/plan-to-invoker` exists (and Codex symlink if used). Optional: `bash scripts/test-plan-to-invoker-skill.sh` when changing skill layout.
 - **Repo rule:** See `.cursor/rules/skill-command-precedence.mdc` for the always-on summary.
 
-- Every step in a plan MUST be testable. Each implementation step must have a corresponding verification with a concrete, executable command that produces a clear pass/fail exit code (e.g. `pnpm test`, `git diff --name-only`). Do not use AI prompts for test tasks — use commands only.
+- Every step in a plan MUST be testable. Each implementation step must have a corresponding verification with a concrete, executable command that produces a clear pass/fail exit code (e.g. `git diff --name-only`, targeted repro commands, headless Invoker verification). Do not use AI prompts for test tasks — use commands only.
 - Bug fix plans MUST follow a three-phase approach before any implementation:
   1. **Reproduce** -- Find or write a concrete reproduction case (a failing test or a command that demonstrates the bug). Report back the exact repro steps and observed vs. expected behavior. Do not proceed until the bug is reliably reproducible.
   2. **Debug and report** -- Investigate and report: (a) the root cause — why the code is in the buggy state, and (b) the test gap — how the bug escaped existing tests (missing coverage, wrong assumptions, untested edge case, etc.).

--- a/scripts/test-plan-to-invoker-skill.sh
+++ b/scripts/test-plan-to-invoker-skill.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Contract tests for the plan-to-invoker skill: runtime verification must stay documented.
+# Contract tests for the plan-to-invoker skill: planning/runtime guidance must stay documented.
 # Run from repo root: bash scripts/test-plan-to-invoker-skill.sh
 set -euo pipefail
 
@@ -53,11 +53,11 @@ if [[ -e "$CODEX_LINK" ]]; then
   esac
 fi
 
-# SKILL.md — runtime verification + Invoker headless as complementary lane
+# SKILL.md — runtime verification + Invoker headless as planning lane
 must_contain "$SKILL_MD" "## Intended flow (do not skip steps)" "SKILL must document the full flow"
 must_contain "$SKILL_MD" "Runtime verification (Phase 1b)" "SKILL must require runtime behavioral verification"
 must_contain "$SKILL_MD" "Invoker headless" "SKILL must mention Invoker headless as a verification lane"
-must_contain "$SKILL_MD" "pnpm test" "SKILL must mention pnpm test for behavioral proof"
+must_contain "$SKILL_MD" "deferred to implementation verification" "SKILL must defer planning-time package test runs unless repro/debug requires them"
 must_contain "$SKILL_MD" "terminal stack workflows must end with" "SKILL must require the final full-suite regression gate for standalone plans and terminal stack workflows"
 must_contain "$SKILL_MD" "Grep-only checks" "SKILL must separate grep from behavioral verification"
 must_contain "$SKILL_MD" "see playbook" "SKILL Execution must reference the playbook"
@@ -69,11 +69,11 @@ must_contain "$SKILL_MD" "Review compression" "SKILL must require review compres
 must_contain "$SKILL_MD" "Review claim:" "SKILL must require review claim metadata"
 must_contain "$SKILL_MD" "Safety invariant:" "SKILL must require safety invariant metadata"
 
-# Playbook — Phase 1a / 1b (three lanes) and anti-patterns
+# Playbook — Phase 1a / 1b planning lanes and anti-patterns
 must_contain "$PLAYBOOK" "### Phase 1a — Static analysis" "Playbook must define Phase 1a"
 must_contain "$PLAYBOOK" "### Phase 1b — Runtime verification" "Playbook must define runtime behavioral verification"
 must_contain "$PLAYBOOK" "Phase 1b-invoker" "Playbook must define Invoker headless verification lane"
-must_contain "$PLAYBOOK" "pnpm test" "Playbook must document pnpm test for behavioral verification"
+must_contain "$PLAYBOOK" "Prefer lightweight scripted reproductions" "Playbook must prefer lightweight repro checks during planning"
 must_contain "$PLAYBOOK" "pnpm run test:all" "Playbook must document the final full-suite regression gate"
 must_contain "$PLAYBOOK" "Invoker is mandatory" "Playbook must warn when Invoker verification is mandatory"
 must_contain "$PLAYBOOK" "coverageItems" "Playbook must document row-level coverage for policy-matrix sources"

--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -14,12 +14,12 @@ Minimal controller skill. Keep policy short here; use deterministic scripts and 
 
 1. Discuss scope/risk with the user.
 2. Phase 1a static analysis.
-3. Runtime verification (Phase 1b): run targeted `pnpm test`, plus Invoker headless when applicable.
+3. Runtime verification (Phase 1b): run Invoker headless verification when applicable; defer package-test commands to implementation verification unless a reproduction specifically needs them.
 4. Generate implementation YAML from verified facts.
 5. Validate with deterministic scripts.
 6. Present plan and submit on confirmation.
 
-Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b evidence.
+Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b headless evidence.
 
 **Review compression (required for implementation plans):** Before authoring any plan with `onFinish != none`, apply `skills/review-compression/SKILL.md`. Split by reviewer cognition, not file count: one local review claim, one safety invariant, one slice rationale, and one architectural effect per implementation task. This applies to Invoker and non-Invoker target repos.
 
@@ -115,12 +115,12 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
 
 ## Runtime verification (Phase 1b)
 
-- Unit/package lane: `cd packages/<pkg> && pnpm test`
 - Invoker headless lane: run `./submit-plan.sh plans/verify-<slug>.yaml` when flow involves orchestrator/executor/persistence/headless behavior
 - Visual proof lane when UI changes apply
+- Package tests are optional in planning and should be deferred to implementation verification unless needed to reproduce/debug a specific hypothesis
 - Implementation-plan full-suite gate: standalone implementation plans and terminal stack workflows must end with `pnpm run test:all` from the repo root and depend on every earlier task. Non-terminal stack workflows should end with focused verification; validate them with `skill-doctor --stack-manifest <file>` so the stack position is explicit.
 
-When Invoker config enables heavyweight command routing, keep `pnpm ...` commands in the plan as normal command tasks unless a specific remote target must be declared explicitly. Runtime config may auto-route those commands to SSH.
+When Invoker config enables heavyweight command routing, keep implementation-phase `pnpm ...` commands in the plan as normal command tasks unless a specific remote target must be declared explicitly. Runtime config may auto-route those commands to SSH.
 
 Authoring YAML is not verification; execution is verification.
 

--- a/skills/plan-to-invoker/playbooks/verify-then-build.md
+++ b/skills/plan-to-invoker/playbooks/verify-then-build.md
@@ -66,21 +66,19 @@ bash skills/plan-to-invoker/scripts/skill-doctor.sh \
 
 For policy-matrix inputs, `skill-doctor` now fails if the coverage map or stack manifest is missing.
 
-### Phase 1b — Runtime verification (three lanes)
+### Phase 1b — Runtime verification (planning lanes)
 
 **Required** when the investigation claims something about **executed** behavior (not just “this string appears in a file”). **Phase 1b has three parts; use all that apply.**
 
-#### Phase 1b-unit — Package tests (agent shell)
+#### Phase 1b-unit (optional) — Focused local reproducer
 
-- Run **`cd packages/<pkg> && pnpm test`**, optionally scoped to a test file that encodes the hypothesis.
-- **Alternative:** `node scripts/verify-<slug>.mjs` (or `tsx`) that imports production modules and asserts output — must follow repo environment rules.
+- Run a focused reproducer only when it is needed to prove or debug the planning hypothesis.
+- Prefer lightweight scripted reproductions (`node scripts/verify-<slug>.mjs`, `tsx`, or existing targeted checks) over broad package test runs during planning.
 - **Record** pass/fail and what each result proves.
-
-**When:** Always appropriate for logic that can be expressed in Vitest (components, pure functions, parsers).
 
 #### Phase 1b-invoker — Headless Invoker (`submit-plan.sh`)
 
-- **Actually execute** `./submit-plan.sh plans/verify-<slug>.yaml` after `pnpm --filter @invoker/app build` if `packages/app/dist/main.js` is missing.
+- **Actually execute** `./submit-plan.sh plans/verify-<slug>.yaml` once local headless prerequisites are available.
 - Optionally wrap with `./run.sh --headless delete-all` first to avoid duplicate task IDs.
 - **Record** exit code and relevant log lines (e.g. `tee /tmp/invoker-verify.txt`).
 - **Authoring** a verify YAML or running **`validate-plan.sh` only** does **not** satisfy Phase 1b-invoker — those do not run the orchestrator or write SQLite.
@@ -99,7 +97,7 @@ For policy-matrix inputs, `skill-doctor` now fails if the coverage map or stack 
 
 #### Combine Phase 1a + 1b in YAML
 
-Submit **one** verification plan YAML that includes **static** tasks (Phase 1a) **and** **runtime** tasks: at least `pnpm test` **and/or** commands that only run when the verify plan is **submitted** via `submit-plan.sh` (e.g. SQLite assertions after a minimal task). **Anti-pattern:** verify plan with **only** `rg`/`test -f` and **no** `pnpm test` and **no** path that exercises Invoker when Phase 1b-invoker applies.
+Submit **one** verification plan YAML that includes **static** tasks (Phase 1a) **and** runtime tasks that run only when the verify plan is **submitted** via `submit-plan.sh` (for example SQLite assertions after a minimal task). **Anti-pattern:** verify plan with **only** `rg`/`test -f` and no path that exercises Invoker when Phase 1b-invoker applies.
 
 #### Validate YAML shape (not behavior)
 
@@ -127,7 +125,7 @@ bash skills/plan-to-invoker/scripts/parse-results.sh < /tmp/invoker-verify.txt
 #### Interpret results
 
 - **Static tasks passed** → files/patterns OK.
-- **Unit tests passed** → in-package hypothesis holds.
+- **Focused reproducer passed** → the planning hypothesis holds for the exercised path.
 - **Invoker run exited 0** → orchestration/persistence/headless path holds.
 - **Any failed** → revise assumptions or add a failing repro before implementation.
 
@@ -195,7 +193,7 @@ Generate the implementation plan, validate with `scripts/validate-plan.sh`, pres
 - **Skipping verification for plans that reference 3+ specific files** — these are exactly the plans most likely to have stale assumptions.
 - **Static-only verification for behavioral claims** — `rg`/`test -f` prove presence of text, not runtime behavior.
 - **Treating `validate-plan.sh` as proof** — it only validates YAML structure.
-- **Stopping at `pnpm test` when Phase 1b-invoker is mandatory** — Invoker path unverified.
+- **Stopping at static checks when Phase 1b-invoker is mandatory** — Invoker path unverified.
 - **Not cleaning up verification workflow** — Invoker may still have the verify plan running. Use `delete-all` before submitting implementation when needed.
 - **Trusting file paths from a plan without checking** — plans can reference moved, renamed, or deleted files. Verify first.
 - **Proceeding after verification failures without adjusting** — the whole point of Phase 1 is to inform Phase 2.


### PR DESCRIPTION
## Summary
- Update `plan-to-invoker` guidance so planning Phase 1b emphasizes Invoker headless verification and focused repros, while deferring package-wide `pnpm test` commands to implementation verification unless explicitly needed for reproduction/debugging.
- Align policy docs/rules and contract checks (`skills/plan-to-invoker/SKILL.md`, playbook, `CLAUDE.md`, `.cursor` precedence rule, and `scripts/test-plan-to-invoker-skill.sh`) with the new planning-phase behavior.
- Cost context from `reports/planning-vs-execution-tool-breakdown.csv` (current combined/codex/claude report): planning `pnpm` shell calls account for `66` calls in combined planning (`2.3%` of planning shell-verb calls), with projected planning cost attribution of `$5.40` (`3.1%` of combined planning shell-verb projected cost; Codex planning: `66` calls, `$5.40`; Claude planning: `0` calls).

## Test plan
- [x] `bash scripts/test-plan-to-invoker-skill.sh`
- [x] `rg "Phase 1b.*pnpm test|pnpm test" skills/plan-to-invoker/SKILL.md` (expect no matches)