### PR TITLE
Camera lock Step 2: viewport ownership

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -36,6 +36,16 @@ import {
   EXPERIMENT_SPAWN_PIVOT_OPEN_TERMINAL_MESSAGE,
 } from './isExperimentSpawnPivot.js';
 import { parsePlanText } from './lib/plan-parser.js';
+import {
+  createGraphCameraCommandIssuer,
+  loadCameraLockPreference,
+  saveCameraLockPreference,
+  type CameraLockPreference,
+  type GraphCameraCommand,
+  type GraphCameraCommandInput,
+  type GraphCameraCommandIssuer,
+  type GraphScope,
+} from './lib/graph-camera.js';
 import type { SystemDiagnostics } from '@invoker/contracts';
 
 type ModalState =
@@ -294,8 +304,26 @@ export function App() {
   const [workflowContextMenu, setWorkflowContextMenu] = useState<{ x: number; y: number; workflowId: string } | null>(null);
   const [keyboardRegion, setKeyboardRegion] = useState<KeyboardRegion>('workflowGraph');
   const [previousGraphRegion, setPreviousGraphRegion] = useState<KeyboardRegion>('workflowGraph');
-  const [centerWorkflowId, setCenterWorkflowId] = useState<string | null>(null);
-  const [centerTaskId, setCenterTaskId] = useState<string | null>(null);
+  // Typed graph camera state. The graph viewport is user-owned after the
+  // initial render: only explicit navigation commands (issued through the
+  // central factory) move it. No per-handler event++/requestId++ counters.
+  const cameraIssuerRef = useRef<GraphCameraCommandIssuer | null>(null);
+  if (!cameraIssuerRef.current) {
+    cameraIssuerRef.current = createGraphCameraCommandIssuer();
+  }
+  const [cameraCommand, setCameraCommand] = useState<GraphCameraCommand | null>(null);
+  const [cameraPreference, setCameraPreference] = useState<CameraLockPreference>(() =>
+    loadCameraLockPreference(),
+  );
+  // Mirror preference into a ref so event handlers read the live value without
+  // being re-created on every preference change.
+  const cameraPreferenceRef = useRef(cameraPreference);
+  useEffect(() => {
+    cameraPreferenceRef.current = cameraPreference;
+  }, [cameraPreference]);
+  // Temporary, non-persisted suppression of the camera lock after a manual pan
+  // or wheel zoom. The next explicit node selection clears it.
+  const cameraSuppressedRef = useRef(false);
   const [bottomStatusIndex, setBottomStatusIndex] = useState(0);
   const [searchOpen, setSearchOpen] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
@@ -598,15 +626,38 @@ export function App() {
     return { x: Math.max(24, window.innerWidth / 2), y: Math.max(24, window.innerHeight / 2) };
   }, []);
 
