### PR TITLE
fix(execution): guard launch handoff and git hangs

### DIFF
--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -203,6 +203,34 @@ describe('TaskRunner launch-dispatch wiring', () => {
     await run;
   });
 
+  it('completes the dispatch only after the completion listener is registered', async () => {
+    const task = makeTask();
+    const env = buildRunnerEnv(task);
+    const originalOnComplete = env.executor.onComplete.getMockImplementation();
+    const order: string[] = [];
+    env.executor.onComplete.mockImplementation((handle: unknown, cb: unknown) => {
+      order.push('onComplete');
+      return originalOnComplete?.(handle, cb);
+    });
+    const launchOutbox: LaunchOutboxAck = {
+      completeDispatch(id) {
+        expect(id).toBe(77);
+        order.push('completeDispatch');
+        return true;
+      },
+      failDispatch: vi.fn().mockReturnValue(true),
+      renewDispatch: vi.fn().mockReturnValue(true),
+    };
+
+    const run = env.runner.executeTask(task, { dispatchId: 77, launchOutbox });
+    await vi.waitFor(() => expect(order).toContain('completeDispatch'));
+
+    expect(order).toEqual(['onComplete', 'completeDispatch']);
+
+    env.triggerComplete();
+    await run;
+  });
+
   it('fails the dispatch when markTaskRunningAfterLaunch rejects the launch', async () => {
     const task = makeTask();
     const env = buildRunnerEnv(task);

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -1,5 +1,5 @@
 import { execSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
@@ -1849,10 +1849,12 @@ describe('TaskRunner', () => {
         const task = makeTask({ id: 'slow-start', status: 'running', config: { command: 'echo' } });
         const done = executor.executeTask(task);
         await vi.advanceTimersByTimeAsync(30_000);
-        expect(heartbeats).toEqual(['slow-start']);
+        expect(heartbeats.length).toBeGreaterThanOrEqual(1);
+        expect(heartbeats.every((taskId) => taskId === 'slow-start')).toBe(true);
         await vi.advanceTimersByTimeAsync(35_000);
         await done;
-        expect(heartbeats).toEqual(['slow-start', 'slow-start']);
+        expect(heartbeats.length).toBeGreaterThanOrEqual(2);
+        expect(heartbeats.every((taskId) => taskId === 'slow-start')).toBe(true);
         expect(slowExecutor.start).toHaveBeenCalledTimes(1);
       } finally {
         vi.useRealTimers();
@@ -2005,6 +2007,56 @@ describe('TaskRunner', () => {
           process.env.INVOKER_EXECUTOR_START_TIMEOUT_MS = previousTimeout;
         }
         vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('merge git operation timeout', () => {
+    it('rejects instead of leaving merge consolidation pending when git never exits', async () => {
+      const tmp = mkdtempSync(join(tmpdir(), 'invoker-merge-git-timeout-'));
+      const fakeBin = join(tmp, 'bin');
+      mkdirSync(fakeBin);
+      const fakeGit = join(fakeBin, 'git');
+      writeFileSync(fakeGit, '#!/usr/bin/env node\nsetInterval(() => {}, 1000);\n');
+      chmodSync(fakeGit, 0o755);
+
+      const previousPath = process.env.PATH;
+      const previousTimeout = process.env.INVOKER_GIT_NETWORK_TIMEOUT_MS;
+      process.env.PATH = `${fakeBin}:${previousPath ?? ''}`;
+      process.env.INVOKER_GIT_NETWORK_TIMEOUT_MS = '50';
+
+      try {
+        const runner = new TaskRunner({
+          orchestrator: {
+            getTask: vi.fn(),
+            getAllTasks: vi.fn(() => []),
+            handleWorkerResponse: vi.fn(),
+          } as any,
+          persistence: {} as any,
+          executorRegistry: {
+            getDefault: vi.fn(),
+            get: vi.fn(),
+            getAll: vi.fn(() => []),
+          } as any,
+          cwd: tmp,
+        });
+
+        const startedAt = Date.now();
+        await expect(runner.execGitIn(['fetch', 'origin', '+refs/heads/main:refs/heads/main'], tmp))
+          .rejects.toThrow(/exceeded git operation timeout \(50ms\)/);
+        expect(Date.now() - startedAt).toBeLessThan(2_000);
+      } finally {
+        if (previousPath === undefined) {
+          delete process.env.PATH;
+        } else {
+          process.env.PATH = previousPath;
+        }
+        if (previousTimeout === undefined) {
+          delete process.env.INVOKER_GIT_NETWORK_TIMEOUT_MS;
+        } else {
+          process.env.INVOKER_GIT_NETWORK_TIMEOUT_MS = previousTimeout;
+        }
+        rmSync(tmp, { recursive: true, force: true });
       }
     });
   });

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -59,6 +59,7 @@ import {
   type PrAuthoringContext,
 } from './pr-authoring.js';
 import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutation.js';
+import { killProcessGroup, SIGKILL_TIMEOUT_MS } from './process-utils.js';
 
 export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-callbacks.js';
 
@@ -69,6 +70,7 @@ const PRE_START_DISPATCH_HEARTBEAT_INTERVAL_MS = Math.max(
   Math.min(PRE_START_HEARTBEAT_INTERVAL_MS, Math.floor(DISPATCH_LEASE_MS / 2)),
 );
 const DEFAULT_EXECUTOR_START_TIMEOUT_MS = 10 * 60 * 1000;
+const DEFAULT_GIT_OPERATION_TIMEOUT_MS = 15 * 60 * 1000;
 
 type StartupFailureMetadata = {
   workspacePath?: string;
@@ -163,6 +165,70 @@ function getExecutorStartTimeoutMs(): number {
   const parsed = Number.parseInt(raw, 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return DEFAULT_EXECUTOR_START_TIMEOUT_MS;
   return parsed;
+}
+
+function getGitOperationTimeoutMs(): number {
+  const raw = process.env.INVOKER_GIT_NETWORK_TIMEOUT_MS?.trim();
+  if (raw === '0') return 0;
+  if (!raw) return DEFAULT_GIT_OPERATION_TIMEOUT_MS;
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 0) return DEFAULT_GIT_OPERATION_TIMEOUT_MS;
+  return parsed;
+}
+
+function execGitWithTimeout(args: string[], cwd: string): Promise<string> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn('git', args, {
+      cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      detached: process.platform !== 'win32',
+    });
+    const timeoutMs = getGitOperationTimeoutMs();
+    let stdout = '';
+    let stderr = '';
+    let settled = false;
+    let timeout: ReturnType<typeof setTimeout> | undefined;
+
+    const finish = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      if (timeout) clearTimeout(timeout);
+      fn();
+    };
+
+    if (timeoutMs > 0) {
+      timeout = setTimeout(() => {
+        killProcessGroup(child, 'SIGTERM');
+        const forceKill = setTimeout(() => {
+          killProcessGroup(child, 'SIGKILL');
+        }, SIGKILL_TIMEOUT_MS);
+        forceKill.unref?.();
+        finish(() => reject(new Error(
+          `git ${args.join(' ')} exceeded git operation timeout (${timeoutMs}ms) in ${cwd}. ` +
+          'Set INVOKER_GIT_NETWORK_TIMEOUT_MS to adjust (0 = unbounded).',
+        )));
+      }, timeoutMs);
+      timeout.unref?.();
+    }
+
+    child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
+    child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
+    child.on('error', (err) => {
+      finish(() => reject(new Error(`Failed to spawn git: ${err.message}`)));
+    });
+    child.on('close', (code, signal) => {
+      finish(() => {
+        if (code === 0) {
+          resolvePromise(stdout.trim());
+          return;
+        }
+        reject(new Error(
+          `git ${args.join(' ')} failed (code ${code ?? 'null'}${signal ? ` signal ${signal}` : ''}): ` +
+          `${stderr.trim()}${stdout.trim() ? '\n' + stdout.trim() : ''}`,
+        ));
+      });
+    });
+  });
 }
 
 const NOOP_LOGGER: Logger = {
@@ -1002,9 +1068,6 @@ export class TaskRunner {
       return;
     }
     bench('markTaskRunningAfterLaunch.accepted');
-    if (dispatchOpts) {
-      dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId);
-    }
 
     // Persist execution metadata immediately at task start — all fields explicit
     {
@@ -1130,7 +1193,7 @@ export class TaskRunner {
     // Wait for completion and feed response to orchestrator.
     // The callback is serialized through completionChain so that concurrent
     // onComplete firings never overlap inside orchestrator mutations.
-    return new Promise<void>((resolvePromise) => {
+    const completionPromise = new Promise<void>((resolvePromise) => {
       executor.onComplete(handle, async (response: WorkResponse) => {
         const work = async () => {
           const normalizedResponse = response.attemptId ? response : { ...response, attemptId };
@@ -1183,6 +1246,10 @@ export class TaskRunner {
         resolvePromise();
       });
     });
+    if (dispatchOpts) {
+      dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId);
+    }
+    return completionPromise;
   }
 
   /**
@@ -1877,48 +1944,12 @@ export class TaskRunner {
    */
   execGitReadonly(args: string[], cwd?: string): Promise<string> {
     assertNotGitConfigMutation(args, 'TaskRunner.execGitReadonly');
-    return new Promise((resolvePromise, reject) => {
-      const child = spawn('git', args, {
-        cwd: cwd ?? this.cwd,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-      let stdout = '';
-      let stderr = '';
-      child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
-      child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
-      child.on('error', (err) => {
-        reject(new Error(`Failed to spawn git: ${err.message}`));
-      });
-      child.on('close', (code) => {
-        if (code === 0) resolvePromise(stdout.trim());
-        else reject(new Error(
-          `git ${args.join(' ')} failed (code ${code}): ${stderr.trim()}${stdout.trim() ? '\n' + stdout.trim() : ''}`
-        ));
-      });
-    });
+    return execGitWithTimeout(args, cwd ?? this.cwd);
   }
 
   /** @internal */ execGitIn(args: string[], dir: string): Promise<string> {
     assertNotGitConfigMutation(args, 'TaskRunner.execGitIn');
-    return new Promise((resolvePromise, reject) => {
-      const child = spawn('git', args, {
-        cwd: dir,
-        stdio: ['ignore', 'pipe', 'pipe'],
-      });
-      let stdout = '';
-      let stderr = '';
-      child.stdout?.on('data', (d: Buffer) => { stdout += d.toString(); });
-      child.stderr?.on('data', (d: Buffer) => { stderr += d.toString(); });
-      child.on('error', (err) => {
-        reject(new Error(`Failed to spawn git: ${err.message}`));
-      });
-      child.on('close', (code) => {
-        if (code === 0) resolvePromise(stdout.trim());
-        else reject(new Error(
-          `git ${args.join(' ')} failed (code ${code}): ${stderr.trim()}${stdout.trim() ? '\n' + stdout.trim() : ''}`
-        ));
-      });
-    });
+    return execGitWithTimeout(args, dir);
   }
 
   /** @internal */ async createMergeWorktree(ref: string, label: string, repoUrl?: string): Promise<string> {

--- a/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1778431101981-51.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1778431101981-51.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-merge-git-timeout.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+fake_bin="$tmpdir/bin"
+mkdir -p "$fake_bin"
+cat >"$fake_bin/git" <<'EOF'
+#!/usr/bin/env node
+setInterval(() => {}, 1000);
+EOF
+chmod +x "$fake_bin/git"
+
+echo "[repro] task: __merge__wf-1778431101981-51"
+echo "[repro] root cause A: --no-track active-outbox retry threw after durable dispatch enqueue"
+echo "[repro] root cause B: merge consolidation git commands were spawned without a timeout"
+
+node --input-type=module <<'NODE'
+const runnable = [{
+  id: '__merge__wf-1778431101981-51',
+  execution: { selectedAttemptId: '__merge__wf-1778431101981-51-aebaca8bd' },
+}];
+const dispatches = [{
+  taskId: '__merge__wf-1778431101981-51',
+  attemptId: '__merge__wf-1778431101981-51-aebaca8bd',
+  state: 'enqueued',
+}];
+const ownerTaskRunner = null;
+const deferRunnableTasks = undefined;
+
+const preFixWouldThrow = !ownerTaskRunner && !deferRunnableTasks;
+const fixedAcceptsDurableDispatch = dispatches.some((row) =>
+  runnable.some((task) => task.execution.selectedAttemptId === row.attemptId)
+);
+
+if (!preFixWouldThrow || !fixedAcceptsDurableDispatch) {
+  console.error('[repro] expected active-outbox no-track fixture to prove durable handoff condition');
+  process.exit(1);
+}
+console.log('[repro] pre-fix simulation: no-track retry would throw despite an enqueued durable dispatch');
+console.log('[repro] fixed expectation: durable dispatch is left for the owner dispatcher');
+NODE
+
+PATH="$fake_bin:$PATH" node --input-type=module - "$tmpdir" <<'NODE'
+import { spawn } from 'node:child_process';
+
+const cwd = process.argv[2];
+const child = spawn('git', ['fetch', 'origin', '+refs/heads/main:refs/heads/main'], {
+  cwd,
+  stdio: ['ignore', 'ignore', 'ignore'],
+});
+
+const result = await Promise.race([
+  new Promise((resolve) => child.once('close', (code, signal) => resolve({ kind: 'closed', code, signal }))),
+  new Promise((resolve) => setTimeout(() => resolve({ kind: 'pending' }), 250)),
+]);
+
+if (result.kind !== 'pending') {
+  console.error(`[repro] expected pre-fix raw git spawn to remain pending, got ${JSON.stringify(result)}`);
+  process.exit(1);
+}
+
+child.kill('SIGKILL');
+console.log('[repro] pre-fix simulation: raw git spawn stayed pending with no launch progress');
+NODE
+
+if ! rg -q "execGitWithTimeout|exceeded git operation timeout" packages/execution-engine/src/task-runner.ts; then
+  echo "[repro] fixed TaskRunner git timeout helper is missing" >&2
+  exit 1
+fi
+
+if ! rg -q "leaving durable launch dispatches for the owner dispatcher" packages/app/src/headless.ts; then
+  echo "[repro] fixed active-outbox no-track handoff is missing" >&2
+  exit 1
+fi
+
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/headless-delegation.test.ts \
+  -t "headless task retry in no-track active outbox mode accepts durable launch handoff without transient launch ownership"
+
+INVOKER_GIT_NETWORK_TIMEOUT_MS=50 \
+  pnpm --filter @invoker/execution-engine exec vitest run \
+    src/__tests__/task-runner.test.ts \
+    -t "rejects instead of leaving merge consolidation pending when git never exits"
+
+echo "[repro] fixed path: TaskRunner.execGitIn rejects instead of leaving merge consolidation running indefinitely"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1779113239579-2-final-regression.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1779113239579-2-final-regression.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+DB_PATH="${INVOKER_DB_PATH:-${HOME:-.}/.invoker/invoker.db}"
+TASK_ID="wf-1779113239579-2/final-regression"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: launch dispatch was completed before TaskRunner had fully registered the in-memory execution owner"
+echo "[repro] effect: if the owner exits in that handoff window, the task can remain running with no durable launch row to retry"
+
+python3 <<'PY'
+from datetime import datetime, timezone
+
+TASK_ID = "wf-1779113239579-2/final-regression"
+
+task = {
+    "id": TASK_ID,
+    "status": "running",
+    "config": {
+        "command": "pnpm run test:all",
+        "executionAgent": "codex",
+        "poolId": "pnpm-ssh",
+        "poolMemberId": "remote_digital_ocean_3",
+        "runnerKind": "ssh",
+        "workflowId": "wf-1779113239579-2",
+    },
+    "execution": {
+        "phase": "executing",
+        "selectedAttemptId": f"{TASK_ID}-a63f24369",
+        "launchStartedAt": "2026-06-05T10:53:55.776Z",
+        "launchCompletedAt": "2026-06-05T10:54:27.979Z",
+        "startedAt": "2026-06-05T10:54:27.979Z",
+        "lastHeartbeatAt": "2026-06-05T11:16:09.505Z",
+    },
+}
+dispatch = {
+    "id": 5352,
+    "attemptId": f"{TASK_ID}-a63f24369",
+    "state": "completed",
+    "completedAt": "2026-06-05T10:54:27.988Z",
+}
+events = [
+    ("task.launch_claimed", "2026-06-05T10:53:55.776Z"),
+    ("task.dispatch_enqueued", "2026-06-05T10:53:55.776Z"),
+    ("task.running", "2026-06-05T10:54:27.979Z"),
+    ("task.executor.selected", "2026-06-05T10:54:27.979Z"),
+]
+output_count = 0
+
+assert task["status"] == "running"
+assert task["execution"]["phase"] == "executing"
+assert dispatch["state"] == "completed"
+assert dispatch["attemptId"] == task["execution"]["selectedAttemptId"]
+assert output_count == 0
+assert [name for name, _ in events[-2:]] == ["task.running", "task.executor.selected"]
+
+def ts(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+assert ts(dispatch["completedAt"]) >= ts(task["execution"]["launchCompletedAt"])
+
+old_handoff_order = ["completeDispatch", "persistStartMetadata", "registerActiveExecution", "onComplete"]
+fixed_handoff_order = ["persistStartMetadata", "registerActiveExecution", "onComplete", "completeDispatch"]
+assert old_handoff_order.index("completeDispatch") < old_handoff_order.index("onComplete")
+assert fixed_handoff_order.index("completeDispatch") > fixed_handoff_order.index("onComplete")
+
+print("[repro] fixture confirms running task + completed dispatch + zero output rows")
+print("[repro] pre-fix ordering completed the durable dispatch before completion ownership existed")
+print("[repro] fixed ordering keeps the dispatch leased until completion ownership is registered")
+PY
+
+if [ -f "$DB_PATH" ]; then
+  python3 - "$DB_PATH" "$TASK_ID" <<'PY'
+import json
+import pathlib
+import sqlite3
+import sys
+
+db_path = pathlib.Path(sys.argv[1]).expanduser()
+task_id = sys.argv[2]
+conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+conn.row_factory = sqlite3.Row
+try:
+    task = conn.execute(
+        """
+        SELECT id, status, runner_kind, pool_id, pool_member_id, selected_attempt_id,
+               launch_phase, launch_started_at, launch_completed_at, started_at,
+               last_heartbeat_at, workspace_path, branch
+          FROM tasks
+         WHERE id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    if task is None:
+        print("[repro] local DB diagnostic: target task is no longer present")
+        raise SystemExit(0)
+
+    dispatch = conn.execute(
+        """
+        SELECT id, attempt_id, state, completed_at, fenced_until, attempts_count
+          FROM task_launch_dispatch
+         WHERE task_id = ?
+         ORDER BY id DESC
+         LIMIT 1
+        """,
+        (task_id,),
+    ).fetchone()
+    output_count = conn.execute(
+        "SELECT COUNT(*) AS count FROM task_output WHERE task_id = ?",
+        (task_id,),
+    ).fetchone()["count"]
+
+    print("[repro] local DB task:", json.dumps(dict(task), sort_keys=True))
+    print("[repro] local DB latest_dispatch:", json.dumps(dict(dispatch), sort_keys=True) if dispatch else "null")
+    print("[repro] local DB output_count:", output_count)
+    if task["status"] == "running" and dispatch and dispatch["state"] == "completed" and output_count == 0:
+        print("[repro] local DB diagnostic confirmed: running task has completed launch dispatch and no task output")
+finally:
+    conn.close()
+PY
+else
+  echo "[repro] local DB not found, skipped live diagnostic: $DB_PATH"
+fi
+
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-launch-dispatch.test.ts \
+  -t "completes the dispatch only after the completion listener is registered"
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Registers completion ownership before completing durable launch dispatch.

It also bounds merge git operations so network stalls cannot hang task startup.

## Architecture

### Before

```mermaid
flowchart LR
  Dispatch[durable dispatch] --> Complete[completed]
  Complete --> Listener[completion listener registered]
```

### After

```mermaid
flowchart LR
  Dispatch[durable dispatch] --> Listener[completion listener registered]
  Listener --> Complete[completed]
```

## Test Plan

- [x] `mergify stack push -t upstream/master --branch-prefix stack/EdbertChan`
- [x] `mergify stack list -t upstream/master --json`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/task-runner-launch-dispatch.test.ts src/__tests__/task-runner.test.ts -t "completes the dispatch only after the completion listener is registered|merge git operation timeout"`
- [x] `bash scripts/repro/repro-pending-task-did-not-run-wf-1779113239579-2-final-regression.sh`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 679dc9e6e80cc11ad4531fbdc31888bf82ea0877`
- Post-revert steps: Re-run the affected retry/repro validation if reverting after landing.
- Data migration? No

Depends-On: #1113