### PR TITLE
Add app bridge for workflow-core recreateDownstream

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -98,6 +98,7 @@ function createMocks() {
       setFixAwaitingApproval: vi.fn(),
       retryTask: vi.fn(() => [makeTask()]),
       recreateTask: vi.fn(() => [makeTask()]),
+      recreateDownstream: vi.fn(() => [makeTask()]),
       retryWorkflow: vi.fn(() => [makeTask()]),
       recreateWorkflow: vi.fn(() => [makeTask()]),
       editTaskCommand: vi.fn(() => [makeTask()]),
@@ -161,6 +162,14 @@ function createMocks() {
           return { ok: true, data: mocks.orchestrator.recreateTask(envelope.payload.taskId) };
         } catch (err) {
           return { ok: false, error: { code: 'RECREATE_TASK_FAILED', message: (err as Error).message } };
+        }
+      }),
+      recreateDownstream: vi.fn(async (envelope: { payload: { taskId: string } }) => {
+        try {
+          return { ok: true, data: mocks.orchestrator.recreateDownstream(envelope.payload.taskId) };
+        } catch (err) {
+          const code = err instanceof OrchestratorError ? err.code : 'RECREATE_DOWNSTREAM_FAILED';
+          return { ok: false, error: { code, message: (err as Error).message } };
         }
       }),
       retryWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => {
@@ -256,6 +265,8 @@ beforeEach(() => {
   mocks.orchestrator.getTask.mockImplementation((id: string) => (id === 'task-1' ? makeTask() : undefined));
   mocks.orchestrator.approve.mockResolvedValue([]);
   mocks.orchestrator.retryTask.mockReturnValue([makeTask()]);
+  mocks.orchestrator.recreateTask.mockReturnValue([makeTask()]);
+  mocks.orchestrator.recreateDownstream.mockReturnValue([makeTask()]);
   mocks.orchestrator.beginConflictResolution.mockReturnValue({ savedError: 'saved-error' });
   mocks.orchestrator.editTaskCommand.mockReturnValue([makeTask()]);
   mocks.orchestrator.editTaskPrompt.mockReturnValue([makeTask()]);
@@ -461,6 +472,84 @@ describe('POST /api/tasks/:id/restart', () => {
     expect(res.status).toBe(200);
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledWith([scoped]);
+  });
+});
+
+describe('POST /api/tasks/:id/recreate-downstream', () => {
+  it('routes through the shared facade via CommandService.recreateDownstream', async () => {
+    const downstream = makeTask({
+      id: 'wf-1/child',
+      config: { workflowId: 'wf-1' },
+      status: 'running',
+      execution: { selectedAttemptId: 'attempt-child' },
+    });
+    mocks.orchestrator.recreateDownstream.mockReturnValue([downstream]);
+
+    const res = await request(port, 'POST', '/api/tasks/task-1/recreate-downstream');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.taskId).toBe('task-1');
+    expect(res.body.action).toBe('recreated_downstream');
+    expect(res.body.tasksStarted).toBe(1);
+    expect(mocks.commandService.recreateDownstream).toHaveBeenCalledTimes(1);
+    expect(mocks.commandService.recreateDownstream).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ taskId: 'task-1' }),
+      }),
+    );
+    expect(mocks.orchestrator.recreateDownstream).toHaveBeenCalledWith('task-1');
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledWith([downstream]);
+  });
+
+  it('does not invoke retry/recreate-task/recreate-workflow on the selected task', async () => {
+    await request(port, 'POST', '/api/tasks/task-1/recreate-downstream');
+    expect(mocks.orchestrator.retryTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on downstream recreate failure', async () => {
+    mocks.orchestrator.recreateDownstream.mockImplementation(() => {
+      throw new Error('cannot recreate downstream');
+    });
+    const res = await request(port, 'POST', '/api/tasks/task-1/recreate-downstream');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('cannot recreate downstream');
+  });
+
+  it('returns 404 when the task is not found', async () => {
+    mocks.orchestrator.recreateDownstream.mockImplementation(() => {
+      throw new OrchestratorError(
+        OrchestratorErrorCode.TASK_NOT_FOUND,
+        'Task "missing" not found',
+      );
+    });
+    const res = await request(port, 'POST', '/api/tasks/missing/recreate-downstream');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toContain('Task "missing" not found');
+  });
+
+  it('tops up globally ready tasks after the scoped downstream recreate', async () => {
+    const downstream = makeTask({
+      id: 'wf-1/child',
+      config: { workflowId: 'wf-1' },
+      status: 'running',
+      execution: { selectedAttemptId: 'attempt-child' },
+    });
+    const topup = makeTask({
+      id: 'wf-2/root',
+      config: { workflowId: 'wf-2' },
+      status: 'running',
+      execution: { selectedAttemptId: 'attempt-topup' },
+    });
+    mocks.orchestrator.recreateDownstream.mockReturnValue([downstream]);
+    mocks.orchestrator.startExecution.mockReturnValue([topup]);
+
+    const res = await request(port, 'POST', '/api/tasks/task-1/recreate-downstream');
+    expect(res.status).toBe(200);
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [downstream]);
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [topup]);
   });
 });
 

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -353,6 +353,33 @@ describe('headless-client', () => {
     expect(firstExecCalls).toBe(1);
   }, 15_000);
 
