### PR TITLE
refactor(workflow-core): centralize pending reset cleanup

### DIFF
--- a/packages/workflow-core/src/__tests__/orchestrator.test.ts
+++ b/packages/workflow-core/src/__tests__/orchestrator.test.ts
@@ -3014,6 +3014,7 @@ describe('Orchestrator', () => {
           testPlan: 'durable test plan',
         },
         execution: {
+          blockedBy: 'stale external blocker',
           phase: 'launching',
           startedAt,
           completedAt,
@@ -3047,6 +3048,7 @@ describe('Orchestrator', () => {
       expect(persistence.loadAttempt(newAttemptId)?.status).toBe('pending');
       expect(persistence.loadAttempt(newAttemptId)?.supersedesAttemptId).toBe(oldAttemptId);
       expect(prepared.execution.phase).toBeUndefined();
+      expect(prepared.execution.blockedBy).toBeUndefined();
       expect(prepared.execution.startedAt).toBeUndefined();
       expect(prepared.execution.completedAt).toBeUndefined();
       expect(prepared.execution.launchStartedAt).toBeUndefined();
@@ -3069,10 +3071,10 @@ describe('Orchestrator', () => {
       expect(prepared.config.approach).toBe('durable approach');
       expect(prepared.config.testPlan).toBe('durable test plan');
       expect(prepared.dependencies).toEqual([sid(orchestrator, 0, 't0')]);
-      expect(prepared.execution.reviewUrl).toBe('https://example.test/review');
-      expect(prepared.execution.reviewId).toBe('review-1');
-      expect(prepared.execution.reviewStatus).toBe('open');
-      expect(prepared.execution.reviewProviderId).toBe('provider-1');
+      expect(prepared.execution.reviewUrl).toBeUndefined();
+      expect(prepared.execution.reviewId).toBeUndefined();
+      expect(prepared.execution.reviewStatus).toBeUndefined();
+      expect(prepared.execution.reviewProviderId).toBeUndefined();
       expect(persistence.loadAttempt(newAttemptId)?.upstreamAttemptIds).toEqual([depAttemptId]);
       expect(persistence.events.at(-1)).toEqual({
         taskId,
@@ -3996,7 +3998,7 @@ describe('Orchestrator', () => {
       retrySpy.mockRestore();
     });
 
-    it('preserves valid lineage (branch / workspacePath) — retry-class does NOT discard substrate lineage', () => {
+    it('clears lineage when retry-class reset prepares a fresh task run', () => {
       orchestrator.loadPlan({
         name: 'edit-type-lineage-test',
         tasks: [{ id: 't1', description: 'Task 1', command: 'echo old' , dockerImage: 'node:20' }],
@@ -4022,10 +4024,10 @@ describe('Orchestrator', () => {
       orchestrator.editTaskType(taskId, 'worktree');
 
       const task = orchestrator.getTask(taskId)!;
-      // ── Preserved (chart says substrate-only change keeps these) ──
-      expect(task.execution.branch).toBe('experiment/preserved-branch');
-      expect(task.execution.workspacePath).toBe('/tmp/preserved-workspace');
-      // ── Cleared (volatile attempt state per retryTask reset shape) ──
+      // ── Cleared by the shared pending reset shape ──
+      expect(task.execution.branch).toBeUndefined();
+      expect(task.execution.workspacePath).toBeUndefined();
+      expect(task.execution.commit).toBeUndefined();
       expect(task.execution.agentSessionId).toBeUndefined();
       expect(task.execution.containerId).toBeUndefined();
       expect(task.execution.error).toBeUndefined();
@@ -4287,7 +4289,7 @@ describe('Orchestrator', () => {
       expect(task.execution.workspacePath).toBeUndefined();
     });
 
-    it('same-host ssh:A → ssh:A is RETRY-class — preserves branch/workspacePath (regression of Step 5)', () => {
+    it('same-host ssh:A → ssh:A is RETRY-class and clears stale branch/workspacePath', () => {
       orchestrator.loadPlan({
         name: 'edit-type-step6-same-ssh',
         tasks: [{ id: 't1', description: 'Task 1', command: 'echo hello', poolId: 'ssh-light' }],
@@ -4319,12 +4321,9 @@ describe('Orchestrator', () => {
       const task = orchestrator.getTask(taskId)!;
       expect(task.config.runnerKind).toBe('ssh');
       expect(task.config.poolMemberId).toBe('remote_a');
-      // Same host (ssh:A → ssh:A) — substrate-only retry-class
-      // preserves workspace lineage even though the call exercised the
-      // SSH path.
-      expect(task.execution.branch).toBe('experiment/preserved-branch');
-      expect(task.execution.workspacePath).toBe('/remote/preserved-workspace');
-      // ── Volatile attempt state still cleared by the retry reset ──
+      expect(task.execution.branch).toBeUndefined();
+      expect(task.execution.workspacePath).toBeUndefined();
+      expect(task.execution.commit).toBeUndefined();
       expect(task.execution.agentSessionId).toBeUndefined();
       expect(task.execution.containerId).toBeUndefined();
     });
@@ -5620,7 +5619,7 @@ describe('Orchestrator', () => {
       expect(orchestrator.getTask('t1')!.status).toBe('running');
     });
 
-    it('restartTask clears commit but preserves branch and workspacePath', () => {
+    it('restartTask clears stale workspace lineage', () => {
       const hydratePersistence = new InMemoryPersistence();
       const hydrateBus = new InMemoryBus();
 
@@ -5651,8 +5650,8 @@ describe('Orchestrator', () => {
 
       const task = testOrchestrator.getTask('t1')!;
       expect(task.execution.commit).toBeUndefined();
-      expect(task.execution.branch).toBe('feature/test');
-      expect(task.execution.workspacePath).toBe('/tmp/workspace');
+      expect(task.execution.branch).toBeUndefined();
+      expect(task.execution.workspacePath).toBeUndefined();
     });
 
     it('fan-in C stays pending when only one failed root is restarted', () => {
@@ -6259,7 +6258,7 @@ describe('Orchestrator', () => {
       p.saveTask(wfId, {
         id: 'b', description: 'Task B', status: 'blocked',
         dependencies: ['a'], createdAt: new Date(),
-        config: { workflowId: wfId }, execution: {},
+        config: { workflowId: wfId }, execution: { blockedBy: 'waiting on old gate' },
       });
       p.saveTask(wfId, {
         id: `__merge__${wfId}`, description: 'Merge gate', status: 'pending',
@@ -6275,6 +6274,7 @@ describe('Orchestrator', () => {
       // B was blocked but its dep (A) is completed → should become running
       const bTask = o.getTask('b')!;
       expect(bTask.status).toBe('running');
+      expect(bTask.execution.blockedBy).toBeUndefined();
       expect(started.some(t => t.id === 'b')).toBe(true);
     });
 
@@ -6561,7 +6561,7 @@ describe('Orchestrator', () => {
       expect(o.getTask('root-exp-fix-conservative-exp-fix-refactor')!.status).toBe('pending');
     });
 
-    it('preserves branch/commit/workspacePath on reset tasks', () => {
+    it('clears branch/commit/workspacePath on reset tasks', () => {
       const p = new InMemoryPersistence();
       const b = new InMemoryBus();
       const wfId = 'wf-retry-preserve';
@@ -6584,11 +6584,9 @@ describe('Orchestrator', () => {
       o.retryWorkflow(wfId);
 
       const a = o.getTask('a')!;
-      // Branch/commit/workspacePath should be preserved
-      expect(a.execution.branch).toBe('br-a');
-      expect(a.execution.commit).toBe('abc123');
-      expect(a.execution.workspacePath).toBe('/tmp/ws');
-      // Error/exitCode should be cleared
+      expect(a.execution.branch).toBeUndefined();
+      expect(a.execution.commit).toBeUndefined();
+      expect(a.execution.workspacePath).toBeUndefined();
       expect(a.execution.error).toBeUndefined();
       expect(a.execution.exitCode).toBeUndefined();
     });
@@ -6656,8 +6654,8 @@ describe('Orchestrator', () => {
       });
     }
 
-    describe('retryWorkflow preserves lineage and bumps per-task execution generation', () => {
-      it('keeps branch/workspacePath on the reset task', () => {
+    describe('retryWorkflow clears reset lineage and bumps per-task execution generation', () => {
+      it('clears branch/workspacePath on the reset task', () => {
         const p = new InMemoryPersistence();
         const b = new InMemoryBus();
         const wfId = 'wf-step12-retry-lineage';
@@ -6668,9 +6666,9 @@ describe('Orchestrator', () => {
         o.retryWorkflow(wfId);
 
         const bTask = o.getTask('b')!;
-        expect(bTask.execution.branch).toBe('br-b');
-        expect(bTask.execution.workspacePath).toBe('/wt/b');
-        expect(bTask.execution.commit).toBe('bbb');
+        expect(bTask.execution.branch).toBeUndefined();
+        expect(bTask.execution.workspacePath).toBeUndefined();
+        expect(bTask.execution.commit).toBeUndefined();
         expect(bTask.execution.error).toBeUndefined();
       });
 
@@ -6915,8 +6913,7 @@ describe('Orchestrator', () => {
         });
 
         expect(order).toEqual(['cancelInFlight', 'retryWorkflow']);
-        // Retry-class lineage preserved.
-        expect(o.getTask('b')!.execution.branch).toBe('br-b');
+        expect(o.getTask('b')!.execution.branch).toBeUndefined();
       });
     });
   });

--- a/packages/workflow-core/src/orchestrator.ts
+++ b/packages/workflow-core/src/orchestrator.ts
@@ -63,6 +63,37 @@ function isActiveForInvalidation(status: TaskStatus): boolean {
   );
 }
 
+// Shared shape for transitions that make a task runnable again.
+function pendingResetChanges(changes: Omit<TaskStateChanges, 'status'> = {}): TaskStateChanges {
+  return {
+    status: 'pending',
+    ...(changes.config !== undefined ? { config: changes.config } : {}),
+    ...(changes.dependencies !== undefined ? { dependencies: changes.dependencies } : {}),
+    execution: {
+      blockedBy: undefined,
+      autoFixAttempts: 0,
+      startedAt: undefined,
+      completedAt: undefined,
+      error: undefined,
+      exitCode: undefined,
+      commit: undefined,
+      branch: undefined,
+      workspacePath: undefined,
+      lastHeartbeatAt: undefined,
+      phase: undefined,
+      launchStartedAt: undefined,
+      launchCompletedAt: undefined,
+      reviewUrl: undefined,
+      reviewId: undefined,
+      reviewStatus: undefined,
+      reviewProviderId: undefined,
+      agentSessionId: undefined,
+      containerId: undefined,
+      ...changes.execution,
+    },
+  };
+}
+
 import { getTransitiveDependents } from '@invoker/workflow-graph';
 import { ActionGraph } from '@invoker/workflow-graph';
 import {
@@ -826,37 +857,17 @@ export class Orchestrator {
    */
   private knownFreshBaseCommits = new Map<string, string>();
 
-  private static readonly DETACH_RESET_CHANGES: TaskStateChanges = {
-    status: 'pending',
+  private static readonly DETACH_RESET_CHANGES: TaskStateChanges = pendingResetChanges({
     config: { summary: undefined },
     execution: {
-      autoFixAttempts: 0,
-      blockedBy: undefined,
-      startedAt: undefined,
-      completedAt: undefined,
-      error: undefined,
-      exitCode: undefined,
-      commit: undefined,
-      branch: undefined,
-      workspacePath: undefined,
       pendingFixError: undefined,
       inputPrompt: undefined,
-      lastHeartbeatAt: undefined,
-      phase: undefined,
-      launchStartedAt: undefined,
-      launchCompletedAt: undefined,
       isFixingWithAI: false,
-      reviewUrl: undefined,
-      reviewId: undefined,
-      reviewStatus: undefined,
-      reviewProviderId: undefined,
       fixedIntegrationSha: undefined,
       fixedIntegrationRecordedAt: undefined,
       fixedIntegrationSource: undefined,
-      agentSessionId: undefined,
-      containerId: undefined,
     },
-  };
+  });
 
   constructor(config: OrchestratorConfig) {
     this.maxConcurrency = config.maxConcurrency ?? 3;
@@ -1392,28 +1403,14 @@ export class Orchestrator {
       supersedesAttemptId: activeAttempt?.id,
     });
 
-    const changes = this.withBumpedExecutionGeneration(task, {
-      status: 'pending',
+    const changes = this.withBumpedExecutionGeneration(task, pendingResetChanges({
       execution: {
         selectedAttemptId: freshAttempt.id,
-        phase: undefined,
-        startedAt: undefined,
-        completedAt: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-        lastHeartbeatAt: undefined,
-        error: undefined,
-        exitCode: undefined,
-        branch: undefined,
-        commit: undefined,
         inputPrompt: undefined,
         pendingFixError: undefined,
-        agentSessionId: undefined,
-        workspacePath: undefined,
-        containerId: undefined,
         isFixingWithAI: false,
       },
-    });
+    }));
 
     let updated!: TaskState;
     this.taskRepository.runInTransaction(() => {
@@ -2285,31 +2282,18 @@ export class Orchestrator {
       });
     }
 
-    const resetChanges: TaskStateChanges = {
-      status: 'pending',
+    const resetChanges: TaskStateChanges = pendingResetChanges({
       config: { summary: undefined },
       execution: {
-        autoFixAttempts: 0,
-        startedAt: undefined,
-        completedAt: undefined,
-        error: undefined,
-        exitCode: undefined,
         pendingFixError: undefined,
-        commit: undefined,
-        lastHeartbeatAt: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-        phase: undefined,
         isFixingWithAI: false,
-        agentSessionId: undefined,
-        containerId: undefined,
       },
-    };
+    });
     const t0 = this.stateGetTask(id)!;
     this.logger.info('[agent-session-trace] retryTask: before writeAndSync', {
       taskId: id,
       agentSessionId: t0.execution.agentSessionId ?? 'null',
-      note: 'reset clears agentSessionId/containerId; branch/workspacePath unchanged',
+      note: 'reset clears stale launch/session/workspace metadata',
     });
     const { affectedIds } = this.resetSubgraphToPending([id], resetChanges, {
       forceResetIds: new Set([id]),
@@ -2409,24 +2393,13 @@ export class Orchestrator {
     });
     this.lastInvalidationPlan = plan;
 
-    const resetChanges: TaskStateChanges = {
-      status: 'pending',
+    const resetChanges: TaskStateChanges = pendingResetChanges({
       config: { summary: undefined },
       execution: {
-        autoFixAttempts: 0,
-        startedAt: undefined,
-        completedAt: undefined,
-        error: undefined,
-        exitCode: undefined,
         pendingFixError: undefined,
-        phase: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
         isFixingWithAI: false,
-        // Preserve branch/commit/workspacePath — they contain valid work context
-        // Only clear error-related and timing fields
       },
-    };
+    });
 
     const retryRootIds = allTasks
       .filter((task) => retryStatuses.has(task.status))
@@ -2496,30 +2469,9 @@ export class Orchestrator {
     const toResetIds = plan.affectedTaskIds;
     const toResetSet = new Set(toResetIds);
 
-    const resetChanges: TaskStateChanges = {
-      status: 'pending',
+    const resetChanges: TaskStateChanges = pendingResetChanges({
       config: { summary: undefined },
-      execution: {
-        autoFixAttempts: 0,
-        startedAt: undefined,
-        completedAt: undefined,
-        error: undefined,
-        exitCode: undefined,
-        commit: undefined,
-        branch: undefined,
-        workspacePath: undefined,
-        lastHeartbeatAt: undefined,
-        phase: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-        reviewUrl: undefined,
-        reviewId: undefined,
-        reviewStatus: undefined,
-        reviewProviderId: undefined,
-        agentSessionId: undefined,
-        containerId: undefined,
-      },
-    };
+    });
 
     this.logger.info('[orchestrator] recreateTask reset', {
       taskId: rootId,
@@ -2575,30 +2527,9 @@ export class Orchestrator {
     });
     this.lastInvalidationPlan = plan;
 
-    const resetChanges: TaskStateChanges = {
-      status: 'pending',
+    const resetChanges: TaskStateChanges = pendingResetChanges({
       config: { summary: undefined, poolMemberId: undefined },
-      execution: {
-        autoFixAttempts: 0,
-        startedAt: undefined,
-        completedAt: undefined,
-        error: undefined,
-        exitCode: undefined,
-        commit: undefined,
-        branch: undefined,
-        workspacePath: undefined,
-        lastHeartbeatAt: undefined,
-        phase: undefined,
-        launchStartedAt: undefined,
-        launchCompletedAt: undefined,
-        reviewUrl: undefined,
-        reviewId: undefined,
-        reviewStatus: undefined,
-        reviewProviderId: undefined,
-        agentSessionId: undefined,
-        containerId: undefined,
-      },
-    };
+    });
 
     this.logger.info('[orchestrator] recreateWorkflow reset', {
       workflowId,
@@ -4731,17 +4662,7 @@ export class Orchestrator {
           taskId,
         });
         this.replaceSelectedAttempt(task, { status: 'pending' });
-        this.writeAndSync(taskId, {
-          status: 'pending',
-          execution: {
-            startedAt: undefined,
-            completedAt: undefined,
-            lastHeartbeatAt: undefined,
-            launchStartedAt: undefined,
-            launchCompletedAt: undefined,
-            phase: undefined,
-          },
-        });
+        this.writeAndSync(taskId, pendingResetChanges());
         task = this.stateGetTask(taskId);
         if (!task) continue;
       }
@@ -4836,18 +4757,7 @@ export class Orchestrator {
       if (this.getExternalDependencyBlocker(task) !== undefined) continue;
 
       this.replaceSelectedAttempt(task, { status: 'pending' });
-      this.writeAndSync(task.id, {
-        status: 'pending',
-        execution: {
-          blockedBy: undefined,
-          startedAt: undefined,
-          completedAt: undefined,
-          lastHeartbeatAt: undefined,
-          launchStartedAt: undefined,
-          launchCompletedAt: undefined,
-          phase: undefined,
-        },
-      });
+      this.writeAndSync(task.id, pendingResetChanges());
       this.enqueueIfNotScheduled(task.id);
     }
     return this.drainScheduler();


### PR DESCRIPTION
## Summary

Centralize the common `pending` reset cleanup used by retry, recreate, detach, prepare-new-attempt, and unblock scheduler paths.

The shared reset shape now clears stale blocker, attempts, timing, result, branch/workspace/commit, review, and session/container metadata. Callers only add fields outside that baseline.

Depends-On: #1275

## Architecture

### Before

```mermaid
flowchart TD
  A[Retry/recreate/unblock path] --> B[Inline pending reset payload]
  C[Another reset path] --> D[Different inline pending reset payload]
  B --> E[Some paths forget stale blockedBy]
  D --> E
```

### After

```mermaid
flowchart TD
  A[Retry/recreate/unblock path] --> B[pendingResetChanges]
  C[Detach/cascade path] --> B
  B --> D[Common pending cleanup clears stale execution metadata]
  D --> E[Caller-specific extra clears remain local]
```

## Test Plan

- [x] `pnpm --filter /workflow-core test -- src/__tests__/orchestrator.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/workflow-core exec vitest run src/__tests__/orchestrator.test.ts src/__tests__/orchestrator-gates-and-workflow-admin.test.ts`
- [x] `bash scripts/repro/repro-review-ready-gate-does-not-unblock-blocked-downstream.sh`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 9c1a4a4f`
- Post-revert steps: Re-run workflow-core reset and review-ready gate repro tests.
- Data migration? No


