### PR TITLE
docs: add first agent workflow tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Current version: `0.0.4`. Version history lives in [CHANGELOG.md](CHANGELOG.md).
 | Control actions racing each other | A single serialized control plane mediates every mutation |
 | Multi-agent work becomes hard to supervise | Stacked workflow graphs show parallel runs, dependencies, PRs, and replay paths in one UI |
 
-**What it is (one paragraph):** Invoker is a persisted workflow engine—not just a task list. It runs ready nodes under a concurrency cap, tracks explicit lifecycle states, preserves AI session audit trails, and treats **code changes** (branches, merges, conflicts, pull requests) as part of the execution model. Desktop UI, **headless** CLI, and Slack are surfaces on the same engine. Details: [docs/architecture-overview.md](docs/architecture-overview.md), longer narrative: [docs/invoker-medium-article.md](docs/invoker-medium-article.md).
+**What it is (one paragraph):** Invoker is a persisted workflow engine—not just a task list. It runs ready nodes under a concurrency cap, tracks explicit lifecycle states, preserves AI session audit trails, and treats **code changes** (branches, merges, conflicts, pull requests) as part of the execution model. Desktop UI, **headless** CLI, and Slack are surfaces on the same engine. Package boundaries and runtime invariants live in [ARCHITECTURE.md](ARCHITECTURE.md), and the longer product story lives in [docs/invoker-medium-article.md](docs/invoker-medium-article.md).
 
 ## Prerequisites
 
@@ -43,7 +43,7 @@ For packaged installs, the repo includes npm launchers, direct GitHub Release do
 
 ### Standalone CLI
 
-The standalone CLI does not require Node after installation. It can run plans directly, or delegate to a running Invoker desktop owner when one is available.
+The downloaded standalone CLI binary does not require Node after installation. It can run plans directly, or delegate to a running Invoker desktop owner when one is available. The npm package is a launcher that installs and runs that bundled binary as `invoker-cli`.
 
 Install with npm:
 
@@ -112,11 +112,21 @@ Tagged releases are configured to publish:
 - desktop `.dmg`, `.zip`, `.deb`, and `.AppImage`
 - `SHA256SUMS` covering release assets
 
-Packaged installs bundle the first-party Invoker skills inside the app. On first GUI launch, Invoker prompts you to install those skills into the supported global skill directories for Codex, Claude, and Cursor using `invoker-`-prefixed names so they do not overwrite existing skills. For headless/package-only usage, install the same bundled skills explicitly with:
+Packaged installs bundle the first-party Invoker skills inside the app. On first GUI launch, Invoker prompts you to install those skills into the supported global skill directories for Codex, Claude, and Cursor using `invoker-`-prefixed names so they do not overwrite existing skills. Npm launcher users can install the same bundled skills explicitly with:
 
 ```bash
-invoker --install-skills
+invoker-ui --install-skills
 ```
+
+Source checkouts can install the repo skills with `bash scripts/setup-agent-skills.sh`.
+
+## First tutorial
+
+If you are new to Invoker, start with the guided first workflow:
+
+[docs/tutorial-first-agent-workflow.md](docs/tutorial-first-agent-workflow.md)
+
+The tutorial creates a tiny local git repo, generates both Codex and Claude plan files, then walks through the desktop UI: `Open`, `Start`, task graph inspection, terminal/log access, retry behavior, and how to adapt the same plan shape to your own project.
 
 ## Configuration
 
@@ -185,26 +195,15 @@ Use this when you want Invoker to spread work across machines you already manage
 
 ## Quick start
 
-Start here if you want to get Invoker running locally with the smallest possible setup.
+For a guided first run, use [the first agent workflow tutorial](docs/tutorial-first-agent-workflow.md). It gives you a toy repo and exact UI checkpoints.
 
