### PR TITLE
Fix intent cancellation Step 8: merge-gate side-effect lineage guard (regression gated v2)

### DIFF
--- a/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/merge-gate-executor.test.ts
@@ -1,0 +1,246 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { WorkRequest, WorkResponse } from '@invoker/contracts';
+import {
+  Orchestrator,
+  type Attempt,
+  type OrchestratorMessageBus,
+  type OrchestratorPersistence,
+  type TaskState,
+  type TaskStateChanges,
+} from '@invoker/workflow-core';
+import { MergeGateExecutor } from '../merge-gate-executor.js';
+import type { MergeRunnerHost } from '../merge-runner.js';
+
+interface WorkflowRecord {
+  id: string;
+  name: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  repoUrl?: string;
+  intermediateRepoUrl?: string;
+  onFinish?: string;
+  baseBranch?: string;
+  featureBranch?: string;
+  mergeMode?: 'manual' | 'automatic' | 'external_review';
+}
+
+class InMemoryPersistence implements OrchestratorPersistence {
+  workflows = new Map<string, WorkflowRecord>();
+  tasks = new Map<string, { workflowId: string; task: TaskState }>();
+  attempts = new Map<string, Attempt[]>();
+  updateTask = vi.fn((taskId: string, changes: TaskStateChanges) => {
+    const entry = this.tasks.get(taskId);
+    if (!entry) return;
+    entry.task = {
+      ...entry.task,
+      ...(changes.status !== undefined ? { status: changes.status } : {}),
+      ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
+      config: { ...entry.task.config, ...changes.config },
+      execution: { ...entry.task.execution, ...changes.execution },
+    } as TaskState;
+  });
+  logEvent = vi.fn();
+
+  saveWorkflow(workflow: WorkflowRecord): void {
+    this.workflows.set(workflow.id, workflow);
+  }
+
+  updateWorkflow(workflowId: string, changes: Partial<WorkflowRecord>): void {
+    const existing = this.workflows.get(workflowId);
+    if (existing) this.workflows.set(workflowId, { ...existing, ...changes });
+  }
+
+  loadWorkflow(workflowId: string): WorkflowRecord | undefined {
+    return this.workflows.get(workflowId);
+  }
+
+  listWorkflows(): WorkflowRecord[] {
+    return Array.from(this.workflows.values());
+  }
+
+  saveTask(workflowId: string, task: TaskState): void {
+    this.tasks.set(task.id, { workflowId, task });
+  }
+
+  loadTasks(workflowId: string): TaskState[] {
+    return Array.from(this.tasks.values())
+      .filter((entry) => entry.workflowId === workflowId)
+      .map((entry) => entry.task);
+  }
+
+  saveAttempt(attempt: Attempt): void {
+    const attempts = this.attempts.get(attempt.nodeId) ?? [];
+    attempts.push(attempt);
+    this.attempts.set(attempt.nodeId, attempts);
+  }
+
+  loadAttempts(nodeId: string): Attempt[] {
+    return this.attempts.get(nodeId) ?? [];
+  }
+
+  loadAttempt(attemptId: string): Attempt | undefined {
+    for (const attempts of this.attempts.values()) {
+      const found = attempts.find((attempt) => attempt.id === attemptId);
+      if (found) return found;
+    }
+    return undefined;
+  }
+
+  updateAttempt(attemptId: string, changes: Partial<Attempt>): void {
+    for (const attempts of this.attempts.values()) {
+      const index = attempts.findIndex((attempt) => attempt.id === attemptId);
+      if (index >= 0) {
+        attempts[index] = { ...attempts[index], ...changes } as Attempt;
+        return;
+      }
+    }
+  }
+
+  getWorkspacePath(taskId: string): string | null {
+    return this.tasks.get(taskId)?.task.execution.workspacePath ?? null;
+  }
+}
+
+class InMemoryBus implements OrchestratorMessageBus {
+  publish(): void {}
+  subscribe(): () => void {
+    return () => {};
+  }
+}
+
+function taskIdBySuffix(orchestrator: Orchestrator, suffix: string): string {
+  const task = orchestrator.getAllTasks().find((item) => item.id.endsWith(`/${suffix}`));
+  if (!task) throw new Error(`Task with suffix "${suffix}" not found`);
+  return task.id;
+}
+
+function makeOrchestrator(): { orchestrator: Orchestrator; persistence: InMemoryPersistence } {
+  const persistence = new InMemoryPersistence();
+  const orchestrator = new Orchestrator({
+    persistence,
+    messageBus: new InMemoryBus(),
+    deferRunningUntilLaunch: true,
+  });
+  orchestrator.loadPlan({
+    name: 'merge-gate-lineage',
+    onFinish: 'pull_request',
+    baseBranch: 'master',
+    featureBranch: 'feature/wf',
+    mergeMode: 'manual',
+    tasks: [{ id: 'merge', description: 'Merge gate', command: 'echo merge' }],
+  });
+  return { orchestrator, persistence };
+}
+
+function makeHost(
+  orchestrator: Orchestrator,
+  persistence: InMemoryPersistence,
+  consolidateAndMerge: MergeRunnerHost['consolidateAndMerge'],
+): MergeRunnerHost {
+  return {
+    orchestrator,
+    persistence: persistence as any,
+    defaultBranch: 'master',
+    callbacks: {},
+    cwd: '/repo',
+    createMergeWorktree: vi.fn(async () => '/tmp/gate-clone'),
+    removeMergeWorktree: vi.fn(async () => {}),
+    execGitReadonly: vi.fn(async () => ''),
+    execGitIn: vi.fn(async () => ''),
+    execGh: vi.fn(async () => ''),
+    execPr: vi.fn(async () => 'https://example.test/pr/1'),
+    detectDefaultBranch: vi.fn(async () => 'master'),
+    gitLogMessage: vi.fn(async () => ''),
+    gitDiffStat: vi.fn(async () => ''),
+    executeTasks: vi.fn(async () => {}),
+    buildMergeSummary: vi.fn(async () => 'merge summary'),
+    consolidateAndMerge,
+  };
+}
+
+async function startMergeGate(
+  executor: MergeGateExecutor,
+  task: TaskState,
+): Promise<WorkResponse> {
+  const request: WorkRequest = {
+    requestId: `req-${task.id}`,
+    actionId: task.id,
+    actionType: 'command',
+    attemptId: task.execution.selectedAttemptId,
+    executionGeneration: task.execution.generation ?? 0,
+    inputs: {},
+    callbackUrl: 'http://localhost/callback',
+  };
+  const handle = await executor.start(request);
+  return await new Promise<WorkResponse>((resolve) => {
+    executor.onComplete(handle, resolve);
+  });
+}
+
+describe('MergeGateExecutor lineage guard', () => {
+  it('does not write direct execution metadata when merge-gate work becomes stale before completion', async () => {
+    const { orchestrator, persistence } = makeOrchestrator();
+    const taskId = taskIdBySuffix(orchestrator, 'merge');
+    const [claim] = orchestrator.startExecution();
+    const staleAttemptId = claim!.execution.selectedAttemptId!;
+    const staleGeneration = claim!.execution.generation ?? 0;
+    expect(orchestrator.markTaskRunningAfterLaunch(taskId, staleAttemptId)).toBe(true);
+
+    let replacementAttemptId: string | undefined;
+    const host = makeHost(orchestrator, persistence, vi.fn(async () => {
+      const [replacement] = orchestrator.recreateTask(taskId);
+      replacementAttemptId = replacement!.execution.selectedAttemptId;
+      return undefined;
+    }));
+    const executor = new MergeGateExecutor(host);
+
+    const response = await startMergeGate(executor, claim!);
+
+    expect(response).toMatchObject({
+      actionId: taskId,
+      attemptId: staleAttemptId,
+      executionGeneration: staleGeneration,
+      status: 'review_ready',
+    });
+    expect(persistence.updateTask).not.toHaveBeenCalledWith(
+      taskId,
+      expect.objectContaining({
+        execution: expect.objectContaining({
+          branch: 'feature/wf',
+          workspacePath: '/tmp/gate-clone',
+        }),
+      }),
+    );
+    expect(persistence.logEvent).toHaveBeenCalledWith(
+      taskId,
+      'merge-gate.stale-side-effect-skipped',
+      expect.objectContaining({ tag: 'executor-merge-metadata' }),
+    );
+
+    const staleResult = orchestrator.handleWorkerResponse(response);
+    expect(staleResult).toEqual([]);
+    expect(orchestrator.getTask(taskId)?.execution.selectedAttemptId).toBe(replacementAttemptId);
+    expect(orchestrator.getTask(taskId)?.status).toBe('pending');
+  });
+
+  it('persists valid merge-gate review-ready execution metadata', async () => {
+    const { orchestrator, persistence } = makeOrchestrator();
+    const taskId = taskIdBySuffix(orchestrator, 'merge');
+    const [claim] = orchestrator.startExecution();
+    expect(orchestrator.markTaskRunningAfterLaunch(taskId, claim!.execution.selectedAttemptId!)).toBe(true);
+
+    const host = makeHost(orchestrator, persistence, vi.fn(async () => undefined));
+    const executor = new MergeGateExecutor(host);
+
+    const response = await startMergeGate(executor, claim!);
+
+    expect(response.status).toBe('review_ready');
+    expect(persistence.updateTask).toHaveBeenCalledWith(taskId, {
+      execution: expect.objectContaining({
+        branch: 'feature/wf',
+        workspacePath: '/tmp/gate-clone',
+      }),
+    });
+  });
+});

