### PR TITLE
test(app): isolate daemon new-attempt reset e2e

### DIFF
--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -2,6 +2,7 @@ import { test as base, _electron as electron, expect, type ElectronApplication, 
 import { tmpdir } from 'node:os';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import { SQLiteAdapter } from '@invoker/data-store';
 import { stringify as yamlStringify } from 'yaml';
 import { E2E_REPO_URL } from './fixtures/electron-app.js';
@@ -62,21 +63,72 @@ async function waitForTask(page: Page, taskId: string, predicate: (task: any) =>
 }
 
 async function launchApp(testDir: string, configPath: string): Promise<{ app: ElectronApplication; page: Page }> {
+  const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+  const electronUserDataDir = path.join(testDir, 'electron-user-data');
   const app = await electron.launch({
-    args: launchArgs(),
+    args: [
+      ...launchArgs().slice(0, -1),
+      `--user-data-dir=${electronUserDataDir}`,
+      MAIN_JS,
+    ],
     env: {
       ...process.env,
       NODE_ENV: 'test',
       TZ: 'UTC',
       INVOKER_DB_DIR: testDir,
+      INVOKER_IPC_SOCKET: ipcSocketPath,
       INVOKER_ALLOW_DELETE_ALL: '1',
       INVOKER_E2E_ENABLE_COMPOSITOR: '1',
       INVOKER_REPO_CONFIG_PATH: configPath,
+      INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:
+        process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '5000',
+      INVOKER_EMBEDDED_TERMINAL_BACKEND:
+        process.env.INVOKER_E2E_EMBEDDED_TERMINAL_BACKEND ?? 'pty',
     },
   });
   const page = await app.firstWindow();
   await waitForInvoker(page);
   return { app, page };
+}
+
+async function closeApp(app: ElectronApplication): Promise<void> {
+  const child = app.process();
+  const closePromise = app.close().catch(() => undefined);
+  const timedOut = await Promise.race([
+    closePromise.then(() => false),
+    delay(5_000).then(() => true),
+  ]);
+  if (timedOut) {
+    child.kill('SIGTERM');
+    await Promise.race([closePromise, delay(2_000)]);
+    if (!child.killed) {
+      child.kill('SIGKILL');
+    }
+  }
+}
+
+async function waitForOwnerCloseSettle(): Promise<void> {
+  await delay(1_500);
+}
+
+async function waitForStandaloneOwnerExit(): Promise<void> {
+  await delay(6_000);
+}
+
+async function cleanupWorkflow(page: Page | undefined): Promise<void> {
+  if (!page || page.isClosed()) return;
+  await page.evaluate(async () => {
+    try {
+      await window.invoker.stop();
+    } catch {
+      // Best-effort cleanup; preserve the original test failure.
+    }
+    try {
+      await window.invoker.deleteAllWorkflows();
+    } catch {
+      // Best-effort cleanup; preserve the original test failure.
+    }
+  }).catch(() => undefined);
 }
 
 async function seedStaleLaunchAttempt(dbPath: string, taskId: string, attemptId: string, staleAt: Date): Promise<void> {
@@ -129,10 +181,11 @@ base.describe('Task new-attempt reset repro', () => {
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
 
     let app: ElectronApplication | undefined;
+    let page: Page | undefined;
     try {
       const launched = await launchApp(testDir, configPath);
       app = launched.app;
-      let page = launched.page;
+      page = launched.page;
 
       await page.evaluate(async () => {
         await window.invoker.clear();
@@ -143,8 +196,9 @@ base.describe('Task new-attempt reset repro', () => {
       const loaded = await waitForTask(page, 'slow-task', (task) => task.status === 'pending');
       const oldAttemptId = `${loaded.id}-old-attempt`;
       const staleTs = '2025-01-01T00:00:00.000Z';
-      await app.close();
+      await closeApp(app);
       app = undefined;
+      await waitForOwnerCloseSettle();
       await seedStaleLaunchAttempt(dbPath, loaded.id, oldAttemptId, new Date(staleTs));
 
       const relaunchedApp = await launchApp(testDir, configPath);
@@ -191,7 +245,11 @@ base.describe('Task new-attempt reset repro', () => {
       expect(oldAttempt?.status).toBe('cancelled');
       expect(newAttempt?.status).toBe('running');
     } finally {
-      await app?.close().catch(() => undefined);
+      await cleanupWorkflow(page);
+      if (app) {
+        await closeApp(app).catch(() => undefined);
+        await waitForStandaloneOwnerExit();
+      }
       if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
         rmSync(testDir, { recursive: true, force: true });
       }

--- a/scripts/repro/repro-daemon-task-new-attempt-reset.sh
+++ b/scripts/repro/repro-daemon-task-new-attempt-reset.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: GUI client mode must delegate resume/read state to the daemon owner.
+#
+# Root cause guarded here:
+#   A stale pending launch attempt persisted in SQLite can leave the GUI client
+#   showing the old selectedAttemptId after explicit resume if resume/read state
+#   is handled by the read-only GUI snapshot instead of the daemon owner.
+#
+# Fixed behavior:
+#   Explicit resume supersedes the stale attempt, clears stale launch runtime
+#   fields, and the detached daemon owner exits cleanly before Playwright
+#   worker teardown.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec scripts/test-suites/required/19-task-new-attempt-reset-repro.sh


### PR DESCRIPTION
## Summary

Isolates the daemon new-attempt reset e2e so owner processes and IPC sockets do not leak between test phases.

The repro now reliably proves stale launch attempts are superseded after explicit resume.

## Test Plan

- [x] `scripts/repro/repro-daemon-task-new-attempt-reset.sh`

## Revert Plan

- Safe to revert? Yes, but the stale-attempt repro can become flaky again.
- Revert command: `git revert affcb8315`
- Post-revert steps: None
- Data migration? No

Depends-On: #1118