### PR TITLE
Fix intent cancellation Step 6: worker response lineage guard (regression gated v2)

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -7088,6 +7088,55 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(taskId)?.status).toBe('running');
     });
 
+    it('rejects a response whose attempt id matches but whose execution generation is stale', () => {
+      orchestrator.loadPlan({
+        name: 'attempt-match-stale-generation-rejection',
+        tasks: [{ id: 't1', description: 'Task 1' }],
+      });
+      orchestrator.startExecution();
+
+      const taskId = sid(orchestrator, 0, 't1');
+      const runningTask = orchestrator.getTask(taskId)!;
+      const activeAttemptId = runningTask.execution.selectedAttemptId!;
+      const staleGeneration = runningTask.execution.generation ?? 0;
+
+      // Establish known live lineage, then advance ONLY the execution
+      // generation while keeping the SAME selected attempt. This is the gap
+      // the guard must close: the response's attempt id still matches the
+      // live task, but the generation it was produced under is now stale.
+      persistence.updateTask(taskId, {
+        execution: {
+          branch: 'experiment/live',
+          workspacePath: '/tmp/live-workspace',
+          generation: staleGeneration + 1,
+        },
+      });
+      orchestrator.syncFromDb(taskId.split('/')[0]!);
+
+      const live = orchestrator.getTask(taskId)!;
+      expect(live.execution.selectedAttemptId).toBe(activeAttemptId);
+      expect(live.execution.generation).toBe(staleGeneration + 1);
+
+      const result = orchestrator.handleWorkerResponse(
+        makeResponse({
+          actionId: taskId,
+          attemptId: activeAttemptId,
+          executionGeneration: staleGeneration,
+          status: 'completed',
+          outputs: { exitCode: 0, branch: 'experiment/stale' },
+        }),
+      );
+
+      // Both fields present → both must match. Stale generation ⇒ rejected,
+      // and the stale response leaves the live task untouched.
+      expect(result).toEqual([]);
+      const after = orchestrator.getTask(taskId)!;
+      expect(after.status).toBe('running');
+      expect(after.execution.selectedAttemptId).toBe(activeAttemptId);
+      expect(after.execution.branch).toBe('experiment/live');
+      expect(after.execution.workspacePath).toBe('/tmp/live-workspace');
+    });
+
     it('recreateWorkflow selects a fresh persisted attempt for recreated tasks', () => {
       orchestrator.loadPlan({
         name: 'recreate-attempt-refresh',

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1700,9 +1700,15 @@ export class Orchestrator {
           });
           return [];
         }
+        // Lineage check: when a response carries an executionGeneration it must
+        // match the live task's generation. This applies even when the response
+        // also carries a matching attemptId — a stale generation means the
+        // response belongs to a superseded execution of that attempt. Responses
+        // from older producers that omit executionGeneration remain accepted, so
+        // backwards compatibility is preserved; when both fields are present they
+        // must both match.
         const activeGeneration = this.getExecutionGeneration(earlyTask);
         if (
-          !response.attemptId &&
           response.executionGeneration !== undefined &&
           response.executionGeneration !== activeGeneration
         ) {


### PR DESCRIPTION
Validation passed. Here is the final PR body:

## Summary

Worker responses that carried a matching `attemptId` were accepted without checking `executionGeneration`. A stale generation of the same attempt could therefore mutate the live task graph.

This closes that gap. `handleWorkerResponse` now rejects any response whose `executionGeneration` is present but does not match the live task's active generation, even when the `attemptId` matches.

Older producers that omit `executionGeneration` stay accepted, so backwards compatibility holds. When both fields are present, both must match for the response to apply.

Rejected stale responses are logged as `STALE_GENERATION_REJECTED`, beside the existing `STALE_ATTEMPT_REJECTED` and `SUPERSEDED_ATTEMPT_REJECTED` guards.

This is Step 6 of the intent-cancellation stack and follows the Step 5 review gate (wf-1778583486424-15).

## Architecture

### Before

```mermaid
graph TD
    A[Worker response] --> B{attemptId matches selectedAttemptId?}
    B -- no --> R[Reject: STALE_ATTEMPT]
    B -- yes --> C{attempt discarded?}
    C -- yes --> S[Reject: SUPERSEDED_ATTEMPT]
    C -- no --> APPLY[Apply to task graph]
```

### After

```mermaid
graph TD
    A[Worker response] --> B{attemptId matches selectedAttemptId?}
    B -- no --> R[Reject: STALE_ATTEMPT]
    B -- yes --> C{attempt discarded?}
    C -- yes --> S[Reject: SUPERSEDED_ATTEMPT]
    C -- no --> G{executionGeneration present and not active?}
    G -- yes --> T[Reject: STALE_GENERATION]
    G -- no --> APPLY[Apply to task graph]
```

## Test Plan

- [ ] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts src/__tests__/orchestrator-dispatcher.test.ts`
- [ ] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No