### PR TITLE
fix(release): restore standalone CLI packaging

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -584,5 +584,7 @@ export async function main(argv: string[] = process.argv.slice(2), deps: CliDeps
 }
 
 if (import.meta.url === pathToFileURL(process.argv[1] ?? '').href) {
-  process.exitCode = await main();
+  void main().then((exitCode) => {
+    process.exitCode = exitCode;
+  });
 }

--- a/scripts/build-cli-standalone.mjs
+++ b/scripts/build-cli-standalone.mjs
@@ -70,12 +70,23 @@ try {
   const bundlePath = join(stage, 'index.js');
   const blobPath = join(stage, 'sea-prep.blob');
   const seaConfigPath = join(stage, 'sea-config.json');
+  const standaloneEntryPath = join(stage, 'index.ts');
   const targetNode = await ensureTargetNode(stage);
+  const cliEntryImportPath = join(root, 'packages/cli/src/index.ts').replaceAll('\\', '/');
+
+  await writeFile(standaloneEntryPath, [
+    `import { main } from ${JSON.stringify(cliEntryImportPath)};`,
+    '',
+    'void main().then((exitCode) => {',
+    '  process.exitCode = exitCode;',
+    '});',
+    '',
+  ].join('\n'));
 
   run('pnpm', [
     'exec',
     'tsup',
-    'packages/cli/src/index.ts',
+    standaloneEntryPath,
     '--format',
     'cjs',
     '--platform',
@@ -89,6 +100,12 @@ try {
     stage,
     '--external',
     'node:sqlite',
+    '--external',
+    'dockerode',
+    '--external',
+    'ssh2',
+    '--external',
+    'cpu-features',
   ]);
 
   await writeFile(seaConfigPath, JSON.stringify({


### PR DESCRIPTION
## Summary

Restore v0.0.4 standalone CLI packaging by removing top-level await from the package entrypoint and generating a SEA-only entry file that invokes `main()` directly.

Keep optional native Docker SSH dependencies external during SEA bundling so ignored native build scripts do not fail release builds.

## Test Plan

- [x] `pnpm install --frozen-lockfile`
- [x] `INVOKER_USE_HOST_NODE_FOR_SEA=1 pnpm run dist:cli` reproduced the Homebrew Node sentinel limitation after the bundle fix
- [x] `pnpm run dist:cli && ./release/invoker-cli-0.0.4-darwin-arm64 --version`
- [x] `DB_DIR="$(mktemp -d)" && ./release/invoker-cli-0.0.4-darwin-arm64 run plans/fixtures/hello-world.yaml --standalone --db-dir "$DB_DIR" --json`
- [x] `pnpm --filter @invoker/cli test`
- [x] `pnpm run dist:desktop:mac:arm64`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert da85c13e3`
- Post-revert steps: Re-run `pnpm run dist:cli` before cutting another release tag.
- Data migration? No
