### PR TITLE
Reduce Large Files Step 2: main.ts decomposition

### DIFF
--- a/packages/app/src/__tests__/app-bootstrap.test.ts
+++ b/packages/app/src/__tests__/app-bootstrap.test.ts
@@ -4,6 +4,7 @@ import {
   registerGuiLifecycleHandlers,
   runElectronReadyBootstrap,
   startGuiModeBootstrap,
+  startMainProcessBootstrap,
 } from '../bootstrap/app-bootstrap.js';
 
 function createCommandLineRecorder() {
@@ -163,6 +164,32 @@ describe('app-bootstrap', () => {
 
     expect(requestSingleInstanceLock).not.toHaveBeenCalled();
     expect(setupGuiMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('delegates the composition root to headless or GUI startup without reordering callbacks', () => {
+    const order: string[] = [];
+
+    startMainProcessBootstrap({
+      isHeadless: true,
+      startHeadlessMode: () => {
+        order.push('headless');
+      },
+      startGuiMode: () => {
+        order.push('gui');
+      },
+    });
+
+    startMainProcessBootstrap({
+      isHeadless: false,
+      startHeadlessMode: () => {
+        order.push('headless');
+      },
+      startGuiMode: () => {
+        order.push('gui');
+      },
+    });
+
+    expect(order).toEqual(['headless', 'gui']);
   });
 
   it('registers lifecycle handlers without changing event names', () => {

--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { IpcMain } from 'electron';
 import { TransportError, TransportErrorCode } from '@invoker/transport';
 import {
+  createGuiMutationRegistrars,
   registerBootstrapStateIpc,
   registerGuiMutationHandler,
   registerWorkflowScopedGuiMutationHandler,
@@ -173,6 +174,50 @@ describe('ipc-registration', () => {
         args: ['task-1'],
       },
     ]);
+  });
+
+  it('creates typed registrars that preserve channel registration outputs', async () => {
+    const { ipcMain, handleHandlers } = createFakeIpcMain();
+    const guiMutationHandlers = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+    const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();
+    const runWorkflowMutation = vi.fn(async (_workflowId, _priority, _channel, _args, op) => op());
+    const guiContext: GuiMutationRegistrationContext = {
+      ipcMain,
+      getOwnerMode: () => true,
+      getMessageBus: () => ({ request: vi.fn() }),
+      translateGuiMutationToHeadless: vi.fn(),
+      guiMutationHandlers,
+    };
+    const workflowContext: WorkflowScopedGuiMutationRegistrationContext = {
+      ...guiContext,
+      workflowMutationDispatcher,
+      runWorkflowMutation,
+    };
+
+    const {
+      registerGuiMutationHandler: registerGui,
+      registerWorkflowScopedGuiMutationHandler: registerWorkflowScoped,
+    } = createGuiMutationRegistrars(guiContext, workflowContext);
+
+    registerGui('invoker:plain', async (value) => `plain:${String(value)}`);
+    registerWorkflowScoped(
+      'invoker:scoped',
+      (taskId) => `wf:${String(taskId)}`,
+      'normal',
+      async (value) => `scoped:${String(value)}`,
+    );
+
+    await expect(handleHandlers.get('invoker:plain')?.({}, 'a')).resolves.toBe('plain:a');
+    await expect(handleHandlers.get('invoker:scoped')?.({}, 'task-1')).resolves.toBe('scoped:task-1');
+    expect([...guiMutationHandlers.keys()]).toEqual(['invoker:plain', 'invoker:scoped']);
+    expect([...workflowMutationDispatcher.keys()]).toEqual(['invoker:scoped']);
+    expect(runWorkflowMutation).toHaveBeenCalledWith(
+      'wf:task-1',
+      'normal',
+      'invoker:scoped',
+      ['task-1'],
+      expect.any(Function),
+    );
   });
 
   it('registers bootstrap sync IPC with unchanged payload fields', () => {

--- a/packages/app/src/bootstrap/app-bootstrap.ts
+++ b/packages/app/src/bootstrap/app-bootstrap.ts
@@ -68,6 +68,21 @@ export function startGuiModeBootstrap(options: GuiModeBootstrapOptions): void {
   options.setupGuiMode();
 }
 
+export interface MainProcessBootstrapOptions {
+  isHeadless: boolean;
+  startHeadlessMode: () => void;
+  startGuiMode: () => void;
+}
+
+export function startMainProcessBootstrap(options: MainProcessBootstrapOptions): void {
+  if (options.isHeadless) {
+    options.startHeadlessMode();
+    return;
+  }
+
+  options.startGuiMode();
+}
+
 export interface GuiLifecycleHandlers {
   onWindowAllClosed: () => void;
   onBeforeQuit: (event: { preventDefault: () => void }) => void | Promise<void>;

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -102,6 +102,39 @@ export function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
   });
 }
 
+export interface GuiMutationRegistrars {
+  registerGuiMutationHandler: <TResult = unknown>(
+    channel: string,
+    handler: (...args: unknown[]) => Promise<TResult>,
+  ) => void;
+  registerWorkflowScopedGuiMutationHandler: <TResult = unknown>(
+    channel: string,
+    resolveWorkflowId: (...args: unknown[]) => string | undefined,
+    priority: WorkflowMutationPriority,
+    handler: (...args: unknown[]) => Promise<TResult>,
+  ) => void;
+}
+
+export function createGuiMutationRegistrars(
+  guiContext: GuiMutationRegistrationContext,
+  workflowScopedContext: WorkflowScopedGuiMutationRegistrationContext,
+): GuiMutationRegistrars {
+  return {
+    registerGuiMutationHandler: (channel, handler) => {
+      registerGuiMutationHandler(guiContext, channel, handler);
+    },
+    registerWorkflowScopedGuiMutationHandler: (channel, resolveWorkflowId, priority, handler) => {
+      registerWorkflowScopedGuiMutationHandler(
+        workflowScopedContext,
+        channel,
+        resolveWorkflowId,
+        priority,
+        handler,
+      );
+    },
+  };
+}
+
 export interface BootstrapStateIpcContext {
   ipcMain: Pick<IpcMain, 'on'>;
   getTasks: () => TaskState[];

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -41,6 +41,7 @@ import {
   registerGuiLifecycleHandlers,
   runElectronReadyBootstrap,
   startGuiModeBootstrap,
+  startMainProcessBootstrap,
 } from './bootstrap/app-bootstrap.js';
 
 const enableTestCompositor = process.env.INVOKER_E2E_ENABLE_COMPOSITOR === '1' || Boolean(process.env.CAPTURE_MODE);
@@ -192,9 +193,8 @@ import {
 } from './action-graph-diagnostics.js';
 import { registerReadOnlyIpcHandlers } from './ipc-read-handlers.js';
 import {
+  createGuiMutationRegistrars,
   registerBootstrapStateIpc,
-  registerGuiMutationHandler as registerGuiMutationIpcHandler,
-  registerWorkflowScopedGuiMutationHandler as registerWorkflowScopedGuiMutationIpcHandler,
   type GuiMutationPayload,
   type GuiMutationRegistrationContext,
   type WorkflowScopedGuiMutationRegistrationContext,
@@ -850,7 +850,7 @@ const RED = '\x1b[31m';
 // HEADLESS MODE
 // ══════════════════════════════════════════════════════════════
 
-if (isHeadless) {
+function startHeadlessMode(): void {
   const runHeadlessMain = async (): Promise<void> => {
     const agentRegistry = registerBuiltinAgents();
     const command = cliArgs[0];
@@ -1740,16 +1740,17 @@ if (isHeadless) {
       process.exit(1);
     },
   });
-} else {
-  // ══════════════════════════════════════════════════════════════
-  // GUI MODE
-  // ══════════════════════════════════════════════════════════════
-  startGuiModeBootstrap({
+}
+
+startMainProcessBootstrap({
+  isHeadless,
+  startHeadlessMode,
+  startGuiMode: () => startGuiModeBootstrap({
     app,
     isTest: process.env.NODE_ENV === 'test',
     setupGuiMode,
-  });
-}
+  }),
+});
 
 // ══════════════════════════════════════════════════════════════
 // GUI MODE
@@ -2742,27 +2743,13 @@ function createEmbeddedTerminalBackendFromConfig(
     runWorkflowMutation,
   };
 
-  function registerGuiMutationHandler<TResult = unknown>(
-    channel: string,
-    handler: (...args: unknown[]) => Promise<TResult>,
-  ): void {
-    registerGuiMutationIpcHandler(guiMutationRegistrationContext, channel, handler);
-  }
-
-  function registerWorkflowScopedGuiMutationHandler<TResult = unknown>(
-    channel: string,
-    resolveWorkflowId: (...args: unknown[]) => string | undefined,
-    priority: WorkflowMutationPriority,
-    handler: (...args: unknown[]) => Promise<TResult>,
-  ): void {
-    registerWorkflowScopedGuiMutationIpcHandler(
-      workflowScopedGuiMutationRegistrationContext,
-      channel,
-      resolveWorkflowId,
-      priority,
-      handler,
-    );
-  }
+  const {
+    registerGuiMutationHandler,
+    registerWorkflowScopedGuiMutationHandler,
+  } = createGuiMutationRegistrars(
+    guiMutationRegistrationContext,
+    workflowScopedGuiMutationRegistrationContext,
+  );
 
   function createWindow(): void {
     createMainWindow({


### PR DESCRIPTION
## Summary

`main.ts` now delegates headless and GUI startup selection to a focused bootstrap helper.

GUI mutation IPC registration now uses typed registrar factories instead of inline wrapper functions in the composition root.

The extracted seams preserve existing startup ordering, IPC channel behavior, and follower-to-owner delegation contracts.

## Architecture

### Before

```mermaid
graph TD
    MAIN["main.ts composition root"]
    HEADLESS["Inline headless branch"]
    GUI["Inline GUI bootstrap branch"]
    SETUP["setupGuiMode"]
    WRAPPERS["Inline mutation registrar wrappers"]
    IPC["registerGuiMutationHandler / registerWorkflowScopedGuiMutationHandler"]

    MAIN --> HEADLESS
    MAIN --> GUI
    GUI --> SETUP
    SETUP --> WRAPPERS
    WRAPPERS --> IPC
```

### After

```mermaid
graph TD
    MAIN["main.ts composition root"]
    BOOT["startMainProcessBootstrap"]
    HEADLESS["startHeadlessMode callback"]
    GUI["startGuiModeBootstrap callback"]
    SETUP["setupGuiMode"]
    FACTORY["createGuiMutationRegistrars"]
    IPC["registerGuiMutationHandler / registerWorkflowScopedGuiMutationHandler"]

    MAIN --> BOOT
    BOOT --> HEADLESS
    BOOT --> GUI
    GUI --> SETUP
    SETUP --> FACTORY
    FACTORY --> IPC
```

## Test Plan

- [x] `cd packages/app && pnpm test -- src/__tests__/bridge-orchestrator-executor.test.ts`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None
- Data migration? No