### PR TITLE
fix(scripts): classify retry-loop capacity and lease waits

### DIFF
--- a/scripts/repro/repro-pending-task-did-not-run-wf-1778431095371-43-regression-inv-63.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1778431095371-43-regression-inv-63.sh
@@ -20,7 +20,7 @@ task = {
     "id": "wf-1778431095371-43/regression-inv-63",
     "createdAt": "2026-06-03T18:00:00.000Z",
     "status": "pending",
-    "config": {"poolId": "pnpm-ssh", "runnerKind": "worktree"},
+    "config": {"poolId": "pnpm-ssh", "runnerKind": "ssh"},
     "execution": {},
 }
 queue = {

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1778431097453-46-regression-inv-117.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1778431097453-46-regression-inv-117.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="wf-1778431097453-46/regression-inv-117"
+DB_PATH="${INVOKER_DB_PATH:-${HOME:-.}/.invoker/invoker.db}"
+
+state_dir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-active-dispatch-owner-repro.XXXXXX")"
+state_file="$state_dir/submissions.tsv"
+trap 'rm -rf "$state_dir"' EXIT
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: active launch-dispatch rows were present while no owner dispatcher was guaranteed alive"
+echo "[repro] failure mode: retry loop escalated stale pending/launching queue work to Codex before giving the owner dispatcher a cycle to launch it"
+
+python3 - "$ROOT" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+script = (root / "scripts/retry-pending-autofix-failed.sh").read_text(encoding="utf-8")
+
+task_id = "wf-1778431097453-46/regression-inv-117"
+task = {
+    "id": task_id,
+    "status": "pending",
+    "config": {
+        "command": "pnpm run test:all",
+        "executionAgent": "codex",
+        "poolId": "pnpm-ssh",
+        "poolMemberId": "remote_digital_ocean_3",
+        "runnerKind": "ssh",
+        "workflowId": "wf-1778431097453-46",
+    },
+    "execution": {
+        "selectedAttemptId": f"{task_id}-a21776f85",
+        "branch": "experiment/wf-1778431097453-46/regression-inv-117/g81.t180.a-a063969b2-6ccf4eee",
+        "lastHeartbeatAt": "2026-06-06T01:43:09.976Z",
+        "launchStartedAt": "2026-06-06T01:43:09.976Z",
+        "phase": "launching",
+    },
+}
+queue = {
+    "maxConcurrency": 12,
+    "queued": [],
+    "running": [
+        {
+            "attemptId": f"{task_id}-a21776f85",
+            "taskId": task_id,
+        }
+    ],
+    "runningCount": 6,
+}
+active_dispatch_rows = [
+    {
+        "id": 5605,
+        "taskId": task_id,
+        "attemptId": f"{task_id}-a21776f85",
+        "state": "enqueued",
+        "attemptsCount": 2,
+        "dispatchOwner": None,
+        "fencedUntil": None,
+    }
+]
+owner_ping_ready = False
+audit = [
+    (
+        "2026-06-06 01:43:09",
+        "task.launch_claimed",
+        {
+            "execution": {
+                "selectedAttemptId": f"{task_id}-a21776f85",
+                "generation": 182,
+                "phase": "launching",
+                "launchStartedAt": "2026-06-06T01:43:09.976Z",
+            }
+        },
+    ),
+    (
+        "2026-06-06 01:43:09",
+        "task.dispatch_enqueued",
+        {
+            "dispatchId": 5605,
+            "attemptId": f"{task_id}-a21776f85",
+            "workflowId": "wf-1778431097453-46",
+            "generation": 182,
+            "state": "enqueued",
+        },
+    ),
+    (
+        "2026-06-06 01:46:23",
+        "task.launch_dispatch_reaped",
+        {
+            "dispatchId": 5605,
+            "attemptId": f"{task_id}-a21776f85",
+            "attemptsCount": 1,
+            "reason": "lease_expired",
+        },
+    ),
+    (
+        "2026-06-06 01:49:23",
+        "task.launch_dispatch_reaped",
+        {
+            "dispatchId": 5605,
+            "attemptId": f"{task_id}-a21776f85",
+            "attemptsCount": 2,
+            "reason": "lease_expired",
+        },
+    ),
+]
+
+running_ids = {item["taskId"] for item in queue["running"]}
+events = [event_type for _created_at, event_type, _payload in audit]
+reaps = [payload for _created_at, event_type, payload in audit if event_type == "task.launch_dispatch_reaped"]
+post_claim_executor_events = [
+    event_type
+    for _created_at, event_type, _payload in audit
+    if event_type in {
+        "task.executor.selected",
+        "task.executor.deferred",
+        "task.executor.startup-retry",
+        "task.running",
+        "task.failed",
+    }
+]
+
+assert task["status"] == "pending"
+assert task["execution"]["phase"] == "launching"
+assert task_id in running_ids
+assert active_dispatch_rows
+assert any(row["state"] in {"enqueued", "leased"} for row in active_dispatch_rows)
+assert events[:2] == ["task.launch_claimed", "task.dispatch_enqueued"]
+assert len(reaps) == 2
+assert {payload["reason"] for payload in reaps} == {"lease_expired"}
+assert not post_claim_executor_events
+
+old_retry_loop_would_investigate = (
+    task["status"] == "pending"
+    and task["execution"].get("phase") == "launching"
+    and task_id in running_ids
+    and bool(task["execution"].get("lastHeartbeatAt"))
+)
+fixed_loop_should_start_owner = bool(active_dispatch_rows) and not owner_ping_ready
+fixed_retry_loop_starts_owner = (
+    "active_launch_dispatch_count()" in script
+    and "start_managed_headless_owner" in script
+    and "managed_owner_started_for_dispatch=true" in script
+    and "pending investigation deferred (managed owner dispatcher started for active launch dispatch rows:" in script
+)
+assert old_retry_loop_would_investigate
+assert fixed_loop_should_start_owner
+if not fixed_retry_loop_starts_owner:
+    raise SystemExit("retry loop does not force owner dispatcher startup before pending investigation")
+
+print("[repro] fixture asserts pending/launching task was queue-running with no executor launch event")
+print("[repro] fixture asserts dispatch 5605 was repeatedly reaped for lease_expired")
+print("[repro] fixture asserts active launch dispatch rows existed while owner ping was not ready")
+print("[repro] source asserts fixed retry loop starts an owner and defers investigation for active dispatch rows")
+PY
+
+if [ -f "$DB_PATH" ]; then
+  python3 - "$DB_PATH" "$TASK_ID" <<'PY'
+import json
+import pathlib
+import sqlite3
+import sys
+
+db_path = pathlib.Path(sys.argv[1]).expanduser()
+task_id = sys.argv[2]
+conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+conn.row_factory = sqlite3.Row
+try:
+    task = conn.execute(
+        """
+        SELECT id, status, runner_kind, pool_id, pool_member_id, selected_attempt_id,
+               launch_phase, launch_started_at, last_heartbeat_at
+          FROM tasks
+         WHERE id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    if task is None:
+        print("[repro] local DB diagnostic: target task is no longer present")
+        raise SystemExit(0)
+
+    dispatch_rows = conn.execute(
+        """
+        SELECT id, attempt_id, state, attempts_count, dispatch_owner, fenced_until, last_error
+          FROM task_launch_dispatch
+         WHERE task_id = ?
+         ORDER BY id DESC
+         LIMIT 5
+        """,
+        (task_id,),
+    ).fetchall()
+    recent_events = conn.execute(
+        """
+        SELECT event_type, payload
+          FROM events
+         WHERE task_id = ?
+         ORDER BY id DESC
+         LIMIT 12
+        """,
+        (task_id,),
+    ).fetchall()
+
+    print("[repro] local DB task:", json.dumps(dict(task), sort_keys=True))
+    print("[repro] local DB launch_dispatch_rows:", json.dumps([dict(row) for row in dispatch_rows], sort_keys=True))
+    print("[repro] local DB recent_events:", json.dumps([dict(row) for row in recent_events], sort_keys=True))
+finally:
+    conn.close()
+PY
+else
+  echo "[repro] local DB not found, skipped live diagnostic: $DB_PATH"
+fi
+
+INVOKER_RETRY_PENDING_AUTOFIX_STATE_DIR="$state_dir" \
+INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE="$state_file" \
+  scripts/retry-pending-autofix-failed.sh --self-test

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1778825469103-6-final-regression-sqlite-flush-optimization.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1778825469103-6-final-regression-sqlite-flush-optimization.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+DB_PATH="${INVOKER_DB_PATH:-${HOME:-.}/.invoker/invoker.db}"
+TASK_ID="wf-1778825469103-6/final-regression-sqlite-flush-optimization"
+
+log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-pending-final-regression-repro.XXXXXX.log")"
+state_file="$(mktemp "${TMPDIR:-/tmp}/invoker-pending-final-regression-state.XXXXXX.tsv")"
+trap 'rm -f "$log_file" "$state_file"' EXIT
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: the first launch was actively deferred by SSH pool leases/capacity, but retry diagnostics treated queued pending work as a no-launch task to investigate."
+echo "[repro] fixed behavior: active SSH pool-capacity blockers are excluded from pending investigation, while truly running SSH tasks without active leases are investigated."
+
+python3 - "$ROOT" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+script = (root / "scripts/retry-pending-autofix-failed.sh").read_text(encoding="utf-8")
+
+task_id = "wf-1778825469103-6/final-regression-sqlite-flush-optimization"
+first_attempt = f"{task_id}-a9ac56d13"
+
+task = {
+    "id": task_id,
+    "status": "pending",
+    "config": {
+        "workflowId": "wf-1778825469103-6",
+        "runnerKind": "ssh",
+        "poolId": "pnpm-ssh",
+        "poolMemberId": "remote_digital_ocean_3",
+    },
+    "execution": {
+        "selectedAttemptId": first_attempt,
+        "generation": 203,
+        "lastHeartbeatAt": "2026-06-05T06:09:06.636Z",
+        "phase": "launching",
+        "launchStartedAt": "2026-06-05T06:09:06.636Z",
+    },
+}
+queue = {
+    "queued": [{"taskId": task_id}],
+    "running": [],
+    "runningCount": 0,
+    "maxConcurrency": 12,
+}
+audit = [
+    ("task.launch_claimed", {"attemptId": first_attempt, "generation": 203}),
+    ("task.dispatch_enqueued", {"dispatchId": 4991, "attemptId": first_attempt}),
+    ("task.executor.deferred", {
+        "reason": "ssh-resource-lease-held",
+        "poolId": "pnpm-ssh",
+        "poolMemberId": "remote_digital_ocean_3",
+        "resourceKey": "ssh:invoker@165.22.161.97:22",
+    }),
+    ("task.executor.deferred", {
+        "reason": "ssh-resource-lease-held",
+        "poolId": "pnpm-ssh",
+        "poolMemberId": "remote_digital_ocean_4",
+        "resourceKey": "ssh:invoker@138.68.230.225:22",
+    }),
+    ("task.executor.deferred", {
+        "reason": "execution-pool-capacity",
+        "poolId": "pnpm-ssh",
+        "excludedMemberKeys": ["ssh:remote_digital_ocean_3", "ssh:remote_digital_ocean_4"],
+    }),
+    ("task.launch_dispatch_invalidated", {"dispatchId": 4991, "reason": "task deferred"}),
+    ("task.deferred", {"status": "pending", "execution": {}}),
+]
+
+queued_ids = {entry["taskId"] for entry in queue["queued"]}
+defer_reasons = {
+    payload.get("reason")
+    for event_type, payload in audit
+    if event_type == "task.executor.deferred"
+}
+
+assert task["status"] == "pending"
+assert task_id in queued_ids
+assert task["config"]["runnerKind"] == "ssh"
+assert task["config"]["poolId"] == "pnpm-ssh"
+assert {"ssh-resource-lease-held", "execution-pool-capacity"} <= defer_reasons
+
+pre_fix_would_investigate = (
+    task["status"] == "pending"
+    and task_id in queued_ids
+    and bool(task["execution"].get("lastHeartbeatAt"))
+)
+fixed_classifier_blocks_on_capacity = (
+    task["status"] == "pending"
+    and task_id in queued_ids
+    and task["config"].get("poolId") == "pnpm-ssh"
+    and "execution-pool-capacity" in defer_reasons
+)
+assert pre_fix_would_investigate
+assert fixed_classifier_blocks_on_capacity
+
+required_source = [
+    "write_pool_capacity_blocked_file",
+    "pool-capacity-blocked=",
+    "pending investigation excludes active SSH pool capacity blockers",
+    "pending investigation deferred (pool capacity blockers remain:",
+    "write_ssh_running_without_lease_file",
+    "pending investigation includes SSH running tasks without active leases",
+]
+missing = [needle for needle in required_source if needle not in script]
+if missing:
+    raise SystemExit("fixed retry diagnostics are missing: " + ", ".join(missing))
+
+print("[repro] fixture asserts the target's first launch was blocked by SSH pool leases/capacity")
+print("[repro] pre-fix classifier would escalate the queued pending task as no-launch work")
+print("[repro] fixed classifier defers investigation while active pool capacity blockers remain")
+PY
+
+if [ -f "$DB_PATH" ]; then
+  python3 - "$DB_PATH" "$TASK_ID" <<'PY'
+import json
+import pathlib
+import sqlite3
+import sys
+
+db_path = pathlib.Path(sys.argv[1]).expanduser()
+task_id = sys.argv[2]
+conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+conn.row_factory = sqlite3.Row
+try:
+    task = conn.execute(
+        """
+        SELECT id, status, runner_kind, pool_id, pool_member_id, selected_attempt_id,
+               launch_phase, launch_started_at, launch_completed_at, started_at,
+               last_heartbeat_at, workspace_path, branch
+          FROM tasks
+         WHERE id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    if task is None:
+        print("[repro] local DB diagnostic: target task is no longer present")
+        raise SystemExit(0)
+
+    active_leases = conn.execute(
+        """
+        SELECT resource_key, holder_id, pool_member_id, lease_expires_at
+          FROM execution_resource_leases
+         WHERE task_id = ?
+           AND resource_type = 'ssh'
+           AND lease_expires_at IS NOT NULL
+           AND julianday(lease_expires_at) > julianday('now')
+         ORDER BY resource_key
+        """,
+        (task_id,),
+    ).fetchall()
+    dispatches = conn.execute(
+        """
+        SELECT id, attempt_id, state, last_error
+          FROM task_launch_dispatch
+         WHERE task_id = ?
+         ORDER BY id
+        """,
+        (task_id,),
+    ).fetchall()
+    recent_defer_reasons = conn.execute(
+        """
+        SELECT payload
+          FROM events
+         WHERE task_id = ?
+           AND event_type = 'task.executor.deferred'
+         ORDER BY id DESC
+         LIMIT 8
+        """,
+        (task_id,),
+    ).fetchall()
+    reasons = []
+    for row in recent_defer_reasons:
+        try:
+            payload = json.loads(row["payload"] or "{}")
+        except json.JSONDecodeError:
+            payload = {}
+        if payload.get("reason"):
+            reasons.append(payload["reason"])
+
+    print("[repro] local DB task:", json.dumps(dict(task), sort_keys=True))
+    print("[repro] local DB active_ssh_lease_count:", len(active_leases))
+    print("[repro] local DB dispatches:", json.dumps([dict(row) for row in dispatches], sort_keys=True))
+    print("[repro] local DB recent_defer_reasons:", ",".join(sorted(set(reasons))))
+finally:
+    conn.close()
+PY
+else
+  echo "[repro] local DB not found, skipped live diagnostic: $DB_PATH"
+fi
+
+INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE="$state_file" \
+  scripts/retry-pending-autofix-failed.sh --self-test | tee "$log_file"
+
+grep -Fq "self-test: pool-capacity deferred queued task blocks pending investigation" "$log_file"
+grep -Fq "self-test: all passed" "$log_file"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1779680045111-2-final-regression-test-all.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1779680045111-2-final-regression-test-all.sh
@@ -5,15 +5,15 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 cd "$ROOT"
 
 DB_PATH="${INVOKER_DB_PATH:-${HOME:-.}/.invoker/invoker.db}"
-TASK_ID="wf-1780292402489-6/final-regression-test-all"
+TASK_ID="wf-1779680045111-2/final-regression-test-all"
 
-tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-final-regression-no-lease.XXXXXX")"
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-wf-1779680045111-2.XXXXXX")"
 trap 'rm -rf "$tmpdir"' EXIT
 db="$tmpdir/repro.db"
 
 echo "[repro] task: $TASK_ID"
-echo "[repro] root cause: retry diagnostics misclassified SSH lease state around launch"
-echo "[repro] effect: pending launch leases could be cleaned up, and running SSH tasks without active leases were not investigated"
+echo "[repro] root cause: the SSH task reached running/executing, but no active selected-attempt SSH lease remained."
+echo "[repro] fixed behavior: retry diagnostics route running SSH tasks without active leases to pending investigation."
 
 sqlite3 "$db" <<'SQL'
 CREATE TABLE tasks (
@@ -21,7 +21,8 @@ CREATE TABLE tasks (
   status TEXT,
   runner_kind TEXT,
   pool_member_id TEXT,
-  selected_attempt_id TEXT
+  selected_attempt_id TEXT,
+  last_heartbeat_at TEXT
 );
 
 CREATE TABLE execution_resource_leases (
@@ -39,63 +40,29 @@ CREATE TABLE execution_resource_leases (
 );
 
 INSERT INTO tasks VALUES
-  ('wf-repro/final-regression', 'pending', 'ssh', 'remote_digital_ocean_4', 'wf-repro/final-regression-afea42916'),
-  ('wf-repro/running-no-lease', 'running', 'ssh', 'remote_digital_ocean_4', 'wf-repro/running-no-lease-afea42916');
+  ('wf-repro/final-regression-no-lease', 'running', 'ssh', 'remote_digital_ocean_3', 'wf-repro/final-regression-no-lease-a2680c65c', datetime('now')),
+  ('wf-repro/healthy-running', 'running', 'ssh', 'remote_digital_ocean_4', 'wf-repro/healthy-running-a1', datetime('now'));
 
 INSERT INTO execution_resource_leases
   (resource_key, resource_type, holder_id, task_id, pool_id, pool_member_id,
    acquired_at, last_heartbeat_at, lease_expires_at, metadata_json)
 VALUES
   ('ssh:invoker@138.68.230.225:22', 'ssh',
-   'runner:123:wf-repro/final-regression:wf-repro/final-regression-afea42916',
-   'wf-repro/final-regression', 'pnpm-ssh', 'remote_digital_ocean_4',
+   'runner:123:wf-repro/healthy-running:wf-repro/healthy-running-a1',
+   'wf-repro/healthy-running', 'pnpm-ssh', 'remote_digital_ocean_4',
    datetime('now'), datetime('now'), datetime('now', '+20 minutes'), NULL);
 SQL
 
-old_orphan_count="$(sqlite3 "$db" <<'SQL'
+old_detector_count="$(sqlite3 "$db" <<'SQL'
 SELECT COUNT(*)
-FROM execution_resource_leases l
-LEFT JOIN tasks t ON t.id = l.task_id
-WHERE l.resource_type = 'ssh'
-  AND l.task_id IS NOT NULL
-  AND TRIM(l.task_id) != ''
-  AND l.lease_expires_at IS NOT NULL
-  AND julianday(l.lease_expires_at) > julianday('now')
-  AND (
-    COALESCE(t.status, '<missing>') != 'running'
-    OR t.selected_attempt_id IS NULL
-    OR TRIM(t.selected_attempt_id) = ''
-    OR NOT (
-      l.holder_id = t.selected_attempt_id
-      OR l.holder_id LIKE '%:' || t.selected_attempt_id
-    )
-  );
+FROM tasks t
+WHERE t.status = 'running'
+  AND t.runner_kind = 'ssh'
+  AND t.last_heartbeat_at IS NOT NULL
+  AND julianday(t.last_heartbeat_at) < julianday('now', '-5 minutes');
 SQL
 )"
-
-fixed_orphan_count="$(sqlite3 "$db" <<'SQL'
-SELECT COUNT(*)
-FROM execution_resource_leases l
-LEFT JOIN tasks t ON t.id = l.task_id
-WHERE l.resource_type = 'ssh'
-  AND l.task_id IS NOT NULL
-  AND TRIM(l.task_id) != ''
-  AND l.lease_expires_at IS NOT NULL
-  AND julianday(l.lease_expires_at) > julianday('now')
-  AND (
-    t.id IS NULL
-    OR COALESCE(t.status, '<missing>') NOT IN ('running', 'pending')
-    OR t.selected_attempt_id IS NULL
-    OR TRIM(t.selected_attempt_id) = ''
-    OR NOT (
-      l.holder_id = t.selected_attempt_id
-      OR l.holder_id LIKE '%:' || t.selected_attempt_id
-    )
-  );
-SQL
-)"
-
-running_without_lease_count="$(sqlite3 "$db" <<'SQL'
+fixed_detector_count="$(sqlite3 "$db" <<'SQL'
 SELECT COUNT(*)
 FROM tasks t
 WHERE t.status = 'running'
@@ -117,18 +84,13 @@ WHERE t.status = 'running'
 SQL
 )"
 
-if [ "$old_orphan_count" != "1" ]; then
-  echo "expected old cleanup query to misclassify the pending selected-attempt SSH lease, got $old_orphan_count" >&2
+if [ "$old_detector_count" != "0" ]; then
+  echo "expected pre-fix detector model to miss the no-lease running task, got $old_detector_count" >&2
   exit 1
 fi
 
-if [ "$fixed_orphan_count" != "0" ]; then
-  echo "expected fixed cleanup query to preserve the pending selected-attempt SSH lease, got $fixed_orphan_count" >&2
-  exit 1
-fi
-
-if [ "$running_without_lease_count" != "1" ]; then
-  echo "expected fixed detector to flag one running SSH task without a lease, got $running_without_lease_count" >&2
+if [ "$fixed_detector_count" != "1" ]; then
+  echo "expected fixed detector to flag exactly one running SSH task without a lease, got $fixed_detector_count" >&2
   exit 1
 fi
 
@@ -143,14 +105,14 @@ required = [
     "write_ssh_running_without_lease_file",
     "ssh-running-no-lease=",
     "pending investigation includes SSH running tasks without active leases",
-    "COALESCE(t.status, '<missing>') NOT IN ('running', 'pending')",
+    "pending investigation includes SSH running tasks without active leases: $(count_lines \"$ssh_running_without_lease_file\")",
 ]
 missing = [needle for needle in required if needle not in script]
 if missing:
     raise SystemExit("fixed retry diagnostics are missing: " + ", ".join(missing))
 
-print("[repro] fixed source: pending selected-attempt SSH leases are preserved")
-print("[repro] fixed source: running SSH tasks without active leases are routed to investigation")
+print("[repro] pre-fix model: running SSH task with no active lease was not classified")
+print("[repro] fixed source: no-lease running SSH tasks are counted and routed to investigation")
 PY
 
 if [ -f "$DB_PATH" ]; then
@@ -197,12 +159,8 @@ try:
 
     print("[repro] local DB task:", json.dumps(dict(task), sort_keys=True))
     print("[repro] local DB active_matching_ssh_lease_count:", len(active_leases))
-    if task["status"] == "running" and task["runner_kind"] == "ssh":
-        assert task["selected_attempt_id"]
-        if len(active_leases) == 0:
-            print("[repro] local DB diagnostic confirmed: running SSH task has no active matching lease")
-        else:
-            print("[repro] local DB diagnostic: target currently has an active matching lease")
+    if task["status"] == "running" and task["runner_kind"] == "ssh" and len(active_leases) == 0:
+        print("[repro] local DB diagnostic confirmed: running SSH task has no active matching lease")
 finally:
     conn.close()
 PY

--- a/scripts/repro/repro-runner-capacity-underused-by-failed-upstream.sh
+++ b/scripts/repro/repro-runner-capacity-underused-by-failed-upstream.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-capacity-underuse.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+db="$tmpdir/repro.db"
+
+is_disk_full_error() {
+  case "$1" in
+    *"No space left on device"*|*"Out of diskspace"*|*"REMOTE_DISK_FULL"*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+slugify_task_id() {
+  printf '%s' "$1" | sed 's/[^A-Za-z0-9._-]/_/g'
+}
+
+sqlite3 "$db" <<'SQL'
+CREATE TABLE tasks (
+  id TEXT PRIMARY KEY,
+  status TEXT NOT NULL,
+  runner_kind TEXT,
+  pool_id TEXT,
+  dependencies TEXT DEFAULT '[]',
+  selected_attempt_id TEXT,
+  error TEXT
+);
+
+CREATE TABLE task_launch_dispatch (
+  id INTEGER PRIMARY KEY,
+  task_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  state TEXT NOT NULL
+);
+
+INSERT INTO tasks
+  (id, status, runner_kind, pool_id, dependencies, selected_attempt_id, error)
+VALUES
+  (
+    'wf-repro/ssh-upstream',
+    'failed',
+    'ssh',
+    'pnpm-ssh',
+    '[]',
+    'wf-repro/ssh-upstream-a1',
+    'Executor startup failed (ssh): fatal: cannot create directory: No space left on device'
+  ),
+  (
+    'wf-repro/downstream-regression',
+    'pending',
+    'worktree',
+    'pnpm-ssh',
+    '["wf-repro/ssh-upstream"]',
+    'wf-repro/downstream-regression-a1',
+    NULL
+  ),
+  (
+    'wf-repro/merge',
+    'pending',
+    'merge',
+    NULL,
+    '["wf-repro/downstream-regression"]',
+    'wf-repro/merge-a1',
+    NULL
+  );
+SQL
+
+ready_count="$(sqlite3 "$db" <<'SQL'
+WITH pending AS (
+  SELECT
+    id,
+    COALESCE(dependencies, '[]') AS dependencies,
+    COALESCE(selected_attempt_id, '') AS selected_attempt_id
+  FROM tasks
+  WHERE status = 'pending'
+    AND COALESCE(runner_kind, 'worktree') != 'merge'
+)
+SELECT COUNT(*)
+FROM pending p
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM json_each(p.dependencies) dep
+  LEFT JOIN tasks dt ON dt.id = dep.value
+  WHERE COALESCE(dt.status, 'missing') NOT IN ('completed', 'complete', 'review_ready')
+)
+AND NOT EXISTS (
+  SELECT 1
+  FROM task_launch_dispatch d
+  WHERE d.task_id = p.id
+    AND (p.selected_attempt_id = '' OR d.attempt_id = p.selected_attempt_id)
+    AND d.state IN ('enqueued', 'leased', 'acknowledged')
+);
+SQL
+)"
+
+failed_disk_blockers="$(sqlite3 "$db" <<'SQL'
+SELECT COUNT(*)
+FROM tasks
+WHERE status = 'failed'
+  AND runner_kind = 'ssh'
+  AND error LIKE '%No space left on device%';
+SQL
+)"
+
+active_dispatches="$(sqlite3 "$db" <<'SQL'
+SELECT COUNT(*)
+FROM task_launch_dispatch
+WHERE state IN ('enqueued', 'leased', 'acknowledged');
+SQL
+)"
+
+configured_ssh_capacity=2
+
+if [ "$ready_count" != "0" ]; then
+  echo "expected zero runnable non-merge pending tasks, got $ready_count" >&2
+  exit 1
+fi
+
+if [ "$failed_disk_blockers" != "1" ]; then
+  echo "expected one disk-full SSH startup blocker, got $failed_disk_blockers" >&2
+  exit 1
+fi
+
+if [ "$active_dispatches" != "0" ]; then
+  echo "expected no active launch dispatch rows, got $active_dispatches" >&2
+  exit 1
+fi
+
+cleanup_dir="$tmpdir/remote-cleanup"
+mkdir -p "$cleanup_dir"
+
+failed_total=0
+disk_full_cleanup_skipped=0
+analysis_failure_count=0
+analysis_failures_file="$tmpdir/analysis-failures.txt"
+: > "$analysis_failures_file"
+
+while IFS=$'\t' read -r task_id runner_kind pool_id error_text; do
+  [ -n "$task_id" ] || continue
+  failed_total=$((failed_total + 1))
+
+  if [ "$runner_kind" = "ssh" ] && is_disk_full_error "$error_text"; then
+    disk_full_cleanup_skipped=$((disk_full_cleanup_skipped + 1))
+    cleanup_marker="$cleanup_dir/$(slugify_task_id "$task_id").cleanup-skipped"
+    {
+      printf 'task_id=%s\n' "$task_id"
+      printf 'runner_kind=%s\n' "$runner_kind"
+      printf 'pool_id=%s\n' "$pool_id"
+      printf 'cleanup=simulated-remote-execution-cleanup\n'
+      printf 'reason=disk-full-ssh-infra-blocker\n'
+      printf 'error=%s\n' "$error_text"
+    } > "$cleanup_marker"
+    continue
+  fi
+
+  analysis_failure_count=$((analysis_failure_count + 1))
+  printf '%s\t%s\t%s\t%s\n' "$task_id" "$runner_kind" "$pool_id" "$error_text" >> "$analysis_failures_file"
+done < <(
+  sqlite3 -separator $'\t' "$db" <<'SQL'
+SELECT
+  id,
+  COALESCE(runner_kind, ''),
+  COALESCE(pool_id, ''),
+  COALESCE(error, '')
+FROM tasks
+WHERE status = 'failed'
+ORDER BY id;
+SQL
+)
+
+if [ "$disk_full_cleanup_skipped" != "$failed_disk_blockers" ]; then
+  echo "expected disk-full cleanup-skipped count to match disk-full blockers: cleanup-skipped=$disk_full_cleanup_skipped blockers=$failed_disk_blockers" >&2
+  exit 1
+fi
+
+if [ "$analysis_failure_count" != "0" ]; then
+  echo "unexpected non-disk-full failed tasks in repro failure analysis:" >&2
+  sed -n '1,120p' "$analysis_failures_file" >&2
+  exit 1
+fi
+
+cat <<EOF
+PASS: spare runner capacity can be real while no runner is usable.
+
+configured_ssh_capacity=$configured_ssh_capacity
+ready_pending_non_merge_tasks=$ready_count
+active_launch_dispatch_rows=$active_dispatches
+failed_disk_full_ssh_blockers=$failed_disk_blockers
+failed_tasks_total=$failed_total
+disk_full_cleanup_skipped=$disk_full_cleanup_skipped
+analysis_failure_count=$analysis_failure_count
+
+Root cause reproduced: the queue is not filling all runners because the runnable frontier
+is blocked by a failed SSH upstream task. More capacity cannot run downstream tasks until
+the failed upstream task is retried/fixed.
+EOF

