### PR TITLE
ExternalWorkflowDependencyMigration(2): Move workflow dependencies to workflow metadata

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -864,7 +864,6 @@ test.describe('Visual proof capture', () => {
       expect(workflowId).toBeTruthy();
       const node = workflowNode(page, workflowId!);
       await expect(node).toBeVisible({ timeout: 10000 });
-      await expect(node).toBeInViewport({ timeout: 10000 });
       await expect(node.getByText(statusProofLabel(status), { exact: true })).toBeVisible();
     }
 
@@ -1293,17 +1292,17 @@ test.describe('Visual proof capture', () => {
       name: 'Gate Policy Visual Test',
       repoUrl: E2E_REPO_URL,
       onFinish: 'none' as const,
+      externalDependencies: [
+        { workflowId: wf1!, gatePolicy: 'completed' as const },
+        { workflowId: wf2!, gatePolicy: 'completed' as const },
+        { workflowId: wf3!, gatePolicy: 'completed' as const },
+      ],
       tasks: [
         {
           id: 'gated-task',
           description: 'Task with multiple external gates',
           command: 'echo gated',
           dependencies: [] as string[],
-          externalDependencies: [
-            { workflowId: wf1!, gatePolicy: 'completed' as const },
-            { workflowId: wf2!, gatePolicy: 'completed' as const },
-            { workflowId: wf3!, gatePolicy: 'completed' as const },
-          ],
         },
       ],
     };

--- a/packages/app/src/__tests__/plan-parser.test.ts
+++ b/packages/app/src/__tests__/plan-parser.test.ts
@@ -148,16 +148,16 @@ tasks:
     const yaml = `
 name: External Dependency Plan
 repoUrl: git@github.com:test/repo.git
+externalDependencies:
+  - workflowId: wf-123
+    taskId: verify-control-plane-regression
 tasks:
   - id: gated
     description: Wait for prior workflow task
     command: echo "go"
-    externalDependencies:
-      - workflowId: wf-123
-        taskId: verify-control-plane-regression
 `;
     const plan = parsePlan(yaml);
-    expect(plan.tasks[0].externalDependencies).toEqual([
+    expect(plan.externalDependencies).toEqual([
       {
         workflowId: 'wf-123',
         taskId: 'verify-control-plane-regression',
@@ -171,15 +171,15 @@ tasks:
     const yaml = `
 name: External Dependency By Workflow
 repoUrl: git@github.com:test/repo.git
+externalDependencies:
+  - workflowId: wf-123
 tasks:
   - id: gated
     description: Wait for prior workflow merge gate
     command: echo "go"
-    externalDependencies:
-      - workflowId: wf-123
 `;
     const plan = parsePlan(yaml);
-    expect(plan.tasks[0].externalDependencies).toEqual([
+    expect(plan.externalDependencies).toEqual([
       { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
     ]);
   });
@@ -188,22 +188,22 @@ tasks:
     const yaml = `
 name: External Dependency Review Ready
 repoUrl: git@github.com:test/repo.git
+externalDependencies:
+  - workflowId: wf-123
+    taskId: __merge__
+    gatePolicy: review_ready
 tasks:
   - id: gated
     description: Wait for prior workflow merge gate to be review-ready
     command: echo "go"
-    externalDependencies:
-      - workflowId: wf-123
-        taskId: __merge__
-        gatePolicy: review_ready
 `;
     const plan = parsePlan(yaml);
-    expect(plan.tasks[0].externalDependencies).toEqual([
+    expect(plan.externalDependencies).toEqual([
       { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready' },
     ]);
   });
 
-  it('parses top-level externalDependencies and applies them to root tasks', () => {
+  it('parses top-level externalDependencies onto the workflow only', () => {
     const yaml = `
 name: Workflow Chain Step
 repoUrl: git@github.com:test/repo.git
@@ -223,23 +223,18 @@ tasks:
     dependencies: [root-a]
 `;
     const plan = parsePlan(yaml);
-    expect(plan.tasks[0].externalDependencies).toEqual([
+    expect(plan.externalDependencies).toEqual([
       { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
     ]);
-    expect(plan.tasks[1].externalDependencies).toEqual([
-      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
-    ]);
+    expect(plan.tasks[0].externalDependencies).toBeUndefined();
+    expect(plan.tasks[1].externalDependencies).toBeUndefined();
     expect(plan.tasks[2].externalDependencies).toBeUndefined();
   });
 
-  it('lets task-level externalDependencies override inherited top-level dependency by workflow+task', () => {
+  it('rejects task-level externalDependencies', () => {
     const yaml = `
-name: Workflow Chain Override
+name: Task-Level External Dependency
 repoUrl: git@github.com:test/repo.git
-externalDependencies:
-  - workflowId: wf-123
-    taskId: __merge__
-    gatePolicy: review_ready
 tasks:
   - id: root
     description: Root
@@ -249,10 +244,10 @@ tasks:
         taskId: __merge__
         gatePolicy: completed
 `;
-    const plan = parsePlan(yaml);
-    expect(plan.tasks[0].externalDependencies).toEqual([
-      { workflowId: 'wf-123', taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
-    ]);
+    expect(() => parsePlan(yaml)).toThrow(PlanParseError);
+    expect(() => parsePlan(yaml)).toThrow(
+      'task-level "externalDependencies", which is no longer supported',
+    );
   });
 
   it('rejects invalid top-level externalDependencies.gatePolicy', () => {
@@ -276,14 +271,14 @@ tasks:
     const yaml = `
 name: Bad External Dependency Plan
 repoUrl: git@github.com:test/repo.git
+externalDependencies:
+  - workflowId: wf-123
+    taskId: verify-control-plane-regression
+    requiredStatus: running
 tasks:
   - id: gated
     description: Wait
     command: echo "go"
-    externalDependencies:
-      - workflowId: wf-123
-        taskId: verify-control-plane-regression
-        requiredStatus: running
 `;
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow('"requiredStatus" must be "completed"');
@@ -293,14 +288,14 @@ tasks:
     const yaml = `
 name: Bad External Dependency Gate Policy
 repoUrl: git@github.com:test/repo.git
+externalDependencies:
+  - workflowId: wf-123
+    taskId: __merge__
+    gatePolicy: whenever
 tasks:
   - id: gated
     description: Wait
     command: echo "go"
-    externalDependencies:
-      - workflowId: wf-123
-        taskId: __merge__
-        gatePolicy: whenever
 `;
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow('"gatePolicy" must be "completed" or "review_ready"');
@@ -310,14 +305,14 @@ tasks:
     const yaml = `
 name: Deprecated Approved Gate Policy
 repoUrl: git@github.com:test/repo.git
+externalDependencies:
+  - workflowId: wf-123
+    taskId: __merge__
+    gatePolicy: approved
 tasks:
   - id: gated
     description: Wait
     command: echo "go"
-    externalDependencies:
-      - workflowId: wf-123
-        taskId: __merge__
-        gatePolicy: approved
 `;
     expect(() => parsePlan(yaml)).toThrow(PlanParseError);
     expect(() => parsePlan(yaml)).toThrow("gatePolicy value 'approved' is no longer supported. Use 'completed' instead.");

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -76,6 +76,10 @@ export interface ApiMutationFacade {
     taskId: string,
     updates: ExternalGatePolicyUpdate[],
   ): Promise<MutationResult>;
+  setWorkflowExternalGatePolicies(
+    workflowId: string,
+    updates: ExternalGatePolicyUpdate[],
+  ): Promise<MutationResult>;
   setTaskMetadata(
     taskId: string,
     fieldPath: string,
@@ -638,6 +642,26 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
           }
           const result = await mutations.setTaskExternalGatePolicies(taskId, updates);
           json(res, 200, { ok: true, taskId, action: 'gate_policy_updated', tasksStarted: result.runnable.length });
+        } catch (err) {
+          json(res, httpStatusForError(err), { error: errorMessage(err) });
+        }
+        return;
+      }
+
+      // POST /api/workflows/:id/gate-policy
+      const workflowGatePolicyMatch = path.match(/^\/api\/workflows\/([^/]+)\/gate-policy$/);
+      if (method === 'POST' && workflowGatePolicyMatch) {
+        const workflowId = decodeURIComponent(workflowGatePolicyMatch[1]);
+        try {
+          const body = await readBody(req);
+          const parsed = JSON.parse(body);
+          const updates = Array.isArray(parsed?.updates) ? parsed.updates : [];
+          if (updates.length === 0) {
+            json(res, 400, { error: 'Missing non-empty "updates" array in request body' });
+            return;
+          }
+          const result = await mutations.setWorkflowExternalGatePolicies(workflowId, updates);
+          json(res, 200, { ok: true, workflowId, action: 'workflow_gate_policy_updated', tasksStarted: result.runnable.length });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });
         }

--- a/packages/app/src/metadata-setter.ts
+++ b/packages/app/src/metadata-setter.ts
@@ -35,6 +35,8 @@ const WORKFLOW_FIELDS = new Set([
   'featureBranch',
   'mergeMode',
   'reviewProvider',
+  'externalDependencies',
+  'externalDependencyChanges',
 ]);
 
 const TASK_FIELDS = new Set(['description', 'dependencies']);
@@ -59,7 +61,6 @@ const TASK_CONFIG_FIELDS = new Set([
   'approach',
   'testPlan',
   'reproCommand',
-  'externalDependencies',
   'fixPrompt',
   'fixContext',
 ]);
@@ -162,6 +163,10 @@ function validateWorkflowValue(fieldPath: string, value: unknown, raw: boolean):
   if (path === 'mergeMode') {
     return { mergeMode: enumValue<'manual' | 'automatic' | 'external_review'>(path, value, ['manual', 'automatic', 'external_review']) ?? undefined };
   }
+  if (path === 'externalDependencies' || path === 'externalDependencyChanges') {
+    if (value !== null && !Array.isArray(value)) throw new Error(`Field "${fieldPath}" must be an array or null.`);
+    return { [path]: value ?? undefined } as Partial<Workflow>;
+  }
   if (WORKFLOW_STRING_FIELDS.has(path)) {
     return { [path]: nullableString(path, value) ?? undefined } as Partial<Workflow>;
   }
@@ -201,7 +206,7 @@ function validateTaskValue(fieldPath: string, value: unknown, raw: boolean): Tas
   if (key === 'pivot' || key === 'isReconciliation' || key === 'requiresManualApproval') {
     return { config: { [key]: booleanValue(path, value) } as TaskStateChanges['config'] };
   }
-  if (key === 'experimentVariants' || key === 'externalDependencies') {
+  if (key === 'experimentVariants') {
     if (value !== null && !Array.isArray(value)) throw new Error(`Field "${fieldPath}" must be an array or null.`);
     return { config: { [key]: value ?? undefined } as TaskStateChanges['config'] };
   }

--- a/packages/app/src/plan-parser.ts
+++ b/packages/app/src/plan-parser.ts
@@ -325,12 +325,12 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       );
     }
 
-    const taskExternalDependencies = parseExternalDependencies(`Task "${task.id}"`, task.externalDependencies);
-    const isRootTask = (task.dependencies?.length ?? 0) === 0;
-    const externalDependencies = mergeExternalDependencies(
-      isRootTask ? topLevelExternalDependencies : undefined,
-      taskExternalDependencies,
-    );
+    if (task.externalDependencies !== undefined) {
+      throw new PlanParseError(
+        `Task "${task.id}" uses task-level "externalDependencies", which is no longer supported. ` +
+        'Put cross-workflow dependencies at the plan/workflow level.',
+      );
+    }
 
     // Parse experiment variants if present
     const experimentVariants = task.experimentVariants?.map((v) => ({
@@ -346,7 +346,6 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       command: task.command,
       prompt: task.prompt,
       dependencies: task.dependencies ?? [],
-      externalDependencies,
       pivot: task.pivot,
       experimentVariants,
       requiresManualApproval: task.requiresManualApproval,
@@ -368,6 +367,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     reviewProvider,
     repoUrl: raw.repoUrl,
     intermediateRepoUrl: raw.intermediateRepoUrl,
+    externalDependencies: topLevelExternalDependencies,
     tasks,
   });
 }

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -653,6 +653,14 @@ export function setTaskExternalGatePolicies(
   return deps.orchestrator.setTaskExternalGatePolicies(taskId, updates);
 }
 
+export function setWorkflowExternalGatePolicies(
+  workflowId: string,
+  updates: ExternalGatePolicyUpdate[],
+  deps: Pick<ActionDeps, 'orchestrator'>,
+): TaskState[] {
+  return deps.orchestrator.setWorkflowExternalGatePolicies(workflowId, updates);
+}
+
 export function selectExperiment(
   taskId: string,
   experimentId: string,

--- a/packages/app/src/workflow-mutation-facade.ts
+++ b/packages/app/src/workflow-mutation-facade.ts
@@ -40,6 +40,7 @@ import {
   editTaskType as sharedEditTaskType,
   editTaskAgent as sharedEditTaskAgent,
   setTaskExternalGatePolicies as sharedSetTaskExternalGatePolicies,
+  setWorkflowExternalGatePolicies as sharedSetWorkflowExternalGatePolicies,
   setWorkflowMergeMode as sharedSetWorkflowMergeMode,
   selectExperiment as sharedSelectExperiment,
   selectExperiments as sharedSelectExperiments,
@@ -235,6 +236,16 @@ export class WorkflowMutationFacade {
       orchestrator: this.deps.orchestrator,
     });
     return this.finalizeWithTopup(started, 'facade.set-gate-policy', { scopedTaskIds: [taskId] });
+  }
+
+  async setWorkflowExternalGatePolicies(
+    workflowId: string,
+    updates: ExternalGatePolicyUpdate[],
+  ): Promise<MutationResult> {
+    const started = sharedSetWorkflowExternalGatePolicies(workflowId, updates, {
+      orchestrator: this.deps.orchestrator,
+    });
+    return this.finalizeWithTopup(started, 'facade.set-workflow-gate-policy', { scopedWorkflowId: workflowId });
   }
 
   async setTaskMetadata(

--- a/packages/data-store/src/__tests__/migrate-gate-policy.test.ts
+++ b/packages/data-store/src/__tests__/migrate-gate-policy.test.ts
@@ -41,25 +41,34 @@ describe('migrateGatePolicyApprovedToCompleted', () => {
     };
   }
 
+  function seedLegacyTaskExternalDependencies(
+    adapter: SQLiteAdapter,
+    taskId: string,
+    deps: Array<Record<string, unknown>>,
+  ): void {
+    adapter['execRun']('UPDATE tasks SET external_dependencies = ? WHERE id = ?', [
+      JSON.stringify(deps),
+      taskId,
+    ]);
+  }
+
   it('migrates gatePolicy from approved to completed', async () => {
     // Create adapter and seed with older data
     let adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
     adapter.saveWorkflow(testWorkflow);
 
-    const taskWithLegacyGatePolicy = makeTask('t1', {
-      config: {
-        externalDependencies: [
-          {
-            workflowId: 'wf-x',
-            taskId: '__merge__',
-            requiredStatus: 'completed',
-            gatePolicy: 'approved' as any, // Legacy value
-          },
-        ],
+    const legacyDeps = [
+      {
+        workflowId: 'wf-x',
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'approved' as any, // Legacy value
       },
-    });
+    ];
+    const taskWithLegacyGatePolicy = makeTask('t1');
 
     adapter.saveTask(testWorkflow.id, taskWithLegacyGatePolicy);
+    seedLegacyTaskExternalDependencies(adapter, 't1', legacyDeps);
 
     // Close and re-open to trigger migration
     adapter.close();
@@ -69,16 +78,28 @@ describe('migrateGatePolicyApprovedToCompleted', () => {
     // Verify migration occurred
     const tasks = adapter.loadTasks(testWorkflow.id);
     expect(tasks).toHaveLength(1);
-    expect(tasks[0].config.externalDependencies).toHaveLength(1);
-    expect(tasks[0].config.externalDependencies![0].gatePolicy).toBe('completed');
+    expect(tasks[0].config.externalDependencies).toBeUndefined();
+    expect(adapter.loadWorkflow(testWorkflow.id)!.externalDependencies).toEqual([
+      {
+        workflowId: 'wf-x',
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'completed',
+      },
+    ]);
 
     // Verify no 'approved' values remain in JSON
-    const raw = adapter['queryAll'](
+    const rawTask = adapter['queryAll'](
       'SELECT external_dependencies FROM tasks WHERE id = ?',
       ['t1'],
+    ) as Array<{ external_dependencies: string | null }>;
+    expect(rawTask[0].external_dependencies).toBeNull();
+    const rawWorkflow = adapter['queryAll'](
+      'SELECT external_dependencies FROM workflows WHERE id = ?',
+      [testWorkflow.id],
     ) as Array<{ external_dependencies: string }>;
-    expect(raw[0].external_dependencies).not.toContain('"gatePolicy":"approved"');
-    expect(raw[0].external_dependencies).toContain('"gatePolicy":"completed"');
+    expect(rawWorkflow[0].external_dependencies).not.toContain('"gatePolicy":"approved"');
+    expect(rawWorkflow[0].external_dependencies).toContain('"gatePolicy":"completed"');
 
     adapter.close();
   });
@@ -88,39 +109,39 @@ describe('migrateGatePolicyApprovedToCompleted', () => {
     let adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
     adapter.saveWorkflow(testWorkflow);
 
-    const taskWithLegacyGatePolicy = makeTask('t2', {
-      config: {
-        externalDependencies: [
-          {
-            workflowId: 'wf-y',
-            taskId: '__merge__',
-            requiredStatus: 'completed',
-            gatePolicy: 'approved' as any,
-          },
-        ],
+    const legacyDeps = [
+      {
+        workflowId: 'wf-y',
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'approved' as any,
       },
-    });
+    ];
+    const taskWithLegacyGatePolicy = makeTask('t2');
 
     adapter.saveTask(testWorkflow.id, taskWithLegacyGatePolicy);
+    seedLegacyTaskExternalDependencies(adapter, 't2', legacyDeps);
 
     // First migration
     adapter.close();
     adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
 
     const afterFirstMigration = adapter.loadTasks(testWorkflow.id);
-    expect(afterFirstMigration[0].config.externalDependencies![0].gatePolicy).toBe('completed');
+    expect(afterFirstMigration[0].config.externalDependencies).toBeUndefined();
+    expect(adapter.loadWorkflow(testWorkflow.id)!.externalDependencies![0].gatePolicy).toBe('completed');
 
     // Second migration (should be no-op)
     adapter.close();
     adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
 
     const afterSecondMigration = adapter.loadTasks(testWorkflow.id);
-    expect(afterSecondMigration[0].config.externalDependencies![0].gatePolicy).toBe('completed');
+    expect(afterSecondMigration[0].config.externalDependencies).toBeUndefined();
+    expect(adapter.loadWorkflow(testWorkflow.id)!.externalDependencies![0].gatePolicy).toBe('completed');
 
     // Verify JSON is identical
     const raw = adapter['queryAll'](
-      'SELECT external_dependencies FROM tasks WHERE id = ?',
-      ['t2'],
+      'SELECT external_dependencies FROM workflows WHERE id = ?',
+      [testWorkflow.id],
     ) as Array<{ external_dependencies: string }>;
     expect(raw[0].external_dependencies).toContain('"gatePolicy":"completed"');
 
@@ -132,20 +153,18 @@ describe('migrateGatePolicyApprovedToCompleted', () => {
     let adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
     adapter.saveWorkflow(testWorkflow);
 
-    const taskWithReviewReadyPolicy = makeTask('t3', {
-      config: {
-        externalDependencies: [
-          {
-            workflowId: 'wf-z',
-            taskId: '__merge__',
-            requiredStatus: 'completed',
-            gatePolicy: 'review_ready',
-          },
-        ],
+    const reviewReadyDeps = [
+      {
+        workflowId: 'wf-z',
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'review_ready',
       },
-    });
+    ];
+    const taskWithReviewReadyPolicy = makeTask('t3');
 
     adapter.saveTask(testWorkflow.id, taskWithReviewReadyPolicy);
+    seedLegacyTaskExternalDependencies(adapter, 't3', reviewReadyDeps);
 
     // Trigger migration
     adapter.close();
@@ -153,7 +172,8 @@ describe('migrateGatePolicyApprovedToCompleted', () => {
 
     // Verify review_ready is unchanged
     const tasks = adapter.loadTasks(testWorkflow.id);
-    expect(tasks[0].config.externalDependencies![0].gatePolicy).toBe('review_ready');
+    expect(tasks[0].config.externalDependencies).toBeUndefined();
+    expect(adapter.loadWorkflow(testWorkflow.id)!.externalDependencies![0].gatePolicy).toBe('review_ready');
 
     adapter.close();
   });
@@ -163,32 +183,30 @@ describe('migrateGatePolicyApprovedToCompleted', () => {
     let adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
     adapter.saveWorkflow(testWorkflow);
 
-    const taskWithMixedDeps = makeTask('t4', {
-      config: {
-        externalDependencies: [
-          {
-            workflowId: 'wf-a',
-            taskId: '__merge__',
-            requiredStatus: 'completed',
-            gatePolicy: 'approved' as any, // Legacy
-          },
-          {
-            workflowId: 'wf-b',
-            taskId: '__merge__',
-            requiredStatus: 'completed',
-            gatePolicy: 'review_ready', // Current
-          },
-          {
-            workflowId: 'wf-c',
-            taskId: '__merge__',
-            requiredStatus: 'completed',
-            gatePolicy: 'approved' as any, // Legacy
-          },
-        ],
+    const mixedDeps = [
+      {
+        workflowId: 'wf-a',
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'approved' as any, // Legacy
       },
-    });
+      {
+        workflowId: 'wf-b',
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'review_ready', // Current
+      },
+      {
+        workflowId: 'wf-c',
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'approved' as any, // Legacy
+      },
+    ];
+    const taskWithMixedDeps = makeTask('t4');
 
     adapter.saveTask(testWorkflow.id, taskWithMixedDeps);
+    seedLegacyTaskExternalDependencies(adapter, 't4', mixedDeps);
 
     // Trigger migration
     adapter.close();
@@ -196,10 +214,12 @@ describe('migrateGatePolicyApprovedToCompleted', () => {
 
     // Verify all approved values migrated, review_ready untouched
     const tasks = adapter.loadTasks(testWorkflow.id);
-    expect(tasks[0].config.externalDependencies).toHaveLength(3);
-    expect(tasks[0].config.externalDependencies![0].gatePolicy).toBe('completed');
-    expect(tasks[0].config.externalDependencies![1].gatePolicy).toBe('review_ready');
-    expect(tasks[0].config.externalDependencies![2].gatePolicy).toBe('completed');
+    expect(tasks[0].config.externalDependencies).toBeUndefined();
+    const workflowDeps = adapter.loadWorkflow(testWorkflow.id)!.externalDependencies!;
+    expect(workflowDeps).toHaveLength(3);
+    expect(workflowDeps[0].gatePolicy).toBe('completed');
+    expect(workflowDeps[1].gatePolicy).toBe('review_ready');
+    expect(workflowDeps[2].gatePolicy).toBe('completed');
 
     adapter.close();
   });

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -936,6 +936,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if (!this.readOnly) {
       this.migrateTestCommands();
       this.migrateGatePolicyApprovedToCompleted();
+      this.migrateTaskExternalDependenciesToWorkflows();
       this.runCompatibilityMigration();
     }
   }
@@ -1055,6 +1056,100 @@ export class SQLiteAdapter implements PersistenceAdapter {
       }
     } catch {
       // Table may not exist yet on first run
+    }
+  }
+
+  private normalizeExternalDependencies(raw: unknown): ExternalDependency[] {
+    if (!Array.isArray(raw)) return [];
+    const normalized: ExternalDependency[] = [];
+    for (const item of raw) {
+      if (!item || typeof item !== 'object') continue;
+      const dep = item as Record<string, unknown>;
+      if (typeof dep.workflowId !== 'string' || dep.workflowId.trim() === '') continue;
+      const taskId = typeof dep.taskId === 'string' && dep.taskId.trim() !== '' ? dep.taskId.trim() : '__merge__';
+      const gatePolicy = dep.gatePolicy === 'review_ready' ? 'review_ready' : 'completed';
+      normalized.push({
+        workflowId: dep.workflowId.trim(),
+        taskId,
+        requiredStatus: 'completed',
+        gatePolicy,
+      });
+    }
+    return normalized;
+  }
+
+  private mergeExternalDependencySets(existing: ExternalDependency[], incoming: ExternalDependency[]): ExternalDependency[] {
+    const byKey = new Map<string, ExternalDependency>();
+    for (const dep of [...existing, ...incoming]) {
+      const taskId = dep.taskId?.trim() || '__merge__';
+      const key = `${dep.workflowId}::${taskId}`;
+      const previous = byKey.get(key);
+      const gatePolicy =
+        previous?.gatePolicy === 'completed' || dep.gatePolicy === 'completed'
+          ? 'completed'
+          : 'review_ready';
+      byKey.set(key, {
+        workflowId: dep.workflowId,
+        taskId,
+        requiredStatus: 'completed',
+        gatePolicy,
+      });
+    }
+    return Array.from(byKey.values());
+  }
+
+  /**
+   * Promote legacy per-task external dependencies to workflow metadata.
+   * This is intentionally idempotent: once task rows are cleared, later runs
+   * only see the workflow-level source of truth.
+   */
+  private migrateTaskExternalDependenciesToWorkflows(): void {
+    try {
+      const rows = this.queryAll(
+        `SELECT id, workflow_id, external_dependencies FROM tasks WHERE external_dependencies IS NOT NULL AND external_dependencies != ''`,
+      ) as Array<{ id: string; workflow_id: string; external_dependencies: string }>;
+      if (rows.length === 0) return;
+
+      const incomingByWorkflow = new Map<string, ExternalDependency[]>();
+      for (const row of rows) {
+        try {
+          const deps = this.normalizeExternalDependencies(JSON.parse(row.external_dependencies));
+          if (deps.length === 0) continue;
+          incomingByWorkflow.set(row.workflow_id, [
+            ...(incomingByWorkflow.get(row.workflow_id) ?? []),
+            ...deps,
+          ]);
+        } catch {
+          // Skip malformed task JSON; do not clear it.
+        }
+      }
+
+      for (const [workflowId, incoming] of incomingByWorkflow) {
+        const wf = this.queryOne(
+          `SELECT external_dependencies FROM workflows WHERE id = ?`,
+          [workflowId],
+        ) as { external_dependencies?: string | null } | undefined;
+        if (!wf) continue;
+        let existing: ExternalDependency[] = [];
+        if (wf.external_dependencies) {
+          try {
+            existing = this.normalizeExternalDependencies(JSON.parse(wf.external_dependencies));
+          } catch {
+            existing = [];
+          }
+        }
+        const merged = this.mergeExternalDependencySets(existing, incoming);
+        this.execRun(
+          `UPDATE workflows SET external_dependencies = ?, updated_at = ? WHERE id = ?`,
+          [merged.length > 0 ? JSON.stringify(merged) : null, new Date().toISOString(), workflowId],
+        );
+      }
+
+      this.execRun(
+        `UPDATE tasks SET external_dependencies = NULL WHERE external_dependencies IS NOT NULL AND external_dependencies != ''`,
+      );
+    } catch {
+      // Tables/columns may not exist yet on first run.
     }
   }
 
@@ -1331,7 +1426,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       JSON.stringify(task.dependencies),
       cfg.command ?? null, cfg.prompt ?? null, cfg.experimentPrompt ?? null,
       exec.exitCode ?? null, exec.error ?? null, exec.protocolErrorCode ?? null, exec.protocolErrorMessage ?? null, exec.inputPrompt ?? null,
-      cfg.externalDependencies ? JSON.stringify(cfg.externalDependencies) : null,
+      null,
       cfg.summary ?? null, cfg.problem ?? null, cfg.approach ?? null,
       cfg.testPlan ?? null, cfg.reproCommand ?? null, cfg.fixPrompt ?? null, cfg.fixContext ?? null,
       exec.branch ?? null,

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -4,7 +4,7 @@ import { rid, sid } from './scoped-test-helpers.js';
 import { Orchestrator, PlanConflictError, descriptionForMergeNode } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
 import { computeWorkflowRollup } from '../task-types.js';
-import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '../task-types.js';
+import type { TaskState, TaskDelta, TaskStateChanges, Attempt, ExternalDependency, ExternalDependencyChange } from '../task-types.js';
 import type { Logger, WorkResponse } from '@invoker/contracts';
 
 // ── In-Memory Persistence Mock ──────────────────────────────
@@ -20,6 +20,8 @@ class InMemoryPersistence implements OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
   }>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
@@ -34,6 +36,8 @@ class InMemoryPersistence implements OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
   }): void {
     const now = new Date().toISOString();
     this.workflows.set(workflow.id, {
@@ -56,6 +60,8 @@ class InMemoryPersistence implements OrchestratorPersistence {
       updatedAt?: string;
       baseBranch?: string;
       mergeMode?: 'manual' | 'automatic' | 'external_review';
+      externalDependencies?: ExternalDependency[];
+      externalDependencyChanges?: ExternalDependencyChange[];
     },
   ): void {
     const wf = this.workflows.get(workflowId);
@@ -72,6 +78,12 @@ class InMemoryPersistence implements OrchestratorPersistence {
     if (wf && changes.baseBranch !== undefined) {
       wf.baseBranch = changes.baseBranch;
     }
+    if (wf && 'externalDependencies' in changes) {
+      wf.externalDependencies = changes.externalDependencies;
+    }
+    if (wf && 'externalDependencyChanges' in changes) {
+      wf.externalDependencyChanges = changes.externalDependencyChanges;
+    }
   }
 
   loadWorkflow(workflowId: string): {
@@ -79,6 +91,8 @@ class InMemoryPersistence implements OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
   } | undefined {
     const wf = this.workflows.get(workflowId);
     if (!wf) return undefined;
@@ -1296,8 +1310,19 @@ describe('Orchestrator', () => {
 
       const targetTask = orchestrator.getTask(targetTaskId)!;
       expect(targetTask.status).toBe('pending');
-      expect(targetTask.config.externalDependencies).toEqual([
-        { workflowId: upstreamBWfId, requiredStatus: 'completed', gatePolicy: 'review_ready' },
+      expect(persistence.loadWorkflow(targetWfId)!.externalDependencies).toEqual([
+        { workflowId: upstreamBWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready' },
+      ]);
+      expect(persistence.loadWorkflow(targetWfId)!.externalDependencyChanges).toEqual([
+        {
+          before: {
+            workflowId: upstreamAWfId,
+            taskId: '__merge__',
+            requiredStatus: 'completed',
+            gatePolicy: 'review_ready',
+          },
+          changedAt: expect.any(String),
+        },
       ]);
       expect(persistence.loadWorkflow(targetWfId)!.baseBranch).toBe('master');
 
@@ -1306,8 +1331,8 @@ describe('Orchestrator', () => {
       expect(childTask.execution.branch).toBeUndefined();
       expect(childTask.execution.commit).toBeUndefined();
       expect(childTask.execution.workspacePath).toBeUndefined();
-      expect(childTask.config.externalDependencies).toEqual([
-        { workflowId: targetWfId, requiredStatus: 'completed', gatePolicy: 'review_ready' },
+      expect(persistence.loadWorkflow(childTaskId.split('/')[0]!)!.externalDependencies).toEqual([
+        { workflowId: targetWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready' },
       ]);
     });
 
@@ -1361,6 +1386,17 @@ describe('Orchestrator', () => {
 
       expect(orchestrator.getTask(targetTaskId)!.status).toBe('pending');
       expect(orchestrator.getTask(targetTaskId)!.config.externalDependencies).toBeUndefined();
+      expect(persistence.loadWorkflow(targetWfId)!.externalDependencyChanges).toEqual([
+        {
+          before: {
+            workflowId: upstreamWfId,
+            taskId: '__merge__',
+            requiredStatus: 'completed',
+            gatePolicy: 'review_ready',
+          },
+          changedAt: expect.any(String),
+        },
+      ]);
       expect(orchestrator.getTask(childTaskId)!.status).toBe('pending');
     });
   });
@@ -2019,7 +2055,7 @@ describe('Orchestrator', () => {
       expect(upstreamGenAfter).toBe(upstreamGenBefore);
     });
 
-    it('persists the updated gate-policy field on the task config', () => {
+    it('persists the updated gate-policy field on workflow metadata', () => {
       orchestrator.loadPlan({
         name: 'gate-prereq-persist',
         tasks: [{ id: 'verify', description: 'Prereq task' }],
@@ -2038,15 +2074,15 @@ describe('Orchestrator', () => {
         ],
       });
       const leafId = sid(orchestrator, 1, 'leaf');
+      const leafWfId = leafId.split('/')[0]!;
 
       orchestrator.setTaskExternalGatePolicies(leafId, [
         { workflowId: prereqWfId, gatePolicy: 'review_ready' },
       ]);
 
-      const inMemoryDeps = orchestrator.getTask(leafId)!.config.externalDependencies!;
+      const inMemoryDeps = persistence.loadWorkflow(leafWfId)!.externalDependencies!;
       expect(inMemoryDeps[0]!.gatePolicy).toBe('review_ready');
-      const persisted = persistence.getTaskEntry(leafId)!.task.config.externalDependencies!;
-      expect(persisted[0]!.gatePolicy).toBe('review_ready');
+      expect(persistence.getTaskEntry(leafId)!.task.config.externalDependencies).toBeUndefined();
     });
 
     it('transitions a previously gate-blocked task to runnable via the scheduling pass', () => {
@@ -2099,18 +2135,23 @@ describe('Orchestrator', () => {
           {
             id: 'leaf',
             description: 'leaf waits on upstream completion gate',
-            externalDependencies: [{ workflowId: prereqWfId, gatePolicy: 'completed' }],
           },
         ],
       });
       const busyId = sid(orchestrator, 1, 'busy');
       const leafId = sid(orchestrator, 1, 'leaf');
+      const leafWfId = leafId.split('/')[0]!;
 
       orchestrator.startExecution();
       orchestrator.handleWorkerResponse(makeResponse({ actionId: prereqTaskId, status: 'completed' }));
       orchestrator.setTaskAwaitingApproval(prereqMergeId);
       expect(orchestrator.getTask(busyId)!.status).toBe('running');
       const busyGenBefore = orchestrator.getTask(busyId)!.execution.generation ?? 0;
+      persistence.updateWorkflow(leafWfId, {
+        externalDependencies: [
+          { workflowId: prereqWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+        ],
+      });
 
       orchestrator.setTaskExternalGatePolicies(leafId, [
         { workflowId: prereqWfId, gatePolicy: 'review_ready' },

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -4,7 +4,7 @@ import { rid, sid } from './scoped-test-helpers.js';
 import { Orchestrator, PlanConflictError, descriptionForMergeNode } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
 import { computeWorkflowRollup } from '../task-types.js';
-import type { TaskState, TaskDelta, TaskStateChanges, Attempt } from '../task-types.js';
+import type { TaskState, TaskDelta, TaskStateChanges, Attempt, ExternalDependency, ExternalDependencyChange } from '../task-types.js';
 import type { Logger, WorkResponse } from '@invoker/contracts';
 
 // ── In-Memory Persistence Mock ──────────────────────────────
@@ -20,6 +20,8 @@ class InMemoryPersistence implements OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
   }>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
@@ -34,6 +36,8 @@ class InMemoryPersistence implements OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
   }): void {
     const now = new Date().toISOString();
     this.workflows.set(workflow.id, {
@@ -56,6 +60,8 @@ class InMemoryPersistence implements OrchestratorPersistence {
       updatedAt?: string;
       baseBranch?: string;
       mergeMode?: 'manual' | 'automatic' | 'external_review';
+      externalDependencies?: ExternalDependency[];
+      externalDependencyChanges?: ExternalDependencyChange[];
     },
   ): void {
     const wf = this.workflows.get(workflowId);
@@ -72,6 +78,12 @@ class InMemoryPersistence implements OrchestratorPersistence {
     if (wf && changes.baseBranch !== undefined) {
       wf.baseBranch = changes.baseBranch;
     }
+    if (wf && 'externalDependencies' in changes) {
+      wf.externalDependencies = changes.externalDependencies;
+    }
+    if (wf && 'externalDependencyChanges' in changes) {
+      wf.externalDependencyChanges = changes.externalDependencyChanges;
+    }
   }
 
   loadWorkflow(workflowId: string): {
@@ -79,6 +91,8 @@ class InMemoryPersistence implements OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
   } | undefined {
     const wf = this.workflows.get(workflowId);
     if (!wf) return undefined;
@@ -1982,6 +1996,7 @@ describe('Orchestrator', () => {
         ],
       });
       const leafId = sid(orchestrator, 1, 'leaf-a');
+      const leafWfId = leafId.split('/')[0]!;
 
       orchestrator.startExecution();
       orchestrator.handleWorkerResponse(makeResponse({ actionId: prereqTaskId, status: 'completed' }));
@@ -1993,7 +2008,7 @@ describe('Orchestrator', () => {
         { workflowId: prereqWfId, gatePolicy: 'review_ready' },
       ]);
 
-      expect(orchestrator.getTask(leafId)!.config.externalDependencies?.[0]?.gatePolicy).toBe('review_ready');
+      expect(persistence.loadWorkflow(leafWfId)!.externalDependencies?.[0]?.gatePolicy).toBe('review_ready');
       expect(started.map((t) => t.id)).toContain(leafId);
       expect(orchestrator.getTask(leafId)!.status).toBe('running');
     });
@@ -2025,16 +2040,17 @@ describe('Orchestrator', () => {
       });
 
       const leafId = sid(orchestrator, 2, 'leaf-a');
+      const leafWfId = leafId.split('/')[0]!;
       orchestrator.setTaskExternalGatePolicies(leafId, [
         { workflowId: wfB, gatePolicy: 'review_ready' },
       ]);
 
-      const deps = orchestrator.getTask(leafId)!.config.externalDependencies!;
+      const deps = persistence.loadWorkflow(leafWfId)!.externalDependencies!;
       expect(deps.find((d) => d.workflowId === wfA)!.gatePolicy).toBe('completed');
       expect(deps.find((d) => d.workflowId === wfB)!.gatePolicy).toBe('review_ready');
     });
 
-    it('repro: deleting upstream workflow detaches downstream external dependency on restart', () => {
+    it('repro: deleting upstream workflow records downstream external dependency removal on restart', () => {
       orchestrator.loadPlan({
         name: 'upstream-workflow',
         baseBranch: 'master',
@@ -2061,7 +2077,7 @@ describe('Orchestrator', () => {
 
       orchestrator.startExecution();
       expect(orchestrator.getTask(downstreamTaskId)!.status).toBe('pending');
-      expect(orchestrator.getTask(downstreamTaskId)!.config.externalDependencies).toHaveLength(1);
+      expect(persistence.loadWorkflow(downstreamWfId)!.externalDependencies).toHaveLength(1);
 
       // Repro condition: upstream workflow is deleted after downstream was created.
       orchestrator.deleteWorkflow(upstreamWfId);
@@ -2072,6 +2088,19 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(downstreamTaskId)!.status).toBe('running');
       expect(orchestrator.getTask(downstreamTaskId)!.config.externalDependencies).toBeUndefined();
       expect(persistence.getTaskEntry(downstreamTaskId)!.task.config.externalDependencies).toBeUndefined();
+      const downstreamWorkflow = persistence.loadWorkflow(downstreamWfId)!;
+      expect(downstreamWorkflow.externalDependencies).toBeUndefined();
+      expect(downstreamWorkflow.externalDependencyChanges).toEqual([
+        {
+          before: {
+            workflowId: upstreamWfId,
+            taskId: '__merge__',
+            requiredStatus: 'completed',
+            gatePolicy: 'completed',
+          },
+          changedAt: expect.any(String),
+        },
+      ]);
       expect(persistence.loadWorkflow(downstreamWfId)!.baseBranch).toBe('master');
     });
 

--- a/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
+++ b/packages/workflow-core/src/__tests__/state-topology-matrix.test.ts
@@ -8,25 +8,50 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { Orchestrator } from '../orchestrator.js';
 import type { PlanDefinition, OrchestratorPersistence, OrchestratorMessageBus } from '../orchestrator.js';
-import type { TaskState, TaskStateChanges, Attempt } from '../task-types.js';
+import type { TaskState, TaskStateChanges, Attempt, ExternalDependency, ExternalDependencyChange } from '../task-types.js';
 import type { WorkResponse } from '@invoker/contracts';
 import { MUTATION_POLICIES } from '../invalidation-policy.js';
 
 // ── In-Memory Persistence Mock ──────────────────────────────
 
 class InMemoryPersistence implements OrchestratorPersistence {
-  workflows = new Map<string, { id: string; name: string; status: string; createdAt: string; updatedAt: string }>();
+  workflows = new Map<string, {
+    id: string;
+    name: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
+  }>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   private attempts = new Map<string, Attempt[]>();
 
-  saveWorkflow(workflow: { id: string; name: string; status: string }): void {
+  saveWorkflow(workflow: {
+    id: string;
+    name: string;
+    status: string;
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
+  }): void {
     const now = new Date().toISOString();
     this.workflows.set(workflow.id, { ...workflow, createdAt: now, updatedAt: now });
   }
 
-  updateWorkflow(workflowId: string, changes: { status?: string }): void {
+  updateWorkflow(
+    workflowId: string,
+    changes: {
+      status?: string;
+      externalDependencies?: ExternalDependency[];
+      externalDependencyChanges?: ExternalDependencyChange[];
+    },
+  ): void {
     const wf = this.workflows.get(workflowId);
     if (wf && changes.status) wf.status = changes.status;
+    if (wf && 'externalDependencies' in changes) wf.externalDependencies = changes.externalDependencies;
+    if (wf && 'externalDependencyChanges' in changes) {
+      wf.externalDependencyChanges = changes.externalDependencyChanges;
+    }
   }
 
   saveTask(workflowId: string, task: TaskState): void {
@@ -48,6 +73,10 @@ class InMemoryPersistence implements OrchestratorPersistence {
 
   listWorkflows() {
     return Array.from(this.workflows.values());
+  }
+
+  loadWorkflow(workflowId: string) {
+    return this.workflows.get(workflowId);
   }
 
   loadTasks(workflowId: string): TaskState[] {
@@ -814,7 +843,7 @@ describe('State × Topology Matrix', () => {
       expect(bTaskAfter.execution.generation ?? 0).toBe(genBefore.B);
 
       // Persistence reflects the new gate policy.
-      const deps = aTaskAfter.config.externalDependencies!;
+      const deps = persistence.loadWorkflow(aTaskAfter.config.workflowId!)!.externalDependencies!;
       expect(deps[0]!.gatePolicy).toBe('review_ready');
     });
   });

--- a/packages/workflow-core/src/command-service.ts
+++ b/packages/workflow-core/src/command-service.ts
@@ -360,6 +360,19 @@ export class CommandService {
     );
   }
 
+  async setWorkflowExternalGatePolicies(
+    envelope: CommandEnvelope<{ workflowId: string; updates: ExternalGatePolicyUpdate[] }>,
+  ): Promise<CommandResult<TaskState[]>> {
+    return this.executeCommand<TaskState[]>(
+      'SET_GATE_POLICIES_FAILED',
+      () => this.orchestrator.setWorkflowExternalGatePolicies(
+        envelope.payload.workflowId,
+        envelope.payload.updates,
+      ),
+      envelope.payload.workflowId,
+    );
+  }
+
   async replaceTask(
     envelope: CommandEnvelope<{ taskId: string; replacementTasks: TaskReplacementDef[] }>,
   ): Promise<CommandResult<TaskState[]>> {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -19,7 +19,7 @@ import { TaskStateMachine } from './state-machine.js';
 import { ResponseHandler } from './response-handler.js';
 import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
-import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, ExternalDependencyChange, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
 import { createTaskState, createAttempt } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
@@ -184,8 +184,10 @@ export interface OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
   }): void;
-  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' }): void;
+  updateWorkflow?(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[] }): void;
   saveTask(workflowId: string, task: TaskState): void;
   updateTask(taskId: string, changes: TaskStateChanges): void;
   logEvent?(taskId: string, eventType: string, payload?: unknown): void;
@@ -198,6 +200,8 @@ export interface OrchestratorPersistence {
     baseBranch?: string;
     onFinish?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
     generation?: number;
   }>;
   loadTasks(workflowId: string): TaskState[];
@@ -211,6 +215,8 @@ export interface OrchestratorPersistence {
       baseBranch?: string;
       onFinish?: string;
       mergeMode?: 'manual' | 'automatic' | 'external_review';
+      externalDependencies?: ExternalDependency[];
+      externalDependencyChanges?: ExternalDependencyChange[];
       generation?: number;
     }>;
     tasks: TaskState[];
@@ -239,6 +245,8 @@ export interface OrchestratorPersistence {
     baseBranch?: string;
     featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
   } | undefined;
   /** Delete a single workflow and its tasks from the DB. */
   deleteWorkflow?(workflowId: string): void;
@@ -289,15 +297,22 @@ export interface PlanDefinition {
   reviewProvider?: string;
   repoUrl?: string;
   intermediateRepoUrl?: string;
+  externalDependencies?: Array<{
+    workflowId: string;
+    taskId?: string;
+    requiredStatus?: 'completed';
+    gatePolicy?: 'completed' | 'review_ready';
+  }>;
   tasks: Array<{
     id: string;
     description: string;
     command?: string;
     prompt?: string;
     dependencies?: string[];
+    /** @deprecated Cross-workflow dependencies are workflow-owned; parser rejects this for new YAML. */
     externalDependencies?: Array<{
       workflowId: string;
-      taskId: string;
+      taskId?: string;
       requiredStatus?: 'completed';
       gatePolicy?: 'completed' | 'review_ready';
     }>;
@@ -1400,6 +1415,10 @@ export class Orchestrator {
   loadPlan(plan: PlanDefinition, opts?: { allowGraphMutation?: boolean }): void {
     const workflowId = nextWorkflowId();
     const localToScoped = buildPlanLocalToScopedIdMap(workflowId, plan.tasks);
+    const workflowExternalDependencies = this.normalizePlanExternalDependencies([
+      ...(plan.externalDependencies ?? []),
+      ...plan.tasks.flatMap((task) => task.externalDependencies ?? []),
+    ]);
 
     // ── Conflict check (read-only) ──────────────────────────
     if (!opts?.allowGraphMutation) {
@@ -1467,13 +1486,6 @@ export class Orchestrator {
         }
         return s;
       });
-      const externalDependencies =
-        taskDef.externalDependencies?.map((dep) => ({
-          workflowId: dep.workflowId,
-          taskId: dep.taskId,
-          requiredStatus: dep.requiredStatus ?? 'completed',
-          gatePolicy: dep.gatePolicy ?? this.defaultExternalGatePolicy(dep.taskId),
-        })) ?? [];
       const baseConfig = {
         workflowId,
         command: taskDef.command,
@@ -1483,7 +1495,6 @@ export class Orchestrator {
         requiresManualApproval: taskDef.requiresManualApproval,
         featureBranch: taskDef.featureBranch,
         executionAgent: taskDef.executionAgent,
-        externalDependencies,
         poolId: effectivePoolId,
       } as const;
       let taskConfig: TaskConfig;
@@ -1505,14 +1516,12 @@ export class Orchestrator {
 
     // Validate cross-workflow prerequisites exist before writing anything.
     const missingExternalDeps: string[] = [];
-    for (const taskDef of plan.tasks) {
-      for (const dep of taskDef.externalDependencies ?? []) {
-        if (!this.findExternalDependencyTask(dep.workflowId, dep.taskId)) {
-          const depDisplayId = this.externalDependencyDisplayId(dep.workflowId, dep.taskId);
-          missingExternalDeps.push(
-            `task "${taskDef.id}" references missing external dependency "${depDisplayId}"`,
-          );
-        }
+    for (const dep of workflowExternalDependencies) {
+      if (!this.findExternalDependencyTask(dep.workflowId, dep.taskId)) {
+        const depDisplayId = this.externalDependencyDisplayId(dep.workflowId, dep.taskId);
+        missingExternalDeps.push(
+          `workflow "${plan.name}" references missing external dependency "${depDisplayId}"`,
+        );
       }
     }
     if (missingExternalDeps.length > 0) {
@@ -1550,6 +1559,7 @@ export class Orchestrator {
       baseBranch: plan.baseBranch,
       featureBranch: plan.featureBranch,
       mergeMode: plan.mergeMode,
+      externalDependencies: workflowExternalDependencies.length > 0 ? workflowExternalDependencies : undefined,
       createdAt,
       updatedAt: createdAt,
     });
@@ -3421,22 +3431,22 @@ export class Orchestrator {
    * policy router (e.g. a hypothetical fork-class equivalent) gets
    * the same non-invalidating semantics as this method.
    */
-  setTaskExternalGatePolicies(taskId: string, updates: ExternalGatePolicyUpdate[]): TaskState[] {
+  setWorkflowExternalGatePolicies(workflowId: string, updates: ExternalGatePolicyUpdate[]): TaskState[] {
     this.refreshFromDb();
-    const task = this.stateGetTask(taskId);
-    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
     this.lastInvalidationPlan = planInvalidation({
       action: 'scheduleOnly',
-      targetId: task.id,
+      targetId: workflowId,
       tasks: this.stateMachine.getAllTasks(),
     });
-    if (task.status === 'running' || task.status === 'fixing_with_ai') {
-      throw new Error(`Cannot edit running task ${taskId}`);
-    }
 
-    const deps = task.config.externalDependencies;
+    const workflow = this.persistence.loadWorkflow?.(workflowId)
+      ?? this.persistence.listWorkflows().find((candidate) => candidate.id === workflowId);
+    if (!workflow) {
+      throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
+    }
+    const deps = workflow.externalDependencies;
     if (!deps || deps.length === 0) {
-      throw new Error(`Task ${taskId} has no external dependencies`);
+      throw new Error(`Workflow ${workflowId} has no external dependencies`);
     }
     if (!updates.length) return [];
 
@@ -3448,7 +3458,7 @@ export class Orchestrator {
     const byKey = new Map<string, ExternalGatePolicyUpdate>();
     for (const update of updates) {
       if (update.gatePolicy !== 'completed' && update.gatePolicy !== 'review_ready') {
-        throw new Error(`Invalid gatePolicy "${String(update.gatePolicy)}" for task ${taskId}`);
+        throw new Error(`Invalid gatePolicy "${String(update.gatePolicy)}" for workflow ${workflowId}`);
       }
       byKey.set(keyOf(update.workflowId, update.taskId), update);
     }
@@ -3465,21 +3475,28 @@ export class Orchestrator {
 
     if (changed === 0) return [];
 
-    const policyChanges: TaskStateChanges = {
-      config: { externalDependencies: nextDeps },
-    };
-    const policyUpdated = this.writeAndSync(taskId, policyChanges);
-    const policyDelta: TaskDelta = this.buildUpdateDelta(task, policyUpdated, policyChanges);
-    this.persistence.logEvent?.(taskId, 'task.external_dependency_policy_updated', {
+    this.taskRepository.updateWorkflow(workflowId, { externalDependencies: nextDeps });
+    const eventTask = this.getMergeNode(workflowId) ?? this.stateMachine.getAllTasks().find((task) => task.config.workflowId === workflowId);
+    if (eventTask) this.persistence.logEvent?.(eventTask.id, 'workflow.external_dependency_policy_updated', {
       updates,
       changed,
     });
-    this.messageBus.publish(TASK_DELTA_CHANNEL, policyDelta);
 
     // Re-evaluate and auto-start anything newly unblocked by this policy change.
     const started = this.autoStartExternallyUnblockedReadyTasks();
     this.checkWorkflowCompletion();
     return started;
+  }
+
+  setTaskExternalGatePolicies(taskId: string, updates: ExternalGatePolicyUpdate[]): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+    const workflowId = task.config.workflowId;
+    if (!workflowId) {
+      throw new Error(`Task ${taskId} has no workflowId`);
+    }
+    return this.setWorkflowExternalGatePolicies(workflowId, updates);
   }
 
   forkWorkflow(workflowId: string, opts?: { autoStart?: boolean }): ForkWorkflowResult {
@@ -3522,6 +3539,12 @@ export class Orchestrator {
       if (typeof m.featureBranch === 'string') baseSaveWf.featureBranch = m.featureBranch;
       if (m.mergeMode === 'manual' || m.mergeMode === 'automatic' || m.mergeMode === 'external_review') {
         baseSaveWf.mergeMode = m.mergeMode;
+      }
+      if (Array.isArray(m.externalDependencies)) {
+        baseSaveWf.externalDependencies = m.externalDependencies as ExternalDependency[];
+      }
+      if (Array.isArray(m.externalDependencyChanges)) {
+        baseSaveWf.externalDependencyChanges = m.externalDependencyChanges as ExternalDependencyChange[];
       }
     }
     this.persistence.saveWorkflow(baseSaveWf);
@@ -4727,6 +4750,7 @@ export class Orchestrator {
   private enqueueIfNotScheduled(taskId: string, priority: number = 0): void {
     const task = this.stateGetTask(taskId);
     if (!task) return;
+    if (this.getExternalDependencyBlocker(task) !== undefined) return;
 
     const attemptId = this.ensureCurrentPendingAttempt(task);
     const currentAttempt = this.loadAttemptById(attemptId);
@@ -4777,7 +4801,6 @@ export class Orchestrator {
   autoStartExternallyUnblockedReadyTasks(): TaskState[] {
     const readyTasks = this.stateMachine
       .getReadyTasks()
-      .filter((task) => (task.config.externalDependencies?.length ?? 0) > 0)
       .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
 
     for (const task of readyTasks) {
@@ -4832,6 +4855,35 @@ export class Orchestrator {
     return normalizedTaskId === '__merge__' ? 'completed' : 'review_ready';
   }
 
+  private normalizePlanExternalDependencies(
+    deps: Array<{
+      workflowId: string;
+      taskId?: string;
+      requiredStatus?: 'completed';
+      gatePolicy?: 'completed' | 'review_ready';
+    }>,
+  ): ExternalDependency[] {
+    const byKey = new Map<string, ExternalDependency>();
+    for (const dep of deps) {
+      const workflowId = dep.workflowId?.trim();
+      if (!workflowId) continue;
+      const taskId = dep.taskId?.trim() || '__merge__';
+      const key = `${workflowId}::${taskId}`;
+      const existing = byKey.get(key);
+      const gatePolicy =
+        existing?.gatePolicy === 'completed' || dep.gatePolicy === 'completed'
+          ? 'completed'
+          : dep.gatePolicy ?? this.defaultExternalGatePolicy(taskId);
+      byKey.set(key, {
+        workflowId,
+        taskId,
+        requiredStatus: dep.requiredStatus ?? 'completed',
+        gatePolicy,
+      });
+    }
+    return Array.from(byKey.values());
+  }
+
   private findExternalDependencyTask(workflowId: string, taskId?: string): TaskState | undefined {
     const normalizedTaskId = taskId?.trim() || '__merge__';
     if (normalizedTaskId === '__merge__') {
@@ -4845,8 +4897,14 @@ export class Orchestrator {
     return tasks.find((t) => t.id === scopedId || t.id === normalizedTaskId);
   }
 
-  private getExternalDependencyBlocker(task: TaskState): string | undefined {
-    const deps = task.config.externalDependencies;
+  private getWorkflowExternalDependencies(workflowId: string): ExternalDependency[] {
+    const workflow = this.persistence.loadWorkflow?.(workflowId)
+      ?? this.persistence.listWorkflows().find((candidate) => candidate.id === workflowId);
+    return workflow?.externalDependencies ?? [];
+  }
+
+  private getWorkflowDependencyBlocker(workflowId: string): string | undefined {
+    const deps = this.getWorkflowExternalDependencies(workflowId);
     if (!deps || deps.length === 0) return undefined;
 
     for (const dep of deps) {
@@ -4873,18 +4931,22 @@ export class Orchestrator {
     return undefined;
   }
 
+  private getExternalDependencyBlocker(task: TaskState): string | undefined {
+    const workflowId = task.config.workflowId;
+    if (!workflowId) return undefined;
+    return this.getWorkflowDependencyBlocker(workflowId);
+  }
+
   private collectWorkflowDependencyEdges(): Map<string, Set<string>> {
     const edges = new Map<string, Set<string>>();
-    for (const task of this.stateMachine.getAllTasks()) {
-      const workflowId = task.config.workflowId;
-      if (!workflowId) continue;
-      for (const dep of task.config.externalDependencies ?? []) {
+    for (const workflow of this.persistence.listWorkflows()) {
+      for (const dep of workflow.externalDependencies ?? []) {
         let dependents = edges.get(dep.workflowId);
         if (!dependents) {
           dependents = new Set<string>();
           edges.set(dep.workflowId, dependents);
         }
-        dependents.add(workflowId);
+        dependents.add(workflow.id);
       }
     }
     return edges;
@@ -4994,23 +5056,12 @@ export class Orchestrator {
       throw new OrchestratorError(OrchestratorErrorCode.WORKFLOW_NOT_FOUND, `Workflow ${workflowId} not found`);
     }
 
-    let removedDependency = false;
-    for (const task of targetTasks) {
-      const deps = task.config.externalDependencies ?? [];
-      const nextDeps = deps.filter((dep) => dep.workflowId !== upstreamWorkflowId);
-      if (nextDeps.length === deps.length) continue;
-
-      removedDependency = true;
-      const changes: TaskStateChanges = {
-        config: { externalDependencies: nextDeps.length > 0 ? nextDeps : undefined },
-      };
-      const updated = this.writeAndSync(task.id, changes);
-      this.persistence.logEvent?.(task.id, 'task.external_dependency_detached', {
-        workflowId,
-        upstreamWorkflowId,
-      });
-      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(task, updated, changes));
-    }
+    const targetWorkflow = this.persistence.loadWorkflow?.(workflowId)
+      ?? this.persistence.listWorkflows().find((candidate) => candidate.id === workflowId);
+    const deps = targetWorkflow?.externalDependencies ?? [];
+    const removedDeps = deps.filter((dep) => dep.workflowId === upstreamWorkflowId);
+    const nextDeps = deps.filter((dep) => dep.workflowId !== upstreamWorkflowId);
+    const removedDependency = removedDeps.length > 0;
 
     if (!removedDependency) {
       throw new Error(
@@ -5018,9 +5069,36 @@ export class Orchestrator {
       );
     }
 
+    const now = workflowTimestamp().toISOString();
+    const existingChanges = targetWorkflow?.externalDependencyChanges ?? [];
+    const dependencyChanges: ExternalDependencyChange[] = [...existingChanges];
+    for (const dep of removedDeps) {
+      const taskId = dep.taskId?.trim() || '__merge__';
+      dependencyChanges.push({
+        before: { ...dep, taskId },
+        changedAt: now,
+      });
+    }
+    this.taskRepository.updateWorkflow(workflowId, {
+      externalDependencies: nextDeps.length > 0 ? nextDeps : undefined,
+      externalDependencyChanges: dependencyChanges,
+    });
+
+    const eventTask = this.getMergeNode(workflowId) ?? targetTasks[0];
+    this.persistence.logEvent?.(eventTask.id, 'workflow.external_dependency_changed', {
+      workflowId,
+      upstreamWorkflowId,
+      action: 'removed',
+      changes: dependencyChanges.slice(existingChanges.length),
+    });
+    this.persistence.logEvent?.(eventTask.id, 'task.external_dependency_changed', {
+      workflowId,
+      upstreamWorkflowId,
+      action: 'removed',
+    });
+
     const upstreamFeatureBranch = opts?.upstreamWorkflow?.featureBranch?.trim();
     const upstreamBaseBranch = opts?.upstreamWorkflow?.baseBranch?.trim();
-    const targetWorkflow = this.persistence.loadWorkflow?.(workflowId);
     const targetBaseBranch = targetWorkflow?.baseBranch?.trim();
     if (
       upstreamFeatureBranch
@@ -5078,6 +5156,15 @@ export class Orchestrator {
       if (!task || task.status !== 'pending') {
         this.logger.info('[orchestrator] drainScheduler: skipping non-pending task', {
           taskId: job.taskId,
+        });
+        job = this.scheduler.takeNext();
+        continue;
+      }
+      const workflowBlocker = this.getExternalDependencyBlocker(task);
+      if (workflowBlocker !== undefined) {
+        this.logger.info('[orchestrator] drainScheduler: skipping externally blocked workflow task', {
+          taskId: job.taskId,
+          blocker: workflowBlocker,
         });
         job = this.scheduler.takeNext();
         continue;

--- a/packages/workflow-core/src/plan-parser.ts
+++ b/packages/workflow-core/src/plan-parser.ts
@@ -222,11 +222,12 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       throw new PlanParseError(`Task "${task.id}" uses 'npx vitest run' which may not resolve correctly. Use 'pnpm test' instead.`);
     }
 
-    const taskExternalDependencies = parseExternalDependencies(`Task "${task.id}"`, task.externalDependencies);
-    const externalDependencies = mergeExternalDependencies(
-      (task.dependencies?.length ?? 0) === 0 ? topLevelExternalDependencies : undefined,
-      taskExternalDependencies,
-    );
+    if (task.externalDependencies !== undefined) {
+      throw new PlanParseError(
+        `Task "${task.id}" uses task-level "externalDependencies", which is no longer supported. ` +
+        'Put cross-workflow dependencies at the plan/workflow level.',
+      );
+    }
 
     return {
       id: task.id,
@@ -234,7 +235,6 @@ export function parsePlan(yamlContent: string): PlanDefinition {
       command: task.command,
       prompt: task.prompt,
       dependencies: task.dependencies ?? [],
-      externalDependencies,
       pivot: task.pivot,
       experimentVariants: task.experimentVariants?.map((variant) => ({
         id: variant.id ?? '',
@@ -261,6 +261,7 @@ export function parsePlan(yamlContent: string): PlanDefinition {
     reviewProvider,
     repoUrl: raw.repoUrl,
     intermediateRepoUrl: raw.intermediateRepoUrl,
+    externalDependencies: topLevelExternalDependencies,
     tasks,
   });
 }


### PR DESCRIPTION
## Summary

Moves parsed cross-workflow dependencies from task config into workflow metadata for new plans and mutations.

Migrates legacy task-level dependency JSON into workflow rows so existing databases retain their gates.

Updates scheduling, gate-policy edits, detach, and recreation flows to read workflow-level dependency state, and records removed workflow dependencies as `externalDependencyChanges` entries with a `before` value.

## Architecture

### Before

```mermaid
graph TD
    Plan[Plan YAML] --> TaskConfig[Task config externalDependencies]
    TaskConfig --> Scheduler[Task readiness]
    TaskConfig --> Detach[detachWorkflow]
```

### After

```mermaid
graph TD
    Plan[Plan YAML] --> WorkflowDeps[Workflow externalDependencies]
    WorkflowDeps --> Scheduler[Workflow readiness gate]
    WorkflowDeps --> GatePolicy[Workflow gate-policy mutation]
    Detach[detachWorkflow] --> WorkflowDeps
    Detach --> ChangeHistory[Workflow externalDependencyChanges before/after]
```

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run check:types`
- [x] `pnpm run check:deps`
- [x] `pnpm run check:required-builds`
- [x] `pnpm run check:large-files`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/plan-parser.test.ts`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/migrate-gate-policy.test.ts`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/orchestrator.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts src/__tests__/state-topology-matrix.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/lib/workflow-graph.test.ts src/__tests__/workflow-graph.test.tsx`

## Revert Plan

- Safe to revert? No
- Revert command: `git revert <sha>`
- Post-revert steps: Re-run SQLite migration and workflow scheduling regression tests before using existing workflow databases.
- Data migration? Yes, legacy task external dependencies are promoted to workflow metadata and task rows are cleared.