### PR TITLE
ExternalWorkflowDependencyMigration(3): Render workflow dependency lineage from metadata

### DIFF
--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -268,6 +268,8 @@ export function serializeWorkflow(wf: Workflow): Record<string, unknown> {
     ...(wf.featureBranch != null && { featureBranch: wf.featureBranch }),
     ...(wf.mergeMode != null && { mergeMode: wf.mergeMode }),
     ...(wf.reviewProvider != null && { reviewProvider: wf.reviewProvider }),
+    ...(wf.externalDependencies != null && { externalDependencies: wf.externalDependencies }),
+    ...(wf.externalDependencyChanges != null && { externalDependencyChanges: wf.externalDependencyChanges }),
     ...(wf.generation != null && { generation: wf.generation }),
   };
 }

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -11,8 +11,8 @@ vi.mock('@xyflow/react', async () => {
 
 const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
 
-function wf(id: string, status: WorkflowStatus): WorkflowMeta {
-  return { id, name: id, status };
+function wf(id: string, status: WorkflowStatus, overrides: Partial<WorkflowMeta> = {}): WorkflowMeta {
+  return { id, name: id, status, ...overrides };
 }
 
 function task(id: string, workflowId: string): TaskState {
@@ -107,6 +107,43 @@ describe('WorkflowGraph', () => {
 
     expect(screen.getByTestId('workflow-graph-react-flow')).toBeInTheDocument();
     expect(screen.getByTestId('mock-react-flow')).toBeInTheDocument();
+  });
+
+  it('renders dependency-change lineage edges separately from active dependency edges', () => {
+    const workflows = new Map([
+      ['wf-a', wf('wf-a', 'review_ready')],
+      [
+        'wf-b',
+        wf('wf-b', 'running', {
+          externalDependencyChanges: [
+            {
+              before: {
+                workflowId: 'wf-a',
+                taskId: '__merge__',
+                requiredStatus: 'completed',
+                gatePolicy: 'completed',
+              },
+              changedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      ],
+    ]);
+
+    render(
+      <WorkflowGraph
+        tasks={new Map()}
+        workflows={workflows}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    const edge = screen.getByTestId('rf__edge-workflow:historical:wf-a->wf-b');
+    expect(edge).toHaveAttribute('data-source', 'wf-a');
+    expect(edge).toHaveAttribute('data-target', 'wf-b');
   });
 
   it('re-fits after a non-empty workflow snapshot replacement', async () => {

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -114,19 +114,22 @@ function WorkflowGraphInner({
   }, [graph.nodes, positions, selectedWorkflowId, statusFilters]);
 
   const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => ({
-    id: `workflow:${edge.source}->${edge.target}`,
+    id: `workflow:${edge.kind}:${edge.source}->${edge.target}`,
     source: edge.source,
     target: edge.target,
     type: 'smoothstep',
     animated: false,
     style: {
-      stroke: 'rgba(148,163,184,0.55)',
-      strokeWidth: 2,
+      stroke: edge.kind === 'historical' ? 'rgba(245,158,11,0.5)' : 'rgba(148,163,184,0.55)',
+      strokeWidth: edge.kind === 'historical' ? 1.5 : 2,
+      strokeDasharray: edge.kind === 'historical' ? '6 6' : undefined,
     },
+    data: { kind: edge.kind },
+    ariaLabel: edge.kind === 'historical' ? 'Historical workflow dependency' : 'Active workflow dependency',
     zIndex: 0,
     markerEnd: {
       type: MarkerType.ArrowClosed,
-      color: 'rgba(148,163,184,0.55)',
+      color: edge.kind === 'historical' ? 'rgba(245,158,11,0.5)' : 'rgba(148,163,184,0.55)',
       width: 16,
       height: 16,
     },
@@ -134,7 +137,7 @@ function WorkflowGraphInner({
 
   const graphSignature = useMemo(() => {
     const nodeIds = graph.nodes.map((node) => node.id).join('|');
-    const edgeIds = graph.edges.map((edge) => `${edge.source}->${edge.target}`).join('|');
+    const edgeIds = graph.edges.map((edge) => `${edge.kind}:${edge.source}->${edge.target}`).join('|');
     return `${nodeIds}::${edgeIds}`;
   }, [graph.edges, graph.nodes]);
 

--- a/packages/ui/src/lib/workflow-graph.test.ts
+++ b/packages/ui/src/lib/workflow-graph.test.ts
@@ -6,28 +6,26 @@ function makeWorkflow(
   id: string,
   status: WorkflowMeta['status'] = 'running',
   createdAt?: string,
+  externalDependencies: WorkflowMeta['externalDependencies'] = [],
+  externalDependencyChanges: WorkflowMeta['externalDependencyChanges'] = [],
 ): WorkflowMeta {
-  return { id, name: id, status, createdAt };
+  return {
+    id,
+    name: id,
+    status,
+    createdAt,
+    externalDependencies,
+    externalDependencyChanges,
+  };
 }
 
-function makeTask(
-  id: string,
-  workflowId: string,
-  externalDependencies: Array<{ workflowId: string; taskId?: string }> = [],
-): TaskState {
+function makeTask(id: string, workflowId: string): TaskState {
   return {
     id,
     description: id,
     status: 'pending',
     dependencies: [],
-    config: {
-      workflowId,
-      externalDependencies: externalDependencies.map((dep) => ({
-        workflowId: dep.workflowId,
-        taskId: dep.taskId,
-        requiredStatus: 'completed' as const,
-      })),
-    },
+    config: { workflowId },
     execution: {},
     taskStateVersion: 1,
   };
@@ -37,49 +35,49 @@ describe('deriveWorkflowGraph', () => {
   it('derives linear stack edges', () => {
     const workflows = new Map([
       ['A', makeWorkflow('A')],
-      ['B', makeWorkflow('B')],
-      ['C', makeWorkflow('C')],
+      ['B', makeWorkflow('B', 'running', undefined, [{ workflowId: 'A' }])],
+      ['C', makeWorkflow('C', 'running', undefined, [{ workflowId: 'B' }])],
     ]);
     const tasks = new Map<string, TaskState>([
-      ['b1', makeTask('b1', 'B', [{ workflowId: 'A' }])],
-      ['c1', makeTask('c1', 'C', [{ workflowId: 'B' }])],
+      ['b1', makeTask('b1', 'B')],
+      ['c1', makeTask('c1', 'C')],
     ]);
 
     const graph = deriveWorkflowGraph(workflows, tasks);
     expect(graph.edges).toEqual([
-      { source: 'A', target: 'B' },
-      { source: 'B', target: 'C' },
+      { source: 'A', target: 'B', kind: 'active' },
+      { source: 'B', target: 'C', kind: 'active' },
     ]);
   });
 
   it('supports fork and fan-in', () => {
     const workflows = new Map([
       ['A', makeWorkflow('A')],
-      ['B', makeWorkflow('B')],
-      ['C', makeWorkflow('C')],
-      ['D', makeWorkflow('D')],
+      ['B', makeWorkflow('B', 'running', undefined, [{ workflowId: 'A' }])],
+      ['C', makeWorkflow('C', 'running', undefined, [{ workflowId: 'A' }])],
+      ['D', makeWorkflow('D', 'running', undefined, [{ workflowId: 'B' }, { workflowId: 'C' }])],
     ]);
     const tasks = new Map<string, TaskState>([
-      ['b1', makeTask('b1', 'B', [{ workflowId: 'A' }])],
-      ['c1', makeTask('c1', 'C', [{ workflowId: 'A' }])],
-      ['d1', makeTask('d1', 'D', [{ workflowId: 'B' }, { workflowId: 'C' }])],
+      ['b1', makeTask('b1', 'B')],
+      ['c1', makeTask('c1', 'C')],
+      ['d1', makeTask('d1', 'D')],
     ]);
 
     const graph = deriveWorkflowGraph(workflows, tasks);
     expect(graph.edges).toEqual([
-      { source: 'A', target: 'B' },
-      { source: 'A', target: 'C' },
-      { source: 'B', target: 'D' },
-      { source: 'C', target: 'D' },
+      { source: 'A', target: 'B', kind: 'active' },
+      { source: 'A', target: 'C', kind: 'active' },
+      { source: 'B', target: 'D', kind: 'active' },
+      { source: 'C', target: 'D', kind: 'active' },
     ]);
   });
 
   it('collects missing external dependencies without crashing', () => {
     const workflows = new Map([
-      ['B', makeWorkflow('B')],
+      ['B', makeWorkflow('B', 'running', undefined, [{ workflowId: 'missing' }])],
     ]);
     const tasks = new Map<string, TaskState>([
-      ['b1', makeTask('b1', 'B', [{ workflowId: 'missing' }])],
+      ['b1', makeTask('b1', 'B')],
     ]);
 
     const graph = deriveWorkflowGraph(workflows, tasks);
@@ -97,6 +95,86 @@ describe('deriveWorkflowGraph', () => {
     expect(graph.nodes.map((node) => node.id)).toEqual(['A', 'B']);
     expect(graph.edges).toEqual([]);
   });
+
+  it('derives dependency-change lineage separately from active dependency edges', () => {
+    const workflows = new Map([
+      ['A', makeWorkflow('A')],
+      [
+        'B',
+        makeWorkflow('B', 'running', undefined, [], [
+          {
+            before: {
+              workflowId: 'A',
+              taskId: '__merge__',
+              requiredStatus: 'completed',
+              gatePolicy: 'completed',
+            },
+            changedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ]),
+      ],
+    ]);
+
+    const graph = deriveWorkflowGraph(workflows, new Map());
+
+    expect(graph.edges).toEqual([
+      { source: 'A', target: 'B', kind: 'historical' },
+    ]);
+  });
+
+  it('does not duplicate active edges for dependency addition history', () => {
+    const dependency = {
+      workflowId: 'A',
+      taskId: '__merge__',
+      requiredStatus: 'completed' as const,
+      gatePolicy: 'completed' as const,
+    };
+    const workflows = new Map([
+      ['A', makeWorkflow('A')],
+      [
+        'B',
+        makeWorkflow('B', 'running', undefined, [dependency], [
+          {
+            after: dependency,
+            changedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ]),
+      ],
+    ]);
+
+    const graph = deriveWorkflowGraph(workflows, new Map());
+
+    expect(graph.edges).toEqual([
+      { source: 'A', target: 'B', kind: 'active' },
+    ]);
+  });
+
+  it('derives both sides of a dependency replacement history', () => {
+    const before = {
+      workflowId: 'A',
+      taskId: '__merge__',
+      requiredStatus: 'completed' as const,
+      gatePolicy: 'completed' as const,
+    };
+    const after = {
+      workflowId: 'C',
+      taskId: '__merge__',
+      requiredStatus: 'completed' as const,
+      gatePolicy: 'completed' as const,
+    };
+    const workflows = new Map([
+      ['A', makeWorkflow('A')],
+      ['B', makeWorkflow('B', 'running', undefined, [], [{ before, after, changedAt: '2026-01-01T00:00:00.000Z' }])],
+      ['C', makeWorkflow('C')],
+    ]);
+
+    const graph = deriveWorkflowGraph(workflows, new Map());
+
+    expect(graph.edges).toEqual([
+      { source: 'A', target: 'B', kind: 'historical' },
+      { source: 'C', target: 'B', kind: 'historical' },
+    ]);
+  });
 });
 
 describe('layoutWorkflowGraph', () => {
@@ -107,7 +185,7 @@ describe('layoutWorkflowGraph', () => {
         makeWorkflow('chain-b', 'running', '2026-01-01T00:00:00.000Z'),
         makeWorkflow('solo', 'running', '2026-02-01T00:00:00.000Z'),
       ],
-      [{ source: 'chain-a', target: 'chain-b' }],
+      [{ source: 'chain-a', target: 'chain-b', kind: 'active' }],
     );
 
     const positions = layoutWorkflowGraph(graph, 100, 50, 25);
@@ -126,8 +204,8 @@ describe('layoutWorkflowGraph', () => {
         makeWorkflow('newer-b', 'running', '2026-03-01T00:00:00.000Z'),
       ],
       [
-        { source: 'older-a', target: 'older-b' },
-        { source: 'newer-a', target: 'newer-b' },
+        { source: 'older-a', target: 'older-b', kind: 'active' },
+        { source: 'newer-a', target: 'newer-b', kind: 'active' },
       ],
     );
 
@@ -166,9 +244,9 @@ describe('layoutWorkflowGraph', () => {
         makeWorkflow('older', 'running', '2026-01-01T00:00:00.000Z'),
       ],
       [
-        { source: 'root', target: 'left' },
-        { source: 'root', target: 'middle' },
-        { source: 'root', target: 'right' },
+        { source: 'root', target: 'left', kind: 'active' },
+        { source: 'root', target: 'middle', kind: 'active' },
+        { source: 'root', target: 'right', kind: 'active' },
       ],
     );
 
@@ -187,7 +265,7 @@ describe('layoutWorkflowGraph', () => {
         makeWorkflow('fix-step-2', 'running', '2026-01-01T00:00:00.000Z'),
         { ...makeWorkflow('cost-query', 'running', '2026-02-01T00:00:00.000Z'), name: 'Cost Query' },
       ],
-      [{ source: 'fix-step-1', target: 'fix-step-2' }],
+      [{ source: 'fix-step-1', target: 'fix-step-2', kind: 'active' }],
     );
 
     const positions = layoutWorkflowGraph(graph, 100, 50, 25);
@@ -207,10 +285,10 @@ describe('layoutWorkflowGraph', () => {
         makeWorkflow('z-join'),
       ],
       [
-        { source: 'a-root', target: 'y-target' },
-        { source: 'b-root', target: 'x-target' },
-        { source: 'x-target', target: 'z-join' },
-        { source: 'y-target', target: 'z-join' },
+        { source: 'a-root', target: 'y-target', kind: 'active' },
+        { source: 'b-root', target: 'x-target', kind: 'active' },
+        { source: 'x-target', target: 'z-join', kind: 'active' },
+        { source: 'y-target', target: 'z-join', kind: 'active' },
       ],
     );
 

--- a/packages/ui/src/lib/workflow-graph.ts
+++ b/packages/ui/src/lib/workflow-graph.ts
@@ -9,6 +9,7 @@ export interface WorkflowGraphNode {
 export interface WorkflowGraphEdge {
   source: string;
   target: string;
+  kind: 'active' | 'historical';
 }
 
 export interface WorkflowGraph {
@@ -36,21 +37,37 @@ export function deriveWorkflowGraph(
   const edges: WorkflowGraphEdge[] = [];
   const missingDependencies = new Set<string>();
 
-  for (const task of tasks.values()) {
-    const targetWorkflowId = task.config.workflowId;
-    if (!targetWorkflowId) continue;
-    const deps = task.config.externalDependencies ?? [];
-    for (const dep of deps) {
+  void tasks;
+
+  for (const workflow of workflows.values()) {
+    const targetWorkflowId = workflow.id;
+    for (const dep of workflow.externalDependencies ?? []) {
       const sourceWorkflowId = dep.workflowId;
       if (!workflows.has(sourceWorkflowId)) {
         missingDependencies.add(`${sourceWorkflowId}->${targetWorkflowId}`);
         continue;
       }
       if (sourceWorkflowId === targetWorkflowId) continue;
-      const key = `${sourceWorkflowId}->${targetWorkflowId}`;
+      const key = `active:${sourceWorkflowId}->${targetWorkflowId}`;
       if (edgeKeys.has(key)) continue;
       edgeKeys.add(key);
-      edges.push({ source: sourceWorkflowId, target: targetWorkflowId });
+      edges.push({ source: sourceWorkflowId, target: targetWorkflowId, kind: 'active' });
+    }
+    for (const change of workflow.externalDependencyChanges ?? []) {
+      for (const dependency of [change.before, change.after]) {
+        if (!dependency) continue;
+        const sourceWorkflowId = dependency.workflowId;
+        if (!workflows.has(sourceWorkflowId)) {
+          missingDependencies.add(`${sourceWorkflowId}->${targetWorkflowId}`);
+          continue;
+        }
+        if (sourceWorkflowId === targetWorkflowId) continue;
+        if (edgeKeys.has(`active:${sourceWorkflowId}->${targetWorkflowId}`)) continue;
+        const key = `historical:${sourceWorkflowId}->${targetWorkflowId}`;
+        if (edgeKeys.has(key)) continue;
+        edgeKeys.add(key);
+        edges.push({ source: sourceWorkflowId, target: targetWorkflowId, kind: 'historical' });
+      }
     }
   }
 

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -43,6 +43,13 @@ export interface ExternalDependency {
   readonly gatePolicy?: 'completed' | 'review_ready';
 }
 
+export interface ExternalDependencyChange {
+  readonly before?: ExternalDependency;
+  readonly after?: ExternalDependency;
+  readonly changedAt: string;
+  readonly changedBy?: string;
+}
+
 export interface ExternalGatePolicyUpdate {
   workflowId: string;
   taskId?: string;
@@ -162,6 +169,8 @@ export interface WorkflowMeta {
   repoUrl?: string;
   intermediateRepoUrl?: string;
   reviewProvider?: string;
+  externalDependencies?: readonly ExternalDependency[];
+  externalDependencyChanges?: readonly ExternalDependencyChange[];
   createdAt?: string;
   updatedAt?: string;
 }
@@ -251,6 +260,7 @@ export interface PlanDefinition {
   onFinish?: 'none' | 'merge' | 'pull_request';
   baseBranch?: string;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
+  externalDependencies?: ExternalDependency[];
 }
 
 // ── Task Replacement ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Serializes workflow external dependencies and dependency-change history so the UI receives workflow-owned dependency metadata.

Derives active workflow graph edges from `externalDependencies` and historical edges from both sides of `externalDependencyChanges`, while avoiding duplicate historical edges for dependencies that are currently active.

## Architecture

### Before

```mermaid
graph TD
    TaskConfig[Task config externalDependencies] --> Graph[Workflow graph edges]
```

### After

```mermaid
graph TD
    WorkflowDeps[Workflow externalDependencies] --> ActiveGraph[Active graph edges]
    ChangeHistory[Workflow externalDependencyChanges before/after] --> HistoricalGraph[Historical dependency edges]
```

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run check:types`
- [x] `pnpm run check:deps`
- [x] `pnpm run check:required-builds`
- [x] `pnpm run check:large-files`
- [x] `pnpm --filter @invoker/ui build`
- [x] `pnpm --filter @invoker/app build`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/plan-parser.test.ts`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/migrate-gate-policy.test.ts`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/orchestrator.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts src/__tests__/state-topology-matrix.test.ts`
- [x] `pnpm --filter @invoker/ui exec vitest run src/lib/workflow-graph.test.ts src/__tests__/workflow-graph.test.tsx`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <sha>`
- Post-revert steps: None
- Data migration? No