### PR TITLE
Add live owner submission to invoker CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "check:types": "tsc -p tsconfig.typecheck.json",
     "check:large-files": "node scripts/check-large-files.mjs",
     "check:all": "pnpm run check:deps && pnpm run check:types && pnpm run check:required-builds && pnpm run check:large-files && bash scripts/check-owner-boundary.sh",
-    "lint": "pnpm run check:all"
+    "lint": "pnpm run check:all",
+    "dev:cli": "pnpm --filter @invoker/cli build && node packages/cli/dist/index.js"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -22,6 +22,14 @@
       {
         "from": "../../skills",
         "to": "skills"
+      },
+      {
+        "from": "../cli/dist",
+        "to": "invoker-cli/dist"
+      },
+      {
+        "from": "../cli/package.json",
+        "to": "invoker-cli/package.json"
       }
     ],
     "files": [

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -48,7 +48,12 @@ function electronCommandArgs(args: string[]): string[] {
 
 async function runElectronHeadless(args: string[]): Promise<number> {
   const electronLauncher = resolve(repoRoot, 'scripts', 'electron.cjs');
-  const child = spawn(process.execPath, [electronLauncher, ...electronCommandArgs(args)], {
+  const nodeArgs = [electronLauncher, ...electronCommandArgs(args)];
+  const command = process.platform === 'linux' && !process.env.DISPLAY ? 'xvfb-run' : process.execPath;
+  const commandArgs = command === 'xvfb-run'
+    ? ['--auto-servernum', process.execPath, ...nodeArgs]
+    : nodeArgs;
+  const child = spawn(command, commandArgs, {
     cwd: repoRoot,
     stdio: 'inherit',
     env: {

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,9 @@
+# Invoker CLI
+
+Standalone headless Invoker runner.
+
+```bash
+invoker-cli run plans/fixtures/hello-world.yaml --db-dir /tmp/invoker-cli-smoke-db
+```
+
+The v1 archive distribution requires Node 26.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "@invoker/cli",
+  "version": "0.0.2",
+  "description": "Standalone Invoker command-line runner",
+  "type": "module",
+  "bin": {
+    "invoker-cli": "dist/index.js"
+  },
+  "files": [
+    "dist/**/*",
+    "package.json",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "test": "pnpm run build && vitest run",
+    "clean": "rm -rf dist"
+  },
+  "dependencies": {
+    "@invoker/contracts": "workspace:*",
+    "@invoker/data-store": "workspace:*",
+    "@invoker/transport": "workspace:*",
+    "@invoker/workflow-core": "workspace:*",
+    "yaml": "^2.8.2"
+  },
+  "devDependencies": {
+    "@types/node": "^25.3.3",
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -1,0 +1,168 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { LocalBus } from '@invoker/transport';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { main } from '../index.js';
+
+const repoRoot = resolve(__dirname, '../../../..');
+const cliPath = resolve(repoRoot, 'packages/cli/dist/index.js');
+const fixturePlan = resolve(repoRoot, 'plans/fixtures/hello-world.yaml');
+
+function runCli(args: string[]) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: repoRoot,
+    encoding: 'utf8',
+  });
+}
+
+function captureProcessOutput() {
+  let stdout = '';
+  let stderr = '';
+  const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+    stdout += chunk.toString();
+    return true;
+  });
+  const stderrSpy = vi.spyOn(process.stderr, 'write').mockImplementation((chunk: any) => {
+    stderr += chunk.toString();
+    return true;
+  });
+  return {
+    get stdout() { return stdout; },
+    get stderr() { return stderr; },
+    restore() {
+      stdoutSpy.mockRestore();
+      stderrSpy.mockRestore();
+    },
+  };
+}
+
+describe('invoker-cli', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('--help exits 0', () => {
+    const result = runCli(['--help']);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('invoker-cli run <plan.yaml>');
+  });
+
+  it('runs the hello-world fixture with an isolated db dir', () => {
+    const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-test-db-'));
+    const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir]);
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('hello-from-invoker-cli');
+  });
+
+  it('--json emits a successful workflow result object', () => {
+    const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-json-db-'));
+    const result = runCli(['run', fixturePlan, '--standalone', '--db-dir', dbDir, '--json']);
+    expect(result.status).toBe(0);
+    const lines = result.stdout.trim().split('\n');
+    const json = JSON.parse(lines[lines.length - 1]);
+    expect(json.workflow.status).toBe('success');
+  });
+
+  it('invalid YAML exits non-zero with a validation error', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'invoker-cli-invalid-'));
+    const invalidPlan = join(dir, 'invalid.yaml');
+    writeFileSync(invalidPlan, 'name: [broken\n', 'utf8');
+    const result = runCli(['run', invalidPlan, '--standalone', '--db-dir', join(dir, 'db')]);
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain('Invalid YAML');
+  });
+
+  it('--live delegates run to a reachable GUI owner', async () => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    const runHandler = vi.fn(async (req: unknown) => {
+      expect(req).toEqual(expect.objectContaining({
+        planPath: fixturePlan,
+        traceId: expect.stringContaining('invoker-cli.headless.run'),
+      }));
+      return { workflowId: 'wf-live-1', tasks: [] };
+    });
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'gui-1', mode: 'gui' }));
+    bus.onRequest('headless.run', runHandler);
+
+    const code = await main(['run', fixturePlan, '--live'], { createMessageBus: () => bus });
+
+    expect(code).toBe(0);
+    expect(runHandler).toHaveBeenCalledTimes(1);
+    expect(output.stdout).toContain('Delegated to live owner - workflow: wf-live-1');
+    output.restore();
+  });
+
+  it('--live exits non-zero when no GUI owner is reachable', async () => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+
+    const code = await main(['run', fixturePlan, '--live'], { createMessageBus: () => bus });
+
+    expect(code).toBe(1);
+    expect(output.stderr).toContain('No running Invoker UI owner is reachable');
+    output.restore();
+  });
+
+  it('--standalone never opens IPC and still runs hello-world', async () => {
+    const output = captureProcessOutput();
+    const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-standalone-db-'));
+    const createMessageBus = vi.fn(() => {
+      throw new Error('unexpected IPC');
+    });
+
+    const code = await main(
+      ['run', fixturePlan, '--standalone', '--db-dir', dbDir],
+      { createMessageBus },
+    );
+
+    expect(code).toBe(0);
+    expect(createMessageBus).not.toHaveBeenCalled();
+    expect(output.stdout).toContain('hello-from-invoker-cli');
+    output.restore();
+  });
+
+  it('auto mode delegates when a GUI owner exists', async () => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    const runHandler = vi.fn(async () => ({ workflowId: 'wf-auto-live', tasks: [] }));
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'gui-1', mode: 'gui' }));
+    bus.onRequest('headless.run', runHandler);
+
+    const code = await main(['run', fixturePlan], { createMessageBus: () => bus });
+
+    expect(code).toBe(0);
+    expect(runHandler).toHaveBeenCalledTimes(1);
+    expect(output.stdout).toContain('wf-auto-live');
+    output.restore();
+  });
+
+  it('auto mode falls back to standalone when no GUI owner exists', async () => {
+    const output = captureProcessOutput();
+    const bus = new LocalBus();
+    const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-auto-db-'));
+
+    const code = await main(
+      ['run', fixturePlan, '--db-dir', dbDir],
+      { createMessageBus: () => bus },
+    );
+
+    expect(code).toBe(0);
+    expect(output.stdout).toContain('hello-from-invoker-cli');
+    output.restore();
+  });
+
+  it('rejects --db-dir with --live', async () => {
+    const output = captureProcessOutput();
+    const dbDir = mkdtempSync(join(tmpdir(), 'invoker-cli-live-db-'));
+
+    const code = await main(['run', fixturePlan, '--live', '--db-dir', dbDir]);
+
+    expect(code).toBe(1);
+    expect(output.stderr).toContain('--db-dir cannot be used with --live');
+    output.restore();
+  });
+});

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1,0 +1,405 @@
+import { spawn } from 'node:child_process';
+import { mkdirSync } from 'node:fs';
+import { dirname, resolve, join } from 'node:path';
+import { homedir } from 'node:os';
+import { pathToFileURL } from 'node:url';
+import type { Logger, WorkResponse } from '@invoker/contracts';
+import { SQLiteAdapter, SqliteTaskRepository } from '@invoker/data-store';
+import {
+  IpcBus,
+  TransportError,
+  TransportErrorCode,
+  type MessageBus,
+} from '@invoker/transport';
+import {
+  Orchestrator,
+  parsePlanFile,
+  type OrchestratorMessageBus,
+  type TaskState,
+} from '@invoker/workflow-core';
+
+const VERSION = '0.0.2';
+
+type CliOptions = {
+  dbDir?: string;
+  config?: string;
+  json: boolean;
+  mode: 'auto' | 'live' | 'standalone';
+};
+
+type RunResult = {
+  workflowId: string;
+  status: 'success' | 'failed';
+  completedTasks: number;
+  failedTasks: number;
+  mode: 'standalone' | 'live';
+};
+
+type LiveOwnerInfo = {
+  ownerId: string;
+  mode: string;
+};
+
+type LiveSubmissionResult = {
+  workflowId: string;
+  tasks: unknown[];
+  ownerId?: string;
+};
+
+type CliDeps = {
+  createMessageBus?: () => Promise<MessageBus> | MessageBus;
+};
+
+const silentLogger: Logger = {
+  debug() {},
+  info() {},
+  warn() {},
+  error() {},
+  child() { return silentLogger; },
+};
+
+const noopBus: OrchestratorMessageBus = {
+  publish() {},
+};
+
+function usage(): string {
+  return [
+    'Usage:',
+    '  invoker-cli run <plan.yaml> [--live|--standalone] [--db-dir <path>] [--config <path>] [--json]',
+    '  invoker-cli --help',
+    '  invoker-cli --version',
+    '',
+    'Commands:',
+    '  run <plan.yaml>  Submit to a live Invoker UI when available, otherwise run standalone.',
+    '',
+    'Options:',
+    '  --live           Require a running Invoker UI owner and submit over IPC.',
+    '  --standalone     Skip IPC and run with an isolated CLI database.',
+    '  --db-dir <path>  Runtime database directory. Defaults to ~/.invoker-cli',
+    '  --config <path>  Optional config path reserved for CLI runtime configuration.',
+    '  --json           Emit a machine-readable result summary.',
+    '  --help           Show this help text.',
+    '  --version        Show the CLI version.',
+  ].join('\n');
+}
+
+function parseArgs(argv: string[]): { command?: string; planPath?: string; options: CliOptions } {
+  const options: CliOptions = { json: false, mode: 'auto' };
+  const positional: string[] = [];
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === '--db-dir') {
+      const value = argv[++i];
+      if (!value) throw new Error('Missing value for --db-dir');
+      options.dbDir = value;
+    } else if (arg === '--config') {
+      const value = argv[++i];
+      if (!value) throw new Error('Missing value for --config');
+      options.config = value;
+    } else if (arg === '--json') {
+      options.json = true;
+    } else if (arg === '--live') {
+      if (options.mode === 'standalone') throw new Error('Cannot combine --live and --standalone');
+      options.mode = 'live';
+    } else if (arg === '--standalone') {
+      if (options.mode === 'live') throw new Error('Cannot combine --live and --standalone');
+      options.mode = 'standalone';
+    } else if (arg === '--help' || arg === '-h') {
+      positional.push('--help');
+    } else if (arg === '--version' || arg === '-v') {
+      positional.push('--version');
+    } else if (arg.startsWith('--')) {
+      throw new Error(`Unknown option: ${arg}`);
+    } else {
+      positional.push(arg);
+    }
+  }
+
+  return {
+    command: positional[0],
+    planPath: positional[1],
+    options,
+  };
+}
+
+function createTraceId(channel: string): string {
+  return `${channel}:${process.pid}:${Date.now()}:${Math.random().toString(16).slice(2, 8)}`;
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  const TIMEOUT = Symbol('timeout');
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<typeof TIMEOUT>((resolveTimeout) => {
+    timeoutHandle = setTimeout(() => resolveTimeout(TIMEOUT), timeoutMs);
+    timeoutHandle.unref?.();
+  });
+  try {
+    const result = await Promise.race([promise, timeout]);
+    if (result === TIMEOUT) {
+      throw new Error(`Timed out after ${timeoutMs}ms`);
+    }
+    return result as T;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+}
+
+async function discoverLiveOwner(bus: MessageBus, timeoutMs = 1_000): Promise<LiveOwnerInfo | null> {
+  try {
+    const raw = await withTimeout(
+      bus.request('headless.owner-ping', {}),
+      timeoutMs,
+    );
+    if (!raw || typeof raw !== 'object') return null;
+    const response = raw as Record<string, unknown>;
+    if (response.mode !== 'gui') return null;
+    return {
+      ownerId: typeof response.ownerId === 'string' ? response.ownerId : '',
+      mode: 'gui',
+    };
+  } catch (err) {
+    if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
+      return null;
+    }
+    if (err instanceof Error && err.message.startsWith('Timed out after ')) {
+      return null;
+    }
+    return null;
+  }
+}
+
+function validateLiveSubmissionResponse(raw: unknown): LiveSubmissionResult {
+  if (!raw || typeof raw !== 'object') {
+    throw new Error(`Live owner returned invalid headless.run response: expected object, got ${raw === null ? 'null' : typeof raw}`);
+  }
+  const response = raw as Record<string, unknown>;
+  if (typeof response.workflowId !== 'string' || response.workflowId.length === 0) {
+    throw new Error('Live owner returned invalid headless.run response: missing workflowId');
+  }
+  if (!Array.isArray(response.tasks)) {
+    throw new Error('Live owner returned invalid headless.run response: missing tasks array');
+  }
+  return {
+    workflowId: response.workflowId,
+    tasks: response.tasks,
+    ownerId: typeof response.ownerId === 'string' ? response.ownerId : undefined,
+  };
+}
+
+async function submitPlanToLiveOwner(
+  planPath: string,
+  bus: MessageBus,
+  owner: LiveOwnerInfo,
+  timeoutMs = 5_000,
+): Promise<LiveSubmissionResult> {
+  const absolutePlanPath = resolve(planPath);
+  const raw = await withTimeout(
+    bus.request('headless.run', {
+      planPath: absolutePlanPath,
+      traceId: createTraceId('invoker-cli.headless.run'),
+    }),
+    timeoutMs,
+  );
+  return {
+    ...validateLiveSubmissionResponse(raw),
+    ownerId: owner.ownerId,
+  };
+}
+
+async function runShellCommand(command: string, cwd: string): Promise<{ exitCode: number; output: string }> {
+  return new Promise((resolveCommand) => {
+    let output = '';
+    const child = spawn(command, {
+      cwd,
+      shell: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: process.env,
+    });
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      output += text;
+      process.stdout.write(text);
+    });
+    child.stderr.on('data', (chunk: Buffer) => {
+      const text = chunk.toString();
+      output += text;
+      process.stderr.write(text);
+    });
+    child.on('error', (err) => {
+      output += `${err.message}\n`;
+      resolveCommand({ exitCode: 1, output });
+    });
+    child.on('close', (code) => {
+      resolveCommand({ exitCode: code ?? 1, output });
+    });
+  });
+}
+
+function responseForTask(
+  task: TaskState,
+  status: WorkResponse['status'],
+  outputs: WorkResponse['outputs'],
+): WorkResponse {
+  return {
+    requestId: `cli-${task.id}`,
+    actionId: task.id,
+    attemptId: task.execution.selectedAttemptId,
+    executionGeneration: task.execution.generation ?? 0,
+    status,
+    outputs,
+  };
+}
+
+async function executeStartedTasks(orchestrator: Orchestrator, tasks: TaskState[], cwd: string): Promise<void> {
+  const queue = [...tasks];
+  while (queue.length > 0) {
+    const task = queue.shift()!;
+    if (task.config.isMergeNode) {
+      queue.push(...orchestrator.handleWorkerResponse(responseForTask(task, 'completed', {
+        exitCode: 0,
+        summary: 'No merge action configured for standalone CLI run.',
+      })));
+      continue;
+    }
+
+    if (!task.config.command) {
+      queue.push(...orchestrator.handleWorkerResponse(responseForTask(task, 'failed', {
+        exitCode: 1,
+        error: 'Standalone CLI v1 supports command tasks only.',
+      })));
+      continue;
+    }
+
+    const result = await runShellCommand(task.config.command, cwd);
+    queue.push(...orchestrator.handleWorkerResponse(responseForTask(
+      task,
+      result.exitCode === 0 ? 'completed' : 'failed',
+      result.exitCode === 0
+        ? { exitCode: 0, summary: result.output }
+        : { exitCode: result.exitCode, error: result.output || `Command exited with code ${result.exitCode}` },
+    )));
+  }
+}
+
+async function runPlan(planPath: string, options: CliOptions): Promise<RunResult> {
+  const absolutePlanPath = resolve(planPath);
+  const dbDir = resolve(options.dbDir ?? join(homedir(), '.invoker-cli'));
+  mkdirSync(dbDir, { recursive: true });
+
+  if (options.config) {
+    process.env.INVOKER_CONFIG = resolve(options.config);
+  }
+
+  const persistence = await SQLiteAdapter.create(join(dbDir, 'invoker.db'), {
+    ownerCapability: true,
+    outputDir: join(dbDir, 'outputs'),
+  });
+
+  try {
+    const orchestrator = new Orchestrator({
+      persistence,
+      taskRepository: new SqliteTaskRepository(persistence),
+      messageBus: noopBus,
+      logger: silentLogger,
+      maxConcurrency: 1,
+      launchOutboxMode: 'disabled',
+    });
+    const plan = await parsePlanFile(absolutePlanPath);
+    orchestrator.loadPlan(plan);
+    const started = orchestrator.startExecution();
+    await executeStartedTasks(orchestrator, started, dirname(absolutePlanPath));
+
+    const workflow = persistence.listWorkflows()[0];
+    const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflow?.id);
+    const failedTasks = tasks.filter((task) => task.status === 'failed').length;
+    const completedTasks = tasks.filter((task) => task.status === 'completed').length;
+    return {
+      workflowId: workflow?.id ?? 'unknown',
+      status: failedTasks === 0 ? 'success' : 'failed',
+      completedTasks,
+      failedTasks,
+      mode: 'standalone',
+    };
+  } finally {
+    persistence.close();
+  }
+}
+
+function printRunResult(result: RunResult, json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify({ workflow: { id: result.workflowId, status: result.status }, result })}\n`);
+  } else if (result.mode === 'live') {
+    process.stdout.write(`Delegated to live owner - workflow: ${result.workflowId}\n`);
+  }
+}
+
+async function createDefaultMessageBus(): Promise<MessageBus> {
+  const bus = new IpcBus(undefined, { allowServe: false });
+  await bus.ready();
+  return bus;
+}
+
+export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps = {}): Promise<number> {
+  let bus: MessageBus | undefined;
+  try {
+    const parsed = parseArgs(argv);
+    if (!parsed.command || parsed.command === '--help') {
+      process.stdout.write(`${usage()}\n`);
+      return 0;
+    }
+    if (parsed.command === '--version') {
+      process.stdout.write(`${VERSION}\n`);
+      return 0;
+    }
+    if (parsed.command !== 'run') {
+      throw new Error(`Unknown command: ${parsed.command}`);
+    }
+    if (!parsed.planPath) {
+      throw new Error('Missing plan file. Usage: invoker-cli run <plan.yaml>');
+    }
+
+    if (parsed.options.mode === 'live' && parsed.options.dbDir) {
+      throw new Error('--db-dir cannot be used with --live because the UI owner database is authoritative');
+    }
+
+    if (parsed.options.mode !== 'standalone') {
+      bus = await (deps.createMessageBus?.() ?? createDefaultMessageBus());
+      const owner = await discoverLiveOwner(bus);
+      if (owner) {
+        if (parsed.options.dbDir) {
+          throw new Error('--db-dir cannot be used when a live UI owner accepts the run; use --standalone to force an isolated database');
+        }
+        const submitted = await submitPlanToLiveOwner(parsed.planPath, bus, owner);
+        printRunResult({
+          workflowId: submitted.workflowId,
+          status: 'success',
+          completedTasks: 0,
+          failedTasks: 0,
+          mode: 'live',
+        }, parsed.options.json);
+        return 0;
+      }
+      if (parsed.options.mode === 'live') {
+        throw new Error('No running Invoker UI owner is reachable; start the UI or omit --live to run standalone');
+      }
+    }
+
+    const result = await runPlan(parsed.planPath, parsed.options);
+    printRunResult(result, parsed.options.json);
+    return result.status === 'success' ? 0 : 1;
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  } finally {
+    const disconnect = (bus as { disconnect?: () => void } | undefined)?.disconnect;
+    if (disconnect) {
+      disconnect.call(bus);
+    }
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
+  process.exitCode = await main();
+}

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": [
+    "src/**/*.ts"
+  ]
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'tsup';
+
+export default defineConfig({
+  entry: ['src/index.ts'],
+  format: ['esm'],
+  dts: false,
+  clean: true,
+  banner: {
+    js: '#!/usr/bin/env node',
+  },
+  external: ['node:sqlite', 'yaml'],
+  noExternal: [
+    '@invoker/contracts',
+    '@invoker/data-store',
+    '@invoker/transport',
+    '@invoker/workflow-core',
+    '@invoker/workflow-graph',
+    'neverthrow',
+  ],
+});

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig, mergeConfig } from 'vitest/config';
+import sharedConfig from '../../vitest.shared.ts';
+
+export default mergeConfig(sharedConfig, defineConfig({
+  test: {
+    exclude: ['**/node_modules/**', '**/dist/**'],
+  },
+}));

--- a/packages/workflow-core/package.json
+++ b/packages/workflow-core/package.json
@@ -20,7 +20,8 @@
   "dependencies": {
     "@invoker/workflow-graph": "workspace:*",
     "@invoker/contracts": "workspace:*",
-    "neverthrow": "^8.2.0"
+    "neverthrow": "^8.2.0",
+    "yaml": "^2.8.2"
   },
   "devDependencies": {
     "@types/node": "^25.3.3",

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -4,6 +4,7 @@ export * from './response-handler.js';
 export * from './scheduler.js';
 export * from './orchestrator.js';
 export * from './task-id-scope.js';
+export * from './plan-parser.js';
 export * from './fallback-policy.js';
 export * from './graph-mutation.js';
 export * from './command-service.js';

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -1,0 +1,271 @@
+import { execFileSync } from 'node:child_process';
+import { parse as parseYaml } from 'yaml';
+import type { PlanDefinition } from './orchestrator.js';
+
+export class PlanParseError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PlanParseError';
+  }
+}
+
+export interface RawExperimentVariant {
+  id?: string;
+  description?: string;
+  prompt?: string;
+  command?: string;
+}
+
+export interface RawPlanTask {
+  id?: string;
+  description?: string;
+  command?: string;
+  prompt?: string;
+  dependencies?: string[];
+  externalDependencies?: Array<{
+    workflowId?: string;
+    taskId?: string;
+    requiredStatus?: string;
+    gatePolicy?: string;
+  }>;
+  pivot?: boolean;
+  experimentVariants?: RawExperimentVariant[];
+  requiresManualApproval?: boolean;
+  featureBranch?: string;
+  dockerImage?: string;
+  poolId?: string;
+  executionAgent?: string;
+}
+
+export interface RawPlan {
+  name?: string;
+  description?: string;
+  visualProof?: boolean;
+  onFinish?: string;
+  baseBranch?: string;
+  featureBranch?: string;
+  mergeMode?: string;
+  reviewProvider?: string;
+  repoUrl?: string;
+  intermediateRepoUrl?: string;
+  externalDependencies?: Array<{
+    workflowId?: string;
+    taskId?: string;
+    requiredStatus?: string;
+    gatePolicy?: string;
+  }>;
+  tasks?: RawPlanTask[];
+}
+
+function detectDefaultBranchRemote(repoUrl: string): string {
+  try {
+    const output = execFileSync('git', ['ls-remote', '--symref', repoUrl, 'HEAD'], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+      timeout: 10_000,
+    }).trim();
+    const match = output.match(/ref:\s+refs\/heads\/(\S+)\s+HEAD/);
+    if (match) return match[1];
+  } catch {
+    // Network and local-path failures fall back to the common default.
+  }
+  return 'main';
+}
+
+function resolveDefaultBaseBranch(plan: PlanDefinition): string {
+  const branch = plan.baseBranch;
+  if (typeof branch === 'string' && branch.trim() !== '') return branch.trim();
+  return plan.repoUrl ? detectDefaultBranchRemote(plan.repoUrl) : 'main';
+}
+
+export function applyPlanDefinitionDefaults(plan: PlanDefinition): PlanDefinition {
+  const slug = plan.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+  const featureBranch = typeof plan.featureBranch === 'string' && plan.featureBranch.trim() !== ''
+    ? plan.featureBranch.trim()
+    : `plan/${slug}`;
+
+  return {
+    ...plan,
+    onFinish: plan.onFinish ?? 'pull_request',
+    baseBranch: resolveDefaultBaseBranch(plan),
+    featureBranch,
+  };
+}
+
+type ParsedExternalDependency = {
+  workflowId: string;
+  taskId: string;
+  requiredStatus: 'completed';
+  gatePolicy: 'completed' | 'review_ready';
+};
+
+function parseExternalDependencies(
+  ownerLabel: string,
+  deps?: Array<{ workflowId?: string; taskId?: string; requiredStatus?: string; gatePolicy?: string }>,
+): ParsedExternalDependency[] | undefined {
+  if (!deps) return undefined;
+  return deps.map((dep, depIndex) => {
+    if (!dep.workflowId || typeof dep.workflowId !== 'string') {
+      throw new PlanParseError(`${ownerLabel} externalDependencies[${depIndex}] must have a string "workflowId"`);
+    }
+    if (dep.taskId !== undefined && typeof dep.taskId !== 'string') {
+      throw new PlanParseError(`${ownerLabel} externalDependencies[${depIndex}] "taskId" must be a string when provided`);
+    }
+    if (dep.requiredStatus !== undefined && dep.requiredStatus !== 'completed') {
+      throw new PlanParseError(`${ownerLabel} externalDependencies[${depIndex}] "requiredStatus" must be "completed"`);
+    }
+    if (dep.gatePolicy !== undefined && dep.gatePolicy !== 'completed' && dep.gatePolicy !== 'review_ready') {
+      if (dep.gatePolicy === 'approved') {
+        throw new PlanParseError("gatePolicy value 'approved' is no longer supported. Use 'completed' instead.");
+      }
+      throw new PlanParseError(`${ownerLabel} externalDependencies[${depIndex}] "gatePolicy" must be "completed" or "review_ready"`);
+    }
+    const taskId = dep.taskId?.trim() || '__merge__';
+    return {
+      workflowId: dep.workflowId,
+      taskId,
+      requiredStatus: 'completed',
+      gatePolicy: (dep.gatePolicy ?? (taskId === '__merge__' ? 'completed' : 'review_ready')) as 'completed' | 'review_ready',
+    };
+  });
+}
+
+function mergeExternalDependencies(
+  inheritedDeps: ParsedExternalDependency[] | undefined,
+  taskDeps: ParsedExternalDependency[] | undefined,
+): ParsedExternalDependency[] | undefined {
+  if (!inheritedDeps && !taskDeps) return undefined;
+  const merged = new Map<string, ParsedExternalDependency>();
+  for (const dep of inheritedDeps ?? []) merged.set(`${dep.workflowId}::${dep.taskId}`, dep);
+  for (const dep of taskDeps ?? []) merged.set(`${dep.workflowId}::${dep.taskId}`, dep);
+  const values = [...merged.values()];
+  return values.length > 0 ? values : undefined;
+}
+
+const legacyTaskRoutingKeys = [
+  ['executor', 'Type'].join(''),
+  ['remote', 'Target', 'Id'].join(''),
+  'runnerKind',
+  'poolMemberId',
+] as const;
+
+function assertNoLegacyRoutingKeys(ownerLabel: string, value: object): void {
+  for (const key of legacyTaskRoutingKeys) {
+    if (Object.prototype.hasOwnProperty.call(value, key)) {
+      throw new PlanParseError(
+        `${ownerLabel} uses unsupported routing field "${key}". Use "poolId" for pools and "dockerImage" for Docker.`,
+      );
+    }
+  }
+}
+
+export function parsePlan(yamlContent: string): PlanDefinition {
+  let raw: RawPlan;
+  try {
+    raw = parseYaml(yamlContent) as RawPlan;
+  } catch (err) {
+    throw new PlanParseError(`Invalid YAML: ${err instanceof Error ? err.message : String(err)}`);
+  }
+
+  if (!raw || typeof raw !== 'object') throw new PlanParseError('Plan must be a YAML object');
+  if (!raw.name || typeof raw.name !== 'string') throw new PlanParseError('Plan must have a "name" field');
+  if (!raw.tasks || !Array.isArray(raw.tasks) || raw.tasks.length === 0) {
+    throw new PlanParseError('Plan must have a non-empty "tasks" array');
+  }
+
+  const hasOwn = (obj: object, key: string): boolean => Object.prototype.hasOwnProperty.call(obj, key);
+  if (hasOwn(raw as object, 'autoFix')) {
+    throw new PlanParseError('Plan-level "autoFix" is no longer supported. Configure "~/.invoker/config.json" with "autoFixRetries" instead.');
+  }
+  if (hasOwn(raw as object, 'autoFixRetries')) {
+    throw new PlanParseError('Plan-level "autoFixRetries" is no longer supported. Configure "~/.invoker/config.json" with "autoFixRetries" instead.');
+  }
+  assertNoLegacyRoutingKeys('Plan', raw as object);
+
+  const validOnFinishValues = ['none', 'merge', 'pull_request'] as const;
+  if (raw.onFinish !== undefined && !validOnFinishValues.includes(raw.onFinish as any)) {
+    throw new PlanParseError(`"onFinish" must be one of: ${validOnFinishValues.join(', ')}. Got: "${raw.onFinish}"`);
+  }
+  const onFinish = (raw.onFinish as (typeof validOnFinishValues)[number]) ?? 'pull_request';
+
+  const validMergeModes = ['manual', 'automatic', 'external_review'] as const;
+  if (raw.mergeMode !== undefined && !validMergeModes.includes(raw.mergeMode as any)) {
+    throw new PlanParseError(`"mergeMode" must be one of: ${validMergeModes.join(', ')}. Got: "${raw.mergeMode}"`);
+  }
+  const mergeMode = raw.mergeMode as (typeof validMergeModes)[number] | undefined;
+  const reviewProvider = raw.reviewProvider ?? (raw.mergeMode === 'external_review' ? 'github' : undefined);
+
+  if (!raw.repoUrl || typeof raw.repoUrl !== 'string') {
+    throw new PlanParseError('Plan must have a "repoUrl" field (e.g. repoUrl: git@github.com:user/repo.git).');
+  }
+  if (raw.intermediateRepoUrl !== undefined) {
+    if (typeof raw.intermediateRepoUrl !== 'string' || raw.intermediateRepoUrl.trim() === '') {
+      throw new PlanParseError('Plan "intermediateRepoUrl" must be a non-empty string when provided.');
+    }
+    raw.intermediateRepoUrl = raw.intermediateRepoUrl.trim();
+  }
+
+  const topLevelExternalDependencies = parseExternalDependencies('Plan', raw.externalDependencies);
+  const tasks = raw.tasks.map((task, index) => {
+    if (!task.id || typeof task.id !== 'string') throw new PlanParseError(`Task at index ${index} must have an "id" field`);
+    if (!task.description || typeof task.description !== 'string') {
+      throw new PlanParseError(`Task "${task.id}" must have a "description" field`);
+    }
+    assertNoLegacyRoutingKeys(`Task "${task.id}"`, task as object);
+    if (hasOwn(task as object, 'autoFix')) {
+      throw new PlanParseError(`Task "${task.id}" uses "autoFix", which is no longer supported in plan YAML. Configure "~/.invoker/config.json" with "autoFixRetries" instead.`);
+    }
+    if (hasOwn(task as object, 'autoFixRetries')) {
+      throw new PlanParseError(`Task "${task.id}" uses "autoFixRetries", which is no longer supported in plan YAML. Configure "~/.invoker/config.json" with "autoFixRetries" instead.`);
+    }
+    if (task.command && /\bnpx vitest run\b/.test(task.command)) {
+      throw new PlanParseError(`Task "${task.id}" uses 'npx vitest run' which may not resolve correctly. Use 'pnpm test' instead.`);
+    }
+
+    const taskExternalDependencies = parseExternalDependencies(`Task "${task.id}"`, task.externalDependencies);
+    const externalDependencies = mergeExternalDependencies(
+      (task.dependencies?.length ?? 0) === 0 ? topLevelExternalDependencies : undefined,
+      taskExternalDependencies,
+    );
+
+    return {
+      id: task.id,
+      description: task.description,
+      command: task.command,
+      prompt: task.prompt,
+      dependencies: task.dependencies ?? [],
+      externalDependencies,
+      pivot: task.pivot,
+      experimentVariants: task.experimentVariants?.map((variant) => ({
+        id: variant.id ?? '',
+        description: variant.description ?? '',
+        prompt: variant.prompt,
+        command: variant.command,
+      })),
+      requiresManualApproval: task.requiresManualApproval,
+      featureBranch: task.featureBranch,
+      dockerImage: task.dockerImage,
+      poolId: task.poolId,
+      executionAgent: task.executionAgent?.trim() || undefined,
+    };
+  });
+
+  return applyPlanDefinitionDefaults({
+    name: raw.name,
+    description: raw.description,
+    visualProof: raw.visualProof,
+    onFinish,
+    baseBranch: raw.baseBranch,
+    featureBranch: raw.featureBranch,
+    mergeMode,
+    reviewProvider,
+    repoUrl: raw.repoUrl,
+    intermediateRepoUrl: raw.intermediateRepoUrl,
+    tasks,
+  });
+}
+
+export async function parsePlanFile(filePath: string): Promise<PlanDefinition> {
+  const { readFile } = await import('node:fs/promises');
+  return parsePlan(await readFile(filePath, 'utf8'));
+}

--- a/plans/fixtures/hello-world.yaml
+++ b/plans/fixtures/hello-world.yaml
@@ -1,0 +1,8 @@
+name: Hello World CLI
+description: Standalone CLI smoke fixture.
+repoUrl: .
+onFinish: none
+tasks:
+  - id: hello
+    description: Print hello from the standalone CLI.
+    command: echo hello-from-invoker-cli

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,6 +95,37 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
 
+  packages/cli:
+    dependencies:
+      '@invoker/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+      '@invoker/data-store':
+        specifier: workspace:*
+        version: link:../data-store
+      '@invoker/transport':
+        specifier: workspace:*
+        version: link:../transport
+      '@invoker/workflow-core':
+        specifier: workspace:*
+        version: link:../workflow-core
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
+    devDependencies:
+      '@types/node':
+        specifier: ^25.3.3
+        version: 25.3.3
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@25.3.3)(jiti@2.6.1)(jsdom@25.0.1)(yaml@2.8.2)
+
   packages/contracts:
     dependencies:
       '@invoker/workflow-graph':
@@ -496,6 +527,9 @@ importers:
       neverthrow:
         specifier: ^8.2.0
         version: 8.2.0
+      yaml:
+        specifier: ^2.8.2
+        version: 2.8.2
     devDependencies:
       '@types/node':
         specifier: ^25.3.3

--- a/scripts/check-owner-boundary.sh
+++ b/scripts/check-owner-boundary.sh
@@ -18,6 +18,7 @@ if command -v rg >/dev/null 2>&1; then
     --glob '!**/e2e/**' \
     --glob '!**/node_modules/**' \
     --glob '!packages/app/src/main.ts' \
+    --glob '!packages/cli/src/index.ts' \
     --glob '!packages/persistence/src/sqlite-adapter.ts' \
     --glob '!packages/data-store/src/sqlite-adapter.ts' || true)"
 
@@ -30,7 +31,8 @@ if command -v rg >/dev/null 2>&1; then
     --glob '!**/dist/**' \
     --glob '!**/e2e/**' \
     --glob '!**/node_modules/**' \
-    --glob '!packages/app/src/main.ts' || true)"
+    --glob '!packages/app/src/main.ts' \
+    --glob '!packages/cli/src/index.ts' || true)"
 
   # 3) Owner init path in main.ts must explicitly pass ownerCapability.
   if ! rg -n "ownerCapability:\s*!readOnly" packages/app/src/main.ts >/dev/null; then
@@ -47,6 +49,7 @@ else
     --exclude="*.d.ts" \
     --exclude="*.test.ts" \
     | grep -v '^packages/app/src/main.ts:' \
+    | grep -v '^packages/cli/src/index.ts:' \
     | grep -v '^packages/persistence/src/sqlite-adapter.ts:' \
     | grep -v '^packages/data-store/src/sqlite-adapter.ts:' || true)"
 
@@ -57,7 +60,8 @@ else
     --exclude-dir="node_modules" \
     --exclude="*.d.ts" \
     --exclude="*.test.ts" \
-    | grep -v '^packages/app/src/main.ts:' || true)"
+    | grep -v '^packages/app/src/main.ts:' \
+    | grep -v '^packages/cli/src/index.ts:' || true)"
 
   if ! grep -nE "ownerCapability:[[:space:]]*!readOnly" packages/app/src/main.ts >/dev/null; then
     echo "[owner-boundary] main.ts initServices must pass ownerCapability: !readOnly" >&2

--- a/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
+++ b/scripts/e2e-dry-run/cases/case-2.13-rebase-recreate-coalesced.sh
@@ -66,13 +66,13 @@ trap 'rm -rf "$TMP_DIR" "$CFG_FILE"; invoker_e2e_cleanup' EXIT
 echo "==> case 2.13: race reset intents (rebase + recreate x4)"
 (
   set +e
-  invoker_e2e_run_headless rebase-recreate "$TASK_ID" >"$TMP_DIR/rebase.out" 2>&1
+  invoker_e2e_run_headless --no-track rebase-recreate "$TASK_ID" >"$TMP_DIR/rebase.out" 2>&1
   echo $? >"$TMP_DIR/rebase.code"
 ) &
 for i in 1 2 3 4; do
   (
     set +e
-    invoker_e2e_run_headless recreate "$WF_ID" >"$TMP_DIR/recreate-$i.out" 2>&1
+    invoker_e2e_run_headless --no-track recreate "$WF_ID" >"$TMP_DIR/recreate-$i.out" 2>&1
     echo $? >"$TMP_DIR/recreate-$i.code"
   ) &
 done

--- a/scripts/e2e-dry-run/run-all.sh
+++ b/scripts/e2e-dry-run/run-all.sh
@@ -9,6 +9,47 @@ cd "$ROOT"
 source "$ROOT/scripts/e2e-dry-run/lib/common.sh"
 invoker_e2e_ensure_app_built
 
+# Start one shared Xvfb instance for the whole shard on headless Linux. This
+# avoids per-Electron-invocation xvfb-run startup overhead (which races with
+# timing-sensitive cases) and also prevents crashes inside scripts that bypass
+# the runElectronHeadless wrapper (e.g. headless_query in headless-lib.sh,
+# which spawns the Electron binary directly). Once DISPLAY is exported the
+# fallback `xvfb-run` paths in submit-plan.sh and headless-client.ts become
+# no-ops because they only engage when DISPLAY is unset.
+SHARED_XVFB_PID=""
+if [ "$(uname)" = "Linux" ] && [ -z "${DISPLAY:-}" ] && command -v Xvfb >/dev/null 2>&1; then
+  display_num=99
+  while [ "$display_num" -lt 200 ] && [ -e "/tmp/.X11-unix/X${display_num}" ]; do
+    display_num=$((display_num + 1))
+  done
+  Xvfb ":${display_num}" -screen 0 1024x768x24 -nolisten tcp >/tmp/invoker-shared-xvfb.log 2>&1 &
+  SHARED_XVFB_PID=$!
+  export DISPLAY=":${display_num}"
+  # Wait briefly for the Xvfb socket to appear.
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    [ -e "/tmp/.X11-unix/X${display_num}" ] && break
+    sleep 0.2
+  done
+  if ! [ -e "/tmp/.X11-unix/X${display_num}" ]; then
+    echo "WARN: shared Xvfb on DISPLAY=${DISPLAY} did not become ready in time; falling back to per-call xvfb-run" >&2
+    kill "$SHARED_XVFB_PID" 2>/dev/null || true
+    wait "$SHARED_XVFB_PID" 2>/dev/null || true
+    SHARED_XVFB_PID=""
+    unset DISPLAY
+  else
+    echo "==> e2e: started shared Xvfb on DISPLAY=${DISPLAY} (pid=${SHARED_XVFB_PID})"
+  fi
+fi
+
+cleanup_shared_xvfb() {
+  if [ -n "${SHARED_XVFB_PID:-}" ]; then
+    kill "$SHARED_XVFB_PID" 2>/dev/null || true
+    wait "$SHARED_XVFB_PID" 2>/dev/null || true
+    SHARED_XVFB_PID=""
+  fi
+}
+trap cleanup_shared_xvfb EXIT
+
 shopt -s nullglob
 cases=()
 if [ "$#" -gt 0 ]; then

--- a/scripts/package-cli-archives.sh
+++ b/scripts/package-cli-archives.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+VERSION="$(node -p "require('$ROOT/packages/cli/package.json').version")"
+OUT_DIR="$ROOT/release/cli"
+STAGE="$(mktemp -d "${TMPDIR:-/tmp}/invoker-cli-package.XXXXXX")"
+
+cd "$ROOT"
+pnpm --filter @invoker/cli build
+rm -rf "$OUT_DIR"
+mkdir -p "$OUT_DIR"
+
+for platform in darwin linux win32; do
+  for arch in x64 arm64; do
+    name="invoker-cli-${VERSION}-${platform}-${arch}"
+    dir="$STAGE/$name"
+    mkdir -p "$dir/dist"
+    cp -R packages/cli/dist/. "$dir/dist/"
+    cp packages/cli/package.json "$dir/package.json"
+    cp packages/cli/README.md "$dir/README.md"
+    if [[ "$platform" == "win32" ]]; then
+      cat > "$dir/invoker-cli.cmd" <<'CMD'
+@echo off
+node "%~dp0\dist\index.js" %*
+CMD
+      (cd "$STAGE" && zip -qr "$OUT_DIR/$name.zip" "$name")
+    else
+      cat > "$dir/invoker-cli" <<'SH'
+#!/usr/bin/env sh
+exec node "$(dirname "$0")/dist/index.js" "$@"
+SH
+      chmod +x "$dir/invoker-cli"
+      (cd "$STAGE" && tar -czf "$OUT_DIR/$name.tar.gz" "$name")
+    fi
+  done
+done
+
+echo "CLI archives written to $OUT_DIR"

--- a/scripts/package-desktop.sh
+++ b/scripts/package-desktop.sh
@@ -35,6 +35,7 @@ if [ -n "$MAC_ARCH" ] && [ "$TARGET" != "mac" ]; then
 fi
 
 pnpm --filter @invoker/ui build
+pnpm --filter @invoker/cli build
 pnpm --filter @invoker/app build
 
 rm -rf packages/app/dist/ui

--- a/scripts/test-invoker-cli-smoke.sh
+++ b/scripts/test-invoker-cli-smoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DB_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-cli-smoke-db.XXXXXX")"
+
+cd "$ROOT"
+pnpm --filter @invoker/cli build
+
+BEFORE="$(pgrep -af '[E]lectron|owner-serve' || true)"
+OUTPUT="$(./packages/cli/dist/index.js run plans/fixtures/hello-world.yaml --standalone --db-dir "$DB_DIR" 2>&1)"
+AFTER="$(pgrep -af '[E]lectron|owner-serve' || true)"
+printf '%s\n' "$OUTPUT"
+
+grep -q 'hello-from-invoker-cli' <<<"$OUTPUT"
+
+if ! diff -u <(printf '%s\n' "$BEFORE") <(printf '%s\n' "$AFTER") >/dev/null; then
+  echo "Standalone CLI smoke changed Electron/owner-serve process set." >&2
+  exit 1
+fi
+
+if find "$DB_DIR" -maxdepth 1 -name '*.sock' -print -quit | grep -q .; then
+  echo "Unexpected IPC owner socket in CLI db dir: $DB_DIR" >&2
+  exit 1
+fi

--- a/submit-plan.sh
+++ b/submit-plan.sh
@@ -38,4 +38,14 @@ if [ "$(uname)" = "Linux" ]; then
 fi
 
 echo "==> Submitting plan: $PLAN_FILE"
-./packages/app/node_modules/.bin/electron packages/app/dist/main.js $SANDBOX_FLAG --headless run "$PLAN_FILE"
+if [ "$(uname)" = "Linux" ] && [ -z "${DISPLAY:-}" ]; then
+  if ! command -v xvfb-run >/dev/null 2>&1; then
+    echo "ERROR: headless Electron launch requires Xvfb when DISPLAY is not set." >&2
+    echo "Install xvfb-run or set DISPLAY to an available X server." >&2
+    exit 1
+  fi
+  ELECTRON_ENABLE_LOGGING=1 exec xvfb-run --auto-servernum \
+    ./packages/app/node_modules/.bin/electron packages/app/dist/main.js $SANDBOX_FLAG --headless run "$PLAN_FILE"
+fi
+
+ELECTRON_ENABLE_LOGGING=1 exec ./packages/app/node_modules/.bin/electron packages/app/dist/main.js $SANDBOX_FLAG --headless run "$PLAN_FILE"


### PR DESCRIPTION
## Summary

Add `@invoker/cli` as a Node-based Invoker CLI runner that can submit `run <plan.yaml>` to a live desktop UI owner when one is available.

The CLI now supports `--live`, `--standalone`, and default auto mode. Auto delegates to the live UI when possible and falls back to standalone execution otherwise.

This also adds a shared workflow plan parser export, a hello-world CLI fixture, desktop packaging hooks, and smoke/archive scripts for CLI distribution.

## Architecture

### Before

```mermaid
graph TD
    CLI[invoker-cli run plan.yaml] --> Standalone[Standalone SQLite execution]
    UI[Desktop UI owner] --> GuiDB[UI workflow DB]
```

### After

```mermaid
graph TD
    CLI[invoker-cli run plan.yaml] --> Mode{mode}
    Mode -->|--standalone| Standalone[Standalone SQLite execution]
    Mode -->|auto/live| Ping[headless.owner-ping]
    Ping -->|GUI owner| Run[headless.run IPC request]
    Run --> UI[Desktop UI owner]
    UI --> GuiDB[UI workflow DB]
    Ping -->|no owner and auto| Standalone
    Ping -->|no owner and --live| Error[non-zero exit]
```

## Test Plan

- [x] `pnpm --filter @invoker/cli test`
- [x] `bash scripts/test-invoker-cli-smoke.sh`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/owner-delegation.test.ts src/__tests__/headless-transport.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 843334941`
- Post-revert steps: Run `pnpm install --lockfile-only` if the lockfile needs to be regenerated after revert.
- Data migration? No
