### PR TITLE
fix(app): coalesce duplicate workflow retry submissions

### DIFF
--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -569,6 +569,85 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
+  it('coalesces duplicate fire-and-forget headless workflow retries while queued or running', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    adapter.saveWorkflow({
+      id: 'wf-2',
+      name: 'wf-2',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const runningGate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (_channel, args) => {
+        const payload = args[0] as { args?: string[] } | undefined;
+        const command = payload?.args?.join(' ') ?? String(args[0]);
+        order.push(command);
+        if (command === 'retry wf-2') {
+          await runningGate.promise;
+        }
+      },
+    );
+
+    const firstQueued = coordinator.submit(
+      'wf-1',
+      'high',
+      'headless.exec',
+      [{ args: ['retry', 'wf-1'], noTrack: true }],
+      { deferDrain: true },
+    );
+    const queuedDuplicates = Array.from({ length: 25 }, () =>
+      coordinator.submit(
+        'wf-1',
+        'high',
+        'headless.exec',
+        [{ args: ['retry', 'wf-1'], noTrack: true }],
+        { deferDrain: true },
+      ),
+    );
+
+    expect(new Set([firstQueued, ...queuedDuplicates])).toEqual(new Set([firstQueued]));
+
+    const firstRunning = coordinator.submit(
+      'wf-2',
+      'high',
+      'headless.exec',
+      [{ args: ['retry', 'wf-2'], noTrack: true }],
+    );
+    await waitFor(() => order.includes('retry wf-2'));
+
+    const runningDuplicates = Array.from({ length: 25 }, () =>
+      coordinator.submit(
+        'wf-2',
+        'high',
+        'headless.exec',
+        [{ args: ['retry', 'wf-2'], noTrack: true }],
+      ),
+    );
+
+    expect(new Set([firstRunning, ...runningDuplicates])).toEqual(new Set([firstRunning]));
+    runningGate.resolve();
+
+    await waitFor(() => adapter.listWorkflowMutationIntents(undefined, ['completed']).length === 2);
+
+    expect(order.sort()).toEqual(['retry wf-1', 'retry wf-2']);
+    expect(adapter.listWorkflowMutationIntents('wf-1')).toHaveLength(1);
+    expect(adapter.listWorkflowMutationIntents('wf-2')).toHaveLength(1);
+  });
+
   it('requeues interrupted running workflow mutations on restart and drains persisted queued work', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -95,6 +95,19 @@ export class PersistedWorkflowMutationCoordinator {
     args: unknown[],
     options?: { deferDrain?: boolean },
   ): number {
+    const coalesced = this.findOpenCoalescibleRetryIntent(workflowId, channel, args);
+    if (coalesced) {
+      this.trace(
+        `submit coalesced workflow=${workflowId} channel=${channel} into intent=${coalesced.id} status=${coalesced.status}`,
+      );
+      if (options?.deferDrain) {
+        this.scheduleWorkflowDrainDeferred(workflowId);
+      } else {
+        this.scheduleWorkflowDrain(workflowId);
+      }
+      return coalesced.id;
+    }
+
     const intentId = this.persistence.enqueueWorkflowMutationIntent(workflowId, channel, args, priority);
     this.enqueueStartedAtMs.set(intentId, Date.now());
     this.createTiming(workflowId, channel, intentId, args)
@@ -112,6 +125,35 @@ export class PersistedWorkflowMutationCoordinator {
       this.scheduleWorkflowDrain(workflowId);
     }
     return intentId;
+  }
+
+  private findOpenCoalescibleRetryIntent(
+    workflowId: string,
+    channel: string,
+    args: unknown[],
+  ): WorkflowMutationIntent | undefined {
+    const key = this.coalescibleRetryKey(channel, args);
+    if (!key) return undefined;
+    const open = this.persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
+    return open.find((intent) => this.coalescibleRetryKey(intent.channel, intent.args) === key);
+  }
+
+  private coalescibleRetryKey(channel: string, args: unknown[]): string | null {
+    if (channel === 'invoker:retry-workflow') {
+      const target = typeof args[0] === 'string' ? args[0] : '';
+      return /^wf-[^/]+$/.test(target) ? `retry-workflow:${target}` : null;
+    }
+    if (channel !== 'headless.exec') {
+      return null;
+    }
+    const payload = args[0] as { args?: unknown[] } | undefined;
+    const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
+    const command = typeof rawArgs[0] === 'string' ? rawArgs[0] : '';
+    const target = typeof rawArgs[1] === 'string' ? rawArgs[1] : '';
+    if (command !== 'retry' || !/^wf-[^/]+$/.test(target)) {
+      return null;
+    }
+    return `retry-workflow:${target}`;
   }
 
   async resumePending(): Promise<void> {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -7035,6 +7035,7 @@ describe('Orchestrator', () => {
       expect(queueStatus.runningCount).toBe(1);
       expect(queueStatus.running[0]?.taskId).toBe(taskId);
       expect(queueStatus.running[0]?.attemptId).toBe(selectedAttemptId);
+      expect(queueStatus.queued.map((task) => task.taskId)).not.toContain(taskId);
     });
 
     it('restartTask supersedes a claimed selected attempt before relaunching', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -4298,9 +4298,11 @@ export class Orchestrator {
         return { task, attemptId, attempt };
       })
       .filter(({ task, attempt }) => this.isTaskExecutionActive(task, attempt, now));
+    const activeTaskIds = new Set(activeAttempts.map(({ task }) => task.id));
     const queuedTasks = this.stateMachine
       .getReadyTasks()
       .filter((task) => task.status === 'pending')
+      .filter((task) => !activeTaskIds.has(task.id))
       .filter((task) => this.getExternalDependencyBlocker(task) === undefined)
       .map((task) => {
         const attempt = task.execution.selectedAttemptId


### PR DESCRIPTION
## Summary

Coalesce duplicate workflow retry submissions in the persisted workflow mutation coordinator.

This prevents repeated retry requests for the same workflow from scheduling duplicate mutation work.

Clear pending fix errors during retry/recreate paths covered by workflow-core tests.

## Architecture

### Before

```mermaid
flowchart LR
  RequestA[retry request] --> Queue[mutation queue]
  RequestB[duplicate retry request] --> Queue
```

### After

```mermaid
flowchart LR
  RequestA[retry request] --> Coordinator[mutation coordinator]
  RequestB[duplicate retry request] --> Coordinator
  Coordinator --> Queue[one queued mutation]
```

## Test Plan

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/persisted-workflow-mutation-coordinator.test.ts`
- [ ] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 05689ce50`
- Post-revert steps: Re-run retry submission and workflow-core retry validation.
- Data migration? No

Depends-On: #1125