### PR TITLE
Camera lock Step 1: navigation model

### DIFF
--- a/packages/ui/src/__tests__/graph-camera.test.ts
+++ b/packages/ui/src/__tests__/graph-camera.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  CAMERA_LOCK_PREFERENCE_STORAGE_KEY,
+  DEFAULT_CAMERA_LOCK_PREFERENCE,
+  createGraphCameraCommandIssuer,
+  isCameraMode,
+  isGraphScope,
+  loadCameraLockPreference,
+  saveCameraLockPreference,
+  type CameraLockPreference,
+  type PreferenceStorage,
+} from '../lib/graph-camera.js';
+
+/** In-memory storage double matching the {@link PreferenceStorage} surface. */
+function createMemoryStorage(seed?: Record<string, string>): PreferenceStorage & {
+  raw: Map<string, string>;
+} {
+  const raw = new Map<string, string>(Object.entries(seed ?? {}));
+  return {
+    raw,
+    getItem: (key) => (raw.has(key) ? (raw.get(key) as string) : null),
+    setItem: (key, value) => {
+      raw.set(key, value);
+    },
+  };
+}
+
+describe('graph-camera defaults', () => {
+  it('defaults to toggle mode with the lock enabled', () => {
+    expect(DEFAULT_CAMERA_LOCK_PREFERENCE.mode).toBe('toggle');
+    expect(DEFAULT_CAMERA_LOCK_PREFERENCE.enabled).toBe(true);
+  });
+
+  it('freezes the default so callers cannot mutate the shared constant', () => {
+    expect(Object.isFrozen(DEFAULT_CAMERA_LOCK_PREFERENCE)).toBe(true);
+  });
+
+  it('returns the default for empty storage', () => {
+    const storage = createMemoryStorage();
+    expect(loadCameraLockPreference(storage)).toEqual({ mode: 'toggle', enabled: true });
+  });
+
+  it('returns a fresh copy, not the shared frozen default', () => {
+    const loaded = loadCameraLockPreference(createMemoryStorage());
+    expect(loaded).not.toBe(DEFAULT_CAMERA_LOCK_PREFERENCE);
+    expect(Object.isFrozen(loaded)).toBe(false);
+  });
+});
+
+describe('graph-camera type guards', () => {
+  it('recognizes valid camera modes and scopes', () => {
+    expect(isCameraMode('toggle')).toBe(true);
+    expect(isCameraMode('once')).toBe(true);
+    expect(isGraphScope('workflow')).toBe(true);
+    expect(isGraphScope('task')).toBe(true);
+  });
+
+  it('rejects invalid camera modes and scopes', () => {
+    expect(isCameraMode('always')).toBe(false);
+    expect(isCameraMode(undefined)).toBe(false);
+    expect(isCameraMode(2)).toBe(false);
+    expect(isGraphScope('graph')).toBe(false);
+    expect(isGraphScope(null)).toBe(false);
+  });
+});
+
+describe('graph-camera persistence', () => {
+  it('loads a valid persisted preference', () => {
+    const stored: CameraLockPreference = { mode: 'once', enabled: false };
+    const storage = createMemoryStorage({
+      [CAMERA_LOCK_PREFERENCE_STORAGE_KEY]: JSON.stringify(stored),
+    });
+    expect(loadCameraLockPreference(storage)).toEqual(stored);
+  });
+
+  it('round-trips through save and load', () => {
+    const storage = createMemoryStorage();
+    const preference: CameraLockPreference = { mode: 'once', enabled: false };
+
+    expect(saveCameraLockPreference(preference, storage)).toBe(true);
+    expect(storage.raw.has(CAMERA_LOCK_PREFERENCE_STORAGE_KEY)).toBe(true);
+    expect(loadCameraLockPreference(storage)).toEqual(preference);
+  });
+
+  it.each([
+    ['not json at all', 'this is not json{'],
+    ['a json primitive', '42'],
+    ['a json null', 'null'],
+    ['a json array', '[]'],
+    ['an unknown mode', JSON.stringify({ mode: 'always', enabled: true })],
+    ['a non-boolean enabled', JSON.stringify({ mode: 'toggle', enabled: 'yes' })],
+    ['a missing mode', JSON.stringify({ enabled: true })],
+    ['a missing enabled', JSON.stringify({ mode: 'toggle' })],
+  ])('falls back to defaults for malformed storage: %s', (_label, rawValue) => {
+    const storage = createMemoryStorage({
+      [CAMERA_LOCK_PREFERENCE_STORAGE_KEY]: rawValue,
+    });
+    expect(loadCameraLockPreference(storage)).toEqual(DEFAULT_CAMERA_LOCK_PREFERENCE);
+  });
+
+  it('falls back to defaults when storage getItem throws', () => {
+    const throwingStorage: PreferenceStorage = {
+      getItem: () => {
+        throw new Error('storage disabled');
+      },
+      setItem: () => {},
+    };
+    expect(loadCameraLockPreference(throwingStorage)).toEqual(DEFAULT_CAMERA_LOCK_PREFERENCE);
+  });
+
+  it('reports failure when saving to storage that throws', () => {
+    const throwingStorage: PreferenceStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('quota exceeded');
+      },
+    };
+    expect(saveCameraLockPreference({ mode: 'toggle', enabled: true }, throwingStorage)).toBe(false);
+  });
+});
+
+describe('graph-camera command issuer', () => {
+  let issuer: ReturnType<typeof createGraphCameraCommandIssuer>;
+
+  beforeEach(() => {
+    issuer = createGraphCameraCommandIssuer();
+  });
+
+  it('starts at sequence 0 and issues monotonically increasing sequences', () => {
+    expect(issuer.current()).toBe(0);
+    const first = issuer.issue({ kind: 'centerSelection', scope: 'workflow', reason: 'select' });
+    const second = issuer.issue({ kind: 'fitInitial', scope: 'task', reason: 'mount' });
+    expect(first.sequence).toBe(1);
+    expect(second.sequence).toBe(2);
+    expect(issuer.current()).toBe(2);
+  });
+
+  it('builds centerSelection commands with scope, target and reason', () => {
+    const command = issuer.centerSelection('task', 'task-7', 'user click');
+    expect(command).toEqual({
+      kind: 'centerSelection',
+      scope: 'task',
+      target: 'task-7',
+      reason: 'user click',
+      sequence: 1,
+    });
+  });
+
+  it('builds fitInitial commands with a null target', () => {
+    const command = issuer.fitInitial('workflow');
+    expect(command.kind).toBe('fitInitial');
+    expect(command.scope).toBe('workflow');
+    expect(command.target).toBeNull();
+    expect(command.reason).toBe('fitInitial');
+    expect(command.sequence).toBe(1);
+  });
+
+  it('defaults an omitted target to null', () => {
+    const command = issuer.issue({ kind: 'fitInitial', scope: 'workflow', reason: 'reset' });
+    expect(command.target).toBeNull();
+  });
+
+  it('keeps independent sequences per issuer', () => {
+    const other = createGraphCameraCommandIssuer();
+    issuer.centerSelection('workflow', 'a');
+    issuer.centerSelection('workflow', 'b');
+    const otherCommand = other.centerSelection('task', 'c');
+    expect(issuer.current()).toBe(2);
+    expect(otherCommand.sequence).toBe(1);
+  });
+});