+  it('delegates recreate-downstream to a standalone-capable owner endpoint with the task id and --no-track', async () => {
+    const bus = new LocalBus();
+    const ownerHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.exec', ownerHandler);
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+
+    const runElectronHeadless = vi.fn(async () => 0);
+
+    const exitCode = await runHeadlessClientCommand(
+      ['recreate-downstream', 'wf-1/task-1', '--no-track'],
+      {
+        messageBus: bus,
+        ensureStandaloneOwner: vi.fn(async () => {}),
+        runElectronHeadless,
+      },
+    );
+
+    expect(exitCode).toBe(0);
+    expect(ownerHandler).toHaveBeenCalledTimes(1);
+    expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
+      args: ['recreate-downstream', 'wf-1/task-1'],
+      noTrack: true,
+      waitForApproval: false,
+    }));
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+  });
+
   it('falls back to the host runtime for non-mutating commands', async () => {
     const runElectronHeadless = vi.fn(async () => 0);
     const exitCode = await runHeadlessClientCommand(['query', 'workflows'], {

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -20,6 +20,7 @@
  * Write endpoints:
  *   POST   /api/tasks/:id/cancel
  *   POST   /api/tasks/:id/restart
+ *   POST   /api/tasks/:id/recreate-downstream
  *   POST   /api/tasks/:id/resolve-conflict  body: { agent? }
  *   POST   /api/tasks/:id/approve
  *   POST   /api/tasks/:id/reject       body: { reason? }
@@ -64,6 +65,7 @@ export interface ApiMutationFacade {
   cancelTask(taskId: string): Promise<CancelMutationResult>;
   retryTask(taskId: string): Promise<MutationResult>;
   recreateTask(taskId: string): Promise<MutationResult>;
+  recreateDownstream(taskId: string): Promise<MutationResult>;
   resolveConflict(taskId: string, agentName?: string): Promise<ResolveConflictMutationResult>;
   approveTask(taskId: string): Promise<ApproveMutationResult>;
   rejectTask(taskId: string, reason?: string): void;
@@ -295,6 +297,24 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         try {
           const result = await mutations.recreateTask(taskId);
           json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted: result.runnable.length });
+        } catch (err) {
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
+        }
+        return;
+      }
+
+      // POST /api/tasks/:id/recreate-downstream
+      const recreateDownstreamMatch = path.match(/^\/api\/tasks\/([^/]+)\/recreate-downstream$/);
+      if (method === 'POST' && recreateDownstreamMatch) {
+        const taskId = decodeURIComponent(recreateDownstreamMatch[1]);
+        try {
+          const result = await mutations.recreateDownstream(taskId);
+          json(res, 200, {
+            ok: true,
+            taskId,
+            action: 'recreated_downstream',
+            tasksStarted: result.runnable.length,
+          });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -32,6 +32,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'retry-task', kind: 'write' },
   { name: 'recreate', kind: 'write' },
   { name: 'recreate-task', kind: 'write' },
+  { name: 'recreate-downstream', kind: 'write' },
   { name: 'replace-task', kind: 'special' },
   { name: 'fork-workflow', kind: 'special' },
   { name: 'detach-workflow', kind: 'write' },

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1035,6 +1035,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'recreate-task':
       await headlessRecreateTask(args[1], deps);
       break;
+    case 'recreate-downstream':
+      await headlessRecreateDownstream(args[1], deps);
+      break;
     case 'replace-task':
       throw new Error(
         'Headless replace-task is disabled because it is not a safe supported CLI flow. ' +
@@ -1209,6 +1212,7 @@ ${BOLD}Execute:${RESET}
   retry-task <taskId>                                 Retry a single failed/stuck task
   recreate <workflowId>                                Recreate workflow: wipe all state, new generation
   recreate-task <taskId>                               Recreate task + downstream (task-scoped reset)
+  recreate-downstream <taskId>                         Recreate only downstream of task (preserves selected task)
   fork-workflow <workflowId>                          Fork a live workflow into a new branched workflow (Step 14)
   detach-workflow <workflowId> <upstreamWorkflowId>  Detach one upstream workflow and void downstream to pending
   rebase-retry <workflowId|mergeTaskId|taskId>        Refresh pool base, then retry incomplete work
@@ -1909,6 +1913,73 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
   }
   if (deps.noTrack) {
     process.stdout.write('[headless] --no-track enabled: recreate-task accepted; exiting without tracking.\n');
+    autoFix.unsubscribe();
+    return;
+  }
+  if (workflowId) {
+    await trackHeadlessWorkflow(workflowId, deps, {
+      hasBackgroundWork: autoFix.isBusy,
+      printSummary: false,
+      printTaskOutput: true,
+      setExitCodeOnFailure: false,
+    });
+  }
+  autoFix.unsubscribe();
+}
+
+async function headlessRecreateDownstream(taskId: string, deps: HeadlessDeps): Promise<void> {
+  if (!taskId) {
+    throw new Error('Missing arguments. Usage: --headless recreate-downstream <taskId>');
+  }
+  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'recreate-downstream');
+  if (!restored) return;
+  taskId = restored.resolvedTaskId;
+  if (deps.mutationTiming) {
+    await deps.mutationTiming.span(
+      'headless.recreate-downstream.preemptTaskSubgraph',
+      { taskId },
+      () => preemptTaskSubgraph(taskId, deps),
+    );
+  } else {
+    await preemptTaskSubgraph(taskId, deps);
+  }
+
+  const envelope = makeEnvelope('recreate-downstream', 'headless', 'task', { taskId });
+  const result = deps.mutationTiming
+    ? await deps.mutationTiming.span(
+      'headless.recreate-downstream.commandService.recreateDownstream',
+      { taskId },
+      () => deps.commandService.recreateDownstream(envelope),
+    )
+    : await deps.commandService.recreateDownstream(envelope);
+  if (!result.ok) throw new Error(result.error.message);
+  const started = result.data;
+  const runnable = started.filter(isDispatchableLaunch);
+  const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
+  process.stdout.write(`Recreate downstream of "${taskId}" — ${runnable.length} task(s) to execute (pool fetch skipped)\n`);
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  remoteFetchForPool.enabled = false;
+  let topup: TaskState[] = [];
+  try {
+    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: te,
+      logger: deps.logger,
+      context: 'headless.recreate-downstream',
+      started,
+      ...(workflowId ? { scopedWorkflowId: workflowId } : { scopedTaskIds: [taskId] }),
+      mutationTiming: deps.mutationTiming,
+    }));
+  } finally {
+    remoteFetchForPool.enabled = true;
+  }
+  if (runnable.length + topup.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: recreate-downstream accepted; exiting without tracking.\n');
     autoFix.unsubscribe();
     return;
   }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1018,6 +1018,7 @@ if (isHeadless) {
               return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'high' };
             case 'cancel':
             case 'recreate-task':
