### PR TITLE
feat: install invoker-cli via npm-ui and desktop app, release 0.0.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
             command: pnpm run check:large-files
           - name: TypeScript Types
             command: pnpm run check:types
+          - name: Release Version Sync
+            command: pnpm run check:versions
 
     name: quality / ${{ matrix.name }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check release version sync
+        run: pnpm run check:versions
+
       - name: Build standalone CLI
         env:
           INVOKER_TARGET_PLATFORM: ${{ matrix.platform }}
@@ -225,7 +228,11 @@ jobs:
               return
             fi
 
-            npm publish "./${package_dir}" --access public
+            # Pack with pnpm (rewrites workspace:* deps to the exact version),
+            # then publish the tarball with npm (which would not rewrite them).
+            local tarball
+            tarball="$(pnpm --filter "${name}" pack --pack-destination "${RUNNER_TEMP}" | tail -n 1)"
+            npm publish "${tarball}" --access public
           }
 
           publish_if_missing packages/npm-cli

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "invoker",
   "private": true,
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Auditable multi-agent orchestration with a mutating action graph",
   "scripts": {
     "postinstall": "node scripts/electron.cjs --install-only",
@@ -42,7 +42,9 @@
     "check:deps": "depcruise packages --config .dependency-cruiser.js",
     "check:types": "tsc -p tsconfig.typecheck.json",
     "check:large-files": "node scripts/check-large-files.mjs",
-    "check:all": "pnpm run check:deps && pnpm run check:types && pnpm run check:required-builds && pnpm run check:large-files && bash scripts/check-owner-boundary.sh",
+    "check:versions": "node scripts/check-version-sync.mjs",
+    "bump-version": "node scripts/bump-version.mjs",
+    "check:all": "pnpm run check:deps && pnpm run check:types && pnpm run check:required-builds && pnpm run check:large-files && pnpm run check:versions && bash scripts/check-owner-boundary.sh",
     "lint": "pnpm run check:all"
   },
   "pnpm": {

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -2,7 +2,7 @@
   "name": "@invoker/app",
   "productName": "Invoker",
   "desktopName": "invoker.desktop",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Invoker desktop app",
   "homepage": "https://github.com/Neko-Catpital-Labs/Invoker",
   "author": {

--- a/packages/app/src/__tests__/app-menu.test.ts
+++ b/packages/app/src/__tests__/app-menu.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildAppMenuTemplate } from '../app-menu.js';
+
+function findUpdateItem(template: ReturnType<typeof buildAppMenuTemplate>) {
+  const tools = template.find((item) => item.label === 'Tools');
+  const submenu = tools?.submenu;
+  if (!Array.isArray(submenu)) return undefined;
+  return submenu.find((item) => item.label === 'Update invoker-cli');
+}
+
+describe('buildAppMenuTemplate', () => {
+  it('includes a Tools → Update invoker-cli item that fires the callback', () => {
+    const onUpdateInvokerCli = vi.fn();
+    const template = buildAppMenuTemplate({ isMac: true, onUpdateInvokerCli });
+
+    const item = findUpdateItem(template);
+    expect(item).toBeDefined();
+    (item?.click as () => void)();
+    expect(onUpdateInvokerCli).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes the appMenu role only on macOS', () => {
+    const mac = buildAppMenuTemplate({ isMac: true, onUpdateInvokerCli: () => {} });
+    const linux = buildAppMenuTemplate({ isMac: false, onUpdateInvokerCli: () => {} });
+
+    expect(mac[0]?.role).toBe('appMenu');
+    expect(linux.some((item) => item.role === 'appMenu')).toBe(false);
+    expect(findUpdateItem(linux)).toBeDefined();
+  });
+});

--- a/packages/app/src/__tests__/cli-installer.test.ts
+++ b/packages/app/src/__tests__/cli-installer.test.ts
@@ -1,0 +1,170 @@
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  maybeAutoInstallCli,
+  resolveCliInstallerStatus,
+  updateInvokerCli,
+  type CliInstallerContext,
+} from '../cli-installer.js';
+
+const APP_VERSION = '0.0.3';
+
+function writeFakeCli(filePath: string, version: string): void {
+  writeFileSync(filePath, `#!/usr/bin/env bash\necho "${version}"\n`, 'utf8');
+  chmodSync(filePath, 0o755);
+}
+
+describe('cli-installer', () => {
+  let scratchDir: string;
+  let bundledCliPath: string;
+  let lockedDirs: string[];
+
+  function makeContext(overrides: Partial<CliInstallerContext> = {}): CliInstallerContext {
+    return {
+      isPackaged: true,
+      bundledCliPath,
+      appVersion: APP_VERSION,
+      platform: 'darwin',
+      env: { PATH: '/usr/bin:/bin' },
+      homeDir: path.join(scratchDir, 'home'),
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    scratchDir = mkdtempSync(path.join(tmpdir(), 'invoker-cli-installer-'));
+    bundledCliPath = path.join(scratchDir, 'bundled-invoker-cli');
+    writeFakeCli(bundledCliPath, APP_VERSION);
+    lockedDirs = [];
+  });
+
+  afterEach(() => {
+    for (const dir of lockedDirs) chmodSync(dir, 0o755);
+    rmSync(scratchDir, { recursive: true, force: true });
+  });
+
+  it('installs into the first writable candidate dir when not installed', () => {
+    const installDir = path.join(scratchDir, 'bin');
+    mkdirSync(installDir);
+    const context = makeContext({ candidateInstallDirs: [installDir] });
+
+    const result = updateInvokerCli(context);
+
+    expect(result.ok).toBe(true);
+    expect(result.updated).toBe(true);
+    const installedPath = path.join(installDir, 'invoker-cli');
+    expect(result.installedTo).toBe(installedPath);
+    expect(statSync(installedPath).mode & 0o777).toBe(0o755);
+    expect(result.status.installedVersion).toBe(APP_VERSION);
+    expect(result.status.upToDate).toBe(true);
+  });
+
+  it('overwrites an outdated install found on PATH, in place', () => {
+    const pathDir = path.join(scratchDir, 'on-path-bin');
+    mkdirSync(pathDir);
+    const existing = path.join(pathDir, 'invoker-cli');
+    writeFakeCli(existing, '0.0.1');
+    const context = makeContext({
+      env: { PATH: `${pathDir}:/usr/bin:/bin` },
+      candidateInstallDirs: [path.join(scratchDir, 'unused-bin')],
+    });
+
+    const result = updateInvokerCli(context);
+
+    expect(result.ok).toBe(true);
+    expect(result.updated).toBe(true);
+    expect(result.installedTo).toBe(existing);
+    expect(readFileSync(existing, 'utf8')).toContain(APP_VERSION);
+    expect(result.status.upToDate).toBe(true);
+  });
+
+  it('is a no-op when the installed version matches the app version', () => {
+    const pathDir = path.join(scratchDir, 'on-path-bin');
+    mkdirSync(pathDir);
+    const existing = path.join(pathDir, 'invoker-cli');
+    writeFakeCli(existing, APP_VERSION);
+    const before = readFileSync(existing, 'utf8');
+    const context = makeContext({ env: { PATH: `${pathDir}:/usr/bin:/bin` } });
+
+    const result = updateInvokerCli(context);
+
+    expect(result.ok).toBe(true);
+    expect(result.updated).toBe(false);
+    expect(readFileSync(existing, 'utf8')).toBe(before);
+  });
+
+  it('falls back to the next candidate when the first dir is unwritable', () => {
+    const locked = path.join(scratchDir, 'locked-bin');
+    const fallback = path.join(scratchDir, 'fallback-bin');
+    mkdirSync(locked);
+    chmodSync(locked, 0o555);
+    lockedDirs.push(locked);
+    const context = makeContext({ candidateInstallDirs: [locked, fallback] });
+
+    const result = updateInvokerCli(context);
+
+    expect(result.ok).toBe(true);
+    expect(result.installedTo).toBe(path.join(fallback, 'invoker-cli'));
+  });
+
+  it('warns when the install dir is not on PATH', () => {
+    const installDir = path.join(scratchDir, 'off-path-bin');
+    const context = makeContext({ candidateInstallDirs: [installDir] });
+
+    const result = updateInvokerCli(context);
+
+    expect(result.ok).toBe(true);
+    expect(result.status.warning).toContain(installDir);
+    expect(result.status.warning).toContain('PATH');
+  });
+
+  it('scopes detection and install to INVOKER_CLI_INSTALL_DIR when set', () => {
+    const pathDir = path.join(scratchDir, 'on-path-bin');
+    mkdirSync(pathDir);
+    writeFakeCli(path.join(pathDir, 'invoker-cli'), APP_VERSION);
+    const overrideDir = path.join(scratchDir, 'override-bin');
+    const context = makeContext({
+      env: { PATH: `${pathDir}:/usr/bin:/bin`, INVOKER_CLI_INSTALL_DIR: overrideDir },
+    });
+
+    const result = updateInvokerCli(context);
+
+    expect(result.ok).toBe(true);
+    expect(result.updated).toBe(true);
+    expect(result.installedTo).toBe(path.join(overrideDir, 'invoker-cli'));
+  });
+
+  it('resolves status in under 4s when the installed binary hangs (main-thread guard)', () => {
+    const pathDir = path.join(scratchDir, 'on-path-bin');
+    mkdirSync(pathDir);
+    const hanging = path.join(pathDir, 'invoker-cli');
+    writeFileSync(hanging, '#!/usr/bin/env bash\nsleep 60\nexit 0\n', 'utf8');
+    chmodSync(hanging, 0o755);
+    const context = makeContext({ env: { PATH: `${pathDir}:/usr/bin:/bin` } });
+
+    const startedAt = Date.now();
+    const status = resolveCliInstallerStatus(context);
+    const elapsedMs = Date.now() - startedAt;
+
+    expect(elapsedMs).toBeLessThan(4000);
+    expect(status.installedVersion).toBeUndefined();
+    expect(status.upToDate).toBe(false);
+  }, 6000);
+
+  it('does nothing in non-packaged (dev) runs', () => {
+    const context = makeContext({ isPackaged: false });
+
+    expect(maybeAutoInstallCli(context, () => {})).toBeNull();
+    expect(resolveCliInstallerStatus(context).supported).toBe(false);
+  });
+
+  it('reports unsupported when the bundled binary is missing', () => {
+    const context = makeContext({ bundledCliPath: path.join(scratchDir, 'missing') });
+
+    expect(resolveCliInstallerStatus(context).supported).toBe(false);
+    expect(maybeAutoInstallCli(context, () => {})).toBeNull();
+  });
+});

