### PR TITLE
Gate launch dispatch on current readiness

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -738,7 +738,7 @@ describe('LaunchDispatcher', () => {
       expect(adapter.loadLaunchDispatchById(1)?.lastError).toBeUndefined();
     });
 
-    it('active mode retires a dispatch row when the selected attempt changed', () => {
+    it('active mode abandons a dispatch row when the selected attempt changed after lease', () => {
       const task = seedWorkflowAndTask('wf-a/t-stale', 'wf-a', {
         selectedAttemptId: 'attempt-old',
         generation: 0,
@@ -774,12 +774,70 @@ describe('LaunchDispatcher', () => {
 
       expect(executeTask).not.toHaveBeenCalled();
       const after = adapter.loadLaunchDispatchById(enq.id);
-      expect(after?.state).toBe('completed');
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/selected attempt or generation changed/);
       const events = adapter.getEvents(task.id);
-      expect(events.some((event) => event.eventType === 'task.launch_dispatch_superseded')).toBe(true);
+      expect(events.some((event) => event.eventType === 'task.launch_dispatch_invalidated')).toBe(true);
     });
 
-    it('active mode fails the dispatch when the orchestrator has no matching task', () => {
+    it('active mode abandons the dispatch when readiness is blocked', () => {
+      const task = seedWorkflowAndTask('wf-a/t-blocked', 'wf-a', {
+        selectedAttemptId: 'attempt-blocked',
+        generation: 0,
+      });
+      const enq = adapter.enqueueLaunchDispatch({
+        taskId: task.id,
+        attemptId: 'attempt-blocked',
+        workflowId: 'wf-a',
+        generation: 0,
+      });
+      expect(adapter.claimExecutionResourceLease({
+        resourceKey: 'ssh:blocked',
+        resourceType: 'ssh',
+        holderId: 'holder-blocked',
+        taskId: task.id,
+      })).toBe(true);
+      const executeTask = vi.fn();
+      const dispatcher = new LaunchDispatcher({
+        persistence: adapter,
+        ownerId: 'owner-a',
+        orchestrator: {
+          prepareTaskForNewAttempt: vi.fn(),
+          getTask: vi.fn().mockReturnValue(task as any),
+          getTaskLaunchReadiness: vi.fn().mockReturnValue({
+            ready: false,
+            reason: 'waiting on wf-a/upstream (pending)',
+            task,
+          }),
+        },
+        taskRunnerProvider: () => ({ executeTask }),
+        mode: 'active',
+        maxConcurrency: 4,
+      });
+
+      dispatcher.poll();
+
+      expect(executeTask).not.toHaveBeenCalled();
+      const after = adapter.loadLaunchDispatchById(enq.id);
+      expect(after?.state).toBe('abandoned');
+      expect(after?.lastError).toMatch(/no longer launch-ready/);
+      expect(adapter.listExecutionResourceLeasesByTask(task.id)).toEqual([]);
+      const events = adapter.getEvents(task.id);
+      const invalidated = events.find((event) => event.eventType === 'task.launch_dispatch_invalidated');
+      expect(JSON.parse(invalidated!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        reason: 'not_launch_ready',
+        readinessReason: 'waiting on wf-a/upstream (pending)',
+      });
+      const released = events.find((event) => event.eventType === 'task.launch_dispatch_lease_released');
+      expect(JSON.parse(released!.payload!)).toMatchObject({
+        dispatchId: enq.id,
+        reason: 'not_launch_ready',
+        resourceKey: 'ssh:blocked',
+      });
+    });
+
+    it('active mode abandons the dispatch when the orchestrator has no matching task', () => {
       seedWorkflowAndTask('wf-a/t-missing', 'wf-a', {
         selectedAttemptId: 'attempt-missing',
         generation: 0,
@@ -806,9 +864,7 @@ describe('LaunchDispatcher', () => {
 
       expect(executeTask).not.toHaveBeenCalled();
       const after = adapter.loadLaunchDispatchById(enq.id);
-      // failDispatch re-enqueues with last_error set (so the next poll
-      // can try again after the fence expires).
-      expect(after?.state).toBe('enqueued');
+      expect(after?.state).toBe('abandoned');
       expect(after?.lastError).toMatch(/missing from orchestrator state/);
     });
 

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -305,6 +305,7 @@ async function dispatchHeadlessRunnableTasks(
         deps.orchestrator.prepareTaskForNewAttempt(taskId, reason),
       syncFromDb: (workflowId) => deps.orchestrator.syncFromDb(workflowId),
       getTask: (taskId) => deps.orchestrator.getTask(taskId),
+      getTaskLaunchReadiness: (taskId) => deps.orchestrator.getTaskLaunchReadiness(taskId),
     },
     taskRunnerProvider: () => taskExecutor,
     ownerId: `headless-${process.pid}`,

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -15,7 +15,7 @@
 
 import type { SQLiteAdapter, TaskLaunchDispatch, TaskLaunchDispatchState } from '@invoker/data-store';
 import type { LaunchOutboxAck } from '@invoker/execution-engine';
-import type { TaskState } from '@invoker/workflow-core';
+import type { TaskLaunchReadiness, TaskState } from '@invoker/workflow-core';
 import { DISPATCH_MAX_ATTEMPTS, type Logger } from '@invoker/contracts';
 
 export type LaunchDispatcherMode = 'observe' | 'active';
@@ -46,6 +46,7 @@ export interface LaunchDispatcherOrchestrator {
   prepareTaskForNewAttempt(taskId: string, reason: string): unknown;
   syncFromDb?(workflowId: string): void;
   getTask?(taskId: string): TaskState | undefined;
+  getTaskLaunchReadiness?(taskId: string): TaskLaunchReadiness;
 }
 
 /**
@@ -180,16 +181,38 @@ export class LaunchDispatcher {
       });
       if (!leased) break;
       dispatched += 1;
-      const task = this.resolveTaskForDispatch(leased);
+      let task = this.resolveTaskForDispatch(leased);
       if (!task) {
-        this.failDispatch(
-          leased.id,
-          new Error(`Task ${leased.taskId} missing from orchestrator state at dispatch time`),
+        this.abandonInvalidDispatch(
+          leased,
+          `Task ${leased.taskId} missing from orchestrator state at dispatch time`,
+          'task_missing',
         );
-        break;
+        continue;
+      }
+      const readiness = this.orchestrator?.getTaskLaunchReadiness?.(leased.taskId);
+      if (readiness) {
+        if (!readiness.ready) {
+          this.abandonInvalidDispatch(
+            leased,
+            `Task ${leased.taskId} is no longer launch-ready: ${readiness.reason}`,
+            'not_launch_ready',
+            { readinessReason: readiness.reason },
+          );
+          continue;
+        }
+        task = readiness.task;
       }
       if (!this.dispatchMatchesTask(leased, task)) {
-        this.retireSupersededDispatch(leased, task);
+        this.abandonInvalidDispatch(
+          leased,
+          `Launch dispatch ${leased.id} is stale: selected attempt or generation changed`,
+          'selected_attempt_changed',
+          {
+            selectedAttemptId: task.execution.selectedAttemptId,
+            selectedGeneration: task.execution.generation ?? 0,
+          },
+        );
         continue;
       }
       // Fire-and-forget within the loop: the dispatch row is the durable
@@ -236,24 +259,32 @@ export class LaunchDispatcher {
       && (task.execution.generation ?? 0) === (dispatch.generation ?? 0);
   }
 
-  private retireSupersededDispatch(dispatch: TaskLaunchDispatch, task: TaskState): void {
-    const accepted = this.persistence.markLaunchDispatchCompleted(dispatch.id);
-    this.persistence.logEvent?.(dispatch.taskId, 'task.launch_dispatch_superseded', {
+  private abandonInvalidDispatch(
+    dispatch: TaskLaunchDispatch,
+    message: string,
+    reason: string,
+    details: Record<string, unknown> = {},
+  ): void {
+    const accepted = this.persistence.markLaunchDispatchAbandoned(dispatch.id, message);
+    if (accepted) {
+      this.releaseTaskResourceLeases(dispatch.taskId, dispatch.id, reason);
+    }
+    this.persistence.logEvent?.(dispatch.taskId, 'task.launch_dispatch_invalidated', {
       dispatchId: dispatch.id,
       dispatchAttemptId: dispatch.attemptId,
       dispatchGeneration: dispatch.generation,
-      selectedAttemptId: task.execution.selectedAttemptId,
-      selectedGeneration: task.execution.generation ?? 0,
-      reason: 'selected_attempt_changed',
+      reason,
+      message,
+      accepted,
+      ...details,
     });
-    this.logger?.warn?.('[launch-dispatcher] retired superseded dispatch', {
+    this.logger?.warn?.('[launch-dispatcher] abandoned invalid dispatch', {
       ownerId: this.ownerId,
       dispatchId: dispatch.id,
       taskId: dispatch.taskId,
       dispatchAttemptId: dispatch.attemptId,
       dispatchGeneration: dispatch.generation,
-      selectedAttemptId: task.execution.selectedAttemptId,
-      selectedGeneration: task.execution.generation ?? 0,
+      reason,
       accepted,
       module: 'launch-dispatcher',
     });
@@ -353,7 +384,11 @@ export class LaunchDispatcher {
    * propagate (abandonStuckLeases must remain idempotent under
    * repeated polls).
    */
-  private releaseTaskResourceLeases(taskId: string, dispatchId: number): void {
+  private releaseTaskResourceLeases(
+    taskId: string,
+    dispatchId: number,
+    reason = 'launch-dispatch-abandoned',
+  ): void {
     let leases: ReadonlyArray<{ resourceKey: string; holderId: string; resourceType: string }> = [];
     try {
       leases = this.persistence.listExecutionResourceLeasesByTask(taskId);
@@ -381,7 +416,7 @@ export class LaunchDispatcher {
           resourceKey: lease.resourceKey,
           resourceType: lease.resourceType,
           holderId: lease.holderId,
-          reason: 'launch-dispatch-abandoned',
+          reason,
         });
       } catch (err) {
         this.logger?.warn?.(

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -563,6 +563,50 @@ describe('Orchestrator launch claims', () => {
     ).toHaveLength(2);
   });
 
+  it('getTaskLaunchReadiness rejects pending tasks whose local dependencies are not satisfied', () => {
+    const { orchestrator } = makeOrchestrator();
+    orchestrator.loadPlan({
+      name: 'launch-readiness-local-deps',
+      onFinish: 'none',
+      tasks: [
+        { id: 'a', description: 'upstream', command: 'echo a' },
+        { id: 'b', description: 'downstream', command: 'echo b', dependencies: ['a'] },
+      ],
+    });
+
+    const upstreamId = taskIdBySuffix(orchestrator, 'a');
+    const downstreamId = taskIdBySuffix(orchestrator, 'b');
+    const readiness = orchestrator.getTaskLaunchReadiness(downstreamId);
+
+    expect(readiness.ready).toBe(false);
+    expect(readiness.reason).toBe(`waiting on ${upstreamId} (pending)`);
+  });
+
+  it('drainScheduler drops stale queued jobs whose dependencies are not launch-ready', () => {
+    const { orchestrator, persistence } = makeOrchestrator({
+      deferRunningUntilLaunch: true,
+      enqueueLaunchDispatchEnabled: true,
+      launchOutboxMode: 'observe',
+      maxConcurrency: 4,
+    });
+    orchestrator.loadPlan({
+      name: 'scheduler-readiness-gate',
+      onFinish: 'none',
+      tasks: [
+        { id: 'a', description: 'upstream', command: 'echo a' },
+        { id: 'b', description: 'downstream', command: 'echo b', dependencies: ['a'] },
+      ],
+    });
+    const downstreamId = taskIdBySuffix(orchestrator, 'b');
+
+    (orchestrator as any).scheduler.enqueue({ taskId: downstreamId, priority: 10 });
+    const started = (orchestrator as any).drainScheduler() as TaskState[];
+
+    expect(started).toEqual([]);
+    expect(orchestrator.getTask(downstreamId)?.status).toBe('pending');
+    expect(persistence.launchDispatchRows.some((row) => row.taskId === downstreamId)).toBe(false);
+  });
+
   it('ignores responses for a selected attempt row that has been superseded', () => {
     const { orchestrator, persistence } = makeOrchestrator();
     orchestrator.loadPlan({

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -163,6 +163,11 @@ export interface ExecutionResourceLeaseReleaseRow {
   taskId?: string;
 }
 
+export type TaskLaunchReadiness =
+  | { ready: true; task: TaskState }
+  | { ready: false; reason: string; task?: TaskState };
+type LaunchReadinessOptions = { bypassLocalDependencyReadiness?: boolean };
+
 export interface OrchestratorPersistence {
   saveWorkflow(workflow: {
     id: string;
@@ -3816,7 +3821,7 @@ export class Orchestrator {
         return !hasInternalDeps;
       })
       .map((rt) => scopeLocal(rt.id));
-    return this.autoStartReadyTasks(rootIds);
+    return this.autoStartReadyTasks(rootIds, 0, { bypassLocalDependencyReadiness: true });
   }
 
   /**
@@ -4770,7 +4775,7 @@ export class Orchestrator {
     }
   }
 
-  private autoStartReadyTasks(taskIds: string[], priority: number = 0): TaskState[] {
+  private autoStartReadyTasks(taskIds: string[], priority: number = 0, opts?: LaunchReadinessOptions): TaskState[] {
     for (const taskId of taskIds) {
       let task = this.stateGetTask(taskId);
       if (!task) continue;
@@ -4797,13 +4802,13 @@ export class Orchestrator {
         if (!task) continue;
       }
 
-      this.enqueueIfNotScheduled(taskId, priority);
+      this.enqueueIfNotScheduled(taskId, priority, opts);
     }
 
     return this.drainScheduler();
   }
 
-  private enqueueIfNotScheduled(taskId: string, priority: number = 0): void {
+  private enqueueIfNotScheduled(taskId: string, priority: number = 0, opts?: LaunchReadinessOptions): void {
     const task = this.stateGetTask(taskId);
     if (!task) return;
     if (this.getExternalDependencyBlocker(task) !== undefined) return;
@@ -4827,13 +4832,26 @@ export class Orchestrator {
       .getQueuedJobs()
       .find((job) => job.attemptId === attemptId || job.taskId === taskId);
     if (queuedJob) {
-      if (priority > queuedJob.priority) {
+      const shouldReplaceQueuedJob =
+        priority > queuedJob.priority ||
+        (opts?.bypassLocalDependencyReadiness === true && !queuedJob.bypassLocalDependencyReadiness);
+      if (shouldReplaceQueuedJob) {
         this.scheduler.removeJob(queuedJob.attemptId ?? queuedJob.taskId);
-        this.scheduler.enqueue({ taskId, attemptId, priority });
+        this.scheduler.enqueue({
+          taskId,
+          attemptId,
+          priority: Math.max(priority, queuedJob.priority),
+          ...(opts?.bypassLocalDependencyReadiness ? { bypassLocalDependencyReadiness: true } : {}),
+        });
       }
       return;
     }
-    this.scheduler.enqueue({ taskId, attemptId, priority });
+    this.scheduler.enqueue({
+      taskId,
+      attemptId,
+      priority,
+      ...(opts?.bypassLocalDependencyReadiness ? { bypassLocalDependencyReadiness: true } : {}),
+    });
   }
 
   /**
@@ -4888,15 +4906,47 @@ export class Orchestrator {
     return this.drainScheduler();
   }
 
-  private areLocalDependenciesSatisfied(task: TaskState): boolean {
-    return task.dependencies.every((depId) => {
-      const dep = this.stateGetTask(depId);
-      if (!dep) return false;
-      if (task.config?.isReconciliation) {
-        return dep.status === 'completed' || dep.status === 'failed' || dep.status === 'closed' || dep.status === 'stale';
+  getTaskLaunchReadiness(taskId: string, opts?: LaunchReadinessOptions): TaskLaunchReadiness {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) {
+      return { ready: false, reason: `task ${taskId} not found` };
+    }
+    if (task.status !== 'pending') {
+      return { ready: false, reason: `task status is ${task.status}`, task };
+    }
+
+    if (!opts?.bypassLocalDependencyReadiness) {
+      const localBlocker = this.getLocalDependencyBlocker(task);
+      if (localBlocker) {
+        return { ready: false, reason: localBlocker, task };
       }
-      return dep.status === 'completed' || dep.status === 'stale';
-    });
+    }
+
+    const externalBlocker = this.getExternalDependencyBlocker(task);
+    if (externalBlocker) {
+      return { ready: false, reason: externalBlocker, task };
+    }
+
+    return { ready: true, task };
+  }
+
+  private areLocalDependenciesSatisfied(task: TaskState): boolean {
+    return this.getLocalDependencyBlocker(task) === undefined;
+  }
+
+  private getLocalDependencyBlocker(task: TaskState): string | undefined {
+    for (const depId of task.dependencies) {
+      const dep = this.stateGetTask(depId);
+      if (!dep) return `missing dependency ${depId}`;
+      const satisfied = task.config?.isReconciliation
+        ? dep.status === 'completed' || dep.status === 'failed' || dep.status === 'closed' || dep.status === 'stale'
+        : dep.status === 'completed' || dep.status === 'stale';
+      if (!satisfied) {
+        return `waiting on ${depId} (${dep.status})`;
+      }
+    }
+    return undefined;
   }
 
   private externalDependencyDisplayId(workflowId: string, taskId?: string): string {
@@ -5204,27 +5254,22 @@ export class Orchestrator {
     });
     let job = availableSlots > 0 ? this.scheduler.takeNext() : null;
     while (job && availableSlots > 0) {
-      const task = this.stateGetTask(job.taskId);
+      const readiness = this.getTaskLaunchReadiness(job.taskId, {
+        bypassLocalDependencyReadiness: job.bypassLocalDependencyReadiness,
+      });
       this.logger.info('[orchestrator] drainScheduler: dequeued', {
         taskId: job.taskId,
-        actualStatus: task?.status ?? 'NOT_FOUND',
+        actualStatus: readiness.task?.status ?? 'NOT_FOUND',
       });
-      if (!task || task.status !== 'pending') {
-        this.logger.info('[orchestrator] drainScheduler: skipping non-pending task', {
+      if (!readiness.ready) {
+        this.logger.info('[orchestrator] drainScheduler: skipping non-ready task', {
           taskId: job.taskId,
+          reason: readiness.reason,
         });
         job = this.scheduler.takeNext();
         continue;
       }
-      const workflowBlocker = this.getExternalDependencyBlocker(task);
-      if (workflowBlocker !== undefined) {
-        this.logger.info('[orchestrator] drainScheduler: skipping externally blocked workflow task', {
-          taskId: job.taskId,
-          blocker: workflowBlocker,
-        });
-        job = this.scheduler.takeNext();
-        continue;
-      }
+      const task = readiness.task;
 
       const now = new Date();
       let attemptId = job.attemptId ?? this.ensureCurrentPendingAttempt(task);

--- a/packages/workflow-core/src/scheduler.ts
+++ b/packages/workflow-core/src/scheduler.ts
@@ -16,6 +16,9 @@ export interface TaskJob {
   taskId: string;
   attemptId?: string;
   priority: number;
+  // Reserved for replacement-root launches. Normal queued work must pass
+  // dependency readiness at dequeue time.
+  bypassLocalDependencyReadiness?: boolean;
 }
 
 export class TaskScheduler {

--- a/scripts/repro/repro-launch-dispatch-readiness-gates.sh
+++ b/scripts/repro/repro-launch-dispatch-readiness-gates.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/invoker-launch-readiness.XXXXXX")"
+
+cleanup() {
+  local ec=$?
+  if [[ "${REPRO_KEEP_TMP:-0}" != "1" ]]; then
+    rm -rf "$TMP_ROOT"
+  else
+    echo "repro: kept temp root: $TMP_ROOT"
+  fi
+  return "$ec"
+}
+trap cleanup EXIT
+
+echo "temp_root : $TMP_ROOT"
+
+echo
+echo "==> lower-stack lifecycle invalidation repro"
+bash "$ROOT_DIR/scripts/repro/repro-launch-dispatch-lifecycle-invalidation.sh" \
+  >"$TMP_ROOT/lifecycle-invalidation.log" 2>&1
+tail -n 12 "$TMP_ROOT/lifecycle-invalidation.log"
+
+echo
+echo "==> workflow-core scheduler readiness gates"
+(
+  cd "$ROOT_DIR"
+  pnpm --filter @invoker/workflow-core exec vitest run \
+    --reporter verbose \
+    --exclude '**/node_modules/**' \
+    src/__tests__/orchestrator-dispatcher.test.ts \
+    -t 'getTaskLaunchReadiness rejects pending tasks whose local dependencies are not satisfied|drainScheduler drops stale queued jobs whose dependencies are not launch-ready'
+)
+
+echo
+echo "==> app launch dispatcher readiness gates"
+(
+  cd "$ROOT_DIR"
+  pnpm --filter @invoker/app exec vitest run \
+    --reporter verbose \
+    --exclude '**/node_modules/**' \
+    src/__tests__/launch-dispatcher.test.ts \
+    -t 'active mode abandons a dispatch row when the selected attempt changed after lease|active mode abandons the dispatch when readiness is blocked|active mode abandons the dispatch when the orchestrator has no matching task'
+)
+
+echo
+echo "==> readiness gates repro matched expectation"


### PR DESCRIPTION
## Summary

Adds an orchestrator launch-readiness query that proves current task status, local dependencies, and external dependencies.

Uses that query in scheduler drain and active launch dispatch before any task is handed to the runner.

Invalid active dispatch rows are abandoned and resource leases are released instead of being completed or retried.

## Architecture

### Before

```mermaid
graph TD
    A[Scheduler dequeues job] --> B[Checks pending status]
    B --> C[Claims attempt and enqueues dispatch]
    D[Active dispatcher leases row] --> E[Checks task exists and attempt matches]
    E --> F[TaskRunner executes]
```

### After

```mermaid
graph TD
    A[Scheduler dequeues job] --> B[Checks launch readiness]
    B --> C{Dependencies ready now?}
    C -- yes --> D[Claim attempt and enqueue dispatch]
    C -- no --> E[Drop stale scheduler job]
    F[Active dispatcher leases row] --> G[Reload readiness]
    G --> H{Still launch-ready?}
    H -- yes --> I[TaskRunner executes]
    H -- no --> J[Abandon dispatch and release leases]
```

## Test Plan

- [x] `pnpm --filter @invoker/workflow-core exec vitest run --reporter verbose --exclude '**/node_modules/**' src/__tests__/orchestrator-dispatcher.test.ts -t 'getTaskLaunchReadiness|drainScheduler drops stale queued jobs|invalidates downstream launch dispatches'`
- [x] `pnpm --filter @invoker/app exec vitest run --reporter verbose --exclude '**/node_modules/**' src/__tests__/launch-dispatcher.test.ts`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run --reporter verbose --exclude '**/node_modules/**' src/__tests__/orchestrator-dispatcher.test.ts`
- [x] `bash scripts/repro/repro-launch-dispatch-readiness-gates.sh`
- [x] `pnpm --filter @invoker/workflow-core build`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes, if downstream PRs do not depend on readiness events.
- Revert command: `git revert a09113bab`
- Post-revert steps: Rerun launch dispatcher and orchestrator dispatcher tests.
- Data migration? No.

Depends-On: #1066