+            case 'recreate-downstream':
               return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'high' };
             case 'approve':
             case 'reject':
@@ -2071,6 +2072,7 @@ function createEmbeddedTerminalBackendFromConfig(
         return { workflowId: workflowIdForTargetArg(arg0), priority: 'high' };
       case 'cancel':
       case 'recreate-task':
+      case 'recreate-downstream':
         return { workflowId: workflowIdForTaskArg(arg0), priority: 'high' };
       case 'approve':
       case 'reject':
@@ -2146,6 +2148,8 @@ function createEmbeddedTerminalBackendFromConfig(
         return { channel: 'headless.exec', request: { args: ['recreate', String(arg0)] } };
       case 'invoker:recreate-task':
         return { channel: 'headless.exec', request: { args: ['recreate-task', String(arg0)] } };
+      case 'invoker:recreate-downstream':
+        return { channel: 'headless.exec', request: { args: ['recreate-downstream', String(arg0)] } };
       case 'invoker:retry-workflow':
         return { channel: 'headless.exec', request: { args: ['retry', String(arg0)] } };
       case 'invoker:rebase-retry':
@@ -3497,6 +3501,55 @@ function createEmbeddedTerminalBackendFromConfig(
         }
       } catch (err) {
         logger.error(`recreate-task failed: ${err}`, { module: 'ipc' });
+        throw err;
+      }
+      },
+    );
+
+    registerWorkflowScopedGuiMutationHandler(
+      'invoker:recreate-downstream',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'high',
+      async (taskIdArg: unknown) => {
+      const taskId = String(taskIdArg);
+      logger.info(`recreate-downstream: "${taskId}"`, { module: 'ipc' });
+      try {
+        if (activeMutationContext?.mutationTiming) {
+          await activeMutationContext.mutationTiming.span(
+            'main.ipc.recreate-downstream.preemptTaskSubgraph',
+            { taskId },
+            () => preemptTaskSubgraph(taskId),
+          );
+        } else {
+          await preemptTaskSubgraph(taskId);
+        }
+        const envelope = makeEnvelope('recreate-downstream', 'ui', 'task', { taskId });
+        const result = activeMutationContext?.mutationTiming
+          ? await activeMutationContext.mutationTiming.span(
+            'main.ipc.recreate-downstream.commandService.recreateDownstream',
+            { taskId },
+            () => commandService.recreateDownstream(envelope),
+          )
+          : await commandService.recreateDownstream(envelope);
+        if (!result.ok) throw new Error(result.error.message);
+        const started = result.data;
+        const scopedWorkflowId = workflowIdForTaskArg(taskIdArg);
+        remoteFetchForPool.enabled = false;
+        try {
+          await dispatchStartedTasksWithGlobalTopup({
+            orchestrator,
+            taskExecutor: requireTaskExecutor(),
+            logger,
+            context: 'ipc.recreate-downstream',
+            started,
+            scopedWorkflowId,
+            mutationTiming: activeMutationContext?.mutationTiming,
+          });
+        } finally {
+          remoteFetchForPool.enabled = true;
+        }
+      } catch (err) {
+        logger.error(`recreate-downstream failed: ${err}`, { module: 'ipc' });
         throw err;
       }
       },

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -259,6 +259,13 @@ export function recreateTask(
   return deps.orchestrator.recreateTask(taskId);
 }
 
+export function recreateDownstream(
+  taskId: string,
+  deps: Pick<ActionDeps, 'orchestrator'>,
+): TaskState[] {
+  return deps.orchestrator.recreateDownstream(taskId);
+}
+
 export function cancelWorkflow(
   workflowId: string,
   deps: Pick<ActionDeps, 'orchestrator'>,

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -29,6 +29,7 @@ import {
   retryWorkflow as sharedRetryWorkflow,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
+  recreateDownstream as sharedRecreateDownstream,
   recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
   rebaseRetry as sharedRebaseRetry,
   rebaseRecreate as sharedRebaseRecreate,
@@ -173,6 +174,21 @@ export class WorkflowMutationFacade {
       }),
     );
     return this.finalizeWithTopup(started, 'facade.recreate-task', { scopedTaskIds: [taskId] });
+  }
+
+  async recreateDownstream(taskId: string): Promise<MutationResult> {
+    const started = await this.runViaCommandService(
+      'task',
+      taskId,
+      (cs) => cs.recreateDownstream(makeEnvelope('facade.recreate-downstream', 'surface', 'task', { taskId })),
+      () => sharedRecreateDownstream(taskId, { orchestrator: this.deps.orchestrator }),
+    );
+    const scopedWorkflowId = this.deps.orchestrator.getTask(taskId)?.config.workflowId;
+    return this.finalizeWithTopup(
+      started,
+      'facade.recreate-downstream',
+      scopedWorkflowId ? { scopedWorkflowId } : { scopedTaskIds: [taskId] },
+    );
   }
 
   async selectExperiment(taskId: string, experimentId: string): Promise<MutationResult> {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -481,6 +481,16 @@ export const IpcChannels = {
     request: [taskId: string];
     response: void;
   },
+  /**
+   * Recreate only a task's downstream dependents. The target task
+   * itself is preserved (status, branch, commit, workspacePath,
+   * selectedAttemptId, generation); descendants receive recreate-class
+   * fresh lineage and are auto-started.
+   */
+  'invoker:recreate-downstream': {} as {
+    request: [taskId: string];
+    response: void;
+  },
   'invoker:retry-workflow': {} as {
     request: [workflowId: string];
     response: void;

--- a/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
@@ -92,6 +92,65 @@ describe('InvalidationPlan policy registry', () => {
     });
   });
 
