### PR TITLE
Fix intent cancellation Step 2: fix flow lineage guards (regression gated v2)

### DIFF
--- a/packages/app/src/__tests__/resolve-conflict-action.test.ts
+++ b/packages/app/src/__tests__/resolve-conflict-action.test.ts
@@ -11,6 +11,7 @@ import type { SQLiteAdapter } from '@invoker/data-store';
 import { resolveConflictAction } from '../workflow-actions.js';
 
 describe('resolveConflictAction', () => {
+  const lineage = { taskId: 'task-a', selectedAttemptId: 'att-1', generation: 1 };
   let orchestrator: {
     getTask: ReturnType<typeof vi.fn>;
     beginConflictResolution: ReturnType<typeof vi.fn>;
@@ -49,9 +50,9 @@ describe('resolveConflictAction', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a', lineage);
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', 'saved-err', undefined);
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err', lineage);
     expect(orchestrator.revertConflictResolution).not.toHaveBeenCalled();
     expect(persistence.appendTaskOutput).not.toHaveBeenCalled();
   });
@@ -77,7 +78,7 @@ describe('resolveConflictAction', () => {
       autoApproveAIFixes: true,
     });
 
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'saved-err', lineage);
     expect(approve).toHaveBeenCalledWith('task-a');
     expect(taskExecutorWithApprove.executeTasks).not.toHaveBeenCalled();
     expect(taskExecutorWithApprove.publishAfterFix).not.toHaveBeenCalled();
@@ -102,6 +103,7 @@ describe('resolveConflictAction', () => {
       'task-a',
       'saved-err',
       'claude failed',
+      lineage,
     );
     expect(orchestrator.setFixAwaitingApproval).not.toHaveBeenCalled();
   });

--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -795,7 +795,11 @@ describe('autoFixOnFailure', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a', {
+      taskId: 'task-a',
+      selectedAttemptId: undefined,
+      generation: 0,
+    });
     expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'claude', 'boom');
     expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
@@ -886,7 +890,11 @@ describe('autoFixOnFailure', () => {
       taskExecutor: taskExecutor as unknown as TaskRunner,
     });
 
-    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a');
+    expect(orchestrator.beginConflictResolution).toHaveBeenCalledWith('task-a', {
+      taskId: 'task-a',
+      selectedAttemptId: undefined,
+      generation: 0,
+    });
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
     expect(orchestrator.retryTask).toHaveBeenCalledWith('task-a');
@@ -1340,7 +1348,11 @@ describe('fixWithAgentAction', () => {
 
     expect(taskExecutor.fixWithAgent).toHaveBeenCalledWith('task-a', 'test output', 'codex', 'boom');
     expect(taskExecutor.resolveConflict).not.toHaveBeenCalled();
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom', {
+      taskId: 'task-a',
+      selectedAttemptId: undefined,
+      generation: 0,
+    });
     expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
   });
 
@@ -1379,7 +1391,11 @@ describe('fixWithAgentAction', () => {
 
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError);
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError, {
+      taskId: 'task-a',
+      selectedAttemptId: undefined,
+      generation: 0,
+    });
     expect(result).toEqual({ kind: 'resolveConflict', autoApproved: false, started: [] });
   });
 
@@ -1414,7 +1430,11 @@ describe('fixWithAgentAction', () => {
 
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError);
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError, {
+      taskId: 'task-a',
+      selectedAttemptId: undefined,
+      generation: 0,
+    });
     expect(result).toEqual({ kind: 'resolveConflict', autoApproved: false, started: [] });
   });
 
@@ -2415,7 +2435,11 @@ describe('fixWithAgentAction lineage guard', () => {
     });
 
     // Normal path should proceed
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', 'boom', {
+      taskId: 'task-a',
+      selectedAttemptId: 'att-1',
+      generation: 5,
+    });
     expect(result).toEqual({ kind: 'fixWithAgent', autoApproved: false, started: [] });
   });
 });
