### PR TITLE
chore(release): prepare v0.0.4 packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ env:
 
 jobs:
   build-cli:
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -26,7 +27,7 @@ jobs:
           - runner: ubuntu-24.04-arm
             platform: linux
             arch: arm64
-          - runner: macos-13
+          - runner: macos-15-intel
             platform: darwin
             arch: x64
           - runner: macos-latest
@@ -69,13 +70,20 @@ jobs:
           if-no-files-found: error
 
   build-desktop:
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:
         include:
           - runner: ubuntu-latest
             build_command: pnpm run dist:desktop:linux
-            artifact_name: desktop-linux
+            artifact_name: desktop-linux-x64
+            artifact_glob: |
+              release/*.AppImage
+              release/*.deb
+          - runner: ubuntu-24.04-arm
+            build_command: pnpm run dist:desktop:linux
+            artifact_name: desktop-linux-arm64
             artifact_glob: |
               release/*.AppImage
               release/*.deb
@@ -85,7 +93,7 @@ jobs:
             artifact_glob: |
               release/*.dmg
               release/*.zip
-          - runner: macos-13
+          - runner: macos-15-intel
             build_command: pnpm run dist:desktop:mac:x64
             artifact_name: desktop-mac-x64
             artifact_glob: |
@@ -144,6 +152,33 @@ jobs:
       - name: Generate combined checksums
         run: bash scripts/release-sha256.sh
 
+      - name: Verify complete release asset set
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          required=(
+            "invoker-cli-${version}-linux-x64.tar.gz"
+            "invoker-cli-${version}-linux-arm64.tar.gz"
+            "invoker-cli-${version}-darwin-x64.tar.gz"
+            "invoker-cli-${version}-darwin-arm64.tar.gz"
+            "Invoker-${version}-x86_64.AppImage"
+            "Invoker-${version}-arm64.AppImage"
+            "Invoker-${version}-amd64.deb"
+            "Invoker-${version}-arm64.deb"
+            "Invoker-${version}-x64.dmg"
+            "Invoker-${version}-arm64.dmg"
+            "Invoker-${version}-x64.zip"
+            "Invoker-${version}-arm64.zip"
+            "SHA256SUMS"
+          )
+          missing=0
+          for asset in "${required[@]}"; do
+            if [ ! -f "release/${asset}" ]; then
+              echo "Missing release asset: ${asset}" >&2
+              missing=1
+            fi
+          done
+          exit "$missing"
+
       - name: Publish GitHub release assets
         uses: softprops/action-gh-release@v2
         with:
@@ -176,8 +211,6 @@ jobs:
 
       - name: Publish npm packages
         if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          pnpm --filter @neko-catpital-labs/invoker-cli publish --access public --no-git-checks
-          pnpm --filter @neko-catpital-labs/invoker-ui publish --access public --no-git-checks
+          npm publish ./packages/npm-cli --access public --provenance
+          npm publish ./packages/npm-ui --access public --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to Invoker will be documented in this file.
 
+## 0.0.4
+
+- Publish complete CLI and desktop release assets for npm launcher packages.
+- Prepare public npm publication for `@neko-catpital-labs/invoker-cli` and `@neko-catpital-labs/invoker-ui`.
+
 ## 0.1.0
 
 - Establish `0.1.0` as the initial documented version baseline for the repository.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Persisted workflow orchestration: a DAG of tasks in isolated workspaces, composed through git branches, merge gates, and review.**
 
-Current version: `0.0.3`. Version history lives in [CHANGELOG.md](CHANGELOG.md).
+Current version: `0.0.4`. Version history lives in [CHANGELOG.md](CHANGELOG.md).
 
 ## Overview
 
@@ -57,7 +57,7 @@ invoker-cli run plans/fixtures/hello-world.yaml --standalone
 Or download the platform binary from GitHub Releases:
 
 ```bash
-version=0.0.3
+version=0.0.4
 case "$(uname -s)" in
   Darwin) platform=darwin ;;
   Linux) platform=linux ;;
@@ -77,7 +77,7 @@ chmod +x invoker-cli
 Release checksums are published as `SHA256SUMS`. To verify a downloaded binary:
 
 ```bash
-curl -L -O "https://github.com/Neko-Catpital-Labs/Invoker/releases/download/v0.0.3/SHA256SUMS"
+curl -L -O "https://github.com/Neko-Catpital-Labs/Invoker/releases/download/v0.0.4/SHA256SUMS"
 shasum -a 256 -c SHA256SUMS --ignore-missing
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invoker",
   "private": true,
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only",

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "@invoker/app",
   "productName": "Invoker",
   "desktopName": "invoker.desktop",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Invoker desktop app",
   "homepage": "https://github.com/Neko-Catpital-Labs/Invoker",
   "author": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Standalone Invoker command-line runner",
   "type": "module",
   "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,7 +25,7 @@ import {
   type TaskState,
 } from '@invoker/workflow-core';
 
-const VERSION = '0.0.3';
+const VERSION = '0.0.4';
 
 type CliOptions = {
   dbDir?: string;

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/contracts",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "deprecated": "Use @invoker/workflow-core instead",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/data-store/package.json
+++ b/packages/data-store/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/data-store",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/execution-engine/package.json
+++ b/packages/execution-engine/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/execution-engine",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/graph/package.json
+++ b/packages/graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/graph",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "deprecated": "Use @invoker/workflow-graph instead",
   "description": "Pure action graph data structure — nodes, edges, DAG ops, mutations (compatibility layer)",
   "type": "module",

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@neko-catpital-labs/invoker-cli",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Invoker standalone CLI installer",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Neko-Catpital-Labs/Invoker.git",
+    "directory": "packages/npm-cli"
+  },
   "bin": {
     "invoker-cli": "bin/invoker-cli.js"
   },

--- a/packages/npm-ui/package.json
+++ b/packages/npm-ui/package.json
@@ -1,8 +1,13 @@
 {
   "name": "@neko-catpital-labs/invoker-ui",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Invoker desktop UI launcher",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Neko-Catpital-Labs/Invoker.git",
+    "directory": "packages/npm-ui"
+  },
   "bin": {
     "invoker-ui": "bin/invoker-ui.js"
   },

--- a/packages/npm-ui/scripts/install.js
+++ b/packages/npm-ui/scripts/install.js
@@ -21,10 +21,11 @@ const baseUrl = process.env.INVOKER_RELEASE_BASE_URL ?? `https://github.com/${re
 const vendor = join(root, 'vendor');
 
 const arch = process.arch;
+const linuxAssetArch = arch === 'x64' ? 'x86_64' : arch;
 const asset = process.platform === 'darwin'
   ? `Invoker-${pkg.version}-${arch}.zip`
   : process.platform === 'linux'
-    ? `Invoker-${pkg.version}-${arch}.AppImage`
+    ? `Invoker-${pkg.version}-${linuxAssetArch}.AppImage`
     : undefined;
 
 if (!asset) {

--- a/packages/persistence/package.json
+++ b/packages/persistence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/persistence",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/protocol",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "deprecated": "Use @invoker/contracts instead",
   "type": "module",
   "main": "src/index.ts",

--- a/packages/runtime-adapters/package.json
+++ b/packages/runtime-adapters/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/runtime-adapters",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/runtime-domain/package.json
+++ b/packages/runtime-domain/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/runtime-domain",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/runtime-service/package.json
+++ b/packages/runtime-service/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/runtime-service",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/shell/package.json
+++ b/packages/shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/shell",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/surfaces/package.json
+++ b/packages/surfaces/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/surfaces",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {

--- a/packages/svc-api/package.json
+++ b/packages/svc-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/svc-api",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/test-kit/package.json
+++ b/packages/test-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/test-kit",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "type": "module",
   "main": "src/index.ts",

--- a/packages/transport/package.json
+++ b/packages/transport/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/transport",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/ui",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/web-app/package.json
+++ b/packages/web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/web-app",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/workflow-core/package.json
+++ b/packages/workflow-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/workflow-core",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/packages/workflow-graph/package.json
+++ b/packages/workflow-graph/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/workflow-graph",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Pure action graph data structure — nodes, edges, DAG ops, mutations",
   "type": "module",
   "main": "src/index.ts",


### PR DESCRIPTION
## Summary

Prepare the repository for the v0.0.4 release from canonical master.

Bump package versions and docs to 0.0.4. Add release workflow safeguards so npm launchers publish only after complete CLI and desktop assets exist.

## Architecture

### Before

```mermaid
flowchart TD
  Tag[Tag push] --> Build[Build partial platform matrix]
  Build --> Release[Publish GitHub release assets]
  Release --> Npm[pnpm publish with NPM_TOKEN]
  Build -. cancellation .-> Skip[Publish job skipped]
```

### After

```mermaid
flowchart TD
  Tag[Tag push] --> Build[Build full supported platform matrix]
  Build --> Verify[Verify required asset set]
  Verify --> Release[Publish GitHub release assets]
  Release --> Npm[npm trusted publishing with provenance]
```

## Test Plan

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `npm pack --dry-run --json ./packages/npm-cli`
- [x] `npm pack --dry-run --json ./packages/npm-ui`
- [x] `pnpm run check:types`
- [x] `pnpm run check:required-builds`
- [x] `node -e` YAML parse for `.github/workflows/release.yml`
- [x] `git diff --check`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 0ca0fdf66`
- Post-revert steps: Do not push `v0.0.4`; rerun release prep after restoring the release workflow.
- Data migration? No
