### PR TITLE
Fix intent cancellation Step 3: SSH startup lineage guards (regression gated v2)

### DIFF
--- a/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-worktree-metadata-repro.test.ts
@@ -144,4 +144,93 @@ describe('SSH worktree metadata repro', () => {
       }),
     }));
   });
+
+  it('blocks stale SSH startup metadata after the selected attempt advances', async () => {
+    const ownerPath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-bc7a0b71';
+    const branch = 'experiment/wf-1/test-execution-engine-bc7a0b71';
+    let rejectStart!: (err: unknown) => void;
+    const startPromise = new Promise<never>((_resolve, reject) => {
+      rejectStart = reject;
+    });
+    const failingExecutor = {
+      type: 'ssh',
+      start: vi.fn(async () => await startPromise),
+      onComplete: vi.fn(),
+      onOutput: vi.fn(),
+      onHeartbeat: vi.fn(),
+      kill: vi.fn(),
+      destroyAll: vi.fn(),
+    };
+
+    const task = makeTask({
+      id: 'wf-1/test-execution-engine',
+      config: { command: 'pnpm test', runnerKind: 'ssh' },
+      execution: { selectedAttemptId: 'attempt-1', generation: 1 },
+    });
+
+    const updateTask = vi.fn();
+    const appendTaskOutput = vi.fn();
+    const logEvent = vi.fn();
+    const handleResponse = vi.fn();
+
+    const runner = new TaskRunner({
+      orchestrator: {
+        getTask: () => task,
+        getAllTasks: () => [task],
+        handleWorkerResponse: handleResponse,
+      } as any,
+      persistence: {
+        updateTask,
+        appendTaskOutput,
+        logEvent,
+      } as any,
+      executorRegistry: {
+        getDefault: () => failingExecutor,
+        get: () => failingExecutor,
+        getAll: () => [failingExecutor],
+      } as any,
+      cwd: '/tmp',
+    });
+
+    const run = runner.executeTask(task);
+    await vi.waitFor(() => expect(failingExecutor.start).toHaveBeenCalledTimes(1));
+    task.execution.selectedAttemptId = 'attempt-2';
+    task.execution.generation = 2;
+    task.execution.workspacePath = '/home/invoker/.invoker/worktrees/049de5b865cc/experiment-wf-1-test-execution-engine-new';
+    task.execution.branch = 'experiment/wf-1/test-execution-engine-new';
+
+    rejectStart(Object.assign(
+      new Error(
+        'SSH remote script failed (exit=128)\n' +
+          `STDERR:\nPreparing worktree (checking out '${branch}')\n` +
+          `fatal: '${branch}' is already used by worktree at '${ownerPath}'\n`,
+      ),
+      { workspacePath: ownerPath, branch },
+    ));
+    await run;
+
+    expect(updateTask).not.toHaveBeenCalledWith('wf-1/test-execution-engine', expect.objectContaining({
+      execution: expect.objectContaining({
+        workspacePath: ownerPath,
+        branch,
+      }),
+    }));
+    expect(handleResponse).not.toHaveBeenCalled();
+    expect(appendTaskOutput).toHaveBeenCalledWith(
+      'wf-1/test-execution-engine',
+      expect.stringContaining('Executor startup failed (ssh): SSH remote script failed'),
+    );
+    expect(logEvent).toHaveBeenCalledWith(
+      'wf-1/test-execution-engine',
+      'task.executor.startup-failure-stale',
+      expect.objectContaining({
+        attemptId: 'attempt-1',
+        generation: 1,
+        currentAttemptId: 'attempt-2',
+        currentGeneration: 2,
+        workspacePath: ownerPath,
+        branch,
+      }),
+    );
+  });
 });

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1239,6 +1239,79 @@ describe('TaskRunner', () => {
       expect(handleWorkerResponse).not.toHaveBeenCalled();
     });
 
