### PR TITLE
Enforce stack-first plan-to-invoker workflows

### DIFF
--- a/skills/plan-to-invoker/SKILL.md
+++ b/skills/plan-to-invoker/SKILL.md
@@ -68,6 +68,10 @@ Grep-only checks are Phase 1a only; behavioral claims require executed Phase 1b 
 
 **Review compression (required for implementation plans):** Before authoring any plan with `onFinish != none`, apply `skills/review-compression/SKILL.md`. Split by reviewer cognition, not file count: one local review claim, one safety invariant, one slice rationale, and one architectural effect per implementation task. This applies to Invoker and non-Invoker target repos.
 
+**Stack-first authoring (default for implementation plans):** For any plan with `onFinish != none`, default to an authored Invoker workflow stack, not one YAML with many implementation tasks. In Invoker, one YAML file is one workflow; `tasks:` are only tasks inside that workflow. If the implementation has more than one review slice, layer, implementation prompt task, package boundary, UI+non-UI boundary, or PR-worthy commit, write multiple `step-N` YAML files and submit them with `scripts/submit-workflow-chain.sh`. Later workflow templates must depend on the previous workflow's merge gate with `externalDependencies` using `workflowId: "__UPSTREAM_WORKFLOW_ID__"`, `taskId: "__merge__"`, `requiredStatus: completed`, and `gatePolicy: review_ready` unless the user explicitly requests a different gate.
+
+**Standalone workflow waiver (exception, not default):** A single implementation workflow is allowed only when the whole change is one review claim that fits in one implementation prompt task plus verification, or when the user explicitly asks for a single workflow. Any standalone implementation YAML with multiple prompt tasks must include a top-level `description` section headed `Standalone workflow waiver:` explaining why it is not split. Without that waiver, `lint-task-atomicity.sh` rejects multi-prompt standalone implementation workflows.
+
 **Policy-matrix documents:** When the source is an architecture or policy document with a decision table, exception rules, or cross-cutting invariants, you must preserve row-level coverage before authoring workflows. Do not stop at files/functions/packages; every required policy row must map to a workflow step or an explicit waiver.
 
 **Delegated task hints (hard requirement for implementation plans):** For plans with `onFinish != none`, every prompt task must include `Files:`, `Change types:`, and `Acceptance criteria:` sections in `description`. Prompt text must be zero-context executable: assume no prior chat knowledge, include deterministic pass/fail expectations, and keep instructions self-contained. Verify-only plans (`onFinish: none`) keep delegation hints advisory.
@@ -147,8 +151,8 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
    `bash scripts/ui-visual-proof.sh --label before` and `--label after`
 9. `step-remote-ci-verify` (high-risk changes)
    `bash skills/remote-ci-verify/scripts/run-remote-ci-verify.sh`
-10. `step-submit` (no stacking)
-    Use when the plan has NO `externalDependencies`.
+10. `step-submit-standalone-waived` (exception path)
+    Use only for verify-only plans, explicitly requested single-workflow plans, or implementation plans that satisfy the `Standalone workflow waiver:` rule.
     `./submit-plan.sh <plan-file>`
     If the target repo is Invoker itself, finish the PR publication step with `mergify stack push` from the working branch after the stack of commits is ready.
 10a. `step-submit-stacked` (single plan with upstream dependency)
@@ -159,10 +163,10 @@ If `skill-doctor.sh` fails, run individual checks to isolate the problem:
      4. Submit: `./submit-plan.sh <plan-file>`
      5. If the target repo is Invoker itself, publish/update the resulting PR stack with `mergify stack push` after submission-side commits are ready.
 10b. `step-submit-chain` (batch stacking, multiple template plans)
-     Use when submitting an entire dependency chain at once.
+     Default path for implementation work with more than one review slice.
      `./scripts/submit-workflow-chain.sh [--gate-policy completed|review_ready] <plan1.yaml> <plan2.template.yaml> ...`
      The chain script handles: template rendering, baseBranch rewrite, merge-gate injection, sequential submission. For Invoker-on-Invoker work only, publish the resulting GitHub PR stack with `mergify stack push` once the chain's commits are prepared.
-     Strict default: when `--gate-policy` is omitted, chain submission enforces `taskId: "__merge__"` + `requiredStatus: completed` + `gatePolicy: completed` for upstream workflow dependencies.
+     Strict default: when `--gate-policy` is omitted, chain submission enforces `taskId: "__merge__"` + `requiredStatus: completed` + `gatePolicy: review_ready` for upstream workflow dependencies.
 
 ## Runtime verification (Phase 1b)
 

--- a/skills/plan-to-invoker/references/task-patterns.md
+++ b/skills/plan-to-invoker/references/task-patterns.md
@@ -29,6 +29,23 @@ Command tasks run under the platform default shell unless the command explicitly
 
 These are constraints, not guidelines. Violating them produces broken plans.
 
