### PR TITLE
Add nightly Invoker benchmark harness

### DIFF
--- a/docs/invoker-benchmark-nightly.md
+++ b/docs/invoker-benchmark-nightly.md
@@ -1,0 +1,62 @@
+# Invoker Benchmark Nightly Launcher
+
+The benchmark harness lives in `invoker-benchmarks/` and is intended to be
+installed on the coordinator at:
+
+```text
+/home/invoker/invoker-benchmarks/
+```
+
+Cron should invoke only:
+
+```bash
+/home/invoker/invoker-benchmarks/bin/run-nightly-benchmark.sh
+```
+
+Default schedule:
+
+```cron
+0 0 * * * TZ=Asia/Hong_Kong /home/invoker/invoker-benchmarks/bin/run-nightly-benchmark.sh
+```
+
+## Install
+
+1. Copy `invoker-benchmarks/` to `/home/invoker/invoker-benchmarks/` on
+   `remote_digital_ocean_1`.
+2. Copy `config/benchmark.env.example` to `config/benchmark.env` and fill in
+   Mixpanel auth if live emission is desired.
+3. Generate worker inventory from the coordinator Invoker config:
+
+```bash
+/home/invoker/invoker-benchmarks/bin/sync-worker-credentials.sh \
+  --write-workers /home/invoker/invoker-benchmarks/config/workers.json
+```
+
+The generated worker list includes `remote_digital_ocean_2`,
+`remote_digital_ocean_3`, `remote_digital_ocean_4`, and `remote_linode_1`.
+The coordinator only orchestrates and does not run benchmark jobs.
+
+## Validation
+
+```bash
+/home/invoker/invoker-benchmarks/bin/run-nightly-benchmark.sh --dry-run
+/home/invoker/invoker-benchmarks/bin/run-nightly-benchmark.sh --smoke
+/home/invoker/invoker-benchmarks/bin/run-nightly-benchmark.sh --limit 6
+```
+
+No-argument nightly runs publish metrics by default. Add `--no-emit-mixpanel`
+to write `mixpanel-export.jsonl` locally without publishing. Smoke runs publish
+only when `--emit-mixpanel` is passed.
+
+## Runtime Output
+
+Each batch writes to:
+
+```text
+/home/invoker/invoker-benchmarks/runs/YYYY-MM-DD_HH-mm-ss_HKT_<batch_id>/
+```
+
+The coordinator writes `summary.md`, `summary.json`, `job-matrix.tsv`,
+`worker-assignments.tsv`, and `mixpanel-export.jsonl`. Each job writes
+`job.json`, logs, generated plan, token usage, raw sessions, and the disposable
+checkout under `jobs/<run_id>/`.

