### PR TITLE
Detach lineage Step 3: guardrails and regression

### DIFF
--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -2777,8 +2777,11 @@ async function headlessDetachWorkflow(
   });
   const result = await deps.commandService.detachWorkflow(envelope);
   if (!result.ok) throw new Error(result.error.message);
+  // Spell out the outcome so automation logs can correlate this mutation with
+  // the detached-lineage provenance recorded on the workflow.
   process.stdout.write(
-    `Detached workflow ${workflowId} from upstream workflow ${upstreamWorkflowId}\n`,
+    `Detached workflow ${workflowId} from upstream workflow ${upstreamWorkflowId}. ` +
+      `Active dependency removed; detached lineage remains visible.\n`,
   );
 }
 

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -126,7 +126,10 @@ interface WorkflowContextMenuProps {
   onRecreateWorkflow: (workflowId: string) => void;
   onCancelWorkflow: (workflowId: string) => void;
   onDeleteWorkflow: (workflowId: string) => void;
+  onDetachWorkflow: (workflowId: string) => void;
   onCopyWorkflowId: (workflowId: string) => void;
+  /** True when this workflow has exactly one upstream dependency that can be detached from the UI. */
+  canDetach: boolean;
   onClose: (options?: ContextMenuCloseOptions) => void;
   autoFocus?: boolean;
 }
@@ -161,7 +164,9 @@ function WorkflowContextMenu({
   onRecreateWorkflow,
   onCancelWorkflow,
   onDeleteWorkflow,
+  onDetachWorkflow,
   onCopyWorkflowId,
+  canDetach,
   onClose,
   autoFocus = false,
 }: WorkflowContextMenuProps): JSX.Element {
@@ -246,6 +251,9 @@ function WorkflowContextMenu({
           { id: 'rebase-recreate', label: 'Rebase and Recreate', className: dangerButtonClass, action: () => runAction(onRebaseRecreate) },
           { id: 'recreate-workflow', label: 'Recreate Workflow', className: dangerButtonClass, action: () => runAction(onRecreateWorkflow) },
           { id: 'cancel-workflow', label: 'Cancel Workflow', className: dangerButtonClass, action: () => runAction(onCancelWorkflow) },
+          ...(canDetach
+            ? [{ id: 'detach-workflow', label: 'Detach Upstream Workflow', className: dangerButtonClass, action: () => runAction(onDetachWorkflow) }]
+            : []),
           { id: 'delete-workflow', label: 'Delete Workflow', className: dangerButtonClass, action: () => runAction(onDeleteWorkflow) },
         ]),
   ];
@@ -421,6 +429,8 @@ export function App() {
   const [terminalSessions, setTerminalSessions] = useState<TerminalSessionDescriptor[]>([]);
   const [activeTerminalSessionId, setActiveTerminalSessionId] = useState<string | null>(null);
   const [workflowContextMenu, setWorkflowContextMenu] = useState<WorkflowContextMenuState | null>(null);
+  // Transient, user-visible outcome line for a confirmed workflow detach.
+  const [detachNotice, setDetachNotice] = useState<string | null>(null);
   const [keyboardRegion, setKeyboardRegion] = useState<KeyboardRegion>('workflowGraph');
   const [previousGraphRegion, setPreviousGraphRegion] = useState<KeyboardRegion>('workflowGraph');
   // Typed graph camera state. The graph viewport is user-owned after the
@@ -1396,6 +1406,39 @@ export function App() {
     }
   }, [refreshTaskGraph, selectedWorkflowId]);
 
