### PR TITLE
fix(app): wait for owner launch handoff in no-track retries

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -912,6 +912,284 @@ describe('headless delegation enforcement', () => {
         expect(runnable[0]?.id).toBe('wf-1/task-1');
       });
 
+      it('headless workflow retry in no-track active outbox mode waits for owner launch handoff before returning', async () => {
+        const preemptWorkflowExecution = vi.fn(async () => ({ cancelled: [], runningCancelled: [] }));
+        const runnableTask = {
+          id: 'wf-1/task-1',
+          description: 'ready launch',
+          status: 'pending',
+          dependencies: [],
+          config: { workflowId: 'wf-1', runnerKind: 'worktree' },
+          execution: { selectedAttemptId: 'attempt-1', generation: 7, phase: 'launching' },
+        } as any;
+        mockDeps.invokerConfig = {
+          ...mockDeps.invokerConfig,
+          launchOutboxMode: 'active',
+          defaultBranch: 'main',
+        } as any;
+        mockDeps.commandService.retryWorkflow = vi.fn(async () => ({
+          ok: true as const,
+          data: [runnableTask],
+        }));
+        mockDeps.orchestrator.startExecution = vi.fn(() => []);
+        mockDeps.orchestrator.syncFromDb = vi.fn();
+        mockDeps.orchestrator.getTask = vi.fn((taskId: string) =>
+          taskId === runnableTask.id ? runnableTask : undefined,
+        );
+        mockDeps.orchestrator.getTaskLaunchReadiness = vi.fn((taskId: string) =>
+          taskId === runnableTask.id
+            ? { ready: true as const, task: runnableTask }
+            : { ready: false as const, reason: 'missing' },
+        );
+
+        let claimed = false;
+        const launchDispatch = {
+          id: 42,
+          taskId: runnableTask.id,
+          attemptId: 'attempt-1',
+          workflowId: 'wf-1',
+          state: 'leased',
+          priority: 'normal',
+          generation: 7,
+          enqueuedAt: new Date().toISOString(),
+          attemptsCount: 1,
+        };
+        let activeDispatches = [launchDispatch];
+        Object.assign(mockDeps.persistence as any, {
+          reapExpiredLaunchDispatchLeases: vi.fn(() => []),
+          listAbandonableLaunchDispatchLeases: vi.fn(() => []),
+          claimLaunchDispatchAtomic: vi.fn(() => {
+            if (claimed) return undefined;
+            claimed = true;
+            return launchDispatch;
+          }),
+          listLaunchDispatchesByState: vi.fn(() => activeDispatches),
+          markLaunchDispatchCompleted: vi.fn(() => {
+            activeDispatches = [];
+            return true;
+          }),
+          markLaunchDispatchFailed: vi.fn(() => true),
+          markLaunchDispatchAbandoned: vi.fn(() => true),
+          listExecutionResourceLeasesByTask: vi.fn(() => []),
+          releaseExecutionResourceLease: vi.fn(),
+          logEvent: vi.fn(),
+        });
+
+        let capturedDispatchOpts: any;
+        const executeTask = vi.fn(async (_task: any, dispatchOpts?: any) => {
+          capturedDispatchOpts = dispatchOpts;
+          return new Promise<void>(() => {});
+        });
+        const deferRunnableTasks = vi.fn();
+        const depsWithNoTrack: HeadlessDeps = {
+          ...mockDeps,
+          noTrack: true,
+          preemptWorkflowExecution,
+          deferRunnableTasks,
+          ownerTaskRunnerProvider: () => ({ executeTask } as any),
+        } as HeadlessDeps;
+
+        let resolved = false;
+        const runPromise = runHeadless(['retry', 'wf-1'], depsWithNoTrack).then(() => {
+          resolved = true;
+        });
+
+        await vi.waitFor(() => expect(executeTask).toHaveBeenCalledTimes(1));
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(resolved).toBe(false);
+
+        capturedDispatchOpts?.launchOutbox.completeDispatch(capturedDispatchOpts.dispatchId);
+        await runPromise;
+
+        expect((mockDeps.persistence as any).claimLaunchDispatchAtomic).toHaveBeenCalled();
+        expect(executeTask.mock.calls[0]?.[0]?.id).toBe('wf-1/task-1');
+        expect(deferRunnableTasks).not.toHaveBeenCalled();
+        expect((mockDeps.persistence as any).markLaunchDispatchCompleted).toHaveBeenCalledWith(42);
+      });
+
+      it('headless task retry in no-track active outbox mode waits for owner launch handoff before returning', async () => {
+        const preemptTaskSubgraph = vi.fn(async () => {});
+        const runnableTask = {
+          id: 'wf-1/task-1',
+          description: 'ready launch',
+          status: 'pending',
+          dependencies: [],
+          config: { workflowId: 'wf-1', runnerKind: 'worktree' },
+          execution: { selectedAttemptId: 'attempt-1', generation: 9, phase: 'launching' },
+        } as any;
+        mockDeps.invokerConfig = {
+          ...mockDeps.invokerConfig,
+          launchOutboxMode: 'active',
+          defaultBranch: 'main',
+        } as any;
+        mockDeps.orchestrator.getPersistedActiveTaskIds = vi.fn(() => new Set<string>());
+        mockDeps.orchestrator.syncFromDb = vi.fn();
+        mockDeps.persistence.listWorkflows = vi.fn(() => [{
+          id: 'wf-1',
+          name: 'Workflow one',
+          generation: 0,
+          status: 'running' as const,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }]);
+        mockDeps.persistence.loadTasks = vi.fn(() => [{
+          id: 'wf-1/task-1',
+          status: 'failed',
+          config: { workflowId: 'wf-1' },
+          execution: {},
+        } as any]);
+        mockDeps.commandService.retryTask = vi.fn(async () => ({
+          ok: true as const,
+          data: [runnableTask],
+        }));
+        mockDeps.orchestrator.startExecution = vi.fn(() => []);
+        mockDeps.orchestrator.getTask = vi.fn((taskId: string) =>
+          taskId === runnableTask.id ? runnableTask : undefined,
+        );
+        mockDeps.orchestrator.getTaskLaunchReadiness = vi.fn((taskId: string) =>
+          taskId === runnableTask.id
+            ? { ready: true as const, task: runnableTask }
+            : { ready: false as const, reason: 'missing' },
+        );
+
+        let claimed = false;
+        const launchDispatch = {
+          id: 77,
+          taskId: runnableTask.id,
+          attemptId: 'attempt-1',
+          workflowId: 'wf-1',
+          state: 'leased',
+          priority: 'normal',
+          generation: 9,
+          enqueuedAt: new Date().toISOString(),
+          attemptsCount: 1,
+        };
+        let activeDispatches = [launchDispatch];
+        Object.assign(mockDeps.persistence as any, {
+          reapExpiredLaunchDispatchLeases: vi.fn(() => []),
+          listAbandonableLaunchDispatchLeases: vi.fn(() => []),
+          claimLaunchDispatchAtomic: vi.fn(() => {
+            if (claimed) return undefined;
+            claimed = true;
+            return launchDispatch;
+          }),
+          listLaunchDispatchesByState: vi.fn(() => activeDispatches),
+          markLaunchDispatchCompleted: vi.fn(() => {
+            activeDispatches = [];
+            return true;
+          }),
+          markLaunchDispatchFailed: vi.fn(() => true),
+          markLaunchDispatchAbandoned: vi.fn(() => true),
+          listExecutionResourceLeasesByTask: vi.fn(() => []),
+          releaseExecutionResourceLease: vi.fn(),
+          logEvent: vi.fn(),
+        });
+
+        let capturedDispatchOpts: any;
+        const executeTask = vi.fn(async (_task: any, dispatchOpts?: any) => {
+          capturedDispatchOpts = dispatchOpts;
+          return new Promise<void>(() => {});
+        });
+        const deferRunnableTasks = vi.fn();
+        const depsWithNoTrack: HeadlessDeps = {
+          ...mockDeps,
+          noTrack: true,
+          preemptTaskSubgraph,
+          deferRunnableTasks,
+          ownerTaskRunnerProvider: () => ({ executeTask } as any),
+        } as HeadlessDeps;
+
+        let resolved = false;
+        const runPromise = runHeadless(['retry-task', 'wf-1/task-1'], depsWithNoTrack).then(() => {
+          resolved = true;
+        });
+
+        await vi.waitFor(() => expect(executeTask).toHaveBeenCalledTimes(1));
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(resolved).toBe(false);
+
+        capturedDispatchOpts?.launchOutbox.completeDispatch(capturedDispatchOpts.dispatchId);
+        await runPromise;
+
+        expect((mockDeps.persistence as any).claimLaunchDispatchAtomic).toHaveBeenCalled();
+        expect(executeTask.mock.calls[0]?.[0]?.id).toBe('wf-1/task-1');
+        expect(deferRunnableTasks).not.toHaveBeenCalled();
+        expect((mockDeps.persistence as any).markLaunchDispatchCompleted).toHaveBeenCalledWith(77);
+      });
+
+      it('headless task retry in no-track active outbox mode rejects transient launch ownership', async () => {
+        const preemptTaskSubgraph = vi.fn(async () => {});
+        const runnableTask = {
+          id: '__merge__wf-1778826126740-7',
+          description: 'Review gate for Fix build warning noise',
+          status: 'pending',
+          dependencies: ['wf-1778826126740-7/regression-test-all'],
+          config: { workflowId: 'wf-1778826126740-7', runnerKind: 'merge', isMergeNode: true },
+          execution: {
+            selectedAttemptId: '__merge__wf-1778826126740-7-a9e08b36d',
+            generation: 91,
+            phase: 'launching',
+          },
+        } as any;
+        mockDeps.invokerConfig = {
+          ...mockDeps.invokerConfig,
+          launchOutboxMode: 'active',
+          defaultBranch: 'master',
+        } as any;
+        mockDeps.orchestrator.getPersistedActiveTaskIds = vi.fn(() => new Set<string>());
+        mockDeps.orchestrator.syncFromDb = vi.fn();
+        mockDeps.persistence.listWorkflows = vi.fn(() => [{
+          id: 'wf-1778826126740-7',
+          name: 'Fix build warning noise',
+          generation: 73,
+          status: 'running' as const,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }]);
+        mockDeps.persistence.loadTasks = vi.fn(() => [{
+          id: runnableTask.id,
+          status: 'failed',
+          config: { workflowId: 'wf-1778826126740-7', isMergeNode: true, runnerKind: 'merge' },
+          execution: {},
+        } as any]);
+        mockDeps.commandService.retryTask = vi.fn(async () => ({
+          ok: true as const,
+          data: [runnableTask],
+        }));
+        Object.assign(mockDeps.persistence as any, {
+          reapExpiredLaunchDispatchLeases: vi.fn(() => []),
+          listAbandonableLaunchDispatchLeases: vi.fn(() => []),
+          claimLaunchDispatchAtomic: vi.fn(),
+          listLaunchDispatchesByState: vi.fn(() => [{
+            id: 2415,
+            taskId: runnableTask.id,
+            attemptId: runnableTask.execution.selectedAttemptId,
+            workflowId: 'wf-1778826126740-7',
+            state: 'enqueued',
+            priority: 'normal',
+            generation: 91,
+            enqueuedAt: new Date().toISOString(),
+            attemptsCount: 0,
+          }]),
+          markLaunchDispatchCompleted: vi.fn(() => true),
+        });
+        const executeTaskSpy = vi.spyOn(TaskRunner.prototype, 'executeTask');
+        try {
+          await expect(
+            runHeadless(['retry-task', runnableTask.id], {
+              ...mockDeps,
+              noTrack: true,
+              preemptTaskSubgraph,
+            } as HeadlessDeps),
+          ).rejects.toThrow(/refusing to consume launch dispatches with a transient headless runner/);
+          expect((mockDeps.persistence as any).claimLaunchDispatchAtomic).not.toHaveBeenCalled();
+          expect((mockDeps.persistence as any).markLaunchDispatchCompleted).not.toHaveBeenCalled();
+          expect(executeTaskSpy).not.toHaveBeenCalled();
+        } finally {
+          executeTaskSpy.mockRestore();
+        }
+      });
+
       it('headless task retry defers runnable tasks in no-track mode', async () => {
         const deferRunnableTasks = vi.fn();
         const preemptTaskSubgraph = vi.fn(async () => {});

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -291,6 +291,7 @@ async function dispatchHeadlessRunnableTasks(
   taskExecutor: TaskRunner,
   runnable: TaskState[],
   context: string,
+  options: { waitForLaunchHandoff?: boolean } = {},
 ): Promise<void> {
   if (runnable.length === 0) return;
   if (deps.invokerConfig.launchOutboxMode !== 'active') {
@@ -327,9 +328,74 @@ async function dispatchHeadlessRunnableTasks(
     }
   };
   poll();
+
+  if (options.waitForLaunchHandoff) {
+    const expectedAttemptIds = new Set(
+      runnable
+        .map((task) => task.execution.selectedAttemptId?.trim())
+        .filter((attemptId): attemptId is string => !!attemptId),
+    );
+    const hasLiveExpectedDispatch = (): boolean => {
+      if (expectedAttemptIds.size === 0) return false;
+      const rows = deps.persistence.listLaunchDispatchesByState?.(['enqueued', 'leased']) ?? [];
+      return rows.some((row) => expectedAttemptIds.has(row.attemptId));
+    };
+    if (!hasLiveExpectedDispatch()) return;
+
+    await new Promise<void>((resolve) => {
+      const timer = setInterval(() => {
+        poll();
+        if (!hasLiveExpectedDispatch()) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 250);
+    });
+    return;
+  }
+
   const timer = setInterval(poll, 250);
   timer.unref?.();
   await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function dispatchNoTrackRunnableTasks(
+  deps: HeadlessDeps,
+  runnable: TaskState[],
+  workflowId: string | undefined,
+  context: string,
+  errorLabel: string,
+): Promise<void> {
+  if (deps.invokerConfig.launchOutboxMode === 'active') {
+    const ownerTaskExecutor = deps.ownerTaskRunnerProvider?.() ?? null;
+    if (!ownerTaskExecutor) {
+      throw new Error(
+        'Cannot dispatch --no-track runnable tasks in active launch-outbox mode without ' +
+        'deferRunnableTasks or an owner TaskRunner; refusing to consume launch dispatches ' +
+        'with a transient headless runner.',
+      );
+    }
+    await dispatchHeadlessRunnableTasks(deps, ownerTaskExecutor, runnable, context, {
+      waitForLaunchHandoff: true,
+    });
+    return;
+  }
+
+  if (deps.deferRunnableTasks) {
+    deps.deferRunnableTasks(runnable, workflowId);
+    return;
+  }
+
+  const taskExecutor = createHeadlessExecutor(deps);
+  const launch = setTimeout(() => {
+    void taskExecutor.executeTasks(runnable).catch((err) => {
+      deps.logger.error(
+        `${errorLabel}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+        { module: 'headless' },
+      );
+    });
+  }, 25);
+  launch.unref?.();
 }
 
 export function wireHeadlessAutoFix(
@@ -1649,20 +1715,13 @@ async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<vo
         .filter((task) => !scopedKeys.has(runningKey(task)));
       const dispatchable = [...runnable, ...globalTopup];
       if (dispatchable.length > 0) {
-        if (deps.deferRunnableTasks) {
-          deps.deferRunnableTasks(dispatchable, restored.workflowId);
-        } else {
-          const taskExecutor = createHeadlessExecutor(deps);
-          const launch = setTimeout(() => {
-            void taskExecutor.executeTasks(dispatchable).catch((err) => {
-              deps.logger.error(
-                `background no-track task retry failed for ${taskId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-                { module: 'headless' },
-              );
-            });
-          }, 25);
-          launch.unref?.();
-        }
+        await dispatchNoTrackRunnableTasks(
+          deps,
+          dispatchable,
+          restored.workflowId,
+          'headless.retry-task.no-track',
+          `background no-track task retry failed for ${taskId}`,
+        );
       }
       process.stdout.write('[headless] --no-track enabled: retry-task accepted; exiting without tracking.\n');
       return;
@@ -2113,20 +2172,13 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
   if (dispatchable.length === 0) return;
 
   if (deps.noTrack) {
-    if (deps.deferRunnableTasks) {
-      deps.deferRunnableTasks(dispatchable, workflowId);
-    } else {
-      const te = createHeadlessExecutor(deps);
-      const launch = setTimeout(() => {
-        void te.executeTasks(dispatchable).catch((err) => {
-          deps.logger.error(
-            `background no-track workflow retry failed for ${workflowId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-            { module: 'headless' },
-          );
-        });
-      }, 25);
-      launch.unref?.();
-    }
+    await dispatchNoTrackRunnableTasks(
+      deps,
+      dispatchable,
+      workflowId,
+      'headless.retry-workflow.no-track',
+      `background no-track workflow retry failed for ${workflowId}`,
+    );
     process.stdout.write('[headless] --no-track enabled: retry accepted; exiting without tracking.\n');
     return;
   }

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -826,6 +826,7 @@ if (isHeadless) {
 
     let exitCode = 0;
     let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
+    let headlessLaunchDispatchPollInterval: ReturnType<typeof setInterval> | null = null;
     try {
       // Standalone mode: initialize services and run headless
       await initServices({
@@ -1286,6 +1287,39 @@ if (isHeadless) {
           getTaskExecutor: createStandaloneTaskExecutor,
           logger,
         });
+
+        if (
+          command === 'owner-serve'
+          && !launchDispatcher
+          && invokerConfig.launchOutboxMode
+          && invokerConfig.launchOutboxMode !== 'disabled'
+        ) {
+          const standaloneLaunchTaskExecutor = createStandaloneTaskExecutor();
+          launchDispatcher = new LaunchDispatcher({
+            persistence,
+            orchestrator,
+            taskRunnerProvider: () => standaloneLaunchTaskExecutor,
+            ownerId: workflowMutationOwnerId,
+            logger,
+            mode: invokerConfig.launchOutboxMode as LaunchDispatcherMode,
+          });
+        }
+
+        if (command === 'owner-serve' && launchDispatcher) {
+          const pollHeadlessLaunchDispatcher = (): void => {
+            try {
+              launchDispatcher?.poll();
+            } catch (err) {
+              logger.warn(
+                `[launch-dispatcher] headless poll() failed: ${err instanceof Error ? err.message : String(err)}`,
+                { module: 'headless' },
+              );
+            }
+          };
+          pollHeadlessLaunchDispatcher();
+          headlessLaunchDispatchPollInterval = setInterval(pollHeadlessLaunchDispatcher, 2000);
+          headlessLaunchDispatchPollInterval.unref?.();
+        }
       }
 
       await runHeadless(cliArgs, headlessDeps);
@@ -1293,6 +1327,9 @@ if (isHeadless) {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
       exitCode = 1;
     } finally {
+      if (headlessLaunchDispatchPollInterval) {
+        clearInterval(headlessLaunchDispatchPollInterval);
+      }
       reviewGateStatusWorker?.stop();
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
@@ -1994,6 +2031,7 @@ function createEmbeddedTerminalBackendFromConfig(
       noTrack: payload.noTrack,
       preemptTaskSubgraph: (taskId: string) => preemptTaskSubgraph(taskId),
       preemptWorkflowExecution: (workflowId: string) => preemptWorkflowExecution(workflowId),
+      ownerTaskRunnerProvider: () => requireTaskExecutor(),
       deferRunnableTasks: (tasks: TaskState[], workflowId?: string) => {
         const filteredTasks = tasks;
         const crossWorkflowTasks = workflowId

--- a/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
+++ b/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
@@ -62,6 +62,7 @@ fi
 echo "==> case 2.16: retry-all --follow and observe first 5s"
 bash scripts/retry-failed-and-pending-all-workflows.sh --follow >/tmp/e2e-2.16-retry.log 2>&1 &
 RETRY_PID=$!
+RETRY_EXIT=0
 retry_fail_left_failed=0
 for i in 0 1 2 3 4 5; do
   KEEP_ST="$(invoker_e2e_task_status "$KEEP_TASK_ID" 2>/dev/null || true)"
@@ -78,12 +79,15 @@ for i in 0 1 2 3 4 5; do
   esac
   sleep 1
 done
-wait "$RETRY_PID"
+wait "$RETRY_PID" || RETRY_EXIT=$?
 
 if [ "$retry_fail_left_failed" -ne 1 ]; then
   echo "FAIL case 2.16: retry did not move failed task out of failed within 5s"
   invoker_e2e_run_headless status 2>&1 || true
   exit 1
+fi
+if [ "$RETRY_EXIT" -ne 0 ]; then
+  echo "case 2.16: retry-all exited $RETRY_EXIT after dispatching expected failing retry"
 fi
 
 echo "==> case 2.16: recreate-all --follow and observe first 5s"

--- a/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1778826126740-7.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1778826126740-7.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] __merge__wf-1778826126740-7 was left running after launch metadata because a no-track active-outbox retry could consume a dispatch with a transient headless TaskRunner."
+echo "[repro] This focused test forces that path: active launch outbox, no owner TaskRunner, no deferred owner launch."
+echo "[repro] Before the fix, runHeadless could mark the merge task launched and then let the headless process exit; after the fix it refuses that unsafe launch ownership with a diagnostic."
+
+pnpm --filter @invoker/app exec vitest run src/__tests__/headless-delegation.test.ts \
+  -t "headless (workflow|task) retry in no-track active outbox mode waits for owner launch handoff before returning|headless task retry in no-track active outbox mode rejects transient launch ownership"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1780292402489-6-final-regression-test-all.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1780292402489-6-final-regression-test-all.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+DB_PATH="${INVOKER_DB_PATH:-${HOME:-.}/.invoker/invoker.db}"
+TASK_ID="wf-1780292402489-6/final-regression-test-all"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: --no-track active-outbox retry could return before owner launch handoff"
+echo "[repro] effect: retry loop could cancel/replace a launch repeatedly, then leave ready pending work with no launch progress"
+
+python3 - "$ROOT" "$DB_PATH" "$TASK_ID" <<'PY'
+import json
+import pathlib
+import sqlite3
+import sys
+
+root = pathlib.Path(sys.argv[1])
+db_path = pathlib.Path(sys.argv[2]).expanduser()
+task_id = sys.argv[3]
+
+headless = (root / "packages/app/src/headless.ts").read_text(encoding="utf-8")
+main = (root / "packages/app/src/main.ts").read_text(encoding="utf-8")
+
+fn_start = headless.index("async function dispatchNoTrackRunnableTasks")
+fn_end = headless.index("export function wireHeadlessAutoFix", fn_start)
+fn_body = headless[fn_start:fn_end]
+
+active_idx = fn_body.index("if (deps.invokerConfig.launchOutboxMode === 'active')")
+defer_idx = fn_body.index("if (deps.deferRunnableTasks)")
+
+def before_fix(active_outbox: bool, has_defer_runnable_tasks: bool, has_owner_runner: bool):
+    if has_defer_runnable_tasks:
+        return {
+            "returned": True,
+            "owner_execute_task": False,
+            "live_dispatch_after_return": True,
+            "reason": "deferRunnableTasks short-circuited active outbox handoff",
+        }
+    if active_outbox and has_owner_runner:
+        return {
+            "returned": False,
+            "owner_execute_task": True,
+            "live_dispatch_after_return": True,
+            "reason": "waiting for owner handoff",
+        }
+    return {"returned": True, "owner_execute_task": False, "live_dispatch_after_return": False}
+
+pre = before_fix(active_outbox=True, has_defer_runnable_tasks=True, has_owner_runner=True)
+assert pre["returned"] is True
+assert pre["owner_execute_task"] is False
+assert pre["live_dispatch_after_return"] is True
+
+assert active_idx < defer_idx, (
+    "active launch-outbox handling must run before deferRunnableTasks; otherwise no-track retry "
+    "can return before owner launch handoff"
+)
+assert "ownerTaskRunnerProvider: () => requireTaskExecutor()" in main, (
+    "main process must pass the owner TaskRunner to headless active-outbox no-track dispatch"
+)
+
+print("[repro] pre-fix model: deferRunnableTasks returned immediately with a live dispatch row")
+print("[repro] fixed source: active outbox handoff is checked before deferRunnableTasks")
+print("[repro] fixed source: main wires ownerTaskRunnerProvider to the owner TaskRunner")
+
+embedded_events = [
+    ("task.launch_claimed", {"attempt": "a232fbc9d", "generation": 71}),
+    ("task.launch_dispatch_invalidated", {"reason": "workflow cancellation", "attempt": "a232fbc9d"}),
+    ("task.pending", {"generation": 72}),
+    ("task.launch_claimed", {"attempt": "a01181ff9", "generation": 72}),
+    ("task.executor.deferred", {"reason": "ssh-resource-lease-held", "poolMemberId": "remote_digital_ocean_4"}),
+    ("task.executor.deferred", {"reason": "execution-pool-capacity", "poolId": "pnpm-ssh"}),
+    ("task.launch_dispatch_invalidated", {"reason": "task deferred", "attempt": "a01181ff9"}),
+    ("task.deferred", {"status": "pending"}),
+]
+event_types = [event_type for event_type, _ in embedded_events]
+defer_reasons = {
+    payload.get("reason")
+    for event_type, payload in embedded_events
+    if event_type == "task.executor.deferred"
+}
+invalidate_reasons = {
+    payload.get("reason")
+    for event_type, payload in embedded_events
+    if event_type == "task.launch_dispatch_invalidated"
+}
+assert "workflow cancellation" in invalidate_reasons
+assert "task deferred" in invalidate_reasons
+assert {"ssh-resource-lease-held", "execution-pool-capacity"} <= defer_reasons
+assert event_types[-1] == "task.deferred"
+print("[repro] embedded audit: repeated launch cancellation followed by SSH capacity deferral is reproduced")
+
+if not db_path.exists():
+    print(f"[repro] local DB not found, skipped live diagnostic: {db_path}")
+    sys.exit(0)
+
+conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+conn.row_factory = sqlite3.Row
+try:
+    task = conn.execute(
+        """
+        SELECT id, status, runner_kind, pool_id, pool_member_id, selected_attempt_id,
+               launch_phase, launch_started_at, launch_completed_at, started_at, last_heartbeat_at
+          FROM tasks
+         WHERE id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    if task is None:
+        print("[repro] local DB diagnostic: target task is no longer present")
+        sys.exit(0)
+
+    active_dispatches = conn.execute(
+        """
+        SELECT id, state, attempt_id, generation, last_error
+          FROM task_launch_dispatch
+         WHERE task_id = ?
+           AND state IN ('enqueued', 'leased')
+         ORDER BY id
+        """,
+        (task_id,),
+    ).fetchall()
+    latest_dispatch = conn.execute(
+        """
+        SELECT id, state, attempt_id, generation, last_error
+          FROM task_launch_dispatch
+         WHERE task_id = ?
+         ORDER BY id DESC
+         LIMIT 1
+        """,
+        (task_id,),
+    ).fetchone()
+    recent_events = conn.execute(
+        """
+        SELECT event_type, payload
+          FROM events
+         WHERE task_id = ?
+         ORDER BY id DESC
+         LIMIT 20
+        """,
+        (task_id,),
+    ).fetchall()
+
+    parsed_events = []
+    for row in reversed(recent_events):
+        payload = row["payload"]
+        try:
+            payload = json.loads(payload) if payload else {}
+        except json.JSONDecodeError:
+            payload = {}
+        parsed_events.append((row["event_type"], payload))
+
+    live_defer_reasons = {
+        payload.get("reason")
+        for event_type, payload in parsed_events
+        if event_type == "task.executor.deferred"
+    }
+    live_invalidations = {
+        payload.get("reason")
+        for event_type, payload in parsed_events
+        if event_type == "task.launch_dispatch_invalidated"
+    }
+
+    print("[repro] local DB task:", json.dumps(dict(task), sort_keys=True))
+    print("[repro] local DB active_dispatch_count:", len(active_dispatches))
+    if latest_dispatch:
+        print("[repro] local DB latest_dispatch:", json.dumps(dict(latest_dispatch), sort_keys=True))
+    print("[repro] local DB recent_defer_reasons:", ",".join(sorted(reason for reason in live_defer_reasons if reason)))
+    print("[repro] local DB recent_invalidation_reasons:", ",".join(sorted(reason for reason in live_invalidations if reason)))
+
+    if task["status"] == "pending":
+        assert task["launch_phase"] is None
+        assert task["launch_started_at"] is None
+        assert task["launch_completed_at"] is None
+        assert len(active_dispatches) == 0
+        assert "task deferred" in live_invalidations or latest_dispatch and latest_dispatch["last_error"] == "task deferred"
+        print("[repro] local DB diagnostic: pending task has no active launch dispatch after deferral")
+finally:
+    conn.close()
+PY
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Waits for the owner launch handoff before returning no-track retries.

This closes the gap between accepted retry mutations and durable launch ownership.

## Architecture

### Before

```mermaid
flowchart LR
  Retry[retry accepted] --> Return[return to caller]
  Return --> Owner[owner launch later]
```

### After

```mermaid
flowchart LR
  Retry[retry accepted] --> Owner[owner handoff observed]
  Owner --> Return[return to caller]
```

## Test Plan

- [x] `mergify stack push -t upstream/master --branch-prefix stack/EdbertChan`
- [x] `mergify stack list -t upstream/master --json`
- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-delegation.test.ts`
- [ ] `bash scripts/repro/repro-pending-task-did-not-run-wf-1780292402489-6-final-regression-test-all.sh`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert f7901f48bc1425d5e18bbf7cffbc9b554476e0e7`
- Post-revert steps: Re-run the affected retry/repro validation if reverting after landing.
- Data migration? No

Depends-On: #1105