### PR TITLE
Prevent macOS Electron restore modal

### DIFF
--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -202,6 +202,23 @@ function withLinuxSandboxFallback(binaryPath, args) {
   return ['--no-sandbox', ...args];
 }
 
+function withMacOSPersistenceIgnoreState(args) {
+  if (process.platform !== 'darwin') {
+    return args;
+  }
+  if (args.includes('-ApplePersistenceIgnoreState')) {
+    return args;
+  }
+
+  // AppKit can show a blocking "reopen windows?" crash-recovery modal before
+  // Electron runs our JS, which also stalls headless CLI invocations.
+  //
+  // Keep Electron's app path as argv[1]; putting this flag before the script
+  // prevents Electron from loading dist/main.js.
+  const insertAt = args.length > 0 ? 1 : 0;
+  return [...args.slice(0, insertAt), '-ApplePersistenceIgnoreState', 'YES', ...args.slice(insertAt)];
+}
+
 async function main() {
   const args = process.argv.slice(2);
 
@@ -216,7 +233,7 @@ async function main() {
     return;
   }
 
-  const launchArgs = withLinuxSandboxFallback(binaryPath, args);
+  const launchArgs = withMacOSPersistenceIgnoreState(withLinuxSandboxFallback(binaryPath, args));
   const child = spawn(binaryPath, launchArgs, {
     cwd: process.cwd(),
     env: process.env,


### PR DESCRIPTION
## Summary

Disables the macOS Electron restore modal for this app launcher.

Startup no longer stalls on the system restore prompt after abnormal termination.

## Test Plan

- [x] `mergify stack push -t upstream/master --branch-prefix stack/EdbertChan`
- [x] `mergify stack list -t upstream/master --json`
- [ ] `node scripts/electron.cjs --help`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 52ca5fb4d1d4a406f2428f352d8d50b1e2a33412`
- Post-revert steps: Re-run the affected retry/repro validation if reverting after landing.
- Data migration? No

Depends-On: #1104