+  const handleDetachWorkflow = useCallback(async (workflowId: string) => {
+    setWorkflowContextMenu(null);
+    const workflow = workflows.get(workflowId);
+    const deps = workflow?.externalDependencies ?? [];
+    // UI detach targets a single upstream edge so the confirmation can name
+    // both endpoints. Multi-upstream detach stays on the headless/API surface.
+    if (deps.length !== 1) return;
+    const upstreamWorkflowId = deps[0].workflowId;
+    const downstreamName = workflow?.name ?? workflowId;
+    const upstreamName = workflows.get(upstreamWorkflowId)?.name ?? upstreamWorkflowId;
+    const confirmed = window.confirm(
+      `Detach "${downstreamName}" from upstream "${upstreamName}"?\n\n` +
+      `This removes the active dependency so "${downstreamName}" no longer waits on "${upstreamName}". ` +
+      `The detached lineage stays visible in the graph. Neither workflow is deleted.`,
+    );
+    if (!confirmed) return;
+    try {
+      await window.invoker?.detachWorkflow(workflowId, upstreamWorkflowId);
+      setDetachNotice(
+        `Detached "${downstreamName}" from upstream "${upstreamName}". The active dependency was removed; detached lineage remains visible.`,
+      );
+      refreshTaskGraph();
+    } catch (err) {
+      console.error('Detach Workflow failed:', err);
+    }
+  }, [workflows, refreshTaskGraph]);
+
+  useEffect(() => {
+    if (!detachNotice) return;
+    const timer = setTimeout(() => setDetachNotice(null), 6000);
+    return () => clearTimeout(timer);
+  }, [detachNotice]);
+
   const handleFix = useCallback(async (taskId: string, agentName: string) => {
     setContextMenu(null);
     const task = tasks.get(taskId);
@@ -2199,10 +2242,23 @@ export function App() {
           onRecreateWorkflow={(workflowId) => void handleRecreateWorkflow(workflowId)}
           onCancelWorkflow={(workflowId) => void handleCancelWorkflow(workflowId)}
           onDeleteWorkflow={(workflowId) => void handleDeleteWorkflow(workflowId)}
+          onDetachWorkflow={(workflowId) => void handleDetachWorkflow(workflowId)}
+          canDetach={(workflows.get(workflowContextMenu.workflowId)?.externalDependencies?.length ?? 0) === 1}
           onCopyWorkflowId={handleCopyWorkflowId}
           onClose={closeContextMenu}
           autoFocus={Boolean(workflowContextMenu.returnFocusRegion)}
         />
+      )}
+
+      {detachNotice && (
+        <div
+          role="status"
+          aria-live="polite"
+          data-testid="detach-feedback"
+          className="fixed bottom-4 left-1/2 z-50 -translate-x-1/2 rounded-md border border-gray-600 bg-gray-800 px-4 py-2 text-sm text-gray-100 shadow-xl"
+        >
+          {detachNotice}
+        </div>
       )}
 
       {contextMenu && contextMenuTask && (

--- a/packages/ui/src/__tests__/context-menu-e2e.test.tsx
+++ b/packages/ui/src/__tests__/context-menu-e2e.test.tsx
@@ -278,6 +278,92 @@ describe('Context menu (component)', () => {
     await waitFor(() => expect(mock.api.deleteWorkflow).toHaveBeenCalledWith('wf-1'));
   });
 
+  describe('workflow detach', () => {
+    const upTask = makeUITask({
+      id: 'task-up',
+      description: 'Upstream task',
+      status: 'completed',
+      command: 'echo up',
+      workflowId: 'wf-up',
+    });
+    const downTask = makeUITask({
+      id: 'task-down',
+      description: 'Downstream task',
+      status: 'pending',
+      command: 'echo down',
+      workflowId: 'wf-down',
+    });
+    const stackWorkflows: WorkflowMeta[] = [
+      { id: 'wf-up', name: 'Upstream Workflow', status: 'running', baseBranch: 'master' },
+      {
+        id: 'wf-down',
+        name: 'Downstream Workflow',
+        status: 'running',
+        baseBranch: 'master',
+        externalDependencies: [{ workflowId: 'wf-up', requiredStatus: 'completed' }],
+      },
+    ];
+
+    async function setupStack() {
+      render(<App />);
+      act(() => mock.setTasks([upTask, downTask], stackWorkflows));
+      await waitFor(() => {
+        expect(screen.getByTestId('workflow-node-wf-down')).toBeInTheDocument();
+      });
+    }
+
+    it('offers detach for a workflow with a single upstream dependency', async () => {
+      await setupStack();
+
+      fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-down'));
+      fireEvent.click(await screen.findByText('More'));
+      expect(await screen.findByText('Detach Upstream Workflow')).toBeInTheDocument();
+    });
+
+    it('hides detach for a workflow with no upstream dependency', async () => {
+      await setupStack();
+
+      fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-up'));
+      fireEvent.click(await screen.findByText('More'));
+      expect(screen.queryByText('Detach Upstream Workflow')).not.toBeInTheDocument();
+    });
+
+    it('confirms naming both workflows, then detaches once and shows feedback', async () => {
+      const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+      await setupStack();
+
+      fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-down'));
+      fireEvent.click(await screen.findByText('More'));
+      fireEvent.click(await screen.findByText('Detach Upstream Workflow'));
+
+      await waitFor(() =>
+        expect(mock.api.detachWorkflow).toHaveBeenCalledWith('wf-down', 'wf-up'),
+      );
+      expect(mock.api.detachWorkflow).toHaveBeenCalledTimes(1);
+
+      const confirmMessage = confirmSpy.mock.calls.at(-1)?.[0] as string;
+      expect(confirmMessage).toContain('Downstream Workflow');
+      expect(confirmMessage).toContain('Upstream Workflow');
+
+      const feedback = await screen.findByTestId('detach-feedback');
+      expect(feedback).toHaveTextContent('Downstream Workflow');
+      expect(feedback).toHaveTextContent('Upstream Workflow');
+    });
+
+    it('does not detach when the confirmation is cancelled', async () => {
+      vi.spyOn(window, 'confirm').mockReturnValue(false);
+      await setupStack();
+
+      fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-down'));
+      fireEvent.click(await screen.findByText('More'));
+      fireEvent.click(await screen.findByText('Detach Upstream Workflow'));
+
+      await waitFor(() => expect(window.confirm).toHaveBeenCalled());
+      expect(mock.api.detachWorkflow).not.toHaveBeenCalled();
+      expect(screen.queryByTestId('detach-feedback')).not.toBeInTheDocument();
+    });
+  });
+
   it('workflow context menu copies workflow id', async () => {
     await setup();
     fireEvent.contextMenu(screen.getByTestId('workflow-node-wf-1'));

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -180,6 +180,7 @@ export function createMockInvoker(
     deleteAllWorkflows: vi.fn(async () => {}),
     deleteAllWorkflowsBulk: vi.fn(async () => {}),
     deleteWorkflow: vi.fn(async () => {}),
+    detachWorkflow: vi.fn(async () => {}),
     cleanupWorktrees: vi.fn(async () => ({ removed: [], errors: [] })),
     recreateWorkflow: vi.fn(async () => {}),
     recreateTask: vi.fn(async () => {}),

--- a/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
+++ b/packages/ui/src/__tests__/visual-proof-snapshots.test.tsx
@@ -71,6 +71,65 @@ describe('Visual proof snapshots', () => {
     });
   });
 
+  it('detached-lineage graph state — detached marker distinct from active dependency edge', async () => {
+    // Deterministic fixture: one shared upstream workflow with two downstreams —
+    // one still actively depending on it, one explicitly detached. Proves the
+    // detached lineage renders as a distinct dashed edge + badge, not as an
+    // active solid edge.
+    const workflows: WorkflowMeta[] = [
+      { id: 'wf-up', name: 'Upstream', status: 'completed' },
+      {
+        id: 'wf-active',
+        name: 'Active downstream',
+        status: 'running',
+        externalDependencies: [{ workflowId: 'wf-up', requiredStatus: 'completed' }],
+      },
+      {
+        id: 'wf-detached',
+        name: 'Detached downstream',
+        status: 'running',
+        detachedExternalDependencies: [
+          {
+            workflowId: 'wf-up',
+            taskId: '__merge__',
+            requiredStatus: 'completed',
+            gatePolicy: 'completed',
+            detachedAt: '2026-01-02T00:00:00.000Z',
+          },
+        ],
+      },
+    ];
+    const upstream = makeUITask({ id: 'task-up', description: 'Upstream task', status: 'completed', workflowId: 'wf-up' });
+    const active = makeUITask({ id: 'task-active', description: 'Active downstream task', status: 'running', workflowId: 'wf-active' });
+    const detached = makeUITask({ id: 'task-detached', description: 'Detached downstream task', status: 'running', workflowId: 'wf-detached' });
+
+    render(<App />);
+    act(() => mock.setTasks([upstream, active, detached], workflows));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('workflow-node-wf-active')).toBeInTheDocument();
+      expect(screen.getByTestId('workflow-node-wf-detached')).toBeInTheDocument();
+    });
+
+    // Active dependency: solid edge (no dash), distinct accessible name.
+    const activeEdge = screen.getByTestId('rf__edge-workflow:active:wf-up->wf-active');
+    expect(activeEdge).toHaveAttribute('data-kind', 'active');
+    expect(activeEdge).toHaveAttribute('data-stroke-dasharray', '');
+    expect(activeEdge).toHaveAccessibleName('Active workflow dependency');
+
+    // Detached lineage: dashed edge, distinct kind + accessible name.
+    const detachedEdge = screen.getByTestId('rf__edge-workflow:detached:wf-up->wf-detached');
+    expect(detachedEdge).toHaveAttribute('data-kind', 'detached');
+    expect(detachedEdge).toHaveAttribute('data-stroke-dasharray', '5 6');
+    expect(detachedEdge).toHaveAccessibleName('Detached workflow lineage');
+
+    // The detached downstream carries the "Detached" badge; the active one does not.
+    const badge = screen.getByTestId('workflow-node-wf-detached-detached-lineage');
+    expect(badge).toHaveTextContent('Detached');
+    expect(badge).toHaveAttribute('title', 'Detached from 1 upstream workflow');
+    expect(screen.queryByTestId('workflow-node-wf-active-detached-lineage')).not.toBeInTheDocument();
+  });
+
   it('workflow and task context menus render', async () => {
     const workflows: WorkflowMeta[] = [{ id: 'wf-alpha', name: 'Alpha', status: 'running' }];
     const alpha = makeUITask({ id: 'task-alpha', description: 'First test task', status: 'running', workflowId: 'wf-alpha' });


### PR DESCRIPTION
## Summary

Detach actions now require explicit confirmation before changing workflow topology.

Successful detach calls now produce visible UI feedback and clearer headless/API output that names both workflows.

Snapshot coverage now checks that active dependencies and detached lineage remain visually distinct.

## Review Claim

Approve adding explicit detach confirmation and outcome feedback across the user and headless command surfaces.

## Review Lane

behavior

## Review Unit

activation-surface

## Safety Invariant

The detach mutation remains the same existing operation, and scheduling semantics are unchanged.

Automation still reaches the API and headless detach entry points without any interactive UI requirement.

## Slice Rationale

This final slice belongs after lineage recording and graph presentation, so the detach action can name what it is changing.

It keeps the user-facing guardrails together with the command feedback reviewers need to audit the operation.

## Non-goals

This does not change detach scheduling semantics.

This does not remove API or headless automation support for detach.

This does not change detached-lineage persistence or recovery behavior.

## Architecture

### Before

```mermaid
graph TD
    UI[Workflow context menu] --> Mutation[detachWorkflow mutation]
    CLI[Headless/API callers] --> Mutation
    Mutation --> Graph[Workflow graph refresh]
    Graph --> Silent[Topology changes without explicit outcome feedback]
```

### After

```mermaid
graph TD
    UI[Workflow context menu] --> Confirm[Confirmation names downstream and upstream]
    Confirm --> Mutation[Same detachWorkflow mutation]
    CLI[Headless/API callers] --> Mutation
    Mutation --> Feedback[UI status, API message, and headless output]
    Feedback --> Graph[Workflow graph refresh with detached lineage visible]
```

## Test Plan

- [x] `cd packages/ui && pnpm test src/__tests__/context-menu-e2e.test.tsx src/__tests__/workflow-graph.test.tsx src/__tests__/visual-proof-snapshots.test.tsx`
- [x] `pnpm run test:all`

## Visual Proof

This PR adds a UI surface for the existing detach operation: a guarded context-menu action plus outcome feedback. The detached-lineage edge and `DETACHED` chip in the graph already exist on `master`; what is new here is how a user triggers detach and the confirmation/feedback around it.

<details open>
<summary>New "Detach Upstream Workflow" context-menu action</summary>

Appears only when the workflow has exactly one detachable upstream dependency. Selecting it opens a confirmation dialog that names both workflows before any change.

![detach context menu item](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260624-f1ff59/detach-context-menu-item.png)

</details>

<details open>
<summary>Confirmation outcome feedback</summary>

After the user confirms, a transient toast names both workflows and the result.

![detach confirmation feedback](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260624-f1ff59/detach-confirmation-feedback.png)

</details>

<details>
<summary>Video walkthrough</summary>

- [Detach guardrail walkthrough (webm)](https://pub-cf646cda2bd945d683792ee19b5f9d98.r2.dev/pr-images/20260624-f1ff59/detach-guardrail-walkthrough.webm)

</details>

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert a584f59de`
- Post-revert steps: Re-run `pnpm run test:all` after reverting.
- Data migration? No

