### PR TITLE
fix(dispatch): use fixed launch TTL diagnostics

### DIFF
--- a/packages/app/src/__tests__/launch-dispatcher.test.ts
+++ b/packages/app/src/__tests__/launch-dispatcher.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { SQLiteAdapter } from '@invoker/data-store';
-import type { Logger } from '@invoker/contracts';
+import { DISPATCH_LEASE_MS, type Logger } from '@invoker/contracts';
 import { InMemoryBus } from '@invoker/test-kit';
 import { Orchestrator } from '@invoker/workflow-core';
 import { LaunchDispatcher } from '../launch-dispatcher.js';
@@ -192,6 +192,35 @@ describe('LaunchDispatcher', () => {
       const { dispatcher } = makeDispatcher();
       expect(dispatcher.completeDispatch(enqueued.id)).toBe(true);
       expect(dispatcher.completeDispatch(enqueued.id)).toBe(false);
+    });
+
+    it('uses a fixed dispatch TTL long enough for normal executor startup', () => {
+      seedWorkflowAndTask('attempt-fixed-ttl');
+      const enqueued = adapter.enqueueLaunchDispatch({
+        taskId: 'wf-1/t1',
+        attemptId: 'attempt-fixed-ttl',
+        workflowId: 'wf-1',
+        generation: 0,
+      });
+      const claimedAt = '2026-06-04T22:38:44.000Z';
+      const claimed = adapter.claimLaunchDispatchAtomic({
+        ownerId: 'owner-test',
+        nowIso: claimedAt,
+      });
+      expect(claimed?.id).toBe(enqueued.id);
+      expect(claimed?.fencedUntil).toBe(
+        new Date(new Date(claimedAt).getTime() + DISPATCH_LEASE_MS).toISOString(),
+      );
+
+      const { dispatcher } = makeDispatcher();
+      expect(dispatcher.reapExpiredLeases(
+        new Date(new Date(claimedAt).getTime() + DISPATCH_LEASE_MS - 1).toISOString(),
+      )).toBe(0);
+      expect(adapter.loadLaunchDispatchById(enqueued.id)?.state).toBe('leased');
+      expect(dispatcher.reapExpiredLeases(
+        new Date(new Date(claimedAt).getTime() + DISPATCH_LEASE_MS + 1).toISOString(),
+      )).toBe(1);
+      expect(adapter.loadLaunchDispatchById(enqueued.id)?.state).toBe('enqueued');
     });
 
     it('fail re-enqueues a leased row with the error message and clears the owner', () => {

--- a/packages/app/src/__tests__/launch-invariant.test.ts
+++ b/packages/app/src/__tests__/launch-invariant.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { TaskEvent } from '@invoker/data-store';
+import { DISPATCH_LEASE_MS, DISPATCH_MAX_ATTEMPTS } from '@invoker/contracts';
 import {
   DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS,
   LaunchInvariantViolationError,
@@ -130,6 +131,8 @@ describe('assertLaunchInvariant', () => {
   });
 
   it('exposes a default maxGapMs anchored to the dispatch lease budget', () => {
-    expect(DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS).toBe(270_000);
+    expect(DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS).toBe(
+      DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30_000,
+    );
   });
 });

--- a/packages/app/src/__tests__/launch-invariant.ts
+++ b/packages/app/src/__tests__/launch-invariant.ts
@@ -22,6 +22,7 @@
  */
 
 import type { PersistenceAdapter, TaskEvent } from '@invoker/data-store';
+import { DISPATCH_LEASE_MS, DISPATCH_MAX_ATTEMPTS } from '@invoker/contracts';
 
 export const LAUNCH_CLAIM_EVENT_TYPE = 'task.launch_claimed';
 
@@ -35,13 +36,13 @@ export const TERMINAL_LAUNCH_EVENT_TYPES: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * Default upper bound on the gap between `task.launch_claimed` and the
- * next terminal launch event. Matches `3 * DISPATCH_LEASE_MS *
- * DISPATCH_MAX_ATTEMPTS` (= 270 s with the proposed dispatch defaults of
- * 30 s lease and 3 attempts). Tests that drive a deterministic in-memory
+ * Default upper bound on the gap between `task.launch_claimed` and the next
+ * terminal launch event. It follows the fixed dispatch crash-recovery window
+ * with a small scheduler buffer. Tests that drive a deterministic in-memory
  * scenario should pass a tighter bound.
  */
-export const DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS = 270_000;
+export const DEFAULT_LAUNCH_INVARIANT_MAX_GAP_MS =
+  DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30_000;
 
 export type LaunchInvariantPersistence = Pick<
   PersistenceAdapter,

--- a/packages/app/src/launch-dispatcher.ts
+++ b/packages/app/src/launch-dispatcher.ts
@@ -155,9 +155,9 @@ export class LaunchDispatcher {
    * Active-mode dispatch loop. Lease enqueued rows up to the per-poll
    * batch bound and hand each one to the
    * TaskRunner. The TaskRunner complete/fail flow drives the rest of
-   * the lifecycle; if the JS promise drops mid-flight, the durable
-   * outbox row stays leased and the next poll's `reapExpiredLeases`
-   * reclaims it after `DISPATCH_LEASE_MS`.
+   * the lifecycle; if the JS promise drops mid-flight, the durable outbox
+   * row stays leased until the fixed dispatch crash-recovery TTL expires,
+   * then the next poll's `reapExpiredLeases` reclaims it.
    */
   private dispatchActive(): void {
     const runner = this.taskRunnerProvider?.() ?? null;

--- a/packages/contracts/src/launch-timeouts.ts
+++ b/packages/contracts/src/launch-timeouts.ts
@@ -12,6 +12,6 @@
 
 export const ATTEMPT_LEASE_MS = 20 * 60 * 1000;
 
-export const DISPATCH_LEASE_MS = 30_000;
+export const DISPATCH_LEASE_MS = 12 * 60 * 1000;
 
 export const DISPATCH_MAX_ATTEMPTS = 3;

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -297,6 +297,17 @@ describe('SQLiteAdapter', () => {
 
       const byAttempt = adapter.loadLaunchDispatchByAttempt('attempt-1');
       expect(byAttempt?.id).toBe(inserted.id);
+
+      const events = adapter.getEvents('wf-launch/t1');
+      const enqueuedEvent = events.find((event) => event.eventType === 'task.launch_dispatch_enqueued');
+      expect(enqueuedEvent).toBeDefined();
+      expect(JSON.parse(enqueuedEvent!.payload!)).toMatchObject({
+        dispatchId: inserted.id,
+        attemptId: 'attempt-1',
+        workflowId: 'wf-launch',
+        generation: 0,
+        priority: 'normal',
+      });
     });
 
     it('returns existing row instead of creating a duplicate active dispatch for the same attempt', () => {
@@ -534,6 +545,17 @@ describe('SQLiteAdapter', () => {
         expect(claimed?.attemptsCount).toBe(1);
         expect(claimed?.fencedUntil).toBeDefined();
         expect(claimed?.leasedAt).toBeDefined();
+        const events = adapter.getEvents('wf-launch/t1');
+        const claimedEvent = events.find((event) => event.eventType === 'task.launch_dispatch_claimed');
+        expect(claimedEvent).toBeDefined();
+        expect(JSON.parse(claimedEvent!.payload!)).toMatchObject({
+          dispatchId: enqueued.id,
+          ownerId: 'runner-1',
+          attemptId: 'attempt-claim-1',
+          workflowId: 'wf-launch',
+          generation: 0,
+          fencedUntil: claimed?.fencedUntil,
+        });
       });
 
       it('returns undefined when no enqueued rows exist', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -3298,7 +3298,15 @@ export class SQLiteAdapter implements PersistenceAdapter {
       if (!inserted) {
         throw new Error('Failed to read back inserted task_launch_dispatch row');
       }
-      return this.rowToTaskLaunchDispatch(inserted);
+      const dispatch = this.rowToTaskLaunchDispatch(inserted);
+      this.logEvent(input.taskId, 'task.launch_dispatch_enqueued', {
+        dispatchId: dispatch.id,
+        attemptId: input.attemptId,
+        workflowId: input.workflowId,
+        generation: input.generation,
+        priority,
+      });
+      return dispatch;
     });
   }
 
@@ -3424,7 +3432,17 @@ export class SQLiteAdapter implements PersistenceAdapter {
           'SELECT * FROM task_launch_dispatch WHERE id = ?',
           [candidateId],
         );
-        return row ? this.rowToTaskLaunchDispatch(row) : undefined;
+        if (!row) return undefined;
+        const dispatch = this.rowToTaskLaunchDispatch(row);
+        this.logEvent(dispatch.taskId, 'task.launch_dispatch_claimed', {
+          dispatchId: dispatch.id,
+          ownerId: options.ownerId,
+          attemptId: dispatch.attemptId,
+          workflowId: dispatch.workflowId,
+          generation: dispatch.generation,
+          fencedUntil: dispatch.fencedUntil,
+        });
+        return dispatch;
       }
     });
   }

