### PR TITLE
Add workflow-core recreateDownstream primitive

### DIFF
--- a/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
@@ -92,6 +92,65 @@ describe('InvalidationPlan policy registry', () => {
     });
   });
 
+  it('plans task recreate-downstream as descendants only, excluding the target', () => {
+    const tasks = [
+      task('wf-1/root', 'wf-1'),
+      task('wf-1/child', 'wf-1', ['wf-1/root']),
+      task('wf-1/grandchild', 'wf-1', ['wf-1/child']),
+      task('wf-1/sibling', 'wf-1'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/root',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'recreateDownstream',
+      scope: 'task',
+      mode: 'recreate',
+      affectedWorkflowIds: ['wf-1'],
+      // Target 'wf-1/root' is preserved; siblings are untouched.
+      affectedTaskIds: ['wf-1/child', 'wf-1/grandchild'],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+  });
+
+  it('plans recreate-downstream of a mid-chain task as the strictly-downstream tail', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/b', 'wf-1', ['wf-1/a']),
+      task('wf-1/c', 'wf-1', ['wf-1/b']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/b',
+      tasks,
+    });
+
+    // recreateDownstream(B) over A -> B -> C affects C only.
+    expect(plan.affectedTaskIds).toEqual(['wf-1/c']);
+  });
+
+  it('plans recreate-downstream of a leaf as an empty affected set (no-op)', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/b', 'wf-1', ['wf-1/a']),
+      task('wf-1/c', 'wf-1', ['wf-1/b']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/c',
+      tasks,
+    });
+
+    expect(plan.affectedTaskIds).toEqual([]);
+    expect(plan.affectedWorkflowIds).toEqual([]);
+  });
+
   it('plans task retry as the task plus non-completed descendants', () => {
     const tasks = [
       task('wf-1/root', 'wf-1', [], 'failed'),

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -525,6 +525,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
   'fixReject',
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',
@@ -534,6 +535,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
 const INVALIDATING_ACTIONS: readonly InvalidationAction[] = [
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5845,6 +5845,176 @@ describe('Orchestrator', () => {
       expect(x.execution.workspacePath).toBe('/tmp/x');
     });
 
+    // ── recreateDownstream ───────────────────────────────────
+    //
+    // Builds an A -> B -> C chain (plus an unrelated root X and the
+    // workflow merge gate) directly in persistence so each test
+    // exercises the primitive in isolation, mirroring the
+    // `recreateTask resets only target + downstream` fixture above.
+    function buildDownstreamChain(wf: string) {
+      const testPersistence = new InMemoryPersistence();
+      const testBus = new InMemoryBus();
+
+      testPersistence.saveTask(wf, {
+        id: 'A',
+        description: 'Root',
+        status: 'completed',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-a',
+          commit: 'a1',
+          workspacePath: '/tmp/a',
+          agentSessionId: 'sess-a',
+          containerId: 'cont-a',
+          selectedAttemptId: 'A-att',
+          generation: 5,
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'B',
+        description: 'Middle',
+        status: 'completed',
+        dependencies: ['A'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-b',
+          commit: 'b1',
+          workspacePath: '/tmp/b',
+          agentSessionId: 'sess-b',
+          containerId: 'cont-b',
+          generation: 2,
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'C',
+        description: 'Leaf',
+        status: 'completed',
+        dependencies: ['B'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-c',
+          commit: 'c1',
+          workspacePath: '/tmp/c',
+          agentSessionId: 'sess-c',
+          containerId: 'cont-c',
+          generation: 2,
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'X',
+        description: 'Unrelated root',
+        status: 'completed',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: { branch: 'br-x', commit: 'x1', workspacePath: '/tmp/x', exitCode: 0 },
+      });
+
+      const testOrchestrator = new Orchestrator({
+        persistence: testPersistence,
+        messageBus: testBus,
+        maxConcurrency: 3,
+      });
+      testOrchestrator.syncFromDb(wf);
+      return testOrchestrator;
+    }
+
+    it('recreateDownstream(A) preserves the target and resets B and C', () => {
+      const o = buildDownstreamChain('wf-recreate-downstream-root');
+
+      const started = o.recreateDownstream('A');
+
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+      const x = o.getTask('X')!;
+
+      // Target A is fully preserved: status, lineage, metadata, the
+      // selected attempt, and the execution generation are unchanged.
+      expect(a.status).toBe('completed');
+      expect(a.execution.branch).toBe('br-a');
+      expect(a.execution.commit).toBe('a1');
+      expect(a.execution.workspacePath).toBe('/tmp/a');
+      expect(a.execution.agentSessionId).toBe('sess-a');
+      expect(a.execution.containerId).toBe('cont-a');
+      expect(a.execution.selectedAttemptId).toBe('A-att');
+      expect(a.execution.generation).toBe(5);
+
+      // Descendants are reset recreate-class: no longer completed,
+      // lineage + session/container metadata cleared, generation bumped.
+      expect(b.status).not.toBe('completed');
+      expect(b.execution.branch).toBeUndefined();
+      expect(b.execution.commit).toBeUndefined();
+      expect(b.execution.workspacePath).toBeUndefined();
+      expect(b.execution.agentSessionId).toBeUndefined();
+      expect(b.execution.containerId).toBeUndefined();
+      expect(b.execution.generation).toBe(3);
+
+      expect(c.status).toBe('pending');
+      expect(c.execution.branch).toBeUndefined();
+      expect(c.execution.workspacePath).toBeUndefined();
+      expect(c.execution.generation).toBe(3);
+
+      // Unrelated root X is untouched.
+      expect(x.status).toBe('completed');
+      expect(x.execution.branch).toBe('br-x');
+
+      // Ready descendant B (its only dependency A stayed completed) is
+      // returned for dispatch; the preserved target A never is.
+      const startedIds = started.map((t) => t.id);
+      expect(startedIds).toContain('B');
+      expect(startedIds).not.toContain('A');
+    });
+
+    it('recreateDownstream(B) resets C only, leaving A and B unchanged', () => {
+      const o = buildDownstreamChain('wf-recreate-downstream-mid');
+
+      o.recreateDownstream('B');
+
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+
+      // A and the target B are both preserved.
+      expect(a.status).toBe('completed');
+      expect(a.execution.generation).toBe(5);
+      expect(b.status).toBe('completed');
+      expect(b.execution.branch).toBe('br-b');
+      expect(b.execution.workspacePath).toBe('/tmp/b');
+      expect(b.execution.agentSessionId).toBe('sess-b');
+      expect(b.execution.generation).toBe(2);
+
+      // Only C is reset.
+      expect(c.status).not.toBe('completed');
+      expect(c.execution.branch).toBeUndefined();
+      expect(c.execution.workspacePath).toBeUndefined();
+      expect(c.execution.generation).toBe(3);
+    });
+
+    it('recreateDownstream(leaf) is a no-op that returns no started tasks', () => {
+      const o = buildDownstreamChain('wf-recreate-downstream-leaf');
+
+      const started = o.recreateDownstream('C');
+
+      const c = o.getTask('C')!;
+
+      // Leaf C is fully preserved and nothing is dispatched.
+      expect(started).toEqual([]);
+      expect(c.status).toBe('completed');
+      expect(c.execution.branch).toBe('br-c');
+      expect(c.execution.commit).toBe('c1');
+      expect(c.execution.workspacePath).toBe('/tmp/c');
+      expect(c.execution.agentSessionId).toBe('sess-c');
+      expect(c.execution.generation).toBe(2);
+    });
+
     it('drainScheduler sets lastHeartbeatAt when starting a task', () => {
       orchestrator.loadPlan({
         name: 'heartbeat-start-test',

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -8,6 +8,7 @@ export type InvalidationAction =
   | 'retryTask'
   | 'retryWorkflow'
   | 'recreateTask'
+  | 'recreateDownstream'
   | 'recreateWorkflow'
   | 'recreateWorkflowFromFreshBase'
   | 'workflowFork';
@@ -70,6 +71,14 @@ export interface InvalidationDeps {
   cancelInFlight: CancelInFlightFn;
   retryTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   recreateTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  /**
+   * Recreate-class reset of the target's transitive downstream subgraph,
+   * leaving the target task itself untouched. Optional so existing
+   * `InvalidationDeps` builders (and tests) need not supply it; the
+   * router throws an explicit missing-dep error if the action is routed
+   * without it wired.
+   */
+  recreateDownstream?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   retryWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflowFromFreshBase?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
@@ -247,6 +256,18 @@ export const ACTION_SPECS: Readonly<Record<InvalidationAction, ActionSpec>> = Ob
     reason: 'task.recreate',
     selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
   },
+  // Like `recreateTask`, but the target task is preserved: only its
+  // transitive downstream dependents are reset (recreate-class). The
+  // affected set is `descendantsOf(target)` — the target itself is never
+  // included, so a leaf target yields an empty set (no-op).
+  recreateDownstream: {
+    scope: 'task',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'task.recreateDownstream',
+    selectAffectedTasks: ({ targetId, tasks }) => descendantsOf(targetId, taskMap(tasks)),
+  },
   retryWorkflow: {
     scope: 'workflow',
     stages: INVALIDATING_STAGES,
@@ -377,6 +398,17 @@ async function invokePrimitive(
       return await deps.retryTask(ctx.id);
     case 'recreateTask':
       return await deps.recreateTask(ctx.id);
+    case 'recreateDownstream': {
+      if (!deps.recreateDownstream) {
+        throw new Error(
+          "applyInvalidation: 'recreateDownstream' dep is missing. " +
+            'Production callers wire this via buildInvalidationDeps in ' +
+            '@invoker/app/workflow-actions; tests must supply ' +
+            'deps.recreateDownstream to use this action.',
+        );
+      }
+      return await deps.recreateDownstream(ctx.id);
+    }
     case 'retryWorkflow':
       return await deps.retryWorkflow(ctx.id);
     case 'recreateWorkflow':
@@ -425,6 +457,7 @@ export interface InvalidationDepsOrchestrator {
   cancelWorkflow(workflowId: string): { runningCancelled: string[] };
   retryTask(taskId: string): TaskState[];
   recreateTask(taskId: string): TaskState[];
+  recreateDownstream(taskId: string): TaskState[];
   retryWorkflow(workflowId: string): TaskState[];
   recreateWorkflow(workflowId: string): TaskState[];
   recreateWorkflowFromFreshBase(workflowId: string): Promise<TaskState[]>;
@@ -487,6 +520,7 @@ export function buildOrchestratorOnlyInvalidationDeps(
     cancelInFlight: buildCancelInFlight({ orchestrator }),
     retryTask: (taskId) => orchestrator.retryTask(taskId),
     recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    recreateDownstream: (taskId) => orchestrator.recreateDownstream(taskId),
     retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
     recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
     recreateWorkflowFromFreshBase: (workflowId) =>

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1093,6 +1093,7 @@ export class Orchestrator {
   private cancelActiveBeforeInvalidation(
     scope: 'task' | 'workflow',
     id: string,
+    opts?: { excludeRoot?: boolean },
   ): string[] {
     let candidates: TaskState[];
     if (scope === 'task') {
@@ -1105,8 +1106,11 @@ export class Orchestrator {
         taskMap,
         (t) => t.status === 'completed' || t.status === 'stale',
       );
+      // `recreateDownstream` preserves the target task, so its
+      // cancel-first pass must skip the root and only interrupt
+      // active attempts in the downstream subgraph.
       candidates = [
-        root,
+        ...(opts?.excludeRoot ? [] : [root]),
         ...descendantIds
           .map((d) => taskMap.get(d))
           .filter((t): t is TaskState => !!t),
@@ -2514,6 +2518,100 @@ export class Orchestrator {
     };
 
     this.logger.info('[orchestrator] recreateTask reset', {
+      taskId: rootId,
+      resetCount: toResetIds.length,
+    });
+
+    for (const id of toResetIds) {
+      const current = this.stateGetTask(id);
+      if (!current) continue;
+      const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
+      const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
+      const priorAttemptId = current.execution.selectedAttemptId;
+      this.replaceSelectedAttempt(current);
+      this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(current, recreateUpdated, changesWithGeneration));
+
+      this.deferredTaskIds.delete(id);
+      this.clearQueuedSchedulerEntries(id, priorAttemptId);
+    }
+
+    const readyIds = this.stateMachine
+      .getReadyTasks()
+      .map((t) => t.id)
+      .filter((id) => toResetSet.has(id));
+    plan = withSchedulerEnqueueCandidates(plan, readyIds);
+    this.lastInvalidationPlan = plan;
+    return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
+  }
+
+  /**
+   * Task-scoped downstream recreate: reset the target's transitive
+   * downstream dependents to pending with recreate-style execution
+   * clearing, leaving the target task itself untouched, then auto-start
+   * newly-ready descendants within that affected subgraph.
+   *
+   * Differs from `recreateTask` only in that the target is preserved:
+   * the affected set is `descendantsOf(target)` (the target is never
+   * included). A leaf target has no descendants, so this is a no-op
+   * that returns no started tasks.
+   */
+  recreateDownstream(taskId: string): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+
+    const rootId = task.id;
+
+    // Step 18 cancel-first invariant, scoped to the downstream subgraph:
+    // interrupt active attempts on the dependents BEFORE the recreate
+    // reset, but never touch the preserved target task. Defense-in-depth
+    // for direct callers; a no-op when invoked through `applyInvalidation`.
+    this.cancelActiveBeforeInvalidation('task', rootId, { excludeRoot: true });
+    let plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: rootId,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
+    const toResetIds = plan.affectedTaskIds;
+    const toResetSet = new Set(toResetIds);
+
+    // Leaf target: no downstream dependents → preserve the target and
+    // start nothing.
+    if (toResetIds.length === 0) {
+      this.logger.info('[orchestrator] recreateDownstream no-op (leaf target)', {
+        taskId: rootId,
+      });
+      return [];
+    }
+
+    const resetChanges: TaskStateChanges = {
+      status: 'pending',
+      config: { summary: undefined },
+      execution: {
+        autoFixAttempts: 0,
+        startedAt: undefined,
+        completedAt: undefined,
+        error: undefined,
+        exitCode: undefined,
+        commit: undefined,
+        branch: undefined,
+        workspacePath: undefined,
+        lastHeartbeatAt: undefined,
+        phase: undefined,
+        launchStartedAt: undefined,
+        launchCompletedAt: undefined,
+        reviewUrl: undefined,
+        reviewId: undefined,
+        reviewStatus: undefined,
+        reviewProviderId: undefined,
+        agentSessionId: undefined,
+        containerId: undefined,
+      },
+    };
+
+    this.logger.info('[orchestrator] recreateDownstream reset', {
       taskId: rootId,
       resetCount: toResetIds.length,
     });


### PR DESCRIPTION
## Summary

Adds a task-scoped `recreateDownstream` primitive to workflow-core. It recreate-resets a task's transitive downstream dependents while leaving the target task itself untouched.

For a chain `A -> B -> C`, `recreateDownstream(A)` preserves A and resets B and C. `recreateDownstream(B)` resets C only. A leaf call is a no-op.

Descendant resets use recreate-class semantics: fresh lineage, cleared attempt/session/container metadata, a bumped execution generation, and ready descendants returned for dispatch.

The primitive follows the existing invalidation/action-table pattern. A new `recreateDownstream` action selects `descendantsOf(target)` (excluding the target), so the affected-task set falls out of `planInvalidation` rather than an ad hoc traversal.

This PR is the workflow-core core slice only. No app IPC, API, headless commands, renderer types, or UI menu items are added.

## Architecture

The new action reuses the same planning, cancel-first, and reset machinery as `recreateTask`. The only structural difference is the affected-set selector and a cancel-first pass that excludes the target root.

### Before

```mermaid
graph TD
    subgraph Table[invalidation action table]
        RT[recreateTask: target + descendants]
    end
    Caller[orchestrator primitive] --> RT
    RT --> Plan[planInvalidation]
    Plan --> Reset[recreate-class reset of affected set]
```

### After

```mermaid
graph TD
    subgraph Table[invalidation action table]
        RT[recreateTask: target + descendants]
        RD[recreateDownstream: descendants only]
    end
    Caller[orchestrator primitive] --> RD
    RD --> Cancel[cancel-first, excludeRoot: target preserved]
    Cancel --> Plan[planInvalidation]
    Plan --> Reset[recreate-class reset of descendants]
    Reset --> Ready[ready descendants dispatched]
```

## Test Plan

- [ ] `cd packages/workflow-core && pnpm test -- src/__tests__/orchestrator.test.ts src/__tests__/invalidation-plan.test.ts`
- [ ] `cd packages/workflow-core && pnpm exec tsc --noEmit`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
