### PR TITLE
Detach lineage Step 2: workflow graph UI

### DIFF
--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1604,6 +1604,70 @@ test.describe('Visual proof capture', () => {
     await captureScreenshot(page, 'stacked-workflows');
   });
 
+  test('detached-workflow-lineage — active edge becomes detached lineage', async ({ page }) => {
+    const upstreamWorkflowId = await loadPlanAndSelectWorkflow(page, {
+      name: 'Detach Upstream Workflow',
+      repoUrl: E2E_REPO_URL,
+      onFinish: 'pull_request' as const,
+      mergeMode: 'external_review',
+      tasks: [
+        { id: 'detach-upstream-task', description: 'Upstream detach prerequisite', command: 'echo upstream', dependencies: [] as string[] },
+      ],
+    });
+
+    const downstreamWorkflowId = await loadPlanAndSelectWorkflow(page, {
+      name: 'Detach Downstream Workflow',
+      repoUrl: E2E_REPO_URL,
+      onFinish: 'pull_request' as const,
+      mergeMode: 'external_review',
+      externalDependencies: [{ workflowId: upstreamWorkflowId, gatePolicy: 'review_ready' as const }],
+      tasks: [
+        { id: 'detach-downstream-task', description: 'Downstream after detachment', command: 'echo downstream', dependencies: [] as string[] },
+      ],
+    });
+
+    await page.getByTestId('selected-workflow-mini-dag').evaluate((element) => {
+      (element as HTMLElement).style.display = 'none';
+    });
+    const minimizeInspector = page.getByRole('button', { name: 'Minimize inspector' });
+    if (await minimizeInspector.isVisible().catch(() => false)) {
+      await minimizeInspector.click();
+      await expect(page.getByRole('button', { name: 'Maximize inspector' })).toBeVisible();
+    }
+    await page.getByRole('button', { name: 'Fit View' }).first().click();
+    await page.waitForTimeout(200);
+
+    await expect(workflowNode(page, upstreamWorkflowId)).toBeInViewport();
+    await expect(workflowNode(page, downstreamWorkflowId)).toBeInViewport();
+    await expect(page.getByTestId(`rf__edge-workflow:active:${upstreamWorkflowId}->${downstreamWorkflowId}`)).toHaveCount(1);
+    await expect(page.getByTestId(`workflow-node-${downstreamWorkflowId}-detached-lineage`)).toHaveCount(0);
+
+    await captureScreenshot(page, 'detached-workflow-lineage-before');
+
+    await page.evaluate(
+      ({ workflowId, upstreamWorkflowId }) => window.invoker.detachWorkflow(workflowId, upstreamWorkflowId),
+      { workflowId: downstreamWorkflowId, upstreamWorkflowId },
+    );
+    await page.getByRole('button', { name: 'Refresh' }).click();
+    await page.waitForFunction(
+      ({ source, target }) => (
+        !document.querySelector(`[data-testid="rf__edge-workflow:active:${source}->${target}"]`)
+        && document.querySelector(`[data-testid="rf__edge-workflow:detached:${source}->${target}"]`)
+        && document.querySelector(`[data-testid="workflow-node-${target}-detached-lineage"]`)
+      ),
+      { source: upstreamWorkflowId, target: downstreamWorkflowId },
+      { timeout: 10000 },
+    );
+    await page.getByRole('button', { name: 'Fit View' }).first().click();
+    await page.waitForTimeout(200);
+
+    await expect(page.getByTestId(`rf__edge-workflow:active:${upstreamWorkflowId}->${downstreamWorkflowId}`)).toHaveCount(0);
+    await expect(page.getByTestId(`rf__edge-workflow:detached:${upstreamWorkflowId}->${downstreamWorkflowId}`)).toHaveCount(1);
+    await expect(page.getByTestId(`workflow-node-${downstreamWorkflowId}-detached-lineage`)).toHaveText('Detached');
+
+    await captureScreenshot(page, 'detached-workflow-lineage-after');
+  });
+
   test('terminate-wording — task-level uses Terminate, workflow-level keeps Cancel', async ({ page }) => {
     await loadPlan(page, TEST_PLAN);
     const now = new Date();

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -395,6 +395,10 @@ export const IpcChannels = {
     request: [workflowId: string];
     response: void;
   },
+  'invoker:detach-workflow': {} as {
+    request: [workflowId: string, upstreamWorkflowId: string];
+    response: void;
+  },
   'invoker:load-workflow': {} as {
     request: [workflowId: string];
     response: { workflow: unknown; tasks: unknown[] };

--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -1263,7 +1263,7 @@ describe('merge gate commit topology (real git)', () => {
 
     const tipMsgI = execSync('git log -1 --format=%s master', { cwd: tmpDir }).toString().trim();
     expect(tipMsgI).toBe('Intermediate Workflow');
-  });
+  }, 60_000);
 
   it('orchestrator.approve() with hook triggers real squash merge into master', async () => {
     const masterHead = execSync('git rev-parse HEAD', { cwd: tmpDir }).toString().trim();
@@ -1394,7 +1394,7 @@ describe('merge gate commit topology (real git)', () => {
       { cwd: tmpDir },
     ).toString().trim().split('\n').filter(l => l.length > 0);
     expect(newCommits.length).toBe(1);
-  });
+  }, 60_000);
 
 });
 

