### PR TITLE
Workflow graph detach lineage clarity

### DIFF
--- a/packages/app/src/__tests__/api-server.test.ts
+++ b/packages/app/src/__tests__/api-server.test.ts
@@ -998,6 +998,7 @@ describe('POST /api/workflows/:id/detach', () => {
     expect(res.status).toBe(200);
     expect(res.body.ok).toBe(true);
     expect(res.body.action).toBe('detached');
+    expect(res.body.provenanceField).toBe('detachedExternalDependencies');
     expect(mocks.detachWorkflow).toHaveBeenCalledWith('wf-1', 'wf-0');
   });
 

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1678,5 +1678,28 @@ describe('headless delegation enforcement', () => {
       expect(mockDeps.commandService.deleteWorkflow).toHaveBeenCalled();
       expect(callOrder).toEqual(['preempt', 'delete']);
     });
+
+    it('headless detach-workflow routes through commandService and reports detached provenance', async () => {
+      mockDeps.commandService.detachWorkflow = vi.fn(async () => ({ ok: true as const, data: undefined })) as any;
+      const stdout = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      let output = '';
+
+      try {
+        await runHeadless(['detach-workflow', 'wf-child', 'wf-upstream'], mockDeps);
+        output = stdout.mock.calls.map((call) => String(call[0])).join('');
+      } finally {
+        stdout.mockRestore();
+      }
+
+      expect(mockDeps.commandService.detachWorkflow).toHaveBeenCalledWith(expect.objectContaining({
+        payload: {
+          workflowId: 'wf-child',
+          upstreamWorkflowId: 'wf-upstream',
+        },
+      }));
+      expect(output).toContain('wf-child');
+      expect(output).toContain('wf-upstream');
+      expect(output).toContain('detachedExternalDependencies');
+    });
   });
 });

--- a/packages/app/src/api-server.ts
+++ b/packages/app/src/api-server.ts
@@ -707,12 +707,22 @@ export function startApiServer(deps: ApiServerDeps): ApiServer {
             json(res, 400, { error: 'Missing "upstreamWorkflowId" in request body' });
             return;
           }
-          await detachWorkflow(workflowId, String(upstreamWorkflowId));
+          const upstreamId = String(upstreamWorkflowId);
+          apiLogger?.info(
+            `detach-workflow begin workflow="${workflowId}" upstream="${upstreamId}" provenance="detachedExternalDependencies"`,
+            { module: 'api-server' },
+          );
+          await detachWorkflow(workflowId, upstreamId);
+          apiLogger?.info(
+            `detach-workflow end workflow="${workflowId}" upstream="${upstreamId}" activeExternalDependencies="removed" provenance="detachedExternalDependencies"`,
+            { module: 'api-server' },
+          );
           json(res, 200, {
             ok: true,
             workflowId,
-            upstreamWorkflowId,
+            upstreamWorkflowId: upstreamId,
             action: 'detached',
+            provenanceField: 'detachedExternalDependencies',
           });
         } catch (err) {
           json(res, httpStatusForError(err), { error: errorMessage(err) });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -177,9 +177,17 @@ function buildHeadlessApiServerDeps(
       if (!cmdResult.ok) throw new Error(cmdResult.error.message);
     },
     detachWorkflow: async (workflowId: string, upstreamWorkflowId: string) => {
+      deps.logger.info(
+        `headless API detach-workflow begin workflow="${workflowId}" upstream="${upstreamWorkflowId}" provenance="detachedExternalDependencies"`,
+        { module: 'headless-api' },
+      );
       const envelope = makeEnvelope('detach-workflow', 'headless', 'workflow', { workflowId, upstreamWorkflowId });
       const cmdResult = await deps.commandService.detachWorkflow(envelope);
       if (!cmdResult.ok) throw new Error(cmdResult.error.message);
+      deps.logger.info(
+        `headless API detach-workflow end workflow="${workflowId}" upstream="${upstreamWorkflowId}" activeExternalDependencies="removed" provenance="detachedExternalDependencies"`,
+        { module: 'headless-api' },
+      );
     },
   };
 }
