### PR TITLE
fix(workflow-core): unblock review-ready gate dependents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
             .node-version
 
       - name: Install test system packages
-        run: apt-get update && apt-get install -y unzip xvfb
+        run: apt-get update && apt-get install -y unzip xvfb jq make g++ python3
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -155,7 +155,11 @@ jobs:
         env:
           INVOKER_TEST_ALL_PROOF: '1'
           INVOKER_TEST_ALL_JOBS: '1'
-        run: bash scripts/run-all-tests.sh
+          TMPDIR: ${{ runner.temp }}/invoker-tmp
+        run: |
+          mkdir -p "$TMPDIR"
+          chmod 1777 "$TMPDIR"
+          bash scripts/run-all-tests.sh
 
   required-fast:
     needs: build-artifacts

--- a/packages/app/src/__tests__/headless-client.test.ts
+++ b/packages/app/src/__tests__/headless-client.test.ts
@@ -1,9 +1,25 @@
 import { describe, expect, it, vi } from 'vitest';
 import { LocalBus } from '@invoker/transport';
 
-import { SharedMutationOwnerTimeoutError, runHeadlessClientCommand } from '../headless-client.js';
+import { SharedMutationOwnerTimeoutError, electronCommandArgs, runHeadlessClientCommand } from '../headless-client.js';
 
 describe('headless-client', () => {
+  it('passes Linux headless stability flags before the app entry point', () => {
+    const args = electronCommandArgs(['query', 'workflows'], 'linux');
+    const mainIndex = args.findIndex((arg) => arg.endsWith('/main.js'));
+
+    expect(mainIndex).toBeGreaterThan(0);
+    expect(args.slice(0, mainIndex)).toEqual([
+      '--no-sandbox',
+      '--disable-dev-shm-usage',
+      '--disable-gpu',
+      '--disable-gpu-compositing',
+      '--disable-gpu-sandbox',
+      '--disable-software-rasterizer',
+    ]);
+    expect(args.slice(mainIndex + 1)).toEqual(['--headless', 'query', 'workflows']);
+  });
+
   it('delegates mutating commands to a standalone-capable owner endpoint', async () => {
     const bus = new LocalBus();
     const ownerHandler = vi.fn(async () => ({ ok: true }));

--- a/packages/app/src/headless-client.ts
+++ b/packages/app/src/headless-client.ts
@@ -35,10 +35,19 @@ function delegationClientLog(message: string): void {
   process.stderr.write(`[headless-client] ${message}\n`);
 }
 
-function electronCommandArgs(args: string[]): string[] {
+export function electronCommandArgs(args: string[], platform: NodeJS.Platform = process.platform): string[] {
   const mainJs = resolve(__dirname, 'main.js');
   return [
-    ...(process.platform === 'linux' ? ['--no-sandbox'] : []),
+    ...(platform === 'linux'
+      ? [
+          '--no-sandbox',
+          '--disable-dev-shm-usage',
+          '--disable-gpu',
+          '--disable-gpu-compositing',
+          '--disable-gpu-sandbox',
+          '--disable-software-rasterizer',
+        ]
+      : []),
     mainJs,
     '--headless',
     ...args,

--- a/packages/execution-engine/src/__tests__/auto-commit.test.ts
+++ b/packages/execution-engine/src/__tests__/auto-commit.test.ts
@@ -948,6 +948,8 @@ describe('merge gate commit topology (real git)', () => {
       getAllTasks: () => tasks,
       handleWorkerResponse: () => [],
       setTaskAwaitingApproval: () => {},
+      setTaskReviewReady: () => {},
+      autoStartExternallyUnblockedReadyTasks: () => [],
     };
     const persistence = {
       loadWorkflow: () => workflow,

--- a/packages/execution-engine/src/__tests__/create-merge-worktree.test.ts
+++ b/packages/execution-engine/src/__tests__/create-merge-worktree.test.ts
@@ -7,8 +7,8 @@
  *
  * Pattern: bare remote + working clone + TaskRunner with real git.
  */
-import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { execSync } from 'node:child_process';
@@ -46,7 +46,7 @@ describe('createMergeWorktree isolation (real git)', { timeout: 30_000 }, () => 
     if (root) rmSync(root, { recursive: true, force: true });
   });
 
-  function buildExecutor(cwd: string) {
+  function buildExecutor(cwd: string, logger?: any) {
     const registry = new ExecutorRegistry();
     return new TaskRunner({
       orchestrator: { getAllTasks: () => [] } as any,
@@ -54,7 +54,20 @@ describe('createMergeWorktree isolation (real git)', { timeout: 30_000 }, () => 
       executorRegistry: registry,
       cwd,
       defaultBranch: 'master',
+      logger,
     });
+  }
+
+  function createMockLogger() {
+    const logger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      child: vi.fn(),
+    };
+    logger.child.mockReturnValue(logger);
+    return logger;
   }
 
   it('clone origin points to real remote, not host cwd', async () => {
@@ -209,6 +222,49 @@ describe('createMergeWorktree isolation (real git)', { timeout: 30_000 }, () => 
     expect(cloneHeadSha).not.toBe(hostMasterSha);
 
     await executor.removeMergeWorktree(clonePath);
+  });
+
+  it('retries clone without local hardlinks when local clone crosses filesystems', async () => {
+    root = mkdtempSync(join(tmpdir(), 'merge-wt-exdev-'));
+    const cloneSource = join(root, 'source');
+    const clonePath = join(root, 'clone');
+    const logger = createMockLogger();
+    const executor = buildExecutor(root, logger);
+    const calls: string[][] = [];
+
+    (executor as any).execGitReadonly = vi.fn(async (args: string[]) => {
+      calls.push(args);
+      if (args.includes('--local')) {
+        mkdirSync(clonePath, { recursive: true });
+        throw new Error('fatal: failed to create link: Invalid cross-device link');
+      }
+      expect(existsSync(clonePath)).toBe(false);
+      mkdirSync(clonePath, { recursive: true });
+      return '';
+    });
+
+    await (executor as any).cloneMergeWorktree(cloneSource, clonePath);
+
+    expect(calls).toEqual([
+      ['clone', '--local', '--no-checkout', cloneSource, clonePath],
+      ['clone', '--no-local', '--no-checkout', cloneSource, clonePath],
+    ]);
+    expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('retrying without hardlinks'));
+  });
+
+  it('does not retry other local clone failures', async () => {
+    root = mkdtempSync(join(tmpdir(), 'merge-wt-clone-fail-'));
+    const cloneSource = join(root, 'source');
+    const clonePath = join(root, 'clone');
+    const executor = buildExecutor(root);
+    const err = new Error('fatal: authentication failed');
+
+    (executor as any).execGitReadonly = vi.fn(async () => {
+      throw err;
+    });
+
+    await expect((executor as any).cloneMergeWorktree(cloneSource, clonePath)).rejects.toThrow(err);
+    expect((executor as any).execGitReadonly).toHaveBeenCalledTimes(1);
   });
 
 });

--- a/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
+++ b/packages/execution-engine/src/__tests__/publish-after-fix.test.ts
@@ -91,6 +91,8 @@ function makeHost(hostDir: string, gateDir: string, allTasks: TaskState[]): Merg
       getAllTasks: () => allTasks,
       handleWorkerResponse: vi.fn(),
       setTaskAwaitingApproval: vi.fn(),
+      setTaskReviewReady: vi.fn(),
+      autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
     } as any,
     callbacks: {} as any,
     async execGitReadonly(args: string[]) {
@@ -170,8 +172,8 @@ describe('publishAfterFixImpl integration (real git)', () => {
     // Feature branch should contain Claude's fix file
     expect(existsSync(join(sandbox.hostDir, 'fix.txt'))).toBe(true);
 
-    // orchestrator.setTaskAwaitingApproval should have been called
-    expect(host.orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith('__merge__wf-int', expect.objectContaining({
+    // orchestrator.setTaskReviewReady should have been called
+    expect(host.orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-int', expect.objectContaining({
       execution: expect.objectContaining({ branch: 'plan/feature' }),
     }));
   });
@@ -212,7 +214,7 @@ describe('publishAfterFixImpl integration (real git)', () => {
     git('checkout plan/feature', sandbox.hostDir);
     expect(existsSync(join(sandbox.hostDir, 'fix.txt'))).toBe(true);
     expect(existsSync(join(sandbox.hostDir, 'late-change.txt'))).toBe(false);
-    expect(host.orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith(
+    expect(host.orchestrator.setTaskReviewReady).toHaveBeenCalledWith(
       '__merge__wf-int',
       expect.objectContaining({
         execution: expect.objectContaining({
@@ -362,8 +364,8 @@ describe('publishAfterFixImpl integration (real git)', () => {
     const isAncestor = gitSilent(`merge-base --is-ancestor ${headBeforePublish} ${featureSha}`, sandbox.hostDir);
     expect(isAncestor).toBe('');
 
-    // The merge gate must reach awaiting_approval state.
-    expect(host.orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith(
+    // The merge gate must reach review_ready state.
+    expect(host.orchestrator.setTaskReviewReady).toHaveBeenCalledWith(
       '__merge__wf-int',
       expect.objectContaining({
         execution: expect.objectContaining({ branch: 'plan/feature' }),

--- a/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner-fix-publish-and-ssh.test.ts
@@ -460,10 +460,12 @@ describe('TaskRunner', () => {
           mergeTask,
         ];
         const setTaskReviewReady = vi.fn();
+        const autoStartExternallyUnblockedReadyTasksMock = vi.fn(() => []);
         const orchestrator = {
           getTask: (id: string) => allTasks.find(t => t.id === id),
           getAllTasks: () => allTasks,
           setTaskReviewReady,
+          autoStartExternallyUnblockedReadyTasks: autoStartExternallyUnblockedReadyTasksMock,
           startExecution: vi.fn(() => []),
         };
         const updateAttempt = vi.fn();
@@ -520,6 +522,7 @@ describe('TaskRunner', () => {
             }),
           }),
         );
+        expect(autoStartExternallyUnblockedReadyTasksMock).toHaveBeenCalled();
       } finally {
         vi.useRealTimers();
       }
@@ -1610,6 +1613,8 @@ describe('TaskRunner', () => {
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
 
       const persistence = {
@@ -1994,6 +1999,8 @@ describe('TaskRunner', () => {
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
 
       const persistence = {
@@ -2114,8 +2121,8 @@ describe('TaskRunner', () => {
         }),
       );
 
-      // Task set to awaiting_approval with PR metadata
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
+      // Task set to review_ready with PR metadata
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
         execution: expect.objectContaining({
           branch: 'plan/feature',
           reviewUrl: 'https://github.com/owner/repo/pull/99',
@@ -2154,11 +2161,11 @@ describe('TaskRunner', () => {
       expect(persistence.updateTask).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
         execution: expect.objectContaining({ reviewUrl: 'https://github.com/owner/repo/pull/100' }),
       }));
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalled();
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
     });
 
-    it('no featureBranch: early exit with setTaskAwaitingApproval', async () => {
+    it('no featureBranch: early exit with setTaskReviewReady', async () => {
       const { executor, mergeTask, orchestrator, gitCalls } = setupPublishAfterFix({
         featureBranch: undefined,
         gateWorkspacePath: '/tmp/gate-clone',
@@ -2166,7 +2173,7 @@ describe('TaskRunner', () => {
 
       await executor.publishAfterFix(mergeTask);
 
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-pub', expect.objectContaining({
         config: expect.objectContaining({ runnerKind: 'worktree' }),
         execution: expect.objectContaining({ workspacePath: '/tmp/gate-clone' }),
       }));
@@ -2214,7 +2221,7 @@ describe('TaskRunner', () => {
           }),
         }),
       }));
-      expect(orchestrator.setTaskAwaitingApproval).not.toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).not.toHaveBeenCalled();
     });
 
     it('detach-HEAD sequence: exact order regression test', async () => {
@@ -3962,6 +3969,8 @@ describe('TaskRunner', () => {
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -4037,6 +4046,8 @@ describe('TaskRunner', () => {
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({

--- a/packages/execution-engine/src/__tests__/task-runner.test.ts
+++ b/packages/execution-engine/src/__tests__/task-runner.test.ts
@@ -2543,6 +2543,8 @@ describe('TaskRunner', () => {
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -2611,8 +2613,8 @@ describe('TaskRunner', () => {
       const deleteCall = gitCalls.find(c => c[0] === 'branch' && c[1] === '-D' && c[2] === 'plan/feature');
       expect(deleteCall).toBeDefined();
 
-      // Default mergeMode is 'manual', so setTaskAwaitingApproval is called with metadata
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
+      // Default mergeMode is 'manual', so setTaskReviewReady is called with metadata
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
         config: expect.objectContaining({ runnerKind: 'worktree' }),
         execution: expect.objectContaining({ branch: 'plan/feature', workspacePath: '/tmp/mock-wt' }),
       }));
@@ -2931,6 +2933,8 @@ describe('TaskRunner', () => {
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -2985,8 +2989,8 @@ describe('TaskRunner', () => {
       const squashCall = gitCalls.find(c => c[0] === 'merge' && c.includes('--squash'));
       expect(squashCall).toBeUndefined();
 
-      // Should call setTaskAwaitingApproval with metadata instead of handleWorkerResponse
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
+      // Should call setTaskReviewReady with metadata instead of handleWorkerResponse
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
         config: expect.objectContaining({ runnerKind: 'worktree' }),
         execution: expect.objectContaining({ branch: 'plan/feature', workspacePath: '/tmp/mock-wt' }),
       }));
@@ -3083,6 +3087,8 @@ describe('TaskRunner', () => {
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -3168,8 +3174,8 @@ describe('TaskRunner', () => {
         }),
       );
 
-      // Should set task awaiting approval with PR metadata (not handleWorkerResponse)
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
+      // Should set task review-ready with PR metadata (not handleWorkerResponse)
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
         config: expect.objectContaining({ runnerKind: 'worktree' }),
         execution: expect.objectContaining({
           branch: 'plan/feature',
@@ -3194,6 +3200,8 @@ describe('TaskRunner', () => {
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -3283,7 +3291,7 @@ describe('TaskRunner', () => {
           branch: 'plan/example',
         }),
       }));
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
         execution: expect.objectContaining({
           workspacePath: gateWorkspace,
           branch: 'plan/example',
@@ -3347,6 +3355,8 @@ console.log(JSON.stringify(out));
         getAllTasks: () => [...allTasks, mergeTask],
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -3409,12 +3419,14 @@ console.log(JSON.stringify(out));
       expect(providerBody).toContain('![after](https://img.example.test/after--merge-gate-no-inline-approve.png)');
     });
 
-    it('executeMergeNode goes to awaiting_approval when mergeMode=manual and onFinish=none', async () => {
+    it('executeMergeNode goes to review_ready when mergeMode=manual and onFinish=none', async () => {
       const orchestrator = {
         getTask: () => null,
         getAllTasks: () => [],
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -3445,7 +3457,7 @@ console.log(JSON.stringify(out));
       await (executor as any).executeMergeNode(mergeTask);
 
       // No featureBranch set → gateWorkspacePath is undefined
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
         config: expect.objectContaining({ runnerKind: 'worktree' }),
         execution: expect.objectContaining({ workspacePath: undefined }),
       }));
@@ -3458,6 +3470,8 @@ console.log(JSON.stringify(out));
         getAllTasks: () => [],
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -3502,6 +3516,8 @@ console.log(JSON.stringify(out));
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -3567,8 +3583,8 @@ console.log(JSON.stringify(out));
         }),
       );
 
-      // Should pass PR metadata through setTaskAwaitingApproval
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
+      // Should pass PR metadata through setTaskReviewReady
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
         config: expect.objectContaining({ runnerKind: 'worktree' }),
         execution: expect.objectContaining({
           branch: 'plan/feature',
@@ -3589,6 +3605,8 @@ console.log(JSON.stringify(out));
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -3654,6 +3672,8 @@ console.log(JSON.stringify(out));
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -3708,16 +3728,18 @@ console.log(JSON.stringify(out));
       await (executor as any).executeMergeNode(mergeTask);
 
       expect(mergeGateProvider.createReview).toHaveBeenCalled();
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalled();
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalled();
       expect(orchestrator.handleWorkerResponse).not.toHaveBeenCalled();
     });
 
-    it('executeMergeNode goes to awaiting_approval when mergeMode=manual and no featureBranch', async () => {
+    it('executeMergeNode goes to review_ready when mergeMode=manual and no featureBranch', async () => {
       const orchestrator = {
         getTask: () => null,
         getAllTasks: () => [],
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -3748,7 +3770,7 @@ console.log(JSON.stringify(out));
       await (executor as any).executeMergeNode(mergeTask);
 
       // No featureBranch set → gateWorkspacePath is undefined
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith('__merge__wf-1', expect.objectContaining({
         config: expect.objectContaining({ runnerKind: 'worktree' }),
         execution: expect.objectContaining({ workspacePath: undefined }),
       }));
@@ -3830,6 +3852,8 @@ console.log(JSON.stringify(out));
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -3899,6 +3923,8 @@ console.log(JSON.stringify(out));
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -4115,6 +4141,8 @@ console.log(JSON.stringify(out));
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -4179,7 +4207,7 @@ console.log(JSON.stringify(out));
       expect(mergeGateProvider.createReview).toHaveBeenCalledWith(
         expect.objectContaining({ body: '## Summary\n\nAuthored PR body from summary' }),
       );
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith(
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith(
         '__merge__wf-1',
         expect.objectContaining({
           config: expect.objectContaining({ summary: '## Summary\nTest summary' }),
@@ -4196,6 +4224,8 @@ console.log(JSON.stringify(out));
         getAllTasks: () => allTasks,
         handleWorkerResponse: vi.fn(() => []),
         setTaskAwaitingApproval: vi.fn(),
+        setTaskReviewReady: vi.fn(),
+        autoStartExternallyUnblockedReadyTasks: vi.fn(() => []),
       };
       const persistence = {
         loadWorkflow: () => ({
@@ -4237,7 +4267,7 @@ console.log(JSON.stringify(out));
 
       await (executor as any).executeMergeNode(mergeTask);
 
-      expect(orchestrator.setTaskAwaitingApproval).toHaveBeenCalledWith(
+      expect(orchestrator.setTaskReviewReady).toHaveBeenCalledWith(
         '__merge__wf-1',
         expect.objectContaining({
           config: expect.objectContaining({ summary: '## Summary\nManual summary' }),

--- a/packages/execution-engine/src/merge-runner.ts
+++ b/packages/execution-engine/src/merge-runner.ts
@@ -59,16 +59,11 @@ async function resolveBaseCheckoutRef(
  * Start any newly-ready downstream tasks (e.g., cross-workflow review_ready deps).
  */
 async function startReviewReadyDependents(host: MergeRunnerHost): Promise<void> {
-  const orchestrator = host.orchestrator as unknown as {
-    startExecution?: () => TaskState[];
-  };
-  if (typeof orchestrator.startExecution !== 'function') {
+  const newlyStarted = host.orchestrator.autoStartExternallyUnblockedReadyTasks();
+  if (newlyStarted.length === 0) {
     return;
   }
-  const newlyStarted = orchestrator.startExecution();
-  if (newlyStarted.length > 0) {
-    await host.executeTasks(newlyStarted);
-  }
+  await host.executeTasks(newlyStarted);
 }
 
 function setMergeGateReviewReady(
@@ -76,15 +71,7 @@ function setMergeGateReviewReady(
   taskId: string,
   changes: TaskStateChanges,
 ): void {
-  const orchestrator = host.orchestrator as unknown as {
-    setTaskReviewReady?: (id: string, c?: TaskStateChanges) => void;
-    setTaskAwaitingApproval?: (id: string, c?: TaskStateChanges) => void;
-  };
-  if (typeof orchestrator.setTaskReviewReady === 'function') {
-    orchestrator.setTaskReviewReady(taskId, changes);
-    return;
-  }
-  orchestrator.setTaskAwaitingApproval?.(taskId, changes);
+  host.orchestrator.setTaskReviewReady(taskId, changes);
 }
 
 function buildMergeConflictJson(errorText: string, failedBranch: string): string | undefined {

--- a/packages/execution-engine/src/task-runner.ts
+++ b/packages/execution-engine/src/task-runner.ts
@@ -1969,8 +1969,7 @@ export class TaskRunner {
       }
     }
 
-    // Clone with hard-linked objects — near-instant, fully isolated refs
-    await this.execGitReadonly(['clone', '--local', '--no-checkout', cloneSource, clonePath]);
+    await this.cloneMergeWorktree(cloneSource, clonePath);
     // Detach HEAD so the fetch can overwrite all branch refs (including the default branch)
     const headSha = (await this.execGitIn(['rev-parse', 'HEAD'], clonePath)).trim();
     await this.execGitIn(['update-ref', '--no-deref', 'HEAD', headSha], clonePath);
@@ -2088,6 +2087,26 @@ export class TaskRunner {
     }
     await this.execGitIn(['checkout', '--detach', refSha], clonePath);
     return clonePath;
+  }
+
+  /** @internal */ async cloneMergeWorktree(cloneSource: string, clonePath: string): Promise<void> {
+    try {
+      // Hard-linked objects make local pool clones near-instant while keeping refs isolated.
+      await this.execGitReadonly(['clone', '--local', '--no-checkout', cloneSource, clonePath]);
+    } catch (err) {
+      const message = err instanceof Error ? `${err.message}\n${err.stack ?? ''}` : String(err);
+      if (!message.includes('Invalid cross-device link') && !message.includes('EXDEV')) {
+        throw err;
+      }
+
+      // CI may place the repo/mirror and temp merge clone on different mounts,
+      // where Git's hardlink-based local clone fails with EXDEV.
+      this.logger.warn(
+        `[createMergeWorktree] Local clone crossed filesystems; retrying without hardlinks: ${message.split('\n')[0]}`,
+      );
+      rmSync(clonePath, { recursive: true, force: true });
+      await this.execGitReadonly(['clone', '--no-local', '--no-checkout', cloneSource, clonePath]);
+    }
   }
 
   /** @internal */ async removeMergeWorktree(dir: string): Promise<void> {

--- a/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator-gates-and-workflow-admin.test.ts
@@ -2120,6 +2120,42 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask(leafId)!.status).toBe('running');
     });
 
+    it('transitions an already-blocked review_ready dependent to runnable via the external gate pass', () => {
+      orchestrator.loadPlan({
+        name: 'gate-prereq-review-ready',
+        tasks: [{ id: 'verify', description: 'Prereq task' }],
+      });
+      const prereqTaskId = sid(orchestrator, 0, 'verify');
+      const prereqWfId = prereqTaskId.split('/')[0]!;
+      const prereqMergeId = `__merge__${prereqWfId}`;
+
+      orchestrator.loadPlan({
+        name: 'gate-downstream-blocked-review-ready',
+        externalDependencies: [
+          { workflowId: prereqWfId, taskId: '__merge__', requiredStatus: 'completed', gatePolicy: 'review_ready' },
+        ],
+        tasks: [{ id: 'leaf', description: 'leaf waits on upstream review-ready gate' }],
+      });
+      const leafId = sid(orchestrator, 1, 'leaf');
+
+      persistence.updateTask(prereqTaskId, { status: 'completed', execution: { completedAt: new Date() } });
+      persistence.updateTask(prereqMergeId, {
+        status: 'review_ready',
+        execution: { reviewUrl: 'https://example.invalid/pull/1', reviewStatus: 'Awaiting review' },
+      });
+      persistence.updateTask(leafId, {
+        status: 'blocked',
+        execution: { blockedBy: `waiting on ${prereqMergeId} (running)` },
+      });
+      orchestrator.syncAllFromDb();
+
+      const started = orchestrator.autoStartExternallyUnblockedReadyTasks();
+
+      expect(started.map((t) => t.id)).toContain(leafId);
+      expect(orchestrator.getTask(leafId)!.status).toBe('running');
+      expect(orchestrator.getTask(leafId)!.execution.blockedBy).toBeUndefined();
+    });
+
     it('does NOT cancel an already-running task on the same workflow', () => {
       orchestrator.loadPlan({
         name: 'gate-prereq-running',

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -4812,11 +4812,12 @@ export class Orchestrator {
    * same chart-mandated unblock-pass without cancelling any
    * in-flight work.
    *
-   * Was `private` before Step 15; exposed publicly so
-   * `applyInvalidation`'s `'scheduleOnly'` dep can invoke it
-   * type-safely. No other behavior changes.
+   * Also rehydrates already-blocked tasks whose external gate has
+   * since cleared; review-ready merge runners use this path after
+   * moving an upstream gate out of `running`.
    */
   autoStartExternallyUnblockedReadyTasks(): TaskState[] {
+    const started = this.autoStartUnblockedTasks();
     const readyTasks = this.stateMachine
       .getReadyTasks()
       .filter((task) => this.getExternalDependencyBlocker(task) === undefined);
@@ -4824,7 +4825,8 @@ export class Orchestrator {
     for (const task of readyTasks) {
       this.enqueueIfNotScheduled(task.id);
     }
-    return this.drainScheduler();
+    started.push(...this.drainScheduler());
+    return started;
   }
 
   private autoStartUnblockedTasks(): TaskState[] {
@@ -4837,6 +4839,7 @@ export class Orchestrator {
       this.writeAndSync(task.id, {
         status: 'pending',
         execution: {
+          blockedBy: undefined,
           startedAt: undefined,
           completedAt: undefined,
           lastHeartbeatAt: undefined,

--- a/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
+++ b/scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh
@@ -60,13 +60,16 @@ if [ -z "$MERGE_ID" ]; then
 fi
 echo "==> case 4.3: merge gate ID=$MERGE_ID"
 
-# headlessApprove exits before the merge gate finishes (it only awaits the
-# directly started tasks, not cascading merge nodes). The merge gate is left in
-# "running" state with its work interrupted. Resume the workflow so the merge
-# gate is detected as orphaned, restarted, and runs to completion.
+# headlessApprove may exit before the cascading merge node finishes. Resume only
+# when the gate still needs recovery; it may already be review_ready here.
 WF_ID="${MERGE_ID#__merge__}"
-echo "==> case 4.3: resume workflow $WF_ID to let merge gate run"
-invoker_e2e_run_headless resume "$WF_ID"
+STM=$(invoker_e2e_task_status "$MERGE_ID")
+if [ "$STM" != "awaiting_approval" ] && [ "$STM" != "review_ready" ]; then
+  echo "==> case 4.3: resume workflow $WF_ID to let merge gate run"
+  invoker_e2e_run_headless resume "$WF_ID"
+else
+  echo "==> case 4.3: merge gate already $STM; resume not needed"
+fi
 invoker_e2e_wait_settled "$MERGE_ID"
 
 STM=$(invoker_e2e_task_status "$MERGE_ID")

--- a/scripts/e2e-dry-run/lib/common.sh
+++ b/scripts/e2e-dry-run/lib/common.sh
@@ -292,7 +292,9 @@ invoker_e2e_run_headless() {
       return 0
     fi
     case "$status" in
-      124|137|143)
+      # 133 is SIGTRAP from transient headless Electron startup failures in
+      # constrained Linux CI containers.
+      124|133|137|143)
         if [ "$attempt" -lt "$max_attempts" ]; then
           echo "WARN: headless command interrupted (exit=$status), retrying once: $*" >&2
           attempt=$((attempt + 1))
@@ -323,7 +325,9 @@ invoker_e2e_submit_plan() {
       return 0
     fi
     case "$status" in
-      124|137|143)
+      # 133 is SIGTRAP from transient headless Electron startup failures in
+      # constrained Linux CI containers.
+      124|133|137|143)
         if [ "$attempt" -lt "$max_attempts" ]; then
           echo "WARN: submit-plan interrupted (exit=$status), retrying once: $plan_path $*" >&2
           attempt=$((attempt + 1))

--- a/scripts/repro/repro-review-ready-gate-does-not-unblock-blocked-downstream.sh
+++ b/scripts/repro/repro-review-ready-gate-does-not-unblock-blocked-downstream.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+TMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/invoker-review-ready-gate-repro.XXXXXX")"
+TEST_DIR="$ROOT_DIR/packages/data-store/.tmp/review-ready-gate-repro.$$"
+TEST_FILE="$TEST_DIR/review-ready-gate-repro.test.ts"
+DB_DIR="$TMP_ROOT/db"
+
+cleanup() {
+  local ec=$?
+  rm -rf "$TEST_DIR"
+  rm -rf "$TMP_ROOT"
+  return "$ec"
+}
+trap cleanup EXIT
+
+mkdir -p "$DB_DIR" "$TEST_DIR"
+
+cat > "$TEST_FILE" <<'TS'
+import { mkdtempSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { afterEach, describe, expect, it } from 'vitest';
+import { SQLiteAdapter } from '@invoker/data-store';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { OrchestratorMessageBus } from '@invoker/workflow-core';
+
+class NoopBus implements OrchestratorMessageBus {
+  publish(): void {}
+}
+
+type ReproCase = {
+  adapter: SQLiteAdapter;
+  orchestrator: Orchestrator;
+  upstreamMergeId: string;
+  downstreamTaskId: string;
+};
+
+const adapters: SQLiteAdapter[] = [];
+
+async function createReproCase(name: string): Promise<ReproCase> {
+  const dbDir = mkdtempSync(join(tmpdir(), `invoker-review-ready-${name}-`));
+  process.env.INVOKER_DB_DIR = dbDir;
+  const adapter = await SQLiteAdapter.create(join(dbDir, 'invoker.db'), { ownerCapability: true });
+  adapters.push(adapter);
+
+  const orchestrator = new Orchestrator({
+    persistence: adapter,
+    messageBus: new NoopBus(),
+    maxConcurrency: 10,
+  });
+
+  orchestrator.loadPlan({
+    name: `upstream-${name}`,
+    mergeMode: 'external_review',
+    tasks: [{ id: 'upstream-leaf', description: 'upstream leaf' }],
+  });
+  const upstreamWfId = orchestrator.getWorkflowIds()[0]!;
+  const upstreamLeafId = `${upstreamWfId}/upstream-leaf`;
+  const upstreamMergeId = `__merge__${upstreamWfId}`;
+
+  orchestrator.loadPlan({
+    name: `downstream-${name}`,
+    externalDependencies: [
+      {
+        workflowId: upstreamWfId,
+        taskId: '__merge__',
+        requiredStatus: 'completed',
+        gatePolicy: 'review_ready',
+      },
+    ],
+    tasks: [{ id: 'downstream-leaf', description: 'downstream should start on upstream review_ready' }],
+  });
+  const downstreamWfId = orchestrator.getWorkflowIds()[1]!;
+  const downstreamTaskId = `${downstreamWfId}/downstream-leaf`;
+
+  adapter.updateTask(upstreamLeafId, {
+    status: 'completed',
+    execution: { completedAt: new Date() },
+  });
+  adapter.updateTask(upstreamMergeId, {
+    status: 'running',
+    execution: { startedAt: new Date(), lastHeartbeatAt: new Date() },
+  });
+  adapter.updateTask(downstreamTaskId, {
+    status: 'blocked',
+    execution: { blockedBy: `waiting on ${upstreamMergeId} (running)` },
+  });
+  orchestrator.syncAllFromDb();
+
+  return { adapter, orchestrator, upstreamMergeId, downstreamTaskId };
+}
+
+afterEach(() => {
+  while (adapters.length > 0) {
+    adapters.pop()?.close();
+  }
+});
+
+describe('review_ready external gate blocked downstream repro', () => {
+  it('verifies the merge-runner-equivalent path unblocks already-blocked review_ready dependents', async () => {
+    const bug = await createReproCase('bug-path');
+
+    bug.orchestrator.setTaskReviewReady(bug.upstreamMergeId, {
+      execution: {
+        branch: 'feature/upstream',
+        reviewUrl: 'https://example.invalid/pull/1',
+        reviewId: '1',
+        reviewStatus: 'Awaiting review',
+      },
+    });
+    const bugStarted = bug.orchestrator.autoStartExternallyUnblockedReadyTasks();
+    const bugDownstream = bug.orchestrator.getTask(bug.downstreamTaskId)!;
+    const bugUpstream = bug.orchestrator.getTask(bug.upstreamMergeId)!;
+
+    console.log(JSON.stringify({
+      case: 'merge-runner-equivalent',
+      upstreamStatus: bugUpstream.status,
+      downstreamStatus: bugDownstream.status,
+      downstreamBlockedBy: bugDownstream.execution.blockedBy,
+      startedIds: bugStarted.map((task) => task.id),
+    }));
+
+    expect(bugUpstream.status).toBe('review_ready');
+    expect(bugDownstream.status).toBe('running');
+    expect(bugDownstream.execution.blockedBy).toBeUndefined();
+    expect(bugStarted.map((task) => task.id)).toContain(bug.downstreamTaskId);
+
+    const control = await createReproCase('control-path');
+    const controlStarted = control.orchestrator.handleWorkerResponse({
+      requestId: 'req-review-ready',
+      actionId: control.upstreamMergeId,
+      executionGeneration: control.orchestrator.getTask(control.upstreamMergeId)?.execution.generation ?? 0,
+      status: 'review_ready',
+      outputs: {
+        exitCode: 0,
+        summary: 'ready for review',
+        branch: 'feature/upstream',
+        reviewUrl: 'https://example.invalid/pull/1',
+        reviewId: '1',
+        reviewStatus: 'Awaiting review',
+      },
+    });
+    const controlDownstream = control.orchestrator.getTask(control.downstreamTaskId)!;
+    const controlUpstream = control.orchestrator.getTask(control.upstreamMergeId)!;
+
+    console.log(JSON.stringify({
+      case: 'handleWorkerResponse-control',
+      upstreamStatus: controlUpstream.status,
+      downstreamStatus: controlDownstream.status,
+      downstreamBlockedBy: controlDownstream.execution.blockedBy ?? null,
+      startedIds: controlStarted.map((task) => task.id),
+    }));
+
+    expect(controlUpstream.status).toBe('review_ready');
+    expect(controlStarted.map((task) => task.id)).toContain(control.downstreamTaskId);
+    expect(controlDownstream.status).toBe('running');
+  });
+});
+TS
+
+echo "temporary_root=$TMP_ROOT"
+echo "temporary_db_dir=$DB_DIR"
+echo "repro_test=$TEST_FILE"
+echo "command=INVOKER_DB_DIR=$DB_DIR pnpm --filter @invoker/data-store exec vitest run $TEST_FILE --reporter=dot"
+
+(
+  cd "$ROOT_DIR"
+  INVOKER_DB_DIR="$DB_DIR" pnpm --filter @invoker/data-store exec vitest run "$TEST_FILE" --reporter=dot
+)
+
+echo "PASS: verified setTaskReviewReady()+autoStartExternallyUnblockedReadyTasks starts an already-blocked review_ready dependent, matching handleWorkerResponse(review_ready)."


### PR DESCRIPTION
## Summary

Start downstream workflows when an upstream external review gate reaches `review_ready`, even if the downstream task had already been persisted as `blocked`.

The external gate scheduler now rehydrates blocked tasks whose gate has cleared, clears stale `blockedBy` text, and merge-runner review-ready transitions use that scheduler instead of plain `startExecution()`.

## Architecture

### Before

```mermaid
flowchart TD
  A[Merge runner marks upstream gate review_ready] --> B[startExecution]
  B --> C[Only pending ready tasks are drained]
  D[Downstream task persisted as blocked] --> E[Not considered runnable]
```

### After

```mermaid
flowchart TD
  A[Merge runner marks upstream gate review_ready] --> B[autoStartExternallyUnblockedReadyTasks]
  B --> C[Rehydrate blocked tasks whose external gate cleared]
  C --> D[Clear blockedBy and move to pending]
  D --> E[Drain scheduler and execute downstream task]
```

## Test Plan

- [x] `pnpm install --frozen-lockfile --ignore-scripts`
- [x] `pnpm --filter @invoker/workflow-core test -- src/__tests__/orchestrator-gates-and-workflow-admin.test.ts -t "already-blocked review_ready"`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/task-runner-fix-publish-and-ssh.test.ts -t "executeMergeNode heartbeat lease"`
- [x] `bash scripts/repro/repro-review-ready-gate-does-not-unblock-blocked-downstream.sh`
- [x] `pnpm run check:types`
- [x] `pnpm --filter /app exec vitest run src/__tests__/headless-client.test.ts`
- [x] `pnpm --filter /contracts exec vitest run src/__tests__/repo-root.test.ts`
- [x] `bash -n scripts/e2e-dry-run/lib/common.sh`
- [x] `bash scripts/e2e-dry-run/cases/case-4.3-fix-then-pr.sh`
- [x] `pnpm --filter /execution-engine test`
- [x] `pnpm test`
- [x] `pnpm --filter @invoker/execution-engine exec vitest run src/__tests__/create-merge-worktree.test.ts`
- [x] `bash scripts/test-suites/required/16-branch-carry-forward.sh`
- [x] `bash scripts/test-suites/required/15-submit-workflow-chain.sh`
- [x] `bash scripts/test-suites/required/10-vitest-workspace.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert d0b28c1a7`
- Post-revert steps: Restart any daemon/headless owners before retrying affected workflow gates.
- Data migration? No