--- a/scripts/repro/repro-running-ssh-task-without-lease.sh
+++ b/scripts/repro/repro-running-ssh-task-without-lease.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-repro-ssh-no-lease.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+db="$tmpdir/repro.db"
+
+sqlite3 "$db" <<'SQL'
+CREATE TABLE tasks (
+  id TEXT PRIMARY KEY,
+  status TEXT,
+  runner_kind TEXT,
+  pool_member_id TEXT,
+  selected_attempt_id TEXT
+);
+
+CREATE TABLE execution_resource_leases (
+  resource_key TEXT,
+  resource_type TEXT,
+  holder_id TEXT,
+  task_id TEXT,
+  pool_id TEXT,
+  pool_member_id TEXT,
+  acquired_at TEXT,
+  last_heartbeat_at TEXT,
+  lease_expires_at TEXT,
+  metadata_json TEXT,
+  PRIMARY KEY(resource_key, holder_id)
+);
+
+INSERT INTO tasks VALUES
+  ('wf-repro/pending-ssh', 'pending', 'ssh', 'remote-a', 'wf-repro/pending-ssh-a1'),
+  ('wf-repro/running-no-lease', 'running', 'ssh', 'remote-b', 'wf-repro/running-no-lease-a1');
+
+INSERT INTO execution_resource_leases
+  (resource_key, resource_type, holder_id, task_id, pool_id, pool_member_id,
+   acquired_at, last_heartbeat_at, lease_expires_at, metadata_json)
+VALUES
+  ('ssh:invoker@host-a:22', 'ssh', 'owner:123:wf-repro/pending-ssh:wf-repro/pending-ssh-a1',
+   'wf-repro/pending-ssh', 'pnpm-ssh', 'remote-a',
+   datetime('now'), datetime('now'), datetime('now', '+20 minutes'), NULL);
+SQL
+
+old_orphan_count="$(sqlite3 "$db" <<'SQL'
+SELECT COUNT(*)
+FROM execution_resource_leases l
+LEFT JOIN tasks t ON t.id = l.task_id
+WHERE l.resource_type = 'ssh'
+  AND l.task_id IS NOT NULL
+  AND TRIM(l.task_id) != ''
+  AND l.lease_expires_at IS NOT NULL
+  AND julianday(l.lease_expires_at) > julianday('now')
+  AND (
+    COALESCE(t.status, '<missing>') != 'running'
+    OR t.selected_attempt_id IS NULL
+    OR TRIM(t.selected_attempt_id) = ''
+    OR NOT (
+      l.holder_id = t.selected_attempt_id
+      OR l.holder_id LIKE '%:' || t.selected_attempt_id
+    )
+  );
+SQL
+)"
+
+fixed_orphan_count="$(sqlite3 "$db" <<'SQL'
+SELECT COUNT(*)
+FROM execution_resource_leases l
+LEFT JOIN tasks t ON t.id = l.task_id
+WHERE l.resource_type = 'ssh'
+  AND l.task_id IS NOT NULL
+  AND TRIM(l.task_id) != ''
+  AND l.lease_expires_at IS NOT NULL
+  AND julianday(l.lease_expires_at) > julianday('now')
+  AND (
+    t.id IS NULL
+    OR COALESCE(t.status, '<missing>') NOT IN ('running', 'pending')
+    OR t.selected_attempt_id IS NULL
+    OR TRIM(t.selected_attempt_id) = ''
+    OR NOT (
+      l.holder_id = t.selected_attempt_id
+      OR l.holder_id LIKE '%:' || t.selected_attempt_id
+    )
+  );
+SQL
+)"
+
+running_without_lease_count="$(sqlite3 "$db" <<'SQL'
+SELECT COUNT(*)
+FROM tasks t
+WHERE t.status = 'running'
+  AND t.runner_kind = 'ssh'
+  AND t.selected_attempt_id IS NOT NULL
+  AND TRIM(t.selected_attempt_id) != ''
+  AND NOT EXISTS (
+    SELECT 1
+    FROM execution_resource_leases l
+    WHERE l.resource_type = 'ssh'
+      AND l.task_id = t.id
+      AND l.lease_expires_at IS NOT NULL
+      AND julianday(l.lease_expires_at) > julianday('now')
+      AND (
+        l.holder_id = t.selected_attempt_id
+        OR l.holder_id LIKE '%:' || t.selected_attempt_id
+      )
+  );
+SQL
+)"
+
+if [ "$old_orphan_count" != "1" ]; then
+  echo "expected old query to misclassify the pending selected-attempt lease, got $old_orphan_count" >&2
+  exit 1
+fi
+
+if [ "$fixed_orphan_count" != "0" ]; then
+  echo "expected fixed orphan query to preserve the pending selected-attempt lease, got $fixed_orphan_count" >&2
+  exit 1
+fi
+
+if [ "$running_without_lease_count" != "1" ]; then
+  echo "expected fixed detector to flag the running SSH task without a lease, got $running_without_lease_count" >&2
+  exit 1
+fi
+
+echo "repro passed: pending selected-attempt SSH leases are preserved and running SSH tasks without leases are detected"

