### PR TITLE
test(repro): tolerate unavailable live db diagnostics

### DIFF
--- a/scripts/repro/repro-pending-task-did-not-run-wf-1778431097453-46-regression-inv-117.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1778431097453-46-regression-inv-117.sh
@@ -170,7 +170,11 @@ import sys
 
 db_path = pathlib.Path(sys.argv[1]).expanduser()
 task_id = sys.argv[2]
-conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+except sqlite3.Error as exc:
+    print(f"[repro] skipped live diagnostic: unable to open local DB: {exc}")
+    raise SystemExit(0)
 conn.row_factory = sqlite3.Row
 try:
     task = conn.execute(
@@ -210,6 +214,8 @@ try:
     print("[repro] local DB task:", json.dumps(dict(task), sort_keys=True))
     print("[repro] local DB launch_dispatch_rows:", json.dumps([dict(row) for row in dispatch_rows], sort_keys=True))
     print("[repro] local DB recent_events:", json.dumps([dict(row) for row in recent_events], sort_keys=True))
+except sqlite3.Error as exc:
+    print(f"[repro] skipped live diagnostic: unable to read local DB: {exc}")
 finally:
     conn.close()
 PY

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1779113239579-2-final-regression.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1779113239579-2-final-regression.sh
@@ -81,7 +81,11 @@ import sys
 
 db_path = pathlib.Path(sys.argv[1]).expanduser()
 task_id = sys.argv[2]
-conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+except sqlite3.Error as exc:
+    print(f"[repro] skipped live diagnostic: unable to open local DB: {exc}")
+    raise SystemExit(0)
 conn.row_factory = sqlite3.Row
 try:
     task = conn.execute(
@@ -118,6 +122,8 @@ try:
     print("[repro] local DB output_count:", output_count)
     if task["status"] == "running" and dispatch and dispatch["state"] == "completed" and output_count == 0:
         print("[repro] local DB diagnostic confirmed: running task has completed launch dispatch and no task output")
+except sqlite3.Error as exc:
+    print(f"[repro] skipped live diagnostic: unable to read local DB: {exc}")
 finally:
     conn.close()
 PY

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1779680045111-2-final-regression-test-all.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1779680045111-2-final-regression-test-all.sh
@@ -124,7 +124,11 @@ import sys
 
 db_path = pathlib.Path(sys.argv[1]).expanduser()
 task_id = sys.argv[2]
-conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+except sqlite3.Error as exc:
+    print(f"[repro] skipped live diagnostic: unable to open local DB: {exc}")
+    raise SystemExit(0)
 conn.row_factory = sqlite3.Row
 try:
     task = conn.execute(
@@ -161,6 +165,8 @@ try:
     print("[repro] local DB active_matching_ssh_lease_count:", len(active_leases))
     if task["status"] == "running" and task["runner_kind"] == "ssh" and len(active_leases) == 0:
         print("[repro] local DB diagnostic confirmed: running SSH task has no active matching lease")
+except sqlite3.Error as exc:
+    print(f"[repro] skipped live diagnostic: unable to read local DB: {exc}")
 finally:
     conn.close()
 PY

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1780292402489-6-final-regression-test-all.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1780292402489-6-final-regression-test-all.sh
@@ -162,7 +162,11 @@ import sys
 
 db_path = pathlib.Path(sys.argv[1]).expanduser()
 task_id = sys.argv[2]
-conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+except sqlite3.Error as exc:
+    print(f"[repro] skipped live diagnostic: unable to open local DB: {exc}")
+    raise SystemExit(0)
 conn.row_factory = sqlite3.Row
 try:
     task = conn.execute(
@@ -203,6 +207,8 @@ try:
             print("[repro] local DB diagnostic confirmed: running SSH task has no active matching lease")
         else:
             print("[repro] local DB diagnostic: target currently has an active matching lease")
+except sqlite3.Error as exc:
+    print(f"[repro] skipped live diagnostic: unable to read local DB: {exc}")
 finally:
     conn.close()
 PY


### PR DESCRIPTION
## Summary

Makes repro live-database diagnostics fail open when the local DB is unavailable.

The synthetic root-cause proof still runs even after cleanup removes or locks production state.

## Test Plan

- [x] `mergify stack push -t upstream/master --branch-prefix stack/EdbertChan`
- [x] `mergify stack list -t upstream/master --json`
- [x] `bash scripts/repro/repro-pending-task-did-not-run-wf-1778431097453-46-regression-inv-117.sh`
- [x] `bash scripts/repro/repro-pending-task-did-not-run-wf-1779113239579-2-final-regression.sh`
- [x] `bash scripts/repro/repro-pending-task-did-not-run-wf-1779680045111-2-final-regression-test-all.sh`
- [x] `bash scripts/repro/repro-pending-task-did-not-run-wf-1780292402489-6-final-regression-test-all.sh`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert c971754930afeca8fb8da1f3d51e2498e547616e`
- Post-revert steps: Re-run the affected retry/repro validation if reverting after landing.
- Data migration? No

Depends-On: #1116