+  it('plans task recreate-downstream as descendants only, excluding the target', () => {
+    const tasks = [
+      task('wf-1/root', 'wf-1'),
+      task('wf-1/child', 'wf-1', ['wf-1/root']),
+      task('wf-1/grandchild', 'wf-1', ['wf-1/child']),
+      task('wf-1/sibling', 'wf-1'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/root',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'recreateDownstream',
+      scope: 'task',
+      mode: 'recreate',
+      affectedWorkflowIds: ['wf-1'],
+      // Target 'wf-1/root' is preserved; siblings are untouched.
+      affectedTaskIds: ['wf-1/child', 'wf-1/grandchild'],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+  });
+
+  it('plans recreate-downstream of a mid-chain task as the strictly-downstream tail', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/b', 'wf-1', ['wf-1/a']),
+      task('wf-1/c', 'wf-1', ['wf-1/b']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/b',
+      tasks,
+    });
+
+    // recreateDownstream(B) over A -> B -> C affects C only.
+    expect(plan.affectedTaskIds).toEqual(['wf-1/c']);
+  });
+
+  it('plans recreate-downstream of a leaf as an empty affected set (no-op)', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/b', 'wf-1', ['wf-1/a']),
+      task('wf-1/c', 'wf-1', ['wf-1/b']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/c',
+      tasks,
+    });
+
+    expect(plan.affectedTaskIds).toEqual([]);
+    expect(plan.affectedWorkflowIds).toEqual([]);
+  });
+
   it('plans task retry as the task plus non-completed descendants', () => {
     const tasks = [
       task('wf-1/root', 'wf-1', [], 'failed'),

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -525,6 +525,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
   'fixReject',
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',
@@ -534,6 +535,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
 const INVALIDATING_ACTIONS: readonly InvalidationAction[] = [
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5845,6 +5845,176 @@ describe('Orchestrator', () => {
       expect(x.execution.workspacePath).toBe('/tmp/x');
     });
 
+    // ── recreateDownstream ───────────────────────────────────
+    //
+    // Builds an A -> B -> C chain (plus an unrelated root X and the
+    // workflow merge gate) directly in persistence so each test
+    // exercises the primitive in isolation, mirroring the
+    // `recreateTask resets only target + downstream` fixture above.
+    function buildDownstreamChain(wf: string) {
+      const testPersistence = new InMemoryPersistence();
+      const testBus = new InMemoryBus();
+
+      testPersistence.saveTask(wf, {
+        id: 'A',
+        description: 'Root',
+        status: 'completed',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-a',
+          commit: 'a1',
+          workspacePath: '/tmp/a',
+          agentSessionId: 'sess-a',
+          containerId: 'cont-a',
+          selectedAttemptId: 'A-att',
+          generation: 5,
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'B',
+        description: 'Middle',
+        status: 'completed',
+        dependencies: ['A'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-b',
+          commit: 'b1',
+          workspacePath: '/tmp/b',
+          agentSessionId: 'sess-b',
+          containerId: 'cont-b',
+          generation: 2,
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'C',
+        description: 'Leaf',
+        status: 'completed',
+        dependencies: ['B'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-c',
+          commit: 'c1',
+          workspacePath: '/tmp/c',
+          agentSessionId: 'sess-c',
+          containerId: 'cont-c',
+          generation: 2,
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'X',
+        description: 'Unrelated root',
+        status: 'completed',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: { branch: 'br-x', commit: 'x1', workspacePath: '/tmp/x', exitCode: 0 },
+      });
+
+      const testOrchestrator = new Orchestrator({
+        persistence: testPersistence,
+        messageBus: testBus,
+        maxConcurrency: 3,
+      });
+      testOrchestrator.syncFromDb(wf);
+      return testOrchestrator;
+    }
+
+    it('recreateDownstream(A) preserves the target and resets B and C', () => {
+      const o = buildDownstreamChain('wf-recreate-downstream-root');
+
+      const started = o.recreateDownstream('A');
+
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+      const x = o.getTask('X')!;
+
+      // Target A is fully preserved: status, lineage, metadata, the
+      // selected attempt, and the execution generation are unchanged.
+      expect(a.status).toBe('completed');
+      expect(a.execution.branch).toBe('br-a');
+      expect(a.execution.commit).toBe('a1');
+      expect(a.execution.workspacePath).toBe('/tmp/a');
+      expect(a.execution.agentSessionId).toBe('sess-a');
+      expect(a.execution.containerId).toBe('cont-a');
+      expect(a.execution.selectedAttemptId).toBe('A-att');
+      expect(a.execution.generation).toBe(5);
+
+      // Descendants are reset recreate-class: no longer completed,
+      // lineage + session/container metadata cleared, generation bumped.
+      expect(b.status).not.toBe('completed');
+      expect(b.execution.branch).toBeUndefined();
+      expect(b.execution.commit).toBeUndefined();
+      expect(b.execution.workspacePath).toBeUndefined();
+      expect(b.execution.agentSessionId).toBeUndefined();
+      expect(b.execution.containerId).toBeUndefined();
+      expect(b.execution.generation).toBe(3);
+
+      expect(c.status).toBe('pending');
+      expect(c.execution.branch).toBeUndefined();
+      expect(c.execution.workspacePath).toBeUndefined();
+      expect(c.execution.generation).toBe(3);
+
+      // Unrelated root X is untouched.
+      expect(x.status).toBe('completed');
+      expect(x.execution.branch).toBe('br-x');
+
+      // Ready descendant B (its only dependency A stayed completed) is
+      // returned for dispatch; the preserved target A never is.
+      const startedIds = started.map((t) => t.id);
+      expect(startedIds).toContain('B');
+      expect(startedIds).not.toContain('A');
+    });
+
+    it('recreateDownstream(B) resets C only, leaving A and B unchanged', () => {
+      const o = buildDownstreamChain('wf-recreate-downstream-mid');
+
+      o.recreateDownstream('B');
+
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+
+      // A and the target B are both preserved.
+      expect(a.status).toBe('completed');
+      expect(a.execution.generation).toBe(5);
+      expect(b.status).toBe('completed');
+      expect(b.execution.branch).toBe('br-b');
+      expect(b.execution.workspacePath).toBe('/tmp/b');
+      expect(b.execution.agentSessionId).toBe('sess-b');
+      expect(b.execution.generation).toBe(2);
+
+      // Only C is reset.
+      expect(c.status).not.toBe('completed');
+      expect(c.execution.branch).toBeUndefined();
+      expect(c.execution.workspacePath).toBeUndefined();
+      expect(c.execution.generation).toBe(3);
+    });
+
+    it('recreateDownstream(leaf) is a no-op that returns no started tasks', () => {
+      const o = buildDownstreamChain('wf-recreate-downstream-leaf');
+
+      const started = o.recreateDownstream('C');
+
+      const c = o.getTask('C')!;
+
+      // Leaf C is fully preserved and nothing is dispatched.
+      expect(started).toEqual([]);
+      expect(c.status).toBe('completed');
+      expect(c.execution.branch).toBe('br-c');
+      expect(c.execution.commit).toBe('c1');
+      expect(c.execution.workspacePath).toBe('/tmp/c');
+      expect(c.execution.agentSessionId).toBe('sess-c');
+      expect(c.execution.generation).toBe(2);
+    });
+
     it('drainScheduler sets lastHeartbeatAt when starting a task', () => {
       orchestrator.loadPlan({
         name: 'heartbeat-start-test',

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -166,6 +166,23 @@ export class CommandService {
   }
 
   /**
+   * Recreate only a task's downstream dependents. The selected task is
+   * preserved exactly (status, branch, commit, workspacePath,
+   * selectedAttemptId, agent/session/container metadata, and
+   * generation); descendants receive recreate-class fresh lineage and
+   * are auto-started through the existing dispatch path.
+   */
+  async recreateDownstream(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'RECREATE_DOWNSTREAM_FAILED',
+      () => applyInvalidation('task', 'recreateDownstream', envelope.payload.taskId, this.invalidationDeps),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
+  /**
    * @deprecated Step 13 (`docs/architecture/task-invalidation-roadmap.md`):
    * `restartTask` was the overloaded "retry-or-recreate" verb the
    * chart's "Naming inconsistency" section flagged. Use the explicit

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -8,6 +8,7 @@ export type InvalidationAction =
   | 'retryTask'
   | 'retryWorkflow'
   | 'recreateTask'
+  | 'recreateDownstream'
   | 'recreateWorkflow'
   | 'recreateWorkflowFromFreshBase'
   | 'workflowFork';
@@ -70,6 +71,14 @@ export interface InvalidationDeps {
   cancelInFlight: CancelInFlightFn;
   retryTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   recreateTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  /**
+   * Recreate-class reset of the target's transitive downstream subgraph,
+   * leaving the target task itself untouched. Optional so existing
+   * `InvalidationDeps` builders (and tests) need not supply it; the
+   * router throws an explicit missing-dep error if the action is routed
+   * without it wired.
+   */
+  recreateDownstream?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   retryWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflowFromFreshBase?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
@@ -247,6 +256,18 @@ export const ACTION_SPECS: Readonly<Record<InvalidationAction, ActionSpec>> = Ob
     reason: 'task.recreate',
     selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
   },
+  // Like `recreateTask`, but the target task is preserved: only its
+  // transitive downstream dependents are reset (recreate-class). The
+  // affected set is `descendantsOf(target)` — the target itself is never
+  // included, so a leaf target yields an empty set (no-op).
+  recreateDownstream: {
+    scope: 'task',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'task.recreateDownstream',
+    selectAffectedTasks: ({ targetId, tasks }) => descendantsOf(targetId, taskMap(tasks)),
+  },
   retryWorkflow: {
     scope: 'workflow',
     stages: INVALIDATING_STAGES,
@@ -377,6 +398,17 @@ async function invokePrimitive(
       return await deps.retryTask(ctx.id);
     case 'recreateTask':
       return await deps.recreateTask(ctx.id);
+    case 'recreateDownstream': {
+      if (!deps.recreateDownstream) {
+        throw new Error(
+          "applyInvalidation: 'recreateDownstream' dep is missing. " +
+            'Production callers wire this via buildInvalidationDeps in ' +
+            '@invoker/app/workflow-actions; tests must supply ' +
+            'deps.recreateDownstream to use this action.',
+        );
+      }
+      return await deps.recreateDownstream(ctx.id);
+    }
     case 'retryWorkflow':
       return await deps.retryWorkflow(ctx.id);
     case 'recreateWorkflow':
@@ -425,6 +457,7 @@ export interface InvalidationDepsOrchestrator {
   cancelWorkflow(workflowId: string): { runningCancelled: string[] };
   retryTask(taskId: string): TaskState[];
   recreateTask(taskId: string): TaskState[];
+  recreateDownstream(taskId: string): TaskState[];
   retryWorkflow(workflowId: string): TaskState[];
   recreateWorkflow(workflowId: string): TaskState[];
   recreateWorkflowFromFreshBase(workflowId: string): Promise<TaskState[]>;
@@ -487,6 +520,7 @@ export function buildOrchestratorOnlyInvalidationDeps(
     cancelInFlight: buildCancelInFlight({ orchestrator }),
     retryTask: (taskId) => orchestrator.retryTask(taskId),
     recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    recreateDownstream: (taskId) => orchestrator.recreateDownstream(taskId),
     retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
     recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
     recreateWorkflowFromFreshBase: (workflowId) =>

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1093,6 +1093,7 @@ export class Orchestrator {
   private cancelActiveBeforeInvalidation(
     scope: 'task' | 'workflow',
     id: string,
+    opts?: { excludeRoot?: boolean },
   ): string[] {
     let candidates: TaskState[];
     if (scope === 'task') {
@@ -1105,8 +1106,11 @@ export class Orchestrator {
         taskMap,
         (t) => t.status === 'completed' || t.status === 'stale',
       );
+      // `recreateDownstream` preserves the target task, so its
+      // cancel-first pass must skip the root and only interrupt
+      // active attempts in the downstream subgraph.
       candidates = [
-        root,
+        ...(opts?.excludeRoot ? [] : [root]),
         ...descendantIds
           .map((d) => taskMap.get(d))
           .filter((t): t is TaskState => !!t),
@@ -2514,6 +2518,100 @@ export class Orchestrator {
     };
 
     this.logger.info('[orchestrator] recreateTask reset', {
+      taskId: rootId,
+      resetCount: toResetIds.length,
+    });
+
+    for (const id of toResetIds) {
+      const current = this.stateGetTask(id);
+      if (!current) continue;
+      const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
+      const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
+      const priorAttemptId = current.execution.selectedAttemptId;
+      this.replaceSelectedAttempt(current);
+      this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(current, recreateUpdated, changesWithGeneration));
+
+      this.deferredTaskIds.delete(id);
+      this.clearQueuedSchedulerEntries(id, priorAttemptId);
+    }
+
+    const readyIds = this.stateMachine
+      .getReadyTasks()
+      .map((t) => t.id)
+      .filter((id) => toResetSet.has(id));
+    plan = withSchedulerEnqueueCandidates(plan, readyIds);
+    this.lastInvalidationPlan = plan;
+    return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
+  }
+
+  /**
+   * Task-scoped downstream recreate: reset the target's transitive
+   * downstream dependents to pending with recreate-style execution
+   * clearing, leaving the target task itself untouched, then auto-start
+   * newly-ready descendants within that affected subgraph.
+   *
+   * Differs from `recreateTask` only in that the target is preserved:
+   * the affected set is `descendantsOf(target)` (the target is never
+   * included). A leaf target has no descendants, so this is a no-op
+   * that returns no started tasks.
+   */
+  recreateDownstream(taskId: string): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+
+    const rootId = task.id;
+
+    // Step 18 cancel-first invariant, scoped to the downstream subgraph:
+    // interrupt active attempts on the dependents BEFORE the recreate
+    // reset, but never touch the preserved target task. Defense-in-depth
+    // for direct callers; a no-op when invoked through `applyInvalidation`.
+    this.cancelActiveBeforeInvalidation('task', rootId, { excludeRoot: true });
+    let plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: rootId,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
+    const toResetIds = plan.affectedTaskIds;
+    const toResetSet = new Set(toResetIds);
+
+    // Leaf target: no downstream dependents → preserve the target and
+    // start nothing.
+    if (toResetIds.length === 0) {
+      this.logger.info('[orchestrator] recreateDownstream no-op (leaf target)', {
+        taskId: rootId,
+      });
+      return [];
+    }
+
+    const resetChanges: TaskStateChanges = {
+      status: 'pending',
+      config: { summary: undefined },
+      execution: {
+        autoFixAttempts: 0,
+        startedAt: undefined,
+        completedAt: undefined,
+        error: undefined,
+        exitCode: undefined,
+        commit: undefined,
+        branch: undefined,
+        workspacePath: undefined,
+        lastHeartbeatAt: undefined,
+        phase: undefined,
+        launchStartedAt: undefined,
+        launchCompletedAt: undefined,
+        reviewUrl: undefined,
+        reviewId: undefined,
+        reviewStatus: undefined,
+        reviewProviderId: undefined,
+        agentSessionId: undefined,
+        containerId: undefined,
+      },
+    };
+
+    this.logger.info('[orchestrator] recreateDownstream reset', {
       taskId: rootId,
       resetCount: toResetIds.length,
     });


### PR DESCRIPTION
## Summary

Wire the existing workflow-core `recreateDownstream` primitive through every app-bridge layer so renderer / headless / HTTP entry points can recreate-reset only a task's transitive downstream dependents while preserving the selected task's status, branch, commit, workspacePath, selectedAttemptId, agent/session/container metadata, and execution generation.

- New IPC channel `invoker:recreate-downstream` is auto-exposed on `window.invoker.recreateDownstream(taskId)` via the existing contracts → preload runtime derivation.
- New main-process handler routes through `CommandService.recreateDownstream` and dispatches started downstream tasks through the established `dispatchStartedTasksWithGlobalTopup` lifecycle (scoped by the workflow containing the seed task).
- New `./run.sh --headless recreate-downstream <taskId>` command flows through the same `CommandService` seam and respects `--no-track`.
- New `POST /api/tasks/:id/recreate-downstream` route goes through the shared `WorkflowMutationFacade` and returns a concrete `{ ok, taskId, action: 'recreated_downstream', tasksStarted }` response.
- `recreate-task`, `retry-task`, `recreate-workflow`, and `retry-workflow` behavior is unchanged; the new verb is additive.

Renderer context-menu UI, visual proof scenarios, and screenshots are intentionally deferred to a later slice — this PR is the bridge slice only.

## Architecture

### Before

```mermaid
flowchart LR
  UI[Renderer / Headless / API] -- recreate-task --> IPC[invoker:recreate-task]
  IPC --> CS[CommandService.recreateTask]
  CS --> ORCH[Orchestrator.recreateTask]
  ORCH --> SEED[(Seed task: RESET)]
  ORCH --> DESC[(Descendants: RESET)]
  ORCH -.no entry point.-> DOWN[Orchestrator.recreateDownstream]
  style DOWN stroke-dasharray: 4 4,color:#888
```

### After

```mermaid
flowchart LR
  UI[Renderer / Headless / API]
  UI -- recreate-task --> IPC1[invoker:recreate-task]
  UI -- recreate-downstream --> IPC2[invoker:recreate-downstream]
  IPC1 --> CS1[CommandService.recreateTask]
  IPC2 --> CS2[CommandService.recreateDownstream]
  CS1 --> ORCH1[Orchestrator.recreateTask]
  CS2 --> ORCH2[Orchestrator.recreateDownstream]
  ORCH1 --> SEEDR[(Seed task: RESET)]
  ORCH1 --> DESCR[(Descendants: RESET)]
  ORCH2 --> SEEDK[(Seed task: PRESERVED)]
  ORCH2 --> DESCR2[(Descendants only: RESET)]
```

The new path reuses the same mutex serialization, dispatch, and global-topup primitives as the existing recreate-class verbs; only the affected set differs (descendants only vs. seed + descendants).

## Test Plan

- [x] `cd packages/app && pnpm test src/__tests__/headless-client.test.ts src/__tests__/api-server.test.ts` — 2 test files, 93 tests pass, including a new headless-client test that asserts `recreate-downstream <taskId> --no-track` delegates to the standalone owner endpoint and 5 new api-server tests covering happy-path routing, isolation from retry/recreate-task/recreate-workflow, 400 on domain failure, 404 on `TASK_NOT_FOUND`, and global top-up after the scoped downstream recreate.
- [x] `cd packages/app && pnpm test` — full app suite (66 files, 1016 tests) passes.
- [x] `cd packages/workflow-core && pnpm test` — full workflow-core suite (49 files, 1046 tests) passes after adding `CommandService.recreateDownstream`.
- [x] `pnpm -F @invoker/app build` — typecheck / tsup build clean.

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — the orchestrator primitive remains and no callers outside this PR depend on the new IPC channel, REST route, headless command, or facade method.
- Data migration? No