### PR TITLE
Add Codex resume bypass flag

### DIFF
--- a/packages/app/e2e/fixtures/electron-app.ts
+++ b/packages/app/e2e/fixtures/electron-app.ts
@@ -79,8 +79,9 @@ if [[ "\${1:-}" == "resume" ]]; then
     echo "stdin is not a terminal" >&2
     exit 12
   fi
+  session_id="\${@: -1}"
   sleep 1
-  echo "TTY OK: codex resume \${2:-}"
+  echo "TTY OK: codex resume \${session_id:-}"
   exit 0
 fi
 if [[ "\${1:-}" == "exec" ]]; then

--- a/packages/app/e2e/visual-proof.spec.ts
+++ b/packages/app/e2e/visual-proof.spec.ts
@@ -1608,7 +1608,7 @@ test.describe('Visual proof capture', () => {
     const workspacePath = '/home/invoker/.invoker/worktrees/wf-ssh/experiment-ssh-resume';
     const sessionId = 'codex-session-ssh-123';
     const terminalSessionId = 'visual-proof-ssh-session';
-    const sshInnerCommand = `cd '${workspacePath}' && codex resume ${sessionId}`;
+    const sshInnerCommand = `cd '${workspacePath}' && codex resume --dangerously-bypass-approvals-and-sandbox ${sessionId}`;
     const sshArgs = ['-i', '/tmp/e2e_id_rsa', '-t', 'invoker@remote-do-1', sshInnerCommand];
     const terminalOutput = [
       '$ ssh -i /tmp/e2e_id_rsa -t invoker@remote-do-1\r\n',
@@ -1684,7 +1684,7 @@ test.describe('Visual proof capture', () => {
     await expect(page.getByTestId('terminal-tab-wf-test-1/ssh-resume')).toHaveAttribute('data-active', 'true');
     await expect(page.getByTestId('terminal-session-command')).toContainText('ssh');
     await expect(page.getByTestId('terminal-session-command')).toContainText(workspacePath);
-    await expect(page.getByTestId('terminal-session-command')).toContainText(`codex resume ${sessionId}`);
+    await expect(page.getByTestId('terminal-session-command')).toContainText(`codex resume --dangerously-bypass-approvals-and-sandbox ${sessionId}`);
     await expect(page.getByTestId('terminal-pane-wf-test-1/ssh-resume')).toBeVisible();
     const terminalPane = page.getByTestId('terminal-pane-wf-test-1/ssh-resume');
     await page.waitForFunction(() => {

--- a/packages/app/src/__tests__/embedded-terminal-manager.test.ts
+++ b/packages/app/src/__tests__/embedded-terminal-manager.test.ts
@@ -135,22 +135,27 @@ describe('EmbeddedTerminalManager', () => {
       spawn: vi.fn(() => spawned),
     };
     const mgr = new EmbeddedTerminalManager({ backend });
+    const codexResumeArgs = [
+      'resume',
+      '--dangerously-bypass-approvals-and-sandbox',
+      'session-1',
+    ];
 
     const first = mgr.openOrReuse({
       taskId: 'task-injected',
-      spec: { command: 'codex', args: ['resume', 'session-1'] },
+      spec: { command: 'codex', args: codexResumeArgs },
       cwd: '/tmp/wt',
     });
     const second = mgr.openOrReuse({
       taskId: 'task-injected',
-      spec: { command: 'codex', args: ['resume', 'session-1'] },
+      spec: { command: 'codex', args: codexResumeArgs },
       cwd: '/tmp/wt',
     });
 
     expect(second.sessionId).toBe(first.sessionId);
     expect(backend.spawn).toHaveBeenCalledTimes(1);
     expect(backend.spawn).toHaveBeenCalledWith(expect.objectContaining({
-      spec: { command: 'codex', args: ['resume', 'session-1'] },
+      spec: { command: 'codex', args: codexResumeArgs },
       cwd: '/tmp/wt',
       defaultShell: expect.any(String),
     }));
@@ -230,16 +235,24 @@ describe('EmbeddedTerminalManager', () => {
 
     const session = mgr.openOrReuse({
       taskId: 'task-1',
-      spec: { command: 'codex', args: ['resume', 'codex-session-1'], cwd: '/tmp/wt' },
+      spec: {
+        command: 'codex',
+        args: ['resume', '--dangerously-bypass-approvals-and-sandbox', 'codex-session-1'],
+        cwd: '/tmp/wt',
+      },
       cwd: '/tmp/wt',
     });
 
     expect(session.command).toBe('codex');
-    expect(session.args).toEqual(['resume', 'codex-session-1']);
+    expect(session.args).toEqual([
+      'resume',
+      '--dangerously-bypass-approvals-and-sandbox',
+      'codex-session-1',
+    ]);
     expect(session.cwd).toBe('/tmp/wt');
     expect(bashSpawnFn).toHaveBeenCalledWith(
       'codex',
-      ['resume', 'codex-session-1'],
+      ['resume', '--dangerously-bypass-approvals-and-sandbox', 'codex-session-1'],
       expect.objectContaining({ cwd: '/tmp/wt', stdio: ['pipe', 'pipe', 'pipe'] }),
     );
   });

--- a/packages/app/src/__tests__/open-terminal.test.ts
+++ b/packages/app/src/__tests__/open-terminal.test.ts
@@ -1065,6 +1065,7 @@ describe('getRestoredTerminalSpec dispatches codex vs claude session resume', ()
       const spec = wt.getRestoredTerminalSpec(meta);
       expect(spec.command).toBe('codex');
       expect(spec.args).toContain('resume');
+      expect(spec.args).toContain('--dangerously-bypass-approvals-and-sandbox');
       expect(spec.args).toContain('codex-sess-123');
       // Must NOT be claude
       expect(spec.command).not.toBe('claude');
@@ -1136,6 +1137,7 @@ describe('getRestoredTerminalSpec dispatches codex vs claude session resume', ()
       const innerCmd = spec.args![spec.args!.length - 1];
       expect(innerCmd).toContain('codex');
       expect(innerCmd).toContain('resume');
+      expect(innerCmd).toContain('--dangerously-bypass-approvals-and-sandbox');
       expect(innerCmd).toContain('codex-remote-sess');
       // Must NOT be claude --resume
       expect(innerCmd).not.toContain('claude --resume');
@@ -1183,6 +1185,7 @@ describe('getRestoredTerminalSpec dispatches codex vs claude session resume', ()
       expect(scriptArg).toContain('codex');
       expect(scriptArg).toContain('exec');
       expect(scriptArg).toContain('resume');
+      expect(scriptArg).toContain('--dangerously-bypass-approvals-and-sandbox');
       expect(scriptArg).toContain('codex-docker-sess');
       expect(scriptArg).not.toContain('claude --resume');
     });
@@ -1364,6 +1367,7 @@ describe('fix-with-agent → open-terminal produces correct agent resume command
     expect(resolved.spec.command).toBe('codex');
     expect(resolved.spec.args).toEqual([
       'resume',
+      '--dangerously-bypass-approvals-and-sandbox',
       '019e386c-87c7-71e1-80bb-eb649ae99b82',
     ]);
     expect(resolved.spec.command).not.toBe('claude');

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -591,11 +591,18 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
   // Compose runtime services from persistence-backed adapters.
   // Headless startup routes through composeHeadlessStartup so the
   // headless path has an explicit composition entry point.
+  const executionAgentRegistry = options?.executionAgentRegistry ?? registerBuiltinAgents();
   const runtimeServiceDeps = {
     workspaceProbe: new WorkspaceProbeAdapter(persistence),
     containerProbe: new ContainerProbeAdapter(persistence),
     sessionProbe: new SessionProbeAdapter(persistence),
-    terminalLauncher: new TerminalLauncherAdapter(),
+    terminalLauncher: new TerminalLauncherAdapter({
+      resumeCommandResolver: (agentName, sessionId) => {
+        const agent = executionAgentRegistry.getOrThrow(agentName);
+        const resume = agent.buildResumeArgs(sessionId);
+        return { command: resume.cmd, args: resume.args };
+      },
+    }),
   };
   runtimeServices = isHeadless
     ? composeHeadlessStartup(runtimeServiceDeps)
@@ -608,7 +615,7 @@ async function initServices(options?: InitServicesOptions): Promise<void> {
       worktreeBaseDir: path.resolve(invokerHomeRoot, 'worktrees'),
       cacheDir: path.resolve(invokerHomeRoot, 'repos'),
       maxWorktrees: effectiveMaxConcurrency,
-      agentRegistry: options?.executionAgentRegistry,
+      agentRegistry: executionAgentRegistry,
     }),
   );
   const taskRepository = new SqliteTaskRepository(persistence);

--- a/packages/execution-engine/src/__tests__/codex-execution-agent.test.ts
+++ b/packages/execution-engine/src/__tests__/codex-execution-agent.test.ts
@@ -34,7 +34,17 @@ describe('CodexExecutionAgent', () => {
     const agent = new CodexExecutionAgent({ command: 'codex-cli' });
     const resume = agent.buildResumeArgs('sess-123');
     expect(resume.cmd).toBe('codex-cli');
-    expect(resume.args).toEqual(['resume', 'sess-123']);
+    expect(resume.args).toEqual([
+      'resume',
+      '--dangerously-bypass-approvals-and-sandbox',
+      'sess-123',
+    ]);
+  });
+
+  it('buildResumeArgs preserves plain resume when bypass is disabled', () => {
+    const agent = new CodexExecutionAgent({ bypassApprovalsAndSandbox: false, fullAuto: true });
+    const resume = agent.buildResumeArgs('sess-plain');
+    expect(resume.args).toEqual(['resume', 'sess-plain']);
   });
 
   it('buildFixCommand uses sandbox/approval bypass by default', () => {

--- a/packages/execution-engine/src/agents/codex-execution-agent.ts
+++ b/packages/execution-engine/src/agents/codex-execution-agent.ts
@@ -50,7 +50,7 @@ export class CodexExecutionAgent implements ExecutionAgent {
   buildCommand(fullPrompt: string): AgentCommandSpec {
     const sessionId = randomUUID();
     const args = ['exec', '--json'];
-    if (this.bypassApprovalsAndSandbox) args.push('--dangerously-bypass-approvals-and-sandbox');
+    if (this.bypassApprovalsAndSandbox) args.push(...this.buildBypassArgs());
     else if (this.fullAuto) args.push('--full-auto');
     args.push(fullPrompt);
     return { cmd: this.command, args, sessionId, fullPrompt };
@@ -59,16 +59,22 @@ export class CodexExecutionAgent implements ExecutionAgent {
   buildResumeArgs(sessionId: string): { cmd: string; args: string[] } {
     return {
       cmd: this.command,
-      args: ['resume', sessionId],
+      args: ['resume', ...this.buildBypassArgs(), sessionId],
     };
   }
 
   buildFixCommand(prompt: string): AgentCommandSpec {
     const sessionId = randomUUID();
     const args = ['exec', '--json'];
-    if (this.bypassApprovalsAndSandbox) args.push('--dangerously-bypass-approvals-and-sandbox');
+    if (this.bypassApprovalsAndSandbox) args.push(...this.buildBypassArgs());
     else if (this.fullAuto) args.push('--full-auto');
     args.push(prompt);
     return { cmd: this.command, args, sessionId };
+  }
+
+  private buildBypassArgs(): string[] {
+    return this.bypassApprovalsAndSandbox
+      ? ['--dangerously-bypass-approvals-and-sandbox']
+      : [];
   }
 }

--- a/packages/runtime-adapters/src/__tests__/terminal-launcher.test.ts
+++ b/packages/runtime-adapters/src/__tests__/terminal-launcher.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AttachmentResult } from '@invoker/runtime-domain';
+import { TerminalLauncherAdapter } from '../terminal-launcher.js';
+import {
+  buildMacOSOsascriptArgs,
+  spawnDetachedTerminal,
+} from '../terminal-launch.js';
+
+vi.mock('../terminal-launch.js', () => ({
+  buildLinuxXTerminalBashScript: vi.fn(() => 'cd /tmp && codex resume'),
+  buildMacOSOsascriptArgs: vi.fn(() => ['-e', 'do script']),
+  spawnDetachedTerminal: vi.fn(async () => ({ opened: true })),
+}));
+
+describe('TerminalLauncherAdapter', () => {
+  beforeEach(() => {
+    vi.mocked(buildMacOSOsascriptArgs).mockClear();
+    vi.mocked(spawnDetachedTerminal).mockClear();
+  });
+
+  it('uses the injected resolver for agent resume commands', async () => {
+    const launcher = new TerminalLauncherAdapter({
+      platform: 'darwin',
+      resumeCommandResolver: (agentName, sessionId) => ({
+        command: agentName,
+        args: ['resume', '--dangerously-bypass-approvals-and-sandbox', sessionId],
+      }),
+    });
+
+    const result = await launcher.launchTerminal({
+      taskId: 'task-codex',
+      workspacePath: '/tmp/workspace',
+      agentName: 'codex',
+      sessionId: 'codex-session',
+    });
+
+    expect(result.result).toBe(AttachmentResult.Attached);
+    expect(buildMacOSOsascriptArgs).toHaveBeenCalledWith(
+      {
+        cwd: '/tmp/workspace',
+        command: 'codex',
+        args: ['resume', '--dangerously-bypass-approvals-and-sandbox', 'codex-session'],
+      },
+      '/tmp/workspace',
+    );
+  });
+
+  it('keeps the legacy fallback when no resolver is configured', async () => {
+    const launcher = new TerminalLauncherAdapter({ platform: 'darwin' });
+
+    await launcher.launchTerminal({
+      taskId: 'task-claude',
+      workspacePath: '/tmp/workspace',
+      agentName: 'claude',
+      sessionId: 'claude-session',
+    });
+
+    expect(buildMacOSOsascriptArgs).toHaveBeenCalledWith(
+      {
+        cwd: '/tmp/workspace',
+        command: 'claude',
+        args: ['--resume', 'claude-session'],
+      },
+      '/tmp/workspace',
+    );
+  });
+});

--- a/packages/runtime-adapters/src/terminal-launcher.ts
+++ b/packages/runtime-adapters/src/terminal-launcher.ts
@@ -14,11 +14,17 @@ import {
  * Terminal launcher adapter - launches external OS terminal for a task.
  * Platform-specific implementation (macOS Terminal.app / Linux x-terminal-emulator).
  */
+export type ResumeCommandResolver = (
+  agentName: string,
+  sessionId: string,
+) => { command: string; args: string[] };
+
 export class TerminalLauncherAdapter implements TerminalLauncher {
   constructor(
     private options: {
       platform?: NodeJS.Platform;
       onTerminalClose?: (taskId: string) => void;
+      resumeCommandResolver?: ResumeCommandResolver;
     } = {},
   ) {}
 
@@ -38,8 +44,12 @@ export class TerminalLauncherAdapter implements TerminalLauncher {
 
     // Build command spec for agent resume if session available
     if (sessionId && agentName) {
-      spec.command = agentName;
-      spec.args = ['--resume', sessionId];
+      const resume = this.options.resumeCommandResolver?.(agentName, sessionId) ?? {
+        command: agentName,
+        args: ['--resume', sessionId],
+      };
+      spec.command = resume.command;
+      spec.args = resume.args;
     }
 
     const onClose = () => {


### PR DESCRIPTION
## Summary

Codex interactive resume commands now include `--dangerously-bypass-approvals-and-sandbox`, matching automated Codex exec and fix runs.

Terminal launcher resume command construction can delegate to the execution agent registry, keeping the active app terminal path and runtime launcher path aligned.

## Test Plan

- [x] `pnpm --filter @invoker/runtime-adapters test`
- [x] `pnpm --filter @invoker/app test -- src/__tests__/open-terminal.test.ts src/__tests__/embedded-terminal-manager.test.ts`
- [x] `pnpm --filter @invoker/execution-engine test -- src/__tests__/codex-execution-agent.test.ts src/__tests__/agent-executor-matrix.test.ts`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 2d560b89f`
- Post-revert steps: None
- Data migration? No
