### PR TITLE
Fix text-form merge conflict recovery

### DIFF
--- a/packages/app/src/__tests__/workflow-actions.test.ts
+++ b/packages/app/src/__tests__/workflow-actions.test.ts
@@ -520,7 +520,11 @@ describe('approveTask', () => {
       status: 'awaiting_approval',
       config: { workflowId: 'wf-1' },
       execution: {
-        pendingFixError: JSON.stringify({ type: 'merge_conflict', conflictFiles: ['a.ts'] }),
+        pendingFixError: JSON.stringify({
+          type: 'merge_conflict',
+          failedBranch: 'experiment/foo',
+          conflictFiles: ['a.ts'],
+        }),
         workspacePath: '/tmp/task-a',
         branch: 'task-a',
       },
@@ -1268,6 +1272,30 @@ describe('selectFailureRecoveryRoute', () => {
     expect(route).toEqual({ kind: 'resolveConflict' });
   });
 
+  it('uses resolveConflict for parseable text merge conflicts when a workspace exists', () => {
+    const route = selectFailureRecoveryRoute(
+      makeTask({
+        config: { workflowId: 'wf-1' },
+        execution: { workspacePath: '/tmp/task-a' },
+      }) as any,
+      'Executor startup failed (ssh): Merge conflict merging experiment/foo: packages/app/src/headless.ts',
+    );
+
+    expect(route).toEqual({ kind: 'resolveConflict' });
+  });
+
+  it('uses fixWithAgent for conflict-looking text without recoverable metadata', () => {
+    const route = selectFailureRecoveryRoute(
+      makeTask({
+        config: { workflowId: 'wf-1' },
+        execution: { workspacePath: '/tmp/task-a' },
+      }) as any,
+      'CONFLICT (content): Merge conflict in src/foo.ts\nAutomatic merge failed; fix conflicts and commit.',
+    );
+
+    expect(route).toEqual({ kind: 'fixWithAgent' });
+  });
+
   it('uses fixWithAgent for non-merge failures', () => {
     const route = selectFailureRecoveryRoute(
       makeTask({
@@ -1350,6 +1378,41 @@ describe('fixWithAgentAction', () => {
     });
 
     expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'claude');
+    expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
+    expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError);
+    expect(result).toEqual({ kind: 'resolveConflict', autoApproved: false, started: [] });
+  });
+
+  it('dispatches text merge conflicts with a stale workspace to taskExecutor.resolveConflict', async () => {
+    const mergeError = 'Executor startup failed (ssh): Merge conflict merging experiment/foo: packages/app/src/headless.ts';
+    const orchestrator = {
+      getTask: vi.fn(() => makeTask({
+        status: 'failed',
+        config: { workflowId: 'wf-1' },
+        execution: { error: mergeError, workspacePath: '/tmp/stale-task-a' },
+      })),
+      beginConflictResolution: vi.fn(() => ({ savedError: mergeError })),
+      setFixAwaitingApproval: vi.fn(),
+      revertConflictResolution: vi.fn(),
+    };
+    const persistence = {
+      getTaskOutput: vi.fn(),
+      appendTaskOutput: vi.fn(),
+    };
+    const taskExecutor = {
+      fixWithAgent: vi.fn(),
+      resolveConflict: vi.fn().mockResolvedValue(undefined),
+    };
+
+    const result = await fixWithAgentAction('task-a', {
+      orchestrator: orchestrator as unknown as Orchestrator,
+      persistence: persistence as unknown as SQLiteAdapter,
+      taskExecutor: taskExecutor as unknown as TaskRunner,
+    }, {
+      agentName: 'codex',
+    });
+
+    expect(taskExecutor.resolveConflict).toHaveBeenCalledWith('task-a', mergeError, 'codex');
     expect(taskExecutor.fixWithAgent).not.toHaveBeenCalled();
     expect(orchestrator.setFixAwaitingApproval).toHaveBeenCalledWith('task-a', mergeError);
     expect(result).toEqual({ kind: 'resolveConflict', autoApproved: false, started: [] });

--- a/packages/app/src/workflow-actions.ts
+++ b/packages/app/src/workflow-actions.ts
@@ -18,6 +18,7 @@ import {
   OrchestratorError,
   OrchestratorErrorCode,
   buildCancelInFlight as buildCoreCancelInFlight,
+  parseMergeConflictError,
 } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { TaskRunner, ReviewGateCiFailureTrigger } from '@invoker/execution-engine';
@@ -148,7 +149,7 @@ export async function approveTask(
   const shouldResume =
     fixedTask &&
     task !== undefined &&
-    (task.config.isMergeNode || isMergeConflictError(task.execution.pendingFixError ?? ''));
+    (task.config.isMergeNode || Boolean(parseMergeConflictError(task.execution.pendingFixError ?? '')));
   const started = await (
     shouldResume
       ? (deps.resumeAfterFixApproval ?? deps.orchestrator.resumeTaskAfterFixApproval.bind(deps.orchestrator))
@@ -916,34 +917,11 @@ export type FailureRecoveryRoute =
   | { kind: 'resolveConflict' }
   | { kind: 'recreateWorkflowFromFreshBase'; workflowId: string };
 
-function isMergeConflictError(error: string): boolean {
-  for (const c of [error, error.trim(), error.split('\n\n').at(-1)?.trim() ?? '']) {
-    if (!c) continue;
-    try { if ((JSON.parse(c) as any)?.type === 'merge_conflict') return true; } catch { /* not JSON */ }
-    const jsonStart = c.indexOf('{');
-    if (jsonStart >= 0) {
-      try {
-        if ((JSON.parse(c.slice(jsonStart)) as any)?.type === 'merge_conflict') return true;
-      } catch {
-        /* not parseable JSON tail */
-      }
-    }
-    if (
-      c.includes('CONFLICT (') ||
-      c.includes('Automatic merge failed') ||
-      c.includes('Merge conflict merging ')
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
 export function selectFailureRecoveryRoute(
   task: TaskState,
   savedError: string,
 ): FailureRecoveryRoute {
-  if (!isMergeConflictError(savedError)) {
+  if (!parseMergeConflictError(savedError)) {
     return { kind: 'fixWithAgent' };
   }
 

--- a/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
+++ b/packages/execution-engine/src/__tests__/conflict-resolver.test.ts
@@ -150,6 +150,41 @@ describe('resolveConflictImpl', () => {
     ).resolves.toBeUndefined();
   });
 
+  it('uses text-form startup merge conflicts to resolve with savedError', async () => {
+    const spawnAgentFix = vi.fn(async () => ({ stdout: '', sessionId: 'sess-text-conflict' }));
+    const execGitIn = vi.fn(async (args: string[]) => {
+      if (args[0] === 'branch') return 'main';
+      if (args[0] === 'merge') throw new Error('conflict reproduced');
+      return '';
+    });
+    const conflictError = 'Executor startup failed (ssh): Merge conflict merging experiment/foo: packages/app/src/headless.ts';
+    const task = {
+      id: 'task-1',
+      status: 'fixing_with_ai',
+      execution: { error: undefined, branch: 'invoker/task-1', workspacePath: createTempWorkspace() },
+      config: {},
+    };
+    const host: ConflictResolverHost = {
+      ...makeHost(task),
+      execGitIn,
+      spawnAgentFix,
+    };
+
+    await expect(
+      resolveConflictImpl(host, 'task-1', conflictError, 'codex'),
+    ).resolves.toBeUndefined();
+
+    expect(execGitIn).toHaveBeenCalledWith(
+      ['merge', '--no-edit', '-m', 'Merge upstream experiment/foo', 'experiment/foo'],
+      task.execution.workspacePath,
+    );
+    expect(spawnAgentFix).toHaveBeenCalledWith(
+      expect.stringContaining('Conflicting files: packages/app/src/headless.ts'),
+      task.execution.workspacePath,
+      'codex',
+    );
+  });
+
   it('threads agentName="codex" to spawnAgentFix when merge fails', async () => {
     const spawnAgentFix = vi.fn<(prompt: string, cwd: string, agentName?: string) => Promise<{ stdout: string; sessionId: string }>>(
       async () => ({ stdout: '', sessionId: 'sess-conflict-codex' }),

--- a/packages/execution-engine/src/conflict-resolver.ts
+++ b/packages/execution-engine/src/conflict-resolver.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
 import type { Orchestrator } from '@invoker/workflow-core';
-import { OrchestratorError, OrchestratorErrorCode } from '@invoker/workflow-core';
+import { OrchestratorError, OrchestratorErrorCode, parseMergeConflictError } from '@invoker/workflow-core';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import { cleanElectronEnv, resolveExecutableOnCurrentPath } from './process-utils.js';
 import type { ExecutionAgent } from './agent.js';
@@ -185,12 +185,8 @@ export async function resolveConflictImpl(
   const errorStr = savedError ?? task.execution.error;
   if (!errorStr) throw new Error(`Task ${taskId} has no error information`);
 
-  let conflictInfo: { failedBranch: string; conflictFiles: string[] };
-  try {
-    const parsed = JSON.parse(errorStr);
-    if (parsed?.type !== 'merge_conflict') throw new Error('not a merge conflict');
-    conflictInfo = { failedBranch: parsed.failedBranch, conflictFiles: parsed.conflictFiles };
-  } catch {
+  const conflictInfo = parseMergeConflictError(errorStr);
+  if (!conflictInfo) {
     host.persistence.logEvent?.(taskId, 'debug.auto-fix', {
       phase: 'resolve-conflict-parse-failed',
       errorPreview: String(errorStr).slice(0, 400),

--- a/packages/workflow-core/src/__tests__/merge-conflict-error.test.ts
+++ b/packages/workflow-core/src/__tests__/merge-conflict-error.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { parseMergeConflictError } from '../merge-conflict-error.js';
+
+describe('parseMergeConflictError', () => {
+  it('parses merge-conflict JSON payloads', () => {
+    expect(parseMergeConflictError(JSON.stringify({
+      type: 'merge_conflict',
+      failedBranch: 'experiment/foo',
+      conflictFiles: ['src/foo.ts'],
+    }))).toEqual({
+      failedBranch: 'experiment/foo',
+      conflictFiles: ['src/foo.ts'],
+    });
+  });
+
+  it('parses wrapped JSON tails', () => {
+    expect(parseMergeConflictError([
+      '[Fix with Agent failed] boom',
+      '',
+      JSON.stringify({
+        type: 'merge_conflict',
+        failedBranch: 'experiment/foo',
+        conflictFiles: ['src/foo.ts'],
+      }),
+    ].join('\n'))).toEqual({
+      failedBranch: 'experiment/foo',
+      conflictFiles: ['src/foo.ts'],
+    });
+  });
+
+  it('parses wrapped local executor startup text', () => {
+    expect(parseMergeConflictError(
+      'Executor startup failed (ssh): Merge conflict merging experiment/foo: packages/app/src/headless.ts, packages/app/src/main.ts',
+    )).toEqual({
+      failedBranch: 'experiment/foo',
+      conflictFiles: ['packages/app/src/headless.ts', 'packages/app/src/main.ts'],
+    });
+  });
+
+  it('parses SSH remote merge-conflict text', () => {
+    expect(parseMergeConflictError([
+      'Merge conflict merging upstream branch "experiment/foo" on remote.',
+      'Conflicting files:',
+      'packages/app/src/headless.ts',
+      'packages/app/src/main.ts',
+    ].join('\n'))).toEqual({
+      failedBranch: 'experiment/foo',
+      conflictFiles: ['packages/app/src/headless.ts', 'packages/app/src/main.ts'],
+    });
+  });
+
+  it('ignores conflict-looking text without recoverable metadata', () => {
+    expect(parseMergeConflictError(
+      'CONFLICT (content): Merge conflict in src/foo.ts\nAutomatic merge failed; fix conflicts and then commit the result.',
+    )).toBeUndefined();
+  });
+});

--- a/packages/workflow-core/src/index.ts
+++ b/packages/workflow-core/src/index.ts
@@ -4,6 +4,7 @@ export * from './response-handler.js';
 export * from './scheduler.js';
 export * from './orchestrator.js';
 export * from './task-id-scope.js';
+export * from './merge-conflict-error.js';
 export * from './plan-parser.js';
 export * from './fallback-policy.js';
 export * from './graph-mutation.js';

--- a/packages/workflow-core/src/merge-conflict-error.ts
+++ b/packages/workflow-core/src/merge-conflict-error.ts
@@ -1,0 +1,91 @@
+export interface ParsedMergeConflictError {
+  failedBranch: string;
+  conflictFiles: string[];
+}
+
+function isRecoverableConflictFile(file: string): boolean {
+  return (
+    file.length > 0
+    && file !== '(see task output)'
+    && !file.startsWith('at ')
+    && !file.startsWith('[Ssh')
+  );
+}
+
+function normalizeConflictFiles(files: unknown): string[] {
+  if (!Array.isArray(files)) return [];
+  return files
+    .filter((file): file is string => typeof file === 'string')
+    .map((file) => file.trim())
+    .filter(isRecoverableConflictFile);
+}
+
+function fromJsonObject(value: unknown): ParsedMergeConflictError | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const obj = value as Record<string, unknown>;
+  if (obj.type !== 'merge_conflict') return undefined;
+
+  const failedBranch = typeof obj.failedBranch === 'string' ? obj.failedBranch.trim() : '';
+  const conflictFiles = normalizeConflictFiles(obj.conflictFiles);
+  if (!failedBranch || conflictFiles.length === 0) return undefined;
+  return { failedBranch, conflictFiles };
+}
+
+function tryParseJson(value: string): ParsedMergeConflictError | undefined {
+  try {
+    return fromJsonObject(JSON.parse(value));
+  } catch {
+    return undefined;
+  }
+}
+
+function jsonCandidates(value: string): string[] {
+  const trimmed = value.trim();
+  const candidates = [trimmed, trimmed.split('\n\n').at(-1)?.trim() ?? ''];
+  const jsonStart = trimmed.indexOf('{');
+  if (jsonStart >= 0) candidates.push(trimmed.slice(jsonStart).trim());
+  return candidates.filter((candidate) => candidate.length > 0);
+}
+
+function parseCommaSeparatedFiles(value: string): string[] {
+  return value
+    .split(',')
+    .map((file) => file.trim())
+    .filter(isRecoverableConflictFile);
+}
+
+function parseLineSeparatedFiles(value: string): string[] {
+  return value
+    .split(/\r?\n/)
+    .map((file) => file.trim())
+    .filter(isRecoverableConflictFile);
+}
+
+function parseLocalTextMergeConflict(value: string): ParsedMergeConflictError | undefined {
+  const match = value.match(/Merge conflict merging\s+(.+?):\s*([^\n]+)/);
+  const failedBranch = match?.[1]?.trim() ?? '';
+  const conflictFiles = parseCommaSeparatedFiles(match?.[2] ?? '');
+  if (!failedBranch || conflictFiles.length === 0) return undefined;
+  return { failedBranch, conflictFiles };
+}
+
+function parseRemoteTextMergeConflict(value: string): ParsedMergeConflictError | undefined {
+  const match = value.match(
+    /Merge conflict merging upstream branch "([^"]+)" on remote\.\s*\r?\nConflicting files:\r?\n([\s\S]+)/,
+  );
+  const failedBranch = match?.[1]?.trim() ?? '';
+  const conflictFiles = parseLineSeparatedFiles(match?.[2] ?? '');
+  if (!failedBranch || conflictFiles.length === 0) return undefined;
+  return { failedBranch, conflictFiles };
+}
+
+export function parseMergeConflictError(value: string | undefined): ParsedMergeConflictError | undefined {
+  if (!value) return undefined;
+
+  for (const candidate of jsonCandidates(value)) {
+    const parsed = tryParseJson(candidate);
+    if (parsed) return parsed;
+  }
+
+  return parseRemoteTextMergeConflict(value) ?? parseLocalTextMergeConflict(value);
+}

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -26,6 +26,7 @@ import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
 import type { Logger, WorkResponse } from '@invoker/contracts';
 import { ATTEMPT_LEASE_MS } from '@invoker/contracts';
 import { normalizeRunnerKind } from '@invoker/workflow-graph';
+import { parseMergeConflictError } from './merge-conflict-error.js';
 
 const MERGE_TRACE_LOG = resolve(homedir(), '.invoker', 'merge-trace.log');
 function mergeTrace(tag: string, data: Record<string, unknown>): void {
@@ -125,29 +126,6 @@ const noopLogger: Logger = {
 
 function stripFixFailureWrapper(errorText: string): string {
   return errorText.replace(FIX_FAILURE_PREFIX_RE, '');
-}
-
-function tryParseJsonObject(value: string | undefined): Record<string, unknown> | undefined {
-  if (!value) return undefined;
-  try {
-    const parsed: unknown = JSON.parse(value);
-    return parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>) : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function parseMergeConflictError(
-  value: string | undefined,
-): { failedBranch: string; conflictFiles: string[] } | undefined {
-  const obj = tryParseJsonObject(value);
-  if (obj?.type !== 'merge_conflict') return undefined;
-
-  const failedBranch = typeof obj.failedBranch === 'string' ? obj.failedBranch : '';
-  const conflictFiles = Array.isArray(obj.conflictFiles)
-    ? obj.conflictFiles.filter((file): file is string => typeof file === 'string')
-    : [];
-  return { failedBranch, conflictFiles };
 }
 
 function nextLeaseExpiry(from: Date): Date {


### PR DESCRIPTION
## Summary

Fix with Codex now uses one merge-conflict parser across app routing, orchestrator persistence, and conflict resolution.

Wrapped SSH startup errors like `Merge conflict merging ...` now provide the same branch and file metadata as JSON conflict payloads.

Generic conflict-looking text without recoverable metadata no longer routes into conflict resolution.

## Architecture

### Before

```mermaid
graph TD
    A[Fix with Codex] --> B[Text detector]
    B --> C[resolveConflict]
    C --> D[JSON-only parser]
    D --> E[Immediate failure]
```

### After

```mermaid
graph TD
    A[Fix with Codex] --> B[Shared conflict parser]
    B --> C{Branch and files parsed?}
    C -->|Yes| D[resolveConflict]
    C -->|No| E[normal fix route]
    D --> B
```

## Test Plan

- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/merge-conflict-error.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/workflow-actions.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/conflict-resolver.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 247d6e099058215267061bd4a54d35f251e9bb1d`
- Post-revert steps: None
- Data migration? No
