### PR TITLE
Reject non-portable pipefail command tasks

### DIFF
--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -74,6 +74,8 @@ When converting from an existing conversation, transcript, or plan document, alw
 
 For portable command-only smoke plans, avoid nested `sh -c`, `bash -c`, or `bash -lc` quoting when the nested command string contains shell variables such as `$value` or `${value}`. Prefer literal smoke commands like `printf '%s\n' 'Supported: deterministic command-only smoke' && test 1 -eq 1` or `test 1 -eq 1`, or use a direct command without the nested shell wrapper.
 
+Command tasks run under the platform default shell unless the command explicitly invokes another shell. Keep generated commands POSIX-shell portable; if a command needs bash-only behavior such as `set -o pipefail` or `set -euo pipefail`, write it as an explicit bash command, for example `bash -lc 'set -euo pipefail; ...'`.
+
 ### Fallback commands (for debugging individual checks)
 
 If `skill-doctor.sh` fails, run individual checks to isolate the problem:

--- a/skills/plan-to-invoker/fixtures/negative/edge-nonportable-pipefail.yaml
+++ b/skills/plan-to-invoker/fixtures/negative/edge-nonportable-pipefail.yaml
@@ -1,0 +1,9 @@
+name: "Non-portable pipefail command"
+repoUrl: git@github.com:example-org/acme-repo.git
+onFinish: none
+tasks:
+  - id: unsafe-pipefail
+    description: "Default-shell command uses bash-only pipefail"
+    command: |
+      set -euo pipefail
+      echo ok | tee /tmp/invoker-pipefail-proof

--- a/skills/plan-to-invoker/fixtures/positive/08-bash-wrapped-pipefail.yaml
+++ b/skills/plan-to-invoker/fixtures/positive/08-bash-wrapped-pipefail.yaml
@@ -1,0 +1,8 @@
+name: "Bash-wrapped pipefail command"
+repoUrl: git@github.com:example-org/acme-repo.git
+onFinish: none
+tasks:
+  - id: bash-pipefail
+    description: "Command explicitly runs bash for pipefail support"
+    command: >-
+      bash -lc 'set -euo pipefail; echo ok | tee /tmp/invoker-pipefail-proof'

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -23,6 +23,8 @@ Source of truth: `packages/surfaces/src/slack/plan-conversation.ts:100-116`
 | **Capture visual proof (after)** | `command` | `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build && bash scripts/ui-visual-proof.sh --label after` — depends on **all** implementation tasks |
 | **Invoker-on-Invoker PR publication** | repo-level workflow note | Keep `onFinish: pull_request` + `mergeMode: github`, then publish/update the commit stack with `mergify stack push` once the branch is ready |
 
+Command tasks run under the platform default shell unless the command explicitly invokes another shell. Keep commands POSIX-shell portable by default. If a command needs bash-only options such as `set -o pipefail` or `set -euo pipefail`, wrap it explicitly, for example `bash -lc 'set -euo pipefail; ...'`.
+
 ## Dependency Rules
 
 These are constraints, not guidelines. Violating them produces broken plans.

--- a/skills/plan-to-invoker/scripts/test-validate-plan.sh
+++ b/skills/plan-to-invoker/scripts/test-validate-plan.sh
@@ -407,6 +407,80 @@ EOF
   return 0
 }
 
