### PR TITLE
feat(app): route GUI and headless mutations through daemon owner

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -11,7 +11,7 @@ import { resolveRepoRoot } from '@invoker/contracts';
 import { test as base, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import { stringify as yamlStringify } from 'yaml';
@@ -24,12 +24,30 @@ export type ElectronFixtures = {
 
 const repoRoot = resolveRepoRoot(__dirname);
 
+async function removeTestDir(dir: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      lastError = err;
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOTEMPTY' && code !== 'EBUSY' && code !== 'EPERM') {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+  throw lastError;
+}
+
 export const test = base.extend<ElectronFixtures>({
   testDir: async ({}, use) => {
     const dir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-'));
     await use(dir);
     if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
-      rmSync(dir, { recursive: true, force: true });
+      await removeTestDir(dir);
     }
   },
 
@@ -40,8 +58,10 @@ export const test = base.extend<ElectronFixtures>({
     const markerRoot = path.join(testDir, 'e2e-markers');
     const configPath = path.join(testDir, 'e2e-config.json');
     const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    const electronUserDataDir = path.join(testDir, 'electron-user-data');
     await fs.mkdir(stubDir, { recursive: true });
     await fs.mkdir(markerRoot, { recursive: true });
+    await fs.mkdir(electronUserDataDir, { recursive: true });
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
     try {
       await fs.symlink(claudeMarker, path.join(stubDir, 'claude'));
@@ -76,6 +96,7 @@ exit 64
         ...(process.platform === 'linux'
           ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
           : []),
+        `--user-data-dir=${electronUserDataDir}`,
         path.resolve(__dirname, '..', '..', 'dist', 'main.js'),
       ],
       env: {
@@ -87,6 +108,8 @@ exit 64
         INVOKER_ALLOW_DELETE_ALL: '1',
         INVOKER_E2E_ENABLE_COMPOSITOR: '1',
         INVOKER_REPO_CONFIG_PATH: configPath,
+        INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:
+          process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '10000',
         INVOKER_EMBEDDED_TERMINAL_BACKEND:
           process.env.INVOKER_E2E_EMBEDDED_TERMINAL_BACKEND ?? 'pty',
         INVOKER_E2E_MARKER_ROOT: markerRoot,
@@ -115,6 +138,13 @@ exit 64
     await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
 
     await use(page);
+    try {
+      await page.evaluate(async () => {
+        await window.invoker.deleteAllWorkflows();
+      });
+    } catch {
+      // Best-effort cleanup; the test failure itself should remain the signal.
+    }
   },
 });
 

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -1,8 +1,8 @@
 import { execFile } from 'node:child_process';
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
-import type { Page } from '@playwright/test';
+import { _electron as electron, type Page } from '@playwright/test';
 import { resolveRepoRoot } from '@invoker/contracts';
 import { stringify as yamlStringify } from 'yaml';
 
@@ -19,19 +19,29 @@ const execFileAsync = promisify(execFile);
 const repoRoot = resolveRepoRoot(__dirname);
 const RESPONSIVE_INTERACTION_TIMEOUT_MS = 15000;
 
-async function runHeadlessClient(testDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+async function ensureHeadlessTestConfig(testDir: string): Promise<void> {
+  await writeFile(path.join(testDir, 'e2e-config.json'), JSON.stringify({ autoFixRetries: 0 }), 'utf8');
+}
+
+function headlessTestEnv(testDir: string): NodeJS.ProcessEnv {
   const configPath = path.join(testDir, 'e2e-config.json');
   const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+  return {
+    ...process.env,
+    NODE_ENV: 'test',
+    TZ: 'UTC',
+    INVOKER_DB_DIR: testDir,
+    INVOKER_IPC_SOCKET: ipcSocketPath,
+    INVOKER_REPO_CONFIG_PATH: configPath,
+  };
+}
+
+async function runHeadlessClient(testDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  await ensureHeadlessTestConfig(testDir);
   const clientPath = path.join(repoRoot, 'packages', 'app', 'dist', 'headless-client.js');
   return await execFileAsync('node', [clientPath, ...args], {
     cwd: repoRoot,
-    env: {
-      ...process.env,
-      NODE_ENV: 'test',
-      INVOKER_DB_DIR: testDir,
-      INVOKER_IPC_SOCKET: ipcSocketPath,
-      INVOKER_REPO_CONFIG_PATH: configPath,
-    },
+    env: headlessTestEnv(testDir),
     maxBuffer: 10 * 1024 * 1024,
   });
 }
@@ -42,6 +52,16 @@ function parseWorkflowId(stdout: string): string {
   const direct = stdout.match(/Workflow ID: (wf-[^\s]+)/);
   if (direct?.[1]) return direct[1];
   throw new Error(`No workflow id found in stdout:\n${stdout}`);
+}
+
+function expectDelegated(stdout: string): void {
+  expect(stdout).toContain('Delegated to owner');
+}
+
+function parseJsonStdout(stdout: string): Record<string, unknown> {
+  const line = stdout.split(/\r?\n/).map((entry) => entry.trim()).find((entry) => entry.startsWith('{'));
+  if (!line) throw new Error(`No JSON object found in stdout:\n${stdout}`);
+  return JSON.parse(line) as Record<string, unknown>;
 }
 
 async function assertTaskPanelResponsive(page: Page, timeoutMs: number): Promise<void> {
@@ -90,6 +110,7 @@ test.describe('Headless thundering herd', () => {
     workflowIds.add(currentWorkflowId);
     for (let i = 0; i < 8; i += 1) {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
+      expectDelegated(result.stdout);
       // Use the workflow id echoed by this exact submission. Querying shared
       // persisted state from the app layer both violates the owner boundary
       // and is ambiguous when many workflows are created concurrently.
@@ -113,22 +134,76 @@ test.describe('Headless thundering herd', () => {
     await assertTaskPanelResponsive(page, RESPONSIVE_INTERACTION_TIMEOUT_MS);
     expect(Date.now() - secondInteractionStartedAt).toBeLessThan(RESPONSIVE_INTERACTION_TIMEOUT_MS);
 
-    await Promise.all(burst);
+    const retryResults = await Promise.all(burst);
+    for (const result of retryResults) {
+      expectDelegated(result.stdout);
+    }
 
     const perf = await page.evaluate(async () => await window.invoker.getUiPerfStats());
     expect(perf.maxRendererEventLoopLagMs).toBeLessThan(1000);
     expect(perf.maxRendererLongTaskMs).toBeLessThan(1500);
 
-    const ownerServe = await execFileAsync('bash', [
-      '-lc',
-      "pgrep -af '[e]lectron/dist/electron .*packages/app/dist/main.js.*--headless owner-serve' || true",
-    ]);
-    expect(ownerServe.stdout.trim()).toBe('');
+    const delegatedPerf = parseJsonStdout(
+      (await runHeadlessClient(testDir, ['query', 'ui-perf', '--output', 'json'])).stdout,
+    );
+    expect(delegatedPerf.ownerMode).toBe('standalone');
+  });
 
-    const retryElectrons = await execFileAsync('bash', [
-      '-lc',
-      "pgrep -af '[e]lectron/dist/electron .*packages/app/dist/main.js.*--headless retry ' || true",
-    ]);
-    expect(retryElectrons.stdout.trim()).toBe('');
+  test('standalone owner serves delegated headless commands from isolated test paths', async ({ testDir }) => {
+    await ensureHeadlessTestConfig(testDir);
+    const userDataDir = path.join(testDir, 'owner-electron-user-data');
+    await mkdir(userDataDir, { recursive: true });
+
+    const ownerApp = await electron.launch({
+      args: [
+        ...(process.platform === 'linux'
+          ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
+          : []),
+        `--user-data-dir=${userDataDir}`,
+        path.join(repoRoot, 'packages', 'app', 'dist', 'main.js'),
+        '--headless',
+        'owner-serve',
+      ],
+      env: {
+        ...headlessTestEnv(testDir),
+        INVOKER_HEADLESS_STANDALONE: '1',
+        INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS: '60000',
+      },
+    });
+
+    try {
+      await expect(async () => {
+        const result = await runHeadlessClient(testDir, ['query', 'ui-perf', '--output', 'json']);
+        const stats = parseJsonStdout(result.stdout);
+        expect(stats.ownerMode).toBe('standalone');
+      }).toPass({ timeout: 20000 });
+
+      const daemonPlan = {
+        name: 'Standalone Owner Delegation',
+        repoUrl: E2E_REPO_URL,
+        onFinish: 'none' as const,
+        tasks: [
+          {
+            id: 'daemon-root',
+            description: 'Daemon root',
+            command: 'echo daemon-root',
+            dependencies: [],
+          },
+        ],
+      };
+      const planPath = path.join(testDir, 'standalone-owner-plan.yaml');
+      await writeFile(planPath, yamlStringify(daemonPlan), 'utf8');
+
+      const runResult = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
+      expectDelegated(runResult.stdout);
+      expect(parseWorkflowId(runResult.stdout)).toMatch(/^wf-/);
+
+      const queue = await runHeadlessClient(testDir, ['query', 'queue', '--output', 'json']);
+      const queueStatus = parseJsonStdout(queue.stdout);
+      expect(Array.isArray(queueStatus.running)).toBe(true);
+      expect(Array.isArray(queueStatus.queued)).toBe(true);
+    } finally {
+      await ownerApp.close().catch(() => undefined);
+    }
   });
 });

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -29,21 +29,33 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
-  it('delegates mutating commands to an existing non-standalone owner without bootstrapping', async () => {
-    const bus = new LocalBus();
-    const ownerHandler = vi.fn(async () => ({ ok: true }));
+  it('does not use an existing non-standalone owner as a mutation target', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    const guiOwnerHandler = vi.fn(async () => ({ ok: true }));
+    const daemonOwnerHandler = vi.fn(async () => ({ ok: true }));
 
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    bus.onRequest('headless.exec', ownerHandler);
+    firstBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-gui', mode: 'gui' }));
+    firstBus.onRequest('headless.exec', guiOwnerHandler);
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-daemon', mode: 'standalone' }));
+    secondBus.onRequest('headless.exec', daemonOwnerHandler);
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(firstBus)
+      .mockResolvedValue(secondBus);
 
     const exitCode = await runHeadlessClientCommand(['retry', 'wf-1', '--no-track'], {
-      messageBus: bus,
-      ensureStandaloneOwner: vi.fn(async () => {}),
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
       runElectronHeadless: vi.fn(async () => 0),
     });
 
     expect(exitCode).toBe(0);
-    expect(ownerHandler).toHaveBeenCalledTimes(1);
+    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+    expect(guiOwnerHandler).not.toHaveBeenCalled();
+    expect(daemonOwnerHandler).toHaveBeenCalledTimes(1);
   });
 
   it('uses a longer no-track delegation timeout for an already-running standalone owner under load', async () => {
@@ -146,22 +158,16 @@ describe('headless-client', () => {
     expect(ownerHandler).toHaveBeenCalledTimes(1);
   });
 
-  it('passes the refreshed bus into bootstrap after an owner-timeout retry', async () => {
+  it('uses a refreshed standalone owner without bootstrapping', async () => {
     const firstBus = new LocalBus();
     const secondBus = new LocalBus();
-    let bootstrapCalls = 0;
+    const runHandler = vi.fn(async () => ({ workflowId: 'wf-bootstrap', tasks: [] }));
 
     secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
-    secondBus.onRequest('headless.run', async () => ({ workflowId: 'wf-bootstrap', tasks: [] }));
+    secondBus.onRequest('headless.run', runHandler);
 
-    const ensureStandaloneOwner = vi.fn(async (_bus?: unknown) => {
-      bootstrapCalls += 1;
-      if (bootstrapCalls === 1) {
-        throw new SharedMutationOwnerTimeoutError();
-      }
-    });
+    const ensureStandaloneOwner = vi.fn(async () => {});
     const refreshMessageBus = vi.fn()
-      .mockResolvedValueOnce(secondBus)
       .mockResolvedValueOnce(secondBus)
       .mockResolvedValue(secondBus);
 
@@ -173,8 +179,9 @@ describe('headless-client', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(1, secondBus);
-    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(2, secondBus);
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(refreshMessageBus).toHaveBeenCalledTimes(1);
+    expect(runHandler).toHaveBeenCalledTimes(1);
   });
 
   it('uses a longer no-track delegation timeout after bootstrap under load', async () => {
@@ -327,18 +334,19 @@ describe('headless-client', () => {
     expect(refreshMessageBus).toHaveBeenCalled();
   }, 15_000);
 
-  it('uses the current non-standalone owner directly without refreshing or bootstrapping', async () => {
+  it('refreshes past a non-standalone owner before delegating a mutation', async () => {
     const firstBus = new LocalBus();
-    let firstExecCalls = 0;
+    const secondBus = new LocalBus();
+    const firstExecHandler = vi.fn(async () => ({ ok: true }));
+    const secondExecHandler = vi.fn(async () => ({ ok: true }));
 
     firstBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    firstBus.onRequest('headless.exec', async () => {
-      firstExecCalls += 1;
-      return { ok: true };
-    });
+    firstBus.onRequest('headless.exec', firstExecHandler);
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
+    secondBus.onRequest('headless.exec', secondExecHandler);
 
     const ensureStandaloneOwner = vi.fn(async () => {});
-    const refreshMessageBus = vi.fn(async () => firstBus);
+    const refreshMessageBus = vi.fn(async () => secondBus);
 
     const exitCode = await runHeadlessClientCommand(['recreate', 'wf-3', '--no-track'], {
       messageBus: firstBus,
@@ -349,8 +357,9 @@ describe('headless-client', () => {
 
     expect(exitCode).toBe(0);
     expect(ensureStandaloneOwner).not.toHaveBeenCalled();
-    expect(refreshMessageBus).not.toHaveBeenCalled();
-    expect(firstExecCalls).toBe(1);
+    expect(refreshMessageBus).toHaveBeenCalled();
+    expect(firstExecHandler).not.toHaveBeenCalled();
+    expect(secondExecHandler).toHaveBeenCalledTimes(1);
   }, 15_000);
 
   it('falls back to the host runtime for non-mutating commands', async () => {

--- a/packages/app/src/__tests__/headless-owner-bootstrap.test.ts
+++ b/packages/app/src/__tests__/headless-owner-bootstrap.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  OWNER_BOOTSTRAP_LOCK_DIR,
+  tryAcquireOwnerBootstrapLock,
+} from '../headless-owner-bootstrap.js';
+
+describe('headless-owner-bootstrap', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTempHome(): string {
+    const tempDir = mkdtempSync(join(tmpdir(), 'invoker-owner-bootstrap-'));
+    tempDirs.push(tempDir);
+    return tempDir;
+  }
+
+  it('serializes concurrent bootstrap attempts with a process pid lock', () => {
+    const home = makeTempHome();
+    const firstLock = tryAcquireOwnerBootstrapLock(home);
+
+    expect(firstLock).not.toBeNull();
+    expect(tryAcquireOwnerBootstrapLock(home)).toBeNull();
+
+    firstLock?.release();
+    expect(existsSync(join(home, OWNER_BOOTSTRAP_LOCK_DIR))).toBe(false);
+  });
+
+  it('recovers from a stale lock directory with no pid file', () => {
+    const home = makeTempHome();
+    mkdirSync(join(home, OWNER_BOOTSTRAP_LOCK_DIR));
+
+    const lock = tryAcquireOwnerBootstrapLock(home);
+
+    expect(lock).not.toBeNull();
+    expect(existsSync(join(home, OWNER_BOOTSTRAP_LOCK_DIR, 'pid'))).toBe(true);
+    lock?.release();
+  });
+
+  it('creates the invoker home root before acquiring the lock', () => {
+    const parent = makeTempHome();
+    const missingHome = join(parent, 'missing-home');
+
+    const lock = tryAcquireOwnerBootstrapLock(missingHome);
+
+    expect(lock).not.toBeNull();
+    expect(existsSync(join(missingHome, OWNER_BOOTSTRAP_LOCK_DIR, 'pid'))).toBe(true);
+    lock?.release();
+  });
+});

--- a/packages/app/src/__tests__/owner-resolver.test.ts
+++ b/packages/app/src/__tests__/owner-resolver.test.ts
@@ -277,6 +277,33 @@ describe('owner-resolver', () => {
       expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
     });
 
+    it('uses a standalone owner discovered after refresh without bootstrapping', async () => {
+      const firstBus = new LocalBus();
+      const secondBus = new LocalBus();
+      secondBus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-refreshed',
+        mode: 'standalone',
+      }));
+
+      const ensureStandaloneOwner = vi.fn(async () => {});
+      const refreshMessageBus = vi.fn(async () => secondBus);
+      const resolver = createOwnerResolver({
+        messageBus: firstBus,
+        refreshMessageBus,
+        ensureStandaloneOwner,
+      }, {
+        discoveryTimeoutMs: 100,
+        refreshDiscoveryTimeoutMs: 100,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-refreshed');
+      expect(result.bus).toBe(secondBus);
+      expect(refreshMessageBus).toHaveBeenCalledTimes(1);
+      expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    });
+
     it('retries bootstrap when the first attempt does not produce a reachable owner', async () => {
       const bus = new LocalBus();
       let bootstrapCalls = 0;
@@ -304,6 +331,38 @@ describe('owner-resolver', () => {
       const result = await resolver.resolve();
       expect(result.owner.ownerId).toBe('owner-retry');
       expect(bootstrapCalls).toBe(2);
+    });
+
+    it('retries configured bootstrap timeout errors', async () => {
+      const bus = new LocalBus();
+      const retryableError = new Error('owner bootstrap timed out');
+      let bootstrapCalls = 0;
+
+      const ensureStandaloneOwner = vi.fn(async () => {
+        bootstrapCalls += 1;
+        if (bootstrapCalls === 1) {
+          throw retryableError;
+        }
+        bus.onRequest('headless.owner-ping', async () => ({
+          ok: true,
+          ownerId: 'owner-after-timeout',
+          mode: 'standalone',
+        }));
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+        isRetryableBootstrapError: (error) => error === retryableError,
+      }, {
+        discoveryTimeoutMs: 100,
+        postBootstrapReadyTimeoutMs: 500,
+        maxBootstrapAttempts: 2,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-after-timeout');
+      expect(ensureStandaloneOwner).toHaveBeenCalledTimes(2);
     });
 
     it('throws after exhausting all bootstrap attempts', async () => {

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -23,10 +23,9 @@ import {
 import { loadConfig } from './config.js';
 import {
   discoverOwner,
-  isOwnerReachable,
   isStandaloneCapable,
 } from './owner-endpoint.js';
-import { createOwnerResolver } from './owner-resolver.js';
+import { createOwnerResolver, type ResolvedOwner } from './owner-resolver.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -206,53 +205,6 @@ async function delegateReadOnlyQuery(
   return true;
 }
 
-async function delegateAfterBootstrap(
-  args: string[],
-  deps: Pick<HeadlessClientDeps, 'refreshMessageBus'>,
-  bus: MessageBus,
-  waitForApproval?: boolean,
-  noTrack?: boolean,
-): Promise<DelegationOutcome> {
-  const startedAt = Date.now();
-  delegationClientLog(`post-bootstrap delegation loop begin timeoutMs=${POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS}`);
-  const deadline = Date.now() + POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS;
-  let messageBus = bus;
-  let attempts = 0;
-  let lastOutcome: DelegationOutcome = { kind: 'no-handler' };
-  while (Date.now() < deadline) {
-    attempts += 1;
-    const owner = await discoverOwner(messageBus, 1_000);
-    delegationClientLog(
-      `post-bootstrap attempt=${attempts} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
-    );
-    if (isStandaloneCapable(owner)) {
-      const outcome = await delegateMutation(
-        args,
-        messageBus,
-        waitForApproval,
-        noTrack,
-        noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
-      );
-      lastOutcome = outcome;
-      if (outcome.kind === 'delegated') {
-        delegationClientLog(`post-bootstrap delegation succeeded attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
-        return outcome;
-      }
-      if (outcome.kind === 'protocol-error') {
-        delegationClientLog(`post-bootstrap protocol-error attempts=${attempts} message=${outcome.message}`);
-        return outcome;
-      }
-      // timeout or no-handler: retry after refresh
-    }
-    if (deps.refreshMessageBus) {
-      messageBus = await deps.refreshMessageBus();
-    }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-  delegationClientLog(`post-bootstrap delegation exhausted attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
-  return lastOutcome;
-}
-
 export interface HeadlessClientDeps {
   messageBus: MessageBus;
   ensureStandaloneOwner: (bus?: MessageBus) => Promise<void>;
@@ -331,107 +283,59 @@ async function resolveOwnerAndDelegate(
 ): Promise<number | null> {
   const startedAt = Date.now();
   delegationClientLog(`resolveOwnerAndDelegate begin command=${args[0] ?? '<missing>'} noTrack=${noTrack ? 'true' : 'false'}`);
-  let messageBus = deps.messageBus;
   const resolvedExitCode = (): number => {
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
   };
 
-  // Phase 1: Discover a standalone-capable owner and delegate
-  const owner = await discoverOwner(messageBus, 3_000);
-  delegationClientLog(
-    `phase1 discover standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
+  const resolver = createOwnerResolver(
+    {
+      messageBus: deps.messageBus,
+      refreshMessageBus: deps.refreshMessageBus,
+      ensureStandaloneOwner: deps.ensureStandaloneOwner,
+      isRetryableBootstrapError: isSharedMutationOwnerTimeoutError,
+    },
+    {
+      discoveryTimeoutMs: 3_000,
+      refreshDiscoveryTimeoutMs: 1_000,
+      postBootstrapReadyTimeoutMs: POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS,
+      maxBootstrapAttempts: POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS,
+    },
   );
-  if (isStandaloneCapable(owner)) {
-    const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
-    delegationClientLog(`phase1 outcome=${outcome.kind}`);
-    if (outcome.kind === 'delegated') {
-      delegationClientLog(`phase1 delegated successfully elapsedMs=${Date.now() - startedAt}`);
-      return resolvedExitCode();
-    }
-    if (outcome.kind === 'protocol-error') {
-      delegationClientLog(`phase1 protocol-error: ${outcome.message}`);
-      return null;
-    }
-    // timeout or no-handler: fall through to next phase
-  }
 
-  // Phase 2: Try any reachable owner (may be non-standalone)
-  if (isOwnerReachable(owner)) {
-    const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
-    delegationClientLog(`phase2 outcome=${outcome.kind} ownerId=${owner.ownerId}`);
-    if (outcome.kind === 'delegated') {
-      delegationClientLog(`phase2 delegated to reachable owner elapsedMs=${Date.now() - startedAt}`);
-      return resolvedExitCode();
-    }
-    if (outcome.kind === 'protocol-error') {
-      delegationClientLog(`phase2 protocol-error: ${outcome.message}`);
-      return null;
-    }
-  } else {
-    delegationClientLog('phase2 skipped: no reachable owner');
-  }
-
-  // Phase 3: Refresh and retry against any reachable owner
-  if (isOwnerReachable(owner) && deps.refreshMessageBus) {
-    delegationClientLog('phase3 refreshing message bus');
-    messageBus = await deps.refreshMessageBus();
-    const refreshedOwner = await discoverOwner(messageBus, 1_000);
-    delegationClientLog(
-      `phase3 discover ownerReachable=${isOwnerReachable(refreshedOwner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(refreshedOwner) ? 'true' : 'false'} ownerId=${refreshedOwner?.ownerId ?? '<none>'}`,
-    );
-    if (isOwnerReachable(refreshedOwner)) {
-      const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
-      delegationClientLog(`phase3 outcome=${outcome.kind}`);
-      if (outcome.kind === 'delegated') {
-        delegationClientLog(`phase3 delegated successfully elapsedMs=${Date.now() - startedAt}`);
-        return resolvedExitCode();
-      }
-      if (outcome.kind === 'protocol-error') {
-        delegationClientLog(`phase3 protocol-error: ${outcome.message}`);
+  for (let attempt = 0; attempt < POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS; attempt += 1) {
+    delegationClientLog(`resolve attempt=${attempt + 1}/${POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS}`);
+    let resolved: ResolvedOwner;
+    try {
+      resolved = await resolver.resolve(true);
+    } catch (err) {
+      if (err instanceof Error && /Could not resolve a standalone-capable owner/.test(err.message)) {
+        delegationClientLog(`resolve attempt failed: ${err.message}`);
         return null;
       }
+      throw err;
     }
-    delegationClientLog('phase3 delegation did not succeed');
-  }
+    delegationClientLog(`resolved standalone ownerId=${resolved.owner.ownerId}`);
 
-  // Phase 4: Bootstrap with bounded retry loop
-  if (deps.refreshMessageBus) {
-    messageBus = await deps.refreshMessageBus();
-  }
-  for (let attempt = 0; attempt < POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS; attempt += 1) {
-    delegationClientLog(`phase4 bootstrap attempt=${attempt + 1}/${POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS}`);
-    try {
-      await deps.ensureStandaloneOwner(messageBus);
-    } catch (err) {
-      if (!isSharedMutationOwnerTimeoutError(err)) {
-        throw err;
-      }
-      if (!deps.refreshMessageBus) {
-        throw err;
-      }
-      delegationClientLog(`phase4 bootstrap timeout; refreshing bus and retrying attempt=${attempt + 1}`);
-      messageBus = await deps.refreshMessageBus();
-      await deps.ensureStandaloneOwner(messageBus);
-    }
-    if (deps.refreshMessageBus) {
-      messageBus = await deps.refreshMessageBus();
-    }
-    const outcome = await delegateAfterBootstrap(args, deps, messageBus, waitForApproval, noTrack);
-    delegationClientLog(`phase4 post-bootstrap outcome=${outcome.kind} attempt=${attempt + 1}`);
+    const outcome = await delegateMutation(
+      args,
+      resolved.bus,
+      waitForApproval,
+      noTrack,
+      noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
+    );
+    delegationClientLog(`delegate outcome=${outcome.kind} attempt=${attempt + 1}`);
     if (outcome.kind === 'delegated') {
-      delegationClientLog(`phase4 delegated successfully attempt=${attempt + 1} elapsedMs=${Date.now() - startedAt}`);
+      delegationClientLog(`delegated successfully attempt=${attempt + 1} elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
     if (outcome.kind === 'protocol-error') {
-      delegationClientLog(`phase4 protocol-error attempt=${attempt + 1}: ${outcome.message}`);
+      delegationClientLog(`protocol-error attempt=${attempt + 1}: ${outcome.message}`);
       return null;
     }
-    // timeout or no-handler: retry next bootstrap attempt
     if (!deps.refreshMessageBus) {
       break;
     }
-    messageBus = await deps.refreshMessageBus();
   }
 
   delegationClientLog(`resolveOwnerAndDelegate failed after elapsedMs=${Date.now() - startedAt}`);

--- a/packages/app/src/headless-owner-bootstrap.ts
+++ b/packages/app/src/headless-owner-bootstrap.ts
@@ -13,6 +13,7 @@ export function tryAcquireOwnerBootstrapLock(invokerHomeRoot: string): OwnerBoot
   const lockDir = join(invokerHomeRoot, OWNER_BOOTSTRAP_LOCK_DIR);
 
   try {
+    mkdirSync(invokerHomeRoot, { recursive: true });
     mkdirSync(lockDir);
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
@@ -28,10 +29,12 @@ export function tryAcquireOwnerBootstrapLock(invokerHomeRoot: string): OwnerBoot
           return tryAcquireOwnerBootstrapLock(invokerHomeRoot);
         }
       }
+      rmSync(lockDir, { recursive: true, force: true });
+      return tryAcquireOwnerBootstrapLock(invokerHomeRoot);
     } catch {
-      return null;
+      rmSync(lockDir, { recursive: true, force: true });
+      return tryAcquireOwnerBootstrapLock(invokerHomeRoot);
     }
-    return null;
   }
 
   writeFileSync(join(lockDir, 'pid'), String(process.pid), 'utf8');

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -53,6 +53,21 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     getTaskDeltaStreamSequence,
   } = context;
 
+  async function delegateOwnerQuery<T>(kind: string, request: Record<string, unknown> = {}): Promise<T | null> {
+    if (getOwnerMode?.() !== false) return null;
+    try {
+      return await getMessageBus?.().request<Record<string, unknown>, T>('headless.query', { kind, ...request }) ?? null;
+    } catch (err) {
+      logger.warn(
+        `${kind} owner delegation failed; falling back to local read-only snapshot: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { module: 'ipc' },
+      );
+      return null;
+    }
+  }
+
   ipcMain.handle('invoker:list-workflows', () => persistence.listWorkflows());
   ipcMain.handle('invoker:get-execution-pools', () => Object.keys(loadConfig().executionPools ?? {}));
 
@@ -76,48 +91,37 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
   ipcMain.handle('invoker:get-tasks', async (_event, forceRefresh?: boolean) => {
     const startedAtMs = Date.now();
     const orchestrator = getOrchestrator();
-    if (forceRefresh && getOwnerMode?.() === false) {
-      try {
-        const delegated = await getMessageBus?.().request<{ kind: string; forceRefresh: boolean }, {
-          tasks: TaskState[];
-          workflows: unknown[];
-          streamSequence: number;
-        }>('headless.query', { kind: 'tasks', forceRefresh: true });
-        if (delegated && Array.isArray(delegated.tasks) && Array.isArray(delegated.workflows)) {
-          const previousTaskIds = new Set(lastKnownTaskStates.keys());
-          lastKnownTaskStates.clear();
-          for (const task of delegated.tasks) {
-            lastKnownTaskStates.set(task.id, JSON.stringify(task));
-            previousTaskIds.delete(task.id);
-            const mainWindow = getMainWindow();
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              sendTaskDeltaToRenderer({ type: 'created', task });
-            }
-          }
-          const mainWindow = getMainWindow();
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            for (const removedTaskId of previousTaskIds) {
-              sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
-            }
-            requestWorkflowMetadataPublish('get-tasks-force-refresh-delegated');
-          }
-          setLastKnownWorkflowCount(delegated.workflows.length);
-          recordStartupDuration('get-tasks.force-refresh.delegated-return', startedAtMs, {
-            taskCount: delegated.tasks.length,
-            workflowCount: delegated.workflows.length,
-            jsonSizeBytes: Buffer.byteLength(JSON.stringify(delegated), 'utf8'),
-            streamSequence: delegated.streamSequence,
-          });
-          return delegated;
+    const delegated = await delegateOwnerQuery<{
+      tasks: TaskState[];
+      workflows: unknown[];
+      streamSequence: number;
+    }>('tasks', { forceRefresh: forceRefresh === true });
+    if (delegated && Array.isArray(delegated.tasks) && Array.isArray(delegated.workflows)) {
+      const previousTaskIds = new Set(lastKnownTaskStates.keys());
+      lastKnownTaskStates.clear();
+      for (const task of delegated.tasks) {
+        lastKnownTaskStates.set(task.id, JSON.stringify(task));
+        previousTaskIds.delete(task.id);
+        const mainWindow = getMainWindow();
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          sendTaskDeltaToRenderer({ type: 'created', task });
         }
-      } catch (err) {
-        logger.warn(
-          `get-tasks(forceRefresh=true) owner delegation failed; falling back to local read-only snapshot: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-          { module: 'ipc' },
-        );
       }
+      const mainWindow = getMainWindow();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        for (const removedTaskId of previousTaskIds) {
+          sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
+        }
+        requestWorkflowMetadataPublish(forceRefresh ? 'get-tasks-force-refresh-delegated' : 'get-tasks-delegated');
+      }
+      setLastKnownWorkflowCount(delegated.workflows.length);
+      recordStartupDuration(forceRefresh ? 'get-tasks.force-refresh.delegated-return' : 'get-tasks.delegated-return', startedAtMs, {
+        taskCount: delegated.tasks.length,
+        workflowCount: delegated.workflows.length,
+        jsonSizeBytes: Buffer.byteLength(JSON.stringify(delegated), 'utf8'),
+        streamSequence: delegated.streamSequence,
+      });
+      return delegated;
     }
     if (forceRefresh) {
       timeStartupPhase('get-tasks.force-refresh.syncAllFromDb', () => orchestrator.syncAllFromDb(), () => ({
@@ -163,7 +167,9 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
   });
 
   ipcMain.handle('invoker:get-events', (_event, taskId: string) => persistence.getEvents(taskId));
-  ipcMain.handle('invoker:get-status', () => getOrchestrator().getWorkflowStatus());
+  ipcMain.handle('invoker:get-status', async () => (
+    await delegateOwnerQuery('workflow-status') ?? getOrchestrator().getWorkflowStatus()
+  ));
   ipcMain.handle('invoker:get-task-by-id', (_event, taskId: string) => loadTaskByIdFromPersistence(taskId) ?? null);
   ipcMain.handle('invoker:get-task-output', (_event, taskId: string) => persistence.getTaskOutput(taskId));
   ipcMain.handle('invoker:get-output-chunks', (_event, taskId: string) => persistence.getOutputChunks(taskId));

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -189,6 +189,11 @@ import {
   type HeadlessExecMutationPayload,
 } from './headless-batch-exec.js';
 import {
+  spawnDetachedStandaloneOwner,
+  tryAcquireOwnerBootstrapLock,
+} from './headless-owner-bootstrap.js';
+import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
+import {
   rebuildTaskRunner as rebuildTaskRunnerWiring,
   requireWiredTaskRunner,
   type TaskHandleMap,
@@ -295,6 +300,26 @@ interface HeadlessResumeMutationPayload {
 }
 
 type HeadlessOwnerMode = 'standalone' | 'gui';
+type GuiOwnerPreference = 'auto' | 'daemon' | 'gui';
+
+function resolveGuiOwnerPreference(): GuiOwnerPreference {
+  const raw = (process.env.INVOKER_GUI_OWNER_MODE ?? '').trim().toLowerCase();
+  if (raw === 'daemon' || raw === 'client' || raw === 'follower') return 'daemon';
+  if (raw === 'auto') return 'auto';
+  if (raw === 'gui' || raw === 'owner' || raw === 'local') return 'gui';
+  if (process.env.INVOKER_GUI_DAEMON_OWNER === '1') return 'daemon';
+  return 'daemon';
+}
+
+function guiOwnerBootstrapTimeoutMs(): number {
+  const parsed = Number.parseInt(
+    process.env.INVOKER_GUI_OWNER_BOOTSTRAP_TIMEOUT_MS
+      ?? process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS
+      ?? '60000',
+    10,
+  );
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60000;
+}
 
 function headlessExecLogFields(
   payload: HeadlessExecMutationPayload,
@@ -387,6 +412,49 @@ const invokerConfig: InvokerConfig = (() => {
   }
 })();
 
+async function discoverStandaloneOwnerForGui(waitMs: number): Promise<boolean> {
+  let ownerBus = new IpcBus(undefined, { allowServe: false });
+  try {
+    await ownerBus.ready();
+    const deadline = Date.now() + waitMs;
+    while (Date.now() < deadline) {
+      const owner = await discoverOwner(ownerBus, 500);
+      if (isStandaloneCapable(owner)) {
+        logger.info(`daemon owner ready ownerId=${owner.ownerId}`, { module: 'init' });
+        return true;
+      }
+      ownerBus.disconnect();
+      ownerBus = new IpcBus(undefined, { allowServe: false });
+      await ownerBus.ready();
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    return false;
+  } finally {
+    ownerBus.disconnect();
+  }
+}
+
+async function ensureStandaloneOwnerForGui(): Promise<void> {
+  if (await discoverStandaloneOwnerForGui(2_000)) return;
+
+  const invokerHomeRoot = resolveInvokerHomeRoot();
+  const timeoutMs = guiOwnerBootstrapTimeoutMs();
+  const bootstrapLock = tryAcquireOwnerBootstrapLock(invokerHomeRoot);
+  try {
+    if (bootstrapLock) {
+      logger.info('spawning daemon owner for GUI client mode', { module: 'init' });
+      spawnDetachedStandaloneOwner(repoRoot);
+    } else {
+      logger.info('waiting for daemon owner bootstrap held by another process', { module: 'init' });
+    }
+    if (await discoverStandaloneOwnerForGui(timeoutMs)) return;
+  } finally {
+    bootstrapLock?.release();
+  }
+
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for daemon owner`);
+}
+
 function getSafeInvokerConfigForLogging(config: InvokerConfig): Record<string, unknown> {
   const safeConfig = { ...config } as Record<string, unknown> & {
     docker?: InvokerConfig['docker'];
@@ -448,10 +516,14 @@ function installPackagedSkills(mode: import('@invoker/contracts').BundledSkillsI
 }
 
 async function initServices(options?: InitServicesOptions): Promise<void> {
-  messageBus = new IpcBus();
   const invokerHomeRoot = resolveInvokerHomeRoot();
   mkdirSync(invokerHomeRoot, { recursive: true });
   const readOnly = options?.readOnly === true;
+  const previousMessageBus = typeof messageBus === 'undefined' ? null : messageBus;
+  previousMessageBus?.disconnect();
+  const serviceMessageBus = new IpcBus(undefined, { allowServe: !readOnly });
+  await serviceMessageBus.ready();
+  messageBus = serviceMessageBus;
   const dbPath = path.join(invokerHomeRoot, 'invoker.db');
   if (!readOnly) {
     writerLock = acquireDbWriterLock(dbPath, `main:initServices pid=${process.pid}`);
@@ -906,6 +978,33 @@ if (isHeadless) {
 
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
         switch (payload.channel) {
+          case 'invoker:clear': {
+            logger.info('clear — stopping all tasks and resetting daemon DAG', { module: 'ipc-delegate' });
+            await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: undefined });
+            await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
+            orchestrator = new Orchestrator({
+              persistence,
+              messageBus,
+              taskRepository: new SqliteTaskRepository(persistence),
+              maxConcurrency: effectiveMaxConcurrency,
+              defaultAutoFixRetries: invokerConfig.autoFixRetries,
+              executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
+              defaultPoolId: invokerConfig.defaultPoolId,
+              availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
+              deferRunningUntilLaunch: true,
+              launchOutboxMode: invokerConfig.launchOutboxMode,
+            });
+            commandService = new CommandService(
+              orchestrator,
+              buildInvalidationDeps({
+                logger,
+                orchestrator,
+                persistence,
+                taskExecutor: () => latestTaskExecutor,
+              }),
+            );
+            return undefined;
+          }
           case 'invoker:load-plan': {
             const planText = String(payload.args[0] ?? '');
             const { parsePlan } = await import('./plan-parser.js');
@@ -919,6 +1018,40 @@ if (isHeadless) {
             const started = orchestrator.startExecution();
             await executor.executeTasks(started);
             return started;
+          }
+          case 'invoker:stop': {
+            logger.info('stop — destroying all daemon executors', { module: 'ipc-delegate' });
+            const failInFlightTasks = (): void => {
+              const allTasks = orchestrator.getAllTasks();
+              for (const task of allTasks) {
+                if (isTaskInFlightForForcedStop(task)) {
+                  logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc-delegate' });
+                  orchestrator.handleWorkerResponse({
+                    requestId: `stop-${task.id}`,
+                    actionId: task.id,
+                    attemptId: task.execution.selectedAttemptId,
+                    executionGeneration: task.execution.generation ?? 0,
+                    status: 'failed',
+                    outputs: { exitCode: 1, error: 'Stopped by user' },
+                  });
+                }
+              }
+            };
+            failInFlightTasks();
+            await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
+            failInFlightTasks();
+            return undefined;
+          }
+          case 'invoker:inject-task-states': {
+            if (process.env.NODE_ENV !== 'test') {
+              throw new Error('inject-task-states is only available in tests');
+            }
+            const updates = payload.args[0] as Array<{ taskId: string; changes: TaskStateChanges }>;
+            for (const { taskId, changes } of updates) {
+              persistence.updateTask(taskId, changes);
+            }
+            orchestrator.syncAllFromDb();
+            return undefined;
           }
           case 'invoker:set-merge-branch': {
             const workflowId = String(payload.args[0]);
@@ -1004,7 +1137,7 @@ if (isHeadless) {
       // In standalone owner mode, serve delegated requests from peer headless processes.
       if (standaloneMode && messageBus) {
         const standaloneOwnerIdleTimeoutMs = Number.parseInt(
-          process.env.INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '2000',
+          process.env.INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '0',
           10,
         );
         let standaloneOwnerLastActivityAt = Date.now();
@@ -1012,6 +1145,9 @@ if (isHeadless) {
           standaloneOwnerLastActivityAt = Date.now();
         };
         headlessDeps.isStandaloneOwnerIdle = () => {
+          if (!Number.isFinite(standaloneOwnerIdleTimeoutMs) || standaloneOwnerIdleTimeoutMs <= 0) {
+            return false;
+          }
           const idleForMs = Date.now() - standaloneOwnerLastActivityAt;
           if (idleForMs < standaloneOwnerIdleTimeoutMs) return false;
           const hasQueuedOrRunningMutations =
@@ -1211,6 +1347,9 @@ if (isHeadless) {
           if (kind === 'queue') {
             return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
           }
+          if (kind === 'workflow-status') {
+            return orchestrator.getWorkflowStatus();
+          }
           if (kind === 'tasks') {
             if ((req as { forceRefresh?: boolean }).forceRefresh) {
               orchestrator.syncAllFromDb();
@@ -1280,6 +1419,10 @@ if (isHeadless) {
             });
           });
           return { ok: true };
+        });
+        messageBus.onRequest('headless.gui-mutation', async (req: unknown) => {
+          noteStandaloneOwnerActivity();
+          return executeStandaloneGuiMutation(req as GuiMutationPayload);
         });
 
         reviewGateStatusWorker = startReviewGateStatusWorker({
@@ -2208,16 +2351,21 @@ function createEmbeddedTerminalBackendFromConfig(
   }
 
   function translateGuiMutationToHeadless(payload: GuiMutationPayload):
+    | { channel: 'headless.gui-mutation'; request: GuiMutationPayload }
     | { channel: 'headless.run'; request: HeadlessRunMutationPayload }
     | { channel: 'headless.resume'; request: HeadlessResumeMutationPayload }
     | { channel: 'headless.exec'; request: HeadlessExecMutationPayload }
     | null {
     const [arg0, arg1, arg2] = payload.args;
     switch (payload.channel) {
+      case 'invoker:load-plan':
+        return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:start':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:stop':
-        return { channel: 'headless.exec', request: { args: ['stop'] } };
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:clear':
-        return { channel: 'headless.exec', request: { args: ['clear'] } };
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
         const workflows = persistence.listWorkflows();
         const workflowId = workflows[0]?.id;
@@ -2714,22 +2862,62 @@ function createEmbeddedTerminalBackendFromConfig(
 
   const runGuiReadyBootstrap = async (): Promise<void> => {
     recordStartupMark('app.whenReady');
-    ownerMode = true;
-    try {
-      recordStartupMark('initServices.start');
-      await initServices({ executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
-      recordStartupMark('initServices.end', { ownerMode: true });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (!message.includes('[db-writer-lock]')) {
+    const guiOwnerPreference = resolveGuiOwnerPreference();
+    let daemonGuiOwner = false;
+    if (guiOwnerPreference === 'daemon') {
+      try {
+        recordStartupMark('daemonOwner.ensure.start');
+        await ensureStandaloneOwnerForGui();
+        recordStartupMark('daemonOwner.ensure.end');
+        daemonGuiOwner = true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
         process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
         app.quit();
         return;
       }
-      recordStartupMark('initServices.readOnly.start');
-      await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+    } else if (guiOwnerPreference === 'auto') {
+      recordStartupMark('daemonOwner.discover.start');
+      try {
+        daemonGuiOwner = await discoverStandaloneOwnerForGui(1_000);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(`daemon owner auto-discovery failed; starting GUI owner locally: ${message}`, { module: 'init' });
+        daemonGuiOwner = false;
+      }
+      recordStartupMark('daemonOwner.discover.end', { daemonOwner: daemonGuiOwner });
+    }
+
+    if (daemonGuiOwner) {
       ownerMode = false;
-      recordStartupMark('initServices.readOnly.end', { ownerMode: false });
+      try {
+        recordStartupMark('initServices.readOnly.start');
+        await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+        recordStartupMark('initServices.readOnly.end', { ownerMode: false, daemonOwner: true });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
+        app.quit();
+        return;
+      }
+    } else {
+      ownerMode = true;
+      try {
+        recordStartupMark('initServices.start');
+        await initServices({ executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+        recordStartupMark('initServices.end', { ownerMode: true });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (!message.includes('[db-writer-lock]')) {
+          process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
+          app.quit();
+          return;
+        }
+        recordStartupMark('initServices.readOnly.start');
+        await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+        ownerMode = false;
+        recordStartupMark('initServices.readOnly.end', { ownerMode: false });
+      }
     }
 
     if (ownerMode) {
@@ -2807,6 +2995,9 @@ function createEmbeddedTerminalBackendFromConfig(
         }
         if (kind === 'queue') {
           return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+        }
+        if (kind === 'workflow-status') {
+          return orchestrator.getWorkflowStatus();
         }
         if (kind === 'tasks') {
           if ((req as { forceRefresh?: boolean }).forceRefresh) {
@@ -3005,32 +3196,42 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     if (process.env.NODE_ENV === 'test') {
+      const injectTaskStates = async (updates: Array<{ taskId: string; changes: TaskStateChanges }>): Promise<void> => {
+        for (const { taskId, changes } of updates) {
+          const before = orchestrator.getTask(taskId);
+          const previousSnapshot = lastKnownTaskStates.get(taskId);
+          const previousTaskStateVersion = previousSnapshot
+            ? (
+                (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
+                ?? before?.taskStateVersion
+                ?? 1
+              )
+            : (before?.taskStateVersion ?? 0);
+          persistence.updateTask(taskId, changes);
+          messageBus.publish(Channels.TASK_DELTA, {
+            type: 'updated',
+            taskId,
+            changes,
+            previousTaskStateVersion,
+            taskStateVersion: previousTaskStateVersion + 1,
+          } satisfies TaskDelta);
+        }
+        orchestrator.syncAllFromDb();
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          requestWorkflowMetadataPublish('gap-detect');
+        }
+      };
       ipcMain.handle(
         'invoker:inject-task-states',
         async (_event, updates: Array<{ taskId: string; changes: TaskStateChanges }>) => {
-          for (const { taskId, changes } of updates) {
-            const before = orchestrator.getTask(taskId);
-            const previousSnapshot = lastKnownTaskStates.get(taskId);
-            const previousTaskStateVersion = previousSnapshot
-              ? (
-                  (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
-                  ?? before?.taskStateVersion
-                  ?? 1
-                )
-              : (before?.taskStateVersion ?? 0);
-            persistence.updateTask(taskId, changes);
-            messageBus.publish(Channels.TASK_DELTA, {
-              type: 'updated',
-              taskId,
-              changes,
-              previousTaskStateVersion,
-              taskStateVersion: previousTaskStateVersion + 1,
-            } satisfies TaskDelta);
+          if (!ownerMode) {
+            await messageBus.request('headless.gui-mutation', {
+              channel: 'invoker:inject-task-states',
+              args: [updates],
+            } satisfies GuiMutationPayload);
+            return;
           }
-          orchestrator.syncAllFromDb();
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            requestWorkflowMetadataPublish('gap-detect');
-          }
+          await injectTaskStates(updates);
         },
       );
     }
@@ -3108,15 +3309,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
     registerGuiMutationHandler('invoker:clear', async () => {
       logger.info('clear — stopping all tasks and resetting DAG', { module: 'ipc' });
-      const workflows = persistence.listWorkflows();
-
-      for (const workflow of workflows) {
-        try {
-          await performCancelWorkflow(workflow.id);
-        } catch (err) {
-          logger.error(`clear: failed to cancel workflow "${workflow.id}": ${err}`, { module: 'ipc' });
-        }
-      }
+      await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
 
       orchestrator = new Orchestrator({
@@ -3142,6 +3335,9 @@ function createEmbeddedTerminalBackendFromConfig(
       );
       rebuildTaskRunner();
       taskHandles.clear();
+      lastKnownTaskStates.clear();
+      lastKnownWorkflowCount = 0;
+      requestWorkflowMetadataPublish('clear');
     });
 
     registerReadOnlyIpcHandlers({

--- a/packages/app/src/owner-resolver.ts
+++ b/packages/app/src/owner-resolver.ts
@@ -40,6 +40,8 @@ export interface OwnerResolverDeps {
   refreshMessageBus?: () => Promise<MessageBus>;
   /** Bootstrap a standalone owner process. */
   ensureStandaloneOwner: (bus: MessageBus) => Promise<void>;
+  /** Whether a bootstrap error should be treated as a failed attempt and retried. */
+  isRetryableBootstrapError?: (error: unknown) => boolean;
 }
 
 // ── Configuration ───────────────────────────────────────────
@@ -133,6 +135,13 @@ export function createOwnerResolver(
     return { resolved: true, owner, bus };
   }
 
+  function acceptsOwner(
+    owner: OwnerDiscoveryResult,
+    requireStandalone: boolean,
+  ): owner is OwnerEndpointInfo {
+    return requireStandalone ? isStandaloneCapable(owner) : isOwnerReachable(owner);
+  }
+
   const resolver: OwnerResolver = {
     async discover(): Promise<OwnerResolveResult> {
       const owner = await discoverOwner(currentBus, discoveryTimeoutMs);
@@ -179,18 +188,32 @@ export function createOwnerResolver(
     async resolve(requireStandalone = true): Promise<ResolvedOwner> {
       // Phase 1: Try immediate discovery
       const immediate = await discoverOwner(currentBus, discoveryTimeoutMs);
-      if (requireStandalone ? isStandaloneCapable(immediate) : isOwnerReachable(immediate)) {
-        return { owner: immediate!, bus: currentBus };
+      if (acceptsOwner(immediate, requireStandalone)) {
+        return { owner: immediate, bus: currentBus };
       }
 
       // Phase 2: Refresh and retry
       if (deps.refreshMessageBus) {
         currentBus = await deps.refreshMessageBus();
+        const refreshed = await discoverOwner(currentBus, refreshDiscoveryTimeoutMs);
+        if (acceptsOwner(refreshed, requireStandalone)) {
+          return { owner: refreshed, bus: currentBus };
+        }
       }
 
       // Phase 3: Bootstrap with retry loop
       for (let attempt = 0; attempt < maxBootstrapAttempts; attempt += 1) {
-        await deps.ensureStandaloneOwner(currentBus);
+        try {
+          await deps.ensureStandaloneOwner(currentBus);
+        } catch (error) {
+          if (!deps.isRetryableBootstrapError?.(error)) {
+            throw error;
+          }
+          if (deps.refreshMessageBus) {
+            currentBus = await deps.refreshMessageBus();
+          }
+          continue;
+        }
 
         if (deps.refreshMessageBus) {
           currentBus = await deps.refreshMessageBus();

--- a/scripts/repro/repro-daemon-clear-does-not-rehydrate.sh
+++ b/scripts/repro/repro-daemon-clear-does-not-rehydrate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Repro: GUI clear in daemon-owner mode must purge durable workflow state.
+#
+# Root cause guarded here:
+#   `invoker:clear` used to reset only the in-memory DAG. With GUI daemon-owner
+#   reads, the next snapshot could rehydrate tasks from SQLite, so the UI still
+#   saw old tasks after clear.
+#
+# Fixed behavior:
+#   `window.invoker.clear()` leaves the task list empty in the renderer.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/ui build
+pnpm --filter @invoker/app build
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec pnpm --filter @invoker/app exec xvfb-run --auto-servernum playwright test \
+    e2e/workflow-lifecycle.spec.ts \
+    -g 'clear resets task state via IPC'
+fi
+
+exec pnpm --filter @invoker/app exec playwright test \
+  e2e/workflow-lifecycle.spec.ts \
+  -g 'clear resets task state via IPC'

--- a/scripts/repro/repro-daemon-owner-routing.sh
+++ b/scripts/repro/repro-daemon-owner-routing.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: GUI/headless mutations must route through one standalone daemon owner.
+#
+# Root cause guarded here:
+#   A GUI process that opens the SQLite DB as the mutation owner can race with
+#   headless submitters and other GUI instances. In daemon-owner mode the GUI
+#   must become a read-only client and delegate write IPC to the shared owner.
+#
+# Fixed behavior:
+#   The owner bootstrap/thundering-herd e2e proves peer clients converge on one
+#   standalone-capable owner instead of stealing the IPC socket or DB writer.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/app build
+exec scripts/repro/repro-headless-thundering-herd.sh


### PR DESCRIPTION
## Summary

Routes GUI and headless write mutations through a standalone daemon owner so the GUI runs as a read-only client by default.

Keeps durable clear behavior in the same PR because daemon-mode clear must not rehydrate deleted workflow state from SQLite.

## Architecture

### Before

```mermaid
graph TD
    GUI[GUI process] --> DB[(SQLite writer)]
    Headless[Headless submitter] --> Owner[Ad hoc owner]
```

### After

```mermaid
graph TD
    GUI[Read-only GUI client] --> Owner[Standalone daemon owner]
    Headless[Headless submitter] --> Owner
    Owner --> DB[(SQLite writer)]
```

## Test Plan

- [x] `pnpm --filter @invoker/app build`
- [x] `scripts/repro/repro-daemon-owner-routing.sh`
- [x] `scripts/repro/repro-daemon-clear-does-not-rehydrate.sh`

## Revert Plan

- Safe to revert? No, downstream daemon-owner fixes depend on this routing.
- Revert command: `git revert e33e72136`
- Post-revert steps: Revert dependent stacked PRs first.
- Data migration? No

Depends-On: #1120