### PR TITLE
fix(workflow-core): clear pending fix error on retry reset

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -799,6 +799,7 @@ describe('Orchestrator', () => {
       const task = orchestrator.getTask('f2')!;
       expect(task.status === 'pending' || task.status === 'running').toBe(true);
       expect(task.execution.isFixingWithAI).toBeFalsy();
+      expect(task.execution.pendingFixError).toBeUndefined();
     });
 
     it('revertConflictResolution restores failed state', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2292,6 +2292,7 @@ export class Orchestrator {
         completedAt: undefined,
         error: undefined,
         exitCode: undefined,
+        pendingFixError: undefined,
         commit: undefined,
         lastHeartbeatAt: undefined,
         launchStartedAt: undefined,


### PR DESCRIPTION
## Summary

Clear stale pending-fix errors when a task is prepared for retry.

The next attempt starts from current retry state instead of inherited failure text.

## Test Plan

- [ ] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 75e8dd2c9`
- Post-revert steps: Re-run affected retry and fix-approval validation.
- Data migration? No

Depends-On: #1174