-If you need to turn a product or implementation plan into an Invoker workflow, use the `invoker-plan-to-invoker` skill. Repo installs can install bundled prefixed skill copies with `bash scripts/setup-agent-skills.sh`. Packaged installs can install the bundled `invoker-plan-to-invoker` copy from the first-run System Setup prompt or with `invoker --install-skills`. The canonical skill source lives at [skills/plan-to-invoker/SKILL.md](skills/plan-to-invoker/SKILL.md), and its deterministic validation entrypoint is `bash skills/plan-to-invoker/scripts/skill-doctor.sh <plan-file>`.
-
-1. Install the prerequisites above.
-2. Clone the repo and run the installation commands.
-3. Start Invoker with `./run.sh`. It will bootstrap missing workspace dependencies and build what it needs before launching.
-4. Choose one surface:
-   - Desktop UI: `./run.sh`
-   - Headless CLI: `./run.sh --headless ...`
-   - App development with hot reload: `pnpm run dev:hot`
-5. Point Invoker at a plan and at the machines you already control. Invoker orchestrates work across configured executors; it does not create or provision those machines for you.
-
-**Desktop app:**
+For day-to-day use, start the desktop app:
 
 ```bash
 ./run.sh
 ```
 
-**Headless**:
+Or run a plan through the headless surface:
 
 ```bash
 ./run.sh --headless --help
@@ -212,32 +211,13 @@ If you need to turn a product or implementation plan into an Invoker workflow, u
 ./run.sh --headless run /path/to/plan.yaml
 ```
 
-Mutating headless CLI commands use a standalone headless owner process. They do not delegate execution into the desktop GUI process, even if the GUI app is already running. Read-only shared queries such as `query queue` and `query ui-perf` may still talk to an existing owner.
-
-GUI-launched workflows still inherit the GUI app environment. On macOS, apps launched from Finder often have a narrower `PATH` than your terminal. If you start workflows from the desktop app, make sure tools like `pnpm`, `git`, and any configured agent CLIs are available to the GUI launch context.
-
-**Hot-reload app development**:
+For app development with hot reload:
 
 ```bash
 pnpm run dev:hot
 ```
 
-Use `--output text|label|json|jsonl` on `query` commands. Only **one** process should **write** the workflow database at a time; see [docs/persistence-architecture-single-writer.md](docs/persistence-architecture-single-writer.md).
-
-**Cost queries:**
-
-```bash
-# Grouped cost rollup (JSON shape: { scope, groupBy, totals, groups, metadata })
-./run.sh --headless query cost --output json
-./run.sh --headless query cost --workflow wf-1 --group-by task,agent --output json
-
-# Raw normalized cost events
-./run.sh --headless query cost-events --output json
-./run.sh --headless query cost-events --output jsonl
-
-# Pipe JSONL events through jq for scripted analysis
-./run.sh --headless query cost-events --output jsonl | jq 'select(.confidence == "exact")'
-```
+GUI-launched workflows inherit the GUI app environment. On macOS, apps launched from Finder often have a narrower `PATH` than your terminal. If workflows need `pnpm`, `git`, `codex`, or `claude`, start Invoker from a terminal or make those tools available to GUI-launched apps.
 
 **Example plan:**
 
@@ -249,7 +229,7 @@ description: |
 repoUrl: git@github.com:your-org/your-repo.git
 baseBranch: main
 onFinish: pull_request
-mergeMode: github
+mergeMode: external_review
 tasks:
   - id: plan
     description: Ask an AI agent to produce a scoped implementation plan
