### PR TITLE
test(dispatch): add launch queue handoff repro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
             command: bash scripts/test-suites/required/18-start-running-mece-repros.sh
           - name: Task New Attempt Reset Repro
             command: bash scripts/test-suites/required/19-task-new-attempt-reset-repro.sh
+          - name: Launch Dispatch Queue Repro
+            command: bash scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh
 
     name: required-fast / ${{ matrix.name }}
 

--- a/scripts/repro/compiled-workspace-loader.mjs
+++ b/scripts/repro/compiled-workspace-loader.mjs
@@ -1,0 +1,22 @@
+import { dirname, join, resolve as resolvePath } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolvePath(__dirname, '../..');
+
+const redirects = new Map([
+  ['@invoker/workflow-graph', join(root, 'packages/workflow-graph/dist/index.js')],
+  ['@invoker/contracts', join(root, 'packages/contracts/dist/index.js')],
+  ['@invoker/workflow-core', join(root, 'packages/workflow-core/dist/index.js')],
+]);
+
+export async function resolve(specifier, context, nextResolve) {
+  const redirected = redirects.get(specifier);
+  if (redirected) {
+    return {
+      url: pathToFileURL(redirected).href,
+      shortCircuit: true,
+    };
+  }
+  return nextResolve(specifier, context);
+}

--- a/scripts/repro/repro-launch-dispatch-queue-handoff.mjs
+++ b/scripts/repro/repro-launch-dispatch-queue-handoff.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '../..');
+const distPath = join(root, 'packages/data-store/dist/index.js');
+const { SQLiteAdapter } = await import(pathToFileURL(distPath).href);
+
+const tempDir = mkdtempSync(join(tmpdir(), 'invoker-launch-dispatch-repro-'));
+const dbPath = join(tempDir, 'invoker.db');
+const workflowId = 'wf-launch-dispatch-repro';
+const nowIso = '2026-06-04T00:00:00.000Z';
+const expiredIso = '2026-06-03T23:59:00.000Z';
+const targetTaskId = `${workflowId}/target`;
+const targetAttemptId = `${targetTaskId}-attempt`;
+
+let adapter;
+
+function fail(message) {
+  throw new Error(`[launch-dispatch-repro] ${message}`);
+}
+
+function makeTask(id, attemptId, status = 'pending', generation = 0) {
+  return {
+    id,
+    description: id,
+    status,
+    dependencies: [],
+    createdAt: new Date(nowIso),
+    config: { workflowId },
+    execution: { selectedAttemptId: attemptId, generation, phase: 'launching' },
+    taskStateVersion: 1,
+  };
+}
+
+function saveTask(id, attemptId, status = 'pending', generation = 0) {
+  adapter.saveTask(workflowId, makeTask(id, attemptId, status, generation));
+  adapter.updateTask(id, {
+    status,
+    execution: { selectedAttemptId: attemptId, generation, phase: 'launching' },
+  });
+}
+
+function scalar(sql) {
+  const result = adapter.db.exec(sql);
+  return Number(result[0]?.values?.[0]?.[0] ?? 0);
+}
+
+try {
+  adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+  adapter.saveWorkflow({
+    id: workflowId,
+    name: 'launch dispatch queue handoff repro',
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  });
+
+  for (let i = 0; i < 12; i += 1) {
+    const taskId = `${workflowId}/legacy-${i}`;
+    const currentAttemptId = `${taskId}-current`;
+    const staleAttemptId = `${taskId}-stale`;
+    saveTask(taskId, currentAttemptId, 'pending', 1);
+    const row = adapter.enqueueLaunchDispatch({
+      taskId,
+      attemptId: staleAttemptId,
+      workflowId,
+      generation: 0,
+    });
+    adapter.db.run(
+      `UPDATE task_launch_dispatch
+          SET state = 'acknowledged',
+              dispatch_owner = 'old-owner',
+              leased_at = ?,
+              acknowledged_at = ?,
+              fenced_until = ?,
+              attempts_count = 1
+        WHERE id = ?`,
+      [expiredIso, expiredIso, expiredIso, row.id],
+    );
+  }
+
+  saveTask(targetTaskId, targetAttemptId, 'pending', 0);
+  const target = adapter.enqueueLaunchDispatch({
+    taskId: targetTaskId,
+    attemptId: targetAttemptId,
+    workflowId,
+    generation: 0,
+  });
+
+  const report = adapter.runCompatibilityMigration();
+  const legacyAckCount = scalar(
+    `SELECT COUNT(*) AS count FROM task_launch_dispatch WHERE state = 'acknowledged'`,
+  );
+  if (legacyAckCount !== 0) {
+    fail(
+      `compatibility migration left ${legacyAckCount} acknowledged row(s); ` +
+        `report=${JSON.stringify(report)}`,
+    );
+  }
+
+  const targetAfterMigration = adapter.loadLaunchDispatchById(target.id);
+  if (targetAfterMigration?.state !== 'enqueued') {
+    fail(`target dispatch should remain enqueued, got ${targetAfterMigration?.state ?? 'missing'}`);
+  }
+
+  const leased = adapter.claimLaunchDispatchAtomic({
+    ownerId: 'repro-owner',
+    nowIso,
+  });
+  if (!leased) {
+    fail('claimLaunchDispatchAtomic returned undefined while target row was enqueued');
+  }
+  if (leased.id !== target.id) {
+    fail(`expected to lease target dispatch ${target.id}, leased ${leased.id}`);
+  }
+  if (leased.state !== 'leased') {
+    fail(`expected leased target state, got ${leased.state}`);
+  }
+
+  const abandonedLegacyCount = scalar(
+    `SELECT COUNT(*) AS count FROM task_launch_dispatch WHERE state = 'abandoned'`,
+  );
+  if (abandonedLegacyCount !== 12) {
+    fail(`expected 12 abandoned legacy rows, got ${abandonedLegacyCount}`);
+  }
+
+  console.log('[launch-dispatch-repro] passed');
+} finally {
+  adapter?.close();
+  rmSync(tempDir, { recursive: true, force: true });
+}

--- a/scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh
+++ b/scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Standalone regression proof for stale launch-dispatch acknowledgements blocking queued work.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+ensure_built() {
+  local package_name="$1"
+  local package_dir="$2"
+  if [ ! -f "$package_dir/dist/index.js" ] ||
+    find "$package_dir/src" -type f -newer "$package_dir/dist/index.js" | grep -q .; then
+    pnpm --filter "$package_name" build
+  fi
+}
+
+ensure_built @invoker/workflow-graph "$ROOT/packages/workflow-graph"
+ensure_built @invoker/contracts "$ROOT/packages/contracts"
+ensure_built @invoker/workflow-core "$ROOT/packages/workflow-core"
+ensure_built @invoker/data-store "$ROOT/packages/data-store"
+
+exec node \
+  --loader "$ROOT/scripts/repro/compiled-workspace-loader.mjs" \
+  "$ROOT/scripts/repro/repro-launch-dispatch-queue-handoff.mjs"


### PR DESCRIPTION
## Summary

Adds a compiled-workspace repro for launch queue handoff.

The required CI matrix now protects stale launch-dispatch compatibility behavior.

## Test Plan

- [x] `mergify stack push -t upstream/master --branch-prefix stack/EdbertChan`
- [x] `mergify stack list -t upstream/master --json`
- [ ] `bash scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 676d5aa67c223c5c7e9ad1c3f568e46761d7c464`
- Post-revert steps: Re-run the affected retry/repro validation if reverting after landing.
- Data migration? No

Depends-On: #1102