### PR TITLE
workflow-core: add recreateDownstream primitive

### DIFF
--- a/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-plan.test.ts
@@ -31,6 +31,10 @@ describe('InvalidationPlan policy registry', () => {
       scope: 'task',
       mode: 'recreate',
     });
+    expect(ACTION_SPECS.recreateDownstream).toMatchObject({
+      scope: 'task',
+      mode: 'recreate',
+    });
     expect(ACTION_SPECS.retryWorkflow).toMatchObject({
       scope: 'workflow',
       mode: 'retry',
@@ -90,6 +94,66 @@ describe('InvalidationPlan policy registry', () => {
       affectedTaskIds: ['wf-1/child', 'wf-1/grandchild', 'wf-1/root'],
       lockPlan: { workflowIds: ['wf-1'] },
     });
+  });
+
+  it('plans downstream recreate as descendants only, excluding the target', () => {
+    const tasks = [
+      task('wf-1/root', 'wf-1'),
+      task('wf-1/child', 'wf-1', ['wf-1/root']),
+      task('wf-1/grandchild', 'wf-1', ['wf-1/child']),
+      task('wf-1/sibling', 'wf-1'),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/root',
+      tasks,
+    });
+
+    expect(plan).toMatchObject({
+      action: 'recreateDownstream',
+      scope: 'task',
+      mode: 'recreate',
+      affectedWorkflowIds: ['wf-1'],
+      affectedTaskIds: ['wf-1/child', 'wf-1/grandchild'],
+      lockPlan: { workflowIds: ['wf-1'] },
+    });
+    expect(plan.affectedTaskIds).not.toContain('wf-1/root');
+    expect(plan.affectedTaskIds).not.toContain('wf-1/sibling');
+  });
+
+  it('plans downstream recreate on an intermediate node as its descendants only', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/b', 'wf-1', ['wf-1/a']),
+      task('wf-1/c', 'wf-1', ['wf-1/b']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/b',
+      tasks,
+    });
+
+    expect(plan.affectedTaskIds).toEqual(['wf-1/c']);
+  });
+
+  it('plans downstream recreate on a leaf as an empty affected set (no-op)', () => {
+    const tasks = [
+      task('wf-1/a', 'wf-1'),
+      task('wf-1/b', 'wf-1', ['wf-1/a']),
+      task('wf-1/c', 'wf-1', ['wf-1/b']),
+    ];
+
+    const plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: 'wf-1/c',
+      tasks,
+    });
+
+    expect(plan.affectedTaskIds).toEqual([]);
+    expect(plan.affectedWorkflowIds).toEqual([]);
+    expect(plan.schedulerEnqueueCandidates).toEqual([]);
   });
 
   it('plans task retry as the task plus non-completed descendants', () => {

--- a/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
+++ b/packages/workflow-core/src/__tests__/invalidation-policy.test.ts
@@ -525,6 +525,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
   'fixReject',
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',
@@ -534,6 +535,7 @@ const ALL_INVALIDATION_ACTIONS: readonly InvalidationAction[] = [
 const INVALIDATING_ACTIONS: readonly InvalidationAction[] = [
   'retryTask',
   'recreateTask',
+  'recreateDownstream',
   'retryWorkflow',
   'recreateWorkflow',
   'recreateWorkflowFromFreshBase',

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -5942,6 +5942,169 @@ describe('Orchestrator', () => {
       expect(x.execution.workspacePath).toBe('/tmp/x');
     });
 
+    function loadRecreateDownstreamChain(wf: string) {
+      const testPersistence = new InMemoryPersistence();
+      const testBus = new InMemoryBus();
+
+      testPersistence.saveTask(wf, {
+        id: 'A',
+        description: 'Root',
+        status: 'completed',
+        dependencies: [],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-a',
+          commit: 'a1',
+          workspacePath: '/tmp/a',
+          agentSessionId: 'sess-a',
+          containerId: 'ct-a',
+          generation: 3,
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'B',
+        description: 'Middle',
+        status: 'completed',
+        dependencies: ['A'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-b',
+          commit: 'b1',
+          workspacePath: '/tmp/b',
+          agentSessionId: 'sess-b',
+          containerId: 'ct-b',
+          generation: 2,
+          exitCode: 0,
+        },
+      });
+      testPersistence.saveTask(wf, {
+        id: 'C',
+        description: 'Leaf',
+        status: 'completed',
+        dependencies: ['B'],
+        createdAt: new Date(),
+        config: { workflowId: wf },
+        execution: {
+          branch: 'br-c',
+          commit: 'c1',
+          workspacePath: '/tmp/c',
+          agentSessionId: 'sess-c',
+          containerId: 'ct-c',
+          generation: 1,
+          exitCode: 0,
+        },
+      });
+
+      const testOrchestrator = new Orchestrator({
+        persistence: testPersistence,
+        messageBus: testBus,
+        maxConcurrency: 3,
+      });
+      testOrchestrator.syncFromDb(wf);
+      return testOrchestrator;
+    }
+
+    it('recreateDownstream(A) preserves A and resets B and C', () => {
+      const o = loadRecreateDownstreamChain('wf-recreate-downstream-a');
+      o.recreateDownstream('A');
+
+      const a = o.getTask('A')!;
+      // A (the selected task) is left entirely unchanged.
+      expect(a.status).toBe('completed');
+      expect(a.execution.branch).toBe('br-a');
+      expect(a.execution.commit).toBe('a1');
+      expect(a.execution.workspacePath).toBe('/tmp/a');
+      expect(a.execution.agentSessionId).toBe('sess-a');
+      expect(a.execution.containerId).toBe('ct-a');
+      expect(a.execution.generation).toBe(3);
+
+      // B and C are recreated with fresh lineage and bumped generation.
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+      expect(b.status === 'running' || b.status === 'pending').toBe(true);
+      expect(c.status).toBe('pending');
+      for (const t of [b, c]) {
+        expect(t.execution.branch).toBeUndefined();
+        expect(t.execution.commit).toBeUndefined();
+        expect(t.execution.workspacePath).toBeUndefined();
+        expect(t.execution.agentSessionId).toBeUndefined();
+        expect(t.execution.containerId).toBeUndefined();
+      }
+      expect(b.execution.generation).toBe(3);
+      expect(c.execution.generation).toBe(2);
+    });
+
+    it('recreateDownstream(B) resets C only, leaving A and B unchanged', () => {
+      const o = loadRecreateDownstreamChain('wf-recreate-downstream-b');
+      o.recreateDownstream('B');
+
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+
+      expect(a.status).toBe('completed');
+      expect(a.execution.branch).toBe('br-a');
+      expect(a.execution.generation).toBe(3);
+
+      // B is the selected task here — fully preserved.
+      expect(b.status).toBe('completed');
+      expect(b.execution.branch).toBe('br-b');
+      expect(b.execution.commit).toBe('b1');
+      expect(b.execution.workspacePath).toBe('/tmp/b');
+      expect(b.execution.agentSessionId).toBe('sess-b');
+      expect(b.execution.containerId).toBe('ct-b');
+      expect(b.execution.generation).toBe(2);
+
+      // Only C is recreated.
+      expect(c.status === 'running' || c.status === 'pending').toBe(true);
+      expect(c.execution.branch).toBeUndefined();
+      expect(c.execution.workspacePath).toBeUndefined();
+      expect(c.execution.agentSessionId).toBeUndefined();
+      expect(c.execution.containerId).toBeUndefined();
+      expect(c.execution.generation).toBe(2);
+    });
+
+    it('recreateDownstream on a leaf is a no-op returning no started tasks', () => {
+      const o = loadRecreateDownstreamChain('wf-recreate-downstream-leaf');
+      const started = o.recreateDownstream('C');
+
+      expect(started).toEqual([]);
+
+      const a = o.getTask('A')!;
+      const b = o.getTask('B')!;
+      const c = o.getTask('C')!;
+      // Nothing changed anywhere — including the leaf itself.
+      expect(a.status).toBe('completed');
+      expect(b.status).toBe('completed');
+      expect(c.status).toBe('completed');
+      expect(c.execution.branch).toBe('br-c');
+      expect(c.execution.commit).toBe('c1');
+      expect(c.execution.workspacePath).toBe('/tmp/c');
+      expect(c.execution.agentSessionId).toBe('sess-c');
+      expect(c.execution.containerId).toBe('ct-c');
+      expect(c.execution.generation).toBe(1);
+    });
+
+    it('recreateDownstream plans only the ready descendants for dispatch', () => {
+      const o = loadRecreateDownstreamChain('wf-recreate-downstream-dispatch');
+      const started = o.recreateDownstream('A');
+
+      // A stays completed, so B becomes ready; C is gated behind B and
+      // is not yet ready. The invalidation plan records exactly the
+      // ready descendant set handed to the scheduler.
+      const plan = o.getLastInvalidationPlan()!;
+      expect(plan.action).toBe('recreateDownstream');
+      expect(plan.affectedTaskIds).toEqual(['B', 'C']);
+      expect(plan.schedulerEnqueueCandidates.map((c) => c.taskId)).toEqual(['B']);
+
+      // The preserved target is never returned as a started task.
+      expect(started.map((t) => t.id)).not.toContain('A');
+      expect(started.map((t) => t.id)).not.toContain('C');
+    });
+
     it('drainScheduler sets lastHeartbeatAt when starting a task', () => {
       orchestrator.loadPlan({
         name: 'heartbeat-start-test',

--- a/packages/workflow-core/src/invalidation-policy.ts
+++ b/packages/workflow-core/src/invalidation-policy.ts
@@ -8,6 +8,7 @@ export type InvalidationAction =
   | 'retryTask'
   | 'retryWorkflow'
   | 'recreateTask'
+  | 'recreateDownstream'
   | 'recreateWorkflow'
   | 'recreateWorkflowFromFreshBase'
   | 'workflowFork';
@@ -70,6 +71,13 @@ export interface InvalidationDeps {
   cancelInFlight: CancelInFlightFn;
   retryTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   recreateTask: (taskId: string) => TaskState[] | Promise<TaskState[]>;
+  /**
+   * Recreate every transitive downstream dependent of a task while
+   * leaving the task itself untouched. Optional like `workflowFork` /
+   * `scheduleOnly`: production callers wire it via the orchestrator;
+   * tests must supply it to route the action.
+   */
+  recreateDownstream?: (taskId: string) => TaskState[] | Promise<TaskState[]>;
   retryWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflow: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
   recreateWorkflowFromFreshBase?: (workflowId: string) => TaskState[] | Promise<TaskState[]>;
@@ -247,6 +255,17 @@ export const ACTION_SPECS: Readonly<Record<InvalidationAction, ActionSpec>> = Ob
     reason: 'task.recreate',
     selectAffectedTasks: ({ targetId, tasks }) => taskAndDescendants(targetId, tasks),
   },
+  recreateDownstream: {
+    // Like `recreateTask`, but the target itself is preserved: only its
+    // transitive downstream dependents are recreated. The affected set
+    // therefore excludes the target and is empty for a leaf (no-op).
+    scope: 'task',
+    stages: INVALIDATING_STAGES,
+    cascadesAcrossWorkflows: true,
+    mode: 'recreate',
+    reason: 'task.recreateDownstream',
+    selectAffectedTasks: ({ targetId, tasks }) => descendantsOf(targetId, taskMap(tasks)),
+  },
   retryWorkflow: {
     scope: 'workflow',
     stages: INVALIDATING_STAGES,
@@ -377,6 +396,17 @@ async function invokePrimitive(
       return await deps.retryTask(ctx.id);
     case 'recreateTask':
       return await deps.recreateTask(ctx.id);
+    case 'recreateDownstream': {
+      if (!deps.recreateDownstream) {
+        throw new Error(
+          "applyInvalidation: 'recreateDownstream' dep is missing. " +
+            'Production callers wire this via buildInvalidationDeps in ' +
+            '@invoker/app/workflow-actions; tests must supply ' +
+            'deps.recreateDownstream to use this action.',
+        );
+      }
+      return await deps.recreateDownstream(ctx.id);
+    }
     case 'retryWorkflow':
       return await deps.retryWorkflow(ctx.id);
     case 'recreateWorkflow':
@@ -425,6 +455,7 @@ export interface InvalidationDepsOrchestrator {
   cancelWorkflow(workflowId: string): { runningCancelled: string[] };
   retryTask(taskId: string): TaskState[];
   recreateTask(taskId: string): TaskState[];
+  recreateDownstream(taskId: string): TaskState[];
   retryWorkflow(workflowId: string): TaskState[];
   recreateWorkflow(workflowId: string): TaskState[];
   recreateWorkflowFromFreshBase(workflowId: string): Promise<TaskState[]>;
@@ -487,6 +518,7 @@ export function buildOrchestratorOnlyInvalidationDeps(
     cancelInFlight: buildCancelInFlight({ orchestrator }),
     retryTask: (taskId) => orchestrator.retryTask(taskId),
     recreateTask: (taskId) => orchestrator.recreateTask(taskId),
+    recreateDownstream: (taskId) => orchestrator.recreateDownstream(taskId),
     retryWorkflow: (workflowId) => orchestrator.retryWorkflow(workflowId),
     recreateWorkflow: (workflowId) => orchestrator.recreateWorkflow(workflowId),
     recreateWorkflowFromFreshBase: (workflowId) =>

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1187,6 +1187,20 @@ export class Orchestrator {
         .filter((t) => t.config.workflowId === id);
     }
 
+    return this.cancelActiveCandidates(candidates, scope);
+  }
+
+  /**
+   * Mark every actively-running task in `candidates` as `failed` with a
+   * cancel marker, freeing its scheduler slot. Shared by
+   * `cancelActiveBeforeInvalidation` (task/workflow scope) and the
+   * downstream-only recreate path, which must interrupt descendants
+   * WITHOUT touching the preserved target task.
+   */
+  private cancelActiveCandidates(
+    candidates: readonly TaskState[],
+    scope: 'task' | 'workflow',
+  ): string[] {
     const cancelled: string[] = [];
     for (const t of candidates) {
       if (!isActiveForInvalidation(t.status)) continue;
@@ -2588,6 +2602,107 @@ export class Orchestrator {
       resetCount: toResetIds.length,
     });
     this.invalidateLaunchArtifactsForTasks(toResetIds, 'task recreation reset');
+
+    for (const id of toResetIds) {
+      const current = this.stateGetTask(id);
+      if (!current) continue;
+      const changesWithGeneration = this.withBumpedExecutionGeneration(current, resetChanges);
+      const recreateUpdated = this.writeAndSync(id, changesWithGeneration);
+      const priorAttemptId = current.execution.selectedAttemptId;
+      this.replaceSelectedAttempt(current);
+      this.persistence.logEvent?.(id, 'task.pending', changesWithGeneration);
+      this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(current, recreateUpdated, changesWithGeneration));
+
+      this.deferredTaskIds.delete(id);
+      this.clearQueuedSchedulerEntries(id, priorAttemptId);
+    }
+
+    const readyIds = this.stateMachine
+      .getReadyTasks()
+      .map((t) => t.id)
+      .filter((id) => toResetSet.has(id));
+    plan = withSchedulerEnqueueCandidates(plan, readyIds);
+    this.lastInvalidationPlan = plan;
+    return this.autoStartReadyTasks(readyIds, Orchestrator.EXPEDITED_PRIORITY);
+  }
+
+  /**
+   * Downstream-only recreate: leave the selected task untouched and
+   * reset all of its transitive downstream dependents to pending with
+   * recreate-style execution clearing, then auto-start the descendants
+   * that become ready. For a chain A -> B -> C, `recreateDownstream(A)`
+   * resets B and C; `recreateDownstream(B)` resets C. Calling it on a
+   * leaf is a no-op that returns no started tasks.
+   *
+   * This is the task-preserving sibling of `recreateTask`: it reuses the
+   * `recreateDownstream` action-table entry (whose affected set is the
+   * target's descendants, excluding the target) and the same
+   * recreate-class reset payload, so descendants get fresh lineage,
+   * cleared attempt/session/container metadata, and a bumped execution
+   * generation, while the target's status, branch, commit, workspace,
+   * selected attempt, agent/session/container metadata, and generation
+   * stay exactly as they were.
+   */
+  recreateDownstream(taskId: string): TaskState[] {
+    this.refreshFromDb();
+    const task = this.stateGetTask(taskId);
+    if (!task) throw new OrchestratorError(OrchestratorErrorCode.TASK_NOT_FOUND, `Task ${taskId} not found`);
+
+    const rootId = task.id;
+
+    // Descendant-only affected set (target preserved); empty for a leaf.
+    let plan = planInvalidation({
+      action: 'recreateDownstream',
+      targetId: rootId,
+      tasks: this.stateMachine.getAllTasks(),
+    });
+    this.lastInvalidationPlan = plan;
+    const toResetIds = plan.affectedTaskIds;
+    const toResetSet = new Set(toResetIds);
+
+    // Leaf no-op: nothing downstream to recreate, nothing to dispatch.
+    if (toResetIds.length === 0) {
+      this.logger.info('[orchestrator] recreateDownstream no-op (leaf)', { taskId: rootId });
+      return [];
+    }
+
+    // Step 18 cancel-first invariant, scoped to the descendants only so
+    // the preserved target's active attempt is never interrupted.
+    const descendants = toResetIds
+      .map((id) => this.stateGetTask(id))
+      .filter((t): t is TaskState => !!t);
+    this.cancelActiveCandidates(descendants, 'task');
+
+    const resetChanges: TaskStateChanges = {
+      status: 'pending',
+      config: { summary: undefined },
+      execution: {
+        autoFixAttempts: 0,
+        startedAt: undefined,
+        completedAt: undefined,
+        error: undefined,
+        exitCode: undefined,
+        commit: undefined,
+        branch: undefined,
+        workspacePath: undefined,
+        lastHeartbeatAt: undefined,
+        phase: undefined,
+        launchStartedAt: undefined,
+        launchCompletedAt: undefined,
+        reviewUrl: undefined,
+        reviewId: undefined,
+        reviewStatus: undefined,
+        reviewProviderId: undefined,
+        agentSessionId: undefined,
+        containerId: undefined,
+      },
+    };
+
+    this.logger.info('[orchestrator] recreateDownstream reset', {
+      taskId: rootId,
+      resetCount: toResetIds.length,
+    });
+    this.invalidateLaunchArtifactsForTasks(toResetIds, 'downstream recreation reset');
 
     for (const id of toResetIds) {
       const current = this.stateGetTask(id);


### PR DESCRIPTION
## Summary

This adds a `recreateDownstream` primitive to `workflow-core`. It recreates every transitive downstream dependent of a task.

The selected task itself is left untouched. Only its descendants are reset.

For a chain `A -> B -> C`, `recreateDownstream(A)` resets `B` and `C`. `recreateDownstream(B)` resets `C` only.

Calling it on a leaf is a no-op that returns no started tasks.

Descendants get recreate-class semantics: fresh lineage, cleared attempt, session, and container metadata, and a bumped execution generation.

The target keeps its status, branch, commit, workspace, selected attempt, agent metadata, and generation exactly as they were.

It follows the existing invalidation/action-table pattern rather than adding an ad hoc path, reusing the same reset payload as `recreateTask`.

## Architecture

The new action reuses the `recreateTask` machinery but swaps the affected-task selector from "task plus descendants" to "descendants only", and scopes the cancel-first pass to descendants so the target is never interrupted.

### Before

```mermaid
graph TD
    subgraph Actions[Invalidation action table]
        RT[recreateTask: target + descendants]
        RW[recreateWorkflow: whole workflow]
    end
    RT -->|reset| Target[Target task]
    RT -->|reset| Desc[Descendants]
```

### After

```mermaid
graph TD
    subgraph Actions[Invalidation action table]
        RT[recreateTask: target + descendants]
        RD[recreateDownstream: descendants only]
        RW[recreateWorkflow: whole workflow]
    end
    RT -->|reset| Target[Target task]
    RT -->|reset| Desc[Descendants]
    RD -->|preserve| Target
    RD -->|reset + bump generation| Desc
```

## Test Plan

- [ ] `cd packages/workflow-core && pnpm test -- src/__tests__/orchestrator.test.ts src/__tests__/invalidation-plan.test.ts`
- [ ] `cd packages/workflow-core && pnpm exec vitest run src/__tests__/invalidation-policy.test.ts`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert cf224e9c`
- Post-revert steps: None
- Data migration? No