--- a/scripts/retry-pending-autofix-failed.sh
+++ b/scripts/retry-pending-autofix-failed.sh
@@ -253,7 +253,10 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-STATE_DIR="$(mktemp -d -t invoker-retry-pending-autofix.XXXXXX)"
+STATE_DIR="${INVOKER_RETRY_PENDING_AUTOFIX_STATE_DIR:-}"
+if [ -z "$STATE_DIR" ]; then
+  STATE_DIR="$(mktemp -d -t invoker-retry-pending-autofix.XXXXXX)"
+fi
 SUBMISSIONS_FILE="${INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE:-${HOME:-.}/.invoker/retry-pending-autofix-failed-submissions.tsv}"
 DB_PATH="${INVOKER_DB_PATH:-${INVOKER_DB_DIR:-${HOME:-.}/.invoker}/invoker.db}"
 HEADLESS_CLIENT_JS="$REPO_ROOT/packages/app/dist/headless-client.js"
@@ -262,7 +265,9 @@ MANAGED_OWNER_LOG="$STATE_DIR/managed-owner.log"
 mkdir -p "$(dirname "$SUBMISSIONS_FILE")"
 touch "$SUBMISSIONS_FILE"
 cleanup() {
-  rm -rf "$STATE_DIR"
+  if [ -z "${INVOKER_RETRY_PENDING_AUTOFIX_STATE_DIR:-}" ]; then
+    rm -rf "$STATE_DIR"
+  fi
 }
 trap cleanup EXIT
 
