### PR TITLE
Add app/contract bridge for recreateDownstream primitive

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -98,6 +98,7 @@ function createMocks() {
       setFixAwaitingApproval: vi.fn(),
       retryTask: vi.fn(() => [makeTask()]),
       recreateTask: vi.fn(() => [makeTask()]),
+      recreateDownstream: vi.fn(() => [makeTask()]),
       retryWorkflow: vi.fn(() => [makeTask()]),
       recreateWorkflow: vi.fn(() => [makeTask()]),
       editTaskCommand: vi.fn(() => [makeTask()]),
@@ -161,6 +162,13 @@ function createMocks() {
           return { ok: true, data: mocks.orchestrator.recreateTask(envelope.payload.taskId) };
         } catch (err) {
           return { ok: false, error: { code: 'RECREATE_TASK_FAILED', message: (err as Error).message } };
+        }
+      }),
+      recreateDownstream: vi.fn(async (envelope: { payload: { taskId: string } }) => {
+        try {
+          return { ok: true, data: mocks.orchestrator.recreateDownstream(envelope.payload.taskId) };
+        } catch (err) {
+          return { ok: false, error: { code: 'RECREATE_DOWNSTREAM_FAILED', message: (err as Error).message } };
         }
       }),
       retryWorkflow: vi.fn(async (envelope: { payload: { workflowId: string } }) => {
@@ -256,6 +264,7 @@ beforeEach(() => {
   mocks.orchestrator.getTask.mockImplementation((id: string) => (id === 'task-1' ? makeTask() : undefined));
   mocks.orchestrator.approve.mockResolvedValue([]);
   mocks.orchestrator.retryTask.mockReturnValue([makeTask()]);
+  mocks.orchestrator.recreateDownstream.mockReturnValue([makeTask()]);
   mocks.orchestrator.beginConflictResolution.mockReturnValue({ savedError: 'saved-error' });
   mocks.orchestrator.editTaskCommand.mockReturnValue([makeTask()]);
   mocks.orchestrator.editTaskPrompt.mockReturnValue([makeTask()]);
@@ -461,6 +470,58 @@ describe('POST /api/tasks/:id/restart', () => {
     expect(res.status).toBe(200);
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(1);
     expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledWith([scoped]);
+  });
+});
+
+describe('POST /api/tasks/:id/recreate-downstream', () => {
+  it('recreates downstream via facade recreateDownstream', async () => {
+    const res = await request(port, 'POST', '/api/tasks/task-1/recreate-downstream');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.taskId).toBe('task-1');
+    expect(res.body.action).toBe('recreated_downstream');
+    expect(mocks.commandService.recreateDownstream).toHaveBeenCalledTimes(1);
+    expect(mocks.orchestrator.recreateDownstream).toHaveBeenCalledWith('task-1');
+    // The selected task itself is never recreate-reset by this route.
+    expect(mocks.orchestrator.recreateTask).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on error', async () => {
+    mocks.orchestrator.recreateDownstream.mockImplementation(() => {
+      throw new Error('task has no downstream');
+    });
+    const res = await request(port, 'POST', '/api/tasks/task-1/recreate-downstream');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('task has no downstream');
+  });
+
+  it('does not match the recreate (task) route', async () => {
+    await request(port, 'POST', '/api/tasks/task-1/recreate-downstream');
+    expect(mocks.orchestrator.recreateTask).not.toHaveBeenCalled();
+    expect(mocks.orchestrator.recreateDownstream).toHaveBeenCalledWith('task-1');
+  });
+
+  it('tops up globally ready tasks after scoped downstream launch', async () => {
+    const scoped = makeTask({
+      id: 'wf-1/task-2',
+      config: { workflowId: 'wf-1' },
+      status: 'running',
+      execution: { selectedAttemptId: 'attempt-2' },
+    });
+    const topup = makeTask({
+      id: 'wf-2/task-9',
+      config: { workflowId: 'wf-2' },
+      status: 'running',
+      execution: { selectedAttemptId: 'attempt-9' },
+    });
+    mocks.orchestrator.recreateDownstream.mockReturnValue([scoped]);
+    mocks.orchestrator.startExecution.mockReturnValue([topup]);
+
+    const res = await request(port, 'POST', '/api/tasks/task-1/recreate-downstream');
+    expect(res.status).toBe(200);
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenCalledTimes(2);
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(1, [scoped]);
+    expect(mocks.taskExecutor.executeTasks).toHaveBeenNthCalledWith(2, [topup]);
   });
 });
 

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -29,6 +29,32 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
+  it('delegates `recreate-downstream <taskId>` to the owner endpoint and honors --no-track', async () => {
+    const bus = new LocalBus();
+    const ownerHandler = vi.fn(async () => ({ ok: true }));
+    bus.onRequest('headless.exec', ownerHandler);
+    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'standalone' }));
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const runElectronHeadless = vi.fn(async () => 0);
+
+    const exitCode = await runHeadlessClientCommand(['recreate-downstream', 'wf-1/task-1', '--no-track'], {
+      messageBus: bus,
+      ensureStandaloneOwner,
+      runElectronHeadless,
+    });
+
+    expect(exitCode).toBe(0);
+    // recreate-downstream is a mutating command, so it is delegated to the
+    // shared owner endpoint rather than falling back to the host runtime.
+    expect(ownerHandler).toHaveBeenCalledWith(expect.objectContaining({
+      args: ['recreate-downstream', 'wf-1/task-1'],
+      noTrack: true,
+      waitForApproval: false,
+    }));
+    expect(runElectronHeadless).not.toHaveBeenCalled();
+  });
+
   it('delegates mutating commands to an existing non-standalone owner without bootstrapping', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -64,6 +64,7 @@ export interface ApiMutationFacade {
   cancelTask(taskId: string): Promise<CancelMutationResult>;
   retryTask(taskId: string): Promise<MutationResult>;
   recreateTask(taskId: string): Promise<MutationResult>;
+  recreateDownstream(taskId: string): Promise<MutationResult>;
   resolveConflict(taskId: string, agentName?: string): Promise<ResolveConflictMutationResult>;
   approveTask(taskId: string): Promise<ApproveMutationResult>;
   rejectTask(taskId: string, reason?: string): void;
@@ -295,6 +296,24 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
         try {
           const result = await mutations.recreateTask(taskId);
           json(res, 200, { ok: true, taskId, action: 'recreated', tasksStarted: result.runnable.length });
+        } catch (err) {
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
+        }
+        return;
+      }
+
+      // POST /api/tasks/:id/recreate-downstream
+      const recreateDownstreamMatch = path.match(/^\/api\/tasks\/([^/]+)\/recreate-downstream$/);
+      if (method === 'POST' && recreateDownstreamMatch) {
+        const taskId = decodeURIComponent(recreateDownstreamMatch[1]);
+        try {
+          const result = await mutations.recreateDownstream(taskId);
+          json(res, 200, {
+            ok: true,
+            taskId,
+            action: 'recreated_downstream',
+            tasksStarted: result.runnable.length,
+          });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }

--- a/packages/app/src/headless-command-registry.ts
+++ b/packages/app/src/headless-command-registry.ts
@@ -32,6 +32,7 @@ export const HEADLESS_COMMANDS = [
   { name: 'retry-task', kind: 'write' },
   { name: 'recreate', kind: 'write' },
   { name: 'recreate-task', kind: 'write' },
+  { name: 'recreate-downstream', kind: 'write' },
   { name: 'replace-task', kind: 'special' },
   { name: 'fork-workflow', kind: 'special' },
   { name: 'detach-workflow', kind: 'write' },

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1035,6 +1035,9 @@ export async function runHeadless(args: string[], deps: HeadlessDeps): Promise<v
     case 'recreate-task':
       await headlessRecreateTask(args[1], deps);
       break;
+    case 'recreate-downstream':
+      await headlessRecreateDownstream(args[1], deps);
+      break;
     case 'replace-task':
       throw new Error(
         'Headless replace-task is disabled because it is not a safe supported CLI flow. ' +
@@ -1909,6 +1912,72 @@ async function headlessRecreateTask(taskId: string, deps: HeadlessDeps): Promise
   }
   if (deps.noTrack) {
     process.stdout.write('[headless] --no-track enabled: recreate-task accepted; exiting without tracking.\n');
+    autoFix.unsubscribe();
+    return;
+  }
+  if (workflowId) {
+    await trackHeadlessWorkflow(workflowId, deps, {
+      hasBackgroundWork: autoFix.isBusy,
+      printSummary: false,
+      printTaskOutput: true,
+      setExitCodeOnFailure: false,
+    });
+  }
+  autoFix.unsubscribe();
+}
+
+async function headlessRecreateDownstream(taskId: string, deps: HeadlessDeps): Promise<void> {
+  if (!taskId) {
+    throw new Error('Missing arguments. Usage: --headless recreate-downstream <taskId>');
+  }
+  const restored = restoreWorkflowForTaskUnlessDeleteAllWon(taskId, deps, 'recreate-downstream');
+  if (!restored) return;
+  taskId = restored.resolvedTaskId;
+  if (deps.mutationTiming) {
+    await deps.mutationTiming.span(
+      'headless.recreate-downstream.preemptTaskSubgraph',
+      { taskId },
+      () => preemptTaskSubgraph(taskId, deps),
+    );
+  } else {
+    await preemptTaskSubgraph(taskId, deps);
+  }
+
+  const recreateDownstreamEnvelope = makeEnvelope('recreate-downstream', 'headless', 'task', { taskId });
+  const recreateDownstreamResult = deps.mutationTiming
+    ? await deps.mutationTiming.span(
+      'headless.recreate-downstream.commandService.recreateDownstream',
+      { taskId },
+      () => deps.commandService.recreateDownstream(recreateDownstreamEnvelope),
+    )
+    : await deps.commandService.recreateDownstream(recreateDownstreamEnvelope);
+  if (!recreateDownstreamResult.ok) throw new Error(recreateDownstreamResult.error.message);
+  const started = recreateDownstreamResult.data;
+  const runnable = started.filter(isDispatchableLaunch);
+  const workflowId = deps.orchestrator.getTask(taskId)?.config.workflowId;
+  process.stdout.write(`Recreate downstream of "${taskId}" — ${runnable.length} task(s) to execute (pool fetch skipped)\n`);
+  const te = createHeadlessExecutor(deps);
+  const autoFix = wireHeadlessAutoFix(deps, te);
+  remoteFetchForPool.enabled = false;
+  let topup: TaskState[] = [];
+  try {
+    ({ topup } = await dispatchStartedTasksWithGlobalTopup({
+      orchestrator: deps.orchestrator,
+      taskExecutor: te,
+      logger: deps.logger,
+      context: 'headless.recreate-downstream',
+      started,
+      mutationTiming: deps.mutationTiming,
+    }));
+  } finally {
+    remoteFetchForPool.enabled = true;
+  }
+  if (runnable.length + topup.length === 0) {
+    autoFix.unsubscribe();
+    return;
+  }
+  if (deps.noTrack) {
+    process.stdout.write('[headless] --no-track enabled: recreate-downstream accepted; exiting without tracking.\n');
     autoFix.unsubscribe();
     return;
   }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -3508,6 +3508,54 @@ function createEmbeddedTerminalBackendFromConfig(
     );
 
     registerWorkflowScopedGuiMutationHandler(
+      'invoker:recreate-downstream',
+      (taskIdArg: unknown) => workflowIdForTaskArg(taskIdArg),
+      'high',
+      async (taskIdArg: unknown) => {
+      const taskId = String(taskIdArg);
+      logger.info(`recreate-downstream: "${taskId}"`, { module: 'ipc' });
+      try {
+        if (activeMutationContext?.mutationTiming) {
+          await activeMutationContext.mutationTiming.span(
+            'main.ipc.recreate-downstream.preemptTaskSubgraph',
+            { taskId },
+            () => preemptTaskSubgraph(taskId),
+          );
+        } else {
+          await preemptTaskSubgraph(taskId);
+        }
+        const recreateDownstreamEnvelope = makeEnvelope('recreate-downstream', 'ui', 'task', { taskId });
+        const recreateDownstreamResult = activeMutationContext?.mutationTiming
+          ? await activeMutationContext.mutationTiming.span(
+            'main.ipc.recreate-downstream.commandService.recreateDownstream',
+            { taskId },
+            () => commandService.recreateDownstream(recreateDownstreamEnvelope),
+          )
+          : await commandService.recreateDownstream(recreateDownstreamEnvelope);
+        if (!recreateDownstreamResult.ok) throw new Error(recreateDownstreamResult.error.message);
+        const started = recreateDownstreamResult.data;
+        remoteFetchForPool.enabled = false;
+        try {
+          await dispatchStartedTasksWithGlobalTopup({
+            orchestrator,
+            taskExecutor: requireTaskExecutor(),
+            logger,
+            context: 'ipc.recreate-downstream',
+            started,
+            scopedTaskIds: [taskId],
+            mutationTiming: activeMutationContext?.mutationTiming,
+          });
+        } finally {
+          remoteFetchForPool.enabled = true;
+        }
+      } catch (err) {
+        logger.error(`recreate-downstream failed: ${err}`, { module: 'ipc' });
+        throw err;
+      }
+      },
+    );
+
+    registerWorkflowScopedGuiMutationHandler(
       'invoker:retry-workflow',
       (workflowIdArg: unknown) => String(workflowIdArg),
       'high',

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -259,6 +259,13 @@ export function recreateTask(
   return deps.orchestrator.recreateTask(taskId);
 }
 
+export function recreateDownstream(
+  taskId: string,
+  deps: Pick<ActionDeps, 'orchestrator'>,
+): TaskState[] {
+  return deps.orchestrator.recreateDownstream(taskId);
+}
+
 export function cancelWorkflow(
   workflowId: string,
   deps: Pick<ActionDeps, 'orchestrator'>,

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -29,6 +29,7 @@ import {
   retryWorkflow as sharedRetryWorkflow,
   recreateWorkflow as sharedRecreateWorkflow,
   recreateTask as sharedRecreateTask,
+  recreateDownstream as sharedRecreateDownstream,
   recreateWorkflowFromFreshBase as sharedRecreateWorkflowFromFreshBase,
   rebaseRetry as sharedRebaseRetry,
   rebaseRecreate as sharedRebaseRecreate,
@@ -173,6 +174,16 @@ export class WorkflowMutationFacade {
       }),
     );
     return this.finalizeWithTopup(started, 'facade.recreate-task', { scopedTaskIds: [taskId] });
+  }
+
+  async recreateDownstream(taskId: string): Promise<MutationResult> {
+    const started = await this.runViaCommandService(
+      'task',
+      taskId,
+      (cs) => cs.recreateDownstream(makeEnvelope('facade.recreate-downstream', 'surface', 'task', { taskId })),
+      () => sharedRecreateDownstream(taskId, { orchestrator: this.deps.orchestrator }),
+    );
+    return this.finalizeWithTopup(started, 'facade.recreate-downstream', { scopedTaskIds: [taskId] });
   }
 
   async selectExperiment(taskId: string, experimentId: string): Promise<MutationResult> {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -481,6 +481,17 @@ export const IpcChannels = {
     request: [taskId: string];
     response: void;
   },
+  /**
+   * Recreate-class invalidation scoped to a task's **downstream**
+   * dependents only — the selected task itself is preserved (its
+   * status, branch, commit, workspacePath, and attempt metadata are
+   * untouched) while its transitive descendants are reset with
+   * recreate semantics. Generated as `window.invoker.recreateDownstream`.
+   */
+  'invoker:recreate-downstream': {} as {
+    request: [taskId: string];
+    response: void;
+  },
   'invoker:retry-workflow': {} as {
     request: [workflowId: string];
     response: void;

--- a/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
@@ -31,6 +31,10 @@ describe('InvalidationPlan policy registry', () => {
       scope: 'task',
       mode: 'recreate',
     });
+    expect(ACTION_SPECS.recreateDownstream).toMatchObject({
+      scope: 'task',
+      mode: 'recreate',
+    });
     expect(ACTION_SPECS.retryWorkflow).toMatchObject({
       scope: 'workflow',
       mode: 'retry',
@@ -90,6 +94,48 @@ describe('InvalidationPlan policy registry', () => {
       affectedTaskIds: ['wf-1/child', 'wf-1/grandchild', 'wf-1/root'],
       lockPlan: { workflowIds: ['wf-1'] },
     });
+  });
+
+  it('plans downstream recreate as descendants only, excluding the target', () => {
+    const tasks = [
+      task('wf-1/root', 'wf-1'),
+      task('wf-1/child', 'wf-1', ['wf-1/root']),
+      task('wf-1/grandchild', 'wf-1', ['wf-1/child']),
+      task('wf-1/sibling', 'wf-1'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/root',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'recreateDownstream',
+      scope: 'task',
+      mode: 'recreate',
+      affectedWorkflowIds: ['wf-1'],
+      // Target 'wf-1/root' is NOT in the affected set; siblings are untouched.
+      affectedTaskIds: ['wf-1/child', 'wf-1/grandchild'],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+  });
+
+  it('plans downstream recreate on a leaf as an empty affected set', () => {
+    const tasks = [
+      task('wf-1/root', 'wf-1'),
+      task('wf-1/leaf', 'wf-1', ['wf-1/root']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/leaf',
+      tasks,
+    });
+
+    expect(plan.affectedTaskIds).toEqual([]);
+    expect(plan.affectedWorkflowIds).toEqual([]);
+    expect(plan.lockPlan.workflowIds).toEqual([]);
   });
 
   it('plans task retry as the task plus non-completed descendants', () => {

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -308,6 +308,51 @@ describe('applyInvalidation: workflowFork optional dep', () => {
   });
 });
 
+describe('applyInvalidation: recreateDownstream optional dep', () => {
+  it('throws an explicit missing-dep error when dep is absent', async () => {
+    const deps = makeDeps();
+    await expect(
+      applyInvalidation('task', 'recreateDownstream', 'task-a', deps),
+    ).rejects.toThrow(/'recreateDownstream' dep is missing/);
+  });
+
+  it('routes to the provided dep when present', async () => {
+    const recreateDownstream = vi.fn(async () => []);
+    const deps = makeDeps({ recreateDownstream });
+    await applyInvalidation('task', 'recreateDownstream', 'task-a', deps);
+    expect(recreateDownstream).toHaveBeenCalledWith('task-a');
+  });
+
+  it('rejects workflow-scoped invocation with recreateDownstream action', async () => {
+    const deps = makeDeps({ recreateDownstream: vi.fn(async () => []) });
+    await expect(
+      applyInvalidation('workflow', 'recreateDownstream', 'wf-1', deps),
+    ).rejects.toThrow(/requires scope 'task'/);
+    expect(deps.cancelInFlight).not.toHaveBeenCalled();
+  });
+
+  it('cancel-first ordering applies to recreateDownstream', async () => {
+    const recreateDownstream = vi.fn(async () => []);
+    const deps = makeDeps({ recreateDownstream });
+    await applyInvalidation('task', 'recreateDownstream', 'task-a', deps);
+    expect(deps.cancelInFlight).toHaveBeenCalledWith('task', 'task-a');
+    expect(deps.cancelInFlight.mock.invocationCallOrder[0]).toBeLessThan(
+      recreateDownstream.mock.invocationCallOrder[0],
+    );
+  });
+
+  it('cascadeDownstream runs after recreateDownstream', async () => {
+    const cascadeDownstream = vi.fn(async () => []);
+    const recreateDownstream = vi.fn(async () => []);
+    const deps = makeDeps({ cascadeDownstream, recreateDownstream });
+    await applyInvalidation('task', 'recreateDownstream', 'task-a', deps);
+    expect(cascadeDownstream).toHaveBeenCalledWith('task', 'task-a');
+    expect(recreateDownstream.mock.invocationCallOrder[0]).toBeLessThan(
+      cascadeDownstream.mock.invocationCallOrder[0],
+    );
+  });
+});
+
 // Step 15 (`docs/architecture/task-invalidation-roadmap.md`): the
 // `'scheduleOnly'` action represents the chart's intentional
 // non-invalidating outlier — "Change external gate policy" is a
@@ -525,6 +570,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
   'fixReject',
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',
@@ -534,6 +580,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
 const INVALIDATING_ACTIONS: readonly InvalidationAction[] = [
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5865,6 +5865,217 @@ describe('Orchestrator', () => {
       expect(x.execution.workspacePath).toBe('/tmp/x');
     });
 
+    // ── recreateDownstream (task-scope, descendants only) ──────────
+    //
+    // Shared A → B → C → merge chain plus an unrelated root X, matching
+    // the `recreateTask` scope fixture above. `recreateDownstream`
+    // differs from `recreateTask` in one way: the TARGET task is
+    // preserved; only its transitive dependents are reset.
+    function buildDownstreamChain() {
+      const testPersistence = new InMemoryPersistence();
+      const testBus = new InMemoryBus();
+      const wf = 'wf-recreate-downstream';
+
+      testPersistence.saveTask(wf, {
+        id: 'A',
+        description: 'Root',
+        status: 'completed',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-a',
+          commit: 'a1',
+          workspacePath: '/tmp/a',
+          agentSessionId: 'sess-a',
+          containerId: 'ctr-a',
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'B',
+        description: 'Middle',
+        status: 'completed',
+        dependencies: ['A'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-b',
+          commit: 'b1',
+          workspacePath: '/tmp/b',
+          agentSessionId: 'sess-b',
+          containerId: 'ctr-b',
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'C',
+        description: 'Leaf',
+        status: 'completed',
+        dependencies: ['B'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-c',
+          commit: 'c1',
+          workspacePath: '/tmp/c',
+          agentSessionId: 'sess-c',
+          containerId: 'ctr-c',
+          exitCode: 0,
+        },
+      });
+
+      const testOrchestrator = new Orchestrator({
+        persistence: testPersistence,
+        messageBus: testBus,
+        maxConcurrency: 3,
+      });
+      testOrchestrator.syncFromDb(wf);
+      return testOrchestrator;
+    }
+
+    it('recreateDownstream(A) preserves the root and resets B and C (recreate-class)', () => {
+      const o = buildDownstreamChain();
+
+      const aBefore = o.getTask('A')!;
+      const aGenBefore = aBefore.execution.generation ?? 0;
+      const aAttemptBefore = aBefore.execution.selectedAttemptId;
+      const cGenBefore = o.getTask('C')!.execution.generation ?? 0;
+
+      o.recreateDownstream('A');
+
+      // Root A is untouched: status, lineage, agent/session/container,
+      // selected attempt, and execution generation all preserved.
+      const a = o.getTask('A')!;
+      expect(a.status).toBe('completed');
+      expect(a.execution.branch).toBe('br-a');
+      expect(a.execution.commit).toBe('a1');
+      expect(a.execution.workspacePath).toBe('/tmp/a');
+      expect(a.execution.agentSessionId).toBe('sess-a');
+      expect(a.execution.containerId).toBe('ctr-a');
+      expect(a.execution.selectedAttemptId).toBe(aAttemptBefore);
+      expect(a.execution.generation ?? 0).toBe(aGenBefore);
+
+      // Descendants B and C are recreate-reset: pending (or auto-started
+      // running for the now-ready B), fresh lineage, cleared metadata,
+      // bumped generation.
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+      expect(b.status === 'running' || b.status === 'pending').toBe(true);
+      expect(c.status).toBe('pending');
+
+      expect(b.execution.branch).toBeUndefined();
+      expect(b.execution.commit).toBeUndefined();
+      expect(b.execution.workspacePath).toBeUndefined();
+      expect(b.execution.agentSessionId).toBeUndefined();
+      expect(b.execution.containerId).toBeUndefined();
+
+      expect(c.execution.branch).toBeUndefined();
+      expect(c.execution.commit).toBeUndefined();
+      expect(c.execution.workspacePath).toBeUndefined();
+      expect(c.execution.agentSessionId).toBeUndefined();
+      expect(c.execution.containerId).toBeUndefined();
+      expect(c.execution.generation ?? 0).toBeGreaterThan(cGenBefore);
+    });
+
+    it('recreateDownstream(B) resets C only, leaving A and B unchanged', () => {
+      const o = buildDownstreamChain();
+
+      const started = o.recreateDownstream('B');
+
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+
+      // A and B preserved verbatim.
+      expect(a.status).toBe('completed');
+      expect(a.execution.branch).toBe('br-a');
+      expect(a.execution.workspacePath).toBe('/tmp/a');
+      expect(b.status).toBe('completed');
+      expect(b.execution.branch).toBe('br-b');
+      expect(b.execution.workspacePath).toBe('/tmp/b');
+
+      // Only C is reset.
+      expect(c.status === 'running' || c.status === 'pending').toBe(true);
+      expect(c.execution.branch).toBeUndefined();
+      expect(c.execution.workspacePath).toBeUndefined();
+
+      // Any started task must be a descendant — never the preserved A/B.
+      for (const t of started) {
+        expect(t.id === 'A' || t.id === 'B').toBe(false);
+      }
+    });
+
+    it('recreateDownstream on a leaf is a no-op and returns no started tasks', () => {
+      const o = buildDownstreamChain();
+
+      const cBefore = o.getTask('C')!;
+      const cGenBefore = cBefore.execution.generation ?? 0;
+      const cAttemptBefore = cBefore.execution.selectedAttemptId;
+
+      const started = o.recreateDownstream('C');
+
+      expect(started).toEqual([]);
+
+      // Whole chain is untouched.
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+      expect(a.status).toBe('completed');
+      expect(b.status).toBe('completed');
+      expect(c.status).toBe('completed');
+      expect(c.execution.branch).toBe('br-c');
+      expect(c.execution.workspacePath).toBe('/tmp/c');
+      expect(c.execution.selectedAttemptId).toBe(cAttemptBefore);
+      expect(c.execution.generation ?? 0).toBe(cGenBefore);
+    });
+
+    it('recreateDownstream preserves an ACTIVE (running) target while resetting descendants', () => {
+      const testPersistence = new InMemoryPersistence();
+      const testBus = new InMemoryBus();
+      const wf = 'wf-recreate-downstream-active';
+
+      testPersistence.saveTask(wf, {
+        id: 'A',
+        description: 'Running root',
+        status: 'running',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: { branch: 'br-a', commit: 'a1', workspacePath: '/tmp/a' },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'B',
+        description: 'Downstream',
+        status: 'pending',
+        dependencies: ['A'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: { branch: 'br-b', commit: 'b1', workspacePath: '/tmp/b' },
+      });
+
+      const o = new Orchestrator({
+        persistence: testPersistence,
+        messageBus: testBus,
+        maxConcurrency: 3,
+      });
+      o.syncFromDb(wf);
+
+      o.recreateDownstream('A');
+
+      // The running target is NOT cancelled by the descendant-scoped
+      // cancel-first pass.
+      const a = o.getTask('A')!;
+      expect(a.status).toBe('running');
+      expect(a.execution.branch).toBe('br-a');
+
+      // B is reset; it stays pending because A is still running (not ready).
+      const b = o.getTask('B')!;
+      expect(b.status).toBe('pending');
+      expect(b.execution.branch).toBeUndefined();
+      expect(b.execution.workspacePath).toBeUndefined();
+    });
+
     it('drainScheduler sets lastHeartbeatAt when starting a task', () => {
       orchestrator.loadPlan({
         name: 'heartbeat-start-test',

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -166,6 +166,25 @@ export class CommandService {
   }
 
   /**
+   * Recreate a task's **downstream** dependents — recreate-class
+   * invalidation scoped to the selected task's transitive descendants
+   * only. Unlike `recreateTask`, the selected task itself is preserved:
+   * its status, branch/commit/workspacePath lineage, attempt metadata,
+   * and execution generation are not mutated. Use this to rerun
+   * subsequent tasks on top of a manually updated selected-task branch
+   * without discarding that task's work.
+   */
+  async recreateDownstream(
+    envelope: CommandEnvelope<{ taskId: string }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'RECREATE_DOWNSTREAM_FAILED',
+      () => applyInvalidation('task', 'recreateDownstream', envelope.payload.taskId, this.invalidationDeps),
+      this.workflowIdForTask(envelope.payload.taskId),
+    );
+  }
+
+  /**
    * @deprecated Step 13 (`docs/architecture/task-invalidation-roadmap.md`):
    * `restartTask` was the overloaded "retry-or-recreate" verb the
    * chart's "Naming inconsistency" section flagged. Use the explicit

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -8,6 +8,7 @@ export type InvalidationAction =
   | 'retryTask'
   | 'retryWorkflow'
   | 'recreateTask'
+  | 'recreateDownstream'
   | 'recreateWorkflow'
   | 'recreateWorkflowFromFreshBase'
   | 'workflowFork';
@@ -70,6 +71,13 @@ export interface InvalidationDeps {
   cancelInFlight: CancelInFlightFn;
   retryTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   recreateTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  /**
+   * Task-scope downstream recreate: resets the target's descendants
+   * (recreate-class) while preserving the target task. Optional like
+   * `workflowFork` — callers that never route `'recreateDownstream'`
+   * may omit it; the router throws an explicit missing-dep error.
+   */
+  recreateDownstream?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   retryWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflowFromFreshBase?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
@@ -247,6 +255,17 @@ export const ACTION_SPECS: Readonly<Record<InvalidationAction, ActionSpec>> = Ob
     reason: 'task.recreate',
     selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
   },
+  recreateDownstream: {
+    scope: 'task',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'task.recreateDownstream',
+    // Recreate-class reset of the target's descendants ONLY — the
+    // target task itself is preserved. Contrast `recreateTask`, whose
+    // `taskAndDescendants` also resets the target.
+    selectAffectedTasks: ({ targetId, tasks }) => descendantsOf(targetId, taskMap(tasks)),
+  },
   retryWorkflow: {
     scope: 'workflow',
     stages: INVALIDATING_STAGES,
@@ -377,6 +396,17 @@ async function invokePrimitive(
       return await deps.retryTask(ctx.id);
     case 'recreateTask':
       return await deps.recreateTask(ctx.id);
+    case 'recreateDownstream': {
+      if (!deps.recreateDownstream) {
+        throw new Error(
+          "applyInvalidation: 'recreateDownstream' dep is missing. " +
+            'Production callers wire this via buildInvalidationDeps in ' +
+            '@invoker/app/workflow-actions; tests must supply ' +
+            'deps.recreateDownstream to use this action.',
+        );
+      }
+      return await deps.recreateDownstream(ctx.id);
+    }
     case 'retryWorkflow':
       return await deps.retryWorkflow(ctx.id);
     case 'recreateWorkflow':
@@ -425,6 +455,7 @@ export interface InvalidationDepsOrchestrator {
   cancelWorkflow(workflowId: string): { runningCancelled: string[] };
   retryTask(taskId: string): TaskState[];
   recreateTask(taskId: string): TaskState[];
+  recreateDownstream(taskId: string): TaskState[];
   retryWorkflow(workflowId: string): TaskState[];
   recreateWorkflow(workflowId: string): TaskState[];
   recreateWorkflowFromFreshBase(workflowId: string): Promise<TaskState[]>;
@@ -487,6 +518,7 @@ export function buildOrchestratorOnlyInvalidationDeps(
     cancelInFlight: buildCancelInFlight({ orchestrator }),
     retryTask: (taskId) => orchestrator.retryTask(taskId),
     recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    recreateDownstream: (taskId) => orchestrator.recreateDownstream(taskId),
     retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
     recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
     recreateWorkflowFromFreshBase: (workflowId) =>

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1099,6 +1099,7 @@ export class Orchestrator {
   private cancelActiveBeforeInvalidation(
     scope: 'task' | 'workflow',
     id: string,
+    opts?: { excludeRoot?: boolean },
   ): string[] {
     let candidates: TaskState[];
     if (scope === 'task') {
@@ -1111,12 +1112,12 @@ export class Orchestrator {
         taskMap,
         (t) => t.status === 'completed' || t.status === 'stale',
       );
-      candidates = [
-        root,
-        ...descendantIds
-          .map((d) => taskMap.get(d))
-          .filter((t): t is TaskState => !!t),
-      ];
+      const descendants = descendantIds
+        .map((d) => taskMap.get(d))
+        .filter((t): t is TaskState => !!t);
+      // `recreateDownstream` preserves the target task, so its active
+      // attempt must NOT be cancelled — only descendants are interrupted.
+      candidates = opts?.excludeRoot ? descendants : [root, ...descendants];
     } else {
       candidates = this.stateMachine
         .getAllTasks()
@@ -2525,6 +2526,100 @@ export class Orchestrator {
     };
 
     this.logger.info('[orchestrator] recreateTask reset', {
+      taskId: rootId,
+      resetCount: toResetIds.length,
+    });
+
+    for (const id of toResetIds) {
+      const current = this.stateGetTask(id);
+      if (!current) continue;
+      const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
+      const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
+      const priorAttemptId = current.execution.selectedAttemptId;
+      this.replaceSelectedAttempt(current);
+      this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(current, recreateUpdated, changesWithGeneration));
+
+      this.deferredTaskIds.delete(id);
+      this.clearQueuedSchedulerEntries(id, priorAttemptId);
+    }
+
+    const readyIds = this.stateMachine
+      .getReadyTasks()
+      .map((t) => t.id)
+      .filter((id) => toResetSet.has(id));
+    plan = withSchedulerEnqueueCandidates(plan, readyIds);
+    this.lastInvalidationPlan = plan;
+    return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
+  }
+
+  /**
+   * Task-scoped **downstream** recreate: reset every transitive
+   * dependent of the target task — but NOT the target itself — to
+   * pending using recreate-class execution clearing, then auto-start
+   * newly ready tasks within that affected subgraph.
+   *
+   * Contrast with {@link recreateTask}, which also resets the target.
+   * For a chain A → B → C:
+   *   recreateTask(A)        → resets A, B, C
+   *   recreateDownstream(A)  → preserves A; resets B, C
+   *   recreateDownstream(B)  → preserves A, B; resets C
+   *
+   * Calling it on a leaf task (no descendants) is a no-op and returns
+   * an empty array. The target task's status, branch, commit,
+   * workspacePath, selectedAttemptId, agent/session/container metadata,
+   * and execution generation are all left untouched.
+   */
+  recreateDownstream(taskId: string): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+
+    const rootId = task.id;
+
+    // Step 18 cancel-first invariant, scoped to descendants only:
+    // interrupt active attempts on the downstream subgraph BEFORE the
+    // recreate reset, while leaving the preserved target's active
+    // attempt running. Defense-in-depth for direct callers; a no-op
+    // when invoked through `applyInvalidation`.
+    this.cancelActiveBeforeInvalidation('task', rootId, { excludeRoot: true });
+    let plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: rootId,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
+    // `selectAffectedTasks` for `recreateDownstream` returns descendants
+    // only, so `affectedTaskIds` already excludes the target task.
+    const toResetIds = plan.affectedTaskIds;
+    const toResetSet = new Set(toResetIds);
+
+    const resetChanges: TaskStateChanges = {
+      status: 'pending',
+      config: { summary: undefined },
+      execution: {
+        autoFixAttempts: 0,
+        startedAt: undefined,
+        completedAt: undefined,
+        error: undefined,
+        exitCode: undefined,
+        commit: undefined,
+        branch: undefined,
+        workspacePath: undefined,
+        lastHeartbeatAt: undefined,
+        phase: undefined,
+        launchStartedAt: undefined,
+        launchCompletedAt: undefined,
+        reviewUrl: undefined,
+        reviewId: undefined,
+        reviewStatus: undefined,
+        reviewProviderId: undefined,
+        agentSessionId: undefined,
+        containerId: undefined,
+      },
+    };
+
+    this.logger.info('[orchestrator] recreateDownstream reset', {
       taskId: rootId,
       resetCount: toResetIds.length,
     });


### PR DESCRIPTION
## Summary

This PR adds the app and contract bridge for the existing workflow-core `recreateDownstream` primitive.

It adds no renderer UI. It only wires the primitive through the contract, IPC, headless, and HTTP surfaces.

`recreateDownstream` preserves the selected task and recreate-resets only its transitive downstream dependents. Operators need this to rerun subsequent tasks on top of a manually fixed selected-task branch.

The primitive already existed in the orchestrator and invalidation policy.

This slice exposes it through a new IPC channel, a CommandService method, a facade method, a headless command, and an API route.

Each surface mirrors the existing `recreate-task` and `retry-task` patterns. The new path inherits the same mutation serialization, downstream dispatch, and global topup lifecycle.

Existing recreate-task and retry-task behavior is untouched.

## Architecture

### Before

```mermaid
graph TD
    UI[window.invoker.recreateTask] --> IPCa[invoker:recreate-task]
    CLIa[headless recreate-task] --> CSa
    APIa[POST /tasks/:id/recreate] --> Facade
    IPCa --> CSa[CommandService.recreateTask]
    Facade[Facade.recreateTask] --> CSa
    CSa --> ORCa[Orchestrator.recreateTask]
    ORCd[Orchestrator.recreateDownstream unreachable]
```

### After

```mermaid
graph TD
    UI[window.invoker.recreateDownstream] --> IPCd[invoker:recreate-downstream]
    CLId[headless recreate-downstream with --no-track] --> CSd
    APId[POST /tasks/:id/recreate-downstream] --> Facade
    IPCd --> CSd[CommandService.recreateDownstream]
    Facade[Facade.recreateDownstream] --> CSd
    CSd --> APPLY[applyInvalidation task recreateDownstream]
    APPLY --> ORCd[Orchestrator.recreateDownstream]
    IPCd --> DISPATCH[dispatchStartedTasksWithGlobalTopup]
```

## Test Plan

- [ ] `cd packages/app && pnpm test -- src/__tests__/headless-client.test.ts src/__tests__/api-server.test.ts`
- [ ] `pnpm --filter @invoker/contracts build`
- [ ] `pnpm --filter @invoker/workflow-core build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 1507bbce`
- Post-revert steps: None. The change is additive; reverting removes the new channel, command, route, and CommandService method without touching existing recreate-task/retry-task paths.
- Data migration? No