--- a/packages/app/src/app-menu.ts
+++ b/packages/app/src/app-menu.ts
@@ -1,0 +1,30 @@
+import type { MenuItemConstructorOptions } from 'electron';
+
+export interface AppMenuOptions {
+  isMac: boolean;
+  onUpdateInvokerCli: () => void;
+}
+
+/**
+ * Pure template builder (no Electron runtime imports) so it can be unit
+ * tested under plain Node. main.ts passes the result to
+ * `Menu.buildFromTemplate` / `Menu.setApplicationMenu`.
+ */
+export function buildAppMenuTemplate(options: AppMenuOptions): MenuItemConstructorOptions[] {
+  return [
+    ...(options.isMac ? [{ role: 'appMenu' } as MenuItemConstructorOptions] : []),
+    { role: 'fileMenu' },
+    { role: 'editMenu' },
+    { role: 'viewMenu' },
+    { role: 'windowMenu' },
+    {
+      label: 'Tools',
+      submenu: [
+        {
+          label: 'Update invoker-cli',
+          click: () => options.onUpdateInvokerCli(),
+        },
+      ],
+    },
+  ];
+}

--- a/packages/app/src/cli-installer.ts
+++ b/packages/app/src/cli-installer.ts
@@ -1,0 +1,246 @@
+import { spawnSync } from 'node:child_process';
+import {
+  accessSync,
+  chmodSync,
+  constants,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from 'node:fs';
+import { delimiter, dirname, join } from 'node:path';
+
+import type { CliInstallerStatus, CliInstallResult } from '@invoker/contracts';
+
+const CLI_BINARY_NAME = 'invoker-cli';
+
+export interface CliInstallerContext {
+  isPackaged: boolean;
+  /** Path to the version-matched binary bundled in the app resources. */
+  bundledCliPath: string;
+  appVersion: string;
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+  homeDir: string;
+  /** Test override for the default install-dir candidates. */
+  candidateInstallDirs?: string[];
+}
+
+function defaultCandidateInstallDirs(context: CliInstallerContext): string[] {
+  const override = context.env.INVOKER_CLI_INSTALL_DIR;
+  if (override) return [override];
+  if (context.candidateInstallDirs) return context.candidateInstallDirs;
+  return ['/usr/local/bin', join(context.homeDir, '.local', 'bin')];
+}
+
+function pathDirs(context: CliInstallerContext): string[] {
+  return (context.env.PATH ?? '').split(delimiter).filter(Boolean);
+}
+
+/**
+ * Dirs to scan for an existing install. GUI-launched macOS apps inherit the
+ * minimal launchd PATH (`/usr/bin:/bin:...`), so relying on PATH alone would
+ * miss installs in /usr/local/bin or ~/.local/bin — always include the
+ * well-known locations explicitly.
+ */
+function searchDirs(context: CliInstallerContext): string[] {
+  // An explicit install dir scopes both detection and installation to that
+  // one location (used by the hermetic e2e scripts).
+  const override = context.env.INVOKER_CLI_INSTALL_DIR;
+  if (override) return [override];
+  const dirs = [
+    ...defaultCandidateInstallDirs(context),
+    ...pathDirs(context),
+    '/usr/local/bin',
+    '/opt/homebrew/bin',
+    join(context.homeDir, '.local', 'bin'),
+  ];
+  return [...new Set(dirs)];
+}
+
+function isExecutableFile(path: string): boolean {
+  try {
+    if (!statSync(path).isFile()) return false;
+    accessSync(path, constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function probeVersion(binaryPath: string): string | undefined {
+  // CRITICAL: spawnSync blocks the Electron main thread. Mirror the
+  // detectTool() guard in system-diagnostics.ts — 3s timeout + SIGKILL so a
+  // wedged binary cannot stall the app.
+  const result = spawnSync(binaryPath, ['--version'], {
+    encoding: 'utf8',
+    timeout: 3000,
+    killSignal: 'SIGKILL',
+  });
+  if (result.error || result.signal === 'SIGKILL' || result.status !== 0) {
+    return undefined;
+  }
+  const version = (result.stdout ?? '').trim().split('\n')[0]?.trim();
+  return version || undefined;
+}
+
+export function findInstalledCli(
+  context: CliInstallerContext,
+): { path: string; version?: string } | null {
+  for (const dir of searchDirs(context)) {
+    const candidate = join(dir, CLI_BINARY_NAME);
+    if (isExecutableFile(candidate)) {
+      return { path: candidate, version: probeVersion(candidate) };
+    }
+  }
+  return null;
+}
+
+function isWritableDir(dir: string): boolean {
+  try {
+    if (!statSync(dir).isDirectory()) return false;
+    accessSync(dir, constants.W_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function selectInstallDir(
+  context: CliInstallerContext,
+): { dir: string; warning?: string } | null {
+  const candidates = defaultCandidateInstallDirs(context);
+  let chosen: string | undefined;
+  for (const dir of candidates) {
+    if (isWritableDir(dir)) {
+      chosen = dir;
+      break;
+    }
+  }
+  if (!chosen) {
+    // Fall back to creating the last candidate (the user-writable one). Never
+    // escalate privileges for the earlier system dirs.
+    const fallback = candidates[candidates.length - 1];
+    if (!fallback) return null;
+    try {
+      mkdirSync(fallback, { recursive: true });
+    } catch {
+      return null;
+    }
+    if (!isWritableDir(fallback)) return null;
+    chosen = fallback;
+  }
+  const warning = pathDirs(context).includes(chosen)
+    ? undefined
+    : `${chosen} is not on your PATH. Add it (e.g. export PATH="${chosen}:$PATH") to run ${CLI_BINARY_NAME} from a terminal.`;
+  return { dir: chosen, warning };
+}
+
+export function writeCliBinary(bundledPath: string, targetPath: string): void {
+  // Write-then-rename so an in-use binary is replaced atomically (ETXTBSY
+  // guard), and read/write instead of copyFileSync so APFS does not clone
+  // extended attributes (quarantine flags) from the app bundle.
+  const tmpPath = `${targetPath}.tmp-${process.pid}`;
+  try {
+    writeFileSync(tmpPath, readFileSync(bundledPath));
+    chmodSync(tmpPath, 0o755);
+    renameSync(tmpPath, targetPath);
+  } catch (err) {
+    rmSync(tmpPath, { force: true });
+    throw err;
+  }
+}
+
+function isSupported(context: CliInstallerContext): boolean {
+  return (
+    context.isPackaged &&
+    (context.platform === 'darwin' || context.platform === 'linux') &&
+    existsSync(context.bundledCliPath)
+  );
+}
+
+export function resolveCliInstallerStatus(
+  context: CliInstallerContext,
+  lastInstallError?: string,
+): CliInstallerStatus {
+  const supported = isSupported(context);
+  const installed = supported ? findInstalledCli(context) : null;
+  let warning: string | undefined;
+  if (installed) {
+    const installedDir = dirname(installed.path);
+    if (!pathDirs(context).includes(installedDir)) {
+      warning = `${installedDir} is not on your PATH. Add it (e.g. export PATH="${installedDir}:$PATH") to run ${CLI_BINARY_NAME} from a terminal.`;
+    }
+  } else if (supported) {
+    warning = selectInstallDir(context)?.warning;
+  }
+  return {
+    supported,
+    bundledVersion: context.appVersion,
+    installedVersion: installed?.version,
+    installedPath: installed?.path,
+    upToDate: installed?.version === context.appVersion,
+    warning,
+    lastInstallError,
+  };
+}
+
+export function updateInvokerCli(context: CliInstallerContext): CliInstallResult {
+  try {
+    if (!isSupported(context)) {
+      return {
+        ok: false,
+        updated: false,
+        error: 'invoker-cli install is only available in the packaged desktop app.',
+        status: resolveCliInstallerStatus(context),
+      };
+    }
+    const installed = findInstalledCli(context);
+    if (installed?.version === context.appVersion) {
+      return { ok: true, updated: false, installedTo: installed.path, status: resolveCliInstallerStatus(context) };
+    }
+    // Prefer updating an existing install in place — its dir is already on
+    // the user's effective PATH.
+    let targetPath: string;
+    if (installed) {
+      targetPath = installed.path;
+    } else {
+      const selection = selectInstallDir(context);
+      if (!selection) {
+        const error = 'No writable install directory found for invoker-cli.';
+        return { ok: false, updated: false, error, status: resolveCliInstallerStatus(context, error) };
+      }
+      targetPath = join(selection.dir, CLI_BINARY_NAME);
+    }
+    writeCliBinary(context.bundledCliPath, targetPath);
+    return { ok: true, updated: true, installedTo: targetPath, status: resolveCliInstallerStatus(context) };
+  } catch (err) {
+    const error = err instanceof Error ? err.message : String(err);
+    return { ok: false, updated: false, error, status: resolveCliInstallerStatus(context, error) };
+  }
+}
+
+/**
+ * Launch hook: silently install/update invoker-cli so packaged-app users get
+ * the command on PATH without a manual step. No-op in dev runs and on
+ * unsupported platforms.
+ */
+export function maybeAutoInstallCli(
+  context: CliInstallerContext,
+  log: (message: string) => void,
+): CliInstallResult | null {
+  if (!isSupported(context)) return null;
+  const result = updateInvokerCli(context);
+  if (result.updated) {
+    log(`installed invoker-cli ${context.appVersion} to ${result.installedTo}`);
+  } else if (!result.ok) {
+    log(`invoker-cli auto-install failed: ${result.error}`);
+  }
+  if (result.status.warning) {
+    log(result.status.warning);
+  }
+  return result;
+}

--- a/packages/app/src/main.ts
+++ b/packages/app/src/main.ts
@@ -32,9 +32,10 @@
  * Using the same Electron binary for both modes provides a consistent runtime.
  */
 
-import { app, ipcMain, type BrowserWindow } from 'electron';
+import { app, dialog, ipcMain, Menu, type BrowserWindow } from 'electron';
 import * as path from 'node:path';
 import { mkdirSync } from 'node:fs';
+import { homedir } from 'node:os';
 import {
   configureEarlyElectronApp,
   registerGuiLifecycleHandlers,
@@ -49,6 +50,12 @@ const earlyHeadlessMode = process.argv.includes('--headless')
   || process.argv.slice(2).includes('install-skills');
 
 configureEarlyElectronApp({ app, enableTestCompositor, isHeadless: earlyHeadlessMode });
+
+// Isolate userData (and with it the single-instance lock) for e2e runs so a
+// test instance can launch alongside a normally running Invoker.
+if (process.env.INVOKER_USER_DATA_DIR) {
+  app.setPath('userData', process.env.INVOKER_USER_DATA_DIR);
+}
 
 import { Orchestrator, CommandService, OrchestratorErrorCode } from '@invoker/workflow-core';
 import type {
@@ -148,6 +155,14 @@ import {
 } from './embedded-terminal-manager.js';
 import { collectSystemDiagnostics } from './system-diagnostics.js';
 import { installBundledSkills, resolveBundledSkillsStatus } from './bundled-skills.js';
+import {
+  maybeAutoInstallCli,
+  resolveCliInstallerStatus,
+  updateInvokerCli,
+  type CliInstallerContext,
+} from './cli-installer.js';
+import { resolveBundledCliPath } from './cli-helper.js';
+import { buildAppMenuTemplate } from './app-menu.js';
 import { createRequire } from 'node:module';
 import { acquireDbWriterLock, type DbWriterLockResult } from './db-writer-lock.js';
 import { applyDelta, recoverQuarantinedTask, TaskSnapshotCache } from './delta-merge.js';
@@ -537,6 +552,31 @@ function getBundledSkillsStatus() {
 
 function installPackagedSkills(mode: import('@invoker/contracts').BundledSkillsInstallMode = 'install') {
   return installBundledSkills(buildBundledSkillsContext(), mode);
+}
+
+function buildCliInstallerContext(): CliInstallerContext {
+  return {
+    isPackaged: app.isPackaged,
+    bundledCliPath: resolveBundledCliPath({ isPackaged: app.isPackaged }),
+    appVersion: app.getVersion(),
+    platform: process.platform,
+    env: process.env,
+    homeDir: homedir(),
+  };
+}
+
+function updateInvokerCliFromMenu(): void {
+  const result = updateInvokerCli(buildCliInstallerContext());
+  const detail = result.ok
+    ? result.updated
+      ? `invoker-cli ${app.getVersion()} installed to ${result.installedTo}.${result.status.warning ? `\n\n${result.status.warning}` : ''}`
+      : `invoker-cli is already up to date (${app.getVersion()}) at ${result.installedTo}.`
+    : `Update failed: ${result.error}`;
+  void dialog.showMessageBox({
+    type: result.ok ? 'info' : 'error',
+    message: 'Update invoker-cli',
+    detail,
+  });
 }
 
 async function initServices(options?: InitServicesOptions): Promise<void> {
@@ -4423,6 +4463,7 @@ function createEmbeddedTerminalBackendFromConfig(
         platform: process.platform,
         arch: process.arch,
         bundledSkills: getBundledSkillsStatus(),
+        cliInstaller: resolveCliInstallerStatus(buildCliInstallerContext()),
       });
     });
 
@@ -4432,6 +4473,10 @@ function createEmbeddedTerminalBackendFromConfig(
 
     ipcMain.handle('invoker:install-bundled-skills', (_event, mode = 'install') => {
       return installPackagedSkills(mode);
+    });
+
+    ipcMain.handle('invoker:update-invoker-cli', () => {
+      return updateInvokerCli(buildCliInstallerContext());
     });
 
     registerGuiMutationHandler('invoker:replace-task', async (taskIdArg: unknown, replacementTasksArg: unknown) => {
@@ -4515,9 +4560,31 @@ function createEmbeddedTerminalBackendFromConfig(
       return embeddedTerminalManager.close(sessionId);
     });
 
+    Menu.setApplicationMenu(
+      Menu.buildFromTemplate(
+        buildAppMenuTemplate({
+          isMac: process.platform === 'darwin',
+          onUpdateInvokerCli: updateInvokerCliFromMenu,
+        }),
+      ),
+    );
+
     seedUiSnapshotCache();
     createWindow();
     recordStartupMark('createWindow.end');
+
+    // Auto-install/update the bundled invoker-cli onto the user's PATH.
+    // Deferred past first paint; the version probe spawnSync still blocks
+    // briefly, so it must never run before the window is up.
+    setTimeout(() => {
+      try {
+        maybeAutoInstallCli(buildCliInstallerContext(), (message) =>
+          logger.info(message, { module: 'cli-installer' }),
+        );
+      } catch (err) {
+        logger.warn(`invoker-cli auto-install failed: ${err}`, { module: 'cli-installer' });
+      }
+    }, 0);
 
     registerMainWindowActivateHandler({
       app,

--- a/packages/app/src/system-diagnostics.ts
+++ b/packages/app/src/system-diagnostics.ts
@@ -59,6 +59,7 @@ export function collectSystemDiagnostics(args: {
   platform: NodeJS.Platform;
   arch: string;
   bundledSkills?: SystemDiagnostics['bundledSkills'];
+  cliInstaller?: SystemDiagnostics['cliInstaller'];
 }): SystemDiagnostics {
   return {
     platform: args.platform,
@@ -66,6 +67,7 @@ export function collectSystemDiagnostics(args: {
     appVersion: args.appVersion,
     isPackaged: args.isPackaged,
     bundledSkills: args.bundledSkills,
+    cliInstaller: args.cliInstaller,
     tools: [
       detectTool('git', 'Git', 'git', ['--version'], 'Install Git before running workflows.', true),
       detectTool('node', 'Node.js', 'node', ['--version'], 'Install Node.js 26 for repo-based workflows.'),

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@invoker/cli",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Standalone Invoker command-line runner",
   "type": "module",
   "bin": {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -25,7 +25,7 @@ import {
   type TaskState,
 } from '@invoker/workflow-core';
 
-const VERSION = '0.0.4';
+const VERSION = '0.0.5';
 
 type CliOptions = {
   dbDir?: string;

--- a/packages/contracts/src/ipc-channels.ts
+++ b/packages/contracts/src/ipc-channels.ts
@@ -245,6 +245,26 @@ export interface BundledSkillsStatus {
 
 export type BundledSkillsInstallMode = 'install' | 'update' | 'reinstall';
 
+export interface CliInstallerStatus {
+  /** Packaged app + bundled binary present + darwin/linux. */
+  supported: boolean;
+  bundledVersion: string;
+  installedVersion?: string;
+  installedPath?: string;
+  upToDate: boolean;
+  /** e.g. the chosen install dir is not on the user's PATH. */
+  warning?: string;
+  lastInstallError?: string;
+}
+
+export interface CliInstallResult {
+  ok: boolean;
+  updated: boolean;
+  installedTo?: string;
+  error?: string;
+  status: CliInstallerStatus;
+}
+
 export interface SystemDiagnostics {
   platform: string;
   arch: string;
@@ -252,6 +272,7 @@ export interface SystemDiagnostics {
   isPackaged: boolean;
   tools: SystemToolStatus[];
   bundledSkills?: BundledSkillsStatus;
+  cliInstaller?: CliInstallerStatus;
 }
 
 // ── Embedded terminal session types ─────────────────────────
@@ -604,6 +625,10 @@ export const IpcChannels = {
   'invoker:install-bundled-skills': {} as {
     request: [mode?: BundledSkillsInstallMode];
     response: BundledSkillsStatus;
+  },
+  'invoker:update-invoker-cli': {} as {
+    request: [];
+    response: CliInstallResult;
   },
 
 } as const;

--- a/packages/npm-cli/package.json
+++ b/packages/npm-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-cli",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Invoker standalone CLI installer",
   "type": "module",
   "repository": {

--- a/packages/npm-ui/README.md
+++ b/packages/npm-ui/README.md
@@ -1,8 +1,15 @@
 # @neko-catpital-labs/invoker-ui
 
-Installs a launcher for the Invoker desktop UI from the matching GitHub Release.
+Installs a launcher for the Invoker desktop UI from the matching GitHub Release, plus the
+standalone `invoker-cli` command (via a version-pinned dependency on
+`@neko-catpital-labs/invoker-cli`).
 
 ```sh
 npm install -g @neko-catpital-labs/invoker-ui
 invoker-ui
+invoker-cli --version
 ```
+
+Note: `@neko-catpital-labs/invoker-cli` also exposes an `invoker-cli` bin. If you install both
+packages globally, the bin names collide; that is harmless — both run the same version-pinned
+binary.

--- a/packages/npm-ui/bin/invoker-cli.js
+++ b/packages/npm-ui/bin/invoker-cli.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+
+let cliPackageJson;
+try {
+  cliPackageJson = require.resolve('@neko-catpital-labs/invoker-cli/package.json');
+} catch {
+  console.error(
+    'The @neko-catpital-labs/invoker-cli dependency is not installed. Reinstall @neko-catpital-labs/invoker-ui.',
+  );
+  process.exit(1);
+}
+
+const binary = join(dirname(cliPackageJson), 'vendor', 'invoker-cli');
+
+if (!existsSync(binary)) {
+  console.error(
+    `invoker-cli binary is missing at ${binary}. Its postinstall did not run or failed — ` +
+      'reinstall @neko-catpital-labs/invoker-ui, or run `npm rebuild @neko-catpital-labs/invoker-cli`.',
+  );
+  process.exit(1);
+}
+
+const result = spawnSync(binary, process.argv.slice(2), { stdio: 'inherit' });
+process.exit(result.status ?? 1);

--- a/packages/npm-ui/package.json
+++ b/packages/npm-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@neko-catpital-labs/invoker-ui",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Invoker desktop UI launcher",
   "type": "module",
   "repository": {
@@ -9,7 +9,8 @@
     "directory": "packages/npm-ui"
   },
   "bin": {
-    "invoker-ui": "bin/invoker-ui.js"
+    "invoker-ui": "bin/invoker-ui.js",
+    "invoker-cli": "bin/invoker-cli.js"
   },
   "files": [
     "bin/**/*",
@@ -19,9 +20,13 @@
     "README.md"
   ],
   "scripts": {
-    "postinstall": "node scripts/install.js"
+    "postinstall": "node scripts/install.js",
+    "test": "node scripts/test-wrapper.mjs"
   },
   "publishConfig": {
     "access": "public"
+  },
+  "dependencies": {
+    "@neko-catpital-labs/invoker-cli": "workspace:*"
   }
 }

--- a/packages/npm-ui/scripts/test-wrapper.mjs
+++ b/packages/npm-ui/scripts/test-wrapper.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Verifies the invoker-cli bin wrapper: it must resolve the
+// @neko-catpital-labs/invoker-cli dependency's vendor binary and spawn it,
+// and emit a clear error when the vendor binary is missing (postinstall
+// skipped/failed).
+import assert from 'node:assert/strict';
+import { execFileSync } from 'node:child_process';
+import { chmodSync, cpSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const scratch = mkdtempSync(join(tmpdir(), 'invoker-ui-wrapper-'));
+
+try {
+  const pkgDir = join(scratch, 'pkg');
+  mkdirSync(join(pkgDir, 'bin'), { recursive: true });
+  cpSync(join(packageRoot, 'bin', 'invoker-cli.js'), join(pkgDir, 'bin', 'invoker-cli.js'));
+  writeFileSync(join(pkgDir, 'package.json'), JSON.stringify({ name: 'wrapper-under-test', type: 'module' }));
+
+  const depDir = join(pkgDir, 'node_modules', '@neko-catpital-labs', 'invoker-cli');
+  mkdirSync(join(depDir, 'vendor'), { recursive: true });
+  writeFileSync(
+    join(depDir, 'package.json'),
+    JSON.stringify({ name: '@neko-catpital-labs/invoker-cli', version: '0.0.3' }),
+  );
+
+  // Missing vendor binary → clear reinstall hint, non-zero exit.
+  let missingError = '';
+  try {
+    execFileSync(process.execPath, [join(pkgDir, 'bin', 'invoker-cli.js'), '--version'], { encoding: 'utf8' });
+    assert.fail('expected the wrapper to exit non-zero when the vendor binary is missing');
+  } catch (err) {
+    missingError = String(err.stderr ?? '');
+  }
+  assert.match(missingError, /binary is missing/, `unexpected missing-vendor error: ${missingError}`);
+  assert.match(missingError, /npm rebuild @neko-catpital-labs\/invoker-cli/);
+
+  // Vendor binary present → wrapper spawns it and forwards args/exit code.
+  const fakeBinary = join(depDir, 'vendor', 'invoker-cli');
+  writeFileSync(fakeBinary, '#!/usr/bin/env bash\nif [ "$1" = "--version" ]; then echo "0.0.3"; exit 0; fi\nexit 7\n');
+  chmodSync(fakeBinary, 0o755);
+
+  const version = execFileSync(process.execPath, [join(pkgDir, 'bin', 'invoker-cli.js'), '--version'], {
+    encoding: 'utf8',
+  }).trim();
+  assert.equal(version, '0.0.3');
+
+  try {
+    execFileSync(process.execPath, [join(pkgDir, 'bin', 'invoker-cli.js'), 'not-a-flag'], { encoding: 'utf8' });
+    assert.fail('expected the wrapper to forward the binary exit code');
+  } catch (err) {
+    assert.equal(err.status, 7);
+  }
+
+  console.log('ok invoker-ui invoker-cli wrapper');
+} finally {
+  rmSync(scratch, { recursive: true, force: true });
+}

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -371,6 +371,8 @@ export function App() {
   const [showSystemBanner, setShowSystemBanner] = useState(false);
   const [installSkillsPending, setInstallSkillsPending] = useState(false);
   const [installSkillsError, setInstallSkillsError] = useState<string | null>(null);
+  const [updateCliPending, setUpdateCliPending] = useState(false);
+  const [updateCliError, setUpdateCliError] = useState<string | null>(null);
   const [inspectorCollapsed, setInspectorCollapsed] = useState(false);
   const [advancedMetadataExpanded, setAdvancedMetadataExpanded] = useState(false);
   const [terminalCollapsed, setTerminalCollapsed] = useState(true);
@@ -1589,6 +1591,22 @@ export function App() {
     }
   }, [refreshSystemDiagnostics]);
 
+  const handleUpdateInvokerCli = useCallback(async () => {
+    try {
+      setUpdateCliPending(true);
+      setUpdateCliError(null);
+      const result = await window.invoker?.updateInvokerCli?.();
+      if (result && !result.ok) {
+        setUpdateCliError(result.error ?? 'invoker-cli update failed.');
+      }
+      refreshSystemDiagnostics();
+    } catch (err) {
+      setUpdateCliError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setUpdateCliPending(false);
+    }
+  }, [refreshSystemDiagnostics]);
+
   return (
     <div className="h-screen flex flex-col bg-gray-900 text-gray-100" onClick={() => closeContextMenu()}>
       {showSystemBanner && (
@@ -1975,6 +1993,9 @@ export function App() {
           installPending={installSkillsPending}
           installError={installSkillsError}
           onInstallBundledSkills={handleInstallBundledSkills}
+          updateCliPending={updateCliPending}
+          updateCliError={updateCliError}
+          onUpdateInvokerCli={handleUpdateInvokerCli}
           onClose={() => setShowSystemSetup(false)}
         />
       )}

--- a/packages/ui/src/__tests__/system-setup-cli.test.tsx
+++ b/packages/ui/src/__tests__/system-setup-cli.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * Component test: "Invoker CLI" section of the SystemSetupModal.
+ *
+ * The packaged desktop app installs/updates the bundled invoker-cli binary
+ * onto the user's PATH; this section surfaces the installed-vs-app version
+ * status and a manual Install/Update action.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { SystemDiagnostics, CliInstallerStatus } from '@invoker/contracts';
+
+import { SystemSetupModal } from '../components/SystemSetupModal.js';
+
+function makeDiagnostics(cliInstaller: CliInstallerStatus | undefined): SystemDiagnostics {
+  return {
+    platform: 'darwin',
+    arch: 'arm64',
+    appVersion: '0.0.3',
+    isPackaged: true,
+    tools: [],
+    cliInstaller,
+  };
+}
+
+describe('SystemSetupModal — Invoker CLI section', () => {
+  it('shows an outdated install and fires onUpdateInvokerCli from the button', () => {
+    const onUpdateInvokerCli = vi.fn();
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics({
+          supported: true,
+          bundledVersion: '0.0.3',
+          installedVersion: '0.0.2',
+          installedPath: '/usr/local/bin/invoker-cli',
+          upToDate: false,
+        })}
+        onUpdateInvokerCli={onUpdateInvokerCli}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/Installed 0\.0\.2 at \/usr\/local\/bin\/invoker-cli — app version 0\.0\.3/)).toBeInTheDocument();
+    expect(screen.getByText('Update available')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Update invoker-cli' }));
+    expect(onUpdateInvokerCli).toHaveBeenCalledTimes(1);
+  });
+
+  it('offers Install when invoker-cli is missing', () => {
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics({
+          supported: true,
+          bundledVersion: '0.0.3',
+          upToDate: false,
+        })}
+        onUpdateInvokerCli={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Not installed')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Install invoker-cli' })).toBeInTheDocument();
+  });
+
+  it('hides the button when up to date and shows the PATH warning when present', () => {
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics({
+          supported: true,
+          bundledVersion: '0.0.3',
+          installedVersion: '0.0.3',
+          installedPath: '/Users/me/.local/bin/invoker-cli',
+          upToDate: true,
+          warning: '/Users/me/.local/bin is not on your PATH.',
+        })}
+        onUpdateInvokerCli={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.getByText('Up to date')).toBeInTheDocument();
+    expect(screen.getByText('/Users/me/.local/bin is not on your PATH.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /invoker-cli/ })).not.toBeInTheDocument();
+  });
+
+  it('hides the section entirely when unsupported (dev mode)', () => {
+    render(
+      <SystemSetupModal
+        diagnostics={makeDiagnostics({ supported: false, bundledVersion: '0.0.3', upToDate: false })}
+        onUpdateInvokerCli={() => {}}
+        onClose={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText('Invoker CLI')).not.toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/components/SystemSetupModal.tsx
+++ b/packages/ui/src/components/SystemSetupModal.tsx
@@ -5,6 +5,9 @@ interface SystemSetupModalProps {
   installPending?: boolean;
   installError?: string | null;
   onInstallBundledSkills?: (mode?: 'install' | 'update' | 'reinstall') => void;
+  updateCliPending?: boolean;
+  updateCliError?: string | null;
+  onUpdateInvokerCli?: () => void;
   onClose: () => void;
 }
 
@@ -13,10 +16,14 @@ export function SystemSetupModal({
   installPending = false,
   installError = null,
   onInstallBundledSkills,
+  updateCliPending = false,
+  updateCliError = null,
+  onUpdateInvokerCli,
   onClose,
 }: SystemSetupModalProps) {
   const installedAgents = diagnostics?.tools.filter((tool) => (tool.id === 'claude' || tool.id === 'codex') && tool.installed) ?? [];
   const bundledSkills = diagnostics?.bundledSkills;
+  const cliInstaller = diagnostics?.cliInstaller;
   const canInstallBundledSkills = Boolean(bundledSkills?.available && onInstallBundledSkills);
   const installActionLabel = bundledSkills?.targets.some((target) => target.installed && !target.upToDate)
     ? 'Update Skills'
@@ -117,6 +124,49 @@ export function SystemSetupModal({
                     </button>
                   )}
                 </div>
+              )}
+            </div>
+          )}
+
+          {cliInstaller?.supported && (
+            <div className="rounded border border-indigo-700/60 bg-indigo-950/30 px-4 py-4 space-y-3">
+              <div>
+                <div className="text-sm font-medium text-indigo-100">Invoker CLI</div>
+                <div className="text-sm text-indigo-200/80 mt-1">
+                  The `invoker-cli` command is installed onto your PATH and kept at the app&apos;s version.
+                </div>
+              </div>
+
+              <div className="text-sm text-gray-300">
+                {cliInstaller.installedVersion
+                  ? `Installed ${cliInstaller.installedVersion} at ${cliInstaller.installedPath} — app version ${cliInstaller.bundledVersion}`
+                  : 'Not installed'}
+                {' '}
+                <span className={cliInstaller.upToDate ? 'text-green-400' : cliInstaller.installedVersion ? 'text-yellow-300' : 'text-amber-300'}>
+                  {cliInstaller.upToDate ? 'Up to date' : cliInstaller.installedVersion ? 'Update available' : ''}
+                </span>
+              </div>
+
+              {cliInstaller.warning && (
+                <div className="rounded border border-amber-600/50 bg-amber-950/40 px-3 py-2 text-sm text-amber-100">
+                  {cliInstaller.warning}
+                </div>
+              )}
+
+              {(cliInstaller.lastInstallError || updateCliError) && (
+                <div className="rounded border border-red-700/50 bg-red-950/30 px-3 py-2 text-sm text-red-200">
+                  {updateCliError ?? cliInstaller.lastInstallError}
+                </div>
+              )}
+
+              {onUpdateInvokerCli && !cliInstaller.upToDate && (
+                <button
+                  onClick={() => onUpdateInvokerCli()}
+                  disabled={updateCliPending}
+                  className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 disabled:bg-indigo-900 disabled:text-indigo-200 text-white rounded text-sm font-medium transition-colors"
+                >
+                  {updateCliPending ? 'Updating…' : cliInstaller.installedVersion ? 'Update invoker-cli' : 'Install invoker-cli'}
+                </button>
               )}
             </div>
           )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,7 +247,11 @@ importers:
 
   packages/npm-cli: {}
 
-  packages/npm-ui: {}
+  packages/npm-ui:
+    dependencies:
+      '@neko-catpital-labs/invoker-cli':
+        specifier: workspace:*
+        version: link:../npm-cli
 
   packages/persistence:
     dependencies:

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+// Bumps every release version string in one run, then verifies they agree:
+//
+//   node scripts/bump-version.mjs 0.0.5
+//
+// Covers the root + four publishable package.json files and the VERSION
+// constant baked into the CLI source. After this, commit and tag (vX.Y.Z) to
+// trigger the release workflow.
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawnSync } from 'node:child_process';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+const newVersion = process.argv[2];
+
+if (!newVersion || !/^\d+\.\d+\.\d+(-[\w.]+)?$/.test(newVersion)) {
+  console.error('Usage: node scripts/bump-version.mjs <semver, e.g. 0.0.5>');
+  process.exit(64);
+}
+
+const packageJsonPaths = [
+  'package.json',
+  'packages/app/package.json',
+  'packages/cli/package.json',
+  'packages/npm-cli/package.json',
+  'packages/npm-ui/package.json',
+];
+
+for (const relPath of packageJsonPaths) {
+  const absPath = join(root, relPath);
+  const pkg = JSON.parse(readFileSync(absPath, 'utf8'));
+  const oldVersion = pkg.version;
+  pkg.version = newVersion;
+  writeFileSync(absPath, `${JSON.stringify(pkg, null, 2)}\n`);
+  console.log(`${relPath}: ${oldVersion} -> ${newVersion}`);
+}
+
+const cliSourcePath = join(root, 'packages/cli/src/index.ts');
+const cliSource = readFileSync(cliSourcePath, 'utf8');
+if (!/^const VERSION = '[^']+';$/m.test(cliSource)) {
+  console.error(`Could not find "const VERSION = '...'" in ${cliSourcePath}`);
+  process.exit(1);
+}
+writeFileSync(cliSourcePath, cliSource.replace(/^const VERSION = '[^']+';$/m, `const VERSION = '${newVersion}';`));
+console.log(`packages/cli/src/index.ts: VERSION -> ${newVersion}`);
+
+const check = spawnSync(process.execPath, [join(root, 'scripts/check-version-sync.mjs')], { stdio: 'inherit' });
+process.exit(check.status ?? 1);

--- a/scripts/check-version-sync.mjs
+++ b/scripts/check-version-sync.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// The desktop app pins the invoker-cli it installs to its own version, and
+// the npm-ui package pins its invoker-cli dependency via workspace:* — so
+// every published version string must stay aligned. Fails CI/release when
+// any of them drift.
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = dirname(dirname(fileURLToPath(import.meta.url)));
+
+const sources = [
+  ['package.json', JSON.parse(readFileSync(join(root, 'package.json'), 'utf8')).version],
+  ['packages/app/package.json', JSON.parse(readFileSync(join(root, 'packages/app/package.json'), 'utf8')).version],
+  ['packages/cli/package.json', JSON.parse(readFileSync(join(root, 'packages/cli/package.json'), 'utf8')).version],
+  ['packages/npm-cli/package.json', JSON.parse(readFileSync(join(root, 'packages/npm-cli/package.json'), 'utf8')).version],
+  ['packages/npm-ui/package.json', JSON.parse(readFileSync(join(root, 'packages/npm-ui/package.json'), 'utf8')).version],
+  [
+    'packages/cli/src/index.ts (const VERSION)',
+    readFileSync(join(root, 'packages/cli/src/index.ts'), 'utf8').match(/^const VERSION = '([^']+)';$/m)?.[1],
+  ],
+];
+
+const versions = new Set(sources.map(([, version]) => version));
+if (versions.size === 1 && !versions.has(undefined)) {
+  console.log(`ok all release versions are ${sources[0][1]}`);
+  process.exit(0);
+}
+
+console.error('Version mismatch — these must all be identical:');
+for (const [source, version] of sources) {
+  console.error(`  ${String(version ?? 'NOT FOUND').padEnd(12)} ${source}`);
+}
+process.exit(1);

--- a/scripts/e2e-dmg-cli-install.sh
+++ b/scripts/e2e-dmg-cli-install.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# E2E: prove the Mac DMG install auto-installs and auto-updates invoker-cli.
+# Mounts the locally built DMG, copies Invoker.app out (a real DMG install),
+# launches it with INVOKER_CLI_INSTALL_DIR pointed at a scratch dir (keeps the
+# test hermetic — no writes to /usr/local/bin), and asserts:
+#   1. fresh launch installs invoker-cli at the app version
+#   2. an outdated invoker-cli is auto-updated on the next launch
+#
+# Usage: bash scripts/e2e-dmg-cli-install.sh
+#   Expects release/Invoker-<version>-<arch>.dmg to exist
+#   (built by scripts/e2e-npm-cli-install.sh or `pnpm run dist:desktop:mac`).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "This e2e script exercises the macOS DMG; run it on a Mac." >&2
+  exit 64
+fi
+
+VERSION="$(node -p "require('./packages/app/package.json').version")"
+ARCH="$(node -p "process.arch")"
+DMG="release/Invoker-$VERSION-$ARCH.dmg"
+[ -f "$DMG" ] || { echo "Missing $DMG — build it first (pnpm run dist:desktop:mac:$ARCH)." >&2; exit 1; }
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-dmg.XXXXXX")"
+MOUNT_POINT="$SCRATCH/mnt"
+APP_DIR="$SCRATCH/Applications"
+BIN_DIR="$SCRATCH/bin"
+APP_PID=""
+
+cleanup() {
+  # The app spawns children (e.g. a `--headless owner-serve` daemon); kill by
+  # scratch path so nothing outlives the test.
+  pkill -f "$(basename "$SCRATCH")" 2>/dev/null || true
+  hdiutil detach "$MOUNT_POINT" >/dev/null 2>&1 || true
+  rm -rf "$SCRATCH"
+}
+trap cleanup EXIT
+
+fail() {
+  echo "FAIL: $1" >&2
+  if [ -f "$SCRATCH/app.log" ]; then
+    echo "--- app stdout/stderr (tail):" >&2
+    tail -20 "$SCRATCH/app.log" >&2
+  fi
+  if [ -f "$SCRATCH/db/invoker.log" ]; then
+    echo "--- invoker.log (tail):" >&2
+    tail -20 "$SCRATCH/db/invoker.log" >&2
+  fi
+  exit 1
+}
+
+# 1. "Install" the DMG: mount, copy Invoker.app out, unmount.
+mkdir -p "$MOUNT_POINT" "$APP_DIR" "$SCRATCH/home" "$SCRATCH/user-data" "$SCRATCH/db" "$BIN_DIR"
+hdiutil attach "$DMG" -nobrowse -readonly -mountpoint "$MOUNT_POINT" >/dev/null
+cp -R "$MOUNT_POINT/Invoker.app" "$APP_DIR/"
+hdiutil detach "$MOUNT_POINT" >/dev/null
+APP_BINARY="$APP_DIR/Invoker.app/Contents/MacOS/Invoker"
+[ -x "$APP_BINARY" ] || fail "DMG did not contain a launchable Invoker.app"
+
+launch_app() {
+  # HOME + INVOKER_USER_DATA_DIR + INVOKER_DB_DIR keep the test instance fully
+  # isolated: its own Electron userData (and single-instance lock, so it can
+  # run alongside a normally running Invoker), its own DB, no writes to the
+  # real home.
+  HOME="$SCRATCH/home" \
+  INVOKER_USER_DATA_DIR="$SCRATCH/user-data" \
+  INVOKER_CLI_INSTALL_DIR="$BIN_DIR" \
+  INVOKER_DB_DIR="$SCRATCH/db" \
+    "$APP_BINARY" >"$SCRATCH/app.log" 2>&1 &
+  APP_PID=$!
+}
+
+quit_app() {
+  kill "$APP_PID" 2>/dev/null || true
+  wait "$APP_PID" 2>/dev/null || true
+  APP_PID=""
+  # Also reap app-spawned children (daemon owner, helpers) between phases.
+  pkill -f "$(basename "$SCRATCH")" 2>/dev/null || true
+}
+
+wait_for_cli_version() {
+  local expected="$1"
+  for _ in $(seq 1 60); do
+    if [ -x "$BIN_DIR/invoker-cli" ]; then
+      local actual
+      actual="$("$BIN_DIR/invoker-cli" --version 2>/dev/null || true)"
+      [ "$actual" = "$expected" ] && return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# 2. Fresh-install case: launch with no invoker-cli present.
+launch_app
+wait_for_cli_version "$VERSION" \
+  || fail "fresh launch did not install invoker-cli $VERSION into $BIN_DIR within 60s"
+quit_app
+echo "ok fresh DMG launch installed invoker-cli $VERSION"
+
+# 3. Update case: seed an outdated invoker-cli, relaunch, expect overwrite.
+cat > "$BIN_DIR/invoker-cli" <<'FAKE'
+#!/usr/bin/env bash
+echo "0.0.1"
+FAKE
+chmod 755 "$BIN_DIR/invoker-cli"
+[ "$("$BIN_DIR/invoker-cli" --version)" = "0.0.1" ] || fail "could not seed the outdated fake cli"
+
+launch_app
+wait_for_cli_version "$VERSION" \
+  || fail "relaunch did not auto-update outdated invoker-cli to $VERSION within 60s"
+quit_app
+echo "ok relaunch auto-updated outdated invoker-cli to $VERSION"

--- a/scripts/e2e-npm-cli-install.sh
+++ b/scripts/e2e-npm-cli-install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# E2E: prove that `npm install` of the published npm packages yields a working
+# `invoker-cli` command, using locally built release artifacts served over
+# localhost instead of a GitHub release (both postinstalls honor
+# INVOKER_RELEASE_BASE_URL).
+#
+# Usage: bash scripts/e2e-npm-cli-install.sh
+#   INVOKER_E2E_SKIP_BUILD=1   reuse existing release/ artifacts
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+if [ "$(uname -s)" != "Darwin" ]; then
+  echo "This e2e script builds and installs macOS artifacts; run it on a Mac." >&2
+  exit 64
+fi
+
+VERSION="$(node -p "require('./packages/npm-cli/package.json').version")"
+ARCH="$(node -p "process.arch")"
+CLI_TARBALL="release/invoker-cli-$VERSION-darwin-$ARCH.tar.gz"
+UI_ZIP="release/Invoker-$VERSION-$ARCH.zip"
+
+SCRATCH="$(mktemp -d "${TMPDIR:-/tmp}/invoker-e2e-npm.XXXXXX")"
+SERVER_PID=""
+cleanup() {
+  [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+  rm -rf "$SCRATCH"
+}
+trap cleanup EXIT
+
+# 1. Build the real release artifacts locally.
+if [ "${INVOKER_E2E_SKIP_BUILD:-0}" != "1" ]; then
+  pnpm run dist:cli
+  bash scripts/package-desktop.sh --mac "--$ARCH"
+fi
+for artifact in "$CLI_TARBALL" "$UI_ZIP"; do
+  if [ ! -f "$artifact" ]; then
+    echo "Missing $artifact — run without INVOKER_E2E_SKIP_BUILD=1 to build it." >&2
+    exit 1
+  fi
+done
+bash scripts/release-sha256.sh
+
+# 2. Serve release/ on localhost so the postinstall download + sha
+#    verification paths run for real.
+PORT="${INVOKER_E2E_PORT:-8763}"
+python3 -m http.server "$PORT" --directory release --bind 127.0.0.1 >/dev/null 2>&1 &
+SERVER_PID=$!
+for _ in $(seq 1 50); do
+  curl -fsS "http://127.0.0.1:$PORT/SHA256SUMS" >/dev/null 2>&1 && break
+  sleep 0.2
+done
+curl -fsS "http://127.0.0.1:$PORT/SHA256SUMS" >/dev/null
+
+# 3. Pack both npm packages (pnpm pack rewrites workspace:* to the exact
+#    version, same as publish).
+PACK_DIR="$SCRATCH/tarballs"
+mkdir -p "$PACK_DIR"
+pnpm --filter @neko-catpital-labs/invoker-cli pack --pack-destination "$PACK_DIR" >/dev/null
+pnpm --filter @neko-catpital-labs/invoker-ui pack --pack-destination "$PACK_DIR" >/dev/null
+CLI_TGZ="$(ls "$PACK_DIR"/*invoker-cli*.tgz)"
+UI_TGZ="$(ls "$PACK_DIR"/*invoker-ui*.tgz)"
+
+# 4. Install both tarballs in ONE command so npm satisfies the ui→cli
+#    dependency from the local tarball instead of the registry.
+PROJECT_DIR="$SCRATCH/project"
+mkdir -p "$PROJECT_DIR"
+(
+  cd "$PROJECT_DIR"
+  INVOKER_RELEASE_BASE_URL="http://127.0.0.1:$PORT" \
+    npm install --no-fund --no-audit "$CLI_TGZ" "$UI_TGZ"
+)
+
+# 5. Assertions.
+fail() { echo "FAIL: $1" >&2; exit 1; }
+
+ACTUAL_VERSION="$("$PROJECT_DIR/node_modules/.bin/invoker-cli" --version)"
+[ "$ACTUAL_VERSION" = "$VERSION" ] \
+  || fail "node_modules/.bin/invoker-cli --version printed '$ACTUAL_VERSION', expected '$VERSION'"
+
+# The ui package's own wrapper must resolve the dependency's vendor binary
+# (proves the new bin entry works, independent of which package won .bin).
+UI_WRAPPER_VERSION="$(node "$PROJECT_DIR/node_modules/@neko-catpital-labs/invoker-ui/bin/invoker-cli.js" --version)"
+[ "$UI_WRAPPER_VERSION" = "$VERSION" ] \
+  || fail "invoker-ui's invoker-cli wrapper printed '$UI_WRAPPER_VERSION', expected '$VERSION'"
+
+[ -d "$PROJECT_DIR/node_modules/@neko-catpital-labs/invoker-ui/vendor/Invoker.app" ] \
+  || fail "invoker-ui postinstall did not download/extract Invoker.app"
+
+node -e "
+  const pkg = require('$PROJECT_DIR/node_modules/@neko-catpital-labs/invoker-ui/package.json');
+  if (!pkg.bin['invoker-cli']) throw new Error('invoker-ui is missing the invoker-cli bin entry');
+  if (pkg.dependencies['@neko-catpital-labs/invoker-cli'] !== '$VERSION') {
+    throw new Error('invoker-ui dependency is not pinned to $VERSION: ' + pkg.dependencies['@neko-catpital-labs/invoker-cli']);
+  }
+"
+
+echo "ok npm install yields working invoker-cli $VERSION (direct bin + ui wrapper + pinned dependency)"


### PR DESCRIPTION
## Summary

`npm install -g @neko-catpital-labs/invoker-ui` now also installs the `invoker-cli` command, and the desktop app auto-installs or auto-updates it on launch. Versions bump to 0.0.5.

Manual update actions live in System Setup and a new Tools menu. Installs are silent: `/usr/local/bin` when already writable, else `~/.local/bin`; never a password prompt.

The release workflow now packs with `pnpm pack` before `npm publish` so `workspace:*` pins rewrite, `check:versions` guards version drift, and `scripts/bump-version.mjs` bumps everything in one run.

## Test Plan

- [x] `pnpm run check:versions`
- [x] `pnpm run check:types`
- [x] `pnpm --filter @invoker/app test` (1085 passed, includes new cli-installer + app-menu suites)
- [x] `pnpm --filter @invoker/ui test` (482 passed, includes new SystemSetupModal section suite)
- [x] `pnpm --filter @neko-catpital-labs/invoker-ui test` (bin wrapper resolution + missing-vendor error path)
- [x] `bash scripts/e2e-npm-cli-install.sh` — builds real release artifacts, serves them on localhost, npm-installs the packed tarballs into a clean project, asserts `invoker-cli --version` prints 0.0.5 via both the direct bin and the invoker-ui wrapper, and that the dependency is pinned to 0.0.5
- [x] `bash scripts/e2e-dmg-cli-install.sh` — mounts the built DMG, copies Invoker.app out, launches it hermetically (isolated HOME/userData/DB/install dir), asserts fresh launch installs invoker-cli 0.0.5 and a planted outdated 0.0.1 binary is auto-updated on relaunch

## Revert Plan

- Safe to revert? Yes
- Revert command: `git revert <merge-sha>`
- Post-revert steps: None for code. If 0.0.5 was already published to npm, those versions are immutable on the registry; the next release must use a new version number regardless.
- Data migration? No
