### PR TITLE
fix(workflow-core): clear launch lineage on retry reset

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2975,7 +2975,7 @@ describe('Orchestrator', () => {
   });
 
   describe('prepareTaskForNewAttempt', () => {
-    it('resets a running launching task to pending with a fresh selected attempt and preserves durable fields', () => {
+    it('resets a running launching task to pending with a fresh selected attempt and clears launch lineage', () => {
       orchestrator.loadPlan({
         name: 'prepare-running-launching',
         tasks: [
@@ -3058,6 +3058,8 @@ describe('Orchestrator', () => {
       expect(prepared.execution.pendingFixError).toBeUndefined();
       expect(prepared.execution.agentSessionId).toBeUndefined();
       expect(prepared.execution.workspacePath).toBeUndefined();
+      expect(prepared.execution.branch).toBeUndefined();
+      expect(prepared.execution.commit).toBeUndefined();
       expect(prepared.execution.containerId).toBeUndefined();
       expect(prepared.execution.isFixingWithAI).toBe(false);
       expect(prepared.config.command).toBe('pnpm test');
@@ -3067,8 +3069,6 @@ describe('Orchestrator', () => {
       expect(prepared.config.approach).toBe('durable approach');
       expect(prepared.config.testPlan).toBe('durable test plan');
       expect(prepared.dependencies).toEqual([sid(orchestrator, 0, 't0')]);
-      expect(prepared.execution.branch).toBe('feature/task');
-      expect(prepared.execution.commit).toBe('abc123');
       expect(prepared.execution.reviewUrl).toBe('https://example.test/review');
       expect(prepared.execution.reviewId).toBe('review-1');
       expect(prepared.execution.reviewStatus).toBe('open');

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -1404,6 +1404,8 @@ export class Orchestrator {
         lastHeartbeatAt: undefined,
         error: undefined,
         exitCode: undefined,
+        branch: undefined,
+        commit: undefined,
         inputPrompt: undefined,
         pendingFixError: undefined,
         agentSessionId: undefined,

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1778825469103-6-implement-sqlite-flush-optimization.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1778825469103-6-implement-sqlite-flush-optimization.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+TASK_ID="wf-1778825469103-6/implement-sqlite-flush-optimization"
+
+echo "[repro] task: $TASK_ID"
+echo "[repro] root cause: prepareTaskForNewAttempt cleared workspacePath but retained stale branch metadata."
+echo "[repro] effect: the next worktree launch was not forced fresh, so content-hash reuse could select an old attempt workspace."
+
+python3 <<'PY'
+TASK_ID = "wf-1778825469103-6/implement-sqlite-flush-optimization"
+
+task = {
+    "id": TASK_ID,
+    "status": "running",
+    "execution": {
+        "generation": 189,
+        "selectedAttemptId": f"{TASK_ID}-a82665236",
+        "phase": "executing",
+        "launchStartedAt": "2026-06-05T02:22:31.311Z",
+        "launchCompletedAt": "2026-06-05T02:23:16.452Z",
+    },
+}
+
+executor_selected_event = {
+    "eventType": "task.executor.selected",
+    "payload": {
+        "attemptId": f"{TASK_ID}-a82665236",
+        "workspacePath": (
+            "/Users/edbertchan/.invoker/worktrees/64a63486912a/"
+            "experiment-wf-1778825469103-6-implement-sqlite-flush-optimization-"
+            "g78.t188.a-a3ed992b9-fbfdc0f9"
+        ),
+        "branch": (
+            "experiment/wf-1778825469103-6/implement-sqlite-flush-optimization/"
+            "g78.t189.a-a82665236-fbfdc0f9"
+        ),
+    },
+}
+
+pre_fix_reset_execution = {
+    # This was the bad shape produced by prepareTaskForNewAttempt: generation
+    # changed and workspacePath was cleared, but branch still pointed at the
+    # previous attempt.
+    "generation": 189,
+    "selectedAttemptId": f"{TASK_ID}-a82665236",
+    "branch": (
+        "experiment/wf-1778825469103-6/implement-sqlite-flush-optimization/"
+        "g78.t188.a-a3ed992b9-fbfdc0f9"
+    ),
+    "workspacePath": None,
+}
+
+def lifecycle_fragment(value: str) -> str:
+    for fragment in value.replace("/", "-").split("-"):
+        if fragment.startswith("g78.t"):
+            return fragment
+    raise AssertionError(f"missing lifecycle fragment in {value!r}")
+
+branch = executor_selected_event["payload"]["branch"]
+workspace_path = executor_selected_event["payload"]["workspacePath"]
+assert task["status"] == "running"
+assert task["execution"]["phase"] == "executing"
+assert executor_selected_event["payload"]["attemptId"] == task["execution"]["selectedAttemptId"]
+assert "g78.t189.a-a82665236" in branch
+assert "g78.t188.a-a3ed992b9" in workspace_path
+assert lifecycle_fragment(branch) != lifecycle_fragment(workspace_path)
+
+old_should_force_fresh_workspace = (
+    pre_fix_reset_execution["generation"] > 0
+    and pre_fix_reset_execution.get("branch") is None
+    and pre_fix_reset_execution.get("workspacePath") is None
+)
+assert old_should_force_fresh_workspace is False
+
+fixed_reset_execution = {
+    **pre_fix_reset_execution,
+    "branch": None,
+}
+fixed_should_force_fresh_workspace = (
+    fixed_reset_execution["generation"] > 0
+    and fixed_reset_execution.get("branch") is None
+    and fixed_reset_execution.get("workspacePath") is None
+)
+assert fixed_should_force_fresh_workspace is True
+
+print("[repro] pre-fix diagnostic confirmed: branch lifecycle t189 selected workspace lifecycle t188")
+print("[repro] pre-fix reset shape would not force a fresh worktree")
+print("[repro] fixed reset shape clears branch and forces fresh worktree selection")
+PY
+
+echo "[repro] Prove the fix in workflow-core."
+pnpm --filter @invoker/workflow-core exec vitest run \
+  src/__tests__/orchestrator.test.ts \
+  -t "resets a running launching task to pending with a fresh selected attempt and clears launch lineage"
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Clear launch lineage when retry reset restarts a task.

This prevents stale launch metadata from an older attempt from carrying into the new attempt.

Add a repro for the pending-task case that exposed stale launch lineage after retry reset.

## Test Plan

- [ ] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts`
- [ ] `bash scripts/repro/repro-pending-task-did-not-run-wf-1778825469103-6-implement-sqlite-flush-optimization.sh`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 6afc27b5b`
- Post-revert steps: Re-run workflow-core retry reset validation.
- Data migration? No

Depends-On: #1129