--- a/invoker-benchmarks/bin/emit-mixpanel-events.sh
+++ b/invoker-benchmarks/bin/emit-mixpanel-events.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BATCH_DIR=""
+EMIT=0
+
+usage() {
+  cat <<'EOF'
+Usage: emit-mixpanel-events.sh --batch-dir PATH [--emit]
+
+Writes mixpanel-export.jsonl in the batch folder. With --emit, imports events
+to Mixpanel using MIXPANEL_TOKEN and either MIXPANEL_API_SECRET or service account auth.
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --batch-dir) BATCH_DIR="${2:-}"; shift 2 ;;
+    --emit) EMIT=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$BATCH_DIR" ]] || die "Missing --batch-dir"
+[[ -d "$BATCH_DIR" ]] || die "Missing batch dir: $BATCH_DIR"
+
+BENCHMARK_ROOT="${BENCHMARK_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+ENV_FILE="${BENCHMARK_ENV_FILE:-$BENCHMARK_ROOT/config/benchmark.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+python3 - "$BATCH_DIR" "${MIXPANEL_TOKEN:-}" "${MIXPANEL_SCHEMA_VERSION:-invoker_benchmark_v1}" <<'PY'
+import hashlib
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+batch_dir = Path(sys.argv[1])
+token = sys.argv[2]
+schema = sys.argv[3]
+summary_path = batch_dir / "summary.json"
+summary = json.loads(summary_path.read_text()) if summary_path.exists() else {}
+batch_id = summary.get("batch_id") or batch_dir.name
+now = int(datetime.now(timezone.utc).timestamp())
+
+def insert_id(*parts):
+    key = "|".join(str(p) for p in parts)
+    return "bench-" + hashlib.sha256(key.encode()).hexdigest()[:32]
+
+def event(name, props):
+    row_id = insert_id(batch_id, name, props.get("run_id", ""), props.get("task_id", ""))
+    base = {
+        "token": token,
+        "distinct_id": "invoker-benchmark",
+        "time": now,
+        "$insert_id": row_id,
+        "benchmark_schema_version": schema,
+        "batch_id": batch_id,
+    }
+    base.update(props)
+    return {"event": name, "properties": base}
+
+events = [
+    event("benchmark_batch", {
+        "invoker_sha": summary.get("invoker_sha"),
+        "job_count": summary.get("job_count", 0),
+        "status_counts": summary.get("status_counts", {}),
+    })
+]
+
+for job_path in sorted((batch_dir / "jobs").glob("*/job.json")):
+    try:
+        job = json.loads(job_path.read_text())
+    except Exception:
+        continue
+    run_props = {
+        "run_id": job.get("run_id"),
+        "conversation_id": job.get("conversation_id"),
+        "conversation_file": job.get("conversation_file"),
+        "model": job.get("model"),
+        "mode": job.get("mode"),
+        "invoker_sha": job.get("invoker_sha"),
+        "status": job.get("status"),
+        "exit_code": job.get("exit_code"),
+        "commit_count": len(job.get("commits") or []),
+        "changed_file_count": len(job.get("changed_files") or []),
+    }
+    events.append(event("benchmark_run", run_props))
+    events.append(event("benchmark_task", {
+        **run_props,
+        "task_id": job.get("run_id"),
+        "workflow_id": job.get("workflow_id"),
+        "terminal_state": job.get("status"),
+        "manual": job.get("status") == "manual",
+        "review_ready": job.get("status") == "review_ready",
+        "timeout": job.get("status") == "timeout",
+        "failed": job.get("status") in {"failed", "timeout", "invalid_job_json"},
+    }))
+    token_path = job_path.parent / "token-usage.json"
+    if token_path.exists():
+        try:
+            usage = json.loads(token_path.read_text())
+        except Exception:
+            usage = {}
+        events.append(event("benchmark_token_usage", {
+            **run_props,
+            "input_tokens": usage.get("input_tokens", 0),
+            "cache_read_tokens": usage.get("cache_read_tokens", 0),
+            "cache_creation_tokens": usage.get("cache_creation_tokens", 0),
+            "output_tokens": usage.get("output_tokens", 0),
+            "reasoning_tokens": usage.get("reasoning_tokens", 0),
+            "total_tokens": usage.get("total_tokens", 0),
+            "fresh_input_tokens": usage.get("fresh_input_tokens", 0),
+            "normalized_total_tokens": usage.get("normalized_total_tokens", 0),
+            "estimated_cost_usd": usage.get("estimated_cost_usd", 0),
+            "phase": usage.get("phase", "task"),
+            "autofix_phase_cost_usd": usage.get("autofix_phase_cost_usd", 0),
+            "original_phase_cost_usd": usage.get("original_phase_cost_usd", usage.get("estimated_cost_usd", 0)),
+        }))
+
+out = batch_dir / "mixpanel-export.jsonl"
+out.write_text("\n".join(json.dumps(item, sort_keys=True) for item in events) + "\n")
+print(f"wrote {len(events)} events to {out}")
+PY
+
+if [[ "$EMIT" -ne 1 ]]; then
+  exit 0
+fi
+
+[[ -n "${MIXPANEL_TOKEN:-}" ]] || die "Missing MIXPANEL_TOKEN"
+if [[ -z "${MIXPANEL_API_SECRET:-}" && ( -z "${MIXPANEL_SERVICE_ACCOUNT_USER:-}" || -z "${MIXPANEL_SERVICE_ACCOUNT_PASS:-}" ) ]]; then
+  die "Missing Mixpanel auth: set MIXPANEL_API_SECRET or MIXPANEL_SERVICE_ACCOUNT_USER + MIXPANEL_SERVICE_ACCOUNT_PASS"
+fi
+
+python3 - "$BATCH_DIR/mixpanel-export.jsonl" "${MIXPANEL_ENDPOINT:-https://api.mixpanel.com/import}" "${MIXPANEL_PROJECT_ID:-}" <<'PY'
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+jsonl, endpoint, project_id = sys.argv[1:]
+events = [json.loads(line) for line in Path(jsonl).read_text().splitlines() if line.strip()]
+if project_id:
+    sep = "&" if "?" in endpoint else "?"
+    endpoint = f"{endpoint}{sep}{urllib.parse.urlencode({'project_id': project_id})}"
+
+user = os.getenv("MIXPANEL_SERVICE_ACCOUNT_USER") or ""
+password = os.getenv("MIXPANEL_SERVICE_ACCOUNT_PASS") or ""
+api_secret = os.getenv("MIXPANEL_API_SECRET") or ""
+if user and password:
+    auth = base64.b64encode(f"{user}:{password}".encode()).decode()
+elif api_secret:
+    auth = base64.b64encode(f"{api_secret}:".encode()).decode()
+else:
+    raise SystemExit("missing auth")
+
+for offset in range(0, len(events), 2000):
+    payload = json.dumps(events[offset:offset + 2000]).encode()
+    req = urllib.request.Request(endpoint, data=payload, method="POST")
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Authorization", f"Basic {auth}")
+    try:
+        with urllib.request.urlopen(req, timeout=60) as response:
+            body = response.read().decode()
+    except urllib.error.HTTPError as exc:
+        raise SystemExit(f"Mixpanel import failed: HTTP {exc.code} {exc.read().decode(errors='ignore')}")
+    if body and body not in {"1", "OK"}:
+        print(body)
+print(f"emitted {len(events)} Mixpanel events")
+PY

--- a/invoker-benchmarks/bin/run-nightly-benchmark.sh
+++ b/invoker-benchmarks/bin/run-nightly-benchmark.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DEFAULT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$DEFAULT_ROOT/config/benchmark.env"
+WORKERS_FILE=""
+DRY_RUN=0
+SMOKE=0
+LIMIT=""
+EMIT_MIXPANEL=0
+EMIT_MIXPANEL_SET=0
+
+usage() {
+  cat <<'EOF'
+Usage: run-nightly-benchmark.sh [--dry-run] [--smoke] [--limit N] [--emit-mixpanel] [--no-emit-mixpanel] [--env-file PATH] [--workers-file PATH]
+
+Options:
+  --dry-run          Validate config and print the job assignment plan only.
+  --smoke            Run one conversation across all modes for the first model on one worker.
+  --limit N          Run only the first N matrix jobs.
+  --emit-mixpanel    Publish Mixpanel events after aggregation.
+  --no-emit-mixpanel Write mixpanel-export.jsonl but do not publish.
+  --env-file PATH    Benchmark env file. Defaults to config/benchmark.env.
+  --workers-file PATH Worker inventory JSON. Defaults to config/workers.json.
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+log() {
+  echo "[$(date '+%Y-%m-%d %H:%M:%S %Z')] $*"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --smoke) SMOKE=1; shift ;;
+    --limit)
+      LIMIT="${2:-}"
+      [[ "$LIMIT" =~ ^[0-9]+$ ]] || die "Missing or invalid value for --limit"
+      shift 2
+      ;;
+    --emit-mixpanel) EMIT_MIXPANEL=1; EMIT_MIXPANEL_SET=1; shift ;;
+    --no-emit-mixpanel) EMIT_MIXPANEL=0; EMIT_MIXPANEL_SET=1; shift ;;
+    --env-file)
+      ENV_FILE="${2:-}"
+      [[ -n "$ENV_FILE" ]] || die "Missing value for --env-file"
+      shift 2
+      ;;
+    --workers-file)
+      WORKERS_FILE="${2:-}"
+      [[ -n "$WORKERS_FILE" ]] || die "Missing value for --workers-file"
+      shift 2
+      ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -f "$ENV_FILE" ]] || die "Missing env file: $ENV_FILE"
+
+# shellcheck disable=SC1090
+set -a
+source "$ENV_FILE"
+set +a
+
+export TZ="${TZ:-Asia/Hong_Kong}"
+BENCHMARK_ROOT="${BENCHMARK_ROOT:-$DEFAULT_ROOT}"
+WORKERS_FILE="${WORKERS_FILE:-$BENCHMARK_ROOT/config/workers.json}"
+MANIFEST_FILE="${MANIFEST_FILE:-$BENCHMARK_ROOT/config/corpus-manifest.json}"
+RUNS_DIR="$BENCHMARK_ROOT/runs"
+MODELS="${MODELS:-codex,claude}"
+MODES="${MODES:-baseline_direct,invoker_workflow,invoker_auto_fix}"
+WORKER_CONCURRENCY_PER_HOST="${WORKER_CONCURRENCY_PER_HOST:-1}"
+if [[ "$EMIT_MIXPANEL_SET" -eq 0 && "$DRY_RUN" -eq 0 && "$SMOKE" -eq 0 && "${BENCHMARK_EMIT_MIXPANEL_DEFAULT:-1}" != "0" ]]; then
+  EMIT_MIXPANEL=1
+fi
+
+[[ "$WORKER_CONCURRENCY_PER_HOST" == "1" ]] || die "Only WORKER_CONCURRENCY_PER_HOST=1 is currently supported"
+[[ -n "${CORPUS_DIR:-}" ]] || die "Missing CORPUS_DIR"
+[[ -n "${INVOKER_REPO:-}" ]] || die "Missing INVOKER_REPO"
+[[ -n "${INVOKER_BRANCH:-}" ]] || die "Missing INVOKER_BRANCH"
+
+if [[ ! -f "$WORKERS_FILE" ]]; then
+  if [[ -f "$HOME/.invoker/config.json" ]]; then
+    log "workers.json missing; generating from ~/.invoker/config.json"
+    "$BENCHMARK_ROOT/bin/sync-worker-credentials.sh" --write-workers "$WORKERS_FILE" --no-ssh
+  else
+    die "Missing workers file: $WORKERS_FILE"
+  fi
+fi
+
+mapfile -t WORKERS < <(python3 - "$WORKERS_FILE" <<'PY'
+import json, sys
+path = sys.argv[1]
+data = json.load(open(path))
+for worker in data.get("workers", []):
+    if worker.get("enabled", True):
+        user = worker.get("user") or "invoker"
+        host = worker.get("host") or worker.get("name")
+        port = int(worker.get("port") or 22)
+        name = worker.get("name") or host
+        if host:
+            print(f"{name}\t{user}@{host}\t{port}")
+PY
+)
+
+[[ "${#WORKERS[@]}" -gt 0 ]] || die "No enabled workers in $WORKERS_FILE"
+if [[ "$SMOKE" -eq 1 ]]; then
+  WORKERS=("${WORKERS[0]}")
+fi
+
+INVOKER_SHA="${INVOKER_SHA:-}"
+if [[ -z "$INVOKER_SHA" ]]; then
+  if INVOKER_SHA="$(git ls-remote "$INVOKER_REPO" "refs/heads/$INVOKER_BRANCH" | awk '{print $1}' | head -n 1)" && [[ -n "$INVOKER_SHA" ]]; then
+    :
+  elif [[ "$DRY_RUN" -eq 1 ]]; then
+    INVOKER_SHA="dry-run-unresolved"
+  else
+    die "Unable to resolve $INVOKER_REPO $INVOKER_BRANCH"
+  fi
+fi
+
+RUN_STAMP="$(date '+%Y-%m-%d_%H-%M-%S_%Z')"
+BATCH_ID="${BATCH_ID:-${RUN_STAMP}_$(printf '%s' "$INVOKER_SHA" | cut -c1-12)_$$}"
+BATCH_DIR="$RUNS_DIR/$BATCH_ID"
+MATRIX_FILE="$BATCH_DIR/job-matrix.tsv"
+ASSIGNMENTS_FILE="$BATCH_DIR/worker-assignments.tsv"
+
+mkdir -p "$BATCH_DIR/jobs"
+
+python3 - "$CORPUS_DIR" "$MANIFEST_FILE" "$MODELS" "$MODES" "$SMOKE" "${LIMIT:-}" "$MATRIX_FILE" "$ASSIGNMENTS_FILE" "${WORKERS[@]}" <<'PY'
+import glob
+import json
+import sys
+from pathlib import Path
+
+corpus_dir = Path(sys.argv[1])
+manifest_file = Path(sys.argv[2])
+models = [x.strip() for x in sys.argv[3].split(",") if x.strip()]
+modes = [x.strip() for x in sys.argv[4].split(",") if x.strip()]
+smoke = sys.argv[5] == "1"
+limit = int(sys.argv[6]) if sys.argv[6] else None
+matrix_file = Path(sys.argv[7])
+assignments_file = Path(sys.argv[8])
+workers = [item.split("\t", 2) for item in sys.argv[9:]]
+
+manifest = {}
+if manifest_file.exists():
+    manifest = json.loads(manifest_file.read_text())
+
+conversations = []
+if "sessions" in manifest:
+    for item in manifest["sessions"]:
+        rel = item["file"] if isinstance(item, dict) else str(item)
+        conversations.append(corpus_dir / rel)
+else:
+    globs = manifest.get("file_globs") or ["*.jsonl", "*.json", "*.md", "*.txt"]
+    seen = set()
+    for pattern in globs:
+        for path in sorted(glob.glob(str(corpus_dir / pattern))):
+            if path not in seen:
+                seen.add(path)
+                conversations.append(Path(path))
+
+expected = manifest.get("expected_conversation_count")
+if not conversations:
+    raise SystemExit(f"No corpus conversations found in {corpus_dir}")
+if expected and len(conversations) != int(expected):
+    raise SystemExit(f"Expected {expected} corpus conversations, found {len(conversations)} in {corpus_dir}")
+
+if smoke:
+    conversations = conversations[:1]
+    models = models[:1]
+
+jobs = []
+for conversation in conversations:
+    session_id = conversation.stem
+    for model in models:
+        for mode in modes:
+            run_id = f"{session_id}__{model}__{mode}"
+            jobs.append((run_id, str(conversation), session_id, model, mode))
+
+if limit is not None:
+    jobs = jobs[:limit]
+
+matrix_file.write_text("\n".join("\t".join(row) for row in jobs) + ("\n" if jobs else ""))
+
+lines = []
+for index, row in enumerate(jobs):
+    worker = workers[index % len(workers)]
+    lines.append("\t".join([worker[0], worker[1], worker[2], *row]))
+assignments_file.write_text("\n".join(lines) + ("\n" if lines else ""))
+
+print(f"conversation_count={len(conversations)}")
+print(f"model_count={len(models)}")
+print(f"mode_count={len(modes)}")
+print(f"job_count={len(jobs)}")
+print(f"worker_count={len(workers)}")
+PY
+
+log "batch_id=$BATCH_ID invoker_sha=$INVOKER_SHA"
+log "matrix=$(wc -l < "$MATRIX_FILE" | tr -d ' ') jobs assignments=$ASSIGNMENTS_FILE"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+  log "dry-run worker assignment plan:"
+  column -t -s $'\t' "$ASSIGNMENTS_FILE" || cat "$ASSIGNMENTS_FILE"
+  exit 0
+fi
+
+sync_runtime_to_worker() {
+  local target="$1"
+  local port="$2"
+  ssh -p "$port" "$target" "mkdir -p '$BENCHMARK_ROOT/bin' '$BENCHMARK_ROOT/config' '$BENCHMARK_ROOT/corpus' '$BENCHMARK_ROOT/runs'"
+  rsync -az -e "ssh -p $port" "$BENCHMARK_ROOT/bin/" "$target:$BENCHMARK_ROOT/bin/"
+  rsync -az -e "ssh -p $port" "$BENCHMARK_ROOT/config/" "$target:$BENCHMARK_ROOT/config/"
+  rsync -az -e "ssh -p $port" "$CORPUS_DIR/" "$target:$CORPUS_DIR/"
+}
+
+run_worker_queue() {
+  local worker_name="$1"
+  local target="$2"
+  local port="$3"
+  local queue_file="$4"
+  local worker_log="$BATCH_DIR/${worker_name}.log"
+
+  log "syncing runtime to $worker_name"
+  sync_runtime_to_worker "$target" "$port" >>"$worker_log" 2>&1
+
+  while IFS=$'\t' read -r run_id conversation_file session_id model mode; do
+    [[ -n "$run_id" ]] || continue
+    log "dispatch worker=$worker_name run_id=$run_id"
+    if ssh -p "$port" "$target" \
+      "BENCHMARK_ROOT='$BENCHMARK_ROOT' '$BENCHMARK_ROOT/bin/run-worker-job.sh' --batch-id '$BATCH_ID' --run-id '$run_id' --conversation-file '$conversation_file' --model '$model' --mode '$mode' --invoker-sha '$INVOKER_SHA'" \
+      >>"$worker_log" 2>&1; then
+      log "complete worker=$worker_name run_id=$run_id"
+    else
+      log "failed worker=$worker_name run_id=$run_id"
+    fi
+    mkdir -p "$BATCH_DIR/jobs/$run_id"
+    rsync -az -e "ssh -p $port" "$target:$BENCHMARK_ROOT/runs/$BATCH_ID/jobs/$run_id/" "$BATCH_DIR/jobs/$run_id/" >>"$worker_log" 2>&1 || true
+  done < "$queue_file"
+}
+
+QUEUE_DIR="$BATCH_DIR/queues"
+mkdir -p "$QUEUE_DIR"
+while IFS=$'\t' read -r worker_name target port run_id conversation_file session_id model mode; do
+  printf '%s\t%s\t%s\t%s\t%s\n' "$run_id" "$conversation_file" "$session_id" "$model" "$mode" >>"$QUEUE_DIR/$worker_name.tsv"
+done < "$ASSIGNMENTS_FILE"
+
+pids=()
+for worker in "${WORKERS[@]}"; do
+  IFS=$'\t' read -r worker_name target port <<<"$worker"
+  queue_file="$QUEUE_DIR/$worker_name.tsv"
+  [[ -s "$queue_file" ]] || continue
+  run_worker_queue "$worker_name" "$target" "$port" "$queue_file" &
+  pids+=("$!")
+done
+
+status=0
+for pid in "${pids[@]}"; do
+  if ! wait "$pid"; then
+    status=1
+  fi
+done
+
+python3 - "$BATCH_DIR" "$BATCH_ID" "$INVOKER_SHA" <<'PY'
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+batch_dir = Path(sys.argv[1])
+batch_id = sys.argv[2]
+invoker_sha = sys.argv[3]
+jobs = []
+for path in sorted((batch_dir / "jobs").glob("*/job.json")):
+    try:
+        jobs.append(json.loads(path.read_text()))
+    except json.JSONDecodeError:
+        jobs.append({"run_id": path.parent.name, "status": "invalid_job_json"})
+
+counts = {}
+for job in jobs:
+    counts[job.get("status", "unknown")] = counts.get(job.get("status", "unknown"), 0) + 1
+
+summary = {
+    "batch_id": batch_id,
+    "invoker_sha": invoker_sha,
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "job_count": len(jobs),
+    "status_counts": counts,
+    "jobs": jobs,
+}
+(batch_dir / "summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True))
+
+lines = [
+    f"# Invoker benchmark batch {batch_id}",
+    "",
+    f"- Invoker SHA: `{invoker_sha}`",
+    f"- Jobs collected: {len(jobs)}",
+]
+for key in sorted(counts):
+    lines.append(f"- {key}: {counts[key]}")
+(batch_dir / "summary.md").write_text("\n".join(lines) + "\n")
+PY
+
+emit_args=("$BENCHMARK_ROOT/bin/emit-mixpanel-events.sh" --batch-dir "$BATCH_DIR")
+if [[ "$EMIT_MIXPANEL" -eq 1 ]]; then
+  emit_args+=(--emit)
+fi
+"${emit_args[@]}"
+
+log "summary=$BATCH_DIR/summary.md"
+exit "$status"

--- a/invoker-benchmarks/bin/run-worker-job.sh
+++ b/invoker-benchmarks/bin/run-worker-job.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BATCH_ID=""
+RUN_ID=""
+CONVERSATION_FILE=""
+MODEL=""
+MODE=""
+INVOKER_SHA=""
+
+usage() {
+  cat <<'EOF'
+Usage: run-worker-job.sh --batch-id ID --run-id ID --conversation-file PATH --model codex|claude --mode MODE --invoker-sha SHA
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --batch-id) BATCH_ID="${2:-}"; shift 2 ;;
+    --run-id) RUN_ID="${2:-}"; shift 2 ;;
+    --conversation-file) CONVERSATION_FILE="${2:-}"; shift 2 ;;
+    --model) MODEL="${2:-}"; shift 2 ;;
+    --mode) MODE="${2:-}"; shift 2 ;;
+    --invoker-sha) INVOKER_SHA="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "Unknown argument: $1" ;;
+  esac
+done
+
+[[ -n "$BATCH_ID" ]] || die "Missing --batch-id"
+[[ -n "$RUN_ID" ]] || die "Missing --run-id"
+[[ -n "$CONVERSATION_FILE" ]] || die "Missing --conversation-file"
+[[ -n "$MODEL" ]] || die "Missing --model"
+[[ -n "$MODE" ]] || die "Missing --mode"
+[[ -n "$INVOKER_SHA" ]] || die "Missing --invoker-sha"
+
+BENCHMARK_ROOT="${BENCHMARK_ROOT:-/home/invoker/invoker-benchmarks}"
+ENV_FILE="${BENCHMARK_ENV_FILE:-$BENCHMARK_ROOT/config/benchmark.env}"
+if [[ -f "$ENV_FILE" ]]; then
+  # shellcheck disable=SC1090
+  set -a
+  source "$ENV_FILE"
+  set +a
+fi
+
+export TZ="${TZ:-Asia/Hong_Kong}"
+JOB_DIR="$BENCHMARK_ROOT/runs/$BATCH_ID/jobs/$RUN_ID"
+CHECKOUT_DIR="$JOB_DIR/checkout"
+RAW_SESSIONS_DIR="$JOB_DIR/raw-sessions"
+GENERATED_PLAN="$JOB_DIR/generated-plan.yaml"
+STDOUT_LOG="$JOB_DIR/stdout.log"
+STDERR_LOG="$JOB_DIR/stderr.log"
+STARTED_AT="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+mkdir -p "$JOB_DIR" "$RAW_SESSIONS_DIR"
+exec > >(tee -a "$STDOUT_LOG") 2> >(tee -a "$STDERR_LOG" >&2)
+
+write_job_json() {
+  local status="$1"
+  local exit_code="${2:-0}"
+  python3 - "$JOB_DIR/job.json" "$BATCH_ID" "$RUN_ID" "$CONVERSATION_FILE" "$MODEL" "$MODE" "$INVOKER_SHA" "$STARTED_AT" "$status" "$exit_code" <<'PY'
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+path, batch_id, run_id, conv, model, mode, sha, started, status, exit_code = sys.argv[1:]
+job_dir = Path(path).parent
+checkout = job_dir / "checkout"
+
+def run_git(args):
+    try:
+        return subprocess.check_output(["git", "-C", str(checkout), *args], text=True, stderr=subprocess.DEVNULL).strip()
+    except Exception:
+        return ""
+
+commits = []
+log = run_git(["log", "--oneline", f"{sha}..HEAD"])
+if log:
+    commits = log.splitlines()
+changed = run_git(["status", "--short"])
+payload = {
+    "batch_id": batch_id,
+    "run_id": run_id,
+    "conversation_file": conv,
+    "conversation_id": Path(conv).stem,
+    "model": model,
+    "mode": mode,
+    "invoker_sha": sha,
+    "started_at": started,
+    "finished_at": datetime.now(timezone.utc).isoformat(),
+    "status": status,
+    "exit_code": int(exit_code),
+    "commits": commits,
+    "changed_files": [line[3:] if len(line) > 3 else line for line in changed.splitlines()],
+    "artifacts": {
+        "stdout": "stdout.log",
+        "stderr": "stderr.log",
+        "generated_plan": "generated-plan.yaml",
+        "invoker_events": "invoker-events.jsonl",
+        "token_usage": "token-usage.json",
+        "raw_sessions": "raw-sessions",
+        "checkout": "checkout",
+    },
+}
+Path(path).write_text(json.dumps(payload, indent=2, sort_keys=True))
+PY
+}
+
+on_exit() {
+  local code=$?
+  if [[ "$code" -ne 0 && ! -f "$JOB_DIR/job.json" ]]; then
+    write_job_json failed "$code" || true
+  fi
+}
+trap on_exit EXIT
+
+snapshot_session_dirs() {
+  find "$HOME/.codex/sessions" "$HOME/.claude" -type f 2>/dev/null | sort > "$JOB_DIR/session-files-before.txt" || true
+}
+
+collect_new_sessions() {
+  find "$HOME/.codex/sessions" "$HOME/.claude" -type f 2>/dev/null | sort > "$JOB_DIR/session-files-after.txt" || true
+  comm -13 "$JOB_DIR/session-files-before.txt" "$JOB_DIR/session-files-after.txt" > "$JOB_DIR/session-files-new.txt" || true
+  while IFS= read -r file; do
+    [[ -f "$file" ]] || continue
+    rel="${file#$HOME/}"
+    mkdir -p "$RAW_SESSIONS_DIR/$(dirname "$rel")"
+    cp "$file" "$RAW_SESSIONS_DIR/$rel" || true
+  done < "$JOB_DIR/session-files-new.txt"
+}
+
+clear_non_credential_state() {
+  rm -rf \
+    "$HOME/.cache/codex" \
+    "$HOME/.cache/claude" \
+    "$HOME/.codex/benchmark-scratch" \
+    "$HOME/.claude/benchmark-scratch" \
+    "$HOME/.invoker/benchmark-scratch" \
+    /tmp/invoker-benchmark-* 2>/dev/null || true
+}
+
+install_checkout() {
+  rm -rf "$CHECKOUT_DIR"
+  git clone --no-checkout "${INVOKER_REPO:-https://github.com/Neko-Catpital-Labs/Invoker.git}" "$CHECKOUT_DIR"
+  git -C "$CHECKOUT_DIR" checkout "$INVOKER_SHA"
+  (
+    cd "$CHECKOUT_DIR"
+    if [[ -f pnpm-lock.yaml ]]; then
+      corepack enable >/dev/null 2>&1 || true
+      pnpm install --frozen-lockfile
+      pnpm run build --if-present
+    elif [[ -f package-lock.json ]]; then
+      npm ci
+      npm run build --if-present
+    elif [[ -f yarn.lock ]]; then
+      yarn install --frozen-lockfile
+      yarn build || true
+    fi
+  )
+}
+
+run_template() {
+  local template="$1"
+  if [[ -z "$template" ]]; then
+    return 1
+  fi
+  (
+    cd "$CHECKOUT_DIR"
+    export CHECKOUT_DIR CONVERSATION_FILE MODEL MODE JOB_DIR GENERATED_PLAN INVOKER_SHA
+    eval "$template"
+  )
+}
+
+default_baseline() {
+  (
+    cd "$CHECKOUT_DIR"
+    case "$MODEL" in
+      codex)
+        command -v codex >/dev/null || die "codex CLI not found and BENCHMARK_BASELINE_CODEX_COMMAND is unset"
+        codex exec --skip-git-repo-check "$(cat "$CONVERSATION_FILE")"
+        ;;
+      claude)
+        command -v claude >/dev/null || die "claude CLI not found and BENCHMARK_BASELINE_CLAUDE_COMMAND is unset"
+        claude -p "$(cat "$CONVERSATION_FILE")"
+        ;;
+      *) die "Unsupported model: $MODEL" ;;
+    esac
+  )
+}
+
+default_plan() {
+  case "$MODEL" in
+    codex)
+      if ! run_template "${BENCHMARK_PLAN_CODEX_COMMAND:-}"; then
+        command -v codex >/dev/null || die "codex CLI not found and BENCHMARK_PLAN_CODEX_COMMAND is unset"
+        (cd "$CHECKOUT_DIR" && codex exec --skip-git-repo-check "/plan-to-invoker\n$(cat "$CONVERSATION_FILE")") > "$GENERATED_PLAN"
+      fi
+      ;;
+    claude)
+      if ! run_template "${BENCHMARK_PLAN_CLAUDE_COMMAND:-}"; then
+        command -v claude >/dev/null || die "claude CLI not found and BENCHMARK_PLAN_CLAUDE_COMMAND is unset"
+        (cd "$CHECKOUT_DIR" && claude -p "/plan-to-invoker\n$(cat "$CONVERSATION_FILE")") > "$GENERATED_PLAN"
+      fi
+      ;;
+    *) die "Unsupported model: $MODEL" ;;
+  esac
+}
+
+default_invoker_submit() {
+  (
+    cd "$CHECKOUT_DIR"
+    export INVOKER_AUTOFIX="$1"
+    if run_template "${BENCHMARK_INVOKER_SUBMIT_COMMAND:-}"; then
+      return 0
+    fi
+    if command -v invoker >/dev/null; then
+      invoker workflow submit "$GENERATED_PLAN" --model "$MODEL" --no-pr --no-autostart --stop-at review_ready ${INVOKER_AUTOFIX:+--autofix}
+    elif [[ -x ./bin/invoker ]]; then
+      ./bin/invoker workflow submit "$GENERATED_PLAN" --model "$MODEL" --no-pr --no-autostart --stop-at review_ready ${INVOKER_AUTOFIX:+--autofix}
+    else
+      die "Invoker CLI not found and BENCHMARK_INVOKER_SUBMIT_COMMAND is unset"
+    fi
+  )
+}
+
+extract_token_usage() {
+  python3 - "$RAW_SESSIONS_DIR" "$JOB_DIR/token-usage.json" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+root = Path(sys.argv[1])
+out = Path(sys.argv[2])
+totals = {
+    "input_tokens": 0,
+    "cache_read_tokens": 0,
+    "cache_creation_tokens": 0,
+    "output_tokens": 0,
+    "reasoning_tokens": 0,
+    "total_tokens": 0,
+    "estimated_cost_usd": 0.0,
+}
+
+def add_usage(obj):
+    usage = obj.get("usage") if isinstance(obj, dict) else None
+    if not isinstance(usage, dict):
+        usage = obj if isinstance(obj, dict) else {}
+    mapping = {
+        "input_tokens": ["input_tokens", "inputTokens"],
+        "cache_read_tokens": ["cache_read_input_tokens", "cacheReadInputTokens", "cached_input_tokens", "cachedInputTokens"],
+        "cache_creation_tokens": ["cache_creation_input_tokens", "cacheCreationInputTokens"],
+        "output_tokens": ["output_tokens", "outputTokens"],
+        "reasoning_tokens": ["reasoning_tokens", "reasoningTokens"],
+        "total_tokens": ["total_tokens", "totalTokens"],
+        "estimated_cost_usd": ["estimated_cost_usd", "costUSD", "totalCost"],
+    }
+    for dest, keys in mapping.items():
+        for key in keys:
+            value = usage.get(key)
+            if isinstance(value, (int, float)):
+                totals[dest] += value
+                break
+
+for path in root.rglob("*"):
+    if not path.is_file():
+        continue
+    try:
+        lines = path.read_text(errors="ignore").splitlines()
+    except Exception:
+        continue
+    for line in lines:
+        line = line.strip()
+        if not line.startswith("{"):
+            continue
+        try:
+            add_usage(json.loads(line))
+        except Exception:
+            pass
+
+if not totals["total_tokens"]:
+    totals["total_tokens"] = totals["input_tokens"] + totals["cache_read_tokens"] + totals["cache_creation_tokens"] + totals["output_tokens"] + totals["reasoning_tokens"]
+totals["fresh_input_tokens"] = totals["input_tokens"] + totals["cache_creation_tokens"]
+totals["normalized_total_tokens"] = totals["fresh_input_tokens"] + totals["output_tokens"] + totals["reasoning_tokens"]
+out.write_text(json.dumps(totals, indent=2, sort_keys=True))
+PY
+}
+
+echo "START run_id=$RUN_ID model=$MODEL mode=$MODE sha=$INVOKER_SHA"
+snapshot_session_dirs
+clear_non_credential_state
+install_checkout
+
+status="succeeded"
+case "$MODE" in
+  baseline_direct)
+    baseline_var="BENCHMARK_BASELINE_${MODEL^^}_COMMAND"
+    if ! run_template "${!baseline_var:-}"; then
+      default_baseline
+    fi
+    ;;
+  invoker_workflow)
+    default_plan
+    default_invoker_submit ""
+    status="review_ready"
+    ;;
+  invoker_auto_fix)
+    default_plan
+    default_invoker_submit "1"
+    status="review_ready"
+    ;;
+  *) die "Unsupported mode: $MODE" ;;
+esac
+
+collect_new_sessions
+extract_token_usage
+touch "$JOB_DIR/invoker-events.jsonl"
+write_job_json "$status" 0
+echo "END run_id=$RUN_ID status=$status"

