### PR TITLE
Fix launch outbox pool deferral handoff

### DIFF
--- a/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
+++ b/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
@@ -1,0 +1,175 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import type { WorkResponse } from '@invoker/contracts';
+import { InMemoryBus } from '@invoker/test-kit';
+import { Orchestrator, type PlanDefinition, type TaskState } from '@invoker/workflow-core';
+import { LaunchDispatcher } from '../launch-dispatcher.js';
+
+type Harness = {
+  dir: string;
+  persistence: SQLiteAdapter;
+  orchestrator: Orchestrator;
+};
+
+const harnesses: Harness[] = [];
+
+afterEach(() => {
+  for (const harness of harnesses.splice(0)) {
+    harness.persistence.close();
+    rmSync(harness.dir, { recursive: true, force: true });
+  }
+});
+
+async function makeHarness(name: string): Promise<Harness> {
+  const dir = mkdtempSync(join(tmpdir(), `invoker-${name}-`));
+  const persistence = await SQLiteAdapter.create(join(dir, 'invoker-repro.db'), {
+    ownerCapability: true,
+  });
+  const orchestrator = new Orchestrator({
+    persistence: persistence as any,
+    messageBus: new InMemoryBus(),
+    maxConcurrency: 1,
+    deferRunningUntilLaunch: true,
+    launchOutboxMode: 'active',
+  });
+  const harness = { dir, persistence, orchestrator };
+  harnesses.push(harness);
+  return harness;
+}
+
+function singleTaskPlan(name: string): PlanDefinition {
+  return {
+    name,
+    baseBranch: 'master',
+    featureBranch: `experiment/${name}`,
+    onFinish: 'none',
+    tasks: [
+      {
+        id: 'pool-task',
+        description: 'pool task',
+        command: 'echo pool-task',
+      },
+    ],
+  };
+}
+
+function completeResponse(task: TaskState, attemptId: string): WorkResponse {
+  return {
+    requestId: `req-${task.id}`,
+    actionId: task.id,
+    attemptId,
+    executionGeneration: task.execution.generation ?? 0,
+    status: 'completed',
+    outputs: { exitCode: 0 },
+  };
+}
+
+async function flushDispatcherPromises(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function runPoolDeferralScenario(options: { completeDeferredDispatch: boolean }) {
+  const { persistence, orchestrator } = await makeHarness(
+    options.completeDeferredDispatch ? 'pool-deferral-fixed' : 'pool-deferral-root-cause',
+  );
+  orchestrator.loadPlan(singleTaskPlan('pool-deferral-outbox-repro'));
+
+  const [firstClaim] = orchestrator.startExecution();
+  expect(firstClaim).toBeDefined();
+  const taskId = firstClaim!.id;
+  const firstAttemptId = firstClaim!.execution.selectedAttemptId!;
+
+  let runnerCalls = 0;
+  const dispatcher = new LaunchDispatcher({
+    persistence,
+    orchestrator: {
+      prepareTaskForNewAttempt: (id, reason) => orchestrator.prepareTaskForNewAttempt(id, reason),
+      getTask: (id) => orchestrator.getTask(id),
+    },
+    taskRunnerProvider: () => ({
+      async executeTask(task, opts) {
+        runnerCalls += 1;
+        const dispatchOpts = opts!;
+        expect(dispatchOpts.launchOutbox.ackDispatch(dispatchOpts.dispatchId, 'pool-runner')).toBe(true);
+        const attemptId = task.execution.selectedAttemptId!;
+
+        if (runnerCalls === 1) {
+          persistence.logEvent(task.id, 'task.executor.deferred', {
+            reason: 'execution-pool-capacity',
+            message: 'Execution pool "pnpm-ssh" has no member capacity available',
+            attemptId,
+          });
+          orchestrator.deferTask(task.id);
+          if (options.completeDeferredDispatch) {
+            expect(dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId)).toBe(true);
+          }
+          return;
+        }
+
+        expect(orchestrator.markTaskRunningAfterLaunch(task.id, attemptId)).toBe(true);
+        expect(dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId)).toBe(true);
+        const latest = orchestrator.getTask(task.id)!;
+        orchestrator.handleWorkerResponse(completeResponse(latest, attemptId));
+      },
+    }),
+    ownerId: 'pool-owner',
+    mode: 'active',
+    maxConcurrency: 1,
+    maxLeasesPerPoll: 1,
+  });
+
+  dispatcher.poll();
+  await flushDispatcherPromises();
+
+  const [replacementClaim] = orchestrator.startExecution();
+  expect(replacementClaim).toBeDefined();
+  const replacementAttemptId = replacementClaim!.execution.selectedAttemptId!;
+  expect(replacementAttemptId).not.toBe(firstAttemptId);
+
+  dispatcher.poll();
+  await flushDispatcherPromises();
+
+  return {
+    firstAttemptId,
+    replacementAttemptId,
+    runnerCalls,
+    task: orchestrator.getTask(taskId)!,
+    liveRows: persistence
+      .listLaunchDispatchesByState(['enqueued', 'leased', 'acknowledged'])
+      .filter((row) => row.taskId === taskId)
+      .map((row) => ({ attemptId: row.attemptId, state: row.state })),
+    completedRows: persistence
+      .listLaunchDispatchesByState(['completed'])
+      .filter((row) => row.taskId === taskId)
+      .map((row) => ({ attemptId: row.attemptId, state: row.state })),
+  };
+}
+
+describe('launch pool deferral outbox repro', () => {
+  it('proves the root cause: an acknowledged deferred row blocks the replacement launch', async () => {
+    const result = await runPoolDeferralScenario({ completeDeferredDispatch: false });
+
+    expect(result.runnerCalls).toBe(1);
+    expect(result.task.status).toBe('pending');
+    expect(result.task.execution.phase).toBe('launching');
+    expect(result.liveRows).toEqual([
+      { attemptId: result.firstAttemptId, state: 'acknowledged' },
+      { attemptId: result.replacementAttemptId, state: 'enqueued' },
+    ]);
+  });
+
+  it('proves the fix: completing the deferred row frees capacity for the replacement launch', async () => {
+    const result = await runPoolDeferralScenario({ completeDeferredDispatch: true });
+
+    expect(result.runnerCalls).toBe(2);
+    expect(result.task.status).toBe('completed');
+    expect(result.liveRows).toEqual([]);
+    expect(result.completedRows).toEqual([
+      { attemptId: result.firstAttemptId, state: 'completed' },
+      { attemptId: result.replacementAttemptId, state: 'completed' },
+    ]);
+  });
+});

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
 import { TaskRunner, type LaunchOutboxAck } from '../task-runner.js';