@@ -2516,7 +2540,7 @@ describe('autoFixOnFailure lineage guard', () => {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => {
         getTaskCallCount++;
-        if (getTaskCallCount <= 4) {
+        if (getTaskCallCount <= 5) {
           return makeTask({
             status: 'failed',
             config: { workflowId: 'wf-1' },
@@ -2537,7 +2561,10 @@ describe('autoFixOnFailure lineage guard', () => {
         });
       }),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginConflictResolution: vi.fn(() => ({
+        savedError: 'boom',
+        lineage: { taskId: 'task-a', selectedAttemptId: 'att-1', generation: 5 },
+      })),
       setFixAwaitingApproval: vi.fn(),
       retryTask: vi.fn(() => []),
       revertConflictResolution: vi.fn(),
@@ -2570,7 +2597,7 @@ describe('autoFixOnFailure lineage guard', () => {
       shouldAutoFix: vi.fn(() => true),
       getTask: vi.fn(() => {
         getTaskCallCount++;
-        if (getTaskCallCount <= 4) {
+        if (getTaskCallCount <= 5) {
           return makeTask({
             status: 'failed',
             config: { workflowId: 'wf-1' },
@@ -2590,7 +2617,10 @@ describe('autoFixOnFailure lineage guard', () => {
         });
       }),
       getAutoFixRetryBudget: vi.fn(() => 3),
-      beginConflictResolution: vi.fn(() => ({ savedError: 'boom' })),
+      beginConflictResolution: vi.fn(() => ({
+        savedError: 'boom',
+        lineage: { taskId: 'task-a', selectedAttemptId: 'att-1', generation: 5 },
+      })),
       setFixAwaitingApproval: vi.fn(),
       retryTask: vi.fn(() => []),
       revertConflictResolution: vi.fn(),
@@ -2736,7 +2766,11 @@ describe('autoFixOnReviewGateFailure', () => {
       expect.stringContaining('This auto-fix was triggered by failed CI'),
     );
     expect(taskExecutor.fixWithAgent.mock.calls[0]?.[4]).toContain('test-all');
-    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('merge-a', 'Review-gate CI failed');
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('merge-a', 'Review-gate CI failed', {
+      taskId: 'merge-a',
+      selectedAttemptId: 'att-1',
+      generation: 7,
+    });
   });
 
   it('does not start when review-gate lineage is stale', async () => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -125,6 +125,8 @@ import {
   deleteAllWorkflows as sharedDeleteAllWorkflows,
   deleteAllWorkflowsBulk as sharedDeleteAllWorkflowsBulk,
   fixWithAgentAction,
+  assertLineageCurrent,
+  captureTaskLineage,
   rebaseRetry,
   rebaseRecreate,
   recreateWorkflow as sharedRecreateWorkflow,
@@ -1599,6 +1601,8 @@ function createEmbeddedTerminalBackendFromConfig(
     if (!task) {
       throw new Error(`Task ${taskId} not found`);
     }
+    const entryLineage = captureTaskLineage(taskId, orchestrator);
+    assertLineageCurrent(entryLineage, orchestrator, activeMutationContext?.signal);
     const savedError = task.execution.error ?? '';
     const recoveryRoute = selectFailureRecoveryRoute(task, savedError);
     logger.info(
@@ -1607,6 +1611,7 @@ function createEmbeddedTerminalBackendFromConfig(
     );
 
     if (source === 'auto-fix') {
+      assertLineageCurrent(entryLineage, orchestrator, activeMutationContext?.signal);
       const attemptsBefore = task?.execution.autoFixAttempts ?? 0;
       const attemptsAfter = attemptsBefore + 1;
       persistence.updateTask(taskId, {

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -61,7 +61,7 @@ export function captureTaskLineage(
 ): TaskLineageSnapshot {
   const task = orchestrator.getTask(taskId);
   return {
-    taskId,
+    taskId: task?.id ?? taskId,
     selectedAttemptId: task?.execution.selectedAttemptId,
     generation: task?.execution.generation ?? 0,
   };
@@ -809,8 +809,9 @@ export async function resolveConflictAction(
   const { orchestrator, persistence, taskExecutor } = deps;
   const entryLineage = captureTaskLineage(taskId, orchestrator);
   assertLineageCurrent(entryLineage, orchestrator, signal);
-  const { savedError } = orchestrator.beginConflictResolution(taskId);
-  const lineage = captureTaskLineage(taskId, orchestrator);
+  const beginResult = orchestrator.beginConflictResolution(taskId, entryLineage);
+  const { savedError } = beginResult;
+  const lineage = beginResult.lineage ?? captureTaskLineage(taskId, orchestrator);
   try {
     assertLineageCurrent(lineage, orchestrator, signal);
     await taskExecutor.resolveConflict(taskId, savedError, agentName);
@@ -822,7 +823,7 @@ export async function resolveConflictAction(
     assertLineageCurrent(lineage, orchestrator, signal);
     persistence.appendTaskOutput(taskId, `\n[Resolve Conflict] Failed: ${msg}`);
     assertLineageCurrent(lineage, orchestrator, signal);
-    orchestrator.revertConflictResolution(taskId, savedError, msg);
+    orchestrator.revertConflictResolution(taskId, savedError, msg, lineage);
     throw err;
   }
 }
@@ -865,8 +866,9 @@ export async function fixWithAgentAction(
 
   const entryLineage = captureTaskLineage(taskId, orchestrator);
   assertLineageCurrent(entryLineage, orchestrator, options.signal);
-  const { savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId);
-  const lineage = captureTaskLineage(taskId, orchestrator);
+  const beginResult = orchestrator.beginConflictResolution(taskId, entryLineage);
+  const persistedSavedError = beginResult.savedError;
+  const lineage = beginResult.lineage ?? captureTaskLineage(taskId, orchestrator);
   try {
     assertLineageCurrent(lineage, orchestrator, options.signal);
     if (recoveryRoute.kind === 'resolveConflict') {
@@ -890,7 +892,7 @@ export async function fixWithAgentAction(
     assertLineageCurrent(lineage, orchestrator, options.signal);
     persistence.appendTaskOutput(taskId, `\n[${errorLabel}] Failed: ${msg}`);
     assertLineageCurrent(lineage, orchestrator, options.signal);
-    orchestrator.revertConflictResolution(taskId, persistedSavedError, msg);
+    orchestrator.revertConflictResolution(taskId, persistedSavedError, msg, lineage);
     throw err;
   }
 }
@@ -908,7 +910,12 @@ export async function finalizeAppliedFix(
     );
   }
   if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
-  deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
+  if (lineage) {
+    deps.orchestrator.setFixAwaitingApproval(taskId, savedError, lineage);
+  } else {
+    deps.orchestrator.setFixAwaitingApproval(taskId, savedError);
+  }
+  if (lineage) assertLineageCurrent(lineage, deps.orchestrator, signal);
   if (!deps.autoApproveAIFixes) {
     return { autoApproved: false, started: [] };
   }
@@ -1168,8 +1175,13 @@ export async function autoFixOnFailure(
       return;
     }
 
-    ({ savedError: persistedSavedError } = orchestrator.beginConflictResolution(taskId));
-    lineage = captureTaskLineage(taskId, orchestrator);
+    assertLineageCurrent(entryLineage, orchestrator, deps.signal);
+    {
+      const beginResult = orchestrator.beginConflictResolution(taskId, entryLineage);
+      persistedSavedError = beginResult.savedError;
+      lineage = beginResult.lineage ?? captureTaskLineage(taskId, orchestrator);
+    }
+    if (!lineage) throw new StaleLineageError(`Auto-fix for ${taskId} did not create a fix lineage`);
     assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'auto-fix-begin-conflict-resolution',
@@ -1251,7 +1263,7 @@ export async function autoFixOnFailure(
     const detailedMsg = diagnostics ? `${msg}\n\n${diagnostics}` : msg;
     if (persistedSavedError !== undefined) {
       if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
-      orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg);
+      orchestrator.revertConflictResolution(taskId, persistedSavedError, detailedMsg, lineage);
     }
   }
 }
@@ -1349,15 +1361,19 @@ export async function autoFixOnReviewGateFailure(
   let persistedSavedError: string | undefined;
   let lineage: TaskLineageSnapshot | undefined;
   try {
-    ({ savedError: persistedSavedError } = orchestrator.beginAutoFixSession(trigger.taskId, {
-      savedError,
-      expectedLineage: {
-        taskId: trigger.taskId,
-        selectedAttemptId: trigger.selectedAttemptId,
-        generation: trigger.generation,
-      },
-    }));
-    lineage = captureTaskLineage(trigger.taskId, orchestrator);
+    {
+      const beginResult = orchestrator.beginAutoFixSession(trigger.taskId, {
+        savedError,
+        expectedLineage: {
+          taskId: trigger.taskId,
+          selectedAttemptId: trigger.selectedAttemptId,
+          generation: trigger.generation,
+        },
+      });
+      persistedSavedError = beginResult.savedError;
+      lineage = beginResult.lineage ?? captureTaskLineage(trigger.taskId, orchestrator);
+    }
+    if (!lineage) throw new StaleLineageError(`Review-gate CI auto-fix for ${trigger.taskId} did not create a fix lineage`);
     assertLineageCurrent(lineage, orchestrator, deps.signal);
     persistence.logEvent?.(trigger.taskId, 'debug.auto-fix', {
       phase: 'review-gate-ci-auto-fix-start',
@@ -1405,7 +1421,7 @@ export async function autoFixOnReviewGateFailure(
     );
     if (persistedSavedError !== undefined) {
       if (lineage) assertLineageCurrent(lineage, orchestrator, deps.signal);
-      orchestrator.revertConflictResolution(trigger.taskId, persistedSavedError, msg);
+      orchestrator.revertConflictResolution(trigger.taskId, persistedSavedError, msg, lineage);
     }
   }
 }

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -637,6 +637,23 @@ describe('Orchestrator', () => {
       expect(savedError).toBe(mergeConflictError);
     });
 
+    it('beginConflictResolution rejects stale expected lineage without changing task state', () => {
+      const task = orchestrator.getTask('t2')!;
+
+      expect(() => orchestrator.beginConflictResolution('t2', {
+        taskId: 't2',
+        selectedAttemptId: 'stale-attempt',
+        generation: task.execution.generation ?? 0,
+      })).toThrow('lineage is stale');
+
+      const after = orchestrator.getTask('t2')!;
+      expect(after.status).toBe('failed');
+      expect(after.execution.error).toBe(mergeConflictError);
+      expect(after.execution.selectedAttemptId).toBe(task.execution.selectedAttemptId);
+      expect(after.execution.generation ?? 0).toBe(task.execution.generation ?? 0);
+      expect(publishedDeltas).toHaveLength(0);
+    });
+
     it('revertConflictResolution restores failed state with mergeConflict', () => {
       const { savedError } = orchestrator.beginConflictResolution('t2');
       const fixAttemptId = orchestrator.getTask('t2')!.execution.selectedAttemptId;
@@ -662,6 +679,40 @@ describe('Orchestrator', () => {
           d.changes.status === 'failed',
       );
       expect(failedDeltas).toHaveLength(1);
+    });
+
+    it('revertConflictResolution no-ops when the fix-session lineage is stale', () => {
+      const { savedError } = orchestrator.beginConflictResolution('t2');
+      const staleFixTask = orchestrator.getTask('t2')!;
+      const staleLineage = {
+        taskId: staleFixTask.id,
+        selectedAttemptId: staleFixTask.execution.selectedAttemptId,
+        generation: staleFixTask.execution.generation ?? 0,
+      };
+      persistence.updateTask('t2', {
+        status: 'running',
+        execution: {
+          selectedAttemptId: 'newer-attempt',
+          generation: staleLineage.generation + 1,
+          branch: 'newer-branch',
+          workspacePath: '/tmp/newer-workspace',
+          agentSessionId: 'newer-session',
+          error: 'newer execution error',
+        },
+      });
+
+      publishedDeltas = [];
+      orchestrator.revertConflictResolution('t2', savedError, 'late agent failure', staleLineage);
+
+      const task = orchestrator.getTask('t2')!;
+      expect(task.status).toBe('running');
+      expect(task.execution.error).toBe('newer execution error');
+      expect(task.execution.branch).toBe('newer-branch');
+      expect(task.execution.workspacePath).toBe('/tmp/newer-workspace');
+      expect(task.execution.agentSessionId).toBe('newer-session');
+      expect(task.execution.selectedAttemptId).toBe('newer-attempt');
+      expect(task.execution.generation).toBe(staleLineage.generation + 1);
+      expect(publishedDeltas).toHaveLength(0);
     });
 
     it('revertConflictResolution uses agent-agnostic fix failure prefix', () => {
@@ -780,6 +831,39 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('f2')!.execution.agentSessionId).toBe('sess-fix-1');
       expect(orchestrator.getTask('f2')!.execution.lastAgentSessionId).toBe('sess-fix-1');
       expect(orchestrator.getTask('f2')!.execution.lastAgentName).toBe('codex');
+    });
+
+    it('setFixAwaitingApproval no-ops when the fix-session lineage is stale', () => {
+      orchestrator.beginConflictResolution('f2');
+      const staleFixTask = orchestrator.getTask('f2')!;
+      const staleLineage = {
+        taskId: staleFixTask.id,
+        selectedAttemptId: staleFixTask.execution.selectedAttemptId,
+        generation: staleFixTask.execution.generation ?? 0,
+      };
+      persistence.updateTask('f2', {
+        status: 'running',
+        execution: {
+          selectedAttemptId: 'newer-fix-attempt',
+          generation: staleLineage.generation + 1,
+          branch: 'newer-fix-branch',
+          workspacePath: '/tmp/newer-fix-workspace',
+          agentSessionId: 'newer-fix-session',
+        },
+      });
+
+      publishedDeltas = [];
+      orchestrator.setFixAwaitingApproval('f2', 'test failed: expected 1 to be 2', staleLineage);
+
+      const task = orchestrator.getTask('f2')!;
+      expect(task.status).toBe('running');
+      expect(task.execution.pendingFixError).toBeUndefined();
+      expect(task.execution.branch).toBe('newer-fix-branch');
+      expect(task.execution.workspacePath).toBe('/tmp/newer-fix-workspace');
+      expect(task.execution.agentSessionId).toBe('newer-fix-session');
+      expect(task.execution.selectedAttemptId).toBe('newer-fix-attempt');
+      expect(task.execution.generation).toBe(staleLineage.generation + 1);
+      expect(publishedDeltas).toHaveLength(0);
     });
 
     it('pendingFixError is readable via getTask', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2834,7 +2834,10 @@ export class Orchestrator {
    * Clears terminal failure fields on the row so SQLite does not show stale error/exit/completed.
    * Returns the saved error string so the caller can revert on failure.
    */
-  beginConflictResolution(taskId: string, expectedLineage?: TaskLineageExpectation): { savedError: string } {
+  beginConflictResolution(
+    taskId: string,
+    expectedLineage?: TaskLineageExpectation,
+  ): { savedError: string; lineage: { taskId: string; selectedAttemptId: string | undefined; generation: number } } {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
@@ -2879,7 +2882,14 @@ export class Orchestrator {
     this.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
 
-    return { savedError };
+    return {
+      savedError,
+      lineage: {
+        taskId: id,
+        selectedAttemptId: attemptId,
+        generation: conflictUpdated.execution.generation ?? 0,
+      },
+    };
   }
 
   /**
@@ -2890,7 +2900,7 @@ export class Orchestrator {
   beginAutoFixSession(
     taskId: string,
     opts: { savedError?: string; expectedLineage?: TaskLineageExpectation } = {},
-  ): { savedError: string } {
+  ): { savedError: string; lineage: { taskId: string; selectedAttemptId: string | undefined; generation: number } } {
     this.refreshFromDb();
     const task = this.stateGetTask(taskId);
     if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
@@ -2939,7 +2949,14 @@ export class Orchestrator {
     const delta: TaskDelta = this.buildUpdateDelta(task, updated, changesWithGeneration);
     this.persistence.logEvent?.(id, 'task.fixing_with_ai', changesWithGeneration);
     this.messageBus.publish(TASK_DELTA_CHANNEL, delta);
-    return { savedError };
+    return {
+      savedError,
+      lineage: {
+        taskId: id,
+        selectedAttemptId: attemptId,
+        generation: updated.execution.generation ?? 0,
+      },
+    };
   }
 
   /**
@@ -4059,7 +4076,10 @@ export class Orchestrator {
 
   private taskMatchesLineageExpectation(task: TaskState, expected?: TaskLineageExpectation): boolean {
     if (!expected) return true;
-    if (expected.taskId !== undefined && expected.taskId !== task.id) return false;
+    if (expected.taskId !== undefined && expected.taskId !== task.id) {
+      const expectedTask = this.stateGetTask(expected.taskId);
+      if (expectedTask?.id !== task.id) return false;
+    }
     if (expected.selectedAttemptId !== task.execution.selectedAttemptId) return false;
     if (expected.generation !== undefined && expected.generation !== (task.execution.generation ?? 0)) return false;
     return true;


### PR DESCRIPTION
## Summary

Adds lineage snapshots to fix-with-agent, conflict-resolution, auto-fix, and review-gate fix flows so stale async results abort before writing state.

Orchestrator fix-session entry points now return the active fix lineage, and late approval or revert calls no-op when that lineage is stale.

Regression coverage exercises stale begin, awaiting-approval, revert, and workflow action paths to protect newer attempts from late fix results.

## Architecture

### Before

```mermaid
flowchart TD
    A[Fix flow captures task] --> B[Begin fix session]
    B --> C[Agent or resolver runs asynchronously]
    C --> D[Approval or revert writes by task id]
    D --> E[Newer selected attempt can be overwritten]
```

### After

```mermaid
flowchart TD
    A[Fix flow captures entry lineage] --> B[Begin fix session validates expected lineage]
    B --> C[Orchestrator returns fix session lineage]
    C --> D[Async checkpoints assert lineage and cancellation]
    D --> E{Lineage still current}
    E -- Yes --> F[Approval or revert writes with expected lineage]
    E -- No --> G[Abort or no op preserves newer attempt]
```

## Test Plan

- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert -m 1 5dc8cc18`
- Post-revert steps: Re-run `pnpm run test:all`.
- Data migration? No