### PR TITLE
Fix intent cancellation Step 5: repro and regression verification (regression gated v2)

### DIFF
--- a/packages/contracts/src/types.ts
+++ b/packages/contracts/src/types.ts
@@ -57,6 +57,12 @@ export interface WorkRequestInputs {
   /** When true, executors must not reuse existing task worktrees for this run. */
   freshWorkspace?: boolean;
   /**
+   * Terminal verification commands may complete successfully even if publishing
+   * their empty audit commit fails. Do not set this when downstream tasks need
+   * the executor branch.
+   */
+  allowUnpublishedEmptyResult?: boolean;
+  /**
    * Persisted worktree metadata for the same task/action, loaded by the
    * orchestrator from storage. Executors may validate this against git before
    * reusing it, but should not infer action identity from branch name patterns.

--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -2161,6 +2161,49 @@ describe('BaseExecutor.handleProcessExit push semantics', () => {
     expect(response?.outputs.error).toBe('push denied');
   });
 
+  it('keeps terminal command successful when only its empty audit commit push fails', async () => {
+    execSync('git checkout -b invoker/verify', { cwd: cloneDir });
+
+    const req = makeRequest('verify-task', {
+      command: 'pnpm run test:all',
+      allowUnpublishedEmptyResult: true,
+    });
+    const entry = executor.registerTestEntry('e-verify', req);
+    let response: WorkResponse | undefined;
+    entry.completeListeners.add((r) => { response = r; });
+
+    vi.spyOn(BaseExecutor.prototype as any, 'pushBranchToRemote').mockResolvedValue('push denied');
+
+    await executor.testHandleProcessExit('e-verify', req, cloneDir, 0, { branch: 'invoker/verify' });
+
+    expect(response?.status).toBe('completed');
+    expect(response?.outputs.exitCode).toBe(0);
+    expect(response?.outputs.error).toBeUndefined();
+    expect(response?.outputs.commitHash).toBeDefined();
+    expect(entry.outputBuffer.join('')).toContain('preserving command success');
+  });
+
+  it('still fails terminal command publish errors when the command produced file changes', async () => {
+    execSync('git checkout -b invoker/verify-changes', { cwd: cloneDir });
+    writeFileSync(join(cloneDir, 'generated.txt'), 'changed\n');
+
+    const req = makeRequest('verify-changes-task', {
+      command: 'node scripts/generate.js',
+      allowUnpublishedEmptyResult: true,
+    });
+    const entry = executor.registerTestEntry('e-verify-changes', req);
+    let response: WorkResponse | undefined;
+    entry.completeListeners.add((r) => { response = r; });
+
+    vi.spyOn(BaseExecutor.prototype as any, 'pushBranchToRemote').mockResolvedValue('push denied');
+
+    await executor.testHandleProcessExit('e-verify-changes', req, cloneDir, 0, { branch: 'invoker/verify-changes' });
+
+    expect(response?.status).toBe('failed');
+    expect(response?.outputs.exitCode).toBe(1);
+    expect(response?.outputs.error).toBe('push denied');
+  });
+
   it('marks codex ai_task as failed when semantic sandbox denial appears in output despite exit 0', async () => {
     execSync('git checkout -b invoker/semantic-fail', { cwd: cloneDir });
 

--- a/packages/execution-engine/src/__tests__/ssh-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-executor.test.ts
@@ -1028,6 +1028,36 @@ describe('SshExecutor entry lifecycle', () => {
     expect(completed).toBe(true);
   });
 
+  it('keeps terminal command successful when empty remote result push fails', async () => {
+    const request = makeRequest({
+      inputs: {
+        command: 'pnpm run test:all',
+        repoUrl: 'git@github.com:test/repo.git',
+        allowUnpublishedEmptyResult: true,
+      },
+    });
+    vi.spyOn(ssh as any, 'remoteGitRecordAndPush').mockResolvedValue({
+      commitHash: 'abcdef1234567890abcdef1234567890abcdef12',
+      emptyResultCommit: true,
+      error: 'remote commit or push failed (code 128): fatal: unable to access remote',
+    });
+
+    const handle = await ssh.start(request);
+    const responsePromise = new Promise<WorkResponse>((resolve) => {
+      ssh.onComplete(handle, resolve);
+    });
+
+    const sshProcess = spawnedProcesses[spawnedProcesses.length - 1];
+    sshProcess.emit('close', 0, null);
+
+    const response = await responsePromise;
+
+    expect(response.status).toBe('completed');
+    expect(response.outputs.exitCode).toBe(0);
+    expect(response.outputs.error).toBeUndefined();
+    expect(response.outputs.commitHash).toBe('abcdef1234567890abcdef1234567890abcdef12');
+  });
+
   it('filters remote heartbeat markers from output and emits heartbeat events', async () => {
     const request = makeRequest({
       inputs: {

--- a/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
+++ b/packages/execution-engine/src/__tests__/ssh-git-exec.test.ts
@@ -467,6 +467,9 @@ describe('buildRecordAndPushScript', () => {
     expect(script).toContain('git commit --allow-empty -F');
     expect(script).toContain('git commit -F');
     expect(script).toContain('HASH=$(git rev-parse HEAD)');
+    expect(script).toContain('__INVOKER_RECORD_KIND__');
+    expect(script).toContain('__INVOKER_COMMIT_HASH__');
+    expect(script).toContain('__INVOKER_PUSH_FAILED__');
     expect(script).toContain('git push origin "$BR:refs/heads/$BR"');
     expect(script).toContain('printf "%s" "$HASH"');
   });
@@ -580,6 +583,21 @@ describe('parseRecordAndPushOutput', () => {
   it('uses stderr when stdout is empty on failure', () => {
     const result = parseRecordAndPushOutput('', 1, 'fatal: unable to access remote');
     expect(result.error).toContain('unable to access remote');
+  });
+
+  it('recovers empty commit metadata when push fails after commit', () => {
+    const stdout = [
+      '[branch abc123] invoker: verify',
+      '__INVOKER_RECORD_KIND__=empty',
+      '__INVOKER_COMMIT_HASH__=abcdef1234567890abcdef1234567890abcdef12',
+      '__INVOKER_PUSH_FAILED__=128',
+      '',
+    ].join('\n');
+    const result = parseRecordAndPushOutput(stdout, 128, 'fatal: unable to access remote');
+
+    expect(result.error).toContain('remote commit or push failed');
+    expect(result.commitHash).toBe('abcdef1234567890abcdef1234567890abcdef12');
+    expect(result.emptyResultCommit).toBe(true);
   });
 });
 

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -2089,7 +2089,7 @@ describe('TaskRunner', () => {
         type: 'worktree',
         start: async (req: any) => {
           capturedRequest = req;
-          return { executionId: 'exec-branch-repo', taskId: 'task-branch-repo' };
+          return { executionId: 'exec-branch-repo', taskId: 'task-branch-repo', workspacePath: '/tmp/wt', branch: 'experiment/task-branch-repo' };
         },
         onOutput: () => () => {},
         onComplete: (_handle: any, cb: any) => {
@@ -2128,6 +2128,104 @@ describe('TaskRunner', () => {
       expect(capturedRequest).toBeDefined();
       expect(capturedRequest.inputs.branchRepoUrl).toBe('git@example.com:owner/branches.git');
       expect(capturedRequest.inputs.intermediateRepoUrl).toBeUndefined();
+    });
+
+    it('allows unpublished empty results only for terminal command leaves', async () => {
+      let capturedRequest: any;
+      const capturingExecutor = {
+        type: 'worktree',
+        start: async (req: any) => {
+          capturedRequest = req;
+          return { executionId: 'exec-terminal', taskId: 'terminal-command', workspacePath: '/tmp/wt', branch: 'experiment/terminal-command' };
+        },
+        onOutput: () => () => {},
+        onComplete: (_handle: any, cb: any) => {
+          cb({ requestId: 'r', actionId: 'terminal-command', status: 'completed', outputs: { exitCode: 0 } });
+          return () => {};
+        },
+        onHeartbeat: () => () => {},
+      };
+      const terminalTask = makeTask({
+        id: 'terminal-command',
+        status: 'running',
+        config: { command: 'pnpm run test:all', workflowId: 'wf-terminal' },
+      });
+      const registry = {
+        getDefault: () => capturingExecutor,
+        get: () => capturingExecutor,
+        getAll: () => [capturingExecutor],
+      };
+      const persistence = {
+        updateTask: vi.fn(),
+        loadWorkflow: () => ({ generation: 0 }),
+      };
+      const orchestrator = {
+        getTask: (id: string) => id === terminalTask.id ? terminalTask : undefined,
+        getAllTasks: () => [terminalTask],
+        handleWorkerResponse: vi.fn(),
+      };
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: registry as any,
+        cwd: '/tmp',
+      });
+
+      await executor.executeTask(terminalTask);
+
+      expect(capturedRequest.inputs.allowUnpublishedEmptyResult).toBe(true);
+    });
+
+    it('does not allow unpublished empty results for commands with downstream dependents', async () => {
+      let capturedRequest: any;
+      const capturingExecutor = {
+        type: 'worktree',
+        start: async (req: any) => {
+          capturedRequest = req;
+          return { executionId: 'exec-upstream', taskId: 'upstream-command', workspacePath: '/tmp/wt', branch: 'experiment/upstream-command' };
+        },
+        onOutput: () => () => {},
+        onComplete: (_handle: any, cb: any) => {
+          cb({ requestId: 'r', actionId: 'upstream-command', status: 'completed', outputs: { exitCode: 0 } });
+          return () => {};
+        },
+        onHeartbeat: () => () => {},
+      };
+      const upstreamTask = makeTask({
+        id: 'upstream-command',
+        status: 'running',
+        config: { command: 'pnpm run generate', workflowId: 'wf-terminal' },
+      });
+      const downstreamTask = makeTask({
+        id: 'downstream-command',
+        status: 'pending',
+        dependencies: ['upstream-command'],
+        config: { command: 'pnpm run test', workflowId: 'wf-terminal' },
+      });
+      const registry = {
+        getDefault: () => capturingExecutor,
+        get: () => capturingExecutor,
+        getAll: () => [capturingExecutor],
+      };
+      const persistence = {
+        updateTask: vi.fn(),
+        loadWorkflow: () => ({ generation: 0 }),
+      };
+      const orchestrator = {
+        getTask: (id: string) => id === upstreamTask.id ? upstreamTask : downstreamTask,
+        getAllTasks: () => [upstreamTask, downstreamTask],
+        handleWorkerResponse: vi.fn(),
+      };
+      const executor = new TaskRunner({
+        orchestrator: orchestrator as any,
+        persistence: persistence as any,
+        executorRegistry: registry as any,
+        cwd: '/tmp',
+      });
+
+      await executor.executeTask(upstreamTask);
+
+      expect(capturedRequest.inputs.allowUnpublishedEmptyResult).toBeUndefined();
     });
 
     it('encodes workflow generation, task generation, and attemptId in request lifecycleTag', async () => {

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -1768,8 +1768,8 @@ describe('WorktreeExecutor', () => {
 
     it('keeps heartbeats alive while close finalization is pending', async () => {
       (executor as any).heartbeatIntervalMs = 20;
-      const finalizeDeferred = createDeferred<string | null>();
-      vi.spyOn(executor as any, 'recordTaskResult').mockImplementation(() => finalizeDeferred.promise);
+      const finalizeDeferred = createDeferred<{ commitHash: string | null; emptyResultCommit: boolean }>();
+      vi.spyOn(executor as any, 'recordTaskResultWithMetadata').mockImplementation(() => finalizeDeferred.promise);
 
       const { taskProcess } = setupSpawnMock();
       const request = makeRequest();
@@ -1791,7 +1791,7 @@ describe('WorktreeExecutor', () => {
       expect(completed).toBe(false);
       expect(heartbeatCount).toBeGreaterThan(0);
 
-      finalizeDeferred.resolve('abc123');
+      finalizeDeferred.resolve({ commitHash: 'abc123', emptyResultCommit: false });
       await waitForCondition(() => completed);
     });
 

--- a/packages/execution-engine/src/base-executor.ts
+++ b/packages/execution-engine/src/base-executor.ts
@@ -46,6 +46,11 @@ interface HeartbeatOptions {
   emitIntervalHeartbeat?: boolean;
 }
 
+export interface TaskResultRecord {
+  commitHash: string | null;
+  emptyResultCommit: boolean;
+}
+
 export interface ClaudeSessionParams {
   sessionId: string;
   cliArgs: string[];
@@ -690,16 +695,41 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     request: WorkRequest,
     exitCode: number,
   ): Promise<string | null> {
+    const result = await this.recordTaskResultWithMetadata(cwd, request, exitCode);
+    return result.commitHash;
+  }
+
+  protected async recordTaskResultWithMetadata(
+    cwd: string,
+    request: WorkRequest,
+    exitCode: number,
+  ): Promise<TaskResultRecord> {
     try {
       const hash = await this.autoCommit(cwd, request);
-      if (hash) return hash;
+      if (hash) return { commitHash: hash, emptyResultCommit: false };
 
       const message = this.buildResultCommitMessage(request, exitCode);
       await this.execGitSimple(['commit', '--allow-empty', '-m', message], cwd);
-      return (await this.execGitSimple(['rev-parse', 'HEAD'], cwd)).trim();
+      return {
+        commitHash: (await this.execGitSimple(['rev-parse', 'HEAD'], cwd)).trim(),
+        emptyResultCommit: true,
+      };
     } catch {
-      return null;
+      return { commitHash: null, emptyResultCommit: false };
     }
+  }
+
+  protected isPublishFailureNonBlocking(
+    request: WorkRequest,
+    exitCode: number,
+    result: TaskResultRecord,
+    publishError: string | undefined,
+  ): boolean {
+    return publishError !== undefined
+      && exitCode === 0
+      && request.actionType === 'command'
+      && request.inputs.allowUnpublishedEmptyResult === true
+      && result.emptyResultCommit;
   }
 
   /**
@@ -949,10 +979,11 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     }
 
     let commitHash: string | undefined;
+    let resultRecord: TaskResultRecord = { commitHash: null, emptyResultCommit: false };
     let status: 'completed' | 'failed' = effectiveExitCode === 0 ? 'completed' : 'failed';
     try {
-      const hash = await this.recordTaskResult(cwd, request, effectiveExitCode);
-      commitHash = hash ?? undefined;
+      resultRecord = await this.recordTaskResultWithMetadata(cwd, request, effectiveExitCode);
+      commitHash = resultRecord.commitHash ?? undefined;
     } catch (err) {
       this.emitOutput(executionId,
         `[${this.type}] recordTaskResult error: ${err}\n`);
@@ -963,7 +994,19 @@ export abstract class BaseExecutor<TEntry extends BaseEntry> implements Executor
     if (opts?.branch) {
       pushError = await this.pushBranchToRemote(cwd, opts.branch, executionId);
     }
-    if (effectiveExitCode === 0 && pushError !== undefined && opts?.branch) {
+    const nonBlockingPublishFailure = this.isPublishFailureNonBlocking(
+      request,
+      effectiveExitCode,
+      resultRecord,
+      pushError,
+    );
+    if (nonBlockingPublishFailure) {
+      this.emitOutput(
+        executionId,
+        `[${this.type}] Branch publish failed for terminal empty command result; preserving command success.\n`,
+      );
+    }
+    if (effectiveExitCode === 0 && pushError !== undefined && opts?.branch && !nonBlockingPublishFailure) {
       status = 'failed';
     }
 

--- a/packages/execution-engine/src/ssh-executor.ts
+++ b/packages/execution-engine/src/ssh-executor.ts
@@ -1048,8 +1048,24 @@ ${runProvisionSection}stop_bootstrap_heartbeat
             if (fin.commitHash) commitHash = fin.commitHash;
             if (fin.error) {
               this.emitOutput(executionId, `[SshExecutor] ${fin.error}\n`);
-              if (exitCode === 0) status = 'failed';
-              mappedError = fin.error;
+              const nonBlockingPublishFailure = this.isPublishFailureNonBlocking(
+                request,
+                exitCode,
+                {
+                  commitHash: fin.commitHash ?? null,
+                  emptyResultCommit: fin.emptyResultCommit === true,
+                },
+                fin.error,
+              );
+              if (nonBlockingPublishFailure) {
+                this.emitOutput(
+                  executionId,
+                  '[SshExecutor] Branch publish failed for terminal empty command result; preserving command success.\n',
+                );
+              } else {
+                if (exitCode === 0) status = 'failed';
+                mappedError = fin.error;
+              }
             }
             console.info(
               `[ssh-lifecycle] remote finalize end task=${request.actionId} executionId=${executionId} ` +

--- a/packages/execution-engine/src/ssh-git-exec.ts
+++ b/packages/execution-engine/src/ssh-git-exec.ts
@@ -370,19 +370,31 @@ trap 'rm -f "$M"' EXIT
 GIT_NAME=$(echo ${userNameB} | base64 -d)
 GIT_EMAIL=$(echo ${userEmailB} | base64 -d)
 if git diff --cached --quiet; then
+  RESULT_KIND=empty
   echo ${emB} | base64 -d > "$M"
   GIT_AUTHOR_NAME="$GIT_NAME" GIT_AUTHOR_EMAIL="$GIT_EMAIL" GIT_COMMITTER_NAME="$GIT_NAME" GIT_COMMITTER_EMAIL="$GIT_EMAIL" git commit --allow-empty -F "$M"
 else
+  RESULT_KIND=changes
   echo ${chB} | base64 -d > "$M"
   GIT_AUTHOR_NAME="$GIT_NAME" GIT_AUTHOR_EMAIL="$GIT_EMAIL" GIT_COMMITTER_NAME="$GIT_NAME" GIT_COMMITTER_EMAIL="$GIT_EMAIL" git commit -F "$M"
 fi
 HASH=$(git rev-parse HEAD)
+printf "__INVOKER_RECORD_KIND__=%s\\n" "$RESULT_KIND"
+printf "__INVOKER_COMMIT_HASH__=%s\\n" "$HASH"
 BR=$(echo ${brB} | base64 -d)
 PUSH_URL=$(echo ${pushRemoteUrlB} | base64 -d)
 if [ -n "$PUSH_URL" ]; then
-  git push "$PUSH_URL" "$BR:refs/heads/$BR"
+  git push "$PUSH_URL" "$BR:refs/heads/$BR" || {
+    code=$?
+    printf "__INVOKER_PUSH_FAILED__=%s\\n" "$code"
+    exit "$code"
+  }
 else
-  git push origin "$BR:refs/heads/$BR"
+  git push origin "$BR:refs/heads/$BR" || {
+    code=$?
+    printf "__INVOKER_PUSH_FAILED__=%s\\n" "$code"
+    exit "$code"
+  }
 fi
 printf "%s" "$HASH"
 `;
@@ -391,6 +403,7 @@ printf "%s" "$HASH"
 export interface GitRecordAndPushResult {
   commitHash?: string;
   error?: string;
+  emptyResultCommit?: boolean;
 }
 
 /**
@@ -402,18 +415,37 @@ export function parseRecordAndPushOutput(
   exitCode: number,
   stderr: string,
 ): GitRecordAndPushResult {
+  const lines = stdout.split('\n').map((l) => l.trim()).filter(Boolean);
+  const markerHash = [...lines]
+    .reverse()
+    .find((line) => line.startsWith('__INVOKER_COMMIT_HASH__='))
+    ?.slice('__INVOKER_COMMIT_HASH__='.length);
+  const markerKind = [...lines]
+    .reverse()
+    .find((line) => line.startsWith('__INVOKER_RECORD_KIND__='))
+    ?.slice('__INVOKER_RECORD_KIND__='.length);
+  const validMarkerHash = typeof markerHash === 'string' && /^[0-9a-f]{7,40}$/i.test(markerHash)
+    ? markerHash
+    : undefined;
+
   if (exitCode !== 0) {
-    return { error: `remote commit or push failed (code ${exitCode}): ${stderr.trim() || stdout.trim()}` };
+    return {
+      ...(validMarkerHash ? { commitHash: validMarkerHash } : {}),
+      ...(markerKind === 'empty' ? { emptyResultCommit: true } : {}),
+      error: `remote commit or push failed (code ${exitCode}): ${stderr.trim() || stdout.trim()}`,
+    };
   }
 
-  const lines = stdout.split('\n').map((l) => l.trim()).filter(Boolean);
-  const hash = lines[lines.length - 1] ?? '';
+  const hash = validMarkerHash ?? lines[lines.length - 1] ?? '';
 
   if (!/^[0-9a-f]{7,40}$/i.test(hash)) {
     return { error: `remote commit: unexpected output (last line: ${hash.slice(0, 80)})` };
   }
 
-  return { commitHash: hash };
+  return {
+    commitHash: hash,
+    ...(markerKind === 'empty' ? { emptyResultCommit: true } : {}),
+  };
 }
 
 /**

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -836,6 +836,9 @@ export class TaskRunner {
         baseBranch,
         baseCommit,
         freshWorkspace: this.shouldUseFreshWorkspace(task),
+        allowUnpublishedEmptyResult: actionType === 'command' && this.isTerminalCommandLeaf(task)
+          ? true
+          : undefined,
         reusableWorktree: task.execution.branch && task.execution.workspacePath
           ? {
             branch: task.execution.branch,
@@ -1223,6 +1226,17 @@ export class TaskRunner {
     return (task.execution.generation ?? 0) > 0
       && task.execution.branch === undefined
       && task.execution.workspacePath === undefined;
+  }
+
+  private isTerminalCommandLeaf(task: TaskState): boolean {
+    const getAllTasks = this.orchestrator.getAllTasks;
+    if (typeof getAllTasks !== 'function') return false;
+    const workflowId = task.config.workflowId;
+    return !getAllTasks.call(this.orchestrator).some((candidate: TaskState) => {
+      if (candidate.id === task.id) return false;
+      if (workflowId && candidate.config.workflowId !== workflowId) return false;
+      return candidate.dependencies.includes(task.id);
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary

Adds a terminal command verification escape hatch for successful leaf commands that only produced an empty audit commit.

This keeps a passed final gate from being reported failed when branch publication fails after the command already exited 0.

Remote SSH result publishing now emits structured commit-kind and commit-hash markers before pushing, so failed pushes can still be classified.

The branch also reruns the shared cancellation/stale-SSH repro, focused coordinator coverage, focused SSH metadata coverage, and `test:all` gate.

## Architecture

### Before

```mermaid
graph TD
    T[TaskRunner command task] --> R[WorkRequest]
    R --> E[Executor runs command]
    E --> C[Record result commit]
    C --> P[Push branch]
    P -->|push fails after empty commit| F[Report task failed]
```

### After

```mermaid
graph TD
    T[TaskRunner command task] --> L{Leaf command?}
    L -->|yes| R[WorkRequest allowUnpublishedEmptyResult]
    L -->|no| S[Normal WorkRequest]
    R --> E[Executor runs command]
    S --> E
    E --> C[Record result kind and hash]
    C --> P[Push branch]
    P -->|empty commit push fails and command exited 0| OK[Preserve completed result]
    P -->|changed result or upstream task push fails| F[Report publish failure]
```

## Test Plan

- [x] `bash scripts/repro/repro-fix-intent-cancellation-and-stale-ssh-metadata.sh --expect fixed`
- [x] `cd packages/app && pnpm exec vitest run src/__tests__/persisted-workflow-mutation-coordinator.test.ts`
- [x] `cd packages/execution-engine && pnpm test -- src/__tests__/ssh-worktree-metadata-repro.test.ts`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes, if dependent stack branches are also updated not to rely on terminal empty-result publish tolerance.
- Revert command: `git revert -m 1 6fff4a0f` from this stack branch, or revert the eventual PR merge commit.
- Post-revert steps: Re-run the shared repro, focused regressions, and `pnpm run test:all`.
- Data migration? No