+# Test: command tasks using pipefail must explicitly run through bash
+test_pipefail_without_bash_fails() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: pipefail-portability-test
+repoUrl: git@github.com:user/repo.git
+onFinish: none
+tasks:
+  - id: unsafe-pipefail
+    description: Command uses bash-only pipefail under the default shell
+    command: |
+      set -euo pipefail
+      echo ok | tee /tmp/invoker-pipefail-proof
+EOF
+
+  local output
+  set +e
+  output=$(bash "$VALIDATE_SCRIPT" "$temp_plan" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Expected non-zero exit code for pipefail command without bash" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  if ! echo "$output" | jq -e '[.[] | select(.errorType == "non_portable_pipefail" and .field == "command" and .taskId == "unsafe-pipefail")] | length == 1' &>/dev/null; then
+    echo "Expected non_portable_pipefail for unsafe-pipefail command" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  return 0
+}
+
+# Test: bash-wrapped pipefail commands remain valid
+test_pipefail_with_bash_validates() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: pipefail-bash-test
+repoUrl: git@github.com:user/repo.git
+onFinish: none
+tasks:
+  - id: bash-pipefail
+    description: Command explicitly runs bash for pipefail support
+    command: >-
+      bash -lc 'set -euo pipefail; echo ok | tee /tmp/invoker-pipefail-proof'
+EOF
+
+  local output
+  output=$(bash "$VALIDATE_SCRIPT" "$temp_plan" 2>&1)
+  local exit_code=$?
+
+  if [[ $exit_code -ne 0 ]]; then
+    echo "Expected exit code 0, got $exit_code" >&2
+    echo "Output: $output" >&2
+    return 1
+  fi
+
+  if ! echo "$output" | grep -q '"valid"[[:space:]]*:[[:space:]]*true'; then
+    echo "Expected valid:true in output, got: $output" >&2
+    return 1
+  fi
+
+  return 0
+}
+
 # Test: experiment variant commands use the same nested shell guard
 test_experiment_variant_nested_shell_variable_expansion_fails() {
   local temp_plan
@@ -505,6 +579,8 @@ run_test "Banned pattern (npx vitest run) should be detected" test_banned_patter
 run_test "Nested shell variable expansion should be rejected" test_nested_shell_variable_expansion_fails
 run_test "Literal smoke command should validate" test_literal_smoke_command_validates
 run_test "Direct shell variable command should validate" test_direct_shell_variable_command_validates
+run_test "Pipefail without bash should be rejected" test_pipefail_without_bash_fails
+run_test "Pipefail with bash should validate" test_pipefail_with_bash_validates
 run_test "Experiment variant nested shell variable expansion should be rejected" test_experiment_variant_nested_shell_variable_expansion_fails
 run_test "Error objects should have correct field structure" test_error_field_structure
 

--- a/skills/plan-to-invoker/scripts/validate-plan.mjs
+++ b/skills/plan-to-invoker/scripts/validate-plan.mjs
@@ -53,6 +53,7 @@ const VALID_GATE_POLICY = ['completed', 'review_ready'];
 
 const NESTED_SHELL_INVOCATION = /\b(?:sh|bash)\s+-(?:c|lc)\b/g;
 const SHELL_VARIABLE_REFERENCE = /\$(?:[A-Za-z_][A-Za-z0-9_]*|\{[A-Za-z_][A-Za-z0-9_]*\})/;
+const EXPLICIT_BASH_COMMAND = /^\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S+)\s+)*bash\s+-(?:lc|cl|c)\b/;
 
 function hasUnsafeNestedShellVariableExpansion(command) {
   NESTED_SHELL_INVOCATION.lastIndex = 0;
@@ -65,6 +66,16 @@ function hasUnsafeNestedShellVariableExpansion(command) {
   }
 
   return false;
+}
+
+function usesPipefailSetCommand(command) {
+  return command
+    .split(/[;&|()\n]/)
+    .some((segment) => /^\s*set\s+/.test(segment) && /\bpipefail\b/.test(segment));
+}
+
+function isExplicitBashCommand(command) {
+  return EXPLICIT_BASH_COMMAND.test(command);
 }
 
 function extractNestedShellCommand(command, startIndex) {
@@ -106,6 +117,16 @@ function pushUnsafeCommandError(errors, taskId, field, command) {
     field,
     taskId,
     message: `Task "${taskId}" uses a nested shell command with shell variable references. Avoid sh -c/bash -c quoting with variables in plan command fields; use a direct command or literal smoke command instead.`,
+    value: command,
+  });
+}
+
+function pushNonPortablePipefailError(errors, taskId, field, command) {
+  errors.push({
+    errorType: 'non_portable_pipefail',
+    field,
+    taskId,
+    message: `Task "${taskId}" uses bash-only pipefail without explicitly running the command through bash. Use bash -lc 'set -euo pipefail; ...' or write POSIX-compatible shell for Invoker command tasks.`,
     value: command,
   });
 }
@@ -378,6 +399,10 @@ function validatePlan(yamlContent) {
       pushUnsafeCommandError(errors, taskId, 'command', task.command);
     }
 