--- a/invoker-benchmarks/bin/sync-worker-credentials.sh
+++ b/invoker-benchmarks/bin/sync-worker-credentials.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+WRITE_WORKERS=""
+NO_SSH=0
+
+usage() {
+  cat <<'EOF'
+Usage: sync-worker-credentials.sh [--write-workers PATH] [--no-ssh]
+
+Generates workers.json from ~/.invoker/config.json. Unless --no-ssh is passed,
+also syncs Codex, Claude, SSH, and Invoker config directories to enabled workers.
+EOF
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --write-workers) WRITE_WORKERS="${2:-}"; shift 2 ;;
+    --no-ssh) NO_SSH=1; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "Unknown argument: $1" ;;
+  esac
+done
+
+CONFIG_PATH="${INVOKER_CONFIG_PATH:-$HOME/.invoker/config.json}"
+[[ -f "$CONFIG_PATH" ]] || die "Missing Invoker config: $CONFIG_PATH"
+
+if [[ -n "$WRITE_WORKERS" ]]; then
+  mkdir -p "$(dirname "$WRITE_WORKERS")"
+  python3 - "$CONFIG_PATH" "$WRITE_WORKERS" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+config_path, out_path = map(Path, sys.argv[1:])
+config = json.loads(config_path.read_text())
+raw_targets = config.get("remoteTargets") or config.get("sshTargets") or config.get("remotes") or config.get("targets") or []
+if isinstance(raw_targets, dict):
+    iterable = []
+    for name, value in raw_targets.items():
+        item = dict(value) if isinstance(value, dict) else {"host": str(value)}
+        item.setdefault("name", name)
+        iterable.append(item)
+else:
+    iterable = raw_targets
+
+wanted = {"remote_digital_ocean_2", "remote_digital_ocean_3", "remote_digital_ocean_4", "remote_linode_1"}
+workers = []
+for item in iterable:
+    if not isinstance(item, dict):
+        continue
+    name = item.get("name") or item.get("id") or item.get("alias") or item.get("host")
+    if name not in wanted:
+        continue
+    workers.append({
+        "name": name,
+        "host": item.get("host") or name,
+        "user": item.get("user") or "invoker",
+        "port": int(item.get("port") or 22),
+        "enabled": True,
+    })
+
+payload = {"version": 1, "coordinator": "remote_digital_ocean_1", "workers": workers}
+out_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+print(f"wrote {len(workers)} workers to {out_path}")
+PY
+fi
+
+[[ "$NO_SSH" -eq 1 ]] && exit 0
+
+WORKERS_FILE="${WRITE_WORKERS:-${BENCHMARK_ROOT:-/home/invoker/invoker-benchmarks}/config/workers.json}"
+[[ -f "$WORKERS_FILE" ]] || die "Missing workers file: $WORKERS_FILE"
+
+mapfile -t WORKERS < <(python3 - "$WORKERS_FILE" <<'PY'
+import json, sys
+data = json.load(open(sys.argv[1]))
+for worker in data.get("workers", []):
+    if worker.get("enabled", True):
+        print(f"{worker.get('user', 'invoker')}@{worker.get('host', worker.get('name'))}\t{int(worker.get('port') or 22)}")
+PY
+)
+
+for worker in "${WORKERS[@]}"; do
+  IFS=$'\t' read -r target port <<<"$worker"
+  echo "syncing credentials to $target"
+  ssh -p "$port" "$target" "mkdir -p ~/.codex ~/.claude ~/.invoker ~/.ssh && chmod 700 ~/.ssh"
+  for dir in "$HOME/.codex" "$HOME/.claude" "$HOME/.invoker"; do
+    [[ -d "$dir" ]] || continue
+    remote_dir="$(basename "$dir")"
+    rsync -az --exclude 'sessions/' --exclude 'benchmark-scratch/' -e "ssh -p $port" "$dir/" "$target:~/$remote_dir/"
+  done
+  if [[ -d "$HOME/.ssh" ]]; then
+    rsync -az --exclude '*.pub' --exclude 'known_hosts.old' -e "ssh -p $port" "$HOME/.ssh/" "$target:~/.ssh/"
+    ssh -p "$port" "$target" "chmod 700 ~/.ssh && find ~/.ssh -type f -exec chmod 600 {} \\;"
+  fi
+done

