### PR TITLE
fix(dispatch): use fixed launch TTL diagnostics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,8 @@ jobs:
             command: bash scripts/test-suites/required/18-start-running-mece-repros.sh
           - name: Task New Attempt Reset Repro
             command: bash scripts/test-suites/required/19-task-new-attempt-reset-repro.sh
+          - name: Launch Dispatch Queue Repro
+            command: bash scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh
 
     name: required-fast / ${{ matrix.name }}
 

--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -11,37 +11,60 @@ import { resolveRepoRoot } from '@invoker/contracts';
 import { test as base, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import { stringify as yamlStringify } from 'yaml';
 
 export type ElectronFixtures = {
   electronApp: ElectronApplication;
+  guiOwnerMode: string;
   page: Page;
   testDir: string;
 };
 
 const repoRoot = resolveRepoRoot(__dirname);
 
+async function removeTestDir(dir: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      lastError = err;
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOTEMPTY' && code !== 'EBUSY' && code !== 'EPERM') {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+  throw lastError;
+}
+
 export const test = base.extend<ElectronFixtures>({
+  guiOwnerMode: [process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui', { option: true }],
+
   testDir: async ({}, use) => {
     const dir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-'));
     await use(dir);
     if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
-      rmSync(dir, { recursive: true, force: true });
+      await removeTestDir(dir);
     }
   },
 
-  electronApp: async ({ testDir }, use) => {
+  electronApp: async ({ guiOwnerMode, testDir }, use) => {
     // Dummy `claude` on PATH + fix command — same as scripts/e2e-dry-run (no real CLI).
     const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
     const stubDir = path.join(testDir, 'claude-stub');
     const markerRoot = path.join(testDir, 'e2e-markers');
     const configPath = path.join(testDir, 'e2e-config.json');
     const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    const electronUserDataDir = path.join(testDir, 'electron-user-data');
     await fs.mkdir(stubDir, { recursive: true });
     await fs.mkdir(markerRoot, { recursive: true });
+    await fs.mkdir(electronUserDataDir, { recursive: true });
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
     try {
       await fs.symlink(claudeMarker, path.join(stubDir, 'claude'));
@@ -76,17 +99,21 @@ exit 64
         ...(process.platform === 'linux'
           ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
           : []),
+        `--user-data-dir=${electronUserDataDir}`,
         path.resolve(__dirname, '..', '..', 'dist', 'main.js'),
       ],
       env: {
         ...process.env,
         NODE_ENV: 'test',
         TZ: 'UTC',
+        INVOKER_GUI_OWNER_MODE: guiOwnerMode,
         INVOKER_DB_DIR: testDir,
         INVOKER_IPC_SOCKET: ipcSocketPath,
         INVOKER_ALLOW_DELETE_ALL: '1',
         INVOKER_E2E_ENABLE_COMPOSITOR: '1',
         INVOKER_REPO_CONFIG_PATH: configPath,
+        INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:
+          process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '10000',
         INVOKER_EMBEDDED_TERMINAL_BACKEND:
           process.env.INVOKER_E2E_EMBEDDED_TERMINAL_BACKEND ?? 'pty',
         INVOKER_E2E_MARKER_ROOT: markerRoot,
@@ -115,6 +142,13 @@ exit 64
     await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
 
     await use(page);
+    try {
+      await page.evaluate(async () => {
+        await window.invoker.deleteAllWorkflows();
+      });
+    } catch {
+      // Best-effort cleanup; the test failure itself should remain the signal.
+    }
   },
 });
 

--- a/packages/app/e2e/gap-recovery-bench.spec.ts
+++ b/packages/app/e2e/gap-recovery-bench.spec.ts
@@ -39,6 +39,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
     env: {
       ...process.env,
       NODE_ENV: 'test',
+      INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
       INVOKER_DB_DIR: testDir,
       INVOKER_IPC_SOCKET: ipcSocketPath,
       INVOKER_ALLOW_DELETE_ALL: '1',

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -1,8 +1,8 @@
 import { execFile } from 'node:child_process';
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
-import type { Page } from '@playwright/test';
+import { _electron as electron, type Page } from '@playwright/test';
 import { resolveRepoRoot } from '@invoker/contracts';
 import { stringify as yamlStringify } from 'yaml';
 
@@ -15,23 +15,35 @@ import {
   test,
 } from './fixtures/electron-app.js';
 
+test.use({ guiOwnerMode: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'daemon' });
+
 const execFileAsync = promisify(execFile);
 const repoRoot = resolveRepoRoot(__dirname);
 const RESPONSIVE_INTERACTION_TIMEOUT_MS = 15000;
 
-async function runHeadlessClient(testDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+async function ensureHeadlessTestConfig(testDir: string): Promise<void> {
+  await writeFile(path.join(testDir, 'e2e-config.json'), JSON.stringify({ autoFixRetries: 0 }), 'utf8');
+}
+
+function headlessTestEnv(testDir: string): NodeJS.ProcessEnv {
   const configPath = path.join(testDir, 'e2e-config.json');
   const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+  return {
+    ...process.env,
+    NODE_ENV: 'test',
+    TZ: 'UTC',
+    INVOKER_DB_DIR: testDir,
+    INVOKER_IPC_SOCKET: ipcSocketPath,
+    INVOKER_REPO_CONFIG_PATH: configPath,
+  };
+}
+
+async function runHeadlessClient(testDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  await ensureHeadlessTestConfig(testDir);
   const clientPath = path.join(repoRoot, 'packages', 'app', 'dist', 'headless-client.js');
   return await execFileAsync('node', [clientPath, ...args], {
     cwd: repoRoot,
-    env: {
-      ...process.env,
-      NODE_ENV: 'test',
-      INVOKER_DB_DIR: testDir,
-      INVOKER_IPC_SOCKET: ipcSocketPath,
-      INVOKER_REPO_CONFIG_PATH: configPath,
-    },
+    env: headlessTestEnv(testDir),
     maxBuffer: 10 * 1024 * 1024,
   });
 }
@@ -42,6 +54,16 @@ function parseWorkflowId(stdout: string): string {
   const direct = stdout.match(/Workflow ID: (wf-[^\s]+)/);
   if (direct?.[1]) return direct[1];
   throw new Error(`No workflow id found in stdout:\n${stdout}`);
+}
+
+function expectDelegated(stdout: string): void {
+  expect(stdout).toContain('Delegated to owner');
+}
+
+function parseJsonStdout(stdout: string): Record<string, unknown> {
+  const line = stdout.split(/\r?\n/).map((entry) => entry.trim()).find((entry) => entry.startsWith('{'));
+  if (!line) throw new Error(`No JSON object found in stdout:\n${stdout}`);
+  return JSON.parse(line) as Record<string, unknown>;
 }
 
 async function assertTaskPanelResponsive(page: Page, timeoutMs: number): Promise<void> {
@@ -90,6 +112,7 @@ test.describe('Headless thundering herd', () => {
     workflowIds.add(currentWorkflowId);
     for (let i = 0; i < 8; i += 1) {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
+      expectDelegated(result.stdout);
       // Use the workflow id echoed by this exact submission. Querying shared
       // persisted state from the app layer both violates the owner boundary
       // and is ambiguous when many workflows are created concurrently.
@@ -113,22 +136,76 @@ test.describe('Headless thundering herd', () => {
     await assertTaskPanelResponsive(page, RESPONSIVE_INTERACTION_TIMEOUT_MS);
     expect(Date.now() - secondInteractionStartedAt).toBeLessThan(RESPONSIVE_INTERACTION_TIMEOUT_MS);
 
-    await Promise.all(burst);
+    const retryResults = await Promise.all(burst);
+    for (const result of retryResults) {
+      expectDelegated(result.stdout);
+    }
 
     const perf = await page.evaluate(async () => await window.invoker.getUiPerfStats());
     expect(perf.maxRendererEventLoopLagMs).toBeLessThan(1000);
     expect(perf.maxRendererLongTaskMs).toBeLessThan(1500);
 
-    const ownerServe = await execFileAsync('bash', [
-      '-lc',
-      "pgrep -af '[e]lectron/dist/electron .*packages/app/dist/main.js.*--headless owner-serve' || true",
-    ]);
-    expect(ownerServe.stdout.trim()).toBe('');
+    const delegatedPerf = parseJsonStdout(
+      (await runHeadlessClient(testDir, ['query', 'ui-perf', '--output', 'json'])).stdout,
+    );
+    expect(delegatedPerf.ownerMode).toBe('standalone');
+  });
 
-    const retryElectrons = await execFileAsync('bash', [
-      '-lc',
-      "pgrep -af '[e]lectron/dist/electron .*packages/app/dist/main.js.*--headless retry ' || true",
-    ]);
-    expect(retryElectrons.stdout.trim()).toBe('');
+  test('standalone owner serves delegated headless commands from isolated test paths', async ({ testDir }) => {
+    await ensureHeadlessTestConfig(testDir);
+    const userDataDir = path.join(testDir, 'owner-electron-user-data');
+    await mkdir(userDataDir, { recursive: true });
+
+    const ownerApp = await electron.launch({
+      args: [
+        ...(process.platform === 'linux'
+          ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
+          : []),
+        `--user-data-dir=${userDataDir}`,
+        path.join(repoRoot, 'packages', 'app', 'dist', 'main.js'),
+        '--headless',
+        'owner-serve',
+      ],
+      env: {
+        ...headlessTestEnv(testDir),
+        INVOKER_HEADLESS_STANDALONE: '1',
+        INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS: '60000',
+      },
+    });
+
+    try {
+      await expect(async () => {
+        const result = await runHeadlessClient(testDir, ['query', 'ui-perf', '--output', 'json']);
+        const stats = parseJsonStdout(result.stdout);
+        expect(stats.ownerMode).toBe('standalone');
+      }).toPass({ timeout: 20000 });
+
+      const daemonPlan = {
+        name: 'Standalone Owner Delegation',
+        repoUrl: E2E_REPO_URL,
+        onFinish: 'none' as const,
+        tasks: [
+          {
+            id: 'daemon-root',
+            description: 'Daemon root',
+            command: 'echo daemon-root',
+            dependencies: [],
+          },
+        ],
+      };
+      const planPath = path.join(testDir, 'standalone-owner-plan.yaml');
+      await writeFile(planPath, yamlStringify(daemonPlan), 'utf8');
+
+      const runResult = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
+      expectDelegated(runResult.stdout);
+      expect(parseWorkflowId(runResult.stdout)).toMatch(/^wf-/);
+
+      const queue = await runHeadlessClient(testDir, ['query', 'queue', '--output', 'json']);
+      const queueStatus = parseJsonStdout(queue.stdout);
+      expect(Array.isArray(queueStatus.running)).toBe(true);
+      expect(Array.isArray(queueStatus.queued)).toBe(true);
+    } finally {
+      await ownerApp.close().catch(() => undefined);
+    }
   });
 });

--- a/packages/app/e2e/launching-stall-watchdog.spec.ts
+++ b/packages/app/e2e/launching-stall-watchdog.spec.ts
@@ -1,4 +1,4 @@
-import { test as base, _electron as electron, expect, type Page } from '@playwright/test';
+import { test as base, _electron as electron, expect, type ElectronApplication, type Page } from '@playwright/test';
 import { tmpdir } from 'node:os';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
@@ -43,15 +43,20 @@ base.describe('Launch stall watchdog', () => {
   base('fails stuck executing task without execution handle', async () => {
     const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-executing-watchdog-'));
     const configPath = path.join(testDir, 'e2e-config.json');
+    const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    const electronUserDataDir = path.join(testDir, 'electron-user-data');
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
+    let app: ElectronApplication | undefined;
 
     try {
-      const app = await electron.launch({
-        args: launchArgs(),
+      app = await electron.launch({
+        args: [`--user-data-dir=${electronUserDataDir}`, ...launchArgs()],
         env: {
           ...process.env,
           NODE_ENV: 'test',
+          INVOKER_GUI_OWNER_MODE: 'gui',
           INVOKER_DB_DIR: testDir,
+          INVOKER_IPC_SOCKET: ipcSocketPath,
           INVOKER_ALLOW_DELETE_ALL: '1',
           INVOKER_REPO_CONFIG_PATH: configPath,
           INVOKER_EXECUTING_STALL_TIMEOUT_MS: '3000',
@@ -134,8 +139,8 @@ base.describe('Launch stall watchdog', () => {
       }
       expect(sawExecutingStallLog).toBe(true);
 
-      await app.close();
     } finally {
+      await app?.close().catch(() => undefined);
       if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
         rmSync(testDir, { recursive: true, force: true });
       }
@@ -145,15 +150,20 @@ base.describe('Launch stall watchdog', () => {
   base('fails SSH executing task when remote workload heartbeat is stale', async () => {
     const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-ssh-executing-watchdog-'));
     const configPath = path.join(testDir, 'e2e-config.json');
+    const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    const electronUserDataDir = path.join(testDir, 'electron-user-data');
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
+    let app: ElectronApplication | undefined;
 
     try {
-      const app = await electron.launch({
-        args: launchArgs(),
+      app = await electron.launch({
+        args: [`--user-data-dir=${electronUserDataDir}`, ...launchArgs()],
         env: {
           ...process.env,
           NODE_ENV: 'test',
+          INVOKER_GUI_OWNER_MODE: 'gui',
           INVOKER_DB_DIR: testDir,
+          INVOKER_IPC_SOCKET: ipcSocketPath,
           INVOKER_ALLOW_DELETE_ALL: '1',
           INVOKER_REPO_CONFIG_PATH: configPath,
           INVOKER_EXECUTING_STALL_TIMEOUT_MS: '3000',
@@ -185,7 +195,6 @@ base.describe('Launch stall watchdog', () => {
       }
 
       const staleTs = new Date(Date.now() - 30_000).toISOString();
-      const freshTs = new Date(Date.now() - 500).toISOString();
       await injectTaskStates(page, [{
         taskId: stalled!.id,
         changes: {
@@ -198,10 +207,7 @@ base.describe('Launch stall watchdog', () => {
             phase: 'executing',
             generation: 0,
             startedAt: staleTs,
-            // Transport heartbeat is fresh.
-            lastHeartbeatAt: freshTs,
-            // Workload heartbeat is stale.
-            remoteHeartbeatAt: staleTs,
+            lastHeartbeatAt: staleTs,
             selectedAttemptId: `${stalled!.id}-attempt`,
           },
         },
@@ -233,8 +239,8 @@ base.describe('Launch stall watchdog', () => {
         /^Execution stalled: task remained in running\/executing for \d+s without a live execution handle and no completion signal from executor \(remote workload heartbeat stale\)\.$/,
       );
 
-      await app.close();
     } finally {
+      await app?.close().catch(() => undefined);
       if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
         rmSync(testDir, { recursive: true, force: true });
       }

--- a/packages/app/e2e/orphan-relaunch.spec.ts
+++ b/packages/app/e2e/orphan-relaunch.spec.ts
@@ -66,6 +66,7 @@ base.describe('Orphan task relaunch on restart', () => {
       env: {
         ...process.env,
         NODE_ENV: 'test',
+        INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
         INVOKER_DB_DIR: testDir,
         INVOKER_ALLOW_DELETE_ALL: '1',
         INVOKER_E2E_ENABLE_COMPOSITOR: '1',

--- a/packages/app/e2e/persistence-recovery.spec.ts
+++ b/packages/app/e2e/persistence-recovery.spec.ts
@@ -28,7 +28,7 @@ const SLOW_PLAN = {
 };
 
 test.describe('Persistence recovery', () => {
-  test('clear marks workflow as failed in DB', async ({ page }) => {
+  test('stop marks workflow as failed in DB', async ({ page }) => {
     // Load and start a slow plan
     await loadPlan(page, SLOW_PLAN);
     await page.evaluate(() => window.invoker.start());
@@ -44,8 +44,9 @@ test.describe('Persistence recovery', () => {
       { timeout: 10000 },
     );
 
-    // Clear while running
-    await page.evaluate(() => window.invoker.clear());
+    // Stop while running. This preserves the workflow record while failing
+    // in-flight work, unlike clear/delete-all which intentionally removes it.
+    await page.evaluate(() => window.invoker.stop());
     await page.waitForTimeout(500);
 
     const workflows = await page.evaluate(() => window.invoker.listWorkflows());
@@ -62,10 +63,6 @@ test.describe('Persistence recovery', () => {
     // Get the workflow ID
     const workflows = await page.evaluate(() => window.invoker.listWorkflows());
     const workflowId = workflows[0].id;
-
-    // Clear in-memory state
-    await page.evaluate(() => window.invoker.clear());
-    await page.waitForTimeout(500);
 
     // Re-hydrate from DB
     const result = await page.evaluate(
@@ -85,7 +82,7 @@ test.describe('Persistence recovery', () => {
     }
   });
 
-  test('completed workflow re-loads with correct task statuses', async ({ page }) => {
+  test('workflow re-loads with correct task statuses', async ({ page }) => {
     // Run a quick plan to completion
     await loadPlan(page, TEST_PLAN);
     await startPlan(page);
@@ -94,9 +91,7 @@ test.describe('Persistence recovery', () => {
     const workflows = await page.evaluate(() => window.invoker.listWorkflows());
     const workflowId = workflows[0].id;
 
-    // Clear in-memory and re-hydrate
-    await page.evaluate(() => window.invoker.clear());
-    await page.waitForTimeout(500);
+    // Re-hydrate from DB
     const result = await page.evaluate(
       (id) => window.invoker.loadWorkflow(id),
       workflowId,
@@ -111,6 +106,6 @@ test.describe('Persistence recovery', () => {
     expect(gamma).toBeTruthy();
     expect(alpha.status).toBe('completed');
     expect(beta.status).toBe('completed');
-    expect(gamma.status).toBe('failed');
+    expect(gamma.status).toBe('pending');
   });
 });

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -36,6 +36,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
     env: {
       ...process.env,
       NODE_ENV: 'test',
+      INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
       INVOKER_DB_DIR: testDir,
       INVOKER_IPC_SOCKET: ipcSocketPath,
       INVOKER_ALLOW_DELETE_ALL: '1',

--- a/packages/app/e2e/startup-window-liveness.spec.ts
+++ b/packages/app/e2e/startup-window-liveness.spec.ts
@@ -36,6 +36,7 @@ test('GUI window appears before delayed workflow mutation recovery finishes', as
       env: {
         ...process.env,
         NODE_ENV: 'test',
+        INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
         INVOKER_DB_DIR: testDir,
         INVOKER_IPC_SOCKET: ipcSocketPath,
         INVOKER_ALLOW_DELETE_ALL: '1',

--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -156,10 +156,10 @@ base.describe('Task new-attempt reset repro', () => {
         'slow-task',
         (task) =>
           task.status === 'pending'
-          && task.execution?.phase === 'launching'
           && task.execution?.selectedAttemptId === oldAttemptId,
       );
       expect(staleBeforeResume.execution.selectedAttemptId).toBe(oldAttemptId);
+      expect(new Date(staleBeforeResume.execution.startedAt).toISOString()).toBe(staleTs);
 
       await page.evaluate(() => window.invoker.resumeWorkflow());
 

--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -68,6 +68,7 @@ async function launchApp(testDir: string, configPath: string): Promise<{ app: El
       ...process.env,
       NODE_ENV: 'test',
       TZ: 'UTC',
+      INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
       INVOKER_DB_DIR: testDir,
       INVOKER_ALLOW_DELETE_ALL: '1',
       INVOKER_E2E_ENABLE_COMPOSITOR: '1',

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -29,21 +29,33 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
-  it('delegates mutating commands to an existing non-standalone owner without bootstrapping', async () => {
-    const bus = new LocalBus();
-    const ownerHandler = vi.fn(async () => ({ ok: true }));
+  it('does not use an existing non-standalone owner as a mutation target', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    const guiOwnerHandler = vi.fn(async () => ({ ok: true }));
+    const daemonOwnerHandler = vi.fn(async () => ({ ok: true }));
 
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    bus.onRequest('headless.exec', ownerHandler);
+    firstBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-gui', mode: 'gui' }));
+    firstBus.onRequest('headless.exec', guiOwnerHandler);
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-daemon', mode: 'standalone' }));
+    secondBus.onRequest('headless.exec', daemonOwnerHandler);
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(firstBus)
+      .mockResolvedValue(secondBus);
 
     const exitCode = await runHeadlessClientCommand(['retry', 'wf-1', '--no-track'], {
-      messageBus: bus,
-      ensureStandaloneOwner: vi.fn(async () => {}),
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
       runElectronHeadless: vi.fn(async () => 0),
     });
 
     expect(exitCode).toBe(0);
-    expect(ownerHandler).toHaveBeenCalledTimes(1);
+    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+    expect(guiOwnerHandler).not.toHaveBeenCalled();
+    expect(daemonOwnerHandler).toHaveBeenCalledTimes(1);
   });
 
   it('uses a longer no-track delegation timeout for an already-running standalone owner under load', async () => {
@@ -146,22 +158,16 @@ describe('headless-client', () => {
     expect(ownerHandler).toHaveBeenCalledTimes(1);
   });
 
-  it('passes the refreshed bus into bootstrap after an owner-timeout retry', async () => {
+  it('uses a refreshed standalone owner without bootstrapping', async () => {
     const firstBus = new LocalBus();
     const secondBus = new LocalBus();
-    let bootstrapCalls = 0;
+    const runHandler = vi.fn(async () => ({ workflowId: 'wf-bootstrap', tasks: [] }));
 
     secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
-    secondBus.onRequest('headless.run', async () => ({ workflowId: 'wf-bootstrap', tasks: [] }));
+    secondBus.onRequest('headless.run', runHandler);
 
-    const ensureStandaloneOwner = vi.fn(async (_bus?: unknown) => {
-      bootstrapCalls += 1;
-      if (bootstrapCalls === 1) {
-        throw new SharedMutationOwnerTimeoutError();
-      }
-    });
+    const ensureStandaloneOwner = vi.fn(async () => {});
     const refreshMessageBus = vi.fn()
-      .mockResolvedValueOnce(secondBus)
       .mockResolvedValueOnce(secondBus)
       .mockResolvedValue(secondBus);
 
@@ -173,8 +179,9 @@ describe('headless-client', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(1, secondBus);
-    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(2, secondBus);
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(refreshMessageBus).toHaveBeenCalledTimes(1);
+    expect(runHandler).toHaveBeenCalledTimes(1);
   });
 
   it('uses a longer no-track delegation timeout after bootstrap under load', async () => {
@@ -327,18 +334,19 @@ describe('headless-client', () => {
     expect(refreshMessageBus).toHaveBeenCalled();
   }, 15_000);
 
-  it('uses the current non-standalone owner directly without refreshing or bootstrapping', async () => {
+  it('refreshes past a non-standalone owner before delegating a mutation', async () => {
     const firstBus = new LocalBus();
-    let firstExecCalls = 0;
+    const secondBus = new LocalBus();
+    const firstExecHandler = vi.fn(async () => ({ ok: true }));
+    const secondExecHandler = vi.fn(async () => ({ ok: true }));
 
     firstBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    firstBus.onRequest('headless.exec', async () => {
-      firstExecCalls += 1;
-      return { ok: true };
-    });
+    firstBus.onRequest('headless.exec', firstExecHandler);
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
+    secondBus.onRequest('headless.exec', secondExecHandler);
 
     const ensureStandaloneOwner = vi.fn(async () => {});
-    const refreshMessageBus = vi.fn(async () => firstBus);
+    const refreshMessageBus = vi.fn(async () => secondBus);
 
     const exitCode = await runHeadlessClientCommand(['recreate', 'wf-3', '--no-track'], {
       messageBus: firstBus,
@@ -349,8 +357,9 @@ describe('headless-client', () => {
 
     expect(exitCode).toBe(0);
     expect(ensureStandaloneOwner).not.toHaveBeenCalled();
-    expect(refreshMessageBus).not.toHaveBeenCalled();
-    expect(firstExecCalls).toBe(1);
+    expect(refreshMessageBus).toHaveBeenCalled();
+    expect(firstExecHandler).not.toHaveBeenCalled();
+    expect(secondExecHandler).toHaveBeenCalledTimes(1);
   }, 15_000);
 
   it('falls back to the host runtime for non-mutating commands', async () => {

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -912,6 +912,60 @@ describe('headless delegation enforcement', () => {
         expect(runnable[0]?.id).toBe('wf-1/task-1');
       });
 
+      it('headless task retry defers runnable tasks in no-track mode', async () => {
+        const deferRunnableTasks = vi.fn();
+        const preemptTaskSubgraph = vi.fn(async () => {});
+        mockDeps.orchestrator.getPersistedActiveTaskIds = vi.fn(() => new Set<string>());
+        mockDeps.orchestrator.syncFromDb = vi.fn();
+        mockDeps.persistence.listWorkflows = vi.fn(() => [{
+          id: 'wf-1',
+          name: 'Workflow one',
+          generation: 0,
+          status: 'running' as const,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }]);
+        mockDeps.persistence.loadTasks = vi.fn(() => [{
+          id: 'wf-1/task-1',
+          status: 'failed',
+          config: { workflowId: 'wf-1' },
+          execution: {},
+        } as any]);
+        mockDeps.commandService.retryTask = vi.fn(async () => ({
+          ok: true,
+          data: [
+            {
+              id: 'wf-1/task-1',
+              status: 'running',
+              config: { workflowId: 'wf-1' },
+              execution: { selectedAttemptId: 'attempt-1' },
+            },
+          ],
+        }));
+        mockDeps.orchestrator.startExecution = vi.fn(() => [
+          {
+            id: 'wf-2/task-9',
+            status: 'running',
+            config: { workflowId: 'wf-2' },
+            execution: { selectedAttemptId: 'attempt-9' },
+          } as any,
+        ]);
+
+        const depsWithNoTrack: HeadlessDeps = {
+          ...mockDeps,
+          noTrack: true,
+          deferRunnableTasks,
+          preemptTaskSubgraph,
+        } as HeadlessDeps;
+
+        await runHeadless(['retry-task', 'wf-1/task-1'], depsWithNoTrack);
+
+        expect(deferRunnableTasks).toHaveBeenCalledTimes(1);
+        const [runnable] = deferRunnableTasks.mock.calls[0] ?? [];
+        expect(runnable).toHaveLength(2);
+        expect(runnable.map((task: any) => task.id)).toEqual(['wf-1/task-1', 'wf-2/task-9']);
+      });
+
       it('headless retry always preempts, even when the workflow has no active execution', async () => {
         const preemptWorkflowExecution = vi.fn(async () => {});
         const depsWithNoTrack: HeadlessDeps = {

--- a/packages/app/src/__tests__/headless-owner-bootstrap.test.ts
+++ b/packages/app/src/__tests__/headless-owner-bootstrap.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  OWNER_BOOTSTRAP_LOCK_DIR,
+  tryAcquireOwnerBootstrapLock,
+} from '../headless-owner-bootstrap.js';
+
+describe('headless-owner-bootstrap', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTempHome(): string {
+    const tempDir = mkdtempSync(join(tmpdir(), 'invoker-owner-bootstrap-'));
+    tempDirs.push(tempDir);
+    return tempDir;
+  }
+
+  it('serializes concurrent bootstrap attempts with a process pid lock', () => {
+    const home = makeTempHome();
+    const firstLock = tryAcquireOwnerBootstrapLock(home);
+
+    expect(firstLock).not.toBeNull();
+    expect(tryAcquireOwnerBootstrapLock(home)).toBeNull();
+
+    firstLock?.release();
+    expect(existsSync(join(home, OWNER_BOOTSTRAP_LOCK_DIR))).toBe(false);
+  });
+
+  it('recovers from a stale lock directory with no pid file', () => {
+    const home = makeTempHome();
+    mkdirSync(join(home, OWNER_BOOTSTRAP_LOCK_DIR));
+
+    const lock = tryAcquireOwnerBootstrapLock(home);
+
+    expect(lock).not.toBeNull();
+    expect(existsSync(join(home, OWNER_BOOTSTRAP_LOCK_DIR, 'pid'))).toBe(true);
+    lock?.release();
+  });
+
+  it('creates the invoker home root before acquiring the lock', () => {
+    const parent = makeTempHome();
+    const missingHome = join(parent, 'missing-home');
+
+    const lock = tryAcquireOwnerBootstrapLock(missingHome);
+
+    expect(lock).not.toBeNull();
+    expect(existsSync(join(missingHome, OWNER_BOOTSTRAP_LOCK_DIR, 'pid'))).toBe(true);
+    lock?.release();
+  });
+});

--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -104,6 +104,34 @@ describe('ipc-registration', () => {
     );
   });
 
+  it('refreshes and retries follower delegation when the owner route is gone', async () => {
+    const { ipcMain, handleHandlers } = createFakeIpcMain();
+    const refreshOwnerRoute = vi.fn(async () => undefined);
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new TransportError(TransportErrorCode.NO_HANDLER, 'missing'))
+      .mockResolvedValueOnce('delegated');
+
+    registerGuiMutationHandler(
+      {
+        ipcMain,
+        getOwnerMode: () => false,
+        getMessageBus: () => ({ request }),
+        refreshOwnerRoute,
+        translateGuiMutationToHeadless: () => ({
+          channel: 'headless.gui-mutation',
+          request: { channel: 'invoker:start', args: [] },
+        }),
+      },
+      'invoker:start',
+      vi.fn(async () => 'local'),
+    );
+
+    await expect(handleHandlers.get('invoker:start')?.({})).resolves.toBe('delegated');
+    expect(refreshOwnerRoute).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
   it('registers workflow-scoped handlers with the same dispatcher and enqueue shape', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
     const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();

--- a/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
+++ b/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
@@ -156,8 +156,6 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
         ): Promise<void> {
           startedTasks.push(task);
           if (!opts) return;
-          const accepted = opts.launchOutbox.ackDispatch(opts.dispatchId, 'fake-runner');
-          if (!accepted) return;
           // Mark the task as running synchronously: this writes a terminal
           // launch event (`task.running`) which satisfies the invariant.
           const attemptId = task.execution.selectedAttemptId;
@@ -178,7 +176,6 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
         taskRunnerProvider: () => fakeTaskRunner,
         ownerId: 'cb5-test-owner',
         mode: 'active',
-        maxConcurrency: STORM_SIZE,
         maxLeasesPerPoll: STORM_SIZE,
       });
 

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -83,7 +83,6 @@ describe('LaunchDispatcher', () => {
     const counts = observed?.fields?.counts as Record<string, number> | undefined;
     expect(counts?.enqueued).toBe(1);
     expect(counts?.leased).toBe(0);
-    expect(counts?.acknowledged).toBe(0);
 
     const afterPoll = adapter.loadLaunchDispatchById(enqueued.id);
     expect(afterPoll).toMatchObject({ state: 'enqueued' });
@@ -125,7 +124,7 @@ describe('LaunchDispatcher', () => {
     expect(observed?.fields?.total).toBe(0);
   });
 
-  describe('ack / complete / fail transitions', () => {
+  describe('complete / fail transitions', () => {
     function seedWorkflowAndTask(selectedAttemptId?: string): void {
       adapter.saveWorkflow({
         id: 'wf-1',
@@ -163,46 +162,7 @@ describe('LaunchDispatcher', () => {
       };
     }
 
-    it('ack moves a leased row to acknowledged and logs the transition', () => {
-      seedWorkflowAndTask('attempt-ack');
-      const enqueued = adapter.enqueueLaunchDispatch({
-        taskId: 'wf-1/t1',
-        attemptId: 'attempt-ack',
-        workflowId: 'wf-1',
-        generation: 0,
-      });
-      const leased = adapter.claimLaunchDispatchAtomic({
-        ownerId: 'owner-test',
-        maxConcurrency: 4,
-      });
-      expect(leased?.id).toBe(enqueued.id);
-
-      const { dispatcher, logger } = makeDispatcher();
-      expect(dispatcher.ackDispatch(enqueued.id, 'runner-1')).toBe(true);
-
-      const after = adapter.loadLaunchDispatchById(enqueued.id);
-      expect(after?.state).toBe('acknowledged');
-      expect(after?.dispatchOwner).toBe('runner-1');
-
-      const ackLog = logger.records.find((entry) => entry.msg.includes('ack'));
-      expect(ackLog?.fields?.accepted).toBe(true);
-      expect(ackLog?.fields?.dispatchId).toBe(enqueued.id);
-    });
-
-    it('ack returns false when the row is no longer leased', () => {
-      seedWorkflowAndTask();
-      const enqueued = adapter.enqueueLaunchDispatch({
-        taskId: 'wf-1/t1',
-        attemptId: 'attempt-ack-stale',
-        workflowId: 'wf-1',
-        generation: 0,
-      });
-
-      const { dispatcher } = makeDispatcher();
-      expect(dispatcher.ackDispatch(enqueued.id, 'runner-1')).toBe(false);
-    });
-
-    it('complete moves an acknowledged row to completed', () => {
+    it('complete moves a live row to completed', () => {
       seedWorkflowAndTask();
       const enqueued = adapter.enqueueLaunchDispatch({
         taskId: 'wf-1/t1',
@@ -244,7 +204,6 @@ describe('LaunchDispatcher', () => {
       });
       adapter.claimLaunchDispatchAtomic({
         ownerId: 'owner-test',
-        maxConcurrency: 4,
       });
 
       const { dispatcher } = makeDispatcher();
@@ -267,7 +226,6 @@ describe('LaunchDispatcher', () => {
       });
       adapter.claimLaunchDispatchAtomic({
         ownerId: 'owner-test',
-        maxConcurrency: 4,
       });
 
       const { dispatcher } = makeDispatcher();
@@ -359,7 +317,7 @@ describe('LaunchDispatcher', () => {
       expect(dispatcher.reapExpiredLeases()).toBe(0);
     });
 
-    it('abandonStuckLeases abandons acknowledged rows past max attempts and calls prepareTaskForNewAttempt', () => {
+    it('abandonStuckLeases abandons leased rows past max attempts and calls prepareTaskForNewAttempt', () => {
       seed();
       const row = adapter.enqueueLaunchDispatch({
         taskId: 'wf-r/t1',
@@ -370,7 +328,7 @@ describe('LaunchDispatcher', () => {
       const pastIso = new Date(Date.now() - 60_000).toISOString();
       (adapter as any).db.run(
         `UPDATE task_launch_dispatch
-           SET state = 'acknowledged', dispatch_owner = 'owner-x',
+           SET state = 'leased', dispatch_owner = 'owner-x',
                fenced_until = ?, attempts_count = 2, last_error = 'startup error'
          WHERE id = ?`,
         [pastIso, row.id],
@@ -405,7 +363,7 @@ describe('LaunchDispatcher', () => {
       const pastIso = new Date(Date.now() - 60_000).toISOString();
       (adapter as any).db.run(
         `UPDATE task_launch_dispatch
-           SET state = 'acknowledged', dispatch_owner = 'owner-x',
+           SET state = 'leased', dispatch_owner = 'owner-x',
                fenced_until = ?, attempts_count = 2, last_error = 'ssh-selection stuck'
          WHERE id = ?`,
         [pastIso, row.id],
@@ -488,7 +446,7 @@ describe('LaunchDispatcher', () => {
       const pastIso = new Date(Date.now() - 60_000).toISOString();
       (adapter as any).db.run(
         `UPDATE task_launch_dispatch
-           SET state = 'acknowledged', fenced_until = ?, attempts_count = 2,
+           SET state = 'leased', fenced_until = ?, attempts_count = 2,
                dispatch_owner = 'owner-x'
          WHERE id = ?`,
         [pastIso, row.id],
@@ -513,7 +471,7 @@ describe('LaunchDispatcher', () => {
       const futureIso = new Date(Date.now() + 60_000).toISOString();
       (adapter as any).db.run(
         `UPDATE task_launch_dispatch
-           SET state = 'acknowledged', fenced_until = ?, attempts_count = 5
+           SET state = 'leased', fenced_until = ?, attempts_count = 5
          WHERE id = ?`,
         [futureIso, futureRow.id],
       );
@@ -527,7 +485,7 @@ describe('LaunchDispatcher', () => {
       const pastIso = new Date(Date.now() - 60_000).toISOString();
       (adapter as any).db.run(
         `UPDATE task_launch_dispatch
-           SET state = 'acknowledged', fenced_until = ?, attempts_count = 1
+           SET state = 'leased', fenced_until = ?, attempts_count = 1
          WHERE id = ?`,
         [pastIso, underAttemptRow.id],
       );
@@ -621,7 +579,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
       dispatcher.poll();
 
@@ -633,7 +590,7 @@ describe('LaunchDispatcher', () => {
       expect(optsArg.launchOutbox).toBe(dispatcher);
 
       // Row is leased on this poll; the runner will transition it via
-      // ackDispatch/completeDispatch (those are unit-tested elsewhere).
+      // completeDispatch/failDispatch (those are unit-tested elsewhere).
       const after = adapter.loadLaunchDispatchById(enq.id);
       expect(after?.state).toBe('leased');
       expect(after?.dispatchOwner).toBe('owner-a');
@@ -678,7 +635,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 10,
         maxLeasesPerPoll: 2,
       });
       dispatcher.poll();
@@ -727,7 +683,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 1,
       });
 
       dispatcher.poll();
@@ -767,7 +722,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
 
       dispatcher.poll();
@@ -812,7 +766,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
 
       dispatcher.poll();
@@ -858,7 +811,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
       dispatcher.poll();
 
@@ -879,7 +831,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
       dispatcher.poll();
       expect(executeTask).not.toHaveBeenCalled();
@@ -906,7 +857,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
       dispatcher.poll();
       // Wait one microtask tick for the .catch backstop to run.

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SQLiteAdapter } from '@invoker/data-store';
-import type { Logger } from '@invoker/contracts';
+import { DISPATCH_LEASE_MS, type Logger } from '@invoker/contracts';
 import { InMemoryBus } from '@invoker/test-kit';
 import { Orchestrator } from '@invoker/workflow-core';
 import { LaunchDispatcher } from '../launch-dispatcher.js';
@@ -192,6 +192,35 @@ describe('LaunchDispatcher', () => {
       const { dispatcher } = makeDispatcher();
       expect(dispatcher.completeDispatch(enqueued.id)).toBe(true);
       expect(dispatcher.completeDispatch(enqueued.id)).toBe(false);
+    });
+
+    it('uses a fixed dispatch TTL long enough for normal executor startup', () => {
+      seedWorkflowAndTask('attempt-fixed-ttl');
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-1/t1',
+        attemptId: 'attempt-fixed-ttl',
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+      const claimedAt = '2026-06-04T22:38:44.000Z';
+      const claimed = adapter.claimLaunchDispatchAtomic({
+        ownerId: 'owner-test',
+        nowIso: claimedAt,
+      });
+      expect(claimed?.id).toBe(enqueued.id);
+      expect(claimed?.fencedUntil).toBe(
+        new Date(new Date(claimedAt).getTime() + DISPATCH_LEASE_MS).toISOString(),
+      );
+
+      const { dispatcher } = makeDispatcher();
+      expect(dispatcher.reapExpiredLeases(
+        new Date(new Date(claimedAt).getTime() + DISPATCH_LEASE_MS - 1).toISOString(),
+      )).toBe(0);
+      expect(adapter.loadLaunchDispatchById(enqueued.id)?.state).toBe('leased');
+      expect(dispatcher.reapExpiredLeases(
+        new Date(new Date(claimedAt).getTime() + DISPATCH_LEASE_MS + 1).toISOString(),
+      )).toBe(1);
+      expect(adapter.loadLaunchDispatchById(enqueued.id)?.state).toBe('enqueued');
     });
 
     it('fail re-enqueues a leased row with the error message and clears the owner', () => {

--- a/packages/app/src/__tests__/launch-invariant.test.ts
+++ b/packages/app/src/__tests__/launch-invariant.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { TaskEvent } from '@invoker/data-store';
+import { DISPATCH_LEASE_MS, DISPATCH_MAX_ATTEMPTS } from '@invoker/contracts';
 import {
   DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS,
   LaunchInvariantViolationError,
@@ -130,6 +131,8 @@ describe('assertLaunchInvariant', () => {
   });
 
   it('exposes a default maxGapMs anchored to the dispatch lease budget', () => {
-    expect(DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS).toBe(270_000);
+    expect(DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS).toBe(
+      DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30_000,
+    );
   });
 });

--- a/packages/app/src/__tests__/launch-invariant.ts
+++ b/packages/app/src/__tests__/launch-invariant.ts
@@ -22,6 +22,7 @@
  */
 
 import type { PersistenceAdapter, TaskEvent } from '@invoker/data-store';
+import { DISPATCH_LEASE_MS, DISPATCH_MAX_ATTEMPTS } from '@invoker/contracts';
 
 export const LAUNCH_CLAIM_EVENT_TYPE = 'task.launch_claimed';
 
@@ -35,13 +36,13 @@ export const TERMINAL_LAUNCH_EVENT_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Default upper bound on the gap between `task.launch_claimed` and the
- * next terminal launch event. Matches `3 * DISPATCH_LEASE_MS *
- * DISPATCH_MAX_ATTEMPTS` (= 270 s with the proposed dispatch defaults of
- * 30 s lease and 3 attempts). Tests that drive a deterministic in-memory
+ * Default upper bound on the gap between `task.launch_claimed` and the next
+ * terminal launch event. It follows the fixed dispatch crash-recovery window
+ * with a small scheduler buffer. Tests that drive a deterministic in-memory
  * scenario should pass a tighter bound.
  */
-export const DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS = 270_000;
+export const DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS =
+  DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30_000;
 
 export type LaunchInvariantPersistence = Pick<
   PersistenceAdapter,

--- a/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
+++ b/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
@@ -94,7 +94,6 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
       async executeTask(task, opts) {
         runnerCalls += 1;
         const dispatchOpts = opts!;
-        expect(dispatchOpts.launchOutbox.ackDispatch(dispatchOpts.dispatchId, 'pool-runner')).toBe(true);
         const attemptId = task.execution.selectedAttemptId!;
 
         if (runnerCalls === 1) {
@@ -118,7 +117,6 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
     }),
     ownerId: 'pool-owner',
     mode: 'active',
-    maxConcurrency: 1,
     maxLeasesPerPoll: 1,
   });
 
@@ -139,7 +137,7 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
     runnerCalls,
     task: orchestrator.getTask(taskId)!,
     liveRows: persistence
-      .listLaunchDispatchesByState(['enqueued', 'leased', 'acknowledged'])
+      .listLaunchDispatchesByState(['enqueued', 'leased'])
       .filter((row) => row.taskId === taskId)
       .map((row) => ({ attemptId: row.attemptId, state: row.state })),
     abandonedRows: persistence
@@ -155,7 +153,7 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
 }
 
 describe('launch pool deferral outbox repro', () => {
-  it('invalidates an acknowledged deferred row so it cannot block the replacement launch', async () => {
+  it('invalidates a leased deferred row so it cannot block the replacement launch', async () => {
     const result = await runPoolDeferralScenario({ completeDeferredDispatch: false });
 
     expect(result.runnerCalls).toBe(2);

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -219,7 +219,7 @@ describe('open-terminal integration', () => {
     // Mock the pool to return our temp directory
     Object.defineProperty(executor, 'pool', {
       value: {
-        ensureClone: vi.fn().mockResolvedValue(mockWorktreeDir),
+        ensureCloneThroughRepoQueue: vi.fn().mockResolvedValue(mockWorktreeDir),
         acquireWorktree: vi.fn().mockResolvedValue({
           worktreePath: mockWorktreeDir,
           branch: 'test-branch',

--- a/packages/app/src/__tests__/owner-resolver.test.ts
+++ b/packages/app/src/__tests__/owner-resolver.test.ts
@@ -277,6 +277,33 @@ describe('owner-resolver', () => {
       expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
     });
 
+    it('uses a standalone owner discovered after refresh without bootstrapping', async () => {
+      const firstBus = new LocalBus();
+      const secondBus = new LocalBus();
+      secondBus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-refreshed',
+        mode: 'standalone',
+      }));
+
+      const ensureStandaloneOwner = vi.fn(async () => {});
+      const refreshMessageBus = vi.fn(async () => secondBus);
+      const resolver = createOwnerResolver({
+        messageBus: firstBus,
+        refreshMessageBus,
+        ensureStandaloneOwner,
+      }, {
+        discoveryTimeoutMs: 100,
+        refreshDiscoveryTimeoutMs: 100,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-refreshed');
+      expect(result.bus).toBe(secondBus);
+      expect(refreshMessageBus).toHaveBeenCalledTimes(1);
+      expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    });
+
     it('retries bootstrap when the first attempt does not produce a reachable owner', async () => {
       const bus = new LocalBus();
       let bootstrapCalls = 0;
@@ -304,6 +331,38 @@ describe('owner-resolver', () => {
       const result = await resolver.resolve();
       expect(result.owner.ownerId).toBe('owner-retry');
       expect(bootstrapCalls).toBe(2);
+    });
+
+    it('retries configured bootstrap timeout errors', async () => {
+      const bus = new LocalBus();
+      const retryableError = new Error('owner bootstrap timed out');
+      let bootstrapCalls = 0;
+
+      const ensureStandaloneOwner = vi.fn(async () => {
+        bootstrapCalls += 1;
+        if (bootstrapCalls === 1) {
+          throw retryableError;
+        }
+        bus.onRequest('headless.owner-ping', async () => ({
+          ok: true,
+          ownerId: 'owner-after-timeout',
+          mode: 'standalone',
+        }));
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+        isRetryableBootstrapError: (error) => error === retryableError,
+      }, {
+        discoveryTimeoutMs: 100,
+        postBootstrapReadyTimeoutMs: 500,
+        maxBootstrapAttempts: 2,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-after-timeout');
+      expect(ensureStandaloneOwner).toHaveBeenCalledTimes(2);
     });
 
     it('throws after exhausting all bootstrap attempts', async () => {

--- a/packages/app/src/__tests__/system-diagnostics.test.ts
+++ b/packages/app/src/__tests__/system-diagnostics.test.ts
@@ -1,0 +1,68 @@
+import { mkdtempSync, writeFileSync, chmodSync, rmSync } from 'node:fs';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { describe, expect, it, afterAll, beforeAll } from 'vitest';
+
+import { detectTool } from '../system-diagnostics.js';
+
+/**
+ * Regression for the deterministic Electron main-thread wedge observed
+ * 2026-06-04: `spawnSync('docker', ['--version'])` blocked forever when
+ * Docker Desktop was installed but not running, which froze the renderer
+ * IPC handler `invoker:get-system-diagnostics` and consequently every
+ * other timer, IPC, and HTTP request on the main thread.
+ *
+ * The fix is the 3000ms `timeout` + SIGKILL on `spawnSync` inside
+ * `detectTool`. This test simulates a hanging CLI with a small shell
+ * script that sleeps for 60 seconds, and asserts:
+ *   1. detectTool returns within 4 seconds (well under 60s)
+ *   2. it returns `installed: false` for the hung tool (because we cannot
+ *      verify the binary works if it never replies)
+ */
+describe('detectTool — main-thread hang protection', () => {
+  let scratchDir: string;
+  let hangingCli: string;
+
+  beforeAll(() => {
+    scratchDir = mkdtempSync(path.join(tmpdir(), 'invoker-syscall-diag-'));
+    hangingCli = path.join(scratchDir, 'fake-hanging-cli');
+    writeFileSync(
+      hangingCli,
+      '#!/usr/bin/env bash\nsleep 60\nexit 0\n',
+      'utf8',
+    );
+    chmodSync(hangingCli, 0o755);
+  });
+
+  afterAll(() => {
+    rmSync(scratchDir, { recursive: true, force: true });
+  });
+
+  it('returns within ~3s when the CLI hangs (the Electron-wedge regression)', () => {
+    const startedAt = Date.now();
+    const result = detectTool(
+      'fake',
+      'Fake CLI',
+      hangingCli,
+      ['--version'],
+      'irrelevant install hint',
+    );
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(4000);
+    expect(result.installed).toBe(false);
+    expect(result.id).toBe('fake');
+  }, 6000);
+
+  it('still returns a populated version for a working CLI', () => {
+    const result = detectTool(
+      'node',
+      'Node.js',
+      'node',
+      ['--version'],
+      'irrelevant install hint',
+    );
+    expect(result.installed).toBe(true);
+    expect(result.version).toMatch(/^v\d+/);
+  }, 5000);
+});

--- a/packages/app/src/formatter.ts
+++ b/packages/app/src/formatter.ts
@@ -284,6 +284,8 @@ export function serializeTask(task: TaskState): Record<string, unknown> {
   if (task.config.command != null) config.command = task.config.command;
   if (task.config.prompt != null) config.prompt = task.config.prompt;
   if (task.config.runnerKind != null) config.runnerKind = task.config.runnerKind;
+  if (task.config.poolId != null) config.poolId = task.config.poolId;
+  if (task.config.poolMemberId != null) config.poolMemberId = task.config.poolMemberId;
   if (task.config.isMergeNode != null) config.isMergeNode = task.config.isMergeNode;
   if (task.config.executionAgent != null) config.executionAgent = task.config.executionAgent;
   if (task.config.featureBranch != null) config.featureBranch = task.config.featureBranch;
@@ -307,6 +309,7 @@ export function serializeTask(task: TaskState): Record<string, unknown> {
   if (task.execution.launchStartedAt != null) execution.launchStartedAt = task.execution.launchStartedAt instanceof Date ? task.execution.launchStartedAt.toISOString() : task.execution.launchStartedAt;
   if (task.execution.launchCompletedAt != null) execution.launchCompletedAt = task.execution.launchCompletedAt instanceof Date ? task.execution.launchCompletedAt.toISOString() : task.execution.launchCompletedAt;
   if (task.execution.lastHeartbeatAt != null) execution.lastHeartbeatAt = task.execution.lastHeartbeatAt instanceof Date ? task.execution.lastHeartbeatAt.toISOString() : task.execution.lastHeartbeatAt;
+  if (task.execution.pendingFixError != null) execution.pendingFixError = task.execution.pendingFixError;
   if (task.execution.mergeConflict != null) {
     execution.mergeConflict = {
       failedBranch: task.execution.mergeConflict.failedBranch,

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -23,10 +23,9 @@ import {
 import { loadConfig } from './config.js';
 import {
   discoverOwner,
-  isOwnerReachable,
   isStandaloneCapable,
 } from './owner-endpoint.js';
-import { createOwnerResolver } from './owner-resolver.js';
+import { createOwnerResolver, type ResolvedOwner } from './owner-resolver.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -206,53 +205,6 @@ async function delegateReadOnlyQuery(
   return true;
 }
 
-async function delegateAfterBootstrap(
-  args: string[],
-  deps: Pick<HeadlessClientDeps, 'refreshMessageBus'>,
-  bus: MessageBus,
-  waitForApproval?: boolean,
-  noTrack?: boolean,
-): Promise<DelegationOutcome> {
-  const startedAt = Date.now();
-  delegationClientLog(`post-bootstrap delegation loop begin timeoutMs=${POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS}`);
-  const deadline = Date.now() + POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS;
-  let messageBus = bus;
-  let attempts = 0;
-  let lastOutcome: DelegationOutcome = { kind: 'no-handler' };
-  while (Date.now() < deadline) {
-    attempts += 1;
-    const owner = await discoverOwner(messageBus, 1_000);
-    delegationClientLog(
-      `post-bootstrap attempt=${attempts} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
-    );
-    if (isStandaloneCapable(owner)) {
-      const outcome = await delegateMutation(
-        args,
-        messageBus,
-        waitForApproval,
-        noTrack,
-        noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
-      );
-      lastOutcome = outcome;
-      if (outcome.kind === 'delegated') {
-        delegationClientLog(`post-bootstrap delegation succeeded attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
-        return outcome;
-      }
-      if (outcome.kind === 'protocol-error') {
-        delegationClientLog(`post-bootstrap protocol-error attempts=${attempts} message=${outcome.message}`);
-        return outcome;
-      }
-      // timeout or no-handler: retry after refresh
-    }
-    if (deps.refreshMessageBus) {
-      messageBus = await deps.refreshMessageBus();
-    }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-  delegationClientLog(`post-bootstrap delegation exhausted attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
-  return lastOutcome;
-}
-
 export interface HeadlessClientDeps {
   messageBus: MessageBus;
   ensureStandaloneOwner: (bus?: MessageBus) => Promise<void>;
@@ -331,107 +283,59 @@ async function resolveOwnerAndDelegate(
 ): Promise<number | null> {
   const startedAt = Date.now();
   delegationClientLog(`resolveOwnerAndDelegate begin command=${args[0] ?? '<missing>'} noTrack=${noTrack ? 'true' : 'false'}`);
-  let messageBus = deps.messageBus;
   const resolvedExitCode = (): number => {
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
   };
 
-  // Phase 1: Discover a standalone-capable owner and delegate
-  const owner = await discoverOwner(messageBus, 3_000);
-  delegationClientLog(
-    `phase1 discover standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
+  const resolver = createOwnerResolver(
+    {
+      messageBus: deps.messageBus,
+      refreshMessageBus: deps.refreshMessageBus,
+      ensureStandaloneOwner: deps.ensureStandaloneOwner,
+      isRetryableBootstrapError: isSharedMutationOwnerTimeoutError,
+    },
+    {
+      discoveryTimeoutMs: 3_000,
+      refreshDiscoveryTimeoutMs: 1_000,
+      postBootstrapReadyTimeoutMs: POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS,
+      maxBootstrapAttempts: POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS,
+    },
   );
-  if (isStandaloneCapable(owner)) {
-    const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
-    delegationClientLog(`phase1 outcome=${outcome.kind}`);
-    if (outcome.kind === 'delegated') {
-      delegationClientLog(`phase1 delegated successfully elapsedMs=${Date.now() - startedAt}`);
-      return resolvedExitCode();
-    }
-    if (outcome.kind === 'protocol-error') {
-      delegationClientLog(`phase1 protocol-error: ${outcome.message}`);
-      return null;
-    }
-    // timeout or no-handler: fall through to next phase
-  }
 
-  // Phase 2: Try any reachable owner (may be non-standalone)
-  if (isOwnerReachable(owner)) {
-    const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
-    delegationClientLog(`phase2 outcome=${outcome.kind} ownerId=${owner.ownerId}`);
-    if (outcome.kind === 'delegated') {
-      delegationClientLog(`phase2 delegated to reachable owner elapsedMs=${Date.now() - startedAt}`);
-      return resolvedExitCode();
-    }
-    if (outcome.kind === 'protocol-error') {
-      delegationClientLog(`phase2 protocol-error: ${outcome.message}`);
-      return null;
-    }
-  } else {
-    delegationClientLog('phase2 skipped: no reachable owner');
-  }
-
-  // Phase 3: Refresh and retry against any reachable owner
-  if (isOwnerReachable(owner) && deps.refreshMessageBus) {
-    delegationClientLog('phase3 refreshing message bus');
-    messageBus = await deps.refreshMessageBus();
-    const refreshedOwner = await discoverOwner(messageBus, 1_000);
-    delegationClientLog(
-      `phase3 discover ownerReachable=${isOwnerReachable(refreshedOwner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(refreshedOwner) ? 'true' : 'false'} ownerId=${refreshedOwner?.ownerId ?? '<none>'}`,
-    );
-    if (isOwnerReachable(refreshedOwner)) {
-      const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
-      delegationClientLog(`phase3 outcome=${outcome.kind}`);
-      if (outcome.kind === 'delegated') {
-        delegationClientLog(`phase3 delegated successfully elapsedMs=${Date.now() - startedAt}`);
-        return resolvedExitCode();
-      }
-      if (outcome.kind === 'protocol-error') {
-        delegationClientLog(`phase3 protocol-error: ${outcome.message}`);
+  for (let attempt = 0; attempt < POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS; attempt += 1) {
+    delegationClientLog(`resolve attempt=${attempt + 1}/${POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS}`);
+    let resolved: ResolvedOwner;
+    try {
+      resolved = await resolver.resolve(true);
+    } catch (err) {
+      if (err instanceof Error && /Could not resolve a standalone-capable owner/.test(err.message)) {
+        delegationClientLog(`resolve attempt failed: ${err.message}`);
         return null;
       }
+      throw err;
     }
-    delegationClientLog('phase3 delegation did not succeed');
-  }
+    delegationClientLog(`resolved standalone ownerId=${resolved.owner.ownerId}`);
 
-  // Phase 4: Bootstrap with bounded retry loop
-  if (deps.refreshMessageBus) {
-    messageBus = await deps.refreshMessageBus();
-  }
-  for (let attempt = 0; attempt < POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS; attempt += 1) {
-    delegationClientLog(`phase4 bootstrap attempt=${attempt + 1}/${POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS}`);
-    try {
-      await deps.ensureStandaloneOwner(messageBus);
-    } catch (err) {
-      if (!isSharedMutationOwnerTimeoutError(err)) {
-        throw err;
-      }
-      if (!deps.refreshMessageBus) {
-        throw err;
-      }
-      delegationClientLog(`phase4 bootstrap timeout; refreshing bus and retrying attempt=${attempt + 1}`);
-      messageBus = await deps.refreshMessageBus();
-      await deps.ensureStandaloneOwner(messageBus);
-    }
-    if (deps.refreshMessageBus) {
-      messageBus = await deps.refreshMessageBus();
-    }
-    const outcome = await delegateAfterBootstrap(args, deps, messageBus, waitForApproval, noTrack);
-    delegationClientLog(`phase4 post-bootstrap outcome=${outcome.kind} attempt=${attempt + 1}`);
+    const outcome = await delegateMutation(
+      args,
+      resolved.bus,
+      waitForApproval,
+      noTrack,
+      noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
+    );
+    delegationClientLog(`delegate outcome=${outcome.kind} attempt=${attempt + 1}`);
     if (outcome.kind === 'delegated') {
-      delegationClientLog(`phase4 delegated successfully attempt=${attempt + 1} elapsedMs=${Date.now() - startedAt}`);
+      delegationClientLog(`delegated successfully attempt=${attempt + 1} elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
     if (outcome.kind === 'protocol-error') {
-      delegationClientLog(`phase4 protocol-error attempt=${attempt + 1}: ${outcome.message}`);
+      delegationClientLog(`protocol-error attempt=${attempt + 1}: ${outcome.message}`);
       return null;
     }
-    // timeout or no-handler: retry next bootstrap attempt
     if (!deps.refreshMessageBus) {
       break;
     }
-    messageBus = await deps.refreshMessageBus();
   }
 
   delegationClientLog(`resolveOwnerAndDelegate failed after elapsedMs=${Date.now() - startedAt}`);

--- a/packages/app/src/headless-owner-bootstrap.ts
+++ b/packages/app/src/headless-owner-bootstrap.ts
@@ -13,6 +13,7 @@ export function tryAcquireOwnerBootstrapLock(invokerHomeRoot: string): OwnerBoot
   const lockDir = join(invokerHomeRoot, OWNER_BOOTSTRAP_LOCK_DIR);
 
   try {
+    mkdirSync(invokerHomeRoot, { recursive: true });
     mkdirSync(lockDir);
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
@@ -28,10 +29,12 @@ export function tryAcquireOwnerBootstrapLock(invokerHomeRoot: string): OwnerBoot
           return tryAcquireOwnerBootstrapLock(invokerHomeRoot);
         }
       }
+      rmSync(lockDir, { recursive: true, force: true });
+      return tryAcquireOwnerBootstrapLock(invokerHomeRoot);
     } catch {
-      return null;
+      rmSync(lockDir, { recursive: true, force: true });
+      return tryAcquireOwnerBootstrapLock(invokerHomeRoot);
     }
-    return null;
   }
 
   writeFileSync(join(lockDir, 'pid'), String(process.pid), 'utf8');

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -311,7 +311,6 @@ async function dispatchHeadlessRunnableTasks(
     ownerId: `headless-${process.pid}`,
     logger: deps.logger,
     mode: 'active',
-    maxConcurrency: Math.max(1, deps.invokerConfig.maxConcurrency ?? 16),
   });
   deps.logger?.debug?.(
     `[headless] ${context}: launchOutboxMode=active — polling local launch dispatcher for ${runnable.length} runnable task(s)`,
@@ -1021,6 +1020,7 @@ async function headlessMigrateCompatibility(deps: HeadlessDeps): Promise<void> {
   process.stdout.write(`  migratedFixingWithAiStatuses: ${report.migratedFixingWithAiStatuses}\n`);
   process.stdout.write(`  normalizedMergeModes: ${report.normalizedMergeModes}\n`);
   process.stdout.write(`  staleAutoFixExperimentTasks: ${report.staleAutoFixExperimentTasks}\n`);
+  process.stdout.write(`  normalizedLegacyAcknowledgedLaunchDispatches: ${report.normalizedLegacyAcknowledgedLaunchDispatches}\n`);
 }
 
 async function headlessInstallSkills(

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1637,6 +1637,37 @@ async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<vo
     const runnable = result.data.filter(isDispatchableLaunch);
     process.stdout.write(`Restarted task "${taskId}" — ${runnable.length} task(s) to execute\n`);
 
+    if (deps.noTrack) {
+      const runningKey = (task: TaskState): string => {
+        const attemptId = task.execution.selectedAttemptId?.trim();
+        return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
+      };
+      const scopedKeys = new Set(runnable.map((task) => runningKey(task)));
+      const globalTopup = deps.orchestrator
+        .startExecution()
+        .filter(isDispatchableLaunch)
+        .filter((task) => !scopedKeys.has(runningKey(task)));
+      const dispatchable = [...runnable, ...globalTopup];
+      if (dispatchable.length > 0) {
+        if (deps.deferRunnableTasks) {
+          deps.deferRunnableTasks(dispatchable, restored.workflowId);
+        } else {
+          const taskExecutor = createHeadlessExecutor(deps);
+          const launch = setTimeout(() => {
+            void taskExecutor.executeTasks(dispatchable).catch((err) => {
+              deps.logger.error(
+                `background no-track task retry failed for ${taskId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+                { module: 'headless' },
+              );
+            });
+          }, 25);
+          launch.unref?.();
+        }
+      }
+      process.stdout.write('[headless] --no-track enabled: retry-task accepted; exiting without tracking.\n');
+      return;
+    }
+
     const taskExecutor = createHeadlessExecutor(deps);
     const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
     const { topup } = await dispatchStartedTasksWithGlobalTopup({

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -3,6 +3,7 @@ import type { Logger, SearchOptions } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
 import type { Orchestrator, TaskDelta, TaskState } from '@invoker/workflow-core';
+import type { MessageBus } from '@invoker/transport';
 import { loadConfig } from './config.js';
 import type { TaskSnapshotCache } from './delta-merge.js';
 
@@ -24,6 +25,8 @@ export interface RegisterReadOnlyIpcHandlersContext {
     agentRegistry: AgentRegistry,
     tasks: TaskState[],
   ) => Promise<unknown>;
+  getOwnerMode?: () => boolean;
+  getMessageBus?: () => Pick<MessageBus, 'request'>;
   timeStartupPhase: <T>(label: string, fn: () => T, fields?: () => Record<string, unknown>) => T;
   recordStartupDuration: (label: string, startedAtMs: number, fields?: Record<string, unknown>) => void;
   getTaskDeltaStreamSequence: () => number;
@@ -43,6 +46,8 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     setLastKnownWorkflowCount,
     loadTaskByIdFromPersistence,
     resolveAgentSession,
+    getOwnerMode,
+    getMessageBus,
     timeStartupPhase,
     recordStartupDuration,
     getTaskDeltaStreamSequence,
@@ -68,9 +73,52 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     return { workflow, tasks };
   });
 
-  ipcMain.handle('invoker:get-tasks', (_event, forceRefresh?: boolean) => {
+  ipcMain.handle('invoker:get-tasks', async (_event, forceRefresh?: boolean) => {
     const startedAtMs = Date.now();
     const orchestrator = getOrchestrator();
+    if (forceRefresh && getOwnerMode?.() === false) {
+      try {
+        const delegated = await getMessageBus?.().request<{ kind: string; forceRefresh: boolean }, {
+          tasks: TaskState[];
+          workflows: unknown[];
+          streamSequence: number;
+        }>('headless.query', { kind: 'tasks', forceRefresh: true });
+        if (delegated && Array.isArray(delegated.tasks) && Array.isArray(delegated.workflows)) {
+          const previousTaskIds = new Set(lastKnownTaskStates.keys());
+          lastKnownTaskStates.clear();
+          for (const task of delegated.tasks) {
+            lastKnownTaskStates.set(task.id, JSON.stringify(task));
+            previousTaskIds.delete(task.id);
+            const mainWindow = getMainWindow();
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              sendTaskDeltaToRenderer({ type: 'created', task });
+            }
+          }
+          const mainWindow = getMainWindow();
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            for (const removedTaskId of previousTaskIds) {
+              sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
+            }
+            requestWorkflowMetadataPublish('get-tasks-force-refresh-delegated');
+          }
+          setLastKnownWorkflowCount(delegated.workflows.length);
+          recordStartupDuration('get-tasks.force-refresh.delegated-return', startedAtMs, {
+            taskCount: delegated.tasks.length,
+            workflowCount: delegated.workflows.length,
+            jsonSizeBytes: Buffer.byteLength(JSON.stringify(delegated), 'utf8'),
+            streamSequence: delegated.streamSequence,
+          });
+          return delegated;
+        }
+      } catch (err) {
+        logger.warn(
+          `get-tasks(forceRefresh=true) owner delegation failed; falling back to local read-only snapshot: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          { module: 'ipc' },
+        );
+      }
+    }
     if (forceRefresh) {
       timeStartupPhase('get-tasks.force-refresh.syncAllFromDb', () => orchestrator.syncAllFromDb(), () => ({
         taskCount: orchestrator.getAllTasks().length,

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -53,6 +53,21 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     getTaskDeltaStreamSequence,
   } = context;
 
+  async function delegateOwnerQuery<T>(kind: string, request: Record<string, unknown> = {}): Promise<T | null> {
+    if (getOwnerMode?.() !== false) return null;
+    try {
+      return await getMessageBus?.().request<Record<string, unknown>, T>('headless.query', { kind, ...request }) ?? null;
+    } catch (err) {
+      logger.warn(
+        `${kind} owner delegation failed; falling back to local read-only snapshot: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { module: 'ipc' },
+      );
+      return null;
+    }
+  }
+
   ipcMain.handle('invoker:list-workflows', () => persistence.listWorkflows());
   ipcMain.handle('invoker:get-execution-pools', () => Object.keys(loadConfig().executionPools ?? {}));
 
@@ -76,48 +91,37 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
   ipcMain.handle('invoker:get-tasks', async (_event, forceRefresh?: boolean) => {
     const startedAtMs = Date.now();
     const orchestrator = getOrchestrator();
-    if (forceRefresh && getOwnerMode?.() === false) {
-      try {
-        const delegated = await getMessageBus?.().request<{ kind: string; forceRefresh: boolean }, {
-          tasks: TaskState[];
-          workflows: unknown[];
-          streamSequence: number;
-        }>('headless.query', { kind: 'tasks', forceRefresh: true });
-        if (delegated && Array.isArray(delegated.tasks) && Array.isArray(delegated.workflows)) {
-          const previousTaskIds = new Set(lastKnownTaskStates.keys());
-          lastKnownTaskStates.clear();
-          for (const task of delegated.tasks) {
-            lastKnownTaskStates.set(task.id, JSON.stringify(task));
-            previousTaskIds.delete(task.id);
-            const mainWindow = getMainWindow();
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              sendTaskDeltaToRenderer({ type: 'created', task });
-            }
-          }
-          const mainWindow = getMainWindow();
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            for (const removedTaskId of previousTaskIds) {
-              sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
-            }
-            requestWorkflowMetadataPublish('get-tasks-force-refresh-delegated');
-          }
-          setLastKnownWorkflowCount(delegated.workflows.length);
-          recordStartupDuration('get-tasks.force-refresh.delegated-return', startedAtMs, {
-            taskCount: delegated.tasks.length,
-            workflowCount: delegated.workflows.length,
-            jsonSizeBytes: Buffer.byteLength(JSON.stringify(delegated), 'utf8'),
-            streamSequence: delegated.streamSequence,
-          });
-          return delegated;
+    const delegated = await delegateOwnerQuery<{
+      tasks: TaskState[];
+      workflows: unknown[];
+      streamSequence: number;
+    }>('tasks', { forceRefresh: forceRefresh === true });
+    if (delegated && Array.isArray(delegated.tasks) && Array.isArray(delegated.workflows)) {
+      const previousTaskIds = new Set(lastKnownTaskStates.keys());
+      lastKnownTaskStates.clear();
+      for (const task of delegated.tasks) {
+        lastKnownTaskStates.set(task.id, JSON.stringify(task));
+        previousTaskIds.delete(task.id);
+        const mainWindow = getMainWindow();
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          sendTaskDeltaToRenderer({ type: 'created', task });
         }
-      } catch (err) {
-        logger.warn(
-          `get-tasks(forceRefresh=true) owner delegation failed; falling back to local read-only snapshot: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-          { module: 'ipc' },
-        );
       }
+      const mainWindow = getMainWindow();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        for (const removedTaskId of previousTaskIds) {
+          sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
+        }
+        requestWorkflowMetadataPublish(forceRefresh ? 'get-tasks-force-refresh-delegated' : 'get-tasks-delegated');
+      }
+      setLastKnownWorkflowCount(delegated.workflows.length);
+      recordStartupDuration(forceRefresh ? 'get-tasks.force-refresh.delegated-return' : 'get-tasks.delegated-return', startedAtMs, {
+        taskCount: delegated.tasks.length,
+        workflowCount: delegated.workflows.length,
+        jsonSizeBytes: Buffer.byteLength(JSON.stringify(delegated), 'utf8'),
+        streamSequence: delegated.streamSequence,
+      });
+      return delegated;
     }
     if (forceRefresh) {
       timeStartupPhase('get-tasks.force-refresh.syncAllFromDb', () => orchestrator.syncAllFromDb(), () => ({
@@ -163,7 +167,9 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
   });
 
   ipcMain.handle('invoker:get-events', (_event, taskId: string) => persistence.getEvents(taskId));
-  ipcMain.handle('invoker:get-status', () => getOrchestrator().getWorkflowStatus());
+  ipcMain.handle('invoker:get-status', async () => (
+    await delegateOwnerQuery('workflow-status') ?? getOrchestrator().getWorkflowStatus()
+  ));
   ipcMain.handle('invoker:get-task-by-id', (_event, taskId: string) => loadTaskByIdFromPersistence(taskId) ?? null);
   ipcMain.handle('invoker:get-task-output', (_event, taskId: string) => persistence.getTaskOutput(taskId));
   ipcMain.handle('invoker:get-output-chunks', (_event, taskId: string) => persistence.getOutputChunks(taskId));

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -17,6 +17,7 @@ export interface GuiMutationRegistrationContext {
   ipcMain: IpcMain;
   getOwnerMode: () => boolean;
   getMessageBus: () => Pick<MessageBus, 'request'>;
+  refreshOwnerRoute?: () => Promise<void>;
   translateGuiMutationToHeadless: (payload: GuiMutationPayload) => TranslatedGuiMutation;
   guiMutationHandlers?: Map<string, (...args: unknown[]) => Promise<unknown>>;
 }
@@ -41,7 +42,34 @@ export function registerGuiMutationHandler<TResult = unknown>(
         translated.request,
       );
     } catch (err) {
-      if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
+      if (
+        err instanceof TransportError
+        && (
+          err.code === TransportErrorCode.NO_HANDLER
+          || err.code === TransportErrorCode.DISCONNECTED
+        )
+        && context.refreshOwnerRoute
+      ) {
+        await context.refreshOwnerRoute();
+        try {
+          return await context.getMessageBus().request<typeof translated.request, TResult>(
+            translated.channel,
+            translated.request,
+          );
+        } catch (retryErr) {
+          if (retryErr instanceof TransportError && retryErr.code === TransportErrorCode.NO_HANDLER) {
+            throw new Error('No mutation owner is available');
+          }
+          throw retryErr;
+        }
+      }
+      if (
+        err instanceof TransportError
+        && (
+          err.code === TransportErrorCode.NO_HANDLER
+          || err.code === TransportErrorCode.DISCONNECTED
+        )
+      ) {
         throw new Error('No mutation owner is available');
       }
       throw err;

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -23,12 +23,11 @@ export type LaunchDispatcherMode = 'observe' | 'active';
 export type LaunchDispatcherPersistence = Pick<
   SQLiteAdapter,
   | 'listLaunchDispatchesByState'
-  | 'markLaunchDispatchAcknowledged'
   | 'markLaunchDispatchCompleted'
   | 'markLaunchDispatchFailed'
   | 'markLaunchDispatchAbandoned'
   | 'reapExpiredLaunchDispatchLeases'
-  | 'listAbandonableAcknowledgedLeases'
+  | 'listAbandonableLaunchDispatchLeases'
   | 'claimLaunchDispatchAtomic'
   | 'listExecutionResourceLeasesByTask'
   | 'releaseExecutionResourceLease'
@@ -77,14 +76,12 @@ export interface LaunchDispatcherOptions {
   logger?: Logger;
   mode: LaunchDispatcherMode;
   maxAttempts?: number;
-  maxConcurrency?: number;
   maxLeasesPerPoll?: number;
 }
 
 const OBSERVED_STATES: readonly TaskLaunchDispatchState[] = [
   'enqueued',
   'leased',
-  'acknowledged',
 ];
 
 export class LaunchDispatcher {
@@ -95,7 +92,6 @@ export class LaunchDispatcher {
   private readonly logger?: Logger;
   private readonly mode: LaunchDispatcherMode;
   private readonly maxAttempts: number;
-  private readonly maxConcurrency: number;
   private readonly maxLeasesPerPoll: number;
 
   constructor(options: LaunchDispatcherOptions) {
@@ -106,7 +102,6 @@ export class LaunchDispatcher {
     this.logger = options.logger;
     this.mode = options.mode;
     this.maxAttempts = options.maxAttempts ?? DISPATCH_MAX_ATTEMPTS;
-    this.maxConcurrency = options.maxConcurrency ?? 16;
     // Bound a single poll's work so the dispatcher cannot starve other
     // owner-loop ticks; the leftover rows are picked up on the next tick.
     this.maxLeasesPerPoll = options.maxLeasesPerPoll ?? 32;
@@ -124,11 +119,11 @@ export class LaunchDispatcher {
    * Single dispatcher tick:
    *
    *   1. Reap any leased rows whose dispatch lease expired (TaskRunner
-   *      never acked — we want to try again).
-   *   2. Abandon any acknowledged rows whose dispatch lease expired AND
-   *      that have exhausted their retry budget (TaskRunner accepted
-   *      ownership but never completed; report the failure and let the
-   *      orchestrator prepare a fresh attempt).
+   *      never completed startup — we want to try again).
+   *   2. Abandon any leased rows whose dispatch lease expired AND that
+   *      have exhausted their retry budget (TaskRunner accepted ownership
+   *      but never completed; report the failure and let the orchestrator
+   *      prepare a fresh attempt).
    *   3. In observe mode, log the aggregate state counts. In active mode,
    *      (CB.5) lease and dispatch new work.
    *
@@ -157,10 +152,10 @@ export class LaunchDispatcher {
   }
 
   /**
-   * Active-mode dispatch loop. Lease as many enqueued rows as capacity
-   * allows (bounded by `maxLeasesPerPoll`) and hand each one to the
-   * TaskRunner. The TaskRunner ack/complete/fail flow drives the rest
-   * of the lifecycle; if the JS promise drops mid-flight, the durable
+   * Active-mode dispatch loop. Lease enqueued rows up to the per-poll
+   * batch bound and hand each one to the
+   * TaskRunner. The TaskRunner complete/fail flow drives the rest of
+   * the lifecycle; if the JS promise drops mid-flight, the durable
    * outbox row stays leased and the next poll's `reapExpiredLeases`
    * reclaims it after `DISPATCH_LEASE_MS`.
    */
@@ -177,7 +172,6 @@ export class LaunchDispatcher {
     while (dispatched < this.maxLeasesPerPoll) {
       const leased = this.persistence.claimLaunchDispatchAtomic({
         ownerId: this.ownerId,
-        maxConcurrency: this.maxConcurrency,
       });
       if (!leased) break;
       dispatched += 1;
@@ -297,7 +291,10 @@ export class LaunchDispatcher {
    * Returns the number of rows reaped.
    */
   reapExpiredLeases(nowIso?: string): number {
-    const reaped = this.persistence.reapExpiredLaunchDispatchLeases(nowIso);
+    const reaped = this.persistence.reapExpiredLaunchDispatchLeases({
+      nowIso,
+      maxAttempts: this.maxAttempts,
+    });
     for (const row of reaped) {
       this.persistence.logEvent?.(row.taskId, 'task.launch_dispatch_reaped', {
         dispatchId: row.id,
@@ -318,14 +315,14 @@ export class LaunchDispatcher {
   }
 
   /**
-   * For every `acknowledged` row whose fence has expired AND whose
+   * For every `leased` row whose fence has expired AND whose
    * attempts_count has reached `maxAttempts`, transition it to
    * `abandoned`, ask the orchestrator to prepare a fresh attempt, and
    * emit a real `task.failed` event with a concrete error message.
    * Returns the number of rows abandoned.
    */
   abandonStuckLeases(nowIso?: string): number {
-    const candidates = this.persistence.listAbandonableAcknowledgedLeases({
+    const candidates = this.persistence.listAbandonableLaunchDispatchLeases({
       nowIso,
       maxAttempts: this.maxAttempts,
     });
@@ -446,26 +443,7 @@ export class LaunchDispatcher {
   }
 
   /**
-   * Transition a leased dispatch row to acknowledged. Called by the
-   * TaskRunner at the top of {@link executeTask} once it has accepted
-   * ownership of the launch. Returns false when the row is no longer
-   * in `leased` (e.g. it was reaped first), in which case the runner
-   * should bail out without starting the executor.
-   */
-  ackDispatch(dispatchId: number, runnerId: string): boolean {
-    const ok = this.persistence.markLaunchDispatchAcknowledged(dispatchId, runnerId);
-    this.logger?.info?.('[launch-dispatcher] ack', {
-      ownerId: this.ownerId,
-      dispatchId,
-      runnerId,
-      accepted: ok,
-      module: 'launch-dispatcher',
-    });
-    return ok;
-  }
-
-  /**
-   * Transition an acknowledged dispatch row to completed. Called by the
+   * Transition a live dispatch row to completed. Called by the
    * TaskRunner once {@link markTaskRunningAfterLaunch} has succeeded
    * (the executor handle is live and the task is in the executing
    * phase). Returns false when the row is already terminal.
@@ -508,7 +486,6 @@ function countByState(
   const counts: Record<TaskLaunchDispatchState, number> = {
     enqueued: 0,
     leased: 0,
-    acknowledged: 0,
     completed: 0,
     abandoned: 0,
   };

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -155,9 +155,9 @@ export class LaunchDispatcher {
    * Active-mode dispatch loop. Lease enqueued rows up to the per-poll
    * batch bound and hand each one to the
    * TaskRunner. The TaskRunner complete/fail flow drives the rest of
-   * the lifecycle; if the JS promise drops mid-flight, the durable
-   * outbox row stays leased and the next poll's `reapExpiredLeases`
-   * reclaims it after `DISPATCH_LEASE_MS`.
+   * the lifecycle; if the JS promise drops mid-flight, the durable outbox
+   * row stays leased until the fixed dispatch crash-recovery TTL expires,
+   * then the next poll's `reapExpiredLeases` reclaims it.
    */
   private dispatchActive(): void {
     const runner = this.taskRunnerProvider?.() ?? null;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1007,6 +1007,32 @@ if (isHeadless) {
           };
 
           switch (command) {
+            case 'set': {
+              const [, subCommand, targetArg] = payload.args;
+              switch (subCommand) {
+                case 'workflow':
+                case 'merge-mode':
+                  return {
+                    workflowId: targetArg === undefined ? undefined : String(targetArg),
+                    priority: 'high',
+                  };
+                case 'command':
+                case 'prompt':
+                case 'executor':
+                case 'agent':
+                case 'fix-prompt':
+                case 'fix-context':
+                case 'gate-policy':
+                case 'task':
+                  return {
+                    workflowId: targetArg === undefined ? undefined : standaloneWorkflowIdForTaskArg(targetArg),
+                    priority: 'high',
+                  };
+                default:
+                  return { priority: 'normal' };
+              }
+            }
+            case 'resume':
             case 'retry':
               return {
                 workflowId: arg0 === undefined ? undefined : standaloneWorkflowIdForTaskArg(arg0),
@@ -1019,6 +1045,7 @@ if (isHeadless) {
             case 'rebase-recreate':
               return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'high' };
             case 'cancel':
+            case 'retry-task':
             case 'recreate-task':
               return { workflowId: standaloneWorkflowIdForTaskArg(arg0), priority: 'high' };
             case 'approve':
@@ -2016,8 +2043,28 @@ function createEmbeddedTerminalBackendFromConfig(
     if (!command) return { priority: 'normal' };
 
     switch (command) {
+      case 'set': {
+        const [, subCommand, targetArg] = payload.args;
+        switch (subCommand) {
+          case 'workflow':
+          case 'merge-mode':
+            return { workflowId: targetArg === undefined ? undefined : String(targetArg), priority: 'high' };
+          case 'command':
+          case 'prompt':
+          case 'executor':
+          case 'agent':
+          case 'fix-prompt':
+          case 'fix-context':
+          case 'gate-policy':
+          case 'task':
+            return { workflowId: workflowIdForTaskArg(targetArg), priority: 'high' };
+          default:
+            return { priority: 'normal' };
+        }
+      }
+      case 'resume':
       case 'retry':
-        return { workflowId: workflowIdForTaskArg(arg0), priority: 'high' };
+        return { workflowId: workflowIdForTargetArg(arg0), priority: 'high' };
       case 'recreate':
       case 'cancel-workflow':
       case 'delete':
@@ -2027,6 +2074,7 @@ function createEmbeddedTerminalBackendFromConfig(
       case 'rebase-recreate':
         return { workflowId: workflowIdForTargetArg(arg0), priority: 'high' };
       case 'cancel':
+      case 'retry-task':
       case 'recreate-task':
         return { workflowId: workflowIdForTaskArg(arg0), priority: 'high' };
       case 'approve':

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -189,6 +189,11 @@ import {
   type HeadlessExecMutationPayload,
 } from './headless-batch-exec.js';
 import {
+  spawnDetachedStandaloneOwner,
+  tryAcquireOwnerBootstrapLock,
+} from './headless-owner-bootstrap.js';
+import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
+import {
   rebuildTaskRunner as rebuildTaskRunnerWiring,
   requireWiredTaskRunner,
   type TaskHandleMap,
@@ -295,6 +300,26 @@ interface HeadlessResumeMutationPayload {
 }
 
 type HeadlessOwnerMode = 'standalone' | 'gui';
+type GuiOwnerPreference = 'auto' | 'daemon' | 'gui';
+
+function resolveGuiOwnerPreference(): GuiOwnerPreference {
+  const raw = (process.env.INVOKER_GUI_OWNER_MODE ?? '').trim().toLowerCase();
+  if (raw === 'daemon' || raw === 'client' || raw === 'follower') return 'daemon';
+  if (raw === 'auto') return 'auto';
+  if (raw === 'gui' || raw === 'owner' || raw === 'local') return 'gui';
+  if (process.env.INVOKER_GUI_DAEMON_OWNER === '1') return 'daemon';
+  return 'daemon';
+}
+
+function guiOwnerBootstrapTimeoutMs(): number {
+  const parsed = Number.parseInt(
+    process.env.INVOKER_GUI_OWNER_BOOTSTRAP_TIMEOUT_MS
+      ?? process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS
+      ?? '60000',
+    10,
+  );
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60000;
+}
 
 function headlessExecLogFields(
   payload: HeadlessExecMutationPayload,
@@ -387,6 +412,69 @@ const invokerConfig: InvokerConfig = (() => {
   }
 })();
 
+async function discoverStandaloneOwnerForGui(waitMs: number): Promise<boolean> {
+  let ownerBus = new IpcBus(undefined, { allowServe: false });
+  try {
+    await ownerBus.ready();
+    const deadline = Date.now() + waitMs;
+    while (Date.now() < deadline) {
+      const owner = await discoverOwner(ownerBus, 500);
+      if (isStandaloneCapable(owner)) {
+        logger.info(`daemon owner ready ownerId=${owner.ownerId}`, { module: 'init' });
+        return true;
+      }
+      ownerBus.disconnect();
+      ownerBus = new IpcBus(undefined, { allowServe: false });
+      await ownerBus.ready();
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    return false;
+  } finally {
+    ownerBus.disconnect();
+  }
+}
+
+async function ensureStandaloneOwnerForGui(): Promise<void> {
+  if (await discoverStandaloneOwnerForGui(2_000)) return;
+
+  const invokerHomeRoot = resolveInvokerHomeRoot();
+  const timeoutMs = guiOwnerBootstrapTimeoutMs();
+  const bootstrapLock = tryAcquireOwnerBootstrapLock(invokerHomeRoot);
+  try {
+    if (bootstrapLock) {
+      logger.info('spawning daemon owner for GUI client mode', { module: 'init' });
+      spawnDetachedStandaloneOwner(repoRoot);
+    } else {
+      logger.info('waiting for daemon owner bootstrap held by another process', { module: 'init' });
+    }
+    if (await discoverStandaloneOwnerForGui(timeoutMs)) return;
+  } finally {
+    bootstrapLock?.release();
+  }
+
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for daemon owner`);
+}
+
+let guiOwnerRouteRefreshPromise: Promise<void> | null = null;
+
+async function refreshGuiMutationOwnerRoute(): Promise<void> {
+  if (resolveGuiOwnerPreference() !== 'daemon') return;
+  if (!guiOwnerRouteRefreshPromise) {
+    guiOwnerRouteRefreshPromise = (async () => {
+      await ensureStandaloneOwnerForGui();
+      const previousMessageBus = typeof messageBus === 'undefined' ? null : messageBus;
+      const refreshedMessageBus = new IpcBus(undefined, { allowServe: false });
+      await refreshedMessageBus.ready();
+      messageBus = refreshedMessageBus;
+      previousMessageBus?.disconnect();
+      logger.info('refreshed daemon owner IPC route for GUI mutation', { module: 'ipc-delegate' });
+    })().finally(() => {
+      guiOwnerRouteRefreshPromise = null;
+    });
+  }
+  await guiOwnerRouteRefreshPromise;
+}
+
 function getSafeInvokerConfigForLogging(config: InvokerConfig): Record<string, unknown> {
   const safeConfig = { ...config } as Record<string, unknown> & {
     docker?: InvokerConfig['docker'];
@@ -448,10 +536,14 @@ function installPackagedSkills(mode: import('@invoker/contracts').BundledSkillsI
 }
 
 async function initServices(options?: InitServicesOptions): Promise<void> {
-  messageBus = new IpcBus();
   const invokerHomeRoot = resolveInvokerHomeRoot();
   mkdirSync(invokerHomeRoot, { recursive: true });
   const readOnly = options?.readOnly === true;
+  const previousMessageBus = typeof messageBus === 'undefined' ? null : messageBus;
+  previousMessageBus?.disconnect();
+  const serviceMessageBus = new IpcBus(undefined, { allowServe: !readOnly });
+  await serviceMessageBus.ready();
+  messageBus = serviceMessageBus;
   const dbPath = path.join(invokerHomeRoot, 'invoker.db');
   if (!readOnly) {
     writerLock = acquireDbWriterLock(dbPath, `main:initServices pid=${process.pid}`);
@@ -905,6 +997,33 @@ if (isHeadless) {
 
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
         switch (payload.channel) {
+          case 'invoker:clear': {
+            logger.info('clear — stopping all tasks and resetting daemon DAG', { module: 'ipc-delegate' });
+            await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: undefined });
+            await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
+            orchestrator = new Orchestrator({
+              persistence,
+              messageBus,
+              taskRepository: new SqliteTaskRepository(persistence),
+              maxConcurrency: effectiveMaxConcurrency,
+              defaultAutoFixRetries: invokerConfig.autoFixRetries,
+              executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
+              defaultPoolId: invokerConfig.defaultPoolId,
+              availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
+              deferRunningUntilLaunch: true,
+              launchOutboxMode: invokerConfig.launchOutboxMode,
+            });
+            commandService = new CommandService(
+              orchestrator,
+              buildInvalidationDeps({
+                logger,
+                orchestrator,
+                persistence,
+                taskExecutor: () => latestTaskExecutor,
+              }),
+            );
+            return undefined;
+          }
           case 'invoker:load-plan': {
             const planText = String(payload.args[0] ?? '');
             const { parsePlan } = await import('./plan-parser.js');
@@ -918,6 +1037,40 @@ if (isHeadless) {
             const started = orchestrator.startExecution();
             await executor.executeTasks(started);
             return started;
+          }
+          case 'invoker:stop': {
+            logger.info('stop — destroying all daemon executors', { module: 'ipc-delegate' });
+            const failInFlightTasks = (): void => {
+              const allTasks = orchestrator.getAllTasks();
+              for (const task of allTasks) {
+                if (isTaskInFlightForForcedStop(task)) {
+                  logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc-delegate' });
+                  orchestrator.handleWorkerResponse({
+                    requestId: `stop-${task.id}`,
+                    actionId: task.id,
+                    attemptId: task.execution.selectedAttemptId,
+                    executionGeneration: task.execution.generation ?? 0,
+                    status: 'failed',
+                    outputs: { exitCode: 1, error: 'Stopped by user' },
+                  });
+                }
+              }
+            };
+            failInFlightTasks();
+            await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
+            failInFlightTasks();
+            return undefined;
+          }
+          case 'invoker:inject-task-states': {
+            if (process.env.NODE_ENV !== 'test') {
+              throw new Error('inject-task-states is only available in tests');
+            }
+            const updates = payload.args[0] as Array<{ taskId: string; changes: TaskStateChanges }>;
+            for (const { taskId, changes } of updates) {
+              persistence.updateTask(taskId, changes);
+            }
+            orchestrator.syncAllFromDb();
+            return undefined;
           }
           case 'invoker:set-merge-branch': {
             const workflowId = String(payload.args[0]);
@@ -1003,7 +1156,7 @@ if (isHeadless) {
       // In standalone owner mode, serve delegated requests from peer headless processes.
       if (standaloneMode && messageBus) {
         const standaloneOwnerIdleTimeoutMs = Number.parseInt(
-          process.env.INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '2000',
+          process.env.INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '0',
           10,
         );
         let standaloneOwnerLastActivityAt = Date.now();
@@ -1011,6 +1164,9 @@ if (isHeadless) {
           standaloneOwnerLastActivityAt = Date.now();
         };
         headlessDeps.isStandaloneOwnerIdle = () => {
+          if (!Number.isFinite(standaloneOwnerIdleTimeoutMs) || standaloneOwnerIdleTimeoutMs <= 0) {
+            return false;
+          }
           const idleForMs = Date.now() - standaloneOwnerLastActivityAt;
           if (idleForMs < standaloneOwnerIdleTimeoutMs) return false;
           const hasQueuedOrRunningMutations =
@@ -1026,10 +1182,6 @@ if (isHeadless) {
         ): { workflowId?: string; priority: WorkflowMutationPriority } => {
           const [command, arg0] = payload.args;
           if (!command) return { priority: 'normal' };
-
-          const standaloneWorkflowIdForTaskArg = (taskIdArg: unknown): string => {
-            return resolveHeadlessTargetWorkflowId(taskIdArg, persistence);
-          };
 
           switch (command) {
             case 'set': {
@@ -1084,6 +1236,10 @@ if (isHeadless) {
           }
         };
 
+        const standaloneWorkflowIdForTaskArg = (taskIdArg: unknown): string => {
+          return resolveHeadlessTargetWorkflowId(taskIdArg, persistence);
+        };
+
         const runStandaloneWorkflowMutation = async <T>(
           workflowId: string | undefined,
           priority: WorkflowMutationPriority,
@@ -1111,6 +1267,22 @@ if (isHeadless) {
             return { ok: true };
           });
         }
+        if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
+          workflowMutationDispatcher.set('invoker:fix-with-agent', async (taskIdArg: unknown, agentNameArg?: unknown) => {
+            const args = ['fix', String(taskIdArg)];
+            if (typeof agentNameArg === 'string' && agentNameArg.length > 0) {
+              args.push(agentNameArg);
+            }
+            await runHeadless(args, {
+              ...headlessDeps,
+              waitForApproval: false,
+              noTrack: true,
+              signal: activeMutationContext?.signal,
+              mutationTiming: activeMutationContext?.mutationTiming,
+            });
+            return { ok: true };
+          });
+        }
         if (!workflowMutationCoordinator) {
           workflowMutationCoordinator = new PersistedWorkflowMutationCoordinator(
             persistence,
@@ -1131,6 +1303,176 @@ if (isHeadless) {
           );
         }
 
+        const buildStandaloneAutoFixQueueSnapshot = (taskId: string): Record<string, unknown> => {
+          const workflowId = standaloneWorkflowIdForTaskArg(taskId);
+          if (!workflowId) {
+            return {
+              workflowId: null,
+              openIntentCountForWorkflow: 0,
+              openFixIntentCountForWorkflow: 0,
+              openFixIntentCountForTask: 0,
+              openFixIntentForTask: false,
+              openFixIntentHead: null,
+              openFixIntentPreview: [],
+            };
+          }
+          const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
+          const openFixIntents = openIntents.filter((intent) => (
+            intent.channel === 'invoker:fix-with-agent' || intent.channel === 'headless.exec'
+          ));
+          const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
+          return {
+            workflowId,
+            openIntentCountForWorkflow: openIntents.length,
+            openFixIntentCountForWorkflow: openFixIntents.length,
+            openFixIntentCountForTask: openTaskFixIntents.length,
+            openFixIntentForTask: openTaskFixIntents.length > 0,
+            openFixIntentHead: openTaskFixIntents[0]
+              ? {
+                id: openTaskFixIntents[0].id,
+                status: openTaskFixIntents[0].status,
+                channel: openTaskFixIntents[0].channel,
+              }
+              : null,
+            openFixIntentPreview: openTaskFixIntents.slice(0, 5).map((intent) => ({
+              id: intent.id,
+              status: intent.status,
+              channel: intent.channel,
+            })),
+          };
+        };
+
+        const logStandaloneAutoFixDebug = (
+          taskId: string,
+          phase: string,
+          details: Record<string, unknown> = {},
+        ): void => {
+          const task = orchestrator.getTask(taskId);
+          const payload = {
+            phase,
+            status: task?.status ?? 'missing',
+            autoFixAttempts: task?.execution.autoFixAttempts ?? null,
+            ...buildStandaloneAutoFixQueueSnapshot(taskId),
+            ...details,
+          };
+          persistence.logEvent?.(taskId, 'debug.auto-fix', payload);
+          logger.info(
+            `[auto-fix-debug][standalone] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}`,
+            { module: 'auto-fix' },
+          );
+        };
+
+        const scheduleStandaloneAutoFix = (taskId: string): void => {
+          logStandaloneAutoFixDebug(taskId, 'schedule-enter');
+          if (!workflowMutationCoordinator) {
+            logStandaloneAutoFixDebug(taskId, 'schedule-skip', { reason: 'no-workflow-mutation-coordinator' });
+            return;
+          }
+          if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
+            logStandaloneAutoFixDebug(taskId, 'schedule-skip', { reason: 'fix-handler-not-ready' });
+            return;
+          }
+          const workflowId = standaloneWorkflowIdForTaskArg(taskId);
+          if (!workflowId) {
+            logStandaloneAutoFixDebug(taskId, 'schedule-skip', { reason: 'workflow-not-found' });
+            return;
+          }
+          const shouldAutoFixNow = orchestrator.shouldAutoFix(taskId);
+          if (!shouldAutoFixNow) {
+            logStandaloneAutoFixDebug(taskId, 'schedule-skip', {
+              reason: 'shouldAutoFix-false',
+              shouldAutoFix: shouldAutoFixNow,
+            });
+            return;
+          }
+          const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
+          const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
+          if (openTaskFixIntents.length > 0) {
+            logStandaloneAutoFixDebug(taskId, 'schedule-skip', {
+              reason: 'already-queued-intent',
+              existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
+            });
+            return;
+          }
+          const configuredAgent = loadConfig().autoFixAgent?.trim();
+          const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
+          logStandaloneAutoFixDebug(taskId, 'schedule-enqueue');
+          logStandaloneAutoFixDebug(taskId, 'schedule-enqueued');
+          void workflowMutationCoordinator.enqueue(
+            workflowId,
+            'normal',
+            'invoker:fix-with-agent',
+            [taskId, selectedAgent],
+          )
+            .then(() => {
+              logStandaloneAutoFixDebug(taskId, 'schedule-dispatch-finished');
+            })
+            .catch((err) => {
+              if (err instanceof StaleLineageError) {
+                logger.info(`auto-fix discarded stale result for "${taskId}": ${err.message}`, { module: 'auto-fix' });
+                return;
+              }
+              logStandaloneAutoFixDebug(taskId, 'schedule-dispatch-error', {
+                error: err instanceof Error ? err.stack ?? err.message : String(err),
+              });
+            });
+        };
+
+        const maybeScheduleStandaloneAutoFix = (
+          task: TaskState,
+          trigger: 'delta' | 'poll',
+        ): boolean => {
+          if (task.status !== 'failed') return false;
+          const cancellationError = shouldSkipAutoFixForError(task.execution.error);
+          const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(task.id);
+          logStandaloneAutoFixDebug(task.id, `${trigger}-failed`, {
+            shouldSkipForCancellation: cancellationError,
+            shouldAutoFixFromOrchestrator,
+          });
+          if (!cancellationError && shouldAutoFixFromOrchestrator) {
+            logStandaloneAutoFixDebug(task.id, `${trigger}-trigger-schedule`);
+            scheduleStandaloneAutoFix(task.id);
+            return true;
+          }
+          return false;
+        };
+
+        const startStandaloneAutoFixRecoveryPoll = (workflowId: string): void => {
+          const startedAtMs = Date.now();
+          const maxPollMs = 90_000;
+          const poll = setInterval(() => {
+            if (Date.now() - startedAtMs > maxPollMs) {
+              clearInterval(poll);
+              return;
+            }
+            try {
+              orchestrator.syncFromDb(workflowId);
+              const scheduled = orchestrator
+                .getAllTasks()
+                .filter((task) => task.config.workflowId === workflowId)
+                .some((task) => maybeScheduleStandaloneAutoFix(task, 'poll'));
+              if (scheduled) {
+                clearInterval(poll);
+              }
+            } catch (err) {
+              logger.warn(
+                `standalone auto-fix recovery poll failed for "${workflowId}": ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+                { module: 'auto-fix' },
+              );
+            }
+          }, 1_000);
+          poll.unref?.();
+        };
+
+        messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
+          const d = delta as TaskDelta;
+          if (d.type !== 'updated' || d.changes.status !== 'failed') return;
+          const task = orchestrator.getTask(d.taskId);
+          if (task) maybeScheduleStandaloneAutoFix(task, 'delta');
+        });
+
         const executeStandaloneHeadlessRun = async (
           payload: HeadlessRunMutationPayload,
         ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
@@ -1144,6 +1486,7 @@ if (isHeadless) {
           createStandaloneTaskExecutor().executeTasks(started).catch(err => {
             logger.error(`headless.run: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
           });
+          startStandaloneAutoFixRecoveryPoll(workflowId);
           logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
           const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
           return { workflowId, tasks };
@@ -1209,6 +1552,9 @@ if (isHeadless) {
           }
           if (kind === 'queue') {
             return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+          }
+          if (kind === 'workflow-status') {
+            return orchestrator.getWorkflowStatus();
           }
           if (kind === 'tasks') {
             if ((req as { forceRefresh?: boolean }).forceRefresh) {
@@ -1279,6 +1625,10 @@ if (isHeadless) {
             });
           });
           return { ok: true };
+        });
+        messageBus.onRequest('headless.gui-mutation', async (req: unknown) => {
+          noteStandaloneOwnerActivity();
+          return executeStandaloneGuiMutation(req as GuiMutationPayload);
         });
 
         reviewGateStatusWorker = startReviewGateStatusWorker({
@@ -2170,16 +2520,21 @@ function createEmbeddedTerminalBackendFromConfig(
   }
 
   function translateGuiMutationToHeadless(payload: GuiMutationPayload):
+    | { channel: 'headless.gui-mutation'; request: GuiMutationPayload }
     | { channel: 'headless.run'; request: HeadlessRunMutationPayload }
     | { channel: 'headless.resume'; request: HeadlessResumeMutationPayload }
     | { channel: 'headless.exec'; request: HeadlessExecMutationPayload }
     | null {
     const [arg0, arg1, arg2] = payload.args;
     switch (payload.channel) {
+      case 'invoker:load-plan':
+        return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:start':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:stop':
-        return { channel: 'headless.exec', request: { args: ['stop'] } };
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:clear':
-        return { channel: 'headless.exec', request: { args: ['clear'] } };
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
         const workflows = persistence.listWorkflows();
         const workflowId = workflows[0]?.id;
@@ -2221,6 +2576,8 @@ function createEmbeddedTerminalBackendFromConfig(
         return { channel: 'headless.exec', request: { args: ['rebase-retry', String(arg0)] } };
       case 'invoker:rebase-recreate':
         return { channel: 'headless.exec', request: { args: ['rebase-recreate', String(arg0)] } };
+      case 'invoker:set-merge-branch':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:set-merge-mode':
         return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
       case 'invoker:approve-merge': {
@@ -2294,6 +2651,7 @@ function createEmbeddedTerminalBackendFromConfig(
     ipcMain,
     getOwnerMode: () => ownerMode,
     getMessageBus: () => messageBus,
+    refreshOwnerRoute: refreshGuiMutationOwnerRoute,
     translateGuiMutationToHeadless,
     guiMutationHandlers,
   };
@@ -2471,7 +2829,10 @@ function createEmbeddedTerminalBackendFromConfig(
     if (deferredStartupTriggered) return;
     deferredStartupTriggered = true;
     recordStartupMark('deferred-startup.begin');
-    const startupPollDelayMs = Number.parseInt(process.env.INVOKER_STARTUP_POLL_DELAY_MS ?? '10000', 10) || 10000;
+    const configuredStartupPollDelayMs = Number.parseInt(process.env.INVOKER_STARTUP_POLL_DELAY_MS ?? '10000', 10);
+    const startupPollDelayMs = Number.isFinite(configuredStartupPollDelayMs)
+      ? configuredStartupPollDelayMs
+      : 10000;
 
     setTimeout(() => {
       if (!ownerMode) return;
@@ -2676,22 +3037,62 @@ function createEmbeddedTerminalBackendFromConfig(
 
   const runGuiReadyBootstrap = async (): Promise<void> => {
     recordStartupMark('app.whenReady');
-    ownerMode = true;
-    try {
-      recordStartupMark('initServices.start');
-      await initServices({ executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
-      recordStartupMark('initServices.end', { ownerMode: true });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (!message.includes('[db-writer-lock]')) {
+    const guiOwnerPreference = resolveGuiOwnerPreference();
+    let daemonGuiOwner = false;
+    if (guiOwnerPreference === 'daemon') {
+      try {
+        recordStartupMark('daemonOwner.ensure.start');
+        await ensureStandaloneOwnerForGui();
+        recordStartupMark('daemonOwner.ensure.end');
+        daemonGuiOwner = true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
         process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
         app.quit();
         return;
       }
-      recordStartupMark('initServices.readOnly.start');
-      await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+    } else if (guiOwnerPreference === 'auto') {
+      recordStartupMark('daemonOwner.discover.start');
+      try {
+        daemonGuiOwner = await discoverStandaloneOwnerForGui(1_000);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(`daemon owner auto-discovery failed; starting GUI owner locally: ${message}`, { module: 'init' });
+        daemonGuiOwner = false;
+      }
+      recordStartupMark('daemonOwner.discover.end', { daemonOwner: daemonGuiOwner });
+    }
+
+    if (daemonGuiOwner) {
       ownerMode = false;
-      recordStartupMark('initServices.readOnly.end', { ownerMode: false });
+      try {
+        recordStartupMark('initServices.readOnly.start');
+        await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+        recordStartupMark('initServices.readOnly.end', { ownerMode: false, daemonOwner: true });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
+        app.quit();
+        return;
+      }
+    } else {
+      ownerMode = true;
+      try {
+        recordStartupMark('initServices.start');
+        await initServices({ executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+        recordStartupMark('initServices.end', { ownerMode: true });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (!message.includes('[db-writer-lock]')) {
+          process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
+          app.quit();
+          return;
+        }
+        recordStartupMark('initServices.readOnly.start');
+        await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+        ownerMode = false;
+        recordStartupMark('initServices.readOnly.end', { ownerMode: false });
+      }
     }
 
     if (ownerMode) {
@@ -2769,6 +3170,9 @@ function createEmbeddedTerminalBackendFromConfig(
         }
         if (kind === 'queue') {
           return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+        }
+        if (kind === 'workflow-status') {
+          return orchestrator.getWorkflowStatus();
         }
         if (kind === 'tasks') {
           if ((req as { forceRefresh?: boolean }).forceRefresh) {
@@ -2967,32 +3371,42 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     if (process.env.NODE_ENV === 'test') {
+      const injectTaskStates = async (updates: Array<{ taskId: string; changes: TaskStateChanges }>): Promise<void> => {
+        for (const { taskId, changes } of updates) {
+          const before = orchestrator.getTask(taskId);
+          const previousSnapshot = lastKnownTaskStates.get(taskId);
+          const previousTaskStateVersion = previousSnapshot
+            ? (
+                (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
+                ?? before?.taskStateVersion
+                ?? 1
+              )
+            : (before?.taskStateVersion ?? 0);
+          persistence.updateTask(taskId, changes);
+          messageBus.publish(Channels.TASK_DELTA, {
+            type: 'updated',
+            taskId,
+            changes,
+            previousTaskStateVersion,
+            taskStateVersion: previousTaskStateVersion + 1,
+          } satisfies TaskDelta);
+        }
+        orchestrator.syncAllFromDb();
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          requestWorkflowMetadataPublish('gap-detect');
+        }
+      };
       ipcMain.handle(
         'invoker:inject-task-states',
         async (_event, updates: Array<{ taskId: string; changes: TaskStateChanges }>) => {
-          for (const { taskId, changes } of updates) {
-            const before = orchestrator.getTask(taskId);
-            const previousSnapshot = lastKnownTaskStates.get(taskId);
-            const previousTaskStateVersion = previousSnapshot
-              ? (
-                  (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
-                  ?? before?.taskStateVersion
-                  ?? 1
-                )
-              : (before?.taskStateVersion ?? 0);
-            persistence.updateTask(taskId, changes);
-            messageBus.publish(Channels.TASK_DELTA, {
-              type: 'updated',
-              taskId,
-              changes,
-              previousTaskStateVersion,
-              taskStateVersion: previousTaskStateVersion + 1,
-            } satisfies TaskDelta);
+          if (!ownerMode) {
+            await messageBus.request('headless.gui-mutation', {
+              channel: 'invoker:inject-task-states',
+              args: [updates],
+            } satisfies GuiMutationPayload);
+            return;
           }
-          orchestrator.syncAllFromDb();
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            requestWorkflowMetadataPublish('gap-detect');
-          }
+          await injectTaskStates(updates);
         },
       );
     }
@@ -3070,15 +3484,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
     registerGuiMutationHandler('invoker:clear', async () => {
       logger.info('clear — stopping all tasks and resetting DAG', { module: 'ipc' });
-      const workflows = persistence.listWorkflows();
-
-      for (const workflow of workflows) {
-        try {
-          await performCancelWorkflow(workflow.id);
-        } catch (err) {
-          logger.error(`clear: failed to cancel workflow "${workflow.id}": ${err}`, { module: 'ipc' });
-        }
-      }
+      await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
 
       orchestrator = new Orchestrator({
@@ -3104,6 +3510,9 @@ function createEmbeddedTerminalBackendFromConfig(
       );
       rebuildTaskRunner();
       taskHandles.clear();
+      lastKnownTaskStates.clear();
+      lastKnownWorkflowCount = 0;
+      requestWorkflowMetadataPublish('clear');
     });
 
     registerReadOnlyIpcHandlers({

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -606,7 +606,7 @@ async function wireSlackBot(deps: SlackBotDeps): Promise<any> {
   let repoUrl = process.env.INVOKER_REPO_URL;
   if (!repoUrl) {
     try {
-      repoUrl = execSync('git remote get-url origin', { cwd: repoRoot, encoding: 'utf8' }).trim();
+      repoUrl = execSync('git remote get-url origin', { cwd: repoRoot, encoding: 'utf8', timeout: 5000 }).trim();
     } catch {
       deps.logFn('slack', 'warn', 'Could not detect repoUrl from git remote; plans will require repoUrl in YAML');
     }
@@ -2510,9 +2510,20 @@ function createEmbeddedTerminalBackendFromConfig(
         maybeDelayResume: maybeDelayWorkflowResumeForTest,
       });
 
-      startSlackBot(requireTaskExecutor(), taskHandles).catch((err) => {
-        logger.info(`Not started: ${err instanceof Error ? err.message : String(err)}`, { module: 'slack' });
-      });
+      // Skip Slack startup when env vars are missing. Avoids a dynamic
+      // `import('dotenv')` inside wireSlackBot whose promise can stall when
+      // the ESM loader gets stuck behind other startup work (e.g. the docker
+      // CLI hang we observed). startSlackBot would throw on missing env vars
+      // immediately after dotenv anyway.
+      const slackEnvVars = ['SLACK_BOT_TOKEN', 'SLACK_APP_TOKEN', 'SLACK_SIGNING_SECRET', 'SLACK_CHANNEL_ID'];
+      const slackEnvMissing = slackEnvVars.filter((v) => !process.env[v]);
+      if (slackEnvMissing.length > 0) {
+        logger.info(`Slack bot not started (missing env: ${slackEnvMissing.join(', ')})`, { module: 'slack' });
+      } else {
+        startSlackBot(requireTaskExecutor(), taskHandles).catch((err) => {
+          logger.info(`Not started: ${err instanceof Error ? err.message : String(err)}`, { module: 'slack' });
+        });
+      }
 
       setTimeout(() => {
         dbPollInterval = setInterval(() => {

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -205,6 +205,26 @@ function isTaskInFlightForForcedStop(task: TaskState): boolean {
     || (task.status === 'pending' && task.execution.phase === 'launching');
 }
 
+function isTaskRecoverableOnExplicitResume(task: TaskState): boolean {
+  if (task.status === 'running') return true;
+  if (task.status !== 'pending' || !task.execution.selectedAttemptId) return false;
+  if (task.execution.phase === 'launching') return true;
+
+  return Boolean(
+    task.execution.startedAt
+    || task.execution.launchStartedAt
+    || task.execution.launchCompletedAt
+    || task.execution.lastHeartbeatAt
+    || task.execution.workspacePath
+    || task.execution.agentSessionId
+    || task.execution.containerId
+    || task.execution.error
+    || task.execution.exitCode !== undefined
+    || task.execution.inputPrompt
+    || task.execution.pendingFixError,
+  );
+}
+
 declare const __BUILD_SHA__: string | undefined;
 declare const __BUILD_VERSION__: string | undefined;
 
@@ -864,15 +884,20 @@ if (isHeadless) {
         return { workflowId, tasks };
       };
 
+      const executeStandaloneResumeStartedTasks = async (
+        executor: ReturnType<typeof createStandaloneTaskExecutor>,
+        started: TaskState[],
+      ): Promise<void> => {
+        if (invokerConfig.launchOutboxMode !== 'active') {
+          await executor.executeTasks(started);
+        }
+      };
+
       const executeStandaloneHeadlessResume = async (payload: HeadlessResumeMutationPayload): Promise<unknown> => {
         const { workflowId } = payload;
         const executor = createStandaloneTaskExecutor();
-        orchestrator.syncFromDb(workflowId);
-        // CC.2: orphan relaunch removed. orchestrator.startExecution()
-        // enqueues into the task_launch_dispatch outbox; the
-        // LaunchDispatcher's poll loop is the single recovery path.
-        const started = orchestrator.startExecution();
-        await executor.executeTasks(started);
+        const started = orchestrator.resumeWorkflow(workflowId);
+        await executeStandaloneResumeStartedTasks(executor, started);
         logger.info(`standalone resumed ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
         const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
         return { workflowId, tasks };
@@ -1124,19 +1149,26 @@ if (isHeadless) {
           return { workflowId, tasks };
         };
 
+        const executeStandaloneResumeStartedTasks = (
+          executor: ReturnType<typeof createStandaloneTaskExecutor>,
+          started: TaskState[],
+          workflowId: string,
+        ): void => {
+          if (started.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
+            executor.executeTasks(started).catch(err => {
+              logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
+            });
+          }
+        };
+
         const executeStandaloneHeadlessResume = async (
           payload: HeadlessResumeMutationPayload,
         ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
           const { workflowId } = payload;
-          orchestrator.syncFromDb(workflowId);
           const executor = createStandaloneTaskExecutor();
 
-          const allStarted = orchestrator.startExecution();
-          if (allStarted.length > 0) {
-            executor.executeTasks(allStarted).catch(err => {
-              logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
-            });
-          }
+          const allStarted = orchestrator.resumeWorkflow(workflowId);
+          executeStandaloneResumeStartedTasks(executor, allStarted, workflowId);
           const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
           return { workflowId, tasks };
         };
@@ -1177,6 +1209,32 @@ if (isHeadless) {
           }
           if (kind === 'queue') {
             return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+          }
+          if (kind === 'tasks') {
+            if ((req as { forceRefresh?: boolean }).forceRefresh) {
+              orchestrator.syncAllFromDb();
+            }
+            return {
+              tasks: orchestrator.getAllTasks(),
+              workflows: persistence.listWorkflows(),
+              streamSequence: 0,
+            };
+          }
+          if (kind === 'action-graph') {
+            orchestrator.syncAllFromDb();
+            const tasks = orchestrator.getAllTasks();
+            const workflows = persistence.listWorkflows();
+            return buildActionGraphDiagnostics({
+              workflows,
+              tasks,
+              attemptsByTaskId: new Map(tasks.map((task) => [task.id, persistence.loadAttempts(task.id)])),
+              queueStatus: orchestrator.getQueueStatus(),
+              mutationIntents: persistence.listWorkflowMutationIntents(),
+              mutationLeases: persistence.listWorkflowMutationLeases(),
+              eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
+              activityLogs: persistence.getActivityLogs(0, 200),
+              stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
+            });
           }
           throw new Error(`Unsupported headless query: ${String(kind)}`);
         });
@@ -1871,6 +1929,17 @@ function createEmbeddedTerminalBackendFromConfig(
     return requireWiredTaskRunner(() => taskExecutor);
   }
 
+  function executeHeadlessResumeStartedTasks(
+    started: TaskState[],
+    workflowId: string,
+  ): void {
+    if (started.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
+      requireTaskExecutor().executeTasks(started).catch(err => {
+        logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
+      });
+    }
+  }
+
   async function executeHeadlessRun(payload: HeadlessRunMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
     const { parsePlanFile } = await import('./plan-parser.js');
     const plan = await parsePlanFile(payload.planPath);
@@ -1892,14 +1961,9 @@ function createEmbeddedTerminalBackendFromConfig(
 
   async function executeHeadlessResume(payload: HeadlessResumeMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
     const { workflowId } = payload;
-    orchestrator.syncFromDb(workflowId);
 
-    const allStarted = orchestrator.startExecution();
-    if (allStarted.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
-      requireTaskExecutor().executeTasks(allStarted).catch(err => {
-        logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
-      });
-    }
+    const allStarted = orchestrator.resumeWorkflow(workflowId);
+    executeHeadlessResumeStartedTasks(allStarted, workflowId);
     const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
     return { workflowId, tasks };
   }
@@ -2649,7 +2713,6 @@ function createEmbeddedTerminalBackendFromConfig(
           ownerId: workflowMutationOwnerId,
           logger,
           mode: invokerConfig.launchOutboxMode as LaunchDispatcherMode,
-          maxConcurrency: effectiveMaxConcurrency,
         });
       }
     } else {
@@ -2695,6 +2758,32 @@ function createEmbeddedTerminalBackendFromConfig(
         }
         if (kind === 'queue') {
           return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+        }
+        if (kind === 'tasks') {
+          if ((req as { forceRefresh?: boolean }).forceRefresh) {
+            orchestrator.syncAllFromDb();
+          }
+          return {
+            tasks: orchestrator.getAllTasks(),
+            workflows: persistence.listWorkflows(),
+            streamSequence: getTaskDeltaStreamSequence(),
+          };
+        }
+        if (kind === 'action-graph') {
+          orchestrator.syncAllFromDb();
+          const tasks = orchestrator.getAllTasks();
+          const workflows = persistence.listWorkflows();
+          return buildActionGraphDiagnostics({
+            workflows,
+            tasks,
+            attemptsByTaskId: new Map(tasks.map((task) => [task.id, persistence.loadAttempts(task.id)])),
+            queueStatus: orchestrator.getQueueStatus(),
+            mutationIntents: persistence.listWorkflowMutationIntents(),
+            mutationLeases: persistence.listWorkflowMutationLeases(),
+            eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
+            activityLogs: persistence.getActivityLogs(0, 200),
+            stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
+          });
         }
         throw new Error(`Unsupported headless query: ${String(kind)}`);
       });
@@ -2915,14 +3004,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
       orchestrator.syncAllFromDb();
 
-      const tasksToRecover = orchestrator.getAllTasks().filter((task) =>
-        task.status === 'running'
-        || (
-          task.status === 'pending'
-          && task.execution.phase === 'launching'
-          && !!task.execution.selectedAttemptId
-        )
-      );
+      const tasksToRecover = orchestrator.getAllTasks().filter(isTaskRecoverableOnExplicitResume);
       for (const task of tasksToRecover) {
         orchestrator.prepareTaskForNewAttempt(task.id, 'resume_workflow_recovery');
       }
@@ -2938,6 +3020,16 @@ function createEmbeddedTerminalBackendFromConfig(
       logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
       if (allStarted.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
         void requireTaskExecutor().executeTasks(allStarted);
+      }
+      if (allStarted.length > 0 && invokerConfig.launchOutboxMode === 'active' && launchDispatcher) {
+        try {
+          launchDispatcher.poll();
+        } catch (err) {
+          logger.warn(
+            `resume-workflow: launch dispatcher poll failed: ${err instanceof Error ? err.message : String(err)}`,
+            { module: 'ipc' },
+          );
+        }
       }
       return { workflow: workflows[0], taskCount: tasks.length, startedCount: allStarted.length };
     });
@@ -3016,6 +3108,8 @@ function createEmbeddedTerminalBackendFromConfig(
       setLastKnownWorkflowCount: (count) => { lastKnownWorkflowCount = count; },
       loadTaskByIdFromPersistence,
       resolveAgentSession,
+      getOwnerMode: () => ownerMode,
+      getMessageBus: () => messageBus,
       timeStartupPhase,
       recordStartupDuration,
       getTaskDeltaStreamSequence,
@@ -3252,7 +3346,19 @@ function createEmbeddedTerminalBackendFromConfig(
       return orchestrator.getQueueStatus();
     });
 
-    ipcMain.handle('invoker:get-action-graph', () => {
+    ipcMain.handle('invoker:get-action-graph', async () => {
+      if (!ownerMode) {
+        try {
+          return await messageBus.request('headless.query', { kind: 'action-graph' });
+        } catch (err) {
+          logger.warn(
+            `get-action-graph owner delegation failed; falling back to local read-only snapshot: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            { module: 'ipc' },
+          );
+        }
+      }
       orchestrator.syncAllFromDb();
       const tasks = orchestrator.getAllTasks();
       const workflows = persistence.listWorkflows();

--- a/packages/app/src/owner-resolver.ts
+++ b/packages/app/src/owner-resolver.ts
@@ -40,6 +40,8 @@ export interface OwnerResolverDeps {
   refreshMessageBus?: () => Promise<MessageBus>;
   /** Bootstrap a standalone owner process. */
   ensureStandaloneOwner: (bus: MessageBus) => Promise<void>;
+  /** Whether a bootstrap error should be treated as a failed attempt and retried. */
+  isRetryableBootstrapError?: (error: unknown) => boolean;
 }
 
 // ── Configuration ───────────────────────────────────────────
@@ -133,6 +135,13 @@ export function createOwnerResolver(
     return { resolved: true, owner, bus };
   }
 
+  function acceptsOwner(
+    owner: OwnerDiscoveryResult,
+    requireStandalone: boolean,
+  ): owner is OwnerEndpointInfo {
+    return requireStandalone ? isStandaloneCapable(owner) : isOwnerReachable(owner);
+  }
+
   const resolver: OwnerResolver = {
     async discover(): Promise<OwnerResolveResult> {
       const owner = await discoverOwner(currentBus, discoveryTimeoutMs);
@@ -179,18 +188,32 @@ export function createOwnerResolver(
     async resolve(requireStandalone = true): Promise<ResolvedOwner> {
       // Phase 1: Try immediate discovery
       const immediate = await discoverOwner(currentBus, discoveryTimeoutMs);
-      if (requireStandalone ? isStandaloneCapable(immediate) : isOwnerReachable(immediate)) {
-        return { owner: immediate!, bus: currentBus };
+      if (acceptsOwner(immediate, requireStandalone)) {
+        return { owner: immediate, bus: currentBus };
       }
 
       // Phase 2: Refresh and retry
       if (deps.refreshMessageBus) {
         currentBus = await deps.refreshMessageBus();
+        const refreshed = await discoverOwner(currentBus, refreshDiscoveryTimeoutMs);
+        if (acceptsOwner(refreshed, requireStandalone)) {
+          return { owner: refreshed, bus: currentBus };
+        }
       }
 
       // Phase 3: Bootstrap with retry loop
       for (let attempt = 0; attempt < maxBootstrapAttempts; attempt += 1) {
-        await deps.ensureStandaloneOwner(currentBus);
+        try {
+          await deps.ensureStandaloneOwner(currentBus);
+        } catch (error) {
+          if (!deps.isRetryableBootstrapError?.(error)) {
+            throw error;
+          }
+          if (deps.refreshMessageBus) {
+            currentBus = await deps.refreshMessageBus();
+          }
+          continue;
+        }
 
         if (deps.refreshMessageBus) {
           currentBus = await deps.refreshMessageBus();

--- a/packages/app/src/system-diagnostics.ts
+++ b/packages/app/src/system-diagnostics.ts
@@ -2,7 +2,14 @@ import { spawnSync } from 'node:child_process';
 
 import type { SystemDiagnostics, SystemToolStatus } from '@invoker/contracts';
 
-function detectTool(
+/**
+ * Exported only so the regression test in
+ * `__tests__/system-diagnostics.test.ts` can call this directly to verify
+ * the spawnSync timeout protects the Electron main thread from a CLI whose
+ * version probe hangs (e.g. `docker --version` when Docker Desktop has been
+ * installed but is not running).
+ */
+export function detectTool(
   id: string,
   name: string,
   command: string,
@@ -10,8 +17,19 @@ function detectTool(
   installHint: string,
   required = false,
 ): SystemToolStatus {
-  const result = spawnSync(command, versionArgs, { encoding: 'utf8' });
+  // CRITICAL: spawnSync blocks the Electron main thread. If a CLI's daemon
+  // is unreachable (e.g. `docker --version` when Docker Desktop is not
+  // running), the child can hang indefinitely and wedge the entire app.
+  // The 3s timeout + SIGKILL guarantees startup cannot stall here.
+  const result = spawnSync(command, versionArgs, {
+    encoding: 'utf8',
+    timeout: 3000,
+    killSignal: 'SIGKILL',
+  });
   if (result.error) {
+    return { id, name, required, installed: false, installHint };
+  }
+  if (result.signal === 'SIGKILL') {
     return { id, name, required, installed: false, installHint };
   }
   if (typeof result.status === 'number' && result.status !== 0) {

--- a/packages/contracts/src/launch-timeouts.ts
+++ b/packages/contracts/src/launch-timeouts.ts
@@ -12,6 +12,6 @@
 
 export const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
 
-export const DISPATCH_LEASE_MS = 30_000;
+export const DISPATCH_LEASE_MS = 12 * 60 * 1000;
 
 export const DISPATCH_MAX_ATTEMPTS = 3;

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -319,7 +319,7 @@ describe('SQLiteAdapter', () => {
       expect(second.id).toBe(first.id);
       expect(second.priority).toBe('high');
       expect(
-        adapter.listLaunchDispatchesByState(['enqueued', 'leased', 'acknowledged']),
+        adapter.listLaunchDispatchesByState(['enqueued', 'leased']),
       ).toHaveLength(1);
     });
 
@@ -363,30 +363,77 @@ describe('SQLiteAdapter', () => {
       expect(completedOnly).toEqual(['attempt-a']);
     });
 
-    it('markLaunchDispatchAcknowledged only succeeds for leased rows', () => {
-      setupWorkflowAndTask();
-      const row = adapter.enqueueLaunchDispatch({
-        taskId: 'wf-launch/t1',
-        attemptId: 'attempt-ack',
+    it('runCompatibilityMigration normalizes legacy acknowledged rows', () => {
+      adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
+      saveLaunchTask('wf-launch', 'wf-launch/t-future', 'attempt-future');
+      saveLaunchTask('wf-launch', 'wf-launch/t-expired', 'attempt-expired');
+      saveLaunchTask('wf-launch', 'wf-launch/t-stale', 'attempt-current');
+      const future = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t-future',
+        attemptId: 'attempt-future',
         workflowId: 'wf-launch',
         generation: 0,
       });
-
-      expect(adapter.markLaunchDispatchAcknowledged(row.id, 'runner-1')).toBe(false);
-
+      const expired = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t-expired',
+        attemptId: 'attempt-expired',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      const stale = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t-stale',
+        attemptId: 'attempt-stale',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      const now = Date.now();
       (adapter as any).db.run(
-        `UPDATE task_launch_dispatch SET state = 'leased', fenced_until = datetime('now', '+30 seconds') WHERE id = ?`,
-        [row.id],
+        `UPDATE task_launch_dispatch SET state = 'acknowledged', dispatch_owner = 'owner-future',
+            leased_at = ?, acknowledged_at = ?, fenced_until = ?
+         WHERE id = ?`,
+        [
+          new Date(now - 1_000).toISOString(),
+          new Date(now - 1_000).toISOString(),
+          new Date(now + 60_000).toISOString(),
+          future.id,
+        ],
+      );
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'acknowledged', dispatch_owner = 'owner-expired',
+            leased_at = ?, acknowledged_at = ?, fenced_until = ?
+         WHERE id = ?`,
+        [
+          new Date(now - 120_000).toISOString(),
+          new Date(now - 120_000).toISOString(),
+          new Date(now - 60_000).toISOString(),
+          expired.id,
+        ],
+      );
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'acknowledged', dispatch_owner = 'owner-stale',
+            leased_at = ?, acknowledged_at = ?, fenced_until = ?
+         WHERE id = ?`,
+        [
+          new Date(now - 120_000).toISOString(),
+          new Date(now - 120_000).toISOString(),
+          new Date(now + 60_000).toISOString(),
+          stale.id,
+        ],
       );
 
-      expect(adapter.markLaunchDispatchAcknowledged(row.id, 'runner-1')).toBe(true);
-      const after = adapter.loadLaunchDispatchById(row.id);
-      expect(after?.state).toBe('acknowledged');
-      expect(after?.dispatchOwner).toBe('runner-1');
-      expect(after?.acknowledgedAt).toBeDefined();
-      expect(after?.fencedUntil).toBeDefined();
+      const report = adapter.runCompatibilityMigration();
 
-      expect(adapter.markLaunchDispatchAcknowledged(row.id, 'runner-1')).toBe(false);
+      expect(report.normalizedLegacyAcknowledgedLaunchDispatches).toBe(3);
+      expect(adapter.loadLaunchDispatchById(future.id)?.state).toBe('leased');
+      expect(adapter.loadLaunchDispatchById(expired.id)?.state).toBe('enqueued');
+      const staleAfter = adapter.loadLaunchDispatchById(stale.id);
+      expect(staleAfter?.state).toBe('abandoned');
+      expect(staleAfter?.lastError).toMatch(/Legacy acknowledged launch dispatch is stale/);
+      const legacyCount = sqliteScalar(
+        adapter,
+        `SELECT COUNT(*) AS count FROM task_launch_dispatch WHERE state = 'acknowledged'`,
+      );
+      expect(legacyCount).toBe(0);
     });
 
     it('markLaunchDispatchCompleted transitions to completed and rejects already-terminal rows', () => {
@@ -456,7 +503,7 @@ describe('SQLiteAdapter', () => {
         [futureIso, live.id],
       );
 
-      const reaped = adapter.reapExpiredLaunchDispatchLeases(now.toISOString());
+      const reaped = adapter.reapExpiredLaunchDispatchLeases({ nowIso: now.toISOString() });
       expect(reaped.map((row) => row.attemptId)).toEqual(['attempt-expired']);
       const expiredAfter = adapter.loadLaunchDispatchById(expired.id);
       expect(expiredAfter?.state).toBe('enqueued');
@@ -479,7 +526,6 @@ describe('SQLiteAdapter', () => {
 
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-1',
-          maxConcurrency: 4,
         });
 
         expect(claimed?.id).toBe(enqueued.id);
@@ -494,7 +540,6 @@ describe('SQLiteAdapter', () => {
         setupWorkflowAndTask();
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-1',
-          maxConcurrency: 4,
         });
         expect(claimed).toBeUndefined();
       });
@@ -512,11 +557,9 @@ describe('SQLiteAdapter', () => {
 
         const first = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-a',
-          maxConcurrency: 4,
         });
         const second = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-b',
-          maxConcurrency: 4,
         });
 
         expect(first?.dispatchOwner).toBe('runner-a');
@@ -551,15 +594,12 @@ describe('SQLiteAdapter', () => {
 
         const firstClaim = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-pri',
-          maxConcurrency: 4,
         });
         const secondClaim = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-pri',
-          maxConcurrency: 4,
         });
         const thirdClaim = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-pri',
-          maxConcurrency: 4,
         });
 
         expect(firstClaim?.id).toBe(high.id);
@@ -567,65 +607,40 @@ describe('SQLiteAdapter', () => {
         expect(thirdClaim?.attemptId).toBe('attempt-low');
       });
 
-      it('enforces maxConcurrency by counting leased + acknowledged rows', () => {
+      it('leases queued work even when legacy acknowledged rows exist', () => {
         adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
-        saveLaunchTask('wf-launch', 'wf-launch/t-cap-1', 'attempt-cap-1');
-        saveLaunchTask('wf-launch', 'wf-launch/t-cap-2', 'attempt-cap-2');
-        adapter.enqueueLaunchDispatch({
-          taskId: 'wf-launch/t-cap-1',
-          attemptId: 'attempt-cap-1',
+        for (let i = 0; i < 12; i += 1) {
+          const taskId = `wf-launch/t-legacy-${i}`;
+          const attemptId = `attempt-legacy-${i}`;
+          saveLaunchTask('wf-launch', taskId, attemptId);
+          const legacy = adapter.enqueueLaunchDispatch({
+            taskId,
+            attemptId,
+            workflowId: 'wf-launch',
+            generation: 0,
+          });
+          (adapter as any).db.run(
+            `UPDATE task_launch_dispatch
+               SET state = 'acknowledged', dispatch_owner = 'old-owner',
+                   fenced_until = ?, attempts_count = 1
+             WHERE id = ?`,
+            [new Date(Date.now() - 60_000).toISOString(), legacy.id],
+          );
+        }
+        saveLaunchTask('wf-launch', 'wf-launch/t-target', 'attempt-target');
+        const target = adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t-target',
+          attemptId: 'attempt-target',
           workflowId: 'wf-launch',
           generation: 0,
         });
-        adapter.enqueueLaunchDispatch({
-          taskId: 'wf-launch/t-cap-2',
-          attemptId: 'attempt-cap-2',
-          workflowId: 'wf-launch',
-          generation: 0,
-        });
 
-        const first = adapter.claimLaunchDispatchAtomic({
-          ownerId: 'runner-c',
-          maxConcurrency: 1,
-        });
-        expect(first?.attemptId).toBe('attempt-cap-1');
-
-        const blocked = adapter.claimLaunchDispatchAtomic({
-          ownerId: 'runner-c',
-          maxConcurrency: 1,
-        });
-        expect(blocked).toBeUndefined();
-
-        adapter.markLaunchDispatchAcknowledged(first!.id, 'runner-c');
-        const stillBlocked = adapter.claimLaunchDispatchAtomic({
-          ownerId: 'runner-c',
-          maxConcurrency: 1,
-        });
-        expect(stillBlocked).toBeUndefined();
-
-        adapter.markLaunchDispatchCompleted(first!.id);
-        const unblocked = adapter.claimLaunchDispatchAtomic({
-          ownerId: 'runner-c',
-          maxConcurrency: 1,
-        });
-        expect(unblocked?.attemptId).toBe('attempt-cap-2');
-      });
-
-      it('returns undefined when maxConcurrency is zero', () => {
-        setupWorkflowAndTask('wf-launch', 'wf-launch/t1', {
-          selectedAttemptId: 'attempt-zero',
-        });
-        adapter.enqueueLaunchDispatch({
-          taskId: 'wf-launch/t1',
-          attemptId: 'attempt-zero',
-          workflowId: 'wf-launch',
-          generation: 0,
-        });
         const claimed = adapter.claimLaunchDispatchAtomic({
-          ownerId: 'runner-z',
-          maxConcurrency: 0,
+          ownerId: 'runner-c',
         });
-        expect(claimed).toBeUndefined();
+
+        expect(claimed?.id).toBe(target.id);
+        expect(claimed?.state).toBe('leased');
       });
 
       it('abandons a stale selected-attempt candidate and scans to the next valid row', () => {
@@ -649,7 +664,6 @@ describe('SQLiteAdapter', () => {
 
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-scan',
-          maxConcurrency: 4,
           nowIso: '2026-06-03T00:00:00.000Z',
         });
 
@@ -673,7 +687,6 @@ describe('SQLiteAdapter', () => {
 
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-generation',
-          maxConcurrency: 4,
           nowIso: '2026-06-03T00:01:00.000Z',
         });
 
@@ -697,7 +710,6 @@ describe('SQLiteAdapter', () => {
 
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-status',
-          maxConcurrency: 4,
           nowIso: '2026-06-03T00:02:00.000Z',
         });
 
@@ -720,7 +732,6 @@ describe('SQLiteAdapter', () => {
 
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-missing',
-          maxConcurrency: 4,
           nowIso: '2026-06-03T00:03:00.000Z',
         });
 
@@ -747,12 +758,6 @@ describe('SQLiteAdapter', () => {
         workflowId: 'wf-launch',
         generation: 0,
       });
-      const acknowledged = adapter.enqueueLaunchDispatch({
-        taskId: 'wf-launch/t1',
-        attemptId: 'attempt-live-1c',
-        workflowId: 'wf-launch',
-        generation: 0,
-      });
       const completed = adapter.enqueueLaunchDispatch({
         taskId: 'wf-launch/t1',
         attemptId: 'attempt-completed',
@@ -769,10 +774,6 @@ describe('SQLiteAdapter', () => {
         `UPDATE task_launch_dispatch SET state = 'leased', dispatch_owner = 'owner-1', fenced_until = '2026-06-03T00:05:00.000Z' WHERE id = ?`,
         [leased.id],
       );
-      (adapter as any).db.run(
-        `UPDATE task_launch_dispatch SET state = 'acknowledged', dispatch_owner = 'owner-2', fenced_until = '2026-06-03T00:05:00.000Z' WHERE id = ?`,
-        [acknowledged.id],
-      );
       adapter.markLaunchDispatchCompleted(completed.id, '2026-06-03T00:04:00.000Z');
 
       const invalidated = adapter.abandonLaunchDispatchesForTasks(
@@ -784,9 +785,8 @@ describe('SQLiteAdapter', () => {
       expect(invalidated.map((row) => ({ id: row.id, state: row.state }))).toEqual([
         { id: enqueued.id, state: 'enqueued' },
         { id: leased.id, state: 'leased' },
-        { id: acknowledged.id, state: 'acknowledged' },
       ]);
-      for (const row of [enqueued, leased, acknowledged]) {
+      for (const row of [enqueued, leased]) {
         const after = adapter.loadLaunchDispatchById(row.id);
         expect(after?.state).toBe('abandoned');
         expect(after?.completedAt).toBe('2026-06-03T00:06:00.000Z');
@@ -852,7 +852,7 @@ describe('SQLiteAdapter', () => {
 
       adapter.deleteWorkflow('wf-launch');
 
-      expect(adapter.listLaunchDispatchesByState(['enqueued', 'leased', 'acknowledged'])).toEqual([]);
+      expect(adapter.listLaunchDispatchesByState(['enqueued', 'leased'])).toEqual([]);
       expect(adapter.listExecutionResourceLeases()).toEqual([]);
     });
   });
@@ -2608,6 +2608,7 @@ describe('SQLiteAdapter', () => {
         normalizedMergeModes: 1,
         staleAutoFixExperimentTasks: 2,
         normalizedStaleLaunchMetadata: 0,
+        normalizedLegacyAcknowledgedLaunchDispatches: 0,
         backfilledMissingSshPoolMemberIds: 0,
       });
       const taskById = new Map(adapter.loadTasks('wf-1').map((task) => [task.id, task]));
@@ -2624,6 +2625,7 @@ describe('SQLiteAdapter', () => {
         normalizedMergeModes: 0,
         staleAutoFixExperimentTasks: 0,
         normalizedStaleLaunchMetadata: 0,
+        normalizedLegacyAcknowledgedLaunchDispatches: 0,
         backfilledMissingSshPoolMemberIds: 0,
       });
     });
@@ -2698,6 +2700,87 @@ describe('SQLiteAdapter', () => {
 
       const secondRun = adapter.runCompatibilityMigration();
       expect(secondRun.normalizedStaleLaunchMetadata).toBe(0);
+    });
+
+    it('normalizes stale pending launch claims when their dispatch is no longer active', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const expiredAt = new Date(Date.now() - 60_000);
+      const claimedAt = new Date(expiredAt.getTime() - 60_000);
+      const liveClaimedAt = new Date();
+      const liveExpiresAt = new Date(Date.now() + 60_000);
+      const expiredAttempt = createAttempt('stale-pending-launch', {
+        status: 'claimed',
+        claimedAt,
+        lastHeartbeatAt: claimedAt,
+        leaseExpiresAt: expiredAt,
+      });
+      const liveAttempt = createAttempt('live-pending-launch', {
+        status: 'claimed',
+        claimedAt: liveClaimedAt,
+        lastHeartbeatAt: liveClaimedAt,
+        leaseExpiresAt: liveExpiresAt,
+      });
+      adapter.saveTask('wf-1', makeTask('stale-pending-launch', {
+        status: 'pending',
+        execution: {
+          phase: 'launching',
+          selectedAttemptId: expiredAttempt.id,
+          launchStartedAt: claimedAt,
+          lastHeartbeatAt: claimedAt,
+        },
+      }));
+      adapter.saveTask('wf-1', makeTask('live-pending-launch', {
+        status: 'pending',
+        execution: {
+          phase: 'launching',
+          selectedAttemptId: liveAttempt.id,
+          launchStartedAt: new Date(),
+          lastHeartbeatAt: new Date(),
+        },
+      }));
+      adapter.updateTask('stale-pending-launch', {
+        execution: { selectedAttemptId: expiredAttempt.id },
+      });
+      adapter.updateTask('live-pending-launch', {
+        execution: { selectedAttemptId: liveAttempt.id },
+      });
+      adapter.saveAttempt(expiredAttempt);
+      adapter.saveAttempt(liveAttempt);
+      const staleDispatch = adapter.enqueueLaunchDispatch({
+        taskId: 'stale-pending-launch',
+        attemptId: expiredAttempt.id,
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+      adapter.markLaunchDispatchAbandoned(
+        staleDispatch.id,
+        'task is no longer launch-ready',
+        '2026-06-04T01:57:45.435Z',
+      );
+      const liveDispatch = adapter.enqueueLaunchDispatch({
+        taskId: 'live-pending-launch',
+        attemptId: liveAttempt.id,
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+
+      const report = adapter.runCompatibilityMigration();
+
+      expect(report.normalizedStaleLaunchMetadata).toBe(1);
+      const staleTask = adapter.loadTask('stale-pending-launch');
+      expect(staleTask?.status).toBe('pending');
+      expect(staleTask?.execution.phase).toBeUndefined();
+      expect(staleTask?.execution.launchStartedAt).toBeUndefined();
+      expect(staleTask?.execution.lastHeartbeatAt).toBeUndefined();
+      expect(adapter.loadAttempt(expiredAttempt.id)?.status).toBe('pending');
+      expect(adapter.loadAttempt(expiredAttempt.id)?.claimedAt).toBeUndefined();
+      expect(adapter.loadAttempt(expiredAttempt.id)?.leaseExpiresAt).toBeUndefined();
+
+      const liveTask = adapter.loadTask('live-pending-launch');
+      expect(liveTask?.execution.phase).toBe('launching');
+      expect(adapter.loadAttempt(liveAttempt.id)?.status).toBe('claimed');
+      expect(adapter.loadLaunchDispatchById(liveDispatch.id)?.state).toBe('enqueued');
+      expect(adapter.runCompatibilityMigration().normalizedStaleLaunchMetadata).toBe(0);
     });
   });
 

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -297,6 +297,17 @@ describe('SQLiteAdapter', () => {
 
       const byAttempt = adapter.loadLaunchDispatchByAttempt('attempt-1');
       expect(byAttempt?.id).toBe(inserted.id);
+
+      const events = adapter.getEvents('wf-launch/t1');
+      const enqueuedEvent = events.find((event) => event.eventType === 'task.launch_dispatch_enqueued');
+      expect(enqueuedEvent).toBeDefined();
+      expect(JSON.parse(enqueuedEvent!.payload!)).toMatchObject({
+        dispatchId: inserted.id,
+        attemptId: 'attempt-1',
+        workflowId: 'wf-launch',
+        generation: 0,
+        priority: 'normal',
+      });
     });
 
     it('returns existing row instead of creating a duplicate active dispatch for the same attempt', () => {
@@ -534,6 +545,17 @@ describe('SQLiteAdapter', () => {
         expect(claimed?.attemptsCount).toBe(1);
         expect(claimed?.fencedUntil).toBeDefined();
         expect(claimed?.leasedAt).toBeDefined();
+        const events = adapter.getEvents('wf-launch/t1');
+        const claimedEvent = events.find((event) => event.eventType === 'task.launch_dispatch_claimed');
+        expect(claimedEvent).toBeDefined();
+        expect(JSON.parse(claimedEvent!.payload!)).toMatchObject({
+          dispatchId: enqueued.id,
+          ownerId: 'runner-1',
+          attemptId: 'attempt-claim-1',
+          workflowId: 'wf-launch',
+          generation: 0,
+          fencedUntil: claimed?.fencedUntil,
+        });
       });
 
       it('returns undefined when no enqueued rows exist', () => {

--- a/packages/data-store/src/__tests__/stale-downstream-launch-dispatch-repro.test.ts
+++ b/packages/data-store/src/__tests__/stale-downstream-launch-dispatch-repro.test.ts
@@ -137,7 +137,6 @@ describe('stale downstream launch dispatch repro', () => {
 
     const leased = adapter.claimLaunchDispatchAtomic({
       ownerId: 'repro-owner',
-      maxConcurrency: 1,
       nowIso: '2026-06-03T00:02:00.000Z',
     });
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -235,7 +235,6 @@ export interface WorkflowMutationLease {
 export type TaskLaunchDispatchState =
   | 'enqueued'
   | 'leased'
-  | 'acknowledged'
   | 'completed'
   | 'abandoned';
 
@@ -251,7 +250,6 @@ export interface TaskLaunchDispatch {
   dispatchOwner?: string;
   enqueuedAt: string;
   leasedAt?: string;
-  acknowledgedAt?: string;
   completedAt?: string;
   fencedUntil?: string;
   attemptsCount: number;
@@ -420,6 +418,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     normalizedMergeModes: number;
     staleAutoFixExperimentTasks: number;
     normalizedStaleLaunchMetadata: number;
+    normalizedLegacyAcknowledgedLaunchDispatches: number;
     backfilledMissingSshPoolMemberIds: number;
   } {
     const report = {
@@ -427,6 +426,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       normalizedMergeModes: 0,
       staleAutoFixExperimentTasks: 0,
       normalizedStaleLaunchMetadata: 0,
+      normalizedLegacyAcknowledgedLaunchDispatches: 0,
       backfilledMissingSshPoolMemberIds: 0,
     };
     this.runTransaction(() => {
@@ -495,6 +495,113 @@ export class SQLiteAdapter implements PersistenceAdapter {
            AND (julianday(started_at) - julianday(launch_started_at)) * 86400.0 > 3600.0`,
       );
       report.normalizedStaleLaunchMetadata = this.db.getRowsModified();
+
+      const nowIso = new Date().toISOString();
+      const stalePendingLaunchRows = this.queryAll(
+        `SELECT t.id, t.selected_attempt_id
+           FROM tasks t
+           LEFT JOIN attempts a ON a.id = t.selected_attempt_id
+          WHERE t.status = 'pending'
+            AND t.launch_phase = 'launching'
+            AND t.selected_attempt_id IS NOT NULL
+            AND TRIM(t.selected_attempt_id) != ''
+            AND NOT EXISTS (
+              SELECT 1
+                FROM task_launch_dispatch live
+               WHERE live.task_id = t.id
+                 AND live.attempt_id = t.selected_attempt_id
+                 AND live.state IN ('enqueued', 'leased')
+            )
+            AND (
+              a.id IS NULL
+              OR a.lease_expires_at IS NULL
+              OR a.lease_expires_at <= ?
+            )`,
+        [nowIso],
+      ) as Array<{ id: string; selected_attempt_id?: string | null }>;
+      if (stalePendingLaunchRows.length > 0) {
+        const taskIds = stalePendingLaunchRows.map((row) => String(row.id));
+        const taskPlaceholders = taskIds.map(() => '?').join(', ');
+        this.db.run(
+          `UPDATE tasks
+              SET launch_phase = NULL,
+                  launch_started_at = NULL,
+                  launch_completed_at = NULL,
+                  last_heartbeat_at = NULL
+            WHERE id IN (${taskPlaceholders})`,
+          taskIds,
+        );
+
+        const attemptIds = stalePendingLaunchRows
+          .map((row) => row.selected_attempt_id)
+          .filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
+        if (attemptIds.length > 0) {
+          const attemptPlaceholders = attemptIds.map(() => '?').join(', ');
+          this.db.run(
+            `UPDATE attempts
+                SET status = 'pending',
+                    claimed_at = NULL,
+                    last_heartbeat_at = NULL,
+                    lease_expires_at = NULL
+              WHERE id IN (${attemptPlaceholders})
+                AND status = 'claimed'`,
+            attemptIds,
+          );
+        }
+        report.normalizedStaleLaunchMetadata += stalePendingLaunchRows.length;
+      }
+
+      this.db.run(
+        `UPDATE task_launch_dispatch
+         SET state = 'abandoned',
+             completed_at = ?,
+             last_error = 'Legacy acknowledged launch dispatch is stale after acknowledgement removal',
+             dispatch_owner = NULL,
+             fenced_until = NULL
+         WHERE state = 'acknowledged'
+           AND (
+             NOT EXISTS (
+               SELECT 1
+               FROM tasks t
+               WHERE t.id = task_launch_dispatch.task_id
+                 AND t.status = 'pending'
+                 AND COALESCE(t.selected_attempt_id, '') = task_launch_dispatch.attempt_id
+                 AND COALESCE(t.execution_generation, 0) = task_launch_dispatch.generation
+             )
+             OR EXISTS (
+               SELECT 1
+               FROM task_launch_dispatch live
+               WHERE live.attempt_id = task_launch_dispatch.attempt_id
+                 AND live.id != task_launch_dispatch.id
+                 AND live.state IN ('enqueued', 'leased')
+             )
+           )`,
+        [nowIso],
+      );
+      report.normalizedLegacyAcknowledgedLaunchDispatches += this.db.getRowsModified();
+
+      this.db.run(
+        `UPDATE task_launch_dispatch
+         SET state = 'leased',
+             leased_at = COALESCE(leased_at, acknowledged_at, ?),
+             acknowledged_at = NULL
+         WHERE state = 'acknowledged'
+           AND fenced_until IS NOT NULL
+           AND fenced_until >= ?`,
+        [nowIso, nowIso],
+      );
+      report.normalizedLegacyAcknowledgedLaunchDispatches += this.db.getRowsModified();
+
+      this.db.run(
+        `UPDATE task_launch_dispatch
+         SET state = 'enqueued',
+             dispatch_owner = NULL,
+             leased_at = NULL,
+             acknowledged_at = NULL,
+             fenced_until = NULL
+         WHERE state = 'acknowledged'`,
+      );
+      report.normalizedLegacyAcknowledgedLaunchDispatches += this.db.getRowsModified();
 
       // One-time compatibility backfill for SSH tasks created before
       // pool_member_id was durably written to tasks. Runtime routing must use
@@ -812,7 +919,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
       CREATE UNIQUE INDEX IF NOT EXISTS idx_task_launch_dispatch_active_attempt
         ON task_launch_dispatch(attempt_id)
-        WHERE state IN ('enqueued', 'leased', 'acknowledged');
+        WHERE state IN ('enqueued', 'leased');
 
       CREATE INDEX IF NOT EXISTS idx_task_launch_dispatch_ready
         ON task_launch_dispatch(state, priority, id)
@@ -937,6 +1044,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.db.run('DROP INDEX IF EXISTS idx_attempts_node');
     this.db.run('CREATE INDEX IF NOT EXISTS idx_attempts_node_created ON attempts(node_id, created_at)');
     this.db.run('CREATE INDEX IF NOT EXISTS idx_tasks_workflow_id ON tasks(workflow_id)');
+    this.db.run('DROP INDEX IF EXISTS idx_task_launch_dispatch_active_attempt');
+    this.db.run(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_task_launch_dispatch_active_attempt
+        ON task_launch_dispatch(attempt_id)
+        WHERE state IN ('enqueued', 'leased')
+    `);
 
     if (!this.readOnly) {
       this.migrateTestCommands();
@@ -3162,7 +3275,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       const existing = this.queryOne(
         `SELECT * FROM task_launch_dispatch
            WHERE attempt_id = ?
-             AND state IN ('enqueued', 'leased', 'acknowledged')
+             AND state IN ('enqueued', 'leased')
            LIMIT 1`,
         [input.attemptId],
       );
@@ -3178,7 +3291,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       const inserted = this.queryOne(
         `SELECT * FROM task_launch_dispatch
            WHERE attempt_id = ?
-             AND state IN ('enqueued', 'leased', 'acknowledged')
+             AND state IN ('enqueued', 'leased')
            LIMIT 1`,
         [input.attemptId],
       );
@@ -3201,7 +3314,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     const row = this.queryOne(
       `SELECT * FROM task_launch_dispatch
          WHERE attempt_id = ?
-           AND state IN ('enqueued', 'leased', 'acknowledged')
+           AND state IN ('enqueued', 'leased')
          ORDER BY id DESC
          LIMIT 1`,
       [attemptId],
@@ -3224,32 +3337,23 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   /**
-   * Atomic capacity-gated lease of the next enqueued dispatch row.
+   * Atomic lease of the next enqueued dispatch row.
    *
    * Selects the oldest enqueued row (priority high < normal < low, then id
-   * ascending) and transitions it to `leased` only if the current count of
-   * `leased | acknowledged` rows is below `maxConcurrency`. Wrapped in an
-   * IMMEDIATE transaction so concurrent dispatchers cannot double-lease.
-   * Returns the freshly leased row or `undefined` when nothing is enqueued,
-   * capacity is exhausted, or another dispatcher beat us to it.
+   * ascending) and transitions it to `leased`. Wrapped in an IMMEDIATE
+   * transaction so concurrent dispatchers cannot double-lease. Returns the
+   * freshly leased row or `undefined` when nothing is enqueued or another
+   * dispatcher beat us to it.
    */
   claimLaunchDispatchAtomic(options: {
     ownerId: string;
-    maxConcurrency: number;
     nowIso?: string;
   }): TaskLaunchDispatch | undefined {
-    if (options.maxConcurrency <= 0) return undefined;
     const now = options.nowIso ?? new Date().toISOString();
     const fencedUntil = new Date(
       new Date(now).getTime() + DISPATCH_LEASE_MS,
     ).toISOString();
     return this.runTransaction(() => {
-      const activeRow = this.queryOne(
-        `SELECT COUNT(*) AS active FROM task_launch_dispatch
-           WHERE state IN ('leased', 'acknowledged')`,
-      );
-      const active = Number(activeRow?.active ?? 0);
-      if (active >= options.maxConcurrency) return undefined;
       while (true) {
         const candidate = this.queryOne(
           `SELECT
@@ -3325,28 +3429,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
     });
   }
 
-  markLaunchDispatchAcknowledged(
-    id: number,
-    runnerId: string,
-    nowIso?: string,
-  ): boolean {
-    const now = nowIso ?? new Date().toISOString();
-    const fencedUntil = new Date(
-      new Date(now).getTime() + DISPATCH_LEASE_MS,
-    ).toISOString();
-    this.execRun(
-      `UPDATE task_launch_dispatch
-         SET state = 'acknowledged',
-             acknowledged_at = ?,
-             dispatch_owner = ?,
-             fenced_until = ?
-       WHERE id = ?
-         AND state = 'leased'`,
-      [now, runnerId, fencedUntil, id],
-    );
-    return (this.db.getRowsModified?.() ?? 0) > 0;
-  }
-
   markLaunchDispatchCompleted(id: number, nowIso?: string): boolean {
     const now = nowIso ?? new Date().toISOString();
     this.execRun(
@@ -3378,21 +3460,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return (this.db.getRowsModified?.() ?? 0) > 0;
   }
 
-  /**
-   * Return the dispatch rows in `acknowledged` whose fence has expired AND
-   * whose `attempts_count` has reached `maxAttempts`. These are the rows
-   * that the dispatcher should abandon and report to the orchestrator —
-   * they have already burned through their retry budget without the
-   * TaskRunner finishing the launch.
-   */
-  listAbandonableAcknowledgedLeases(options: {
+  listAbandonableLaunchDispatchLeases(options: {
     nowIso?: string;
     maxAttempts: number;
   }): TaskLaunchDispatch[] {
     const now = options.nowIso ?? new Date().toISOString();
     const rows = this.queryAll(
       `SELECT * FROM task_launch_dispatch
-         WHERE state = 'acknowledged'
+         WHERE state = 'leased'
            AND fenced_until IS NOT NULL
            AND fenced_until < ?
            AND attempts_count >= ?
@@ -3441,7 +3516,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         `SELECT id, task_id, attempt_id, workflow_id, state, generation
            FROM task_launch_dispatch
           WHERE task_id IN (${taskPlaceholders})
-            AND state IN ('enqueued', 'leased', 'acknowledged')
+            AND state IN ('enqueued', 'leased')
           ORDER BY id ASC`,
         ids,
       );
@@ -3457,7 +3532,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
                 dispatch_owner = NULL,
                 fenced_until = NULL
           WHERE id IN (${idPlaceholders})
-            AND state IN ('enqueued', 'leased', 'acknowledged')`,
+            AND state IN ('enqueued', 'leased')`,
         [now, reason, ...rowIds],
       );
 
@@ -3472,15 +3547,20 @@ export class SQLiteAdapter implements PersistenceAdapter {
     });
   }
 
-  reapExpiredLaunchDispatchLeases(nowIso?: string): TaskLaunchDispatch[] {
-    const now = nowIso ?? new Date().toISOString();
+  reapExpiredLaunchDispatchLeases(options: {
+    nowIso?: string;
+    maxAttempts?: number;
+  } = {}): TaskLaunchDispatch[] {
+    const now = options.nowIso ?? new Date().toISOString();
+    const maxAttempts = options.maxAttempts ?? Number.MAX_SAFE_INTEGER;
     return this.runTransaction(() => {
       const expired = this.queryAll(
         `SELECT * FROM task_launch_dispatch
            WHERE state = 'leased'
              AND fenced_until IS NOT NULL
-             AND fenced_until < ?`,
-        [now],
+             AND fenced_until < ?
+             AND attempts_count < ?`,
+        [now, maxAttempts],
       );
       if (expired.length === 0) return [];
       this.execRun(
@@ -3490,8 +3570,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
                fenced_until = NULL
          WHERE state = 'leased'
            AND fenced_until IS NOT NULL
-           AND fenced_until < ?`,
-        [now],
+           AND fenced_until < ?
+           AND attempts_count < ?`,
+        [now, maxAttempts],
       );
       return expired.map((row) => {
         const reset = { ...row, state: 'enqueued', dispatch_owner: null, fenced_until: null };
@@ -3514,7 +3595,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
       dispatchOwner: row.dispatch_owner ? String(row.dispatch_owner) : undefined,
       enqueuedAt: String(row.enqueued_at),
       leasedAt: row.leased_at ? String(row.leased_at) : undefined,
-      acknowledgedAt: row.acknowledged_at ? String(row.acknowledged_at) : undefined,
       completedAt: row.completed_at ? String(row.completed_at) : undefined,
       fencedUntil: row.fenced_until ? String(row.fenced_until) : undefined,
       attemptsCount: Number(row.attempts_count ?? 0),

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3298,7 +3298,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (!inserted) {
         throw new Error('Failed to read back inserted task_launch_dispatch row');
       }
-      return this.rowToTaskLaunchDispatch(inserted);
+      const dispatch = this.rowToTaskLaunchDispatch(inserted);
+      this.logEvent(input.taskId, 'task.launch_dispatch_enqueued', {
+        dispatchId: dispatch.id,
+        attemptId: input.attemptId,
+        workflowId: input.workflowId,
+        generation: input.generation,
+        priority,
+      });
+      return dispatch;
     });
   }
 
@@ -3424,7 +3432,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
           'SELECT * FROM task_launch_dispatch WHERE id = ?',
           [candidateId],
         );
-        return row ? this.rowToTaskLaunchDispatch(row) : undefined;
+        if (!row) return undefined;
+        const dispatch = this.rowToTaskLaunchDispatch(row);
+        this.logEvent(dispatch.taskId, 'task.launch_dispatch_claimed', {
+          dispatchId: dispatch.id,
+          ownerId: options.ownerId,
+          attemptId: dispatch.attemptId,
+          workflowId: dispatch.workflowId,
+          generation: dispatch.generation,
+          fencedUntil: dispatch.fencedUntil,
+        });
+        return dispatch;
       }
     });
   }

--- a/packages/execution-engine/src/__tests__/process-utils.test.ts
+++ b/packages/execution-engine/src/__tests__/process-utils.test.ts
@@ -26,6 +26,7 @@ const originalShell = process.env.SHELL;
 const originalElectronRunAsNode = process.env.ELECTRON_RUN_AS_NODE;
 const originalElectronNoAsar = process.env.ELECTRON_NO_ASAR;
 const originalElectronNoAttachConsole = process.env.ELECTRON_NO_ATTACH_CONSOLE;
+const originalInvokerRepoConfigPath = process.env.INVOKER_REPO_CONFIG_PATH;
 
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', { value: platform, configurable: true });
@@ -54,6 +55,8 @@ describe('process-utils shell environment resolution', () => {
     else process.env.ELECTRON_NO_ASAR = originalElectronNoAsar;
     if (originalElectronNoAttachConsole === undefined) delete process.env.ELECTRON_NO_ATTACH_CONSOLE;
     else process.env.ELECTRON_NO_ATTACH_CONSOLE = originalElectronNoAttachConsole;
+    if (originalInvokerRepoConfigPath === undefined) delete process.env.INVOKER_REPO_CONFIG_PATH;
+    else process.env.INVOKER_REPO_CONFIG_PATH = originalInvokerRepoConfigPath;
   });
 
   afterEach(() => {
@@ -85,6 +88,7 @@ describe('process-utils shell environment resolution', () => {
     process.env.ELECTRON_RUN_AS_NODE = '1';
     process.env.ELECTRON_NO_ASAR = '1';
     process.env.ELECTRON_NO_ATTACH_CONSOLE = '1';
+    process.env.INVOKER_REPO_CONFIG_PATH = '/tmp/operator-only-repo-config.json';
 
     const { processUtils, mockedSpawn } = await loadProcessUtils();
     const proc = createMockProcess();
@@ -110,6 +114,7 @@ describe('process-utils shell environment resolution', () => {
     expect(processUtils.cleanElectronEnv()).not.toHaveProperty('ELECTRON_RUN_AS_NODE');
     expect(processUtils.cleanElectronEnv()).not.toHaveProperty('ELECTRON_NO_ASAR');
     expect(processUtils.cleanElectronEnv()).not.toHaveProperty('ELECTRON_NO_ATTACH_CONSOLE');
+    expect(processUtils.cleanElectronEnv()).not.toHaveProperty('INVOKER_REPO_CONFIG_PATH');
 
     const second = await processUtils.initializeShellEnvironment();
     expect(second).toEqual(result);

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -467,50 +467,26 @@ describe('RepoPool', () => {
       });
     });
 
-    it('concurrent fetches from separate pools sharing cacheDir both succeed', async () => {
-      // Setup: bare repo so multiple clones can fetch concurrently
-      const bareDir = mkdtempSync(join(tmpdir(), 'repo-pool-bare-'));
-      const sourceDir = mkdtempSync(join(tmpdir(), 'repo-pool-src-'));
+    it('separate pools sharing cacheDir tolerate fetch failures', async () => {
+      await pool.ensureClone(localRepoUrl);
+
+      const pool2 = new RepoPool({ cacheDir: tmpDir });
+      const pool3 = new RepoPool({ cacheDir: tmpDir });
+      spyFetchToFail(pool2);
+      spyFetchToFail(pool3);
+
       try {
-        execSync('git init --bare -b master', { cwd: bareDir });
-        execSync(`git clone ${bareDir} .`, { cwd: sourceDir });
-        execSync('git config user.email "t@t.com" && git config user.name "T"', { cwd: sourceDir });
-        execSync('git commit --allow-empty -m "init"', { cwd: sourceDir });
-        execSync('git branch -M master', { cwd: sourceDir });
-        execSync('git push -u origin master', { cwd: sourceDir });
-        for (let i = 0; i < 15; i++) {
-          execSync(`git checkout -b experiment/b-${i} master`, { cwd: sourceDir });
-          execSync(`git commit --allow-empty -m "b${i}" && git push origin experiment/b-${i}`, { cwd: sourceDir });
-        }
-        execSync('git checkout master', { cwd: sourceDir });
-
-        // Initial clone via pool
-        await pool.ensureClone(bareDir);
-
-        // Force-push all branches to create stale tracking refs
-        for (let i = 0; i < 15; i++) {
-          execSync(`git checkout experiment/b-${i}`, { cwd: sourceDir });
-          execSync(`git commit --allow-empty -m "rewrite ${i}" && git push --force origin experiment/b-${i}`, { cwd: sourceDir });
-        }
-
-        // Two separate pools share cacheDir — their fetches race on the same .git dir
-        const pool2 = new RepoPool({ cacheDir: tmpDir });
-        const pool3 = new RepoPool({ cacheDir: tmpDir });
-
         const [r1, r2] = await Promise.all([
-          pool2.ensureClone(bareDir),
-          pool3.ensureClone(bareDir),
+          pool2.ensureClone(localRepoUrl),
+          pool3.ensureClone(localRepoUrl),
         ]);
 
         expect(r1).toBe(r2);
         const sha = execSync('git rev-parse origin/master', { cwd: r1 }).toString().trim();
         expect(sha).toBeTruthy();
-
+      } finally {
         await pool2.destroyAll();
         await pool3.destroyAll();
-      } finally {
-        rmSync(bareDir, { recursive: true, force: true });
-        rmSync(sourceDir, { recursive: true, force: true });
       }
     });
   });

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -48,17 +48,17 @@ describe('RepoPool', () => {
     rmSync(localRepoUrl, { recursive: true, force: true });
   });
 
-  it('ensureClone: clones repo on first call', async () => {
-    const path = await pool.ensureClone(localRepoUrl);
+  it('ensureCloneThroughRepoQueue: clones repo on first call', async () => {
+    const path = await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     expect(path).toBeDefined();
     // Verify it's a git repo
     const result = execSync('git rev-parse --is-inside-work-tree', { cwd: path }).toString().trim();
     expect(result).toBe('true');
   });
 
-  it('ensureClone: returns cached path on second call', async () => {
-    const p1 = await pool.ensureClone(localRepoUrl);
-    const p2 = await pool.ensureClone(localRepoUrl);
+  it('ensureCloneThroughRepoQueue: returns cached path on second call', async () => {
+    const p1 = await pool.ensureCloneThroughRepoQueue(localRepoUrl);
+    const p2 = await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     expect(p1).toBe(p2);
   });
 
@@ -78,19 +78,19 @@ describe('RepoPool', () => {
     const httpsUrl = 'https://github.com/Neko-Catpital-Labs/Invoker';
     const sshUrl = 'git@github.com:Neko-Catpital-Labs/Invoker.git';
     const clonePath = githubPool.getClonePath(httpsUrl);
-    const doEnsureClone = vi
-      .spyOn(githubPool as any, 'doEnsureClone')
+    const ensureCloneUnqueued = vi
+      .spyOn(githubPool as any, 'ensureCloneUnqueued')
       .mockImplementation(async (_repoUrl: string) => clonePath);
 
     const [p1, p2] = await Promise.all([
-      githubPool.ensureClone(httpsUrl),
-      githubPool.ensureClone(sshUrl),
+      githubPool.ensureCloneThroughRepoQueue(httpsUrl),
+      githubPool.ensureCloneThroughRepoQueue(sshUrl),
     ]);
 
     expect(p1).toBe(clonePath);
     expect(p2).toBe(clonePath);
-    expect(doEnsureClone).toHaveBeenCalledTimes(1);
-    expect(doEnsureClone).toHaveBeenCalledWith(httpsUrl);
+    expect(ensureCloneUnqueued).toHaveBeenCalledTimes(1);
+    expect(ensureCloneUnqueued).toHaveBeenCalledWith(httpsUrl);
     await githubPool.destroyAll();
   });
 
@@ -131,7 +131,7 @@ describe('RepoPool', () => {
   });
 
   it('destroyAll: removes all worktrees but preserves cache', async () => {
-    const clonePath = await pool.ensureClone(localRepoUrl);
+    const clonePath = await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     await pool.acquireWorktree(localRepoUrl, 'b1');
     await pool.acquireWorktree(localRepoUrl, 'b2');
     await pool.destroyAll();
@@ -391,17 +391,17 @@ describe('RepoPool', () => {
       );
     }
 
-    it('ensureClone succeeds when fetch --all fails', async () => {
-      await pool.ensureClone(localRepoUrl);
+    it('ensureCloneThroughRepoQueue succeeds when fetch --all fails', async () => {
+      await pool.ensureCloneThroughRepoQueue(localRepoUrl);
       spyFetchToFail(pool);
 
-      const path = await pool.ensureClone(localRepoUrl);
+      const path = await pool.ensureCloneThroughRepoQueue(localRepoUrl);
       expect(path).toBeDefined();
       expect(existsSync(path)).toBe(true);
     });
 
     it('refreshMirrorForRebase succeeds when fetch --all fails', async () => {
-      await pool.ensureClone(localRepoUrl);
+      await pool.ensureCloneThroughRepoQueue(localRepoUrl);
       spyFetchToFail(pool);
 
       const dir = await pool.refreshMirrorForRebase(localRepoUrl, 'master');
@@ -410,7 +410,7 @@ describe('RepoPool', () => {
     });
 
     it('skips per-base fetch after a successful full origin ref refresh', async () => {
-      await pool.ensureClone(localRepoUrl);
+      await pool.ensureCloneThroughRepoQueue(localRepoUrl);
       const orig = (pool as any).execGit.bind(pool);
       const execGit = vi.spyOn(pool as any, 'execGit').mockImplementation(
         (...params: unknown[]) => {
@@ -440,7 +440,7 @@ describe('RepoPool', () => {
     });
 
     it('reuses the base commit resolved by the rebase refresh batch', async () => {
-      await pool.ensureClone(localRepoUrl);
+      await pool.ensureCloneThroughRepoQueue(localRepoUrl);
       const orig = (pool as any).execGit.bind(pool);
       const execGit = vi.spyOn(pool as any, 'execGit').mockImplementation(
         (...params: unknown[]) => {
@@ -468,7 +468,7 @@ describe('RepoPool', () => {
     });
 
     it('separate pools sharing cacheDir tolerate fetch failures', async () => {
-      await pool.ensureClone(localRepoUrl);
+      await pool.ensureCloneThroughRepoQueue(localRepoUrl);
 
       const pool2 = new RepoPool({ cacheDir: tmpDir });
       const pool3 = new RepoPool({ cacheDir: tmpDir });
@@ -477,8 +477,8 @@ describe('RepoPool', () => {
 
       try {
         const [r1, r2] = await Promise.all([
-          pool2.ensureClone(localRepoUrl),
-          pool3.ensureClone(localRepoUrl),
+          pool2.ensureCloneThroughRepoQueue(localRepoUrl),
+          pool3.ensureCloneThroughRepoQueue(localRepoUrl),
         ]);
 
         expect(r1).toBe(r2);
@@ -877,8 +877,8 @@ describe('RepoPool', () => {
     });
   });
 
-  it('ensureClone skips network refresh when remoteFetchForPool.enabled is false', async () => {
-    await pool.ensureClone(localRepoUrl);
+  it('ensureCloneThroughRepoQueue skips network refresh when remoteFetchForPool.enabled is false', async () => {
+    await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     const clonePath = pool.getClonePath(localRepoUrl);
     const shaBefore = execSync('git rev-parse origin/master', { cwd: clonePath }).toString().trim();
 
@@ -886,12 +886,12 @@ describe('RepoPool', () => {
     execSync('git add -A && git commit -m "upstream advance"', { cwd: localRepoUrl });
 
     remoteFetchForPool.enabled = false;
-    await pool.ensureClone(localRepoUrl);
+    await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     const shaSkipped = execSync('git rev-parse origin/master', { cwd: clonePath }).toString().trim();
     expect(shaSkipped).toBe(shaBefore);
 
     remoteFetchForPool.enabled = true;
-    await pool.ensureClone(localRepoUrl);
+    await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     const shaFresh = execSync('git rev-parse origin/master', { cwd: clonePath }).toString().trim();
     expect(shaFresh).not.toBe(shaBefore);
   });

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
 import { TaskRunner, type LaunchOutboxAck } from '../task-runner.js';
@@ -32,6 +32,11 @@ function makeTask(overrides: Partial<TaskState> = {}): TaskState {
 
 interface RunnerEnv {
   runner: TaskRunner;
+  persistence: {
+    updateTask: ReturnType<typeof vi.fn>;
+    loadAttempts: ReturnType<typeof vi.fn>;
+    logEvent: ReturnType<typeof vi.fn>;
+  };
   orchestrator: {
     getTask: ReturnType<typeof vi.fn>;
     markTaskRunningAfterLaunch: ReturnType<typeof vi.fn>;
@@ -50,11 +55,15 @@ interface RunnerEnv {
   triggerComplete: () => void;
 }
 
-function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}): RunnerEnv {
+function buildRunnerEnv(task: TaskState, options: {
+  startThrows?: Error;
+  startImpl?: (request: any) => Promise<any>;
+} = {}): RunnerEnv {
   let completeCallback: ((response: WorkResponse) => void) | undefined;
   const executor = {
     type: 'worktree',
     start: vi.fn().mockImplementation(async (request: any) => {
+      if (options.startImpl) return options.startImpl(request);
       if (options.startThrows) throw options.startThrows;
       return {
         executionId: `exec-${request.actionId}`,
@@ -79,13 +88,14 @@ function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}):
     handleWorkerResponse: vi.fn().mockReturnValue([]),
     deferTask: vi.fn(),
   };
+  const persistence = {
+    updateTask: vi.fn(),
+    loadAttempts: vi.fn().mockReturnValue([]),
+    logEvent: vi.fn(),
+  };
   const runner = new TaskRunner({
     orchestrator: orchestrator as any,
-    persistence: {
-      updateTask: vi.fn(),
-      loadAttempts: vi.fn().mockReturnValue([]),
-      logEvent: vi.fn(),
-    } as any,
+    persistence: persistence as any,
     executorRegistry: {
       get: vi.fn().mockReturnValue(executor),
       getAll: vi.fn().mockReturnValue([['worktree', executor]]),
@@ -96,6 +106,7 @@ function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}):
   });
   return {
     runner,
+    persistence,
     orchestrator,
     executor,
     triggerComplete: () => {
@@ -132,6 +143,10 @@ function makeLaunchOutbox(): LaunchOutboxAck & {
 }
 
 describe('TaskRunner launch-dispatch wiring', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('keeps dispatch leased and proceeds to executor.start', async () => {
     const task = makeTask();
     const env = buildRunnerEnv(task, { startThrows: new Error('isolated start sentinel') });
@@ -155,6 +170,38 @@ describe('TaskRunner launch-dispatch wiring', () => {
     const failArg = launchOutbox.failCalls[0][1];
     expect(failArg).toBeInstanceOf(Error);
     expect((failArg as Error).message).toMatch(/startup explosion/);
+  });
+
+  it('logs executor start begin with launch-dispatch context while executor.start is pending', async () => {
+    const task = makeTask();
+    let resolveStart: (() => void) | undefined;
+    const env = buildRunnerEnv(task, {
+      startImpl: async (request) => new Promise((resolve) => {
+        resolveStart = () => resolve({
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/tmp/mock-ws',
+          branch: `experiment/${request.actionId}-mock`,
+        });
+      }),
+    });
+    const launchOutbox = makeLaunchOutbox();
+
+    const run = env.runner.executeTask(task, { dispatchId: 99, launchOutbox });
+    await vi.waitFor(() => expect(env.persistence.logEvent).toHaveBeenCalledWith(
+      task.id,
+      'task.executor.start_begin',
+      expect.objectContaining({
+        dispatchId: 99,
+        attemptId: 'attempt-1',
+        executorType: 'worktree',
+      }),
+    ));
+
+    resolveStart?.();
+    await vi.waitFor(() => expect(env.executor.onComplete).toHaveBeenCalled());
+    env.triggerComplete();
+    await run;
   });
 
   it('fails the dispatch when markTaskRunningAfterLaunch rejects the launch', async () => {

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -112,21 +112,14 @@ function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}):
 }
 
 function makeLaunchOutbox(): LaunchOutboxAck & {
-  ackCalls: Array<[number, string]>;
   completeCalls: number[];
   failCalls: Array<[number, unknown]>;
 } {
-  const ackCalls: Array<[number, string]> = [];
   const completeCalls: number[] = [];
   const failCalls: Array<[number, unknown]> = [];
   return {
-    ackCalls,
     completeCalls,
     failCalls,
-    ackDispatch(id, runnerId) {
-      ackCalls.push([id, runnerId]);
-      return true;
-    },
     completeDispatch(id) {
       completeCalls.push(id);
       return true;
@@ -139,31 +132,14 @@ function makeLaunchOutbox(): LaunchOutboxAck & {
 }
 
 describe('TaskRunner launch-dispatch wiring', () => {
-  it('acks dispatch at the top of executeTask and proceeds to executor.start when accepted', async () => {
+  it('keeps dispatch leased and proceeds to executor.start', async () => {
     const task = makeTask();
     const env = buildRunnerEnv(task, { startThrows: new Error('isolated start sentinel') });
     const launchOutbox = makeLaunchOutbox();
 
     await env.runner.executeTask(task, { dispatchId: 42, launchOutbox });
 
-    expect(launchOutbox.ackCalls).toHaveLength(1);
-    expect(launchOutbox.ackCalls[0][0]).toBe(42);
-    expect(launchOutbox.ackCalls[0][1]).toMatch(/^[0-9a-f-]+$/);
     expect(env.executor.start).toHaveBeenCalledTimes(1);
-  });
-
-  it('does NOT call the executor when ackDispatch returns false', async () => {
-    const task = makeTask();
-    const env = buildRunnerEnv(task);
-    const launchOutbox = makeLaunchOutbox();
-    launchOutbox.ackDispatch = vi.fn().mockReturnValue(false);
-
-    await env.runner.executeTask(task, { dispatchId: 99, launchOutbox });
-
-    expect(env.executor.start).not.toHaveBeenCalled();
-    expect(env.orchestrator.markTaskRunningAfterLaunch).not.toHaveBeenCalled();
-    expect(launchOutbox.completeCalls).toHaveLength(0);
-    expect(launchOutbox.failCalls).toHaveLength(0);
   });
 
   it('calls failDispatch when the executor start throws', async () => {
@@ -173,13 +149,28 @@ describe('TaskRunner launch-dispatch wiring', () => {
 
     await env.runner.executeTask(task, { dispatchId: 7, launchOutbox });
 
-    expect(launchOutbox.ackCalls).toHaveLength(1);
     expect(launchOutbox.completeCalls).toHaveLength(0);
     expect(launchOutbox.failCalls).toHaveLength(1);
     expect(launchOutbox.failCalls[0][0]).toBe(7);
     const failArg = launchOutbox.failCalls[0][1];
     expect(failArg).toBeInstanceOf(Error);
     expect((failArg as Error).message).toMatch(/startup explosion/);
+  });
+
+  it('fails the dispatch when markTaskRunningAfterLaunch rejects the launch', async () => {
+    const task = makeTask();
+    const env = buildRunnerEnv(task);
+    env.orchestrator.markTaskRunningAfterLaunch.mockReturnValue(false);
+    const launchOutbox = makeLaunchOutbox();
+
+    await env.runner.executeTask(task, { dispatchId: 8, launchOutbox });
+
+    expect(env.executor.start).toHaveBeenCalledTimes(1);
+    expect(env.executor.kill).toHaveBeenCalledTimes(1);
+    expect(launchOutbox.completeCalls).toHaveLength(0);
+    expect(launchOutbox.failCalls).toHaveLength(1);
+    expect(launchOutbox.failCalls[0][0]).toBe(8);
+    expect((launchOutbox.failCalls[0][1] as Error).message).toMatch(/Launch rejected/);
   });
 
   it('completes the dispatch row when resource-limit defers the launch', async () => {
@@ -194,7 +185,6 @@ describe('TaskRunner launch-dispatch wiring', () => {
 
     await env.runner.executeTask(task, { dispatchId: 321, launchOutbox });
 
-    expect(launchOutbox.ackCalls).toHaveLength(1);
     expect(env.orchestrator.deferTask).toHaveBeenCalledWith(task.id);
     expect(launchOutbox.completeCalls).toEqual([321]);
     expect(launchOutbox.failCalls).toHaveLength(0);
@@ -207,7 +197,6 @@ describe('TaskRunner launch-dispatch wiring', () => {
 
     await env.runner.executeTask(task);
 
-    expect(launchOutbox.ackCalls).toHaveLength(0);
     expect(launchOutbox.completeCalls).toHaveLength(0);
     expect(launchOutbox.failCalls).toHaveLength(0);
     expect(env.executor.start).toHaveBeenCalled();
@@ -243,7 +232,6 @@ describe('TaskRunner launch-dispatch wiring', () => {
     await env.runner.executeTask(task, { dispatchId: 123, launchOutbox });
 
     expect(env.executor.start).not.toHaveBeenCalled();
-    expect(launchOutbox.ackCalls).toHaveLength(0);
     expect(launchOutbox.failCalls).toHaveLength(1);
     expect(launchOutbox.failCalls[0][0]).toBe(123);
     expect((launchOutbox.failCalls[0][1] as Error).message).toMatch(/Duplicate launch suppressed/);
@@ -254,7 +242,7 @@ describe('TaskRunner launch-dispatch wiring', () => {
     // BEFORE the normal markTaskRunningAfterLaunch completeDispatch
     // path (it synthesises a spawn_experiments WorkResponse and
     // returns). Without an explicit completeDispatch here, the parent
-    // pivot's outbox row stays acknowledged → reaped → abandoned.
+    // pivot's outbox row stays leased and is retried or abandoned.
     const pivotTask = makeTask({
       id: 'wf-pivot/parent',
       config: {
@@ -276,9 +264,6 @@ describe('TaskRunner launch-dispatch wiring', () => {
 
     await env.runner.executeTask(pivotTask, { dispatchId: 555, launchOutbox });
 
-    // ackDispatch fired at the top of executeTask.
-    expect(launchOutbox.ackCalls).toHaveLength(1);
-    expect(launchOutbox.ackCalls[0][0]).toBe(555);
     // The pivot path emits a spawn_experiments WorkResponse and then,
     // critically, terminates the parent's dispatch row.
     expect(env.orchestrator.handleWorkerResponse).toHaveBeenCalled();

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -48,11 +48,11 @@ function makeRequest(overrides: Partial<WorkRequest> = {}): WorkRequest {
 
 /**
  * Mock the RepoPool on a WorktreeExecutor instance so that
- * pool.ensureClone / pool.acquireWorktree bypass real git.
+ * pool.ensureCloneThroughRepoQueue / pool.acquireWorktree bypass real git.
  */
 function mockPool(fam: WorktreeExecutor) {
   const pool = {
-    ensureClone: vi.fn().mockResolvedValue('/fake/cache/clone'),
+    ensureCloneThroughRepoQueue: vi.fn().mockResolvedValue('/fake/cache/clone'),
     reconcileActiveWorktrees: vi.fn(),
     acquireWorktree: vi.fn().mockImplementation((_repoUrl: string, branch: string) => {
       const sanitized = branch.replace(/\//g, '-');
@@ -773,7 +773,7 @@ describe('WorktreeExecutor', () => {
     const branch = 'experiment/action-1-abc12345';
     const worktreePath = '/fake/worktrees/experiment-action-1-abc12345';
     const pool = {
-      ensureClone: vi.fn().mockResolvedValue('/fake/cache/clone'),
+      ensureCloneThroughRepoQueue: vi.fn().mockResolvedValue('/fake/cache/clone'),
       reconcileActiveWorktrees: vi.fn(),
       acquireWorktree: vi.fn().mockResolvedValue({
         clonePath: '/fake/cache/clone',

--- a/packages/execution-engine/src/__tests__/worktree-leak-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-leak-repro.test.ts
@@ -39,7 +39,7 @@ function makeRequest(overrides: Partial<WorkRequest> = {}): WorkRequest {
  */
 function mockPool(fam: WorktreeExecutor) {
   const pool = {
-    ensureClone: vi.fn().mockResolvedValue('/fake/cache/clone'),
+    ensureCloneThroughRepoQueue: vi.fn().mockResolvedValue('/fake/cache/clone'),
     acquireWorktree: vi.fn().mockImplementation((_repoUrl: string, branch: string) => {
       const sanitized = branch.replace(/\//g, '-');
       return Promise.resolve({
@@ -211,7 +211,7 @@ describe('BUG REPRO: worktree lifecycle leaks', () => {
     expect((executor as any).entries.size).toBe(0);
   });
 
-  it('should call pool.ensureClone (which fetches) before branching when baseBranch is set', async () => {
+  it('should call pool.ensureCloneThroughRepoQueue (which fetches) before branching when baseBranch is set', async () => {
     const { taskProcess } = setupSpawnMock();
 
     const request = makeRequest({
@@ -219,9 +219,9 @@ describe('BUG REPRO: worktree lifecycle leaks', () => {
     });
     await executor.start(request);
 
-    // pool.ensureClone handles fetching internally (git fetch --all on existing clones)
+    // pool.ensureCloneThroughRepoQueue handles fetching internally (git fetch --all on existing clones)
     const pool = (executor as any).pool;
-    expect(pool.ensureClone).toHaveBeenCalledWith('git@github.com:test/repo.git');
+    expect(pool.ensureCloneThroughRepoQueue).toHaveBeenCalledWith('git@github.com:test/repo.git');
 
     // Cleanup
     taskProcess.emit('close', 0, null);

--- a/packages/execution-engine/src/process-utils.ts
+++ b/packages/execution-engine/src/process-utils.ts
@@ -222,6 +222,7 @@ export function cleanElectronEnv(): NodeJS.ProcessEnv {
   delete env.ELECTRON_RUN_AS_NODE;
   delete env.ELECTRON_NO_ASAR;
   delete env.ELECTRON_NO_ATTACH_CONSOLE;
+  delete env.INVOKER_REPO_CONFIG_PATH;
   env.PATH = getEffectivePath();
   return env;
 }

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -436,39 +436,39 @@ export class RepoPool {
     return timing.span(functionName, metadata, fn);
   }
 
-  async ensureClone(repoUrl: string): Promise<string> {
+  async ensureCloneThroughRepoQueue(repoUrl: string): Promise<string> {
     const bench = createExecutionBench({
       module: 'repo-pool-bench',
       baseMetadata: { repoUrl },
     });
-    bench('RepoPool.ensureClone.begin');
+    bench('RepoPool.ensureCloneThroughRepoQueue.begin');
     const repoKey = this.repoKey(repoUrl);
     // Join the per-repo git operation chain so fetch/clone cannot race with
     // worktree acquisition, rebase refresh, or branch cleanup against the same
     // shared cache.
     const existing = this.cloneLocks.get(repoKey);
     if (existing) {
-      bench('RepoPool.ensureClone.waitForExistingLock.before');
+      bench('RepoPool.ensureCloneThroughRepoQueue.waitForExistingLock.before');
       const clonePath = await existing;
-      bench('RepoPool.ensureClone.waitForExistingLock.after', { clonePath });
+      bench('RepoPool.ensureCloneThroughRepoQueue.waitForExistingLock.after', { clonePath });
       return clonePath;
     }
 
     const prev = this.repoChains.get(repoKey) ?? Promise.resolve();
     const queuedAtMs = Date.now();
     const promise = prev.then(() => {
-      bench('RepoPool.ensureClone.repoChainWait.after', { durationMs: Date.now() - queuedAtMs });
-      return this.doEnsureClone(repoUrl);
+      bench('RepoPool.ensureCloneThroughRepoQueue.repoChainWait.after', { durationMs: Date.now() - queuedAtMs });
+      return this.ensureCloneUnqueued(repoUrl);
     });
     this.cloneLocks.set(repoKey, promise);
     this.repoChains.set(repoKey, promise.catch(() => {}));
     try {
       const clonePath = await promise;
-      bench('RepoPool.ensureClone.after', { clonePath });
+      bench('RepoPool.ensureCloneThroughRepoQueue.after', { clonePath });
       return clonePath;
     } finally {
       this.cloneLocks.delete(repoKey);
-      bench('RepoPool.ensureClone.lockDeleted');
+      bench('RepoPool.ensureCloneThroughRepoQueue.lockDeleted');
     }
   }
 
@@ -567,53 +567,53 @@ export class RepoPool {
     bench('RepoPool.runPreserveOrResetWithRecovery.retryRunBashLocal.after');
   }
 
-  private async doEnsureClone(repoUrl: string): Promise<string> {
+  private async ensureCloneUnqueued(repoUrl: string): Promise<string> {
     const bench = createExecutionBench({
       module: 'repo-pool-bench',
       baseMetadata: { repoUrl },
     });
     const dir = this.cloneDir(repoUrl);
-    bench('RepoPool.doEnsureClone.begin', { dir, exists: existsSync(dir) });
+    bench('RepoPool.ensureCloneUnqueued.begin', { dir, exists: existsSync(dir) });
     if (existsSync(dir)) {
       if (remoteFetchForPool.enabled) {
         try {
-          bench('RepoPool.doEnsureClone.gitFetchAllPrune.before', { dir });
+          bench('RepoPool.ensureCloneUnqueued.gitFetchAllPrune.before', { dir });
           await this.execGit(['fetch', '--all', '--prune'], dir);
-          bench('RepoPool.doEnsureClone.gitFetchAllPrune.after', { dir });
+          bench('RepoPool.ensureCloneUnqueued.gitFetchAllPrune.after', { dir });
         } catch (err) {
-          console.warn(`[RepoPool] doEnsureClone fetch failed: ${err}`);
-          bench('RepoPool.doEnsureClone.gitFetchAllPrune.failed', {
+          console.warn(`[RepoPool] ensureCloneUnqueued fetch failed: ${err}`);
+          bench('RepoPool.ensureCloneUnqueued.gitFetchAllPrune.failed', {
             dir,
             error: err instanceof Error ? err.message : String(err),
           });
         }
         // Advance local HEAD branch to match origin so rev-parse returns the fresh ref
         try {
-          bench('RepoPool.doEnsureClone.gitCurrentBranch.before', { dir });
+          bench('RepoPool.ensureCloneUnqueued.gitCurrentBranch.before', { dir });
           const branch = (await this.execGit(['rev-parse', '--abbrev-ref', 'HEAD'], dir)).trim();
-          bench('RepoPool.doEnsureClone.gitCurrentBranch.after', { dir, branch });
+          bench('RepoPool.ensureCloneUnqueued.gitCurrentBranch.after', { dir, branch });
           if (branch !== 'HEAD') {
-            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.before', { dir, branch });
+            bench('RepoPool.ensureCloneUnqueued.gitFastForwardCurrentBranch.before', { dir, branch });
             await this.execGit(['merge', '--ff-only', `origin/${branch}`], dir);
-            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.after', { dir, branch });
+            bench('RepoPool.ensureCloneUnqueued.gitFastForwardCurrentBranch.after', { dir, branch });
           } else {
-            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.skipped', { dir, branch });
+            bench('RepoPool.ensureCloneUnqueued.gitFastForwardCurrentBranch.skipped', { dir, branch });
           }
         } catch (err) {
-          bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.failed', {
+          bench('RepoPool.ensureCloneUnqueued.gitFastForwardCurrentBranch.failed', {
             dir,
             error: err instanceof Error ? err.message : String(err),
           });
           /* non-ff or detached; leave as-is */
         }
       }
-      bench('RepoPool.doEnsureClone.returnExisting', { dir });
+      bench('RepoPool.ensureCloneUnqueued.returnExisting', { dir });
       return dir;
     }
     mkdirSync(this.cacheDir, { recursive: true });
-    bench('RepoPool.doEnsureClone.gitClone.before', { dir });
+    bench('RepoPool.ensureCloneUnqueued.gitClone.before', { dir });
     await this.execGit(['clone', repoUrl, dir], this.cacheDir);
-    bench('RepoPool.doEnsureClone.gitClone.after', { dir });
+    bench('RepoPool.ensureCloneUnqueued.gitClone.after', { dir });
     return dir;
   }
 
@@ -687,9 +687,9 @@ export class RepoPool {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree branch=${branch} (bashPreserveOrReset here; BaseExecutor.setupTaskBranch is not used for this path)`,
     );
-    bench('RepoPool.doAcquireWorktree.ensureClone.before');
-    const clonePath = await this.doEnsureClone(repoUrl);
-    bench('RepoPool.doAcquireWorktree.ensureClone.after', { clonePath });
+    bench('RepoPool.doAcquireWorktree.ensureCloneUnqueued.before');
+    const clonePath = await this.ensureCloneUnqueued(repoUrl);
+    bench('RepoPool.doAcquireWorktree.ensureCloneUnqueued.after', { clonePath });
     const repoKey = this.repoKey(repoUrl);
     const active = this.activeWorktrees.get(repoKey) ?? new Set();
     bench('RepoPool.doAcquireWorktree.activeWorktreeCount', { activeCount: active.size, maxWorktrees: this.maxWorktrees });

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -442,8 +442,10 @@ export class RepoPool {
       baseMetadata: { repoUrl },
     });
     bench('RepoPool.ensureClone.begin');
-    // Serialize clone operations per repo to prevent concurrent clone races
     const repoKey = this.repoKey(repoUrl);
+    // Join the per-repo git operation chain so fetch/clone cannot race with
+    // worktree acquisition, rebase refresh, or branch cleanup against the same
+    // shared cache.
     const existing = this.cloneLocks.get(repoKey);
     if (existing) {
       bench('RepoPool.ensureClone.waitForExistingLock.before');
@@ -452,8 +454,14 @@ export class RepoPool {
       return clonePath;
     }
 
-    const promise = this.doEnsureClone(repoUrl);
+    const prev = this.repoChains.get(repoKey) ?? Promise.resolve();
+    const queuedAtMs = Date.now();
+    const promise = prev.then(() => {
+      bench('RepoPool.ensureClone.repoChainWait.after', { durationMs: Date.now() - queuedAtMs });
+      return this.doEnsureClone(repoUrl);
+    });
     this.cloneLocks.set(repoKey, promise);
+    this.repoChains.set(repoKey, promise.catch(() => {}));
     try {
       const clonePath = await promise;
       bench('RepoPool.ensureClone.after', { clonePath });
@@ -680,7 +688,7 @@ export class RepoPool {
       `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree branch=${branch} (bashPreserveOrReset here; BaseExecutor.setupTaskBranch is not used for this path)`,
     );
     bench('RepoPool.doAcquireWorktree.ensureClone.before');
-    const clonePath = await this.ensureClone(repoUrl);
+    const clonePath = await this.doEnsureClone(repoUrl);
     bench('RepoPool.doAcquireWorktree.ensureClone.after', { clonePath });
     const repoKey = this.repoKey(repoUrl);
     const active = this.activeWorktrees.get(repoKey) ?? new Set();

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -178,13 +178,12 @@ const NOOP_LOGGER: Logger = {
  * never depends on the app shell, the app provides this implementation
  * via the LaunchDispatcher.
  *
- * Each method MUST be safe to call even if the dispatch row was reaped
- * between the dispatcher's lease and the runner's call — the
- * persistence layer returns false in that case and the runner bails
- * out without starting the executor.
+ * Each method MUST be safe to call even if the dispatch row was
+ * reaped between the dispatcher's lease and the runner's call — the
+ * persistence layer returns false in that case and the runner treats
+ * it as a benign race.
  */
 export interface LaunchOutboxAck {
-  ackDispatch(dispatchId: number, runnerId: string): boolean;
   completeDispatch(dispatchId: number): boolean;
   failDispatch(dispatchId: number, error: unknown): boolean;
 }
@@ -521,19 +520,6 @@ export class TaskRunner {
       }
       return;
     }
-    if (dispatchOpts) {
-      const accepted = dispatchOpts.launchOutbox.ackDispatch(
-        dispatchOpts.dispatchId,
-        this.runnerInstanceId,
-      );
-      if (!accepted) {
-        this.logger.warn(
-          `[TaskRunner] launch dispatch ack rejected (lease reaped?) for task=${task.id} attempt=${attemptId} dispatchId=${dispatchOpts.dispatchId}`,
-        );
-        bench('executeTask.dispatchAckRejected');
-        return;
-      }
-    }
     this.logger.info(
       `[TaskRunner] launch accepted task=${task.id} attempt=${attemptId} status=${task.status} ` +
         `phase=${task.execution.phase ?? 'none'} generation=${startGeneration} ` +
@@ -667,11 +653,10 @@ export class TaskRunner {
       // CD.1 / Issue 13: terminate the parent pivot task's outbox row.
       // Without this, drainScheduler enqueued a launch-dispatch row for
       // the pivot, but executeTaskInner returns here without ever
-      // calling completeDispatch — so the row stays acknowledged,
-      // gets reaped after DISPATCH_LEASE_MS, and is eventually
-      // abandoned. The spawn_experiments path is the terminal state
-      // for the pivot itself; only the spawned variants should
-      // continue through the outbox.
+      // calling completeDispatch, so the row stays leased and is retried
+      // or abandoned. The spawn_experiments path is the terminal state
+      // for the pivot itself; only the spawned variants should continue
+      // through the outbox.
       if (dispatchOpts) {
         try {
           dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId);
@@ -996,6 +981,12 @@ export class TaskRunner {
       this.releasePoolSelectionLease(this.pendingPoolSelections.get(task.id));
       this.pendingPoolSelections.delete(task.id);
       await this.cleanupPerTaskDockerExecutor(task);
+      if (dispatchOpts) {
+        dispatchOpts.launchOutbox.failDispatch(
+          dispatchOpts.dispatchId,
+          new Error('Launch rejected as stale or non-executable after executor start'),
+        );
+      }
       bench('markTaskRunningAfterLaunch.rejected');
       return;
     }

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -323,7 +323,7 @@ export class TaskRunner {
     const executor = this.executorRegistry.get('worktree');
     if (!(executor instanceof WorktreeExecutor)) return undefined;
     try {
-      return await executor.getRepoPool().ensureClone(trimmed);
+      return await executor.getRepoPool().ensureCloneThroughRepoQueue(trimmed);
     } catch (err) {
       this.logger.warn(`[merge] ensureRepoMirrorPath failed for ${trimmed}`, { err });
       return undefined;

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -62,7 +62,7 @@ import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutati
 
 export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-callbacks.js';
 
-/** Keeps `lastHeartbeatAt` fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). Matches BaseExecutor default heartbeat cadence. */
+/** Keeps launch metadata fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). */
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_EXECUTOR_START_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -842,6 +842,13 @@ export class TaskRunner {
         `[TaskRunner] executor.start begin task=${task.id} attempt=${attemptId} executor=${executor.type} ` +
           `generation=${task.execution.generation ?? 0}`,
       );
+      this.persistence.logEvent?.(task.id, 'task.executor.start_begin', {
+        dispatchId: dispatchOpts?.dispatchId,
+        attemptId,
+        executorType: executor.type,
+        poolId: poolSelectionForStart?.poolId,
+        poolMemberId: poolSelectionForStart?.member.id,
+      });
       bench('onLaunchStart.before', {
         executorType: executor.type,
       });

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -153,9 +153,9 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     const t0 = Date.now();
     const log = (step: string) => traceExecution(`[WorktreeExecutor] start task=${request.actionId} step=${step} elapsed=${Date.now() - t0}ms`);
 
-    bench('RepoPool.ensureClone.before');
-    const clonePath = await this.pool.ensureClone(repoUrl);
-    bench('RepoPool.ensureClone.after', { clonePath });
+    bench('RepoPool.ensureCloneThroughRepoQueue.before');
+    const clonePath = await this.pool.ensureCloneThroughRepoQueue(repoUrl);
+    bench('RepoPool.ensureCloneThroughRepoQueue.after', { clonePath });
     const baseRef = request.inputs.baseBranch ?? 'HEAD';
     const runGit = (args: string[]) => this.execGitSimple(args, clonePath);
     let baseHead = request.inputs.baseCommit?.trim();

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -22,7 +22,7 @@ interface LaunchDispatchRow {
   taskId: string;
   attemptId: string;
   workflowId: string;
-  state: 'enqueued' | 'leased' | 'acknowledged' | 'completed' | 'abandoned';
+  state: 'enqueued' | 'leased' | 'completed' | 'abandoned';
   priority: 'high' | 'normal' | 'low';
   generation: number;
 }
@@ -118,12 +118,12 @@ class InMemoryPersistence implements OrchestratorPersistence {
     workflowId: string;
     priority?: 'high' | 'normal' | 'low';
     generation: number;
-  }): { id: number } {
+  }): { id: number; state: LaunchDispatchRow['state']; priority: LaunchDispatchRow['priority'] } {
     if (!this.enqueueLaunchDispatchEnabled) {
       throw new Error('enqueueLaunchDispatch called when not enabled');
     }
     const existing = this.launchDispatchRows.find((row) => row.attemptId === input.attemptId);
-    if (existing) return { id: existing.id };
+    if (existing) return { id: existing.id, state: existing.state, priority: existing.priority };
     const row: LaunchDispatchRow = {
       id: this.nextDispatchId++,
       taskId: input.taskId,
@@ -134,7 +134,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
       generation: input.generation,
     };
     this.launchDispatchRows.push(row);
-    return { id: row.id };
+    return { id: row.id, state: row.state, priority: row.priority };
   }
 
   abandonLaunchDispatchesForTasks(
@@ -146,7 +146,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
     const rows = this.launchDispatchRows.filter(
       (row) =>
         taskSet.has(row.taskId) &&
-        (row.state === 'enqueued' || row.state === 'leased' || row.state === 'acknowledged'),
+        (row.state === 'enqueued' || row.state === 'leased'),
     );
     const invalidated = rows.map((row) => ({
       id: row.id,

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2925,6 +2925,53 @@ describe('Orchestrator', () => {
       expect(resumePersistence.loadAttempt(oldAttempt.id)?.status).toBe('superseded');
       expect(resumePersistence.loadAttempt(newAttemptId!)?.status).toBe('running');
     });
+
+    it('recovers normalized stale pending tasks that still carry selected-attempt runtime state', () => {
+      const resumePersistence = new InMemoryPersistence();
+      const oldAttempt: Attempt = {
+        id: 't1-aold',
+        nodeId: 't1',
+        queuePriority: 0,
+        status: 'pending',
+        upstreamAttemptIds: [],
+        createdAt: new Date('2025-01-01T00:00:00.000Z'),
+      };
+      resumePersistence.saveTask('wf-resume', {
+        id: 't1',
+        description: 'Pending task with stale launch metadata',
+        status: 'pending',
+        dependencies: [],
+        createdAt: new Date(),
+        config: {},
+        execution: {
+          startedAt: new Date('2025-01-01T00:00:00.000Z'),
+          selectedAttemptId: oldAttempt.id,
+          workspacePath: '/tmp/stale-workspace',
+          agentSessionId: 'stale-session',
+          error: 'stale launch error',
+        },
+      });
+      resumePersistence.saveAttempt(oldAttempt);
+
+      const resumeOrchestrator = new Orchestrator({
+        persistence: resumePersistence,
+        messageBus: bus,
+        maxConcurrency: 3,
+      });
+
+      const started = resumeOrchestrator.resumeWorkflow('wf-resume');
+
+      expect(started).toHaveLength(1);
+      const resumed = resumeOrchestrator.getTask('t1')!;
+      expect(resumed.status).toBe('running');
+      expect(resumed.execution.selectedAttemptId).toBeTruthy();
+      expect(resumed.execution.selectedAttemptId).not.toBe(oldAttempt.id);
+      expect(resumed.execution.workspacePath).toBeUndefined();
+      expect(resumed.execution.agentSessionId).toBeUndefined();
+      expect(resumed.execution.error).toBeUndefined();
+      expect(resumePersistence.loadAttempt(oldAttempt.id)?.status).toBe('superseded');
+      expect(resumePersistence.loadAttempt(resumed.execution.selectedAttemptId!)?.status).toBe('running');
+    });
   });
 
   describe('prepareTaskForNewAttempt', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -265,7 +265,11 @@ export interface OrchestratorPersistence {
     workflowId: string;
     priority?: 'high' | 'normal' | 'low';
     generation: number;
-  }): { id: number };
+  }): {
+    id: number;
+    state?: 'enqueued' | 'leased' | 'completed' | 'abandoned';
+    priority?: 'high' | 'normal' | 'low';
+  };
   abandonLaunchDispatchesForTasks?(
     taskIds: readonly string[],
     reason: string,
@@ -3830,20 +3834,33 @@ export class Orchestrator {
    * Resume a previously persisted workflow by restoring tasks
    * and auto-starting ready tasks.
    */
+  private isRecoverableResumeTask(task: TaskState): boolean {
+    if (task.status === 'running') return true;
+    if (task.status !== 'pending' || !task.execution.selectedAttemptId) return false;
+    if (task.execution.phase === 'launching') return true;
+
+    return Boolean(
+      task.execution.startedAt
+      || task.execution.launchStartedAt
+      || task.execution.launchCompletedAt
+      || task.execution.lastHeartbeatAt
+      || task.execution.workspacePath
+      || task.execution.agentSessionId
+      || task.execution.containerId
+      || task.execution.error
+      || task.execution.exitCode !== undefined
+      || task.execution.inputPrompt
+      || task.execution.pendingFixError,
+    );
+  }
+
   resumeWorkflow(workflowId: string): TaskState[] {
     this.syncFromDb(workflowId);
     const workflowTaskIds = new Set(this.persistence.loadTasks(workflowId).map((task) => task.id));
     const tasksToRecover = this.stateMachine
       .getAllTasks()
       .filter((task) => task.config.workflowId === workflowId || workflowTaskIds.has(task.id))
-      .filter((task) =>
-        task.status === 'running'
-        || (
-          task.status === 'pending'
-          && task.execution.phase === 'launching'
-          && !!task.execution.selectedAttemptId
-        )
-      );
+      .filter((task) => this.isRecoverableResumeTask(task));
     for (const task of tasksToRecover) {
       this.prepareTaskForNewAttempt(task.id, 'resume_workflow_recovery');
     }
@@ -5288,6 +5305,20 @@ export class Orchestrator {
           this.persistence.logEvent?.(job.taskId, 'task.dispatch_enqueued', {
             ...changes,
             dispatchId: dispatch.id,
+            attemptId: launchAttemptId,
+            workflowId: task.config.workflowId,
+            generation: this.getExecutionGeneration(task),
+            state: dispatch.state,
+            priority: dispatch.priority,
+          });
+          this.logger.info('[orchestrator] drainScheduler: launch dispatch enqueued', {
+            taskId: job.taskId,
+            attemptId: launchAttemptId,
+            workflowId: task.config.workflowId,
+            generation: this.getExecutionGeneration(task),
+            dispatchId: dispatch.id,
+            state: dispatch.state,
+            priority: dispatch.priority,
           });
         } catch (err) {
           this.logger.warn('[orchestrator] drainScheduler: enqueueLaunchDispatch failed', {

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -97,18 +97,35 @@ invoker_e2e_init() {
   invoker_e2e_ensure_branch_aliases
 }
 
+invoker_e2e_pid_cmdline() {
+  local pid="$1"
+  if [ -r "/proc/$pid/cmdline" ]; then
+    tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true
+    return 0
+  fi
+  ps -p "$pid" -o command= 2>/dev/null || true
+}
+
+invoker_e2e_pid_has_env() {
+  local pid="$1" key="$2" value="$3"
+  if [ -r "/proc/$pid/environ" ]; then
+    tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep -Fqx "$key=$value"
+    return $?
+  fi
+  # macOS has no /proc/<pid>/environ; `ps eww` appends the environment to the
+  # command line, which is enough for exact e2e temp paths and port values.
+  ps eww -p "$pid" -o command= 2>/dev/null | grep -Fq "$key=$value"
+}
+
 invoker_e2e_kill_owned_headless_processes() {
   # Kill only the headless processes that belong to this test run.
   # Scope by this case's INVOKER_DB_DIR/INVOKER_API_PORT so one case's EXIT trap
   # cannot SIGTERM another concurrently-running case.
   if [ -n "${INVOKER_DB_DIR:-}" ] || [ -n "${INVOKER_API_PORT:-}" ]; then
-    local pid environ_blob cmdline
+    local pid cmdline
     while IFS= read -r pid; do
       [ -n "$pid" ] || continue
-      [ -r "/proc/$pid/environ" ] || continue
-      [ -r "/proc/$pid/cmdline" ] || continue
-      environ_blob="$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null || true)"
-      cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
+      cmdline="$(invoker_e2e_pid_cmdline "$pid")"
       case "$cmdline" in
         *"--headless"*)
           ;;
@@ -116,12 +133,13 @@ invoker_e2e_kill_owned_headless_processes() {
           continue
           ;;
       esac
-      if [ -n "${INVOKER_DB_DIR:-}" ] && ! printf '%s\n' "$environ_blob" | grep -Fqx "INVOKER_DB_DIR=$INVOKER_DB_DIR"; then
-        if [ -n "${INVOKER_API_PORT:-}" ] && ! printf '%s\n' "$environ_blob" | grep -Fqx "INVOKER_API_PORT=$INVOKER_API_PORT"; then
-          continue
-        fi
+      if [ -n "${INVOKER_DB_DIR:-}" ] && invoker_e2e_pid_has_env "$pid" "INVOKER_DB_DIR" "$INVOKER_DB_DIR"; then
+        kill "$pid" 2>/dev/null || true
+        continue
       fi
-      kill "$pid" 2>/dev/null || true
+      if [ -n "${INVOKER_API_PORT:-}" ] && invoker_e2e_pid_has_env "$pid" "INVOKER_API_PORT" "$INVOKER_API_PORT"; then
+        kill "$pid" 2>/dev/null || true
+      fi
     done < <(pgrep -f '(/electron|packages/app/dist/main.js|headless-client.js|run.sh --headless)' 2>/dev/null || true)
   fi
 }
@@ -440,17 +458,14 @@ invoker_e2e_wait_workflow_visible() {
 
 invoker_e2e_count_owned_headless_processes() {
   local count=0
-  local pid environ_blob cmdline
+  local pid cmdline
   if [ -z "${INVOKER_DB_DIR:-}" ] && [ -z "${INVOKER_API_PORT:-}" ]; then
     printf '0'
     return 0
   fi
   while IFS= read -r pid; do
     [ -n "$pid" ] || continue
-    [ -r "/proc/$pid/environ" ] || continue
-    [ -r "/proc/$pid/cmdline" ] || continue
-    environ_blob="$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null || true)"
-    cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
+    cmdline="$(invoker_e2e_pid_cmdline "$pid")"
     case "$cmdline" in
       *"--headless"*)
         ;;
@@ -458,12 +473,14 @@ invoker_e2e_count_owned_headless_processes() {
         continue
         ;;
     esac
-    if [ -n "${INVOKER_DB_DIR:-}" ] && ! printf '%s\n' "$environ_blob" | grep -Fqx "INVOKER_DB_DIR=$INVOKER_DB_DIR"; then
-      if [ -n "${INVOKER_API_PORT:-}" ] && ! printf '%s\n' "$environ_blob" | grep -Fqx "INVOKER_API_PORT=$INVOKER_API_PORT"; then
-        continue
-      fi
+    if [ -n "${INVOKER_DB_DIR:-}" ] && invoker_e2e_pid_has_env "$pid" "INVOKER_DB_DIR" "$INVOKER_DB_DIR"; then
+      count=$((count + 1))
+      continue
     fi
-    count=$((count + 1))
+    if [ -n "${INVOKER_API_PORT:-}" ] && invoker_e2e_pid_has_env "$pid" "INVOKER_API_PORT" "$INVOKER_API_PORT"; then
+      count=$((count + 1))
+      continue
+    fi
   done < <(pgrep -f '(/electron|packages/app/dist/main.js|headless-client.js|run.sh --headless)' 2>/dev/null || true)
   printf '%s' "$count"
 }

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -385,7 +385,10 @@ PY
 # Usage: ST=$(invoker_e2e_task_status <taskId>)
 invoker_e2e_task_status() {
   local task_id="$1"
-  invoker_e2e_run_headless task-status "$task_id" 2>/dev/null | tail -1
+  invoker_e2e_run_headless task-status "$task_id" 2>/dev/null \
+    | sed 's/\x1b\[[0-9;]*m//g' \
+    | grep -E '^(pending|running|completed|failed|awaiting_approval|review_ready|fixing_with_ai|closed|skipped)$' \
+    | tail -1
 }
 
 # Poll until task status equals expected (1s interval). Use after cancel/restart

--- a/scripts/electron.cjs
+++ b/scripts/electron.cjs
@@ -202,6 +202,23 @@ function withLinuxSandboxFallback(binaryPath, args) {
   return ['--no-sandbox', ...args];
 }
 
+function withMacOSPersistenceIgnoreState(args) {
+  if (process.platform !== 'darwin') {
+    return args;
+  }
+  if (args.includes('-ApplePersistenceIgnoreState')) {
+    return args;
+  }
+
+  // AppKit can show a blocking "reopen windows?" crash-recovery modal before
+  // Electron runs our JS, which also stalls headless CLI invocations.
+  //
+  // Keep Electron's app path as argv[1]; putting this flag before the script
+  // prevents Electron from loading dist/main.js.
+  const insertAt = args.length > 0 ? 1 : 0;
+  return [...args.slice(0, insertAt), '-ApplePersistenceIgnoreState', 'YES', ...args.slice(insertAt)];
+}
+
 async function main() {
   const args = process.argv.slice(2);
 
@@ -216,7 +233,7 @@ async function main() {
     return;
   }
 
-  const launchArgs = withLinuxSandboxFallback(binaryPath, args);
+  const launchArgs = withMacOSPersistenceIgnoreState(withLinuxSandboxFallback(binaryPath, args));
   const child = spawn(binaryPath, launchArgs, {
     cwd: process.cwd(),
     env: process.env,

--- a/scripts/repro-docker-spawnsync-hang.js
+++ b/scripts/repro-docker-spawnsync-hang.js
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+/**
+ * Repro: does `spawnSync('docker', ['--version'])` actually hang on this
+ * machine?
+ *
+ * Mirrors what `packages/app/src/system-diagnostics.ts` does, with extra
+ * timing so we can see if/where it blocks. Exits with code 0 if docker
+ * responds in under 5s; exits with code 2 if it hangs past 5s.
+ */
+const { spawnSync } = require('node:child_process');
+
+const command = process.argv[2] || 'docker';
+const args = process.argv.slice(3);
+if (args.length === 0) args.push('--version');
+
+console.log(`[repro] PID=${process.pid} spawning: ${command} ${args.join(' ')} (no timeout)`);
+const started = Date.now();
+
+// Watchdog: independent timer prints elapsed every second so we can see
+// the spawnSync is actually blocking the event loop.
+const watchdog = setInterval(() => {
+  process.stderr.write(`[repro] still spawning after ${Date.now() - started}ms\n`);
+  if (Date.now() - started > 5000) {
+    process.stderr.write('[repro] >5s elapsed — assuming HANG, exiting 2\n');
+    // We have to exit hard because the main thread is in spawnSync;
+    // setInterval can't actually fire while spawnSync blocks the event loop.
+    process.exit(2);
+  }
+}, 1000);
+watchdog.unref?.();
+
+const result = spawnSync(command, args, { encoding: 'utf8' });
+const elapsed = Date.now() - started;
+clearInterval(watchdog);
+
+if (result.error) {
+  console.error(`[repro] error after ${elapsed}ms:`, result.error);
+  process.exit(3);
+}
+console.log(`[repro] returned in ${elapsed}ms status=${result.status} signal=${result.signal}`);
+console.log(`[repro] stdout: ${(result.stdout || '').trim()}`);
+console.log(`[repro] stderr: ${(result.stderr || '').trim()}`);
+process.exit(0);

--- a/scripts/repro/compiled-workspace-loader.mjs
+++ b/scripts/repro/compiled-workspace-loader.mjs
@@ -1,0 +1,22 @@
+import { dirname, join, resolve as resolvePath } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolvePath(__dirname, '../..');
+
+const redirects = new Map([
+  ['@invoker/workflow-graph', join(root, 'packages/workflow-graph/dist/index.js')],
+  ['@invoker/contracts', join(root, 'packages/contracts/dist/index.js')],
+  ['@invoker/workflow-core', join(root, 'packages/workflow-core/dist/index.js')],
+]);
+
+export async function resolve(specifier, context, nextResolve) {
+  const redirected = redirects.get(specifier);
+  if (redirected) {
+    return {
+      url: pathToFileURL(redirected).href,
+      shortCircuit: true,
+    };
+  }
+  return nextResolve(specifier, context);
+}

--- a/scripts/repro/repro-daemon-clear-does-not-rehydrate.sh
+++ b/scripts/repro/repro-daemon-clear-does-not-rehydrate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Repro: GUI clear in daemon-owner mode must purge durable workflow state.
+#
+# Root cause guarded here:
+#   `invoker:clear` used to reset only the in-memory DAG. With GUI daemon-owner
+#   reads, the next snapshot could rehydrate tasks from SQLite, so the UI still
+#   saw old tasks after clear.
+#
+# Fixed behavior:
+#   `window.invoker.clear()` leaves the task list empty in the renderer.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/ui build
+pnpm --filter @invoker/app build
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec pnpm --filter @invoker/app exec xvfb-run --auto-servernum playwright test \
+    e2e/workflow-lifecycle.spec.ts \
+    -g 'clear resets task state via IPC'
+fi
+
+exec pnpm --filter @invoker/app exec playwright test \
+  e2e/workflow-lifecycle.spec.ts \
+  -g 'clear resets task state via IPC'

--- a/scripts/repro/repro-daemon-owner-routing.sh
+++ b/scripts/repro/repro-daemon-owner-routing.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: GUI/headless mutations must route through one standalone daemon owner.
+#
+# Root cause guarded here:
+#   A GUI process that opens the SQLite DB as the mutation owner can race with
+#   headless submitters and other GUI instances. In daemon-owner mode the GUI
+#   must become a read-only client and delegate write IPC to the shared owner.
+#
+# Fixed behavior:
+#   The owner bootstrap/thundering-herd e2e proves peer clients converge on one
+#   standalone-capable owner instead of stealing the IPC socket or DB writer.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/app build
+exec scripts/repro/repro-headless-thundering-herd.sh

--- a/scripts/repro/repro-launch-claim-orphan.sh
+++ b/scripts/repro/repro-launch-claim-orphan.sh
@@ -14,9 +14,9 @@ set -euo pipefail
 # invariant is:
 #
 #   Every `task.launch_claimed` event must be followed within
-#   `2 * DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS` (180 seconds with
-#   the defaults from packages/contracts) by a terminal launch event for
-#   the same `attempt_id`. Terminal launch events are:
+#   `DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30s` (2190 seconds with
+#   the defaults from packages/contracts) by a terminal launch event for the
+#   same `attempt_id`. Terminal launch events are:
 #
 #     - task.executor.selected
 #     - task.executor.deferred
@@ -31,9 +31,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 EXPECTATION=""
 TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-900}"
-# DISPATCH_LEASE_MS = 30000, DISPATCH_MAX_ATTEMPTS = 3 → 180 seconds.
+# DISPATCH_LEASE_MS = 720000, DISPATCH_MAX_ATTEMPTS = 3, buffer = 30s → 2190 seconds.
 # Override via env if the contracts module bumps these defaults.
-WAIT_BOUND_SECONDS="${REPRO_LAUNCH_INVARIANT_BOUND_SECONDS:-180}"
+WAIT_BOUND_SECONDS="${REPRO_LAUNCH_INVARIANT_BOUND_SECONDS:-2190}"
 
 usage() {
   cat <<'EOF'
@@ -45,7 +45,7 @@ What it proves:
   Every `task.launch_claimed` event recorded during a storm of
   workflow-scope rebase-recreate mutations is paired with a terminal
   launch event for the SAME attempt_id within the dispatch invariant
-  bound (default 2 * DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS = 180s).
+  bound (default DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30s = 2190s).
 
   Any claim without a matching terminal event is an orphaned launch —
   the exact failure mode the launch-handoff re-architecture was built
@@ -53,7 +53,7 @@ What it proves:
 
 Environment:
   REPRO_TIMEOUT_SECONDS                 storm timeout (default 900)
-  REPRO_LAUNCH_INVARIANT_BOUND_SECONDS  invariant bound (default 180)
+  REPRO_LAUNCH_INVARIANT_BOUND_SECONDS  invariant bound (default 2190)
   INVOKER_DB_PATH / INVOKER_DB_DIR      same as other repro scripts
 EOF
 }

--- a/scripts/repro/repro-launch-dispatch-queue-handoff.mjs
+++ b/scripts/repro/repro-launch-dispatch-queue-handoff.mjs
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const root = resolve(__dirname, '../..');
+const distPath = join(root, 'packages/data-store/dist/index.js');
+const { SQLiteAdapter } = await import(pathToFileURL(distPath).href);
+
+const tempDir = mkdtempSync(join(tmpdir(), 'invoker-launch-dispatch-repro-'));
+const dbPath = join(tempDir, 'invoker.db');
+const workflowId = 'wf-launch-dispatch-repro';
+const nowIso = '2026-06-04T00:00:00.000Z';
+const expiredIso = '2026-06-03T23:59:00.000Z';
+const targetTaskId = `${workflowId}/target`;
+const targetAttemptId = `${targetTaskId}-attempt`;
+
+let adapter;
+
+function fail(message) {
+  throw new Error(`[launch-dispatch-repro] ${message}`);
+}
+
+function makeTask(id, attemptId, status = 'pending', generation = 0) {
+  return {
+    id,
+    description: id,
+    status,
+    dependencies: [],
+    createdAt: new Date(nowIso),
+    config: { workflowId },
+    execution: { selectedAttemptId: attemptId, generation, phase: 'launching' },
+    taskStateVersion: 1,
+  };
+}
+
+function saveTask(id, attemptId, status = 'pending', generation = 0) {
+  adapter.saveTask(workflowId, makeTask(id, attemptId, status, generation));
+  adapter.updateTask(id, {
+    status,
+    execution: { selectedAttemptId: attemptId, generation, phase: 'launching' },
+  });
+}
+
+function scalar(sql) {
+  const result = adapter.db.exec(sql);
+  return Number(result[0]?.values?.[0]?.[0] ?? 0);
+}
+
+try {
+  adapter = await SQLiteAdapter.create(dbPath, { ownerCapability: true });
+  adapter.saveWorkflow({
+    id: workflowId,
+    name: 'launch dispatch queue handoff repro',
+    createdAt: nowIso,
+    updatedAt: nowIso,
+  });
+
+  for (let i = 0; i < 12; i += 1) {
+    const taskId = `${workflowId}/legacy-${i}`;
+    const currentAttemptId = `${taskId}-current`;
+    const staleAttemptId = `${taskId}-stale`;
+    saveTask(taskId, currentAttemptId, 'pending', 1);
+    const row = adapter.enqueueLaunchDispatch({
+      taskId,
+      attemptId: staleAttemptId,
+      workflowId,
+      generation: 0,
+    });
+    adapter.db.run(
+      `UPDATE task_launch_dispatch
+          SET state = 'acknowledged',
+              dispatch_owner = 'old-owner',
+              leased_at = ?,
+              acknowledged_at = ?,
+              fenced_until = ?,
+              attempts_count = 1
+        WHERE id = ?`,
+      [expiredIso, expiredIso, expiredIso, row.id],
+    );
+  }
+
+  saveTask(targetTaskId, targetAttemptId, 'pending', 0);
+  const target = adapter.enqueueLaunchDispatch({
+    taskId: targetTaskId,
+    attemptId: targetAttemptId,
+    workflowId,
+    generation: 0,
+  });
+
+  const report = adapter.runCompatibilityMigration();
+  const legacyAckCount = scalar(
+    `SELECT COUNT(*) AS count FROM task_launch_dispatch WHERE state = 'acknowledged'`,
+  );
+  if (legacyAckCount !== 0) {
+    fail(
+      `compatibility migration left ${legacyAckCount} acknowledged row(s); ` +
+        `report=${JSON.stringify(report)}`,
+    );
+  }
+
+  const targetAfterMigration = adapter.loadLaunchDispatchById(target.id);
+  if (targetAfterMigration?.state !== 'enqueued') {
+    fail(`target dispatch should remain enqueued, got ${targetAfterMigration?.state ?? 'missing'}`);
+  }
+
+  const leased = adapter.claimLaunchDispatchAtomic({
+    ownerId: 'repro-owner',
+    nowIso,
+  });
+  if (!leased) {
+    fail('claimLaunchDispatchAtomic returned undefined while target row was enqueued');
+  }
+  if (leased.id !== target.id) {
+    fail(`expected to lease target dispatch ${target.id}, leased ${leased.id}`);
+  }
+  if (leased.state !== 'leased') {
+    fail(`expected leased target state, got ${leased.state}`);
+  }
+
+  const abandonedLegacyCount = scalar(
+    `SELECT COUNT(*) AS count FROM task_launch_dispatch WHERE state = 'abandoned'`,
+  );
+  if (abandonedLegacyCount !== 12) {
+    fail(`expected 12 abandoned legacy rows, got ${abandonedLegacyCount}`);
+  }
+
+  console.log('[launch-dispatch-repro] passed');
+} finally {
+  adapter?.close();
+  rmSync(tempDir, { recursive: true, force: true });
+}

--- a/scripts/repro/repro-no-track-exec-queue-classifier.sh
+++ b/scripts/repro/repro-no-track-exec-queue-classifier.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+EXPECTATION="fixed"
+KEEP_TEMP=false
+
+for arg in "$@"; do
+  case "$arg" in
+    --expect-bug) EXPECTATION="bug" ;;
+    --expect-fixed) EXPECTATION="fixed" ;;
+    --keep-temp) KEEP_TEMP=true ;;
+    *)
+      echo "usage: $0 [--expect-bug|--expect-fixed] [--keep-temp]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+TMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-no-track-classifier.XXXXXX")"
+HOME_DIR="$TMP_DIR/home"
+DB_DIR="$HOME_DIR/.invoker"
+IPC_SOCKET="$TMP_DIR/ipc.sock"
+PLAN_PATH="$TMP_DIR/repro-plan.yaml"
+REPO_FIXTURE_DIR="$TMP_DIR/repro-repo"
+SEED_STDOUT="$TMP_DIR/seed.stdout.log"
+SEED_STDERR="$TMP_DIR/seed.stderr.log"
+OWNER_STDOUT="$TMP_DIR/owner.stdout.log"
+OWNER_STDERR="$TMP_DIR/owner.stderr.log"
+RETRY_STDOUT="$TMP_DIR/retry-task.stdout.log"
+RETRY_STDERR="$TMP_DIR/retry-task.stderr.log"
+RESUME_STDOUT="$TMP_DIR/resume.stdout.log"
+RESUME_STDERR="$TMP_DIR/resume.stderr.log"
+SET_EXECUTOR_STDOUT="$TMP_DIR/set-executor.stdout.log"
+SET_EXECUTOR_STDERR="$TMP_DIR/set-executor.stderr.log"
+
+cleanup() {
+  if [[ -n "${OWNER_PID:-}" ]]; then
+    kill "$OWNER_PID" >/dev/null 2>&1 || true
+    wait "$OWNER_PID" >/dev/null 2>&1 || true
+  fi
+  if [[ "$KEEP_TEMP" != true ]]; then
+    rm -rf "$TMP_DIR" >/dev/null 2>&1 || true
+  fi
+}
+trap cleanup EXIT
+
+wait_for_owner_ready() {
+  local started_at
+  started_at="$(date +%s)"
+  while true; do
+    if grep -q 'owner-ipc-ready' "$DB_DIR/invoker.log" 2>/dev/null; then
+      return 0
+    fi
+    if (( $(date +%s) - started_at >= 30 )); then
+      echo "repro: timed out waiting for local owner IPC readiness" >&2
+      cat "$OWNER_STDERR" >&2 || true
+      exit 1
+    fi
+    sleep 0.1
+  done
+}
+
+run_no_track_exec() {
+  local stdout_file="$1"
+  local stderr_file="$2"
+  shift 2
+
+  set +e
+  HOME="$HOME_DIR" \
+    INVOKER_DB_DIR="$DB_DIR" \
+    INVOKER_IPC_SOCKET="$IPC_SOCKET" \
+    node "$ROOT_DIR/scripts/headless-ipc.js" exec --no-track -- "$@" \
+    >"$stdout_file" 2>"$stderr_file"
+  local status=$?
+  set -e
+  return "$status"
+}
+
+assert_bug_result() {
+  local label="$1"
+  local status="$2"
+  local stdout_file="$3"
+  local stderr_file="$4"
+
+  if [[ "$status" -eq 0 ]]; then
+    echo "repro: expected $label to fail before fix, but it succeeded" >&2
+    cat "$stdout_file" >&2 || true
+    exit 1
+  fi
+  if ! grep -q 'workflow-not-resolved' "$stderr_file"; then
+    echo "repro: expected $label to fail with workflow-not-resolved" >&2
+    echo "stdout:" >&2
+    cat "$stdout_file" >&2 || true
+    echo "stderr:" >&2
+    cat "$stderr_file" >&2 || true
+    exit 1
+  fi
+}
+
+assert_fixed_result() {
+  local label="$1"
+  local status="$2"
+  local stdout_file="$3"
+  local stderr_file="$4"
+
+  if [[ "$status" -ne 0 ]]; then
+    echo "repro: expected $label to queue after fix, but it failed" >&2
+    echo "stdout:" >&2
+    cat "$stdout_file" >&2 || true
+    echo "stderr:" >&2
+    cat "$stderr_file" >&2 || true
+    exit 1
+  fi
+  if ! grep -q '"ok":true' "$stdout_file" || ! grep -q '"intentId"' "$stdout_file"; then
+    echo "repro: expected $label to return a queued intent acknowledgement" >&2
+    cat "$stdout_file" >&2 || true
+    exit 1
+  fi
+}
+
+mkdir -p "$DB_DIR"
+
+pushd "$ROOT_DIR" >/dev/null
+
+if [[ ! -f packages/app/dist/main.js || ! -f packages/transport/dist/index.js ]]; then
+  pnpm --filter @invoker/app build >/dev/null
+fi
+
+git -C "$TMP_DIR" init -b main repro-repo >/dev/null 2>&1
+git -C "$REPO_FIXTURE_DIR" config user.name "Invoker Repro"
+git -C "$REPO_FIXTURE_DIR" config user.email "repro@example.com"
+printf 'no-track classifier repro fixture\n' > "$REPO_FIXTURE_DIR/README.md"
+git -C "$REPO_FIXTURE_DIR" add README.md
+git -C "$REPO_FIXTURE_DIR" commit -m "Initial fixture" >/dev/null 2>&1
+
+cat > "$PLAN_PATH" <<EOF
+name: No Track Queue Classifier Repro
+repoUrl: $REPO_FIXTURE_DIR
+tasks:
+  - id: task-1
+    description: Repro task used only to satisfy workflow queue foreign keys
+    command: >-
+      bash -lc 'exit 0'
+EOF
+
+HOME="$HOME_DIR" \
+  INVOKER_DB_DIR="$DB_DIR" \
+  INVOKER_HEADLESS_STANDALONE=1 \
+  NODE_ENV=test \
+  "$ROOT_DIR/scripts/electron.cjs" "$ROOT_DIR/packages/app/dist/main.js" --headless --no-track run "$PLAN_PATH" \
+  >"$SEED_STDOUT" 2>"$SEED_STDERR"
+
+WORKFLOW_ID="$(sed -n 's/^Workflow ID: //p' "$SEED_STDOUT" | head -n1)"
+if [[ -z "$WORKFLOW_ID" ]]; then
+  echo "repro: failed to seed workflow id" >&2
+  cat "$SEED_STDOUT" >&2 || true
+  cat "$SEED_STDERR" >&2 || true
+  exit 1
+fi
+
+for _ in {1..100}; do
+  if [[ ! -f "$DB_DIR/invoker.db.lock/pid" ]]; then
+    break
+  fi
+  LOCK_PID="$(cat "$DB_DIR/invoker.db.lock/pid" 2>/dev/null || true)"
+  if [[ -z "$LOCK_PID" ]] || ! kill -0 "$LOCK_PID" >/dev/null 2>&1; then
+    rm -rf "$DB_DIR/invoker.db.lock"
+    break
+  fi
+  sleep 0.1
+done
+
+HOME="$HOME_DIR" \
+  INVOKER_DB_DIR="$DB_DIR" \
+  INVOKER_IPC_SOCKET="$IPC_SOCKET" \
+  NODE_ENV=test \
+  "$ROOT_DIR/scripts/electron.cjs" "$ROOT_DIR/packages/app/dist/main.js" \
+  >"$OWNER_STDOUT" 2>"$OWNER_STDERR" &
+OWNER_PID=$!
+
+wait_for_owner_ready
+
+retry_status=0
+run_no_track_exec "$RETRY_STDOUT" "$RETRY_STDERR" retry-task "$WORKFLOW_ID/task-1" || retry_status=$?
+
+resume_status=0
+run_no_track_exec "$RESUME_STDOUT" "$RESUME_STDERR" resume "$WORKFLOW_ID" || resume_status=$?
+
+set_executor_status=0
+run_no_track_exec "$SET_EXECUTOR_STDOUT" "$SET_EXECUTOR_STDERR" set executor "$WORKFLOW_ID/task-1" worktree || set_executor_status=$?
+
+if [[ "$EXPECTATION" == "bug" ]]; then
+  assert_bug_result "retry-task" "$retry_status" "$RETRY_STDOUT" "$RETRY_STDERR"
+  assert_bug_result "resume" "$resume_status" "$RESUME_STDOUT" "$RESUME_STDERR"
+  assert_bug_result "set executor" "$set_executor_status" "$SET_EXECUTOR_STDOUT" "$SET_EXECUTOR_STDERR"
+  echo "repro: confirmed bug"
+else
+  assert_fixed_result "retry-task" "$retry_status" "$RETRY_STDOUT" "$RETRY_STDERR"
+  assert_fixed_result "resume" "$resume_status" "$RESUME_STDOUT" "$RESUME_STDERR"
+  assert_fixed_result "set executor" "$set_executor_status" "$SET_EXECUTOR_STDOUT" "$SET_EXECUTOR_STDERR"
+echo "repro: confirmed fix"
+fi
+
+echo "workflow: $WORKFLOW_ID"
+echo "retry-task exit: $retry_status"
+echo "resume exit: $resume_status"
+echo "set executor exit: $set_executor_status"
+echo "tmp-dir: $TMP_DIR"
+
+popd >/dev/null

--- a/scripts/repro/repro-noisy-headless-task-status-parser.sh
+++ b/scripts/repro/repro-noisy-headless-task-status-parser.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Repro: dry-run task status parsing must ignore Electron/ANSI noise.
+#
+# Root cause guarded here:
+#   Some CI/headless runs print Electron warnings or ANSI-decorated log lines
+#   around the actual task status. The old parser used `tail -1`, so a trailing
+#   warning could be mistaken for the status.
+#
+# Fixed behavior:
+#   `invoker_e2e_task_status` strips ANSI sequences and returns the last valid
+#   task status token only.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+source scripts/e2e-dry-run/lib/common.sh
+
+invoker_e2e_run_headless() {
+  local _task_status_command="$1"
+  local _task_id="$2"
+  printf '\033[33m(node:123) Electron warning before status\033[0m\n'
+  printf 'running\n'
+  printf '\033[32mcompleted\033[0m\n'
+  printf '(node:123) trailing deprecation warning\n'
+}
+
+status="$(invoker_e2e_task_status wf-test/noisy-task)"
+if [[ "$status" != "completed" ]]; then
+  echo "FAIL noisy status parser: expected completed, got: ${status:-<empty>}" >&2
+  exit 1
+fi
+
+echo "PASS noisy status parser returned completed"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1780385813241-5-capture-after-visual-proof.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1780385813241-5-capture-after-visual-proof.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] wf-1780385813241-5/capture-after-visual-proof was reaped while executor.start was still launching."
+echo "[repro] The attempt heartbeat stayed fresh, but the old 30s launch-dispatch lease expired and was recycled."
+echo "[repro] The first test proves the fixed dispatch TTL survives normal executor startup and still reaps after expiry."
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/launch-dispatcher.test.ts \
+  -t "uses a fixed dispatch TTL long enough for normal executor startup"
+
+echo "[repro] The second test proves TaskRunner records where launch startup reached."
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-launch-dispatch.test.ts \
+  -t "logs executor start begin with launch-dispatch context while executor.start is pending"
+
+echo "[repro] passed"

--- a/scripts/retry-pending-autofix-failed.sh
+++ b/scripts/retry-pending-autofix-failed.sh
@@ -1,0 +1,556 @@
+#!/usr/bin/env bash
+# Continuously nudge pending workflow work, retry failed tasks once,
+# auto-fix still-failed tasks with Codex, approve AI-fix approval gates,
+# and move SSH-assigned recovery work to local worktrees before running it.
+#
+# Usage:
+#   bash scripts/retry-pending-autofix-failed.sh
+#   bash scripts/retry-pending-autofix-failed.sh --dry-run --once
+#   bash scripts/retry-pending-autofix-failed.sh --workflow wf-123 --interval 10
+set -euo pipefail
+
+# shellcheck source=scripts/headless-lib.sh
+source "$(dirname "$0")/headless-lib.sh"
+
+DRY_RUN=false
+INTERVAL_SECONDS=30
+MAX_CYCLES=0
+INCLUDE_MERGE=true
+RESUME_PENDING=true
+RETRY_FAILED=true
+AUTOFIX_FAILED=true
+APPROVE_FIXES=true
+LOCALIZE_SSH=true
+RESUME_COOLDOWN_SECONDS=60
+FIX_COOLDOWN_SECONDS=300
+APPROVE_COOLDOWN_SECONDS=30
+LOCALIZE_COOLDOWN_SECONDS=60
+FIX_DEDUPE_SECONDS=300
+INFRA_RETRY_COOLDOWN_SECONDS=300
+RESUME_DEDUPE_SECONDS=60
+WORKFLOW_FILTERS=()
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: scripts/retry-pending-autofix-failed.sh [options]
+
+Loop actions:
+  - resume every workflow that still has pending tasks
+  - run `retry-task <taskId>` once for every failed task
+  - run `fix <taskId> codex` for failed tasks already retried by this loop
+  - retry infrastructure failures with a cooldown instead of sending them to Codex
+  - run `set executor <taskId> worktree` for pending, failed, or fix-approval SSH tasks before resume/retry/fix/approve
+  - run `approve <taskId>` for awaiting_approval tasks that have pendingFixError
+
+Options:
+  --dry-run                     Print planned commands without mutating state
+  --once                        Run one scan/action cycle and exit
+  --max-cycles <n>              Run n cycles; 0 means forever (default: 0)
+  --interval <seconds>          Sleep between cycles (default: 30)
+  --workflow <workflowId>       Limit to a workflow; may be repeated
+  --no-merge                    Skip failed/approval actions for merge nodes
+  --no-resume-pending           Do not resume workflows with pending tasks
+  --no-retry-failed             Do not retry failed tasks before autofix
+  --no-autofix-failed           Do not submit Codex fixes for failed tasks
+  --no-approve-fixes            Do not approve AI-fix approval tasks
+  --no-localize-ssh             Do not switch SSH-assigned recovery tasks to local worktrees
+  --no-localize-failed-ssh      Deprecated alias for --no-localize-ssh
+  --resume-cooldown <seconds>   Per-workflow resume cooldown (default: 60)
+  --fix-cooldown <seconds>      Per-task fix cooldown (default: 300)
+  --approve-cooldown <seconds>  Per-task approval cooldown (default: 30)
+  --localize-cooldown <seconds> Per-task executor-switch cooldown (default: 60)
+  -h, --help                    Show this help
+EOF
+}
+
+positive_int_or_zero() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+positive_int() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]]
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      DRY_RUN=true
+      shift
+      ;;
+    --once)
+      MAX_CYCLES=1
+      shift
+      ;;
+    --max-cycles)
+      MAX_CYCLES="${2:-}"
+      positive_int_or_zero "$MAX_CYCLES" || { echo "Invalid --max-cycles: $MAX_CYCLES" >&2; exit 2; }
+      shift 2
+      ;;
+    --interval)
+      INTERVAL_SECONDS="${2:-}"
+      positive_int "$INTERVAL_SECONDS" || { echo "Invalid --interval: $INTERVAL_SECONDS" >&2; exit 2; }
+      shift 2
+      ;;
+    --workflow)
+      [[ -n "${2:-}" ]] || { echo "Missing value for --workflow" >&2; exit 2; }
+      WORKFLOW_FILTERS+=("$2")
+      shift 2
+      ;;
+    --no-merge)
+      INCLUDE_MERGE=false
+      shift
+      ;;
+    --no-resume-pending)
+      RESUME_PENDING=false
+      shift
+      ;;
+    --no-retry-failed)
+      RETRY_FAILED=false
+      shift
+      ;;
+    --no-autofix-failed)
+      AUTOFIX_FAILED=false
+      shift
+      ;;
+    --no-approve-fixes)
+      APPROVE_FIXES=false
+      shift
+      ;;
+    --no-localize-failed-ssh)
+      LOCALIZE_SSH=false
+      shift
+      ;;
+    --no-localize-ssh)
+      LOCALIZE_SSH=false
+      shift
+      ;;
+    --resume-cooldown)
+      RESUME_COOLDOWN_SECONDS="${2:-}"
+      positive_int_or_zero "$RESUME_COOLDOWN_SECONDS" || { echo "Invalid --resume-cooldown: $RESUME_COOLDOWN_SECONDS" >&2; exit 2; }
+      shift 2
+      ;;
+    --fix-cooldown)
+      FIX_COOLDOWN_SECONDS="${2:-}"
+      positive_int_or_zero "$FIX_COOLDOWN_SECONDS" || { echo "Invalid --fix-cooldown: $FIX_COOLDOWN_SECONDS" >&2; exit 2; }
+      shift 2
+      ;;
+    --approve-cooldown)
+      APPROVE_COOLDOWN_SECONDS="${2:-}"
+      positive_int_or_zero "$APPROVE_COOLDOWN_SECONDS" || { echo "Invalid --approve-cooldown: $APPROVE_COOLDOWN_SECONDS" >&2; exit 2; }
+      shift 2
+      ;;
+    --localize-cooldown)
+      LOCALIZE_COOLDOWN_SECONDS="${2:-}"
+      positive_int_or_zero "$LOCALIZE_COOLDOWN_SECONDS" || { echo "Invalid --localize-cooldown: $LOCALIZE_COOLDOWN_SECONDS" >&2; exit 2; }
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+STATE_DIR="$(mktemp -d -t invoker-retry-pending-autofix.XXXXXX)"
+SUBMISSIONS_FILE="${INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE:-${HOME:-.}/.invoker/retry-pending-autofix-failed-submissions.tsv}"
+mkdir -p "$(dirname "$SUBMISSIONS_FILE")"
+touch "$SUBMISSIONS_FILE"
+cleanup() {
+  rm -rf "$STATE_DIR"
+}
+trap cleanup EXIT
+
+headless_mutation_no_track() {
+  if [ "$STANDALONE_MODE" = "1" ]; then
+    "$RUNNER" --headless --no-track "$@"
+    return $?
+  fi
+  node "$IPC_HELPER" exec --no-track -- "$@"
+}
+
+recently_submitted() {
+  local kind="$1"
+  local target="$2"
+  local cooldown="$3"
+  local now_epoch="$4"
+
+  if [ "$cooldown" -le 0 ]; then
+    return 1
+  fi
+
+  awk -F '\t' \
+    -v kind="$kind" \
+    -v target="$target" \
+    -v now_epoch="$now_epoch" \
+    -v cooldown="$cooldown" \
+    '$1 == kind && $2 == target && (now_epoch - $3) < cooldown { found = 1 } END { exit found ? 0 : 1 }' \
+    "$SUBMISSIONS_FILE"
+}
+
+ever_submitted() {
+  local kind="$1"
+  local target="$2"
+
+  awk -F '\t' \
+    -v kind="$kind" \
+    -v target="$target" \
+    '$1 == kind && $2 == target { found = 1 } END { exit found ? 0 : 1 }' \
+    "$SUBMISSIONS_FILE"
+}
+
+record_submission() {
+  local kind="$1"
+  local target="$2"
+  local now_epoch="$3"
+  printf '%s\t%s\t%s\n' "$kind" "$target" "$now_epoch" >> "$SUBMISSIONS_FILE"
+}
+
+contains_line() {
+  local file="$1"
+  local target="$2"
+  grep -Fxq -- "$target" "$file"
+}
+
+dispatch_no_track() {
+  local kind="$1"
+  local target="$2"
+  local cooldown="$3"
+  local now_epoch="$4"
+  shift 4
+
+  if recently_submitted "$kind" "$target" "$cooldown" "$now_epoch"; then
+    echo "  skip $kind $target (cooldown ${cooldown}s)"
+    return 0
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    echo "  dry-run: $*"
+    return 0
+  fi
+
+  local output=""
+  local code=0
+  set +e
+  output="$(headless_mutation_no_track "$@" 2>&1)"
+  code=$?
+  set -e
+  printf '%s\n' "$output"
+  if [ "$code" -eq 0 ]; then
+    record_submission "$kind" "$target" "$now_epoch"
+    return 0
+  fi
+  echo "  failed $kind $target (exit $code)" >&2
+  return "$code"
+}
+
+write_workflows_file() {
+  local workflows_file="$1"
+  : > "$workflows_file"
+  if [ "${#WORKFLOW_FILTERS[@]}" -gt 0 ]; then
+    printf '%s\n' "${WORKFLOW_FILTERS[@]}" > "$workflows_file"
+    return
+  fi
+  headless_workflow_ids query workflows --output label > "$workflows_file"
+}
+
+collect_tasks_jsonl() {
+  local workflows_file="$1"
+  local tasks_file="$2"
+  : > "$tasks_file"
+
+  local wf_id=""
+  while IFS= read -r wf_id; do
+    [ -n "$wf_id" ] || continue
+    headless_query query tasks --workflow "$wf_id" --output jsonl \
+      | grep '^{' >> "$tasks_file" || true
+  done < "$workflows_file"
+}
+
+build_targets() {
+  local tasks_file="$1"
+  local pending_workflows_file="$2"
+  local failed_tasks_file="$3"
+  local approvals_file="$4"
+  local localize_ssh_file="$5"
+  local infra_retry_file="$6"
+
+  python3 - "$tasks_file" "$pending_workflows_file" "$failed_tasks_file" "$approvals_file" "$localize_ssh_file" "$infra_retry_file" "$INCLUDE_MERGE" <<'PY'
+import json
+import pathlib
+import sys
+
+tasks_path = pathlib.Path(sys.argv[1])
+pending_workflows_path = pathlib.Path(sys.argv[2])
+failed_tasks_path = pathlib.Path(sys.argv[3])
+approvals_path = pathlib.Path(sys.argv[4])
+localize_ssh_path = pathlib.Path(sys.argv[5])
+infra_retry_path = pathlib.Path(sys.argv[6])
+include_merge = sys.argv[7] == "true"
+
+pending_workflows = set()
+failed_tasks = []
+approvals = []
+localize_ssh = []
+infra_retry = []
+
+INFRA_FAILURE_PATTERNS = (
+    "Execution stalled:",
+    "Executor startup failed",
+    "Worktree provisioning failed",
+    "Failed to spawn provisioning process",
+    "process.cwd failed",
+    "Unable to read current working directory",
+    "Application quit",
+)
+
+def is_infra_failure(error_text: str) -> bool:
+    return any(pattern in error_text for pattern in INFRA_FAILURE_PATTERNS)
+
+for raw in tasks_path.read_text(encoding="utf-8").splitlines():
+    raw = raw.strip()
+    if not raw:
+        continue
+    try:
+        task = json.loads(raw)
+    except json.JSONDecodeError:
+        continue
+
+    task_id = str(task.get("id") or "")
+    if not task_id:
+        continue
+    config = task.get("config") if isinstance(task.get("config"), dict) else {}
+    execution = task.get("execution") if isinstance(task.get("execution"), dict) else {}
+    workflow_id = (
+        config.get("workflowId")
+        or task.get("workflowId")
+        or (task_id.split("/", 1)[0] if "/" in task_id else "")
+    )
+    status = task.get("status")
+    is_merge = bool(config.get("isMergeNode")) or task_id.startswith("__merge__")
+    if is_merge and not include_merge:
+        continue
+
+    runner_kind = config.get("runnerKind")
+    error_text = str(execution.get("error") or task.get("error") or "")
+
+    if status == "pending" and workflow_id:
+        pending_workflows.add(str(workflow_id))
+        if runner_kind == "ssh":
+            localize_ssh.append(task_id)
+    elif status == "failed":
+        failed_tasks.append(task_id)
+        if is_infra_failure(error_text):
+            infra_retry.append(task_id)
+        if runner_kind == "ssh":
+            localize_ssh.append(task_id)
+    elif status == "awaiting_approval" and execution.get("pendingFixError"):
+        if runner_kind == "ssh":
+            localize_ssh.append(task_id)
+        approvals.append(task_id)
+
+pending_workflows_path.write_text(
+    "".join(f"{workflow_id}\n" for workflow_id in sorted(pending_workflows)),
+    encoding="utf-8",
+)
+failed_tasks_path.write_text(
+    "".join(f"{task_id}\n" for task_id in sorted(set(failed_tasks))),
+    encoding="utf-8",
+)
+approvals_path.write_text(
+    "".join(f"{task_id}\n" for task_id in sorted(set(approvals))),
+    encoding="utf-8",
+)
+localize_ssh_path.write_text(
+    "".join(f"{task_id}\n" for task_id in sorted(set(localize_ssh))),
+    encoding="utf-8",
+)
+infra_retry_path.write_text(
+    "".join(f"{task_id}\n" for task_id in sorted(set(infra_retry))),
+    encoding="utf-8",
+)
+PY
+}
+
+count_lines() {
+  local file="$1"
+  if [ ! -s "$file" ]; then
+    printf '0'
+    return
+  fi
+  wc -l < "$file" | tr -d ' '
+}
+
+run_cycle() {
+  local cycle="$1"
+  local now_epoch
+  now_epoch="$(date +%s)"
+
+  local cycle_dir="$STATE_DIR/cycle-$cycle"
+  mkdir -p "$cycle_dir"
+  local workflows_file="$cycle_dir/workflows.txt"
+  local tasks_file="$cycle_dir/tasks.jsonl"
+  local pending_workflows_file="$cycle_dir/pending-workflows.txt"
+  local failed_tasks_file="$cycle_dir/failed-tasks.txt"
+  local approvals_file="$cycle_dir/fix-approvals.txt"
+  local localize_ssh_file="$cycle_dir/localize-ssh.txt"
+  local infra_retry_file="$cycle_dir/infra-retry.txt"
+  local retried_failed_tasks_file="$cycle_dir/retried-failed-tasks.txt"
+  local localized_failed_tasks_file="$cycle_dir/localized-failed-tasks.txt"
+  local localized_workflows_file="$cycle_dir/localized-workflows.txt"
+  : > "$retried_failed_tasks_file"
+  : > "$localized_failed_tasks_file"
+  : > "$localized_workflows_file"
+
+  write_workflows_file "$workflows_file"
+  if [ ! -s "$workflows_file" ]; then
+    echo "cycle $cycle: no workflows found"
+    return 0
+  fi
+
+  collect_tasks_jsonl "$workflows_file" "$tasks_file"
+  build_targets "$tasks_file" "$pending_workflows_file" "$failed_tasks_file" "$approvals_file" "$localize_ssh_file" "$infra_retry_file"
+
+  local pending_count failed_count approval_count localize_count infra_retry_count
+  pending_count="$(count_lines "$pending_workflows_file")"
+  failed_count="$(count_lines "$failed_tasks_file")"
+  approval_count="$(count_lines "$approvals_file")"
+  localize_count="$(count_lines "$localize_ssh_file")"
+  infra_retry_count="$(count_lines "$infra_retry_file")"
+
+  echo "cycle $cycle: pending-workflows=$pending_count failed-tasks=$failed_count infra-retry=$infra_retry_count fix-approvals=$approval_count ssh-to-worktree=$localize_count"
+
+  local failures=0
+  local target=""
+
+  if [ "$LOCALIZE_SSH" = true ] && [ -s "$localize_ssh_file" ]; then
+    echo "switching SSH-assigned recovery tasks to local worktrees"
+    while IFS= read -r target; do
+      [ -n "$target" ] || continue
+      if dispatch_no_track localize-worktree "$target" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch" set executor "$target" worktree; then
+        printf '%s\n' "$target" >> "$localized_failed_tasks_file"
+        if [[ "$target" == */* ]]; then
+          printf '%s\n' "${target%%/*}" >> "$localized_workflows_file"
+        fi
+      else
+        failures=$((failures + 1))
+      fi
+    done < "$localize_ssh_file"
+  fi
+
+  if [ "$APPROVE_FIXES" = true ] && [ -s "$approvals_file" ]; then
+    echo "approving AI fix approvals"
+    while IFS= read -r target; do
+      [ -n "$target" ] || continue
+      if contains_line "$localized_failed_tasks_file" "$target"; then
+        echo "  skip approve $target (executor switch queued this cycle)"
+        continue
+      fi
+      dispatch_no_track approve "$target" "$APPROVE_COOLDOWN_SECONDS" "$now_epoch" approve "$target" \
+        || failures=$((failures + 1))
+    done < "$approvals_file"
+  fi
+
+  if [ "$RETRY_FAILED" = true ] && [ -s "$failed_tasks_file" ]; then
+    echo "retrying failed tasks"
+    while IFS= read -r target; do
+      [ -n "$target" ] || continue
+      if contains_line "$localized_failed_tasks_file" "$target"; then
+        echo "  skip retry-failed $target (executor switch queued this cycle)"
+        continue
+      fi
+      if contains_line "$infra_retry_file" "$target"; then
+        dispatch_no_track retry-infra "$target" "$INFRA_RETRY_COOLDOWN_SECONDS" "$now_epoch" retry-task "$target" \
+          || failures=$((failures + 1))
+        continue
+      fi
+      if ever_submitted retry-failed "$target"; then
+        echo "  skip retry-failed $target (already retried by this loop)"
+        continue
+      fi
+      if dispatch_no_track retry-failed "$target" 0 "$now_epoch" retry-task "$target"; then
+        printf '%s\n' "$target" >> "$retried_failed_tasks_file"
+      else
+        failures=$((failures + 1))
+      fi
+    done < "$failed_tasks_file"
+  fi
+
+  if [ "$AUTOFIX_FAILED" = true ] && [ -s "$failed_tasks_file" ]; then
+    echo "submitting Codex fixes for failed tasks"
+    while IFS= read -r target; do
+      [ -n "$target" ] || continue
+      if contains_line "$localized_failed_tasks_file" "$target"; then
+        echo "  skip fix $target (executor switch queued this cycle)"
+        continue
+      fi
+      if contains_line "$infra_retry_file" "$target"; then
+        echo "  skip fix $target (infrastructure failure; retrying instead)"
+        continue
+      fi
+      if contains_line "$retried_failed_tasks_file" "$target"; then
+        echo "  skip fix $target (retried this cycle)"
+        continue
+      fi
+      if recently_submitted fix "$target" "$FIX_DEDUPE_SECONDS" "$now_epoch"; then
+        echo "  skip fix $target (fix submitted recently)"
+        continue
+      fi
+      dispatch_no_track fix "$target" "$FIX_COOLDOWN_SECONDS" "$now_epoch" fix "$target" codex \
+        || failures=$((failures + 1))
+    done < "$failed_tasks_file"
+  fi
+
+  if [ "$RESUME_PENDING" = true ] && [ -s "$pending_workflows_file" ]; then
+    echo "resuming workflows with pending tasks"
+    while IFS= read -r target; do
+      [ -n "$target" ] || continue
+      if contains_line "$localized_workflows_file" "$target"; then
+        echo "  skip resume $target (executor switch queued this cycle)"
+        continue
+      fi
+      local resume_cooldown="$RESUME_COOLDOWN_SECONDS"
+      if [ "$resume_cooldown" -lt "$RESUME_DEDUPE_SECONDS" ]; then
+        resume_cooldown="$RESUME_DEDUPE_SECONDS"
+      fi
+      dispatch_no_track resume "$target" "$resume_cooldown" "$now_epoch" resume "$target" \
+        || failures=$((failures + 1))
+    done < "$pending_workflows_file"
+  fi
+
+  if [ "$failures" -gt 0 ]; then
+    echo "cycle $cycle: $failures command(s) failed to submit" >&2
+    return 1
+  fi
+  return 0
+}
+
+echo "retry/autofix loop starting"
+echo "dryRun=$DRY_RUN interval=${INTERVAL_SECONDS}s maxCycles=$MAX_CYCLES includeMerge=$INCLUDE_MERGE"
+echo "resumePending=$RESUME_PENDING retryFailed=$RETRY_FAILED autofixFailed=$AUTOFIX_FAILED approveFixes=$APPROVE_FIXES localizeSsh=$LOCALIZE_SSH"
+
+cycle=1
+overall_failures=0
+while :; do
+  if ! run_cycle "$cycle"; then
+    overall_failures=$((overall_failures + 1))
+  fi
+
+  if [ "$MAX_CYCLES" -gt 0 ] && [ "$cycle" -ge "$MAX_CYCLES" ]; then
+    break
+  fi
+
+  cycle=$((cycle + 1))
+  sleep "$INTERVAL_SECONDS"
+done
+
+if [ "$overall_failures" -gt 0 ]; then
+  echo "completed with $overall_failures failed cycle(s)" >&2
+  exit 1
+fi
+
+echo "completed"

--- a/scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh
+++ b/scripts/test-suites/required/25-launch-dispatch-queue-handoff-repro.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Standalone regression proof for stale launch-dispatch acknowledgements blocking queued work.
+set -euo pipefail
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "$ROOT"
+
+ensure_built() {
+  local package_name="$1"
+  local package_dir="$2"
+  if [ ! -f "$package_dir/dist/index.js" ] ||
+    find "$package_dir/src" -type f -newer "$package_dir/dist/index.js" | grep -q .; then
+    pnpm --filter "$package_name" build
+  fi
+}
+
+ensure_built @invoker/workflow-graph "$ROOT/packages/workflow-graph"
+ensure_built @invoker/contracts "$ROOT/packages/contracts"
+ensure_built @invoker/workflow-core "$ROOT/packages/workflow-core"
+ensure_built @invoker/data-store "$ROOT/packages/data-store"
+
+exec node \
+  --loader "$ROOT/scripts/repro/compiled-workspace-loader.mjs" \
+  "$ROOT/scripts/repro/repro-launch-dispatch-queue-handoff.mjs"


### PR DESCRIPTION
## Summary

Use a fixed 12 minute launch-dispatch TTL instead of renewing launch leases while executor startup is pending.

This keeps dispatch retry behavior simple while covering the normal 10 minute executor startup timeout.

Record durable launch breadcrumbs when dispatch is enqueued, claimed, and executor startup begins.

Those events make a waiting launch debuggable without holding the dispatch path open.

## Architecture

### Before

```mermaid
flowchart LR
  Dispatch[dispatch claimed] --> Startup[executor startup]
  Startup --> Renew[renew dispatch lease]
  Renew --> Startup
  Startup --> Running[executor running]
```

### After

```mermaid
flowchart LR
  Enqueue[dispatch enqueued event] --> Dispatch[dispatch claimed]
  Dispatch --> ClaimLog[dispatch claimed event]
  ClaimLog --> Startup[executor start begin event]
  Startup --> Running[executor running]
  Dispatch -. fixed 12 minute TTL .-> Reap[crash recovery reap]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatcher.test.ts src/__tests__/launch-invariant.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-launch-dispatch.test.ts`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts -t "task_launch_dispatch outbox|launch dispatch"`
- [x] `pnpm --filter @invoker/data-store exec vitest run src/__tests__/sqlite-adapter.test.ts`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner.test.ts -t "reports launch-in-progress callbacks|fails a task when executor.start never resolves|fires onHeartbeat while awaiting a slow executor.start"`
- [x] `pnpm run check:types`
- [x] `bash scripts/repro/repro-pending-task-did-not-run-wf-1780385813241-5-capture-after-visual-proof.sh`
- [x] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit>`
- Post-revert steps: Re-run the affected launch-dispatch and retry-loop validation.
- Data migration? No

Depends-On: #1122