### PR TITLE
Fix intent cancellation Step 9: launch dispatch generation validation (regression gated v2)

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -754,6 +754,57 @@ describe('LaunchDispatcher', () => {
         execution: {
           ...task.execution,
           selectedAttemptId: 'attempt-current',
+          generation: 0,
+        },
+      };
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(currentTask as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+        mode: 'active',
+        maxConcurrency: 4,
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/not the selected attempt/);
+      const events = adapter.getEvents(task.id);
+      const invalidated = events.find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        dispatchAttemptId: 'attempt-old',
+        dispatchGeneration: 0,
+        reason: 'selected_attempt_mismatch',
+        selectedAttemptId: 'attempt-current',
+        selectedGeneration: 0,
+        accepted: true,
+      });
+    });
+
+    it('active mode abandons a dispatch row when the generation changed after lease', () => {
+      const task = seedWorkflowAndTask('wf-a/t-stale-generation', 'wf-a', {
+        selectedAttemptId: 'attempt-generation',
+        generation: 0,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-generation',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      const currentTask = {
+        ...task,
+        execution: {
+          ...task.execution,
+          selectedAttemptId: 'attempt-generation',
           generation: 1,
         },
       };
@@ -775,9 +826,18 @@ describe('LaunchDispatcher', () => {
       expect(executeTask).not.toHaveBeenCalled();
       const after = adapter.loadLaunchDispatchById(enq.id);
       expect(after?.state).toBe('abandoned');
-      expect(after?.lastError).toMatch(/selected attempt or generation changed/);
+      expect(after?.lastError).toMatch(/does not match task generation/);
       const events = adapter.getEvents(task.id);
-      expect(events.some((event) => event.eventType === 'task.launch_dispatch_invalidated')).toBe(true);
+      const invalidated = events.find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        dispatchAttemptId: 'attempt-generation',
+        dispatchGeneration: 0,
+        reason: 'generation_mismatch',
+        selectedAttemptId: 'attempt-generation',
+        selectedGeneration: 1,
+        accepted: true,
+      });
     });
 
     it('active mode abandons the dispatch when readiness is blocked', () => {

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -203,11 +203,12 @@ export class LaunchDispatcher {
         }
         task = readiness.task;
       }
-      if (!this.dispatchMatchesTask(leased, task)) {
+      const lineageMismatch = this.getDispatchLineageMismatch(leased, task);
+      if (lineageMismatch) {
         this.abandonInvalidDispatch(
           leased,
-          `Launch dispatch ${leased.id} is stale: selected attempt or generation changed`,
-          'selected_attempt_changed',
+          lineageMismatch.message,
+          lineageMismatch.reason,
           {
             selectedAttemptId: task.execution.selectedAttemptId,
             selectedGeneration: task.execution.generation ?? 0,
@@ -254,9 +255,29 @@ export class LaunchDispatcher {
     return this.orchestrator?.getTask?.(dispatch.taskId);
   }
 
-  private dispatchMatchesTask(dispatch: TaskLaunchDispatch, task: TaskState): boolean {
-    return task.execution.selectedAttemptId === dispatch.attemptId
-      && (task.execution.generation ?? 0) === (dispatch.generation ?? 0);
+  private getDispatchLineageMismatch(
+    dispatch: TaskLaunchDispatch,
+    task: TaskState,
+  ): { reason: string; message: string } | undefined {
+    if (task.execution.selectedAttemptId !== dispatch.attemptId) {
+      return {
+        reason: 'selected_attempt_mismatch',
+        message:
+          `Launch dispatch ${dispatch.id} is stale: attempt ${dispatch.attemptId} ` +
+          `is not the selected attempt ${task.execution.selectedAttemptId ?? 'none'}`,
+      };
+    }
+    const selectedGeneration = task.execution.generation ?? 0;
+    const dispatchGeneration = dispatch.generation ?? 0;
+    if (selectedGeneration !== dispatchGeneration) {
+      return {
+        reason: 'generation_mismatch',
+        message:
+          `Launch dispatch ${dispatch.id} is stale: generation ${dispatchGeneration} ` +
+          `does not match task generation ${selectedGeneration}`,
+      };
+    }
+    return undefined;
   }
 
   private abandonInvalidDispatch(

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -657,6 +657,17 @@ describe('SQLiteAdapter', () => {
         const staleAfter = adapter.loadLaunchDispatchById(stale.id);
         expect(staleAfter?.state).toBe('abandoned');
         expect(staleAfter?.lastError).toMatch(/not the selected attempt/);
+        const events = adapter.getEvents('wf-launch/t-stale');
+        const invalidated = events.find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+        expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+          source: 'launch-dispatch-claim',
+          dispatchId: stale.id,
+          attemptId: 'attempt-stale',
+          dispatchGeneration: 0,
+          reason: 'selected_attempt_mismatch',
+          selectedAttemptId: 'attempt-current',
+          selectedGeneration: 0,
+        });
       });
 
       it('abandons stale generation candidates', () => {
@@ -681,6 +692,17 @@ describe('SQLiteAdapter', () => {
         const after = adapter.loadLaunchDispatchById(row.id);
         expect(after?.state).toBe('abandoned');
         expect(after?.lastError).toMatch(/does not match task generation/);
+        const events = adapter.getEvents('wf-launch/t1');
+        const invalidated = events.find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+        expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+          source: 'launch-dispatch-claim',
+          dispatchId: row.id,
+          attemptId: 'attempt-generation',
+          dispatchGeneration: 1,
+          reason: 'generation_mismatch',
+          selectedAttemptId: 'attempt-generation',
+          selectedGeneration: 2,
+        });
       });
 
       it('abandons non-pending task candidates', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3274,20 +3274,25 @@ export class SQLiteAdapter implements PersistenceAdapter {
         const candidateId = Number(candidate.id);
 
         let staleReason: string | undefined;
+        let staleReasonCode: string | undefined;
         if (!candidate.current_task_id) {
           staleReason = `Launch dispatch ${candidateId} is stale: task ${String(candidate.task_id)} no longer exists`;
+          staleReasonCode = 'task_missing';
         } else if (String(candidate.current_task_status) !== 'pending') {
           staleReason =
             `Launch dispatch ${candidateId} is stale: task ${String(candidate.task_id)} ` +
             `status is ${String(candidate.current_task_status)}`;
+          staleReasonCode = 'task_not_pending';
         } else if (String(candidate.current_selected_attempt_id ?? '') !== String(candidate.attempt_id)) {
           staleReason =
             `Launch dispatch ${candidateId} is stale: attempt ${String(candidate.attempt_id)} ` +
             `is not the selected attempt ${String(candidate.current_selected_attempt_id ?? 'none')}`;
+          staleReasonCode = 'selected_attempt_mismatch';
         } else if (Number(candidate.current_execution_generation ?? 0) !== Number(candidate.generation ?? 0)) {
           staleReason =
             `Launch dispatch ${candidateId} is stale: generation ${String(candidate.generation)} ` +
             `does not match task generation ${String(candidate.current_execution_generation ?? 0)}`;
+          staleReasonCode = 'generation_mismatch';
         }
 
         if (staleReason) {
@@ -3302,6 +3307,27 @@ export class SQLiteAdapter implements PersistenceAdapter {
                AND state = 'enqueued'`,
             [now, staleReason, candidateId],
           );
+          if ((this.db.getRowsModified?.() ?? 0) > 0 && candidate.current_task_id) {
+            this.logEvent(String(candidate.task_id), 'task.launch_dispatch_invalidated', {
+              source: 'launch-dispatch-claim',
+              dispatchId: candidateId,
+              attemptId: String(candidate.attempt_id),
+              dispatchAttemptId: String(candidate.attempt_id),
+              workflowId: String(candidate.workflow_id),
+              generation: Number(candidate.generation ?? 0),
+              dispatchGeneration: Number(candidate.generation ?? 0),
+              reason: staleReasonCode ?? 'stale_dispatch',
+              message: staleReason,
+              selectedAttemptId: candidate.current_selected_attempt_id
+                ? String(candidate.current_selected_attempt_id)
+                : undefined,
+              selectedGeneration: Number(candidate.current_execution_generation ?? 0),
+              taskStatus: candidate.current_task_status
+                ? String(candidate.current_task_status)
+                : undefined,
+              invalidatedAt: now,
+            });
+          }
           continue;
         }
 


### PR DESCRIPTION
## Summary

Launch dispatch rows store a generation, but the active dispatch path did not check that a row still matched the current task before launch. Stale rows could start work.

This change validates each launch dispatch row against the current attempt and generation before handing off, so stale rows are skipped.

<details>
<summary>Review metadata</summary>

Review Claim: Launch dispatch validates each row against the current attempt and generation before handing off.

Review Lane: behavior

Review Unit: validation-policy

Safety Invariant: Rows failing the lineage check are skipped, so no new work starts for stale generations; matching rows behave as before.

Slice Rationale: This slice only adds the pre-handoff lineage validation and is grouped as one validation-policy change.

</details>

## Non-goals

Does not change how rows are written or how generations are assigned.

## Test Plan

- [ ] `cd packages/app && pnpm test`
- [ ] `cd packages/execution-engine && pnpm test`
- [ ] `cd packages/workflow-core && pnpm test`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No
