### PR TITLE
fix(app): persist delegated auto-fix intent in daemon owner

### DIFF
--- a/scripts/repro/repro-daemon-autofix-persisted-intent.sh
+++ b/scripts/repro/repro-daemon-autofix-persisted-intent.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Repro: delegated no-track runs must persist auto-fix mutation intent.
+#
+# Root cause guarded here:
+#   In daemon/owner mode, a delegated no-track run could fail a task without the
+#   standalone owner enqueueing the persisted `invoker:fix-with-agent` workflow
+#   mutation intent. The failure event existed, but the auto-fix intent was not
+#   durable.
+#
+# Fixed behavior:
+#   The failing task records task.failed, debug.auto-fix schedule-enqueued, and
+#   a persisted invoker:fix-with-agent row in workflow_mutation_intents.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/app build
+exec scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh


### PR DESCRIPTION
## Summary

Add a repro proving delegated auto-fix intent survives routing through the daemon owner.

This guards the owner-routed mutation path introduced earlier in the stack.

## Test Plan

- [ ] `bash scripts/repro/repro-daemon-autofix-persisted-intent.sh`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 9f75cb8e6`
- Post-revert steps: Re-run daemon auto-fix intent validation.
- Data migration? No

Depends-On: #1109