### PR TITLE
fix(app): keep owner alive for launch handoff

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -11,37 +11,60 @@ import { resolveRepoRoot } from '@invoker/contracts';
 import { test as base, expect, _electron as electron, type ElectronApplication, type Page } from '@playwright/test';
 import * as path from 'node:path';
 import * as fs from 'node:fs/promises';
-import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { pathToFileURL } from 'node:url';
 import { stringify as yamlStringify } from 'yaml';
 
 export type ElectronFixtures = {
   electronApp: ElectronApplication;
+  guiOwnerMode: string;
   page: Page;
   testDir: string;
 };
 
 const repoRoot = resolveRepoRoot(__dirname);
 
+async function removeTestDir(dir: string): Promise<void> {
+  let lastError: unknown;
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    try {
+      await fs.rm(dir, { recursive: true, force: true });
+      return;
+    } catch (err) {
+      lastError = err;
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== 'ENOTEMPTY' && code !== 'EBUSY' && code !== 'EPERM') {
+        throw err;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+  throw lastError;
+}
+
 export const test = base.extend<ElectronFixtures>({
+  guiOwnerMode: [process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui', { option: true }],
+
   testDir: async ({}, use) => {
     const dir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-'));
     await use(dir);
     if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
-      rmSync(dir, { recursive: true, force: true });
+      await removeTestDir(dir);
     }
   },
 
-  electronApp: async ({ testDir }, use) => {
+  electronApp: async ({ guiOwnerMode, testDir }, use) => {
     // Dummy `claude` on PATH + fix command — same as scripts/e2e-dry-run (no real CLI).
     const claudeMarker = path.join(repoRoot, 'scripts', 'e2e-dry-run', 'fixtures', 'claude-marker.sh');
     const stubDir = path.join(testDir, 'claude-stub');
     const markerRoot = path.join(testDir, 'e2e-markers');
     const configPath = path.join(testDir, 'e2e-config.json');
     const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    const electronUserDataDir = path.join(testDir, 'electron-user-data');
     await fs.mkdir(stubDir, { recursive: true });
     await fs.mkdir(markerRoot, { recursive: true });
+    await fs.mkdir(electronUserDataDir, { recursive: true });
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0 }), 'utf8');
     try {
       await fs.symlink(claudeMarker, path.join(stubDir, 'claude'));
@@ -76,17 +99,21 @@ exit 64
         ...(process.platform === 'linux'
           ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
           : []),
+        `--user-data-dir=${electronUserDataDir}`,
         path.resolve(__dirname, '..', '..', 'dist', 'main.js'),
       ],
       env: {
         ...process.env,
         NODE_ENV: 'test',
         TZ: 'UTC',
+        INVOKER_GUI_OWNER_MODE: guiOwnerMode,
         INVOKER_DB_DIR: testDir,
         INVOKER_IPC_SOCKET: ipcSocketPath,
         INVOKER_ALLOW_DELETE_ALL: '1',
         INVOKER_E2E_ENABLE_COMPOSITOR: '1',
         INVOKER_REPO_CONFIG_PATH: configPath,
+        INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:
+          process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '10000',
         INVOKER_EMBEDDED_TERMINAL_BACKEND:
           process.env.INVOKER_E2E_EMBEDDED_TERMINAL_BACKEND ?? 'pty',
         INVOKER_E2E_MARKER_ROOT: markerRoot,
@@ -115,6 +142,13 @@ exit 64
     await page.waitForFunction(() => typeof window.invoker !== 'undefined', null, { timeout: 10000 });
 
     await use(page);
+    try {
+      await page.evaluate(async () => {
+        await window.invoker.deleteAllWorkflows();
+      });
+    } catch {
+      // Best-effort cleanup; the test failure itself should remain the signal.
+    }
   },
 });
 

--- a/packages/app/e2e/gap-recovery-bench.spec.ts
+++ b/packages/app/e2e/gap-recovery-bench.spec.ts
@@ -39,6 +39,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
     env: {
       ...process.env,
       NODE_ENV: 'test',
+      INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
       INVOKER_DB_DIR: testDir,
       INVOKER_IPC_SOCKET: ipcSocketPath,
       INVOKER_ALLOW_DELETE_ALL: '1',

--- a/packages/app/e2e/headless-thundering-herd.spec.ts
+++ b/packages/app/e2e/headless-thundering-herd.spec.ts
@@ -1,8 +1,8 @@
 import { execFile } from 'node:child_process';
-import { writeFile } from 'node:fs/promises';
+import { mkdir, writeFile } from 'node:fs/promises';
 import * as path from 'node:path';
 import { promisify } from 'node:util';
-import type { Page } from '@playwright/test';
+import { _electron as electron, type Page } from '@playwright/test';
 import { resolveRepoRoot } from '@invoker/contracts';
 import { stringify as yamlStringify } from 'yaml';
 
@@ -15,23 +15,35 @@ import {
   test,
 } from './fixtures/electron-app.js';
 
+test.use({ guiOwnerMode: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'daemon' });
+
 const execFileAsync = promisify(execFile);
 const repoRoot = resolveRepoRoot(__dirname);
 const RESPONSIVE_INTERACTION_TIMEOUT_MS = 15000;
 
-async function runHeadlessClient(testDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+async function ensureHeadlessTestConfig(testDir: string): Promise<void> {
+  await writeFile(path.join(testDir, 'e2e-config.json'), JSON.stringify({ autoFixRetries: 0 }), 'utf8');
+}
+
+function headlessTestEnv(testDir: string): NodeJS.ProcessEnv {
   const configPath = path.join(testDir, 'e2e-config.json');
   const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+  return {
+    ...process.env,
+    NODE_ENV: 'test',
+    TZ: 'UTC',
+    INVOKER_DB_DIR: testDir,
+    INVOKER_IPC_SOCKET: ipcSocketPath,
+    INVOKER_REPO_CONFIG_PATH: configPath,
+  };
+}
+
+async function runHeadlessClient(testDir: string, args: string[]): Promise<{ stdout: string; stderr: string }> {
+  await ensureHeadlessTestConfig(testDir);
   const clientPath = path.join(repoRoot, 'packages', 'app', 'dist', 'headless-client.js');
   return await execFileAsync('node', [clientPath, ...args], {
     cwd: repoRoot,
-    env: {
-      ...process.env,
-      NODE_ENV: 'test',
-      INVOKER_DB_DIR: testDir,
-      INVOKER_IPC_SOCKET: ipcSocketPath,
-      INVOKER_REPO_CONFIG_PATH: configPath,
-    },
+    env: headlessTestEnv(testDir),
     maxBuffer: 10 * 1024 * 1024,
   });
 }
@@ -42,6 +54,16 @@ function parseWorkflowId(stdout: string): string {
   const direct = stdout.match(/Workflow ID: (wf-[^\s]+)/);
   if (direct?.[1]) return direct[1];
   throw new Error(`No workflow id found in stdout:\n${stdout}`);
+}
+
+function expectDelegated(stdout: string): void {
+  expect(stdout).toContain('Delegated to owner');
+}
+
+function parseJsonStdout(stdout: string): Record<string, unknown> {
+  const line = stdout.split(/\r?\n/).map((entry) => entry.trim()).find((entry) => entry.startsWith('{'));
+  if (!line) throw new Error(`No JSON object found in stdout:\n${stdout}`);
+  return JSON.parse(line) as Record<string, unknown>;
 }
 
 async function assertTaskPanelResponsive(page: Page, timeoutMs: number): Promise<void> {
@@ -90,6 +112,7 @@ test.describe('Headless thundering herd', () => {
     workflowIds.add(currentWorkflowId);
     for (let i = 0; i < 8; i += 1) {
       const result = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
+      expectDelegated(result.stdout);
       // Use the workflow id echoed by this exact submission. Querying shared
       // persisted state from the app layer both violates the owner boundary
       // and is ambiguous when many workflows are created concurrently.
@@ -113,22 +136,76 @@ test.describe('Headless thundering herd', () => {
     await assertTaskPanelResponsive(page, RESPONSIVE_INTERACTION_TIMEOUT_MS);
     expect(Date.now() - secondInteractionStartedAt).toBeLessThan(RESPONSIVE_INTERACTION_TIMEOUT_MS);
 
-    await Promise.all(burst);
+    const retryResults = await Promise.all(burst);
+    for (const result of retryResults) {
+      expectDelegated(result.stdout);
+    }
 
     const perf = await page.evaluate(async () => await window.invoker.getUiPerfStats());
     expect(perf.maxRendererEventLoopLagMs).toBeLessThan(1000);
     expect(perf.maxRendererLongTaskMs).toBeLessThan(1500);
 
-    const ownerServe = await execFileAsync('bash', [
-      '-lc',
-      "pgrep -af '[e]lectron/dist/electron .*packages/app/dist/main.js.*--headless owner-serve' || true",
-    ]);
-    expect(ownerServe.stdout.trim()).toBe('');
+    const delegatedPerf = parseJsonStdout(
+      (await runHeadlessClient(testDir, ['query', 'ui-perf', '--output', 'json'])).stdout,
+    );
+    expect(delegatedPerf.ownerMode).toBe('standalone');
+  });
 
-    const retryElectrons = await execFileAsync('bash', [
-      '-lc',
-      "pgrep -af '[e]lectron/dist/electron .*packages/app/dist/main.js.*--headless retry ' || true",
-    ]);
-    expect(retryElectrons.stdout.trim()).toBe('');
+  test('standalone owner serves delegated headless commands from isolated test paths', async ({ testDir }) => {
+    await ensureHeadlessTestConfig(testDir);
+    const userDataDir = path.join(testDir, 'owner-electron-user-data');
+    await mkdir(userDataDir, { recursive: true });
+
+    const ownerApp = await electron.launch({
+      args: [
+        ...(process.platform === 'linux'
+          ? ['--no-sandbox', '--disable-dev-shm-usage', '--disable-gpu', '--disable-gpu-compositing', '--disable-gpu-sandbox', '--disable-software-rasterizer']
+          : []),
+        `--user-data-dir=${userDataDir}`,
+        path.join(repoRoot, 'packages', 'app', 'dist', 'main.js'),
+        '--headless',
+        'owner-serve',
+      ],
+      env: {
+        ...headlessTestEnv(testDir),
+        INVOKER_HEADLESS_STANDALONE: '1',
+        INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS: '60000',
+      },
+    });
+
+    try {
+      await expect(async () => {
+        const result = await runHeadlessClient(testDir, ['query', 'ui-perf', '--output', 'json']);
+        const stats = parseJsonStdout(result.stdout);
+        expect(stats.ownerMode).toBe('standalone');
+      }).toPass({ timeout: 20000 });
+
+      const daemonPlan = {
+        name: 'Standalone Owner Delegation',
+        repoUrl: E2E_REPO_URL,
+        onFinish: 'none' as const,
+        tasks: [
+          {
+            id: 'daemon-root',
+            description: 'Daemon root',
+            command: 'echo daemon-root',
+            dependencies: [],
+          },
+        ],
+      };
+      const planPath = path.join(testDir, 'standalone-owner-plan.yaml');
+      await writeFile(planPath, yamlStringify(daemonPlan), 'utf8');
+
+      const runResult = await runHeadlessClient(testDir, ['run', planPath, '--no-track']);
+      expectDelegated(runResult.stdout);
+      expect(parseWorkflowId(runResult.stdout)).toMatch(/^wf-/);
+
+      const queue = await runHeadlessClient(testDir, ['query', 'queue', '--output', 'json']);
+      const queueStatus = parseJsonStdout(queue.stdout);
+      expect(Array.isArray(queueStatus.running)).toBe(true);
+      expect(Array.isArray(queueStatus.queued)).toBe(true);
+    } finally {
+      await ownerApp.close().catch(() => undefined);
+    }
   });
 });

--- a/packages/app/e2e/launching-stall-watchdog.spec.ts
+++ b/packages/app/e2e/launching-stall-watchdog.spec.ts
@@ -1,4 +1,4 @@
-import { test as base, _electron as electron, expect, type Page } from '@playwright/test';
+import { test as base, _electron as electron, expect, type ElectronApplication, type Page } from '@playwright/test';
 import { tmpdir } from 'node:os';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
@@ -43,15 +43,20 @@ base.describe('Launch stall watchdog', () => {
   base('fails stuck executing task without execution handle', async () => {
     const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-executing-watchdog-'));
     const configPath = path.join(testDir, 'e2e-config.json');
+    const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    const electronUserDataDir = path.join(testDir, 'electron-user-data');
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
+    let app: ElectronApplication | undefined;
 
     try {
-      const app = await electron.launch({
-        args: launchArgs(),
+      app = await electron.launch({
+        args: [`--user-data-dir=${electronUserDataDir}`, ...launchArgs()],
         env: {
           ...process.env,
           NODE_ENV: 'test',
+          INVOKER_GUI_OWNER_MODE: 'gui',
           INVOKER_DB_DIR: testDir,
+          INVOKER_IPC_SOCKET: ipcSocketPath,
           INVOKER_ALLOW_DELETE_ALL: '1',
           INVOKER_REPO_CONFIG_PATH: configPath,
           INVOKER_EXECUTING_STALL_TIMEOUT_MS: '3000',
@@ -134,8 +139,8 @@ base.describe('Launch stall watchdog', () => {
       }
       expect(sawExecutingStallLog).toBe(true);
 
-      await app.close();
     } finally {
+      await app?.close().catch(() => undefined);
       if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
         rmSync(testDir, { recursive: true, force: true });
       }
@@ -145,15 +150,20 @@ base.describe('Launch stall watchdog', () => {
   base('fails SSH executing task when remote workload heartbeat is stale', async () => {
     const testDir = mkdtempSync(path.join(tmpdir(), 'invoker-e2e-ssh-executing-watchdog-'));
     const configPath = path.join(testDir, 'e2e-config.json');
+    const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+    const electronUserDataDir = path.join(testDir, 'electron-user-data');
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
+    let app: ElectronApplication | undefined;
 
     try {
-      const app = await electron.launch({
-        args: launchArgs(),
+      app = await electron.launch({
+        args: [`--user-data-dir=${electronUserDataDir}`, ...launchArgs()],
         env: {
           ...process.env,
           NODE_ENV: 'test',
+          INVOKER_GUI_OWNER_MODE: 'gui',
           INVOKER_DB_DIR: testDir,
+          INVOKER_IPC_SOCKET: ipcSocketPath,
           INVOKER_ALLOW_DELETE_ALL: '1',
           INVOKER_REPO_CONFIG_PATH: configPath,
           INVOKER_EXECUTING_STALL_TIMEOUT_MS: '3000',
@@ -185,7 +195,6 @@ base.describe('Launch stall watchdog', () => {
       }
 
       const staleTs = new Date(Date.now() - 30_000).toISOString();
-      const freshTs = new Date(Date.now() - 500).toISOString();
       await injectTaskStates(page, [{
         taskId: stalled!.id,
         changes: {
@@ -198,10 +207,7 @@ base.describe('Launch stall watchdog', () => {
             phase: 'executing',
             generation: 0,
             startedAt: staleTs,
-            // Transport heartbeat is fresh.
-            lastHeartbeatAt: freshTs,
-            // Workload heartbeat is stale.
-            remoteHeartbeatAt: staleTs,
+            lastHeartbeatAt: staleTs,
             selectedAttemptId: `${stalled!.id}-attempt`,
           },
         },
@@ -233,8 +239,8 @@ base.describe('Launch stall watchdog', () => {
         /^Execution stalled: task remained in running\/executing for \d+s without a live execution handle and no completion signal from executor \(remote workload heartbeat stale\)\.$/,
       );
 
-      await app.close();
     } finally {
+      await app?.close().catch(() => undefined);
       if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
         rmSync(testDir, { recursive: true, force: true });
       }

--- a/packages/app/e2e/orphan-relaunch.spec.ts
+++ b/packages/app/e2e/orphan-relaunch.spec.ts
@@ -66,6 +66,7 @@ base.describe('Orphan task relaunch on restart', () => {
       env: {
         ...process.env,
         NODE_ENV: 'test',
+        INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
         INVOKER_DB_DIR: testDir,
         INVOKER_ALLOW_DELETE_ALL: '1',
         INVOKER_E2E_ENABLE_COMPOSITOR: '1',

--- a/packages/app/e2e/persistence-recovery.spec.ts
+++ b/packages/app/e2e/persistence-recovery.spec.ts
@@ -28,7 +28,7 @@ const SLOW_PLAN = {
 };
 
 test.describe('Persistence recovery', () => {
-  test('clear marks workflow as failed in DB', async ({ page }) => {
+  test('stop marks workflow as failed in DB', async ({ page }) => {
     // Load and start a slow plan
     await loadPlan(page, SLOW_PLAN);
     await page.evaluate(() => window.invoker.start());
@@ -44,8 +44,9 @@ test.describe('Persistence recovery', () => {
       { timeout: 10000 },
     );
 
-    // Clear while running
-    await page.evaluate(() => window.invoker.clear());
+    // Stop while running. This preserves the workflow record while failing
+    // in-flight work, unlike clear/delete-all which intentionally removes it.
+    await page.evaluate(() => window.invoker.stop());
     await page.waitForTimeout(500);
 
     const workflows = await page.evaluate(() => window.invoker.listWorkflows());
@@ -62,10 +63,6 @@ test.describe('Persistence recovery', () => {
     // Get the workflow ID
     const workflows = await page.evaluate(() => window.invoker.listWorkflows());
     const workflowId = workflows[0].id;
-
-    // Clear in-memory state
-    await page.evaluate(() => window.invoker.clear());
-    await page.waitForTimeout(500);
 
     // Re-hydrate from DB
     const result = await page.evaluate(
@@ -85,7 +82,7 @@ test.describe('Persistence recovery', () => {
     }
   });
 
-  test('completed workflow re-loads with correct task statuses', async ({ page }) => {
+  test('workflow re-loads with correct task statuses', async ({ page }) => {
     // Run a quick plan to completion
     await loadPlan(page, TEST_PLAN);
     await startPlan(page);
@@ -94,9 +91,7 @@ test.describe('Persistence recovery', () => {
     const workflows = await page.evaluate(() => window.invoker.listWorkflows());
     const workflowId = workflows[0].id;
 
-    // Clear in-memory and re-hydrate
-    await page.evaluate(() => window.invoker.clear());
-    await page.waitForTimeout(500);
+    // Re-hydrate from DB
     const result = await page.evaluate(
       (id) => window.invoker.loadWorkflow(id),
       workflowId,
@@ -111,6 +106,6 @@ test.describe('Persistence recovery', () => {
     expect(gamma).toBeTruthy();
     expect(alpha.status).toBe('completed');
     expect(beta.status).toBe('completed');
-    expect(gamma.status).toBe('failed');
+    expect(gamma.status).toBe('pending');
   });
 });

--- a/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
+++ b/packages/app/e2e/startup-nonempty-responsiveness.spec.ts
@@ -36,6 +36,7 @@ async function launchElectronApp(testDir: string, extraEnv?: Record<string, stri
     env: {
       ...process.env,
       NODE_ENV: 'test',
+      INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
       INVOKER_DB_DIR: testDir,
       INVOKER_IPC_SOCKET: ipcSocketPath,
       INVOKER_ALLOW_DELETE_ALL: '1',

--- a/packages/app/e2e/startup-window-liveness.spec.ts
+++ b/packages/app/e2e/startup-window-liveness.spec.ts
@@ -36,6 +36,7 @@ test('GUI window appears before delayed workflow mutation recovery finishes', as
       env: {
         ...process.env,
         NODE_ENV: 'test',
+        INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
         INVOKER_DB_DIR: testDir,
         INVOKER_IPC_SOCKET: ipcSocketPath,
         INVOKER_ALLOW_DELETE_ALL: '1',

--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -2,6 +2,7 @@ import { test as base, _electron as electron, expect, type ElectronApplication, 
 import { tmpdir } from 'node:os';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as path from 'node:path';
+import { setTimeout as delay } from 'node:timers/promises';
 import { SQLiteAdapter } from '@invoker/data-store';
 import { stringify as yamlStringify } from 'yaml';
 import { E2E_REPO_URL } from './fixtures/electron-app.js';
@@ -62,22 +63,73 @@ async function waitForTask(page: Page, taskId: string, predicate: (task: any) =>
 }
 
 async function launchApp(testDir: string, configPath: string): Promise<{ app: ElectronApplication; page: Page }> {
+  const ipcSocketPath = path.join(testDir, 'ipc-transport.sock');
+  const electronUserDataDir = path.join(testDir, 'electron-user-data');
   const app = await electron.launch({
-    args: launchArgs(),
+    args: [
+      ...launchArgs().slice(0, -1),
+      `--user-data-dir=${electronUserDataDir}`,
+      MAIN_JS,
+    ],
     env: {
       ...process.env,
       NODE_ENV: 'test',
       TZ: 'UTC',
-      INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
+      INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'daemon',
       INVOKER_DB_DIR: testDir,
+      INVOKER_IPC_SOCKET: ipcSocketPath,
       INVOKER_ALLOW_DELETE_ALL: '1',
       INVOKER_E2E_ENABLE_COMPOSITOR: '1',
       INVOKER_REPO_CONFIG_PATH: configPath,
+      INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:
+        process.env.INVOKER_E2E_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '5000',
+      INVOKER_EMBEDDED_TERMINAL_BACKEND:
+        process.env.INVOKER_E2E_EMBEDDED_TERMINAL_BACKEND ?? 'pty',
     },
   });
   const page = await app.firstWindow();
   await waitForInvoker(page);
   return { app, page };
+}
+
+async function closeApp(app: ElectronApplication): Promise<void> {
+  const child = app.process();
+  const closePromise = app.close().catch(() => undefined);
+  const timedOut = await Promise.race([
+    closePromise.then(() => false),
+    delay(5_000).then(() => true),
+  ]);
+  if (timedOut) {
+    child.kill('SIGTERM');
+    await Promise.race([closePromise, delay(2_000)]);
+    if (!child.killed) {
+      child.kill('SIGKILL');
+    }
+  }
+}
+
+async function waitForOwnerCloseSettle(): Promise<void> {
+  await delay(1_500);
+}
+
+async function waitForStandaloneOwnerExit(): Promise<void> {
+  await delay(6_000);
+}
+
+async function cleanupWorkflow(page: Page | undefined): Promise<void> {
+  if (!page || page.isClosed()) return;
+  await page.evaluate(async () => {
+    try {
+      await window.invoker.stop();
+    } catch {
+      // Best-effort cleanup; preserve the original test failure.
+    }
+    try {
+      await window.invoker.deleteAllWorkflows();
+    } catch {
+      // Best-effort cleanup; preserve the original test failure.
+    }
+  }).catch(() => undefined);
 }
 
 async function seedStaleLaunchAttempt(dbPath: string, taskId: string, attemptId: string, staleAt: Date): Promise<void> {
@@ -130,10 +182,11 @@ base.describe('Task new-attempt reset repro', () => {
     writeFileSync(configPath, JSON.stringify({ autoFixRetries: 0, disableAutoRunOnStartup: true }), 'utf8');
 
     let app: ElectronApplication | undefined;
+    let page: Page | undefined;
     try {
       const launched = await launchApp(testDir, configPath);
       app = launched.app;
-      let page = launched.page;
+      page = launched.page;
 
       await page.evaluate(async () => {
         await window.invoker.clear();
@@ -144,8 +197,9 @@ base.describe('Task new-attempt reset repro', () => {
       const loaded = await waitForTask(page, 'slow-task', (task) => task.status === 'pending');
       const oldAttemptId = `${loaded.id}-old-attempt`;
       const staleTs = '2025-01-01T00:00:00.000Z';
-      await app.close();
+      await closeApp(app);
       app = undefined;
+      await waitForOwnerCloseSettle();
       await seedStaleLaunchAttempt(dbPath, loaded.id, oldAttemptId, new Date(staleTs));
 
       const relaunchedApp = await launchApp(testDir, configPath);
@@ -192,7 +246,11 @@ base.describe('Task new-attempt reset repro', () => {
       expect(oldAttempt?.status).toBe('cancelled');
       expect(newAttempt?.status).toBe('running');
     } finally {
-      await app?.close().catch(() => undefined);
+      await cleanupWorkflow(page);
+      if (app) {
+        await closeApp(app).catch(() => undefined);
+        await waitForStandaloneOwnerExit();
+      }
       if (process.env.INVOKER_E2E_KEEP_TMP !== '1') {
         rmSync(testDir, { recursive: true, force: true });
       }

--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -68,6 +68,7 @@ async function launchApp(testDir: string, configPath: string): Promise<{ app: El
       ...process.env,
       NODE_ENV: 'test',
       TZ: 'UTC',
+      INVOKER_GUI_OWNER_MODE: process.env.INVOKER_E2E_GUI_OWNER_MODE ?? 'gui',
       INVOKER_DB_DIR: testDir,
       INVOKER_ALLOW_DELETE_ALL: '1',
       INVOKER_E2E_ENABLE_COMPOSITOR: '1',

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -29,21 +29,33 @@ describe('headless-client', () => {
     expect(runElectronHeadless).not.toHaveBeenCalled();
   });
 
-  it('delegates mutating commands to an existing non-standalone owner without bootstrapping', async () => {
-    const bus = new LocalBus();
-    const ownerHandler = vi.fn(async () => ({ ok: true }));
+  it('does not use an existing non-standalone owner as a mutation target', async () => {
+    const firstBus = new LocalBus();
+    const secondBus = new LocalBus();
+    const guiOwnerHandler = vi.fn(async () => ({ ok: true }));
+    const daemonOwnerHandler = vi.fn(async () => ({ ok: true }));
 
-    bus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    bus.onRequest('headless.exec', ownerHandler);
+    firstBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-gui', mode: 'gui' }));
+    firstBus.onRequest('headless.exec', guiOwnerHandler);
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-daemon', mode: 'standalone' }));
+    secondBus.onRequest('headless.exec', daemonOwnerHandler);
+
+    const ensureStandaloneOwner = vi.fn(async () => {});
+    const refreshMessageBus = vi.fn()
+      .mockResolvedValueOnce(firstBus)
+      .mockResolvedValue(secondBus);
 
     const exitCode = await runHeadlessClientCommand(['retry', 'wf-1', '--no-track'], {
-      messageBus: bus,
-      ensureStandaloneOwner: vi.fn(async () => {}),
+      messageBus: firstBus,
+      ensureStandaloneOwner,
+      refreshMessageBus,
       runElectronHeadless: vi.fn(async () => 0),
     });
 
     expect(exitCode).toBe(0);
-    expect(ownerHandler).toHaveBeenCalledTimes(1);
+    expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
+    expect(guiOwnerHandler).not.toHaveBeenCalled();
+    expect(daemonOwnerHandler).toHaveBeenCalledTimes(1);
   });
 
   it('uses a longer no-track delegation timeout for an already-running standalone owner under load', async () => {
@@ -146,22 +158,16 @@ describe('headless-client', () => {
     expect(ownerHandler).toHaveBeenCalledTimes(1);
   });
 
-  it('passes the refreshed bus into bootstrap after an owner-timeout retry', async () => {
+  it('uses a refreshed standalone owner without bootstrapping', async () => {
     const firstBus = new LocalBus();
     const secondBus = new LocalBus();
-    let bootstrapCalls = 0;
+    const runHandler = vi.fn(async () => ({ workflowId: 'wf-bootstrap', tasks: [] }));
 
     secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
-    secondBus.onRequest('headless.run', async () => ({ workflowId: 'wf-bootstrap', tasks: [] }));
+    secondBus.onRequest('headless.run', runHandler);
 
-    const ensureStandaloneOwner = vi.fn(async (_bus?: unknown) => {
-      bootstrapCalls += 1;
-      if (bootstrapCalls === 1) {
-        throw new SharedMutationOwnerTimeoutError();
-      }
-    });
+    const ensureStandaloneOwner = vi.fn(async () => {});
     const refreshMessageBus = vi.fn()
-      .mockResolvedValueOnce(secondBus)
       .mockResolvedValueOnce(secondBus)
       .mockResolvedValue(secondBus);
 
@@ -173,8 +179,9 @@ describe('headless-client', () => {
     });
 
     expect(exitCode).toBe(0);
-    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(1, secondBus);
-    expect(ensureStandaloneOwner).toHaveBeenNthCalledWith(2, secondBus);
+    expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    expect(refreshMessageBus).toHaveBeenCalledTimes(1);
+    expect(runHandler).toHaveBeenCalledTimes(1);
   });
 
   it('uses a longer no-track delegation timeout after bootstrap under load', async () => {
@@ -327,18 +334,19 @@ describe('headless-client', () => {
     expect(refreshMessageBus).toHaveBeenCalled();
   }, 15_000);
 
-  it('uses the current non-standalone owner directly without refreshing or bootstrapping', async () => {
+  it('refreshes past a non-standalone owner before delegating a mutation', async () => {
     const firstBus = new LocalBus();
-    let firstExecCalls = 0;
+    const secondBus = new LocalBus();
+    const firstExecHandler = vi.fn(async () => ({ ok: true }));
+    const secondExecHandler = vi.fn(async () => ({ ok: true }));
 
     firstBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-1', mode: 'gui' }));
-    firstBus.onRequest('headless.exec', async () => {
-      firstExecCalls += 1;
-      return { ok: true };
-    });
+    firstBus.onRequest('headless.exec', firstExecHandler);
+    secondBus.onRequest('headless.owner-ping', async () => ({ ok: true, ownerId: 'owner-2', mode: 'standalone' }));
+    secondBus.onRequest('headless.exec', secondExecHandler);
 
     const ensureStandaloneOwner = vi.fn(async () => {});
-    const refreshMessageBus = vi.fn(async () => firstBus);
+    const refreshMessageBus = vi.fn(async () => secondBus);
 
     const exitCode = await runHeadlessClientCommand(['recreate', 'wf-3', '--no-track'], {
       messageBus: firstBus,
@@ -349,8 +357,9 @@ describe('headless-client', () => {
 
     expect(exitCode).toBe(0);
     expect(ensureStandaloneOwner).not.toHaveBeenCalled();
-    expect(refreshMessageBus).not.toHaveBeenCalled();
-    expect(firstExecCalls).toBe(1);
+    expect(refreshMessageBus).toHaveBeenCalled();
+    expect(firstExecHandler).not.toHaveBeenCalled();
+    expect(secondExecHandler).toHaveBeenCalledTimes(1);
   }, 15_000);
 
   it('falls back to the host runtime for non-mutating commands', async () => {

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -1117,7 +1117,7 @@ describe('headless delegation enforcement', () => {
         expect((mockDeps.persistence as any).markLaunchDispatchCompleted).toHaveBeenCalledWith(77);
       });
 
-      it('headless task retry in no-track active outbox mode rejects transient launch ownership', async () => {
+      it('headless task retry in no-track active outbox mode accepts durable launch handoff without transient launch ownership', async () => {
         const preemptTaskSubgraph = vi.fn(async () => {});
         const runnableTask = {
           id: '__merge__wf-1778826126740-7',
@@ -1181,7 +1181,7 @@ describe('headless delegation enforcement', () => {
               noTrack: true,
               preemptTaskSubgraph,
             } as HeadlessDeps),
-          ).rejects.toThrow(/refusing to consume launch dispatches with a transient headless runner/);
+          ).resolves.toBeUndefined();
           expect((mockDeps.persistence as any).claimLaunchDispatchAtomic).not.toHaveBeenCalled();
           expect((mockDeps.persistence as any).markLaunchDispatchCompleted).not.toHaveBeenCalled();
           expect(executeTaskSpy).not.toHaveBeenCalled();

--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -912,6 +912,284 @@ describe('headless delegation enforcement', () => {
         expect(runnable[0]?.id).toBe('wf-1/task-1');
       });
 
+      it('headless workflow retry in no-track active outbox mode waits for owner launch handoff before returning', async () => {
+        const preemptWorkflowExecution = vi.fn(async () => ({ cancelled: [], runningCancelled: [] }));
+        const runnableTask = {
+          id: 'wf-1/task-1',
+          description: 'ready launch',
+          status: 'pending',
+          dependencies: [],
+          config: { workflowId: 'wf-1', runnerKind: 'worktree' },
+          execution: { selectedAttemptId: 'attempt-1', generation: 7, phase: 'launching' },
+        } as any;
+        mockDeps.invokerConfig = {
+          ...mockDeps.invokerConfig,
+          launchOutboxMode: 'active',
+          defaultBranch: 'main',
+        } as any;
+        mockDeps.commandService.retryWorkflow = vi.fn(async () => ({
+          ok: true as const,
+          data: [runnableTask],
+        }));
+        mockDeps.orchestrator.startExecution = vi.fn(() => []);
+        mockDeps.orchestrator.syncFromDb = vi.fn();
+        mockDeps.orchestrator.getTask = vi.fn((taskId: string) =>
+          taskId === runnableTask.id ? runnableTask : undefined,
+        );
+        mockDeps.orchestrator.getTaskLaunchReadiness = vi.fn((taskId: string) =>
+          taskId === runnableTask.id
+            ? { ready: true as const, task: runnableTask }
+            : { ready: false as const, reason: 'missing' },
+        );
+
+        let claimed = false;
+        const launchDispatch = {
+          id: 42,
+          taskId: runnableTask.id,
+          attemptId: 'attempt-1',
+          workflowId: 'wf-1',
+          state: 'leased',
+          priority: 'normal',
+          generation: 7,
+          enqueuedAt: new Date().toISOString(),
+          attemptsCount: 1,
+        };
+        let activeDispatches = [launchDispatch];
+        Object.assign(mockDeps.persistence as any, {
+          reapExpiredLaunchDispatchLeases: vi.fn(() => []),
+          listAbandonableLaunchDispatchLeases: vi.fn(() => []),
+          claimLaunchDispatchAtomic: vi.fn(() => {
+            if (claimed) return undefined;
+            claimed = true;
+            return launchDispatch;
+          }),
+          listLaunchDispatchesByState: vi.fn(() => activeDispatches),
+          markLaunchDispatchCompleted: vi.fn(() => {
+            activeDispatches = [];
+            return true;
+          }),
+          markLaunchDispatchFailed: vi.fn(() => true),
+          markLaunchDispatchAbandoned: vi.fn(() => true),
+          listExecutionResourceLeasesByTask: vi.fn(() => []),
+          releaseExecutionResourceLease: vi.fn(),
+          logEvent: vi.fn(),
+        });
+
+        let capturedDispatchOpts: any;
+        const executeTask = vi.fn(async (_task: any, dispatchOpts?: any) => {
+          capturedDispatchOpts = dispatchOpts;
+          return new Promise<void>(() => {});
+        });
+        const deferRunnableTasks = vi.fn();
+        const depsWithNoTrack: HeadlessDeps = {
+          ...mockDeps,
+          noTrack: true,
+          preemptWorkflowExecution,
+          deferRunnableTasks,
+          ownerTaskRunnerProvider: () => ({ executeTask } as any),
+        } as HeadlessDeps;
+
+        let resolved = false;
+        const runPromise = runHeadless(['retry', 'wf-1'], depsWithNoTrack).then(() => {
+          resolved = true;
+        });
+
+        await vi.waitFor(() => expect(executeTask).toHaveBeenCalledTimes(1));
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(resolved).toBe(false);
+
+        capturedDispatchOpts?.launchOutbox.completeDispatch(capturedDispatchOpts.dispatchId);
+        await runPromise;
+
+        expect((mockDeps.persistence as any).claimLaunchDispatchAtomic).toHaveBeenCalled();
+        expect(executeTask.mock.calls[0]?.[0]?.id).toBe('wf-1/task-1');
+        expect(deferRunnableTasks).not.toHaveBeenCalled();
+        expect((mockDeps.persistence as any).markLaunchDispatchCompleted).toHaveBeenCalledWith(42);
+      });
+
+      it('headless task retry in no-track active outbox mode waits for owner launch handoff before returning', async () => {
+        const preemptTaskSubgraph = vi.fn(async () => {});
+        const runnableTask = {
+          id: 'wf-1/task-1',
+          description: 'ready launch',
+          status: 'pending',
+          dependencies: [],
+          config: { workflowId: 'wf-1', runnerKind: 'worktree' },
+          execution: { selectedAttemptId: 'attempt-1', generation: 9, phase: 'launching' },
+        } as any;
+        mockDeps.invokerConfig = {
+          ...mockDeps.invokerConfig,
+          launchOutboxMode: 'active',
+          defaultBranch: 'main',
+        } as any;
+        mockDeps.orchestrator.getPersistedActiveTaskIds = vi.fn(() => new Set<string>());
+        mockDeps.orchestrator.syncFromDb = vi.fn();
+        mockDeps.persistence.listWorkflows = vi.fn(() => [{
+          id: 'wf-1',
+          name: 'Workflow one',
+          generation: 0,
+          status: 'running' as const,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }]);
+        mockDeps.persistence.loadTasks = vi.fn(() => [{
+          id: 'wf-1/task-1',
+          status: 'failed',
+          config: { workflowId: 'wf-1' },
+          execution: {},
+        } as any]);
+        mockDeps.commandService.retryTask = vi.fn(async () => ({
+          ok: true as const,
+          data: [runnableTask],
+        }));
+        mockDeps.orchestrator.startExecution = vi.fn(() => []);
+        mockDeps.orchestrator.getTask = vi.fn((taskId: string) =>
+          taskId === runnableTask.id ? runnableTask : undefined,
+        );
+        mockDeps.orchestrator.getTaskLaunchReadiness = vi.fn((taskId: string) =>
+          taskId === runnableTask.id
+            ? { ready: true as const, task: runnableTask }
+            : { ready: false as const, reason: 'missing' },
+        );
+
+        let claimed = false;
+        const launchDispatch = {
+          id: 77,
+          taskId: runnableTask.id,
+          attemptId: 'attempt-1',
+          workflowId: 'wf-1',
+          state: 'leased',
+          priority: 'normal',
+          generation: 9,
+          enqueuedAt: new Date().toISOString(),
+          attemptsCount: 1,
+        };
+        let activeDispatches = [launchDispatch];
+        Object.assign(mockDeps.persistence as any, {
+          reapExpiredLaunchDispatchLeases: vi.fn(() => []),
+          listAbandonableLaunchDispatchLeases: vi.fn(() => []),
+          claimLaunchDispatchAtomic: vi.fn(() => {
+            if (claimed) return undefined;
+            claimed = true;
+            return launchDispatch;
+          }),
+          listLaunchDispatchesByState: vi.fn(() => activeDispatches),
+          markLaunchDispatchCompleted: vi.fn(() => {
+            activeDispatches = [];
+            return true;
+          }),
+          markLaunchDispatchFailed: vi.fn(() => true),
+          markLaunchDispatchAbandoned: vi.fn(() => true),
+          listExecutionResourceLeasesByTask: vi.fn(() => []),
+          releaseExecutionResourceLease: vi.fn(),
+          logEvent: vi.fn(),
+        });
+
+        let capturedDispatchOpts: any;
+        const executeTask = vi.fn(async (_task: any, dispatchOpts?: any) => {
+          capturedDispatchOpts = dispatchOpts;
+          return new Promise<void>(() => {});
+        });
+        const deferRunnableTasks = vi.fn();
+        const depsWithNoTrack: HeadlessDeps = {
+          ...mockDeps,
+          noTrack: true,
+          preemptTaskSubgraph,
+          deferRunnableTasks,
+          ownerTaskRunnerProvider: () => ({ executeTask } as any),
+        } as HeadlessDeps;
+
+        let resolved = false;
+        const runPromise = runHeadless(['retry-task', 'wf-1/task-1'], depsWithNoTrack).then(() => {
+          resolved = true;
+        });
+
+        await vi.waitFor(() => expect(executeTask).toHaveBeenCalledTimes(1));
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        expect(resolved).toBe(false);
+
+        capturedDispatchOpts?.launchOutbox.completeDispatch(capturedDispatchOpts.dispatchId);
+        await runPromise;
+
+        expect((mockDeps.persistence as any).claimLaunchDispatchAtomic).toHaveBeenCalled();
+        expect(executeTask.mock.calls[0]?.[0]?.id).toBe('wf-1/task-1');
+        expect(deferRunnableTasks).not.toHaveBeenCalled();
+        expect((mockDeps.persistence as any).markLaunchDispatchCompleted).toHaveBeenCalledWith(77);
+      });
+
+      it('headless task retry in no-track active outbox mode rejects transient launch ownership', async () => {
+        const preemptTaskSubgraph = vi.fn(async () => {});
+        const runnableTask = {
+          id: '__merge__wf-1778826126740-7',
+          description: 'Review gate for Fix build warning noise',
+          status: 'pending',
+          dependencies: ['wf-1778826126740-7/regression-test-all'],
+          config: { workflowId: 'wf-1778826126740-7', runnerKind: 'merge', isMergeNode: true },
+          execution: {
+            selectedAttemptId: '__merge__wf-1778826126740-7-a9e08b36d',
+            generation: 91,
+            phase: 'launching',
+          },
+        } as any;
+        mockDeps.invokerConfig = {
+          ...mockDeps.invokerConfig,
+          launchOutboxMode: 'active',
+          defaultBranch: 'master',
+        } as any;
+        mockDeps.orchestrator.getPersistedActiveTaskIds = vi.fn(() => new Set<string>());
+        mockDeps.orchestrator.syncFromDb = vi.fn();
+        mockDeps.persistence.listWorkflows = vi.fn(() => [{
+          id: 'wf-1778826126740-7',
+          name: 'Fix build warning noise',
+          generation: 73,
+          status: 'running' as const,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }]);
+        mockDeps.persistence.loadTasks = vi.fn(() => [{
+          id: runnableTask.id,
+          status: 'failed',
+          config: { workflowId: 'wf-1778826126740-7', isMergeNode: true, runnerKind: 'merge' },
+          execution: {},
+        } as any]);
+        mockDeps.commandService.retryTask = vi.fn(async () => ({
+          ok: true as const,
+          data: [runnableTask],
+        }));
+        Object.assign(mockDeps.persistence as any, {
+          reapExpiredLaunchDispatchLeases: vi.fn(() => []),
+          listAbandonableLaunchDispatchLeases: vi.fn(() => []),
+          claimLaunchDispatchAtomic: vi.fn(),
+          listLaunchDispatchesByState: vi.fn(() => [{
+            id: 2415,
+            taskId: runnableTask.id,
+            attemptId: runnableTask.execution.selectedAttemptId,
+            workflowId: 'wf-1778826126740-7',
+            state: 'enqueued',
+            priority: 'normal',
+            generation: 91,
+            enqueuedAt: new Date().toISOString(),
+            attemptsCount: 0,
+          }]),
+          markLaunchDispatchCompleted: vi.fn(() => true),
+        });
+        const executeTaskSpy = vi.spyOn(TaskRunner.prototype, 'executeTask');
+        try {
+          await expect(
+            runHeadless(['retry-task', runnableTask.id], {
+              ...mockDeps,
+              noTrack: true,
+              preemptTaskSubgraph,
+            } as HeadlessDeps),
+          ).rejects.toThrow(/refusing to consume launch dispatches with a transient headless runner/);
+          expect((mockDeps.persistence as any).claimLaunchDispatchAtomic).not.toHaveBeenCalled();
+          expect((mockDeps.persistence as any).markLaunchDispatchCompleted).not.toHaveBeenCalled();
+          expect(executeTaskSpy).not.toHaveBeenCalled();
+        } finally {
+          executeTaskSpy.mockRestore();
+        }
+      });
+
       it('headless task retry defers runnable tasks in no-track mode', async () => {
         const deferRunnableTasks = vi.fn();
         const preemptTaskSubgraph = vi.fn(async () => {});

--- a/packages/app/src/__tests__/headless-owner-bootstrap.test.ts
+++ b/packages/app/src/__tests__/headless-owner-bootstrap.test.ts
@@ -1,0 +1,59 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  OWNER_BOOTSTRAP_LOCK_DIR,
+  tryAcquireOwnerBootstrapLock,
+} from '../headless-owner-bootstrap.js';
+
+describe('headless-owner-bootstrap', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const tempDir of tempDirs.splice(0)) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  function makeTempHome(): string {
+    const tempDir = mkdtempSync(join(tmpdir(), 'invoker-owner-bootstrap-'));
+    tempDirs.push(tempDir);
+    return tempDir;
+  }
+
+  it('serializes concurrent bootstrap attempts with a process pid lock', () => {
+    const home = makeTempHome();
+    const firstLock = tryAcquireOwnerBootstrapLock(home);
+
+    expect(firstLock).not.toBeNull();
+    expect(tryAcquireOwnerBootstrapLock(home)).toBeNull();
+
+    firstLock?.release();
+    expect(existsSync(join(home, OWNER_BOOTSTRAP_LOCK_DIR))).toBe(false);
+  });
+
+  it('recovers from a stale lock directory with no pid file', () => {
+    const home = makeTempHome();
+    mkdirSync(join(home, OWNER_BOOTSTRAP_LOCK_DIR));
+
+    const lock = tryAcquireOwnerBootstrapLock(home);
+
+    expect(lock).not.toBeNull();
+    expect(existsSync(join(home, OWNER_BOOTSTRAP_LOCK_DIR, 'pid'))).toBe(true);
+    lock?.release();
+  });
+
+  it('creates the invoker home root before acquiring the lock', () => {
+    const parent = makeTempHome();
+    const missingHome = join(parent, 'missing-home');
+
+    const lock = tryAcquireOwnerBootstrapLock(missingHome);
+
+    expect(lock).not.toBeNull();
+    expect(existsSync(join(missingHome, OWNER_BOOTSTRAP_LOCK_DIR, 'pid'))).toBe(true);
+    lock?.release();
+  });
+});

--- a/packages/app/src/__tests__/ipc-registration.test.ts
+++ b/packages/app/src/__tests__/ipc-registration.test.ts
@@ -104,6 +104,34 @@ describe('ipc-registration', () => {
     );
   });
 
+  it('refreshes and retries follower delegation when the owner route is gone', async () => {
+    const { ipcMain, handleHandlers } = createFakeIpcMain();
+    const refreshOwnerRoute = vi.fn(async () => undefined);
+    const request = vi
+      .fn()
+      .mockRejectedValueOnce(new TransportError(TransportErrorCode.NO_HANDLER, 'missing'))
+      .mockResolvedValueOnce('delegated');
+
+    registerGuiMutationHandler(
+      {
+        ipcMain,
+        getOwnerMode: () => false,
+        getMessageBus: () => ({ request }),
+        refreshOwnerRoute,
+        translateGuiMutationToHeadless: () => ({
+          channel: 'headless.gui-mutation',
+          request: { channel: 'invoker:start', args: [] },
+        }),
+      },
+      'invoker:start',
+      vi.fn(async () => 'local'),
+    );
+
+    await expect(handleHandlers.get('invoker:start')?.({})).resolves.toBe('delegated');
+    expect(refreshOwnerRoute).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledTimes(2);
+  });
+
   it('registers workflow-scoped handlers with the same dispatcher and enqueue shape', async () => {
     const { ipcMain, handleHandlers } = createFakeIpcMain();
     const workflowMutationDispatcher = new Map<string, (...args: unknown[]) => Promise<unknown>>();

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SQLiteAdapter } from '@invoker/data-store';
-import type { Logger } from '@invoker/contracts';
+import { DISPATCH_LEASE_MS, type Logger } from '@invoker/contracts';
 import { InMemoryBus } from '@invoker/test-kit';
 import { Orchestrator } from '@invoker/workflow-core';
 import { LaunchDispatcher } from '../launch-dispatcher.js';
@@ -192,6 +192,35 @@ describe('LaunchDispatcher', () => {
       const { dispatcher } = makeDispatcher();
       expect(dispatcher.completeDispatch(enqueued.id)).toBe(true);
       expect(dispatcher.completeDispatch(enqueued.id)).toBe(false);
+    });
+
+    it('uses a fixed dispatch TTL long enough for normal executor startup', () => {
+      seedWorkflowAndTask('attempt-fixed-ttl');
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-1/t1',
+        attemptId: 'attempt-fixed-ttl',
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+      const claimedAt = '2026-06-04T22:38:44.000Z';
+      const claimed = adapter.claimLaunchDispatchAtomic({
+        ownerId: 'owner-test',
+        nowIso: claimedAt,
+      });
+      expect(claimed?.id).toBe(enqueued.id);
+      expect(claimed?.fencedUntil).toBe(
+        new Date(new Date(claimedAt).getTime() + DISPATCH_LEASE_MS).toISOString(),
+      );
+
+      const { dispatcher } = makeDispatcher();
+      expect(dispatcher.reapExpiredLeases(
+        new Date(new Date(claimedAt).getTime() + DISPATCH_LEASE_MS - 1).toISOString(),
+      )).toBe(0);
+      expect(adapter.loadLaunchDispatchById(enqueued.id)?.state).toBe('leased');
+      expect(dispatcher.reapExpiredLeases(
+        new Date(new Date(claimedAt).getTime() + DISPATCH_LEASE_MS + 1).toISOString(),
+      )).toBe(1);
+      expect(adapter.loadLaunchDispatchById(enqueued.id)?.state).toBe('enqueued');
     });
 
     it('fail re-enqueues a leased row with the error message and clears the owner', () => {

--- a/packages/app/src/__tests__/launch-invariant.test.ts
+++ b/packages/app/src/__tests__/launch-invariant.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { TaskEvent } from '@invoker/data-store';
+import { DISPATCH_LEASE_MS, DISPATCH_MAX_ATTEMPTS } from '@invoker/contracts';
 import {
   DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS,
   LaunchInvariantViolationError,
@@ -130,6 +131,8 @@ describe('assertLaunchInvariant', () => {
   });
 
   it('exposes a default maxGapMs anchored to the dispatch lease budget', () => {
-    expect(DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS).toBe(270_000);
+    expect(DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS).toBe(
+      DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30_000,
+    );
   });
 });

--- a/packages/app/src/__tests__/launch-invariant.ts
+++ b/packages/app/src/__tests__/launch-invariant.ts
@@ -22,6 +22,7 @@
  */
 
 import type { PersistenceAdapter, TaskEvent } from '@invoker/data-store';
+import { DISPATCH_LEASE_MS, DISPATCH_MAX_ATTEMPTS } from '@invoker/contracts';
 
 export const LAUNCH_CLAIM_EVENT_TYPE = 'task.launch_claimed';
 
@@ -35,13 +36,13 @@ export const TERMINAL_LAUNCH_EVENT_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Default upper bound on the gap between `task.launch_claimed` and the
- * next terminal launch event. Matches `3 * DISPATCH_LEASE_MS *
- * DISPATCH_MAX_ATTEMPTS` (= 270 s with the proposed dispatch defaults of
- * 30 s lease and 3 attempts). Tests that drive a deterministic in-memory
+ * Default upper bound on the gap between `task.launch_claimed` and the next
+ * terminal launch event. It follows the fixed dispatch crash-recovery window
+ * with a small scheduler buffer. Tests that drive a deterministic in-memory
  * scenario should pass a tighter bound.
  */
-export const DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS = 270_000;
+export const DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS =
+  DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30_000;
 
 export type LaunchInvariantPersistence = Pick<
   PersistenceAdapter,

--- a/packages/app/src/__tests__/owner-resolver.test.ts
+++ b/packages/app/src/__tests__/owner-resolver.test.ts
@@ -277,6 +277,33 @@ describe('owner-resolver', () => {
       expect(ensureStandaloneOwner).toHaveBeenCalledTimes(1);
     });
 
+    it('uses a standalone owner discovered after refresh without bootstrapping', async () => {
+      const firstBus = new LocalBus();
+      const secondBus = new LocalBus();
+      secondBus.onRequest('headless.owner-ping', async () => ({
+        ok: true,
+        ownerId: 'owner-refreshed',
+        mode: 'standalone',
+      }));
+
+      const ensureStandaloneOwner = vi.fn(async () => {});
+      const refreshMessageBus = vi.fn(async () => secondBus);
+      const resolver = createOwnerResolver({
+        messageBus: firstBus,
+        refreshMessageBus,
+        ensureStandaloneOwner,
+      }, {
+        discoveryTimeoutMs: 100,
+        refreshDiscoveryTimeoutMs: 100,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-refreshed');
+      expect(result.bus).toBe(secondBus);
+      expect(refreshMessageBus).toHaveBeenCalledTimes(1);
+      expect(ensureStandaloneOwner).not.toHaveBeenCalled();
+    });
+
     it('retries bootstrap when the first attempt does not produce a reachable owner', async () => {
       const bus = new LocalBus();
       let bootstrapCalls = 0;
@@ -304,6 +331,38 @@ describe('owner-resolver', () => {
       const result = await resolver.resolve();
       expect(result.owner.ownerId).toBe('owner-retry');
       expect(bootstrapCalls).toBe(2);
+    });
+
+    it('retries configured bootstrap timeout errors', async () => {
+      const bus = new LocalBus();
+      const retryableError = new Error('owner bootstrap timed out');
+      let bootstrapCalls = 0;
+
+      const ensureStandaloneOwner = vi.fn(async () => {
+        bootstrapCalls += 1;
+        if (bootstrapCalls === 1) {
+          throw retryableError;
+        }
+        bus.onRequest('headless.owner-ping', async () => ({
+          ok: true,
+          ownerId: 'owner-after-timeout',
+          mode: 'standalone',
+        }));
+      });
+
+      const resolver = createOwnerResolver({
+        messageBus: bus,
+        ensureStandaloneOwner,
+        isRetryableBootstrapError: (error) => error === retryableError,
+      }, {
+        discoveryTimeoutMs: 100,
+        postBootstrapReadyTimeoutMs: 500,
+        maxBootstrapAttempts: 2,
+      });
+
+      const result = await resolver.resolve();
+      expect(result.owner.ownerId).toBe('owner-after-timeout');
+      expect(ensureStandaloneOwner).toHaveBeenCalledTimes(2);
     });
 
     it('throws after exhausting all bootstrap attempts', async () => {

--- a/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
+++ b/packages/app/src/__tests__/persisted-workflow-mutation-coordinator.test.ts
@@ -569,6 +569,85 @@ describe('PersistedWorkflowMutationCoordinator', () => {
     ]);
   });
 
+  it('coalesces duplicate fire-and-forget headless workflow retries while queued or running', async () => {
+    const adapter = await SQLiteAdapter.create(':memory:');
+    adapters.push(adapter);
+    adapter.saveWorkflow({
+      id: 'wf-1',
+      name: 'wf-1',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+    adapter.saveWorkflow({
+      id: 'wf-2',
+      name: 'wf-2',
+      status: 'running',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    const runningGate = deferred();
+    const order: string[] = [];
+    const coordinator = new PersistedWorkflowMutationCoordinator(
+      adapter,
+      'owner-1',
+      async (_channel, args) => {
+        const payload = args[0] as { args?: string[] } | undefined;
+        const command = payload?.args?.join(' ') ?? String(args[0]);
+        order.push(command);
+        if (command === 'retry wf-2') {
+          await runningGate.promise;
+        }
+      },
+    );
+
+    const firstQueued = coordinator.submit(
+      'wf-1',
+      'high',
+      'headless.exec',
+      [{ args: ['retry', 'wf-1'], noTrack: true }],
+      { deferDrain: true },
+    );
+    const queuedDuplicates = Array.from({ length: 25 }, () =>
+      coordinator.submit(
+        'wf-1',
+        'high',
+        'headless.exec',
+        [{ args: ['retry', 'wf-1'], noTrack: true }],
+        { deferDrain: true },
+      ),
+    );
+
+    expect(new Set([firstQueued, ...queuedDuplicates])).toEqual(new Set([firstQueued]));
+
+    const firstRunning = coordinator.submit(
+      'wf-2',
+      'high',
+      'headless.exec',
+      [{ args: ['retry', 'wf-2'], noTrack: true }],
+    );
+    await waitFor(() => order.includes('retry wf-2'));
+
+    const runningDuplicates = Array.from({ length: 25 }, () =>
+      coordinator.submit(
+        'wf-2',
+        'high',
+        'headless.exec',
+        [{ args: ['retry', 'wf-2'], noTrack: true }],
+      ),
+    );
+
+    expect(new Set([firstRunning, ...runningDuplicates])).toEqual(new Set([firstRunning]));
+    runningGate.resolve();
+
+    await waitFor(() => adapter.listWorkflowMutationIntents(undefined, ['completed']).length === 2);
+
+    expect(order.sort()).toEqual(['retry wf-1', 'retry wf-2']);
+    expect(adapter.listWorkflowMutationIntents('wf-1')).toHaveLength(1);
+    expect(adapter.listWorkflowMutationIntents('wf-2')).toHaveLength(1);
+  });
+
   it('requeues interrupted running workflow mutations on restart and drains persisted queued work', async () => {
     const adapter = await SQLiteAdapter.create(':memory:');
     adapters.push(adapter);

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -23,10 +23,9 @@ import {
 import { loadConfig } from './config.js';
 import {
   discoverOwner,
-  isOwnerReachable,
   isStandaloneCapable,
 } from './owner-endpoint.js';
-import { createOwnerResolver } from './owner-resolver.js';
+import { createOwnerResolver, type ResolvedOwner } from './owner-resolver.js';
 
 const RED = '\x1b[31m';
 const RESET = '\x1b[0m';
@@ -206,53 +205,6 @@ async function delegateReadOnlyQuery(
   return true;
 }
 
-async function delegateAfterBootstrap(
-  args: string[],
-  deps: Pick<HeadlessClientDeps, 'refreshMessageBus'>,
-  bus: MessageBus,
-  waitForApproval?: boolean,
-  noTrack?: boolean,
-): Promise<DelegationOutcome> {
-  const startedAt = Date.now();
-  delegationClientLog(`post-bootstrap delegation loop begin timeoutMs=${POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS}`);
-  const deadline = Date.now() + POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS;
-  let messageBus = bus;
-  let attempts = 0;
-  let lastOutcome: DelegationOutcome = { kind: 'no-handler' };
-  while (Date.now() < deadline) {
-    attempts += 1;
-    const owner = await discoverOwner(messageBus, 1_000);
-    delegationClientLog(
-      `post-bootstrap attempt=${attempts} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
-    );
-    if (isStandaloneCapable(owner)) {
-      const outcome = await delegateMutation(
-        args,
-        messageBus,
-        waitForApproval,
-        noTrack,
-        noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
-      );
-      lastOutcome = outcome;
-      if (outcome.kind === 'delegated') {
-        delegationClientLog(`post-bootstrap delegation succeeded attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
-        return outcome;
-      }
-      if (outcome.kind === 'protocol-error') {
-        delegationClientLog(`post-bootstrap protocol-error attempts=${attempts} message=${outcome.message}`);
-        return outcome;
-      }
-      // timeout or no-handler: retry after refresh
-    }
-    if (deps.refreshMessageBus) {
-      messageBus = await deps.refreshMessageBus();
-    }
-    await new Promise((resolve) => setTimeout(resolve, 250));
-  }
-  delegationClientLog(`post-bootstrap delegation exhausted attempts=${attempts} elapsedMs=${Date.now() - startedAt}`);
-  return lastOutcome;
-}
-
 export interface HeadlessClientDeps {
   messageBus: MessageBus;
   ensureStandaloneOwner: (bus?: MessageBus) => Promise<void>;
@@ -331,107 +283,59 @@ async function resolveOwnerAndDelegate(
 ): Promise<number | null> {
   const startedAt = Date.now();
   delegationClientLog(`resolveOwnerAndDelegate begin command=${args[0] ?? '<missing>'} noTrack=${noTrack ? 'true' : 'false'}`);
-  let messageBus = deps.messageBus;
   const resolvedExitCode = (): number => {
     const exitCode = process.exitCode;
     return typeof exitCode === 'number' ? exitCode : 0;
   };
 
-  // Phase 1: Discover a standalone-capable owner and delegate
-  const owner = await discoverOwner(messageBus, 3_000);
-  delegationClientLog(
-    `phase1 discover standaloneCapable=${isStandaloneCapable(owner) ? 'true' : 'false'} ownerReachable=${isOwnerReachable(owner) ? 'true' : 'false'} ownerId=${owner?.ownerId ?? '<none>'}`,
+  const resolver = createOwnerResolver(
+    {
+      messageBus: deps.messageBus,
+      refreshMessageBus: deps.refreshMessageBus,
+      ensureStandaloneOwner: deps.ensureStandaloneOwner,
+      isRetryableBootstrapError: isSharedMutationOwnerTimeoutError,
+    },
+    {
+      discoveryTimeoutMs: 3_000,
+      refreshDiscoveryTimeoutMs: 1_000,
+      postBootstrapReadyTimeoutMs: POST_BOOTSTRAP_OWNER_READY_TIMEOUT_MS,
+      maxBootstrapAttempts: POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS,
+    },
   );
-  if (isStandaloneCapable(owner)) {
-    const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
-    delegationClientLog(`phase1 outcome=${outcome.kind}`);
-    if (outcome.kind === 'delegated') {
-      delegationClientLog(`phase1 delegated successfully elapsedMs=${Date.now() - startedAt}`);
-      return resolvedExitCode();
-    }
-    if (outcome.kind === 'protocol-error') {
-      delegationClientLog(`phase1 protocol-error: ${outcome.message}`);
-      return null;
-    }
-    // timeout or no-handler: fall through to next phase
-  }
 
-  // Phase 2: Try any reachable owner (may be non-standalone)
-  if (isOwnerReachable(owner)) {
-    const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
-    delegationClientLog(`phase2 outcome=${outcome.kind} ownerId=${owner.ownerId}`);
-    if (outcome.kind === 'delegated') {
-      delegationClientLog(`phase2 delegated to reachable owner elapsedMs=${Date.now() - startedAt}`);
-      return resolvedExitCode();
-    }
-    if (outcome.kind === 'protocol-error') {
-      delegationClientLog(`phase2 protocol-error: ${outcome.message}`);
-      return null;
-    }
-  } else {
-    delegationClientLog('phase2 skipped: no reachable owner');
-  }
-
-  // Phase 3: Refresh and retry against any reachable owner
-  if (isOwnerReachable(owner) && deps.refreshMessageBus) {
-    delegationClientLog('phase3 refreshing message bus');
-    messageBus = await deps.refreshMessageBus();
-    const refreshedOwner = await discoverOwner(messageBus, 1_000);
-    delegationClientLog(
-      `phase3 discover ownerReachable=${isOwnerReachable(refreshedOwner) ? 'true' : 'false'} standaloneCapable=${isStandaloneCapable(refreshedOwner) ? 'true' : 'false'} ownerId=${refreshedOwner?.ownerId ?? '<none>'}`,
-    );
-    if (isOwnerReachable(refreshedOwner)) {
-      const outcome = await delegateMutation(args, messageBus, waitForApproval, noTrack);
-      delegationClientLog(`phase3 outcome=${outcome.kind}`);
-      if (outcome.kind === 'delegated') {
-        delegationClientLog(`phase3 delegated successfully elapsedMs=${Date.now() - startedAt}`);
-        return resolvedExitCode();
-      }
-      if (outcome.kind === 'protocol-error') {
-        delegationClientLog(`phase3 protocol-error: ${outcome.message}`);
+  for (let attempt = 0; attempt < POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS; attempt += 1) {
+    delegationClientLog(`resolve attempt=${attempt + 1}/${POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS}`);
+    let resolved: ResolvedOwner;
+    try {
+      resolved = await resolver.resolve(true);
+    } catch (err) {
+      if (err instanceof Error && /Could not resolve a standalone-capable owner/.test(err.message)) {
+        delegationClientLog(`resolve attempt failed: ${err.message}`);
         return null;
       }
+      throw err;
     }
-    delegationClientLog('phase3 delegation did not succeed');
-  }
+    delegationClientLog(`resolved standalone ownerId=${resolved.owner.ownerId}`);
 
-  // Phase 4: Bootstrap with bounded retry loop
-  if (deps.refreshMessageBus) {
-    messageBus = await deps.refreshMessageBus();
-  }
-  for (let attempt = 0; attempt < POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS; attempt += 1) {
-    delegationClientLog(`phase4 bootstrap attempt=${attempt + 1}/${POST_BOOTSTRAP_OWNER_RESTART_ATTEMPTS}`);
-    try {
-      await deps.ensureStandaloneOwner(messageBus);
-    } catch (err) {
-      if (!isSharedMutationOwnerTimeoutError(err)) {
-        throw err;
-      }
-      if (!deps.refreshMessageBus) {
-        throw err;
-      }
-      delegationClientLog(`phase4 bootstrap timeout; refreshing bus and retrying attempt=${attempt + 1}`);
-      messageBus = await deps.refreshMessageBus();
-      await deps.ensureStandaloneOwner(messageBus);
-    }
-    if (deps.refreshMessageBus) {
-      messageBus = await deps.refreshMessageBus();
-    }
-    const outcome = await delegateAfterBootstrap(args, deps, messageBus, waitForApproval, noTrack);
-    delegationClientLog(`phase4 post-bootstrap outcome=${outcome.kind} attempt=${attempt + 1}`);
+    const outcome = await delegateMutation(
+      args,
+      resolved.bus,
+      waitForApproval,
+      noTrack,
+      noTrack ? POST_BOOTSTRAP_NO_TRACK_DELEGATION_TIMEOUT_MS : DEFAULT_NO_TRACK_DELEGATION_TIMEOUT_MS,
+    );
+    delegationClientLog(`delegate outcome=${outcome.kind} attempt=${attempt + 1}`);
     if (outcome.kind === 'delegated') {
-      delegationClientLog(`phase4 delegated successfully attempt=${attempt + 1} elapsedMs=${Date.now() - startedAt}`);
+      delegationClientLog(`delegated successfully attempt=${attempt + 1} elapsedMs=${Date.now() - startedAt}`);
       return resolvedExitCode();
     }
     if (outcome.kind === 'protocol-error') {
-      delegationClientLog(`phase4 protocol-error attempt=${attempt + 1}: ${outcome.message}`);
+      delegationClientLog(`protocol-error attempt=${attempt + 1}: ${outcome.message}`);
       return null;
     }
-    // timeout or no-handler: retry next bootstrap attempt
     if (!deps.refreshMessageBus) {
       break;
     }
-    messageBus = await deps.refreshMessageBus();
   }
 
   delegationClientLog(`resolveOwnerAndDelegate failed after elapsedMs=${Date.now() - startedAt}`);

--- a/packages/app/src/headless-owner-bootstrap.ts
+++ b/packages/app/src/headless-owner-bootstrap.ts
@@ -13,6 +13,7 @@ export function tryAcquireOwnerBootstrapLock(invokerHomeRoot: string): OwnerBoot
   const lockDir = join(invokerHomeRoot, OWNER_BOOTSTRAP_LOCK_DIR);
 
   try {
+    mkdirSync(invokerHomeRoot, { recursive: true });
     mkdirSync(lockDir);
   } catch (err: unknown) {
     if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
@@ -28,10 +29,12 @@ export function tryAcquireOwnerBootstrapLock(invokerHomeRoot: string): OwnerBoot
           return tryAcquireOwnerBootstrapLock(invokerHomeRoot);
         }
       }
+      rmSync(lockDir, { recursive: true, force: true });
+      return tryAcquireOwnerBootstrapLock(invokerHomeRoot);
     } catch {
-      return null;
+      rmSync(lockDir, { recursive: true, force: true });
+      return tryAcquireOwnerBootstrapLock(invokerHomeRoot);
     }
-    return null;
   }
 
   writeFileSync(join(lockDir, 'pid'), String(process.pid), 'utf8');

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -368,17 +368,37 @@ async function dispatchNoTrackRunnableTasks(
 ): Promise<void> {
   if (deps.invokerConfig.launchOutboxMode === 'active') {
     const ownerTaskExecutor = deps.ownerTaskRunnerProvider?.() ?? null;
-    if (!ownerTaskExecutor) {
+    if (ownerTaskExecutor) {
+      await dispatchHeadlessRunnableTasks(deps, ownerTaskExecutor, runnable, context, {
+        waitForLaunchHandoff: true,
+      });
+      return;
+    }
+
+    const expectedAttemptIds = new Set(
+      runnable
+        .map((task) => task.execution.selectedAttemptId?.trim())
+        .filter((attemptId): attemptId is string => !!attemptId),
+    );
+    const hasDurableDispatch = expectedAttemptIds.size > 0
+      && (deps.persistence.listLaunchDispatchesByState?.(['enqueued', 'leased']) ?? [])
+        .some((row) => expectedAttemptIds.has(row.attemptId));
+    if (hasDurableDispatch) {
+      deps.logger.info(
+        `${context}: launchOutboxMode=active and no owner TaskRunner in this process; ` +
+        'leaving durable launch dispatches for the owner dispatcher.',
+        { module: 'headless' },
+      );
+      return;
+    }
+
+    if (!deps.deferRunnableTasks) {
       throw new Error(
         'Cannot dispatch --no-track runnable tasks in active launch-outbox mode without ' +
         'deferRunnableTasks or an owner TaskRunner; refusing to consume launch dispatches ' +
         'with a transient headless runner.',
       );
     }
-    await dispatchHeadlessRunnableTasks(deps, ownerTaskExecutor, runnable, context, {
-      waitForLaunchHandoff: true,
-    });
-    return;
   }
 
   if (deps.deferRunnableTasks) {
@@ -1296,7 +1316,6 @@ async function headlessOwnerServe(deps: Pick<HeadlessDeps, 'isStandaloneOwnerIdl
         finish();
       }
     }, idlePollMs);
-    idleTimer.unref?.();
     process.once('SIGTERM', finish);
     process.once('SIGINT', finish);
   });

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -291,6 +291,7 @@ async function dispatchHeadlessRunnableTasks(
   taskExecutor: TaskRunner,
   runnable: TaskState[],
   context: string,
+  options: { waitForLaunchHandoff?: boolean } = {},
 ): Promise<void> {
   if (runnable.length === 0) return;
   if (deps.invokerConfig.launchOutboxMode !== 'active') {
@@ -327,9 +328,74 @@ async function dispatchHeadlessRunnableTasks(
     }
   };
   poll();
+
+  if (options.waitForLaunchHandoff) {
+    const expectedAttemptIds = new Set(
+      runnable
+        .map((task) => task.execution.selectedAttemptId?.trim())
+        .filter((attemptId): attemptId is string => !!attemptId),
+    );
+    const hasLiveExpectedDispatch = (): boolean => {
+      if (expectedAttemptIds.size === 0) return false;
+      const rows = deps.persistence.listLaunchDispatchesByState?.(['enqueued', 'leased']) ?? [];
+      return rows.some((row) => expectedAttemptIds.has(row.attemptId));
+    };
+    if (!hasLiveExpectedDispatch()) return;
+
+    await new Promise<void>((resolve) => {
+      const timer = setInterval(() => {
+        poll();
+        if (!hasLiveExpectedDispatch()) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 250);
+    });
+    return;
+  }
+
   const timer = setInterval(poll, 250);
   timer.unref?.();
   await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+async function dispatchNoTrackRunnableTasks(
+  deps: HeadlessDeps,
+  runnable: TaskState[],
+  workflowId: string | undefined,
+  context: string,
+  errorLabel: string,
+): Promise<void> {
+  if (deps.invokerConfig.launchOutboxMode === 'active') {
+    const ownerTaskExecutor = deps.ownerTaskRunnerProvider?.() ?? null;
+    if (!ownerTaskExecutor) {
+      throw new Error(
+        'Cannot dispatch --no-track runnable tasks in active launch-outbox mode without ' +
+        'deferRunnableTasks or an owner TaskRunner; refusing to consume launch dispatches ' +
+        'with a transient headless runner.',
+      );
+    }
+    await dispatchHeadlessRunnableTasks(deps, ownerTaskExecutor, runnable, context, {
+      waitForLaunchHandoff: true,
+    });
+    return;
+  }
+
+  if (deps.deferRunnableTasks) {
+    deps.deferRunnableTasks(runnable, workflowId);
+    return;
+  }
+
+  const taskExecutor = createHeadlessExecutor(deps);
+  const launch = setTimeout(() => {
+    void taskExecutor.executeTasks(runnable).catch((err) => {
+      deps.logger.error(
+        `${errorLabel}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+        { module: 'headless' },
+      );
+    });
+  }, 25);
+  launch.unref?.();
 }
 
 export function wireHeadlessAutoFix(
@@ -1649,20 +1715,13 @@ async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<vo
         .filter((task) => !scopedKeys.has(runningKey(task)));
       const dispatchable = [...runnable, ...globalTopup];
       if (dispatchable.length > 0) {
-        if (deps.deferRunnableTasks) {
-          deps.deferRunnableTasks(dispatchable, restored.workflowId);
-        } else {
-          const taskExecutor = createHeadlessExecutor(deps);
-          const launch = setTimeout(() => {
-            void taskExecutor.executeTasks(dispatchable).catch((err) => {
-              deps.logger.error(
-                `background no-track task retry failed for ${taskId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-                { module: 'headless' },
-              );
-            });
-          }, 25);
-          launch.unref?.();
-        }
+        await dispatchNoTrackRunnableTasks(
+          deps,
+          dispatchable,
+          restored.workflowId,
+          'headless.retry-task.no-track',
+          `background no-track task retry failed for ${taskId}`,
+        );
       }
       process.stdout.write('[headless] --no-track enabled: retry-task accepted; exiting without tracking.\n');
       return;
@@ -2113,20 +2172,13 @@ async function headlessRetryWorkflow(workflowId: string, deps: HeadlessDeps): Pr
   if (dispatchable.length === 0) return;
 
   if (deps.noTrack) {
-    if (deps.deferRunnableTasks) {
-      deps.deferRunnableTasks(dispatchable, workflowId);
-    } else {
-      const te = createHeadlessExecutor(deps);
-      const launch = setTimeout(() => {
-        void te.executeTasks(dispatchable).catch((err) => {
-          deps.logger.error(
-            `background no-track workflow retry failed for ${workflowId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
-            { module: 'headless' },
-          );
-        });
-      }, 25);
-      launch.unref?.();
-    }
+    await dispatchNoTrackRunnableTasks(
+      deps,
+      dispatchable,
+      workflowId,
+      'headless.retry-workflow.no-track',
+      `background no-track workflow retry failed for ${workflowId}`,
+    );
     process.stdout.write('[headless] --no-track enabled: retry accepted; exiting without tracking.\n');
     return;
   }

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -53,6 +53,21 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     getTaskDeltaStreamSequence,
   } = context;
 
+  async function delegateOwnerQuery<T>(kind: string, request: Record<string, unknown> = {}): Promise<T | null> {
+    if (getOwnerMode?.() !== false) return null;
+    try {
+      return await getMessageBus?.().request<Record<string, unknown>, T>('headless.query', { kind, ...request }) ?? null;
+    } catch (err) {
+      logger.warn(
+        `${kind} owner delegation failed; falling back to local read-only snapshot: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+        { module: 'ipc' },
+      );
+      return null;
+    }
+  }
+
   ipcMain.handle('invoker:list-workflows', () => persistence.listWorkflows());
   ipcMain.handle('invoker:get-execution-pools', () => Object.keys(loadConfig().executionPools ?? {}));
 
@@ -76,48 +91,37 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
   ipcMain.handle('invoker:get-tasks', async (_event, forceRefresh?: boolean) => {
     const startedAtMs = Date.now();
     const orchestrator = getOrchestrator();
-    if (forceRefresh && getOwnerMode?.() === false) {
-      try {
-        const delegated = await getMessageBus?.().request<{ kind: string; forceRefresh: boolean }, {
-          tasks: TaskState[];
-          workflows: unknown[];
-          streamSequence: number;
-        }>('headless.query', { kind: 'tasks', forceRefresh: true });
-        if (delegated && Array.isArray(delegated.tasks) && Array.isArray(delegated.workflows)) {
-          const previousTaskIds = new Set(lastKnownTaskStates.keys());
-          lastKnownTaskStates.clear();
-          for (const task of delegated.tasks) {
-            lastKnownTaskStates.set(task.id, JSON.stringify(task));
-            previousTaskIds.delete(task.id);
-            const mainWindow = getMainWindow();
-            if (mainWindow && !mainWindow.isDestroyed()) {
-              sendTaskDeltaToRenderer({ type: 'created', task });
-            }
-          }
-          const mainWindow = getMainWindow();
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            for (const removedTaskId of previousTaskIds) {
-              sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
-            }
-            requestWorkflowMetadataPublish('get-tasks-force-refresh-delegated');
-          }
-          setLastKnownWorkflowCount(delegated.workflows.length);
-          recordStartupDuration('get-tasks.force-refresh.delegated-return', startedAtMs, {
-            taskCount: delegated.tasks.length,
-            workflowCount: delegated.workflows.length,
-            jsonSizeBytes: Buffer.byteLength(JSON.stringify(delegated), 'utf8'),
-            streamSequence: delegated.streamSequence,
-          });
-          return delegated;
+    const delegated = await delegateOwnerQuery<{
+      tasks: TaskState[];
+      workflows: unknown[];
+      streamSequence: number;
+    }>('tasks', { forceRefresh: forceRefresh === true });
+    if (delegated && Array.isArray(delegated.tasks) && Array.isArray(delegated.workflows)) {
+      const previousTaskIds = new Set(lastKnownTaskStates.keys());
+      lastKnownTaskStates.clear();
+      for (const task of delegated.tasks) {
+        lastKnownTaskStates.set(task.id, JSON.stringify(task));
+        previousTaskIds.delete(task.id);
+        const mainWindow = getMainWindow();
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          sendTaskDeltaToRenderer({ type: 'created', task });
         }
-      } catch (err) {
-        logger.warn(
-          `get-tasks(forceRefresh=true) owner delegation failed; falling back to local read-only snapshot: ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-          { module: 'ipc' },
-        );
       }
+      const mainWindow = getMainWindow();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        for (const removedTaskId of previousTaskIds) {
+          sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
+        }
+        requestWorkflowMetadataPublish(forceRefresh ? 'get-tasks-force-refresh-delegated' : 'get-tasks-delegated');
+      }
+      setLastKnownWorkflowCount(delegated.workflows.length);
+      recordStartupDuration(forceRefresh ? 'get-tasks.force-refresh.delegated-return' : 'get-tasks.delegated-return', startedAtMs, {
+        taskCount: delegated.tasks.length,
+        workflowCount: delegated.workflows.length,
+        jsonSizeBytes: Buffer.byteLength(JSON.stringify(delegated), 'utf8'),
+        streamSequence: delegated.streamSequence,
+      });
+      return delegated;
     }
     if (forceRefresh) {
       timeStartupPhase('get-tasks.force-refresh.syncAllFromDb', () => orchestrator.syncAllFromDb(), () => ({
@@ -163,7 +167,9 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
   });
 
   ipcMain.handle('invoker:get-events', (_event, taskId: string) => persistence.getEvents(taskId));
-  ipcMain.handle('invoker:get-status', () => getOrchestrator().getWorkflowStatus());
+  ipcMain.handle('invoker:get-status', async () => (
+    await delegateOwnerQuery('workflow-status') ?? getOrchestrator().getWorkflowStatus()
+  ));
   ipcMain.handle('invoker:get-task-by-id', (_event, taskId: string) => loadTaskByIdFromPersistence(taskId) ?? null);
   ipcMain.handle('invoker:get-task-output', (_event, taskId: string) => persistence.getTaskOutput(taskId));
   ipcMain.handle('invoker:get-output-chunks', (_event, taskId: string) => persistence.getOutputChunks(taskId));

--- a/packages/app/src/ipc/ipc-registration.ts
+++ b/packages/app/src/ipc/ipc-registration.ts
@@ -17,6 +17,7 @@ export interface GuiMutationRegistrationContext {
   ipcMain: IpcMain;
   getOwnerMode: () => boolean;
   getMessageBus: () => Pick<MessageBus, 'request'>;
+  refreshOwnerRoute?: () => Promise<void>;
   translateGuiMutationToHeadless: (payload: GuiMutationPayload) => TranslatedGuiMutation;
   guiMutationHandlers?: Map<string, (...args: unknown[]) => Promise<unknown>>;
 }
@@ -41,7 +42,34 @@ export function registerGuiMutationHandler<TResult = unknown>(
         translated.request,
       );
     } catch (err) {
-      if (err instanceof TransportError && err.code === TransportErrorCode.NO_HANDLER) {
+      if (
+        err instanceof TransportError
+        && (
+          err.code === TransportErrorCode.NO_HANDLER
+          || err.code === TransportErrorCode.DISCONNECTED
+        )
+        && context.refreshOwnerRoute
+      ) {
+        await context.refreshOwnerRoute();
+        try {
+          return await context.getMessageBus().request<typeof translated.request, TResult>(
+            translated.channel,
+            translated.request,
+          );
+        } catch (retryErr) {
+          if (retryErr instanceof TransportError && retryErr.code === TransportErrorCode.NO_HANDLER) {
+            throw new Error('No mutation owner is available');
+          }
+          throw retryErr;
+        }
+      }
+      if (
+        err instanceof TransportError
+        && (
+          err.code === TransportErrorCode.NO_HANDLER
+          || err.code === TransportErrorCode.DISCONNECTED
+        )
+      ) {
         throw new Error('No mutation owner is available');
       }
       throw err;

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -155,9 +155,9 @@ export class LaunchDispatcher {
    * Active-mode dispatch loop. Lease enqueued rows up to the per-poll
    * batch bound and hand each one to the
    * TaskRunner. The TaskRunner complete/fail flow drives the rest of
-   * the lifecycle; if the JS promise drops mid-flight, the durable
-   * outbox row stays leased and the next poll's `reapExpiredLeases`
-   * reclaims it after `DISPATCH_LEASE_MS`.
+   * the lifecycle; if the JS promise drops mid-flight, the durable outbox
+   * row stays leased until the fixed dispatch crash-recovery TTL expires,
+   * then the next poll's `reapExpiredLeases` reclaims it.
    */
   private dispatchActive(): void {
     const runner = this.taskRunnerProvider?.() ?? null;

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -189,6 +189,11 @@ import {
   type HeadlessExecMutationPayload,
 } from './headless-batch-exec.js';
 import {
+  spawnDetachedStandaloneOwner,
+  tryAcquireOwnerBootstrapLock,
+} from './headless-owner-bootstrap.js';
+import { discoverOwner, isStandaloneCapable } from './owner-endpoint.js';
+import {
   rebuildTaskRunner as rebuildTaskRunnerWiring,
   requireWiredTaskRunner,
   type TaskHandleMap,
@@ -295,6 +300,26 @@ interface HeadlessResumeMutationPayload {
 }
 
 type HeadlessOwnerMode = 'standalone' | 'gui';
+type GuiOwnerPreference = 'auto' | 'daemon' | 'gui';
+
+function resolveGuiOwnerPreference(): GuiOwnerPreference {
+  const raw = (process.env.INVOKER_GUI_OWNER_MODE ?? '').trim().toLowerCase();
+  if (raw === 'daemon' || raw === 'client' || raw === 'follower') return 'daemon';
+  if (raw === 'auto') return 'auto';
+  if (raw === 'gui' || raw === 'owner' || raw === 'local') return 'gui';
+  if (process.env.INVOKER_GUI_DAEMON_OWNER === '1') return 'daemon';
+  return 'daemon';
+}
+
+function guiOwnerBootstrapTimeoutMs(): number {
+  const parsed = Number.parseInt(
+    process.env.INVOKER_GUI_OWNER_BOOTSTRAP_TIMEOUT_MS
+      ?? process.env.INVOKER_HEADLESS_OWNER_BOOTSTRAP_TIMEOUT_MS
+      ?? '60000',
+    10,
+  );
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 60000;
+}
 
 function headlessExecLogFields(
   payload: HeadlessExecMutationPayload,
@@ -387,6 +412,69 @@ const invokerConfig: InvokerConfig = (() => {
   }
 })();
 
+async function discoverStandaloneOwnerForGui(waitMs: number): Promise<boolean> {
+  let ownerBus = new IpcBus(undefined, { allowServe: false });
+  try {
+    await ownerBus.ready();
+    const deadline = Date.now() + waitMs;
+    while (Date.now() < deadline) {
+      const owner = await discoverOwner(ownerBus, 500);
+      if (isStandaloneCapable(owner)) {
+        logger.info(`daemon owner ready ownerId=${owner.ownerId}`, { module: 'init' });
+        return true;
+      }
+      ownerBus.disconnect();
+      ownerBus = new IpcBus(undefined, { allowServe: false });
+      await ownerBus.ready();
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+    return false;
+  } finally {
+    ownerBus.disconnect();
+  }
+}
+
+async function ensureStandaloneOwnerForGui(): Promise<void> {
+  if (await discoverStandaloneOwnerForGui(2_000)) return;
+
+  const invokerHomeRoot = resolveInvokerHomeRoot();
+  const timeoutMs = guiOwnerBootstrapTimeoutMs();
+  const bootstrapLock = tryAcquireOwnerBootstrapLock(invokerHomeRoot);
+  try {
+    if (bootstrapLock) {
+      logger.info('spawning daemon owner for GUI client mode', { module: 'init' });
+      spawnDetachedStandaloneOwner(repoRoot);
+    } else {
+      logger.info('waiting for daemon owner bootstrap held by another process', { module: 'init' });
+    }
+    if (await discoverStandaloneOwnerForGui(timeoutMs)) return;
+  } finally {
+    bootstrapLock?.release();
+  }
+
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for daemon owner`);
+}
+
+let guiOwnerRouteRefreshPromise: Promise<void> | null = null;
+
+async function refreshGuiMutationOwnerRoute(): Promise<void> {
+  if (resolveGuiOwnerPreference() !== 'daemon') return;
+  if (!guiOwnerRouteRefreshPromise) {
+    guiOwnerRouteRefreshPromise = (async () => {
+      await ensureStandaloneOwnerForGui();
+      const previousMessageBus = typeof messageBus === 'undefined' ? null : messageBus;
+      const refreshedMessageBus = new IpcBus(undefined, { allowServe: false });
+      await refreshedMessageBus.ready();
+      messageBus = refreshedMessageBus;
+      previousMessageBus?.disconnect();
+      logger.info('refreshed daemon owner IPC route for GUI mutation', { module: 'ipc-delegate' });
+    })().finally(() => {
+      guiOwnerRouteRefreshPromise = null;
+    });
+  }
+  await guiOwnerRouteRefreshPromise;
+}
+
 function getSafeInvokerConfigForLogging(config: InvokerConfig): Record<string, unknown> {
   const safeConfig = { ...config } as Record<string, unknown> & {
     docker?: InvokerConfig['docker'];
@@ -448,10 +536,14 @@ function installPackagedSkills(mode: import('@invoker/contracts').BundledSkillsI
 }
 
 async function initServices(options?: InitServicesOptions): Promise<void> {
-  messageBus = new IpcBus();
   const invokerHomeRoot = resolveInvokerHomeRoot();
   mkdirSync(invokerHomeRoot, { recursive: true });
   const readOnly = options?.readOnly === true;
+  const previousMessageBus = typeof messageBus === 'undefined' ? null : messageBus;
+  previousMessageBus?.disconnect();
+  const serviceMessageBus = new IpcBus(undefined, { allowServe: !readOnly });
+  await serviceMessageBus.ready();
+  messageBus = serviceMessageBus;
   const dbPath = path.join(invokerHomeRoot, 'invoker.db');
   if (!readOnly) {
     writerLock = acquireDbWriterLock(dbPath, `main:initServices pid=${process.pid}`);
@@ -906,6 +998,33 @@ if (isHeadless) {
 
       const executeStandaloneGuiMutation = async (payload: GuiMutationPayload): Promise<unknown> => {
         switch (payload.channel) {
+          case 'invoker:clear': {
+            logger.info('clear — stopping all tasks and resetting daemon DAG', { module: 'ipc-delegate' });
+            await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: undefined });
+            await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
+            orchestrator = new Orchestrator({
+              persistence,
+              messageBus,
+              taskRepository: new SqliteTaskRepository(persistence),
+              maxConcurrency: effectiveMaxConcurrency,
+              defaultAutoFixRetries: invokerConfig.autoFixRetries,
+              executorRoutingRules: invokerConfig.executorRoutingRules ?? [],
+              defaultPoolId: invokerConfig.defaultPoolId,
+              availablePoolIds: Object.keys(invokerConfig.executionPools ?? {}),
+              deferRunningUntilLaunch: true,
+              launchOutboxMode: invokerConfig.launchOutboxMode,
+            });
+            commandService = new CommandService(
+              orchestrator,
+              buildInvalidationDeps({
+                logger,
+                orchestrator,
+                persistence,
+                taskExecutor: () => latestTaskExecutor,
+              }),
+            );
+            return undefined;
+          }
           case 'invoker:load-plan': {
             const planText = String(payload.args[0] ?? '');
             const { parsePlan } = await import('./plan-parser.js');
@@ -919,6 +1038,40 @@ if (isHeadless) {
             const started = orchestrator.startExecution();
             await executor.executeTasks(started);
             return started;
+          }
+          case 'invoker:stop': {
+            logger.info('stop — destroying all daemon executors', { module: 'ipc-delegate' });
+            const failInFlightTasks = (): void => {
+              const allTasks = orchestrator.getAllTasks();
+              for (const task of allTasks) {
+                if (isTaskInFlightForForcedStop(task)) {
+                  logger.info(`stop — failing in-flight task "${task.id}" (${task.status})`, { module: 'ipc-delegate' });
+                  orchestrator.handleWorkerResponse({
+                    requestId: `stop-${task.id}`,
+                    actionId: task.id,
+                    attemptId: task.execution.selectedAttemptId,
+                    executionGeneration: task.execution.generation ?? 0,
+                    status: 'failed',
+                    outputs: { exitCode: 1, error: 'Stopped by user' },
+                  });
+                }
+              }
+            };
+            failInFlightTasks();
+            await Promise.all(executorRegistry.getAll().map(f => f.destroyAll()));
+            failInFlightTasks();
+            return undefined;
+          }
+          case 'invoker:inject-task-states': {
+            if (process.env.NODE_ENV !== 'test') {
+              throw new Error('inject-task-states is only available in tests');
+            }
+            const updates = payload.args[0] as Array<{ taskId: string; changes: TaskStateChanges }>;
+            for (const { taskId, changes } of updates) {
+              persistence.updateTask(taskId, changes);
+            }
+            orchestrator.syncAllFromDb();
+            return undefined;
           }
           case 'invoker:set-merge-branch': {
             const workflowId = String(payload.args[0]);
@@ -1004,7 +1157,7 @@ if (isHeadless) {
       // In standalone owner mode, serve delegated requests from peer headless processes.
       if (standaloneMode && messageBus) {
         const standaloneOwnerIdleTimeoutMs = Number.parseInt(
-          process.env.INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '2000',
+          process.env.INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS ?? '0',
           10,
         );
         let standaloneOwnerLastActivityAt = Date.now();
@@ -1012,6 +1165,9 @@ if (isHeadless) {
           standaloneOwnerLastActivityAt = Date.now();
         };
         headlessDeps.isStandaloneOwnerIdle = () => {
+          if (!Number.isFinite(standaloneOwnerIdleTimeoutMs) || standaloneOwnerIdleTimeoutMs <= 0) {
+            return false;
+          }
           const idleForMs = Date.now() - standaloneOwnerLastActivityAt;
           if (idleForMs < standaloneOwnerIdleTimeoutMs) return false;
           const hasQueuedOrRunningMutations =
@@ -1027,10 +1183,6 @@ if (isHeadless) {
         ): { workflowId?: string; priority: WorkflowMutationPriority } => {
           const [command, arg0] = payload.args;
           if (!command) return { priority: 'normal' };
-
-          const standaloneWorkflowIdForTaskArg = (taskIdArg: unknown): string => {
-            return resolveHeadlessTargetWorkflowId(taskIdArg, persistence);
-          };
 
           switch (command) {
             case 'set': {
@@ -1085,6 +1237,10 @@ if (isHeadless) {
           }
         };
 
+        const standaloneWorkflowIdForTaskArg = (taskIdArg: unknown): string => {
+          return resolveHeadlessTargetWorkflowId(taskIdArg, persistence);
+        };
+
         const runStandaloneWorkflowMutation = async <T>(
           workflowId: string | undefined,
           priority: WorkflowMutationPriority,
@@ -1112,6 +1268,22 @@ if (isHeadless) {
             return { ok: true };
           });
         }
+        if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
+          workflowMutationDispatcher.set('invoker:fix-with-agent', async (taskIdArg: unknown, agentNameArg?: unknown) => {
+            const args = ['fix', String(taskIdArg)];
+            if (typeof agentNameArg === 'string' && agentNameArg.length > 0) {
+              args.push(agentNameArg);
+            }
+            await runHeadless(args, {
+              ...headlessDeps,
+              waitForApproval: false,
+              noTrack: true,
+              signal: activeMutationContext?.signal,
+              mutationTiming: activeMutationContext?.mutationTiming,
+            });
+            return { ok: true };
+          });
+        }
         if (!workflowMutationCoordinator) {
           workflowMutationCoordinator = new PersistedWorkflowMutationCoordinator(
             persistence,
@@ -1132,6 +1304,176 @@ if (isHeadless) {
           );
         }
 
+        const buildStandaloneAutoFixQueueSnapshot = (taskId: string): Record<string, unknown> => {
+          const workflowId = standaloneWorkflowIdForTaskArg(taskId);
+          if (!workflowId) {
+            return {
+              workflowId: null,
+              openIntentCountForWorkflow: 0,
+              openFixIntentCountForWorkflow: 0,
+              openFixIntentCountForTask: 0,
+              openFixIntentForTask: false,
+              openFixIntentHead: null,
+              openFixIntentPreview: [],
+            };
+          }
+          const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
+          const openFixIntents = openIntents.filter((intent) => (
+            intent.channel === 'invoker:fix-with-agent' || intent.channel === 'headless.exec'
+          ));
+          const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
+          return {
+            workflowId,
+            openIntentCountForWorkflow: openIntents.length,
+            openFixIntentCountForWorkflow: openFixIntents.length,
+            openFixIntentCountForTask: openTaskFixIntents.length,
+            openFixIntentForTask: openTaskFixIntents.length > 0,
+            openFixIntentHead: openTaskFixIntents[0]
+              ? {
+                id: openTaskFixIntents[0].id,
+                status: openTaskFixIntents[0].status,
+                channel: openTaskFixIntents[0].channel,
+              }
+              : null,
+            openFixIntentPreview: openTaskFixIntents.slice(0, 5).map((intent) => ({
+              id: intent.id,
+              status: intent.status,
+              channel: intent.channel,
+            })),
+          };
+        };
+
+        const logStandaloneAutoFixDebug = (
+          taskId: string,
+          phase: string,
+          details: Record<string, unknown> = {},
+        ): void => {
+          const task = orchestrator.getTask(taskId);
+          const payload = {
+            phase,
+            status: task?.status ?? 'missing',
+            autoFixAttempts: task?.execution.autoFixAttempts ?? null,
+            ...buildStandaloneAutoFixQueueSnapshot(taskId),
+            ...details,
+          };
+          persistence.logEvent?.(taskId, 'debug.auto-fix', payload);
+          logger.info(
+            `[auto-fix-debug][standalone] task="${taskId}" phase=${phase} payload=${JSON.stringify(payload)}`,
+            { module: 'auto-fix' },
+          );
+        };
+
+        const scheduleStandaloneAutoFix = (taskId: string): void => {
+          logStandaloneAutoFixDebug(taskId, 'schedule-enter');
+          if (!workflowMutationCoordinator) {
+            logStandaloneAutoFixDebug(taskId, 'schedule-skip', { reason: 'no-workflow-mutation-coordinator' });
+            return;
+          }
+          if (!workflowMutationDispatcher.has('invoker:fix-with-agent')) {
+            logStandaloneAutoFixDebug(taskId, 'schedule-skip', { reason: 'fix-handler-not-ready' });
+            return;
+          }
+          const workflowId = standaloneWorkflowIdForTaskArg(taskId);
+          if (!workflowId) {
+            logStandaloneAutoFixDebug(taskId, 'schedule-skip', { reason: 'workflow-not-found' });
+            return;
+          }
+          const shouldAutoFixNow = orchestrator.shouldAutoFix(taskId);
+          if (!shouldAutoFixNow) {
+            logStandaloneAutoFixDebug(taskId, 'schedule-skip', {
+              reason: 'shouldAutoFix-false',
+              shouldAutoFix: shouldAutoFixNow,
+            });
+            return;
+          }
+          const openIntents = persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
+          const openTaskFixIntents = listOpenFixIntentsForTask(openIntents, taskId);
+          if (openTaskFixIntents.length > 0) {
+            logStandaloneAutoFixDebug(taskId, 'schedule-skip', {
+              reason: 'already-queued-intent',
+              existingIntentIds: openTaskFixIntents.map((intent) => intent.id),
+            });
+            return;
+          }
+          const configuredAgent = loadConfig().autoFixAgent?.trim();
+          const selectedAgent = configuredAgent && configuredAgent.length > 0 ? configuredAgent : undefined;
+          logStandaloneAutoFixDebug(taskId, 'schedule-enqueue');
+          logStandaloneAutoFixDebug(taskId, 'schedule-enqueued');
+          void workflowMutationCoordinator.enqueue(
+            workflowId,
+            'normal',
+            'invoker:fix-with-agent',
+            [taskId, selectedAgent],
+          )
+            .then(() => {
+              logStandaloneAutoFixDebug(taskId, 'schedule-dispatch-finished');
+            })
+            .catch((err) => {
+              if (err instanceof StaleLineageError) {
+                logger.info(`auto-fix discarded stale result for "${taskId}": ${err.message}`, { module: 'auto-fix' });
+                return;
+              }
+              logStandaloneAutoFixDebug(taskId, 'schedule-dispatch-error', {
+                error: err instanceof Error ? err.stack ?? err.message : String(err),
+              });
+            });
+        };
+
+        const maybeScheduleStandaloneAutoFix = (
+          task: TaskState,
+          trigger: 'delta' | 'poll',
+        ): boolean => {
+          if (task.status !== 'failed') return false;
+          const cancellationError = shouldSkipAutoFixForError(task.execution.error);
+          const shouldAutoFixFromOrchestrator = orchestrator.shouldAutoFix(task.id);
+          logStandaloneAutoFixDebug(task.id, `${trigger}-failed`, {
+            shouldSkipForCancellation: cancellationError,
+            shouldAutoFixFromOrchestrator,
+          });
+          if (!cancellationError && shouldAutoFixFromOrchestrator) {
+            logStandaloneAutoFixDebug(task.id, `${trigger}-trigger-schedule`);
+            scheduleStandaloneAutoFix(task.id);
+            return true;
+          }
+          return false;
+        };
+
+        const startStandaloneAutoFixRecoveryPoll = (workflowId: string): void => {
+          const startedAtMs = Date.now();
+          const maxPollMs = 90_000;
+          const poll = setInterval(() => {
+            if (Date.now() - startedAtMs > maxPollMs) {
+              clearInterval(poll);
+              return;
+            }
+            try {
+              orchestrator.syncFromDb(workflowId);
+              const scheduled = orchestrator
+                .getAllTasks()
+                .filter((task) => task.config.workflowId === workflowId)
+                .some((task) => maybeScheduleStandaloneAutoFix(task, 'poll'));
+              if (scheduled) {
+                clearInterval(poll);
+              }
+            } catch (err) {
+              logger.warn(
+                `standalone auto-fix recovery poll failed for "${workflowId}": ${
+                  err instanceof Error ? err.message : String(err)
+                }`,
+                { module: 'auto-fix' },
+              );
+            }
+          }, 1_000);
+          poll.unref?.();
+        };
+
+        messageBus.subscribe(Channels.TASK_DELTA, (delta: unknown) => {
+          const d = delta as TaskDelta;
+          if (d.type !== 'updated' || d.changes.status !== 'failed') return;
+          const task = orchestrator.getTask(d.taskId);
+          if (task) maybeScheduleStandaloneAutoFix(task, 'delta');
+        });
+
         const executeStandaloneHeadlessRun = async (
           payload: HeadlessRunMutationPayload,
         ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
@@ -1145,6 +1487,7 @@ if (isHeadless) {
           createStandaloneTaskExecutor().executeTasks(started).catch(err => {
             logger.error(`headless.run: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
           });
+          startStandaloneAutoFixRecoveryPoll(workflowId);
           logger.info(`started ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
           const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
           return { workflowId, tasks };
@@ -1210,6 +1553,9 @@ if (isHeadless) {
           }
           if (kind === 'queue') {
             return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+          }
+          if (kind === 'workflow-status') {
+            return orchestrator.getWorkflowStatus();
           }
           if (kind === 'tasks') {
             if ((req as { forceRefresh?: boolean }).forceRefresh) {
@@ -1280,6 +1626,10 @@ if (isHeadless) {
             });
           });
           return { ok: true };
+        });
+        messageBus.onRequest('headless.gui-mutation', async (req: unknown) => {
+          noteStandaloneOwnerActivity();
+          return executeStandaloneGuiMutation(req as GuiMutationPayload);
         });
 
         reviewGateStatusWorker = startReviewGateStatusWorker({
@@ -2208,16 +2558,21 @@ function createEmbeddedTerminalBackendFromConfig(
   }
 
   function translateGuiMutationToHeadless(payload: GuiMutationPayload):
+    | { channel: 'headless.gui-mutation'; request: GuiMutationPayload }
     | { channel: 'headless.run'; request: HeadlessRunMutationPayload }
     | { channel: 'headless.resume'; request: HeadlessResumeMutationPayload }
     | { channel: 'headless.exec'; request: HeadlessExecMutationPayload }
     | null {
     const [arg0, arg1, arg2] = payload.args;
     switch (payload.channel) {
+      case 'invoker:load-plan':
+        return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:start':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:stop':
-        return { channel: 'headless.exec', request: { args: ['stop'] } };
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:clear':
-        return { channel: 'headless.exec', request: { args: ['clear'] } };
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resume-workflow': {
         const workflows = persistence.listWorkflows();
         const workflowId = workflows[0]?.id;
@@ -2259,6 +2614,8 @@ function createEmbeddedTerminalBackendFromConfig(
         return { channel: 'headless.exec', request: { args: ['rebase-retry', String(arg0)] } };
       case 'invoker:rebase-recreate':
         return { channel: 'headless.exec', request: { args: ['rebase-recreate', String(arg0)] } };
+      case 'invoker:set-merge-branch':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:set-merge-mode':
         return { channel: 'headless.exec', request: { args: ['set', 'merge-mode', String(arg0), String(arg1)] } };
       case 'invoker:approve-merge': {
@@ -2332,6 +2689,7 @@ function createEmbeddedTerminalBackendFromConfig(
     ipcMain,
     getOwnerMode: () => ownerMode,
     getMessageBus: () => messageBus,
+    refreshOwnerRoute: refreshGuiMutationOwnerRoute,
     translateGuiMutationToHeadless,
     guiMutationHandlers,
   };
@@ -2509,7 +2867,10 @@ function createEmbeddedTerminalBackendFromConfig(
     if (deferredStartupTriggered) return;
     deferredStartupTriggered = true;
     recordStartupMark('deferred-startup.begin');
-    const startupPollDelayMs = Number.parseInt(process.env.INVOKER_STARTUP_POLL_DELAY_MS ?? '10000', 10) || 10000;
+    const configuredStartupPollDelayMs = Number.parseInt(process.env.INVOKER_STARTUP_POLL_DELAY_MS ?? '10000', 10);
+    const startupPollDelayMs = Number.isFinite(configuredStartupPollDelayMs)
+      ? configuredStartupPollDelayMs
+      : 10000;
 
     setTimeout(() => {
       if (!ownerMode) return;
@@ -2714,22 +3075,62 @@ function createEmbeddedTerminalBackendFromConfig(
 
   const runGuiReadyBootstrap = async (): Promise<void> => {
     recordStartupMark('app.whenReady');
-    ownerMode = true;
-    try {
-      recordStartupMark('initServices.start');
-      await initServices({ executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
-      recordStartupMark('initServices.end', { ownerMode: true });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      if (!message.includes('[db-writer-lock]')) {
+    const guiOwnerPreference = resolveGuiOwnerPreference();
+    let daemonGuiOwner = false;
+    if (guiOwnerPreference === 'daemon') {
+      try {
+        recordStartupMark('daemonOwner.ensure.start');
+        await ensureStandaloneOwnerForGui();
+        recordStartupMark('daemonOwner.ensure.end');
+        daemonGuiOwner = true;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
         process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
         app.quit();
         return;
       }
-      recordStartupMark('initServices.readOnly.start');
-      await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+    } else if (guiOwnerPreference === 'auto') {
+      recordStartupMark('daemonOwner.discover.start');
+      try {
+        daemonGuiOwner = await discoverStandaloneOwnerForGui(1_000);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        logger.warn(`daemon owner auto-discovery failed; starting GUI owner locally: ${message}`, { module: 'init' });
+        daemonGuiOwner = false;
+      }
+      recordStartupMark('daemonOwner.discover.end', { daemonOwner: daemonGuiOwner });
+    }
+
+    if (daemonGuiOwner) {
       ownerMode = false;
-      recordStartupMark('initServices.readOnly.end', { ownerMode: false });
+      try {
+        recordStartupMark('initServices.readOnly.start');
+        await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+        recordStartupMark('initServices.readOnly.end', { ownerMode: false, daemonOwner: true });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
+        app.quit();
+        return;
+      }
+    } else {
+      ownerMode = true;
+      try {
+        recordStartupMark('initServices.start');
+        await initServices({ executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+        recordStartupMark('initServices.end', { ownerMode: true });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (!message.includes('[db-writer-lock]')) {
+          process.stderr.write(`${RED}Error:${RESET} ${message}\n`);
+          app.quit();
+          return;
+        }
+        recordStartupMark('initServices.readOnly.start');
+        await initServices({ readOnly: true, executionAgentRegistry: agentRegistry, startupSyncMode: 'none' });
+        ownerMode = false;
+        recordStartupMark('initServices.readOnly.end', { ownerMode: false });
+      }
     }
 
     if (ownerMode) {
@@ -2807,6 +3208,9 @@ function createEmbeddedTerminalBackendFromConfig(
         }
         if (kind === 'queue') {
           return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+        }
+        if (kind === 'workflow-status') {
+          return orchestrator.getWorkflowStatus();
         }
         if (kind === 'tasks') {
           if ((req as { forceRefresh?: boolean }).forceRefresh) {
@@ -3005,32 +3409,42 @@ function createEmbeddedTerminalBackendFromConfig(
     });
 
     if (process.env.NODE_ENV === 'test') {
+      const injectTaskStates = async (updates: Array<{ taskId: string; changes: TaskStateChanges }>): Promise<void> => {
+        for (const { taskId, changes } of updates) {
+          const before = orchestrator.getTask(taskId);
+          const previousSnapshot = lastKnownTaskStates.get(taskId);
+          const previousTaskStateVersion = previousSnapshot
+            ? (
+                (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
+                ?? before?.taskStateVersion
+                ?? 1
+              )
+            : (before?.taskStateVersion ?? 0);
+          persistence.updateTask(taskId, changes);
+          messageBus.publish(Channels.TASK_DELTA, {
+            type: 'updated',
+            taskId,
+            changes,
+            previousTaskStateVersion,
+            taskStateVersion: previousTaskStateVersion + 1,
+          } satisfies TaskDelta);
+        }
+        orchestrator.syncAllFromDb();
+        if (mainWindow && !mainWindow.isDestroyed()) {
+          requestWorkflowMetadataPublish('gap-detect');
+        }
+      };
       ipcMain.handle(
         'invoker:inject-task-states',
         async (_event, updates: Array<{ taskId: string; changes: TaskStateChanges }>) => {
-          for (const { taskId, changes } of updates) {
-            const before = orchestrator.getTask(taskId);
-            const previousSnapshot = lastKnownTaskStates.get(taskId);
-            const previousTaskStateVersion = previousSnapshot
-              ? (
-                  (JSON.parse(previousSnapshot) as { taskStateVersion?: number }).taskStateVersion
-                  ?? before?.taskStateVersion
-                  ?? 1
-                )
-              : (before?.taskStateVersion ?? 0);
-            persistence.updateTask(taskId, changes);
-            messageBus.publish(Channels.TASK_DELTA, {
-              type: 'updated',
-              taskId,
-              changes,
-              previousTaskStateVersion,
-              taskStateVersion: previousTaskStateVersion + 1,
-            } satisfies TaskDelta);
+          if (!ownerMode) {
+            await messageBus.request('headless.gui-mutation', {
+              channel: 'invoker:inject-task-states',
+              args: [updates],
+            } satisfies GuiMutationPayload);
+            return;
           }
-          orchestrator.syncAllFromDb();
-          if (mainWindow && !mainWindow.isDestroyed()) {
-            requestWorkflowMetadataPublish('gap-detect');
-          }
+          await injectTaskStates(updates);
         },
       );
     }
@@ -3108,15 +3522,7 @@ function createEmbeddedTerminalBackendFromConfig(
 
     registerGuiMutationHandler('invoker:clear', async () => {
       logger.info('clear — stopping all tasks and resetting DAG', { module: 'ipc' });
-      const workflows = persistence.listWorkflows();
-
-      for (const workflow of workflows) {
-        try {
-          await performCancelWorkflow(workflow.id);
-        } catch (err) {
-          logger.error(`clear: failed to cancel workflow "${workflow.id}": ${err}`, { module: 'ipc' });
-        }
-      }
+      await sharedDeleteAllWorkflows({ logger, orchestrator, taskExecutor: taskExecutor ?? undefined });
       await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
 
       orchestrator = new Orchestrator({
@@ -3142,6 +3548,9 @@ function createEmbeddedTerminalBackendFromConfig(
       );
       rebuildTaskRunner();
       taskHandles.clear();
+      lastKnownTaskStates.clear();
+      lastKnownWorkflowCount = 0;
+      requestWorkflowMetadataPublish('clear');
     });
 
     registerReadOnlyIpcHandlers({

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -826,6 +826,7 @@ if (isHeadless) {
 
     let exitCode = 0;
     let reviewGateStatusWorker: ReviewGateStatusWorker | null = null;
+    let headlessLaunchDispatchPollInterval: ReturnType<typeof setInterval> | null = null;
     try {
       // Standalone mode: initialize services and run headless
       await initServices({
@@ -1286,6 +1287,39 @@ if (isHeadless) {
           getTaskExecutor: createStandaloneTaskExecutor,
           logger,
         });
+
+        if (
+          command === 'owner-serve'
+          && !launchDispatcher
+          && invokerConfig.launchOutboxMode
+          && invokerConfig.launchOutboxMode !== 'disabled'
+        ) {
+          const standaloneLaunchTaskExecutor = createStandaloneTaskExecutor();
+          launchDispatcher = new LaunchDispatcher({
+            persistence,
+            orchestrator,
+            taskRunnerProvider: () => standaloneLaunchTaskExecutor,
+            ownerId: workflowMutationOwnerId,
+            logger,
+            mode: invokerConfig.launchOutboxMode as LaunchDispatcherMode,
+          });
+        }
+
+        if (command === 'owner-serve' && launchDispatcher) {
+          const pollHeadlessLaunchDispatcher = (): void => {
+            try {
+              launchDispatcher?.poll();
+            } catch (err) {
+              logger.warn(
+                `[launch-dispatcher] headless poll() failed: ${err instanceof Error ? err.message : String(err)}`,
+                { module: 'headless' },
+              );
+            }
+          };
+          pollHeadlessLaunchDispatcher();
+          headlessLaunchDispatchPollInterval = setInterval(pollHeadlessLaunchDispatcher, 2000);
+          headlessLaunchDispatchPollInterval.unref?.();
+        }
       }
 
       await runHeadless(cliArgs, headlessDeps);
@@ -1293,6 +1327,9 @@ if (isHeadless) {
       process.stderr.write(`${RED}Error:${RESET} ${err instanceof Error ? err.message : String(err)}\n`);
       exitCode = 1;
     } finally {
+      if (headlessLaunchDispatchPollInterval) {
+        clearInterval(headlessLaunchDispatchPollInterval);
+      }
       reviewGateStatusWorker?.stop();
       if (ownsHeadlessShutdown && executorRegistry) {
         await Promise.all(executorRegistry.getAll().map(f => f.destroyAll().catch(() => undefined)));
@@ -1994,6 +2031,7 @@ function createEmbeddedTerminalBackendFromConfig(
       noTrack: payload.noTrack,
       preemptTaskSubgraph: (taskId: string) => preemptTaskSubgraph(taskId),
       preemptWorkflowExecution: (workflowId: string) => preemptWorkflowExecution(workflowId),
+      ownerTaskRunnerProvider: () => requireTaskExecutor(),
       deferRunnableTasks: (tasks: TaskState[], workflowId?: string) => {
         const filteredTasks = tasks;
         const crossWorkflowTasks = workflowId

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -1173,6 +1173,9 @@ if (isHeadless) {
           const hasQueuedOrRunningMutations =
             persistence.listWorkflowMutationIntents(undefined, ['queued', 'running']).length > 0;
           if (hasQueuedOrRunningMutations) return false;
+          const hasActiveLaunchDispatches =
+            persistence.listLaunchDispatchesByState?.(['enqueued', 'leased']).length > 0;
+          if (hasActiveLaunchDispatches) return false;
           return !orchestrator.getAllTasks().some(
             (task) => task.status === 'running' || task.status === 'fixing_with_ai',
           );

--- a/packages/app/src/owner-resolver.ts
+++ b/packages/app/src/owner-resolver.ts
@@ -40,6 +40,8 @@ export interface OwnerResolverDeps {
   refreshMessageBus?: () => Promise<MessageBus>;
   /** Bootstrap a standalone owner process. */
   ensureStandaloneOwner: (bus: MessageBus) => Promise<void>;
+  /** Whether a bootstrap error should be treated as a failed attempt and retried. */
+  isRetryableBootstrapError?: (error: unknown) => boolean;
 }
 
 // ── Configuration ───────────────────────────────────────────
@@ -133,6 +135,13 @@ export function createOwnerResolver(
     return { resolved: true, owner, bus };
   }
 
+  function acceptsOwner(
+    owner: OwnerDiscoveryResult,
+    requireStandalone: boolean,
+  ): owner is OwnerEndpointInfo {
+    return requireStandalone ? isStandaloneCapable(owner) : isOwnerReachable(owner);
+  }
+
   const resolver: OwnerResolver = {
     async discover(): Promise<OwnerResolveResult> {
       const owner = await discoverOwner(currentBus, discoveryTimeoutMs);
@@ -179,18 +188,32 @@ export function createOwnerResolver(
     async resolve(requireStandalone = true): Promise<ResolvedOwner> {
       // Phase 1: Try immediate discovery
       const immediate = await discoverOwner(currentBus, discoveryTimeoutMs);
-      if (requireStandalone ? isStandaloneCapable(immediate) : isOwnerReachable(immediate)) {
-        return { owner: immediate!, bus: currentBus };
+      if (acceptsOwner(immediate, requireStandalone)) {
+        return { owner: immediate, bus: currentBus };
       }
 
       // Phase 2: Refresh and retry
       if (deps.refreshMessageBus) {
         currentBus = await deps.refreshMessageBus();
+        const refreshed = await discoverOwner(currentBus, refreshDiscoveryTimeoutMs);
+        if (acceptsOwner(refreshed, requireStandalone)) {
+          return { owner: refreshed, bus: currentBus };
+        }
       }
 
       // Phase 3: Bootstrap with retry loop
       for (let attempt = 0; attempt < maxBootstrapAttempts; attempt += 1) {
-        await deps.ensureStandaloneOwner(currentBus);
+        try {
+          await deps.ensureStandaloneOwner(currentBus);
+        } catch (error) {
+          if (!deps.isRetryableBootstrapError?.(error)) {
+            throw error;
+          }
+          if (deps.refreshMessageBus) {
+            currentBus = await deps.refreshMessageBus();
+          }
+          continue;
+        }
 
         if (deps.refreshMessageBus) {
           currentBus = await deps.refreshMessageBus();

--- a/packages/app/src/persisted-workflow-mutation-coordinator.ts
+++ b/packages/app/src/persisted-workflow-mutation-coordinator.ts
@@ -95,6 +95,19 @@ export class PersistedWorkflowMutationCoordinator {
     args: unknown[],
     options?: { deferDrain?: boolean },
   ): number {
+    const coalesced = this.findOpenCoalescibleRetryIntent(workflowId, channel, args);
+    if (coalesced) {
+      this.trace(
+        `submit coalesced workflow=${workflowId} channel=${channel} into intent=${coalesced.id} status=${coalesced.status}`,
+      );
+      if (options?.deferDrain) {
+        this.scheduleWorkflowDrainDeferred(workflowId);
+      } else {
+        this.scheduleWorkflowDrain(workflowId);
+      }
+      return coalesced.id;
+    }
+
     const intentId = this.persistence.enqueueWorkflowMutationIntent(workflowId, channel, args, priority);
     this.enqueueStartedAtMs.set(intentId, Date.now());
     this.createTiming(workflowId, channel, intentId, args)
@@ -112,6 +125,35 @@ export class PersistedWorkflowMutationCoordinator {
       this.scheduleWorkflowDrain(workflowId);
     }
     return intentId;
+  }
+
+  private findOpenCoalescibleRetryIntent(
+    workflowId: string,
+    channel: string,
+    args: unknown[],
+  ): WorkflowMutationIntent | undefined {
+    const key = this.coalescibleRetryKey(channel, args);
+    if (!key) return undefined;
+    const open = this.persistence.listWorkflowMutationIntents(workflowId, ['queued', 'running']);
+    return open.find((intent) => this.coalescibleRetryKey(intent.channel, intent.args) === key);
+  }
+
+  private coalescibleRetryKey(channel: string, args: unknown[]): string | null {
+    if (channel === 'invoker:retry-workflow') {
+      const target = typeof args[0] === 'string' ? args[0] : '';
+      return /^wf-[^/]+$/.test(target) ? `retry-workflow:${target}` : null;
+    }
+    if (channel !== 'headless.exec') {
+      return null;
+    }
+    const payload = args[0] as { args?: unknown[] } | undefined;
+    const rawArgs = Array.isArray(payload?.args) ? payload.args : [];
+    const command = typeof rawArgs[0] === 'string' ? rawArgs[0] : '';
+    const target = typeof rawArgs[1] === 'string' ? rawArgs[1] : '';
+    if (command !== 'retry' || !/^wf-[^/]+$/.test(target)) {
+      return null;
+    }
+    return `retry-workflow:${target}`;
   }
 
   async resumePending(): Promise<void> {

--- a/packages/contracts/src/launch-timeouts.ts
+++ b/packages/contracts/src/launch-timeouts.ts
@@ -12,6 +12,6 @@
 
 export const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
 
-export const DISPATCH_LEASE_MS = 30_000;
+export const DISPATCH_LEASE_MS = 12 * 60 * 1000;
 
 export const DISPATCH_MAX_ATTEMPTS = 3;

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -297,6 +297,17 @@ describe('SQLiteAdapter', () => {
 
       const byAttempt = adapter.loadLaunchDispatchByAttempt('attempt-1');
       expect(byAttempt?.id).toBe(inserted.id);
+
+      const events = adapter.getEvents('wf-launch/t1');
+      const enqueuedEvent = events.find((event) => event.eventType === 'task.launch_dispatch_enqueued');
+      expect(enqueuedEvent).toBeDefined();
+      expect(JSON.parse(enqueuedEvent!.payload!)).toMatchObject({
+        dispatchId: inserted.id,
+        attemptId: 'attempt-1',
+        workflowId: 'wf-launch',
+        generation: 0,
+        priority: 'normal',
+      });
     });
 
     it('returns existing row instead of creating a duplicate active dispatch for the same attempt', () => {
@@ -534,6 +545,17 @@ describe('SQLiteAdapter', () => {
         expect(claimed?.attemptsCount).toBe(1);
         expect(claimed?.fencedUntil).toBeDefined();
         expect(claimed?.leasedAt).toBeDefined();
+        const events = adapter.getEvents('wf-launch/t1');
+        const claimedEvent = events.find((event) => event.eventType === 'task.launch_dispatch_claimed');
+        expect(claimedEvent).toBeDefined();
+        expect(JSON.parse(claimedEvent!.payload!)).toMatchObject({
+          dispatchId: enqueued.id,
+          ownerId: 'runner-1',
+          attemptId: 'attempt-claim-1',
+          workflowId: 'wf-launch',
+          generation: 0,
+          fencedUntil: claimed?.fencedUntil,
+        });
       });
 
       it('returns undefined when no enqueued rows exist', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3298,7 +3298,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (!inserted) {
         throw new Error('Failed to read back inserted task_launch_dispatch row');
       }
-      return this.rowToTaskLaunchDispatch(inserted);
+      const dispatch = this.rowToTaskLaunchDispatch(inserted);
+      this.logEvent(input.taskId, 'task.launch_dispatch_enqueued', {
+        dispatchId: dispatch.id,
+        attemptId: input.attemptId,
+        workflowId: input.workflowId,
+        generation: input.generation,
+        priority,
+      });
+      return dispatch;
     });
   }
 
@@ -3424,7 +3432,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
           'SELECT * FROM task_launch_dispatch WHERE id = ?',
           [candidateId],
         );
-        return row ? this.rowToTaskLaunchDispatch(row) : undefined;
+        if (!row) return undefined;
+        const dispatch = this.rowToTaskLaunchDispatch(row);
+        this.logEvent(dispatch.taskId, 'task.launch_dispatch_claimed', {
+          dispatchId: dispatch.id,
+          ownerId: options.ownerId,
+          attemptId: dispatch.attemptId,
+          workflowId: dispatch.workflowId,
+          generation: dispatch.generation,
+          fencedUntil: dispatch.fencedUntil,
+        });
+        return dispatch;
       }
     });
   }

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
 import { TaskRunner, type LaunchOutboxAck } from '../task-runner.js';
@@ -32,6 +32,11 @@ function makeTask(overrides: Partial<TaskState> = {}): TaskState {
 
 interface RunnerEnv {
   runner: TaskRunner;
+  persistence: {
+    updateTask: ReturnType<typeof vi.fn>;
+    loadAttempts: ReturnType<typeof vi.fn>;
+    logEvent: ReturnType<typeof vi.fn>;
+  };
   orchestrator: {
     getTask: ReturnType<typeof vi.fn>;
     markTaskRunningAfterLaunch: ReturnType<typeof vi.fn>;
@@ -50,11 +55,15 @@ interface RunnerEnv {
   triggerComplete: () => void;
 }
 
-function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}): RunnerEnv {
+function buildRunnerEnv(task: TaskState, options: {
+  startThrows?: Error;
+  startImpl?: (request: any) => Promise<any>;
+} = {}): RunnerEnv {
   let completeCallback: ((response: WorkResponse) => void) | undefined;
   const executor = {
     type: 'worktree',
     start: vi.fn().mockImplementation(async (request: any) => {
+      if (options.startImpl) return options.startImpl(request);
       if (options.startThrows) throw options.startThrows;
       return {
         executionId: `exec-${request.actionId}`,
@@ -79,13 +88,14 @@ function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}):
     handleWorkerResponse: vi.fn().mockReturnValue([]),
     deferTask: vi.fn(),
   };
+  const persistence = {
+    updateTask: vi.fn(),
+    loadAttempts: vi.fn().mockReturnValue([]),
+    logEvent: vi.fn(),
+  };
   const runner = new TaskRunner({
     orchestrator: orchestrator as any,
-    persistence: {
-      updateTask: vi.fn(),
-      loadAttempts: vi.fn().mockReturnValue([]),
-      logEvent: vi.fn(),
-    } as any,
+    persistence: persistence as any,
     executorRegistry: {
       get: vi.fn().mockReturnValue(executor),
       getAll: vi.fn().mockReturnValue([['worktree', executor]]),
@@ -96,6 +106,7 @@ function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}):
   });
   return {
     runner,
+    persistence,
     orchestrator,
     executor,
     triggerComplete: () => {
@@ -132,6 +143,10 @@ function makeLaunchOutbox(): LaunchOutboxAck & {
 }
 
 describe('TaskRunner launch-dispatch wiring', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('keeps dispatch leased and proceeds to executor.start', async () => {
     const task = makeTask();
     const env = buildRunnerEnv(task, { startThrows: new Error('isolated start sentinel') });
@@ -155,6 +170,38 @@ describe('TaskRunner launch-dispatch wiring', () => {
     const failArg = launchOutbox.failCalls[0][1];
     expect(failArg).toBeInstanceOf(Error);
     expect((failArg as Error).message).toMatch(/startup explosion/);
+  });
+
+  it('logs executor start begin with launch-dispatch context while executor.start is pending', async () => {
+    const task = makeTask();
+    let resolveStart: (() => void) | undefined;
+    const env = buildRunnerEnv(task, {
+      startImpl: async (request) => new Promise((resolve) => {
+        resolveStart = () => resolve({
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/tmp/mock-ws',
+          branch: `experiment/${request.actionId}-mock`,
+        });
+      }),
+    });
+    const launchOutbox = makeLaunchOutbox();
+
+    const run = env.runner.executeTask(task, { dispatchId: 99, launchOutbox });
+    await vi.waitFor(() => expect(env.persistence.logEvent).toHaveBeenCalledWith(
+      task.id,
+      'task.executor.start_begin',
+      expect.objectContaining({
+        dispatchId: 99,
+        attemptId: 'attempt-1',
+        executorType: 'worktree',
+      }),
+    ));
+
+    resolveStart?.();
+    await vi.waitFor(() => expect(env.executor.onComplete).toHaveBeenCalled());
+    env.triggerComplete();
+    await run;
   });
 
   it('fails the dispatch when markTaskRunningAfterLaunch rejects the launch', async () => {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -62,7 +62,7 @@ import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutati
 
 export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-callbacks.js';
 
-/** Keeps `lastHeartbeatAt` fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). Matches BaseExecutor default heartbeat cadence. */
+/** Keeps launch metadata fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). */
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_EXECUTOR_START_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -842,6 +842,13 @@ export class TaskRunner {
         `[TaskRunner] executor.start begin task=${task.id} attempt=${attemptId} executor=${executor.type} ` +
           `generation=${task.execution.generation ?? 0}`,
       );
+      this.persistence.logEvent?.(task.id, 'task.executor.start_begin', {
+        dispatchId: dispatchOpts?.dispatchId,
+        attemptId,
+        executorType: executor.type,
+        poolId: poolSelectionForStart?.poolId,
+        poolMemberId: poolSelectionForStart?.member.id,
+      });
       bench('onLaunchStart.before', {
         executorType: executor.type,
       });

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -799,6 +799,7 @@ describe('Orchestrator', () => {
       const task = orchestrator.getTask('f2')!;
       expect(task.status === 'pending' || task.status === 'running').toBe(true);
       expect(task.execution.isFixingWithAI).toBeFalsy();
+      expect(task.execution.pendingFixError).toBeUndefined();
     });
 
     it('revertConflictResolution restores failed state', () => {

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -7035,6 +7035,7 @@ describe('Orchestrator', () => {
       expect(queueStatus.runningCount).toBe(1);
       expect(queueStatus.running[0]?.taskId).toBe(taskId);
       expect(queueStatus.running[0]?.attemptId).toBe(selectedAttemptId);
+      expect(queueStatus.queued.map((task) => task.taskId)).not.toContain(taskId);
     });
 
     it('restartTask supersedes a claimed selected attempt before relaunching', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -2292,6 +2292,7 @@ export class Orchestrator {
         completedAt: undefined,
         error: undefined,
         exitCode: undefined,
+        pendingFixError: undefined,
         commit: undefined,
         lastHeartbeatAt: undefined,
         launchStartedAt: undefined,

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -4298,9 +4298,11 @@ export class Orchestrator {
         return { task, attemptId, attempt };
       })
       .filter(({ task, attempt }) => this.isTaskExecutionActive(task, attempt, now));
+    const activeTaskIds = new Set(activeAttempts.map(({ task }) => task.id));
     const queuedTasks = this.stateMachine
       .getReadyTasks()
       .filter((task) => task.status === 'pending')
+      .filter((task) => !activeTaskIds.has(task.id))
       .filter((task) => this.getExternalDependencyBlocker(task) === undefined)
       .map((task) => {
         const attempt = task.execution.selectedAttemptId

--- a/scripts/auto-recover-loop.sh
+++ b/scripts/auto-recover-loop.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Wait for a wedged Electron PID to die, then relaunch ./run.sh and the
+# autofix retry loop. Useful when the GUI owner is stuck in UE state and we
+# don't want to force-kill long-running tasks.
+#
+# Usage: bash scripts/auto-recover-loop.sh <wedged_pid>
+set -euo pipefail
+
+WEDGED_PID="${1:?usage: auto-recover-loop.sh <wedged_pid>}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LOG_DIR="$HOME/.invoker/auto-recover"
+mkdir -p "$LOG_DIR"
+
+echo "[auto-recover] waiting for PID $WEDGED_PID to terminate..."
+while kill -0 "$WEDGED_PID" 2>/dev/null; do
+  sleep 30
+done
+echo "[auto-recover] PID $WEDGED_PID is gone at $(date -u +%FT%TZ)"
+
+echo "[auto-recover] killing any straggler Electron processes..."
+bash "$REPO_ROOT/scripts/kill-all-electron.sh" || true
+sleep 2
+
+echo "[auto-recover] launching ./run.sh"
+RUN_LOG="$LOG_DIR/run-$(date +%Y%m%dT%H%M%SZ).log"
+nohup "$REPO_ROOT/run.sh" > "$RUN_LOG" 2>&1 &
+RUN_PID=$!
+echo "[auto-recover] run.sh pid=$RUN_PID log=$RUN_LOG"
+disown "$RUN_PID" || true
+
+echo "[auto-recover] waiting for owner-ipc-ready (max 600s)..."
+START=$(date +%s)
+while :; do
+  if tail -c 200000 "$HOME/.invoker/invoker.log" 2>/dev/null | grep -q 'owner-ipc-ready'; then
+    LATEST="$(tail -c 200000 "$HOME/.invoker/invoker.log" | grep 'owner-ipc-ready' | tail -1)"
+    if echo "$LATEST" | grep -q "$(date -u +%FT%H)"; then
+      echo "[auto-recover] owner-ipc-ready seen: $LATEST"
+      break
+    fi
+  fi
+  if (( $(date +%s) - START > 600 )); then
+    echo "[auto-recover] WARNING: owner-ipc-ready not seen within 600s; continuing anyway"
+    break
+  fi
+  sleep 5
+done
+
+LOOP_LOG="$LOG_DIR/loop-$(date +%Y%m%dT%H%M%SZ).log"
+echo "[auto-recover] launching retry loop -> $LOOP_LOG"
+nohup bash "$REPO_ROOT/scripts/retry-pending-autofix-failed.sh" --interval 60 > "$LOOP_LOG" 2>&1 &
+LOOP_PID=$!
+echo "[auto-recover] retry loop pid=$LOOP_PID"
+disown "$LOOP_PID" || true
+
+echo "[auto-recover] done. run.sh=$RUN_PID retry-loop=$LOOP_PID"

--- a/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
+++ b/scripts/e2e-dry-run/cases/case-2.16-retry-vs-recreate-five-second-window.sh
@@ -62,6 +62,7 @@ fi
 echo "==> case 2.16: retry-all --follow and observe first 5s"
 bash scripts/retry-failed-and-pending-all-workflows.sh --follow >/tmp/e2e-2.16-retry.log 2>&1 &
 RETRY_PID=$!
+RETRY_EXIT=0
 retry_fail_left_failed=0
 for i in 0 1 2 3 4 5; do
   KEEP_ST="$(invoker_e2e_task_status "$KEEP_TASK_ID" 2>/dev/null || true)"
@@ -78,12 +79,15 @@ for i in 0 1 2 3 4 5; do
   esac
   sleep 1
 done
-wait "$RETRY_PID"
+wait "$RETRY_PID" || RETRY_EXIT=$?
 
 if [ "$retry_fail_left_failed" -ne 1 ]; then
   echo "FAIL case 2.16: retry did not move failed task out of failed within 5s"
   invoker_e2e_run_headless status 2>&1 || true
   exit 1
+fi
+if [ "$RETRY_EXIT" -ne 0 ]; then
+  echo "case 2.16: retry-all exited $RETRY_EXIT after dispatching expected failing retry"
 fi
 
 echo "==> case 2.16: recreate-all --follow and observe first 5s"

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -385,7 +385,10 @@ PY
 # Usage: ST=$(invoker_e2e_task_status <taskId>)
 invoker_e2e_task_status() {
   local task_id="$1"
-  invoker_e2e_run_headless task-status "$task_id" 2>/dev/null | tail -1
+  invoker_e2e_run_headless task-status "$task_id" 2>/dev/null \
+    | sed 's/\x1b\[[0-9;]*m//g' \
+    | grep -E '^(pending|running|completed|failed|awaiting_approval|review_ready|fixing_with_ai|closed|skipped)$' \
+    | tail -1
 }
 
 # Poll until task status equals expected (1s interval). Use after cancel/restart

--- a/scripts/monitor-loop-status.sh
+++ b/scripts/monitor-loop-status.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Periodic snapshot of queue + workflow stats for the autofix loop.
+# Logs a single JSON line per snapshot to make tailing easy.
+#
+# Usage: bash scripts/monitor-loop-status.sh [interval_seconds]
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ELECTRON="$ROOT_DIR/scripts/electron.cjs"
+MAIN="$ROOT_DIR/packages/app/dist/main.js"
+
+INTERVAL="${1:-120}"
+
+snapshot() {
+  local now queue stats
+  now="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+  queue="$("$ELECTRON" "$MAIN" --headless query queue --output json 2>/dev/null || echo '{}')"
+  stats="$("$ELECTRON" "$MAIN" --headless query stats --output json 2>/dev/null || echo '{}')"
+
+  python3 - "$now" "$queue" "$stats" <<'PY'
+import json
+import sys
+
+now = sys.argv[1]
+queue = json.loads(sys.argv[2] or "{}")
+stats = json.loads(sys.argv[3] or "{}")
+
+running_count = queue.get("runningCount") if isinstance(queue, dict) else None
+running_list = queue.get("running") if isinstance(queue, dict) else None
+running_ids = [r.get("taskId") for r in running_list] if isinstance(running_list, list) else []
+
+snapshot = {
+    "time": now,
+    "runningCount": running_count,
+    "runningTasks": running_ids,
+    "workflowsTotal": stats.get("totalWorkflows"),
+    "workflowsCompleted": stats.get("completed"),
+    "workflowsFailed": stats.get("failed"),
+    "workflowsRunning": stats.get("running"),
+    "successRatePct": stats.get("successRate"),
+}
+print(json.dumps(snapshot))
+PY
+}
+
+echo "[monitor] starting interval=${INTERVAL}s pid=$$"
+while :; do
+  snapshot
+  sleep "$INTERVAL"
+done

--- a/scripts/repro/repro-daemon-autofix-persisted-intent.sh
+++ b/scripts/repro/repro-daemon-autofix-persisted-intent.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Repro: delegated no-track runs must persist auto-fix mutation intent.
+#
+# Root cause guarded here:
+#   In daemon/owner mode, a delegated no-track run could fail a task without the
+#   standalone owner enqueueing the persisted `invoker:fix-with-agent` workflow
+#   mutation intent. The failure event existed, but the auto-fix intent was not
+#   durable.
+#
+# Fixed behavior:
+#   The failing task records task.failed, debug.auto-fix schedule-enqueued, and
+#   a persisted invoker:fix-with-agent row in workflow_mutation_intents.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/app build
+exec scripts/e2e-dry-run/cases/case-2.17-autofix-persists-fix-intent.sh

--- a/scripts/repro/repro-daemon-clear-does-not-rehydrate.sh
+++ b/scripts/repro/repro-daemon-clear-does-not-rehydrate.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Repro: GUI clear in daemon-owner mode must purge durable workflow state.
+#
+# Root cause guarded here:
+#   `invoker:clear` used to reset only the in-memory DAG. With GUI daemon-owner
+#   reads, the next snapshot could rehydrate tasks from SQLite, so the UI still
+#   saw old tasks after clear.
+#
+# Fixed behavior:
+#   `window.invoker.clear()` leaves the task list empty in the renderer.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/ui build
+pnpm --filter @invoker/app build
+
+if command -v xvfb-run >/dev/null 2>&1; then
+  exec pnpm --filter @invoker/app exec xvfb-run --auto-servernum playwright test \
+    e2e/workflow-lifecycle.spec.ts \
+    -g 'clear resets task state via IPC'
+fi
+
+exec pnpm --filter @invoker/app exec playwright test \
+  e2e/workflow-lifecycle.spec.ts \
+  -g 'clear resets task state via IPC'

--- a/scripts/repro/repro-daemon-owner-routing.sh
+++ b/scripts/repro/repro-daemon-owner-routing.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: GUI/headless mutations must route through one standalone daemon owner.
+#
+# Root cause guarded here:
+#   A GUI process that opens the SQLite DB as the mutation owner can race with
+#   headless submitters and other GUI instances. In daemon-owner mode the GUI
+#   must become a read-only client and delegate write IPC to the shared owner.
+#
+# Fixed behavior:
+#   The owner bootstrap/thundering-herd e2e proves peer clients converge on one
+#   standalone-capable owner instead of stealing the IPC socket or DB writer.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+pnpm --filter @invoker/app build
+exec scripts/repro/repro-headless-thundering-herd.sh

--- a/scripts/repro/repro-daemon-task-new-attempt-reset.sh
+++ b/scripts/repro/repro-daemon-task-new-attempt-reset.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Repro: GUI client mode must delegate resume/read state to the daemon owner.
+#
+# Root cause guarded here:
+#   A stale pending launch attempt persisted in SQLite can leave the GUI client
+#   showing the old selectedAttemptId after explicit resume if resume/read state
+#   is handled by the read-only GUI snapshot instead of the daemon owner.
+#
+# Fixed behavior:
+#   Explicit resume supersedes the stale attempt, clears stale launch runtime
+#   fields, and the detached daemon owner exits cleanly before Playwright
+#   worker teardown.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+exec scripts/test-suites/required/19-task-new-attempt-reset-repro.sh

--- a/scripts/repro/repro-duplicate-ssh-attempt-capacity-leak.sh
+++ b/scripts/repro/repro-duplicate-ssh-attempt-capacity-leak.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_PATH="${INVOKER_DB_PATH:-$HOME/.invoker/invoker.db}"
+TASK_ID="${1:-wf-1778431095371-43/regression-inv-63}"
+
+if [ ! -f "$DB_PATH" ]; then
+  echo "FAIL: Invoker DB not found: $DB_PATH" >&2
+  exit 1
+fi
+
+python3 - "$DB_PATH" "$TASK_ID" <<'PY'
+import sqlite3
+import sys
+
+db_path, task_id = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+
+task = conn.execute(
+    """
+    SELECT id, status, selected_attempt_id, runner_kind, pool_member_id
+    FROM tasks
+    WHERE id = ?
+    """,
+    (task_id,),
+).fetchone()
+if task is None:
+    print(f"FAIL: task not found: {task_id}", file=sys.stderr)
+    sys.exit(1)
+
+leases = conn.execute(
+    """
+    SELECT resource_key, holder_id, task_id, pool_id, pool_member_id,
+           acquired_at, last_heartbeat_at, lease_expires_at
+    FROM execution_resource_leases
+    WHERE task_id = ?
+      AND resource_type = 'ssh'
+    ORDER BY pool_member_id, resource_key
+    """,
+    (task_id,),
+).fetchall()
+
+active_attempt = task["selected_attempt_id"]
+duplicate_attempt_leases = [
+    row for row in leases
+    if active_attempt and active_attempt in (row["holder_id"] or "")
+]
+members = {row["pool_member_id"] for row in duplicate_attempt_leases}
+
+print(f"task={task['id']}")
+print(f"status={task['status']}")
+print(f"selected_attempt_id={active_attempt}")
+print(f"task_pool_member_id={task['pool_member_id']}")
+print(f"ssh_leases_for_selected_attempt={len(duplicate_attempt_leases)}")
+for row in duplicate_attempt_leases:
+    print(
+        "lease "
+        f"member={row['pool_member_id']} "
+        f"resource={row['resource_key']} "
+        f"heartbeat={row['last_heartbeat_at']} "
+        f"expires={row['lease_expires_at']}"
+    )
+
+if task["status"] != "running":
+    print("FAIL: expected task to be running for this live capacity leak repro", file=sys.stderr)
+    sys.exit(1)
+if len(members) <= 1:
+    print(
+        "FAIL: duplicate SSH capacity leak is not present; expected the same selected attempt "
+        "to hold leases on more than one SSH member",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+if task["pool_member_id"] not in members:
+    print(
+        "FAIL: task row points at a member that is not among active selected-attempt leases",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+stale_members = sorted(member for member in members if member != task["pool_member_id"])
+print("PASS: duplicate selected-attempt SSH leases reproduce the capacity leak")
+print("stale_duplicate_members=" + ",".join(stale_members))
+PY

--- a/scripts/repro/repro-headless-owner-bootstrap-idle-timeout.sh
+++ b/scripts/repro/repro-headless-owner-bootstrap-idle-timeout.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "$ROOT_DIR/scripts/headless-lib.sh"
+
+TMP_ROOT="$(mktemp -d -t invoker-owner-idle-repro.XXXXXX)"
+OWNER_PID=""
+
+cleanup() {
+  if [[ -n "$OWNER_PID" ]]; then
+    local children
+    children="$(pgrep -P "$OWNER_PID" 2>/dev/null || true)"
+    if [[ -n "$children" ]]; then
+      # shellcheck disable=SC2086
+      kill $children 2>/dev/null || true
+    fi
+    kill "$OWNER_PID" 2>/dev/null || true
+  fi
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+wait_for_log() {
+  local file="$1"
+  local needle="$2"
+  local deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    if [[ -f "$file" ]] && grep -Fq "$needle" "$file"; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for '$needle' in $file" >&2
+  [[ -f "$file" ]] && tail -80 "$file" >&2
+  return 1
+}
+
+owner_ping() {
+  local socket_path="$1"
+  INVOKER_IPC_SOCKET="$socket_path" node --input-type=module <<'NODE'
+import { IpcBus } from './packages/transport/dist/index.js';
+const bus = new IpcBus(undefined, { allowServe: false, requestDeadlineMs: 500 });
+try {
+  await bus.ready();
+  const response = await bus.request('headless.owner-ping', {});
+  if (!response || response.ok !== true) {
+    throw new Error(`unexpected response: ${JSON.stringify(response)}`);
+  }
+  process.stdout.write(`${JSON.stringify(response)}\n`);
+} finally {
+  bus.disconnect();
+}
+NODE
+}
+
+start_owner() {
+  local db_dir="$1"
+  local socket_path="$2"
+  local idle_ms="$3"
+  local log_file="$4"
+  INVOKER_DB_DIR="$db_dir" \
+    INVOKER_IPC_SOCKET="$socket_path" \
+    INVOKER_REPO_CONFIG_PATH="$TMP_ROOT/config.json" \
+    INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS="$idle_ms" \
+    INVOKER_HEADLESS_STANDALONE=1 \
+    "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless owner-serve >"$log_file" 2>&1 &
+  OWNER_PID="$!"
+  wait_for_log "$log_file" "standalone owner ready"
+}
+
+cat > "$TMP_ROOT/config.json" <<'JSON'
+{
+  "allowGraphMutation": true,
+  "disableAutoRunOnStartup": true,
+  "launchOutboxMode": "active"
+}
+JSON
+
+SHORT_DB="$TMP_ROOT/short-db"
+SHORT_SOCKET="$TMP_ROOT/short.sock"
+SHORT_LOG="$TMP_ROOT/short-owner.log"
+mkdir -p "$SHORT_DB"
+start_owner "$SHORT_DB" "$SHORT_SOCKET" 50 "$SHORT_LOG"
+sleep 1
+if owner_ping "$SHORT_SOCKET" >"$TMP_ROOT/short-ping.out" 2>"$TMP_ROOT/short-ping.err"; then
+  echo "FAIL: short-idle owner still answered after idle expiry" >&2
+  cat "$TMP_ROOT/short-ping.out" >&2
+  exit 1
+fi
+cleanup
+trap cleanup EXIT
+OWNER_PID=""
+
+LONG_DB="$TMP_ROOT/long-db"
+LONG_SOCKET="$TMP_ROOT/long.sock"
+LONG_LOG="$TMP_ROOT/long-owner.log"
+mkdir -p "$LONG_DB"
+start_owner "$LONG_DB" "$LONG_SOCKET" 60000 "$LONG_LOG"
+if ! owner_ping "$LONG_SOCKET" >"$TMP_ROOT/long-ping.out" 2>"$TMP_ROOT/long-ping.err"; then
+  echo "FAIL: long-idle owner did not answer owner-ping" >&2
+  cat "$TMP_ROOT/long-ping.err" >&2
+  exit 1
+fi
+
+echo "PASS: short owner idle timeout drops owner-ping; long timeout keeps bootstrap owner discoverable"

--- a/scripts/repro/repro-implement-autofix-worker-merge-conflict.sh
+++ b/scripts/repro/repro-implement-autofix-worker-merge-conflict.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TASK_ID="${TASK_ID:-wf-1780400659189-5/implement-autofix-worker}"
+DB_PATH="${INVOKER_DB_PATH:-${HOME:-}/.invoker/invoker.db}"
+
+if [ ! -f "$DB_PATH" ]; then
+  echo "missing Invoker DB: $DB_PATH" >&2
+  exit 2
+fi
+
+read_task_field() {
+  local field="$1"
+  sqlite3 "$DB_PATH" "SELECT $field FROM tasks WHERE id = '$TASK_ID';"
+}
+
+WORKTREE_PATH="${WORKTREE_PATH:-$(read_task_field workspace_path)}"
+OURS_BRANCH="${OURS_BRANCH:-$(read_task_field branch)}"
+THEIRS_BRANCH="${THEIRS_BRANCH:-$(sqlite3 "$DB_PATH" "SELECT json_extract(error, '$.failedBranch') FROM tasks WHERE id = '$TASK_ID';")}"
+CONFLICT_FILE="${CONFLICT_FILE:-packages/app/src/headless.ts}"
+
+if [ -z "$WORKTREE_PATH" ] || [ ! -e "$WORKTREE_PATH/.git" ]; then
+  echo "missing task worktree for $TASK_ID: $WORKTREE_PATH" >&2
+  exit 2
+fi
+
+resolve_ref() {
+  local ref="$1"
+  if git -C "$WORKTREE_PATH" rev-parse --verify --quiet "$ref^{commit}" >/dev/null; then
+    printf '%s\n' "$ref"
+    return 0
+  fi
+  if git -C "$WORKTREE_PATH" rev-parse --verify --quiet "origin/$ref^{commit}" >/dev/null; then
+    printf '%s\n' "origin/$ref"
+    return 0
+  fi
+  echo "missing git ref: $ref" >&2
+  return 1
+}
+
+OURS_REF="$(resolve_ref "$OURS_BRANCH")"
+THEIRS_REF="$(resolve_ref "$THEIRS_BRANCH")"
+BASE_REF="$(git -C "$WORKTREE_PATH" merge-base "$OURS_REF" "$THEIRS_REF")"
+MERGE_TREE_OUTPUT="$(git -C "$WORKTREE_PATH" merge-tree "$BASE_REF" "$OURS_REF" "$THEIRS_REF")"
+
+if printf '%s\n' "$MERGE_TREE_OUTPUT" | grep -Fq "$CONFLICT_FILE" \
+  && printf '%s\n' "$MERGE_TREE_OUTPUT" | grep -Fq '<<<<<<<'; then
+  echo "PASS: merge conflict reproduced for $TASK_ID"
+  echo "ours=$OURS_REF"
+  echo "theirs=$THEIRS_REF"
+  echo "base=$BASE_REF"
+  printf '%s\n' "$MERGE_TREE_OUTPUT" | grep -n -E "changed in both|<<<<<<<|=======|>>>>>>>|$CONFLICT_FILE" | head -40
+  exit 0
+fi
+
+echo "FAIL: expected merge conflict was not reproduced for $TASK_ID" >&2
+echo "ours=$OURS_REF" >&2
+echo "theirs=$THEIRS_REF" >&2
+echo "base=$BASE_REF" >&2
+exit 1

--- a/scripts/repro/repro-launch-claim-orphan.sh
+++ b/scripts/repro/repro-launch-claim-orphan.sh
@@ -14,9 +14,9 @@ set -euo pipefail
 # invariant is:
 #
 #   Every `task.launch_claimed` event must be followed within
-#   `2 * DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS` (180 seconds with
-#   the defaults from packages/contracts) by a terminal launch event for
-#   the same `attempt_id`. Terminal launch events are:
+#   `DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30s` (2190 seconds with
+#   the defaults from packages/contracts) by a terminal launch event for the
+#   same `attempt_id`. Terminal launch events are:
 #
 #     - task.executor.selected
 #     - task.executor.deferred
@@ -31,9 +31,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 EXPECTATION=""
 TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-900}"
-# DISPATCH_LEASE_MS = 30000, DISPATCH_MAX_ATTEMPTS = 3 → 180 seconds.
+# DISPATCH_LEASE_MS = 720000, DISPATCH_MAX_ATTEMPTS = 3, buffer = 30s → 2190 seconds.
 # Override via env if the contracts module bumps these defaults.
-WAIT_BOUND_SECONDS="${REPRO_LAUNCH_INVARIANT_BOUND_SECONDS:-180}"
+WAIT_BOUND_SECONDS="${REPRO_LAUNCH_INVARIANT_BOUND_SECONDS:-2190}"
 
 usage() {
   cat <<'EOF'
@@ -45,7 +45,7 @@ What it proves:
   Every `task.launch_claimed` event recorded during a storm of
   workflow-scope rebase-recreate mutations is paired with a terminal
   launch event for the SAME attempt_id within the dispatch invariant
-  bound (default 2 * DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS = 180s).
+  bound (default DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30s = 2190s).
 
   Any claim without a matching terminal event is an orphaned launch —
   the exact failure mode the launch-handoff re-architecture was built
@@ -53,7 +53,7 @@ What it proves:
 
 Environment:
   REPRO_TIMEOUT_SECONDS                 storm timeout (default 900)
-  REPRO_LAUNCH_INVARIANT_BOUND_SECONDS  invariant bound (default 180)
+  REPRO_LAUNCH_INVARIANT_BOUND_SECONDS  invariant bound (default 2190)
   INVOKER_DB_PATH / INVOKER_DB_DIR      same as other repro scripts
 EOF
 }

--- a/scripts/repro/repro-local-stale-attempt-process-leak.sh
+++ b/scripts/repro/repro-local-stale-attempt-process-leak.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_PATH="${INVOKER_DB_PATH:-$HOME/.invoker/invoker.db}"
+TASK_ID="${1:-wf-1780385813241-5/capture-after-visual-proof}"
+
+python3 - "$DB_PATH" "$TASK_ID" <<'PY'
+import sqlite3
+import subprocess
+import sys
+
+db_path, task_id = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+task = conn.execute(
+    "SELECT id, status, selected_attempt_id FROM tasks WHERE id = ?",
+    (task_id,),
+).fetchone()
+if task is None:
+    print(f"FAIL: task not found: {task_id}", file=sys.stderr)
+    sys.exit(1)
+
+selected_attempt = task["selected_attempt_id"] or ""
+slug = task_id.replace("/", "-")
+matches = []
+ps_output = subprocess.check_output(["ps", "-axo", "pid=,command="], text=True, errors="replace")
+for line in ps_output.splitlines():
+    stripped = line.strip()
+    if not stripped:
+        continue
+    pid, _, cmd = stripped.partition(" ")
+    if slug not in cmd and task_id not in cmd:
+        continue
+    matches.append((pid, cmd[:1000]))
+
+print(f"task={task['id']}")
+print(f"status={task['status']}")
+print(f"selected_attempt_id={selected_attempt}")
+print(f"matching_processes={len(matches)}")
+for pid, cmd in matches[:80]:
+    print(f"process pid={pid} selectedAttemptInCmd={selected_attempt in cmd} cmd={cmd}")
+
+if task["status"] != "running":
+    print("FAIL: expected task to be running for this live local process leak repro", file=sys.stderr)
+    sys.exit(1)
+if not matches:
+    print("FAIL: no local processes found for running task", file=sys.stderr)
+    sys.exit(1)
+if selected_attempt and any(selected_attempt in cmd for _, cmd in matches):
+    print("FAIL: live processes match selected attempt; stale-attempt leak is not present", file=sys.stderr)
+    sys.exit(1)
+
+print("PASS: running task has local processes from a stale/non-selected attempt")
+PY

--- a/scripts/repro/repro-noisy-headless-task-status-parser.sh
+++ b/scripts/repro/repro-noisy-headless-task-status-parser.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Repro: dry-run task status parsing must ignore Electron/ANSI noise.
+#
+# Root cause guarded here:
+#   Some CI/headless runs print Electron warnings or ANSI-decorated log lines
+#   around the actual task status. The old parser used `tail -1`, so a trailing
+#   warning could be mistaken for the status.
+#
+# Fixed behavior:
+#   `invoker_e2e_task_status` strips ANSI sequences and returns the last valid
+#   task status token only.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+source scripts/e2e-dry-run/lib/common.sh
+
+invoker_e2e_run_headless() {
+  local _task_status_command="$1"
+  local _task_id="$2"
+  printf '\033[33m(node:123) Electron warning before status\033[0m\n'
+  printf 'running\n'
+  printf '\033[32mcompleted\033[0m\n'
+  printf '(node:123) trailing deprecation warning\n'
+}
+
+status="$(invoker_e2e_task_status wf-test/noisy-task)"
+if [[ "$status" != "completed" ]]; then
+  echo "FAIL noisy status parser: expected completed, got: ${status:-<empty>}" >&2
+  exit 1
+fi
+
+echo "PASS noisy status parser returned completed"

--- a/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1778826126740-7.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-__merge__wf-1778826126740-7.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] __merge__wf-1778826126740-7 was left running after launch metadata because a no-track active-outbox retry could consume a dispatch with a transient headless TaskRunner."
+echo "[repro] This focused test forces that path: active launch outbox, no owner TaskRunner, no deferred owner launch."
+echo "[repro] Before the fix, runHeadless could mark the merge task launched and then let the headless process exit; after the fix it refuses that unsafe launch ownership with a diagnostic."
+
+pnpm --filter @invoker/app exec vitest run src/__tests__/headless-delegation.test.ts \
+  -t "headless (workflow|task) retry in no-track active outbox mode waits for owner launch handoff before returning|headless task retry in no-track active outbox mode rejects transient launch ownership"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1778431095371-43-regression-inv-63.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1778431095371-43-regression-inv-63.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-pending-pool-deferral-repro.XXXXXX.log")"
+state_file="$(mktemp "${TMPDIR:-/tmp}/invoker-pending-pool-deferral-state.XXXXXX.tsv")"
+trap 'rm -f "$log_file" "$state_file"' EXIT
+
+echo "[repro] wf-1778431095371-43/regression-inv-63 was pending because pnpm-ssh launch attempts were repeatedly deferred by SSH resource leases / pool capacity."
+echo "[repro] After each deferral, deferTask clears launch timestamps and leaves the task pending in the queue."
+echo "[repro] Before the fix, retry-pending-autofix-failed treated that queue-active no-timestamp shape as stale and launched Codex investigation."
+echo "[repro] After the fix, the retry loop treats that shape as an active blocker and waits for capacity instead."
+
+python3 <<'PY'
+import json
+
+task = {
+    "id": "wf-1778431095371-43/regression-inv-63",
+    "createdAt": "2026-06-03T18:00:00.000Z",
+    "status": "pending",
+    "config": {"poolId": "pnpm-ssh", "runnerKind": "worktree"},
+    "execution": {},
+}
+queue = {
+    "queued": [{"taskId": "wf-1778431095371-43/regression-inv-63"}],
+    "running": [],
+    "runningCount": 0,
+}
+audit = [
+    {
+        "eventType": "task.executor.deferred",
+        "payload": json.dumps({"reason": "ssh-resource-lease-held", "poolId": "pnpm-ssh"}),
+    },
+    {
+        "eventType": "task.executor.deferred",
+        "payload": json.dumps({"reason": "execution-pool-capacity", "poolId": "pnpm-ssh"}),
+    },
+    {
+        "eventType": "task.deferred",
+        "payload": json.dumps({"status": "pending", "execution": {}}),
+    },
+]
+
+task_id = task["id"]
+queued_ids = {row.get("taskId") for row in queue["queued"]}
+defer_reasons = {
+    json.loads(row["payload"]).get("reason")
+    for row in audit
+    if row["eventType"] == "task.executor.deferred"
+}
+assert task["status"] == "pending"
+assert not task["execution"].get("launchStartedAt")
+assert task_id in queued_ids
+assert task["config"]["poolId"] == "pnpm-ssh"
+assert {"ssh-resource-lease-held", "execution-pool-capacity"} <= defer_reasons
+
+# Pre-fix retry loop logic treated old queued tasks with no launch metadata as
+# stale, so it selected this capacity-deferred task for local Codex
+# investigation. The fixed classifier first honors the active queue state and
+# only considers launch/heartbeat timestamps for queue-active staleness.
+old_classifier_would_investigate = (
+    task["status"] == "pending"
+    and not task["execution"].get("launchStartedAt")
+    and bool(task.get("createdAt"))
+)
+fixed_classifier_blocks = (
+    task["status"] == "pending"
+    and task_id in queued_ids
+    and not task["execution"].get("launchStartedAt")
+)
+assert old_classifier_would_investigate
+assert fixed_classifier_blocks
+print("[repro] diagnostic fixture asserts queued pending task plus pnpm-ssh lease/capacity deferrals")
+print("[repro] pre-fix classifier would investigate; fixed classifier blocks on active queue")
+PY
+
+INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE="$state_file" \
+  scripts/retry-pending-autofix-failed.sh --self-test | tee "$log_file"
+
+grep -Fq "self-test: queue-active pending task after pool deferral is treated as blocker" "$log_file"
+grep -Fq "self-test: all passed" "$log_file"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1780292402489-6-final-regression-test-all.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1780292402489-6-final-regression-test-all.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+DB_PATH="${INVOKER_DB_PATH:-${HOME:-.}/.invoker/invoker.db}"
+TASK_ID="wf-1780292402489-6/final-regression-test-all"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: --no-track active-outbox retry could return before owner launch handoff"
+echo "[repro] effect: retry loop could cancel/replace a launch repeatedly, then leave ready pending work with no launch progress"
+
+python3 - "$ROOT" "$DB_PATH" "$TASK_ID" <<'PY'
+import json
+import pathlib
+import sqlite3
+import sys
+
+root = pathlib.Path(sys.argv[1])
+db_path = pathlib.Path(sys.argv[2]).expanduser()
+task_id = sys.argv[3]
+
+headless = (root / "packages/app/src/headless.ts").read_text(encoding="utf-8")
+main = (root / "packages/app/src/main.ts").read_text(encoding="utf-8")
+
+fn_start = headless.index("async function dispatchNoTrackRunnableTasks")
+fn_end = headless.index("export function wireHeadlessAutoFix", fn_start)
+fn_body = headless[fn_start:fn_end]
+
+active_idx = fn_body.index("if (deps.invokerConfig.launchOutboxMode === 'active')")
+defer_idx = fn_body.index("if (deps.deferRunnableTasks)")
+
+def before_fix(active_outbox: bool, has_defer_runnable_tasks: bool, has_owner_runner: bool):
+    if has_defer_runnable_tasks:
+        return {
+            "returned": True,
+            "owner_execute_task": False,
+            "live_dispatch_after_return": True,
+            "reason": "deferRunnableTasks short-circuited active outbox handoff",
+        }
+    if active_outbox and has_owner_runner:
+        return {
+            "returned": False,
+            "owner_execute_task": True,
+            "live_dispatch_after_return": True,
+            "reason": "waiting for owner handoff",
+        }
+    return {"returned": True, "owner_execute_task": False, "live_dispatch_after_return": False}
+
+pre = before_fix(active_outbox=True, has_defer_runnable_tasks=True, has_owner_runner=True)
+assert pre["returned"] is True
+assert pre["owner_execute_task"] is False
+assert pre["live_dispatch_after_return"] is True
+
+assert active_idx < defer_idx, (
+    "active launch-outbox handling must run before deferRunnableTasks; otherwise no-track retry "
+    "can return before owner launch handoff"
+)
+assert "ownerTaskRunnerProvider: () => requireTaskExecutor()" in main, (
+    "main process must pass the owner TaskRunner to headless active-outbox no-track dispatch"
+)
+
+print("[repro] pre-fix model: deferRunnableTasks returned immediately with a live dispatch row")
+print("[repro] fixed source: active outbox handoff is checked before deferRunnableTasks")
+print("[repro] fixed source: main wires ownerTaskRunnerProvider to the owner TaskRunner")
+
+embedded_events = [
+    ("task.launch_claimed", {"attempt": "a232fbc9d", "generation": 71}),
+    ("task.launch_dispatch_invalidated", {"reason": "workflow cancellation", "attempt": "a232fbc9d"}),
+    ("task.pending", {"generation": 72}),
+    ("task.launch_claimed", {"attempt": "a01181ff9", "generation": 72}),
+    ("task.executor.deferred", {"reason": "ssh-resource-lease-held", "poolMemberId": "remote_digital_ocean_4"}),
+    ("task.executor.deferred", {"reason": "execution-pool-capacity", "poolId": "pnpm-ssh"}),
+    ("task.launch_dispatch_invalidated", {"reason": "task deferred", "attempt": "a01181ff9"}),
+    ("task.deferred", {"status": "pending"}),
+]
+event_types = [event_type for event_type, _ in embedded_events]
+defer_reasons = {
+    payload.get("reason")
+    for event_type, payload in embedded_events
+    if event_type == "task.executor.deferred"
+}
+invalidate_reasons = {
+    payload.get("reason")
+    for event_type, payload in embedded_events
+    if event_type == "task.launch_dispatch_invalidated"
+}
+assert "workflow cancellation" in invalidate_reasons
+assert "task deferred" in invalidate_reasons
+assert {"ssh-resource-lease-held", "execution-pool-capacity"} <= defer_reasons
+assert event_types[-1] == "task.deferred"
+print("[repro] embedded audit: repeated launch cancellation followed by SSH capacity deferral is reproduced")
+
+if not db_path.exists():
+    print(f"[repro] local DB not found, skipped live diagnostic: {db_path}")
+    sys.exit(0)
+
+conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+conn.row_factory = sqlite3.Row
+try:
+    task = conn.execute(
+        """
+        SELECT id, status, runner_kind, pool_id, pool_member_id, selected_attempt_id,
+               launch_phase, launch_started_at, launch_completed_at, started_at, last_heartbeat_at
+          FROM tasks
+         WHERE id = ?
+        """,
+        (task_id,),
+    ).fetchone()
+    if task is None:
+        print("[repro] local DB diagnostic: target task is no longer present")
+        sys.exit(0)
+
+    active_dispatches = conn.execute(
+        """
+        SELECT id, state, attempt_id, generation, last_error
+          FROM task_launch_dispatch
+         WHERE task_id = ?
+           AND state IN ('enqueued', 'leased')
+         ORDER BY id
+        """,
+        (task_id,),
+    ).fetchall()
+    latest_dispatch = conn.execute(
+        """
+        SELECT id, state, attempt_id, generation, last_error
+          FROM task_launch_dispatch
+         WHERE task_id = ?
+         ORDER BY id DESC
+         LIMIT 1
+        """,
+        (task_id,),
+    ).fetchone()
+    recent_events = conn.execute(
+        """
+        SELECT event_type, payload
+          FROM events
+         WHERE task_id = ?
+         ORDER BY id DESC
+         LIMIT 20
+        """,
+        (task_id,),
+    ).fetchall()
+
+    parsed_events = []
+    for row in reversed(recent_events):
+        payload = row["payload"]
+        try:
+            payload = json.loads(payload) if payload else {}
+        except json.JSONDecodeError:
+            payload = {}
+        parsed_events.append((row["event_type"], payload))
+
+    live_defer_reasons = {
+        payload.get("reason")
+        for event_type, payload in parsed_events
+        if event_type == "task.executor.deferred"
+    }
+    live_invalidations = {
+        payload.get("reason")
+        for event_type, payload in parsed_events
+        if event_type == "task.launch_dispatch_invalidated"
+    }
+
+    print("[repro] local DB task:", json.dumps(dict(task), sort_keys=True))
+    print("[repro] local DB active_dispatch_count:", len(active_dispatches))
+    if latest_dispatch:
+        print("[repro] local DB latest_dispatch:", json.dumps(dict(latest_dispatch), sort_keys=True))
+    print("[repro] local DB recent_defer_reasons:", ",".join(sorted(reason for reason in live_defer_reasons if reason)))
+    print("[repro] local DB recent_invalidation_reasons:", ",".join(sorted(reason for reason in live_invalidations if reason)))
+
+    if task["status"] == "pending":
+        assert task["launch_phase"] is None
+        assert task["launch_started_at"] is None
+        assert task["launch_completed_at"] is None
+        assert len(active_dispatches) == 0
+        assert "task deferred" in live_invalidations or latest_dispatch and latest_dispatch["last_error"] == "task deferred"
+        print("[repro] local DB diagnostic: pending task has no active launch dispatch after deferral")
+finally:
+    conn.close()
+PY
+
+echo "[repro] passed"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1780385813241-5-capture-after-visual-proof.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1780385813241-5-capture-after-visual-proof.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] wf-1780385813241-5/capture-after-visual-proof was reaped while executor.start was still launching."
+echo "[repro] The attempt heartbeat stayed fresh, but the old 30s launch-dispatch lease expired and was recycled."
+echo "[repro] The first test proves the fixed dispatch TTL survives normal executor startup and still reaps after expiry."
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/launch-dispatcher.test.ts \
+  -t "uses a fixed dispatch TTL long enough for normal executor startup"
+
+echo "[repro] The second test proves TaskRunner records where launch startup reached."
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-launch-dispatch.test.ts \
+  -t "logs executor start begin with launch-dispatch context while executor.start is pending"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1780386838237-8-run-full-regression.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1780386838237-8-run-full-regression.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+log_file="$(mktemp "${TMPDIR:-/tmp}/invoker-wf-1780386838237-8-run-full-regression.XXXXXX.log")"
+state_file="$(mktemp "${TMPDIR:-/tmp}/invoker-wf-1780386838237-8-run-full-regression-state.XXXXXX.tsv")"
+trap 'rm -f "$log_file" "$state_file"' EXIT
+
+echo "[repro] wf-1780386838237-8/run-full-regression dependencies were complete and the task was queued."
+echo "[repro] Launch attempts were repeatedly deferred by pnpm-ssh resource leases / pool capacity before executor selection."
+echo "[repro] The diagnostic condition is a stale SSH execution-resource lease from an older cancelled attempt consuming a pool member."
+
+python3 <<'PY'
+import sqlite3
+
+TASK_ID = "wf-1780386838237-8/run-full-regression"
+OLD_ATTEMPT = "wf-1780386838237-8/run-full-regression-a84a0aaa8"
+NEW_ATTEMPT = "wf-1780386838237-8/run-full-regression-ab7333ae8"
+
+task = {
+    "id": TASK_ID,
+    "status": "pending",
+    "config": {"workflowId": "wf-1780386838237-8", "runnerKind": "ssh", "poolId": "pnpm-ssh"},
+    "execution": {"lastHeartbeatAt": "2026-06-04T23:04:46.711Z"},
+}
+queue = {
+    "maxConcurrency": 12,
+    "runningCount": 2,
+    "queued": [{"taskId": TASK_ID}],
+    "running": [
+        {"taskId": "wf-1780385813241-5/capture-after-visual-proof"},
+        {"taskId": "wf-1778825464672-5/final-regression-ui-bundle-splitting"},
+    ],
+}
+audit_reasons = {
+    "ssh-resource-lease-held",
+    "execution-pool-capacity",
+}
+
+assert task["status"] == "pending"
+assert TASK_ID in {row["taskId"] for row in queue["queued"]}
+assert {"ssh-resource-lease-held", "execution-pool-capacity"} <= audit_reasons
+
+conn = sqlite3.connect(":memory:")
+conn.execute(
+    """
+    CREATE TABLE execution_resource_leases (
+      resource_key TEXT,
+      resource_type TEXT,
+      holder_id TEXT,
+      task_id TEXT,
+      pool_id TEXT,
+      pool_member_id TEXT,
+      lease_expires_at TEXT,
+      PRIMARY KEY(resource_key, holder_id)
+    )
+    """
+)
+
+def holder(attempt):
+    return f"a39a9582-9db7-460f-b04a-110aefd04e55:81568:{TASK_ID}:{attempt}"
+
+conn.execute(
+    """
+    INSERT INTO execution_resource_leases
+      (resource_key, resource_type, holder_id, task_id, pool_id, pool_member_id, lease_expires_at)
+    VALUES (?, 'ssh', ?, ?, 'pnpm-ssh', 'remote_digital_ocean_4', '2099-01-01T00:20:00Z')
+    """,
+    ("ssh:invoker@138.68.230.225:22", holder(OLD_ATTEMPT), TASK_ID),
+)
+
+def claim_resource(resource_key, holder_id):
+    active = conn.execute(
+        """
+        SELECT holder_id
+          FROM execution_resource_leases
+         WHERE resource_key = ?
+           AND holder_id != ?
+           AND lease_expires_at > '2026-06-04T23:04:17.000Z'
+         LIMIT 1
+        """,
+        (resource_key, holder_id),
+    ).fetchone()
+    if active:
+        return False
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO execution_resource_leases
+          (resource_key, resource_type, holder_id, task_id, pool_id, pool_member_id, lease_expires_at)
+        VALUES (?, 'ssh', ?, ?, 'pnpm-ssh', 'remote_digital_ocean_4', '2099-01-01T00:20:00Z')
+        """,
+        (resource_key, holder_id, TASK_ID),
+    )
+    return True
+
+resource_key = "ssh:invoker@138.68.230.225:22"
+new_holder = holder(NEW_ATTEMPT)
+pre_fix_launch_blocked = not claim_resource(resource_key, new_holder)
+assert pre_fix_launch_blocked
+
+released = conn.execute(
+    """
+    DELETE FROM execution_resource_leases
+     WHERE task_id = ?
+       AND holder_id != ?
+    """,
+    (TASK_ID, new_holder),
+).rowcount
+assert released == 1
+post_fix_launch_can_claim = claim_resource(resource_key, new_holder)
+assert post_fix_launch_can_claim
+
+print("[repro] pre-fix: stale old-attempt SSH lease blocks the new launch claim")
+print("[repro] post-fix: releasing orphan/stale task leases lets the new attempt claim the pool member")
+print("[repro] queued pending task with no launch metadata is capacity-blocked work, not a code-generation failure")
+PY
+
+INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE="$state_file" \
+  scripts/retry-pending-autofix-failed.sh --self-test | tee "$log_file"
+
+grep -Fq "self-test: active SSH lease for pending task is released" "$log_file"
+grep -Fq "self-test: active SSH lease for old attempt on running task is released" "$log_file"
+grep -Fq "self-test: queue-active pending task after pool deferral is treated as blocker" "$log_file"
+grep -Fq "self-test: all passed" "$log_file"
+
+echo "[repro] passed"

--- a/scripts/repro/repro-ready-pending-without-launch-dispatch.sh
+++ b/scripts/repro/repro-ready-pending-without-launch-dispatch.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+OUT_FILE="$(mktemp -t invoker-ready-pending-without-dispatch.XXXXXX.log)"
+trap 'rm -f "$OUT_FILE"' EXIT
+
+bash "$ROOT_DIR/scripts/retry-pending-autofix-failed.sh" --self-test > "$OUT_FILE" 2>&1
+
+grep -Fq "self-test: ready pending task without launch dispatch resets retry state" "$OUT_FILE"
+grep -Fq "self-test: all passed" "$OUT_FILE"
+
+echo "PASS: ready pending tasks without launch dispatch reset retry state and submit targeted retry-task recovery"

--- a/scripts/repro/repro-retry-loop-managed-owner-survives-launcher-exit.sh
+++ b/scripts/repro/repro-retry-loop-managed-owner-survives-launcher-exit.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# shellcheck source=scripts/headless-lib.sh
+source "$ROOT_DIR/scripts/headless-lib.sh"
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-managed-owner-survives.XXXXXX")"
+owner_pid_file="$tmpdir/owner.pid"
+owner_log="$tmpdir/owner.log"
+db_dir="$tmpdir/db"
+socket_path="$tmpdir/ipc.sock"
+config_path="$tmpdir/config.json"
+
+cleanup() {
+  if [ -s "$owner_pid_file" ]; then
+    kill "$(cat "$owner_pid_file")" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$tmpdir"
+}
+trap cleanup EXIT
+
+cat > "$config_path" <<'JSON'
+{
+  "allowGraphMutation": true,
+  "disableAutoRunOnStartup": true,
+  "launchOutboxMode": "active"
+}
+JSON
+mkdir -p "$db_dir"
+
+wait_for_log() {
+  local deadline=$((SECONDS + 30))
+  while (( SECONDS < deadline )); do
+    if [ -f "$owner_log" ] && grep -Fq "standalone owner ready" "$owner_log"; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  echo "timed out waiting for standalone owner readiness" >&2
+  [ -f "$owner_log" ] && tail -80 "$owner_log" >&2
+  return 1
+}
+
+owner_ping() {
+  INVOKER_IPC_SOCKET="$socket_path" node --input-type=module <<'NODE'
+import { IpcBus } from './packages/transport/dist/index.js';
+const bus = new IpcBus(undefined, { allowServe: false, requestDeadlineMs: 1000 });
+try {
+  await bus.ready();
+  const response = await bus.request('headless.owner-ping', {});
+  if (!response || response.ok !== true) {
+    throw new Error(`unexpected response: ${JSON.stringify(response)}`);
+  }
+} finally {
+  bus.disconnect();
+}
+NODE
+}
+
+(
+  cd "$ROOT_DIR"
+  env \
+    INVOKER_DB_DIR="$db_dir" \
+    INVOKER_IPC_SOCKET="$socket_path" \
+    INVOKER_REPO_CONFIG_PATH="$config_path" \
+    INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS=60000 \
+    INVOKER_HEADLESS_STANDALONE=1 \
+    nohup "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless owner-serve > "$owner_log" 2>&1 &
+  printf '%s\n' "$!" > "$owner_pid_file"
+)
+
+wait_for_log
+sleep 1
+
+if ! kill -0 "$(cat "$owner_pid_file")" >/dev/null 2>&1; then
+  echo "managed owner exited after launcher shell returned" >&2
+  tail -80 "$owner_log" >&2 || true
+  exit 1
+fi
+
+if ! owner_ping; then
+  echo "managed owner did not answer owner-ping after launcher shell returned" >&2
+  tail -80 "$owner_log" >&2 || true
+  exit 1
+fi
+
+cat <<EOF
+PASS: retry-loop managed owner survives launcher shell exit.
+
+owner_pid=$(cat "$owner_pid_file")
+db_dir=$db_dir
+socket_path=$socket_path
+
+Root cause guarded: a retry-loop helper that backgrounds owner-serve must detach
+it from the helper shell, otherwise submitted launch-dispatch rows can be left
+without a live dispatcher after the helper exits.
+EOF

--- a/scripts/repro/repro-retry-workflow-stale-ssh-pool-member.sh
+++ b/scripts/repro/repro-retry-workflow-stale-ssh-pool-member.sh
@@ -1,0 +1,125 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DB_PATH="${INVOKER_DB_PATH:-$HOME/.invoker/invoker.db}"
+MODE="expect-bug"
+
+case "${1:-}" in
+  --expect-fixed)
+    MODE="expect-fixed"
+    shift
+    ;;
+  "" )
+    ;;
+  * )
+    echo "usage: $0 [--expect-fixed]" >&2
+    exit 2
+    ;;
+esac
+
+if [ ! -f "$DB_PATH" ]; then
+  echo "missing Invoker DB: $DB_PATH" >&2
+  exit 2
+fi
+
+python3 - "$DB_PATH" "$MODE" <<'PY'
+import json
+import sqlite3
+import sys
+
+db_path, mode = sys.argv[1], sys.argv[2]
+conn = sqlite3.connect(db_path)
+conn.row_factory = sqlite3.Row
+
+rows = conn.execute(
+    """
+    SELECT
+      id,
+      workflow_id,
+      status,
+      runner_kind,
+      pool_id,
+      pool_member_id,
+      workspace_path,
+      branch,
+      launch_phase,
+      launch_started_at,
+      started_at,
+      last_heartbeat_at,
+      selected_attempt_id
+    FROM tasks
+    WHERE status = 'pending'
+      AND runner_kind = 'ssh'
+      AND pool_id IS NOT NULL
+      AND pool_member_id IS NOT NULL
+      AND (workspace_path IS NOT NULL OR branch IS NOT NULL)
+      AND launch_phase IS NULL
+      AND launch_started_at IS NULL
+    ORDER BY last_heartbeat_at DESC, id
+    """
+).fetchall()
+
+def latest_events(task_id):
+    events = conn.execute(
+        """
+        SELECT event_type, payload, created_at
+        FROM events
+        WHERE task_id = ?
+          AND event_type IN (
+            'task.executor.selected',
+            'task.executor.deferred',
+            'task.pending',
+            'task.launch_dispatch_invalidated',
+            'task.execution_resource_lease_released'
+          )
+        ORDER BY id DESC
+        LIMIT 12
+        """,
+        (task_id,),
+    ).fetchall()
+    result = []
+    for event in reversed(events):
+        payload = event["payload"]
+        try:
+            payload = json.loads(payload) if payload else None
+        except json.JSONDecodeError:
+            pass
+        result.append({
+            "created_at": event["created_at"],
+            "event_type": event["event_type"],
+            "payload": payload,
+        })
+    return result
+
+print(f"mode={mode}")
+print(f"matching_stale_ssh_pins={len(rows)}")
+
+for row in rows[:10]:
+    data = dict(row)
+    print(json.dumps(data, sort_keys=True))
+    selected = any(event["event_type"] == "task.executor.selected" for event in latest_events(row["id"]))
+    pending = any(event["event_type"] == "task.pending" for event in latest_events(row["id"]))
+    deferred = any(event["event_type"] == "task.executor.deferred" for event in latest_events(row["id"]))
+    print(
+        "audit_flags "
+        f"task={row['id']} "
+        f"selected={str(selected).lower()} "
+        f"pending_reset={str(pending).lower()} "
+        f"deferred={str(deferred).lower()}"
+    )
+    for event in latest_events(row["id"])[-5:]:
+        print(json.dumps(event, sort_keys=True))
+
+if mode == "expect-fixed":
+    if rows:
+        print("FAIL: pending pool-routed SSH tasks still have stale explicit poolMemberId pins")
+        sys.exit(1)
+    print("PASS: no pending pool-routed SSH tasks retain stale explicit poolMemberId pins")
+    sys.exit(0)
+
+if not rows:
+    print("FAIL: no stale SSH pool member pin found to demonstrate the retry deferral root cause")
+    sys.exit(1)
+
+print("PASS: stale explicit SSH poolMemberId pins are present on pending retry work")
+PY

--- a/scripts/repro/repro-ssh-ref-lock-storage-pressure.sh
+++ b/scripts/repro/repro-ssh-ref-lock-storage-pressure.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT="${TMPDIR:-/tmp}/invoker-repro-ssh-ref-lock-storage-pressure.$$"
+REPO="$TMP_ROOT/repo"
+
+cleanup() {
+  chmod -R u+w "$TMP_ROOT" 2>/dev/null || true
+  rm -rf "$TMP_ROOT"
+}
+trap cleanup EXIT
+
+mkdir -p "$REPO"
+git init -q "$REPO"
+git -C "$REPO" config user.name "Invoker Repro"
+git -C "$REPO" config user.email "repro@example.com"
+printf 'base\n' > "$REPO/file.txt"
+git -C "$REPO" add file.txt
+git -C "$REPO" commit -q -m "base"
+
+mkdir -p "$REPO/.git/refs/heads/experiment"
+chmod u-w "$REPO/.git/refs/heads/experiment"
+
+set +e
+output="$(
+  git -C "$REPO" update-ref \
+    refs/heads/experiment/wf-storage-pressure/task/g0.t0.a-deadbeef \
+    HEAD 2>&1
+)"
+status=$?
+set -e
+
+if [ "$status" -eq 0 ]; then
+  echo "FAIL: git update-ref succeeded even though refs/heads/experiment is not writable" >&2
+  exit 1
+fi
+
+case "$output" in
+  *"cannot lock ref"*|*"unable to create directory"*|*"Permission denied"*|*"couldn't write"*)
+    echo "PASS: unwritable ref storage reproduces SSH bootstrap ref-lock failure"
+    echo "$output" | sed -n '1,6p'
+    ;;
+  *)
+    echo "FAIL: git failed, but not with the expected ref-lock/write error" >&2
+    echo "$output" >&2
+    exit 1
+    ;;
+esac
+
+echo "Remote incident evidence to compare against:"
+echo "- affected task errors contained: Executor startup failed (ssh) ... couldn't write ... .lock"
+echo "- remote_digital_ocean_4 was at 100% disk before cleanup; after cleanup it had free space again"

--- a/scripts/repro/repro-standalone-owner-idle-ignores-active-launch-dispatch.sh
+++ b/scripts/repro/repro-standalone-owner-idle-ignores-active-launch-dispatch.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tmpdir="$(mktemp -d "${TMPDIR:-/tmp}/invoker-owner-idle-launch-dispatch.XXXXXX")"
+trap 'rm -rf "$tmpdir"' EXIT
+
+db="$tmpdir/repro.db"
+
+sqlite3 "$db" <<'SQL'
+CREATE TABLE tasks (
+  id TEXT PRIMARY KEY,
+  status TEXT NOT NULL
+);
+
+CREATE TABLE workflow_mutation_intents (
+  id INTEGER PRIMARY KEY,
+  status TEXT NOT NULL
+);
+
+CREATE TABLE task_launch_dispatch (
+  id INTEGER PRIMARY KEY,
+  task_id TEXT NOT NULL,
+  state TEXT NOT NULL
+);
+
+INSERT INTO tasks (id, status)
+VALUES ('wf-repro/launching-task', 'pending');
+
+INSERT INTO task_launch_dispatch (id, task_id, state)
+VALUES
+  (1, 'wf-repro/launching-task', 'enqueued'),
+  (2, 'wf-repro/launching-task', 'leased');
+SQL
+
+old_idle="$(sqlite3 "$db" <<'SQL'
+SELECT CASE
+  WHEN EXISTS (
+    SELECT 1
+    FROM workflow_mutation_intents
+    WHERE status IN ('queued', 'running')
+  ) THEN 'false'
+  WHEN EXISTS (
+    SELECT 1
+    FROM tasks
+    WHERE status IN ('running', 'fixing_with_ai')
+  ) THEN 'false'
+  ELSE 'true'
+END;
+SQL
+)"
+
+fixed_idle="$(sqlite3 "$db" <<'SQL'
+SELECT CASE
+  WHEN EXISTS (
+    SELECT 1
+    FROM workflow_mutation_intents
+    WHERE status IN ('queued', 'running')
+  ) THEN 'false'
+  WHEN EXISTS (
+    SELECT 1
+    FROM task_launch_dispatch
+    WHERE state IN ('enqueued', 'leased')
+  ) THEN 'false'
+  WHEN EXISTS (
+    SELECT 1
+    FROM tasks
+    WHERE status IN ('running', 'fixing_with_ai')
+  ) THEN 'false'
+  ELSE 'true'
+END;
+SQL
+)"
+
+active_dispatches="$(sqlite3 "$db" <<'SQL'
+SELECT COUNT(*)
+FROM task_launch_dispatch
+WHERE state IN ('enqueued', 'leased');
+SQL
+)"
+
+pending_launching_tasks="$(sqlite3 "$db" <<'SQL'
+SELECT COUNT(*)
+FROM tasks
+WHERE status = 'pending';
+SQL
+)"
+
+if [ "$active_dispatches" != "2" ]; then
+  echo "expected two active launch dispatch rows, got $active_dispatches" >&2
+  exit 1
+fi
+
+if [ "$pending_launching_tasks" != "1" ]; then
+  echo "expected one pending launching task, got $pending_launching_tasks" >&2
+  exit 1
+fi
+
+if [ "$old_idle" != "true" ]; then
+  echo "expected old idle predicate to wrongly report idle, got $old_idle" >&2
+  exit 1
+fi
+
+if [ "$fixed_idle" != "false" ]; then
+  echo "expected fixed idle predicate to stay non-idle, got $fixed_idle" >&2
+  exit 1
+fi
+
+cat <<EOF
+PASS: standalone owner idle must account for active launch dispatch rows.
+
+pending_launching_tasks=$pending_launching_tasks
+active_launch_dispatch_rows=$active_dispatches
+old_idle_predicate=$old_idle
+fixed_idle_predicate=$fixed_idle
+
+Root cause reproduced: launch-outbox tasks can remain pending while their
+task_launch_dispatch rows are enqueued or leased. An owner idle predicate that
+only checks running/fixing tasks can exit and leave no dispatcher to consume them.
+EOF

--- a/scripts/repro/repro-underfilled-capacity-ready-pending-no-dispatch.sh
+++ b/scripts/repro/repro-underfilled-capacity-ready-pending-no-dispatch.sh
@@ -1,0 +1,147 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_DIR="$(mktemp -d -t invoker-underfilled-capacity.XXXXXX)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+DB="$TMP_DIR/invoker.db"
+STATE_FILE="$TMP_DIR/retry-state.tsv"
+
+sqlite3 "$DB" <<'SQL'
+CREATE TABLE tasks (
+  id TEXT PRIMARY KEY,
+  workflow_id TEXT NOT NULL,
+  status TEXT,
+  runner_kind TEXT,
+  pool_member_id TEXT,
+  dependencies TEXT DEFAULT '[]',
+  selected_attempt_id TEXT,
+  launch_phase TEXT,
+  blocked_by TEXT,
+  started_at TEXT,
+  last_heartbeat_at TEXT
+);
+
+CREATE TABLE task_launch_dispatch (
+  id INTEGER PRIMARY KEY,
+  task_id TEXT NOT NULL,
+  attempt_id TEXT NOT NULL,
+  workflow_id TEXT NOT NULL,
+  state TEXT NOT NULL,
+  enqueued_at TEXT,
+  leased_at TEXT,
+  completed_at TEXT,
+  last_error TEXT
+);
+
+CREATE TABLE events (
+  id INTEGER PRIMARY KEY,
+  task_id TEXT NOT NULL,
+  event_type TEXT NOT NULL,
+  payload TEXT,
+  created_at TEXT
+);
+
+CREATE TABLE execution_resource_leases (
+  resource_key TEXT PRIMARY KEY,
+  resource_type TEXT,
+  holder_id TEXT,
+  task_id TEXT,
+  pool_member_id TEXT,
+  last_heartbeat_at TEXT,
+  lease_expires_at TEXT
+);
+
+INSERT INTO tasks
+  (id, workflow_id, status, runner_kind, pool_member_id, dependencies, selected_attempt_id, launch_phase, started_at, last_heartbeat_at)
+VALUES
+  ('wf-a/ssh-regression', 'wf-a', 'running', 'ssh', 'remote-a', '[]', 'wf-a/ssh-regression-a1', 'executing', datetime('now', '-10 minutes'), datetime('now', '-20 seconds')),
+  ('wf-b/ssh-regression', 'wf-b', 'running', 'ssh', 'remote-b', '[]', 'wf-b/ssh-regression-a1', 'executing', datetime('now', '-10 minutes'), datetime('now', '-20 seconds')),
+  ('wf-c/visual-proof', 'wf-c', 'running', 'worktree', NULL, '[]', 'wf-c/visual-proof-a1', 'executing', datetime('now', '-10 minutes'), datetime('now', '-20 seconds')),
+  ('wf-d/ready-worktree', 'wf-d', 'pending', 'worktree', NULL, '[]', 'wf-d/ready-worktree-a3', NULL, NULL, NULL),
+  ('__merge__wf-d', 'wf-d', 'pending', 'merge', NULL, '["wf-d/ready-worktree"]', '__merge__wf-d-a1', NULL, NULL, NULL);
+
+INSERT INTO execution_resource_leases
+  (resource_key, resource_type, holder_id, task_id, pool_member_id, last_heartbeat_at, lease_expires_at)
+VALUES
+  ('ssh:remote-a', 'ssh', 'owner:wf-a/ssh-regression-a1', 'wf-a/ssh-regression', 'remote-a', datetime('now', '-20 seconds'), datetime('now', '+20 minutes')),
+  ('ssh:remote-b', 'ssh', 'owner:wf-b/ssh-regression-a1', 'wf-b/ssh-regression', 'remote-b', datetime('now', '-20 seconds'), datetime('now', '+20 minutes'));
+
+INSERT INTO task_launch_dispatch
+  (id, task_id, attempt_id, workflow_id, state, enqueued_at, leased_at, completed_at, last_error)
+VALUES
+  (1, 'wf-d/ready-worktree', 'wf-d/ready-worktree-a1', 'wf-d', 'abandoned', datetime('now', '-8 minutes'), datetime('now', '-8 minutes'), datetime('now', '-7 minutes'), 'workflow cancellation'),
+  (2, 'wf-d/ready-worktree', 'wf-d/ready-worktree-a2', 'wf-d', 'abandoned', datetime('now', '-6 minutes'), datetime('now', '-6 minutes'), datetime('now', '-5 minutes'), 'task deferred');
+
+INSERT INTO events (id, task_id, event_type, payload, created_at)
+VALUES
+  (1, 'wf-d/ready-worktree', 'task.cancelled', '{"reason":"workflow retry superseded attempt"}', datetime('now', '-7 minutes')),
+  (2, 'wf-d/ready-worktree', 'task.executor.deferred', '{"reason":"dependency-or-gate-not-runnable"}', datetime('now', '-5 minutes'));
+SQL
+
+printf 'retry-workflow\twf-d\t%s\n' "$(date +%s)" > "$STATE_FILE"
+
+running_count="$(sqlite3 "$DB" "SELECT COUNT(*) FROM tasks WHERE status='running';")"
+active_dispatch_count="$(sqlite3 "$DB" "SELECT COUNT(*) FROM task_launch_dispatch WHERE state IN ('enqueued','leased','acknowledged');")"
+ready_no_dispatch="$(
+  sqlite3 -noheader "$DB" "
+    WITH pending AS (
+      SELECT id, COALESCE(dependencies, '[]') AS dependencies, COALESCE(selected_attempt_id, '') AS selected_attempt_id
+      FROM tasks
+      WHERE status = 'pending'
+        AND COALESCE(runner_kind, 'worktree') != 'merge'
+        AND COALESCE(blocked_by, '') = ''
+    )
+    SELECT p.id
+    FROM pending p
+    WHERE NOT EXISTS (
+        SELECT 1
+        FROM json_each(p.dependencies) dep
+        LEFT JOIN tasks dt ON dt.id = dep.value
+        WHERE COALESCE(dt.status, 'missing') NOT IN ('completed', 'complete', 'review_ready')
+      )
+      AND NOT EXISTS (
+        SELECT 1
+        FROM task_launch_dispatch d
+        WHERE d.task_id = p.id
+          AND (p.selected_attempt_id = '' OR d.attempt_id = p.selected_attempt_id)
+          AND d.state IN ('enqueued', 'leased', 'acknowledged')
+      )
+    ORDER BY p.id;
+  "
+)"
+old_loop_would_skip="$(awk -F '\t' '$1 == "retry-workflow" && $2 == "wf-d" { found = 1 } END { print found ? "yes" : "no" }' "$STATE_FILE")"
+
+echo "temporary_db=$DB"
+echo "configured_capacity=12"
+echo "running_count=$running_count"
+echo "active_dispatch_count=$active_dispatch_count"
+echo "ready_without_dispatch=$ready_no_dispatch"
+echo "old_loop_would_skip_workflow_retry=$old_loop_would_skip"
+echo "dispatch_timeline:"
+sqlite3 -header -column "$DB" "
+  SELECT id, task_id, attempt_id, state, completed_at, last_error
+  FROM task_launch_dispatch
+  ORDER BY id;
+"
+
+if [ "$running_count" != "3" ]; then
+  echo "FAIL: expected exactly three running tasks" >&2
+  exit 1
+fi
+if [ "$active_dispatch_count" != "0" ]; then
+  echo "FAIL: expected no active dispatch rows" >&2
+  exit 1
+fi
+if [ "$ready_no_dispatch" != "wf-d/ready-worktree" ]; then
+  echo "FAIL: expected wf-d/ready-worktree to be ready without dispatch" >&2
+  exit 1
+fi
+if [ "$old_loop_would_skip" != "yes" ]; then
+  echo "FAIL: expected old loop retry memory to suppress workflow retry" >&2
+  exit 1
+fi
+
+echo "fixed_loop_action=retry-task wf-d/ready-worktree"
+echo "PASS: underfilled capacity is reproduced by a ready pending task with no active dispatch plus stale workflow retry memory"

--- a/scripts/retry-pending-autofix-failed.sh
+++ b/scripts/retry-pending-autofix-failed.sh
@@ -628,7 +628,8 @@ try:
           AND l.lease_expires_at IS NOT NULL
           AND julianday(l.lease_expires_at) > julianday('now')
           AND (
-            COALESCE(t.status, '<missing>') != 'running'
+            t.id IS NULL
+            OR COALESCE(t.status, '<missing>') NOT IN ('running', 'pending')
             OR t.selected_attempt_id IS NULL
             OR TRIM(t.selected_attempt_id) = ''
             OR NOT (
@@ -661,6 +662,286 @@ output_path.write_text(
     ),
     encoding="utf-8",
 )
+PY
+}
+
+write_ssh_running_without_lease_file() {
+  local ssh_running_without_lease_file="$1"
+  : > "$ssh_running_without_lease_file"
+
+  [ -f "$DB_PATH" ] || return 0
+
+  python3 - "$DB_PATH" "$ssh_running_without_lease_file" <<'PY'
+import pathlib
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+output_path = pathlib.Path(sys.argv[2])
+conn = None
+
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        SELECT t.id AS task_id
+        FROM tasks t
+        WHERE t.status = 'running'
+          AND t.runner_kind = 'ssh'
+          AND t.selected_attempt_id IS NOT NULL
+          AND TRIM(t.selected_attempt_id) != ''
+          AND NOT EXISTS (
+            SELECT 1
+            FROM execution_resource_leases l
+            WHERE l.resource_type = 'ssh'
+              AND l.task_id = t.id
+              AND l.lease_expires_at IS NOT NULL
+              AND julianday(l.lease_expires_at) > julianday('now')
+              AND (
+                l.holder_id = t.selected_attempt_id
+                OR l.holder_id LIKE '%:' || t.selected_attempt_id
+              )
+          )
+        ORDER BY t.id
+        """
+    ).fetchall()
+except sqlite3.Error:
+    rows = []
+finally:
+    if conn is not None:
+        conn.close()
+
+output_path.write_text(
+    "".join(f"{row['task_id']}\n" for row in rows),
+    encoding="utf-8",
+)
+PY
+}
+
+write_ssh_running_active_lease_file() {
+  local ssh_running_active_lease_file="$1"
+  : > "$ssh_running_active_lease_file"
+
+  [ -f "$DB_PATH" ] || return 0
+
+  python3 - "$DB_PATH" "$ssh_running_active_lease_file" <<'PY'
+import pathlib
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+output_path = pathlib.Path(sys.argv[2])
+conn = None
+
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        SELECT DISTINCT t.id AS task_id
+        FROM tasks t
+        JOIN execution_resource_leases l
+          ON l.task_id = t.id
+         AND (
+           l.holder_id = t.selected_attempt_id
+           OR l.holder_id LIKE '%:' || t.selected_attempt_id
+         )
+        WHERE t.status = 'running'
+          AND t.runner_kind = 'ssh'
+          AND t.selected_attempt_id IS NOT NULL
+          AND TRIM(t.selected_attempt_id) != ''
+          AND l.resource_type = 'ssh'
+          AND l.lease_expires_at IS NOT NULL
+          AND julianday(l.lease_expires_at) > julianday('now')
+        ORDER BY t.id
+        """
+    ).fetchall()
+except sqlite3.Error:
+    rows = []
+finally:
+    if conn is not None:
+        conn.close()
+
+output_path.write_text(
+    "".join(f"{row['task_id']}\n" for row in rows),
+    encoding="utf-8",
+)
+PY
+}
+
+write_pool_capacity_blocked_file() {
+  local queue_file="$1"
+  local pool_capacity_blocked_file="$2"
+  : > "$pool_capacity_blocked_file"
+
+  [ -f "$DB_PATH" ] || return 0
+
+  python3 - "$DB_PATH" "$queue_file" "$pool_capacity_blocked_file" <<'PY'
+import json
+import pathlib
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+queue_path = pathlib.Path(sys.argv[2])
+output_path = pathlib.Path(sys.argv[3])
+
+active_queue_task_ids = set()
+
+def collect_queue_task_ids(value):
+    if isinstance(value, dict):
+        task_id = value.get("taskId") or value.get("id")
+        if task_id:
+            active_queue_task_ids.add(str(task_id))
+        for nested in value.values():
+            if isinstance(nested, (dict, list)):
+                collect_queue_task_ids(nested)
+    elif isinstance(value, list):
+        for item in value:
+            collect_queue_task_ids(item)
+
+if queue_path.exists() and queue_path.stat().st_size > 0:
+    try:
+        queue = json.loads(queue_path.read_text(encoding="utf-8", errors="replace"))
+    except json.JSONDecodeError:
+        queue = {}
+    if isinstance(queue, dict):
+        collect_queue_task_ids(queue.get("queued"))
+
+if not active_queue_task_ids:
+    raise SystemExit(0)
+
+conn = None
+blocked = []
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    placeholders = ",".join("?" for _ in active_queue_task_ids)
+    tasks = conn.execute(
+        f"""
+        SELECT id
+        FROM tasks
+        WHERE id IN ({placeholders})
+          AND status = 'pending'
+          AND runner_kind = 'ssh'
+          AND pool_id IS NOT NULL
+          AND TRIM(pool_id) != ''
+        ORDER BY id
+        """,
+        tuple(sorted(active_queue_task_ids)),
+    ).fetchall()
+    for task in tasks:
+        task_id = task["id"]
+        latest_terminal = conn.execute(
+            """
+            SELECT COALESCE(MAX(id), 0) AS event_id
+            FROM events
+            WHERE task_id = ?
+              AND event_type IN (
+                'task.executor.selected',
+                'task.running',
+                'task.completed',
+                'task.failed',
+                'task.cancelled'
+              )
+            """,
+            (task_id,),
+        ).fetchone()["event_id"]
+        latest_defer = conn.execute(
+            """
+            SELECT payload
+            FROM events
+            WHERE task_id = ?
+              AND event_type = 'task.executor.deferred'
+              AND id > ?
+            ORDER BY id DESC
+            LIMIT 1
+            """,
+            (task_id, latest_terminal),
+        ).fetchone()
+        try:
+            payload = json.loads(latest_defer["payload"] if latest_defer else "{}")
+        except json.JSONDecodeError:
+            payload = {}
+        if payload.get("reason") in {"execution-pool-capacity", "ssh-resource-lease-held"}:
+            blocked.append(task_id)
+except sqlite3.Error:
+    blocked = []
+finally:
+    if conn is not None:
+        conn.close()
+
+output_path.write_text(
+    "".join(f"{task_id}\n" for task_id in blocked),
+    encoding="utf-8",
+)
+PY
+}
+
+write_ready_pending_without_dispatch_file() {
+  local ready_pending_without_dispatch_file="$1"
+  : > "$ready_pending_without_dispatch_file"
+
+  [ -f "$DB_PATH" ] || return 0
+
+  python3 - "$DB_PATH" "$ready_pending_without_dispatch_file" <<'PY'
+import pathlib
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+output_path = pathlib.Path(sys.argv[2])
+
+conn = None
+ready = []
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    ready = [
+        row["id"]
+        for row in conn.execute(
+            """
+            WITH pending AS (
+              SELECT
+                id,
+                COALESCE(dependencies, '[]') AS dependencies,
+                COALESCE(selected_attempt_id, '') AS selected_attempt_id,
+                COALESCE(launch_phase, '') AS launch_phase
+              FROM tasks
+              WHERE status = 'pending'
+                AND COALESCE(runner_kind, 'worktree') != 'merge'
+            )
+            SELECT p.id
+            FROM pending p
+            WHERE p.launch_phase NOT IN ('launching', 'executing')
+              AND NOT EXISTS (
+                SELECT 1
+                FROM json_each(p.dependencies) dep
+                LEFT JOIN tasks dt ON dt.id = dep.value
+                WHERE COALESCE(dt.status, 'missing') NOT IN ('completed', 'complete', 'review_ready')
+              )
+              AND NOT EXISTS (
+                SELECT 1
+                FROM task_launch_dispatch d
+                WHERE d.task_id = p.id
+                  AND (
+                    p.selected_attempt_id = ''
+                    OR d.attempt_id = p.selected_attempt_id
+                  )
+                  AND d.state IN ('enqueued', 'leased', 'acknowledged')
+              )
+            ORDER BY p.id
+            """
+        ).fetchall()
+    ]
+except sqlite3.Error:
+    ready = []
+finally:
+    if conn is not None:
+        conn.close()
+
+output_path.write_text("".join(f"{task_id}\n" for task_id in ready), encoding="utf-8")
 PY
 }
 
@@ -1537,9 +1818,14 @@ run_cycle() {
   local stale_ssh_pin_file="$cycle_dir/stale-ssh-pin.txt"
   local duplicate_ssh_leases_file="$cycle_dir/duplicate-ssh-leases.tsv"
   local orphan_ssh_leases_file="$cycle_dir/orphan-ssh-leases.tsv"
+  local ssh_running_without_lease_file="$cycle_dir/ssh-running-without-lease.txt"
+  local ssh_running_active_lease_file="$cycle_dir/ssh-running-active-lease.txt"
+  local pool_capacity_blocked_file="$cycle_dir/pool-capacity-blocked.txt"
+  local ready_pending_without_dispatch_file="$cycle_dir/ready-pending-without-dispatch.txt"
   local stale_investigation_file="$cycle_dir/stale-investigation-tasks.txt"
   local retried_workflows_file="$cycle_dir/retried-workflows.txt"
   local retried_failed_tasks_file="$cycle_dir/retried-failed-tasks.txt"
+  local retried_ready_no_dispatch_tasks_file="$cycle_dir/retried-ready-no-dispatch-tasks.txt"
   local localized_failed_tasks_file="$cycle_dir/localized-failed-tasks.txt"
   local localized_workflows_file="$cycle_dir/localized-workflows.txt"
   local cleared_ssh_pin_tasks_file="$cycle_dir/cleared-ssh-pin-tasks.txt"
@@ -1548,6 +1834,7 @@ run_cycle() {
   local released_orphan_ssh_leases_file="$cycle_dir/released-orphan-ssh-leases.tsv"
   : > "$retried_workflows_file"
   : > "$retried_failed_tasks_file"
+  : > "$retried_ready_no_dispatch_tasks_file"
   : > "$localized_failed_tasks_file"
   : > "$localized_workflows_file"
   : > "$cleared_ssh_pin_tasks_file"
@@ -1576,10 +1863,14 @@ run_cycle() {
   build_targets "$tasks_file" "$queue_file" "$pending_workflows_file" "$failed_tasks_file" "$approvals_file" "$localize_ssh_file" "$infra_retry_file" "$auto_fix_attempts_file" "$stale_fixing_file" "$stale_active_queue_file" "$stale_running_file" "$stale_ssh_pin_file" "$pending_tasks_file" "$blocking_tasks_file" "$status_counts_file" "$now_epoch"
   write_duplicate_ssh_leases_file "$duplicate_ssh_leases_file"
   write_orphan_ssh_leases_file "$orphan_ssh_leases_file"
+  write_ssh_running_without_lease_file "$ssh_running_without_lease_file"
+  write_ssh_running_active_lease_file "$ssh_running_active_lease_file"
+  write_pool_capacity_blocked_file "$queue_file" "$pool_capacity_blocked_file"
+  write_ready_pending_without_dispatch_file "$ready_pending_without_dispatch_file"
   write_exhausted_fixes_file "$failed_tasks_file" "$auto_fix_attempts_file" "$exhausted_fixes_file"
   write_effective_blockers_file "$blocking_tasks_file" "$exhausted_fixes_file" "$effective_blocking_tasks_file"
 
-  local retry_workflow_count pending_count pending_task_count blocking_task_count failed_count exhausted_fix_count approval_count localize_count infra_retry_count stale_fixing_count stale_active_queue_count stale_running_count stale_ssh_pin_count duplicate_ssh_lease_count orphan_ssh_lease_count
+  local retry_workflow_count pending_count pending_task_count blocking_task_count failed_count exhausted_fix_count approval_count localize_count infra_retry_count stale_fixing_count stale_active_queue_count stale_running_count stale_ssh_pin_count duplicate_ssh_lease_count orphan_ssh_lease_count ssh_running_without_lease_count ssh_running_active_lease_count pool_capacity_blocked_count ready_pending_without_dispatch_count
   retry_workflow_count="$(count_lines "$retry_workflows_file")"
   pending_count="$(count_lines "$pending_workflows_file")"
   pending_task_count="$(count_lines "$pending_tasks_file")"
@@ -1595,8 +1886,12 @@ run_cycle() {
   stale_ssh_pin_count="$(count_lines "$stale_ssh_pin_file")"
   duplicate_ssh_lease_count="$(count_lines "$duplicate_ssh_leases_file")"
   orphan_ssh_lease_count="$(count_lines "$orphan_ssh_leases_file")"
+  ssh_running_without_lease_count="$(count_lines "$ssh_running_without_lease_file")"
+  ssh_running_active_lease_count="$(count_lines "$ssh_running_active_lease_file")"
+  pool_capacity_blocked_count="$(count_lines "$pool_capacity_blocked_file")"
+  ready_pending_without_dispatch_count="$(count_lines "$ready_pending_without_dispatch_file")"
 
-  echo "cycle $cycle: retry-workflows=$retry_workflow_count pending-workflows=$pending_count pending-tasks=$pending_task_count blockers=$blocking_task_count failed-tasks=$failed_count exhausted-fixes=$exhausted_fix_count infra-retry=$infra_retry_count fix-approvals=$approval_count stale-fixing=$stale_fixing_count stale-queue-pending=$stale_active_queue_count stale-running=$stale_running_count stale-ssh-pin=$stale_ssh_pin_count duplicate-ssh-lease=$duplicate_ssh_lease_count orphan-ssh-lease=$orphan_ssh_lease_count ssh-to-worktree=$localize_count"
+  echo "cycle $cycle: retry-workflows=$retry_workflow_count pending-workflows=$pending_count pending-tasks=$pending_task_count blockers=$blocking_task_count failed-tasks=$failed_count exhausted-fixes=$exhausted_fix_count infra-retry=$infra_retry_count fix-approvals=$approval_count stale-fixing=$stale_fixing_count stale-queue-pending=$stale_active_queue_count stale-running=$stale_running_count ssh-running-no-lease=$ssh_running_without_lease_count ssh-running-active-lease=$ssh_running_active_lease_count pool-capacity-blocked=$pool_capacity_blocked_count ready-no-dispatch=$ready_pending_without_dispatch_count stale-ssh-pin=$stale_ssh_pin_count duplicate-ssh-lease=$duplicate_ssh_lease_count orphan-ssh-lease=$orphan_ssh_lease_count ssh-to-worktree=$localize_count"
 
   local failures=0
   local target=""
@@ -1687,6 +1982,39 @@ run_cycle() {
     done < "$duplicate_ssh_leases_file"
   fi
 
+  if [ -s "$ready_pending_without_dispatch_file" ]; then
+    local reset_for_ready_pending=false
+    while IFS= read -r target; do
+      [ -n "$target" ] || continue
+      if ! ever_submitted ready-no-dispatch "$target"; then
+        reset_for_ready_pending=true
+        break
+      fi
+    done < "$ready_pending_without_dispatch_file"
+    if [ "$reset_for_ready_pending" = true ]; then
+      echo "ready pending tasks missing launch dispatch rows: $(count_lines "$ready_pending_without_dispatch_file")"
+      reset_submission_state_after_repair "ready-pending-without-dispatch" "$now_epoch" "$cycle_dir"
+      while IFS= read -r target; do
+        [ -n "$target" ] || continue
+        record_submission ready-no-dispatch "$target" "$now_epoch"
+      done < "$ready_pending_without_dispatch_file"
+    fi
+    echo "retrying ready pending tasks missing launch dispatch rows"
+    while IFS= read -r target; do
+      [ -n "$target" ] || continue
+      if recently_submitted retry-ready-no-dispatch "$target" "$RESUME_COOLDOWN_SECONDS" "$now_epoch"; then
+        echo "  skip retry-ready-no-dispatch $target (retried recently)"
+        continue
+      fi
+      if dispatch_no_track retry-ready-no-dispatch "$target" "$RESUME_COOLDOWN_SECONDS" "$now_epoch" retry-task "$target"; then
+        [ "$LAST_DISPATCH_SUBMITTED" = true ] || continue
+        printf '%s\n' "$target" >> "$retried_ready_no_dispatch_tasks_file"
+      else
+        failures=$((failures + 1))
+      fi
+    done < "$ready_pending_without_dispatch_file"
+  fi
+
   if [ "$RETRY_INCOMPLETE_WORKFLOWS" = true ] && [ -s "$retry_workflows_file" ]; then
     echo "retrying workflows not completed or review_ready"
     while IFS= read -r target; do
@@ -1764,6 +2092,10 @@ run_cycle() {
         echo "  skip retry-failed $target (workflow retried this cycle)"
         continue
       fi
+      if contains_line "$retried_ready_no_dispatch_tasks_file" "$target"; then
+        echo "  skip retry-failed $target (ready missing-dispatch task retried this cycle)"
+        continue
+      fi
       if contains_line "$localized_failed_tasks_file" "$target"; then
         echo "  skip retry-failed $target (executor switch queued this cycle)"
         continue
@@ -1794,6 +2126,10 @@ run_cycle() {
       target_wf="$(target_workflow_id "$target")"
       if contains_line "$retried_workflows_file" "$target_wf"; then
         echo "  skip fix $target (workflow retried this cycle)"
+        continue
+      fi
+      if contains_line "$retried_ready_no_dispatch_tasks_file" "$target"; then
+        echo "  skip fix $target (ready missing-dispatch task retried this cycle)"
         continue
       fi
       if contains_line "$localized_failed_tasks_file" "$target"; then
@@ -1831,6 +2167,8 @@ run_cycle() {
   if [ "$failures" -eq 0 ]; then
     if [ -s "$retried_workflows_file" ]; then
       echo "pending investigation deferred (workflow retries submitted this cycle: $(count_lines "$retried_workflows_file"))"
+    elif [ -s "$retried_ready_no_dispatch_tasks_file" ]; then
+      echo "pending investigation deferred (ready missing-dispatch task retries submitted this cycle: $(count_lines "$retried_ready_no_dispatch_tasks_file"))"
     elif [ -s "$localized_workflows_file" ]; then
       echo "pending investigation deferred (executor switches submitted this cycle: $(count_lines "$localized_workflows_file"))"
     elif [ -s "$cleared_ssh_pin_workflows_file" ]; then
@@ -1842,14 +2180,30 @@ run_cycle() {
     else
       local investigation_tasks_file="$pending_tasks_file"
       local investigation_blockers_file="$effective_blocking_tasks_file"
-      if [ -s "$stale_active_queue_file" ] || [ -s "$stale_running_file" ]; then
+      if [ -s "$stale_active_queue_file" ] || [ -s "$stale_running_file" ] || [ -s "$ssh_running_without_lease_file" ]; then
         : > "$stale_investigation_file"
-        cat "$stale_active_queue_file" "$stale_running_file" 2>/dev/null | sed '/^$/d' | sort -u > "$stale_investigation_file"
+        cat "$stale_active_queue_file" "$stale_running_file" "$ssh_running_without_lease_file" 2>/dev/null | sed '/^$/d' | sort -u > "$stale_investigation_file"
+        if [ -s "$pool_capacity_blocked_file" ]; then
+          local filtered_stale_investigation_file
+          filtered_stale_investigation_file="$cycle_dir/stale-investigation-filtered.txt"
+          grep -vxFf "$pool_capacity_blocked_file" "$stale_investigation_file" > "$filtered_stale_investigation_file" || true
+          mv "$filtered_stale_investigation_file" "$stale_investigation_file"
+        fi
         if [ -s "$stale_active_queue_file" ]; then
           echo "pending investigation includes stale queue-active pending tasks: $(count_lines "$stale_active_queue_file")"
         fi
         if [ -s "$stale_running_file" ]; then
           echo "pending investigation includes stale running tasks: $(count_lines "$stale_running_file")"
+        fi
+        if [ -s "$ssh_running_without_lease_file" ]; then
+          echo "pending investigation includes SSH running tasks without active leases: $(count_lines "$ssh_running_without_lease_file")"
+        fi
+        if [ -s "$pool_capacity_blocked_file" ]; then
+          echo "pending investigation excludes active SSH pool capacity blockers: $(count_lines "$pool_capacity_blocked_file")"
+        fi
+        if [ ! -s "$stale_investigation_file" ]; then
+          echo "pending investigation deferred (pool capacity blockers remain: $(count_lines "$pool_capacity_blocked_file"))"
+          return 0
         fi
         investigation_tasks_file="$stale_investigation_file"
         investigation_blockers_file="$cycle_dir/stale-investigation-blockers.txt"
@@ -2052,6 +2406,106 @@ SELFTEST_CODEX
   self_test_assert_contains "$codex_commands_file" "exec --cd"
   self_test_assert_contains "$test_root/investigate.out" "reset retry state after repair"
 
+  echo "self-test: ready pending task without launch dispatch resets retry state"
+  self_test_reset
+  printf 'retry-workflow\twf-1000-24\t%s\nretry-workflow\twf-1000-25\t%s\n' "$now_epoch" "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-24" "wf-1000-25" > "$workflows_label_file"
+  printf '%s\n' \
+    '{"id":"wf-1000-24","status":"running"}' \
+    '{"id":"wf-1000-25","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-25/blocker"}],"queued":[],"runningCount":1,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"id":"wf-1000-24/root","status":"pending","config":{"workflowId":"wf-1000-24","runnerKind":"worktree"},"execution":{"selectedAttemptId":"wf-1000-24/root-a1"}}' > "$tasks_dir/wf-1000-24.jsonl"
+  printf '%s\n' '{"id":"wf-1000-25/blocker","status":"running","config":{"workflowId":"wf-1000-25","runnerKind":"worktree"},"execution":{"lastHeartbeatAt":"2099-01-01T00:00:00Z","startedAt":"2099-01-01T00:00:00Z","phase":"executing"}}' > "$tasks_dir/wf-1000-25.jsonl"
+  python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+conn = sqlite3.connect(db_path)
+with conn:
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          status TEXT,
+          runner_kind TEXT,
+          dependencies TEXT,
+          selected_attempt_id TEXT,
+          launch_phase TEXT
+        );
+        CREATE TABLE task_launch_dispatch (
+          task_id TEXT,
+          attempt_id TEXT,
+          state TEXT
+        );
+        INSERT INTO tasks
+          (id, status, runner_kind, dependencies, selected_attempt_id, launch_phase)
+        VALUES
+          ('wf-1000-24/root', 'pending', 'worktree', '[]', 'wf-1000-24/root-a1', ''),
+          ('wf-1000-25/blocker', 'running', 'worktree', '[]', 'wf-1000-25/blocker-a1', 'executing');
+        """
+    )
+conn.close()
+PY
+  run_cycle selftest-ready-no-dispatch > "$test_root/ready-no-dispatch.out" 2>&1 || { sed -n '1,220p' "$test_root/ready-no-dispatch.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/ready-no-dispatch.out" "ready-no-dispatch=1"
+  self_test_assert_contains "$test_root/ready-no-dispatch.out" "ready pending tasks missing launch dispatch rows: 1"
+  self_test_assert_contains "$test_root/ready-no-dispatch.out" "retrying ready pending tasks missing launch dispatch rows"
+  self_test_assert_contains "$test_root/ready-no-dispatch.out" "reset retry state after repair"
+  self_test_assert_contains "$commands_file" "retry wf-1000-24"
+  self_test_assert_contains "$commands_file" "retry-task wf-1000-24/root"
+  self_test_assert_not_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: pool-capacity deferred queued task blocks pending investigation"
+  self_test_reset
+  printf 'retry-workflow\twf-1000-23\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-23" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-23","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"queued":[{"taskId":"wf-1000-23/regression"}],"running":[],"runningCount":0,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"id":"wf-1000-23/regression","status":"pending","config":{"workflowId":"wf-1000-23","runnerKind":"ssh","poolId":"pnpm-ssh"},"execution":{"selectedAttemptId":"wf-1000-23/regression-a1","lastHeartbeatAt":"2000-01-01T00:00:00Z"}}' > "$tasks_dir/wf-1000-23.jsonl"
+  python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+conn = sqlite3.connect(db_path)
+with conn:
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          status TEXT,
+          runner_kind TEXT,
+          pool_id TEXT
+        );
+        CREATE TABLE events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          task_id TEXT,
+          event_type TEXT,
+          payload TEXT
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO tasks VALUES (?, ?, ?, ?)",
+        ("wf-1000-23/regression", "pending", "ssh", "pnpm-ssh"),
+    )
+    conn.execute(
+        "INSERT INTO events (task_id, event_type, payload) VALUES (?, ?, ?)",
+        (
+            "wf-1000-23/regression",
+            "task.executor.deferred",
+            '{"reason":"execution-pool-capacity","poolId":"pnpm-ssh"}',
+        ),
+    )
+conn.close()
+PY
+  run_cycle selftest-pool-capacity-blocked > "$test_root/pool-capacity-blocked.out" 2>&1 || { sed -n '1,240p' "$test_root/pool-capacity-blocked.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/pool-capacity-blocked.out" "pool-capacity-blocked=1"
+  self_test_assert_contains "$test_root/pool-capacity-blocked.out" "pending investigation excludes active SSH pool capacity blockers: 1"
+  self_test_assert_contains "$test_root/pool-capacity-blocked.out" "pending investigation deferred (pool capacity blockers remain: 1)"
+  self_test_assert_not_contains "$codex_commands_file" "exec --cd"
+
   echo "self-test: healthy pending SSH task is investigated without executor switch"
   self_test_reset
   printf 'retry-workflow\twf-1000-13\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
@@ -2166,9 +2620,10 @@ PY
   [ "$remaining_leases" = "ssh:invoker@host-a:22 remote-a" ] || self_test_fail "unexpected leases after duplicate release: $remaining_leases"
   self_test_assert_contains "$test_root/duplicate-ssh-lease.out" "pending investigation deferred (duplicate SSH leases released this cycle: 1)"
 
-  echo "self-test: active SSH lease for pending task is released"
+  echo "self-test: active selected-attempt SSH lease for pending task is preserved"
   self_test_reset
   RETRY_INCOMPLETE_WORKFLOWS=true
+  INVESTIGATE_PENDING=false
   printf 'retry-workflow\twf-1000-20\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
   printf '%s\n' "wf-1000-20" > "$workflows_label_file"
   printf '%s\n' '{"id":"wf-1000-20","status":"running"}' > "$workflows_jsonl_file"
@@ -2221,9 +2676,8 @@ with conn:
 conn.close()
 PY
   run_cycle selftest-orphan-ssh-lease > "$test_root/orphan-ssh-lease.out" 2>&1 || { sed -n '1,240p' "$test_root/orphan-ssh-lease.out" >&2; return 1; }
-  self_test_assert_contains "$test_root/orphan-ssh-lease.out" "orphan-ssh-lease=1"
-  self_test_assert_contains "$test_root/orphan-ssh-lease.out" "released orphan SSH lease wf-1000-20/regression status=pending member=remote-a"
-  self_test_assert_contains "$test_root/orphan-ssh-lease.out" "pending investigation deferred (orphan SSH leases released this cycle: 1)"
+  self_test_assert_contains "$test_root/orphan-ssh-lease.out" "orphan-ssh-lease=0"
+  self_test_assert_not_contains "$test_root/orphan-ssh-lease.out" "released orphan SSH lease wf-1000-20/regression"
   remaining_leases="$(python3 - "$DB_PATH" <<'PY'
 import sqlite3
 import sys
@@ -2232,7 +2686,57 @@ print(conn.execute("SELECT COUNT(*) FROM execution_resource_leases").fetchone()[
 conn.close()
 PY
 )"
-  [ "$remaining_leases" = "0" ] || self_test_fail "expected orphan lease to be released, remaining=$remaining_leases"
+  [ "$remaining_leases" = "1" ] || self_test_fail "expected pending selected-attempt lease to be preserved, remaining=$remaining_leases"
+
+  echo "self-test: running SSH task without active lease is investigated"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  printf 'retry-workflow\twf-1000-22\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-22" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-22","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-22/regression"}],"queued":[],"runningCount":1,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"id":"wf-1000-22/regression","status":"running","config":{"workflowId":"wf-1000-22","runnerKind":"ssh","poolId":"pnpm-ssh","poolMemberId":"remote-a"},"execution":{"selectedAttemptId":"wf-1000-22/regression-a1","lastHeartbeatAt":"2099-01-01T00:00:00Z","startedAt":"2099-01-01T00:00:00Z","phase":"executing"}}' > "$tasks_dir/wf-1000-22.jsonl"
+  python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+conn = sqlite3.connect(db_path)
+with conn:
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          status TEXT,
+          runner_kind TEXT,
+          pool_member_id TEXT,
+          selected_attempt_id TEXT
+        );
+        CREATE TABLE execution_resource_leases (
+          resource_key TEXT,
+          resource_type TEXT,
+          holder_id TEXT,
+          task_id TEXT,
+          pool_id TEXT,
+          pool_member_id TEXT,
+          acquired_at TEXT,
+          last_heartbeat_at TEXT,
+          lease_expires_at TEXT,
+          metadata_json TEXT,
+          PRIMARY KEY(resource_key, holder_id)
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO tasks VALUES (?, ?, ?, ?, ?)",
+        ("wf-1000-22/regression", "running", "ssh", "remote-a", "wf-1000-22/regression-a1"),
+    )
+conn.close()
+PY
+  run_cycle selftest-ssh-running-no-lease > "$test_root/ssh-running-no-lease.out" 2>&1 || { sed -n '1,260p' "$test_root/ssh-running-no-lease.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/ssh-running-no-lease.out" "ssh-running-no-lease=1"
+  self_test_assert_contains "$test_root/ssh-running-no-lease.out" "pending investigation includes SSH running tasks without active leases: 1"
+  self_test_assert_contains "$test_root/ssh-running-no-lease.out" "investigated pending task with Codex: wf-1000-22/regression"
 
   echo "self-test: active SSH lease for old attempt on running task is released"
   self_test_reset

--- a/scripts/retry-pending-autofix-failed.sh
+++ b/scripts/retry-pending-autofix-failed.sh
@@ -1,7 +1,12 @@
 #!/usr/bin/env bash
-# Continuously nudge pending workflow work, retry failed tasks once,
-# auto-fix still-failed tasks with Codex, approve AI-fix approval gates,
-# and move SSH-assigned recovery work to local worktrees before running it.
+# Continuously retry workflow work that is not complete/review-ready,
+# retry failed tasks once,
+# auto-fix still-failed tasks with Codex up to three times per task,
+# recover stale AI-fix sessions and stale running tasks after restarts,
+# approve AI-fix approval gates,
+# clear stale explicit SSH host pins left by prior pool-routed attempts,
+# release duplicate selected-attempt SSH leases that consume extra pool hosts,
+# and optionally move SSH-assigned recovery work to local worktrees before running it.
 #
 # Usage:
 #   bash scripts/retry-pending-autofix-failed.sh
@@ -16,11 +21,26 @@ DRY_RUN=false
 INTERVAL_SECONDS=30
 MAX_CYCLES=0
 INCLUDE_MERGE=true
-RESUME_PENDING=true
+RETRY_INCOMPLETE_WORKFLOWS=true
 RETRY_FAILED=true
 AUTOFIX_FAILED=true
 APPROVE_FIXES=true
-LOCALIZE_SSH=true
+LOCALIZE_SSH=false
+SELF_TEST=false
+MAX_FIX_ATTEMPTS=3
+RECOVER_STALE_AI_STATES=true
+STALE_AI_STATE_SECONDS=300
+STALE_ACTIVE_QUEUE_SECONDS=300
+INVESTIGATE_PENDING=true
+INVESTIGATE_COOLDOWN_SECONDS=1800
+RESET_STATE_AFTER_REPAIR=true
+CODEX_COMMAND="${CODEX_COMMAND:-codex}"
+CODEX_PROMPT_MAX_BYTES=1000000
+INVESTIGATION_DIR="${INVOKER_RETRY_PENDING_AUTOFIX_INVESTIGATION_DIR:-${HOME:-.}/.invoker/retry-pending-autofix-investigations}"
+SKIP_SLEEP_AFTER_CYCLE=false
+QUERY_TIMEOUT_SECONDS="${INVOKER_RETRY_PENDING_AUTOFIX_QUERY_TIMEOUT_SECONDS:-120}"
+IPC_FALLBACK_TO_STANDALONE="${INVOKER_RETRY_PENDING_AUTOFIX_IPC_FALLBACK_TO_STANDALONE:-true}"
+LAST_DISPATCH_SUBMITTED=false
 RESUME_COOLDOWN_SECONDS=60
 FIX_COOLDOWN_SECONDS=300
 APPROVE_COOLDOWN_SECONDS=30
@@ -35,24 +55,42 @@ usage() {
 Usage: scripts/retry-pending-autofix-failed.sh [options]
 
 Loop actions:
-  - resume every workflow that still has pending tasks
+  - run `retry <workflowId>` for every workflow not completed or review_ready
   - run `retry-task <taskId>` once for every failed task
-  - run `fix <taskId> codex` for failed tasks already retried by this loop
+  - run `fix <taskId> codex` for failed tasks already retried by this loop, up to three times per task
+  - recover stale fixing_with_ai tasks after restarts
+  - investigate stale running tasks that no longer have launch progress
   - retry infrastructure failures with a cooldown instead of sending them to Codex
-  - run `set executor <taskId> worktree` for pending, failed, or fix-approval SSH tasks before resume/retry/fix/approve
-  - run `approve <taskId>` for awaiting_approval tasks that have pendingFixError
+  - clear stale explicit SSH pool member pins from pending pool-routed retry work
+  - release duplicate active SSH leases held by the same selected task attempt
+  - optionally run `set executor <taskId> worktree` for stale/failed SSH recovery tasks before resume/retry/fix/approve
+  - run `approve <taskId>` for approval-state tasks that have pendingFixError
+  - when only pending nonterminal tasks remain, ask local Codex to investigate why each pending task did not run
 
 Options:
   --dry-run                     Print planned commands without mutating state
+  --self-test                   Run deterministic script self-tests with mocked Invoker state
   --once                        Run one scan/action cycle and exit
   --max-cycles <n>              Run n cycles; 0 means forever (default: 0)
   --interval <seconds>          Sleep between cycles (default: 30)
   --workflow <workflowId>       Limit to a workflow; may be repeated
   --no-merge                    Skip failed/approval actions for merge nodes
-  --no-resume-pending           Do not resume workflows with pending tasks
+  --no-retry-incomplete         Do not retry workflows unless completed or review_ready
+  --no-resume-pending           Deprecated alias for --no-retry-incomplete
   --no-retry-failed             Do not retry failed tasks before autofix
   --no-autofix-failed           Do not submit Codex fixes for failed tasks
+  --max-fix-attempts <n>        Per-task Codex fix cap; max 3, 0 disables fixes (default: 3)
+  --no-recover-stale-ai-states  Do not recover stale fixing_with_ai tasks
+  --stale-ai-state-age <seconds> Age before AI states are treated as restart-stale (default: 300)
+  --stale-active-queue-age <sec> Age before queue-active pending tasks are investigated (default: 300)
+  --no-investigate-pending      Do not invoke local Codex for pending tasks after active work drains
+  --investigate-cooldown <sec>  Per-task Codex investigation cooldown (default: 1800)
+  --codex-command <path>        Codex executable for pending investigation (default: codex)
+  --no-reset-state-after-repair Do not blank saved retry state after a successful Codex repair pass
+  --query-timeout <seconds>     Read-only headless query timeout; 0 disables it (default: 120)
+  --no-ipc-fallback             Do not retry failed IPC mutations in standalone mode
   --no-approve-fixes            Do not approve AI-fix approval tasks
+  --localize-ssh                Switch stale/failed SSH recovery tasks to local worktrees
   --no-localize-ssh             Do not switch SSH-assigned recovery tasks to local worktrees
   --no-localize-failed-ssh      Deprecated alias for --no-localize-ssh
   --resume-cooldown <seconds>   Per-workflow resume cooldown (default: 60)
@@ -75,6 +113,10 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
     --dry-run)
       DRY_RUN=true
+      shift
+      ;;
+    --self-test)
+      SELF_TEST=true
       shift
       ;;
     --once)
@@ -100,8 +142,12 @@ while [[ $# -gt 0 ]]; do
       INCLUDE_MERGE=false
       shift
       ;;
+    --no-retry-incomplete)
+      RETRY_INCOMPLETE_WORKFLOWS=false
+      shift
+      ;;
     --no-resume-pending)
-      RESUME_PENDING=false
+      RETRY_INCOMPLETE_WORKFLOWS=false
       shift
       ;;
     --no-retry-failed)
@@ -112,8 +158,59 @@ while [[ $# -gt 0 ]]; do
       AUTOFIX_FAILED=false
       shift
       ;;
+    --max-fix-attempts)
+      MAX_FIX_ATTEMPTS="${2:-}"
+      positive_int_or_zero "$MAX_FIX_ATTEMPTS" || { echo "Invalid --max-fix-attempts: $MAX_FIX_ATTEMPTS" >&2; exit 2; }
+      [ "$MAX_FIX_ATTEMPTS" -le 3 ] || { echo "Invalid --max-fix-attempts: $MAX_FIX_ATTEMPTS (max: 3)" >&2; exit 2; }
+      shift 2
+      ;;
+    --no-recover-stale-ai-states)
+      RECOVER_STALE_AI_STATES=false
+      shift
+      ;;
+    --stale-ai-state-age)
+      STALE_AI_STATE_SECONDS="${2:-}"
+      positive_int_or_zero "$STALE_AI_STATE_SECONDS" || { echo "Invalid --stale-ai-state-age: $STALE_AI_STATE_SECONDS" >&2; exit 2; }
+      shift 2
+      ;;
+    --stale-active-queue-age)
+      STALE_ACTIVE_QUEUE_SECONDS="${2:-}"
+      positive_int_or_zero "$STALE_ACTIVE_QUEUE_SECONDS" || { echo "Invalid --stale-active-queue-age: $STALE_ACTIVE_QUEUE_SECONDS" >&2; exit 2; }
+      shift 2
+      ;;
+    --no-investigate-pending)
+      INVESTIGATE_PENDING=false
+      shift
+      ;;
+    --investigate-cooldown)
+      INVESTIGATE_COOLDOWN_SECONDS="${2:-}"
+      positive_int_or_zero "$INVESTIGATE_COOLDOWN_SECONDS" || { echo "Invalid --investigate-cooldown: $INVESTIGATE_COOLDOWN_SECONDS" >&2; exit 2; }
+      shift 2
+      ;;
+    --codex-command)
+      [[ -n "${2:-}" ]] || { echo "Missing value for --codex-command" >&2; exit 2; }
+      CODEX_COMMAND="$2"
+      shift 2
+      ;;
+    --no-reset-state-after-repair)
+      RESET_STATE_AFTER_REPAIR=false
+      shift
+      ;;
+    --query-timeout)
+      QUERY_TIMEOUT_SECONDS="${2:-}"
+      positive_int_or_zero "$QUERY_TIMEOUT_SECONDS" || { echo "Invalid --query-timeout: $QUERY_TIMEOUT_SECONDS" >&2; exit 2; }
+      shift 2
+      ;;
+    --no-ipc-fallback)
+      IPC_FALLBACK_TO_STANDALONE=false
+      shift
+      ;;
     --no-approve-fixes)
       APPROVE_FIXES=false
+      shift
+      ;;
+    --localize-ssh)
+      LOCALIZE_SSH=true
       shift
       ;;
     --no-localize-failed-ssh)
@@ -158,6 +255,10 @@ done
 
 STATE_DIR="$(mktemp -d -t invoker-retry-pending-autofix.XXXXXX)"
 SUBMISSIONS_FILE="${INVOKER_RETRY_PENDING_AUTOFIX_STATE_FILE:-${HOME:-.}/.invoker/retry-pending-autofix-failed-submissions.tsv}"
+DB_PATH="${INVOKER_DB_PATH:-${INVOKER_DB_DIR:-${HOME:-.}/.invoker}/invoker.db}"
+HEADLESS_CLIENT_JS="$REPO_ROOT/packages/app/dist/headless-client.js"
+MANAGED_OWNER_PID=""
+MANAGED_OWNER_LOG="$STATE_DIR/managed-owner.log"
 mkdir -p "$(dirname "$SUBMISSIONS_FILE")"
 touch "$SUBMISSIONS_FILE"
 cleanup() {
@@ -165,12 +266,133 @@ cleanup() {
 }
 trap cleanup EXIT
 
+owner_ping_ready() {
+  node --input-type=module <<'NODE' >/dev/null 2>&1
+import { IpcBus } from './packages/transport/dist/index.js';
+const bus = new IpcBus(undefined, { allowServe: false, requestDeadlineMs: 1000 });
+try {
+  await bus.ready();
+  const response = await bus.request('headless.owner-ping', {});
+  if (!response || response.ok !== true) process.exit(1);
+} catch {
+  process.exit(1);
+} finally {
+  bus.disconnect();
+}
+NODE
+}
+
+managed_owner_alive() {
+  [ -n "$MANAGED_OWNER_PID" ] && kill -0 "$MANAGED_OWNER_PID" 2>/dev/null
+}
+
+start_managed_headless_owner() {
+  if owner_ping_ready; then
+    return 0
+  fi
+
+  if managed_owner_alive; then
+    :
+  else
+    MANAGED_OWNER_LOG="$STATE_DIR/managed-owner-$(date +%s).log"
+    echo "  starting managed standalone owner for retry loop (log: $MANAGED_OWNER_LOG)" >&2
+    INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS="${INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:-86400000}" \
+      INVOKER_HEADLESS_STANDALONE=1 \
+      "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless owner-serve > "$MANAGED_OWNER_LOG" 2>&1 &
+    MANAGED_OWNER_PID="$!"
+  fi
+
+  local deadline=$((SECONDS + 90))
+  while (( SECONDS < deadline )); do
+    if owner_ping_ready; then
+      return 0
+    fi
+    if [ -n "$MANAGED_OWNER_PID" ] && ! kill -0 "$MANAGED_OWNER_PID" 2>/dev/null; then
+      echo "  managed owner exited before becoming ready" >&2
+      [ -f "$MANAGED_OWNER_LOG" ] && tail -80 "$MANAGED_OWNER_LOG" >&2
+      return 1
+    fi
+    sleep 0.5
+  done
+
+  echo "  timed out waiting for managed standalone owner" >&2
+  [ -f "$MANAGED_OWNER_LOG" ] && tail -80 "$MANAGED_OWNER_LOG" >&2
+  return 1
+}
+
 headless_mutation_no_track() {
   if [ "$STANDALONE_MODE" = "1" ]; then
-    "$RUNNER" --headless --no-track "$@"
+    INVOKER_HEADLESS_STANDALONE=1 "$RUNNER" --headless --no-track "$@"
     return $?
   fi
-  node "$IPC_HELPER" exec --no-track -- "$@"
+
+  local output=""
+  local code=0
+  set +e
+  output="$(node "$IPC_HELPER" exec --no-track -- "$@" 2>&1)"
+  code=$?
+  set -e
+  if [ "$code" -eq 0 ]; then
+    printf '%s\n' "$output"
+    return 0
+  fi
+
+  if [ "$IPC_FALLBACK_TO_STANDALONE" = true ] \
+    && printf '%s\n' "$output" | grep -Eq 'No request handler registered for channel: headless\.exec|NO_HANDLER'; then
+    printf '%s\n' "$output" >&2
+    echo "  IPC headless.exec handler unavailable; ensuring managed standalone owner" >&2
+    if start_managed_headless_owner; then
+      set +e
+      output="$(node "$IPC_HELPER" exec --no-track -- "$@" 2>&1)"
+      code=$?
+      set -e
+      if [ "$code" -eq 0 ]; then
+        printf '%s\n' "$output"
+        return 0
+      fi
+      printf '%s\n' "$output" >&2
+    fi
+    if [ -f "$HEADLESS_CLIENT_JS" ]; then
+      echo "  managed owner path unavailable; falling back to headless-client owner bootstrap" >&2
+      INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS="${INVOKER_STANDALONE_OWNER_IDLE_TIMEOUT_MS:-86400000}" \
+        node "$HEADLESS_CLIENT_JS" --no-track "$@"
+    else
+      echo "  missing built headless client at $HEADLESS_CLIENT_JS; falling back to direct runner" >&2
+      INVOKER_HEADLESS_STANDALONE=1 "$RUNNER" --headless --no-track "$@"
+    fi
+    return $?
+  fi
+
+  printf '%s\n' "$output" >&2
+  return "$code"
+}
+
+bounded_headless_query() {
+  local attempts=3
+  local attempt=1
+  local code=0
+  local output_file="$STATE_DIR/query-output.$$.$RANDOM"
+
+  while [ "$attempt" -le "$attempts" ]; do
+    set +e
+    # shellcheck disable=SC2086
+    run_with_optional_timeout "$QUERY_TIMEOUT_SECONDS" \
+      "$ELECTRON" "$MAIN" $SANDBOX_FLAG --headless "$@" > "$output_file" 2>/dev/null
+    code=$?
+    set -e
+    if [ "$code" -eq 0 ]; then
+      cat "$output_file"
+      rm -f "$output_file"
+      return 0
+    fi
+    if [ "$attempt" -lt "$attempts" ]; then
+      sleep "$attempt"
+    fi
+    attempt=$((attempt + 1))
+  done
+
+  rm -f "$output_file"
+  return "$code"
 }
 
 recently_submitted() {
@@ -203,6 +425,17 @@ ever_submitted() {
     "$SUBMISSIONS_FILE"
 }
 
+submission_count() {
+  local kind="$1"
+  local target="$2"
+
+  awk -F '\t' \
+    -v kind="$kind" \
+    -v target="$target" \
+    '$1 == kind && $2 == target { count += 1 } END { print count + 0 }' \
+    "$SUBMISSIONS_FILE"
+}
+
 record_submission() {
   local kind="$1"
   local target="$2"
@@ -216,6 +449,288 @@ contains_line() {
   grep -Fxq -- "$target" "$file"
 }
 
+slugify_id() {
+  local value="$1"
+  printf '%s' "$value" \
+    | tr '/:@ ' '----' \
+    | tr -cd 'A-Za-z0-9_.-' \
+    | cut -c 1-160
+}
+
+target_workflow_id() {
+  local target="$1"
+  if [[ "$target" == */* ]]; then
+    printf '%s\n' "${target%%/*}"
+    return
+  fi
+  if [[ "$target" == __merge__wf-* ]]; then
+    printf '%s\n' "${target#__merge__}"
+    return
+  fi
+  printf '%s\n' "$target"
+}
+
+task_auto_fix_attempts() {
+  local file="$1"
+  local target="$2"
+
+  awk -F '\t' \
+    -v target="$target" \
+    '$1 == target { attempts = $2 } END { print attempts + 0 }' \
+    "$file"
+}
+
+write_exhausted_fixes_file() {
+  local failed_tasks_file="$1"
+  local auto_fix_attempts_file="$2"
+  local exhausted_fixes_file="$3"
+
+  : > "$exhausted_fixes_file"
+  [ -s "$failed_tasks_file" ] || return 0
+
+  local target=""
+  while IFS= read -r target; do
+    [ -n "$target" ] || continue
+    local task_attempts submitted_attempts fix_attempts
+    task_attempts="$(task_auto_fix_attempts "$auto_fix_attempts_file" "$target")"
+    submitted_attempts="$(submission_count fix "$target")"
+    fix_attempts="$submitted_attempts"
+    if [ "$task_attempts" -gt "$fix_attempts" ]; then
+      fix_attempts="$task_attempts"
+    fi
+    if [ "$fix_attempts" -ge "$MAX_FIX_ATTEMPTS" ]; then
+      printf '%s\n' "$target" >> "$exhausted_fixes_file"
+    fi
+  done < "$failed_tasks_file"
+}
+
+write_effective_blockers_file() {
+  local blocking_tasks_file="$1"
+  local exhausted_fixes_file="$2"
+  local effective_blocking_tasks_file="$3"
+
+  if [ ! -s "$exhausted_fixes_file" ]; then
+    cp "$blocking_tasks_file" "$effective_blocking_tasks_file"
+    return 0
+  fi
+  grep -Fxv -f "$exhausted_fixes_file" "$blocking_tasks_file" > "$effective_blocking_tasks_file" || true
+}
+
+write_duplicate_ssh_leases_file() {
+  local duplicate_ssh_leases_file="$1"
+  : > "$duplicate_ssh_leases_file"
+
+  [ -f "$DB_PATH" ] || return 0
+
+  python3 - "$DB_PATH" "$duplicate_ssh_leases_file" <<'PY'
+import pathlib
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+output_path = pathlib.Path(sys.argv[2])
+conn = None
+
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        WITH selected_active_ssh_leases AS (
+          SELECT
+            t.id AS task_id,
+            t.selected_attempt_id AS selected_attempt_id,
+            t.pool_member_id AS assigned_pool_member_id,
+            l.resource_key AS resource_key,
+            l.holder_id AS holder_id,
+            l.pool_member_id AS lease_pool_member_id,
+            COUNT(*) OVER (PARTITION BY t.id, t.selected_attempt_id) AS selected_lease_count
+          FROM tasks t
+          JOIN execution_resource_leases l
+            ON l.task_id = t.id
+           AND (
+             l.holder_id = t.selected_attempt_id
+             OR l.holder_id LIKE '%:' || t.selected_attempt_id
+           )
+          WHERE t.status = 'running'
+            AND t.runner_kind = 'ssh'
+            AND t.selected_attempt_id IS NOT NULL
+            AND TRIM(t.selected_attempt_id) != ''
+            AND t.pool_member_id IS NOT NULL
+            AND TRIM(t.pool_member_id) != ''
+            AND l.resource_type = 'ssh'
+            AND l.lease_expires_at IS NOT NULL
+            AND julianday(l.lease_expires_at) > julianday('now')
+        )
+        SELECT task_id, resource_key, holder_id, lease_pool_member_id, assigned_pool_member_id
+        FROM selected_active_ssh_leases
+        WHERE selected_lease_count > 1
+          AND COALESCE(lease_pool_member_id, '') != assigned_pool_member_id
+        ORDER BY task_id, lease_pool_member_id, resource_key
+        """
+    ).fetchall()
+except sqlite3.Error:
+    rows = []
+finally:
+    if conn is not None:
+        conn.close()
+
+output_path.write_text(
+    "".join(
+        "\t".join(
+            [
+                str(row["task_id"]),
+                str(row["resource_key"]),
+                str(row["holder_id"]),
+                str(row["lease_pool_member_id"] or ""),
+                str(row["assigned_pool_member_id"] or ""),
+            ]
+        )
+        + "\n"
+        for row in rows
+    ),
+    encoding="utf-8",
+)
+PY
+}
+
+write_orphan_ssh_leases_file() {
+  local orphan_ssh_leases_file="$1"
+  : > "$orphan_ssh_leases_file"
+
+  [ -f "$DB_PATH" ] || return 0
+
+  python3 - "$DB_PATH" "$orphan_ssh_leases_file" <<'PY'
+import pathlib
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+output_path = pathlib.Path(sys.argv[2])
+conn = None
+
+try:
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        """
+        SELECT
+          l.task_id AS task_id,
+          l.resource_key AS resource_key,
+          l.holder_id AS holder_id,
+          COALESCE(l.pool_member_id, '') AS lease_pool_member_id,
+          COALESCE(t.status, '<missing>') AS task_status
+        FROM execution_resource_leases l
+        LEFT JOIN tasks t ON t.id = l.task_id
+        WHERE l.resource_type = 'ssh'
+          AND l.task_id IS NOT NULL
+          AND TRIM(l.task_id) != ''
+          AND l.lease_expires_at IS NOT NULL
+          AND julianday(l.lease_expires_at) > julianday('now')
+          AND (
+            COALESCE(t.status, '<missing>') != 'running'
+            OR t.selected_attempt_id IS NULL
+            OR TRIM(t.selected_attempt_id) = ''
+            OR NOT (
+              l.holder_id = t.selected_attempt_id
+              OR l.holder_id LIKE '%:' || t.selected_attempt_id
+            )
+          )
+        ORDER BY l.task_id, l.pool_member_id, l.resource_key
+        """
+    ).fetchall()
+except sqlite3.Error:
+    rows = []
+finally:
+    if conn is not None:
+        conn.close()
+
+output_path.write_text(
+    "".join(
+        "\t".join(
+            [
+                str(row["task_id"]),
+                str(row["resource_key"]),
+                str(row["holder_id"]),
+                str(row["lease_pool_member_id"]),
+                str(row["task_status"]),
+            ]
+        )
+        + "\n"
+        for row in rows
+    ),
+    encoding="utf-8",
+)
+PY
+}
+
+release_duplicate_ssh_lease() {
+  local task_id="$1"
+  local resource_key="$2"
+  local holder_id="$3"
+
+  if [ "$DRY_RUN" = true ]; then
+    echo "  dry-run: release duplicate SSH lease task=$task_id resource=$resource_key holder=$holder_id"
+    LAST_DISPATCH_SUBMITTED=true
+    return 0
+  fi
+
+  python3 - "$DB_PATH" "$task_id" "$resource_key" "$holder_id" <<'PY'
+import sqlite3
+import sys
+
+db_path, task_id, resource_key, holder_id = sys.argv[1:5]
+
+conn = sqlite3.connect(db_path)
+try:
+    with conn:
+        cursor = conn.execute(
+            """
+            DELETE FROM execution_resource_leases
+             WHERE task_id = ?
+               AND resource_key = ?
+               AND holder_id = ?
+            """,
+            (task_id, resource_key, holder_id),
+        )
+    if cursor.rowcount < 1:
+        print("no matching duplicate SSH lease row to release", file=sys.stderr)
+        sys.exit(1)
+finally:
+    conn.close()
+PY
+}
+
+reset_submission_state_after_repair() {
+  local reason="$1"
+  local now_epoch="$2"
+  local marker_dir="$3"
+  local backup_file="${SUBMISSIONS_FILE}.${now_epoch}.bak"
+
+  if [ "$RESET_STATE_AFTER_REPAIR" != true ]; then
+    echo "  skip retry-state reset after repair (disabled)"
+    return 0
+  fi
+
+  if [ "$DRY_RUN" = true ]; then
+    echo "  dry-run: reset retry state after repair ($reason): $SUBMISSIONS_FILE"
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$SUBMISSIONS_FILE")" "$marker_dir"
+  if [ -e "$SUBMISSIONS_FILE" ]; then
+    mv "$SUBMISSIONS_FILE" "$backup_file"
+  fi
+  : > "$SUBMISSIONS_FILE"
+  {
+    printf 'time=%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    printf 'reason=%s\n' "$reason"
+    printf 'state_file=%s\n' "$SUBMISSIONS_FILE"
+    printf 'backup_file=%s\n' "$backup_file"
+  } > "$marker_dir/retry-state-reset.txt"
+  echo "  reset retry state after repair: $SUBMISSIONS_FILE (backup: $backup_file)"
+}
+
 dispatch_no_track() {
   local kind="$1"
   local target="$2"
@@ -223,6 +738,7 @@ dispatch_no_track() {
   local now_epoch="$4"
   shift 4
 
+  LAST_DISPATCH_SUBMITTED=false
   if recently_submitted "$kind" "$target" "$cooldown" "$now_epoch"; then
     echo "  skip $kind $target (cooldown ${cooldown}s)"
     return 0
@@ -230,6 +746,7 @@ dispatch_no_track() {
 
   if [ "$DRY_RUN" = true ]; then
     echo "  dry-run: $*"
+    LAST_DISPATCH_SUBMITTED=true
     return 0
   fi
 
@@ -242,6 +759,7 @@ dispatch_no_track() {
   printf '%s\n' "$output"
   if [ "$code" -eq 0 ]; then
     record_submission "$kind" "$target" "$now_epoch"
+    LAST_DISPATCH_SUBMITTED=true
     return 0
   fi
   echo "  failed $kind $target (exit $code)" >&2
@@ -255,7 +773,16 @@ write_workflows_file() {
     printf '%s\n' "${WORKFLOW_FILTERS[@]}" > "$workflows_file"
     return
   fi
-  headless_workflow_ids query workflows --output label > "$workflows_file"
+  if [[ -n "${INVOKER_HEADLESS_WORKFLOW_IDS_FILE:-}" ]]; then
+    grep -E '^wf-[0-9]+-[0-9]+$' "$INVOKER_HEADLESS_WORKFLOW_IDS_FILE" > "$workflows_file" || true
+    return
+  fi
+  local raw_workflows_file="${workflows_file}.raw"
+  if ! bounded_headless_query query workflows --output label > "$raw_workflows_file"; then
+    echo "failed to query workflow ids" >&2
+    return 1
+  fi
+  grep -E '^wf-[0-9]+-[0-9]+$' "$raw_workflows_file" > "$workflows_file" || true
 }
 
 collect_tasks_jsonl() {
@@ -266,37 +793,124 @@ collect_tasks_jsonl() {
   local wf_id=""
   while IFS= read -r wf_id; do
     [ -n "$wf_id" ] || continue
-    headless_query query tasks --workflow "$wf_id" --output jsonl \
-      | grep '^{' >> "$tasks_file" || true
+    local raw_tasks_file="${tasks_file}.${wf_id}.raw"
+    if ! bounded_headless_query query tasks --workflow "$wf_id" --output jsonl > "$raw_tasks_file"; then
+      echo "failed to query tasks for workflow $wf_id" >&2
+      return 1
+    fi
+    grep '^{' "$raw_tasks_file" >> "$tasks_file" || true
   done < "$workflows_file"
 }
 
-build_targets() {
-  local tasks_file="$1"
-  local pending_workflows_file="$2"
-  local failed_tasks_file="$3"
-  local approvals_file="$4"
-  local localize_ssh_file="$5"
-  local infra_retry_file="$6"
+write_retry_workflows_file() {
+  local retry_workflows_file="$1"
+  local workflows_jsonl="$2"
+  : > "$retry_workflows_file"
+  : > "$workflows_jsonl"
 
-  python3 - "$tasks_file" "$pending_workflows_file" "$failed_tasks_file" "$approvals_file" "$localize_ssh_file" "$infra_retry_file" "$INCLUDE_MERGE" <<'PY'
+  local raw_workflows_file="${workflows_jsonl}.raw"
+  if ! bounded_headless_query query workflows --output jsonl > "$raw_workflows_file"; then
+    echo "failed to query workflow statuses" >&2
+    return 1
+  fi
+  grep '^{' "$raw_workflows_file" > "$workflows_jsonl" || true
+
+  python3 - "$retry_workflows_file" "$workflows_jsonl" "${WORKFLOW_FILTERS[@]}" <<'PY'
 import json
 import pathlib
 import sys
 
+output_path = pathlib.Path(sys.argv[1])
+workflows_path = pathlib.Path(sys.argv[2])
+filters = set(sys.argv[3:])
+terminal_statuses = {"completed", "complete", "review_ready"}
+targets = []
+
+for raw in workflows_path.read_text(encoding="utf-8").splitlines():
+    raw = raw.strip()
+    if not raw.startswith("{"):
+        continue
+    try:
+        workflow = json.loads(raw)
+    except json.JSONDecodeError:
+        continue
+    workflow_id = str(workflow.get("id") or "")
+    if not workflow_id:
+        continue
+    if filters and workflow_id not in filters:
+        continue
+    if str(workflow.get("status") or "") in terminal_statuses:
+        continue
+    targets.append(workflow_id)
+
+output_path.write_text(
+    "".join(f"{workflow_id}\n" for workflow_id in sorted(set(targets))),
+    encoding="utf-8",
+)
+PY
+}
+
+build_targets() {
+  local tasks_file="$1"
+  local queue_file="$2"
+  local pending_workflows_file="$3"
+  local failed_tasks_file="$4"
+  local approvals_file="$5"
+  local localize_ssh_file="$6"
+  local infra_retry_file="$7"
+  local auto_fix_attempts_file="$8"
+  local stale_fixing_file="$9"
+  local stale_active_queue_file="${10}"
+  local stale_running_file="${11}"
+  local stale_ssh_pin_file="${12}"
+  local pending_tasks_file="${13}"
+  local blocking_tasks_file="${14}"
+  local status_counts_file="${15}"
+  local now_epoch="${16}"
+
+  python3 - "$tasks_file" "$queue_file" "$pending_workflows_file" "$failed_tasks_file" "$approvals_file" "$localize_ssh_file" "$infra_retry_file" "$auto_fix_attempts_file" "$stale_fixing_file" "$stale_active_queue_file" "$stale_running_file" "$stale_ssh_pin_file" "$pending_tasks_file" "$blocking_tasks_file" "$status_counts_file" "$now_epoch" "$INCLUDE_MERGE" "$RECOVER_STALE_AI_STATES" "$STALE_AI_STATE_SECONDS" "$STALE_ACTIVE_QUEUE_SECONDS" <<'PY'
+import datetime
+import json
+import pathlib
+import sys
+from collections import Counter
+
 tasks_path = pathlib.Path(sys.argv[1])
-pending_workflows_path = pathlib.Path(sys.argv[2])
-failed_tasks_path = pathlib.Path(sys.argv[3])
-approvals_path = pathlib.Path(sys.argv[4])
-localize_ssh_path = pathlib.Path(sys.argv[5])
-infra_retry_path = pathlib.Path(sys.argv[6])
-include_merge = sys.argv[7] == "true"
+queue_path = pathlib.Path(sys.argv[2])
+pending_workflows_path = pathlib.Path(sys.argv[3])
+failed_tasks_path = pathlib.Path(sys.argv[4])
+approvals_path = pathlib.Path(sys.argv[5])
+localize_ssh_path = pathlib.Path(sys.argv[6])
+infra_retry_path = pathlib.Path(sys.argv[7])
+auto_fix_attempts_path = pathlib.Path(sys.argv[8])
+stale_fixing_path = pathlib.Path(sys.argv[9])
+stale_active_queue_path = pathlib.Path(sys.argv[10])
+stale_running_path = pathlib.Path(sys.argv[11])
+stale_ssh_pin_path = pathlib.Path(sys.argv[12])
+pending_tasks_path = pathlib.Path(sys.argv[13])
+blocking_tasks_path = pathlib.Path(sys.argv[14])
+status_counts_path = pathlib.Path(sys.argv[15])
+now_epoch = int(sys.argv[16])
+include_merge = sys.argv[17] == "true"
+recover_stale_ai_states = sys.argv[18] == "true"
+stale_ai_state_seconds = int(sys.argv[19])
+stale_active_queue_seconds = int(sys.argv[20])
 
 pending_workflows = set()
+pending_tasks = []
+blocking_tasks = []
 failed_tasks = []
 approvals = []
 localize_ssh = []
 infra_retry = []
+stale_fixing = []
+stale_active_queue = []
+stale_running = []
+stale_ssh_pin = []
+auto_fix_attempts = {}
+status_counts = Counter()
+terminal_task_statuses = {"completed", "complete", "review_ready"}
+active_queue_task_ids = set()
 
 INFRA_FAILURE_PATTERNS = (
     "Execution stalled:",
@@ -310,6 +924,79 @@ INFRA_FAILURE_PATTERNS = (
 
 def is_infra_failure(error_text: str) -> bool:
     return any(pattern in error_text for pattern in INFRA_FAILURE_PATTERNS)
+
+def parse_attempts(value) -> int:
+    try:
+        return max(0, int(value))
+    except (TypeError, ValueError):
+        return 0
+
+def parse_epoch(value):
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        epoch = float(value)
+        return epoch / 1000 if epoch > 10_000_000_000 else epoch
+    text = str(value).strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=datetime.timezone.utc)
+    return dt.timestamp()
+
+def is_stale_ai_state(execution: dict) -> bool:
+    if not recover_stale_ai_states:
+        return False
+    if stale_ai_state_seconds <= 0:
+        return True
+    epochs = [
+        parse_epoch(execution.get("lastHeartbeatAt")),
+        parse_epoch(execution.get("startedAt")),
+    ]
+    latest_epoch = max((epoch for epoch in epochs if epoch is not None), default=None)
+    if latest_epoch is None:
+        return True
+    return (now_epoch - latest_epoch) >= stale_ai_state_seconds
+
+def is_stale_active_queue(execution: dict) -> bool:
+    if stale_active_queue_seconds <= 0:
+        return True
+    epochs = [
+        parse_epoch(execution.get("lastHeartbeatAt")),
+        parse_epoch(execution.get("launchStartedAt")),
+        parse_epoch(execution.get("startedAt")),
+    ]
+    latest_epoch = max((epoch for epoch in epochs if epoch is not None), default=None)
+    if latest_epoch is None:
+        return False
+    return (now_epoch - latest_epoch) >= stale_active_queue_seconds
+
+def collect_queue_task_ids(value):
+    if isinstance(value, dict):
+        task_id = value.get("taskId") or value.get("id")
+        if task_id:
+            active_queue_task_ids.add(str(task_id))
+        for nested in value.values():
+            if isinstance(nested, (dict, list)):
+                collect_queue_task_ids(nested)
+    elif isinstance(value, list):
+        for item in value:
+            collect_queue_task_ids(item)
+
+if queue_path.exists() and queue_path.stat().st_size > 0:
+    try:
+        queue = json.loads(queue_path.read_text(encoding="utf-8", errors="replace"))
+    except json.JSONDecodeError:
+        queue = {}
+    if isinstance(queue, dict):
+        collect_queue_task_ids(queue.get("running"))
+        collect_queue_task_ids(queue.get("queued"))
 
 for raw in tasks_path.read_text(encoding="utf-8").splitlines():
     raw = raw.strip()
@@ -325,6 +1012,8 @@ for raw in tasks_path.read_text(encoding="utf-8").splitlines():
         continue
     config = task.get("config") if isinstance(task.get("config"), dict) else {}
     execution = task.get("execution") if isinstance(task.get("execution"), dict) else {}
+    if isinstance(execution, dict) and task.get("createdAt") is not None:
+        execution = {**execution, "createdAt": task.get("createdAt")}
     workflow_id = (
         config.get("workflowId")
         or task.get("workflowId")
@@ -336,22 +1025,59 @@ for raw in tasks_path.read_text(encoding="utf-8").splitlines():
         continue
 
     runner_kind = config.get("runnerKind")
+    pool_id = config.get("poolId")
+    pool_member_id = config.get("poolMemberId")
     error_text = str(execution.get("error") or task.get("error") or "")
+    status_text = str(status or "")
+    status_counts[status_text or "unknown"] += 1
 
-    if status == "pending" and workflow_id:
+    has_prior_launch_metadata = bool(execution.get("workspacePath") or execution.get("branch"))
+    has_launch_claim = bool(execution.get("launchStartedAt") or execution.get("phase"))
+    if (
+        status == "pending"
+        and task_id in active_queue_task_ids
+        and runner_kind == "ssh"
+        and pool_id
+        and pool_member_id
+        and has_prior_launch_metadata
+        and not has_launch_claim
+    ):
+        stale_ssh_pin.append(task_id)
+
+    if task_id in active_queue_task_ids and status_text not in terminal_task_statuses:
+        if status == "pending" and is_stale_active_queue(execution):
+            if workflow_id:
+                pending_workflows.add(str(workflow_id))
+            pending_tasks.append(task_id)
+            stale_active_queue.append(task_id)
+            continue
+        if status == "running" and is_stale_active_queue(execution):
+            stale_running.append(task_id)
+            continue
+        blocking_tasks.append(task_id)
+    elif status == "pending" and workflow_id:
         pending_workflows.add(str(workflow_id))
-        if runner_kind == "ssh":
-            localize_ssh.append(task_id)
+        pending_tasks.append(task_id)
     elif status == "failed":
+        blocking_tasks.append(task_id)
         failed_tasks.append(task_id)
+        auto_fix_attempts[task_id] = parse_attempts(execution.get("autoFixAttempts"))
         if is_infra_failure(error_text):
             infra_retry.append(task_id)
         if runner_kind == "ssh":
             localize_ssh.append(task_id)
-    elif status == "awaiting_approval" and execution.get("pendingFixError"):
-        if runner_kind == "ssh":
-            localize_ssh.append(task_id)
+    elif status == "fixing_with_ai" or (status == "running" and execution.get("isFixingWithAI") is True):
+        blocking_tasks.append(task_id)
+        if is_stale_ai_state(execution):
+            stale_fixing.append(task_id)
+    elif status == "running" and is_stale_active_queue(execution):
+        stale_running.append(task_id)
+    elif status in {"awaiting_approval", "review_ready"} and execution.get("pendingFixError"):
+        if status != "review_ready":
+            blocking_tasks.append(task_id)
         approvals.append(task_id)
+    elif status_text not in terminal_task_statuses and status_text != "pending":
+        blocking_tasks.append(task_id)
 
 pending_workflows_path.write_text(
     "".join(f"{workflow_id}\n" for workflow_id in sorted(pending_workflows)),
@@ -373,6 +1099,38 @@ infra_retry_path.write_text(
     "".join(f"{task_id}\n" for task_id in sorted(set(infra_retry))),
     encoding="utf-8",
 )
+auto_fix_attempts_path.write_text(
+    "".join(f"{task_id}\t{auto_fix_attempts[task_id]}\n" for task_id in sorted(auto_fix_attempts)),
+    encoding="utf-8",
+)
+stale_fixing_path.write_text(
+    "".join(f"{task_id}\n" for task_id in sorted(set(stale_fixing))),
+    encoding="utf-8",
+)
+stale_active_queue_path.write_text(
+    "".join(f"{task_id}\n" for task_id in sorted(set(stale_active_queue))),
+    encoding="utf-8",
+)
+stale_running_path.write_text(
+    "".join(f"{task_id}\n" for task_id in sorted(set(stale_running))),
+    encoding="utf-8",
+)
+stale_ssh_pin_path.write_text(
+    "".join(f"{task_id}\n" for task_id in sorted(set(stale_ssh_pin))),
+    encoding="utf-8",
+)
+pending_tasks_path.write_text(
+    "".join(f"{task_id}\n" for task_id in sorted(set(pending_tasks))),
+    encoding="utf-8",
+)
+blocking_tasks_path.write_text(
+    "".join(f"{task_id}\n" for task_id in sorted(set(blocking_tasks))),
+    encoding="utf-8",
+)
+status_counts_path.write_text(
+    "".join(f"{status}\t{count}\n" for status, count in sorted(status_counts.items())),
+    encoding="utf-8",
+)
 PY
 }
 
@@ -385,6 +1143,371 @@ count_lines() {
   wc -l < "$file" | tr -d ' '
 }
 
+write_pending_investigation_prompt() {
+  local target="$1"
+  local prompt_file="$2"
+  local tasks_file="$3"
+  local workflows_jsonl="$4"
+  local queue_file="$5"
+  local audit_file="$6"
+  local status_counts_file="$7"
+  local repro_slug="$8"
+
+  python3 - "$target" "$prompt_file" "$tasks_file" "$workflows_jsonl" "$queue_file" "$audit_file" "$status_counts_file" "$repro_slug" "$REPO_ROOT" <<'PY'
+import json
+import pathlib
+import sys
+
+target = sys.argv[1]
+prompt_path = pathlib.Path(sys.argv[2])
+tasks_path = pathlib.Path(sys.argv[3])
+workflows_path = pathlib.Path(sys.argv[4])
+queue_path = pathlib.Path(sys.argv[5])
+audit_path = pathlib.Path(sys.argv[6])
+status_counts_path = pathlib.Path(sys.argv[7])
+repro_slug = sys.argv[8]
+repo_root = pathlib.Path(sys.argv[9])
+
+workflow_id = target.split("/", 1)[0] if "/" in target else (
+    target.removeprefix("__merge__") if target.startswith("__merge__wf-") else target
+)
+
+def read_jsonl(path):
+    rows = []
+    if not path.exists():
+        return rows
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        raw = raw.strip()
+        if not raw.startswith("{"):
+            continue
+        try:
+            rows.append(json.loads(raw))
+        except json.JSONDecodeError:
+            continue
+    return rows
+
+def read_json(path):
+    if not path.exists() or path.stat().st_size == 0:
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8", errors="replace"))
+    except json.JSONDecodeError:
+        return path.read_text(encoding="utf-8", errors="replace")[-12000:]
+
+def truncate_text(value, limit=4000):
+    if value is None:
+        return None
+    text = str(value)
+    if len(text) <= limit:
+        return text
+    return text[:limit] + f"\n... truncated {len(text) - limit} chars ..."
+
+def compact_config(config):
+    if not isinstance(config, dict):
+        return {}
+    keys = (
+        "workflowId",
+        "runnerKind",
+        "poolId",
+        "poolMemberId",
+        "isMergeNode",
+        "command",
+        "executionAgent",
+    )
+    return {key: config.get(key) for key in keys if key in config}
+
+def compact_execution(execution):
+    if not isinstance(execution, dict):
+        return {}
+    keys = (
+        "phase",
+        "selectedAttemptId",
+        "generation",
+        "autoFixAttempts",
+        "isFixingWithAI",
+        "lastHeartbeatAt",
+        "launchStartedAt",
+        "launchCompletedAt",
+        "startedAt",
+        "completedAt",
+        "exitCode",
+        "error",
+        "branch",
+        "commit",
+    )
+    result = {key: execution.get(key) for key in keys if key in execution}
+    if "error" in result:
+        result["error"] = truncate_text(result["error"], 4000)
+    return result
+
+def compact_task(task, include_description=False):
+    if not isinstance(task, dict):
+        return None
+    result = {
+        "id": task.get("id"),
+        "status": task.get("status"),
+        "dependencies": task.get("dependencies") if isinstance(task.get("dependencies"), list) else [],
+        "config": compact_config(task.get("config")),
+        "execution": compact_execution(task.get("execution")),
+    }
+    if include_description:
+        result["description"] = truncate_text(task.get("description"), 3000)
+    return result
+
+def compact_workflow(workflow):
+    if not isinstance(workflow, dict):
+        return None
+    keys = (
+        "id",
+        "name",
+        "status",
+        "generation",
+        "baseBranch",
+        "featureBranch",
+        "mergeMode",
+        "onFinish",
+        "updatedAt",
+    )
+    return {key: workflow.get(key) for key in keys if key in workflow}
+
+def compact_queue_item(item):
+    if isinstance(item, dict):
+        keys = ("taskId", "id", "attemptId", "state", "status", "priority")
+        return {key: item.get(key) for key in keys if key in item}
+    return item
+
+def compact_queue(queue):
+    if not isinstance(queue, dict):
+        return truncate_text(queue, 12000) if queue is not None else None
+    result = {}
+    for key in ("maxConcurrency", "runningCount", "queuedCount", "fixingCount"):
+        if key in queue:
+            result[key] = queue.get(key)
+    for key in ("running", "queued"):
+        value = queue.get(key)
+        if isinstance(value, list):
+            result[key] = [compact_queue_item(item) for item in value[:80]]
+            if len(value) > 80:
+                result[f"{key}Truncated"] = len(value) - 80
+    return result
+
+def compact_audit_event(event):
+    if not isinstance(event, dict):
+        return truncate_text(event, 2000)
+    result = {}
+    for key in ("id", "createdAt", "eventType", "taskId"):
+        if key in event:
+            result[key] = event.get(key)
+    if "payload" in event:
+        result["payload"] = truncate_text(event.get("payload"), 2000)
+    return result
+
+def compact_audit(audit):
+    if isinstance(audit, list):
+        return [compact_audit_event(event) for event in audit[-80:]]
+    if isinstance(audit, dict):
+        result = {}
+        for key, value in audit.items():
+            if isinstance(value, list):
+                result[key] = [compact_audit_event(event) for event in value[-80:]]
+                if len(value) > 80:
+                    result[f"{key}Truncated"] = len(value) - 80
+            elif isinstance(value, (dict, str)):
+                result[key] = truncate_text(json.dumps(value, sort_keys=True) if isinstance(value, dict) else value, 4000)
+            else:
+                result[key] = value
+        return result
+    return truncate_text(audit, 12000) if audit is not None else None
+
+tasks = read_jsonl(tasks_path)
+workflows = read_jsonl(workflows_path)
+task = next((item for item in tasks if str(item.get("id") or "") == target), None)
+workflow = next((item for item in workflows if str(item.get("id") or "") == workflow_id), None)
+workflow_tasks = [
+    compact_task(item) for item in tasks
+    if str((item.get("config") or {}).get("workflowId") or item.get("workflowId") or "").strip() == workflow_id
+    or str(item.get("id") or "").startswith(workflow_id + "/")
+    or str(item.get("id") or "") == "__merge__" + workflow_id
+]
+task_snapshot = compact_task(task, include_description=True)
+workflow_snapshot = compact_workflow(workflow)
+queue_snapshot = compact_queue(read_json(queue_path))
+audit_snapshot = compact_audit(read_json(audit_path))
+status_counts = status_counts_path.read_text(encoding="utf-8", errors="replace") if status_counts_path.exists() else ""
+
+body = f"""You are Codex running locally in this repository:
+{repo_root}
+
+Goal:
+Investigate why this task did not run.
+
+Task to investigate:
+{target}
+
+Required outcome:
+- Identify the root cause that left this task pending/running without launch progress.
+- Fix the root cause in the smallest appropriate way.
+- Add a reproducible script at scripts/repro/repro-pending-task-did-not-run-{repro_slug}.sh.
+- The repro script must prove the root cause: demonstrate the pending/running non-launch condition before the fix and pass after the fix.
+- If the root cause is environmental or stale local state and cannot be forced in-process, the repro script must capture and assert the diagnostic condition that prevented launch.
+- Run the repro script and the smallest relevant regression command.
+- If the fix touches TypeScript or bundled runtime code used by headless Invoker, rebuild the smallest necessary artifact before returning.
+- Do not submit Invoker workflows from this Codex session. Work directly in the local checkout.
+- Do not edit unrelated files.
+
+Important context:
+- This Codex session was invoked by scripts/retry-pending-autofix-failed.sh because the retry loop drained to pending work.
+- The bug to investigate is not "make this one task complete"; it is why Invoker did not launch the task or let it make progress after retries.
+- If the root cause is environmental or stale local state rather than repo code, document the evidence and make the repro script capture the condition if possible.
+- Evidence snapshots below are compacted to avoid exceeding Codex input limits; use headless queries locally if you need more detail.
+
+Status counts for scanned tasks:
+```text
+{status_counts.strip()}
+```
+
+Task JSON:
+```json
+{json.dumps(task_snapshot, indent=2, sort_keys=True) if task_snapshot is not None else "null"}
+```
+
+Workflow JSON:
+```json
+{json.dumps(workflow_snapshot, indent=2, sort_keys=True) if workflow_snapshot is not None else "null"}
+```
+
+Workflow task snapshot:
+```json
+{json.dumps(workflow_tasks, indent=2, sort_keys=True)}
+```
+
+Queue snapshot:
+```json
+{json.dumps(queue_snapshot, indent=2, sort_keys=True) if not isinstance(queue_snapshot, str) else queue_snapshot}
+```
+
+Task audit:
+```json
+{json.dumps(audit_snapshot, indent=2, sort_keys=True) if not isinstance(audit_snapshot, str) else audit_snapshot}
+```
+"""
+prompt_path.write_text(body, encoding="utf-8")
+PY
+}
+
+run_pending_investigations() {
+  local pending_tasks_file="$1"
+  local blocking_tasks_file="$2"
+  local tasks_file="$3"
+  local workflows_jsonl="$4"
+  local queue_file="$5"
+  local status_counts_file="$6"
+  local now_epoch="$7"
+  local cycle_dir="$8"
+
+  if [ "$INVESTIGATE_PENDING" != true ]; then
+    return 0
+  fi
+  if [ ! -s "$pending_tasks_file" ]; then
+    return 0
+  fi
+  if [ -s "$blocking_tasks_file" ]; then
+    echo "pending investigation deferred (non-pending blockers remain: $(count_lines "$blocking_tasks_file"))"
+    return 0
+  fi
+
+  if [ "$DRY_RUN" != true ] && ! command -v "$CODEX_COMMAND" >/dev/null 2>&1; then
+    echo "  failed investigate-pending: codex command not found: $CODEX_COMMAND" >&2
+    return 1
+  fi
+
+  echo "investigating pending tasks with local Codex"
+  local target=""
+  local failures=0
+  local successes=0
+  local planned=0
+  local batch_stamp
+  batch_stamp="$(date -u +%Y%m%dT%H%M%SZ)"
+
+  while IFS= read -r target; do
+    [ -n "$target" ] || continue
+    if recently_submitted investigate-pending "$target" "$INVESTIGATE_COOLDOWN_SECONDS" "$now_epoch"; then
+      echo "  skip investigate-pending $target (cooldown ${INVESTIGATE_COOLDOWN_SECONDS}s)"
+      continue
+    fi
+
+    local slug repro_slug task_dir prompt_file audit_file stdout_file stderr_file last_message_file code
+    slug="$(slugify_id "$target")"
+    repro_slug="$slug"
+    if [ "$DRY_RUN" = true ]; then
+      task_dir="$cycle_dir/investigate-$slug"
+    else
+      task_dir="$INVESTIGATION_DIR/$batch_stamp-$slug"
+    fi
+    mkdir -p "$task_dir"
+    prompt_file="$task_dir/prompt.md"
+    audit_file="$task_dir/audit.json"
+    stdout_file="$task_dir/codex.stdout.log"
+    stderr_file="$task_dir/codex.stderr.log"
+    last_message_file="$task_dir/codex.last-message.md"
+
+    bounded_headless_query query audit "$target" --output json > "$audit_file" || true
+    write_pending_investigation_prompt "$target" "$prompt_file" "$tasks_file" "$workflows_jsonl" "$queue_file" "$audit_file" "$status_counts_file" "$repro_slug"
+    local prompt_bytes
+    prompt_bytes="$(wc -c < "$prompt_file" | tr -d ' ')"
+    echo "  investigate-pending prompt $target (${prompt_bytes} bytes)"
+    if [ "$prompt_bytes" -gt "$CODEX_PROMPT_MAX_BYTES" ]; then
+      echo "  failed investigate-pending $target (prompt too large: ${prompt_bytes} bytes)" >&2
+      failures=$((failures + 1))
+      continue
+    fi
+
+    if [ "$DRY_RUN" = true ]; then
+      echo "  dry-run: $CODEX_COMMAND --ask-for-approval never exec --cd $REPO_ROOT --sandbox workspace-write --output-last-message $last_message_file - < $prompt_file"
+      planned=$((planned + 1))
+      continue
+    fi
+
+    set +e
+    "$CODEX_COMMAND" --ask-for-approval never exec \
+      --cd "$REPO_ROOT" \
+      --sandbox workspace-write \
+      --output-last-message "$last_message_file" \
+      - < "$prompt_file" > "$stdout_file" 2> "$stderr_file"
+    code=$?
+    set -e
+
+    if [ "$code" -eq 0 ]; then
+      echo "  investigated pending task with Codex: $target"
+      record_submission investigate-pending "$target" "$now_epoch"
+      successes=$((successes + 1))
+      reset_submission_state_after_repair "pending-investigation" "$now_epoch" "$INVESTIGATION_DIR/$batch_stamp-state-reset"
+      SKIP_SLEEP_AFTER_CYCLE=true
+      return 0
+    else
+      echo "  failed investigate-pending $target (exit $code; logs: $task_dir)" >&2
+      failures=$((failures + 1))
+    fi
+  done < "$pending_tasks_file"
+
+  if [ "$DRY_RUN" = true ]; then
+    if [ "$planned" -gt 0 ]; then
+      reset_submission_state_after_repair "dry-run-pending-investigation" "$now_epoch" "$cycle_dir"
+    fi
+    return 0
+  fi
+
+  if [ "$successes" -gt 0 ]; then
+    reset_submission_state_after_repair "pending-investigation" "$now_epoch" "$INVESTIGATION_DIR/$batch_stamp-state-reset"
+    SKIP_SLEEP_AFTER_CYCLE=true
+  fi
+
+  if [ "$failures" -gt 0 ]; then
+    return 1
+  fi
+  return 0
+}
+
 run_cycle() {
   local cycle="$1"
   local now_epoch
@@ -393,36 +1516,87 @@ run_cycle() {
   local cycle_dir="$STATE_DIR/cycle-$cycle"
   mkdir -p "$cycle_dir"
   local workflows_file="$cycle_dir/workflows.txt"
+  local workflow_status_jsonl="$cycle_dir/workflows-status.jsonl"
+  local retry_workflows_file="$cycle_dir/retry-workflows.txt"
+  local queue_file="$cycle_dir/queue.json"
   local tasks_file="$cycle_dir/tasks.jsonl"
   local pending_workflows_file="$cycle_dir/pending-workflows.txt"
+  local pending_tasks_file="$cycle_dir/pending-tasks.txt"
+  local blocking_tasks_file="$cycle_dir/blocking-tasks.txt"
+  local effective_blocking_tasks_file="$cycle_dir/effective-blocking-tasks.txt"
+  local status_counts_file="$cycle_dir/status-counts.tsv"
   local failed_tasks_file="$cycle_dir/failed-tasks.txt"
+  local exhausted_fixes_file="$cycle_dir/exhausted-fixes.txt"
   local approvals_file="$cycle_dir/fix-approvals.txt"
   local localize_ssh_file="$cycle_dir/localize-ssh.txt"
   local infra_retry_file="$cycle_dir/infra-retry.txt"
+  local auto_fix_attempts_file="$cycle_dir/auto-fix-attempts.tsv"
+  local stale_fixing_file="$cycle_dir/stale-fixing-ai.txt"
+  local stale_active_queue_file="$cycle_dir/stale-active-queue-pending.txt"
+  local stale_running_file="$cycle_dir/stale-running.txt"
+  local stale_ssh_pin_file="$cycle_dir/stale-ssh-pin.txt"
+  local duplicate_ssh_leases_file="$cycle_dir/duplicate-ssh-leases.tsv"
+  local orphan_ssh_leases_file="$cycle_dir/orphan-ssh-leases.tsv"
+  local stale_investigation_file="$cycle_dir/stale-investigation-tasks.txt"
+  local retried_workflows_file="$cycle_dir/retried-workflows.txt"
   local retried_failed_tasks_file="$cycle_dir/retried-failed-tasks.txt"
   local localized_failed_tasks_file="$cycle_dir/localized-failed-tasks.txt"
   local localized_workflows_file="$cycle_dir/localized-workflows.txt"
+  local cleared_ssh_pin_tasks_file="$cycle_dir/cleared-ssh-pin-tasks.txt"
+  local cleared_ssh_pin_workflows_file="$cycle_dir/cleared-ssh-pin-workflows.txt"
+  local released_duplicate_ssh_leases_file="$cycle_dir/released-duplicate-ssh-leases.tsv"
+  local released_orphan_ssh_leases_file="$cycle_dir/released-orphan-ssh-leases.tsv"
+  : > "$retried_workflows_file"
   : > "$retried_failed_tasks_file"
   : > "$localized_failed_tasks_file"
   : > "$localized_workflows_file"
+  : > "$cleared_ssh_pin_tasks_file"
+  : > "$cleared_ssh_pin_workflows_file"
+  : > "$released_duplicate_ssh_leases_file"
+  : > "$released_orphan_ssh_leases_file"
 
-  write_workflows_file "$workflows_file"
+  if ! write_workflows_file "$workflows_file"; then
+    echo "cycle $cycle: failed to collect workflow ids" >&2
+    return 1
+  fi
   if [ ! -s "$workflows_file" ]; then
     echo "cycle $cycle: no workflows found"
     return 0
   fi
 
-  collect_tasks_jsonl "$workflows_file" "$tasks_file"
-  build_targets "$tasks_file" "$pending_workflows_file" "$failed_tasks_file" "$approvals_file" "$localize_ssh_file" "$infra_retry_file"
+  if ! write_retry_workflows_file "$retry_workflows_file" "$workflow_status_jsonl"; then
+    echo "cycle $cycle: failed to collect workflow statuses" >&2
+    return 1
+  fi
+  bounded_headless_query query queue --output json > "$queue_file" || printf '{}\n' > "$queue_file"
+  if ! collect_tasks_jsonl "$workflows_file" "$tasks_file"; then
+    echo "cycle $cycle: failed to collect task states" >&2
+    return 1
+  fi
+  build_targets "$tasks_file" "$queue_file" "$pending_workflows_file" "$failed_tasks_file" "$approvals_file" "$localize_ssh_file" "$infra_retry_file" "$auto_fix_attempts_file" "$stale_fixing_file" "$stale_active_queue_file" "$stale_running_file" "$stale_ssh_pin_file" "$pending_tasks_file" "$blocking_tasks_file" "$status_counts_file" "$now_epoch"
+  write_duplicate_ssh_leases_file "$duplicate_ssh_leases_file"
+  write_orphan_ssh_leases_file "$orphan_ssh_leases_file"
+  write_exhausted_fixes_file "$failed_tasks_file" "$auto_fix_attempts_file" "$exhausted_fixes_file"
+  write_effective_blockers_file "$blocking_tasks_file" "$exhausted_fixes_file" "$effective_blocking_tasks_file"
 
-  local pending_count failed_count approval_count localize_count infra_retry_count
+  local retry_workflow_count pending_count pending_task_count blocking_task_count failed_count exhausted_fix_count approval_count localize_count infra_retry_count stale_fixing_count stale_active_queue_count stale_running_count stale_ssh_pin_count duplicate_ssh_lease_count orphan_ssh_lease_count
+  retry_workflow_count="$(count_lines "$retry_workflows_file")"
   pending_count="$(count_lines "$pending_workflows_file")"
+  pending_task_count="$(count_lines "$pending_tasks_file")"
+  blocking_task_count="$(count_lines "$effective_blocking_tasks_file")"
   failed_count="$(count_lines "$failed_tasks_file")"
+  exhausted_fix_count="$(count_lines "$exhausted_fixes_file")"
   approval_count="$(count_lines "$approvals_file")"
   localize_count="$(count_lines "$localize_ssh_file")"
   infra_retry_count="$(count_lines "$infra_retry_file")"
+  stale_fixing_count="$(count_lines "$stale_fixing_file")"
+  stale_active_queue_count="$(count_lines "$stale_active_queue_file")"
+  stale_running_count="$(count_lines "$stale_running_file")"
+  stale_ssh_pin_count="$(count_lines "$stale_ssh_pin_file")"
+  duplicate_ssh_lease_count="$(count_lines "$duplicate_ssh_leases_file")"
+  orphan_ssh_lease_count="$(count_lines "$orphan_ssh_leases_file")"
 
-  echo "cycle $cycle: pending-workflows=$pending_count failed-tasks=$failed_count infra-retry=$infra_retry_count fix-approvals=$approval_count ssh-to-worktree=$localize_count"
+  echo "cycle $cycle: retry-workflows=$retry_workflow_count pending-workflows=$pending_count pending-tasks=$pending_task_count blockers=$blocking_task_count failed-tasks=$failed_count exhausted-fixes=$exhausted_fix_count infra-retry=$infra_retry_count fix-approvals=$approval_count stale-fixing=$stale_fixing_count stale-queue-pending=$stale_active_queue_count stale-running=$stale_running_count stale-ssh-pin=$stale_ssh_pin_count duplicate-ssh-lease=$duplicate_ssh_lease_count orphan-ssh-lease=$orphan_ssh_lease_count ssh-to-worktree=$localize_count"
 
   local failures=0
   local target=""
@@ -431,10 +1605,16 @@ run_cycle() {
     echo "switching SSH-assigned recovery tasks to local worktrees"
     while IFS= read -r target; do
       [ -n "$target" ] || continue
+      if ever_submitted localize-worktree "$target"; then
+        echo "  skip localize-worktree $target (already switched by this loop)"
+        continue
+      fi
       if dispatch_no_track localize-worktree "$target" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch" set executor "$target" worktree; then
-        printf '%s\n' "$target" >> "$localized_failed_tasks_file"
-        if [[ "$target" == */* ]]; then
-          printf '%s\n' "${target%%/*}" >> "$localized_workflows_file"
+        if [ "$LAST_DISPATCH_SUBMITTED" = true ]; then
+          printf '%s\n' "$target" >> "$localized_failed_tasks_file"
+          if [[ "$target" == */* ]]; then
+            printf '%s\n' "${target%%/*}" >> "$localized_workflows_file"
+          fi
         fi
       else
         failures=$((failures + 1))
@@ -442,10 +1622,129 @@ run_cycle() {
     done < "$localize_ssh_file"
   fi
 
+  if [ -s "$stale_ssh_pin_file" ]; then
+    echo "clearing stale explicit SSH pool member pins"
+    while IFS= read -r target; do
+      [ -n "$target" ] || continue
+      if recently_submitted clear-ssh-pin "$target" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch"; then
+        echo "  skip clear-ssh-pin $target (cleared recently)"
+        continue
+      fi
+      if dispatch_no_track clear-ssh-pin "$target" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch" set executor "$target" ssh; then
+        if [ "$LAST_DISPATCH_SUBMITTED" = true ]; then
+          printf '%s\n' "$target" >> "$cleared_ssh_pin_tasks_file"
+          if [[ "$target" == */* ]]; then
+            printf '%s\n' "${target%%/*}" >> "$cleared_ssh_pin_workflows_file"
+          fi
+        fi
+      else
+        failures=$((failures + 1))
+      fi
+    done < "$stale_ssh_pin_file"
+  fi
+
+  if [ -s "$orphan_ssh_leases_file" ]; then
+    echo "releasing active SSH leases for non-running tasks"
+    while IFS=$'\t' read -r target resource_key holder_id lease_pool_member_id task_status; do
+      [ -n "$target" ] || continue
+      local orphan_key
+      orphan_key="$target|$resource_key|$holder_id"
+      if recently_submitted release-orphan-ssh-lease "$orphan_key" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch"; then
+        echo "  skip release-orphan-ssh-lease $target $lease_pool_member_id (released recently)"
+        continue
+      fi
+      LAST_DISPATCH_SUBMITTED=false
+      if release_duplicate_ssh_lease "$target" "$resource_key" "$holder_id"; then
+        record_submission release-orphan-ssh-lease "$orphan_key" "$now_epoch"
+        LAST_DISPATCH_SUBMITTED=true
+        printf '%s\t%s\t%s\t%s\t%s\n' "$target" "$resource_key" "$holder_id" "$lease_pool_member_id" "$task_status" >> "$released_orphan_ssh_leases_file"
+        echo "  released orphan SSH lease $target status=$task_status member=$lease_pool_member_id resource=$resource_key"
+      else
+        failures=$((failures + 1))
+      fi
+    done < "$orphan_ssh_leases_file"
+  fi
+
+  if [ -s "$duplicate_ssh_leases_file" ]; then
+    echo "releasing duplicate selected-attempt SSH leases"
+    while IFS=$'\t' read -r target resource_key holder_id lease_pool_member_id assigned_pool_member_id; do
+      [ -n "$target" ] || continue
+      local duplicate_key
+      duplicate_key="$target|$resource_key|$holder_id"
+      if recently_submitted release-duplicate-ssh-lease "$duplicate_key" "$LOCALIZE_COOLDOWN_SECONDS" "$now_epoch"; then
+        echo "  skip release-duplicate-ssh-lease $target $lease_pool_member_id (released recently)"
+        continue
+      fi
+      LAST_DISPATCH_SUBMITTED=false
+      if release_duplicate_ssh_lease "$target" "$resource_key" "$holder_id"; then
+        record_submission release-duplicate-ssh-lease "$duplicate_key" "$now_epoch"
+        LAST_DISPATCH_SUBMITTED=true
+        printf '%s\t%s\t%s\t%s\t%s\n' "$target" "$resource_key" "$holder_id" "$lease_pool_member_id" "$assigned_pool_member_id" >> "$released_duplicate_ssh_leases_file"
+        echo "  released duplicate SSH lease $target member=$lease_pool_member_id assigned=$assigned_pool_member_id resource=$resource_key"
+      else
+        failures=$((failures + 1))
+      fi
+    done < "$duplicate_ssh_leases_file"
+  fi
+
+  if [ "$RETRY_INCOMPLETE_WORKFLOWS" = true ] && [ -s "$retry_workflows_file" ]; then
+    echo "retrying workflows not completed or review_ready"
+    while IFS= read -r target; do
+      [ -n "$target" ] || continue
+      if contains_line "$localized_workflows_file" "$target"; then
+        echo "  skip retry-workflow $target (executor switch queued this cycle)"
+        continue
+      fi
+      if contains_line "$cleared_ssh_pin_workflows_file" "$target"; then
+        echo "  skip retry-workflow $target (stale SSH pin cleared this cycle)"
+        continue
+      fi
+      if ever_submitted retry-workflow "$target"; then
+        echo "  skip retry-workflow $target (already retried by this loop)"
+        continue
+      fi
+      local retry_cooldown="$RESUME_COOLDOWN_SECONDS"
+      if [ "$retry_cooldown" -lt "$RESUME_DEDUPE_SECONDS" ]; then
+        retry_cooldown="$RESUME_DEDUPE_SECONDS"
+      fi
+      if dispatch_no_track retry-workflow "$target" "$retry_cooldown" "$now_epoch" retry "$target"; then
+        [ "$LAST_DISPATCH_SUBMITTED" = true ] || continue
+        printf '%s\n' "$target" >> "$retried_workflows_file"
+      else
+        failures=$((failures + 1))
+      fi
+    done < "$retry_workflows_file"
+  fi
+
+  if [ "$RECOVER_STALE_AI_STATES" = true ] && [ -s "$stale_fixing_file" ]; then
+    echo "recovering stale AI fix sessions"
+    while IFS= read -r target; do
+      [ -n "$target" ] || continue
+      local target_wf
+      target_wf="$(target_workflow_id "$target")"
+      if contains_line "$retried_workflows_file" "$target_wf"; then
+        echo "  skip recover-fixing $target (workflow retried this cycle)"
+        continue
+      fi
+      if contains_line "$localized_failed_tasks_file" "$target"; then
+        echo "  skip recover-fixing $target (executor switch queued this cycle)"
+        continue
+      fi
+      dispatch_no_track recover-fixing "$target" "$FIX_COOLDOWN_SECONDS" "$now_epoch" retry-task "$target" \
+        || failures=$((failures + 1))
+    done < "$stale_fixing_file"
+  fi
+
   if [ "$APPROVE_FIXES" = true ] && [ -s "$approvals_file" ]; then
     echo "approving AI fix approvals"
     while IFS= read -r target; do
       [ -n "$target" ] || continue
+      local target_wf
+      target_wf="$(target_workflow_id "$target")"
+      if contains_line "$retried_workflows_file" "$target_wf"; then
+        echo "  skip approve $target (workflow retried this cycle)"
+        continue
+      fi
       if contains_line "$localized_failed_tasks_file" "$target"; then
         echo "  skip approve $target (executor switch queued this cycle)"
         continue
@@ -459,6 +1758,12 @@ run_cycle() {
     echo "retrying failed tasks"
     while IFS= read -r target; do
       [ -n "$target" ] || continue
+      local target_wf
+      target_wf="$(target_workflow_id "$target")"
+      if contains_line "$retried_workflows_file" "$target_wf"; then
+        echo "  skip retry-failed $target (workflow retried this cycle)"
+        continue
+      fi
       if contains_line "$localized_failed_tasks_file" "$target"; then
         echo "  skip retry-failed $target (executor switch queued this cycle)"
         continue
@@ -473,6 +1778,7 @@ run_cycle() {
         continue
       fi
       if dispatch_no_track retry-failed "$target" 0 "$now_epoch" retry-task "$target"; then
+        [ "$LAST_DISPATCH_SUBMITTED" = true ] || continue
         printf '%s\n' "$target" >> "$retried_failed_tasks_file"
       else
         failures=$((failures + 1))
@@ -484,6 +1790,12 @@ run_cycle() {
     echo "submitting Codex fixes for failed tasks"
     while IFS= read -r target; do
       [ -n "$target" ] || continue
+      local target_wf
+      target_wf="$(target_workflow_id "$target")"
+      if contains_line "$retried_workflows_file" "$target_wf"; then
+        echo "  skip fix $target (workflow retried this cycle)"
+        continue
+      fi
       if contains_line "$localized_failed_tasks_file" "$target"; then
         echo "  skip fix $target (executor switch queued this cycle)"
         continue
@@ -496,6 +1808,17 @@ run_cycle() {
         echo "  skip fix $target (retried this cycle)"
         continue
       fi
+      local fix_attempts task_attempts submitted_attempts
+      task_attempts="$(task_auto_fix_attempts "$auto_fix_attempts_file" "$target")"
+      submitted_attempts="$(submission_count fix "$target")"
+      fix_attempts="$submitted_attempts"
+      if [ "$task_attempts" -gt "$fix_attempts" ]; then
+        fix_attempts="$task_attempts"
+      fi
+      if [ "$fix_attempts" -ge "$MAX_FIX_ATTEMPTS" ]; then
+        echo "  skip fix $target (max fix attempts reached: $fix_attempts/$MAX_FIX_ATTEMPTS)"
+        continue
+      fi
       if recently_submitted fix "$target" "$FIX_DEDUPE_SECONDS" "$now_epoch"; then
         echo "  skip fix $target (fix submitted recently)"
         continue
@@ -505,21 +1828,40 @@ run_cycle() {
     done < "$failed_tasks_file"
   fi
 
-  if [ "$RESUME_PENDING" = true ] && [ -s "$pending_workflows_file" ]; then
-    echo "resuming workflows with pending tasks"
-    while IFS= read -r target; do
-      [ -n "$target" ] || continue
-      if contains_line "$localized_workflows_file" "$target"; then
-        echo "  skip resume $target (executor switch queued this cycle)"
-        continue
+  if [ "$failures" -eq 0 ]; then
+    if [ -s "$retried_workflows_file" ]; then
+      echo "pending investigation deferred (workflow retries submitted this cycle: $(count_lines "$retried_workflows_file"))"
+    elif [ -s "$localized_workflows_file" ]; then
+      echo "pending investigation deferred (executor switches submitted this cycle: $(count_lines "$localized_workflows_file"))"
+    elif [ -s "$cleared_ssh_pin_workflows_file" ]; then
+      echo "pending investigation deferred (stale SSH pins cleared this cycle: $(count_lines "$cleared_ssh_pin_workflows_file"))"
+    elif [ -s "$released_orphan_ssh_leases_file" ]; then
+      echo "pending investigation deferred (orphan SSH leases released this cycle: $(count_lines "$released_orphan_ssh_leases_file"))"
+    elif [ -s "$released_duplicate_ssh_leases_file" ]; then
+      echo "pending investigation deferred (duplicate SSH leases released this cycle: $(count_lines "$released_duplicate_ssh_leases_file"))"
+    else
+      local investigation_tasks_file="$pending_tasks_file"
+      local investigation_blockers_file="$effective_blocking_tasks_file"
+      if [ -s "$stale_active_queue_file" ] || [ -s "$stale_running_file" ]; then
+        : > "$stale_investigation_file"
+        cat "$stale_active_queue_file" "$stale_running_file" 2>/dev/null | sed '/^$/d' | sort -u > "$stale_investigation_file"
+        if [ -s "$stale_active_queue_file" ]; then
+          echo "pending investigation includes stale queue-active pending tasks: $(count_lines "$stale_active_queue_file")"
+        fi
+        if [ -s "$stale_running_file" ]; then
+          echo "pending investigation includes stale running tasks: $(count_lines "$stale_running_file")"
+        fi
+        investigation_tasks_file="$stale_investigation_file"
+        investigation_blockers_file="$cycle_dir/stale-investigation-blockers.txt"
+        : > "$investigation_blockers_file"
+        if [ -s "$effective_blocking_tasks_file" ]; then
+          echo "stale task investigation bypasses unrelated blockers: $(count_lines "$effective_blocking_tasks_file")"
+        fi
       fi
-      local resume_cooldown="$RESUME_COOLDOWN_SECONDS"
-      if [ "$resume_cooldown" -lt "$RESUME_DEDUPE_SECONDS" ]; then
-        resume_cooldown="$RESUME_DEDUPE_SECONDS"
+      if ! run_pending_investigations "$investigation_tasks_file" "$investigation_blockers_file" "$tasks_file" "$workflow_status_jsonl" "$queue_file" "$status_counts_file" "$now_epoch" "$cycle_dir"; then
+        failures=$((failures + 1))
       fi
-      dispatch_no_track resume "$target" "$resume_cooldown" "$now_epoch" resume "$target" \
-        || failures=$((failures + 1))
-    done < "$pending_workflows_file"
+    fi
   fi
 
   if [ "$failures" -gt 0 ]; then
@@ -529,13 +1871,633 @@ run_cycle() {
   return 0
 }
 
+run_self_tests() {
+  local test_root="$STATE_DIR/self-test"
+  local tasks_dir="$test_root/tasks"
+  local commands_file="$test_root/commands.log"
+  local codex_commands_file="$test_root/codex-commands.log"
+  local workflows_label_file="$test_root/workflows.label"
+  local workflows_jsonl_file="$test_root/workflows.jsonl"
+  local self_test_queue_file="$test_root/queue.json"
+  local fake_codex="$test_root/fake-codex"
+  mkdir -p "$tasks_dir" "$test_root"
+
+  cat > "$fake_codex" <<'SELFTEST_CODEX'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${SELF_TEST_CODEX_COMMANDS_FILE:?}"
+while [[ $# -gt 0 ]]; do
+  if [[ "$1" == "--output-last-message" ]]; then
+    shift
+    printf 'self-test codex ok\n' > "$1"
+    break
+  fi
+  shift
+done
+cat >/dev/null
+SELFTEST_CODEX
+  chmod +x "$fake_codex"
+
+  export SELF_TEST_CODEX_COMMANDS_FILE="$codex_commands_file"
+
+  bounded_headless_query() {
+    if [ "${SELF_TEST_QUERY_FAIL:-}" = "$*" ]; then
+      return 124
+    fi
+
+    if [ "$*" = "query workflows --output label" ]; then
+      cat "$workflows_label_file"
+      return 0
+    fi
+    if [ "$*" = "query workflows --output jsonl" ]; then
+      cat "$workflows_jsonl_file"
+      return 0
+    fi
+    if [ "$*" = "query queue --output json" ]; then
+      cat "$self_test_queue_file"
+      return 0
+    fi
+    if [ "${1:-}" = "query" ] && [ "${2:-}" = "tasks" ] && [ "${3:-}" = "--workflow" ]; then
+      local wf_id="${4:-}"
+      [ -f "$tasks_dir/$wf_id.jsonl" ] && cat "$tasks_dir/$wf_id.jsonl"
+      return 0
+    fi
+    if [ "${1:-}" = "query" ] && [ "${2:-}" = "audit" ]; then
+      printf '{}\n'
+      return 0
+    fi
+
+    echo "unexpected self-test query: $*" >&2
+    return 99
+  }
+
+  headless_mutation_no_track() {
+    printf '%s\n' "$*" >> "$commands_file"
+    printf '{"ok":true}\n'
+    return 0
+  }
+
+  self_test_fail() {
+    echo "SELF-TEST FAIL: $*" >&2
+    return 1
+  }
+
+  self_test_assert_contains() {
+    local file="$1"
+    local needle="$2"
+    grep -Fq -- "$needle" "$file" 2>/dev/null || {
+      echo "SELF-TEST FAIL: expected '$needle' in $file" >&2
+      [ -f "$file" ] && sed -n '1,120p' "$file" >&2
+      return 1
+    }
+  }
+
+  self_test_assert_not_contains() {
+    local file="$1"
+    local needle="$2"
+    if grep -Fq -- "$needle" "$file" 2>/dev/null; then
+      echo "SELF-TEST FAIL: did not expect '$needle' in $file" >&2
+      sed -n '1,120p' "$file" >&2
+      return 1
+    fi
+  }
+
+  self_test_reset() {
+    rm -rf "$tasks_dir" "$test_root/investigations"
+    mkdir -p "$tasks_dir"
+    rm -f "$test_root/invoker.db"
+    : > "$commands_file"
+    : > "$codex_commands_file"
+    : > "$workflows_label_file"
+    : > "$workflows_jsonl_file"
+    printf '{"runningCount":0,"fixingCount":0}\n' > "$self_test_queue_file"
+    SUBMISSIONS_FILE="$test_root/submissions.tsv"
+    DB_PATH="$test_root/invoker.db"
+    : > "$SUBMISSIONS_FILE"
+    WORKFLOW_FILTERS=()
+    DRY_RUN=false
+    RETRY_INCOMPLETE_WORKFLOWS=true
+    RETRY_FAILED=true
+    AUTOFIX_FAILED=true
+    APPROVE_FIXES=true
+    LOCALIZE_SSH=true
+    MAX_FIX_ATTEMPTS=3
+    RECOVER_STALE_AI_STATES=true
+    STALE_AI_STATE_SECONDS=300
+    STALE_ACTIVE_QUEUE_SECONDS=300
+    INVESTIGATE_PENDING=true
+    INVESTIGATE_COOLDOWN_SECONDS=1800
+    RESET_STATE_AFTER_REPAIR=true
+    IPC_FALLBACK_TO_STANDALONE=true
+    CODEX_COMMAND="$fake_codex"
+    INVESTIGATION_DIR="$test_root/investigations"
+    RESUME_COOLDOWN_SECONDS=60
+    FIX_COOLDOWN_SECONDS=300
+    APPROVE_COOLDOWN_SECONDS=30
+    LOCALIZE_COOLDOWN_SECONDS=60
+    FIX_DEDUPE_SECONDS=300
+    INFRA_RETRY_COOLDOWN_SECONDS=300
+    RESUME_DEDUPE_SECONDS=60
+    LAST_DISPATCH_SUBMITTED=false
+    SKIP_SLEEP_AFTER_CYCLE=false
+    SELF_TEST_QUERY_FAIL=""
+  }
+
+  echo "self-test: incomplete workflows retry once and defer duplicate task actions"
+  self_test_reset
+  printf '%s\n' "wf-1000-1" "wf-1000-2" "wf-1000-3" > "$workflows_label_file"
+  printf '%s\n' \
+    '{"id":"wf-1000-1","status":"completed"}' \
+    '{"id":"wf-1000-2","status":"review_ready"}' \
+    '{"id":"wf-1000-3","status":"running"}' > "$workflows_jsonl_file"
+  : > "$tasks_dir/wf-1000-1.jsonl"
+  : > "$tasks_dir/wf-1000-2.jsonl"
+  printf '%s\n' '{"id":"wf-1000-3/fail","status":"failed","config":{"workflowId":"wf-1000-3","runnerKind":"worktree"},"execution":{"error":"unit failure","autoFixAttempts":0}}' > "$tasks_dir/wf-1000-3.jsonl"
+  run_cycle selftest-retry > "$test_root/retry.out" 2>&1 || { sed -n '1,160p' "$test_root/retry.out" >&2; return 1; }
+  self_test_assert_contains "$commands_file" "retry wf-1000-3"
+  self_test_assert_not_contains "$commands_file" "retry wf-1000-1"
+  self_test_assert_not_contains "$commands_file" "retry wf-1000-2"
+  self_test_assert_not_contains "$commands_file" "retry-task wf-1000-3/fail"
+  self_test_assert_not_contains "$commands_file" "fix wf-1000-3/fail codex"
+
+  echo "self-test: autofix attempt cap blocks fourth Codex fix"
+  self_test_reset
+  RETRY_FAILED=false
+  printf '%s\n' "wf-1000-4" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-4","status":"completed"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"id":"wf-1000-4/fail","status":"failed","config":{"workflowId":"wf-1000-4","runnerKind":"worktree"},"execution":{"error":"unit failure","autoFixAttempts":3}}' > "$tasks_dir/wf-1000-4.jsonl"
+  run_cycle selftest-cap > "$test_root/cap.out" 2>&1 || { sed -n '1,160p' "$test_root/cap.out" >&2; return 1; }
+  self_test_assert_not_contains "$commands_file" "fix wf-1000-4/fail codex"
+  self_test_assert_contains "$test_root/cap.out" "max fix attempts reached: 3/3"
+
+  echo "self-test: autofix below cap still submits"
+  self_test_reset
+  RETRY_FAILED=false
+  printf '%s\n' "wf-1000-4" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-4","status":"completed"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"id":"wf-1000-4/fail","status":"failed","config":{"workflowId":"wf-1000-4","runnerKind":"worktree"},"execution":{"error":"unit failure","autoFixAttempts":2}}' > "$tasks_dir/wf-1000-4.jsonl"
+  run_cycle selftest-fix > "$test_root/fix.out" 2>&1 || { sed -n '1,160p' "$test_root/fix.out" >&2; return 1; }
+  self_test_assert_contains "$commands_file" "fix wf-1000-4/fail codex"
+
+  echo "self-test: pending investigation runs after workflow retry dedupe"
+  self_test_reset
+  local now_epoch
+  now_epoch="$(date +%s)"
+  printf 'retry-workflow\twf-1000-5\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-5" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-5","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"id":"wf-1000-5/pending","status":"pending","config":{"workflowId":"wf-1000-5","runnerKind":"worktree"},"execution":{}}' > "$tasks_dir/wf-1000-5.jsonl"
+  run_cycle selftest-investigate > "$test_root/investigate.out" 2>&1 || { sed -n '1,200p' "$test_root/investigate.out" >&2; return 1; }
+  self_test_assert_not_contains "$commands_file" "retry wf-1000-5"
+  self_test_assert_contains "$test_root/investigate.out" "skip retry-workflow wf-1000-5 (already retried by this loop)"
+  self_test_assert_contains "$codex_commands_file" "exec --cd"
+  self_test_assert_contains "$test_root/investigate.out" "reset retry state after repair"
+
+  echo "self-test: healthy pending SSH task is investigated without executor switch"
+  self_test_reset
+  printf 'retry-workflow\twf-1000-13\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-13" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-13","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"id":"wf-1000-13/pending","status":"pending","config":{"workflowId":"wf-1000-13","runnerKind":"ssh"},"execution":{}}' > "$tasks_dir/wf-1000-13.jsonl"
+  run_cycle selftest-prior-localize > "$test_root/prior-localize.out" 2>&1 || { sed -n '1,200p' "$test_root/prior-localize.out" >&2; return 1; }
+  self_test_assert_not_contains "$commands_file" "set executor wf-1000-13/pending worktree"
+  self_test_assert_not_contains "$commands_file" "set executor wf-1000-13/pending ssh"
+  self_test_assert_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: stale SSH pool member pin is cleared without localizing"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  printf '%s\n' "wf-1000-16" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-16","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[],"queued":[{"taskId":"wf-1000-16/regression"}],"runningCount":0,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"id":"wf-1000-16/regression","status":"pending","config":{"workflowId":"wf-1000-16","runnerKind":"ssh","poolId":"pnpm-ssh","poolMemberId":"remote-a"},"execution":{"workspacePath":"~/.invoker/worktrees/wf-1000-16-regression","branch":"experiment/wf-1000-16/regression"}}' > "$tasks_dir/wf-1000-16.jsonl"
+  run_cycle selftest-stale-ssh-pin > "$test_root/stale-ssh-pin.out" 2>&1 || { sed -n '1,220p' "$test_root/stale-ssh-pin.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/stale-ssh-pin.out" "stale-ssh-pin=1"
+  self_test_assert_contains "$commands_file" "set executor wf-1000-16/regression ssh"
+  self_test_assert_not_contains "$commands_file" "set executor wf-1000-16/regression worktree"
+  self_test_assert_contains "$test_root/stale-ssh-pin.out" "skip retry-workflow wf-1000-16 (stale SSH pin cleared this cycle)"
+  self_test_assert_contains "$test_root/stale-ssh-pin.out" "pending investigation deferred (stale SSH pins cleared this cycle: 1)"
+
+  echo "self-test: stale SSH pin clearing is repeatable after cooldown"
+  self_test_reset
+  local old_epoch
+  old_epoch=$((now_epoch - LOCALIZE_COOLDOWN_SECONDS - 1))
+  printf 'clear-ssh-pin\twf-1000-17/regression\t%s\n' "$old_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-17" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-17","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[],"queued":[{"taskId":"wf-1000-17/regression"}],"runningCount":0,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"id":"wf-1000-17/regression","status":"pending","config":{"workflowId":"wf-1000-17","runnerKind":"ssh","poolId":"pnpm-ssh","poolMemberId":"remote-a"},"execution":{"workspacePath":"~/.invoker/worktrees/wf-1000-17-regression","branch":"experiment/wf-1000-17/regression"}}' > "$tasks_dir/wf-1000-17.jsonl"
+  run_cycle selftest-stale-ssh-pin-repeat > "$test_root/stale-ssh-pin-repeat.out" 2>&1 || { sed -n '1,220p' "$test_root/stale-ssh-pin-repeat.out" >&2; return 1; }
+  self_test_assert_contains "$commands_file" "set executor wf-1000-17/regression ssh"
+
+  echo "self-test: duplicate selected-attempt SSH lease releases only non-assigned member"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  printf 'retry-workflow\twf-1000-18\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-18" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-18","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-18/regression"}],"queued":[],"runningCount":1,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"id":"wf-1000-18/regression","status":"running","config":{"workflowId":"wf-1000-18","runnerKind":"ssh","poolId":"pnpm-ssh","poolMemberId":"remote-a"},"execution":{"selectedAttemptId":"wf-1000-18/regression-a1","lastHeartbeatAt":"2000-01-01T00:00:00Z","startedAt":"2000-01-01T00:00:00Z","phase":"executing"}}' > "$tasks_dir/wf-1000-18.jsonl"
+  python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+conn = sqlite3.connect(db_path)
+with conn:
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          status TEXT,
+          runner_kind TEXT,
+          pool_member_id TEXT,
+          selected_attempt_id TEXT
+        );
+        CREATE TABLE execution_resource_leases (
+          resource_key TEXT,
+          resource_type TEXT,
+          holder_id TEXT,
+          task_id TEXT,
+          pool_id TEXT,
+          pool_member_id TEXT,
+          acquired_at TEXT,
+          last_heartbeat_at TEXT,
+          lease_expires_at TEXT,
+          metadata_json TEXT,
+          PRIMARY KEY(resource_key, holder_id)
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO tasks VALUES (?, ?, ?, ?, ?)",
+        ("wf-1000-18/regression", "running", "ssh", "remote-a", "wf-1000-18/regression-a1"),
+    )
+    for resource_key, member in [
+        ("ssh:invoker@host-a:22", "remote-a"),
+        ("ssh:invoker@host-b:22", "remote-b"),
+    ]:
+        conn.execute(
+            """
+            INSERT INTO execution_resource_leases
+              (resource_key, resource_type, holder_id, task_id, pool_id, pool_member_id,
+               acquired_at, last_heartbeat_at, lease_expires_at, metadata_json)
+            VALUES (?, 'ssh', ?, ?, 'pnpm-ssh', ?, '2099-01-01T00:00:00Z',
+                    '2099-01-01T00:00:00Z', '2099-01-01T00:20:00Z', NULL)
+            """,
+            (resource_key, f"owner:123:wf-1000-18/regression:wf-1000-18/regression-a1", "wf-1000-18/regression", member),
+        )
+conn.close()
+PY
+  run_cycle selftest-duplicate-ssh-lease > "$test_root/duplicate-ssh-lease.out" 2>&1 || { sed -n '1,240p' "$test_root/duplicate-ssh-lease.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/duplicate-ssh-lease.out" "duplicate-ssh-lease=1"
+  self_test_assert_contains "$test_root/duplicate-ssh-lease.out" "released duplicate SSH lease wf-1000-18/regression member=remote-b assigned=remote-a"
+  local remaining_leases
+  remaining_leases="$(python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+conn = sqlite3.connect(sys.argv[1])
+rows = conn.execute(
+    "SELECT resource_key || ' ' || pool_member_id FROM execution_resource_leases ORDER BY resource_key"
+).fetchall()
+print("\n".join(row[0] for row in rows))
+conn.close()
+PY
+)"
+  [ "$remaining_leases" = "ssh:invoker@host-a:22 remote-a" ] || self_test_fail "unexpected leases after duplicate release: $remaining_leases"
+  self_test_assert_contains "$test_root/duplicate-ssh-lease.out" "pending investigation deferred (duplicate SSH leases released this cycle: 1)"
+
+  echo "self-test: active SSH lease for pending task is released"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  printf 'retry-workflow\twf-1000-20\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-20" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-20","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"id":"wf-1000-20/regression","status":"pending","config":{"workflowId":"wf-1000-20","runnerKind":"ssh","poolId":"pnpm-ssh","poolMemberId":"remote-a"},"execution":{"selectedAttemptId":"wf-1000-20/regression-a1"}}' > "$tasks_dir/wf-1000-20.jsonl"
+  python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+conn = sqlite3.connect(db_path)
+with conn:
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          status TEXT,
+          runner_kind TEXT,
+          pool_member_id TEXT,
+          selected_attempt_id TEXT
+        );
+        CREATE TABLE execution_resource_leases (
+          resource_key TEXT,
+          resource_type TEXT,
+          holder_id TEXT,
+          task_id TEXT,
+          pool_id TEXT,
+          pool_member_id TEXT,
+          acquired_at TEXT,
+          last_heartbeat_at TEXT,
+          lease_expires_at TEXT,
+          metadata_json TEXT,
+          PRIMARY KEY(resource_key, holder_id)
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO tasks VALUES (?, ?, ?, ?, ?)",
+        ("wf-1000-20/regression", "pending", "ssh", "remote-a", "wf-1000-20/regression-a1"),
+    )
+    conn.execute(
+        """
+        INSERT INTO execution_resource_leases
+          (resource_key, resource_type, holder_id, task_id, pool_id, pool_member_id,
+           acquired_at, last_heartbeat_at, lease_expires_at, metadata_json)
+        VALUES ('ssh:invoker@host-a:22', 'ssh', 'owner:123:wf-1000-20/regression:wf-1000-20/regression-a1',
+                'wf-1000-20/regression', 'pnpm-ssh', 'remote-a',
+                '2099-01-01T00:00:00Z', '2099-01-01T00:00:00Z', '2099-01-01T00:20:00Z', NULL)
+        """
+    )
+conn.close()
+PY
+  run_cycle selftest-orphan-ssh-lease > "$test_root/orphan-ssh-lease.out" 2>&1 || { sed -n '1,240p' "$test_root/orphan-ssh-lease.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/orphan-ssh-lease.out" "orphan-ssh-lease=1"
+  self_test_assert_contains "$test_root/orphan-ssh-lease.out" "released orphan SSH lease wf-1000-20/regression status=pending member=remote-a"
+  self_test_assert_contains "$test_root/orphan-ssh-lease.out" "pending investigation deferred (orphan SSH leases released this cycle: 1)"
+  remaining_leases="$(python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+conn = sqlite3.connect(sys.argv[1])
+print(conn.execute("SELECT COUNT(*) FROM execution_resource_leases").fetchone()[0])
+conn.close()
+PY
+)"
+  [ "$remaining_leases" = "0" ] || self_test_fail "expected orphan lease to be released, remaining=$remaining_leases"
+
+  echo "self-test: active SSH lease for old attempt on running task is released"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  printf 'retry-workflow\twf-1000-21\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-21" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-21","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-21/regression"}],"queued":[],"runningCount":1,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"id":"wf-1000-21/regression","status":"running","config":{"workflowId":"wf-1000-21","runnerKind":"ssh","poolId":"pnpm-ssh","poolMemberId":"remote-b"},"execution":{"selectedAttemptId":"wf-1000-21/regression-new","lastHeartbeatAt":"2099-01-01T00:00:00Z","startedAt":"2099-01-01T00:00:00Z","phase":"executing"}}' > "$tasks_dir/wf-1000-21.jsonl"
+  python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+conn = sqlite3.connect(db_path)
+with conn:
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY,
+          status TEXT,
+          runner_kind TEXT,
+          pool_member_id TEXT,
+          selected_attempt_id TEXT
+        );
+        CREATE TABLE execution_resource_leases (
+          resource_key TEXT,
+          resource_type TEXT,
+          holder_id TEXT,
+          task_id TEXT,
+          pool_id TEXT,
+          pool_member_id TEXT,
+          acquired_at TEXT,
+          last_heartbeat_at TEXT,
+          lease_expires_at TEXT,
+          metadata_json TEXT,
+          PRIMARY KEY(resource_key, holder_id)
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO tasks VALUES (?, ?, ?, ?, ?)",
+        ("wf-1000-21/regression", "running", "ssh", "remote-b", "wf-1000-21/regression-new"),
+    )
+    for resource_key, member, attempt in [
+        ("ssh:invoker@host-a:22", "remote-a", "wf-1000-21/regression-old"),
+        ("ssh:invoker@host-b:22", "remote-b", "wf-1000-21/regression-new"),
+    ]:
+        conn.execute(
+            """
+            INSERT INTO execution_resource_leases
+              (resource_key, resource_type, holder_id, task_id, pool_id, pool_member_id,
+               acquired_at, last_heartbeat_at, lease_expires_at, metadata_json)
+            VALUES (?, 'ssh', ?, 'wf-1000-21/regression', 'pnpm-ssh', ?,
+                    '2099-01-01T00:00:00Z', '2099-01-01T00:00:00Z', '2099-01-01T00:20:00Z', NULL)
+            """,
+            (resource_key, f"owner:123:wf-1000-21/regression:{attempt}", member),
+        )
+conn.close()
+PY
+  run_cycle selftest-old-attempt-ssh-lease > "$test_root/old-attempt-ssh-lease.out" 2>&1 || { sed -n '1,260p' "$test_root/old-attempt-ssh-lease.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/old-attempt-ssh-lease.out" "orphan-ssh-lease=1"
+  self_test_assert_contains "$test_root/old-attempt-ssh-lease.out" "released orphan SSH lease wf-1000-21/regression status=running member=remote-a"
+  remaining_leases="$(python3 - "$DB_PATH" <<'PY'
+import sqlite3
+import sys
+conn = sqlite3.connect(sys.argv[1])
+rows = conn.execute("SELECT resource_key || ' ' || pool_member_id FROM execution_resource_leases ORDER BY resource_key").fetchall()
+print("\n".join(row[0] for row in rows))
+conn.close()
+PY
+)"
+  [ "$remaining_leases" = "ssh:invoker@host-b:22 remote-b" ] || self_test_fail "unexpected leases after old-attempt release: $remaining_leases"
+
+  echo "self-test: max-exhausted failed task does not block pending investigation"
+  self_test_reset
+  printf '%s\n' "wf-1000-14" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-14","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' \
+    '{"id":"wf-1000-14/pending","status":"pending","config":{"workflowId":"wf-1000-14","runnerKind":"worktree"},"execution":{}}' \
+    '{"id":"wf-1000-14/fail","status":"failed","config":{"workflowId":"wf-1000-14","runnerKind":"worktree"},"execution":{"error":"unit failure","autoFixAttempts":0}}' > "$tasks_dir/wf-1000-14.jsonl"
+  {
+    printf 'retry-workflow\twf-1000-14\t%s\n' "$now_epoch"
+    printf 'retry-failed\twf-1000-14/fail\t%s\n' "$now_epoch"
+    printf 'fix\twf-1000-14/fail\t%s\n' "$now_epoch"
+    printf 'fix\twf-1000-14/fail\t%s\n' "$now_epoch"
+    printf 'fix\twf-1000-14/fail\t%s\n' "$now_epoch"
+  } > "$SUBMISSIONS_FILE"
+  run_cycle selftest-exhausted-fix > "$test_root/exhausted-fix.out" 2>&1 || { sed -n '1,240p' "$test_root/exhausted-fix.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/exhausted-fix.out" "failed-tasks=1 exhausted-fixes=1"
+  self_test_assert_contains "$test_root/exhausted-fix.out" "blockers=0"
+  self_test_assert_contains "$test_root/exhausted-fix.out" "max fix attempts reached: 3/3"
+  self_test_assert_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: prior workflow retry does not starve failed autofix"
+  self_test_reset
+  printf '%s\n' "wf-1000-8" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-8","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"id":"wf-1000-8/fail","status":"failed","config":{"workflowId":"wf-1000-8","runnerKind":"worktree"},"execution":{"error":"unit failure","autoFixAttempts":0}}' > "$tasks_dir/wf-1000-8.jsonl"
+  {
+    printf 'retry-workflow\twf-1000-8\t%s\n' "$now_epoch"
+    printf 'retry-failed\twf-1000-8/fail\t%s\n' "$now_epoch"
+  } > "$SUBMISSIONS_FILE"
+  run_cycle selftest-prior-workflow-retry > "$test_root/prior-workflow-retry.out" 2>&1 || { sed -n '1,200p' "$test_root/prior-workflow-retry.out" >&2; return 1; }
+  self_test_assert_not_contains "$commands_file" "retry wf-1000-8"
+  self_test_assert_contains "$test_root/prior-workflow-retry.out" "skip retry-workflow wf-1000-8 (already retried by this loop)"
+  self_test_assert_contains "$commands_file" "fix wf-1000-8/fail codex"
+
+  echo "self-test: non-pending blockers defer pending investigation"
+  self_test_reset
+  printf '%s\n' "wf-1000-6" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-6","status":"completed"}' > "$workflows_jsonl_file"
+  printf '%s\n' \
+    '{"id":"wf-1000-6/pending","status":"pending","config":{"workflowId":"wf-1000-6","runnerKind":"worktree"},"execution":{}}' \
+    '{"id":"wf-1000-6/input","status":"needs_input","config":{"workflowId":"wf-1000-6","runnerKind":"worktree"},"execution":{}}' > "$tasks_dir/wf-1000-6.jsonl"
+  run_cycle selftest-blocker > "$test_root/blocker.out" 2>&1 || { sed -n '1,160p' "$test_root/blocker.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/blocker.out" "pending investigation deferred (non-pending blockers remain: 1)"
+  self_test_assert_not_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: fresh running task defers pending investigation"
+  self_test_reset
+  local fresh_running_ts
+  fresh_running_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '%s\n' "wf-1000-12" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-12","status":"completed"}' > "$workflows_jsonl_file"
+  printf '%s\n' \
+    '{"id":"wf-1000-12/pending","status":"pending","config":{"workflowId":"wf-1000-12","runnerKind":"worktree"},"execution":{}}' \
+    "{\"id\":\"wf-1000-12/run\",\"status\":\"running\",\"config\":{\"workflowId\":\"wf-1000-12\",\"runnerKind\":\"worktree\"},\"execution\":{\"lastHeartbeatAt\":\"$fresh_running_ts\",\"startedAt\":\"$fresh_running_ts\",\"phase\":\"executing\"}}" > "$tasks_dir/wf-1000-12.jsonl"
+  run_cycle selftest-fresh-running-blocker > "$test_root/fresh-running-blocker.out" 2>&1 || { sed -n '1,160p' "$test_root/fresh-running-blocker.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/fresh-running-blocker.out" "blockers=1"
+  self_test_assert_contains "$test_root/fresh-running-blocker.out" "stale-running=0"
+  self_test_assert_contains "$test_root/fresh-running-blocker.out" "pending investigation deferred (non-pending blockers remain: 1)"
+  self_test_assert_not_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: queue-active pending task is treated as blocker"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=false
+  local fresh_queue_ts
+  fresh_queue_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf '%s\n' "wf-1000-7" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-7","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-7/pending"}],"queued":[],"runningCount":1,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '{"id":"wf-1000-7/pending","status":"pending","config":{"workflowId":"wf-1000-7","runnerKind":"worktree"},"execution":{"lastHeartbeatAt":"%s","launchStartedAt":"%s"}}\n' "$fresh_queue_ts" "$fresh_queue_ts" > "$tasks_dir/wf-1000-7.jsonl"
+  run_cycle selftest-queue-active > "$test_root/queue-active.out" 2>&1 || { sed -n '1,160p' "$test_root/queue-active.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/queue-active.out" "pending-tasks=0 blockers=1"
+  self_test_assert_contains "$test_root/queue-active.out" "stale-queue-pending=0"
+  self_test_assert_not_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: queue-active pending task after pool deferral is treated as blocker"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=false
+  printf '%s\n' "wf-1000-15" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-15","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[],"queued":[{"taskId":"wf-1000-15/regression"}],"runningCount":0,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' '{"id":"wf-1000-15/regression","status":"pending","config":{"workflowId":"wf-1000-15","runnerKind":"worktree","poolId":"pnpm-ssh"},"execution":{"branch":"experiment/wf-1000-15/regression"}}' > "$tasks_dir/wf-1000-15.jsonl"
+  run_cycle selftest-queue-active-pool-deferral > "$test_root/queue-active-pool-deferral.out" 2>&1 || { sed -n '1,200p' "$test_root/queue-active-pool-deferral.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/queue-active-pool-deferral.out" "pending-tasks=0 blockers=1"
+  self_test_assert_contains "$test_root/queue-active-pool-deferral.out" "stale-queue-pending=0"
+  self_test_assert_not_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: stale queue-active pending task is investigated"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  local stale_queue_ts
+  stale_queue_ts="2000-01-01T00:00:00Z"
+  printf 'retry-workflow\twf-1000-9\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-9" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-9","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-9/pending"}],"queued":[],"runningCount":1,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '{"id":"wf-1000-9/pending","status":"pending","config":{"workflowId":"wf-1000-9","runnerKind":"worktree"},"execution":{"lastHeartbeatAt":"%s","launchStartedAt":"%s","phase":"launching"}}\n' "$stale_queue_ts" "$stale_queue_ts" > "$tasks_dir/wf-1000-9.jsonl"
+  run_cycle selftest-stale-queue-active > "$test_root/stale-queue-active.out" 2>&1 || { sed -n '1,200p' "$test_root/stale-queue-active.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/stale-queue-active.out" "pending-tasks=1 blockers=0"
+  self_test_assert_contains "$test_root/stale-queue-active.out" "stale-queue-pending=1"
+  self_test_assert_contains "$test_root/stale-queue-active.out" "pending investigation includes stale queue-active pending tasks: 1"
+  self_test_assert_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: old queue-active pending task without launch metadata remains blocked"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  fresh_running_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'retry-workflow\twf-1000-22\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-22" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-22","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[],"queued":[{"taskId":"wf-1000-22/pending"},{"taskId":"wf-1000-22/fresh"}],"runningCount":0,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '%s\n' \
+    '{"id":"wf-1000-22/pending","createdAt":"2000-01-01T00:00:00Z","status":"pending","config":{"workflowId":"wf-1000-22","runnerKind":"worktree","poolId":"pnpm-ssh"},"execution":{}}' \
+    "{\"id\":\"wf-1000-22/fresh\",\"status\":\"running\",\"config\":{\"workflowId\":\"wf-1000-22\",\"runnerKind\":\"worktree\"},\"execution\":{\"lastHeartbeatAt\":\"$fresh_running_ts\",\"startedAt\":\"$fresh_running_ts\",\"phase\":\"executing\"}}" > "$tasks_dir/wf-1000-22.jsonl"
+  run_cycle selftest-old-queue-active-no-launch > "$test_root/old-queue-active-no-launch.out" 2>&1 || { sed -n '1,220p' "$test_root/old-queue-active-no-launch.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/old-queue-active-no-launch.out" "pending-tasks=0 blockers=2"
+  self_test_assert_contains "$test_root/old-queue-active-no-launch.out" "stale-queue-pending=0"
+  self_test_assert_not_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: stale running task is investigated"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  printf 'retry-workflow\twf-1000-12\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-12" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-12","status":"running"}' > "$workflows_jsonl_file"
+  printf '{"id":"wf-1000-12/run","status":"running","config":{"workflowId":"wf-1000-12","runnerKind":"worktree"},"execution":{"lastHeartbeatAt":"%s","startedAt":"%s","phase":"executing"}}\n' "$stale_queue_ts" "$stale_queue_ts" > "$tasks_dir/wf-1000-12.jsonl"
+  run_cycle selftest-stale-running > "$test_root/stale-running.out" 2>&1 || { sed -n '1,200p' "$test_root/stale-running.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/stale-running.out" "blockers=0"
+  self_test_assert_contains "$test_root/stale-running.out" "stale-running=1"
+  self_test_assert_contains "$test_root/stale-running.out" "pending investigation includes stale running tasks: 1"
+  self_test_assert_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: stale running task investigation bypasses fresh blockers"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  fresh_running_ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+  printf 'retry-workflow\twf-1000-19\t%s\n' "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '%s\n' "wf-1000-19" > "$workflows_label_file"
+  printf '%s\n' '{"id":"wf-1000-19","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-19/stale"},{"taskId":"wf-1000-19/fresh"}],"queued":[],"runningCount":2,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf '{"id":"wf-1000-19/stale","status":"running","config":{"workflowId":"wf-1000-19","runnerKind":"worktree"},"execution":{"lastHeartbeatAt":"%s","startedAt":"%s","phase":"executing"}}\n' "$stale_queue_ts" "$stale_queue_ts" > "$tasks_dir/wf-1000-19.jsonl"
+  printf '{"id":"wf-1000-19/fresh","status":"running","config":{"workflowId":"wf-1000-19","runnerKind":"worktree"},"execution":{"lastHeartbeatAt":"%s","startedAt":"%s","phase":"executing"}}\n' "$fresh_running_ts" "$fresh_running_ts" >> "$tasks_dir/wf-1000-19.jsonl"
+  run_cycle selftest-stale-running-bypass > "$test_root/stale-running-bypass.out" 2>&1 || { sed -n '1,220p' "$test_root/stale-running-bypass.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/stale-running-bypass.out" "blockers=1"
+  self_test_assert_contains "$test_root/stale-running-bypass.out" "stale-running=1"
+  self_test_assert_contains "$test_root/stale-running-bypass.out" "stale task investigation bypasses unrelated blockers: 1"
+  self_test_assert_contains "$codex_commands_file" "exec --cd"
+
+  echo "self-test: successful pending investigation restarts before next stale target"
+  self_test_reset
+  RETRY_INCOMPLETE_WORKFLOWS=true
+  printf '%s\n' "wf-1000-10" "wf-1000-11" > "$workflows_label_file"
+  printf '%s\n' \
+    '{"id":"wf-1000-10","status":"running"}' \
+    '{"id":"wf-1000-11","status":"running"}' > "$workflows_jsonl_file"
+  printf '%s\n' '{"running":[{"taskId":"wf-1000-10/pending"},{"taskId":"wf-1000-11/pending"}],"queued":[],"runningCount":2,"maxConcurrency":12}' > "$self_test_queue_file"
+  printf 'retry-workflow\twf-1000-10\t%s\nretry-workflow\twf-1000-11\t%s\n' "$now_epoch" "$now_epoch" > "$SUBMISSIONS_FILE"
+  printf '{"id":"wf-1000-10/pending","status":"pending","config":{"workflowId":"wf-1000-10","runnerKind":"worktree"},"execution":{"lastHeartbeatAt":"%s","launchStartedAt":"%s","phase":"launching"}}\n' "$stale_queue_ts" "$stale_queue_ts" > "$tasks_dir/wf-1000-10.jsonl"
+  printf '{"id":"wf-1000-11/pending","status":"pending","config":{"workflowId":"wf-1000-11","runnerKind":"worktree"},"execution":{"lastHeartbeatAt":"%s","launchStartedAt":"%s","phase":"launching"}}\n' "$stale_queue_ts" "$stale_queue_ts" > "$tasks_dir/wf-1000-11.jsonl"
+  run_cycle selftest-single-repair-restart > "$test_root/single-repair-restart.out" 2>&1 || { sed -n '1,200p' "$test_root/single-repair-restart.out" >&2; return 1; }
+  self_test_assert_contains "$test_root/single-repair-restart.out" "stale-queue-pending=2"
+  self_test_assert_contains "$test_root/single-repair-restart.out" "reset retry state after repair"
+  local codex_command_count
+  codex_command_count="$(wc -l < "$codex_commands_file" | tr -d ' ')"
+  [ "$codex_command_count" = "1" ] || self_test_fail "expected one pending investigation before restart, got $codex_command_count"
+
+  echo "self-test: required query failure fails the cycle"
+  self_test_reset
+  SELF_TEST_QUERY_FAIL="query workflows --output label"
+  if run_cycle selftest-query-fail > "$test_root/query-fail.out" 2>&1; then
+    self_test_fail "query failure cycle unexpectedly succeeded"
+    return 1
+  fi
+  self_test_assert_contains "$test_root/query-fail.out" "failed to collect workflow ids"
+
+  echo "self-test: all passed"
+}
+
+if [ "$SELF_TEST" = true ]; then
+  run_self_tests
+  exit $?
+fi
+
 echo "retry/autofix loop starting"
 echo "dryRun=$DRY_RUN interval=${INTERVAL_SECONDS}s maxCycles=$MAX_CYCLES includeMerge=$INCLUDE_MERGE"
-echo "resumePending=$RESUME_PENDING retryFailed=$RETRY_FAILED autofixFailed=$AUTOFIX_FAILED approveFixes=$APPROVE_FIXES localizeSsh=$LOCALIZE_SSH"
+echo "retryIncompleteWorkflows=$RETRY_INCOMPLETE_WORKFLOWS retryFailed=$RETRY_FAILED autofixFailed=$AUTOFIX_FAILED maxFixAttempts=$MAX_FIX_ATTEMPTS recoverStaleAiStates=$RECOVER_STALE_AI_STATES staleAiStateAge=${STALE_AI_STATE_SECONDS}s staleActiveQueueAge=${STALE_ACTIVE_QUEUE_SECONDS}s approveFixes=$APPROVE_FIXES localizeSsh=$LOCALIZE_SSH"
+echo "investigatePending=$INVESTIGATE_PENDING investigateCooldown=${INVESTIGATE_COOLDOWN_SECONDS}s resetStateAfterRepair=$RESET_STATE_AFTER_REPAIR queryTimeout=${QUERY_TIMEOUT_SECONDS}s ipcFallbackToStandalone=$IPC_FALLBACK_TO_STANDALONE codexCommand=$CODEX_COMMAND"
 
 cycle=1
 overall_failures=0
 while :; do
+  SKIP_SLEEP_AFTER_CYCLE=false
   if ! run_cycle "$cycle"; then
     overall_failures=$((overall_failures + 1))
   fi
@@ -545,6 +2507,9 @@ while :; do
   fi
 
   cycle=$((cycle + 1))
+  if [ "$SKIP_SLEEP_AFTER_CYCLE" = true ]; then
+    continue
+  fi
   sleep "$INTERVAL_SECONDS"
 done
 


### PR DESCRIPTION
## Summary

Keep the daemon owner alive while launch handoff is still active.

This prevents owner shutdown from abandoning active launch dispatch work before the handoff finishes.

Update owner, headless, launch-dispatch, retry-loop, and e2e coverage around owner lifetime and launch progress.

## Architecture

### Before

```mermaid
flowchart LR
  Caller[caller] --> Owner[daemon owner]
  Owner --> Launch[launch handoff]
  Owner -. idle .-> Exit[owner exits]
```

### After

```mermaid
flowchart LR
  Caller[caller] --> Owner[daemon owner]
  Owner --> Launch[launch handoff]
  Launch --> Active[owner remains alive]
```

## Test Plan

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/headless-delegation.test.ts src/__tests__/launch-dispatcher.test.ts src/__tests__/owner-resolver.test.ts`
- [ ] `bash scripts/repro/repro-retry-loop-managed-owner-survives-launcher-exit.sh`
- [ ] `bash scripts/repro/repro-standalone-owner-idle-ignores-active-launch-dispatch.sh`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit>`
- Post-revert steps: Re-run owner lifetime and launch handoff repros.
- Data migration? No

Depends-On: #1127
