### PR TITLE
Recovery lifecycle stack 1: event foundation

### DIFF
--- a/docs/architecture/recovery-lifecycle-workers.md
+++ b/docs/architecture/recovery-lifecycle-workers.md
@@ -1,0 +1,116 @@
+# Recovery Lifecycle Worker Architecture
+
+## Summary
+
+State transitions publish lifecycle events. Recovery behavior is owned by subscriber workers.
+
+The producer of a persisted workflow or task state change is responsible for publishing a lifecycle wakeup after the durable state change is recorded. The producer must not directly auto-fix, recreate, or launch external recovery scripts as part of handling a failed delta. Auto-fix and external recovery are worker responsibilities, and workers must act through the same normal command routes used by operators.
+
+This is a docs-only architecture note. It describes the target contract and does not change runtime behavior.
+
+## Current Overlap
+
+Auto-fix and external recovery both respond to failed deltas today, but they do so as separate direct handlers. That makes failed-delta recovery ownership ambiguous:
+
+1. Auto-fix can be scheduled directly from failure handling.
+2. External recovery can be launched directly from failure handling.
+3. Both paths can observe the same failed state and compete to decide what recovery means.
+
+The overlap is not only duplication. It hides recovery policy inside producers that should be responsible for state transition and publication, not for choosing a recovery implementation.
+
+## Target Model
+
+Lifecycle events are ephemeral wakeups, not durable truth. Persisted workflow and task state remains authoritative.
+
+```mermaid
+flowchart LR
+  PersistedChange[Persisted state change] --> Event[Lifecycle event]
+  Event --> Worker[Worker wake]
+  Worker --> Scan[Persisted scan]
+  Scan --> Decision[Reconcile recovery need]
+  Decision --> Command[Normal command submission]
+  Command --> PersistedChange
+```
+
+The target model separates responsibilities:
+
+| Responsibility | Owner | Contract |
+| --- | --- | --- |
+| Persist state transition | Producer | Write the authoritative workflow or task state first. |
+| Publish lifecycle wakeup | Producer | Emit an event after the persisted transition so subscribers can re-check state. |
+| Decide recovery action | Worker | Read persisted state and reconcile whether work is still needed. |
+| Execute recovery | Worker through command route | Submit normal commands rather than mutating recovery state directly. |
+
+Producers must not directly auto-fix, recreate, or launch external recovery scripts. They publish lifecycle events and leave recovery decisions to subscribers.
+
+## Durable State Authority
+
+The message bus is not the source of truth. Lifecycle events may be missed, duplicated, delayed, or observed by multiple subscribers. Workers must treat events as prompts to inspect durable state.
+
+Required behavior:
+
+1. Persisted workflow and task state determines whether recovery is needed.
+2. Lifecycle events only wake subscribers so they can scan persisted state.
+3. Workers must be idempotent against repeated wakeups.
+4. Workers must tolerate missed events by relying on periodic or startup scans where needed.
+5. Recovery commands must re-check current state through existing command handling before making changes.
+
+This preserves the existing persistence model while allowing the recovery system to become event-driven.
+
+## Worker Wakeups
+
+A lifecycle event should carry enough context to make wakeups efficient, such as workflow ID, task ID, transition type, and generation where available. That context is an optimization, not authority.
+
+On wake, a worker should:
+
+1. Load the current persisted workflow and task state.
+2. Ignore stale wakeups that no longer match the persisted generation or status.
+3. Decide whether its specific recovery responsibility applies.
+4. Submit a normal command when recovery is still needed.
+5. Record any worker-owned bookkeeping through normal persistence paths.
+
+Workers may subscribe to the same lifecycle event stream. Contention is controlled by persisted state checks and command-route validation, not by assuming one subscriber receives a unique event.
+
+## Auto-Fix Worker
+
+The auto-fix worker owns automatic fix attempts for states that qualify for agent-driven repair. It subscribes to lifecycle wakeups, scans persisted state, and decides whether an auto-fix command should be submitted.
+
+The worker should only act when persisted state shows that:
+
+1. The workflow or task is in a state eligible for auto-fix.
+2. No newer generation has superseded the failed state.
+3. Auto-fix policy allows another attempt.
+4. No incompatible recovery action is already in progress.
+
+When those checks pass, the auto-fix worker submits the normal fix command. It must not be invoked directly by the producer that recorded the failed transition.
+
+## External Recovery Worker
+
+The external recovery worker owns integration with external recovery automation. It subscribes to lifecycle wakeups, scans persisted state, and decides whether an external recovery command should be submitted or whether an external process should be coordinated through a command route.
+
+The worker should only act when persisted state shows that:
+
+1. The workflow or task is in a state eligible for external recovery.
+2. The current generation still matches the observed failure.
+3. External recovery policy selects this workflow or task.
+4. Auto-fix or another recovery path has not already claimed or resolved the state.
+
+External scripts must not be launched directly by state-transition producers. Any external recovery launch must be initiated by the external recovery worker after it has reconciled persisted state.
+
+## Cleanup Of Direct Handlers
+
+Later implementation slices should remove failed-delta handlers that directly schedule auto-fix or directly launch external recovery scripts. Those handlers should become lifecycle publishers only.
+
+Cleanup should preserve these invariants:
+
+1. State changes are persisted before lifecycle events are published.
+2. Lifecycle events are wakeups and may be replayed or missed.
+3. Persisted state remains authoritative for all recovery decisions.
+4. Recovery workers submit normal commands instead of bypassing command handling.
+5. Producers do not directly auto-fix, recreate, or launch external recovery scripts.
+
+## What I Intend To Do
+
+1. Event foundation: add lifecycle-event publication at the relevant persisted state transitions, with producers limited to publishing wakeups after durable state changes.
+2. Auto-fix worker: move automatic fix behavior behind a subscriber worker that wakes on lifecycle events, scans persisted state, and submits normal fix commands.
+3. External recovery cleanup and regression: move external recovery launch behavior behind its worker, remove direct failed-delta launch paths, and add regression coverage that proves producers publish wakeups without owning recovery.

