### PR TITLE
ExternalWorkflowDependencyMigration(1): Add workflow dependency metadata storage

### DIFF
--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -5,7 +5,7 @@
  * This allows swapping storage backends (in-memory, SQLite, etc.)
  */
 
-import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup } from '@invoker/workflow-core';
+import type { TaskState, TaskStateChanges, PlanDefinition, Attempt, WorkflowDerivedStatus, WorkflowRollup, ExternalDependency, ExternalDependencyChange } from '@invoker/workflow-core';
 import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
 
 // ── Conversation Types ─────────────────────────────────────
@@ -47,6 +47,8 @@ export interface Workflow {
   featureBranch?: string;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
   reviewProvider?: string;
+  externalDependencies?: ExternalDependency[];
+  externalDependencyChanges?: ExternalDependencyChange[];
   generation?: number;
   createdAt: string;
   updatedAt: string;
@@ -77,7 +79,7 @@ export interface WorkflowTaskSnapshot {
 export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: Workflow): void;
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'generation' | 'updatedAt'>>): void;
+  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'generation' | 'updatedAt'>>): void;
   loadWorkflow(workflowId: string): Workflow | undefined;
   listWorkflows(): Workflow[];
   searchWorkflowsAndTasks(query: string, opts?: SearchOptions): SearchResultItem[];

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -28,6 +28,8 @@ import type {
   TaskStatus,
   WorkflowRollup,
   WorkflowRollupTaskSummary,
+  ExternalDependency,
+  ExternalDependencyChange,
 } from '@invoker/workflow-core';
 import { DISPATCH_LEASE_MS } from '@invoker/contracts';
 import type { SearchResultItem, SearchOptions } from '@invoker/contracts';
@@ -582,6 +584,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
         feature_branch TEXT,
         merge_mode TEXT,
         review_provider TEXT,
+        external_dependencies TEXT,
+        external_dependency_changes TEXT,
         generation INTEGER DEFAULT 0,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
@@ -887,6 +891,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE tasks ADD COLUMN agent_session_id TEXT',
       'ALTER TABLE attempts ADD COLUMN agent_session_id TEXT',
       'ALTER TABLE workflows ADD COLUMN review_provider TEXT',
+      'ALTER TABLE workflows ADD COLUMN external_dependencies TEXT',
+      'ALTER TABLE workflows ADD COLUMN external_dependency_changes TEXT',
       // execution_agent / agent_name: interchangeable agent support
       'ALTER TABLE tasks ADD COLUMN execution_agent TEXT',
       'ALTER TABLE tasks ADD COLUMN agent_name TEXT',
@@ -960,6 +966,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
         feature_branch TEXT,
         merge_mode TEXT,
         review_provider TEXT,
+        external_dependencies TEXT,
+        external_dependency_changes TEXT,
         generation INTEGER DEFAULT 0,
         created_at TEXT DEFAULT (datetime('now')),
         updated_at TEXT DEFAULT (datetime('now'))
@@ -969,12 +977,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
       INSERT INTO workflows_new (
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
-        review_provider, generation, created_at, updated_at
+        review_provider, external_dependencies, external_dependency_changes,
+        generation, created_at, updated_at
       )
       SELECT
         id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url,
         branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode,
-        review_provider, generation, created_at, updated_at
+        review_provider, external_dependencies, external_dependency_changes,
+        generation, created_at, updated_at
       FROM workflows
     `);
     this.db.run('DROP TABLE workflows');
@@ -1052,8 +1062,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
   saveWorkflow(workflow: Workflow): void {
     this.execRun(`
