### PR TITLE
Add workflow-core recreateDownstream primitive

### DIFF
--- a/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
@@ -31,6 +31,10 @@ describe('InvalidationPlan policy registry', () => {
       scope: 'task',
       mode: 'recreate',
     });
+    expect(ACTION_SPECS.recreateDownstream).toMatchObject({
+      scope: 'task',
+      mode: 'recreate',
+    });
     expect(ACTION_SPECS.retryWorkflow).toMatchObject({
       scope: 'workflow',
       mode: 'retry',
@@ -90,6 +94,66 @@ describe('InvalidationPlan policy registry', () => {
       affectedTaskIds: ['wf-1/child', 'wf-1/grandchild', 'wf-1/root'],
       lockPlan: { workflowIds: ['wf-1'] },
     });
+  });
+
+  it('plans downstream recreate as the descendants only, excluding the target', () => {
+    const tasks = [
+      task('wf-1/root', 'wf-1'),
+      task('wf-1/child', 'wf-1', ['wf-1/root']),
+      task('wf-1/grandchild', 'wf-1', ['wf-1/child']),
+      task('wf-1/sibling', 'wf-1'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/root',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'recreateDownstream',
+      scope: 'task',
+      mode: 'recreate',
+      affectedWorkflowIds: ['wf-1'],
+      // root and sibling are NOT reset — only the transitive descendants.
+      affectedTaskIds: ['wf-1/child', 'wf-1/grandchild'],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+  });
+
+  it('plans downstream recreate from a mid-chain task as that task’s descendants only', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/b', 'wf-1', ['wf-1/a']),
+      task('wf-1/c', 'wf-1', ['wf-1/b']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/b',
+      tasks,
+    });
+
+    // B preserved; only C is reset.
+    expect(plan.affectedTaskIds).toEqual(['wf-1/c']);
+  });
+
+  it('plans downstream recreate of a leaf as an empty (no-op) footprint', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/leaf', 'wf-1', ['wf-1/a']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/leaf',
+      tasks,
+    });
+
+    expect(plan.affectedTaskIds).toEqual([]);
+    expect(plan.affectedWorkflowIds).toEqual([]);
+    expect(plan.lockPlan.workflowIds).toEqual([]);
+    expect(plan.schedulerEnqueueCandidates).toEqual([]);
   });
 
   it('plans task retry as the task plus non-completed descendants', () => {

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -12,6 +12,7 @@ type MockedDeps = InvalidationDeps & {
   cancelInFlight: ReturnType<typeof vi.fn>;
   retryTask: ReturnType<typeof vi.fn>;
   recreateTask: ReturnType<typeof vi.fn>;
+  recreateDownstream?: ReturnType<typeof vi.fn>;
   retryWorkflow: ReturnType<typeof vi.fn>;
   recreateWorkflow: ReturnType<typeof vi.fn>;
   recreateWorkflowFromFreshBase?: ReturnType<typeof vi.fn>;
@@ -274,6 +275,45 @@ describe('applyInvalidation: recreateWorkflowFromFreshBase optional dep', () => 
   });
 });
 
