### PR TITLE
Fix workflow task purge durable FK cleanup

### DIFF
--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1128,6 +1128,36 @@ describe('SQLiteAdapter', () => {
       expect(adapter.replayOutputFrom('t-spool-1', 0)).toEqual([]);
       expect(adapter.getOutputTail('t-spool-1')).toEqual([]);
     });
+
+    it('removes durable workflow coordinator rows before deleting tasks', () => {
+      adapter.saveWorkflow(testWorkflow);
+      adapter.saveTask('wf-1', makeTask('t1'));
+
+      const attempt = createAttempt('t1', { status: 'running' });
+      adapter.saveAttempt(attempt);
+
+      const intentId = adapter.enqueueWorkflowMutationIntent(
+        'wf-1', 'test-channel', [{ action: 'delete' }], 'normal',
+      );
+      adapter.claimWorkflowMutationLease('wf-1', 'owner-1', {
+        activeIntentId: intentId,
+        activeMutationKind: 'delete',
+      });
+      adapter.enqueueLaunchDispatch({
+        taskId: 't1',
+        attemptId: attempt.id,
+        workflowId: 'wf-1',
+        generation: 1,
+      });
+
+      expect(() => adapter.deleteAllTasks('wf-1')).not.toThrow();
+
+      expect(adapter.loadWorkflow('wf-1')).toBeDefined();
+      expect(adapter.loadTasks('wf-1')).toEqual([]);
+      expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM workflow_mutation_intents WHERE workflow_id = 'wf-1'")).toBe(0);
+      expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM workflow_mutation_leases WHERE workflow_id = 'wf-1'")).toBe(0);
+      expect(sqliteScalar(adapter, "SELECT COUNT(*) FROM task_launch_dispatch WHERE workflow_id = 'wf-1'")).toBe(0);
+    });
   });
 
   describe('agentSessionId persistence', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1720,6 +1720,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
   deleteAllTasks(workflowId: string): void {
     const taskIds = this.getTaskIdsForWorkflow(workflowId);
     this.runTransaction(() => {
+      this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
+      this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
+      this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
       this.db.run(`
         DELETE FROM events WHERE task_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?


### PR DESCRIPTION
## Summary

Fix `deleteAllTasks` to clear durable workflow coordinator rows before deleting workflow task rows.

This matches the existing workflow deletion cleanup and prevents FK failures when task purge paths see mutation intents, leases, or launch dispatch rows.

## Test Plan

- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts -t "deleteAllTasks" --reporter=verbose`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts -t "deletes workflow with mutation intents, leases, and launch dispatch rows" --reporter=verbose`

## Revert Plan

Revert with `git revert 8aab569ee`.

No migration or manual cleanup is required; this only changes deletion ordering for existing rows.