-      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, generation, created_at, updated_at)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      INSERT OR REPLACE INTO workflows (id, name, description, visual_proof, plan_file, repo_url, intermediate_repo_url, branch, on_finish, base_branch, parent_remote, feature_branch, merge_mode, review_provider, external_dependencies, external_dependency_changes, generation, created_at, updated_at)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `, [
       workflow.id, workflow.name,
       workflow.description ?? null,
@@ -1062,12 +1072,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
       workflow.onFinish ?? null, workflow.baseBranch ?? null, null, workflow.featureBranch ?? null,
       workflow.mergeMode ?? null,
       workflow.reviewProvider ?? null,
+      workflow.externalDependencies ? JSON.stringify(workflow.externalDependencies) : null,
+      workflow.externalDependencyChanges ? JSON.stringify(workflow.externalDependencyChanges) : null,
       workflow.generation ?? 0,
       workflow.createdAt, workflow.updatedAt,
     ]);
   }
 
-  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'generation' | 'updatedAt'>>): void {
+  updateWorkflow(workflowId: string, changes: Partial<Pick<Workflow, 'name' | 'description' | 'visualProof' | 'planFile' | 'repoUrl' | 'intermediateRepoUrl' | 'branch' | 'onFinish' | 'baseBranch' | 'featureBranch' | 'mergeMode' | 'reviewProvider' | 'externalDependencies' | 'externalDependencyChanges' | 'generation' | 'updatedAt'>>): void {
     const setClauses: string[] = [];
     const values: unknown[] = [];
     const columnMap: Record<string, string> = {
@@ -1102,6 +1114,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
     }
     if (changes.mergeMode !== undefined) {
       // handled by columnMap; kept for backward-compatible patch shapes
+    }
+    if (changes.externalDependencies !== undefined) {
+      setClauses.push('external_dependencies = ?');
+      values.push(changes.externalDependencies ? JSON.stringify(changes.externalDependencies) : null);
+    }
+    if (changes.externalDependencyChanges !== undefined) {
+      setClauses.push('external_dependency_changes = ?');
+      values.push(changes.externalDependencyChanges ? JSON.stringify(changes.externalDependencyChanges) : null);
     }
     setClauses.push('updated_at = ?');
     values.push(changes.updatedAt ?? new Date().toISOString());
@@ -2433,6 +2453,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
       featureBranch: row.feature_branch ?? undefined,
       mergeMode: row.merge_mode ?? undefined,
       reviewProvider: row.review_provider ?? undefined,
+      externalDependencies: row.external_dependencies ? JSON.parse(row.external_dependencies) : undefined,
+      externalDependencyChanges: row.external_dependency_changes ? JSON.parse(row.external_dependency_changes) as ExternalDependencyChange[] : undefined,
       generation: row.generation ?? 0,
       createdAt: row.created_at,
       updatedAt: row.updated_at,

--- a/packages/test-kit/src/in-memory-persistence.ts
+++ b/packages/test-kit/src/in-memory-persistence.ts
@@ -1,5 +1,5 @@
 import { computeWorkflowRollup } from '@invoker/workflow-core';
-import type { TaskState, TaskStateChanges, OrchestratorPersistence, Attempt } from '@invoker/workflow-core';
+import type { TaskState, TaskStateChanges, OrchestratorPersistence, Attempt, ExternalDependency, ExternalDependencyChange } from '@invoker/workflow-core';
 
 /**
  * In-memory implementation of OrchestratorPersistence for testing.
@@ -11,6 +11,8 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     createdAt: string; updatedAt: string;
     onFinish?: string; baseBranch?: string; featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
     generation?: number;
   }>();
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
@@ -21,6 +23,8 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     createdAt?: string; updatedAt?: string;
     onFinish?: string; baseBranch?: string; featureBranch?: string;
     mergeMode?: 'manual' | 'automatic' | 'external_review';
+    externalDependencies?: ExternalDependency[];
+    externalDependencyChanges?: ExternalDependencyChange[];
     generation?: number;
   }): void {
     const now = new Date().toISOString();
@@ -31,13 +35,15 @@ export class InMemoryPersistence implements OrchestratorPersistence {
     });
   }
 
-  updateWorkflow(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review' }): void {
+  updateWorkflow(workflowId: string, changes: { updatedAt?: string; baseBranch?: string; generation?: number; mergeMode?: 'manual' | 'automatic' | 'external_review'; externalDependencies?: ExternalDependency[]; externalDependencyChanges?: ExternalDependencyChange[] }): void {
     const wf = this.workflows.get(workflowId);
     if (wf) {
       if (changes.updatedAt) wf.updatedAt = changes.updatedAt;
       if (changes.baseBranch !== undefined) wf.baseBranch = changes.baseBranch;
       if (changes.generation !== undefined) wf.generation = changes.generation;
       if (changes.mergeMode !== undefined) wf.mergeMode = changes.mergeMode;
+      if ('externalDependencies' in changes) wf.externalDependencies = changes.externalDependencies;
+      if ('externalDependencyChanges' in changes) wf.externalDependencyChanges = changes.externalDependencyChanges;
     }
   }
 

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -10,7 +10,7 @@
  * inside orchestrator.ts.
  */
 
-import type { TaskState, TaskStateChanges, Attempt, WorkflowDerivedStatus } from '@invoker/workflow-graph';
+import type { TaskState, TaskStateChanges, Attempt, WorkflowDerivedStatus, ExternalDependency, ExternalDependencyChange } from '@invoker/workflow-graph';
 
 // ── Workflow value types (inline in OrchestratorPersistence today) ────
 
@@ -27,6 +27,8 @@ export interface WorkflowRecord {
   baseBranch?: string;
   featureBranch?: string;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
+  externalDependencies?: ExternalDependency[];
+  externalDependencyChanges?: ExternalDependencyChange[];
 }
 
 export interface WorkflowChanges {
@@ -44,6 +46,8 @@ export interface WorkflowChanges {
   generation?: number;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
   reviewProvider?: string;
+  externalDependencies?: ExternalDependency[];
+  externalDependencyChanges?: ExternalDependencyChange[];
 }
 
 export type AttemptChanges = Partial<

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -96,6 +96,13 @@ export interface ExternalDependency {
   readonly gatePolicy?: 'completed' | 'review_ready';
 }
 
+export interface ExternalDependencyChange {
+  readonly before?: ExternalDependency;
+  readonly after?: ExternalDependency;
+  readonly changedAt: string;
+  readonly changedBy?: string;
+}
+
 // ── Task Execution (runtime state) ─────────────────────────
 // Never copied when cloning. Reset on restart.
 


### PR DESCRIPTION
## Summary

Adds workflow-level external dependency and dependency-change history fields to shared workflow types and persistence ports.

Persists `externalDependencies` and `externalDependencyChanges` on SQLite workflow rows and in-memory test stores without changing task-level scheduling behavior yet.

Uses `externalDependencyChanges` entries with optional `before` and `after` dependencies so additions, removals, and future replacements can be represented by the same metadata shape.

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run check:types`
- [x] `pnpm run check:deps`
- [x] `pnpm run check:required-builds`
- [x] `pnpm run check:large-files`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/plan-parser.test.ts`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/migrate-gate-policy.test.ts`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/orchestrator.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts src/__tests__/state-topology-matrix.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/lib/workflow-graph.test.ts src/__tests__/workflow-graph.test.tsx`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? Yes, this adds nullable SQLite workflow columns; reverting code leaves unused columns in existing databases.
