### PR TITLE
Fix recreated launch orphan dispatch

### DIFF
--- a/packages/app/e2e/edit-task-command.spec.ts
+++ b/packages/app/e2e/edit-task-command.spec.ts
@@ -27,6 +27,22 @@ async function selectTaskAndWaitForCommandEditor(page: Page, taskSuffix: string)
   }
 }
 
+async function openCommandEditor(page: Page, taskSuffix: string) {
+  const commandDisplay = page.locator('[data-testid="command-display"]');
+  const textarea = page.locator('[data-testid="edit-command-input"]');
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await selectTaskAndWaitForCommandEditor(page, taskSuffix);
+    await commandDisplay.dblclick();
+    try {
+      await expect(textarea).toBeVisible({ timeout: 5000 });
+      return textarea;
+    } catch (err) {
+      if (attempt === 2) throw err;
+    }
+  }
+  throw new Error(`Command editor did not open for ${taskSuffix}`);
+}
+
 const EDIT_CMD_PLAN = {
   name: 'E2E Edit Command Plan',
   repoUrl: E2E_REPO_URL,
@@ -61,16 +77,8 @@ test.describe('Edit task command', () => {
     await waitForTaskStatus(page, 'task-setup', 'completed');
     await waitForTaskStatus(page, 'task-will-fail', 'failed');
 
-    // Click the failed task node to select it
-    await selectTaskAndWaitForCommandEditor(page, 'task-will-fail');
-
-    // Double-click the command display to enter edit mode.
-    const commandDisplay = page.locator('[data-testid="command-display"]');
-    await commandDisplay.dblclick();
-
-    // The textarea should appear with the old command.
-    const textarea = page.locator('[data-testid="edit-command-input"]');
-    await expect(textarea).toBeVisible({ timeout: 2000 });
+    // Open command edit mode and verify the old command.
+    const textarea = await openCommandEditor(page, 'task-will-fail');
     const oldValue = await textarea.inputValue();
     expect(oldValue).toBe('exit 1');
 
@@ -126,12 +134,7 @@ test.describe('Edit task command', () => {
     expect(beforeEditChild).toBeDefined();
     const beforeGeneration = beforeEditChild?.execution?.generation ?? 0;
 
-    // Click parent task to select it
-    await selectTaskAndWaitForCommandEditor(page, 'parent-task');
-
-    const commandDisplay = page.locator('[data-testid="command-display"]');
-    await commandDisplay.dblclick();
-    const textarea = page.locator('[data-testid="edit-command-input"]');
+    const textarea = await openCommandEditor(page, 'parent-task');
     await textarea.fill('echo updated-parent');
 
     const saveBtn = page.locator('[data-testid="save-command-btn"]');

--- a/packages/app/e2e/edit-task-prompt.spec.ts
+++ b/packages/app/e2e/edit-task-prompt.spec.ts
@@ -27,6 +27,22 @@ async function selectTaskAndWaitForPromptDisplay(page: Page, taskSuffix: string)
   }
 }
 
+async function openPromptEditor(page: Page, taskSuffix: string) {
+  const commandDisplay = page.locator('[data-testid="command-display"]');
+  const textarea = page.locator('[data-testid="edit-prompt-input"]');
+  for (let attempt = 0; attempt < 3; attempt++) {
+    await selectTaskAndWaitForPromptDisplay(page, taskSuffix);
+    await commandDisplay.dblclick();
+    try {
+      await expect(textarea).toBeVisible({ timeout: 5000 });
+      return textarea;
+    } catch (err) {
+      if (attempt === 2) throw err;
+    }
+  }
+  throw new Error(`Prompt editor did not open for ${taskSuffix}`);
+}
+
 const EDIT_PROMPT_PLAN = {
   name: 'E2E Edit Prompt Plan',
   repoUrl: E2E_REPO_URL,
@@ -61,16 +77,8 @@ test.describe('Edit task prompt', () => {
     await waitForTaskStatus(page, 'task-setup', 'completed');
     await waitForTaskStatus(page, 'task-prompt', 'completed', 30000);
 
-    // Click the prompt task node to select it
-    await selectTaskAndWaitForPromptDisplay(page, 'task-prompt');
-
-    // Double-click the command display area to enter prompt edit mode.
-    const commandDisplay = page.locator('[data-testid="command-display"]');
-    await commandDisplay.dblclick();
-
-    // The prompt textarea should appear with the old prompt.
-    const textarea = page.locator('[data-testid="edit-prompt-input"]');
-    await expect(textarea).toBeVisible({ timeout: 2000 });
+    // Open prompt edit mode and verify the old prompt.
+    const textarea = await openPromptEditor(page, 'task-prompt');
     const oldValue = await textarea.inputValue();
     expect(oldValue).toBe('Implement the initial feature');
 
@@ -126,12 +134,7 @@ test.describe('Edit task prompt', () => {
     expect(beforeEditChild).toBeDefined();
     const beforeGeneration = beforeEditChild?.execution?.generation ?? 0;
 
-    // Click parent prompt task to select it
-    await selectTaskAndWaitForPromptDisplay(page, 'parent-prompt');
-
-    const commandDisplay = page.locator('[data-testid="command-display"]');
-    await commandDisplay.dblclick();
-    const textarea = page.locator('[data-testid="edit-prompt-input"]');
+    const textarea = await openPromptEditor(page, 'parent-prompt');
     await textarea.fill('Updated prompt instruction');
 
     const saveBtn = page.locator('[data-testid="save-prompt-btn"]');

--- a/packages/app/e2e/task-death-logs.spec.ts
+++ b/packages/app/e2e/task-death-logs.spec.ts
@@ -83,7 +83,7 @@ test.describe('Task death logs', () => {
     await loadPlan(page, DEATH_LOG_PLAN);
     await startPlan(page);
 
-    await waitForTaskStatus(page, 'task-die', 'failed', 10000);
+    await waitForTaskStatus(page, 'task-die', 'failed');
 
     const tasks = await getTasks(page);
     const task = findTaskByIdSuffix(tasks, 'task-die');

--- a/packages/app/e2e/workflow-lifecycle.spec.ts
+++ b/packages/app/e2e/workflow-lifecycle.spec.ts
@@ -11,6 +11,7 @@ import {
   TEST_PLAN,
   loadPlan,
   startPlan,
+  waitForTaskStarted,
   waitForTaskStatus,
   findTaskByIdSuffix,
 } from './fixtures/electron-app.js';
@@ -20,11 +21,8 @@ test.describe('Workflow lifecycle', () => {
     await loadPlan(page, TEST_PLAN);
     await startPlan(page);
 
-    // task-alpha should start running (or may have already completed)
-    const result = await page.evaluate(() => window.invoker.getTasks());
-    const tasks = Array.isArray(result) ? result : result.tasks;
-    const alpha = findTaskByIdSuffix(tasks, 'task-alpha');
-    expect(['running', 'completed']).toContain(alpha?.status);
+    const alphaStatus = await waitForTaskStarted(page, 'task-alpha');
+    expect(['running', 'completed']).toContain(alphaStatus);
   });
 
   test('tasks complete in dependency order', async ({ page }) => {

--- a/packages/app/src/__tests__/config.test.ts
+++ b/packages/app/src/__tests__/config.test.ts
@@ -30,7 +30,7 @@ vi.mock('node:os', async (importOriginal) => {
 describe('loadConfig', () => {
   it('returns config with default launchOutboxMode when no files exist', () => {
     const config = loadConfig();
-    expect(config).toEqual({ launchOutboxMode: 'disabled' });
+    expect(config).toEqual({ launchOutboxMode: 'active' });
   });
 
   it('reads user-level ~/.invoker/config.json', () => {
@@ -256,8 +256,14 @@ describe('resolveEmbeddedTerminalBackendConfig', () => {
 });
 
 describe('resolveLaunchOutboxMode', () => {
-  it('defaults to disabled when INVOKER_LAUNCH_OUTBOX is unset', () => {
-    expect(resolveLaunchOutboxMode({})).toBe('disabled');
+  it('defaults to active when INVOKER_LAUNCH_OUTBOX is unset', () => {
+    expect(resolveLaunchOutboxMode({})).toBe('active');
+  });
+
+  it('returns disabled when INVOKER_LAUNCH_OUTBOX=disabled', () => {
+    expect(
+      resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'disabled' }),
+    ).toBe('disabled');
   });
 
   it('returns observe when INVOKER_LAUNCH_OUTBOX=observe', () => {
@@ -272,12 +278,12 @@ describe('resolveLaunchOutboxMode', () => {
     ).toBe('active');
   });
 
-  it('falls back to disabled with a warning for unknown values', () => {
+  it('falls back to active with a warning for unknown values', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     try {
       expect(
         resolveLaunchOutboxMode({ INVOKER_LAUNCH_OUTBOX: 'on' }),
-      ).toBe('disabled');
+      ).toBe('active');
       expect(warnSpy).toHaveBeenCalledOnce();
       expect(warnSpy.mock.calls[0]?.[0]).toMatch(/Unknown INVOKER_LAUNCH_OUTBOX/);
     } finally {

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SQLiteAdapter } from '@invoker/data-store';
 import type { Logger } from '@invoker/contracts';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator } from '@invoker/workflow-core';
 import { LaunchDispatcher } from '../launch-dispatcher.js';
 
 function makeLogger(): Logger & {
@@ -556,7 +558,11 @@ describe('LaunchDispatcher', () => {
   });
 
   describe('active mode dispatch (CB.5)', () => {
-    function seedWorkflowAndTask(taskId: string, workflowId = 'wf-a') {
+    function seedWorkflowAndTask(
+      taskId: string,
+      workflowId = 'wf-a',
+      execution: Record<string, unknown> = {},
+    ) {
       adapter.saveWorkflow({
         id: workflowId,
         name: workflowId,
@@ -571,7 +577,7 @@ describe('LaunchDispatcher', () => {
         dependencies: [],
         createdAt: new Date(),
         config: { workflowId },
-        execution: {},
+        execution,
         taskStateVersion: 1,
       };
       adapter.saveTask(workflowId, task);
@@ -579,7 +585,10 @@ describe('LaunchDispatcher', () => {
     }
 
     it('active mode leases an enqueued row and hands it to the TaskRunner', () => {
-      const task = seedWorkflowAndTask('wf-a/t1');
+      const task = seedWorkflowAndTask('wf-a/t1', 'wf-a', {
+        selectedAttemptId: 'attempt-active-1',
+        generation: 0,
+      });
       const enq = adapter.enqueueLaunchDispatch({
         taskId: task.id,
         attemptId: 'attempt-active-1',
@@ -637,7 +646,10 @@ describe('LaunchDispatcher', () => {
         dependencies: [],
         createdAt: new Date(),
         config: { workflowId: 'wf-a' },
-        execution: {},
+        execution: {
+          selectedAttemptId: `attempt-multi-${id.at(-1)}`,
+          generation: 0,
+        },
         taskStateVersion: 1,
       } as any));
 
@@ -655,6 +667,92 @@ describe('LaunchDispatcher', () => {
       });
       dispatcher.poll();
       expect(executeTask).toHaveBeenCalledTimes(2);
+    });
+
+    it('active mode hydrates the workflow before treating a dispatch row as missing', () => {
+      const writer = new Orchestrator({
+        persistence: adapter as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 1,
+        deferRunningUntilLaunch: true,
+        launchOutboxMode: 'active',
+      });
+      writer.loadPlan({
+        name: 'cold-cache-dispatch',
+        tasks: [
+          {
+            id: 'alpha',
+            description: 'alpha',
+            command: 'echo alpha',
+          },
+        ],
+      });
+      const [started] = writer.startExecution();
+      expect(started).toBeDefined();
+
+      const cold = new Orchestrator({
+        persistence: adapter as any,
+        messageBus: new InMemoryBus(),
+        maxConcurrency: 1,
+        deferRunningUntilLaunch: true,
+        launchOutboxMode: 'active',
+      });
+      expect(cold.getTask(started!.id)).toBeUndefined();
+
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: (taskId, reason) =>
+            cold.prepareTaskForNewAttempt(taskId, reason),
+          syncFromDb: (workflowId) => cold.syncFromDb(workflowId),
+          getTask: (taskId) => cold.getTask(taskId),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+        mode: 'active',
+        maxConcurrency: 1,
+      });
+
+      dispatcher.poll();
+
+      expect(cold.getTask(started!.id)).toBeDefined();
+      expect(executeTask).toHaveBeenCalledTimes(1);
+      expect(executeTask.mock.calls[0]?.[0].id).toBe(started!.id);
+      expect(adapter.loadLaunchDispatchById(1)?.lastError).toBeUndefined();
+    });
+
+    it('active mode retires a dispatch row when the selected attempt changed', () => {
+      const task = seedWorkflowAndTask('wf-a/t-stale', 'wf-a', {
+        selectedAttemptId: 'attempt-current',
+        generation: 1,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-old',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      const executeTask = vi.fn().mockResolvedValue(undefined);
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(task as any),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+        mode: 'active',
+        maxConcurrency: 4,
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('completed');
+      const events = adapter.getEvents(task.id);
+      expect(events.some((event) => event.eventType === 'task.launch_dispatch_superseded')).toBe(true);
     });
 
     it('active mode fails the dispatch when the orchestrator has no matching task', () => {
@@ -705,7 +803,10 @@ describe('LaunchDispatcher', () => {
     });
 
     it('active mode catches runner promise rejections via failDispatch backstop', async () => {
-      const task = seedWorkflowAndTask('wf-a/t-throw');
+      const task = seedWorkflowAndTask('wf-a/t-throw', 'wf-a', {
+        selectedAttemptId: 'attempt-throw',
+        generation: 0,
+      });
       const enq = adapter.enqueueLaunchDispatch({
         taskId: task.id,
         attemptId: 'attempt-throw',

--- a/packages/app/src/config.ts
+++ b/packages/app/src/config.ts
@@ -268,7 +268,7 @@ export function loadConfig(): InvokerConfig {
  * Resolve the launch-outbox feature-flag mode from the
  * `INVOKER_LAUNCH_OUTBOX` env var.
  *
- * Returns `'disabled'` when the var is unset, empty, or holds an
+ * Returns `'active'` when the var is unset, empty, or holds an
  * unrecognised value (with a console warning for unknown values so
  * operators notice typos like `INVOKER_LAUNCH_OUTBOX=on`).
  */
@@ -276,15 +276,15 @@ export function resolveLaunchOutboxMode(
   env: NodeJS.ProcessEnv = process.env,
 ): LaunchOutboxMode {
   const raw = env.INVOKER_LAUNCH_OUTBOX;
-  if (typeof raw !== 'string' || raw.trim() === '') return 'disabled';
+  if (typeof raw !== 'string' || raw.trim() === '') return 'active';
   const normalized = raw.trim().toLowerCase();
   if (normalized === 'disabled' || normalized === 'observe' || normalized === 'active') {
     return normalized;
   }
   console.warn(
-    `[config] Unknown INVOKER_LAUNCH_OUTBOX value "${raw}"; falling back to "disabled".`,
+    `[config] Unknown INVOKER_LAUNCH_OUTBOX value "${raw}"; falling back to "active".`,
   );
-  return 'disabled';
+  return 'active';
 }
 
 export type EmbeddedTerminalBackendConfig = 'bash' | 'pty';

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -58,6 +58,7 @@ import {
   finalizeMutationWithGlobalTopup,
   isDispatchableLaunch,
 } from './global-topup.js';
+import { LaunchDispatcher } from './launch-dispatcher.js';
 import { resolveHeadlessTargetWorkflowId } from './headless-command-classification.js';
 import { trackWorkflow } from './headless-watch.js';
 import { preemptWorkflowBeforeMutation, type WorkflowCancelResult } from './workflow-preemption.js';
@@ -151,6 +152,7 @@ function buildHeadlessApiServerDeps(
       persistence: deps.persistence,
       taskExecutor,
       dispatchMode: deps.mutationTiming ? 'fire-and-forget' : 'await',
+      launchOutboxMode: deps.invokerConfig.launchOutboxMode,
       autoApproveAIFixes: deps.invokerConfig?.autoApproveAIFixes,
       killRunningTask: (taskId: string) => taskExecutor.killActiveExecution(taskId),
       commandService: deps.commandService,
@@ -278,6 +280,52 @@ export function createHeadlessExecutor(
     },
   });
   return executor;
+}
+
+async function dispatchHeadlessRunnableTasks(
+  deps: HeadlessDeps,
+  taskExecutor: TaskRunner,
+  runnable: TaskState[],
+  context: string,
+): Promise<void> {
+  if (runnable.length === 0) return;
+  if (deps.invokerConfig.launchOutboxMode !== 'active') {
+    await taskExecutor.executeTasks(runnable);
+    return;
+  }
+
+  const dispatcher = new LaunchDispatcher({
+    persistence: deps.persistence,
+    orchestrator: {
+      prepareTaskForNewAttempt: (taskId, reason) =>
+        deps.orchestrator.prepareTaskForNewAttempt(taskId, reason),
+      syncFromDb: (workflowId) => deps.orchestrator.syncFromDb(workflowId),
+      getTask: (taskId) => deps.orchestrator.getTask(taskId),
+    },
+    taskRunnerProvider: () => taskExecutor,
+    ownerId: `headless-${process.pid}`,
+    logger: deps.logger,
+    mode: 'active',
+    maxConcurrency: Math.max(1, deps.invokerConfig.maxConcurrency ?? 16),
+  });
+  deps.logger?.debug?.(
+    `[headless] ${context}: launchOutboxMode=active — polling local launch dispatcher for ${runnable.length} runnable task(s)`,
+    { module: 'headless' },
+  );
+  const poll = (): void => {
+    try {
+      dispatcher.poll();
+    } catch (err) {
+      deps.logger?.warn?.(
+        `[headless] ${context}: local launch dispatcher poll failed: ${err instanceof Error ? err.message : String(err)}`,
+        { module: 'headless' },
+      );
+    }
+  };
+  poll();
+  const timer = setInterval(poll, 250);
+  timer.unref?.();
+  await new Promise<void>((resolve) => setImmediate(resolve));
 }
 
 export function wireHeadlessAutoFix(
@@ -2126,9 +2174,7 @@ async function headlessEdit(taskId: string, newCommand: string, deps: HeadlessDe
   const result = await deps.commandService.editTaskCommand(envelope);
   if (!result.ok) throw new Error(result.error.message);
   const runnable = result.data.filter(isDispatchableLaunch);
-  if (runnable.length > 0) {
-    await taskExecutor.executeTasks(runnable);
-  }
+  await dispatchHeadlessRunnableTasks(deps, taskExecutor, runnable, 'edit-task-command');
   process.stdout.write(`Edited task "${taskId}" command → "${newCommand}"\n`);
 
   if (deps.noTrack) {
@@ -2160,9 +2206,7 @@ async function headlessEditPrompt(taskId: string, newPrompt: string, deps: Headl
   const result = await deps.commandService.editTaskPrompt(envelope);
   if (!result.ok) throw new Error(result.error.message);
   const runnable = result.data.filter(isDispatchableLaunch);
-  if (runnable.length > 0) {
-    await taskExecutor.executeTasks(runnable);
-  }
+  await dispatchHeadlessRunnableTasks(deps, taskExecutor, runnable, 'edit-task-prompt');
   process.stdout.write(`Edited task "${taskId}" prompt → "${newPrompt}"\n`);
 
   if (deps.noTrack) {
@@ -2204,9 +2248,7 @@ async function headlessEditExecutor(
   const result = await deps.commandService.editTaskType(envelope);
   if (!result.ok) throw new Error(result.error.message);
   const runnable = result.data.filter(isDispatchableLaunch);
-  if (runnable.length > 0) {
-    await taskExecutor.executeTasks(runnable);
-  }
+  await dispatchHeadlessRunnableTasks(deps, taskExecutor, runnable, 'edit-task-type');
   process.stdout.write(
     `Edited task "${taskId}" executor → "${runnerKind}"` +
     `${poolMemberId ? ` (poolMemberId=${poolMemberId})` : ''}\n`,
@@ -2242,9 +2284,7 @@ async function headlessEditAgent(taskId: string, agentName: string, deps: Headle
   const result = await deps.commandService.editTaskAgent(envelope);
   if (!result.ok) throw new Error(result.error.message);
   const runnable = result.data.filter(isDispatchableLaunch);
-  if (runnable.length > 0) {
-    await taskExecutor.executeTasks(runnable);
-  }
+  await dispatchHeadlessRunnableTasks(deps, taskExecutor, runnable, 'edit-task-agent');
   process.stdout.write(`Edited task "${taskId}" agent → "${agentName}"\n`);
 
   if (deps.noTrack) {

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -44,6 +44,7 @@ export type LaunchDispatcherPersistence = Pick<
  */
 export interface LaunchDispatcherOrchestrator {
   prepareTaskForNewAttempt(taskId: string, reason: string): unknown;
+  syncFromDb?(workflowId: string): void;
   getTask?(taskId: string): TaskState | undefined;
 }
 
@@ -179,12 +180,16 @@ export class LaunchDispatcher {
       });
       if (!leased) break;
       dispatched += 1;
-      const task = this.orchestrator?.getTask?.(leased.taskId);
+      const task = this.resolveTaskForDispatch(leased);
       if (!task) {
         this.failDispatch(
           leased.id,
           new Error(`Task ${leased.taskId} missing from orchestrator state at dispatch time`),
         );
+        break;
+      }
+      if (!this.dispatchMatchesTask(leased, task)) {
+        this.retireSupersededDispatch(leased, task);
         continue;
       }
       // Fire-and-forget within the loop: the dispatch row is the durable
@@ -207,6 +212,51 @@ export class LaunchDispatcher {
         module: 'launch-dispatcher',
       });
     }
+  }
+
+  private resolveTaskForDispatch(dispatch: TaskLaunchDispatch): TaskState | undefined {
+    try {
+      this.orchestrator?.syncFromDb?.(dispatch.workflowId);
+    } catch (err) {
+      this.logger?.warn?.('[launch-dispatcher] workflow hydration failed before dispatch', {
+        ownerId: this.ownerId,
+        workflowId: dispatch.workflowId,
+        taskId: dispatch.taskId,
+        dispatchId: dispatch.id,
+        error: err instanceof Error ? err.message : String(err),
+        module: 'launch-dispatcher',
+      });
+    }
+
+    return this.orchestrator?.getTask?.(dispatch.taskId);
+  }
+
+  private dispatchMatchesTask(dispatch: TaskLaunchDispatch, task: TaskState): boolean {
+    return task.execution.selectedAttemptId === dispatch.attemptId
+      && (task.execution.generation ?? 0) === (dispatch.generation ?? 0);
+  }
+
+  private retireSupersededDispatch(dispatch: TaskLaunchDispatch, task: TaskState): void {
+    const accepted = this.persistence.markLaunchDispatchCompleted(dispatch.id);
+    this.persistence.logEvent?.(dispatch.taskId, 'task.launch_dispatch_superseded', {
+      dispatchId: dispatch.id,
+      dispatchAttemptId: dispatch.attemptId,
+      dispatchGeneration: dispatch.generation,
+      selectedAttemptId: task.execution.selectedAttemptId,
+      selectedGeneration: task.execution.generation ?? 0,
+      reason: 'selected_attempt_changed',
+    });
+    this.logger?.warn?.('[launch-dispatcher] retired superseded dispatch', {
+      ownerId: this.ownerId,
+      dispatchId: dispatch.id,
+      taskId: dispatch.taskId,
+      dispatchAttemptId: dispatch.attemptId,
+      dispatchGeneration: dispatch.generation,
+      selectedAttemptId: task.execution.selectedAttemptId,
+      selectedGeneration: task.execution.generation ?? 0,
+      accepted,
+      module: 'launch-dispatcher',
+    });
   }
 
   /**

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -645,7 +645,9 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
       }
       case 'select_experiment': {
         const started = orchestrator.selectExperiment(command.taskId, command.experimentId);
-        await deps.executor.executeTasks(started);
+        if (invokerConfig.launchOutboxMode !== 'active') {
+          await deps.executor.executeTasks(started);
+        }
         break;
       }
       case 'provide_input':
@@ -664,7 +666,9 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
         orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
         const started = orchestrator.startExecution();
         deps.logFn('trace', 'info', `slackBot: startExecution returned ${started.length} tasks: [${started.map((t: any) => t.id).join(', ')}]`);
-        await deps.executor.executeTasks(started);
+        if (invokerConfig.launchOutboxMode !== 'active') {
+          await deps.executor.executeTasks(started);
+        }
         break;
       }
     }
@@ -1828,9 +1832,11 @@ function createEmbeddedTerminalBackendFromConfig(
     orchestrator.loadPlan(plan, { allowGraphMutation: invokerConfig.allowGraphMutation });
     const workflowId = orchestrator.getWorkflowIds().find(id => !wfIdsBefore.has(id))!;
     const started = orchestrator.startExecution();
-    requireTaskExecutor().executeTasks(started).catch(err => {
-      logger.error(`headless.run: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
-    });
+    if (invokerConfig.launchOutboxMode !== 'active') {
+      requireTaskExecutor().executeTasks(started).catch(err => {
+        logger.error(`headless.run: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
+      });
+    }
     logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
     const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
     return { workflowId, tasks };
@@ -1841,7 +1847,7 @@ function createEmbeddedTerminalBackendFromConfig(
     orchestrator.syncFromDb(workflowId);
 
     const allStarted = orchestrator.startExecution();
-    if (allStarted.length > 0) {
+    if (allStarted.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
       requireTaskExecutor().executeTasks(allStarted).catch(err => {
         logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
       });
@@ -1888,6 +1894,13 @@ function createEmbeddedTerminalBackendFromConfig(
           );
         }
         if (filteredTasks.length === 0) {
+          return;
+        }
+        if (invokerConfig.launchOutboxMode === 'active') {
+          logger.info(
+            `deferRunnableTasks accepted by launch outbox workflow="${workflowId ?? 'unknown'}" count=${filteredTasks.length}`,
+            { module: 'ipc-delegate' },
+          );
           return;
         }
         // Keep this path timer-based for now: it is a low-blast-radius, mutation-safe
@@ -2342,6 +2355,7 @@ function createEmbeddedTerminalBackendFromConfig(
           commandService,
           taskExecutor: requireTaskExecutor(),
           autoApproveAIFixes: invokerConfig.autoApproveAIFixes,
+          launchOutboxMode: invokerConfig.launchOutboxMode,
           killRunningTask,
         }),
         queueWorkflowMutation: (workflowId, priority, channel, args, options) => {
@@ -2445,7 +2459,7 @@ function createEmbeddedTerminalBackendFromConfig(
                     logger.error(`[executing-stall] forcing failure for "${task.id}": ${executingError}`, { module: 'db-poll' });
                     const startedAfterFailure = orchestrator.handleWorkerResponse(failedResponse);
                     const runnableAfterFailure = startedAfterFailure.filter(isDispatchableLaunch);
-                    if (runnableAfterFailure.length > 0) {
+                    if (runnableAfterFailure.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
                       logger.info(
                         `[executing-stall] dispatching ${runnableAfterFailure.length} task(s) started after failing "${task.id}"`,
                         { module: 'db-poll' },
@@ -2701,7 +2715,7 @@ function createEmbeddedTerminalBackendFromConfig(
       logger.info('auto-run on startup disabled by config', { module: 'init' });
     } else {
       const allStarted = orchestrator.startExecution();
-      if (allStarted.length > 0) {
+      if (allStarted.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
         requireTaskExecutor().executeTasks(allStarted);
       }
     }
@@ -2826,7 +2840,9 @@ function createEmbeddedTerminalBackendFromConfig(
       logger.info('start', { module: 'ipc' });
       const started = orchestrator.startExecution();
       logger.info(`startExecution returned ${started.length} tasks: [${started.map(t => t.id).join(', ')}]`, { module: 'ipc' });
-      await requireTaskExecutor().executeTasks(started);
+      if (invokerConfig.launchOutboxMode !== 'active') {
+        await requireTaskExecutor().executeTasks(started);
+      }
       return started;
     });
 
@@ -2859,7 +2875,7 @@ function createEmbeddedTerminalBackendFromConfig(
         }
       }
       logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
-      if (allStarted.length > 0) {
+      if (allStarted.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
         void requireTaskExecutor().executeTasks(allStarted);
       }
       return { workflow: workflows[0], taskCount: tasks.length, startedCount: allStarted.length };
@@ -3029,6 +3045,7 @@ function createEmbeddedTerminalBackendFromConfig(
         started,
         mutationTiming: activeMutationContext?.mutationTiming,
         scopedTaskIds: [taskId],
+        launchOutboxMode: invokerConfig.launchOutboxMode,
       });
       },
     );
@@ -3053,11 +3070,15 @@ function createEmbeddedTerminalBackendFromConfig(
           const result = await commandService.selectExperiment(envelope);
           if (!result.ok) throw new Error(result.error.message);
           const runnable = result.data.filter(isDispatchableLaunch);
-          await requireTaskExecutor().executeTasks(runnable);
+          if (invokerConfig.launchOutboxMode !== 'active') {
+            await requireTaskExecutor().executeTasks(runnable);
+          }
         } else {
           // Multi-select: needs taskExecutor for branch merge, stays in workflow-actions
           const newlyStarted = await sharedSelectExperiments(taskId, ids, { orchestrator, taskExecutor: requireTaskExecutor() });
-          await requireTaskExecutor().executeTasks(newlyStarted);
+          if (invokerConfig.launchOutboxMode !== 'active') {
+            await requireTaskExecutor().executeTasks(newlyStarted);
+          }
         }
       } catch (err) {
         logger.error(`select-experiment failed: ${err}`, { module: 'ipc' });
@@ -3102,6 +3123,7 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.restart-task',
           started,
           scopedTaskIds: [taskId],
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`restart-task failed: ${err}`, { module: 'ipc' });
@@ -3125,6 +3147,7 @@ function createEmbeddedTerminalBackendFromConfig(
           logger,
           context: 'ipc.cancel-task',
           mutationTiming: activeMutationContext?.mutationTiming,
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
         return result;
       } catch (err) {
@@ -3154,6 +3177,7 @@ function createEmbeddedTerminalBackendFromConfig(
           logger,
           context: 'ipc.cancel-workflow',
           mutationTiming: activeMutationContext?.mutationTiming,
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
         return result;
       } catch (err) {
@@ -3254,6 +3278,7 @@ function createEmbeddedTerminalBackendFromConfig(
             started,
             scopedWorkflowId: workflowId,
             mutationTiming: activeMutationContext?.mutationTiming,
+            launchOutboxMode: invokerConfig.launchOutboxMode,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -3302,6 +3327,7 @@ function createEmbeddedTerminalBackendFromConfig(
             started,
             scopedTaskIds: [taskId],
             mutationTiming: activeMutationContext?.mutationTiming,
+            launchOutboxMode: invokerConfig.launchOutboxMode,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -3347,6 +3373,7 @@ function createEmbeddedTerminalBackendFromConfig(
             started: result.data,
             scopedWorkflowId: workflowId,
             mutationTiming: activeMutationContext?.mutationTiming,
+            launchOutboxMode: invokerConfig.launchOutboxMode,
           });
         } finally {
           remoteFetchForPool.enabled = true;
@@ -3391,6 +3418,7 @@ function createEmbeddedTerminalBackendFromConfig(
           started,
           scopedWorkflowId: workflowId,
           mutationTiming: activeMutationContext?.mutationTiming,
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`rebase-retry failed: ${err}`, { module: 'ipc' });
@@ -3433,6 +3461,7 @@ function createEmbeddedTerminalBackendFromConfig(
           started,
           scopedWorkflowId: workflowId,
           mutationTiming: activeMutationContext?.mutationTiming,
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`rebase-recreate failed: ${err}`, { module: 'ipc' });
@@ -3459,6 +3488,7 @@ function createEmbeddedTerminalBackendFromConfig(
             context: 'ipc.set-merge-branch',
             started,
             scopedTaskIds: [mergeTask.id],
+            launchOutboxMode: invokerConfig.launchOutboxMode,
           });
         }
       } catch (err) {
@@ -3505,6 +3535,7 @@ function createEmbeddedTerminalBackendFromConfig(
           started,
           mutationTiming: activeMutationContext?.mutationTiming,
           scopedWorkflowId: workflowId,
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`approve-merge failed: ${err}`, { module: 'ipc' });
@@ -3554,6 +3585,7 @@ function createEmbeddedTerminalBackendFromConfig(
           started: result.started,
           mutationTiming: activeMutationContext?.mutationTiming,
           scopedTaskIds: [taskId],
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         if (err instanceof StaleLineageError) {
@@ -3566,6 +3598,7 @@ function createEmbeddedTerminalBackendFromConfig(
           logger,
           context: 'ipc.resolve-conflict.failure',
           mutationTiming: activeMutationContext?.mutationTiming,
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
         logger.error(`resolve-conflict failed: ${err}`, { module: 'ipc' });
         throw err;
@@ -3590,6 +3623,7 @@ function createEmbeddedTerminalBackendFromConfig(
           started,
           mutationTiming: activeMutationContext?.mutationTiming,
           scopedTaskIds: [taskId],
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         if (err instanceof StaleLineageError) {
@@ -3602,6 +3636,7 @@ function createEmbeddedTerminalBackendFromConfig(
           logger,
           context: 'ipc.fix-with-agent.failure',
           mutationTiming: activeMutationContext?.mutationTiming,
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
         logger.error(`fix-with-agent failed: ${err}`, { module: 'ipc' });
         throw err;
@@ -3624,6 +3659,7 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.edit-task-command',
           started: result.data,
           scopedTaskIds: [taskId],
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`edit-task-command failed: ${err}`, { module: 'ipc' });
@@ -3646,6 +3682,7 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.edit-task-prompt',
           started: result.data,
           scopedTaskIds: [taskId],
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`edit-task-prompt failed: ${err}`, { module: 'ipc' });
@@ -3669,6 +3706,7 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.edit-task-type',
           started: result.data,
           scopedTaskIds: [taskId],
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`edit-task-type failed: ${err}`, { module: 'ipc' });
@@ -3691,6 +3729,7 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.edit-task-pool',
           started: result.data,
           scopedTaskIds: [taskId],
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`edit-task-pool failed: ${err}`, { module: 'ipc' });
@@ -3713,6 +3752,7 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.edit-task-agent',
           started: result.data,
           scopedTaskIds: [taskId],
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
       } catch (err) {
         logger.error(`edit-task-agent failed: ${err}`, { module: 'ipc' });
@@ -3737,6 +3777,7 @@ function createEmbeddedTerminalBackendFromConfig(
             context: 'ipc.set-task-external-gate-policies',
             started: result.data,
             scopedTaskIds: [taskId],
+            launchOutboxMode: invokerConfig.launchOutboxMode,
           });
         } catch (err) {
           logger.error(`set-task-external-gate-policies failed: ${err}`, { module: 'ipc' });
@@ -3789,6 +3830,7 @@ function createEmbeddedTerminalBackendFromConfig(
           context: 'ipc.replace-task',
           started: result.data,
           scopedTaskIds: [taskId, ...result.data.map((task) => task.id)],
+          launchOutboxMode: invokerConfig.launchOutboxMode,
         });
         return result.data;
       } catch (err) {

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -54,6 +54,7 @@ import {
   dispatchStartedTasksWithGlobalTopup,
   executeGlobalTopup,
   isDispatchableLaunch,
+  type LaunchOutboxMode,
 } from './global-topup.js';
 import {
   setTaskMetadata as sharedSetTaskMetadata,
@@ -111,6 +112,7 @@ export interface WorkflowMutationFacadeDeps {
   commandService?: CommandService;
   taskExecutor: TaskRunner;
   dispatchMode?: 'await' | 'fire-and-forget';
+  launchOutboxMode?: LaunchOutboxMode;
   autoApproveAIFixes?: boolean;
   /** Optional pre-kill hook for active task executions. */
   killRunningTask?: (taskId: string) => Promise<void>;
@@ -351,7 +353,9 @@ export class WorkflowMutationFacade {
       logger: this.deps.logger,
     });
     const runnable = result.started.filter(isDispatchableLaunch);
-    await this.deps.taskExecutor.executeTasks(runnable);
+    if (this.deps.launchOutboxMode !== 'active') {
+      await this.deps.taskExecutor.executeTasks(runnable);
+    }
     const topup = await this.topupOnly('facade.fork-workflow');
     return {
       forkedWorkflowId: result.forkedWorkflowId,
@@ -470,6 +474,7 @@ export class WorkflowMutationFacade {
       context,
       started,
       dispatchMode: this.deps.dispatchMode,
+      launchOutboxMode: this.deps.launchOutboxMode,
       ...scope,
     });
   }
@@ -519,6 +524,7 @@ export class WorkflowMutationFacade {
       logger: this.deps.logger,
       context,
       dispatchMode: this.deps.dispatchMode,
+      launchOutboxMode: this.deps.launchOutboxMode,
     });
   }
 }

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -213,6 +213,27 @@ describe('TaskRunner launch-dispatch wiring', () => {
     expect(env.executor.start).toHaveBeenCalled();
   });
 
+  it('does not recursively execute newly-started tasks when launched from the outbox', async () => {
+    const task = makeTask();
+    const child = makeTask({
+      id: 'wf-d/child',
+      description: 'child',
+      execution: { selectedAttemptId: 'child-attempt-1', generation: 0, phase: 'launching' },
+    });
+    const env = buildRunnerEnv(task);
+    env.orchestrator.handleWorkerResponse.mockReturnValue([child]);
+    const launchOutbox = makeLaunchOutbox();
+
+    const run = env.runner.executeTask(task, { dispatchId: 314, launchOutbox });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    env.triggerComplete();
+    await run;
+
+    expect(env.executor.start).toHaveBeenCalledTimes(1);
+    expect(env.executor.start.mock.calls[0]?.[0].actionId).toBe(task.id);
+    expect(launchOutbox.completeCalls).toEqual([314]);
+  });
+
   it('fails the dispatch and short-circuits when the attempt is already launching', async () => {
     const task = makeTask();
     const env = buildRunnerEnv(task, { startThrows: new Error('unused') });

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -447,6 +447,20 @@ export class TaskRunner {
     await Promise.all(tasks.map((task) => this.executeTask(task)));
   }
 
+  private executeNewlyStartedTasks(
+    tasks: TaskState[],
+    dispatchOpts?: LaunchDispatchOptions,
+  ): void {
+    if (tasks.length === 0) return;
+    if (dispatchOpts) {
+      this.logger.debug(
+        `[TaskRunner] durable launch outbox owns ${tasks.length} newly-started task(s); skipping recursive executeTasks`,
+      );
+      return;
+    }
+    void this.executeTasks(tasks);
+  }
+
   /**
    * Execute a single task through the executor pipeline.
    *
@@ -605,9 +619,7 @@ export class TaskRunner {
       };
       this.callbacks.onComplete?.(task.id, response);
       const newlyStarted = this.orchestrator.handleWorkerResponse(response) ?? [];
-      if (newlyStarted.length > 0) {
-        this.executeTasks(newlyStarted);
-      }
+      this.executeNewlyStartedTasks(newlyStarted, dispatchOpts);
     } finally {
       this.launchingAttemptIds.delete(attemptId);
       bench('executeTask.settled');
@@ -651,9 +663,7 @@ export class TaskRunner {
         },
       };
       const newlyStarted = this.orchestrator.handleWorkerResponse(response) ?? [];
-      if (newlyStarted.length > 0) {
-        this.executeTasks(newlyStarted);
-      }
+      this.executeNewlyStartedTasks(newlyStarted, dispatchOpts);
       // CD.1 / Issue 13: terminate the parent pivot task's outbox row.
       // Without this, drainScheduler enqueued a launch-dispatch row for
       // the pivot, but executeTaskInner returns here without ever
@@ -1148,10 +1158,7 @@ export class TaskRunner {
             this.callbacks.onComplete?.(task.id, normalizedResponse);
 
             const newlyStarted = this.orchestrator.handleWorkerResponse(normalizedResponse) ?? [];
-
-            if (newlyStarted.length > 0) {
-              this.executeTasks(newlyStarted);
-            }
+            this.executeNewlyStartedTasks(newlyStarted, dispatchOpts);
           } catch (err) {
             this.logger.error(`[TaskRunner] onComplete handler failed for task=${task.id}`, { err });
             const errResponse: WorkResponse = {

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -1631,6 +1631,34 @@ describe('Orchestrator', () => {
       expect(task.execution.lastHeartbeatAt).toBeUndefined();
     });
 
+    it('clears launch claim metadata when deferring a launch-claimed task', () => {
+      const launchingOrchestrator = new Orchestrator({
+        persistence,
+        messageBus: bus,
+        logger: consoleLogger,
+        maxConcurrency: 3,
+        deferRunningUntilLaunch: true,
+      });
+      launchingOrchestrator.loadPlan({
+        name: 'defer-launch-claim-test',
+        tasks: [{ id: 'task-a', description: 'Task A' }],
+      });
+      const started = launchingOrchestrator.startExecution();
+      expect(started.length).toBe(1);
+      expect(launchingOrchestrator.getTask('task-a')!.status).toBe('pending');
+      expect(launchingOrchestrator.getTask('task-a')!.execution.phase).toBe('launching');
+
+      launchingOrchestrator.deferTask('task-a');
+
+      const task = launchingOrchestrator.getTask('task-a')!;
+      expect(task.status).toBe('pending');
+      expect(task.execution.phase).toBeUndefined();
+      expect(task.execution.launchStartedAt).toBeUndefined();
+      expect(task.execution.launchCompletedAt).toBeUndefined();
+      expect(task.execution.startedAt).toBeUndefined();
+      expect(task.execution.lastHeartbeatAt).toBeUndefined();
+    });
+
     it('replaces the selected attempt when deferring a task', () => {
       orchestrator.loadPlan({
         name: 'defer-attempt-refresh',

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -4203,10 +4203,18 @@ export class Orchestrator {
     if (!task) return;
     const id = task.id;
 
-    // Transition running → pending
+    // Transition running → pending. A deferred launch must not retain the
+    // launch-claimed phase; otherwise it can be mistaken for an actively
+    // dispatchable launch with no executor owner.
     const changes: TaskStateChanges = {
       status: 'pending',
-      execution: { startedAt: undefined, lastHeartbeatAt: undefined },
+      execution: {
+        startedAt: undefined,
+        lastHeartbeatAt: undefined,
+        phase: undefined,
+        launchStartedAt: undefined,
+        launchCompletedAt: undefined,
+      },
     };
     const deferUpdated = this.writeAndSync(id, changes);
     const delta: TaskDelta = this.buildUpdateDelta(task, deferUpdated, changes);


### PR DESCRIPTION
## Summary

This fixes recreated tasks that were accepted but never run under active durable launch dispatch.

The dispatcher now hydrates cold workflow state before dispatching and retires superseded rows whose attempt or generation no longer matches the selected task attempt.

Outbox-launched task completions no longer recursively launch newly started tasks in memory, so durable dispatch remains the single handoff path.

Headless edit commands stop directly executing runnable follow-up tasks when active durable dispatch is enabled.

## Architecture

### Before

```mermaid
graph TD
    A[Recreate accepted] --> B[New attempt selected]
    C[Old dispatch row] --> D[Dispatcher leases row]
    D --> E[TaskRunner may execute current task]
    E --> F[Completion starts follow-up tasks in memory]
    F --> G[Durable dispatch row remains acknowledged]
```

### After

```mermaid
graph TD
    A[Recreate accepted] --> B[New attempt selected]
    C[Old dispatch row] --> D[Dispatcher hydrates workflow state]
    D --> E{Attempt and generation match?}
    E -->|No| F[Retire superseded dispatch]
    E -->|Yes| G[TaskRunner executes outbox dispatch]
    G --> H[Follow-up tasks stay owned by durable dispatch]
```

## Test Plan

- [x] `pnpm --filter @invoker/app test src/__tests__/launch-dispatcher.test.ts src/__tests__/launch-pool-deferral-outbox-repro.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test src/__tests__/task-runner-launch-dispatch.test.ts`
- [x] `pnpm --filter @invoker/execution-engine build`
- [x] `pnpm --filter @invoker/app build`
- [x] `INVOKER_PLAYWRIGHT_WORKERS=1 pnpm --filter @invoker/app test:e2e e2e/edit-task-command.spec.ts -g "edit a failed task command" --reporter=line`
- [x] `INVOKER_PLAYWRIGHT_WORKERS=1 pnpm --filter @invoker/app test:e2e e2e/edit-task-command.spec.ts e2e/edit-task-prompt.spec.ts e2e/fix-with-agent-transition.spec.ts e2e/fix-with-claude.spec.ts e2e/orphan-relaunch.spec.ts --reporter=line`
- [x] `INVOKER_PLAYWRIGHT_WORKERS=1 pnpm --filter @invoker/app test:e2e e2e/workflow-lifecycle.spec.ts e2e/task-death-logs.spec.ts e2e/persistence-lifecycle.spec.ts e2e/persistence-recovery.spec.ts e2e/restart-failed-task.spec.ts --reporter=line`
- [x] `bash scripts/e2e-dry-run/cases/case-1.4-edit-restart.sh`
- [x] `pnpm --filter @invoker/app test src/__tests__/config.test.ts src/__tests__/launch-claim-orphan-regression.test.ts src/__tests__/launch-dispatcher.test.ts src/__tests__/app-layer-handoff-repro.test.ts`
- [x] `git diff --check`
- [x] `INVOKER_TEST_ALL_FORCE_RERUN=1 pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert df646279c`
- Post-revert steps: Set `INVOKER_LAUNCH_OUTBOX=active` manually if durable launch dispatch is still required.
- Data migration? No