--- a/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-launch-dispatch.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { TaskState } from '@invoker/workflow-core';
 import type { WorkResponse, Logger } from '@invoker/contracts';
 import { TaskRunner, type LaunchOutboxAck } from '../task-runner.js';
@@ -32,6 +32,11 @@ function makeTask(overrides: Partial<TaskState> = {}): TaskState {
 
 interface RunnerEnv {
   runner: TaskRunner;
+  persistence: {
+    updateTask: ReturnType<typeof vi.fn>;
+    loadAttempts: ReturnType<typeof vi.fn>;
+    logEvent: ReturnType<typeof vi.fn>;
+  };
   orchestrator: {
     getTask: ReturnType<typeof vi.fn>;
     markTaskRunningAfterLaunch: ReturnType<typeof vi.fn>;
@@ -50,11 +55,15 @@ interface RunnerEnv {
   triggerComplete: () => void;
 }
 
-function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}): RunnerEnv {
+function buildRunnerEnv(task: TaskState, options: {
+  startThrows?: Error;
+  startImpl?: (request: any) => Promise<any>;
+} = {}): RunnerEnv {
   let completeCallback: ((response: WorkResponse) => void) | undefined;
   const executor = {
     type: 'worktree',
     start: vi.fn().mockImplementation(async (request: any) => {
+      if (options.startImpl) return options.startImpl(request);
       if (options.startThrows) throw options.startThrows;
       return {
         executionId: `exec-${request.actionId}`,
@@ -79,13 +88,14 @@ function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}):
     handleWorkerResponse: vi.fn().mockReturnValue([]),
     deferTask: vi.fn(),
   };
+  const persistence = {
+    updateTask: vi.fn(),
+    loadAttempts: vi.fn().mockReturnValue([]),
+    logEvent: vi.fn(),
+  };
   const runner = new TaskRunner({
     orchestrator: orchestrator as any,
-    persistence: {
-      updateTask: vi.fn(),
-      loadAttempts: vi.fn().mockReturnValue([]),
-      logEvent: vi.fn(),
-    } as any,
+    persistence: persistence as any,
     executorRegistry: {
       get: vi.fn().mockReturnValue(executor),
       getAll: vi.fn().mockReturnValue([['worktree', executor]]),
@@ -96,6 +106,7 @@ function buildRunnerEnv(task: TaskState, options: { startThrows?: Error } = {}):
   });
   return {
     runner,
+    persistence,
     orchestrator,
     executor,
     triggerComplete: () => {
@@ -132,6 +143,10 @@ function makeLaunchOutbox(): LaunchOutboxAck & {
 }
 
 describe('TaskRunner launch-dispatch wiring', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it('keeps dispatch leased and proceeds to executor.start', async () => {
     const task = makeTask();
     const env = buildRunnerEnv(task, { startThrows: new Error('isolated start sentinel') });
@@ -155,6 +170,38 @@ describe('TaskRunner launch-dispatch wiring', () => {
     const failArg = launchOutbox.failCalls[0][1];
     expect(failArg).toBeInstanceOf(Error);
     expect((failArg as Error).message).toMatch(/startup explosion/);
+  });
+
+  it('logs executor start begin with launch-dispatch context while executor.start is pending', async () => {
+    const task = makeTask();
+    let resolveStart: (() => void) | undefined;
+    const env = buildRunnerEnv(task, {
+      startImpl: async (request) => new Promise((resolve) => {
+        resolveStart = () => resolve({
+          executionId: `exec-${request.actionId}`,
+          taskId: request.actionId,
+          workspacePath: '/tmp/mock-ws',
+          branch: `experiment/${request.actionId}-mock`,
+        });
+      }),
+    });
+    const launchOutbox = makeLaunchOutbox();
+
+    const run = env.runner.executeTask(task, { dispatchId: 99, launchOutbox });
+    await vi.waitFor(() => expect(env.persistence.logEvent).toHaveBeenCalledWith(
+      task.id,
+      'task.executor.start_begin',
+      expect.objectContaining({
+        dispatchId: 99,
+        attemptId: 'attempt-1',
+        executorType: 'worktree',
+      }),
+    ));
+
+    resolveStart?.();
+    await vi.waitFor(() => expect(env.executor.onComplete).toHaveBeenCalled());
+    env.triggerComplete();
+    await run;
   });
 
   it('fails the dispatch when markTaskRunningAfterLaunch rejects the launch', async () => {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -62,7 +62,7 @@ import { assertNotGitConfigMutation, ensureRemoteUrl } from './git-config-mutati
 
 export type { TaskHeartbeatEvent, TaskRunnerCallbacks } from './task-runner-callbacks.js';
 
-/** Keeps `lastHeartbeatAt` fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). Matches BaseExecutor default heartbeat cadence. */
+/** Keeps launch metadata fresh while `executor.start()` is awaited (SSH remote setup/provision can take minutes). */
 const PRE_START_HEARTBEAT_INTERVAL_MS = 30_000;
 const DEFAULT_EXECUTOR_START_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -842,6 +842,13 @@ export class TaskRunner {
         `[TaskRunner] executor.start begin task=${task.id} attempt=${attemptId} executor=${executor.type} ` +
           `generation=${task.execution.generation ?? 0}`,
       );
+      this.persistence.logEvent?.(task.id, 'task.executor.start_begin', {
+        dispatchId: dispatchOpts?.dispatchId,
+        attemptId,
+        executorType: executor.type,
+        poolId: poolSelectionForStart?.poolId,
+        poolMemberId: poolSelectionForStart?.member.id,
+      });
       bench('onLaunchStart.before', {
         executorType: executor.type,
       });

--- a/scripts/repro/repro-launch-claim-orphan.sh
+++ b/scripts/repro/repro-launch-claim-orphan.sh
@@ -14,9 +14,9 @@ set -euo pipefail
 # invariant is:
 #
 #   Every `task.launch_claimed` event must be followed within
-#   `2 * DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS` (180 seconds with
-#   the defaults from packages/contracts) by a terminal launch event for
-#   the same `attempt_id`. Terminal launch events are:
+#   `DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30s` (2190 seconds with
+#   the defaults from packages/contracts) by a terminal launch event for the
+#   same `attempt_id`. Terminal launch events are:
 #
 #     - task.executor.selected
 #     - task.executor.deferred
@@ -31,9 +31,9 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 EXPECTATION=""
 TIMEOUT_SECONDS="${REPRO_TIMEOUT_SECONDS:-900}"
-# DISPATCH_LEASE_MS = 30000, DISPATCH_MAX_ATTEMPTS = 3 → 180 seconds.
+# DISPATCH_LEASE_MS = 720000, DISPATCH_MAX_ATTEMPTS = 3, buffer = 30s → 2190 seconds.
 # Override via env if the contracts module bumps these defaults.
-WAIT_BOUND_SECONDS="${REPRO_LAUNCH_INVARIANT_BOUND_SECONDS:-180}"
+WAIT_BOUND_SECONDS="${REPRO_LAUNCH_INVARIANT_BOUND_SECONDS:-2190}"
 
 usage() {
   cat <<'EOF'
@@ -45,7 +45,7 @@ What it proves:
   Every `task.launch_claimed` event recorded during a storm of
   workflow-scope rebase-recreate mutations is paired with a terminal
   launch event for the SAME attempt_id within the dispatch invariant
-  bound (default 2 * DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS = 180s).
+  bound (default DISPATCH_LEASE_MS * DISPATCH_MAX_ATTEMPTS + 30s = 2190s).
 
   Any claim without a matching terminal event is an orphaned launch —
   the exact failure mode the launch-handoff re-architecture was built
@@ -53,7 +53,7 @@ What it proves:
 
 Environment:
   REPRO_TIMEOUT_SECONDS                 storm timeout (default 900)
-  REPRO_LAUNCH_INVARIANT_BOUND_SECONDS  invariant bound (default 180)
+  REPRO_LAUNCH_INVARIANT_BOUND_SECONDS  invariant bound (default 2190)
   INVOKER_DB_PATH / INVOKER_DB_DIR      same as other repro scripts
 EOF
 }

--- a/scripts/repro/repro-pending-task-did-not-run-wf-1780385813241-5-capture-after-visual-proof.sh
+++ b/scripts/repro/repro-pending-task-did-not-run-wf-1780385813241-5-capture-after-visual-proof.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+echo "[repro] wf-1780385813241-5/capture-after-visual-proof was reaped while executor.start was still launching."
+echo "[repro] The attempt heartbeat stayed fresh, but the old 30s launch-dispatch lease expired and was recycled."
+echo "[repro] The first test proves the fixed dispatch TTL survives normal executor startup and still reaps after expiry."
+pnpm --filter @invoker/app exec vitest run \
+  src/__tests__/launch-dispatcher.test.ts \
+  -t "uses a fixed dispatch TTL long enough for normal executor startup"
+
+echo "[repro] The second test proves TaskRunner records where launch startup reached."
+pnpm --filter @invoker/execution-engine exec vitest run \
+  src/__tests__/task-runner-launch-dispatch.test.ts \
+  -t "logs executor start begin with launch-dispatch context while executor.start is pending"
+
+echo "[repro] passed"


### PR DESCRIPTION
## Summary

Replace launch lease renewal with a fixed launch TTL and better wait diagnostics.

Pending tasks now keep an enqueue/wait log instead of extending the launch lease indefinitely.

## Architecture

### Before

```mermaid
flowchart LR
  Dispatch[launch dispatch] --> Lease[renew launch lease]
  Lease --> Wait[wait for worker handoff]
```

### After

```mermaid
flowchart LR
  Dispatch[launch dispatch] --> TTL[fixed launch TTL]
  TTL --> Log[enqueue and wait diagnostics]
```

## Test Plan

- [ ] `pnpm --filter @invoker/app exec vitest run src/__tests__/launch-dispatcher.test.ts`
- [ ] `bash scripts/repro/repro-noisy-headless-task-status-parser.sh`
- [ ] GitHub CI for this stacked PR

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 3f1e3d235`
- Post-revert steps: Re-run launch dispatch TTL diagnostics validation.
- Data migration? No

Depends-On: #1172