--- a/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
+++ b/packages/app/src/__tests__/lifecycle-event-bridge.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Channels, LocalBus, type MessageBus } from '@invoker/transport';
+import type { TaskDelta, TaskState } from '@invoker/workflow-core';
+import {
+  isWorkflowLifecycleEvent,
+  type WorkflowLifecycleEvent,
+} from '../lifecycle-events.js';
+import { startLifecycleEventBridge } from '../lifecycle-event-bridge.js';
+
+const CREATED_AT = '2026-06-04T00:00:00.000Z';
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id: 'wf-1/task-a',
+    description: 'test task',
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2026-06-03T00:00:00.000Z'),
+    config: { workflowId: 'wf-1' },
+    execution: { generation: 3, selectedAttemptId: 'attempt-1' },
+    taskStateVersion: 1,
+    ...overrides,
+  } as TaskState;
+}
+
+function collectLifecycleEvents(bus: MessageBus): WorkflowLifecycleEvent[] {
+  const events: WorkflowLifecycleEvent[] = [];
+  bus.subscribe<WorkflowLifecycleEvent>(Channels.WORKFLOW_LIFECYCLE, (event) => events.push(event));
+  return events;
+}
+
+describe('lifecycle event bridge', () => {
+  it('publishes task.created lifecycle events from created deltas', () => {
+    const bus = new LocalBus();
+    const events = collectLifecycleEvents(bus);
+    startLifecycleEventBridge({ messageBus: bus, now: () => CREATED_AT });
+
+    bus.publish<TaskDelta>(Channels.TASK_DELTA, { type: 'created', task: makeTask() });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventKey: 'task.created|workflow:wf-1|task:wf-1/task-a|generation:3|attempt:attempt-1|task-state:1',
+      kind: 'task.created',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      status: 'pending',
+      taskStateVersion: 1,
+      generation: 3,
+      attemptId: 'attempt-1',
+      createdAt: CREATED_AT,
+    });
+    expect(isWorkflowLifecycleEvent(events[0])).toBe(true);
+  });
+
+  it.each([
+    ['failed', 'task.failed'],
+    ['completed', 'task.completed'],
+    ['review_ready', 'task.review_ready'],
+    ['awaiting_approval', 'task.awaiting_approval'],
+    ['needs_input', 'task.needs_input'],
+  ] as const)('publishes %s status updates as %s lifecycle events', (status, kind) => {
+    const bus = new LocalBus();
+    const events = collectLifecycleEvents(bus);
+    startLifecycleEventBridge({
+      messageBus: bus,
+      getInitialTasks: () => [makeTask({ status: 'running', taskStateVersion: 5 })],
+      now: () => CREATED_AT,
+    });
+
+    bus.publish<TaskDelta>(Channels.TASK_DELTA, {
+      type: 'updated',
+      taskId: 'wf-1/task-a',
+      changes: { status, execution: { generation: 4, selectedAttemptId: 'attempt-2' } },
+      taskStateVersion: 6,
+      previousTaskStateVersion: 5,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventKey: `${kind}|workflow:wf-1|task:wf-1/task-a|generation:4|attempt:attempt-2|task-state:6`,
+      kind,
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      status,
+      previousStatus: 'running',
+      taskStateVersion: 6,
+      generation: 4,
+      attemptId: 'attempt-2',
+      createdAt: CREATED_AT,
+    });
+  });
+
+  it('publishes task.updated for non-status updates using cached task status', () => {
+    const bus = new LocalBus();
+    const events = collectLifecycleEvents(bus);
+    startLifecycleEventBridge({
+      messageBus: bus,
+      getInitialTasks: () => [makeTask({ status: 'running', taskStateVersion: 8 })],
+      now: () => CREATED_AT,
+    });
+
+    bus.publish<TaskDelta>(Channels.TASK_DELTA, {
+      type: 'updated',
+      taskId: 'wf-1/task-a',
+      changes: { execution: { branch: 'feature/test' } },
+      taskStateVersion: 9,
+      previousTaskStateVersion: 8,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventKey: 'task.updated|workflow:wf-1|task:wf-1/task-a|generation:3|attempt:attempt-1|task-state:9',
+      kind: 'task.updated',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      status: 'running',
+      previousStatus: 'running',
+      taskStateVersion: 9,
+      generation: 3,
+      attemptId: 'attempt-1',
+      createdAt: CREATED_AT,
+    });
+  });
+
+  it('publishes task.removed lifecycle events from removed deltas', () => {
+    const bus = new LocalBus();
+    const events = collectLifecycleEvents(bus);
+    startLifecycleEventBridge({
+      messageBus: bus,
+      getInitialTasks: () => [makeTask({ status: 'failed', taskStateVersion: 9 })],
+      now: () => CREATED_AT,
+    });
+
+    bus.publish<TaskDelta>(Channels.TASK_DELTA, {
+      type: 'removed',
+      taskId: 'wf-1/task-a',
+      previousTaskStateVersion: 9,
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      eventKey: 'task.removed|workflow:wf-1|task:wf-1/task-a|generation:3|attempt:attempt-1|task-state:9',
+      kind: 'task.removed',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      status: 'failed',
+      previousStatus: 'failed',
+      taskStateVersion: 9,
+      generation: 3,
+      attemptId: 'attempt-1',
+      createdAt: CREATED_AT,
+    });
+  });
+
+  it('does not call recovery or TaskRunner methods while publishing wakeups', () => {
+    const bus = new LocalBus();
+    const recoverySurface = {
+      fixWithAgent: vi.fn(),
+      executeTasks: vi.fn(),
+      recreateWorkflowFromFreshBase: vi.fn(),
+      launchExternalRecovery: vi.fn(),
+      resolveConflict: vi.fn(),
+    };
+    startLifecycleEventBridge({
+      messageBus: bus,
+      getInitialTasks: () => [makeTask({ status: 'running', taskStateVersion: 5 })],
+      now: () => CREATED_AT,
+    });
+
+    bus.publish<TaskDelta>(Channels.TASK_DELTA, {
+      type: 'updated',
+      taskId: 'wf-1/task-a',
+      changes: { status: 'failed' },
+      taskStateVersion: 6,
+      previousTaskStateVersion: 5,
+    });
+
+    expect(recoverySurface.fixWithAgent).not.toHaveBeenCalled();
+    expect(recoverySurface.executeTasks).not.toHaveBeenCalled();
+    expect(recoverySurface.recreateWorkflowFromFreshBase).not.toHaveBeenCalled();
+    expect(recoverySurface.launchExternalRecovery).not.toHaveBeenCalled();
+    expect(recoverySurface.resolveConflict).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes cleanly', () => {
+    const bus = new LocalBus();
+    const events = collectLifecycleEvents(bus);
+    const bridge = startLifecycleEventBridge({ messageBus: bus, now: () => CREATED_AT });
+
+    bridge.stop();
+    bus.publish<TaskDelta>(Channels.TASK_DELTA, { type: 'created', task: makeTask() });
+
+    expect(events).toEqual([]);
+  });
+});

