### PR TITLE
Gate task deltas before renderer delivery

### DIFF
--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1483,8 +1483,13 @@ function createEmbeddedTerminalBackendFromConfig(
   const taskDeltaStream = createTaskDeltaStreamSequence();
   const getTaskDeltaStreamSequence = (): number => taskDeltaStream.current();
 
-  const sendTaskDeltaToRenderer = (delta: TaskDelta): void => {
-    workflowMetadataInvalidator?.markFromTaskDelta(delta);
+  const sendTaskDeltaToRenderer = (
+    delta: TaskDelta,
+    options: { markWorkflowMetadata?: boolean } = {},
+  ): void => {
+    if (options.markWorkflowMetadata !== false) {
+      workflowMetadataInvalidator?.markFromTaskDelta(delta);
+    }
     if (!mainWindow || mainWindow.isDestroyed() || !uiInteractive) {
       return;
     }
@@ -2903,9 +2908,8 @@ function createEmbeddedTerminalBackendFromConfig(
       if (traceUiDeltaFlow) {
         logger.debug(`delta→ui: ${JSON.stringify(delta)}`, { module: 'ui' });
       }
-      sendTaskDeltaToRenderer(delta as TaskDelta);
-
       const d = delta as TaskDelta;
+      workflowMetadataInvalidator?.markFromTaskDelta(d);
       const deltaTaskId = d.type === 'updated' || d.type === 'removed'
         ? d.taskId
         : undefined;
@@ -2923,6 +2927,9 @@ function createEmbeddedTerminalBackendFromConfig(
       }
 
       const { quarantined } = applyDelta(d, lastKnownTaskStates);
+      if (quarantined.length === 0) {
+        sendTaskDeltaToRenderer(d, { markWorkflowMetadata: false });
+      }
       for (const taskId of quarantined) {
         logger.info(`[gap-detect] quarantined task="${taskId}" — triggering authoritative reload`, { module: 'delta-merge' });
         const { rendererDelta } = recoverQuarantinedTask(lastKnownTaskStates, taskId, {


### PR DESCRIPTION
## Summary

Route task deltas through the main-process owner cache before renderer delivery.

The renderer now receives only deltas that the owner cache accepted or recovered, which lays the single-writer UI foundation.

## Architecture

### Before

```mermaid
flowchart LR
  Producer[Task delta producer] --> Bus[messageBus TASK_DELTA]
  Bus --> Renderer[renderer DAG]
  Bus --> OwnerCache[main owner cache apply/quarantine]
  OwnerCache --> Recovery[authoritative recovery]
```

### After

```mermaid
flowchart LR
  Producer[Task delta producer] --> Bus[messageBus TASK_DELTA]
  Bus --> OwnerCache[main owner cache apply/quarantine]
  OwnerCache --> Accepted[accepted delta]
  OwnerCache --> Recovery[authoritative recovery]
  Accepted --> Renderer[renderer DAG]
  Recovery --> Renderer
```

## Test Plan

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/delta-merge.test.ts src/__tests__/synthetic-merge-quarantine-loop-repro.test.ts src/__tests__/task-delta-stream-sequence.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 26d9087c2`
- Post-revert steps: Re-run the app delta/quarantine tests above.
- Data migration? No