--- a/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
+++ b/packages/ui/src/__tests__/helpers/mock-react-flow.tsx
@@ -67,6 +67,9 @@ export function createReactFlowMock() {
             data-testid={`rf__edge-${edge.id}`}
             data-source={edge.source}
             data-target={edge.target}
+            data-kind={edge.data?.kind}
+            data-stroke-dasharray={edge.style?.strokeDasharray ?? ''}
+            aria-label={edge.ariaLabel}
           />
         ))}
         {nodes.map((node) => {

--- a/packages/ui/src/__tests__/workflow-graph.test.tsx
+++ b/packages/ui/src/__tests__/workflow-graph.test.tsx
@@ -127,6 +127,43 @@ describe('WorkflowGraph', () => {
     expect(screen.getByTestId('mock-react-flow')).toBeInTheDocument();
   });
 
+  it('renders active workflow dependency edges normally', () => {
+    const workflows = new Map([
+      ['wf-a', wf('wf-a', 'review_ready')],
+      [
+        'wf-b',
+        wf('wf-b', 'running', {
+          externalDependencies: [
+            {
+              workflowId: 'wf-a',
+              taskId: '__merge__',
+              requiredStatus: 'completed',
+              gatePolicy: 'completed',
+            },
+          ],
+        }),
+      ],
+    ]);
+
+    render(
+      <WorkflowGraph
+        tasks={new Map()}
+        workflows={workflows}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    const edge = screen.getByTestId('rf__edge-workflow:active:wf-a->wf-b');
+    expect(edge).toHaveAttribute('data-source', 'wf-a');
+    expect(edge).toHaveAttribute('data-target', 'wf-b');
+    expect(edge).toHaveAttribute('data-kind', 'active');
+    expect(edge).toHaveAttribute('data-stroke-dasharray', '');
+    expect(edge).toHaveAccessibleName('Active workflow dependency');
+  });
+
   it('renders dependency-change lineage edges separately from active dependency edges', () => {
     const workflows = new Map([
       ['wf-a', wf('wf-a', 'review_ready')],
@@ -162,6 +199,49 @@ describe('WorkflowGraph', () => {
     const edge = screen.getByTestId('rf__edge-workflow:historical:wf-a->wf-b');
     expect(edge).toHaveAttribute('data-source', 'wf-a');
     expect(edge).toHaveAttribute('data-target', 'wf-b');
+  });
+
+  it('renders detached provenance as detached lineage instead of an orphaned downstream workflow', () => {
+    const workflows = new Map([
+      ['wf-a', wf('wf-a', 'review_ready')],
+      [
+        'wf-b',
+        wf('wf-b', 'running', {
+          detachedExternalDependencies: [
+            {
+              workflowId: 'wf-a',
+              taskId: '__merge__',
+              requiredStatus: 'completed',
+              gatePolicy: 'completed',
+              detachedAt: '2026-01-02T00:00:00.000Z',
+            },
+          ],
+        }),
+      ],
+    ]);
+
+    render(
+      <WorkflowGraph
+        tasks={new Map()}
+        workflows={workflows}
+        selectedWorkflowId={null}
+        statusFilters={new Set()}
+        onSelectWorkflow={() => {}}
+        onWorkflowContextMenu={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId('rf__edge-workflow:active:wf-a->wf-b')).not.toBeInTheDocument();
+    const edge = screen.getByTestId('rf__edge-workflow:detached:wf-a->wf-b');
+    expect(edge).toHaveAttribute('data-source', 'wf-a');
+    expect(edge).toHaveAttribute('data-target', 'wf-b');
+    expect(edge).toHaveAttribute('data-kind', 'detached');
+    expect(edge).toHaveAttribute('data-stroke-dasharray', '5 6');
+    expect(edge).toHaveAccessibleName('Detached workflow lineage');
+
+    const badge = screen.getByTestId('workflow-node-wf-b-detached-lineage');
+    expect(badge).toHaveTextContent('Detached');
+    expect(badge).toHaveAttribute('title', 'Detached from 1 upstream workflow');
   });
 
   it('fits the viewport exactly once on the first non-empty render', async () => {

--- a/packages/ui/src/components/WorkflowGraph.tsx
+++ b/packages/ui/src/components/WorkflowGraph.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import type { MouseEvent } from 'react';
 import type { TaskState, WorkflowMeta, WorkflowStatus } from '../types.js';
 import type { GraphCameraCommand } from '../lib/graph-camera.js';
-import { deriveWorkflowGraph, layoutWorkflowGraph } from '../lib/workflow-graph.js';
+import { deriveWorkflowGraph, layoutWorkflowGraph, type WorkflowGraphEdge } from '../lib/workflow-graph.js';
 import { WorkflowNode } from './WorkflowNode.js';
 import {
   Background,
@@ -45,6 +45,35 @@ interface WorkflowNodeData extends Record<string, unknown> {
 const nodeTypes = {
   workflowNode: WorkflowFlowNode,
 };
+
+function workflowEdgeVisual(kind: WorkflowGraphEdge['kind']): {
+  stroke: string;
+  strokeWidth: number;
+  strokeDasharray?: string;
+  ariaLabel: string;
+} {
+  if (kind === 'detached') {
+    return {
+      stroke: 'rgba(217,119,6,0.58)',
+      strokeWidth: 1.5,
+      strokeDasharray: '5 6',
+      ariaLabel: 'Detached workflow lineage',
+    };
+  }
+  if (kind === 'historical') {
+    return {
+      stroke: 'rgba(245,158,11,0.5)',
+      strokeWidth: 1.5,
+      strokeDasharray: '6 6',
+      ariaLabel: 'Historical workflow dependency',
+    };
+  }
+  return {
+    stroke: 'rgba(148,163,184,0.55)',
+    strokeWidth: 2,
+    ariaLabel: 'Active workflow dependency',
+  };
+}
 
 function WorkflowFlowNode({ data }: NodeProps<Node<WorkflowNodeData>>): JSX.Element {
   return (
@@ -123,27 +152,30 @@ function WorkflowGraphInner({
     return nextNodes;
   }, [graph.nodes, positions, selectedWorkflowId, statusFilters]);
 
-  const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => ({
-    id: `workflow:${edge.kind}:${edge.source}->${edge.target}`,
-    source: edge.source,
-    target: edge.target,
-    type: 'smoothstep',
-    animated: false,
-    style: {
-      stroke: edge.kind === 'historical' ? 'rgba(245,158,11,0.5)' : 'rgba(148,163,184,0.55)',
-      strokeWidth: edge.kind === 'historical' ? 1.5 : 2,
-      strokeDasharray: edge.kind === 'historical' ? '6 6' : undefined,
-    },
-    data: { kind: edge.kind },
-    ariaLabel: edge.kind === 'historical' ? 'Historical workflow dependency' : 'Active workflow dependency',
-    zIndex: 0,
-    markerEnd: {
-      type: MarkerType.ArrowClosed,
-      color: edge.kind === 'historical' ? 'rgba(245,158,11,0.5)' : 'rgba(148,163,184,0.55)',
-      width: 16,
-      height: 16,
-    },
-  })), [graph.edges]);
+  const edges = useMemo<Edge[]>(() => graph.edges.map((edge) => {
+    const visual = workflowEdgeVisual(edge.kind);
+    return {
+      id: `workflow:${edge.kind}:${edge.source}->${edge.target}`,
+      source: edge.source,
+      target: edge.target,
+      type: 'smoothstep',
+      animated: false,
+      style: {
+        stroke: visual.stroke,
+        strokeWidth: visual.strokeWidth,
+        strokeDasharray: visual.strokeDasharray,
+      },
+      data: { kind: edge.kind },
+      ariaLabel: visual.ariaLabel,
+      zIndex: 0,
+      markerEnd: {
+        type: MarkerType.ArrowClosed,
+        color: visual.stroke,
+        width: 16,
+        height: 16,
+      },
+    };
+  }), [graph.edges]);
 
   // First non-empty render fits the whole graph once. React Flow only mounts
   // when there is at least one node (the empty state short-circuits below), so

--- a/packages/ui/src/components/WorkflowNode.tsx
+++ b/packages/ui/src/components/WorkflowNode.tsx
@@ -22,6 +22,7 @@ export function WorkflowNode({
   onContextMenu,
 }: WorkflowNodeProps): JSX.Element {
   const visual = workflowStatusVisual(workflow.status);
+  const detachedDependencyCount = workflow.detachedExternalDependencies?.length ?? 0;
 
   return (
     <div
@@ -48,8 +49,19 @@ export function WorkflowNode({
       {isWorkflowStatusActive(workflow.status) && visual.pulse && (
         <div className={`absolute -left-1 top-1/2 h-2 w-2 -translate-y-1/2 rounded-full ${visual.railClass} animate-ping`} />
       )}
+      {detachedDependencyCount > 0 && (
+        <div
+          data-testid={`workflow-node-${workflow.id}-detached-lineage`}
+          title={`Detached from ${detachedDependencyCount} upstream workflow${detachedDependencyCount === 1 ? '' : 's'}`}
+          className="absolute right-2 top-2 rounded border border-amber-400/35 bg-amber-950/45 px-1.5 py-0.5 text-[9px] font-medium uppercase leading-none text-amber-300"
+        >
+          Detached
+        </div>
+      )}
 
-      <div className="text-[13px] font-semibold text-gray-100 truncate">{workflow.name || workflow.id}</div>
+      <div className={`text-[13px] font-semibold text-gray-100 truncate ${detachedDependencyCount > 0 ? 'pr-16' : ''}`}>
+        {workflow.name || workflow.id}
+      </div>
       <div className="mt-1 text-[11px] text-gray-400 truncate">{workflow.id}</div>
       <div className={`mt-2 text-[10px] uppercase tracking-wide ${visual.textClass}`}>{statusLabel(workflow.status)}</div>
     </div>

--- a/packages/ui/src/lib/workflow-graph.test.ts
+++ b/packages/ui/src/lib/workflow-graph.test.ts
@@ -8,6 +8,7 @@ function makeWorkflow(
   createdAt?: string,
   externalDependencies: WorkflowMeta['externalDependencies'] = [],
   externalDependencyChanges: WorkflowMeta['externalDependencyChanges'] = [],
+  detachedExternalDependencies: WorkflowMeta['detachedExternalDependencies'] = [],
 ): WorkflowMeta {
   return {
     id,
@@ -16,6 +17,7 @@ function makeWorkflow(
     createdAt,
     externalDependencies,
     externalDependencyChanges,
+    detachedExternalDependencies,
   };
 }
 
@@ -132,6 +134,89 @@ describe('deriveWorkflowGraph', () => {
 
     expect(graph.edges).toEqual([
       { source: 'A', target: 'B', kind: 'historical' },
+    ]);
+  });
+
+  it('derives detached provenance as a detached lineage edge', () => {
+    const workflows = new Map([
+      ['A', makeWorkflow('A')],
+      [
+        'B',
+        makeWorkflow('B', 'running', undefined, [], [], [
+          {
+            workflowId: 'A',
+            taskId: '__merge__',
+            requiredStatus: 'completed',
+            gatePolicy: 'completed',
+            detachedAt: '2026-01-02T00:00:00.000Z',
+          },
+        ]),
+      ],
+    ]);
+
+    const graph = deriveWorkflowGraph(workflows, new Map());
+
+    expect(graph.edges).toEqual([
+      { source: 'A', target: 'B', kind: 'detached' },
+    ]);
+  });
+
+  it('keeps active dependency edges authoritative over detached provenance', () => {
+    const activeDependency = {
+      workflowId: 'A',
+      taskId: '__merge__',
+      requiredStatus: 'completed' as const,
+      gatePolicy: 'completed' as const,
+    };
+    const workflows = new Map([
+      ['A', makeWorkflow('A')],
+      [
+        'B',
+        makeWorkflow('B', 'running', undefined, [activeDependency], [], [
+          {
+            ...activeDependency,
+            detachedAt: '2026-01-02T00:00:00.000Z',
+          },
+        ]),
+      ],
+    ]);
+
+    const graph = deriveWorkflowGraph(workflows, new Map());
+
+    expect(graph.edges).toEqual([
+      { source: 'A', target: 'B', kind: 'active' },
+    ]);
+  });
+
+  it('prefers detached provenance over generic dependency-change history', () => {
+    const dependency = {
+      workflowId: 'A',
+      taskId: '__merge__',
+      requiredStatus: 'completed' as const,
+      gatePolicy: 'completed' as const,
+    };
+    const workflows = new Map([
+      ['A', makeWorkflow('A')],
+      [
+        'B',
+        makeWorkflow('B', 'running', undefined, [], [
+          {
+            before: dependency,
+            changedAt: '2026-01-01T00:00:00.000Z',
+          },
+        ], [
+          {
+            ...dependency,
+            detachedAt: '2026-01-02T00:00:00.000Z',
+          },
+        ]),
+      ],
+    ]);
+
+    const graph = deriveWorkflowGraph(workflows, new Map());
+
+    expect(graph.edges).toEqual([
+      { source: 'A', target: 'B', kind: 'detached' },
     ]);
   });
 
@@ -309,6 +394,21 @@ describe('layoutWorkflowGraph', () => {
 
     expect(positions.get('y-target')).toEqual({ x: 180, y: 80 });
     expect(positions.get('x-target')).toEqual({ x: 180, y: 130 });
+  });
+
+  it('uses detached edges to keep former stack relationships grouped', () => {
+    const graph = makeGraph(
+      [
+        makeWorkflow('upstream', 'running', '2026-03-01T00:00:00.000Z'),
+        makeWorkflow('downstream', 'running', '2026-03-01T00:00:00.000Z'),
+      ],
+      [{ source: 'upstream', target: 'downstream', kind: 'detached' }],
+    );
+
+    const positions = layoutWorkflowGraph(graph, 100, 50, 25);
+
+    expect(positions.get('upstream')).toEqual({ x: 80, y: 80 });
+    expect(positions.get('downstream')).toEqual({ x: 180, y: 80 });
   });
 });
 

--- a/packages/ui/src/lib/workflow-graph.ts
+++ b/packages/ui/src/lib/workflow-graph.ts
@@ -10,7 +10,7 @@ export interface WorkflowGraphNode {
 export interface WorkflowGraphEdge {
   source: string;
   target: string;
-  kind: 'active' | 'historical';
+  kind: 'active' | 'historical' | 'detached';
 }
 
 export interface WorkflowGraph {
@@ -77,10 +77,17 @@ export function deriveWorkflowGraph(
         continue;
       }
       if (sourceWorkflowId === targetWorkflowId) continue;
-      const key = `active:${sourceWorkflowId}->${targetWorkflowId}`;
-      if (edgeKeys.has(key)) continue;
-      edgeKeys.add(key);
-      edges.push({ source: sourceWorkflowId, target: targetWorkflowId, kind: 'active' });
+      addWorkflowEdge(edges, edgeKeys, 'active', sourceWorkflowId, targetWorkflowId);
+    }
+    for (const dependency of workflow.detachedExternalDependencies ?? []) {
+      const sourceWorkflowId = dependency.workflowId;
+      if (!workflows.has(sourceWorkflowId)) {
+        missingDependencies.add(`${sourceWorkflowId}->${targetWorkflowId}`);
+        continue;
+      }
+      if (sourceWorkflowId === targetWorkflowId) continue;
+      if (hasWorkflowEdge(edgeKeys, 'active', sourceWorkflowId, targetWorkflowId)) continue;
+      addWorkflowEdge(edges, edgeKeys, 'detached', sourceWorkflowId, targetWorkflowId);
     }
     for (const change of workflow.externalDependencyChanges ?? []) {
       for (const dependency of [change.before, change.after]) {
@@ -91,11 +98,9 @@ export function deriveWorkflowGraph(
           continue;
         }
         if (sourceWorkflowId === targetWorkflowId) continue;
-        if (edgeKeys.has(`active:${sourceWorkflowId}->${targetWorkflowId}`)) continue;
-        const key = `historical:${sourceWorkflowId}->${targetWorkflowId}`;
-        if (edgeKeys.has(key)) continue;
-        edgeKeys.add(key);
-        edges.push({ source: sourceWorkflowId, target: targetWorkflowId, kind: 'historical' });
+        if (hasWorkflowEdge(edgeKeys, 'active', sourceWorkflowId, targetWorkflowId)) continue;
+        if (hasWorkflowEdge(edgeKeys, 'detached', sourceWorkflowId, targetWorkflowId)) continue;
+        addWorkflowEdge(edges, edgeKeys, 'historical', sourceWorkflowId, targetWorkflowId);
       }
     }
   }
@@ -105,6 +110,28 @@ export function deriveWorkflowGraph(
     edges,
     missingDependencies: [...missingDependencies].sort(),
   };
+}
+
+function hasWorkflowEdge(
+  edgeKeys: Set<string>,
+  kind: WorkflowGraphEdge['kind'],
+  sourceWorkflowId: string,
+  targetWorkflowId: string,
+): boolean {
+  return edgeKeys.has(`${kind}:${sourceWorkflowId}->${targetWorkflowId}`);
+}
+
+function addWorkflowEdge(
+  edges: WorkflowGraphEdge[],
+  edgeKeys: Set<string>,
+  kind: WorkflowGraphEdge['kind'],
+  sourceWorkflowId: string,
+  targetWorkflowId: string,
+): void {
+  const key = `${kind}:${sourceWorkflowId}->${targetWorkflowId}`;
+  if (edgeKeys.has(key)) return;
+  edgeKeys.add(key);
+  edges.push({ source: sourceWorkflowId, target: targetWorkflowId, kind });
 }
 
 export function layoutWorkflowGraph(


### PR DESCRIPTION
## Summary

Render detached workflow lineage in the workflow graph instead of leaving downstream workflows visually orphaned.

Detached provenance now appears as a distinct non-active relationship, so it does not look like an active scheduling dependency.

This is stacked on Step 1, which supplies the detached dependency provenance contract.

## Architecture

### Before

```mermaid
graph TD
    W[Workflow metadata] --> D[Graph derivation]
    D --> A[Active dependency edges]
    D --> H[Historical dependency-change edges]
    A --> L[Layout components]
    H --> L
    L --> R[React Flow graph]
    W -. detached provenance ignored .-> O[Orphaned downstream node]
```

### After

```mermaid
graph TD
    W[Workflow metadata] --> D[Graph derivation]
    D --> A[Active dependency edges]
    D --> X[Detached lineage edges]
    D --> H[Historical dependency-change edges]
    A --> P[Edge precedence]
    X --> P
    H --> P
    P --> L[Weak-component layout]
    L --> R[React Flow graph]
    X --> B[Detached node badge]
```

## Test Plan

- [x] `cd packages/ui && pnpm test src/lib/workflow-graph.test.ts src/__tests__/workflow-graph.test.tsx`
- [x] `pnpm run test:all`
- [x] `pnpm --filter @invoker/app test:e2e visual-proof.spec.ts -g "detached-workflow-lineage"`
- [x] `CAPTURE_MODE=after pnpm --filter @invoker/app test:e2e visual-proof.spec.ts -g "detached-workflow-lineage"`

## Visual Proof

Before detachment: the downstream workflow has an active dependency edge and no detached badge.

![Before detachment](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260619-99679c/detached-workflow-lineage-before.png)

After detachment: the edge becomes dashed amber lineage and the downstream workflow shows `DETACHED`.

![After detachment](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260619-99679c/detached-workflow-lineage-after.png)

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert -m 1 bf78271b`
- Post-revert steps: Re-run `pnpm run test:all`.
- Data migration? No