--- a/packages/app/src/__tests__/lifecycle-events.test.ts
+++ b/packages/app/src/__tests__/lifecycle-events.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect } from 'vitest';
+import { Channels } from '@invoker/transport';
+import type { TaskDelta, TaskState } from '@invoker/workflow-core';
+import {
+  buildLifecycleEventFromTaskDelta,
+  buildReviewGateCiFailedLifecycleEvent,
+  buildTaskUpdatedLifecycleEvent,
+  buildWorkflowWakeupLifecycleEvent,
+  isTaskLifecycleEvent,
+  isWorkflowLifecycleEvent,
+  lifecycleEventKindForTaskStatus,
+} from '../lifecycle-events.js';
+
+const CREATED_AT = '2026-06-04T00:00:00.000Z';
+
+function makeTask(overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id: 'wf-1/task-a',
+    description: 'test task',
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2026-06-03T00:00:00.000Z'),
+    config: { workflowId: 'wf-1' },
+    execution: { generation: 3, selectedAttemptId: 'attempt-1' },
+    taskStateVersion: 1,
+    ...overrides,
+  } as TaskState;
+}
+
+describe('worker lifecycle channel', () => {
+  it('adds workflow lifecycle without changing existing task channels', () => {
+    expect(Channels.TASK_DELTA).toBe('task.delta');
+    expect(Channels.TASK_OUTPUT).toBe('task.output');
+    expect(Channels.WORKFLOW_LIFECYCLE).toBe('workflow.lifecycle');
+  });
+});
+
+describe('lifecycle event helpers', () => {
+  it('builds task.created from created deltas', () => {
+    const event = buildLifecycleEventFromTaskDelta(
+      { type: 'created', task: makeTask() },
+      { createdAt: CREATED_AT },
+    );
+
+    expect(event).toMatchObject({
+      eventKey: 'task.created|workflow:wf-1|task:wf-1/task-a|generation:3|attempt:attempt-1|task-state:1',
+      kind: 'task.created',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      status: 'pending',
+      taskStateVersion: 1,
+      generation: 3,
+      attemptId: 'attempt-1',
+      createdAt: CREATED_AT,
+    });
+    expect(isTaskLifecycleEvent(event)).toBe(true);
+  });
+
+  it('builds task.updated from non-terminal status updates', () => {
+    const delta: TaskDelta = {
+      type: 'updated',
+      taskId: 'wf-1/task-a',
+      changes: { status: 'running', execution: { generation: 4, selectedAttemptId: 'attempt-2' } },
+      taskStateVersion: 2,
+      previousTaskStateVersion: 1,
+    };
+
+    const event = buildLifecycleEventFromTaskDelta(delta, {
+      workflowId: 'wf-1',
+      previousStatus: 'pending',
+      createdAt: CREATED_AT,
+    });
+
+    expect(event).toMatchObject({
+      eventKey: 'task.updated|workflow:wf-1|task:wf-1/task-a|generation:4|attempt:attempt-2|task-state:2',
+      kind: 'task.updated',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      status: 'running',
+      previousStatus: 'pending',
+      taskStateVersion: 2,
+      generation: 4,
+      attemptId: 'attempt-2',
+      createdAt: CREATED_AT,
+    });
+  });
+
+  it('maps completed and failed status updates to worker lifecycle kinds', () => {
+    expect(lifecycleEventKindForTaskStatus('completed')).toBe('task.completed');
+    expect(lifecycleEventKindForTaskStatus('failed')).toBe('task.failed');
+
+    const completed = buildTaskUpdatedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      status: 'completed',
+      previousStatus: 'running',
+      taskStateVersion: 3,
+      generation: 4,
+      attemptId: 'attempt-2',
+      createdAt: CREATED_AT,
+    });
+    const failed = buildTaskUpdatedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-b',
+      status: 'failed',
+      previousStatus: 'running',
+      taskStateVersion: 4,
+      generation: 1,
+      attemptId: 'attempt-3',
+      createdAt: CREATED_AT,
+    });
+
+    expect(completed.kind).toBe('task.completed');
+    expect(failed.kind).toBe('task.failed');
+    expect(completed.eventKey).toBe('task.completed|workflow:wf-1|task:wf-1/task-a|generation:4|attempt:attempt-2|task-state:3');
+    expect(failed.eventKey).toBe('task.failed|workflow:wf-1|task:wf-1/task-b|generation:1|attempt:attempt-3|task-state:4');
+  });
+
+  it('maps review readiness status updates to worker lifecycle kinds', () => {
+    const reviewReady = buildTaskUpdatedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      previousStatus: 'running',
+      taskStateVersion: 5,
+      generation: 2,
+      createdAt: CREATED_AT,
+    });
+
+    expect(reviewReady.kind).toBe('task.review_ready');
+  });
+
+  it('builds task.removed from removed deltas', () => {
+    const event = buildLifecycleEventFromTaskDelta(
+      { type: 'removed', taskId: 'wf-1/task-a', previousTaskStateVersion: 9 },
+      {
+        workflowId: 'wf-1',
+        previousStatus: 'failed',
+        generation: 6,
+        attemptId: 'attempt-9',
+        createdAt: CREATED_AT,
+      },
+    );
+
+    expect(event).toMatchObject({
+      eventKey: 'task.removed|workflow:wf-1|task:wf-1/task-a|generation:6|attempt:attempt-9|task-state:9',
+      kind: 'task.removed',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      previousStatus: 'failed',
+      taskStateVersion: 9,
+      generation: 6,
+      attemptId: 'attempt-9',
+      createdAt: CREATED_AT,
+    });
+  });
+
+  it('builds review_gate.ci_failed lifecycle wakeups', () => {
+    const event = buildReviewGateCiFailedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      taskStateVersion: 12,
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      headRef: 'feature/ci-red',
+      branch: 'feature/ci-red',
+      failedChecks: [
+        { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
+      ],
+      statusText: 'CI failed',
+      generation: 7,
+      attemptId: 'attempt-merge',
+      createdAt: CREATED_AT,
+    });
+
+    expect(event).toMatchObject({
+      eventKey: 'review_gate.ci_failed|workflow:wf-1|task:wf-1/merge|generation:7|attempt:attempt-merge|task-state:12|review:123:abc123',
+      kind: 'review_gate.ci_failed',
+      workflowId: 'wf-1',
+      taskId: 'wf-1/merge',
+      status: 'review_ready',
+      taskStateVersion: 12,
+      reviewId: '123',
+      reviewUrl: 'https://github.com/owner/repo/pull/123',
+      headSha: 'abc123',
+      generation: 7,
+      attemptId: 'attempt-merge',
+      createdAt: CREATED_AT,
+      statusText: 'CI failed',
+    });
+    expect(event.failedChecks).toEqual([
+      { name: 'test-all', conclusion: 'FAILURE', detailsUrl: 'https://github.com/owner/repo/actions/runs/1' },
+    ]);
+    expect(isWorkflowLifecycleEvent(event)).toBe(true);
+  });
+
+  it('builds workflow.wakeup events for persisted-state reconciliation', () => {
+    const event = buildWorkflowWakeupLifecycleEvent({
+      workflowId: 'wf-1',
+      status: 'running',
+      generation: 8,
+      reason: 'stalled_workflow_recovery',
+      createdAt: CREATED_AT,
+    });
+
+    expect(event).toEqual({
+      eventKey: 'workflow.wakeup|workflow:wf-1|generation:8|reason:stalled_workflow_recovery',
+      kind: 'workflow.wakeup',
+      workflowId: 'wf-1',
+      status: 'running',
+      generation: 8,
+      createdAt: CREATED_AT,
+      reason: 'stalled_workflow_recovery',
+    });
+    expect(isWorkflowLifecycleEvent(event)).toBe(true);
+  });
+
+  it('rejects malformed lifecycle events', () => {
+    expect(isWorkflowLifecycleEvent({ kind: 'task.failed' })).toBe(false);
+    expect(isWorkflowLifecycleEvent({ ...buildWorkflowWakeupLifecycleEvent({
+      workflowId: 'wf-1',
+      generation: 1,
+      reason: 'manual_reconcile',
+      createdAt: CREATED_AT,
+    }), generation: '1' })).toBe(false);
+  });
+});

