### PR TITLE
fix(app): hide headless Electron on macOS

### DIFF
--- a/packages/app/src/__tests__/app-bootstrap.test.ts
+++ b/packages/app/src/__tests__/app-bootstrap.test.ts
@@ -32,6 +32,7 @@ describe('app-bootstrap', () => {
       app,
       platform: 'linux',
       enableTestCompositor: false,
+      isHeadless: false,
     });
 
     expect(disableHardwareAcceleration).toHaveBeenCalledTimes(1);
@@ -46,6 +47,56 @@ describe('app-bootstrap', () => {
       'disable-software-rasterizer',
       'class',
     ]);
+  });
+
+  it('keeps macOS headless mode out of the Dock', () => {
+    const recorder = createCommandLineRecorder();
+    const setActivationPolicy = vi.fn();
+    const hideDock = vi.fn();
+    const app = {
+      disableHardwareAcceleration: vi.fn(),
+      commandLine: recorder.commandLine,
+      name: '',
+      setActivationPolicy,
+      dock: {
+        hide: hideDock,
+      },
+    };
+
+    configureEarlyElectronApp({
+      app,
+      platform: 'darwin',
+      enableTestCompositor: false,
+      isHeadless: true,
+    });
+
+    expect(setActivationPolicy).toHaveBeenCalledWith('accessory');
+    expect(hideDock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not hide the Dock for macOS GUI mode', () => {
+    const recorder = createCommandLineRecorder();
+    const setActivationPolicy = vi.fn();
+    const hideDock = vi.fn();
+    const app = {
+      disableHardwareAcceleration: vi.fn(),
+      commandLine: recorder.commandLine,
+      name: '',
+      setActivationPolicy,
+      dock: {
+        hide: hideDock,
+      },
+    };
+
+    configureEarlyElectronApp({
+      app,
+      platform: 'darwin',
+      enableTestCompositor: false,
+      isHeadless: false,
+    });
+
+    expect(setActivationPolicy).not.toHaveBeenCalled();
+    expect(hideDock).not.toHaveBeenCalled();
   });
 
   it('runs ready bootstrap only after Electron readiness resolves', async () => {

--- a/packages/app/src/bootstrap/app-bootstrap.ts
+++ b/packages/app/src/bootstrap/app-bootstrap.ts
@@ -1,9 +1,10 @@
 import type { App } from 'electron';
 
 export interface EarlyElectronAppOptions {
-  app: Pick<App, 'disableHardwareAcceleration' | 'commandLine' | 'name'>;
+  app: Pick<App, 'disableHardwareAcceleration' | 'commandLine' | 'name'> & Partial<Pick<App, 'setActivationPolicy' | 'dock'>>;
   platform?: NodeJS.Platform;
   enableTestCompositor: boolean;
+  isHeadless: boolean;
 }
 
 export function configureEarlyElectronApp(options: EarlyElectronAppOptions): void {
@@ -28,6 +29,11 @@ export function configureEarlyElectronApp(options: EarlyElectronAppOptions): voi
   options.app.name = 'invoker';
   if (platform === 'linux') {
     options.app.commandLine.appendSwitch('class', 'invoker');
+  }
+
+  if (platform === 'darwin' && options.isHeadless) {
+    options.app.setActivationPolicy?.('accessory');
+    options.app.dock?.hide();
   }
 }
 

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -44,8 +44,11 @@ import {
 
 const enableTestCompositor = process.env.INVOKER_E2E_ENABLE_COMPOSITOR === '1' || Boolean(process.env.CAPTURE_MODE);
 const hideE2eWindow = process.env.NODE_ENV === 'test' && process.env.INVOKER_E2E_HIDE_WINDOW !== '0';
+const earlyHeadlessMode = process.argv.includes('--headless')
+  || process.argv.includes('--install-skills')
+  || process.argv.slice(2).includes('install-skills');
 
-configureEarlyElectronApp({ app, enableTestCompositor });
+configureEarlyElectronApp({ app, enableTestCompositor, isHeadless: earlyHeadlessMode });
 
 import { Orchestrator, CommandService, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type {


### PR DESCRIPTION
## Summary

Keep macOS headless Electron owner processes out of the Dock and app switcher by applying the accessory activation policy during early bootstrap.

Leave GUI mode unchanged and cover both headless and GUI macOS bootstrap behavior in tests.

## Test Plan

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/app-bootstrap.test.ts`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert fec89344f`
- Post-revert steps: Restart any running headless owners to restore previous macOS activation behavior.
- Data migration? No
