### PR TITLE
Fix watchdog heartbeat completion races

### DIFF
--- a/packages/app/src/__tests__/executing-stall.test.ts
+++ b/packages/app/src/__tests__/executing-stall.test.ts
@@ -51,6 +51,22 @@ describe('evaluateExecutingStall', () => {
     expect(result.staleReason).toBe('executor heartbeat stale');
   });
 
+  it('does not terminally stall a worktree task on heartbeat gap alone while the attempt lease is still valid', () => {
+    const result = evaluateExecutingStall({
+      now,
+      phase: 'executing',
+      runnerKind: 'worktree',
+      executingStartedAt: startedAt,
+      executorHeartbeatAt: new Date(now.getTime() - 4 * 60_000),
+      leaseExpiresAt: new Date(now.getTime() + 10 * 60_000),
+      executingStallTimeoutMs: timeoutMs,
+    });
+
+    expect(result.heartbeatStale).toBe(true);
+    expect(result.leaseExpired).toBe(false);
+    expect(result.executingStalled).toBe(false);
+  });
+
   it('prioritizes lease expiration as the stale reason', () => {
     const result = evaluateExecutingStall({
       now,

--- a/packages/app/src/executing-stall.ts
+++ b/packages/app/src/executing-stall.ts
@@ -35,12 +35,13 @@ export function evaluateExecutingStall(input: ExecutingStallEvaluationInput): Ex
   const heartbeatStale =
     !heartbeatSource || now.getTime() - heartbeatSource.getTime() >= executingStallTimeoutMs;
   const leaseExpired = !!leaseExpiresAt && leaseExpiresAt.getTime() < now.getTime();
+  const leaseStillValid = !!leaseExpiresAt && leaseExpiresAt.getTime() >= now.getTime();
   const executingAgeMs = executingStartedAt ? now.getTime() - executingStartedAt.getTime() : 0;
   const executingStalled =
     phase === 'executing'
     && executingStartedAt !== undefined
     && executingAgeMs >= executingStallTimeoutMs
-    && (leaseExpired || heartbeatStale);
+    && (leaseExpired || (!leaseStillValid && heartbeatStale));
 
   const staleReason = leaseExpired
     ? 'attempt lease expired'

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -23,6 +23,16 @@ import { BaseExecutor } from '../base-executor.js';
 
 const mockedSpawn = vi.mocked(spawn);
 
+function createDeferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function makeRequest(overrides: Partial<WorkRequest> = {}): WorkRequest {
   const { inputs: inputOverrides, ...restOverrides } = overrides;
   return {
@@ -1754,6 +1764,35 @@ describe('WorktreeExecutor', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it('keeps heartbeats alive while close finalization is pending', async () => {
+      (executor as any).heartbeatIntervalMs = 20;
+      const finalizeDeferred = createDeferred<string | null>();
+      vi.spyOn(executor as any, 'recordTaskResult').mockImplementation(() => finalizeDeferred.promise);
+
+      const { taskProcess } = setupSpawnMock();
+      const request = makeRequest();
+      const handle = await executor.start(request);
+
+      let heartbeatCount = 0;
+      let completed = false;
+      executor.onHeartbeat(handle, () => {
+        heartbeatCount += 1;
+      });
+      executor.onComplete(handle, () => {
+        completed = true;
+      });
+
+      (taskProcess as any).exitCode = 0;
+      taskProcess.emit('close', 0, null);
+      await new Promise((resolve) => setTimeout(resolve, 80));
+
+      expect(completed).toBe(false);
+      expect(heartbeatCount).toBeGreaterThan(0);
+
+      finalizeDeferred.resolve('abc123');
+      await waitForCondition(() => completed);
     });
 
     it('heartbeat stops after completion to prevent duplicate events', async () => {

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -932,7 +932,6 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     },
   ): Promise<void> {
     const entry = this.entries.get(executionId);
-    if (entry) entry.completed = true;
     const bufferedOutput = entry?.outputBuffer.join('') ?? '';
     const semanticFailure = this.detectSemanticFailure(request, bufferedOutput, exitCode);
     const effectiveExitCode = (exitCode === 0 && semanticFailure)

--- a/packages/execution-engine/src/docker-executor.ts
+++ b/packages/execution-engine/src/docker-executor.ts
@@ -453,20 +453,25 @@ export class DockerExecutor extends BaseExecutor<ContainerEntry> {
       child.on('close', (code, signal) => {
         void this.containerContext.run(container.id, async () => {
           const exitCode = code ?? (signal ? 1 : 0);
+          entry.finalizingAfterClose = true;
 
-          await this.handleProcessExit(executionId, request, CONTAINER_CWD, exitCode, {
-            signal,
-            branch: handle.branch,
-            agentSessionId: entry.agentSessionId,
-            agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
-          });
-
-          // Stop the idle container after git finalize completes
           try {
-            const c = docker.getContainer(container.id);
-            await c.stop({ t: CONTAINER_STOP_TIMEOUT_S });
-          } catch {
-            // Container may already be stopped
+            await this.handleProcessExit(executionId, request, CONTAINER_CWD, exitCode, {
+              signal,
+              branch: handle.branch,
+              agentSessionId: entry.agentSessionId,
+              agentName: request.actionType === 'ai_task' ? executionAgent : undefined,
+            });
+
+            // Stop the idle container after git finalize completes
+            try {
+              const c = docker.getContainer(container.id);
+              await c.stop({ t: CONTAINER_STOP_TIMEOUT_S });
+            } catch {
+              // Container may already be stopped
+            }
+          } finally {
+            entry.finalizingAfterClose = false;
           }
         });
       });

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -497,6 +497,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
 
     child.on('close', async (code, signal) => {
       const exitCode = code ?? (signal ? 1 : 0);
+      entry.finalizingAfterClose = true;
       try {
         if (driver && entry.rawStdout) {
           // Extract real backend session/thread ID BEFORE writing the file,
@@ -539,6 +540,7 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
       } finally {
         const ent = this.entries.get(executionId);
         if (ent) {
+          ent.finalizingAfterClose = false;
           ent.process = null;
           ent.phase = 'completed';
           this.softReleasePoolSlot(ent);


### PR DESCRIPTION
## Summary

Prevent the executing-stall watchdog from failing a running task on heartbeat staleness alone while its selected attempt lease is still valid.

Keep executor heartbeats alive after the child process closes while worktree or docker finalization is still pending.

Add regressions for both races, including the proven worktree case where completion is pending but heartbeats previously stopped.

## Architecture

### Before

```mermaid
graph TD
    A[Child process closes] --> B[handleProcessExit marks entry completed]
    B --> C[Heartbeat timer stops]
    C --> D[Finalization still pending]
    D --> E[Watchdog can see stale heartbeat before completion]
```

### After

```mermaid
graph TD
    A[Child process closes] --> B[Executor marks finalizingAfterClose]
    B --> C[Heartbeat timer continues during finalization]
    C --> D[Completion response is emitted]
    D --> E[Entry is marked completed and heartbeat stops]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/executing-stall.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/worktree-executor.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/ssh-executor.test.ts -t "keeps heartbeats alive while close finalization is pending"`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 06b7ba19b`
- Post-revert steps: None
- Data migration? No
