### PR TITLE
Invalidate launch artifacts on lifecycle resets

### DIFF
--- a/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
+++ b/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
@@ -83,6 +83,7 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
   const firstAttemptId = firstClaim!.execution.selectedAttemptId!;
 
   let runnerCalls = 0;
+  let deferredCompleteResult: boolean | undefined;
   const dispatcher = new LaunchDispatcher({
     persistence,
     orchestrator: {
@@ -104,7 +105,7 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
           });
           orchestrator.deferTask(task.id);
           if (options.completeDeferredDispatch) {
-            expect(dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId)).toBe(true);
+            deferredCompleteResult = dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId);
           }
           return;
         }
@@ -141,34 +142,44 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
       .listLaunchDispatchesByState(['enqueued', 'leased', 'acknowledged'])
       .filter((row) => row.taskId === taskId)
       .map((row) => ({ attemptId: row.attemptId, state: row.state })),
+    abandonedRows: persistence
+      .listLaunchDispatchesByState(['abandoned'])
+      .filter((row) => row.taskId === taskId)
+      .map((row) => ({ attemptId: row.attemptId, state: row.state })),
     completedRows: persistence
       .listLaunchDispatchesByState(['completed'])
       .filter((row) => row.taskId === taskId)
       .map((row) => ({ attemptId: row.attemptId, state: row.state })),
