### PR TITLE
Recreate Downstream Stack 20260601133250 3: Task menu activation

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1011,6 +1011,25 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'workflow-context-menu-organization');
   });
 
+  test('task context menu shows Recreate Downstream action', async ({ page }) => {
+    await loadPlanAndSelectWorkflow(page, MENU_PROOF_PLAN);
+
+    const taskMenu = await openContextMenu(page, page.locator('.react-flow__node[data-testid$="task-alpha"]'));
+    await page.getByRole('menuitem', { name: 'More' }).click();
+    await expect(taskMenu.getByRole('menuitem', { name: 'Recreate from Task' })).toBeVisible();
+    await expect(taskMenu.getByRole('menuitem', { name: 'Recreate Downstream' })).toBeVisible();
+
+    await captureScreenshot(page, 'task-context-menu-recreate-downstream');
+
+    await page.keyboard.press('Escape');
+    await expect(taskMenu).toBeHidden();
+
+    const workflowMenu = await openContextMenu(page, page.locator('[data-testid^="workflow-node-"]'));
+    await page.getByRole('menuitem', { name: 'More' }).click();
+    await expect(workflowMenu.getByRole('menuitem', { name: 'Recreate Workflow' })).toBeVisible();
+    await expect(workflowMenu.getByRole('menuitem', { name: 'Recreate Downstream' })).toHaveCount(0);
+  });
+
   test('context menu keeps danger separator when cancel action is absent', async ({ page }) => {
     await loadPlan(page, TEST_PLAN);
     await injectTaskStates(page, [

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
-import { TaskRunner, type LaunchOutboxAck } from '../task-runner.js';
+import { TaskRunner, type LaunchOutboxAck, type TaskRunnerCallbacks } from '../task-runner.js';
 import { ResourceLimitError } from '../repo-pool.js';
 
 function makeLogger(): Logger {
@@ -52,12 +52,13 @@ interface RunnerEnv {
     destroyAll: ReturnType<typeof vi.fn>;
     type: string;
   };
-  triggerComplete: () => void;
+  triggerComplete: (response?: Partial<WorkResponse>) => void;
 }
 
 function buildRunnerEnv(task: TaskState, options: {
   startThrows?: Error;
   startImpl?: (request: any) => Promise<any>;
+  callbacks?: TaskRunnerCallbacks;
 } = {}): RunnerEnv {
   let completeCallback: ((response: WorkResponse) => void) | undefined;
   const executor = {
@@ -103,13 +104,14 @@ function buildRunnerEnv(task: TaskState, options: {
     } as any,
     cwd: '/tmp/test-runner-dispatch',
     logger: makeLogger(),
+    callbacks: options.callbacks,
   });
   return {
     runner,
     persistence,
     orchestrator,
     executor,
-    triggerComplete: () => {
+    triggerComplete: (response?: Partial<WorkResponse>) => {
       completeCallback?.({
         requestId: 'req',
         actionId: task.id,
@@ -117,6 +119,7 @@ function buildRunnerEnv(task: TaskState, options: {
         executionGeneration: task.execution.generation ?? 0,
         status: 'completed',
         outputs: { exitCode: 0 },
+        ...response,
       });
     },
   };
@@ -268,6 +271,35 @@ describe('TaskRunner launch-dispatch wiring', () => {
     expect(env.executor.start).toHaveBeenCalledTimes(1);
     expect(env.executor.start.mock.calls[0]?.[0].actionId).toBe(task.id);
     expect(launchOutbox.completeCalls).toEqual([314]);
+  });
+
+  it('commits review_ready before app completion observers can fail', async () => {
+    const task = makeTask({
+      id: 'wf-d/review-gate-response',
+      description: 'review gate response',
+      status: 'running',
+      config: { workflowId: 'wf-d' },
+      execution: { selectedAttemptId: 'review-attempt-1', generation: 2, phase: 'launching' },
+    });
+    const onComplete = vi.fn(() => {
+      throw new Error('observer failed after output flush');
+    });
+    const env = buildRunnerEnv(task, { callbacks: { onComplete } });
+
+    const run = env.runner.executeTask(task);
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    env.triggerComplete({
+      status: 'review_ready',
+      outputs: { exitCode: 0, summary: 'ready for review' },
+    });
+    await run;
+
+    const statuses = env.orchestrator.handleWorkerResponse.mock.calls.map(([response]) => response.status);
+    expect(statuses).toEqual(['review_ready']);
+    expect(onComplete).toHaveBeenCalledWith(
+      task.id,
+      expect.objectContaining({ status: 'review_ready' }),
+    );
   });
 
   it('fails the dispatch and short-circuits when the attempt is already launching', async () => {

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -686,7 +686,6 @@ export async function executeMergeNodeImpl(
   };
 
   host.persistence.updateTask(task.id, legacyChanges);
-  host.callbacks.onComplete?.(task.id, response);
 
   if (response.status === 'review_ready') {
     setMergeGateReviewReady(host, task.id, legacyChanges);
@@ -696,6 +695,14 @@ export async function executeMergeNodeImpl(
     if (newlyStarted.length > 0) {
       host.executeTasks(newlyStarted);
     }
+  }
+
+  try {
+    host.callbacks.onComplete?.(task.id, response);
+  } catch (err) {
+    console.warn(
+      `[merge] completion callback observer failed for ${task.id}: ${err instanceof Error ? err.message : String(err)}`,
+    );
   }
 }
 

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -669,8 +669,12 @@ export class TaskRunner {
           error: err instanceof Error ? (err.stack ?? err.message) : String(err),
         },
       };
-      this.callbacks.onComplete?.(task.id, response);
       const newlyStarted = this.orchestrator.handleWorkerResponse(response) ?? [];
+      try {
+        this.callbacks.onComplete?.(task.id, response);
+      } catch (callbackErr) {
+        this.logger.error(`[TaskRunner] completion callback observer failed for task=${task.id}`, { err: callbackErr });
+      }
       this.executeNewlyStartedTasks(newlyStarted, dispatchOpts);
     } finally {
       this.launchingAttemptIds.delete(attemptId);
@@ -1203,36 +1207,57 @@ export class TaskRunner {
               `status=${normalizedResponse.status} exitCode=${normalizedResponse.outputs.exitCode ?? 'none'} ` +
               `executionId=${handle.executionId} activeExecutions=${this.activeExecutions.size}`,
           );
+          let newlyStarted: TaskState[] = [];
           try {
-            traceExecution(
-              `[task-runner] onComplete taskId=${task.id} responseStatus=${response.status} ` +
-                `responseAttemptId=${normalizedResponse.attemptId ?? attemptId} responseGeneration=${response.executionGeneration} executionId=${handle.executionId}`,
-            );
-            traceExecution(
-              `${RESTART_TO_BRANCH_TRACE} resolvePromise | task.config.isMergeNode = ${task.config.isMergeNode}`,
-            );
-            this.callbacks.onComplete?.(task.id, normalizedResponse);
+            try {
+              traceExecution(
+                `[task-runner] onComplete taskId=${task.id} responseStatus=${response.status} ` +
+                  `responseAttemptId=${normalizedResponse.attemptId ?? attemptId} responseGeneration=${response.executionGeneration} executionId=${handle.executionId}`,
+              );
+              traceExecution(
+                `${RESTART_TO_BRANCH_TRACE} resolvePromise | task.config.isMergeNode = ${task.config.isMergeNode}`,
+              );
+              newlyStarted = this.orchestrator.handleWorkerResponse(normalizedResponse) ?? [];
+            } catch (err) {
+              this.logger.error(`[TaskRunner] worker response handling failed for task=${task.id}`, { err });
+              const errResponse: WorkResponse = {
+                requestId: response.requestId,
+                actionId: task.id,
+                attemptId,
+                executionGeneration: task.execution.generation ?? 0,
+                status: 'failed',
+                outputs: {
+                  exitCode: 1,
+                  error: err instanceof Error ? (err.stack ?? err.message) : String(err),
+                },
+              };
+              try {
+                this.orchestrator.handleWorkerResponse(errResponse);
+              } catch (fallbackErr) {
+                this.logger.error(`[TaskRunner] fallback failure response handling failed for task=${task.id}`, { err: fallbackErr });
+              }
+              try {
+                this.callbacks.onComplete?.(task.id, errResponse);
+              } catch (callbackErr) {
+                this.logger.error(`[TaskRunner] completion callback observer failed for task=${task.id}`, { err: callbackErr });
+              }
+              return;
+            }
 
-            const newlyStarted = this.orchestrator.handleWorkerResponse(normalizedResponse) ?? [];
+            try {
+              this.callbacks.onComplete?.(task.id, normalizedResponse);
+            } catch (err) {
+              this.logger.error(`[TaskRunner] completion callback observer failed for task=${task.id}`, { err });
+            }
+
             this.executeNewlyStartedTasks(newlyStarted, dispatchOpts);
-          } catch (err) {
-            this.logger.error(`[TaskRunner] onComplete handler failed for task=${task.id}`, { err });
-            const errResponse: WorkResponse = {
-              requestId: response.requestId,
-              actionId: task.id,
-              attemptId,
-              executionGeneration: task.execution.generation ?? 0,
-              status: 'failed',
-              outputs: {
-                exitCode: 1,
-                error: err instanceof Error ? (err.stack ?? err.message) : String(err),
-              },
-            };
-            this.callbacks.onComplete?.(task.id, errResponse);
-            this.orchestrator.handleWorkerResponse(errResponse);
           } finally {
             // Clean up per-task Docker executor to avoid resource leaks
-            await this.cleanupPerTaskDockerExecutor(task);
+            try {
+              await this.cleanupPerTaskDockerExecutor(task);
+            } catch (cleanupErr) {
+              this.logger.warn(`[TaskRunner] completion cleanup failed for task=${task.id}`, { err: cleanupErr });
+            }
           }
         };
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1222,6 +1222,15 @@ export function App() {
     }
   }, []);
 
+  const handleRecreateDownstream = useCallback(async (taskId: string) => {
+    setContextMenu(null);
+    try {
+      await window.invoker?.recreateDownstream(taskId);
+    } catch (err) {
+      console.error('Recreate Downstream failed:', err);
+    }
+  }, []);
+
   const handleDeleteWorkflow = useCallback(async (workflowId: string) => {
     setContextMenu(null);
     const confirmed = window.confirm(
@@ -2028,6 +2037,7 @@ export function App() {
           onReplace={handleReplaceTask}
           onOpenTerminal={handleOpenTerminal}
           onRecreateTask={handleRecreateTask}
+          onRecreateDownstream={handleRecreateDownstream}
           onFix={handleFix}
           onCancel={handleCancelTask}
           onClose={closeContextMenu}

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -64,9 +64,12 @@ describe('Context menu (component)', () => {
     mock.cleanup();
   });
 
-  async function setup() {
+  async function setup(
+    tasks = [alpha, beta, merge],
+    workflowList = workflows,
+  ) {
     render(<App />);
-    act(() => mock.setTasks([alpha, beta, merge], workflows));
+    act(() => mock.setTasks(tasks, workflowList));
 
     await waitFor(() => {
       expect(screen.getByTestId('workflow-node-wf-1')).toBeInTheDocument();
@@ -83,10 +86,12 @@ describe('Context menu (component)', () => {
       expect(screen.getByText('Copy Workflow ID')).toBeInTheDocument();
       expect(screen.getByText('More')).toBeInTheDocument();
     });
+    expect(screen.queryByText('Recreate Downstream')).not.toBeInTheDocument();
     expect(screen.queryByText('Recreate Workflow')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('More'));
     expect(await screen.findByText('Rebase and Retry')).toBeInTheDocument();
     expect(screen.getByText('Rebase and Recreate')).toBeInTheDocument();
+    expect(screen.queryByText('Recreate Downstream')).not.toBeInTheDocument();
   });
 
   it('task context menu still works in mini DAG', async () => {
@@ -103,6 +108,64 @@ describe('Context menu (component)', () => {
     expect(screen.queryByText('Retry Workflow')).not.toBeInTheDocument();
     expect(screen.queryByText('Cancel Workflow')).not.toBeInTheDocument();
     expect(screen.queryByText('Delete Workflow')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('More'));
+    expect(await screen.findByText('Recreate from Task')).toBeInTheDocument();
+    expect(screen.getByText('Recreate Downstream')).toBeInTheDocument();
+    expect(screen.getByText('Terminate Task')).toBeInTheDocument();
+  });
+
+  it('task context menu calls recreateDownstream for workflow-owned tasks', async () => {
+    await setup();
+    fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    fireEvent.click(await screen.findByText('More'));
+    fireEvent.click(await screen.findByText('Recreate Downstream'));
+
+    await waitFor(() => expect(mock.api.recreateDownstream).toHaveBeenCalledWith('task-alpha'));
+    expect(mock.api.recreateTask).not.toHaveBeenCalled();
+  });
+
+  it('task context menu disables Recreate Downstream while the task is running', async () => {
+    const runningTask = makeUITask({
+      id: 'task-running',
+      description: 'Running workflow task',
+      status: 'running',
+      command: 'sleep 30',
+      workflowId: 'wf-1',
+    });
+
+    await setup([runningTask]);
+    fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-task-running')).toBeInTheDocument();
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('rf__node-task-running'));
+    fireEvent.click(await screen.findByText('More'));
+    const recreateDownstream = await screen.findByRole('menuitem', { name: 'Recreate Downstream' });
+
+    expect(recreateDownstream).toBeDisabled();
+    fireEvent.click(recreateDownstream);
+    expect(mock.api.recreateDownstream).not.toHaveBeenCalled();
+  });
+
+  it('task context menu keeps Recreate from Task routed to recreateTask', async () => {
+    await setup();
+    fireEvent.click(screen.getByTestId('workflow-node-wf-1'));
+    await waitFor(() => {
+      expect(screen.getByTestId('rf__node-task-alpha')).toBeInTheDocument();
+    });
+
+    fireEvent.contextMenu(screen.getByTestId('rf__node-task-alpha'));
+    fireEvent.click(await screen.findByText('More'));
+    fireEvent.click(await screen.findByText('Recreate from Task'));
+
+    await waitFor(() => expect(mock.api.recreateTask).toHaveBeenCalledWith('task-alpha'));
+    expect(mock.api.recreateDownstream).not.toHaveBeenCalled();
   });
 
   it('workflow context menu retries workflow', async () => {

--- a/packages/ui/src/__tests__/context-menu.test.ts
+++ b/packages/ui/src/__tests__/context-menu.test.ts
@@ -122,6 +122,36 @@ describe('ContextMenu getMenuItems', () => {
       expect(recreateTask).toBeDefined();
       expect(recreateTask?.action).toBe('onRecreateTask');
     });
+
+    it('shows Recreate Downstream for workflow-owned tasks', () => {
+      const task = makeTask({ status: 'failed', workflowId: 'wf-1' });
+      const items = getMenuItems(task);
+
+      const recreateDownstream = items.find((item) => item.id === 'recreate-downstream');
+      expect(recreateDownstream).toBeDefined();
+      expect(recreateDownstream).toMatchObject({
+        label: 'Recreate Downstream',
+        enabled: true,
+        action: 'onRecreateDownstream',
+        variant: 'danger',
+      });
+    });
+
+    it('hides Recreate Downstream for non-workflow tasks', () => {
+      const task = makeTask({ status: 'failed' });
+      const items = getMenuItems(task);
+
+      expect(items.find((item) => item.id === 'recreate-downstream')).toBeUndefined();
+    });
+
+    it('disables Recreate Downstream while the task is running', () => {
+      const task = makeTask({ status: 'running', workflowId: 'wf-1' });
+      const items = getMenuItems(task);
+
+      const recreateDownstream = items.find((item) => item.id === 'recreate-downstream');
+      expect(recreateDownstream).toBeDefined();
+      expect(recreateDownstream?.enabled).toBe(false);
+    });
   });
 
   describe('Restart visibility', () => {
@@ -226,7 +256,7 @@ describe('ContextMenu getMenuItems', () => {
       const task = makeTask({ status: 'failed', workflowId: 'wf-1' });
       const items = getMenuItems(task);
 
-      const dangerIds = ['cancel-task', 'recreate-task'];
+      const dangerIds = ['cancel-task', 'recreate-task', 'recreate-downstream'];
       dangerIds.forEach((id) => {
         const item = items.find((i) => i.id === id);
         expect(item?.variant).toBe('danger');

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -158,6 +158,7 @@ export function createMockInvoker(
     cleanupWorktrees: vi.fn(async () => ({ removed: [], errors: [] })),
     recreateWorkflow: vi.fn(async () => {}),
     recreateTask: vi.fn(async () => {}),
+    recreateDownstream: vi.fn(async () => {}),
     retryWorkflow: vi.fn(async () => {}),
     rebaseRetry: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),
     rebaseRecreate: vi.fn(async () => ({ success: true, rebasedBranches: [], errors: [] })),

--- a/packages/ui/src/components/ContextMenu.tsx
+++ b/packages/ui/src/components/ContextMenu.tsx
@@ -23,6 +23,7 @@ interface ContextMenuProps {
   onReplace: (taskId: string) => void;
   onOpenTerminal: (taskId: string) => void;
   onRecreateTask?: (taskId: string) => void;
+  onRecreateDownstream?: (taskId: string) => void;
   onFix?: (taskId: string, agentName: string) => void;
   onCancel?: (taskId: string) => void;
   onClose: (options?: { restoreFocus?: boolean }) => void;
@@ -47,6 +48,7 @@ export function ContextMenu({
   onReplace,
   onOpenTerminal,
   onRecreateTask,
+  onRecreateDownstream,
   onFix,
   onCancel,
   onClose,
@@ -65,6 +67,7 @@ export function ContextMenu({
   // Filter items based on available handlers
   const availableItems = items.filter((item) => {
     if (item.action === 'onRecreateTask' && !onRecreateTask) return false;
+    if (item.action === 'onRecreateDownstream' && !onRecreateDownstream) return false;
     if (item.action === 'onFix' && !onFix) return false;
     if (item.action === 'onCancel' && !onCancel) return false;
     return true;
@@ -227,6 +230,9 @@ export function ContextMenu({
         break;
       case 'onRecreateTask':
         onRecreateTask?.(task.id);
+        break;
+      case 'onRecreateDownstream':
+        onRecreateDownstream?.(task.id);
         break;
       case 'onFix':
         if (item.agentName) {

--- a/packages/ui/src/lib/context-menu-items.ts
+++ b/packages/ui/src/lib/context-menu-items.ts
@@ -129,6 +129,13 @@ export function getMenuItems(
       separator: !canCancel ? 'danger' : undefined,
     });
 
+    items.push({
+      id: 'recreate-downstream',
+      label: 'Recreate Downstream',
+      enabled: task.status !== 'running',
+      action: 'onRecreateDownstream',
+      variant: 'danger',
+    });
   }
 
   return items;


### PR DESCRIPTION
## Summary

Adds a task context-menu action for `Recreate Downstream`.

The action calls `window.invoker.recreateDownstream(taskId)` through the app bridge added by the parent stack.

Existing task actions keep their current labels, ordering, and handlers.

The branch also fixes the merge-gate stall found while preparing this PR.

Review-ready state is now committed before app completion observers run, so observer failures cannot strand a completed gate.

## Architecture

### Before

```mermaid
graph TD
    TaskMenu[Task context menu] --> RecreateTask[Recreate from Task]
    RecreateTask --> App[App handler]
    App --> Bridge[window.invoker.recreateTask]
    Executor[TaskRunner completion] --> Observer[App completion observer]
    Observer --> State[Orchestrator state update]
```

### After

```mermaid
graph TD
    TaskMenu[Task context menu] --> RecreateTask[Recreate from Task]
    TaskMenu --> RecreateDownstream[Recreate Downstream]
    RecreateDownstream --> App[App handler]
    App --> Bridge[window.invoker.recreateDownstream]
    Executor[TaskRunner completion] --> State[Orchestrator state update]
    State --> Observer[App completion observer]
```

Renderer changes are limited to menu item construction, click dispatch, App wiring, mocks, and focused tests.

Execution-engine changes only reorder completion handling and isolate observer failures after durable task state is written.

## Visual Proof

Task context menu showing `Recreate Downstream`:

![Task context menu showing Recreate Downstream](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260612-000b0e/task-context-menu-recreate-downstream.png)

Walkthrough video:

[task-context-menu-recreate-downstream.webm](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260612-000b0e/task-context-menu-recreate-downstream.webm)

## Test Plan

- [x] `pnpm --filter @invoker/app exec playwright test e2e/visual-proof.spec.ts -g "task context menu shows Recreate Downstream action"`
- [x] `cd packages/app && CAPTURE_MODE=after CAPTURE_VIDEO=1 npx playwright test e2e/visual-proof.spec.ts -g "task context menu shows Recreate Downstream action"`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-launch-dispatch.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/__tests__/context-menu.test.ts src/__tests__/context-menu-e2e.test.tsx`
- [x] `pnpm install --frozen-lockfile`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0ad5c05d f7d41bff 73aa800d`
- Post-revert steps: Reopen the workflow if PR #1002 still needs review.
- Data migration? No