+    if (typeof task.command === 'string' && usesPipefailSetCommand(task.command) && !isExplicitBashCommand(task.command)) {
+      pushNonPortablePipefailError(errors, taskId, 'command', task.command);
+    }
+
     // Validate obsolete executor routing fields.
     if (task.runnerKind !== undefined) {
       errors.push({
@@ -439,6 +464,10 @@ function validatePlan(yamlContent) {
 
           if (typeof variant.command === 'string' && hasUnsafeNestedShellVariableExpansion(variant.command)) {
             pushUnsafeCommandError(errors, taskId, `experimentVariants[${varIndex}].command`, variant.command);
+          }
+
+          if (typeof variant.command === 'string' && usesPipefailSetCommand(variant.command) && !isExplicitBashCommand(variant.command)) {
+            pushNonPortablePipefailError(errors, taskId, `experimentVariants[${varIndex}].command`, variant.command);
           }
         });
       }

--- a/skills/plan-to-invoker/scripts/validate-plan.ts
+++ b/skills/plan-to-invoker/scripts/validate-plan.ts
@@ -28,6 +28,7 @@ type ExternalDep = { workflowId?: string; taskId?: string; requiredStatus?: stri
 
 const NESTED_SHELL_INVOCATION = /\b(?:sh|bash)\s+-(?:c|lc)\b/g;
 const SHELL_VARIABLE_REFERENCE = /\$(?:[A-Za-z_][A-Za-z0-9_]*|\{[A-Za-z_][A-Za-z0-9_]*\})/;
+const EXPLICIT_BASH_COMMAND = /^\s*(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S+)\s+)*bash\s+-(?:lc|cl|c)\b/;
 
 function hasUnsafeNestedShellVariableExpansion(command: string): boolean {
   NESTED_SHELL_INVOCATION.lastIndex = 0;
@@ -40,6 +41,16 @@ function hasUnsafeNestedShellVariableExpansion(command: string): boolean {
   }
 
   return false;
+}
+
+function usesPipefailSetCommand(command: string): boolean {
+  return command
+    .split(/[;&|()\n]/)
+    .some((segment) => /^\s*set\s+/.test(segment) && /\bpipefail\b/.test(segment));
+}
+
+function isExplicitBashCommand(command: string): boolean {
+  return EXPLICIT_BASH_COMMAND.test(command);
 }
 
 function extractNestedShellCommand(command: string, startIndex: number): string | null {
@@ -86,6 +97,21 @@ function pushUnsafeCommandError(
     field,
     taskId,
     message: `Task "${taskId}" uses a nested shell command with shell variable references. Avoid sh -c/bash -c quoting with variables in plan command fields; use a direct command or literal smoke command instead.`,
+    value: command,
+  });
+}
+
+function pushNonPortablePipefailError(
+  errors: ValidationError[],
+  taskId: string,
+  field: string,
+  command: string,
+): void {
+  errors.push({
+    errorType: 'non_portable_pipefail',
+    field,
+    taskId,
+    message: `Task "${taskId}" uses bash-only pipefail without explicitly running the command through bash. Use bash -lc 'set -euo pipefail; ...' or write POSIX-compatible shell for Invoker command tasks.`,
     value: command,
   });
 }
@@ -366,6 +392,10 @@ function validatePlan(yamlContent: string): ValidationError[] {
       pushUnsafeCommandError(errors, taskId, 'command', task.command);
     }
 
+    if (typeof task.command === 'string' && usesPipefailSetCommand(task.command) && !isExplicitBashCommand(task.command)) {
+      pushNonPortablePipefailError(errors, taskId, 'command', task.command);
+    }
+
     // Validate obsolete executor routing fields.
     if (task.runnerKind !== undefined) {
       errors.push({
@@ -427,6 +457,10 @@ function validatePlan(yamlContent: string): ValidationError[] {
 
           if (typeof variant.command === 'string' && hasUnsafeNestedShellVariableExpansion(variant.command)) {
             pushUnsafeCommandError(errors, taskId, `experimentVariants[${varIndex}].command`, variant.command);
+          }
+
+          if (typeof variant.command === 'string' && usesPipefailSetCommand(variant.command) && !isExplicitBashCommand(variant.command)) {
+            pushNonPortablePipefailError(errors, taskId, `experimentVariants[${varIndex}].command`, variant.command);
           }
         });
       }


### PR DESCRIPTION
## Summary

This rejects generated command tasks that use bash-only `pipefail` without explicitly invoking bash.

It prevents plans from validating under Invoker and later failing when command tasks run under a default `/bin/sh` shell.

The plan-to-invoker guidance now tells authors to keep commands POSIX portable or wrap bash-only commands with `bash -lc`.

## Test Plan

- [x] `bash scripts/test-plan-to-invoker-skill.sh`
- [x] `bash skills/plan-to-invoker/scripts/test-validate-plan.sh && bash skills/plan-to-invoker/scripts/test-fixtures.sh`
- [x] `bash skills/plan-to-invoker/scripts/skill-doctor.sh --skip-assumptions --skip-atomicity skills/plan-to-invoker/fixtures/negative/edge-nonportable-pipefail.yaml`
- [x] `bash skills/plan-to-invoker/scripts/skill-doctor.sh --skip-assumptions --skip-atomicity skills/plan-to-invoker/fixtures/positive/08-bash-wrapped-pipefail.yaml`
- [x] `bash -lc 'set -euo pipefail; echo ok | tee /tmp/invoker-pipefail-proof'`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert c3753313`
- Post-revert steps: None
- Data migration? No
