### PR TITLE
Use RxJS for renderer task delta batching

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,7 @@
     "js-yaml": "^4.1.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
+    "rxjs": "^7.8.2",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0"
   },

--- a/packages/ui/src/lib/task-delta-pipeline.ts
+++ b/packages/ui/src/lib/task-delta-pipeline.ts
@@ -1,3 +1,5 @@
+import { merge, queueScheduler, Subject, Subscription, timer } from 'rxjs';
+import { observeOn, takeUntil } from 'rxjs/operators';
 import type { TaskDelta } from '../types.js';
 
 export interface TaskDeltaPipeline {
@@ -17,29 +19,44 @@ export interface CreateTaskDeltaPipelineOptions {
 /**
  * UI-local FIFO batching pipeline for task deltas.
  *
- * This keeps batching concerns isolated behind a tiny interface so we can swap
- * implementation details later without touching hook/business logic.
- *
- * NOTE: We are considering using RxJS at some point for richer stream
- * composition (buffering, throttling, multi-source fan-in). This module is the
- * current in-house boundary for that future migration.
+ * This keeps batching concerns isolated behind a tiny interface while RxJS
+ * owns the scheduling/control-stream plumbing at the renderer boundary.
  */
 export function createTaskDeltaPipeline(
   options: CreateTaskDeltaPipelineOptions,
 ): TaskDeltaPipeline {
   const flushMs = options.flushMs ?? 100;
   const maxBatchSize = options.maxBatchSize ?? 250;
+  const inboundDeltas$ = new Subject<TaskDelta>();
+  const timerFlush$ = new Subject<void>();
+  const flushNow$ = new Subject<void>();
+  const clear$ = new Subject<void>();
+  const dispose$ = new Subject<void>();
+  const stopTimer$ = merge(flushNow$, clear$, dispose$);
+  const flushRequests$ = merge(timerFlush$, flushNow$);
+  const subscriptions = new Subscription();
   let queue: TaskDelta[] = [];
-  let timer: ReturnType<typeof setTimeout> | null = null;
+  let timerSubscription: Subscription | null = null;
+  let disposed = false;
 
-  const flushNow = (): void => {
+  const cancelTimer = (): void => {
+    timerSubscription?.unsubscribe();
+    timerSubscription = null;
+  };
+
+  const schedule = (): void => {
+    if (timerSubscription || disposed) return;
+    timerSubscription = timer(flushMs).pipe(takeUntil(stopTimer$)).subscribe(() => {
+      timerSubscription = null;
+      timerFlush$.next();
+    });
+  };
+
+  const flushQueue = (): void => {
     if (queue.length === 0) return;
     const batchSize = Math.min(maxBatchSize, queue.length);
     const batch = queue.splice(0, batchSize);
-    if (timer) {
-      clearTimeout(timer);
-      timer = null;
-    }
+    cancelTimer();
     if (queue.length > 0) {
       options.onLargeBatch?.({ batchSize: batch.length, remaining: queue.length });
       schedule();
@@ -47,33 +64,53 @@ export function createTaskDeltaPipeline(
     options.onBatch(batch);
   };
 
-  const schedule = (): void => {
-    if (timer) return;
-    timer = setTimeout(() => {
-      timer = null;
-      flushNow();
-    }, flushMs);
-  };
+  subscriptions.add(
+    inboundDeltas$.pipe(observeOn(queueScheduler), takeUntil(dispose$)).subscribe((delta) => {
+      queue.push(delta);
+      schedule();
+    }),
+  );
+  subscriptions.add(
+    flushRequests$.pipe(takeUntil(dispose$)).subscribe(() => {
+      flushQueue();
+    }),
+  );
+  subscriptions.add(
+    clear$.pipe(takeUntil(dispose$)).subscribe(() => {
+      cancelTimer();
+      queue = [];
+    }),
+  );
+  subscriptions.add(
+    dispose$.subscribe(() => {
+      disposed = true;
+      cancelTimer();
+      queue = [];
+    }),
+  );
 
   return {
     push(delta: TaskDelta): void {
-      queue.push(delta);
-      schedule();
+      if (disposed) return;
+      inboundDeltas$.next(delta);
     },
-    flushNow,
+    flushNow(): void {
+      if (disposed) return;
+      flushNow$.next();
+    },
     clear(): void {
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
-      }
-      queue = [];
+      if (disposed) return;
+      clear$.next();
     },
     dispose(): void {
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
-      }
-      queue = [];
+      if (disposed) return;
+      dispose$.next();
+      subscriptions.unsubscribe();
+      inboundDeltas$.complete();
+      timerFlush$.complete();
+      flushNow$.complete();
+      clear$.complete();
+      dispose$.complete();
     },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -467,6 +467,9 @@ importers:
       react-dom:
         specifier: ^19.0.0
         version: 19.2.4(react@19.2.4)
+      rxjs:
+        specifier: ^7.8.2
+        version: 7.8.2
       xterm:
         specifier: ^5.3.0
         version: 5.3.0
@@ -3292,6 +3295,9 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  rxjs@7.8.2:
+    resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -3605,6 +3611,9 @@ packages:
   tsconfig-paths@4.2.0:
     resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
     engines: {node: '>=6'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
   tsscmp@1.0.6:
     resolution: {integrity: sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==}
@@ -6869,6 +6878,10 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  rxjs@7.8.2:
+    dependencies:
+      tslib: 2.8.1
+
   safe-buffer@5.2.1: {}
 
   safe-regex@2.1.1:
@@ -7230,6 +7243,8 @@ snapshots:
       json5: 2.2.3
       minimist: 1.2.8
       strip-bom: 3.0.0
+
+  tslib@2.8.1: {}
 
   tsscmp@1.0.6: {}
 


### PR DESCRIPTION
## Summary

Adds RxJS to the UI package and moves the renderer task-delta batching boundary onto RxJS subjects and timers.

The public `TaskDeltaPipeline` interface stays unchanged and preserves FIFO batching, explicit flushes, clear, dispose, and chunked backpressure.

## Architecture

### Before

```mermaid
graph TD
    Delta[TaskDelta push] --> Queue[Local array queue]
    Queue --> Timeout[setTimeout flush window]
    Timeout --> Batch[onBatch]
```

### After

```mermaid
graph TD
    Delta[TaskDelta push] --> Inbound[RxJS Subject]
    Flush[flush/clear/dispose controls] --> Control[RxJS control streams]
    Inbound --> Queue[Local FIFO queue]
    Control --> Timer[RxJS timer scheduling]
    Timer --> Batch[onBatch]
```

## Test Plan

- [x] `cd packages/ui && pnpm exec vitest run src/__tests__/task-delta-pipeline.test.ts src/__tests__/use-tasks.test.tsx src/__tests__/use-tasks-stream-gap-detect.test.tsx`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 4b9e1367a`
- Post-revert steps: Run `pnpm install --lockfile-only` if the lockfile needs dependency cleanup.
- Data migration? No