+## Workflow Stack Default
+
+For implementation work (`onFinish != none`), default to a stack of workflow YAML
+files. One YAML file is one Invoker workflow; multiple `tasks:` entries inside
+that file are not a workflow stack.
+
+Split into multiple workflow files when the plan has more than one review slice,
+layer, implementation prompt task, package boundary, UI+non-UI boundary, or
+PR-worthy commit. Submit the resulting chain with
+`scripts/submit-workflow-chain.sh`, using `__UPSTREAM_WORKFLOW_ID__` in later
+templates so each workflow depends on the previous workflow's `__merge__` task.
+
+Standalone implementation workflows are exceptions. If a standalone
+implementation workflow contains multiple prompt tasks, it must include
+`Standalone workflow waiver:` in the top-level description with the reason it is
+not split.
+
 ### Must be sequential (add dependency)
 - **Same file modified by two tasks** → one depends on the other. Order by logical sequence.
 - **Test task** → depends on the implementation task it verifies.

--- a/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
+++ b/skills/plan-to-invoker/scripts/lint-task-atomicity.sh
@@ -47,7 +47,9 @@ if [[ ! -f "$file" ]]; then
 fi
 
 require_final_test_all=1
+stack_manifest_provided=0
 if [[ -n "$stack_manifest_file" ]]; then
+  stack_manifest_provided=1
   if [[ ! -f "$stack_manifest_file" ]]; then
     echo "ERROR: Stack manifest not found: $stack_manifest_file" >&2
     exit 1
@@ -116,7 +118,7 @@ PY
   )"
 fi
 
