### PR TITLE
Fix GUI open-terminal PTY replay

### DIFF
--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -156,6 +156,36 @@ describe('EmbeddedTerminalManager', () => {
     }));
   });
 
+  it('returns synchronous backend output in the opened descriptor replay snapshot', () => {
+    const spawned = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+    const backend: EmbeddedTerminalBackend = {
+      name: 'pty',
+      spawn: vi.fn((opts) => {
+        opts.emitOutput('early output\n');
+        return spawned;
+      }),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+    const events: string[] = [];
+    mgr.on('output', (e) => events.push(e.data));
+
+    const session = mgr.openOrReuse({ taskId: 'task-early', spec: {}, cwd: '/tmp/wt' });
+
+    expect(session.outputSnapshot).toBe('early output\n');
+    expect(events).toEqual(['early output\n']);
+    expect(mgr.list()).toMatchObject([
+      { sessionId: session.sessionId, outputSnapshot: 'early output\n' },
+    ]);
+
+    const reused = mgr.openOrReuse({ taskId: 'task-early', spec: {}, cwd: '/tmp/wt' });
+    expect(reused.sessionId).toBe(session.sessionId);
+    expect(reused.outputSnapshot).toBe('early output\n');
+  });
+
   it('opens a distinct session when the same task resolves to a different terminal target', () => {
     const child1 = createFakeChild();
     const child2 = createFakeChild();
@@ -229,6 +259,34 @@ describe('EmbeddedTerminalManager', () => {
 
     expect(events.map((e) => e.data)).toEqual(['hello', 'err']);
     expect(events.every((e) => e.sessionId === session.sessionId)).toBe(true);
+    expect(mgr.get(session.sessionId)?.outputSnapshot).toBe('helloerr');
+    expect(mgr.list()[0]?.outputSnapshot).toBe('helloerr');
+  });
+
+  it('bounds each session replay snapshot to the most recent 64 KiB', () => {
+    const maxSnapshotChars = 64 * 1024;
+    const spawned = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+    let emitOutput: ((data: string) => void) | undefined;
+    const backend: EmbeddedTerminalBackend = {
+      name: 'bash',
+      spawn: vi.fn((opts) => {
+        emitOutput = opts.emitOutput;
+        return spawned;
+      }),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+
+    const session = mgr.openOrReuse({ taskId: 'task-buffer', spec: {}, cwd: '/tmp/wt' });
+    emitOutput?.('a'.repeat(maxSnapshotChars));
+    emitOutput?.('tail');
+
+    const snapshot = mgr.get(session.sessionId)?.outputSnapshot;
+    expect(snapshot).toHaveLength(maxSnapshotChars);
+    expect(snapshot).toBe(`${'a'.repeat(maxSnapshotChars - 'tail'.length)}tail`);
   });
 
   it('write() forwards data to bash stdin in spawn mode', () => {
@@ -294,6 +352,34 @@ describe('EmbeddedTerminalManager', () => {
     child.emit('exit', 0);
 
     expect(exits).toEqual([{ sessionId: session.sessionId, exitCode: 0 }]);
+    expect(mgr.list()).toHaveLength(0);
+  });
+
+  it('handles synchronous backend output and exit during spawn without uninitialized state', () => {
+    const spawned = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      close: vi.fn(),
+    };
+    const backend: EmbeddedTerminalBackend = {
+      name: 'bash',
+      spawn: vi.fn((opts) => {
+        opts.emitOutput('before-exit\n');
+        opts.emitExit(7);
+        return spawned;
+      }),
+    };
+    const mgr = new EmbeddedTerminalManager({ backend });
+    const exits: Array<{ sessionId: string; exitCode?: number }> = [];
+    mgr.on('exit', (e) => exits.push({ sessionId: e.sessionId, exitCode: e.exitCode }));
+
+    const session = mgr.openOrReuse({ taskId: 'task-sync-exit', spec: {}, cwd: '/tmp/wt' });
+
+    expect(session.status).toBe('exited');
+    expect(session.exitCode).toBe(7);
+    expect(session.outputSnapshot).toBe('before-exit\n');
+    expect(spawned.close).toHaveBeenCalledTimes(1);
+    expect(exits).toEqual([{ sessionId: session.sessionId, exitCode: 7 }]);
     expect(mgr.list()).toHaveLength(0);
   });
 

--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -156,7 +156,8 @@ describe('EmbeddedTerminalManager', () => {
     }));
   });
 
-  it('returns synchronous backend output in the opened descriptor replay snapshot', () => {
+  it('replays PTY first-frame output emitted before openOrReuse returns', () => {
+    const firstFrame = 'FIRST_FRAME_FROM_PTY\n';
     const spawned = {
       write: vi.fn(),
       resize: vi.fn(),
@@ -165,25 +166,24 @@ describe('EmbeddedTerminalManager', () => {
     const backend: EmbeddedTerminalBackend = {
       name: 'pty',
       spawn: vi.fn((opts) => {
-        opts.emitOutput('early output\n');
+        opts.emitOutput(firstFrame);
         return spawned;
       }),
     };
     const mgr = new EmbeddedTerminalManager({ backend });
-    const events: string[] = [];
-    mgr.on('output', (e) => events.push(e.data));
 
     const session = mgr.openOrReuse({ taskId: 'task-early', spec: {}, cwd: '/tmp/wt' });
+    const latePaneOutput = [session.outputSnapshot ?? ''];
+    mgr.on('output', (e) => latePaneOutput.push(e.data));
 
-    expect(session.outputSnapshot).toBe('early output\n');
-    expect(events).toEqual(['early output\n']);
+    expect(latePaneOutput).toEqual([firstFrame]);
     expect(mgr.list()).toMatchObject([
-      { sessionId: session.sessionId, outputSnapshot: 'early output\n' },
+      { sessionId: session.sessionId, outputSnapshot: firstFrame },
     ]);
 
     const reused = mgr.openOrReuse({ taskId: 'task-early', spec: {}, cwd: '/tmp/wt' });
     expect(reused.sessionId).toBe(session.sessionId);
-    expect(reused.outputSnapshot).toBe('early output\n');
+    expect(reused.outputSnapshot).toBe(firstFrame);
   });
 
   it('opens a distinct session when the same task resolves to a different terminal target', () => {

--- a/packages/app/src/embedded-terminal-manager.ts
+++ b/packages/app/src/embedded-terminal-manager.ts
@@ -23,6 +23,8 @@ import type { Executor, ExecutorHandle, TerminalSpec } from '@invoker/execution-
 
 export type EmbeddedTerminalBackendName = 'bash' | 'pty';
 
+const MAX_OUTPUT_SNAPSHOT_CHARS = 64 * 1024;
+
 export interface PtyForkOptionsLike {
   name: string;
   cols: number;
@@ -103,6 +105,7 @@ interface BaseSessionState {
   createdAt: string;
   status: 'running' | 'exited';
   exitCode?: number;
+  outputSnapshot: string;
 }
 
 interface SpawnSessionState extends BaseSessionState {
@@ -138,6 +141,7 @@ function describeSession(state: SessionState): TerminalSessionDescriptor {
     mode: state.mode,
     attached: state.mode === 'attached',
     createdAt: state.createdAt,
+    outputSnapshot: state.outputSnapshot,
   };
 }
 
@@ -281,37 +285,98 @@ export class EmbeddedTerminalManager extends EventEmitter {
       cwd: opts.cwd,
       createdAt,
       status: 'running' as const,
+      outputSnapshot: '',
     };
 
-    let state: SessionState;
     if (opts.attach) {
-      const unsubscribe = opts.attach.executor.onOutput(opts.attach.handle, (data) => {
-        this.emitOutput(sessionId, opts.taskId, data);
-      });
-      state = {
+      const state: AttachedSessionState = {
         ...base,
         mode: 'attached',
         attach: opts.attach,
-        unsubscribeOutput: unsubscribe,
+        unsubscribeOutput: () => {},
       };
-    } else {
+      this.sessions.set(sessionId, state);
+      this.targetIndex.set(targetKey, sessionId);
+
+      let unsubscribe: () => void;
+      try {
+        unsubscribe = opts.attach.executor.onOutput(opts.attach.handle, (data) => {
+          this.emitOutput(state, data);
+        });
+      } catch (err) {
+        this.sessions.delete(sessionId);
+        if (this.targetIndex.get(targetKey) === sessionId) {
+          this.targetIndex.delete(targetKey);
+        }
+        throw err;
+      }
+      state.unsubscribeOutput = unsubscribe;
+      if (state.status === 'exited') {
+        try {
+          unsubscribe();
+        } catch {
+          /* unsubscribe is best-effort */
+        }
+      }
+      return describeSession(state);
+    }
+
+    const pendingProcess: SpawnedTerminalProcess = {
+      write() {
+        throw new Error(`Session "${sessionId}" process is not ready.`);
+      },
+      resize() {
+        // Resize before the backend returns a process handle is ignored.
+      },
+      close() {
+        // There is no process handle to close yet.
+      },
+    };
+    const state: SpawnSessionState = {
+      ...base,
+      mode: 'spawn',
+      backend: this.backend.name,
+      process: pendingProcess,
+    };
+    this.sessions.set(sessionId, state);
+    this.targetIndex.set(targetKey, sessionId);
+
+    const noPendingExit = Symbol('no-pending-exit');
+    let pendingExitCode: number | undefined | typeof noPendingExit = noPendingExit;
+    try {
       const process = this.backend.spawn({
         spec: opts.spec,
         cwd: opts.cwd,
         defaultShell: this.defaultShell,
-        emitOutput: (data) => this.emitOutput(sessionId, opts.taskId, data),
-        emitExit: (exitCode) => this.finalizeSession(state, exitCode),
+        emitOutput: (data) => this.emitOutput(state, data),
+        emitExit: (exitCode) => {
+          if (state.process === pendingProcess) {
+            pendingExitCode = exitCode;
+            return;
+          }
+          this.finalizeSession(state, exitCode);
+        },
       });
-      state = {
-        ...base,
-        mode: 'spawn',
-        backend: this.backend.name,
-        process,
-      };
+      state.process = process;
+      if (state.status === 'exited') {
+        try {
+          process.close();
+        } catch {
+          /* process cleanup is best-effort */
+        }
+      }
+    } catch (err) {
+      this.sessions.delete(sessionId);
+      if (this.targetIndex.get(targetKey) === sessionId) {
+        this.targetIndex.delete(targetKey);
+      }
+      throw err;
     }
 
-    this.sessions.set(sessionId, state);
-    this.targetIndex.set(targetKey, sessionId);
+    if (pendingExitCode !== noPendingExit) {
+      this.finalizeSession(state, pendingExitCode);
+    }
+
     return describeSession(state);
   }
 
@@ -402,10 +467,20 @@ export class EmbeddedTerminalManager extends EventEmitter {
     this.emit('exit', payload);
   }
 
-  private emitOutput(sessionId: string, taskId: string, data: string): void {
-    const payload: TerminalOutputEvent = { sessionId, taskId, data };
+  private emitOutput(state: SessionState, data: string): void {
+    state.outputSnapshot = trimOutputSnapshot(state.outputSnapshot + data);
+    const payload: TerminalOutputEvent = {
+      sessionId: state.sessionId,
+      taskId: state.taskId,
+      data,
+    };
     this.emit('output', payload);
   }
+}
+
+function trimOutputSnapshot(snapshot: string): string {
+  if (snapshot.length <= MAX_OUTPUT_SNAPSHOT_CHARS) return snapshot;
+  return snapshot.slice(snapshot.length - MAX_OUTPUT_SNAPSHOT_CHARS);
 }
 
 function resolveBackend(options: EmbeddedTerminalManagerOptions): EmbeddedTerminalBackend {

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -277,6 +277,8 @@ export interface TerminalSessionDescriptor {
   mode: 'spawn' | 'attached';
   attached: boolean;
   createdAt: string;
+  /** Bounded recent terminal output snapshot used to seed newly mounted panes. */
+  outputSnapshot?: string;
 }
 
 export interface TerminalOutputEvent {

--- a/packages/ui/src/__tests__/helpers/mock-invoker.ts
+++ b/packages/ui/src/__tests__/helpers/mock-invoker.ts
@@ -15,6 +15,7 @@ import type {
   TaskConfig,
   TaskExecution,
 } from '../../types.js';
+import type { TerminalOutputEvent } from '@invoker/contracts';
 
 export interface MockInvoker {
   /** The mock InvokerAPI object installed on window.invoker. */
@@ -25,6 +26,8 @@ export interface MockInvoker {
   fireDelta: (delta: TaskDelta) => void;
   /** Fire a workflows-changed event. */
   fireWorkflowsChanged: (workflows: WorkflowMeta[]) => void;
+  /** Fire an embedded terminal output event to subscribers. */
+  fireTerminalOutput: (event: TerminalOutputEvent) => void;
   /** Install the mock on window.invoker. */
   install: () => void;
   /** Remove window.invoker. */
@@ -39,6 +42,7 @@ export function createMockInvoker(
   let workflowSnapshot = initialWorkflows;
   let deltaCallback: ((delta: TaskDelta) => void) | undefined;
   let workflowsCallback: ((workflows: unknown[]) => void) | undefined;
+  const terminalOutputCallbacks = new Set<(event: TerminalOutputEvent) => void>();
 
   const api: InvokerAPI = {
     // Defer resolution one microtask so snapshot is read after synchronous setTasks()
@@ -140,7 +144,10 @@ export function createMockInvoker(
     terminalWrite: vi.fn(async () => ({ ok: true })),
     terminalResize: vi.fn(async () => ({ ok: true })),
     terminalClose: vi.fn(async () => ({ ok: true })),
-    onTerminalOutput: vi.fn(() => () => {}),
+    onTerminalOutput: vi.fn((cb: (event: TerminalOutputEvent) => void) => {
+      terminalOutputCallbacks.add(cb);
+      return () => { terminalOutputCallbacks.delete(cb); };
+    }),
     onTerminalExit: vi.fn(() => () => {}),
     resumeWorkflow: vi.fn(async () => null),
     listWorkflows: vi.fn(async () => []),
@@ -191,6 +198,12 @@ export function createMockInvoker(
     workflowsCallback?.(workflows);
   }
 
+  function fireTerminalOutput(event: TerminalOutputEvent) {
+    for (const callback of terminalOutputCallbacks) {
+      callback(event);
+    }
+  }
+
   function install() {
     (window as unknown as { invoker: InvokerAPI }).invoker = api;
     (window as unknown as { __INVOKER_BOOTSTRAP__?: { tasks: TaskState[]; workflows: WorkflowMeta[] } }).__INVOKER_BOOTSTRAP__ = {
@@ -200,11 +213,12 @@ export function createMockInvoker(
   }
 
   function cleanup() {
+    terminalOutputCallbacks.clear();
     delete (window as unknown as { invoker?: unknown }).invoker;
     delete (window as unknown as { __INVOKER_BOOTSTRAP__?: unknown }).__INVOKER_BOOTSTRAP__;
   }
 
-  return { api, setTasks, fireDelta, fireWorkflowsChanged, install, cleanup };
+  return { api, setTasks, fireDelta, fireWorkflowsChanged, fireTerminalOutput, install, cleanup };
 }
 
 /** Create a minimal TaskState for testing. */

--- a/packages/ui/src/__tests__/terminal-drawer.test.tsx
+++ b/packages/ui/src/__tests__/terminal-drawer.test.tsx
@@ -12,11 +12,69 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { render, screen, act, waitFor, fireEvent } from '@testing-library/react';
 import { createMockInvoker, makeUITask, type MockInvoker } from './helpers/mock-invoker.js';
 import type { WorkflowMeta } from '../types.js';
+import type { TerminalSessionDescriptor } from '@invoker/contracts';
 
 vi.mock('@xyflow/react', async () => {
   const { createReactFlowMock } = await import('./helpers/mock-react-flow.js');
   return createReactFlowMock();
 });
+
+const xtermMock = vi.hoisted(() => {
+  type DataHandler = (data: string) => void;
+
+  const instances: MockTerminal[] = [];
+  const fitInstances: MockFitAddon[] = [];
+  const writeLog: string[] = [];
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    dataHandler: DataHandler | null = null;
+    loadAddon = vi.fn();
+    open = vi.fn();
+    write = vi.fn((data: string) => {
+      writeLog.push(data);
+    });
+    onData = vi.fn((cb: DataHandler) => {
+      this.dataHandler = cb;
+      return { dispose: vi.fn() };
+    });
+    focus = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      instances.push(this);
+    }
+
+    emitData(data: string) {
+      this.dataHandler?.(data);
+    }
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+
+    constructor() {
+      fitInstances.push(this);
+    }
+  }
+
+  return {
+    Terminal: MockTerminal,
+    FitAddon: MockFitAddon,
+    instances,
+    fitInstances,
+    writeLog,
+    reset: () => {
+      instances.length = 0;
+      fitInstances.length = 0;
+      writeLog.length = 0;
+    },
+  };
+});
+
+vi.mock('xterm', () => ({ Terminal: xtermMock.Terminal }));
+vi.mock('xterm-addon-fit', () => ({ FitAddon: xtermMock.FitAddon }));
 
 const { App } = await import('../App.js');
 
@@ -35,6 +93,21 @@ const taskBeta = makeUITask({
   dependencies: ['task-alpha'],
 });
 
+function makeTerminalSession(
+  taskId: string,
+  overrides: Partial<TerminalSessionDescriptor> = {},
+): TerminalSessionDescriptor {
+  return {
+    sessionId: `mock-session-${taskId}`,
+    taskId,
+    status: 'running',
+    mode: 'spawn',
+    attached: false,
+    createdAt: new Date('2025-01-01T00:00:00Z').toISOString(),
+    ...overrides,
+  };
+}
+
 async function selectWorkflow(): Promise<void> {
   await waitFor(() => {
     expect(screen.getByTestId('workflow-node-wf-a')).toBeInTheDocument();
@@ -49,6 +122,7 @@ describe('Terminal drawer (component)', () => {
   let mock: MockInvoker;
 
   beforeEach(() => {
+    xtermMock.reset();
     mock = createMockInvoker();
     mock.install();
   });
@@ -171,5 +245,112 @@ describe('Terminal drawer (component)', () => {
       expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument();
     });
     expect(mock.api.openTerminal).toHaveBeenCalledWith('task-alpha');
+  });
+
+  it('seeds the replay snapshot before live terminal output', async () => {
+    const session = makeTerminalSession('task-alpha', {
+      outputSnapshot: 'early line\n',
+    });
+    (mock.api.openTerminal as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      opened: true,
+      session,
+    });
+
+    render(<App />);
+    act(() => mock.setTasks([taskAlpha], workflows));
+    await selectWorkflow();
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+
+    await waitFor(() => {
+      expect(xtermMock.writeLog).toEqual(['early line\n']);
+    });
+
+    act(() => {
+      mock.fireTerminalOutput({
+        sessionId: session.sessionId,
+        taskId: session.taskId,
+        data: 'live line\n',
+      });
+    });
+
+    await waitFor(() => {
+      expect(xtermMock.writeLog).toEqual(['early line\n', 'live line\n']);
+    });
+  });
+
+  it('does not duplicate the replay snapshot when the same session re-renders', async () => {
+    const session = makeTerminalSession('task-alpha', {
+      outputSnapshot: 'replayed once\n',
+    });
+    (mock.api.openTerminal as ReturnType<typeof vi.fn>).mockResolvedValue({
+      opened: true,
+      session,
+    });
+
+    render(<App />);
+    act(() => mock.setTasks([taskAlpha], workflows));
+    await selectWorkflow();
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    await waitFor(() => {
+      expect(xtermMock.writeLog).toEqual(['replayed once\n']);
+    });
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    await waitFor(() => {
+      expect(mock.api.openTerminal).toHaveBeenCalledTimes(2);
+    });
+
+    expect(xtermMock.writeLog).toEqual(['replayed once\n']);
+  });
+
+  it('keeps live output, input, resize, close, tab selection, and preview wiring intact', async () => {
+    (mock.api.openTerminal as ReturnType<typeof vi.fn>).mockImplementation(async (taskId: string) => ({
+      opened: true,
+      session: makeTerminalSession(taskId, {
+        command: 'sh',
+        args: ['-lc', taskId],
+      }),
+    }));
+
+    render(<App />);
+    act(() => mock.setTasks([taskAlpha, taskBeta], workflows));
+    await selectWorkflow();
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-alpha'));
+    await waitFor(() => expect(screen.getByTestId('terminal-tab-task-alpha')).toBeInTheDocument());
+    await waitFor(() => {
+      expect(mock.api.terminalResize).toHaveBeenCalledWith('mock-session-task-alpha', 80, 24);
+    });
+
+    fireEvent.doubleClick(screen.getByTestId('rf__node-task-beta'));
+    await waitFor(() => expect(screen.getByTestId('terminal-tab-task-beta')).toBeInTheDocument());
+    expect(screen.getByTestId('terminal-tab-task-beta')).toHaveAttribute('data-active', 'true');
+
+    fireEvent.click(screen.getByRole('tab', { name: /Alpha description/i }));
+    expect(screen.getByTestId('terminal-tab-task-alpha')).toHaveAttribute('data-active', 'true');
+
+    act(() => {
+      xtermMock.instances[0]?.emitData('pwd\n');
+    });
+    expect(mock.api.terminalWrite).toHaveBeenCalledWith('mock-session-task-alpha', 'pwd\n');
+
+    act(() => {
+      mock.fireTerminalOutput({
+        sessionId: 'mock-session-task-alpha',
+        taskId: 'task-alpha',
+        data: 'alpha live output\n',
+      });
+    });
+    await waitFor(() => {
+      expect(xtermMock.writeLog).toContain('alpha live output\n');
+      expect(screen.getByTestId('terminal-session-output-preview')).toHaveTextContent('alpha live output');
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Close terminal for Alpha description' }));
+    await waitFor(() => {
+      expect(mock.api.terminalClose).toHaveBeenCalledWith('mock-session-task-alpha');
+    });
   });
 });

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -34,16 +34,52 @@ interface TerminalSessionPaneProps {
   onOutput: (sessionId: string, data: string) => void;
 }
 
+type SeededOutputSnapshot = {
+  sessionId: string;
+  snapshot: string;
+  term: XTermTerminal;
+};
+
 function lastNonEmptyLine(data: string): string {
   const clean = data.replace(ANSI_PATTERN, '').replace(/\r/g, '\n');
   const lines = clean.split('\n').map((line) => line.trim()).filter(Boolean);
   return lines.at(-1) ?? '';
 }
 
+function seedTerminalOutputSnapshot(
+  term: XTermTerminal,
+  session: TerminalSessionDescriptor,
+  seededSnapshotRef: { current: SeededOutputSnapshot | null },
+): void {
+  const outputSnapshot = session.outputSnapshot;
+  const seededSnapshot = seededSnapshotRef.current;
+  if (
+    outputSnapshot &&
+    (
+      !seededSnapshot ||
+      seededSnapshot.sessionId !== session.sessionId ||
+      seededSnapshot.snapshot !== outputSnapshot ||
+      seededSnapshot.term !== term
+    )
+  ) {
+    try {
+      term.write(outputSnapshot);
+      seededSnapshotRef.current = {
+        sessionId: session.sessionId,
+        snapshot: outputSnapshot,
+        term,
+      };
+    } catch {
+      /* terminal disposed */
+    }
+  }
+}
+
 function TerminalSessionPane({ session, isActive, hasHeader, onOutput }: TerminalSessionPaneProps): JSX.Element {
   const containerRef = useRef<HTMLDivElement | null>(null);
   const termRef = useRef<XTermTerminal | null>(null);
   const fitRef = useRef<FitAddon | null>(null);
+  const seededSnapshotRef = useRef<SeededOutputSnapshot | null>(null);
 
   useEffect(() => {
     const host = containerRef.current;
@@ -68,6 +104,8 @@ function TerminalSessionPane({ session, isActive, hasHeader, onOutput }: Termina
     }
     termRef.current = term;
     fitRef.current = fit;
+
+    seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
 
     const inputDisposable = term.onData((data) => {
       void window.invoker?.terminalWrite?.(session.sessionId, data);
@@ -125,6 +163,12 @@ function TerminalSessionPane({ session, isActive, hasHeader, onOutput }: Termina
       fitRef.current = null;
     };
   }, [onOutput, session.sessionId]);
+
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    seedTerminalOutputSnapshot(term, session, seededSnapshotRef);
+  }, [session.outputSnapshot, session.sessionId]);
 
   useEffect(() => {
     if (!isActive) return;

--- a/packages/ui/src/components/TerminalDrawer.tsx
+++ b/packages/ui/src/components/TerminalDrawer.tsx
@@ -69,8 +69,11 @@ function seedTerminalOutputSnapshot(
         snapshot: outputSnapshot,
         term,
       };
-    } catch {
-      /* terminal disposed */
+    } catch (err) {
+      console.warn(
+        `Failed to seed output snapshot for terminal session ${session.sessionId}:`,
+        err,
+      );
     }
   }
 }

--- a/scripts/repro-gui-open-terminal-pty-race.sh
+++ b/scripts/repro-gui-open-terminal-pty-race.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+pnpm --dir packages/app exec vitest run \
+  src/__tests__/embedded-terminal-manager.test.ts \
+  -t "replays PTY first-frame output emitted before openOrReuse returns"


### PR DESCRIPTION
## Summary

Fixes GUI Open Terminal blank panes caused by embedded PTY output emitted before React subscribes to terminal output events.

Embedded terminal descriptors now carry a bounded recent-output snapshot, so newly opened and restored panes can seed xterm before live streaming continues.

Adds deterministic app and UI regression coverage for first-frame PTY output, snapshot bounds, synchronous backend exit, and drawer replay seeding.

## Architecture

### Before

```mermaid
flowchart TD
    A[GUI double-clicks task] --> B[main openTerminal]
    B --> C[EmbeddedTerminalManager openOrReuse]
    C --> D[PTY backend emits output during spawn]
    D --> E[main emits invoker:terminal-output]
    B --> F[renderer receives session descriptor]
    F --> G[React mounts TerminalSessionPane]
    G --> H[renderer subscribes to output]
    E -. missed .-> H
    H --> I[Blank xterm pane until later output]
```

### After

```mermaid
flowchart TD
    A[GUI double-clicks task] --> B[main openTerminal]
    B --> C[EmbeddedTerminalManager openOrReuse]
    C --> D[Create session state before spawn]
    D --> E[PTY backend emits output]
    E --> F[Append to bounded outputSnapshot]
    F --> G[Return descriptor with snapshot]
    G --> H[TerminalSessionPane writes snapshot to xterm once]
    E --> I[Continue live invoker:terminal-output events]
    I --> H
    J[terminalList reload] --> G
```

## Test Plan

- [x] `bash scripts/repro-gui-open-terminal-pty-race.sh`
- [x] `cd packages/app && pnpm test -- src/__tests__/embedded-terminal-manager.test.ts`
- [x] `cd packages/ui && pnpm test -- src/__tests__/terminal-drawer.test.tsx`
- [x] `pnpm --filter @invoker/ui build && pnpm --filter @invoker/app build`
- [x] `cd packages/app && pnpm exec playwright test e2e/embedded-terminal-pty.spec.ts`
- [x] `pnpm run test:all`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-commit-sha>`
- Post-revert steps: None
- Data migration? No