@@ -2608,7 +2616,7 @@ async function headlessDetachWorkflow(
   const result = await deps.commandService.detachWorkflow(envelope);
   if (!result.ok) throw new Error(result.error.message);
   process.stdout.write(
-    `Detached workflow ${workflowId} from upstream workflow ${upstreamWorkflowId}\n`,
+    `Detached workflow ${workflowId} from upstream workflow ${upstreamWorkflowId}; active externalDependencies removed; provenance recorded in detachedExternalDependencies.\n`,
   );
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1799,11 +1799,17 @@ function createEmbeddedTerminalBackendFromConfig(
   }
 
   async function performDetachWorkflow(workflowId: string, upstreamWorkflowId: string): Promise<void> {
-    logger.info(`performDetachWorkflow begin workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
+    logger.info(
+      `performDetachWorkflow begin workflow="${workflowId}" upstream="${upstreamWorkflowId}" provenance="detachedExternalDependencies"`,
+      { module: 'kill' },
+    );
     const envelope = makeEnvelope('detach-workflow', 'ui', 'workflow', { workflowId, upstreamWorkflowId });
     const result = await commandService.detachWorkflow(envelope);
     if (!result.ok) throw new Error(result.error.message);
-    logger.info(`performDetachWorkflow end workflow="${workflowId}" upstream="${upstreamWorkflowId}"`, { module: 'kill' });
+    logger.info(
+      `performDetachWorkflow end workflow="${workflowId}" upstream="${upstreamWorkflowId}" activeExternalDependencies="removed" provenance="detachedExternalDependencies"`,
+      { module: 'kill' },
+    );
   }
 
   /** Orchestrator error codes that preemption treats as benign (cancel is best-effort). */
@@ -3026,6 +3032,7 @@ function createEmbeddedTerminalBackendFromConfig(
         );
         try {
           await performDetachWorkflow(workflowId, upstreamWorkflowId);
+          requestWorkflowMetadataPublish('detach-workflow');
         } catch (err) {
           logger.error(`detach-workflow failed: ${err}`, { module: 'ipc' });
           throw err;

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -15,6 +15,8 @@ import type {
   TaskStateChanges,
   WorkflowDerivedStatus,
   WorkflowRollup,
+  ExternalDependency,
+  ExternalDependencyChange,
 } from '@invoker/workflow-graph';
 
 export type { WorkflowDerivedStatus, WorkflowRollup } from '@invoker/workflow-graph';
@@ -44,6 +46,8 @@ export interface WorkflowMeta {
   mergeMode?: string;
   repoUrl?: string;
   intermediateRepoUrl?: string;
+  externalDependencies?: ExternalDependency[];
+  externalDependencyChanges?: ExternalDependencyChange[];
   createdAt?: string;
   updatedAt?: string;
 }
@@ -356,6 +360,10 @@ export const IpcChannels = {
   },
   'invoker:delete-workflow': {} as {
     request: [workflowId: string];
+    response: void;
+  },
+  'invoker:detach-workflow': {} as {
+    request: [workflowId: string, upstreamWorkflowId: string];
     response: void;
   },
   'invoker:load-workflow': {} as {

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -132,6 +132,43 @@ describe('SQLiteAdapter', () => {
       });
     });
 
+    it('round-trips detached external dependency provenance through saveTask and updateTask', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const provenance = [
+        {
+          workflowId: 'wf-upstream',
+          taskId: '__merge__',
+          requiredStatus: 'completed' as const,
+          gatePolicy: 'review_ready' as const,
+          detachedAt: '2026-06-02T08:57:38.000Z',
+        },
+      ];
+
+      // Persisted via saveTask.
+      adapter.saveTask('wf-1', makeTask('merge-node', {
+        config: { isMergeNode: true, detachedExternalDependencies: provenance },
+      }));
+      expect(adapter.loadTask('merge-node')?.config.detachedExternalDependencies).toEqual(provenance);
+
+      // Appended via updateTask.
+      const appended = [
+        ...provenance,
+        {
+          workflowId: 'wf-upstream-2',
+          taskId: 't5',
+          requiredStatus: 'completed' as const,
+          gatePolicy: 'completed' as const,
+          detachedAt: '2026-06-02T09:00:00.000Z',
+        },
+      ];
+      adapter.updateTask('merge-node', { config: { detachedExternalDependencies: appended } });
+      expect(adapter.loadTask('merge-node')?.config.detachedExternalDependencies).toEqual(appended);
+
+      // Cleared when set back to undefined.
+      adapter.updateTask('merge-node', { config: { detachedExternalDependencies: undefined } });
+      expect(adapter.loadTask('merge-node')?.config.detachedExternalDependencies).toBeUndefined();
+    });
+
     it('loads all workflows and tasks in one startup snapshot', () => {
       const wf2: Workflow = {
         ...testWorkflow,

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -608,6 +608,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         protocol_error_message TEXT,
         input_prompt TEXT,
         external_dependencies TEXT,
+        detached_external_dependencies TEXT,
 
         -- Context
         summary TEXT,
@@ -920,6 +921,8 @@ export class SQLiteAdapter implements PersistenceAdapter {
       'ALTER TABLE attempts ADD COLUMN claimed_at TEXT',
       'ALTER TABLE attempts ADD COLUMN lease_expires_at TEXT',
       'ALTER TABLE tasks ADD COLUMN task_state_version INTEGER NOT NULL DEFAULT 1',
+      // Read-only provenance for cross-workflow dependencies removed by detachWorkflow.
+      'ALTER TABLE tasks ADD COLUMN detached_external_dependencies TEXT',
     ];
     for (const sql of migrations) {
       try {
@@ -1382,7 +1385,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.execRun(`
       INSERT OR REPLACE INTO tasks (
         id, workflow_id, description, status, blocked_by, dependencies,
-        command, prompt, experiment_prompt, exit_code, error, protocol_error_code, protocol_error_message, input_prompt, external_dependencies,
+        command, prompt, experiment_prompt, exit_code, error, protocol_error_code, protocol_error_message, input_prompt, external_dependencies, detached_external_dependencies,
         summary, problem, approach, test_plan, repro_command, fix_prompt, fix_context,
         branch, commit_hash, fixed_integration_sha, fixed_integration_recorded_at, fixed_integration_source, parent_task,
         pivot, experiment_variants, is_reconciliation, selected_experiment,
@@ -1404,7 +1407,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         task_state_version
       ) VALUES (
         ?, ?, ?, ?, ?, ?,
-        ?, ?, ?, ?, ?, ?, ?, ?, ?,
+        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?, ?, ?,
         ?, ?, ?, ?,
@@ -1432,6 +1435,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       cfg.command ?? null, cfg.prompt ?? null, cfg.experimentPrompt ?? null,
       exec.exitCode ?? null, exec.error ?? null, exec.protocolErrorCode ?? null, exec.protocolErrorMessage ?? null, exec.inputPrompt ?? null,
       null,
+      cfg.detachedExternalDependencies ? JSON.stringify(cfg.detachedExternalDependencies) : null,
       cfg.summary ?? null, cfg.problem ?? null, cfg.approach ?? null,
       cfg.testPlan ?? null, cfg.reproCommand ?? null, cfg.fixPrompt ?? null, cfg.fixContext ?? null,
       exec.branch ?? null,
@@ -1546,6 +1550,10 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if ('externalDependencies' in changes.config) {
         setClauses.push('external_dependencies = ?');
         values.push(changes.config.externalDependencies ? JSON.stringify(changes.config.externalDependencies) : null);
+      }
+      if ('detachedExternalDependencies' in changes.config) {
+        setClauses.push('detached_external_dependencies = ?');
+        values.push(changes.config.detachedExternalDependencies ? JSON.stringify(changes.config.detachedExternalDependencies) : null);
       }
     }
 
@@ -2586,6 +2594,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         command: row.command ?? undefined,
         prompt: row.prompt ?? undefined,
         externalDependencies: row.external_dependencies ? JSON.parse(row.external_dependencies) : undefined,
+        detachedExternalDependencies: row.detached_external_dependencies ? JSON.parse(row.detached_external_dependencies) : undefined,
         experimentPrompt: row.experiment_prompt ?? undefined,
         pivot: row.pivot === 1 ? true : undefined,
         experimentVariants: row.experiment_variants ? JSON.parse(row.experiment_variants) : undefined,

--- a/packages/graph/src/types.ts
+++ b/packages/graph/src/types.ts
@@ -47,6 +47,17 @@ export interface TaskConfig {
   readonly executionAgent?: string;
   /** Cross-workflow prerequisites for this task. */
   readonly externalDependencies?: readonly ExternalDependency[];
+  /**
+   * Read-only provenance for cross-workflow prerequisites removed by
+   * `detachWorkflow`. Ignored by scheduling; preserved so the UI can
+   * distinguish a detached upstream stack edge from independence.
+   */
+  readonly detachedExternalDependencies?: readonly DetachedExternalDependency[];
+}
+
+export interface DetachedExternalDependency extends ExternalDependency {
+  /** ISO-8601 timestamp at which `detachWorkflow` removed this dependency. */
+  readonly detachedAt: string;
 }
 
 export interface ExternalDependency {

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -82,16 +82,24 @@ function normalizedSearchText(value: string | undefined): string {
   return (value ?? '').toLowerCase();
 }
 
+function workflowIdentity(workflow: WorkflowMeta | undefined, fallbackId: string): string {
+  const name = workflow?.name?.trim();
+  return name && name !== fallbackId ? `${name} (${fallbackId})` : fallbackId;
+}
+
 interface WorkflowContextMenuProps {
   x: number;
   y: number;
   workflowId: string;
+  workflow?: WorkflowMeta;
+  workflows: Map<string, WorkflowMeta>;
   onOpenWorkflow: (workflowId: string) => void;
   onOpenPr: (workflowId: string) => void;
   onRetryWorkflow: (workflowId: string) => void;
   onRebaseRetry: (workflowId: string) => void;
   onRebaseRecreate: (workflowId: string) => void;
   onRecreateWorkflow: (workflowId: string) => void;
+  onDetachWorkflow: (workflowId: string, upstreamWorkflowId: string) => void;
   onCancelWorkflow: (workflowId: string) => void;
   onDeleteWorkflow: (workflowId: string) => void;
   onCopyWorkflowId: (workflowId: string) => void;
@@ -102,12 +110,15 @@ function WorkflowContextMenu({
   x,
   y,
   workflowId,
+  workflow,
+  workflows,
   onOpenWorkflow,
   onOpenPr,
   onRetryWorkflow,
   onRebaseRetry,
   onRebaseRecreate,
   onRecreateWorkflow,
+  onDetachWorkflow,
   onCancelWorkflow,
   onDeleteWorkflow,
   onCopyWorkflowId,
@@ -170,7 +181,19 @@ function WorkflowContextMenu({
     onClose();
   };
 
+  const runDetachAction = (upstreamWorkflowId: string) => {
+    onDetachWorkflow(workflowId, upstreamWorkflowId);
+    onClose();
+  };
+
+  const upstreamWorkflowIds = Array.from(new Set(
+    (workflow?.externalDependencies ?? [])
+      .map((dependency) => dependency.workflowId)
+      .filter((upstreamWorkflowId) => upstreamWorkflowId && upstreamWorkflowId !== workflowId),
+  )).sort((a, b) => workflowIdentity(workflows.get(a), a).localeCompare(workflowIdentity(workflows.get(b), b)));
+
   const buttonClass = 'w-full px-3 py-1.5 text-left text-sm text-gray-100 hover:bg-gray-700';
+  const warningButtonClass = 'w-full px-3 py-1.5 text-left text-sm text-yellow-300 hover:bg-gray-700';
   const dangerButtonClass = 'w-full px-3 py-1.5 text-left text-sm text-red-300 hover:bg-gray-700';
 
   return (
@@ -217,6 +240,16 @@ function WorkflowContextMenu({
           <button role="menuitem" onClick={() => runAction(onRecreateWorkflow)} className={dangerButtonClass}>
             Recreate Workflow
           </button>
+          {upstreamWorkflowIds.map((upstreamWorkflowId) => (
+            <button
+              key={upstreamWorkflowId}
+              role="menuitem"
+              onClick={() => runDetachAction(upstreamWorkflowId)}
+              className={warningButtonClass}
+            >
+              Detach from {workflowIdentity(workflows.get(upstreamWorkflowId), upstreamWorkflowId)}
+            </button>
+          ))}
           <button role="menuitem" onClick={() => runAction(onCancelWorkflow)} className={dangerButtonClass}>
             Cancel Workflow
           </button>
@@ -300,6 +333,7 @@ export function App() {
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [searchActiveIndex, setSearchActiveIndex] = useState(0);
+  const [actionFeedback, setActionFeedback] = useState<string | null>(null);
   const uiPerfThrottleRef = useRef<Record<string, number>>({});
   const lastShiftAtRef = useRef(0);
   const searchInputRef = useRef<HTMLInputElement>(null);
@@ -1077,6 +1111,24 @@ export function App() {
     }
   }, [refreshTasks, selectedWorkflowId]);
 
+  const handleDetachWorkflow = useCallback(async (workflowId: string, upstreamWorkflowId: string) => {
+    setWorkflowContextMenu(null);
+    const downstreamIdentity = workflowIdentity(workflows.get(workflowId), workflowId);
+    const upstreamIdentity = workflowIdentity(workflows.get(upstreamWorkflowId), upstreamWorkflowId);
+    const confirmed = window.confirm(
+      `Detach downstream workflow "${downstreamIdentity}" from upstream workflow "${upstreamIdentity}"?\n\n` +
+      'This removes the active scheduling dependency and records detachedExternalDependencies provenance.',
+    );
+    if (!confirmed) return;
+    try {
+      await window.invoker?.detachWorkflow(workflowId, upstreamWorkflowId);
+      setActionFeedback(`Detached ${downstreamIdentity} from ${upstreamIdentity}`);
+      refreshTasks(true);
+    } catch (err) {
+      console.error('Detach Workflow failed:', err);
+    }
+  }, [refreshTasks, workflows]);
+
   const handleFix = useCallback(async (taskId: string, agentName: string) => {
     setContextMenu(null);
     const task = tasks.get(taskId);
@@ -1670,6 +1722,16 @@ export function App() {
                   keyboardActiveKey={keyboardRegion === 'bottomBar' ? visibleStatusKeys[bottomStatusIndex] ?? null : null}
                   onStatusClick={(filterKey, event) => handleStatusClick(filterKey as WorkflowStatus, event)}
                 />
+                {actionFeedback && (
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    data-testid="action-feedback"
+                    className="border-t border-gray-700 bg-gray-900 px-4 py-1.5 text-xs text-gray-200"
+                  >
+                    {actionFeedback}
+                  </div>
+                )}
                 <TerminalDrawer
                   collapsed={terminalCollapsed}
                   onToggle={() => setTerminalCollapsed((prev) => !prev)}
@@ -1815,12 +1877,15 @@ export function App() {
           x={workflowContextMenu.x}
           y={workflowContextMenu.y}
           workflowId={workflowContextMenu.workflowId}
+          workflow={workflows.get(workflowContextMenu.workflowId)}
+          workflows={workflows}
           onOpenWorkflow={handleWorkflowClick}
           onOpenPr={handleOpenWorkflowPr}
           onRetryWorkflow={(workflowId) => void handleRetryWorkflow(workflowId)}
           onRebaseRetry={(workflowId) => void handleRebaseRetry(workflowId)}
           onRebaseRecreate={(workflowId) => void handleRebaseRecreate(workflowId)}
           onRecreateWorkflow={(workflowId) => void handleRecreateWorkflow(workflowId)}
+          onDetachWorkflow={(workflowId, upstreamWorkflowId) => void handleDetachWorkflow(workflowId, upstreamWorkflowId)}
           onCancelWorkflow={(workflowId) => void handleCancelWorkflow(workflowId)}
           onDeleteWorkflow={(workflowId) => void handleDeleteWorkflow(workflowId)}
           onCopyWorkflowId={handleCopyWorkflowId}

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -64,12 +64,16 @@ describe('Context menu (component)', () => {
     mock.cleanup();
   });
 
-  async function setup() {
+  async function setup(
+    nextTasks = [alpha, beta, merge],
+    nextWorkflows = workflows,
+    waitForWorkflowId = 'wf-1',
+  ) {
     render(<App />);
-    act(() => mock.setTasks([alpha, beta, merge], workflows));
+    act(() => mock.setTasks(nextTasks, nextWorkflows));
 
     await waitFor(() => {
-      expect(screen.getByTestId('workflow-node-wf-1')).toBeInTheDocument();
+      expect(screen.getByTestId(`workflow-node-${waitForWorkflowId}`)).toBeInTheDocument();
     });
   }
 
@@ -150,6 +154,62 @@ describe('Context menu (component)', () => {
     fireEvent.click(await screen.findByText('More'));
     fireEvent.click(await screen.findByText('Delete Workflow'));
     await waitFor(() => expect(mock.api.deleteWorkflow).toHaveBeenCalledWith('wf-1'));
+  });
+
+  it('workflow context menu confirms before detaching an upstream workflow', async () => {
+    const confirm = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    const upstreamTask = makeUITask({ id: 'wf-upstream/root', workflowId: 'wf-upstream' });
+    const downstreamTask = makeUITask({ id: 'wf-child/root', workflowId: 'wf-child' });
+    const detachWorkflows: WorkflowMeta[] = [
+      { id: 'wf-upstream', name: 'Upstream Workflow', status: 'review_ready' },
+      {
+        id: 'wf-child',
+        name: 'Child Workflow',
+        status: 'running',
+        externalDependencies: [
+          { workflowId: 'wf-upstream', requiredStatus: 'completed', gatePolicy: 'completed' },
+        ],
+      },
+    ];
+
+    await setup([upstreamTask, downstreamTask], detachWorkflows, 'wf-child');
+    fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-child'));
+    fireEvent.click(await screen.findByText('More'));
+    fireEvent.click(await screen.findByText('Detach from Upstream Workflow (wf-upstream)'));
+
+    await waitFor(() => expect(mock.api.detachWorkflow).toHaveBeenCalledWith('wf-child', 'wf-upstream'));
+    expect(mock.api.detachWorkflow).toHaveBeenCalledTimes(1);
+    expect(confirm).toHaveBeenCalledWith(expect.stringContaining('Child Workflow (wf-child)'));
+    expect(confirm).toHaveBeenCalledWith(expect.stringContaining('Upstream Workflow (wf-upstream)'));
+    expect(await screen.findByTestId('action-feedback')).toHaveTextContent(
+      'Detached Child Workflow (wf-child) from Upstream Workflow (wf-upstream)',
+    );
+  });
+
+  it('workflow context menu does not detach when confirmation is cancelled', async () => {
+    vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const upstreamTask = makeUITask({ id: 'wf-upstream/root', workflowId: 'wf-upstream' });
+    const downstreamTask = makeUITask({ id: 'wf-child/root', workflowId: 'wf-child' });
+    const detachWorkflows: WorkflowMeta[] = [
+      { id: 'wf-upstream', name: 'Upstream Workflow', status: 'review_ready' },
+      {
+        id: 'wf-child',
+        name: 'Child Workflow',
+        status: 'running',
+        externalDependencies: [
+          { workflowId: 'wf-upstream', requiredStatus: 'completed', gatePolicy: 'completed' },
+        ],
+      },
+    ];
+
+    await setup([upstreamTask, downstreamTask], detachWorkflows, 'wf-child');
+    fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-child'));
+    fireEvent.click(await screen.findByText('More'));
+    fireEvent.click(await screen.findByText('Detach from Upstream Workflow (wf-upstream)'));
+
+    await waitFor(() => expect(window.confirm).toHaveBeenCalled());
+    expect(mock.api.detachWorkflow).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('action-feedback')).not.toBeInTheDocument();
   });
 
   it('workflow context menu copies workflow id', async () => {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -148,6 +148,7 @@ export function createMockInvoker(
     deleteAllWorkflows: vi.fn(async () => {}),
     deleteAllWorkflowsBulk: vi.fn(async () => {}),
     deleteWorkflow: vi.fn(async () => {}),
+    detachWorkflow: vi.fn(async () => {}),
     cleanupWorktrees: vi.fn(async () => ({ removed: [], errors: [] })),
     recreateWorkflow: vi.fn(async () => {}),
     recreateTask: vi.fn(async () => {}),

--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -51,6 +51,9 @@ export function createReactFlowMock() {
             data-testid={`rf__edge-${edge.id}`}
             data-source={edge.source}
             data-target={edge.target}
+            data-kind={edge.data?.kind}
+            aria-label={edge.ariaLabel}
+            style={edge.style}
           />
         ))}
         {nodes.map((node) => {

--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -71,6 +71,83 @@ describe('Visual proof snapshots', () => {
     });
   });
 
+  it('workflow graph detached lineage visual proof', async () => {
+    const workflows: WorkflowMeta[] = [
+      { id: 'wf-upstream', name: 'Upstream', status: 'review_ready' },
+      {
+        id: 'wf-active-child',
+        name: 'Active child',
+        status: 'running',
+        externalDependencies: [{ workflowId: 'wf-upstream', requiredStatus: 'completed' }],
+      },
+      {
+        id: 'wf-detached-child',
+        name: 'Detached child',
+        status: 'running',
+        externalDependencyChanges: [
+          {
+            before: { workflowId: 'wf-upstream', requiredStatus: 'completed', gatePolicy: 'review_ready' },
+            changedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      },
+    ];
+    const upstream = makeUITask({
+      id: 'task-upstream',
+      description: 'Upstream merge gate',
+      status: 'review_ready',
+      workflowId: 'wf-upstream',
+    });
+    const activeChild = makeUITask({
+      id: 'task-active-child',
+      description: 'Still actively depends on upstream',
+      status: 'running',
+      workflowId: 'wf-active-child',
+    });
+    const detachedChild = makeUITask({
+      id: 'task-detached-child',
+      description: 'Detached downstream merge gate',
+      status: 'running',
+      workflowId: 'wf-detached-child',
+      config: {
+        workflowId: 'wf-detached-child',
+        isMergeNode: true,
+        detachedExternalDependencies: [
+          {
+            workflowId: 'wf-upstream',
+            requiredStatus: 'completed',
+            gatePolicy: 'review_ready',
+            detachedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ],
+      } as any,
+    });
+
+    render(<App />);
+    act(() => mock.setTasks([upstream, activeChild, detachedChild], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-upstream')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-active-child')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-detached-child')).toBeInTheDocument();
+    });
+
+    const activeEdge = screen.getByTestId('rf__edge-workflow:active:wf-upstream->wf-active-child');
+    expect(activeEdge).toHaveAttribute('data-kind', 'active');
+    expect(activeEdge).toHaveAttribute('aria-label', 'Active workflow dependency');
+    expect(activeEdge.getAttribute('style') ?? '').not.toContain('stroke-dasharray');
+
+    const detachedEdge = screen.getByTestId('rf__edge-workflow:detached:wf-upstream->wf-detached-child');
+    expect(detachedEdge).toHaveAttribute('data-kind', 'detached');
+    expect(detachedEdge).toHaveAttribute('aria-label', 'Detached workflow dependency');
+    expect(detachedEdge.getAttribute('style') ?? '').toContain('stroke-dasharray: 6 6');
+    expect(screen.queryByTestId('rf__edge-workflow:active:wf-upstream->wf-detached-child')).not.toBeInTheDocument();
+
+    const detachedBadge = screen.getByTestId('workflow-node-wf-detached-child-detached-badge');
+    expect(detachedBadge).toHaveTextContent('Detached');
+    expect(detachedBadge).toHaveAttribute('title', 'Detached from 1 upstream workflow');
+  });
+
   it('workflow and task context menus render', async () => {
     const workflows: WorkflowMeta[] = [{ id: 'wf-alpha', name: 'Alpha', status: 'running' }];
     const alpha = makeUITask({ id: 'task-alpha', description: 'First test task', status: 'running', workflowId: 'wf-alpha' });

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -15,13 +15,17 @@ function wf(id: string, status: WorkflowStatus, overrides: Partial<WorkflowMeta>
   return { id, name: id, status, ...overrides };
 }
 
-function task(id: string, workflowId: string): TaskState {
+function task(
+  id: string,
+  workflowId: string,
+  config: Partial<TaskState['config']> = {},
+): TaskState {
   return {
     id,
     description: id,
     status: 'pending',
     dependencies: [],
-    config: { workflowId },
+    config: { workflowId, ...config },
     execution: {},
     taskStateVersion: 1,
   };
@@ -107,6 +111,105 @@ describe('WorkflowGraph', () => {
 
     expect(screen.getByTestId('workflow-graph-react-flow')).toBeInTheDocument();
     expect(screen.getByTestId('mock-react-flow')).toBeInTheDocument();
+  });
+
+  it('renders active workflow dependency edges normally', () => {
+    const workflows = new Map([
+      ['wf-a', wf('wf-a', 'review_ready')],
+      [
+        'wf-b',
+        wf('wf-b', 'running', {
+          externalDependencies: [
+            {
+              workflowId: 'wf-a',
+              taskId: '__merge__',
+              requiredStatus: 'completed',
+              gatePolicy: 'review_ready',
+            },
+          ],
+        }),
+      ],
+    ]);
+
+    render(
+      <WorkflowGraph
+        tasks={new Map()}
+        workflows={workflows}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    const edge = screen.getByTestId('rf__edge-workflow:active:wf-a->wf-b');
+    expect(edge).toHaveAttribute('data-source', 'wf-a');
+    expect(edge).toHaveAttribute('data-target', 'wf-b');
+    expect(edge).toHaveAttribute('data-kind', 'active');
+    expect(edge).toHaveAttribute('aria-label', 'Active workflow dependency');
+    expect(edge.getAttribute('style') ?? '').not.toContain('stroke-dasharray');
+  });
+
+  it('renders detached workflow provenance as a dashed edge and node badge', () => {
+    const workflows = new Map([
+      ['wf-a', wf('wf-a', 'review_ready')],
+      [
+        'wf-b',
+        wf('wf-b', 'running', {
+          externalDependencyChanges: [
+            {
+              before: {
+                workflowId: 'wf-a',
+                taskId: '__merge__',
+                requiredStatus: 'completed',
+                gatePolicy: 'review_ready',
+              },
+              changedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      ],
+    ]);
+    const tasks = new Map([
+      [
+        'wf-b/__merge__',
+        task('wf-b/__merge__', 'wf-b', {
+          isMergeNode: true,
+          detachedExternalDependencies: [
+            {
+              workflowId: 'wf-a',
+              taskId: '__merge__',
+              requiredStatus: 'completed',
+              gatePolicy: 'review_ready',
+              detachedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      ],
+    ]);
+
+    render(
+      <WorkflowGraph
+        tasks={tasks}
+        workflows={workflows}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    const edge = screen.getByTestId('rf__edge-workflow:detached:wf-a->wf-b');
+    expect(edge).toHaveAttribute('data-source', 'wf-a');
+    expect(edge).toHaveAttribute('data-target', 'wf-b');
+    expect(edge).toHaveAttribute('data-kind', 'detached');
+    expect(edge).toHaveAttribute('aria-label', 'Detached workflow dependency');
+    expect(edge.getAttribute('style') ?? '').toContain('stroke-dasharray: 6 6');
+    expect(screen.queryByTestId('rf__edge-workflow:historical:wf-a->wf-b')).not.toBeInTheDocument();
+
+    const badge = screen.getByTestId('workflow-node-wf-b-detached-badge');
+    expect(badge).toHaveTextContent('Detached');
+    expect(badge).toHaveAttribute('title', 'Detached from 1 upstream workflow');
   });
 
   it('renders dependency-change lineage edges separately from active dependency edges', () => {

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { MouseEvent } from 'react';
 import type { TaskState, WorkflowMeta, WorkflowStatus } from '../types.js';
-import { deriveWorkflowGraph, layoutWorkflowGraph } from '../lib/workflow-graph.js';
+import { deriveWorkflowGraph, layoutWorkflowGraph, type WorkflowGraphEdge } from '../lib/workflow-graph.js';
 import { WorkflowNode } from './WorkflowNode.js';
 import {
   Background,
@@ -32,6 +32,7 @@ interface WorkflowNodeData extends Record<string, unknown> {
   workflow: WorkflowMeta;
   selected: boolean;
   dimmed: boolean;
+  detachedDependencyCount: number;
 }
 
 const nodeTypes = {
@@ -51,6 +52,7 @@ function WorkflowFlowNode({ data }: NodeProps<Node<WorkflowNodeData>>): JSX.Elem
         workflow={data.workflow}
         selected={data.selected}
         dimmed={data.dimmed}
+        detachedDependencyCount={data.detachedDependencyCount}
         onClick={() => {}}
         onContextMenu={() => {}}
       />
@@ -106,6 +108,7 @@ function WorkflowGraphInner({
           workflow: node.workflow,
           selected: selectedWorkflowId === node.id,
           dimmed,
+          detachedDependencyCount: node.detachedDependencyCount,
         },
       };
     });
@@ -113,27 +116,30 @@ function WorkflowGraphInner({
     return nextNodes;
   }, [graph.nodes, positions, selectedWorkflowId, statusFilters]);
 
-  const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => ({
-    id: `workflow:${edge.kind}:${edge.source}->${edge.target}`,
-    source: edge.source,
-    target: edge.target,
-    type: 'smoothstep',
-    animated: false,
-    style: {
-      stroke: edge.kind === 'historical' ? 'rgba(245,158,11,0.5)' : 'rgba(148,163,184,0.55)',
-      strokeWidth: edge.kind === 'historical' ? 1.5 : 2,
-      strokeDasharray: edge.kind === 'historical' ? '6 6' : undefined,
-    },
-    data: { kind: edge.kind },
-    ariaLabel: edge.kind === 'historical' ? 'Historical workflow dependency' : 'Active workflow dependency',
-    zIndex: 0,
-    markerEnd: {
-      type: MarkerType.ArrowClosed,
-      color: edge.kind === 'historical' ? 'rgba(245,158,11,0.5)' : 'rgba(148,163,184,0.55)',
-      width: 16,
-      height: 16,
-    },
-  })), [graph.edges]);
+  const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => {
+    const presentation = workflowEdgePresentation(edge.kind);
+    return {
+      id: `workflow:${edge.kind}:${edge.source}->${edge.target}`,
+      source: edge.source,
+      target: edge.target,
+      type: 'smoothstep',
+      animated: false,
+      style: {
+        stroke: presentation.stroke,
+        strokeWidth: presentation.strokeWidth,
+        strokeDasharray: presentation.strokeDasharray,
+      },
+      data: { kind: edge.kind },
+      ariaLabel: presentation.ariaLabel,
+      zIndex: 0,
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color: presentation.stroke,
+        width: 16,
+        height: 16,
+      },
+    };
+  }), [graph.edges]);
 
   const graphSignature = useMemo(() => {
     const nodeIds = graph.nodes.map((node) => node.id).join('|');
@@ -276,4 +282,33 @@ export function WorkflowGraph(props: WorkflowGraphProps): JSX.Element {
       <WorkflowGraphInner {...props} />
     </ReactFlowProvider>
   );
+}
+
+function workflowEdgePresentation(kind: WorkflowGraphEdge['kind']): {
+  stroke: string;
+  strokeWidth: number;
+  strokeDasharray?: string;
+  ariaLabel: string;
+} {
+  if (kind === 'detached') {
+    return {
+      stroke: 'rgba(245,158,11,0.62)',
+      strokeWidth: 1.5,
+      strokeDasharray: '6 6',
+      ariaLabel: 'Detached workflow dependency',
+    };
+  }
+  if (kind === 'historical') {
+    return {
+      stroke: 'rgba(245,158,11,0.42)',
+      strokeWidth: 1.25,
+      strokeDasharray: '4 7',
+      ariaLabel: 'Historical workflow dependency',
+    };
+  }
+  return {
+    stroke: 'rgba(148,163,184,0.55)',
+    strokeWidth: 2,
+    ariaLabel: 'Active workflow dependency',
+  };
 }

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -6,6 +6,7 @@ interface WorkflowNodeProps {
   workflow: WorkflowMeta;
   selected: boolean;
   dimmed: boolean;
+  detachedDependencyCount?: number;
   onClick: () => void;
   onContextMenu: (event: MouseEvent<HTMLDivElement>) => void;
 }
@@ -18,10 +19,14 @@ export function WorkflowNode({
   workflow,
   selected,
   dimmed,
+  detachedDependencyCount = 0,
   onClick,
   onContextMenu,
 }: WorkflowNodeProps): JSX.Element {
   const visual = workflowStatusVisual(workflow.status);
+  const detachedTitle = detachedDependencyCount === 1
+    ? 'Detached from 1 upstream workflow'
+    : `Detached from ${detachedDependencyCount} upstream workflows`;
 
   return (
     <div
@@ -49,7 +54,18 @@ export function WorkflowNode({
         <div className={`absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rounded-full ${visual.railClass} animate-ping`} />
       )}
 
-      <div className="text-[13px] font-semibold text-gray-100 truncate">{workflow.name || workflow.id}</div>
+      <div className="flex min-w-0 items-center gap-2">
+        <div className="min-w-0 flex-1 text-[13px] font-semibold text-gray-100 truncate">{workflow.name || workflow.id}</div>
+        {detachedDependencyCount > 0 && (
+          <div
+            data-testid={`workflow-node-${workflow.id}-detached-badge`}
+            title={detachedTitle}
+            className="shrink-0 rounded border border-amber-500/35 bg-amber-500/10 px-1.5 py-0.5 text-[9px] font-semibold text-amber-300"
+          >
+            Detached
+          </div>
+        )}
+      </div>
       <div className="mt-1 text-[11px] text-gray-400 truncate">{workflow.id}</div>
       <div className={`mt-2 text-[10px] uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
     </div>

--- a/packages/ui/src/lib/workflow-graph.test.ts
+++ b/packages/ui/src/lib/workflow-graph.test.ts
@@ -19,13 +19,17 @@ function makeWorkflow(
   };
 }
 
-function makeTask(id: string, workflowId: string): TaskState {
+function makeTask(
+  id: string,
+  workflowId: string,
+  config: Partial<TaskState['config']> = {},
+): TaskState {
   return {
     id,
     description: id,
     status: 'pending',
     dependencies: [],
-    config: { workflowId },
+    config: { workflowId, ...config },
     execution: {},
     taskStateVersion: 1,
   };
@@ -120,6 +124,119 @@ describe('deriveWorkflowGraph', () => {
     expect(graph.edges).toEqual([
       { source: 'A', target: 'B', kind: 'historical' },
     ]);
+  });
+
+  it('derives detached lineage from task config provenance', () => {
+    const workflows = new Map([
+      ['A', makeWorkflow('A')],
+      [
+        'B',
+        makeWorkflow('B', 'running', undefined, [], [
+          {
+            before: {
+              workflowId: 'A',
+              taskId: '__merge__',
+              requiredStatus: 'completed',
+              gatePolicy: 'review_ready',
+            },
+            changedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ]),
+      ],
+    ]);
+    const tasks = new Map<string, TaskState>([
+      [
+        'B/__merge__',
+        makeTask('B/__merge__', 'B', {
+          isMergeNode: true,
+          detachedExternalDependencies: [
+            {
+              workflowId: 'A',
+              taskId: '__merge__',
+              requiredStatus: 'completed',
+              gatePolicy: 'review_ready',
+              detachedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      ],
+    ]);
+
+    const graph = deriveWorkflowGraph(workflows, tasks);
+
+    expect(graph.edges).toEqual([
+      { source: 'A', target: 'B', kind: 'detached' },
+    ]);
+    expect(graph.nodes.find((node) => node.id === 'B')?.detachedDependencyCount).toBe(1);
+  });
+
+  it('does not duplicate detached lineage entries', () => {
+    const workflows = new Map([
+      ['A', makeWorkflow('A')],
+      ['B', makeWorkflow('B')],
+    ]);
+    const tasks = new Map<string, TaskState>([
+      [
+        'B/__merge__',
+        makeTask('B/__merge__', 'B', {
+          isMergeNode: true,
+          detachedExternalDependencies: [
+            {
+              workflowId: 'A',
+              taskId: '__merge__',
+              requiredStatus: 'completed',
+              gatePolicy: 'review_ready',
+              detachedAt: '2026-01-01T00:00:00.000Z',
+            },
+            {
+              workflowId: 'A',
+              taskId: '__merge__',
+              requiredStatus: 'completed',
+              gatePolicy: 'review_ready',
+              detachedAt: '2026-01-02T00:00:00.000Z',
+            },
+          ],
+        }),
+      ],
+    ]);
+
+    const graph = deriveWorkflowGraph(workflows, tasks);
+
+    expect(graph.edges).toEqual([
+      { source: 'A', target: 'B', kind: 'detached' },
+    ]);
+    expect(graph.nodes.find((node) => node.id === 'B')?.detachedDependencyCount).toBe(1);
+  });
+
+  it('keeps active dependency edges authoritative over detached provenance', () => {
+    const workflows = new Map([
+      ['A', makeWorkflow('A')],
+      ['B', makeWorkflow('B', 'running', undefined, [{ workflowId: 'A' }])],
+    ]);
+    const tasks = new Map<string, TaskState>([
+      [
+        'B/__merge__',
+        makeTask('B/__merge__', 'B', {
+          isMergeNode: true,
+          detachedExternalDependencies: [
+            {
+              workflowId: 'A',
+              taskId: '__merge__',
+              requiredStatus: 'completed',
+              gatePolicy: 'review_ready',
+              detachedAt: '2026-01-01T00:00:00.000Z',
+            },
+          ],
+        }),
+      ],
+    ]);
+
+    const graph = deriveWorkflowGraph(workflows, tasks);
+
+    expect(graph.edges).toEqual([
+      { source: 'A', target: 'B', kind: 'active' },
+    ]);
+    expect(graph.nodes.find((node) => node.id === 'B')?.detachedDependencyCount).toBe(0);
   });
 
   it('does not duplicate active edges for dependency addition history', () => {
@@ -297,6 +414,21 @@ describe('layoutWorkflowGraph', () => {
     expect(positions.get('y-target')).toEqual({ x: 180, y: 80 });
     expect(positions.get('x-target')).toEqual({ x: 180, y: 130 });
   });
+
+  it('uses detached edges when grouping workflow components', () => {
+    const graph = makeGraph(
+      [
+        makeWorkflow('upstream', 'running', '2026-03-01T00:00:00.000Z'),
+        makeWorkflow('downstream', 'running', '2026-03-01T00:00:00.000Z'),
+      ],
+      [{ source: 'upstream', target: 'downstream', kind: 'detached' }],
+    );
+
+    const positions = layoutWorkflowGraph(graph, 100, 50, 25);
+
+    expect(positions.get('upstream')).toEqual({ x: 80, y: 80 });
+    expect(positions.get('downstream')).toEqual({ x: 180, y: 80 });
+  });
 });
 
 function makeGraph(
@@ -304,7 +436,12 @@ function makeGraph(
   edges: WorkflowGraph['edges'],
 ): WorkflowGraph {
   return {
-    nodes: workflows.map((workflow) => ({ id: workflow.id, name: workflow.name, workflow })),
+    nodes: workflows.map((workflow) => ({
+      id: workflow.id,
+      name: workflow.name,
+      workflow,
+      detachedDependencyCount: 0,
+    })),
     edges,
     missingDependencies: [],
   };

--- a/packages/ui/src/lib/workflow-graph.ts
+++ b/packages/ui/src/lib/workflow-graph.ts
@@ -4,12 +4,13 @@ export interface WorkflowGraphNode {
   id: string;
   name: string;
   workflow: WorkflowMeta;
+  detachedDependencyCount: number;
 }
 
 export interface WorkflowGraphEdge {
   source: string;
   target: string;
-  kind: 'active' | 'historical';
+  kind: 'active' | 'detached' | 'historical';
 }
 
 export interface WorkflowGraph {
@@ -27,17 +28,10 @@ export function deriveWorkflowGraph(
   workflows: Map<string, WorkflowMeta>,
   tasks: Map<string, TaskState>,
 ): WorkflowGraph {
-  const nodes: WorkflowGraphNode[] = [...workflows.values()].map((workflow) => ({
-    id: workflow.id,
-    name: workflow.name,
-    workflow,
-  }));
-
   const edgeKeys = new Set<string>();
   const edges: WorkflowGraphEdge[] = [];
   const missingDependencies = new Set<string>();
-
-  void tasks;
+  const detachedSourcesByTarget = new Map<string, Set<string>>();
 
   for (const workflow of workflows.values()) {
     const targetWorkflowId = workflow.id;
@@ -53,6 +47,31 @@ export function deriveWorkflowGraph(
       edgeKeys.add(key);
       edges.push({ source: sourceWorkflowId, target: targetWorkflowId, kind: 'active' });
     }
+  }
+
+  for (const task of [...tasks.values()].sort((a, b) => a.id.localeCompare(b.id))) {
+    const targetWorkflowId = task.config.workflowId;
+    if (!targetWorkflowId || !workflows.has(targetWorkflowId)) continue;
+    for (const dep of task.config.detachedExternalDependencies ?? []) {
+      const sourceWorkflowId = dep.workflowId;
+      if (!workflows.has(sourceWorkflowId)) {
+        missingDependencies.add(`${sourceWorkflowId}->${targetWorkflowId}`);
+        continue;
+      }
+      if (sourceWorkflowId === targetWorkflowId) continue;
+      if (edgeKeys.has(`active:${sourceWorkflowId}->${targetWorkflowId}`)) continue;
+      const key = `detached:${sourceWorkflowId}->${targetWorkflowId}`;
+      if (edgeKeys.has(key)) continue;
+      edgeKeys.add(key);
+      edges.push({ source: sourceWorkflowId, target: targetWorkflowId, kind: 'detached' });
+      const sources = detachedSourcesByTarget.get(targetWorkflowId) ?? new Set<string>();
+      sources.add(sourceWorkflowId);
+      detachedSourcesByTarget.set(targetWorkflowId, sources);
+    }
+  }
+
+  for (const workflow of workflows.values()) {
+    const targetWorkflowId = workflow.id;
     for (const change of workflow.externalDependencyChanges ?? []) {
       for (const dependency of [change.before, change.after]) {
         if (!dependency) continue;
@@ -63,6 +82,7 @@ export function deriveWorkflowGraph(
         }
         if (sourceWorkflowId === targetWorkflowId) continue;
         if (edgeKeys.has(`active:${sourceWorkflowId}->${targetWorkflowId}`)) continue;
+        if (edgeKeys.has(`detached:${sourceWorkflowId}->${targetWorkflowId}`)) continue;
         const key = `historical:${sourceWorkflowId}->${targetWorkflowId}`;
         if (edgeKeys.has(key)) continue;
         edgeKeys.add(key);
@@ -70,6 +90,13 @@ export function deriveWorkflowGraph(
       }
     }
   }
+
+  const nodes: WorkflowGraphNode[] = [...workflows.values()].map((workflow) => ({
+    id: workflow.id,
+    name: workflow.name,
+    workflow,
+    detachedDependencyCount: detachedSourcesByTarget.get(workflow.id)?.size ?? 0,
+  }));
 
   return {
     nodes: nodes.sort((a, b) => a.name.localeCompare(b.name)),

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -50,6 +50,16 @@ export interface ExternalDependencyChange {
   readonly changedBy?: string;
 }
 
+/**
+ * Read-only provenance for a cross-workflow dependency removed by
+ * `detachWorkflow`. Mirrors `@invoker/workflow-graph`'s
+ * `DetachedExternalDependency`; lets the renderer distinguish a detached
+ * stack edge from a genuinely independent workflow.
+ */
+export interface DetachedExternalDependency extends ExternalDependency {
+  readonly detachedAt: string;
+}
+
 export interface ExternalGatePolicyUpdate {
   workflowId: string;
   taskId?: string;
@@ -83,6 +93,12 @@ export interface TaskConfig {
   readonly testPlan?: string;
   readonly reproCommand?: string;
   readonly externalDependencies?: readonly ExternalDependency[];
+  /**
+   * Read-only provenance for cross-workflow dependencies removed by
+   * `detachWorkflow`, carried on the workflow's merge-gate node. Not used
+   * for scheduling; rendered to mark detached upstream stack edges.
+   */
+  readonly detachedExternalDependencies?: readonly DetachedExternalDependency[];
 }
 
 // ── Task Execution (runtime fields) ────────────────────────

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -1336,6 +1336,128 @@ describe('Orchestrator', () => {
       ]);
     });
 
+    it('records read-only detach provenance on the merge node while keeping the active dependency removed', () => {
+      orchestrator.loadPlan({
+        name: 'prov-upstream-a',
+        baseBranch: 'master',
+        featureBranch: 'feature/prov-upstream-a',
+        tasks: [{ id: 'verify-a', description: 'upstream A prerequisite' }],
+      });
+      const upstreamAWfId = sid(orchestrator, 0, 'verify-a').split('/')[0]!;
+
+      orchestrator.loadPlan({
+        name: 'prov-upstream-b',
+        baseBranch: 'master',
+        featureBranch: 'feature/prov-upstream-b',
+        tasks: [{ id: 'verify-b', description: 'upstream B prerequisite' }],
+      });
+      const upstreamBWfId = sid(orchestrator, 1, 'verify-b').split('/')[0]!;
+
+      orchestrator.loadPlan({
+        name: 'prov-target',
+        baseBranch: 'master',
+        featureBranch: 'feature/prov-target',
+        tasks: [
+          {
+            id: 'wait-for-upstreams',
+            description: 'target waits for two upstream workflows',
+            externalDependencies: [
+              { workflowId: upstreamAWfId, gatePolicy: 'review_ready' },
+              { workflowId: upstreamBWfId, gatePolicy: 'completed' },
+            ],
+          },
+        ],
+      });
+      const targetTaskId = sid(orchestrator, 2, 'wait-for-upstreams');
+      const targetWfId = targetTaskId.split('/')[0]!;
+
+      orchestrator.detachWorkflow(targetWfId, upstreamAWfId);
+
+      // Active dependency for the detached upstream is removed — scheduling is unchanged.
+      expect(persistence.loadWorkflow(targetWfId)!.externalDependencies).toEqual([
+        { workflowId: upstreamBWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed' },
+      ]);
+
+      // Read-only provenance for the removed edge is preserved on the merge node and persisted.
+      const expectedProvenance = {
+        workflowId: upstreamAWfId,
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'review_ready',
+        detachedAt: expect.any(String),
+      };
+      const mergeNodeId = orchestrator.getMergeNode(targetWfId)!.id;
+      expect(orchestrator.getMergeNode(targetWfId)!.config.detachedExternalDependencies).toEqual([
+        expectedProvenance,
+      ]);
+      const persistedMergeNode = persistence.loadTasks(targetWfId).find((task) => task.id === mergeNodeId)!;
+      expect(persistedMergeNode.config.detachedExternalDependencies).toEqual([expectedProvenance]);
+
+      // Existing audit-trail change record remains intact.
+      expect(persistence.loadWorkflow(targetWfId)!.externalDependencyChanges).toEqual([
+        {
+          before: {
+            workflowId: upstreamAWfId,
+            taskId: '__merge__',
+            requiredStatus: 'completed',
+            gatePolicy: 'review_ready',
+          },
+          changedAt: expect.any(String),
+        },
+      ]);
+    });
+
+    it('appends detach provenance without introducing duplicates across successive detaches and reloads', () => {
+      orchestrator.loadPlan({
+        name: 'dup-upstream-a',
+        baseBranch: 'master',
+        featureBranch: 'feature/dup-upstream-a',
+        tasks: [{ id: 'verify-a', description: 'upstream A prerequisite' }],
+      });
+      const upstreamAWfId = sid(orchestrator, 0, 'verify-a').split('/')[0]!;
+
+      orchestrator.loadPlan({
+        name: 'dup-upstream-b',
+        baseBranch: 'master',
+        featureBranch: 'feature/dup-upstream-b',
+        tasks: [{ id: 'verify-b', description: 'upstream B prerequisite' }],
+      });
+      const upstreamBWfId = sid(orchestrator, 1, 'verify-b').split('/')[0]!;
+
+      orchestrator.loadPlan({
+        name: 'dup-target',
+        baseBranch: 'master',
+        featureBranch: 'feature/dup-target',
+        tasks: [
+          {
+            id: 'wait-for-upstreams',
+            description: 'target waits for two upstream workflows',
+            externalDependencies: [
+              { workflowId: upstreamAWfId, gatePolicy: 'review_ready' },
+              { workflowId: upstreamBWfId, gatePolicy: 'completed' },
+            ],
+          },
+        ],
+      });
+      const targetWfId = sid(orchestrator, 2, 'wait-for-upstreams').split('/')[0]!;
+
+      orchestrator.detachWorkflow(targetWfId, upstreamAWfId);
+      // The second detach reloads the merge node (provenance for A already persisted),
+      // then appends B without re-adding A.
+      orchestrator.detachWorkflow(targetWfId, upstreamBWfId);
+
+      expect(orchestrator.getMergeNode(targetWfId)!.config.detachedExternalDependencies).toEqual([
+        { workflowId: upstreamAWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready', detachedAt: expect.any(String) },
+        { workflowId: upstreamBWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'completed', detachedAt: expect.any(String) },
+      ]);
+
+      // Re-detaching an already-detached upstream is rejected and never grows provenance.
+      expect(() => orchestrator.detachWorkflow(targetWfId, upstreamAWfId)).toThrow(
+        /does not depend on upstream workflow/,
+      );
+      expect(orchestrator.getMergeNode(targetWfId)!.config.detachedExternalDependencies).toHaveLength(2);
+    });
+
     it('voids a running target workflow and its descendants back to pending without auto-starting them', () => {
       orchestrator.loadPlan({
         name: 'upstream-runtime',

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -19,7 +19,7 @@ import { TaskStateMachine } from './state-machine.js';
 import { ResponseHandler } from './response-handler.js';
 import type { ParsedResponse } from './response-handler.js';
 import { TaskScheduler } from './scheduler.js';
-import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, ExternalDependencyChange, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
+import type { TaskState, TaskDelta, TaskStateChanges, TaskConfig, Attempt, ExternalDependency, ExternalDependencyChange, DetachedExternalDependency, TaskStatus, TaskHeartbeatSource } from '@invoker/workflow-graph';
 import type { RunnerKind } from '@invoker/workflow-graph';
 import { createTaskState, createAttempt } from '@invoker/workflow-graph';
 import type { WorkflowDerivedStatus } from '@invoker/workflow-graph';
@@ -5141,6 +5141,53 @@ export class Orchestrator {
       .filter((t): t is TaskState => !!t);
   }
 
+  /**
+   * Append read-only detach provenance to a carrier task's config (the
+   * detached workflow's merge-gate node).
+   *
+   * Each removed dependency is normalized exactly like the
+   * `externalDependencyChanges` audit record (empty/absent `taskId` →
+   * `__merge__`) and stamped with `detachedAt`. The list is append-only and
+   * de-duplicated by (upstream workflow, task selector, required status, gate
+   * policy) so repeated detach attempts and sync/reload cycles never grow
+   * duplicate entries. This never participates in scheduling — active
+   * `externalDependencies` are removed separately by the caller.
+   */
+  private recordDetachedDependencyProvenance(
+    carrierTaskId: string,
+    removedDeps: readonly ExternalDependency[],
+    detachedAt: string,
+  ): void {
+    if (removedDeps.length === 0) return;
+    const carrier = this.stateGetTask(carrierTaskId);
+    if (!carrier) return;
+
+    const keyOf = (dep: Pick<ExternalDependency, 'workflowId' | 'taskId' | 'requiredStatus' | 'gatePolicy'>): string =>
+      `${dep.workflowId}::${dep.taskId?.trim() || '__merge__'}::${dep.requiredStatus}::${dep.gatePolicy ?? ''}`;
+
+    const existing = carrier.config.detachedExternalDependencies ?? [];
+    const seen = new Set(existing.map((dep) => keyOf(dep)));
+
+    const additions: DetachedExternalDependency[] = [];
+    for (const dep of removedDeps) {
+      const key = keyOf(dep);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      additions.push({
+        ...dep,
+        taskId: dep.taskId?.trim() || '__merge__',
+        detachedAt,
+      });
+    }
+    if (additions.length === 0) return;
+
+    const changes: TaskStateChanges = {
+      config: { detachedExternalDependencies: [...existing, ...additions] },
+    };
+    const updated = this.writeAndSync(carrierTaskId, changes);
+    this.messageBus.publish(TASK_DELTA_CHANNEL, this.buildUpdateDelta(carrier, updated, changes));
+  }
+
   private detachWorkflowInternal(
     workflowId: string,
     upstreamWorkflowId: string,
@@ -5191,6 +5238,13 @@ export class Orchestrator {
     });
 
     const eventTask = this.getMergeNode(workflowId) ?? targetTasks[0];
+
+    // Persist read-only provenance for the removed edge(s) on the workflow's
+    // merge-gate node. Active externalDependencies stay removed above, so
+    // scheduling/blocker behavior is unchanged; this only lets the renderer
+    // tell a detached workflow apart from a genuinely independent one.
+    this.recordDetachedDependencyProvenance(eventTask.id, removedDeps, now);
+
     this.persistence.logEvent?.(eventTask.id, 'workflow.external_dependency_changed', {
       workflowId,
       upstreamWorkflowId,

--- a/packages/workflow-graph/src/types.ts
+++ b/packages/workflow-graph/src/types.ts
@@ -44,6 +44,15 @@ export interface BaseTaskConfig {
   readonly executionAgent?: string;
   /** Cross-workflow prerequisites for this task. */
   readonly externalDependencies?: readonly ExternalDependency[];
+  /**
+   * Read-only provenance for cross-workflow prerequisites that were
+   * explicitly removed by `detachWorkflow`. Active scheduling/blocker
+   * behavior ignores these — they exist so the UI can distinguish a
+   * genuinely independent workflow from one that was detached from an
+   * upstream stack edge. Append-only and de-duplicated; never consulted
+   * by the scheduler. Carried on the workflow's merge-gate node.
+   */
+  readonly detachedExternalDependencies?: readonly DetachedExternalDependency[];
   /** Execution pool identifier for shared queue/drain scheduling across substrates. */
   readonly poolId?: string;
   /** Legacy direct SSH pool member selection used by editable runner controls. */
@@ -101,6 +110,19 @@ export interface ExternalDependencyChange {
   readonly after?: ExternalDependency;
   readonly changedAt: string;
   readonly changedBy?: string;
+}
+
+/**
+ * Read-only provenance record for a cross-workflow dependency removed by
+ * `detachWorkflow`. Captures the full removed dependency (upstream workflow
+ * id, task selector, required status and gate policy) plus the time it was
+ * detached, so the renderer can attribute a detached stack edge without
+ * replaying audit events. `taskId` is normalized to `__merge__` when the
+ * removed dependency targeted the upstream workflow's merge gate.
+ */
+export interface DetachedExternalDependency extends ExternalDependency {
+  /** ISO-8601 timestamp at which `detachWorkflow` removed this dependency. */
+  readonly detachedAt: string;
 }
 
 // ── Task Execution (runtime state) ─────────────────────────


### PR DESCRIPTION
## Summary

Detached workflow lineage now persists as read-only provenance when `detachWorkflow` removes active cross-workflow dependencies.

Workflow graph derivation separates active dependency edges from detached lineage, so detached stacks remain visible without affecting scheduler readiness.

Detach surfaces now require clearer confirmation or output and report the removed upstream/base rewrite for operators.

## Architecture

### Before

```mermaid
graph TD
    DETACH["detachWorkflow"]
    DETACH --> REMOVE["Remove upstream from externalDependencies"]
    REMOVE --> STORE["Persist task config without lineage"]
    STORE --> GRAPH["Workflow graph reads tasks and workflows"]
    GRAPH --> EDGE["Derive edges only from active externalDependencies"]
    EDGE --> ORPHAN["Detached downstream appears orphaned"]
    REMOVE --> SCHED["Scheduler no longer waits on upstream"]
```

### After

```mermaid
graph TD
    SURFACE["UI headless and API detach surfaces"]
    DETACH["detachWorkflow"]
    SURFACE --> DETACH
    SURFACE --> FEEDBACK["Confirmation or output names downstream and upstream"]
    DETACH --> ACTIVE["Remove upstream from active externalDependencies"]
    DETACH --> PROV["Append deduped detachedExternalDependencies provenance"]
    ACTIVE --> SCHED["Scheduler readiness uses active dependencies only"]
    PROV --> SQLITE["SQLite persists and loadTasks returns provenance"]
    SQLITE --> DERIVE["Workflow graph derives detached lineage edges"]
    DERIVE --> LAYOUT["Layout keeps former stack nodes connected"]
    LAYOUT --> UI["Render dashed read-only lineage and node annotation"]
```

## Test Plan

- [x] `cd packages/workflow-core && pnpm test src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `cd packages/data-store && pnpm test src/__tests__/sqlite-adapter.test.ts`
- [x] `cd packages/ui && pnpm test src/lib/workflow-graph.test.ts src/__tests__/workflow-graph.test.tsx src/__tests__/context-menu-e2e.test.tsx`
- [x] `pnpm run test:all`

## Visual Proof

> Warning: visual proof capture failed and screenshots could not be attached. Visual proof capture failed (exit 1): [visual-proof] Running capture-before...
[visual-proof] Capturing to /Users/edbertchan/Documents/GitHub/Invoker/packages/app/e2e/visual-proof/before
[visual-proof] Building UI and app...
sh: vite: command not found
[visual-proof] ERROR: Build failed

## Revert Plan

- Safe to revert? Yes. This restores the previous detach graph behavior; any recorded provenance remains inert task-config metadata.
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No schema migration. Optional `detachedExternalDependencies` JSON can remain on existing tasks and be ignored after revert.