### PR TITLE
fix(release): allow npm token bootstrap fallback

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,6 +211,12 @@ jobs:
 
       - name: Publish npm packages
         if: startsWith(github.ref, 'refs/tags/v')
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          npm publish ./packages/npm-cli --access public --provenance
-          npm publish ./packages/npm-ui --access public --provenance
+          publish_args=(--access public)
+          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
+            publish_args+=(--provenance)
+          fi
+          npm publish ./packages/npm-cli "${publish_args[@]}"
+          npm publish ./packages/npm-ui "${publish_args[@]}"


### PR DESCRIPTION
## Summary

Allow v0.0.4 npm publishing to bootstrap with an npm automation token when trusted publishing is not configured yet.

Keep trusted publishing as the no-token path, but use `NPM_TOKEN` when the repository secret exists.

## Test Plan

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `node` YAML parse and publish-step assertions for `.github/workflows/release.yml`
- [x] `git diff --check`
- [x] `bash -n` on the extracted publish step body

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert d16fef583`
- Post-revert steps: Configure npm trusted publishing before pushing a release tag.
- Data migration? No
