### PR TITLE
refactor(execution): name queued repo clone path

### DIFF
--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -219,7 +219,7 @@ describe('open-terminal integration', () => {
     // Mock the pool to return our temp directory
     Object.defineProperty(executor, 'pool', {
       value: {
-        ensureClone: vi.fn().mockResolvedValue(mockWorktreeDir),
+        ensureCloneThroughRepoQueue: vi.fn().mockResolvedValue(mockWorktreeDir),
         acquireWorktree: vi.fn().mockResolvedValue({
           worktreePath: mockWorktreeDir,
           branch: 'test-branch',

--- a/packages/execution-engine/src/__tests__/repo-pool.test.ts
+++ b/packages/execution-engine/src/__tests__/repo-pool.test.ts
@@ -48,17 +48,17 @@ describe('RepoPool', () => {
     rmSync(localRepoUrl, { recursive: true, force: true });
   });
 
-  it('ensureClone: clones repo on first call', async () => {
-    const path = await pool.ensureClone(localRepoUrl);
+  it('ensureCloneThroughRepoQueue: clones repo on first call', async () => {
+    const path = await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     expect(path).toBeDefined();
     // Verify it's a git repo
     const result = execSync('git rev-parse --is-inside-work-tree', { cwd: path }).toString().trim();
     expect(result).toBe('true');
   });
 
-  it('ensureClone: returns cached path on second call', async () => {
-    const p1 = await pool.ensureClone(localRepoUrl);
-    const p2 = await pool.ensureClone(localRepoUrl);
+  it('ensureCloneThroughRepoQueue: returns cached path on second call', async () => {
+    const p1 = await pool.ensureCloneThroughRepoQueue(localRepoUrl);
+    const p2 = await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     expect(p1).toBe(p2);
   });
 
@@ -78,19 +78,19 @@ describe('RepoPool', () => {
     const httpsUrl = 'https://github.com/Neko-Catpital-Labs/Invoker';
     const sshUrl = 'git@github.com:Neko-Catpital-Labs/Invoker.git';
     const clonePath = githubPool.getClonePath(httpsUrl);
-    const doEnsureClone = vi
-      .spyOn(githubPool as any, 'doEnsureClone')
+    const ensureCloneUnqueued = vi
+      .spyOn(githubPool as any, 'ensureCloneUnqueued')
       .mockImplementation(async (_repoUrl: string) => clonePath);
 
     const [p1, p2] = await Promise.all([
-      githubPool.ensureClone(httpsUrl),
-      githubPool.ensureClone(sshUrl),
+      githubPool.ensureCloneThroughRepoQueue(httpsUrl),
+      githubPool.ensureCloneThroughRepoQueue(sshUrl),
     ]);
 
     expect(p1).toBe(clonePath);
     expect(p2).toBe(clonePath);
-    expect(doEnsureClone).toHaveBeenCalledTimes(1);
-    expect(doEnsureClone).toHaveBeenCalledWith(httpsUrl);
+    expect(ensureCloneUnqueued).toHaveBeenCalledTimes(1);
+    expect(ensureCloneUnqueued).toHaveBeenCalledWith(httpsUrl);
     await githubPool.destroyAll();
   });
 
@@ -131,7 +131,7 @@ describe('RepoPool', () => {
   });
 
   it('destroyAll: removes all worktrees but preserves cache', async () => {
-    const clonePath = await pool.ensureClone(localRepoUrl);
+    const clonePath = await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     await pool.acquireWorktree(localRepoUrl, 'b1');
     await pool.acquireWorktree(localRepoUrl, 'b2');
     await pool.destroyAll();
@@ -391,17 +391,17 @@ describe('RepoPool', () => {
       );
     }
 
-    it('ensureClone succeeds when fetch --all fails', async () => {
-      await pool.ensureClone(localRepoUrl);
+    it('ensureCloneThroughRepoQueue succeeds when fetch --all fails', async () => {
+      await pool.ensureCloneThroughRepoQueue(localRepoUrl);
       spyFetchToFail(pool);
 
-      const path = await pool.ensureClone(localRepoUrl);
+      const path = await pool.ensureCloneThroughRepoQueue(localRepoUrl);
       expect(path).toBeDefined();
       expect(existsSync(path)).toBe(true);
     });
 
     it('refreshMirrorForRebase succeeds when fetch --all fails', async () => {
-      await pool.ensureClone(localRepoUrl);
+      await pool.ensureCloneThroughRepoQueue(localRepoUrl);
       spyFetchToFail(pool);
 
       const dir = await pool.refreshMirrorForRebase(localRepoUrl, 'master');
@@ -410,7 +410,7 @@ describe('RepoPool', () => {
     });
 
     it('skips per-base fetch after a successful full origin ref refresh', async () => {
-      await pool.ensureClone(localRepoUrl);
+      await pool.ensureCloneThroughRepoQueue(localRepoUrl);
       const orig = (pool as any).execGit.bind(pool);
       const execGit = vi.spyOn(pool as any, 'execGit').mockImplementation(
         (...params: unknown[]) => {
@@ -440,7 +440,7 @@ describe('RepoPool', () => {
     });
 
     it('reuses the base commit resolved by the rebase refresh batch', async () => {
-      await pool.ensureClone(localRepoUrl);
+      await pool.ensureCloneThroughRepoQueue(localRepoUrl);
       const orig = (pool as any).execGit.bind(pool);
       const execGit = vi.spyOn(pool as any, 'execGit').mockImplementation(
         (...params: unknown[]) => {
@@ -468,7 +468,7 @@ describe('RepoPool', () => {
     });
 
     it('separate pools sharing cacheDir tolerate fetch failures', async () => {
-      await pool.ensureClone(localRepoUrl);
+      await pool.ensureCloneThroughRepoQueue(localRepoUrl);
 
       const pool2 = new RepoPool({ cacheDir: tmpDir });
       const pool3 = new RepoPool({ cacheDir: tmpDir });
@@ -477,8 +477,8 @@ describe('RepoPool', () => {
 
       try {
         const [r1, r2] = await Promise.all([
-          pool2.ensureClone(localRepoUrl),
-          pool3.ensureClone(localRepoUrl),
+          pool2.ensureCloneThroughRepoQueue(localRepoUrl),
+          pool3.ensureCloneThroughRepoQueue(localRepoUrl),
         ]);
 
         expect(r1).toBe(r2);
@@ -877,8 +877,8 @@ describe('RepoPool', () => {
     });
   });
 
-  it('ensureClone skips network refresh when remoteFetchForPool.enabled is false', async () => {
-    await pool.ensureClone(localRepoUrl);
+  it('ensureCloneThroughRepoQueue skips network refresh when remoteFetchForPool.enabled is false', async () => {
+    await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     const clonePath = pool.getClonePath(localRepoUrl);
     const shaBefore = execSync('git rev-parse origin/master', { cwd: clonePath }).toString().trim();
 
@@ -886,12 +886,12 @@ describe('RepoPool', () => {
     execSync('git add -A && git commit -m "upstream advance"', { cwd: localRepoUrl });
 
     remoteFetchForPool.enabled = false;
-    await pool.ensureClone(localRepoUrl);
+    await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     const shaSkipped = execSync('git rev-parse origin/master', { cwd: clonePath }).toString().trim();
     expect(shaSkipped).toBe(shaBefore);
 
     remoteFetchForPool.enabled = true;
-    await pool.ensureClone(localRepoUrl);
+    await pool.ensureCloneThroughRepoQueue(localRepoUrl);
     const shaFresh = execSync('git rev-parse origin/master', { cwd: clonePath }).toString().trim();
     expect(shaFresh).not.toBe(shaBefore);
   });

--- a/packages/execution-engine/src/__tests__/worktree-executor.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-executor.test.ts
@@ -48,11 +48,11 @@ function makeRequest(overrides: Partial<WorkRequest> = {}): WorkRequest {
 
 /**
  * Mock the RepoPool on a WorktreeExecutor instance so that
- * pool.ensureClone / pool.acquireWorktree bypass real git.
+ * pool.ensureCloneThroughRepoQueue / pool.acquireWorktree bypass real git.
  */
 function mockPool(fam: WorktreeExecutor) {
   const pool = {
-    ensureClone: vi.fn().mockResolvedValue('/fake/cache/clone'),
+    ensureCloneThroughRepoQueue: vi.fn().mockResolvedValue('/fake/cache/clone'),
     reconcileActiveWorktrees: vi.fn(),
     acquireWorktree: vi.fn().mockImplementation((_repoUrl: string, branch: string) => {
       const sanitized = branch.replace(/\//g, '-');
@@ -773,7 +773,7 @@ describe('WorktreeExecutor', () => {
     const branch = 'experiment/action-1-abc12345';
     const worktreePath = '/fake/worktrees/experiment-action-1-abc12345';
     const pool = {
-      ensureClone: vi.fn().mockResolvedValue('/fake/cache/clone'),
+      ensureCloneThroughRepoQueue: vi.fn().mockResolvedValue('/fake/cache/clone'),
       reconcileActiveWorktrees: vi.fn(),
       acquireWorktree: vi.fn().mockResolvedValue({
         clonePath: '/fake/cache/clone',

--- a/packages/execution-engine/src/__tests__/worktree-leak-repro.test.ts
+++ b/packages/execution-engine/src/__tests__/worktree-leak-repro.test.ts
@@ -39,7 +39,7 @@ function makeRequest(overrides: Partial<WorkRequest> = {}): WorkRequest {
  */
 function mockPool(fam: WorktreeExecutor) {
   const pool = {
-    ensureClone: vi.fn().mockResolvedValue('/fake/cache/clone'),
+    ensureCloneThroughRepoQueue: vi.fn().mockResolvedValue('/fake/cache/clone'),
     acquireWorktree: vi.fn().mockImplementation((_repoUrl: string, branch: string) => {
       const sanitized = branch.replace(/\//g, '-');
       return Promise.resolve({
@@ -211,7 +211,7 @@ describe('BUG REPRO: worktree lifecycle leaks', () => {
     expect((executor as any).entries.size).toBe(0);
   });
 
-  it('should call pool.ensureClone (which fetches) before branching when baseBranch is set', async () => {
+  it('should call pool.ensureCloneThroughRepoQueue (which fetches) before branching when baseBranch is set', async () => {
     const { taskProcess } = setupSpawnMock();
 
     const request = makeRequest({
@@ -219,9 +219,9 @@ describe('BUG REPRO: worktree lifecycle leaks', () => {
     });
     await executor.start(request);
 
-    // pool.ensureClone handles fetching internally (git fetch --all on existing clones)
+    // pool.ensureCloneThroughRepoQueue handles fetching internally (git fetch --all on existing clones)
     const pool = (executor as any).pool;
-    expect(pool.ensureClone).toHaveBeenCalledWith('git@github.com:test/repo.git');
+    expect(pool.ensureCloneThroughRepoQueue).toHaveBeenCalledWith('git@github.com:test/repo.git');
 
     // Cleanup
     taskProcess.emit('close', 0, null);

--- a/packages/execution-engine/src/repo-pool.ts
+++ b/packages/execution-engine/src/repo-pool.ts
@@ -436,39 +436,39 @@ export class RepoPool {
     return timing.span(functionName, metadata, fn);
   }
 
-  async ensureClone(repoUrl: string): Promise<string> {
+  async ensureCloneThroughRepoQueue(repoUrl: string): Promise<string> {
     const bench = createExecutionBench({
       module: 'repo-pool-bench',
       baseMetadata: { repoUrl },
     });
-    bench('RepoPool.ensureClone.begin');
+    bench('RepoPool.ensureCloneThroughRepoQueue.begin');
     const repoKey = this.repoKey(repoUrl);
     // Join the per-repo git operation chain so fetch/clone cannot race with
     // worktree acquisition, rebase refresh, or branch cleanup against the same
     // shared cache.
     const existing = this.cloneLocks.get(repoKey);
     if (existing) {
-      bench('RepoPool.ensureClone.waitForExistingLock.before');
+      bench('RepoPool.ensureCloneThroughRepoQueue.waitForExistingLock.before');
       const clonePath = await existing;
-      bench('RepoPool.ensureClone.waitForExistingLock.after', { clonePath });
+      bench('RepoPool.ensureCloneThroughRepoQueue.waitForExistingLock.after', { clonePath });
       return clonePath;
     }
 
     const prev = this.repoChains.get(repoKey) ?? Promise.resolve();
     const queuedAtMs = Date.now();
     const promise = prev.then(() => {
-      bench('RepoPool.ensureClone.repoChainWait.after', { durationMs: Date.now() - queuedAtMs });
-      return this.doEnsureClone(repoUrl);
+      bench('RepoPool.ensureCloneThroughRepoQueue.repoChainWait.after', { durationMs: Date.now() - queuedAtMs });
+      return this.ensureCloneUnqueued(repoUrl);
     });
     this.cloneLocks.set(repoKey, promise);
     this.repoChains.set(repoKey, promise.catch(() => {}));
     try {
       const clonePath = await promise;
-      bench('RepoPool.ensureClone.after', { clonePath });
+      bench('RepoPool.ensureCloneThroughRepoQueue.after', { clonePath });
       return clonePath;
     } finally {
       this.cloneLocks.delete(repoKey);
-      bench('RepoPool.ensureClone.lockDeleted');
+      bench('RepoPool.ensureCloneThroughRepoQueue.lockDeleted');
     }
   }
 
@@ -567,53 +567,53 @@ export class RepoPool {
     bench('RepoPool.runPreserveOrResetWithRecovery.retryRunBashLocal.after');
   }
 
-  private async doEnsureClone(repoUrl: string): Promise<string> {
+  private async ensureCloneUnqueued(repoUrl: string): Promise<string> {
     const bench = createExecutionBench({
       module: 'repo-pool-bench',
       baseMetadata: { repoUrl },
     });
     const dir = this.cloneDir(repoUrl);
-    bench('RepoPool.doEnsureClone.begin', { dir, exists: existsSync(dir) });
+    bench('RepoPool.ensureCloneUnqueued.begin', { dir, exists: existsSync(dir) });
     if (existsSync(dir)) {
       if (remoteFetchForPool.enabled) {
         try {
-          bench('RepoPool.doEnsureClone.gitFetchAllPrune.before', { dir });
+          bench('RepoPool.ensureCloneUnqueued.gitFetchAllPrune.before', { dir });
           await this.execGit(['fetch', '--all', '--prune'], dir);
-          bench('RepoPool.doEnsureClone.gitFetchAllPrune.after', { dir });
+          bench('RepoPool.ensureCloneUnqueued.gitFetchAllPrune.after', { dir });
         } catch (err) {
-          console.warn(`[RepoPool] doEnsureClone fetch failed: ${err}`);
-          bench('RepoPool.doEnsureClone.gitFetchAllPrune.failed', {
+          console.warn(`[RepoPool] ensureCloneUnqueued fetch failed: ${err}`);
+          bench('RepoPool.ensureCloneUnqueued.gitFetchAllPrune.failed', {
             dir,
             error: err instanceof Error ? err.message : String(err),
           });
         }
         // Advance local HEAD branch to match origin so rev-parse returns the fresh ref
         try {
-          bench('RepoPool.doEnsureClone.gitCurrentBranch.before', { dir });
+          bench('RepoPool.ensureCloneUnqueued.gitCurrentBranch.before', { dir });
           const branch = (await this.execGit(['rev-parse', '--abbrev-ref', 'HEAD'], dir)).trim();
-          bench('RepoPool.doEnsureClone.gitCurrentBranch.after', { dir, branch });
+          bench('RepoPool.ensureCloneUnqueued.gitCurrentBranch.after', { dir, branch });
           if (branch !== 'HEAD') {
-            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.before', { dir, branch });
+            bench('RepoPool.ensureCloneUnqueued.gitFastForwardCurrentBranch.before', { dir, branch });
             await this.execGit(['merge', '--ff-only', `origin/${branch}`], dir);
-            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.after', { dir, branch });
+            bench('RepoPool.ensureCloneUnqueued.gitFastForwardCurrentBranch.after', { dir, branch });
           } else {
-            bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.skipped', { dir, branch });
+            bench('RepoPool.ensureCloneUnqueued.gitFastForwardCurrentBranch.skipped', { dir, branch });
           }
         } catch (err) {
-          bench('RepoPool.doEnsureClone.gitFastForwardCurrentBranch.failed', {
+          bench('RepoPool.ensureCloneUnqueued.gitFastForwardCurrentBranch.failed', {
             dir,
             error: err instanceof Error ? err.message : String(err),
           });
           /* non-ff or detached; leave as-is */
         }
       }
-      bench('RepoPool.doEnsureClone.returnExisting', { dir });
+      bench('RepoPool.ensureCloneUnqueued.returnExisting', { dir });
       return dir;
     }
     mkdirSync(this.cacheDir, { recursive: true });
-    bench('RepoPool.doEnsureClone.gitClone.before', { dir });
+    bench('RepoPool.ensureCloneUnqueued.gitClone.before', { dir });
     await this.execGit(['clone', repoUrl, dir], this.cacheDir);
-    bench('RepoPool.doEnsureClone.gitClone.after', { dir });
+    bench('RepoPool.ensureCloneUnqueued.gitClone.after', { dir });
     return dir;
   }
 
@@ -687,9 +687,9 @@ export class RepoPool {
     traceExecution(
       `${RESTART_TO_BRANCH_TRACE} RepoPool.doAcquireWorktree branch=${branch} (bashPreserveOrReset here; BaseExecutor.setupTaskBranch is not used for this path)`,
     );
-    bench('RepoPool.doAcquireWorktree.ensureClone.before');
-    const clonePath = await this.doEnsureClone(repoUrl);
-    bench('RepoPool.doAcquireWorktree.ensureClone.after', { clonePath });
+    bench('RepoPool.doAcquireWorktree.ensureCloneUnqueued.before');
+    const clonePath = await this.ensureCloneUnqueued(repoUrl);
+    bench('RepoPool.doAcquireWorktree.ensureCloneUnqueued.after', { clonePath });
     const repoKey = this.repoKey(repoUrl);
     const active = this.activeWorktrees.get(repoKey) ?? new Set();
     bench('RepoPool.doAcquireWorktree.activeWorktreeCount', { activeCount: active.size, maxWorktrees: this.maxWorktrees });

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -323,7 +323,7 @@ export class TaskRunner {
     const executor = this.executorRegistry.get('worktree');
     if (!(executor instanceof WorktreeExecutor)) return undefined;
     try {
-      return await executor.getRepoPool().ensureClone(trimmed);
+      return await executor.getRepoPool().ensureCloneThroughRepoQueue(trimmed);
     } catch (err) {
       this.logger.warn(`[merge] ensureRepoMirrorPath failed for ${trimmed}`, { err });
       return undefined;

--- a/packages/execution-engine/src/worktree-executor.ts
+++ b/packages/execution-engine/src/worktree-executor.ts
@@ -153,9 +153,9 @@ export class WorktreeExecutor extends BaseExecutor<WorktreeEntry> {
     const t0 = Date.now();
     const log = (step: string) => traceExecution(`[WorktreeExecutor] start task=${request.actionId} step=${step} elapsed=${Date.now() - t0}ms`);
 
-    bench('RepoPool.ensureClone.before');
-    const clonePath = await this.pool.ensureClone(repoUrl);
-    bench('RepoPool.ensureClone.after', { clonePath });
+    bench('RepoPool.ensureCloneThroughRepoQueue.before');
+    const clonePath = await this.pool.ensureCloneThroughRepoQueue(repoUrl);
+    bench('RepoPool.ensureCloneThroughRepoQueue.after', { clonePath });
     const baseRef = request.inputs.baseBranch ?? 'HEAD';
     const runGit = (args: string[]) => this.execGitSimple(args, clonePath);
     let baseHead = request.inputs.baseCommit?.trim();


### PR DESCRIPTION
## Summary

Renames the queued RepoPool clone entry point from `ensureClone` to `ensureCloneThroughRepoQueue`.

Renames the private helper from `doEnsureClone` to `ensureCloneUnqueued`, making queued and unqueued clone paths explicit.

Behavior stays unchanged: clone deduping still uses `cloneLocks`, and repo-chain serialization still uses `repoChains`.

## Test Plan

- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/repo-pool.test.ts src/__tests__/worktree-executor.test.ts src/__tests__/worktree-leak-repro.test.ts`
- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/open-terminal.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test`
- [x] GitHub CI for the updated Mergify stack

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0b3500990c6768cb92fbfb56780e701c09fa2c3d`
- Post-revert steps: Re-run the execution-engine and app Vitest suites if reverting after landing.
- Data migration? No

Depends-On: #1099