### PR TITLE
Route task heartbeats through orchestrator

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -135,9 +135,12 @@ const YELLOW = '\x1b[33m';
 
 // ── Shared Helpers ───────────────────────────────────────────
 
-function headlessHeartbeat(taskId: string, deps: Pick<HeadlessDeps, 'persistence'>): void {
-  const now = new Date();
-  try { deps.persistence.updateTask(taskId, { execution: { lastHeartbeatAt: now } }); } catch { /* db locked */ }
+function headlessHeartbeat(
+  taskId: string,
+  event: { at: Date; source: 'executor' | 'remote_workload' },
+  deps: Pick<HeadlessDeps, 'orchestrator'>,
+): void {
+  deps.orchestrator.recordTaskHeartbeat(taskId, { at: event.at, source: event.source });
 }
 
 function buildHeadlessApiServerDeps(
@@ -273,7 +276,7 @@ export function createHeadlessExecutor(
           deps.logger.error(`Failed to persist output for ${taskId}: ${err}`, { module: 'output' });
         }
       },
-      onHeartbeat: (taskId) => headlessHeartbeat(taskId, deps),
+      onHeartbeat: (taskId, event) => headlessHeartbeat(taskId, event, deps),
       ...callbackOverrides,
     },
   });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1483,8 +1483,13 @@ function createEmbeddedTerminalBackendFromConfig(
   const taskDeltaStream = createTaskDeltaStreamSequence();
   const getTaskDeltaStreamSequence = (): number => taskDeltaStream.current();
 
-  const sendTaskDeltaToRenderer = (delta: TaskDelta): void => {
-    workflowMetadataInvalidator?.markFromTaskDelta(delta);
+  const sendTaskDeltaToRenderer = (
+    delta: TaskDelta,
+    options: { markWorkflowMetadata?: boolean } = {},
+  ): void => {
+    if (options.markWorkflowMetadata !== false) {
+      workflowMetadataInvalidator?.markFromTaskDelta(delta);
+    }
     if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) {
       return;
     }
@@ -1759,8 +1764,8 @@ function createEmbeddedTerminalBackendFromConfig(
             { module: 'exec' },
           );
         },
-        onHeartbeat: (taskId) => {
-          const now = new Date();
+        onHeartbeat: (taskId, event) => {
+          const now = event.at;
           const task = orchestrator.getTask(taskId);
           const previousHeartbeat = task?.execution.lastHeartbeatAt instanceof Date
             ? task.execution.lastHeartbeatAt
@@ -1768,12 +1773,7 @@ function createEmbeddedTerminalBackendFromConfig(
               ? new Date(task.execution.lastHeartbeatAt)
               : undefined;
           const heartbeatGapMs = previousHeartbeat ? now.getTime() - previousHeartbeat.getTime() : undefined;
-          try { persistence.updateTask(taskId, { execution: { lastHeartbeatAt: now } }); } catch { /* db locked */ }
-          messageBus.publish(Channels.TASK_DELTA, {
-            type: 'updated' as const,
-            taskId,
-            changes: { execution: { lastHeartbeatAt: now } },
-          });
+          orchestrator.recordTaskHeartbeat(taskId, { at: now, source: event.source });
           logger.info(
             `Heartbeat for "${taskId}" (status: ${task?.status ?? 'unknown'}, generation: ${task?.execution.generation ?? 'unknown'}, gapMs: ${heartbeatGapMs ?? 'first'})`,
             { module: 'heartbeat' },
@@ -2903,9 +2903,8 @@ function createEmbeddedTerminalBackendFromConfig(
       if (traceUiDeltaFlow) {
         logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
       }
-      sendTaskDeltaToRenderer(delta as TaskDelta);
-
       const d = delta as TaskDelta;
+      workflowMetadataInvalidator?.markFromTaskDelta(d);
       const deltaTaskId = d.type === 'updated' || d.type === 'removed'
         ? d.taskId
         : undefined;
@@ -2923,6 +2922,9 @@ function createEmbeddedTerminalBackendFromConfig(
       }
 
       const { quarantined } = applyDelta(d, lastKnownTaskStates);
+      if (quarantined.length === 0) {
+        sendTaskDeltaToRenderer(d, { markWorkflowMetadata: false });
+      }
       for (const taskId of quarantined) {
         logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
         const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -4270,8 +4270,8 @@ describe('TaskRunner', () => {
     });
   });
 
-  describe('SSH heartbeat persistence metadata', () => {
-    it('stores remote workload heartbeat metadata for SSH executors', async () => {
+  describe('SSH heartbeat owner callback metadata', () => {
+    it('passes remote workload heartbeat metadata to the owner callback', async () => {
       const runningTask = makeTask({
         id: 'task-ssh-heartbeat',
         status: 'running',
@@ -4306,6 +4306,7 @@ describe('TaskRunner', () => {
         }),
       } as any;
 
+      const onHeartbeat = vi.fn();
       const runner = new TaskRunner({
         orchestrator: {
           getTask: vi.fn((id: string) => (id === runningTask.id ? runningTask : undefined)),
@@ -4325,7 +4326,7 @@ describe('TaskRunner', () => {
           getAll: vi.fn(() => []),
         } as any,
         cwd: '/tmp',
-        callbacks: { onHeartbeat: vi.fn() },
+        callbacks: { onHeartbeat },
       });
 
       const pending = runner.executeTask(runningTask);
@@ -4339,14 +4340,19 @@ describe('TaskRunner', () => {
       });
       await pending;
 
-      expect(updateTask).toHaveBeenCalledWith(
+      expect(updateTask).not.toHaveBeenCalledWith(
         runningTask.id,
         expect.objectContaining({
           execution: expect.objectContaining({
             lastHeartbeatAt: expect.any(Date),
-            remoteHeartbeatAt: expect.any(Date),
-            heartbeatSource: 'remote_workload',
           }),
+        }),
+      );
+      expect(onHeartbeat).toHaveBeenCalledWith(
+        runningTask.id,
+        expect.objectContaining({
+          at: expect.any(Date),
+          source: 'remote_workload',
         }),
       );
       expect(updateAttempt).toHaveBeenCalledWith(

--- a/packages/execution-engine/src/task-runner-callbacks.ts
+++ b/packages/execution-engine/src/task-runner-callbacks.ts
@@ -1,5 +1,11 @@
 import type { WorkResponse } from '@invoker/contracts';
 import type { Executor, ExecutorHandle } from './executor.js';
+import type { TaskHeartbeatSource } from '@invoker/workflow-core';
+
+export interface TaskHeartbeatEvent {
+  at: Date;
+  source: TaskHeartbeatSource;
+}
 
 export interface TaskRunnerCallbacks {
   onOutput?: (taskId: string, data: string) => void;
@@ -8,6 +14,6 @@ export interface TaskRunnerCallbacks {
   onLaunchFailed?: (taskId: string, error: Error, executor: Executor) => void;
   onSpawned?: (taskId: string, handle: ExecutorHandle, executor: Executor) => void;
   onComplete?: (taskId: string, response: WorkResponse) => void;
-  onHeartbeat?: (taskId: string) => void;
+  onHeartbeat?: (taskId: string, event: TaskHeartbeatEvent) => void;
   onLaunchSettled?: (taskId: string) => void;
 }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -853,7 +853,7 @@ export class TaskRunner {
           lastHeartbeatAt: now,
           leaseExpiresAt: nextLeaseExpiry(now),
         } as any);
-        this.callbacks.onHeartbeat?.(task.id);
+        this.callbacks.onHeartbeat?.(task.id, { at: now, source: 'executor' });
       }, PRE_START_HEARTBEAT_INTERVAL_MS);
       let preStartTimeout: ReturnType<typeof setTimeout> | undefined;
       try {
@@ -1100,15 +1100,10 @@ export class TaskRunner {
         lastHeartbeatAt: now,
         leaseExpiresAt: nextLeaseExpiry(now),
       } as any);
-      this.persistence.updateTask(task.id, {
-        execution: {
-          lastHeartbeatAt: now,
-          ...(isRemoteWorkloadHeartbeat
-            ? { remoteHeartbeatAt: now, heartbeatSource: 'remote_workload' as const }
-            : { heartbeatSource: 'executor' as const }),
-        },
-      } as any);
-      this.callbacks.onHeartbeat?.(task.id);
+      this.callbacks.onHeartbeat?.(task.id, {
+        at: now,
+        source: isRemoteWorkloadHeartbeat ? 'remote_workload' : 'executor',
+      });
     });
 
     // Wait for completion and feed response to orchestrator.
@@ -2222,7 +2217,7 @@ export class TaskRunner {
         lastHeartbeatAt: now,
         leaseExpiresAt: nextLeaseExpiry(now),
       } as any);
-      this.callbacks.onHeartbeat?.(taskId);
+      this.callbacks.onHeartbeat?.(taskId, { at: now, source: 'executor' });
     };
 
     const heartbeatTimer = setInterval(heartbeat, PRE_START_HEARTBEAT_INTERVAL_MS);

--- a/packages/test-kit/src/in-memory-persistence.ts
+++ b/packages/test-kit/src/in-memory-persistence.ts
@@ -85,6 +85,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
         ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
         config: { ...entry.task.config, ...changes.config },
         execution: { ...entry.task.execution, ...changes.execution },
+        taskStateVersion: (entry.task.taskStateVersion ?? 1) + 1,
       } as TaskState;
     }
   }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -134,6 +134,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
         ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
         config: { ...entry.task.config, ...changes.config },
         execution: { ...entry.task.execution, ...changes.execution },
+        taskStateVersion: (entry.task.taskStateVersion ?? 1) + 1,
       } as TaskState;
     }
   }
@@ -301,6 +302,52 @@ describe('Orchestrator', () => {
       messageBus: bus,
       maxConcurrency: 3,
       logger: consoleLogger,
+    });
+  });
+
+  describe('recordTaskHeartbeat', () => {
+    it('persists heartbeat metadata and publishes a versioned task delta', () => {
+      orchestrator.loadPlan({
+        name: 'heartbeat-owner',
+        onFinish: 'none',
+        tasks: [
+          { id: 'task-a', description: 'Task A', command: 'echo a' },
+        ],
+      });
+      publishedDeltas = [];
+      const taskId = sid(orchestrator, 0, 'task-a');
+      const before = orchestrator.getTask(taskId)!;
+      const at = new Date('2026-06-02T12:00:00.000Z');
+
+      const updated = orchestrator.recordTaskHeartbeat(taskId, {
+        at,
+        source: 'remote_workload',
+      });
+
+      expect(updated?.execution.lastHeartbeatAt).toEqual(at);
+      expect(updated?.execution.remoteHeartbeatAt).toEqual(at);
+      expect(updated?.execution.heartbeatSource).toBe('remote_workload');
+      expect(updated?.taskStateVersion).toBe(before.taskStateVersion + 1);
+
+      const persisted = persistence.getTaskEntry(taskId)?.task;
+      expect(persisted?.execution.lastHeartbeatAt).toEqual(at);
+      expect(persisted?.execution.remoteHeartbeatAt).toEqual(at);
+      expect(persisted?.execution.heartbeatSource).toBe('remote_workload');
+
+      expect(publishedDeltas).toHaveLength(1);
+      expect(publishedDeltas[0]).toMatchObject({
+        type: 'updated',
+        taskId,
+        changes: {
+          execution: {
+            lastHeartbeatAt: at,
+            remoteHeartbeatAt: at,
+            heartbeatSource: 'remote_workload',
+          },
+        },
+        previousTaskStateVersion: before.taskStateVersion,
+        taskStateVersion: before.taskStateVersion + 1,
+      });
     });
   });
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -19,7 +19,7 @@ import { TaskStateMachine } from './state-machine.js';
 import { ResponseHandler } from './response-handler.js';
 import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
-import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, TaskStatus } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
 import { createTaskState, createAttempt } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
@@ -3989,6 +3989,27 @@ export class Orchestrator {
 
   getTask(taskId: string): TaskState | undefined {
     return this.stateGetTask(taskId);
+  }
+
+  recordTaskHeartbeat(
+    taskId: string,
+    options: { at?: Date; source?: TaskHeartbeatSource } = {},
+  ): TaskState | undefined {
+    const task = this.stateGetTask(taskId);
+    if (!task) return undefined;
+
+    const at = options.at ?? new Date();
+    const source = options.source ?? 'executor';
+    const changes: TaskStateChanges = {
+      execution: {
+        lastHeartbeatAt: at,
+        heartbeatSource: source,
+        ...(source === 'remote_workload' ? { remoteHeartbeatAt: at } : {}),
+      },
+    };
+    const updated = this.writeAndSync(task.id, changes, { skipWorkflowStatusSync: true });
+    this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
+    return updated;
   }
 
   getAutoFixRetryBudget(taskId: string): number {


### PR DESCRIPTION
## Summary

Route task heartbeat mutations through the orchestrator instead of letting the execution engine and app publish task state independently.

Heartbeat updates now publish versioned `TASK_DELTA`s, and the main-process bridge only forwards deltas after owner-cache apply or recovery.

## Architecture

### Before

```mermaid
flowchart LR
  Runner[TaskRunner heartbeat] --> DirectDb[persistence.updateTask]
  App[App heartbeat callback] --> DirectDb
  App --> RawDelta[manual unversioned TASK_DELTA]
  RawDelta --> Renderer[renderer DAG]
  RawDelta --> OwnerCache[main owner cache quarantine]
```

### After

```mermaid
flowchart LR
  Runner[TaskRunner heartbeat event] --> Owner[orchestrator.recordTaskHeartbeat]
  Owner --> Db[persistence.updateTask with taskStateVersion]
  Owner --> VersionedDelta[versioned TASK_DELTA]
  VersionedDelta --> OwnerCache[main owner cache apply/recover]
  OwnerCache --> Renderer[renderer DAG]
```

## Test Plan

- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/orchestrator.test.ts`
- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/delta-merge.test.ts src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts src/__tests__/task-delta-stream-sequence.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0c85152ab`
- Post-revert steps: Re-run the focused task delta and heartbeat tests above.
- Data migration? No
