### PR TITLE
fix(app): keep owner alive for launch handoff

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1117,7 +1117,7 @@ describe('headless delegation enforcement', () => {
         expect((mockDeps.persistence as any).markLaunchDispatchCompleted).toHaveBeenCalledWith(77);
       });
 
-      it('headless task retry in no-track active outbox mode rejects transient launch ownership', async () => {
+      it('headless task retry in no-track active outbox mode accepts durable launch handoff without transient launch ownership', async () => {
         const preemptTaskSubgraph = vi.fn(async () => {});
         const runnableTask = {
           id: '__merge__wf-1778826126740-7',
@@ -1181,7 +1181,7 @@ describe('headless delegation enforcement', () => {
               noTrack: true,
               preemptTaskSubgraph,
             } as HeadlessDeps),
-          ).rejects.toThrow(/refusing to consume launch dispatches with a transient headless runner/);
+          ).resolves.toBeUndefined();
           expect((mockDeps.persistence as any).claimLaunchDispatchAtomic).not.toHaveBeenCalled();
           expect((mockDeps.persistence as any).markLaunchDispatchCompleted).not.toHaveBeenCalled();
           expect(executeTaskSpy).not.toHaveBeenCalled();

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -368,17 +368,37 @@ async function dispatchNoTrackRunnableTasks(
 ): Promise<void> {
   if (deps.invokerConfig.launchOutboxMode === 'active') {
     const ownerTaskExecutor = deps.ownerTaskRunnerProvider?.() ?? null;
-    if (!ownerTaskExecutor) {
+    if (ownerTaskExecutor) {
+      await dispatchHeadlessRunnableTasks(deps, ownerTaskExecutor, runnable, context, {
+        waitForLaunchHandoff: true,
+      });
+      return;
+    }
+
+    const expectedAttemptIds = new Set(
+      runnable
+        .map((task) => task.execution.selectedAttemptId?.trim())
+        .filter((attemptId): attemptId is string => !!attemptId),
+    );
+    const hasDurableDispatch = expectedAttemptIds.size > 0
+      && (deps.persistence.listLaunchDispatchesByState?.(['enqueued', 'leased']) ?? [])
+        .some((row) => expectedAttemptIds.has(row.attemptId));
+    if (hasDurableDispatch) {
+      deps.logger.info(
+        `${context}: launchOutboxMode=active and no owner TaskRunner in this process; ` +
+        'leaving durable launch dispatches for the owner dispatcher.',
+        { module: 'headless' },
+      );
+      return;
+    }
+
+    if (!deps.deferRunnableTasks) {
       throw new Error(
         'Cannot dispatch --no-track runnable tasks in active launch-outbox mode without ' +
         'deferRunnableTasks or an owner TaskRunner; refusing to consume launch dispatches ' +
         'with a transient headless runner.',
       );
     }
-    await dispatchHeadlessRunnableTasks(deps, ownerTaskExecutor, runnable, context, {
-      waitForLaunchHandoff: true,
-    });
-    return;
   }
 
   if (deps.deferRunnableTasks) {
@@ -1296,7 +1316,6 @@ async function headlessOwnerServe(deps: Pick<HeadlessDeps, 'isStandaloneOwnerIdl
         finish();
       }
     }, idlePollMs);
-    idleTimer.unref?.();
     process.once('SIGTERM', finish);
     process.once('SIGINT', finish);
   });

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1153,6 +1153,9 @@ if (isHeadless) {
           const hasQueuedOrRunningMutations =
             persistence.listWorkflowMutationIntents(undefined, ['queued', 'running']).length > 0;
           if (hasQueuedOrRunningMutations) return false;
+          const hasActiveLaunchDispatches =
+            persistence.listLaunchDispatchesByState?.(['enqueued', 'leased']).length > 0;
+          if (hasActiveLaunchDispatches) return false;
           return !orchestrator.getAllTasks().some(
             (task) => task.status === 'running' || task.status === 'fixing_with_ai',
           );

--- a/scripts/repro/repro-retry-loop-managed-owner-survives-launcher-exit.sh
+++ b/scripts/repro/repro-retry-loop-managed-owner-survives-launcher-exit.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/headless-lib.sh
+source "$ROOT_DIR/scripts/headless-lib.sh"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-managed-owner-survives.XXXXXX")"
+owner_pid_file="$tmpdir/owner.pid"
+owner_log="$tmpdir/owner.log"
+db_dir="$tmpdir/db"
+socket_path="$tmpdir/ipc.sock"
+config_path="$tmpdir/config.json"
+
+cleanup() {
+  if [ -s "$owner_pid_file" ]; then
+    kill "$(cat "$owner_pid_file")" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+cat > "$config_path" <<'JSON'
+{
+  "allowGraphMutation": true,
+  "disableAutoRunOnStartup": true,
+  "launchOutboxMode": "active"
+}
+JSON
+mkdir -p "$db_dir"
+
+wait_for_log() {
+  local deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    if [ -f "$owner_log" ] && grep -Fq "standalone owner ready" "$owner_log"; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for standalone owner readiness" >&2
+  [ -f "$owner_log" ] && tail -80 "$owner_log" >&2
+  return 1
+}
+
+owner_ping() {
+  INVOKER_IPC_SOCKET="$socket_path" node --input-type=module <<'NODE'
+import { IpcBus } from './packages/transport/dist/index.js';
+const bus = new IpcBus(undefined, { allowServe: false, requestDeadlineMs: 1000 });
+try {
+  await bus.ready();
+  const response = await bus.request('headless.owner-ping', {});
+  if (!response || response.ok !== true) {
+    throw new Error(`unexpected response: ${JSON.stringify(response)}`);
+  }
+} finally {
+  bus.disconnect();
+}
+NODE
+}
+
+(
+  cd "$ROOT_DIR"
+  env \
+    INVOKER_DB_DIR="$db_dir" \
+    INVOKER_IPC_SOCKET="$socket_path" \
+    INVOKER_REPO_CONFIG_PATH="$config_path" \
+    INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS=60000 \
+    INVOKER_HEADLESS_STANDALONE=1 \
+    nohup "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless owner-serve > "$owner_log" 2>&1 &
+  printf '%s\n' "$!" > "$owner_pid_file"
+)
+
+wait_for_log
+sleep 1
+
+if ! kill -0 "$(cat "$owner_pid_file")" >/dev/null 2>&1; then
+  echo "managed owner exited after launcher shell returned" >&2
+  tail -80 "$owner_log" >&2 || true
+  exit 1
+fi
+
+if ! owner_ping; then
+  echo "managed owner did not answer owner-ping after launcher shell returned" >&2
+  tail -80 "$owner_log" >&2 || true
+  exit 1
+fi
+
+cat <<EOF
+PASS: retry-loop managed owner survives launcher shell exit.
+
+owner_pid=$(cat "$owner_pid_file")
+db_dir=$db_dir
+socket_path=$socket_path
+
+Root cause guarded: a retry-loop helper that backgrounds owner-serve must detach
+it from the helper shell, otherwise submitted launch-dispatch rows can be left
+without a live dispatcher after the helper exits.
+EOF

--- a/scripts/repro/repro-standalone-owner-idle-ignores-active-launch-dispatch.sh
+++ b/scripts/repro/repro-standalone-owner-idle-ignores-active-launch-dispatch.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-owner-idle-launch-dispatch.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+db="$tmpdir/repro.db"
+
+sqlite3 "$db" <<'SQL'
+CREATE TABLE tasks (
+  id TEXT PRIMARY KEY,
+  status TEXT NOT NULL
+);
+
+CREATE TABLE workflow_mutation_intents (
+  id INTEGER PRIMARY KEY,
+  status TEXT NOT NULL
+);
+
+CREATE TABLE task_launch_dispatch (
+  id INTEGER PRIMARY KEY,
+  task_id TEXT NOT NULL,
+  state TEXT NOT NULL
+);
+
+INSERT INTO tasks (id, status)
+VALUES ('wf-repro/launching-task', 'pending');
+
+INSERT INTO task_launch_dispatch (id, task_id, state)
+VALUES
+  (1, 'wf-repro/launching-task', 'enqueued'),
+  (2, 'wf-repro/launching-task', 'leased');
+SQL
+
+old_idle="$(sqlite3 "$db" <<'SQL'
+SELECT CASE
+  WHEN EXISTS (
+    SELECT 1
+    FROM workflow_mutation_intents
+    WHERE status IN ('queued', 'running')
+  ) THEN 'false'
+  WHEN EXISTS (
+    SELECT 1
+    FROM tasks
+    WHERE status IN ('running', 'fixing_with_ai')
+  ) THEN 'false'
+  ELSE 'true'
+END;
+SQL
+)"
+
+fixed_idle="$(sqlite3 "$db" <<'SQL'
+SELECT CASE
+  WHEN EXISTS (
+    SELECT 1
+    FROM workflow_mutation_intents
+    WHERE status IN ('queued', 'running')
+  ) THEN 'false'
+  WHEN EXISTS (
+    SELECT 1
+    FROM task_launch_dispatch
+    WHERE state IN ('enqueued', 'leased')
+  ) THEN 'false'
+  WHEN EXISTS (
+    SELECT 1
+    FROM tasks
+    WHERE status IN ('running', 'fixing_with_ai')
+  ) THEN 'false'
+  ELSE 'true'
+END;
+SQL
+)"
+
+active_dispatches="$(sqlite3 "$db" <<'SQL'
+SELECT COUNT(*)
+FROM task_launch_dispatch
+WHERE state IN ('enqueued', 'leased');
+SQL
+)"
+
+pending_launching_tasks="$(sqlite3 "$db" <<'SQL'
+SELECT COUNT(*)
+FROM tasks
+WHERE status = 'pending';
+SQL
+)"
+
+if [ "$active_dispatches" != "2" ]; then
+  echo "expected two active launch dispatch rows, got $active_dispatches" >&2
+  exit 1
+fi
+
+if [ "$pending_launching_tasks" != "1" ]; then
+  echo "expected one pending launching task, got $pending_launching_tasks" >&2
+  exit 1
+fi
+
+if [ "$old_idle" != "true" ]; then
+  echo "expected old idle predicate to wrongly report idle, got $old_idle" >&2
+  exit 1
+fi
+
+if [ "$fixed_idle" != "false" ]; then
+  echo "expected fixed idle predicate to stay non-idle, got $fixed_idle" >&2
+  exit 1
+fi
+
+cat <<EOF
+PASS: standalone owner idle must account for active launch dispatch rows.
+
+pending_launching_tasks=$pending_launching_tasks
+active_launch_dispatch_rows=$active_dispatches
+old_idle_predicate=$old_idle
+fixed_idle_predicate=$fixed_idle
+
+Root cause reproduced: launch-outbox tasks can remain pending while their
+task_launch_dispatch rows are enqueued or leased. An owner idle predicate that
+only checks running/fixing tasks can exit and leave no dispatcher to consume them.
+EOF


### PR DESCRIPTION
## Summary

Keeps the owner process alive long enough to finish launch handoff.

Managed owner startup now survives launcher exit and active dispatch rows.

## Architecture

### Before

```mermaid
flowchart LR
  Launcher --> Owner[managed owner]
  Launcher --> Exit[exits]
  Owner --> Stop[may stop before handoff]
```

### After

```mermaid
flowchart LR
  Launcher --> Owner[managed owner]
  Owner --> Dispatch[active launch dispatch]
  Dispatch --> Handoff[durable handoff]
```

## Test Plan

- [x] `mergify stack push -t upstream/master --branch-prefix stack/EdbertChan`
- [x] `mergify stack list -t upstream/master --json`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-delegation.test.ts -t "durable launch handoff|active outbox mode"`
- [x] `bash scripts/repro/repro-retry-loop-managed-owner-survives-launcher-exit.sh`
- [x] `bash scripts/repro/repro-standalone-owner-idle-ignores-active-launch-dispatch.sh`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert cd6e25d8f3dfa29a9cf2e3b6aae46066e5594d96`
- Post-revert steps: Re-run the affected retry/repro validation if reverting after landing.
- Data migration? No

Depends-On: #1112