+    deferredCompleteResult,
   };
 }
 
 describe('launch pool deferral outbox repro', () => {
-  it('proves the root cause: an acknowledged deferred row blocks the replacement launch', async () => {
+  it('invalidates an acknowledged deferred row so it cannot block the replacement launch', async () => {
     const result = await runPoolDeferralScenario({ completeDeferredDispatch: false });
 
-    expect(result.runnerCalls).toBe(1);
-    expect(result.task.status).toBe('pending');
-    expect(result.task.execution.phase).toBe('launching');
-    expect(result.liveRows).toEqual([
-      { attemptId: result.firstAttemptId, state: 'acknowledged' },
-      { attemptId: result.replacementAttemptId, state: 'enqueued' },
+    expect(result.runnerCalls).toBe(2);
+    expect(result.task.status).toBe('completed');
+    expect(result.liveRows).toEqual([]);
+    expect(result.abandonedRows).toEqual([
+      { attemptId: result.firstAttemptId, state: 'abandoned' },
+    ]);
+    expect(result.completedRows).toEqual([
+      { attemptId: result.replacementAttemptId, state: 'completed' },
     ]);
   });
 
-  it('proves the fix: completing the deferred row frees capacity for the replacement launch', async () => {
+  it('rejects late completion of an already-invalidated deferred row', async () => {
     const result = await runPoolDeferralScenario({ completeDeferredDispatch: true });
 
     expect(result.runnerCalls).toBe(2);
     expect(result.task.status).toBe('completed');
     expect(result.liveRows).toEqual([]);
+    expect(result.deferredCompleteResult).toBe(false);
+    expect(result.abandonedRows).toEqual([
+      { attemptId: result.firstAttemptId, state: 'abandoned' },
+    ]);
     expect(result.completedRows).toEqual([
-      { attemptId: result.firstAttemptId, state: 'completed' },
       { attemptId: result.replacementAttemptId, state: 'completed' },
     ]);
   });

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -731,6 +731,108 @@ describe('SQLiteAdapter', () => {
       });
     });
 
+    it('abandonLaunchDispatchesForTasks abandons active rows for the selected task set', () => {
+      adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
+      saveLaunchTask('wf-launch', 'wf-launch/t1', 'attempt-live-1');
+      saveLaunchTask('wf-launch', 'wf-launch/t2', 'attempt-live-2');
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-live-1',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      const leased = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-live-1b',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      const acknowledged = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-live-1c',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      const completed = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t1',
+        attemptId: 'attempt-completed',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      const unrelated = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t2',
+        attemptId: 'attempt-live-2',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'leased', dispatch_owner = 'owner-1', fenced_until = '2026-06-03T00:05:00.000Z' WHERE id = ?`,
+        [leased.id],
+      );
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'acknowledged', dispatch_owner = 'owner-2', fenced_until = '2026-06-03T00:05:00.000Z' WHERE id = ?`,
+        [acknowledged.id],
+      );
+      adapter.markLaunchDispatchCompleted(completed.id, '2026-06-03T00:04:00.000Z');
+
+      const invalidated = adapter.abandonLaunchDispatchesForTasks(
+        ['wf-launch/t1'],
+        'reset invalidated launch dispatch',
+        '2026-06-03T00:06:00.000Z',
+      );
+
+      expect(invalidated.map((row) => ({ id: row.id, state: row.state }))).toEqual([
+        { id: enqueued.id, state: 'enqueued' },
+        { id: leased.id, state: 'leased' },
+        { id: acknowledged.id, state: 'acknowledged' },
+      ]);
+      for (const row of [enqueued, leased, acknowledged]) {
+        const after = adapter.loadLaunchDispatchById(row.id);
+        expect(after?.state).toBe('abandoned');
+        expect(after?.completedAt).toBe('2026-06-03T00:06:00.000Z');
+        expect(after?.lastError).toBe('reset invalidated launch dispatch');
+        expect(after?.dispatchOwner).toBeUndefined();
+        expect(after?.fencedUntil).toBeUndefined();
+      }
+      expect(adapter.loadLaunchDispatchById(completed.id)?.state).toBe('completed');
+      expect(adapter.loadLaunchDispatchById(unrelated.id)?.state).toBe('enqueued');
+    });
+
+    it('releaseExecutionResourceLeasesForTasks releases only leases held by the selected task set', () => {
+      adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
+      saveLaunchTask('wf-launch', 'wf-launch/t1', 'attempt-lease-1');
+      saveLaunchTask('wf-launch', 'wf-launch/t2', 'attempt-lease-2');
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:lifecycle-1',
+        resourceType: 'ssh',
+        holderId: 'holder-lifecycle-1',
+        taskId: 'wf-launch/t1',
+      })).toBe(true);
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:lifecycle-2',
+        resourceType: 'ssh',
+        holderId: 'holder-lifecycle-2',
+        taskId: 'wf-launch/t2',
+      })).toBe(true);
+
+      const released = adapter.releaseExecutionResourceLeasesForTasks(
+        ['wf-launch/t1'],
+        'reset invalidated resource lease',
+        '2026-06-03T00:07:00.000Z',
+      );
+
+      expect(released).toEqual([
+        {
+          resourceKey: 'ssh:lifecycle-1',
+          resourceType: 'ssh',
+          holderId: 'holder-lifecycle-1',
+          taskId: 'wf-launch/t1',
+        },
+      ]);
+      expect(adapter.listExecutionResourceLeasesByTask('wf-launch/t1')).toEqual([]);
+      expect(adapter.listExecutionResourceLeasesByTask('wf-launch/t2')).toHaveLength(1);
+    });
+
     it('deleteWorkflow removes launch dispatches and execution resource leases for deleted tasks', () => {
       setupWorkflowAndTask('wf-launch', 'wf-launch/t1', {
         selectedAttemptId: 'attempt-delete-cleanup',

--- a/packages/data-store/src/adapter.ts
+++ b/packages/data-store/src/adapter.ts
@@ -76,6 +76,22 @@ export interface WorkflowTaskSnapshot {
   tasksByWorkflowId: Map<string, TaskState[]>;
 }
 
+export interface LaunchDispatchInvalidationRow {
+  id: number;
+  taskId: string;
+  attemptId: string;
+  workflowId: string;
+  state: string;
+  generation: number;
+}
+
+export interface ExecutionResourceLeaseReleaseRow {
+  resourceKey: string;
+  resourceType: string;
+  holderId: string;
+  taskId?: string;
+}
+
 export interface PersistenceAdapter {
   // Workflows
   saveWorkflow(workflow: Workflow): void;
@@ -134,6 +150,17 @@ export interface PersistenceAdapter {
     taskChanges: TaskStateChanges,
     attemptPatch: Partial<Pick<Attempt, 'status' | 'exitCode' | 'error' | 'completedAt'>>
   ): void;
+
+  abandonLaunchDispatchesForTasks(
+    taskIds: readonly string[],
+    reason: string,
+    nowIso?: string,
+  ): LaunchDispatchInvalidationRow[];
+  releaseExecutionResourceLeasesForTasks(
+    taskIds: readonly string[],
+    reason: string,
+    nowIso?: string,
+  ): ExecutionResourceLeaseReleaseRow[];
 
   // Agent queries
   /** Read the configured execution agent name for a task (e.g. 'claude', 'codex'). */

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -39,6 +39,8 @@ import {
   normalizeRunnerKind,
 } from '@invoker/workflow-core';
 import type {
+  ExecutionResourceLeaseReleaseRow,
+  LaunchDispatchInvalidationRow,
   PersistenceAdapter,
   Workflow,
   WorkflowTaskSnapshot,
@@ -3114,6 +3116,40 @@ export class SQLiteAdapter implements PersistenceAdapter {
     }));
   }
 
+  releaseExecutionResourceLeasesForTasks(
+    taskIds: readonly string[],
+    _reason: string,
+    _nowIso?: string,
+  ): ExecutionResourceLeaseReleaseRow[] {
+    const ids = Array.from(new Set(taskIds.filter((id): id is string => typeof id === 'string' && id.length > 0)));
+    if (ids.length === 0) return [];
+    const placeholders = ids.map(() => '?').join(', ');
+
+    return this.runTransaction(() => {
+      const rows = this.queryAll(
+        `SELECT resource_key, resource_type, holder_id, task_id
+           FROM execution_resource_leases
+          WHERE task_id IN (${placeholders})
+          ORDER BY acquired_at ASC, resource_key ASC`,
+        ids,
+      );
+      if (rows.length === 0) return [];
+
+      this.execRun(
+        `DELETE FROM execution_resource_leases
+          WHERE task_id IN (${placeholders})`,
+        ids,
+      );
+
+      return rows.map((row) => ({
+        resourceKey: String(row.resource_key),
+        resourceType: String(row.resource_type),
+        holderId: String(row.holder_id),
+        taskId: row.task_id ? String(row.task_id) : undefined,
+      }));
+    });
+  }
+
   enqueueLaunchDispatch(input: {
     taskId: string;
     attemptId: string;
@@ -3388,6 +3424,52 @@ export class SQLiteAdapter implements PersistenceAdapter {
       [now, errorMessage, id],
     );
     return (this.db.getRowsModified?.() ?? 0) > 0;
+  }
+
+  abandonLaunchDispatchesForTasks(
+    taskIds: readonly string[],
+    reason: string,
+    nowIso?: string,
+  ): LaunchDispatchInvalidationRow[] {
+    const ids = Array.from(new Set(taskIds.filter((id): id is string => typeof id === 'string' && id.length > 0)));
+    if (ids.length === 0) return [];
+    const now = nowIso ?? new Date().toISOString();
+    const taskPlaceholders = ids.map(() => '?').join(', ');
+
+    return this.runTransaction(() => {
+      const rows = this.queryAll(
+        `SELECT id, task_id, attempt_id, workflow_id, state, generation
+           FROM task_launch_dispatch
+          WHERE task_id IN (${taskPlaceholders})
+            AND state IN ('enqueued', 'leased', 'acknowledged')
+          ORDER BY id ASC`,
+        ids,
+      );
+      if (rows.length === 0) return [];
+
+      const rowIds = rows.map((row) => Number(row.id));
+      const idPlaceholders = rowIds.map(() => '?').join(', ');
+      this.execRun(
+        `UPDATE task_launch_dispatch
+            SET state = 'abandoned',
+                completed_at = ?,
+                last_error = ?,
+                dispatch_owner = NULL,
+                fenced_until = NULL
+          WHERE id IN (${idPlaceholders})
+            AND state IN ('enqueued', 'leased', 'acknowledged')`,
+        [now, reason, ...rowIds],
+      );
+
+      return rows.map((row) => ({
+        id: Number(row.id),
+        taskId: String(row.task_id),
+        attemptId: String(row.attempt_id),
+        workflowId: String(row.workflow_id),
+        state: String(row.state),
+        generation: Number(row.generation ?? 0),
+      }));
+    });
   }
 
   reapExpiredLaunchDispatchLeases(nowIso?: string): TaskLaunchDispatch[] {

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import { Orchestrator } from '../orchestrator.js';
 import type {
   Attempt,
+  ExecutionResourceLeaseReleaseRow,
+  LaunchDispatchInvalidationRow,
   OrchestratorMessageBus,
   OrchestratorPersistence,
   PlanDefinition,
@@ -20,8 +22,16 @@ interface LaunchDispatchRow {
   taskId: string;
   attemptId: string;
   workflowId: string;
+  state: 'enqueued' | 'leased' | 'acknowledged' | 'completed' | 'abandoned';
   priority: 'high' | 'normal' | 'low';
   generation: number;
+}
+
+interface ExecutionResourceLeaseRow {
+  resourceKey: string;
+  resourceType: string;
+  holderId: string;
+  taskId: string;
 }
 
 class InMemoryPersistence implements OrchestratorPersistence {
@@ -29,6 +39,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
   tasks = new Map<string, { workflowId: string; task: TaskState }>();
   events: LoggedEvent[] = [];
   launchDispatchRows: LaunchDispatchRow[] = [];
+  executionResourceLeases: ExecutionResourceLeaseRow[] = [];
   enqueueLaunchDispatchEnabled = false;
   private attempts = new Map<string, Attempt[]>();
   private nextDispatchId = 1;
@@ -118,11 +129,48 @@ class InMemoryPersistence implements OrchestratorPersistence {
       taskId: input.taskId,
       attemptId: input.attemptId,
       workflowId: input.workflowId,
+      state: 'enqueued',
       priority: input.priority ?? 'normal',
       generation: input.generation,
     };
     this.launchDispatchRows.push(row);
     return { id: row.id };
+  }
+
+  abandonLaunchDispatchesForTasks(
+    taskIds: readonly string[],
+    _reason: string,
+    _nowIso?: string,
+  ): LaunchDispatchInvalidationRow[] {
+    const taskSet = new Set(taskIds);
+    const rows = this.launchDispatchRows.filter(
+      (row) =>
+        taskSet.has(row.taskId) &&
+        (row.state === 'enqueued' || row.state === 'leased' || row.state === 'acknowledged'),
+    );
+    const invalidated = rows.map((row) => ({
+      id: row.id,
+      taskId: row.taskId,
+      attemptId: row.attemptId,
+      workflowId: row.workflowId,
+      state: row.state,
+      generation: row.generation,
+    }));
+    for (const row of rows) {
+      row.state = 'abandoned';
+    }
+    return invalidated;
+  }
+
+  releaseExecutionResourceLeasesForTasks(
+    taskIds: readonly string[],
+    _reason: string,
+    _nowIso?: string,
+  ): ExecutionResourceLeaseReleaseRow[] {
+    const taskSet = new Set(taskIds);
+    const released = this.executionResourceLeases.filter((lease) => taskSet.has(lease.taskId));
+    this.executionResourceLeases = this.executionResourceLeases.filter((lease) => !taskSet.has(lease.taskId));
+    return released.map((lease) => ({ ...lease }));
   }
 }
 
@@ -417,6 +465,102 @@ describe('Orchestrator launch claims', () => {
     expect(downstream.execution.phase).toBeUndefined();
     expect(downstream.execution.launchStartedAt).toBeUndefined();
     expect(downstream.execution.launchCompletedAt).toBeUndefined();
+  });
+
+  it('invalidates downstream launch dispatches and leases when retryTask resets the subgraph', () => {
+    const { orchestrator, persistence } = makeOrchestrator({
+      deferRunningUntilLaunch: true,
+      enqueueLaunchDispatchEnabled: true,
+      launchOutboxMode: 'observe',
+      maxConcurrency: 4,
+    });
+    orchestrator.loadPlan({
+      name: 'invalidate-retry-task-launch-artifacts',
+      onFinish: 'none',
+      tasks: [
+        { id: 'a', description: 'upstream', command: 'echo a' },
+        { id: 'b', description: 'downstream', command: 'echo b', dependencies: ['a'] },
+      ],
+    });
+
+    const upstreamId = taskIdBySuffix(orchestrator, 'a');
+    const downstreamId = taskIdBySuffix(orchestrator, 'b');
+    const [upstreamClaim] = orchestrator.startExecution();
+    expect(orchestrator.markTaskRunningAfterLaunch(upstreamId, upstreamClaim!.execution.selectedAttemptId!)).toBe(true);
+    respondForTask(orchestrator, upstreamId, 'completed');
+    const downstreamDispatch = persistence.launchDispatchRows.find((row) => row.taskId === downstreamId)!;
+    downstreamDispatch.state = 'leased';
+    persistence.executionResourceLeases.push({
+      resourceKey: 'ssh:downstream',
+      resourceType: 'ssh',
+      holderId: 'holder-downstream',
+      taskId: downstreamId,
+    });
+
+    orchestrator.retryTask(upstreamId);
+
+    expect(downstreamDispatch.state).toBe('abandoned');
+    expect(persistence.executionResourceLeases).toEqual([]);
+    expect(persistence.events).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          taskId: downstreamId,
+          eventType: 'task.launch_dispatch_invalidated',
+          payload: expect.objectContaining({
+            dispatchId: downstreamDispatch.id,
+            previousState: 'leased',
+            reason: 'task subgraph reset to pending',
+          }),
+        }),
+        expect.objectContaining({
+          taskId: downstreamId,
+          eventType: 'task.execution_resource_lease_released',
+          payload: expect.objectContaining({
+            resourceKey: 'ssh:downstream',
+            holderId: 'holder-downstream',
+            reason: 'task subgraph reset to pending',
+          }),
+        }),
+      ]),
+    );
+  });
+
+  it('invalidates launch dispatches and leases when cancelling a workflow', () => {
+    const { orchestrator, persistence } = makeOrchestrator({
+      deferRunningUntilLaunch: true,
+      enqueueLaunchDispatchEnabled: true,
+      launchOutboxMode: 'observe',
+      maxConcurrency: 4,
+    });
+    orchestrator.loadPlan({
+      name: 'invalidate-cancel-workflow-launch-artifacts',
+      onFinish: 'none',
+      tasks: [
+        { id: 'a', description: 'first', command: 'echo a' },
+        { id: 'b', description: 'second', command: 'echo b' },
+      ],
+    });
+    const workflowId = orchestrator.getWorkflowIds()[0]!;
+    const started = orchestrator.startExecution();
+    for (const task of started) {
+      persistence.executionResourceLeases.push({
+        resourceKey: `ssh:${task.id}`,
+        resourceType: 'ssh',
+        holderId: `holder:${task.id}`,
+        taskId: task.id,
+      });
+    }
+
+    orchestrator.cancelWorkflow(workflowId);
+
+    expect(persistence.launchDispatchRows.map((row) => row.state)).toEqual(['abandoned', 'abandoned']);
+    expect(persistence.executionResourceLeases).toEqual([]);
+    expect(
+      persistence.events.filter((event) => event.eventType === 'task.launch_dispatch_invalidated'),
+    ).toHaveLength(2);
+    expect(
+      persistence.events.filter((event) => event.eventType === 'task.execution_resource_lease_released'),
+    ).toHaveLength(2);
   });
 
   it('ignores responses for a selected attempt row that has been superseded', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -147,6 +147,22 @@ export class PlanConflictError extends Error {
 
 // ── Adapter Interfaces ──────────────────────────────────────
 
+export interface LaunchDispatchInvalidationRow {
+  id: number;
+  taskId: string;
+  attemptId: string;
+  workflowId: string;
+  state: string;
+  generation: number;
+}
+
+export interface ExecutionResourceLeaseReleaseRow {
+  resourceKey: string;
+  resourceType: string;
+  holderId: string;
+  taskId?: string;
+}
+
 export interface OrchestratorPersistence {
   saveWorkflow(workflow: {
     id: string;
@@ -245,6 +261,16 @@ export interface OrchestratorPersistence {
     priority?: 'high' | 'normal' | 'low';
     generation: number;
   }): { id: number };
+  abandonLaunchDispatchesForTasks?(
+    taskIds: readonly string[],
+    reason: string,
+    nowIso?: string,
+  ): LaunchDispatchInvalidationRow[];
+  releaseExecutionResourceLeasesForTasks?(
+    taskIds: readonly string[],
+    reason: string,
+    nowIso?: string,
+  ): ExecutionResourceLeaseReleaseRow[];
 }
 
 export interface OrchestratorMessageBus {
@@ -995,6 +1021,44 @@ export class Orchestrator {
     return ids;
   }
 
+  private invalidateLaunchArtifactsForTasks(
+    taskIds: readonly string[],
+    reason: string,
+    now: Date = new Date(),
+  ): void {
+    const ids = Array.from(new Set(taskIds.filter((id) => typeof id === 'string' && id.length > 0)));
+    if (ids.length === 0) return;
+
+    const invalidatedAt = now.toISOString();
+    const invalidatedDispatches =
+      this.persistence.abandonLaunchDispatchesForTasks?.(ids, reason, invalidatedAt) ?? [];
+    const releasedLeases =
+      this.persistence.releaseExecutionResourceLeasesForTasks?.(ids, reason, invalidatedAt) ?? [];
+
+    for (const row of invalidatedDispatches) {
+      this.persistence.logEvent?.(row.taskId, 'task.launch_dispatch_invalidated', {
+        dispatchId: row.id,
+        attemptId: row.attemptId,
+        workflowId: row.workflowId,
+        previousState: row.state,
+        generation: row.generation,
+        reason,
+        invalidatedAt,
+      });
+    }
+
+    for (const row of releasedLeases) {
+      if (!row.taskId) continue;
+      this.persistence.logEvent?.(row.taskId, 'task.execution_resource_lease_released', {
+        resourceKey: row.resourceKey,
+        resourceType: row.resourceType,
+        holderId: row.holderId,
+        reason,
+        invalidatedAt,
+      });
+    }
+  }
+
   /**
    * Reset root tasks and all downstream dependents to pending using the
    * provided reset payload. Returns the affected IDs and currently-ready IDs.
@@ -1011,6 +1075,8 @@ export class Orchestrator {
     const pendingTaskDeltas: TaskDelta[] = [];
 
     this.taskRepository.runInTransaction(() => {
+      this.invalidateLaunchArtifactsForTasks(affectedIds, 'task subgraph reset to pending');
+
       for (const id of affectedIds) {
         const current = this.stateGetTask(id);
         if (!current) continue;
@@ -2516,6 +2582,7 @@ export class Orchestrator {
       taskId: rootId,
       resetCount: toResetIds.length,
     });
+    this.invalidateLaunchArtifactsForTasks(toResetIds, 'task recreation reset');
 
     for (const id of toResetIds) {
       const current = this.stateGetTask(id);
@@ -2596,6 +2663,10 @@ export class Orchestrator {
     });
     this.logger.info(
       '[agent-session-trace] recreateWorkflow: resetChanges.execution clears agentSessionId/containerId (DB NULL before next run)',
+    );
+    this.invalidateLaunchArtifactsForTasks(
+      allTasks.map((task) => task.id),
+      'workflow recreation reset',
     );
     for (const task of allTasks) {
       const prevSess = task.execution.agentSessionId ?? null;
@@ -3674,6 +3745,7 @@ export class Orchestrator {
       taskMap,
       (t) => !!t.config.isMergeNode,
     );
+    this.invalidateLaunchArtifactsForTasks([sourceId, ...descendantIds], 'task replacement');
     for (const id of descendantIds) {
       const staleBefore = this.stateGetTask(id);
       if (!staleBefore) continue;
@@ -4114,6 +4186,7 @@ export class Orchestrator {
     const toCancelIds = [rootId, ...descendantIds];
     const cancelled: string[] = [];
     const runningCancelled: string[] = [];
+    this.invalidateLaunchArtifactsForTasks(toCancelIds, 'task cancellation');
 
     for (const id of toCancelIds) {
       const t = this.stateGetTask(id);
@@ -4180,6 +4253,10 @@ export class Orchestrator {
 
     const cancelled: string[] = [];
     const runningCancelled: string[] = [];
+    this.invalidateLaunchArtifactsForTasks(
+      allTasks.filter((task) => cancellable.has(task.status)).map((task) => task.id),
+      'workflow cancellation',
+    );
 
     for (const task of allTasks) {
       if (!cancellable.has(task.status)) continue;
@@ -4224,6 +4301,7 @@ export class Orchestrator {
     const task = this.stateGetTask(taskId);
     if (!task) return;
     const id = task.id;
+    this.invalidateLaunchArtifactsForTasks([id], 'task deferred');
 
     // Transition running → pending. A deferred launch must not retain the
     // launch-claimed phase; otherwise it can be mistaken for an actively

--- a/scripts/repro/repro-launch-dispatch-lifecycle-invalidation.sh
+++ b/scripts/repro/repro-launch-dispatch-lifecycle-invalidation.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/invoker-launch-lifecycle.XXXXXX")"
+
+cleanup() {
+  local ec=$?
+  if [[ "${REPRO_KEEP_TMP:-0}" != "1" ]]; then
+    rm -rf "$TMP_ROOT"
+  else
+    echo "repro: kept temp root: $TMP_ROOT"
+  fi
+  return "$ec"
+}
+trap cleanup EXIT
+
+echo "temp_root : $TMP_ROOT"
+
+echo
+echo "==> stale downstream dispatch temp-DB repro"
+bash "$ROOT_DIR/scripts/repro/repro-stale-downstream-launch-dispatch.sh" --expect-fixed \
+  >"$TMP_ROOT/stale-downstream.log" 2>&1
+tail -n 8 "$TMP_ROOT/stale-downstream.log"
+
+echo
+echo "==> SQLite lifecycle invalidation hooks"
+(
+  cd "$ROOT_DIR"
+  pnpm --filter @invoker/data-store exec vitest run \
+    --reporter verbose \
+    --exclude '**/node_modules/**' \
+    src/__tests__/sqlite-adapter.test.ts \
+    -t 'abandonLaunchDispatchesForTasks|releaseExecutionResourceLeasesForTasks'
+)
+
+echo
+echo "==> orchestrator lifecycle invalidation"
+(
+  cd "$ROOT_DIR"
+  pnpm --filter @invoker/workflow-core exec vitest run \
+    --reporter verbose \
+    --exclude '**/node_modules/**' \
+    src/__tests__/orchestrator-dispatcher.test.ts \
+    -t 'invalidates downstream launch dispatches and leases when retryTask resets the subgraph|invalidates launch dispatches and leases when cancelling a workflow'
+)
+
+echo
+echo "==> lifecycle invalidation repro matched expectation"


### PR DESCRIPTION
## Summary

Adds durable invalidation hooks for launch dispatch rows and task-owned execution resource leases.

Calls those hooks from lifecycle mutations before reset, cancel, defer, and replacement writes can leave downstream launch work alive.

Records audit events for abandoned dispatches and released resource leases.

## Architecture

### Before

```mermaid
graph TD
    A[Lifecycle mutation resets task lineage] --> B[Task state changes]
    A --> C[Scheduler queues cleared]
    D[Durable launch dispatch rows] --> E[Remain live]
    F[Execution resource leases] --> G[Remain reserved]
```

### After

```mermaid
graph TD
    A[Lifecycle mutation resets task lineage] --> B[Collect affected task ids]
    B --> C[Abandon live dispatch rows]
    B --> D[Release task-owned resource leases]
    C --> E[Write task state changes]
    D --> E
```

## Test Plan

- [x] `pnpm --filter @invoker/data-store exec vitest run --reporter verbose --exclude '**/node_modules/**' src/__tests__/sqlite-adapter.test.ts -t 'abandonLaunchDispatchesForTasks|releaseExecutionResourceLeasesForTasks|deleteWorkflow removes launch dispatches'`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run --reporter verbose --exclude '**/node_modules/**' src/__tests__/orchestrator-dispatcher.test.ts -t 'invalidates downstream launch dispatches and leases when retryTask resets the subgraph|invalidates launch dispatches and leases when cancelling a workflow'`
- [x] `bash scripts/repro/repro-launch-dispatch-lifecycle-invalidation.sh`
- [x] `pnpm --filter @invoker/data-store build`
- [x] `pnpm --filter @invoker/workflow-core build`

## Revert Plan

- Safe to revert? Yes, before the readiness-gates stack layer merges.
- Revert command: `git revert 10054b6dd`
- Post-revert steps: Rerun lifecycle invalidation and stale dispatch repro scripts.
- Data migration? No.

Depends-On: #1065