--- a/packages/ui/src/lib/graph-camera.ts
+++ b/packages/ui/src/lib/graph-camera.ts
@@ -1,0 +1,218 @@
+/**
+ * Shared vocabulary for graph camera behaviour across the workflow graph and
+ * the selected-workflow task DAG.
+ *
+ * This module is the single source of truth for:
+ *  - which graph a camera command targets (`GraphScope`),
+ *  - whether the camera re-centres on every selection or only once
+ *    (`CameraMode`),
+ *  - the persisted camera-lock preference (`CameraLockPreference`),
+ *  - one-shot viewport commands (`GraphCameraCommand`), and
+ *  - the monotonic command sequence.
+ *
+ * Crucially, the monotonic `sequence` only ever increments inside the issuer
+ * returned by {@link createGraphCameraCommandIssuer}. No App-level selection
+ * handler should keep its own `event++` / `requestId++` counter — they consume
+ * commands from an issuer instead. React Flow keeps owning x/y/zoom locally;
+ * these commands are intent ("centre this selection"), not a controlled
+ * viewport.
+ */
+
+/** Which graph a camera command applies to. */
+export type GraphScope = 'workflow' | 'task';
+
+/**
+ * How aggressively the camera follows selection.
+ *  - `toggle`: re-centre whenever the selection changes (lock stays on).
+ *  - `once`: centre a single time, then release until re-armed.
+ */
+export type CameraMode = 'toggle' | 'once';
+
+/** Persisted camera-lock preference. */
+export interface CameraLockPreference {
+  /** Follow-selection behaviour. */
+  mode: CameraMode;
+  /** Whether the camera lock is engaged at all. */
+  enabled: boolean;
+}
+
+/** The kinds of one-shot viewport commands the UI can issue. */
+export type GraphCameraCommandKind = 'centerSelection' | 'fitInitial';
+
+/**
+ * A one-shot viewport command. Consumers act on a command when its `sequence`
+ * is greater than the last one they handled, then record the new sequence.
+ */
+export interface GraphCameraCommand {
+  /** What the viewport should do. */
+  kind: GraphCameraCommandKind;
+  /** Which graph the command targets. */
+  scope: GraphScope;
+  /** The node id to centre on, or `null` for whole-graph commands. */
+  target: string | null;
+  /** Human-readable cause, useful for debugging suppressed/forced moves. */
+  reason: string;
+  /** Monotonically increasing per issuer; the only mutable camera counter. */
+  sequence: number;
+}
+
+/** Valid {@link CameraMode} values. */
+const CAMERA_MODES: ReadonlySet<CameraMode> = new Set<CameraMode>(['toggle', 'once']);
+
+/** Valid {@link GraphScope} values. */
+const GRAPH_SCOPES: ReadonlySet<GraphScope> = new Set<GraphScope>(['workflow', 'task']);
+
+/** localStorage key for the persisted camera-lock preference. */
+export const CAMERA_LOCK_PREFERENCE_STORAGE_KEY = 'invoker.ui.cameraLockPreference';
+
+/**
+ * Default preference: follow selection on every change, lock engaged.
+ * Frozen so callers cannot mutate the shared default in place.
+ */
+export const DEFAULT_CAMERA_LOCK_PREFERENCE: CameraLockPreference = Object.freeze({
+  mode: 'toggle',
+  enabled: true,
+});
+
+/** Narrow an arbitrary value to a {@link CameraMode}. */
+export function isCameraMode(value: unknown): value is CameraMode {
+  return typeof value === 'string' && CAMERA_MODES.has(value as CameraMode);
+}
+
+/** Narrow an arbitrary value to a {@link GraphScope}. */
+export function isGraphScope(value: unknown): value is GraphScope {
+  return typeof value === 'string' && GRAPH_SCOPES.has(value as GraphScope);
+}
+
+/**
+ * Validate a parsed value as a {@link CameraLockPreference}. Returns a fresh,
+ * fully-typed preference, or `null` if the shape is malformed.
+ */
+function parseCameraLockPreference(value: unknown): CameraLockPreference | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const candidate = value as Record<string, unknown>;
+  if (!isCameraMode(candidate.mode)) return null;
+  if (typeof candidate.enabled !== 'boolean') return null;
+  return { mode: candidate.mode, enabled: candidate.enabled };
+}
+
+/**
+ * Minimal storage surface so this module works against `window.localStorage`,
+ * a test double, or `undefined` (e.g. SSR / disabled storage).
+ */
+export interface PreferenceStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+/**
+ * Resolve the storage to use. Falls back to `globalThis.localStorage` when
+ * available, otherwise `undefined` so callers degrade to defaults safely.
+ */
+function resolveStorage(storage?: PreferenceStorage): PreferenceStorage | undefined {
+  if (storage) return storage;
+  const globalStorage = (globalThis as { localStorage?: PreferenceStorage }).localStorage;
+  return globalStorage ?? undefined;
+}
+
+/**
+ * Load the persisted camera-lock preference, falling back to
+ * {@link DEFAULT_CAMERA_LOCK_PREFERENCE} for missing, unparseable, or malformed
+ * values. Never throws.
+ */
+export function loadCameraLockPreference(storage?: PreferenceStorage): CameraLockPreference {
+  const store = resolveStorage(storage);
+  if (!store) return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
+
+  let raw: string | null;
+  try {
+    raw = store.getItem(CAMERA_LOCK_PREFERENCE_STORAGE_KEY);
+  } catch {
+    return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
+  }
+  if (raw === null) return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
+  }
+
+  return parseCameraLockPreference(parsed) ?? { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
+}
+
+/**
+ * Persist the camera-lock preference. Swallows storage errors (quota, disabled
+ * storage) so a failed save never breaks the UI. Returns whether the write
+ * succeeded.
+ */
+export function saveCameraLockPreference(
+  preference: CameraLockPreference,
+  storage?: PreferenceStorage,
+): boolean {
+  const store = resolveStorage(storage);
+  if (!store) return false;
+  try {
+    store.setItem(CAMERA_LOCK_PREFERENCE_STORAGE_KEY, JSON.stringify(preference));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Fields required to issue a command; `sequence` is supplied by the issuer. */
+export interface GraphCameraCommandInput {
+  kind: GraphCameraCommandKind;
+  scope: GraphScope;
+  /** Defaults to `null` for whole-graph commands. */
+  target?: string | null;
+  reason: string;
+}
+
+/**
+ * The only object permitted to mint {@link GraphCameraCommand}s. It owns the
+ * monotonic `sequence`, so no selection handler needs an ad hoc counter.
+ */
+export interface GraphCameraCommandIssuer {
+  /** Issue an arbitrary command, incrementing the sequence. */
+  issue(input: GraphCameraCommandInput): GraphCameraCommand;
+  /** Convenience: centre the given target within a scope. */
+  centerSelection(scope: GraphScope, target: string, reason?: string): GraphCameraCommand;
+  /** Convenience: fit the whole graph for an initial view. */
+  fitInitial(scope: GraphScope, reason?: string): GraphCameraCommand;
+  /** The sequence of the most recently issued command (0 before any). */
+  current(): number;
+}
+
+/**
+ * Create a command issuer. Each issuer owns an independent monotonic sequence
+ * starting at 0; the first issued command has `sequence` 1.
+ */
+export function createGraphCameraCommandIssuer(): GraphCameraCommandIssuer {
+  let sequence = 0;
+
+  function issue(input: GraphCameraCommandInput): GraphCameraCommand {
+    sequence += 1;
+    return {
+      kind: input.kind,
+      scope: input.scope,
+      target: input.target ?? null,
+      reason: input.reason,
+      sequence,
+    };
+  }
+
+  return {
+    issue,
+    centerSelection(scope, target, reason = 'centerSelection') {
+      return issue({ kind: 'centerSelection', scope, target, reason });
+    },
+    fitInitial(scope, reason = 'fitInitial') {
+      return issue({ kind: 'fitInitial', scope, target: null, reason });
+    },
+    current() {
+      return sequence;
+    },
+  };
+}


### PR DESCRIPTION
Validation passed. Final PR body:

## Summary

Adds a typed camera and graph navigation model plus persisted preference helpers in the UI package, the foundation for later camera lock workflows.

It names concepts that were previously implicit: graph scope, camera mode, lock preference, and one-shot viewport commands.

Camera lock defaults to toggle mode with lock enabled. The mode and enabled preference persist across reloads through localStorage, falling back safely when storage is unavailable.

Command creation is centralized in a factory that owns the monotonic sequence, so later workflows can drop ad hoc `event++` and `requestId++` wiring.

This slice changes no visible graph behavior on its own. React Flow viewport ownership stays local; the new module is only consumed by later steps in the stack.

Because this is Invoker changing Invoker, the resulting GitHub stack is published or updated with `mergify stack push` once the chain is ready.

## Test Plan

- [ ] `cd packages/ui && pnpm test src/__tests__/graph-camera.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None — the module is additive and has no consumers yet.
- Data migration? No