### PR TITLE
fix(data-store): clearing a workflow's external dependencies was silently ignored

### DIFF
--- a/packages/data-store/src/__tests__/delete-workflow-dependent-cleanup.test.ts
+++ b/packages/data-store/src/__tests__/delete-workflow-dependent-cleanup.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Repro: deleting (or detaching from) an upstream workflow must clear the
+ * dependent's externalDependencies in the real SQLite store.
+ *
+ * `Orchestrator.detachWorkflowInternal` clears the last dependency by passing
+ * `externalDependencies: undefined` to `updateWorkflow`. The test-kit
+ * InMemoryPersistence honors that (presence semantics), but SQLiteAdapter
+ * skipped undefined fields, leaving a dangling dependency row. The dependent's
+ * external gate then evaluates to "missing prerequisite" forever and every
+ * task in it is pinned at pending — observed live after deleting an upstream
+ * workflow whose dependent had exactly one external dependency.
+ */
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Orchestrator } from '@invoker/workflow-core';
+import type { OrchestratorMessageBus } from '@invoker/workflow-core';
+import { SQLiteAdapter } from '../sqlite-adapter.js';
+
+class NoopBus implements OrchestratorMessageBus {
+  publish(): void {}
+  subscribe(): () => void {
+    return () => undefined;
+  }
+}
+
+describe('delete/detach upstream workflow clears dependent externalDependencies', () => {
+  let adapter: SQLiteAdapter | undefined;
+  let cleanupDir: string | undefined;
+
+  afterEach(() => {
+    adapter?.close();
+    adapter = undefined;
+    if (cleanupDir) {
+      rmSync(cleanupDir, { recursive: true, force: true });
+      cleanupDir = undefined;
+    }
+  });
+
+  async function setupStack(): Promise<{
+    orchestrator: Orchestrator;
+    upstreamWfId: string;
+    downstreamWfId: string;
+    downstreamRootId: string;
+  }> {
+    cleanupDir = mkdtempSync(join(tmpdir(), 'invoker-delete-dependent-cleanup-'));
+    adapter = await SQLiteAdapter.create(join(cleanupDir, 'invoker.db'), { ownerCapability: true });
+
+    const orchestrator = new Orchestrator({
+      persistence: adapter,
+      messageBus: new NoopBus(),
+      maxConcurrency: 8,
+    });
+
+    orchestrator.loadPlan({
+      name: 'upstream',
+      baseBranch: 'master',
+      featureBranch: 'feature/upstream',
+      tasks: [{ id: 'leaf', description: 'upstream leaf' }],
+    });
+    const upstreamWfId = orchestrator.getAllTasks()
+      .find((t) => !t.config.isMergeNode)!.config.workflowId!;
+
+    orchestrator.loadPlan({
+      name: 'downstream',
+      baseBranch: 'feature/upstream',
+      featureBranch: 'feature/downstream',
+      externalDependencies: [
+        { workflowId: upstreamWfId, taskId: '__merge__', requiredStatus: 'completed' },
+      ],
+      tasks: [{ id: 'root', description: 'downstream root' }],
+    });
+    const downstreamRootId = orchestrator.getAllTasks()
+      .find((t) => !t.config.isMergeNode && t.id.endsWith('/root'))!.id;
+    const downstreamWfId = downstreamRootId.split('/')[0]!;
+
+    expect(adapter.loadWorkflow(downstreamWfId)!.externalDependencies).toHaveLength(1);
+    return { orchestrator, upstreamWfId, downstreamWfId, downstreamRootId };
+  }
+
+  it('deleteWorkflow(upstream) clears the single dangling dependency and unblocks the dependent', async () => {
+    const { orchestrator, upstreamWfId, downstreamWfId, downstreamRootId } = await setupStack();
+
+    orchestrator.deleteWorkflow(upstreamWfId);
+
+    const survivor = adapter!.loadWorkflow(downstreamWfId)!;
+    expect(survivor.externalDependencies).toBeUndefined();
+    // The detach provenance must be recorded.
+    expect(survivor.externalDependencyChanges?.length ?? 0).toBeGreaterThan(0);
+
+    // With no dangling gate the dependent's root task must dispatch.
+    const started = orchestrator.startExecution();
+    expect(started.map((t) => t.id)).toContain(downstreamRootId);
+  });
+
+  it('detachWorkflow with a single dependency clears it and unblocks the dependent', async () => {
+    const { orchestrator, upstreamWfId, downstreamWfId, downstreamRootId } = await setupStack();
+
+    orchestrator.detachWorkflow(downstreamWfId, upstreamWfId);
+
+    expect(adapter!.loadWorkflow(downstreamWfId)!.externalDependencies).toBeUndefined();
+
+    const started = orchestrator.startExecution();
+    expect(started.map((t) => t.id)).toContain(downstreamRootId);
+  });
+});

--- a/packages/data-store/src/__tests__/sqlite-adapter.test.ts
+++ b/packages/data-store/src/__tests__/sqlite-adapter.test.ts
@@ -1259,6 +1259,60 @@ describe('SQLiteAdapter', () => {
       const loaded = adapter.loadWorkflow('wf-1');
       expect(loaded!.updatedAt >= before).toBe(true);
     });