--- a/invoker-benchmarks/config/benchmark.env.example
+++ b/invoker-benchmarks/config/benchmark.env.example
@@ -1,0 +1,32 @@
+# Copy to /home/invoker/invoker-benchmarks/config/benchmark.env on the coordinator.
+
+TZ=Asia/Hong_Kong
+BENCHMARK_ROOT=/home/invoker/invoker-benchmarks
+INVOKER_REPO=https://github.com/Neko-Catpital-Labs/Invoker.git
+INVOKER_BRANCH=master
+CORPUS_DIR=/home/invoker/invoker-benchmarks/corpus/submit-to-invoker-sessions-2026-05-26
+MODELS=codex,claude
+MODES=baseline_direct,invoker_workflow,invoker_auto_fix
+WORKER_CONCURRENCY_PER_HOST=1
+MIXPANEL_PROJECT_ID=4027782
+MIXPANEL_SCHEMA_VERSION=invoker_benchmark_v1
+# No-arg nightly runs publish by default. Use --no-emit-mixpanel or set this to
+# 0 for a local-only run that still writes mixpanel-export.jsonl.
+BENCHMARK_EMIT_MIXPANEL_DEFAULT=1
+
+# Required only when emitting to Mixpanel.
+MIXPANEL_TOKEN=
+MIXPANEL_ENDPOINT=https://api.mixpanel.com/import
+MIXPANEL_SERVICE_ACCOUNT_USER=
+MIXPANEL_SERVICE_ACCOUNT_PASS=
+MIXPANEL_API_SECRET=
+
+# Optional command templates evaluated by run-worker-job.sh.
+# Available variables: CHECKOUT_DIR, CONVERSATION_FILE, MODEL, MODE, JOB_DIR,
+# GENERATED_PLAN, INVOKER_SHA, INVOKER_AUTOFIX.
+#
+# BENCHMARK_BASELINE_CODEX_COMMAND='codex exec --skip-git-repo-check "$(cat "$CONVERSATION_FILE")"'
+# BENCHMARK_BASELINE_CLAUDE_COMMAND='claude -p "$(cat "$CONVERSATION_FILE")"'
+# BENCHMARK_PLAN_CODEX_COMMAND='codex exec --skip-git-repo-check /plan-to-invoker < "$CONVERSATION_FILE" > "$GENERATED_PLAN"'
+# BENCHMARK_PLAN_CLAUDE_COMMAND='claude -p /plan-to-invoker < "$CONVERSATION_FILE" > "$GENERATED_PLAN"'
+# BENCHMARK_INVOKER_SUBMIT_COMMAND='invoker workflow submit "$GENERATED_PLAN" --model "$MODEL" --no-pr --no-autostart --stop-at review_ready'