--- a/packages/app/src/__tests__/lifecycle-events.test.ts
+++ b/packages/app/src/__tests__/lifecycle-events.test.ts
@@ -130,6 +130,22 @@ describe('lifecycle event helpers', () => {
     expect(reviewReady.kind).toBe('task.review_ready');
   });
 
+  it('maps needs_input status updates to worker lifecycle kinds', () => {
+    const needsInput = buildTaskUpdatedLifecycleEvent({
+      workflowId: 'wf-1',
+      taskId: 'wf-1/task-a',
+      status: 'needs_input',
+      previousStatus: 'running',
+      taskStateVersion: 6,
+      generation: 2,
+      createdAt: CREATED_AT,
+    });
+
+    expect(lifecycleEventKindForTaskStatus('needs_input')).toBe('task.needs_input');
+    expect(needsInput.kind).toBe('task.needs_input');
+    expect(isWorkflowLifecycleEvent(needsInput)).toBe(true);
+  });
+
   it('builds task.removed from removed deltas', () => {
     const event = buildLifecycleEventFromTaskDelta(
       { type: 'removed', taskId: 'wf-1/task-a', previousTaskStateVersion: 9 },

--- a/packages/app/src/lifecycle-event-bridge.ts
+++ b/packages/app/src/lifecycle-event-bridge.ts
@@ -1,0 +1,160 @@
+import { Channels, type MessageBus, type Unsubscribe } from '@invoker/transport';
+import type { TaskDelta, TaskState, TaskStatus } from '@invoker/workflow-core';
+import {
+  buildTaskCreatedLifecycleEvent,
+  buildTaskRemovedLifecycleEvent,
+  buildTaskUpdatedLifecycleEvent,
+  type WorkflowLifecycleEvent,
+} from './lifecycle-events.js';
+
+interface LifecycleTaskMetadata {
+  readonly workflowId: string;
+  readonly status: TaskStatus;
+  readonly taskStateVersion: number;
+  readonly generation: number;
+  readonly attemptId?: string;
+}
+
+export interface LifecycleEventBridgeOptions {
+  readonly messageBus: MessageBus;
+  readonly getInitialTasks?: () => readonly TaskState[];
+  readonly getTask?: (taskId: string) => TaskState | undefined;
+  readonly now?: () => string | Date;
+  readonly logger?: {
+    warn(message: string, details?: Record<string, unknown>): void;
+  };
+}
+
+export interface LifecycleEventBridge {
+  readonly stop: Unsubscribe;
+}
+
+export function startLifecycleEventBridge(options: LifecycleEventBridgeOptions): LifecycleEventBridge {
+  const taskMetadata = new Map<string, LifecycleTaskMetadata>();
+
+  for (const task of options.getInitialTasks?.() ?? []) {
+    rememberTask(taskMetadata, task);
+  }
+
+  const stop = options.messageBus.subscribe<TaskDelta>(Channels.TASK_DELTA, (delta) => {
+    try {
+      const event = buildEventForTaskDelta(delta, taskMetadata, options);
+      updateTaskMetadata(delta, taskMetadata, options);
+      if (event) {
+        options.messageBus.publish(Channels.WORKFLOW_LIFECYCLE, event);
+      }
+    } catch (err) {
+      options.logger?.warn('failed to publish workflow lifecycle event from task delta', {
+        module: 'lifecycle-event-bridge',
+        err,
+        delta,
+      });
+    }
+  });
+
+  return { stop };
+}
+
+function buildEventForTaskDelta(
+  delta: TaskDelta,
+  taskMetadata: ReadonlyMap<string, LifecycleTaskMetadata>,
+  options: LifecycleEventBridgeOptions,
+): WorkflowLifecycleEvent | undefined {
+  const createdAt = options.now?.();
+  switch (delta.type) {
+    case 'created':
+      return buildTaskCreatedLifecycleEvent(delta.task, { createdAt });
+    case 'updated': {
+      const currentTask = options.getTask?.(delta.taskId);
+      const previous = taskMetadata.get(delta.taskId);
+      const status = delta.changes.status ?? currentTask?.status ?? previous?.status;
+      const workflowId = currentTask?.config.workflowId ?? previous?.workflowId ?? inferWorkflowIdFromTaskId(delta.taskId);
+      if (!status || !workflowId) return undefined;
+      return buildTaskUpdatedLifecycleEvent({
+        workflowId,
+        taskId: delta.taskId,
+        status,
+        previousStatus: previous?.status,
+        taskStateVersion: delta.taskStateVersion,
+        generation: delta.changes.execution?.generation
+          ?? currentTask?.execution.generation
+          ?? previous?.generation
+          ?? 0,
+        attemptId: delta.changes.execution?.selectedAttemptId
+          ?? currentTask?.execution.selectedAttemptId
+          ?? previous?.attemptId,
+        createdAt,
+      });
+    }
+    case 'removed': {
+      const previous = taskMetadata.get(delta.taskId);
+      const workflowId = previous?.workflowId ?? inferWorkflowIdFromTaskId(delta.taskId);
+      if (!workflowId) return undefined;
+      return buildTaskRemovedLifecycleEvent({
+        workflowId,
+        taskId: delta.taskId,
+        status: previous?.status,
+        previousStatus: previous?.status,
+        taskStateVersion: delta.previousTaskStateVersion,
+        generation: previous?.generation ?? 0,
+        attemptId: previous?.attemptId,
+        createdAt,
+      });
+    }
+  }
+}
+
+function updateTaskMetadata(
+  delta: TaskDelta,
+  taskMetadata: Map<string, LifecycleTaskMetadata>,
+  options: LifecycleEventBridgeOptions,
+): void {
+  switch (delta.type) {
+    case 'created':
+      rememberTask(taskMetadata, delta.task);
+      return;
+    case 'updated': {
+      const currentTask = options.getTask?.(delta.taskId);
+      if (currentTask) {
+        rememberTask(taskMetadata, currentTask);
+        return;
+      }
+      const previous = taskMetadata.get(delta.taskId);
+      const workflowId = previous?.workflowId ?? inferWorkflowIdFromTaskId(delta.taskId);
+      const status = delta.changes.status ?? previous?.status;
+      if (!workflowId || !status) return;
+      taskMetadata.set(delta.taskId, {
+        workflowId,
+        status,
+        taskStateVersion: delta.taskStateVersion,
+        generation: delta.changes.execution?.generation ?? previous?.generation ?? 0,
+        attemptId: delta.changes.execution?.selectedAttemptId ?? previous?.attemptId,
+      });
+      return;
+    }
+    case 'removed':
+      taskMetadata.delete(delta.taskId);
+      return;
+  }
+}
+
+function rememberTask(
+  taskMetadata: Map<string, LifecycleTaskMetadata>,
+  task: TaskState,
+): void {
+  const workflowId = task.config.workflowId ?? inferWorkflowIdFromTaskId(task.id);
+  if (!workflowId) return;
+  taskMetadata.set(task.id, {
+    workflowId,
+    status: task.status,
+    taskStateVersion: task.taskStateVersion,
+    generation: task.execution.generation ?? 0,
+    attemptId: task.execution.selectedAttemptId,
+  });
+}
+
+function inferWorkflowIdFromTaskId(taskId: string): string | undefined {
+  const slashIndex = taskId.indexOf('/');
+  if (slashIndex <= 0) return undefined;
+  return taskId.slice(0, slashIndex);
+}

--- a/packages/app/src/lifecycle-events.ts
+++ b/packages/app/src/lifecycle-events.ts
@@ -1,0 +1,411 @@
+import type {
+  TaskDelta,
+  TaskState,
+  TaskStatus,
+  WorkflowDerivedStatus,
+} from '@invoker/workflow-core';
+
+export const WORKFLOW_LIFECYCLE_EVENT_KINDS = [
+  'task.created',
+  'task.updated',
+  'task.completed',
+  'task.failed',
+  'task.review_ready',
+  'task.awaiting_approval',
+  'task.removed',
+  'review_gate.ci_failed',
+  'workflow.wakeup',
+] as const;
+
+export type WorkflowLifecycleEventKind = typeof WORKFLOW_LIFECYCLE_EVENT_KINDS[number];
+export type WorkflowLifecycleStatus = TaskStatus | WorkflowDerivedStatus;
+
+export interface WorkflowLifecycleEventBase {
+  readonly eventKey: string;
+  readonly kind: WorkflowLifecycleEventKind;
+  readonly workflowId: string;
+  readonly taskId?: string;
+  readonly status?: WorkflowLifecycleStatus;
+  readonly previousStatus?: TaskStatus;
+  readonly taskStateVersion?: number;
+  readonly generation: number;
+  readonly attemptId?: string;
+  readonly createdAt: string;
+}
+
+export interface TaskLifecycleEvent extends WorkflowLifecycleEventBase {
+  readonly kind:
+    | 'task.created'
+    | 'task.updated'
+    | 'task.completed'
+    | 'task.failed'
+    | 'task.review_ready'
+    | 'task.awaiting_approval'
+    | 'task.removed';
+  readonly taskId: string;
+  readonly status?: TaskStatus;
+}
+
+export interface ReviewGateFailedCheck {
+  readonly name: string;
+  readonly conclusion?: string;
+  readonly detailsUrl?: string;
+}
+
+export interface ReviewGateCiFailedLifecycleEvent extends WorkflowLifecycleEventBase {
+  readonly kind: 'review_gate.ci_failed';
+  readonly taskId: string;
+  readonly status: TaskStatus;
+  readonly reviewId: string;
+  readonly reviewUrl: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly branch?: string;
+  readonly failedChecks: readonly ReviewGateFailedCheck[];
+  readonly statusText: string;
+}
+
+export interface WorkflowWakeupLifecycleEvent extends WorkflowLifecycleEventBase {
+  readonly kind: 'workflow.wakeup';
+  readonly reason: WorkflowWakeupReason;
+  readonly status?: WorkflowDerivedStatus;
+}
+
+export type WorkflowLifecycleEvent =
+  | TaskLifecycleEvent
+  | ReviewGateCiFailedLifecycleEvent
+  | WorkflowWakeupLifecycleEvent;
+
+export type WorkflowWakeupReason =
+  | 'startup_reconcile'
+  | 'stalled_workflow_recovery'
+  | 'external_dependency_reconcile'
+  | 'manual_reconcile';
+
+export interface LifecycleBuildOptions {
+  readonly workflowId?: string;
+  readonly previousStatus?: TaskStatus;
+  readonly generation?: number;
+  readonly attemptId?: string;
+  readonly createdAt?: string | Date;
+}
+
+export interface TaskUpdatedLifecycleEventInput extends LifecycleBuildOptions {
+  readonly workflowId: string;
+  readonly taskId: string;
+  readonly status: TaskStatus;
+  readonly taskStateVersion: number;
+}
+
+export interface TaskRemovedLifecycleEventInput extends LifecycleBuildOptions {
+  readonly workflowId: string;
+  readonly taskId: string;
+  readonly status?: TaskStatus;
+  readonly taskStateVersion: number;
+}
+
+export interface ReviewGateCiFailedLifecycleEventInput extends LifecycleBuildOptions {
+  readonly workflowId: string;
+  readonly taskId: string;
+  readonly status: TaskStatus;
+  readonly taskStateVersion: number;
+  readonly reviewId: string;
+  readonly reviewUrl: string;
+  readonly headSha?: string;
+  readonly headRef?: string;
+  readonly branch?: string;
+  readonly failedChecks: readonly ReviewGateFailedCheck[];
+  readonly statusText: string;
+}
+
+export interface WorkflowWakeupLifecycleEventInput {
+  readonly workflowId: string;
+  readonly status?: WorkflowDerivedStatus;
+  readonly generation?: number;
+  readonly reason: WorkflowWakeupReason;
+  readonly createdAt?: string | Date;
+}
+
+const STATUS_VALUES: readonly WorkflowLifecycleStatus[] = [
+  'pending',
+  'running',
+  'fixing_with_ai',
+  'completed',
+  'failed',
+  'closed',
+  'needs_input',
+  'blocked',
+  'review_ready',
+  'awaiting_approval',
+  'stale',
+];
+
+const EVENT_KIND_SET = new Set<string>(WORKFLOW_LIFECYCLE_EVENT_KINDS);
+const STATUS_SET = new Set<string>(STATUS_VALUES);
+
+export function lifecycleEventKindForTaskStatus(status: TaskStatus): TaskLifecycleEvent['kind'] {
+  switch (status) {
+    case 'completed':
+      return 'task.completed';
+    case 'failed':
+      return 'task.failed';
+    case 'review_ready':
+      return 'task.review_ready';
+    case 'awaiting_approval':
+      return 'task.awaiting_approval';
+    default:
+      return 'task.updated';
+  }
+}
+
+export function buildLifecycleEventKey(input: {
+  readonly kind: WorkflowLifecycleEventKind;
+  readonly workflowId: string;
+  readonly taskId?: string;
+  readonly taskStateVersion?: number;
+  readonly generation?: number;
+  readonly attemptId?: string;
+  readonly discriminator?: string;
+}): string {
+  return [
+    input.kind,
+    `workflow:${input.workflowId}`,
+    input.taskId ? `task:${input.taskId}` : undefined,
+    `generation:${input.generation ?? 0}`,
+    input.attemptId ? `attempt:${input.attemptId}` : undefined,
+    input.taskStateVersion != null ? `task-state:${input.taskStateVersion}` : undefined,
+    input.discriminator,
+  ].filter((part): part is string => typeof part === 'string' && part.length > 0).join('|');
+}
+
+export function buildTaskCreatedLifecycleEvent(
+  task: TaskState,
+  options: LifecycleBuildOptions = {},
+): TaskLifecycleEvent {
+  const workflowId = requireWorkflowId(options.workflowId ?? task.config.workflowId, task.id);
+  const generation = options.generation ?? task.execution.generation ?? 0;
+  const attemptId = options.attemptId ?? task.execution.selectedAttemptId;
+  return buildTaskLifecycleEvent({
+    kind: 'task.created',
+    workflowId,
+    taskId: task.id,
+    status: task.status,
+    taskStateVersion: task.taskStateVersion,
+    generation,
+    attemptId,
+    createdAt: options.createdAt,
+  });
+}
+
+export function buildTaskUpdatedLifecycleEvent(input: TaskUpdatedLifecycleEventInput): TaskLifecycleEvent {
+  return buildTaskLifecycleEvent({
+    kind: lifecycleEventKindForTaskStatus(input.status),
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    status: input.status,
+    previousStatus: input.previousStatus,
+    taskStateVersion: input.taskStateVersion,
+    generation: input.generation ?? 0,
+    attemptId: input.attemptId,
+    createdAt: input.createdAt,
+  });
+}
+
+export function buildTaskRemovedLifecycleEvent(input: TaskRemovedLifecycleEventInput): TaskLifecycleEvent {
+  return buildTaskLifecycleEvent({
+    kind: 'task.removed',
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    status: input.status,
+    previousStatus: input.previousStatus,
+    taskStateVersion: input.taskStateVersion,
+    generation: input.generation ?? 0,
+    attemptId: input.attemptId,
+    createdAt: input.createdAt,
+  });
+}
+
+export function buildReviewGateCiFailedLifecycleEvent(
+  input: ReviewGateCiFailedLifecycleEventInput,
+): ReviewGateCiFailedLifecycleEvent {
+  const eventKey = buildLifecycleEventKey({
+    kind: 'review_gate.ci_failed',
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    taskStateVersion: input.taskStateVersion,
+    generation: input.generation,
+    attemptId: input.attemptId,
+    discriminator: `review:${input.reviewId}:${input.headSha ?? 'no-head-sha'}`,
+  });
+
+  return {
+    eventKey,
+    kind: 'review_gate.ci_failed',
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    status: input.status,
+    taskStateVersion: input.taskStateVersion,
+    generation: input.generation ?? 0,
+    ...(input.previousStatus ? { previousStatus: input.previousStatus } : {}),
+    ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+    createdAt: normalizeCreatedAt(input.createdAt),
+    reviewId: input.reviewId,
+    reviewUrl: input.reviewUrl,
+    ...(input.headSha ? { headSha: input.headSha } : {}),
+    ...(input.headRef ? { headRef: input.headRef } : {}),
+    ...(input.branch ? { branch: input.branch } : {}),
+    failedChecks: input.failedChecks.map((check) => ({ ...check })),
+    statusText: input.statusText,
+  };
+}
+
+export function buildWorkflowWakeupLifecycleEvent(
+  input: WorkflowWakeupLifecycleEventInput,
+): WorkflowWakeupLifecycleEvent {
+  const generation = input.generation ?? 0;
+  return {
+    eventKey: buildLifecycleEventKey({
+      kind: 'workflow.wakeup',
+      workflowId: input.workflowId,
+      generation,
+      discriminator: `reason:${input.reason}`,
+    }),
+    kind: 'workflow.wakeup',
+    workflowId: input.workflowId,
+    ...(input.status ? { status: input.status } : {}),
+    generation,
+    createdAt: normalizeCreatedAt(input.createdAt),
+    reason: input.reason,
+  };
+}
+
+export function buildLifecycleEventFromTaskDelta(
+  delta: TaskDelta,
+  options: LifecycleBuildOptions = {},
+): TaskLifecycleEvent {
+  switch (delta.type) {
+    case 'created':
+      return buildTaskCreatedLifecycleEvent(delta.task, options);
+    case 'updated': {
+      const status = delta.changes.status ?? options.previousStatus;
+      return buildTaskUpdatedLifecycleEvent({
+        workflowId: requireWorkflowId(options.workflowId, delta.taskId),
+        taskId: delta.taskId,
+        status: requireTaskStatus(status, delta.taskId),
+        previousStatus: options.previousStatus,
+        taskStateVersion: delta.taskStateVersion,
+        generation: options.generation ?? delta.changes.execution?.generation,
+        attemptId: options.attemptId ?? delta.changes.execution?.selectedAttemptId,
+        createdAt: options.createdAt,
+      });
+    }
+    case 'removed':
+      return buildTaskRemovedLifecycleEvent({
+        workflowId: requireWorkflowId(options.workflowId, delta.taskId),
+        taskId: delta.taskId,
+        status: undefined,
+        previousStatus: options.previousStatus,
+        taskStateVersion: delta.previousTaskStateVersion,
+        generation: options.generation,
+        attemptId: options.attemptId,
+        createdAt: options.createdAt,
+      });
+  }
+}
+
+export function isWorkflowLifecycleEventKind(value: unknown): value is WorkflowLifecycleEventKind {
+  return typeof value === 'string' && EVENT_KIND_SET.has(value);
+}
+
+export function isWorkflowLifecycleEvent(value: unknown): value is WorkflowLifecycleEvent {
+  if (!isRecord(value)) return false;
+  if (typeof value.eventKey !== 'string') return false;
+  if (!isWorkflowLifecycleEventKind(value.kind)) return false;
+  if (typeof value.workflowId !== 'string') return false;
+  if (typeof value.createdAt !== 'string') return false;
+  if (typeof value.generation !== 'number') return false;
+  if (value.taskId != null && typeof value.taskId !== 'string') return false;
+  if (value.status != null && !isWorkflowLifecycleStatus(value.status)) return false;
+  if (value.previousStatus != null && !isTaskStatus(value.previousStatus)) return false;
+  if (value.taskStateVersion != null && typeof value.taskStateVersion !== 'number') return false;
+  if (value.attemptId != null && typeof value.attemptId !== 'string') return false;
+
+  switch (value.kind) {
+    case 'task.created':
+    case 'task.updated':
+    case 'task.completed':
+    case 'task.failed':
+    case 'task.review_ready':
+    case 'task.awaiting_approval':
+    case 'task.removed':
+      return typeof value.taskId === 'string';
+    case 'review_gate.ci_failed':
+      return typeof value.taskId === 'string'
+        && typeof value.status === 'string'
+        && typeof value.reviewId === 'string'
+        && typeof value.reviewUrl === 'string'
+        && Array.isArray(value.failedChecks)
+        && typeof value.statusText === 'string';
+    case 'workflow.wakeup':
+      return value.reason === 'startup_reconcile'
+        || value.reason === 'stalled_workflow_recovery'
+        || value.reason === 'external_dependency_reconcile'
+        || value.reason === 'manual_reconcile';
+  }
+}
+
+export function isTaskLifecycleEvent(value: unknown): value is TaskLifecycleEvent {
+  return isWorkflowLifecycleEvent(value) && value.kind.startsWith('task.');
+}
+
+function buildTaskLifecycleEvent(input: {
+  readonly kind: TaskLifecycleEvent['kind'];
+  readonly workflowId: string;
+  readonly taskId: string;
+  readonly status?: TaskStatus;
+  readonly previousStatus?: TaskStatus;
+  readonly taskStateVersion: number;
+  readonly generation: number;
+  readonly attemptId?: string;
+  readonly createdAt?: string | Date;
+}): TaskLifecycleEvent {
+  return {
+    eventKey: buildLifecycleEventKey(input),
+    kind: input.kind,
+    workflowId: input.workflowId,
+    taskId: input.taskId,
+    ...(input.status ? { status: input.status } : {}),
+    ...(input.previousStatus ? { previousStatus: input.previousStatus } : {}),
+    taskStateVersion: input.taskStateVersion,
+    generation: input.generation,
+    ...(input.attemptId ? { attemptId: input.attemptId } : {}),
+    createdAt: normalizeCreatedAt(input.createdAt),
+  };
+}
+
+function normalizeCreatedAt(createdAt: string | Date | undefined): string {
+  if (createdAt instanceof Date) return createdAt.toISOString();
+  return createdAt ?? new Date().toISOString();
+}
+
+function requireWorkflowId(workflowId: string | undefined, taskId: string): string {
+  if (workflowId) return workflowId;
+  throw new Error(`workflowId is required to build lifecycle event for task ${taskId}`);
+}
+
+function requireTaskStatus(status: TaskStatus | undefined, taskId: string): TaskStatus {
+  if (status) return status;
+  throw new Error(`status is required to build lifecycle event for task ${taskId}`);
+}
+
+function isWorkflowLifecycleStatus(value: unknown): value is WorkflowLifecycleStatus {
+  return typeof value === 'string' && STATUS_SET.has(value);
+}
+
+function isTaskStatus(value: unknown): value is TaskStatus {
+  return isWorkflowLifecycleStatus(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/app/src/lifecycle-events.ts
+++ b/packages/app/src/lifecycle-events.ts
@@ -12,6 +12,7 @@ export const WORKFLOW_LIFECYCLE_EVENT_KINDS = [
   'task.failed',
   'task.review_ready',
   'task.awaiting_approval',
+  'task.needs_input',
   'task.removed',
   'review_gate.ci_failed',
   'workflow.wakeup',
@@ -41,6 +42,7 @@ export interface TaskLifecycleEvent extends WorkflowLifecycleEventBase {
     | 'task.failed'
     | 'task.review_ready'
     | 'task.awaiting_approval'
+    | 'task.needs_input'
     | 'task.removed';
   readonly taskId: string;
   readonly status?: TaskStatus;
@@ -153,6 +155,8 @@ export function lifecycleEventKindForTaskStatus(status: TaskStatus): TaskLifecyc
       return 'task.review_ready';
     case 'awaiting_approval':
       return 'task.awaiting_approval';
+    case 'needs_input':
+      return 'task.needs_input';
     default:
       return 'task.updated';
   }
@@ -337,6 +341,7 @@ export function isWorkflowLifecycleEvent(value: unknown): value is WorkflowLifec
     case 'task.failed':
     case 'task.review_ready':
     case 'task.awaiting_approval':
+    case 'task.needs_input':
     case 'task.removed':
       return typeof value.taskId === 'string';
     case 'review_gate.ci_failed':

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -182,7 +182,7 @@ import {
   type WorkflowScopedGuiMutationRegistrationContext,
 } from './ipc/ipc-registration.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
-import { startLifecycleEventBridge } from './lifecycle-event-bridge.js';
+import { startLifecycleEventBridge, type LifecycleEventBridge } from './lifecycle-event-bridge.js';
 import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
 import {
   executeNoTrackHeadlessBatch,
@@ -807,6 +807,7 @@ if (isHeadless) {
 
     let exitCode = 0;
     let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
+    let lifecycleEventBridge: LifecycleEventBridge | null = null;
     try {
       // Standalone mode: initialize services and run headless
       await initServices({
@@ -1197,6 +1198,13 @@ if (isHeadless) {
           return { ok: true };
         });
 
+        lifecycleEventBridge = startLifecycleEventBridge({
+          messageBus,
+          getInitialTasks: () => orchestrator.getAllTasks(),
+          getTask: (taskId) => orchestrator.getTask(taskId),
+          logger,
+        });
+
         reviewGateStatusWorker = startReviewGateStatusWorker({
           ownerMode: true,
           getTaskExecutor: createStandaloneTaskExecutor,
@@ -1209,6 +1217,7 @@ if (isHeadless) {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
       exitCode = 1;
     } finally {
+      lifecycleEventBridge?.stop();
       reviewGateStatusWorker?.stop();
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -182,6 +182,7 @@ import {
   type WorkflowScopedGuiMutationRegistrationContext,
 } from './ipc/ipc-registration.js';
 import { createTaskDeltaStreamSequence } from './task-delta-stream-sequence.js';
+import { startLifecycleEventBridge } from './lifecycle-event-bridge.js';
 import { startReviewGateStatusWorker, type ReviewGateStatusWorker } from './review-gate-status-worker.js';
 import {
   executeNoTrackHeadlessBatch,
@@ -2722,6 +2723,14 @@ function createEmbeddedTerminalBackendFromConfig(
     }
 
     bootstrapInitialWorkflowState();
+    if (ownerMode) {
+      startLifecycleEventBridge({
+        messageBus,
+        getInitialTasks: () => orchestrator.getAllTasks(),
+        getTask: (taskId) => orchestrator.getTask(taskId),
+        logger,
+      });
+    }
 
     reviewGateStatusWorker = startReviewGateStatusWorker({
       ownerMode,

--- a/packages/transport/src/message-bus.ts
+++ b/packages/transport/src/message-bus.ts
@@ -41,6 +41,7 @@ export interface MessageBus {
 export const Channels = {
   TASK_DELTA: 'task.delta',
   TASK_OUTPUT: 'task.output',
+  WORKFLOW_LIFECYCLE: 'workflow.lifecycle',
   WORKFLOW_LOADED: 'workflow.loaded',
   EXPERIMENT_SPAWNED: 'experiment.spawned',
   EXPERIMENT_SELECTED: 'experiment.selected',


### PR DESCRIPTION
## Summary

Stack 1 establishes the recovery lifecycle event foundation for later auto-fix and external recovery workers.

It documents the target worker model, adds `WORKFLOW_LIFECYCLE`, and defines typed lifecycle event builders and guards.

The owner-mode bridge converts existing `TASK_DELTA` messages into lifecycle wakeups without mutating task state or running recovery actions.

The bridge starts in both owner paths — GUI bootstrap and headless standalone owner — so whichever process holds ownership publishes lifecycle events, and stops on headless shutdown.

## Architecture

### Before

```mermaid
flowchart TD
    Persisted["Persisted task state"] --> Delta["TASK_DELTA"]
    Delta --> ExistingWatchers["Renderer and existing watchers"]
    Delta --> DirectRecovery["Direct failed-delta recovery handlers"]
    DirectRecovery --> AutoFix["Auto-fix scheduling"]
    DirectRecovery --> ExternalRecovery["External recovery launch"]
```

### After

```mermaid
flowchart TD
    Persisted["Persisted task state"] --> Delta["TASK_DELTA"]
    Delta --> ExistingWatchers["Renderer and existing watchers"]
    Delta --> ExistingRecovery["Existing recovery handlers unchanged"]
    Delta --> Bridge["Lifecycle event bridge (GUI owner or headless standalone owner)"]
    Bridge --> Lifecycle["WORKFLOW_LIFECYCLE"]
    Lifecycle -.-> FutureWorkers["Downstream recovery workers"]
    FutureWorkers -.-> Scan["Scan persisted workflow and task state"]
    Scan -.-> Commands["Normal command routes"]
    Commands -.-> Persisted
```

## Test Plan

- [x] `cd packages/app && pnpm test src/__tests__/lifecycle-events.test.ts src/__tests__/lifecycle-event-bridge.test.ts`
- [x] `cd packages/app && pnpm test` (full app package suite: 1057 passed, 1 skipped)
- [x] `cd packages/app && pnpm run build`

## Revert Plan

- Safe to revert? Yes, if dependent worker stack PRs are reverted or not yet merged.
- Revert command: `git revert <merge-sha>`
- Post-revert steps: Rebase or revert downstream stack branches that import `WORKFLOW_LIFECYCLE` or lifecycle event helpers.
- Data migration? No