+    it('uses launch-time generation when startup fails after in-place lineage mutation', async () => {
+      const handleWorkerResponse = vi.fn();
+      const updateTask = vi.fn();
+      const appendTaskOutput = vi.fn();
+      const logEvent = vi.fn();
+      const task = makeTask({
+        id: 'stale-mutated-gen',
+        status: 'running',
+        config: { command: 'echo hi', runnerKind: 'ssh' as any },
+        execution: { selectedAttemptId: 'attempt-1', generation: 1 },
+      });
+      const orchestrator = {
+        getTask: () => task,
+        handleWorkerResponse,
+      };
+      let rejectStart!: (err: unknown) => void;
+      const startPromise = new Promise<never>((_resolve, reject) => {
+        rejectStart = reject;
+      });
+      const throwingExecutor = {
+        type: 'ssh',
+        start: vi.fn(async () => await startPromise),
+        onOutput: () => () => {},
+        onComplete: () => () => {},
+      };
+      const registry = {
+        getDefault: () => throwingExecutor,
+        get: () => throwingExecutor,
+        getAll: () => [throwingExecutor],
+      };
+
+      const runner = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: { updateTask, appendTaskOutput, logEvent } as any,
+        executorRegistry: registry as any,
+        cwd: '/tmp',
+      });
+
+      const run = runner.executeTask(task);
+      await vi.waitFor(() => expect(throwingExecutor.start).toHaveBeenCalledTimes(1));
+      task.execution.generation = 2;
+      const startupErr: any = new Error('late provision failed');
+      startupErr.workspacePath = '/tmp/mutated-gen-old-worktree';
+      startupErr.branch = 'experiment/mutated-gen-old-branch';
+      rejectStart(startupErr);
+      await run;
+
+      expect(updateTask).not.toHaveBeenCalledWith(
+        'stale-mutated-gen',
+        expect.objectContaining({
+          execution: expect.objectContaining({ workspacePath: '/tmp/mutated-gen-old-worktree' }),
+        }),
+      );
+      expect(handleWorkerResponse).not.toHaveBeenCalled();
+      expect(appendTaskOutput).toHaveBeenCalledWith(
+        'stale-mutated-gen',
+        expect.stringContaining('Executor startup failed (ssh): late provision failed'),
+      );
+      expect(logEvent).toHaveBeenCalledWith(
+        'stale-mutated-gen',
+        'task.executor.startup-failure-stale',
+        expect.objectContaining({
+          attemptId: 'attempt-1',
+          generation: 1,
+          currentAttemptId: 'attempt-1',
+          currentGeneration: 2,
+          runnerKind: 'ssh',
+          workspacePath: '/tmp/mutated-gen-old-worktree',
+          branch: 'experiment/mutated-gen-old-branch',
+        }),
+      );
+    });
+
     it('still persists metadata and emits response when lineage is current', async () => {
       const handleWorkerResponse = vi.fn();
       const updateTask = vi.fn();

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -494,6 +494,33 @@ export class TaskRunner {
     return false;
   }
 
+  private logStaleStartupFailure(
+    taskId: string,
+    attemptId: string,
+    startGeneration: number,
+    executorType: string,
+    err: unknown,
+    meta: StartupFailureMetadata,
+  ): void {
+    try {
+      const current = this.orchestrator.getTask(taskId);
+      this.persistence.logEvent?.(taskId, 'task.executor.startup-failure-stale', {
+        attemptId,
+        generation: startGeneration,
+        currentAttemptId: current?.execution.selectedAttemptId,
+        currentGeneration: current?.execution.generation ?? 0,
+        runnerKind: executorType,
+        error: err instanceof Error ? err.message : String(err),
+        workspacePath: meta.workspacePath,
+        branch: meta.branch,
+        agentSessionId: meta.agentSessionId,
+        containerId: meta.containerId,
+      });
+    } catch {
+      // Diagnostics are best-effort; stale launches must not mutate live execution state.
+    }
+  }
+
   async executeTask(task: TaskState, dispatchOpts?: LaunchDispatchOptions): Promise<void> {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} TaskRunner.executeTask BEGIN taskId=${task.id} isMergeNode=${Boolean(task.config.isMergeNode)} status=${task.status}`,
@@ -932,9 +959,13 @@ export class TaskRunner {
         // current.  If the task has moved to a newer attempt or generation
         // (e.g. via recreate-task), writing old workspace/branch metadata
         // would corrupt the live attempt's state.
+        const startupFailureIsStale = this.isLaunchStale(task.id, attemptId, startGeneration);
+        if (startupFailureIsStale) {
+          this.logStaleStartupFailure(task.id, attemptId, startGeneration, executor.type, err, meta);
+        }
         if (
           (meta.workspacePath || meta.branch || meta.agentSessionId || meta.containerId)
-          && !this.isLaunchStale(task.id, attemptId, task.execution.generation ?? 0)
+          && !startupFailureIsStale
         ) {
           const execution: Record<string, string> = {};
           if (meta.workspacePath) execution.workspacePath = meta.workspacePath;


### PR DESCRIPTION
## Summary

TaskRunner now evaluates SSH startup-failure metadata against the launch-time generation captured before `executor.start`.

Stale startup failures log diagnostics instead of writing old workspace, branch, session, or container metadata onto the live task row.

The stale path keeps the failed WorkResponse suppressed for newer lineages while preserving output logging for diagnostics.

Regression coverage exercises in-place generation mutation and selected-attempt advancement, including the remote worktree collision repro.

## Architecture

### Before

```mermaid
graph TD
    LAUNCH["Launch captures attempt id"]
    START["SSH executor.start"]
    ADVANCE["Task lineage advances"]
    FAIL["Startup failure returns old metadata"]
    CHECK["Metadata guard reads mutable task generation"]
    WRITE["Old workspace and branch can be persisted"]
    SUPPRESS["Outer stale guard may suppress failed response"]

    LAUNCH --> START
    START --> FAIL
    ADVANCE --> CHECK
    FAIL --> CHECK
    CHECK --> WRITE
    CHECK --> SUPPRESS

    style WRITE fill:#ffcdd2
```

### After

```mermaid
graph TD
    LAUNCH["Launch captures attempt id and generation"]
    START["SSH executor.start"]
    ADVANCE["Task lineage advances"]
    FAIL["Startup failure returns old metadata"]
    CHECK["Metadata guard compares current lineage to launch snapshot"]
    LOG["Log stale startup-failure diagnostics"]
    DROP["Skip live metadata update"]
    RESPONSE["Outer guard suppresses failed response"]

    LAUNCH --> START
    START --> FAIL
    ADVANCE --> CHECK
    FAIL --> CHECK
    CHECK --> LOG
    CHECK --> DROP
    CHECK --> RESPONSE

    style LOG fill:#fff3e0
    style DROP fill:#c8e6c9
    style RESPONSE fill:#c8e6c9
```

## Test Plan

- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert -m 1 b7eda4c9`
- Post-revert steps: None
- Data migration? No