+describe('applyInvalidation: recreateDownstream optional dep', () => {
+  it('throws an explicit missing-dep error when dep is absent', async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('task', 'recreateDownstream', 'task-a', deps),
+    ).rejects.toThrow(/'recreateDownstream' dep is missing/);
+  });
+
+  it('routes to the provided dep when present', async () => {
+    const recreateDownstream = vi.fn(async () => []);
+    const deps = makeDeps({ recreateDownstream });
+    await applyInvalidation('task', 'recreateDownstream', 'task-a', deps);
+    expect(recreateDownstream).toHaveBeenCalledWith('task-a');
+  });
+
+  it('rejects workflow-scoped invocation with recreateDownstream action', async () => {
+    const recreateDownstream = vi.fn(async () => []);
+    const deps = makeDeps({ recreateDownstream });
+    await expect(
+      applyInvalidation('workflow', 'recreateDownstream', 'wf-1', deps),
+    ).rejects.toThrow(/requires scope 'task'/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+  });
+
+  it('cancel-first ordering and cross-workflow cascade apply to recreateDownstream', async () => {
+    const recreateDownstream = vi.fn(async () => []);
+    const cascadeDownstream = vi.fn(async () => []);
+    const deps = makeDeps({ recreateDownstream, cascadeDownstream });
+    await applyInvalidation('task', 'recreateDownstream', 'task-a', deps);
+    expect(deps.cancelInFlight).toHaveBeenCalledWith('task', 'task-a');
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      recreateDownstream.mock.invocationCallOrder[0],
+    );
+    expect(recreateDownstream.mock.invocationCallOrder[0]).toBeLessThan(
+      cascadeDownstream.mock.invocationCallOrder[0],
+    );
+  });
+});
+
 describe('applyInvalidation: workflowFork optional dep', () => {
   it('throws an explicit missing-dep error when dep is absent', async () => {
     const deps = makeDeps();
@@ -525,6 +565,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
   'fixReject',
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',
@@ -534,6 +575,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
 const INVALIDATING_ACTIONS: readonly InvalidationAction[] = [
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5886,6 +5886,201 @@ describe('Orchestrator', () => {
     });
   });
 
+  // ── recreateDownstream ───────────────────────────────────
+
+  describe('recreateDownstream', () => {
+    // Seed a linear chain A -> B -> C, each completed with distinct
+    // lineage / session metadata, plus a populated execution generation
+    // so "unchanged" assertions are meaningful.
+    const seedChain = (
+      p: InMemoryPersistence,
+      wf: string,
+    ): void => {
+      p.saveTask(wf, {
+        id: 'A',
+        description: 'Root',
+        status: 'completed',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-a',
+          commit: 'a1',
+          workspacePath: '/tmp/a',
+          exitCode: 0,
+          generation: 4,
+          selectedAttemptId: 'attempt-a',
+          agentSessionId: 'sess-a',
+          containerId: 'cont-a',
+        },
+      });
+      p.saveTask(wf, {
+        id: 'B',
+        description: 'Middle',
+        status: 'completed',
+        dependencies: ['A'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-b',
+          commit: 'b1',
+          workspacePath: '/tmp/b',
+          exitCode: 0,
+          generation: 2,
+          agentSessionId: 'sess-b',
+          containerId: 'cont-b',
+        },
+      });
+      p.saveTask(wf, {
+        id: 'C',
+        description: 'Leaf',
+        status: 'completed',
+        dependencies: ['B'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-c',
+          commit: 'c1',
+          workspacePath: '/tmp/c',
+          exitCode: 0,
+          generation: 1,
+          agentSessionId: 'sess-c',
+          containerId: 'cont-c',
+        },
+      });
+    };
+
+    const makeOrchestrator = (wf: string): Orchestrator => {
+      const p = new InMemoryPersistence();
+      seedChain(p, wf);
+      const o = new Orchestrator({
+        persistence: p,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 3,
+      });
+      o.syncFromDb(wf);
+      return o;
+    };
+
+    it('leaves the selected root untouched and resets all descendants (recreate semantics)', () => {
+      const wf = 'wf-recreate-downstream-root';
+      const o = makeOrchestrator(wf);
+
+      o.recreateDownstream('A');
+
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+
+      // Root A is fully preserved: status, lineage, selected attempt,
+      // session/container metadata, and generation all unchanged.
+      expect(a.status).toBe('completed');
+      expect(a.execution.branch).toBe('br-a');
+      expect(a.execution.commit).toBe('a1');
+      expect(a.execution.workspacePath).toBe('/tmp/a');
+      expect(a.execution.selectedAttemptId).toBe('attempt-a');
+      expect(a.execution.agentSessionId).toBe('sess-a');
+      expect(a.execution.containerId).toBe('cont-a');
+      expect(a.execution.generation).toBe(4);
+
+      // B and C are recreate-reset: fresh lineage, stale session/container
+      // metadata cleared, execution generation bumped exactly once.
+      expect(b.status === 'running' || b.status === 'pending').toBe(true);
+      expect(b.execution.branch).toBeUndefined();
+      expect(b.execution.commit).toBeUndefined();
+      expect(b.execution.workspacePath).toBeUndefined();
+      expect(b.execution.agentSessionId).toBeUndefined();
+      expect(b.execution.containerId).toBeUndefined();
+      expect(b.execution.generation).toBe(3);
+
+      expect(c.status).toBe('pending');
+      expect(c.execution.branch).toBeUndefined();
+      expect(c.execution.commit).toBeUndefined();
+      expect(c.execution.workspacePath).toBeUndefined();
+      expect(c.execution.agentSessionId).toBeUndefined();
+      expect(c.execution.containerId).toBeUndefined();
+      expect(c.execution.generation).toBe(2);
+    });
+
+    it('resets only C when invoked on the mid-chain task B', () => {
+      const wf = 'wf-recreate-downstream-mid';
+      const o = makeOrchestrator(wf);
+
+      const started = o.recreateDownstream('B');
+      // The freshly-ready descendant is returned for dispatch.
+      expect(started.map((t) => t.id)).toContain('C');
+
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+
+      // A and B both preserved; only C is reset.
+      expect(a.status).toBe('completed');
+      expect(a.execution.branch).toBe('br-a');
+      expect(a.execution.generation).toBe(4);
+
+      expect(b.status).toBe('completed');
+      expect(b.execution.branch).toBe('br-b');
+      expect(b.execution.commit).toBe('b1');
+      expect(b.execution.workspacePath).toBe('/tmp/b');
+      expect(b.execution.agentSessionId).toBe('sess-b');
+      expect(b.execution.containerId).toBe('cont-b');
+      expect(b.execution.generation).toBe(2);
+
+      // C is reset and — since its only dependency B stays completed —
+      // is immediately ready, so it is returned for dispatch (running).
+      expect(c.status === 'running' || c.status === 'pending').toBe(true);
+      expect(c.execution.branch).toBeUndefined();
+      expect(c.execution.workspacePath).toBeUndefined();
+      expect(c.execution.generation).toBe(2);
+    });
+
+    it('is a no-op on a leaf task and returns no started tasks', () => {
+      const wf = 'wf-recreate-downstream-leaf';
+      const o = makeOrchestrator(wf);
+
+      const started = o.recreateDownstream('C');
+
+      expect(started).toEqual([]);
+
+      // Every task is left exactly as seeded.
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+      expect(a.status).toBe('completed');
+      expect(b.status).toBe('completed');
+      expect(c.status).toBe('completed');
+      expect(c.execution.branch).toBe('br-c');
+      expect(c.execution.workspacePath).toBe('/tmp/c');
+      expect(c.execution.agentSessionId).toBe('sess-c');
+      expect(c.execution.generation).toBe(1);
+    });
+
+    it('records an invalidation plan whose affected-task set is the descendants only', () => {
+      const wf = 'wf-recreate-downstream-plan';
+      const o = makeOrchestrator(wf);
+
+      o.recreateDownstream('A');
+      const rootPlan = o.getLastInvalidationPlan()!;
+      expect(rootPlan).toMatchObject({
+        action: 'recreateDownstream',
+        scope: 'task',
+        mode: 'recreate',
+        affectedTaskIds: ['B', 'C'],
+      });
+
+      // Mid-chain: only the single descendant.
+      const o2 = makeOrchestrator('wf-recreate-downstream-plan-2');
+      o2.recreateDownstream('B');
+      expect(o2.getLastInvalidationPlan()!.affectedTaskIds).toEqual(['C']);
+
+      // Leaf: empty affected set.
+      const o3 = makeOrchestrator('wf-recreate-downstream-plan-3');
+      o3.recreateDownstream('C');
+      expect(o3.getLastInvalidationPlan()!.affectedTaskIds).toEqual([]);
+    });
+  });
+
   // ── retryWorkflow ────────────────────────────────────────
 
   describe('retryWorkflow', () => {

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -8,6 +8,7 @@ export type InvalidationAction =
   | 'retryTask'
   | 'retryWorkflow'
   | 'recreateTask'
+  | 'recreateDownstream'
   | 'recreateWorkflow'
   | 'recreateWorkflowFromFreshBase'
   | 'workflowFork';
@@ -70,6 +71,13 @@ export interface InvalidationDeps {
   cancelInFlight: CancelInFlightFn;
   retryTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   recreateTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  /**
+   * Recreate every downstream dependent of the target task while leaving
+   * the target itself untouched. Optional so existing `InvalidationDeps`
+   * constructors (e.g. the app-side `buildInvalidationDeps`) keep
+   * compiling until they opt in; routed callers must provide it.
+   */
+  recreateDownstream?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   retryWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflowFromFreshBase?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
@@ -81,7 +89,7 @@ export interface InvalidationDeps {
   /**
    * Cross-workflow cascade hook. Invoked only for actions that change
    * execution state:
-   *   - task scope:     `retryTask`, `recreateTask`
+   *   - task scope:     `retryTask`, `recreateTask`, `recreateDownstream`
    *   - workflow scope: `retryWorkflow`, `recreateWorkflow`,
    *                     `recreateWorkflowFromFreshBase`, `workflowFork`
    *
@@ -187,6 +195,21 @@ function taskAndDescendants(
   return [root, ...descendantsOf(taskId, byId, stop)];
 }
 
+/**
+ * Transitive descendants of `taskId` WITHOUT the task itself. Mirrors
+ * `taskAndDescendants` but drops the root — the downstream-only footprint
+ * used by `recreateDownstream`, which leaves the selected task untouched.
+ */
+function descendantsOnly(
+  taskId: string,
+  tasks: readonly TaskState[],
+  stop?: (task: TaskState) => boolean,
+): TaskState[] {
+  const byId = taskMap(tasks);
+  if (!byId.has(taskId)) return [];
+  return descendantsOf(taskId, byId, stop);
+}
+
 function retryStop(task: TaskState): boolean {
   return task.status === 'completed' || task.status === 'stale';
 }
@@ -246,6 +269,17 @@ export const ACTION_SPECS: Readonly<Record<InvalidationAction, ActionSpec>> = Ob
     mode: 'recreate',
     reason: 'task.recreate',
     selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
+  },
+  recreateDownstream: {
+    scope: 'task',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'task.recreateDownstream',
+    // Downstream-only footprint: the selected task is preserved; every
+    // transitive descendant gets recreate-class semantics. A leaf task
+    // yields an empty set (no-op).
+    selectAffectedTasks: ({ targetId, tasks }) => descendantsOnly(targetId, tasks),
   },
   retryWorkflow: {
     scope: 'workflow',
@@ -377,6 +411,17 @@ async function invokePrimitive(
       return await deps.retryTask(ctx.id);
     case 'recreateTask':
       return await deps.recreateTask(ctx.id);
+    case 'recreateDownstream': {
+      if (!deps.recreateDownstream) {
+        throw new Error(
+          "applyInvalidation: 'recreateDownstream' dep is missing. " +
+            'Production callers wire this via buildInvalidationDeps in ' +
+            '@invoker/app/workflow-actions; tests must supply ' +
+            'deps.recreateDownstream to use this action.',
+        );
+      }
+      return await deps.recreateDownstream(ctx.id);
+    }
     case 'retryWorkflow':
       return await deps.retryWorkflow(ctx.id);
     case 'recreateWorkflow':
@@ -425,6 +470,7 @@ export interface InvalidationDepsOrchestrator {
   cancelWorkflow(workflowId: string): { runningCancelled: string[] };
   retryTask(taskId: string): TaskState[];
   recreateTask(taskId: string): TaskState[];
+  recreateDownstream(taskId: string): TaskState[];
   retryWorkflow(workflowId: string): TaskState[];
   recreateWorkflow(workflowId: string): TaskState[];
   recreateWorkflowFromFreshBase(workflowId: string): Promise<TaskState[]>;
@@ -487,6 +533,7 @@ export function buildOrchestratorOnlyInvalidationDeps(
     cancelInFlight: buildCancelInFlight({ orchestrator }),
     retryTask: (taskId) => orchestrator.retryTask(taskId),
     recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    recreateDownstream: (taskId) => orchestrator.recreateDownstream(taskId),
     retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
     recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
     recreateWorkflowFromFreshBase: (workflowId) =>

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1123,10 +1123,22 @@ export class Orchestrator {
         .filter((t) => t.config.workflowId === id);
     }
 
+    return this.cancelActiveCandidates(candidates, `${scope}-scope`);
+  }
+
+  /**
+   * Mark each actively-running candidate as `failed` with an explicit
+   * cancel marker, clearing its deferred-set / queued scheduler entries.
+   * Pending / blocked / failed / completed / etc. tasks are skipped so a
+   * subsequent reset path sees the expected lineage. Shared by the
+   * scope-based `cancelActiveBeforeInvalidation` and the downstream-only
+   * `recreateDownstream` (which must leave its selected task untouched).
+   */
+  private cancelActiveCandidates(candidates: TaskState[], label: string): string[] {
     const cancelled: string[] = [];
     for (const t of candidates) {
       if (!isActiveForInvalidation(t.status)) continue;
-      const error = `Cancelled before ${scope}-scope invalidation`;
+      const error = `Cancelled before ${label} invalidation`;
       const completedAt = new Date();
       const changes: TaskStateChanges = {
         status: 'failed',
@@ -2525,6 +2537,111 @@ export class Orchestrator {
     };
 
     this.logger.info('[orchestrator] recreateTask reset', {
+      taskId: rootId,
+      resetCount: toResetIds.length,
+    });
+
+    for (const id of toResetIds) {
+      const current = this.stateGetTask(id);
+      if (!current) continue;
+      const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
+      const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
+      const priorAttemptId = current.execution.selectedAttemptId;
+      this.replaceSelectedAttempt(current);
+      this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(current, recreateUpdated, changesWithGeneration));
+
+      this.deferredTaskIds.delete(id);
+      this.clearQueuedSchedulerEntries(id, priorAttemptId);
+    }
+
+    const readyIds = this.stateMachine
+      .getReadyTasks()
+      .map((t) => t.id)
+      .filter((id) => toResetSet.has(id));
+    plan = withSchedulerEnqueueCandidates(plan, readyIds);
+    this.lastInvalidationPlan = plan;
+    return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
+  }
+
+  /**
+   * Task-scoped downstream recreate: leave the SELECTED task fully intact
+   * (status, branch, commit, workspacePath, selectedAttemptId,
+   * agent/session/container metadata, and execution generation all
+   * unchanged) and reset every transitive descendant with recreate-class
+   * semantics — fresh lineage, stale attempt/session/container metadata
+   * cleared, and execution generation bumped — then auto-start the newly
+   * ready descendants for dispatch.
+   *
+   * A leaf task (no downstream dependents) is a no-op: nothing is reset
+   * and no tasks are started.
+   *
+   * Shares the recreate reset shape with `recreateTask`; the only
+   * difference is the affected-task footprint — descendants ONLY, never
+   * the target — sourced from the `recreateDownstream` action spec via
+   * `planInvalidation`.
+   */
+  recreateDownstream(taskId: string): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+
+    const rootId = task.id;
+
+    let plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: rootId,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
+    // Descendants only — `planInvalidation` never includes `rootId` for
+    // the `recreateDownstream` action, guaranteeing the selected task is
+    // left untouched below.
+    const toResetIds = plan.affectedTaskIds;
+    const toResetSet = new Set(toResetIds);
+
+    // Leaf no-op: no downstream dependents → nothing to reset or start.
+    if (toResetIds.length === 0) {
+      this.logger.info('[orchestrator] recreateDownstream no-op (leaf)', { taskId: rootId });
+      return [];
+    }
+
+    // Step 18 cancel-first invariant: interrupt active attempts on the
+    // downstream subgraph BEFORE the recreate reset writes pending
+    // state, while leaving the selected task untouched. Defense-in-depth
+    // for direct callers that bypass `applyInvalidation`'s upstream
+    // cancel; a no-op when invoked through `applyInvalidation`.
+    const descendantCandidates = toResetIds
+      .map((id) => this.stateGetTask(id))
+      .filter((t): t is TaskState => !!t);
+    this.cancelActiveCandidates(descendantCandidates, 'downstream-scope');
+
+    const resetChanges: TaskStateChanges = {
+      status: 'pending',
+      config: { summary: undefined },
+      execution: {
+        autoFixAttempts: 0,
+        startedAt: undefined,
+        completedAt: undefined,
+        error: undefined,
+        exitCode: undefined,
+        commit: undefined,
+        branch: undefined,
+        workspacePath: undefined,
+        lastHeartbeatAt: undefined,
+        phase: undefined,
+        launchStartedAt: undefined,
+        launchCompletedAt: undefined,
+        reviewUrl: undefined,
+        reviewId: undefined,
+        reviewStatus: undefined,
+        reviewProviderId: undefined,
+        agentSessionId: undefined,
+        containerId: undefined,
+      },
+    };
+
+    this.logger.info('[orchestrator] recreateDownstream reset', {
       taskId: rootId,
       resetCount: toResetIds.length,
     });


### PR DESCRIPTION
## Summary

Adds a task-scoped `recreateDownstream` primitive to workflow-core. It leaves the selected task fully intact and applies recreate-class semantics to that task's transitive descendants only.

For a chain `A -> B -> C`, `recreateDownstream(A)` keeps A unchanged and resets B and C. `recreateDownstream(B)` resets only C.

Called on a leaf, it is a no-op and returns no started tasks.

Descendant resets reuse the existing recreate reset shape: fresh lineage (branch, commit, and workspacePath cleared), stale attempt/session/container metadata cleared, execution generation bumped, and the freshly-ready descendants returned for dispatch.

The selected task's status, branch, commit, workspacePath, selectedAttemptId, agent/session/container metadata, and generation are never touched, because the action's affected-task footprint excludes the target.

This is the core slice only. No app IPC, API, headless commands, renderer types, or UI menu items are added here.

## Architecture

The new primitive follows the established action-table pattern rather than an ad hoc path. It is a `recreateDownstream` entry in `ACTION_SPECS` whose `selectAffectedTasks` returns descendants-only, the sibling of `recreateTask`'s task-plus-descendants.

So `planInvalidation` computes the affected set, lock plan, and enqueue candidates the same way as every other action. The orchestrator method sources its reset footprint from that plan and shares the recreate reset shape with `recreateTask`.

### Before

```mermaid
graph TD
    M[mutation / caller] --> P[planInvalidation]
    P --> SPECS[ACTION_SPECS]
    SPECS --> RT[recreateTask: task + descendants]
    SPECS --> RW[recreateWorkflow: whole workflow]
    RT --> O[Orchestrator reset + dispatch]
    RW --> O
```

### After

```mermaid
graph TD
    M[mutation / caller] --> P[planInvalidation]
    P --> SPECS[ACTION_SPECS]
    SPECS --> RT[recreateTask: task + descendants]
    SPECS --> RD[recreateDownstream: descendants only]
    SPECS --> RW[recreateWorkflow: whole workflow]
    RT --> O[Orchestrator reset + dispatch]
    RD --> O
    RW --> O
    RD -. selected task preserved .- KEEP[target unchanged]
```

## Test Plan

- [ ] `cd packages/workflow-core && pnpm test -- src/__tests__/orchestrator.test.ts src/__tests__/invalidation-plan.test.ts`
- [ ] `cd packages/workflow-core && pnpm test -- src/__tests__/invalidation-policy.test.ts`
- [ ] `cd packages/workflow-core && npx tsc --noEmit -p tsconfig.json`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