--- a/packages/execution-engine/src/merge-gate-executor.ts
+++ b/packages/execution-engine/src/merge-gate-executor.ts
@@ -4,7 +4,7 @@ import type { TaskState } from '@invoker/workflow-core';
 import { BaseExecutor, type BaseEntry } from './base-executor.js';
 import type { ExecutorHandle, PersistedTaskMeta, TerminalSpec } from './executor.js';
 import type { MergeRunnerHost } from './merge-runner.js';
-import { runMergeGateActionImpl } from './merge-runner.js';
+import { runMergeGateActionImpl, updateMergeGateTaskIfCurrent } from './merge-runner.js';
 import { normalizeBranchForGithubCli } from './github-branch-ref.js';
 
 interface MergeGateEntry extends BaseEntry {
@@ -123,11 +123,19 @@ export class MergeGateExecutor extends BaseExecutor<MergeGateEntry> {
 
     try {
       this.emitOutput(handle.executionId, `[merge] Starting merge gate action: ${task.id}\n`);
-      const result = await runMergeGateActionImpl(this.host, task, { gateWorkspacePath });
+      const lineage = {
+        attemptId: entry.request.attemptId,
+        executionGeneration: entry.request.executionGeneration,
+      };
+      const result = await runMergeGateActionImpl(this.host, task, { gateWorkspacePath, lineage });
       if (result.taskChanges.execution) {
-        this.host.persistence.updateTask(task.id, {
-          execution: result.taskChanges.execution,
-        });
+        updateMergeGateTaskIfCurrent(
+          this.host,
+          task.id,
+          lineage,
+          { execution: result.taskChanges.execution },
+          'executor-merge-metadata',
+        );
       }
       this.emitOutput(handle.executionId, `[merge] Merge gate action finished: ${task.id} status=${result.response.status}\n`);
       this.emitComplete(handle.executionId, this.withAttempt(entry.request, result.response));

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -87,6 +87,87 @@ function setMergeGateReviewReady(
   orchestrator.setTaskAwaitingApproval?.(taskId, changes);
 }
 
+export interface MergeGateExecutionLineage {
+  attemptId?: string;
+  executionGeneration: number;
+}
+
+function captureMergeGateLineage(task: TaskState): MergeGateExecutionLineage {
+  return {
+    attemptId: task.execution.selectedAttemptId,
+    executionGeneration: task.execution.generation ?? 0,
+  };
+}
+
+export function isMergeGateLineageCurrent(
+  host: MergeRunnerHost,
+  taskId: string,
+  lineage: MergeGateExecutionLineage,
+): boolean {
+  const current = host.orchestrator.getTask(taskId);
+  if (!current) return true;
+  if (lineage.attemptId && current.execution.selectedAttemptId !== lineage.attemptId) return false;
+  return (current.execution.generation ?? 0) === lineage.executionGeneration;
+}
+
+function logStaleMergeGateSideEffect(
+  host: MergeRunnerHost,
+  taskId: string,
+  lineage: MergeGateExecutionLineage,
+  tag: string,
+): void {
+  const current = host.orchestrator.getTask(taskId);
+  mergeTrace('MERGE_GATE_STALE_SIDE_EFFECT_SKIPPED', {
+    taskId,
+    tag,
+    attemptId: lineage.attemptId ?? null,
+    generation: lineage.executionGeneration,
+    currentAttemptId: current?.execution.selectedAttemptId ?? null,
+    currentGeneration: current?.execution.generation ?? null,
+  });
+  try {
+    host.persistence.logEvent?.(taskId, 'merge-gate.stale-side-effect-skipped', {
+      tag,
+      attemptId: lineage.attemptId,
+      generation: lineage.executionGeneration,
+      currentAttemptId: current?.execution.selectedAttemptId,
+      currentGeneration: current?.execution.generation ?? 0,
+    });
+  } catch {
+    /* diagnostics only */
+  }
+}
+
+export function updateMergeGateTaskIfCurrent(
+  host: MergeRunnerHost,
+  taskId: string,
+  lineage: MergeGateExecutionLineage,
+  changes: TaskStateChanges,
+  tag: string,
+): boolean {
+  if (!isMergeGateLineageCurrent(host, taskId, lineage)) {
+    logStaleMergeGateSideEffect(host, taskId, lineage, tag);
+    return false;
+  }
+  host.persistence.updateTask(taskId, changes);
+  return true;
+}
+
+function setMergeGateReviewReadyIfCurrent(
+  host: MergeRunnerHost,
+  taskId: string,
+  lineage: MergeGateExecutionLineage,
+  changes: TaskStateChanges,
+  tag: string,
+): boolean {
+  if (!isMergeGateLineageCurrent(host, taskId, lineage)) {
+    logStaleMergeGateSideEffect(host, taskId, lineage, tag);
+    return false;
+  }
+  setMergeGateReviewReady(host, taskId, changes);
+  return true;
+}
+
 function buildMergeConflictJson(errorText: string, failedBranch: string): string | undefined {
   const hasConflictMarkers =
     errorText.includes('CONFLICT (') ||
@@ -408,8 +489,9 @@ export interface MergeGateActionResult {
 export async function runMergeGateActionImpl(
   host: MergeRunnerHost,
   task: TaskState,
-  opts: { gateWorkspacePath?: string } = {},
+  opts: { gateWorkspacePath?: string; lineage?: MergeGateExecutionLineage } = {},
 ): Promise<MergeGateActionResult> {
+  const lineage = opts.lineage ?? captureMergeGateLineage(task);
   const workflowId = task.config.workflowId;
   const workflow = workflowId
     ? host.persistence.loadWorkflow(workflowId)
@@ -441,13 +523,19 @@ export async function runMergeGateActionImpl(
       `mergeMode=${mergeMode} onFinish=${onFinish} dbWorkspacePath=${safeGetWorkspacePath(host.persistence, task.id) ?? 'NULL'}`,
   );
 
-  host.persistence.updateTask(task.id, {
-    execution: {
-      reviewUrl: undefined,
-      reviewId: undefined,
-      reviewStatus: undefined,
+  updateMergeGateTaskIfCurrent(
+    host,
+    task.id,
+    lineage,
+    {
+      execution: {
+        reviewUrl: undefined,
+        reviewId: undefined,
+        reviewStatus: undefined,
+      },
     },
-  });
+    'clear-review-metadata',
+  );
 
   // Create a persistent gate worktree so workspacePath is never the main repo.
   // Use baseBranch as the ref because featureBranch may not exist yet
@@ -501,7 +589,8 @@ export async function runMergeGateActionImpl(
         response = {
           requestId: `merge-${task.id}`,
           actionId: task.id,
-          executionGeneration: task.execution.generation ?? 0,
+          attemptId: lineage.attemptId,
+          executionGeneration: lineage.executionGeneration,
           status: 'review_ready',
           outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
         };
@@ -575,7 +664,8 @@ export async function runMergeGateActionImpl(
         response = {
           requestId: `merge-${task.id}`,
           actionId: task.id,
-          executionGeneration: task.execution.generation ?? 0,
+          attemptId: lineage.attemptId,
+          executionGeneration: lineage.executionGeneration,
           status: 'review_ready',
           outputs: {
             exitCode: 0,
@@ -603,7 +693,8 @@ export async function runMergeGateActionImpl(
       response = {
         requestId: `merge-${task.id}`,
         actionId: task.id,
-        executionGeneration: task.execution.generation ?? 0,
+        attemptId: lineage.attemptId,
+        executionGeneration: lineage.executionGeneration,
         status: 'completed',
         outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
       };
@@ -611,7 +702,8 @@ export async function runMergeGateActionImpl(
       response = {
         requestId: `merge-${task.id}`,
         actionId: task.id,
-        executionGeneration: task.execution.generation ?? 0,
+        attemptId: lineage.attemptId,
+        executionGeneration: lineage.executionGeneration,
         status: 'failed',
         outputs: {
           exitCode: 1,
@@ -633,7 +725,8 @@ export async function runMergeGateActionImpl(
       response = {
         requestId: `merge-${task.id}`,
         actionId: task.id,
-        executionGeneration: task.execution.generation ?? 0,
+        attemptId: lineage.attemptId,
+        executionGeneration: lineage.executionGeneration,
         status: 'review_ready',
         outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
       };
@@ -648,7 +741,8 @@ export async function runMergeGateActionImpl(
     response = {
       requestId: `merge-${task.id}`,
       actionId: task.id,
-      executionGeneration: task.execution.generation ?? 0,
+      attemptId: lineage.attemptId,
+      executionGeneration: lineage.executionGeneration,
       status: 'completed',
       outputs: { exitCode: 0, summary, branch: featureBranch ?? undefined },
     };
@@ -685,7 +779,8 @@ export async function executeMergeNodeImpl(
   host: MergeRunnerHost,
   task: TaskState,
 ): Promise<void> {
-  const result = await runMergeGateActionImpl(host, task);
+  const lineage = captureMergeGateLineage(task);
+  const result = await runMergeGateActionImpl(host, task, { lineage });
   const { response } = result;
   const legacyConfig = {
     ...(result.taskChanges.config ?? {}),
@@ -698,11 +793,11 @@ export async function executeMergeNodeImpl(
     config: legacyConfig,
   };
 
-  host.persistence.updateTask(task.id, legacyChanges);
+  updateMergeGateTaskIfCurrent(host, task.id, lineage, legacyChanges, 'legacy-merge-metadata');
   host.callbacks.onComplete?.(task.id, response);
 
   if (response.status === 'review_ready') {
-    setMergeGateReviewReady(host, task.id, legacyChanges);
+    setMergeGateReviewReadyIfCurrent(host, task.id, lineage, legacyChanges, 'legacy-review-ready');
     await startReviewReadyDependents(host);
   } else {
     const newlyStarted = host.orchestrator.handleWorkerResponse(response) ?? [];
@@ -832,6 +927,7 @@ export async function publishAfterFixImpl(
   host: MergeRunnerHost,
   task: TaskState,
 ): Promise<void> {
+  const lineage = captureMergeGateLineage(task);
   const workflowId = task.config.workflowId;
   const workflow = workflowId
     ? host.persistence.loadWorkflow(workflowId)
@@ -871,15 +967,21 @@ export async function publishAfterFixImpl(
         `[merge-gate-workspace] publishAfterFix early return (no featureBranch) task=${task.id} ` +
           `will persist workspacePath=${gateWorkspacePath ?? 'NULL'}`,
       );
-      setMergeGateReviewReady(host, task.id, {
-        config: { runnerKind: 'worktree', summary },
-        execution: {
-          workspacePath: gateWorkspacePath,
-          fixedIntegrationSha: undefined,
-          fixedIntegrationRecordedAt: undefined,
-          fixedIntegrationSource: undefined,
+      setMergeGateReviewReadyIfCurrent(
+        host,
+        task.id,
+        lineage,
+        {
+          config: { runnerKind: 'worktree', summary },
+          execution: {
+            workspacePath: gateWorkspacePath,
+            fixedIntegrationSha: undefined,
+            fixedIntegrationRecordedAt: undefined,
+            fixedIntegrationSource: undefined,
+          },
         },
-      });
+        'post-fix-no-feature-branch',
+      );
       await startReviewReadyDependents(host);
       return;
     }
@@ -1079,19 +1181,25 @@ export async function publishAfterFixImpl(
 
 
 
-      setMergeGateReviewReady(host, task.id, {
-        config: { runnerKind: 'worktree', summary },
-        execution: {
-          branch: featureBranch,
-          workspacePath: gateWorkspacePath,
-          reviewUrl: result.url,
-          reviewId: result.identifier,
-          reviewStatus: 'Awaiting review',
-          fixedIntegrationSha: undefined,
-          fixedIntegrationRecordedAt: undefined,
-          fixedIntegrationSource: undefined,
+      setMergeGateReviewReadyIfCurrent(
+        host,
+        task.id,
+        lineage,
+        {
+          config: { runnerKind: 'worktree', summary },
+          execution: {
+            branch: featureBranch,
+            workspacePath: gateWorkspacePath,
+            reviewUrl: result.url,
+            reviewId: result.identifier,
+            reviewStatus: 'Awaiting review',
+            fixedIntegrationSha: undefined,
+            fixedIntegrationRecordedAt: undefined,
+            fixedIntegrationSource: undefined,
+          },
         },
-      });
+        'post-fix-external-review-ready',
+      );
       await startReviewReadyDependents(host);
       return;
     }
@@ -1113,22 +1221,34 @@ export async function publishAfterFixImpl(
       });
       const reviewUrl = await host.execPr(baseBranch, featureBranch, workflow?.name ?? 'Workflow', prBody, consolidateDir);
       console.log(`[merge] Post-fix: created pull request ${reviewUrl}`);
-      host.persistence.updateTask(task.id, {
-        config: { summary },
-        execution: { reviewUrl },
-      });
+      updateMergeGateTaskIfCurrent(
+        host,
+        task.id,
+        lineage,
+        {
+          config: { summary },
+          execution: { reviewUrl },
+        },
+        'post-fix-review-url',
+      );
     }
 
-    setMergeGateReviewReady(host, task.id, {
-      config: { runnerKind: 'worktree', summary },
-      execution: {
-        branch: featureBranch,
-        workspacePath: gateWorkspacePath,
-        fixedIntegrationSha: undefined,
-        fixedIntegrationRecordedAt: undefined,
-        fixedIntegrationSource: undefined,
+    setMergeGateReviewReadyIfCurrent(
+      host,
+      task.id,
+      lineage,
+      {
+        config: { runnerKind: 'worktree', summary },
+        execution: {
+          branch: featureBranch,
+          workspacePath: gateWorkspacePath,
+          fixedIntegrationSha: undefined,
+          fixedIntegrationRecordedAt: undefined,
+          fixedIntegrationSource: undefined,
+        },
       },
-    });
+      'post-fix-review-ready',
+    );
     await startReviewReadyDependents(host);
     mergeTrace('PUBLISH_AFTER_FIX_DONE', { taskId: task.id });
   } catch (err) {
@@ -1150,7 +1270,8 @@ export async function publishAfterFixImpl(
     const failedResponse: WorkResponse = {
       requestId: `postfix-${task.id}`,
       actionId: task.id,
-      executionGeneration: task.execution.generation ?? 0,
+      attemptId: lineage.attemptId,
+      executionGeneration: lineage.executionGeneration,
       status: 'failed',
       outputs: { exitCode: 1, error: outputError },
     };


### PR DESCRIPTION
## Summary

A superseded merge-gate run could still write execution metadata after a newer run took over. This change blocks those late writes.

At each metadata write, the merge gate re-checks the run lineage. If the run is no longer active, it logs the side effect and skips the write.

This closes a routing gap where an old gate response persisted state the current run did not expect.

<details>
<summary>Review metadata</summary>

Review Claim: Merge-gate metadata writes are dropped when the run is no longer the active lineage.

Review Lane: behavior

Review Unit: routing

Safety Invariant: The guard only drops writes from non-active lineages; the active run still persists its metadata, so no current behavior is lost.

Slice Rationale: This slice only adds the lineage check around merge-gate metadata writes and builds on Step 7's post-start generation guard.

</details>

## Non-goals

This slice does not change worker-response gating, post-start launch dispatch, or the Step 7 generation guard. It does not change poll/approval runtime behavior in `task-runner.ts`.

## Architecture

### Before

```mermaid
graph TD
    A["Merge gate attempt starts"] --> B["Runner or executor performs side effects"]
    B --> C["Task may be recreated or generation changes"]
    C --> D["Old run writes execution metadata"]
    D --> E["Worker response later ignored as superseded"]
```

### After

```mermaid
graph TD
    A["Merge gate attempt starts"] --> B["Capture attempt and generation"]
    B --> C["Runner or executor reaches metadata write"]
    C --> D{"Lineage still current?"}
    D -- "Yes" --> E["Persist execution or review-ready metadata"]
    D -- "No" --> F["Log side effect and skip write"]
    E --> G["Emit response with captured lineage"]
    F --> G
```

## Test Plan

- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `cd packages/workflow-core && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert -m 1 7bd2ad5a2`
- Post-revert steps: None
- Data migration? No