@@ -278,6 +258,10 @@ tasks:
     poolId: staging-a
     dependencies: [api, ui]
 ```
+
+If you need to turn a product or implementation plan into an Invoker workflow, use the `invoker-plan-to-invoker` skill. Source checkouts can install prefixed skill copies with `bash scripts/setup-agent-skills.sh`. Packaged installs can install the bundled `invoker-plan-to-invoker` copy from the first-run System Setup prompt or, for npm launcher installs, with `invoker-ui --install-skills`.
+
+Use `--output text|label|json|jsonl` on headless `query` commands. Only **one** process should **write** the workflow database at a time; see [docs/persistence-architecture-single-writer.md](docs/persistence-architecture-single-writer.md).
 
 ## Architecture (at a glance)
 
@@ -324,7 +308,8 @@ Layer rules: [ARCHITECTURE.md](ARCHITECTURE.md). Agent/repo conventions: [CLAUDE
 
 | Doc | Use |
 | --- | --- |
-| [docs/architecture-overview.md](docs/architecture-overview.md) | Runtime layers, scheduler, comparisons |
+| [docs/tutorial-first-agent-workflow.md](docs/tutorial-first-agent-workflow.md) | Guided first run on a toy project using Codex or Claude |
+| [ARCHITECTURE.md](ARCHITECTURE.md) | Package layering, mutation boundaries, error contracts |
 | [docs/invoker-medium-article.md](docs/invoker-medium-article.md) | Product story, glossary, mapping tables |
 | [docs/persistence-architecture-single-writer.md](docs/persistence-architecture-single-writer.md) | SQLite / sql.js single writer |
 | [docs/invoker-config-example.json](docs/invoker-config-example.json) | Example `config.json` with local and remote executor settings |
@@ -336,7 +321,7 @@ Layer rules: [ARCHITECTURE.md](ARCHITECTURE.md). Agent/repo conventions: [CLAUDE
 - **DB conflicts** — Do not run two writers on the same DB; headless CLI mutations use a standalone owner, while GUI-started workflows stay owned by the desktop app process.
 - **`pnpm` or `git` not found from the desktop app** — On macOS this is often a Finder/GUI `PATH` issue. Launch Invoker from a terminal with `./run.sh`, or make the required binaries available to GUI-launched apps.
 - **Missing bundled agent skills** — `bash scripts/setup-agent-skills.sh`
-- **Install failures** — Use Node 22 as per `engines`
+- **Install failures** — Use Node 26 as per `engines`
 - **Obsidian (README / Mermaid)** — In **Source** mode the diagram stays plain text. Open **Reading view** (book icon in the header, or the *Toggle reading view* command). **Live Preview** usually renders Mermaid as well; if you see an empty box or a parse error, update Obsidian, try the default theme, and disable CSS snippets (some themes hide Mermaid).
 
 ## Contributing

--- a/docs/tutorial-first-agent-workflow.md
+++ b/docs/tutorial-first-agent-workflow.md
@@ -1,0 +1,165 @@
+# First Agent Workflow Tutorial
+
+This guide walks through a small Invoker workflow on a toy Node.js project. It is meant to answer the first onboarding question: "what do I click, what runs, and how would I adapt this to my own repo?"
+
+The workflow uses an agent task to fix a failing test, then a command task to verify the fix.
+
+## What you will run
+
+The tutorial creates a temporary git repo with this shape:
+
+```text
+package.json
+src/greeter.js
+test/greeter.test.js
+invoker-plans/
+  first-agent-workflow-codex.yaml
+  first-agent-workflow-claude.yaml
+```
+
+The starting implementation is intentionally wrong. The tests expect `Hello, Ada!`, but the implementation returns `Hello Ada`.
+
+## Before you start
+
+Install Invoker and build it from the repo root:
+
+```bash
+pnpm install
+bash scripts/setup-agent-skills.sh
+pnpm run build
+```
+
+Make sure at least one supported agent CLI is installed and authenticated:
+
+```bash
+codex --version
+# or
+claude --version
+```
+
+If you launch the desktop app from Finder on macOS, it may not inherit your terminal `PATH`. For this tutorial, start Invoker from the terminal so it can find `node`, `npm`, `git`, and your agent CLI.
+
+## Create the toy project
+
+From the Invoker repo root, run:
+
+```bash
+examples/first-agent-workflow/create-local-project.sh
+```
+
+The script prints the generated project path and two plan paths. By default, the project is created at:
+
+```text
+/tmp/invoker-first-agent-workflow
+```
+
+Confirm the initial test failure:
+
+```bash
+cd /tmp/invoker-first-agent-workflow
+npm test
+```
+
+You should see a failing `node --test` run. That failure is the work the agent will fix.
+
+## Open the plan
+
+Start the desktop app from the Invoker repo root:
+
+```bash
+./run.sh
+```
+
+In the left rail, click `Open`.
+
+Choose one generated plan:
+
+```text
+/tmp/invoker-first-agent-workflow/invoker-plans/first-agent-workflow-codex.yaml
+```
+
+or:
+
+```text
+/tmp/invoker-first-agent-workflow/invoker-plans/first-agent-workflow-claude.yaml
+```
+
+Checkpoint: the left rail should show the plan name, and a `Start` button should appear.
+
+## Start the workflow
+
+Click `Start`.
+
+Checkpoint: the `Home` view should show one workflow node. Select it to open the workflow task DAG.
+
+The DAG has two tasks:
+
+- `fix-greeter`: an agent prompt task that edits the toy project.
+- `verify`: a command task that runs `npm test` after `fix-greeter` completes.
+
+Select `fix-greeter` to see details in the inspector. Its status should move through running states while the selected agent works in an isolated Invoker worktree.
+
+After `fix-greeter` completes, `verify` should become runnable and then run `npm test`.
+
+Checkpoint: when the workflow is done, both tasks should be `COMPLETED`.
+
+## Inspect what happened
+
+Use these views while or after the workflow runs:
+
+- `Home`: workflow graph and selected workflow task DAG.
+- `Timeline`: ordered lifecycle events.
+- `History`: completed and previous task attempts.
+- `Queue`: runnable/running task queue.
+- `Action Graph`: lower-level action state for debugging.
+
+Click a task in the DAG to inspect status, timing, command or prompt text, workspace metadata, and errors.
+
+Double-click a task, or right-click it and choose `Open Terminal`, to open a terminal session for that task when a managed workspace is available.
+
+## If something fails
+
+If the agent task fails because the agent CLI is missing or unauthenticated, install or log in to the CLI, then retry the task or rerun the workflow.
+
+If `verify` fails, select the failed task and read the inspector error. You can right-click the workflow and choose `Retry Workflow`, or right-click an individual failed task and choose a task action such as retry or open terminal.
+
+If the desktop app cannot find `npm`, `node`, `git`, `codex`, or `claude`, quit it and restart with `./run.sh` from your terminal.
+
+## Use the same pattern on your own repo
+
+The generated YAML is intentionally small:
+
+```yaml
+name: First agent workflow (codex)
+repoUrl: /tmp/invoker-first-agent-workflow
+baseBranch: HEAD
+onFinish: none
+mergeMode: manual
+tasks:
+  - id: fix-greeter
+    description: Fix the greeter implementation so the Node test suite passes.
+    prompt: |
+      You are working in a small Node.js project.
+      Make the existing test suite pass.
+    executionAgent: codex
+    dependencies: []
+
+  - id: verify
+    description: Run the test suite after the agent fix.
+    command: npm test
+    dependencies: [fix-greeter]
+```
+
+To adapt it:
+
+- Change `repoUrl` to your repo URL or local repo path.
+- Change `baseBranch` to your target branch, such as `main`.
+- Replace the prompt with the concrete change you want.
+- Replace `npm test` with your real verification command.
+- Use `executionAgent: codex` or `executionAgent: claude`, depending on the agent you want.
+
+Keep `onFinish: none` while learning. Once you want Invoker to converge branches into review or merge flow, use a remote-backed repo and switch to `onFinish: pull_request` or `onFinish: merge` with an appropriate merge mode.
+
+## Why this exists
+
+Invoker has architecture and reference docs, but a first-time user needs a procedural path before they need the internals. This tutorial is that path: create a repo, open a plan, start a workflow, inspect the graph, and map the same workflow shape back to a real project.

--- a/examples/first-agent-workflow/README.md
+++ b/examples/first-agent-workflow/README.md
@@ -1,0 +1,16 @@
+# First Agent Workflow Example
+
+This example backs the first-run tutorial in [../../docs/tutorial-first-agent-workflow.md](../../docs/tutorial-first-agent-workflow.md).
+
+Run the generator from the Invoker repo root:
+
+```bash
+examples/first-agent-workflow/create-local-project.sh
+```
+
+It creates a temporary local git repo with a failing Node test and generates two Invoker plans:
+
+- `first-agent-workflow-codex.yaml`
+- `first-agent-workflow-claude.yaml`
+
+Open either generated plan in the desktop app and click `Start`.

--- a/examples/first-agent-workflow/create-local-project.sh
+++ b/examples/first-agent-workflow/create-local-project.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")" && pwd)"
+TEMPLATE_DIR="$ROOT/template"
+TARGET_DIR="${1:-${TMPDIR:-/tmp}/invoker-first-agent-workflow}"
+PLAN_DIR="$TARGET_DIR/invoker-plans"
+
+if [ -e "$TARGET_DIR" ] && [ -n "$(find "$TARGET_DIR" -mindepth 1 -maxdepth 1 2>/dev/null)" ]; then
+  echo "Target directory already exists and is not empty: $TARGET_DIR" >&2
+  echo "Choose an empty path, or remove the directory and rerun this script." >&2
+  exit 1
+fi
+
+mkdir -p "$TARGET_DIR"
+cp -R "$TEMPLATE_DIR"/. "$TARGET_DIR"/
+
+(
+  cd "$TARGET_DIR"
+  git init -q
+  git checkout -q -b main
+  git config user.name "Invoker Tutorial"
+  git config user.email "invoker-tutorial@example.com"
+  git add package.json src test
+  git commit -q -m "Initial failing greeter"
+)
+
+mkdir -p "$PLAN_DIR"
+REPO_URL="$(cd "$TARGET_DIR" && pwd)"
+REPO_URL_YAML="'$(printf "%s" "$REPO_URL" | sed "s/'/''/g")'"
+
+write_plan() {
+  local agent="$1"
+  local path="$PLAN_DIR/first-agent-workflow-${agent}.yaml"
+
+  cat > "$path" <<EOF
+name: First agent workflow (${agent})
+description: Fix a tiny Node greeter project, then verify it with node --test.
+repoUrl: $REPO_URL_YAML
+baseBranch: HEAD
+onFinish: none
+mergeMode: manual
+tasks:
+  - id: fix-greeter
+    description: Fix the greeter implementation so the Node test suite passes.
+    prompt: |
+      You are working in a small Node.js project.
+
+      Goal:
+      - Make the existing test suite pass.
+
+      Files:
+      - src/greeter.js
+      - test/greeter.test.js
+
+      Acceptance criteria:
+      - Do not change the tests unless they are clearly wrong.
+      - Keep the implementation small.
+      - Run npm test before finishing.
+    executionAgent: ${agent}
+    dependencies: []
+
+  - id: verify
+    description: Run the test suite after the agent fix.
+    command: npm test
+    dependencies: [fix-greeter]
+EOF
+}
+
+write_plan codex
+write_plan claude
+
+cat <<EOF
+Created tutorial project:
+  $TARGET_DIR
+
+Generated Invoker plans:
+  $PLAN_DIR/first-agent-workflow-codex.yaml
+  $PLAN_DIR/first-agent-workflow-claude.yaml
+
+The initial tests intentionally fail. Use one of the generated plan files in Invoker.
+EOF

--- a/examples/first-agent-workflow/template/package.json
+++ b/examples/first-agent-workflow/template/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "invoker-first-agent-workflow",
+  "version": "0.0.0",
+  "private": true,
+  "type": "commonjs",
+  "scripts": {
+    "test": "node --test"
+  }
+}

--- a/examples/first-agent-workflow/template/src/greeter.js
+++ b/examples/first-agent-workflow/template/src/greeter.js
@@ -1,0 +1,5 @@
+function greet(name = 'there') {
+  return `Hello ${name}`;
+}
+
+module.exports = { greet };

--- a/examples/first-agent-workflow/template/test/greeter.test.js
+++ b/examples/first-agent-workflow/template/test/greeter.test.js
@@ -1,0 +1,11 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { greet } = require('../src/greeter.js');
+
+test('greets a named person', () => {
+  assert.equal(greet('Ada'), 'Hello, Ada!');
+});
+
+test('greets a default person', () => {
+  assert.equal(greet(), 'Hello, there!');
+});


### PR DESCRIPTION
## Summary

Add a guided first agent workflow tutorial for new Invoker users.

The tutorial creates a tiny local git repo, generates Codex and Claude plan files, and walks through the desktop app flow.

Simplify and refresh the README front door so first-time users see current commands before deeper configuration and architecture material.

## Test Plan

- [x] `bash -n examples/first-agent-workflow/create-local-project.sh`
- [x] `examples/first-agent-workflow/create-local-project.sh "$tmpdir/project with spaces"`
- [x] `npm test` in the generated toy project, expected failure before agent fix
- [x] `node` YAML parse/shape check for generated Codex and Claude plans
- [x] `rg -n "architecture-overview|invoker --install-skills|Standalone CLI does not require Node|Node 22|mergeMode: github" README.md docs/tutorial-first-agent-workflow.md examples/first-agent-workflow`
- [x] `git diff --check`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 6ec3c177c`
- Post-revert steps: None
- Data migration? No
