### PR TITLE
fix(scripts): parse noisy headless task statuses

### DIFF
--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -385,7 +385,10 @@ PY
 # Usage: ST=$(invoker_e2e_task_status <taskId>)
 invoker_e2e_task_status() {
   local task_id="$1"
-  invoker_e2e_run_headless task-status "$task_id" 2>/dev/null | tail -1
+  invoker_e2e_run_headless task-status "$task_id" 2>/dev/null \
+    | sed 's/\x1b\[[0-9;]*m//g' \
+    | grep -E '^(pending|running|completed|failed|awaiting_approval|review_ready|fixing_with_ai|closed|skipped)$' \
+    | tail -1
 }
 
 # Poll until task status equals expected (1s interval). Use after cancel/restart

--- a/scripts/repro/repro-noisy-headless-task-status-parser.sh
+++ b/scripts/repro/repro-noisy-headless-task-status-parser.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Repro: dry-run task status parsing must ignore Electron/ANSI noise.
+#
+# Root cause guarded here:
+#   Some CI/headless runs print Electron warnings or ANSI-decorated log lines
+#   around the actual task status. The old parser used `tail -1`, so a trailing
+#   warning could be mistaken for the status.
+#
+# Fixed behavior:
+#   `invoker_e2e_task_status` strips ANSI sequences and returns the last valid
+#   task status token only.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+source scripts/e2e-dry-run/lib/common.sh
+
+invoker_e2e_run_headless() {
+  local _task_status_command="$1"
+  local _task_id="$2"
+  printf '\033[33m(node:123) Electron warning before status\033[0m\n'
+  printf 'running\n'
+  printf '\033[32mcompleted\033[0m\n'
+  printf '(node:123) trailing deprecation warning\n'
+}
+
+status="$(invoker_e2e_task_status wf-test/noisy-task)"
+if [[ "$status" != "completed" ]]; then
+  echo "FAIL noisy status parser: expected completed, got: ${status:-<empty>}" >&2
+  exit 1
+fi
+
+echo "PASS noisy status parser returned completed"


### PR DESCRIPTION


Depends-On: #1147