### PR TITLE
Fence stale launch dispatch claims

### DIFF
--- a/docs/incidents/2026-06-03-stale-downstream-launch-dispatch.md
+++ b/docs/incidents/2026-06-03-stale-downstream-launch-dispatch.md
@@ -1,0 +1,147 @@
+# Stale Downstream Launch Dispatch After Dependency Reset
+
+Date: 2026-06-03
+
+## Summary
+
+A downstream launch dispatch row can survive after one of its prerequisites
+reverts from `completed` to `pending`. If the old dispatch row is later leased,
+the downstream task can run against an invalid DAG snapshot.
+
+This was observed with the camera-lock review gate:
+
+- Upstream verification task:
+  `wf-1780385791355-3/verify-viewport-camera-tests`
+- Downstream review gate:
+  `__merge__wf-1780385791355-3`
+- Production log evidence showed the merge node running while its dependency was
+  pending:
+  `merge node "__merge__wf-1780385791355-3" status=running deps=[wf-1780385791355-3/verify-viewport-camera-tests=pending] hasDep=false`
+
+The root issue is not the review gate failure itself. The review gate should not
+have started after its prerequisite reverted to `pending`.
+
+## Repro
+
+Focused repro:
+
+```sh
+pnpm --filter @invoker/data-store exec vitest run \
+  --reporter verbose \
+  --exclude '**/node_modules/**' \
+  src/__tests__/stale-downstream-launch-dispatch-repro.test.ts
+```
+
+Bash repro using a temporary SQLite DB:
+
+```sh
+bash scripts/repro/repro-stale-downstream-launch-dispatch.sh --expect-issue
+```
+
+The repro seeds this sequence:
+
+1. Save an upstream verification task as `completed`, generation 1.
+2. Save a dependent merge task as `pending`, generation 1.
+3. Enqueue a launch dispatch for the merge task at generation 1.
+4. Reset the upstream verification task to `pending`, generation 2.
+5. Reset the merge task to `pending`, generation 2, with a new selected attempt.
+6. Call `claimLaunchDispatchAtomic`.
+
+Current behavior leases the stale generation-1 merge dispatch:
+
+```text
+task rows:
+id                                     status   dependencies                             selected_attempt_id                              execution_generation
+__merge__wf-stale-downstream-dispatch  pending  ["wf-stale-downstream-dispatch/verify"]  __merge__wf-stale-downstream-dispatch-attempt-2  2
+wf-stale-downstream-dispatch/verify    pending  []                                       wf-stale-downstream-dispatch/verify-attempt-2    2
+
+launch dispatch rows:
+id  task_id                                attempt_id                                       state   generation  dispatch_owner  leased_at
+1   __merge__wf-stale-downstream-dispatch  __merge__wf-stale-downstream-dispatch-attempt-1  leased  1           repro-owner     2026-06-03T00:02:00.000Z
+```
+
+Expected fixed behavior: the old dispatch is abandoned or skipped, and no
+downstream lease is returned until the dependency is completed again and a fresh
+dispatch exists for the current downstream attempt.
+
+## Root Cause
+
+`task_launch_dispatch` readiness is established when the scheduler enqueues a
+row. `claimLaunchDispatchAtomic` currently leases `state = 'enqueued'` rows by
+priority and id. It does not prove that the row still matches the authoritative
+task snapshot at lease time.
+
+The missing checks are:
+
+- dispatch `attempt_id` still equals the task `selected_attempt_id`
+- dispatch `generation` still equals the task `execution_generation`
+- the task is still launchable
+- dependencies are still satisfied
+- reset/retry/recreate paths abandoned downstream dispatch rows that were
+  created from an older graph snapshot
+
+`resetSubgraphToPending` clears queued scheduler entries, but launch dispatch
+rows are durable outbox rows and are not invalidated there.
+
+## Fix Plan
+
+1. Add a persistence helper to abandon active launch dispatches for a set of
+   task ids.
+
+   Candidate API:
+
+   ```ts
+   abandonLaunchDispatchesForTasks(taskIds, reason, nowIso?)
+   ```
+
+   It should mark `enqueued`, `leased`, and `acknowledged` rows as `abandoned`,
+   clear owner/fence fields, set terminal timestamps and `last_error`, and emit
+   a launch-dispatch invalidation event.
+
+2. Call that helper from `resetSubgraphToPending` for every affected task in the
+   reset subgraph. This covers upstream retry, task recreate, workflow recreate,
+   rebase, fix approval, and fix rejection paths that replace selected attempts.
+
+3. Add lease-time validation to `claimLaunchDispatchAtomic` before returning a
+   row. At minimum, a row is leaseable only when:
+
+   - the joined task exists
+   - task status is `pending`
+   - dispatch attempt matches `tasks.selected_attempt_id`
+   - dispatch generation matches `tasks.execution_generation`
+
+   Rows that fail those checks should be abandoned and skipped.
+
+4. Add a second readiness check in the active launch dispatcher before handing a
+   lease to the task runner. It should reload the task graph and refuse to launch
+   when local dependencies are not currently satisfied. This protects against
+   stale leases even if a future reset path misses the explicit invalidation
+   call.
+
+5. Release execution resource leases for invalidated downstream dispatches. Use
+   the existing execution resource lease release path so an abandoned launch
+   dispatch cannot keep SSH or pool capacity reserved.
+
+6. Convert the repros into passing regression checks:
+
+   ```sh
+   pnpm --filter @invoker/data-store exec vitest run \
+     --reporter verbose \
+     --exclude '**/node_modules/**' \
+     src/__tests__/stale-downstream-launch-dispatch-repro.test.ts
+
+   bash scripts/repro/repro-stale-downstream-launch-dispatch.sh --expect-fixed
+   ```
+
+7. Add focused coverage around the integration points:
+
+   - `SQLiteAdapter.claimLaunchDispatchAtomic` skips stale attempt/generation
+     rows.
+   - `LaunchDispatcher` abandons an active lease and does not call
+     `executeTask` when dependencies are no longer satisfied.
+   - orchestrator reset/retry paths abandon launch dispatches for descendants
+     and merge nodes.
+
+No schema migration is required because `task_launch_dispatch.state` already
+supports `abandoned`. An index on `(task_id, state)` is optional if the
+invalidation query needs help at scale.

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -126,7 +126,7 @@ describe('LaunchDispatcher', () => {
   });
 
   describe('ack / complete / fail transitions', () => {
-    function seedWorkflowAndTask(): void {
+    function seedWorkflowAndTask(selectedAttemptId?: string): void {
       adapter.saveWorkflow({
         id: 'wf-1',
         name: 'wf-1',
@@ -144,6 +144,11 @@ describe('LaunchDispatcher', () => {
         execution: {},
         taskStateVersion: 1,
       });
+      if (selectedAttemptId) {
+        adapter.updateTask('wf-1/t1', {
+          execution: { selectedAttemptId, generation: 0 },
+        });
+      }
     }
 
     function makeDispatcher(logger = makeLogger()) {
@@ -159,7 +164,7 @@ describe('LaunchDispatcher', () => {
     }
 
     it('ack moves a leased row to acknowledged and logs the transition', () => {
-      seedWorkflowAndTask();
+      seedWorkflowAndTask('attempt-ack');
       const enqueued = adapter.enqueueLaunchDispatch({
         taskId: 'wf-1/t1',
         attemptId: 'attempt-ack',
@@ -230,7 +235,7 @@ describe('LaunchDispatcher', () => {
     });
 
     it('fail re-enqueues a leased row with the error message and clears the owner', () => {
-      seedWorkflowAndTask();
+      seedWorkflowAndTask('attempt-fail');
       const enqueued = adapter.enqueueLaunchDispatch({
         taskId: 'wf-1/t1',
         attemptId: 'attempt-fail',
@@ -253,7 +258,7 @@ describe('LaunchDispatcher', () => {
     });
 
     it('fail coerces a non-Error value to its string form', () => {
-      seedWorkflowAndTask();
+      seedWorkflowAndTask('attempt-fail-string');
       const enqueued = adapter.enqueueLaunchDispatch({
         taskId: 'wf-1/t1',
         attemptId: 'attempt-fail-string',
@@ -581,6 +586,14 @@ describe('LaunchDispatcher', () => {
         taskStateVersion: 1,
       };
       adapter.saveTask(workflowId, task);
+      if (typeof execution.selectedAttemptId === 'string') {
+        adapter.updateTask(taskId, {
+          execution: {
+            selectedAttemptId: execution.selectedAttemptId,
+            generation: typeof execution.generation === 'number' ? execution.generation : 0,
+          },
+        });
+      }
       return task;
     }
 
@@ -628,7 +641,10 @@ describe('LaunchDispatcher', () => {
 
     it('active mode loops until maxLeasesPerPoll is reached', () => {
       for (let i = 0; i < 3; i += 1) {
-        seedWorkflowAndTask(`wf-a/t${i}`);
+        seedWorkflowAndTask(`wf-a/t${i}`, 'wf-a', {
+          selectedAttemptId: `attempt-multi-${i}`,
+          generation: 0,
+        });
       }
       for (let i = 0; i < 3; i += 1) {
         adapter.enqueueLaunchDispatch({
@@ -724,8 +740,8 @@ describe('LaunchDispatcher', () => {
 
     it('active mode retires a dispatch row when the selected attempt changed', () => {
       const task = seedWorkflowAndTask('wf-a/t-stale', 'wf-a', {
-        selectedAttemptId: 'attempt-current',
-        generation: 1,
+        selectedAttemptId: 'attempt-old',
+        generation: 0,
       });
       const enq = adapter.enqueueLaunchDispatch({
         taskId: task.id,
@@ -733,13 +749,21 @@ describe('LaunchDispatcher', () => {
         workflowId: 'wf-a',
         generation: 0,
       });
+      const currentTask = {
+        ...task,
+        execution: {
+          ...task.execution,
+          selectedAttemptId: 'attempt-current',
+          generation: 1,
+        },
+      };
       const executeTask = vi.fn().mockResolvedValue(undefined);
       const dispatcher = new LaunchDispatcher({
         persistence: adapter,
         ownerId: 'owner-a',
         orchestrator: {
           prepareTaskForNewAttempt: vi.fn(),
-          getTask: vi.fn().mockReturnValue(task as any),
+          getTask: vi.fn().mockReturnValue(currentTask as any),
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
@@ -756,7 +780,10 @@ describe('LaunchDispatcher', () => {
     });
 
     it('active mode fails the dispatch when the orchestrator has no matching task', () => {
-      seedWorkflowAndTask('wf-a/t-missing');
+      seedWorkflowAndTask('wf-a/t-missing', 'wf-a', {
+        selectedAttemptId: 'attempt-missing',
+        generation: 0,
+      });
       const enq = adapter.enqueueLaunchDispatch({
         taskId: 'wf-a/t-missing',
         attemptId: 'attempt-missing',

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -230,9 +230,46 @@ describe('SQLiteAdapter', () => {
   });
 
   describe('task_launch_dispatch outbox', () => {
-    function setupWorkflowAndTask(workflowId = 'wf-launch', taskId = 'wf-launch/t1'): void {
+    function setupWorkflowAndTask(
+      workflowId = 'wf-launch',
+      taskId = 'wf-launch/t1',
+      opts: {
+        selectedAttemptId?: string;
+        generation?: number;
+        status?: TaskState['status'];
+      } = {},
+    ): void {
       adapter.saveWorkflow({ ...testWorkflow, id: workflowId });
-      adapter.saveTask(workflowId, makeTask(taskId, { config: { workflowId } }));
+      adapter.saveTask(workflowId, makeTask(taskId, {
+        status: opts.status ?? 'pending',
+        config: { workflowId },
+        execution: {
+          generation: opts.generation ?? 0,
+        },
+      }));
+      if (opts.selectedAttemptId) {
+        adapter.updateTask(taskId, {
+          execution: { selectedAttemptId: opts.selectedAttemptId },
+        });
+      }
+    }
+
+    function saveLaunchTask(
+      workflowId: string,
+      taskId: string,
+      attemptId: string,
+      opts: { generation?: number; status?: TaskState['status'] } = {},
+    ): void {
+      adapter.saveTask(workflowId, makeTask(taskId, {
+        status: opts.status ?? 'pending',
+        config: { workflowId },
+        execution: {
+          generation: opts.generation ?? 0,
+        },
+      }));
+      adapter.updateTask(taskId, {
+        execution: { selectedAttemptId: attemptId },
+      });
     }
 
     it('round-trips enqueueLaunchDispatch + load by id and attempt', () => {
@@ -430,7 +467,9 @@ describe('SQLiteAdapter', () => {
 
     describe('claimLaunchDispatchAtomic', () => {
       it('leases the only enqueued row when capacity allows', () => {
-        setupWorkflowAndTask();
+        setupWorkflowAndTask('wf-launch', 'wf-launch/t1', {
+          selectedAttemptId: 'attempt-claim-1',
+        });
         const enqueued = adapter.enqueueLaunchDispatch({
           taskId: 'wf-launch/t1',
           attemptId: 'attempt-claim-1',
@@ -461,7 +500,9 @@ describe('SQLiteAdapter', () => {
       });
 
       it('does not double-lease an already-leased row', () => {
-        setupWorkflowAndTask();
+        setupWorkflowAndTask('wf-launch', 'wf-launch/t1', {
+          selectedAttemptId: 'attempt-conflict',
+        });
         adapter.enqueueLaunchDispatch({
           taskId: 'wf-launch/t1',
           attemptId: 'attempt-conflict',
@@ -483,22 +524,25 @@ describe('SQLiteAdapter', () => {
       });
 
       it('orders by priority (high, normal, low) then by insertion order', () => {
-        setupWorkflowAndTask();
+        adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
+        saveLaunchTask('wf-launch', 'wf-launch/t-normal', 'attempt-normal-1');
+        saveLaunchTask('wf-launch', 'wf-launch/t-low', 'attempt-low');
+        saveLaunchTask('wf-launch', 'wf-launch/t-high', 'attempt-high');
         const normal1 = adapter.enqueueLaunchDispatch({
-          taskId: 'wf-launch/t1',
+          taskId: 'wf-launch/t-normal',
           attemptId: 'attempt-normal-1',
           workflowId: 'wf-launch',
           generation: 0,
         });
         adapter.enqueueLaunchDispatch({
-          taskId: 'wf-launch/t1',
+          taskId: 'wf-launch/t-low',
           attemptId: 'attempt-low',
           workflowId: 'wf-launch',
           priority: 'low',
           generation: 0,
         });
         const high = adapter.enqueueLaunchDispatch({
-          taskId: 'wf-launch/t1',
+          taskId: 'wf-launch/t-high',
           attemptId: 'attempt-high',
           workflowId: 'wf-launch',
           priority: 'high',
@@ -524,15 +568,17 @@ describe('SQLiteAdapter', () => {
       });
 
       it('enforces maxConcurrency by counting leased + acknowledged rows', () => {
-        setupWorkflowAndTask();
+        adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
+        saveLaunchTask('wf-launch', 'wf-launch/t-cap-1', 'attempt-cap-1');
+        saveLaunchTask('wf-launch', 'wf-launch/t-cap-2', 'attempt-cap-2');
         adapter.enqueueLaunchDispatch({
-          taskId: 'wf-launch/t1',
+          taskId: 'wf-launch/t-cap-1',
           attemptId: 'attempt-cap-1',
           workflowId: 'wf-launch',
           generation: 0,
         });
         adapter.enqueueLaunchDispatch({
-          taskId: 'wf-launch/t1',
+          taskId: 'wf-launch/t-cap-2',
           attemptId: 'attempt-cap-2',
           workflowId: 'wf-launch',
           generation: 0,
@@ -566,7 +612,9 @@ describe('SQLiteAdapter', () => {
       });
 
       it('returns undefined when maxConcurrency is zero', () => {
-        setupWorkflowAndTask();
+        setupWorkflowAndTask('wf-launch', 'wf-launch/t1', {
+          selectedAttemptId: 'attempt-zero',
+        });
         adapter.enqueueLaunchDispatch({
           taskId: 'wf-launch/t1',
           attemptId: 'attempt-zero',
@@ -579,6 +627,131 @@ describe('SQLiteAdapter', () => {
         });
         expect(claimed).toBeUndefined();
       });
+
+      it('abandons a stale selected-attempt candidate and scans to the next valid row', () => {
+        adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
+        saveLaunchTask('wf-launch', 'wf-launch/t-stale', 'attempt-current');
+        saveLaunchTask('wf-launch', 'wf-launch/t-valid', 'attempt-valid');
+        const stale = adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t-stale',
+          attemptId: 'attempt-stale',
+          workflowId: 'wf-launch',
+          priority: 'high',
+          generation: 0,
+        });
+        const valid = adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t-valid',
+          attemptId: 'attempt-valid',
+          workflowId: 'wf-launch',
+          priority: 'normal',
+          generation: 0,
+        });
+
+        const claimed = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-scan',
+          maxConcurrency: 4,
+          nowIso: '2026-06-03T00:00:00.000Z',
+        });
+
+        expect(claimed?.id).toBe(valid.id);
+        const staleAfter = adapter.loadLaunchDispatchById(stale.id);
+        expect(staleAfter?.state).toBe('abandoned');
+        expect(staleAfter?.lastError).toMatch(/not the selected attempt/);
+      });
+
+      it('abandons stale generation candidates', () => {
+        setupWorkflowAndTask('wf-launch', 'wf-launch/t1', {
+          selectedAttemptId: 'attempt-generation',
+          generation: 2,
+        });
+        const row = adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t1',
+          attemptId: 'attempt-generation',
+          workflowId: 'wf-launch',
+          generation: 1,
+        });
+
+        const claimed = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-generation',
+          maxConcurrency: 4,
+          nowIso: '2026-06-03T00:01:00.000Z',
+        });
+
+        expect(claimed).toBeUndefined();
+        const after = adapter.loadLaunchDispatchById(row.id);
+        expect(after?.state).toBe('abandoned');
+        expect(after?.lastError).toMatch(/does not match task generation/);
+      });
+
+      it('abandons non-pending task candidates', () => {
+        setupWorkflowAndTask('wf-launch', 'wf-launch/t1', {
+          selectedAttemptId: 'attempt-failed-task',
+          status: 'failed',
+        });
+        const row = adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t1',
+          attemptId: 'attempt-failed-task',
+          workflowId: 'wf-launch',
+          generation: 0,
+        });
+
+        const claimed = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-status',
+          maxConcurrency: 4,
+          nowIso: '2026-06-03T00:02:00.000Z',
+        });
+
+        expect(claimed).toBeUndefined();
+        const after = adapter.loadLaunchDispatchById(row.id);
+        expect(after?.state).toBe('abandoned');
+        expect(after?.lastError).toMatch(/status is failed/);
+      });
+
+      it('abandons missing-task candidates', () => {
+        adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
+        (adapter as any).db.run('PRAGMA foreign_keys = OFF');
+        (adapter as any).db.run(
+          `INSERT INTO task_launch_dispatch (
+            task_id, attempt_id, workflow_id, state, priority, generation
+          ) VALUES ('wf-launch/missing', 'attempt-missing-task', 'wf-launch', 'enqueued', 'normal', 0)`,
+        );
+        (adapter as any).db.run('PRAGMA foreign_keys = ON');
+        const row = adapter.loadLaunchDispatchByAttempt('attempt-missing-task')!;
+
+        const claimed = adapter.claimLaunchDispatchAtomic({
+          ownerId: 'runner-missing',
+          maxConcurrency: 4,
+          nowIso: '2026-06-03T00:03:00.000Z',
+        });
+
+        expect(claimed).toBeUndefined();
+        const after = adapter.loadLaunchDispatchById(row.id);
+        expect(after?.state).toBe('abandoned');
+        expect(after?.lastError).toMatch(/no longer exists/);
+      });
+    });
+
+    it('deleteWorkflow removes launch dispatches and execution resource leases for deleted tasks', () => {
+      setupWorkflowAndTask('wf-launch', 'wf-launch/t1', {
+        selectedAttemptId: 'attempt-delete-cleanup',
+      });
+      adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-delete-cleanup',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:delete-cleanup',
+        resourceType: 'ssh',
+        holderId: 'holder-delete-cleanup',
+        taskId: 'wf-launch/t1',
+      })).toBe(true);
+
+      adapter.deleteWorkflow('wf-launch');
+
+      expect(adapter.listLaunchDispatchesByState(['enqueued', 'leased', 'acknowledged'])).toEqual([]);
+      expect(adapter.listExecutionResourceLeases()).toEqual([]);
     });
   });
 

--- a/packages/data-store/src/__tests__/stale-downstream-launch-dispatch-repro.test.ts
+++ b/packages/data-store/src/__tests__/stale-downstream-launch-dispatch-repro.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+import type { Workflow } from '../adapter.js';
+import type { TaskState } from '@invoker/workflow-core';
+
+const WORKFLOW_ID = 'wf-stale-downstream-dispatch';
+const UPSTREAM_ID = `${WORKFLOW_ID}/verify`;
+const MERGE_ID = `__merge__${WORKFLOW_ID}`;
+
+function makeWorkflow(): Workflow {
+  const now = new Date('2026-06-03T00:00:00.000Z').toISOString();
+  return {
+    id: WORKFLOW_ID,
+    name: 'stale downstream dispatch repro',
+    status: 'running',
+    createdAt: now,
+    updatedAt: now,
+  };
+}
+
+function makeTask(
+  id: string,
+  overrides: Partial<TaskState> = {},
+): TaskState {
+  const {
+    config: overrideConfig,
+    execution: overrideExecution,
+    ...rest
+  } = overrides;
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    createdAt: new Date('2026-06-03T00:00:00.000Z'),
+    taskStateVersion: 1,
+    ...rest,
+    config: {
+      workflowId: WORKFLOW_ID,
+      ...overrideConfig,
+    },
+    execution: {
+      ...overrideExecution,
+    },
+  };
+}
+
+describe('stale downstream launch dispatch repro', () => {
+  let adapter: SQLiteAdapter | undefined;
+  let cleanupDir: string | undefined;
+
+  afterEach(() => {
+    adapter?.close();
+    adapter = undefined;
+    if (cleanupDir) {
+      rmSync(cleanupDir, { recursive: true, force: true });
+      cleanupDir = undefined;
+    }
+  });
+
+  async function createAdapter(): Promise<SQLiteAdapter> {
+    const reproDbPath = process.env.INVOKER_STALE_DISPATCH_REPRO_DB_PATH;
+    if (reproDbPath) {
+      rmSync(reproDbPath, { force: true });
+      return SQLiteAdapter.create(reproDbPath, { ownerCapability: true });
+    }
+    cleanupDir = mkdtempSync(join(tmpdir(), 'invoker-stale-dispatch-repro-'));
+    return SQLiteAdapter.create(join(cleanupDir, 'invoker.db'), { ownerCapability: true });
+  }
+
+  it('does not lease a stale merge gate dispatch after its prerequisite reverts to pending', async () => {
+    adapter = await createAdapter();
+    adapter.saveWorkflow(makeWorkflow());
+
+    adapter.saveTask(
+      WORKFLOW_ID,
+      makeTask(UPSTREAM_ID, {
+        status: 'completed',
+        execution: {
+          generation: 1,
+          selectedAttemptId: `${UPSTREAM_ID}-attempt-1`,
+          completedAt: new Date('2026-06-03T00:01:00.000Z'),
+          commit: 'old-green-commit',
+        },
+      }),
+    );
+    adapter.saveTask(
+      WORKFLOW_ID,
+      makeTask(MERGE_ID, {
+        status: 'pending',
+        dependencies: [UPSTREAM_ID],
+        config: {
+          workflowId: WORKFLOW_ID,
+          isMergeNode: true,
+        },
+        execution: {
+          generation: 1,
+          selectedAttemptId: `${MERGE_ID}-attempt-1`,
+        },
+      }),
+    );
+
+    const staleDispatch = adapter.enqueueLaunchDispatch({
+      taskId: MERGE_ID,
+      attemptId: `${MERGE_ID}-attempt-1`,
+      workflowId: WORKFLOW_ID,
+      generation: 1,
+    });
+
+    // This models retry/recreate of the upstream verification after the
+    // downstream merge gate had already been enqueued. The downstream task
+    // receives a fresh generation and selected attempt, but the old outbox
+    // dispatch row is still present.
+    adapter.updateTask(UPSTREAM_ID, {
+      status: 'pending',
+      execution: {
+        generation: 2,
+        selectedAttemptId: `${UPSTREAM_ID}-attempt-2`,
+        completedAt: undefined,
+        commit: undefined,
+      },
+    });
+    adapter.updateTask(MERGE_ID, {
+      status: 'pending',
+      execution: {
+        generation: 2,
+        selectedAttemptId: `${MERGE_ID}-attempt-2`,
+      },
+    });
+    adapter.logEvent?.(UPSTREAM_ID, 'task.pending', {
+      status: 'pending',
+      execution: { generation: 2, selectedAttemptId: `${UPSTREAM_ID}-attempt-2` },
+    });
+
+    const leased = adapter.claimLaunchDispatchAtomic({
+      ownerId: 'repro-owner',
+      maxConcurrency: 1,
+      nowIso: '2026-06-03T00:02:00.000Z',
+    });
+
+    expect(leased, [
+      'The stale merge dispatch must be invalidated or skipped before lease.',
+      `dispatch=${staleDispatch.id}`,
+      `upstream=${UPSTREAM_ID} is pending`,
+      `merge task selected attempt is ${MERGE_ID}-attempt-2`,
+      `dispatch attempt is ${MERGE_ID}-attempt-1`,
+    ].join(' ')).toBeUndefined();
+  });
+});

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -819,6 +819,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
       CREATE INDEX IF NOT EXISTS idx_task_launch_dispatch_workflow_state
         ON task_launch_dispatch(workflow_id, state);
 
+      CREATE INDEX IF NOT EXISTS idx_task_launch_dispatch_task_state
+        ON task_launch_dispatch(task_id, state);
+
       CREATE TABLE IF NOT EXISTS execution_resource_leases (
         resource_key TEXT NOT NULL,
         resource_type TEXT NOT NULL,
@@ -1839,6 +1842,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
       this.db.run(`
+        DELETE FROM execution_resource_leases WHERE task_id IN (
+          SELECT id FROM tasks WHERE workflow_id = ?
+        )
+      `, [workflowId]);
+      this.db.run(`
         DELETE FROM events WHERE task_id IN (
           SELECT id FROM tasks WHERE workflow_id = ?
         )
@@ -1869,6 +1877,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM workflow_mutation_leases');
       this.db.run('DELETE FROM workflow_mutation_intents');
       this.db.run('DELETE FROM task_launch_dispatch');
+      this.db.run('DELETE FROM execution_resource_leases');
       this.db.run('DELETE FROM events');
       this.db.run('DELETE FROM task_output');
       this.db.run('DELETE FROM attempts');
@@ -1887,6 +1896,11 @@ export class SQLiteAdapter implements PersistenceAdapter {
       this.db.run('DELETE FROM workflow_mutation_leases WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM workflow_mutation_intents WHERE workflow_id = ?', [workflowId]);
       this.db.run('DELETE FROM task_launch_dispatch WHERE workflow_id = ?', [workflowId]);
+      this.db.run(`
+        DELETE FROM execution_resource_leases WHERE task_id IN (
+          SELECT id FROM tasks WHERE workflow_id = ?
+        )
+      `, [workflowId]);
 
       this.db.run(`
         DELETE FROM events WHERE task_id IN (
@@ -3200,36 +3214,78 @@ export class SQLiteAdapter implements PersistenceAdapter {
       );
       const active = Number(activeRow?.active ?? 0);
       if (active >= options.maxConcurrency) return undefined;
-      const candidate = this.queryOne(
-        `SELECT id FROM task_launch_dispatch
-           WHERE state = 'enqueued'
-           ORDER BY CASE priority
+      while (true) {
+        const candidate = this.queryOne(
+          `SELECT
+             d.*,
+             t.id AS current_task_id,
+             t.status AS current_task_status,
+             t.selected_attempt_id AS current_selected_attempt_id,
+             t.execution_generation AS current_execution_generation
+           FROM task_launch_dispatch d
+           LEFT JOIN tasks t ON t.id = d.task_id
+           WHERE d.state = 'enqueued'
+           ORDER BY CASE d.priority
              WHEN 'high' THEN 0
              WHEN 'normal' THEN 1
              ELSE 2
-           END, id
+           END, d.id
            LIMIT 1`,
-      );
-      if (!candidate || candidate.id == null) return undefined;
-      const candidateId = Number(candidate.id);
-      this.execRun(
-        `UPDATE task_launch_dispatch
-           SET state = 'leased',
-               dispatch_owner = ?,
-               leased_at = ?,
-               fenced_until = ?,
-               attempts_count = attempts_count + 1
-         WHERE id = ?
-           AND state = 'enqueued'`,
-        [options.ownerId, now, fencedUntil, candidateId],
-      );
-      const updated = (this.db.getRowsModified?.() ?? 0) > 0;
-      if (!updated) return undefined;
-      const row = this.queryOne(
-        'SELECT * FROM task_launch_dispatch WHERE id = ?',
-        [candidateId],
-      );
-      return row ? this.rowToTaskLaunchDispatch(row) : undefined;
+        );
+        if (!candidate || candidate.id == null) return undefined;
+        const candidateId = Number(candidate.id);
+
+        let staleReason: string | undefined;
+        if (!candidate.current_task_id) {
+          staleReason = `Launch dispatch ${candidateId} is stale: task ${String(candidate.task_id)} no longer exists`;
+        } else if (String(candidate.current_task_status) !== 'pending') {
+          staleReason =
+            `Launch dispatch ${candidateId} is stale: task ${String(candidate.task_id)} ` +
+            `status is ${String(candidate.current_task_status)}`;
+        } else if (String(candidate.current_selected_attempt_id ?? '') !== String(candidate.attempt_id)) {
+          staleReason =
+            `Launch dispatch ${candidateId} is stale: attempt ${String(candidate.attempt_id)} ` +
+            `is not the selected attempt ${String(candidate.current_selected_attempt_id ?? 'none')}`;
+        } else if (Number(candidate.current_execution_generation ?? 0) !== Number(candidate.generation ?? 0)) {
+          staleReason =
+            `Launch dispatch ${candidateId} is stale: generation ${String(candidate.generation)} ` +
+            `does not match task generation ${String(candidate.current_execution_generation ?? 0)}`;
+        }
+
+        if (staleReason) {
+          this.execRun(
+            `UPDATE task_launch_dispatch
+               SET state = 'abandoned',
+                   completed_at = ?,
+                   last_error = ?,
+                   dispatch_owner = NULL,
+                   fenced_until = NULL
+             WHERE id = ?
+               AND state = 'enqueued'`,
+            [now, staleReason, candidateId],
+          );
+          continue;
+        }
+
+        this.execRun(
+          `UPDATE task_launch_dispatch
+             SET state = 'leased',
+                 dispatch_owner = ?,
+                 leased_at = ?,
+                 fenced_until = ?,
+                 attempts_count = attempts_count + 1
+           WHERE id = ?
+             AND state = 'enqueued'`,
+          [options.ownerId, now, fencedUntil, candidateId],
+        );
+        const updated = (this.db.getRowsModified?.() ?? 0) > 0;
+        if (!updated) return undefined;
+        const row = this.queryOne(
+          'SELECT * FROM task_launch_dispatch WHERE id = ?',
+          [candidateId],
+        );
+        return row ? this.rowToTaskLaunchDispatch(row) : undefined;
+      }
     });
   }
 

--- a/scripts/repro/repro-stale-downstream-launch-dispatch.sh
+++ b/scripts/repro/repro-stale-downstream-launch-dispatch.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION=""
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bash scripts/repro/repro-stale-downstream-launch-dispatch.sh --expect-issue
+  bash scripts/repro/repro-stale-downstream-launch-dispatch.sh --expect-fixed
+
+What it proves:
+  A downstream launch dispatch row that was enqueued while its dependency was
+  completed must be invalidated or skipped if that dependency later reverts to
+  pending before the dispatch is leased.
+
+Exit codes:
+  0  observed behavior matches expectation
+  1  observed behavior does not match expectation
+  2  invalid repro usage
+
+Set REPRO_KEEP_TMP=1 to keep the temporary DB and log directory.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --expect-issue)
+      EXPECTATION="issue"
+      shift
+      ;;
+    --expect-fixed)
+      EXPECTATION="fixed"
+      shift
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "repro: unknown arg: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "$EXPECTATION" != "issue" && "$EXPECTATION" != "fixed" ]]; then
+  echo "repro: choose --expect-issue or --expect-fixed" >&2
+  usage >&2
+  exit 2
+fi
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "missing required command: $1" >&2
+    exit 2
+  }
+}
+
+require_cmd pnpm
+require_cmd sqlite3
+
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/invoker-stale-dispatch.XXXXXX")"
+DB_DIR="$TMP_ROOT/db"
+DB_PATH="$DB_DIR/invoker.db"
+LOG_PATH="$TMP_ROOT/vitest.log"
+mkdir -p "$DB_DIR"
+
+cleanup() {
+  local ec=$?
+  if [[ "${REPRO_KEEP_TMP:-0}" != "1" ]]; then
+    rm -rf "$TMP_ROOT"
+  else
+    echo "repro: kept temp root: $TMP_ROOT"
+  fi
+  return "$ec"
+}
+trap cleanup EXIT
+
+set +e
+(
+  cd "$ROOT_DIR"
+  INVOKER_STALE_DISPATCH_REPRO_DB_PATH="$DB_PATH" \
+    pnpm --filter @invoker/data-store exec vitest run \
+      --reporter verbose \
+      --exclude '**/node_modules/**' \
+      src/__tests__/stale-downstream-launch-dispatch-repro.test.ts
+) >"$LOG_PATH" 2>&1
+TEST_STATUS=$?
+set -e
+
+WORKFLOW_ID="wf-stale-downstream-dispatch"
+UPSTREAM_ID="${WORKFLOW_ID}/verify"
+MERGE_ID="__merge__${WORKFLOW_ID}"
+
+STALE_LEASE_COUNT=0
+if [[ -f "$DB_PATH" ]]; then
+  STALE_LEASE_COUNT="$(
+    sqlite3 -noheader "$DB_PATH" "
+      select count(*)
+      from task_launch_dispatch d
+      join tasks merge_task on merge_task.id = d.task_id
+      join tasks upstream on upstream.id = '$UPSTREAM_ID'
+      where d.task_id = '$MERGE_ID'
+        and d.state = 'leased'
+        and upstream.status != 'completed'
+        and d.attempt_id != coalesce(merge_task.selected_attempt_id, '');
+    "
+  )"
+fi
+
+if [[ "$STALE_LEASE_COUNT" -gt 0 ]]; then
+  OBSERVED="issue"
+elif [[ "$TEST_STATUS" -eq 0 ]]; then
+  OBSERVED="fixed"
+else
+  OBSERVED="test-error"
+fi
+
+echo "stale_downstream_dispatch_test_exit : $TEST_STATUS"
+echo "stale_downstream_dispatch_observed  : $OBSERVED"
+echo "expected                            : $EXPECTATION"
+echo "temp_db                             : $DB_PATH"
+echo "vitest_log                          : $LOG_PATH"
+
+if [[ -f "$DB_PATH" ]]; then
+  echo
+  echo "task rows:"
+  sqlite3 -header -column "$DB_PATH" "
+    select id, status, dependencies, selected_attempt_id, execution_generation
+    from tasks
+    where id in ('$UPSTREAM_ID', '$MERGE_ID')
+    order by id;
+  "
+
+  echo
+  echo "launch dispatch rows:"
+  sqlite3 -header -column "$DB_PATH" "
+    select id, task_id, attempt_id, state, generation, dispatch_owner, leased_at, last_error
+    from task_launch_dispatch
+    order by id;
+  "
+fi
+
+if [[ "$OBSERVED" != "$EXPECTATION" ]]; then
+  echo
+  echo "--- vitest log ---"
+  cat "$LOG_PATH"
+  exit 1
+fi
+
+echo "==> repro matched expectation"


### PR DESCRIPTION
## Summary

Adds a temp-DB repro for stale downstream launch dispatch rows after dependency reset.

Fences SQLite dispatch claims so stale attempt, generation, missing-task, and non-pending task rows are abandoned before lease.

Also cleans execution resource leases when workflows or workflow task sets are deleted.

## Architecture

### Before

```mermaid
graph TD
    A[Dependency reverts to pending] --> B[Old downstream dispatch remains enqueued]
    B --> C[claimLaunchDispatchAtomic leases by priority only]
    C --> D[Downstream task can run against stale graph]
```

### After

```mermaid
graph TD
    A[Dependency reverts to pending] --> B[Old downstream dispatch remains enqueued]
    B --> C[claimLaunchDispatchAtomic joins current task row]
    C --> D{Attempt, generation, status valid?}
    D -- yes --> E[Lease dispatch]
    D -- no --> F[Abandon stale row and scan next candidate]
```

## Test Plan

- [x] `pnpm --filter @invoker/data-store exec vitest run --reporter verbose --exclude '**/node_modules/**' src/__tests__/stale-downstream-launch-dispatch-repro.test.ts src/__tests__/sqlite-adapter.test.ts`
- [x] `bash scripts/repro/repro-stale-downstream-launch-dispatch.sh --expect-fixed`

## Revert Plan

- Safe to revert? Yes, before dependent stack layers merge.
- Revert command: `git revert ce80e6aeb`
- Post-revert steps: Rerun the stale downstream dispatch repro.
- Data migration? No.