### PR TITLE
Reject unsafe nested shell variables in plan validation

### DIFF
--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -72,6 +72,8 @@ For policy-matrix inputs, it also checks that row-level coverage was extracted a
 
 When converting from an existing conversation, transcript, or plan document, always pass that original artifact as `--source-file <source>`. If the source already contains a concrete Invoker YAML plan, `skill-doctor` rejects generated plans that drop or replace its task IDs, including generic smoke plans.
 
+For portable command-only smoke plans, avoid nested `sh -c`, `bash -c`, or `bash -lc` quoting when the nested command string contains shell variables such as `$value` or `${value}`. Prefer literal smoke commands like `printf '%s\n' 'Supported: deterministic command-only smoke' && test 1 -eq 1` or `test 1 -eq 1`, or use a direct command without the nested shell wrapper.
+
 ### Fallback commands (for debugging individual checks)
 
 If `skill-doctor.sh` fails, run individual checks to isolate the problem:

--- a/skills/plan-to-invoker/scripts/test-validate-plan.sh
+++ b/skills/plan-to-invoker/scripts/test-validate-plan.sh
@@ -305,6 +305,149 @@ EOF
   return 0
 }
 
+# Test: nested shell command strings must not use shell variables
+test_nested_shell_variable_expansion_fails() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: nested-shell-variable-test
+repoUrl: git@github.com:user/repo.git
+onFinish: none
+tasks:
+  - id: unsafe-smoke
+    description: Exact failed nightly command
+    command: >-
+      sh -c "value='Supported: deterministic command-only smoke'; printf '%s\n' \"$value\"; test \"$value\" = 'Supported: deterministic command-only smoke'"
+EOF
+
+  local output
+  set +e
+  output=$(bash "$VALIDATE_SCRIPT" "$temp_plan" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Expected non-zero exit code for nested shell variable command" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  if ! echo "$output" | jq -e '[.[] | select(.errorType == "unsafe_shell_variable_expansion" and .field == "command" and .taskId == "unsafe-smoke")] | length == 1' &>/dev/null; then
+    echo "Expected unsafe_shell_variable_expansion for unsafe-smoke command" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+# Test: simple literal command-only smoke plans should still validate
+test_literal_smoke_command_validates() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: literal-smoke-test
+repoUrl: git@github.com:user/repo.git
+onFinish: none
+tasks:
+  - id: literal-smoke
+    description: Literal smoke command
+    command: "printf '%s\n' 'Supported: deterministic command-only smoke' && test 1 -eq 1"
+EOF
+
+  local output
+  output=$(bash "$VALIDATE_SCRIPT" "$temp_plan" 2>&1)
+  local exit_code=$?
+
+  if [[ $exit_code -ne 0 ]]; then
+    echo "Expected exit code 0, got $exit_code" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  if ! echo "$output" | grep -q '"valid"[[:space:]]*:[[:space:]]*true'; then
+    echo "Expected valid:true in output, got: $output" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+# Test: direct shell variables remain valid when no nested sh -c/bash -c is used
+test_direct_shell_variable_command_validates() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: direct-shell-variable-test
+repoUrl: git@github.com:user/repo.git
+onFinish: none
+tasks:
+  - id: direct-variable
+    description: Direct shell variable command
+    command: >-
+      value=ok; printf '%s\n' "$value"
+EOF
+
+  local output
+  output=$(bash "$VALIDATE_SCRIPT" "$temp_plan" 2>&1)
+  local exit_code=$?
+
+  if [[ $exit_code -ne 0 ]]; then
+    echo "Expected exit code 0, got $exit_code" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+# Test: experiment variant commands use the same nested shell guard
+test_experiment_variant_nested_shell_variable_expansion_fails() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: experiment-variant-shell-variable-test
+repoUrl: git@github.com:user/repo.git
+onFinish: none
+tasks:
+  - id: experiment-task
+    description: Experiment variant with unsafe command
+    prompt: "Compare variants"
+    experimentVariants:
+      - name: unsafe
+        command: >-
+          bash -lc "value='variant'; printf '%s\n' \"$value\""
+EOF
+
+  local output
+  set +e
+  output=$(bash "$VALIDATE_SCRIPT" "$temp_plan" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Expected non-zero exit code for unsafe experiment variant command" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  if ! echo "$output" | jq -e '[.[] | select(.errorType == "unsafe_shell_variable_expansion" and .field == "experimentVariants[0].command" and .taskId == "experiment-task")] | length == 1' &>/dev/null; then
+    echo "Expected unsafe_shell_variable_expansion for experiment variant command" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  return 0
+}
+
 # Test: Verify error has required fields with correct types
 test_error_field_structure() {
   local output
@@ -359,6 +502,10 @@ run_test "Minimal invalid plan should report missing fields" test_minimal_invali
 run_test "Command+prompt conflict should be detected" test_command_prompt_conflict
 run_test "Invalid dependency should be detected" test_invalid_dependency
 run_test "Banned pattern (npx vitest run) should be detected" test_banned_pattern
+run_test "Nested shell variable expansion should be rejected" test_nested_shell_variable_expansion_fails
+run_test "Literal smoke command should validate" test_literal_smoke_command_validates
+run_test "Direct shell variable command should validate" test_direct_shell_variable_command_validates
+run_test "Experiment variant nested shell variable expansion should be rejected" test_experiment_variant_nested_shell_variable_expansion_fails
 run_test "Error objects should have correct field structure" test_error_field_structure
 
 echo ""

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -51,6 +51,65 @@ const VALID_MERGE_MODE = ['manual', 'automatic', 'github', 'external_review'];
 const VALID_REQUIRED_STATUS = ['completed', 'review_ready'];
 const VALID_GATE_POLICY = ['completed', 'review_ready'];
 
+const NESTED_SHELL_INVOCATION = /\b(?:sh|bash)\s+-(?:c|lc)\b/g;
+const SHELL_VARIABLE_REFERENCE = /\$(?:[A-Za-z_][A-Za-z0-9_]*|\{[A-Za-z_][A-Za-z0-9_]*\})/;
+
+function hasUnsafeNestedShellVariableExpansion(command) {
+  NESTED_SHELL_INVOCATION.lastIndex = 0;
+
+  for (let match = NESTED_SHELL_INVOCATION.exec(command); match !== null; match = NESTED_SHELL_INVOCATION.exec(command)) {
+    const nestedCommand = extractNestedShellCommand(command, match.index + match[0].length);
+    if (nestedCommand !== null && SHELL_VARIABLE_REFERENCE.test(nestedCommand)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function extractNestedShellCommand(command, startIndex) {
+  let index = startIndex;
+  while (index < command.length && /\s/.test(command[index])) {
+    index += 1;
+  }
+
+  const quote = command[index];
+  if (quote !== '"' && quote !== "'") {
+    return null;
+  }
+
+  let nestedCommand = '';
+  index += 1;
+
+  for (; index < command.length; index += 1) {
+    const char = command[index];
+    if (char === quote && !hasOddBackslashRun(command, index)) {
+      return nestedCommand;
+    }
+    nestedCommand += char;
+  }
+
+  return nestedCommand;
+}
+
+function hasOddBackslashRun(value, index) {
+  let count = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === '\\'; cursor -= 1) {
+    count += 1;
+  }
+  return count % 2 === 1;
+}
+
+function pushUnsafeCommandError(errors, taskId, field, command) {
+  errors.push({
+    errorType: 'unsafe_shell_variable_expansion',
+    field,
+    taskId,
+    message: `Task "${taskId}" uses a nested shell command with shell variable references. Avoid sh -c/bash -c quoting with variables in plan command fields; use a direct command or literal smoke command instead.`,
+    value: command,
+  });
+}
+
 /**
  * Validate a single externalDependencies array (reused for both plan-level and task-level).
  */
@@ -315,6 +374,10 @@ function validatePlan(yamlContent) {
       });
     }
 
+    if (typeof task.command === 'string' && hasUnsafeNestedShellVariableExpansion(task.command)) {
+      pushUnsafeCommandError(errors, taskId, 'command', task.command);
+    }
+
     // Validate obsolete executor routing fields.
     if (task.runnerKind !== undefined) {
       errors.push({
@@ -372,6 +435,10 @@ function validatePlan(yamlContent) {
               taskId,
               message: `Task "${taskId}" experimentVariants[${varIndex}] cannot define both "command" and "prompt"`,
             });
+          }
+
+          if (typeof variant.command === 'string' && hasUnsafeNestedShellVariableExpansion(variant.command)) {
+            pushUnsafeCommandError(errors, taskId, `experimentVariants[${varIndex}].command`, variant.command);
           }
         });
       }