+import { ResourceLimitError } from '../repo-pool.js';
 
 function makeLogger(): Logger {
   const noop = () => {};
@@ -179,6 +180,24 @@ describe('TaskRunner launch-dispatch wiring', () => {
     const failArg = launchOutbox.failCalls[0][1];
     expect(failArg).toBeInstanceOf(Error);
     expect((failArg as Error).message).toMatch(/startup explosion/);
+  });
+
+  it('completes the dispatch row when resource-limit defers the launch', async () => {
+    const task = makeTask();
+    const env = buildRunnerEnv(task);
+    const message = 'Execution pool "pnpm-ssh" has no member capacity available';
+    const resourceLimit = new ResourceLimitError(message);
+    (env.runner as any).executeTaskInner = vi.fn().mockRejectedValue(
+      new Error(message, { cause: resourceLimit }),
+    );
+    const launchOutbox = makeLaunchOutbox();
+
+    await env.runner.executeTask(task, { dispatchId: 321, launchOutbox });
+
+    expect(launchOutbox.ackCalls).toHaveLength(1);
+    expect(env.orchestrator.deferTask).toHaveBeenCalledWith(task.id);
+    expect(launchOutbox.completeCalls).toEqual([321]);
+    expect(launchOutbox.failCalls).toHaveLength(0);
   });
 
   it('is a no-op for the outbox when dispatchOpts is omitted', async () => {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -539,6 +539,15 @@ export class TaskRunner {
       if (cause instanceof ResourceLimitError) {
         traceExecution(`[TaskRunner] executeTask deferred for task=${task.id}: ${cause.message}`);
         this.orchestrator.deferTask(task.id);
+        if (dispatchOpts) {
+          const completed = dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId);
+          bench('executeTask.dispatchCompletedAfterDeferral', { accepted: completed });
+          if (!completed) {
+            this.logger.warn(
+              `[TaskRunner] launch dispatch complete rejected after resource-limit defer for task=${task.id} attempt=${attemptId} dispatchId=${dispatchOpts.dispatchId}`,
+            );
+          }
+        }
         return;
       }
 

--- a/scripts/repro/repro-launch-pool-deferral-outbox.sh
+++ b/scripts/repro/repro-launch-pool-deferral-outbox.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$repo_root"
+
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/launch-pool-deferral-outbox-repro.test.ts \
+  --reporter=verbose
+
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-launch-dispatch.test.ts \
+  --reporter=verbose \
+  --testNamePattern 'completes the dispatch row when resource-limit defers the launch'


### PR DESCRIPTION
## Summary

Fix launch outbox handoff after SSH or pool-capacity deferrals.

When a launch is deferred for pool capacity, TaskRunner now cleans up the already-accepted dispatch attempt after `deferTask(...)` handles that attempt.

This prevents the stale acknowledged dispatch row from consuming dispatcher capacity and blocking the replacement launch attempt.

## Architecture

### Before

```mermaid
graph TD
    A[LaunchDispatcher leases row] --> B[TaskRunner ackDispatch]
    B --> C[ResourceLimitError]
    C --> D[orchestrator.deferTask]
    D --> E[Replacement attempt enqueued]
    B --> F[Old row remains acknowledged]
    F --> G[Dispatcher capacity stays occupied]
    G --> H[Replacement row stays enqueued]
```

### After

```mermaid
graph TD
    A[LaunchDispatcher leases row] --> B[TaskRunner ackDispatch]
    B --> C[ResourceLimitError]
    C --> D[orchestrator.deferTask]
    D --> E[Clean up accepted dispatch attempt]
    E --> F[Replacement attempt can be leased]
    F --> G[Task reaches running or completed]
```

## Test Plan

- [x] `scripts/repro/repro-launch-pool-deferral-outbox.sh`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-launch-dispatch.test.ts --reporter=verbose`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 6a44aa022`
- Post-revert steps: None
- Data migration? No
