### PR TITLE
fix(e2e): clean up owned headless processes on macOS

### DIFF
--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -97,18 +97,35 @@ invoker_e2e_init() {
   invoker_e2e_ensure_branch_aliases
 }
 
+invoker_e2e_pid_cmdline() {
+  local pid="$1"
+  if [ -r "/proc/$pid/cmdline" ]; then
+    tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true
+    return 0
+  fi
+  ps -p "$pid" -o command= 2>/dev/null || true
+}
+
+invoker_e2e_pid_has_env() {
+  local pid="$1" key="$2" value="$3"
+  if [ -r "/proc/$pid/environ" ]; then
+    tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep -Fqx "$key=$value"
+    return $?
+  fi
+  # macOS has no /proc/<pid>/environ; `ps eww` appends the environment to the
+  # command line, which is enough for exact e2e temp paths and port values.
+  ps eww -p "$pid" -o command= 2>/dev/null | grep -Fq "$key=$value"
+}
+
 invoker_e2e_kill_owned_headless_processes() {
   # Kill only the headless processes that belong to this test run.
   # Scope by this case's INVOKER_DB_DIR/INVOKER_API_PORT so one case's EXIT trap
   # cannot SIGTERM another concurrently-running case.
   if [ -n "${INVOKER_DB_DIR:-}" ] || [ -n "${INVOKER_API_PORT:-}" ]; then
-    local pid environ_blob cmdline
+    local pid cmdline
     while IFS= read -r pid; do
       [ -n "$pid" ] || continue
-      [ -r "/proc/$pid/environ" ] || continue
-      [ -r "/proc/$pid/cmdline" ] || continue
-      environ_blob="$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null || true)"
-      cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
+      cmdline="$(invoker_e2e_pid_cmdline "$pid")"
       case "$cmdline" in
         *"--headless"*)
           ;;
@@ -116,12 +133,13 @@ invoker_e2e_kill_owned_headless_processes() {
           continue
           ;;
       esac
-      if [ -n "${INVOKER_DB_DIR:-}" ] && ! printf '%s\n' "$environ_blob" | grep -Fqx "INVOKER_DB_DIR=$INVOKER_DB_DIR"; then
-        if [ -n "${INVOKER_API_PORT:-}" ] && ! printf '%s\n' "$environ_blob" | grep -Fqx "INVOKER_API_PORT=$INVOKER_API_PORT"; then
-          continue
-        fi
+      if [ -n "${INVOKER_DB_DIR:-}" ] && invoker_e2e_pid_has_env "$pid" "INVOKER_DB_DIR" "$INVOKER_DB_DIR"; then
+        kill "$pid" 2>/dev/null || true
+        continue
       fi
-      kill "$pid" 2>/dev/null || true
+      if [ -n "${INVOKER_API_PORT:-}" ] && invoker_e2e_pid_has_env "$pid" "INVOKER_API_PORT" "$INVOKER_API_PORT"; then
+        kill "$pid" 2>/dev/null || true
+      fi
     done < <(pgrep -f '(/electron|packages/app/dist/main.js|headless-client.js|run.sh --headless)' 2>/dev/null || true)
   fi
 }
@@ -440,17 +458,14 @@ invoker_e2e_wait_workflow_visible() {
 
 invoker_e2e_count_owned_headless_processes() {
   local count=0
-  local pid environ_blob cmdline
+  local pid cmdline
   if [ -z "${INVOKER_DB_DIR:-}" ] && [ -z "${INVOKER_API_PORT:-}" ]; then
     printf '0'
     return 0
   fi
   while IFS= read -r pid; do
     [ -n "$pid" ] || continue
-    [ -r "/proc/$pid/environ" ] || continue
-    [ -r "/proc/$pid/cmdline" ] || continue
-    environ_blob="$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null || true)"
-    cmdline="$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null || true)"
+    cmdline="$(invoker_e2e_pid_cmdline "$pid")"
     case "$cmdline" in
       *"--headless"*)
         ;;
@@ -458,12 +473,14 @@ invoker_e2e_count_owned_headless_processes() {
         continue
         ;;
     esac
-    if [ -n "${INVOKER_DB_DIR:-}" ] && ! printf '%s\n' "$environ_blob" | grep -Fqx "INVOKER_DB_DIR=$INVOKER_DB_DIR"; then
-      if [ -n "${INVOKER_API_PORT:-}" ] && ! printf '%s\n' "$environ_blob" | grep -Fqx "INVOKER_API_PORT=$INVOKER_API_PORT"; then
-        continue
-      fi
+    if [ -n "${INVOKER_DB_DIR:-}" ] && invoker_e2e_pid_has_env "$pid" "INVOKER_DB_DIR" "$INVOKER_DB_DIR"; then
+      count=$((count + 1))
+      continue
     fi
-    count=$((count + 1))
+    if [ -n "${INVOKER_API_PORT:-}" ] && invoker_e2e_pid_has_env "$pid" "INVOKER_API_PORT" "$INVOKER_API_PORT"; then
+      count=$((count + 1))
+      continue
+    fi
   done < <(pgrep -f '(/electron|packages/app/dist/main.js|headless-client.js|run.sh --headless)' 2>/dev/null || true)
   printf '%s' "$count"
 }


### PR DESCRIPTION
Problem: E2E dry-run cleanup depended on /proc cmdline and environ files, so macOS runs could leave nested headless Electron owners alive after a case exited.

Solution: add portable process command/environment helpers that use /proc where available and ps eww on macOS, then reuse them for owned-process kill and count paths.

Depends-On: #1137