+
+    it('clears externalDependencies when the key is present with undefined', () => {
+      adapter.saveWorkflow({
+        ...testWorkflow,
+        externalDependencies: [
+          { workflowId: 'wf-upstream', taskId: '__merge__', requiredStatus: 'completed' },
+        ],
+      });
+
+      adapter.updateWorkflow('wf-1', { externalDependencies: undefined });
+
+      expect(adapter.loadWorkflow('wf-1')!.externalDependencies).toBeUndefined();
+    });
+
+    it('leaves externalDependencies untouched when the key is absent', () => {
+      const deps = [
+        { workflowId: 'wf-upstream', taskId: '__merge__', requiredStatus: 'completed' as const },
+      ];
+      adapter.saveWorkflow({ ...testWorkflow, externalDependencies: deps });
+
+      adapter.updateWorkflow('wf-1', { generation: 2 });
+
+      expect(adapter.loadWorkflow('wf-1')!.externalDependencies).toEqual(deps);
+    });
+
+    it('clears externalDependencyChanges when the key is present with undefined', () => {
+      adapter.saveWorkflow({
+        ...testWorkflow,
+        externalDependencyChanges: [
+          {
+            before: { workflowId: 'wf-upstream', taskId: '__merge__', requiredStatus: 'completed' },
+            changedAt: '2026-06-11T00:00:00.000Z',
+          },
+        ],
+      });
+
+      adapter.updateWorkflow('wf-1', { externalDependencyChanges: undefined });
+
+      expect(adapter.loadWorkflow('wf-1')!.externalDependencyChanges).toBeUndefined();
+    });
+
+    it('leaves externalDependencyChanges untouched when the key is absent', () => {
+      const changes = [
+        {
+          before: { workflowId: 'wf-upstream', taskId: '__merge__', requiredStatus: 'completed' as const },
+          changedAt: '2026-06-11T00:00:00.000Z',
+        },
+      ];
+      adapter.saveWorkflow({ ...testWorkflow, externalDependencyChanges: changes });
+
+      adapter.updateWorkflow('wf-1', { generation: 2 });
+
+      expect(adapter.loadWorkflow('wf-1')!.externalDependencyChanges).toEqual(changes);
+    });
   });
 
   describe('logEvent + getEvents', () => {

--- a/packages/data-store/src/sqlite-adapter.ts
+++ b/packages/data-store/src/sqlite-adapter.ts
@@ -1328,11 +1328,16 @@ export class SQLiteAdapter implements PersistenceAdapter {
     if (changes.mergeMode !== undefined) {
       // handled by columnMap; kept for backward-compatible patch shapes
     }
-    if (changes.externalDependencies !== undefined) {
+    // Presence semantics (matching updateTask's config.externalDependencies):
+    // key present with undefined ⇒ clear the column; key absent ⇒ unchanged.
+    // detachWorkflowInternal clears a dependent's last dependency by passing
+    // `externalDependencies: undefined` — a skip-if-undefined check here left
+    // dangling dependencies behind after upstream workflow deletion.
+    if ('externalDependencies' in changes) {
       setClauses.push('external_dependencies = ?');
       values.push(changes.externalDependencies ? JSON.stringify(changes.externalDependencies) : null);
     }
-    if (changes.externalDependencyChanges !== undefined) {
+    if ('externalDependencyChanges' in changes) {
       setClauses.push('external_dependency_changes = ?');
       values.push(changes.externalDependencyChanges ? JSON.stringify(changes.externalDependencyChanges) : null);
     }

--- a/packages/workflow-core/src/task-repository.ts
+++ b/packages/workflow-core/src/task-repository.ts
@@ -46,7 +46,14 @@ export interface WorkflowChanges {
   generation?: number;
   mergeMode?: 'manual' | 'automatic' | 'external_review';
   reviewProvider?: string;
+  /**
+   * Presence semantics: a key explicitly set to `undefined` clears the
+   * stored value (NULL column); an absent key leaves it unchanged.
+   * `detachWorkflowInternal` relies on this to clear a dependent's last
+   * external dependency when the upstream workflow is detached or deleted.
+   */
   externalDependencies?: ExternalDependency[];
+  /** Same presence semantics as `externalDependencies`. */
   externalDependencyChanges?: ExternalDependencyChange[];
 }
 


### PR DESCRIPTION
## Summary

When a workflow is deleted, Invoker removes it from each dependent's "waiting on" list.

The database layer ignored that removal: "set the list to nothing" looked identical to "no change requested." So dependents waited forever on a deleted workflow (live example: WF-INV-143).

Fix: `updateWorkflow` now treats `externalDependencies: undefined` as "clear the list." Omitting the key still means "leave it unchanged." Same for `externalDependencyChanges`.

## Test Plan

- [x] `cd packages/data-store && pnpm exec vitest run src/__tests__/delete-workflow-dependent-cleanup.test.ts` (fails before the fix, passes after)
- [x] `cd packages/data-store && pnpm test`
- [x] `cd packages/workflow-core && pnpm test`
- [x] `cd packages/app && pnpm test`
- [x] `pnpm run check:types`

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert 85628580e`
- Post-revert steps: None — reverting restores the dangling-dependency bug; rows already cleared stay cleared (no schema change).
- Data migration? No. Past deletions are not auto-repaired; run `--headless detach-workflow <dependent> <deleted-upstream>` per affected workflow after deploying.
