### PR TITLE
Fix PR status owner delegation route

### DIFF
--- a/packages/app/src/__tests__/gui-mutation-translation.test.ts
+++ b/packages/app/src/__tests__/gui-mutation-translation.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from 'node:fs';
+import * as path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const mainSource = readFileSync(path.resolve(__dirname, '..', 'main.ts'), 'utf8');
+
+function getTranslatorSource(): string {
+  const start = mainSource.indexOf('function translateGuiMutationToHeadless');
+  const end = mainSource.indexOf('  async function performSharedApproveTask', start);
+  expect(start).toBeGreaterThanOrEqual(0);
+  expect(end).toBeGreaterThan(start);
+  return mainSource.slice(start, end);
+}
+
+describe('GUI mutation translation', () => {
+  it.each([
+    'invoker:check-pr-statuses',
+    'invoker:check-pr-status',
+  ])('routes %s to the owner GUI mutation handler', (channel) => {
+    const translatorSource = getTranslatorSource();
+    expect(translatorSource).toMatch(
+      new RegExp(
+        `case '${channel}':\\s*return \\{ channel: 'headless\\.gui-mutation', request: payload \\};`,
+      ),
+    );
+  });
+});

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -2609,6 +2609,10 @@ function createEmbeddedTerminalBackendFromConfig(
         if (!mergeTask) return null;
         return { channel: 'headless.exec', request: { args: ['approve', mergeTask.id] } };
       }
+      case 'invoker:check-pr-statuses':
+        return { channel: 'headless.gui-mutation', request: payload };
+      case 'invoker:check-pr-status':
+        return { channel: 'headless.gui-mutation', request: payload };
       case 'invoker:resolve-conflict':
         return arg1 === undefined
           ? { channel: 'headless.exec', request: { args: ['resolve-conflict', String(arg0)] } }


### PR DESCRIPTION
## Summary

Follower GUI windows can invoke PR status refresh without hitting a missing delegation route.

The PR status channels now delegate to the owner through the existing GUI mutation path.

A focused regression test locks both PR status channels to that owner route.

## Architecture

### Before

```mermaid
graph TD
    A[Follower renderer] --> B[invoker:check-pr-statuses]
    B --> C[translateGuiMutationToHeadless]
    C --> D[null route]
    D --> E[No owner delegation route error]
```

### After

```mermaid
graph TD
    A[Follower renderer] --> B[invoker:check-pr-statuses]
    B --> C[translateGuiMutationToHeadless]
    C --> D[headless.gui-mutation]
    D --> E[Owner PR status handler]
```

## Test Plan

- [x] `pnpm --filter @invoker/app exec vitest run src/__tests__/gui-mutation-translation.test.ts`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app build`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 15d9ac98d`
- Post-revert steps: None
- Data migration? No
