### PR TITLE
fix(dispatch): remove acknowledged launch state

### DIFF
--- a/packages/app/e2e/task-new-attempt-reset.spec.ts
+++ b/packages/app/e2e/task-new-attempt-reset.spec.ts
@@ -156,10 +156,10 @@ base.describe('Task new-attempt reset repro', () => {
         'slow-task',
         (task) =>
           task.status === 'pending'
-          && task.execution?.phase === 'launching'
           && task.execution?.selectedAttemptId === oldAttemptId,
       );
       expect(staleBeforeResume.execution.selectedAttemptId).toBe(oldAttemptId);
+      expect(new Date(staleBeforeResume.execution.startedAt).toISOString()).toBe(staleTs);
 
       await page.evaluate(() => window.invoker.resumeWorkflow());
 

--- a/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
+++ b/packages/app/src/__tests__/launch-claim-orphan-regression.test.ts
@@ -156,8 +156,6 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
         ): Promise<void> {
           startedTasks.push(task);
           if (!opts) return;
-          const accepted = opts.launchOutbox.ackDispatch(opts.dispatchId, 'fake-runner');
-          if (!accepted) return;
           // Mark the task as running synchronously: this writes a terminal
           // launch event (`task.running`) which satisfies the invariant.
           const attemptId = task.execution.selectedAttemptId;
@@ -178,7 +176,6 @@ describe('launch-claim orphan regression (2026-05-22 storm)', () => {
         taskRunnerProvider: () => fakeTaskRunner,
         ownerId: 'cb5-test-owner',
         mode: 'active',
-        maxConcurrency: STORM_SIZE,
         maxLeasesPerPoll: STORM_SIZE,
       });
 

--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -83,7 +83,6 @@ describe('LaunchDispatcher', () => {
     const counts = observed?.fields?.counts as Record<string, number> | undefined;
     expect(counts?.enqueued).toBe(1);
     expect(counts?.leased).toBe(0);
-    expect(counts?.acknowledged).toBe(0);
 
     const afterPoll = adapter.loadLaunchDispatchById(enqueued.id);
     expect(afterPoll).toMatchObject({ state: 'enqueued' });
@@ -125,7 +124,7 @@ describe('LaunchDispatcher', () => {
     expect(observed?.fields?.total).toBe(0);
   });
 
-  describe('ack / complete / fail transitions', () => {
+  describe('complete / fail transitions', () => {
     function seedWorkflowAndTask(selectedAttemptId?: string): void {
       adapter.saveWorkflow({
         id: 'wf-1',
@@ -163,46 +162,7 @@ describe('LaunchDispatcher', () => {
       };
     }
 
-    it('ack moves a leased row to acknowledged and logs the transition', () => {
-      seedWorkflowAndTask('attempt-ack');
-      const enqueued = adapter.enqueueLaunchDispatch({
-        taskId: 'wf-1/t1',
-        attemptId: 'attempt-ack',
-        workflowId: 'wf-1',
-        generation: 0,
-      });
-      const leased = adapter.claimLaunchDispatchAtomic({
-        ownerId: 'owner-test',
-        maxConcurrency: 4,
-      });
-      expect(leased?.id).toBe(enqueued.id);
-
-      const { dispatcher, logger } = makeDispatcher();
-      expect(dispatcher.ackDispatch(enqueued.id, 'runner-1')).toBe(true);
-
-      const after = adapter.loadLaunchDispatchById(enqueued.id);
-      expect(after?.state).toBe('acknowledged');
-      expect(after?.dispatchOwner).toBe('runner-1');
-
-      const ackLog = logger.records.find((entry) => entry.msg.includes('ack'));
-      expect(ackLog?.fields?.accepted).toBe(true);
-      expect(ackLog?.fields?.dispatchId).toBe(enqueued.id);
-    });
-
-    it('ack returns false when the row is no longer leased', () => {
-      seedWorkflowAndTask();
-      const enqueued = adapter.enqueueLaunchDispatch({
-        taskId: 'wf-1/t1',
-        attemptId: 'attempt-ack-stale',
-        workflowId: 'wf-1',
-        generation: 0,
-      });
-
-      const { dispatcher } = makeDispatcher();
-      expect(dispatcher.ackDispatch(enqueued.id, 'runner-1')).toBe(false);
-    });
-
-    it('complete moves an acknowledged row to completed', () => {
+    it('complete moves a live row to completed', () => {
       seedWorkflowAndTask();
       const enqueued = adapter.enqueueLaunchDispatch({
         taskId: 'wf-1/t1',
@@ -244,7 +204,6 @@ describe('LaunchDispatcher', () => {
       });
       adapter.claimLaunchDispatchAtomic({
         ownerId: 'owner-test',
-        maxConcurrency: 4,
       });
 
       const { dispatcher } = makeDispatcher();
@@ -267,7 +226,6 @@ describe('LaunchDispatcher', () => {
       });
       adapter.claimLaunchDispatchAtomic({
         ownerId: 'owner-test',
-        maxConcurrency: 4,
       });
 
       const { dispatcher } = makeDispatcher();
@@ -359,7 +317,7 @@ describe('LaunchDispatcher', () => {
       expect(dispatcher.reapExpiredLeases()).toBe(0);
     });
 
-    it('abandonStuckLeases abandons acknowledged rows past max attempts and calls prepareTaskForNewAttempt', () => {
+    it('abandonStuckLeases abandons leased rows past max attempts and calls prepareTaskForNewAttempt', () => {
       seed();
       const row = adapter.enqueueLaunchDispatch({
         taskId: 'wf-r/t1',
@@ -370,7 +328,7 @@ describe('LaunchDispatcher', () => {
       const pastIso = new Date(Date.now() - 60_000).toISOString();
       (adapter as any).db.run(
         `UPDATE task_launch_dispatch
-           SET state = 'acknowledged', dispatch_owner = 'owner-x',
+           SET state = 'leased', dispatch_owner = 'owner-x',
                fenced_until = ?, attempts_count = 2, last_error = 'startup error'
          WHERE id = ?`,
         [pastIso, row.id],
@@ -405,7 +363,7 @@ describe('LaunchDispatcher', () => {
       const pastIso = new Date(Date.now() - 60_000).toISOString();
       (adapter as any).db.run(
         `UPDATE task_launch_dispatch
-           SET state = 'acknowledged', dispatch_owner = 'owner-x',
+           SET state = 'leased', dispatch_owner = 'owner-x',
                fenced_until = ?, attempts_count = 2, last_error = 'ssh-selection stuck'
          WHERE id = ?`,
         [pastIso, row.id],
@@ -488,7 +446,7 @@ describe('LaunchDispatcher', () => {
       const pastIso = new Date(Date.now() - 60_000).toISOString();
       (adapter as any).db.run(
         `UPDATE task_launch_dispatch
-           SET state = 'acknowledged', fenced_until = ?, attempts_count = 2,
+           SET state = 'leased', fenced_until = ?, attempts_count = 2,
                dispatch_owner = 'owner-x'
          WHERE id = ?`,
         [pastIso, row.id],
@@ -513,7 +471,7 @@ describe('LaunchDispatcher', () => {
       const futureIso = new Date(Date.now() + 60_000).toISOString();
       (adapter as any).db.run(
         `UPDATE task_launch_dispatch
-           SET state = 'acknowledged', fenced_until = ?, attempts_count = 5
+           SET state = 'leased', fenced_until = ?, attempts_count = 5
          WHERE id = ?`,
         [futureIso, futureRow.id],
       );
@@ -527,7 +485,7 @@ describe('LaunchDispatcher', () => {
       const pastIso = new Date(Date.now() - 60_000).toISOString();
       (adapter as any).db.run(
         `UPDATE task_launch_dispatch
-           SET state = 'acknowledged', fenced_until = ?, attempts_count = 1
+           SET state = 'leased', fenced_until = ?, attempts_count = 1
          WHERE id = ?`,
         [pastIso, underAttemptRow.id],
       );
@@ -621,7 +579,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
       dispatcher.poll();
 
@@ -633,7 +590,7 @@ describe('LaunchDispatcher', () => {
       expect(optsArg.launchOutbox).toBe(dispatcher);
 
       // Row is leased on this poll; the runner will transition it via
-      // ackDispatch/completeDispatch (those are unit-tested elsewhere).
+      // completeDispatch/failDispatch (those are unit-tested elsewhere).
       const after = adapter.loadLaunchDispatchById(enq.id);
       expect(after?.state).toBe('leased');
       expect(after?.dispatchOwner).toBe('owner-a');
@@ -678,7 +635,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 10,
         maxLeasesPerPoll: 2,
       });
       dispatcher.poll();
@@ -727,7 +683,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 1,
       });
 
       dispatcher.poll();
@@ -767,7 +722,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
 
       dispatcher.poll();
@@ -812,7 +766,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
 
       dispatcher.poll();
@@ -858,7 +811,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
       dispatcher.poll();
 
@@ -879,7 +831,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
       dispatcher.poll();
       expect(executeTask).not.toHaveBeenCalled();
@@ -906,7 +857,6 @@ describe('LaunchDispatcher', () => {
         },
         taskRunnerProvider: () => ({ executeTask }),
         mode: 'active',
-        maxConcurrency: 4,
       });
       dispatcher.poll();
       // Wait one microtask tick for the .catch backstop to run.

--- a/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
+++ b/packages/app/src/__tests__/launch-pool-deferral-outbox-repro.test.ts
@@ -94,7 +94,6 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
       async executeTask(task, opts) {
         runnerCalls += 1;
         const dispatchOpts = opts!;
-        expect(dispatchOpts.launchOutbox.ackDispatch(dispatchOpts.dispatchId, 'pool-runner')).toBe(true);
         const attemptId = task.execution.selectedAttemptId!;
 
         if (runnerCalls === 1) {
@@ -118,7 +117,6 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
     }),
     ownerId: 'pool-owner',
     mode: 'active',
-    maxConcurrency: 1,
     maxLeasesPerPoll: 1,
   });
 
@@ -139,7 +137,7 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
     runnerCalls,
     task: orchestrator.getTask(taskId)!,
     liveRows: persistence
-      .listLaunchDispatchesByState(['enqueued', 'leased', 'acknowledged'])
+      .listLaunchDispatchesByState(['enqueued', 'leased'])
       .filter((row) => row.taskId === taskId)
       .map((row) => ({ attemptId: row.attemptId, state: row.state })),
     abandonedRows: persistence
@@ -155,7 +153,7 @@ async function runPoolDeferralScenario(options: { completeDeferredDispatch: bool
 }
 
 describe('launch pool deferral outbox repro', () => {
-  it('invalidates an acknowledged deferred row so it cannot block the replacement launch', async () => {
+  it('invalidates a leased deferred row so it cannot block the replacement launch', async () => {
     const result = await runPoolDeferralScenario({ completeDeferredDispatch: false });
 
     expect(result.runnerCalls).toBe(2);

--- a/packages/app/src/headless.ts
+++ b/packages/app/src/headless.ts
@@ -311,7 +311,6 @@ async function dispatchHeadlessRunnableTasks(
     ownerId: `headless-${process.pid}`,
     logger: deps.logger,
     mode: 'active',
-    maxConcurrency: Math.max(1, deps.invokerConfig.maxConcurrency ?? 16),
   });
   deps.logger?.debug?.(
     `[headless] ${context}: launchOutboxMode=active — polling local launch dispatcher for ${runnable.length} runnable task(s)`,
@@ -1021,6 +1020,7 @@ async function headlessMigrateCompatibility(deps: HeadlessDeps): Promise<void> {
   process.stdout.write(`  migratedFixingWithAiStatuses: ${report.migratedFixingWithAiStatuses}\n`);
   process.stdout.write(`  normalizedMergeModes: ${report.normalizedMergeModes}\n`);
   process.stdout.write(`  staleAutoFixExperimentTasks: ${report.staleAutoFixExperimentTasks}\n`);
+  process.stdout.write(`  normalizedLegacyAcknowledgedLaunchDispatches: ${report.normalizedLegacyAcknowledgedLaunchDispatches}\n`);
 }
 
 async function headlessInstallSkills(

--- a/packages/app/src/ipc-read-handlers.ts
+++ b/packages/app/src/ipc-read-handlers.ts
@@ -3,6 +3,7 @@ import type { Logger, SearchOptions } from '@invoker/contracts';
 import type { SQLiteAdapter } from '@invoker/data-store';
 import type { AgentRegistry } from '@invoker/execution-engine';
 import type { Orchestrator, TaskDelta, TaskState } from '@invoker/workflow-core';
+import type { MessageBus } from '@invoker/transport';
 import { loadConfig } from './config.js';
 import type { TaskSnapshotCache } from './delta-merge.js';
 
@@ -24,6 +25,8 @@ export interface RegisterReadOnlyIpcHandlersContext {
     agentRegistry: AgentRegistry,
     tasks: TaskState[],
   ) => Promise<unknown>;
+  getOwnerMode?: () => boolean;
+  getMessageBus?: () => Pick<MessageBus, 'request'>;
   timeStartupPhase: <T>(label: string, fn: () => T, fields?: () => Record<string, unknown>) => T;
   recordStartupDuration: (label: string, startedAtMs: number, fields?: Record<string, unknown>) => void;
   getTaskDeltaStreamSequence: () => number;
@@ -43,6 +46,8 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     setLastKnownWorkflowCount,
     loadTaskByIdFromPersistence,
     resolveAgentSession,
+    getOwnerMode,
+    getMessageBus,
     timeStartupPhase,
     recordStartupDuration,
     getTaskDeltaStreamSequence,
@@ -68,9 +73,52 @@ export function registerReadOnlyIpcHandlers(context: RegisterReadOnlyIpcHandlers
     return { workflow, tasks };
   });
 
-  ipcMain.handle('invoker:get-tasks', (_event, forceRefresh?: boolean) => {
+  ipcMain.handle('invoker:get-tasks', async (_event, forceRefresh?: boolean) => {
     const startedAtMs = Date.now();
     const orchestrator = getOrchestrator();
+    if (forceRefresh && getOwnerMode?.() === false) {
+      try {
+        const delegated = await getMessageBus?.().request<{ kind: string; forceRefresh: boolean }, {
+          tasks: TaskState[];
+          workflows: unknown[];
+          streamSequence: number;
+        }>('headless.query', { kind: 'tasks', forceRefresh: true });
+        if (delegated && Array.isArray(delegated.tasks) && Array.isArray(delegated.workflows)) {
+          const previousTaskIds = new Set(lastKnownTaskStates.keys());
+          lastKnownTaskStates.clear();
+          for (const task of delegated.tasks) {
+            lastKnownTaskStates.set(task.id, JSON.stringify(task));
+            previousTaskIds.delete(task.id);
+            const mainWindow = getMainWindow();
+            if (mainWindow && !mainWindow.isDestroyed()) {
+              sendTaskDeltaToRenderer({ type: 'created', task });
+            }
+          }
+          const mainWindow = getMainWindow();
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            for (const removedTaskId of previousTaskIds) {
+              sendTaskDeltaToRenderer({ type: 'removed', taskId: removedTaskId, previousTaskStateVersion: 0 });
+            }
+            requestWorkflowMetadataPublish('get-tasks-force-refresh-delegated');
+          }
+          setLastKnownWorkflowCount(delegated.workflows.length);
+          recordStartupDuration('get-tasks.force-refresh.delegated-return', startedAtMs, {
+            taskCount: delegated.tasks.length,
+            workflowCount: delegated.workflows.length,
+            jsonSizeBytes: Buffer.byteLength(JSON.stringify(delegated), 'utf8'),
+            streamSequence: delegated.streamSequence,
+          });
+          return delegated;
+        }
+      } catch (err) {
+        logger.warn(
+          `get-tasks(forceRefresh=true) owner delegation failed; falling back to local read-only snapshot: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+          { module: 'ipc' },
+        );
+      }
+    }
     if (forceRefresh) {
       timeStartupPhase('get-tasks.force-refresh.syncAllFromDb', () => orchestrator.syncAllFromDb(), () => ({
         taskCount: orchestrator.getAllTasks().length,

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -23,12 +23,11 @@ export type LaunchDispatcherMode = 'observe' | 'active';
 export type LaunchDispatcherPersistence = Pick<
   SQLiteAdapter,
   | 'listLaunchDispatchesByState'
-  | 'markLaunchDispatchAcknowledged'
   | 'markLaunchDispatchCompleted'
   | 'markLaunchDispatchFailed'
   | 'markLaunchDispatchAbandoned'
   | 'reapExpiredLaunchDispatchLeases'
-  | 'listAbandonableAcknowledgedLeases'
+  | 'listAbandonableLaunchDispatchLeases'
   | 'claimLaunchDispatchAtomic'
   | 'listExecutionResourceLeasesByTask'
   | 'releaseExecutionResourceLease'
@@ -77,14 +76,12 @@ export interface LaunchDispatcherOptions {
   logger?: Logger;
   mode: LaunchDispatcherMode;
   maxAttempts?: number;
-  maxConcurrency?: number;
   maxLeasesPerPoll?: number;
 }
 
 const OBSERVED_STATES: readonly TaskLaunchDispatchState[] = [
   'enqueued',
   'leased',
-  'acknowledged',
 ];
 
 export class LaunchDispatcher {
@@ -95,7 +92,6 @@ export class LaunchDispatcher {
   private readonly logger?: Logger;
   private readonly mode: LaunchDispatcherMode;
   private readonly maxAttempts: number;
-  private readonly maxConcurrency: number;
   private readonly maxLeasesPerPoll: number;
 
   constructor(options: LaunchDispatcherOptions) {
@@ -106,7 +102,6 @@ export class LaunchDispatcher {
     this.logger = options.logger;
     this.mode = options.mode;
     this.maxAttempts = options.maxAttempts ?? DISPATCH_MAX_ATTEMPTS;
-    this.maxConcurrency = options.maxConcurrency ?? 16;
     // Bound a single poll's work so the dispatcher cannot starve other
     // owner-loop ticks; the leftover rows are picked up on the next tick.
     this.maxLeasesPerPoll = options.maxLeasesPerPoll ?? 32;
@@ -124,11 +119,11 @@ export class LaunchDispatcher {
    * Single dispatcher tick:
    *
    *   1. Reap any leased rows whose dispatch lease expired (TaskRunner
-   *      never acked — we want to try again).
-   *   2. Abandon any acknowledged rows whose dispatch lease expired AND
-   *      that have exhausted their retry budget (TaskRunner accepted
-   *      ownership but never completed; report the failure and let the
-   *      orchestrator prepare a fresh attempt).
+   *      never completed startup — we want to try again).
+   *   2. Abandon any leased rows whose dispatch lease expired AND that
+   *      have exhausted their retry budget (TaskRunner accepted ownership
+   *      but never completed; report the failure and let the orchestrator
+   *      prepare a fresh attempt).
    *   3. In observe mode, log the aggregate state counts. In active mode,
    *      (CB.5) lease and dispatch new work.
    *
@@ -157,10 +152,10 @@ export class LaunchDispatcher {
   }
 
   /**
-   * Active-mode dispatch loop. Lease as many enqueued rows as capacity
-   * allows (bounded by `maxLeasesPerPoll`) and hand each one to the
-   * TaskRunner. The TaskRunner ack/complete/fail flow drives the rest
-   * of the lifecycle; if the JS promise drops mid-flight, the durable
+   * Active-mode dispatch loop. Lease enqueued rows up to the per-poll
+   * batch bound and hand each one to the
+   * TaskRunner. The TaskRunner complete/fail flow drives the rest of
+   * the lifecycle; if the JS promise drops mid-flight, the durable
    * outbox row stays leased and the next poll's `reapExpiredLeases`
    * reclaims it after `DISPATCH_LEASE_MS`.
    */
@@ -177,7 +172,6 @@ export class LaunchDispatcher {
     while (dispatched < this.maxLeasesPerPoll) {
       const leased = this.persistence.claimLaunchDispatchAtomic({
         ownerId: this.ownerId,
-        maxConcurrency: this.maxConcurrency,
       });
       if (!leased) break;
       dispatched += 1;
@@ -297,7 +291,10 @@ export class LaunchDispatcher {
    * Returns the number of rows reaped.
    */
   reapExpiredLeases(nowIso?: string): number {
-    const reaped = this.persistence.reapExpiredLaunchDispatchLeases(nowIso);
+    const reaped = this.persistence.reapExpiredLaunchDispatchLeases({
+      nowIso,
+      maxAttempts: this.maxAttempts,
+    });
     for (const row of reaped) {
       this.persistence.logEvent?.(row.taskId, 'task.launch_dispatch_reaped', {
         dispatchId: row.id,
@@ -318,14 +315,14 @@ export class LaunchDispatcher {
   }
 
   /**
-   * For every `acknowledged` row whose fence has expired AND whose
+   * For every `leased` row whose fence has expired AND whose
    * attempts_count has reached `maxAttempts`, transition it to
    * `abandoned`, ask the orchestrator to prepare a fresh attempt, and
    * emit a real `task.failed` event with a concrete error message.
    * Returns the number of rows abandoned.
    */
   abandonStuckLeases(nowIso?: string): number {
-    const candidates = this.persistence.listAbandonableAcknowledgedLeases({
+    const candidates = this.persistence.listAbandonableLaunchDispatchLeases({
       nowIso,
       maxAttempts: this.maxAttempts,
     });
@@ -446,26 +443,7 @@ export class LaunchDispatcher {
   }
 
   /**
-   * Transition a leased dispatch row to acknowledged. Called by the
-   * TaskRunner at the top of {@link executeTask} once it has accepted
-   * ownership of the launch. Returns false when the row is no longer
-   * in `leased` (e.g. it was reaped first), in which case the runner
-   * should bail out without starting the executor.
-   */
-  ackDispatch(dispatchId: number, runnerId: string): boolean {
-    const ok = this.persistence.markLaunchDispatchAcknowledged(dispatchId, runnerId);
-    this.logger?.info?.('[launch-dispatcher] ack', {
-      ownerId: this.ownerId,
-      dispatchId,
-      runnerId,
-      accepted: ok,
-      module: 'launch-dispatcher',
-    });
-    return ok;
-  }
-
-  /**
-   * Transition an acknowledged dispatch row to completed. Called by the
+   * Transition a live dispatch row to completed. Called by the
    * TaskRunner once {@link markTaskRunningAfterLaunch} has succeeded
    * (the executor handle is live and the task is in the executing
    * phase). Returns false when the row is already terminal.
@@ -508,7 +486,6 @@ function countByState(
   const counts: Record<TaskLaunchDispatchState, number> = {
     enqueued: 0,
     leased: 0,
-    acknowledged: 0,
     completed: 0,
     abandoned: 0,
   };

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -205,6 +205,26 @@ function isTaskInFlightForForcedStop(task: TaskState): boolean {
     || (task.status === 'pending' && task.execution.phase === 'launching');
 }
 
+function isTaskRecoverableOnExplicitResume(task: TaskState): boolean {
+  if (task.status === 'running') return true;
+  if (task.status !== 'pending' || !task.execution.selectedAttemptId) return false;
+  if (task.execution.phase === 'launching') return true;
+
+  return Boolean(
+    task.execution.startedAt
+    || task.execution.launchStartedAt
+    || task.execution.launchCompletedAt
+    || task.execution.lastHeartbeatAt
+    || task.execution.workspacePath
+    || task.execution.agentSessionId
+    || task.execution.containerId
+    || task.execution.error
+    || task.execution.exitCode !== undefined
+    || task.execution.inputPrompt
+    || task.execution.pendingFixError,
+  );
+}
+
 declare const __BUILD_SHA__: string | undefined;
 declare const __BUILD_VERSION__: string | undefined;
 
@@ -864,15 +884,20 @@ if (isHeadless) {
         return { workflowId, tasks };
       };
 
+      const executeStandaloneResumeStartedTasks = async (
+        executor: ReturnType<typeof createStandaloneTaskExecutor>,
+        started: TaskState[],
+      ): Promise<void> => {
+        if (invokerConfig.launchOutboxMode !== 'active') {
+          await executor.executeTasks(started);
+        }
+      };
+
       const executeStandaloneHeadlessResume = async (payload: HeadlessResumeMutationPayload): Promise<unknown> => {
         const { workflowId } = payload;
         const executor = createStandaloneTaskExecutor();
-        orchestrator.syncFromDb(workflowId);
-        // CC.2: orphan relaunch removed. orchestrator.startExecution()
-        // enqueues into the task_launch_dispatch outbox; the
-        // LaunchDispatcher's poll loop is the single recovery path.
-        const started = orchestrator.startExecution();
-        await executor.executeTasks(started);
+        const started = orchestrator.resumeWorkflow(workflowId);
+        await executeStandaloneResumeStartedTasks(executor, started);
         logger.info(`standalone resumed ${started.length} tasks for workflow "${workflowId}"`, { module: 'ipc-delegate' });
         const tasks = orchestrator.getAllTasks().filter((task) => task.config.workflowId === workflowId);
         return { workflowId, tasks };
@@ -1124,19 +1149,26 @@ if (isHeadless) {
           return { workflowId, tasks };
         };
 
+        const executeStandaloneResumeStartedTasks = (
+          executor: ReturnType<typeof createStandaloneTaskExecutor>,
+          started: TaskState[],
+          workflowId: string,
+        ): void => {
+          if (started.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
+            executor.executeTasks(started).catch(err => {
+              logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
+            });
+          }
+        };
+
         const executeStandaloneHeadlessResume = async (
           payload: HeadlessResumeMutationPayload,
         ): Promise<{ workflowId: string; tasks: TaskState[] }> => {
           const { workflowId } = payload;
-          orchestrator.syncFromDb(workflowId);
           const executor = createStandaloneTaskExecutor();
 
-          const allStarted = orchestrator.startExecution();
-          if (allStarted.length > 0) {
-            executor.executeTasks(allStarted).catch(err => {
-              logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
-            });
-          }
+          const allStarted = orchestrator.resumeWorkflow(workflowId);
+          executeStandaloneResumeStartedTasks(executor, allStarted, workflowId);
           const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
           return { workflowId, tasks };
         };
@@ -1177,6 +1209,32 @@ if (isHeadless) {
           }
           if (kind === 'queue') {
             return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+          }
+          if (kind === 'tasks') {
+            if ((req as { forceRefresh?: boolean }).forceRefresh) {
+              orchestrator.syncAllFromDb();
+            }
+            return {
+              tasks: orchestrator.getAllTasks(),
+              workflows: persistence.listWorkflows(),
+              streamSequence: 0,
+            };
+          }
+          if (kind === 'action-graph') {
+            orchestrator.syncAllFromDb();
+            const tasks = orchestrator.getAllTasks();
+            const workflows = persistence.listWorkflows();
+            return buildActionGraphDiagnostics({
+              workflows,
+              tasks,
+              attemptsByTaskId: new Map(tasks.map((task) => [task.id, persistence.loadAttempts(task.id)])),
+              queueStatus: orchestrator.getQueueStatus(),
+              mutationIntents: persistence.listWorkflowMutationIntents(),
+              mutationLeases: persistence.listWorkflowMutationLeases(),
+              eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
+              activityLogs: persistence.getActivityLogs(0, 200),
+              stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
+            });
           }
           throw new Error(`Unsupported headless query: ${String(kind)}`);
         });
@@ -1871,6 +1929,17 @@ function createEmbeddedTerminalBackendFromConfig(
     return requireWiredTaskRunner(() => taskExecutor);
   }
 
+  function executeHeadlessResumeStartedTasks(
+    started: TaskState[],
+    workflowId: string,
+  ): void {
+    if (started.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
+      requireTaskExecutor().executeTasks(started).catch(err => {
+        logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
+      });
+    }
+  }
+
   async function executeHeadlessRun(payload: HeadlessRunMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
     const { parsePlanFile } = await import('./plan-parser.js');
     const plan = await parsePlanFile(payload.planPath);
@@ -1892,14 +1961,9 @@ function createEmbeddedTerminalBackendFromConfig(
 
   async function executeHeadlessResume(payload: HeadlessResumeMutationPayload): Promise<{ workflowId: string; tasks: TaskState[] }> {
     const { workflowId } = payload;
-    orchestrator.syncFromDb(workflowId);
 
-    const allStarted = orchestrator.startExecution();
-    if (allStarted.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
-      requireTaskExecutor().executeTasks(allStarted).catch(err => {
-        logger.error(`headless.resume: executeTasks failed for "${workflowId}": ${err}`, { module: 'ipc-delegate' });
-      });
-    }
+    const allStarted = orchestrator.resumeWorkflow(workflowId);
+    executeHeadlessResumeStartedTasks(allStarted, workflowId);
     const tasks = orchestrator.getAllTasks().filter(t => t.config.workflowId === workflowId);
     return { workflowId, tasks };
   }
@@ -2649,7 +2713,6 @@ function createEmbeddedTerminalBackendFromConfig(
           ownerId: workflowMutationOwnerId,
           logger,
           mode: invokerConfig.launchOutboxMode as LaunchDispatcherMode,
-          maxConcurrency: effectiveMaxConcurrency,
         });
       }
     } else {
@@ -2695,6 +2758,32 @@ function createEmbeddedTerminalBackendFromConfig(
         }
         if (kind === 'queue') {
           return orchestrator.getQueueStatus() as unknown as Record<string, unknown>;
+        }
+        if (kind === 'tasks') {
+          if ((req as { forceRefresh?: boolean }).forceRefresh) {
+            orchestrator.syncAllFromDb();
+          }
+          return {
+            tasks: orchestrator.getAllTasks(),
+            workflows: persistence.listWorkflows(),
+            streamSequence: getTaskDeltaStreamSequence(),
+          };
+        }
+        if (kind === 'action-graph') {
+          orchestrator.syncAllFromDb();
+          const tasks = orchestrator.getAllTasks();
+          const workflows = persistence.listWorkflows();
+          return buildActionGraphDiagnostics({
+            workflows,
+            tasks,
+            attemptsByTaskId: new Map(tasks.map((task) => [task.id, persistence.loadAttempts(task.id)])),
+            queueStatus: orchestrator.getQueueStatus(),
+            mutationIntents: persistence.listWorkflowMutationIntents(),
+            mutationLeases: persistence.listWorkflowMutationLeases(),
+            eventsByTaskId: new Map(tasks.map((task) => [task.id, persistence.getEvents(task.id)])),
+            activityLogs: persistence.getActivityLogs(0, 200),
+            stallThresholdMs: resolveActionDiagnosticsStallThresholdMs(invokerConfig),
+          });
         }
         throw new Error(`Unsupported headless query: ${String(kind)}`);
       });
@@ -2915,14 +3004,7 @@ function createEmbeddedTerminalBackendFromConfig(
       }
       orchestrator.syncAllFromDb();
 
-      const tasksToRecover = orchestrator.getAllTasks().filter((task) =>
-        task.status === 'running'
-        || (
-          task.status === 'pending'
-          && task.execution.phase === 'launching'
-          && !!task.execution.selectedAttemptId
-        )
-      );
+      const tasksToRecover = orchestrator.getAllTasks().filter(isTaskRecoverableOnExplicitResume);
       for (const task of tasksToRecover) {
         orchestrator.prepareTaskForNewAttempt(task.id, 'resume_workflow_recovery');
       }
@@ -2938,6 +3020,16 @@ function createEmbeddedTerminalBackendFromConfig(
       logger.info(`resume-workflow: ${tasks.length} tasks loaded across ${workflows.length} workflows, ${allStarted.length} started`, { module: 'ipc' });
       if (allStarted.length > 0 && invokerConfig.launchOutboxMode !== 'active') {
         void requireTaskExecutor().executeTasks(allStarted);
+      }
+      if (allStarted.length > 0 && invokerConfig.launchOutboxMode === 'active' && launchDispatcher) {
+        try {
+          launchDispatcher.poll();
+        } catch (err) {
+          logger.warn(
+            `resume-workflow: launch dispatcher poll failed: ${err instanceof Error ? err.message : String(err)}`,
+            { module: 'ipc' },
+          );
+        }
       }
       return { workflow: workflows[0], taskCount: tasks.length, startedCount: allStarted.length };
     });
@@ -3016,6 +3108,8 @@ function createEmbeddedTerminalBackendFromConfig(
       setLastKnownWorkflowCount: (count) => { lastKnownWorkflowCount = count; },
       loadTaskByIdFromPersistence,
       resolveAgentSession,
+      getOwnerMode: () => ownerMode,
+      getMessageBus: () => messageBus,
       timeStartupPhase,
       recordStartupDuration,
       getTaskDeltaStreamSequence,
@@ -3252,7 +3346,19 @@ function createEmbeddedTerminalBackendFromConfig(
       return orchestrator.getQueueStatus();
     });
 
-    ipcMain.handle('invoker:get-action-graph', () => {
+    ipcMain.handle('invoker:get-action-graph', async () => {
+      if (!ownerMode) {
+        try {
+          return await messageBus.request('headless.query', { kind: 'action-graph' });
+        } catch (err) {
+          logger.warn(
+            `get-action-graph owner delegation failed; falling back to local read-only snapshot: ${
+              err instanceof Error ? err.message : String(err)
+            }`,
+            { module: 'ipc' },
+          );
+        }
+      }
       orchestrator.syncAllFromDb();
       const tasks = orchestrator.getAllTasks();
       const workflows = persistence.listWorkflows();

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -319,7 +319,7 @@ describe('SQLiteAdapter', () => {
       expect(second.id).toBe(first.id);
       expect(second.priority).toBe('high');
       expect(
-        adapter.listLaunchDispatchesByState(['enqueued', 'leased', 'acknowledged']),
+        adapter.listLaunchDispatchesByState(['enqueued', 'leased']),
       ).toHaveLength(1);
     });
 
@@ -363,30 +363,77 @@ describe('SQLiteAdapter', () => {
       expect(completedOnly).toEqual(['attempt-a']);
     });
 
-    it('markLaunchDispatchAcknowledged only succeeds for leased rows', () => {
-      setupWorkflowAndTask();
-      const row = adapter.enqueueLaunchDispatch({
-        taskId: 'wf-launch/t1',
-        attemptId: 'attempt-ack',
+    it('runCompatibilityMigration normalizes legacy acknowledged rows', () => {
+      adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
+      saveLaunchTask('wf-launch', 'wf-launch/t-future', 'attempt-future');
+      saveLaunchTask('wf-launch', 'wf-launch/t-expired', 'attempt-expired');
+      saveLaunchTask('wf-launch', 'wf-launch/t-stale', 'attempt-current');
+      const future = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t-future',
+        attemptId: 'attempt-future',
         workflowId: 'wf-launch',
         generation: 0,
       });
-
-      expect(adapter.markLaunchDispatchAcknowledged(row.id, 'runner-1')).toBe(false);
-
+      const expired = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t-expired',
+        attemptId: 'attempt-expired',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      const stale = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-launch/t-stale',
+        attemptId: 'attempt-stale',
+        workflowId: 'wf-launch',
+        generation: 0,
+      });
+      const now = Date.now();
       (adapter as any).db.run(
-        `UPDATE task_launch_dispatch SET state = 'leased', fenced_until = datetime('now', '+30 seconds') WHERE id = ?`,
-        [row.id],
+        `UPDATE task_launch_dispatch SET state = 'acknowledged', dispatch_owner = 'owner-future',
+            leased_at = ?, acknowledged_at = ?, fenced_until = ?
+         WHERE id = ?`,
+        [
+          new Date(now - 1_000).toISOString(),
+          new Date(now - 1_000).toISOString(),
+          new Date(now + 60_000).toISOString(),
+          future.id,
+        ],
+      );
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'acknowledged', dispatch_owner = 'owner-expired',
+            leased_at = ?, acknowledged_at = ?, fenced_until = ?
+         WHERE id = ?`,
+        [
+          new Date(now - 120_000).toISOString(),
+          new Date(now - 120_000).toISOString(),
+          new Date(now - 60_000).toISOString(),
+          expired.id,
+        ],
+      );
+      (adapter as any).db.run(
+        `UPDATE task_launch_dispatch SET state = 'acknowledged', dispatch_owner = 'owner-stale',
+            leased_at = ?, acknowledged_at = ?, fenced_until = ?
+         WHERE id = ?`,
+        [
+          new Date(now - 120_000).toISOString(),
+          new Date(now - 120_000).toISOString(),
+          new Date(now + 60_000).toISOString(),
+          stale.id,
+        ],
       );
 
-      expect(adapter.markLaunchDispatchAcknowledged(row.id, 'runner-1')).toBe(true);
-      const after = adapter.loadLaunchDispatchById(row.id);
-      expect(after?.state).toBe('acknowledged');
-      expect(after?.dispatchOwner).toBe('runner-1');
-      expect(after?.acknowledgedAt).toBeDefined();
-      expect(after?.fencedUntil).toBeDefined();
+      const report = adapter.runCompatibilityMigration();
 
-      expect(adapter.markLaunchDispatchAcknowledged(row.id, 'runner-1')).toBe(false);
+      expect(report.normalizedLegacyAcknowledgedLaunchDispatches).toBe(3);
+      expect(adapter.loadLaunchDispatchById(future.id)?.state).toBe('leased');
+      expect(adapter.loadLaunchDispatchById(expired.id)?.state).toBe('enqueued');
+      const staleAfter = adapter.loadLaunchDispatchById(stale.id);
+      expect(staleAfter?.state).toBe('abandoned');
+      expect(staleAfter?.lastError).toMatch(/Legacy acknowledged launch dispatch is stale/);
+      const legacyCount = sqliteScalar(
+        adapter,
+        `SELECT COUNT(*) AS count FROM task_launch_dispatch WHERE state = 'acknowledged'`,
+      );
+      expect(legacyCount).toBe(0);
     });
 
     it('markLaunchDispatchCompleted transitions to completed and rejects already-terminal rows', () => {
@@ -456,7 +503,7 @@ describe('SQLiteAdapter', () => {
         [futureIso, live.id],
       );
 
-      const reaped = adapter.reapExpiredLaunchDispatchLeases(now.toISOString());
+      const reaped = adapter.reapExpiredLaunchDispatchLeases({ nowIso: now.toISOString() });
       expect(reaped.map((row) => row.attemptId)).toEqual(['attempt-expired']);
       const expiredAfter = adapter.loadLaunchDispatchById(expired.id);
       expect(expiredAfter?.state).toBe('enqueued');
@@ -479,7 +526,6 @@ describe('SQLiteAdapter', () => {
 
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-1',
-          maxConcurrency: 4,
         });
 
         expect(claimed?.id).toBe(enqueued.id);
@@ -494,7 +540,6 @@ describe('SQLiteAdapter', () => {
         setupWorkflowAndTask();
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-1',
-          maxConcurrency: 4,
         });
         expect(claimed).toBeUndefined();
       });
@@ -512,11 +557,9 @@ describe('SQLiteAdapter', () => {
 
         const first = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-a',
-          maxConcurrency: 4,
         });
         const second = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-b',
-          maxConcurrency: 4,
         });
 
         expect(first?.dispatchOwner).toBe('runner-a');
@@ -551,15 +594,12 @@ describe('SQLiteAdapter', () => {
 
         const firstClaim = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-pri',
-          maxConcurrency: 4,
         });
         const secondClaim = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-pri',
-          maxConcurrency: 4,
         });
         const thirdClaim = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-pri',
-          maxConcurrency: 4,
         });
 
         expect(firstClaim?.id).toBe(high.id);
@@ -567,65 +607,40 @@ describe('SQLiteAdapter', () => {
         expect(thirdClaim?.attemptId).toBe('attempt-low');
       });
 
-      it('enforces maxConcurrency by counting leased + acknowledged rows', () => {
+      it('leases queued work even when legacy acknowledged rows exist', () => {
         adapter.saveWorkflow({ ...testWorkflow, id: 'wf-launch' });
-        saveLaunchTask('wf-launch', 'wf-launch/t-cap-1', 'attempt-cap-1');
-        saveLaunchTask('wf-launch', 'wf-launch/t-cap-2', 'attempt-cap-2');
-        adapter.enqueueLaunchDispatch({
-          taskId: 'wf-launch/t-cap-1',
-          attemptId: 'attempt-cap-1',
+        for (let i = 0; i < 12; i += 1) {
+          const taskId = `wf-launch/t-legacy-${i}`;
+          const attemptId = `attempt-legacy-${i}`;
+          saveLaunchTask('wf-launch', taskId, attemptId);
+          const legacy = adapter.enqueueLaunchDispatch({
+            taskId,
+            attemptId,
+            workflowId: 'wf-launch',
+            generation: 0,
+          });
+          (adapter as any).db.run(
+            `UPDATE task_launch_dispatch
+               SET state = 'acknowledged', dispatch_owner = 'old-owner',
+                   fenced_until = ?, attempts_count = 1
+             WHERE id = ?`,
+            [new Date(Date.now() - 60_000).toISOString(), legacy.id],
+          );
+        }
+        saveLaunchTask('wf-launch', 'wf-launch/t-target', 'attempt-target');
+        const target = adapter.enqueueLaunchDispatch({
+          taskId: 'wf-launch/t-target',
+          attemptId: 'attempt-target',
           workflowId: 'wf-launch',
           generation: 0,
         });
-        adapter.enqueueLaunchDispatch({
-          taskId: 'wf-launch/t-cap-2',
-          attemptId: 'attempt-cap-2',
-          workflowId: 'wf-launch',
-          generation: 0,
-        });
 
-        const first = adapter.claimLaunchDispatchAtomic({
-          ownerId: 'runner-c',
-          maxConcurrency: 1,
-        });
-        expect(first?.attemptId).toBe('attempt-cap-1');
-
-        const blocked = adapter.claimLaunchDispatchAtomic({
-          ownerId: 'runner-c',
-          maxConcurrency: 1,
-        });
-        expect(blocked).toBeUndefined();
-
-        adapter.markLaunchDispatchAcknowledged(first!.id, 'runner-c');
-        const stillBlocked = adapter.claimLaunchDispatchAtomic({
-          ownerId: 'runner-c',
-          maxConcurrency: 1,
-        });
-        expect(stillBlocked).toBeUndefined();
-
-        adapter.markLaunchDispatchCompleted(first!.id);
-        const unblocked = adapter.claimLaunchDispatchAtomic({
-          ownerId: 'runner-c',
-          maxConcurrency: 1,
-        });
-        expect(unblocked?.attemptId).toBe('attempt-cap-2');
-      });
-
-      it('returns undefined when maxConcurrency is zero', () => {
-        setupWorkflowAndTask('wf-launch', 'wf-launch/t1', {
-          selectedAttemptId: 'attempt-zero',
-        });
-        adapter.enqueueLaunchDispatch({
-          taskId: 'wf-launch/t1',
-          attemptId: 'attempt-zero',
-          workflowId: 'wf-launch',
-          generation: 0,
-        });
         const claimed = adapter.claimLaunchDispatchAtomic({
-          ownerId: 'runner-z',
-          maxConcurrency: 0,
+          ownerId: 'runner-c',
         });
-        expect(claimed).toBeUndefined();
+
+        expect(claimed?.id).toBe(target.id);
+        expect(claimed?.state).toBe('leased');
       });
 
       it('abandons a stale selected-attempt candidate and scans to the next valid row', () => {
@@ -649,7 +664,6 @@ describe('SQLiteAdapter', () => {
 
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-scan',
-          maxConcurrency: 4,
           nowIso: '2026-06-03T00:00:00.000Z',
         });
 
@@ -673,7 +687,6 @@ describe('SQLiteAdapter', () => {
 
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-generation',
-          maxConcurrency: 4,
           nowIso: '2026-06-03T00:01:00.000Z',
         });
 
@@ -697,7 +710,6 @@ describe('SQLiteAdapter', () => {
 
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-status',
-          maxConcurrency: 4,
           nowIso: '2026-06-03T00:02:00.000Z',
         });
 
@@ -720,7 +732,6 @@ describe('SQLiteAdapter', () => {
 
         const claimed = adapter.claimLaunchDispatchAtomic({
           ownerId: 'runner-missing',
-          maxConcurrency: 4,
           nowIso: '2026-06-03T00:03:00.000Z',
         });
 
@@ -747,12 +758,6 @@ describe('SQLiteAdapter', () => {
         workflowId: 'wf-launch',
         generation: 0,
       });
-      const acknowledged = adapter.enqueueLaunchDispatch({
-        taskId: 'wf-launch/t1',
-        attemptId: 'attempt-live-1c',
-        workflowId: 'wf-launch',
-        generation: 0,
-      });
       const completed = adapter.enqueueLaunchDispatch({
         taskId: 'wf-launch/t1',
         attemptId: 'attempt-completed',
@@ -769,10 +774,6 @@ describe('SQLiteAdapter', () => {
         `UPDATE task_launch_dispatch SET state = 'leased', dispatch_owner = 'owner-1', fenced_until = '2026-06-03T00:05:00.000Z' WHERE id = ?`,
         [leased.id],
       );
-      (adapter as any).db.run(
-        `UPDATE task_launch_dispatch SET state = 'acknowledged', dispatch_owner = 'owner-2', fenced_until = '2026-06-03T00:05:00.000Z' WHERE id = ?`,
-        [acknowledged.id],
-      );
       adapter.markLaunchDispatchCompleted(completed.id, '2026-06-03T00:04:00.000Z');
 
       const invalidated = adapter.abandonLaunchDispatchesForTasks(
@@ -784,9 +785,8 @@ describe('SQLiteAdapter', () => {
       expect(invalidated.map((row) => ({ id: row.id, state: row.state }))).toEqual([
         { id: enqueued.id, state: 'enqueued' },
         { id: leased.id, state: 'leased' },
-        { id: acknowledged.id, state: 'acknowledged' },
       ]);
-      for (const row of [enqueued, leased, acknowledged]) {
+      for (const row of [enqueued, leased]) {
         const after = adapter.loadLaunchDispatchById(row.id);
         expect(after?.state).toBe('abandoned');
         expect(after?.completedAt).toBe('2026-06-03T00:06:00.000Z');
@@ -852,7 +852,7 @@ describe('SQLiteAdapter', () => {
 
       adapter.deleteWorkflow('wf-launch');
 
-      expect(adapter.listLaunchDispatchesByState(['enqueued', 'leased', 'acknowledged'])).toEqual([]);
+      expect(adapter.listLaunchDispatchesByState(['enqueued', 'leased'])).toEqual([]);
       expect(adapter.listExecutionResourceLeases()).toEqual([]);
     });
   });
@@ -2608,6 +2608,7 @@ describe('SQLiteAdapter', () => {
         normalizedMergeModes: 1,
         staleAutoFixExperimentTasks: 2,
         normalizedStaleLaunchMetadata: 0,
+        normalizedLegacyAcknowledgedLaunchDispatches: 0,
         backfilledMissingSshPoolMemberIds: 0,
       });
       const taskById = new Map(adapter.loadTasks('wf-1').map((task) => [task.id, task]));
@@ -2624,6 +2625,7 @@ describe('SQLiteAdapter', () => {
         normalizedMergeModes: 0,
         staleAutoFixExperimentTasks: 0,
         normalizedStaleLaunchMetadata: 0,
+        normalizedLegacyAcknowledgedLaunchDispatches: 0,
         backfilledMissingSshPoolMemberIds: 0,
       });
     });
@@ -2698,6 +2700,87 @@ describe('SQLiteAdapter', () => {
 
       const secondRun = adapter.runCompatibilityMigration();
       expect(secondRun.normalizedStaleLaunchMetadata).toBe(0);
+    });
+
+    it('normalizes stale pending launch claims when their dispatch is no longer active', () => {
+      adapter.saveWorkflow(testWorkflow);
+      const expiredAt = new Date(Date.now() - 60_000);
+      const claimedAt = new Date(expiredAt.getTime() - 60_000);
+      const liveClaimedAt = new Date();
+      const liveExpiresAt = new Date(Date.now() + 60_000);
+      const expiredAttempt = createAttempt('stale-pending-launch', {
+        status: 'claimed',
+        claimedAt,
+        lastHeartbeatAt: claimedAt,
+        leaseExpiresAt: expiredAt,
+      });
+      const liveAttempt = createAttempt('live-pending-launch', {
+        status: 'claimed',
+        claimedAt: liveClaimedAt,
+        lastHeartbeatAt: liveClaimedAt,
+        leaseExpiresAt: liveExpiresAt,
+      });
+      adapter.saveTask('wf-1', makeTask('stale-pending-launch', {
+        status: 'pending',
+        execution: {
+          phase: 'launching',
+          selectedAttemptId: expiredAttempt.id,
+          launchStartedAt: claimedAt,
+          lastHeartbeatAt: claimedAt,
+        },
+      }));
+      adapter.saveTask('wf-1', makeTask('live-pending-launch', {
+        status: 'pending',
+        execution: {
+          phase: 'launching',
+          selectedAttemptId: liveAttempt.id,
+          launchStartedAt: new Date(),
+          lastHeartbeatAt: new Date(),
+        },
+      }));
+      adapter.updateTask('stale-pending-launch', {
+        execution: { selectedAttemptId: expiredAttempt.id },
+      });
+      adapter.updateTask('live-pending-launch', {
+        execution: { selectedAttemptId: liveAttempt.id },
+      });
+      adapter.saveAttempt(expiredAttempt);
+      adapter.saveAttempt(liveAttempt);
+      const staleDispatch = adapter.enqueueLaunchDispatch({
+        taskId: 'stale-pending-launch',
+        attemptId: expiredAttempt.id,
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+      adapter.markLaunchDispatchAbandoned(
+        staleDispatch.id,
+        'task is no longer launch-ready',
+        '2026-06-04T01:57:45.435Z',
+      );
+      const liveDispatch = adapter.enqueueLaunchDispatch({
+        taskId: 'live-pending-launch',
+        attemptId: liveAttempt.id,
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+
+      const report = adapter.runCompatibilityMigration();
+
+      expect(report.normalizedStaleLaunchMetadata).toBe(1);
+      const staleTask = adapter.loadTask('stale-pending-launch');
+      expect(staleTask?.status).toBe('pending');
+      expect(staleTask?.execution.phase).toBeUndefined();
+      expect(staleTask?.execution.launchStartedAt).toBeUndefined();
+      expect(staleTask?.execution.lastHeartbeatAt).toBeUndefined();
+      expect(adapter.loadAttempt(expiredAttempt.id)?.status).toBe('pending');
+      expect(adapter.loadAttempt(expiredAttempt.id)?.claimedAt).toBeUndefined();
+      expect(adapter.loadAttempt(expiredAttempt.id)?.leaseExpiresAt).toBeUndefined();
+
+      const liveTask = adapter.loadTask('live-pending-launch');
+      expect(liveTask?.execution.phase).toBe('launching');
+      expect(adapter.loadAttempt(liveAttempt.id)?.status).toBe('claimed');
+      expect(adapter.loadLaunchDispatchById(liveDispatch.id)?.state).toBe('enqueued');
+      expect(adapter.runCompatibilityMigration().normalizedStaleLaunchMetadata).toBe(0);
     });
   });
 

--- a/packages/data-store/src/__tests__/stale-downstream-launch-dispatch-repro.test.ts
+++ b/packages/data-store/src/__tests__/stale-downstream-launch-dispatch-repro.test.ts
@@ -137,7 +137,6 @@ describe('stale downstream launch dispatch repro', () => {
 
     const leased = adapter.claimLaunchDispatchAtomic({
       ownerId: 'repro-owner',
-      maxConcurrency: 1,
       nowIso: '2026-06-03T00:02:00.000Z',
     });
 

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -235,7 +235,6 @@ export interface WorkflowMutationLease {
 export type TaskLaunchDispatchState =
   | 'enqueued'
   | 'leased'
-  | 'acknowledged'
   | 'completed'
   | 'abandoned';
 
@@ -251,7 +250,6 @@ export interface TaskLaunchDispatch {
   dispatchOwner?: string;
   enqueuedAt: string;
   leasedAt?: string;
-  acknowledgedAt?: string;
   completedAt?: string;
   fencedUntil?: string;
   attemptsCount: number;
@@ -420,6 +418,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     normalizedMergeModes: number;
     staleAutoFixExperimentTasks: number;
     normalizedStaleLaunchMetadata: number;
+    normalizedLegacyAcknowledgedLaunchDispatches: number;
     backfilledMissingSshPoolMemberIds: number;
   } {
     const report = {
@@ -427,6 +426,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       normalizedMergeModes: 0,
       staleAutoFixExperimentTasks: 0,
       normalizedStaleLaunchMetadata: 0,
+      normalizedLegacyAcknowledgedLaunchDispatches: 0,
       backfilledMissingSshPoolMemberIds: 0,
     };
     this.runTransaction(() => {
@@ -495,6 +495,113 @@ export class SQLiteAdapter implements PersistenceAdapter {
            AND (julianday(started_at) - julianday(launch_started_at)) * 86400.0 > 3600.0`,
       );
       report.normalizedStaleLaunchMetadata = this.db.getRowsModified();
+
+      const nowIso = new Date().toISOString();
+      const stalePendingLaunchRows = this.queryAll(
+        `SELECT t.id, t.selected_attempt_id
+           FROM tasks t
+           LEFT JOIN attempts a ON a.id = t.selected_attempt_id
+          WHERE t.status = 'pending'
+            AND t.launch_phase = 'launching'
+            AND t.selected_attempt_id IS NOT NULL
+            AND TRIM(t.selected_attempt_id) != ''
+            AND NOT EXISTS (
+              SELECT 1
+                FROM task_launch_dispatch live
+               WHERE live.task_id = t.id
+                 AND live.attempt_id = t.selected_attempt_id
+                 AND live.state IN ('enqueued', 'leased')
+            )
+            AND (
+              a.id IS NULL
+              OR a.lease_expires_at IS NULL
+              OR a.lease_expires_at <= ?
+            )`,
+        [nowIso],
+      ) as Array<{ id: string; selected_attempt_id?: string | null }>;
+      if (stalePendingLaunchRows.length > 0) {
+        const taskIds = stalePendingLaunchRows.map((row) => String(row.id));
+        const taskPlaceholders = taskIds.map(() => '?').join(', ');
+        this.db.run(
+          `UPDATE tasks
+              SET launch_phase = NULL,
+                  launch_started_at = NULL,
+                  launch_completed_at = NULL,
+                  last_heartbeat_at = NULL
+            WHERE id IN (${taskPlaceholders})`,
+          taskIds,
+        );
+
+        const attemptIds = stalePendingLaunchRows
+          .map((row) => row.selected_attempt_id)
+          .filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
+        if (attemptIds.length > 0) {
+          const attemptPlaceholders = attemptIds.map(() => '?').join(', ');
+          this.db.run(
+            `UPDATE attempts
+                SET status = 'pending',
+                    claimed_at = NULL,
+                    last_heartbeat_at = NULL,
+                    lease_expires_at = NULL
+              WHERE id IN (${attemptPlaceholders})
+                AND status = 'claimed'`,
+            attemptIds,
+          );
+        }
+        report.normalizedStaleLaunchMetadata += stalePendingLaunchRows.length;
+      }
+
+      this.db.run(
+        `UPDATE task_launch_dispatch
+         SET state = 'abandoned',
+             completed_at = ?,
+             last_error = 'Legacy acknowledged launch dispatch is stale after acknowledgement removal',
+             dispatch_owner = NULL,
+             fenced_until = NULL
+         WHERE state = 'acknowledged'
+           AND (
+             NOT EXISTS (
+               SELECT 1
+               FROM tasks t
+               WHERE t.id = task_launch_dispatch.task_id
+                 AND t.status = 'pending'
+                 AND COALESCE(t.selected_attempt_id, '') = task_launch_dispatch.attempt_id
+                 AND COALESCE(t.execution_generation, 0) = task_launch_dispatch.generation
+             )
+             OR EXISTS (
+               SELECT 1
+               FROM task_launch_dispatch live
+               WHERE live.attempt_id = task_launch_dispatch.attempt_id
+                 AND live.id != task_launch_dispatch.id
+                 AND live.state IN ('enqueued', 'leased')
+             )
+           )`,
+        [nowIso],
+      );
+      report.normalizedLegacyAcknowledgedLaunchDispatches += this.db.getRowsModified();
+
+      this.db.run(
+        `UPDATE task_launch_dispatch
+         SET state = 'leased',
+             leased_at = COALESCE(leased_at, acknowledged_at, ?),
+             acknowledged_at = NULL
+         WHERE state = 'acknowledged'
+           AND fenced_until IS NOT NULL
+           AND fenced_until >= ?`,
+        [nowIso, nowIso],
+      );
+      report.normalizedLegacyAcknowledgedLaunchDispatches += this.db.getRowsModified();
+
+      this.db.run(
+        `UPDATE task_launch_dispatch
+         SET state = 'enqueued',
+             dispatch_owner = NULL,
+             leased_at = NULL,
+             acknowledged_at = NULL,
+             fenced_until = NULL
+         WHERE state = 'acknowledged'`,
+      );
+      report.normalizedLegacyAcknowledgedLaunchDispatches += this.db.getRowsModified();
 
       // One-time compatibility backfill for SSH tasks created before
       // pool_member_id was durably written to tasks. Runtime routing must use
@@ -812,7 +919,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
 
       CREATE UNIQUE INDEX IF NOT EXISTS idx_task_launch_dispatch_active_attempt
         ON task_launch_dispatch(attempt_id)
-        WHERE state IN ('enqueued', 'leased', 'acknowledged');
+        WHERE state IN ('enqueued', 'leased');
 
       CREATE INDEX IF NOT EXISTS idx_task_launch_dispatch_ready
         ON task_launch_dispatch(state, priority, id)
@@ -937,6 +1044,12 @@ export class SQLiteAdapter implements PersistenceAdapter {
     this.db.run('DROP INDEX IF EXISTS idx_attempts_node');
     this.db.run('CREATE INDEX IF NOT EXISTS idx_attempts_node_created ON attempts(node_id, created_at)');
     this.db.run('CREATE INDEX IF NOT EXISTS idx_tasks_workflow_id ON tasks(workflow_id)');
+    this.db.run('DROP INDEX IF EXISTS idx_task_launch_dispatch_active_attempt');
+    this.db.run(`
+      CREATE UNIQUE INDEX IF NOT EXISTS idx_task_launch_dispatch_active_attempt
+        ON task_launch_dispatch(attempt_id)
+        WHERE state IN ('enqueued', 'leased')
+    `);
 
     if (!this.readOnly) {
       this.migrateTestCommands();
@@ -3162,7 +3275,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       const existing = this.queryOne(
         `SELECT * FROM task_launch_dispatch
            WHERE attempt_id = ?
-             AND state IN ('enqueued', 'leased', 'acknowledged')
+             AND state IN ('enqueued', 'leased')
            LIMIT 1`,
         [input.attemptId],
       );
@@ -3178,7 +3291,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
       const inserted = this.queryOne(
         `SELECT * FROM task_launch_dispatch
            WHERE attempt_id = ?
-             AND state IN ('enqueued', 'leased', 'acknowledged')
+             AND state IN ('enqueued', 'leased')
            LIMIT 1`,
         [input.attemptId],
       );
@@ -3201,7 +3314,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
     const row = this.queryOne(
       `SELECT * FROM task_launch_dispatch
          WHERE attempt_id = ?
-           AND state IN ('enqueued', 'leased', 'acknowledged')
+           AND state IN ('enqueued', 'leased')
          ORDER BY id DESC
          LIMIT 1`,
       [attemptId],
@@ -3224,32 +3337,23 @@ export class SQLiteAdapter implements PersistenceAdapter {
   }
 
   /**
-   * Atomic capacity-gated lease of the next enqueued dispatch row.
+   * Atomic lease of the next enqueued dispatch row.
    *
    * Selects the oldest enqueued row (priority high < normal < low, then id
-   * ascending) and transitions it to `leased` only if the current count of
-   * `leased | acknowledged` rows is below `maxConcurrency`. Wrapped in an
-   * IMMEDIATE transaction so concurrent dispatchers cannot double-lease.
-   * Returns the freshly leased row or `undefined` when nothing is enqueued,
-   * capacity is exhausted, or another dispatcher beat us to it.
+   * ascending) and transitions it to `leased`. Wrapped in an IMMEDIATE
+   * transaction so concurrent dispatchers cannot double-lease. Returns the
+   * freshly leased row or `undefined` when nothing is enqueued or another
+   * dispatcher beat us to it.
    */
   claimLaunchDispatchAtomic(options: {
     ownerId: string;
-    maxConcurrency: number;
     nowIso?: string;
   }): TaskLaunchDispatch | undefined {
-    if (options.maxConcurrency <= 0) return undefined;
     const now = options.nowIso ?? new Date().toISOString();
     const fencedUntil = new Date(
       new Date(now).getTime() + DISPATCH_LEASE_MS,
     ).toISOString();
     return this.runTransaction(() => {
-      const activeRow = this.queryOne(
-        `SELECT COUNT(*) AS active FROM task_launch_dispatch
-           WHERE state IN ('leased', 'acknowledged')`,
-      );
-      const active = Number(activeRow?.active ?? 0);
-      if (active >= options.maxConcurrency) return undefined;
       while (true) {
         const candidate = this.queryOne(
           `SELECT
@@ -3325,28 +3429,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
     });
   }
 
-  markLaunchDispatchAcknowledged(
-    id: number,
-    runnerId: string,
-    nowIso?: string,
-  ): boolean {
-    const now = nowIso ?? new Date().toISOString();
-    const fencedUntil = new Date(
-      new Date(now).getTime() + DISPATCH_LEASE_MS,
-    ).toISOString();
-    this.execRun(
-      `UPDATE task_launch_dispatch
-         SET state = 'acknowledged',
-             acknowledged_at = ?,
-             dispatch_owner = ?,
-             fenced_until = ?
-       WHERE id = ?
-         AND state = 'leased'`,
-      [now, runnerId, fencedUntil, id],
-    );
-    return (this.db.getRowsModified?.() ?? 0) > 0;
-  }
-
   markLaunchDispatchCompleted(id: number, nowIso?: string): boolean {
     const now = nowIso ?? new Date().toISOString();
     this.execRun(
@@ -3378,21 +3460,14 @@ export class SQLiteAdapter implements PersistenceAdapter {
     return (this.db.getRowsModified?.() ?? 0) > 0;
   }
 
-  /**
-   * Return the dispatch rows in `acknowledged` whose fence has expired AND
-   * whose `attempts_count` has reached `maxAttempts`. These are the rows
-   * that the dispatcher should abandon and report to the orchestrator —
-   * they have already burned through their retry budget without the
-   * TaskRunner finishing the launch.
-   */
-  listAbandonableAcknowledgedLeases(options: {
+  listAbandonableLaunchDispatchLeases(options: {
     nowIso?: string;
     maxAttempts: number;
   }): TaskLaunchDispatch[] {
     const now = options.nowIso ?? new Date().toISOString();
     const rows = this.queryAll(
       `SELECT * FROM task_launch_dispatch
-         WHERE state = 'acknowledged'
+         WHERE state = 'leased'
            AND fenced_until IS NOT NULL
            AND fenced_until < ?
            AND attempts_count >= ?
@@ -3441,7 +3516,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
         `SELECT id, task_id, attempt_id, workflow_id, state, generation
            FROM task_launch_dispatch
           WHERE task_id IN (${taskPlaceholders})
-            AND state IN ('enqueued', 'leased', 'acknowledged')
+            AND state IN ('enqueued', 'leased')
           ORDER BY id ASC`,
         ids,
       );
@@ -3457,7 +3532,7 @@ export class SQLiteAdapter implements PersistenceAdapter {
                 dispatch_owner = NULL,
                 fenced_until = NULL
           WHERE id IN (${idPlaceholders})
-            AND state IN ('enqueued', 'leased', 'acknowledged')`,
+            AND state IN ('enqueued', 'leased')`,
         [now, reason, ...rowIds],
       );
 
@@ -3472,15 +3547,20 @@ export class SQLiteAdapter implements PersistenceAdapter {
     });
   }
 
-  reapExpiredLaunchDispatchLeases(nowIso?: string): TaskLaunchDispatch[] {
-    const now = nowIso ?? new Date().toISOString();
+  reapExpiredLaunchDispatchLeases(options: {
+    nowIso?: string;
+    maxAttempts?: number;
+  } = {}): TaskLaunchDispatch[] {
+    const now = options.nowIso ?? new Date().toISOString();
+    const maxAttempts = options.maxAttempts ?? Number.MAX_SAFE_INTEGER;
     return this.runTransaction(() => {
       const expired = this.queryAll(
         `SELECT * FROM task_launch_dispatch
            WHERE state = 'leased'
              AND fenced_until IS NOT NULL
-             AND fenced_until < ?`,
-        [now],
+             AND fenced_until < ?
+             AND attempts_count < ?`,
+        [now, maxAttempts],
       );
       if (expired.length === 0) return [];
       this.execRun(
@@ -3490,8 +3570,9 @@ export class SQLiteAdapter implements PersistenceAdapter {
                fenced_until = NULL
          WHERE state = 'leased'
            AND fenced_until IS NOT NULL
-           AND fenced_until < ?`,
-        [now],
+           AND fenced_until < ?
+           AND attempts_count < ?`,
+        [now, maxAttempts],
       );
       return expired.map((row) => {
         const reset = { ...row, state: 'enqueued', dispatch_owner: null, fenced_until: null };
@@ -3514,7 +3595,6 @@ export class SQLiteAdapter implements PersistenceAdapter {
       dispatchOwner: row.dispatch_owner ? String(row.dispatch_owner) : undefined,
       enqueuedAt: String(row.enqueued_at),
       leasedAt: row.leased_at ? String(row.leased_at) : undefined,
-      acknowledgedAt: row.acknowledged_at ? String(row.acknowledged_at) : undefined,
       completedAt: row.completed_at ? String(row.completed_at) : undefined,
       fencedUntil: row.fenced_until ? String(row.fenced_until) : undefined,
       attemptsCount: Number(row.attempts_count ?? 0),

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -112,21 +112,14 @@ function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}):
 }
 
 function makeLaunchOutbox(): LaunchOutboxAck & {
-  ackCalls: Array<[number, string]>;
   completeCalls: number[];
   failCalls: Array<[number, unknown]>;
 } {
-  const ackCalls: Array<[number, string]> = [];
   const completeCalls: number[] = [];
   const failCalls: Array<[number, unknown]> = [];
   return {
-    ackCalls,
     completeCalls,
     failCalls,
-    ackDispatch(id, runnerId) {
-      ackCalls.push([id, runnerId]);
-      return true;
-    },
     completeDispatch(id) {
       completeCalls.push(id);
       return true;
@@ -139,31 +132,14 @@ function makeLaunchOutbox(): LaunchOutboxAck & {
 }
 
 describe('TaskRunner launch-dispatch wiring', () => {
-  it('acks dispatch at the top of executeTask and proceeds to executor.start when accepted', async () => {
+  it('keeps dispatch leased and proceeds to executor.start', async () => {
     const task = makeTask();
     const env = buildRunnerEnv(task, { startThrows: new Error('isolated start sentinel') });
     const launchOutbox = makeLaunchOutbox();
 
     await env.runner.executeTask(task, { dispatchId: 42, launchOutbox });
 
-    expect(launchOutbox.ackCalls).toHaveLength(1);
-    expect(launchOutbox.ackCalls[0][0]).toBe(42);
-    expect(launchOutbox.ackCalls[0][1]).toMatch(/^[0-9a-f-]+$/);
     expect(env.executor.start).toHaveBeenCalledTimes(1);
-  });
-
-  it('does NOT call the executor when ackDispatch returns false', async () => {
-    const task = makeTask();
-    const env = buildRunnerEnv(task);
-    const launchOutbox = makeLaunchOutbox();
-    launchOutbox.ackDispatch = vi.fn().mockReturnValue(false);
-
-    await env.runner.executeTask(task, { dispatchId: 99, launchOutbox });
-
-    expect(env.executor.start).not.toHaveBeenCalled();
-    expect(env.orchestrator.markTaskRunningAfterLaunch).not.toHaveBeenCalled();
-    expect(launchOutbox.completeCalls).toHaveLength(0);
-    expect(launchOutbox.failCalls).toHaveLength(0);
   });
 
   it('calls failDispatch when the executor start throws', async () => {
@@ -173,13 +149,28 @@ describe('TaskRunner launch-dispatch wiring', () => {
 
     await env.runner.executeTask(task, { dispatchId: 7, launchOutbox });
 
-    expect(launchOutbox.ackCalls).toHaveLength(1);
     expect(launchOutbox.completeCalls).toHaveLength(0);
     expect(launchOutbox.failCalls).toHaveLength(1);
     expect(launchOutbox.failCalls[0][0]).toBe(7);
     const failArg = launchOutbox.failCalls[0][1];
     expect(failArg).toBeInstanceOf(Error);
     expect((failArg as Error).message).toMatch(/startup explosion/);
+  });
+
+  it('fails the dispatch when markTaskRunningAfterLaunch rejects the launch', async () => {
+    const task = makeTask();
+    const env = buildRunnerEnv(task);
+    env.orchestrator.markTaskRunningAfterLaunch.mockReturnValue(false);
+    const launchOutbox = makeLaunchOutbox();
+
+    await env.runner.executeTask(task, { dispatchId: 8, launchOutbox });
+
+    expect(env.executor.start).toHaveBeenCalledTimes(1);
+    expect(env.executor.kill).toHaveBeenCalledTimes(1);
+    expect(launchOutbox.completeCalls).toHaveLength(0);
+    expect(launchOutbox.failCalls).toHaveLength(1);
+    expect(launchOutbox.failCalls[0][0]).toBe(8);
+    expect((launchOutbox.failCalls[0][1] as Error).message).toMatch(/Launch rejected/);
   });
 
   it('completes the dispatch row when resource-limit defers the launch', async () => {
@@ -194,7 +185,6 @@ describe('TaskRunner launch-dispatch wiring', () => {
 
     await env.runner.executeTask(task, { dispatchId: 321, launchOutbox });
 
-    expect(launchOutbox.ackCalls).toHaveLength(1);
     expect(env.orchestrator.deferTask).toHaveBeenCalledWith(task.id);
     expect(launchOutbox.completeCalls).toEqual([321]);
     expect(launchOutbox.failCalls).toHaveLength(0);
@@ -207,7 +197,6 @@ describe('TaskRunner launch-dispatch wiring', () => {
 
     await env.runner.executeTask(task);
 
-    expect(launchOutbox.ackCalls).toHaveLength(0);
     expect(launchOutbox.completeCalls).toHaveLength(0);
     expect(launchOutbox.failCalls).toHaveLength(0);
     expect(env.executor.start).toHaveBeenCalled();
@@ -243,7 +232,6 @@ describe('TaskRunner launch-dispatch wiring', () => {
     await env.runner.executeTask(task, { dispatchId: 123, launchOutbox });
 
     expect(env.executor.start).not.toHaveBeenCalled();
-    expect(launchOutbox.ackCalls).toHaveLength(0);
     expect(launchOutbox.failCalls).toHaveLength(1);
     expect(launchOutbox.failCalls[0][0]).toBe(123);
     expect((launchOutbox.failCalls[0][1] as Error).message).toMatch(/Duplicate launch suppressed/);
@@ -254,7 +242,7 @@ describe('TaskRunner launch-dispatch wiring', () => {
     // BEFORE the normal markTaskRunningAfterLaunch completeDispatch
     // path (it synthesises a spawn_experiments WorkResponse and
     // returns). Without an explicit completeDispatch here, the parent
-    // pivot's outbox row stays acknowledged → reaped → abandoned.
+    // pivot's outbox row stays leased and is retried or abandoned.
     const pivotTask = makeTask({
       id: 'wf-pivot/parent',
       config: {
@@ -276,9 +264,6 @@ describe('TaskRunner launch-dispatch wiring', () => {
 
     await env.runner.executeTask(pivotTask, { dispatchId: 555, launchOutbox });
 
-    // ackDispatch fired at the top of executeTask.
-    expect(launchOutbox.ackCalls).toHaveLength(1);
-    expect(launchOutbox.ackCalls[0][0]).toBe(555);
     // The pivot path emits a spawn_experiments WorkResponse and then,
     // critically, terminates the parent's dispatch row.
     expect(env.orchestrator.handleWorkerResponse).toHaveBeenCalled();

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -178,13 +178,12 @@ const NOOP_LOGGER: Logger = {
  * never depends on the app shell, the app provides this implementation
  * via the LaunchDispatcher.
  *
- * Each method MUST be safe to call even if the dispatch row was reaped
- * between the dispatcher's lease and the runner's call — the
- * persistence layer returns false in that case and the runner bails
- * out without starting the executor.
+ * Each method MUST be safe to call even if the dispatch row was
+ * reaped between the dispatcher's lease and the runner's call — the
+ * persistence layer returns false in that case and the runner treats
+ * it as a benign race.
  */
 export interface LaunchOutboxAck {
-  ackDispatch(dispatchId: number, runnerId: string): boolean;
   completeDispatch(dispatchId: number): boolean;
   failDispatch(dispatchId: number, error: unknown): boolean;
 }
@@ -521,19 +520,6 @@ export class TaskRunner {
       }
       return;
     }
-    if (dispatchOpts) {
-      const accepted = dispatchOpts.launchOutbox.ackDispatch(
-        dispatchOpts.dispatchId,
-        this.runnerInstanceId,
-      );
-      if (!accepted) {
-        this.logger.warn(
-          `[TaskRunner] launch dispatch ack rejected (lease reaped?) for task=${task.id} attempt=${attemptId} dispatchId=${dispatchOpts.dispatchId}`,
-        );
-        bench('executeTask.dispatchAckRejected');
-        return;
-      }
-    }
     this.logger.info(
       `[TaskRunner] launch accepted task=${task.id} attempt=${attemptId} status=${task.status} ` +
         `phase=${task.execution.phase ?? 'none'} generation=${startGeneration} ` +
@@ -667,11 +653,10 @@ export class TaskRunner {
       // CD.1 / Issue 13: terminate the parent pivot task's outbox row.
       // Without this, drainScheduler enqueued a launch-dispatch row for
       // the pivot, but executeTaskInner returns here without ever
-      // calling completeDispatch — so the row stays acknowledged,
-      // gets reaped after DISPATCH_LEASE_MS, and is eventually
-      // abandoned. The spawn_experiments path is the terminal state
-      // for the pivot itself; only the spawned variants should
-      // continue through the outbox.
+      // calling completeDispatch, so the row stays leased and is retried
+      // or abandoned. The spawn_experiments path is the terminal state
+      // for the pivot itself; only the spawned variants should continue
+      // through the outbox.
       if (dispatchOpts) {
         try {
           dispatchOpts.launchOutbox.completeDispatch(dispatchOpts.dispatchId);
@@ -996,6 +981,12 @@ export class TaskRunner {
       this.releasePoolSelectionLease(this.pendingPoolSelections.get(task.id));
       this.pendingPoolSelections.delete(task.id);
       await this.cleanupPerTaskDockerExecutor(task);
+      if (dispatchOpts) {
+        dispatchOpts.launchOutbox.failDispatch(
+          dispatchOpts.dispatchId,
+          new Error('Launch rejected as stale or non-executable after executor start'),
+        );
+      }
       bench('markTaskRunningAfterLaunch.rejected');
       return;
     }

--- a/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-dispatcher.test.ts
@@ -22,7 +22,7 @@ interface LaunchDispatchRow {
   taskId: string;
   attemptId: string;
   workflowId: string;
-  state: 'enqueued' | 'leased' | 'acknowledged' | 'completed' | 'abandoned';
+  state: 'enqueued' | 'leased' | 'completed' | 'abandoned';
   priority: 'high' | 'normal' | 'low';
   generation: number;
 }
@@ -118,12 +118,12 @@ class InMemoryPersistence implements OrchestratorPersistence {
     workflowId: string;
     priority?: 'high' | 'normal' | 'low';
     generation: number;
-  }): { id: number } {
+  }): { id: number; state: LaunchDispatchRow['state']; priority: LaunchDispatchRow['priority'] } {
     if (!this.enqueueLaunchDispatchEnabled) {
       throw new Error('enqueueLaunchDispatch called when not enabled');
     }
     const existing = this.launchDispatchRows.find((row) => row.attemptId === input.attemptId);
-    if (existing) return { id: existing.id };
+    if (existing) return { id: existing.id, state: existing.state, priority: existing.priority };
     const row: LaunchDispatchRow = {
       id: this.nextDispatchId++,
       taskId: input.taskId,
@@ -134,7 +134,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
       generation: input.generation,
     };
     this.launchDispatchRows.push(row);
-    return { id: row.id };
+    return { id: row.id, state: row.state, priority: row.priority };
   }
 
   abandonLaunchDispatchesForTasks(
@@ -146,7 +146,7 @@ class InMemoryPersistence implements OrchestratorPersistence {
     const rows = this.launchDispatchRows.filter(
       (row) =>
         taskSet.has(row.taskId) &&
-        (row.state === 'enqueued' || row.state === 'leased' || row.state === 'acknowledged'),
+        (row.state === 'enqueued' || row.state === 'leased'),
     );
     const invalidated = rows.map((row) => ({
       id: row.id,

--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -2925,6 +2925,53 @@ describe('Orchestrator', () => {
       expect(resumePersistence.loadAttempt(oldAttempt.id)?.status).toBe('superseded');
       expect(resumePersistence.loadAttempt(newAttemptId!)?.status).toBe('running');
     });
+
+    it('recovers normalized stale pending tasks that still carry selected-attempt runtime state', () => {
+      const resumePersistence = new InMemoryPersistence();
+      const oldAttempt: Attempt = {
+        id: 't1-aold',
+        nodeId: 't1',
+        queuePriority: 0,
+        status: 'pending',
+        upstreamAttemptIds: [],
+        createdAt: new Date('2025-01-01T00:00:00.000Z'),
+      };
+      resumePersistence.saveTask('wf-resume', {
+        id: 't1',
+        description: 'Pending task with stale launch metadata',
+        status: 'pending',
+        dependencies: [],
+        createdAt: new Date(),
+        config: {},
+        execution: {
+          startedAt: new Date('2025-01-01T00:00:00.000Z'),
+          selectedAttemptId: oldAttempt.id,
+          workspacePath: '/tmp/stale-workspace',
+          agentSessionId: 'stale-session',
+          error: 'stale launch error',
+        },
+      });
+      resumePersistence.saveAttempt(oldAttempt);
+
+      const resumeOrchestrator = new Orchestrator({
+        persistence: resumePersistence,
+        messageBus: bus,
+        maxConcurrency: 3,
+      });
+
+      const started = resumeOrchestrator.resumeWorkflow('wf-resume');
+
+      expect(started).toHaveLength(1);
+      const resumed = resumeOrchestrator.getTask('t1')!;
+      expect(resumed.status).toBe('running');
+      expect(resumed.execution.selectedAttemptId).toBeTruthy();
+      expect(resumed.execution.selectedAttemptId).not.toBe(oldAttempt.id);
+      expect(resumed.execution.workspacePath).toBeUndefined();
+      expect(resumed.execution.agentSessionId).toBeUndefined();
+      expect(resumed.execution.error).toBeUndefined();
+      expect(resumePersistence.loadAttempt(oldAttempt.id)?.status).toBe('superseded');
+      expect(resumePersistence.loadAttempt(resumed.execution.selectedAttemptId!)?.status).toBe('running');
+    });
   });
 
   describe('prepareTaskForNewAttempt', () => {

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -265,7 +265,11 @@ export interface OrchestratorPersistence {
     workflowId: string;
     priority?: 'high' | 'normal' | 'low';
     generation: number;
-  }): { id: number };
+  }): {
+    id: number;
+    state?: 'enqueued' | 'leased' | 'completed' | 'abandoned';
+    priority?: 'high' | 'normal' | 'low';
+  };
   abandonLaunchDispatchesForTasks?(
     taskIds: readonly string[],
     reason: string,
@@ -3830,20 +3834,33 @@ export class Orchestrator {
    * Resume a previously persisted workflow by restoring tasks
    * and auto-starting ready tasks.
    */
+  private isRecoverableResumeTask(task: TaskState): boolean {
+    if (task.status === 'running') return true;
+    if (task.status !== 'pending' || !task.execution.selectedAttemptId) return false;
+    if (task.execution.phase === 'launching') return true;
+
+    return Boolean(
+      task.execution.startedAt
+      || task.execution.launchStartedAt
+      || task.execution.launchCompletedAt
+      || task.execution.lastHeartbeatAt
+      || task.execution.workspacePath
+      || task.execution.agentSessionId
+      || task.execution.containerId
+      || task.execution.error
+      || task.execution.exitCode !== undefined
+      || task.execution.inputPrompt
+      || task.execution.pendingFixError,
+    );
+  }
+
   resumeWorkflow(workflowId: string): TaskState[] {
     this.syncFromDb(workflowId);
     const workflowTaskIds = new Set(this.persistence.loadTasks(workflowId).map((task) => task.id));
     const tasksToRecover = this.stateMachine
       .getAllTasks()
       .filter((task) => task.config.workflowId === workflowId || workflowTaskIds.has(task.id))
-      .filter((task) =>
-        task.status === 'running'
-        || (
-          task.status === 'pending'
-          && task.execution.phase === 'launching'
-          && !!task.execution.selectedAttemptId
-        )
-      );
+      .filter((task) => this.isRecoverableResumeTask(task));
     for (const task of tasksToRecover) {
       this.prepareTaskForNewAttempt(task.id, 'resume_workflow_recovery');
     }
@@ -5288,6 +5305,20 @@ export class Orchestrator {
           this.persistence.logEvent?.(job.taskId, 'task.dispatch_enqueued', {
             ...changes,
             dispatchId: dispatch.id,
+            attemptId: launchAttemptId,
+            workflowId: task.config.workflowId,
+            generation: this.getExecutionGeneration(task),
+            state: dispatch.state,
+            priority: dispatch.priority,
+          });
+          this.logger.info('[orchestrator] drainScheduler: launch dispatch enqueued', {
+            taskId: job.taskId,
+            attemptId: launchAttemptId,
+            workflowId: task.config.workflowId,
+            generation: this.getExecutionGeneration(task),
+            dispatchId: dispatch.id,
+            state: dispatch.state,
+            priority: dispatch.priority,
           });
         } catch (err) {
           this.logger.warn('[orchestrator] drainScheduler: enqueueLaunchDispatch failed', {


### PR DESCRIPTION
Problem: launch-dispatch rows could get stuck in an acknowledged state that counted as active work but was no longer part of the retry/claim path, blocking queued launches and hiding stale pending launch claims.

Solution: keep dispatch ownership in leased until completion/failure, abandon or requeue expired leased rows by attempt budget, migrate legacy acknowledged rows, and update app, data-store, task-runner, and orchestrator tests for the simplified lifecycle.

Depends-On: #1139