### PR TITLE
fix(app): make no-track retry-task return after dispatch

### DIFF
--- a/packages/app/src/__tests__/headless-delegation.test.ts
+++ b/packages/app/src/__tests__/headless-delegation.test.ts
@@ -912,6 +912,60 @@ describe('headless delegation enforcement', () => {
         expect(runnable[0]?.id).toBe('wf-1/task-1');
       });
 
+      it('headless task retry defers runnable tasks in no-track mode', async () => {
+        const deferRunnableTasks = vi.fn();
+        const preemptTaskSubgraph = vi.fn(async () => {});
+        mockDeps.orchestrator.getPersistedActiveTaskIds = vi.fn(() => new Set<string>());
+        mockDeps.orchestrator.syncFromDb = vi.fn();
+        mockDeps.persistence.listWorkflows = vi.fn(() => [{
+          id: 'wf-1',
+          name: 'Workflow one',
+          generation: 0,
+          status: 'running' as const,
+          createdAt: new Date().toISOString(),
+          updatedAt: new Date().toISOString(),
+        }]);
+        mockDeps.persistence.loadTasks = vi.fn(() => [{
+          id: 'wf-1/task-1',
+          status: 'failed',
+          config: { workflowId: 'wf-1' },
+          execution: {},
+        } as any]);
+        mockDeps.commandService.retryTask = vi.fn(async () => ({
+          ok: true,
+          data: [
+            {
+              id: 'wf-1/task-1',
+              status: 'running',
+              config: { workflowId: 'wf-1' },
+              execution: { selectedAttemptId: 'attempt-1' },
+            },
+          ],
+        }));
+        mockDeps.orchestrator.startExecution = vi.fn(() => [
+          {
+            id: 'wf-2/task-9',
+            status: 'running',
+            config: { workflowId: 'wf-2' },
+            execution: { selectedAttemptId: 'attempt-9' },
+          } as any,
+        ]);
+
+        const depsWithNoTrack: HeadlessDeps = {
+          ...mockDeps,
+          noTrack: true,
+          deferRunnableTasks,
+          preemptTaskSubgraph,
+        } as HeadlessDeps;
+
+        await runHeadless(['retry-task', 'wf-1/task-1'], depsWithNoTrack);
+
+        expect(deferRunnableTasks).toHaveBeenCalledTimes(1);
+        const [runnable] = deferRunnableTasks.mock.calls[0] ?? [];
+        expect(runnable).toHaveLength(2);
+        expect(runnable.map((task: any) => task.id)).toEqual(['wf-1/task-1', 'wf-2/task-9']);
+      });
+
       it('headless retry always preempts, even when the workflow has no active execution', async () => {
         const preemptWorkflowExecution = vi.fn(async () => {});
         const depsWithNoTrack: HeadlessDeps = {

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -1637,6 +1637,37 @@ async function headlessRetryTask(taskId: string, deps: HeadlessDeps): Promise<vo
     const runnable = result.data.filter(isDispatchableLaunch);
     process.stdout.write(`Restarted task "${taskId}" — ${runnable.length} task(s) to execute\n`);
 
+    if (deps.noTrack) {
+      const runningKey = (task: TaskState): string => {
+        const attemptId = task.execution.selectedAttemptId?.trim();
+        return attemptId ? `attempt:${attemptId}` : `task:${task.id}`;
+      };
+      const scopedKeys = new Set(runnable.map((task) => runningKey(task)));
+      const globalTopup = deps.orchestrator
+        .startExecution()
+        .filter(isDispatchableLaunch)
+        .filter((task) => !scopedKeys.has(runningKey(task)));
+      const dispatchable = [...runnable, ...globalTopup];
+      if (dispatchable.length > 0) {
+        if (deps.deferRunnableTasks) {
+          deps.deferRunnableTasks(dispatchable, restored.workflowId);
+        } else {
+          const taskExecutor = createHeadlessExecutor(deps);
+          const launch = setTimeout(() => {
+            void taskExecutor.executeTasks(dispatchable).catch((err) => {
+              deps.logger.error(
+                `background no-track task retry failed for ${taskId}: ${err instanceof Error ? err.stack ?? err.message : String(err)}`,
+                { module: 'headless' },
+              );
+            });
+          }, 25);
+          launch.unref?.();
+        }
+      }
+      process.stdout.write('[headless] --no-track enabled: retry-task accepted; exiting without tracking.\n');
+      return;
+    }
+
     const taskExecutor = createHeadlessExecutor(deps);
     const autoFix = wireHeadlessAutoFix(deps, taskExecutor);
     const { topup } = await dispatchStartedTasksWithGlobalTopup({


### PR DESCRIPTION
Problem: retry-task --no-track accepted the retry but still entered workflow tracking, keeping headless.exec mutation intents open until the retried task finished.

Solution: in no-track mode, defer the scoped retry work plus global top-up tasks and return immediately after dispatch acceptance; add regression coverage for the deferral path.

Depends-On: #1138