@@ -296,9 +301,10 @@ start_managed_headless_owner() {
   else
     MANAGED_OWNER_LOG="$STATE_DIR/managed-owner-$(date +%s).log"
     echo "  starting managed standalone owner for retry loop (log: $MANAGED_OWNER_LOG)" >&2
-    INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS="${INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:-86400000}" \
+    env \
+      INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS="${INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:-86400000}" \
       INVOKER_HEADLESS_STANDALONE=1 \
-      "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless owner-serve > "$MANAGED_OWNER_LOG" 2>&1 &
+      nohup "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless owner-serve > "$MANAGED_OWNER_LOG" 2>&1 &
     MANAGED_OWNER_PID="$!"
   fi
 
@@ -773,11 +779,13 @@ PY
 write_pool_capacity_blocked_file() {
   local queue_file="$1"
   local pool_capacity_blocked_file="$2"
+  local now_epoch="$3"
+  local defer_cooldown_seconds="$4"
   : > "$pool_capacity_blocked_file"
 
   [ -f "$DB_PATH" ] || return 0
 
-  python3 - "$DB_PATH" "$queue_file" "$pool_capacity_blocked_file" <<'PY'
+  python3 - "$DB_PATH" "$queue_file" "$pool_capacity_blocked_file" "$now_epoch" "$defer_cooldown_seconds" <<'PY'
 import json
 import pathlib
 import sqlite3
@@ -786,6 +794,8 @@ import sys
 db_path = sys.argv[1]
 queue_path = pathlib.Path(sys.argv[2])
 output_path = pathlib.Path(sys.argv[3])
+now_epoch = int(sys.argv[4])
+defer_cooldown_seconds = int(sys.argv[5])
 
 active_queue_task_ids = set()
 
@@ -809,27 +819,38 @@ if queue_path.exists() and queue_path.stat().st_size > 0:
     if isinstance(queue, dict):
         collect_queue_task_ids(queue.get("queued"))
 
-if not active_queue_task_ids:
-    raise SystemExit(0)
-
 conn = None
 blocked = []
 try:
     conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
     conn.row_factory = sqlite3.Row
-    placeholders = ",".join("?" for _ in active_queue_task_ids)
+    task_args = []
+    active_filter = ""
+    if active_queue_task_ids:
+        placeholders = ",".join("?" for _ in active_queue_task_ids)
+        active_filter = f"OR id IN ({placeholders})"
+        task_args.extend(sorted(active_queue_task_ids))
     tasks = conn.execute(
         f"""
         SELECT id
         FROM tasks
-        WHERE id IN ({placeholders})
-          AND status = 'pending'
+        WHERE status = 'pending'
           AND runner_kind = 'ssh'
           AND pool_id IS NOT NULL
           AND TRIM(pool_id) != ''
+          AND (
+            EXISTS (
+              SELECT 1
+              FROM events e
+              WHERE e.task_id = tasks.id
+                AND e.event_type = 'task.executor.deferred'
+                AND CAST(strftime('%s', e.created_at) AS INTEGER) >= ?
+            )
+            {active_filter}
+          )
         ORDER BY id
         """,
-        tuple(sorted(active_queue_task_ids)),
+        (now_epoch - defer_cooldown_seconds, *task_args),
     ).fetchall()
     for task in tasks:
         task_id = task["id"]
@@ -850,7 +871,7 @@ try:
         ).fetchone()["event_id"]
         latest_defer = conn.execute(
             """
-            SELECT payload
+            SELECT payload, created_at
             FROM events
             WHERE task_id = ?
               AND event_type = 'task.executor.deferred'
@@ -864,7 +885,10 @@ try:
             payload = json.loads(latest_defer["payload"] if latest_defer else "{}")
         except json.JSONDecodeError:
             payload = {}
-        if payload.get("reason") in {"execution-pool-capacity", "ssh-resource-lease-held"}:
+        if payload.get("reason") not in {"execution-pool-capacity", "ssh-resource-lease-held"}:
+            continue
+        defer_epoch = conn.execute("SELECT CAST(strftime('%s', ?) AS INTEGER)", (latest_defer["created_at"],)).fetchone()[0]
+        if task_id in active_queue_task_ids or (defer_epoch is not None and defer_epoch >= now_epoch - defer_cooldown_seconds):
             blocked.append(task_id)
 except sqlite3.Error:
     blocked = []
@@ -942,6 +966,38 @@ finally:
         conn.close()
 
 output_path.write_text("".join(f"{task_id}\n" for task_id in ready), encoding="utf-8")
+PY
+}
+
+filter_ready_pending_capacity_blockers() {
+  local ready_pending_without_dispatch_file="$1"
+  local pool_capacity_blocked_file="$2"
+
+  [ -s "$ready_pending_without_dispatch_file" ] || return 0
+  [ -s "$pool_capacity_blocked_file" ] || return 0
+
+  python3 - "$ready_pending_without_dispatch_file" "$pool_capacity_blocked_file" <<'PY'
+import pathlib
+import sys
+
+ready_path = pathlib.Path(sys.argv[1])
+blocked_path = pathlib.Path(sys.argv[2])
+
+blocked = {
+    line.strip()
+    for line in blocked_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    if line.strip()
+}
+ready = [
+    line.strip()
+    for line in ready_path.read_text(encoding="utf-8", errors="replace").splitlines()
+    if line.strip()
+]
+
+ready_path.write_text(
+    "".join(f"{task_id}\n" for task_id in ready if task_id not in blocked),
+    encoding="utf-8",
+)
 PY
 }
 
@@ -1424,6 +1480,16 @@ count_lines() {
   wc -l < "$file" | tr -d ' '
 }
 
+active_launch_dispatch_count() {
+  if [ ! -f "$DB_PATH" ]; then
+    printf '0'
+    return
+  fi
+  sqlite3 -cmd '.timeout 5000' "$DB_PATH" \
+    "SELECT COUNT(*) FROM task_launch_dispatch WHERE state IN ('enqueued','leased');" 2>/dev/null \
+    || printf '0'
+}
+
 write_pending_investigation_prompt() {
   local target="$1"
   local prompt_file="$2"
@@ -1826,6 +1892,7 @@ run_cycle() {
   local retried_workflows_file="$cycle_dir/retried-workflows.txt"
   local retried_failed_tasks_file="$cycle_dir/retried-failed-tasks.txt"
   local retried_ready_no_dispatch_tasks_file="$cycle_dir/retried-ready-no-dispatch-tasks.txt"
+  local retried_ready_no_dispatch_workflows_file="$cycle_dir/retried-ready-no-dispatch-workflows.txt"
   local localized_failed_tasks_file="$cycle_dir/localized-failed-tasks.txt"
   local localized_workflows_file="$cycle_dir/localized-workflows.txt"
   local cleared_ssh_pin_tasks_file="$cycle_dir/cleared-ssh-pin-tasks.txt"
@@ -1835,6 +1902,7 @@ run_cycle() {
   : > "$retried_workflows_file"
   : > "$retried_failed_tasks_file"
   : > "$retried_ready_no_dispatch_tasks_file"
+  : > "$retried_ready_no_dispatch_workflows_file"
   : > "$localized_failed_tasks_file"
   : > "$localized_workflows_file"
   : > "$cleared_ssh_pin_tasks_file"
@@ -1865,8 +1933,9 @@ run_cycle() {
   write_orphan_ssh_leases_file "$orphan_ssh_leases_file"
   write_ssh_running_without_lease_file "$ssh_running_without_lease_file"
   write_ssh_running_active_lease_file "$ssh_running_active_lease_file"
-  write_pool_capacity_blocked_file "$queue_file" "$pool_capacity_blocked_file"
+  write_pool_capacity_blocked_file "$queue_file" "$pool_capacity_blocked_file" "$now_epoch" "$RESUME_COOLDOWN_SECONDS"
   write_ready_pending_without_dispatch_file "$ready_pending_without_dispatch_file"
+  filter_ready_pending_capacity_blockers "$ready_pending_without_dispatch_file" "$pool_capacity_blocked_file"
   write_exhausted_fixes_file "$failed_tasks_file" "$auto_fix_attempts_file" "$exhausted_fixes_file"
   write_effective_blockers_file "$blocking_tasks_file" "$exhausted_fixes_file" "$effective_blocking_tasks_file"
 
@@ -1895,6 +1964,17 @@ run_cycle() {
 
   local failures=0
   local target=""
+  local active_dispatch_count
+  local managed_owner_started_for_dispatch=false
+  active_dispatch_count="$(active_launch_dispatch_count)"
+  if [ "$DRY_RUN" != true ] && [ "$active_dispatch_count" -gt 0 ] && ! owner_ping_ready; then
+    echo "active launch dispatch rows need an owner dispatcher: $active_dispatch_count"
+    if ! start_managed_headless_owner; then
+      failures=$((failures + 1))
+    else
+      managed_owner_started_for_dispatch=true
+    fi
+  fi
 
   if [ "$LOCALIZE_SSH" = true ] && [ -s "$localize_ssh_file" ]; then
     echo "switching SSH-assigned recovery tasks to local worktrees"
@@ -2009,6 +2089,7 @@ run_cycle() {
       if dispatch_no_track retry-ready-no-dispatch "$target" "$RESUME_COOLDOWN_SECONDS" "$now_epoch" retry-task "$target"; then
         [ "$LAST_DISPATCH_SUBMITTED" = true ] || continue
         printf '%s\n' "$target" >> "$retried_ready_no_dispatch_tasks_file"
+        printf '%s\n' "$(target_workflow_id "$target")" >> "$retried_ready_no_dispatch_workflows_file"
       else
         failures=$((failures + 1))
       fi
@@ -2025,6 +2106,10 @@ run_cycle() {
       fi
       if contains_line "$cleared_ssh_pin_workflows_file" "$target"; then
         echo "  skip retry-workflow $target (stale SSH pin cleared this cycle)"
+        continue
+      fi
+      if contains_line "$retried_ready_no_dispatch_workflows_file" "$target"; then
+        echo "  skip retry-workflow $target (ready missing-dispatch task retried this cycle)"
         continue
       fi
       if ever_submitted retry-workflow "$target"; then
@@ -2177,6 +2262,8 @@ run_cycle() {
       echo "pending investigation deferred (orphan SSH leases released this cycle: $(count_lines "$released_orphan_ssh_leases_file"))"
     elif [ -s "$released_duplicate_ssh_leases_file" ]; then
       echo "pending investigation deferred (duplicate SSH leases released this cycle: $(count_lines "$released_duplicate_ssh_leases_file"))"
+    elif [ "$managed_owner_started_for_dispatch" = true ]; then
+      echo "pending investigation deferred (managed owner dispatcher started for active launch dispatch rows: $active_dispatch_count)"
     else
       local investigation_tasks_file="$pending_tasks_file"
       local investigation_blockers_file="$effective_blocking_tasks_file"
@@ -2212,7 +2299,10 @@ run_cycle() {
           echo "stale task investigation bypasses unrelated blockers: $(count_lines "$effective_blocking_tasks_file")"
         fi
       fi
-      if ! run_pending_investigations "$investigation_tasks_file" "$investigation_blockers_file" "$tasks_file" "$workflow_status_jsonl" "$queue_file" "$status_counts_file" "$now_epoch" "$cycle_dir"; then
+      if [ "$investigation_tasks_file" = "$pending_tasks_file" ] && [ -s "$pool_capacity_blocked_file" ]; then
+        echo "pending investigation excludes active SSH pool capacity blockers: $(count_lines "$pool_capacity_blocked_file")"
+        echo "pending investigation deferred (pool capacity blockers remain: $(count_lines "$pool_capacity_blocked_file"))"
+      elif ! run_pending_investigations "$investigation_tasks_file" "$investigation_blockers_file" "$tasks_file" "$workflow_status_jsonl" "$queue_file" "$status_counts_file" "$now_epoch" "$cycle_dir"; then
         failures=$((failures + 1))
       fi
     fi
@@ -2290,6 +2380,16 @@ SELFTEST_CODEX
     return 0
   }
 
+  owner_ping_ready() {
+    [ "${SELF_TEST_OWNER_READY:-true}" = true ]
+  }
+
+  start_managed_headless_owner() {
+    printf 'start-managed-owner\n' >> "$test_root/owner-starts.log"
+    SELF_TEST_OWNER_READY=true
+    return 0
+  }
+
   self_test_fail() {
     echo "SELF-TEST FAIL: $*" >&2
     return 1
@@ -2321,6 +2421,7 @@ SELFTEST_CODEX
     rm -f "$test_root/invoker.db"
     : > "$commands_file"
     : > "$codex_commands_file"
+    : > "$test_root/owner-starts.log"
     : > "$workflows_label_file"
     : > "$workflows_jsonl_file"
     printf '{"runningCount":0,"fixingCount":0}\n' > "$self_test_queue_file"
@@ -2354,6 +2455,7 @@ SELFTEST_CODEX
     LAST_DISPATCH_SUBMITTED=false
     SKIP_SLEEP_AFTER_CYCLE=false
     SELF_TEST_QUERY_FAIL=""
+    SELF_TEST_OWNER_READY=true
   }
 
   echo "self-test: incomplete workflows retry once and defer duplicate task actions"
@@ -2452,16 +2554,17 @@ PY
   self_test_assert_contains "$test_root/ready-no-dispatch.out" "ready pending tasks missing launch dispatch rows: 1"
   self_test_assert_contains "$test_root/ready-no-dispatch.out" "retrying ready pending tasks missing launch dispatch rows"
   self_test_assert_contains "$test_root/ready-no-dispatch.out" "reset retry state after repair"
-  self_test_assert_contains "$commands_file" "retry wf-1000-24"
+  self_test_assert_not_contains "$commands_file" "retry wf-1000-24"
+  self_test_assert_contains "$test_root/ready-no-dispatch.out" "skip retry-workflow wf-1000-24 (ready missing-dispatch task retried this cycle)"
   self_test_assert_contains "$commands_file" "retry-task wf-1000-24/root"
   self_test_assert_not_contains "$codex_commands_file" "exec --cd"
 
-  echo "self-test: pool-capacity deferred queued task blocks pending investigation"
+  echo "self-test: recent pool-capacity deferred task blocks ready-no-dispatch retries"
   self_test_reset
   printf 'retry-workflow\twf-1000-23\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
   printf '%s\n' "wf-1000-23" > "$workflows_label_file"
   printf '%s\n' '{"id":"wf-1000-23","status":"running"}' > "$workflows_jsonl_file"
-  printf '%s\n' '{"queued":[{"taskId":"wf-1000-23/regression"}],"running":[],"runningCount":0,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"queued":[],"running":[],"runningCount":0,"maxConcurrency":12}' > "$self_test_queue_file"
   printf '%s\n' '{"id":"wf-1000-23/regression","status":"pending","config":{"workflowId":"wf-1000-23","runnerKind":"ssh","poolId":"pnpm-ssh"},"execution":{"selectedAttemptId":"wf-1000-23/regression-a1","lastHeartbeatAt":"2000-01-01T00:00:00Z"}}' > "$tasks_dir/wf-1000-23.jsonl"
   python3 - "$DB_PATH" <<'PY'
 import sqlite3
@@ -2476,19 +2579,23 @@ with conn:
           id TEXT PRIMARY KEY,
           status TEXT,
           runner_kind TEXT,
-          pool_id TEXT
+          pool_id TEXT,
+          dependencies TEXT,
+          selected_attempt_id TEXT,
+          launch_phase TEXT
         );
         CREATE TABLE events (
           id INTEGER PRIMARY KEY AUTOINCREMENT,
           task_id TEXT,
           event_type TEXT,
-          payload TEXT
+          payload TEXT,
+          created_at TEXT DEFAULT (datetime('now'))
         );
         """
     )
     conn.execute(
-        "INSERT INTO tasks VALUES (?, ?, ?, ?)",
-        ("wf-1000-23/regression", "pending", "ssh", "pnpm-ssh"),
+        "INSERT INTO tasks VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("wf-1000-23/regression", "pending", "ssh", "pnpm-ssh", "[]", "wf-1000-23/regression-a1", ""),
     )
     conn.execute(
         "INSERT INTO events (task_id, event_type, payload) VALUES (?, ?, ?)",
@@ -2502,8 +2609,42 @@ conn.close()
 PY
   run_cycle selftest-pool-capacity-blocked > "$test_root/pool-capacity-blocked.out" 2>&1 || { sed -n '1,240p' "$test_root/pool-capacity-blocked.out" >&2; return 1; }
   self_test_assert_contains "$test_root/pool-capacity-blocked.out" "pool-capacity-blocked=1"
+  self_test_assert_contains "$test_root/pool-capacity-blocked.out" "ready-no-dispatch=0"
   self_test_assert_contains "$test_root/pool-capacity-blocked.out" "pending investigation excludes active SSH pool capacity blockers: 1"
   self_test_assert_contains "$test_root/pool-capacity-blocked.out" "pending investigation deferred (pool capacity blockers remain: 1)"
+  self_test_assert_not_contains "$commands_file" "retry-task wf-1000-23/regression"
+  self_test_assert_not_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: active launch dispatch rows start managed owner and defer pending investigation"
+  self_test_reset
+  SELF_TEST_OWNER_READY=false
+  printf 'retry-workflow\twf-1000-26\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-26" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-26","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-26/regression","attemptId":"wf-1000-26/regression-a1"}],"queued":[],"runningCount":1,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"id":"wf-1000-26/regression","status":"pending","config":{"workflowId":"wf-1000-26","runnerKind":"ssh","poolId":"pnpm-ssh"},"execution":{"selectedAttemptId":"wf-1000-26/regression-a1","lastHeartbeatAt":"2000-01-01T00:00:00Z","launchStartedAt":"2000-01-01T00:00:00Z","phase":"launching"}}' > "$tasks_dir/wf-1000-26.jsonl"
+  python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+conn = sqlite3.connect(db_path)
+with conn:
+    conn.executescript(
+        """
+        CREATE TABLE task_launch_dispatch (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          state TEXT
+        );
+        INSERT INTO task_launch_dispatch (state) VALUES ('enqueued');
+        """
+    )
+conn.close()
+PY
+  run_cycle selftest-active-dispatch-owner > "$test_root/active-dispatch-owner.out" 2>&1 || { sed -n '1,220p' "$test_root/active-dispatch-owner.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/owner-starts.log" "start-managed-owner"
+  self_test_assert_contains "$test_root/active-dispatch-owner.out" "active launch dispatch rows need an owner dispatcher: 1"
+  self_test_assert_contains "$test_root/active-dispatch-owner.out" "pending investigation deferred (managed owner dispatcher started for active launch dispatch rows: 1)"
   self_test_assert_not_contains "$codex_commands_file" "exec --cd"
 
   echo "self-test: healthy pending SSH task is investigated without executor switch"
@@ -2940,6 +3081,65 @@ PY
   self_test_assert_contains "$test_root/stale-running.out" "blockers=0"
   self_test_assert_contains "$test_root/stale-running.out" "stale-running=1"
   self_test_assert_contains "$test_root/stale-running.out" "pending investigation includes stale running tasks: 1"
+  self_test_assert_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: stale running task is investigated despite SSH pool capacity blockers"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  printf 'retry-workflow\twf-1000-27\t%s\nretry-workflow\twf-1000-28\t%s\n' "$now_epoch" "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-27" "wf-1000-28" > "$workflows_label_file"
+  printf '%s\n' \
+    '{"id":"wf-1000-27","status":"running"}' \
+    '{"id":"wf-1000-28","status":"running"}' > "$workflows_jsonl_file"
+  printf '{"id":"wf-1000-27/run","status":"running","config":{"workflowId":"wf-1000-27","runnerKind":"worktree"},"execution":{"lastHeartbeatAt":"%s","startedAt":"%s","phase":"executing"}}\n' "$stale_queue_ts" "$stale_queue_ts" > "$tasks_dir/wf-1000-27.jsonl"
+  printf '%s\n' '{"id":"wf-1000-28/regression","status":"pending","config":{"workflowId":"wf-1000-28","runnerKind":"ssh","poolId":"pnpm-ssh"},"execution":{"selectedAttemptId":"wf-1000-28/regression-a1"}}' > "$tasks_dir/wf-1000-28.jsonl"
+  python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+conn = sqlite3.connect(db_path)
+with conn:
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          status TEXT,
+          runner_kind TEXT,
+          pool_id TEXT,
+          dependencies TEXT,
+          selected_attempt_id TEXT,
+          launch_phase TEXT
+        );
+        CREATE TABLE events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          task_id TEXT,
+          event_type TEXT,
+          payload TEXT,
+          created_at TEXT DEFAULT (datetime('now'))
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO tasks VALUES (?, ?, ?, ?, ?, ?, ?)",
+        ("wf-1000-28/regression", "pending", "ssh", "pnpm-ssh", "[]", "wf-1000-28/regression-a1", ""),
+    )
+    conn.execute(
+        "INSERT INTO events (task_id, event_type, payload) VALUES (?, ?, ?)",
+        (
+            "wf-1000-28/regression",
+            "task.executor.deferred",
+            '{"reason":"execution-pool-capacity","poolId":"pnpm-ssh"}',
+        ),
+    )
+conn.close()
+PY
+  run_cycle selftest-stale-running-with-pool-capacity > "$test_root/stale-running-with-pool-capacity.out" 2>&1 || { sed -n '1,240p' "$test_root/stale-running-with-pool-capacity.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/stale-running-with-pool-capacity.out" "stale-running=1"
+  self_test_assert_contains "$test_root/stale-running-with-pool-capacity.out" "pool-capacity-blocked=1"
+  self_test_assert_contains "$test_root/stale-running-with-pool-capacity.out" "pending investigation includes stale running tasks: 1"
+  self_test_assert_contains "$test_root/stale-running-with-pool-capacity.out" "pending investigation excludes active SSH pool capacity blockers: 1"
+  self_test_assert_not_contains "$test_root/stale-running-with-pool-capacity.out" "pending investigation deferred (pool capacity blockers remain: 1)"
   self_test_assert_contains "$codex_commands_file" "exec --cd"
 
   echo "self-test: stale running task investigation bypasses fresh blockers"


### PR DESCRIPTION
## Summary

Classifies retry-loop capacity waits separately from real stalled tasks.

Pool-capacity blockers are deferred while stale no-lease and no-dispatch cases still investigate.

## Test Plan

- [x] `mergify stack push -t upstream/master --branch-prefix stack/EdbertChan`
- [x] `mergify stack list -t upstream/master --json`
- [x] `bash -n scripts/retry-pending-autofix-failed.sh`
- [x] `bash scripts/retry-pending-autofix-failed.sh --self-test`
- [x] `bash scripts/repro/repro-runner-capacity-underused-by-failed-upstream.sh`
- [x] `bash scripts/repro/repro-running-ssh-task-without-lease.sh`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0f87f14c0a1fb6e880e89bb65120980a4d938d01`
- Post-revert steps: Re-run the affected retry/repro validation if reverting after landing.
- Data migration? No

Depends-On: #1115