--- a/invoker-benchmarks/config/corpus-manifest.json
+++ b/invoker-benchmarks/config/corpus-manifest.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "corpus": "submit-to-invoker-sessions-2026-05-26",
+  "expected_conversation_count": 48,
+  "file_globs": [
+    "*.jsonl",
+    "*.json",
+    "*.md",
+    "*.txt"
+  ]
+}

--- a/invoker-benchmarks/config/workers.json.example
+++ b/invoker-benchmarks/config/workers.json.example
@@ -1,0 +1,34 @@
+{
+  "version": 1,
+  "coordinator": "remote_digital_ocean_1",
+  "workers": [
+    {
+      "name": "remote_digital_ocean_2",
+      "host": "remote_digital_ocean_2",
+      "user": "invoker",
+      "port": 22,
+      "enabled": true
+    },
+    {
+      "name": "remote_digital_ocean_3",
+      "host": "remote_digital_ocean_3",
+      "user": "invoker",
+      "port": 22,
+      "enabled": true
+    },
+    {
+      "name": "remote_digital_ocean_4",
+      "host": "remote_digital_ocean_4",
+      "user": "invoker",
+      "port": 22,
+      "enabled": true
+    },
+    {
+      "name": "remote_linode_1",
+      "host": "remote_linode_1",
+      "user": "invoker",
+      "port": 22,
+      "enabled": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add installable nightly Invoker benchmark harness under invoker-benchmarks
- add coordinator/worker scripts, config examples, corpus manifest, and operations doc
- support cron execution, dry-run matrix validation, worker credential sync, artifact aggregation, and Mixpanel export

## Verification
- bash -n invoker-benchmarks/bin/*.sh
- installed harness on remote_digital_ocean_1 at /home/invoker/invoker-benchmarks
- installed coordinator crontab entry
- coordinator dry-run currently stops because the fixed corpus directory is empty/missing