### PR TITLE
Recreate Downstream Stack 20260601133250 1: Core mutation primitive

### DIFF
--- a/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
@@ -31,6 +31,10 @@ describe('InvalidationPlan policy registry', () => {
       scope: 'task',
       mode: 'recreate',
     });
+    expect(ACTION_SPECS.recreateDownstream).toMatchObject({
+      scope: 'task',
+      mode: 'recreate',
+    });
     expect(ACTION_SPECS.retryWorkflow).toMatchObject({
       scope: 'workflow',
       mode: 'retry',
@@ -90,6 +94,66 @@ describe('InvalidationPlan policy registry', () => {
       affectedTaskIds: ['wf-1/child', 'wf-1/grandchild', 'wf-1/root'],
       lockPlan: { workflowIds: ['wf-1'] },
     });
+  });
+
+  it('plans downstream recreate as descendants only, excluding the target', () => {
+    const tasks = [
+      task('wf-1/root', 'wf-1'),
+      task('wf-1/child', 'wf-1', ['wf-1/root']),
+      task('wf-1/grandchild', 'wf-1', ['wf-1/child']),
+      task('wf-1/sibling', 'wf-1'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/root',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'recreateDownstream',
+      scope: 'task',
+      mode: 'recreate',
+      affectedWorkflowIds: ['wf-1'],
+      affectedTaskIds: ['wf-1/child', 'wf-1/grandchild'],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+    expect(plan.affectedTaskIds).not.toContain('wf-1/root');
+    expect(plan.affectedTaskIds).not.toContain('wf-1/sibling');
+  });
+
+  it('plans downstream recreate on an intermediate node as its descendants only', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/b', 'wf-1', ['wf-1/a']),
+      task('wf-1/c', 'wf-1', ['wf-1/b']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/b',
+      tasks,
+    });
+
+    expect(plan.affectedTaskIds).toEqual(['wf-1/c']);
+  });
+
+  it('plans downstream recreate on a leaf as an empty affected set (no-op)', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/b', 'wf-1', ['wf-1/a']),
+      task('wf-1/c', 'wf-1', ['wf-1/b']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/c',
+      tasks,
+    });
+
+    expect(plan.affectedTaskIds).toEqual([]);
+    expect(plan.affectedWorkflowIds).toEqual([]);
+    expect(plan.schedulerEnqueueCandidates).toEqual([]);
   });
 
   it('plans task retry as the task plus non-completed descendants', () => {

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -525,6 +525,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
   'fixReject',
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',
@@ -534,6 +535,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
 const INVALIDATING_ACTIONS: readonly InvalidationAction[] = [
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5942,6 +5942,169 @@ describe('Orchestrator', () => {
       expect(x.execution.workspacePath).toBe('/tmp/x');
     });
 
+    function loadRecreateDownstreamChain(wf: string) {
+      const testPersistence = new InMemoryPersistence();
+      const testBus = new InMemoryBus();
+
+      testPersistence.saveTask(wf, {
+        id: 'A',
+        description: 'Root',
+        status: 'completed',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-a',
+          commit: 'a1',
+          workspacePath: '/tmp/a',
+          agentSessionId: 'sess-a',
+          containerId: 'ct-a',
+          generation: 3,
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'B',
+        description: 'Middle',
+        status: 'completed',
+        dependencies: ['A'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-b',
+          commit: 'b1',
+          workspacePath: '/tmp/b',
+          agentSessionId: 'sess-b',
+          containerId: 'ct-b',
+          generation: 2,
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'C',
+        description: 'Leaf',
+        status: 'completed',
+        dependencies: ['B'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-c',
+          commit: 'c1',
+          workspacePath: '/tmp/c',
+          agentSessionId: 'sess-c',
+          containerId: 'ct-c',
+          generation: 1,
+          exitCode: 0,
+        },
+      });
+
+      const testOrchestrator = new Orchestrator({
+        persistence: testPersistence,
+        messageBus: testBus,
+        maxConcurrency: 3,
+      });
+      testOrchestrator.syncFromDb(wf);
+      return testOrchestrator;
+    }
+
+    it('recreateDownstream(A) preserves A and resets B and C', () => {
+      const o = loadRecreateDownstreamChain('wf-recreate-downstream-a');
+      o.recreateDownstream('A');
+
+      const a = o.getTask('A')!;
+      // A (the selected task) is left entirely unchanged.
+      expect(a.status).toBe('completed');
+      expect(a.execution.branch).toBe('br-a');
+      expect(a.execution.commit).toBe('a1');
+      expect(a.execution.workspacePath).toBe('/tmp/a');
+      expect(a.execution.agentSessionId).toBe('sess-a');
+      expect(a.execution.containerId).toBe('ct-a');
+      expect(a.execution.generation).toBe(3);
+
+      // B and C are recreated with fresh lineage and bumped generation.
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+      expect(b.status === 'running' || b.status === 'pending').toBe(true);
+      expect(c.status).toBe('pending');
+      for (const t of [b, c]) {
+        expect(t.execution.branch).toBeUndefined();
+        expect(t.execution.commit).toBeUndefined();
+        expect(t.execution.workspacePath).toBeUndefined();
+        expect(t.execution.agentSessionId).toBeUndefined();
+        expect(t.execution.containerId).toBeUndefined();
+      }
+      expect(b.execution.generation).toBe(3);
+      expect(c.execution.generation).toBe(2);
+    });
+
+    it('recreateDownstream(B) resets C only, leaving A and B unchanged', () => {
+      const o = loadRecreateDownstreamChain('wf-recreate-downstream-b');
+      o.recreateDownstream('B');
+
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+
+      expect(a.status).toBe('completed');
+      expect(a.execution.branch).toBe('br-a');
+      expect(a.execution.generation).toBe(3);
+
+      // B is the selected task here — fully preserved.
+      expect(b.status).toBe('completed');
+      expect(b.execution.branch).toBe('br-b');
+      expect(b.execution.commit).toBe('b1');
+      expect(b.execution.workspacePath).toBe('/tmp/b');
+      expect(b.execution.agentSessionId).toBe('sess-b');
+      expect(b.execution.containerId).toBe('ct-b');
+      expect(b.execution.generation).toBe(2);
+
+      // Only C is recreated.
+      expect(c.status === 'running' || c.status === 'pending').toBe(true);
+      expect(c.execution.branch).toBeUndefined();
+      expect(c.execution.workspacePath).toBeUndefined();
+      expect(c.execution.agentSessionId).toBeUndefined();
+      expect(c.execution.containerId).toBeUndefined();
+      expect(c.execution.generation).toBe(2);
+    });
+
+    it('recreateDownstream on a leaf is a no-op returning no started tasks', () => {
+      const o = loadRecreateDownstreamChain('wf-recreate-downstream-leaf');
+      const started = o.recreateDownstream('C');
+
+      expect(started).toEqual([]);
+
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+      // Nothing changed anywhere — including the leaf itself.
+      expect(a.status).toBe('completed');
+      expect(b.status).toBe('completed');
+      expect(c.status).toBe('completed');
+      expect(c.execution.branch).toBe('br-c');
+      expect(c.execution.commit).toBe('c1');
+      expect(c.execution.workspacePath).toBe('/tmp/c');
+      expect(c.execution.agentSessionId).toBe('sess-c');
+      expect(c.execution.containerId).toBe('ct-c');
+      expect(c.execution.generation).toBe(1);
+    });
+
+    it('recreateDownstream plans only the ready descendants for dispatch', () => {
+      const o = loadRecreateDownstreamChain('wf-recreate-downstream-dispatch');
+      const started = o.recreateDownstream('A');
+
+      // A stays completed, so B becomes ready; C is gated behind B and
+      // is not yet ready. The invalidation plan records exactly the
+      // ready descendant set handed to the scheduler.
+      const plan = o.getLastInvalidationPlan()!;
+      expect(plan.action).toBe('recreateDownstream');
+      expect(plan.affectedTaskIds).toEqual(['B', 'C']);
+      expect(plan.schedulerEnqueueCandidates.map((c) => c.taskId)).toEqual(['B']);
+
+      // The preserved target is never returned as a started task.
+      expect(started.map((t) => t.id)).not.toContain('A');
+      expect(started.map((t) => t.id)).not.toContain('C');
+    });
+
     it('drainScheduler sets lastHeartbeatAt when starting a task', () => {
       orchestrator.loadPlan({
         name: 'heartbeat-start-test',

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -6012,7 +6012,6 @@ describe('Orchestrator', () => {
       o.recreateDownstream('A');
 
       const a = o.getTask('A')!;
-      // A (the selected task) is left entirely unchanged.
       expect(a.status).toBe('completed');
       expect(a.execution.branch).toBe('br-a');
       expect(a.execution.commit).toBe('a1');
@@ -6021,7 +6020,6 @@ describe('Orchestrator', () => {
       expect(a.execution.containerId).toBe('ct-a');
       expect(a.execution.generation).toBe(3);
 
-      // B and C are recreated with fresh lineage and bumped generation.
       const b = o.getTask('B')!;
       const c = o.getTask('C')!;
       expect(b.status === 'running' || b.status === 'pending').toBe(true);
@@ -6049,7 +6047,6 @@ describe('Orchestrator', () => {
       expect(a.execution.branch).toBe('br-a');
       expect(a.execution.generation).toBe(3);
 
-      // B is the selected task here — fully preserved.
       expect(b.status).toBe('completed');
       expect(b.execution.branch).toBe('br-b');
       expect(b.execution.commit).toBe('b1');
@@ -6058,7 +6055,6 @@ describe('Orchestrator', () => {
       expect(b.execution.containerId).toBe('ct-b');
       expect(b.execution.generation).toBe(2);
 
-      // Only C is recreated.
       expect(c.status === 'running' || c.status === 'pending').toBe(true);
       expect(c.execution.branch).toBeUndefined();
       expect(c.execution.workspacePath).toBeUndefined();
@@ -6076,7 +6072,6 @@ describe('Orchestrator', () => {
       const a = o.getTask('A')!;
       const b = o.getTask('B')!;
       const c = o.getTask('C')!;
-      // Nothing changed anywhere — including the leaf itself.
       expect(a.status).toBe('completed');
       expect(b.status).toBe('completed');
       expect(c.status).toBe('completed');
@@ -6092,15 +6087,11 @@ describe('Orchestrator', () => {
       const o = loadRecreateDownstreamChain('wf-recreate-downstream-dispatch');
       const started = o.recreateDownstream('A');
 
-      // A stays completed, so B becomes ready; C is gated behind B and
-      // is not yet ready. The invalidation plan records exactly the
-      // ready descendant set handed to the scheduler.
       const plan = o.getLastInvalidationPlan()!;
       expect(plan.action).toBe('recreateDownstream');
       expect(plan.affectedTaskIds).toEqual(['B', 'C']);
       expect(plan.schedulerEnqueueCandidates.map((c) => c.taskId)).toEqual(['B']);
 
-      // The preserved target is never returned as a started task.
       expect(started.map((t) => t.id)).not.toContain('A');
       expect(started.map((t) => t.id)).not.toContain('C');
     });

--- a/packages/workflow-core/src/executor-routing.ts
+++ b/packages/workflow-core/src/executor-routing.ts
@@ -1,0 +1,239 @@
+import type { RunnerKind } from '@invoker/workflow-graph';
+
+/**
+ * A single routing rule that validates task pool placement against command patterns.
+ * When a rule matches a task command, the orchestrator validates that the task's
+ * pool destination conforms to the rule's requirements.
+ */
+export interface ExecutorRoutingRule {
+  /** Substring to match against the task command. */
+  pattern?: string;
+  /** Regular expression matched against the task command; compiled with new RegExp(regex). */
+  regex?: string;
+  /** Required execution pool ID for matching commands. */
+  poolId: string;
+  /**
+   * Rule behavior:
+   * - enforce (default): task must already declare matching executor/destination
+   * - route: auto-apply rule executor/destination when omitted, and reject conflicts
+   */
+  strategy?: 'enforce' | 'route';
+}
+
+export interface CommandRoutingMatcher {
+  pattern?: string;
+  regex?: string;
+}
+
+export interface HeavyweightCommandRoutingPolicy {
+  enabled?: boolean;
+  poolId: string;
+  matchers?: CommandRoutingMatcher[];
+}
+
+const DEFAULT_HEAVYWEIGHT_COMMAND_MATCHERS: CommandRoutingMatcher[] = [
+  { regex: '\\bpnpm(?:\\s|$)' },
+];
+
+function validateRoutingDestinationAvailability(
+  taskId: string,
+  command: string,
+  sourceLabel: string,
+  poolId: string | undefined,
+  availablePoolIds: Set<string>,
+): void {
+  if (availablePoolIds.size > 0 && (!poolId || !availablePoolIds.has(poolId))) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
+      `but config poolId="${poolId}" is not defined in executionPools.`,
+    );
+  }
+  if (availablePoolIds.size === 0) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
+      'but no executionPools are configured.',
+    );
+  }
+}
+
+export function buildHeavyweightRoutingRules(
+  taskId: string,
+  policy: HeavyweightCommandRoutingPolicy | undefined,
+): ExecutorRoutingRule[] {
+  if (!policy || policy.enabled === false) {
+    return [];
+  }
+
+  const matchers = policy.matchers?.length ? policy.matchers : DEFAULT_HEAVYWEIGHT_COMMAND_MATCHERS;
+  if (!policy.poolId) {
+    throw new Error(
+      `Task "${taskId}" matched heavyweight command routing, ` +
+      'but config is missing destination: set poolId.',
+    );
+  }
+
+  return matchers.map((matcher) => ({
+    pattern: matcher.pattern,
+    regex: matcher.regex,
+    poolId: policy.poolId,
+    strategy: 'route',
+  }));
+}
+
+function applyRoutingRule(
+  taskId: string,
+  command: string,
+  planPoolId: string | undefined,
+  rule: ExecutorRoutingRule,
+  sourceLabel: string,
+  availablePoolIds: Set<string>,
+): { poolId?: string } | undefined {
+  validateRoutingDestinationAvailability(
+    taskId,
+    command,
+    sourceLabel,
+    rule.poolId,
+    availablePoolIds,
+  );
+  if (planPoolId !== undefined && planPoolId !== rule.poolId) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" matched ${sourceLabel} and must use ` +
+      `poolId="${rule.poolId}", but plan declares poolId="${planPoolId}"`,
+    );
+  }
+  return {
+    poolId: rule.poolId ?? planPoolId,
+  };
+}
+
+/**
+ * Finds the first executor routing rule that matches the given command.
+ * A rule matches when `pattern` is a substring of `command`, `regex` compiles and tests
+ * true against `command`, or both (either is sufficient).
+ * Returns the matching rule or undefined if no rule matches.
+ */
+export function findMatchingExecutorRoutingRule(
+  command: string,
+  rules: ExecutorRoutingRule[],
+): ExecutorRoutingRule | undefined {
+  for (const rule of rules) {
+    const patternMatch = rule.pattern !== undefined && command.includes(rule.pattern);
+    const regexMatch = rule.regex !== undefined && new RegExp(rule.regex).test(command);
+    if (patternMatch || regexMatch) {
+      return rule;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Validates that a task's routing conforms to pool routing rules.
+ * Returns immediately if the task has no command or no rules are configured.
+ * When a rule matches the task command, throws if the task's poolId does not
+ * match the rule's requirements.
+ */
+export function assertExecutorRoutingConforms(
+  taskId: string,
+  command: string | undefined,
+  planPoolId: string | undefined,
+  rules: ExecutorRoutingRule[],
+): void {
+  if (!command || rules.length === 0) {
+    return;
+  }
+
+  const matchingRule = findMatchingExecutorRoutingRule(command, rules);
+  if (!matchingRule) {
+    return;
+  }
+
+  if (planPoolId !== matchingRule.poolId) {
+    throw new Error(
+      `Task "${taskId}" with command "${command}" requires poolId="${matchingRule.poolId}" ` +
+      `but plan declares poolId="${planPoolId ?? '(undefined)'}"`
+    );
+  }
+}
+
+export function resolveExecutorRouting(
+  taskId: string,
+  command: string | undefined,
+  planPoolId: string | undefined,
+  defaultPoolId: string | undefined,
+  rules: ExecutorRoutingRule[],
+  availablePoolIds: Set<string>,
+): { poolId?: string; reason: ExecutorRoutingReason } {
+  if (defaultPoolId && availablePoolIds.size > 0 && !availablePoolIds.has(defaultPoolId)) {
+    throw new Error(
+      `Task "${taskId}" cannot use defaultPoolId="${defaultPoolId}" because it is not defined in executionPools.`,
+    );
+  }
+
+  const initialPoolId = planPoolId ?? defaultPoolId;
+  const initialReason: ExecutorRoutingReason = initialPoolId
+    ? { type: 'poolId', poolId: initialPoolId }
+    : { type: 'defaultWorktree' };
+
+  if (!command || rules.length === 0) {
+    return {
+      poolId: initialPoolId,
+      reason: initialReason,
+    };
+  }
+
+  let effectivePoolId = initialPoolId;
+  let reason: ExecutorRoutingReason = initialReason;
+
+  const routingRules = rules.filter((rule) => (rule.strategy ?? 'enforce') === 'route');
+  const matchingRoutingRule = findMatchingExecutorRoutingRule(command, routingRules);
+  if (matchingRoutingRule) {
+    const routed = applyRoutingRule(
+      taskId,
+      command,
+      planPoolId,
+      matchingRoutingRule,
+      'routing rule',
+      availablePoolIds,
+    );
+    effectivePoolId = routed?.poolId ?? effectivePoolId;
+    if (routed?.poolId) {
+      reason = {
+        type: 'routingRule',
+        poolId: routed.poolId,
+        ...(matchingRoutingRule.pattern !== undefined ? { pattern: matchingRoutingRule.pattern } : {}),
+        ...(matchingRoutingRule.regex !== undefined ? { regex: matchingRoutingRule.regex } : {}),
+      };
+    }
+  }
+
+  const enforcementRules = rules.filter((rule) => (rule.strategy ?? 'enforce') === 'enforce');
+  assertExecutorRoutingConforms(
+    taskId,
+    command,
+    effectivePoolId,
+    enforcementRules,
+  );
+
+  return {
+    poolId: effectivePoolId,
+    reason,
+  };
+}
+
+export type ExecutorRoutingReason =
+  | { type: 'dockerImage' }
+  | { type: 'poolId'; poolId: string }
+  | { type: 'routingRule'; poolId: string; pattern?: string; regex?: string }
+  | { type: 'defaultWorktree' };
+
+export function buildExecutorRoutedPayload(
+  runnerKind: RunnerKind,
+  poolId: string | undefined,
+  reason: ExecutorRoutingReason,
+): Record<string, unknown> {
+  return {
+    runnerKind,
+    ...(poolId ? { poolId } : {}),
+    reason,
+  };
+}

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -8,6 +8,7 @@ export type InvalidationAction =
   | 'retryTask'
   | 'retryWorkflow'
   | 'recreateTask'
+  | 'recreateDownstream'
   | 'recreateWorkflow'
   | 'recreateWorkflowFromFreshBase'
   | 'workflowFork';
@@ -70,6 +71,13 @@ export interface InvalidationDeps {
   cancelInFlight: CancelInFlightFn;
   retryTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   recreateTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  /**
+   * Recreate every transitive downstream dependent of a task while
+   * leaving the task itself untouched. Optional like `workflowFork` /
+   * `scheduleOnly`: production callers wire it via the orchestrator;
+   * tests must supply it to route the action.
+   */
+  recreateDownstream?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   retryWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflowFromFreshBase?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
@@ -247,6 +255,17 @@ export const ACTION_SPECS: Readonly<Record<InvalidationAction, ActionSpec>> = Ob
     reason: 'task.recreate',
     selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
   },
+  recreateDownstream: {
+    // Like `recreateTask`, but the target itself is preserved: only its
+    // transitive downstream dependents are recreated. The affected set
+    // therefore excludes the target and is empty for a leaf (no-op).
+    scope: 'task',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'task.recreateDownstream',
+    selectAffectedTasks: ({ targetId, tasks }) => descendantsOf(targetId, taskMap(tasks)),
+  },
   retryWorkflow: {
     scope: 'workflow',
     stages: INVALIDATING_STAGES,
@@ -377,6 +396,17 @@ async function invokePrimitive(
       return await deps.retryTask(ctx.id);
     case 'recreateTask':
       return await deps.recreateTask(ctx.id);
+    case 'recreateDownstream': {
+      if (!deps.recreateDownstream) {
+        throw new Error(
+          "applyInvalidation: 'recreateDownstream' dep is missing. " +
+            'Production callers wire this via buildInvalidationDeps in ' +
+            '@invoker/app/workflow-actions; tests must supply ' +
+            'deps.recreateDownstream to use this action.',
+        );
+      }
+      return await deps.recreateDownstream(ctx.id);
+    }
     case 'retryWorkflow':
       return await deps.retryWorkflow(ctx.id);
     case 'recreateWorkflow':
@@ -425,6 +455,7 @@ export interface InvalidationDepsOrchestrator {
   cancelWorkflow(workflowId: string): { runningCancelled: string[] };
   retryTask(taskId: string): TaskState[];
   recreateTask(taskId: string): TaskState[];
+  recreateDownstream(taskId: string): TaskState[];
   retryWorkflow(workflowId: string): TaskState[];
   recreateWorkflow(workflowId: string): TaskState[];
   recreateWorkflowFromFreshBase(workflowId: string): Promise<TaskState[]>;
@@ -487,6 +518,7 @@ export function buildOrchestratorOnlyInvalidationDeps(
     cancelInFlight: buildCancelInFlight({ orchestrator }),
     retryTask: (taskId) => orchestrator.retryTask(taskId),
     recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    recreateDownstream: (taskId) => orchestrator.recreateDownstream(taskId),
     retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
     recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
     recreateWorkflowFromFreshBase: (workflowId) =>

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -71,12 +71,7 @@ export interface InvalidationDeps {
   cancelInFlight: CancelInFlightFn;
   retryTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   recreateTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
-  /**
-   * Recreate every transitive downstream dependent of a task while
-   * leaving the task itself untouched. Optional like `workflowFork` /
-   * `scheduleOnly`: production callers wire it via the orchestrator;
-   * tests must supply it to route the action.
-   */
+  /** Recreate a task's transitive downstream dependents while leaving the task itself untouched. */
   recreateDownstream?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   retryWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
@@ -256,9 +251,6 @@ export const ACTION_SPECS: Readonly<Record<InvalidationAction, ActionSpec>> = Ob
     selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
   },
   recreateDownstream: {
-    // Like `recreateTask`, but the target itself is preserved: only its
-    // transitive downstream dependents are recreated. The affected set
-    // therefore excludes the target and is empty for a leaf (no-op).
     scope: 'task',
     stages: INVALIDATING_STAGES,
     cascadesAcrossWorkflows: true,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -27,6 +27,14 @@ import type { Logger, WorkResponse } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import { normalizeRunnerKind } from '@invoker/workflow-graph';
 import { parseMergeConflictError } from './merge-conflict-error.js';
+import {
+  buildExecutorRoutedPayload,
+  buildHeavyweightRoutingRules,
+  resolveExecutorRouting,
+  type ExecutorRoutingReason,
+  type ExecutorRoutingRule,
+  type HeavyweightCommandRoutingPolicy,
+} from './executor-routing.js';
 
 const MERGE_TRACE_LOG = resolve(homedir(), '.invoker', 'merge-trace.log');
 function mergeTrace(tag: string, data: Record<string, unknown>): void {
@@ -113,6 +121,32 @@ function workflowTimestamp(): Date {
   }
   return new Date();
 }
+/** Recreate-class reset: fresh lineage, cleared attempt/session/container metadata. */
+const RECREATE_RESET_CHANGES: TaskStateChanges = {
+  status: 'pending',
+  config: { summary: undefined },
+  execution: {
+    autoFixAttempts: 0,
+    startedAt: undefined,
+    completedAt: undefined,
+    error: undefined,
+    exitCode: undefined,
+    commit: undefined,
+    branch: undefined,
+    workspacePath: undefined,
+    lastHeartbeatAt: undefined,
+    phase: undefined,
+    launchStartedAt: undefined,
+    launchCompletedAt: undefined,
+    reviewUrl: undefined,
+    reviewId: undefined,
+    reviewStatus: undefined,
+    reviewProviderId: undefined,
+    agentSessionId: undefined,
+    containerId: undefined,
+  },
+};
+
 const FIX_FAILURE_PREFIX_RE = /^\[Fix with (?:Claude|Agent) failed\] [^\n]*\n\n/;
 const TRACE_PERSIST_SYNC = process.env.INVOKER_TRACE_PERSIST_SYNC === '1';
 const TRACE_WORKER_RESPONSE = process.env.INVOKER_TRACE_WORKER_RESPONSE === '1';
@@ -451,243 +485,13 @@ export interface ExternalGatePolicyUpdate {
   gatePolicy: 'completed' | 'review_ready';
 }
 
-/**
- * A single routing rule that validates task pool placement against command patterns.
- * When a rule matches a task command, the orchestrator validates that the task's
- * pool destination conforms to the rule's requirements.
- */
-export interface ExecutorRoutingRule {
-  /** Substring to match against the task command. */
-  pattern?: string;
-  /** Regular expression matched against the task command; compiled with new RegExp(regex). */
-  regex?: string;
-  /** Required execution pool ID for matching commands. */
-  poolId: string;
-  /**
-   * Rule behavior:
-   * - enforce (default): task must already declare matching executor/destination
-   * - route: auto-apply rule executor/destination when omitted, and reject conflicts
-   */
-  strategy?: 'enforce' | 'route';
-}
-
-export interface CommandRoutingMatcher {
-  pattern?: string;
-  regex?: string;
-}
-
-export interface HeavyweightCommandRoutingPolicy {
-  enabled?: boolean;
-  poolId: string;
-  matchers?: CommandRoutingMatcher[];
-}
-
-const DEFAULT_HEAVYWEIGHT_COMMAND_MATCHERS: CommandRoutingMatcher[] = [
-  { regex: '\\bpnpm(?:\\s|$)' },
-];
-
-function validateRoutingDestinationAvailability(
-  taskId: string,
-  command: string,
-  sourceLabel: string,
-  poolId: string | undefined,
-  availablePoolIds: Set<string>,
-): void {
-  if (availablePoolIds.size > 0 && (!poolId || !availablePoolIds.has(poolId))) {
-    throw new Error(
-      `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
-      `but config poolId="${poolId}" is not defined in executionPools.`,
-    );
-  }
-  if (availablePoolIds.size === 0) {
-    throw new Error(
-      `Task "${taskId}" with command "${command}" matched ${sourceLabel}, ` +
-      'but no executionPools are configured.',
-    );
-  }
-}
-
-function buildHeavyweightRoutingRules(
-  taskId: string,
-  policy: HeavyweightCommandRoutingPolicy | undefined,
-): ExecutorRoutingRule[] {
-  if (!policy || policy.enabled === false) {
-    return [];
-  }
-
-  const matchers = policy.matchers?.length ? policy.matchers : DEFAULT_HEAVYWEIGHT_COMMAND_MATCHERS;
-  if (!policy.poolId) {
-    throw new Error(
-      `Task "${taskId}" matched heavyweight command routing, ` +
-      'but config is missing destination: set poolId.',
-    );
-  }
-
-  return matchers.map((matcher) => ({
-    pattern: matcher.pattern,
-    regex: matcher.regex,
-    poolId: policy.poolId,
-    strategy: 'route',
-  }));
-}
-
-function applyRoutingRule(
-  taskId: string,
-  command: string,
-  planPoolId: string | undefined,
-  rule: ExecutorRoutingRule,
-  sourceLabel: string,
-  availablePoolIds: Set<string>,
-): { poolId?: string } | undefined {
-  validateRoutingDestinationAvailability(
-    taskId,
-    command,
-    sourceLabel,
-    rule.poolId,
-    availablePoolIds,
-  );
-  if (planPoolId !== undefined && planPoolId !== rule.poolId) {
-    throw new Error(
-      `Task "${taskId}" with command "${command}" matched ${sourceLabel} and must use ` +
-      `poolId="${rule.poolId}", but plan declares poolId="${planPoolId}"`,
-    );
-  }
-  return {
-    poolId: rule.poolId ?? planPoolId,
-  };
-}
-
-/**
- * Finds the first executor routing rule that matches the given command.
- * A rule matches when `pattern` is a substring of `command`, `regex` compiles and tests
- * true against `command`, or both (either is sufficient).
- * Returns the matching rule or undefined if no rule matches.
- */
-export function findMatchingExecutorRoutingRule(
-  command: string,
-  rules: ExecutorRoutingRule[],
-): ExecutorRoutingRule | undefined {
-  for (const rule of rules) {
-    const patternMatch = rule.pattern !== undefined && command.includes(rule.pattern);
-    const regexMatch = rule.regex !== undefined && new RegExp(rule.regex).test(command);
-    if (patternMatch || regexMatch) {
-      return rule;
-    }
-  }
-  return undefined;
-}
-
-/**
- * Validates that a task's routing conforms to pool routing rules.
- * Returns immediately if the task has no command or no rules are configured.
- * When a rule matches the task command, throws if the task's poolId does not
- * match the rule's requirements.
- */
-export function assertExecutorRoutingConforms(
-  taskId: string,
-  command: string | undefined,
-  planPoolId: string | undefined,
-  rules: ExecutorRoutingRule[],
-): void {
-  if (!command || rules.length === 0) {
-    return;
-  }
-
-  const matchingRule = findMatchingExecutorRoutingRule(command, rules);
-  if (!matchingRule) {
-    return;
-  }
-
-  if (planPoolId !== matchingRule.poolId) {
-    throw new Error(
-      `Task "${taskId}" with command "${command}" requires poolId="${matchingRule.poolId}" ` +
-      `but plan declares poolId="${planPoolId ?? '(undefined)'}"`
-    );
-  }
-}
-
-function resolveExecutorRouting(
-  taskId: string,
-  command: string | undefined,
-  planPoolId: string | undefined,
-  defaultPoolId: string | undefined,
-  rules: ExecutorRoutingRule[],
-  availablePoolIds: Set<string>,
-): { poolId?: string; reason: ExecutorRoutingReason } {
-  if (defaultPoolId && availablePoolIds.size > 0 && !availablePoolIds.has(defaultPoolId)) {
-    throw new Error(
-      `Task "${taskId}" cannot use defaultPoolId="${defaultPoolId}" because it is not defined in executionPools.`,
-    );
-  }
-
-  const initialPoolId = planPoolId ?? defaultPoolId;
-  const initialReason: ExecutorRoutingReason = initialPoolId
-    ? { type: 'poolId', poolId: initialPoolId }
-    : { type: 'defaultWorktree' };
-
-  if (!command || rules.length === 0) {
-    return {
-      poolId: initialPoolId,
-      reason: initialReason,
-    };
-  }
-
-  let effectivePoolId = initialPoolId;
-  let reason: ExecutorRoutingReason = initialReason;
-
-  const routingRules = rules.filter((rule) => (rule.strategy ?? 'enforce') === 'route');
-  const matchingRoutingRule = findMatchingExecutorRoutingRule(command, routingRules);
-  if (matchingRoutingRule) {
-    const routed = applyRoutingRule(
-      taskId,
-      command,
-      planPoolId,
-      matchingRoutingRule,
-      'routing rule',
-      availablePoolIds,
-    );
-    effectivePoolId = routed?.poolId ?? effectivePoolId;
-    if (routed?.poolId) {
-      reason = {
-        type: 'routingRule',
-        poolId: routed.poolId,
-        ...(matchingRoutingRule.pattern !== undefined ? { pattern: matchingRoutingRule.pattern } : {}),
-        ...(matchingRoutingRule.regex !== undefined ? { regex: matchingRoutingRule.regex } : {}),
-      };
-    }
-  }
-
-  const enforcementRules = rules.filter((rule) => (rule.strategy ?? 'enforce') === 'enforce');
-  assertExecutorRoutingConforms(
-    taskId,
-    command,
-    effectivePoolId,
-    enforcementRules,
-  );
-
-  return {
-    poolId: effectivePoolId,
-    reason,
-  };
-}
-
-type ExecutorRoutingReason =
-  | { type: 'dockerImage' }
-  | { type: 'poolId'; poolId: string }
-  | { type: 'routingRule'; poolId: string; pattern?: string; regex?: string }
-  | { type: 'defaultWorktree' };
-
-function buildExecutorRoutedPayload(
-  runnerKind: RunnerKind,
-  poolId: string | undefined,
-  reason: ExecutorRoutingReason,
-): Record<string, unknown> {
-  return {
-    runnerKind,
-    ...(poolId ? { poolId } : {}),
-    reason,
-  };
-}
+export {
+  findMatchingExecutorRoutingRule,
+  assertExecutorRoutingConforms,
+  type ExecutorRoutingRule,
+  type CommandRoutingMatcher,
+  type HeavyweightCommandRoutingPolicy,
+} from './executor-routing.js';
 
 /**
  * Adapt an OrchestratorPersistence into the TaskRepository port.
@@ -2557,50 +2361,33 @@ export class Orchestrator {
     // Defense-in-depth for direct callers (CommandService.recreateTask
     // wired in Step 17); a no-op when invoked through `applyInvalidation`.
     this.cancelActiveBeforeInvalidation('task', rootId);
-    let plan = planInvalidation({
+    const plan = planInvalidation({
       action: 'recreateTask',
       targetId: rootId,
       tasks: this.stateMachine.getAllTasks(),
     });
     this.lastInvalidationPlan = plan;
-    const toResetIds = plan.affectedTaskIds;
-    const toResetSet = new Set(toResetIds);
-
-    const resetChanges: TaskStateChanges = {
-      status: 'pending',
-      config: { summary: undefined },
-      execution: {
-        autoFixAttempts: 0,
-        startedAt: undefined,
-        completedAt: undefined,
-        error: undefined,
-        exitCode: undefined,
-        commit: undefined,
-        branch: undefined,
-        workspacePath: undefined,
-        lastHeartbeatAt: undefined,
-        phase: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-        reviewUrl: undefined,
-        reviewId: undefined,
-        reviewStatus: undefined,
-        reviewProviderId: undefined,
-        agentSessionId: undefined,
-        containerId: undefined,
-      },
-    };
-
     this.logger.info('[orchestrator] recreateTask reset', {
       taskId: rootId,
-      resetCount: toResetIds.length,
+      resetCount: plan.affectedTaskIds.length,
     });
-    this.invalidateLaunchArtifactsForTasks(toResetIds, 'task recreation reset');
+    return this.applyRecreateReset(plan, 'task recreation reset');
+  }
+
+  /**
+   * Shared tail of the recreate-class mutations: apply `RECREATE_RESET_CHANGES`
+   * to every task in `plan.affectedTaskIds`, then auto-start the ones that
+   * become ready.
+   */
+  private applyRecreateReset(plan: InvalidationPlan, artifactReason: string): TaskState[] {
+    const toResetIds = plan.affectedTaskIds;
+    const toResetSet = new Set(toResetIds);
+    this.invalidateLaunchArtifactsForTasks(toResetIds, artifactReason);
 
     for (const id of toResetIds) {
       const current = this.stateGetTask(id);
       if (!current) continue;
-      const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
+      const changesWithGeneration = this.withBumpedExecutionGeneration(current, RECREATE_RESET_CHANGES);
       const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
       const priorAttemptId = current.execution.selectedAttemptId;
       this.replaceSelectedAttempt(current);
@@ -2615,8 +2402,7 @@ export class Orchestrator {
       .getReadyTasks()
       .map((t) => t.id)
       .filter((id) => toResetSet.has(id));
-    plan = withSchedulerEnqueueCandidates(plan, readyIds);
-    this.lastInvalidationPlan = plan;
+    this.lastInvalidationPlan = withSchedulerEnqueueCandidates(plan, readyIds);
     return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
   }
 
@@ -2632,14 +2418,13 @@ export class Orchestrator {
 
     const rootId = task.id;
 
-    let plan = planInvalidation({
+    const plan = planInvalidation({
       action: 'recreateDownstream',
       targetId: rootId,
       tasks: this.stateMachine.getAllTasks(),
     });
     this.lastInvalidationPlan = plan;
     const toResetIds = plan.affectedTaskIds;
-    const toResetSet = new Set(toResetIds);
 
     if (toResetIds.length === 0) {
       this.logger.info('[orchestrator] recreateDownstream no-op (leaf)', { taskId: rootId });
@@ -2652,58 +2437,11 @@ export class Orchestrator {
       .filter((t): t is TaskState => !!t);
     this.cancelActiveCandidates(descendants, 'task');
 
-    const resetChanges: TaskStateChanges = {
-      status: 'pending',
-      config: { summary: undefined },
-      execution: {
-        autoFixAttempts: 0,
-        startedAt: undefined,
-        completedAt: undefined,
-        error: undefined,
-        exitCode: undefined,
-        commit: undefined,
-        branch: undefined,
-        workspacePath: undefined,
-        lastHeartbeatAt: undefined,
-        phase: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-        reviewUrl: undefined,
-        reviewId: undefined,
-        reviewStatus: undefined,
-        reviewProviderId: undefined,
-        agentSessionId: undefined,
-        containerId: undefined,
-      },
-    };
-
     this.logger.info('[orchestrator] recreateDownstream reset', {
       taskId: rootId,
       resetCount: toResetIds.length,
     });
-    this.invalidateLaunchArtifactsForTasks(toResetIds, 'downstream recreation reset');
-
-    for (const id of toResetIds) {
-      const current = this.stateGetTask(id);
-      if (!current) continue;
-      const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
-      const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
-      const priorAttemptId = current.execution.selectedAttemptId;
-      this.replaceSelectedAttempt(current);
-      this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
-      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(current, recreateUpdated, changesWithGeneration));
-
-      this.deferredTaskIds.delete(id);
-      this.clearQueuedSchedulerEntries(id, priorAttemptId);
-    }
-
-    const readyIds = this.stateMachine
-      .getReadyTasks()
-      .map((t) => t.id)
-      .filter((id) => toResetSet.has(id));
-    plan = withSchedulerEnqueueCandidates(plan, readyIds);
-    this.lastInvalidationPlan = plan;
-    return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
+    return this.applyRecreateReset(plan, 'downstream recreation reset');
   }
 
   /**
@@ -2732,28 +2470,8 @@ export class Orchestrator {
     this.lastInvalidationPlan = plan;
 
     const resetChanges: TaskStateChanges = {
-      status: 'pending',
+      ...RECREATE_RESET_CHANGES,
       config: { summary: undefined, poolMemberId: undefined },
-      execution: {
-        autoFixAttempts: 0,
-        startedAt: undefined,
-        completedAt: undefined,
-        error: undefined,
-        exitCode: undefined,
-        commit: undefined,
-        branch: undefined,
-        workspacePath: undefined,
-        lastHeartbeatAt: undefined,
-        phase: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-        reviewUrl: undefined,
-        reviewId: undefined,
-        reviewStatus: undefined,
-        reviewProviderId: undefined,
-        agentSessionId: undefined,
-        containerId: undefined,
-      },
     };
 
     this.logger.info('[orchestrator] recreateWorkflow reset', {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1190,13 +1190,7 @@ export class Orchestrator {
     return this.cancelActiveCandidates(candidates, scope);
   }
 
-  /**
-   * Mark every actively-running task in `candidates` as `failed` with a
-   * cancel marker, freeing its scheduler slot. Shared by
-   * `cancelActiveBeforeInvalidation` (task/workflow scope) and the
-   * downstream-only recreate path, which must interrupt descendants
-   * WITHOUT touching the preserved target task.
-   */
+  /** Mark every actively-running task in `candidates` as `failed` with a cancel marker, freeing its scheduler slot. */
   private cancelActiveCandidates(
     candidates: readonly TaskState[],
     scope: 'task' | 'workflow',
@@ -2627,21 +2621,9 @@ export class Orchestrator {
   }
 
   /**
-   * Downstream-only recreate: leave the selected task untouched and
-   * reset all of its transitive downstream dependents to pending with
-   * recreate-style execution clearing, then auto-start the descendants
-   * that become ready. For a chain A -> B -> C, `recreateDownstream(A)`
-   * resets B and C; `recreateDownstream(B)` resets C. Calling it on a
-   * leaf is a no-op that returns no started tasks.
-   *
-   * This is the task-preserving sibling of `recreateTask`: it reuses the
-   * `recreateDownstream` action-table entry (whose affected set is the
-   * target's descendants, excluding the target) and the same
-   * recreate-class reset payload, so descendants get fresh lineage,
-   * cleared attempt/session/container metadata, and a bumped execution
-   * generation, while the target's status, branch, commit, workspace,
-   * selected attempt, agent/session/container metadata, and generation
-   * stay exactly as they were.
+   * Reset a task's transitive downstream dependents to pending (recreate-style)
+   * and auto-start the ones that become ready, leaving the task itself untouched.
+   * Calling it on a leaf is a no-op.
    */
   recreateDownstream(taskId: string): TaskState[] {
     this.refreshFromDb();
@@ -2650,7 +2632,6 @@ export class Orchestrator {
 
     const rootId = task.id;
 
-    // Descendant-only affected set (target preserved); empty for a leaf.
     let plan = planInvalidation({
       action: 'recreateDownstream',
       targetId: rootId,
@@ -2660,14 +2641,12 @@ export class Orchestrator {
     const toResetIds = plan.affectedTaskIds;
     const toResetSet = new Set(toResetIds);
 
-    // Leaf no-op: nothing downstream to recreate, nothing to dispatch.
     if (toResetIds.length === 0) {
       this.logger.info('[orchestrator] recreateDownstream no-op (leaf)', { taskId: rootId });
       return [];
     }
 
-    // Step 18 cancel-first invariant, scoped to the descendants only so
-    // the preserved target's active attempt is never interrupted.
+    // Cancel only descendants so the preserved target's active attempt is never interrupted.
     const descendants = toResetIds
       .map((id) => this.stateGetTask(id))
       .filter((t): t is TaskState => !!t);

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1187,6 +1187,20 @@ export class Orchestrator {
         .filter((t) => t.config.workflowId === id);
     }
 
+    return this.cancelActiveCandidates(candidates, scope);
+  }
+
+  /**
+   * Mark every actively-running task in `candidates` as `failed` with a
+   * cancel marker, freeing its scheduler slot. Shared by
+   * `cancelActiveBeforeInvalidation` (task/workflow scope) and the
+   * downstream-only recreate path, which must interrupt descendants
+   * WITHOUT touching the preserved target task.
+   */
+  private cancelActiveCandidates(
+    candidates: readonly TaskState[],
+    scope: 'task' | 'workflow',
+  ): string[] {
     const cancelled: string[] = [];
     for (const t of candidates) {
       if (!isActiveForInvalidation(t.status)) continue;
@@ -2588,6 +2602,107 @@ export class Orchestrator {
       resetCount: toResetIds.length,
     });
     this.invalidateLaunchArtifactsForTasks(toResetIds, 'task recreation reset');
+
+    for (const id of toResetIds) {
+      const current = this.stateGetTask(id);
+      if (!current) continue;
+      const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
+      const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
+      const priorAttemptId = current.execution.selectedAttemptId;
+      this.replaceSelectedAttempt(current);
+      this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(current, recreateUpdated, changesWithGeneration));
+
+      this.deferredTaskIds.delete(id);
+      this.clearQueuedSchedulerEntries(id, priorAttemptId);
+    }
+
+    const readyIds = this.stateMachine
+      .getReadyTasks()
+      .map((t) => t.id)
+      .filter((id) => toResetSet.has(id));
+    plan = withSchedulerEnqueueCandidates(plan, readyIds);
+    this.lastInvalidationPlan = plan;
+    return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
+  }
+
+  /**
+   * Downstream-only recreate: leave the selected task untouched and
+   * reset all of its transitive downstream dependents to pending with
+   * recreate-style execution clearing, then auto-start the descendants
+   * that become ready. For a chain A -> B -> C, `recreateDownstream(A)`
+   * resets B and C; `recreateDownstream(B)` resets C. Calling it on a
+   * leaf is a no-op that returns no started tasks.
+   *
+   * This is the task-preserving sibling of `recreateTask`: it reuses the
+   * `recreateDownstream` action-table entry (whose affected set is the
+   * target's descendants, excluding the target) and the same
+   * recreate-class reset payload, so descendants get fresh lineage,
+   * cleared attempt/session/container metadata, and a bumped execution
+   * generation, while the target's status, branch, commit, workspace,
+   * selected attempt, agent/session/container metadata, and generation
+   * stay exactly as they were.
+   */
+  recreateDownstream(taskId: string): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+
+    const rootId = task.id;
+
+    // Descendant-only affected set (target preserved); empty for a leaf.
+    let plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: rootId,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
+    const toResetIds = plan.affectedTaskIds;
+    const toResetSet = new Set(toResetIds);
+
+    // Leaf no-op: nothing downstream to recreate, nothing to dispatch.
+    if (toResetIds.length === 0) {
+      this.logger.info('[orchestrator] recreateDownstream no-op (leaf)', { taskId: rootId });
+      return [];
+    }
+
+    // Step 18 cancel-first invariant, scoped to the descendants only so
+    // the preserved target's active attempt is never interrupted.
+    const descendants = toResetIds
+      .map((id) => this.stateGetTask(id))
+      .filter((t): t is TaskState => !!t);
+    this.cancelActiveCandidates(descendants, 'task');
+
+    const resetChanges: TaskStateChanges = {
+      status: 'pending',
+      config: { summary: undefined },
+      execution: {
+        autoFixAttempts: 0,
+        startedAt: undefined,
+        completedAt: undefined,
+        error: undefined,
+        exitCode: undefined,
+        commit: undefined,
+        branch: undefined,
+        workspacePath: undefined,
+        lastHeartbeatAt: undefined,
+        phase: undefined,
+        launchStartedAt: undefined,
+        launchCompletedAt: undefined,
+        reviewUrl: undefined,
+        reviewId: undefined,
+        reviewStatus: undefined,
+        reviewProviderId: undefined,
+        agentSessionId: undefined,
+        containerId: undefined,
+      },
+    };
+
+    this.logger.info('[orchestrator] recreateDownstream reset', {
+      taskId: rootId,
+      resetCount: toResetIds.length,
+    });
+    this.invalidateLaunchArtifactsForTasks(toResetIds, 'downstream recreation reset');
 
     for (const id of toResetIds) {
       const current = this.stateGetTask(id);


### PR DESCRIPTION
## Summary

Recreating a task today wipes the task and everything after it. This adds `recreateDownstream`: rerun only the tasks that come after, keeping the selected task's work.

Engine layer only — app and UI land in later stack PRs.

## Architecture

`recreateDownstream` reuses the recreate-class reset payload and the cancel-first invariant, but its affected set excludes the target. For a chain `A -> B -> C`, `recreateDownstream(A)` resets `B` and `C`; calling it on a leaf is a no-op.

### Before

```mermaid
graph TD
    R[recreateTask A] --> A[Reset A: root]
    R --> B[Reset B: descendant]
    R --> C[Reset C: descendant]
    A --> D[Auto-start ready tasks]
    B --> D
    C --> D
```

### After

```mermaid
graph TD
    R[recreateDownstream A] --> A[Preserve A: root untouched]
    R --> B[Reset B: descendant]
    R --> C[Reset C: descendant]
    B --> D[Auto-start ready descendants]
    C --> D
```

## Test Plan

- [x] `cd packages/workflow-core && pnpm test -- src/__tests__/orchestrator.test.ts src/__tests__/invalidation-plan.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