-awk -v warnDelegation="$warn_delegation" -v strictDelegation="$strict_delegation" -v requireFinalTestAll="$require_final_test_all" '
+awk -v warnDelegation="$warn_delegation" -v strictDelegation="$strict_delegation" -v requireFinalTestAll="$require_final_test_all" -v stackManifestProvided="$stack_manifest_provided" '
 function trim(s) { gsub(/^[ \t]+|[ \t]+$/, "", s); return s }
 function strip_quotes(s) { gsub(/["'\''"]/, "", s); return s }
 function normalize_command(s) {
@@ -232,6 +234,7 @@ function flush_task(    wc, and_count, valid_id, d, desc_lower, idx) {
   }
 
   if (has_prompt) {
+    prompt_task_count++
     if (length(prompt_text) < 120) {
       errors[++errn] = "Task \"" id "\" prompt too short (<120 chars); include file paths + explicit acceptance criteria"
     }
@@ -389,6 +392,9 @@ BEGIN {
   warnn = 0
   taskn = 0
   has_experiment_tasks = 0
+  has_external_dependencies = 0
+  prompt_task_count = 0
+  standalone_workflow_waiver = 0
   on_finish = "pull_request"
   enforce_layering = 1
 }
@@ -396,12 +402,20 @@ BEGIN {
 {
   line = $0
 
+  if (tolower(line) ~ /standalone workflow waiver:/) {
+    standalone_workflow_waiver = 1
+  }
+
   if (!in_task && line ~ /^[[:space:]]*onFinish:[[:space:]]*/) {
     on_finish = line
     sub(/^[[:space:]]*onFinish:[[:space:]]*/, "", on_finish)
     on_finish = trim(strip_quotes(on_finish))
     enforce_layering = (tolower(on_finish) != "none")
     next
+  }
+
+  if (line ~ /^[[:space:]]*externalDependencies:[[:space:]]*$/) {
+    has_external_dependencies = 1
   }
 
   if (in_description_block) {
@@ -552,6 +566,10 @@ END {
   }
 
   if (enforce_layering == 1) {
+    if (stackManifestProvided == 0 && has_external_dependencies == 0 && prompt_task_count > 1 && standalone_workflow_waiver == 0) {
+      errors[++errn] = "Standalone implementation workflow has multiple prompt tasks but no stack context; split into a workflow chain or add \"Standalone workflow waiver:\" with the reason"
+    }
+
     for (idx = 1; idx <= taskn; idx++) {
       deps_csv = task_dependencies[idx]
       if (deps_csv == "") continue

--- a/skills/plan-to-invoker/scripts/test-fixtures.sh
+++ b/skills/plan-to-invoker/scripts/test-fixtures.sh
@@ -293,7 +293,10 @@ test_lint_valid_final_test_all() {
 
   cat > "$temp_plan" <<'EOF'
 name: "Valid final test-all gate"
-description: "Implementation plan with terminal full-suite regression"
+description: |
+  Implementation plan with terminal full-suite regression.
+  Standalone workflow waiver:
+  - This fixture intentionally exercises standalone final-gate lint behavior.
 onFinish: pull_request
 mergeMode: github
 repoUrl: git@github.com:example-org/acme-repo.git
@@ -371,6 +374,104 @@ tasks:
 EOF
 
   bash "$LINT_SCRIPT" "$temp_plan" >/dev/null
+}
+
+test_lint_rejects_multi_prompt_standalone_without_waiver() {
+  local temp_plan
+  temp_plan=$(mktemp)
+  trap "rm -f $temp_plan" RETURN
+
+  cat > "$temp_plan" <<'EOF'
+name: "Invalid multi-prompt standalone workflow"
+description: "Implementation workflow with multiple prompt slices but no stack context."
+onFinish: pull_request
+mergeMode: github
+repoUrl: git@github.com:example-org/acme-repo.git
+tasks:
+  - id: implement-surface
+    description: |
+      Goal:
+      - Implement the contact surface slice.
+      Motivation:
+      - Keep the first implementation step reviewable.
+      Alternative considerations:
+      - Option A (chosen): implement directly.
+      - Option B: defer implementation.
+      Implementation details:
+      - Update packages/foo/src/surface.ts.
+      Layer: contact_surface
+      Feature state: active
+    prompt: |
+      Goal:
+      - Implement the contact surface slice.
+      Motivation:
+      - Keep execution deterministic.
+      Alternative considerations:
+      - Option A (chosen): update packages/foo/src/surface.ts.
+      - Option B: do nothing.
+      Implementation details:
+      - Modify packages/foo/src/surface.ts for the new behavior.
+      Acceptance criteria:
+      - Verify the first implementation slice is present.
+    dependencies: []
+  - id: implement-bridge
+    description: |
+      Goal:
+      - Implement the bridge slice.
+      Motivation:
+      - Keep the second implementation step reviewable.
+      Alternative considerations:
+      - Option A (chosen): implement directly.
+      - Option B: defer implementation.
+      Implementation details:
+      - Update packages/foo/src/bridge.ts.
+      Layer: app_bridge
+      Feature state: active
+    prompt: |
+      Goal:
+      - Implement the bridge slice.
+      Motivation:
+      - Keep execution deterministic.
+      Alternative considerations:
+      - Option A (chosen): update packages/foo/src/bridge.ts.
+      - Option B: do nothing.
+      Implementation details:
+      - Modify packages/foo/src/bridge.ts for the new behavior.
+      Acceptance criteria:
+      - Verify the second implementation slice is present.
+    dependencies: [implement-surface]
+  - id: final-regression
+    description: |
+      Goal:
+      - Run final full-suite regression gate.
+      Motivation:
+      - Validate all standalone tasks together.
+      Alternative considerations:
+      - Option A (chosen): root full-suite verification.
+      - Option B: package-only checks.
+      Implementation details:
+      - Execute the repository test gate.
+      Layer: e2e_regression
+      Feature state: active
+    command: "pnpm run test:all"
+    dependencies: [implement-surface, implement-bridge]
+EOF
+
+  local output
+  set +e
+  output=$(bash "$LINT_SCRIPT" "$temp_plan" 2>&1)
+  local exit_code=$?
+  set -e
+
+  if [[ $exit_code -eq 0 ]]; then
+    echo "Expected lint to reject multi-prompt standalone workflow without waiver" >&2
+    return 1
+  fi
+
+  if ! grep -q 'Standalone implementation workflow has multiple prompt tasks but no stack context' <<<"$output"; then
+    echo "Expected standalone stack-context lint error, got: $output" >&2
+    return 1
+  fi
 }
 
 test_lint_rejects_non_test_all_final_gate() {
@@ -1114,6 +1215,7 @@ run_test "Edge: unrendered_template_placeholder" test_unrendered_template_placeh
 run_test "Edge: stacked_basebranch_default" test_stacked_basebranch_master
 run_test "Edge: unsupported runnerKind field" test_runner_kind_is_unsupported
 run_test "Lint: valid final pnpm run test:all gate" test_lint_valid_final_test_all
+run_test "Lint: reject multi-prompt standalone without waiver" test_lint_rejects_multi_prompt_standalone_without_waiver
 run_test "Lint: reject non-test:all final gate" test_lint_rejects_non_test_all_final_gate
 run_test "Lint: allow non-terminal stack workflow without test:all" test_lint_allows_nonterminal_stack_workflow_without_test_all
 run_test "Lint: reject final gate missing dependencies" test_lint_rejects_final_gate_missing_dependencies


### PR DESCRIPTION
## Summary

Make plan-to-invoker stack-first for implementation plans instead of treating standalone workflows as the normal path.

Document that one YAML file is one Invoker workflow, and that multi-slice implementation work should be authored as chained workflow files.

Add a lint guard so standalone implementation workflows with multiple prompt tasks must include a `Standalone workflow waiver:` explanation.

## Test Plan

- [x] `bash skills/plan-to-invoker/scripts/test-fixtures.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a9e8b9241`
- Post-revert steps: None
- Data migration? No
