### PR TITLE
Route task heartbeats through orchestrator

### DIFF
--- a/packages/app/src/__tests__/task-runner-wiring.test.ts
+++ b/packages/app/src/__tests__/task-runner-wiring.test.ts
@@ -1,5 +1,4 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { Channels } from '@invoker/transport';
 import type { TaskState } from '@invoker/workflow-core';
 import { autoFixOnReviewGateFailure } from '../workflow-actions.js';
 import { loadConfig, resolveSecretsFilePath } from '../config.js';
@@ -75,12 +74,12 @@ describe('task-runner-wiring', () => {
     let latestRunner: any = null;
     const taskHandles = new Map();
     const logger = createLogger();
-    const publishTaskHeartbeat = vi.fn();
     const orchestrator = {
       getTask: vi.fn(() => ({
         status: 'running',
         execution: { generation: 2, lastHeartbeatAt: new Date(Date.now() - 1000) },
       })),
+      recordTaskHeartbeat: vi.fn(),
       setBeforeApproveHook: vi.fn(),
     };
     const persistence = {
@@ -103,7 +102,6 @@ describe('task-runner-wiring', () => {
       taskHandles,
       enqueueTaskOutput: vi.fn(),
       flushTaskOutput: vi.fn(),
-      publishTaskHeartbeat,
       assertFatalExecutionCapacity: vi.fn(),
       getTaskRunner: () => currentRunner,
       setTaskRunner: (value) => { currentRunner = value; },
@@ -138,17 +136,20 @@ describe('task-runner-wiring', () => {
     });
     expect(taskHandles.has('task-1')).toBe(false);
 
-    config.callbacks.onHeartbeat('task-1');
-    expect(persistence.updateTask).toHaveBeenCalledWith('task-1', {
-      execution: { lastHeartbeatAt: expect.any(Date) },
+    const heartbeatAt = new Date('2026-06-03T01:02:03.000Z');
+    config.callbacks.onHeartbeat('task-1', { at: heartbeatAt, source: 'remote_workload' });
+    expect(persistence.updateTask).not.toHaveBeenCalled();
+    expect(orchestrator.recordTaskHeartbeat).toHaveBeenCalledWith('task-1', {
+      at: heartbeatAt,
+      source: 'remote_workload',
     });
-    expect(publishTaskHeartbeat).toHaveBeenCalledWith('task-1', expect.any(Date));
   });
 
   it('keeps review-gate auto-fix and approve hook routed through the current TaskRunner', async () => {
     let currentRunner: any = null;
     const orchestrator = {
       getTask: vi.fn(),
+      recordTaskHeartbeat: vi.fn(),
       setBeforeApproveHook: vi.fn(),
     };
     const persistence = {
@@ -166,7 +167,6 @@ describe('task-runner-wiring', () => {
       taskHandles: new Map(),
       enqueueTaskOutput: vi.fn(),
       flushTaskOutput: vi.fn(),
-      publishTaskHeartbeat: vi.fn(),
       assertFatalExecutionCapacity: vi.fn(),
       getTaskRunner: () => currentRunner,
       setTaskRunner: (value) => { currentRunner = value; },
@@ -206,32 +206,37 @@ describe('task-runner-wiring', () => {
     await runner.executeTasks([{ id: 'task-1' }] as any);
     expect(runner.executeTasks).toHaveBeenCalledWith([{ id: 'task-1' }]);
   });
-
-  it('uses the unchanged heartbeat task-delta channel shape', () => {
-    const published: Array<{ channel: string; payload: unknown }> = [];
-    const publishTaskHeartbeat = (taskId: string, lastHeartbeatAt: Date): void => {
-      published.push({
-        channel: Channels.TASK_DELTA,
-        payload: {
-          type: 'updated' as const,
-          taskId,
-          changes: { execution: { lastHeartbeatAt } },
-        },
-      });
+  it('routes heartbeat metadata through orchestrator-owned task deltas', () => {
+    const at = new Date('2026-06-03T02:03:04.000Z');
+    const recordTaskHeartbeat = vi.fn();
+    const orchestrator = {
+      getTask: vi.fn(() => ({ status: 'running', execution: {} })),
+      recordTaskHeartbeat,
+      setBeforeApproveHook: vi.fn(),
     };
-    const at = new Date();
 
-    publishTaskHeartbeat('task-1', at);
+    rebuildTaskRunner({
+      orchestrator: orchestrator as any,
+      persistence: { updateTask: vi.fn(), loadWorkflow: vi.fn() } as any,
+      executorRegistry: {} as any,
+      repoRoot: '/repo',
+      invokerConfig: {},
+      logger: createLogger() as any,
+      taskHandles: new Map(),
+      enqueueTaskOutput: vi.fn(),
+      flushTaskOutput: vi.fn(),
+      assertFatalExecutionCapacity: vi.fn(),
+      getTaskRunner: () => null,
+      setTaskRunner: vi.fn(),
+      setLatestTaskExecutor: vi.fn(),
+    });
 
-    expect(published).toEqual([
-      {
-        channel: Channels.TASK_DELTA,
-        payload: {
-          type: 'updated',
-          taskId: 'task-1',
-          changes: { execution: { lastHeartbeatAt: at } },
-        },
-      },
-    ]);
+    const config = taskRunnerConstructor.mock.calls[0]?.[0] as any;
+    config.callbacks.onHeartbeat('task-1', { at, source: 'executor' });
+
+    expect(recordTaskHeartbeat).toHaveBeenCalledWith('task-1', {
+      at,
+      source: 'executor',
+    });
   });
 });

--- a/packages/app/src/execution/task-runner-wiring.ts
+++ b/packages/app/src/execution/task-runner-wiring.ts
@@ -26,7 +26,6 @@ export interface TaskRunnerWiringDeps {
   taskHandles: TaskHandleMap;
   enqueueTaskOutput: (taskId: string, data: string) => void;
   flushTaskOutput: (taskId: string) => void;
-  publishTaskHeartbeat: (taskId: string, lastHeartbeatAt: Date) => void;
   assertFatalExecutionCapacity: (label: string) => void;
   getTaskRunner: () => TaskRunner | null;
   setTaskRunner: (taskRunner: TaskRunner) => void;
@@ -118,8 +117,8 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
           { module: 'exec' },
         );
       },
-      onHeartbeat: (taskId) => {
-        const now = new Date();
+      onHeartbeat: (taskId, event) => {
+        const now = event.at;
         const task = deps.orchestrator.getTask(taskId);
         const previousHeartbeat = task?.execution.lastHeartbeatAt instanceof Date
           ? task.execution.lastHeartbeatAt
@@ -127,8 +126,7 @@ export function rebuildTaskRunner(deps: TaskRunnerWiringDeps): TaskRunner {
             ? new Date(task.execution.lastHeartbeatAt)
             : undefined;
         const heartbeatGapMs = previousHeartbeat ? now.getTime() - previousHeartbeat.getTime() : undefined;
-        try { deps.persistence.updateTask(taskId, { execution: { lastHeartbeatAt: now } }); } catch { /* db locked */ }
-        deps.publishTaskHeartbeat(taskId, now);
+        deps.orchestrator.recordTaskHeartbeat(taskId, { at: now, source: event.source });
         deps.logger.info(
           `Heartbeat for "${taskId}" (status: ${task?.status ?? 'unknown'}, generation: ${task?.execution.generation ?? 'unknown'}, gapMs: ${heartbeatGapMs ?? 'first'})`,
           { module: 'heartbeat' },

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -26,6 +26,7 @@ import {
   registerBuiltinAgents,
   assertPlanExecutionAgentsRegistered,
   type AgentRegistry,
+  type TaskHeartbeatEvent,
 } from '@invoker/execution-engine';
 import { loadConfig, resolveSecretsFilePath, type InvokerConfig } from './config.js';
 import { backupPlan } from './plan-backup.js';
@@ -136,9 +137,12 @@ const YELLOW = '\x1b[33m';
 
 // ── Shared Helpers ───────────────────────────────────────────
 
-function headlessHeartbeat(taskId: string, deps: Pick<HeadlessDeps, 'persistence'>): void {
-  const now = new Date();
-  try { deps.persistence.updateTask(taskId, { execution: { lastHeartbeatAt: now } }); } catch { /* db locked */ }
+function headlessHeartbeat(
+  taskId: string,
+  event: TaskHeartbeatEvent,
+  deps: Pick<HeadlessDeps, 'orchestrator'>,
+): void {
+  deps.orchestrator.recordTaskHeartbeat(taskId, { at: event.at, source: event.source });
 }
 
 function buildHeadlessApiServerDeps(
@@ -275,7 +279,7 @@ export function createHeadlessExecutor(
           deps.logger.error(`Failed to persist output for ${taskId}: ${err}`, { module: 'output' });
         }
       },
-      onHeartbeat: (taskId) => headlessHeartbeat(taskId, deps),
+      onHeartbeat: (taskId, event) => headlessHeartbeat(taskId, event, deps),
       ...callbackOverrides,
     },
   });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1734,13 +1734,6 @@ function createEmbeddedTerminalBackendFromConfig(
       taskHandles,
       enqueueTaskOutput,
       flushTaskOutput,
-      publishTaskHeartbeat: (taskId, lastHeartbeatAt) => {
-        messageBus.publish(Channels.TASK_DELTA, {
-          type: 'updated' as const,
-          taskId,
-          changes: { execution: { lastHeartbeatAt } },
-        });
-      },
       assertFatalExecutionCapacity,
       getTaskRunner: () => taskExecutor,
       setTaskRunner: (runner) => { taskExecutor = runner; },

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -3249,7 +3249,7 @@ describe('TaskRunner', () => {
     it('TaskRunner passes heartbeat events to callbacks.onHeartbeat', async () => {
       vi.useFakeTimers();
       try {
-        const receivedHeartbeats: string[] = [];
+        const receivedHeartbeats: Array<{ taskId: string; at: Date; source: string }> = [];
         const heartbeatCallbacks: Array<(taskId: string) => void> = [];
         let completeCallback: ((response: WorkResponse) => void) | undefined;
         const handle = { executionId: 'exec-gc-3', taskId: 'gc-task-3', workspacePath: '/tmp/mock-worktree' };
@@ -3278,8 +3278,8 @@ describe('TaskRunner', () => {
           } as any,
           cwd: '/tmp',
           callbacks: {
-            onHeartbeat: (taskId: string) => {
-              receivedHeartbeats.push(taskId);
+            onHeartbeat: (taskId, event) => {
+              receivedHeartbeats.push({ taskId, ...event });
             },
           },
         });
@@ -3294,7 +3294,13 @@ describe('TaskRunner', () => {
         heartbeatCallbacks.forEach(cb => cb('gc-task-3'));
 
         // Verify TaskRunner forwarded the heartbeat to its callback
-        expect(receivedHeartbeats).toContain('gc-task-3');
+        expect(receivedHeartbeats).toEqual([
+          {
+            taskId: 'gc-task-3',
+            at: expect.any(Date),
+            source: 'executor',
+          },
+        ]);
 
         // Fire completion so executeTask resolves and the test doesn't hang.
         completeCallback?.({
@@ -4270,8 +4276,8 @@ describe('TaskRunner', () => {
     });
   });
 
-  describe('SSH heartbeat persistence metadata', () => {
-    it('stores remote workload heartbeat metadata for SSH executors', async () => {
+  describe('SSH heartbeat owner callback metadata', () => {
+    it('passes remote workload heartbeat metadata to the owner callback', async () => {
       const runningTask = makeTask({
         id: 'task-ssh-heartbeat',
         status: 'running',
@@ -4306,6 +4312,7 @@ describe('TaskRunner', () => {
         }),
       } as any;
 
+      const onHeartbeat = vi.fn();
       const runner = new TaskRunner({
         orchestrator: {
           getTask: vi.fn((id: string) => (id === runningTask.id ? runningTask : undefined)),
@@ -4325,7 +4332,7 @@ describe('TaskRunner', () => {
           getAll: vi.fn(() => []),
         } as any,
         cwd: '/tmp',
-        callbacks: { onHeartbeat: vi.fn() },
+        callbacks: { onHeartbeat },
       });
 
       const pending = runner.executeTask(runningTask);
@@ -4339,14 +4346,19 @@ describe('TaskRunner', () => {
       });
       await pending;
 
-      expect(updateTask).toHaveBeenCalledWith(
+      expect(updateTask).not.toHaveBeenCalledWith(
         runningTask.id,
         expect.objectContaining({
           execution: expect.objectContaining({
             lastHeartbeatAt: expect.any(Date),
-            remoteHeartbeatAt: expect.any(Date),
-            heartbeatSource: 'remote_workload',
           }),
+        }),
+      );
+      expect(onHeartbeat).toHaveBeenCalledWith(
+        runningTask.id,
+        expect.objectContaining({
+          at: expect.any(Date),
+          source: 'remote_workload',
         }),
       );
       expect(updateAttempt).toHaveBeenCalledWith(

--- a/packages/execution-engine/src/task-runner-callbacks.ts
+++ b/packages/execution-engine/src/task-runner-callbacks.ts
@@ -1,5 +1,11 @@
 import type { WorkResponse } from '@invoker/contracts';
+import type { TaskHeartbeatSource } from '@invoker/workflow-core';
 import type { Executor, ExecutorHandle } from './executor.js';
+
+export interface TaskHeartbeatEvent {
+  at: Date;
+  source: TaskHeartbeatSource;
+}
 
 export interface TaskRunnerCallbacks {
   onOutput?: (taskId: string, data: string) => void;
@@ -8,6 +14,6 @@ export interface TaskRunnerCallbacks {
   onLaunchFailed?: (taskId: string, error: Error, executor: Executor) => void;
   onSpawned?: (taskId: string, handle: ExecutorHandle, executor: Executor) => void;
   onComplete?: (taskId: string, response: WorkResponse) => void;
-  onHeartbeat?: (taskId: string) => void;
+  onHeartbeat?: (taskId: string, event: TaskHeartbeatEvent) => void;
   onLaunchSettled?: (taskId: string) => void;
 }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -60,7 +60,7 @@ import {
 } from './pr-authoring.js';
 import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
 
-export type { TaskRunnerCallbacks } from './task-runner-callbacks.js';
+export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-callbacks.js';
 
 /** Keeps `lastHeartbeatAt` fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). Matches BaseExecutor default heartbeat cadence. */
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
@@ -872,7 +872,7 @@ export class TaskRunner {
           lastHeartbeatAt: now,
           leaseExpiresAt: nextLeaseExpiry(now),
         } as any);
-        this.callbacks.onHeartbeat?.(task.id);
+        this.callbacks.onHeartbeat?.(task.id, { at: now, source: 'executor' });
       }, PRE_START_HEARTBEAT_INTERVAL_MS);
       let preStartTimeout: ReturnType<typeof setTimeout> | undefined;
       try {
@@ -1119,15 +1119,10 @@ export class TaskRunner {
         lastHeartbeatAt: now,
         leaseExpiresAt: nextLeaseExpiry(now),
       } as any);
-      this.persistence.updateTask(task.id, {
-        execution: {
-          lastHeartbeatAt: now,
-          ...(isRemoteWorkloadHeartbeat
-            ? { remoteHeartbeatAt: now, heartbeatSource: 'remote_workload' as const }
-            : { heartbeatSource: 'executor' as const }),
-        },
-      } as any);
-      this.callbacks.onHeartbeat?.(task.id);
+      this.callbacks.onHeartbeat?.(task.id, {
+        at: now,
+        source: isRemoteWorkloadHeartbeat ? 'remote_workload' : 'executor',
+      });
     });
 
     // Wait for completion and feed response to orchestrator.
@@ -2238,7 +2233,7 @@ export class TaskRunner {
         lastHeartbeatAt: now,
         leaseExpiresAt: nextLeaseExpiry(now),
       } as any);
-      this.callbacks.onHeartbeat?.(taskId);
+      this.callbacks.onHeartbeat?.(taskId, { at: now, source: 'executor' });
     };
 
     const heartbeatTimer = setInterval(heartbeat, PRE_START_HEARTBEAT_INTERVAL_MS);

--- a/packages/test-kit/src/in-memory-persistence.ts
+++ b/packages/test-kit/src/in-memory-persistence.ts
@@ -85,6 +85,7 @@ export class InMemoryPersistence implements OrchestratorPersistence {
         ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
         config: { ...entry.task.config, ...changes.config },
         execution: { ...entry.task.execution, ...changes.execution },
+        taskStateVersion: (entry.task.taskStateVersion ?? 1) + 1,
       } as TaskState;
     }
   }

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -134,6 +134,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
         ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
         config: { ...entry.task.config, ...changes.config },
         execution: { ...entry.task.execution, ...changes.execution },
+        taskStateVersion: (entry.task.taskStateVersion ?? 1) + 1,
       } as TaskState;
     }
   }
@@ -301,6 +302,53 @@ describe('Orchestrator', () => {
       messageBus: bus,
       maxConcurrency: 3,
       logger: consoleLogger,
+    });
+  });
+
+  describe('recordTaskHeartbeat', () => {
+    it('persists heartbeat metadata and publishes a versioned task delta', () => {
+      orchestrator.loadPlan({
+        name: 'heartbeat-owner',
+        onFinish: 'none',
+        tasks: [
+          { id: 'task-a', description: 'Task A', command: 'echo a' },
+        ],
+      });
+      publishedDeltas = [];
+      const taskId = sid(orchestrator, 0, 'task-a');
+      const before = orchestrator.getTask(taskId)!;
+      const beforeVersion = before.taskStateVersion ?? 1;
+      const at = new Date('2026-06-02T12:00:00.000Z');
+
+      const updated = orchestrator.recordTaskHeartbeat(taskId, {
+        at,
+        source: 'remote_workload',
+      });
+
+      expect(updated?.execution.lastHeartbeatAt).toEqual(at);
+      expect(updated?.execution.remoteHeartbeatAt).toEqual(at);
+      expect(updated?.execution.heartbeatSource).toBe('remote_workload');
+      expect(updated?.taskStateVersion).toBe(beforeVersion + 1);
+
+      const persisted = persistence.getTaskEntry(taskId)?.task;
+      expect(persisted?.execution.lastHeartbeatAt).toEqual(at);
+      expect(persisted?.execution.remoteHeartbeatAt).toEqual(at);
+      expect(persisted?.execution.heartbeatSource).toBe('remote_workload');
+
+      expect(publishedDeltas).toHaveLength(1);
+      expect(publishedDeltas[0]).toMatchObject({
+        type: 'updated',
+        taskId,
+        changes: {
+          execution: {
+            lastHeartbeatAt: at,
+            remoteHeartbeatAt: at,
+            heartbeatSource: 'remote_workload',
+          },
+        },
+        previousTaskStateVersion: beforeVersion,
+        taskStateVersion: beforeVersion + 1,
+      });
     });
   });
 

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -19,7 +19,7 @@ import { TaskStateMachine } from './state-machine.js';
 import { ResponseHandler } from './response-handler.js';
 import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
-import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, TaskStatus } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
 import { createTaskState, createAttempt } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
@@ -3989,6 +3989,27 @@ export class Orchestrator {
 
   getTask(taskId: string): TaskState | undefined {
     return this.stateGetTask(taskId);
+  }
+
+  recordTaskHeartbeat(
+    taskId: string,
+    options: { at?: Date; source?: TaskHeartbeatSource } = {},
+  ): TaskState | undefined {
+    const task = this.stateGetTask(taskId);
+    if (!task) return undefined;
+
+    const at = options.at ?? new Date();
+    const source = options.source ?? 'executor';
+    const changes: TaskStateChanges = {
+      execution: {
+        lastHeartbeatAt: at,
+        heartbeatSource: source,
+        ...(source === 'remote_workload' ? { remoteHeartbeatAt: at } : {}),
+      },
+    };
+    const updated = this.writeAndSync(task.id, changes, { skipWorkflowStatusSync: true });
+    this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
+    return updated;
   }
 
   getAutoFixRetryBudget(taskId: string): number {


### PR DESCRIPTION
## Summary

Moves task heartbeat state changes behind the orchestrator while leaving attempt heartbeat and lease renewal inside `TaskRunner`.

`TaskRunner` now emits `{ at, source }` heartbeat events, and app/headless callbacks call `recordTaskHeartbeat` to persist metadata and publish versioned task deltas.

## Architecture

### Before

```mermaid
graph TD
    Runner[TaskRunner heartbeat] --> Attempt[Attempt lease renewal]
    Runner --> TaskWrite[Direct persistence.updateTask]
    Runner --> AppDelta[App-published task delta]
```

### After

```mermaid
graph TD
    Runner[TaskRunner heartbeat event] --> Attempt[Attempt lease renewal]
    Runner --> Callback[App/headless callback]
    Callback --> Orchestrator[recordTaskHeartbeat]
    Orchestrator --> TaskWrite[Persist task heartbeat metadata]
    Orchestrator --> Delta[Versioned task delta]
```

## Test Plan

- [x] `cd packages/app && pnpm exec vitest run src/__tests__/task-runner-wiring.test.ts`
- [x] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/orchestrator.test.ts`
- [x] `cd packages/execution-engine && pnpm exec vitest run src/__tests__/task-runner-fix-publish-and-ssh.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes, revert this PR before earlier stack PRs.
- Revert command: `git revert ed4ddc80b`
- Post-revert steps: None
- Data migration? No