--- a/skills/plan-to-invoker/scripts/validate-plan.ts
+++ b/skills/plan-to-invoker/scripts/validate-plan.ts
@@ -26,6 +26,70 @@ const VALID_GATE_POLICY = ['completed', 'review_ready'] as const;
 
 type ExternalDep = { workflowId?: string; taskId?: string; requiredStatus?: string; gatePolicy?: string };
 
+const NESTED_SHELL_INVOCATION = /\b(?:sh|bash)\s+-(?:c|lc)\b/g;
+const SHELL_VARIABLE_REFERENCE = /\$(?:[A-Za-z_][A-Za-z0-9_]*|\{[A-Za-z_][A-Za-z0-9_]*\})/;
+
+function hasUnsafeNestedShellVariableExpansion(command: string): boolean {
+  NESTED_SHELL_INVOCATION.lastIndex = 0;
+
+  for (let match = NESTED_SHELL_INVOCATION.exec(command); match !== null; match = NESTED_SHELL_INVOCATION.exec(command)) {
+    const nestedCommand = extractNestedShellCommand(command, match.index + match[0].length);
+    if (nestedCommand !== null && SHELL_VARIABLE_REFERENCE.test(nestedCommand)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+function extractNestedShellCommand(command: string, startIndex: number): string | null {
+  let index = startIndex;
+  while (index < command.length && /\s/.test(command[index])) {
+    index += 1;
+  }
+
+  const quote = command[index];
+  if (quote !== '"' && quote !== "'") {
+    return null;
+  }
+
+  let nestedCommand = '';
+  index += 1;
+
+  for (; index < command.length; index += 1) {
+    const char = command[index];
+    if (char === quote && !hasOddBackslashRun(command, index)) {
+      return nestedCommand;
+    }
+    nestedCommand += char;
+  }
+
+  return nestedCommand;
+}
+
+function hasOddBackslashRun(value: string, index: number): boolean {
+  let count = 0;
+  for (let cursor = index - 1; cursor >= 0 && value[cursor] === '\\'; cursor -= 1) {
+    count += 1;
+  }
+  return count % 2 === 1;
+}
+
+function pushUnsafeCommandError(
+  errors: ValidationError[],
+  taskId: string,
+  field: string,
+  command: string,
+): void {
+  errors.push({
+    errorType: 'unsafe_shell_variable_expansion',
+    field,
+    taskId,
+    message: `Task "${taskId}" uses a nested shell command with shell variable references. Avoid sh -c/bash -c quoting with variables in plan command fields; use a direct command or literal smoke command instead.`,
+    value: command,
+  });
+}
+
 /**
  * Validate a single externalDependencies array (reused for both plan-level and task-level).
  * @param deps - The array to validate
@@ -298,6 +362,10 @@ function validatePlan(yamlContent: string): ValidationError[] {
       });
     }
 
+    if (typeof task.command === 'string' && hasUnsafeNestedShellVariableExpansion(task.command)) {
+      pushUnsafeCommandError(errors, taskId, 'command', task.command);
+    }
+
     // Validate obsolete executor routing fields.
     if (task.runnerKind !== undefined) {
       errors.push({
@@ -355,6 +423,10 @@ function validatePlan(yamlContent: string): ValidationError[] {
               taskId,
               message: `Task "${taskId}" experimentVariants[${varIndex}] cannot define both "command" and "prompt"`,
             });
+          }
+
+          if (typeof variant.command === 'string' && hasUnsafeNestedShellVariableExpansion(variant.command)) {
+            pushUnsafeCommandError(errors, taskId, `experimentVariants[${varIndex}].command`, variant.command);
           }
         });
       }


### PR DESCRIPTION
## Summary

Reject plan command fields that combine nested shell wrappers with shell variable references.

This blocks command-only smoke plans where the outer shell can expand variables before `sh -c` or `bash -c` runs.

Document literal smoke command guidance for the plan-to-invoker skill.

## Test Plan

- [x] `bash skills/plan-to-invoker/scripts/test-validate-plan.sh`
- [x] `bash scripts/test-plan-to-invoker-skill.sh`
- [x] Manual unsafe temp plan: `bash skills/plan-to-invoker/scripts/validate-plan.sh "$tmp_bad"` exited 1 with `unsafe_shell_variable_expansion`
- [x] Manual literal temp plan: `bash skills/plan-to-invoker/scripts/validate-plan.sh "$tmp_good"` exited 0 with `valid: true`
- [x] `git diff --check`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0ca7c851`
- Post-revert steps: None
- Data migration? No