+  // The only path that mints camera commands. The issuer owns the monotonic
+  // sequence, so no selection handler keeps its own counter.
+  const issueCameraCommand = useCallback((input: GraphCameraCommandInput): GraphCameraCommand => {
+    const command = cameraIssuerRef.current!.issue(input);
+    setCameraCommand(command);
+    return command;
+  }, []);
+
+  // An explicit node selection (mouse click or arrow key) clears any temporary
+  // manual suppression and re-centers the targeted graph when the lock is on.
+  const recenterForSelection = useCallback((scope: GraphScope, target: string) => {
+    cameraSuppressedRef.current = false;
+    if (cameraPreferenceRef.current.enabled) {
+      issueCameraCommand({ kind: 'centerSelection', scope, target, reason: 'selection' });
+    }
+  }, [issueCameraCommand]);
+
+  // A manual pan or wheel zoom temporarily suppresses the lock and must not
+  // autofocus the graph — no camera command is issued here.
+  const handleManualViewport = useCallback(() => {
+    cameraSuppressedRef.current = true;
+  }, []);
+
   const selectWorkflowById = useCallback((workflowId: string) => {
     setWorkflowSelectionDismissed(false);
     setSelectedWorkflowId(workflowId);
     setSelectedTaskId(null);
     setContextMenu(null);
     setWorkflowContextMenu(null);
-    setCenterWorkflowId(workflowId);
+    recenterForSelection('workflow', workflowId);
     focusKeyboardRegion('workflowGraph');
-  }, [focusKeyboardRegion]);
+  }, [focusKeyboardRegion, recenterForSelection]);
 
   const selectTaskById = useCallback((taskId: string) => {
     const task = tasks.get(taskId);
@@ -615,13 +666,12 @@ export function App() {
     setWorkflowSelectionDismissed(false);
     if (task.config.workflowId) {
       setSelectedWorkflowId(task.config.workflowId);
-      setCenterWorkflowId(task.config.workflowId);
     }
     setContextMenu(null);
     setWorkflowContextMenu(null);
-    setCenterTaskId(task.id);
+    recenterForSelection('task', task.id);
     focusKeyboardRegion('taskGraph');
-  }, [focusKeyboardRegion, tasks]);
+  }, [focusKeyboardRegion, recenterForSelection, tasks]);
 
   const selectRelativeNode = useCallback((direction: 'ArrowUp' | 'ArrowDown' | 'ArrowLeft' | 'ArrowRight') => {
     const inTaskGraph = keyboardRegion === 'taskGraph';
@@ -738,6 +788,32 @@ export function App() {
 
       if (isEditableKeyboardTarget(event.target) || modal.type !== 'none') return;
 
+      // F1 is the keyboard-only camera lock control. It is already ignored for
+      // input/modal/terminal/editable targets by the guard above.
+      if (event.key === 'F1') {
+        event.preventDefault();
+        const inTaskGraph = keyboardRegion === 'taskGraph';
+        const scope: GraphScope = inTaskGraph ? 'task' : 'workflow';
+        const target = inTaskGraph ? selectedTaskId : (selectedWorkflow?.id ?? selectedWorkflowId);
+        const preference = cameraPreferenceRef.current;
+        cameraSuppressedRef.current = false;
+        if (preference.mode === 'toggle') {
+          // Toggle mode flips the lock; enabling it immediately centers the
+          // current selection.
+          const nextEnabled = !preference.enabled;
+          const nextPreference: CameraLockPreference = { mode: preference.mode, enabled: nextEnabled };
+          setCameraPreference(nextPreference);
+          saveCameraLockPreference(nextPreference);
+          if (nextEnabled && target) {
+            issueCameraCommand({ kind: 'centerSelection', scope, target, reason: 'f1-toggle-enable' });
+          }
+        } else if (target) {
+          // Once mode centers a single time without changing the preference.
+          issueCameraCommand({ kind: 'centerSelection', scope, target, reason: 'f1-once' });
+        }
+        return;
+      }
+
       if (event.key === 'Tab') {
         event.preventDefault();
         const currentIndex = KEYBOARD_REGION_ORDER.indexOf(keyboardRegion);
@@ -844,6 +920,7 @@ export function App() {
     bottomStatusIndex,
     focusKeyboardRegion,
     handleStatusClick,
+    issueCameraCommand,
     keyboardRegion,
     miniDagTasks,
     modal.type,
@@ -854,6 +931,7 @@ export function App() {
     searchResults,
     selectRelativeNode,
     selectTaskById,
+    selectedTaskId,
     selectedWorkflow,
     selectedWorkflowId,
     visibleStatusKeys,
@@ -870,7 +948,8 @@ export function App() {
       setSelectedWorkflowId(task.config.workflowId);
     }
     setWorkflowContextMenu(null);
-  }, []);
+    recenterForSelection('task', task.id);
+  }, [recenterForSelection]);
 
   const openTerminalForTaskId = useCallback(async (taskId: string) => {
     const task = tasks.get(taskId);
@@ -921,7 +1000,8 @@ export function App() {
     setSelectedTaskId(null);
     setContextMenu(null);
     setWorkflowContextMenu(null);
-  }, []);
+    recenterForSelection('workflow', workflowId);
+  }, [recenterForSelection]);
 
   const handleWorkflowContextMenu = useCallback((event: React.MouseEvent<HTMLDivElement>, workflowId: string) => {
     event.preventDefault();
@@ -1620,10 +1700,11 @@ export function App() {
                     tasks={tasks}
                     workflows={workflows}
                     selectedWorkflowId={selectedWorkflow?.id ?? null}
-                    centerWorkflowId={centerWorkflowId}
+                    cameraCommand={cameraCommand}
                     statusFilters={statusFilters}
                     onSelectWorkflow={handleWorkflowClick}
                     onWorkflowContextMenu={handleWorkflowContextMenu}
+                    onManualViewport={handleManualViewport}
                   />
                   {selectedWorkflow && miniDagTasks.size > 0 && (
                     <FloatingGraphPanel
@@ -1644,10 +1725,11 @@ export function App() {
                           tasks={miniDagTasks}
                           workflows={selectedTaskDagWorkflows}
                           selectedTaskId={selectedTaskId}
-                          centerTaskId={centerTaskId}
+                          cameraCommand={cameraCommand}
                           onTaskClick={handleTaskClick}
                           onTaskDoubleClick={handleTaskDoubleClick}
                           onTaskContextMenu={handleTaskContextMenu}
+                          onManualViewport={handleManualViewport}
                           statusFilters={new Set()}
                         />
                       </div>

--- a/packages/ui/src/__tests__/graph-camera.test.ts
+++ b/packages/ui/src/__tests__/graph-camera.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  CAMERA_LOCK_PREFERENCE_STORAGE_KEY,
+  DEFAULT_CAMERA_LOCK_PREFERENCE,
+  createGraphCameraCommandIssuer,
+  isCameraMode,
+  isGraphScope,
+  loadCameraLockPreference,
+  saveCameraLockPreference,
+  type CameraLockPreference,
+  type PreferenceStorage,
+} from '../lib/graph-camera.js';
+
+/** In-memory storage double matching the {@link PreferenceStorage} surface. */
+function createMemoryStorage(seed?: Record<string, string>): PreferenceStorage & {
+  raw: Map<string, string>;
+} {
+  const raw = new Map<string, string>(Object.entries(seed ?? {}));
+  return {
+    raw,
+    getItem: (key) => (raw.has(key) ? (raw.get(key) as string) : null),
+    setItem: (key, value) => {
+      raw.set(key, value);
+    },
+  };
+}
+
+describe('graph-camera defaults', () => {
+  it('defaults to toggle mode with the lock enabled', () => {
+    expect(DEFAULT_CAMERA_LOCK_PREFERENCE.mode).toBe('toggle');
+    expect(DEFAULT_CAMERA_LOCK_PREFERENCE.enabled).toBe(true);
+  });
+
+  it('freezes the default so callers cannot mutate the shared constant', () => {
+    expect(Object.isFrozen(DEFAULT_CAMERA_LOCK_PREFERENCE)).toBe(true);
+  });
+
+  it('returns the default for empty storage', () => {
+    const storage = createMemoryStorage();
+    expect(loadCameraLockPreference(storage)).toEqual({ mode: 'toggle', enabled: true });
+  });
+
+  it('returns a fresh copy, not the shared frozen default', () => {
+    const loaded = loadCameraLockPreference(createMemoryStorage());
+    expect(loaded).not.toBe(DEFAULT_CAMERA_LOCK_PREFERENCE);
+    expect(Object.isFrozen(loaded)).toBe(false);
+  });
+});
+
+describe('graph-camera type guards', () => {
+  it('recognizes valid camera modes and scopes', () => {
+    expect(isCameraMode('toggle')).toBe(true);
+    expect(isCameraMode('once')).toBe(true);
+    expect(isGraphScope('workflow')).toBe(true);
+    expect(isGraphScope('task')).toBe(true);
+  });
+
+  it('rejects invalid camera modes and scopes', () => {
+    expect(isCameraMode('always')).toBe(false);
+    expect(isCameraMode(undefined)).toBe(false);
+    expect(isCameraMode(2)).toBe(false);
+    expect(isGraphScope('graph')).toBe(false);
+    expect(isGraphScope(null)).toBe(false);
+  });
+});
+
+describe('graph-camera persistence', () => {
+  it('loads a valid persisted preference', () => {
+    const stored: CameraLockPreference = { mode: 'once', enabled: false };
+    const storage = createMemoryStorage({
+      [CAMERA_LOCK_PREFERENCE_STORAGE_KEY]: JSON.stringify(stored),
+    });
+    expect(loadCameraLockPreference(storage)).toEqual(stored);
+  });
+
+  it('round-trips through save and load', () => {
+    const storage = createMemoryStorage();
+    const preference: CameraLockPreference = { mode: 'once', enabled: false };
+
+    expect(saveCameraLockPreference(preference, storage)).toBe(true);
+    expect(storage.raw.has(CAMERA_LOCK_PREFERENCE_STORAGE_KEY)).toBe(true);
+    expect(loadCameraLockPreference(storage)).toEqual(preference);
+  });
+
+  it.each([
+    ['not json at all', 'this is not json{'],
+    ['a json primitive', '42'],
+    ['a json null', 'null'],
+    ['a json array', '[]'],
+    ['an unknown mode', JSON.stringify({ mode: 'always', enabled: true })],
+    ['a non-boolean enabled', JSON.stringify({ mode: 'toggle', enabled: 'yes' })],
+    ['a missing mode', JSON.stringify({ enabled: true })],
+    ['a missing enabled', JSON.stringify({ mode: 'toggle' })],
+  ])('falls back to defaults for malformed storage: %s', (_label, rawValue) => {
+    const storage = createMemoryStorage({
+      [CAMERA_LOCK_PREFERENCE_STORAGE_KEY]: rawValue,
+    });
+    expect(loadCameraLockPreference(storage)).toEqual(DEFAULT_CAMERA_LOCK_PREFERENCE);
+  });
+
+  it('falls back to defaults when storage getItem throws', () => {
+    const throwingStorage: PreferenceStorage = {
+      getItem: () => {
+        throw new Error('storage disabled');
+      },
+      setItem: () => {},
+    };
+    expect(loadCameraLockPreference(throwingStorage)).toEqual(DEFAULT_CAMERA_LOCK_PREFERENCE);
+  });
+
+  it('reports failure when saving to storage that throws', () => {
+    const throwingStorage: PreferenceStorage = {
+      getItem: () => null,
+      setItem: () => {
+        throw new Error('quota exceeded');
+      },
+    };
+    expect(saveCameraLockPreference({ mode: 'toggle', enabled: true }, throwingStorage)).toBe(false);
+  });
+});
+
+describe('graph-camera command issuer', () => {
+  let issuer: ReturnType<typeof createGraphCameraCommandIssuer>;
+
+  beforeEach(() => {
+    issuer = createGraphCameraCommandIssuer();
+  });
+
+  it('starts at sequence 0 and issues monotonically increasing sequences', () => {
+    expect(issuer.current()).toBe(0);
+    const first = issuer.issue({ kind: 'centerSelection', scope: 'workflow', reason: 'select' });
+    const second = issuer.issue({ kind: 'fitInitial', scope: 'task', reason: 'mount' });
+    expect(first.sequence).toBe(1);
+    expect(second.sequence).toBe(2);
+    expect(issuer.current()).toBe(2);
+  });
+
+  it('builds centerSelection commands with scope, target and reason', () => {
+    const command = issuer.centerSelection('task', 'task-7', 'user click');
+    expect(command).toEqual({
+      kind: 'centerSelection',
+      scope: 'task',
+      target: 'task-7',
+      reason: 'user click',
+      sequence: 1,
+    });
+  });
+
+  it('builds fitInitial commands with a null target', () => {
+    const command = issuer.fitInitial('workflow');
+    expect(command.kind).toBe('fitInitial');
+    expect(command.scope).toBe('workflow');
+    expect(command.target).toBeNull();
+    expect(command.reason).toBe('fitInitial');
+    expect(command.sequence).toBe(1);
+  });
+
+  it('defaults an omitted target to null', () => {
+    const command = issuer.issue({ kind: 'fitInitial', scope: 'workflow', reason: 'reset' });
+    expect(command.target).toBeNull();
+  });
+
+  it('keeps independent sequences per issuer', () => {
+    const other = createGraphCameraCommandIssuer();
+    issuer.centerSelection('workflow', 'a');
+    issuer.centerSelection('workflow', 'b');
+    const otherCommand = other.centerSelection('task', 'c');
+    expect(issuer.current()).toBe(2);
+    expect(otherCommand.sequence).toBe(1);
+  });
+});

--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -19,6 +19,8 @@ import { vi } from 'vitest';
 export function createReactFlowMock() {
   const fitView = vi.fn();
   const setCenter = vi.fn();
+  const getZoom = vi.fn(() => 1);
+  const getViewport = vi.fn(() => ({ x: 0, y: 0, zoom: 1 }));
   const MockReactFlow = React.forwardRef(function MockReactFlow(
     props: {
       nodes?: Array<{
@@ -32,19 +34,33 @@ export function createReactFlowMock() {
       onNodeClick?: (event: React.MouseEvent, node: any) => void;
       onNodeContextMenu?: (event: React.MouseEvent, node: any) => void;
       onNodeDoubleClick?: (event: React.MouseEvent, node: any) => void;
+      onMoveStart?: (event: unknown, viewport: { x: number; y: number; zoom: number }) => void;
       onInit?: () => void;
       children?: React.ReactNode;
     },
     _ref: React.Ref<unknown>,
   ) {
-    const { nodes = [], nodeTypes = {}, onNodeClick, onNodeContextMenu, onNodeDoubleClick, children } = props;
+    const { nodes = [], nodeTypes = {}, onNodeClick, onNodeContextMenu, onNodeDoubleClick, onMoveStart, children } = props;
 
     React.useEffect(() => {
       props.onInit?.();
     }, []);
 
+    // Background pane: panning or wheel-zooming here simulates a user-driven
+    // viewport move, forwarding a non-null event to onMoveStart (mirroring real
+    // React Flow, which passes null for programmatic moves). It is a sibling of
+    // the node elements, so node clicks do not trigger manual-viewport events.
+    const emitManualMove = (event: unknown) =>
+      onMoveStart?.(event, { x: 0, y: 0, zoom: getZoom() });
+
     return (
       <div data-testid="mock-react-flow" className="react-flow">
+        <div
+          data-testid="rf__pane"
+          className="react-flow__pane"
+          onPointerDown={(e) => emitManualMove(e.nativeEvent)}
+          onWheel={(e) => emitManualMove(e.nativeEvent)}
+        />
         {props.edges?.map((edge: any) => (
           <div
             key={edge.id}
@@ -87,9 +103,11 @@ export function createReactFlowMock() {
   return {
     ReactFlow: MockReactFlow,
     ReactFlowProvider: MockReactFlowProvider,
-    useReactFlow: () => ({ fitView, setCenter }),
+    useReactFlow: () => ({ fitView, setCenter, getZoom, getViewport }),
     __setCenterMock: setCenter,
     __fitViewMock: fitView,
+    __getZoomMock: getZoom,
+    __getViewportMock: getViewport,
     applyNodeChanges: vi.fn((changes: unknown[], nodes: unknown[]) => nodes),
     Background: () => null,
     Controls: () => null,

--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -108,7 +108,24 @@ export function createReactFlowMock() {
     __fitViewMock: fitView,
     __getZoomMock: getZoom,
     __getViewportMock: getViewport,
-    applyNodeChanges: vi.fn((changes: unknown[], nodes: unknown[]) => nodes),
+    // Faithful-enough applyNodeChanges: real @xyflow/react records measured
+    // dimensions on the node (node.measured) for 'dimensions' changes and flips
+    // node.selected for 'select' changes. The TaskDAG relies on measured being
+    // preserved across task-delta re-renders, so the mock must mirror that.
+    applyNodeChanges: vi.fn((changes: Array<Record<string, any>>, nodes: Array<Record<string, any>>) => {
+      const next = nodes.map((node) => ({ ...node }));
+      const byId = new Map(next.map((node) => [node.id as string, node]));
+      for (const change of changes) {
+        const node = byId.get(change.id as string);
+        if (!node) continue;
+        if (change.type === 'dimensions' && change.dimensions) {
+          node.measured = { ...change.dimensions };
+        } else if (change.type === 'select') {
+          node.selected = change.selected;
+        }
+      }
+      return next;
+    }),
     Background: () => null,
     Controls: () => null,
     MarkerType: { ArrowClosed: 'arrowclosed' },

--- a/packages/ui/src/__tests__/keyboard-controls.test.tsx
+++ b/packages/ui/src/__tests__/keyboard-controls.test.tsx
@@ -5,16 +5,22 @@
  * Dropped: Ctrl+Backtick terminal toggle, terminal toggle bar (Electron shell features).
  */
 
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, type Mock } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { vi } from 'vitest';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
+import { CAMERA_LOCK_PREFERENCE_STORAGE_KEY } from '../lib/graph-camera.js';
 import type { WorkflowMeta } from '../types.js';
+import * as ReactFlowModule from '@xyflow/react';
 
 vi.mock('@xyflow/react', async () => {
   const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
   return createReactFlowMock();
 });
+
+const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
+const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
+const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
 
 const { App } = await import('../App.js');
 
@@ -232,5 +238,238 @@ describe('Side rail controls (component)', () => {
 
     expect(screen.getByTestId('keyboard-search-overlay')).toBeInTheDocument();
     expect(screen.getByTestId('workflow-graph-surface')).toHaveAttribute('data-keyboard-active', 'true');
+  });
+});
+
+/**
+ * Camera-lock keyboard/mouse contract at the App level. These prove the App
+ * owns camera intent (selection, active scope, lock preference, suppression)
+ * and that React Flow only moves when the App issues a typed command. Each
+ * setCenter call here flows from App → the correctly-scoped graph component.
+ */
+describe('Camera lock controls (component)', () => {
+  let mock: MockInvoker;
+  /** Active getBoundingClientRect spy, restored after each test. */
+  let rectSpy: ReturnType<typeof vi.spyOn> | null = null;
+
+  const threeWorkflows: WorkflowMeta[] = [
+    { id: 'wf-a', name: 'Alpha Workflow', status: 'running' },
+    { id: 'wf-b', name: 'Beta Workflow', status: 'pending' },
+    { id: 'wf-c', name: 'Gamma Workflow', status: 'pending' },
+  ];
+
+  const threeTasks = [
+    makeUITask({ id: 'wf-a/t', description: 'Alpha Task', workflowId: 'wf-a', command: 'echo a' }),
+    makeUITask({ id: 'wf-b/t', description: 'Beta Task', workflowId: 'wf-b', command: 'echo b' }),
+    makeUITask({ id: 'wf-c/t', description: 'Gamma Task', workflowId: 'wf-c', command: 'echo c' }),
+  ];
+
+  beforeEach(() => {
+    // jsdom in this project ships without localStorage, but the App persists
+    // the camera-lock preference there. Install a fresh in-memory shim so seeded
+    // preferences load and toggles round-trip within a test.
+    const store = new Map<string, string>();
+    Object.defineProperty(globalThis, 'localStorage', {
+      configurable: true,
+      value: {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => { store.set(k, String(v)); },
+        removeItem: (k: string) => { store.delete(k); },
+        clear: () => { store.clear(); },
+        key: (i: number) => [...store.keys()][i] ?? null,
+        get length() { return store.size; },
+      },
+    });
+    mock = createMockInvoker();
+    mock.install();
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    getZoomMock.mockReset();
+    getZoomMock.mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    rectSpy?.mockRestore();
+    rectSpy = null;
+    mock.cleanup();
+    delete (globalThis as { localStorage?: unknown }).localStorage;
+  });
+
+  /**
+   * Render the App, wait for the first workflow node and the single initial
+   * fit, then clear the viewport spies so a test asserts only on post-mount
+   * camera moves. Seed localStorage BEFORE calling this to control the lock.
+   */
+  async function renderAndSettle(
+    wfs: WorkflowMeta[] = workflows,
+    tks = tasks,
+  ) {
+    mock.setTasks(tks, wfs);
+    render(<App />);
+    await screen.findByTestId(`workflow-node-${wfs[0].id}`);
+    await waitFor(() => expect(fitViewMock).toHaveBeenCalled());
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+  }
+
+  /** Flush a single animation frame so any scheduled camera move can run. */
+  function flushFrame() {
+    return new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+  }
+
+  /**
+   * Stub getBoundingClientRect by data-testid so arrow navigation sees real
+   * geometry (jsdom otherwise reports every rect as 0×0). `lefts` maps a node
+   * testid to its left edge; each node is 200×80, so center.x = left + 100.
+   */
+  function stubNodeRects(lefts: Record<string, number>) {
+    rectSpy = vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(
+      function (this: HTMLElement) {
+        const testId = this.getAttribute('data-testid') ?? '';
+        const left = lefts[testId];
+        if (left === undefined) {
+          return {
+            x: 0, y: 0, top: 0, left: 0, right: 0, bottom: 0, width: 0, height: 0,
+            toJSON() {},
+          } as DOMRect;
+        }
+        return {
+          x: left, y: 100, top: 100, left, right: left + 200, bottom: 180,
+          width: 200, height: 80, toJSON() {},
+        } as DOMRect;
+      },
+    );
+  }
+
+  it('F1 toggle mode defaults on, toggles off then on, and re-centers the selection when re-enabled', async () => {
+    await renderAndSettle();
+
+    // Default region is the workflow graph with wf-a selected. The lock is on
+    // by default, so the first F1 toggles it OFF (no camera move).
+    key('F1');
+    await flushFrame();
+    expect(setCenterMock).not.toHaveBeenCalled();
+
+    // The second F1 toggles the lock back ON and immediately centers wf-a.
+    key('F1');
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+    // Lock-driven centering preserves zoom; it never whole-graph fits.
+    expect(fitViewMock).not.toHaveBeenCalled();
+    // The toggled preference is persisted.
+    expect(JSON.parse(localStorage.getItem(CAMERA_LOCK_PREFERENCE_STORAGE_KEY)!)).toEqual({
+      mode: 'toggle',
+      enabled: true,
+    });
+  });
+
+  it('F1 once mode centers once without changing the lock preference', async () => {
+    localStorage.setItem(
+      CAMERA_LOCK_PREFERENCE_STORAGE_KEY,
+      JSON.stringify({ mode: 'once', enabled: true }),
+    );
+    await renderAndSettle();
+
+    key('F1');
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+    // Once mode must not rewrite the persisted preference.
+    expect(JSON.parse(localStorage.getItem(CAMERA_LOCK_PREFERENCE_STORAGE_KEY)!)).toEqual({
+      mode: 'once',
+      enabled: true,
+    });
+
+    // Once mode re-centers on each press (it never disables the lock).
+    key('F1');
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('a manual background pan or wheel does not autofocus the graph', async () => {
+    await renderAndSettle();
+
+    const pane = screen.getAllByTestId('rf__pane')[0];
+    fireEvent.pointerDown(pane);
+    fireEvent.wheel(pane);
+
+    await flushFrame();
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it('clicking a workflow node centers it when the lock is enabled', async () => {
+    await renderAndSettle();
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-b'));
+
+    // Selecting wf-b re-centers the workflow graph on it. (A fresh mini-dag for
+    // wf-b legitimately fits once on mount, so we assert only the recenter.)
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('clicking a workflow node does not center when the lock is disabled', async () => {
+    localStorage.setItem(
+      CAMERA_LOCK_PREFERENCE_STORAGE_KEY,
+      JSON.stringify({ mode: 'toggle', enabled: false }),
+    );
+    await renderAndSettle();
+
+    fireEvent.click(screen.getByTestId('workflow-node-wf-b'));
+
+    await flushFrame();
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('arrow navigation re-centers the newly selected node when the lock is enabled', async () => {
+    await renderAndSettle();
+
+    key('ArrowRight');
+
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('arrow navigation selects the geometrically nearest node, not the alphabetical neighbor', async () => {
+    await renderAndSettle(threeWorkflows, threeTasks);
+
+    // wf-a is current (center 100). To its right, wf-c (center 200) is nearer
+    // than wf-b (center 300). The alphabetical neighbor would be wf-b, so
+    // landing on wf-c proves arrow nav uses geometry.
+    stubNodeRects({
+      'workflow-node-wf-a': 0,
+      'workflow-node-wf-b': 200,
+      'workflow-node-wf-c': 100,
+    });
+
+    key('ArrowRight');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Gamma Workflow task DAG');
+    });
+  });
+
+  it('arrow navigation stays put when there is no node further in that direction', async () => {
+    await renderAndSettle(threeWorkflows, threeTasks);
+
+    // Lay nodes left→right as wf-a, wf-b, wf-c so wf-c is both the rightmost
+    // node and the alphabetically-last one — the boundary where ArrowRight has
+    // nowhere to go and must not move the selection.
+    stubNodeRects({
+      'workflow-node-wf-a': 0,
+      'workflow-node-wf-b': 200,
+      'workflow-node-wf-c': 400,
+    });
+
+    // Select the rightmost node first, and wait for its recenter to fire so the
+    // pending animation frame can't leak into the assertion below.
+    fireEvent.click(screen.getByTestId('workflow-node-wf-c'));
+    await waitFor(() => {
+      expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Gamma Workflow task DAG');
+    });
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalled());
+    setCenterMock.mockClear();
+
+    key('ArrowRight');
+
+    await flushFrame();
+    // Selection unchanged and no recenter was issued.
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(screen.getByTestId('selected-workflow-mini-dag')).toHaveTextContent('Gamma Workflow task DAG');
   });
 });

--- a/packages/ui/src/__tests__/task-dag-stability.test.ts
+++ b/packages/ui/src/__tests__/task-dag-stability.test.ts
@@ -10,7 +10,7 @@ import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vite
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { createElement } from 'react';
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { applyNodeChanges, type Node, type NodeChange } from '@xyflow/react';
 import * as ReactFlowModule from '@xyflow/react';
 import { TaskDAG } from '../components/TaskDAG.js';
@@ -331,5 +331,176 @@ describe('TaskDAG stability', () => {
       expect(reactFlowBlock).toContain('nodes={rfNodes}');
       expect(reactFlowBlock).not.toMatch(/nodes=\{nodes\}/);
     });
+  });
+});
+
+// ── Camera ownership (viewport-fighting regression) ─────────
+// These assert the runtime camera contract: React Flow owns x/y/zoom after the
+// initial fit, and the DAG only moves the viewport when it consumes a typed,
+// task-scoped command exactly once. Status refreshes and topology changes must
+// never re-fit or re-center, which is what kept the old graph fighting the user.
+describe('TaskDAG camera ownership', () => {
+  beforeEach(() => {
+    fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    getZoomMock.mockReset();
+    getZoomMock.mockReturnValue(1);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  /** Build a tasks Map from a list of task ids (all in workflow wf-a). */
+  function tasksMap(...ids: string[]): Map<string, TaskState> {
+    return new Map(ids.map((id) => [id, dagTask(id)] as const));
+  }
+
+  it('fits the viewport exactly once on the first non-empty render', async () => {
+    render(createElement(TaskDAG, { tasks: tasksMap('task-a') }));
+
+    // onInit fires once for the first non-empty render and never re-fits.
+    await waitFor(() => expect(fitViewMock).toHaveBeenCalledTimes(1));
+    expect(fitViewMock).toHaveBeenCalledWith({ padding: 0.2 });
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('does not move the camera on a status-only update', async () => {
+    const { rerender } = await renderDagAndSettleInitialFit({
+      tasks: tasksMap('task-a'),
+      selectedTaskId: 'task-a',
+    });
+
+    // Same topology, only the task status changes.
+    rerender(
+      createElement(TaskDAG, {
+        tasks: new Map([['task-a', dagTask('task-a', { status: 'running' })]]),
+        selectedTaskId: 'task-a',
+      }),
+    );
+
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves the camera when the topology changes (a task is added)', async () => {
+    const { rerender } = await renderDagAndSettleInitialFit({ tasks: tasksMap('task-a') });
+
+    rerender(createElement(TaskDAG, { tasks: tasksMap('task-a', 'task-b') }));
+
+    // The new node renders without remounting React Flow or moving the camera.
+    expect(await screen.findByTestId('rf__node-task-b')).toBeInTheDocument();
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('centers the selected task on a centerSelection command, preserving the current zoom', async () => {
+    const issuer = createGraphCameraCommandIssuer();
+    getZoomMock.mockReturnValue(1.5);
+
+    const { rerender } = await renderDagAndSettleInitialFit({
+      tasks: tasksMap('task-a'),
+      selectedTaskId: 'task-a',
+    });
+
+    rerender(
+      createElement(TaskDAG, {
+        tasks: tasksMap('task-a'),
+        selectedTaskId: 'task-a',
+        cameraCommand: issuer.centerSelection('task', 'task-a'),
+      }),
+    );
+
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+    // Centering must preserve the live zoom (not reset to 1).
+    const [, , options] = setCenterMock.mock.calls[0];
+    expect(options).toMatchObject({ zoom: 1.5 });
+    // A center command must never trigger a whole-graph fit.
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it('consumes a fitInitial command by fitting the graph', async () => {
+    const issuer = createGraphCameraCommandIssuer();
+
+    const { rerender } = await renderDagAndSettleInitialFit({
+      tasks: tasksMap('task-a'),
+      selectedTaskId: 'task-a',
+    });
+
+    rerender(
+      createElement(TaskDAG, {
+        tasks: tasksMap('task-a'),
+        selectedTaskId: 'task-a',
+        cameraCommand: issuer.fitInitial('task'),
+      }),
+    );
+
+    await waitFor(() => expect(fitViewMock).toHaveBeenCalledTimes(1));
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores a camera command scoped to the workflow graph', async () => {
+    const issuer = createGraphCameraCommandIssuer();
+
+    const { rerender } = await renderDagAndSettleInitialFit({
+      tasks: tasksMap('task-a'),
+      selectedTaskId: 'task-a',
+    });
+
+    rerender(
+      createElement(TaskDAG, {
+        tasks: tasksMap('task-a'),
+        selectedTaskId: 'task-a',
+        cameraCommand: issuer.centerSelection('workflow', 'task-a'),
+      }),
+    );
+
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it('consumes each command once by sequence, not on every re-render', async () => {
+    const issuer = createGraphCameraCommandIssuer();
+    const command = issuer.centerSelection('task', 'task-a');
+
+    const { rerender } = await renderDagAndSettleInitialFit({
+      tasks: tasksMap('task-a'),
+      selectedTaskId: 'task-a',
+    });
+
+    const props = {
+      tasks: tasksMap('task-a'),
+      selectedTaskId: 'task-a' as const,
+      cameraCommand: command,
+    };
+    rerender(createElement(TaskDAG, props));
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+
+    // Re-rendering with the SAME command object must not re-fire the move —
+    // this is what prevents data refreshes from fighting the user's camera.
+    rerender(createElement(TaskDAG, props));
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    expect(setCenterMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports manual viewport interaction on background pan and wheel without autofocusing', async () => {
+    const onManualViewport = vi.fn();
+
+    await renderDagAndSettleInitialFit({
+      tasks: tasksMap('task-a'),
+      selectedTaskId: 'task-a',
+      onManualViewport,
+    });
+
+    const pane = screen.getByTestId('rf__pane');
+    fireEvent.pointerDown(pane);
+    fireEvent.wheel(pane);
+
+    expect(onManualViewport).toHaveBeenCalledTimes(2);
+    // A manual move must never autofocus the graph.
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(fitViewMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/__tests__/task-dag-stability.test.ts
+++ b/packages/ui/src/__tests__/task-dag-stability.test.ts
@@ -6,15 +6,54 @@
  * - rfNodes state preserves measured dimensions from task-derived node updates
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi, type Mock } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { createElement } from 'react';
+import { cleanup, render, waitFor } from '@testing-library/react';
 import { applyNodeChanges, type Node, type NodeChange } from '@xyflow/react';
+import * as ReactFlowModule from '@xyflow/react';
+import { TaskDAG } from '../components/TaskDAG.js';
+import { createGraphCameraCommandIssuer } from '../lib/graph-camera.js';
+import type { TaskState } from '../types.js';
+
+vi.mock('@xyflow/react', async () => {
+  const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
+  return createReactFlowMock();
+});
+
+const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
+const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
+const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
 
 const source = readFileSync(
   resolve(__dirname, '..', 'components', 'TaskDAG.tsx'),
   'utf-8',
 );
+
+function dagTask(id: string, overrides: Partial<TaskState> = {}): TaskState {
+  return {
+    id,
+    description: id,
+    status: 'pending',
+    dependencies: [],
+    config: { workflowId: 'wf-a' },
+    execution: {},
+    taskStateVersion: 1,
+    ...overrides,
+  } as TaskState;
+}
+
+/** Mount a TaskDAG (createElement keeps this a .ts file) and wait for the
+ * single first-render fit to settle, then clear the viewport spies so a test
+ * can assert on the calls that happen after the initial mount. */
+async function renderDagAndSettleInitialFit(props: Parameters<typeof TaskDAG>[0]) {
+  const utils = render(createElement(TaskDAG, props));
+  await waitFor(() => expect(fitViewMock).toHaveBeenCalledTimes(1));
+  fitViewMock.mockClear();
+  setCenterMock.mockClear();
+  return utils;
+}
 
 describe('TaskDAG stability', () => {
   describe('selection wiring', () => {

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -146,7 +146,7 @@ describe('WorkflowGraph', () => {
     expect(edge).toHaveAttribute('data-target', 'wf-b');
   });
 
-  it('re-fits after a non-empty workflow snapshot replacement', async () => {
+  it('preserves the camera across a non-empty workflow snapshot replacement', async () => {
     const workflows = new Map([
       ['wf-a', wf('wf-a', 'running')],
     ]);
@@ -165,6 +165,8 @@ describe('WorkflowGraph', () => {
       />,
     );
 
+    // Clear the initial first-render fit so we can assert topology changes
+    // afterwards do not move the camera.
     fitViewMock.mockClear();
 
     const refreshedWorkflows = new Map([
@@ -187,9 +189,9 @@ describe('WorkflowGraph', () => {
       />,
     );
 
-    await vi.waitFor(() => {
-      expect(fitViewMock).toHaveBeenCalledWith({ padding: 0.2 });
-    });
-    expect(screen.getByTestId('workflow-node-wf-b')).toBeInTheDocument();
+    // The new workflow renders without remounting React Flow…
+    expect(await screen.findByTestId('workflow-node-wf-b')).toBeInTheDocument();
+    // …and the user-owned camera is preserved (no implicit re-fit).
+    expect(fitViewMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -1,6 +1,7 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 import { WorkflowGraph } from '../components/WorkflowGraph.js';
+import { createGraphCameraCommandIssuer } from '../lib/graph-camera.js';
 import type { TaskState, WorkflowMeta, WorkflowStatus } from '../types.js';
 import * as ReactFlowModule from '@xyflow/react';
 
@@ -10,6 +11,8 @@ vi.mock('@xyflow/react', async () => {
 });
 
 const fitViewMock = (ReactFlowModule as unknown as { __fitViewMock: Mock }).__fitViewMock;
+const setCenterMock = (ReactFlowModule as unknown as { __setCenterMock: Mock }).__setCenterMock;
+const getZoomMock = (ReactFlowModule as unknown as { __getZoomMock: Mock }).__getZoomMock;
 
 function wf(id: string, status: WorkflowStatus, overrides: Partial<WorkflowMeta> = {}): WorkflowMeta {
   return { id, name: id, status, ...overrides };
@@ -27,9 +30,24 @@ function task(id: string, workflowId: string): TaskState {
   };
 }
 
+/** Render a one-workflow graph and wait for the initial first-render fit to
+ * settle, then clear the viewport spies so a test can assert on the calls that
+ * happen *after* the initial mount. */
+async function renderAndSettleInitialFit(props: Parameters<typeof WorkflowGraph>[0]) {
+  const utils = render(<WorkflowGraph {...props} />);
+  // onInit schedules the single first-render fit in a rAF; wait for it.
+  await waitFor(() => expect(fitViewMock).toHaveBeenCalledTimes(1));
+  fitViewMock.mockClear();
+  setCenterMock.mockClear();
+  return utils;
+}
+
 describe('WorkflowGraph', () => {
   beforeEach(() => {
     fitViewMock.mockClear();
+    setCenterMock.mockClear();
+    getZoomMock.mockReset();
+    getZoomMock.mockReturnValue(1);
   });
 
   it('calls selection and context menu handlers', () => {
@@ -146,15 +164,11 @@ describe('WorkflowGraph', () => {
     expect(edge).toHaveAttribute('data-target', 'wf-b');
   });
 
-  it('preserves the camera across a non-empty workflow snapshot replacement', async () => {
-    const workflows = new Map([
-      ['wf-a', wf('wf-a', 'running')],
-    ]);
-    const tasks = new Map([
-      ['t1', task('t1', 'wf-a')],
-    ]);
+  it('fits the viewport exactly once on the first non-empty render', async () => {
+    const workflows = new Map([['wf-a', wf('wf-a', 'running')]]);
+    const tasks = new Map([['t1', task('t1', 'wf-a')]]);
 
-    const { rerender } = render(
+    render(
       <WorkflowGraph
         tasks={tasks}
         workflows={workflows}
@@ -165,9 +179,28 @@ describe('WorkflowGraph', () => {
       />,
     );
 
-    // Clear the initial first-render fit so we can assert topology changes
-    // afterwards do not move the camera.
-    fitViewMock.mockClear();
+    // onInit fires once for the first non-empty render and never re-fits.
+    await waitFor(() => expect(fitViewMock).toHaveBeenCalledTimes(1));
+    expect(fitViewMock).toHaveBeenCalledWith({ padding: 0.2 });
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves the camera across a non-empty workflow snapshot replacement', async () => {
+    const workflows = new Map([
+      ['wf-a', wf('wf-a', 'running')],
+    ]);
+    const tasks = new Map([
+      ['t1', task('t1', 'wf-a')],
+    ]);
+
+    const { rerender } = await renderAndSettleInitialFit({
+      tasks,
+      workflows,
+      selectedWorkflowId: null,
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+    });
 
     const refreshedWorkflows = new Map([
       ['wf-a', wf('wf-a', 'running')],
@@ -191,7 +224,183 @@ describe('WorkflowGraph', () => {
 
     // The new workflow renders without remounting React Flow…
     expect(await screen.findByTestId('workflow-node-wf-b')).toBeInTheDocument();
-    // …and the user-owned camera is preserved (no implicit re-fit).
+    // …and the user-owned camera is preserved (no implicit re-fit or re-center).
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('does not move the camera on a status-only update', async () => {
+    const tasks = new Map([['t1', task('t1', 'wf-a')]]);
+
+    const { rerender } = await renderAndSettleInitialFit({
+      tasks,
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+    });
+
+    // Same topology, only the workflow status changes.
+    rerender(
+      <WorkflowGraph
+        tasks={tasks}
+        workflows={new Map([['wf-a', wf('wf-a', 'completed')]])}
+        selectedWorkflowId="wf-a"
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    // Give any stray rAF a chance to flush before asserting nothing happened.
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    expect(fitViewMock).not.toHaveBeenCalled();
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('centers the selected workflow on a centerSelection command, preserving the current zoom', async () => {
+    const issuer = createGraphCameraCommandIssuer();
+    getZoomMock.mockReturnValue(1.75);
+
+    const { rerender } = await renderAndSettleInitialFit({
+      tasks: new Map([['t1', task('t1', 'wf-a')]]),
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+    });
+
+    rerender(
+      <WorkflowGraph
+        tasks={new Map([['t1', task('t1', 'wf-a')]])}
+        workflows={new Map([['wf-a', wf('wf-a', 'running')]])}
+        selectedWorkflowId="wf-a"
+        cameraCommand={issuer.centerSelection('workflow', 'wf-a')}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+    // Centering must preserve the live zoom (not reset to 1).
+    const [, , options] = setCenterMock.mock.calls[0];
+    expect(options).toMatchObject({ zoom: 1.75 });
+    // A center command must never trigger a whole-graph fit.
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it('consumes a fitInitial command by fitting the graph', async () => {
+    const issuer = createGraphCameraCommandIssuer();
+
+    const { rerender } = await renderAndSettleInitialFit({
+      tasks: new Map([['t1', task('t1', 'wf-a')]]),
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+    });
+
+    rerender(
+      <WorkflowGraph
+        tasks={new Map([['t1', task('t1', 'wf-a')]])}
+        workflows={new Map([['wf-a', wf('wf-a', 'running')]])}
+        selectedWorkflowId="wf-a"
+        cameraCommand={issuer.fitInitial('workflow')}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    await waitFor(() => expect(fitViewMock).toHaveBeenCalledTimes(1));
+    expect(setCenterMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores a camera command scoped to another graph', async () => {
+    const issuer = createGraphCameraCommandIssuer();
+
+    const { rerender } = await renderAndSettleInitialFit({
+      tasks: new Map([['t1', task('t1', 'wf-a')]]),
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+    });
+
+    rerender(
+      <WorkflowGraph
+        tasks={new Map([['t1', task('t1', 'wf-a')]])}
+        workflows={new Map([['wf-a', wf('wf-a', 'running')]])}
+        selectedWorkflowId="wf-a"
+        cameraCommand={issuer.centerSelection('task', 't1')}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    expect(setCenterMock).not.toHaveBeenCalled();
+    expect(fitViewMock).not.toHaveBeenCalled();
+  });
+
+  it('consumes each command once by sequence, not on every re-render', async () => {
+    const issuer = createGraphCameraCommandIssuer();
+    const command = issuer.centerSelection('workflow', 'wf-a');
+
+    const { rerender } = await renderAndSettleInitialFit({
+      tasks: new Map([['t1', task('t1', 'wf-a')]]),
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+    });
+
+    const props = {
+      tasks: new Map([['t1', task('t1', 'wf-a')]]),
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a' as const,
+      cameraCommand: command,
+      statusFilters: new Set<WorkflowStatus>(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+    };
+    rerender(<WorkflowGraph {...props} />);
+    await waitFor(() => expect(setCenterMock).toHaveBeenCalledTimes(1));
+
+    // Re-rendering with the SAME command object must not re-fire the move —
+    // this is what prevents data refreshes from fighting the user's camera.
+    rerender(<WorkflowGraph {...props} />);
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    expect(setCenterMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports manual viewport interaction on background pan and wheel without autofocusing', async () => {
+    const onManualViewport = vi.fn();
+
+    await renderAndSettleInitialFit({
+      tasks: new Map([['t1', task('t1', 'wf-a')]]),
+      workflows: new Map([['wf-a', wf('wf-a', 'running')]]),
+      selectedWorkflowId: 'wf-a',
+      statusFilters: new Set(),
+      onSelectWorkflow: () => {},
+      onWorkflowContextMenu: () => {},
+      onManualViewport,
+    });
+
+    const pane = screen.getByTestId('rf__pane');
+    fireEvent.pointerDown(pane);
+    fireEvent.wheel(pane);
+
+    expect(onManualViewport).toHaveBeenCalledTimes(2);
+    // A manual move must never autofocus the graph.
+    expect(setCenterMock).not.toHaveBeenCalled();
     expect(fitViewMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/ui/src/components/TaskDAG.tsx
+++ b/packages/ui/src/components/TaskDAG.tsx
@@ -22,6 +22,7 @@ import {
 import '@xyflow/react/dist/style.css';
 
 import type { TaskState, WorkflowMeta } from '../types.js';
+import type { GraphCameraCommand } from '../lib/graph-camera.js';
 import { layoutNodes, layoutTaskGraph, type LayoutEdge, type TaskGraphLayout } from '../lib/layout.js';
 import { getEdgeStyle, getEffectiveVisualStatus, matchesStatusFilter } from '../lib/colors.js';
 import { TaskNode } from './TaskNode.js';
@@ -40,10 +41,17 @@ interface TaskDAGProps {
   tasks: Map<string, TaskState>;
   workflows?: Map<string, WorkflowMeta>;
   selectedTaskId?: string | null;
-  centerTaskId?: string | null;
+  /**
+   * Latest typed camera command. The DAG consumes each command once by
+   * sequence; commands scoped to other graphs are ignored. React Flow keeps
+   * owning x/y/zoom locally — this is intent, not a controlled viewport.
+   */
+  cameraCommand?: GraphCameraCommand | null;
   onTaskClick?: (task: TaskState) => void;
   onTaskDoubleClick?: (task: TaskState) => void;
   onTaskContextMenu?: (task: TaskState, event: React.MouseEvent) => void;
+  /** Fired when the user manually pans or zooms the viewport. */
+  onManualViewport?: () => void;
   statusFilters?: Set<string>;
 }
 
@@ -143,19 +151,25 @@ function mergeMeasuredNodeState(prevNodes: Node[], nextNodes: Node[]): Node[] {
   });
 }
 
-function TaskDAGInner({ tasks, workflows, selectedTaskId, centerTaskId, onTaskClick, onTaskDoubleClick, onTaskContextMenu, statusFilters }: TaskDAGProps) {
-  const { fitView, setCenter } = useReactFlow();
+function TaskDAGInner({ tasks, workflows, selectedTaskId, cameraCommand, onTaskClick, onTaskDoubleClick, onTaskContextMenu, onManualViewport, statusFilters }: TaskDAGProps) {
+  const { fitView, setCenter, getZoom } = useReactFlow();
   const prevNodeCount = useRef(0);
   const lastNodeClickRef = useRef<{ id: string; at: number } | null>(null);
   const reportedGraphVisibleRef = useRef(false);
   const watchdogMissCountRef = useRef(0);
   const watchdogRecoveryAttemptedRef = useRef(false);
+  const lastHandledCameraSeqRef = useRef(0);
+  const initFitFrameRef = useRef(0);
   const [layoutState, setLayoutState] = useState<LayoutState | null>(null);
   const [flowInstanceKey, setFlowInstanceKey] = useState(0);
 
   const onInitHandler = useCallback(() => {
-    requestAnimationFrame(() => fitView({ padding: 0.2 }));
+    initFitFrameRef.current = requestAnimationFrame(() => fitView({ padding: 0.2 }));
   }, [fitView]);
+
+  // Cancel a pending first-fit frame on unmount so it never fires against a
+  // torn-down graph after the component has gone away.
+  useEffect(() => () => cancelAnimationFrame(initFitFrameRef.current), []);
 
   const rawGraph = useMemo(() => {
     const taskArray = [...tasks.values()];
@@ -409,29 +423,56 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, centerTaskId, onTaskCl
     }
   }, []);
 
-  // Re-fit view when the actual rendered node count changes (includes merge gate)
+  // Topology changes (added/removed nodes) reset the watchdog recovery state but
+  // preserve the camera — a status refresh or new task must never re-fit or
+  // re-center. The initial fit is owned by onInit (first non-empty mount).
   useEffect(() => {
     if (nodes.length !== prevNodeCount.current && nodes.length > 0) {
       prevNodeCount.current = nodes.length;
       watchdogMissCountRef.current = 0;
       watchdogRecoveryAttemptedRef.current = false;
-      requestAnimationFrame(() => fitView({ padding: 0.2 }));
     }
-  }, [nodes.length, fitView]);
+  }, [nodes.length]);
 
+  // Manual pan/zoom from the user. React Flow passes a non-null DOM event for
+  // user-driven moves and null for programmatic setCenter/fitView, so this only
+  // reports genuine manual interaction.
+  const onMoveStart = useCallback(
+    (event: unknown) => {
+      if (event) onManualViewport?.();
+    },
+    [onManualViewport],
+  );
+
+  // Consume each task-scoped camera command exactly once, by sequence. Centering
+  // preserves the current zoom so ordinary refreshes never zoom the graph; only
+  // an explicit fitInitial command refits.
   useEffect(() => {
-    if (!centerTaskId || nodes.length === 0) return;
-    const node = nodes.find((candidate) => candidate.id === centerTaskId);
+    const command = cameraCommand;
+    if (!command || command.scope !== 'task') return;
+    if (command.sequence <= lastHandledCameraSeqRef.current) return;
+    lastHandledCameraSeqRef.current = command.sequence;
+    if (nodes.length === 0) return;
+
+    if (command.kind === 'fitInitial') {
+      const frame = requestAnimationFrame(() => fitView({ padding: 0.2 }));
+      return () => cancelAnimationFrame(frame);
+    }
+
+    const targetId = command.target;
+    if (!targetId) return;
+    const node = nodes.find((candidate) => candidate.id === targetId);
     if (!node) return;
     const frame = requestAnimationFrame(() => {
       if (typeof setCenter === 'function') {
-        setCenter(node.position.x + 132, node.position.y + 55, { zoom: 1, duration: 180 });
+        const zoom = typeof getZoom === 'function' ? getZoom() : 1;
+        setCenter(node.position.x + 132, node.position.y + 55, { zoom, duration: 180 });
       } else {
         fitView({ padding: 0.2 });
       }
     });
     return () => cancelAnimationFrame(frame);
-  }, [centerTaskId, fitView, nodes, setCenter]);
+  }, [cameraCommand, fitView, getZoom, nodes, setCenter]);
 
   useEffect(() => {
     if (reportedGraphVisibleRef.current || nodes.length === 0 || typeof window === 'undefined') {
@@ -559,6 +600,7 @@ function TaskDAGInner({ tasks, workflows, selectedTaskId, centerTaskId, onTaskCl
         onNodeClick={onNodeClick}
         onNodeDoubleClick={onNodeDoubleClick}
         onNodeContextMenu={onNodeContextMenu}
+        onMoveStart={onMoveStart}
         onInit={onInitHandler}
         zoomOnDoubleClick={false}
         minZoom={0.3}

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { MouseEvent } from 'react';
 import type { TaskState, WorkflowMeta, WorkflowStatus } from '../types.js';
+import type { GraphCameraCommand } from '../lib/graph-camera.js';
 import { deriveWorkflowGraph, layoutWorkflowGraph } from '../lib/workflow-graph.js';
 import { WorkflowNode } from './WorkflowNode.js';
 import {
@@ -22,10 +23,17 @@ interface WorkflowGraphProps {
   tasks: Map<string, TaskState>;
   workflows: Map<string, WorkflowMeta>;
   selectedWorkflowId: string | null;
-  centerWorkflowId?: string | null;
+  /**
+   * Latest typed camera command. The graph consumes each command once by
+   * sequence; commands scoped to other graphs are ignored. React Flow keeps
+   * owning x/y/zoom locally — this is intent, not a controlled viewport.
+   */
+  cameraCommand?: GraphCameraCommand | null;
   statusFilters: Set<WorkflowStatus>;
   onSelectWorkflow: (workflowId: string) => void;
   onWorkflowContextMenu: (event: MouseEvent, workflowId: string) => void;
+  /** Fired when the user manually pans or zooms the viewport. */
+  onManualViewport?: () => void;
 }
 
 interface WorkflowNodeData extends Record<string, unknown> {
@@ -68,14 +76,16 @@ function WorkflowGraphInner({
   tasks,
   workflows,
   selectedWorkflowId,
-  centerWorkflowId,
+  cameraCommand,
   statusFilters,
   onSelectWorkflow,
   onWorkflowContextMenu,
+  onManualViewport,
 }: WorkflowGraphProps): JSX.Element {
-  const { fitView, setCenter } = useReactFlow();
-  const prevNodeCount = useRef(0);
+  const { fitView, setCenter, getZoom } = useReactFlow();
   const reportedVisibleRef = useRef(false);
+  const lastHandledCameraSeqRef = useRef(0);
+  const initFitFrameRef = useRef(0);
   const graphMetricsRef = useRef({ deriveMs: 0, layoutMs: 0, objectsMs: 0 });
   const graph = useMemo(() => {
     const startedAt = performance.now();
@@ -135,24 +145,27 @@ function WorkflowGraphInner({
     },
   })), [graph.edges]);
 
-  const graphSignature = useMemo(() => {
-    const nodeIds = graph.nodes.map((node) => node.id).join('|');
-    const edgeIds = graph.edges.map((edge) => `${edge.kind}:${edge.source}->${edge.target}`).join('|');
-    return `${nodeIds}::${edgeIds}`;
-  }, [graph.edges, graph.nodes]);
-
+  // First non-empty render fits the whole graph once. React Flow only mounts
+  // when there is at least one node (the empty state short-circuits below), so
+  // onInit fires exactly on the first non-empty render — no graphSignature key
+  // and no per-update remount are needed.
   const onInitHandler = useCallback(() => {
-    requestAnimationFrame(() => fitView({ padding: 0.2 }));
+    initFitFrameRef.current = requestAnimationFrame(() => fitView({ padding: 0.2 }));
   }, [fitView]);
 
-  useEffect(() => {
-    if (nodes.length !== prevNodeCount.current && nodes.length > 0) {
-      prevNodeCount.current = nodes.length;
-      const frame = requestAnimationFrame(() => fitView({ padding: 0.2 }));
-      return () => cancelAnimationFrame(frame);
-    }
-    return undefined;
-  }, [fitView, nodes.length]);
+  // Cancel a pending first-fit frame on unmount so it never fires against a
+  // torn-down graph after the component has gone away.
+  useEffect(() => () => cancelAnimationFrame(initFitFrameRef.current), []);
+
+  // Manual pan/zoom from the user. React Flow passes a non-null DOM event for
+  // user-driven moves and null for programmatic setCenter/fitView, so this only
+  // reports genuine manual interaction.
+  const onMoveStart = useCallback(
+    (event: unknown) => {
+      if (event) onManualViewport?.();
+    },
+    [onManualViewport],
+  );
 
   const onNodeClick = useCallback((_event: MouseEvent, node: Node) => {
     onSelectWorkflow(node.id);
@@ -186,27 +199,35 @@ function WorkflowGraphInner({
     return () => cancelAnimationFrame(frame);
   }, [graph.edges.length, graph.nodes.length]);
 
+  // Consume each workflow-scoped camera command exactly once, by sequence.
+  // Centering preserves the current zoom so ordinary refreshes never zoom the
+  // graph; only an explicit fitInitial command refits.
   useEffect(() => {
-    if (graph.nodes.length === 0 || typeof window === 'undefined') return;
-    const frame = requestAnimationFrame(() => {
-      requestAnimationFrame(() => fitView({ padding: 0.2 }));
-    });
-    return () => cancelAnimationFrame(frame);
-  }, [fitView, graph.nodes.length, graphSignature]);
+    const command = cameraCommand;
+    if (!command || command.scope !== 'workflow') return;
+    if (command.sequence <= lastHandledCameraSeqRef.current) return;
+    lastHandledCameraSeqRef.current = command.sequence;
+    if (nodes.length === 0) return;
 
-  useEffect(() => {
-    if (!centerWorkflowId || nodes.length === 0) return;
-    const node = nodes.find((candidate) => candidate.id === centerWorkflowId);
+    if (command.kind === 'fitInitial') {
+      const frame = requestAnimationFrame(() => fitView({ padding: 0.2 }));
+      return () => cancelAnimationFrame(frame);
+    }
+
+    const targetId = command.target;
+    if (!targetId) return;
+    const node = nodes.find((candidate) => candidate.id === targetId);
     if (!node) return;
     const frame = requestAnimationFrame(() => {
       if (typeof setCenter === 'function') {
-        setCenter(node.position.x + 110, node.position.y + 45, { zoom: 1, duration: 180 });
+        const zoom = typeof getZoom === 'function' ? getZoom() : 1;
+        setCenter(node.position.x + 110, node.position.y + 45, { zoom, duration: 180 });
       } else {
         fitView({ padding: 0.2 });
       }
     });
     return () => cancelAnimationFrame(frame);
-  }, [centerWorkflowId, fitView, nodes, setCenter]);
+  }, [cameraCommand, fitView, getZoom, nodes, setCenter]);
 
   useEffect(() => {
     if (nodes.length === 0) return;
@@ -241,12 +262,12 @@ function WorkflowGraphInner({
     >
       <div data-testid="workflow-graph-react-flow" className="h-full w-full">
         <ReactFlow
-          key={graphSignature}
           nodes={nodes}
           edges={edges}
           nodeTypes={nodeTypes}
           onNodeClick={onNodeClick}
           onNodeContextMenu={onNodeContextMenu}
+          onMoveStart={onMoveStart}
           onInit={onInitHandler}
           zoomOnDoubleClick={false}
           minZoom={0.3}

--- a/packages/ui/src/lib/graph-camera.ts
+++ b/packages/ui/src/lib/graph-camera.ts
@@ -1,0 +1,218 @@
+/**
+ * Shared vocabulary for graph camera behaviour across the workflow graph and
+ * the selected-workflow task DAG.
+ *
+ * This module is the single source of truth for:
+ *  - which graph a camera command targets (`GraphScope`),
+ *  - whether the camera re-centres on every selection or only once
+ *    (`CameraMode`),
+ *  - the persisted camera-lock preference (`CameraLockPreference`),
+ *  - one-shot viewport commands (`GraphCameraCommand`), and
+ *  - the monotonic command sequence.
+ *
+ * Crucially, the monotonic `sequence` only ever increments inside the issuer
+ * returned by {@link createGraphCameraCommandIssuer}. No App-level selection
+ * handler should keep its own `event++` / `requestId++` counter — they consume
+ * commands from an issuer instead. React Flow keeps owning x/y/zoom locally;
+ * these commands are intent ("centre this selection"), not a controlled
+ * viewport.
+ */
+
+/** Which graph a camera command applies to. */
+export type GraphScope = 'workflow' | 'task';
+
+/**
+ * How aggressively the camera follows selection.
+ *  - `toggle`: re-centre whenever the selection changes (lock stays on).
+ *  - `once`: centre a single time, then release until re-armed.
+ */
+export type CameraMode = 'toggle' | 'once';
+
+/** Persisted camera-lock preference. */
+export interface CameraLockPreference {
+  /** Follow-selection behaviour. */
+  mode: CameraMode;
+  /** Whether the camera lock is engaged at all. */
+  enabled: boolean;
+}
+
+/** The kinds of one-shot viewport commands the UI can issue. */
+export type GraphCameraCommandKind = 'centerSelection' | 'fitInitial';
+
+/**
+ * A one-shot viewport command. Consumers act on a command when its `sequence`
+ * is greater than the last one they handled, then record the new sequence.
+ */
+export interface GraphCameraCommand {
+  /** What the viewport should do. */
+  kind: GraphCameraCommandKind;
+  /** Which graph the command targets. */
+  scope: GraphScope;
+  /** The node id to centre on, or `null` for whole-graph commands. */
+  target: string | null;
+  /** Human-readable cause, useful for debugging suppressed/forced moves. */
+  reason: string;
+  /** Monotonically increasing per issuer; the only mutable camera counter. */
+  sequence: number;
+}
+
+/** Valid {@link CameraMode} values. */
+const CAMERA_MODES: ReadonlySet<CameraMode> = new Set<CameraMode>(['toggle', 'once']);
+
+/** Valid {@link GraphScope} values. */
+const GRAPH_SCOPES: ReadonlySet<GraphScope> = new Set<GraphScope>(['workflow', 'task']);
+
+/** localStorage key for the persisted camera-lock preference. */
+export const CAMERA_LOCK_PREFERENCE_STORAGE_KEY = 'invoker.ui.cameraLockPreference';
+
+/**
+ * Default preference: follow selection on every change, lock engaged.
+ * Frozen so callers cannot mutate the shared default in place.
+ */
+export const DEFAULT_CAMERA_LOCK_PREFERENCE: CameraLockPreference = Object.freeze({
+  mode: 'toggle',
+  enabled: true,
+});
+
+/** Narrow an arbitrary value to a {@link CameraMode}. */
+export function isCameraMode(value: unknown): value is CameraMode {
+  return typeof value === 'string' && CAMERA_MODES.has(value as CameraMode);
+}
+
+/** Narrow an arbitrary value to a {@link GraphScope}. */
+export function isGraphScope(value: unknown): value is GraphScope {
+  return typeof value === 'string' && GRAPH_SCOPES.has(value as GraphScope);
+}
+
+/**
+ * Validate a parsed value as a {@link CameraLockPreference}. Returns a fresh,
+ * fully-typed preference, or `null` if the shape is malformed.
+ */
+function parseCameraLockPreference(value: unknown): CameraLockPreference | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const candidate = value as Record<string, unknown>;
+  if (!isCameraMode(candidate.mode)) return null;
+  if (typeof candidate.enabled !== 'boolean') return null;
+  return { mode: candidate.mode, enabled: candidate.enabled };
+}
+
+/**
+ * Minimal storage surface so this module works against `window.localStorage`,
+ * a test double, or `undefined` (e.g. SSR / disabled storage).
+ */
+export interface PreferenceStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+/**
+ * Resolve the storage to use. Falls back to `globalThis.localStorage` when
+ * available, otherwise `undefined` so callers degrade to defaults safely.
+ */
+function resolveStorage(storage?: PreferenceStorage): PreferenceStorage | undefined {
+  if (storage) return storage;
+  const globalStorage = (globalThis as { localStorage?: PreferenceStorage }).localStorage;
+  return globalStorage ?? undefined;
+}
+
+/**
+ * Load the persisted camera-lock preference, falling back to
+ * {@link DEFAULT_CAMERA_LOCK_PREFERENCE} for missing, unparseable, or malformed
+ * values. Never throws.
+ */
+export function loadCameraLockPreference(storage?: PreferenceStorage): CameraLockPreference {
+  const store = resolveStorage(storage);
+  if (!store) return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
+
+  let raw: string | null;
+  try {
+    raw = store.getItem(CAMERA_LOCK_PREFERENCE_STORAGE_KEY);
+  } catch {
+    return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
+  }
+  if (raw === null) return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
+  }
+
+  return parseCameraLockPreference(parsed) ?? { ...DEFAULT_CAMERA_LOCK_PREFERENCE };
+}
+
+/**
+ * Persist the camera-lock preference. Swallows storage errors (quota, disabled
+ * storage) so a failed save never breaks the UI. Returns whether the write
+ * succeeded.
+ */
+export function saveCameraLockPreference(
+  preference: CameraLockPreference,
+  storage?: PreferenceStorage,
+): boolean {
+  const store = resolveStorage(storage);
+  if (!store) return false;
+  try {
+    store.setItem(CAMERA_LOCK_PREFERENCE_STORAGE_KEY, JSON.stringify(preference));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Fields required to issue a command; `sequence` is supplied by the issuer. */
+export interface GraphCameraCommandInput {
+  kind: GraphCameraCommandKind;
+  scope: GraphScope;
+  /** Defaults to `null` for whole-graph commands. */
+  target?: string | null;
+  reason: string;
+}
+
+/**
+ * The only object permitted to mint {@link GraphCameraCommand}s. It owns the
+ * monotonic `sequence`, so no selection handler needs an ad hoc counter.
+ */
+export interface GraphCameraCommandIssuer {
+  /** Issue an arbitrary command, incrementing the sequence. */
+  issue(input: GraphCameraCommandInput): GraphCameraCommand;
+  /** Convenience: centre the given target within a scope. */
+  centerSelection(scope: GraphScope, target: string, reason?: string): GraphCameraCommand;
+  /** Convenience: fit the whole graph for an initial view. */
+  fitInitial(scope: GraphScope, reason?: string): GraphCameraCommand;
+  /** The sequence of the most recently issued command (0 before any). */
+  current(): number;
+}
+
+/**
+ * Create a command issuer. Each issuer owns an independent monotonic sequence
+ * starting at 0; the first issued command has `sequence` 1.
+ */
+export function createGraphCameraCommandIssuer(): GraphCameraCommandIssuer {
+  let sequence = 0;
+
+  function issue(input: GraphCameraCommandInput): GraphCameraCommand {
+    sequence += 1;
+    return {
+      kind: input.kind,
+      scope: input.scope,
+      target: input.target ?? null,
+      reason: input.reason,
+      sequence,
+    };
+  }
+
+  return {
+    issue,
+    centerSelection(scope, target, reason = 'centerSelection') {
+      return issue({ kind: 'centerSelection', scope, target, reason });
+    },
+    fitInitial(scope, reason = 'fitInitial') {
+      return issue({ kind: 'fitInitial', scope, target: null, reason });
+    },
+    current() {
+      return sequence;
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Camera lock now drives workflow and task graph centering through typed, one-shot camera commands owned by App.

React Flow viewport state stays local after the first non-empty render, so status refreshes and topology updates preserve user pan and zoom.

Manual pan or wheel zoom temporarily suppresses automatic lock until the next explicit node selection or F1 center command.

The graphSignature remount path and persistent center props are removed from ordinary update paths.

Focused regression tests cover F1 modes, active scope handoff, zoom preservation, manual suppression, and repeated fitView/setCenter prevention.

## Architecture

### Before

```mermaid
graph TD
    App["App<br/>selection handlers"]
    CenterProps["Persistent centerWorkflowId<br/>and centerTaskId props"]
    WorkflowGraph["WorkflowGraph<br/>React Flow viewport"]
    TaskDAG["TaskDAG<br/>React Flow viewport"]
    Refresh["Task and workflow refresh"]
    Signature["graphSignature and<br/>node count effects"]
    Moves["Repeated fitView<br/>or setCenter"]
    User["User pan or zoom"]

    App --> CenterProps
    CenterProps --> WorkflowGraph
    CenterProps --> TaskDAG
    Refresh --> Signature
    Signature --> Moves
    Moves --> WorkflowGraph
    Moves --> TaskDAG
    User --> WorkflowGraph
    User --> TaskDAG
    Moves -. "can override" .-> User
```

### After

```mermaid
graph TD
    App["App<br/>selection, active scope,<br/>camera preference"]
    Preference["Persisted camera lock<br/>preference"]
    Issuer["Graph camera command issuer<br/>monotonic sequence"]
    Command["One-shot centerSelection<br/>command"]
    WorkflowGraph["WorkflowGraph<br/>local React Flow viewport"]
    TaskDAG["TaskDAG<br/>local React Flow viewport"]
    InitialFit["First non-empty render<br/>fitView once"]
    Manual["Manual pan or wheel zoom"]
    Suppression["Temporary lock suppression"]
    Refresh["Status or topology refresh"]
    Preserve["Preserve current camera"]

    Preference --> App
    App --> Issuer
    Issuer --> Command
    Command --> WorkflowGraph
    Command --> TaskDAG
    InitialFit --> WorkflowGraph
    InitialFit --> TaskDAG
    Manual --> Suppression
    Suppression --> App
    Refresh --> Preserve
    Preserve --> WorkflowGraph
    Preserve --> TaskDAG
```

## Test Plan

- [x] `cd packages/ui && pnpm test src/__tests__/graph-camera.test.ts src/__tests__/workflow-graph.test.tsx src/__tests__/task-dag-stability.test.ts src/__tests__/keyboard-controls.test.tsx`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None required.
- Data migration? No